### PR TITLE
Cluster config

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/bindings/ServerBindings.java
+++ b/graylog2-server/src/main/java/org/graylog2/bindings/ServerBindings.java
@@ -44,6 +44,7 @@ import org.graylog2.bindings.providers.SystemJobManagerProvider;
 import org.graylog2.buffers.processors.ServerProcessBufferProcessor;
 import org.graylog2.bundles.BundleService;
 import org.graylog2.database.MongoConnection;
+import org.graylog2.events.ClusterEventBus;
 import org.graylog2.filters.FilterService;
 import org.graylog2.filters.FilterServiceImpl;
 import org.graylog2.indexer.SetIndexReadOnlyJob;
@@ -119,7 +120,7 @@ public class ServerBindings extends AbstractModule {
 
     private void bindProviders() {
         bind(RotationStrategy.class).toProvider(RotationStrategyProvider.class);
-        bind(EventBus.class).annotatedWith(named("cluster_event_bus")).toProvider(ClusterEventBusProvider.class).asEagerSingleton();
+        bind(EventBus.class).annotatedWith(ClusterEventBus.class).toProvider(ClusterEventBusProvider.class).asEagerSingleton();
     }
 
     private void bindFactoryModules() {

--- a/graylog2-server/src/main/java/org/graylog2/cluster/ClusterConfig.java
+++ b/graylog2-server/src/main/java/org/graylog2/cluster/ClusterConfig.java
@@ -1,0 +1,67 @@
+/**
+ * This file is part of Graylog.
+ *
+ * Graylog is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.graylog2.cluster;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.auto.value.AutoValue;
+import org.hibernate.validator.constraints.NotEmpty;
+import org.joda.time.DateTime;
+import org.joda.time.DateTimeZone;
+import org.mongojack.Id;
+import org.mongojack.ObjectId;
+
+import javax.annotation.Nullable;
+
+@AutoValue
+public abstract class ClusterConfig {
+    @Id
+    @ObjectId
+    @Nullable
+    public abstract String id();
+
+    @JsonProperty
+    @Nullable
+    public abstract String type();
+
+    @JsonProperty
+    @Nullable
+    public abstract Object payload();
+
+    @JsonProperty
+    @Nullable
+    public abstract DateTime lastUpdated();
+
+    @JsonProperty
+    @Nullable
+    public abstract String lastUpdatedBy();
+
+    @JsonCreator
+    public static ClusterConfig create(@Id @ObjectId @JsonProperty("_id") @Nullable String id,
+                                       @JsonProperty("type") @Nullable String type,
+                                       @JsonProperty("payload") @Nullable Object payload,
+                                       @JsonProperty("last_updated") @Nullable DateTime lastUpdated,
+                                       @JsonProperty("last_updated_by") @Nullable String lastUpdatedBy) {
+        return new AutoValue_ClusterConfig(id, type, payload, lastUpdated, lastUpdatedBy);
+    }
+
+    public static ClusterConfig create(@NotEmpty String type,
+                                       @NotEmpty Object payload,
+                                       @NotEmpty String nodeId) {
+        return create(null, type, payload, DateTime.now(DateTimeZone.UTC), nodeId);
+    }
+}

--- a/graylog2-server/src/main/java/org/graylog2/cluster/ClusterConfigChangedEvent.java
+++ b/graylog2-server/src/main/java/org/graylog2/cluster/ClusterConfigChangedEvent.java
@@ -1,0 +1,46 @@
+/**
+ * This file is part of Graylog.
+ *
+ * Graylog is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.graylog2.cluster;
+
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.auto.value.AutoValue;
+import org.hibernate.validator.constraints.NotEmpty;
+import org.joda.time.DateTime;
+
+@JsonAutoDetect
+@AutoValue
+public abstract class ClusterConfigChangedEvent {
+    @JsonProperty
+    public abstract DateTime date();
+
+    @JsonProperty
+    @NotEmpty
+    public abstract String nodeId();
+
+    @JsonProperty
+    @NotEmpty
+    public abstract String type();
+
+    @JsonCreator
+    public static ClusterConfigChangedEvent create(@JsonProperty("date") DateTime date,
+                                                   @JsonProperty("node_id") @NotEmpty String nodeId,
+                                                   @JsonProperty("type") @NotEmpty String type) {
+        return new AutoValue_ClusterConfigChangedEvent(date, nodeId, type);
+    }
+}

--- a/graylog2-server/src/main/java/org/graylog2/cluster/ClusterConfigService.java
+++ b/graylog2-server/src/main/java/org/graylog2/cluster/ClusterConfigService.java
@@ -1,0 +1,123 @@
+/**
+ * This file is part of Graylog.
+ *
+ * Graylog is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.graylog2.cluster;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.eventbus.EventBus;
+import com.mongodb.DBCollection;
+import com.mongodb.WriteConcern;
+import org.graylog2.bindings.providers.MongoJackObjectMapperProvider;
+import org.graylog2.database.MongoConnection;
+import org.graylog2.events.ClusterEventBus;
+import org.graylog2.plugin.ServerStatus;
+import org.graylog2.plugin.system.NodeId;
+import org.graylog2.shared.utilities.AutoValueUtils;
+import org.joda.time.DateTime;
+import org.joda.time.DateTimeZone;
+import org.mongojack.DBQuery;
+import org.mongojack.DBSort;
+import org.mongojack.JacksonDBCollection;
+import org.mongojack.WriteResult;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.inject.Inject;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+public class ClusterConfigService {
+    private static final Logger LOG = LoggerFactory.getLogger(ClusterConfigService.class);
+
+    @VisibleForTesting
+    static final String COLLECTION_NAME = "cluster_config";
+
+    private final JacksonDBCollection<ClusterConfig, String> dbCollection;
+    private final NodeId nodeId;
+    private final ObjectMapper objectMapper;
+    private final EventBus clusterEventBus;
+
+    @Inject
+    public ClusterConfigService(final MongoJackObjectMapperProvider mapperProvider,
+                                final MongoConnection mongoConnection,
+                                final NodeId nodeId,
+                                final ObjectMapper objectMapper,
+                                @ClusterEventBus final EventBus clusterEventBus) {
+        this(JacksonDBCollection.wrap(prepareCollection(mongoConnection), ClusterConfig.class, String.class, mapperProvider.get()),
+                nodeId, objectMapper, clusterEventBus);
+    }
+
+    ClusterConfigService(final JacksonDBCollection<ClusterConfig, String> dbCollection,
+                         final NodeId nodeId,
+                         final ObjectMapper objectMapper,
+                         final EventBus clusterEventBus) {
+        this.nodeId = checkNotNull(nodeId);
+        this.dbCollection = checkNotNull(dbCollection);
+        this.objectMapper = checkNotNull(objectMapper);
+        this.clusterEventBus = checkNotNull(clusterEventBus);
+    }
+
+    @VisibleForTesting
+    static DBCollection prepareCollection(final MongoConnection mongoConnection) {
+        DBCollection coll = mongoConnection.getDatabase().getCollection(COLLECTION_NAME);
+        coll.createIndex(DBSort.asc("type"), "unique_type", true);
+        coll.setWriteConcern(WriteConcern.MAJORITY);
+
+        return coll;
+    }
+
+    private <T> T extractPayload(Object payload, Class<T> type) {
+        try {
+            return objectMapper.convertValue(payload, type);
+        } catch (IllegalArgumentException e) {
+            LOG.debug("Error while deserializing payload", e);
+            return null;
+        }
+    }
+
+    public <T> T get(Class<T> type) {
+        ClusterConfig config = dbCollection.findOne(DBQuery.is("type", type.getCanonicalName()));
+
+        if(config == null) {
+            LOG.warn("Couldn't find cluster config of type {}", type.getCanonicalName());
+            return null;
+        }
+
+        T result = extractPayload(config.payload(), type);
+        if(result == null) {
+            LOG.error("Couldn't extract payload from cluster config (type: {})", type.getCanonicalName());
+        }
+
+        return result;
+    }
+
+    public <T> void write(T payload) {
+        if(payload == null) {
+            LOG.debug("Payload was null. Skipping.");
+            return;
+        }
+
+        String canonicalClassName = AutoValueUtils.getCanonicalName(payload.getClass());
+        ClusterConfig clusterConfig = ClusterConfig.create(canonicalClassName, payload, nodeId.toString());
+
+        dbCollection.update(DBQuery.is("type", canonicalClassName), clusterConfig, true, false, WriteConcern.MAJORITY);
+
+        ClusterConfigChangedEvent event = ClusterConfigChangedEvent.create(
+                DateTime.now(DateTimeZone.UTC), nodeId.toString(), canonicalClassName);
+        clusterEventBus.post(event);
+    }
+}

--- a/graylog2-server/src/main/java/org/graylog2/events/ClusterEventBus.java
+++ b/graylog2-server/src/main/java/org/graylog2/events/ClusterEventBus.java
@@ -1,0 +1,33 @@
+/**
+ * This file is part of Graylog.
+ *
+ * Graylog is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.graylog2.events;
+
+import com.google.inject.BindingAnnotation;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import static java.lang.annotation.ElementType.FIELD;
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.ElementType.PARAMETER;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+@BindingAnnotation
+@Target({FIELD, PARAMETER, METHOD})
+@Retention(RUNTIME)
+public @interface ClusterEventBus {
+}

--- a/graylog2-server/src/main/java/org/graylog2/events/ClusterEventPeriodical.java
+++ b/graylog2-server/src/main/java/org/graylog2/events/ClusterEventPeriodical.java
@@ -32,6 +32,7 @@ import org.graylog2.bindings.providers.MongoJackObjectMapperProvider;
 import org.graylog2.database.MongoConnection;
 import org.graylog2.plugin.periodical.Periodical;
 import org.graylog2.plugin.system.NodeId;
+import org.graylog2.shared.utilities.AutoValueUtils;
 import org.mongojack.DBCursor;
 import org.mongojack.DBSort;
 import org.mongojack.DBUpdate;
@@ -176,7 +177,7 @@ public class ClusterEventPeriodical extends Periodical {
             return;
         }
 
-        final String className = getCanonicalName(event.getClass());
+        final String className = AutoValueUtils.getCanonicalName(event.getClass());
         final ClusterEvent clusterEvent = ClusterEvent.create(nodeId.toString(), className, event);
 
         try {
@@ -217,25 +218,5 @@ public class ClusterEventPeriodical extends Periodical {
             return null;
 
         }
-    }
-
-    /**
-     * Get the canonical class name of the provided {@link Class} with special handling of Google AutoValue classes.
-     *
-     * @param aClass a class
-     * @return the canonical class name of {@code aClass} or its super class in case of an auto-generated class by
-     * Google AutoValue
-     * @see Class#getCanonicalName()
-     * @see com.google.auto.value.AutoValue
-     */
-    private String getCanonicalName(final Class<?> aClass) {
-        final Class<?> cls;
-        if (aClass.getSimpleName().startsWith("AutoValue_")) {
-            cls = aClass.getSuperclass();
-        } else {
-            cls = aClass;
-        }
-
-        return cls.getCanonicalName();
     }
 }

--- a/graylog2-server/src/main/java/org/graylog2/events/ClusterEventPeriodical.java
+++ b/graylog2-server/src/main/java/org/graylog2/events/ClusterEventPeriodical.java
@@ -42,7 +42,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import javax.inject.Inject;
-import javax.inject.Named;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
@@ -63,7 +62,7 @@ public class ClusterEventPeriodical extends Periodical {
                                   final NodeId nodeId,
                                   final ObjectMapper objectMapper,
                                   final EventBus serverEventBus,
-                                  @Named("cluster_event_bus") final EventBus clusterEventBus) {
+                                  @ClusterEventBus final EventBus clusterEventBus) {
         this(JacksonDBCollection.wrap(prepareCollection(mongoConnection), ClusterEvent.class, String.class, mapperProvider.get()),
                 nodeId, objectMapper, serverEventBus, clusterEventBus);
     }
@@ -87,7 +86,7 @@ public class ClusterEventPeriodical extends Periodical {
 
         DBCollection coll = db.getCollection(COLLECTION_NAME);
 
-        if(coll.isCapped()) {
+        if (coll.isCapped()) {
             LOG.warn("The \"{}\" collection in MongoDB is capped which will cause problems. Please drop the collection.", COLLECTION_NAME);
         }
 
@@ -147,7 +146,7 @@ public class ClusterEventPeriodical extends Periodical {
             LOG.debug("Opening MongoDB cursor on \"{}\"", COLLECTION_NAME);
 
             final DBCursor<ClusterEvent> cursor = eventCursor(nodeId);
-            if(LOG.isTraceEnabled()) {
+            if (LOG.isTraceEnabled()) {
                 LOG.trace("MongoDB query plan: {}", cursor.explain());
             }
 

--- a/graylog2-server/src/main/java/org/graylog2/rest/resources/system/debug/DebugEventsResource.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/resources/system/debug/DebugEventsResource.java
@@ -22,6 +22,7 @@ import com.wordnik.swagger.annotations.Api;
 import com.wordnik.swagger.annotations.ApiOperation;
 import com.wordnik.swagger.annotations.ApiParam;
 import org.apache.shiro.authz.annotation.RequiresAuthentication;
+import org.graylog2.events.ClusterEventBus;
 import org.graylog2.plugin.system.NodeId;
 import org.graylog2.shared.rest.resources.RestResource;
 import org.graylog2.system.debug.DebugEvent;
@@ -29,7 +30,6 @@ import org.graylog2.system.debug.DebugEventHolder;
 
 import javax.annotation.Nullable;
 import javax.inject.Inject;
-import javax.inject.Named;
 import javax.ws.rs.Consumes;
 import javax.ws.rs.GET;
 import javax.ws.rs.POST;
@@ -52,7 +52,7 @@ public class DebugEventsResource extends RestResource {
     @Inject
     public DebugEventsResource(NodeId nodeId,
                                EventBus serverEventBus,
-                               @Named("cluster_event_bus") EventBus clusterEventBus) {
+                               @ClusterEventBus EventBus clusterEventBus) {
         this.nodeId = checkNotNull(nodeId);
         this.serverEventBus = checkNotNull(serverEventBus);
         this.clusterEventBus = checkNotNull(clusterEventBus);

--- a/graylog2-server/src/main/java/org/graylog2/system/debug/ClusterDebugEventListener.java
+++ b/graylog2-server/src/main/java/org/graylog2/system/debug/ClusterDebugEventListener.java
@@ -18,11 +18,11 @@ package org.graylog2.system.debug;
 
 import com.google.common.eventbus.EventBus;
 import com.google.common.eventbus.Subscribe;
+import org.graylog2.events.ClusterEventBus;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import javax.inject.Inject;
-import javax.inject.Named;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
@@ -30,7 +30,7 @@ public class ClusterDebugEventListener {
     private static final Logger LOG = LoggerFactory.getLogger(ClusterDebugEventListener.class);
 
     @Inject
-    public ClusterDebugEventListener(@Named("cluster_event_bus") EventBus clusterEventBus) {
+    public ClusterDebugEventListener(@ClusterEventBus EventBus clusterEventBus) {
         checkNotNull(clusterEventBus).register(this);
     }
 

--- a/graylog2-server/src/test/java/org/graylog2/cluster/ClusterConfigServiceTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/cluster/ClusterConfigServiceTest.java
@@ -1,0 +1,274 @@
+/**
+ * This file is part of Graylog.
+ *
+ * Graylog is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.graylog2.cluster;
+
+import com.codahale.metrics.json.MetricsModule;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.PropertyNamingStrategy;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.databind.module.SimpleModule;
+import com.fasterxml.jackson.datatype.guava.GuavaModule;
+import com.fasterxml.jackson.datatype.joda.JodaModule;
+import com.google.common.eventbus.EventBus;
+import com.google.common.eventbus.Subscribe;
+import com.lordofthejars.nosqlunit.annotation.UsingDataSet;
+import com.lordofthejars.nosqlunit.core.LoadStrategyEnum;
+import com.lordofthejars.nosqlunit.mongodb.InMemoryMongoDb;
+import com.mongodb.BasicDBObjectBuilder;
+import com.mongodb.DBCollection;
+import com.mongodb.DBObject;
+import com.mongodb.WriteConcern;
+import org.graylog2.bindings.providers.MongoJackObjectMapperProvider;
+import org.graylog2.database.MongoConnection;
+import org.graylog2.database.MongoConnectionRule;
+import org.graylog2.database.ObjectIdSerializer;
+import org.graylog2.plugin.system.NodeId;
+import org.graylog2.shared.jackson.SizeSerializer;
+import org.graylog2.shared.rest.RangeJsonSerializer;
+import org.joda.time.DateTime;
+import org.joda.time.DateTimeUtils;
+import org.joda.time.DateTimeZone;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.Spy;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import java.util.Collections;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+
+import static com.lordofthejars.nosqlunit.mongodb.InMemoryMongoDb.InMemoryMongoRuleBuilder.newInMemoryMongoDbRule;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+
+@RunWith(MockitoJUnitRunner.class)
+public class ClusterConfigServiceTest {
+    @ClassRule
+    public static final InMemoryMongoDb IN_MEMORY_MONGO_DB = newInMemoryMongoDbRule().build();
+    private static final DateTime TIME = new DateTime(2015, 4, 1, 0, 0, DateTimeZone.UTC);
+    private static final String COLLECTION_NAME = ClusterConfigService.COLLECTION_NAME;
+
+    @Rule
+    public MongoConnectionRule mongoRule = MongoConnectionRule.build("test");
+    private final ObjectMapper objectMapper = new ObjectMapper()
+            .disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS)
+            .setPropertyNamingStrategy(new PropertyNamingStrategy.LowerCaseWithUnderscoresStrategy())
+            .registerModule(new JodaModule())
+            .registerModule(new GuavaModule())
+            .registerModule(new MetricsModule(TimeUnit.SECONDS, TimeUnit.SECONDS, false))
+            .registerModule(new SimpleModule()
+                    .addSerializer(new ObjectIdSerializer())
+                    .addSerializer(new RangeJsonSerializer())
+                    .addSerializer(new SizeSerializer()));
+    @Mock
+    private NodeId nodeId;
+    @Spy
+    private EventBus clusterEventBus;
+    private MongoConnection mongoConnection;
+    private ClusterConfigService clusterConfigService;
+
+    @Before
+    public void setUpService() throws Exception {
+        DateTimeUtils.setCurrentMillisFixed(TIME.getMillis());
+
+        this.mongoConnection = mongoRule.getMongoConnection();
+
+        MongoJackObjectMapperProvider provider = new MongoJackObjectMapperProvider(objectMapper);
+        when(nodeId.toString()).thenReturn("ID");
+
+        this.clusterConfigService = new ClusterConfigService(
+                provider,
+                mongoRule.getMongoConnection(),
+                nodeId,
+                objectMapper,
+                clusterEventBus
+        );
+    }
+
+    @After
+    public void tearDown() {
+        DateTimeUtils.setCurrentMillisSystem();
+    }
+
+    @Test
+    @UsingDataSet(loadStrategy = LoadStrategyEnum.DELETE_ALL)
+    public void getReturnsExistingConfig() throws Exception {
+        DBObject dbObject = new BasicDBObjectBuilder()
+                .add("type", CustomConfig.class.getCanonicalName())
+                .add("payload", Collections.singletonMap("text", "TEST"))
+                .add("last_updated", TIME.toString())
+                .add("last_updated_by", "ID")
+                .get();
+        final DBCollection collection = mongoConnection.getDatabase().getCollection(COLLECTION_NAME);
+        collection.save(dbObject);
+
+        assertThat(collection.count()).isEqualTo(1L);
+
+        CustomConfig customConfig = clusterConfigService.get(CustomConfig.class);
+        assertThat(customConfig.text).isEqualTo("TEST");
+    }
+
+    @Test
+    @UsingDataSet(loadStrategy = LoadStrategyEnum.DELETE_ALL)
+    public void getReturnsNullOnNonExistingConfig() throws Exception {
+        final DBCollection collection = mongoConnection.getDatabase().getCollection(COLLECTION_NAME);
+        assertThat(collection.count()).isEqualTo(0L);
+
+        assertThat(clusterConfigService.get(CustomConfig.class)).isNull();
+    }
+
+    @Test
+    @UsingDataSet(loadStrategy = LoadStrategyEnum.DELETE_ALL)
+    public void getReturnsNullOnInvalidPayload() throws Exception {
+        DBObject dbObject = new BasicDBObjectBuilder()
+                .add("type", CustomConfig.class.getCanonicalName())
+                .add("payload", "wrong payload")
+                .add("last_updated", TIME.toString())
+                .add("last_updated_by", "ID")
+                .get();
+        final DBCollection collection = mongoConnection.getDatabase().getCollection(COLLECTION_NAME);
+        collection.save(dbObject);
+
+        assertThat(collection.count()).isEqualTo(1L);
+
+        assertThat(clusterConfigService.get(CustomConfig.class)).isNull();
+    }
+
+    @Test
+    @UsingDataSet(loadStrategy = LoadStrategyEnum.DELETE_ALL)
+    public void writeIgnoresNull() throws Exception {
+        final DBCollection collection = mongoConnection.getDatabase().getCollection(COLLECTION_NAME);
+        assertThat(collection.count()).isEqualTo(0L);
+
+        clusterConfigService.write(null);
+
+        assertThat(collection.count()).isEqualTo(0L);
+    }
+
+    @Test
+    @UsingDataSet(loadStrategy = LoadStrategyEnum.DELETE_ALL)
+    public void writePersistsClusterConfig() throws Exception {
+        CustomConfig customConfig = new CustomConfig();
+        customConfig.text = "TEST";
+
+        final DBCollection collection = mongoConnection.getDatabase().getCollection(COLLECTION_NAME);
+        assertThat(collection.count()).isEqualTo(0L);
+
+        clusterConfigService.write(customConfig);
+
+        assertThat(collection.count()).isEqualTo(1L);
+
+        DBObject dbObject = collection.findOne();
+        assertThat((String) dbObject.get("type")).isEqualTo(CustomConfig.class.getCanonicalName());
+        assertThat((String) dbObject.get("last_updated_by")).isEqualTo("ID");
+    }
+
+    @Test
+    @UsingDataSet(loadStrategy = LoadStrategyEnum.DELETE_ALL)
+    public void writeUpdatesExistingClusterConfig() throws Exception {
+        CustomConfig customConfig = new CustomConfig();
+        customConfig.text = "TEST";
+
+        DBObject seedObject = new BasicDBObjectBuilder()
+                .add("type", CustomConfig.class.getCanonicalName())
+                .add("payload", Collections.singletonMap("text", "ORIGINAL"))
+                .add("last_updated", TIME.toString())
+                .add("last_updated_by", "NOT ID")
+                .get();
+        final DBCollection collection = mongoConnection.getDatabase().getCollection(COLLECTION_NAME);
+        collection.save(seedObject);
+        assertThat(collection.count()).isEqualTo(1L);
+
+        clusterConfigService.write(customConfig);
+
+        assertThat(collection.count()).isEqualTo(1L);
+
+        DBObject dbObject = collection.findOne();
+        assertThat((String) dbObject.get("type")).isEqualTo(CustomConfig.class.getCanonicalName());
+        assertThat((String) dbObject.get("last_updated_by")).isEqualTo("ID");
+
+        @SuppressWarnings("unchecked")
+        Map<String, Object> payload = (Map<String, Object>) dbObject.get("payload");
+
+        assertThat(payload).containsEntry("text", "TEST");
+    }
+
+    @Test
+    @UsingDataSet(loadStrategy = LoadStrategyEnum.DELETE_ALL)
+    public void writePostsClusterConfigChangedEvent() throws Exception {
+        CustomConfig customConfig = new CustomConfig();
+        customConfig.text = "TEST";
+
+        final ClusterConfigChangedEventHandler eventHandler = new ClusterConfigChangedEventHandler();
+        clusterEventBus.register(eventHandler);
+
+        final DBCollection collection = mongoConnection.getDatabase().getCollection(COLLECTION_NAME);
+        assertThat(collection.count()).isEqualTo(0L);
+
+        clusterConfigService.write(customConfig);
+
+        assertThat(collection.count()).isEqualTo(1L);
+        assertThat(eventHandler.event).isNotNull();
+        assertThat(eventHandler.event.nodeId()).isEqualTo("ID");
+        assertThat(eventHandler.event.type()).isEqualTo(CustomConfig.class.getCanonicalName());
+
+        clusterEventBus.unregister(eventHandler);
+    }
+
+
+    @Test
+    public void prepareCollectionCreatesIndexesOnExistingCollection() throws Exception {
+        DBCollection original = mongoConnection.getDatabase().createCollection(COLLECTION_NAME, null);
+        original.dropIndexes();
+        assertThat(original.getName()).isEqualTo(COLLECTION_NAME);
+        assertThat(original.getIndexInfo()).hasSize(1);
+
+        DBCollection collection = ClusterConfigService.prepareCollection(mongoConnection);
+        assertThat(collection.getName()).isEqualTo(COLLECTION_NAME);
+        assertThat(collection.getIndexInfo()).hasSize(2);
+        assertThat(collection.getWriteConcern()).isEqualTo(WriteConcern.MAJORITY);
+    }
+
+    @Test
+    @UsingDataSet(loadStrategy = LoadStrategyEnum.DELETE_ALL)
+    public void prepareCollectionCreatesCollectionIfItDoesNotExist() throws Exception {
+        assertThat(mongoConnection.getDatabase().collectionExists(COLLECTION_NAME)).isFalse();
+        DBCollection collection = ClusterConfigService.prepareCollection(mongoConnection);
+
+        assertThat(collection.getName()).isEqualTo(COLLECTION_NAME);
+        assertThat(collection.getIndexInfo()).hasSize(2);
+        assertThat(collection.getWriteConcern()).isEqualTo(WriteConcern.MAJORITY);
+    }
+
+    public static class ClusterConfigChangedEventHandler {
+        public volatile ClusterConfigChangedEvent event;
+
+        @Subscribe
+        public void handleSimpleEvent(ClusterConfigChangedEvent event) {
+            this.event = ClusterConfigChangedEvent.create(
+                    event.date(),
+                    event.nodeId(),
+                    event.type()
+            );
+        }
+    }
+}

--- a/graylog2-server/src/test/java/org/graylog2/cluster/CustomConfig.java
+++ b/graylog2-server/src/test/java/org/graylog2/cluster/CustomConfig.java
@@ -1,0 +1,21 @@
+/**
+ * This file is part of Graylog.
+ *
+ * Graylog is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.graylog2.cluster;
+
+public class CustomConfig {
+    public String text;
+}

--- a/graylog2-shared/src/main/java/org/graylog2/shared/utilities/AutoValueUtils.java
+++ b/graylog2-shared/src/main/java/org/graylog2/shared/utilities/AutoValueUtils.java
@@ -1,0 +1,45 @@
+/**
+ * This file is part of Graylog.
+ *
+ * Graylog is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.graylog2.shared.utilities;
+
+/**
+ * Utility methods related to Google AutoValue
+ */
+public final class AutoValueUtils {
+    private AutoValueUtils() {
+    }
+
+    /**
+     * Get the canonical class name of the provided {@link Class} with special handling of Google AutoValue classes.
+     *
+     * @param aClass a class
+     * @return the canonical class name of {@code aClass} or its super class in case of an auto-generated class by
+     * Google AutoValue
+     * @see Class#getCanonicalName()
+     * @see com.google.auto.value.AutoValue
+     */
+    public static String getCanonicalName(final Class<?> aClass) {
+        final Class<?> cls;
+        if (aClass.getSimpleName().startsWith("AutoValue_")) {
+            cls = aClass.getSuperclass();
+        } else {
+            cls = aClass;
+        }
+
+        return cls.getCanonicalName();
+    }
+}


### PR DESCRIPTION
This PR adds capabilities to use a cluster-wide configuration in Graylog, which is persisted in MongoDB.

The cluster configuration is basically a big key-value map with the FQCN of the custom configuration class (JavaBean convention) as lookup key. The value is the serialized value of this custom configuration class.