### PR TITLE
Make tokenizer filter to recognize double quoted values so it will not b...

### DIFF
--- a/src/test/java/org/graylog2/filters/TokenizerFilterTest.java
+++ b/src/test/java/org/graylog2/filters/TokenizerFilterTest.java
@@ -163,6 +163,17 @@ public class TokenizerFilterTest {
         assertEquals("v4", msg.getAdditionalData().get("_k4"));
     }
 
+    @Test
+    public void testFilterWithQuotedValue() {
+        LogMessageImpl msg = new LogMessageImpl();
+        msg.setShortMessage("otters in k1=\"v1\" more otters");
+        TokenizerFilter f = new TokenizerFilter();
+        f.filter(msg, new GraylogServerStub());
+
+        assertEquals("There should be 1 kv pairs", 1, msg.getAdditionalData().size());
+        assertEquals("v1", msg.getAdditionalData().get("_k1"));
+    }
+
    @Test
     public void testFilterWithIDAdditionalField() {
         LogMessageImpl msg = new LogMessageImpl();


### PR DESCRIPTION
...reak on whitespace in a quoted value string

With this I can use tokenizer filter for our Astaro firewall logs with success:

2012: 10:18-16:20:47 ulogd[6288]: id="2002" severity="info" sys="SecureNet" sub="packetfilter" name="Packet accepted" action="accept" fwrule="7" initf="eth0" outitf="eth2" srcmac="xx:xx:xx:xx:xx:xx" dstmac="xx:xx:xx:xx:xx:xx" srcip="172.16.3.145" dstip="10.1.1.5" proto="17" length="74" tos="0x00" prec="0x00" ttl="126" srcport="55200" dstport="53"
