### PR TITLE
Update syslog install script

### DIFF
--- a/install-syslog4j-jar.sh
+++ b/install-syslog4j-jar.sh
@@ -1,2 +1,5 @@
+MVN_REPO="/tmp/graylog2-server-build-${USER}"
+MVN_OPTS=-Dmaven.repo.local=${MVN_REPO}
+
 echo "Installing provided syslog4j jar to local mvn repository for great justice!"
-mvn install:install-file -DgroupId=org.syslog4j -DartifactId=syslog4j -Dversion=0.9.46 -Dpackaging=jar -Dfile=lib/syslog4j-0.9.46-bin.jar
+mvn install:install-file ${MVN_OPTS} -DgroupId=org.syslog4j -DartifactId=syslog4j -Dversion=0.9.46 -Dpackaging=jar -Dfile=lib/syslog4j-0.9.46-bin.jar


### PR DESCRIPTION
This is just to match up with the `MVN_REPO` setting in the `Makefile`, so that you can do:

``` bash
$ ./install-syslog4j-jar.sh
$ make
```

It was failing for me otherwise.
