### PR TITLE
Simple cluster event bus

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/bindings/InitializerBindings.java
+++ b/graylog2-server/src/main/java/org/graylog2/bindings/InitializerBindings.java
@@ -19,11 +19,13 @@ package org.graylog2.bindings;
 import com.google.common.util.concurrent.Service;
 import com.google.inject.AbstractModule;
 import com.google.inject.multibindings.Multibinder;
-import org.graylog2.initializers.*;
+import org.graylog2.events.ClusterEventService;
+import org.graylog2.initializers.BufferSynchronizerService;
+import org.graylog2.initializers.DashboardRegistryService;
+import org.graylog2.initializers.IndexerSetupService;
+import org.graylog2.initializers.MetricsReporterService;
+import org.graylog2.initializers.OutputSetupService;
 
-/**
- * @author Dennis Oelkers <dennis@torch.sh>
- */
 public class InitializerBindings extends AbstractModule {
     @Override
     protected void configure() {
@@ -33,5 +35,6 @@ public class InitializerBindings extends AbstractModule {
         serviceBinder.addBinding().to(IndexerSetupService.class);
         serviceBinder.addBinding().to(BufferSynchronizerService.class);
         serviceBinder.addBinding().to(OutputSetupService.class);
+        serviceBinder.addBinding().to(ClusterEventService.class);
     }
 }

--- a/graylog2-server/src/main/java/org/graylog2/bindings/ServerBindings.java
+++ b/graylog2-server/src/main/java/org/graylog2/bindings/ServerBindings.java
@@ -16,12 +16,12 @@
  */
 package org.graylog2.bindings;
 
+import com.google.common.eventbus.EventBus;
 import com.google.inject.AbstractModule;
 import com.google.inject.Scopes;
 import com.google.inject.TypeLiteral;
 import com.google.inject.assistedinject.FactoryModuleBuilder;
 import com.google.inject.multibindings.Multibinder;
-import com.google.inject.name.Names;
 import org.apache.shiro.mgt.DefaultSecurityManager;
 import org.elasticsearch.node.Node;
 import org.graylog2.Configuration;
@@ -31,6 +31,7 @@ import org.graylog2.alerts.types.FieldValueAlertCondition;
 import org.graylog2.alerts.types.MessageCountAlertCondition;
 import org.graylog2.bindings.providers.BundleExporterProvider;
 import org.graylog2.bindings.providers.BundleImporterProvider;
+import org.graylog2.bindings.providers.ClusterEventBusProvider;
 import org.graylog2.bindings.providers.DefaultSecurityManagerProvider;
 import org.graylog2.bindings.providers.EsNodeProvider;
 import org.graylog2.bindings.providers.LdapConnectorProvider;
@@ -89,6 +90,8 @@ import javax.ws.rs.container.DynamicFeature;
 import javax.ws.rs.ext.ExceptionMapper;
 import java.util.Set;
 
+import static com.google.inject.name.Names.named;
+
 public class ServerBindings extends AbstractModule {
     private final Configuration configuration;
     private final Set<ServerStatus.Capability> capabilities;
@@ -114,6 +117,7 @@ public class ServerBindings extends AbstractModule {
 
     private void bindProviders() {
         bind(RotationStrategy.class).toProvider(RotationStrategyProvider.class);
+        bind(EventBus.class).annotatedWith(named("cluster_event_bus")).toProvider(ClusterEventBusProvider.class).asEagerSingleton();
     }
 
     private void bindFactoryModules() {
@@ -160,7 +164,7 @@ public class ServerBindings extends AbstractModule {
         bind(BundleExporterProvider.class).in(Scopes.SINGLETON);
         bind(ClusterStatsModule.class).asEagerSingleton();
 
-        bind(String[].class).annotatedWith(Names.named("RestControllerPackages")).toInstance(new String[]{
+        bind(String[].class).annotatedWith(named("RestControllerPackages")).toInstance(new String[]{
                 "org.graylog2.rest.resources",
                 "org.graylog2.shared.rest.resources"
         });
@@ -203,7 +207,7 @@ public class ServerBindings extends AbstractModule {
     }
 
     private void bindAdditionalJerseyComponents() {
-        Multibinder<Class> componentBinder = Multibinder.newSetBinder(binder(), Class.class, Names.named("additionalJerseyComponents"));
+        Multibinder<Class> componentBinder = Multibinder.newSetBinder(binder(), Class.class, named("additionalJerseyComponents"));
         componentBinder.addBinding().toInstance(ScrollChunkWriter.class);
     }
 

--- a/graylog2-server/src/main/java/org/graylog2/bindings/providers/ClusterEventBusProvider.java
+++ b/graylog2-server/src/main/java/org/graylog2/bindings/providers/ClusterEventBusProvider.java
@@ -1,0 +1,62 @@
+/**
+ * This file is part of Graylog.
+ *
+ * Graylog is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.graylog2.bindings.providers;
+
+import com.codahale.metrics.InstrumentedExecutorService;
+import com.codahale.metrics.MetricRegistry;
+import com.google.common.eventbus.AsyncEventBus;
+import com.google.common.eventbus.EventBus;
+import com.google.common.util.concurrent.ThreadFactoryBuilder;
+import org.graylog2.plugin.BaseConfiguration;
+import org.graylog2.shared.events.DeadEventLoggingListener;
+
+import javax.inject.Inject;
+import javax.inject.Named;
+import javax.inject.Provider;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ThreadFactory;
+
+import static com.codahale.metrics.MetricRegistry.name;
+
+public class ClusterEventBusProvider implements Provider<EventBus> {
+    private final int asyncEventbusProcessors;
+    private final MetricRegistry metricRegistry;
+
+    @Inject
+    public ClusterEventBusProvider(@Named("async_eventbus_processors") final int asyncEventbusProcessors,
+                                   final MetricRegistry metricRegistry) {
+        this.asyncEventbusProcessors = asyncEventbusProcessors;
+        this.metricRegistry = metricRegistry;
+    }
+
+    @Override
+    public EventBus get() {
+        final EventBus eventBus = new AsyncEventBus("cluster-eventbus", executorService(asyncEventbusProcessors));
+        eventBus.register(new DeadEventLoggingListener());
+
+        return eventBus;
+    }
+
+    private ExecutorService executorService(int nThreads) {
+        final ThreadFactory threadFactory = new ThreadFactoryBuilder().setDaemon(true).setNameFormat("cluster-eventbus-handler-%d").build();
+        return new InstrumentedExecutorService(
+                Executors.newFixedThreadPool(nThreads, threadFactory),
+                metricRegistry,
+                name("cluster-eventbus", "executor-service"));
+    }
+}

--- a/graylog2-server/src/main/java/org/graylog2/events/ClusterEvent.java
+++ b/graylog2-server/src/main/java/org/graylog2/events/ClusterEvent.java
@@ -1,0 +1,85 @@
+/**
+ * This file is part of Graylog.
+ *
+ * Graylog is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.graylog2.events;
+
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.auto.value.AutoValue;
+import org.graylog2.plugin.system.NodeId;
+import org.hibernate.validator.constraints.NotEmpty;
+import org.joda.time.DateTime;
+import org.joda.time.DateTimeZone;
+import org.mongojack.Id;
+import org.mongojack.ObjectId;
+
+import javax.annotation.Nullable;
+import java.util.Collections;
+import java.util.Map;
+import java.util.Set;
+
+@JsonAutoDetect
+@AutoValue
+public abstract class ClusterEvent {
+    @Id
+    @ObjectId
+    @Nullable
+    public abstract String id();
+
+    @JsonProperty
+    @Nullable
+    public abstract DateTime date();
+
+    @JsonProperty
+    @Nullable
+    public abstract String producer();
+
+    @JsonProperty
+    @Nullable
+    public abstract Set<String> consumers();
+
+    @JsonProperty
+    @Nullable
+    public abstract String eventClass();
+
+    @JsonProperty
+    @Nullable
+    public abstract Map<String, Object> payload();
+
+
+    @JsonCreator
+    public static ClusterEvent create(@Id @ObjectId @JsonProperty("_id") @Nullable String id,
+                                      @JsonProperty("date") @Nullable DateTime date,
+                                      @JsonProperty("producer") @Nullable String producer,
+                                      @JsonProperty("consumers") @Nullable Set<String> consumers,
+                                      @JsonProperty("event_class") @Nullable String eventClass,
+                                      @JsonProperty("payload") @Nullable Map<String, Object> payload) {
+        return new AutoValue_ClusterEvent(id, date, producer, consumers, eventClass, payload);
+    }
+
+    public static ClusterEvent create(@NotEmpty String producer,
+                                      @NotEmpty String eventClass,
+                                      @NotEmpty Map<String, Object> payload) {
+        return new AutoValue_ClusterEvent(null,
+                DateTime.now(DateTimeZone.UTC),
+                producer,
+                Collections.<String>emptySet(),
+                eventClass,
+                payload);
+    }
+}

--- a/graylog2-server/src/main/java/org/graylog2/events/ClusterEvent.java
+++ b/graylog2-server/src/main/java/org/graylog2/events/ClusterEvent.java
@@ -59,7 +59,7 @@ public abstract class ClusterEvent {
 
     @JsonProperty
     @Nullable
-    public abstract Map<String, Object> payload();
+    public abstract Object payload();
 
 
     @JsonCreator
@@ -68,13 +68,13 @@ public abstract class ClusterEvent {
                                       @JsonProperty("producer") @Nullable String producer,
                                       @JsonProperty("consumers") @Nullable Set<String> consumers,
                                       @JsonProperty("event_class") @Nullable String eventClass,
-                                      @JsonProperty("payload") @Nullable Map<String, Object> payload) {
+                                      @JsonProperty("payload") @Nullable Object payload) {
         return new AutoValue_ClusterEvent(id, date, producer, consumers, eventClass, payload);
     }
 
     public static ClusterEvent create(@NotEmpty String producer,
                                       @NotEmpty String eventClass,
-                                      @NotEmpty Map<String, Object> payload) {
+                                      @NotEmpty Object payload) {
         return new AutoValue_ClusterEvent(null,
                 DateTime.now(DateTimeZone.UTC),
                 producer,

--- a/graylog2-server/src/main/java/org/graylog2/events/ClusterEventService.java
+++ b/graylog2-server/src/main/java/org/graylog2/events/ClusterEventService.java
@@ -19,6 +19,7 @@ package org.graylog2.events;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.annotations.VisibleForTesting;
+import com.google.common.eventbus.DeadEvent;
 import com.google.common.eventbus.EventBus;
 import com.google.common.eventbus.Subscribe;
 import com.google.common.util.concurrent.AbstractExecutionThreadService;
@@ -181,6 +182,11 @@ public class ClusterEventService extends AbstractExecutionThreadService {
 
     @Subscribe
     public void publishClusterEvent(Object event) {
+        if(event instanceof DeadEvent) {
+            LOG.debug("Skipping DeadEvent on cluster event bus");
+            return;
+        }
+
         final String className = event.getClass().getCanonicalName();
         final ClusterEvent clusterEvent = ClusterEvent.create(nodeId.toString(), className, event);
         final String id = dbCollection.save(clusterEvent).getSavedId();

--- a/graylog2-server/src/main/java/org/graylog2/events/ClusterEventService.java
+++ b/graylog2-server/src/main/java/org/graylog2/events/ClusterEventService.java
@@ -136,7 +136,7 @@ public class ClusterEventService extends AbstractExecutionThreadService {
         final WriteResult<ClusterEvent, String> writeResult = dbCollection.updateById(eventId, DBUpdate.addToSet("consumers", nodeId.toString()));
     }
 
-    private Object extractPayload(Map<String, Object> payload, String eventClass) {
+    private Object extractPayload(Object payload, String eventClass) {
         try {
             final Class<?> clazz = Class.forName(eventClass);
             return objectMapper.convertValue(payload, clazz);
@@ -182,9 +182,7 @@ public class ClusterEventService extends AbstractExecutionThreadService {
     @Subscribe
     public void publishClusterEvent(Object event) {
         final String className = event.getClass().getCanonicalName();
-        final Map<String, Object> payload = objectMapper.convertValue(event, new TypeReference<Map<String, Object>>() {
-        });
-        final ClusterEvent clusterEvent = ClusterEvent.create(nodeId.toString(), className, payload);
+        final ClusterEvent clusterEvent = ClusterEvent.create(nodeId.toString(), className, event);
         final String id = dbCollection.save(clusterEvent).getSavedId();
         LOG.debug("Published cluster event with ID <{}> and type <{}>", id, className);
     }

--- a/graylog2-server/src/main/java/org/graylog2/events/ClusterEventService.java
+++ b/graylog2-server/src/main/java/org/graylog2/events/ClusterEventService.java
@@ -197,7 +197,12 @@ public class ClusterEventService extends AbstractExecutionThreadService {
 
         final String className = event.getClass().getCanonicalName();
         final ClusterEvent clusterEvent = ClusterEvent.create(nodeId.toString(), className, event);
-        final String id = dbCollection.save(clusterEvent).getSavedId();
-        LOG.debug("Published cluster event with ID <{}> and type <{}>", id, className);
+
+        try {
+            final String id = dbCollection.save(clusterEvent).getSavedId();
+            LOG.debug("Published cluster event with ID <{}> and type <{}>", id, className);
+        } catch (MongoException e) {
+            LOG.error("Couldn't publish cluster event of type <" + className + ">", e);
+        }
     }
 }

--- a/graylog2-server/src/main/java/org/graylog2/events/ClusterEventService.java
+++ b/graylog2-server/src/main/java/org/graylog2/events/ClusterEventService.java
@@ -31,6 +31,7 @@ import com.mongodb.DB;
 import com.mongodb.DBCollection;
 import com.mongodb.DBObject;
 import com.mongodb.MongoException;
+import com.mongodb.WriteConcern;
 import org.graylog2.bindings.providers.MongoJackObjectMapperProvider;
 import org.graylog2.database.MongoConnection;
 import org.graylog2.plugin.system.NodeId;
@@ -121,6 +122,8 @@ public class ClusterEventService extends AbstractExecutionThreadService {
         coll.createIndex(DBSort.asc("consumers"));
         coll.addOption(Bytes.QUERYOPTION_TAILABLE | Bytes.QUERYOPTION_AWAITDATA);
 
+        coll.setWriteConcern(WriteConcern.MAJORITY);
+
         return coll;
     }
 
@@ -142,6 +145,7 @@ public class ClusterEventService extends AbstractExecutionThreadService {
     }
 
     private void updateConsumers(final String eventId, final NodeId nodeId) {
+
         final WriteResult<ClusterEvent, String> writeResult = dbCollection.updateById(eventId, DBUpdate.addToSet("consumers", nodeId.toString()));
     }
 

--- a/graylog2-server/src/main/java/org/graylog2/events/ClusterEventService.java
+++ b/graylog2-server/src/main/java/org/graylog2/events/ClusterEventService.java
@@ -1,0 +1,191 @@
+/**
+ * This file is part of Graylog.
+ *
+ * Graylog is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.graylog2.events;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.eventbus.EventBus;
+import com.google.common.eventbus.Subscribe;
+import com.google.common.util.concurrent.AbstractExecutionThreadService;
+import com.google.common.util.concurrent.Uninterruptibles;
+import com.mongodb.BasicDBList;
+import com.mongodb.BasicDBObject;
+import com.mongodb.BasicDBObjectBuilder;
+import com.mongodb.Bytes;
+import com.mongodb.DB;
+import com.mongodb.DBCollection;
+import com.mongodb.DBObject;
+import org.graylog2.bindings.providers.MongoJackObjectMapperProvider;
+import org.graylog2.database.MongoConnection;
+import org.graylog2.plugin.system.NodeId;
+import org.mongojack.DBCursor;
+import org.mongojack.DBSort;
+import org.mongojack.DBUpdate;
+import org.mongojack.JacksonDBCollection;
+import org.mongojack.WriteResult;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.inject.Inject;
+import javax.inject.Named;
+import javax.inject.Singleton;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+@Singleton
+public class ClusterEventService extends AbstractExecutionThreadService {
+    private static final Logger LOG = LoggerFactory.getLogger(ClusterEventService.class);
+
+    @VisibleForTesting
+    static final String COLLECTION_NAME = "cluster_events";
+
+    private final JacksonDBCollection<ClusterEvent, String> dbCollection;
+    private final NodeId nodeId;
+    private final ObjectMapper objectMapper;
+    private final EventBus serverEventBus;
+    private final EventBus clusterEventBus;
+
+    @Inject
+    public ClusterEventService(final MongoJackObjectMapperProvider mapperProvider,
+                               final MongoConnection mongoConnection,
+                               final NodeId nodeId,
+                               final ObjectMapper objectMapper,
+                               final EventBus serverEventBus,
+                               @Named("cluster_event_bus") final EventBus clusterEventBus) {
+        this(JacksonDBCollection.wrap(prepareCollection(mongoConnection), ClusterEvent.class, String.class, mapperProvider.get()),
+                nodeId, objectMapper, serverEventBus, clusterEventBus);
+    }
+
+    ClusterEventService(final JacksonDBCollection<ClusterEvent, String> dbCollection,
+                        final NodeId nodeId,
+                        final ObjectMapper objectMapper,
+                        final EventBus serverEventBus,
+                        final EventBus clusterEventBus) {
+        this.nodeId = checkNotNull(nodeId);
+        this.dbCollection = checkNotNull(dbCollection);
+        this.objectMapper = checkNotNull(objectMapper);
+        this.serverEventBus = checkNotNull(serverEventBus);
+        this.clusterEventBus = checkNotNull(clusterEventBus);
+
+        this.clusterEventBus.register(this);
+    }
+
+    @VisibleForTesting
+    static DBCollection prepareCollection(final MongoConnection mongoConnection) {
+        final DB db = mongoConnection.getDatabase();
+
+        final DBCollection coll;
+        if (!db.collectionExists(COLLECTION_NAME)) {
+            final DBObject options = BasicDBObjectBuilder.start()
+                    .add("capped", true)
+                    .add("size", 32768)
+                    .get();
+
+            coll = db.createCollection(COLLECTION_NAME, options);
+        } else {
+            coll = db.getCollection(COLLECTION_NAME);
+        }
+
+        if (!db.getCollection(COLLECTION_NAME).isCapped()) {
+            LOG.warn("The MongoDB collection \"{}\" should be capped but isn't. "
+                    + "Please drop the collection and restart Graylog", COLLECTION_NAME);
+        }
+
+        coll.createIndex(DBSort.asc("producer"));
+        coll.createIndex(DBSort.asc("consumers"));
+        coll.addOption(Bytes.QUERYOPTION_TAILABLE | Bytes.QUERYOPTION_AWAITDATA);
+
+        return coll;
+    }
+
+    private DBCursor<ClusterEvent> eventCursor(NodeId nodeId) {
+        // Resorting to ugly MongoDB Java Client because of https://github.com/devbliss/mongojack/issues/88
+        final DBObject producerClause = new BasicDBObject("producer", new BasicDBObject("$ne", nodeId.toString()));
+        final BasicDBList consumersList = new BasicDBList();
+        consumersList.add(nodeId.toString());
+        final DBObject consumersClause = new BasicDBObject("consumers", new BasicDBObject("$nin", consumersList));
+        final BasicDBList and = new BasicDBList();
+        and.add(producerClause);
+        and.add(consumersClause);
+        final DBObject query = new BasicDBObject("$and", and);
+
+        return dbCollection.find(query)
+                .sort(DBSort.asc("$natural"))
+                .addOption(Bytes.QUERYOPTION_TAILABLE)
+                .addOption(Bytes.QUERYOPTION_AWAITDATA);
+    }
+
+    private void updateConsumers(final String eventId, final NodeId nodeId) {
+        final WriteResult<ClusterEvent, String> writeResult = dbCollection.updateById(eventId, DBUpdate.addToSet("consumers", nodeId.toString()));
+    }
+
+    private Object extractPayload(Map<String, Object> payload, String eventClass) {
+        try {
+            final Class<?> clazz = Class.forName(eventClass);
+            return objectMapper.convertValue(payload, clazz);
+        } catch (ClassNotFoundException e) {
+            LOG.debug("Couldn't load class <" + eventClass + "> for event", e);
+            return null;
+        } catch (IllegalArgumentException e) {
+            LOG.debug("Error while deserializing payload", e);
+            return null;
+
+        }
+    }
+
+    @Override
+    protected void run() throws Exception {
+        while (isRunning()) {
+            try {
+                LOG.debug("Opening MongoDB cursor on \"{}\"", COLLECTION_NAME);
+                final DBCursor<ClusterEvent> cursor = eventCursor(nodeId);
+                while (cursor.hasNext()) {
+                    ClusterEvent clusterEvent = cursor.next();
+                    LOG.trace("Processing cluster event: {}", clusterEvent);
+
+                    Object payload = extractPayload(clusterEvent.payload(), clusterEvent.eventClass());
+                    if (payload != null) {
+                        serverEventBus.post(payload);
+                    } else {
+                        LOG.warn("Couldn't extract payload of cluster event with ID <{}>", clusterEvent.id());
+                        LOG.debug("Invalid payload in cluster event: {}", clusterEvent);
+                    }
+
+                    updateConsumers(clusterEvent.id(), nodeId);
+                }
+            } catch (Exception e) {
+                LOG.warn("Error while reading cluster events from MongoDB, retrying.", e);
+            }
+
+            // Don't overwhelm the server
+            Uninterruptibles.sleepUninterruptibly(1L, TimeUnit.SECONDS);
+        }
+    }
+
+    @Subscribe
+    public void publishClusterEvent(Object event) {
+        final String className = event.getClass().getCanonicalName();
+        final Map<String, Object> payload = objectMapper.convertValue(event, new TypeReference<Map<String, Object>>() {
+        });
+        final ClusterEvent clusterEvent = ClusterEvent.create(nodeId.toString(), className, payload);
+        final String id = dbCollection.save(clusterEvent).getSavedId();
+        LOG.debug("Published cluster event with ID <{}> and type <{}>", id, className);
+    }
+}

--- a/graylog2-server/src/test/java/org/graylog2/events/ClusterEventServiceTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/events/ClusterEventServiceTest.java
@@ -1,0 +1,249 @@
+/**
+ * This file is part of Graylog.
+ *
+ * Graylog is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.graylog2.events;
+
+import com.codahale.metrics.json.MetricsModule;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.PropertyNamingStrategy;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.databind.module.SimpleModule;
+import com.fasterxml.jackson.datatype.guava.GuavaModule;
+import com.fasterxml.jackson.datatype.joda.JodaModule;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.eventbus.EventBus;
+import com.google.common.util.concurrent.Service;
+import com.google.common.util.concurrent.ServiceManager;
+import com.google.common.util.concurrent.Uninterruptibles;
+import com.lordofthejars.nosqlunit.annotation.UsingDataSet;
+import com.lordofthejars.nosqlunit.core.LoadStrategyEnum;
+import com.lordofthejars.nosqlunit.mongodb.InMemoryMongoDb;
+import com.mongodb.BasicDBObjectBuilder;
+import com.mongodb.Bytes;
+import com.mongodb.DBCollection;
+import com.mongodb.DBObject;
+import org.graylog2.bindings.providers.MongoJackObjectMapperProvider;
+import org.graylog2.database.MongoConnection;
+import org.graylog2.database.MongoConnectionRule;
+import org.graylog2.database.ObjectIdSerializer;
+import org.graylog2.plugin.system.NodeId;
+import org.graylog2.shared.jackson.SizeSerializer;
+import org.graylog2.shared.rest.RangeJsonSerializer;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.Spy;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+
+import static com.lordofthejars.nosqlunit.mongodb.InMemoryMongoDb.InMemoryMongoRuleBuilder.newInMemoryMongoDbRule;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@RunWith(MockitoJUnitRunner.class)
+public class ClusterEventServiceTest {
+    @ClassRule
+    public static final InMemoryMongoDb IN_MEMORY_MONGO_DB = newInMemoryMongoDbRule().build();
+
+    @Rule
+    public MongoConnectionRule mongoRule = MongoConnectionRule.build("test");
+
+    private ClusterEventService clusterEventService;
+    private MongoConnection mongoConnection;
+    @Mock
+    private NodeId nodeId;
+    @Spy
+    private EventBus serverEventBus;
+    @Spy
+    private EventBus clusterEventBus;
+
+    @Before
+    public void setUpService() throws Exception {
+        this.mongoConnection = mongoRule.getMongoConnection();
+
+        ObjectMapper objectMapper = new ObjectMapper()
+                .disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS)
+                .setPropertyNamingStrategy(new PropertyNamingStrategy.LowerCaseWithUnderscoresStrategy())
+                .registerModule(new JodaModule())
+                .registerModule(new GuavaModule())
+                .registerModule(new MetricsModule(TimeUnit.SECONDS, TimeUnit.SECONDS, false))
+                .registerModule(new SimpleModule()
+                        .addSerializer(new ObjectIdSerializer())
+                        .addSerializer(new RangeJsonSerializer())
+                        .addSerializer(new SizeSerializer()));
+
+        MongoJackObjectMapperProvider provider = new MongoJackObjectMapperProvider(objectMapper);
+        when(nodeId.toString()).thenReturn("ID");
+
+        this.clusterEventService = new ClusterEventService(
+                provider,
+                mongoRule.getMongoConnection(),
+                nodeId,
+                objectMapper,
+                serverEventBus,
+                clusterEventBus
+        );
+    }
+
+    @Test
+    public void clusterEventServiceRegistersItselfWithClusterEventBus() throws Exception {
+        verify(clusterEventBus, times(1)).register(clusterEventService);
+    }
+
+    @Test
+    @UsingDataSet(loadStrategy = LoadStrategyEnum.DELETE_ALL)
+    public void runHandlesInvalidPayloadsGracefully() throws Exception {
+        DBObject event = new BasicDBObjectBuilder()
+                .add("date", "2015-04-01T00:00:00.000Z")
+                .add("producer", "TEST-PRODUCER")
+                .add("consumers", Collections.emptyList())
+                .add("event_class", SimpleEvent.class.getCanonicalName())
+                .add("payload", ImmutableMap.of("HAHA", "test"))
+                .get();
+        final DBCollection collection = mongoConnection.getDatabase().getCollection(ClusterEventService.COLLECTION_NAME);
+        collection.save(event);
+
+        assertThat(collection.count()).isEqualTo(1L);
+
+        ServiceManager serviceManager = new ServiceManager(Collections.singleton(clusterEventService));
+
+        serviceManager
+                .startAsync()
+                .awaitHealthy(1L, TimeUnit.SECONDS);
+
+        assertThat(serviceManager.servicesByState().get(Service.State.RUNNING)).contains(clusterEventService);
+        assertThat(clusterEventService.isRunning()).isTrue();
+
+        Uninterruptibles.sleepUninterruptibly(1L, TimeUnit.SECONDS);
+
+        assertThat(collection.count()).isEqualTo(1L);
+
+        DBObject dbObject = collection.findOne();
+
+        @SuppressWarnings("unchecked")
+        final List<String> consumers = (List<String>) dbObject.get("consumers");
+        assertThat(consumers).containsExactly(nodeId.toString());
+
+        serviceManager
+                .stopAsync()
+                .awaitStopped(5L, TimeUnit.SECONDS);
+
+        verify(serverEventBus, never()).post(any());
+        verify(clusterEventBus, never()).post(any());
+    }
+
+    @Test
+    public void testRun() throws Exception {
+        DBObject event = new BasicDBObjectBuilder()
+                .add("date", "2015-04-01T00:00:00.000Z")
+                .add("producer", "TEST-PRODUCER")
+                .add("consumers", Collections.emptyList())
+                .add("event_class", SimpleEvent.class.getCanonicalName())
+                .add("payload", ImmutableMap.of("payload", "test"))
+                .get();
+        final DBCollection collection = mongoConnection.getDatabase().getCollection(ClusterEventService.COLLECTION_NAME);
+        collection.save(event);
+
+        assertThat(collection.count()).isEqualTo(1L);
+
+        ServiceManager serviceManager = new ServiceManager(Collections.singleton(clusterEventService));
+
+        serviceManager
+                .startAsync()
+                .awaitHealthy(1L, TimeUnit.SECONDS);
+
+        assertThat(serviceManager.servicesByState().get(Service.State.RUNNING)).contains(clusterEventService);
+        assertThat(clusterEventService.isRunning()).isTrue();
+
+        Uninterruptibles.sleepUninterruptibly(1L, TimeUnit.SECONDS);
+
+        assertThat(collection.count()).isEqualTo(1L);
+
+        DBObject dbObject = collection.findOne();
+
+        @SuppressWarnings("unchecked")
+        final List<String> consumers = (List<String>) dbObject.get("consumers");
+        assertThat(consumers).containsExactly(nodeId.toString());
+
+        serviceManager
+                .stopAsync()
+                .awaitStopped(5L, TimeUnit.SECONDS);
+
+        verify(serverEventBus, times(1)).post(new SimpleEvent("test"));
+        verify(clusterEventBus, never()).post(event);
+    }
+
+    @Test
+    @UsingDataSet(loadStrategy = LoadStrategyEnum.DELETE_ALL)
+    public void testPublishClusterEvent() throws Exception {
+        DBCollection collection = mongoConnection.getDatabase().getCollection(ClusterEventService.COLLECTION_NAME);
+        SimpleEvent event = new SimpleEvent("test");
+
+        assertThat(collection.count()).isEqualTo(0L);
+
+        clusterEventService.publishClusterEvent(event);
+
+        verify(clusterEventBus, never()).post(any());
+        assertThat(collection.count()).isEqualTo(1L);
+
+        DBObject dbObject = collection.findOne();
+
+        assertThat((String) dbObject.get("producer")).isEqualTo(nodeId.toString());
+        assertThat((String) dbObject.get("event_class")).isEqualTo(SimpleEvent.class.getCanonicalName());
+
+        @SuppressWarnings("unchecked")
+        Map<String, Object> payload = (Map<String, Object>) dbObject.get("payload");
+        assertThat(payload).containsEntry("payload", "test");
+    }
+
+    @Test
+    public void prepareCollectionCreatesIndexesOnExistingCollection() throws Exception {
+        DBCollection original = mongoConnection.getDatabase().createCollection(ClusterEventService.COLLECTION_NAME, null);
+        original.dropIndexes();
+        assertThat(original.getName()).isEqualTo(ClusterEventService.COLLECTION_NAME);
+        assertThat(original.getIndexInfo()).hasSize(1);
+
+
+        DBCollection collection = ClusterEventService.prepareCollection(mongoConnection);
+        assertThat(collection.getName()).isEqualTo(ClusterEventService.COLLECTION_NAME);
+        assertThat(collection.getIndexInfo()).hasSize(3);
+        assertThat(collection.getOptions() & Bytes.QUERYOPTION_AWAITDATA).isEqualTo(Bytes.QUERYOPTION_AWAITDATA);
+        assertThat(collection.getOptions() & Bytes.QUERYOPTION_TAILABLE).isEqualTo(Bytes.QUERYOPTION_TAILABLE);
+    }
+
+    @Test
+    public void prepareCollectionCreatesCollectionIfItDoesNotExist() throws Exception {
+        DBCollection collection = ClusterEventService.prepareCollection(mongoConnection);
+
+        assertThat(collection.getName()).isEqualTo(ClusterEventService.COLLECTION_NAME);
+        // Not supported by Fongo at the moment.
+        // assertThat(collection.isCapped()).isTrue();
+        assertThat(collection.getIndexInfo()).hasSize(3);
+        assertThat(collection.getOptions() & Bytes.QUERYOPTION_AWAITDATA).isEqualTo(Bytes.QUERYOPTION_AWAITDATA);
+        assertThat(collection.getOptions() & Bytes.QUERYOPTION_TAILABLE).isEqualTo(Bytes.QUERYOPTION_TAILABLE);
+    }
+}

--- a/graylog2-server/src/test/java/org/graylog2/events/ClusterEventServiceTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/events/ClusterEventServiceTest.java
@@ -37,6 +37,7 @@ import com.mongodb.BasicDBObjectBuilder;
 import com.mongodb.Bytes;
 import com.mongodb.DBCollection;
 import com.mongodb.DBObject;
+import com.mongodb.WriteConcern;
 import org.graylog2.bindings.providers.MongoJackObjectMapperProvider;
 import org.graylog2.database.MongoConnection;
 import org.graylog2.database.MongoConnectionRule;
@@ -289,12 +290,12 @@ public class ClusterEventServiceTest {
         assertThat(original.getName()).isEqualTo(ClusterEventService.COLLECTION_NAME);
         assertThat(original.getIndexInfo()).hasSize(1);
 
-
         DBCollection collection = ClusterEventService.prepareCollection(mongoConnection);
         assertThat(collection.getName()).isEqualTo(ClusterEventService.COLLECTION_NAME);
         assertThat(collection.getIndexInfo()).hasSize(3);
         assertThat(collection.getOptions() & Bytes.QUERYOPTION_AWAITDATA).isEqualTo(Bytes.QUERYOPTION_AWAITDATA);
         assertThat(collection.getOptions() & Bytes.QUERYOPTION_TAILABLE).isEqualTo(Bytes.QUERYOPTION_TAILABLE);
+        assertThat(collection.getWriteConcern()).isEqualTo(WriteConcern.MAJORITY);
     }
 
     @Test
@@ -307,6 +308,7 @@ public class ClusterEventServiceTest {
         assertThat(collection.getIndexInfo()).hasSize(3);
         assertThat(collection.getOptions() & Bytes.QUERYOPTION_AWAITDATA).isEqualTo(Bytes.QUERYOPTION_AWAITDATA);
         assertThat(collection.getOptions() & Bytes.QUERYOPTION_TAILABLE).isEqualTo(Bytes.QUERYOPTION_TAILABLE);
+        assertThat(collection.getWriteConcern()).isEqualTo(WriteConcern.MAJORITY);
     }
 
     public static class SimpleEventHandler {

--- a/graylog2-server/src/test/java/org/graylog2/events/SimpleEvent.java
+++ b/graylog2-server/src/test/java/org/graylog2/events/SimpleEvent.java
@@ -1,0 +1,50 @@
+/**
+ * This file is part of Graylog.
+ *
+ * Graylog is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.graylog2.events;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+
+import java.util.Objects;
+
+public class SimpleEvent {
+    public String payload;
+
+    public SimpleEvent() {}
+
+    public SimpleEvent(String payload) {
+        this.payload = payload;
+    }
+
+    @Override
+    public String toString() {
+        return "payload=" + payload;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+
+        SimpleEvent event = (SimpleEvent) o;
+        return Objects.equals(payload, event.payload);
+    }
+
+    @Override
+    public int hashCode() {
+        return payload != null ? payload.hashCode() : 0;
+    }
+}

--- a/graylog2-shared/src/main/java/org/graylog2/shared/bindings/providers/EventBusProvider.java
+++ b/graylog2-shared/src/main/java/org/graylog2/shared/bindings/providers/EventBusProvider.java
@@ -22,6 +22,7 @@ import com.google.common.eventbus.AsyncEventBus;
 import com.google.common.eventbus.EventBus;
 import com.google.common.util.concurrent.ThreadFactoryBuilder;
 import org.graylog2.plugin.BaseConfiguration;
+import org.graylog2.shared.events.DeadEventLoggingListener;
 
 import javax.inject.Inject;
 import javax.inject.Provider;
@@ -43,7 +44,10 @@ public class EventBusProvider implements Provider<EventBus> {
 
     @Override
     public EventBus get() {
-        return new AsyncEventBus("graylog2-eventbus", executorService(configuration.getAsyncEventbusProcessors()));
+        final EventBus eventBus = new AsyncEventBus("graylog-eventbus", executorService(configuration.getAsyncEventbusProcessors()));
+        eventBus.register(new DeadEventLoggingListener());
+
+        return eventBus;
     }
 
     private ExecutorService executorService(int nThreads) {

--- a/graylog2-shared/src/main/java/org/graylog2/shared/events/DeadEventLoggingListener.java
+++ b/graylog2-shared/src/main/java/org/graylog2/shared/events/DeadEventLoggingListener.java
@@ -1,0 +1,32 @@
+/**
+ * This file is part of Graylog.
+ *
+ * Graylog is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.graylog2.shared.events;
+
+import com.google.common.eventbus.DeadEvent;
+import com.google.common.eventbus.Subscribe;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class DeadEventLoggingListener {
+    private static final Logger LOGGER = LoggerFactory.getLogger(DeadEventLoggingListener.class);
+
+    @Subscribe
+    public void handleDeadEvent(DeadEvent event) {
+        LOGGER.debug("Received unhandled event of type <{}>", event.getEvent().getClass().getCanonicalName());
+        LOGGER.trace("Dead event contents: {}", event.getEvent());
+    }
+}

--- a/graylog2-shared/src/test/java/org/graylog2/shared/events/DeadEventLoggingListenerTest.java
+++ b/graylog2-shared/src/test/java/org/graylog2/shared/events/DeadEventLoggingListenerTest.java
@@ -1,0 +1,62 @@
+/**
+ * This file is part of Graylog.
+ *
+ * Graylog is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.graylog2.shared.events;
+
+import com.google.common.eventbus.DeadEvent;
+import com.google.common.eventbus.EventBus;
+import org.junit.Test;
+
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+public class DeadEventLoggingListenerTest {
+
+    @Test
+    public void testHandleDeadEvent() {
+        final DeadEventLoggingListener listener = new DeadEventLoggingListener();
+        final DeadEvent event = new DeadEvent(this, new SimpleEvent("test"));
+
+        listener.handleDeadEvent(event);
+    }
+
+    @Test
+    public void testEventListenerWithEventBus() {
+        final EventBus eventBus = new EventBus("test");
+        final SimpleEvent event = new SimpleEvent("test");
+        final DeadEventLoggingListener listener = spy(new DeadEventLoggingListener());
+        eventBus.register(listener);
+
+        eventBus.post(event);
+
+        verify(listener, times(1)).handleDeadEvent(any(DeadEvent.class));
+    }
+
+    public static class SimpleEvent {
+        public String payload;
+
+        public SimpleEvent(String payload) {
+            this.payload = payload;
+        }
+
+        @Override
+        public String toString() {
+            return "payload=" + payload;
+        }
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -708,6 +708,12 @@
                 <version>0.8.1</version>
                 <scope>test</scope>
             </dependency>
+            <dependency>
+                <groupId>com.github.fakemongo</groupId>
+                <artifactId>fongo</artifactId>
+                <version>1.6.2</version>
+                <scope>test</scope>
+            </dependency>
 
             <dependency>
                 <groupId>org.graylog.telemetry</groupId>


### PR DESCRIPTION
This PR adds a simple cluster event bus based on [MongoDB capped collections](http://docs.mongodb.org/manual/core/capped-collections/) and [Guava EventBus](https://code.google.com/p/guava-libraries/wiki/EventBusExplained).

The cluster event bus can be used to send events from one Graylog node to all other Graylog nodes in the cluster, e. g. to trigger a configuration reload. All events should be consumed once by each node (also if an error occurred while processing the cluster event or its payload).

Underneath it all, the cluster event bus is using a capped collection in MongoDB which is regularly polled by each Graylog node (also see http://docs.mongodb.org/manual/tutorial/create-tailable-cursor/). Once the document has been processed by a particular node, its node ID is being added to the "consumers" array of the document so that it won't read it again. The deserialized payload of a cluster event is being posted to the local server EventBus so that other parts of the node can react upon it.

A Graylog node will *not* process messages it produced itself, so any event that should be processed locally as well, has to be sent to the cluster *and* to the server event bus.

Every event being sent to the cluster is being wrapped inside a `ClusterEvent` and *must* be serializable and deserializable by Jackson, otherwise the receivers won't be able to deserialize the payload of the cluster event!