### PR TITLE
Only process fully applied cluster state changes in ClusterStateMonitor

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/indexer/esplugin/ClusterStateMonitor.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/esplugin/ClusterStateMonitor.java
@@ -20,6 +20,7 @@ import com.google.common.collect.Maps;
 import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.cluster.ClusterChangedEvent;
 import org.elasticsearch.cluster.ClusterService;
+import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.ClusterStateListener;
 import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.common.hppc.cursors.ObjectObjectCursor;
@@ -50,6 +51,11 @@ public class ClusterStateMonitor extends org.elasticsearch.common.component.Abst
 
     @Override
     public void clusterChanged(ClusterChangedEvent event) {
+        if(event.previousState().status() != ClusterState.ClusterStateStatus.APPLIED) {
+            // Only process fully applied cluster states
+            return;
+        }
+
         if (event.state().getNodes().masterAndDataNodes().isEmpty()) {
             log.warn("No Elasticsearch data nodes in cluster, cluster is completely offline.");
         }


### PR DESCRIPTION
When starting Graylog, the initial cluster state is unknown and the list of nodes is empty, which triggered a false positive alert that the cluster was down.

Fixes issue 1111111111b (#1023).