### PR TITLE
Make heartbeat timeout option for AmqpTransport optional

### DIFF
--- a/graylog2-inputs/src/main/java/org/graylog2/inputs/transports/AmqpTransport.java
+++ b/graylog2-inputs/src/main/java/org/graylog2/inputs/transports/AmqpTransport.java
@@ -317,7 +317,7 @@ public class AmqpTransport extends ThrottleableTransport {
                             "Heartbeat timeout",
                             ConnectionFactory.DEFAULT_HEARTBEAT,
                             "Heartbeat interval in seconds (use 0 to disable heartbeat)",
-                            ConfigurationField.Optional.NOT_OPTIONAL
+                            ConfigurationField.Optional.OPTIONAL
                     )
             );
 


### PR DESCRIPTION
Updating Graylog from 1.0 to 1.1 breaks any existing AMQP input because the old inputs do not have the mandatory heartbeat timeout configuration option. There is no reason to make this field mandatory because there is a default for it.

This should help users with AMQP inputs upgrading from 1.0 to 1.2.

Any objections?

Refs #1010 (comment about updating from 1.0 to 1.1)