### PR TITLE
Fix override source

### DIFF
--- a/graylog2-inputs/src/main/java/org/graylog2/inputs/codecs/GelfCodec.java
+++ b/graylog2-inputs/src/main/java/org/graylog2/inputs/codecs/GelfCodec.java
@@ -19,7 +19,6 @@ package org.graylog2.inputs.codecs;
 import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import javax.inject.Inject;
 import com.google.inject.assistedinject.Assisted;
 import org.graylog2.inputs.codecs.gelf.GELFMessage;
 import org.graylog2.inputs.transports.TcpTransport;
@@ -40,6 +39,7 @@ import org.slf4j.LoggerFactory;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
+import javax.inject.Inject;
 import java.util.Iterator;
 import java.util.Map;
 
@@ -222,12 +222,7 @@ public class GelfCodec extends AbstractCodec {
     }
 
     @ConfigClass
-    public static class Config implements AbstractCodec.Config {
-        @Override
-        public ConfigurationRequest getRequestedConfiguration() {
-            return new ConfigurationRequest();
-        }
-
+    public static class Config extends AbstractCodec.Config {
         @Override
         public void overrideDefaultValues(@Nonnull ConfigurationRequest cr) {
             if (cr.containsField(NettyTransport.CK_PORT)) {

--- a/graylog2-inputs/src/main/java/org/graylog2/inputs/codecs/JsonPathCodec.java
+++ b/graylog2-inputs/src/main/java/org/graylog2/inputs/codecs/JsonPathCodec.java
@@ -125,10 +125,10 @@ public class JsonPathCodec extends AbstractCodec {
     }
 
     @ConfigClass
-    public static class Config implements AbstractCodec.Config {
+    public static class Config extends AbstractCodec.Config {
         @Override
         public ConfigurationRequest getRequestedConfiguration() {
-            final ConfigurationRequest r = new ConfigurationRequest();
+            final ConfigurationRequest r = super.getRequestedConfiguration();
 
             r.addField(new TextField(
                     CK_PATH,

--- a/graylog2-inputs/src/main/java/org/graylog2/inputs/codecs/RadioMessageCodec.java
+++ b/graylog2-inputs/src/main/java/org/graylog2/inputs/codecs/RadioMessageCodec.java
@@ -94,12 +94,7 @@ public class RadioMessageCodec extends AbstractCodec {
     }
 
     @ConfigClass
-    public static class Config implements AbstractCodec.Config {
-        @Override
-        public ConfigurationRequest getRequestedConfiguration() {
-            return new ConfigurationRequest();
-        }
-
+    public static class Config extends AbstractCodec.Config {
         @Override
         public void overrideDefaultValues(@Nonnull ConfigurationRequest cr) {
 

--- a/graylog2-inputs/src/main/java/org/graylog2/inputs/codecs/RandomHttpMessageCodec.java
+++ b/graylog2-inputs/src/main/java/org/graylog2/inputs/codecs/RandomHttpMessageCodec.java
@@ -17,15 +17,14 @@
 package org.graylog2.inputs.codecs;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import javax.inject.Inject;
 import com.google.inject.assistedinject.Assisted;
 import org.graylog2.inputs.random.generators.FakeHttpRawMessageGenerator;
-import org.graylog2.plugin.inputs.annotations.Codec;
-import org.graylog2.plugin.inputs.annotations.ConfigClass;
-import org.graylog2.plugin.inputs.annotations.FactoryClass;
 import org.graylog2.plugin.Message;
 import org.graylog2.plugin.configuration.Configuration;
 import org.graylog2.plugin.configuration.ConfigurationRequest;
+import org.graylog2.plugin.inputs.annotations.Codec;
+import org.graylog2.plugin.inputs.annotations.ConfigClass;
+import org.graylog2.plugin.inputs.annotations.FactoryClass;
 import org.graylog2.plugin.inputs.codecs.AbstractCodec;
 import org.graylog2.plugin.inputs.codecs.CodecAggregator;
 import org.graylog2.plugin.journal.RawMessage;
@@ -34,6 +33,7 @@ import org.slf4j.LoggerFactory;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
+import javax.inject.Inject;
 import java.io.IOException;
 
 import static org.graylog2.inputs.random.generators.FakeHttpRawMessageGenerator.GeneratorState;
@@ -84,12 +84,7 @@ public class RandomHttpMessageCodec extends AbstractCodec {
     }
 
     @ConfigClass
-    public static class Config implements AbstractCodec.Config {
-        @Override
-        public ConfigurationRequest getRequestedConfiguration() {
-            return new ConfigurationRequest();
-        }
-
+    public static class Config extends AbstractCodec.Config {
         @Override
         public void overrideDefaultValues(@Nonnull ConfigurationRequest cr) {
 

--- a/graylog2-inputs/src/main/java/org/graylog2/inputs/codecs/RawCodec.java
+++ b/graylog2-inputs/src/main/java/org/graylog2/inputs/codecs/RawCodec.java
@@ -87,12 +87,7 @@ public class RawCodec extends AbstractCodec {
     }
 
     @ConfigClass
-    public static class Config implements AbstractCodec.Config {
-        @Override
-        public ConfigurationRequest getRequestedConfiguration() {
-            return new ConfigurationRequest();
-        }
-
+    public static class Config extends AbstractCodec.Config {
         @Override
         public void overrideDefaultValues(@Nonnull ConfigurationRequest cr) {
             if (cr.containsField(NettyTransport.CK_PORT)) {

--- a/graylog2-inputs/src/main/java/org/graylog2/inputs/codecs/SyslogCodec.java
+++ b/graylog2-inputs/src/main/java/org/graylog2/inputs/codecs/SyslogCodec.java
@@ -210,10 +210,10 @@ public class SyslogCodec extends AbstractCodec {
     }
 
     @ConfigClass
-    public static class Config implements AbstractCodec.Config {
+    public static class Config extends AbstractCodec.Config {
         @Override
         public ConfigurationRequest getRequestedConfiguration() {
-            final ConfigurationRequest r = new ConfigurationRequest();
+            final ConfigurationRequest r = super.getRequestedConfiguration();
 
             r.addField(
                     new BooleanField(

--- a/graylog2-plugin-interfaces/src/main/java/org/graylog2/plugin/Message.java
+++ b/graylog2-plugin-interfaces/src/main/java/org/graylog2/plugin/Message.java
@@ -217,6 +217,10 @@ public class Message {
         return getFieldAs(String.class, FIELD_SOURCE);
     }
 
+    public void setSource(final String source) {
+        fields.put(FIELD_SOURCE, source);
+    }
+
     public void addField(final String key, final Object value) {
         // Don't accept protected keys. (some are allowed though lol)
         if (RESERVED_FIELDS.contains(key) && !RESERVED_SETTABLE_FIELDS.contains(key) || !validKey(key)) {

--- a/graylog2-plugin-interfaces/src/main/java/org/graylog2/plugin/configuration/ConfigurationRequest.java
+++ b/graylog2-plugin-interfaces/src/main/java/org/graylog2/plugin/configuration/ConfigurationRequest.java
@@ -133,13 +133,13 @@ public class ConfigurationRequest {
                     }
                     break;
                 case NumberField.FIELD_TYPE:
-                    if (!config.intIsSet(name)) {
+                    if (config.intIsSet(name)) {
                         values.put(name, config.getInt(name));
                     }
                     break;
                 case TextField.FIELD_TYPE:
                 case DropdownField.FIELD_TYPE:
-                    if (!config.stringIsSet(name)) {
+                    if (config.stringIsSet(name)) {
                         values.put(name, config.getString(name));
                     }
                     break;

--- a/graylog2-plugin-interfaces/src/main/java/org/graylog2/plugin/inputs/MessageInput.java
+++ b/graylog2-plugin-interfaces/src/main/java/org/graylog2/plugin/inputs/MessageInput.java
@@ -28,12 +28,15 @@ import com.codahale.metrics.MetricSet;
 import com.codahale.metrics.Timer;
 import com.fasterxml.jackson.annotation.JsonValue;
 import com.google.common.collect.Maps;
-import org.graylog2.plugin.*;
+import org.graylog2.plugin.AbstractDescriptor;
+import org.graylog2.plugin.LocalMetricRegistry;
+import org.graylog2.plugin.ServerStatus;
+import org.graylog2.plugin.Stoppable;
+import org.graylog2.plugin.Tools;
 import org.graylog2.plugin.buffers.InputBuffer;
 import org.graylog2.plugin.configuration.Configuration;
 import org.graylog2.plugin.configuration.ConfigurationException;
 import org.graylog2.plugin.configuration.ConfigurationRequest;
-import org.graylog2.plugin.configuration.fields.ConfigurationField;
 import org.graylog2.plugin.configuration.fields.TextField;
 import org.graylog2.plugin.inputs.codecs.Codec;
 import org.graylog2.plugin.inputs.transports.Transport;
@@ -50,7 +53,6 @@ import java.util.Map;
 public abstract class MessageInput implements Stoppable {
     private static final Logger LOG = LoggerFactory.getLogger(MessageInput.class);
 
-    public static final String CK_OVERRIDE_SOURCE = "override_source";
     public static final String FIELD_ID = "_id";
     public static final String FIELD_TYPE = "type";
     public static final String FIELD_NODE_ID = "node_id";
@@ -394,16 +396,6 @@ public abstract class MessageInput implements Stoppable {
             final ConfigurationRequest r = new ConfigurationRequest();
             r.putAll(transport.getFields());
             r.putAll(codec.getFields());
-
-            // TODO implement universal override (in raw message maybe?)
-            r.addField(new TextField(
-                    CK_OVERRIDE_SOURCE,
-                    "Override source",
-                    null,
-                    "The source is a hostname derived from the received packet by default. Set this if you want to override " +
-                            "it with a custom string.",
-                    ConfigurationField.Optional.OPTIONAL
-            ));
 
             // give the codec the opportunity to override default values for certain configuration fields,
             // this is commonly being used to default to some well known port for protocols such as GELF or syslog

--- a/graylog2-plugin-interfaces/src/main/java/org/graylog2/plugin/inputs/codecs/AbstractCodec.java
+++ b/graylog2-plugin-interfaces/src/main/java/org/graylog2/plugin/inputs/codecs/AbstractCodec.java
@@ -23,6 +23,9 @@
 package org.graylog2.plugin.inputs.codecs;
 
 import org.graylog2.plugin.configuration.Configuration;
+import org.graylog2.plugin.configuration.ConfigurationRequest;
+import org.graylog2.plugin.configuration.fields.ConfigurationField;
+import org.graylog2.plugin.configuration.fields.TextField;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -57,5 +60,28 @@ public abstract class AbstractCodec implements Codec {
             }
         }
         return name;
+    }
+
+    public abstract static class Config implements Codec.Config {
+        @Override
+        public ConfigurationRequest getRequestedConfiguration() {
+            final ConfigurationRequest configurationRequest = new ConfigurationRequest();
+
+            // TODO implement universal override (in raw message maybe?)
+            configurationRequest.addField(new TextField(
+                    CK_OVERRIDE_SOURCE,
+                    "Override source",
+                    null,
+                    "The source is a hostname derived from the received packet by default. Set this if you want to override " +
+                            "it with a custom string.",
+                    ConfigurationField.Optional.OPTIONAL
+            ));
+
+            return configurationRequest;
+        }
+
+        @Override
+        public void overrideDefaultValues(@Nonnull ConfigurationRequest cr) {
+        }
     }
 }

--- a/graylog2-plugin-interfaces/src/main/java/org/graylog2/plugin/inputs/codecs/Codec.java
+++ b/graylog2-plugin-interfaces/src/main/java/org/graylog2/plugin/inputs/codecs/Codec.java
@@ -48,6 +48,8 @@ public interface Codec {
     }
 
     public interface Config {
+        public static final String CK_OVERRIDE_SOURCE = "override_source";
+
         ConfigurationRequest getRequestedConfiguration();
         void overrideDefaultValues(@Nonnull ConfigurationRequest cr);
     }

--- a/graylog2-shared/src/main/java/org/graylog2/shared/buffers/processors/DecodingProcessor.java
+++ b/graylog2-shared/src/main/java/org/graylog2/shared/buffers/processors/DecodingProcessor.java
@@ -179,6 +179,10 @@ public class DecodingProcessor implements EventHandler<MessageEvent> {
             }
         }
 
+        if (codec.getConfiguration().stringIsSet(Codec.Config.CK_OVERRIDE_SOURCE)) {
+            message.setSource(codec.getConfiguration().getString(Codec.Config.CK_OVERRIDE_SOURCE));
+        }
+
         metricRegistry.meter(name(baseMetricName, "processedMessages")).mark();
         return message;
     }


### PR DESCRIPTION
This implements a possible solution for #848.

The "override_source" configuration option is currently not used. In this implementation I decided to make "override_source" a codec option. This might not be optimal because it increases the `RawMessage` payload and thus the size of the message journal on disk. It might be better to do this before the `RawMessage` is emitted into the journal.

Please comment.

The change in the `ConfigurationRequest` class (commit d0e5043) fixes a bug IMO, please let me know if I misunderstand something here.