### PR TITLE
added exit codes

### DIFF
--- a/bin/graylogctl
+++ b/bin/graylogctl
@@ -89,10 +89,12 @@ status() {
         else
             echo "Stale pid file with $pid - removing..."
             rm ${GRAYLOG_PID}
+            exit 1
         fi
     fi
 
     echo "graylog-server not running"
+    exit 1
 }
 
 get_pid() {


### PR DESCRIPTION
Monitoring tools like icinga need an exit status for evaluation of the system is running or not