### PR TITLE
Remove hard-coded limit for UDP receive buffer size

### DIFF
--- a/graylog2-inputs/src/main/java/org/graylog2/inputs/transports/UdpTransport.java
+++ b/graylog2-inputs/src/main/java/org/graylog2/inputs/transports/UdpTransport.java
@@ -67,7 +67,7 @@ public class UdpTransport extends NettyTransport {
     public Bootstrap getBootstrap() {
         final ConnectionlessBootstrap bootstrap = new ConnectionlessBootstrap(new NioDatagramChannelFactory(workerExecutor));
 
-        final int recvBufferSize = Math.min(Ints.saturatedCast(getRecvBufferSize()), 65536);
+        final int recvBufferSize = Ints.saturatedCast(getRecvBufferSize());
         LOG.debug("Setting receive buffer size to {} bytes", recvBufferSize);
         bootstrap.setOption("receiveBufferSizePredictorFactory", new FixedReceiveBufferSizePredictorFactory(recvBufferSize));
         bootstrap.setOption("receiveBufferSize", recvBufferSize);

--- a/graylog2-inputs/src/main/java/org/graylog2/inputs/transports/UdpTransport.java
+++ b/graylog2-inputs/src/main/java/org/graylog2/inputs/transports/UdpTransport.java
@@ -17,6 +17,7 @@
 package org.graylog2.inputs.transports;
 
 import com.codahale.metrics.InstrumentedExecutorService;
+import com.github.joschi.jadconfig.util.Size;
 import com.google.common.primitives.Ints;
 import com.google.common.util.concurrent.ThreadFactoryBuilder;
 import com.google.inject.assistedinject.Assisted;
@@ -90,7 +91,8 @@ public class UdpTransport extends NettyTransport {
         public ConfigurationRequest getRequestedConfiguration() {
             final ConfigurationRequest r = super.getRequestedConfiguration();
 
-            r.addField(ConfigurationRequest.Templates.recvBufferSize(CK_RECV_BUFFER_SIZE, 16384));
+            final int recvBufferSize = Ints.saturatedCast(Size.kilobytes(256L).toBytes());
+            r.addField(ConfigurationRequest.Templates.recvBufferSize(CK_RECV_BUFFER_SIZE, recvBufferSize));
 
             return r;
         }

--- a/graylog2-inputs/src/test/java/org/graylog2/inputs/transports/UdpTransportTest.java
+++ b/graylog2-inputs/src/test/java/org/graylog2/inputs/transports/UdpTransportTest.java
@@ -211,7 +211,7 @@ public class UdpTransportTest {
         final UdpTransport.Config config = new UdpTransport.Config();
         final ConfigurationRequest requestedConfiguration = config.getRequestedConfiguration();
 
-        assertThat(requestedConfiguration.getField(NettyTransport.CK_RECV_BUFFER_SIZE).getDefaultValue()).isEqualTo(16384);
+        assertThat(requestedConfiguration.getField(NettyTransport.CK_RECV_BUFFER_SIZE).getDefaultValue()).isEqualTo(262144);
     }
 
     private void sendUdpDatagram(String hostname, int port, int size) throws IOException {

--- a/graylog2-inputs/src/test/java/org/graylog2/inputs/transports/UdpTransportTest.java
+++ b/graylog2-inputs/src/test/java/org/graylog2/inputs/transports/UdpTransportTest.java
@@ -16,7 +16,9 @@
  */
 package org.graylog2.inputs.transports;
 
+import com.github.joschi.jadconfig.util.Size;
 import com.google.common.collect.ImmutableMap;
+import com.google.common.primitives.Ints;
 import com.google.common.util.concurrent.Callables;
 import com.google.common.util.concurrent.Uninterruptibles;
 import org.apache.commons.lang3.SystemUtils;
@@ -179,15 +181,16 @@ public class UdpTransportTest {
     }
 
     @Test
-    public void receiveBufferSizeIsLimited() throws Exception {
+    public void receiveBufferSizeIsNotLimited() throws Exception {
+        final int recvBufferSize = Ints.saturatedCast(Size.megabytes(1L).toBytes());
         ImmutableMap<String, Object> source = ImmutableMap.<String, Object>of(
                 NettyTransport.CK_BIND_ADDRESS, BIND_ADDRESS,
                 NettyTransport.CK_PORT, PORT,
-                NettyTransport.CK_RECV_BUFFER_SIZE, Integer.MAX_VALUE);
+                NettyTransport.CK_RECV_BUFFER_SIZE, recvBufferSize);
         Configuration config = new Configuration(source);
         UdpTransport udpTransport = new UdpTransport(config, throughputCounter, new LocalMetricRegistry());
 
-        assertThat(udpTransport.getBootstrap().getOption("receiveBufferSize")).isEqualTo(65536);
+        assertThat(udpTransport.getBootstrap().getOption("receiveBufferSize")).isEqualTo(recvBufferSize);
     }
 
     @Test


### PR DESCRIPTION
This PR removes the hard-coded upper limit of 64 KiB for the receive buffer size of UDP inputs. Additionally it increases the default from 16 KiB to 256 KiB.