### PR TITLE
Add rudimentary Elasticsearch request time metrics

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/ESTimestampFixup.java
+++ b/graylog2-server/src/main/java/org/graylog2/ESTimestampFixup.java
@@ -47,6 +47,7 @@ import org.elasticsearch.common.unit.TimeValue;
 import org.elasticsearch.index.query.QueryBuilders;
 import org.elasticsearch.node.Node;
 import org.elasticsearch.search.SearchHit;
+import org.graylog2.bindings.providers.EsClientProvider;
 import org.graylog2.bindings.providers.EsNodeProvider;
 import org.graylog2.configuration.ElasticsearchConfiguration;
 import org.graylog2.plugin.Tools;
@@ -138,6 +139,7 @@ public class ESTimestampFixup {
         protected void configure() {
             bind(Configuration.class).toInstance(configuration);
             bind(Node.class).toProvider(EsNodeProvider.class).in(Scopes.SINGLETON);
+            bind(Client.class).toProvider(EsClientProvider.class).in(Scopes.SINGLETON);
         }
     }
 

--- a/graylog2-server/src/main/java/org/graylog2/bindings/ServerBindings.java
+++ b/graylog2-server/src/main/java/org/graylog2/bindings/ServerBindings.java
@@ -23,6 +23,7 @@ import com.google.inject.TypeLiteral;
 import com.google.inject.assistedinject.FactoryModuleBuilder;
 import com.google.inject.multibindings.Multibinder;
 import org.apache.shiro.mgt.DefaultSecurityManager;
+import org.elasticsearch.client.Client;
 import org.elasticsearch.node.Node;
 import org.graylog2.Configuration;
 import org.graylog2.alerts.AlertSender;
@@ -33,6 +34,7 @@ import org.graylog2.bindings.providers.BundleExporterProvider;
 import org.graylog2.bindings.providers.BundleImporterProvider;
 import org.graylog2.bindings.providers.ClusterEventBusProvider;
 import org.graylog2.bindings.providers.DefaultSecurityManagerProvider;
+import org.graylog2.bindings.providers.EsClientProvider;
 import org.graylog2.bindings.providers.EsNodeProvider;
 import org.graylog2.bindings.providers.LdapConnectorProvider;
 import org.graylog2.bindings.providers.LdapUserAuthenticatorProvider;
@@ -154,7 +156,8 @@ public class ServerBindings extends AbstractModule {
         } else {
             install(new NoopJournalModule());
         }
-        bind(Node.class).toProvider(EsNodeProvider.class).in(Scopes.SINGLETON);
+        bind(Node.class).toProvider(EsNodeProvider.class).asEagerSingleton();
+        bind(Client.class).toProvider(EsClientProvider.class).asEagerSingleton();
         bind(SystemJobManager.class).toProvider(SystemJobManagerProvider.class);
         bind(RulesEngine.class).toProvider(RulesEngineProvider.class);
         bind(LdapConnector.class).toProvider(LdapConnectorProvider.class);

--- a/graylog2-server/src/main/java/org/graylog2/bindings/providers/EsClientProvider.java
+++ b/graylog2-server/src/main/java/org/graylog2/bindings/providers/EsClientProvider.java
@@ -16,7 +16,6 @@
  */
 package org.graylog2.bindings.providers;
 
-import com.codahale.metrics.MetricRegistry;
 import org.elasticsearch.client.Client;
 import org.elasticsearch.node.Node;
 
@@ -24,20 +23,16 @@ import javax.inject.Inject;
 import javax.inject.Provider;
 import javax.inject.Singleton;
 
-import static com.google.common.base.Preconditions.checkNotNull;
-
+@Singleton
 public class EsClientProvider implements Provider<Client> {
     private final Node node;
-    private final MetricRegistry metricRegistry;
 
     @Inject
-    public EsClientProvider(Node node, MetricRegistry metricRegistry) {
+    public EsClientProvider(Node node) {
         this.node = node;
-        this.metricRegistry = checkNotNull(metricRegistry);
     }
 
     @Override
-    @Singleton
     public Client get() {
         return node.client();
     }

--- a/graylog2-server/src/main/java/org/graylog2/bindings/providers/EsClientProvider.java
+++ b/graylog2-server/src/main/java/org/graylog2/bindings/providers/EsClientProvider.java
@@ -14,28 +14,31 @@
  * You should have received a copy of the GNU General Public License
  * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
  */
-package org.graylog2.indexer.counts;
+package org.graylog2.bindings.providers;
 
-import org.elasticsearch.action.count.CountRequest;
+import com.codahale.metrics.MetricRegistry;
 import org.elasticsearch.client.Client;
-import org.graylog2.indexer.Deflector;
+import org.elasticsearch.node.Node;
 
 import javax.inject.Inject;
+import javax.inject.Provider;
 import javax.inject.Singleton;
 
-@Singleton
-public class Counts {
-    private final Client c;
-    private final Deflector deflector;
+import static com.google.common.base.Preconditions.checkNotNull;
+
+public class EsClientProvider implements Provider<Client> {
+    private final Node node;
+    private final MetricRegistry metricRegistry;
 
     @Inject
-    public Counts(Client client, Deflector deflector) {
-        this.c = client;
-        this.deflector = deflector;
+    public EsClientProvider(Node node, MetricRegistry metricRegistry) {
+        this.node = node;
+        this.metricRegistry = checkNotNull(metricRegistry);
     }
 
-    public long total() {
-        return c.count(new CountRequest(deflector.getAllDeflectorIndexNames())).actionGet().getCount();
+    @Override
+    @Singleton
+    public Client get() {
+        return node.client();
     }
-
 }

--- a/graylog2-server/src/main/java/org/graylog2/indexer/cluster/Cluster.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/cluster/Cluster.java
@@ -26,7 +26,6 @@ import org.elasticsearch.action.admin.cluster.node.info.NodesInfoRequest;
 import org.elasticsearch.action.admin.cluster.node.info.NodesInfoResponse;
 import org.elasticsearch.client.Client;
 import org.elasticsearch.cluster.node.DiscoveryNode;
-import org.elasticsearch.node.Node;
 import org.graylog2.indexer.Deflector;
 import org.graylog2.indexer.esplugin.ClusterStateMonitor;
 import org.slf4j.Logger;
@@ -53,9 +52,9 @@ public class Cluster {
     private ScheduledExecutorService scheduler;
 
     @Inject
-    public Cluster(Node node, Deflector deflector, @Named("daemonScheduler") ScheduledExecutorService scheduler) {
+    public Cluster(Client client, Deflector deflector, @Named("daemonScheduler") ScheduledExecutorService scheduler) {
         this.scheduler = scheduler;
-        this.c = node.client();
+        this.c = client;
         this.deflector = deflector;
         // unfortunately we can't use guice here, because elasticsearch and graylog2 use different injectors and we can't
         // get to the instance to bridge.
@@ -120,7 +119,7 @@ public class Cluster {
     }
 
     /**
-     * Check if the Elasticsearch {@link Node} is connected and that the cluster health status
+     * Check if the Elasticsearch {@link org.elasticsearch.node.Node} is connected and that the cluster health status
      * is not {@link ClusterHealthStatus#RED} and that the {@link org.graylog2.indexer.Deflector#isUp() deflector is up}.
      *
      * @return {@code true} if the Elasticsearch client is up and the cluster is healthy and the deflector is up, {@code false} otherwise

--- a/graylog2-server/src/main/java/org/graylog2/indexer/indices/Indices.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/indices/Indices.java
@@ -16,7 +16,6 @@
  */
 package org.graylog2.indexer.indices;
 
-import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
@@ -57,7 +56,6 @@ import org.elasticsearch.common.hppc.cursors.ObjectObjectCursor;
 import org.elasticsearch.common.settings.ImmutableSettings;
 import org.elasticsearch.common.unit.TimeValue;
 import org.elasticsearch.index.query.QueryBuilder;
-import org.elasticsearch.node.Node;
 import org.elasticsearch.search.SearchHit;
 import org.graylog2.configuration.ElasticsearchConfiguration;
 import org.graylog2.indexer.IndexNotFoundException;
@@ -84,11 +82,6 @@ public class Indices implements IndexManagement {
     private final ElasticsearchConfiguration configuration;
 
     @Inject
-    public Indices(Node node, ElasticsearchConfiguration configuration) {
-        this(node.client(), configuration);
-    }
-
-    @VisibleForTesting
     public Indices(Client client, ElasticsearchConfiguration configuration) {
         this.c = client;
         this.configuration = configuration;

--- a/graylog2-server/src/main/java/org/graylog2/indexer/messages/Messages.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/messages/Messages.java
@@ -17,8 +17,6 @@
 package org.graylog2.indexer.messages;
 
 import com.google.common.collect.Lists;
-import javax.inject.Inject;
-import javax.inject.Singleton;
 import org.elasticsearch.action.WriteConsistencyLevel;
 import org.elasticsearch.action.admin.indices.analyze.AnalyzeRequestBuilder;
 import org.elasticsearch.action.admin.indices.analyze.AnalyzeResponse;
@@ -34,7 +32,6 @@ import org.elasticsearch.action.support.replication.ReplicationType;
 import org.elasticsearch.client.Client;
 import org.elasticsearch.common.xcontent.XContentType;
 import org.elasticsearch.indices.IndexMissingException;
-import org.elasticsearch.node.Node;
 import org.graylog2.configuration.ElasticsearchConfiguration;
 import org.graylog2.indexer.DeadLetter;
 import org.graylog2.indexer.Deflector;
@@ -43,13 +40,12 @@ import org.graylog2.plugin.Message;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import javax.inject.Inject;
+import javax.inject.Singleton;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.LinkedBlockingQueue;
 
-/**
- * @author Lennart Koopmann <lennart@socketfeed.com>
- */
 @Singleton
 public class Messages {
     public static final String TYPE = "message";
@@ -60,9 +56,9 @@ public class Messages {
     private LinkedBlockingQueue<List<DeadLetter>> deadLetterQueue;
 
     @Inject
-	public Messages(Node node, ElasticsearchConfiguration configuration) {
+	public Messages(Client client, ElasticsearchConfiguration configuration) {
         this.configuration = configuration;
-        this.c = node.client();
+        this.c = client;
         this.deadLetterQueue = new LinkedBlockingQueue<>(1000);
     }
 

--- a/graylog2-server/src/main/java/org/graylog2/indexer/searches/Searches.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/searches/Searches.java
@@ -67,7 +67,7 @@ import java.util.Set;
 import java.util.concurrent.TimeUnit;
 
 import static org.elasticsearch.index.query.QueryBuilders.matchAllQuery;
-import static org.elasticsearch.index.query.QueryBuilders.queryString;
+import static org.elasticsearch.index.query.QueryBuilders.queryStringQuery;
 
 @Singleton
 public class Searches {
@@ -414,7 +414,7 @@ public class Searches {
                                 .interval(interval.toESInterval()))
                 .filter(standardFilters(range, filter));
 
-        QueryStringQueryBuilder qs = queryString(query);
+        QueryStringQueryBuilder qs = queryStringQuery(query);
         qs.allowLeadingWildcard(configuration.isAllowLeadingWildcardSearches());
 
         SearchRequestBuilder srb = c.prepareSearch();
@@ -445,7 +445,7 @@ public class Searches {
                 )
                 .filter(standardFilters(range, filter));
 
-        QueryStringQueryBuilder qs = queryString(query);
+        QueryStringQueryBuilder qs = queryStringQuery(query);
         qs.allowLeadingWildcard(configuration.isAllowLeadingWildcardSearches());
 
         SearchRequestBuilder srb = c.prepareSearch();
@@ -535,7 +535,7 @@ public class Searches {
         if (query.trim().equals("*")) {
             srb.setQuery(matchAllQuery());
         } else {
-            QueryStringQueryBuilder qs = queryString(query);
+            QueryStringQueryBuilder qs = queryStringQuery(query);
             qs.allowLeadingWildcard(configuration.isAllowLeadingWildcardSearches());
             srb.setQuery(qs);
         }
@@ -606,7 +606,7 @@ public class Searches {
         }
 
         if (filter != null && !filter.isEmpty() && !filter.equals("*")) {
-            bfb.must(FilterBuilders.queryFilter(QueryBuilders.queryString(filter)));
+            bfb.must(FilterBuilders.queryFilter(QueryBuilders.queryStringQuery(filter)));
             set = true;
         }
 

--- a/graylog2-server/src/main/java/org/graylog2/indexer/searches/Searches.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/searches/Searches.java
@@ -18,7 +18,6 @@ package org.graylog2.indexer.searches;
 
 import com.codahale.metrics.MetricRegistry;
 import com.codahale.metrics.Timer;
-import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.Sets;
 import org.elasticsearch.action.search.SearchRequest;
 import org.elasticsearch.action.search.SearchRequestBuilder;
@@ -32,7 +31,6 @@ import org.elasticsearch.index.query.FilterBuilders;
 import org.elasticsearch.index.query.QueryBuilder;
 import org.elasticsearch.index.query.QueryBuilders;
 import org.elasticsearch.index.query.QueryStringQueryBuilder;
-import org.elasticsearch.node.Node;
 import org.elasticsearch.search.SearchHit;
 import org.elasticsearch.search.aggregations.AggregationBuilders;
 import org.elasticsearch.search.aggregations.bucket.filter.Filter;
@@ -150,17 +148,8 @@ public class Searches {
     public Searches(Configuration configuration,
                     Deflector deflector,
                     IndexRangeService indexRangeService,
-                    Node node,
+                    Client client,
                     MetricRegistry metricRegistry) {
-        this(configuration, deflector, indexRangeService, node.client(), metricRegistry);
-    }
-
-    @VisibleForTesting
-    Searches(Configuration configuration,
-             Deflector deflector,
-             IndexRangeService indexRangeService,
-             Client client,
-             MetricRegistry metricRegistry) {
         this.configuration = checkNotNull(configuration);
         this.deflector = checkNotNull(deflector);
         this.indexRangeService = checkNotNull(indexRangeService);

--- a/graylog2-server/src/main/java/org/graylog2/indexer/searches/Searches.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/searches/Searches.java
@@ -80,7 +80,7 @@ public class Searches {
     public static final String AGG_HISTOGRAM = "gl2_histogram";
     public static final String AGG_EXTENDED_STATS = "gl2_extended_stats";
 
-    public static enum TermsStatsOrder {
+    public enum TermsStatsOrder {
         TERM,
         REVERSE_TERM,
         COUNT,
@@ -95,7 +95,7 @@ public class Searches {
         REVERSE_MEAN
     }
 
-    public static enum DateHistogramInterval {
+    public enum DateHistogramInterval {
         YEAR(Period.years(1)),
         QUARTER(Period.months(3)),
         MONTH(Period.months(1)),

--- a/graylog2-server/src/main/java/org/graylog2/system/stats/elasticsearch/ElasticsearchProbe.java
+++ b/graylog2-server/src/main/java/org/graylog2/system/stats/elasticsearch/ElasticsearchProbe.java
@@ -25,9 +25,9 @@ import org.elasticsearch.action.admin.cluster.stats.ClusterStatsRequest;
 import org.elasticsearch.action.admin.cluster.stats.ClusterStatsResponse;
 import org.elasticsearch.action.admin.cluster.tasks.PendingClusterTasksRequest;
 import org.elasticsearch.action.admin.cluster.tasks.PendingClusterTasksResponse;
+import org.elasticsearch.client.Client;
 import org.elasticsearch.client.ClusterAdminClient;
 import org.elasticsearch.cluster.service.PendingClusterTask;
-import org.elasticsearch.node.Node;
 import org.graylog2.indexer.indices.Indices;
 
 import javax.inject.Inject;
@@ -35,17 +35,17 @@ import java.util.List;
 
 @Singleton
 public class ElasticsearchProbe {
-    private final Node node;
+    private final Client client;
     private final Indices indices;
 
     @Inject
-    public ElasticsearchProbe(Node node, Indices indices) {
-        this.node = node;
+    public ElasticsearchProbe(Client client, Indices indices) {
+        this.client = client;
         this.indices = indices;
     }
 
     public ElasticsearchStats elasticsearchStats() {
-        final ClusterAdminClient adminClient = node.client().admin().cluster();
+        final ClusterAdminClient adminClient = client.admin().cluster();
 
         final ClusterStatsResponse clusterStatsResponse = adminClient.clusterStats(new ClusterStatsRequest()).actionGet();
         final String clusterName = clusterStatsResponse.getClusterNameAsString();


### PR DESCRIPTION
Record metrics about how long Elasticsearch requests took to complete in `Searches` class.

This records a single metric "org.graylog2.indexer.searches.Searches.elasticsearch.requests" which can be used as a rough indicator on how long Elasticsearch requests take to complete.