### PR TITLE
Minor change of POM for Maven 3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -146,6 +146,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-jar-plugin</artifactId>
+                <version>2.3.1</version>
                 <configuration>
                     <archive>
                         <manifest>
@@ -155,7 +156,9 @@
                 </configuration>
             </plugin>
             <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-assembly-plugin</artifactId>
+                <version>2.2.1</version>
                 <configuration>
                     <archive>
                         <manifest>


### PR DESCRIPTION
- Added explicit version to maven-jar-plugin and maven-assembly-plugin

Really only a minor change so that Maven 3 won't complain about the missing version identifiers for maven-jar-plugin and maven-assembly-plugin.
