### PR TITLE
Changed the messageFilter order

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/bindings/MessageFilterBindings.java
+++ b/graylog2-server/src/main/java/org/graylog2/bindings/MessageFilterBindings.java
@@ -36,7 +36,7 @@ public class MessageFilterBindings extends AbstractModule {
         Multibinder<MessageFilter> messageFilters = Multibinder.newSetBinder(binder(), MessageFilter.class);
         messageFilters.addBinding().to(StaticFieldFilter.class);
         messageFilters.addBinding().to(ExtractorFilter.class);
-        messageFilters.addBinding().to(StreamMatcherFilter.class);
         messageFilters.addBinding().to(RewriteFilter.class);
+        messageFilters.addBinding().to(StreamMatcherFilter.class);
     }
 }


### PR DESCRIPTION
Changed the messageFilter order so that we can use fields added by RewriteFilter(Drools) in stream rules.
