### PR TITLE
Prevent duplicate loading of plugins in PluginLoader

### DIFF
--- a/graylog2-plugin-interfaces/src/main/java/org/graylog2/plugin/Version.java
+++ b/graylog2-plugin-interfaces/src/main/java/org/graylog2/plugin/Version.java
@@ -22,6 +22,7 @@
  */
 package org.graylog2.plugin;
 
+import com.google.common.collect.ComparisonChain;
 import com.google.common.io.Resources;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -32,14 +33,16 @@ import java.util.Objects;
 import java.util.Properties;
 
 import static com.google.common.base.Charsets.UTF_8;
+import static com.google.common.base.Preconditions.checkNotNull;
 import static com.google.common.base.Strings.isNullOrEmpty;
+import static com.google.common.base.Strings.nullToEmpty;
 
 /**
  * Following semantic versioning.
- *
+ * <p/>
  * http://semver.org/
  */
-public class Version {
+public class Version implements Comparable<Version> {
     private static final Logger LOG = LoggerFactory.getLogger(Version.class);
 
     public final int major;
@@ -52,6 +55,7 @@ public class Version {
      * Reads the current version from the classpath, using version.properties and git.properties.
      */
     public static final Version CURRENT_CLASSPATH;
+
     static {
         Version tmpVersion;
         try {
@@ -150,5 +154,20 @@ public class Version {
     @Override
     public int hashCode() {
         return Objects.hash(major, minor, patch, additional, abbrevCommitSha);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public int compareTo(Version that) {
+        checkNotNull(that);
+        return ComparisonChain.start()
+                .compare(this.major, that.major)
+                .compare(this.minor, that.minor)
+                .compare(this.patch, that.patch)
+                .compareFalseFirst(isNullOrEmpty(this.additional), isNullOrEmpty(that.additional))
+                .compare(nullToEmpty(this.additional), nullToEmpty(that.additional))
+                .result();
     }
 }

--- a/graylog2-plugin-interfaces/src/test/java/org/graylog2/plugin/VersionTest.java
+++ b/graylog2-plugin-interfaces/src/test/java/org/graylog2/plugin/VersionTest.java
@@ -22,18 +22,13 @@
  */
 package org.graylog2.plugin;
 
-import org.graylog2.plugin.Version;
 import org.testng.annotations.Test;
 
 import static org.testng.AssertJUnit.assertEquals;
 import static org.testng.AssertJUnit.assertFalse;
 import static org.testng.AssertJUnit.assertTrue;
 
-/**
- * @author Lennart Koopmann <lennart@torch.sh>
- */
 public class VersionTest {
-
     @Test
     public void testGetName() throws Exception {
         assertEquals("0.20.0", new Version(0, 20, 0).toString());
@@ -132,5 +127,60 @@ public class VersionTest {
         assertFalse(v.sameOrHigher(new Version(2, 19, 0, "rc.1")));
         assertTrue(v.sameOrHigher(new Version(0, 0, 0)));
         assertFalse(v.sameOrHigher(new Version(Integer.MAX_VALUE, Integer.MAX_VALUE, Integer.MAX_VALUE)));
+    }
+
+    @Test
+    public void testCompareTo() {
+        Version v = new Version(0, 20, 2);
+
+        assertTrue(v.compareTo(new Version(0, 19, 0)) > 0);
+        assertTrue(v.compareTo(new Version(0, 18, 2)) > 0);
+        assertTrue(v.compareTo(new Version(0, 19, 9001)) > 0);
+
+        assertTrue(v.compareTo(new Version(0, 20, 2)) == 0);
+        assertTrue(v.compareTo(new Version(0, 20, 0)) > 0);
+        assertTrue(v.compareTo(new Version(1, 0, 0)) < 0);
+        assertTrue(v.compareTo(new Version(1, 0, 9001)) < 0);
+        assertTrue(v.compareTo(new Version(1, 20, 0)) < 0);
+        assertTrue(v.compareTo(new Version(1, 1, 0)) < 0);
+        assertTrue(v.compareTo(new Version(3, 2, 1)) < 0);
+
+        assertTrue(v.compareTo(new Version(0, 19, 0, "rc.1")) > 0);
+        assertTrue(v.compareTo(new Version(1, 19, 0, "rc.1")) < 0);
+        assertTrue(v.compareTo(new Version(0, 21, 0, "rc.1")) < 0);
+        assertTrue(v.compareTo(new Version(0, 20, 1, "rc.1")) > 0);
+        assertTrue(v.compareTo(new Version(0, 20, 0, "rc.1")) > 0);
+        assertTrue(v.compareTo(new Version(0, 20, 2, "rc.1")) > 0);
+        assertTrue(v.compareTo(new Version(0, 20, 3, "rc.1")) < 0);
+
+        v = new Version(1, 5, 0);
+
+        assertTrue(v.compareTo(new Version(0, 19, 0)) > 0);
+        assertTrue(v.compareTo(new Version(1, 0, 0)) > 0);
+        assertTrue(v.compareTo(new Version(0, 19, 9001)) > 0);
+        assertTrue(v.compareTo(new Version(1, 5, 0)) == 0);
+        assertTrue(v.compareTo(new Version(1, 4, 9)) > 0);
+
+        assertTrue(v.compareTo(new Version(1, 6, 0)) < 0);
+        assertTrue(v.compareTo(new Version(3, 0, 0)) < 0);
+        assertTrue(v.compareTo(new Version(1, 5, 9001)) < 0);
+        assertTrue(v.compareTo(new Version(1, 20, 0)) < 0);
+        assertTrue(v.compareTo(new Version(1, 20, 5)) < 0);
+        assertTrue(v.compareTo(new Version(3, 2, 1)) < 0);
+
+        assertTrue(v.compareTo(new Version(0, 19, 0, "rc.1")) > 0);
+        assertTrue(v.compareTo(new Version(2, 19, 0, "rc.1")) < 0);
+        assertTrue(v.compareTo(new Version(0, 0, 0)) > 0);
+        assertTrue(v.compareTo(new Version(Integer.MAX_VALUE, Integer.MAX_VALUE, Integer.MAX_VALUE)) < 0);
+
+        v = new Version(1, 0, 0, "beta.2");
+        assertTrue(v.compareTo(new Version(1, 0, 0, "beta.1")) > 0);
+        assertTrue(v.compareTo(new Version(1, 0, 0, "beta.2")) == 0);
+        assertTrue(v.compareTo(new Version(1, 0, 0, "beta.3")) < 0);
+        assertTrue(v.compareTo(new Version(1, 0, 0, "alpha.1")) > 0);
+        assertTrue(v.compareTo(new Version(1, 0, 0, "alpha.3")) > 0);
+        assertTrue(v.compareTo(new Version(1, 0, 0, "rc.1")) < 0);
+        assertTrue(v.compareTo(new Version(1, 0, 0, "rc.3")) < 0);
+        assertTrue(v.compareTo(new Version(1, 0, 0)) < 0);
     }
 }

--- a/graylog2-server/src/test/java/org/graylog2/shared/plugins/PluginComparatorTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/shared/plugins/PluginComparatorTest.java
@@ -1,0 +1,125 @@
+/**
+ * This file is part of Graylog.
+ *
+ * Graylog is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.graylog2.shared.plugins;
+
+import org.graylog2.plugin.Plugin;
+import org.graylog2.plugin.PluginMetaData;
+import org.graylog2.plugin.PluginModule;
+import org.graylog2.plugin.ServerStatus;
+import org.graylog2.plugin.Version;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+import java.net.URI;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Set;
+
+import static org.testng.Assert.assertTrue;
+
+public class PluginComparatorTest {
+    private PluginLoader.PluginComparator comparator = new PluginLoader.PluginComparator();
+
+    @DataProvider(name = "test", parallel = true)
+    public static Object[][] provideData() {
+        return new Object[][]{
+                {new TestPlugin("u", "n", new Version(1, 0, 0)), new TestPlugin("u", "n", new Version(1, 0, 0)), 0},
+                {new TestPlugin("u1", "n", new Version(1, 0, 0)), new TestPlugin("u2", "n", new Version(1, 0, 0)), -1},
+                {new TestPlugin("u", "n1", new Version(1, 0, 0)), new TestPlugin("u", "n2", new Version(1, 0, 0)), -1},
+                {new TestPlugin("u2", "n1", new Version(1, 0, 0)), new TestPlugin("u1", "n2", new Version(1, 0, 0)), 1},
+                {new TestPlugin("u", "n", new Version(1, 0, 0, "beta.1")), new TestPlugin("u", "n", new Version(1, 0, 0)), -1},
+                {new TestPlugin("u", "n", new Version(1, 0, 0, "beta.1")), new TestPlugin("u", "n", new Version(1, 0, 0, "alpha.5")), 1},
+                {new TestPlugin("u", "n", new Version(1, 0, 1)), new TestPlugin("u", "n", new Version(1, 0, 0)), 1},
+                {new TestPlugin("u", "n", new Version(1, 0, 0)), new TestPlugin("u", "n", new Version(1, 0, 1)), -1},
+                {new TestPlugin("u", "n", new Version(2, 0, 0)), new TestPlugin("u", "n", new Version(1, 0, 0)), 1},
+                {new TestPlugin("u", "n", new Version(1, 1, 0)), new TestPlugin("u", "n", new Version(1, 0, 0)), 1},
+                {new TestPlugin("u", "n", new Version(1, 0, 1)), new TestPlugin("u", "n", new Version(1, 0, 0)), 1}
+        };
+    }
+
+    @Test(dataProvider = "test")
+    public void testCompare(Plugin p1, Plugin p2, int result) throws Exception {
+        assertTrue(comparator.compare(p1, p2) == result);
+    }
+
+    public static class TestPlugin implements Plugin {
+        private final String uniqueId;
+        private final String name;
+        private final Version version;
+
+        public TestPlugin(String uniqueId, String name, Version version) {
+            this.uniqueId = uniqueId;
+            this.name = name;
+            this.version = version;
+        }
+
+        @Override
+        public PluginMetaData metadata() {
+            return new PluginMetaData() {
+                @Override
+                public String getUniqueId() {
+                    return uniqueId;
+                }
+
+                @Override
+                public String getName() {
+                    return name;
+                }
+
+                @Override
+                public String getAuthor() {
+                    return null;
+                }
+
+                @Override
+                public URI getURL() {
+                    return null;
+                }
+
+                @Override
+                public Version getVersion() {
+                    return version;
+                }
+
+                @Override
+                public String getDescription() {
+                    return null;
+                }
+
+                @Override
+                public Version getRequiredVersion() {
+                    return null;
+                }
+
+                @Override
+                public Set<ServerStatus.Capability> getRequiredCapabilities() {
+                    return null;
+                }
+            };
+        }
+
+        @Override
+        public Collection<PluginModule> modules() {
+            return Collections.emptySet();
+        }
+
+        @Override
+        public String toString() {
+            return uniqueId + " " + name + " " + version;
+        }
+    }
+}

--- a/graylog2-shared/src/main/java/org/graylog2/shared/plugins/PluginLoader.java
+++ b/graylog2-shared/src/main/java/org/graylog2/shared/plugins/PluginLoader.java
@@ -16,8 +16,14 @@
  */
 package org.graylog2.shared.plugins;
 
+import com.google.common.base.Function;
+import com.google.common.collect.ComparisonChain;
 import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.ImmutableSortedSet;
+import com.google.common.collect.Iterables;
 import org.graylog2.plugin.Plugin;
+import org.graylog2.plugin.PluginMetaData;
+import org.graylog2.plugin.PluginModule;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -25,9 +31,14 @@ import java.io.File;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.net.URLClassLoader;
+import java.util.Collection;
 import java.util.Collections;
+import java.util.Comparator;
+import java.util.Objects;
 import java.util.ServiceLoader;
 import java.util.Set;
+
+import static com.google.inject.internal.util.$Preconditions.checkNotNull;
 
 public class PluginLoader {
     private static final Logger LOG = LoggerFactory.getLogger(PluginLoader.class);
@@ -39,12 +50,10 @@ public class PluginLoader {
     }
 
     public Set<Plugin> loadPlugins() {
-        final ImmutableSet.Builder<Plugin> plugins = ImmutableSet.builder();
-
-        plugins.addAll(loadClassPathPlugins());
-        plugins.addAll(loadJarPlugins());
-
-        return plugins.build();
+        return ImmutableSortedSet.orderedBy(new PluginComparator())
+                .addAll(Iterables.transform(loadJarPlugins(), new PluginAdapterFunction()))
+                .addAll(Iterables.transform(loadClassPathPlugins(), new PluginAdapterFunction()))
+                .build();
     }
 
     private Iterable<Plugin> loadClassPathPlugins() {
@@ -89,5 +98,73 @@ public class PluginLoader {
         }
 
         return plugins.build();
+    }
+
+    public static class PluginComparator implements Comparator<Plugin> {
+        /**
+         * {@inheritDoc}
+         */
+        @Override
+        public int compare(Plugin o1, Plugin o2) {
+            return ComparisonChain.start()
+                    .compare(o1.metadata().getUniqueId(), o2.metadata().getUniqueId())
+                    .compare(o1.metadata().getName(), o2.metadata().getName())
+                    .compare(o1.metadata().getVersion(), o2.metadata().getVersion())
+                    .result();
+        }
+    }
+
+    /**
+     * Adapter for {@link org.graylog2.plugin.Plugin} which implements {@link #equals(Object)} and {@link #hashCode()}
+     * only taking {@link org.graylog2.plugin.PluginMetaData#getUniqueId()} into account.
+     */
+    public static class PluginAdapter implements Plugin {
+        private final Plugin plugin;
+
+        public PluginAdapter(Plugin plugin) {
+            this.plugin = checkNotNull(plugin);
+        }
+
+        @Override
+        public PluginMetaData metadata() {
+            return plugin.metadata();
+        }
+
+        @Override
+        public Collection<PluginModule> modules() {
+            return plugin.modules();
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(plugin.metadata().getUniqueId());
+        }
+
+        @Override
+        public boolean equals(Object obj) {
+            if (this == obj) {
+                return true;
+            }
+
+            if (obj instanceof Plugin) {
+                final Plugin that = (Plugin) obj;
+                return Objects.equals(this.metadata().getUniqueId(), that.metadata().getUniqueId());
+            }
+
+            return false;
+        }
+
+        @Override
+        public String toString() {
+            final PluginMetaData metadata = plugin.metadata();
+            return metadata.getName() + " " + metadata.getVersion() + " [" + metadata.getUniqueId() + "]";
+        }
+    }
+
+    private static class PluginAdapterFunction implements Function<Plugin, Plugin> {
+        @Override
+        public Plugin apply(Plugin input) {
+            return new PluginAdapter(input);
+        }
     }
 }


### PR DESCRIPTION
When plugins were available multiple times on the class path or in the plugin directory of Graylog, the PluginLoader used to load identical plugins multiple times. By using a sorted set and a specialized Comparator<Plugin> in PluginLoader we prevent that behaviour.