### PR TITLE
Add http response header so that the connection will be close after each Http request.

### DIFF
--- a/src/main/java/org/graylog2/inputs/http/GELFHttpHandler.java
+++ b/src/main/java/org/graylog2/inputs/http/GELFHttpHandler.java
@@ -84,6 +84,11 @@ public class GELFHttpHandler extends SimpleChannelHandler {
 
         if (keepAlive) {
             response.setHeader(HttpHeaders.Names.CONNECTION, HttpHeaders.Values.KEEP_ALIVE);
+            
+            //Set Http Response Headers to close connection after each request
+            //And allow CORS.
+            response.setHeader(HttpHeaders.Names.ACCESS_CONTROL_ALLOW_ORIGIN, "*");
+            response.setHeader(HttpHeaders.Names.CONTENT_LENGTH, 0);
         }
 
         final ChannelFuture channelFuture = channel.write(response);


### PR DESCRIPTION
Without setting the Http Response Header(CONTET-LENGTH) the http request will not be close so other requests cannot be processed.
Also,  JavaScript function XMLHttpRequest might generate a CORS ERROR Without the Header(ACCESS_CONTROL_ALLOW_ORIGIN).

Thanks.
