### PR TITLE
Add Jersey filter which adds the node ID on HTTP responses

### DIFF
--- a/graylog2-shared/src/main/java/org/graylog2/shared/initializers/RestApiService.java
+++ b/graylog2-shared/src/main/java/org/graylog2/shared/initializers/RestApiService.java
@@ -33,6 +33,7 @@ import org.graylog2.jersey.container.netty.SecurityContextFactory;
 import org.graylog2.plugin.BaseConfiguration;
 import org.graylog2.plugin.rest.PluginRestResource;
 import org.graylog2.shared.rest.CORSFilter;
+import org.graylog2.shared.rest.NodeIdResponseFilter;
 import org.graylog2.shared.rest.PrintModelProcessor;
 import org.graylog2.shared.rest.exceptionmappers.AnyExceptionClassMapper;
 import org.graylog2.shared.rest.exceptionmappers.JacksonPropertyExceptionMapper;
@@ -281,7 +282,8 @@ public class RestApiService extends AbstractIdleService {
                     }
                 })
                 .registerFinder(new PackageNamesScanner(restControllerPackages, true))
-                .registerResources(additionalResources);
+                .registerResources(additionalResources)
+                .register(NodeIdResponseFilter.class);
 
         for (Class<? extends ExceptionMapper> exceptionMapper : exceptionMappers) {
             rc.registerClasses(exceptionMapper);

--- a/graylog2-shared/src/main/java/org/graylog2/shared/rest/NodeIdResponseFilter.java
+++ b/graylog2-shared/src/main/java/org/graylog2/shared/rest/NodeIdResponseFilter.java
@@ -1,0 +1,41 @@
+/**
+ * This file is part of Graylog.
+ *
+ * Graylog is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.graylog2.shared.rest;
+
+import org.graylog2.plugin.system.NodeId;
+
+import javax.inject.Inject;
+import javax.ws.rs.container.ContainerRequestContext;
+import javax.ws.rs.container.ContainerResponseContext;
+import javax.ws.rs.container.ContainerResponseFilter;
+import java.io.IOException;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+public class NodeIdResponseFilter implements ContainerResponseFilter {
+    private final NodeId nodeId;
+
+    @Inject
+    public NodeIdResponseFilter(NodeId nodeId) {
+        this.nodeId = checkNotNull(nodeId);
+    }
+
+    @Override
+    public void filter(ContainerRequestContext requestContext, ContainerResponseContext responseContext) throws IOException {
+        responseContext.getHeaders().add("X-Graylog-Node-ID", nodeId.toString());
+    }
+}


### PR DESCRIPTION
Knowing exactly which node sent a response might be useful in an environment
with multiple Graylog nodes behind a load-balancer.

Vaguely refs #1184