### PR TITLE
Adding basic OR-matching for Streams.

### DIFF
--- a/graylog2-plugin-interfaces/src/main/java/org/graylog2/plugin/streams/Stream.java
+++ b/graylog2-plugin-interfaces/src/main/java/org/graylog2/plugin/streams/Stream.java
@@ -22,11 +22,14 @@
  */
 package org.graylog2.plugin.streams;
 
+import com.fasterxml.jackson.annotation.JsonValue;
 import org.graylog2.plugin.database.Persisted;
 
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+
+import static com.google.common.base.Strings.emptyToNull;
 
 public interface Stream extends Persisted {
     enum MatchingType {
@@ -36,7 +39,7 @@ public interface Stream extends Persisted {
         public static final MatchingType DEFAULT = AND;
 
         public static MatchingType valueOfOrDefault(String name) {
-            return (name == null ? DEFAULT : valueOf(name));
+            return (emptyToNull(name) == null ? DEFAULT : valueOf(name));
         }
     }
 

--- a/graylog2-plugin-interfaces/src/main/java/org/graylog2/plugin/streams/Stream.java
+++ b/graylog2-plugin-interfaces/src/main/java/org/graylog2/plugin/streams/Stream.java
@@ -29,34 +29,40 @@ import java.util.Map;
 import java.util.Set;
 
 public interface Stream extends Persisted {
+    enum MatchingType {
+        AND,
+        OR
+    }
 
-    public String getId();
+    String getId();
 
-    public String getTitle();
+    String getTitle();
 
-    public String getDescription();
+    String getDescription();
 
-    public Boolean getDisabled();
+    Boolean getDisabled();
 
-    public String getContentPack();
+    String getContentPack();
 
-    public void setTitle(String title);
+    void setTitle(String title);
 
-    public void setDescription(String description);
+    void setDescription(String description);
 
-    public void setDisabled(Boolean disabled);
+    void setDisabled(Boolean disabled);
 
-    public void setContentPack(String contentPack);
+    void setContentPack(String contentPack);
 
-    public Boolean isPaused();
+    Boolean isPaused();
 
     Map<String, List<String>> getAlertReceivers();
 
-    public Map<String, Object> asMap(List<StreamRule> streamRules);
+    Map<String, Object> asMap(List<StreamRule> streamRules);
 
-    public String toString();
+    String toString();
 
-    public List<StreamRule> getStreamRules();
+    List<StreamRule> getStreamRules();
 
-    public Set<Output> getOutputs();
+    Set<Output> getOutputs();
+
+    MatchingType getMatchingType();
 }

--- a/graylog2-plugin-interfaces/src/main/java/org/graylog2/plugin/streams/Stream.java
+++ b/graylog2-plugin-interfaces/src/main/java/org/graylog2/plugin/streams/Stream.java
@@ -22,7 +22,6 @@
  */
 package org.graylog2.plugin.streams;
 
-import com.fasterxml.jackson.annotation.JsonValue;
 import org.graylog2.plugin.database.Persisted;
 
 import java.util.List;

--- a/graylog2-plugin-interfaces/src/main/java/org/graylog2/plugin/streams/Stream.java
+++ b/graylog2-plugin-interfaces/src/main/java/org/graylog2/plugin/streams/Stream.java
@@ -31,7 +31,13 @@ import java.util.Set;
 public interface Stream extends Persisted {
     enum MatchingType {
         AND,
-        OR
+        OR;
+
+        public static final MatchingType DEFAULT = AND;
+
+        public static MatchingType valueOfOrDefault(String name) {
+            return (name == null ? DEFAULT : valueOf(name));
+        }
     }
 
     String getId();

--- a/graylog2-plugin-interfaces/src/test/java/org/graylog2/plugin/streams/MatchingTypeTest.java
+++ b/graylog2-plugin-interfaces/src/test/java/org/graylog2/plugin/streams/MatchingTypeTest.java
@@ -1,0 +1,21 @@
+package org.graylog2.plugin.streams;
+
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+public class MatchingTypeTest {
+
+    @Test
+    public void testValueOfOrDefault() throws Exception {
+        assertEquals(Stream.MatchingType.valueOfOrDefault("AND"), Stream.MatchingType.AND);
+        assertEquals(Stream.MatchingType.valueOfOrDefault("OR"), Stream.MatchingType.OR);
+        assertEquals(Stream.MatchingType.valueOfOrDefault(null), Stream.MatchingType.DEFAULT);
+        assertEquals(Stream.MatchingType.valueOfOrDefault(""), Stream.MatchingType.DEFAULT);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testValueOfOrDefaultThrowsExceptionForUnknownEnumName() {
+        Stream.MatchingType.valueOfOrDefault("FOO");
+    }
+}

--- a/graylog2-plugin-interfaces/src/test/java/org/graylog2/plugin/streams/MatchingTypeTest.java
+++ b/graylog2-plugin-interfaces/src/test/java/org/graylog2/plugin/streams/MatchingTypeTest.java
@@ -1,3 +1,25 @@
+/**
+ * The MIT License
+ * Copyright (c) 2012 Graylog, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
 package org.graylog2.plugin.streams;
 
 import org.junit.Test;

--- a/graylog2-server/src/main/java/org/graylog2/rest/resources/streams/requests/CreateStreamRequest.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/resources/streams/requests/CreateStreamRequest.java
@@ -44,11 +44,16 @@ public abstract class CreateStreamRequest {
     @Nullable
     public abstract String contentPack();
 
+    @JsonProperty
+    @Nullable
+    public abstract String matchingType();
+
     @JsonCreator
     public static CreateStreamRequest create(@JsonProperty("title") @NotEmpty String title,
                                              @JsonProperty("description") @Nullable String description,
                                              @JsonProperty("rules") @Nullable List<CreateStreamRuleRequest> rules,
-                                             @JsonProperty("content_pack") @Nullable String contentPack) {
-        return new AutoValue_CreateStreamRequest(title, description, rules, contentPack);
+                                             @JsonProperty("content_pack") @Nullable String contentPack,
+                                             @JsonProperty("matching_type") @Nullable String matchingType) {
+        return new AutoValue_CreateStreamRequest(title, description, rules, contentPack, matchingType);
     }
 }

--- a/graylog2-server/src/main/java/org/graylog2/rest/resources/streams/requests/CreateStreamRequest.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/resources/streams/requests/CreateStreamRequest.java
@@ -46,7 +46,6 @@ public abstract class CreateStreamRequest {
     public abstract String contentPack();
 
     @JsonProperty
-    @Nullable
     public abstract Stream.MatchingType matchingType();
 
     @JsonCreator

--- a/graylog2-server/src/main/java/org/graylog2/rest/resources/streams/requests/CreateStreamRequest.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/resources/streams/requests/CreateStreamRequest.java
@@ -54,7 +54,7 @@ public abstract class CreateStreamRequest {
                                              @JsonProperty("description") @Nullable String description,
                                              @JsonProperty("rules") @Nullable List<CreateStreamRuleRequest> rules,
                                              @JsonProperty("content_pack") @Nullable String contentPack,
-                                             @JsonProperty("matching_type") @Nullable Stream.MatchingType matchingType) {
-        return new AutoValue_CreateStreamRequest(title, description, rules, contentPack, matchingType);
+                                             @JsonProperty("matching_type") @Nullable String matchingType) {
+        return new AutoValue_CreateStreamRequest(title, description, rules, contentPack, Stream.MatchingType.valueOfOrDefault(matchingType));
     }
 }

--- a/graylog2-server/src/main/java/org/graylog2/rest/resources/streams/requests/CreateStreamRequest.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/resources/streams/requests/CreateStreamRequest.java
@@ -20,6 +20,7 @@ import com.fasterxml.jackson.annotation.JsonAutoDetect;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.auto.value.AutoValue;
+import org.graylog2.plugin.streams.Stream;
 import org.graylog2.rest.resources.streams.rules.requests.CreateStreamRuleRequest;
 import org.hibernate.validator.constraints.NotEmpty;
 
@@ -46,14 +47,14 @@ public abstract class CreateStreamRequest {
 
     @JsonProperty
     @Nullable
-    public abstract String matchingType();
+    public abstract Stream.MatchingType matchingType();
 
     @JsonCreator
     public static CreateStreamRequest create(@JsonProperty("title") @NotEmpty String title,
                                              @JsonProperty("description") @Nullable String description,
                                              @JsonProperty("rules") @Nullable List<CreateStreamRuleRequest> rules,
                                              @JsonProperty("content_pack") @Nullable String contentPack,
-                                             @JsonProperty("matching_type") @Nullable String matchingType) {
+                                             @JsonProperty("matching_type") @Nullable Stream.MatchingType matchingType) {
         return new AutoValue_CreateStreamRequest(title, description, rules, contentPack, matchingType);
     }
 }

--- a/graylog2-server/src/main/java/org/graylog2/streams/StreamImpl.java
+++ b/graylog2-server/src/main/java/org/graylog2/streams/StreamImpl.java
@@ -54,6 +54,7 @@ public class StreamImpl extends PersistedImpl implements Stream {
     public static final String FIELD_DISABLED = "disabled";
     public static final String FIELD_CREATED_AT = "created_at";
     public static final String FIELD_CREATOR_USER_ID = "creator_user_id";
+    public static final String FIELD_MATCHING_TYPE = "matching_type";
     public static final String EMBEDDED_ALERT_CONDITIONS = "alert_conditions";
 
     private final List<StreamRule> streamRules;
@@ -193,4 +194,14 @@ public class StreamImpl extends PersistedImpl implements Stream {
         return (Map<String, List<String>>) fields.get(FIELD_ALERT_RECEIVERS);
     }
 
+    @Override
+    public MatchingType getMatchingType() {
+        final String matchingTypeString = (String)fields.get(FIELD_MATCHING_TYPE);
+
+        if (matchingTypeString == null) {
+            return MatchingType.AND;
+        } else {
+            return MatchingType.valueOf(matchingTypeString);
+        }
+    }
 }

--- a/graylog2-server/src/main/java/org/graylog2/streams/StreamRouterEngine.java
+++ b/graylog2-server/src/main/java/org/graylog2/streams/StreamRouterEngine.java
@@ -68,7 +68,7 @@ public class StreamRouterEngine {
     private final Set<String> regexFields = Sets.newHashSet();
 
     public interface Factory {
-        public StreamRouterEngine create(List<Stream> streams, ExecutorService executorService);
+        StreamRouterEngine create(List<Stream> streams, ExecutorService executorService);
     }
 
     @Inject

--- a/graylog2-server/src/main/java/org/graylog2/streams/StreamRouterEngine.java
+++ b/graylog2-server/src/main/java/org/graylog2/streams/StreamRouterEngine.java
@@ -248,8 +248,10 @@ public class StreamRouterEngine {
     private class StreamMatch {
         private final int ruleCount;
         private int matches = 0;
+        private final Stream stream;
 
         public StreamMatch(Stream stream) {
+            this.stream = stream;
             this.ruleCount = stream.getStreamRules().size();
         }
 
@@ -258,8 +260,11 @@ public class StreamRouterEngine {
         }
 
         public boolean isMatched() {
-            // If a stream has multiple stream rules, all of the rules have to match.
-            return ruleCount == matches;
+            switch (stream.getMatchingType()) {
+                case AND: return ruleCount == matches;
+                case OR: return ruleCount > 0;
+                default: return ruleCount == matches;
+            }
         }
     }
 

--- a/graylog2-server/src/main/java/org/graylog2/streams/StreamServiceImpl.java
+++ b/graylog2-server/src/main/java/org/graylog2/streams/StreamServiceImpl.java
@@ -95,6 +95,7 @@ public class StreamServiceImpl extends PersistedServiceImpl implements StreamSer
         streamData.put(StreamImpl.FIELD_CREATOR_USER_ID, userId);
         streamData.put(StreamImpl.FIELD_CREATED_AT, Tools.iso8601());
         streamData.put(StreamImpl.FIELD_CONTENT_PACK, cr.contentPack());
+        streamData.put(StreamImpl.FIELD_MATCHING_TYPE, Stream.MatchingType.valueOf(cr.matchingType()));
 
         return create(streamData);
     }

--- a/graylog2-server/src/main/java/org/graylog2/streams/StreamServiceImpl.java
+++ b/graylog2-server/src/main/java/org/graylog2/streams/StreamServiceImpl.java
@@ -95,7 +95,7 @@ public class StreamServiceImpl extends PersistedServiceImpl implements StreamSer
         streamData.put(StreamImpl.FIELD_CREATOR_USER_ID, userId);
         streamData.put(StreamImpl.FIELD_CREATED_AT, Tools.iso8601());
         streamData.put(StreamImpl.FIELD_CONTENT_PACK, cr.contentPack());
-        streamData.put(StreamImpl.FIELD_MATCHING_TYPE, Stream.MatchingType.valueOfOrDefault(cr.matchingType()));
+        streamData.put(StreamImpl.FIELD_MATCHING_TYPE, Stream.MatchingType.valueOfOrDefault(cr.matchingType()).toString());
 
         return create(streamData);
     }

--- a/graylog2-server/src/main/java/org/graylog2/streams/StreamServiceImpl.java
+++ b/graylog2-server/src/main/java/org/graylog2/streams/StreamServiceImpl.java
@@ -95,7 +95,7 @@ public class StreamServiceImpl extends PersistedServiceImpl implements StreamSer
         streamData.put(StreamImpl.FIELD_CREATOR_USER_ID, userId);
         streamData.put(StreamImpl.FIELD_CREATED_AT, Tools.iso8601());
         streamData.put(StreamImpl.FIELD_CONTENT_PACK, cr.contentPack());
-        streamData.put(StreamImpl.FIELD_MATCHING_TYPE, Stream.MatchingType.valueOfOrDefault(cr.matchingType()).toString());
+        streamData.put(StreamImpl.FIELD_MATCHING_TYPE, cr.matchingType().toString());
 
         return create(streamData);
     }

--- a/graylog2-server/src/main/java/org/graylog2/streams/StreamServiceImpl.java
+++ b/graylog2-server/src/main/java/org/graylog2/streams/StreamServiceImpl.java
@@ -95,7 +95,7 @@ public class StreamServiceImpl extends PersistedServiceImpl implements StreamSer
         streamData.put(StreamImpl.FIELD_CREATOR_USER_ID, userId);
         streamData.put(StreamImpl.FIELD_CREATED_AT, Tools.iso8601());
         streamData.put(StreamImpl.FIELD_CONTENT_PACK, cr.contentPack());
-        streamData.put(StreamImpl.FIELD_MATCHING_TYPE, Stream.MatchingType.valueOf(cr.matchingType()));
+        streamData.put(StreamImpl.FIELD_MATCHING_TYPE, Stream.MatchingType.valueOfOrDefault(cr.matchingType()));
 
         return create(streamData);
     }

--- a/graylog2-server/src/test/java/org/graylog2/streams/StreamMock.java
+++ b/graylog2-server/src/test/java/org/graylog2/streams/StreamMock.java
@@ -152,4 +152,9 @@ public class StreamMock implements Stream {
                 ", title='" + title + '\'' +
                 '}';
     }
+
+    @Override
+    public MatchingType getMatchingType() {
+        return MatchingType.AND;
+    }
 }

--- a/graylog2-server/src/test/java/org/graylog2/streams/StreamRouterEngineTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/streams/StreamRouterEngineTest.java
@@ -505,10 +505,12 @@ public class StreamRouterEngineTest {
         final StreamRule streamRule2 = getStreamRuleMock("StreamRule2Id", StreamRuleType.EXACT, dummyField, "not" + dummyValue);
 
         final Stream stream1 = mock(Stream.class);
+        when(stream1.getId()).thenReturn("Stream1Id");
         when(stream1.getMatchingType()).thenReturn(Stream.MatchingType.OR);
         when(stream1.getStreamRules()).thenReturn(Lists.newArrayList(streamRule1, streamRule2));
 
         final Stream stream2 = mock(Stream.class);
+        when(stream2.getId()).thenReturn("Stream2Id");
         when(stream2.getMatchingType()).thenReturn(Stream.MatchingType.AND);
         when(stream2.getStreamRules()).thenReturn(Lists.newArrayList(streamRule1, streamRule2));
 

--- a/graylog2-server/src/test/java/org/graylog2/streams/StreamRouterEngineTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/streams/StreamRouterEngineTest.java
@@ -517,7 +517,7 @@ public class StreamRouterEngineTest {
         when(message.getField(eq(dummyField))).thenReturn(dummyValue);
         when(message.getFieldNames()).thenReturn(Sets.newHashSet(dummyField));
 
-        final StreamRouterEngine engine = newEngine(Lists.newArrayList(stream1));
+        final StreamRouterEngine engine = newEngine(Lists.newArrayList(stream1, stream2));
 
         final List<Stream> result = engine.match(message);
 

--- a/integration-tests/src/test/java/integration/streams/StreamsTest.java
+++ b/integration-tests/src/test/java/integration/streams/StreamsTest.java
@@ -213,12 +213,9 @@ public class StreamsTest extends BaseRestTest {
     @Test
     public void creatingInvalidMatchingStreamShouldFail() throws Exception {
         final int beforeCount = streamCount();
-        final String streamTitle = "Another Test Stream";
-        final String description = "This is a test stream.";
-        final String matchingType = "OR";
 
-        final ValidatableResponse response = createStreamFromRequest(jsonResourceForMethod());
-        response.statusCode(400);
+        createStreamFromRequest(jsonResourceForMethod())
+            .statusCode(400);
 
         final int afterCount = streamCount();
         assertThat(afterCount).isEqualTo(beforeCount);

--- a/integration-tests/src/test/java/integration/streams/StreamsTest.java
+++ b/integration-tests/src/test/java/integration/streams/StreamsTest.java
@@ -73,6 +73,7 @@ public class StreamsTest extends BaseRestTest {
                 .assertThat()
                 .body("title", equalTo("TestStream"))
                 .body("disabled", equalTo(true))
+                .body("matching_type", equalTo("AND"))
                 .body("description", equalTo(null));
     }
 
@@ -96,13 +97,46 @@ public class StreamsTest extends BaseRestTest {
         assertThat(afterCount).isEqualTo(beforeCount+1);
 
         given()
-            .when()
+                .when()
                 .get("/streams/" + streamId)
-            .then()
+                .then()
                 .statusCode(200)
                 .assertThat()
                 .body("title", equalTo(streamTitle))
                 .body("disabled", equalTo(true))
+                .body("matching_type", equalTo("AND"))
+                .body("description", equalTo(description));
+    }
+
+    @Test
+    public void createOrMatchingStreamWithTitleAndDescription() throws Exception {
+        final int beforeCount = streamCount();
+        final String streamTitle = "Another Test Stream";
+        final String description = "This is a test stream.";
+        final String matchingType = "OR";
+
+        final JsonPath response = createStreamFromRequest(jsonResourceForMethod())
+                .statusCode(201)
+                .body(".", containsAllKeys("stream_id"))
+                .extract().jsonPath();
+
+        final String streamId = response.getString("stream_id");
+
+        assertThat(streamId).isNotNull().isNotEmpty();
+
+        final int afterCount = streamCount();
+
+        assertThat(afterCount).isEqualTo(beforeCount+1);
+
+        given()
+                .when()
+                .get("/streams/" + streamId)
+                .then()
+                .statusCode(200)
+                .assertThat()
+                .body("title", equalTo(streamTitle))
+                .body("disabled", equalTo(true))
+                .body("matching_type", equalTo(matchingType))
                 .body("description", equalTo(description));
     }
 
@@ -123,7 +157,7 @@ public class StreamsTest extends BaseRestTest {
 
         final int afterCount = streamCount();
 
-        assertThat(afterCount).isEqualTo(beforeCount+1);
+        assertThat(afterCount).isEqualTo(beforeCount + 1);
 
         final JsonPath getResponse = given()
                 .when()
@@ -134,6 +168,7 @@ public class StreamsTest extends BaseRestTest {
                 .assertThat()
                 .body("title", equalTo(streamTitle))
                 .body("disabled", equalTo(true))
+                .body("matching_type", equalTo("AND"))
                 .body("description", equalTo(description))
                 .extract().jsonPath();
 
@@ -169,6 +204,20 @@ public class StreamsTest extends BaseRestTest {
         final int beforeCount = streamCount();
 
         final ValidatableResponse response = createStreamFromRequest("{}");
+        response.statusCode(400);
+
+        final int afterCount = streamCount();
+        assertThat(afterCount).isEqualTo(beforeCount);
+    }
+
+    @Test
+    public void creatingInvalidMatchingStreamShouldFail() throws Exception {
+        final int beforeCount = streamCount();
+        final String streamTitle = "Another Test Stream";
+        final String description = "This is a test stream.";
+        final String matchingType = "OR";
+
+        final ValidatableResponse response = createStreamFromRequest(jsonResourceForMethod());
         response.statusCode(400);
 
         final int afterCount = streamCount();

--- a/integration-tests/src/test/resources/integration/streams/create-or-matching-stream-with-title-and-description.json
+++ b/integration-tests/src/test/resources/integration/streams/create-or-matching-stream-with-title-and-description.json
@@ -1,0 +1,1 @@
+{"title": "Another Test Stream", "description" : "This is a test stream.", "matching_type" : "OR"}

--- a/integration-tests/src/test/resources/integration/streams/creating-invalid-matching-stream-should-fail.json
+++ b/integration-tests/src/test/resources/integration/streams/creating-invalid-matching-stream-should-fail.json
@@ -1,0 +1,1 @@
+{"title": "Another Test Stream", "description": "This is a test stream.", "matching_type": "INVALID"}


### PR DESCRIPTION
- Adds attribute to streams that defines their matching type
- Matching type is AND per default if matching type is not specified
- Allowing to specify matching type during stream creation via REST api
- Adding basic integration tests