### PR TITLE
Harden extractors import in REST client

### DIFF
--- a/graylog2-plugin-interfaces/src/main/java/org/graylog2/plugin/rest/JsonProcessingExceptionMapper.java
+++ b/graylog2-plugin-interfaces/src/main/java/org/graylog2/plugin/rest/JsonProcessingExceptionMapper.java
@@ -1,0 +1,42 @@
+/**
+ * The MIT License
+ * Copyright (c) 2012 Graylog, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.graylog2.plugin.rest;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.ext.ExceptionMapper;
+import javax.ws.rs.ext.Provider;
+
+import static com.google.common.base.MoreObjects.firstNonNull;
+import static javax.ws.rs.core.Response.status;
+
+@Provider
+public class JsonProcessingExceptionMapper implements ExceptionMapper<JsonProcessingException> {
+    @Override
+    public Response toResponse(JsonProcessingException e) {
+        final ApiError apiError = new ApiError(firstNonNull(e.getMessage(), "Couldn't process JSON input"));
+        return status(Response.Status.BAD_REQUEST).type(MediaType.APPLICATION_JSON_TYPE).entity(apiError).build();
+    }
+}

--- a/graylog2-plugin-interfaces/src/test/java/org/graylog2/plugin/rest/JsonProcessingExceptionMapperTest.java
+++ b/graylog2-plugin-interfaces/src/test/java/org/graylog2/plugin/rest/JsonProcessingExceptionMapperTest.java
@@ -1,0 +1,53 @@
+/**
+ * The MIT License
+ * Copyright (c) 2012 Graylog, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.graylog2.plugin.rest;
+
+import com.fasterxml.jackson.core.JsonLocation;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonMappingException;
+import org.testng.annotations.Test;
+
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.ext.ExceptionMapper;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
+
+public class JsonProcessingExceptionMapperTest {
+
+    @Test
+    public void testToResponse() throws Exception {
+        ExceptionMapper<JsonProcessingException> mapper = new JsonProcessingExceptionMapper();
+
+        Response response = mapper.toResponse(new JsonMappingException("Boom!", JsonLocation.NA, new RuntimeException("rootCause")));
+
+        assertEquals(response.getStatusInfo(), Response.Status.BAD_REQUEST);
+        assertEquals(response.getMediaType(), MediaType.APPLICATION_JSON_TYPE);
+        assertTrue(response.hasEntity());
+        assertTrue(response.getEntity() instanceof ApiError);
+
+        final ApiError responseEntity = (ApiError)response.getEntity();
+        assertTrue(responseEntity.message.startsWith("Boom!"));
+    }
+}

--- a/graylog2-rest-client/src/main/java/org/graylog2/restclient/models/Extractor.java
+++ b/graylog2-rest-client/src/main/java/org/graylog2/restclient/models/Extractor.java
@@ -16,27 +16,28 @@
  */
 package org.graylog2.restclient.models;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.google.inject.assistedinject.Assisted;
 import com.google.inject.assistedinject.AssistedInject;
-import org.graylog2.restclient.lib.ApiClient;
 import org.graylog2.restclient.models.api.requests.CreateExtractorRequest;
 import org.graylog2.restclient.models.api.responses.system.ExtractorSummaryResponse;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
-/**
- * @author Lennart Koopmann <lennart@torch.sh>
- */
+import static com.google.common.base.Preconditions.checkNotNull;
+
 public class Extractor {
-    private static final Logger log = LoggerFactory.getLogger(Extractor.class);
+    private static final Logger LOG = LoggerFactory.getLogger(Extractor.class);
 
     public interface Factory {
         Extractor fromResponse(ExtractorSummaryResponse esr);
+
         Extractor forCreate(CursorStrategy cursorStrategy,
                             @Assisted("title") String title,
                             @Assisted("sourceField") String sourceField,
@@ -77,6 +78,7 @@ public class Extractor {
         }
 
     }
+
     public enum ConditionType {
         NONE,
         STRING,
@@ -85,10 +87,7 @@ public class Extractor {
         public static ConditionType fromString(String name) {
             return valueOf(name.toUpperCase());
         }
-
     }
-    private final ApiClient api;
-    private final UserService userService;
 
     private String id;
     private final String title;
@@ -108,10 +107,7 @@ public class Extractor {
     private int order;
 
     @AssistedInject
-    private Extractor(ApiClient api, UserService userService, @Assisted ExtractorSummaryResponse esr) {
-        this.api = api;
-        this.userService = userService;
-
+    private Extractor(UserService userService, @Assisted ExtractorSummaryResponse esr) {
         this.id = esr.id;
         this.title = esr.title;
         this.cursorStrategy = CursorStrategy.fromString(esr.cursorStrategy);
@@ -129,20 +125,16 @@ public class Extractor {
         this.order = esr.order;
     }
 
+    @VisibleForTesting
     @AssistedInject
-    private Extractor(ApiClient api,
-                     UserService userService,
-                     @Assisted CursorStrategy cursorStrategy,
-                     @Assisted("title") String title,
-                     @Assisted("sourceField") String sourceField,
-                     @Assisted("targetField") String targetField,
-                     @Assisted Type type,
-                     @Assisted User creatorUser,
-                     @Assisted ConditionType conditionType,
-                     @Assisted("conditionValue") String conditionValue) {
-        this.api = api;
-        this.userService = userService;
-
+    Extractor(@Assisted CursorStrategy cursorStrategy,
+              @Assisted("title") String title,
+              @Assisted("sourceField") String sourceField,
+              @Assisted("targetField") String targetField,
+              @Assisted Type type,
+              @Assisted User creatorUser,
+              @Assisted ConditionType conditionType,
+              @Assisted("conditionValue") String conditionValue) {
         this.id = null;
         this.title = title;
         this.cursorStrategy = cursorStrategy;
@@ -182,7 +174,7 @@ public class Extractor {
         return request;
     }
 
-    public void loadConfigFromForm(Type extractorType, Map<String,String[]> form) {
+    public void loadConfigFromForm(Type extractorType, Map<String, String[]> form) {
         switch (extractorType) {
             case REGEX:
                 loadRegexConfig(form);
@@ -200,18 +192,25 @@ public class Extractor {
     }
 
     public void loadConfigFromImport(Type type, Map<String, Object> extractorConfig) {
+        checkNotNull(type, "Extractor type must not be null.");
+        checkNotNull(extractorConfig, "Extractor configuration must not be null.");
+
         // we go the really easy way here.
-        Map<String, String[]> looksLikeForm = Maps.newHashMap();
+        Map<String, String[]> looksLikeForm = Maps.newHashMapWithExpectedSize(extractorConfig.size());
 
         for (Map.Entry<String, Object> e : extractorConfig.entrySet()) {
-            looksLikeForm.put(e.getKey(), new String[]{ e.getValue().toString() });
+            looksLikeForm.put(e.getKey(), new String[]{e.getValue().toString()});
         }
 
         loadConfigFromForm(type, looksLikeForm);
     }
 
-    public void loadConvertersFromForm(Map<String,String[]> form) {
-        for(String name : extractSelectedConverters(form)) {
+    public void loadConvertersFromForm(Map<String, String[]> form) {
+        if (form == null || form.isEmpty()) {
+            return;
+        }
+
+        for (String name : extractSelectedConverters(form)) {
             Converter.Type converterType = Converter.Type.valueOf(name.toUpperCase());
             Map<String, Object> converterConfig = extractConverterConfig(converterType, form);
 
@@ -219,18 +218,19 @@ public class Extractor {
         }
     }
 
+    @SuppressWarnings("unchecked")
     public void loadConvertersFromImport(List<Map<String, Object>> imports) {
-        for (Map<String, Object> imp : imports) {
-            Converter converter = new Converter(
-                    Converter.Type.valueOf(((String) imp.get("type")).toUpperCase()),
-                    (Map<String, Object>) imp.get("config")
-            );
+        if (imports == null || imports.isEmpty()) {
+            return;
+        }
 
-            converters.add(converter);
+        for (Map<String, Object> imp : imports) {
+            final Converter.Type type = Converter.Type.valueOf(((String) imp.get("type")).toUpperCase());
+            converters.add(new Converter(type, (Map<String, Object>) imp.get("config")));
         }
     }
 
-    private Map<String, Object> extractConverterConfig(Converter.Type converterType, Map<String,String[]> form) {
+    private Map<String, Object> extractConverterConfig(Converter.Type converterType, Map<String, String[]> form) {
         Map<String, Object> config = Maps.newHashMap();
         switch (converterType) {
             case DATE:
@@ -255,16 +255,23 @@ public class Extractor {
                     } else if (csv_separator.length() == 2) {
                         if (csv_separator.charAt(0) == '\\') {
                             switch (csv_separator.charAt(1)) {
-                                case 'n': c = '\n'; break;
-                                case 't': c = '\t'; break;
-                                case '\\': c = '\\'; break;
-                                default: log.error("Unknown escape sequence {}, cannot create CSV converter", csv_separator);
+                                case 'n':
+                                    c = '\n';
+                                    break;
+                                case 't':
+                                    c = '\t';
+                                    break;
+                                case '\\':
+                                    c = '\\';
+                                    break;
+                                default:
+                                    LOG.error("Unknown escape sequence {}, cannot create CSV converter", csv_separator);
                             }
                         } else {
-                            log.error("Illegal escape sequence '{}', cannot create CSV converter", csv_separator);
+                            LOG.error("Illegal escape sequence '{}', cannot create CSV converter", csv_separator);
                         }
                     } else {
-                        log.error("No valid separator, cannot create CSV converter.");
+                        LOG.error("No valid separator, cannot create CSV converter.");
                     }
                     config.put("separator", c);
                 }
@@ -287,22 +294,25 @@ public class Extractor {
     }
 
     private List<String> extractSelectedConverters(Map<String, String[]> form) {
-        List<String> result = Lists.newArrayList();
+        if (form == null || form.isEmpty()) {
+            return Collections.emptyList();
+        }
 
-        for (Map.Entry<String,String[]> f : form.entrySet()) {
+        final List<String> result = Lists.newArrayListWithCapacity(form.size());
+        for (Map.Entry<String, String[]> f : form.entrySet()) {
             try {
                 if (f.getKey().startsWith("converter_") && f.getValue()[0].equals("enabled")) {
                     result.add(f.getKey().substring("converter_".length()));
                 }
-            } catch(Exception e) {
-                continue;
+            } catch (Exception e) {
+                // Ignore
             }
         }
 
         return result;
     }
 
-    private void loadRegexConfig(Map<String,String[]> form) {
+    private void loadRegexConfig(Map<String, String[]> form) {
         if (!formFieldSet(form, "regex_value")) {
             throw new RuntimeException("Missing extractor config: regex_value");
         }
@@ -310,7 +320,7 @@ public class Extractor {
         extractorConfig.put("regex_value", form.get("regex_value")[0]);
     }
 
-    private void loadSubstringConfig(Map<String,String[]> form) {
+    private void loadSubstringConfig(Map<String, String[]> form) {
         if (!formFieldSet(form, "begin_index") || !formFieldSet(form, "end_index")) {
             throw new RuntimeException("Missing extractor config: begin_index or end_index.");
         }
@@ -319,7 +329,7 @@ public class Extractor {
         extractorConfig.put("end_index", Integer.parseInt(form.get("end_index")[0]));
     }
 
-    private void loadSplitAndIndexConfig(Map<String,String[]> form) {
+    private void loadSplitAndIndexConfig(Map<String, String[]> form) {
         if (!formFieldSet(form, "split_by") || !formFieldSet(form, "index")) {
             throw new RuntimeException("Missing extractor config: split_by or index.");
         }
@@ -327,8 +337,8 @@ public class Extractor {
         extractorConfig.put("split_by", form.get("split_by")[0]);
         extractorConfig.put("index", Integer.parseInt(form.get("index")[0]));
     }
-    
-    private void loadGrokConfig(Map<String,String[]> form) {
+
+    private void loadGrokConfig(Map<String, String[]> form) {
         if (!formFieldSet(form, "grok_pattern")) {
             throw new RuntimeException("Missing extractor config: grok_pattern");
         }
@@ -336,14 +346,18 @@ public class Extractor {
         extractorConfig.put("grok_pattern", form.get("grok_pattern")[0]);
     }
 
-    private boolean formFieldSet(Map<String,String[]> form, String key) {
+    private boolean formFieldSet(Map<String, String[]> form, String key) {
         return form.get(key) != null && form.get(key)[0] != null && !form.get(key)[0].isEmpty();
     }
 
+    @SuppressWarnings("unchecked")
     private List<Converter> buildConverterList(List<Map<String, Object>> converters) {
-        List<Converter> cl = Lists.newArrayList();
+        if (converters == null || converters.isEmpty()) {
+            return Collections.emptyList();
+        }
 
-        for(Map<String, Object> converterSummary : converters) {
+        final List<Converter> cl = Lists.newArrayListWithCapacity(converters.size());
+        for (Map<String, Object> converterSummary : converters) {
             cl.add(new Converter(
                     Converter.Type.fromString(converterSummary.get("type").toString()),
                     (Map<String, Object>) converterSummary.get("config")

--- a/graylog2-rest-client/src/test/java/org/graylog2/restclient/models/ExtractorTest.java
+++ b/graylog2-rest-client/src/test/java/org/graylog2/restclient/models/ExtractorTest.java
@@ -1,0 +1,149 @@
+package org.graylog2.restclient.models;
+
+import com.google.common.collect.ImmutableMap;
+import org.mockito.Mock;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import java.util.Collections;
+import java.util.Map;
+
+import static org.mockito.MockitoAnnotations.initMocks;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
+
+public class ExtractorTest {
+    private Extractor extractor;
+    @Mock
+    private User mockUser;
+
+    @BeforeMethod
+    public void setUp() {
+        initMocks(this);
+        extractor = new Extractor(Extractor.CursorStrategy.COPY, "title", "source", "target",
+                Extractor.Type.COPY_INPUT, mockUser, Extractor.ConditionType.NONE, "");
+    }
+
+    @Test(expectedExceptions = NullPointerException.class,
+            expectedExceptionsMessageRegExp = "Extractor type must not be null\\.$")
+    public void loadConfigFromImportThrowsNPEIfTypeIsNull() throws Exception {
+        extractor.loadConfigFromImport(null, Collections.<String, Object>emptyMap());
+    }
+
+    @Test(expectedExceptions = NullPointerException.class,
+            expectedExceptionsMessageRegExp = "^Extractor configuration must not be null\\.$")
+    public void loadConfigFromImportThrowsNPEIfConfigIsNull() throws Exception {
+        extractor.loadConfigFromImport(Extractor.Type.COPY_INPUT, null);
+    }
+
+    @Test
+    public void loadConfigFromImportSucceedsWithEmptyConfigForCopyInputExtractor() throws Exception {
+        extractor.loadConfigFromImport(Extractor.Type.COPY_INPUT, Collections.<String, Object>emptyMap());
+        assertTrue(extractor.getExtractorConfig().isEmpty());
+    }
+
+    @Test
+    public void loadConfigFromImportSucceedsWithValidConfigForGrokExtractor() throws Exception {
+        extractor.loadConfigFromImport(Extractor.Type.GROK, Collections.<String, Object>singletonMap("grok_pattern", "pattern"));
+        assertEquals(extractor.getExtractorConfig().get("grok_pattern"), "pattern");
+    }
+
+    @Test
+    public void loadConfigFromImportSucceedsWithValidConfigForRegexExtractor() throws Exception {
+        extractor.loadConfigFromImport(Extractor.Type.REGEX, Collections.<String, Object>singletonMap("regex_value", "pattern"));
+        assertEquals(extractor.getExtractorConfig().get("regex_value"), "pattern");
+    }
+
+    @Test
+    public void loadConfigFromImportSucceedsWithValidConfigForSplitAndIndexExtractor() throws Exception {
+        extractor.loadConfigFromImport(
+                Extractor.Type.SPLIT_AND_INDEX,
+                ImmutableMap.<String, Object>of(
+                        "split_by", ",",
+                        "index", "0"
+                ));
+        assertEquals(extractor.getExtractorConfig().get("split_by"), ",");
+        assertEquals(extractor.getExtractorConfig().get("index"), 0);
+    }
+
+    @Test
+    public void loadConfigFromImportSucceedsWithValidConfigForSubstringExtractor() throws Exception {
+        extractor.loadConfigFromImport(
+                Extractor.Type.SUBSTRING,
+                ImmutableMap.<String, Object>of(
+                        "begin_index", "0",
+                        "end_index", "1"
+                ));
+        assertEquals(extractor.getExtractorConfig().get("begin_index"), 0);
+        assertEquals(extractor.getExtractorConfig().get("end_index"), 1);
+    }
+
+    @Test(expectedExceptions = RuntimeException.class,
+            expectedExceptionsMessageRegExp = "^Missing extractor config:.*")
+    public void loadConfigFromImportFailsWithEmptyConfigForGrokExtractor() throws Exception {
+        extractor.loadConfigFromImport(Extractor.Type.GROK, Collections.<String, Object>emptyMap());
+    }
+
+    @Test(expectedExceptions = RuntimeException.class,
+            expectedExceptionsMessageRegExp = "^Missing extractor config:.*")
+    public void loadConfigFromImportFailsWithEmptyConfigForRegexExtractor() throws Exception {
+        extractor.loadConfigFromImport(Extractor.Type.REGEX, Collections.<String, Object>emptyMap());
+    }
+
+    @Test(expectedExceptions = RuntimeException.class,
+            expectedExceptionsMessageRegExp = "^Missing extractor config:.*")
+    public void loadConfigFromImportFailsWithEmptyConfigForSplitAndIndexExtractor() throws Exception {
+        extractor.loadConfigFromImport(Extractor.Type.SPLIT_AND_INDEX, Collections.<String, Object>emptyMap());
+    }
+
+    @Test(expectedExceptions = RuntimeException.class,
+            expectedExceptionsMessageRegExp = "^Missing extractor config:.*")
+    public void loadConfigFromImportFailsWithEmptyConfigForSubstringExtractor() throws Exception {
+        extractor.loadConfigFromImport(Extractor.Type.SUBSTRING, Collections.<String, Object>emptyMap());
+    }
+
+    @Test
+    public void loadConvertersFromFormDoesNothingIfFormIsNull() throws Exception {
+        extractor.loadConvertersFromForm(null);
+        assertTrue(extractor.getConverters().isEmpty());
+    }
+
+    @Test
+    public void loadConvertersFromFormDoesNothingIfFormIsEmpty() throws Exception {
+        extractor.loadConvertersFromForm(Collections.<String, String[]>emptyMap());
+        assertTrue(extractor.getConverters().isEmpty());
+    }
+
+    @Test
+    public void testLoadConvertersFromForm() throws Exception {
+        extractor.loadConvertersFromForm(ImmutableMap.of("converter_lowercase", new String[]{"enabled"}));
+        assertEquals(extractor.getConverters().size(), 1);
+
+        Converter converter = extractor.getConverters().get(0);
+        assertEquals(converter.getType(), "lowercase");
+    }
+
+    @Test
+    public void loadConvertersFromImportDoesNothingIfImportsIsNull() throws Exception {
+        extractor.loadConvertersFromImport(null);
+        assertTrue(extractor.getConverters().isEmpty());
+    }
+
+    @Test
+    public void loadConvertersFromImportDoesNothingIfImportsIsEmpty() throws Exception {
+        extractor.loadConvertersFromImport(Collections.<Map<String, Object>>emptyList());
+        assertTrue(extractor.getConverters().isEmpty());
+    }
+
+    @Test
+    public void testLoadConvertersFromImport() throws Exception {
+        extractor.loadConvertersFromImport(Collections.<Map<String, Object>>singletonList(ImmutableMap.of(
+                "type", "lowercase",
+                "config", Collections.<String, Object>emptyMap()
+        )));
+        assertEquals(extractor.getConverters().size(), 1);
+
+        Converter converter = extractor.getConverters().get(0);
+        assertEquals(converter.getType(), "lowercase");
+    }
+}

--- a/graylog2-shared/src/main/java/org/graylog2/shared/initializers/RestApiService.java
+++ b/graylog2-shared/src/main/java/org/graylog2/shared/initializers/RestApiService.java
@@ -19,6 +19,7 @@ package org.graylog2.shared.initializers;
 import com.codahale.metrics.InstrumentedExecutorService;
 import com.codahale.metrics.MetricRegistry;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.jaxrs.json.JacksonJaxbJsonProvider;
 import com.google.common.util.concurrent.AbstractIdleService;
 import com.google.common.util.concurrent.ThreadFactoryBuilder;
 import org.glassfish.jersey.jackson.JacksonFeature;
@@ -33,6 +34,7 @@ import org.graylog2.jersey.container.netty.SecurityContextFactory;
 import org.graylog2.plugin.BaseConfiguration;
 import org.graylog2.plugin.rest.AnyExceptionClassMapper;
 import org.graylog2.plugin.rest.JacksonPropertyExceptionMapper;
+import org.graylog2.plugin.rest.JsonProcessingExceptionMapper;
 import org.graylog2.plugin.rest.PluginRestResource;
 import org.graylog2.plugin.rest.WebApplicationExceptionMapper;
 import org.graylog2.shared.rest.CORSFilter;
@@ -65,6 +67,8 @@ import javax.ws.rs.container.DynamicFeature;
 import javax.ws.rs.core.UriBuilder;
 import javax.ws.rs.ext.ContextResolver;
 import javax.ws.rs.ext.ExceptionMapper;
+import javax.ws.rs.ext.MessageBodyReader;
+import javax.ws.rs.ext.MessageBodyWriter;
 import java.io.File;
 import java.net.InetSocketAddress;
 import java.net.URI;
@@ -268,16 +272,19 @@ public class RestApiService extends AbstractIdleService {
         ResourceConfig rc = new ResourceConfig()
                 .property(NettyContainer.PROPERTY_BASE_URI, listenUri)
                 .registerClasses(
+                        JacksonJaxbJsonProvider.class,
+                        MessageBodyReader.class,
+                        MessageBodyWriter.class,
+                        JsonProcessingExceptionMapper.class,
                         JacksonPropertyExceptionMapper.class,
                         AnyExceptionClassMapper.class,
                         WebApplicationExceptionMapper.class)
                 .register(new ContextResolver<ObjectMapper>() {
-                              @Override
-                              public ObjectMapper getContext(Class<?> type) {
-                                  return objectMapper;
-                              }
-                          })
-                .register(JacksonFeature.class)
+                    @Override
+                    public ObjectMapper getContext(Class<?> type) {
+                        return objectMapper;
+                    }
+                })
                 .registerFinder(new PackageNamesScanner(restControllerPackages, true))
                 .registerResources(additionalResources);
 


### PR DESCRIPTION
This PR improves the reliability of extractor imports by handling null values and empty collections gracefully whenever possible and by returning more user-friendly messages (as part of thrown exceptions).

Refs #942