### PR TITLE
Fix standard deviation statistical widget

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/dashboards/widgets/StatisticalCountWidget.java
+++ b/graylog2-server/src/main/java/org/graylog2/dashboards/widgets/StatisticalCountWidget.java
@@ -32,7 +32,40 @@ import java.util.Map;
 import static com.google.common.base.Strings.isNullOrEmpty;
 
 public class StatisticalCountWidget extends SearchResultCountWidget {
-    private final String statsFunction;
+    public enum StatisticalFunction {
+        COUNT("count"),
+        MEAN("mean"),
+        STANDARD_DEVIATION("std_deviation"),
+        MIN("min"),
+        MAX("max"),
+        SUM("sum"),
+        VARIANCE("variance"),
+        SUM_OF_SQUARES("squares"),
+        CARDINALITY("cardinality");
+
+        private final String function;
+
+        StatisticalFunction(String function) {
+            this.function = function;
+        }
+
+        @Override
+        public String toString() {
+            return this.function;
+        }
+
+        public static StatisticalFunction fromString(String function) {
+            for (StatisticalFunction statisticalFunction : StatisticalFunction.values()) {
+                if (statisticalFunction.toString().equals(function)) {
+                    return statisticalFunction;
+                }
+            }
+
+            throw new IllegalArgumentException("Statistic function " + function + " is not supported");
+        }
+    }
+
+    private final StatisticalFunction statsFunction;
     private final String field;
     private final String streamId;
 
@@ -56,7 +89,9 @@ public class StatisticalCountWidget extends SearchResultCountWidget {
               timeRange,
               creatorUserId);
         this.field = (String) config.get("field");
-        this.statsFunction = (String) config.get("stats_function");
+        String statsFunction = (String) config.get("stats_function");
+        // We accidentally modified the standard deviation function name, we need this to make old widgets work again
+        this.statsFunction = (statsFunction.equals("stddev")) ? StatisticalFunction.STANDARD_DEVIATION : StatisticalFunction.fromString(statsFunction);
         this.streamId = (String) config.get("stream_id");
     }
 
@@ -66,7 +101,7 @@ public class StatisticalCountWidget extends SearchResultCountWidget {
         final ImmutableMap.Builder<String, Object> persistedConfig = ImmutableMap.builder();
         persistedConfig.putAll(inheritedConfig);
         persistedConfig.put("field", field);
-        persistedConfig.put("stats_function", statsFunction);
+        persistedConfig.put("stats_function", statsFunction.toString());
         if (!isNullOrEmpty(streamId)) {
             persistedConfig.put("stream_id", streamId);
         }
@@ -76,23 +111,23 @@ public class StatisticalCountWidget extends SearchResultCountWidget {
 
     private Number getStatisticalValue(FieldStatsResult fieldStatsResult) {
         switch (statsFunction) {
-            case "count":
+            case COUNT:
                 return fieldStatsResult.getCount();
-            case "mean":
+            case MEAN:
                 return fieldStatsResult.getMean();
-            case "stddev":
+            case STANDARD_DEVIATION:
                 return fieldStatsResult.getStdDeviation();
-            case "min":
+            case MIN:
                 return fieldStatsResult.getMin();
-            case "max":
+            case MAX:
                 return fieldStatsResult.getMax();
-            case "sum":
+            case SUM:
                 return fieldStatsResult.getSum();
-            case "variance":
+            case VARIANCE:
                 return fieldStatsResult.getVariance();
-            case "squares":
+            case SUM_OF_SQUARES:
                 return fieldStatsResult.getSumOfSquares();
-            case "cardinality":
+            case CARDINALITY:
                 return fieldStatsResult.getCardinality();
             default:
                 throw new IllegalArgumentException("Statistic function " + statsFunction + " is not supported");
@@ -109,7 +144,7 @@ public class StatisticalCountWidget extends SearchResultCountWidget {
                 filter = null;
             }
             // if we only need the cardinality, we can skip calculating the extended stats and vice versa
-            boolean isCardinalityFunction = "cardinality".equals(statsFunction);
+            boolean isCardinalityFunction = statsFunction.equals(StatisticalFunction.CARDINALITY);
             final FieldStatsResult fieldStatsResult =
                     getSearches().fieldStats(field,
                                              query,


### PR DESCRIPTION
We accidentally renamed the standard deviation statistical function in 1.1, these changes make both old and new widgets work as intended.

Fixes Graylog2/graylog2-web-interface#1565.