### PR TITLE
Upgrade to Elasticsearch 1.6.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -222,7 +222,7 @@
             <dependency>
                 <groupId>org.elasticsearch</groupId>
                 <artifactId>elasticsearch</artifactId>
-                <version>1.5.2</version>
+                <version>1.6.1</version>
             </dependency>
 
             <dependency>


### PR DESCRIPTION
Due to a remote code execution vulnerability in Elasticsearch prior to 1.6.1 and 1.7.0 which can be triggered through the ES transport protocol (which is also exposed when using a client node), we should upgrade the internally used ES client in Graylog to Elasticsearch 1.6.1.

Details about the vulnerability can be found at https://www.elastic.co/blog/elasticsearch-1-7-0-and-1-6-1-released