### PR TITLE
Also cleanup input metrics if an input is stopped.

### DIFF
--- a/graylog2-plugin-interfaces/src/main/java/org/graylog2/plugin/inputs/MessageInput.java
+++ b/graylog2-plugin-interfaces/src/main/java/org/graylog2/plugin/inputs/MessageInput.java
@@ -163,9 +163,14 @@ public abstract class MessageInput implements Stoppable {
 
     public void stop() {
         transport.stop();
+        cleanupMetrics();
     }
 
     public void terminate() {
+        cleanupMetrics();
+    }
+
+    private void cleanupMetrics() {
         if (localRegistry != null && localRegistry.getMetrics() != null)
             for (String metricName : localRegistry.getMetrics().keySet())
                 metricRegistry.remove(getUniqueReadableId() + "." + metricName);
@@ -182,8 +187,6 @@ public abstract class MessageInput implements Stoppable {
     public Descriptor getDescriptor() {
         return descriptor;
     }
-
-    ;
 
     public String getName() {
         return descriptor.getName();


### PR DESCRIPTION
Otherwise it would leave old metrics references for the input in the global metrics registry.

This resulted in a bug where the input metrics haven't been updated when an input was started again.