### PR TITLE
Store internal message fields ("gl2_*") as doc values

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/configuration/ElasticsearchConfiguration.java
+++ b/graylog2-server/src/main/java/org/graylog2/configuration/ElasticsearchConfiguration.java
@@ -120,9 +120,6 @@ public class ElasticsearchConfiguration {
     @Parameter(value = "index_optimization_max_num_segments", validator = PositiveIntegerValidator.class)
     private int indexOptimizationMaxNumSegments = 1;
 
-    @Parameter(value = "elasticsearch_store_timestamps_as_doc_values")
-    private boolean storeTimestampsAsDocValues = true;
-
     @Parameter(value = "elasticsearch_request_timeout", validator = PositiveDurationValidator.class)
     private Duration requestTimeout = Duration.minutes(1L);
 
@@ -252,10 +249,6 @@ public class ElasticsearchConfiguration {
 
     public String getPathData() {
         return pathData;
-    }
-
-    public boolean isStoreTimestampsAsDocValues() {
-        return storeTimestampsAsDocValues;
     }
 
     public Duration getRequestTimeout() {

--- a/graylog2-server/src/main/java/org/graylog2/indexer/IndexMapping.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/IndexMapping.java
@@ -90,9 +90,9 @@ public class IndexMapping {
                         "format", "date_time"));
     }
 
-    public Map<String, Object> messageMapping(final String analyzer, boolean storeTimestampsAsDocValues) {
+    public Map<String, Object> messageMapping(final String analyzer) {
         return ImmutableMap.of(
-                "properties", partFieldProperties(analyzer, storeTimestampsAsDocValues),
+                "properties", partFieldProperties(analyzer),
                 "dynamic_templates", partDefaultAllInDynamicTemplate(),
                 // Compress source field
                 "_source", enabledAndCompressed(),
@@ -118,14 +118,13 @@ public class IndexMapping {
     /*
      * Enable analyzing for some fields again. Like for message and full_message.
      */
-    private Map<String, Map<String, ? extends Serializable>> partFieldProperties(String analyzer,
-                                                                                 boolean storeTimestampsAsDocValues) {
+    private Map<String, Map<String, ? extends Serializable>> partFieldProperties(String analyzer) {
         return ImmutableMap.of(
                 "message", analyzedString(analyzer),
                 "full_message", analyzedString(analyzer),
                 // http://joda-time.sourceforge.net/api-release/org/joda/time/format/DateTimeFormat.html
                 // http://www.elasticsearch.org/guide/reference/mapping/date-format.html
-                "timestamp", typeTimeWithMillis(storeTimestampsAsDocValues),
+                "timestamp", typeTimeWithMillis(true),
                 // to support wildcard searches in source we need to lowercase the content (wildcard search lowercases search term)
                 "source", analyzedString("analyzer_keyword"));
     }
@@ -137,12 +136,12 @@ public class IndexMapping {
                 "analyzer", analyzer);
     }
 
-    private Map<String, Serializable> typeTimeWithMillis(boolean storeTimestampsAsDocValues) {
+    private Map<String, Serializable> typeTimeWithMillis(boolean storeAsDocValues) {
         final ImmutableMap.Builder<String, Serializable> builder = ImmutableMap.<String, Serializable>builder()
                 .put("type", "date")
                 .put("format", Tools.ES_DATE_FORMAT);
 
-        if (storeTimestampsAsDocValues) {
+        if (storeAsDocValues) {
             builder.put("doc_values", true);
         }
 

--- a/graylog2-server/src/main/java/org/graylog2/indexer/IndexMapping.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/IndexMapping.java
@@ -104,15 +104,23 @@ public class IndexMapping {
      * Disable analyzing for every field by default.
      */
     private List<Map<String, Map<String, Object>>> partDefaultAllInDynamicTemplate() {
-        final Map<String, String> notAnalyzed = ImmutableMap.of("index", "not_analyzed");
+        final Map<String, Serializable> mappingInternal = ImmutableMap.<String, Serializable>of(
+                "index", "not_analyzed",
+                "doc_values", true);
+        final Map<String, Object> defaultInternal = ImmutableMap.of(
+                "match", "gl2_*",
+                "mapping", mappingInternal);
+        final Map<String, Map<String, Object>> templateInternal = ImmutableMap.of("internal_fields", defaultInternal);
+
+        final Map<String, String> mappingAll = ImmutableMap.of("index", "not_analyzed");
         final Map<String, Object> defaultAll = ImmutableMap.of(
                 // Match all
                 "match", "*",
                 // Analyze nothing by default
-                "mapping", notAnalyzed);
-        final Map<String, Map<String, Object>> template = ImmutableMap.of("store_generic", defaultAll);
+                "mapping", mappingAll);
+        final Map<String, Map<String, Object>> templateAll = ImmutableMap.of("store_generic", defaultAll);
 
-        return ImmutableList.of(template);
+        return ImmutableList.of(templateInternal, templateAll);
     }
 
     /*
@@ -137,15 +145,10 @@ public class IndexMapping {
     }
 
     private Map<String, Serializable> typeTimeWithMillis(boolean storeAsDocValues) {
-        final ImmutableMap.Builder<String, Serializable> builder = ImmutableMap.<String, Serializable>builder()
-                .put("type", "date")
-                .put("format", Tools.ES_DATE_FORMAT);
-
-        if (storeAsDocValues) {
-            builder.put("doc_values", true);
-        }
-
-        return builder.build();
+        return ImmutableMap.<String, Serializable>of(
+                "type", "date",
+                "format", Tools.ES_DATE_FORMAT,
+                "doc_values", storeAsDocValues);
     }
 
     private Map<String, Boolean> enabled() {

--- a/graylog2-server/src/main/java/org/graylog2/indexer/indices/Indices.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/indices/Indices.java
@@ -199,8 +199,7 @@ public class Indices implements IndexManagement {
             return false;
         }
 
-        final Map<String, Object> messageMapping = indexMapping.messageMapping(configuration.getAnalyzer(),
-                configuration.isStoreTimestampsAsDocValues());
+        final Map<String, Object> messageMapping = indexMapping.messageMapping(configuration.getAnalyzer());
         final PutMappingResponse messageMappingResponse =
                 indexMapping.createMapping(indexName, IndexMapping.TYPE_MESSAGE, messageMapping).actionGet();
         final Map<String, Object> metaMapping = indexMapping.metaMapping();

--- a/misc/graylog2.conf
+++ b/misc/graylog2.conf
@@ -191,11 +191,6 @@ allow_highlighting = false
 # Note that this setting only takes effect on newly created indices.
 elasticsearch_analyzer = standard
 
-# Store message timestamps as doc values in Elasticsearch. This will improve memory the consumption of
-# Elasticsearch at the cost of some performance at indexing time and increased index size.
-# See http://www.elastic.co/guide/en/elasticsearch/guide/master/doc-values.html for details.
-#elasticsearch_store_timestamps_as_doc_values = true
-
 # Global request timeout for Elasticsearch requests (e. g. during search, index creation, or index time-range
 # calculations) based on a best-effort to restrict the runtime of Elasticsearch operations.
 # Default: 1m


### PR DESCRIPTION
This PR adds a [dynamic mapping](https://www.elastic.co/guide/en/elasticsearch/guide/current/custom-dynamic-mapping.html) for message fields starting with "gl2_"  to be stored as [doc values](https://www.elastic.co/guide/en/elasticsearch/guide/current/doc-values.html).

Additionally it removes the `elasticsearch_store_timestamps_as_doc_values` setting and always stores the `timestamp` message field as doc value.

Closes #1335.