### PR TITLE
Fix setting receive buffer size for UDP-based transports (#1143)

### DIFF
--- a/graylog2-inputs/src/main/java/org/graylog2/inputs/transports/UdpTransport.java
+++ b/graylog2-inputs/src/main/java/org/graylog2/inputs/transports/UdpTransport.java
@@ -67,7 +67,7 @@ public class UdpTransport extends NettyTransport {
     public Bootstrap getBootstrap() {
         final ConnectionlessBootstrap bootstrap = new ConnectionlessBootstrap(new NioDatagramChannelFactory(workerExecutor));
 
-        final int recvBufferSize = Integer.min(Ints.saturatedCast(getRecvBufferSize()), 65536);
+        final int recvBufferSize = Math.min(Ints.saturatedCast(getRecvBufferSize()), 65536);
         LOG.debug("Setting receive buffer size to {} bytes", recvBufferSize);
         bootstrap.setOption("receiveBufferSizePredictorFactory", new FixedReceiveBufferSizePredictorFactory(recvBufferSize));
         bootstrap.setOption("receiveBufferSize", recvBufferSize);

--- a/graylog2-inputs/src/main/java/org/graylog2/inputs/transports/UdpTransport.java
+++ b/graylog2-inputs/src/main/java/org/graylog2/inputs/transports/UdpTransport.java
@@ -33,6 +33,8 @@ import org.jboss.netty.bootstrap.Bootstrap;
 import org.jboss.netty.bootstrap.ConnectionlessBootstrap;
 import org.jboss.netty.channel.FixedReceiveBufferSizePredictorFactory;
 import org.jboss.netty.channel.socket.nio.NioDatagramChannelFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.util.concurrent.Executor;
 import java.util.concurrent.Executors;
@@ -41,6 +43,7 @@ import java.util.concurrent.ThreadFactory;
 import static com.codahale.metrics.MetricRegistry.name;
 
 public class UdpTransport extends NettyTransport {
+    private static final Logger LOG = LoggerFactory.getLogger(UdpTransport.class);
 
     private final Executor workerExecutor;
 
@@ -64,7 +67,8 @@ public class UdpTransport extends NettyTransport {
     public Bootstrap getBootstrap() {
         final ConnectionlessBootstrap bootstrap = new ConnectionlessBootstrap(new NioDatagramChannelFactory(workerExecutor));
 
-        final int recvBufferSize = Ints.saturatedCast(getRecvBufferSize());
+        final int recvBufferSize = Integer.min(Ints.saturatedCast(getRecvBufferSize()), 65536);
+        LOG.debug("Setting receive buffer size to {} bytes", recvBufferSize);
         bootstrap.setOption("receiveBufferSizePredictorFactory", new FixedReceiveBufferSizePredictorFactory(recvBufferSize));
         bootstrap.setOption("receiveBufferSize", recvBufferSize);
 

--- a/graylog2-inputs/src/main/java/org/graylog2/inputs/transports/UdpTransport.java
+++ b/graylog2-inputs/src/main/java/org/graylog2/inputs/transports/UdpTransport.java
@@ -14,33 +14,18 @@
  * You should have received a copy of the GNU General Public License
  * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
  */
-/**
- *
- * This file is part of Graylog.
- *
- * Graylog is free software: you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
- *
- * Graylog is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
- */
 package org.graylog2.inputs.transports;
 
 import com.codahale.metrics.InstrumentedExecutorService;
+import com.google.common.primitives.Ints;
 import com.google.common.util.concurrent.ThreadFactoryBuilder;
 import com.google.inject.assistedinject.Assisted;
 import com.google.inject.assistedinject.AssistedInject;
-import org.graylog2.plugin.inputs.annotations.ConfigClass;
-import org.graylog2.plugin.inputs.annotations.FactoryClass;
 import org.graylog2.plugin.LocalMetricRegistry;
 import org.graylog2.plugin.configuration.Configuration;
+import org.graylog2.plugin.configuration.ConfigurationRequest;
+import org.graylog2.plugin.inputs.annotations.ConfigClass;
+import org.graylog2.plugin.inputs.annotations.FactoryClass;
 import org.graylog2.plugin.inputs.transports.NettyTransport;
 import org.graylog2.plugin.inputs.transports.Transport;
 import org.graylog2.plugin.inputs.util.ThroughputCounter;
@@ -77,11 +62,11 @@ public class UdpTransport extends NettyTransport {
 
     @Override
     public Bootstrap getBootstrap() {
-        final ConnectionlessBootstrap bootstrap =
-                new ConnectionlessBootstrap(new NioDatagramChannelFactory(workerExecutor));
+        final ConnectionlessBootstrap bootstrap = new ConnectionlessBootstrap(new NioDatagramChannelFactory(workerExecutor));
 
-        bootstrap.setOption("receiveBufferSizePredictorFactory", new FixedReceiveBufferSizePredictorFactory(8192));
-        bootstrap.setOption("receiveBufferSize", getRecvBufferSize());
+        final int recvBufferSize = Ints.saturatedCast(getRecvBufferSize());
+        bootstrap.setOption("receiveBufferSizePredictorFactory", new FixedReceiveBufferSizePredictorFactory(recvBufferSize));
+        bootstrap.setOption("receiveBufferSize", recvBufferSize);
 
         return bootstrap;
     }
@@ -95,8 +80,15 @@ public class UdpTransport extends NettyTransport {
         Config getConfig();
     }
 
-    // only here for consistency
     @ConfigClass
     public static class Config extends NettyTransport.Config {
+        @Override
+        public ConfigurationRequest getRequestedConfiguration() {
+            final ConfigurationRequest r = super.getRequestedConfiguration();
+
+            r.addField(ConfigurationRequest.Templates.recvBufferSize(CK_RECV_BUFFER_SIZE, 65535));
+
+            return r;
+        }
     }
 }

--- a/graylog2-inputs/src/main/java/org/graylog2/inputs/transports/UdpTransport.java
+++ b/graylog2-inputs/src/main/java/org/graylog2/inputs/transports/UdpTransport.java
@@ -90,7 +90,7 @@ public class UdpTransport extends NettyTransport {
         public ConfigurationRequest getRequestedConfiguration() {
             final ConfigurationRequest r = super.getRequestedConfiguration();
 
-            r.addField(ConfigurationRequest.Templates.recvBufferSize(CK_RECV_BUFFER_SIZE, 65535));
+            r.addField(ConfigurationRequest.Templates.recvBufferSize(CK_RECV_BUFFER_SIZE, 16384));
 
             return r;
         }

--- a/graylog2-inputs/src/test/java/org/graylog2/inputs/transports/UdpTransportTest.java
+++ b/graylog2-inputs/src/test/java/org/graylog2/inputs/transports/UdpTransportTest.java
@@ -174,6 +174,18 @@ public class UdpTransportTest {
     }
 
     @Test
+    public void receiveBufferSizeIsLimited() throws Exception {
+        ImmutableMap<String, Object> source = ImmutableMap.<String, Object>of(
+                NettyTransport.CK_BIND_ADDRESS, BIND_ADDRESS,
+                NettyTransport.CK_PORT, PORT,
+                NettyTransport.CK_RECV_BUFFER_SIZE, Integer.MAX_VALUE);
+        Configuration config = new Configuration(source);
+        UdpTransport udpTransport = new UdpTransport(config, throughputCounter, new LocalMetricRegistry());
+
+        assertThat(udpTransport.getBootstrap().getOption("receiveBufferSize")).isEqualTo(65536);
+    }
+
+    @Test
     public void receiveBufferSizePredictorIsUsingDefaultSize() throws Exception {
         ReceiveBufferSizePredictorFactory receiveBufferSizePredictorFactory =
                 (ReceiveBufferSizePredictorFactory) udpTransport.getBootstrap().getOption("receiveBufferSizePredictorFactory");

--- a/graylog2-inputs/src/test/java/org/graylog2/inputs/transports/UdpTransportTest.java
+++ b/graylog2-inputs/src/test/java/org/graylog2/inputs/transports/UdpTransportTest.java
@@ -1,0 +1,211 @@
+/**
+ * This file is part of Graylog.
+ *
+ * Graylog is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.graylog2.inputs.transports;
+
+import com.google.common.collect.ImmutableMap;
+import com.google.common.util.concurrent.Callables;
+import com.google.common.util.concurrent.Uninterruptibles;
+import org.graylog2.plugin.LocalMetricRegistry;
+import org.graylog2.plugin.configuration.Configuration;
+import org.graylog2.plugin.configuration.ConfigurationRequest;
+import org.graylog2.plugin.inputs.MessageInput;
+import org.graylog2.plugin.inputs.MisfireException;
+import org.graylog2.plugin.inputs.transports.NettyTransport;
+import org.graylog2.plugin.inputs.util.ThroughputCounter;
+import org.jboss.netty.buffer.ChannelBuffer;
+import org.jboss.netty.channel.ChannelHandler;
+import org.jboss.netty.channel.ChannelHandlerContext;
+import org.jboss.netty.channel.FixedReceiveBufferSizePredictorFactory;
+import org.jboss.netty.channel.MessageEvent;
+import org.jboss.netty.channel.ReceiveBufferSizePredictorFactory;
+import org.jboss.netty.channel.SimpleChannelUpstreamHandler;
+import org.jboss.netty.channel.UpstreamMessageEvent;
+import org.jboss.netty.util.HashedWheelTimer;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.net.DatagramPacket;
+import java.net.DatagramSocket;
+import java.net.InetAddress;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.concurrent.Callable;
+import java.util.concurrent.TimeUnit;
+
+import static com.jayway.awaitility.Awaitility.await;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class UdpTransportTest {
+    private static final String BIND_ADDRESS = "127.0.0.1";
+    private static final int PORT = 5555;
+    private static final int RECV_BUFFER_SIZE = 1024;
+    private static final ImmutableMap<String, Object> CONFIG_SOURCE = ImmutableMap.<String, Object>of(
+            NettyTransport.CK_BIND_ADDRESS, BIND_ADDRESS,
+            NettyTransport.CK_PORT, PORT,
+            NettyTransport.CK_RECV_BUFFER_SIZE, RECV_BUFFER_SIZE);
+    private static final Configuration CONFIGURATION = new Configuration(CONFIG_SOURCE);
+
+    private UdpTransport udpTransport;
+    private ThroughputCounter throughputCounter;
+    private LocalMetricRegistry localMetricRegistry;
+
+    @Before
+    public void setUp() throws Exception {
+        throughputCounter = new ThroughputCounter(new HashedWheelTimer());
+        localMetricRegistry = new LocalMetricRegistry();
+        udpTransport = new UdpTransport(CONFIGURATION, throughputCounter, localMetricRegistry);
+    }
+
+    @Test
+    public void transportReceivesDataSmallerThanRecvBufferSize() throws Exception {
+        final CountingChannelUpstreamHandler handler = new CountingChannelUpstreamHandler();
+        final UdpTransport transport = launchTransportForBootStrapTest(handler);
+
+        sendUdpDatagram(BIND_ADDRESS, PORT, 100);
+        await().atMost(5, TimeUnit.SECONDS).until(new Callable<Boolean>() {
+            @Override
+            public Boolean call() throws Exception {
+                return !handler.getBytesWritten().isEmpty();
+            }
+        });
+        transport.stop();
+
+        assertThat(handler.getBytesWritten()).containsOnly(100);
+    }
+
+    @Test
+    public void transportReceivesDataExactlyRecvBufferSize() throws Exception {
+        final CountingChannelUpstreamHandler handler = new CountingChannelUpstreamHandler();
+        final UdpTransport transport = launchTransportForBootStrapTest(handler);
+
+        // This will be variable depending on the version of the IP protocol and the UDP packet size.
+        final int udpOverhead = 16;
+        final int maxPacketSize = RECV_BUFFER_SIZE - udpOverhead;
+
+        sendUdpDatagram(BIND_ADDRESS, PORT, maxPacketSize);
+        await().atMost(5, TimeUnit.SECONDS).until(new Callable<Boolean>() {
+            @Override
+            public Boolean call() throws Exception {
+                return !handler.getBytesWritten().isEmpty();
+            }
+        });
+        transport.stop();
+
+        assertThat(handler.getBytesWritten()).containsOnly(maxPacketSize);
+    }
+
+    @Test
+    public void transportDiscardsDataLargerRecvBufferSize() throws Exception {
+        final CountingChannelUpstreamHandler handler = new CountingChannelUpstreamHandler();
+        final UdpTransport transport = launchTransportForBootStrapTest(handler);
+
+        sendUdpDatagram(BIND_ADDRESS, PORT, 2 * RECV_BUFFER_SIZE);
+        Uninterruptibles.sleepUninterruptibly(2, TimeUnit.SECONDS);
+
+        transport.stop();
+
+        assertThat(handler.getBytesWritten()).isEmpty();
+    }
+
+    private UdpTransport launchTransportForBootStrapTest(final ChannelHandler channelHandler) throws MisfireException {
+        final UdpTransport transport = new UdpTransport(CONFIGURATION, throughputCounter, new LocalMetricRegistry()) {
+            @Override
+            protected LinkedHashMap<String, Callable<? extends ChannelHandler>> getBaseChannelHandlers(MessageInput input) {
+                final LinkedHashMap<String, Callable<? extends ChannelHandler>> handlers = new LinkedHashMap<>();
+                handlers.put("counter", Callables.returning(channelHandler));
+                handlers.putAll(super.getFinalChannelHandlers(input));
+                return handlers;
+            }
+        };
+
+        final MessageInput messageInput = mock(MessageInput.class);
+        when(messageInput.getId()).thenReturn("TEST");
+        when(messageInput.getName()).thenReturn("TEST");
+
+        transport.launch(messageInput);
+
+        return transport;
+    }
+
+    @Test
+    public void receiveBufferSizeIsDefaultSize() throws Exception {
+        assertThat(udpTransport.getBootstrap().getOption("receiveBufferSize")).isEqualTo(RECV_BUFFER_SIZE);
+    }
+
+    @Test
+    public void receiveBufferSizePredictorIsUsingDefaultSize() throws Exception {
+        ReceiveBufferSizePredictorFactory receiveBufferSizePredictorFactory =
+                (ReceiveBufferSizePredictorFactory) udpTransport.getBootstrap().getOption("receiveBufferSizePredictorFactory");
+        assertThat(receiveBufferSizePredictorFactory).isInstanceOf(FixedReceiveBufferSizePredictorFactory.class);
+        assertThat(receiveBufferSizePredictorFactory.getPredictor().nextReceiveBufferSize()).isEqualTo(RECV_BUFFER_SIZE);
+    }
+
+    @Test
+    public void getMetricSetReturnsLocalMetricRegistry() {
+        assertThat(udpTransport.getMetricSet()).isSameAs(localMetricRegistry);
+    }
+
+    @Test
+    public void testDefaultReceiveBufferSize() throws Exception {
+        final UdpTransport.Config config = new UdpTransport.Config();
+        final ConfigurationRequest requestedConfiguration = config.getRequestedConfiguration();
+
+        assertThat(requestedConfiguration.getField(NettyTransport.CK_RECV_BUFFER_SIZE).getDefaultValue()).isEqualTo(65535);
+    }
+
+    private void sendUdpDatagram(String hostname, int port, int size) throws IOException {
+        final InetAddress address = InetAddress.getByName(hostname);
+        final byte[] data = new byte[size];
+        final DatagramPacket packet = new DatagramPacket(data, data.length, address, port);
+
+        DatagramSocket toSocket = null;
+        try {
+            toSocket = new DatagramSocket();
+            toSocket.send(packet);
+        } finally {
+            if (toSocket != null) {
+                toSocket.close();
+            }
+        }
+    }
+
+    public static class CountingChannelUpstreamHandler extends SimpleChannelUpstreamHandler {
+        private final List<Integer> bytesWritten = new ArrayList<>();
+
+        @Override
+        public void messageReceived(ChannelHandlerContext ctx, MessageEvent e) throws Exception {
+            if (e instanceof UpstreamMessageEvent) {
+                ChannelBuffer buffer = (ChannelBuffer) e.getMessage();
+                try {
+                    synchronized (bytesWritten) {
+                        bytesWritten.add(buffer.readableBytes());
+                    }
+                } finally {
+                    super.messageReceived(ctx, e);
+                }
+            }
+        }
+
+        public List<Integer> getBytesWritten() {
+            return bytesWritten;
+        }
+    }
+}

--- a/graylog2-inputs/src/test/java/org/graylog2/inputs/transports/UdpTransportTest.java
+++ b/graylog2-inputs/src/test/java/org/graylog2/inputs/transports/UdpTransportTest.java
@@ -43,6 +43,7 @@ import java.io.IOException;
 import java.net.DatagramPacket;
 import java.net.DatagramSocket;
 import java.net.InetAddress;
+import java.net.InetSocketAddress;
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -57,7 +58,7 @@ import static org.mockito.Mockito.when;
 
 public class UdpTransportTest {
     private static final String BIND_ADDRESS = "127.0.0.1";
-    private static final int PORT = 5555;
+    private static final int PORT = 0;
     private static final int RECV_BUFFER_SIZE = 1024;
     private static final ImmutableMap<String, Object> CONFIG_SOURCE = ImmutableMap.<String, Object>of(
             NettyTransport.CK_BIND_ADDRESS, BIND_ADDRESS,
@@ -80,8 +81,9 @@ public class UdpTransportTest {
     public void transportReceivesDataSmallerThanRecvBufferSize() throws Exception {
         final CountingChannelUpstreamHandler handler = new CountingChannelUpstreamHandler();
         final UdpTransport transport = launchTransportForBootStrapTest(handler);
+        final InetSocketAddress localAddress = (InetSocketAddress) transport.getLocalAddress();
 
-        sendUdpDatagram(BIND_ADDRESS, PORT, 100);
+        sendUdpDatagram(BIND_ADDRESS, localAddress.getPort(), 100);
         await().atMost(5, TimeUnit.SECONDS).until(new Callable<Boolean>() {
             @Override
             public Boolean call() throws Exception {
@@ -97,12 +99,13 @@ public class UdpTransportTest {
     public void transportReceivesDataExactlyRecvBufferSize() throws Exception {
         final CountingChannelUpstreamHandler handler = new CountingChannelUpstreamHandler();
         final UdpTransport transport = launchTransportForBootStrapTest(handler);
+        final InetSocketAddress localAddress = (InetSocketAddress) transport.getLocalAddress();
 
         // This will be variable depending on the version of the IP protocol and the UDP packet size.
         final int udpOverhead = 16;
         final int maxPacketSize = RECV_BUFFER_SIZE - udpOverhead;
 
-        sendUdpDatagram(BIND_ADDRESS, PORT, maxPacketSize);
+        sendUdpDatagram(BIND_ADDRESS, localAddress.getPort(), maxPacketSize);
         await().atMost(5, TimeUnit.SECONDS).until(new Callable<Boolean>() {
             @Override
             public Boolean call() throws Exception {
@@ -120,8 +123,9 @@ public class UdpTransportTest {
 
         final CountingChannelUpstreamHandler handler = new CountingChannelUpstreamHandler();
         final UdpTransport transport = launchTransportForBootStrapTest(handler);
+        final InetSocketAddress localAddress = (InetSocketAddress) transport.getLocalAddress();
 
-        sendUdpDatagram(BIND_ADDRESS, PORT, 2 * RECV_BUFFER_SIZE);
+        sendUdpDatagram(BIND_ADDRESS, localAddress.getPort(), 2 * RECV_BUFFER_SIZE);
         Uninterruptibles.sleepUninterruptibly(2, TimeUnit.SECONDS);
 
         transport.stop();
@@ -135,8 +139,9 @@ public class UdpTransportTest {
 
         final CountingChannelUpstreamHandler handler = new CountingChannelUpstreamHandler();
         final UdpTransport transport = launchTransportForBootStrapTest(handler);
+        final InetSocketAddress localAddress = (InetSocketAddress) transport.getLocalAddress();
 
-        sendUdpDatagram(BIND_ADDRESS, PORT, 2 * RECV_BUFFER_SIZE);
+        sendUdpDatagram(BIND_ADDRESS, localAddress.getPort(), 2 * RECV_BUFFER_SIZE);
         await().atMost(5, TimeUnit.SECONDS).until(new Callable<Boolean>() {
             @Override
             public Boolean call() throws Exception {

--- a/graylog2-inputs/src/test/java/org/graylog2/inputs/transports/UdpTransportTest.java
+++ b/graylog2-inputs/src/test/java/org/graylog2/inputs/transports/UdpTransportTest.java
@@ -203,7 +203,7 @@ public class UdpTransportTest {
         final UdpTransport.Config config = new UdpTransport.Config();
         final ConfigurationRequest requestedConfiguration = config.getRequestedConfiguration();
 
-        assertThat(requestedConfiguration.getField(NettyTransport.CK_RECV_BUFFER_SIZE).getDefaultValue()).isEqualTo(65535);
+        assertThat(requestedConfiguration.getField(NettyTransport.CK_RECV_BUFFER_SIZE).getDefaultValue()).isEqualTo(16384);
     }
 
     private void sendUdpDatagram(String hostname, int port, int size) throws IOException {

--- a/graylog2-plugin-interfaces/src/main/java/org/graylog2/plugin/inputs/transports/NettyTransport.java
+++ b/graylog2-plugin-interfaces/src/main/java/org/graylog2/plugin/inputs/transports/NettyTransport.java
@@ -58,6 +58,7 @@ import org.slf4j.LoggerFactory;
 
 import javax.annotation.Nullable;
 import java.net.InetSocketAddress;
+import java.net.SocketAddress;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.concurrent.Callable;
@@ -142,7 +143,7 @@ public abstract class NettyTransport implements Transport {
 
 
                 final ServerSocketChannelConfig channelConfig = (ServerSocketChannelConfig) acceptChannel.getConfig();
-                if(channelConfig.getReceiveBufferSize() != getRecvBufferSize()) {
+                if (channelConfig.getReceiveBufferSize() != getRecvBufferSize()) {
                     log.warn("receiveBufferSize (SO_RCVBUF) for {} should be {} but is {}.", acceptChannel, getRecvBufferSize(), channelConfig.getReceiveBufferSize());
                 }
             } else {
@@ -179,8 +180,8 @@ public abstract class NettyTransport implements Transport {
      * <p/>
      * Some common use cases are to add SSL/TLS, connection counters or throttling traffic shapers.
      *
-     * @return the list of initial channelhandlers to add to the {@link org.jboss.netty.channel.ChannelPipelineFactory}
      * @param input
+     * @return the list of initial channelhandlers to add to the {@link org.jboss.netty.channel.ChannelPipelineFactory}
      */
     protected LinkedHashMap<String, Callable<? extends ChannelHandler>> getBaseChannelHandlers(final MessageInput input) {
         LinkedHashMap<String, Callable<? extends ChannelHandler>> handlerList = Maps.newLinkedHashMap();
@@ -206,8 +207,8 @@ public abstract class NettyTransport implements Transport {
      * <p/>
      * One valid use case would be to insert debug handlers in the middle of the list, though.
      *
-     * @return the list of channel handlers at the end of the pipeline
      * @param input
+     * @return the list of channel handlers at the end of the pipeline
      */
     protected LinkedHashMap<String, Callable<? extends ChannelHandler>> getFinalChannelHandlers(final MessageInput input) {
         LinkedHashMap<String, Callable<? extends ChannelHandler>> handlerList = Maps.newLinkedHashMap();
@@ -233,6 +234,19 @@ public abstract class NettyTransport implements Transport {
 
     protected long getRecvBufferSize() {
         return recvBufferSize;
+    }
+
+    /**
+     * Get the local socket address this transport is listening on after being launched.
+     *
+     * @return the listening address of this transport or {@code null} if the transport hasn't been launched yet.
+     */
+    public SocketAddress getLocalAddress() {
+        if (acceptChannel == null || !acceptChannel.isBound()) {
+            return null;
+        }
+
+        return acceptChannel.getLocalAddress();
     }
 
     @Override
@@ -265,7 +279,7 @@ public abstract class NettyTransport implements Transport {
                 if (completeMessage != null) {
                     log.debug("Message aggregation completion, forwarding {}", completeMessage);
                     fireMessageReceived(ctx, completeMessage);
-                } else if(result.isValid()) {
+                } else if (result.isValid()) {
                     log.debug("More chunks necessary to complete this message");
                 } else {
                     invalidChunksMeter.mark();

--- a/graylog2-server/pom.xml
+++ b/graylog2-server/pom.xml
@@ -297,14 +297,6 @@
         </dependency>
 
         <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.assertj</groupId>
-            <artifactId>assertj-core</artifactId>
-        </dependency>
-        <dependency>
             <groupId>org.assertj</groupId>
             <artifactId>assertj-joda-time</artifactId>
         </dependency>
@@ -319,10 +311,6 @@
         <dependency>
             <groupId>org.jukito</groupId>
             <artifactId>jukito</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>com.jayway.awaitility</groupId>
-            <artifactId>awaitility</artifactId>
         </dependency>
     </dependencies>
 

--- a/pom.xml
+++ b/pom.xml
@@ -754,6 +754,14 @@
             <groupId>org.mockito</groupId>
             <artifactId>mockito-all</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.jayway.awaitility</groupId>
+            <artifactId>awaitility</artifactId>
+        </dependency>
     </dependencies>
 
     <build>


### PR DESCRIPTION
This PR fixes the allocation of the receive buffer for UDP-based transports and increases the default receive buffer size for UDP-based transports to 64K.

While the receive buffer size for UDP-based transports could be configured for each transport, the effective size for the receive buffer was fixed to 8192 bytes by using a `FixedReceiveBufferSizePredictor` with a hard-coded value.

By changing the default receive buffer size for UDP-based transports to 65535 bytes and using the configured receive buffer size as value for the `FixedReceiveBufferSizePredictor`, the maximum UDP packet size that can be processed by UDP-based transports is now finally configurable.

As the practical maximum size for a UDP packet is 65507 bytes, the default of 65535 bytes for the receive buffer should be fine (at the cost of increased memory allocations).

Fixes #1143