### PR TITLE
Migrate existing index ranges from MongoDB to Elasticsearch

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/bindings/PersistenceServicesBindings.java
+++ b/graylog2-server/src/main/java/org/graylog2/bindings/PersistenceServicesBindings.java
@@ -31,6 +31,7 @@ import org.graylog2.indexer.PersistedDeadLetterService;
 import org.graylog2.indexer.PersistedDeadLetterServiceImpl;
 import org.graylog2.indexer.ranges.EsIndexRangeService;
 import org.graylog2.indexer.ranges.IndexRangeService;
+import org.graylog2.indexer.ranges.MongoIndexRangeService;
 import org.graylog2.inputs.InputService;
 import org.graylog2.inputs.InputServiceImpl;
 import org.graylog2.notifications.NotificationService;
@@ -63,6 +64,7 @@ public class PersistenceServicesBindings extends AbstractModule {
         bind(IndexFailureService.class).to(IndexFailureServiceImpl.class);
         bind(NodeService.class).to(NodeServiceImpl.class);
         bind(IndexRangeService.class).to(EsIndexRangeService.class).asEagerSingleton();
+        bind(MongoIndexRangeService.class).asEagerSingleton();
         bind(InputService.class).to(InputServiceImpl.class);
         bind(StreamRuleService.class).to(StreamRuleServiceImpl.class);
         bind(UserService.class).to(UserServiceImpl.class);

--- a/graylog2-server/src/main/java/org/graylog2/indexer/ranges/MongoIndexRangeService.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/ranges/MongoIndexRangeService.java
@@ -1,0 +1,125 @@
+/**
+ * This file is part of Graylog.
+ *
+ * Graylog is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.graylog2.indexer.ranges;
+
+import com.google.common.collect.ImmutableSortedSet;
+import com.mongodb.BasicDBObject;
+import com.mongodb.DB;
+import com.mongodb.DBCollection;
+import com.mongodb.DBObject;
+import com.mongodb.WriteResult;
+import org.graylog2.database.MongoConnection;
+import org.graylog2.database.NotFoundException;
+import org.graylog2.database.PersistedServiceImpl;
+import org.joda.time.DateTime;
+import org.joda.time.DateTimeZone;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.inject.Inject;
+import java.util.List;
+import java.util.SortedSet;
+
+import static com.google.common.base.MoreObjects.firstNonNull;
+
+public class MongoIndexRangeService extends PersistedServiceImpl implements IndexRangeService {
+    private static final Logger LOG = LoggerFactory.getLogger(MongoIndexRangeService.class);
+    private static final String COLLECTION_NAME = "index_ranges";
+    private static final String FIELD_MIGRATED = "migrated";
+
+    @Inject
+    public MongoIndexRangeService(final MongoConnection mongoConnection) {
+        super(mongoConnection);
+    }
+
+    @Override
+    public IndexRange get(String index) throws NotFoundException {
+        final DBObject dbo = findOne(new BasicDBObject("index", index), COLLECTION_NAME);
+
+        if (dbo == null) {
+            throw new NotFoundException("Index range for index <" + index + "> not found.");
+        }
+
+        try {
+            return buildIndexRange(dbo);
+        } catch (Exception e) {
+            throw new NotFoundException("Index range for index <" + index + "> not valid.");
+        }
+    }
+
+    private IndexRange buildIndexRange(DBObject dbo) {
+        final String indexName = (String) dbo.get("index");
+        final DateTime begin = new DateTime(0L, DateTimeZone.UTC);
+        final DateTime end = new DateTime((Integer) dbo.get("start") * 1000L, DateTimeZone.UTC);
+        final DateTime calculatedAt = new DateTime((Integer) dbo.get("calculated_at") * 1000L, DateTimeZone.UTC);
+        final int calculationDuration = (Integer) dbo.get("took_ms");
+
+        return IndexRange.create(indexName, begin, end, calculatedAt, calculationDuration);
+    }
+
+    @Override
+    public SortedSet<IndexRange> find(DateTime begin, DateTime end) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public SortedSet<IndexRange> findAll() {
+        final List<DBObject> result = query(new BasicDBObject(FIELD_MIGRATED, new BasicDBObject("$ne", true)), COLLECTION_NAME);
+
+        final ImmutableSortedSet.Builder<IndexRange> indexRanges = ImmutableSortedSet.orderedBy(IndexRange.COMPARATOR);
+        for (DBObject dbo : result) {
+            try {
+                indexRanges.add(buildIndexRange(dbo));
+            } catch (Exception e) {
+                LOG.debug("Couldn't add index range to result set: " + dbo, e);
+            }
+        }
+
+        return indexRanges.build();
+    }
+
+    @Override
+    public void save(IndexRange indexRange) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public IndexRange calculateRange(String index) {
+        throw new UnsupportedOperationException();
+    }
+
+    public boolean markAsMigrated(String index) {
+        final DB db = mongoConnection.getDatabase();
+        final DBCollection collection = db.getCollection(COLLECTION_NAME);
+
+        final DBObject updatedData = new BasicDBObject("$set", new BasicDBObject(FIELD_MIGRATED, true));
+        final DBObject searchQuery = new BasicDBObject("index", index);
+        final WriteResult result = collection.update(searchQuery, updatedData);
+
+        return result.isUpdateOfExisting();
+    }
+
+    public boolean isMigrated(String index) {
+        final DBObject dbo = findOne(new BasicDBObject("index", index), COLLECTION_NAME);
+
+        if (dbo == null) {
+            return false;
+        }
+
+        return firstNonNull((Boolean) dbo.get(FIELD_MIGRATED), false);
+    }
+}

--- a/graylog2-server/src/main/java/org/graylog2/indexer/ranges/MongoIndexRangeService.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/ranges/MongoIndexRangeService.java
@@ -65,8 +65,8 @@ public class MongoIndexRangeService extends PersistedServiceImpl implements Inde
         final String indexName = (String) dbo.get("index");
         final DateTime begin = new DateTime(0L, DateTimeZone.UTC);
         final DateTime end = new DateTime((Integer) dbo.get("start") * 1000L, DateTimeZone.UTC);
-        final DateTime calculatedAt = new DateTime((Integer) dbo.get("calculated_at") * 1000L, DateTimeZone.UTC);
-        final int calculationDuration = (Integer) dbo.get("took_ms");
+        final DateTime calculatedAt = new DateTime(firstNonNull((Integer) dbo.get("calculated_at"), 0) * 1000L, DateTimeZone.UTC);
+        final int calculationDuration = firstNonNull((Integer) dbo.get("took_ms"), 0);
 
         return IndexRange.create(indexName, begin, end, calculatedAt, calculationDuration);
     }

--- a/graylog2-server/src/test/java/org/graylog2/indexer/ranges/MongoIndexRangeServiceTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/indexer/ranges/MongoIndexRangeServiceTest.java
@@ -72,6 +72,15 @@ public class MongoIndexRangeServiceTest {
         indexRangeService.get("invalid");
     }
 
+    @Test
+    @UsingDataSet(loadStrategy = LoadStrategyEnum.CLEAN_INSERT)
+    public void testGetIncompleteIndexRange() throws Exception {
+        final IndexRange indexRange = indexRangeService.get("graylog_99");
+        final DateTime end = new DateTime(2015, 1, 1, 0, 0, 0, 0, DateTimeZone.UTC);
+        final IndexRange expected = IndexRange.create("graylog_99", EPOCH, end, EPOCH, 0);
+        assertThat(indexRange).isEqualTo(expected);
+    }
+
     @Test(expected = UnsupportedOperationException.class)
     public void testFind() throws Exception {
         indexRangeService.find(new DateTime(0L, DateTimeZone.UTC), DateTime.now(DateTimeZone.UTC));
@@ -84,7 +93,9 @@ public class MongoIndexRangeServiceTest {
 
         final DateTime end1 = new DateTime(2015, 1, 2, 0, 0, 0, 0, DateTimeZone.UTC);
         final DateTime end2 = new DateTime(2015, 1, 3, 0, 0, 0, 0, DateTimeZone.UTC);
+        final DateTime end99 = new DateTime(2015, 1, 1, 0, 0, 0, 0, DateTimeZone.UTC);
         assertThat(indexRanges).containsExactly(
+                IndexRange.create("graylog_99", EPOCH, end99, EPOCH, 0),
                 IndexRange.create("graylog_1", EPOCH, end1, end1, 1),
                 IndexRange.create("graylog_2", EPOCH, end2, end2, 2)
         );

--- a/graylog2-server/src/test/java/org/graylog2/indexer/ranges/MongoIndexRangeServiceTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/indexer/ranges/MongoIndexRangeServiceTest.java
@@ -1,0 +1,132 @@
+/**
+ * This file is part of Graylog.
+ *
+ * Graylog is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.graylog2.indexer.ranges;
+
+import com.lordofthejars.nosqlunit.annotation.UsingDataSet;
+import com.lordofthejars.nosqlunit.core.LoadStrategyEnum;
+import com.lordofthejars.nosqlunit.mongodb.InMemoryMongoDb;
+import org.graylog2.database.MongoConnectionRule;
+import org.graylog2.database.NotFoundException;
+import org.joda.time.DateTime;
+import org.joda.time.DateTimeZone;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import java.util.SortedSet;
+
+import static com.lordofthejars.nosqlunit.mongodb.InMemoryMongoDb.InMemoryMongoRuleBuilder.newInMemoryMongoDbRule;
+import static org.assertj.core.api.Assertions.assertThat;
+
+@RunWith(MockitoJUnitRunner.class)
+public class MongoIndexRangeServiceTest {
+    @ClassRule
+    public static final InMemoryMongoDb IN_MEMORY_MONGO_DB = newInMemoryMongoDbRule().build();
+    private static final DateTime EPOCH = new DateTime(0L, DateTimeZone.UTC);
+
+    @Rule
+    public MongoConnectionRule mongoRule = MongoConnectionRule.build("test");
+
+    private MongoIndexRangeService indexRangeService;
+
+    @Before
+    public void setUp() throws Exception {
+        indexRangeService = new MongoIndexRangeService(mongoRule.getMongoConnection());
+    }
+
+    @Test
+    @UsingDataSet(loadStrategy = LoadStrategyEnum.CLEAN_INSERT)
+    public void testGetExistingIndexRange() throws Exception {
+        final IndexRange indexRange = indexRangeService.get("graylog_0");
+        final DateTime end = new DateTime(2015, 1, 1, 0, 0, 0, 0, DateTimeZone.UTC);
+        final IndexRange expected = IndexRange.create("graylog_0", EPOCH, end, end, 0);
+        assertThat(indexRange).isEqualTo(expected);
+    }
+
+    @Test(expected = NotFoundException.class)
+    @UsingDataSet(loadStrategy = LoadStrategyEnum.CLEAN_INSERT)
+    public void testGetNonExistingIndexRange() throws Exception {
+        indexRangeService.get("does-not-exist");
+    }
+
+    @Test(expected = NotFoundException.class)
+    @UsingDataSet(loadStrategy = LoadStrategyEnum.CLEAN_INSERT)
+    public void testGetInvalidIndexRange() throws Exception {
+        indexRangeService.get("invalid");
+    }
+
+    @Test(expected = UnsupportedOperationException.class)
+    public void testFind() throws Exception {
+        indexRangeService.find(new DateTime(0L, DateTimeZone.UTC), DateTime.now(DateTimeZone.UTC));
+    }
+
+    @Test
+    @UsingDataSet(loadStrategy = LoadStrategyEnum.CLEAN_INSERT)
+    public void testFindAll() throws Exception {
+        final SortedSet<IndexRange> indexRanges = indexRangeService.findAll();
+
+        final DateTime end1 = new DateTime(2015, 1, 2, 0, 0, 0, 0, DateTimeZone.UTC);
+        final DateTime end2 = new DateTime(2015, 1, 3, 0, 0, 0, 0, DateTimeZone.UTC);
+        assertThat(indexRanges).containsExactly(
+                IndexRange.create("graylog_1", EPOCH, end1, end1, 1),
+                IndexRange.create("graylog_2", EPOCH, end2, end2, 2)
+        );
+    }
+
+    @Test(expected = UnsupportedOperationException.class)
+    public void testSave() throws Exception {
+        indexRangeService.save((IndexRange) null);
+    }
+
+    @Test(expected = UnsupportedOperationException.class)
+    public void testCalculateRange() throws Exception {
+        indexRangeService.calculateRange("graylog_0");
+    }
+
+    @Test
+    @UsingDataSet(loadStrategy = LoadStrategyEnum.CLEAN_INSERT)
+    public void testMarkAsMigratedIsIdempotent() throws Exception {
+        assertThat(indexRangeService.isMigrated("graylog_0")).isTrue();
+
+        assertThat(indexRangeService.markAsMigrated("graylog_0")).isTrue();
+
+        assertThat(indexRangeService.isMigrated("graylog_0")).isTrue();
+    }
+
+    @Test
+    @UsingDataSet(loadStrategy = LoadStrategyEnum.CLEAN_INSERT)
+    public void testMarkAsMigrated() throws Exception {
+        assertThat(indexRangeService.isMigrated("graylog_1")).isFalse();
+        assertThat(indexRangeService.isMigrated("graylog_2")).isFalse();
+
+        assertThat(indexRangeService.markAsMigrated("graylog_1")).isTrue();
+
+        assertThat(indexRangeService.isMigrated("graylog_1")).isTrue();
+        assertThat(indexRangeService.isMigrated("graylog_2")).isFalse();
+    }
+
+    @Test
+    @UsingDataSet(loadStrategy = LoadStrategyEnum.CLEAN_INSERT)
+    public void testIsMigrated() throws Exception {
+        assertThat(indexRangeService.isMigrated("graylog_0")).isTrue();
+        assertThat(indexRangeService.isMigrated("graylog_1")).isFalse();
+        assertThat(indexRangeService.isMigrated("graylog_2")).isFalse();
+    }
+}

--- a/graylog2-server/src/test/resources/org/graylog2/indexer/ranges/MongoIndexRangeServiceTest.json
+++ b/graylog2-server/src/test/resources/org/graylog2/indexer/ranges/MongoIndexRangeServiceTest.json
@@ -1,0 +1,33 @@
+{
+  "index_ranges": [
+    {
+      "id": "id1",
+      "index": "graylog_0",
+      "start": 1420070400,
+      "took_ms": 0,
+      "calculated_at": 1420070400,
+      "migrated": true
+    },
+    {
+      "id": "id2",
+      "index": "graylog_1",
+      "start": 1420156800,
+      "took_ms": 1,
+      "calculated_at": 1420156800
+    },
+    {
+      "id": "id3",
+      "index": "graylog_2",
+      "start": 1420243200,
+      "took_ms": 2,
+      "calculated_at": 1420243200
+    },
+    {
+      "id": "id4",
+      "index": "invalid",
+      "start": "HAHA",
+      "took_ms": 42,
+      "calculated_at": 1420329600
+    }
+  ]
+}

--- a/graylog2-server/src/test/resources/org/graylog2/indexer/ranges/MongoIndexRangeServiceTest.json
+++ b/graylog2-server/src/test/resources/org/graylog2/indexer/ranges/MongoIndexRangeServiceTest.json
@@ -28,6 +28,11 @@
       "start": "HAHA",
       "took_ms": 42,
       "calculated_at": 1420329600
+    },
+    {
+      "id": "id5",
+      "index": "graylog_99",
+      "start": 1420070400
     }
   ]
 }


### PR DESCRIPTION
To simplify migration to Graylog 1.2.x for existing users, the `IndexRangesMigrationPeriodical` will now migrate existing index ranges from MongoDB to Elasticsearch on startup and mark successfully migrated index ranges as such.