### PR TITLE
Use mutable copy of converter result in Extractor#runConverters()

### DIFF
--- a/graylog2-plugin-interfaces/src/main/java/org/graylog2/plugin/inputs/Extractor.java
+++ b/graylog2-plugin-interfaces/src/main/java/org/graylog2/plugin/inputs/Extractor.java
@@ -36,6 +36,7 @@ import org.slf4j.LoggerFactory;
 
 import java.util.Arrays;
 import java.util.Comparator;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicLong;
@@ -247,21 +248,20 @@ public abstract class Extractor implements EmbeddedPersistable {
                     msg.addField(targetField, converted);
                 } else {
                     @SuppressWarnings("unchecked")
-                    final Map<String, Object> convert =
-                            (Map<String, Object>) converter.convert((String) msg.getField(targetField));
+                    final Map<String, Object> additionalFields = new HashMap<>((Map<String, Object>) converter.convert((String) msg.getField(targetField)));
                     for (final String reservedField : Message.RESERVED_FIELDS) {
-                        if (convert.containsKey(reservedField)) {
+                        if (additionalFields.containsKey(reservedField)) {
                             if (LOG.isDebugEnabled()) {
                                 LOG.debug(
                                         "Not setting reserved field {} from converter {} on message {}, rest of the message is being processed",
                                         reservedField, converter.getType(), msg.getId());
                             }
                             converterExceptions.incrementAndGet();
-                            convert.remove(reservedField);
+                            additionalFields.remove(reservedField);
                         }
                     }
 
-                    msg.addFields(convert);
+                    msg.addFields(additionalFields);
                 }
             } catch (Exception e) {
                 this.converterExceptions.incrementAndGet();


### PR DESCRIPTION
Converters may return an immutable collection of results if they return multiple fields. To ensure that the collection can be modified, a mutable copy is being created on which all operations will take place.

Fixes #1356