### PR TITLE
Move global throughput to metrics

### DIFF
--- a/graylog2-bootstrap/src/main/java/org/graylog2/bootstrap/commands/Server.java
+++ b/graylog2-bootstrap/src/main/java/org/graylog2/bootstrap/commands/Server.java
@@ -24,7 +24,6 @@ import com.mongodb.MongoException;
 import io.airlift.airline.Command;
 import io.airlift.airline.Option;
 import org.graylog2.Configuration;
-import org.graylog2.shared.ServerVersion;
 import org.graylog2.UI;
 import org.graylog2.bindings.AlarmCallbackBindings;
 import org.graylog2.bindings.InitializerBindings;
@@ -82,9 +81,6 @@ public class Server extends ServerBootstrap implements Runnable {
     @Option(name = {"-l", "--local"}, description = "Run Graylog in local mode. Only interesting for Graylog developers.")
     private boolean local = false;
 
-    @Option(name = {"-s", "--statistics"}, description = "Print utilization statistics to STDOUT")
-    private boolean stats = false;
-
     @Option(name = {"-r", "--no-retention"}, description = "Do not automatically remove messages from index that are older than the retention time")
     private boolean noRetention = false;
 
@@ -94,10 +90,6 @@ public class Server extends ServerBootstrap implements Runnable {
 
     public boolean isLocal() {
         return local;
-    }
-
-    public boolean isStats() {
-        return stats;
     }
 
     public boolean performRetention() {

--- a/graylog2-plugin-interfaces/src/main/java/org/graylog2/plugin/GlobalMetricNames.java
+++ b/graylog2-plugin-interfaces/src/main/java/org/graylog2/plugin/GlobalMetricNames.java
@@ -24,7 +24,9 @@ package org.graylog2.plugin;
 
 import static com.codahale.metrics.MetricRegistry.name;
 
-public class GlobalMetricNames {
+public final class GlobalMetricNames {
+
+    private GlobalMetricNames() {}
 
     public static final String INPUT_THROUGHPUT = "org.graylog2.throughput.input";
     public static final String INPUT_THROUGHPUT_RATE = name(INPUT_THROUGHPUT, "1-sec-rate");

--- a/graylog2-plugin-interfaces/src/main/java/org/graylog2/plugin/GlobalMetricNames.java
+++ b/graylog2-plugin-interfaces/src/main/java/org/graylog2/plugin/GlobalMetricNames.java
@@ -1,0 +1,35 @@
+/**
+ * The MIT License
+ * Copyright (c) 2012 Graylog, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.graylog2.plugin;
+
+import static com.codahale.metrics.MetricRegistry.name;
+
+public class GlobalMetricNames {
+
+    public static final String INPUT_THROUGHPUT = "org.graylog.throughput.input";
+    public static final String INPUT_THROUGHPUT_RATE = name(INPUT_THROUGHPUT, "1-sec-rate");
+
+    public static final String OUTPUT_THROUGHPUT = "org.graylog.throughput.output";
+    public static final String OUTPUT_THROUGHPUT_RATE = name(OUTPUT_THROUGHPUT, "1-sec-rate");
+
+}

--- a/graylog2-plugin-interfaces/src/main/java/org/graylog2/plugin/GlobalMetricNames.java
+++ b/graylog2-plugin-interfaces/src/main/java/org/graylog2/plugin/GlobalMetricNames.java
@@ -26,10 +26,10 @@ import static com.codahale.metrics.MetricRegistry.name;
 
 public class GlobalMetricNames {
 
-    public static final String INPUT_THROUGHPUT = "org.graylog.throughput.input";
+    public static final String INPUT_THROUGHPUT = "org.graylog2.throughput.input";
     public static final String INPUT_THROUGHPUT_RATE = name(INPUT_THROUGHPUT, "1-sec-rate");
 
-    public static final String OUTPUT_THROUGHPUT = "org.graylog.throughput.output";
+    public static final String OUTPUT_THROUGHPUT = "org.graylog2.throughput.output";
     public static final String OUTPUT_THROUGHPUT_RATE = name(OUTPUT_THROUGHPUT, "1-sec-rate");
 
 }

--- a/graylog2-plugin-interfaces/src/main/java/org/graylog2/plugin/ServerStatus.java
+++ b/graylog2-plugin-interfaces/src/main/java/org/graylog2/plugin/ServerStatus.java
@@ -25,7 +25,6 @@ package org.graylog2.plugin;
 import com.google.common.collect.Sets;
 import com.google.common.eventbus.EventBus;
 import com.google.common.util.concurrent.Uninterruptibles;
-import javax.inject.Inject;
 import org.graylog2.plugin.lifecycles.Lifecycle;
 import org.graylog2.plugin.system.NodeId;
 import org.joda.time.DateTime;
@@ -33,6 +32,7 @@ import org.joda.time.DateTimeZone;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import javax.inject.Inject;
 import javax.inject.Singleton;
 import java.util.Arrays;
 import java.util.Set;
@@ -51,7 +51,6 @@ public class ServerStatus {
         SERVER,
         RADIO,
         MASTER,
-        STATSMODE,
         LOCALMODE
     }
 
@@ -201,14 +200,6 @@ public class ServerStatus {
 
     public void unlockProcessingPause() {
         processingPauseLocked.set(false);
-    }
-
-    public void setStatsMode(boolean statsMode) {
-        if (statsMode) {
-            addCapability(Capability.STATSMODE);
-        } else {
-            removeCapability(Capability.STATSMODE);
-        }
     }
 
     private ServerStatus removeCapability(Capability capability) {

--- a/graylog2-plugin-interfaces/src/test/java/org/graylog2/plugin/ServerStatusTest.java
+++ b/graylog2-plugin-interfaces/src/test/java/org/graylog2/plugin/ServerStatusTest.java
@@ -177,8 +177,8 @@ public class ServerStatusTest {
 
     @Test
     public void testAddCapabilities() throws Exception {
-        assertEquals(status.addCapabilities(ServerStatus.Capability.LOCALMODE, ServerStatus.Capability.STATSMODE), status);
-        assertTrue(status.hasCapabilities(ServerStatus.Capability.MASTER, ServerStatus.Capability.LOCALMODE, ServerStatus.Capability.STATSMODE));
+        assertEquals(status.addCapabilities(ServerStatus.Capability.LOCALMODE), status);
+        assertTrue(status.hasCapabilities(ServerStatus.Capability.MASTER, ServerStatus.Capability.LOCALMODE));
     }
 
     @Test
@@ -234,15 +234,6 @@ public class ServerStatusTest {
 
         status.unlockProcessingPause();
         assertFalse(status.processingPauseLocked());
-    }
-
-    @Test
-    public void testSetStatsMode() throws Exception {
-        status.setStatsMode(false);
-        assertFalse(status.hasCapability(ServerStatus.Capability.STATSMODE));
-
-        status.setStatsMode(true);
-        assertTrue(status.hasCapability(ServerStatus.Capability.STATSMODE));
     }
 
     @Test

--- a/graylog2-server/src/main/java/org/graylog2/buffers/processors/OutputBufferProcessor.java
+++ b/graylog2-server/src/main/java/org/graylog2/buffers/processors/OutputBufferProcessor.java
@@ -53,8 +53,8 @@ public class OutputBufferProcessor implements WorkHandler<MessageEvent> {
 
     private static final Logger LOG = LoggerFactory.getLogger(OutputBufferProcessor.class);
 
-    public static final String INCOMING_MESSAGES_METRICNAME = name(OutputBufferProcessor.class, "incomingMessages");
-    public static final String PROCESS_TIME_METRICNAME = name(OutputBufferProcessor.class, "processTime");
+    private static final String INCOMING_MESSAGES_METRICNAME = name(OutputBufferProcessor.class, "incomingMessages");
+    private static final String PROCESS_TIME_METRICNAME = name(OutputBufferProcessor.class, "processTime");
 
     private final ExecutorService executor;
 

--- a/graylog2-server/src/main/java/org/graylog2/outputs/ElasticSearchOutput.java
+++ b/graylog2-server/src/main/java/org/graylog2/outputs/ElasticSearchOutput.java
@@ -22,7 +22,6 @@ import com.codahale.metrics.Timer;
 import com.google.common.base.Joiner;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Ordering;
-import javax.inject.Inject;
 import com.google.inject.assistedinject.Assisted;
 import com.google.inject.assistedinject.AssistedInject;
 import org.graylog2.indexer.messages.Messages;
@@ -35,6 +34,7 @@ import org.graylog2.shared.journal.Journal;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import javax.inject.Inject;
 import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -42,6 +42,9 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import static com.codahale.metrics.MetricRegistry.name;
 
 public class ElasticSearchOutput implements MessageOutput {
+    public static final String WRITES_METRICNAME = name(ElasticSearchOutput.class, "writes");
+    public static final String PROCESS_TIME_METRICNAME = name(ElasticSearchOutput.class, "processTime");
+
     private static final String NAME = "ElasticSearch Output";
     private static final Logger LOG = LoggerFactory.getLogger(ElasticSearchOutput.class);
 
@@ -67,8 +70,8 @@ public class ElasticSearchOutput implements MessageOutput {
         this.messages = messages;
         this.journal = journal;
         // Only constructing metrics here. write() get's another Core reference. (because this technically is a plugin)
-        this.writes = metricRegistry.meter(name(ElasticSearchOutput.class, "writes"));
-        this.processTime = metricRegistry.timer(name(ElasticSearchOutput.class, "processTime"));
+        this.writes = metricRegistry.meter(WRITES_METRICNAME);
+        this.processTime = metricRegistry.timer(PROCESS_TIME_METRICNAME);
 
         // Should be set in initialize once this becomes a real plugin.
         isRunning.set(true);

--- a/graylog2-server/src/main/java/org/graylog2/outputs/ElasticSearchOutput.java
+++ b/graylog2-server/src/main/java/org/graylog2/outputs/ElasticSearchOutput.java
@@ -42,8 +42,8 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import static com.codahale.metrics.MetricRegistry.name;
 
 public class ElasticSearchOutput implements MessageOutput {
-    public static final String WRITES_METRICNAME = name(ElasticSearchOutput.class, "writes");
-    public static final String PROCESS_TIME_METRICNAME = name(ElasticSearchOutput.class, "processTime");
+    private static final String WRITES_METRICNAME = name(ElasticSearchOutput.class, "writes");
+    private static final String PROCESS_TIME_METRICNAME = name(ElasticSearchOutput.class, "processTime");
 
     private static final String NAME = "ElasticSearch Output";
     private static final Logger LOG = LoggerFactory.getLogger(ElasticSearchOutput.class);

--- a/graylog2-shared/src/main/java/org/graylog2/periodical/ThroughputCalculator.java
+++ b/graylog2-shared/src/main/java/org/graylog2/periodical/ThroughputCalculator.java
@@ -1,0 +1,135 @@
+/**
+ * This file is part of Graylog.
+ *
+ * Graylog is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.graylog2.periodical;
+
+import com.codahale.metrics.Counter;
+import com.codahale.metrics.Gauge;
+import com.codahale.metrics.MetricRegistry;
+import com.google.common.collect.Iterables;
+import org.graylog2.plugin.periodical.Periodical;
+import org.graylog2.plugin.GlobalMetricNames;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.inject.Inject;
+import java.util.SortedMap;
+import java.util.concurrent.atomic.AtomicLong;
+
+import static org.graylog2.shared.metrics.MetricUtils.filterSingleMetric;
+
+public class ThroughputCalculator extends Periodical {
+    private static final Logger log = LoggerFactory.getLogger(ThroughputCalculator.class);
+
+    private final MetricRegistry metricRegistry;
+    private long prevOutputCount = 0;
+    private final AtomicLong outputCountAvgLastSecond = new AtomicLong(0);
+    private long prevInputCount = 0;
+    private AtomicLong inputCountAvgLastSecond = new AtomicLong(0);
+
+    @Inject
+    public ThroughputCalculator(MetricRegistry metricRegistry) {
+        this.metricRegistry = metricRegistry;
+        try {
+            metricRegistry.register(GlobalMetricNames.OUTPUT_THROUGHPUT_RATE, new Gauge<Long>() {
+                @Override
+                public Long getValue() {
+                    return outputCountAvgLastSecond.get();
+                }
+            });
+
+            metricRegistry.register(GlobalMetricNames.INPUT_THROUGHPUT_RATE, new Gauge<Long>() {
+                @Override
+                public Long getValue() {
+                    return inputCountAvgLastSecond.get();
+                }
+            });
+
+        } catch (Exception e) {
+            log.error("Unable to register metric", e);
+        }
+    }
+
+    @Override
+    public boolean runsForever() {
+        return false;
+    }
+
+    @Override
+    public boolean stopOnGracefulShutdown() {
+        return false;
+    }
+
+    @Override
+    public boolean masterOnly() {
+        return false;
+    }
+
+    @Override
+    public boolean startOnThisNode() {
+        return true;
+    }
+
+    @Override
+    public boolean isDaemon() {
+        return true;
+    }
+
+    @Override
+    public int getInitialDelaySeconds() {
+        return 0;
+    }
+
+    @Override
+    public int getPeriodSeconds() {
+        return 1;
+    }
+
+    @Override
+    protected Logger getLogger() {
+        return log;
+    }
+
+    @Override
+    public void doRun() {
+        final SortedMap<String, Counter> counters = metricRegistry.getCounters(
+                filterSingleMetric(GlobalMetricNames.OUTPUT_THROUGHPUT)
+        );
+
+        final Counter outputThroughput = Iterables.getOnlyElement(counters.values(), null);
+        if (outputThroughput == null) {
+            log.debug("Could not find throughput meter '{}'. Trying again later.", GlobalMetricNames.OUTPUT_THROUGHPUT);
+        } else {
+            final long currentOutputThroughput = outputThroughput.getCount();
+            outputCountAvgLastSecond.set(currentOutputThroughput - prevOutputCount);
+            prevOutputCount = currentOutputThroughput;
+        }
+
+        // rinse and repeat for input throughput
+        final SortedMap<String, Counter> inputCounters = metricRegistry.getCounters(
+                filterSingleMetric(GlobalMetricNames.INPUT_THROUGHPUT)
+        );
+
+        final Counter inputThroughput = Iterables.getOnlyElement(inputCounters.values(), null);
+        if (inputThroughput == null) {
+            log.debug("Could not find throughput meter '{}'. Trying again later.", GlobalMetricNames.INPUT_THROUGHPUT);
+        } else {
+            final long currentInputThroughput = inputThroughput.getCount();
+            inputCountAvgLastSecond.set(currentInputThroughput - prevInputCount);
+            prevInputCount = currentInputThroughput;
+        }
+    }
+}

--- a/graylog2-shared/src/main/java/org/graylog2/periodical/ThroughputCounterManagerThread.java
+++ b/graylog2-shared/src/main/java/org/graylog2/periodical/ThroughputCounterManagerThread.java
@@ -16,15 +16,17 @@
  */
 package org.graylog2.periodical;
 
-import javax.inject.Inject;
 import org.graylog2.plugin.periodical.Periodical;
 import org.graylog2.shared.stats.ThroughputStats;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import javax.inject.Inject;
+
 /**
  * @author Lennart Koopmann <lennart@torch.sh>
  */
+@Deprecated
 public class ThroughputCounterManagerThread extends Periodical {
     private static final Logger LOG = LoggerFactory.getLogger(ThroughputCounterManagerThread.class);
     private final ThroughputStats throughputStats;

--- a/graylog2-shared/src/main/java/org/graylog2/shared/bindings/SharedPeriodicalBindings.java
+++ b/graylog2-shared/src/main/java/org/graylog2/shared/bindings/SharedPeriodicalBindings.java
@@ -18,6 +18,7 @@ package org.graylog2.shared.bindings;
 
 import com.google.inject.AbstractModule;
 import com.google.inject.multibindings.Multibinder;
+import org.graylog2.periodical.ThroughputCalculator;
 import org.graylog2.periodical.ThroughputCounterManagerThread;
 import org.graylog2.plugin.periodical.Periodical;
 
@@ -29,5 +30,7 @@ public class SharedPeriodicalBindings extends AbstractModule {
     protected void configure() {
         Multibinder<Periodical> periodicalBinder = Multibinder.newSetBinder(binder(), Periodical.class);
         periodicalBinder.addBinding().to(ThroughputCounterManagerThread.class);
+        periodicalBinder.addBinding().to(ThroughputCalculator.class);
+
     }
 }

--- a/graylog2-shared/src/main/java/org/graylog2/shared/metrics/MetricUtils.java
+++ b/graylog2-shared/src/main/java/org/graylog2/shared/metrics/MetricUtils.java
@@ -168,7 +168,7 @@ public class MetricUtils {
         return new SingleMetricFilter(name);
     }
 
-    private static class SingleMetricFilter implements MetricFilter {
+    public static class SingleMetricFilter implements MetricFilter {
         private final String allowedName;
         public SingleMetricFilter(String allowedName) {
             this.allowedName = allowedName;

--- a/graylog2-shared/src/main/java/org/graylog2/shared/metrics/MetricUtils.java
+++ b/graylog2-shared/src/main/java/org/graylog2/shared/metrics/MetricUtils.java
@@ -19,6 +19,7 @@ package org.graylog2.shared.metrics;
 import com.codahale.metrics.Histogram;
 import com.codahale.metrics.Meter;
 import com.codahale.metrics.Metric;
+import com.codahale.metrics.MetricFilter;
 import com.codahale.metrics.Timer;
 import com.google.common.collect.Maps;
 import org.graylog2.rest.models.metrics.responses.RateMetricsResponse;
@@ -163,4 +164,19 @@ public class MetricUtils {
         return metrics;
     }
 
+    public static MetricFilter filterSingleMetric(String name) {
+        return new SingleMetricFilter(name);
+    }
+
+    private static class SingleMetricFilter implements MetricFilter {
+        private final String allowedName;
+        public SingleMetricFilter(String allowedName) {
+            this.allowedName = allowedName;
+        }
+
+        @Override
+        public boolean matches(String name, Metric metric) {
+            return allowedName.equals(name);
+        }
+    }
 }

--- a/graylog2-shared/src/main/java/org/graylog2/shared/rest/resources/system/ThroughputResource.java
+++ b/graylog2-shared/src/main/java/org/graylog2/shared/rest/resources/system/ThroughputResource.java
@@ -16,31 +16,36 @@
  */
 package org.graylog2.shared.rest.resources.system;
 
+import com.codahale.metrics.Gauge;
+import com.codahale.metrics.MetricRegistry;
 import com.codahale.metrics.annotation.Timed;
-import org.apache.shiro.authz.annotation.RequiresAuthentication;
-import org.apache.shiro.authz.annotation.RequiresPermissions;
+import com.google.common.collect.Iterables;
 import com.wordnik.swagger.annotations.Api;
 import com.wordnik.swagger.annotations.ApiOperation;
-import org.graylog2.shared.rest.resources.RestResource;
+import org.apache.shiro.authz.annotation.RequiresAuthentication;
+import org.apache.shiro.authz.annotation.RequiresPermissions;
 import org.graylog2.rest.models.system.responses.Throughput;
+import org.graylog2.shared.metrics.MetricUtils;
+import org.graylog2.shared.rest.resources.RestResource;
 import org.graylog2.shared.security.RestPermissions;
-import org.graylog2.shared.stats.ThroughputStats;
+import org.graylog2.plugin.GlobalMetricNames;
 
 import javax.inject.Inject;
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
 import javax.ws.rs.core.MediaType;
+import java.util.SortedMap;
 
 @RequiresAuthentication
 @Api(value = "System/Throughput", description = "Message throughput of this node")
 @Path("/system/throughput")
 public class ThroughputResource extends RestResource {
-    private final ThroughputStats throughputStats;
+    private final MetricRegistry metricRegistry;
 
     @Inject
-    public ThroughputResource(ThroughputStats throughputStats) {
-        this.throughputStats = throughputStats;
+    public ThroughputResource(MetricRegistry metricRegistry) {
+        this.metricRegistry = metricRegistry;
     }
 
     @GET
@@ -49,6 +54,13 @@ public class ThroughputResource extends RestResource {
     @ApiOperation(value = "Current throughput of this node in messages per second")
     @Produces(MediaType.APPLICATION_JSON)
     public Throughput total() {
-        return Throughput.create(throughputStats.getCurrentThroughput());
+        final SortedMap<String, Gauge> gauges = metricRegistry.getGauges(MetricUtils.filterSingleMetric(
+                GlobalMetricNames.OUTPUT_THROUGHPUT_RATE));
+        final Gauge gauge = Iterables.getOnlyElement(gauges.values(), null);
+        if (gauge == null || !(gauge.getValue() instanceof Long)) {
+            return Throughput.create(0);
+        } else {
+            return Throughput.create((Long) gauge.getValue());
+        }
     }
 }

--- a/graylog2-shared/src/main/java/org/graylog2/shared/stats/ThroughputStats.java
+++ b/graylog2-shared/src/main/java/org/graylog2/shared/stats/ThroughputStats.java
@@ -16,7 +16,6 @@
  */
 package org.graylog2.shared.stats;
 
-import com.google.common.collect.Maps;
 import org.cliffc.high_scale_lib.Counter;
 
 import java.util.HashMap;
@@ -27,10 +26,10 @@ import java.util.concurrent.atomic.AtomicReference;
 /**
  * @author Dennis Oelkers <dennis@torch.sh>
  */
+@Deprecated
 public class ThroughputStats {
     private long currentThroughput;
     private final Counter throughputCounter;
-    private final Counter benchmarkCounter;
     private final AtomicReference<ConcurrentHashMap<String, Counter>> streamThroughput;
     private final AtomicReference<HashMap<String, Counter>> currentStreamThroughput;
 
@@ -38,30 +37,22 @@ public class ThroughputStats {
     public ThroughputStats() {
         this.currentThroughput = 0;
         this.throughputCounter = new Counter();
-        this.benchmarkCounter = new Counter();
-        this.streamThroughput = new AtomicReference<ConcurrentHashMap<String, Counter>>(new ConcurrentHashMap<String, Counter>());
-        this.currentStreamThroughput =  new AtomicReference<HashMap<String, Counter>>();
-
+        this.streamThroughput = new AtomicReference<>(new ConcurrentHashMap<String, Counter>());
+        this.currentStreamThroughput =  new AtomicReference<>();
     }
 
+    @Deprecated
     public long getCurrentThroughput() {
         return currentThroughput;
     }
 
+    @Deprecated
     public Counter getThroughputCounter() {
         return throughputCounter;
     }
 
-    public Counter getBenchmarkCounter() {
-        return benchmarkCounter;
-    }
-
     public void setCurrentThroughput(long currentThroughput) {
         this.currentThroughput = currentThroughput;
-    }
-
-    public AtomicReference<ConcurrentHashMap<String, Counter>> getStreamThroughput() {
-        return streamThroughput;
     }
 
     public Map<String, Counter> cycleStreamThroughput() {
@@ -82,12 +73,4 @@ public class ThroughputStats {
         return currentStreamThroughput.get();
     }
 
-    public Map<String, Long> getCurrentStreamThroughputValues() {
-        Map<String, Long> values = Maps.newHashMap();
-        for (Map.Entry<String, Counter> counter : currentStreamThroughput.get().entrySet()) {
-            values.put(counter.getKey(), counter.getValue().longValue());
-        }
-
-        return values;
-    }
 }

--- a/graylog2-shared/src/test/java/org/graylog2/shared/metrics/SingleMetricFilterTest.java
+++ b/graylog2-shared/src/test/java/org/graylog2/shared/metrics/SingleMetricFilterTest.java
@@ -1,0 +1,38 @@
+/**
+ * This file is part of Graylog.
+ *
+ * Graylog is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.graylog2.shared.metrics;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class SingleMetricFilterTest {
+
+    @Test
+    public void testMatches() throws Exception {
+        final MetricUtils.SingleMetricFilter filtersAllowed = new MetricUtils.SingleMetricFilter("allowed");
+
+        // metric is not used and can be null
+        assertTrue(filtersAllowed.matches("allowed", null));
+        // the match is case sensitive
+        assertFalse(filtersAllowed.matches("Allowed", null));
+        // the name must match
+        assertFalse(filtersAllowed.matches("disallowed", null));
+
+    }
+}


### PR DESCRIPTION
Use the metric registry for global node throughput so we can use bulk calls to retrieve them in the web interface.

addresses part of #1071 