### PR TITLE
Fix MongoDB config validation if replica set is used.

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/configuration/MongoDbConfiguration.java
+++ b/graylog2-server/src/main/java/org/graylog2/configuration/MongoDbConfiguration.java
@@ -173,11 +173,11 @@ public class MongoDbConfiguration {
 
     @ValidatorMethod
     public void validate() throws ValidationException {
-        if((isNullOrEmpty(getHost()) || isNullOrEmpty(getDatabase())) && isNullOrEmpty(getUri())) {
+        if ((isNullOrEmpty(getHost()) || isNullOrEmpty(getDatabase()) || getReplicaSet() == null) && isNullOrEmpty(getUri())) {
             throw new ValidationException("Either mongodb_uri OR mongodb_host and mongodb_database must not be empty");
         }
 
-        if(isNullOrEmpty(getUri())) {
+        if (isNullOrEmpty(getUri())) {
             LOG.info("You're using deprecated configuration options for MongoDB. Please use mongodb_uri.");
             LOG.info("Suggested value for mongodb_uri = {}", getMongoClientURI());
         }

--- a/graylog2-server/src/main/java/org/graylog2/configuration/MongoDbConfiguration.java
+++ b/graylog2-server/src/main/java/org/graylog2/configuration/MongoDbConfiguration.java
@@ -173,8 +173,8 @@ public class MongoDbConfiguration {
 
     @ValidatorMethod
     public void validate() throws ValidationException {
-        if ((isNullOrEmpty(getHost()) || isNullOrEmpty(getDatabase()) || getReplicaSet() == null) && isNullOrEmpty(getUri())) {
-            throw new ValidationException("Either mongodb_uri OR mongodb_host and mongodb_database must not be empty");
+        if ((isNullOrEmpty(getHost()) && (getReplicaSet() == null || getReplicaSet().isEmpty()) || isNullOrEmpty(getDatabase()) && isNullOrEmpty(getUri()))) {
+            throw new ValidationException("Either mongodb_uri OR mongodb_host/mongodb_replica_set and mongodb_database must not be empty");
         }
 
         if (isNullOrEmpty(getUri())) {

--- a/graylog2-server/src/test/java/org/graylog2/configuration/MongoDbConfigurationTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/configuration/MongoDbConfigurationTest.java
@@ -134,6 +134,17 @@ public class MongoDbConfigurationTest {
     }
 
     @Test(expected = ValidationException.class)
+    public void validateFailsIfUriAndReplicaSetAreMissing() throws RepositoryException, ValidationException {
+        MongoDbConfiguration configuration = new MongoDbConfiguration();
+        final ImmutableMap<String, String> config = ImmutableMap.of(
+                "mongodb_host", "",
+                "mongodb_replica_set", "",
+                "mongodb_database", "graylog"
+        );
+        new JadConfig(new InMemoryRepository(config), configuration).process();
+    }
+
+    @Test(expected = ValidationException.class)
     public void validateFailsIfUriAndDatabaseAreMissing() throws RepositoryException, ValidationException {
         MongoDbConfiguration configuration = new MongoDbConfiguration();
         final ImmutableMap<String, String> properties = ImmutableMap.of(


### PR DESCRIPTION
It is okay to have an empty mongodb_host if mongodb_replica_set is defined.

Graylog server startup fails without this if a replica set is in use.

Additional whitespace fix.