### PR TITLE
Add MultiMessageCodec interface

### DIFF
--- a/graylog2-plugin-interfaces/src/main/java/org/graylog2/plugin/buffers/MessageEvent.java
+++ b/graylog2-plugin-interfaces/src/main/java/org/graylog2/plugin/buffers/MessageEvent.java
@@ -29,6 +29,7 @@ import org.graylog2.plugin.journal.RawMessage;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
+import java.util.List;
 
 /**
  * @author Lennart Koopmann <lennart@torch.sh>
@@ -45,6 +46,7 @@ public class MessageEvent {
 
     private RawMessage raw;
     private Message msg;
+    private List<Message> msgList;
 
     @Nullable
     public Message getMessage()
@@ -57,6 +59,15 @@ public class MessageEvent {
         this.msg = msg;
     }
 
+    @Nullable
+    public List<Message> getMessageList() {
+        return msgList;
+    }
+
+    public void setMessageList(@Nullable final List<Message> msgList) {
+        this.msgList = msgList;
+    }
+
     /**
      * Sets the raw message but also clears out the {@link #getMessage() message} reference to avoid handling stale messages
      * and to let older messages be garbage collected earlier.
@@ -66,6 +77,7 @@ public class MessageEvent {
     public void setRaw(@Nonnull RawMessage raw) {
         this.raw = raw;
         setMessage(null);
+        setMessageList(null);
     }
 
     public void clearRaw() {
@@ -82,6 +94,7 @@ public class MessageEvent {
         return MoreObjects.toStringHelper(this)
                 .add("raw", raw)
                 .add("message", msg)
+                .add("messageList", msgList)
                 .toString();
     }
 }

--- a/graylog2-plugin-interfaces/src/main/java/org/graylog2/plugin/buffers/MessageEvent.java
+++ b/graylog2-plugin-interfaces/src/main/java/org/graylog2/plugin/buffers/MessageEvent.java
@@ -48,6 +48,10 @@ public class MessageEvent {
     private Message msg;
     private Collection<Message> messages;
 
+    public boolean isSingleMessage() {
+        return msg != null;
+    }
+
     @Nullable
     public Message getMessage()
     {
@@ -68,6 +72,11 @@ public class MessageEvent {
         this.messages = messages;
     }
 
+    public void clearMessages() {
+        setMessage(null);
+        setMessages(null);
+    }
+
     /**
      * Sets the raw message but also clears out the {@link #getMessage() message} and {@link #getMessages() messages}
      * references to avoid handling stale messages and to let older messages be garbage collected earlier.
@@ -76,8 +85,7 @@ public class MessageEvent {
      */
     public void setRaw(@Nonnull RawMessage raw) {
         this.raw = raw;
-        setMessage(null);
-        setMessages(null);
+        clearMessages();
     }
 
     public void clearRaw() {

--- a/graylog2-plugin-interfaces/src/main/java/org/graylog2/plugin/buffers/MessageEvent.java
+++ b/graylog2-plugin-interfaces/src/main/java/org/graylog2/plugin/buffers/MessageEvent.java
@@ -29,7 +29,7 @@ import org.graylog2.plugin.journal.RawMessage;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
-import java.util.List;
+import java.util.Collection;
 
 /**
  * @author Lennart Koopmann <lennart@torch.sh>
@@ -46,7 +46,7 @@ public class MessageEvent {
 
     private RawMessage raw;
     private Message msg;
-    private List<Message> msgList;
+    private Collection<Message> messages;
 
     @Nullable
     public Message getMessage()
@@ -60,24 +60,24 @@ public class MessageEvent {
     }
 
     @Nullable
-    public List<Message> getMessageList() {
-        return msgList;
+    public Collection<Message> getMessages() {
+        return messages;
     }
 
-    public void setMessageList(@Nullable final List<Message> msgList) {
-        this.msgList = msgList;
+    public void setMessages(@Nullable final Collection<Message> messages) {
+        this.messages = messages;
     }
 
     /**
-     * Sets the raw message but also clears out the {@link #getMessage() message} reference to avoid handling stale messages
-     * and to let older messages be garbage collected earlier.
+     * Sets the raw message but also clears out the {@link #getMessage() message} and {@link #getMessages() messages}
+     * references to avoid handling stale messages and to let older messages be garbage collected earlier.
      *
      * @param raw
      */
     public void setRaw(@Nonnull RawMessage raw) {
         this.raw = raw;
         setMessage(null);
-        setMessageList(null);
+        setMessages(null);
     }
 
     public void clearRaw() {
@@ -94,7 +94,7 @@ public class MessageEvent {
         return MoreObjects.toStringHelper(this)
                 .add("raw", raw)
                 .add("message", msg)
-                .add("messageList", msgList)
+                .add("messages", messages)
                 .toString();
     }
 }

--- a/graylog2-plugin-interfaces/src/main/java/org/graylog2/plugin/inputs/codecs/MessageListCodec.java
+++ b/graylog2-plugin-interfaces/src/main/java/org/graylog2/plugin/inputs/codecs/MessageListCodec.java
@@ -1,0 +1,36 @@
+/**
+ * The MIT License
+ * Copyright (c) 2012 Graylog, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package org.graylog2.plugin.inputs.codecs;
+
+import org.graylog2.plugin.Message;
+import org.graylog2.plugin.journal.RawMessage;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import java.util.List;
+
+public interface MessageListCodec extends Codec {
+    @Nullable
+    List<Message> decodeMessageList(@Nonnull RawMessage rawMessage);
+}

--- a/graylog2-plugin-interfaces/src/main/java/org/graylog2/plugin/inputs/codecs/MultiMessageCodec.java
+++ b/graylog2-plugin-interfaces/src/main/java/org/graylog2/plugin/inputs/codecs/MultiMessageCodec.java
@@ -28,9 +28,9 @@ import org.graylog2.plugin.journal.RawMessage;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
-import java.util.List;
+import java.util.Collection;
 
 public interface MultiMessageCodec extends Codec {
     @Nullable
-    List<Message> decodeMessages(@Nonnull RawMessage rawMessage);
+    Collection<Message> decodeMessages(@Nonnull RawMessage rawMessage);
 }

--- a/graylog2-plugin-interfaces/src/main/java/org/graylog2/plugin/inputs/codecs/MultiMessageCodec.java
+++ b/graylog2-plugin-interfaces/src/main/java/org/graylog2/plugin/inputs/codecs/MultiMessageCodec.java
@@ -30,7 +30,7 @@ import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import java.util.List;
 
-public interface MessageListCodec extends Codec {
+public interface MultiMessageCodec extends Codec {
     @Nullable
-    List<Message> decodeMessageList(@Nonnull RawMessage rawMessage);
+    List<Message> decodeMessages(@Nonnull RawMessage rawMessage);
 }

--- a/graylog2-shared/src/main/java/org/graylog2/shared/buffers/processors/DecodingProcessor.java
+++ b/graylog2-shared/src/main/java/org/graylog2/shared/buffers/processors/DecodingProcessor.java
@@ -126,6 +126,8 @@ public class DecodingProcessor implements EventHandler<MessageEvent> {
         final Timer.Context decodeTimeCtx = parseTime.time();
         final long decodeTime;
         try {
+            // This is ugly but needed for backwards compatibility of the Codec interface in 1.x.
+            // TODO The Codec interface should be changed for 2.0 to support collections of messages so we can remove this hack.
             if (codec instanceof MultiMessageCodec) {
                 messages = ((MultiMessageCodec) codec).decodeMessages(raw);
             } else {

--- a/graylog2-shared/src/main/java/org/graylog2/shared/buffers/processors/DecodingProcessor.java
+++ b/graylog2-shared/src/main/java/org/graylog2/shared/buffers/processors/DecodingProcessor.java
@@ -31,7 +31,7 @@ import org.graylog2.plugin.ResolvableInetSocketAddress;
 import org.graylog2.plugin.ServerStatus;
 import org.graylog2.plugin.buffers.MessageEvent;
 import org.graylog2.plugin.inputs.codecs.Codec;
-import org.graylog2.plugin.inputs.codecs.MessageListCodec;
+import org.graylog2.plugin.inputs.codecs.MultiMessageCodec;
 import org.graylog2.plugin.journal.RawMessage;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -81,10 +81,10 @@ public class DecodingProcessor implements EventHandler<MessageEvent> {
         try {
             // always set the result of processMessage, even if it is null, to avoid later stages to process old messages.
             // basically this will make sure old messages are cleared out early.
-            event.setMessageList(processMessage(event.getRaw()));
+            event.setMessages(processMessage(event.getRaw()));
         } finally {
-            if (event.getMessageList() != null) {
-                for (final Message message : event.getMessageList()) {
+            if (event.getMessages() != null) {
+                for (final Message message : event.getMessages()) {
                     message.recordTiming(serverStatus, "decode", context.stop());
                 }
             }
@@ -125,8 +125,8 @@ public class DecodingProcessor implements EventHandler<MessageEvent> {
         final Timer.Context decodeTimeCtx = parseTime.time();
         final long decodeTime;
         try {
-            if (codec instanceof MessageListCodec) {
-                messages = ((MessageListCodec) codec).decodeMessageList(raw);
+            if (codec instanceof MultiMessageCodec) {
+                messages = ((MultiMessageCodec) codec).decodeMessages(raw);
             } else {
                 final Message message = codec.decode(raw);
                 messages = message == null ? null : Collections.singletonList(message);

--- a/graylog2-shared/src/main/java/org/graylog2/shared/buffers/processors/DecodingProcessor.java
+++ b/graylog2-shared/src/main/java/org/graylog2/shared/buffers/processors/DecodingProcessor.java
@@ -37,6 +37,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import javax.annotation.Nullable;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -94,7 +95,7 @@ public class DecodingProcessor implements EventHandler<MessageEvent> {
     }
 
     @Nullable
-    private List<Message> processMessage(final RawMessage raw) throws ExecutionException {
+    private Collection<Message> processMessage(final RawMessage raw) throws ExecutionException {
         if (raw == null) {
             LOG.warn("Ignoring null message");
             return null;
@@ -120,7 +121,7 @@ public class DecodingProcessor implements EventHandler<MessageEvent> {
         }
         final String baseMetricName = name(codec.getClass(), inputIdOnCurrentNode);
 
-        final List<Message> messages;
+        final Collection<Message> messages;
 
         final Timer.Context decodeTimeCtx = parseTime.time();
         final long decodeTime;

--- a/graylog2-shared/src/main/java/org/graylog2/shared/buffers/processors/DecodingProcessor.java
+++ b/graylog2-shared/src/main/java/org/graylog2/shared/buffers/processors/DecodingProcessor.java
@@ -21,6 +21,7 @@ import com.codahale.metrics.MetricRegistry;
 import com.codahale.metrics.Timer;
 import com.google.common.base.Strings;
 import com.google.common.collect.Iterables;
+import com.google.common.collect.Lists;
 import com.google.common.net.InetAddresses;
 import com.google.inject.assistedinject.Assisted;
 import com.google.inject.assistedinject.AssistedInject;
@@ -30,10 +31,14 @@ import org.graylog2.plugin.ResolvableInetSocketAddress;
 import org.graylog2.plugin.ServerStatus;
 import org.graylog2.plugin.buffers.MessageEvent;
 import org.graylog2.plugin.inputs.codecs.Codec;
+import org.graylog2.plugin.inputs.codecs.MessageListCodec;
 import org.graylog2.plugin.journal.RawMessage;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import javax.annotation.Nullable;
+import java.util.Collections;
+import java.util.List;
 import java.util.Map;
 import java.util.NoSuchElementException;
 import java.util.concurrent.ExecutionException;
@@ -76,17 +81,20 @@ public class DecodingProcessor implements EventHandler<MessageEvent> {
         try {
             // always set the result of processMessage, even if it is null, to avoid later stages to process old messages.
             // basically this will make sure old messages are cleared out early.
-            event.setMessage(processMessage(event.getRaw()));
+            event.setMessageList(processMessage(event.getRaw()));
         } finally {
-            if (event.getMessage() != null) {
-                event.getMessage().recordTiming(serverStatus, "decode", context.stop());
+            if (event.getMessageList() != null) {
+                for (final Message message : event.getMessageList()) {
+                    message.recordTiming(serverStatus, "decode", context.stop());
+                }
             }
             // aid garbage collection to collect the raw message early (to avoid promoting it to later generations).
             event.clearRaw();
         }
     }
 
-    private Message processMessage(RawMessage raw) throws ExecutionException {
+    @Nullable
+    private List<Message> processMessage(final RawMessage raw) throws ExecutionException {
         if (raw == null) {
             LOG.warn("Ignoring null message");
             return null;
@@ -112,14 +120,16 @@ public class DecodingProcessor implements EventHandler<MessageEvent> {
         }
         final String baseMetricName = name(codec.getClass(), inputIdOnCurrentNode);
 
-        final Message message;
+        final List<Message> messages;
 
         final Timer.Context decodeTimeCtx = parseTime.time();
         final long decodeTime;
         try {
-            message = codec.decode(raw);
-            if (message != null) {
-                message.setJournalOffset(raw.getJournalOffset());
+            if (codec instanceof MessageListCodec) {
+                messages = ((MessageListCodec) codec).decodeMessageList(raw);
+            } else {
+                final Message message = codec.decode(raw);
+                messages = message == null ? null : Collections.singletonList(message);
             }
         } catch (RuntimeException e) {
             metricRegistry.meter(name(baseMetricName, "failures")).mark();
@@ -128,6 +138,24 @@ public class DecodingProcessor implements EventHandler<MessageEvent> {
             decodeTime = decodeTimeCtx.stop();
         }
 
+        if (messages == null || messages.isEmpty()) {
+            return null;
+        }
+
+        final List<Message> processedMessages = Lists.newArrayListWithCapacity(messages.size());
+
+        for (final Message message : messages) {
+            final Message processedMessage = postProcessMessage(raw, codec, inputIdOnCurrentNode, baseMetricName, message, decodeTime);
+
+            if (processedMessage != null) {
+                processedMessages.add(processedMessage);
+            }
+        }
+
+        return processedMessages;
+    }
+
+    private Message postProcessMessage(RawMessage raw, Codec codec, String inputIdOnCurrentNode, String baseMetricName, Message message, long decodeTime) {
         if (message == null) {
             metricRegistry.meter(name(baseMetricName, "failures")).mark();
             return null;
@@ -140,6 +168,7 @@ public class DecodingProcessor implements EventHandler<MessageEvent> {
             return null;
         }
 
+        message.setJournalOffset(raw.getJournalOffset());
         message.recordTiming(serverStatus, "parse", decodeTime);
         metricRegistry.timer(name(baseMetricName, "parseTime")).update(decodeTime, TimeUnit.NANOSECONDS);
 

--- a/graylog2-shared/src/main/java/org/graylog2/shared/buffers/processors/ProcessBufferProcessor.java
+++ b/graylog2-shared/src/main/java/org/graylog2/shared/buffers/processors/ProcessBufferProcessor.java
@@ -25,7 +25,7 @@ import org.graylog2.plugin.buffers.MessageEvent;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.util.List;
+import java.util.Collection;
 
 import static com.codahale.metrics.MetricRegistry.name;
 
@@ -57,7 +57,7 @@ public abstract class ProcessBufferProcessor implements WorkHandler<MessageEvent
         // TODO The DecodingProcessor does not need to be a EventHandler. We decided to do it like this to keep the change as small as possible for 1.0.0.
         decodingProcessor.onEvent(event, 0L, false);
 
-        final List<Message> messageList = event.getMessageList();
+        final Collection<Message> messageList = event.getMessages();
         if (messageList == null) {
             // skip message events which could not be decoded properly
             return;

--- a/graylog2-shared/src/main/java/org/graylog2/shared/buffers/processors/ProcessBufferProcessor.java
+++ b/graylog2-shared/src/main/java/org/graylog2/shared/buffers/processors/ProcessBufferProcessor.java
@@ -25,6 +25,8 @@ import org.graylog2.plugin.buffers.MessageEvent;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.util.List;
+
 import static com.codahale.metrics.MetricRegistry.name;
 
 /**
@@ -55,11 +57,18 @@ public abstract class ProcessBufferProcessor implements WorkHandler<MessageEvent
         // TODO The DecodingProcessor does not need to be a EventHandler. We decided to do it like this to keep the change as small as possible for 1.0.0.
         decodingProcessor.onEvent(event, 0L, false);
 
-        final Message msg = event.getMessage();
-        if (msg == null) {
+        final List<Message> messageList = event.getMessageList();
+        if (messageList == null) {
             // skip message events which could not be decoded properly
             return;
         }
+
+        for (final Message message : messageList) {
+            dispatchMessage(message);
+        }
+    }
+
+    private void dispatchMessage(final Message msg) {
         incomingMessages.mark();
         final Timer.Context tcx = processTime.time();
 

--- a/graylog2-shared/src/main/java/org/graylog2/shared/buffers/processors/ProcessBufferProcessor.java
+++ b/graylog2-shared/src/main/java/org/graylog2/shared/buffers/processors/ProcessBufferProcessor.java
@@ -57,14 +57,18 @@ public abstract class ProcessBufferProcessor implements WorkHandler<MessageEvent
         // TODO The DecodingProcessor does not need to be a EventHandler. We decided to do it like this to keep the change as small as possible for 1.0.0.
         decodingProcessor.onEvent(event, 0L, false);
 
-        final Collection<Message> messageList = event.getMessages();
-        if (messageList == null) {
-            // skip message events which could not be decoded properly
-            return;
-        }
+        if (event.isSingleMessage()) {
+            dispatchMessage(event.getMessage());
+        } else {
+            final Collection<Message> messageList = event.getMessages();
+            if (messageList == null) {
+                // skip message events which could not be decoded properly
+                return;
+            }
 
-        for (final Message message : messageList) {
-            dispatchMessage(message);
+            for (final Message message : messageList) {
+                dispatchMessage(message);
+            }
         }
     }
 

--- a/graylog2-shared/src/main/java/org/graylog2/shared/buffers/processors/ProcessBufferProcessor.java
+++ b/graylog2-shared/src/main/java/org/graylog2/shared/buffers/processors/ProcessBufferProcessor.java
@@ -70,19 +70,16 @@ public abstract class ProcessBufferProcessor implements WorkHandler<MessageEvent
 
     private void dispatchMessage(final Message msg) {
         incomingMessages.mark();
-        final Timer.Context tcx = processTime.time();
-
 
         LOG.debug("Starting to process message <{}>.", msg.getId());
 
-        try {
+        try (final Timer.Context ignored = processTime.time()) {
             LOG.debug("Finished processing message <{}>. Writing to output buffer.", msg.getId());
             handleMessage(msg);
         } catch (Exception e) {
             LOG.warn("Unable to process message <{}>: {}", msg.getId(), e);
         } finally {
             outgoingMessages.mark();
-            tcx.stop();
         }
     }
 


### PR DESCRIPTION
It makes it possible to decode a list of Message objects from a RawMessage instead of just a single one. This is useful for protocols like NetFlow or collectd where one packet contains multiple messages.

The new interface is needed to keep the Codec interface compatible. A breaking change is only possible with the next major version.

Adjust DecodingProcessor and ProcessBufferProcessor to handle a list of Message objects.

---

I created another branch with a different implementation here:

https://github.com/Graylog2/graylog2-server/compare/feature-message-list-codec-v1

The v1 branch tries to minimize the message list usage, this one (v2) converts the single message to a list as soon as possible to avoid special cases all over the place.

I benchmarked both branches agains master and it looks like there isn't much difference. All branches have been benchmarked twice.

![decoder-bench](https://cloud.githubusercontent.com/assets/461/8732469/f67f7e6e-2bfd-11e5-8300-643c743a5370.png)

I prefer this diff. Any opinions?