### PR TITLE
unsupported messages are now rejected from the amqp

### DIFF
--- a/src/main/java/org/graylog2/inputs/amqp/AMQPConsumer.java
+++ b/src/main/java/org/graylog2/inputs/amqp/AMQPConsumer.java
@@ -202,6 +202,11 @@ public class AMQPConsumer implements Runnable {
                                 channel.basicReject(envelope.getDeliveryTag(), true);
                                 reQueuedMessages.mark();
                                 return;
+                            } catch (java.lang.IllegalStateException e) {
+                                LOG.warn("GELF Message not parsable, rejecting");
+                                channel.basicReject(envelope.getDeliveryTag(), false);
+                                reQueuedMessages.mark();
+                                return;
                             }
                              
                             handledGELFMessages.mark();
@@ -212,6 +217,11 @@ public class AMQPConsumer implements Runnable {
                              } catch (BufferOutOfCapacityException e) {
                                 LOG.warn("ProcessBufferProcessor is out of capacity. Requeuing message!");
                                 channel.basicReject(envelope.getDeliveryTag(), true);
+                                reQueuedMessages.mark();
+                                return;
+                             } catch (java.lang.IllegalStateException e) {
+                                LOG.warn("SYSLOG Message not parsable, rejecting");
+                                channel.basicReject(envelope.getDeliveryTag(), false);
                                 reQueuedMessages.mark();
                                 return;
                              }


### PR DESCRIPTION
When a message is type 'UNSUPPORTED' it is rejected from the amqp.  This will stop the amqp from filling up with unacknowledged messages.  I'm not sure if this is a desirable procedure for everyone, but it works well for me.  Feel free to reject if you don't feel like it's desirable.
