### PR TITLE
Make MongoDB hostInfo, serverStatus, and dbStats optional

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/system/stats/mongo/MongoProbe.java
+++ b/graylog2-server/src/main/java/org/graylog2/system/stats/mongo/MongoProbe.java
@@ -16,6 +16,7 @@
  */
 package org.graylog2.system.stats.mongo;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.Lists;
 import com.google.common.net.HostAndPort;
 import com.mongodb.BasicDBObject;
@@ -25,33 +26,46 @@ import com.mongodb.Mongo;
 import com.mongodb.ServerAddress;
 import org.graylog2.database.MongoConnection;
 import org.joda.time.DateTime;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import javax.inject.Inject;
 import javax.inject.Singleton;
 import java.util.List;
 
+import static com.google.common.base.Preconditions.checkNotNull;
+
 @Singleton
 public class MongoProbe {
-    private final MongoConnection mongoConnection;
+    private static final Logger LOG = LoggerFactory.getLogger(MongoProbe.class);
+
     private final Mongo mongoClient;
     private final DB db;
     private final DB adminDb;
     private final BuildInfo buildInfo;
     private final HostInfo hostInfo;
 
-
     @Inject
     public MongoProbe(MongoConnection mongoConnection) {
-        this.mongoConnection = mongoConnection;
-        this.mongoClient = mongoConnection.connect();
-        this.db = mongoConnection.getDatabase();
-        this.adminDb = mongoClient.getDB("admin");
-
-        this.buildInfo = createBuildInfo();
-        this.hostInfo = createHostInfo();
+        this(mongoConnection.connect(), mongoConnection.getDatabase());
     }
 
-    private HostInfo createHostInfo() {
+    @VisibleForTesting
+    MongoProbe(Mongo mongoClient, DB db) {
+        this(mongoClient, db, mongoClient.getDB("admin"),
+                createBuildInfo(mongoClient.getDB("admin")), createHostInfo(mongoClient.getDB("admin")));
+    }
+
+    @VisibleForTesting
+    MongoProbe(Mongo mongoClient, DB db, DB adminDB, BuildInfo buildInfo, HostInfo hostInfo) {
+        this.mongoClient = checkNotNull(mongoClient);
+        this.db = checkNotNull(db);
+        this.adminDb = checkNotNull(adminDB);
+        this.buildInfo = buildInfo;
+        this.hostInfo = hostInfo;
+    }
+
+    private static HostInfo createHostInfo(DB adminDb) {
         final HostInfo hostInfo;
         final CommandResult hostInfoResult = adminDb.command("hostInfo");
         if (hostInfoResult.ok()) {
@@ -87,13 +101,14 @@ public class MongoProbe {
 
             hostInfo = HostInfo.create(system, os, extra);
         } else {
+            LOG.debug("Couldn't retrieve MongoDB hostInfo: {}", hostInfoResult.getErrorMessage());
             hostInfo = null;
         }
 
         return hostInfo;
     }
 
-    private BuildInfo createBuildInfo() {
+    private static BuildInfo createBuildInfo(DB adminDb) {
         final BuildInfo buildInfo;
         final CommandResult buildInfoResult = adminDb.command("buildInfo");
         if (buildInfoResult.ok()) {
@@ -112,6 +127,7 @@ public class MongoProbe {
 
             );
         } else {
+            LOG.debug("Couldn't retrieve MongoDB buildInfo: {}", buildInfoResult.getErrorMessage());
             buildInfo = null;
         }
 
@@ -166,6 +182,7 @@ public class MongoProbe {
                     dataFileVersion
             );
         } else {
+            LOG.debug("Couldn't retrieve MongoDB dbStats: {}", dbStatsResult.getErrorMessage());
             dbStats = null;
         }
 
@@ -218,12 +235,11 @@ public class MongoProbe {
                     memory,
                     storageEngine);
         } else {
+            LOG.debug("Couldn't retrieve MongoDB serverStatus: {}", serverStatusResult.getErrorMessage());
             serverStatus = null;
         }
 
-
         // TODO Collection stats? http://docs.mongodb.org/manual/reference/command/collStats/
-
         return MongoStats.create(servers, buildInfo, hostInfo, serverStatus, dbStats);
     }
 }

--- a/graylog2-server/src/main/java/org/graylog2/system/stats/mongo/MongoStats.java
+++ b/graylog2-server/src/main/java/org/graylog2/system/stats/mongo/MongoStats.java
@@ -21,6 +21,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.auto.value.AutoValue;
 import com.google.common.net.HostAndPort;
 
+import javax.annotation.Nullable;
 import java.util.List;
 
 @JsonAutoDetect
@@ -33,19 +34,22 @@ public abstract class MongoStats {
     public abstract BuildInfo buildInfo();
 
     @JsonProperty
+    @Nullable
     public abstract HostInfo hostInfo();
 
     @JsonProperty
+    @Nullable
     public abstract ServerStatus serverStatus();
 
     @JsonProperty
+    @Nullable
     public abstract DatabaseStats databaseStats();
 
     public static MongoStats create(List<HostAndPort> servers,
                                     BuildInfo buildInfo,
-                                    HostInfo hostInfo,
-                                    ServerStatus serverStatus,
-                                    DatabaseStats databaseStats) {
+                                    @Nullable HostInfo hostInfo,
+                                    @Nullable ServerStatus serverStatus,
+                                    @Nullable DatabaseStats databaseStats) {
         return new AutoValue_MongoStats(servers, buildInfo, hostInfo, serverStatus, databaseStats);
     }
 }


### PR DESCRIPTION
The MongoDB "hostInfo", "serverStatus", and "dbStats" commands can only be executed
by an admin user and will fail if an unprivileged user will run them.

Fixes #1195