### PR TITLE
Enable configuration of max. HTTP chunk size for HttpTransport

### DIFF
--- a/graylog2-inputs/src/test/java/org/graylog2/inputs/transports/HttpTransportConfigTest.java
+++ b/graylog2-inputs/src/test/java/org/graylog2/inputs/transports/HttpTransportConfigTest.java
@@ -1,0 +1,42 @@
+/**
+ * This file is part of Graylog.
+ *
+ * Graylog is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.graylog2.inputs.transports;
+
+import org.graylog2.plugin.configuration.ConfigurationRequest;
+import org.graylog2.plugin.configuration.fields.ConfigurationField;
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
+
+public class HttpTransportConfigTest {
+
+    @Test
+    public void testGetRequestedConfiguration() throws Exception {
+        HttpTransport.Config config = new HttpTransport.Config();
+
+        final ConfigurationRequest requestedConfiguration = config.getRequestedConfiguration();
+        assertTrue(requestedConfiguration.containsField(HttpTransport.CK_ENABLE_CORS));
+        assertEquals(requestedConfiguration.getField(HttpTransport.CK_ENABLE_CORS).isOptional(), ConfigurationField.Optional.OPTIONAL);
+        assertEquals(requestedConfiguration.getField(HttpTransport.CK_ENABLE_CORS).getDefaultValue(), true);
+
+        assertTrue(requestedConfiguration.containsField(HttpTransport.CK_MAX_CHUNK_SIZE));
+        assertEquals(requestedConfiguration.getField(HttpTransport.CK_MAX_CHUNK_SIZE).isOptional(), ConfigurationField.Optional.OPTIONAL);
+        assertEquals(requestedConfiguration.getField(HttpTransport.CK_MAX_CHUNK_SIZE).getDefaultValue(), 65536);
+
+    }
+}


### PR DESCRIPTION
Add a configuration setting for the maximum HTTP chunk size in HTTP based inputs (using or extending `HttpTransport`), also see [`HttpRequestDecoder`](http://netty.io/3.9/api/org/jboss/netty/handler/codec/http/HttpRequestDecoder.html).