### PR TITLE
Use synchronous replication for bulk indexing

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/indexer/indices/Indices.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/indices/Indices.java
@@ -120,7 +120,6 @@ public class Indices implements IndexManagement {
             }
 
             request.setConsistencyLevel(WriteConsistencyLevel.ONE);
-            request.setReplicationType(ReplicationType.ASYNC);
 
             if (request.numberOfActions() > 0) {
                 BulkResponse response = c.bulk(request.request()).actionGet();

--- a/graylog2-server/src/main/java/org/graylog2/indexer/messages/Messages.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/messages/Messages.java
@@ -98,13 +98,12 @@ public class Messages {
 
         final BulkRequestBuilder request = c.prepareBulk();
         for (Message msg : messages) {
-            request.add(buildIndexRequest(configuration.getIndexPrefix() + "_" + Deflector.DEFLECTOR_SUFFIX,
+            request.add(buildIndexRequest(Deflector.buildName(configuration.getIndexPrefix()),
                                           msg.toElasticSearchObject(),
                                           msg.getId())); // Main index.
         }
 
         request.setConsistencyLevel(WriteConsistencyLevel.ONE);
-        request.setReplicationType(ReplicationType.ASYNC);
 
         final BulkResponse response = c.bulk(request.request()).actionGet();
 


### PR DESCRIPTION
Asynchronous replication will be removed in Elasticsearch 2.0. (elastic/elasticsearch#10114).