### PR TITLE
invert dependency of bootstrap <-> server/radio

### DIFF
--- a/graylog2-bootstrap/pom.xml
+++ b/graylog2-bootstrap/pom.xml
@@ -23,7 +23,7 @@
         <maven>3.0.1</maven>
     </prerequisites>
 
-    <artifactId>graylog2</artifactId>
+    <artifactId>graylog2-bootstrap</artifactId>
     <packaging>jar</packaging>
 
     <parent>
@@ -50,11 +50,11 @@
     <dependencies>
         <dependency>
             <groupId>org.graylog2</groupId>
-            <artifactId>graylog2-radio</artifactId>
+            <artifactId>graylog2-plugin</artifactId>
         </dependency>
         <dependency>
             <groupId>org.graylog2</groupId>
-            <artifactId>graylog2-server</artifactId>
+            <artifactId>graylog2-shared</artifactId>
         </dependency>
         <dependency>
             <groupId>io.airlift</groupId>
@@ -100,41 +100,6 @@
                 </configuration>
             </plugin>
             <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-shade-plugin</artifactId>
-                <configuration>
-                    <transformers>
-                        <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer" />
-                        <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
-                            <mainClass>${mainClass}</mainClass>
-                        </transformer>
-                    </transformers>
-                    <minimizeJar>false</minimizeJar>
-                    <filters>
-                        <filter>
-                            <artifact>log4j:apache-log4j-extras</artifact>
-                            <includes>
-                                <include>**</include>
-                            </includes>
-                        </filter>
-                        <filter>
-                            <artifact>log4j:log4j</artifact>
-                            <includes>
-                                <include>**</include>
-                            </includes>
-                        </filter>
-                    </filters>
-                </configuration>
-                <executions>
-                    <execution>
-                        <phase>package</phase>
-                        <goals>
-                            <goal>shade</goal>
-                        </goals>
-                    </execution>
-                </executions>
-            </plugin>
-            <plugin>
                 <groupId>pl.project13.maven</groupId>
                 <artifactId>git-commit-id-plugin</artifactId>
                 <executions>
@@ -157,39 +122,9 @@
                 </configuration>
             </plugin>
             <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-assembly-plugin</artifactId>
-                <configuration>
-                    <attach>false</attach>
-                    <appendAssemblyId>false</appendAssemblyId>
-                    <descriptors>
-                        <descriptor>src/main/assembly/graylog2.xml</descriptor>
-                    </descriptors>
-                    <!-- to make it easier to collect assemblies, we put them into the _parent's_ build directory -->
-                    <outputDirectory>${project.parent.build.directory}/assembly</outputDirectory>
-                    <finalName>graylog-${project.version}-${maven.build.timestamp}</finalName>
-                </configuration>
-            </plugin>
-            <plugin>
                 <groupId>com.mycila</groupId>
                 <artifactId>license-maven-plugin</artifactId>
             </plugin>
         </plugins>
     </build>
-    <profiles>
-        <profile>
-            <id>release</id>
-            <build>
-                <plugins>
-                    <plugin>
-                        <groupId>org.apache.maven.plugins</groupId>
-                        <artifactId>maven-assembly-plugin</artifactId>
-                        <configuration>
-                            <finalName>graylog-${project.version}</finalName>
-                        </configuration>
-                    </plugin>
-                </plugins>
-            </build>
-        </profile>
-    </profiles>
 </project>

--- a/graylog2-bootstrap/src/main/java/org/graylog2/bootstrap/CliCommand.java
+++ b/graylog2-bootstrap/src/main/java/org/graylog2/bootstrap/CliCommand.java
@@ -1,0 +1,4 @@
+package org.graylog2.bootstrap;
+
+public interface CliCommand extends Runnable {
+}

--- a/graylog2-bootstrap/src/main/java/org/graylog2/bootstrap/CliCommand.java
+++ b/graylog2-bootstrap/src/main/java/org/graylog2/bootstrap/CliCommand.java
@@ -1,3 +1,19 @@
+/**
+ * This file is part of Graylog.
+ *
+ * Graylog is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package org.graylog2.bootstrap;
 
 public interface CliCommand extends Runnable {

--- a/graylog2-bootstrap/src/main/java/org/graylog2/bootstrap/CliCommandsProvider.java
+++ b/graylog2-bootstrap/src/main/java/org/graylog2/bootstrap/CliCommandsProvider.java
@@ -1,0 +1,10 @@
+package org.graylog2.bootstrap;
+
+import io.airlift.airline.Cli;
+
+/**
+ * This class provides the opportunity to add top level commands or command groups to the bootstrap processes.
+ */
+public interface CliCommandsProvider {
+    void addTopLevelCommandsOrGroups(Cli.CliBuilder<CliCommand> builder);
+}

--- a/graylog2-bootstrap/src/main/java/org/graylog2/bootstrap/CliCommandsProvider.java
+++ b/graylog2-bootstrap/src/main/java/org/graylog2/bootstrap/CliCommandsProvider.java
@@ -1,3 +1,19 @@
+/**
+ * This file is part of Graylog.
+ *
+ * Graylog is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package org.graylog2.bootstrap;
 
 import io.airlift.airline.Cli;

--- a/graylog2-bootstrap/src/main/java/org/graylog2/bootstrap/CmdLineTool.java
+++ b/graylog2-bootstrap/src/main/java/org/graylog2/bootstrap/CmdLineTool.java
@@ -43,7 +43,7 @@ import com.google.inject.spi.Message;
 import io.airlift.airline.Command;
 import io.airlift.airline.Option;
 import org.apache.log4j.Level;
-import org.graylog2.UI;
+import org.graylog2.shared.UI;
 import org.graylog2.plugin.BaseConfiguration;
 import org.graylog2.plugin.Plugin;
 import org.graylog2.plugin.PluginConfigBean;
@@ -79,7 +79,7 @@ import java.util.Set;
 
 import static com.google.common.base.Strings.nullToEmpty;
 
-public abstract class CmdLineTool implements Runnable {
+public abstract class CmdLineTool implements CliCommand {
     private static final Logger LOG = LoggerFactory.getLogger(CmdLineTool.class);
 
     protected static final String ENVIRONMENT_PREFIX = "GRAYLOG2_";

--- a/graylog2-bootstrap/src/main/java/org/graylog2/bootstrap/commands/Help.java
+++ b/graylog2-bootstrap/src/main/java/org/graylog2/bootstrap/commands/Help.java
@@ -1,0 +1,7 @@
+package org.graylog2.bootstrap.commands;
+
+import org.graylog2.bootstrap.CliCommand;
+
+/* shallow subclass to make it implement CliCommand */
+public class Help extends io.airlift.airline.Help implements CliCommand {
+}

--- a/graylog2-bootstrap/src/main/java/org/graylog2/bootstrap/commands/Help.java
+++ b/graylog2-bootstrap/src/main/java/org/graylog2/bootstrap/commands/Help.java
@@ -1,3 +1,19 @@
+/**
+ * This file is part of Graylog.
+ *
+ * Graylog is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package org.graylog2.bootstrap.commands;
 
 import org.graylog2.bootstrap.CliCommand;

--- a/graylog2-bootstrap/src/main/java/org/graylog2/bootstrap/commands/ShowVersion.java
+++ b/graylog2-bootstrap/src/main/java/org/graylog2/bootstrap/commands/ShowVersion.java
@@ -17,14 +17,12 @@
 package org.graylog2.bootstrap.commands;
 
 import io.airlift.airline.Command;
+import org.graylog2.bootstrap.CliCommand;
 import org.graylog2.plugin.Tools;
 import org.graylog2.plugin.Version;
 
-/**
- * @author Dennis Oelkers <dennis@torch.sh>
- */
 @Command(name = "version", description = "Show the Graylog and JVM versions")
-public class ShowVersion implements Runnable {
+public class ShowVersion implements CliCommand {
     private final Version version = Version.CURRENT_CLASSPATH;
 
     @Override

--- a/graylog2-radio/pom.xml
+++ b/graylog2-radio/pom.xml
@@ -67,6 +67,10 @@
             <groupId>org.graylog2</groupId>
             <artifactId>graylog2-rest-models</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.graylog2</groupId>
+            <artifactId>graylog2-bootstrap</artifactId>
+        </dependency>
 
         <dependency>
             <groupId>com.github.joschi</groupId>
@@ -76,19 +80,6 @@
         <dependency>
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
-        </dependency>
-
-        <dependency>
-            <groupId>io.dropwizard.metrics</groupId>
-            <artifactId>metrics-annotation</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>io.dropwizard.metrics</groupId>
-            <artifactId>metrics-core</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>io.dropwizard.metrics</groupId>
-            <artifactId>metrics-log4j</artifactId>
         </dependency>
 
         <dependency>

--- a/graylog2-radio/src/main/java/org/graylog2/radio/commands/Radio.java
+++ b/graylog2-radio/src/main/java/org/graylog2/radio/commands/Radio.java
@@ -14,7 +14,7 @@
  * You should have received a copy of the GNU General Public License
  * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
  */
-package org.graylog2.bootstrap.commands;
+package org.graylog2.radio.commands;
 
 import com.google.common.util.concurrent.ServiceManager;
 import com.google.inject.Injector;
@@ -41,7 +41,7 @@ import java.util.List;
 import java.util.Set;
 
 @Command(name = "radio", description = "Start the Graylog radio")
-public class Radio extends ServerBootstrap implements Runnable {
+public class Radio extends ServerBootstrap {
     private static final Logger LOG = LoggerFactory.getLogger(Radio.class);
     private static final Configuration configuration = new Configuration();
 

--- a/graylog2-radio/src/main/java/org/graylog2/radio/commands/RadioCommandsProvider.java
+++ b/graylog2-radio/src/main/java/org/graylog2/radio/commands/RadioCommandsProvider.java
@@ -1,0 +1,12 @@
+package org.graylog2.radio.commands;
+
+import io.airlift.airline.Cli;
+import org.graylog2.bootstrap.CliCommand;
+import org.graylog2.bootstrap.CliCommandsProvider;
+
+public class RadioCommandsProvider implements CliCommandsProvider {
+    @Override
+    public void addTopLevelCommandsOrGroups(Cli.CliBuilder<CliCommand> builder) {
+        builder.withCommand(Radio.class);
+    }
+}

--- a/graylog2-radio/src/main/java/org/graylog2/radio/commands/RadioCommandsProvider.java
+++ b/graylog2-radio/src/main/java/org/graylog2/radio/commands/RadioCommandsProvider.java
@@ -1,3 +1,19 @@
+/**
+ * This file is part of Graylog.
+ *
+ * Graylog is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package org.graylog2.radio.commands;
 
 import io.airlift.airline.Cli;

--- a/graylog2-radio/src/main/resources/META-INF/services/org.graylog2.bootstrap.CliCommandsProvider
+++ b/graylog2-radio/src/main/resources/META-INF/services/org.graylog2.bootstrap.CliCommandsProvider
@@ -1,0 +1,1 @@
+org.graylog2.radio.commands.RadioCommandsProvider

--- a/graylog2-server/pom.xml
+++ b/graylog2-server/pom.xml
@@ -17,7 +17,8 @@
   ~ You should have received a copy of the GNU General Public License
   ~ along with Graylog.  If not, see <http://www.gnu.org/licenses />.
   -->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <prerequisites>
         <maven>3.0.1</maven>
@@ -41,10 +42,22 @@
         <version>1.2.0-SNAPSHOT</version>
     </parent>
 
+    <properties>
+        <mainClass>org.graylog2.bootstrap.Main</mainClass>
+    </properties>
+
     <dependencies>
         <dependency>
             <groupId>org.graylog2</groupId>
             <artifactId>graylog2-plugin</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.graylog2</groupId>
+            <artifactId>graylog2-bootstrap</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.graylog2</groupId>
+            <artifactId>graylog2-radio</artifactId>
         </dependency>
         <dependency>
             <groupId>org.graylog2</groupId>
@@ -316,9 +329,76 @@
     <build>
         <plugins>
             <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-assembly-plugin</artifactId>
+                <configuration>
+                    <attach>false</attach>
+                    <appendAssemblyId>false</appendAssemblyId>
+                    <descriptors>
+                        <descriptor>src/main/assembly/graylog2.xml</descriptor>
+                    </descriptors>
+                    <!-- to make it easier to collect assemblies, we put them into the _parent's_ build directory -->
+                    <outputDirectory>${project.parent.build.directory}/assembly</outputDirectory>
+                    <finalName>graylog-${project.version}-${maven.build.timestamp}</finalName>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-shade-plugin</artifactId>
+                <configuration>
+                    <transformers>
+                        <transformer
+                                implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer"/>
+                        <transformer
+                                implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
+                            <mainClass>${mainClass}</mainClass>
+                        </transformer>
+                    </transformers>
+                    <minimizeJar>false</minimizeJar>
+                    <filters>
+                        <filter>
+                            <artifact>log4j:apache-log4j-extras</artifact>
+                            <includes>
+                                <include>**</include>
+                            </includes>
+                        </filter>
+                        <filter>
+                            <artifact>log4j:log4j</artifact>
+                            <includes>
+                                <include>**</include>
+                            </includes>
+                        </filter>
+                    </filters>
+                </configuration>
+                <executions>
+                    <execution>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>shade</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
                 <groupId>com.mycila</groupId>
                 <artifactId>license-maven-plugin</artifactId>
             </plugin>
         </plugins>
     </build>
+    <profiles>
+        <profile>
+            <id>release</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-assembly-plugin</artifactId>
+                        <configuration>
+                            <finalName>graylog-${project.version}</finalName>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
 </project>

--- a/graylog2-server/src/main/assembly/graylog2.xml
+++ b/graylog2-server/src/main/assembly/graylog2.xml
@@ -42,7 +42,7 @@
     </fileSets>
     <files>
         <file>
-            <source>${project.build.directory}/graylog2.jar</source>
+            <source>${project.build.directory}/graylog2-server-${project.version}.jar</source>
             <destName>graylog.jar</destName>
             <outputDirectory>/</outputDirectory>
         </file>

--- a/graylog2-server/src/main/java/org/graylog2/StartupException.java
+++ b/graylog2-server/src/main/java/org/graylog2/StartupException.java
@@ -16,6 +16,8 @@
  */
 package org.graylog2;
 
+import org.graylog2.shared.UI;
+
 public class StartupException extends RuntimeException {
     private final String description;
     private final String[] docLinks;

--- a/graylog2-server/src/main/java/org/graylog2/commands/Server.java
+++ b/graylog2-server/src/main/java/org/graylog2/commands/Server.java
@@ -14,7 +14,7 @@
  * You should have received a copy of the GNU General Public License
  * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
  */
-package org.graylog2.bootstrap.commands;
+package org.graylog2.commands;
 
 import com.google.common.util.concurrent.ServiceManager;
 import com.google.inject.Injector;
@@ -24,7 +24,7 @@ import com.mongodb.MongoException;
 import io.airlift.airline.Command;
 import io.airlift.airline.Option;
 import org.graylog2.Configuration;
-import org.graylog2.UI;
+import org.graylog2.shared.UI;
 import org.graylog2.bindings.AlarmCallbackBindings;
 import org.graylog2.bindings.InitializerBindings;
 import org.graylog2.bindings.MessageFilterBindings;
@@ -61,7 +61,7 @@ import java.util.Set;
 import java.util.concurrent.TimeUnit;
 
 @Command(name = "server", description = "Start the Graylog server")
-public class Server extends ServerBootstrap implements Runnable {
+public class Server extends ServerBootstrap {
     private static final Logger LOG = LoggerFactory.getLogger(Server.class);
 
     private static final Configuration configuration = new Configuration();

--- a/graylog2-server/src/main/java/org/graylog2/commands/ServerCommandsProvider.java
+++ b/graylog2-server/src/main/java/org/graylog2/commands/ServerCommandsProvider.java
@@ -1,0 +1,28 @@
+package org.graylog2.commands;
+
+import com.google.common.collect.ImmutableSet;
+import io.airlift.airline.Cli;
+import org.graylog2.bootstrap.CliCommand;
+import org.graylog2.bootstrap.CliCommandsProvider;
+import org.graylog2.commands.journal.JournalDecode;
+import org.graylog2.commands.journal.JournalShow;
+import org.graylog2.commands.journal.JournalTruncate;
+
+public class ServerCommandsProvider implements CliCommandsProvider {
+    @Override
+    public void addTopLevelCommandsOrGroups(Cli.CliBuilder<CliCommand> builder) {
+
+        builder.withCommand(Server.class);
+
+        builder.withGroup("journal")
+                .withDescription("Manage the persisted message journal")
+                .withDefaultCommand(JournalShow.class)
+                .withCommands(
+                        ImmutableSet.<Class<? extends CliCommand>>of(
+                                JournalShow.class,
+                                JournalTruncate.class,
+                                JournalDecode.class
+                        ));
+
+    }
+}

--- a/graylog2-server/src/main/java/org/graylog2/commands/ServerCommandsProvider.java
+++ b/graylog2-server/src/main/java/org/graylog2/commands/ServerCommandsProvider.java
@@ -1,3 +1,19 @@
+/**
+ * This file is part of Graylog.
+ *
+ * Graylog is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package org.graylog2.commands;
 
 import com.google.common.collect.ImmutableSet;

--- a/graylog2-server/src/main/java/org/graylog2/commands/journal/AbstractJournalCommand.java
+++ b/graylog2-server/src/main/java/org/graylog2/commands/journal/AbstractJournalCommand.java
@@ -14,7 +14,7 @@
  * You should have received a copy of the GNU General Public License
  * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
  */
-package org.graylog2.bootstrap.commands.journal;
+package org.graylog2.commands.journal;
 
 import com.google.inject.Module;
 import org.graylog2.Configuration;

--- a/graylog2-server/src/main/java/org/graylog2/commands/journal/JournalDecode.java
+++ b/graylog2-server/src/main/java/org/graylog2/commands/journal/JournalDecode.java
@@ -14,7 +14,7 @@
  * You should have received a copy of the GNU General Public License
  * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
  */
-package org.graylog2.bootstrap.commands.journal;
+package org.graylog2.commands.journal;
 
 import com.google.common.base.Splitter;
 import com.google.common.collect.Lists;

--- a/graylog2-server/src/main/java/org/graylog2/commands/journal/JournalShow.java
+++ b/graylog2-server/src/main/java/org/graylog2/commands/journal/JournalShow.java
@@ -14,15 +14,13 @@
  * You should have received a copy of the GNU General Public License
  * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
  */
-package org.graylog2.bootstrap.commands.journal;
+package org.graylog2.commands.journal;
 
 import io.airlift.airline.Command;
 import io.airlift.airline.Option;
 import kafka.log.LogSegment;
 import org.graylog2.shared.journal.KafkaJournal;
 import org.joda.time.DateTime;
-
-import java.io.File;
 
 @SuppressWarnings("LocalCanBeFinal")
 @Command(name = "show", description = "Shows information about the persisted message journal")

--- a/graylog2-server/src/main/java/org/graylog2/commands/journal/JournalTruncate.java
+++ b/graylog2-server/src/main/java/org/graylog2/commands/journal/JournalTruncate.java
@@ -14,7 +14,7 @@
  * You should have received a copy of the GNU General Public License
  * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
  */
-package org.graylog2.bootstrap.commands.journal;
+package org.graylog2.commands.journal;
 
 import io.airlift.airline.Command;
 import io.airlift.airline.Option;

--- a/graylog2-server/src/main/java/org/graylog2/initializers/IndexerSetupService.java
+++ b/graylog2-server/src/main/java/org/graylog2/initializers/IndexerSetupService.java
@@ -36,7 +36,7 @@ import org.elasticsearch.action.admin.cluster.health.ClusterHealthStatus;
 import org.elasticsearch.client.Client;
 import org.elasticsearch.node.Node;
 import org.graylog2.plugin.DocsHelper;
-import org.graylog2.UI;
+import org.graylog2.shared.UI;
 import org.graylog2.configuration.ElasticsearchConfiguration;
 import org.graylog2.plugin.Tools;
 import org.slf4j.Logger;

--- a/graylog2-server/src/main/resources/META-INF/services/org.graylog2.bootstrap.CliCommandsProvider
+++ b/graylog2-server/src/main/resources/META-INF/services/org.graylog2.bootstrap.CliCommandsProvider
@@ -1,0 +1,1 @@
+org.graylog2.commands.ServerCommandsProvider

--- a/graylog2-shared/pom.xml
+++ b/graylog2-shared/pom.xml
@@ -175,6 +175,10 @@
             <groupId>io.dropwizard.metrics</groupId>
             <artifactId>metrics-json</artifactId>
         </dependency>
+        <dependency>
+            <groupId>io.dropwizard.metrics</groupId>
+            <artifactId>metrics-log4j</artifactId>
+        </dependency>
 
         <dependency>
             <groupId>com.github.stephenc.high-scale-lib</groupId>

--- a/graylog2-shared/src/main/java/org/graylog2/shared/UI.java
+++ b/graylog2-shared/src/main/java/org/graylog2/shared/UI.java
@@ -14,7 +14,7 @@
  * You should have received a copy of the GNU General Public License
  * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
  */
-package org.graylog2;
+package org.graylog2.shared;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;

--- a/pom.xml
+++ b/pom.xml
@@ -163,6 +163,11 @@
             </dependency>
             <dependency>
                 <groupId>org.graylog2</groupId>
+                <artifactId>graylog2-bootstrap</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.graylog2</groupId>
                 <artifactId>graylog2-inputs</artifactId>
                 <version>${project.version}</version>
             </dependency>
@@ -928,6 +933,8 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
+                <!-- for some reason Intellij marks two attributes as invalid without the version -->
+                <version>${surefire.version}</version>
                 <configuration>
                     <!-- Use ALL the cores! -->
                     <forkCount>1C</forkCount>


### PR DESCRIPTION
move actual cli commands into their respective modules
use ServiceLoader to find cli command providers at runtime instead of hardcoding them

move assembly into graylog2-server again, and depend on radio for packaging, bootstrap isn't the central place anymore, just some code

moved some helper code to shared for solving package visibility issues