### PR TITLE
Upgrade to Elasticsearch 1.4.x

### DIFF
--- a/graylog2-server/pom.xml
+++ b/graylog2-server/pom.xml
@@ -237,10 +237,6 @@
             <groupId>org.elasticsearch</groupId>
             <artifactId>elasticsearch</artifactId>
         </dependency>
-        <dependency>
-            <groupId>org.apache.lucene</groupId>
-            <artifactId>lucene-queryparser</artifactId>
-        </dependency>
 
         <dependency>
             <groupId>org.kie</groupId>

--- a/graylog2-server/pom.xml
+++ b/graylog2-server/pom.xml
@@ -17,7 +17,8 @@
   ~ You should have received a copy of the GNU General Public License
   ~ along with Graylog.  If not, see <http://www.gnu.org/licenses />.
   -->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <prerequisites>
         <maven>3.0.1</maven>
@@ -293,6 +294,19 @@
         <dependency>
             <groupId>com.wordnik</groupId>
             <artifactId>swagger-annotations</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.lordofthejars</groupId>
+            <artifactId>nosqlunit-elasticsearch</artifactId>
         </dependency>
     </dependencies>
 

--- a/graylog2-server/src/main/java/org/graylog2/indexer/indices/Indices.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/indices/Indices.java
@@ -16,6 +16,7 @@
  */
 package org.graylog2.indexer.indices;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
@@ -84,7 +85,12 @@ public class Indices implements IndexManagement {
 
     @Inject
     public Indices(Node node, ElasticsearchConfiguration configuration) {
-        this.c = node.client();
+        this(node.client(), configuration);
+    }
+
+    @VisibleForTesting
+    public Indices(Client client, ElasticsearchConfiguration configuration) {
+        this.c = client;
         this.configuration = configuration;
     }
 

--- a/graylog2-server/src/main/java/org/graylog2/indexer/results/DateHistogramResult.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/results/DateHistogramResult.java
@@ -19,40 +19,35 @@ package org.graylog2.indexer.results;
 import com.google.common.collect.Maps;
 import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.unit.TimeValue;
-import org.elasticsearch.search.facet.datehistogram.DateHistogramFacet;
+import org.elasticsearch.search.aggregations.bucket.histogram.DateHistogram;
 import org.graylog2.indexer.searches.Searches;
 
 import java.util.Map;
 
-/**
- * @author Lennart Koopmann <lennart@socketfeed.com>
- */
 public class DateHistogramResult extends HistogramResult {
-	
-	private final DateHistogramFacet result;
-	private final Searches.DateHistogramInterval interval;
+    private final DateHistogram result;
+    private final Searches.DateHistogramInterval interval;
 
-	public DateHistogramResult(DateHistogramFacet result, String originalQuery, BytesReference builtQuery, Searches.DateHistogramInterval interval, TimeValue took) {
+    public DateHistogramResult(DateHistogram result, String originalQuery, BytesReference builtQuery, Searches.DateHistogramInterval interval, TimeValue took) {
         super(originalQuery, builtQuery, took);
 
-		this.result = result;
-		this.interval = interval;
-	}
+        this.result = result;
+        this.interval = interval;
+    }
 
     @Override
-	public Searches.DateHistogramInterval getInterval() {
-		return interval;
-	}
+    public Searches.DateHistogramInterval getInterval() {
+        return interval;
+    }
 
     @Override
-	public Map<Long, Long> getResults() {
-		Map<Long, Long> results = Maps.newTreeMap();
-		
-		for (DateHistogramFacet.Entry e : result) {
-			results.put(e.getTime()/1000, e.getCount());
-		}
-		
-		return results;
-	}
-	
+    public Map<Long, Long> getResults() {
+        Map<Long, Long> results = Maps.newTreeMap();
+
+        for (DateHistogram.Bucket bucket : result.getBuckets()) {
+            results.put(bucket.getKeyAsDate().getMillis() / 1000L, bucket.getDocCount());
+        }
+
+        return results;
+    }
 }

--- a/graylog2-server/src/main/java/org/graylog2/indexer/results/FieldStatsResult.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/results/FieldStatsResult.java
@@ -19,13 +19,10 @@ package org.graylog2.indexer.results;
 import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.unit.TimeValue;
 import org.elasticsearch.search.SearchHits;
-import org.elasticsearch.search.facet.statistical.StatisticalFacet;
+import org.elasticsearch.search.aggregations.metrics.stats.extended.ExtendedStats;
 
 import java.util.List;
 
-/**
- * @author Lennart Koopmann <lennart@torch.sh>
- */
 public class FieldStatsResult extends IndexQueryResult {
 
     private final long count;
@@ -38,20 +35,20 @@ public class FieldStatsResult extends IndexQueryResult {
     private final double stdDeviation;
     private List<ResultMessage> searchHits;
 
-    public FieldStatsResult(StatisticalFacet f, String originalQuery, BytesReference builtQuery, TimeValue took) {
+    public FieldStatsResult(ExtendedStats f, String originalQuery, BytesReference builtQuery, TimeValue took) {
         super(originalQuery, builtQuery, took);
 
         this.count = f.getCount();
-        this.sum = f.getTotal();
+        this.sum = f.getSum();
         this.sumOfSquares = f.getSumOfSquares();
-        this.mean = f.getMean();
+        this.mean = f.getAvg();
         this.min = f.getMin();
         this.max = f.getMax();
         this.variance = f.getVariance();
         this.stdDeviation = f.getStdDeviation();
     }
 
-    public FieldStatsResult(StatisticalFacet facet, SearchHits searchHits, String query, BytesReference source, TimeValue took) {
+    public FieldStatsResult(ExtendedStats facet, SearchHits searchHits, String query, BytesReference source, TimeValue took) {
         this(facet, query, source, took);
         this.searchHits = buildResults(searchHits);
     }

--- a/graylog2-server/src/main/java/org/graylog2/indexer/results/TermsStatsResult.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/results/TermsStatsResult.java
@@ -20,21 +20,32 @@ import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.unit.TimeValue;
-import org.elasticsearch.search.facet.termsstats.TermsStatsFacet;
+import org.elasticsearch.search.aggregations.bucket.terms.Terms;
+import org.elasticsearch.search.aggregations.metrics.stats.Stats;
+import org.graylog2.indexer.searches.Searches;
 
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
 
-/**
- * @author Lennart Koopmann <lennart@torch.sh>
- */
 public class TermsStatsResult extends IndexQueryResult {
+    private static final Comparator<Map<String, Object>> COMPARATOR = new Comparator<Map<String, Object>>() {
+        @Override
+        public int compare(Map<String, Object> o1, Map<String, Object> o2) {
+            double o1Mean = (double) o1.get("mean");
+            double o2Mean = (double) o2.get("mean");
+            if (o1Mean > o2Mean) {
+                return -1;
+            } else if (o1Mean < o2Mean) {
+                return 1;
+            }
+            return 0;
+        }
+    };
+    private final Terms facet;
 
-    private final TermsStatsFacet facet;
-
-    public TermsStatsResult(TermsStatsFacet facet, String originalQuery, BytesReference builtQuery, TimeValue took) {
+    public TermsStatsResult(Terms facet, String originalQuery, BytesReference builtQuery, TimeValue took) {
         super(originalQuery, builtQuery, took);
 
         this.facet = facet;
@@ -43,37 +54,26 @@ public class TermsStatsResult extends IndexQueryResult {
     public List<Map<String, Object>> getResults() {
         List<Map<String, Object>> results = Lists.newArrayList();
 
-        for (TermsStatsFacet.Entry e : facet.getEntries()) {
+        for (Terms.Bucket e : facet.getBuckets()) {
             Map<String, Object> resultMap = Maps.newHashMap();
 
-            resultMap.put("key_field", e.getTerm().toString());
+            resultMap.put("key_field", e.getKey());
 
-            resultMap.put("count", e.getCount());
-            resultMap.put("min", e.getMin());
-            resultMap.put("max", e.getMax());
-            resultMap.put("total", e.getTotal());
-            resultMap.put("total_count", e.getTotalCount());
-            resultMap.put("mean", e.getMean());
+            resultMap.put("count", e.getDocCount());
+
+            final Stats stats = e.getAggregations().get(Searches.AGG_STATS);
+            resultMap.put("min", stats.getMin());
+            resultMap.put("max", stats.getMax());
+            resultMap.put("total", stats.getSum());
+            resultMap.put("total_count", stats.getCount());
+            resultMap.put("mean", stats.getAvg());
 
             results.add(resultMap);
         }
 
         // Sort results by descending mean value
-        Collections.sort(results, new Comparator<Map<String, Object>>() {
-            @Override
-            public int compare(Map<String, Object> o1, Map<String, Object> o2) {
-                double o1Mean = (double)o1.get("mean");
-                double o2Mean = (double)o2.get("mean");
-                if (o1Mean > o2Mean) {
-                    return -1;
-                } else if (o1Mean < o2Mean) {
-                    return 1;
-                }
-                return 0;
-            }
-        });
+        Collections.sort(results, COMPARATOR);
 
         return results;
     }
-
 }

--- a/graylog2-server/src/main/java/org/graylog2/indexer/searches/Searches.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/searches/Searches.java
@@ -16,6 +16,7 @@
  */
 package org.graylog2.indexer.searches;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.Sets;
 import org.elasticsearch.action.search.SearchRequest;
 import org.elasticsearch.action.search.SearchRequestBuilder;
@@ -125,10 +126,18 @@ public class Searches {
                     Deflector deflector,
                     IndexRangeService indexRangeService,
                     Node node) {
+        this(configuration, deflector, indexRangeService, node.client());
+    }
+
+    @VisibleForTesting
+    Searches(Configuration configuration,
+                    Deflector deflector,
+                    IndexRangeService indexRangeService,
+                    Client client) {
         this.configuration = configuration;
         this.deflector = deflector;
         this.indexRangeService = indexRangeService;
-        this.c = node.client();
+        this.c = client;
     }
 
     public CountResult count(String query, TimeRange range) {

--- a/graylog2-server/src/main/java/org/graylog2/indexer/searches/Searches.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/searches/Searches.java
@@ -31,15 +31,13 @@ import org.elasticsearch.index.query.QueryBuilders;
 import org.elasticsearch.index.query.QueryStringQueryBuilder;
 import org.elasticsearch.node.Node;
 import org.elasticsearch.search.SearchHit;
-import org.elasticsearch.search.facet.FacetBuilders;
-import org.elasticsearch.search.facet.datehistogram.DateHistogramFacet;
-import org.elasticsearch.search.facet.datehistogram.DateHistogramFacetBuilder;
-import org.elasticsearch.search.facet.statistical.StatisticalFacet;
-import org.elasticsearch.search.facet.statistical.StatisticalFacetBuilder;
-import org.elasticsearch.search.facet.terms.TermsFacet;
-import org.elasticsearch.search.facet.terms.TermsFacetBuilder;
-import org.elasticsearch.search.facet.termsstats.TermsStatsFacet;
-import org.elasticsearch.search.facet.termsstats.TermsStatsFacetBuilder;
+import org.elasticsearch.search.aggregations.AggregationBuilders;
+import org.elasticsearch.search.aggregations.bucket.filter.Filter;
+import org.elasticsearch.search.aggregations.bucket.filter.FilterAggregationBuilder;
+import org.elasticsearch.search.aggregations.bucket.histogram.DateHistogram;
+import org.elasticsearch.search.aggregations.bucket.missing.Missing;
+import org.elasticsearch.search.aggregations.bucket.terms.Terms;
+import org.elasticsearch.search.aggregations.metrics.stats.extended.ExtendedStats;
 import org.elasticsearch.search.sort.SortOrder;
 import org.graylog2.Configuration;
 import org.graylog2.indexer.Deflector;
@@ -73,6 +71,13 @@ import static org.elasticsearch.index.query.QueryBuilders.queryString;
 @Singleton
 public class Searches {
     private static final Logger LOG = LoggerFactory.getLogger(Searches.class);
+
+    public final static String AGG_TERMS = "gl2_terms";
+    public final static String AGG_STATS = "gl2_stats";
+    public final static String AGG_TERMS_STATS = "gl2_termsstats";
+    public static final String AGG_FILTER = "gl2_filter";
+    public static final String AGG_HISTOGRAM = "gl2_histogram";
+    public static final String AGG_EXTENDED_STATS = "gl2_extended_stats";
 
     public static enum TermsStatsOrder {
         TERM,
@@ -114,10 +119,6 @@ public class Searches {
     private final Deflector deflector;
     private final IndexRangeService indexRangeService;
     private final Client c;
-
-    private final static String TERMS_FACET_NAME = "gl2_terms";
-    private final static String STATS_FACET_NAME = "gl2_stats";
-    private final static String TERMS_STATS_FACET_NAME = "gl2_termsstats";
 
     @Inject
     public Searches(Configuration configuration,
@@ -223,20 +224,26 @@ public class Searches {
             srb = filteredSearchRequest(query, filter, IndexHelper.determineAffectedIndices(indexRangeService, deflector, range));
         }
 
-        TermsFacetBuilder terms = new TermsFacetBuilder(TERMS_FACET_NAME);
-        terms.global(false);
-        terms.field(field);
-        terms.size(size);
+        FilterAggregationBuilder builder = AggregationBuilders.filter(AGG_FILTER)
+                .subAggregation(
+                        AggregationBuilders.terms(AGG_TERMS)
+                                .field(field)
+                                .size(size))
+                .subAggregation(
+                        AggregationBuilders.missing("missing")
+                                .field(field))
+                .filter(standardFilters(range, filter));
 
-        terms.facetFilter(standardFilters(range, filter));
-
-        srb.addFacet(terms);
+        srb.addAggregation(builder);
 
         final SearchRequest request = srb.request();
         SearchResponse r = c.search(request).actionGet();
 
+        final Filter f = r.getAggregations().get(AGG_FILTER);
         return new TermsResult(
-                (TermsFacet) r.getFacets().facet(TERMS_FACET_NAME),
+                (Terms) f.getAggregations().get(AGG_TERMS),
+                (Missing) f.getAggregations().get("missing"),
+                f.getDocCount(),
                 query,
                 request.source(),
                 r.getTook()
@@ -259,22 +266,66 @@ public class Searches {
             srb = filteredSearchRequest(query, filter, IndexHelper.determineAffectedIndices(indexRangeService, deflector, range));
         }
 
-        TermsStatsFacetBuilder stats = new TermsStatsFacetBuilder(TERMS_STATS_FACET_NAME);
-        stats.global(false);
-        stats.keyField(keyField);
-        stats.valueField(valueField);
-        stats.order(TermsStatsFacet.ComparatorType.fromString(order.toString().toLowerCase()));
-        stats.size(size);
 
-        stats.facetFilter(standardFilters(range, filter));
+        Terms.Order termsOrder;
+        switch (order) {
+            case COUNT:
+                termsOrder = Terms.Order.count(true);
+                break;
+            case REVERSE_COUNT:
+                termsOrder = Terms.Order.count(false);
+                break;
+            case TERM:
+                termsOrder = Terms.Order.term(true);
+                break;
+            case REVERSE_TERM:
+                termsOrder = Terms.Order.term(false);
+                break;
+            case MIN:
+                termsOrder = Terms.Order.aggregation(AGG_STATS, "min", true);
+                break;
+            case REVERSE_MIN:
+                termsOrder = Terms.Order.aggregation(AGG_STATS, "min", false);
+                break;
+            case MAX:
+                termsOrder = Terms.Order.aggregation(AGG_STATS, "max", true);
+                break;
+            case REVERSE_MAX:
+                termsOrder = Terms.Order.aggregation(AGG_STATS, "max", false);
+                break;
+            case MEAN:
+                termsOrder = Terms.Order.aggregation(AGG_STATS, "avg", true);
+                break;
+            case REVERSE_MEAN:
+                termsOrder = Terms.Order.aggregation(AGG_STATS, "avg", false);
+                break;
+            case TOTAL:
+                termsOrder = Terms.Order.aggregation(AGG_STATS, "sum", true);
+                break;
+            case REVERSE_TOTAL:
+                termsOrder = Terms.Order.aggregation(AGG_STATS, "sum", false);
+                break;
+            default:
+                termsOrder = Terms.Order.count(true);
+        }
 
-        srb.addFacet(stats);
+        FilterAggregationBuilder builder = AggregationBuilders.filter(AGG_FILTER)
+                .subAggregation(
+                        AggregationBuilders.terms(AGG_TERMS_STATS)
+                                .field(keyField)
+                                .subAggregation(AggregationBuilders.stats(AGG_STATS).field(valueField))
+                                .order(termsOrder)
+                                .size(size))
+                .filter(standardFilters(range, filter));
+
+        srb.addAggregation(builder);
 
         final SearchRequest request = srb.request();
         SearchResponse r = c.search(request).actionGet();
 
+        final Filter f = r.getAggregations().get(AGG_FILTER);
         return new TermsStatsResult(
-                (TermsStatsFacet) r.getFacets().facet(TERMS_STATS_FACET_NAME),
+                (Terms) f.getAggregations().get(AGG_TERMS_STATS),
                 query,
                 request.source(),
                 r.getTook()
@@ -298,14 +349,11 @@ public class Searches {
             srb = filteredSearchRequest(query, filter, IndexHelper.determineAffectedIndices(indexRangeService, deflector, range));
         }
 
-        StatisticalFacetBuilder stats = new StatisticalFacetBuilder(STATS_FACET_NAME);
-        stats.global(false);
+        FilterAggregationBuilder builder = AggregationBuilders.filter(AGG_FILTER)
+                .filter(standardFilters(range, filter))
+                .subAggregation(AggregationBuilders.extendedStats(AGG_EXTENDED_STATS).field(field));
 
-        stats.facetFilter(standardFilters(range, filter));
-
-        stats.field(field);
-
-        srb.addFacet(stats);
+        srb.addAggregation(builder);
 
         SearchResponse r;
         final SearchRequest request;
@@ -316,8 +364,9 @@ public class Searches {
             throw new FieldTypeException(e);
         }
 
+        final Filter f = r.getAggregations().get(AGG_FILTER);
         return new FieldStatsResult(
-                (StatisticalFacet) r.getFacets().facet(STATS_FACET_NAME),
+                (ExtendedStats) f.getAggregations().get(AGG_EXTENDED_STATS),
                 r.getHits(),
                 query,
                 request.source(),
@@ -330,11 +379,12 @@ public class Searches {
     }
 
     public HistogramResult histogram(String query, DateHistogramInterval interval, String filter, TimeRange range) {
-        DateHistogramFacetBuilder fb = FacetBuilders.dateHistogramFacet("histogram")
-                .field("timestamp")
-                .interval(interval.toString().toLowerCase());
-
-        fb.facetFilter(standardFilters(range, filter));
+        FilterAggregationBuilder builder = AggregationBuilders.filter(AGG_FILTER)
+                .subAggregation(
+                        AggregationBuilders.dateHistogram(AGG_HISTOGRAM)
+                                .field("timestamp")
+                                .interval(interval.getPeriod().toStandardDuration().getMillis()))
+                .filter(standardFilters(range, filter));
 
         QueryStringQueryBuilder qs = queryString(query);
         qs.allowLeadingWildcard(configuration.isAllowLeadingWildcardSearches());
@@ -343,22 +393,29 @@ public class Searches {
         final Set<String> affectedIndices = IndexHelper.determineAffectedIndices(indexRangeService, deflector, range);
         srb.setIndices(affectedIndices.toArray(new String[affectedIndices.size()]));
         srb.setQuery(qs);
-        srb.addFacet(fb);
+        srb.addAggregation(builder);
 
         final SearchRequest request = srb.request();
         SearchResponse r = c.search(request).actionGet();
-        return new DateHistogramResult((DateHistogramFacet) r.getFacets().facet("histogram"), query,
+
+        final Filter f = r.getAggregations().get(AGG_FILTER);
+        return new DateHistogramResult(
+                (DateHistogram) f.getAggregations().get(AGG_HISTOGRAM),
+                query,
                 request.source(),
-                interval, r.getTook());
+                interval,
+                r.getTook());
     }
 
     public HistogramResult fieldHistogram(String query, String field, DateHistogramInterval interval, String filter, TimeRange range) throws FieldTypeException {
-        DateHistogramFacetBuilder fb = FacetBuilders.dateHistogramFacet("histogram")
-                .keyField("timestamp")
-                .valueField(field)
-                .interval(interval.toString().toLowerCase());
-
-        fb.facetFilter(standardFilters(range, filter));
+        FilterAggregationBuilder builder = AggregationBuilders.filter(AGG_FILTER)
+                .subAggregation(
+                        AggregationBuilders.dateHistogram(AGG_HISTOGRAM)
+                                .field("timestamp")
+                                .subAggregation(AggregationBuilders.stats(AGG_STATS).field(field))
+                                .interval(interval.getPeriod().toStandardDuration().getMillis())
+                )
+                .filter(standardFilters(range, filter));
 
         QueryStringQueryBuilder qs = queryString(query);
         qs.allowLeadingWildcard(configuration.isAllowLeadingWildcardSearches());
@@ -367,7 +424,7 @@ public class Searches {
         final Set<String> affectedIndices = IndexHelper.determineAffectedIndices(indexRangeService, deflector, range);
         srb.setIndices(affectedIndices.toArray(new String[affectedIndices.size()]));
         srb.setQuery(qs);
-        srb.addFacet(fb);
+        srb.addAggregation(builder);
 
         SearchResponse r;
         final SearchRequest request = srb.request();
@@ -377,8 +434,13 @@ public class Searches {
             throw new FieldTypeException(e);
         }
 
-        return new FieldHistogramResult((DateHistogramFacet) r.getFacets().facet("histogram"), query, request.source(),
-                interval, r.getTook());
+        final Filter f = r.getAggregations().get(AGG_FILTER);
+        return new FieldHistogramResult(
+                (DateHistogram) f.getAggregations().get(AGG_HISTOGRAM),
+                query,
+                request.source(),
+                interval,
+                r.getTook());
     }
 
     public SearchHit firstOfIndex(String index) {
@@ -528,10 +590,8 @@ public class Searches {
     }
 
     public class FieldTypeException extends Exception {
-
         public FieldTypeException(Throwable e) {
             super(e);
         }
-
     }
 }

--- a/graylog2-server/src/main/java/org/graylog2/indexer/searches/timeranges/AbsoluteRange.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/searches/timeranges/AbsoluteRange.java
@@ -23,6 +23,9 @@ import org.joda.time.DateTime;
 import org.joda.time.format.ISODateTimeFormat;
 
 import java.util.Map;
+import java.util.Objects;
+
+import static com.google.common.base.Preconditions.checkNotNull;
 
 public class AbsoluteRange implements TimeRange {
 
@@ -30,8 +33,8 @@ public class AbsoluteRange implements TimeRange {
     private final DateTime to;
 
     public AbsoluteRange(DateTime from, DateTime to) {
-        this.from = from;
-        this.to = to;
+        this.from = checkNotNull(from);
+        this.to = checkNotNull(to);
     }
 
     public AbsoluteRange(String from, String to) throws InvalidRangeParametersException {
@@ -88,5 +91,20 @@ public class AbsoluteRange implements TimeRange {
                 .add("from", getFrom())
                 .add("to", getTo())
                 .toString();
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+
+        AbsoluteRange that = (AbsoluteRange) o;
+        return from.equals(that.from) && to.equals(that.to);
+
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(from, to);
     }
 }

--- a/graylog2-server/src/main/java/org/graylog2/indexer/searches/timeranges/KeywordRange.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/searches/timeranges/KeywordRange.java
@@ -22,6 +22,7 @@ import org.graylog2.utilities.date.NaturalDateParser;
 import org.joda.time.DateTime;
 
 import java.util.Map;
+import java.util.Objects;
 
 import static com.google.common.base.Strings.isNullOrEmpty;
 
@@ -101,6 +102,21 @@ public class KeywordRange implements TimeRange {
                 .add("from", getFrom())
                 .add("to", getTo())
                 .toString();
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+
+        KeywordRange that = (KeywordRange) o;
+        return dynamic == that.dynamic && keyword.equals(that.keyword);
+
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(keyword, dynamic);
     }
 }
 

--- a/graylog2-server/src/main/java/org/graylog2/indexer/searches/timeranges/RelativeRange.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/searches/timeranges/RelativeRange.java
@@ -74,4 +74,18 @@ public class RelativeRange implements TimeRange {
                 .add("to", getTo())
                 .toString();
     }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+
+        RelativeRange that = (RelativeRange) o;
+        return range == that.range;
+    }
+
+    @Override
+    public int hashCode() {
+        return range;
+    }
 }

--- a/graylog2-server/src/main/java/org/graylog2/rest/resources/search/responses/TermsResult.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/resources/search/responses/TermsResult.java
@@ -29,7 +29,7 @@ public abstract class TermsResult {
     public abstract long time();
 
     @JsonProperty
-    public abstract Map<String, Integer> terms();
+    public abstract Map<String, Long> terms();
 
     @JsonProperty
     public abstract long missing();
@@ -44,7 +44,7 @@ public abstract class TermsResult {
     public abstract String builtQuery();
 
     public static TermsResult create(long time,
-                                     Map<String, Integer> terms,
+                                     Map<String, Long> terms,
                                      long missing,
                                      long other,
                                      long total,

--- a/graylog2-server/src/main/java/org/graylog2/rest/resources/sources/responses/SourcesList.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/resources/sources/responses/SourcesList.java
@@ -29,7 +29,7 @@ public abstract class SourcesList {
     public abstract int total();
 
     @JsonProperty
-    public abstract Map<String, Integer> sources();
+    public abstract Map<String, Long> sources();
 
     @JsonProperty
     public abstract long tookMs();
@@ -37,7 +37,7 @@ public abstract class SourcesList {
     @JsonProperty
     public abstract int range();
 
-    public static SourcesList create(int total, Map<String, Integer> sources, long tookMs, int range) {
+    public static SourcesList create(int total, Map<String, Long> sources, long tookMs, int range) {
         return new AutoValue_SourcesList(total, sources, tookMs, range);
     }
 

--- a/graylog2-server/src/test/java/org/graylog2/indexer/searches/SearchesTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/indexer/searches/SearchesTest.java
@@ -1,0 +1,304 @@
+/**
+ * This file is part of Graylog.
+ *
+ * Graylog is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.graylog2.indexer.searches;
+
+import autovalue.shaded.com.google.common.common.collect.ImmutableSet;
+import com.lordofthejars.nosqlunit.annotation.UsingDataSet;
+import com.lordofthejars.nosqlunit.core.DatabaseOperation;
+import com.lordofthejars.nosqlunit.core.LoadStrategyEnum;
+import com.lordofthejars.nosqlunit.core.LoadStrategyFactory;
+import com.lordofthejars.nosqlunit.core.LoadStrategyOperation;
+import com.lordofthejars.nosqlunit.core.ReflectionLoadStrategyFactory;
+import com.lordofthejars.nosqlunit.elasticsearch.ElasticsearchRule;
+import com.lordofthejars.nosqlunit.elasticsearch.EmbeddedElasticsearch;
+import org.elasticsearch.action.admin.indices.exists.indices.IndicesExistsResponse;
+import org.elasticsearch.client.Client;
+import org.elasticsearch.client.IndicesAdminClient;
+import org.graylog2.Configuration;
+import org.graylog2.configuration.ElasticsearchConfiguration;
+import org.graylog2.indexer.Deflector;
+import org.graylog2.indexer.indices.Indices;
+import org.graylog2.indexer.ranges.IndexRange;
+import org.graylog2.indexer.ranges.IndexRangeService;
+import org.graylog2.indexer.results.CountResult;
+import org.graylog2.indexer.results.FieldStatsResult;
+import org.graylog2.indexer.results.HistogramResult;
+import org.graylog2.indexer.results.TermsResult;
+import org.graylog2.indexer.results.TermsStatsResult;
+import org.graylog2.indexer.searches.timeranges.AbsoluteRange;
+import org.graylog2.plugin.database.validators.Validator;
+import org.joda.time.DateTime;
+import org.joda.time.DateTimeZone;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Ignore;
+import org.junit.Rule;
+import org.junit.Test;
+
+import javax.inject.Inject;
+import java.io.InputStream;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import static com.lordofthejars.nosqlunit.elasticsearch.ElasticsearchRule.ElasticsearchRuleBuilder.newElasticsearchRule;
+import static com.lordofthejars.nosqlunit.elasticsearch.EmbeddedElasticsearch.EmbeddedElasticsearchRuleBuilder.newEmbeddedElasticsearchRule;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Matchers.anyInt;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.mockito.MockitoAnnotations.initMocks;
+
+public class SearchesTest {
+    @ClassRule
+    public static final EmbeddedElasticsearch EMBEDDED_ELASTICSEARCH = newEmbeddedElasticsearchRule().build();
+
+    @Rule
+    public ElasticsearchRule elasticsearchRule;
+
+    private static final String INDEX_NAME = "graylog";
+    private static final List<IndexRange> INDEX_RANGES = Collections.<IndexRange>singletonList(new IndexRange() {
+        @Override
+        public String getIndexName() {
+            return INDEX_NAME;
+        }
+
+        @Override
+        public DateTime getCalculatedAt() {
+            return DateTime.now();
+        }
+
+        @Override
+        public DateTime getStart() {
+            return new DateTime(2015, 1, 1, 0, 0, DateTimeZone.UTC);
+        }
+
+        @Override
+        public int getCalculationTookMs() {
+            return 0;
+        }
+
+        @Override
+        public String getId() {
+            return "id";
+        }
+
+        @Override
+        public Map<String, Object> getFields() {
+            return Collections.emptyMap();
+        }
+
+        @Override
+        public Map<String, Validator> getValidations() {
+            return Collections.emptyMap();
+        }
+
+        @Override
+        public Map<String, Validator> getEmbeddedValidations(String key) {
+            return Collections.emptyMap();
+        }
+
+        @Override
+        public Map<String, Object> asMap() {
+            return Collections.emptyMap();
+        }
+    });
+
+    private final Deflector deflector = mock(Deflector.class);
+    private final IndexRangeService indexRangeService = mock(IndexRangeService.class);
+
+    private Searches searches;
+
+    @Inject
+    private Client client;
+
+    public SearchesTest() {
+        this.elasticsearchRule = newElasticsearchRule().defaultEmbeddedElasticsearch();
+        this.elasticsearchRule.setLoadStrategyFactory(new IndexCreatingLoadStrategyFactory(Collections.singleton(INDEX_NAME)));
+    }
+
+    @Before
+    public void setUp() throws Exception {
+        initMocks(this);
+        when(indexRangeService.getFrom(anyInt())).thenReturn(INDEX_RANGES);
+        searches = new Searches(new Configuration(), deflector, indexRangeService, client);
+    }
+
+    @Test
+    @UsingDataSet(loadStrategy = LoadStrategyEnum.CLEAN_INSERT)
+    public void testCount() throws Exception {
+        CountResult result = searches.count("*", new AbsoluteRange(
+                new DateTime(2015, 1, 1, 0, 0),
+                new DateTime(2015, 1, 2, 0, 0)));
+
+        assertThat(result.getCount()).isEqualTo(10L);
+    }
+
+    @Test
+    @UsingDataSet(loadStrategy = LoadStrategyEnum.CLEAN_INSERT)
+    public void testTerms() throws Exception {
+        TermsResult result = searches.terms("n", 25, "*", new AbsoluteRange(
+                new DateTime(2015, 1, 1, 0, 0),
+                new DateTime(2015, 1, 2, 0, 0)));
+
+        assertThat(result.getTotal()).isEqualTo(10L);
+        assertThat(result.getMissing()).isEqualTo(2L);
+        assertThat(result.getTerms())
+                .hasSize(4)
+                .containsEntry("1", 2L)
+                .containsEntry("2", 2L)
+                .containsEntry("3", 3L)
+                .containsEntry("4", 1L);
+    }
+
+    @Test
+    @UsingDataSet(loadStrategy = LoadStrategyEnum.CLEAN_INSERT)
+    public void testTermsStats() throws Exception {
+        TermsStatsResult r = searches.termsStats("message", "n", Searches.TermsStatsOrder.COUNT, 25, "*",
+                new AbsoluteRange(
+                        new DateTime(2015, 1, 1, 0, 0),
+                        new DateTime(2015, 1, 2, 0, 0))
+        );
+
+        assertThat(r.getResults()).hasSize(2);
+        assertThat((Map<String, Object>) r.getResults().get(0))
+                .hasSize(7)
+                .containsEntry("key_field", "ho");
+    }
+
+    @Test
+    @UsingDataSet(loadStrategy = LoadStrategyEnum.CLEAN_INSERT)
+    public void testFieldStats() throws Exception {
+        FieldStatsResult result = searches.fieldStats("n", "*", new AbsoluteRange(
+                new DateTime(2015, 1, 1, 0, 0),
+                new DateTime(2015, 1, 2, 0, 0)));
+
+        assertThat(result.getSearchHits()).hasSize(10);
+        assertThat(result.getCount()).isEqualTo(8);
+        assertThat(result.getMin()).isEqualTo(1.0);
+        assertThat(result.getMax()).isEqualTo(4.0);
+        assertThat(result.getMean()).isEqualTo(2.375);
+        assertThat(result.getSum()).isEqualTo(19.0);
+        assertThat(result.getSumOfSquares()).isEqualTo(53.0);
+        assertThat(result.getVariance()).isEqualTo(0.984375);
+        assertThat(result.getStdDeviation()).isEqualTo(0.9921567416492215);
+    }
+
+    @Test
+    @UsingDataSet(loadStrategy = LoadStrategyEnum.CLEAN_INSERT)
+    @SuppressWarnings("unchecked")
+    public void testHistogram() throws Exception {
+        final AbsoluteRange range = new AbsoluteRange(new DateTime(2015, 1, 1, 0, 0), new DateTime(2015, 1, 2, 0, 0));
+        HistogramResult h = searches.histogram("*", Searches.DateHistogramInterval.MINUTE, range);
+
+        assertThat(h.getInterval()).isEqualTo(Searches.DateHistogramInterval.MINUTE);
+        assertThat(h.getHistogramBoundaries()).isEqualTo(range);
+        assertThat(h.getResults())
+                .hasSize(5)
+                .containsEntry(new DateTime(2015, 1, 1, 0, 1, DateTimeZone.UTC).getMillis() / 1000L, 2L)
+                .containsEntry(new DateTime(2015, 1, 1, 0, 2, DateTimeZone.UTC).getMillis() / 1000L, 2L)
+                .containsEntry(new DateTime(2015, 1, 1, 0, 3, DateTimeZone.UTC).getMillis() / 1000L, 2L)
+                .containsEntry(new DateTime(2015, 1, 1, 0, 4, DateTimeZone.UTC).getMillis() / 1000L, 2L)
+                .containsEntry(new DateTime(2015, 1, 1, 0, 5, DateTimeZone.UTC).getMillis() / 1000L, 2L);
+    }
+
+    @Test
+    @UsingDataSet(loadStrategy = LoadStrategyEnum.CLEAN_INSERT)
+    @SuppressWarnings("unchecked")
+    public void testFieldHistogram() throws Exception {
+        final AbsoluteRange range = new AbsoluteRange(new DateTime(2015, 1, 1, 0, 0), new DateTime(2015, 1, 2, 0, 0));
+        HistogramResult h = searches.fieldHistogram("*", "n", Searches.DateHistogramInterval.MINUTE, null, range);
+
+        assertThat(h.getInterval()).isEqualTo(Searches.DateHistogramInterval.MINUTE);
+        assertThat(h.getHistogramBoundaries()).isEqualTo(range);
+        assertThat(h.getResults()).hasSize(5);
+        assertThat((Map<String, Number>) h.getResults().get(new DateTime(2015, 1, 1, 0, 1, DateTimeZone.UTC).getMillis() / 1000L))
+                .containsEntry("total_count", 2L)
+                .containsEntry("total", 0.0);
+        assertThat((Map<String, Number>) h.getResults().get(new DateTime(2015, 1, 1, 0, 2, DateTimeZone.UTC).getMillis() / 1000L))
+                .containsEntry("total_count", 2L)
+                .containsEntry("total", 4.0)
+                .containsEntry("mean", 2.0);
+    }
+
+    public static class IndexCreatingLoadStrategyFactory implements LoadStrategyFactory {
+        private final LoadStrategyFactory loadStrategyFactory;
+        private final Set<String> indexNames;
+
+        public IndexCreatingLoadStrategyFactory(Set<String> indexNames) {
+            this.loadStrategyFactory = new ReflectionLoadStrategyFactory();
+            this.indexNames = ImmutableSet.copyOf(indexNames);
+        }
+
+        @Override
+        public LoadStrategyOperation getLoadStrategyInstance(LoadStrategyEnum loadStrategyEnum, DatabaseOperation databaseOperation) {
+            return loadStrategyFactory.getLoadStrategyInstance(
+                    loadStrategyEnum,
+                    new IndexCreatingDatabaseOperation(databaseOperation, indexNames));
+        }
+    }
+
+    public static class IndexCreatingDatabaseOperation implements DatabaseOperation<Client> {
+        private final DatabaseOperation<Client> databaseOperation;
+        private final Client client;
+        private final Set<String> indexes;
+
+        public IndexCreatingDatabaseOperation(DatabaseOperation<Client> databaseOperation, Set<String> indexes) {
+            this.databaseOperation = databaseOperation;
+            this.client = databaseOperation.connectionManager();
+            this.indexes = ImmutableSet.copyOf(indexes);
+        }
+
+        @Override
+        public void insert(InputStream dataScript) {
+            final IndicesAdminClient indicesAdminClient = client.admin().indices();
+            final String[] indexNames = indexes.toArray(new String[indexes.size()]);
+            IndicesExistsResponse indicesExistsResponse = indicesAdminClient.prepareExists(indexNames)
+                    .execute()
+                    .actionGet();
+
+            if (indicesExistsResponse.isExists()) {
+                client.admin().indices().prepareDelete(indexNames).execute().actionGet();
+            }
+
+            Indices indices = new Indices(client, new ElasticsearchConfiguration());
+            for (String index : indexes) {
+                if (!indices.create(index)) {
+                    throw new IllegalStateException("Couldn't create index " + index);
+                }
+            }
+
+            databaseOperation.insert(dataScript);
+        }
+
+        @Override
+        public void deleteAll() {
+            databaseOperation.deleteAll();
+        }
+
+        @Override
+        public boolean databaseIs(InputStream expectedData) {
+            return databaseOperation.databaseIs(expectedData);
+        }
+
+        @Override
+        public Client connectionManager() {
+            return databaseOperation.connectionManager();
+        }
+    }
+}

--- a/graylog2-server/src/test/resources/org/graylog2/indexer/searches/SearchesTest.json
+++ b/graylog2-server/src/test/resources/org/graylog2/indexer/searches/SearchesTest.json
@@ -1,0 +1,192 @@
+{
+  "documents": [
+    {
+      "document": [
+        {
+          "index": {
+            "indexName": "graylog",
+            "indexType": "message",
+            "indexId": "0"
+          }
+        },
+        {
+          "data": {
+            "source": "example.org",
+            "message": "Hi",
+            "timestamp": "2015-01-01 00:01:00.004"
+          }
+        }
+      ]
+    },
+    {
+      "document": [
+        {
+          "index": {
+            "indexName": "graylog",
+            "indexType": "message",
+            "indexId": "1"
+          }
+        },
+        {
+          "data": {
+            "source": "example.org",
+            "message": "Ho",
+            "timestamp": "2015-01-01 00:02:01.001",
+            "n": 1
+          }
+        }
+      ]
+    },
+    {
+      "document": [
+        {
+          "index": {
+            "indexName": "graylog",
+            "indexType": "message",
+            "indexId": "2"
+          }
+        },
+        {
+          "data": {
+            "source": "example.org",
+            "message": "Hi",
+            "timestamp": "2015-01-01 00:03:02.002",
+            "n": 1
+          }
+        }
+      ]
+    },
+    {
+      "document": [
+        {
+          "index": {
+            "indexName": "graylog",
+            "indexType": "message",
+            "indexId": "3"
+          }
+        },
+        {
+          "data": {
+            "source": "example.org",
+            "message": "Ho",
+            "timestamp": "2015-01-01 00:04:03.003",
+            "n": 2
+          }
+        }
+      ]
+    },
+    {
+      "document": [
+        {
+          "index": {
+            "indexName": "graylog",
+            "indexType": "message",
+            "indexId": "4"
+          }
+        },
+        {
+          "data": {
+            "source": "example.org",
+            "message": "Hi",
+            "timestamp": "2015-01-01 00:05:04.004",
+            "n": 2
+          }
+        }
+      ]
+    },
+    {
+      "document": [
+        {
+          "index": {
+            "indexName": "graylog",
+            "indexType": "message",
+            "indexId": "5"
+          }
+        },
+        {
+          "data": {
+            "source": "example.com",
+            "message": "Ho",
+            "timestamp": "2015-01-01 00:01:05.004"
+          }
+        }
+      ]
+    },
+    {
+      "document": [
+        {
+          "index": {
+            "indexName": "graylog",
+            "indexType": "message",
+            "indexId": "6"
+          }
+        },
+        {
+          "data": {
+            "source": "example.com",
+            "message": "Hi",
+            "timestamp": "2015-01-01 00:02:06.001",
+            "n": 3
+          }
+        }
+      ]
+    },
+    {
+      "document": [
+        {
+          "index": {
+            "indexName": "graylog",
+            "indexType": "message",
+            "indexId": "7"
+          }
+        },
+        {
+          "data": {
+            "source": "example.com",
+            "message": "Ho",
+            "timestamp": "2015-01-01 00:03:07.002",
+            "n": 3
+          }
+        }
+      ]
+    },
+    {
+      "document": [
+        {
+          "index": {
+            "indexName": "graylog",
+            "indexType": "message",
+            "indexId": "8"
+          }
+        },
+        {
+          "data": {
+            "source": "example.com",
+            "message": "Hi",
+            "timestamp": "2015-01-01 00:04:08.003",
+            "n": 3
+          }
+        }
+      ]
+    },
+    {
+      "document": [
+        {
+          "index": {
+            "indexName": "graylog",
+            "indexType": "message",
+            "indexId": "9"
+          }
+        },
+        {
+          "data": {
+            "source": "example.com",
+            "message": "Ho",
+            "timestamp": "2015-01-01 00:05:09.004",
+            "n": 4
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/pom.xml
+++ b/pom.xml
@@ -667,6 +667,26 @@
                 <version>2.4.0</version>
                 <scope>test</scope>
             </dependency>
+
+            <dependency>
+                <groupId>junit</groupId>
+                <artifactId>junit</artifactId>
+                <version>4.12</version>
+                <scope>test</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.assertj</groupId>
+                <artifactId>assertj-core</artifactId>
+                <version>1.7.1</version>
+                <scope>test</scope>
+            </dependency>
+            <dependency>
+                <groupId>com.lordofthejars</groupId>
+                <artifactId>nosqlunit-elasticsearch</artifactId>
+                <version>0.8.1</version>
+                <scope>test</scope>
+            </dependency>
+
             <dependency>
                 <groupId>org.graylog.telemetry</groupId>
                 <artifactId>graylog-telemetry-plugin</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -220,12 +220,7 @@
             <dependency>
                 <groupId>org.elasticsearch</groupId>
                 <artifactId>elasticsearch</artifactId>
-                <version>1.3.7</version>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.lucene</groupId>
-                <artifactId>lucene-queryparser</artifactId>
-                <version>4.9.1</version>
+                <version>1.4.4</version>
             </dependency>
 
             <dependency>


### PR DESCRIPTION
Upgrade to Elasticsearch 1.4.x.

Unfortunately some useful information has been removed from ShardSearchFailure (elasticsearch/elasticsearch@90d2cb7dd506f188b534c72de7ba125e74f6ec21) with no proper replacement. As an alternative to have at least a basic error message for query parse errors, we now parse the query ourselves with a default Lucene query parser.

Refs #847