### PR TITLE
Add histogram metric for time ranges in Elasticsearch queries

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/indexer/searches/timeranges/TimeRanges.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/searches/timeranges/TimeRanges.java
@@ -1,0 +1,42 @@
+/**
+ * This file is part of Graylog.
+ *
+ * Graylog is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.graylog2.indexer.searches.timeranges;
+
+import org.joda.time.Seconds;
+
+public final class TimeRanges {
+    private TimeRanges() {
+    }
+
+    /**
+     * Calculate the number of seconds in the given time range.
+     *
+     * @param timeRange the {@link TimeRange}
+     * @return the number of seconds in the given time range or 0 if an error occurred.
+     */
+    public static int toSeconds(TimeRange timeRange) {
+        if (timeRange.getFrom() == null || timeRange.getTo() == null) {
+            return 0;
+        }
+
+        try {
+            return Seconds.secondsBetween(timeRange.getFrom(), timeRange.getTo()).getSeconds();
+        } catch (IllegalArgumentException e) {
+            return 0;
+        }
+    }
+}

--- a/graylog2-server/src/test/java/org/graylog2/indexer/searches/SearchesTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/indexer/searches/SearchesTest.java
@@ -16,6 +16,7 @@
  */
 package org.graylog2.indexer.searches;
 
+import com.codahale.metrics.Histogram;
 import com.codahale.metrics.MetricRegistry;
 import com.codahale.metrics.Timer;
 import com.google.common.collect.ImmutableSet;
@@ -71,6 +72,7 @@ public class SearchesTest {
     @ClassRule
     public static final EmbeddedElasticsearch EMBEDDED_ELASTICSEARCH = newEmbeddedElasticsearchRule().build();
     private static final String REQUEST_TIMER_NAME = "org.graylog2.indexer.searches.Searches.elasticsearch.requests";
+    private static final String RANGES_HISTOGRAM_NAME = "org.graylog2.indexer.searches.Searches.elasticsearch.ranges";
 
     @Rule
     public ElasticsearchRule elasticsearchRule;
@@ -162,6 +164,7 @@ public class SearchesTest {
                 new DateTime(2015, 1, 2, 0, 0)));
 
         assertThat(metricRegistry.getTimers()).containsKey(REQUEST_TIMER_NAME);
+        assertThat(metricRegistry.getHistograms()).containsKey(RANGES_HISTOGRAM_NAME);
 
         Timer timer = metricRegistry.timer(REQUEST_TIMER_NAME);
         assertThat(timer.getCount()).isEqualTo(1L);
@@ -192,9 +195,14 @@ public class SearchesTest {
                 new DateTime(2015, 1, 2, 0, 0)));
 
         assertThat(metricRegistry.getTimers()).containsKey(REQUEST_TIMER_NAME);
+        assertThat(metricRegistry.getHistograms()).containsKey(RANGES_HISTOGRAM_NAME);
 
         Timer timer = metricRegistry.timer(REQUEST_TIMER_NAME);
         assertThat(timer.getCount()).isEqualTo(1L);
+
+        Histogram histogram = metricRegistry.histogram(RANGES_HISTOGRAM_NAME);
+        assertThat(histogram.getCount()).isEqualTo(1L);
+        assertThat(histogram.getSnapshot().getValues()).containsExactly(86400L);
     }
 
     @Test
@@ -222,9 +230,14 @@ public class SearchesTest {
         );
 
         assertThat(metricRegistry.getTimers()).containsKey(REQUEST_TIMER_NAME);
+        assertThat(metricRegistry.getHistograms()).containsKey(RANGES_HISTOGRAM_NAME);
 
         Timer timer = metricRegistry.timer(REQUEST_TIMER_NAME);
         assertThat(timer.getCount()).isEqualTo(1L);
+
+        Histogram histogram = metricRegistry.histogram(RANGES_HISTOGRAM_NAME);
+        assertThat(histogram.getCount()).isEqualTo(1L);
+        assertThat(histogram.getSnapshot().getValues()).containsExactly(86400L);
     }
 
     @Test
@@ -253,9 +266,14 @@ public class SearchesTest {
                 new DateTime(2015, 1, 2, 0, 0)));
 
         assertThat(metricRegistry.getTimers()).containsKey(REQUEST_TIMER_NAME);
+        assertThat(metricRegistry.getHistograms()).containsKey(RANGES_HISTOGRAM_NAME);
 
         Timer timer = metricRegistry.timer(REQUEST_TIMER_NAME);
         assertThat(timer.getCount()).isEqualTo(1L);
+
+        Histogram histogram = metricRegistry.histogram(RANGES_HISTOGRAM_NAME);
+        assertThat(histogram.getCount()).isEqualTo(1L);
+        assertThat(histogram.getSnapshot().getValues()).containsExactly(86400L);
     }
 
     @Test
@@ -284,9 +302,14 @@ public class SearchesTest {
         HistogramResult h = searches.histogram("*", Searches.DateHistogramInterval.MINUTE, range);
 
         assertThat(metricRegistry.getTimers()).containsKey(REQUEST_TIMER_NAME);
+        assertThat(metricRegistry.getHistograms()).containsKey(RANGES_HISTOGRAM_NAME);
 
         Timer timer = metricRegistry.timer(REQUEST_TIMER_NAME);
         assertThat(timer.getCount()).isEqualTo(1L);
+
+        Histogram histogram = metricRegistry.histogram(RANGES_HISTOGRAM_NAME);
+        assertThat(histogram.getCount()).isEqualTo(1L);
+        assertThat(histogram.getSnapshot().getValues()).containsExactly(86400L);
     }
 
     @Test
@@ -316,9 +339,14 @@ public class SearchesTest {
         HistogramResult h = searches.fieldHistogram("*", "n", Searches.DateHistogramInterval.MINUTE, null, range);
 
         assertThat(metricRegistry.getTimers()).containsKey(REQUEST_TIMER_NAME);
+        assertThat(metricRegistry.getHistograms()).containsKey(RANGES_HISTOGRAM_NAME);
 
         Timer timer = metricRegistry.timer(REQUEST_TIMER_NAME);
         assertThat(timer.getCount()).isEqualTo(1L);
+
+        Histogram histogram = metricRegistry.histogram(RANGES_HISTOGRAM_NAME);
+        assertThat(histogram.getCount()).isEqualTo(1L);
+        assertThat(histogram.getSnapshot().getValues()).containsExactly(86400L);
     }
 
     public static class IndexCreatingLoadStrategyFactory implements LoadStrategyFactory {

--- a/graylog2-server/src/test/java/org/graylog2/indexer/searches/timeranges/TimeRangesTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/indexer/searches/timeranges/TimeRangesTest.java
@@ -1,0 +1,84 @@
+/**
+ * This file is part of Graylog.
+ *
+ * Graylog is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.graylog2.indexer.searches.timeranges;
+
+import org.joda.time.DateTime;
+import org.junit.Test;
+
+import java.util.Collections;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+
+public class TimeRangesTest {
+    @Test
+    public void toSecondsHandlesIncompleteTimeRange() throws Exception {
+        assertThat(TimeRanges.toSeconds(new TimeRange() {
+            @Override
+            public Type getType() {
+                return Type.ABSOLUTE;
+            }
+
+            @Override
+            public Map<String, Object> getPersistedConfig() {
+                return Collections.emptyMap();
+            }
+
+            @Override
+            public DateTime getFrom() {
+                return DateTime.now();
+            }
+
+            @Override
+            public DateTime getTo() {
+                return null;
+            }
+        })).isEqualTo(0);
+        assertThat(TimeRanges.toSeconds(new TimeRange() {
+            @Override
+            public Type getType() {
+                return Type.ABSOLUTE;
+            }
+
+            @Override
+            public Map<String, Object> getPersistedConfig() {
+                return Collections.emptyMap();
+            }
+
+            @Override
+            public DateTime getFrom() {
+                return null;
+            }
+
+            @Override
+            public DateTime getTo() {
+                return DateTime.now();
+            }
+        })).isEqualTo(0);
+    }
+
+    @Test
+    public void toSecondsReturnsCorrectNumberOfSeconds() throws Exception {
+        DateTime from = DateTime.now();
+        DateTime to = from.plusMinutes(5);
+
+        assertThat(TimeRanges.toSeconds(new AbsoluteRange(from, to))).isEqualTo(300);
+        assertThat(TimeRanges.toSeconds(new RelativeRange(300))).isEqualTo(300);
+        assertThat(TimeRanges.toSeconds(new KeywordRange("last 5 minutes"))).isEqualTo(300);
+    }
+}


### PR DESCRIPTION
This PR adds a histogram metric (`org.graylog2.indexer.searches.Searches.elasticsearch.ranges`) which records the time ranges given for Elasticsearch queries generated via the `Searches` class.