### PR TITLE
Log error message if there is a MongoDB connection error

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/bindings/providers/MongoConnectionProvider.java
+++ b/graylog2-server/src/main/java/org/graylog2/bindings/providers/MongoConnectionProvider.java
@@ -19,19 +19,27 @@ package org.graylog2.bindings.providers;
 import org.graylog2.configuration.MongoDbConfiguration;
 import org.graylog2.database.MongoConnection;
 import org.graylog2.database.MongoConnectionImpl;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import javax.inject.Inject;
 import javax.inject.Provider;
 
 public class MongoConnectionProvider implements Provider<MongoConnection> {
+    private static final Logger LOG = LoggerFactory.getLogger(MongoConnectionProvider.class);
     private static MongoConnection mongoConnection = null;
 
     @Inject
     public MongoConnectionProvider(MongoDbConfiguration configuration) {
         if (mongoConnection == null) {
-            mongoConnection = new MongoConnectionImpl(configuration);
+            try {
+                mongoConnection = new MongoConnectionImpl(configuration);
 
-            mongoConnection.connect();
+                mongoConnection.connect();
+            } catch (Exception e) {
+                LOG.error("Error connecting to MongoDB: {}", e.getMessage());
+                throw e;
+            }
         }
     }
 


### PR DESCRIPTION
Logs an early error if MongoDB is not available instead of slowly starting for about 2.5 minutes and then throwing an error.

Fixes #1249