### PR TITLE
Use Jersey's templates to encode query params

### DIFF
--- a/graylog2-rest-client/pom.xml
+++ b/graylog2-rest-client/pom.xml
@@ -173,6 +173,10 @@
             <artifactId>async-http-client</artifactId>
         </dependency>
         <dependency>
+            <groupId>com.squareup.okhttp</groupId>
+            <artifactId>okhttp</artifactId>
+        </dependency>
+        <dependency>
             <groupId>com.typesafe.play</groupId>
             <artifactId>play-java_2.10</artifactId>
             <version>${play.version}</version>
@@ -195,16 +199,6 @@
         <dependency>
             <groupId>org.apache.shiro</groupId>
             <artifactId>shiro-core</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>javax.ws.rs</groupId>
-            <artifactId>jsr311-api</artifactId>
-            <version>1.1.1</version>
-        </dependency>
-        <dependency>
-            <groupId>com.sun.jersey</groupId>
-            <artifactId>jersey-bundle</artifactId>
-            <version>1.18.1</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/graylog2-rest-client/src/main/java/org/graylog2/restclient/lib/ApiClientImpl.java
+++ b/graylog2-rest-client/src/main/java/org/graylog2/restclient/lib/ApiClientImpl.java
@@ -42,6 +42,7 @@ import com.ning.http.client.Request;
 import com.ning.http.client.Response;
 import com.ning.http.client.listener.TransferCompletionHandler;
 import com.ning.http.client.listener.TransferListener;
+import com.squareup.okhttp.HttpUrl;
 import org.graylog2.restclient.models.ClusterEntity;
 import org.graylog2.restclient.models.Node;
 import org.graylog2.restclient.models.Radio;
@@ -55,13 +56,10 @@ import org.slf4j.LoggerFactory;
 import javax.inject.Inject;
 import javax.inject.Named;
 import javax.inject.Singleton;
-import javax.ws.rs.core.UriBuilder;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.ConnectException;
 import java.net.MalformedURLException;
-import java.net.URI;
-import java.net.URISyntaxException;
 import java.net.URL;
 import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
@@ -70,7 +68,6 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ExecutionException;
@@ -638,24 +635,24 @@ class ApiClientImpl implements ApiClient {
             final AsyncHttpClient.BoundRequestBuilder requestBuilder;
             final String userInfo = url.getUserInfo();
             // have to hack around here, because the userInfo will unescape the @ in usernames :(
-            try {
-                url = UriBuilder.fromUri(url.toURI()).userInfo(null).build().toURL();
-            } catch (URISyntaxException | MalformedURLException ignore) {
-                // cannot happen, because it was a valid url before
-            }
+            final HttpUrl httpUrl = HttpUrl.get(url)
+                    .newBuilder()
+                    .username("")
+                    .password("")
+                    .build();
 
             switch (method) {
                 case GET:
-                    requestBuilder = client.prepareGet(url.toString());
+                    requestBuilder = client.prepareGet(httpUrl.toString());
                     break;
                 case POST:
-                    requestBuilder = client.preparePost(url.toString());
+                    requestBuilder = client.preparePost(httpUrl.toString());
                     break;
                 case PUT:
-                    requestBuilder = client.preparePut(url.toString());
+                    requestBuilder = client.preparePut(httpUrl.toString());
                     break;
                 case DELETE:
-                    requestBuilder = client.prepareDelete(url.toString());
+                    requestBuilder = client.prepareDelete(httpUrl.toString());
                     break;
                 default:
                     throw new IllegalStateException("Illegal method " + method.toString());
@@ -696,7 +693,7 @@ class ApiClientImpl implements ApiClient {
             // if this is null there's not much we can do anyway...
             Preconditions.checkNotNull(pathTemplate, "path() needs to be set to a non-null value.");
 
-            URI builtUrl;
+            HttpUrl builtUrl;
             try {
                 String path;
                 if (pathParams.isEmpty()) {
@@ -704,13 +701,14 @@ class ApiClientImpl implements ApiClient {
                 } else {
                     path = MessageFormat.format(pathTemplate, pathParams.toArray());
                 }
-                final List<String> queryParamsValues = Lists.newArrayList();
-                final UriBuilder uriBuilder = UriBuilder.fromUri(target.getTransportAddress());
-                uriBuilder.path(path);
+
+                final HttpUrl.Builder builder = HttpUrl.parse(target.getTransportAddress())
+                        .newBuilder()
+                        .encodedPath(path);
+
                 for (String key : queryParams.keySet()) {
                     for (String value : queryParams.get(key)) {
-                        uriBuilder.queryParam(key, "{" + key + "}");
-                        queryParamsValues.add(value);
+                        builder.addQueryParameter(key, value);
                     }
                 }
 
@@ -719,13 +717,15 @@ class ApiClientImpl implements ApiClient {
                 }
                 if (sessionId != null) {
                     // pass the current session id via basic auth and special "password"
-                    uriBuilder.userInfo(sessionId + ":session");
+                    builder.username(sessionId);
+                    builder.password("session");
                 }
-                builtUrl = uriBuilder.build(queryParamsValues.toArray());
-                return builtUrl.toURL();
-            } catch (MalformedURLException e) {
+
+                builtUrl = builder.build();
+                return builtUrl.url();
+            } catch (RuntimeException e) {
                 LOG.error("Could not build target URL", e);
-                throw new RuntimeException(e);
+                throw e;
             }
         }
 

--- a/graylog2-rest-client/src/test/java/org/graylog2/restclient/lib/ApiClientTest.java
+++ b/graylog2-rest-client/src/test/java/org/graylog2/restclient/lib/ApiClientTest.java
@@ -59,6 +59,16 @@ public class ApiClientTest extends BaseApiTest {
                 "query=+%22.%2B%22",
                 queryParamWithDoubleQuotes.getQuery());
 
+        final URL queryParamWithColon = api.get(EmptyResponse.class).path("/some/resource").queryParam("query", "mac:00\\:12\\:f0\\:53\\:42\\:2b").node(node).unauthenticated().prepareUrl(node);
+        Assert.assertEquals("query param with \\ should be escaped",
+                "query=mac:00%5C:12%5C:f0%5C:53%5C:42%5C:2b",
+                queryParamWithColon.getQuery());
+
+        final URL queryParamWithPercentage = api.get(EmptyResponse.class).path("/some/resource").queryParam("query", "%bcd").node(node).unauthenticated().prepareUrl(node);
+        Assert.assertEquals("query param with % should be escaped",
+                "query=%25bcd",
+                queryParamWithPercentage.getQuery());
+
         final URL urlWithNonAsciiChars = api.get(EmptyResponse.class).node(node).path("/some/resourçe").unauthenticated().prepareUrl(node);
         Assert.assertEquals("non-ascii chars are escaped in path",
                 "/some/resour%C3%A7e",

--- a/graylog2-rest-client/src/test/java/org/graylog2/restclient/lib/ApiClientTest.java
+++ b/graylog2-rest-client/src/test/java/org/graylog2/restclient/lib/ApiClientTest.java
@@ -52,17 +52,12 @@ public class ApiClientTest extends BaseApiTest {
         final URL queryParamWithPlus = api.get(EmptyResponse.class).path("/some/resource").queryParam("query", " (.+)").node(node).unauthenticated().prepareUrl(node);
 
         Assert.assertEquals(url.getUserInfo(), "foo:session");
-        Assert.assertEquals("query param with + should be escaped", "query=+(.%2B)", queryParamWithPlus.getQuery());
+        Assert.assertEquals("query param with + should be escaped", "query=%20(.%2B)", queryParamWithPlus.getQuery());
 
         final URL queryParamWithDoubleQuotes = api.get(EmptyResponse.class).path("/some/resource").queryParam("query", " \".+\"").node(node).unauthenticated().prepareUrl(node);
         Assert.assertEquals("query param with \" should be escaped",
-                "query=+%22.%2B%22",
+                "query=%20%22.%2B%22",
                 queryParamWithDoubleQuotes.getQuery());
-
-        final URL queryParamWithColon = api.get(EmptyResponse.class).path("/some/resource").queryParam("query", "mac:00\\:12\\:f0\\:53\\:42\\:2b").node(node).unauthenticated().prepareUrl(node);
-        Assert.assertEquals("query param with \\ should be escaped",
-                "query=mac:00%5C:12%5C:f0%5C:53%5C:42%5C:2b",
-                queryParamWithColon.getQuery());
 
         final URL queryParamWithPercentage = api.get(EmptyResponse.class).path("/some/resource").queryParam("query", "%bcd").node(node).unauthenticated().prepareUrl(node);
         Assert.assertEquals("query param with % should be escaped",
@@ -110,7 +105,7 @@ public class ApiClientTest extends BaseApiTest {
         Node node2 = it.next();
         api.setHttpClient(client);
 
-        final ApiRequestBuilder<EmptyResponse> requestBuilder = api.get(EmptyResponse.class).path("/some/resource");
+        final ApiRequestBuilder<EmptyResponse> requestBuilder = api.get(EmptyResponse.class).path("/some/resource").unauthenticated();
         final URL url1 = requestBuilder.prepareUrl(node1);
         final URL url2 = requestBuilder.prepareUrl(node2);
         stubHttpProvider.expectResponse(Uri.create(url1.toString()), 200, "{}");


### PR DESCRIPTION
Jersey uses internally contextual encoding for query parameters, meaning that data including a percentage will be treated as percent-encoded parameters, see:
http://jersey.576304.n2.nabble.com/Question-on-the-Encoding-of-Query-Parameters-td4105222.html

In order to avoid adding yet another replace into the value added to the query parameter, we use templates now, whose values need to be provided when the build method is called.

I added a couple of tests to verify that changes in the `ApiClient` work with percentage-signs and backslashes.

Fixes Graylog2/graylog2-web-interface#1544.