### PR TITLE
do not ignore the expected response codes in executeOnAll

### DIFF
--- a/graylog2-rest-client/src/main/java/org/graylog2/restclient/lib/ApiClientImpl.java
+++ b/graylog2-rest-client/src/main/java/org/graylog2/restclient/lib/ApiClientImpl.java
@@ -87,12 +87,12 @@ class ApiClientImpl implements ApiClient {
     @Inject
     private ApiClientImpl(ServerNodes serverNodes, @Named("Default Timeout") Long defaultTimeout) {
         this(serverNodes, defaultTimeout,
-                new ObjectMapper()
-                        .setPropertyNamingStrategy(PropertyNamingStrategy.CAMEL_CASE_TO_LOWER_CASE_WITH_UNDERSCORES)
-                        .disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES)
-                        .setVisibility(PropertyAccessor.FIELD, JsonAutoDetect.Visibility.ANY)
-                        .registerModule(new GuavaModule())
-                        .registerModule(new JodaModule()));
+             new ObjectMapper()
+                     .setPropertyNamingStrategy(PropertyNamingStrategy.CAMEL_CASE_TO_LOWER_CASE_WITH_UNDERSCORES)
+                     .disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES)
+                     .setVisibility(PropertyAccessor.FIELD, JsonAutoDetect.Visibility.ANY)
+                     .registerModule(new GuavaModule())
+                     .registerModule(new JodaModule()));
     }
 
     private ApiClientImpl(ServerNodes serverNodes, Long defaultTimeout, ObjectMapper objectMapper) {
@@ -424,64 +424,14 @@ class ApiClientImpl implements ApiClient {
             }
 
             // Set 200 OK as standard if not defined.
-            if (expectedResponseCodes.isEmpty()) {
-                expectedResponseCodes.add(200);
-            }
+            ensureExpectedResponseCodes();
 
             try {
                 // TODO implement streaming responses
                 Response response = requestBuilder.execute().get(timeoutValue, timeoutUnit);
 
                 target.touch();
-
-                // TODO: once we switch to jackson we can take the media type into account automatically
-                final MediaType responseContentType;
-                if (response.getContentType() == null) {
-                    responseContentType = MediaType.JSON_UTF_8;
-                } else {
-                    responseContentType = MediaType.parse(response.getContentType());
-                }
-
-                if (!responseContentType.is(mediaType.withoutParameters())) {
-                    LOG.warn("We said we'd accept {} but got {} back, let's see how that's going to work out...", mediaType, responseContentType);
-                }
-                if (responseClass.equals(String.class)) {
-                    return responseClass.cast(response.getResponseBody("UTF-8"));
-                }
-
-                final boolean responseCodeIsExpected = expectedResponseCodes.contains(response.getStatusCode());
-                final boolean responseCodeIsSuccessful = response.getStatusCode() >= 200 && response.getStatusCode() < 300;
-                if (responseCodeIsExpected || responseCodeIsSuccessful) {
-                    T result;
-                    try {
-                        if (response.getResponseBody().isEmpty()) {
-                            return null;
-                        }
-
-                        if (responseContentType.is(MediaType.JSON_UTF_8.withoutParameters())) {
-                            result = deserializeJson(response, responseClass);
-                        } else {
-                            LOG.error("Don't know how to deserialize objects with content in {}, expected {}, failing.", responseContentType, mediaType);
-                            throw new APIException(request, response);
-                        }
-
-                        if (result == null) {
-                            throw new APIException(request, response);
-                        }
-
-                        return result;
-                    } catch (Exception e) {
-                        LOG.error("Caught Exception while deserializing JSON request: ", e);
-                        LOG.debug("Response from backend was: " + response.getResponseBody("UTF-8"));
-
-                        throw new APIException(request, response, e);
-                    }
-                } else {
-                    if (!responseCodeIsExpected) {
-                        throw new APIException(request, response);
-                    }
-                    return null;
-                }
+                return handleResponse(request, response);
             } catch (InterruptedException e) {
                 // TODO
                 target.markFailure();
@@ -508,6 +458,60 @@ class ApiClientImpl implements ApiClient {
             throw new APIException(request, new IllegalStateException("Unhandled error condition in API client"));
         }
 
+        private T handleResponse(Request request, Response response) throws IOException, APIException {
+            // TODO: once we switch to jackson we can take the media type into account automatically
+            final MediaType responseContentType;
+            if (response.getContentType() == null) {
+                responseContentType = MediaType.JSON_UTF_8;
+            } else {
+                responseContentType = MediaType.parse(response.getContentType());
+            }
+
+            if (!responseContentType.is(mediaType.withoutParameters())) {
+                LOG.warn("We said we'd accept {} but got {} back, let's see how that's going to work out...", mediaType, responseContentType);
+            }
+            if (responseClass.equals(String.class)) {
+                return responseClass.cast(response.getResponseBody("UTF-8"));
+            }
+
+            final boolean responseCodeIsExpected = expectedResponseCodes.contains(response.getStatusCode());
+            final boolean responseCodeIsSuccessful = response.getStatusCode() >= 200 && response.getStatusCode() < 300;
+            if (responseCodeIsExpected || responseCodeIsSuccessful) {
+                T result;
+                try {
+                    if (response.getResponseBody().isEmpty()) {
+                        return null;
+                    }
+
+                    if (responseContentType.is(MediaType.JSON_UTF_8.withoutParameters())) {
+                        result = deserializeJson(response, responseClass);
+                    } else {
+                        LOG.error("Don't know how to deserialize objects with content in {}, expected {}, failing.", responseContentType, mediaType);
+                        throw new APIException(request, response);
+                    }
+
+                    if (result == null) {
+                        throw new APIException(request, response);
+                    }
+
+                    return result;
+                } catch (Exception e) {
+                    LOG.error("Caught Exception while deserializing JSON request: ", e);
+                    LOG.debug("Response from backend was: " + response.getResponseBody("UTF-8"));
+
+                    throw new APIException(request, response, e);
+                }
+            } else {
+                throw new APIException(request, response);
+            }
+        }
+
+        private void ensureExpectedResponseCodes() {
+            if (expectedResponseCodes.isEmpty()) {
+                expectedResponseCodes.add(200);
+            }
+        }
+
         private void ensureAuthentication() {
             if (!unauthenticated && sessionId == null) {
                 final User user = UserService.current();
@@ -519,14 +523,22 @@ class ApiClientImpl implements ApiClient {
             }
         }
 
+        private class RequestAndFuture {
+            private final Request request;
+            private final ListenableFuture<Response> listenableFuture;
+            public RequestAndFuture(Request request, ListenableFuture<Response> listenableFuture) {
+                this.request = request;
+                this.listenableFuture = listenableFuture;
+            }
+        }
         @Override
-        public Map<Node, T> executeOnAll() {
+        public Map<Node, T> executeOnAll() throws APIException {
             HashMap<Node, T> results = Maps.newHashMap();
             if (node == null && nodes == null) {
                 nodes = serverNodes.all();
             }
 
-            final Map<Node, ListenableFuture<Response>> requests = Maps.newHashMap();
+            final Map<Node, RequestAndFuture> requests = Maps.newHashMap();
             final Collection<Response> responses = Lists.newArrayList();
 
             ensureAuthentication();
@@ -535,8 +547,11 @@ class ApiClientImpl implements ApiClient {
                 try {
                     final AsyncHttpClient.BoundRequestBuilder requestBuilder = requestBuilderForUrl(url);
                     requestBuilder.addHeader(HttpHeaders.ACCEPT, mediaType.toString());
+                    // we need it for the APIException
+
+                    final Request request = requestBuilder.build();
                     if (LOG.isDebugEnabled()) {
-                        LOG.debug("API Request: {}", requestBuilder.build().toString());
+                        LOG.debug("API Request: {}", request.toString());
                     }
                     final ListenableFuture<Response> future = requestBuilder.execute(new AsyncCompletionHandler<Response>() {
                         @Override
@@ -545,19 +560,24 @@ class ApiClientImpl implements ApiClient {
                             return response;
                         }
                     });
-                    requests.put(currentNode, future);
+                    requests.put(currentNode, new RequestAndFuture(request, future));
                 } catch (IOException e) {
                     LOG.error("Cannot execute request", e);
                     currentNode.markFailure();
                 }
             }
-            for (Map.Entry<Node, ListenableFuture<Response>> requestAndNode : requests.entrySet()) {
-                final Node node = requestAndNode.getKey();
-                final ListenableFuture<Response> request = requestAndNode.getValue();
+
+            // Set 200 OK as standard if not defined.
+            ensureExpectedResponseCodes();
+
+            for (Map.Entry<Node, RequestAndFuture> nodeAndRequest : requests.entrySet()) {
+                final Node node = nodeAndRequest.getKey();
+                final ListenableFuture<Response> future = nodeAndRequest.getValue().listenableFuture;
                 try {
-                    final Response response = request.get(timeoutValue, timeoutUnit);
+                    final Response response = future.get(timeoutValue, timeoutUnit);
                     node.touch();
-                    results.put(node, deserializeJson(response, responseClass));
+                    final T result = handleResponse(nodeAndRequest.getValue().request, response);
+                    results.put(node, result);
                 } catch (InterruptedException e) {
                     LOG.error("API call Interrupted", e);
                     node.markFailure();

--- a/graylog2-rest-client/src/main/java/org/graylog2/restclient/lib/ApiRequestBuilder.java
+++ b/graylog2-rest-client/src/main/java/org/graylog2/restclient/lib/ApiRequestBuilder.java
@@ -76,7 +76,7 @@ public interface ApiRequestBuilder<T> {
 
     T execute() throws APIException, IOException;
 
-    Map<Node, T> executeOnAll();
+    Map<Node, T> executeOnAll() throws APIException;
 
     // solely for test purposes
     URL prepareUrl(ClusterEntity node);

--- a/graylog2-rest-client/src/main/java/org/graylog2/restclient/models/ClusterService.java
+++ b/graylog2-rest-client/src/main/java/org/graylog2/restclient/models/ClusterService.java
@@ -154,7 +154,13 @@ public class ClusterService {
 
     public List<NodeJVMStats> getClusterJvmStats() {
         List<NodeJVMStats> result = Lists.newArrayList();
-        Map<Node, ClusterEntityJVMStatsResponse> rs = api.path(routes.SystemResource().jvm(), ClusterEntityJVMStatsResponse.class).fromAllNodes().executeOnAll();
+        Map<Node, ClusterEntityJVMStatsResponse> rs = null;
+        try {
+            rs = api.path(routes.SystemResource().jvm(), ClusterEntityJVMStatsResponse.class).fromAllNodes().executeOnAll();
+        } catch (APIException e) {
+            LOG.error("Unable to load JVM stats", e);
+            return result;
+        }
 
         for (Map.Entry<Node, ClusterEntityJVMStatsResponse> entry : rs.entrySet()) {
             if (entry.getValue() == null) {
@@ -168,10 +174,15 @@ public class ClusterService {
     }
 
     public F.Tuple<Integer, Integer> getClusterThroughput() {
-        final Map<Node, NodeThroughputResponse> responses =
-                api.path(routes.ThroughputResource().total(), NodeThroughputResponse.class)
-                        .fromAllNodes()
-                        .executeOnAll();
+        final Map<Node, NodeThroughputResponse> responses;
+        try {
+            responses = api.path(routes.ThroughputResource().total(), NodeThroughputResponse.class)
+                    .fromAllNodes()
+                    .executeOnAll();
+        } catch (APIException e) {
+            LOG.error("Unable to load cluster throughput", e);
+            return F.Tuple(0, 0);
+        }
         int t = 0;
         for (Map.Entry<Node, NodeThroughputResponse> entry : responses.entrySet()) {
             if (entry.getValue() == null) {

--- a/graylog2-rest-client/src/main/java/org/graylog2/restclient/models/InputService.java
+++ b/graylog2-rest-client/src/main/java/org/graylog2/restclient/models/InputService.java
@@ -18,7 +18,6 @@ package org.graylog2.restclient.models;
 
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
-import javax.inject.Inject;
 import org.graylog2.restclient.lib.APIException;
 import org.graylog2.restclient.lib.ApiClient;
 import org.graylog2.restclient.lib.ExclusiveInputException;
@@ -33,6 +32,7 @@ import org.graylog2.restroutes.generated.routes;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import javax.inject.Inject;
 import java.io.IOException;
 import java.util.AbstractMap;
 import java.util.List;
@@ -67,7 +67,12 @@ public class InputService {
 
     protected Map<ClusterEntity, InputsResponse> getInputsFromAllEntities() {
         Map<ClusterEntity, InputsResponse> result = Maps.newHashMap();
-        result.putAll(api.path(resource.list(), InputsResponse.class).fromAllNodes().executeOnAll());
+        try {
+            result.putAll(api.path(resource.list(), InputsResponse.class).fromAllNodes().executeOnAll());
+        } catch (APIException e) {
+            log.error("Unable to fetch server input list", e);
+            return result;
+        }
         try {
             for(Radio radio : nodeService.radios().values()) {
                 result.put(radio,
@@ -95,7 +100,13 @@ public class InputService {
     }
 
     protected Map<Node, InputsResponse> getInputsFromAllNodes() {
-        return api.path(resource.list(), InputsResponse.class).fromAllNodes().executeOnAll();
+        Map<Node, InputsResponse> responseMap = Maps.newHashMap();
+        try {
+            responseMap.putAll(api.path(resource.list(), InputsResponse.class).fromAllNodes().executeOnAll());
+        } catch (APIException e) {
+            log.error("Unable to fetch input list: ", e);
+        }
+        return responseMap;
     }
 
     public List<InputState> loadAllInputStates(ClusterEntity node) {

--- a/graylog2-rest-client/src/test/java/org/graylog2/restclient/lib/APIExceptionTest.java
+++ b/graylog2-rest-client/src/test/java/org/graylog2/restclient/lib/APIExceptionTest.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2012-2015 TORCH GmbH, 2015 Graylog, Inc.
+ *
+ * This file is part of Graylog.
+ *
+ * Graylog is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.graylog2.restclient.lib;
+
+import com.ning.http.client.Request;
+import com.ning.http.client.RequestBuilder;
+import com.ning.http.client.Response;
+import org.junit.Test;
+import org.mockito.internal.matchers.Contains;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.core.IsNot.not;
+
+public class APIExceptionTest {
+
+    @Test
+    public void testGetMessage() throws Exception {
+        final Request request = new RequestBuilder()
+                .setUrl("http://user:password@localhost:1234/some/path?query=foo#fragment")
+                .build();
+        final APIException apiException = new APIException(request, (Response) null);
+
+        final String message = apiException.getMessage();
+        assertThat(message, not(new Contains(":password")));
+        assertThat(message, new Contains("user@"));
+    }
+}

--- a/graylog2-rest-client/src/test/java/org/graylog2/restclient/lib/ApiClientTest.java
+++ b/graylog2-rest-client/src/test/java/org/graylog2/restclient/lib/ApiClientTest.java
@@ -1,0 +1,128 @@
+/*
+ * Copyright 2012-2015 TORCH GmbH, 2015 Graylog, Inc.
+ *
+ * This file is part of Graylog.
+ *
+ * Graylog is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.graylog2.restclient.lib;
+
+import com.ning.http.client.AsyncHttpClient;
+import com.ning.http.client.AsyncHttpClientConfig;
+import org.graylog2.restclient.models.Node;
+import org.graylog2.restclient.models.api.responses.EmptyResponse;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.net.URL;
+import java.util.Collection;
+import java.util.Iterator;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+
+public class ApiClientTest extends BaseApiTest {
+    private static final Logger log = LoggerFactory.getLogger(ApiClientTest.class);
+
+    private StubHttpProvider stubHttpProvider;
+    private AsyncHttpClient client;
+
+    @Test
+    public void testBuildTarget() throws Exception {
+        setupNodes(AddressNodeId.create("http://horst:12900"));
+
+        // we only have one node configured here
+        final Node node = serverNodes.any();
+        api.setHttpClient(client);
+
+        final URL url = api.get(EmptyResponse.class).path("/some/resource").session("foo").node(node).prepareUrl(node);
+        final URL queryParamWithPlus = api.get(EmptyResponse.class).path("/some/resource").queryParam("query", " (.+)").node(node).unauthenticated().prepareUrl(node);
+
+        Assert.assertEquals(url.getUserInfo(), "foo:session");
+        Assert.assertEquals("query param with + should be escaped", "query=+(.%2B)", queryParamWithPlus.getQuery());
+
+        final URL queryParamWithDoubleQuotes = api.get(EmptyResponse.class).path("/some/resource").queryParam("query", " \".+\"").node(node).unauthenticated().prepareUrl(node);
+        Assert.assertEquals("query param with \" should be escaped",
+                            "query=+%22.%2B%22",
+                            queryParamWithDoubleQuotes.getQuery());
+        
+        final URL urlWithNonAsciiChars = api.get(EmptyResponse.class).node(node).path("/some/resourçe").unauthenticated().prepareUrl(node);
+        Assert.assertEquals("non-ascii chars are escaped in path",
+                            "/some/resour%C3%A7e",
+                            urlWithNonAsciiChars.getPath());
+
+        final URL queryWithAmp = api.get(EmptyResponse.class).node(node).path("/").queryParam("foo", "this&that").prepareUrl(node);
+        Assert.assertEquals("Query params are escaped", "foo=this%26that", queryWithAmp.getQuery());
+    }
+
+    @Test
+    public void testSingleExecute() throws Exception {
+        setupNodes(AddressNodeId.create("http://horst:12900"));
+
+        // we only have one node configured here
+        final Node node = serverNodes.any();
+        api.setHttpClient(client);
+
+        final ApiRequestBuilder<EmptyResponse> requestBuilder =
+                api.get(EmptyResponse.class)
+                        .path("/some/resource")
+                        .unauthenticated()
+                        .node(node)
+                        .timeout(1, TimeUnit.SECONDS);
+        stubHttpProvider.expectResponse(requestBuilder.prepareUrl(node), 200, "{}");
+        final EmptyResponse response = requestBuilder.execute();
+
+        Assert.assertNotNull(response);
+        Assert.assertTrue(stubHttpProvider.isExpectationsFulfilled());
+    }
+
+    @Test
+    public void testParallelExecution() throws Exception {
+        setupNodes(AddressNodeId.create("http://horst1:12900"), AddressNodeId.create("http://horst2:12900"));
+
+        final Collection<Node> nodes = serverNodes.all();
+        final Iterator<Node> it = nodes.iterator();
+        Node node1 = it.next();
+        Node node2 = it.next();
+        api.setHttpClient(client);
+
+        final ApiRequestBuilder<EmptyResponse> requestBuilder = api.get(EmptyResponse.class).path("/some/resource");
+        final URL url1 = requestBuilder.prepareUrl(node1);
+        final URL url2 = requestBuilder.prepareUrl(node2);
+        stubHttpProvider.expectResponse(url1, 200, "{}");
+        stubHttpProvider.expectResponse(url2, 200, "{}");
+
+        final Map<Node, EmptyResponse> responses = requestBuilder.nodes(node1, node2).executeOnAll();
+        Assert.assertFalse(responses.isEmpty());
+        Assert.assertTrue(stubHttpProvider.isExpectationsFulfilled());
+    }
+
+    @Before
+    public void setUp() throws Exception {
+        AsyncHttpClientConfig.Builder builder = new AsyncHttpClientConfig.Builder();
+        builder.setAllowPoolingConnection(false);
+        stubHttpProvider = new StubHttpProvider();
+        client = new AsyncHttpClient(stubHttpProvider, builder.build());
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        client.close();
+        client = null;
+    }
+
+}

--- a/graylog2-rest-client/src/test/java/org/graylog2/restclient/lib/BaseApiTest.java
+++ b/graylog2-rest-client/src/test/java/org/graylog2/restclient/lib/BaseApiTest.java
@@ -1,0 +1,112 @@
+/*
+ * Copyright 2012-2015 TORCH GmbH, 2015 Graylog, Inc.
+ *
+ * This file is part of Graylog.
+ *
+ * Graylog is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.graylog2.restclient.lib;
+
+import com.google.common.base.Function;
+import com.google.common.collect.Collections2;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Lists;
+import com.google.inject.AbstractModule;
+import com.google.inject.Guice;
+import com.google.inject.Injector;
+import com.google.inject.Module;
+import com.google.inject.name.Names;
+import org.graylog2.restclient.models.Node;
+import org.graylog2.restclient.models.api.responses.cluster.NodeSummaryResponse;
+
+import javax.annotation.Nullable;
+import java.net.URI;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.UUID;
+import java.util.concurrent.TimeUnit;
+
+public class BaseApiTest {
+    protected ApiClient api;
+    protected ServerNodes serverNodes;
+    protected Injector injector;
+
+    public Injector setupGuice(final Collection<URI> initialNodes) {
+        List<Module> modules = Lists.newArrayList();
+        modules.add(new ModelFactoryModule());
+
+        modules.add(new AbstractModule() {
+            @Override
+            protected void configure() {
+                bind(URI[].class).annotatedWith(Names.named("Initial Nodes")).toInstance(initialNodes.toArray(new URI[initialNodes.size()]));
+                bind(Long.class).annotatedWith(Names.named("Default Timeout")).toInstance(TimeUnit.SECONDS.toMillis(5));
+            }
+        });
+        return Guice.createInjector(modules);
+    }
+
+    public void registerNodes(ServerNodes serverNodes, Node.Factory factory, AddressNodeId[] nodeDesc) {
+        final ArrayList<Node> nodes = Lists.newArrayList();
+        for (AddressNodeId n : nodeDesc) {
+            NodeSummaryResponse r = new NodeSummaryResponse();
+            r.transportAddress = n.address;
+            r.nodeId = n.nodeId;
+            final Node node = factory.fromSummaryResponse(r);
+            node.touch();
+            nodes.add(node);
+        }
+        serverNodes.put(nodes);
+    }
+
+    public void setupNodes(AddressNodeId... nodes) {
+        final ImmutableList<AddressNodeId> list = ImmutableList.copyOf(nodes);
+        final Collection<URI> uris = Collections2.transform(list, new Function<AddressNodeId, URI>() {
+            @Nullable
+            @Override
+            public URI apply(@Nullable AddressNodeId input) {
+                assert input != null;
+                return input.getUri();
+            }
+        });
+        injector = setupGuice(uris);
+        api = injector.getInstance(ApiClient.class);
+        serverNodes = injector.getInstance(ServerNodes.class);
+        final Node.Factory factory = injector.getInstance(Node.Factory.class);
+
+        registerNodes(serverNodes, factory, nodes);
+    }
+
+    public static class AddressNodeId {
+        public String address;
+        public String nodeId;
+
+        public AddressNodeId(String address, String nodeId) {
+            this.address = address;
+            this.nodeId = nodeId;
+        }
+
+        public URI getUri() {
+            return URI.create(address);
+        }
+
+        public static AddressNodeId create(String address, String nodeId) {
+            return new AddressNodeId(address, nodeId);
+        }
+
+        public static AddressNodeId create(String address) {
+            return new AddressNodeId(address, UUID.randomUUID().toString());
+        }
+    }
+}

--- a/graylog2-rest-client/src/test/java/org/graylog2/restclient/lib/ModelFactoryModule.java
+++ b/graylog2-rest-client/src/test/java/org/graylog2/restclient/lib/ModelFactoryModule.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2012-2015 TORCH GmbH, 2015 Graylog, Inc.
+ *
+ * This file is part of Graylog.
+ *
+ * Graylog is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.graylog2.restclient.lib;
+
+import com.google.inject.AbstractModule;
+import com.google.inject.assistedinject.FactoryModuleBuilder;
+import org.graylog2.restclient.models.AlarmCallback;
+import org.graylog2.restclient.models.Extractor;
+import org.graylog2.restclient.models.Index;
+import org.graylog2.restclient.models.Input;
+import org.graylog2.restclient.models.InputState;
+import org.graylog2.restclient.models.Node;
+import org.graylog2.restclient.models.Output;
+import org.graylog2.restclient.models.Radio;
+import org.graylog2.restclient.models.SavedSearch;
+import org.graylog2.restclient.models.Stream;
+import org.graylog2.restclient.models.StreamRule;
+import org.graylog2.restclient.models.SystemJob;
+import org.graylog2.restclient.models.UniversalSearch;
+import org.graylog2.restclient.models.User;
+import org.graylog2.restclient.models.accounts.LdapSettings;
+import org.graylog2.restclient.models.alerts.AlertCondition;
+import org.graylog2.restclient.models.dashboards.Dashboard;
+
+/**
+ * Provides the bindings for the factories of our models to avoid having lots of static methods everywhere.
+ */
+public class ModelFactoryModule extends AbstractModule {
+    @Override
+    protected void configure() {
+        install(new FactoryModuleBuilder().build(Node.Factory.class));
+        install(new FactoryModuleBuilder().build(Input.Factory.class));
+        install(new FactoryModuleBuilder().build(SystemJob.Factory.class));
+        install(new FactoryModuleBuilder().build(UniversalSearch.Factory.class));
+        install(new FactoryModuleBuilder().build(User.Factory.class));
+        install(new FactoryModuleBuilder().build(Extractor.Factory.class));
+        install(new FactoryModuleBuilder().build(Dashboard.Factory.class));
+        install(new FactoryModuleBuilder().build(LdapSettings.Factory.class));
+        install(new FactoryModuleBuilder().build(Stream.Factory.class));
+        install(new FactoryModuleBuilder().build(StreamRule.Factory.class));
+        install(new FactoryModuleBuilder().build(Radio.Factory.class));
+        install(new FactoryModuleBuilder().build(Index.Factory.class));
+        install(new FactoryModuleBuilder().build(SavedSearch.Factory.class));
+        install(new FactoryModuleBuilder().build(AlertCondition.Factory.class));
+        install(new FactoryModuleBuilder().build(InputState.Factory.class));
+        install(new FactoryModuleBuilder().build(AlarmCallback.Factory.class));
+        install(new FactoryModuleBuilder().build(Output.Factory.class));
+
+        // TODO crutch, because we need the factory for systemjobs in all().
+        // can this be done with a second factory for the list?
+        // or possibly with a factory method returning List<SystemJob> ?
+        requestStaticInjection(SystemJob.class);
+    }
+}

--- a/graylog2-rest-client/src/test/java/org/graylog2/restclient/lib/ServerNodesTest.java
+++ b/graylog2-rest-client/src/test/java/org/graylog2/restclient/lib/ServerNodesTest.java
@@ -1,0 +1,133 @@
+/*
+ * Copyright 2012-2015 TORCH GmbH, 2015 Graylog, Inc.
+ *
+ * This file is part of Graylog.
+ *
+ * Graylog is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.graylog2.restclient.lib;
+
+import com.google.common.collect.ImmutableList;
+import com.ning.http.client.AsyncHttpClient;
+import com.ning.http.client.AsyncHttpClientConfig;
+import org.graylog2.restclient.models.Node;
+import org.graylog2.restclient.models.api.responses.EmptyResponse;
+import org.graylog2.restclient.models.api.responses.cluster.NodeSummaryResponse;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+import static org.junit.Assert.*;
+
+public class ServerNodesTest extends BaseApiTest {
+
+    private AsyncHttpClient client;
+
+    @Test
+    public void testTransportAddressPathNormalization() {
+        setupNodes(AddressNodeId.create("http://localhost:65535"));
+        api.setHttpClient(client);
+        final Node node = serverNodes.any();
+        assertEquals("transport address should have no path", "http://localhost:65535", node.getTransportAddress());
+    }
+
+    @Test
+    public void testFailureCountSingleExecute() throws Exception {
+        setupNodes(AddressNodeId.create("http://localhost:65535"));
+        api.setHttpClient(client);
+
+        final Node node = serverNodes.any();
+
+        try {
+            api.put().path("/").node(node).execute();
+        } catch (Graylog2ServerUnavailableException e) {
+            Node failedNode = serverNodes.any(true);
+            assertFalse("Node should be from configuration", failedNode.isActive());
+            assertEquals(1, failedNode.getFailureCount());
+        }
+    }
+
+    @Test
+    public void testFailureCountParallelExecute() throws Exception {
+        setupNodes(AddressNodeId.create("http://localhost:65535"),AddressNodeId.create("http://localhost:65534"));
+        api.setHttpClient(client);
+
+        final Map<Node, EmptyResponse> emptyResponses = api.put().path("/").executeOnAll();
+
+        assertTrue("Request should have failed", emptyResponses.isEmpty());
+        final List<Node> nodes = serverNodes.all(true);
+        Node failedNode = nodes.get(0);
+        Node failedNode2 = nodes.get(1);
+        assertFalse("Node should be inactive" , failedNode.isActive());
+        assertFalse("Node should be inactive", failedNode2.isActive());
+        assertEquals(1, failedNode.getFailureCount());
+        assertEquals(1, failedNode2.getFailureCount());
+    }
+
+    @Test
+    public void testNodeObjectsRememberedByAddress() throws Exception {
+        final AddressNodeId addressNodeId = AddressNodeId.create("http://localhost:65535", UUID.randomUUID().toString());
+        setupNodes(addressNodeId);
+
+        api.setHttpClient(client);
+        final Node firstNode = serverNodes.any();
+
+        Throwable t = null;
+        try {
+            api.put().path("/").node(firstNode).execute();
+        } catch (Graylog2ServerUnavailableException e) {
+            t = e;
+        }
+        assertNotNull("Should have thrown an Graylog2ServerUnavailableException", t);
+        assertEquals("First node failure count should be 1", 1, firstNode.getFailureCount());
+
+        final Node.Factory nodeFactory = injector.getInstance(Node.Factory.class);
+        final NodeSummaryResponse r1 = new NodeSummaryResponse();
+        r1.transportAddress = "http://localhost:65534";
+        r1.nodeId = UUID.randomUUID().toString();
+
+        final Node newNode = nodeFactory.fromSummaryResponse(r1);
+        newNode.touch();
+        final NodeSummaryResponse r2 = new NodeSummaryResponse();
+        r2.transportAddress = firstNode.getTransportAddress();
+        r2.nodeId = firstNode.getNodeId();
+        final Node sameAsInitialNode = nodeFactory.fromSummaryResponse(r2);
+        sameAsInitialNode.touch();
+        serverNodes.put(ImmutableList.of(newNode, sameAsInitialNode));
+
+        final Map<Node, EmptyResponse> responses = api.put().nodes(serverNodes.all().toArray(new Node[0])).path("/").executeOnAll();
+
+        assertTrue(responses.isEmpty());
+        assertEquals("new node's failureCount is 1", 1, newNode.getFailureCount());
+        assertEquals("initial node's failureCount is 2", 2, firstNode.getFailureCount());
+
+    }
+
+    @Before
+    public void setUp() throws Exception {
+        AsyncHttpClientConfig.Builder builder = new AsyncHttpClientConfig.Builder();
+        builder.setAllowPoolingConnection(false);
+        client = new AsyncHttpClient(builder.build());
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        client.close();
+        client = null;
+    }
+}

--- a/graylog2-rest-client/src/test/java/org/graylog2/restclient/lib/StubHttpProvider.java
+++ b/graylog2-rest-client/src/test/java/org/graylog2/restclient/lib/StubHttpProvider.java
@@ -1,0 +1,389 @@
+/*
+ * Copyright 2012-2015 TORCH GmbH, 2015 Graylog, Inc.
+ *
+ * This file is part of Graylog.
+ *
+ * Graylog is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.graylog2.restclient.lib;
+
+import com.google.common.collect.Maps;
+import com.google.common.collect.Sets;
+import com.ning.http.client.AsyncHandler;
+import com.ning.http.client.AsyncHttpProvider;
+import com.ning.http.client.FluentCaseInsensitiveStringsMap;
+import com.ning.http.client.HttpResponseBodyPart;
+import com.ning.http.client.HttpResponseHeaders;
+import com.ning.http.client.HttpResponseStatus;
+import com.ning.http.client.ListenableFuture;
+import com.ning.http.client.Request;
+import com.ning.http.client.Response;
+import com.ning.http.client.cookie.Cookie;
+import com.ning.http.client.listenable.AbstractListenableFuture;
+import play.mvc.Http;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.net.MalformedURLException;
+import java.net.URI;
+import java.net.URL;
+import java.nio.ByteBuffer;
+import java.nio.charset.Charset;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
+public class StubHttpProvider implements AsyncHttpProvider {
+
+    private Map<URL, Expectation> expectations = Maps.newHashMap();
+    private Set<Expectation> fulfilledExpectations = Sets.newHashSet();
+
+    public StubHttpProvider expectResponse(URL url, int statusCode, String payload) {
+        expectations.put(url, new Expectation(url, statusCode, payload));
+        return this;
+    }
+
+    /**
+     * Can be used to re-use the same StubHttpProvider in test cases, but it's cheap enough to tearDown/setUp a new instance
+     */
+    public void reset() {
+        fulfilledExpectations.clear();
+        expectations.clear();
+    }
+
+    public boolean isExpectationsFulfilled() {
+        return unfulfilledExpectations().isEmpty();
+    }
+
+    public Set<Expectation> unfulfilledExpectations() {
+        return Sets.difference(Sets.newHashSet(expectations.values()), fulfilledExpectations);
+    }
+
+    @Override
+    public <T> ListenableFuture<T> execute(Request request, AsyncHandler<T> handler) throws IOException {
+        final Expectation expectation = expectations.get(new URL(request.getUrl()));
+        if (expectation == null) {
+            throw new RuntimeException("Unknown URL requested, failing test: " + request.getUrl());
+        }
+        fulfilledExpectations.add(expectation);
+        T t = null;
+        try {
+            final URI uri = expectation.getUrl().toURI();
+            handler.onStatusReceived(new HttpResponseStatus(uri, this) {
+                @Override
+                public int getStatusCode() {
+                    return expectation.getStatusCode();
+                }
+
+                @Override
+                public String getStatusText() {
+                    return ""; // TODO
+                }
+
+                @Override
+                public String getProtocolName() {
+                    return expectation.getUrl().getProtocol();
+                }
+
+                @Override
+                public int getProtocolMajorVersion() {
+                    return 1;
+                }
+
+                @Override
+                public int getProtocolMinorVersion() {
+                    return 1;
+                }
+
+                @Override
+                public String getProtocolText() {
+                    return ""; // TODO
+                }
+            });
+            handler.onHeadersReceived(new HttpResponseHeaders(uri, this) {
+                @Override
+                public FluentCaseInsensitiveStringsMap getHeaders() {
+                    return new FluentCaseInsensitiveStringsMap();
+                }
+            });
+            handler.onBodyPartReceived(new HttpResponseBodyPart(uri, this) {
+                @Override
+                public byte[] getBodyPartBytes() {
+                    return expectation.getPayload().getBytes(Charset.forName("UTF-8"));
+                }
+
+                @Override
+                public int writeTo(OutputStream outputStream) throws IOException {
+                    final byte[] bodyPartBytes = getBodyPartBytes();
+                    outputStream.write(bodyPartBytes);
+                    return bodyPartBytes.length;
+                }
+
+                @Override
+                public ByteBuffer getBodyByteBuffer() {
+                    return ByteBuffer.wrap(getBodyPartBytes());
+                }
+
+                @Override
+                public boolean isLast() {
+                    return true;
+                }
+
+                @Override
+                public void markUnderlyingConnectionAsClosed() {
+                }
+
+                @Override
+                public boolean closeUnderlyingConnection() {
+                    return true;
+                }
+
+                @Override
+                public int length() {
+                    return getBodyPartBytes().length;
+                }
+            });
+            t = handler.onCompleted();
+        } catch (Exception e) {
+            e.printStackTrace();  //To change body of catch statement use File | Settings | File Templates.
+        }
+        final T finalT = t;
+        final Future<T> futureT = Executors.newSingleThreadExecutor().submit(new Callable<T>() {
+            @Override
+            public T call() throws Exception {
+                return finalT;
+            }
+        });
+        return new ImmediateFuture<>(futureT);
+    }
+
+    @Override
+    public void close() {
+    }
+
+    @Override
+    public Response prepareResponse(final HttpResponseStatus status, final HttpResponseHeaders headers, final List<HttpResponseBodyPart> bodyParts) {
+        final HttpResponseBodyPart bodyPart = bodyParts.get(0);
+        return new Response() {
+            @Override
+            public int getStatusCode() {
+                return status.getStatusCode();
+            }
+
+            @Override
+            public String getStatusText() {
+                return status.getStatusText();
+            }
+
+            @Override
+            public byte[] getResponseBodyAsBytes() throws IOException {
+                return bodyPart.getBodyPartBytes();
+            }
+
+            @Override
+            public ByteBuffer getResponseBodyAsByteBuffer() throws IOException {
+                return bodyPart.getBodyByteBuffer();
+            }
+
+            @Override
+            public InputStream getResponseBodyAsStream() throws IOException {
+                return null; // TODO
+            }
+
+            @Override
+            public String getResponseBodyExcerpt(int maxLength, String charset) throws IOException {
+                return ""; // TODO
+            }
+
+            @Override
+            public String getResponseBody(String charset) throws IOException {
+                return new String(bodyPart.getBodyPartBytes(), charset);
+            }
+
+            @Override
+            public String getResponseBodyExcerpt(int maxLength) throws IOException {
+                return null; // TODO
+            }
+
+            @Override
+            public String getResponseBody() throws IOException {
+                return new String(bodyPart.getBodyPartBytes());
+            }
+
+            @Override
+            public URI getUri() throws MalformedURLException {
+                return status.getUrl();
+            }
+
+            @Override
+            public String getContentType() {
+                return Http.MimeTypes.JSON;
+            }
+
+            @Override
+            public String getHeader(String name) {
+                return headers.getHeaders().get(name).get(0);
+            }
+
+            @Override
+            public List<String> getHeaders(String name) {
+                return headers.getHeaders().get(name);
+            }
+
+            @Override
+            public FluentCaseInsensitiveStringsMap getHeaders() {
+                return headers.getHeaders();
+            }
+
+            @Override
+            public boolean isRedirected() {
+                return false;
+            }
+
+            @Override
+            public List<Cookie> getCookies() {
+                return null;
+            }
+
+            @Override
+            public boolean hasResponseStatus() {
+                return false;
+            }
+
+            @Override
+            public boolean hasResponseHeaders() {
+                return false;
+            }
+
+            @Override
+            public boolean hasResponseBody() {
+                return false;
+            }
+        };
+    }
+
+    private class Expectation {
+
+        private final URL url;
+        private final int statusCode;
+        private final String payload;
+
+        public Expectation(URL url, int statusCode, String payload) {
+            this.url = url;
+            this.statusCode = statusCode;
+            this.payload = payload;
+        }
+
+        private URL getUrl() {
+            return url;
+        }
+
+        private int getStatusCode() {
+            return statusCode;
+        }
+
+        private String getPayload() {
+            return payload;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if (o == null || getClass() != o.getClass()) return false;
+
+            Expectation that = (Expectation) o;
+
+            if (statusCode != that.statusCode) return false;
+            if (!payload.equals(that.payload)) return false;
+            if (!url.equals(that.url)) return false;
+
+            return true;
+        }
+
+        @Override
+        public int hashCode() {
+            int result = url.hashCode();
+            result = 31 * result + statusCode;
+            result = 31 * result + payload.hashCode();
+            return result;
+        }
+    }
+
+    private class ImmediateFuture<V> extends AbstractListenableFuture<V> {
+
+        private final Future<V> response;
+
+        public ImmediateFuture(Future<V> response) {
+            this.response = response;
+        }
+
+        @Override
+        public void done() {
+        }
+
+        @Override
+        public void abort(Throwable t) {
+        }
+
+        @Override
+        public void content(V v) {
+        }
+
+        @Override
+        public void touch() {
+        }
+
+        @Override
+        public boolean getAndSetWriteHeaders(boolean writeHeader) {
+            return false;
+        }
+
+        @Override
+        public boolean getAndSetWriteBody(boolean writeBody) {
+            return false;
+        }
+
+        @Override
+        public boolean cancel(boolean mayInterruptIfRunning) {
+            return false;
+        }
+
+        @Override
+        public boolean isCancelled() {
+            return false;
+        }
+
+        @Override
+        public boolean isDone() {
+            return true;
+        }
+
+        @Override
+        public V get() throws InterruptedException, ExecutionException {
+            return response.get();
+        }
+
+        @Override
+        public V get(long timeout, TimeUnit unit) throws InterruptedException, ExecutionException, TimeoutException {
+            return response.get(timeout, unit);
+        }
+    }
+}


### PR DESCRIPTION
instead, it now throws an exception if any of the parallel requests failed due to an unexpected return code (e.g. 401) which gives the caller the opportunity to return an error code to its caller (usually the UI)
extracted common code between execute() and executeOnAll() to reduce the fragility of the latter
copied missing test cases from the web interface repository

fixes Graylog2/graylog2-web-interface#1205