### PR TITLE
only do the cluster health request once per REST call to avoid timing out

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/indexer/cluster/Cluster.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/cluster/Cluster.java
@@ -62,31 +62,7 @@ public class Cluster {
         ClusterStateMonitor.setCluster(this);
     }
 
-    public String getName() {
-        return health().getClusterName();
-    }
-
-    public ClusterHealthStatus getHealth() {
-        return health().getStatus();
-    }
-
-    public int getActiveShards() {
-        return health().getActiveShards();
-    }
-
-    public int getInitializingShards() {
-        return health().getInitializingShards();
-    }
-
-    public int getUnassignedShards() {
-        return health().getUnassignedShards();
-    }
-
-    public int getRelocatingShards() {
-        return health().getRelocatingShards();
-    }
-
-    private ClusterHealthResponse health() {
+    public ClusterHealthResponse health() {
         String[] indices = deflector.getAllDeflectorIndexNames();
         return c.admin().cluster().health(new ClusterHealthRequest(indices)).actionGet();
     }
@@ -158,7 +134,7 @@ public class Cluster {
             return false;
         }
         try {
-            return getHealth() != ClusterHealthStatus.RED;
+            return health().getStatus() != ClusterHealthStatus.RED;
         } catch (ElasticsearchException e) {
             LOG.trace("Couldn't determine Elasticsearch health properly", e);
             return false;

--- a/graylog2-server/src/main/java/org/graylog2/periodical/IndexerClusterCheckerThread.java
+++ b/graylog2-server/src/main/java/org/graylog2/periodical/IndexerClusterCheckerThread.java
@@ -16,7 +16,6 @@
  */
 package org.graylog2.periodical;
 
-import javax.inject.Inject;
 import org.elasticsearch.action.admin.cluster.node.info.NodeInfo;
 import org.graylog2.indexer.cluster.Cluster;
 import org.graylog2.notifications.Notification;
@@ -24,6 +23,8 @@ import org.graylog2.notifications.NotificationService;
 import org.graylog2.plugin.periodical.Periodical;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import javax.inject.Inject;
 
 public class IndexerClusterCheckerThread extends Periodical {
     private static final Logger LOG = LoggerFactory.getLogger(IndexerClusterCheckerThread.class);
@@ -46,7 +47,7 @@ public class IndexerClusterCheckerThread extends Periodical {
         }
 
         try {
-            cluster.getHealth();
+            cluster.health().getStatus();
         } catch (Exception e) {
             LOG.info("Indexer not fully initialized yet. Skipping periodic cluster check.");
             return;

--- a/graylog2-server/src/main/java/org/graylog2/rest/resources/system/indexer/IndexerClusterResource.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/resources/system/indexer/IndexerClusterResource.java
@@ -21,6 +21,7 @@ import com.wordnik.swagger.annotations.Api;
 import com.wordnik.swagger.annotations.ApiOperation;
 import org.apache.shiro.authz.annotation.RequiresAuthentication;
 import org.apache.shiro.authz.annotation.RequiresPermissions;
+import org.elasticsearch.action.admin.cluster.health.ClusterHealthResponse;
 import org.graylog2.indexer.cluster.Cluster;
 import org.graylog2.shared.rest.resources.RestResource;
 import org.graylog2.rest.resources.system.indexer.responses.ClusterHealth;
@@ -48,7 +49,7 @@ public class IndexerClusterResource extends RestResource {
     @ApiOperation(value = "Get the cluster name")
     @Produces(MediaType.APPLICATION_JSON)
     public ClusterName clusterName() {
-        return ClusterName.create(cluster.getName());
+        return ClusterName.create(cluster.health().getClusterName());
     }
 
     @GET
@@ -58,12 +59,13 @@ public class IndexerClusterResource extends RestResource {
     @RequiresPermissions(RestPermissions.INDEXERCLUSTER_READ)
     @Produces(MediaType.APPLICATION_JSON)
     public ClusterHealth clusterHealth() {
+        final ClusterHealthResponse health = cluster.health();
         final ClusterHealth.ShardStatus shards = ClusterHealth.ShardStatus.create(
-                cluster.getActiveShards(),
-                cluster.getInitializingShards(),
-                cluster.getRelocatingShards(),
-                cluster.getUnassignedShards());
+                health.getActiveShards(),
+                health.getInitializingShards(),
+                health.getRelocatingShards(),
+                health.getUnassignedShards());
 
-        return ClusterHealth.create(cluster.getHealth().toString().toLowerCase(), shards);
+        return ClusterHealth.create(health.getStatus().toString().toLowerCase(), shards);
     }
 }


### PR DESCRIPTION
it makes no sense to offer individual data about the health because those values are fetched together.
remove the methods that can lead to programming errors and inline them

issue #953