### PR TITLE
Respecting rest_transport_uri when generating entity URLs.

### DIFF
--- a/graylog2-radio/misc/graylog2-radio.conf
+++ b/graylog2-radio/misc/graylog2-radio.conf
@@ -16,8 +16,10 @@ rest_listen_uri = http://127.0.0.1:12950/
 
 # REST API transport address. Defaults to the value of rest_listen_uri. Exception: If rest_listen_uri
 # is set to a wildcard IP address (0.0.0.0) the first non-loopback IPv4 system address is used.
-# This will be promoted in the cluster discovery APIs and other nodes may try to connect on this
-# address. (see rest_listen_uri)
+# If set, his will be promoted in the cluster discovery APIs, so other nodes may try to connect on
+# this address and it is used to generate URLs addressing entities in the REST API. (see rest_listen_uri)
+# You will need to define this, if your Graylog radio is running behind a HTTP proxy that is rewriting
+# the scheme, host name or URI.
 #rest_transport_uri = http://192.168.1.1:12950/
 
 # Enable CORS headers for REST API. This is necessary for JS-clients accessing the server directly.

--- a/graylog2-server/src/main/java/org/graylog2/rest/resources/alarmcallbacks/AlarmCallbackResource.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/resources/alarmcallbacks/AlarmCallbackResource.java
@@ -51,7 +51,6 @@ import javax.ws.rs.PathParam;
 import javax.ws.rs.Produces;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
-import javax.ws.rs.core.UriBuilder;
 import java.net.URI;
 import java.util.List;
 import java.util.Map;
@@ -139,7 +138,7 @@ public class AlarmCallbackResource extends RestResource {
         }
 
         final Map<String, String> result = ImmutableMap.of("alarmcallback_id", id);
-        final URI alarmCallbackUri = UriBuilder.fromResource(AlarmCallbackResource.class)
+        final URI alarmCallbackUri = getUriBuilderToSelf().path(AlarmCallbackResource.class)
                 .path("{alarmCallbackId}")
                 .build(streamid, id);
 

--- a/graylog2-server/src/main/java/org/graylog2/rest/resources/dashboards/DashboardsResource.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/resources/dashboards/DashboardsResource.java
@@ -66,7 +66,6 @@ import javax.ws.rs.Produces;
 import javax.ws.rs.WebApplicationException;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
-import javax.ws.rs.core.UriBuilder;
 import java.net.URI;
 import java.util.List;
 import java.util.Map;
@@ -122,7 +121,7 @@ public class DashboardsResource extends RestResource {
         dashboardRegistry.add(dashboard);
 
         final Map<String, String> result = ImmutableMap.of("dashboard_id", id);
-        final URI dashboardUri = UriBuilder.fromResource(DashboardsResource.class)
+        final URI dashboardUri = getUriBuilderToSelf().path(DashboardsResource.class)
                 .path("{dashboardId}")
                 .build(id);
 
@@ -286,7 +285,7 @@ public class DashboardsResource extends RestResource {
         }
 
         final Map<String, String> result = ImmutableMap.of("widget_id", widget.getId());
-        final URI widgetUri = UriBuilder.fromResource(DashboardsResource.class)
+        final URI widgetUri = getUriBuilderToSelf().path(DashboardsResource.class)
                 .path("{dashboardId}/widgets/{widgetId}")
                 .build(dashboardId, widget.getId());
 

--- a/graylog2-server/src/main/java/org/graylog2/rest/resources/filters/BlacklistSourceResource.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/resources/filters/BlacklistSourceResource.java
@@ -46,7 +46,6 @@ import javax.ws.rs.PathParam;
 import javax.ws.rs.Produces;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
-import javax.ws.rs.core.UriBuilder;
 import java.net.URI;
 import java.util.Collections;
 import java.util.Set;
@@ -83,7 +82,7 @@ public class BlacklistSourceResource extends RestResource {
 
         final FilterDescription savedFilter = filterService.save(filterDescription);
 
-        final URI filterUri = UriBuilder.fromResource(BlacklistSourceResource.class)
+        final URI filterUri = getUriBuilderToSelf().path(BlacklistSourceResource.class)
                 .path("{filterId}")
                 .build(savedFilter._id);
 

--- a/graylog2-server/src/main/java/org/graylog2/rest/resources/search/SavedSearchesResource.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/resources/search/SavedSearchesResource.java
@@ -47,7 +47,6 @@ import javax.ws.rs.PathParam;
 import javax.ws.rs.Produces;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
-import javax.ws.rs.core.UriBuilder;
 import java.net.URI;
 import java.util.List;
 import java.util.Map;
@@ -83,7 +82,7 @@ public class SavedSearchesResource extends SearchResource {
         final SavedSearch search = new SavedSearchImpl(searchData);
         final String id = savedSearchService.save(search);
 
-        final URI searchUri = UriBuilder.fromResource(SavedSearchesResource.class)
+        final URI searchUri = getUriBuilderToSelf().path(SavedSearchesResource.class)
                 .path("{searchId}")
                 .build(id);
 

--- a/graylog2-server/src/main/java/org/graylog2/rest/resources/streams/StreamResource.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/resources/streams/StreamResource.java
@@ -66,7 +66,6 @@ import javax.ws.rs.PathParam;
 import javax.ws.rs.Produces;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
-import javax.ws.rs.core.UriBuilder;
 import java.net.URI;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -119,7 +118,7 @@ public class StreamResource extends RestResource {
         }
 
         final Map<String, String> result = ImmutableMap.of("stream_id", id);
-        final URI streamUri = UriBuilder.fromResource(StreamResource.class)
+        final URI streamUri = getUriBuilderToSelf().path(StreamResource.class)
                 .path("{streamId}")
                 .build(id);
 
@@ -337,7 +336,7 @@ public class StreamResource extends RestResource {
         }
 
         final Map<String, String> result = ImmutableMap.of("stream_id", id);
-        final URI streamUri = UriBuilder.fromResource(StreamResource.class)
+        final URI streamUri = getUriBuilderToSelf().path(StreamResource.class)
                 .path("{streamId}")
                 .build(id);
 

--- a/graylog2-server/src/main/java/org/graylog2/rest/resources/streams/alerts/StreamAlertConditionResource.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/resources/streams/alerts/StreamAlertConditionResource.java
@@ -52,7 +52,6 @@ import javax.ws.rs.PathParam;
 import javax.ws.rs.Produces;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
-import javax.ws.rs.core.UriBuilder;
 import java.net.URI;
 import java.util.List;
 import java.util.Map;
@@ -99,7 +98,7 @@ public class StreamAlertConditionResource extends RestResource {
         streamService.addAlertCondition(stream, alertCondition);
 
         final Map<String, String> result = ImmutableMap.of("alert_condition_id", alertCondition.getId());
-        final URI alertConditionUri = UriBuilder.fromResource(StreamAlertConditionResource.class)
+        final URI alertConditionUri = getUriBuilderToSelf().path(StreamAlertConditionResource.class)
                 .path("{conditionId}")
                 .build(stream.getId(), alertCondition.getId());
 

--- a/graylog2-server/src/main/java/org/graylog2/rest/resources/streams/alerts/StreamAlertReceiverResource.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/resources/streams/alerts/StreamAlertReceiverResource.java
@@ -53,7 +53,6 @@ import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
 import javax.ws.rs.QueryParam;
 import javax.ws.rs.core.Response;
-import javax.ws.rs.core.UriBuilder;
 import java.net.URI;
 import java.util.Collections;
 import java.util.List;
@@ -106,7 +105,7 @@ public class StreamAlertReceiverResource extends RestResource {
         final Stream stream = streamService.load(streamid);
 
         // TODO What's the actual URI of the created resource?
-        final URI streamAlertUri = UriBuilder.fromResource(StreamAlertResource.class).build(streamid);
+        final URI streamAlertUri = getUriBuilderToSelf().path(StreamAlertResource.class).build(streamid);
 
         // Maybe the list already contains this receiver?
         if (stream.getAlertReceivers().containsKey(type) || stream.getAlertReceivers().get(type) != null) {

--- a/graylog2-server/src/main/java/org/graylog2/rest/resources/streams/rules/StreamRuleResource.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/resources/streams/rules/StreamRuleResource.java
@@ -51,7 +51,6 @@ import javax.ws.rs.PathParam;
 import javax.ws.rs.Produces;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
-import javax.ws.rs.core.UriBuilder;
 import java.net.URI;
 import java.util.List;
 
@@ -86,7 +85,7 @@ public class StreamRuleResource extends RestResource {
 
         final SingleStreamRuleSummaryResponse response = SingleStreamRuleSummaryResponse.create(id);
 
-        final URI streamRuleUri = UriBuilder.fromResource(StreamRuleResource.class)
+        final URI streamRuleUri = getUriBuilderToSelf().path(StreamRuleResource.class)
                 .path("{streamRuleId}")
                 .build(streamId, id);
 

--- a/graylog2-server/src/main/java/org/graylog2/rest/resources/system/GrokResource.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/resources/system/GrokResource.java
@@ -41,7 +41,6 @@ import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
 import javax.ws.rs.Produces;
 import javax.ws.rs.core.Response;
-import javax.ws.rs.core.UriBuilder;
 import java.net.URI;
 
 
@@ -88,7 +87,7 @@ public class GrokResource extends RestResource {
 
         final GrokPattern newPattern = grokPatternService.save(pattern);
 
-        final URI patternUri = UriBuilder.fromMethod(GrokResource.class, "listPattern").build(newPattern.id);
+        final URI patternUri = getUriBuilderToSelf().path(GrokResource.class, "listPattern").build(newPattern.id);
         
         return Response.created(patternUri).entity(newPattern).build();
     }

--- a/graylog2-server/src/main/java/org/graylog2/rest/resources/system/bundles/BundleResource.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/resources/system/bundles/BundleResource.java
@@ -47,7 +47,6 @@ import javax.ws.rs.PathParam;
 import javax.ws.rs.Produces;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
-import javax.ws.rs.core.UriBuilder;
 import java.net.URI;
 
 @RequiresAuthentication
@@ -78,7 +77,7 @@ public class BundleResource extends RestResource {
             final ConfigurationBundle configurationBundle) {
         checkPermission(RestPermissions.BUNDLE_CREATE);
         final ConfigurationBundle bundle = bundleService.insert(configurationBundle);
-        final URI bundleUri = UriBuilder.fromResource(BundleResource.class)
+        final URI bundleUri = getUriBuilderToSelf().path(BundleResource.class)
                 .path("{bundleId}")
                 .build(bundle.getId());
 

--- a/graylog2-server/src/main/java/org/graylog2/rest/resources/system/inputs/ExtractorsResource.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/resources/system/inputs/ExtractorsResource.java
@@ -52,7 +52,6 @@ import javax.validation.constraints.NotNull;
 import javax.ws.rs.*;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
-import javax.ws.rs.core.UriBuilder;
 import java.net.URI;
 import java.util.List;
 import java.util.Map;
@@ -124,7 +123,7 @@ public class ExtractorsResource extends RestResource {
         activityWriter.write(new Activity(msg, ExtractorsResource.class));
 
         final Map<String, String> result = ImmutableMap.of("extractor_id", id);
-        final URI extractorUri = UriBuilder.fromResource(ExtractorsResource.class)
+        final URI extractorUri = getUriBuilderToSelf().path(ExtractorsResource.class)
                 .path("{inputId}")
                 .build(input.getId());
 

--- a/graylog2-server/src/main/java/org/graylog2/rest/resources/system/inputs/InputsResource.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/resources/system/inputs/InputsResource.java
@@ -61,7 +61,6 @@ import javax.ws.rs.PathParam;
 import javax.ws.rs.Produces;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
-import javax.ws.rs.core.UriBuilder;
 import java.net.URI;
 import java.util.List;
 import java.util.Map;
@@ -214,7 +213,7 @@ public class InputsResource extends RestResource {
             inputLauncher.launch(input);
         }
 
-        final URI inputUri = UriBuilder.fromResource(InputsResource.class)
+        final URI inputUri = getUriBuilderToSelf().path(InputsResource.class)
                 .path("{inputId}")
                 .build(id);
 
@@ -297,7 +296,7 @@ public class InputsResource extends RestResource {
             throw new BadRequestException("Couldn't find provided input type", e);
         }
 
-        final URI inputUri = UriBuilder.fromResource(InputsResource.class)
+        final URI inputUri = getUriBuilderToSelf().path(InputsResource.class)
                 .path("{inputId}")
                 .build(inputId);
 
@@ -371,5 +370,15 @@ public class InputsResource extends RestResource {
 
         launchExisting(inputId);
         return Response.status(Response.Status.ACCEPTED).build();
+    }
+
+    @GET
+    @Timed
+    @Path("/locationtest")
+    public Response locationtest() {
+        return Response.created(getUriBuilderToSelf().path(InputsResource.class)
+                        .path("{inputId}")
+                        .build("3ed45367fe")
+        ).build();
     }
 }

--- a/graylog2-server/src/main/java/org/graylog2/rest/resources/system/inputs/InputsResource.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/resources/system/inputs/InputsResource.java
@@ -371,14 +371,4 @@ public class InputsResource extends RestResource {
         launchExisting(inputId);
         return Response.status(Response.Status.ACCEPTED).build();
     }
-
-    @GET
-    @Timed
-    @Path("/locationtest")
-    public Response locationtest() {
-        return Response.created(getUriBuilderToSelf().path(InputsResource.class)
-                        .path("{inputId}")
-                        .build("3ed45367fe")
-        ).build();
-    }
 }

--- a/graylog2-server/src/main/java/org/graylog2/rest/resources/system/inputs/StaticFieldsResource.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/resources/system/inputs/StaticFieldsResource.java
@@ -50,7 +50,6 @@ import javax.ws.rs.PathParam;
 import javax.ws.rs.Produces;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
-import javax.ws.rs.core.UriBuilder;
 import java.net.URI;
 
 @RequiresAuthentication
@@ -112,7 +111,7 @@ public class StaticFieldsResource extends RestResource {
         LOG.info(msg);
         activityWriter.write(new Activity(msg, StaticFieldsResource.class));
 
-        final URI inputUri = UriBuilder.fromResource(InputsResource.class)
+        final URI inputUri = getUriBuilderToSelf().path(InputsResource.class)
                 .path("{inputId}")
                 .build(mongoInput.getId());
 

--- a/graylog2-server/src/main/java/org/graylog2/rest/resources/system/outputs/OutputResource.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/resources/system/outputs/OutputResource.java
@@ -16,7 +16,6 @@
  */
 package org.graylog2.rest.resources.system.outputs;
 
-import autovalue.shaded.com.google.common.common.collect.Sets;
 import com.codahale.metrics.annotation.Timed;
 import com.google.common.collect.ImmutableMap;
 import com.wordnik.swagger.annotations.Api;
@@ -54,7 +53,6 @@ import javax.ws.rs.PathParam;
 import javax.ws.rs.Produces;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
-import javax.ws.rs.core.UriBuilder;
 import java.net.URI;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -150,7 +148,7 @@ public class OutputResource extends RestResource {
         );
 
         final Output output = outputService.create(createOutputRequest, getCurrentUser().getName());
-        final URI outputUri = UriBuilder.fromResource(OutputResource.class)
+        final URI outputUri = getUriBuilderToSelf().path(OutputResource.class)
                 .path("{outputId}")
                 .build(output.getId());
 

--- a/graylog2-server/src/main/java/org/graylog2/rest/resources/system/radio/RadiosResource.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/resources/system/radio/RadiosResource.java
@@ -55,7 +55,6 @@ import javax.ws.rs.PathParam;
 import javax.ws.rs.Produces;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
-import javax.ws.rs.core.UriBuilder;
 import java.net.URI;
 import java.util.List;
 import java.util.Map;
@@ -164,7 +163,7 @@ public class RadiosResource extends RestResource {
         final String id = inputService.save(mongoInput);
 
         final Map<String, String> result = ImmutableMap.of("persist_id", id);
-        final URI radioUri = UriBuilder.fromResource(RadiosResource.class)
+        final URI radioUri = getUriBuilderToSelf().path(RadiosResource.class)
                 .path("{radioId}")
                 .build(id);
 

--- a/graylog2-server/src/main/java/org/graylog2/rest/resources/users/UsersResource.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/resources/users/UsersResource.java
@@ -62,7 +62,6 @@ import javax.ws.rs.PathParam;
 import javax.ws.rs.Produces;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
-import javax.ws.rs.core.UriBuilder;
 import java.net.URI;
 import java.util.Collections;
 import java.util.List;
@@ -166,7 +165,7 @@ public class UsersResource extends RestResource {
         final String id = userService.save(user);
         LOG.debug("Saved user {} with id {}", user.getName(), id);
 
-        final URI userUri = UriBuilder.fromResource(UsersResource.class)
+        final URI userUri = getUriBuilderToSelf().path(UsersResource.class)
                 .path("{username}")
                 .build(user.getName());
 

--- a/graylog2-shared/src/main/java/org/graylog2/shared/initializers/RestApiService.java
+++ b/graylog2-shared/src/main/java/org/graylog2/shared/initializers/RestApiService.java
@@ -66,8 +66,6 @@ import javax.ws.rs.container.DynamicFeature;
 import javax.ws.rs.core.UriBuilder;
 import javax.ws.rs.ext.ContextResolver;
 import javax.ws.rs.ext.ExceptionMapper;
-import javax.ws.rs.ext.MessageBodyReader;
-import javax.ws.rs.ext.MessageBodyWriter;
 import java.io.File;
 import java.net.InetSocketAddress;
 import java.net.URI;

--- a/graylog2-shared/src/main/java/org/graylog2/shared/rest/resources/RestResource.java
+++ b/graylog2-shared/src/main/java/org/graylog2/shared/rest/resources/RestResource.java
@@ -25,6 +25,7 @@ import com.fasterxml.jackson.jaxrs.cfg.ObjectWriterModifier;
 import com.github.joschi.jadconfig.util.Size;
 import com.google.common.collect.ImmutableMap;
 import org.apache.shiro.subject.Subject;
+import org.graylog2.plugin.BaseConfiguration;
 import org.graylog2.plugin.ServerStatus;
 import org.graylog2.shared.security.ShiroSecurityContext;
 import org.graylog2.plugin.database.users.User;
@@ -36,10 +37,16 @@ import javax.inject.Inject;
 import javax.ws.rs.ForbiddenException;
 import javax.ws.rs.QueryParam;
 import javax.ws.rs.core.Context;
+import javax.ws.rs.core.HttpHeaders;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.MultivaluedMap;
 import javax.ws.rs.core.SecurityContext;
+import javax.ws.rs.core.UriBuilder;
+import javax.ws.rs.core.UriInfo;
+import java.net.URI;
+import java.net.URISyntaxException;
 import java.security.Principal;
+import java.util.List;
 import java.util.Map;
 
 public abstract class RestResource {
@@ -54,8 +61,14 @@ public abstract class RestResource {
     @Inject
     protected ServerStatus serverStatus;
 
+    @Inject
+    private BaseConfiguration configuration;
+
     @Context
     SecurityContext securityContext;
+
+    @Context
+    UriInfo uriInfo;
 
     @QueryParam("pretty")
     public void setPrettyPrint(boolean prettyPrint) {
@@ -160,5 +173,12 @@ public abstract class RestResource {
         }
 
         return user;
+    }
+
+    protected UriBuilder getUriBuilderToSelf() {
+        if (configuration.getRestTransportUri() != null) {
+            return UriBuilder.fromUri(configuration.getRestTransportUri());
+        } else
+            return uriInfo.getBaseUriBuilder();
     }
 }

--- a/misc/graylog2.conf
+++ b/misc/graylog2.conf
@@ -37,8 +37,10 @@ rest_listen_uri = http://127.0.0.1:12900/
 
 # REST API transport address. Defaults to the value of rest_listen_uri. Exception: If rest_listen_uri
 # is set to a wildcard IP address (0.0.0.0) the first non-loopback IPv4 system address is used.
-# This will be promoted in the cluster discovery APIs and other nodes may try to connect on this
-# address. (see rest_listen_uri)
+# If set, his will be promoted in the cluster discovery APIs, so other nodes may try to connect on
+# this address and it is used to generate URLs addressing entities in the REST API. (see rest_listen_uri)
+# You will need to define this, if your Graylog server is running behind a HTTP proxy that is rewriting
+# the scheme, host name or URI.
 #rest_transport_uri = http://192.168.1.1:12900/
 
 # Enable CORS headers for REST API. This is necessary for JS-clients accessing the server directly.


### PR DESCRIPTION
Adding helper method in REST resource base class which constructs a
UriBuilder pre-populated with the URI defined in rest_transport_uri.
If rest_transport_uri is not defined, it is either taken from
rest_listen_uri or picked from the first external network interface.

This helps us to generate proper Location headers for newly created
entities and allows the user to override the base URI if the Graylog
server/radio is run behind a proxy that is changing the scheme, host
name or URI of the request.

Fixes #1020