### PR TITLE
Solved race-condition when creating SyslogServerThread on slow systems

### DIFF
--- a/src/main/java/org/graylog2/messagehandlers/syslog/SyslogServerThread.java
+++ b/src/main/java/org/graylog2/messagehandlers/syslog/SyslogServerThread.java
@@ -22,6 +22,7 @@ package org.graylog2.messagehandlers.syslog;
 
 import org.graylog2.Main;
 import org.productivity.java.syslog4j.server.SyslogServer;
+import org.productivity.java.syslog4j.server.SyslogServerConfigIF;
 import org.productivity.java.syslog4j.server.SyslogServerIF;
 
 /**
@@ -50,11 +51,15 @@ public class SyslogServerThread extends Thread {
      */
     @Override public void run() {
         String syslogProtocol = Main.masterConfig.getProperty("syslog_protocol");
-        SyslogServerIF syslogServer = SyslogServer.getThreadedInstance(syslogProtocol);
+
+        SyslogServerIF syslogServer = SyslogServer.getInstance(syslogProtocol);
+        SyslogServerConfigIF syslogServerConfig = syslogServer.getConfig();
         
-        syslogServer.getConfig().setPort(port);
-        syslogServer.getConfig().setUseStructuredData(true);
-        syslogServer.getConfig().addEventHandler(new SyslogEventHandler());
+        syslogServerConfig.setPort(port);
+        syslogServerConfig.setUseStructuredData(true);
+        syslogServerConfig.addEventHandler(new SyslogEventHandler());
+
+        syslogServer = SyslogServer.getThreadedInstance(syslogProtocol);
 
         this.coreThread = syslogServer.getThread();
     }
@@ -69,3 +74,4 @@ public class SyslogServerThread extends Thread {
     }
 
 }
+


### PR DESCRIPTION
SyslogServerThread is being created and started from Main and itself creates a TCPNetSyslogServer
or UDPNetSyslogServer thread through SyslogServer#getThreadedInstance in its own Thread#run method.

The *NetSyslogServer's configuration is being changed only after the thread has been started by
SyslogServer#getThreadedInstance which leads to a race-condition:
- If SyslogServerThread can apply the configuration changes _before_ the thread started by
  SyslogServer#getThreadedInstance creates its UDP or TCP socket, everything is fine.
- If SyslogServerThread is being suspended for whatever reason, *NetSyslogServer creates its socket
  with the default configuration, e. g. on port 514 instead of the configured port.

Since processes on most systems cannot bind ports <1024 without root/Administrator privileges,
graylog2-server will fail to start if it's being started by a user not having these privileges.
