### PR TITLE
Upgrade MongoDB Java Driver for compatibility with MongoDB 3.0

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/system/stats/mongo/DatabaseStats.java
+++ b/graylog2-server/src/main/java/org/graylog2/system/stats/mongo/DatabaseStats.java
@@ -56,10 +56,12 @@ public abstract class DatabaseStats {
     public abstract long indexSize();
 
     @JsonProperty
-    public abstract long fileSize();
+    @Nullable
+    public abstract Long fileSize();
 
     @JsonProperty
-    public abstract long nsSizeMB();
+    @Nullable
+    public abstract Long nsSizeMB();
 
     @JsonProperty
     @Nullable
@@ -78,8 +80,8 @@ public abstract class DatabaseStats {
                                        long numExtents,
                                        long indexes,
                                        long indexSize,
-                                       long fileSize,
-                                       long nsSizeMB,
+                                       @Nullable Long fileSize,
+                                       @Nullable Long nsSizeMB,
                                        @Nullable ExtentFreeList extentFreeList,
                                        @Nullable DataFileVersion dataFileVersion) {
         return new AutoValue_DatabaseStats(db, collections, objects, avgObjSize, dataSize, storageSize, numExtents,

--- a/graylog2-server/src/main/java/org/graylog2/system/stats/mongo/MongoProbe.java
+++ b/graylog2-server/src/main/java/org/graylog2/system/stats/mongo/MongoProbe.java
@@ -129,17 +129,26 @@ public class MongoProbe {
         final CommandResult dbStatsResult = db.command("dbStats");
         if (dbStatsResult.ok()) {
             final BasicDBObject extentFreeListMap = (BasicDBObject) dbStatsResult.get("extentFreeList");
-            final DatabaseStats.ExtentFreeList extentFreeList = DatabaseStats.ExtentFreeList.create(
-                    extentFreeListMap.getInt("num"),
-                    extentFreeListMap.getInt("totalSize")
-            );
+            final DatabaseStats.ExtentFreeList extentFreeList;
+            if (extentFreeListMap == null) {
+                extentFreeList = null;
+            } else {
+                extentFreeList = DatabaseStats.ExtentFreeList.create(
+                        extentFreeListMap.getInt("num"),
+                        extentFreeListMap.getInt("totalSize")
+                );
+            }
 
             final BasicDBObject dataFileVersionMap = (BasicDBObject) dbStatsResult.get("dataFileVersion");
-            final DatabaseStats.DataFileVersion dataFileVersion = DatabaseStats.DataFileVersion.create(
-                    dataFileVersionMap.getInt("major"),
-                    dataFileVersionMap.getInt("minor")
-            );
-
+            final DatabaseStats.DataFileVersion dataFileVersion;
+            if (dataFileVersionMap == null) {
+                dataFileVersion = null;
+            } else {
+                dataFileVersion = DatabaseStats.DataFileVersion.create(
+                        dataFileVersionMap.getInt("major"),
+                        dataFileVersionMap.getInt("minor")
+                );
+            }
 
             dbStats = DatabaseStats.create(
                     dbStatsResult.getString("db"),
@@ -151,8 +160,8 @@ public class MongoProbe {
                     dbStatsResult.getLong("numExtents"),
                     dbStatsResult.getLong("indexes"),
                     dbStatsResult.getLong("indexSize"),
-                    dbStatsResult.getLong("fileSize"),
-                    dbStatsResult.getLong("nsSizeMB"),
+                    dbStatsResult.containsField("fileSize") ? dbStatsResult.getLong("fileSize") : null,
+                    dbStatsResult.containsField("nsSizeMB") ? dbStatsResult.getLong("nsSizeMB") : null,
                     extentFreeList,
                     dataFileVersion
             );
@@ -167,7 +176,7 @@ public class MongoProbe {
             final ServerStatus.Connections connections = ServerStatus.Connections.create(
                     connectionsMap.getInt("current"),
                     connectionsMap.getInt("available"),
-                    connectionsMap.getLong("totalCreated")
+                    connectionsMap.containsField("totalCreated") ? connectionsMap.getLong("totalCreated") : null
             );
 
             final BasicDBObject networkMap = (BasicDBObject) serverStatusResult.get("network");

--- a/graylog2-server/src/main/java/org/graylog2/system/stats/mongo/MongoProbe.java
+++ b/graylog2-server/src/main/java/org/graylog2/system/stats/mongo/MongoProbe.java
@@ -196,6 +196,14 @@ public class MongoProbe {
                     memoryMap.getInt("mappedWithJournal")
             );
 
+            final BasicDBObject storageEngineMap = (BasicDBObject) serverStatusResult.get("storageEngine");
+            final ServerStatus.StorageEngine storageEngine;
+            if (storageEngineMap == null) {
+                storageEngine = ServerStatus.StorageEngine.DEFAULT;
+            } else {
+                storageEngine = ServerStatus.StorageEngine.create(storageEngineMap.getString("name"));
+            }
+
             serverStatus = ServerStatus.create(
                     serverStatusResult.getString("host"),
                     serverStatusResult.getString("version"),
@@ -207,7 +215,8 @@ public class MongoProbe {
                     new DateTime(serverStatusResult.getDate("localTime")),
                     connections,
                     network,
-                    memory);
+                    memory,
+                    storageEngine);
         } else {
             serverStatus = null;
         }

--- a/graylog2-server/src/main/java/org/graylog2/system/stats/mongo/ServerStatus.java
+++ b/graylog2-server/src/main/java/org/graylog2/system/stats/mongo/ServerStatus.java
@@ -92,7 +92,7 @@ public abstract class ServerStatus {
 
         public static Connections create(int current,
                                          int available,
-                                         @Nullable long totalCreated) {
+                                         @Nullable Long totalCreated) {
             return new AutoValue_ServerStatus_Connections(current, available, totalCreated);
         }
     }

--- a/graylog2-server/src/main/java/org/graylog2/system/stats/mongo/ServerStatus.java
+++ b/graylog2-server/src/main/java/org/graylog2/system/stats/mongo/ServerStatus.java
@@ -62,6 +62,9 @@ public abstract class ServerStatus {
     @JsonProperty
     public abstract Memory memory();
 
+    @JsonProperty
+    public abstract StorageEngine storageEngine();
+
     public static ServerStatus create(String host,
                                       String version,
                                       String process,
@@ -72,9 +75,10 @@ public abstract class ServerStatus {
                                       DateTime localTime,
                                       Connections connections,
                                       Network network,
-                                      Memory memory) {
+                                      Memory memory,
+                                      StorageEngine storageEngine) {
         return new AutoValue_ServerStatus(host, version, process, pid, uptime, uptimeMillis, uptimeEstimate, localTime,
-                connections, network, memory);
+                connections, network, memory, storageEngine);
     }
 
     @JsonAutoDetect
@@ -144,6 +148,19 @@ public abstract class ServerStatus {
                                     int mapped,
                                     int mappedWithJournal) {
             return new AutoValue_ServerStatus_Memory(bits, resident, virtual, supported, mapped, mappedWithJournal);
+        }
+    }
+
+    @JsonAutoDetect
+    @AutoValue
+    public abstract static class StorageEngine {
+        public static final StorageEngine DEFAULT = create("mmapv1");
+
+        @JsonProperty
+        public abstract String name();
+
+        public static StorageEngine create(String name) {
+            return new AutoValue_ServerStatus_StorageEngine(name);
         }
     }
 

--- a/pom.xml
+++ b/pom.xml
@@ -208,7 +208,7 @@
             <dependency>
                 <groupId>org.mongodb</groupId>
                 <artifactId>mongo-java-driver</artifactId>
-                <version>2.12.4</version>
+                <version>2.13.0</version>
             </dependency>
 
             <dependency>


### PR DESCRIPTION
Upgrade MongoDB Java Driver for compatibility with MongoDB 3.0 and the WiredTiger storage engine.

It also adds the used storage engine of MongoDB to the data collected by `MongoProbe` and fixes some incompatibilities with the output of the [serverStatus command](http://docs.mongodb.org/manual/reference/method/db.serverStatus/).

Locally tested with MongoDB 2.2.7, 2.6.8, and 3.0.0.

Merging this PR will close issue 10000000000b (#1024).