### PR TITLE
fix alertcondition tests

### DIFF
--- a/graylog2-server/src/test/java/org/graylog2/alerts/AlertConditionTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/alerts/AlertConditionTest.java
@@ -38,7 +38,11 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.when;
 
 public abstract class AlertConditionTest {
     protected Stream stream;
@@ -86,7 +90,7 @@ public abstract class AlertConditionTest {
         assertNotNull("Timestamp of returned check result should not be null!", result.getTriggeredAt());
         assertEquals("AlertCondition of result is not the same we created!", result.getTriggeredCondition(), alertCondition);
         long difference = Tools.iso8601().getMillis() - result.getTriggeredAt().getMillis();
-        assertTrue("AlertCondition should be triggered about now", difference < 50);
+        assertTrue("AlertCondition should be triggered about now", difference < 1000);
         assertFalse("Alert was triggered, so we should not be in grace period!", alertService.inGracePeriod(alertCondition));
     }
 

--- a/graylog2-server/src/test/java/org/graylog2/alerts/AlertConditionTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/alerts/AlertConditionTest.java
@@ -27,6 +27,9 @@ import org.graylog2.plugin.alarms.AlertCondition;
 import org.graylog2.plugin.streams.Stream;
 import org.joda.time.DateTime;
 import org.junit.Before;
+import org.mockito.Matchers;
+import org.mockito.invocation.InvocationOnMock;
+import org.mockito.stubbing.Answer;
 
 import java.util.Map;
 
@@ -35,8 +38,7 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.*;
 
 public abstract class AlertConditionTest {
     protected Stream stream;
@@ -54,7 +56,7 @@ public abstract class AlertConditionTest {
         searches = mock(Searches.class);
         mongoConnection = mock(MongoConnection.class);
         // TODO use injection please. this sucks so bad
-        alertService = new AlertServiceImpl(mongoConnection,
+        alertService = spy(new AlertServiceImpl(mongoConnection,
                 new FieldValueAlertCondition.Factory() {
                     @Override
                     public FieldValueAlertCondition createAlertCondition(Stream stream,
@@ -74,7 +76,7 @@ public abstract class AlertConditionTest {
                                                                            Map<String, Object> parameters) {
                         return new MessageCountAlertCondition(searches, stream, id, createdAt, creatorUserId, parameters);
                     }
-                });
+                }));
 
         when(stream.getId()).thenReturn(STREAM_ID);
     }
@@ -103,15 +105,25 @@ public abstract class AlertConditionTest {
     }
 
     protected void alertLastTriggered(int seconds) {
-        //PowerMockito.mockStatic(AlertImpl.class);
-        //PowerMockito.when(alertService.triggeredSecondsAgo(STREAM_ID, CONDITION_ID)).thenReturn(seconds);
-        when(alertService.triggeredSecondsAgo(STREAM_ID, CONDITION_ID)).thenReturn(seconds);
+        // turn it around to avoid actually accessing the database
+        doReturn(seconds).when(alertService).triggeredSecondsAgo(STREAM_ID, CONDITION_ID);
+        // override the mocked object if the condition has not triggered, test code expects null not a mock
+        doAnswer(new Answer() {
+            @Override
+            public AlertCondition.CheckResult answer(InvocationOnMock invocation) throws Throwable {
+                final AlertCondition.CheckResult result = (AlertCondition.CheckResult) invocation.callRealMethod();
+                if (result.isTriggered()) {
+                    return result;
+                }
+                return new AbstractAlertCondition.CheckResult(false, null, result.getResultDescription(), result.getTriggeredAt(), result.getMatchingMessages());
+            }
+        }).when(alertService).triggered(Matchers.<AlertCondition>anyObject());
     }
 
     protected <T extends AbstractAlertCondition> T getTestInstance(Class<T> klazz, Map<String, Object> parameters) {
         try {
-            return klazz.getConstructor(Stream.class, String.class, DateTime.class, String.class, Map.class)
-                    .newInstance(stream, CONDITION_ID, Tools.iso8601(), STREAM_CREATOR, parameters);
+            return klazz.getConstructor(Searches.class, Stream.class, String.class, DateTime.class, String.class, Map.class)
+                    .newInstance(searches, stream, CONDITION_ID, Tools.iso8601(), STREAM_CREATOR, parameters);
         } catch (Exception e) {
             throw new RuntimeException(e);
         }

--- a/graylog2-server/src/test/java/org/graylog2/alerts/types/FieldValueAlertConditionTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/alerts/types/FieldValueAlertConditionTest.java
@@ -23,7 +23,6 @@ import org.graylog2.indexer.searches.Searches;
 import org.graylog2.indexer.searches.timeranges.RelativeRange;
 import org.graylog2.plugin.Tools;
 import org.graylog2.plugin.alarms.AlertCondition;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.mockito.Matchers;
 
@@ -35,7 +34,6 @@ import static org.mockito.Matchers.anyString;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-@Ignore
 public class FieldValueAlertConditionTest extends AlertConditionTest {
     @Test
     public void testConstructor() throws Exception {

--- a/graylog2-server/src/test/java/org/graylog2/alerts/types/MessageCountAlertConditionTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/alerts/types/MessageCountAlertConditionTest.java
@@ -22,25 +22,13 @@ import org.graylog2.indexer.results.CountResult;
 import org.graylog2.indexer.searches.timeranges.TimeRange;
 import org.graylog2.plugin.Tools;
 import org.graylog2.plugin.alarms.AlertCondition;
-import org.junit.Ignore;
 import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.mockito.runners.MockitoJUnitRunner;
 
 import java.util.Map;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
-import static org.mockito.Mockito.any;
-import static org.mockito.Mockito.anyString;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.*;
 
-@Ignore
 public class MessageCountAlertConditionTest extends AlertConditionTest {
     protected final int threshold = 100;
 

--- a/graylog2-server/src/test/java/org/graylog2/alerts/types/MessageCountAlertConditionTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/alerts/types/MessageCountAlertConditionTest.java
@@ -26,8 +26,16 @@ import org.junit.Test;
 
 import java.util.Map;
 
-import static org.junit.Assert.*;
-import static org.mockito.Mockito.*;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 public class MessageCountAlertConditionTest extends AlertConditionTest {
     protected final int threshold = 100;


### PR DESCRIPTION
 - use a spy on AlertService
 - fix non-null value being returned by mocked object
 - constructors need Searches instance

fixes #1159