### PR TITLE
Refactor: More robust alert conditions

### DIFF
--- a/graylog2-plugin-interfaces/src/main/java/org/graylog2/plugin/MessageSummary.java
+++ b/graylog2-plugin-interfaces/src/main/java/org/graylog2/plugin/MessageSummary.java
@@ -107,4 +107,7 @@ public class MessageSummary {
     public Object getField(String key) {
         return message.getField(key);
     }
+
+    @JsonIgnore
+    public Message getRawMessage() { return message;}
 }

--- a/graylog2-plugin-interfaces/src/main/java/org/graylog2/plugin/alarms/AlertCondition.java
+++ b/graylog2-plugin-interfaces/src/main/java/org/graylog2/plugin/alarms/AlertCondition.java
@@ -22,8 +22,6 @@
  */
 package org.graylog2.plugin.alarms;
 
-import com.fasterxml.jackson.annotation.JsonIgnore;
-import org.graylog2.plugin.Message;
 import org.graylog2.plugin.MessageSummary;
 import org.graylog2.plugin.streams.Stream;
 import org.joda.time.DateTime;
@@ -37,15 +35,6 @@ import java.util.Map;
 public interface AlertCondition {
     String getDescription();
 
-    /**
-     * The limited list of internal message objects that matched the alert.
-     * @see org.graylog2.plugin.alarms.AlertCondition.CheckResult#getMatchingMessages()
-     * @return list of Message objects
-     */
-    @Deprecated
-    @JsonIgnore
-    List<Message> getSearchHits();
-
     String getId();
 
     DateTime getCreatedAt();
@@ -56,13 +45,13 @@ public interface AlertCondition {
 
     Map<String, Object> getParameters();
 
-    Integer getBacklog();
+    Integer getBacklogSize();
 
     int getGrace();
 
     String getTypeString();
 
-    public interface CheckResult {
+    interface CheckResult {
         boolean isTriggered();
         String getResultDescription();
         AlertCondition getTriggeredCondition();

--- a/graylog2-plugin-interfaces/src/main/java/org/graylog2/plugin/alarms/AlertCondition.java
+++ b/graylog2-plugin-interfaces/src/main/java/org/graylog2/plugin/alarms/AlertCondition.java
@@ -45,7 +45,7 @@ public interface AlertCondition {
 
     Map<String, Object> getParameters();
 
-    Integer getBacklogSize();
+    Integer getBacklog();
 
     int getGrace();
 

--- a/graylog2-rest-client/src/main/java/org/graylog2/restclient/models/Notification.java
+++ b/graylog2-rest-client/src/main/java/org/graylog2/restclient/models/Notification.java
@@ -38,7 +38,8 @@ public class Notification {
         GC_TOO_LONG,
         JOURNAL_UTILIZATION_TOO_HIGH,
         JOURNAL_UNCOMMITTED_MESSAGES_DELETED,
-        OUTPUT_DISABLED;
+        OUTPUT_DISABLED,
+        GENERIC;
 
         public static Type fromString(String name) {
             return valueOf(name.toUpperCase());

--- a/graylog2-server/src/main/java/org/graylog2/alarmcallbacks/EmailAlarmCallback.java
+++ b/graylog2-server/src/main/java/org/graylog2/alarmcallbacks/EmailAlarmCallback.java
@@ -38,6 +38,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import javax.inject.Inject;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
@@ -97,9 +98,16 @@ public class EmailAlarmCallback implements AlarmCallback {
 
     protected List<Message> getAlarmBacklog(AlertCondition.CheckResult result) {
         final AlertCondition alertCondition = result.getTriggeredCondition();
-        final int effectiveBacklogSize = Math.min(alertCondition.getBacklog(), result.getMatchingMessages().size());
-        final List<MessageSummary> backlogSummaries = result.getMatchingMessages()
-                .subList(0, effectiveBacklogSize-1);
+        final List<MessageSummary> matchingMessages = result.getMatchingMessages();
+
+        final int effectiveBacklogSize = Math.min(alertCondition.getBacklog(), matchingMessages.size());
+
+        if (effectiveBacklogSize == 0) {
+            return Collections.emptyList();
+        }
+
+        final List<MessageSummary> backlogSummaries = matchingMessages.subList(0, effectiveBacklogSize);
+
         final List<Message> backlog = Lists.newArrayListWithCapacity(effectiveBacklogSize);
 
         for (MessageSummary messageSummary : backlogSummaries) {

--- a/graylog2-server/src/main/java/org/graylog2/alarmcallbacks/EmailAlarmCallback.java
+++ b/graylog2-server/src/main/java/org/graylog2/alarmcallbacks/EmailAlarmCallback.java
@@ -99,7 +99,7 @@ public class EmailAlarmCallback implements AlarmCallback {
         final AlertCondition alertCondition = result.getTriggeredCondition();
         final int effectiveBacklogSize = Math.min(alertCondition.getBacklog(), result.getMatchingMessages().size());
         final List<MessageSummary> backlogSummaries = result.getMatchingMessages()
-                .subList(0, Math.max(effectiveBacklogSize-1, 0));
+                .subList(0, effectiveBacklogSize-1);
         final List<Message> backlog = Lists.newArrayListWithCapacity(effectiveBacklogSize);
 
         for (MessageSummary messageSummary : backlogSummaries) {

--- a/graylog2-server/src/main/java/org/graylog2/alarmcallbacks/EmailAlarmCallback.java
+++ b/graylog2-server/src/main/java/org/graylog2/alarmcallbacks/EmailAlarmCallback.java
@@ -16,13 +16,13 @@
  */
 package org.graylog2.alarmcallbacks;
 
-import com.google.common.base.Throwables;
 import com.google.common.collect.Lists;
 import org.graylog2.alerts.AlertSender;
 import org.graylog2.alerts.FormattedEmailAlertSender;
 import org.graylog2.notifications.Notification;
 import org.graylog2.notifications.NotificationService;
 import org.graylog2.plugin.Message;
+import org.graylog2.plugin.MessageSummary;
 import org.graylog2.plugin.alarms.AlertCondition;
 import org.graylog2.plugin.alarms.callbacks.AlarmCallback;
 import org.graylog2.plugin.alarms.callbacks.AlarmCallbackConfigurationException;
@@ -62,19 +62,8 @@ public class EmailAlarmCallback implements AlarmCallback {
         AlertCondition alertCondition = result.getTriggeredCondition();
         if (stream.getAlertReceivers().size() > 0) {
             try {
-                if (alertCondition.getBacklog() > 0 && alertCondition.getSearchHits() != null) {
-                    List<Message> backlog = Lists.newArrayList();
-
-                    for (Message searchHit : alertCondition.getSearchHits()) {
-                        backlog.add(searchHit);
-                    }
-
-                    // Read as many messages as possible (max: backlog size) from backlog.
-                    int readTo = alertCondition.getBacklog();
-                    if(backlog.size() < readTo) {
-                        readTo = backlog.size();
-                    }
-                    alertSender.sendEmails(stream, result, backlog.subList(0, readTo));
+                if (alertCondition.getBacklogSize() > 0 && result.getMatchingMessages() != null) {
+                    alertSender.sendEmails(stream, result, getAlarmBacklog(result));
                 } else {
                     alertSender.sendEmails(stream, result);
                 }
@@ -85,7 +74,7 @@ public class EmailAlarmCallback implements AlarmCallback {
                         .addType(Notification.Type.EMAIL_TRANSPORT_CONFIGURATION_INVALID)
                         .addSeverity(Notification.Severity.NORMAL)
                         .addDetail("stream_id", stream.getId())
-                        .addDetail("exception", Throwables.getStackTraceAsString(e));
+                        .addDetail("exception", e.getMessage());
                 notificationService.publishIfFirst(notification);
             } catch (Exception e) {
                 LOG.error("Stream [" + stream + "] has alert receivers and is triggered, but sending emails failed", e);
@@ -104,6 +93,19 @@ public class EmailAlarmCallback implements AlarmCallback {
                 notificationService.publishIfFirst(notification);
             }
         }
+    }
+
+    protected List<Message> getAlarmBacklog(AlertCondition.CheckResult result) {
+        final AlertCondition alertCondition = result.getTriggeredCondition();
+        final List<MessageSummary> backlogSummaries = result.getMatchingMessages()
+                .subList(0, Math.min(alertCondition.getBacklogSize(), result.getMatchingMessages().size()));
+        final List<Message> backlog = Lists.newArrayList();
+
+        for (MessageSummary messageSummary : backlogSummaries) {
+            backlog.add(messageSummary.getRawMessage());
+        }
+
+        return backlog;
     }
 
     @Override

--- a/graylog2-server/src/main/java/org/graylog2/alarmcallbacks/EmailAlarmCallback.java
+++ b/graylog2-server/src/main/java/org/graylog2/alarmcallbacks/EmailAlarmCallback.java
@@ -97,9 +97,10 @@ public class EmailAlarmCallback implements AlarmCallback {
 
     protected List<Message> getAlarmBacklog(AlertCondition.CheckResult result) {
         final AlertCondition alertCondition = result.getTriggeredCondition();
+        final int effectiveBacklogSize = Math.min(alertCondition.getBacklog(), result.getMatchingMessages().size());
         final List<MessageSummary> backlogSummaries = result.getMatchingMessages()
-                .subList(0, Math.min(alertCondition.getBacklog(), result.getMatchingMessages().size()));
-        final List<Message> backlog = Lists.newArrayList();
+                .subList(0, effectiveBacklogSize-1);
+        final List<Message> backlog = Lists.newArrayListWithCapacity(effectiveBacklogSize);
 
         for (MessageSummary messageSummary : backlogSummaries) {
             backlog.add(messageSummary.getRawMessage());

--- a/graylog2-server/src/main/java/org/graylog2/alarmcallbacks/EmailAlarmCallback.java
+++ b/graylog2-server/src/main/java/org/graylog2/alarmcallbacks/EmailAlarmCallback.java
@@ -62,7 +62,7 @@ public class EmailAlarmCallback implements AlarmCallback {
         AlertCondition alertCondition = result.getTriggeredCondition();
         if (stream.getAlertReceivers().size() > 0) {
             try {
-                if (alertCondition.getBacklogSize() > 0 && result.getMatchingMessages() != null) {
+                if (alertCondition.getBacklog() > 0 && result.getMatchingMessages() != null) {
                     alertSender.sendEmails(stream, result, getAlarmBacklog(result));
                 } else {
                     alertSender.sendEmails(stream, result);
@@ -98,7 +98,7 @@ public class EmailAlarmCallback implements AlarmCallback {
     protected List<Message> getAlarmBacklog(AlertCondition.CheckResult result) {
         final AlertCondition alertCondition = result.getTriggeredCondition();
         final List<MessageSummary> backlogSummaries = result.getMatchingMessages()
-                .subList(0, Math.min(alertCondition.getBacklogSize(), result.getMatchingMessages().size()));
+                .subList(0, Math.min(alertCondition.getBacklog(), result.getMatchingMessages().size()));
         final List<Message> backlog = Lists.newArrayList();
 
         for (MessageSummary messageSummary : backlogSummaries) {

--- a/graylog2-server/src/main/java/org/graylog2/alarmcallbacks/EmailAlarmCallback.java
+++ b/graylog2-server/src/main/java/org/graylog2/alarmcallbacks/EmailAlarmCallback.java
@@ -99,7 +99,7 @@ public class EmailAlarmCallback implements AlarmCallback {
         final AlertCondition alertCondition = result.getTriggeredCondition();
         final int effectiveBacklogSize = Math.min(alertCondition.getBacklog(), result.getMatchingMessages().size());
         final List<MessageSummary> backlogSummaries = result.getMatchingMessages()
-                .subList(0, effectiveBacklogSize-1);
+                .subList(0, Math.max(effectiveBacklogSize-1, 0));
         final List<Message> backlog = Lists.newArrayListWithCapacity(effectiveBacklogSize);
 
         for (MessageSummary messageSummary : backlogSummaries) {

--- a/graylog2-server/src/main/java/org/graylog2/alerts/AbstractAlertCondition.java
+++ b/graylog2-server/src/main/java/org/graylog2/alerts/AbstractAlertCondition.java
@@ -107,7 +107,7 @@ public abstract class AbstractAlertCondition implements EmbeddedPersistable, Ale
 
     @Override
     public Integer getBacklog() {
-        Object rawParameter = getParameters().get("backlog");
+        final Object rawParameter = getParameters().get("backlog");
         if (rawParameter != null && rawParameter instanceof Number) {
             return (Integer) rawParameter;
         } else {
@@ -165,12 +165,6 @@ public abstract class AbstractAlertCondition implements EmbeddedPersistable, Ale
             }
         }
 
-        public CheckResult(boolean isTriggered) {
-            this(false, null, null, null, null);
-            if (isTriggered)
-                throw new RuntimeException("Boolean only constructor should only be called if CheckResult is not triggered!");
-        }
-
         public boolean isTriggered() {
             return isTriggered;
         }
@@ -190,6 +184,12 @@ public abstract class AbstractAlertCondition implements EmbeddedPersistable, Ale
         @Override
         public List<MessageSummary> getMatchingMessages() {
             return summaries;
+        }
+    }
+
+    public static class NegativeCheckResult extends CheckResult {
+        public NegativeCheckResult() {
+            super(false, null, null, null, null);
         }
     }
 

--- a/graylog2-server/src/main/java/org/graylog2/alerts/AbstractAlertCondition.java
+++ b/graylog2-server/src/main/java/org/graylog2/alerts/AbstractAlertCondition.java
@@ -106,7 +106,7 @@ public abstract class AbstractAlertCondition implements EmbeddedPersistable, Ale
     }
 
     @Override
-    public Integer getBacklogSize() {
+    public Integer getBacklog() {
         final Object rawParameter = getParameters().get("backlog");
         if (rawParameter != null && rawParameter instanceof Number) {
             return (Integer) rawParameter;

--- a/graylog2-server/src/main/java/org/graylog2/alerts/AbstractAlertCondition.java
+++ b/graylog2-server/src/main/java/org/graylog2/alerts/AbstractAlertCondition.java
@@ -69,7 +69,7 @@ public abstract class AbstractAlertCondition implements EmbeddedPersistable, Ale
 
     }
 
-    protected abstract CheckResult runCheck();
+    protected abstract AlertCondition.CheckResult runCheck();
 
     @Override
     public String getId() {
@@ -106,7 +106,7 @@ public abstract class AbstractAlertCondition implements EmbeddedPersistable, Ale
     }
 
     @Override
-    public Integer getBacklog() {
+    public Integer getBacklogSize() {
         final Object rawParameter = getParameters().get("backlog");
         if (rawParameter != null && rawParameter instanceof Number) {
             return (Integer) rawParameter;
@@ -188,8 +188,8 @@ public abstract class AbstractAlertCondition implements EmbeddedPersistable, Ale
     }
 
     public static class NegativeCheckResult extends CheckResult {
-        public NegativeCheckResult() {
-            super(false, null, null, null, null);
+        public NegativeCheckResult(AlertCondition alertCondition) {
+            super(false, alertCondition, null, null, null);
         }
     }
 

--- a/graylog2-server/src/main/java/org/graylog2/alerts/AlertServiceImpl.java
+++ b/graylog2-server/src/main/java/org/graylog2/alerts/AlertServiceImpl.java
@@ -209,7 +209,7 @@ public class AlertServiceImpl extends PersistedServiceImpl implements AlertServi
 
         if (inGracePeriod(alertCondition)) {
             LOG.debug("Alert condition [{}] is in grace period. Not triggered.", this);
-            return new AbstractAlertCondition.CheckResult(false);
+            return new AbstractAlertCondition.NegativeCheckResult();
         }
 
         return ((AbstractAlertCondition) alertCondition).runCheck();

--- a/graylog2-server/src/main/java/org/graylog2/alerts/AlertServiceImpl.java
+++ b/graylog2-server/src/main/java/org/graylog2/alerts/AlertServiceImpl.java
@@ -209,7 +209,7 @@ public class AlertServiceImpl extends PersistedServiceImpl implements AlertServi
 
         if (inGracePeriod(alertCondition)) {
             LOG.debug("Alert condition [{}] is in grace period. Not triggered.", this);
-            return new AbstractAlertCondition.NegativeCheckResult();
+            return new AbstractAlertCondition.NegativeCheckResult(alertCondition);
         }
 
         return ((AbstractAlertCondition) alertCondition).runCheck();

--- a/graylog2-server/src/main/java/org/graylog2/alerts/FormattedEmailAlertSender.java
+++ b/graylog2-server/src/main/java/org/graylog2/alerts/FormattedEmailAlertSender.java
@@ -18,10 +18,12 @@ package org.graylog2.alerts;
 
 import com.floreysoft.jmte.Engine;
 import org.graylog2.configuration.EmailConfiguration;
+import org.graylog2.notifications.NotificationService;
 import org.graylog2.plugin.Message;
 import org.graylog2.plugin.alarms.AlertCondition;
 import org.graylog2.plugin.configuration.Configuration;
 import org.graylog2.plugin.streams.Stream;
+import org.graylog2.plugin.system.NodeId;
 import org.graylog2.shared.users.UserService;
 import org.graylog2.streams.StreamRuleService;
 
@@ -36,12 +38,13 @@ public class FormattedEmailAlertSender extends StaticEmailAlertSender implements
             "Date: ${check_result.triggeredAt}\n" +
             "Stream ID: ${stream.id}\n" +
             "Stream title: ${stream.title}\n" +
+            "Stream description: ${stream.description}\n" +
             "${if stream_url}Stream URL: ${stream_url}${end}\n" +
             "\n" +
             "Triggered condition: ${check_result.triggeredCondition}\n" +
             "##########\n\n" +
-            "Last messages accounting for this alert:\n" +
             "${if backlog_size > 0}" +
+            "Last messages accounting for this alert:\n" +
             "${foreach backlog message}\n" +
             "${message}\n" +
             "${end}\n" +
@@ -52,8 +55,12 @@ public class FormattedEmailAlertSender extends StaticEmailAlertSender implements
     private Configuration pluginConfig;
 
     @Inject
-    public FormattedEmailAlertSender(EmailConfiguration configuration, StreamRuleService streamRuleService, UserService userService) {
-        super(configuration, streamRuleService, userService);
+    public FormattedEmailAlertSender(EmailConfiguration configuration,
+                                     StreamRuleService streamRuleService,
+                                     UserService userService,
+                                     NotificationService notificationService,
+                                     NodeId nodeId) {
+        super(configuration, streamRuleService, userService, notificationService, nodeId);
     }
 
     @Override

--- a/graylog2-server/src/main/java/org/graylog2/alerts/StaticEmailAlertSender.java
+++ b/graylog2-server/src/main/java/org/graylog2/alerts/StaticEmailAlertSender.java
@@ -79,7 +79,7 @@ public class StaticEmailAlertSender implements AlertSender {
     private void sendEmail(String emailAddress, Stream stream, AlertCondition.CheckResult checkResult, List<Message> backlog) throws TransportConfigurationException, EmailException {
         LOG.debug("Sending mail to " + emailAddress);
         if(!configuration.isEnabled()) {
-            throw new TransportConfigurationException("Email transport is not enabled in configuration file!");
+            throw new TransportConfigurationException("Email transport is not enabled in server configuration file!");
         }
 
         final Email email = new SimpleEmail();
@@ -192,7 +192,7 @@ public class StaticEmailAlertSender implements AlertSender {
     @Override
     public void sendEmails(Stream stream, AlertCondition.CheckResult checkResult, List<Message> backlog) throws TransportConfigurationException, EmailException {
         if(!configuration.isEnabled()) {
-            throw new TransportConfigurationException("Email transport is not enabled!");
+            throw new TransportConfigurationException("Email transport is not enabled in server configuration file!");
         }
 
         if (stream.getAlertReceivers() == null || stream.getAlertReceivers().isEmpty()) {

--- a/graylog2-server/src/main/java/org/graylog2/alerts/StaticEmailAlertSender.java
+++ b/graylog2-server/src/main/java/org/graylog2/alerts/StaticEmailAlertSender.java
@@ -16,18 +16,22 @@
  */
 package org.graylog2.alerts;
 
+import com.google.common.collect.Lists;
 import org.apache.commons.mail.DefaultAuthenticator;
 import org.apache.commons.mail.Email;
 import org.apache.commons.mail.EmailException;
 import org.apache.commons.mail.SimpleEmail;
 import org.graylog2.configuration.EmailConfiguration;
 import org.graylog2.database.NotFoundException;
+import org.graylog2.notifications.Notification;
+import org.graylog2.notifications.NotificationService;
 import org.graylog2.plugin.Message;
 import org.graylog2.plugin.Tools;
 import org.graylog2.plugin.alarms.AlertCondition;
 import org.graylog2.plugin.alarms.transports.TransportConfigurationException;
 import org.graylog2.plugin.database.users.User;
 import org.graylog2.plugin.streams.Stream;
+import org.graylog2.plugin.system.NodeId;
 import org.graylog2.shared.users.UserService;
 import org.graylog2.streams.StreamRuleService;
 import org.joda.time.DateTime;
@@ -47,14 +51,20 @@ public class StaticEmailAlertSender implements AlertSender {
     private final StreamRuleService streamRuleService;
     protected final EmailConfiguration configuration;
     private final UserService userService;
+    private final NotificationService notificationService;
+    private final NodeId nodeId;
 
     @Inject
     public StaticEmailAlertSender(EmailConfiguration configuration,
                                   StreamRuleService streamRuleService,
-                                  UserService userService) {
+                                  UserService userService,
+                                  NotificationService notificationService,
+                                  NodeId nodeId) {
         this.configuration = configuration;
         this.streamRuleService = streamRuleService;
         this.userService = userService;
+        this.notificationService = notificationService;
+        this.nodeId = nodeId;
     }
 
     @Override
@@ -69,10 +79,10 @@ public class StaticEmailAlertSender implements AlertSender {
     private void sendEmail(String emailAddress, Stream stream, AlertCondition.CheckResult checkResult, List<Message> backlog) throws TransportConfigurationException, EmailException {
         LOG.debug("Sending mail to " + emailAddress);
         if(!configuration.isEnabled()) {
-            throw new TransportConfigurationException("Email transport is not enabled!");
+            throw new TransportConfigurationException("Email transport is not enabled in configuration file!");
         }
 
-        Email email = new SimpleEmail();
+        final Email email = new SimpleEmail();
         email.setHostName(configuration.getHostname());
         email.setSmtpPort(configuration.getPort());
         if (configuration.isUseSsl()) {
@@ -160,7 +170,7 @@ public class StaticEmailAlertSender implements AlertSender {
         if (backlog == null || backlog.isEmpty())
             return "";
 
-        StringBuilder sb = new StringBuilder();
+        final StringBuilder sb = new StringBuilder();
         MessageFormatter messageFormatter = new MessageFormatter();
 
         sb.append("\n\nLast ");
@@ -170,7 +180,7 @@ public class StaticEmailAlertSender implements AlertSender {
             sb.append("relevant message:\n");
         sb.append("======================\n\n");
 
-        for (Message message : backlog) {
+        for (final Message message : backlog) {
             sb.append(messageFormatter.formatForMail(message));
             sb.append("\n");
         }
@@ -189,13 +199,15 @@ public class StaticEmailAlertSender implements AlertSender {
             throw new RuntimeException("Stream [" + stream + "] has no alert receivers.");
         }
 
+        final List<String> recipients = Lists.newArrayList();
+
         // Send emails to subscribed users.
         if(stream.getAlertReceivers().get("users") != null) {
             for (String username : stream.getAlertReceivers().get("users")) {
-                User user = userService.load(username);
+                final User user = userService.load(username);
 
                 if(user != null && user.getEmail() != null && !user.getEmail().isEmpty()) {
-                    sendEmail(user.getEmail(), stream, checkResult, backlog);
+                    recipients.add(user.getEmail());
                 }
             }
         }
@@ -204,9 +216,22 @@ public class StaticEmailAlertSender implements AlertSender {
         if(stream.getAlertReceivers().get("emails") != null) {
             for (String email : stream.getAlertReceivers().get("emails")) {
                 if(!email.isEmpty()) {
-                    sendEmail(email, stream, checkResult, backlog);
+                    recipients.add(email);
                 }
             }
         }
+
+        if (recipients.size() == 0) {
+            final Notification notification = notificationService.buildNow()
+                    .addNode(nodeId.toString())
+                    .addType(Notification.Type.GENERIC)
+                    .addSeverity(Notification.Severity.NORMAL)
+                    .addDetail("title", "Stream \"" + stream.getTitle() + "\" is alerted, but no recipients have been defined!")
+                    .addDetail("description", "To fix this, go to the alerting configuration of the stream and add at least one alert recipient.");
+            notificationService.publishIfFirst(notification);
+        }
+
+        for (String email : recipients)
+            sendEmail(email, stream, checkResult, backlog);
     }
 }

--- a/graylog2-server/src/main/java/org/graylog2/alerts/types/DummyAlertCondition.java
+++ b/graylog2-server/src/main/java/org/graylog2/alerts/types/DummyAlertCondition.java
@@ -17,12 +17,10 @@
 package org.graylog2.alerts.types;
 
 import org.graylog2.alerts.AbstractAlertCondition;
-import org.graylog2.plugin.Message;
 import org.graylog2.plugin.Tools;
 import org.graylog2.plugin.streams.Stream;
 import org.joda.time.DateTime;
 
-import java.util.List;
 import java.util.Map;
 
 /**
@@ -43,10 +41,5 @@ public class DummyAlertCondition extends AbstractAlertCondition {
     @Override
     public CheckResult runCheck() {
         return new CheckResult(true, this, this.description, Tools.iso8601(), null);
-    }
-
-    @Override
-    public List<Message> getSearchHits() {
-        return null;
     }
 }

--- a/graylog2-server/src/main/java/org/graylog2/alerts/types/FieldValueAlertCondition.java
+++ b/graylog2-server/src/main/java/org/graylog2/alerts/types/FieldValueAlertCondition.java
@@ -36,6 +36,7 @@ import org.slf4j.LoggerFactory;
 
 import javax.annotation.Nullable;
 import java.text.DecimalFormat;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
@@ -140,17 +141,21 @@ public class FieldValueAlertCondition extends AbstractAlertCondition {
             }
 
             if (triggered) {
-                final List<MessageSummary> summaries = Lists.newArrayList();
                 final String resultDescription = "Field " + field + " had a " + type + " of "
                         + decimalFormat.format(result) + " in the last " + time + " minutes with trigger condition "
                         + thresholdType + " than " + decimalFormat.format(threshold) + ". "
                         + "(Current grace time: " + grace + " minutes)";
 
+                final List<MessageSummary> summaries;
                 if (getBacklog() > 0) {
-                    for (ResultMessage resultMessage : fieldStatsResult.getSearchHits()) {
+                    final List<ResultMessage> searchHits = fieldStatsResult.getSearchHits();
+                    summaries = Lists.newArrayListWithCapacity(searchHits.size());
+                    for (ResultMessage resultMessage : searchHits) {
                         final Message msg = new Message(resultMessage.getMessage());
                         summaries.add(new MessageSummary(resultMessage.getIndex(), msg));
                     }
+                } else {
+                    summaries = Collections.emptyList();
                 }
 
                 return new CheckResult(true, this, resultDescription, Tools.iso8601(), summaries);

--- a/graylog2-server/src/main/java/org/graylog2/alerts/types/FieldValueAlertCondition.java
+++ b/graylog2-server/src/main/java/org/graylog2/alerts/types/FieldValueAlertCondition.java
@@ -146,7 +146,7 @@ public class FieldValueAlertCondition extends AbstractAlertCondition {
                         + thresholdType + " than " + decimalFormat.format(threshold) + ". "
                         + "(Current grace time: " + grace + " minutes)";
 
-                if (getBacklogSize() > 0) {
+                if (getBacklog() > 0) {
                     for (ResultMessage resultMessage : fieldStatsResult.getSearchHits()) {
                         final Message msg = new Message(resultMessage.getMessage());
                         summaries.add(new MessageSummary(resultMessage.getIndex(), msg));

--- a/graylog2-server/src/main/java/org/graylog2/alerts/types/MessageCountAlertCondition.java
+++ b/graylog2-server/src/main/java/org/graylog2/alerts/types/MessageCountAlertCondition.java
@@ -99,8 +99,8 @@ public class MessageCountAlertCondition extends AbstractAlertCondition {
 
             if (triggered) {
                 final List<MessageSummary> summaries = Lists.newArrayList();
-                if (getBacklogSize() > 0) {
-                    final SearchResult backlogResult = searches.search("*", filter, new RelativeRange(time * 60), getBacklogSize(), 0, new Sorting("timestamp", Sorting.Direction.DESC));
+                if (getBacklog() > 0) {
+                    final SearchResult backlogResult = searches.search("*", filter, new RelativeRange(time * 60), getBacklog(), 0, new Sorting("timestamp", Sorting.Direction.DESC));
                     for (ResultMessage resultMessage : backlogResult.getResults()) {
                         final Message msg = new Message(resultMessage.getMessage());
                         summaries.add(new MessageSummary(resultMessage.getIndex(), msg));

--- a/graylog2-server/src/main/java/org/graylog2/alerts/types/MessageCountAlertCondition.java
+++ b/graylog2-server/src/main/java/org/graylog2/alerts/types/MessageCountAlertCondition.java
@@ -114,7 +114,7 @@ public class MessageCountAlertCondition extends AbstractAlertCondition {
                         + " than " + threshold + " messages. " + "(Current grace time: " + grace + " minutes)";
                 return new CheckResult(true, this, resultDescription, Tools.iso8601(), summaries);
             } else {
-                return new CheckResult(false);
+                return new NegativeCheckResult();
             }
         } catch (InvalidRangeParametersException e) {
             // cannot happen lol

--- a/graylog2-server/src/main/java/org/graylog2/notifications/Notification.java
+++ b/graylog2-server/src/main/java/org/graylog2/notifications/Notification.java
@@ -62,7 +62,8 @@ public interface Notification extends Persisted {
         GC_TOO_LONG,
         JOURNAL_UTILIZATION_TOO_HIGH,
         JOURNAL_UNCOMMITTED_MESSAGES_DELETED,
-        OUTPUT_DISABLED
+        OUTPUT_DISABLED,
+        GENERIC
     }
 
     public enum Severity {

--- a/graylog2-server/src/test/java/org/graylog2/alerts/AbstractAlertConditionTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/alerts/AbstractAlertConditionTest.java
@@ -16,14 +16,12 @@
  */
 package org.graylog2.alerts;
 
-import org.graylog2.plugin.Message;
 import org.graylog2.plugin.Tools;
 import org.graylog2.plugin.alarms.AlertCondition;
 import org.junit.Before;
 import org.junit.Ignore;
 import org.junit.Test;
 
-import java.util.List;
 import java.util.Map;
 
 import static org.junit.Assert.assertFalse;
@@ -72,12 +70,7 @@ public class AbstractAlertConditionTest extends AlertConditionTest {
             }
 
             @Override
-            protected CheckResult runCheck() {
-                return null;
-            }
-
-            @Override
-            public List<Message> getSearchHits() {
+            protected AlertCondition.CheckResult runCheck() {
                 return null;
             }
         };

--- a/graylog2-server/src/test/java/org/graylog2/alerts/FormattedEmailAlertSenderTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/alerts/FormattedEmailAlertSenderTest.java
@@ -17,10 +17,13 @@
 package org.graylog2.alerts;
 
 import org.graylog2.configuration.EmailConfiguration;
+import org.graylog2.notifications.NotificationService;
 import org.graylog2.plugin.Message;
+import org.graylog2.plugin.MessageSummary;
 import org.graylog2.plugin.alarms.AlertCondition;
 import org.graylog2.plugin.configuration.Configuration;
 import org.graylog2.plugin.streams.Stream;
+import org.graylog2.plugin.system.NodeId;
 import org.graylog2.shared.users.UserService;
 import org.graylog2.streams.StreamRuleService;
 import org.joda.time.DateTime;
@@ -44,11 +47,16 @@ public class FormattedEmailAlertSenderTest {
     private StreamRuleService mockStreamRuleService;
     @Mock
     private UserService mockUserService;
+    @Mock
+    private NotificationService mockNotificationService;
+    @Mock
+    private NodeId mockNodeId;
 
     @Test
     public void buildSubjectUsesCustomSubject() throws Exception {
         Configuration pluginConfig = new Configuration(Collections.<String, Object>singletonMap("subject", "Test"));
-        FormattedEmailAlertSender emailAlertSender = new FormattedEmailAlertSender(new EmailConfiguration(), mockStreamRuleService, mockUserService);
+        FormattedEmailAlertSender emailAlertSender = new FormattedEmailAlertSender(new EmailConfiguration(), mockStreamRuleService,
+                mockUserService, mockNotificationService, mockNodeId);
         emailAlertSender.initialize(pluginConfig);
 
         Stream stream = mock(Stream.class);
@@ -61,7 +69,8 @@ public class FormattedEmailAlertSenderTest {
 
     @Test
     public void buildSubjectUsesDefaultSubjectIfConfigDoesNotExist() throws Exception {
-        FormattedEmailAlertSender emailAlertSender = new FormattedEmailAlertSender(new EmailConfiguration(), mockStreamRuleService, mockUserService);
+        FormattedEmailAlertSender emailAlertSender = new FormattedEmailAlertSender(new EmailConfiguration(), mockStreamRuleService,
+                mockUserService, mockNotificationService, mockNodeId);
 
         Stream stream = mock(Stream.class);
         when(stream.getTitle()).thenReturn("Stream Title");
@@ -75,7 +84,8 @@ public class FormattedEmailAlertSenderTest {
     @Test
     public void buildBodyUsesCustomBody() throws Exception {
         Configuration pluginConfig = new Configuration(Collections.<String, Object>singletonMap("body", "Test: ${stream.id}"));
-        FormattedEmailAlertSender emailAlertSender = new FormattedEmailAlertSender(new EmailConfiguration(), mockStreamRuleService, mockUserService);
+        FormattedEmailAlertSender emailAlertSender = new FormattedEmailAlertSender(new EmailConfiguration(), mockStreamRuleService,
+                mockUserService, mockNotificationService, mockNodeId);
         emailAlertSender.initialize(pluginConfig);
 
         Stream stream = mock(Stream.class);
@@ -95,7 +105,8 @@ public class FormattedEmailAlertSenderTest {
 
     @Test
     public void buildBodyUsesDefaultBodyIfConfigDoesNotExist() throws Exception {
-        FormattedEmailAlertSender emailAlertSender = new FormattedEmailAlertSender(new EmailConfiguration(), mockStreamRuleService, mockUserService);
+        FormattedEmailAlertSender emailAlertSender = new FormattedEmailAlertSender(new EmailConfiguration(), mockStreamRuleService,
+                mockUserService, mockNotificationService, mockNodeId);
 
         Stream stream = mock(Stream.class);
         when(stream.getId()).thenReturn("123456");
@@ -124,7 +135,8 @@ public class FormattedEmailAlertSenderTest {
                 return URI.create("https://localhost");
             }
         };
-        FormattedEmailAlertSender emailAlertSender = new FormattedEmailAlertSender(configuration, mockStreamRuleService, mockUserService);
+        FormattedEmailAlertSender emailAlertSender = new FormattedEmailAlertSender(configuration, mockStreamRuleService,
+                mockUserService, mockNotificationService, mockNodeId);
 
         Stream stream = mock(Stream.class);
         when(stream.getId()).thenReturn("123456");
@@ -149,7 +161,8 @@ public class FormattedEmailAlertSenderTest {
                 return null;
             }
         };
-        FormattedEmailAlertSender emailAlertSender = new FormattedEmailAlertSender(configuration, mockStreamRuleService, mockUserService);
+        FormattedEmailAlertSender emailAlertSender = new FormattedEmailAlertSender(configuration, mockStreamRuleService,
+                mockUserService, mockNotificationService, mockNodeId);
 
         Stream stream = mock(Stream.class);
         when(stream.getId()).thenReturn("123456");
@@ -174,7 +187,8 @@ public class FormattedEmailAlertSenderTest {
                 return URI.create("");
             }
         };
-        FormattedEmailAlertSender emailAlertSender = new FormattedEmailAlertSender(configuration, mockStreamRuleService, mockUserService);
+        FormattedEmailAlertSender emailAlertSender = new FormattedEmailAlertSender(configuration, mockStreamRuleService,
+                mockUserService, mockNotificationService, mockNodeId);
 
         Stream stream = mock(Stream.class);
         when(stream.getId()).thenReturn("123456");


### PR DESCRIPTION
While I was browsing through the alerting/emailing code, I made a few minor improvements to it. Included are:

* better default email template
* cleaning up the preparation of the alert backlog (removing searchhits field/method, simplifying fetching tetching the required messages, preparing backlog _only_ if alert is triggered)
* cleaner notification is email transport failed
* adding generic notification which allows raising specific notifications without defining a new type
* raising a notification if a stream alert is triggered, an email transport is configured but no alert recipients are defined (without this it would just do nothing)
