### PR TITLE
Add JBoss Maven repository to parent POM

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -114,6 +114,18 @@
                 <enabled>false</enabled>
             </snapshots>
         </repository>
+        <repository>
+            <id>jboss-public-repository-group</id>
+            <name>JBoss Public Repository Group</name>
+            <url>http://repository.jboss.org/nexus/content/groups/public/</url>
+            <releases>
+                <enabled>true</enabled>
+                <updatePolicy>never</updatePolicy>
+            </releases>
+            <snapshots>
+                <enabled>false</enabled>
+            </snapshots>
+        </repository>
     </repositories>
 
     <!-- Every dependency of the entire project is defined here. It will not be automatically inluded in the projects,


### PR DESCRIPTION
Some artifacts (e. g. `org.jboss.dashboard-builder:dashboard-builder-bom:pom:6.1.0.CR1`) don't seem to exist in Maven Central which made the build fail.

This PR adds the missing repository to the `graylog2-parent` POM.

```
$ mvn -v
Apache Maven 3.2.2 (NON-CANONICAL_2014-06-26T15:14:47_root; 2014-06-26T13:14:47+02:00)
Maven home: /opt/maven
Java version: 1.8.0_05, vendor: Oracle Corporation
Java home: /opt/java/jre
Default locale: de_DE, platform encoding: UTF-8
OS name: "linux", version: "3.15.3-1-arch", arch: "amd64", family: "unix"

$ mvn install
[INFO] Scanning for projects...
[...]
[INFO] ------------------------------------------------------------------------
[INFO] Reactor Build Order:
[INFO] 
[INFO] graylog2
[INFO] graylog2-plugin
[INFO] graylog2-inputs
[INFO] graylog2-shared
[INFO] graylog2-server
[INFO] graylog2-radio
[INFO] graylog2-rest-routes
[INFO]                                                                         
[INFO] ------------------------------------------------------------------------
[INFO] Building graylog2 0.21.0-SNAPSHOT
[INFO] ------------------------------------------------------------------------
[...]
[INFO]                                                                         
[INFO] ------------------------------------------------------------------------
[INFO] Building graylog2-plugin 0.21.0-SNAPSHOT
[INFO] ------------------------------------------------------------------------
[...]
[INFO] ------------------------------------------------------------------------
[INFO] Reactor Summary:
[INFO] 
[INFO] graylog2 ........................................... SUCCESS [ 15.117 s]
[INFO] graylog2-plugin .................................... FAILURE [01:09 min]
[INFO] graylog2-inputs .................................... SKIPPED
[INFO] graylog2-shared .................................... SKIPPED
[INFO] graylog2-server .................................... SKIPPED
[INFO] graylog2-radio ..................................... SKIPPED
[INFO] graylog2-rest-routes ............................... SKIPPED
[INFO] ------------------------------------------------------------------------
[INFO] BUILD FAILURE
[INFO] ------------------------------------------------------------------------
[INFO] Total time: 01:27 min
[INFO] Finished at: 2014-07-08T12:21:14+02:00
[INFO] Final Memory: 14M/110M
[INFO] ------------------------------------------------------------------------
[ERROR] Failed to execute goal on project graylog2-plugin: Could not resolve dependencies for project org.graylog2:graylog2-plugin:jar:0.21.0-SNAPSHOT: Failed to collect dependencies at org.kie:kie-api:jar:6.1.0.CR1: Failed to read artifact descriptor for org.kie:kie-api:jar:6.1.0.CR1: Could not find artifact org.jboss.dashboard-builder:dashboard-builder-bom:pom:6.1.0.CR1 in sonatype-nexus-releases (https://oss.sonatype.org/content/repositories/releases) -> [Help 1]
```
