### PR TITLE
Store timestamps as doc values

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/configuration/ElasticsearchConfiguration.java
+++ b/graylog2-server/src/main/java/org/graylog2/configuration/ElasticsearchConfiguration.java
@@ -118,6 +118,9 @@ public class ElasticsearchConfiguration {
     @Parameter(value = "index_optimization_max_num_segments", validator = PositiveIntegerValidator.class)
     private int indexOptimizationMaxNumSegments = 1;
 
+    @Parameter(value = "elasticsearch_store_timestamps_as_doc_values")
+    private boolean storeTimestampsAsDocValues = true;
+
     public String getClusterName() {
         return clusterName;
     }
@@ -244,5 +247,9 @@ public class ElasticsearchConfiguration {
 
     public String getPathData() {
         return pathData;
+    }
+
+    public boolean isStoreTimestampsAsDocValues() {
+        return storeTimestampsAsDocValues;
     }
 }

--- a/graylog2-server/src/main/java/org/graylog2/indexer/Mapping.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/Mapping.java
@@ -23,6 +23,7 @@ import org.elasticsearch.client.Client;
 import org.graylog2.indexer.messages.Messages;
 import org.graylog2.plugin.Tools;
 
+import java.io.Serializable;
 import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.List;
@@ -109,10 +110,11 @@ public class Mapping {
         return type;
     }
 
-    private static Map<String, String> typeTimeWithMillis() {
-        final Map<String, String> type = Maps.newHashMap();
+    private static Map<String, Serializable> typeTimeWithMillis() {
+        final Map<String, Serializable> type = Maps.newHashMap();
         type.put("type", "date");
         type.put("format", Tools.ES_DATE_FORMAT);
+        type.put("doc_values", true);
 
         return type;
     }

--- a/graylog2-server/src/main/java/org/graylog2/indexer/indices/Indices.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/indices/Indices.java
@@ -203,7 +203,8 @@ public class Indices implements IndexManagement {
         if (!acknowledged) {
             return false;
         }
-        final PutMappingRequest mappingRequest = Mapping.getPutMappingRequest(c, indexName, configuration.getAnalyzer());
+        final PutMappingRequest mappingRequest = Mapping.getPutMappingRequest(c, indexName, configuration.getAnalyzer(),
+                configuration.isStoreTimestampsAsDocValues());
         return c.admin().indices().putMapping(mappingRequest).actionGet().isAcknowledged();
     }
 

--- a/misc/graylog2.conf
+++ b/misc/graylog2.conf
@@ -190,6 +190,11 @@ allow_highlighting = false
 # Note that this setting only takes effect on newly created indices.
 elasticsearch_analyzer = standard
 
+# Store message timestamps as doc values in Elasticsearch. This will improve memory the consumption of
+# Elasticsearch at the cost of some performance at indexing time and increased index size.
+# See http://www.elastic.co/guide/en/elasticsearch/guide/master/doc-values.html for details.
+#elasticsearch_store_timestamps_as_doc_values = true
+
 # Batch size for the Elasticsearch output. This is the maximum (!) number of messages the Elasticsearch output
 # module will get at once and write to Elasticsearch in a batch call. If the configured batch size has not been
 # reached within output_flush_interval seconds, everything that is available will be flushed at once. Remember


### PR DESCRIPTION
This PR changes the default index mapping of Graylog to store message timestamps as [doc values in Elasticsearch](http://www.elastic.co/guide/en/elasticsearch/guide/master/doc-values.html).

This change should prevent the firing of the [field data circuit breaker](http://www.elastic.co/guide/en/elasticsearch/reference/1.5/index-modules-fielddata.html) in Graylog setups with a very large number of indexed messages. Currently timestamps are not stored as doc values, so they basically need to be kept in-memory all the time (and when calculating the index ranges for example) which increases the heap memory consumption by Elasticsearch.

The drawback of this solution is a (small) penalty in search times and larger indices (which should be negligible).