### PR TITLE
added HTTP server support, disabled by default

### DIFF
--- a/misc/graylog2.conf
+++ b/misc/graylog2.conf
@@ -99,6 +99,15 @@ amqp_username = guest
 amqp_password = guest
 amqp_virtualhost = /
 
+# HTTP input
+# the server will accept PUT requests to /gelf or /gelf/raw
+# /gelf can process all standard GELF messages containing the two header bytes
+# /gelf/raw can only process uncompressed GELF messages without any header bytes.
+# the HTTP server allows keep-alive connections and supports compression.
+http_enabled = false
+http_listen_address = 0.0.0.0
+http_listen_port = 12202
+
 # Email transport
 transport_email_enabled = false
 transport_email_hostname = mail.example.com

--- a/src/main/java/org/graylog2/Configuration.java
+++ b/src/main/java/org/graylog2/Configuration.java
@@ -20,11 +20,6 @@
 
 package org.graylog2;
 
-import java.util.Arrays;
-import java.util.List;
-
-import org.apache.log4j.Logger;
-
 import com.github.joschi.jadconfig.Parameter;
 import com.github.joschi.jadconfig.ValidationException;
 import com.github.joschi.jadconfig.ValidatorMethod;
@@ -35,9 +30,13 @@ import com.github.joschi.jadconfig.validators.PositiveIntegerValidator;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.mongodb.ServerAddress;
-import java.net.UnknownHostException;
-import java.util.Map;
+import org.apache.log4j.Logger;
 import org.graylog2.indexer.EmbeddedElasticSearchClient;
+
+import java.net.UnknownHostException;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
 
 /**
  * Helper class to hold configuration of Graylog2
@@ -269,7 +268,16 @@ public class Configuration {
     
     @Parameter(value = "transport_jabber_message_prefix", required = false)
     private String jabberTransportMessagePrefix;
-    
+
+    @Parameter("http_enabled")
+    private boolean httpEnabled = false;
+
+    @Parameter("http_listen_address")
+    private String httpListenAddress = "0.0.0.0";
+
+    @Parameter(value = "http_listen_port", validator = InetPortValidator.class, required = false)
+    private int httpListenPort = 12202;
+
     public boolean isMaster() {
         return isMaster;
     }
@@ -583,4 +591,15 @@ public class Configuration {
         }
     }
 
+    public boolean isHttpEnabled() {
+        return httpEnabled;
+    }
+
+    public String getHttpListenAddress() {
+        return httpListenAddress;
+    }
+
+    public int getHttpListenPort() {
+        return httpListenPort;
+    }
 }

--- a/src/main/java/org/graylog2/Main.java
+++ b/src/main/java/org/graylog2/Main.java
@@ -25,29 +25,25 @@ import com.github.joschi.jadconfig.JadConfig;
 import com.github.joschi.jadconfig.RepositoryException;
 import com.github.joschi.jadconfig.ValidationException;
 import com.github.joschi.jadconfig.repositories.PropertiesRepository;
-import com.google.common.collect.Maps;
-import java.io.File;
-import java.io.FileWriter;
-import java.io.Writer;
-import java.util.Map;
 import org.apache.commons.io.IOUtils;
 import org.apache.log4j.Level;
 import org.apache.log4j.Logger;
 import org.graylog2.activities.Activity;
 import org.graylog2.alarms.transports.EmailTransport;
 import org.graylog2.alarms.transports.JabberTransport;
-import org.graylog2.filters.BlacklistFilter;
-import org.graylog2.filters.CounterUpdateFilter;
-import org.graylog2.filters.RewriteFilter;
-import org.graylog2.filters.StreamMatcherFilter;
-import org.graylog2.filters.TokenizerFilter;
+import org.graylog2.filters.*;
 import org.graylog2.initializers.*;
 import org.graylog2.inputs.amqp.AMQPInput;
 import org.graylog2.inputs.gelf.GELFTCPInput;
 import org.graylog2.inputs.gelf.GELFUDPInput;
+import org.graylog2.inputs.http.GELFHttpInput;
 import org.graylog2.inputs.syslog.SyslogTCPInput;
 import org.graylog2.inputs.syslog.SyslogUDPInput;
 import org.graylog2.outputs.ElasticSearchOutput;
+
+import java.io.File;
+import java.io.FileWriter;
+import java.io.Writer;
 
 /**
  * Main class of Graylog2.
@@ -180,7 +176,9 @@ public final class Main {
         if (configuration.isSyslogTcpEnabled()) { server.registerInput(new SyslogTCPInput()); }
 
         if (configuration.isAmqpEnabled()) { server.registerInput(new AMQPInput()); }
-        
+
+        if (configuration.isHttpEnabled()) { server.registerInput(new GELFHttpInput()); }
+
         // Register message filters.
         server.registerFilter(new RewriteFilter());
         server.registerFilter(new BlacklistFilter());

--- a/src/main/java/org/graylog2/inputs/http/GELFHttpHandler.java
+++ b/src/main/java/org/graylog2/inputs/http/GELFHttpHandler.java
@@ -1,0 +1,106 @@
+/**
+ * Copyright 2012 Kay Roepke <kroepke@googlemail.com>
+ *
+ * This file is part of Graylog2.
+ *
+ * Graylog2 is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog2 is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog2.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+package org.graylog2.inputs.http;
+
+import com.yammer.metrics.Metrics;
+import com.yammer.metrics.core.Meter;
+import org.apache.log4j.Logger;
+import org.graylog2.Core;
+import org.graylog2.gelf.GELFMessage;
+import org.graylog2.gelf.GELFProcessor;
+import org.jboss.netty.buffer.ChannelBuffer;
+import org.jboss.netty.channel.*;
+import org.jboss.netty.handler.codec.http.*;
+
+import java.util.concurrent.TimeUnit;
+
+import static org.jboss.netty.handler.codec.http.HttpHeaders.isKeepAlive;
+
+public class GELFHttpHandler extends SimpleChannelHandler {
+
+    private static final Logger LOG = Logger.getLogger(GELFHttpHandler.class);
+
+    private final Core server;
+    private final Meter receivedMessages = Metrics.newMeter(GELFHttpHandler.class, "ReceivedMessages", "messages", TimeUnit.SECONDS);
+    private final Meter gelfMessages = Metrics.newMeter(GELFHttpHandler.class, "ReceivedGelfMessages", "messages", TimeUnit.SECONDS);
+    private final Meter rawMessages = Metrics.newMeter(GELFHttpHandler.class, "ReceivedRawMessages", "messages", TimeUnit.SECONDS);
+    private final GELFProcessor gelfProcessor;
+
+    public GELFHttpHandler(Core server) {
+        this.server = server;
+        gelfProcessor = new GELFProcessor(server);
+    }
+
+    @Override
+    public void messageReceived(final ChannelHandlerContext ctx, final MessageEvent e) throws Exception {
+        receivedMessages.mark();
+
+        final HttpRequest request = (HttpRequest) e.getMessage();
+        final boolean keepAlive = isKeepAlive(request);
+        final HttpVersion httpRequestVersion = request.getProtocolVersion();
+
+        // to allow for future changes, let's be at least a little strict in what we accept here.
+        if (request.getMethod() != HttpMethod.PUT) {
+            writeResponse(e.getChannel(), keepAlive, httpRequestVersion, HttpResponseStatus.METHOD_NOT_ALLOWED);
+        }
+
+        // there are two variants to get data in via HTTP:
+        // 1. just send a common GELF message, including the header bytes (see GELFMessage.Type)
+        // 2. only sending the uncompressed "raw" message, i.e. only the actual JSON
+        //    currently GELFMessage does not support "RAW", so we jump through some hoops to avoid System.arrayCopy
+        final ChannelBuffer buffer = request.getContent();
+        final byte[] message = new byte[buffer.readableBytes()];
+        buffer.toByteBuffer().get(message, buffer.readerIndex(), buffer.readableBytes());
+
+        final GELFMessage msg;
+        if ("/gelf/raw".equals(request.getUri())) {
+            rawMessages.mark();
+            msg = new GELFMessage(message, true);
+        } else if ("/gelf".equals(request.getUri())) {
+            gelfMessages.mark();
+            msg = new GELFMessage(message);
+        } else {
+            writeResponse(e.getChannel(), keepAlive, httpRequestVersion, HttpResponseStatus.NOT_FOUND);
+            return;
+        }
+
+        gelfProcessor.messageReceived(msg);
+        writeResponse(e.getChannel(), keepAlive, httpRequestVersion, HttpResponseStatus.ACCEPTED);
+    }
+
+    private void writeResponse(Channel channel, boolean keepAlive, HttpVersion httpRequestVersion, HttpResponseStatus status) {
+        final HttpResponse response =
+            new DefaultHttpResponse(httpRequestVersion, status);
+
+        if (keepAlive) {
+            response.setHeader(HttpHeaders.Names.CONNECTION, HttpHeaders.Values.KEEP_ALIVE);
+        }
+
+        final ChannelFuture channelFuture = channel.write(response);
+        if (!keepAlive) {
+            channelFuture.addListener(ChannelFutureListener.CLOSE);
+        }
+    }
+
+    @Override
+    public void exceptionCaught(final ChannelHandlerContext ctx, final ExceptionEvent e) throws Exception {
+        LOG.warn("Could not handle GELF message.", e.getCause());
+    }
+}

--- a/src/main/java/org/graylog2/inputs/http/GELFHttpInput.java
+++ b/src/main/java/org/graylog2/inputs/http/GELFHttpInput.java
@@ -1,0 +1,76 @@
+/**
+ * Copyright 2012 Kay Roepke <kroepke@googlemail.com>
+ *
+ * This file is part of Graylog2.
+ *
+ * Graylog2 is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog2 is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog2.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+package org.graylog2.inputs.http;
+
+import org.apache.commons.lang3.concurrent.BasicThreadFactory;
+import org.apache.log4j.Logger;
+import org.graylog2.Configuration;
+import org.graylog2.Core;
+import org.graylog2.inputs.MessageInput;
+import org.jboss.netty.bootstrap.ServerBootstrap;
+import org.jboss.netty.channel.ChannelException;
+import org.jboss.netty.channel.socket.nio.NioServerSocketChannelFactory;
+
+import java.net.InetSocketAddress;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+
+public class GELFHttpInput implements MessageInput {
+
+    private static final Logger LOG = Logger.getLogger(GELFHttpInput.class);
+
+    @Override
+    public void initialize(final Configuration configuration, final Core graylogServer) {
+        final InetSocketAddress socketAddress = new InetSocketAddress(configuration.getHttpListenAddress(), configuration.getHttpListenPort());
+
+        final ExecutorService bossExecutor = Executors.newCachedThreadPool(
+            new BasicThreadFactory.Builder()
+                .namingPattern("input-gelfhttp-boss-%d")
+                .build());
+
+        final ExecutorService workerExecutor = Executors.newCachedThreadPool(
+            new BasicThreadFactory.Builder()
+                .namingPattern("input-gelfhttp-worker-%d")
+                .build());
+
+        final ServerBootstrap httpBootstrap = new ServerBootstrap(
+            new NioServerSocketChannelFactory(bossExecutor, workerExecutor)
+        );
+        httpBootstrap.setPipelineFactory(new GELFHttpPipelineFactory(graylogServer));
+
+        try {
+            httpBootstrap.bind(socketAddress);
+            LOG.info("Started HTTP GELF server on " + socketAddress);
+        } catch (final ChannelException e) {
+            LOG.fatal("Could not bind HTTP GELF server to address " + socketAddress, e);
+        }
+        Runtime.getRuntime().addShutdownHook(new Thread() {
+            @Override
+            public void run() {
+                httpBootstrap.releaseExternalResources();
+            }
+        });
+    }
+
+    @Override
+    public String getName() {
+        return "HTTP GELF";
+    }
+}

--- a/src/main/java/org/graylog2/inputs/http/GELFHttpPipelineFactory.java
+++ b/src/main/java/org/graylog2/inputs/http/GELFHttpPipelineFactory.java
@@ -1,0 +1,52 @@
+/**
+ * Copyright 2012 Kay Roepke <kroepke@googlemail.com>
+ *
+ * This file is part of Graylog2.
+ *
+ * Graylog2 is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog2 is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog2.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+package org.graylog2.inputs.http;
+
+import org.graylog2.Core;
+import org.jboss.netty.channel.ChannelPipeline;
+import org.jboss.netty.channel.ChannelPipelineFactory;
+import org.jboss.netty.channel.Channels;
+import org.jboss.netty.handler.codec.http.HttpContentDecompressor;
+import org.jboss.netty.handler.codec.http.HttpRequestDecoder;
+import org.jboss.netty.handler.codec.http.HttpResponseEncoder;
+
+public class GELFHttpPipelineFactory implements ChannelPipelineFactory {
+
+    private final Core graylogServer;
+
+    public GELFHttpPipelineFactory(Core graylogServer) {
+        this.graylogServer = graylogServer;
+    }
+
+    @Override
+    public ChannelPipeline getPipeline() throws Exception {
+        final ChannelPipeline pipeline = Channels.pipeline();
+
+        pipeline.addLast("decoder", new HttpRequestDecoder());
+        pipeline.addLast("encoder", new HttpResponseEncoder());
+
+        // only add support for incoming compressed messages, we don't return much (if any) data to the client.
+        pipeline.addLast("decompressor", new HttpContentDecompressor());
+
+        pipeline.addLast("handler", new GELFHttpHandler(graylogServer));
+
+        return pipeline;
+    }
+}


### PR DESCRIPTION
it only allows PUT requests to /gelf and /gelf/raw
/gelf supports all standard GELF messages, like the other inputs
/gelf/raw understands only uncompressed GELF _without_ any header bytes
the HTTP server supports keep-alive and compression via the common HTTP headers
