### PR TITLE
Add config option to change the default widget cache time

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/Configuration.java
+++ b/graylog2-server/src/main/java/org/graylog2/Configuration.java
@@ -130,6 +130,9 @@ public class Configuration extends BaseConfiguration {
     @Parameter(value = "collector_inactive_threshold", validator = PositiveIntegerValidator.class)
     private Duration collectorInactiveThreshold = Duration.minutes(1);
 
+    @Parameter(value = "dashboard_widget_default_cache_time", validator = PositiveIntegerValidator.class)
+    private int dashboardWidgetDefaultCacheTime = 10;
+
     public boolean isMaster() {
         return isMaster;
     }
@@ -261,5 +264,9 @@ public class Configuration extends BaseConfiguration {
 
     public Duration getCollectorInactiveThreshold() {
         return collectorInactiveThreshold;
+    }
+
+    public int getDashboardWidgetDefaultCacheTime() {
+        return dashboardWidgetDefaultCacheTime;
     }
 }

--- a/graylog2-server/src/main/java/org/graylog2/Configuration.java
+++ b/graylog2-server/src/main/java/org/graylog2/Configuration.java
@@ -18,6 +18,7 @@ package org.graylog2;
 
 import com.github.joschi.jadconfig.Parameter;
 import com.github.joschi.jadconfig.util.Duration;
+import com.github.joschi.jadconfig.validators.PositiveDurationValidator;
 import com.github.joschi.jadconfig.validators.PositiveIntegerValidator;
 import com.github.joschi.jadconfig.validators.PositiveLongValidator;
 import org.graylog2.plugin.BaseConfiguration;
@@ -130,8 +131,8 @@ public class Configuration extends BaseConfiguration {
     @Parameter(value = "collector_inactive_threshold", validator = PositiveIntegerValidator.class)
     private Duration collectorInactiveThreshold = Duration.minutes(1);
 
-    @Parameter(value = "dashboard_widget_default_cache_time", validator = PositiveIntegerValidator.class)
-    private int dashboardWidgetDefaultCacheTime = 10;
+    @Parameter(value = "dashboard_widget_default_cache_time", validator = PositiveDurationValidator.class)
+    private Duration dashboardWidgetDefaultCacheTime = Duration.seconds(10l);
 
     public boolean isMaster() {
         return isMaster;
@@ -266,7 +267,7 @@ public class Configuration extends BaseConfiguration {
         return collectorInactiveThreshold;
     }
 
-    public int getDashboardWidgetDefaultCacheTime() {
+    public Duration getDashboardWidgetDefaultCacheTime() {
         return dashboardWidgetDefaultCacheTime;
     }
 }

--- a/graylog2-server/src/main/java/org/graylog2/bindings/ServerBindings.java
+++ b/graylog2-server/src/main/java/org/graylog2/bindings/ServerBindings.java
@@ -46,6 +46,7 @@ import org.graylog2.bindings.providers.SystemJobManagerProvider;
 import org.graylog2.buffers.processors.ServerProcessBufferProcessor;
 import org.graylog2.bundles.BundleService;
 import org.graylog2.cluster.ClusterConfigServiceImpl;
+import org.graylog2.dashboards.widgets.WidgetCacheTime;
 import org.graylog2.database.MongoConnection;
 import org.graylog2.events.ClusterEventBus;
 import org.graylog2.filters.FilterService;
@@ -137,6 +138,7 @@ public class ServerBindings extends AbstractModule {
         install(new FactoryModuleBuilder().build(LdapSettingsImpl.Factory.class));
         install(new FactoryModuleBuilder().build(FieldValueAlertCondition.Factory.class));
         install(new FactoryModuleBuilder().build(MessageCountAlertCondition.Factory.class));
+        install(new FactoryModuleBuilder().build(WidgetCacheTime.Factory.class));
     }
 
     private void bindSingletons() {

--- a/graylog2-server/src/main/java/org/graylog2/bindings/providers/BundleExporterProvider.java
+++ b/graylog2-server/src/main/java/org/graylog2/bindings/providers/BundleExporterProvider.java
@@ -18,6 +18,7 @@ package org.graylog2.bindings.providers;
 
 import org.graylog2.bundles.BundleExporter;
 import org.graylog2.dashboards.DashboardService;
+import org.graylog2.dashboards.widgets.DashboardWidgetCreator;
 import org.graylog2.inputs.InputService;
 import org.graylog2.streams.OutputService;
 import org.graylog2.streams.StreamService;
@@ -31,20 +32,23 @@ public class BundleExporterProvider implements Provider<BundleExporter> {
     private final StreamService streamService;
     private final OutputService outputService;
     private final DashboardService dashboardService;
+    private final DashboardWidgetCreator dashboardWidgetCreator;
 
     @Inject
     public BundleExporterProvider(final InputService inputService,
                                   final StreamService streamService,
                                   final OutputService outputService,
-                                  final DashboardService dashboardService) {
+                                  final DashboardService dashboardService,
+                                  final DashboardWidgetCreator dashboardWidgetCreator) {
         this.inputService = inputService;
         this.streamService = streamService;
         this.outputService = outputService;
         this.dashboardService = dashboardService;
+        this.dashboardWidgetCreator = dashboardWidgetCreator;
     }
 
     @Override
     public BundleExporter get() {
-        return new BundleExporter(inputService, streamService, outputService, dashboardService);
+        return new BundleExporter(inputService, streamService, outputService, dashboardService, dashboardWidgetCreator);
     }
 }

--- a/graylog2-server/src/main/java/org/graylog2/bindings/providers/BundleImporterProvider.java
+++ b/graylog2-server/src/main/java/org/graylog2/bindings/providers/BundleImporterProvider.java
@@ -20,6 +20,7 @@ import com.codahale.metrics.MetricRegistry;
 import org.graylog2.bundles.BundleImporter;
 import org.graylog2.dashboards.DashboardRegistry;
 import org.graylog2.dashboards.DashboardService;
+import org.graylog2.dashboards.widgets.DashboardWidgetCreator;
 import org.graylog2.indexer.searches.Searches;
 import org.graylog2.inputs.InputService;
 import org.graylog2.inputs.extractors.ExtractorFactory;
@@ -44,6 +45,7 @@ public class BundleImporterProvider implements Provider<BundleImporter> {
     private final OutputService outputService;
     private final DashboardService dashboardService;
     private final DashboardRegistry dashboardRegistry;
+    private final DashboardWidgetCreator dashboardWidgetCreator;
     private final ServerStatus serverStatus;
     private final MetricRegistry metricRegistry;
     private final Searches searches;
@@ -59,6 +61,7 @@ public class BundleImporterProvider implements Provider<BundleImporter> {
                                   final OutputService outputService,
                                   final DashboardService dashboardService,
                                   final DashboardRegistry dashboardRegistry,
+                                  final DashboardWidgetCreator dashboardWidgetCreator,
                                   final ServerStatus serverStatus,
                                   final MetricRegistry metricRegistry,
                                   final Searches searches,
@@ -72,6 +75,7 @@ public class BundleImporterProvider implements Provider<BundleImporter> {
         this.outputService = outputService;
         this.dashboardService = dashboardService;
         this.dashboardRegistry = dashboardRegistry;
+        this.dashboardWidgetCreator = dashboardWidgetCreator;
         this.serverStatus = serverStatus;
         this.metricRegistry = metricRegistry;
         this.searches = searches;
@@ -83,7 +87,7 @@ public class BundleImporterProvider implements Provider<BundleImporter> {
     public BundleImporter get() {
         return new BundleImporter(inputService, inputRegistry, extractorFactory,
                 streamService, streamRuleService, outputService, dashboardService,
-                dashboardRegistry, serverStatus, metricRegistry, searches, messageInputFactory,
+                dashboardRegistry, dashboardWidgetCreator, serverStatus, metricRegistry, searches, messageInputFactory,
                 inputLauncher);
     }
 }

--- a/graylog2-server/src/main/java/org/graylog2/bundles/BundleExporter.java
+++ b/graylog2-server/src/main/java/org/graylog2/bundles/BundleExporter.java
@@ -21,6 +21,7 @@ import com.google.common.collect.ImmutableSet;
 import com.mongodb.BasicDBObject;
 import org.graylog2.dashboards.DashboardImpl;
 import org.graylog2.dashboards.DashboardService;
+import org.graylog2.dashboards.widgets.DashboardWidgetCreator;
 import org.graylog2.database.NotFoundException;
 import org.graylog2.inputs.InputService;
 import org.graylog2.streams.OutputService;
@@ -41,6 +42,7 @@ public class BundleExporter {
     private final StreamService streamService;
     private final OutputService outputService;
     private final DashboardService dashboardService;
+    private final DashboardWidgetCreator dashboardWidgetCreator;
 
     private Set<String> streamSet = new HashSet<>();
 
@@ -48,11 +50,13 @@ public class BundleExporter {
     public BundleExporter(final InputService inputService,
                           final StreamService streamService,
                           final OutputService outputService,
-                          final DashboardService dashboardService) {
+                          final DashboardService dashboardService,
+                          final DashboardWidgetCreator dashboardWidgetCreator) {
         this.inputService = inputService;
         this.streamService = streamService;
         this.outputService = outputService;
         this.dashboardService = dashboardService;
+        this.dashboardWidgetCreator = dashboardWidgetCreator;
     }
 
     public ConfigurationBundle export(final ExportBundle exportBundle) {
@@ -290,7 +294,7 @@ public class BundleExporter {
             for (BasicDBObject widgetFields : (List<BasicDBObject>) fields.get(DashboardImpl.EMBEDDED_WIDGETS)) {
                 org.graylog2.dashboards.widgets.DashboardWidget widget;
                 try {
-                    widget = org.graylog2.dashboards.widgets.DashboardWidget.fromPersisted(null, null, widgetFields);
+                    widget = dashboardWidgetCreator.fromPersisted(null, widgetFields);
                 } catch (Exception e) {
                     LOG.warn("Error while exporting widgets of dashboard " + dashboard.getId(), e);
                     continue;

--- a/graylog2-server/src/main/java/org/graylog2/bundles/BundleImporter.java
+++ b/graylog2-server/src/main/java/org/graylog2/bundles/BundleImporter.java
@@ -24,6 +24,7 @@ import org.bson.types.ObjectId;
 import org.graylog2.dashboards.DashboardImpl;
 import org.graylog2.dashboards.DashboardRegistry;
 import org.graylog2.dashboards.DashboardService;
+import org.graylog2.dashboards.widgets.DashboardWidgetCreator;
 import org.graylog2.dashboards.widgets.InvalidWidgetConfigurationException;
 import org.graylog2.database.NotFoundException;
 import org.graylog2.plugin.database.ValidationException;
@@ -78,6 +79,7 @@ public class BundleImporter {
     private final OutputService outputService;
     private final DashboardService dashboardService;
     private final DashboardRegistry dashboardRegistry;
+    private final DashboardWidgetCreator dashboardWidgetCreator;
     private final ServerStatus serverStatus;
     private final MetricRegistry metricRegistry;
     private final Searches searches;
@@ -100,6 +102,7 @@ public class BundleImporter {
                           final OutputService outputService,
                           final DashboardService dashboardService,
                           final DashboardRegistry dashboardRegistry,
+                          final DashboardWidgetCreator dashboardWidgetCreator,
                           final ServerStatus serverStatus,
                           final MetricRegistry metricRegistry,
                           final Searches searches,
@@ -113,6 +116,7 @@ public class BundleImporter {
         this.outputService = outputService;
         this.dashboardService = dashboardService;
         this.dashboardRegistry = dashboardRegistry;
+        this.dashboardWidgetCreator = dashboardWidgetCreator;
         this.serverStatus = serverStatus;
         this.metricRegistry = metricRegistry;
         this.searches = searches;
@@ -534,7 +538,7 @@ public class BundleImporter {
         }
 
         final String widgetId = UUID.randomUUID().toString();
-        return org.graylog2.dashboards.widgets.DashboardWidget.buildDashboardWidget(type, metricRegistry, searches,
+        return dashboardWidgetCreator.buildDashboardWidget(type, searches,
                 widgetId, dashboardWidget.getDescription(), dashboardWidget.getCacheTime(),
                 config, (String) config.get("query"), timeRange, userName);
     }

--- a/graylog2-server/src/main/java/org/graylog2/dashboards/DashboardServiceImpl.java
+++ b/graylog2-server/src/main/java/org/graylog2/dashboards/DashboardServiceImpl.java
@@ -23,6 +23,7 @@ import com.mongodb.BasicDBObject;
 import com.mongodb.DBObject;
 import org.bson.types.ObjectId;
 import org.graylog2.dashboards.widgets.DashboardWidget;
+import org.graylog2.dashboards.widgets.DashboardWidgetCreator;
 import org.graylog2.dashboards.widgets.InvalidWidgetConfigurationException;
 import org.graylog2.database.MongoConnection;
 import org.graylog2.database.NotFoundException;
@@ -43,14 +44,17 @@ public class DashboardServiceImpl extends PersistedServiceImpl implements Dashbo
     private static final Logger LOG = LoggerFactory.getLogger(DashboardServiceImpl.class);
     private final MetricRegistry metricRegistry;
     private final Searches searches;
+    private final DashboardWidgetCreator dashboardWidgetCreator;
 
     @Inject
     public DashboardServiceImpl(MongoConnection mongoConnection,
                                 MetricRegistry metricRegistry,
-                                Searches searches) {
+                                Searches searches,
+                                DashboardWidgetCreator dashboardWidgetCreator) {
         super(mongoConnection);
         this.metricRegistry = metricRegistry;
         this.searches = searches;
+        this.dashboardWidgetCreator = dashboardWidgetCreator;
     }
 
     @Override
@@ -89,7 +93,7 @@ public class DashboardServiceImpl extends PersistedServiceImpl implements Dashbo
                 for (BasicDBObject widgetFields : (List<BasicDBObject>) fields.get(DashboardImpl.EMBEDDED_WIDGETS)) {
                     DashboardWidget widget = null;
                     try {
-                        widget = DashboardWidget.fromPersisted(metricRegistry, searches, widgetFields);
+                        widget = dashboardWidgetCreator.fromPersisted(searches, widgetFields);
                     } catch (DashboardWidget.NoSuchWidgetTypeException e) {
                         LOG.error("No such widget type: [" + widgetFields.get("type") + "] - Dashboard: [" + dashboard.getId() + "]", e);
                         continue;

--- a/graylog2-server/src/main/java/org/graylog2/dashboards/widgets/DashboardWidget.java
+++ b/graylog2-server/src/main/java/org/graylog2/dashboards/widgets/DashboardWidget.java
@@ -22,34 +22,19 @@ import com.codahale.metrics.Timer;
 import com.google.common.base.Supplier;
 import com.google.common.base.Suppliers;
 import com.google.common.collect.ImmutableMap;
-import com.mongodb.BasicDBObject;
-import org.graylog2.indexer.searches.Searches;
-import org.graylog2.indexer.searches.timeranges.AbsoluteRange;
-import org.graylog2.indexer.searches.timeranges.InvalidRangeParametersException;
-import org.graylog2.indexer.searches.timeranges.KeywordRange;
-import org.graylog2.indexer.searches.timeranges.RelativeRange;
-import org.graylog2.indexer.searches.timeranges.TimeRange;
-import org.graylog2.plugin.Tools;
 import org.graylog2.plugin.database.EmbeddedPersistable;
-import org.graylog2.rest.models.dashboards.requests.AddWidgetRequest;
-import org.joda.time.DateTime;
-import org.joda.time.DateTimeZone;
 
 import java.util.Map;
-import java.util.UUID;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 
-import static com.google.common.base.MoreObjects.firstNonNull;
-import static com.google.common.base.Strings.isNullOrEmpty;
-
 public abstract class DashboardWidget implements EmbeddedPersistable {
-    private static final String FIELD_ID = "id";
-    private static final String FIELD_TYPE = "type";
-    private static final String FIELD_DESCRIPTION = "description";
-    private static final String FIELD_CACHE_TIME = "cache_time";
-    private static final String FIELD_CREATOR_USER_ID = "creator_user_id";
-    private static final String FIELD_CONFIG = "config";
+    public static final String FIELD_ID = "id";
+    public static final String FIELD_TYPE = "type";
+    public static final String FIELD_DESCRIPTION = "description";
+    public static final String FIELD_CACHE_TIME = "cache_time";
+    public static final String FIELD_CREATOR_USER_ID = "creator_user_id";
+    public static final String FIELD_CONFIG = "config";
 
     public enum Type {
         SEARCH_RESULT_COUNT,
@@ -80,159 +65,6 @@ public abstract class DashboardWidget implements EmbeddedPersistable {
         this.description = description;
         this.cacheTime = cacheTimeS < 1 ? DEFAULT_CACHE_TIME : cacheTimeS;
         this.cachedResult = Suppliers.memoizeWithExpiration(new ComputationResultSupplier(), this.cacheTime, TimeUnit.SECONDS);
-    }
-
-    public static DashboardWidget fromRequest(MetricRegistry metricRegistry, Searches searches, AddWidgetRequest awr, String userId) throws NoSuchWidgetTypeException, InvalidRangeParametersException, InvalidWidgetConfigurationException {
-        return DashboardWidget.fromRequest(metricRegistry, searches, null, awr, userId);
-    }
-
-    public static DashboardWidget fromRequest(MetricRegistry metricRegistry, Searches searches, String widgetId, AddWidgetRequest awr, String userId) throws NoSuchWidgetTypeException, InvalidRangeParametersException, InvalidWidgetConfigurationException {
-        Type type;
-        try {
-            type = Type.valueOf(awr.type().toUpperCase());
-        } catch (IllegalArgumentException e) {
-            throw new NoSuchWidgetTypeException("No such widget type <" + awr.type() + ">");
-        }
-
-        String id = isNullOrEmpty(widgetId) ? UUID.randomUUID().toString() : widgetId;
-
-        // Build timerange.
-        final String rangeType = (String) awr.config().get("range_type");
-        if (rangeType == null) {
-            throw new InvalidRangeParametersException("range_type not set");
-        }
-
-        final TimeRange timeRange;
-        switch (rangeType) {
-            case "relative":
-                timeRange = new RelativeRange(Integer.parseInt((String) awr.config().get("range")));
-                break;
-            case "keyword":
-                timeRange = new KeywordRange((String) awr.config().get("keyword"), true);
-                break;
-            case "absolute":
-                timeRange = new AbsoluteRange((String) awr.config().get("from"), (String) awr.config().get("to"));
-                break;
-            default:
-                throw new InvalidRangeParametersException("range_type not recognized");
-        }
-
-        return buildDashboardWidget(type, metricRegistry, searches, id, awr.description(), 0, awr.config(),
-                (String) awr.config().get("query"), timeRange, userId);
-    }
-
-    public static DashboardWidget fromPersisted(MetricRegistry metricRegistry, Searches searches, BasicDBObject fields) throws NoSuchWidgetTypeException, InvalidRangeParametersException, InvalidWidgetConfigurationException {
-        Type type;
-        try {
-            type = Type.valueOf(((String) fields.get(FIELD_TYPE)).toUpperCase());
-        } catch (IllegalArgumentException e) {
-            throw new NoSuchWidgetTypeException();
-        }
-
-        BasicDBObject config = (BasicDBObject) fields.get(FIELD_CONFIG);
-
-        // Build timerange.
-        BasicDBObject timerangeConfig = (BasicDBObject) config.get("timerange");
-
-        final String rangeType = (String) timerangeConfig.get(FIELD_TYPE);
-        if (rangeType == null) {
-            throw new InvalidRangeParametersException("range type not set");
-        }
-
-        TimeRange timeRange;
-        switch (rangeType) {
-            case "relative":
-                timeRange = new RelativeRange((Integer) timerangeConfig.get("range"));
-                break;
-            case "keyword":
-                timeRange = new KeywordRange((String) timerangeConfig.get("keyword"), true);
-                break;
-            case "absolute":
-                String from = new DateTime(timerangeConfig.get("from"), DateTimeZone.UTC).toString(Tools.ES_DATE_FORMAT);
-                String to = new DateTime(timerangeConfig.get("to"), DateTimeZone.UTC).toString(Tools.ES_DATE_FORMAT);
-
-                timeRange = new AbsoluteRange(from, to);
-                break;
-            default:
-                throw new InvalidRangeParametersException("range_type not recognized");
-        }
-
-        final String description = (String) fields.get(FIELD_DESCRIPTION);
-        final int cacheTime = (int) firstNonNull(fields.get(FIELD_CACHE_TIME), 0);
-
-        return buildDashboardWidget(type, metricRegistry, searches, (String) fields.get(FIELD_ID), description, cacheTime,
-                config, (String) config.get("query"), timeRange, (String) fields.get(FIELD_CREATOR_USER_ID));
-    }
-
-    public static DashboardWidget buildDashboardWidget(
-            final Type type,
-            final MetricRegistry metricRegistry,
-            final Searches searches,
-            final String widgetId,
-            final String description,
-            final int cacheTime,
-            final Map<String, Object> config,
-            final String query,
-            final TimeRange timeRange,
-            final String creatorUserId) throws NoSuchWidgetTypeException, InvalidWidgetConfigurationException {
-        switch (type) {
-            case SEARCH_RESULT_COUNT:
-                return new SearchResultCountWidget(metricRegistry, searches,
-                        widgetId,
-                        description,
-                        cacheTime,
-                        config,
-                        query,
-                        timeRange,
-                        creatorUserId);
-            case STREAM_SEARCH_RESULT_COUNT:
-                return new StreamSearchResultCountWidget(metricRegistry, searches,
-                        widgetId,
-                        description,
-                        cacheTime,
-                        config,
-                        query,
-                        timeRange,
-                        creatorUserId);
-            case FIELD_CHART:
-                return new FieldChartWidget(metricRegistry, searches,
-                        widgetId,
-                        description,
-                        cacheTime,
-                        config,
-                        query,
-                        timeRange,
-                        creatorUserId);
-            case QUICKVALUES:
-                return new QuickvaluesWidget(metricRegistry, searches,
-                        widgetId,
-                        description,
-                        cacheTime,
-                        config,
-                        query,
-                        timeRange,
-                        creatorUserId);
-            case SEARCH_RESULT_CHART:
-                return new SearchResultChartWidget(metricRegistry, searches,
-                        widgetId,
-                        description,
-                        cacheTime,
-                        config,
-                        query,
-                        timeRange,
-                        creatorUserId);
-            case STATS_COUNT:
-                return new StatisticalCountWidget(metricRegistry, searches,
-                        widgetId,
-                        description,
-                        cacheTime,
-                        config,
-                        query,
-                        timeRange,
-                        creatorUserId);
-            default:
-                throw new NoSuchWidgetTypeException();
-        }
     }
 
     public Type getType() {

--- a/graylog2-server/src/main/java/org/graylog2/dashboards/widgets/DashboardWidget.java
+++ b/graylog2-server/src/main/java/org/graylog2/dashboards/widgets/DashboardWidget.java
@@ -45,8 +45,6 @@ public abstract class DashboardWidget implements EmbeddedPersistable {
         STATS_COUNT
     }
 
-    public static final int DEFAULT_CACHE_TIME = 10;
-
     private final MetricRegistry metricRegistry;
     private final Type type;
     private final String id;
@@ -56,14 +54,14 @@ public abstract class DashboardWidget implements EmbeddedPersistable {
     private String description;
     private Supplier<ComputationResult> cachedResult;
 
-    protected DashboardWidget(MetricRegistry metricRegistry, Type type, String id, String description, int cacheTimeS, Map<String, Object> config, String creatorUserId) {
+    protected DashboardWidget(MetricRegistry metricRegistry, Type type, String id, String description, WidgetCacheTime cacheTime, Map<String, Object> config, String creatorUserId) {
         this.metricRegistry = metricRegistry;
         this.type = type;
         this.id = id;
         this.config = config;
         this.creatorUserId = creatorUserId;
         this.description = description;
-        this.cacheTime = cacheTimeS < 1 ? DEFAULT_CACHE_TIME : cacheTimeS;
+        this.cacheTime = cacheTime.getCacheTime();
         this.cachedResult = Suppliers.memoizeWithExpiration(new ComputationResultSupplier(), this.cacheTime, TimeUnit.SECONDS);
     }
 

--- a/graylog2-server/src/main/java/org/graylog2/dashboards/widgets/DashboardWidgetCreator.java
+++ b/graylog2-server/src/main/java/org/graylog2/dashboards/widgets/DashboardWidgetCreator.java
@@ -39,10 +39,12 @@ import static com.google.common.base.Strings.isNullOrEmpty;
 
 public class DashboardWidgetCreator {
     private final MetricRegistry metricRegistry;
+    private final WidgetCacheTime.Factory cacheTimeFactory;
 
     @Inject
-    public DashboardWidgetCreator(MetricRegistry metricRegistry) {
+    public DashboardWidgetCreator(MetricRegistry metricRegistry, WidgetCacheTime.Factory cacheTimeFactory) {
         this.metricRegistry = metricRegistry;
+        this.cacheTimeFactory = cacheTimeFactory;
     }
 
     public DashboardWidget fromRequest(Searches searches, AddWidgetRequest awr, String userId) throws DashboardWidget.NoSuchWidgetTypeException, InvalidRangeParametersException, InvalidWidgetConfigurationException {
@@ -132,11 +134,14 @@ public class DashboardWidgetCreator {
             final Searches searches,
             final String widgetId,
             final String description,
-            final int cacheTime,
+            final int requestedCacheTime,
             final Map<String, Object> config,
             final String query,
             final TimeRange timeRange,
             final String creatorUserId) throws DashboardWidget.NoSuchWidgetTypeException, InvalidWidgetConfigurationException {
+
+        final WidgetCacheTime cacheTime = cacheTimeFactory.create(requestedCacheTime);
+
         switch (type) {
             case SEARCH_RESULT_COUNT:
                 return new SearchResultCountWidget(metricRegistry, searches,

--- a/graylog2-server/src/main/java/org/graylog2/dashboards/widgets/DashboardWidgetCreator.java
+++ b/graylog2-server/src/main/java/org/graylog2/dashboards/widgets/DashboardWidgetCreator.java
@@ -1,0 +1,199 @@
+/**
+ * This file is part of Graylog.
+ *
+ * Graylog is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.graylog2.dashboards.widgets;
+
+import com.codahale.metrics.MetricRegistry;
+import com.mongodb.BasicDBObject;
+import org.graylog2.indexer.searches.Searches;
+import org.graylog2.indexer.searches.timeranges.AbsoluteRange;
+import org.graylog2.indexer.searches.timeranges.InvalidRangeParametersException;
+import org.graylog2.indexer.searches.timeranges.KeywordRange;
+import org.graylog2.indexer.searches.timeranges.RelativeRange;
+import org.graylog2.indexer.searches.timeranges.TimeRange;
+import org.graylog2.plugin.Tools;
+import org.graylog2.rest.models.dashboards.requests.AddWidgetRequest;
+import org.joda.time.DateTime;
+import org.joda.time.DateTimeZone;
+
+import javax.inject.Inject;
+import java.util.Map;
+import java.util.UUID;
+
+import static com.google.common.base.MoreObjects.firstNonNull;
+import static com.google.common.base.Strings.isNullOrEmpty;
+
+public class DashboardWidgetCreator {
+    private final MetricRegistry metricRegistry;
+
+    @Inject
+    public DashboardWidgetCreator(MetricRegistry metricRegistry) {
+        this.metricRegistry = metricRegistry;
+    }
+
+    public DashboardWidget fromRequest(Searches searches, AddWidgetRequest awr, String userId) throws DashboardWidget.NoSuchWidgetTypeException, InvalidRangeParametersException, InvalidWidgetConfigurationException {
+        return fromRequest(searches, null, awr, userId);
+    }
+
+    public DashboardWidget fromRequest(Searches searches, String widgetId, AddWidgetRequest awr, String userId) throws DashboardWidget.NoSuchWidgetTypeException, InvalidRangeParametersException, InvalidWidgetConfigurationException {
+        DashboardWidget.Type type;
+        try {
+            type = DashboardWidget.Type.valueOf(awr.type().toUpperCase());
+        } catch (IllegalArgumentException e) {
+            throw new DashboardWidget.NoSuchWidgetTypeException("No such widget type <" + awr.type() + ">");
+        }
+
+        String id = isNullOrEmpty(widgetId) ? UUID.randomUUID().toString() : widgetId;
+
+        // Build timerange.
+        final String rangeType = (String) awr.config().get("range_type");
+        if (rangeType == null) {
+            throw new InvalidRangeParametersException("range_type not set");
+        }
+
+        final TimeRange timeRange;
+        switch (rangeType) {
+            case "relative":
+                timeRange = new RelativeRange(Integer.parseInt((String) awr.config().get("range")));
+                break;
+            case "keyword":
+                timeRange = new KeywordRange((String) awr.config().get("keyword"), true);
+                break;
+            case "absolute":
+                timeRange = new AbsoluteRange((String) awr.config().get("from"), (String) awr.config().get("to"));
+                break;
+            default:
+                throw new InvalidRangeParametersException("range_type not recognized");
+        }
+
+        return buildDashboardWidget(type, searches, id, awr.description(), 0, awr.config(),
+                (String) awr.config().get("query"), timeRange, userId);
+    }
+
+    public DashboardWidget fromPersisted(Searches searches, BasicDBObject fields) throws DashboardWidget.NoSuchWidgetTypeException, InvalidRangeParametersException, InvalidWidgetConfigurationException {
+        DashboardWidget.Type type;
+        try {
+            type = DashboardWidget.Type.valueOf(((String) fields.get(DashboardWidget.FIELD_TYPE)).toUpperCase());
+        } catch (IllegalArgumentException e) {
+            throw new DashboardWidget.NoSuchWidgetTypeException();
+        }
+
+        BasicDBObject config = (BasicDBObject) fields.get(DashboardWidget.FIELD_CONFIG);
+
+        // Build timerange.
+        BasicDBObject timerangeConfig = (BasicDBObject) config.get("timerange");
+
+        final String rangeType = (String) timerangeConfig.get(DashboardWidget.FIELD_TYPE);
+        if (rangeType == null) {
+            throw new InvalidRangeParametersException("range type not set");
+        }
+
+        TimeRange timeRange;
+        switch (rangeType) {
+            case "relative":
+                timeRange = new RelativeRange((Integer) timerangeConfig.get("range"));
+                break;
+            case "keyword":
+                timeRange = new KeywordRange((String) timerangeConfig.get("keyword"), true);
+                break;
+            case "absolute":
+                String from = new DateTime(timerangeConfig.get("from"), DateTimeZone.UTC).toString(Tools.ES_DATE_FORMAT);
+                String to = new DateTime(timerangeConfig.get("to"), DateTimeZone.UTC).toString(Tools.ES_DATE_FORMAT);
+
+                timeRange = new AbsoluteRange(from, to);
+                break;
+            default:
+                throw new InvalidRangeParametersException("range_type not recognized");
+        }
+
+        final String description = (String) fields.get(DashboardWidget.FIELD_DESCRIPTION);
+        final int cacheTime = (int) firstNonNull(fields.get(DashboardWidget.FIELD_CACHE_TIME), 0);
+
+        return buildDashboardWidget(type, searches, (String) fields.get(DashboardWidget.FIELD_ID), description, cacheTime,
+                config, (String) config.get("query"), timeRange, (String) fields.get(DashboardWidget.FIELD_CREATOR_USER_ID));
+    }
+
+    public DashboardWidget buildDashboardWidget(
+            final DashboardWidget.Type type,
+            final Searches searches,
+            final String widgetId,
+            final String description,
+            final int cacheTime,
+            final Map<String, Object> config,
+            final String query,
+            final TimeRange timeRange,
+            final String creatorUserId) throws DashboardWidget.NoSuchWidgetTypeException, InvalidWidgetConfigurationException {
+        switch (type) {
+            case SEARCH_RESULT_COUNT:
+                return new SearchResultCountWidget(metricRegistry, searches,
+                        widgetId,
+                        description,
+                        cacheTime,
+                        config,
+                        query,
+                        timeRange,
+                        creatorUserId);
+            case STREAM_SEARCH_RESULT_COUNT:
+                return new StreamSearchResultCountWidget(metricRegistry, searches,
+                        widgetId,
+                        description,
+                        cacheTime,
+                        config,
+                        query,
+                        timeRange,
+                        creatorUserId);
+            case FIELD_CHART:
+                return new FieldChartWidget(metricRegistry, searches,
+                        widgetId,
+                        description,
+                        cacheTime,
+                        config,
+                        query,
+                        timeRange,
+                        creatorUserId);
+            case QUICKVALUES:
+                return new QuickvaluesWidget(metricRegistry, searches,
+                        widgetId,
+                        description,
+                        cacheTime,
+                        config,
+                        query,
+                        timeRange,
+                        creatorUserId);
+            case SEARCH_RESULT_CHART:
+                return new SearchResultChartWidget(metricRegistry, searches,
+                        widgetId,
+                        description,
+                        cacheTime,
+                        config,
+                        query,
+                        timeRange,
+                        creatorUserId);
+            case STATS_COUNT:
+                return new StatisticalCountWidget(metricRegistry, searches,
+                        widgetId,
+                        description,
+                        cacheTime,
+                        config,
+                        query,
+                        timeRange,
+                        creatorUserId);
+            default:
+                throw new DashboardWidget.NoSuchWidgetTypeException();
+        }
+    }
+}

--- a/graylog2-server/src/main/java/org/graylog2/dashboards/widgets/FieldChartWidget.java
+++ b/graylog2-server/src/main/java/org/graylog2/dashboards/widgets/FieldChartWidget.java
@@ -41,7 +41,7 @@ public class FieldChartWidget extends DashboardWidget {
     private final Map<String, Object> config;
     private final Searches searches;
 
-    public FieldChartWidget(MetricRegistry metricRegistry, Searches searches, String id, String description, int cacheTime, Map<String, Object> config, String query, TimeRange timeRange, String creatorUserId) throws InvalidWidgetConfigurationException {
+    public FieldChartWidget(MetricRegistry metricRegistry, Searches searches, String id, String description, WidgetCacheTime cacheTime, Map<String, Object> config, String query, TimeRange timeRange, String creatorUserId) throws InvalidWidgetConfigurationException {
         super(metricRegistry, Type.FIELD_CHART, id, description, cacheTime, config, creatorUserId);
         this.searches = searches;
 

--- a/graylog2-server/src/main/java/org/graylog2/dashboards/widgets/QuickvaluesWidget.java
+++ b/graylog2-server/src/main/java/org/graylog2/dashboards/widgets/QuickvaluesWidget.java
@@ -45,7 +45,7 @@ public class QuickvaluesWidget extends DashboardWidget {
     private final Boolean showPieChart;
     private final Boolean showDataTable;
 
-    public QuickvaluesWidget(MetricRegistry metricRegistry, Searches searches, String id, String description, int cacheTime, Map<String, Object> config, String query, TimeRange timeRange, String creatorUserId) throws InvalidWidgetConfigurationException {
+    public QuickvaluesWidget(MetricRegistry metricRegistry, Searches searches, String id, String description, WidgetCacheTime cacheTime, Map<String, Object> config, String query, TimeRange timeRange, String creatorUserId) throws InvalidWidgetConfigurationException {
         super(metricRegistry, Type.QUICKVALUES, id, description, cacheTime, config, creatorUserId);
         this.searches = searches;
 

--- a/graylog2-server/src/main/java/org/graylog2/dashboards/widgets/SearchResultChartWidget.java
+++ b/graylog2-server/src/main/java/org/graylog2/dashboards/widgets/SearchResultChartWidget.java
@@ -36,7 +36,7 @@ public class SearchResultChartWidget extends DashboardWidget {
     private final String streamId;
     private final Searches searches;
 
-    public SearchResultChartWidget(MetricRegistry metricRegistry, Searches searches, String id, String description, int cacheTime, Map<String, Object> config, String query, TimeRange timeRange, String creatorUserId) {
+    public SearchResultChartWidget(MetricRegistry metricRegistry, Searches searches, String id, String description, WidgetCacheTime cacheTime, Map<String, Object> config, String query, TimeRange timeRange, String creatorUserId) {
         super(metricRegistry, Type.SEARCH_RESULT_CHART, id, description, cacheTime, config, creatorUserId);
         this.searches = searches;
 

--- a/graylog2-server/src/main/java/org/graylog2/dashboards/widgets/SearchResultCountWidget.java
+++ b/graylog2-server/src/main/java/org/graylog2/dashboards/widgets/SearchResultCountWidget.java
@@ -37,11 +37,11 @@ public class SearchResultCountWidget extends DashboardWidget {
     protected final Boolean trend;
     protected final Boolean lowerIsBetter;
 
-    public SearchResultCountWidget(MetricRegistry metricRegistry, Searches searches, String id, String description, int cacheTime, Map<String, Object> config, String query, TimeRange timeRange, String creatorUserId) {
+    public SearchResultCountWidget(MetricRegistry metricRegistry, Searches searches, String id, String description, WidgetCacheTime cacheTime, Map<String, Object> config, String query, TimeRange timeRange, String creatorUserId) {
         this(metricRegistry, Type.SEARCH_RESULT_COUNT, searches, id, description, cacheTime, config, query, timeRange, creatorUserId);
     }
 
-    protected SearchResultCountWidget(MetricRegistry metricRegistry, Type type, Searches searches, String id, String description, int cacheTime, Map<String, Object> config, String query, TimeRange timeRange, String creatorUserId) {
+    protected SearchResultCountWidget(MetricRegistry metricRegistry, Type type, Searches searches, String id, String description, WidgetCacheTime cacheTime, Map<String, Object> config, String query, TimeRange timeRange, String creatorUserId) {
         super(metricRegistry, type, id, description, cacheTime, config, creatorUserId);
         this.searches = searches;
 

--- a/graylog2-server/src/main/java/org/graylog2/dashboards/widgets/StatisticalCountWidget.java
+++ b/graylog2-server/src/main/java/org/graylog2/dashboards/widgets/StatisticalCountWidget.java
@@ -36,7 +36,7 @@ public class StatisticalCountWidget extends SearchResultCountWidget {
     private final String field;
     private final String streamId;
 
-    public StatisticalCountWidget(MetricRegistry metricRegistry, Searches searches, String id, String description, int cacheTime, Map<String, Object> config, String query, TimeRange timeRange, String creatorUserId) {
+    public StatisticalCountWidget(MetricRegistry metricRegistry, Searches searches, String id, String description, WidgetCacheTime cacheTime, Map<String, Object> config, String query, TimeRange timeRange, String creatorUserId) {
         super(metricRegistry, Type.STATS_COUNT, searches, id, description, cacheTime, config, query, timeRange, creatorUserId);
         this.field = (String) config.get("field");
         this.statsFunction = (String) config.get("stats_function");

--- a/graylog2-server/src/main/java/org/graylog2/dashboards/widgets/StreamSearchResultCountWidget.java
+++ b/graylog2-server/src/main/java/org/graylog2/dashboards/widgets/StreamSearchResultCountWidget.java
@@ -28,7 +28,7 @@ import static com.google.common.base.Strings.isNullOrEmpty;
 public class StreamSearchResultCountWidget extends SearchResultCountWidget {
     private final String streamId;
 
-    public StreamSearchResultCountWidget(MetricRegistry metricRegistry, Searches searches, String id, String description, int cacheTime, Map<String, Object> config, String query, TimeRange timeRange, String creatorUserId) {
+    public StreamSearchResultCountWidget(MetricRegistry metricRegistry, Searches searches, String id, String description, WidgetCacheTime cacheTime, Map<String, Object> config, String query, TimeRange timeRange, String creatorUserId) {
         super(metricRegistry, DashboardWidget.Type.STREAM_SEARCH_RESULT_COUNT, searches, id, description, cacheTime, config, query, timeRange, creatorUserId);
         this.streamId = (String) config.get("stream_id");
     }

--- a/graylog2-server/src/main/java/org/graylog2/dashboards/widgets/WidgetCacheTime.java
+++ b/graylog2-server/src/main/java/org/graylog2/dashboards/widgets/WidgetCacheTime.java
@@ -1,0 +1,41 @@
+/**
+ * This file is part of Graylog.
+ *
+ * Graylog is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.graylog2.dashboards.widgets;
+
+import com.google.inject.assistedinject.Assisted;
+
+import javax.inject.Inject;
+import javax.inject.Named;
+
+public class WidgetCacheTime {
+    private final int cacheTime;
+
+    public interface Factory {
+        WidgetCacheTime create(int cacheTime);
+    }
+
+    @Inject
+    public WidgetCacheTime(@Named("dashboard_widget_default_cache_time") int defaultCacheTime,
+                           @Assisted int cacheTime) {
+        this.cacheTime = cacheTime < 1 ? defaultCacheTime : cacheTime;
+    }
+
+    public int getCacheTime() {
+        return cacheTime;
+    }
+}

--- a/graylog2-server/src/main/java/org/graylog2/dashboards/widgets/WidgetCacheTime.java
+++ b/graylog2-server/src/main/java/org/graylog2/dashboards/widgets/WidgetCacheTime.java
@@ -17,6 +17,8 @@
 
 package org.graylog2.dashboards.widgets;
 
+import com.github.joschi.jadconfig.util.Duration;
+import com.google.common.primitives.Ints;
 import com.google.inject.assistedinject.Assisted;
 
 import javax.inject.Inject;
@@ -30,9 +32,9 @@ public class WidgetCacheTime {
     }
 
     @Inject
-    public WidgetCacheTime(@Named("dashboard_widget_default_cache_time") int defaultCacheTime,
+    public WidgetCacheTime(@Named("dashboard_widget_default_cache_time") Duration defaultCacheTime,
                            @Assisted int cacheTime) {
-        this.cacheTime = cacheTime < 1 ? defaultCacheTime : cacheTime;
+        this.cacheTime = cacheTime < 1 ? Ints.saturatedCast(defaultCacheTime.toSeconds()) : cacheTime;
     }
 
     public int getCacheTime() {

--- a/graylog2-server/src/main/java/org/graylog2/rest/resources/dashboards/DashboardsResource.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/resources/dashboards/DashboardsResource.java
@@ -31,6 +31,7 @@ import org.graylog2.dashboards.Dashboard;
 import org.graylog2.dashboards.DashboardRegistry;
 import org.graylog2.dashboards.DashboardService;
 import org.graylog2.dashboards.widgets.DashboardWidget;
+import org.graylog2.dashboards.widgets.DashboardWidgetCreator;
 import org.graylog2.dashboards.widgets.InvalidWidgetConfigurationException;
 import org.graylog2.database.NotFoundException;
 import org.graylog2.plugin.database.ValidationException;
@@ -79,6 +80,7 @@ public class DashboardsResource extends RestResource {
 
     private DashboardService dashboardService;
     private DashboardRegistry dashboardRegistry;
+    private final DashboardWidgetCreator dashboardWidgetCreator;
     private ActivityWriter activityWriter;
     private MetricRegistry metricRegistry;
     private final Searches searches;
@@ -86,11 +88,13 @@ public class DashboardsResource extends RestResource {
     @Inject
     public DashboardsResource(DashboardService dashboardService,
                               DashboardRegistry dashboardRegistry,
+                              DashboardWidgetCreator dashboardWidgetCreator,
                               ActivityWriter activityWriter,
                               MetricRegistry metricRegistry,
                               Searches searches) {
         this.dashboardService = dashboardService;
         this.dashboardRegistry = dashboardRegistry;
+        this.dashboardWidgetCreator = dashboardWidgetCreator;
         this.activityWriter = activityWriter;
         this.metricRegistry = metricRegistry;
         this.searches = searches;
@@ -255,7 +259,7 @@ public class DashboardsResource extends RestResource {
 
         DashboardWidget widget;
         try {
-            widget = DashboardWidget.fromRequest(metricRegistry, searches, awr, getCurrentUser().getName());
+            widget = dashboardWidgetCreator.fromRequest(searches, awr, getCurrentUser().getName());
 
             Dashboard dashboard = dashboardRegistry.get(dashboardId);
 
@@ -387,8 +391,8 @@ public class DashboardsResource extends RestResource {
         }
 
         try {
-            final DashboardWidget updatedWidget = DashboardWidget.fromRequest(metricRegistry,
-                    searches, widgetId, awr, widget.getCreatorUserId());
+            final DashboardWidget updatedWidget = dashboardWidgetCreator.fromRequest(searches,
+                    widgetId, awr, widget.getCreatorUserId());
             updatedWidget.setCacheTime(awr.cacheTime());
 
             dashboardService.removeWidget(dashboard, widget);

--- a/graylog2-server/src/test/java/org/graylog2/dashboards/DashboardServiceImplTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/dashboards/DashboardServiceImplTest.java
@@ -20,6 +20,7 @@ import com.codahale.metrics.MetricRegistry;
 import com.lordofthejars.nosqlunit.annotation.UsingDataSet;
 import com.lordofthejars.nosqlunit.core.LoadStrategyEnum;
 import com.lordofthejars.nosqlunit.mongodb.InMemoryMongoDb;
+import org.graylog2.dashboards.widgets.DashboardWidgetCreator;
 import org.graylog2.database.MongoConnectionRule;
 import org.graylog2.database.NotFoundException;
 import org.graylog2.indexer.searches.Searches;
@@ -54,9 +55,12 @@ public class DashboardServiceImplTest {
     @Mock
     private Searches searches;
 
+    @Mock
+    private DashboardWidgetCreator dashboardWidgetCreator;
+
     @Before
     public void setUpService() throws Exception {
-        this.dashboardService = new DashboardServiceImpl(mongoRule.getMongoConnection(), metricRegistry, searches);
+        this.dashboardService = new DashboardServiceImpl(mongoRule.getMongoConnection(), metricRegistry, searches, dashboardWidgetCreator);
     }
 
     @Test

--- a/graylog2-server/src/test/java/org/graylog2/dashboards/widgets/WidgetCacheTimeTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/dashboards/widgets/WidgetCacheTimeTest.java
@@ -17,6 +17,7 @@
 
 package org.graylog2.dashboards.widgets;
 
+import com.github.joschi.jadconfig.util.Duration;
 import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
@@ -25,12 +26,12 @@ public class WidgetCacheTimeTest {
 
     @Test
     public void test() throws Exception {
-        assertEquals(10, getCacheTime(10, 0));
-        assertEquals(1, getCacheTime(10, 1));
-        assertEquals(2, getCacheTime(10, 2));
+        assertEquals(10, getCacheTime(Duration.seconds(10), 0));
+        assertEquals(1, getCacheTime(Duration.seconds(10), 1));
+        assertEquals(2, getCacheTime(Duration.seconds(10), 2));
     }
 
-    private int getCacheTime(int defaultCacheTime, int cacheTime) {
+    private int getCacheTime(Duration defaultCacheTime, int cacheTime) {
         return new WidgetCacheTime(defaultCacheTime, cacheTime).getCacheTime();
     }
 }

--- a/graylog2-server/src/test/java/org/graylog2/dashboards/widgets/WidgetCacheTimeTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/dashboards/widgets/WidgetCacheTimeTest.java
@@ -1,0 +1,36 @@
+/**
+ * This file is part of Graylog.
+ *
+ * Graylog is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.graylog2.dashboards.widgets;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+public class WidgetCacheTimeTest {
+
+    @Test
+    public void test() throws Exception {
+        assertEquals(10, getCacheTime(10, 0));
+        assertEquals(1, getCacheTime(10, 1));
+        assertEquals(2, getCacheTime(10, 2));
+    }
+
+    private int getCacheTime(int defaultCacheTime, int cacheTime) {
+        return new WidgetCacheTime(defaultCacheTime, cacheTime).getCacheTime();
+    }
+}

--- a/misc/graylog2.conf
+++ b/misc/graylog2.conf
@@ -403,3 +403,6 @@ mongodb_threads_allowed_to_block_multiplier = 5
 
 # Amount of time after which inactive collectors are purged (Default: 14 days)
 #collector_expiration_threshold = 14d
+
+# The default cache time for dashboard widgets. (Default: 10 seconds, minimum: 1 second)
+#dashboard_widget_default_cache_time = 10s


### PR DESCRIPTION
This is my 4th try to make the default widget cache time configurable and it is still a huge change. :confused: I think this version is a step in the right direction to make the dashboard widget code better in the future. (removal of static methods, dependency injection)

Please let me know if you can think of a better way that does not introduce such big changes!

* Refactors static DashboardWidget creator methods into DashboardWidgetCreator and replace usage of static methods with creator object which gets injected.
* Removes the hardcoded default dashboard widget cache time and makes it configurable with the "dashboard_widget_default_cache_time" config file option.
* Introduce a WidgetCacheTime object that decides when the default cache time is used.



Fixes #1170