### PR TITLE
Handle edge case in FieldHistogramResult when DateHistogram contains no buckets

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/indexer/results/FieldHistogramResult.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/results/FieldHistogramResult.java
@@ -79,8 +79,8 @@ public class FieldHistogramResult extends HistogramResult {
             results.put(timestamp, resultMap.build());
         }
 
-        final Long minTimestamp = Collections.min(results.keySet());
-        final Long maxTimestamp = Collections.max(results.keySet());
+        final long minTimestamp = Collections.min(results.keySet());
+        final long maxTimestamp = Collections.max(results.keySet());
         final MutableDateTime currentTime = new MutableDateTime(minTimestamp, DateTimeZone.UTC);
 
         while (currentTime.getMillis() < maxTimestamp) {

--- a/graylog2-server/src/main/java/org/graylog2/indexer/results/FieldHistogramResult.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/results/FieldHistogramResult.java
@@ -24,6 +24,7 @@ import org.elasticsearch.search.aggregations.bucket.histogram.DateHistogram;
 import org.elasticsearch.search.aggregations.metrics.cardinality.Cardinality;
 import org.elasticsearch.search.aggregations.metrics.stats.Stats;
 import org.graylog2.indexer.searches.Searches;
+import org.joda.time.DateTimeZone;
 import org.joda.time.MutableDateTime;
 
 import java.util.Collections;
@@ -80,7 +81,7 @@ public class FieldHistogramResult extends HistogramResult {
 
         final Long minTimestamp = Collections.min(results.keySet());
         final Long maxTimestamp = Collections.max(results.keySet());
-        final MutableDateTime currentTime = new MutableDateTime(minTimestamp);
+        final MutableDateTime currentTime = new MutableDateTime(minTimestamp, DateTimeZone.UTC);
 
         while (currentTime.getMillis() < maxTimestamp) {
             final Map<String, Number> entry = results.get(currentTime.getMillis());

--- a/graylog2-server/src/test/java/org/graylog2/indexer/results/FieldHistogramResultTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/indexer/results/FieldHistogramResultTest.java
@@ -1,0 +1,60 @@
+/**
+ * This file is part of Graylog.
+ *
+ * Graylog is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.graylog2.indexer.results;
+
+import org.elasticsearch.common.bytes.BytesArray;
+import org.elasticsearch.common.unit.TimeValue;
+import org.elasticsearch.search.aggregations.bucket.histogram.DateHistogram;
+import org.graylog2.indexer.searches.Searches;
+import org.junit.Test;
+
+import java.util.Collections;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class FieldHistogramResultTest {
+    @Test
+    public void testGetInterval() throws Exception {
+        final FieldHistogramResult fieldHistogramResult = new FieldHistogramResult(
+                mock(DateHistogram.class),
+                "",
+                BytesArray.EMPTY,
+                Searches.DateHistogramInterval.MINUTE,
+                TimeValue.timeValueMillis(42L)
+        );
+
+        assertThat(fieldHistogramResult.getInterval()).isEqualTo(Searches.DateHistogramInterval.MINUTE);
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    public void getResultsWorksWithZeroBuckets() throws Exception {
+        final DateHistogram dateHistogram = mock(DateHistogram.class);
+        when(dateHistogram.getBuckets()).thenReturn(Collections.EMPTY_LIST);
+        final FieldHistogramResult fieldHistogramResult = new FieldHistogramResult(
+                dateHistogram,
+                "",
+                BytesArray.EMPTY,
+                Searches.DateHistogramInterval.MINUTE,
+                TimeValue.timeValueMillis(42L)
+        );
+
+        assertThat(fieldHistogramResult.getResults()).isEmpty();
+    }
+}


### PR DESCRIPTION
Previously the `FieldHistogramResult#getResults()` method would fail with the following exception from Joda-Time, because `minTimestamp` would be too large to be converted into a DateTime object:
```
java.lang.ArithmeticException: Adding time zone offset caused overflow
        at org.joda.time.DateTimeZone.convertUTCToLocal(DateTimeZone.java:929)
```

Fixes #1257