### PR TITLE
Fix documentation links

### DIFF
--- a/graylog2-inputs/src/main/java/org/graylog2/inputs/gelf/kafka/GELFKafkaInput.java
+++ b/graylog2-inputs/src/main/java/org/graylog2/inputs/gelf/kafka/GELFKafkaInput.java
@@ -75,7 +75,7 @@ public class GELFKafkaInput extends MessageInput {
     public static class Descriptor extends MessageInput.Descriptor {
         @Inject
         public Descriptor() {
-            super(NAME, false, "https://www.graylog.org/documentation/sending/kafka/");
+            super(NAME, false, "");
         }
     }
 

--- a/graylog2-inputs/src/main/java/org/graylog2/inputs/kafka/KafkaInput.java
+++ b/graylog2-inputs/src/main/java/org/graylog2/inputs/kafka/KafkaInput.java
@@ -75,7 +75,7 @@ public class KafkaInput extends MessageInput {
     public static class Descriptor extends MessageInput.Descriptor {
         @Inject
         public Descriptor() {
-            super(NAME, false, "https://www.graylog.org/documentation/sending/kafka/");
+            super(NAME, false, "");
         }
     }
 

--- a/graylog2-inputs/src/main/java/org/graylog2/inputs/misc/jsonpath/JsonPathInput.java
+++ b/graylog2-inputs/src/main/java/org/graylog2/inputs/misc/jsonpath/JsonPathInput.java
@@ -17,15 +17,17 @@
 package org.graylog2.inputs.misc.jsonpath;
 
 import com.codahale.metrics.MetricRegistry;
-import javax.inject.Inject;
 import com.google.inject.assistedinject.Assisted;
 import com.google.inject.assistedinject.AssistedInject;
 import org.graylog2.inputs.codecs.JsonPathCodec;
 import org.graylog2.inputs.transports.HttpPollTransport;
+import org.graylog2.plugin.DocsHelper;
 import org.graylog2.plugin.LocalMetricRegistry;
 import org.graylog2.plugin.ServerStatus;
 import org.graylog2.plugin.configuration.Configuration;
 import org.graylog2.plugin.inputs.MessageInput;
+
+import javax.inject.Inject;
 
 public class JsonPathInput extends MessageInput {
 
@@ -55,7 +57,7 @@ public class JsonPathInput extends MessageInput {
     public static class Descriptor extends MessageInput.Descriptor {
         @Inject
         public Descriptor() {
-            super(NAME, false, "https://www.graylog.org/documentation/sending/jsonpath/");
+            super(NAME, false, DocsHelper.PAGE_SENDING_JSONPATH.toString());
         }
     }
 

--- a/graylog2-inputs/src/main/java/org/graylog2/inputs/raw/kafka/RawKafkaInput.java
+++ b/graylog2-inputs/src/main/java/org/graylog2/inputs/raw/kafka/RawKafkaInput.java
@@ -75,7 +75,7 @@ public class RawKafkaInput extends MessageInput {
     public static class Descriptor extends MessageInput.Descriptor {
         @Inject
         public Descriptor() {
-            super(NAME, false, "https://www.graylog.org/documentation/sending/kafka/");
+            super(NAME, false, "");
         }
     }
 

--- a/graylog2-inputs/src/main/java/org/graylog2/inputs/syslog/kafka/SyslogKafkaInput.java
+++ b/graylog2-inputs/src/main/java/org/graylog2/inputs/syslog/kafka/SyslogKafkaInput.java
@@ -75,7 +75,7 @@ public class SyslogKafkaInput extends MessageInput {
     public static class Descriptor extends MessageInput.Descriptor {
         @Inject
         public Descriptor() {
-            super(NAME, false, "https://www.graylog.org/documentation/sending/kafka/");
+            super(NAME, false, "");
         }
     }
 

--- a/graylog2-plugin-interfaces/src/main/java/org/graylog2/plugin/DocsHelper.java
+++ b/graylog2-plugin-interfaces/src/main/java/org/graylog2/plugin/DocsHelper.java
@@ -1,0 +1,78 @@
+/**
+ * The MIT License
+ * Copyright (c) 2012 Graylog, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+/**
+ * This file is part of Graylog.
+ *
+ * Graylog is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.graylog2.plugin;
+
+public enum DocsHelper {
+    PAGE_SENDING_JSONPATH("sending_data.html#json-path-from-http-api-input"),
+    PAGE_ES_CONFIGURATION("configuring_es.html");
+
+    public static String DOCS_URL = "http://docs.graylog.org/en/";
+    public static final String HELP_DOCS = "http://docs.graylog.org/";
+    public static final String HELP_COMMUNITY = "https://www.graylog.org/community-support/";
+    public static final String HELP_COMMERCIAL = "https://www.graylog.com/support/";
+
+    private final String path;
+
+    DocsHelper(String path) {
+        this.path = path;
+    }
+
+    @Override
+    public String toString() {
+        final String version = Version.CURRENT_CLASSPATH.major + "." + Version.CURRENT_CLASSPATH.minor;
+
+        final StringBuffer sb = new StringBuffer(DOCS_URL)
+                .append(version)
+                .append("/pages/")
+                .append(path);
+
+        return sb.toString();
+    }
+
+    public String toLink(String title) {
+        final StringBuffer sb = new StringBuffer("<a href=\"")
+                .append(toString())
+                .append("\" target=\"_blank\">")
+                .append(title)
+                .append("</a>");
+
+        return sb.toString();
+    }
+}

--- a/graylog2-plugin-interfaces/src/main/java/org/graylog2/plugin/DocsHelper.java
+++ b/graylog2-plugin-interfaces/src/main/java/org/graylog2/plugin/DocsHelper.java
@@ -20,22 +20,6 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
-/**
- * This file is part of Graylog.
- *
- * Graylog is free software: you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
- *
- * Graylog is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
- */
 
 package org.graylog2.plugin;
 

--- a/graylog2-plugin-interfaces/src/main/java/org/graylog2/plugin/DocsHelper.java
+++ b/graylog2-plugin-interfaces/src/main/java/org/graylog2/plugin/DocsHelper.java
@@ -27,10 +27,7 @@ public enum DocsHelper {
     PAGE_SENDING_JSONPATH("sending_data.html#json-path-from-http-api-input"),
     PAGE_ES_CONFIGURATION("configuring_es.html");
 
-    public static String DOCS_URL = "http://docs.graylog.org/en/";
-    public static final String HELP_DOCS = "http://docs.graylog.org/";
-    public static final String HELP_COMMUNITY = "https://www.graylog.org/community-support/";
-    public static final String HELP_COMMERCIAL = "https://www.graylog.com/support/";
+    private static final String DOCS_URL = "http://docs.graylog.org/en/";
 
     private final String path;
 
@@ -42,21 +39,10 @@ public enum DocsHelper {
     public String toString() {
         final String version = Version.CURRENT_CLASSPATH.major + "." + Version.CURRENT_CLASSPATH.minor;
 
-        final StringBuffer sb = new StringBuffer(DOCS_URL)
-                .append(version)
-                .append("/pages/")
-                .append(path);
-
-        return sb.toString();
+        return DOCS_URL + version + "/pages/" + path;
     }
 
     public String toLink(String title) {
-        final StringBuffer sb = new StringBuffer("<a href=\"")
-                .append(toString())
-                .append("\" target=\"_blank\">")
-                .append(title)
-                .append("</a>");
-
-        return sb.toString();
+        return "<a href=\"" + toString() + "\" target=\"_blank\">" + title + "</a>";
     }
 }

--- a/graylog2-server/src/main/java/org/graylog2/UI.java
+++ b/graylog2-server/src/main/java/org/graylog2/UI.java
@@ -16,14 +16,11 @@
  */
 package org.graylog2;
 
+import org.graylog2.plugin.DocsHelper;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 public class UI {
-
-    private static final String HELP_DOCS = "http://docs.graylog.org/";
-    private static final String HELP_COMMUNITY = "https://www.graylog.org/community-support/";
-    private static final String HELP_COMMERCIAL = "https://www.graylog.com/support/";
 
     private static final Logger LOG = LoggerFactory.getLogger(UI.class);
 
@@ -44,9 +41,9 @@ public class UI {
         sb.append("ERROR: ").append(msg).append("\n\n");
 
         sb.append("Need help?").append("\n\n");
-        sb.append("* Official documentation: ").append(HELP_DOCS).append("\n");
-        sb.append("* Community support: ").append(HELP_COMMUNITY).append("\n");
-        sb.append("* Commercial support: ").append(HELP_COMMERCIAL).append("\n");
+        sb.append("* Official documentation: ").append(DocsHelper.HELP_DOCS).append("\n");
+        sb.append("* Community support: ").append(DocsHelper.HELP_COMMUNITY).append("\n");
+        sb.append("* Commercial support: ").append(DocsHelper.HELP_COMMERCIAL).append("\n");
 
         if (docLinks != null && docLinks.length > 0) {
             sb.append("\n").append("But we also got some specific help " +

--- a/graylog2-server/src/main/java/org/graylog2/UI.java
+++ b/graylog2-server/src/main/java/org/graylog2/UI.java
@@ -16,11 +16,14 @@
  */
 package org.graylog2;
 
-import org.graylog2.plugin.DocsHelper;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 public class UI {
+
+    private static final String HELP_DOCS = "http://docs.graylog.org/";
+    private static final String HELP_COMMUNITY = "https://www.graylog.org/community-support/";
+    private static final String HELP_COMMERCIAL = "https://www.graylog.com/support/";
 
     private static final Logger LOG = LoggerFactory.getLogger(UI.class);
 
@@ -41,9 +44,9 @@ public class UI {
         sb.append("ERROR: ").append(msg).append("\n\n");
 
         sb.append("Need help?").append("\n\n");
-        sb.append("* Official documentation: ").append(DocsHelper.HELP_DOCS).append("\n");
-        sb.append("* Community support: ").append(DocsHelper.HELP_COMMUNITY).append("\n");
-        sb.append("* Commercial support: ").append(DocsHelper.HELP_COMMERCIAL).append("\n");
+        sb.append("* Official documentation: ").append(HELP_DOCS).append("\n");
+        sb.append("* Community support: ").append(HELP_COMMUNITY).append("\n");
+        sb.append("* Commercial support: ").append(HELP_COMMERCIAL).append("\n");
 
         if (docLinks != null && docLinks.length > 0) {
             sb.append("\n").append("But we also got some specific help " +

--- a/graylog2-server/src/main/java/org/graylog2/initializers/IndexerSetupService.java
+++ b/graylog2-server/src/main/java/org/graylog2/initializers/IndexerSetupService.java
@@ -35,6 +35,7 @@ import org.elasticsearch.action.admin.cluster.health.ClusterHealthResponse;
 import org.elasticsearch.action.admin.cluster.health.ClusterHealthStatus;
 import org.elasticsearch.client.Client;
 import org.elasticsearch.node.Node;
+import org.graylog2.plugin.DocsHelper;
 import org.graylog2.UI;
 import org.graylog2.configuration.ElasticsearchConfiguration;
 import org.graylog2.plugin.Tools;
@@ -136,7 +137,7 @@ public class IndexerSetupService extends AbstractIdleService {
                 if (ClusterHealthStatus.RED.equals(health.getStatus())) {
                     UI.exitHardWithWall("The Elasticsearch cluster state is RED which means shards are unassigned. "
                                     + "This usually indicates a crashed and corrupt cluster and needs to be investigated. Graylog will shut down.",
-                            "http://docs.graylog.org/en/1.0/pages/configuring_es.html");
+                            DocsHelper.PAGE_ES_CONFIGURATION.toString());
 
                 }
             } catch (ElasticsearchTimeoutException e) {
@@ -185,7 +186,7 @@ public class IndexerSetupService extends AbstractIdleService {
                 UI.exitHardWithWall(
                         "Could not successfully connect to Elasticsearch, if you use multicast check that it is working in your network" +
                                 " and that Elasticsearch is running properly and is reachable. Also check that the cluster.name setting is correct.",
-                        "http://docs.graylog.org/en/1.0/pages/configuring_es.html");
+                        DocsHelper.PAGE_ES_CONFIGURATION.toString());
             }
         } catch (Exception e) {
             bufferSynchronizerService.setIndexerUnavailable();


### PR DESCRIPTION
* Removes links to nonexistent Kafka documentation. (see #983 and Graylog2/documentation#19)
* Introduces a `DocsHelper` enum to avoid hardcoding links in the code base. (see Graylog2/graylog2-web-interface#1466)

This is targeted at the master branch. The 68ea4a8 should be cherry-picked into the 1.1 branch to fix #983.

