### PR TITLE
Address severe issues with AlarmCallbacks

### DIFF
--- a/graylog2-plugin-interfaces/src/main/java/org/graylog2/plugin/alarms/AlertCondition.java
+++ b/graylog2-plugin-interfaces/src/main/java/org/graylog2/plugin/alarms/AlertCondition.java
@@ -22,6 +22,8 @@
  */
 package org.graylog2.plugin.alarms;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import org.graylog2.plugin.Message;
 import org.graylog2.plugin.MessageSummary;
 import org.graylog2.plugin.streams.Stream;
 import org.joda.time.DateTime;
@@ -34,6 +36,15 @@ import java.util.Map;
  */
 public interface AlertCondition {
     String getDescription();
+
+    /**
+      * The limited list of internal message objects that matched the alert.
+      * @see org.graylog2.plugin.alarms.AlertCondition.CheckResult#getMatchingMessages()
+      * @return list of Message objects
+      */
+    @Deprecated
+    @JsonIgnore
+    List<Message> getSearchHits();
 
     String getId();
 

--- a/graylog2-plugin-interfaces/src/main/java/org/graylog2/plugin/configuration/Configuration.java
+++ b/graylog2-plugin-interfaces/src/main/java/org/graylog2/plugin/configuration/Configuration.java
@@ -80,6 +80,11 @@ public class Configuration {
         if (m != null) {
             for(Map.Entry<String, Object> e : m.entrySet()) {
                 try {
+                    if (e.getValue() == null) {
+                        LOG.debug("NULL value in configuration key <{}>", e.getKey());
+                        continue;
+                    }
+
                     if (e.getValue() instanceof String) {
                         strings.put(e.getKey(), (String) e.getValue());
                     } else if (e.getValue() instanceof Integer) {

--- a/graylog2-server/src/main/java/org/graylog2/alerts/AbstractAlertCondition.java
+++ b/graylog2-server/src/main/java/org/graylog2/alerts/AbstractAlertCondition.java
@@ -19,7 +19,6 @@ package org.graylog2.alerts;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Lists;
-import org.graylog2.plugin.Message;
 import org.graylog2.plugin.MessageSummary;
 import org.graylog2.plugin.Tools;
 import org.graylog2.plugin.alarms.AlertCondition;

--- a/graylog2-server/src/main/java/org/graylog2/alerts/AbstractAlertCondition.java
+++ b/graylog2-server/src/main/java/org/graylog2/alerts/AbstractAlertCondition.java
@@ -19,6 +19,7 @@ package org.graylog2.alerts;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Lists;
+import org.graylog2.plugin.Message;
 import org.graylog2.plugin.MessageSummary;
 import org.graylog2.plugin.Tools;
 import org.graylog2.plugin.alarms.AlertCondition;

--- a/graylog2-server/src/main/java/org/graylog2/alerts/types/DummyAlertCondition.java
+++ b/graylog2-server/src/main/java/org/graylog2/alerts/types/DummyAlertCondition.java
@@ -22,6 +22,7 @@ import org.graylog2.plugin.Tools;
 import org.graylog2.plugin.streams.Stream;
 import org.joda.time.DateTime;
 
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
@@ -47,7 +48,7 @@ public class DummyAlertCondition extends AbstractAlertCondition {
 
     @Override
     public List<Message> getSearchHits() {
-        return null;
+        return Collections.EMPTY_LIST;
     }
 
 }

--- a/graylog2-server/src/main/java/org/graylog2/alerts/types/DummyAlertCondition.java
+++ b/graylog2-server/src/main/java/org/graylog2/alerts/types/DummyAlertCondition.java
@@ -26,9 +26,6 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
-/**
- * @author Dennis Oelkers <dennis@torch.sh>
- */
 public class DummyAlertCondition extends AbstractAlertCondition {
     final String description = "Dummy alert to test notifications";
 
@@ -48,7 +45,7 @@ public class DummyAlertCondition extends AbstractAlertCondition {
 
     @Override
     public List<Message> getSearchHits() {
-        return Collections.EMPTY_LIST;
+        return Collections.emptyList();
     }
 
 }

--- a/graylog2-server/src/main/java/org/graylog2/alerts/types/DummyAlertCondition.java
+++ b/graylog2-server/src/main/java/org/graylog2/alerts/types/DummyAlertCondition.java
@@ -17,10 +17,12 @@
 package org.graylog2.alerts.types;
 
 import org.graylog2.alerts.AbstractAlertCondition;
+import org.graylog2.plugin.Message;
 import org.graylog2.plugin.Tools;
 import org.graylog2.plugin.streams.Stream;
 import org.joda.time.DateTime;
 
+import java.util.List;
 import java.util.Map;
 
 /**
@@ -42,4 +44,10 @@ public class DummyAlertCondition extends AbstractAlertCondition {
     public CheckResult runCheck() {
         return new CheckResult(true, this, this.description, Tools.iso8601(), null);
     }
+
+    @Override
+    public List<Message> getSearchHits() {
+        return null;
+    }
+
 }

--- a/graylog2-server/src/main/java/org/graylog2/alerts/types/FieldContentValueAlertCondition.java
+++ b/graylog2-server/src/main/java/org/graylog2/alerts/types/FieldContentValueAlertCondition.java
@@ -49,6 +49,7 @@ public class FieldContentValueAlertCondition extends AbstractAlertCondition {
     private final Configuration configuration;
     private final String field;
     private final String value;
+    private List<Message> searchHits = Lists.newArrayList();
 
     public interface Factory {
         FieldContentValueAlertCondition createAlertCondition(Stream stream, String id, DateTime createdAt, @Assisted("userid") String creatorUserId, Map<String, Object> parameters);
@@ -91,6 +92,7 @@ public class FieldContentValueAlertCondition extends AbstractAlertCondition {
                 summaries = Lists.newArrayListWithCapacity(result.getResults().size());
                 for (ResultMessage resultMessage : result.getResults()) {
                     final Message msg = new Message(resultMessage.getMessage());
+                    searchHits.add(msg);
                     summaries.add(new MessageSummary(resultMessage.getIndex(), msg));
                 }
             } else {
@@ -123,5 +125,10 @@ public class FieldContentValueAlertCondition extends AbstractAlertCondition {
     @Override
     public String getDescription() {
         return "field: " + field + ", value: " + value;
+    }
+
+    @Override
+    public List<Message> getSearchHits() {
+        return searchHits;
     }
 }

--- a/graylog2-server/src/main/java/org/graylog2/alerts/types/FieldContentValueAlertCondition.java
+++ b/graylog2-server/src/main/java/org/graylog2/alerts/types/FieldContentValueAlertCondition.java
@@ -17,7 +17,6 @@
 
 package org.graylog2.alerts.types;
 
-import autovalue.shaded.com.google.common.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
 import com.google.inject.assistedinject.Assisted;
 import com.google.inject.assistedinject.AssistedInject;

--- a/graylog2-server/src/main/java/org/graylog2/alerts/types/FieldContentValueAlertCondition.java
+++ b/graylog2-server/src/main/java/org/graylog2/alerts/types/FieldContentValueAlertCondition.java
@@ -17,6 +17,7 @@
 
 package org.graylog2.alerts.types;
 
+import autovalue.shaded.com.google.common.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
 import com.google.inject.assistedinject.Assisted;
 import com.google.inject.assistedinject.AssistedInject;
@@ -129,6 +130,6 @@ public class FieldContentValueAlertCondition extends AbstractAlertCondition {
 
     @Override
     public List<Message> getSearchHits() {
-        return searchHits;
+        return Lists.newArrayList(searchHits);
     }
 }

--- a/graylog2-server/src/main/java/org/graylog2/alerts/types/FieldValueAlertCondition.java
+++ b/graylog2-server/src/main/java/org/graylog2/alerts/types/FieldValueAlertCondition.java
@@ -62,6 +62,7 @@ public class FieldValueAlertCondition extends AbstractAlertCondition {
     private final String field;
     private final DecimalFormat decimalFormat;
     private final Searches searches;
+    private List<Message> searchHits = Lists.newArrayList();
 
     @AssistedInject
     public FieldValueAlertCondition(Searches searches, @Assisted Stream stream, @Nullable @Assisted String id, @Assisted DateTime createdAt, @Assisted("userid") String creatorUserId, @Assisted Map<String, Object> parameters) {
@@ -86,6 +87,7 @@ public class FieldValueAlertCondition extends AbstractAlertCondition {
                 + ", threshold: " + decimalFormat.format(threshold)
                 + ", grace: " + grace;
     }
+
 
     @Override
     protected CheckResult runCheck() {
@@ -148,10 +150,11 @@ public class FieldValueAlertCondition extends AbstractAlertCondition {
 
                 final List<MessageSummary> summaries;
                 if (getBacklog() > 0) {
-                    final List<ResultMessage> searchHits = fieldStatsResult.getSearchHits();
-                    summaries = Lists.newArrayListWithCapacity(searchHits.size());
-                    for (ResultMessage resultMessage : searchHits) {
+                    final List<ResultMessage> searchResult = fieldStatsResult.getSearchHits();
+                    summaries = Lists.newArrayListWithCapacity(searchResult.size());
+                    for (ResultMessage resultMessage : searchResult) {
                         final Message msg = new Message(resultMessage.getMessage());
+                        this.searchHits.add(msg);
                         summaries.add(new MessageSummary(resultMessage.getIndex(), msg));
                     }
                 } else {
@@ -174,5 +177,10 @@ public class FieldValueAlertCondition extends AbstractAlertCondition {
             LOG.debug("Field [{}] seems not to have a numerical type or doesn't even exist at all. Returning not triggered.", field, e);
             return new NegativeCheckResult(this);
         }
+    }
+
+    @Override
+    public List<Message> getSearchHits() {
+        return searchHits;
     }
 }

--- a/graylog2-server/src/main/java/org/graylog2/alerts/types/FieldValueAlertCondition.java
+++ b/graylog2-server/src/main/java/org/graylog2/alerts/types/FieldValueAlertCondition.java
@@ -16,7 +16,6 @@
  */
 package org.graylog2.alerts.types;
 
-import autovalue.shaded.com.google.common.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
 import com.google.inject.assistedinject.Assisted;
 import com.google.inject.assistedinject.AssistedInject;
@@ -37,7 +36,6 @@ import org.slf4j.LoggerFactory;
 
 import javax.annotation.Nullable;
 import java.text.DecimalFormat;
-import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;

--- a/graylog2-server/src/main/java/org/graylog2/alerts/types/FieldValueAlertCondition.java
+++ b/graylog2-server/src/main/java/org/graylog2/alerts/types/FieldValueAlertCondition.java
@@ -16,6 +16,7 @@
  */
 package org.graylog2.alerts.types;
 
+import autovalue.shaded.com.google.common.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
 import com.google.inject.assistedinject.Assisted;
 import com.google.inject.assistedinject.AssistedInject;
@@ -36,6 +37,7 @@ import org.slf4j.LoggerFactory;
 
 import javax.annotation.Nullable;
 import java.text.DecimalFormat;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -181,6 +183,6 @@ public class FieldValueAlertCondition extends AbstractAlertCondition {
 
     @Override
     public List<Message> getSearchHits() {
-        return searchHits;
+        return Lists.newArrayList(searchHits);
     }
 }

--- a/graylog2-server/src/main/java/org/graylog2/alerts/types/MessageCountAlertCondition.java
+++ b/graylog2-server/src/main/java/org/graylog2/alerts/types/MessageCountAlertCondition.java
@@ -124,4 +124,10 @@ public class MessageCountAlertCondition extends AbstractAlertCondition {
             return null;
         }
     }
+
+    @Override
+    public List<Message> getSearchHits() {
+        return this.searchHits;
+    }
+
 }

--- a/graylog2-server/src/main/java/org/graylog2/alerts/types/MessageCountAlertCondition.java
+++ b/graylog2-server/src/main/java/org/graylog2/alerts/types/MessageCountAlertCondition.java
@@ -127,7 +127,7 @@ public class MessageCountAlertCondition extends AbstractAlertCondition {
 
     @Override
     public List<Message> getSearchHits() {
-        return this.searchHits;
+        return Lists.newArrayList(searchHits);
     }
 
 }

--- a/graylog2-server/src/test/java/org/graylog2/alerts/AbstractAlertConditionTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/alerts/AbstractAlertConditionTest.java
@@ -16,12 +16,14 @@
  */
 package org.graylog2.alerts;
 
+import org.graylog2.plugin.Message;
 import org.graylog2.plugin.Tools;
 import org.graylog2.plugin.alarms.AlertCondition;
 import org.junit.Before;
 import org.junit.Ignore;
 import org.junit.Test;
 
+import java.util.List;
 import java.util.Map;
 
 import static org.junit.Assert.assertFalse;
@@ -71,6 +73,11 @@ public class AbstractAlertConditionTest extends AlertConditionTest {
 
             @Override
             protected AlertCondition.CheckResult runCheck() {
+                return null;
+            }
+
+            @Override
+            public List<Message> getSearchHits() {
                 return null;
             }
         };


### PR DESCRIPTION
This PR fixes #1221 and #1222. Please review and merge.

I thoroughly tested with all alert condition types triggering the Slack alarm callback plugin and the PagerDuty alarm callback plugin.

(this is a replacement for #1223 which was accidentally issued against `master`)