### PR TITLE
Fix a false negative corner case (->network provider of your build host ...

### DIFF
--- a/src/test/java/org/graylog2/ConfigurationTest.java
+++ b/src/test/java/org/graylog2/ConfigurationTest.java
@@ -220,7 +220,7 @@ public class ConfigurationTest {
 
     @Test
     public void testGetMongoDBReplicaSetServersUnknownHost() throws RepositoryException, ValidationException {
-        validProperties.put("mongodb_replica_set", "this-host-hopefully-does-not-exist:27017");
+        validProperties.put("mongodb_replica_set", "this-host-hopefully-does-not-exist.:27017");
         Configuration configuration = new Configuration();
         new JadConfig(new InMemoryRepository(validProperties), configuration).process();
 


### PR DESCRIPTION
...providing both default DNS search domain which in turn has wildcard record)

You can argue that this will only happen because of bad network configuration practice - but sometimes that is outside of your control. A single dot after the hostname signifying the root domain should be sufficient.
