### PR TITLE
Prevent excessive rotation during startup when using time-based retention

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/indexer/indices/Indices.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/indices/Indices.java
@@ -436,7 +436,7 @@ public class Indices implements IndexManagement {
                 .request();
         try {
             final GetIndexResponse response = c.admin().indices()
-                    .getIndex(indexRequest).actionGet(1,TimeUnit.SECONDS);
+                    .getIndex(indexRequest).actionGet();
             final Settings settings = response.settings().get(index);
             if (settings == null) {
                 return null;

--- a/graylog2-server/src/main/java/org/graylog2/indexer/rotation/TimeBasedRotationStrategy.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/rotation/TimeBasedRotationStrategy.java
@@ -17,6 +17,7 @@
 package org.graylog2.indexer.rotation;
 
 import org.graylog2.configuration.ElasticsearchConfiguration;
+import org.graylog2.indexer.indices.Indices;
 import org.graylog2.plugin.Tools;
 import org.graylog2.plugin.indexer.rotation.RotationStrategy;
 import org.joda.time.DateTime;
@@ -39,18 +40,20 @@ public class TimeBasedRotationStrategy implements RotationStrategy {
     private static final Logger log = LoggerFactory.getLogger(TimeBasedRotationStrategy.class);
 
     private final Period rotationPeriod;
+    private final Indices indices;
     private DateTime lastRotation;
     private DateTime anchor;
 
     @Inject
-    public TimeBasedRotationStrategy(ElasticsearchConfiguration configuration) {
-        this(configuration.getMaxTimePerIndex());
+    public TimeBasedRotationStrategy(ElasticsearchConfiguration configuration, Indices indices) {
+        this(configuration.getMaxTimePerIndex(), indices);
     }
 
-    public TimeBasedRotationStrategy(Period rotationPeriod) {
+    public TimeBasedRotationStrategy(Period rotationPeriod, Indices indices) {
         this.rotationPeriod = rotationPeriod.normalizedStandard();
         anchor = determineRotationPeriodAnchor(rotationPeriod);
         lastRotation = null;
+        this.indices = indices;
     }
 
     /**
@@ -114,13 +117,16 @@ public class TimeBasedRotationStrategy implements RotationStrategy {
 
     @Nonnull
     @Override
-    public Result shouldRotate(String ignored) {
-        // in case we could not determine the last time a time-based rotation was performed, always rotate immediately
+    public Result shouldRotate(String index) {
         final DateTime now = Tools.iso8601();
+        // when first started, we might not know the last rotation time, look up the creation time of the index instead.
         if (lastRotation == null) {
-            lastRotation = now;
+            lastRotation = indices.indexCreationDate(index);
             anchor = determineRotationPeriodAnchor(rotationPeriod);
-            return new SimpleResult(true, "No known previous rotation time, forcing index rotation now.");
+            // still not able to figure out the last rotation time, we'll rotate forcibly
+            if (lastRotation == null) {
+                return new SimpleResult(true, "No known previous rotation time, forcing index rotation now.");
+            }
         }
 
         final DateTime nextRotation = anchor.plus(rotationPeriod);

--- a/graylog2-server/src/test/java/org/graylog2/indexer/rotation/TimeBasedRotationStrategyTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/indexer/rotation/TimeBasedRotationStrategyTest.java
@@ -16,7 +16,9 @@
  */
 package org.graylog2.indexer.rotation;
 
+import org.graylog2.indexer.indices.Indices;
 import org.graylog2.plugin.InstantMillisProvider;
+import org.graylog2.plugin.Tools;
 import org.graylog2.plugin.indexer.rotation.RotationStrategy;
 import org.joda.time.DateTime;
 import org.joda.time.DateTimeUtils;
@@ -30,6 +32,9 @@ import static org.joda.time.Period.seconds;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 public class TimeBasedRotationStrategyTest {
 
@@ -88,8 +93,11 @@ public class TimeBasedRotationStrategyTest {
         final InstantMillisProvider clock = new InstantMillisProvider(initialTime);
         DateTimeUtils.setCurrentMillisProvider(clock);
 
+        Indices indices = mock(Indices.class);
+        when(indices.indexCreationDate(anyString())).thenReturn(Tools.iso8601());
+
         final Period period = Period.hours(1);
-        final TimeBasedRotationStrategy hourlyRotation = new TimeBasedRotationStrategy(period);
+        final TimeBasedRotationStrategy hourlyRotation = new TimeBasedRotationStrategy(period, indices);
 
         RotationStrategy.Result result;
 
@@ -114,9 +122,11 @@ public class TimeBasedRotationStrategyTest {
 
         final InstantMillisProvider clock = new InstantMillisProvider(initialTime);
         DateTimeUtils.setCurrentMillisProvider(clock);
+        Indices indices = mock(Indices.class);
+        when(indices.indexCreationDate(anyString())).thenReturn(Tools.iso8601());
 
         final Period period = Period.minutes(10);
-        final TimeBasedRotationStrategy tenMinRotation = new TimeBasedRotationStrategy(period);
+        final TimeBasedRotationStrategy tenMinRotation = new TimeBasedRotationStrategy(period, indices);
         RotationStrategy.Result result;
 
         result = tenMinRotation.shouldRotate("ignored");


### PR DESCRIPTION
Instead of forcing a deflector rotation, use the creation time of the deflector index to determine whether we need to rotate it.