### PR TITLE
add rules checking to configtest

### DIFF
--- a/src/main/java/org/graylog2/Main.java
+++ b/src/main/java/org/graylog2/Main.java
@@ -98,8 +98,12 @@ public final class Main {
             System.exit(1);
         }
 
-        // If we only want to check our configuration, we can gracefully exit here
+        // If we only want to check our configuration, we just initialize the rules engine to check if the rules compile
         if (commandLineArguments.isConfigTest()) {
+            GraylogServer server = new GraylogServer();
+            DroolsInitializer drools = new DroolsInitializer(server, configuration);
+            drools.initialize();
+            // rules have been checked, exit gracefully
             System.exit(0);
         }
 


### PR DESCRIPTION
I've added the compilation of the rules file during configtest so you can check your DRL before you restart and avoid unnecessary crashes. ;)
