### PR TITLE
Enable plugins to announce required (Server/Radio) capabilities

### DIFF
--- a/graylog2-bootstrap/src/main/java/org/graylog2/bootstrap/CmdLineTool.java
+++ b/graylog2-bootstrap/src/main/java/org/graylog2/bootstrap/CmdLineTool.java
@@ -47,6 +47,7 @@ import org.graylog2.plugin.Plugin;
 import org.graylog2.plugin.PluginConfigBean;
 import org.graylog2.plugin.PluginLoaderConfig;
 import org.graylog2.plugin.PluginModule;
+import org.graylog2.plugin.ServerStatus;
 import org.graylog2.plugin.Tools;
 import org.graylog2.plugin.Version;
 import org.graylog2.plugin.system.NodeIdPersistenceException;
@@ -64,6 +65,7 @@ import org.slf4j.bridge.SLF4JBridgeHandler;
 import java.io.File;
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -220,7 +222,7 @@ public abstract class CmdLineTool implements Runnable {
 
     private PluginBindings installPluginConfigAndBindings(String pluginPath) {
         final Set<Plugin> plugins = loadPlugins(pluginPath);
-        final PluginBindings pluginBindings = new PluginBindings(plugins);
+        final PluginBindings pluginBindings = new PluginBindings(plugins, capabilities());
         for (final Plugin plugin : plugins) {
             for (final PluginModule pluginModule : plugin.modules())
                 for (final PluginConfigBean configBean : pluginModule.getConfigBeans())
@@ -358,5 +360,9 @@ public abstract class CmdLineTool implements Runnable {
                 LOG.error("Guice error: {}", message.getMessage());
             }
         }
+    }
+
+    protected Set<ServerStatus.Capability> capabilities() {
+        return Collections.emptySet();
     }
 }

--- a/graylog2-bootstrap/src/main/java/org/graylog2/bootstrap/commands/Radio.java
+++ b/graylog2-bootstrap/src/main/java/org/graylog2/bootstrap/commands/Radio.java
@@ -20,8 +20,9 @@ import com.google.common.util.concurrent.ServiceManager;
 import com.google.inject.Injector;
 import com.google.inject.Module;
 import io.airlift.airline.Command;
-import org.graylog2.bootstrap.ServerBootstrap;
 import org.graylog2.bootstrap.Main;
+import org.graylog2.bootstrap.ServerBootstrap;
+import org.graylog2.plugin.ServerStatus;
 import org.graylog2.radio.Configuration;
 import org.graylog2.radio.bindings.PeriodicalBindings;
 import org.graylog2.radio.bindings.RadioBindings;
@@ -35,15 +36,13 @@ import org.slf4j.LoggerFactory;
 
 import javax.inject.Inject;
 import java.util.Arrays;
+import java.util.EnumSet;
 import java.util.List;
+import java.util.Set;
 
-/**
- * @author Dennis Oelkers <dennis@torch.sh>
- */
 @Command(name = "radio", description = "Start the Graylog2 radio")
 public class Radio extends ServerBootstrap implements Runnable {
     private static final Logger LOG = LoggerFactory.getLogger(Radio.class);
-
     private static final Configuration configuration = new Configuration();
 
     public Radio() {
@@ -52,10 +51,10 @@ public class Radio extends ServerBootstrap implements Runnable {
 
     @Override
     protected List<Module> getCommandBindings() {
-        return Arrays.<Module>asList(new RadioBindings(configuration),
-                                     new RadioInitializerBindings(),
-                                     new PeriodicalBindings(),
-                                     new ObjectMapperModule());
+        return Arrays.<Module>asList(new RadioBindings(configuration, capabilities()),
+                new RadioInitializerBindings(),
+                new PeriodicalBindings(),
+                new ObjectMapperModule());
     }
 
     @Override
@@ -98,5 +97,10 @@ public class Radio extends ServerBootstrap implements Runnable {
     @Override
     protected Class<? extends Runnable> shutdownHook() {
         return ShutdownHook.class;
+    }
+
+    @Override
+    protected Set<ServerStatus.Capability> capabilities() {
+        return EnumSet.of(ServerStatus.Capability.RADIO);
     }
 }

--- a/graylog2-bootstrap/src/main/java/org/graylog2/bootstrap/commands/Server.java
+++ b/graylog2-bootstrap/src/main/java/org/graylog2/bootstrap/commands/Server.java
@@ -239,7 +239,7 @@ public class Server extends ServerBootstrap implements Runnable {
 
     @Override
     protected Set<ServerStatus.Capability> capabilities() {
-        if(configuration.isMaster()) {
+        if (configuration.isMaster()) {
             return EnumSet.of(ServerStatus.Capability.SERVER, ServerStatus.Capability.MASTER);
         } else {
             return EnumSet.of(ServerStatus.Capability.SERVER);

--- a/graylog2-bootstrap/src/main/java/org/graylog2/bootstrap/commands/Server.java
+++ b/graylog2-bootstrap/src/main/java/org/graylog2/bootstrap/commands/Server.java
@@ -36,8 +36,8 @@ import org.graylog2.bindings.RotationStrategyBindings;
 import org.graylog2.bindings.ServerBindings;
 import org.graylog2.bindings.ServerMessageInputBindings;
 import org.graylog2.bindings.ServerObjectMapperModule;
-import org.graylog2.bootstrap.ServerBootstrap;
 import org.graylog2.bootstrap.Main;
+import org.graylog2.bootstrap.ServerBootstrap;
 import org.graylog2.cluster.NodeService;
 import org.graylog2.configuration.ElasticsearchConfiguration;
 import org.graylog2.configuration.EmailConfiguration;
@@ -56,7 +56,9 @@ import org.slf4j.LoggerFactory;
 import javax.inject.Inject;
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.EnumSet;
 import java.util.List;
+import java.util.Set;
 
 @Command(name = "server", description = "Start the Graylog2 server")
 public class Server extends ServerBootstrap implements Runnable {
@@ -128,7 +130,7 @@ public class Server extends ServerBootstrap implements Runnable {
 
     @Override
     protected List<Module> getCommandBindings() {
-        return Arrays.<Module>asList(new ServerBindings(configuration),
+        return Arrays.<Module>asList(new ServerBindings(configuration, capabilities()),
                 new PersistenceServicesBindings(),
                 new ServerMessageInputBindings(),
                 new MessageFilterBindings(),
@@ -232,6 +234,15 @@ public class Server extends ServerBootstrap implements Runnable {
                 LOG.error(UI.wallString("Unable to connect to MongoDB. Is it running and the configuration correct?"));
                 System.exit(-1);
             }
+        }
+    }
+
+    @Override
+    protected Set<ServerStatus.Capability> capabilities() {
+        if(configuration.isMaster()) {
+            return EnumSet.of(ServerStatus.Capability.SERVER, ServerStatus.Capability.MASTER);
+        } else {
+            return EnumSet.of(ServerStatus.Capability.SERVER);
         }
     }
 }

--- a/graylog2-plugin-interfaces/src/main/java/org/graylog2/plugin/PluginMetaData.java
+++ b/graylog2-plugin-interfaces/src/main/java/org/graylog2/plugin/PluginMetaData.java
@@ -23,6 +23,7 @@
 package org.graylog2.plugin;
 
 import java.net.URI;
+import java.util.Set;
 
 public interface PluginMetaData {
     String getUniqueId();
@@ -38,4 +39,6 @@ public interface PluginMetaData {
     String getDescription();
 
     Version getRequiredVersion();
+
+    Set<ServerStatus.Capability> getRequiredCapabilities();
 }

--- a/graylog2-radio/src/main/java/org/graylog2/radio/bindings/RadioBindings.java
+++ b/graylog2-radio/src/main/java/org/graylog2/radio/bindings/RadioBindings.java
@@ -46,12 +46,15 @@ import javax.ws.rs.container.ContainerResponseFilter;
 import javax.ws.rs.container.DynamicFeature;
 import javax.ws.rs.ext.ExceptionMapper;
 import java.io.File;
+import java.util.Set;
 
 public class RadioBindings extends AbstractModule {
     private final Configuration configuration;
+    private final Set<ServerStatus.Capability> capabilities;
 
-    public RadioBindings(Configuration configuration) {
+    public RadioBindings(Configuration configuration, Set<ServerStatus.Capability> capabilities) {
         this.configuration = configuration;
+        this.capabilities = capabilities;
     }
 
     @Override
@@ -83,9 +86,10 @@ public class RadioBindings extends AbstractModule {
         bind(Configuration.class).toInstance(configuration);
         bind(BaseConfiguration.class).toInstance(configuration);
 
-        Multibinder<ServerStatus.Capability> capabilityBinder =
-                Multibinder.newSetBinder(binder(), ServerStatus.Capability.class);
-        capabilityBinder.addBinding().toInstance(ServerStatus.Capability.RADIO);
+        Multibinder<ServerStatus.Capability> capabilityBinder = Multibinder.newSetBinder(binder(), ServerStatus.Capability.class);
+        for(ServerStatus.Capability capability : capabilities) {
+            capabilityBinder.addBinding().toInstance(capability);
+        }
 
         bind(ServerStatus.class).in(Scopes.SINGLETON);
         install(new NoopJournalModule());

--- a/graylog2-server/src/main/java/org/graylog2/bindings/ServerBindings.java
+++ b/graylog2-server/src/main/java/org/graylog2/bindings/ServerBindings.java
@@ -63,7 +63,6 @@ import org.graylog2.plugin.indexer.rotation.RotationStrategy;
 import org.graylog2.rest.NotFoundExceptionMapper;
 import org.graylog2.rest.RestAccessLogFilter;
 import org.graylog2.rest.ValidationExceptionMapper;
-import org.graylog2.shared.security.ShiroSecurityBinding;
 import org.graylog2.security.ShiroSecurityContextFactory;
 import org.graylog2.security.ldap.LdapConnector;
 import org.graylog2.security.ldap.LdapSettingsImpl;
@@ -75,6 +74,7 @@ import org.graylog2.shared.journal.JournalReaderModule;
 import org.graylog2.shared.journal.KafkaJournalModule;
 import org.graylog2.shared.journal.NoopJournalModule;
 import org.graylog2.shared.metrics.jersey2.MetricsDynamicBinding;
+import org.graylog2.shared.security.ShiroSecurityBinding;
 import org.graylog2.shared.system.activities.ActivityWriter;
 import org.graylog2.streams.StreamRouter;
 import org.graylog2.streams.StreamRouterEngine;
@@ -87,12 +87,15 @@ import org.graylog2.system.stats.ClusterStatsModule;
 import javax.ws.rs.container.ContainerResponseFilter;
 import javax.ws.rs.container.DynamicFeature;
 import javax.ws.rs.ext.ExceptionMapper;
+import java.util.Set;
 
 public class ServerBindings extends AbstractModule {
     private final Configuration configuration;
+    private final Set<ServerStatus.Capability> capabilities;
 
-    public ServerBindings(Configuration configuration) {
+    public ServerBindings(Configuration configuration, Set<ServerStatus.Capability> capabilities) {
         this.configuration = configuration;
+        this.capabilities = capabilities;
     }
 
     @Override
@@ -130,11 +133,11 @@ public class ServerBindings extends AbstractModule {
 
         bind(MongoConnection.class).toProvider(MongoConnectionProvider.class);
 
-        Multibinder<ServerStatus.Capability> capabilityBinder =
-                Multibinder.newSetBinder(binder(), ServerStatus.Capability.class);
-        capabilityBinder.addBinding().toInstance(ServerStatus.Capability.SERVER);
-        if (configuration.isMaster())
-            capabilityBinder.addBinding().toInstance(ServerStatus.Capability.MASTER);
+        Multibinder<ServerStatus.Capability> capabilityBinder = Multibinder.newSetBinder(binder(), ServerStatus.Capability.class);
+        for (ServerStatus.Capability capability : capabilities) {
+            capabilityBinder.addBinding().toInstance(capability);
+        }
+
         bind(ServerStatus.class).in(Scopes.SINGLETON);
 
         if (configuration.isMessageJournalEnabled()) {
@@ -176,20 +179,23 @@ public class ServerBindings extends AbstractModule {
     }
 
     private void bindDynamicFeatures() {
-        TypeLiteral<Class<? extends DynamicFeature>> type = new TypeLiteral<Class<? extends DynamicFeature>>(){};
+        TypeLiteral<Class<? extends DynamicFeature>> type = new TypeLiteral<Class<? extends DynamicFeature>>() {
+        };
         Multibinder<Class<? extends DynamicFeature>> setBinder = Multibinder.newSetBinder(binder(), type);
         setBinder.addBinding().toInstance(ShiroSecurityBinding.class);
         setBinder.addBinding().toInstance(MetricsDynamicBinding.class);
     }
 
     private void bindContainerResponseFilters() {
-        TypeLiteral<Class<? extends ContainerResponseFilter>> type = new TypeLiteral<Class<? extends ContainerResponseFilter>>(){};
+        TypeLiteral<Class<? extends ContainerResponseFilter>> type = new TypeLiteral<Class<? extends ContainerResponseFilter>>() {
+        };
         Multibinder<Class<? extends ContainerResponseFilter>> setBinder = Multibinder.newSetBinder(binder(), type);
         setBinder.addBinding().toInstance(RestAccessLogFilter.class);
     }
 
     private void bindExceptionMappers() {
-        TypeLiteral<Class<? extends ExceptionMapper>> type = new TypeLiteral<Class<? extends ExceptionMapper>>(){};
+        TypeLiteral<Class<? extends ExceptionMapper>> type = new TypeLiteral<Class<? extends ExceptionMapper>>() {
+        };
         Multibinder<Class<? extends ExceptionMapper>> setBinder = Multibinder.newSetBinder(binder(), type);
         setBinder.addBinding().toInstance(NotFoundExceptionMapper.class);
         setBinder.addBinding().toInstance(ValidationExceptionMapper.class);

--- a/graylog2-server/src/main/java/org/graylog2/rest/resources/system/PluginResource.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/resources/system/PluginResource.java
@@ -20,6 +20,7 @@ import com.codahale.metrics.annotation.Timed;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Lists;
 import org.graylog2.plugin.PluginMetaData;
+import org.graylog2.plugin.ServerStatus;
 import org.graylog2.plugin.Version;
 import com.wordnik.swagger.annotations.Api;
 import com.wordnik.swagger.annotations.ApiOperation;
@@ -49,6 +50,7 @@ public class PluginResource extends RestResource {
         public final Version version;
         public final String description;
         public final Version required_version;
+        public final Set<ServerStatus.Capability> required_capabilities;
 
         PluginMetaDataValue(PluginMetaData pluginMetaData) {
             this.unique_id = pluginMetaData.getUniqueId();
@@ -58,6 +60,7 @@ public class PluginResource extends RestResource {
             this.version = pluginMetaData.getVersion();
             this.description = pluginMetaData.getDescription();
             this.required_version = pluginMetaData.getRequiredVersion();
+            this.required_capabilities = pluginMetaData.getRequiredCapabilities();
         }
     }
 

--- a/graylog2-shared/src/main/java/org/graylog2/shared/bindings/PluginBindings.java
+++ b/graylog2-shared/src/main/java/org/graylog2/shared/bindings/PluginBindings.java
@@ -16,32 +16,47 @@
  */
 package org.graylog2.shared.bindings;
 
+import com.google.common.collect.Sets;
 import com.google.inject.AbstractModule;
 import com.google.inject.multibindings.Multibinder;
 import org.graylog2.plugin.Plugin;
 import org.graylog2.plugin.PluginMetaData;
 import org.graylog2.plugin.PluginModule;
+import org.graylog2.plugin.ServerStatus;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.util.Set;
 
 public class PluginBindings extends AbstractModule {
-    private final Set<Plugin> plugins;
+    private static final Logger LOG = LoggerFactory.getLogger(PluginBindings.class);
 
-    public PluginBindings(Set<Plugin> plugins) {
+    private final Set<Plugin> plugins;
+    private final Set<ServerStatus.Capability> capabilities;
+
+    public PluginBindings(Set<Plugin> plugins, Set<ServerStatus.Capability> capabilities) {
         this.plugins = plugins;
+        this.capabilities = capabilities;
     }
 
     @Override
     protected void configure() {
         final Multibinder<Plugin> pluginbinder = Multibinder.newSetBinder(binder(), Plugin.class);
         final Multibinder<PluginMetaData> pluginMetaDataBinder = Multibinder.newSetBinder(binder(), PluginMetaData.class);
-        for (final Plugin plugin : plugins) {
-            pluginbinder.addBinding().toInstance(plugin);
-            for (final PluginModule pluginModule : plugin.modules()) {
-                binder().install(pluginModule);
-            }
 
-            pluginMetaDataBinder.addBinding().toInstance(plugin.metadata());
+        for (final Plugin plugin : plugins) {
+            if (capabilities.containsAll(plugin.metadata().getRequiredCapabilities())) {
+                pluginbinder.addBinding().toInstance(plugin);
+                for (final PluginModule pluginModule : plugin.modules()) {
+                    binder().install(pluginModule);
+                }
+
+                pluginMetaDataBinder.addBinding().toInstance(plugin.metadata());
+            } else {
+                LOG.debug("Skipping plugin {} because some capabilities are missing ({}).",
+                        plugin.metadata().getName(),
+                        Sets.difference(plugin.metadata().getRequiredCapabilities(), capabilities));
+            }
         }
     }
 }


### PR DESCRIPTION
The `PluginMetaData` has been extended with the `getRequiredCapabilities()` method. If the returned set contains any capabilities which the enclosing program (currently either Graylog2 Server or Radio) doesn't have, the loading of the plugin is being skipped.