### PR TITLE
Support testing extractors through POST

### DIFF
--- a/graylog2-rest-client/src/main/java/org/graylog2/restclient/models/api/requests/tools/GrokTestRequest.java
+++ b/graylog2-rest-client/src/main/java/org/graylog2/restclient/models/api/requests/tools/GrokTestRequest.java
@@ -1,0 +1,26 @@
+/**
+ * This file is part of Graylog.
+ *
+ * Graylog is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.graylog2.restclient.models.api.requests.tools;
+
+import org.graylog2.restclient.models.api.requests.ApiRequest;
+
+public class GrokTestRequest extends ApiRequest {
+    public String string;
+
+    public String pattern;
+}

--- a/graylog2-rest-client/src/main/java/org/graylog2/restclient/models/api/requests/tools/RegexTestRequest.java
+++ b/graylog2-rest-client/src/main/java/org/graylog2/restclient/models/api/requests/tools/RegexTestRequest.java
@@ -1,0 +1,26 @@
+/**
+ * This file is part of Graylog.
+ *
+ * Graylog is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.graylog2.restclient.models.api.requests.tools;
+
+import org.graylog2.restclient.models.api.requests.ApiRequest;
+
+public class RegexTestRequest extends ApiRequest {
+    public String string;
+
+    public String regex;
+}

--- a/graylog2-rest-client/src/main/java/org/graylog2/restclient/models/api/requests/tools/SplitAndIndexTestRequest.java
+++ b/graylog2-rest-client/src/main/java/org/graylog2/restclient/models/api/requests/tools/SplitAndIndexTestRequest.java
@@ -1,0 +1,30 @@
+/**
+ * This file is part of Graylog.
+ *
+ * Graylog is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.graylog2.restclient.models.api.requests.tools;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import org.graylog2.restclient.models.api.requests.ApiRequest;
+
+public class SplitAndIndexTestRequest extends ApiRequest {
+    public String string;
+
+    @JsonProperty("split_by")
+    public String splitBy;
+
+    public int index;
+}

--- a/graylog2-rest-client/src/main/java/org/graylog2/restclient/models/api/requests/tools/SubstringTestRequest.java
+++ b/graylog2-rest-client/src/main/java/org/graylog2/restclient/models/api/requests/tools/SubstringTestRequest.java
@@ -1,0 +1,28 @@
+/**
+ * This file is part of Graylog.
+ *
+ * Graylog is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.graylog2.restclient.models.api.requests.tools;
+
+import org.graylog2.restclient.models.api.requests.ApiRequest;
+
+public class SubstringTestRequest extends ApiRequest {
+    public String string;
+
+    public int start;
+
+    public int end;
+}

--- a/graylog2-server/src/main/java/org/graylog2/rest/resources/tools/GrokTesterResource.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/resources/tools/GrokTesterResource.java
@@ -24,13 +24,17 @@ import oi.thekraken.grok.api.exception.GrokException;
 import org.apache.shiro.authz.annotation.RequiresAuthentication;
 import org.graylog2.grok.GrokPattern;
 import org.graylog2.grok.GrokPatternService;
+import org.graylog2.rest.resources.tools.requests.GrokTestRequest;
 import org.graylog2.rest.resources.tools.responses.GrokTesterResponse;
 import org.graylog2.shared.rest.resources.RestResource;
 import org.hibernate.validator.constraints.NotEmpty;
 
 import javax.inject.Inject;
+import javax.validation.Valid;
 import javax.validation.constraints.NotNull;
+import javax.ws.rs.Consumes;
 import javax.ws.rs.GET;
+import javax.ws.rs.POST;
 import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
 import javax.ws.rs.QueryParam;
@@ -54,9 +58,21 @@ public class GrokTesterResource extends RestResource {
 
     @GET
     @Timed
-    public Object grokTest(@QueryParam("pattern") @NotEmpty String pattern,
-                           @QueryParam("string") @NotNull String string) throws GrokException {
+    public GrokTesterResponse grokTest(@QueryParam("pattern") @NotEmpty String pattern,
+                                       @QueryParam("string") @NotNull String string) throws GrokException {
 
+        return doTestGrok(string, pattern);
+    }
+
+    @POST
+    @Timed
+    @Consumes(MediaType.APPLICATION_JSON)
+    @Produces(MediaType.APPLICATION_JSON)
+    public GrokTesterResponse testGrok(@Valid @NotNull GrokTestRequest grokTestRequest) throws GrokException {
+        return doTestGrok(grokTestRequest.string(), grokTestRequest.pattern());
+    }
+
+    private GrokTesterResponse doTestGrok(String string, String pattern) throws GrokException {
         final Set<GrokPattern> grokPatterns = grokPatternService.loadAll();
 
         final Grok grok = new Grok();

--- a/graylog2-server/src/main/java/org/graylog2/rest/resources/tools/RegexTesterResource.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/resources/tools/RegexTesterResource.java
@@ -14,16 +14,21 @@
  * You should have received a copy of the GNU General Public License
  * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
  */
+
 package org.graylog2.rest.resources.tools;
 
 import com.codahale.metrics.annotation.Timed;
 import org.apache.shiro.authz.annotation.RequiresAuthentication;
-import org.graylog2.shared.rest.resources.RestResource;
+import org.graylog2.rest.resources.tools.requests.RegexTestRequest;
 import org.graylog2.rest.resources.tools.responses.RegexTesterResponse;
+import org.graylog2.shared.rest.resources.RestResource;
 import org.hibernate.validator.constraints.NotEmpty;
 
+import javax.validation.Valid;
 import javax.validation.constraints.NotNull;
+import javax.ws.rs.Consumes;
 import javax.ws.rs.GET;
+import javax.ws.rs.POST;
 import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
 import javax.ws.rs.QueryParam;
@@ -39,7 +44,19 @@ public class RegexTesterResource extends RestResource {
     @Produces(MediaType.APPLICATION_JSON)
     public RegexTesterResponse regexTester(@QueryParam("regex") @NotEmpty String regex,
                                            @QueryParam("string") @NotNull String string) {
-        final Matcher matcher = Pattern.compile(regex, Pattern.DOTALL).matcher(string);
+        return doTestRegex(string, regex);
+    }
+
+    @POST
+    @Timed
+    @Consumes(MediaType.APPLICATION_JSON)
+    @Produces(MediaType.APPLICATION_JSON)
+    public RegexTesterResponse testRegex(@Valid @NotNull RegexTestRequest regexTestRequest) {
+        return doTestRegex(regexTestRequest.string(), regexTestRequest.regex());
+    }
+
+    private RegexTesterResponse doTestRegex(String example, String regex) {
+        final Matcher matcher = Pattern.compile(regex, Pattern.DOTALL).matcher(example);
         boolean matched = matcher.find();
 
         // Get the first matched group.
@@ -50,6 +67,6 @@ public class RegexTesterResource extends RestResource {
             match = null;
         }
 
-        return RegexTesterResponse.create(matched, match, regex, string);
+        return RegexTesterResponse.create(matched, match, regex, example);
     }
 }

--- a/graylog2-server/src/main/java/org/graylog2/rest/resources/tools/SplitAndIndexTesterResource.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/resources/tools/SplitAndIndexTesterResource.java
@@ -19,12 +19,16 @@ package org.graylog2.rest.resources.tools;
 import com.codahale.metrics.annotation.Timed;
 import org.apache.shiro.authz.annotation.RequiresAuthentication;
 import org.graylog2.inputs.extractors.SplitAndIndexExtractor;
-import org.graylog2.shared.rest.resources.RestResource;
+import org.graylog2.rest.resources.tools.requests.SplitAndIndexTestRequest;
 import org.graylog2.rest.resources.tools.responses.SplitAndIndexTesterResponse;
+import org.graylog2.shared.rest.resources.RestResource;
 
+import javax.validation.Valid;
 import javax.validation.constraints.Min;
 import javax.validation.constraints.NotNull;
+import javax.ws.rs.Consumes;
 import javax.ws.rs.GET;
+import javax.ws.rs.POST;
 import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
 import javax.ws.rs.QueryParam;
@@ -39,10 +43,22 @@ public class SplitAndIndexTesterResource extends RestResource {
     public SplitAndIndexTesterResponse splitAndIndexTester(@QueryParam("split_by") @NotNull String splitBy,
                                                            @QueryParam("index") @Min(0) int index,
                                                            @QueryParam("string") @NotNull String string) {
+        return doSplitAndIndexTest(string, splitBy, index);
+    }
+
+    @POST
+    @Timed
+    @Consumes(MediaType.APPLICATION_JSON)
+    @Produces(MediaType.APPLICATION_JSON)
+    public SplitAndIndexTesterResponse splitAndIndexTest(@Valid @NotNull SplitAndIndexTestRequest splitAndIndexTestRequest) {
+        return doSplitAndIndexTest(splitAndIndexTestRequest.string(),
+                splitAndIndexTestRequest.splitBy(), splitAndIndexTestRequest.index());
+    }
+
+    private SplitAndIndexTesterResponse doSplitAndIndexTest(String string, String splitBy, int index) {
         final String cut = SplitAndIndexExtractor.cut(string, splitBy, index - 1);
         int[] positions = SplitAndIndexExtractor.getCutIndices(string, splitBy, index - 1);
 
         return SplitAndIndexTesterResponse.create((cut != null), cut, positions[0], positions[1]);
     }
-
 }

--- a/graylog2-server/src/main/java/org/graylog2/rest/resources/tools/SubstringTesterResource.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/resources/tools/SubstringTesterResource.java
@@ -19,12 +19,16 @@ package org.graylog2.rest.resources.tools;
 import com.codahale.metrics.annotation.Timed;
 import org.apache.shiro.authz.annotation.RequiresAuthentication;
 import org.graylog2.plugin.Tools;
-import org.graylog2.shared.rest.resources.RestResource;
+import org.graylog2.rest.resources.tools.requests.SubstringTestRequest;
 import org.graylog2.rest.resources.tools.responses.SubstringTesterResponse;
+import org.graylog2.shared.rest.resources.RestResource;
 
+import javax.validation.Valid;
 import javax.validation.constraints.Min;
 import javax.validation.constraints.NotNull;
+import javax.ws.rs.Consumes;
 import javax.ws.rs.GET;
+import javax.ws.rs.POST;
 import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
 import javax.ws.rs.QueryParam;
@@ -39,6 +43,18 @@ public class SubstringTesterResource extends RestResource {
     public SubstringTesterResponse substringTester(@QueryParam("begin_index") @Min(0) int beginIndex,
                                                    @QueryParam("end_index") @Min(1) int endIndex,
                                                    @QueryParam("string") @NotNull String string) {
+        return doSubstringTest(string, beginIndex, endIndex);
+    }
+
+    @POST
+    @Timed
+    @Consumes(MediaType.APPLICATION_JSON)
+    @Produces(MediaType.APPLICATION_JSON)
+    public SubstringTesterResponse testSubstring(@Valid @NotNull SubstringTestRequest substringTestRequest) {
+        return doSubstringTest(substringTestRequest.string(), substringTestRequest.start(), substringTestRequest.end());
+    }
+
+    private SubstringTesterResponse doSubstringTest(String string, int beginIndex, int endIndex) {
         final String cut = Tools.safeSubstring(string, beginIndex, endIndex);
 
         return SubstringTesterResponse.create((cut != null), cut, beginIndex, endIndex);

--- a/graylog2-server/src/main/java/org/graylog2/rest/resources/tools/requests/GrokTestRequest.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/resources/tools/requests/GrokTestRequest.java
@@ -1,0 +1,39 @@
+/**
+ * This file is part of Graylog.
+ *
+ * Graylog is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.graylog2.rest.resources.tools.requests;
+
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.auto.value.AutoValue;
+
+@JsonAutoDetect
+@AutoValue
+public abstract class GrokTestRequest {
+    @JsonProperty
+    public abstract String string();
+
+    @JsonProperty
+    public abstract String pattern();
+
+    @JsonCreator
+    public static GrokTestRequest create(@JsonProperty("string") String string,
+                                         @JsonProperty("pattern") String pattern) {
+        return new AutoValue_GrokTestRequest(string, pattern);
+    }
+}

--- a/graylog2-server/src/main/java/org/graylog2/rest/resources/tools/requests/RegexTestRequest.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/resources/tools/requests/RegexTestRequest.java
@@ -1,0 +1,39 @@
+/**
+ * This file is part of Graylog.
+ *
+ * Graylog is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.graylog2.rest.resources.tools.requests;
+
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.auto.value.AutoValue;
+
+@JsonAutoDetect
+@AutoValue
+public abstract class RegexTestRequest {
+    @JsonProperty
+    public abstract String string();
+
+    @JsonProperty
+    public abstract String regex();
+
+    @JsonCreator
+    public static RegexTestRequest create(@JsonProperty("string") String string,
+                                          @JsonProperty("regex") String regex) {
+        return new AutoValue_RegexTestRequest(string, regex);
+    }
+}

--- a/graylog2-server/src/main/java/org/graylog2/rest/resources/tools/requests/SplitAndIndexTestRequest.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/resources/tools/requests/SplitAndIndexTestRequest.java
@@ -1,0 +1,43 @@
+/**
+ * This file is part of Graylog.
+ *
+ * Graylog is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.graylog2.rest.resources.tools.requests;
+
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.auto.value.AutoValue;
+
+@JsonAutoDetect
+@AutoValue
+public abstract class SplitAndIndexTestRequest {
+    @JsonProperty
+    public abstract String string();
+
+    @JsonProperty("split_by")
+    public abstract String splitBy();
+
+    @JsonProperty
+    public abstract int index();
+
+    @JsonCreator
+    public static SplitAndIndexTestRequest create(@JsonProperty("string") String string,
+                                                  @JsonProperty("split_by") String splitBy,
+                                                  @JsonProperty("index") int index) {
+        return new AutoValue_SplitAndIndexTestRequest(string, splitBy, index);
+    }
+}

--- a/graylog2-server/src/main/java/org/graylog2/rest/resources/tools/requests/SubstringTestRequest.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/resources/tools/requests/SubstringTestRequest.java
@@ -1,0 +1,43 @@
+/**
+ * This file is part of Graylog.
+ *
+ * Graylog is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.graylog2.rest.resources.tools.requests;
+
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.auto.value.AutoValue;
+
+@JsonAutoDetect
+@AutoValue
+public abstract class SubstringTestRequest {
+    @JsonProperty
+    public abstract String string();
+
+    @JsonProperty
+    public abstract int start();
+
+    @JsonProperty
+    public abstract int end();
+
+    @JsonCreator
+    public static SubstringTestRequest create(@JsonProperty("string") String string,
+                                              @JsonProperty("start") int start,
+                                              @JsonProperty("end") int end) {
+        return new AutoValue_SubstringTestRequest(string, start, end);
+    }
+}


### PR DESCRIPTION
Add POST methods to test extractors, as they are better when the example message is long and also avoid encoding issues.

Issue: Graylog2/graylog2-web-interface#1190