### PR TITLE
Added configuration option to set listening address for GELF service

### DIFF
--- a/misc/graylog2.conf
+++ b/misc/graylog2.conf
@@ -40,6 +40,7 @@ mongodb_threads_allowed_to_block_multiplier = 5
 
 # Graylog Extended Log Format (GELF)
 use_gelf = true
+gelf_listen_address = 0.0.0.0
 gelf_listen_port = 12201
 
 # Drools Rule File (Use to rewrite incoming log messages)

--- a/src/main/java/org/graylog2/Configuration.java
+++ b/src/main/java/org/graylog2/Configuration.java
@@ -101,6 +101,9 @@ public class Configuration {
     @Parameter(value = "use_gelf", required = true)
     private boolean useGELF = false;
 
+    @Parameter(value = "gelf_listen_address")
+    private String gelfListenAddress = "0.0.0.0";
+
     @Parameter(value = "gelf_listen_port", required = true, validator = InetPortValidator.class)
     private int gelfListenPort = 12201;
 
@@ -204,6 +207,10 @@ public class Configuration {
 
     public boolean isUseGELF() {
         return useGELF;
+    }
+
+    public String getGelfListenAddress() {
+        return gelfListenAddress;
     }
 
     public int getGelfListenPort() {

--- a/src/main/java/org/graylog2/messagehandlers/gelf/GELFMainThread.java
+++ b/src/main/java/org/graylog2/messagehandlers/gelf/GELFMainThread.java
@@ -23,6 +23,7 @@ package org.graylog2.messagehandlers.gelf;
 import org.apache.log4j.Logger;
 
 import java.net.DatagramPacket;
+import java.net.InetSocketAddress;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 
@@ -37,17 +38,17 @@ public class GELFMainThread extends Thread {
 
     private static final Logger LOG = Logger.getLogger(GELFMainThread.class);
 
-    private int port = 0;
+    private InetSocketAddress socketAddress;
 
     private ExecutorService threadPool = Executors.newCachedThreadPool();
 
     /**
      * Thread responsible for listening for GELF messages.
      *
-     * @param port The TCP port to listen on
+     * @param socketAddress The {@link InetSocketAddress} to bind to
      */
-    public GELFMainThread(int port) {
-        this.port = port;
+    public GELFMainThread(InetSocketAddress socketAddress) {
+        this.socketAddress = socketAddress;
     }
 
     /**
@@ -55,8 +56,8 @@ public class GELFMainThread extends Thread {
      */
     @Override public void run() {
         GELFServer server = new GELFServer();
-        if (!server.create(this.port)) {
-            throw new RuntimeException("Could not start GELF server. Do you have permissions to listen on UDP port " + this.port + "?");
+        if (!server.create(socketAddress)) {
+            throw new RuntimeException("Could not start GELF server. Do you have permissions to bind to " + socketAddress + "?");
         }
 
         // Run forever.

--- a/src/main/java/org/graylog2/messagehandlers/gelf/GELFServer.java
+++ b/src/main/java/org/graylog2/messagehandlers/gelf/GELFServer.java
@@ -25,6 +25,7 @@ import org.apache.log4j.Logger;
 import java.io.IOException;
 import java.net.DatagramPacket;
 import java.net.DatagramSocket;
+import java.net.InetSocketAddress;
 
 /**
  * GELFThread.java: Jun 23, 2010 6:58:07 PM
@@ -47,16 +48,18 @@ public class GELFServer {
     /**
      * Create the UDP socket.
      *
-     * @param port The port to listen on.
+     * @param socketAddress The {@link InetSocketAddress} to bind to
      * @return boolean
      */
-    public boolean create(int port) {
+    public boolean create(InetSocketAddress socketAddress) {
         try {
-            this.serverSocket = new DatagramSocket(port);
+            this.serverSocket = new DatagramSocket(socketAddress);
         } catch(IOException e) {
             LOG.fatal("Could not create ServerSocket in GELFServer::create(): " + e.getMessage(), e);
             return false;
         }
+
+        LOG.info("Started GELF server on " + socketAddress);
 
         return true;
     }


### PR DESCRIPTION
Added configuration option `gelf_listen_address` to set listening address for GELF service. Supports IPv4 and IPv6 as well as hostnames (resolved on startup, see [InetSocketAddress](http://docs.oracle.com/javase/6/docs/api/java/net/InetSocketAddress.html)).

Should fix [#SERVER-27](http://jira.graylog2.org/browse/SERVER-27).
