### PR TITLE
pull out RestApi bindings into its own module

### DIFF
--- a/graylog2-plugin-interfaces/src/main/java/org/graylog2/plugin/inject/Graylog2Module.java
+++ b/graylog2-plugin-interfaces/src/main/java/org/graylog2/plugin/inject/Graylog2Module.java
@@ -27,16 +27,22 @@ import com.google.inject.Key;
 import com.google.inject.TypeLiteral;
 import com.google.inject.assistedinject.FactoryModuleBuilder;
 import com.google.inject.multibindings.MapBinder;
+import com.google.inject.multibindings.Multibinder;
+import com.google.inject.name.Names;
 import org.graylog2.plugin.inputs.MessageInput;
 import org.graylog2.plugin.inputs.annotations.ConfigClass;
 import org.graylog2.plugin.inputs.annotations.FactoryClass;
 import org.graylog2.plugin.inputs.codecs.Codec;
 import org.graylog2.plugin.inputs.transports.Transport;
 import org.graylog2.plugin.outputs.MessageOutput;
+import org.jetbrains.annotations.NotNull;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import javax.annotation.Nullable;
+import javax.ws.rs.container.ContainerResponseFilter;
+import javax.ws.rs.container.DynamicFeature;
+import javax.ws.rs.ext.ExceptionMapper;
 import java.lang.annotation.Annotation;
 
 public abstract class Graylog2Module extends AbstractModule {
@@ -228,4 +234,30 @@ public abstract class Graylog2Module extends AbstractModule {
 
         installOutput(outputMapBinder, target, factoryClass);
     }
+
+    @NotNull
+    protected Multibinder<Class<? extends DynamicFeature>> jerseyDynamicFeatureBinder() {
+        return Multibinder.newSetBinder(binder(), new DynamicFeatureType());
+    }
+
+    @NotNull
+    protected Multibinder<Class<? extends ContainerResponseFilter>> jerseyContainerResponseFilterBinder() {
+        return Multibinder.newSetBinder(binder(), new ContainerResponseFilterType());
+    }
+
+    @NotNull
+    protected Multibinder<Class<? extends ExceptionMapper>> jerseyExceptionMapperBinder() {
+        return Multibinder.newSetBinder(binder(), new ExceptionMapperType());
+    }
+
+    @NotNull
+    protected Multibinder<Class> jerseyAdditionalComponentsBinder() {
+        return Multibinder.newSetBinder(binder(), Class.class, Names.named("additionalJerseyComponents"));
+    }
+
+    private static class DynamicFeatureType extends TypeLiteral<Class<? extends DynamicFeature>> {}
+
+    private static class ContainerResponseFilterType extends TypeLiteral<Class<? extends ContainerResponseFilter>> {}
+
+    private static class ExceptionMapperType extends TypeLiteral<Class<? extends ExceptionMapper>> {}
 }

--- a/graylog2-plugin-interfaces/src/main/java/org/graylog2/plugin/inject/Graylog2Module.java
+++ b/graylog2-plugin-interfaces/src/main/java/org/graylog2/plugin/inject/Graylog2Module.java
@@ -35,10 +35,10 @@ import org.graylog2.plugin.inputs.annotations.FactoryClass;
 import org.graylog2.plugin.inputs.codecs.Codec;
 import org.graylog2.plugin.inputs.transports.Transport;
 import org.graylog2.plugin.outputs.MessageOutput;
-import org.jetbrains.annotations.NotNull;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import javax.ws.rs.container.ContainerResponseFilter;
 import javax.ws.rs.container.DynamicFeature;
@@ -235,22 +235,22 @@ public abstract class Graylog2Module extends AbstractModule {
         installOutput(outputMapBinder, target, factoryClass);
     }
 
-    @NotNull
+    @Nonnull
     protected Multibinder<Class<? extends DynamicFeature>> jerseyDynamicFeatureBinder() {
         return Multibinder.newSetBinder(binder(), new DynamicFeatureType());
     }
 
-    @NotNull
+    @Nonnull
     protected Multibinder<Class<? extends ContainerResponseFilter>> jerseyContainerResponseFilterBinder() {
         return Multibinder.newSetBinder(binder(), new ContainerResponseFilterType());
     }
 
-    @NotNull
+    @Nonnull
     protected Multibinder<Class<? extends ExceptionMapper>> jerseyExceptionMapperBinder() {
         return Multibinder.newSetBinder(binder(), new ExceptionMapperType());
     }
 
-    @NotNull
+    @Nonnull
     protected Multibinder<Class> jerseyAdditionalComponentsBinder() {
         return Multibinder.newSetBinder(binder(), Class.class, Names.named("additionalJerseyComponents"));
     }

--- a/graylog2-radio/src/main/java/org/graylog2/radio/bindings/RadioBindings.java
+++ b/graylog2-radio/src/main/java/org/graylog2/radio/bindings/RadioBindings.java
@@ -16,13 +16,11 @@
  */
 package org.graylog2.radio.bindings;
 
-import com.google.inject.AbstractModule;
-import com.google.inject.TypeLiteral;
-import com.google.inject.multibindings.Multibinder;
 import com.google.inject.name.Names;
 import com.google.inject.util.Providers;
 import org.graylog2.jersey.container.netty.SecurityContextFactory;
 import org.graylog2.plugin.BaseConfiguration;
+import org.graylog2.plugin.inject.Graylog2Module;
 import org.graylog2.radio.Configuration;
 import org.graylog2.radio.bindings.providers.RadioTransportProvider;
 import org.graylog2.radio.buffers.processors.RadioProcessBufferProcessor;
@@ -34,16 +32,12 @@ import org.graylog2.radio.users.NullUserServiceImpl;
 import org.graylog2.shared.buffers.processors.ProcessBufferProcessor;
 import org.graylog2.shared.inputs.PersistedInputs;
 import org.graylog2.shared.journal.NoopJournalModule;
-import org.graylog2.shared.security.ShiroSecurityBinding;
 import org.graylog2.shared.system.activities.ActivityWriter;
 import org.graylog2.shared.users.UserService;
 
-import javax.ws.rs.container.ContainerResponseFilter;
-import javax.ws.rs.container.DynamicFeature;
-import javax.ws.rs.ext.ExceptionMapper;
 import java.io.File;
 
-public class RadioBindings extends AbstractModule {
+public class RadioBindings extends Graylog2Module {
     private final Configuration configuration;
 
     public RadioBindings(Configuration configuration) {
@@ -52,14 +46,9 @@ public class RadioBindings extends AbstractModule {
 
     @Override
     protected void configure() {
-        bindProviders();
         bindSingletons();
         bindTransport();
         bind(ProcessBufferProcessor.class).to(RadioProcessBufferProcessor.class);
-        bindDynamicFeatures();
-        bindContainerResponseFilters();
-        bindExceptionMappers();
-        bindAdditionalJerseyComponents();
         bindInterfaces();
     }
 
@@ -84,30 +73,8 @@ public class RadioBindings extends AbstractModule {
         });
     }
 
-    private void bindProviders() {
-    }
-
     private void bindTransport() {
         bind(RadioTransport.class).toProvider(RadioTransportProvider.class);
     }
 
-    private void bindDynamicFeatures() {
-        TypeLiteral<Class<? extends DynamicFeature>> type = new TypeLiteral<Class<? extends DynamicFeature>>(){};
-        Multibinder<Class<? extends DynamicFeature>> setBinder = Multibinder.newSetBinder(binder(), type);
-        setBinder.addBinding().toInstance(ShiroSecurityBinding.class);
-    }
-
-    private void bindContainerResponseFilters() {
-        TypeLiteral<Class<? extends ContainerResponseFilter>> type = new TypeLiteral<Class<? extends ContainerResponseFilter>>(){};
-        Multibinder<Class<? extends ContainerResponseFilter>> setBinder = Multibinder.newSetBinder(binder(), type);
-    }
-
-    private void bindExceptionMappers() {
-        TypeLiteral<Class<? extends ExceptionMapper>> type = new TypeLiteral<Class<? extends ExceptionMapper>>(){};
-        Multibinder<Class<? extends ExceptionMapper>> setBinder = Multibinder.newSetBinder(binder(), type);
-    }
-
-    private void bindAdditionalJerseyComponents() {
-        Multibinder<Class> componentBinder = Multibinder.newSetBinder(binder(), Class.class, Names.named("additionalJerseyComponents"));
-    }
 }

--- a/graylog2-radio/src/main/java/org/graylog2/radio/commands/Radio.java
+++ b/graylog2-radio/src/main/java/org/graylog2/radio/commands/Radio.java
@@ -29,6 +29,7 @@ import org.graylog2.radio.bindings.RadioBindings;
 import org.graylog2.radio.bindings.RadioInitializerBindings;
 import org.graylog2.radio.cluster.Ping;
 import org.graylog2.shared.bindings.ObjectMapperModule;
+import org.graylog2.shared.bindings.RestApiBindings;
 import org.graylog2.shared.system.activities.Activity;
 import org.graylog2.shared.system.activities.ActivityWriter;
 import org.slf4j.Logger;
@@ -62,7 +63,8 @@ public class Radio extends ServerBootstrap {
                 new RadioBindings(configuration),
                 new RadioInitializerBindings(),
                 new PeriodicalBindings(),
-                new ObjectMapperModule()
+                new ObjectMapperModule(),
+                new RestApiBindings()
         );
     }
 

--- a/graylog2-server/src/main/java/org/graylog2/commands/Server.java
+++ b/graylog2-server/src/main/java/org/graylog2/commands/Server.java
@@ -46,6 +46,7 @@ import org.graylog2.notifications.NotificationService;
 import org.graylog2.plugin.KafkaJournalConfiguration;
 import org.graylog2.plugin.ServerStatus;
 import org.graylog2.shared.UI;
+import org.graylog2.shared.bindings.RestApiBindings;
 import org.graylog2.shared.system.activities.Activity;
 import org.graylog2.shared.system.activities.ActivityWriter;
 import org.graylog2.system.shutdown.GracefulShutdown;
@@ -108,7 +109,8 @@ public class Server extends ServerBootstrap {
                 new MessageOutputBindings(configuration),
                 new RotationStrategyBindings(),
                 new PeriodicalBindings(),
-                new ServerObjectMapperModule()
+                new ServerObjectMapperModule(),
+                new RestApiBindings()
         );
     }
 

--- a/graylog2-shared/src/main/java/org/graylog2/shared/bindings/RestApiBindings.java
+++ b/graylog2-shared/src/main/java/org/graylog2/shared/bindings/RestApiBindings.java
@@ -1,0 +1,48 @@
+/**
+ * This file is part of Graylog.
+ *
+ * Graylog is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.graylog2.shared.bindings;
+
+import com.google.inject.multibindings.Multibinder;
+import org.graylog2.plugin.inject.Graylog2Module;
+import org.graylog2.shared.rest.RestAccessLogFilter;
+import org.graylog2.shared.security.ShiroSecurityBinding;
+
+import javax.ws.rs.container.ContainerResponseFilter;
+import javax.ws.rs.container.DynamicFeature;
+
+public class RestApiBindings extends Graylog2Module {
+    @Override
+    protected void configure() {
+        bindDynamicFeatures();
+        bindContainerResponseFilters();
+        // just to create the binders so they are present in the injector
+        // we don't actually have global REST API bindings for these
+        jerseyExceptionMapperBinder();
+        jerseyAdditionalComponentsBinder();
+    }
+
+    private void bindDynamicFeatures() {
+        Multibinder<Class<? extends DynamicFeature>> setBinder = jerseyDynamicFeatureBinder();
+        setBinder.addBinding().toInstance(ShiroSecurityBinding.class);
+    }
+
+    private void bindContainerResponseFilters() {
+        Multibinder<Class<? extends ContainerResponseFilter>> setBinder = jerseyContainerResponseFilterBinder();
+        setBinder.addBinding().toInstance(RestAccessLogFilter.class);
+    }
+
+}

--- a/graylog2-shared/src/main/java/org/graylog2/shared/rest/RestAccessLogFilter.java
+++ b/graylog2-shared/src/main/java/org/graylog2/shared/rest/RestAccessLogFilter.java
@@ -14,7 +14,7 @@
  * You should have received a copy of the GNU General Public License
  * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
  */
-package org.graylog2.rest;
+package org.graylog2.shared.rest;
 
 import org.graylog2.jersey.container.netty.NettyContainer;
 import org.graylog2.shared.security.ShiroSecurityContext;


### PR DESCRIPTION
unify adding jersey specific bindings through pulling up the various multi binders into a common helper class

the motivation is to be able to simply pull in the RestApiBindings module to spin up jersey and the auth infrastructure and not bind it to the specific node types, those should only list the top level (domain logic) components they need to function, and not mix infrastructure with logic modules