### PR TITLE
Improve rest_transport_uri default value.

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/Configuration.java
+++ b/graylog2-server/src/main/java/org/graylog2/Configuration.java
@@ -394,6 +394,28 @@ public class Configuration extends BaseConfiguration {
         return Tools.getUriStandard(restListenUri);
     }
 
+    public URI getDefaultRestTransportUri() {
+        URI transportUri;
+        URI listenUri = getRestListenUri();
+
+        if (listenUri.getHost().equals("0.0.0.0")) {
+            String guessedIf;
+            try {
+                guessedIf = Tools.guessPrimaryNetworkAddress().getHostAddress();
+            } catch (Exception e) {
+                LOG.error("Could not guess primary network address for rest_transport_uri. Please configure it in your graylog2.conf.", e);
+                throw new RuntimeException("No rest_transport_uri.");
+            }
+
+            String transportStr = "http://" + guessedIf + ":" + listenUri.getPort();
+            transportUri = Tools.getUriStandard(transportStr);
+        } else {
+            transportUri = listenUri;
+        }
+
+        return transportUri;
+    }
+
     public String getRootUsername() {
         return rootUsername;
     }

--- a/graylog2-server/src/main/java/org/graylog2/Main.java
+++ b/graylog2-server/src/main/java/org/graylog2/Main.java
@@ -278,17 +278,8 @@ public final class Main extends NodeRunner {
         }
 
         if (configuration.getRestTransportUri() == null) {
-            String guessedIf;
-            try {
-                guessedIf = Tools.guessPrimaryNetworkAddress().getHostAddress();
-            } catch (Exception e) {
-                LOG.error("Could not guess primary network address for rest_transport_uri. Please configure it in your graylog2.conf.", e);
-                throw new RuntimeException("No rest_transport_uri.");
-            }
-
-            String transportStr = "http://" + guessedIf + ":" + configuration.getRestListenUri().getPort();
-            LOG.info("No rest_transport_uri set. Falling back to [{}].", transportStr);
-            configuration.setRestTransportUri(transportStr);
+            configuration.setRestTransportUri(configuration.getDefaultRestTransportUri().toString());
+            LOG.info("No rest_transport_uri set. Falling back to [{}].", configuration.getRestTransportUri());
         }
 
         return configuration;

--- a/graylog2-server/src/test/java/org/graylog2/ConfigurationTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/ConfigurationTest.java
@@ -195,5 +195,35 @@ public class ConfigurationTest {
 
         Assert.assertEquals(2, configuration.getMongoReplicaSet().size());
     }
-    
+
+    @Test
+    public void testRestTransportUriLocalhost() throws RepositoryException, ValidationException {
+        validProperties.put("rest_listen_uri", "http://127.0.0.1:12900");
+
+        Configuration configuration = new Configuration();
+        new JadConfig(new InMemoryRepository(validProperties), configuration).process();
+
+        Assert.assertEquals("http://127.0.0.1:12900", configuration.getDefaultRestTransportUri().toString());
+    }
+
+    @Test
+    public void testRestTransportUriWildcard() throws RepositoryException, ValidationException {
+        validProperties.put("rest_listen_uri", "http://0.0.0.0:12900");
+
+        Configuration configuration = new Configuration();
+        new JadConfig(new InMemoryRepository(validProperties), configuration).process();
+
+        Assert.assertNotEquals("http://0.0.0.0:12900", configuration.getDefaultRestTransportUri().toString());
+        Assert.assertNotNull(configuration.getDefaultRestTransportUri());
+    }
+
+    @Test
+    public void testRestTransportUriCustom() throws RepositoryException, ValidationException {
+        validProperties.put("rest_listen_uri", "http://10.0.0.1:12900");
+
+        Configuration configuration = new Configuration();
+        new JadConfig(new InMemoryRepository(validProperties), configuration).process();
+
+        Assert.assertEquals("http://10.0.0.1:12900", configuration.getDefaultRestTransportUri().toString());
+    }
 }

--- a/misc/graylog2.conf
+++ b/misc/graylog2.conf
@@ -24,7 +24,8 @@ plugin_dir = plugin
 
 # REST API listen URI. Must be reachable by other graylog2-server nodes if you run a cluster.
 rest_listen_uri = http://127.0.0.1:12900/
-# REST API transport address. Defaults to first non-loopback IPv4 system address and port 12900.
+# REST API transport address. Defaults to the value of rest_listen_uri. Exception: If rest_listen_uri
+# is set to a wildcard IP address (0.0.0.0) the first non-loopback IPv4 system address is used.
 # This will be promoted in the cluster discovery APIs and other nodes may try to connect on this
 # address. (see rest_listen_uri)
 #rest_transport_uri = http://192.168.1.1:12900/


### PR DESCRIPTION
If not set, use the value of rest_listen_uri. Add exception if
rest_listen_uri is 0.0.0.0 to use the first non-loopback IPv4 address.

This is a fix for #557. (Using a new pull request because I accidentally created a pull request against the 0.20 branch.)
