### PR TITLE
Add bulk hasCapacity/insert methods to ProcessBuffer

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -156,7 +156,7 @@
         <dependency>
             <groupId>org.graylog2</groupId>
             <artifactId>graylog2-plugin</artifactId>
-            <version>0.10.12</version>
+            <version>0.10.13-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.productivity.java</groupId>

--- a/src/main/java/org/graylog2/Core.java
+++ b/src/main/java/org/graylog2/Core.java
@@ -20,52 +20,53 @@
 
 package org.graylog2;
 
-import org.graylog2.plugin.Tools;
-import java.util.List;
-import java.util.concurrent.Executors;
-import java.util.concurrent.ScheduledExecutorService;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-import org.graylog2.blacklists.BlacklistCache;
-import org.graylog2.buffers.OutputBuffer;
-import org.graylog2.buffers.ProcessBuffer;
-import org.graylog2.database.MongoBridge;
-import org.graylog2.database.MongoConnection;
-import org.graylog2.indexer.EmbeddedElasticSearchClient;
-import org.graylog2.plugin.initializers.Initializer;
-import org.graylog2.plugin.inputs.MessageInput;
-import org.graylog2.gelf.GELFChunkManager;
-import org.graylog2.plugin.outputs.MessageOutput;
-import org.graylog2.streams.StreamCache;
-
 import com.google.common.collect.Lists;
-import java.util.concurrent.atomic.AtomicInteger;
 import com.google.common.collect.Maps;
-import java.util.Map;
 import com.google.common.util.concurrent.ThreadFactoryBuilder;
 import org.cliffc.high_scale_lib.Counter;
 import org.graylog2.activities.Activity;
 import org.graylog2.activities.ActivityWriter;
+import org.graylog2.blacklists.BlacklistCache;
+import org.graylog2.buffers.OutputBuffer;
+import org.graylog2.buffers.ProcessBuffer;
 import org.graylog2.cluster.Cluster;
 import org.graylog2.database.HostCounterCacheImpl;
+import org.graylog2.database.MongoBridge;
+import org.graylog2.database.MongoConnection;
+import org.graylog2.gelf.GELFChunkManager;
 import org.graylog2.indexer.Deflector;
-import org.graylog2.initializers.*;
+import org.graylog2.indexer.EmbeddedElasticSearchClient;
+import org.graylog2.initializers.StandardInitializerSet;
 import org.graylog2.inputs.StandardInputSet;
 import org.graylog2.plugin.GraylogServer;
+import org.graylog2.plugin.Tools;
 import org.graylog2.plugin.alarms.callbacks.AlarmCallback;
 import org.graylog2.plugin.alarms.callbacks.AlarmCallbackConfigurationException;
 import org.graylog2.plugin.alarms.transports.Transport;
 import org.graylog2.plugin.alarms.transports.TransportConfigurationException;
+import org.graylog2.plugin.buffers.BatchBuffer;
 import org.graylog2.plugin.buffers.Buffer;
 import org.graylog2.plugin.filters.MessageFilter;
 import org.graylog2.plugin.indexer.MessageGateway;
+import org.graylog2.plugin.initializers.Initializer;
 import org.graylog2.plugin.initializers.InitializerConfigurationException;
+import org.graylog2.plugin.inputs.MessageInput;
 import org.graylog2.plugin.inputs.MessageInputConfigurationException;
+import org.graylog2.plugin.outputs.MessageOutput;
 import org.graylog2.plugin.outputs.MessageOutputConfigurationException;
 import org.graylog2.plugin.streams.Stream;
 import org.graylog2.plugins.PluginConfiguration;
 import org.graylog2.plugins.PluginLoader;
+import org.graylog2.streams.StreamCache;
 import org.graylog2.streams.StreamImpl;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.atomic.AtomicInteger;
 
 /**
  * Server core, handling and holding basically everything.
@@ -399,7 +400,7 @@ public class Core implements GraylogServer {
     }
 
     @Override
-    public Buffer getProcessBuffer() {
+    public BatchBuffer getProcessBuffer() {
         return this.processBuffer;
     }
 

--- a/src/main/java/org/graylog2/buffers/ProcessBuffer.java
+++ b/src/main/java/org/graylog2/buffers/ProcessBuffer.java
@@ -21,6 +21,7 @@
 package org.graylog2.buffers;
 
 import com.google.common.util.concurrent.ThreadFactoryBuilder;
+import com.lmax.disruptor.BatchDescriptor;
 import com.lmax.disruptor.MultiThreadedClaimStrategy;
 import com.lmax.disruptor.RingBuffer;
 import com.lmax.disruptor.dsl.Disruptor;
@@ -28,7 +29,8 @@ import com.yammer.metrics.Metrics;
 import com.yammer.metrics.core.Meter;
 import org.graylog2.Core;
 import org.graylog2.buffers.processors.ProcessBufferProcessor;
-import org.graylog2.plugin.buffers.Buffer;
+import org.graylog2.plugin.buffers.BatchBuffer;
+import org.graylog2.plugin.buffers.BufferOutOfCapacityException;
 import org.graylog2.plugin.logmessage.LogMessage;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -36,12 +38,11 @@ import org.slf4j.LoggerFactory;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
-import org.graylog2.plugin.buffers.BufferOutOfCapacityException;
 
 /**
  * @author Lennart Koopmann <lennart@socketfeed.com>
  */
-public class ProcessBuffer implements Buffer {
+public class ProcessBuffer implements BatchBuffer {
 
     private static final Logger LOG = LoggerFactory.getLogger(ProcessBuffer.class);
     
@@ -102,9 +103,49 @@ public class ProcessBuffer implements Buffer {
         incomingMessages.mark();
     }
 
+    /**
+     * Try to insert a batch of messages atomically if sufficient slots are available, failing without blocking or inserting
+     * any messages if sufficient slots are not available.
+     *
+     * @throws BufferOutOfCapacityException if the buffer is bigger than the batch but insufficient free slots are available
+     * @throws IllegalStateException if the batch is bigger than the buffer, so an atomic insert is impossible
+     */
+    @Override
+    public void insert(LogMessage[] logMessages) throws BufferOutOfCapacityException {
+        if (ringBuffer.getBufferSize() < logMessages.length) {
+            throw new IllegalStateException("Message batch size too large for atomic bulk insert to be possible - RingBuffer size (" + ringBuffer.getBufferSize() + ") < message batch size (" + logMessages.length + ")");
+        }
+
+        if (!hasCapacity(logMessages.length)) {
+            LOG.warn("Rejecting message, because I am full. Raise my size or add more processors.");
+            rejectedMessages.mark(logMessages.length);
+            throw new BufferOutOfCapacityException();
+        }
+
+        BatchDescriptor batchDescriptor = ringBuffer.newBatchDescriptor(logMessages.length);
+        if (batchDescriptor.getSize() != logMessages.length)
+            throw new IllegalStateException("Message batch size too large for atomic bulk insert to be possible - BatchDescriptor size (" + batchDescriptor.getSize() + ") < message batch size (" + logMessages.length + ")");
+
+        // FIXME: Unfortunately this will block until the requested number of slots are available, so a race condition exists where two producers can bypass the hasCapacity() check and block if one fills the buffer before the other
+        ringBuffer.next(batchDescriptor);
+        for (int i = 0; i < logMessages.length; i++) {
+            LogMessageEvent event = ringBuffer.get(batchDescriptor.getStart() + (long) i);
+            event.setMessage(logMessages[i]);
+        }
+        ringBuffer.publish(batchDescriptor);
+
+        server.processBufferWatermark().addAndGet(logMessages.length);
+        incomingMessages.mark(logMessages.length);
+    }
+
     @Override
     public boolean hasCapacity() {
-        return ringBuffer.remainingCapacity() > 0;
+        return hasCapacity(1);
+    }
+
+    @Override
+    public boolean hasCapacity(int i) {
+        return ringBuffer.remainingCapacity() >= i;
     }
 
 }

--- a/src/test/java/org/graylog2/buffers/processors/ProcessBufferProcessorTest.java
+++ b/src/test/java/org/graylog2/buffers/processors/ProcessBufferProcessorTest.java
@@ -5,10 +5,22 @@
 
 package org.graylog2.buffers.processors;
 
+import org.graylog2.Configuration;
+import org.graylog2.GraylogServerStub;
+import org.graylog2.buffers.ProcessBuffer;
+import org.graylog2.plugin.buffers.Buffer;
+import org.graylog2.plugin.buffers.BufferOutOfCapacityException;
+import org.graylog2.plugin.logmessage.LogMessage;
 import org.junit.AfterClass;
+import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
-import static org.junit.Assert.*;
+
+import java.util.BitSet;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
 
 /**
  * @author lennart.koopmann
@@ -30,4 +42,120 @@ public class ProcessBufferProcessorTest {
     public void testOnEvent() throws Exception {
     }
 
+    @Test
+    public void testBatching() throws Exception {
+        final QueueBuffer queueBuffer = new QueueBuffer();
+        GraylogServerStub serverStub = new GraylogServerStub() {
+            @Override
+            public Buffer getOutputBuffer() {
+                return queueBuffer;
+            }
+        };
+        Configuration configStub = new Configuration();
+        serverStub.setConfigurationStub(configStub);
+        int bufferSize = configStub.getRingSize();
+
+        ProcessBuffer buffer = new ProcessBuffer(serverStub);
+        buffer.initialize();
+
+        AtomicInteger counter = new AtomicInteger();
+
+        // Empty buffer
+        Assert.assertTrue(buffer.hasCapacity());
+        Assert.assertTrue(buffer.hasCapacity(bufferSize));
+        Assert.assertFalse(buffer.hasCapacity(bufferSize + 1));
+
+        // Overflow (use separate counter as these messages will be thrown away)
+        try {
+            buffer.insert(messages(new AtomicInteger(bufferSize), bufferSize + 1));
+            Assert.fail();
+        } catch (IllegalStateException e) { }
+
+        // Add one message
+        buffer.insert(message(counter));
+
+        Assert.assertTrue(buffer.hasCapacity());
+        Assert.assertTrue(buffer.hasCapacity(bufferSize - 1));
+        Assert.assertFalse(buffer.hasCapacity(bufferSize));
+        Assert.assertFalse(buffer.hasCapacity(bufferSize + 1));
+
+        // Top up to size / 2  messages
+        buffer.insert(messages(counter, (bufferSize / 2) - counter.get()));
+
+        Assert.assertTrue(buffer.hasCapacity());
+        Assert.assertTrue(buffer.hasCapacity(bufferSize / 2));
+        Assert.assertFalse(buffer.hasCapacity((bufferSize / 2) + 1));
+        Assert.assertFalse(buffer.hasCapacity(bufferSize));
+        Assert.assertFalse(buffer.hasCapacity(bufferSize + 1));
+
+        // Overflow (use separate counter as these messages will be thrown away)
+        try {
+            buffer.insert(messages(new AtomicInteger(bufferSize * 2), (bufferSize / 2) + 1));
+            Assert.fail();
+        } catch (BufferOutOfCapacityException e) { }
+
+        Assert.assertTrue(buffer.hasCapacity());
+        Assert.assertTrue(buffer.hasCapacity(bufferSize / 2));
+        Assert.assertFalse(buffer.hasCapacity((bufferSize / 2) + 1));
+        Assert.assertFalse(buffer.hasCapacity(bufferSize));
+        Assert.assertFalse(buffer.hasCapacity(bufferSize + 1));
+
+        // Fill
+        buffer.insert(messages(counter, (bufferSize / 2)));
+
+        Assert.assertFalse(buffer.hasCapacity());
+        Assert.assertFalse(buffer.hasCapacity(2));
+
+        // Drain and verify all messages delivered (multiple processor threads so cannot guarantee this will be in order)
+        queueBuffer.insertLatch.countDown();
+
+        BitSet seenMessages = new BitSet();
+
+        for (int i = 0; i < bufferSize; i++) {
+            int messageId = drainMessage(queueBuffer);
+            if (seenMessages.get(messageId)) Assert.fail("Received message " + messageId + " twice");
+            seenMessages.set(messageId);
+        }
+
+        int firstClearBit = seenMessages.nextClearBit(0);
+        Assert.assertEquals("Missing message " + firstClearBit, bufferSize, firstClearBit);
+    }
+
+    private int drainMessage(QueueBuffer queueBuffer) throws InterruptedException {
+        LogMessage message = queueBuffer.messages.poll(10, TimeUnit.SECONDS);
+        Assert.assertNotNull(message);
+        return Integer.parseInt(message.getShortMessage());
+    }
+
+    private LogMessage message(AtomicInteger i) {
+        LogMessage message = new LogMessage();
+        message.setShortMessage(Integer.toString(i.getAndIncrement()));
+        return message;
+    }
+
+    private LogMessage[] messages(AtomicInteger i, int count) {
+        LogMessage[] messages = new LogMessage[count];
+        for (int j = 0; j < messages.length; j++) {
+            messages[j] = message(i);
+        }
+        return messages;
+    }
+
+    private static class QueueBuffer implements Buffer {
+        final LinkedBlockingQueue<LogMessage> messages = new LinkedBlockingQueue<LogMessage>();
+        final CountDownLatch insertLatch = new CountDownLatch(1);
+
+        @Override
+        public void insert(LogMessage logMessage) throws BufferOutOfCapacityException {
+            messages.add(logMessage);
+            try {
+                insertLatch.await();
+            } catch (InterruptedException ignored) { }
+        }
+
+        @Override
+        public boolean hasCapacity() {
+            return true;
+        }
+    }
 }


### PR DESCRIPTION
For transports that support queueing and redelivery of batches of messages (i.e. [Facebook Scribe](https://github.com/facebook/scribe/wiki)), it is advantageous to add the message batch to the ProcessBuffer atomically.

This means the plugin can fail fast if insufficient capacity is available, and exert backpressure on the transport causing it to queue messages on disk and/or back off (e.g. via Scribe's [TRY_LATER](https://github.com/facebook/scribe/wiki/Logging-Messages) response). Note that Scribe requires the batch of messages to be acknowledged as a whole, so if the batch is partially processed before a failure occurs (i.e. without atomic processing), any part of the batch which was processed will be delivered twice.

It is also slightly more efficient to acquire a sequence number for the whole batch in a single operation rather than incrementing the sequence number by one repeatedly.

This patch implements this functionality for ProcessBuffer only via a new BatchBuffer interface.
