### PR TITLE
Make the key value delimiter configurable. fix #304

### DIFF
--- a/graylog2-server/src/test/java/org/graylog2/inputs/converters/TokenizerConverterTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/inputs/converters/TokenizerConverterTest.java
@@ -152,5 +152,18 @@ public class TokenizerConverterTest {
 
         assertTrue(result.get("_id") != "123");
     }
+    
+    @Test
+    public void testDifferentDelimiter() {
+    	HashMap<String,Object> config = new HashMap<String,Object>();
+    	config.put("delimiter", ':');
+    	
+    	TokenizerConverter f = new TokenizerConverter(config);
+    	Map<String,String> result = (Map<String, String>) f.convert("happy otters k1:v1 k2: v2");
+    	
+    	assertEquals(2, result.size());
+    	assertEquals("v1", result.get("k1"));
+    	assertEquals("v2", result.get("k2"));
+    }
 
 }


### PR DESCRIPTION
This commit allows the key value delimiter to be configurable using the delimiter config option when creating a TokenizerConvertor. See the new test for an example.
