### PR TITLE
Fix edge case in SyslogOctetCountFrameDecoder

### DIFF
--- a/graylog2-inputs/src/main/java/org/graylog2/inputs/syslog/tcp/SyslogOctetCountFrameDecoder.java
+++ b/graylog2-inputs/src/main/java/org/graylog2/inputs/syslog/tcp/SyslogOctetCountFrameDecoder.java
@@ -42,13 +42,16 @@ public class SyslogOctetCountFrameDecoder extends FrameDecoder {
         // Convert the frame length value bytes into an integer without mutating the buffer reader index.
         final String lengthString = buffer.slice(buffer.readerIndex(), frameSizeValueLength).toString(Charsets.UTF_8);
         final int length = Integer.parseInt(lengthString);
+        final int skipLength = frameSizeValueLength + 1; // Frame length value bytes and the whitespace that follows it.
 
-        if (buffer.readableBytes() < length) {
+        // We have to take the skipped bytes (frame size value length + whitespace) into account when checking if
+        // the buffer has enough data to read the complete message.
+        if (buffer.readableBytes() - skipLength < length) {
             // We cannot read the complete frame yet.
             return null;
         } else {
             // Skip the frame length value bytes and the whitespace that follows it.
-            buffer.skipBytes(frameSizeValueLength + 1);
+            buffer.skipBytes(skipLength);
         }
 
         final ChannelBuffer frame = extractFrame(buffer, buffer.readerIndex(), length);


### PR DESCRIPTION
We have to take the skipped bytes (frame size value length + whitespace) into account when checking if the buffer has enough data to read the complete message.

This fixes an exception when reading from the buffer that mostly happened during high load situations.

Fixes #1105