### PR TITLE
Allow import/export of grok patterns in content packs

### DIFF
--- a/graylog2-rest-client/src/main/java/org/graylog2/restclient/models/api/requests/CreateBundleRequest.java
+++ b/graylog2-rest-client/src/main/java/org/graylog2/restclient/models/api/requests/CreateBundleRequest.java
@@ -16,6 +16,8 @@
  */
 package org.graylog2.restclient.models.api.requests;
 
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import org.graylog2.restclient.models.bundles.Dashboard;
 import org.graylog2.restclient.models.bundles.GrokPattern;
 import org.graylog2.restclient.models.bundles.Input;
@@ -24,14 +26,22 @@ import org.graylog2.restclient.models.bundles.Stream;
 
 import java.util.List;
 
+@JsonAutoDetect
 public class CreateBundleRequest extends ApiRequest {
-    public String id;
+    @JsonProperty("name")
     public String name;
+    @JsonProperty("description")
     public String description;
+    @JsonProperty("category")
     public String category;
+    @JsonProperty("inputs")
     public List<Input> inputs;
+    @JsonProperty("streams")
     public List<Stream> streams;
+    @JsonProperty("outputs")
     public List<Output> outputs;
+    @JsonProperty("dashboards")
     public List<Dashboard> dashboards;
+    @JsonProperty("grok_patterns")
     public List<GrokPattern> grokPatterns;
 }

--- a/graylog2-rest-client/src/main/java/org/graylog2/restclient/models/api/requests/CreateBundleRequest.java
+++ b/graylog2-rest-client/src/main/java/org/graylog2/restclient/models/api/requests/CreateBundleRequest.java
@@ -17,6 +17,7 @@
 package org.graylog2.restclient.models.api.requests;
 
 import org.graylog2.restclient.models.bundles.Dashboard;
+import org.graylog2.restclient.models.bundles.GrokPattern;
 import org.graylog2.restclient.models.bundles.Input;
 import org.graylog2.restclient.models.bundles.Output;
 import org.graylog2.restclient.models.bundles.Stream;
@@ -32,4 +33,5 @@ public class CreateBundleRequest extends ApiRequest {
     public List<Stream> streams;
     public List<Output> outputs;
     public List<Dashboard> dashboards;
+    public List<GrokPattern> grokPatterns;
 }

--- a/graylog2-rest-client/src/main/java/org/graylog2/restclient/models/api/requests/ExportBundleRequest.java
+++ b/graylog2-rest-client/src/main/java/org/graylog2/restclient/models/api/requests/ExportBundleRequest.java
@@ -14,47 +14,42 @@
  * You should have received a copy of the GNU General Public License
  * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
  */
-/**
- * This file is part of Graylog.
- *
- * Graylog is free software: you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
- *
- * Graylog is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
- */
 package org.graylog2.restclient.models.api.requests;
 
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.collect.Lists;
 import play.data.validation.Constraints;
 
 import java.util.List;
 
+@JsonAutoDetect
 public class ExportBundleRequest extends ApiRequest {
+    @JsonProperty("name")
     @Constraints.Required
     public String name;
 
+    @JsonProperty("description")
     @Constraints.Required
     public String description;
 
+    @JsonProperty("category")
     @Constraints.Required
     public String category;
 
+    @JsonProperty("inputs")
     public List<String> inputs = Lists.newArrayList();
 
+    @JsonProperty("outputs")
     public List<String> outputs = Lists.newArrayList();
 
+    @JsonProperty("streams")
     public List<String> streams = Lists.newArrayList();
 
+    @JsonProperty("dashboards")
     public List<String> dashboards = Lists.newArrayList();
 
+    @JsonProperty("grok_patterns")
     public List<String> grokPatterns = Lists.newArrayList();
 
     public String getName() {

--- a/graylog2-rest-client/src/main/java/org/graylog2/restclient/models/api/requests/ExportBundleRequest.java
+++ b/graylog2-rest-client/src/main/java/org/graylog2/restclient/models/api/requests/ExportBundleRequest.java
@@ -55,6 +55,8 @@ public class ExportBundleRequest extends ApiRequest {
 
     public List<String> dashboards = Lists.newArrayList();
 
+    public List<String> grokPatterns = Lists.newArrayList();
+
     public String getName() {
         return name;
     }
@@ -109,5 +111,13 @@ public class ExportBundleRequest extends ApiRequest {
 
     public void setDashboards(List<String> dashboards) {
         this.dashboards = dashboards;
+    }
+
+    public List<String> getGrokPatterns() {
+        return grokPatterns;
+    }
+
+    public void setGrokPatterns(List<String> grokPatterns) {
+        this.grokPatterns = grokPatterns;
     }
 }

--- a/graylog2-rest-client/src/main/java/org/graylog2/restclient/models/bundles/ConfigurationBundle.java
+++ b/graylog2-rest-client/src/main/java/org/graylog2/restclient/models/bundles/ConfigurationBundle.java
@@ -23,33 +23,33 @@ import javax.validation.constraints.NotNull;
 import java.util.List;
 
 public class ConfigurationBundle {
-    @JsonProperty
+    @JsonProperty("id")
     private String id;
 
-    @JsonProperty
+    @JsonProperty("name")
     @NotNull
     private String name;
 
-    @JsonProperty
+    @JsonProperty("description")
     @NotNull
     private String description;
 
-    @JsonProperty
+    @JsonProperty("category")
     @NotNull
     private String category;
 
-    @JsonProperty
+    @JsonProperty("inputs")
     private List<Input> inputs = Lists.newArrayList();
 
-    @JsonProperty
+    @JsonProperty("streams")
     private List<Stream> streams = Lists.newArrayList();
 
-    @JsonProperty
+    @JsonProperty("outputs")
     private List<Output> outputs = Lists.newArrayList();
 
-    @JsonProperty
+    @JsonProperty("dashboards")
     private List<Dashboard> dashboards = Lists.newArrayList();
 
-    @JsonProperty
+    @JsonProperty("grok_patterns")
     private List<GrokPattern> grokPatterns = Lists.newArrayList();
 }

--- a/graylog2-rest-client/src/main/java/org/graylog2/restclient/models/bundles/ConfigurationBundle.java
+++ b/graylog2-rest-client/src/main/java/org/graylog2/restclient/models/bundles/ConfigurationBundle.java
@@ -50,4 +50,6 @@ public class ConfigurationBundle {
     @JsonProperty
     private List<Dashboard> dashboards = Lists.newArrayList();
 
+    @JsonProperty
+    private List<GrokPattern> grokPatterns = Lists.newArrayList();
 }

--- a/graylog2-rest-client/src/main/java/org/graylog2/restclient/models/bundles/GrokPattern.java
+++ b/graylog2-rest-client/src/main/java/org/graylog2/restclient/models/bundles/GrokPattern.java
@@ -14,15 +14,32 @@
  * You should have received a copy of the GNU General Public License
  * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
  */
-package org.graylog2.rest.models.system.responses;
+package org.graylog2.restclient.models.bundles;
 
-public class GrokPatternSummary {
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.annotation.JsonProperty;
 
-    public String id;
+@JsonAutoDetect
+public class GrokPattern {
+    @JsonProperty
+    private String name;
 
-    public String name;
+    @JsonProperty
+    private String pattern;
 
-    public String pattern;
+    public String getName() {
+        return name;
+    }
 
-    public String contentPack;
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public String getPattern() {
+        return pattern;
+    }
+
+    public void setPattern(String pattern) {
+        this.pattern = pattern;
+    }
 }

--- a/graylog2-rest-client/src/main/java/org/graylog2/restclient/models/bundles/GrokPattern.java
+++ b/graylog2-rest-client/src/main/java/org/graylog2/restclient/models/bundles/GrokPattern.java
@@ -21,10 +21,10 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 
 @JsonAutoDetect
 public class GrokPattern {
-    @JsonProperty
+    @JsonProperty("name")
     private String name;
 
-    @JsonProperty
+    @JsonProperty("pattern")
     private String pattern;
 
     public String getName() {

--- a/graylog2-server/src/main/java/org/graylog2/bindings/providers/BundleExporterProvider.java
+++ b/graylog2-server/src/main/java/org/graylog2/bindings/providers/BundleExporterProvider.java
@@ -19,6 +19,7 @@ package org.graylog2.bindings.providers;
 import org.graylog2.bundles.BundleExporter;
 import org.graylog2.dashboards.DashboardService;
 import org.graylog2.dashboards.widgets.DashboardWidgetCreator;
+import org.graylog2.grok.GrokPatternService;
 import org.graylog2.inputs.InputService;
 import org.graylog2.streams.OutputService;
 import org.graylog2.streams.StreamService;
@@ -33,22 +34,26 @@ public class BundleExporterProvider implements Provider<BundleExporter> {
     private final OutputService outputService;
     private final DashboardService dashboardService;
     private final DashboardWidgetCreator dashboardWidgetCreator;
+    private final GrokPatternService grokPatternService;
 
     @Inject
     public BundleExporterProvider(final InputService inputService,
                                   final StreamService streamService,
                                   final OutputService outputService,
                                   final DashboardService dashboardService,
-                                  final DashboardWidgetCreator dashboardWidgetCreator) {
+                                  final DashboardWidgetCreator dashboardWidgetCreator,
+                                  final GrokPatternService grokPatternService) {
         this.inputService = inputService;
         this.streamService = streamService;
         this.outputService = outputService;
         this.dashboardService = dashboardService;
         this.dashboardWidgetCreator = dashboardWidgetCreator;
+        this.grokPatternService = grokPatternService;
     }
 
     @Override
     public BundleExporter get() {
-        return new BundleExporter(inputService, streamService, outputService, dashboardService, dashboardWidgetCreator);
+        return new BundleExporter(inputService, streamService, outputService, dashboardService, dashboardWidgetCreator,
+                grokPatternService);
     }
 }

--- a/graylog2-server/src/main/java/org/graylog2/bindings/providers/BundleImporterProvider.java
+++ b/graylog2-server/src/main/java/org/graylog2/bindings/providers/BundleImporterProvider.java
@@ -16,11 +16,11 @@
  */
 package org.graylog2.bindings.providers;
 
-import com.codahale.metrics.MetricRegistry;
 import org.graylog2.bundles.BundleImporter;
 import org.graylog2.dashboards.DashboardRegistry;
 import org.graylog2.dashboards.DashboardService;
 import org.graylog2.dashboards.widgets.DashboardWidgetCreator;
+import org.graylog2.grok.GrokPatternService;
 import org.graylog2.indexer.searches.Searches;
 import org.graylog2.inputs.InputService;
 import org.graylog2.inputs.extractors.ExtractorFactory;
@@ -47,10 +47,10 @@ public class BundleImporterProvider implements Provider<BundleImporter> {
     private final DashboardRegistry dashboardRegistry;
     private final DashboardWidgetCreator dashboardWidgetCreator;
     private final ServerStatus serverStatus;
-    private final MetricRegistry metricRegistry;
     private final Searches searches;
     private final MessageInputFactory messageInputFactory;
     private final InputLauncher inputLauncher;
+    private final GrokPatternService grokPatternService;
 
     @Inject
     public BundleImporterProvider(final InputService inputService,
@@ -63,10 +63,10 @@ public class BundleImporterProvider implements Provider<BundleImporter> {
                                   final DashboardRegistry dashboardRegistry,
                                   final DashboardWidgetCreator dashboardWidgetCreator,
                                   final ServerStatus serverStatus,
-                                  final MetricRegistry metricRegistry,
                                   final Searches searches,
                                   final MessageInputFactory messageInputFactory,
-                                  final InputLauncher inputLauncher) {
+                                  final InputLauncher inputLauncher,
+                                  final GrokPatternService grokPatternService) {
         this.inputService = inputService;
         this.inputRegistry = inputRegistry;
         this.extractorFactory = extractorFactory;
@@ -77,17 +77,17 @@ public class BundleImporterProvider implements Provider<BundleImporter> {
         this.dashboardRegistry = dashboardRegistry;
         this.dashboardWidgetCreator = dashboardWidgetCreator;
         this.serverStatus = serverStatus;
-        this.metricRegistry = metricRegistry;
         this.searches = searches;
         this.messageInputFactory = messageInputFactory;
         this.inputLauncher = inputLauncher;
+        this.grokPatternService = grokPatternService;
     }
 
     @Override
     public BundleImporter get() {
         return new BundleImporter(inputService, inputRegistry, extractorFactory,
                 streamService, streamRuleService, outputService, dashboardService,
-                dashboardRegistry, dashboardWidgetCreator, serverStatus, metricRegistry, searches, messageInputFactory,
-                inputLauncher);
+                dashboardRegistry, dashboardWidgetCreator, serverStatus, searches,
+                messageInputFactory, inputLauncher, grokPatternService);
     }
 }

--- a/graylog2-server/src/main/java/org/graylog2/bundles/BundleExporter.java
+++ b/graylog2-server/src/main/java/org/graylog2/bundles/BundleExporter.java
@@ -23,6 +23,7 @@ import org.graylog2.dashboards.DashboardImpl;
 import org.graylog2.dashboards.DashboardService;
 import org.graylog2.dashboards.widgets.DashboardWidgetCreator;
 import org.graylog2.database.NotFoundException;
+import org.graylog2.grok.GrokPatternService;
 import org.graylog2.inputs.InputService;
 import org.graylog2.streams.OutputService;
 import org.graylog2.streams.StreamService;
@@ -43,6 +44,7 @@ public class BundleExporter {
     private final OutputService outputService;
     private final DashboardService dashboardService;
     private final DashboardWidgetCreator dashboardWidgetCreator;
+    private final GrokPatternService grokPatternService;
 
     private Set<String> streamSet = new HashSet<>();
 
@@ -51,12 +53,14 @@ public class BundleExporter {
                           final StreamService streamService,
                           final OutputService outputService,
                           final DashboardService dashboardService,
-                          final DashboardWidgetCreator dashboardWidgetCreator) {
+                          final DashboardWidgetCreator dashboardWidgetCreator,
+                          final GrokPatternService grokPatternService) {
         this.inputService = inputService;
         this.streamService = streamService;
         this.outputService = outputService;
         this.dashboardService = dashboardService;
         this.dashboardWidgetCreator = dashboardWidgetCreator;
+        this.grokPatternService = grokPatternService;
     }
 
     public ConfigurationBundle export(final ExportBundle exportBundle) {
@@ -67,11 +71,13 @@ public class BundleExporter {
         final Set<Dashboard> dashboards = exportDashboards(exportBundle.getDashboards());
         final Set<Output> outputs = exportOutputs(exportBundle.getOutputs());
         final Set<Stream> streams = exportStreams(streamSet);
+        final Set<GrokPattern> grokPatterns = exportGrokPatterns(exportBundle.getGrokPatterns());
         final Set<Input> inputs = exportInputs(exportBundle.getInputs());
 
         configurationBundle.setName(exportBundle.getName());
         configurationBundle.setCategory(exportBundle.getCategory());
         configurationBundle.setDescription(exportBundle.getDescription());
+        configurationBundle.setGrokPatterns(grokPatterns);
         configurationBundle.setInputs(inputs);
         configurationBundle.setStreams(streams);
         configurationBundle.setOutputs(outputs);
@@ -80,13 +86,38 @@ public class BundleExporter {
         return configurationBundle;
     }
 
+    private Set<GrokPattern> exportGrokPatterns(final Set<String> grokPatterns) {
+        final ImmutableSet.Builder<GrokPattern> grokPatternBuilder = ImmutableSet.builder();
+
+        for (String name : grokPatterns) {
+            final GrokPattern grokPattern = exportGrokPattern(name);
+            if (grokPattern != null) {
+                grokPatternBuilder.add(grokPattern);
+            }
+        }
+
+        return grokPatternBuilder.build();
+    }
+
+    private GrokPattern exportGrokPattern(final String grokPatternName) {
+        final org.graylog2.grok.GrokPattern grokPattern;
+        try {
+            grokPattern = grokPatternService.load(grokPatternName);
+        } catch (NotFoundException e) {
+            LOG.debug("Requested grok pattern \"{}\" not found.", grokPatternName);
+            return null;
+        }
+
+        return GrokPattern.create(grokPattern.name, grokPattern.pattern);
+    }
+
     private Set<Input> exportInputs(final Set<String> inputs) {
         final ImmutableSet.Builder<Input> inputBuilder = ImmutableSet.builder();
 
         for (String inputId : inputs) {
             final Input input = exportInput(inputId);
             if (input != null) {
-                inputBuilder.add(exportInput(inputId));
+                inputBuilder.add(input);
             }
         }
 
@@ -312,7 +343,7 @@ public class BundleExporter {
                 final Object streamId = widgetConfig.get("stream_id");
                 if (streamId instanceof String) {
                     if (streamSet.add((String) streamId)) {
-                        LOG.debug("Adding stream {} to export list", (String) streamId);
+                        LOG.debug("Adding stream {} to export list", streamId);
                     }
                 }
 

--- a/graylog2-server/src/main/java/org/graylog2/bundles/BundleService.java
+++ b/graylog2-server/src/main/java/org/graylog2/bundles/BundleService.java
@@ -28,8 +28,6 @@ import org.mongojack.DBCursor;
 import org.mongojack.DBQuery;
 import org.mongojack.JacksonDBCollection;
 import org.mongojack.WriteResult;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import javax.inject.Inject;
 import javax.inject.Singleton;
@@ -38,7 +36,6 @@ import java.util.Set;
 
 @Singleton
 public class BundleService {
-    private static final Logger LOG = LoggerFactory.getLogger(BundleService.class);
     private static final String COLLECTION_NAME = "content_packs";
 
     private final JacksonDBCollection<ConfigurationBundle, ObjectId> dbCollection;
@@ -76,9 +73,7 @@ public class BundleService {
 
     public ConfigurationBundle findByNameAndCategory(final String name, final String category) {
         final DBQuery.Query query = DBQuery.is("name", name).is("category", category);
-        final ConfigurationBundle bundle = dbCollection.findOne(query);
-
-        return bundle;
+        return dbCollection.findOne(query);
     }
 
     public Set<ConfigurationBundle> loadAll() {

--- a/graylog2-server/src/main/java/org/graylog2/bundles/ConfigurationBundle.java
+++ b/graylog2-server/src/main/java/org/graylog2/bundles/ConfigurationBundle.java
@@ -54,6 +54,9 @@ public class ConfigurationBundle {
     @JsonProperty
     @NotNull
     private Set<Dashboard> dashboards = Collections.emptySet();
+    @JsonProperty
+    @NotNull
+    private Set<GrokPattern> grokPatterns = Collections.emptySet();
 
     public String getId() {
         return id;
@@ -117,5 +120,13 @@ public class ConfigurationBundle {
 
     public void setDashboards(Set<Dashboard> dashboards) {
         this.dashboards = dashboards;
+    }
+
+    public Set<GrokPattern> getGrokPatterns() {
+        return grokPatterns;
+    }
+
+    public void setGrokPatterns(Set<GrokPattern> grokPatterns) {
+        this.grokPatterns = grokPatterns;
     }
 }

--- a/graylog2-server/src/main/java/org/graylog2/bundles/ExportBundle.java
+++ b/graylog2-server/src/main/java/org/graylog2/bundles/ExportBundle.java
@@ -48,6 +48,9 @@ public class ExportBundle {
     @JsonProperty
     @NotNull
     private Set<String> dashboards = Collections.emptySet();
+    @JsonProperty
+    @NotNull
+    private Set<String> grokPatterns = Collections.emptySet();
 
     public String getName() {
         return name;
@@ -103,5 +106,13 @@ public class ExportBundle {
 
     public void setDashboards(Set<String> dashboards) {
         this.dashboards = dashboards;
+    }
+
+    public Set<String> getGrokPatterns() {
+        return grokPatterns;
+    }
+
+    public void setGrokPatterns(Set<String> grokPatterns) {
+        this.grokPatterns = grokPatterns;
     }
 }

--- a/graylog2-server/src/main/java/org/graylog2/bundles/GrokPattern.java
+++ b/graylog2-server/src/main/java/org/graylog2/bundles/GrokPattern.java
@@ -14,15 +14,24 @@
  * You should have received a copy of the GNU General Public License
  * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
  */
-package org.graylog2.rest.models.system.responses;
+package org.graylog2.bundles;
 
-public class GrokPatternSummary {
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.auto.value.AutoValue;
+import org.hibernate.validator.constraints.NotBlank;
 
-    public String id;
+@JsonAutoDetect
+@AutoValue
+public abstract class GrokPattern {
+    @JsonProperty
+    public abstract String name();
 
-    public String name;
+    @JsonProperty
+    public abstract String pattern();
 
-    public String pattern;
-
-    public String contentPack;
+    public static GrokPattern create(@JsonProperty("name") @NotBlank String name,
+                                     @JsonProperty("pattern") @NotBlank String pattern) {
+        return new AutoValue_GrokPattern(name, pattern);
+    }
 }

--- a/graylog2-server/src/main/java/org/graylog2/bundles/GrokPattern.java
+++ b/graylog2-server/src/main/java/org/graylog2/bundles/GrokPattern.java
@@ -17,6 +17,7 @@
 package org.graylog2.bundles;
 
 import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.auto.value.AutoValue;
 import org.hibernate.validator.constraints.NotBlank;
@@ -30,6 +31,7 @@ public abstract class GrokPattern {
     @JsonProperty
     public abstract String pattern();
 
+    @JsonCreator
     public static GrokPattern create(@JsonProperty("name") @NotBlank String name,
                                      @JsonProperty("pattern") @NotBlank String pattern) {
         return new AutoValue_GrokPattern(name, pattern);

--- a/graylog2-server/src/main/java/org/graylog2/grok/GrokPattern.java
+++ b/graylog2-server/src/main/java/org/graylog2/grok/GrokPattern.java
@@ -36,8 +36,8 @@ public class GrokPattern {
     public String toString() {
         return MoreObjects.toStringHelper(this)
                 .add("id", id)
-                .add("name='", name)
-                .add("pattern='", pattern)
+                .add("name", name)
+                .add("pattern", pattern)
                 .add("contentPack", contentPack)
                 .toString();
     }

--- a/graylog2-server/src/main/java/org/graylog2/grok/GrokPattern.java
+++ b/graylog2-server/src/main/java/org/graylog2/grok/GrokPattern.java
@@ -17,28 +17,29 @@
 package org.graylog2.grok;
 
 import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.google.common.base.MoreObjects;
 import org.bson.types.ObjectId;
 
 import javax.persistence.Id;
+import java.util.Objects;
 
 @JsonAutoDetect
 public class GrokPattern {
-
     @Id
     @org.mongojack.ObjectId
     public ObjectId id;
-    
     public String name;
-    
     public String pattern;
+    public String contentPack;
 
     @Override
     public String toString() {
-        return "GrokPattern{" +
-                "id=" + id +
-                ", name='" + name + '\'' +
-                ", pattern='" + pattern + '\'' +
-                '}';
+        return MoreObjects.toStringHelper(this)
+                .add("id", id)
+                .add("name='", name)
+                .add("pattern='", pattern)
+                .add("contentPack", contentPack)
+                .toString();
     }
 
     @Override
@@ -46,18 +47,12 @@ public class GrokPattern {
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
 
-        GrokPattern that = (GrokPattern) o;
-
-        if (!name.equals(that.name)) return false;
-        if (!pattern.equals(that.pattern)) return false;
-
-        return true;
+        final GrokPattern that = (GrokPattern) o;
+        return Objects.equals(this.name, that.name) && Objects.equals(this.pattern, that.pattern);
     }
 
     @Override
     public int hashCode() {
-        int result = name.hashCode();
-        result = 31 * result + pattern.hashCode();
-        return result;
+        return Objects.hash(name, pattern);
     }
 }


### PR DESCRIPTION
Previously it wasn't possible to export or import grok patterns as part of a content pack. This could lead to broken extractors in inputs.

This PR adds the capabilities to import/export grok patterns in content packs.