### PR TITLE
Global timeout for Elasticsearch operations

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/bindings/providers/EsClientProvider.java
+++ b/graylog2-server/src/main/java/org/graylog2/bindings/providers/EsClientProvider.java
@@ -16,24 +16,29 @@
  */
 package org.graylog2.bindings.providers;
 
+import com.github.joschi.jadconfig.util.Duration;
 import org.elasticsearch.client.Client;
 import org.elasticsearch.node.Node;
+import org.graylog2.indexer.elasticsearch.GlobalTimeoutClient;
 
 import javax.inject.Inject;
+import javax.inject.Named;
 import javax.inject.Provider;
 import javax.inject.Singleton;
 
 @Singleton
 public class EsClientProvider implements Provider<Client> {
     private final Node node;
+    private final Duration requestTimeout;
 
     @Inject
-    public EsClientProvider(Node node) {
+    public EsClientProvider(Node node, @Named("elasticsearch_request_timeout") Duration requestTimeout) {
         this.node = node;
+        this.requestTimeout = requestTimeout;
     }
 
     @Override
     public Client get() {
-        return node.client();
+        return new GlobalTimeoutClient(node.client(), requestTimeout.getQuantity(), requestTimeout.getUnit());
     }
 }

--- a/graylog2-server/src/main/java/org/graylog2/configuration/ElasticsearchConfiguration.java
+++ b/graylog2-server/src/main/java/org/graylog2/configuration/ElasticsearchConfiguration.java
@@ -124,7 +124,7 @@ public class ElasticsearchConfiguration {
     private boolean storeTimestampsAsDocValues = true;
 
     @Parameter(value = "elasticsearch_request_timeout", validator = PositiveDurationValidator.class)
-    private Duration requestTimeout = Duration.seconds(30L);
+    private Duration requestTimeout = Duration.minutes(1L);
 
     public String getClusterName() {
         return clusterName;

--- a/graylog2-server/src/main/java/org/graylog2/configuration/ElasticsearchConfiguration.java
+++ b/graylog2-server/src/main/java/org/graylog2/configuration/ElasticsearchConfiguration.java
@@ -18,8 +18,10 @@ package org.graylog2.configuration;
 
 import com.github.joschi.jadconfig.Parameter;
 import com.github.joschi.jadconfig.converters.StringListConverter;
+import com.github.joschi.jadconfig.util.Duration;
 import com.github.joschi.jadconfig.validators.FileReadableValidator;
 import com.github.joschi.jadconfig.validators.InetPortValidator;
+import com.github.joschi.jadconfig.validators.PositiveDurationValidator;
 import com.github.joschi.jadconfig.validators.PositiveIntegerValidator;
 import com.github.joschi.jadconfig.validators.PositiveLongValidator;
 import org.joda.time.Period;
@@ -120,6 +122,9 @@ public class ElasticsearchConfiguration {
 
     @Parameter(value = "elasticsearch_store_timestamps_as_doc_values")
     private boolean storeTimestampsAsDocValues = true;
+
+    @Parameter(value = "elasticsearch_request_timeout", validator = PositiveDurationValidator.class)
+    private Duration requestTimeout = Duration.seconds(30L);
 
     public String getClusterName() {
         return clusterName;
@@ -251,5 +256,9 @@ public class ElasticsearchConfiguration {
 
     public boolean isStoreTimestampsAsDocValues() {
         return storeTimestampsAsDocValues;
+    }
+
+    public Duration getRequestTimeout() {
+        return requestTimeout;
     }
 }

--- a/graylog2-server/src/main/java/org/graylog2/indexer/elasticsearch/GlobalTimeoutClient.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/elasticsearch/GlobalTimeoutClient.java
@@ -1,0 +1,207 @@
+/**
+ * This file is part of Graylog.
+ *
+ * Graylog is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.graylog2.indexer.elasticsearch;
+
+import org.elasticsearch.ElasticsearchException;
+import org.elasticsearch.action.Action;
+import org.elasticsearch.action.ActionFuture;
+import org.elasticsearch.action.ActionRequest;
+import org.elasticsearch.action.ActionRequestBuilder;
+import org.elasticsearch.action.ActionResponse;
+import org.elasticsearch.client.AdminClient;
+import org.elasticsearch.client.Client;
+import org.elasticsearch.client.ClusterAdminClient;
+import org.elasticsearch.client.FilterClient;
+import org.elasticsearch.client.IndicesAdminClient;
+import org.elasticsearch.common.unit.TimeValue;
+
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.base.Preconditions.checkNotNull;
+
+public class GlobalTimeoutClient extends FilterClient {
+    private final long timeout;
+    private final TimeUnit unit;
+
+    public GlobalTimeoutClient(Client in, long timeout, TimeUnit unit) {
+        super(in);
+
+        checkArgument(timeout > 0);
+        this.timeout = timeout;
+        this.unit = checkNotNull(unit);
+    }
+
+    @Override
+    public <Request extends ActionRequest, Response extends ActionResponse, RequestBuilder extends ActionRequestBuilder<Request, Response, RequestBuilder, Client>> ActionFuture<Response> execute(Action<Request, Response, RequestBuilder, Client> action, Request request) {
+        return GlobalTimeoutActionFuture.create(super.execute(action, request), timeout, unit);
+    }
+
+    @Override
+    public ClusterAdminClient cluster() {
+        return new GlobalTimeoutClusterAdminClient(super.cluster(), timeout, unit);
+    }
+
+    @Override
+    public IndicesAdminClient indices() {
+        return new GlobalTimeoutIndicesAdminClient(super.indices(), timeout, unit);
+    }
+
+    @Override
+    public AdminClient admin() {
+        return new GlobalTimeoutAdminClient(super.admin(), timeout, unit);
+    }
+
+    public static class GlobalTimeoutAdminClient implements AdminClient {
+        private final AdminClient in;
+        private final long timeout;
+        private final TimeUnit unit;
+
+        public GlobalTimeoutAdminClient(AdminClient in, long timeout, TimeUnit unit) {
+            this.in = checkNotNull(in);
+
+            checkArgument(timeout > 0);
+            this.timeout = timeout;
+            this.unit = checkNotNull(unit);
+        }
+
+        @Override
+        public IndicesAdminClient indices() {
+            return new GlobalTimeoutIndicesAdminClient(in.indices(), timeout, unit);
+        }
+
+        @Override
+        public ClusterAdminClient cluster() {
+            return new GlobalTimeoutClusterAdminClient(in.cluster(), timeout, unit);
+        }
+    }
+
+    public static class GlobalTimeoutClusterAdminClient extends FilterClient.ClusterAdmin {
+        private final long timeout;
+        private final TimeUnit unit;
+
+        public GlobalTimeoutClusterAdminClient(ClusterAdminClient in, long timeout, TimeUnit unit) {
+            super(in);
+
+            checkArgument(timeout > 0);
+            this.timeout = timeout;
+            this.unit = checkNotNull(unit);
+        }
+
+        @Override
+        public <Request extends ActionRequest, Response extends ActionResponse, RequestBuilder extends ActionRequestBuilder<Request, Response, RequestBuilder, ClusterAdminClient>> ActionFuture<Response> execute(Action<Request, Response, RequestBuilder, ClusterAdminClient> action, Request request) {
+            return GlobalTimeoutActionFuture.create(super.execute(action, request), timeout, unit);
+        }
+    }
+
+    public static class GlobalTimeoutIndicesAdminClient extends FilterClient.IndicesAdmin {
+        private final long timeout;
+        private final TimeUnit unit;
+
+        public GlobalTimeoutIndicesAdminClient(IndicesAdminClient in, long timeout, TimeUnit unit) {
+            super(in);
+
+            checkArgument(timeout > 0);
+            this.timeout = timeout;
+            this.unit = checkNotNull(unit);
+        }
+
+        @Override
+        public <Request extends ActionRequest, Response extends ActionResponse, RequestBuilder extends ActionRequestBuilder<Request, Response, RequestBuilder, IndicesAdminClient>> ActionFuture<Response> execute(Action<Request, Response, RequestBuilder, IndicesAdminClient> action, Request request) {
+            return GlobalTimeoutActionFuture.create(super.execute(action, request), timeout, unit);
+        }
+    }
+
+    public static class GlobalTimeoutActionFuture<T> implements ActionFuture<T> {
+        private final ActionFuture<T> in;
+        private final long timeout;
+        private final TimeUnit unit;
+
+        private GlobalTimeoutActionFuture(ActionFuture<T> in, long timeout, TimeUnit unit) {
+            this.in = checkNotNull(in);
+
+            checkArgument(timeout > 0);
+            this.timeout = timeout;
+            this.unit = checkNotNull(unit);
+        }
+
+        public static <Response extends ActionResponse> GlobalTimeoutActionFuture<Response> create(ActionFuture<Response> actionFuture, long timeout, TimeUnit unit) {
+            return actionFuture == null ? null : new GlobalTimeoutActionFuture<>(actionFuture, timeout, unit);
+        }
+
+        @Override
+        public T actionGet() throws ElasticsearchException {
+            return in.actionGet(timeout, unit);
+        }
+
+        @Override
+        public T actionGet(String timeout) throws ElasticsearchException {
+            return in.actionGet(timeout);
+        }
+
+        @Override
+        public T actionGet(long timeoutMillis) throws ElasticsearchException {
+            return in.actionGet(timeoutMillis);
+        }
+
+        @Override
+        public T actionGet(long timeout, TimeUnit unit) throws ElasticsearchException {
+            return in.actionGet(timeout, unit);
+        }
+
+        @Override
+        public T actionGet(TimeValue timeout) throws ElasticsearchException {
+            return in.actionGet(timeout);
+        }
+
+        @Override
+        public Throwable getRootFailure() {
+            return in.getRootFailure();
+        }
+
+        @Override
+        public boolean cancel(boolean mayInterruptIfRunning) {
+            return in.cancel(mayInterruptIfRunning);
+        }
+
+        @Override
+        public boolean isCancelled() {
+            return in.isCancelled();
+        }
+
+        @Override
+        public boolean isDone() {
+            return in.isDone();
+        }
+
+        @Override
+        public T get() throws InterruptedException, ExecutionException {
+            try {
+                return in.get(timeout, unit);
+            } catch (TimeoutException e) {
+                throw new ExecutionException(e.getCause());
+            }
+        }
+
+        @Override
+        public T get(long timeout, TimeUnit unit) throws InterruptedException, ExecutionException, TimeoutException {
+            return in.get(timeout, unit);
+        }
+    }
+}

--- a/graylog2-server/src/main/java/org/graylog2/indexer/indices/Indices.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/indices/Indices.java
@@ -70,6 +70,7 @@ import javax.inject.Singleton;
 import java.util.Collections;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.TimeUnit;
 
 import static org.elasticsearch.index.query.QueryBuilders.matchAllQuery;
 
@@ -386,12 +387,12 @@ public class Indices implements IndexManagement {
 
     public void optimizeIndex(String index) {
         // http://www.elasticsearch.org/guide/reference/api/admin-indices-optimize/
-        OptimizeRequest or = new OptimizeRequest(index);
+        final OptimizeRequest or = new OptimizeRequest(index)
+                .maxNumSegments(configuration.getIndexOptimizationMaxNumSegments())
+                .onlyExpungeDeletes(false)
+                .flush(true);
 
-        or.maxNumSegments(configuration.getIndexOptimizationMaxNumSegments());
-        or.onlyExpungeDeletes(false);
-        or.flush(true);
-
-        c.admin().indices().optimize(or).actionGet();
+        // Using a specific timeout to override the global Elasticsearch request timeout
+        c.admin().indices().optimize(or).actionGet(1L, TimeUnit.HOURS);
     }
 }

--- a/misc/graylog2.conf
+++ b/misc/graylog2.conf
@@ -198,8 +198,8 @@ elasticsearch_analyzer = standard
 
 # Global request timeout for Elasticsearch requests (e. g. during search, index creation, or index time-range
 # calculations) based on a best-effort to restrict the runtime of Elasticsearch operations.
-# Default: 30s
-#elasticsearch_request_timeout = 30s
+# Default: 1m
+#elasticsearch_request_timeout = 1m
 
 # Batch size for the Elasticsearch output. This is the maximum (!) number of messages the Elasticsearch output
 # module will get at once and write to Elasticsearch in a batch call. If the configured batch size has not been

--- a/misc/graylog2.conf
+++ b/misc/graylog2.conf
@@ -196,6 +196,11 @@ elasticsearch_analyzer = standard
 # See http://www.elastic.co/guide/en/elasticsearch/guide/master/doc-values.html for details.
 #elasticsearch_store_timestamps_as_doc_values = true
 
+# Global request timeout for Elasticsearch requests (e. g. during search, index creation, or index time-range
+# calculations) based on a best-effort to restrict the runtime of Elasticsearch operations.
+# Default: 30s
+#elasticsearch_request_timeout = 30s
+
 # Batch size for the Elasticsearch output. This is the maximum (!) number of messages the Elasticsearch output
 # module will get at once and write to Elasticsearch in a batch call. If the configured batch size has not been
 # reached within output_flush_interval seconds, everything that is available will be flushed at once. Remember


### PR DESCRIPTION
This PR adds the `elasticsearch_request_timeout` setting for applying a global timeout to Elasticsearch operations (default: 30 seconds).

Fixes #1220