### PR TITLE
Fix dynamic keyword time-ranges for dashboard widgets created from content packs

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/bundles/BundleImporter.java
+++ b/graylog2-server/src/main/java/org/graylog2/bundles/BundleImporter.java
@@ -525,7 +525,7 @@ public class BundleImporter {
                 timeRange = new RelativeRange((Integer) timerangeConfig.get("range"));
                 break;
             case "keyword":
-                timeRange = new KeywordRange((String) timerangeConfig.get("keyword"));
+                timeRange = new KeywordRange((String) timerangeConfig.get("keyword"), true);
                 break;
             case "absolute":
                 final String from = new DateTime(timerangeConfig.get("from"), DateTimeZone.UTC).toString(Tools.ES_DATE_FORMAT);

--- a/graylog2-server/src/main/java/org/graylog2/bundles/BundleImporter.java
+++ b/graylog2-server/src/main/java/org/graylog2/bundles/BundleImporter.java
@@ -525,7 +525,7 @@ public class BundleImporter {
                 timeRange = new RelativeRange((Integer) timerangeConfig.get("range"));
                 break;
             case "keyword":
-                timeRange = new KeywordRange((String) timerangeConfig.get("keyword"), true);
+                timeRange = new KeywordRange((String) timerangeConfig.get("keyword"));
                 break;
             case "absolute":
                 final String from = new DateTime(timerangeConfig.get("from"), DateTimeZone.UTC).toString(Tools.ES_DATE_FORMAT);

--- a/graylog2-server/src/main/java/org/graylog2/dashboards/widgets/DashboardWidgetCreator.java
+++ b/graylog2-server/src/main/java/org/graylog2/dashboards/widgets/DashboardWidgetCreator.java
@@ -73,7 +73,7 @@ public class DashboardWidgetCreator {
                 timeRange = new RelativeRange(Integer.parseInt((String) awr.config().get("range")));
                 break;
             case "keyword":
-                timeRange = new KeywordRange((String) awr.config().get("keyword"), true);
+                timeRange = new KeywordRange((String) awr.config().get("keyword"));
                 break;
             case "absolute":
                 timeRange = new AbsoluteRange((String) awr.config().get("from"), (String) awr.config().get("to"));
@@ -110,7 +110,7 @@ public class DashboardWidgetCreator {
                 timeRange = new RelativeRange((Integer) timerangeConfig.get("range"));
                 break;
             case "keyword":
-                timeRange = new KeywordRange((String) timerangeConfig.get("keyword"), true);
+                timeRange = new KeywordRange((String) timerangeConfig.get("keyword"));
                 break;
             case "absolute":
                 String from = new DateTime(timerangeConfig.get("from"), DateTimeZone.UTC).toString(Tools.ES_DATE_FORMAT);

--- a/graylog2-server/src/main/java/org/graylog2/indexer/searches/timeranges/KeywordRange.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/searches/timeranges/KeywordRange.java
@@ -84,6 +84,8 @@ public class KeywordRange implements TimeRange {
     public String toString() {
         return MoreObjects.toStringHelper(this)
                 .add("keyword", getKeyword())
+                .add("from", getFrom())
+                .add("to", getTo())
                 .toString();
     }
 

--- a/graylog2-server/src/main/java/org/graylog2/indexer/searches/timeranges/KeywordRange.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/searches/timeranges/KeywordRange.java
@@ -22,38 +22,25 @@ import org.graylog2.utilities.date.NaturalDateParser;
 import org.joda.time.DateTime;
 
 import java.util.Map;
-import java.util.Objects;
 
 import static com.google.common.base.Strings.isNullOrEmpty;
 
 public class KeywordRange implements TimeRange {
     private static final NaturalDateParser DATE_PARSER = new NaturalDateParser();
-
     private final String keyword;
-    private final boolean dynamic;
 
-    private DateTime from;
-    private DateTime to;
-
-    public KeywordRange(String keyword, boolean dynamic) throws InvalidRangeParametersException {
+    public KeywordRange(String keyword) throws InvalidRangeParametersException {
         if (isNullOrEmpty(keyword)) {
             throw new InvalidRangeParametersException();
         }
 
         try {
-            NaturalDateParser.Result result = parseKeyword(keyword);
-            from = result.getFrom();
-            to = result.getTo();
+            parseKeyword(keyword);
         } catch (NaturalDateParser.DateNotParsableException e) {
             throw new InvalidRangeParametersException("Could not parse from natural date: " + keyword);
         }
 
         this.keyword = keyword;
-        this.dynamic = dynamic;
-    }
-
-    public KeywordRange(String keyword) throws InvalidRangeParametersException {
-        this(keyword, false);
     }
 
     private NaturalDateParser.Result parseKeyword(String keyword) throws NaturalDateParser.DateNotParsableException {
@@ -79,19 +66,17 @@ public class KeywordRange implements TimeRange {
 
     public DateTime getFrom() {
         try {
-            return dynamic ? parseKeyword(keyword).getFrom() : from;
+            return parseKeyword(keyword).getFrom();
         } catch (NaturalDateParser.DateNotParsableException e) {
-            // This should never happen
-            return from;
+            return null;
         }
     }
 
     public DateTime getTo() {
         try {
-            return dynamic ? parseKeyword(keyword).getTo() : to;
+            return parseKeyword(keyword).getTo();
         } catch (NaturalDateParser.DateNotParsableException e) {
-            // This should never happen
-            return to;
+            return null;
         }
     }
 
@@ -99,8 +84,6 @@ public class KeywordRange implements TimeRange {
     public String toString() {
         return MoreObjects.toStringHelper(this)
                 .add("keyword", getKeyword())
-                .add("from", getFrom())
-                .add("to", getTo())
                 .toString();
     }
 
@@ -110,13 +93,13 @@ public class KeywordRange implements TimeRange {
         if (o == null || getClass() != o.getClass()) return false;
 
         KeywordRange that = (KeywordRange) o;
-        return dynamic == that.dynamic && keyword.equals(that.keyword);
+        return keyword.equals(that.keyword);
 
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(keyword, dynamic);
+        return keyword.hashCode();
     }
 }
 


### PR DESCRIPTION
Keyword time-ranges are static by default but should be dynamic for dashboard widgets created from content packs.

This PR additionally makes `KeywordRange` dynamically evaluate the keyword by default and removes the static behaviour completely to prevent accidental usage.

Fixes Graylog2/graylog2-web-interface#1533