### PR TITLE
Handle exceptions in the JournallingMessageHandler.

### DIFF
--- a/graylog2-shared/pom.xml
+++ b/graylog2-shared/pom.xml
@@ -67,6 +67,10 @@
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
         </dependency>
+        <dependency>
+            <groupId>com.github.rholder</groupId>
+            <artifactId>guava-retrying</artifactId>
+        </dependency>
 
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>

--- a/graylog2-shared/src/main/java/org/graylog2/shared/buffers/JournallingMessageHandler.java
+++ b/graylog2-shared/src/main/java/org/graylog2/shared/buffers/JournallingMessageHandler.java
@@ -20,6 +20,7 @@ import com.codahale.metrics.Counter;
 import com.codahale.metrics.MetricRegistry;
 import com.google.common.base.Function;
 import com.google.common.collect.Lists;
+import com.google.common.util.concurrent.Uninterruptibles;
 import com.lmax.disruptor.EventHandler;
 import org.graylog2.shared.journal.Journal;
 import org.slf4j.Logger;
@@ -30,7 +31,10 @@ import javax.inject.Inject;
 import javax.inject.Named;
 import java.util.List;
 import java.util.concurrent.Semaphore;
+import java.util.concurrent.TimeUnit;
 
+import static com.google.common.base.Predicates.notNull;
+import static com.google.common.collect.Collections2.filter;
 import static com.google.common.collect.Lists.transform;
 
 public class JournallingMessageHandler implements EventHandler<RawMessageEvent> {
@@ -58,14 +62,30 @@ public class JournallingMessageHandler implements EventHandler<RawMessageEvent> 
 
             final Converter converter = new Converter();
             // copy to avoid re-running this all the time
-            final List<Journal.Entry> entries = Lists.newArrayList(transform(batch, converter));
-            final long lastOffset = journal.write(entries);
-            log.debug("Processed batch, wrote {} bytes, last journal offset: {}, signalling reader.",
-                      converter.getBytesWritten(),
-                      lastOffset);
-            journalFilled.release();
+            // Remove all null values returned from the converter (might happen if the Converter throws an exception)
+            final List<Journal.Entry> entries = Lists.newArrayList(filter(transform(batch, converter), notNull()));
 
+            // Clear the batch list after transforming it with the Converter because the fields of the RawMessageEvent
+            // objects in there have been set to null and cannot be used anymore.
             batch.clear();
+
+            // Catch all exceptions that might happen during the journal write and retry the operation.
+            // This basically blocks if the journal write always throws an exception. Once the write succeeds, we will
+            // continue.
+            boolean done = false;
+            do {
+                try {
+                    final long lastOffset = journal.write(entries);
+                    log.debug("Processed batch, wrote {} bytes, last journal offset: {}, signalling reader.",
+                            converter.getBytesWritten(),
+                            lastOffset);
+                    journalFilled.release();
+                    done = true;
+                } catch (Exception e) {
+                    log.error("Unable to write to journal - retrying after 250ms", e);
+                    Uninterruptibles.sleepUninterruptibly(250, TimeUnit.MILLISECONDS);
+                }
+            } while (!done);
         }
     }
 
@@ -79,22 +99,27 @@ public class JournallingMessageHandler implements EventHandler<RawMessageEvent> 
         @Nullable
         @Override
         public Journal.Entry apply(RawMessageEvent input) {
-            if (log.isTraceEnabled()) {
-                log.trace("Journalling message {}", input.getMessageId());
+            try {
+                if (log.isTraceEnabled()) {
+                    log.trace("Journalling message {}", input.getMessageId());
+                }
+                final byte[] messageIdBytes = input.getMessageIdBytes();
+                final byte[] encodedRawMessage = input.getEncodedRawMessage();
+
+                // stats
+                final int size = encodedRawMessage.length;
+                bytesWritten += size;
+                byteCounter.inc(size);
+
+                // clear for gc and to avoid promotion to tenured space
+                input.setMessageIdBytes(null);
+                input.setEncodedRawMessage(null);
+                // convert to journal entry
+                return journal.createEntry(messageIdBytes, encodedRawMessage);
+            } catch (Exception e) {
+                log.error("Unable to convert RawMessageEvent to Journal.Entry - skipping event", e);
+                return null;
             }
-            final byte[] messageIdBytes = input.getMessageIdBytes();
-            final byte[] encodedRawMessage = input.getEncodedRawMessage();
-
-            // stats
-            final int size = encodedRawMessage.length;
-            bytesWritten += size;
-            byteCounter.inc(size);
-
-            // clear for gc and to avoid promotion to tenured space
-            input.setMessageIdBytes(null);
-            input.setEncodedRawMessage(null);
-            // convert to journal entry
-            return journal.createEntry(messageIdBytes, encodedRawMessage);
         }
     }
 }

--- a/graylog2-shared/src/main/java/org/graylog2/shared/buffers/RawMessageEvent.java
+++ b/graylog2-shared/src/main/java/org/graylog2/shared/buffers/RawMessageEvent.java
@@ -27,11 +27,11 @@ import java.nio.ByteBuffer;
 public class RawMessageEvent {
 
     // the rawmessage will get be nulled as soon as the encoded raw message is being generated
-    private volatile RawMessage rawMessage;
+    private RawMessage rawMessage;
 
     // once these fields are set, do NOT rely on rawMessage still being non-null!
-    private volatile byte[] messageIdBytes;
-    private volatile byte[] encodedRawMessage;
+    private byte[] messageIdBytes;
+    private byte[] encodedRawMessage;
 
     public static final EventFactory<RawMessageEvent> FACTORY = new EventFactory<RawMessageEvent>() {
         @Override


### PR DESCRIPTION
Before this, an exception from the journal would leave invalid
RawMessageEvent objects in the batch List because the Converter sets
all fields to null after transforming the objects to Journal.Entry
objects. The batch List was not cleared in this case.
With the next endOfBatch the Converter tried to transform the broken
objects again and threw a NPE because the fields are null.

This caused exceptions for every new event coming in and eventually
filled up the memory because the unbounded batch List was never cleared.