### PR TITLE
Add additional settings to GELF output

### DIFF
--- a/graylog2-plugin-interfaces/src/main/java/org/graylog2/plugin/configuration/Configuration.java
+++ b/graylog2-plugin-interfaces/src/main/java/org/graylog2/plugin/configuration/Configuration.java
@@ -29,85 +29,75 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
-import com.google.common.base.Strings;
 import com.google.common.collect.Maps;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import javax.annotation.Nullable;
 import java.io.IOException;
+import java.util.Collections;
 import java.util.Map;
+
+import static com.google.common.base.MoreObjects.firstNonNull;
+import static com.google.common.base.Strings.isNullOrEmpty;
 
 public class Configuration {
     private static final Logger LOG = LoggerFactory.getLogger(Configuration.class);
-    private static final ObjectMapper objectMapper;
+    private static final ObjectMapper objectMapper = new ObjectMapper()
+            .enable(SerializationFeature.ORDER_MAP_ENTRIES_BY_KEYS)
+            .enable(DeserializationFeature.ACCEPT_EMPTY_STRING_AS_NULL_OBJECT);
     public static final Configuration EMPTY_CONFIGURATION = new Configuration(null);
-
-    static {
-        objectMapper = new ObjectMapper();
-        objectMapper
-                .enable(SerializationFeature.ORDER_MAP_ENTRIES_BY_KEYS)
-                .enable(DeserializationFeature.ACCEPT_EMPTY_STRING_AS_NULL_OBJECT);
-    }
 
     @JsonProperty
     private final Map<String, Object> source;
-
     @JsonIgnore
-    private final Map<String, String> strings;
+    private final Map<String, String> strings = Maps.newHashMap();
     @JsonIgnore
-    private final Map<String, Integer> ints;
+    private final Map<String, Integer> ints = Maps.newHashMap();
     @JsonIgnore
-    private final Map<String, Boolean> bools;
-    @JsonIgnore
-    private String serializedSource = null;
+    private final Map<String, Boolean> bools = Maps.newHashMap();
 
     @JsonCreator
-    public Configuration(@JsonProperty("source") Map<String, Object> m) {
-        this.source = m;
+    public Configuration(@JsonProperty("source") @Nullable Map<String, Object> m) {
+        this.source = firstNonNull(m, Collections.<String, Object>emptyMap());
 
-        if (m != null && !m.isEmpty()) {
-            try {
-                this.serializedSource = objectMapper.writeValueAsString(this);
-            } catch (JsonProcessingException e) {
-                LOG.error("Serializing configuration failed.", e);
+        for (Map.Entry<String, Object> e : this.source.entrySet()) {
+            final String key = e.getKey();
+            final Object value = e.getValue();
+
+            if (value == null) {
+                LOG.debug("NULL value in configuration key <{}>", key);
+                continue;
             }
-        }
 
-        strings = Maps.newHashMap();
-        ints = Maps.newHashMap();
-        bools = Maps.newHashMap();
-
-        if (m != null) {
-            for(Map.Entry<String, Object> e : m.entrySet()) {
-                try {
-                    if (e.getValue() == null) {
-                        LOG.debug("NULL value in configuration key <{}>", e.getKey());
-                        continue;
-                    }
-
-                    if (e.getValue() instanceof String) {
-                        strings.put(e.getKey(), (String) e.getValue());
-                    } else if (e.getValue() instanceof Integer) {
-                        ints.put(e.getKey(), (Integer) e.getValue());
-                    } else if (e.getValue() instanceof Long) {
-                        ints.put(e.getKey(), ((Long) e.getValue()).intValue()); // We only support integers but MongoDB likes to return longs.
-                    } else if (e.getValue() instanceof Double) {
-                        ints.put(e.getKey(), ((Double) e.getValue()).intValue()); // same as for longs lol
-                    } else if (e.getValue() instanceof Boolean) {
-                        bools.put(e.getKey(), (Boolean) e.getValue());
-                    } else {
-                        LOG.error("Cannot handle type [{}] of plugin configuration key <{}>.", e.getValue().getClass().getCanonicalName(), e.getKey());
-                    }
-
-                } catch(Exception ex) {
-                    LOG.warn("Could not read input configuration key <" + e.getKey() + ">. Skipping.", ex);
+            try {
+                if (value instanceof String) {
+                    strings.put(key, (String) value);
+                } else if (value instanceof Integer) {
+                    ints.put(key, (Integer) value);
+                } else if (value instanceof Long) {
+                    ints.put(key, ((Long) value).intValue()); // We only support integers but MongoDB likes to return longs.
+                } else if (value instanceof Double) {
+                    ints.put(key, ((Double) value).intValue()); // same as for longs lol
+                } else if (value instanceof Boolean) {
+                    bools.put(key, (Boolean) value);
+                } else {
+                    LOG.error("Cannot handle type [{}] of plugin configuration key <{}>.", value.getClass().getCanonicalName(), key);
                 }
+
+            } catch (Exception ex) {
+                LOG.warn("Could not read input configuration key <" + key + ">. Skipping.", ex);
             }
         }
     }
 
+    @Nullable
     public String getString(String key) {
         return strings.get(key);
+    }
+
+    public String getString(String key, String defaultValue) {
+        return firstNonNull(strings.get(key), defaultValue);
     }
 
     public void setString(String key, String value) {
@@ -118,13 +108,18 @@ public class Configuration {
         return ints.get(key);
     }
 
-    public boolean getBoolean(String key) {
-        if (!bools.containsKey(key)) {
-            return false;
-        }
-
-        return bools.get(key);
+    public int getInt(String key, int defaultValue) {
+        return firstNonNull(ints.get(key), defaultValue);
     }
+
+    public boolean getBoolean(String key) {
+        return getBoolean(key, false);
+    }
+
+    public boolean getBoolean(String key, boolean defaultValue) {
+        return firstNonNull(bools.get(key), defaultValue);
+    }
+
     public boolean booleanIsSet(String key) {
         return bools.containsKey(key);
     }
@@ -133,26 +128,34 @@ public class Configuration {
         bools.put(key, value);
     }
 
+    @Nullable
     public Map<String, Object> getSource() {
         return source;
     }
 
     public boolean stringIsSet(String key) {
-        return strings.get(key) != null && !strings.get(key).isEmpty();
+        return !isNullOrEmpty(strings.get(key));
     }
 
     public boolean intIsSet(String key) {
-        return ints.get(key) != null;
+        return ints.containsKey(key);
     }
 
+    @Nullable
     public String serializeToJson() {
-        return serializedSource;
+        try {
+            return source.isEmpty() ? null : objectMapper.writeValueAsString(this);
+        } catch (JsonProcessingException e) {
+            LOG.error("Serializing configuration failed.", e);
+            return null;
+        }
     }
 
     public static Configuration deserializeFromJson(String json) {
-        if (Strings.isNullOrEmpty(json)) {
+        if (isNullOrEmpty(json)) {
             return EMPTY_CONFIGURATION;
         }
+
         try {
             return objectMapper.readValue(json, Configuration.class);
         } catch (IOException e) {

--- a/graylog2-server/src/main/java/org/graylog2/outputs/GelfOutput.java
+++ b/graylog2-server/src/main/java/org/graylog2/outputs/GelfOutput.java
@@ -29,6 +29,7 @@ import org.graylog2.plugin.Message;
 import org.graylog2.plugin.Tools;
 import org.graylog2.plugin.configuration.Configuration;
 import org.graylog2.plugin.configuration.ConfigurationRequest;
+import org.graylog2.plugin.configuration.fields.BooleanField;
 import org.graylog2.plugin.configuration.fields.ConfigurationField;
 import org.graylog2.plugin.configuration.fields.DropdownField;
 import org.graylog2.plugin.configuration.fields.NumberField;
@@ -54,20 +55,22 @@ public class GelfOutput implements MessageOutput {
     private static final String CK_PROTOCOL = "protocol";
     private static final String CK_HOSTNAME = "hostname";
     private static final String CK_PORT = "port";
+    private static final String CK_CONNECT_TIMEOUT = "connect_timeout";
+    private static final String CK_RECONNECT_DELAY = "reconnect_delay";
+    private static final String CK_TCP_NO_DELAY = "tcp_no_delay";
+    private static final String CK_TCP_KEEP_ALIVE = "tcp_keep_alive";
 
     private final AtomicBoolean isRunning = new AtomicBoolean(false);
 
-    private final Configuration configuration;
     private final GelfTransport transport;
 
     @Inject
     public GelfOutput(@Assisted Configuration configuration) throws MessageOutputConfigurationException {
-        this(configuration, buildTransport(configuration));
+        this(buildTransport(configuration));
     }
 
     @VisibleForTesting
-    GelfOutput(Configuration configuration, GelfTransport gelfTransport) {
-        this.configuration = checkNotNull(configuration);
+    GelfOutput(GelfTransport gelfTransport) {
         this.transport = checkNotNull(gelfTransport);
         isRunning.set(true);
     }
@@ -92,13 +95,21 @@ public class GelfOutput implements MessageOutput {
         final String protocol = configuration.getString(CK_PROTOCOL);
         final String hostname = configuration.getString(CK_HOSTNAME);
         final int port = configuration.getInt(CK_PORT);
+        final int connectTimeout = configuration.getInt(CK_CONNECT_TIMEOUT, 1000);
+        final int reconnectDelay = configuration.getInt(CK_RECONNECT_DELAY, 500);
+        final boolean tcpKeepAlive = configuration.getBoolean(CK_TCP_KEEP_ALIVE, false);
+        final boolean tcpNoDelay = configuration.getBoolean(CK_TCP_NO_DELAY, false);
 
         if (isNullOrEmpty(protocol) || isNullOrEmpty(hostname) || !configuration.intIsSet(CK_PORT)) {
             throw new MessageOutputConfigurationException("Protocol and/or hostname missing!");
         }
 
         final GelfConfiguration gelfConfiguration = new GelfConfiguration(hostname, port)
-                .transport(GelfTransports.valueOf(protocol.toUpperCase()));
+                .transport(GelfTransports.valueOf(protocol.toUpperCase()))
+                .connectTimeout(connectTimeout)
+                .reconnectDelay(reconnectDelay)
+                .tcpKeepAlive(tcpKeepAlive)
+                .tcpNoDelay(tcpNoDelay);
 
         LOG.debug("Initializing GELF sender and connecting to {}://{}:{}", protocol, hostname, port);
 
@@ -189,13 +200,18 @@ public class GelfOutput implements MessageOutput {
     public static class Config extends MessageOutput.Config {
         @Override
         public ConfigurationRequest getRequestedConfiguration() {
-            final ConfigurationRequest configurationRequest = new ConfigurationRequest();
-            configurationRequest.addField(new TextField(CK_HOSTNAME, "Destination host", "", "This is the hostname of the destination", ConfigurationField.Optional.NOT_OPTIONAL));
-            configurationRequest.addField(new NumberField(CK_PORT, "Destination port", 12201, "This is the port of the destination", ConfigurationField.Optional.NOT_OPTIONAL, NumberField.Attribute.IS_PORT_NUMBER));
             final Map<String, String> protocols = ImmutableMap.of(
                     "TCP", "TCP",
                     "UDP", "UDP");
+            final ConfigurationRequest configurationRequest = new ConfigurationRequest();
+            configurationRequest.addField(new TextField(CK_HOSTNAME, "Destination host", "", "This is the hostname of the destination", ConfigurationField.Optional.NOT_OPTIONAL));
+            configurationRequest.addField(new NumberField(CK_PORT, "Destination port", 12201, "This is the port of the destination", ConfigurationField.Optional.NOT_OPTIONAL, NumberField.Attribute.IS_PORT_NUMBER));
             configurationRequest.addField(new DropdownField(CK_PROTOCOL, "Protocol", "TCP", protocols, "The protocol used to connect", ConfigurationField.Optional.NOT_OPTIONAL));
+            configurationRequest.addField(new NumberField(CK_CONNECT_TIMEOUT, "TCP Connect Timeout", 1000, "Connection timeout for TCP connections in milliseconds", ConfigurationField.Optional.OPTIONAL, NumberField.Attribute.ONLY_POSITIVE));
+            configurationRequest.addField(new NumberField(CK_RECONNECT_DELAY, "TCP Reconnect Delay", 500, "Time to wait between reconnects in milliseconds", ConfigurationField.Optional.OPTIONAL, NumberField.Attribute.ONLY_POSITIVE));
+            configurationRequest.addField(new BooleanField(CK_TCP_NO_DELAY, "TCP No Delay", false, "Whether to use Nagle's algorithm for TCP connections."));
+            configurationRequest.addField(new BooleanField(CK_TCP_KEEP_ALIVE, "TCP Keep Alive", false, "Whether to send TCP keep alive packets"));
+
             return configurationRequest;
         }
     }

--- a/graylog2-server/src/test/java/org/graylog2/outputs/GelfOutputTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/outputs/GelfOutputTest.java
@@ -16,11 +16,9 @@
  */
 package org.graylog2.outputs;
 
-import com.google.common.collect.ImmutableMap;
 import org.graylog2.gelfclient.GelfMessage;
 import org.graylog2.gelfclient.transport.GelfTransport;
 import org.graylog2.plugin.Message;
-import org.graylog2.plugin.configuration.Configuration;
 import org.graylog2.plugin.configuration.ConfigurationRequest;
 import org.joda.time.DateTime;
 import org.joda.time.DateTimeZone;
@@ -40,12 +38,7 @@ public class GelfOutputTest {
         final GelfTransport transport = mock(GelfTransport.class);
         final Message message = mock(Message.class);
         final GelfMessage gelfMessage = new GelfMessage("Test");
-        final Configuration configuration = new Configuration(ImmutableMap.<String, Object>of(
-                "hostname", "localhost",
-                "protocol", "tcp",
-                "port", 12201));
-
-        final GelfOutput gelfOutput = Mockito.spy(new GelfOutput(configuration, transport));
+        final GelfOutput gelfOutput = Mockito.spy(new GelfOutput(transport));
         doReturn(gelfMessage).when(gelfOutput).toGELFMessage(message);
 
         gelfOutput.write(message);
@@ -66,11 +59,7 @@ public class GelfOutputTest {
     @Test
     public void testToGELFMessageTimestamp() throws Exception {
         final GelfTransport transport = mock(GelfTransport.class);
-        final Configuration configuration = new Configuration(ImmutableMap.<String, Object>of(
-                "hostname", "localhost",
-                "protocol", "tcp",
-                "port", 12201));
-        final GelfOutput gelfOutput = new GelfOutput(configuration, transport);
+        final GelfOutput gelfOutput = new GelfOutput(transport);
         final DateTime now = DateTime.now(DateTimeZone.UTC);
         final Message message = new Message("Test", "Source", now);
 
@@ -82,11 +71,7 @@ public class GelfOutputTest {
     @Test
     public void testToGELFMessageFullMessage() throws Exception {
         final GelfTransport transport = mock(GelfTransport.class);
-        final Configuration configuration = new Configuration(ImmutableMap.<String, Object>of(
-                "hostname", "localhost",
-                "protocol", "tcp",
-                "port", 12201));
-        final GelfOutput gelfOutput = new GelfOutput(configuration, transport);
+        final GelfOutput gelfOutput = new GelfOutput(transport);
         final DateTime now = DateTime.now(DateTimeZone.UTC);
         final Message message = new Message("Test", "Source", now);
         message.addField(Message.FIELD_FULL_MESSAGE, "Full Message");

--- a/pom.xml
+++ b/pom.xml
@@ -617,7 +617,7 @@
             <dependency>
                 <groupId>org.graylog2</groupId>
                 <artifactId>gelfclient</artifactId>
-                <version>1.2.0</version>
+                <version>1.3.0</version>
             </dependency>
 
             <dependency>


### PR DESCRIPTION
This PR adds additional (optional) settings supported by gelfclient 1.3.0 like TCP keep alive to the GELF output.