### PR TITLE
allow to retrieve field stats for non-numeric fields

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/rest/resources/search/SearchResource.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/resources/search/SearchResource.java
@@ -115,7 +115,7 @@ public abstract class SearchResource extends RestResource {
                 return searches.fieldStats(field, query, filter, timeRange, true, true);
             } catch (Searches.FieldTypeException e1) {
                 LOG.error("Retrieving field statistics for field {} failed while calculating the cardinality. Cause: {}", field, ExceptionUtils.getRootCauseMessage(e1));
-                throw new BadRequestException();
+                throw new BadRequestException("Field " + field + " is not of a numeric type and the cardinality could not be calculated either.", e1);
             }
         }
     }

--- a/graylog2-server/src/main/java/org/graylog2/rest/resources/search/SearchResource.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/resources/search/SearchResource.java
@@ -44,6 +44,7 @@ import org.graylog2.rest.models.search.responses.TermsStatsResult;
 import org.graylog2.rest.models.search.responses.TimeRange;
 import org.graylog2.shared.rest.resources.RestResource;
 import org.graylog2.shared.security.RestPermissions;
+import org.graylog2.shared.utilities.ExceptionUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -110,9 +111,10 @@ public abstract class SearchResource extends RestResource {
             return searches.fieldStats(field, query, filter, timeRange);
         } catch (Searches.FieldTypeException e) {
             try {
+                LOG.debug("Stats query failed, make sure that field [{}] is a numeric type. Retrying without numeric statistics to calculate the field's cardinality.", field);
                 return searches.fieldStats(field, query, filter, timeRange, true, true);
             } catch (Searches.FieldTypeException e1) {
-                LOG.error("Stats query failed. Make sure that field [{}] is a numeric type.", field);
+                LOG.error("Retrieving field statistics for field {} failed while calculating the cardinality. Cause: {}", field, ExceptionUtils.getRootCauseMessage(e1));
                 throw new BadRequestException();
             }
         }

--- a/graylog2-server/src/main/java/org/graylog2/rest/resources/search/SearchResource.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/resources/search/SearchResource.java
@@ -109,8 +109,12 @@ public abstract class SearchResource extends RestResource {
         try {
             return searches.fieldStats(field, query, filter, timeRange);
         } catch (Searches.FieldTypeException e) {
-            LOG.error("Stats query failed. Make sure that field [{}] is a numeric type.", field);
-            throw new BadRequestException();
+            try {
+                return searches.fieldStats(field, query, filter, timeRange, true, true);
+            } catch (Searches.FieldTypeException e1) {
+                LOG.error("Stats query failed. Make sure that field [{}] is a numeric type.", field);
+                throw new BadRequestException();
+            }
         }
     }
 


### PR DESCRIPTION
All fields, except cardinality, will be 0

 - this works by repeating the query but only asking for the cardinality