### PR TITLE
Bumped JadConfig to version 0.3, fixes SERVER-59

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -74,7 +74,7 @@
         <dependency>
             <groupId>com.github.joschi</groupId>
             <artifactId>jadconfig</artifactId>
-            <version>0.2</version>
+            <version>0.3</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>


### PR DESCRIPTION
Trivial change of `pom.xml` to update the version of JadConfig.

See http://jira.graylog2.org/browse/SERVER-59
