### PR TITLE
Don't create a PID file if asked not to do so

### DIFF
--- a/src/main/java/org/graylog2/CommandLineArguments.java
+++ b/src/main/java/org/graylog2/CommandLineArguments.java
@@ -20,6 +20,9 @@ public class CommandLineArguments {
     @Parameter(names = {"-p", "--pidfile"}, description = "File containing the PID of graylog2")
     private String pidFile = TMPDIR + FILE_SEPARATOR + "graylog2.pid";
 
+    @Parameter(names = {"-np", "--no-pid-file"}, description = "Do not use a PID file (overrides -p/--pidfile)")
+    private boolean noPidFile = false;
+
     @Parameter(names = {"-t", "--configtest"}, description = "Validate graylog2 configuration and exit")
     private boolean configTest = false;
 
@@ -49,6 +52,14 @@ public class CommandLineArguments {
 
     public void setPidFile(String pidFile) {
         this.pidFile = pidFile;
+    }
+
+    public boolean isNoPidFile() {
+        return noPidFile;
+    }
+
+    public void setNoPidFile(final boolean noPidFile) {
+        this.noPidFile = noPidFile;
     }
 
     public boolean isConfigTest() {

--- a/src/main/java/org/graylog2/Main.java
+++ b/src/main/java/org/graylog2/Main.java
@@ -110,7 +110,9 @@ public final class Main {
             System.exit(0);
         }
 
-        savePidFile(commandLineArguments.getPidFile());
+        // Do not use a PID file if the user requested not to
+        if (!commandLineArguments.isNoPidFile())
+            savePidFile(commandLineArguments.getPidFile());
 
         // Le server object. This is where all the magic happens.
         GraylogServer server = new GraylogServer();


### PR DESCRIPTION
```
Systems administrators and, more importantly, packagers, may wish to handle 
files by themselves, using tools such as start-stop-daemon or equivalents. I
this scenario, having graylog2 create a PID file is undesirable.

Add an option so that graylog2 not attempt to create a PID file. This allows
more graceful cooperation with such tools.
```
