### PR TITLE
Improving Integration Tests Part II

### DIFF
--- a/integration-tests/README.markdown
+++ b/integration-tests/README.markdown
@@ -1,0 +1,24 @@
+# Integration Tests
+
+__The integration tests need explicit activation by setting the ``skip.integration.tests``
+tunable to *false*.__
+All tests require a running Graylog server to run against, which is not bootstrapped by maven but supposedly
+by the environment the integration tests are running on. Therefore, the tests have a number of tunables with (hopefully)
+reasonable defaults. These are:
+
+| Property               | Default | Description |
+|:-----------------------|:--------|:------------|
+| skip.integration.tests | false   | Enables the integration tests. (Disabled per default) |
+| gl2.port | ``12900`` | Tcp port of the graylog server. |
+| gl2.baseuri | ``"http://localhost"`` | Uri base of the graylog server. Port is overriden by gl2.port if specified. |
+| gl2.admin_user | ``admin`` | Username used for authenticating against server for authenticated requests. |
+| gl2.admin_password | ``admin`` | Password used for authenticating against server for authenticated requests. |
+| mongodb.host | ``"localhost"`` | Hostname of MongoDB server used for seeding tests that require a preseeded database. |
+| mongodb.port | ``27017`` | Tcp port of MongoDB server. |
+| mongodb.database | ``"graylog"`` | Default database name for MongoDB. Tests are able to override this. |
+| es.host | ``"localhost"`` | Hostname used for connecting to elasticsearch cluster during preseeding. |
+| es.cluster.name | ``"graylog"`` | elasticsearch cluster name used during connecting. |
+| es.port | ``9300`` | elasticsearch port used during connecting. |
+
+All tunables are passed as java system properties (i.e. by adding ``-Dmongodb.database=integration`` to the mvn command
+to define a different default MongoDB database).

--- a/integration-tests/README.markdown
+++ b/integration-tests/README.markdown
@@ -8,16 +8,16 @@ reasonable defaults. These are:
 
 | Property               | Default | Description |
 |:-----------------------|:--------|:------------|
-| skip.integration.tests | false   | Enables the integration tests. (Disabled per default) |
+| skip.integration.tests | ``false``   | Enables the integration tests. (Disabled per default) |
 | gl2.port | ``12900`` | Tcp port of the graylog server. |
 | gl2.baseuri | ``"http://localhost"`` | Uri base of the graylog server. Port is overriden by gl2.port if specified. |
 | gl2.admin_user | ``admin`` | Username used for authenticating against server for authenticated requests. |
 | gl2.admin_password | ``admin`` | Password used for authenticating against server for authenticated requests. |
 | mongodb.host | ``"localhost"`` | Hostname of MongoDB server used for seeding tests that require a preseeded database. |
 | mongodb.port | ``27017`` | Tcp port of MongoDB server. |
-| mongodb.database | ``"graylog"`` | Default database name for MongoDB. Tests are able to override this. |
+| mongodb.database | ``"graylog_test"`` | Default database name for MongoDB. Tests are able to override this. |
 | es.host | ``"localhost"`` | Hostname used for connecting to elasticsearch cluster during preseeding. |
-| es.cluster.name | ``"graylog"`` | elasticsearch cluster name used during connecting. |
+| es.cluster.name | ``"graylog_test"`` | elasticsearch cluster name used during connecting. |
 | es.port | ``9300`` | elasticsearch port used during connecting. |
 
 All tunables are passed as java system properties (i.e. by adding ``-Dmongodb.database=integration`` to the mvn command

--- a/integration-tests/pom.xml
+++ b/integration-tests/pom.xml
@@ -116,6 +116,11 @@
             <artifactId>mongo-java-driver</artifactId>
 	        <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>com.lordofthejars</groupId>
+            <artifactId>nosqlunit-elasticsearch</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/integration-tests/src/test/java/integration/IntegrationTestsConfig.java
+++ b/integration-tests/src/test/java/integration/IntegrationTestsConfig.java
@@ -23,53 +23,53 @@ import java.net.URISyntaxException;
 import java.net.URL;
 
 public class IntegrationTestsConfig {
-    private static final String glBaseURi = System.getProperty("gl.baseuri", "http://localhost:12900");
-    private static final String glPort = System.getProperty("gl.port", "12900");
-    private static final String glAdminUser = System.getProperty("gl.admin_user", "admin");
-    private static final String glAdminPassword = System.getProperty("gl.admin_password", "admin");
-    private static final String mongodbHost = System.getProperty("mongodb.host", "localhost");
-    private static final String mongodbPort = System.getProperty("mongodb.port", "27017");
-    private static final String mongodbDatabase = System.getProperty("mongodb.database", "graylog2");
-    private static final String esHost = System.getProperty("es.host", "localhost");
-    private static final String esClusterName = System.getProperty("es.cluster.name", "graylog");
-    private static final String esPort = System.getProperty("es.port", "9300");
+    private static final String GL_BASE_URI = System.getProperty("gl.baseuri", "http://localhost:12900");
+    private static final String GL_PORT = System.getProperty("gl.port", "12900");
+    private static final String GL_ADMIN_USER = System.getProperty("gl.admin_user", "admin");
+    private static final String GL_ADMIN_PASSWORD = System.getProperty("gl.admin_password", "admin");
+    private static final String MONGODB_HOST = System.getProperty("mongodb.host", "localhost");
+    private static final String MONGODB_PORT = System.getProperty("mongodb.port", "27017");
+    private static final String MONGODB_DATABASE = System.getProperty("mongodb.database", "graylog_test");
+    private static final String ES_HOST = System.getProperty("es.host", "localhost");
+    private static final String ES_CLUSTER_NAME = System.getProperty("es.cluster.name", "graylog_test");
+    private static final String ES_PORT = System.getProperty("es.port", "9300");
 
     public static URL getGlServerURL() throws MalformedURLException, URISyntaxException {
-        final URIBuilder result = new URIBuilder(glBaseURi)
-                .setPort(Integer.parseInt(glPort))
+        final URIBuilder result = new URIBuilder(GL_BASE_URI)
+                .setPort(Integer.parseInt(GL_PORT))
                 .setUserInfo(getGlAdminUser(), getGlAdminPassword());
         return result.build().toURL();
     }
 
     public static String getGlAdminUser() {
-        return glAdminUser;
+        return GL_ADMIN_USER;
     }
 
     public static String getGlAdminPassword() {
-        return glAdminPassword;
+        return GL_ADMIN_PASSWORD;
     }
 
     public static String getMongodbHost() {
-        return mongodbHost;
+        return MONGODB_HOST;
     }
 
     public static int getMongodbPort() {
-        return Integer.parseInt(mongodbPort);
+        return Integer.parseInt(MONGODB_PORT);
     }
 
     public static String getMongodbDatabase() {
-        return mongodbDatabase;
+        return MONGODB_DATABASE;
     }
 
     public static String getEsHost() {
-        return esHost;
+        return ES_HOST;
     }
 
     public static int getEsPort() {
-        return Integer.parseInt(esPort);
+        return Integer.parseInt(ES_PORT);
     }
 
     public static String getEsClusterName() {
-        return esClusterName;
+        return ES_CLUSTER_NAME;
     }
 }

--- a/integration-tests/src/test/java/integration/IntegrationTestsConfig.java
+++ b/integration-tests/src/test/java/integration/IntegrationTestsConfig.java
@@ -1,3 +1,19 @@
+/**
+ * This file is part of Graylog.
+ *
+ * Graylog is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package integration;
 
 import org.apache.http.client.utils.URIBuilder;

--- a/integration-tests/src/test/java/integration/IntegrationTestsConfig.java
+++ b/integration-tests/src/test/java/integration/IntegrationTestsConfig.java
@@ -1,0 +1,59 @@
+package integration;
+
+import org.apache.http.client.utils.URIBuilder;
+
+import java.net.MalformedURLException;
+import java.net.URISyntaxException;
+import java.net.URL;
+
+public class IntegrationTestsConfig {
+    private static final String glBaseURi = System.getProperty("gl.baseuri", "http://localhost:12900");
+    private static final String glPort = System.getProperty("gl.port", "12900");
+    private static final String glAdminUser = System.getProperty("gl.admin_user", "admin");
+    private static final String glAdminPassword = System.getProperty("gl.admin_password", "admin");
+    private static final String mongodbHost = System.getProperty("mongodb.host", "localhost");
+    private static final String mongodbPort = System.getProperty("mongodb.port", "27017");
+    private static final String mongodbDatabase = System.getProperty("mongodb.database", "graylog2");
+    private static final String esHost = System.getProperty("es.host", "localhost");
+    private static final String esClusterName = System.getProperty("es.cluster.name", "graylog");
+    private static final String esPort = System.getProperty("es.port", "9300");
+
+    public static URL getGlServerURL() throws MalformedURLException, URISyntaxException {
+        final URIBuilder result = new URIBuilder(glBaseURi)
+                .setPort(Integer.parseInt(glPort))
+                .setUserInfo(getGlAdminUser(), getGlAdminPassword());
+        return result.build().toURL();
+    }
+
+    public static String getGlAdminUser() {
+        return glAdminUser;
+    }
+
+    public static String getGlAdminPassword() {
+        return glAdminPassword;
+    }
+
+    public static String getMongodbHost() {
+        return mongodbHost;
+    }
+
+    public static int getMongodbPort() {
+        return Integer.parseInt(mongodbPort);
+    }
+
+    public static String getMongodbDatabase() {
+        return mongodbDatabase;
+    }
+
+    public static String getEsHost() {
+        return esHost;
+    }
+
+    public static int getEsPort() {
+        return Integer.parseInt(esPort);
+    }
+
+    public static String getEsClusterName() {
+        return esClusterName;
+    }
+}

--- a/integration-tests/src/test/java/integration/MongoDbSeed.java
+++ b/integration-tests/src/test/java/integration/MongoDbSeed.java
@@ -25,5 +25,5 @@ import java.lang.annotation.Target;
 @Retention(RetentionPolicy.RUNTIME)
 public @interface MongoDbSeed {
     String[] locations() default {};
-    String database() default "graylog2";
+    String database() default "";
 }

--- a/integration-tests/src/test/java/integration/MongoDbSeedRule.java
+++ b/integration-tests/src/test/java/integration/MongoDbSeedRule.java
@@ -28,6 +28,7 @@ import java.io.IOException;
 import java.net.URL;
 import java.net.UnknownHostException;
 
+import static com.google.common.base.Strings.emptyToNull;
 import static org.apache.commons.lang3.ObjectUtils.firstNonNull;
 
 public class MongoDbSeedRule implements MethodRule {
@@ -40,9 +41,10 @@ public class MongoDbSeedRule implements MethodRule {
         final MongoDbSeed annotation = firstNonNull(method.getAnnotation(MongoDbSeed.class),
                 method.getDeclaringClass().getAnnotation(MongoDbSeed.class));
         if (annotation != null) {
+            final String databaseName = firstNonNull(emptyToNull(annotation.database()), System.getProperty("mongodb.database", "graylog2"));
             final MongodbSeed mongodbSeed;
             try {
-                mongodbSeed = new MongodbSeed(annotation.database());
+                mongodbSeed = new MongodbSeed(databaseName);
             } catch (UnknownHostException e) {
                 log.error("Unable to seed database: ", e);
                 return new IgnoreStatement("Unable to seed database: " + e.toString());

--- a/integration-tests/src/test/java/integration/MongoDbSeedRule.java
+++ b/integration-tests/src/test/java/integration/MongoDbSeedRule.java
@@ -25,6 +25,9 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
+import java.net.MalformedURLException;
+import java.net.URI;
+import java.net.URISyntaxException;
 import java.net.URL;
 import java.net.UnknownHostException;
 
@@ -41,16 +44,24 @@ public class MongoDbSeedRule implements MethodRule {
         final MongoDbSeed annotation = firstNonNull(method.getAnnotation(MongoDbSeed.class),
                 method.getDeclaringClass().getAnnotation(MongoDbSeed.class));
         if (annotation != null) {
-            final String databaseName = firstNonNull(emptyToNull(annotation.database()), System.getProperty("mongodb.database", "graylog2"));
+            final String databaseName = firstNonNull(emptyToNull(annotation.database()), IntegrationTestsConfig.getMongodbDatabase());
             final MongodbSeed mongodbSeed;
             try {
                 mongodbSeed = new MongodbSeed(databaseName);
             } catch (UnknownHostException e) {
-                log.error("Unable to seed database: ", e);
-                return new IgnoreStatement("Unable to seed database: " + e.toString());
+                final String msg = "Unable to seed database: ";
+                log.error(msg, e);
+                return new IgnoreStatement(msg + e.toString());
             }
             final ServerHelper graylogController = new ServerHelper();
-            final String nodeId = graylogController.getNodeId();
+            final String nodeId;
+            try {
+                nodeId = graylogController.getNodeId();
+            } catch (MalformedURLException | URISyntaxException e) {
+                final String msg = "Unable to determine graylog node id for seeding: ";
+                log.error(msg, e);
+                return new IgnoreStatement(msg + e.toString());
+            }
 
             if (annotation.locations().length > 0) {
                 for (String location : annotation.locations()) {

--- a/integration-tests/src/test/java/integration/RestAssuredSetupRule.java
+++ b/integration-tests/src/test/java/integration/RestAssuredSetupRule.java
@@ -39,7 +39,7 @@ public class RestAssuredSetupRule extends ExternalResource {
     @Override
     protected void before() throws Throwable {
         final ServerHelper serverHelper = new ServerHelper();
-        final URL url = serverHelper.getUrl();
+        final URL url = IntegrationTestsConfig.getGlServerURL();
         RestAssured.baseURI = url.getProtocol() + "://" + url.getHost();
         RestAssured.port = url.getPort();
         String[] userInfo = url.getUserInfo().split(":");

--- a/integration-tests/src/test/java/integration/RestAssuredSetupRule.java
+++ b/integration-tests/src/test/java/integration/RestAssuredSetupRule.java
@@ -21,7 +21,6 @@ import com.jayway.restassured.RestAssured;
 import com.jayway.restassured.authentication.AuthenticationScheme;
 import com.jayway.restassured.builder.RequestSpecBuilder;
 import com.jayway.restassured.config.MatcherConfig;
-import integration.util.graylog.ServerHelper;
 import org.hamcrest.BaseMatcher;
 import org.hamcrest.Description;
 import org.junit.rules.ExternalResource;
@@ -38,7 +37,6 @@ public class RestAssuredSetupRule extends ExternalResource {
 
     @Override
     protected void before() throws Throwable {
-        final ServerHelper serverHelper = new ServerHelper();
         final URL url = IntegrationTestsConfig.getGlServerURL();
         RestAssured.baseURI = url.getProtocol() + "://" + url.getHost();
         RestAssured.port = url.getPort();

--- a/integration-tests/src/test/java/integration/RestAssuredSetupRule.java
+++ b/integration-tests/src/test/java/integration/RestAssuredSetupRule.java
@@ -25,7 +25,7 @@ import org.hamcrest.BaseMatcher;
 import org.hamcrest.Description;
 import org.junit.rules.ExternalResource;
 
-import java.net.URL;
+import java.net.URI;
 
 import static com.jayway.restassured.RestAssured.given;
 import static com.jayway.restassured.RestAssured.preemptive;
@@ -37,10 +37,10 @@ public class RestAssuredSetupRule extends ExternalResource {
 
     @Override
     protected void before() throws Throwable {
-        final URL url = IntegrationTestsConfig.getGlServerURL();
-        RestAssured.baseURI = url.getProtocol() + "://" + url.getHost();
-        RestAssured.port = url.getPort();
-        String[] userInfo = url.getUserInfo().split(":");
+        final URI uri = IntegrationTestsConfig.getGlServerURL();
+        RestAssured.baseURI = uri.getScheme() + "://" + uri.getHost();
+        RestAssured.port = uri.getPort();
+        String[] userInfo = uri.getUserInfo().split(":");
         authenticationScheme = preemptive().basic(userInfo[0], userInfo[1]);
 
         // we want all the details for failed tests

--- a/integration-tests/src/test/java/integration/RestTestIncludingElasticsearch.java
+++ b/integration-tests/src/test/java/integration/RestTestIncludingElasticsearch.java
@@ -1,0 +1,17 @@
+package integration;
+
+import com.lordofthejars.nosqlunit.elasticsearch.ElasticsearchRule;
+import org.elasticsearch.common.settings.ImmutableSettings;
+import org.junit.Rule;
+
+import static com.lordofthejars.nosqlunit.elasticsearch.ElasticsearchRule.ElasticsearchRuleBuilder.newElasticsearchRule;
+import static com.lordofthejars.nosqlunit.elasticsearch.RemoteElasticsearchConfigurationBuilder.remoteElasticsearch;
+
+public class RestTestIncludingElasticsearch extends BaseRestTest {
+    @Rule
+    public ElasticsearchRule elasticsearchRule = newElasticsearchRule().configure(remoteElasticsearch()
+            .host(IntegrationTestsConfig.getEsHost())
+            .settings(ImmutableSettings.builder().put("cluster.name", IntegrationTestsConfig.getEsClusterName()).build())
+            .port(IntegrationTestsConfig.getEsPort()).build()).build();
+
+}

--- a/integration-tests/src/test/java/integration/RestTestIncludingElasticsearch.java
+++ b/integration-tests/src/test/java/integration/RestTestIncludingElasticsearch.java
@@ -1,3 +1,19 @@
+/**
+ * This file is part of Graylog.
+ *
+ * Graylog is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package integration;
 
 import com.lordofthejars.nosqlunit.elasticsearch.ElasticsearchRule;

--- a/integration-tests/src/test/java/integration/search/AbsoluteSearchResourceTest.java
+++ b/integration-tests/src/test/java/integration/search/AbsoluteSearchResourceTest.java
@@ -19,7 +19,6 @@ package integration.search;
 import com.jayway.restassured.path.json.JsonPath;
 import com.jayway.restassured.response.ValidatableResponse;
 import com.lordofthejars.nosqlunit.annotation.UsingDataSet;
-import integration.BaseRestTest;
 import integration.RequiresAuthentication;
 import integration.RestTestIncludingElasticsearch;
 import org.junit.Test;
@@ -65,6 +64,32 @@ public class AbsoluteSearchResourceTest extends RestTestIncludingElasticsearch {
 
         assertThat(response.getInt("total_results")).isEqualTo(0);
         assertThat(response.getList("messages")).isEmpty();
+        assertThat(response.getList("used_indices")).hasSize(1);
+    }
+
+    @Test
+    @UsingDataSet(locations = "searchForExistingKeyword.json")
+    public void searchForExistingKeywordOutsideOfTimeRange() {
+        final ValidatableResponse result = doSearchFor("Testmessage", "2015-06-14T11:32:16.827Z", "2015-06-15T11:32:16.827Z");
+        final JsonPath response = result
+                .statusCode(200)
+                .extract().jsonPath();
+
+        assertThat(response.getInt("total_results")).isEqualTo(0);
+        assertThat(response.getList("messages")).isEmpty();
+        assertThat(response.getList("used_indices")).hasSize(1);
+    }
+
+    @Test
+    @UsingDataSet(locations = "searchForExistingKeyword.json")
+    public void searchForExistingKeywordInsideOfVeryNarrowTimeRange() {
+        final ValidatableResponse result = doSearchFor("Testmessage", "2015-06-16T11:32:16.827Z", "2015-06-16T11:32:16.827Z");
+        final JsonPath response = result
+                .statusCode(200)
+                .extract().jsonPath();
+
+        assertThat(response.getInt("total_results")).isEqualTo(1);
+        assertThat(response.getList("messages")).isNotEmpty();
         assertThat(response.getList("used_indices")).hasSize(1);
     }
 

--- a/integration-tests/src/test/java/integration/search/AbsoluteSearchResourceTest.java
+++ b/integration-tests/src/test/java/integration/search/AbsoluteSearchResourceTest.java
@@ -1,3 +1,19 @@
+/**
+ * This file is part of Graylog.
+ *
+ * Graylog is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package integration.search;
 
 import com.jayway.restassured.path.json.JsonPath;

--- a/integration-tests/src/test/java/integration/search/AbsoluteSearchResourceTest.java
+++ b/integration-tests/src/test/java/integration/search/AbsoluteSearchResourceTest.java
@@ -1,0 +1,75 @@
+package integration.search;
+
+import com.jayway.restassured.path.json.JsonPath;
+import com.jayway.restassured.response.ValidatableResponse;
+import com.lordofthejars.nosqlunit.annotation.UsingDataSet;
+import integration.BaseRestTest;
+import integration.RequiresAuthentication;
+import integration.RestTestIncludingElasticsearch;
+import org.junit.Test;
+
+import static com.jayway.restassured.RestAssured.given;
+import static org.assertj.core.api.Assertions.assertThat;
+
+@RequiresAuthentication
+public class AbsoluteSearchResourceTest extends RestTestIncludingElasticsearch {
+    @Test
+    @UsingDataSet(locations = "searchForExistingKeyword.json")
+    public void searchForAllMessages() {
+        final ValidatableResponse result = doSearchFor("*");
+        final JsonPath response = result
+                .statusCode(200)
+                .extract().jsonPath();
+
+        assertThat(response.getInt("total_results")).isEqualTo(2);
+        assertThat(response.getList("messages")).hasSize(2);
+        assertThat(response.getList("used_indices")).hasSize(1);
+    }
+
+    @Test
+    @UsingDataSet(locations = "searchForExistingKeyword.json")
+    public void searchForExistingKeyword() {
+        final ValidatableResponse result = doSearchFor("Testmessage");
+        final JsonPath response = result
+                .statusCode(200)
+                .extract().jsonPath();
+
+        assertThat(response.getInt("total_results")).isEqualTo(1);
+        assertThat(response.getList("messages")).hasSize(1);
+        assertThat(response.getList("used_indices")).hasSize(1);
+    }
+
+    @Test
+    @UsingDataSet(locations = "searchForExistingKeyword.json")
+    public void searchForNonexistingKeyword() {
+        final ValidatableResponse result = doSearchFor("Nonexistent");
+        final JsonPath response = result
+                .statusCode(200)
+                .extract().jsonPath();
+
+        assertThat(response.getInt("total_results")).isEqualTo(0);
+        assertThat(response.getList("messages")).isEmpty();
+        assertThat(response.getList("used_indices")).hasSize(1);
+    }
+
+    protected ValidatableResponse doSearchFor(String query) {
+        return doSearchFor(query, "1971-03-14T15:09:26.540Z", "2015-08-14T15:09:26.540Z");
+    }
+
+    protected ValidatableResponse doSearchFor(String query, String from, String to) {
+        final ValidatableResponse result = given()
+                .when()
+                .param("query", query)
+                .param("from", from)
+                .param("to", to)
+                .get("/search/universal/absolute")
+                .then()
+                .body(".", containsAllKeys("query", "built_query", "used_indices", "messages", "fields", "time", "total_results", "from", "to"));
+
+        final JsonPath resultBody = result.extract().jsonPath();
+
+        assertThat(resultBody.getString("query")).isEqualTo(query);
+
+        return result;
+    }
+}

--- a/integration-tests/src/test/java/integration/system/collectors/CollectorsTest.java
+++ b/integration-tests/src/test/java/integration/system/collectors/CollectorsTest.java
@@ -20,6 +20,7 @@ import integration.BaseRestTest;
 import integration.RequiresAuthentication;
 import integration.RequiresVersion;
 import org.joda.time.DateTime;
+import org.junit.Ignore;
 import org.junit.Test;
 
 import java.util.List;
@@ -66,8 +67,8 @@ public class CollectorsTest extends BaseRestTest {
                     .assertThat().body("collectors", notNullValue());
     }
 
-    // TODO: reenable after #1273 has been fixed.
-    //@Test
+    @Ignore("TODO: reenable after #1273 has been fixed.")
+    @Test
     @RequiresAuthentication
     public void testGetCollector() throws Exception {
         given().when()

--- a/integration-tests/src/test/java/integration/system/collectors/CollectorsTest.java
+++ b/integration-tests/src/test/java/integration/system/collectors/CollectorsTest.java
@@ -66,7 +66,8 @@ public class CollectorsTest extends BaseRestTest {
                     .assertThat().body("collectors", notNullValue());
     }
 
-    @Test
+    // TODO: reenable after #1273 has been fixed.
+    //@Test
     @RequiresAuthentication
     public void testGetCollector() throws Exception {
         given().when()

--- a/integration-tests/src/test/java/integration/util/graylog/ServerHelper.java
+++ b/integration-tests/src/test/java/integration/util/graylog/ServerHelper.java
@@ -18,6 +18,7 @@ package integration.util.graylog;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import integration.IntegrationTestsConfig;
 import org.apache.commons.codec.binary.Base64;
 import org.apache.http.client.utils.URIBuilder;
 import org.slf4j.Logger;
@@ -31,14 +32,10 @@ import java.net.URISyntaxException;
 import java.net.URL;
 
 public class ServerHelper {
-    private URL url;
     private static final int HTTP_TIMEOUT = 1000;
 
-    public ServerHelper() {
-        this.url = getDefaultServerUrl();
-    }
-
-    public String getNodeId() {
+    public String getNodeId() throws MalformedURLException, URISyntaxException {
+        final URL url = IntegrationTestsConfig.getGlServerURL();
         ObjectMapper mapper = new ObjectMapper();
 
         try {
@@ -59,20 +56,5 @@ public class ServerHelper {
             e.printStackTrace();
         }
         return "00000000-0000-0000-0000-000000000000";
-    }
-
-    public URL getUrl() {
-        return url;
-    }
-
-    private URL getDefaultServerUrl() {
-        try {
-            final URIBuilder uriBuilder = new URIBuilder(System.getProperty("gl2.baseuri", "http://localhost"));
-            uriBuilder.setPort(Integer.parseInt(System.getProperty("gl2.port", "12900")));
-            uriBuilder.setUserInfo(System.getProperty("gl2.admin_user", "admin"), System.getProperty("gl2.admin_password", "admin"));
-            return uriBuilder.build().toURL();
-        } catch (URISyntaxException | MalformedURLException e) {
-            throw new RuntimeException("Invalid URI given. Skipping integration tests.");
-        }
     }
 }

--- a/integration-tests/src/test/java/integration/util/graylog/ServerHelper.java
+++ b/integration-tests/src/test/java/integration/util/graylog/ServerHelper.java
@@ -20,14 +20,12 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import integration.IntegrationTestsConfig;
 import org.apache.commons.codec.binary.Base64;
-import org.apache.http.client.utils.URIBuilder;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.HttpURLConnection;
 import java.net.MalformedURLException;
+import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URL;
 
@@ -35,17 +33,17 @@ public class ServerHelper {
     private static final int HTTP_TIMEOUT = 1000;
 
     public String getNodeId() throws MalformedURLException, URISyntaxException {
-        final URL url = IntegrationTestsConfig.getGlServerURL();
+        final URI uri = IntegrationTestsConfig.getGlServerURL();
         ObjectMapper mapper = new ObjectMapper();
 
         try {
-            HttpURLConnection connection = (HttpURLConnection) new URL(url, "/system").openConnection();
+            HttpURLConnection connection = (HttpURLConnection) new URL(uri.toURL(), "/system").openConnection();
             connection.setConnectTimeout(HTTP_TIMEOUT);
             connection.setReadTimeout(HTTP_TIMEOUT);
             connection.setRequestMethod("GET");
 
-            if (url.getUserInfo() != null) {
-                String encodedUserInfo = Base64.encodeBase64String(url.getUserInfo().getBytes());
+            if (uri.getUserInfo() != null) {
+                String encodedUserInfo = Base64.encodeBase64String(uri.getUserInfo().getBytes());
                 connection.setRequestProperty("Authorization", "Basic " + encodedUserInfo);
             }
 

--- a/integration-tests/src/test/java/integration/util/mongodb/BsonReader.java
+++ b/integration-tests/src/test/java/integration/util/mongodb/BsonReader.java
@@ -56,7 +56,6 @@ public class BsonReader implements DumpReader {
             BSONObject obj;
 
             while((obj = decoder.readObject(fileBytes)) != null) {
-                System.out.println("Real class: " + obj.getClass());
                 final DBObject mongoDocument = new BasicDBObject(obj.toMap());
                 dataset.add(mongoDocument);
             }

--- a/integration-tests/src/test/java/integration/util/mongodb/MongodbSeed.java
+++ b/integration-tests/src/test/java/integration/util/mongodb/MongodbSeed.java
@@ -21,6 +21,7 @@ import com.mongodb.DB;
 import com.mongodb.DBCollection;
 import com.mongodb.DBObject;
 import com.mongodb.MongoClient;
+import integration.IntegrationTestsConfig;
 
 import java.io.IOException;
 import java.net.URI;
@@ -31,14 +32,14 @@ import java.util.Map;
 
 public class MongodbSeed {
     private final MongoClient mongoClient;
-    private final String dbName;
+    private final DB mongoDatabase;
 
     public MongodbSeed(String dbName) throws UnknownHostException {
-        this.dbName = dbName;
         mongoClient = new MongoClient(
-                URI.create(System.getProperty("gl2.baseuri", "http://localhost")).getHost(),
-                Integer.parseInt(System.getProperty("mongodb.port", "27017")));
-        mongoClient.dropDatabase(dbName);
+                IntegrationTestsConfig.getMongodbHost(),
+                IntegrationTestsConfig.getMongodbPort());
+        mongoDatabase = mongoClient.getDB(dbName);
+        mongoDatabase.dropDatabase();
     }
 
     private Map<String, List<DBObject>> parseDatabaseDump(URL seedUrl) throws IOException {
@@ -88,8 +89,6 @@ public class MongodbSeed {
         Map<String, List<DBObject>> collections = parseDatabaseDump(dbPath);
         collections = updateNodeIdFirstNode(collections, nodeId);
         collections = updateNodeIdInputs(collections, nodeId);
-
-        final DB mongoDatabase = mongoClient.getDB(dbName);
 
         for (Map.Entry<String, List<DBObject>> collection : collections.entrySet()) {
             final String collectionName = collection.getKey();

--- a/integration-tests/src/test/resources/integration/search/searchForExistingKeyword.json
+++ b/integration-tests/src/test/resources/integration/search/searchForExistingKeyword.json
@@ -1,0 +1,58 @@
+{
+  "documents": [
+    {
+      "document" : [
+        {
+          "index" : {
+            "indexName": "graylog_0",
+            "indexType": "message",
+            "indexId": "576f90b1-141b-11e5-bf34-e62d59a65072"
+          }
+        },
+        {
+          "data" : {
+            "http_response_code": 200,
+            "gl2_source_node": "f7d48187-686d-4016-b987-a6b24a4eeda2",
+            "resource": "/posts/45326",
+            "http_method": "GET",
+            "timestamp": "2015-06-16 11:32:16.827",
+            "message": "Testmessage",
+            "took_ms": 109,
+            "_id": "576f90b1-141b-11e5-bf34-e62d59a65072",
+            "source": "anotherdoma.in",
+            "gl2_source_input": "557564533b0ce57b68491699",
+            "action": "show",
+            "streams": [
+              "552b92b2e4b0c055e41ffb8e"
+            ],
+            "user_id": 6469981,
+            "controller": "PostsController"
+          }
+        }
+      ]
+    },
+    {
+      "document" : [
+        {
+          "index" : {
+            "indexName": "graylog_0",
+            "indexType": "message",
+            "indexId": "8ef41791-8a91-11e4-a8ac-be1f2031eed1"
+          }
+        },
+        {
+          "data" : {
+            "timestamp": "2014-12-23 10:50:50.121",
+            "message": "successful POST",
+            "randominput": "true",
+            "_id": "8ef41791-8a91-11e4-a8ac-be1f2031eed1",
+            "source": "example.org",
+            "gl2_source_input": "5492c8aa7d8446d2e4c8a764",
+            "gl2_source_node": "f7d48187-686d-4016-b987-a6b24a4eeda2",
+            "streams": [ ]
+          }
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
This is a follow up to https://github.com/Graylog2/graylog2-server/pull/1263, adding:

- elasticsearch integration by supplying a test superclass that is configuring a remote ES
- extraction of system properties parsing used for configuring the test run to separate class
- allow to override default mongodb database name