### PR TITLE
toPath not working in windows

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/rules/DroolsEngine.java
+++ b/graylog2-server/src/main/java/org/graylog2/rules/DroolsEngine.java
@@ -40,11 +40,15 @@ import org.slf4j.LoggerFactory;
 import javax.inject.Singleton;
 import java.io.File;
 import java.io.IOException;
+import java.net.URI;
+import java.net.URISyntaxException;
 import java.net.URL;
 import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.List;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.logging.Level;
 
 @Singleton
 public class DroolsEngine implements RulesEngine {
@@ -176,6 +180,9 @@ public class DroolsEngine implements RulesEngine {
         } catch (RulesCompilationException e) {
             LOG.warn("Unable to add rules due to compilation errors.", e);
             return false;
+        } catch (URISyntaxException ex) {
+            LOG.warn("Unable to add rules due to compilation errors.", ex);
+            return false;
         }
     }
 
@@ -186,7 +193,7 @@ public class DroolsEngine implements RulesEngine {
 
     private KieModule createAndDeployJar(KieServices ks,
                                                 ReleaseId releaseId,
-                                                String... drls) throws RulesCompilationException {
+                                                String... drls) throws RulesCompilationException, URISyntaxException {
         byte[] jar = createKJar(ks, releaseId, null, drls);
         return deployJar(ks, jar);
     }
@@ -194,7 +201,7 @@ public class DroolsEngine implements RulesEngine {
     private byte[] createKJar(KieServices ks,
                                      ReleaseId releaseId,
                                      String pom,
-                                     String... drls) throws RulesCompilationException {
+                                     String... drls) throws RulesCompilationException, URISyntaxException {
         KieFileSystem kfs = ks.newKieFileSystem();
         if (pom != null) {
             kfs.write("pom.xml", pom);
@@ -207,7 +214,9 @@ public class DroolsEngine implements RulesEngine {
             }
         }
         for (URL builtinRuleUrl : builtinRuleUrls) {
-            final Path rulesPath = new File(builtinRuleUrl.getPath()).toPath();
+            
+            URI uri = builtinRuleUrl.toURI();
+            final Path rulesPath = Paths.get(uri);
             final String path = "src/main/resources/" + rulesPath.getFileName();
             final Resource resource = ResourceFactory
                     .newUrlResource(builtinRuleUrl)

--- a/graylog2-server/src/main/java/org/graylog2/rules/DroolsEngine.java
+++ b/graylog2-server/src/main/java/org/graylog2/rules/DroolsEngine.java
@@ -40,14 +40,11 @@ import org.slf4j.LoggerFactory;
 import javax.inject.Singleton;
 import java.io.File;
 import java.io.IOException;
-import java.net.URI;
-import java.net.URISyntaxException;
 import java.net.URL;
-import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.util.List;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicReference;
+import org.apache.commons.io.FilenameUtils;
 
 @Singleton
 public class DroolsEngine implements RulesEngine {
@@ -179,9 +176,6 @@ public class DroolsEngine implements RulesEngine {
         } catch (RulesCompilationException e) {
             LOG.warn("Unable to add rules due to compilation errors.", e);
             return false;
-        } catch (URISyntaxException ex) {
-            LOG.warn("Unable to add rules due to compilation errors.", ex);
-            return false;
         }
     }
 
@@ -192,7 +186,7 @@ public class DroolsEngine implements RulesEngine {
 
     private KieModule createAndDeployJar(KieServices ks,
                                                 ReleaseId releaseId,
-                                                String... drls) throws RulesCompilationException, URISyntaxException {
+                                                String... drls) throws RulesCompilationException {
         byte[] jar = createKJar(ks, releaseId, null, drls);
         return deployJar(ks, jar);
     }
@@ -200,7 +194,7 @@ public class DroolsEngine implements RulesEngine {
     private byte[] createKJar(KieServices ks,
                                      ReleaseId releaseId,
                                      String pom,
-                                     String... drls) throws RulesCompilationException, URISyntaxException {
+                                     String... drls) throws RulesCompilationException {
         KieFileSystem kfs = ks.newKieFileSystem();
         if (pom != null) {
             kfs.write("pom.xml", pom);
@@ -213,10 +207,7 @@ public class DroolsEngine implements RulesEngine {
             }
         }
         for (URL builtinRuleUrl : builtinRuleUrls) {
-            
-            URI uri = builtinRuleUrl.toURI();
-            final Path rulesPath = Paths.get(uri);
-            final String path = "src/main/resources/" + rulesPath.getFileName();
+            final String path = "src/main/resources/" + FilenameUtils.getName(builtinRuleUrl.getPath());
             final Resource resource = ResourceFactory
                     .newUrlResource(builtinRuleUrl)
                     .setSourcePath(path)

--- a/graylog2-server/src/main/java/org/graylog2/rules/DroolsEngine.java
+++ b/graylog2-server/src/main/java/org/graylog2/rules/DroolsEngine.java
@@ -48,7 +48,6 @@ import java.nio.file.Paths;
 import java.util.List;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicReference;
-import java.util.logging.Level;
 
 @Singleton
 public class DroolsEngine implements RulesEngine {


### PR DESCRIPTION
graylog2 server won't start under windows with the following error.

java.nio.file.InvalidPathException: Illegal char <:> at index 4: file:\C:\Program Files\graylog2-server\graylog2-server.jar!\blacklist.drl.

Have changed the .toPath(); -> Paths.get(builtinRuleUrl.toURI());
