### PR TITLE
Fixing a bug that prevents two inputs of the same type being spawned if

### DIFF
--- a/graylog2-plugin-interfaces/src/main/java/org/graylog2/plugin/inputs/MessageInput.java
+++ b/graylog2-plugin-interfaces/src/main/java/org/graylog2/plugin/inputs/MessageInput.java
@@ -132,4 +132,8 @@ public abstract class MessageInput {
         return this.staticFields;
     }
 
+    public String getUniqueReadableId() {
+        String readableId = getClass().getName() + "." + getId();
+        return readableId;
+    }
 }

--- a/graylog2-server/src/main/java/org/graylog2/inputs/gelf/http/GELFHttpInput.java
+++ b/graylog2-server/src/main/java/org/graylog2/inputs/gelf/http/GELFHttpInput.java
@@ -52,12 +52,12 @@ public class GELFHttpInput extends GELFInputBase {
     public void launch() throws MisfireException {
         // Register throughput counter gauges.
         for(Map.Entry<String,Gauge<Long>> gauge : throughputCounter.gauges().entrySet()) {
-            core.metrics().register(MetricRegistry.name(GELFHttpInput.class, gauge.getKey()), gauge.getValue());
+            core.metrics().register(MetricRegistry.name(getUniqueReadableId(), gauge.getKey()), gauge.getValue());
         }
 
         // Register connection counter gauges.
-        core.metrics().register(MetricRegistry.name(GELFHttpInput.class, "open_connections"), connectionCounter.gaugeCurrent());
-        core.metrics().register(MetricRegistry.name(GELFHttpInput.class, "total_connections"), connectionCounter.gaugeTotal());
+        core.metrics().register(MetricRegistry.name(getUniqueReadableId(), "open_connections"), connectionCounter.gaugeCurrent());
+        core.metrics().register(MetricRegistry.name(getUniqueReadableId(), "total_connections"), connectionCounter.gaugeTotal());
 
         final ExecutorService bossExecutor = Executors.newCachedThreadPool(
                 new ThreadFactoryBuilder()

--- a/graylog2-server/src/main/java/org/graylog2/inputs/raw/tcp/RawTCPInput.java
+++ b/graylog2-server/src/main/java/org/graylog2/inputs/raw/tcp/RawTCPInput.java
@@ -57,12 +57,12 @@ public class RawTCPInput extends RawInputBase {
     public void launch() throws MisfireException {
         // Register throughput counter gauges.
         for(Map.Entry<String,Gauge<Long>> gauge : throughputCounter.gauges().entrySet()) {
-            core.metrics().register(MetricRegistry.name(RawTCPInput.class, gauge.getKey()), gauge.getValue());
+            core.metrics().register(MetricRegistry.name(getUniqueReadableId(), gauge.getKey()), gauge.getValue());
         }
 
         // Register connection counter gauges.
-        core.metrics().register(MetricRegistry.name(RawTCPInput.class, "open_connections"), connectionCounter.gaugeCurrent());
-        core.metrics().register(MetricRegistry.name(RawTCPInput.class, "total_connections"), connectionCounter.gaugeTotal());
+        core.metrics().register(MetricRegistry.name(getUniqueReadableId(), "open_connections"), connectionCounter.gaugeCurrent());
+        core.metrics().register(MetricRegistry.name(getUniqueReadableId(), "total_connections"), connectionCounter.gaugeTotal());
 
         final ExecutorService bossThreadPool = Executors.newCachedThreadPool(
                 new ThreadFactoryBuilder()

--- a/graylog2-server/src/main/java/org/graylog2/inputs/syslog/tcp/SyslogTCPInput.java
+++ b/graylog2-server/src/main/java/org/graylog2/inputs/syslog/tcp/SyslogTCPInput.java
@@ -52,12 +52,12 @@ public class SyslogTCPInput extends SyslogInputBase {
     public void launch() throws MisfireException {
         // Register throughput counter gauges.
         for(Map.Entry<String,Gauge<Long>> gauge : throughputCounter.gauges().entrySet()) {
-            core.metrics().register(MetricRegistry.name(SyslogTCPInput.class, gauge.getKey()), gauge.getValue());
+            core.metrics().register(MetricRegistry.name(getUniqueReadableId(), gauge.getKey()), gauge.getValue());
         }
 
         // Register connection counter gauges.
-        core.metrics().register(MetricRegistry.name(SyslogTCPInput.class, "open_connections"), connectionCounter.gaugeCurrent());
-        core.metrics().register(MetricRegistry.name(SyslogTCPInput.class, "total_connections"), connectionCounter.gaugeTotal());
+        core.metrics().register(MetricRegistry.name(getUniqueReadableId(), "open_connections"), connectionCounter.gaugeCurrent());
+        core.metrics().register(MetricRegistry.name(getUniqueReadableId(), "total_connections"), connectionCounter.gaugeTotal());
 
         final ExecutorService bossThreadPool = Executors.newCachedThreadPool(
                 new ThreadFactoryBuilder()


### PR DESCRIPTION
they are using metrics to track connection counts. In those cases the
metric name being used for registration is not unique for the input, so
the second input is getting an exception when launch() is called.

(it also requires on the corresponding change in the web interface, pull request for this will follow)
