### PR TITLE
allow to use log4j-extras classes in log configuration

### DIFF
--- a/graylog2-bootstrap/pom.xml
+++ b/graylog2-bootstrap/pom.xml
@@ -64,6 +64,10 @@
             <groupId>org.graylog.telemetry</groupId>
             <artifactId>graylog-telemetry-plugin</artifactId>
         </dependency>
+        <dependency>
+            <groupId>log4j</groupId>
+            <artifactId>apache-log4j-extras</artifactId>
+        </dependency>
     </dependencies>
 
     <build>

--- a/pom.xml
+++ b/pom.xml
@@ -445,6 +445,11 @@
                 <version>1.2.17</version>
             </dependency>
             <dependency>
+                <groupId>log4j</groupId>
+                <artifactId>apache-log4j-extras</artifactId>
+                <version>1.2.17</version>
+            </dependency>
+            <dependency>
                 <groupId>commons-io</groupId>
                 <artifactId>commons-io</artifactId>
                 <version>2.4</version>


### PR DESCRIPTION
our documentation refers to contrib classes, which, if referenced as documented, prevent proper appender configuration
make log4j:apache-log4j-extras available to bootstrap module

fixes #1042