### PR TITLE
Add check whether index ranges need to be recalculated

### DIFF
--- a/graylog2-rest-client/src/main/java/org/graylog2/restclient/models/Notification.java
+++ b/graylog2-rest-client/src/main/java/org/graylog2/restclient/models/Notification.java
@@ -41,6 +41,7 @@ public class Notification {
         JOURNAL_UTILIZATION_TOO_HIGH,
         JOURNAL_UNCOMMITTED_MESSAGES_DELETED,
         OUTPUT_DISABLED,
+        INDEX_RANGES_RECALCULATION,
         GENERIC;
 
         public static Type fromString(String name) {

--- a/graylog2-server/src/main/java/org/graylog2/bindings/PeriodicalBindings.java
+++ b/graylog2-server/src/main/java/org/graylog2/bindings/PeriodicalBindings.java
@@ -27,6 +27,7 @@ import org.graylog2.periodical.ClusterIdGeneratorPeriodical;
 import org.graylog2.periodical.ContentPackLoaderPeriodical;
 import org.graylog2.periodical.DeadLetterThread;
 import org.graylog2.periodical.GarbageCollectionWarningThread;
+import org.graylog2.periodical.IndexRangesMigrationPeriodical;
 import org.graylog2.periodical.IndexRetentionThread;
 import org.graylog2.periodical.IndexRotationThread;
 import org.graylog2.periodical.IndexerClusterCheckerThread;
@@ -58,5 +59,6 @@ public class PeriodicalBindings extends AbstractModule {
         periodicalBinder.addBinding().to(ClusterEventCleanupPeriodical.class);
         periodicalBinder.addBinding().to(ClusterIdGeneratorPeriodical.class);
         periodicalBinder.addBinding().to(PurgeExpiredCollectorsThread.class);
+        periodicalBinder.addBinding().to(IndexRangesMigrationPeriodical.class);
     }
 }

--- a/graylog2-server/src/main/java/org/graylog2/notifications/Notification.java
+++ b/graylog2-server/src/main/java/org/graylog2/notifications/Notification.java
@@ -65,6 +65,7 @@ public interface Notification extends Persisted {
         JOURNAL_UTILIZATION_TOO_HIGH,
         JOURNAL_UNCOMMITTED_MESSAGES_DELETED,
         OUTPUT_DISABLED,
+        INDEX_RANGES_RECALCULATION,
         GENERIC
     }
 

--- a/graylog2-server/src/main/java/org/graylog2/periodical/IndexRangesMigrationPeriodical.java
+++ b/graylog2-server/src/main/java/org/graylog2/periodical/IndexRangesMigrationPeriodical.java
@@ -1,0 +1,117 @@
+/**
+ * This file is part of Graylog.
+ *
+ * Graylog is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.graylog2.periodical;
+
+import com.google.common.util.concurrent.Uninterruptibles;
+import org.graylog2.indexer.cluster.Cluster;
+import org.graylog2.indexer.indices.Indices;
+import org.graylog2.indexer.ranges.IndexRangeService;
+import org.graylog2.notifications.Notification;
+import org.graylog2.notifications.NotificationService;
+import org.graylog2.plugin.periodical.Periodical;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.inject.Inject;
+import java.util.concurrent.TimeUnit;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+/**
+ * A {@link Periodical} to check if index ranges need to be recalculated and notify the administrators about it.
+ *
+ * @see <a href="https://github.com/Graylog2/graylog2-server/pull/1274">Refactor index ranges handling (#1274)</a>
+ */
+public class IndexRangesMigrationPeriodical extends Periodical {
+    private static final Logger LOG = LoggerFactory.getLogger(IndexRangesMigrationPeriodical.class);
+
+    private final Cluster cluster;
+    private final Indices indices;
+    private final IndexRangeService indexRangeService;
+    private final NotificationService notificationService;
+
+    @Inject
+    public IndexRangesMigrationPeriodical(final Cluster cluster,
+                                          final Indices indices,
+                                          final IndexRangeService indexRangeService,
+                                          final NotificationService notificationService) {
+        this.cluster = checkNotNull(cluster);
+        this.indices = checkNotNull(indices);
+        this.indexRangeService = checkNotNull(indexRangeService);
+        this.notificationService = checkNotNull(notificationService);
+    }
+
+    @Override
+    public void doRun() {
+        while (!cluster.isConnected() || !cluster.isHealthy()) {
+            Uninterruptibles.sleepUninterruptibly(5, TimeUnit.SECONDS);
+        }
+
+        final int numberOfIndices = indices.getAll().size();
+        final int numberOfIndexRanges = indexRangeService.findAll().size();
+        if (numberOfIndices > numberOfIndexRanges) {
+            LOG.info("There are more indices ({}) than there are index ranges ({}). Notifying administrator.",
+                    numberOfIndices, numberOfIndexRanges);
+            final Notification notification = notificationService.buildNow()
+                    .addSeverity(Notification.Severity.URGENT)
+                    .addType(Notification.Type.INDEX_RANGES_RECALCULATION)
+                    .addDetail("indices", numberOfIndices)
+                    .addDetail("index_ranges", numberOfIndexRanges);
+            notificationService.publishIfFirst(notification);
+        }
+    }
+
+    @Override
+    public boolean runsForever() {
+        return true;
+    }
+
+    @Override
+    public boolean stopOnGracefulShutdown() {
+        return false;
+    }
+
+    @Override
+    public boolean masterOnly() {
+        return true;
+    }
+
+    @Override
+    public boolean startOnThisNode() {
+        return true;
+    }
+
+    @Override
+    public boolean isDaemon() {
+        return false;
+    }
+
+    @Override
+    public int getInitialDelaySeconds() {
+        return 0;
+    }
+
+    @Override
+    public int getPeriodSeconds() {
+        return 0;
+    }
+
+    @Override
+    protected Logger getLogger() {
+        return LOG;
+    }
+}

--- a/graylog2-server/src/main/java/org/graylog2/periodical/IndexRangesMigrationPeriodical.java
+++ b/graylog2-server/src/main/java/org/graylog2/periodical/IndexRangesMigrationPeriodical.java
@@ -97,7 +97,7 @@ public class IndexRangesMigrationPeriodical extends Periodical {
 
     @Override
     public boolean isDaemon() {
-        return false;
+        return true;
     }
 
     @Override


### PR DESCRIPTION
The index ranges of all indices need to be recalculated once after updating from an earlier version to Graylog 1.2.0 (see #1274).

This PR adds a periodical which checks on startup whether there are as many index ranges as there are indices and if that's not the case, create a system notification to alert the administrators about this.