### PR TITLE
Change write concern for cluster related entities to FSYNCED

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/cluster/ClusterConfigServiceImpl.java
+++ b/graylog2-server/src/main/java/org/graylog2/cluster/ClusterConfigServiceImpl.java
@@ -75,7 +75,7 @@ public class ClusterConfigServiceImpl implements ClusterConfigService {
     static DBCollection prepareCollection(final MongoConnection mongoConnection) {
         DBCollection coll = mongoConnection.getDatabase().getCollection(COLLECTION_NAME);
         coll.createIndex(DBSort.asc("type"), "unique_type", true);
-        coll.setWriteConcern(WriteConcern.MAJORITY);
+        coll.setWriteConcern(WriteConcern.FSYNCED);
 
         return coll;
     }
@@ -121,7 +121,7 @@ public class ClusterConfigServiceImpl implements ClusterConfigService {
         String canonicalClassName = AutoValueUtils.getCanonicalName(payload.getClass());
         ClusterConfig clusterConfig = ClusterConfig.create(canonicalClassName, payload, nodeId.toString());
 
-        dbCollection.update(DBQuery.is("type", canonicalClassName), clusterConfig, true, false, WriteConcern.MAJORITY);
+        dbCollection.update(DBQuery.is("type", canonicalClassName), clusterConfig, true, false, WriteConcern.FSYNCED);
 
         ClusterConfigChangedEvent event = ClusterConfigChangedEvent.create(
                 DateTime.now(DateTimeZone.UTC), nodeId.toString(), canonicalClassName);

--- a/graylog2-server/src/main/java/org/graylog2/events/ClusterEventCleanupPeriodical.java
+++ b/graylog2-server/src/main/java/org/graylog2/events/ClusterEventCleanupPeriodical.java
@@ -104,7 +104,7 @@ public class ClusterEventCleanupPeriodical extends Periodical {
 
             final long timestamp = DateTime.now(DateTimeZone.UTC).getMillis() - maxEventAge;
             final DBQuery.Query query = DBQuery.lessThan("timestamp", timestamp);
-            final WriteResult<ClusterEvent, String> writeResult = dbCollection.remove(query, WriteConcern.MAJORITY);
+            final WriteResult<ClusterEvent, String> writeResult = dbCollection.remove(query, WriteConcern.FSYNCED);
 
             LOG.debug("Removed {} stale events from \"{}\"", writeResult.getN(), COLLECTION_NAME);
         } catch (Exception e) {

--- a/graylog2-server/src/main/java/org/graylog2/events/ClusterEventPeriodical.java
+++ b/graylog2-server/src/main/java/org/graylog2/events/ClusterEventPeriodical.java
@@ -95,7 +95,7 @@ public class ClusterEventPeriodical extends Periodical {
                 .asc("producer")
                 .asc("consumers"));
 
-        coll.setWriteConcern(WriteConcern.MAJORITY);
+        coll.setWriteConcern(WriteConcern.FSYNCED);
 
         return coll;
     }
@@ -180,7 +180,7 @@ public class ClusterEventPeriodical extends Periodical {
         final ClusterEvent clusterEvent = ClusterEvent.create(nodeId.toString(), className, event);
 
         try {
-            final String id = dbCollection.save(clusterEvent).getSavedId();
+            final String id = dbCollection.save(clusterEvent, WriteConcern.FSYNCED).getSavedId();
             LOG.debug("Published cluster event with ID <{}> and type <{}>", id, className);
         } catch (MongoException e) {
             LOG.error("Couldn't publish cluster event of type <" + className + ">", e);

--- a/graylog2-server/src/test/java/org/graylog2/cluster/ClusterConfigServiceImplTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/cluster/ClusterConfigServiceImplTest.java
@@ -299,7 +299,7 @@ public class ClusterConfigServiceImplTest {
         DBCollection collection = ClusterConfigServiceImpl.prepareCollection(mongoConnection);
         assertThat(collection.getName()).isEqualTo(COLLECTION_NAME);
         assertThat(collection.getIndexInfo()).hasSize(2);
-        assertThat(collection.getWriteConcern()).isEqualTo(WriteConcern.MAJORITY);
+        assertThat(collection.getWriteConcern()).isEqualTo(WriteConcern.FSYNCED);
     }
 
     @Test
@@ -310,7 +310,7 @@ public class ClusterConfigServiceImplTest {
 
         assertThat(collection.getName()).isEqualTo(COLLECTION_NAME);
         assertThat(collection.getIndexInfo()).hasSize(2);
-        assertThat(collection.getWriteConcern()).isEqualTo(WriteConcern.MAJORITY);
+        assertThat(collection.getWriteConcern()).isEqualTo(WriteConcern.FSYNCED);
     }
 
     public static class ClusterConfigChangedEventHandler {

--- a/graylog2-server/src/test/java/org/graylog2/events/ClusterEventPeriodicalTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/events/ClusterEventPeriodicalTest.java
@@ -304,7 +304,7 @@ public class ClusterEventPeriodicalTest {
         DBCollection collection = ClusterEventPeriodical.prepareCollection(mongoConnection);
         assertThat(collection.getName()).isEqualTo(ClusterEventPeriodical.COLLECTION_NAME);
         assertThat(collection.getIndexInfo()).hasSize(2);
-        assertThat(collection.getWriteConcern()).isEqualTo(WriteConcern.MAJORITY);
+        assertThat(collection.getWriteConcern()).isEqualTo(WriteConcern.FSYNCED);
     }
 
     @Test
@@ -315,7 +315,7 @@ public class ClusterEventPeriodicalTest {
 
         assertThat(collection.getName()).isEqualTo(ClusterEventPeriodical.COLLECTION_NAME);
         assertThat(collection.getIndexInfo()).hasSize(2);
-        assertThat(collection.getWriteConcern()).isEqualTo(WriteConcern.MAJORITY);
+        assertThat(collection.getWriteConcern()).isEqualTo(WriteConcern.FSYNCED);
     }
 
     public static class SimpleEventHandler {


### PR DESCRIPTION
The semantics of WriteConcern.MAJORITY have been changed in MongoDB 2.6. Prior
to that version, this write concern produces an error in non-replica set setups.

Since the cluster config and cluster event collections aren't heavily used in
Graylog, it's safe to use the WriteConcern.FSYNCED (i. e. highest guarantee for
writing to master node) for mutating operations on those.

Fixes #1138