### PR TITLE
Json extractor test resource

### DIFF
--- a/graylog2-rest-models/src/main/java/org/graylog2/rest/models/tools/requests/JsonTestRequest.java
+++ b/graylog2-rest-models/src/main/java/org/graylog2/rest/models/tools/requests/JsonTestRequest.java
@@ -1,0 +1,55 @@
+/**
+ * This file is part of Graylog.
+ *
+ * Graylog is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.graylog2.rest.models.tools.requests;
+
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.auto.value.AutoValue;
+import org.hibernate.validator.constraints.NotEmpty;
+
+@JsonAutoDetect
+@AutoValue
+public abstract class JsonTestRequest {
+    @JsonProperty("flatten")
+    public abstract boolean flatten();
+
+    @JsonProperty("list_separator")
+    @NotEmpty
+    public abstract String listSeparator();
+
+    @JsonProperty("key_separator")
+    @NotEmpty
+    public abstract String keySeparator();
+
+    @JsonProperty("kv_separator")
+    @NotEmpty
+    public abstract String kvSeparator();
+
+    @JsonProperty("string")
+    @NotEmpty
+    public abstract String string();
+
+    @JsonCreator
+    public static JsonTestRequest create(@JsonProperty("flatten") boolean flatten,
+                                         @JsonProperty("list_separator") @NotEmpty String listSeparator,
+                                         @JsonProperty("key_separator") @NotEmpty String keySeparator,
+                                         @JsonProperty("kv_separator") @NotEmpty String kvSeparator,
+                                         @JsonProperty("string") @NotEmpty String string) {
+        return new AutoValue_JsonTestRequest(flatten, listSeparator, keySeparator, kvSeparator, string);
+    }
+}

--- a/graylog2-rest-models/src/main/java/org/graylog2/rest/models/tools/responses/JsonTesterResponse.java
+++ b/graylog2-rest-models/src/main/java/org/graylog2/rest/models/tools/responses/JsonTesterResponse.java
@@ -1,0 +1,63 @@
+/**
+ * This file is part of Graylog.
+ *
+ * Graylog is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.graylog2.rest.models.tools.responses;
+
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.auto.value.AutoValue;
+import org.hibernate.validator.constraints.NotEmpty;
+
+import java.util.Map;
+
+@JsonAutoDetect
+@AutoValue
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public abstract class JsonTesterResponse {
+    @JsonProperty("matches")
+    public abstract Map<String, Object> matches();
+
+    @JsonProperty("flatten")
+    public abstract boolean flatten();
+
+    @JsonProperty("line_separator")
+    @NotEmpty
+    public abstract String listSeparator();
+
+    @JsonProperty("key_separator")
+    @NotEmpty
+    public abstract String keySeparator();
+
+    @JsonProperty("kv_separator")
+    @NotEmpty
+    public abstract String kvSeparator();
+
+    @JsonProperty("string")
+    @NotEmpty
+    public abstract String string();
+
+    @JsonCreator
+    public static JsonTesterResponse create(@JsonProperty("matches") Map<String, Object> matches,
+                                            @JsonProperty("flatten") boolean flatten,
+                                            @JsonProperty("line_separator") @NotEmpty String listSeparator,
+                                            @JsonProperty("key_separator") @NotEmpty String keySeparator,
+                                            @JsonProperty("kv_separator") @NotEmpty String kvSeparator,
+                                            @JsonProperty("string") @NotEmpty String string) {
+        return new AutoValue_JsonTesterResponse(matches, flatten, listSeparator, keySeparator, kvSeparator, string);
+    }
+}

--- a/graylog2-server/src/main/java/org/graylog2/rest/resources/tools/JsonTesterResource.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/resources/tools/JsonTesterResource.java
@@ -1,0 +1,93 @@
+/**
+ * This file is part of Graylog.
+ *
+ * Graylog is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.graylog2.rest.resources.tools;
+
+import com.codahale.metrics.MetricRegistry;
+import com.codahale.metrics.annotation.Timed;
+import com.google.common.collect.ImmutableMap;
+import org.apache.shiro.authz.annotation.RequiresAuthentication;
+import org.graylog2.ConfigurationException;
+import org.graylog2.inputs.extractors.JsonExtractor;
+import org.graylog2.plugin.inputs.Converter;
+import org.graylog2.plugin.inputs.Extractor;
+import org.graylog2.rest.models.tools.requests.JsonTestRequest;
+import org.graylog2.rest.models.tools.responses.JsonTesterResponse;
+import org.graylog2.shared.rest.resources.RestResource;
+import org.hibernate.validator.constraints.NotEmpty;
+
+import javax.validation.Valid;
+import javax.validation.constraints.NotNull;
+import javax.ws.rs.BadRequestException;
+import javax.ws.rs.Consumes;
+import javax.ws.rs.DefaultValue;
+import javax.ws.rs.GET;
+import javax.ws.rs.POST;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.QueryParam;
+import javax.ws.rs.core.MediaType;
+import java.util.Collections;
+import java.util.Map;
+
+@RequiresAuthentication
+@Path("/tools/json_tester")
+@Produces(MediaType.APPLICATION_JSON)
+public class JsonTesterResource extends RestResource {
+    @GET
+    @Timed
+    public JsonTesterResponse get(@QueryParam("string") @NotEmpty String string,
+                                  @QueryParam("flatten") @DefaultValue("false") boolean flatten,
+                                  @QueryParam("list_separator") @NotEmpty String listSeparator,
+                                  @QueryParam("key_separator") @NotEmpty String keySeparator,
+                                  @QueryParam("kv_separator") @NotEmpty String kvSeparator) {
+        return testJsonExtractor(string, flatten, listSeparator, keySeparator, kvSeparator);
+    }
+
+    @POST
+    @Timed
+    @Consumes(MediaType.APPLICATION_JSON)
+    public JsonTesterResponse post(@Valid @NotNull JsonTestRequest r) {
+        return testJsonExtractor(r.string(), r.flatten(), r.listSeparator(), r.keySeparator(), r.kvSeparator());
+    }
+
+    private JsonTesterResponse testJsonExtractor(String testString,
+                                                 boolean flatten,
+                                                 String listSeparator,
+                                                 String keySeparator,
+                                                 String kvSeparator) {
+        final Map<String, Object> config = ImmutableMap.<String, Object>of(
+                "flatten", flatten,
+                "list_separator", listSeparator,
+                "key_separator", keySeparator,
+                "kv_separator", kvSeparator
+        );
+        final JsonExtractor extractor;
+        try {
+            extractor = new JsonExtractor(
+                    new MetricRegistry(), "test", "Test", 0L, Extractor.CursorStrategy.COPY, "test", "test",
+                    config, getCurrentUser().getName(), Collections.<Converter>emptyList(), Extractor.ConditionType.NONE, ""
+            );
+        } catch (Extractor.ReservedFieldException e) {
+            throw new BadRequestException("Trying to overwrite a reserved message field", e);
+        } catch (ConfigurationException e) {
+            throw new BadRequestException("Invalid extractor configuration", e);
+        }
+
+        final Map<String, Object> result = extractor.extractJson(testString);
+        return JsonTesterResponse.create(result, flatten, listSeparator, keySeparator, kvSeparator, testString);
+    }
+}


### PR DESCRIPTION
Add JAX-RS resource to test a JSON extractor against an arbitrary string. This was missing from the previous PR.

Refs #1355