### PR TITLE
removed scope system for syslog4j from pom.xml because this prevented sys

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -18,8 +18,6 @@
             <groupId>org.syslog4j</groupId>
             <artifactId>syslog4j</artifactId>
             <version>0.9.46</version>
-            <scope>system</scope>
-            <systemPath>${project.basedir}/lib/syslog4j-0.9.46-bin.jar</systemPath>
         </dependency>
         <dependency>
             <groupId>com.googlecode.json-simple</groupId>


### PR DESCRIPTION
removed scope system for syslog4j from pom.xml because this prevented syslog4j to be compiled into the graylog jar by mvn assembly
