### PR TITLE
Update to syslog4j 0.9.53 to fix parsing structured syslog

### DIFF
--- a/graylog2-inputs/src/test/java/org/graylog2/inputs/codecs/SyslogCodecTest.java
+++ b/graylog2-inputs/src/test/java/org/graylog2/inputs/codecs/SyslogCodecTest.java
@@ -127,7 +127,7 @@ public class SyslogCodecTest {
         final Message message = codec.decode(buildRawMessage(STRUCTURED_ISSUE_845_EMPTY));
 
         assertNotNull(message);
-        assertEquals(message.getMessage(), "- - tralala");
+        assertEquals(message.getMessage(), "tralala");
         assertEquals(((DateTime) message.getField("timestamp")).withZone(DateTimeZone.UTC), new DateTime("2015-01-11T15:35:21.335797Z", DateTimeZone.UTC));
         assertEquals(message.getField("source"), "s000000.example.com");
         assertEquals(message.getField("level"), 0);

--- a/pom.xml
+++ b/pom.xml
@@ -299,7 +299,7 @@
             <dependency>
                 <groupId>org.graylog2</groupId>
                 <artifactId>syslog4j</artifactId>
-                <version>0.9.52</version>
+                <version>0.9.53</version>
             </dependency>
 
             <dependency>


### PR DESCRIPTION
Avoids leading `- - ` in RFC5424 syslog with empty MSGID and STRUCTURED-DATA. See #1161 and Graylog2/syslog4j-graylog2#4 for details.

Fixes #1161.