### PR TITLE
Allow Message.RESERVED_SETTABLE_FIELDS fields set by a GELF message.

### DIFF
--- a/graylog2-inputs/src/main/java/org/graylog2/inputs/codecs/GelfCodec.java
+++ b/graylog2-inputs/src/main/java/org/graylog2/inputs/codecs/GelfCodec.java
@@ -178,7 +178,7 @@ public class GelfCodec extends AbstractCodec {
             }
 
             // Skip standard or already set fields.
-            if (message.getField(key) != null || Message.RESERVED_FIELDS.contains(key)) {
+            if (message.getField(key) != null || (Message.RESERVED_FIELDS.contains(key) && !Message.RESERVED_SETTABLE_FIELDS.contains(key))) {
                 continue;
             }
 


### PR DESCRIPTION
Without this, fields set by the collector ("gl2_source_collector") will get lost.

Fixes Graylog2/graylog2-web-interface#1334