### PR TITLE
Upgrade to Elasticsearch 1.5.1

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/indexer/indices/Indices.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/indices/Indices.java
@@ -275,7 +275,6 @@ public class Indices implements IndexManagement {
     public void flush(String index) {
         FlushRequest flush = new FlushRequest(index);
         flush.force(true); // Just flushes. Even if it is not necessary.
-        flush.full(false);
 
         c.admin().indices().flush(new FlushRequest(index).force(true)).actionGet();
     }
@@ -398,7 +397,6 @@ public class Indices implements IndexManagement {
         or.maxNumSegments(configuration.getIndexOptimizationMaxNumSegments());
         or.onlyExpungeDeletes(false);
         or.flush(true);
-        or.waitForMerge(true); // This makes us block until the operation finished.
 
         c.admin().indices().optimize(or).actionGet();
     }

--- a/pom.xml
+++ b/pom.xml
@@ -221,7 +221,7 @@
             <dependency>
                 <groupId>org.elasticsearch</groupId>
                 <artifactId>elasticsearch</artifactId>
-                <version>1.4.4</version>
+                <version>1.5.1</version>
             </dependency>
 
             <dependency>


### PR DESCRIPTION
Due to the removal of `wait_for_merge` from the ES Optimize API the behaviour
of `Indices#optimizeIndex(String)` changed from blocking to non-blocking.

See elastic/elasticsearch#8921 for details.