### PR TITLE
Handle double values in greater/smaller stream matcher.

### DIFF
--- a/graylog2-plugin-interfaces/src/main/java/org/graylog2/plugin/Tools.java
+++ b/graylog2-plugin-interfaces/src/main/java/org/graylog2/plugin/Tools.java
@@ -23,7 +23,7 @@
 package org.graylog2.plugin;
 
 import com.google.common.io.BaseEncoding;
-import com.google.common.primitives.Ints;
+import com.google.common.primitives.Doubles;
 import org.joda.time.DateTime;
 import org.joda.time.DateTimeZone;
 import org.joda.time.format.DateTimeFormat;
@@ -360,21 +360,21 @@ public final class Tools {
     }
 
     /**
-     * Convert something to an int in a fast way having a good guess
-     * that it is an int. This is perfect for MongoDB data that *should*
-     * have been stored as integers already so there is a high probability
+     * Convert something to a double in a fast way having a good guess
+     * that it is a double. This is perfect for MongoDB data that *should*
+     * have been stored as doubles already so there is a high probability
      * of easy converting.
      *
-     * @param x The object to convert to an int
+     * @param x The object to convert to a double
      * @return Converted object, 0 if empty or something went wrong.
      */
-    public static Integer getInt(Object x) {
+    public static Double getDouble(Object x) {
         if (x == null) {
             return null;
         }
 
-        if (x instanceof Integer) {
-            return (Integer) x;
+        if (x instanceof Double) {
+            return (Double) x;
         }
 
         if (x instanceof String) {
@@ -386,12 +386,12 @@ public final class Tools {
 
         /*
          * This is the last and probably expensive fallback. This should be avoided by
-         * only passing in Integers, Longs or stuff that can be parsed from it's String
+         * only passing in Doubles, Integers, Longs or stuff that can be parsed from it's String
          * representation. You might have to build cached objects that did a safe conversion
          * once for example. There is no way around for the actual values we compare if the
          * user sent them in as non-numerical type.
          */
-        return Ints.tryParse(x.toString());
+        return Doubles.tryParse(x.toString());
     }
 
     /**

--- a/graylog2-server/src/main/java/org/graylog2/streams/matchers/GreaterMatcher.java
+++ b/graylog2-server/src/main/java/org/graylog2/streams/matchers/GreaterMatcher.java
@@ -19,7 +19,7 @@ package org.graylog2.streams.matchers;
 import org.graylog2.plugin.Message;
 import org.graylog2.plugin.streams.StreamRule;
 
-import static org.graylog2.plugin.Tools.getInt;
+import static org.graylog2.plugin.Tools.getDouble;
 
 /**
  * @author Lennart Koopmann <lennart@socketfeed.com>
@@ -28,12 +28,12 @@ public class GreaterMatcher implements StreamRuleMatcher {
 
 	@Override
 	public boolean match(Message msg, StreamRule rule) {
-        Integer msgVal = getInt(msg.getField(rule.getField()));
+        Double msgVal = getDouble(msg.getField(rule.getField()));
         if (msgVal == null) {
             return false;
         }
 
-        Integer ruleVal = getInt(rule.getValue());
+        Double ruleVal = getDouble(rule.getValue());
         if (ruleVal == null) {
             return false;
         }

--- a/graylog2-server/src/main/java/org/graylog2/streams/matchers/SmallerMatcher.java
+++ b/graylog2-server/src/main/java/org/graylog2/streams/matchers/SmallerMatcher.java
@@ -19,7 +19,7 @@ package org.graylog2.streams.matchers;
 import org.graylog2.plugin.Message;
 import org.graylog2.plugin.streams.StreamRule;
 
-import static org.graylog2.plugin.Tools.getInt;
+import static org.graylog2.plugin.Tools.getDouble;
 
 /**
  * @author Lennart Koopmann <lennart@socketfeed.com>
@@ -28,13 +28,13 @@ public class SmallerMatcher implements StreamRuleMatcher {
 
 	@Override
 	public boolean match(Message msg, StreamRule rule) {
-        Integer msgVal = getInt(msg.getField(rule.getField()));
+        Double msgVal = getDouble(msg.getField(rule.getField()));
 
         if (msgVal == null) {
             return false;
         }
 
-        Integer ruleVal = getInt(rule.getValue());
+        Double ruleVal = getDouble(rule.getValue());
         if (ruleVal == null) {
             return false;
         }

--- a/graylog2-server/src/test/java/org/graylog2/ToolsTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/ToolsTest.java
@@ -200,20 +200,29 @@ public class ToolsTest {
 
     @Test
     public void testGetInt() throws Exception {
-        assertEquals(null, Tools.getInt(null));
+        assertEquals(null, Tools.getDouble(null));
+        assertEquals(null, Tools.getDouble(""));
 
-        assertEquals((Integer) 0, Tools.getInt(0));
-        assertEquals((Integer) 1, Tools.getInt(1));
-        assertEquals((Integer) 9001, Tools.getInt(9001));
+        assertEquals(0.0, Tools.getDouble(0), 0);
+        assertEquals(1.0, Tools.getDouble(1), 0);
+        assertEquals(1.42, Tools.getDouble(1.42), 0);
+        assertEquals(9001.0, Tools.getDouble(9001), 0);
+        assertEquals(9001.23, Tools.getDouble(9001.23), 0);
 
-        assertEquals((Integer) 1253453, Tools.getInt((long) 1253453));
-        assertEquals(null, Tools.getInt((double) 5));
-        assertEquals(null, Tools.getInt(18.2));
+        assertEquals(1253453.0, Tools.getDouble((long) 1253453), 0);
 
-        assertEquals((Integer) 88, Tools.getInt("88"));
-        assertEquals(null, Tools.getInt("lol NOT A NUMBER"));
+        assertEquals(88.0, Tools.getDouble("88"), 0);
+        assertEquals(1.42, Tools.getDouble("1.42"), 0);
+        assertEquals(null, Tools.getDouble("lol NOT A NUMBER"));
 
-        assertEquals(null, Tools.getInt(new HashMap<String, String>()));
+        assertEquals(null, Tools.getDouble(new HashMap<String, String>()));
+
+        assertEquals(42.23, Tools.getDouble(new Object() {
+            @Override
+            public String toString() {
+                return "42.23";
+            }
+        }), 0);
     }
 
     @Test

--- a/graylog2-server/src/test/java/org/graylog2/streams/matchers/GreaterMatcherTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/streams/matchers/GreaterMatcherTest.java
@@ -38,7 +38,19 @@ public class GreaterMatcherTest extends MatcherTest {
         StreamRuleMatcher matcher = getMatcher(rule);
         assertTrue(matcher.match(msg, rule));
     }
-    
+
+    @Test
+    public void testSuccessfulDoubleMatch() {
+        StreamRule rule = getSampleRule();
+        rule.setValue("1.0");
+
+        Message msg = getSampleMessage();
+        msg.addField("something", "1.1");
+
+        StreamRuleMatcher matcher = getMatcher(rule);
+        assertTrue(matcher.match(msg, rule));
+    }
+
     @Test
     public void testSuccessfulMatchWithNegativeValue() {
         StreamRule rule = getSampleRule();
@@ -46,6 +58,18 @@ public class GreaterMatcherTest extends MatcherTest {
 
         Message msg = getSampleMessage();
         msg.addField("something", "4");
+
+        StreamRuleMatcher matcher = getMatcher(rule);
+        assertTrue(matcher.match(msg, rule));
+    }
+
+    @Test
+    public void testSuccessfulDoubleMatchWithNegativeValue() {
+        StreamRule rule = getSampleRule();
+        rule.setValue("-54354.0");
+
+        Message msg = getSampleMessage();
+        msg.addField("something", "4.1");
 
         StreamRuleMatcher matcher = getMatcher(rule);
         assertTrue(matcher.match(msg, rule));
@@ -77,6 +101,18 @@ public class GreaterMatcherTest extends MatcherTest {
     }
 
     @Test
+    public void testMissedDoubleMatch() {
+        StreamRule rule = getSampleRule();
+        rule.setValue("25");
+
+        Message msg = getSampleMessage();
+        msg.addField("something", "12.4");
+
+        StreamRuleMatcher matcher = getMatcher(rule);
+        assertFalse(matcher.match(msg, rule));
+    }
+
+    @Test
     public void testMissedInvertedMatch() {
         StreamRule rule = getSampleRule();
         rule.setValue("25");
@@ -102,6 +138,18 @@ public class GreaterMatcherTest extends MatcherTest {
     }
 
     @Test
+    public void testMissedDoubleMatchWithEqualValues() {
+        StreamRule rule = getSampleRule();
+        rule.setValue("-9001.45");
+
+        Message msg = getSampleMessage();
+        msg.addField("something", "-9001.45");
+
+        StreamRuleMatcher matcher = getMatcher(rule);
+        assertFalse(matcher.match(msg, rule));
+    }
+
+    @Test
     public void testSuccessfullInvertedMatchWithEqualValues() {
         StreamRule rule = getSampleRule();
         rule.setValue("-9001");
@@ -121,6 +169,18 @@ public class GreaterMatcherTest extends MatcherTest {
 
         Message msg = getSampleMessage();
         msg.addField("something", "90000");
+
+        StreamRuleMatcher matcher = getMatcher(rule);
+        assertFalse(matcher.match(msg, rule));
+    }
+
+    @Test
+    public void testMissedDoubleMatchWithInvalidValue() {
+        StreamRule rule = getSampleRule();
+        rule.setValue("LOL I AM NOT EVEN A NUMBER");
+
+        Message msg = getSampleMessage();
+        msg.addField("something", "90000.23");
 
         StreamRuleMatcher matcher = getMatcher(rule);
         assertFalse(matcher.match(msg, rule));

--- a/graylog2-server/src/test/java/org/graylog2/streams/matchers/SmallerMatcherTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/streams/matchers/SmallerMatcherTest.java
@@ -39,6 +39,18 @@ public class SmallerMatcherTest extends MatcherTest {
     }
 
     @Test
+    public void testSuccessfulDoubleMatch() {
+        StreamRule rule = getSampleRule();
+        rule.setValue("100");
+
+        Message msg = getSampleMessage();
+        msg.addField("something", "20.45");
+
+        StreamRuleMatcher matcher = getMatcher(rule);
+        assertTrue(matcher.match(msg, rule));
+    }
+
+    @Test
     public void testSuccessfulInvertedMatch() {
         StreamRule rule = getSampleRule();
         rule.setValue("100");
@@ -58,6 +70,18 @@ public class SmallerMatcherTest extends MatcherTest {
 
         Message msg = getSampleMessage();
         msg.addField("something", "-90000");
+
+        StreamRuleMatcher matcher = getMatcher(rule);
+        assertTrue(matcher.match(msg, rule));
+    }
+
+    @Test
+    public void testSuccessfulDoubleMatchWithNegativeValue() {
+        StreamRule rule = getSampleRule();
+        rule.setValue("-54354.42");
+
+        Message msg = getSampleMessage();
+        msg.addField("something", "-90000.12");
 
         StreamRuleMatcher matcher = getMatcher(rule);
         assertTrue(matcher.match(msg, rule));
@@ -89,6 +113,18 @@ public class SmallerMatcherTest extends MatcherTest {
     }
 
     @Test
+    public void testMissedDoubleMatch() {
+        StreamRule rule = getSampleRule();
+        rule.setValue("25");
+
+        Message msg = getSampleMessage();
+        msg.addField("something", "27.45");
+
+        StreamRuleMatcher matcher = getMatcher(rule);
+        assertFalse(matcher.match(msg, rule));
+    }
+
+    @Test
     public void testMissedInvertedMatch() {
         StreamRule rule = getSampleRule();
         rule.setValue("25");
@@ -114,6 +150,18 @@ public class SmallerMatcherTest extends MatcherTest {
     }
 
     @Test
+    public void testMissedDoubleMatchWithEqualValues() {
+        StreamRule rule = getSampleRule();
+        rule.setValue("-9001.23");
+
+        Message msg = getSampleMessage();
+        msg.addField("something", "-9001.23");
+
+        StreamRuleMatcher matcher = getMatcher(rule);
+        assertFalse(matcher.match(msg, rule));
+    }
+
+    @Test
     public void testSuccessfullInvertedMatchWithEqualValues() {
         StreamRule rule = getSampleRule();
         rule.setValue("-9001");
@@ -133,6 +181,18 @@ public class SmallerMatcherTest extends MatcherTest {
 
         Message msg = getSampleMessage();
         msg.addField("something", "-9001");
+
+        StreamRuleMatcher matcher = getMatcher(rule);
+        assertFalse(matcher.match(msg, rule));
+    }
+
+    @Test
+    public void testMissedDoubleMatchWithInvalidValue() {
+        StreamRule rule = getSampleRule();
+        rule.setValue("LOL I AM NOT EVEN A NUMBER");
+
+        Message msg = getSampleMessage();
+        msg.addField("something", "-9001.42");
 
         StreamRuleMatcher matcher = getMatcher(rule);
         assertFalse(matcher.match(msg, rule));


### PR DESCRIPTION
Before this, all values have been converted to ints.

See #1101 for details.

Fixes #1101