### PR TITLE
implement streaming support in API client

### DIFF
--- a/graylog2-rest-client/src/main/java/org/graylog2/restclient/lib/ApiClientImpl.java
+++ b/graylog2-rest-client/src/main/java/org/graylog2/restclient/lib/ApiClientImpl.java
@@ -432,13 +432,11 @@ class ApiClientImpl implements ApiClient {
             ensureExpectedResponseCodes();
 
             try {
-                // TODO implement streaming responses
                 Response response = requestBuilder.execute().get(timeoutValue, timeoutUnit);
 
                 target.touch();
                 return handleResponse(request, response);
             } catch (InterruptedException e) {
-                // TODO
                 target.markFailure();
             } catch (MalformedURLException e) {
                 LOG.error("Malformed URL", e);
@@ -452,7 +450,6 @@ class ApiClientImpl implements ApiClient {
                 LOG.error("REST call failed", rootCause(e));
                 throw new APIException(request, e);
             } catch (IOException e) {
-                // TODO
                 LOG.error("unhandled IOException", rootCause(e));
                 target.markFailure();
                 throw e;
@@ -725,7 +722,6 @@ class ApiClientImpl implements ApiClient {
                 builtUrl = uriBuilder.build();
                 return builtUrl.toURL();
             } catch (MalformedURLException e) {
-                // TODO handle this properly
                 LOG.error("Could not build target URL", e);
                 throw new RuntimeException(e);
             }
@@ -802,7 +798,6 @@ class ApiClientImpl implements ApiClient {
                 LOG.error("Malformed URL", e);
                 throw new RuntimeException("Malformed URL.", e);
             } catch (IOException e) {
-                // TODO
                 LOG.error("unhandled IOException", rootCause(e));
                 target.markFailure();
                 throw e;

--- a/graylog2-rest-client/src/main/java/org/graylog2/restclient/lib/ApiClientImpl.java
+++ b/graylog2-rest-client/src/main/java/org/graylog2/restclient/lib/ApiClientImpl.java
@@ -425,7 +425,7 @@ class ApiClientImpl implements ApiClient {
 
             final Request request = requestBuilder.build();
             if (LOG.isDebugEnabled()) {
-                LOG.debug("API Request: {}", request.toString());
+                LOG.debug("API Request: {}", request);
             }
 
             // Set 200 OK as standard if not defined.
@@ -759,7 +759,7 @@ class ApiClientImpl implements ApiClient {
 
             final Request request = requestBuilder.build();
             if (LOG.isDebugEnabled()) {
-                LOG.debug("API Request: {}", request.toString());
+                LOG.debug("API Request: {}", request);
             }
 
             // Set 200 OK as standard if not defined.

--- a/graylog2-rest-client/src/main/java/org/graylog2/restclient/lib/ApiRequestBuilder.java
+++ b/graylog2-rest-client/src/main/java/org/graylog2/restclient/lib/ApiRequestBuilder.java
@@ -20,9 +20,9 @@ import com.google.common.net.MediaType;
 import org.graylog2.restclient.models.ClusterEntity;
 import org.graylog2.restclient.models.Node;
 import org.graylog2.restclient.models.Radio;
-import org.graylog2.restclient.models.api.requests.ApiRequest;
 
 import java.io.IOException;
+import java.io.InputStream;
 import java.net.URL;
 import java.util.Collection;
 import java.util.Map;
@@ -80,4 +80,6 @@ public interface ApiRequestBuilder<T> {
 
     // solely for test purposes
     URL prepareUrl(ClusterEntity node);
+
+    InputStream executeStreaming() throws APIException, IOException;
 }

--- a/graylog2-rest-client/src/main/java/org/graylog2/restclient/lib/AsyncByteBufferInputStream.java
+++ b/graylog2-rest-client/src/main/java/org/graylog2/restclient/lib/AsyncByteBufferInputStream.java
@@ -1,0 +1,109 @@
+/**
+ * This file is part of Graylog.
+ *
+ * Graylog is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.graylog2.restclient.lib;
+
+import com.google.common.util.concurrent.Uninterruptibles;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.ByteBuffer;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.LinkedBlockingQueue;
+
+public class AsyncByteBufferInputStream extends InputStream {
+
+    private static final ByteBuffer EMPTY_BUFFER = ByteBuffer.allocate(0);
+
+    private ByteArrayInputStream currentBuffer;
+
+    private Throwable failed;
+
+    private boolean done;
+
+    private final BlockingQueue<ByteBuffer> buffers;
+
+    public AsyncByteBufferInputStream() {
+        // 100 limits the amount of memory we are willing to spend before blocking
+        this(100);
+    }
+
+    public AsyncByteBufferInputStream(int size) {
+        buffers = new LinkedBlockingQueue<>(size);
+    }
+
+    private void readNextBuffer() {
+        try {
+            final ByteBuffer buffer = buffers.take();
+            currentBuffer = new ByteArrayInputStream(buffer.array());
+        } catch (InterruptedException ignored) {
+        }
+    }
+
+    @Override
+    public int read() throws IOException {
+        // fail if we encountered an exception
+        if (failed != null) {
+            throw new IOException(failed);
+        }
+        // claim next buffer
+        if (currentBuffer == null) {
+            readNextBuffer();
+        }
+
+        int nextByte = currentBuffer.read();
+        if (nextByte == -1) { // currentBuffer exhausted, load next buffer if present
+            if (buffers.size() == 0 && isDone()) { // there will be no more data
+                return -1;
+            }
+            readNextBuffer(); // this can block until data is present.
+            nextByte = currentBuffer.read(); // on isDone or isFailed the last buffer will be empty
+            // double check for failure to detect empty buffer case
+            if (failed != null) {
+                throw new IOException(failed);
+            }
+        }
+        return nextByte;
+    }
+
+    public Throwable getFailed() {
+        return failed;
+    }
+
+    public void setFailed(Throwable failed) {
+        insertMarkerBuffer();
+        this.failed = failed;
+    }
+
+    public boolean isDone() {
+        return done;
+    }
+
+    public void setDone(boolean done) {
+        insertMarkerBuffer();
+        this.done = done;
+    }
+
+    private void insertMarkerBuffer() {
+        putBuffer(EMPTY_BUFFER);
+    }
+
+    public void putBuffer(ByteBuffer buffer) {
+        Uninterruptibles.putUninterruptibly(buffers, buffer);
+    }
+
+}

--- a/graylog2-rest-client/src/main/java/org/graylog2/restclient/models/UniversalSearch.java
+++ b/graylog2-rest-client/src/main/java/org/graylog2/restclient/models/UniversalSearch.java
@@ -17,17 +17,18 @@
 package org.graylog2.restclient.models;
 
 import com.google.common.base.Joiner;
-import com.google.common.collect.Lists;
 import com.google.common.net.MediaType;
-import javax.inject.Inject;
 import com.google.inject.assistedinject.Assisted;
 import com.google.inject.assistedinject.AssistedInject;
 import org.graylog2.restclient.lib.APIException;
 import org.graylog2.restclient.lib.ApiClient;
 import org.graylog2.restclient.lib.ApiRequestBuilder;
 import org.graylog2.restclient.lib.timeranges.TimeRange;
-import org.graylog2.restclient.models.api.responses.*;
-import org.graylog2.restclient.models.api.responses.system.indices.IndexSummaryResponse;
+import org.graylog2.restclient.models.api.responses.DateHistogramResponse;
+import org.graylog2.restclient.models.api.responses.FieldHistogramResponse;
+import org.graylog2.restclient.models.api.responses.FieldStatsResponse;
+import org.graylog2.restclient.models.api.responses.FieldTermsResponse;
+import org.graylog2.restclient.models.api.responses.SearchResultResponse;
 import org.graylog2.restclient.models.api.results.DateHistogramResult;
 import org.graylog2.restclient.models.api.results.SearchResult;
 import org.graylog2.restroutes.PathMethod;
@@ -37,7 +38,7 @@ import org.slf4j.LoggerFactory;
 
 import javax.annotation.Nullable;
 import java.io.IOException;
-import java.util.List;
+import java.io.InputStream;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
 
@@ -106,6 +107,15 @@ public class UniversalSearch {
     }
 
     private <T> T doSearch(Class<T> clazz, MediaType mediaType, int pageSize, Set<String> selectedFields) throws APIException, IOException {
+        final ApiRequestBuilder<T> builder = getSearchRequestBuilder(clazz, pageSize, selectedFields);
+        return builder
+                .accept(mediaType)
+                .timeout(KEITH, TimeUnit.SECONDS)
+                .expect(200, 400)
+                .execute();
+    }
+
+    private <T> ApiRequestBuilder<T> getSearchRequestBuilder(Class<T> clazz, int pageSize, Set<String> selectedFields) {
         PathMethod pathMethod;
         switch (timeRange.getType()) {
             case ABSOLUTE:
@@ -130,11 +140,7 @@ public class UniversalSearch {
         if (selectedFields != null && !selectedFields.isEmpty()) {
             builder.queryParam("fields", Joiner.on(',').skipNulls().join(selectedFields));
         }
-        return builder
-                .accept(mediaType)
-                .timeout(KEITH, TimeUnit.SECONDS)
-                .expect(200, 400)
-                .execute();
+        return builder;
     }
 
     public SearchResult search() throws IOException, APIException {
@@ -159,8 +165,14 @@ public class UniversalSearch {
         );
     }
 
-    public String searchAsCsv(Set<String> selectedFields) throws IOException, APIException {
-        return doSearch(String.class, MediaType.CSV_UTF_8, 10_000, selectedFields);  // TODO make use of streaming support in the server.
+    public InputStream searchAsCsv(Set<String> selectedFields) throws IOException, APIException {
+        final ApiRequestBuilder<String> builder = getSearchRequestBuilder(String.class,
+                                                                          Integer.MAX_VALUE,
+                                                                          selectedFields);
+        return builder.accept(MediaType.CSV_UTF_8)
+                .timeout(KEITH, TimeUnit.SECONDS)
+                .expect(200, 400)
+                .executeStreaming();
     }
 
     public DateHistogramResult dateHistogram(String interval) throws IOException, APIException {

--- a/graylog2-rest-client/src/test/java/org/graylog2/restclient/lib/AsyncByteBufferInputStreamTest.java
+++ b/graylog2-rest-client/src/test/java/org/graylog2/restclient/lib/AsyncByteBufferInputStreamTest.java
@@ -82,13 +82,9 @@ public class AsyncByteBufferInputStreamTest {
             @Override
             public void run() {
                 for (int i = 0; i < 10; i++) {
-                    try {
-                        stream.putBuffer(ByteBuffer.wrap("12345".getBytes()));
-                        stream.putBuffer(ByteBuffer.wrap("6\n".getBytes()));
-                        System.out.println("Wrote buffers step " + i);
-                    } catch (InterruptedException ignored) {
-
-                    }
+                    stream.putBuffer(ByteBuffer.wrap("12345".getBytes()));
+                    stream.putBuffer(ByteBuffer.wrap("6\n".getBytes()));
+                    System.out.println("Wrote buffers step " + i);
                     sleepUninterruptibly(500, TimeUnit.MILLISECONDS);
                 }
                 stream.setDone(true);
@@ -127,13 +123,9 @@ public class AsyncByteBufferInputStreamTest {
             @Override
             public void run() {
                 for (int i = 0; i < 10; i++) {
-                    try {
-                        stream.putBuffer(ByteBuffer.wrap("12345".getBytes()));
-                        stream.putBuffer(ByteBuffer.wrap("6\n".getBytes()));
-                        System.out.println("Wrote buffers step " + i);
-                    } catch (InterruptedException ignored) {
-
-                    }
+                    stream.putBuffer(ByteBuffer.wrap("12345".getBytes()));
+                    stream.putBuffer(ByteBuffer.wrap("6\n".getBytes()));
+                    System.out.println("Wrote buffers step " + i);
                     sleepUninterruptibly(500, TimeUnit.MILLISECONDS);
                     if (i == 3) {
                         stream.setFailed(new Throwable());

--- a/graylog2-rest-client/src/test/java/org/graylog2/restclient/lib/AsyncByteBufferInputStreamTest.java
+++ b/graylog2-rest-client/src/test/java/org/graylog2/restclient/lib/AsyncByteBufferInputStreamTest.java
@@ -85,7 +85,7 @@ public class AsyncByteBufferInputStreamTest {
                     stream.putBuffer(ByteBuffer.wrap("12345".getBytes()));
                     stream.putBuffer(ByteBuffer.wrap("6\n".getBytes()));
 
-                    sleepUninterruptibly(500, TimeUnit.MILLISECONDS);
+                    sleepUninterruptibly(100, TimeUnit.MILLISECONDS);
                 }
                 stream.setDone(true);
 
@@ -124,7 +124,7 @@ public class AsyncByteBufferInputStreamTest {
                     stream.putBuffer(ByteBuffer.wrap("12345".getBytes()));
                     stream.putBuffer(ByteBuffer.wrap("6\n".getBytes()));
 
-                    sleepUninterruptibly(500, TimeUnit.MILLISECONDS);
+                    sleepUninterruptibly(250, TimeUnit.MILLISECONDS);
                     if (i == 3) {
                         stream.setFailed(new Throwable());
                         return;

--- a/graylog2-rest-client/src/test/java/org/graylog2/restclient/lib/AsyncByteBufferInputStreamTest.java
+++ b/graylog2-rest-client/src/test/java/org/graylog2/restclient/lib/AsyncByteBufferInputStreamTest.java
@@ -24,7 +24,7 @@ import java.nio.ByteBuffer;
 import java.util.concurrent.TimeUnit;
 
 import static com.google.common.util.concurrent.Uninterruptibles.sleepUninterruptibly;
-import static org.junit.Assert.fail;
+import static org.junit.Assert.*;
 
 public class AsyncByteBufferInputStreamTest {
 
@@ -84,28 +84,23 @@ public class AsyncByteBufferInputStreamTest {
                 for (int i = 0; i < 10; i++) {
                     stream.putBuffer(ByteBuffer.wrap("12345".getBytes()));
                     stream.putBuffer(ByteBuffer.wrap("6\n".getBytes()));
-                    System.out.println("Wrote buffers step " + i);
+
                     sleepUninterruptibly(500, TimeUnit.MILLISECONDS);
                 }
                 stream.setDone(true);
 
             }
         };
+        final int[] readBytes = {0};
         final Thread reader = new Thread() {
             @Override
             public void run() {
                 int singleByte = -1;
-                int count = 0;
                 do {
                     try {
                         singleByte = stream.read();
-                        count++;
-                    } catch (IOException e) {
-
-                    }
-                    if (count % 5 == 0) {
-                        System.out.println("read " + count + " bytes");
-                    }
+                        readBytes[0]++;
+                    } catch (IOException ignored) {/* no IO done, it's all in memory */}
                 } while (singleByte != -1);
             }
         };
@@ -113,6 +108,9 @@ public class AsyncByteBufferInputStreamTest {
         writer.start();
         reader.join();
         writer.join();
+        assertTrue(stream.isDone());
+        assertNull(stream.getFailed());
+        assertEquals(71, readBytes[0]);
     }
 
     @Test
@@ -125,7 +123,7 @@ public class AsyncByteBufferInputStreamTest {
                 for (int i = 0; i < 10; i++) {
                     stream.putBuffer(ByteBuffer.wrap("12345".getBytes()));
                     stream.putBuffer(ByteBuffer.wrap("6\n".getBytes()));
-                    System.out.println("Wrote buffers step " + i);
+
                     sleepUninterruptibly(500, TimeUnit.MILLISECONDS);
                     if (i == 3) {
                         stream.setFailed(new Throwable());
@@ -135,6 +133,7 @@ public class AsyncByteBufferInputStreamTest {
 
             }
         };
+        final boolean[] caughtExceptionInReader = {false};
         final Thread reader = new Thread() {
             @Override
             public void run() {
@@ -145,11 +144,8 @@ public class AsyncByteBufferInputStreamTest {
                         singleByte = stream.read();
                         count++;
                     } catch (IOException e) {
-                        System.out.println("Caught exception, success.");
+                        caughtExceptionInReader[0] = true;
                         return;
-                    }
-                    if (count % 5 == 0) {
-                        System.out.println("read " + count + " bytes");
                     }
                     if (count > 50) {
                         fail("Should've caught IOException.");
@@ -161,6 +157,8 @@ public class AsyncByteBufferInputStreamTest {
         writer.start();
         reader.join();
         writer.join();
+        assertTrue(caughtExceptionInReader[0]);
+        assertNotNull(stream.getFailed());
     }
 
 

--- a/graylog2-rest-client/src/test/java/org/graylog2/restclient/lib/AsyncByteBufferInputStreamTest.java
+++ b/graylog2-rest-client/src/test/java/org/graylog2/restclient/lib/AsyncByteBufferInputStreamTest.java
@@ -1,0 +1,175 @@
+/**
+ * This file is part of Graylog.
+ *
+ * Graylog is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.graylog2.restclient.lib;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.util.concurrent.TimeUnit;
+
+import static com.google.common.util.concurrent.Uninterruptibles.sleepUninterruptibly;
+import static org.junit.Assert.fail;
+
+public class AsyncByteBufferInputStreamTest {
+
+    @Test
+    public void testSyncRead() throws InterruptedException, IOException {
+        final AsyncByteBufferInputStream stream = new AsyncByteBufferInputStream();
+
+        stream.putBuffer(ByteBuffer.wrap("123".getBytes()));
+        stream.putBuffer(ByteBuffer.wrap("456".getBytes()));
+
+        // we should be able to read 6 bytes in a row
+        byte[] bytes = new byte[6];
+        final int read = stream.read(bytes);
+        Assert.assertEquals(6, read);
+        Assert.assertArrayEquals("123456".getBytes(), bytes);
+        stream.setDone(true);
+
+        final int nextRead = stream.read();
+        Assert.assertEquals(-1, nextRead);
+        stream.close();
+    }
+
+    @Test
+    public void testDoneWithMoreData() throws InterruptedException, IOException {
+        final AsyncByteBufferInputStream stream = new AsyncByteBufferInputStream();
+
+        stream.putBuffer(ByteBuffer.wrap("123".getBytes()));
+        stream.putBuffer(ByteBuffer.wrap("456".getBytes()));
+
+        // we should be able to read 6 bytes in a row
+        byte[] bytes = new byte[6];
+        final int read = stream.read(bytes);
+        Assert.assertEquals(6, read);
+        Assert.assertArrayEquals("123456".getBytes(), bytes);
+
+        stream.putBuffer(ByteBuffer.wrap("789".getBytes()));
+        stream.setDone(true);
+
+        byte[] finalBytes = new byte[3];
+        final int nextRead = stream.read(finalBytes);
+        Assert.assertEquals(3, nextRead);
+        Assert.assertArrayEquals("789".getBytes(), finalBytes);
+
+        final int eos = stream.read();
+        Assert.assertEquals(-1, eos);
+
+        stream.close();
+    }
+
+    @Test
+    public void testAsync() throws InterruptedException {
+        final AsyncByteBufferInputStream stream = new AsyncByteBufferInputStream();
+
+        final Thread writer = new Thread() {
+            @Override
+            public void run() {
+                for (int i = 0; i < 10; i++) {
+                    try {
+                        stream.putBuffer(ByteBuffer.wrap("12345".getBytes()));
+                        stream.putBuffer(ByteBuffer.wrap("6\n".getBytes()));
+                        System.out.println("Wrote buffers step " + i);
+                    } catch (InterruptedException ignored) {
+
+                    }
+                    sleepUninterruptibly(500, TimeUnit.MILLISECONDS);
+                }
+                stream.setDone(true);
+
+            }
+        };
+        final Thread reader = new Thread() {
+            @Override
+            public void run() {
+                int singleByte = -1;
+                int count = 0;
+                do {
+                    try {
+                        singleByte = stream.read();
+                        count++;
+                    } catch (IOException e) {
+
+                    }
+                    if (count % 5 == 0) {
+                        System.out.println("read " + count + " bytes");
+                    }
+                } while (singleByte != -1);
+            }
+        };
+        reader.start();
+        writer.start();
+        reader.join();
+        writer.join();
+    }
+
+    @Test
+    public void testAsyncException() throws InterruptedException {
+        final AsyncByteBufferInputStream stream = new AsyncByteBufferInputStream();
+
+        final Thread writer = new Thread() {
+            @Override
+            public void run() {
+                for (int i = 0; i < 10; i++) {
+                    try {
+                        stream.putBuffer(ByteBuffer.wrap("12345".getBytes()));
+                        stream.putBuffer(ByteBuffer.wrap("6\n".getBytes()));
+                        System.out.println("Wrote buffers step " + i);
+                    } catch (InterruptedException ignored) {
+
+                    }
+                    sleepUninterruptibly(500, TimeUnit.MILLISECONDS);
+                    if (i == 3) {
+                        stream.setFailed(new Throwable());
+                        return;
+                    }
+                }
+
+            }
+        };
+        final Thread reader = new Thread() {
+            @Override
+            public void run() {
+                int singleByte;
+                int count = 0;
+                do {
+                    try {
+                        singleByte = stream.read();
+                        count++;
+                    } catch (IOException e) {
+                        System.out.println("Caught exception, success.");
+                        return;
+                    }
+                    if (count % 5 == 0) {
+                        System.out.println("read " + count + " bytes");
+                    }
+                    if (count > 50) {
+                        fail("Should've caught IOException.");
+                    }
+                } while (singleByte != -1);
+            }
+        };
+        reader.start();
+        writer.start();
+        reader.join();
+        writer.join();
+    }
+
+
+}

--- a/graylog2-server/pom.xml
+++ b/graylog2-server/pom.xml
@@ -297,14 +297,6 @@
         </dependency>
 
         <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.assertj</groupId>
-            <artifactId>assertj-core</artifactId>
-        </dependency>
-        <dependency>
             <groupId>org.assertj</groupId>
             <artifactId>assertj-joda-time</artifactId>
         </dependency>
@@ -319,10 +311,6 @@
         <dependency>
             <groupId>org.jukito</groupId>
             <artifactId>jukito</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>com.jayway.awaitility</groupId>
-            <artifactId>awaitility</artifactId>
         </dependency>
     </dependencies>
 

--- a/pom.xml
+++ b/pom.xml
@@ -754,6 +754,14 @@
             <groupId>org.mockito</groupId>
             <artifactId>mockito-all</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.jayway.awaitility</groupId>
+            <artifactId>awaitility</artifactId>
+        </dependency>
     </dependencies>
 
     <build>


### PR DESCRIPTION
currently only used for streaming content verbatim to the browser, such as CSV export data

 - the method executeStreaming() gives you a InputStream over the requested bytes

fixes Graylog2/graylog2-web-interface#765