### PR TITLE
Fix NPE in ApiClientImpl

### DIFF
--- a/graylog2-rest-client/src/main/java/org/graylog2/restclient/lib/ApiClientImpl.java
+++ b/graylog2-rest-client/src/main/java/org/graylog2/restclient/lib/ApiClientImpl.java
@@ -603,6 +603,11 @@ class ApiClientImpl implements ApiClient {
                 final ListenableFuture<Response> future = context.listenableFuture;
                 try {
                     final Response response = future.get(timeoutValue, timeoutUnit);
+                    if(response == null) {
+                        LOG.error("Didn't receive response from node {}", node);
+                        node.markFailure();
+                        continue;
+                    }
                     node.touch();
                     final T result = handleResponse(context.request, response);
                     results.put(node, result);


### PR DESCRIPTION
The `Future<Response>` in `ApiClientImpl#executeOnAll()` might return `null` which isn't handled
by `ApiClientImpl#handleResponse()`. Instead of passing the null `Response`, we bail out before.

Example stack trace (gathered from a failed Travis CI run of graylog2-web-interface):
```
[error] Test lib.ServerNodesTest.testNodeObjectsRememberedByAddress failed: java.lang.NullPointerException: null, took 0.126 sec
[error]     at org.graylog2.restclient.lib.ApiClientImpl$ApiRequestBuilder.handleResponse(ApiClientImpl.java:466)
[error]     at org.graylog2.restclient.lib.ApiClientImpl$ApiRequestBuilder.executeOnAll(ApiClientImpl.java:607)
[error]     at lib.ServerNodesTest.testNodeObjectsRememberedByAddress(ServerNodesTest.java:114)
```