### PR TITLE
Add TLS option to AMQP transport

### DIFF
--- a/graylog2-inputs/src/main/java/org/graylog2/inputs/transports/AmqpConsumer.java
+++ b/graylog2-inputs/src/main/java/org/graylog2/inputs/transports/AmqpConsumer.java
@@ -138,10 +138,10 @@ public class AmqpConsumer {
 
         if (tls) {
             try {
-                LOG.info("Enable TLS for AMQP input [{}/{}].", sourceInput.getName(), sourceInput.getId());
+                LOG.info("Enabling TLS for AMQP input [{}/{}].", sourceInput.getName(), sourceInput.getId());
                 factory.useSslProtocol();
             } catch (NoSuchAlgorithmException | KeyManagementException e) {
-                throw new IOException(e);
+                throw new IOException("Couldn't enable TLS for AMQP input.", e);
             }
         }
 

--- a/graylog2-inputs/src/main/java/org/graylog2/inputs/transports/AmqpConsumer.java
+++ b/graylog2-inputs/src/main/java/org/graylog2/inputs/transports/AmqpConsumer.java
@@ -31,6 +31,8 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
+import java.security.KeyManagementException;
+import java.security.NoSuchAlgorithmException;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
@@ -58,6 +60,7 @@ public class AmqpConsumer {
 
     private final MessageInput sourceInput;
     private final int parallelQueues;
+    private final boolean tls;
     private AmqpTransport amqpTransport;
 
     private AtomicLong totalBytesRead = new AtomicLong(0);
@@ -66,7 +69,7 @@ public class AmqpConsumer {
 
     public AmqpConsumer(String hostname, int port, String virtualHost, String username, String password,
                         int prefetchCount, String queue, String exchange, String routingKey, int parallelQueues,
-                        MessageInput sourceInput, ScheduledExecutorService scheduler, AmqpTransport amqpTransport) {
+                        boolean tls, MessageInput sourceInput, ScheduledExecutorService scheduler, AmqpTransport amqpTransport) {
         this.hostname = hostname;
         this.port = port;
         this.virtualHost = virtualHost;
@@ -80,6 +83,7 @@ public class AmqpConsumer {
 
         this.sourceInput = sourceInput;
         this.parallelQueues = parallelQueues;
+        this.tls = tls;
         this.amqpTransport = amqpTransport;
 
         scheduler.scheduleAtFixedRate(new Runnable() {
@@ -131,6 +135,15 @@ public class AmqpConsumer {
         factory.setHost(hostname);
         factory.setPort(port);
         factory.setVirtualHost(virtualHost);
+
+        if (tls) {
+            try {
+                LOG.info("Enable TLS for AMQP input [{}/{}].", sourceInput.getName(), sourceInput.getId());
+                factory.useSslProtocol();
+            } catch (NoSuchAlgorithmException | KeyManagementException e) {
+                throw new IOException(e);
+            }
+        }
 
         // Authenticate?
         if(!isNullOrEmpty(username) && !isNullOrEmpty(password)) {

--- a/graylog2-inputs/src/main/java/org/graylog2/inputs/transports/AmqpTransport.java
+++ b/graylog2-inputs/src/main/java/org/graylog2/inputs/transports/AmqpTransport.java
@@ -302,7 +302,7 @@ public class AmqpTransport extends ThrottleableTransport {
                             CK_TLS,
                             "Enable TLS?",
                             false,
-                            "Enable transport encryption via TLS. (NEEDS correct TLS port setting!)"
+                            "Enable transport encryption via TLS. (requires valid TLS port setting)"
                     )
             );
 

--- a/graylog2-inputs/src/main/java/org/graylog2/inputs/transports/AmqpTransport.java
+++ b/graylog2-inputs/src/main/java/org/graylog2/inputs/transports/AmqpTransport.java
@@ -22,6 +22,7 @@ import com.google.common.eventbus.EventBus;
 import com.google.common.eventbus.Subscribe;
 import com.google.inject.assistedinject.Assisted;
 import com.google.inject.assistedinject.AssistedInject;
+import org.graylog2.plugin.configuration.fields.BooleanField;
 import org.graylog2.plugin.inputs.annotations.ConfigClass;
 import org.graylog2.plugin.inputs.annotations.FactoryClass;
 import org.graylog2.plugin.LocalMetricRegistry;
@@ -54,6 +55,7 @@ public class AmqpTransport extends ThrottleableTransport {
     public static final String CK_QUEUE = "queue";
     public static final String CK_ROUTING_KEY = "routing_key";
     public static final String CK_PARALLEL_QUEUES = "parallel_queues";
+    public static final String CK_TLS = "tls";
 
     private static final Logger LOG = LoggerFactory.getLogger(AmqpTransport.class);
 
@@ -148,6 +150,7 @@ public class AmqpTransport extends ThrottleableTransport {
                 configuration.getString(CK_EXCHANGE),
                 configuration.getString(CK_ROUTING_KEY),
                 configuration.getInt(CK_PARALLEL_QUEUES),
+                configuration.getBoolean(CK_TLS),
                 input,
                 scheduler,
                 this
@@ -291,6 +294,15 @@ public class AmqpTransport extends ThrottleableTransport {
                             1,
                             "Number of parallel QUeues",
                             ConfigurationField.Optional.NOT_OPTIONAL
+                    )
+            );
+
+            cr.addField(
+                    new BooleanField(
+                            CK_TLS,
+                            "Enable TLS?",
+                            false,
+                            "Enable transport encryption via TLS. (NEEDS correct TLS port setting!)"
                     )
             );
 


### PR DESCRIPTION
Adds a TLS option to AMQP transports. The transport connects to broker via SSL/TLS if enabled. This is a simple start without any certificate verification and not client certificate support. Tested with RabbitMQ.

Implementation for #850.

Objections?