### PR TITLE
Add support for java -DconfigPath=/some/config

### DIFF
--- a/src/main/java/org/graylog2/Main.java
+++ b/src/main/java/org/graylog2/Main.java
@@ -70,8 +70,12 @@ public final class Main {
         // Read config.
         System.out.println("[x] Reading config.");
         Main.masterConfig = new Properties();
+        /* Allow -DconfigPath=/some/different/config */
+        String configPath = System.getProperty("configPath", "/etc/graylog2.conf");
+        System.out.println("Using config: " + configPath);
+
         try {
-            FileInputStream configStream = new FileInputStream("/etc/graylog2.conf");
+            FileInputStream configStream = new FileInputStream(configPath);
             Main.masterConfig.load(configStream);
             configStream.close();
         } catch(java.io.IOException e) {


### PR DESCRIPTION
This is useful when someone doesn't have root, or doesn't want root, to be able to configure graylog2.

Tested from source by building (mvn package) and running:
  java -DconfigPath=../graylog2.conf -cp target/_:lib/_ org.graylog2.Main
