### PR TITLE
Added configuration option syslog_listen_address

### DIFF
--- a/src/main/java/org/graylog2/Configuration.java
+++ b/src/main/java/org/graylog2/Configuration.java
@@ -53,6 +53,9 @@ public class Configuration {
     @Parameter(value = "syslog_protocol", required = true)
     private String syslogProtocol = "udp";
 
+    @Parameter(value = "syslog_listen_address")
+    private String syslogListenAddress = "0.0.0.0";
+
     @Parameter(value = "force_syslog_rdns", required = true)
     private boolean forceSyslogRdns = false;
 
@@ -145,6 +148,10 @@ public class Configuration {
 
     public int getSyslogListenPort() {
         return syslogListenPort;
+    }
+
+    public String getSyslogListenAddress() {
+        return syslogListenAddress;
     }
 
     public String getSyslogProtocol() {

--- a/src/main/java/org/graylog2/Main.java
+++ b/src/main/java/org/graylog2/Main.java
@@ -154,7 +154,7 @@ public final class Main {
 
         initializeMongoConnection(configuration);
         initializeRulesEngine(configuration.getDroolsRulesFile());
-        initializeSyslogServer(configuration.getSyslogProtocol(), configuration.getSyslogListenPort());
+        initializeSyslogServer(configuration.getSyslogProtocol(), configuration.getSyslogListenPort(), configuration.getSyslogListenAddress());
         initializeHostCounterCache(scheduler);
 
         // Start message counter thread.
@@ -240,10 +240,10 @@ public final class Main {
         LOG.info("GELF threads started");
     }
 
-    private static void initializeSyslogServer(String syslogProtocol, int syslogPort) {
+    private static void initializeSyslogServer(String syslogProtocol, int syslogPort, String syslogHost) {
 
         // Start the Syslog thread that accepts syslog packages.
-        SyslogServerThread syslogServerThread = new SyslogServerThread(syslogProtocol, syslogPort);
+        SyslogServerThread syslogServerThread = new SyslogServerThread(syslogProtocol, syslogPort, syslogHost);
         syslogServerThread.start();
 
         // Check if the thread started up completely.

--- a/src/main/java/org/graylog2/messagehandlers/syslog/SyslogServerThread.java
+++ b/src/main/java/org/graylog2/messagehandlers/syslog/SyslogServerThread.java
@@ -34,6 +34,7 @@ import org.productivity.java.syslog4j.server.SyslogServerIF;
 public class SyslogServerThread extends Thread {
 
     private int port;
+    private String host;
     private String syslogProtocol;
 
     private Thread coreThread = null;
@@ -44,9 +45,10 @@ public class SyslogServerThread extends Thread {
      * @param syslogProtocol Protocol to use for the Syslog server (tcp/udp)
      * @param port On which port to listen?
      */
-    public SyslogServerThread(String syslogProtocol, int port) {
+    public SyslogServerThread(String syslogProtocol, int port, String host) {
         this.syslogProtocol = syslogProtocol;
         this.port = port;
+        this.host = host;
     }
 
     /**
@@ -58,6 +60,7 @@ public class SyslogServerThread extends Thread {
         SyslogServerConfigIF syslogServerConfig = syslogServer.getConfig();
         
         syslogServerConfig.setPort(port);
+        syslogServerConfig.setHost(host);
         syslogServerConfig.setUseStructuredData(true);
         syslogServerConfig.addEventHandler(new SyslogEventHandler());
 


### PR DESCRIPTION
- syslog_listen_address enables the user to specify the IP address which Syslog4j should listen on
- Thanks to Frederik Happel for providing the patch
