### PR TITLE
Set Content-Length for GELF HTTP Input response

### DIFF
--- a/graylog2-inputs/src/main/java/org/graylog2/inputs/gelf/http/GELFHttpHandler.java
+++ b/graylog2-inputs/src/main/java/org/graylog2/inputs/gelf/http/GELFHttpHandler.java
@@ -37,7 +37,7 @@ import org.jboss.netty.channel.ExceptionEvent;
 import org.jboss.netty.channel.MessageEvent;
 import org.jboss.netty.channel.SimpleChannelHandler;
 import org.jboss.netty.channel.socket.DatagramChannel;
-import org.jboss.netty.handler.codec.http.DefaultFullHttpResponse;
+import org.jboss.netty.handler.codec.http.DefaultHttpResponse;
 import org.jboss.netty.handler.codec.http.HttpHeaders;
 import org.jboss.netty.handler.codec.http.HttpMethod;
 import org.jboss.netty.handler.codec.http.HttpRequest;
@@ -102,7 +102,7 @@ public class GELFHttpHandler extends SimpleChannelHandler {
 
     private void writeResponse(Channel channel, boolean keepAlive, HttpVersion httpRequestVersion, HttpResponseStatus status) {
         final HttpResponse response =
-            new DefaultFullHttpResponse(httpRequestVersion, status);
+            new DefaultHttpResponse(httpRequestVersion, status);
 
         response.setHeader(HttpHeaders.Names.CONTENT_LENGTH, 0);
 


### PR DESCRIPTION
Currently, the GELF HTTP input doesn't work without specifying `Connection: close`. Clients will report a timeout when attempting to submit data. This is due to the fact that, when in keep-alive mode, it [must respond with a content-length](http://stackoverflow.com/a/17232225/840849) so the client knows when the data is finished sending. There are some cases where specifying a `Connection: close` header is not possible. Some load balancers strip or change this header when proxying the request.

This PR adds a Content-Length header to the response. Since we never send any data back, the content-length is hardcoded to 0. Apologies for the extraneous commits, they were made before I realized the project is using netty 3.x.

[Tests are confirmed passing.](https://travis-ci.org/meltingice/graylog2-server/builds/23613438)
