### PR TITLE
Typo in graylog2ctl

### DIFF
--- a/bin/graylog2ctl
+++ b/bin/graylog2ctl
@@ -45,7 +45,7 @@ LOG4J=${LOG4J:=}
 start() {
     echo "Starting graylog2-server ..."
     cd "$GRAYLOG2CTL_DIR/.."
-    $NOHUP $JAVA_CMD ${LOG4J} -jar ${GRAYLOG2_SERVER_JAR} server -f ${GRAYLOG2_CONF} -p ${GRAYLOG2_PID}>> ${LOG_FILE} &
+    $NOHUP $JAVA_CMD ${LOG4J} -jar ${GRAYLOG2_SERVER_JAR} server -f ${GRAYLOG2_CONF} -p ${GRAYLOG2_PID}&> ${LOG_FILE} &
 }
 
 run() {


### PR DESCRIPTION
This typo causes the error "/usr/bin/nohup: redirecting stderr to stdout" on a fresh install of Ubuntu 14.04.1. References for this fix can be found at either http://www.tldp.org/LDP/abs/html/io-redirection.html or http://tldp.org/HOWTO/Bash-Prog-Intro-HOWTO-3.html