### PR TITLE
Masking passwords for alarmcallbacks in web interface.

### DIFF
--- a/graylog2-rest-client/src/main/java/org/graylog2/restclient/models/AlarmCallback.java
+++ b/graylog2-rest-client/src/main/java/org/graylog2/restclient/models/AlarmCallback.java
@@ -72,8 +72,8 @@ public class AlarmCallback extends ConfigurableEntity {
         return configuration;
     }
 
-    public Map<String, Object> getConfiguration(GetSingleAvailableAlarmCallbackResponse typeSummaryResponse) {
-        return getConfiguration(typeSummaryResponse.getRequestedConfiguration());
+    public Map<String, Object> getConfiguration(GetSingleAvailableAlarmCallbackResponse availableAlarmCallbackResponse) {
+        return getConfiguration(availableAlarmCallbackResponse.getRequestedConfiguration());
     }
 
     public DateTime getCreatedAt() {

--- a/graylog2-rest-client/src/main/java/org/graylog2/restclient/models/AlarmCallback.java
+++ b/graylog2-rest-client/src/main/java/org/graylog2/restclient/models/AlarmCallback.java
@@ -16,9 +16,12 @@
  */
 package org.graylog2.restclient.models;
 
+import com.google.common.collect.Maps;
 import com.google.inject.assistedinject.Assisted;
 import com.google.inject.assistedinject.AssistedInject;
+import org.graylog2.restclient.lib.plugin.configuration.RequestedConfigurationField;
 import org.graylog2.restclient.models.api.responses.alarmcallbacks.AlarmCallbackSummaryResponse;
+import org.graylog2.restclient.models.api.responses.alarmcallbacks.GetSingleAvailableAlarmCallbackResponse;
 import org.joda.time.DateTime;
 
 import java.util.Map;
@@ -68,6 +71,19 @@ public class AlarmCallback {
 
     public Map<String, Object> getConfiguration() {
         return configuration;
+    }
+
+    public Map<String, Object> getConfiguration(GetSingleAvailableAlarmCallbackResponse typeSummaryResponse) {
+        final Map<String, Object> result = Maps.newHashMapWithExpectedSize(configuration.size());
+
+        for (final RequestedConfigurationField configurationField : typeSummaryResponse.getRequestedConfiguration()) {
+            if (configurationField.getAttributes().contains("is_password")) {
+                result.put(configurationField.getTitle(), "*******");
+            } else {
+                result.put(configurationField.getTitle(), configuration.get(configurationField.getTitle()));
+            }
+        }
+        return result;
     }
 
     public DateTime getCreatedAt() {

--- a/graylog2-rest-client/src/main/java/org/graylog2/restclient/models/AlarmCallback.java
+++ b/graylog2-rest-client/src/main/java/org/graylog2/restclient/models/AlarmCallback.java
@@ -16,10 +16,8 @@
  */
 package org.graylog2.restclient.models;
 
-import com.google.common.collect.Maps;
 import com.google.inject.assistedinject.Assisted;
 import com.google.inject.assistedinject.AssistedInject;
-import org.graylog2.restclient.lib.plugin.configuration.RequestedConfigurationField;
 import org.graylog2.restclient.models.api.responses.alarmcallbacks.AlarmCallbackSummaryResponse;
 import org.graylog2.restclient.models.api.responses.alarmcallbacks.GetSingleAvailableAlarmCallbackResponse;
 import org.joda.time.DateTime;
@@ -29,7 +27,7 @@ import java.util.Map;
 /**
  * @author Dennis Oelkers <dennis@torch.sh>
  */
-public class AlarmCallback {
+public class AlarmCallback extends ConfigurableEntity {
     public interface Factory {
         public AlarmCallback fromSummaryResponse(String streamId, AlarmCallbackSummaryResponse response);
     }
@@ -69,21 +67,13 @@ public class AlarmCallback {
         return type;
     }
 
+    @Override
     public Map<String, Object> getConfiguration() {
         return configuration;
     }
 
     public Map<String, Object> getConfiguration(GetSingleAvailableAlarmCallbackResponse typeSummaryResponse) {
-        final Map<String, Object> result = Maps.newHashMapWithExpectedSize(configuration.size());
-
-        for (final RequestedConfigurationField configurationField : typeSummaryResponse.getRequestedConfiguration()) {
-            if (configurationField.getAttributes().contains("is_password")) {
-                result.put(configurationField.getTitle(), "*******");
-            } else {
-                result.put(configurationField.getTitle(), configuration.get(configurationField.getTitle()));
-            }
-        }
-        return result;
+        return getConfiguration(typeSummaryResponse.getRequestedConfiguration());
     }
 
     public DateTime getCreatedAt() {

--- a/graylog2-rest-client/src/main/java/org/graylog2/restclient/models/ConfigurableEntity.java
+++ b/graylog2-rest-client/src/main/java/org/graylog2/restclient/models/ConfigurableEntity.java
@@ -1,3 +1,19 @@
+/**
+ * This file is part of Graylog.
+ *
+ * Graylog is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package org.graylog2.restclient.models;
 
 import com.google.common.collect.Maps;

--- a/graylog2-rest-client/src/main/java/org/graylog2/restclient/models/ConfigurableEntity.java
+++ b/graylog2-rest-client/src/main/java/org/graylog2/restclient/models/ConfigurableEntity.java
@@ -16,10 +16,8 @@
  */
 package org.graylog2.restclient.models;
 
-import com.google.common.base.Strings;
 import com.google.common.collect.Maps;
 import org.graylog2.restclient.lib.plugin.configuration.RequestedConfigurationField;
-import org.graylog2.restclient.models.api.responses.alarmcallbacks.GetSingleAvailableAlarmCallbackResponse;
 
 import java.util.List;
 import java.util.Map;

--- a/graylog2-rest-client/src/main/java/org/graylog2/restclient/models/ConfigurableEntity.java
+++ b/graylog2-rest-client/src/main/java/org/graylog2/restclient/models/ConfigurableEntity.java
@@ -16,6 +16,7 @@
  */
 package org.graylog2.restclient.models;
 
+import com.google.common.base.Strings;
 import com.google.common.collect.Maps;
 import org.graylog2.restclient.lib.plugin.configuration.RequestedConfigurationField;
 import org.graylog2.restclient.models.api.responses.alarmcallbacks.GetSingleAvailableAlarmCallbackResponse;
@@ -30,10 +31,12 @@ public abstract class ConfigurableEntity {
         final Map<String, Object> result = Maps.newHashMapWithExpectedSize(getConfiguration().size());
 
         for (final RequestedConfigurationField configurationField : typeResponses) {
-            if (configurationField.getAttributes().contains("is_password")) {
-                result.put(configurationField.getTitle(), "*******");
-            } else {
-                result.put(configurationField.getTitle(), getConfiguration().get(configurationField.getTitle()));
+            if (getConfiguration().get(configurationField.getTitle()) != null) {
+                if (configurationField.getAttributes().contains("is_password")) {
+                    result.put(configurationField.getTitle(), "*******");
+                } else {
+                    result.put(configurationField.getTitle(), getConfiguration().get(configurationField.getTitle()));
+                }
             }
         }
         return result;

--- a/graylog2-rest-client/src/main/java/org/graylog2/restclient/models/ConfigurableEntity.java
+++ b/graylog2-rest-client/src/main/java/org/graylog2/restclient/models/ConfigurableEntity.java
@@ -1,0 +1,25 @@
+package org.graylog2.restclient.models;
+
+import com.google.common.collect.Maps;
+import org.graylog2.restclient.lib.plugin.configuration.RequestedConfigurationField;
+import org.graylog2.restclient.models.api.responses.alarmcallbacks.GetSingleAvailableAlarmCallbackResponse;
+
+import java.util.List;
+import java.util.Map;
+
+public abstract class ConfigurableEntity {
+    public abstract Map<String, Object> getConfiguration();
+
+    public Map<String, Object> getConfiguration(List<RequestedConfigurationField> typeResponses) {
+        final Map<String, Object> result = Maps.newHashMapWithExpectedSize(getConfiguration().size());
+
+        for (final RequestedConfigurationField configurationField : typeResponses) {
+            if (configurationField.getAttributes().contains("is_password")) {
+                result.put(configurationField.getTitle(), "*******");
+            } else {
+                result.put(configurationField.getTitle(), getConfiguration().get(configurationField.getTitle()));
+            }
+        }
+        return result;
+    }
+}

--- a/graylog2-rest-client/src/main/java/org/graylog2/restclient/models/ConfigurableEntity.java
+++ b/graylog2-rest-client/src/main/java/org/graylog2/restclient/models/ConfigurableEntity.java
@@ -27,10 +27,10 @@ import java.util.Map;
 public abstract class ConfigurableEntity {
     public abstract Map<String, Object> getConfiguration();
 
-    public Map<String, Object> getConfiguration(List<RequestedConfigurationField> typeResponses) {
+    public Map<String, Object> getConfiguration(List<RequestedConfigurationField> configurationFields) {
         final Map<String, Object> result = Maps.newHashMapWithExpectedSize(getConfiguration().size());
 
-        for (final RequestedConfigurationField configurationField : typeResponses) {
+        for (final RequestedConfigurationField configurationField : configurationFields) {
             if (getConfiguration().get(configurationField.getTitle()) != null) {
                 if (configurationField.getAttributes().contains("is_password")) {
                     result.put(configurationField.getTitle(), "*******");

--- a/graylog2-rest-client/src/main/java/org/graylog2/restclient/models/Input.java
+++ b/graylog2-rest-client/src/main/java/org/graylog2/restclient/models/Input.java
@@ -264,8 +264,8 @@ public class Input extends ConfigurableEntity {
     public Map<String, Object> getAttributes() {
         return attributes;
     }
-    public Map<String, Object> getAttributes(List<RequestedConfigurationField> typeSummaryResponse ) {
-        return getConfiguration(typeSummaryResponse);
+    public Map<String, Object> getAttributes(List<RequestedConfigurationField> configurationFields ) {
+        return getConfiguration(configurationFields);
     }
 
     public Map<String, Object> getAttributes(InputTypeSummaryResponse typeSummaryResponse ) {

--- a/graylog2-rest-client/src/main/java/org/graylog2/restclient/models/Input.java
+++ b/graylog2-rest-client/src/main/java/org/graylog2/restclient/models/Input.java
@@ -43,7 +43,7 @@ import java.io.IOException;
 import java.util.List;
 import java.util.Map;
 
-public class Input {
+public class Input extends ConfigurableEntity {
 
     private static final org.slf4j.Logger log = LoggerFactory.getLogger(Input.class);
 
@@ -264,18 +264,17 @@ public class Input {
     public Map<String, Object> getAttributes() {
         return attributes;
     }
+    public Map<String, Object> getAttributes(List<RequestedConfigurationField> typeSummaryResponse ) {
+        return getConfiguration(typeSummaryResponse);
+    }
+
     public Map<String, Object> getAttributes(InputTypeSummaryResponse typeSummaryResponse ) {
-        Map<String, Object> result = Maps.newHashMapWithExpectedSize(attributes.size());
+        return getAttributes(typeSummaryResponse.getRequestedConfiguration());
+    }
 
-        for (RequestedConfigurationField configurationField : typeSummaryResponse.getRequestedConfiguration()) {
-            if (configurationField.getAttributes().contains("is_password")) {
-                result.put(configurationField.getTitle(), "*******");
-            } else {
-                result.put(configurationField.getTitle(), attributes.get(configurationField.getTitle()));
-            }
-        }
-
-        return result;
+    @Override
+    public Map<String, Object> getConfiguration() {
+        return getAttributes();
     }
 
     public Boolean getGlobal() {

--- a/graylog2-rest-client/src/test/java/org/graylog2/restclient/models/ConfigurableEntityTest.java
+++ b/graylog2-rest-client/src/test/java/org/graylog2/restclient/models/ConfigurableEntityTest.java
@@ -1,0 +1,109 @@
+package org.graylog2.restclient.models;
+
+import autovalue.shaded.com.google.common.common.collect.Lists;
+import autovalue.shaded.com.google.common.common.collect.Maps;
+import org.graylog2.restclient.lib.plugin.configuration.RequestedConfigurationField;
+import org.graylog2.restclient.lib.plugin.configuration.TextField;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.when;
+import static org.testng.Assert.*;
+
+public class ConfigurableEntityTest {
+    @Mock private ConfigurableEntity configurableEntity;
+    private final Map<String, Object> configuration = Maps.newHashMap();
+    private final List<RequestedConfigurationField> requestedConfigurationFields = Lists.newArrayList();
+
+    @BeforeMethod
+    public void setUp() throws Exception {
+        MockitoAnnotations.initMocks(this);
+        when(configurableEntity.getConfiguration(any(List.class))).thenCallRealMethod();
+        when(configurableEntity.getConfiguration()).thenReturn(configuration);
+    }
+
+    @Test
+    public void testMaskingPasswordField() throws Exception {
+        final String passwordField = "password";
+        configuration.put(passwordField, "foobar");
+        addPasswordField(passwordField);
+
+        final Map<String, Object> result = configurableEntity.getConfiguration(requestedConfigurationFields);
+
+        assertEquals(result.get(passwordField), "*******", "Password should be masked in result!");
+    }
+
+    @Test
+    public void testNotStubbingNonPasswordField() throws Exception {
+        final String userField = "username";
+        final String username = "johndoe";
+        configuration.put(userField, username);
+        addNonPasswordField(userField);
+
+        final Map<String, Object> result = configurableEntity.getConfiguration(requestedConfigurationFields);
+
+        assertEquals(result.get(userField), username, "Non-password field should not be masked in result!");
+    }
+
+    @Test
+    public void testMixedPasswordAndNonPasswordFields() throws Exception {
+        final String passwordField = "password";
+        configuration.put(passwordField, "foobar");
+        addPasswordField(passwordField);
+
+        final String userField = "username";
+        final String username = "johndoe";
+        configuration.put(userField, username);
+        addNonPasswordField(userField);
+
+        final Map<String, Object> result = configurableEntity.getConfiguration(requestedConfigurationFields);
+
+        assertEquals(result.get(userField), username, "Non-password field should not be masked in result!");
+        assertEquals(result.get(passwordField), "*******", "Password should be masked in result!");
+    }
+
+    private void addNonPasswordField(String userField) {
+        final Map.Entry<String, Map<String, Object>> textField = stubConfigurationFieldConfig("text", userField, new ArrayList<String>(), false);
+
+        requestedConfigurationFields.add(new TextField(textField));
+    }
+
+    private void addPasswordField(String passwordFieldName) {
+        final Map.Entry<String, Map<String, Object>> passwordTextField = stubConfigurationFieldConfig("text", passwordFieldName, new ArrayList<String>() {{
+            add("is_password");
+        }}, false);
+
+        requestedConfigurationFields.add(new TextField(passwordTextField));
+    }
+
+    private Map.Entry<String, Map<String, Object>> stubConfigurationFieldConfig(final String type, final String title, final List<String> attributes, final Boolean isOptional) {
+        return new Map.Entry<String, Map<String, Object>>() {
+                @Override
+                public String getKey() {
+                    return title;
+                }
+
+                @Override
+                public Map<String, Object> getValue() {
+                    return new HashMap<String, Object>() {{
+                        put("type", type);
+                        put("attributes", attributes);
+                        put("is_optional", isOptional);
+                    }};
+                }
+
+                @Override
+                public Map<String, Object> setValue(Map<String, Object> value) {
+                    return null;
+                }
+            };
+    }
+}


### PR DESCRIPTION
Adding functionality in rest client which masks password fields of configurable antity.

Usage should be extended to other entities like Outputs which have dynamic configurations too, but this is beyond the scope of this PR.
