### PR TITLE
Introduced threadsafe data structures for ChunkedGELFClientManager

### DIFF
--- a/src/main/java/org/graylog2/Main.java
+++ b/src/main/java/org/graylog2/Main.java
@@ -34,6 +34,7 @@ import org.graylog2.indexer.Indexer;
 import org.graylog2.messagehandlers.amqp.AMQPBroker;
 import org.graylog2.messagehandlers.amqp.AMQPSubscribedQueue;
 import org.graylog2.messagehandlers.amqp.AMQPSubscriberThread;
+import org.graylog2.messagehandlers.gelf.ChunkedGELFClientManager;
 import org.graylog2.messagehandlers.gelf.GELFMainThread;
 import org.graylog2.messagehandlers.syslog.SyslogServerThread;
 import org.graylog2.periodical.ChunkedGELFClientManagerThread;
@@ -172,7 +173,7 @@ public final class Main {
         GELFMainThread gelfThread = new GELFMainThread(gelfPort);
         gelfThread.start();
 
-        ChunkedGELFClientManagerThread gelfManager = new ChunkedGELFClientManagerThread();
+        ChunkedGELFClientManagerThread gelfManager = new ChunkedGELFClientManagerThread(ChunkedGELFClientManager.getInstance());
         gelfManager.start();
 
         LOG.info("GELF threads started");

--- a/src/main/java/org/graylog2/messagehandlers/gelf/ChunkedGELFClientManager.java
+++ b/src/main/java/org/graylog2/messagehandlers/gelf/ChunkedGELFClientManager.java
@@ -20,8 +20,8 @@
 
 package org.graylog2.messagehandlers.gelf;
 
-import java.util.HashMap;
-import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
 
 /**
  * ChunkedGELFClientManager.java: Sep 20, 2010 6:52:36 PM
@@ -33,7 +33,7 @@ import java.util.Map;
  */
 public final class ChunkedGELFClientManager {
 
-    private static Map<String, ChunkedGELFMessage> messageMap = new HashMap<String, ChunkedGELFMessage>();
+    private static ConcurrentMap<String, ChunkedGELFMessage> messageMap = new ConcurrentHashMap<String, ChunkedGELFMessage>();
 
     private static ChunkedGELFClientManager instance;
 
@@ -93,7 +93,7 @@ public final class ChunkedGELFClientManager {
      *
      * @return
      */
-    public Map<String, ChunkedGELFMessage> getMessageMap() {
+    public ConcurrentMap<String, ChunkedGELFMessage> getMessageMap() {
         return messageMap;
     }
 


### PR DESCRIPTION
Changed data structures used in ChunkedGELFClientManager and ChunkedGELFClientManagerThread to classes from `java.util.concurrent` (`ConcurrentMap` and `ConcurrentHashMap`, see http://download.oracle.com/javase/tutorial/essential/concurrency/collections.html) since potentially more than one thread at once will access them.

This should fix SERVER-30 (http://jira.graylog2.org/browse/SERVER-30).
