### PR TITLE
Reimplemented periodical threads with ScheduledExecutorService

### DIFF
--- a/src/main/java/org/graylog2/periodical/ChunkedGELFClientManagerThread.java
+++ b/src/main/java/org/graylog2/periodical/ChunkedGELFClientManagerThread.java
@@ -29,47 +29,46 @@ import java.util.Map;
 
 /**
  * ChunkedGELFClientManagerThread.java: Sep 20, 2010 9:28:37 PM
- *
+ * <p/>
  * [description]
  *
  * @author Lennart Koopmann <lennart@socketfeed.com>
  */
-public class ChunkedGELFClientManagerThread extends Thread {
+public class ChunkedGELFClientManagerThread implements Runnable {
 
     private static final Logger LOG = Logger.getLogger(ChunkedGELFClientManagerThread.class);
+
+    public static final int PERIOD = 10;
+    public static final int INITIAL_DELAY = 0;
+
 
     /**
      * Start the thread. Runs forever.
      */
-    @Override public void run() {
-        // Run forever.
-        while (true) {
-            try {
-                Map<String, ChunkedGELFMessage> messageMap = ChunkedGELFClientManager.getInstance().getMessageMap();
+    @Override
+    public void run() {
+        try {
+            Map<String, ChunkedGELFMessage> messageMap = ChunkedGELFClientManager.getInstance().getMessageMap();
 
-                for(Map.Entry<String, ChunkedGELFMessage> entry : messageMap.entrySet()) {
+            for (Map.Entry<String, ChunkedGELFMessage> entry : messageMap.entrySet()) {
 
-                    String messageId = entry.getKey();
-                    ChunkedGELFMessage message = entry.getValue();
+                String messageId = entry.getKey();
+                ChunkedGELFMessage message = entry.getValue();
 
-                    int fiveSecondsAgo = (int) (System.currentTimeMillis()/1000)-5;
+                int fiveSecondsAgo = (int) (System.currentTimeMillis() / 1000) - 5;
 
-                    try {
-                        if (message.getFirstChunkArrival() < fiveSecondsAgo) {
-                            this.dropMessage(messageId, "Did not completely arrive in time.");
-                        }
-                    } catch (EmptyGELFMessageException e) {
-                        // getFirstChunkArrival() did not work because first part did not arrive yet. Drop anyways.
-                        this.dropMessage(messageId, "First chunk did not arrive.");
+                try {
+                    if (message.getFirstChunkArrival() < fiveSecondsAgo) {
+                        this.dropMessage(messageId, "Did not completely arrive in time.");
                     }
+                } catch (EmptyGELFMessageException e) {
+                    // getFirstChunkArrival() did not work because first part did not arrive yet. Drop anyways.
+                    this.dropMessage(messageId, "First chunk did not arrive.");
                 }
-                
-            } catch (Exception e) {
-                LOG.warn("Error in ChunkedGELFClientManagerThread: " + e.getMessage(), e);
             }
 
-           // Run every 10 seconds.
-           try { Thread.sleep(10000); } catch(InterruptedException e) {}
+        } catch (Exception e) {
+            LOG.warn("Error in ChunkedGELFClientManagerThread: " + e.getMessage(), e);
         }
     }
 
@@ -83,5 +82,4 @@ public class ChunkedGELFClientManagerThread extends Thread {
         LOG.info("Dropping incomplete chunked GELF message <" + messageId + "> (" + reason + ")");
         ChunkedGELFClientManager.getInstance().dropMessage(messageId);
     }
-
 }

--- a/src/main/java/org/graylog2/periodical/HostCounterCacheWriterThread.java
+++ b/src/main/java/org/graylog2/periodical/HostCounterCacheWriterThread.java
@@ -27,34 +27,33 @@ import org.graylog2.database.MongoBridge;
 
 /**
  * HostCounterCacheWriterThread.java: Feb 23, 2011 5:59:58 PM
- *
+ * <p/>
  * Periodically writes host counter cache to hosts collection.
  *
  * @author Lennart Koopmann <lennart@socketfeed.com>
  */
-public class HostCounterCacheWriterThread extends Thread {
+public class HostCounterCacheWriterThread implements Runnable {
 
     private static final Logger LOG = Logger.getLogger(HostCounterCacheWriterThread.class);
+
+    public static final int PERIOD = 5;
+    public static final int INITIAL_DELAY = 5;
 
     /**
      * Start the thread. Runs forever.
      */
-    @Override public void run() {
-        // Run forever.
-        while (true) {
-            try {
-                MongoBridge m = new MongoBridge();
-                for (String host : HostCounterCache.getInstance().getAllHosts()) {
-                    m.upsertHostCount(host, HostCounterCache.getInstance().getCount(host));
-                    HostCounterCache.getInstance().reset(host);
-                }
-            } catch (Exception e) {
-                LOG.warn("Error in HostCounterCacheWriterThread: " + e.getMessage(), e);
+    @Override
+    public void run() {
+        try {
+            MongoBridge m = new MongoBridge();
+            for (String host : HostCounterCache.getInstance().getAllHosts()) {
+                m.upsertHostCount(host, HostCounterCache.getInstance().getCount(host));
+                HostCounterCache.getInstance().reset(host);
             }
-            
-           // Run every 5 seconds.
-           try { Thread.sleep(5000); } catch(InterruptedException e) {}
+        } catch (Exception e) {
+            LOG.warn("Error in HostCounterCacheWriterThread: " + e.getMessage(), e);
         }
+
     }
 
 }

--- a/src/main/java/org/graylog2/periodical/MessageCountWriterThread.java
+++ b/src/main/java/org/graylog2/periodical/MessageCountWriterThread.java
@@ -27,33 +27,31 @@ import org.graylog2.messagehandlers.common.MessageCounter;
 
 /**
  * MessageCountWriterThread.java: Sep 21, 2011 4:09:55 PM
- *
+ * <p/>
  * Periodically writes message counts to message count collection.
  *
  * @author Lennart Koopmann <lennart@socketfeed.com>
  */
-public class MessageCountWriterThread extends Thread {
+public class MessageCountWriterThread implements Runnable {
 
     private static final Logger LOG = Logger.getLogger(MessageCountWriterThread.class);
+
+    public static final int INITIAL_DELAY = 60;
+    public static final int PERIOD = 60;
 
     /**
      * Start the thread. Runs forever.
      */
-    @Override public void run() {
-        // Run forever.
-        while (true) {
-            // Run every 60 seconds.
-            try { Thread.sleep(60000); } catch(InterruptedException e) {}
-
-            MessageCounter counter = MessageCounter.getInstance();
-            try {
-                MongoBridge m = new MongoBridge();
-                m.writeMessageCounts(counter.getTotalCount(), counter.getStreamCounts(), counter.getHostCounts());
-            } catch (Exception e) {
-                LOG.warn("Error in MessageCountWriterThread: " + e.getMessage(), e);
-            } finally {
-                counter.resetAllCounts();
-            }
+    @Override
+    public void run() {
+        MessageCounter counter = MessageCounter.getInstance();
+        try {
+            MongoBridge m = new MongoBridge();
+            m.writeMessageCounts(counter.getTotalCount(), counter.getStreamCounts(), counter.getHostCounts());
+        } catch (Exception e) {
+            LOG.warn("Error in MessageCountWriterThread: " + e.getMessage(), e);
+        } finally {
+            counter.resetAllCounts();
         }
     }
 

--- a/src/main/java/org/graylog2/periodical/ServerValueWriterThread.java
+++ b/src/main/java/org/graylog2/periodical/ServerValueWriterThread.java
@@ -27,35 +27,32 @@ import org.graylog2.database.MongoBridge;
 
 /**
  * ServerValueWriterThread.java
- *
+ * <p/>
  * Periodically writes server values to MongoDB.
  *
  * @author Lennart Koopmann <lennart@socketfeed.com>
  */
-public class ServerValueWriterThread extends Thread {
+public class ServerValueWriterThread implements Runnable {
 
     private static final Logger LOG = Logger.getLogger(ServerValueWriterThread.class);
+
+    public static final int PERIOD = 60;
+    public static final int INITIAL_DELAY = 0;
 
     /**
      * Start the thread. Runs forever.
      */
-    @Override public void run() {
-        // Run forever.
-        while (true) {
-            try {
-                HostSystem.writeSystemHealthHistorically();
+    @Override
+    public void run() {
+        try {
+            HostSystem.writeSystemHealthHistorically();
 
-                // Ping. (Server is running.)
-                MongoBridge m = new MongoBridge();
-                m.setSimpleServerValue("ping", Tools.getUTCTimestamp());
+            // Ping. (Server is running.)
+            MongoBridge m = new MongoBridge();
+            m.setSimpleServerValue("ping", Tools.getUTCTimestamp());
 
-            } catch (Exception e) {
-                LOG.warn("Error in SystemValueHistoryWriterThread: " + e.getMessage(), e);
-            }
-            
-           // Run every 60 seconds.
-           try { Thread.sleep(60000); } catch(InterruptedException e) {}
+        } catch (Exception e) {
+            LOG.warn("Error in SystemValueHistoryWriterThread: " + e.getMessage(), e);
         }
     }
-
 }


### PR DESCRIPTION
Reimplemented periodical threads as scheduled Runnables with ScheduledExecutorService

The usage of Java's ScheduledExecutorService (http://download.oracle.com/javase/7/docs/api/java/util/concurrent/ScheduledExecutorService.html) simplifies the implementation of periodical threads.
