### PR TITLE
Use MongoDB connection string instead of individual settings

### DIFF
--- a/graylog2-bootstrap/src/main/java/org/graylog2/bootstrap/commands/Server.java
+++ b/graylog2-bootstrap/src/main/java/org/graylog2/bootstrap/commands/Server.java
@@ -207,7 +207,9 @@ public class Server extends ServerBootstrap implements Runnable {
         super.annotateInjectorExceptions(messages);
         for (Message message : messages) {
             if (message.getCause() instanceof MongoException) {
-                LOG.error(UI.wallString("Unable to connect to MongoDB. Is it running and the configuration correct?"));
+                MongoException e = (MongoException) message.getCause();
+                LOG.error(UI.wallString("Unable to connect to MongoDB. Is it running and the configuration correct?\n" +
+                        "Details: " + e.getMessage()));
                 System.exit(-1);
             }
         }

--- a/graylog2-server/src/main/java/org/graylog2/database/MongoConnection.java
+++ b/graylog2-server/src/main/java/org/graylog2/database/MongoConnection.java
@@ -16,70 +16,38 @@
  */
 package org.graylog2.database;
 
+import com.mongodb.CommandFailureException;
+import com.mongodb.CommandResult;
 import com.mongodb.DB;
-import com.mongodb.DBCollection;
 import com.mongodb.MongoClient;
-import com.mongodb.MongoClientOptions;
-import com.mongodb.MongoClientOptions.Builder;
-import com.mongodb.ServerAddress;
+import com.mongodb.MongoClientURI;
+import com.mongodb.MongoException;
 import com.mongodb.WriteConcern;
 import org.graylog2.configuration.MongoDbConfiguration;
 
 import javax.inject.Inject;
 import javax.inject.Singleton;
 import java.net.UnknownHostException;
-import java.util.List;
+
+import static com.google.common.base.Preconditions.checkNotNull;
 
 /**
  * MongoDB connection singleton
  */
 @Singleton
 public class MongoConnection {
-    private MongoClient m;
-    private DB db;
-    private DBCollection messageCountsCollection;
-    private String username;
-    private List<ServerAddress> replicaServers;
-    private int threadsAllowedToBlockMultiplier;
-    private boolean useAuth;
-    private int maxConnections;
-    private String database;
-    private String password;
-    private String host;
-    private int port;
+    private final MongoClientURI mongoClientURI;
+
+    private MongoClient m = null;
+    private DB db = null;
 
     @Inject
     public MongoConnection(final MongoDbConfiguration configuration) {
-        this(
-                configuration.getDatabase(),
-                configuration.getHost(),
-                configuration.getPort(),
-                configuration.getReplicaSet(),
-                configuration.isUseAuth(),
-                configuration.getUser(),
-                configuration.getPassword(),
-                configuration.getMaxConnections(),
-                configuration.getThreadsAllowedToBlockMultiplier());
+        this(configuration.getMongoClientURI());
     }
 
-    public MongoConnection(final String database,
-                           final String host,
-                           final int port,
-                           final List<ServerAddress> replicaServers,
-                           final boolean useAuth,
-                           final String username,
-                           final String password,
-                           final int maxConnections,
-                           final int threadsAllowedToBlockMultiplier) {
-        this.host = host;
-        this.port = port;
-        this.database = database;
-        this.replicaServers = replicaServers;
-        this.useAuth = useAuth;
-        this.username = username;
-        this.password = password;
-        this.maxConnections = maxConnections;
-        this.threadsAllowedToBlockMultiplier = threadsAllowedToBlockMultiplier;
+    MongoConnection(MongoClientURI mongoClientURI) {
+        this.mongoClientURI = checkNotNull(mongoClientURI);
     }
 
     /**
@@ -87,32 +55,25 @@ public class MongoConnection {
      */
     public synchronized MongoClient connect() {
         if (m == null) {
-            Builder options = new MongoClientOptions.Builder();
-            options.connectionsPerHost(maxConnections);
-            options.threadsAllowedToBlockForConnectionMultiplier(threadsAllowedToBlockMultiplier);
-
             try {
-
-                // Connect to replica servers if given. Else the standard way to one server.
-                if (replicaServers != null && replicaServers.size() > 0) {
-                    m = new MongoClient(replicaServers, options.build());
-                } else {
-                    ServerAddress address = new ServerAddress(host, port);
-                    m = new MongoClient(address, options.build());
-                }
-                db = m.getDB(database);
+                m = new MongoClient(mongoClientURI);
+                db = m.getDB(mongoClientURI.getDatabase());
                 db.setWriteConcern(WriteConcern.SAFE);
-
-                // Try to authenticate if configured.
-                if (useAuth) {
-                    if (!db.authenticate(username, password.toCharArray())) {
-                        throw new RuntimeException("Could not authenticate to database '" + database + "' with user '" + username + "'.");
-                    }
-                }
             } catch (UnknownHostException e) {
                 throw new RuntimeException("Cannot resolve host name for MongoDB", e);
             }
         }
+
+        try {
+            db.command("{ ping: 1 }");
+        } catch (CommandFailureException e) {
+            if(e.getCode() == 18) {
+                throw new MongoException("Couldn't connect to MongoDB. Please check the authentication credentials.", e);
+            } else {
+                throw new MongoException("Couldn't connect to MongoDB: " + e.getMessage(), e);
+            }
+        }
+
         return m;
     }
 

--- a/graylog2-server/src/main/java/org/graylog2/database/MongoConnection.java
+++ b/graylog2-server/src/main/java/org/graylog2/database/MongoConnection.java
@@ -16,9 +16,6 @@
  */
 package org.graylog2.database;
 
-import javax.inject.Inject;
-import javax.inject.Singleton;
-import com.mongodb.BasicDBObject;
 import com.mongodb.DB;
 import com.mongodb.DBCollection;
 import com.mongodb.MongoClient;
@@ -28,6 +25,8 @@ import com.mongodb.ServerAddress;
 import com.mongodb.WriteConcern;
 import org.graylog2.configuration.MongoDbConfiguration;
 
+import javax.inject.Inject;
+import javax.inject.Singleton;
 import java.net.UnknownHostException;
 import java.util.List;
 
@@ -125,42 +124,4 @@ public class MongoConnection {
     public DB getDatabase() {
         return db;
     }
-
-    public void setUser(String mongoUser) {
-        this.username = mongoUser;
-    }
-
-    public void setReplicaSet(List<ServerAddress> mongoReplicaSet) {
-        this.replicaServers = mongoReplicaSet;
-    }
-
-    public void setThreadsAllowedToBlockMultiplier(
-            int mongoThreadsAllowedToBlockMultiplier) {
-        this.threadsAllowedToBlockMultiplier = mongoThreadsAllowedToBlockMultiplier;
-    }
-
-    public void setUseAuth(boolean mongoUseAuth) {
-        this.useAuth = mongoUseAuth;
-    }
-
-    public void setMaxConnections(int mongoMaxConnections) {
-        this.maxConnections = mongoMaxConnections;
-    }
-
-    public void setDatabase(String mongoDatabase) {
-        this.database = mongoDatabase;
-    }
-
-    public void setPassword(String mongoPassword) {
-        this.password = mongoPassword;
-    }
-
-    public void setHost(String mongoHost) {
-        this.host = mongoHost;
-    }
-
-    public void setPort(int mongoPort) {
-        this.port = mongoPort;
-    }
-
 }

--- a/graylog2-server/src/main/java/org/graylog2/database/MongoConnection.java
+++ b/graylog2-server/src/main/java/org/graylog2/database/MongoConnection.java
@@ -126,26 +126,6 @@ public class MongoConnection {
         return db;
     }
 
-
-    /**
-     * Get the message_counts collection. Lazily checks if correct indices are set.
-     *
-     * @return The messages collection
-     */
-    public DBCollection getMessageCountsColl() {
-        if (this.messageCountsCollection != null) {
-            return this.messageCountsCollection;
-        }
-
-        // Collection has not been cached yet. Do it now.
-        DBCollection coll = getDatabase().getCollection("message_counts");
-
-        coll.createIndex(new BasicDBObject("timestamp", 1));
-
-        this.messageCountsCollection = coll;
-        return coll;
-    }
-
     public void setUser(String mongoUser) {
         this.username = mongoUser;
     }

--- a/graylog2-server/src/test/java/org/graylog2/configuration/MongoDbConfigurationTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/configuration/MongoDbConfigurationTest.java
@@ -16,6 +16,7 @@
  */
 package org.graylog2.configuration;
 
+import autovalue.shaded.com.google.common.common.collect.ImmutableMap;
 import com.github.joschi.jadconfig.JadConfig;
 import com.github.joschi.jadconfig.RepositoryException;
 import com.github.joschi.jadconfig.ValidationException;
@@ -24,6 +25,8 @@ import org.testng.Assert;
 import org.testng.annotations.Test;
 
 import static java.util.Collections.singletonMap;
+import static org.testng.AssertJUnit.assertEquals;
+import static org.testng.AssertJUnit.assertNull;
 
 public class MongoDbConfigurationTest {
     @Test
@@ -31,7 +34,7 @@ public class MongoDbConfigurationTest {
         MongoDbConfiguration configuration = new MongoDbConfiguration();
         new JadConfig(new InMemoryRepository(singletonMap("mongodb_max_connections", "12345")), configuration).process();
 
-        Assert.assertEquals(12345, configuration.getMaxConnections());
+        assertEquals(12345, configuration.getMaxConnections());
     }
 
     @Test
@@ -39,7 +42,7 @@ public class MongoDbConfigurationTest {
         MongoDbConfiguration configuration = new MongoDbConfiguration();
         new JadConfig(new InMemoryRepository(), configuration).process();
 
-        Assert.assertEquals(1000, configuration.getMaxConnections());
+        assertEquals(1000, configuration.getMaxConnections());
     }
 
     @Test
@@ -47,7 +50,7 @@ public class MongoDbConfigurationTest {
         MongoDbConfiguration configuration = new MongoDbConfiguration();
         new JadConfig(new InMemoryRepository(singletonMap("mongodb_threads_allowed_to_block_multiplier", "12345")), configuration).process();
 
-        Assert.assertEquals(12345, configuration.getThreadsAllowedToBlockMultiplier());
+        assertEquals(12345, configuration.getThreadsAllowedToBlockMultiplier());
     }
 
     @Test
@@ -55,7 +58,7 @@ public class MongoDbConfigurationTest {
         MongoDbConfiguration configuration = new MongoDbConfiguration();
         new JadConfig(new InMemoryRepository(), configuration).process();
 
-        Assert.assertEquals(5, configuration.getThreadsAllowedToBlockMultiplier());
+        assertEquals(5, configuration.getThreadsAllowedToBlockMultiplier());
     }
 
     @Test
@@ -63,7 +66,7 @@ public class MongoDbConfigurationTest {
         MongoDbConfiguration configuration = new MongoDbConfiguration();
         new JadConfig(new InMemoryRepository(singletonMap("mongodb_replica_set", "")), configuration).process();
 
-        Assert.assertNull(configuration.getReplicaSet());
+        assertNull(configuration.getReplicaSet());
     }
 
     @Test
@@ -76,7 +79,6 @@ public class MongoDbConfigurationTest {
 
     @Test
     public void testGetMongoDBReplicaSetServersUnknownHost() throws RepositoryException, ValidationException {
-
         MongoDbConfiguration configuration = new MongoDbConfiguration();
         new JadConfig(new InMemoryRepository(singletonMap("mongodb_replica_set", "this-host-hopefully-does-not-exist.:27017")), configuration).process();
 
@@ -96,7 +98,7 @@ public class MongoDbConfigurationTest {
         MongoDbConfiguration configuration = new MongoDbConfiguration();
         new JadConfig(new InMemoryRepository(singletonMap("mongodb_replica_set", "127.0.0.1")), configuration).process();
 
-        Assert.assertEquals(configuration.getReplicaSet().get(0).getPort(), 27017);
+        assertEquals(configuration.getReplicaSet().get(0).getPort(), 27017);
     }
 
     @Test
@@ -104,7 +106,7 @@ public class MongoDbConfigurationTest {
         MongoDbConfiguration configuration = new MongoDbConfiguration();
         new JadConfig(new InMemoryRepository(singletonMap("mongodb_replica_set", "127.0.0.1:27017,127.0.0.1:27018")), configuration).process();
 
-        Assert.assertEquals(2, configuration.getReplicaSet().size());
+        assertEquals(2, configuration.getReplicaSet().size());
     }
 
     @Test
@@ -112,13 +114,108 @@ public class MongoDbConfigurationTest {
         MongoDbConfiguration configuration = new MongoDbConfiguration();
         new JadConfig(new InMemoryRepository(singletonMap("mongodb_replica_set", "fe80::221:6aff:fe6f:6c88,[fe80::221:6aff:fe6f:6c89]:27018,127.0.0.1:27019")), configuration).process();
 
-        Assert.assertEquals(3, configuration.getReplicaSet().size());
+        assertEquals(3, configuration.getReplicaSet().size());
     }
-
 
     @Test(expectedExceptions = ValidationException.class)
     public void testValidateMongoDbAuth() throws RepositoryException, ValidationException {
         MongoDbConfiguration configuration = new MongoDbConfiguration();
         new JadConfig(new InMemoryRepository(singletonMap("mongodb_useauth", "true")), configuration).process();
+    }
+
+    @Test(expectedExceptions = ValidationException.class)
+    public void validateFailsIfUriAndHostAreMissing() throws RepositoryException, ValidationException {
+        MongoDbConfiguration configuration = new MongoDbConfiguration();
+        final ImmutableMap<String, String> config = ImmutableMap.of(
+                "mongodb_host", "",
+                "mongodb_database", "graylog"
+        );
+        new JadConfig(new InMemoryRepository(config), configuration).process();
+    }
+
+    @Test(expectedExceptions = ValidationException.class)
+    public void validateFailsIfUriAndDatabaseAreMissing() throws RepositoryException, ValidationException {
+        MongoDbConfiguration configuration = new MongoDbConfiguration();
+        final ImmutableMap<String, String> properties = ImmutableMap.of(
+                "mongodb_host", "localhost",
+                "mongodb_database", ""
+        );
+        new JadConfig(new InMemoryRepository(properties), configuration).process();
+    }
+
+    @Test
+    public void validateSucceedsIfUriIsEmpty() throws RepositoryException, ValidationException {
+        MongoDbConfiguration configuration = new MongoDbConfiguration();
+        new JadConfig(new InMemoryRepository(singletonMap("mongodb_uri", "")), configuration).process();
+        assertEquals("mongodb://127.0.0.1:27017/graylog2", configuration.getUri());
+    }
+
+    @Test
+    public void validateSucceedsIfUriIsNull() throws RepositoryException, ValidationException {
+        MongoDbConfiguration configuration = new MongoDbConfiguration();
+        new JadConfig(new InMemoryRepository(singletonMap("mongodb_uri", (String) null)), configuration).process();
+        assertEquals("mongodb://127.0.0.1:27017/graylog2", configuration.getUri());
+    }
+
+    @Test
+    public void getMongoClientURIBuildsDatabaseCorrectly() throws Exception {
+        MongoDbConfiguration configuration = new MongoDbConfiguration();
+        final ImmutableMap<String, String> properties = ImmutableMap.of(
+                "mongodb_database", "TEST1234"
+        );
+        new JadConfig(new InMemoryRepository(properties), configuration).process();
+
+        assertEquals("mongodb://127.0.0.1:27017/TEST1234", configuration.getMongoClientURI().toString());
+    }
+
+    @Test
+    public void getMongoClientURIBuildsSingleHostCorrectly() throws Exception {
+        MongoDbConfiguration configuration = new MongoDbConfiguration();
+        final ImmutableMap<String, String> properties = ImmutableMap.of(
+                "mongodb_host", "localhost",
+                "mongodb_database", "graylog"
+        );
+        new JadConfig(new InMemoryRepository(properties), configuration).process();
+
+        assertEquals("mongodb://localhost:27017/graylog", configuration.getMongoClientURI().toString());
+    }
+
+    @Test
+    public void getMongoClientURIBuildsSingleHostWithCustomPortCorrectly() throws Exception {
+        MongoDbConfiguration configuration = new MongoDbConfiguration();
+        final ImmutableMap<String, String> properties = ImmutableMap.of(
+                "mongodb_host", "localhost",
+                "mongodb_port", "12345",
+                "mongodb_database", "graylog"
+        );
+        new JadConfig(new InMemoryRepository(properties), configuration).process();
+
+        assertEquals("mongodb://localhost:12345/graylog", configuration.getMongoClientURI().toString());
+    }
+
+    @Test
+    public void getMongoClientURIBuildsReplicaSetCorrectly() throws Exception {
+        MongoDbConfiguration configuration = new MongoDbConfiguration();
+        final ImmutableMap<String, String> properties = ImmutableMap.of(
+                "mongodb_replica_set", "localhost:1234,localhost:5678,localhost:9012",
+                "mongodb_database", "graylog"
+        );
+        new JadConfig(new InMemoryRepository(properties), configuration).process();
+
+        assertEquals("mongodb://localhost:1234,localhost:5678,localhost:9012/graylog", configuration.getMongoClientURI().toString());
+    }
+
+    @Test
+    public void existingUriTakesPrecedenceInGetMongoClientURI() throws Exception {
+        MongoDbConfiguration configuration = new MongoDbConfiguration();
+        final ImmutableMap<String, String> properties = ImmutableMap.of(
+                "mongodb_host", "localhost",
+                "mongodb_port", "27017",
+                "mongodb_database", "graylog",
+                "mongodb_uri", "mongodb://example.com:1234,127.0.0.1:5678/TEST"
+        );
+        new JadConfig(new InMemoryRepository(properties), configuration).process();
+
+        assertEquals("mongodb://example.com:1234,127.0.0.1:5678/TEST", configuration.getMongoClientURI().toString());
     }
 }

--- a/misc/graylog2.conf
+++ b/misc/graylog2.conf
@@ -300,20 +300,23 @@ lb_recognition_period_seconds = 3
 # Time in milliseconds which Graylog is waiting for all threads to stop on shutdown.
 #shutdown_timeout = 30000
 
-# MongoDB Configuration
-mongodb_useauth = false
-#mongodb_user = grayloguser
-#mongodb_password = 123
-mongodb_host = 127.0.0.1
-#mongodb_replica_set = localhost:27017,localhost:27018,localhost:27019
-mongodb_database = graylog2
-mongodb_port = 27017
+# MongoDB connection string
+# See http://docs.mongodb.org/manual/reference/connection-string/ for details
+mongodb_uri = mongodb://localhost/graylog2
 
-# Raise this according to the maximum connections your MongoDB server can handle if you encounter MongoDB connection problems.
+# Authenticate against the MongoDB server
+#mongodb_uri = mongodb://grayloguser:secret@localhost:27017/graylog2
+
+# Use a replica set instead of a single host
+#mongodb_uri = mongodb://grayloguser:secret@localhost:27017,localhost:27018,localhost:27019/graylog2
+
+# Increase this value according to the maximum connections your MongoDB server can handle from a single client
+# if you encounter MongoDB connection problems.
 mongodb_max_connections = 100
 
 # Number of threads allowed to be blocked by MongoDB connections multiplier. Default: 5
-# If mongodb_max_connections is 100, and mongodb_threads_allowed_to_block_multiplier is 5, then 500 threads can block. More than that and an exception will be thrown.
+# If mongodb_max_connections is 100, and mongodb_threads_allowed_to_block_multiplier is 5,
+# then 500 threads can block. More than that and an exception will be thrown.
 # http://api.mongodb.org/java/current/com/mongodb/MongoOptions.html#threadsAllowedToBlockForConnectionMultiplier
 mongodb_threads_allowed_to_block_multiplier = 5
 


### PR DESCRIPTION
This PR replaces the individual MongoDB configuration settings in `graylog.conf` (e. g. `mongodb_host`, `mongodb_use_auth`, `mongodb_replica_set`) with a single `mongodb_uri` setting following the conventions described at [Connection String URI Format](http://docs.mongodb.org/manual/reference/connection-string/).

Old settings are still supported and are being used to build a connection string if no explicit connection string was provided in the `mongodb_uri` setting. In this case a message about the deprecated settings is being printed on INFO level.

Fixes #968.