### PR TITLE
Allow startup without working Elasticsearch cluster

### DIFF
--- a/graylog2-rest-client/src/main/java/org/graylog2/restclient/models/Notification.java
+++ b/graylog2-rest-client/src/main/java/org/graylog2/restclient/models/Notification.java
@@ -28,6 +28,8 @@ public class Notification {
         MULTI_MASTER,
         NO_MASTER,
         ES_OPEN_FILES,
+        ES_CLUSTER_RED,
+        ES_UNAVAILABLE,
         NO_INPUT_RUNNING,
         INPUT_FAILED_TO_START,
         CHECK_SERVER_CLOCKS,

--- a/graylog2-server/src/main/java/org/graylog2/notifications/Notification.java
+++ b/graylog2-server/src/main/java/org/graylog2/notifications/Notification.java
@@ -47,11 +47,13 @@ public interface Notification extends Persisted {
 
     Notification addNode(String nodeId);
 
-    public enum Type {
+    enum Type {
         DEFLECTOR_EXISTS_AS_INDEX,
         MULTI_MASTER,
         NO_MASTER,
         ES_OPEN_FILES,
+        ES_CLUSTER_RED,
+        ES_UNAVAILABLE,
         NO_INPUT_RUNNING,
         INPUT_FAILED_TO_START,
         CHECK_SERVER_CLOCKS,
@@ -66,7 +68,7 @@ public interface Notification extends Persisted {
         GENERIC
     }
 
-    public enum Severity {
+    enum Severity {
         NORMAL, URGENT
     }
 }

--- a/graylog2-server/src/main/java/org/graylog2/outputs/BlockingBatchedESOutput.java
+++ b/graylog2-server/src/main/java/org/graylog2/outputs/BlockingBatchedESOutput.java
@@ -34,6 +34,7 @@ import org.slf4j.LoggerFactory;
 
 import javax.inject.Inject;
 import java.util.List;
+import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
 
@@ -109,7 +110,7 @@ public class BlockingBatchedESOutput extends ElasticSearchOutput {
         if (!cluster.isConnectedAndHealthy()) {
             try {
                 cluster.waitForConnectedAndHealthy();
-            } catch (InterruptedException e) {
+            } catch (TimeoutException | InterruptedException e) {
                 log.warn("Error while waiting for healthy Elasticsearch cluster. Not flushing.", e);
                 return;
             }


### PR DESCRIPTION
The previous implementation of `IndexerSetupService` (and related classes) would shutdown Graylog if Elasticsearch wasn't available or the cluster health state was RED on startup. This made sense as long as Graylog didn't have a proper on-disk journal in which messages could be persistently buffered.

The new implementation simply acknowledges the unavailability of Elasticsearch and generates an appropriate system notification (and log entries) but does not shutdown Graylog.

Fixes #1136