### PR TITLE
Remove Jersey 1.x from REST client

### DIFF
--- a/graylog2-rest-client/pom.xml
+++ b/graylog2-rest-client/pom.xml
@@ -197,14 +197,8 @@
             <artifactId>shiro-core</artifactId>
         </dependency>
         <dependency>
-            <groupId>javax.ws.rs</groupId>
-            <artifactId>jsr311-api</artifactId>
-            <version>1.1.1</version>
-        </dependency>
-        <dependency>
-            <groupId>com.sun.jersey</groupId>
-            <artifactId>jersey-bundle</artifactId>
-            <version>1.18.1</version>
+            <groupId>com.squareup.okhttp</groupId>
+            <artifactId>okhttp</artifactId>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/graylog2-rest-client/src/test/java/org/graylog2/restclient/lib/ApiClientTest.java
+++ b/graylog2-rest-client/src/test/java/org/graylog2/restclient/lib/ApiClientTest.java
@@ -50,14 +50,14 @@ public class ApiClientTest extends BaseApiTest {
         final URL url = api.get(EmptyResponse.class).path("/some/resource").session("foo").node(node).prepareUrl(node);
         final URL queryParamWithPlus = api.get(EmptyResponse.class).path("/some/resource").queryParam("query", " (.+)").node(node).unauthenticated().prepareUrl(node);
 
-        Assert.assertEquals(url.getUserInfo(), "foo:session");
-        Assert.assertEquals("query param with + should be escaped", "query=+(.%2B)", queryParamWithPlus.getQuery());
+        Assert.assertEquals("foo:session", url.getUserInfo());
+        Assert.assertEquals("query param with + should be escaped", "query=%20(.%2B)", queryParamWithPlus.getQuery());
 
         final URL queryParamWithDoubleQuotes = api.get(EmptyResponse.class).path("/some/resource").queryParam("query", " \".+\"").node(node).unauthenticated().prepareUrl(node);
         Assert.assertEquals("query param with \" should be escaped",
-                            "query=+%22.%2B%22",
+                            "query=%20%22.%2B%22",
                             queryParamWithDoubleQuotes.getQuery());
-        
+
         final URL urlWithNonAsciiChars = api.get(EmptyResponse.class).node(node).path("/some/resourçe").unauthenticated().prepareUrl(node);
         Assert.assertEquals("non-ascii chars are escaped in path",
                             "/some/resour%C3%A7e",


### PR DESCRIPTION
The only reason for depending on Jersey 1.x was the usage of `UriBuilder` in `ApiClientImpl`
which has been replaced with `HttpUrl` from OkHttp 2.4.0 (https://square.github.io/okhttp/javadoc/com/squareup/okhttp/HttpUrl.html).