### PR TITLE
Prevent excessive rotation during startup when using time-based retention

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,6 +34,7 @@ deploy:
       - master
       - 1.0
       - 1.1
+      - 1.2
 env:
   global:
   - secure: MYZwUwFkHwWfJ79JKyDK8VrYVcsax4t+7atMLLVNI4CDxTWZzR4qFGUfauf+7fDEmnGYbMHDRSnzzhVtSR0ZSuvWoSkZ+v62ASmSfglzI2GcMD/VBREq+9TlLasSIa+wR60VvgYwxJnawwJlV6sbjmetT6MWug7/icdi5KgfDlQ=

--- a/graylog2-bootstrap/pom.xml
+++ b/graylog2-bootstrap/pom.xml
@@ -29,7 +29,7 @@
     <parent>
         <groupId>org.graylog2</groupId>
         <artifactId>graylog2-parent</artifactId>
-        <version>1.2.0-rc.1</version>
+        <version>1.2.1-rc.1-SNAPSHOT</version>
     </parent>
 
     <name>graylog2-bootstrap</name>

--- a/graylog2-bootstrap/pom.xml
+++ b/graylog2-bootstrap/pom.xml
@@ -29,7 +29,7 @@
     <parent>
         <groupId>org.graylog2</groupId>
         <artifactId>graylog2-parent</artifactId>
-        <version>1.2.1-rc.1-SNAPSHOT</version>
+        <version>1.2.0-rc.2-SNAPSHOT</version>
     </parent>
 
     <name>graylog2-bootstrap</name>

--- a/graylog2-bootstrap/pom.xml
+++ b/graylog2-bootstrap/pom.xml
@@ -29,7 +29,7 @@
     <parent>
         <groupId>org.graylog2</groupId>
         <artifactId>graylog2-parent</artifactId>
-        <version>1.2.0-SNAPSHOT</version>
+        <version>1.2.0-rc.1</version>
     </parent>
 
     <name>graylog2-bootstrap</name>

--- a/graylog2-inputs/pom.xml
+++ b/graylog2-inputs/pom.xml
@@ -29,7 +29,7 @@
     <parent>
         <groupId>org.graylog2</groupId>
         <artifactId>graylog2-parent</artifactId>
-        <version>1.2.0-rc.1</version>
+        <version>1.2.1-rc.1-SNAPSHOT</version>
     </parent>
 
     <name>graylog2-inputs</name>

--- a/graylog2-inputs/pom.xml
+++ b/graylog2-inputs/pom.xml
@@ -29,7 +29,7 @@
     <parent>
         <groupId>org.graylog2</groupId>
         <artifactId>graylog2-parent</artifactId>
-        <version>1.2.0-SNAPSHOT</version>
+        <version>1.2.0-rc.1</version>
     </parent>
 
     <name>graylog2-inputs</name>

--- a/graylog2-inputs/pom.xml
+++ b/graylog2-inputs/pom.xml
@@ -29,7 +29,7 @@
     <parent>
         <groupId>org.graylog2</groupId>
         <artifactId>graylog2-parent</artifactId>
-        <version>1.2.1-rc.1-SNAPSHOT</version>
+        <version>1.2.0-rc.2-SNAPSHOT</version>
     </parent>
 
     <name>graylog2-inputs</name>

--- a/graylog2-plugin-interfaces/pom.xml
+++ b/graylog2-plugin-interfaces/pom.xml
@@ -11,7 +11,7 @@
     <parent>
         <groupId>org.graylog2</groupId>
         <artifactId>graylog2-parent</artifactId>
-        <version>1.2.0-rc.1</version>
+        <version>1.2.1-rc.1-SNAPSHOT</version>
     </parent>
 
     <name>graylog2-plugin</name>

--- a/graylog2-plugin-interfaces/pom.xml
+++ b/graylog2-plugin-interfaces/pom.xml
@@ -11,7 +11,7 @@
     <parent>
         <groupId>org.graylog2</groupId>
         <artifactId>graylog2-parent</artifactId>
-        <version>1.2.0-SNAPSHOT</version>
+        <version>1.2.0-rc.1</version>
     </parent>
 
     <name>graylog2-plugin</name>

--- a/graylog2-plugin-interfaces/pom.xml
+++ b/graylog2-plugin-interfaces/pom.xml
@@ -11,7 +11,7 @@
     <parent>
         <groupId>org.graylog2</groupId>
         <artifactId>graylog2-parent</artifactId>
-        <version>1.2.1-rc.1-SNAPSHOT</version>
+        <version>1.2.0-rc.2-SNAPSHOT</version>
     </parent>
 
     <name>graylog2-plugin</name>

--- a/graylog2-radio/pom.xml
+++ b/graylog2-radio/pom.xml
@@ -29,7 +29,7 @@
     <parent>
         <groupId>org.graylog2</groupId>
         <artifactId>graylog2-parent</artifactId>
-        <version>1.2.0-rc.1</version>
+        <version>1.2.1-rc.1-SNAPSHOT</version>
     </parent>
 
     <name>graylog2-radio</name>

--- a/graylog2-radio/pom.xml
+++ b/graylog2-radio/pom.xml
@@ -29,7 +29,7 @@
     <parent>
         <groupId>org.graylog2</groupId>
         <artifactId>graylog2-parent</artifactId>
-        <version>1.2.1-rc.1-SNAPSHOT</version>
+        <version>1.2.0-rc.2-SNAPSHOT</version>
     </parent>
 
     <name>graylog2-radio</name>

--- a/graylog2-radio/pom.xml
+++ b/graylog2-radio/pom.xml
@@ -29,7 +29,7 @@
     <parent>
         <groupId>org.graylog2</groupId>
         <artifactId>graylog2-parent</artifactId>
-        <version>1.2.0-SNAPSHOT</version>
+        <version>1.2.0-rc.1</version>
     </parent>
 
     <name>graylog2-radio</name>

--- a/graylog2-rest-client/pom.xml
+++ b/graylog2-rest-client/pom.xml
@@ -11,7 +11,7 @@
     <parent>
         <groupId>org.graylog2</groupId>
         <artifactId>graylog2-parent</artifactId>
-        <version>1.2.0-SNAPSHOT</version>
+        <version>1.2.0-rc.1</version>
     </parent>
 
     <artifactId>graylog2-rest-client</artifactId>

--- a/graylog2-rest-client/pom.xml
+++ b/graylog2-rest-client/pom.xml
@@ -11,7 +11,7 @@
     <parent>
         <groupId>org.graylog2</groupId>
         <artifactId>graylog2-parent</artifactId>
-        <version>1.2.1-rc.1-SNAPSHOT</version>
+        <version>1.2.0-rc.2-SNAPSHOT</version>
     </parent>
 
     <artifactId>graylog2-rest-client</artifactId>

--- a/graylog2-rest-client/pom.xml
+++ b/graylog2-rest-client/pom.xml
@@ -11,7 +11,7 @@
     <parent>
         <groupId>org.graylog2</groupId>
         <artifactId>graylog2-parent</artifactId>
-        <version>1.2.0-rc.1</version>
+        <version>1.2.1-rc.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>graylog2-rest-client</artifactId>

--- a/graylog2-rest-client/src/main/java/org/graylog2/restclient/models/UniversalSearch.java
+++ b/graylog2-rest-client/src/main/java/org/graylog2/restclient/models/UniversalSearch.java
@@ -170,7 +170,7 @@ public class UniversalSearch {
                                                                           Integer.MAX_VALUE,
                                                                           selectedFields);
         return builder.accept(MediaType.CSV_UTF_8)
-                .timeout(KEITH, TimeUnit.SECONDS)
+                .timeout(Long.MAX_VALUE, TimeUnit.SECONDS) // never time out
                 .expect(200, 400)
                 .executeStreaming();
     }

--- a/graylog2-rest-models/pom.xml
+++ b/graylog2-rest-models/pom.xml
@@ -29,7 +29,7 @@
     <parent>
         <artifactId>graylog2-parent</artifactId>
         <groupId>org.graylog2</groupId>
-        <version>1.2.0-rc.1</version>
+        <version>1.2.1-rc.1-SNAPSHOT</version>
     </parent>
 
     <name>graylog2-rest-models</name>

--- a/graylog2-rest-models/pom.xml
+++ b/graylog2-rest-models/pom.xml
@@ -29,7 +29,7 @@
     <parent>
         <artifactId>graylog2-parent</artifactId>
         <groupId>org.graylog2</groupId>
-        <version>1.2.1-rc.1-SNAPSHOT</version>
+        <version>1.2.0-rc.2-SNAPSHOT</version>
     </parent>
 
     <name>graylog2-rest-models</name>

--- a/graylog2-rest-models/pom.xml
+++ b/graylog2-rest-models/pom.xml
@@ -29,7 +29,7 @@
     <parent>
         <artifactId>graylog2-parent</artifactId>
         <groupId>org.graylog2</groupId>
-        <version>1.2.0-SNAPSHOT</version>
+        <version>1.2.0-rc.1</version>
     </parent>
 
     <name>graylog2-rest-models</name>

--- a/graylog2-rest-routes/pom.xml
+++ b/graylog2-rest-routes/pom.xml
@@ -29,7 +29,7 @@
     <parent>
         <groupId>org.graylog2</groupId>
         <artifactId>graylog2-parent</artifactId>
-        <version>1.2.1-rc.1-SNAPSHOT</version>
+        <version>1.2.0-rc.2-SNAPSHOT</version>
     </parent>
 
     <build>

--- a/graylog2-rest-routes/pom.xml
+++ b/graylog2-rest-routes/pom.xml
@@ -29,7 +29,7 @@
     <parent>
         <groupId>org.graylog2</groupId>
         <artifactId>graylog2-parent</artifactId>
-        <version>1.2.0-SNAPSHOT</version>
+        <version>1.2.0-rc.1</version>
     </parent>
 
     <build>

--- a/graylog2-rest-routes/pom.xml
+++ b/graylog2-rest-routes/pom.xml
@@ -29,7 +29,7 @@
     <parent>
         <groupId>org.graylog2</groupId>
         <artifactId>graylog2-parent</artifactId>
-        <version>1.2.0-rc.1</version>
+        <version>1.2.1-rc.1-SNAPSHOT</version>
     </parent>
 
     <build>

--- a/graylog2-server/pom.xml
+++ b/graylog2-server/pom.xml
@@ -38,7 +38,7 @@
     <parent>
         <groupId>org.graylog2</groupId>
         <artifactId>graylog2-parent</artifactId>
-        <version>1.2.0-rc.1</version>
+        <version>1.2.1-rc.1-SNAPSHOT</version>
     </parent>
 
     <properties>

--- a/graylog2-server/pom.xml
+++ b/graylog2-server/pom.xml
@@ -17,8 +17,7 @@
   ~ You should have received a copy of the GNU General Public License
   ~ along with Graylog.  If not, see <http://www.gnu.org/licenses />.
   -->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <prerequisites>
         <maven>3.0.1</maven>
@@ -39,7 +38,7 @@
     <parent>
         <groupId>org.graylog2</groupId>
         <artifactId>graylog2-parent</artifactId>
-        <version>1.2.0-SNAPSHOT</version>
+        <version>1.2.0-rc.1</version>
     </parent>
 
     <properties>
@@ -347,10 +346,8 @@
                 <artifactId>maven-shade-plugin</artifactId>
                 <configuration>
                     <transformers>
-                        <transformer
-                                implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer"/>
-                        <transformer
-                                implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
+                        <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer" />
+                        <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
                             <mainClass>${mainClass}</mainClass>
                         </transformer>
                     </transformers>

--- a/graylog2-server/pom.xml
+++ b/graylog2-server/pom.xml
@@ -38,7 +38,7 @@
     <parent>
         <groupId>org.graylog2</groupId>
         <artifactId>graylog2-parent</artifactId>
-        <version>1.2.1-rc.1-SNAPSHOT</version>
+        <version>1.2.0-rc.2-SNAPSHOT</version>
     </parent>
 
     <properties>

--- a/graylog2-server/src/main/java/org/graylog2/indexer/results/ScrollResult.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/results/ScrollResult.java
@@ -67,7 +67,7 @@ public class ScrollResult extends IndexQueryResult {
             LOG.debug("[{}] Reached end of scroll results.", queryHash, getOriginalQuery());
             return null;
         }
-        LOG.debug("[{}] New scroll id {}", queryHash, search.getScrollId());
+        LOG.debug("[{}][{}] New scroll id {}, number of hits in chunk: {}", queryHash, chunkId, search.getScrollId(), hits.getHits().length);
         scrollId = search.getScrollId(); // save the id for the next request.
 
         return new ScrollChunk(hits, fields, chunkId++);

--- a/graylog2-server/src/main/java/org/graylog2/indexer/rotation/TimeBasedRotationStrategy.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/rotation/TimeBasedRotationStrategy.java
@@ -17,6 +17,7 @@
 package org.graylog2.indexer.rotation;
 
 import org.graylog2.configuration.ElasticsearchConfiguration;
+import org.graylog2.indexer.indices.Indices;
 import org.graylog2.plugin.Tools;
 import org.graylog2.plugin.indexer.rotation.RotationStrategy;
 import org.joda.time.DateTime;
@@ -39,18 +40,20 @@ public class TimeBasedRotationStrategy implements RotationStrategy {
     private static final Logger log = LoggerFactory.getLogger(TimeBasedRotationStrategy.class);
 
     private final Period rotationPeriod;
+    private final Indices indices;
     private DateTime lastRotation;
     private DateTime anchor;
 
     @Inject
-    public TimeBasedRotationStrategy(ElasticsearchConfiguration configuration) {
-        this(configuration.getMaxTimePerIndex());
+    public TimeBasedRotationStrategy(ElasticsearchConfiguration configuration, Indices indices) {
+        this(configuration.getMaxTimePerIndex(), indices);
     }
 
-    public TimeBasedRotationStrategy(Period rotationPeriod) {
+    public TimeBasedRotationStrategy(Period rotationPeriod, Indices indices) {
         this.rotationPeriod = rotationPeriod.normalizedStandard();
         anchor = determineRotationPeriodAnchor(rotationPeriod);
         lastRotation = null;
+        this.indices = indices;
     }
 
     /**
@@ -114,13 +117,16 @@ public class TimeBasedRotationStrategy implements RotationStrategy {
 
     @Nonnull
     @Override
-    public Result shouldRotate(String ignored) {
-        // in case we could not determine the last time a time-based rotation was performed, always rotate immediately
+    public Result shouldRotate(String index) {
         final DateTime now = Tools.iso8601();
+        // when first started, we might not know the last rotation time, look up the creation time of the index instead.
         if (lastRotation == null) {
-            lastRotation = now;
+            lastRotation = indices.indexCreationDate(index);
             anchor = determineRotationPeriodAnchor(rotationPeriod);
-            return new SimpleResult(true, "No known previous rotation time, forcing index rotation now.");
+            // still not able to figure out the last rotation time, we'll rotate forcibly
+            if (lastRotation == null) {
+                return new SimpleResult(true, "No known previous rotation time, forcing index rotation now.");
+            }
         }
 
         final DateTime nextRotation = anchor.plus(rotationPeriod);

--- a/graylog2-server/src/main/java/org/graylog2/outputs/LoggingOutput.java
+++ b/graylog2-server/src/main/java/org/graylog2/outputs/LoggingOutput.java
@@ -32,16 +32,13 @@ import javax.inject.Inject;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicBoolean;
 
-/**
- * @author Dennis Oelkers <dennis@torch.sh>
- */
 public class LoggingOutput implements MessageOutput {
     private static final Logger LOG = LoggerFactory.getLogger(LoggingOutput.class);
     private final AtomicBoolean isRunning = new AtomicBoolean(false);
     private final Configuration configuration;
 
     @Inject
-    public LoggingOutput(@Assisted Stream stream, @Assisted Configuration config) throws MessageOutputConfigurationException {
+    public LoggingOutput(@Assisted Configuration config) throws MessageOutputConfigurationException {
         LOG.info("Initializing");
         configuration = config;
         isRunning.set(true);
@@ -68,7 +65,6 @@ public class LoggingOutput implements MessageOutput {
         for (Message message : messages) {
             write(message);
         }
-
     }
 
     public interface Factory extends MessageOutput.Factory<LoggingOutput> {

--- a/graylog2-server/src/test/java/org/graylog2/indexer/rotation/TimeBasedRotationStrategyTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/indexer/rotation/TimeBasedRotationStrategyTest.java
@@ -16,7 +16,9 @@
  */
 package org.graylog2.indexer.rotation;
 
+import org.graylog2.indexer.indices.Indices;
 import org.graylog2.plugin.InstantMillisProvider;
+import org.graylog2.plugin.Tools;
 import org.graylog2.plugin.indexer.rotation.RotationStrategy;
 import org.joda.time.DateTime;
 import org.joda.time.DateTimeUtils;
@@ -30,6 +32,9 @@ import static org.joda.time.Period.seconds;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 public class TimeBasedRotationStrategyTest {
 
@@ -88,8 +93,11 @@ public class TimeBasedRotationStrategyTest {
         final InstantMillisProvider clock = new InstantMillisProvider(initialTime);
         DateTimeUtils.setCurrentMillisProvider(clock);
 
+        Indices indices = mock(Indices.class);
+        when(indices.indexCreationDate(anyString())).thenReturn(Tools.iso8601());
+
         final Period period = Period.hours(1);
-        final TimeBasedRotationStrategy hourlyRotation = new TimeBasedRotationStrategy(period);
+        final TimeBasedRotationStrategy hourlyRotation = new TimeBasedRotationStrategy(period, indices);
 
         RotationStrategy.Result result;
 
@@ -114,9 +122,11 @@ public class TimeBasedRotationStrategyTest {
 
         final InstantMillisProvider clock = new InstantMillisProvider(initialTime);
         DateTimeUtils.setCurrentMillisProvider(clock);
+        Indices indices = mock(Indices.class);
+        when(indices.indexCreationDate(anyString())).thenReturn(Tools.iso8601());
 
         final Period period = Period.minutes(10);
-        final TimeBasedRotationStrategy tenMinRotation = new TimeBasedRotationStrategy(period);
+        final TimeBasedRotationStrategy tenMinRotation = new TimeBasedRotationStrategy(period, indices);
         RotationStrategy.Result result;
 
         result = tenMinRotation.shouldRotate("ignored");

--- a/graylog2-shared/pom.xml
+++ b/graylog2-shared/pom.xml
@@ -29,7 +29,7 @@
     <parent>
         <groupId>org.graylog2</groupId>
         <artifactId>graylog2-parent</artifactId>
-        <version>1.2.0-rc.1</version>
+        <version>1.2.1-rc.1-SNAPSHOT</version>
     </parent>
 
     <name>graylog2-shared</name>

--- a/graylog2-shared/pom.xml
+++ b/graylog2-shared/pom.xml
@@ -29,7 +29,7 @@
     <parent>
         <groupId>org.graylog2</groupId>
         <artifactId>graylog2-parent</artifactId>
-        <version>1.2.1-rc.1-SNAPSHOT</version>
+        <version>1.2.0-rc.2-SNAPSHOT</version>
     </parent>
 
     <name>graylog2-shared</name>

--- a/graylog2-shared/pom.xml
+++ b/graylog2-shared/pom.xml
@@ -29,7 +29,7 @@
     <parent>
         <groupId>org.graylog2</groupId>
         <artifactId>graylog2-parent</artifactId>
-        <version>1.2.0-SNAPSHOT</version>
+        <version>1.2.0-rc.1</version>
     </parent>
 
     <name>graylog2-shared</name>

--- a/integration-tests/pom.xml
+++ b/integration-tests/pom.xml
@@ -29,7 +29,7 @@
     <parent>
         <groupId>org.graylog2</groupId>
         <artifactId>graylog2-parent</artifactId>
-        <version>1.2.0-rc.1</version>
+        <version>1.2.1-rc.1-SNAPSHOT</version>
     </parent>
 
     <name>integration-tests</name>

--- a/integration-tests/pom.xml
+++ b/integration-tests/pom.xml
@@ -29,7 +29,7 @@
     <parent>
         <groupId>org.graylog2</groupId>
         <artifactId>graylog2-parent</artifactId>
-        <version>1.2.0-SNAPSHOT</version>
+        <version>1.2.0-rc.1</version>
     </parent>
 
     <name>integration-tests</name>

--- a/integration-tests/pom.xml
+++ b/integration-tests/pom.xml
@@ -29,7 +29,7 @@
     <parent>
         <groupId>org.graylog2</groupId>
         <artifactId>graylog2-parent</artifactId>
-        <version>1.2.1-rc.1-SNAPSHOT</version>
+        <version>1.2.0-rc.2-SNAPSHOT</version>
     </parent>
 
     <name>integration-tests</name>

--- a/pom.xml
+++ b/pom.xml
@@ -25,7 +25,7 @@
 
     <groupId>org.graylog2</groupId>
     <artifactId>graylog2-parent</artifactId>
-    <version>1.2.0-SNAPSHOT</version>
+    <version>1.2.0-rc.1</version>
     <packaging>pom</packaging>
     <name>Graylog</name>
     <url>https://www.graylog.org/</url>
@@ -59,7 +59,7 @@
         <connection>scm:git:git://github.com/Graylog2/graylog2-server.git</connection>
         <developerConnection>scm:git:git@github.com:Graylog2/graylog2-server.git</developerConnection>
         <url>https://github.com/Graylog2/graylog2-server</url>
-        <tag>HEAD</tag>
+        <tag>1.2.0-rc.1</tag>
     </scm>
 
     <issueManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -25,7 +25,7 @@
 
     <groupId>org.graylog2</groupId>
     <artifactId>graylog2-parent</artifactId>
-    <version>1.2.0-rc.1</version>
+    <version>1.2.1-rc.1-SNAPSHOT</version>
     <packaging>pom</packaging>
     <name>Graylog</name>
     <url>https://www.graylog.org/</url>
@@ -59,7 +59,7 @@
         <connection>scm:git:git://github.com/Graylog2/graylog2-server.git</connection>
         <developerConnection>scm:git:git@github.com:Graylog2/graylog2-server.git</developerConnection>
         <url>https://github.com/Graylog2/graylog2-server</url>
-        <tag>1.2.0-rc.1</tag>
+        <tag>HEAD</tag>
     </scm>
 
     <issueManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -25,7 +25,7 @@
 
     <groupId>org.graylog2</groupId>
     <artifactId>graylog2-parent</artifactId>
-    <version>1.2.1-rc.1-SNAPSHOT</version>
+    <version>1.2.0-rc.2-SNAPSHOT</version>
     <packaging>pom</packaging>
     <name>Graylog</name>
     <url>https://www.graylog.org/</url>


### PR DESCRIPTION
Instead of forcing a deflector rotation, use the creation time of the deflector index to determine whether we need to rotate it.