### PR TITLE
Make time zone for FlexibleDateConverter configurable

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/inputs/converters/FlexibleDateConverter.java
+++ b/graylog2-server/src/main/java/org/graylog2/inputs/converters/FlexibleDateConverter.java
@@ -24,12 +24,26 @@ import org.joda.time.DateTimeZone;
 
 import java.util.List;
 import java.util.Map;
-import java.util.TimeZone;
 
 public class FlexibleDateConverter extends Converter {
+    private final DateTimeZone timeZone;
 
     public FlexibleDateConverter(Map<String, Object> config) {
         super(Type.FLEXDATE, config);
+
+        this.timeZone = buildTimeZone(config.get("time_zone"));
+    }
+
+    private static DateTimeZone buildTimeZone(Object timeZoneId) {
+        if (timeZoneId instanceof String) {
+            try {
+                return DateTimeZone.forID((String) timeZoneId);
+            } catch (IllegalArgumentException e) {
+                return DateTimeZone.UTC;
+            }
+        } else {
+            return DateTimeZone.UTC;
+        }
     }
 
     @Override
@@ -39,19 +53,18 @@ public class FlexibleDateConverter extends Converter {
         }
 
         // Parser is using local timezone with no constructor parameter passed.
-        Parser parser = new Parser(TimeZone.getTimeZone("UTC"));
+        Parser parser = new Parser(timeZone.toTimeZone());
         List<DateGroup> r = parser.parse(value);
 
         if (r.isEmpty() || r.get(0).getDates().isEmpty()) {
             return null;
         }
 
-        return new DateTime(r.get(0).getDates().get(0), DateTimeZone.UTC);
+        return new DateTime(r.get(0).getDates().get(0), timeZone);
     }
 
     @Override
     public boolean buildsMultipleFields() {
         return false;
     }
-
 }

--- a/graylog2-server/src/main/java/org/graylog2/inputs/converters/FlexibleDateConverter.java
+++ b/graylog2-server/src/main/java/org/graylog2/inputs/converters/FlexibleDateConverter.java
@@ -52,9 +52,8 @@ public class FlexibleDateConverter extends Converter {
             return null;
         }
 
-        // Parser is using local timezone with no constructor parameter passed.
-        Parser parser = new Parser(timeZone.toTimeZone());
-        List<DateGroup> r = parser.parse(value);
+        final Parser parser = new Parser(timeZone.toTimeZone());
+        final List<DateGroup> r = parser.parse(value);
 
         if (r.isEmpty() || r.get(0).getDates().isEmpty()) {
             return null;

--- a/graylog2-server/src/main/java/org/graylog2/inputs/converters/FlexibleDateConverter.java
+++ b/graylog2-server/src/main/java/org/graylog2/inputs/converters/FlexibleDateConverter.java
@@ -25,6 +25,9 @@ import org.joda.time.DateTimeZone;
 import java.util.List;
 import java.util.Map;
 
+import static com.google.common.base.MoreObjects.firstNonNull;
+import static com.google.common.base.Strings.emptyToNull;
+
 public class FlexibleDateConverter extends Converter {
     private final DateTimeZone timeZone;
 
@@ -37,7 +40,9 @@ public class FlexibleDateConverter extends Converter {
     private static DateTimeZone buildTimeZone(Object timeZoneId) {
         if (timeZoneId instanceof String) {
             try {
-                return DateTimeZone.forID((String) timeZoneId);
+                final String timeZoneString = (String) timeZoneId;
+                final String zoneId = firstNonNull(emptyToNull(timeZoneString.trim()), "UTC");
+                return DateTimeZone.forID(zoneId);
             } catch (IllegalArgumentException e) {
                 return DateTimeZone.UTC;
             }

--- a/graylog2-server/src/test/java/org/graylog2/inputs/converters/FlexibleDateConverterTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/inputs/converters/FlexibleDateConverterTest.java
@@ -69,4 +69,20 @@ public class FlexibleDateConverterTest {
         Assertions.assertThat(textualDateTime)
                 .isEqualTo(new DateTime(2014, 3, 12, 14, 0, DateTimeZone.forOffsetHours(12)));
     }
+
+    @Test
+    public void convertUsesUTCIfTimeZoneSettingIsEmpty() throws Exception {
+        Converter c = new FlexibleDateConverter(ImmutableMap.<String, Object>of("time_zone", ""));
+
+        final DateTime dateOnly = (DateTime) c.convert("2014-3-12");
+        assertThat(dateOnly.getZone()).isEqualTo(DateTimeZone.UTC);
+    }
+
+    @Test
+    public void convertUsesUTCIfTimeZoneSettingIsBlank() throws Exception {
+        Converter c = new FlexibleDateConverter(ImmutableMap.<String, Object>of("time_zone", " "));
+
+        final DateTime dateOnly = (DateTime) c.convert("2014-3-12");
+        assertThat(dateOnly.getZone()).isEqualTo(DateTimeZone.UTC);
+    }
 }

--- a/graylog2-server/src/test/java/org/graylog2/inputs/converters/FlexibleDateConverterTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/inputs/converters/FlexibleDateConverterTest.java
@@ -16,23 +16,25 @@
  */
 package org.graylog2.inputs.converters;
 
+import com.google.common.collect.ImmutableMap;
+import org.assertj.jodatime.api.Assertions;
 import org.graylog2.plugin.inputs.Converter;
+import org.joda.time.DateTime;
+import org.joda.time.DateTimeZone;
 import org.junit.Test;
 
-import java.util.HashMap;
+import java.util.Collections;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
-/**
- * @author Lennart Koopmann <lennart@torch.sh>
- */
 public class FlexibleDateConverterTest {
 
     @Test
     public void testConvert() throws Exception {
-        Converter c = new FlexibleDateConverter(new HashMap<String, Object>());
+        Converter c = new FlexibleDateConverter(Collections.<String, Object>emptyMap());
 
         assertNull(c.convert(null));
         assertEquals(null, c.convert(""));
@@ -47,4 +49,24 @@ public class FlexibleDateConverterTest {
         assertTrue(c.convert("Mar 2 13:48:18").toString().contains("-03-02T13:48:18.000"));
     }
 
+    @Test
+    public void convertObeysTimeZone() throws Exception {
+        Converter c = new FlexibleDateConverter(ImmutableMap.<String, Object>of("time_zone", "+12:00"));
+
+        final DateTime dateOnly = (DateTime) c.convert("2014-3-12");
+        assertThat(dateOnly.getZone()).isEqualTo(DateTimeZone.forOffsetHours(12));
+        Assertions.assertThat(dateOnly)
+                .isAfterOrEqualTo(new DateTime(2014, 3, 12, 0, 0, DateTimeZone.forOffsetHours(12)))
+                .isBefore(new DateTime(2014, 3, 13, 0, 0, DateTimeZone.forOffsetHours(12)));
+
+        final DateTime dateTime = (DateTime) c.convert("2014-3-12 12:34");
+        assertThat(dateTime.getZone()).isEqualTo(DateTimeZone.forOffsetHours(12));
+        Assertions.assertThat(dateTime)
+                .isEqualTo(new DateTime(2014, 3, 12, 12, 34, DateTimeZone.forOffsetHours(12)));
+
+        final DateTime textualDateTime = (DateTime) c.convert("Mar 12, 2014 2pm");
+        assertThat(textualDateTime.getZone()).isEqualTo(DateTimeZone.forOffsetHours(12));
+        Assertions.assertThat(textualDateTime)
+                .isEqualTo(new DateTime(2014, 3, 12, 14, 0, DateTimeZone.forOffsetHours(12)));
+    }
 }


### PR DESCRIPTION
This PR adds the configuration option `time_zone` to the `FlexibleDateConverter` which enables users to override the default time zone (default: UTC).