### PR TITLE
in LDAP group lookup use the user specified filter instead of limitin…

### DIFF
--- a/graylog2-rest-client/src/main/java/org/graylog2/restclient/models/accounts/LdapSettings.java
+++ b/graylog2-rest-client/src/main/java/org/graylog2/restclient/models/accounts/LdapSettings.java
@@ -63,7 +63,7 @@ public class LdapSettings {
         response.setGroupMapping(request.groupMapping);
         response.setGroupIdAttribute(request.groupIdAttribute);
         response.setGroupSearchBase(request.groupSearchBase);
-        response.setGroupObjectClass(request.groupObjectClass);
+        response.setGroupSearchPattern(request.groupSearchPattern);
         response.setAdditionalDefaultGroups(request.additionalDefaultGroups);
         this.response = response;
     }
@@ -99,7 +99,7 @@ public class LdapSettings {
         request.groupIdAttribute = getGroupIdAttribute();
         request.groupSearchBase = getGroupSearchBase();
         request.groupMapping = getGroupMapping();
-        request.groupObjectClass = getGroupObjectClass();
+        request.groupSearchPattern = getGroupSearchPattern();
         request.additionalDefaultGroups = getAdditionalDefaultGroups();
         return request;
     }
@@ -228,7 +228,7 @@ public class LdapSettings {
     }
 
     @Nullable
-    public String getGroupObjectClass() {
-        return response.getGroupObjectClass();
+    public String getGroupSearchPattern() {
+        return response.getGroupSearchPattern();
     }
 }

--- a/graylog2-rest-client/src/main/java/org/graylog2/restclient/models/api/requests/accounts/LdapSettingsRequest.java
+++ b/graylog2-rest-client/src/main/java/org/graylog2/restclient/models/api/requests/accounts/LdapSettingsRequest.java
@@ -70,9 +70,9 @@ public class LdapSettingsRequest extends ApiRequest {
     @Nullable
     public String groupIdAttribute;
 
-    @JsonProperty("group_object_class")
+    @JsonProperty("group_search_pattern")
     @Nullable
-    public String groupObjectClass;
+    public String groupSearchPattern;
 
     @JsonProperty("additional_default_groups")
     @Nullable
@@ -194,12 +194,12 @@ public class LdapSettingsRequest extends ApiRequest {
     }
 
     @Nullable
-    public String getGroupObjectClass() {
-        return groupObjectClass;
+    public String getGroupSearchPattern() {
+        return groupSearchPattern;
     }
 
-    public void setGroupObjectClass(@Nullable String groupObjectClass) {
-        this.groupObjectClass = groupObjectClass;
+    public void setGroupSearchPattern(@Nullable String groupSearchPattern) {
+        this.groupSearchPattern = groupSearchPattern;
     }
 
     @Nullable

--- a/graylog2-rest-client/src/main/java/org/graylog2/restclient/models/api/requests/accounts/LdapTestConnectionRequest.java
+++ b/graylog2-rest-client/src/main/java/org/graylog2/restclient/models/api/requests/accounts/LdapTestConnectionRequest.java
@@ -60,6 +60,6 @@ public class LdapTestConnectionRequest extends ApiRequest {
     @JsonProperty("group_id_attribute")
     public String groupIdAttribute;
 
-    @JsonProperty("group_object_class")
-    public String groupObjectClass;
+    @JsonProperty("group_search_pattern")
+    public String groupSearchPattern;
 }

--- a/graylog2-rest-client/src/main/java/org/graylog2/restclient/models/api/responses/accounts/LdapSettingsResponse.java
+++ b/graylog2-rest-client/src/main/java/org/graylog2/restclient/models/api/responses/accounts/LdapSettingsResponse.java
@@ -69,9 +69,9 @@ public class LdapSettingsResponse {
     @Nullable
     public String groupIdAttribute;
 
-    @JsonProperty("group_object_class")
+    @JsonProperty("group_search_pattern")
     @Nullable
-    public String groupObjectClass;
+    public String groupSearchPattern;
 
     @JsonProperty("additional_default_groups")
     @Nullable
@@ -193,12 +193,12 @@ public class LdapSettingsResponse {
     }
 
     @Nullable
-    public String getGroupObjectClass() {
-        return groupObjectClass;
+    public String getGroupSearchPattern() {
+        return groupSearchPattern;
     }
 
-    public void setGroupObjectClass(@Nullable String groupObjectClass) {
-        this.groupObjectClass = groupObjectClass;
+    public void setGroupSearchPattern(@Nullable String groupSearchPattern) {
+        this.groupSearchPattern = groupSearchPattern;
     }
 
     @Nullable

--- a/graylog2-rest-models/src/main/java/org/graylog2/rest/models/system/ldap/requests/LdapSettingsRequest.java
+++ b/graylog2-rest-models/src/main/java/org/graylog2/rest/models/system/ldap/requests/LdapSettingsRequest.java
@@ -81,7 +81,7 @@ public abstract class LdapSettingsRequest {
 
     @JsonProperty
     @Nullable
-    public abstract String groupObjectClass();
+    public abstract String groupSearchPattern();
 
     @JsonCreator
     public static LdapSettingsRequest create(@JsonProperty("enabled") boolean enabled,
@@ -99,7 +99,7 @@ public abstract class LdapSettingsRequest {
                                              @JsonProperty("group_search_base") @Nullable String groupSearchBase,
                                              @JsonProperty("group_id_attribute") @Nullable String groupIdAttribute,
                                              @JsonProperty("additional_default_groups") @Nullable Set<String> additionalDefaultGroups,
-                                             @JsonProperty("group_object_class") @Nullable String groupObjectClass) {
+                                             @JsonProperty("group_search_pattern") @Nullable String groupSearchPattern) {
         return new AutoValue_LdapSettingsRequest(enabled,
                                                  systemUsername,
                                                  systemPassword,
@@ -115,6 +115,6 @@ public abstract class LdapSettingsRequest {
                                                  groupSearchBase,
                                                  groupIdAttribute,
                                                  additionalDefaultGroups,
-                                                 groupObjectClass);
+                                                 groupSearchPattern);
     }
 }

--- a/graylog2-rest-models/src/main/java/org/graylog2/rest/models/system/ldap/requests/LdapTestConfigRequest.java
+++ b/graylog2-rest-models/src/main/java/org/graylog2/rest/models/system/ldap/requests/LdapTestConfigRequest.java
@@ -77,7 +77,7 @@ public abstract class LdapTestConfigRequest {
 
     @JsonProperty
     @Nullable
-    public abstract String groupObjectClass();
+    public abstract String groupSearchPattern();
 
     @JsonCreator
     public static LdapTestConfigRequest create(@JsonProperty("system_username") @Nullable String systemUsername,
@@ -93,7 +93,7 @@ public abstract class LdapTestConfigRequest {
                                                @JsonProperty("test_connect_only") boolean testConnectOnly,
                                                @JsonProperty("group_search_base") @Nullable String groupSearchBase,
                                                @JsonProperty("group_id_attribute") @Nullable String groupIdAttribute,
-                                               @JsonProperty("group_object_class") @Nullable String groupObjectClass) {
+                                               @JsonProperty("group_search_pattern") @Nullable String groupSearchPattern) {
         return new AutoValue_LdapTestConfigRequest(systemUsername,
                                                    systemPassword,
                                                    ldapUri,
@@ -107,6 +107,6 @@ public abstract class LdapTestConfigRequest {
                                                    testConnectOnly,
                                                    groupSearchBase,
                                                    groupIdAttribute,
-                                                   groupObjectClass);
+                                                   groupSearchPattern);
     }
 }

--- a/graylog2-rest-models/src/main/java/org/graylog2/rest/models/system/ldap/responses/LdapSettingsResponse.java
+++ b/graylog2-rest-models/src/main/java/org/graylog2/rest/models/system/ldap/responses/LdapSettingsResponse.java
@@ -78,6 +78,10 @@ public abstract class LdapSettingsResponse {
     @Nullable
     public abstract Set<String> additionalDefaultGroups();
 
+    @JsonProperty
+    @Nullable
+    public abstract String groupSearchPattern();
+
 
     @JsonCreator
     public static LdapSettingsResponse create(@JsonProperty("enabled") boolean enabled,
@@ -94,7 +98,8 @@ public abstract class LdapSettingsResponse {
                                               @JsonProperty("group_mapping") @Nullable Map<String, String> groupMapping,
                                               @JsonProperty("group_search_base") @Nullable String groupSearchBase,
                                               @JsonProperty("group_id_attribute") @Nullable String groupIdAttribute,
-                                              @JsonProperty("additional_default_groups") @Nullable Set<String> additionalDefaultGroups) {
+                                              @JsonProperty("additional_default_groups") @Nullable Set<String> additionalDefaultGroups,
+                                              @JsonProperty("group_search_pattern") @Nullable String groupSearchPattern) {
         return new AutoValue_LdapSettingsResponse(enabled,
                                                   systemUsername,
                                                   systemPassword,
@@ -109,6 +114,7 @@ public abstract class LdapSettingsResponse {
                                                   groupMapping,
                                                   groupSearchBase,
                                                   groupIdAttribute,
-                                                  additionalDefaultGroups);
+                                                  additionalDefaultGroups,
+                                                  groupSearchPattern);
     }
 }

--- a/graylog2-server/src/main/java/org/graylog2/rest/resources/system/ldap/LdapResource.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/resources/system/ldap/LdapResource.java
@@ -110,7 +110,8 @@ public class LdapResource extends RestResource {
                 ldapSettings.getGroupMapping(),
                 ldapSettings.getGroupSearchBase(),
                 ldapSettings.getGroupIdAttribute(),
-                ldapSettings.getAdditionalDefaultGroups());
+                ldapSettings.getAdditionalDefaultGroups(),
+                ldapSettings.getGroupSearchPattern());
     }
 
     @POST
@@ -172,7 +173,7 @@ public class LdapResource extends RestResource {
                         request.activeDirectory(),
                         request.groupSearchBase(),
                         request.groupIdAttribute(),
-                        request.groupObjectClass());
+                        request.groupSearchPattern());
                 if (entry != null) {
                     userPrincipalName = entry.getBindPrincipal();
                     entryMap = entry.getAttributes();
@@ -225,7 +226,7 @@ public class LdapResource extends RestResource {
         ldapSettings.setGroupMapping(request.groupMapping());
         ldapSettings.setGroupSearchBase(request.groupSearchBase());
         ldapSettings.setGroupIdAttribute(request.groupIdAttribute());
-        ldapSettings.setGroupObjectClass(request.groupObjectClass());
+        ldapSettings.setGroupSearchPattern(request.groupSearchPattern());
         ldapSettings.setAdditionalDefaultGroups(request.additionalDefaultGroups());
 
         ldapSettingsService.save(ldapSettings);
@@ -300,7 +301,7 @@ public class LdapResource extends RestResource {
             LdapNetworkConnection connection = ldapConnector.connect(config);
             final Set<String> groups = ldapConnector.listGroups(connection,
                                                                ldapSettings.getGroupSearchBase(),
-                                                               ldapSettings.getGroupObjectClass(),
+                                                               ldapSettings.getGroupSearchPattern(),
                                                                ldapSettings.getGroupIdAttribute());
             return groups;
         } catch (LdapException e) {

--- a/graylog2-server/src/main/java/org/graylog2/security/ldap/LdapConnector.java
+++ b/graylog2-server/src/main/java/org/graylog2/security/ldap/LdapConnector.java
@@ -48,6 +48,8 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.TimeUnit;
 
+import static com.google.common.base.Strings.isNullOrEmpty;
+
 public class LdapConnector {
     private static final Logger LOG = LoggerFactory.getLogger(LdapConnector.class);
 
@@ -106,7 +108,7 @@ public class LdapConnector {
                             boolean activeDirectory,
                             String groupSearchBase,
                             String groupIdAttribute,
-                            String groupObjectClass) throws LdapException, CursorException {
+                            String groupSearchPattern) throws LdapException, CursorException {
         final LdapEntry ldapEntry = new LdapEntry();
 
         final String filter = MessageFormat.format(searchPattern, sanitizePrincipal(principal));
@@ -143,12 +145,12 @@ public class LdapConnector {
                 LOG.trace("No LDAP entry found for filter {}", filter);
                 return null;
             }
-            if (groupSearchBase != null && groupIdAttribute != null && groupObjectClass != null) {
+            if (!isNullOrEmpty(groupSearchBase) && !isNullOrEmpty(groupIdAttribute) && !isNullOrEmpty(groupSearchPattern)) {
                 // TODO ActiveDirectory could use the memberOf attribute, but then we'd need to resolve the CN of each group, too.
                 // TODO we do not check for dynamic groups yet.
                 ldapEntry.addGroups(findGroups(connection,
                                                groupSearchBase,
-                                               groupObjectClass,
+                                               groupSearchPattern,
                                                groupIdAttribute,
                                                ldapEntry.getDn()));
                 LOG.trace("LDAP search found entry for DN {} with search filter {}: {}",
@@ -168,7 +170,7 @@ public class LdapConnector {
 
     public Set<String> findGroups(LdapNetworkConnection connection,
                                   String groupSearchBase,
-                                  String groupObjectClass,
+                                  String groupSearchPattern,
                                   String groupIdAttribute,
                                   String dn) throws LdapException {
         final Set<String> groups = Sets.newHashSet();
@@ -177,10 +179,10 @@ public class LdapConnector {
         try {
             groupSearch = connection.search(
                     groupSearchBase,
-                    "(objectClass=" + groupObjectClass + ")",
+                    groupSearchPattern,
                     SearchScope.SUBTREE,
                     "*");
-            LOG.trace("LDAP search for groups: {} starting at {}", "(objectClass=" + groupObjectClass + ")", groupSearchBase);
+            LOG.trace("LDAP search for groups: {} starting at {}", groupSearchPattern, groupSearchBase);
             for (Entry e : groupSearch) {
                 if (LOG.isTraceEnabled()) {
                     LOG.trace("Group Entry: {}", e.toString("  "));
@@ -190,21 +192,28 @@ public class LdapConnector {
                     continue;
                 }
                 final String groupId = e.get(groupIdAttribute).getString();
-                String memberAttribute;
-                if (e.hasObjectClass("groupOfUniqueNames")) {
-                    memberAttribute = "uniqueMember";
-                } else if (e.hasObjectClass("groupOfNames") || e.hasObjectClass("group")) {
-                    memberAttribute = "member";
+                if (dn == null) {
+                    // no membership lookup possible (we have no user), simply collect the found group names
+                    groups.add(groupId);
                 } else {
-                    LOG.warn("Unable to auto-detect the LDAP group object class, using assuming 'member' is the correct attribute.");
-                    memberAttribute = "member";
-                }
-                final Attribute members = e.get(memberAttribute);
-                if (members != null) {
-                    for (Value<?> member : members) {
-                        LOG.trace("DN {} == {} member?", dn, member.getString());
-                        if (dn.equalsIgnoreCase(member.getString())) {
-                            groups.add(groupId);
+                    // test if the given dn parameter is actually member of any of the found groups
+                    String memberAttribute;
+                    if (e.hasObjectClass("groupOfUniqueNames")) {
+                        memberAttribute = "uniqueMember";
+                    } else if (e.hasObjectClass("groupOfNames") || e.hasObjectClass("group")) {
+                        memberAttribute = "member";
+                    } else {
+                        LOG.warn(
+                                "Unable to auto-detect the LDAP group object class, using assuming 'member' is the correct attribute.");
+                        memberAttribute = "member";
+                    }
+                    final Attribute members = e.get(memberAttribute);
+                    if (members != null) {
+                        for (Value<?> member : members) {
+                            LOG.trace("DN {} == {} member?", dn, member.getString());
+                            if (dn.equalsIgnoreCase(member.getString())) {
+                                groups.add(groupId);
+                            }
                         }
                     }
                 }
@@ -220,33 +229,9 @@ public class LdapConnector {
 
     public Set<String> listGroups(LdapNetworkConnection connection,
                                   String groupSearchBase,
-                                  String groupObjectClass,
+                                  String groupSearchPattern,
                                   String groupIdAttribute) throws LdapException {
-        final Set<String> groups = Sets.newHashSet();
-
-        EntryCursor groupSearch = null;
-        try {
-            groupSearch = connection.search(
-                    groupSearchBase,
-                    "(objectClass=" + groupObjectClass + ")",
-                    SearchScope.SUBTREE,
-                    "*");
-            for (Entry e : groupSearch) {
-                if (!e.containsAttribute(groupIdAttribute)) {
-                    LOG.warn("Unknown group id attribute {}, skipping group entry {}", groupIdAttribute, e);
-                    continue;
-                }
-                final String groupId = e.get(groupIdAttribute).getString();
-                groups.add(groupId);
-            }
-        } finally {
-            if (groupSearch != null) {
-                groupSearch.close();
-            }
-        }
-
-        return groups;
-
+        return findGroups(connection, groupSearchBase, groupSearchPattern, groupIdAttribute, null);
     }
 
     /**

--- a/graylog2-server/src/main/java/org/graylog2/security/ldap/LdapConnector.java
+++ b/graylog2-server/src/main/java/org/graylog2/security/ldap/LdapConnector.java
@@ -204,7 +204,7 @@ public class LdapConnector {
                         memberAttribute = "member";
                     } else {
                         LOG.warn(
-                                "Unable to auto-detect the LDAP group object class, using assuming 'member' is the correct attribute.");
+                                "Unable to auto-detect the LDAP group object class, assuming 'member' is the correct attribute.");
                         memberAttribute = "member";
                     }
                     final Attribute members = e.get(memberAttribute);

--- a/graylog2-server/src/main/java/org/graylog2/security/ldap/LdapSettingsImpl.java
+++ b/graylog2-server/src/main/java/org/graylog2/security/ldap/LdapSettingsImpl.java
@@ -17,6 +17,7 @@
 package org.graylog2.security.ldap;
 
 import com.google.common.base.Function;
+import com.google.common.base.Strings;
 import com.google.common.collect.Collections2;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
@@ -104,8 +105,7 @@ public class LdapSettingsImpl extends PersistedImpl implements LdapSettings {
 
     @Override
     public String getSystemUserName() {
-        final Object o = fields.get(SYSTEM_USERNAME);
-        return o != null ? o.toString() : "";
+        return Strings.nullToEmpty((String) fields.get(SYSTEM_USERNAME));
     }
 
     @Override
@@ -151,8 +151,7 @@ public class LdapSettingsImpl extends PersistedImpl implements LdapSettings {
 
     @Override
     public String getSystemPasswordSalt() {
-        Object o = fields.get(SYSTEM_PASSWORD_SALT);
-        return (o!= null) ? o.toString() : "";
+        return Strings.nullToEmpty((String) fields.get(SYSTEM_PASSWORD_SALT));
     }
 
     @Override
@@ -173,8 +172,7 @@ public class LdapSettingsImpl extends PersistedImpl implements LdapSettings {
 
     @Override
     public String getSearchBase() {
-        final Object o = fields.get(SEARCH_BASE);
-        return o != null ? o.toString() : "";
+        return Strings.nullToEmpty((String) fields.get(SEARCH_BASE));
     }
 
     @Override
@@ -184,8 +182,7 @@ public class LdapSettingsImpl extends PersistedImpl implements LdapSettings {
 
     @Override
     public String getSearchPattern() {
-        final Object o = fields.get(SEARCH_PATTERN);
-        return o != null ? o.toString() : "";
+        return Strings.nullToEmpty((String) fields.get(SEARCH_PATTERN));
     }
 
     @Override
@@ -195,8 +192,7 @@ public class LdapSettingsImpl extends PersistedImpl implements LdapSettings {
 
     @Override
     public String getDisplayNameAttribute() {
-        final Object o = fields.get(DISPLAY_NAME_ATTRIBUTE);
-        return o != null ? o.toString() : "";
+        return Strings.nullToEmpty((String) fields.get(DISPLAY_NAME_ATTRIBUTE));
     }
 
     @Override
@@ -332,8 +328,7 @@ public class LdapSettingsImpl extends PersistedImpl implements LdapSettings {
 
     @Override
     public String getGroupSearchBase() {
-        final Object o = fields.get(GROUP_SEARCH_BASE);
-        return o != null ? o.toString() : "";
+        return Strings.nullToEmpty((String) fields.get(GROUP_SEARCH_BASE));
     }
 
     @Override
@@ -343,8 +338,7 @@ public class LdapSettingsImpl extends PersistedImpl implements LdapSettings {
 
     @Override
     public String getGroupIdAttribute() {
-        final Object o = fields.get(GROUP_ID_ATTRIBUTE);
-        return o != null ? o.toString() : "";
+        return Strings.nullToEmpty((String) fields.get(GROUP_ID_ATTRIBUTE));
     }
 
     @Override
@@ -354,8 +348,7 @@ public class LdapSettingsImpl extends PersistedImpl implements LdapSettings {
 
     @Override
     public String getGroupSearchPattern() {
-        final Object o = fields.get(GROUP_SEARCH_PATTERN);
-        return o != null ? o.toString() : "";
+        return Strings.nullToEmpty((String) fields.get(GROUP_SEARCH_PATTERN));
     }
 
     @Override

--- a/graylog2-server/src/main/java/org/graylog2/security/ldap/LdapSettingsImpl.java
+++ b/graylog2-server/src/main/java/org/graylog2/security/ldap/LdapSettingsImpl.java
@@ -72,7 +72,7 @@ public class LdapSettingsImpl extends PersistedImpl implements LdapSettings {
     public static final String GROUP_MAPPING = "group_role_mapping";
     public static final String GROUP_SEARCH_BASE = "group_search_base";
     public static final String GROUP_ID_ATTRIBUTE = "group_id_attribute";
-    public static final String GROUP_OBJECT_CLASS = "group_object_class";
+    public static final String GROUP_SEARCH_PATTERN = "group_search_pattern";
     public static final String ADDITIONAL_DEFAULT_GROUPS = "additional_default_groups";
 
     protected Configuration configuration;
@@ -353,14 +353,14 @@ public class LdapSettingsImpl extends PersistedImpl implements LdapSettings {
     }
 
     @Override
-    public String getGroupObjectClass() {
-        final Object o = fields.get(GROUP_OBJECT_CLASS);
+    public String getGroupSearchPattern() {
+        final Object o = fields.get(GROUP_SEARCH_PATTERN);
         return o != null ? o.toString() : "";
     }
 
     @Override
-    public void setGroupObjectClass(String groupObjectClass) {
-        fields.put(GROUP_OBJECT_CLASS, groupObjectClass);
+    public void setGroupSearchPattern(String groupSearchPattern) {
+        fields.put(GROUP_SEARCH_PATTERN, groupSearchPattern);
     }
 
     @Override

--- a/graylog2-server/src/main/java/org/graylog2/security/realm/LdapUserAuthenticator.java
+++ b/graylog2-server/src/main/java/org/graylog2/security/realm/LdapUserAuthenticator.java
@@ -97,7 +97,7 @@ public class LdapUserAuthenticator extends AuthenticatingRealm {
                                                              ldapSettings.isActiveDirectory(),
                                                              ldapSettings.getGroupSearchBase(),
                                                              ldapSettings.getGroupIdAttribute(),
-                                                             ldapSettings.getGroupObjectClass());
+                                                             ldapSettings.getGroupSearchPattern());
             if (userEntry == null) {
                 LOG.debug("User {} not found in LDAP", principal);
                 return null;

--- a/graylog2-shared/src/main/java/org/graylog2/shared/security/ldap/LdapSettings.java
+++ b/graylog2-shared/src/main/java/org/graylog2/shared/security/ldap/LdapSettings.java
@@ -90,9 +90,9 @@ public interface LdapSettings extends Persisted {
 
     void setGroupIdAttribute(String groupIdAttribute);
 
-    String getGroupObjectClass();
+    String getGroupSearchPattern();
 
-    void setGroupObjectClass(String groupObjectClass);
+    void setGroupSearchPattern(String groupSearchPattern);
 
     void setAdditionalDefaultGroups(Set<String> strings);
 


### PR DESCRIPTION
…g it to objectClass

 previously we only allowed to filter for objectClass, which could be problematic if LDAP contained thousands of groups.
 this lets the user specify an arbitrary filter for looking up the relevant groups

 #951