### PR TITLE
ensure buffer out of capacity requeue works correctly on amqp client

### DIFF
--- a/src/main/java/org/graylog2/gelf/GELFChunkManager.java
+++ b/src/main/java/org/graylog2/gelf/GELFChunkManager.java
@@ -76,7 +76,7 @@ public class GELFChunkManager extends Thread {
                     if (isComplete(messageId)) {
                         // We got a complete message! Re-assemble and insert to GELFProcessor.
                         LOG.debug("Message <{}> seems to be complete. Handling now.", messageId);
-                        processor.messageReceived(new GELFMessage(chunksToByteArray(messageId)));
+                        processor.messageReceived(new GELFMessage(chunksToByteArray(messageId)), true);
 
                         // Message has been handled. Drop it.
                         LOG.debug("Message <{}> is now being processed. Dropping from chunk map.", messageId);

--- a/src/main/java/org/graylog2/gelf/GELFProcessor.java
+++ b/src/main/java/org/graylog2/gelf/GELFProcessor.java
@@ -55,7 +55,7 @@ public class GELFProcessor {
         this.server = server;
     }
 
-    public void messageReceived(GELFMessage message) throws BufferOutOfCapacityException {
+    public void messageReceived(GELFMessage message, boolean caching) throws BufferOutOfCapacityException {
         incomingMessages.mark();
         
         // Convert to LogMessage
@@ -69,7 +69,12 @@ public class GELFProcessor {
         // Add to process buffer.
         LOG.debug("Adding received GELF message <{}> to process buffer: {}", lm.getId(), lm);
         processedMessages.mark();
-        server.getProcessBuffer().insertCached(lm);
+
+        if (caching) {
+            server.getProcessBuffer().insertCached(lm);
+        } else {
+            server.getProcessBuffer().insertFailFast(lm);
+        }
     }
 
     private LogMessage parse(String message) {

--- a/src/main/java/org/graylog2/inputs/amqp/AMQPConsumer.java
+++ b/src/main/java/org/graylog2/inputs/amqp/AMQPConsumer.java
@@ -196,7 +196,7 @@ public class AMQPConsumer implements Runnable {
                         case GELF:
                             GELFMessage gelf = new GELFMessage(body);
                             try {
-                               gelfProcessor.messageReceived(gelf);
+                               gelfProcessor.messageReceived(gelf, false);
                             } catch (BufferOutOfCapacityException e) {
                                 LOG.warn("ProcessBufferProcessor is out of capacity. Requeuing message!");
                                 channel.basicReject(envelope.getDeliveryTag(), true);
@@ -208,7 +208,7 @@ public class AMQPConsumer implements Runnable {
                             break;
                          case SYSLOG:
                             try {
-                                syslogProcessor.messageReceived(new String(body), connection.getAddress());
+                                syslogProcessor.messageReceived(new String(body), connection.getAddress(), false);
                              } catch (BufferOutOfCapacityException e) {
                                 LOG.warn("ProcessBufferProcessor is out of capacity. Requeuing message!");
                                 channel.basicReject(envelope.getDeliveryTag(), true);

--- a/src/main/java/org/graylog2/inputs/gelf/GELFDispatcher.java
+++ b/src/main/java/org/graylog2/inputs/gelf/GELFDispatcher.java
@@ -74,7 +74,7 @@ public class GELFDispatcher extends SimpleChannelHandler {
         case UNCOMPRESSED:
         case UNSUPPORTED:
             dispatchedUnchunkedMessage.mark();
-            processor.messageReceived(msg);
+            processor.messageReceived(msg, true);
             break;
         }
     }

--- a/src/main/java/org/graylog2/inputs/http/GELFHttpHandler.java
+++ b/src/main/java/org/graylog2/inputs/http/GELFHttpHandler.java
@@ -74,7 +74,7 @@ public class GELFHttpHandler extends SimpleChannelHandler {
             return;
         }
 
-        gelfProcessor.messageReceived(msg);
+        gelfProcessor.messageReceived(msg, true);
         writeResponse(e.getChannel(), keepAlive, httpRequestVersion, HttpResponseStatus.ACCEPTED);
     }
 

--- a/src/main/java/org/graylog2/inputs/syslog/SyslogProcessor.java
+++ b/src/main/java/org/graylog2/inputs/syslog/SyslogProcessor.java
@@ -62,7 +62,7 @@ public class SyslogProcessor {
         this.server = server;
     }
 
-    public void messageReceived(String msg, InetAddress remoteAddress) throws BufferOutOfCapacityException {
+    public void messageReceived(String msg, InetAddress remoteAddress, boolean caching) throws BufferOutOfCapacityException {
         incomingMessages.mark();
 
         // Convert to LogMessage
@@ -89,7 +89,12 @@ public class SyslogProcessor {
         // Add to process buffer.
         LOG.debug("Adding received syslog message <{}> to process buffer: {}", lm.getId(), lm);
         processedMessages.mark();
-        server.getProcessBuffer().insertCached(lm);
+
+        if (caching) {
+            server.getProcessBuffer().insertCached(lm);
+        } else {
+            server.getProcessBuffer().insertFailFast(lm);
+        }
     }
 
     private LogMessage parse(String msg, InetAddress remoteAddress) throws UnknownHostException {

--- a/src/test/java/org/graylog2/inputs/gelf/GELFProcessorTest.java
+++ b/src/test/java/org/graylog2/inputs/gelf/GELFProcessorTest.java
@@ -49,8 +49,8 @@ public class GELFProcessorTest {
         GraylogServerStub serverStub = new GraylogServerStub();
         GELFProcessor processor = new GELFProcessor(serverStub);
 
-        processor.messageReceived(new GELFMessage(TestHelper.zlibCompress(GELF_JSON_COMPLETE)));
-        processor.messageReceived(new GELFMessage(TestHelper.gzipCompress(GELF_JSON_COMPLETE)));
+        processor.messageReceived(new GELFMessage(TestHelper.zlibCompress(GELF_JSON_COMPLETE)), true);
+        processor.messageReceived(new GELFMessage(TestHelper.gzipCompress(GELF_JSON_COMPLETE)), true);
         // All GELF types are tested in GELFMessageTest.
 
         LogMessage lm = serverStub.lastInsertedToProcessBuffer;
@@ -74,7 +74,7 @@ public class GELFProcessorTest {
         GraylogServerStub serverStub = new GraylogServerStub();
         GELFProcessor processor = new GELFProcessor(serverStub);
 
-        processor.messageReceived(new GELFMessage(TestHelper.zlibCompress(GELF_JSON_INCOMPLETE)));
+        processor.messageReceived(new GELFMessage(TestHelper.zlibCompress(GELF_JSON_INCOMPLETE)), true);
         // All GELF types are tested in GELFMessageTest.
 
         LogMessage lm = serverStub.lastInsertedToProcessBuffer;
@@ -88,7 +88,7 @@ public class GELFProcessorTest {
         GraylogServerStub serverStub = new GraylogServerStub();
         GELFProcessor processor = new GELFProcessor(serverStub);
 
-        processor.messageReceived(new GELFMessage(TestHelper.zlibCompress(GELF_JSON_INCOMPLETE)));
+        processor.messageReceived(new GELFMessage(TestHelper.zlibCompress(GELF_JSON_INCOMPLETE)), true);
         // All GELF types are tested in GELFMessageTest.
 
         LogMessage lm = serverStub.lastInsertedToProcessBuffer;
@@ -102,7 +102,7 @@ public class GELFProcessorTest {
         GraylogServerStub serverStub = new GraylogServerStub();
         GELFProcessor processor = new GELFProcessor(serverStub);
 
-        processor.messageReceived(new GELFMessage(TestHelper.zlibCompress(GELF_JSON_INCOMPLETE)));
+        processor.messageReceived(new GELFMessage(TestHelper.zlibCompress(GELF_JSON_INCOMPLETE)), true);
         // All GELF types are tested in GELFMessageTest.
 
         LogMessage lm = serverStub.lastInsertedToProcessBuffer;
@@ -116,7 +116,7 @@ public class GELFProcessorTest {
         GraylogServerStub serverStub = new GraylogServerStub();
         GELFProcessor processor = new GELFProcessor(serverStub);
 
-        processor.messageReceived(new GELFMessage(TestHelper.zlibCompress(GELF_JSON_INCOMPLETE_WITH_ID)));
+        processor.messageReceived(new GELFMessage(TestHelper.zlibCompress(GELF_JSON_INCOMPLETE_WITH_ID)), true);
         // All GELF types are tested in GELFMessageTest.
 
         LogMessage lm = serverStub.lastInsertedToProcessBuffer;
@@ -132,7 +132,7 @@ public class GELFProcessorTest {
         GraylogServerStub serverStub = new GraylogServerStub();
         GELFProcessor processor = new GELFProcessor(serverStub);
 
-        processor.messageReceived(new GELFMessage(TestHelper.zlibCompress(GELF_JSON_INCOMPLETE_WITH_NON_STANDARD_FIELD)));
+        processor.messageReceived(new GELFMessage(TestHelper.zlibCompress(GELF_JSON_INCOMPLETE_WITH_NON_STANDARD_FIELD)), true);
         // All GELF types are tested in GELFMessageTest.
 
         LogMessage lm = serverStub.lastInsertedToProcessBuffer;
@@ -148,7 +148,7 @@ public class GELFProcessorTest {
         GraylogServerStub serverStub = new GraylogServerStub();
         GELFProcessor processor = new GELFProcessor(serverStub);
 
-        processor.messageReceived(new GELFMessage(TestHelper.zlibCompress(GELF_JSON_WITH_MAP)));
+        processor.messageReceived(new GELFMessage(TestHelper.zlibCompress(GELF_JSON_WITH_MAP)), true);
         // All GELF types are tested in GELFMessageTest.
 
         LogMessage lm = serverStub.lastInsertedToProcessBuffer;


### PR DESCRIPTION
it was intended to requeue the message if the buffer is full. but this feature is currently not used, since the amqp is writing directly to the gelfprocessor and the gelfprocessor is inserting the message on a buffer. with this fix the gelfprocessor/syslogprocessor is capable of using a cache or not and amqp will ensure delivery
