### PR TITLE
Allow TLS in GELF HTTP input

### DIFF
--- a/graylog2-inputs/src/main/java/org/graylog2/inputs/transports/TcpTransport.java
+++ b/graylog2-inputs/src/main/java/org/graylog2/inputs/transports/TcpTransport.java
@@ -61,23 +61,13 @@ import static org.jboss.netty.handler.codec.frame.Delimiters.lineDelimiter;
 import static org.jboss.netty.handler.codec.frame.Delimiters.nulDelimiter;
 
 public class TcpTransport extends AbstractTcpTransport {
-    private static final Logger LOG = LoggerFactory.getLogger(TcpTransport.class);
-
     public static final String CK_USE_NULL_DELIMITER = "use_null_delimiter";
-    public static final String CK_MAX_MESSAGE_SIZE = "max_message_size";
-    public static final String CK_TCP_KEEPALIVE = "tcp_keepalive";
-    public static final String CK_TLS_CERT_FILE = "tls_cert_file";
-    public static final String CK_TLS_KEY_FILE = "tls_key_file";
-    public static final String CK_TLS_ENABLE = "tls_enable";
-    public static final String CK_TLS_KEY_PASSWORD = "tls_key_password";
+    private static final String CK_MAX_MESSAGE_SIZE = "max_message_size";
+    private static final String CK_TCP_KEEPALIVE = "tcp_keepalive";
+
     protected final ChannelBuffer[] delimiter;
     protected final int maxFrameLength;
     private final boolean tcpKeepalive;
-    private final boolean tlsEnable;
-    private final String tlsKeyPassword;
-    private final Configuration configuration;
-    private File tlsCertFile;
-    private File tlsKeyFile;
 
     @AssistedInject
     public TcpTransport(@Assisted Configuration configuration,
@@ -91,7 +81,6 @@ public class TcpTransport extends AbstractTcpTransport {
                 throughputCounter,
                 connectionCounter,
                 localRegistry);
-
     }
 
     protected TcpTransport(final Configuration configuration,
@@ -101,29 +90,11 @@ public class TcpTransport extends AbstractTcpTransport {
                            final ConnectionCounter connectionCounter,
                            final LocalMetricRegistry localRegistry) {
         super(configuration, throughputCounter, localRegistry, bossPool, workerPool, connectionCounter);
-        this.configuration = configuration;
 
         final boolean nulDelimiter = configuration.getBoolean(CK_USE_NULL_DELIMITER);
         this.delimiter = nulDelimiter ? nulDelimiter() : lineDelimiter();
         this.tcpKeepalive = configuration.getBoolean(CK_TCP_KEEPALIVE);
-        this.tlsEnable = configuration.getBoolean(CK_TLS_ENABLE);
-        this.tlsCertFile = getTlsFile(configuration, CK_TLS_CERT_FILE);
-        this.tlsKeyFile = getTlsFile(configuration, CK_TLS_KEY_FILE);
-        this.tlsKeyPassword = configuration.getString(CK_TLS_KEY_PASSWORD);
-
-        if (configuration.intIsSet(CK_MAX_MESSAGE_SIZE)) {
-            maxFrameLength = configuration.getInt(CK_MAX_MESSAGE_SIZE);
-        } else {
-            maxFrameLength = Config.DEFAULT_MAX_FRAME_LENGTH;
-        }
-    }
-
-    private File getTlsFile(Configuration configuration, String configKey) {
-        if (configuration.stringIsSet(configKey)) {
-            return new File(configuration.getString(configKey));
-        } else {
-            return new File("");
-        }
+        this.maxFrameLength = configuration.getInt(CK_MAX_MESSAGE_SIZE, Config.DEFAULT_MAX_FRAME_LENGTH);
     }
 
     private static Executor executorService(final String executorName, final String threadNameFormat, final MetricRegistry metricRegistry) {
@@ -140,57 +111,6 @@ public class TcpTransport extends AbstractTcpTransport {
         bootstrap.setOption("child.keepAlive", tcpKeepalive);
 
         return bootstrap;
-    }
-
-    @Override
-    protected LinkedHashMap<String, Callable<? extends ChannelHandler>> getBaseChannelHandlers(final MessageInput input) {
-        final LinkedHashMap<String, Callable<? extends ChannelHandler>> baseChannelHandlers = super.getBaseChannelHandlers(input);
-
-        if (!tlsEnable) {
-            return baseChannelHandlers;
-        }
-
-        final LinkedHashMap<String, Callable<? extends ChannelHandler>> handlerList = Maps.newLinkedHashMap();
-
-        LOG.info("Enabling TLS for input [{}/{}]. key-file=\"{}\" cert-file=\"{}\"", input.getName(), input.getId(), tlsKeyFile.toString(), tlsCertFile.toString());
-
-        if (!tlsCertFile.exists() || !tlsKeyFile.exists()) {
-            LOG.warn("TLS key file or certificate file does not exist, creating a self-signed certificate for input [{}/{}].", input.getName(), input.getId());
-
-            final SelfSignedCertificate ssc;
-            try {
-                ssc = new SelfSignedCertificate(configuration.getString(CK_BIND_ADDRESS) + ":" + configuration.getString(CK_PORT));
-                tlsCertFile = ssc.certificate();
-                tlsKeyFile = ssc.privateKey();
-            } catch (CertificateException e) {
-                LOG.error(String.format("Problem creating a self-signed certificate for input [%s/%s].", input.getName(), input.getId()), e);
-                return baseChannelHandlers;
-            }
-        }
-
-        if (tlsCertFile.exists() && tlsKeyFile.exists()) {
-            handlerList.put("tls", buildSslHandlerCallable());
-        }
-
-        handlerList.putAll(baseChannelHandlers);
-
-        return handlerList;
-    }
-
-    private Callable<ChannelHandler> buildSslHandlerCallable() {
-        return new Callable<ChannelHandler>() {
-            @Override
-            public ChannelHandler call() throws Exception {
-                try {
-                    final SslContext sslCtx = SslContext.newServerContext(tlsCertFile, tlsKeyFile, emptyToNull(tlsKeyPassword));
-
-                    return sslCtx.newHandler();
-                } catch (SSLException e) {
-                    LOG.error("Error creating SSL context. Make sure the certificate and key are in the correct format. cert=X.509 key=PKCS#8");
-                    throw e;
-                }
-            }
-        };
     }
 
     @Override
@@ -249,42 +169,6 @@ public class TcpTransport extends AbstractTcpTransport {
                             "TCP keepalive",
                             false,
                             "Enable TCP keepalive packets"
-                    )
-            );
-            x.addField(
-                    new TextField(
-                            CK_TLS_CERT_FILE,
-                            "TLS cert file",
-                            "",
-                            "Path to the TLS certificate file",
-                            ConfigurationField.Optional.OPTIONAL
-                    )
-            );
-            x.addField(
-                    new TextField(
-                            CK_TLS_KEY_FILE,
-                            "TLS private key file",
-                            "",
-                            "Path to the TLS private key file",
-                            ConfigurationField.Optional.OPTIONAL
-                    )
-            );
-            x.addField(
-                    new BooleanField(
-                            CK_TLS_ENABLE,
-                            "Enable TLS",
-                            false,
-                            "Accept TLS connections"
-                    )
-            );
-            x.addField(
-                    new TextField(
-                            CK_TLS_KEY_PASSWORD,
-                            "TLS key password",
-                            "",
-                            "The password for the encrypted key file.",
-                            ConfigurationField.Optional.OPTIONAL,
-                            TextField.Attribute.IS_PASSWORD
                     )
             );
 

--- a/graylog2-plugin-interfaces/src/main/java/org/graylog2/plugin/inputs/transports/AbstractTcpTransport.java
+++ b/graylog2-plugin-interfaces/src/main/java/org/graylog2/plugin/inputs/transports/AbstractTcpTransport.java
@@ -22,10 +22,17 @@
  */
 package org.graylog2.plugin.inputs.transports;
 
+import com.google.common.collect.Maps;
 import com.google.common.util.concurrent.Callables;
 import org.graylog2.plugin.LocalMetricRegistry;
 import org.graylog2.plugin.configuration.Configuration;
+import org.graylog2.plugin.configuration.ConfigurationRequest;
+import org.graylog2.plugin.configuration.fields.BooleanField;
+import org.graylog2.plugin.configuration.fields.ConfigurationField;
+import org.graylog2.plugin.configuration.fields.NumberField;
+import org.graylog2.plugin.configuration.fields.TextField;
 import org.graylog2.plugin.inputs.MessageInput;
+import org.graylog2.plugin.inputs.annotations.ConfigClass;
 import org.graylog2.plugin.inputs.util.ConnectionCounter;
 import org.graylog2.plugin.inputs.util.ThroughputCounter;
 import org.jboss.netty.bootstrap.Bootstrap;
@@ -33,15 +40,37 @@ import org.jboss.netty.bootstrap.ServerBootstrap;
 import org.jboss.netty.channel.ChannelHandler;
 import org.jboss.netty.channel.FixedReceiveBufferSizePredictorFactory;
 import org.jboss.netty.channel.socket.nio.NioServerSocketChannelFactory;
+import org.jboss.netty.handler.ssl.SslContext;
+import org.jboss.netty.handler.ssl.util.SelfSignedCertificate;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
+import javax.net.ssl.SSLException;
+import java.io.File;
+import java.security.cert.CertificateException;
 import java.util.LinkedHashMap;
 import java.util.concurrent.Callable;
 import java.util.concurrent.Executor;
 
+import static com.google.common.base.Strings.emptyToNull;
+
 public abstract class AbstractTcpTransport extends NettyTransport {
+    private static final Logger LOG = LoggerFactory.getLogger(AbstractTcpTransport.class);
+
+    private static final String CK_TLS_CERT_FILE = "tls_cert_file";
+    private static final String CK_TLS_KEY_FILE = "tls_key_file";
+    private static final String CK_TLS_ENABLE = "tls_enable";
+    private static final String CK_TLS_KEY_PASSWORD = "tls_key_password";
+
     protected final Executor bossExecutor;
     protected final Executor workerExecutor;
     protected final ConnectionCounter connectionCounter;
+    protected final Configuration configuration;
+
+    private final boolean tlsEnable;
+    private final String tlsKeyPassword;
+    private File tlsCertFile;
+    private File tlsKeyFile;
 
     public AbstractTcpTransport(
             Configuration configuration,
@@ -51,12 +80,22 @@ public abstract class AbstractTcpTransport extends NettyTransport {
             Executor workerPool,
             ConnectionCounter connectionCounter) {
         super(configuration, throughputCounter, localRegistry);
+        this.configuration = configuration;
         this.bossExecutor = bossPool;
         this.workerExecutor = workerPool;
         this.connectionCounter = connectionCounter;
 
+        this.tlsEnable = configuration.getBoolean(CK_TLS_ENABLE);
+        this.tlsCertFile = getTlsFile(configuration, CK_TLS_CERT_FILE);
+        this.tlsKeyFile = getTlsFile(configuration, CK_TLS_KEY_FILE);
+        this.tlsKeyPassword = configuration.getString(CK_TLS_KEY_PASSWORD);
+
         this.localRegistry.register("open_connections", connectionCounter.gaugeCurrent());
         this.localRegistry.register("total_connections", connectionCounter.gaugeTotal());
+    }
+
+    private File getTlsFile(Configuration configuration, String configKey) {
+        return new File(configuration.getString(configKey, ""));
     }
 
     @Override
@@ -74,10 +113,95 @@ public abstract class AbstractTcpTransport extends NettyTransport {
     @Override
     protected LinkedHashMap<String, Callable<? extends ChannelHandler>> getBaseChannelHandlers(
             MessageInput input) {
-        final LinkedHashMap<String, Callable<? extends ChannelHandler>> baseChannelHandlers =
-                super.getBaseChannelHandlers(input);
+        final LinkedHashMap<String, Callable<? extends ChannelHandler>> baseChannelHandlers = super.getBaseChannelHandlers(input);
+        final LinkedHashMap<String, Callable<? extends ChannelHandler>> handlerList = Maps.newLinkedHashMap();
         baseChannelHandlers.put("connection-counter", Callables.returning(connectionCounter));
-        return baseChannelHandlers;
+
+        if (!tlsEnable) {
+            return baseChannelHandlers;
+        }
+
+        if (!tlsCertFile.exists() || !tlsKeyFile.exists()) {
+            LOG.warn("TLS key file or certificate file does not exist, creating a self-signed certificate for input [{}/{}].", input.getName(), input.getId());
+
+            try {
+                final SelfSignedCertificate ssc = new SelfSignedCertificate(configuration.getString(CK_BIND_ADDRESS) + ":" + configuration.getString(CK_PORT));
+                tlsCertFile = ssc.certificate();
+                tlsKeyFile = ssc.privateKey();
+            } catch (CertificateException e) {
+                LOG.error(String.format("Problem creating a self-signed certificate for input [%s/%s].", input.getName(), input.getId()), e);
+                return baseChannelHandlers;
+            }
+        }
+
+        if (tlsCertFile.exists() && tlsKeyFile.exists()) {
+            handlerList.put("tls", buildSslHandlerCallable());
+        }
+
+        LOG.info("Enabled TLS for input [{}/{}]. key-file=\"{}\" cert-file=\"{}\"", input.getName(), input.getId(), tlsKeyFile, tlsCertFile);
+        handlerList.putAll(baseChannelHandlers);
+
+        return handlerList;
     }
 
+    private Callable<ChannelHandler> buildSslHandlerCallable() {
+        return new Callable<ChannelHandler>() {
+            @Override
+            public ChannelHandler call() throws Exception {
+                try {
+                    return SslContext.newServerContext(tlsCertFile, tlsKeyFile, emptyToNull(tlsKeyPassword)).newHandler();
+                } catch (SSLException e) {
+                    LOG.error("Error creating SSL context. Make sure the certificate and key are in the correct format: cert=X.509 key=PKCS#8");
+                    throw e;
+                }
+            }
+        };
+    }
+
+    @ConfigClass
+    public static class Config extends NettyTransport.Config {
+        @Override
+        public ConfigurationRequest getRequestedConfiguration() {
+            final ConfigurationRequest x = super.getRequestedConfiguration();
+
+            x.addField(
+                    new TextField(
+                            CK_TLS_CERT_FILE,
+                            "TLS cert file",
+                            "",
+                            "Path to the TLS certificate file",
+                            ConfigurationField.Optional.OPTIONAL
+                    )
+            );
+            x.addField(
+                    new TextField(
+                            CK_TLS_KEY_FILE,
+                            "TLS private key file",
+                            "",
+                            "Path to the TLS private key file",
+                            ConfigurationField.Optional.OPTIONAL
+                    )
+            );
+            x.addField(
+                    new BooleanField(
+                            CK_TLS_ENABLE,
+                            "Enable TLS",
+                            false,
+                            "Accept TLS connections"
+                    )
+            );
+            x.addField(
+                    new TextField(
+                            CK_TLS_KEY_PASSWORD,
+                            "TLS key password",
+                            "",
+                            "The password for the encrypted key file.",
+                            ConfigurationField.Optional.OPTIONAL,
+                            TextField.Attribute.IS_PASSWORD
+                    )
+            );
+
+            return x;
+        }
+    }
 }


### PR DESCRIPTION
This PR moves the TLS settings from `TcpTransport` up into `AbstractTcpTransport` which "automagically" enables using TLS for other TCP-based transports like the HTTP transport used in the GELF HTTP input.