### PR TITLE
Allow mixed plain and quoted k/v pairs in TokenizerConverter

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/inputs/converters/TokenizerConverter.java
+++ b/graylog2-server/src/main/java/org/graylog2/inputs/converters/TokenizerConverter.java
@@ -16,25 +16,19 @@
  */
 package org.graylog2.inputs.converters;
 
-import com.google.common.base.CharMatcher;
-import com.google.common.collect.Maps;
+import com.google.common.collect.ImmutableMap;
 import org.graylog2.plugin.inputs.Converter;
 
+import java.util.Collections;
 import java.util.Map;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-/**
- * @author Lennart Koopmann <lennart@torch.sh>
- */
-public class TokenizerConverter extends Converter {
+import static com.google.common.base.Strings.isNullOrEmpty;
 
-    private static final Pattern p = Pattern.compile("[a-zA-Z0-9_-]*");
-    private static final Pattern kvPattern = Pattern.compile("\\s?=\\s?");
-    private static final Pattern spacePattern = Pattern.compile(" ");
-    private static final Pattern quotedValuePattern = Pattern.compile("([a-zA-Z0-9_-]+=\"[^\"]+\")");
-    private static final CharMatcher QUOTE_MATCHER = CharMatcher.is('"').precomputed();
-    private static final CharMatcher EQUAL_SIGN_MATCHER = CharMatcher.is('=').precomputed();
+public class TokenizerConverter extends Converter {
+    // ┻━┻ ︵ ¯\(ツ)/¯ ︵ ┻━┻
+    private static final Pattern PATTERN = Pattern.compile("(?:^|\\s)(?:([\\w-]+)\\s?=\\s?((?:\"[^\"]+\")|(?:[\\S]+)))");
 
     public TokenizerConverter(Map<String, Object> config) {
         super(Type.TOKENIZER, config);
@@ -42,44 +36,38 @@ public class TokenizerConverter extends Converter {
 
     @Override
     public Object convert(String value) {
-        if (value == null || value.isEmpty()) {
+        if (isNullOrEmpty(value)) {
             return value;
         }
 
-        Map<String, String> fields = Maps.newHashMap();
-
         if (value.contains("=")) {
-            final String nmsg = kvPattern.matcher(value).replaceAll("=");
-            if (nmsg.contains("=\"")) {
-                Matcher m = quotedValuePattern.matcher(nmsg);
-                while (m.find()) {
-                    String[] kv = m.group(1).split("=");
-                    if (kv.length == 2 && p.matcher(kv[0]).matches()) {
-                        fields.put(kv[0].trim(), QUOTE_MATCHER.removeFrom(kv[1]).trim());
-                    }
-                }
-            } else {
-                final String[] parts = spacePattern.split(nmsg);
-                if (parts != null) {
-                    for (String part : parts) {
-                        if (part.contains("=") && EQUAL_SIGN_MATCHER.countIn(part) == 1) {
-                            String[] kv = part.split("=");
-                            if (kv.length == 2 && p.matcher(kv[0]).matches() && !fields.containsKey(kv[0])) {
-                                fields.put(kv[0].trim(), kv[1].trim());
-                            }
-                        }
-                    }
-                }
-            }
-        }
+            final ImmutableMap.Builder<String, String> fields = ImmutableMap.builder();
 
-        return fields;
+            Matcher m = PATTERN.matcher(value);
+            while (m.find()) {
+                if (m.groupCount() != 2) {
+                    continue;
+                }
+
+                fields.put(removeQuotes(m.group(1)), removeQuotes(m.group(2)));
+            }
+
+            return fields.build();
+        } else {
+            return Collections.emptyMap();
+        }
+    }
+
+    private String removeQuotes(String s) {
+        if (s.startsWith("\"")  && s.endsWith("\"")) {
+            return s.substring(1, s.length() - 1);
+        } else {
+            return s;
+        }
     }
 
     @Override
     public boolean buildsMultipleFields() {
         return true;
     }
-
-
 }

--- a/graylog2-server/src/test/java/org/graylog2/inputs/converters/TokenizerConverterTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/inputs/converters/TokenizerConverterTest.java
@@ -22,6 +22,7 @@ import org.junit.Test;
 import java.util.HashMap;
 import java.util.Map;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 
@@ -157,5 +158,43 @@ public class TokenizerConverterTest {
 
         assertEquals(1, result.size());
         assertEquals("123", result.get("_id"));
+    }
+
+    @Test
+    public void testFilterWithMixedQuotedAndPlainValues() {
+        TokenizerConverter f = new TokenizerConverter(new HashMap<String, Object>());
+        @SuppressWarnings("unchecked")
+        Map<String, String> result = (Map<String, String>) f.convert("otters in k1=\"v1\" k2=v2 more otters");
+
+        assertThat(result)
+                .hasSize(2)
+                .containsEntry("k1", "v1")
+                .containsEntry("k2", "v2");
+    }
+
+    @Test
+    public void testFilterWithKeysIncludingDashOrUnderscore() {
+        TokenizerConverter f = new TokenizerConverter(new HashMap<String, Object>());
+        @SuppressWarnings("unchecked")
+        Map<String, String> result = (Map<String, String>) f.convert("otters in k-1=v1 k_2=v2 _k3=v3 more otters");
+
+        assertThat(result)
+                .hasSize(3)
+                .containsEntry("k-1", "v1")
+                .containsEntry("k_2", "v2")
+                .containsEntry("_k3", "v3");
+    }
+
+    @Test
+    public void testFilterRetainsWhitespaceInQuotedValues() {
+        TokenizerConverter f = new TokenizerConverter(new HashMap<String, Object>());
+        @SuppressWarnings("unchecked")
+        Map<String, String> result = (Map<String, String>) f.convert("otters in k1= v1  k2=\" v2\" k3=\" v3 \" more otters");
+
+        assertThat(result)
+                .hasSize(3)
+                .containsEntry("k1", "v1")
+                .containsEntry("k2", " v2")
+                .containsEntry("k3", " v3 ");
     }
 }


### PR DESCRIPTION
TokenizerConverter previously only extracted either plain k/v pairs ('k1=v1') or quoted k/v pairs ('k2="v2"') in strings but not both (the logic was skewed towards quoted k/v pairs).

The new implementation allows a mix of both styles ('k1=v1 k2="v2"') and also allows quoted keys ('"k1"=v1 "k2"="v2"') and retains whitespace characters inside quoted keys and values.

Fixes #1083.