### PR TITLE
Update Netty and AsyncHttpClient

### DIFF
--- a/graylog2-rest-client/src/main/java/org/graylog2/restclient/lib/APIException.java
+++ b/graylog2-rest-client/src/main/java/org/graylog2/restclient/lib/APIException.java
@@ -62,7 +62,7 @@ public class APIException extends Exception {
             sb.append(request.getMethod());
             sb.append(' ');
             try {
-                final URI uri = request.getURI();
+                final URI uri = request.getUri().toJavaNetURI();
                 final String userInfo = uri.getUserInfo();
                 String username = "";
                 if (userInfo != null) {

--- a/graylog2-rest-client/src/test/java/org/graylog2/restclient/lib/ApiClientTest.java
+++ b/graylog2-rest-client/src/test/java/org/graylog2/restclient/lib/ApiClientTest.java
@@ -18,6 +18,7 @@ package org.graylog2.restclient.lib;
 
 import com.ning.http.client.AsyncHttpClient;
 import com.ning.http.client.AsyncHttpClientConfig;
+import com.ning.http.client.uri.Uri;
 import org.graylog2.restclient.models.Node;
 import org.graylog2.restclient.models.api.responses.EmptyResponse;
 import org.junit.After;
@@ -55,13 +56,13 @@ public class ApiClientTest extends BaseApiTest {
 
         final URL queryParamWithDoubleQuotes = api.get(EmptyResponse.class).path("/some/resource").queryParam("query", " \".+\"").node(node).unauthenticated().prepareUrl(node);
         Assert.assertEquals("query param with \" should be escaped",
-                            "query=+%22.%2B%22",
-                            queryParamWithDoubleQuotes.getQuery());
-        
+                "query=+%22.%2B%22",
+                queryParamWithDoubleQuotes.getQuery());
+
         final URL urlWithNonAsciiChars = api.get(EmptyResponse.class).node(node).path("/some/resourçe").unauthenticated().prepareUrl(node);
         Assert.assertEquals("non-ascii chars are escaped in path",
-                            "/some/resour%C3%A7e",
-                            urlWithNonAsciiChars.getPath());
+                "/some/resour%C3%A7e",
+                urlWithNonAsciiChars.getPath());
 
         final URL queryWithAmp = api.get(EmptyResponse.class).node(node).path("/").queryParam("foo", "this&that").prepareUrl(node);
         Assert.assertEquals("Query params are escaped", "foo=this%26that", queryWithAmp.getQuery());
@@ -81,7 +82,8 @@ public class ApiClientTest extends BaseApiTest {
                         .unauthenticated()
                         .node(node)
                         .timeout(1, TimeUnit.SECONDS);
-        stubHttpProvider.expectResponse(requestBuilder.prepareUrl(node), 200, "{}");
+        final URL url = requestBuilder.prepareUrl(node);
+        stubHttpProvider.expectResponse(Uri.create(url.toString()), 200, "{}");
         final EmptyResponse response = requestBuilder.execute();
 
         Assert.assertNotNull(response);
@@ -101,8 +103,8 @@ public class ApiClientTest extends BaseApiTest {
         final ApiRequestBuilder<EmptyResponse> requestBuilder = api.get(EmptyResponse.class).path("/some/resource");
         final URL url1 = requestBuilder.prepareUrl(node1);
         final URL url2 = requestBuilder.prepareUrl(node2);
-        stubHttpProvider.expectResponse(url1, 200, "{}");
-        stubHttpProvider.expectResponse(url2, 200, "{}");
+        stubHttpProvider.expectResponse(Uri.create(url1.toString()), 200, "{}");
+        stubHttpProvider.expectResponse(Uri.create(url2.toString()), 200, "{}");
 
         final Map<Node, EmptyResponse> responses = requestBuilder.nodes(node1, node2).executeOnAll();
         Assert.assertFalse(responses.isEmpty());
@@ -112,7 +114,7 @@ public class ApiClientTest extends BaseApiTest {
     @Before
     public void setUp() throws Exception {
         AsyncHttpClientConfig.Builder builder = new AsyncHttpClientConfig.Builder();
-        builder.setAllowPoolingConnection(false);
+        builder.setAllowPoolingConnections(false);
         stubHttpProvider = new StubHttpProvider();
         client = new AsyncHttpClient(stubHttpProvider, builder.build());
     }

--- a/graylog2-rest-client/src/test/java/org/graylog2/restclient/lib/ServerNodesTest.java
+++ b/graylog2-rest-client/src/test/java/org/graylog2/restclient/lib/ServerNodesTest.java
@@ -30,7 +30,10 @@ import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
 
 public class ServerNodesTest extends BaseApiTest {
 
@@ -62,7 +65,7 @@ public class ServerNodesTest extends BaseApiTest {
 
     @Test
     public void testFailureCountParallelExecute() throws Exception {
-        setupNodes(AddressNodeId.create("http://localhost:65535"),AddressNodeId.create("http://localhost:65534"));
+        setupNodes(AddressNodeId.create("http://localhost:65535"), AddressNodeId.create("http://localhost:65534"));
         api.setHttpClient(client);
 
         final Map<Node, EmptyResponse> emptyResponses = api.put().path("/").executeOnAll();
@@ -71,7 +74,7 @@ public class ServerNodesTest extends BaseApiTest {
         final List<Node> nodes = serverNodes.all(true);
         Node failedNode = nodes.get(0);
         Node failedNode2 = nodes.get(1);
-        assertFalse("Node should be inactive" , failedNode.isActive());
+        assertFalse("Node should be inactive", failedNode.isActive());
         assertFalse("Node should be inactive", failedNode2.isActive());
         assertEquals(1, failedNode.getFailureCount());
         assertEquals(1, failedNode2.getFailureCount());
@@ -119,7 +122,7 @@ public class ServerNodesTest extends BaseApiTest {
     @Before
     public void setUp() throws Exception {
         AsyncHttpClientConfig.Builder builder = new AsyncHttpClientConfig.Builder();
-        builder.setAllowPoolingConnection(false);
+        builder.setAllowPoolingConnections(false);
         client = new AsyncHttpClient(builder.build());
     }
 

--- a/pom.xml
+++ b/pom.xml
@@ -286,7 +286,7 @@
             <dependency>
                 <groupId>io.netty</groupId>
                 <artifactId>netty</artifactId>
-                <version>3.9.8.Final</version>
+                <version>3.10.4.Final</version>
             </dependency>
             <dependency>
                 <groupId>com.jayway.jsonpath</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -296,7 +296,7 @@
             <dependency>
                 <groupId>com.ning</groupId>
                 <artifactId>async-http-client</artifactId>
-                <version>1.8.14</version>
+                <version>1.9.29</version>
             </dependency>
             <dependency>
                 <groupId>com.squareup.okhttp</groupId>


### PR DESCRIPTION
There have been some backwards-incompatible changes in Netty 3.10.x which requires an update to AsyncHttpClient 1.9.x which in turn also has some backwards-incompatible changes.