### PR TITLE
Change Kafka and ES IP address defaults to 127.0.0.1

### DIFF
--- a/graylog2-inputs/src/main/java/org/graylog2/inputs/transports/KafkaTransport.java
+++ b/graylog2-inputs/src/main/java/org/graylog2/inputs/transports/KafkaTransport.java
@@ -322,7 +322,7 @@ public class KafkaTransport extends ThrottleableTransport {
             cr.addField(new TextField(
                     CK_ZOOKEEPER,
                     "ZooKeeper address",
-                    "192.168.1.1:2181",
+                    "127.0.0.1:2181",
                     "Host and port of the ZooKeeper that is managing your Kafka cluster.",
                     ConfigurationField.Optional.NOT_OPTIONAL));
 

--- a/misc/graylog2.conf
+++ b/misc/graylog2.conf
@@ -166,7 +166,7 @@ allow_highlighting = false
 #elasticsearch_http_enabled = false
 
 #elasticsearch_discovery_zen_ping_multicast_enabled = false
-#elasticsearch_discovery_zen_ping_unicast_hosts = 192.168.1.203:9300
+#elasticsearch_discovery_zen_ping_unicast_hosts = 127.0.0.1:9300
 
 # Change the following setting if you are running into problems with timeouts during Elasticsearch cluster discovery.
 # The setting is specified in milliseconds, the default is 5000ms (5 seconds).


### PR DESCRIPTION
Any objections? These defaults help when you do testing.