### PR TITLE
Silence Kafka log chatter.

### DIFF
--- a/graylog2-bootstrap/src/main/resources/log4j.xml
+++ b/graylog2-bootstrap/src/main/resources/log4j.xml
@@ -37,6 +37,13 @@
     <logger name="com.joestelmach.natty.Parser">
         <level value="warn"/>
     </logger>
+    <!-- Silence Kafka log chatter -->
+    <logger name="kafka.log.Log">
+        <level value="warn"/>
+    </logger>
+    <logger name="kafka.log.OffsetIndex">
+        <level value="warn"/>
+    </logger>
     <!-- Root Logger -->
     <root>
         <priority value="warn"/>


### PR DESCRIPTION
Removes log messages like the following.

```
2015-05-28 20:45:24,890 INFO : kafka.log.Log - Rolled new log segment for 'messagejournal-0' in 1 ms.
2015-05-28 20:45:39,282 INFO : kafka.log.Log - Scheduling log segment 24807828642 for log messagejournal-0 for deletion.
2015-05-28 20:45:39,283 INFO : kafka.log.Log - Scheduling log segment 24807961560 for log messagejournal-0 for deletion.
2015-05-28 20:45:39,284 INFO : kafka.log.Log - Deleting segment 24807695384 from log messagejournal-0.
2015-05-28 20:45:39,302 INFO : kafka.log.OffsetIndex - Deleting index /graylog-1.1.1/data/journal/messagejournal-0/00000000024807695384.index.deleted
```

A busy server will log lots of these.