### PR TITLE
Add a sample plist for mananging Graylog2 with launchd on OS X.

### DIFF
--- a/contrib/distro/mac_os_x/org.graylog2.graylog2-server.plist
+++ b/contrib/distro/mac_os_x/org.graylog2.graylog2-server.plist
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>Label</key>
+	<string>org.graylog2.graylog2-server</string>
+	<key>ProgramArguments</key>
+	<array>
+		<string>java</string>
+		<string>-jar</string>
+		<string>/usr/local/Cellar/graylog2-server/0.9.6/graylog2-server.jar</string>
+		<string>-f</string>
+		<string>/usr/local/etc/graylog2.conf</string>
+		<string>-p</string>
+		<string>/tmp/graylog2.pid</string>
+	</array>
+	<key>RunAtLoad</key>
+	<true/>
+	<key>KeepAlive</key>
+	<false/>
+	<key>UserName</key>
+	<string>root</string>
+	<key>WorkingDirectory</key>
+	<string>/usr/local</string>
+	<key>StandardErrorPath</key>
+	<string>/usr/local/var/log/graylog2-server/output.log</string>
+	<key>StandardOutPath</key>
+	<string>/usr/local/var/log/graylog2-server/output.log</string>
+</dict>
+</plist>


### PR DESCRIPTION
Note that this sample plist is using hard-coded locations of where [Homebrew](http://mxcl.github.com/homebrew/) installs Graylog2 0.9.6. For Homebrew, I submitted a [pull request](https://github.com/mxcl/homebrew/pull/11519) for the [graylog2-server.rb brew formula](https://github.com/mxcl/homebrew/blob/master/Library/Formula/graylog2-server.rb) to make it dynamically generate an appropriate plist. For non-Homebrew installs, this plist would need to be tweaked.

launchd resources:
- [Wikipedia page](http://en.wikipedia.org/wiki/Launchd)
- [developer.apple.com - Creating a launchd Property List File](http://developer.apple.com/library/mac/#documentation/MacOSX/Conceptual/BPSystemStartup/Chapters/CreatingLaunchdJobs.html)
