### PR TITLE
Unbreak index range calculation

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/indexer/searches/Searches.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/searches/Searches.java
@@ -485,10 +485,6 @@ public class Searches {
     }
 
     public SearchHit firstOfIndex(String index) {
-        return oneOfIndex(index, matchAllQuery(), SortOrder.DESC);
-    }
-
-    public SearchHit lastOfIndex(String index) {
         return oneOfIndex(index, matchAllQuery(), SortOrder.ASC);
     }
 


### PR DESCRIPTION
When getting the first message timestamp of an index for the "start"
parameter of the index range with "Searches.firstOfIndex()", a DESC
sort order was used. So this was actually getting the last message
timestamp of an index, not the first.

Change "Searches.firstOfIndex()" to use ASC sort order to fix this.

Also remove unused "Searches.lastOfIndex()" method.