### PR TITLE
Run versioncheck periodical with 5 minute initial delay

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/periodical/VersionCheckThread.java
+++ b/graylog2-server/src/main/java/org/graylog2/periodical/VersionCheckThread.java
@@ -179,7 +179,7 @@ public class VersionCheckThread extends Periodical {
 
     @Override
     public int getInitialDelaySeconds() {
-        return 0;
+        return (int) MINUTES.toSeconds(5);
     }
 
     @Override


### PR DESCRIPTION
This way constantly restarted (because of misconfiguration and any kind of watcher process) graylog-server master nodes do not check for a new version constantly.