### PR TITLE
allow users with stream:edit permissions to pause/resume streams

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/rest/resources/streams/StreamResource.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/resources/streams/StreamResource.java
@@ -230,7 +230,7 @@ public class StreamResource extends RestResource {
     })
     public void pause(@ApiParam(name = "streamId", required = true)
                       @PathParam("streamId") @NotEmpty String streamId) throws NotFoundException, ValidationException {
-        checkPermission(RestPermissions.STREAMS_CHANGESTATE, streamId);
+        checkAnyPermission(new String[]{RestPermissions.STREAMS_CHANGESTATE, RestPermissions.STREAMS_EDIT}, streamId);
 
         final Stream stream = streamService.load(streamId);
         streamService.pause(stream);
@@ -246,7 +246,7 @@ public class StreamResource extends RestResource {
     })
     public void resume(@ApiParam(name = "streamId", required = true)
                        @PathParam("streamId") @NotEmpty String streamId) throws NotFoundException, ValidationException {
-        checkPermission(RestPermissions.STREAMS_CHANGESTATE, streamId);
+        checkAnyPermission(new String[]{RestPermissions.STREAMS_CHANGESTATE, RestPermissions.STREAMS_EDIT}, streamId);
 
         final Stream stream = streamService.load(streamId);
         streamService.resume(stream);

--- a/graylog2-server/src/test/java/org/graylog2/rest/resources/RestResourceBaseTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/rest/resources/RestResourceBaseTest.java
@@ -17,11 +17,22 @@
 package org.graylog2.rest.resources;
 
 import com.google.inject.Module;
+import org.apache.shiro.subject.Subject;
 import org.assertj.core.util.Lists;
 import org.graylog2.shared.bindings.GuiceInjectorHolder;
+import org.graylog2.shared.rest.resources.RestResource;
 import org.junit.Before;
+import org.junit.Test;
+import org.mockito.ArgumentMatcher;
+import org.mockito.internal.matchers.VarargMatcher;
 
 import java.util.List;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Matchers.argThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 public class RestResourceBaseTest {
     @Before
@@ -29,5 +40,60 @@ public class RestResourceBaseTest {
         // The list of modules is empty for now so only JIT injection will be used.
         final List<Module> modules = Lists.emptyList();
         GuiceInjectorHolder.createInjector(modules);
+    }
+
+
+    @Test
+    public void testisAnyPermitted() {
+        final PermissionDeniedResource failingResource = new PermissionDeniedResource();
+        final AllPermissionsGrantedResource allGranted = new AllPermissionsGrantedResource();
+        final SomePermissionsGrantedResource someGranted = new SomePermissionsGrantedResource();
+
+        assertFalse("User doesn't have any permissions", failingResource.runCheck());
+        assertTrue("User has all permissions", allGranted.runCheck());
+        assertTrue("User has some permissions", someGranted.runCheck());
+    }
+
+    private static class PermissionDeniedResource extends RestResource {
+        @Override
+        protected Subject getSubject() {
+            final Subject mock = mock(Subject.class);
+            when(mock.isPermitted(argThat(new MyVarargMatcher()))).thenReturn(new boolean[]{false, false});
+            return mock;
+        }
+
+        public boolean runCheck() {
+            return isAnyPermitted(new String[]{"a:b", "a:c"}, "instance");
+        }
+    }
+    private static class AllPermissionsGrantedResource extends RestResource {
+        @Override
+        protected Subject getSubject() {
+            final Subject mock = mock(Subject.class);
+            when(mock.isPermitted(argThat(new MyVarargMatcher()))).thenReturn(new boolean[]{true, true});
+            return mock;
+        }
+
+        public boolean runCheck() {
+            return isAnyPermitted(new String[]{"a:b", "a:c"}, "instance");
+        }
+    }
+    private static class SomePermissionsGrantedResource extends RestResource {
+        @Override
+        protected Subject getSubject() {
+            final Subject mock = mock(Subject.class);
+            when(mock.isPermitted(argThat(new MyVarargMatcher()))).thenReturn(new boolean[]{false, true});
+            return mock;
+        }
+
+        public boolean runCheck() {
+            return isAnyPermitted(new String[]{"a:b", "a:c"}, "instance");
+        }
+    }
+
+    static class MyVarargMatcher extends ArgumentMatcher<String[]> implements VarargMatcher {
+        @Override public boolean matches(Object varargArgument) {
+            return /* does it match? */ true;
+        }
     }
 }

--- a/graylog2-shared/src/main/java/org/graylog2/shared/rest/resources/RestResource.java
+++ b/graylog2-shared/src/main/java/org/graylog2/shared/rest/resources/RestResource.java
@@ -23,7 +23,6 @@ import com.fasterxml.jackson.jaxrs.cfg.EndpointConfigBase;
 import com.fasterxml.jackson.jaxrs.cfg.ObjectWriterInjector;
 import com.fasterxml.jackson.jaxrs.cfg.ObjectWriterModifier;
 import com.google.common.base.Function;
-import com.google.common.base.Predicates;
 import com.google.common.collect.FluentIterable;
 import com.google.common.collect.Iterables;
 import org.apache.shiro.subject.Subject;
@@ -127,7 +126,12 @@ public abstract class RestResource {
 
     protected boolean isAnyPermitted(String... permissions) {
         final boolean[] permitted = getSubject().isPermitted(permissions);
-        return Iterables.any(Arrays.asList(permitted), Predicates.alwaysTrue());
+        for (boolean p : permitted) {
+            if (p) {
+                return true;
+            }
+        }
+        return false;
     }
 
     protected void checkAnyPermission(String permissions[], String instanceId) {

--- a/graylog2-shared/src/main/java/org/graylog2/shared/rest/resources/RestResource.java
+++ b/graylog2-shared/src/main/java/org/graylog2/shared/rest/resources/RestResource.java
@@ -22,14 +22,19 @@ import com.fasterxml.jackson.databind.ObjectWriter;
 import com.fasterxml.jackson.jaxrs.cfg.EndpointConfigBase;
 import com.fasterxml.jackson.jaxrs.cfg.ObjectWriterInjector;
 import com.fasterxml.jackson.jaxrs.cfg.ObjectWriterModifier;
+import com.google.common.base.Function;
+import com.google.common.base.Predicates;
+import com.google.common.collect.FluentIterable;
+import com.google.common.collect.Iterables;
 import org.apache.shiro.subject.Subject;
 import org.graylog2.plugin.BaseConfiguration;
-import org.graylog2.shared.security.ShiroSecurityContext;
 import org.graylog2.plugin.database.users.User;
+import org.graylog2.shared.security.ShiroSecurityContext;
 import org.graylog2.shared.users.UserService;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import javax.annotation.Nullable;
 import javax.inject.Inject;
 import javax.ws.rs.ForbiddenException;
 import javax.ws.rs.QueryParam;
@@ -39,6 +44,7 @@ import javax.ws.rs.core.SecurityContext;
 import javax.ws.rs.core.UriBuilder;
 import javax.ws.rs.core.UriInfo;
 import java.security.Principal;
+import java.util.Arrays;
 
 public abstract class RestResource {
     private static final Logger LOG = LoggerFactory.getLogger(RestResource.class);
@@ -103,6 +109,29 @@ public abstract class RestResource {
 
     protected void checkPermission(String permission, String instanceId) {
         if (!isPermitted(permission, instanceId)) {
+            throw new ForbiddenException("Not authorized to access resource id " + instanceId);
+        }
+    }
+
+    protected boolean isAnyPermitted(String[] permissions, final String instanceId) {
+        final Iterable<String> instancePermissions = Iterables.transform(Arrays.asList(permissions),
+                                                               new Function<String, String>() {
+                                                                   @Nullable
+                                                                   @Override
+                                                                   public String apply(String permission) {
+                                                                       return permission + ":" + instanceId;
+                                                                   }
+                                                               });
+        return isAnyPermitted(FluentIterable.from(instancePermissions).toArray(String.class));
+    }
+
+    protected boolean isAnyPermitted(String... permissions) {
+        final boolean[] permitted = getSubject().isPermitted(permissions);
+        return Iterables.any(Arrays.asList(permitted), Predicates.alwaysTrue());
+    }
+
+    protected void checkAnyPermission(String permissions[], String instanceId) {
+        if (!isAnyPermitted(permissions, instanceId)) {
             throw new ForbiddenException("Not authorized to access resource id " + instanceId);
         }
     }


### PR DESCRIPTION
extend the permission check methods to check for an array of possible permissions

this is in addition to the streams:changestate permission and requires the corresponding web-interface PR to be visible

fixes Graylog2/graylog2-web-interface#1456