### PR TITLE
Migrate user permissions to roles

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/bindings/PeriodicalBindings.java
+++ b/graylog2-server/src/main/java/org/graylog2/bindings/PeriodicalBindings.java
@@ -35,6 +35,7 @@ import org.graylog2.periodical.NodePingThread;
 import org.graylog2.periodical.PurgeExpiredCollectorsThread;
 import org.graylog2.periodical.StreamThroughputCounterManagerThread;
 import org.graylog2.periodical.ThrottleStateUpdaterThread;
+import org.graylog2.periodical.UserPermissionMigrationPeriodical;
 import org.graylog2.periodical.VersionCheckThread;
 import org.graylog2.plugin.periodical.Periodical;
 
@@ -60,5 +61,6 @@ public class PeriodicalBindings extends AbstractModule {
         periodicalBinder.addBinding().to(ClusterIdGeneratorPeriodical.class);
         periodicalBinder.addBinding().to(PurgeExpiredCollectorsThread.class);
         periodicalBinder.addBinding().to(IndexRangesMigrationPeriodical.class);
+        periodicalBinder.addBinding().to(UserPermissionMigrationPeriodical.class);
     }
 }

--- a/graylog2-server/src/main/java/org/graylog2/cluster/UserPermissionMigrationState.java
+++ b/graylog2-server/src/main/java/org/graylog2/cluster/UserPermissionMigrationState.java
@@ -1,0 +1,35 @@
+/**
+ * This file is part of Graylog.
+ *
+ * Graylog is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.graylog2.cluster;
+
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.auto.value.AutoValue;
+
+@JsonAutoDetect
+@AutoValue
+public abstract class UserPermissionMigrationState {
+
+    @JsonProperty
+    public abstract boolean migrationDone();
+
+    @JsonCreator
+    public static UserPermissionMigrationState create(@JsonProperty("migration_done") boolean migrationDone) {
+        return new AutoValue_UserPermissionMigrationState(migrationDone);
+    }
+}

--- a/graylog2-server/src/main/java/org/graylog2/periodical/UserPermissionMigrationPeriodical.java
+++ b/graylog2-server/src/main/java/org/graylog2/periodical/UserPermissionMigrationPeriodical.java
@@ -1,0 +1,167 @@
+/**
+ * This file is part of Graylog.
+ *
+ * Graylog is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.graylog2.periodical;
+
+import com.google.common.base.Predicate;
+import com.google.common.collect.Lists;
+import com.google.common.collect.Sets;
+import org.graylog2.plugin.database.ValidationException;
+import org.graylog2.plugin.database.users.User;
+import org.graylog2.plugin.periodical.Periodical;
+import org.graylog2.shared.security.RestPermissions;
+import org.graylog2.shared.users.UserService;
+import org.graylog2.users.RoleService;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.inject.Inject;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+/**
+ * This task migrates users' permission sets from pre-1.2 style to the built-in roles: admin and reader.
+ *
+ * It does so by preserving the existing stream and dashboard permissions, which can still be assigned to individual users.
+ * It is recommend to migrate to using roles exclusively, but for now both styles will work.
+ */
+public class UserPermissionMigrationPeriodical extends Periodical {
+    private static final Logger log = LoggerFactory.getLogger(UserPermissionMigrationPeriodical.class);
+
+    private final UserService userService;
+    private final RoleService roleService;
+
+    @Inject
+    public UserPermissionMigrationPeriodical(final UserService userService, final RoleService roleService) {
+        this.userService = userService;
+        this.roleService = roleService;
+    }
+
+    @Override
+    public void doRun() {
+        final List<User> users = userService.loadAll();
+        final String adminRoleId = roleService.getAdminRoleObjectId();
+        final String readerRoleId = roleService.getReaderRoleObjectId();
+
+        for (User user : users) {
+            if (user.isLocalAdmin()) {
+                log.debug("Skipping local admin user.");
+                continue;
+            }
+
+            final Set<String> fixedPermissions = Sets.newHashSet();
+            final Set<String> fixedRoleIds = Sets.newHashSet(user.getRoleIds());
+
+            final HashSet<String> permissionSet = Sets.newHashSet(user.getPermissions());
+
+            boolean hasWildcardPermission = permissionSet.contains("*");
+
+            if (hasWildcardPermission && !user.getRoleIds().contains(adminRoleId)) {
+                // need to add the admin role to this user
+                fixedRoleIds.add(adminRoleId);
+            }
+
+            final Set<String> basePermissions = RestPermissions.readerPermissions(user.getName());
+            final boolean hasCompleteReaderSet = permissionSet.containsAll(basePermissions);
+
+            // only migrate the user if it looks like a pre-1.2 user:
+            //   - it has no roles
+            //   - it has the base reader permission set
+            //   - it has the wildcard permissions
+            if (!user.getRoleIds().isEmpty() && hasCompleteReaderSet && hasWildcardPermission) {
+                log.debug("Not migrating user {}, it has already been migrated.", user.getName());
+                continue;
+            }
+            if (hasCompleteReaderSet && !user.getRoleIds().contains(readerRoleId)) {
+                // need to add the reader role to this user
+                fixedRoleIds.add(readerRoleId);
+            }
+            // filter out the individual permissions to dashboards and streams
+            final ArrayList<String> dashboardStreamPermissions = Lists.newArrayList(
+                    Sets.filter(permissionSet,
+                                new Predicate<String>() {
+                                    @Override
+                                    public boolean apply(
+                                            String permission) {
+                                        return !basePermissions.contains(
+                                                permission) && !permission.equals(
+                                                "*");
+                                    }
+                                }));
+            // add the minimal permission set back to the user
+            fixedPermissions.addAll(RestPermissions.userSelfEditPermissions(user.getName()));
+            fixedPermissions.addAll(dashboardStreamPermissions);
+
+            log.info("Migrating permissions to roles for user {} from permissions {} and roles {} to new permissions {} and roles {}",
+                     user.getName(),
+                     permissionSet,
+                     user.getRoleIds(),
+                     fixedPermissions,
+                     fixedRoleIds);
+
+            user.setRoleIds(fixedRoleIds);
+            user.setPermissions(Lists.newArrayList(fixedPermissions));
+            try {
+                userService.save(user);
+            } catch (ValidationException e) {
+                log.error("Unable to migrate user permissions for user " + user.getName(), e);
+            }
+        }
+
+    }
+
+    @Override
+    public boolean runsForever() {
+        return true;
+    }
+
+    @Override
+    public boolean stopOnGracefulShutdown() {
+        return false;
+    }
+
+    @Override
+    public boolean masterOnly() {
+        return true;
+    }
+
+    @Override
+    public boolean startOnThisNode() {
+        return true;
+    }
+
+    @Override
+    public boolean isDaemon() {
+        return false;
+    }
+
+    @Override
+    public int getInitialDelaySeconds() {
+        return 0;
+    }
+
+    @Override
+    public int getPeriodSeconds() {
+        return 0;
+    }
+
+    @Override
+    protected Logger getLogger() {
+        return log;
+    }
+}

--- a/graylog2-server/src/main/java/org/graylog2/periodical/UserPermissionMigrationPeriodical.java
+++ b/graylog2-server/src/main/java/org/graylog2/periodical/UserPermissionMigrationPeriodical.java
@@ -29,8 +29,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import javax.inject.Inject;
-import java.util.ArrayList;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
@@ -67,7 +65,7 @@ public class UserPermissionMigrationPeriodical extends Periodical {
             final Set<String> fixedPermissions = Sets.newHashSet();
             final Set<String> fixedRoleIds = Sets.newHashSet(user.getRoleIds());
 
-            final HashSet<String> permissionSet = Sets.newHashSet(user.getPermissions());
+            final Set<String> permissionSet = Sets.newHashSet(user.getPermissions());
 
             boolean hasWildcardPermission = permissionSet.contains("*");
 
@@ -92,15 +90,12 @@ public class UserPermissionMigrationPeriodical extends Periodical {
                 fixedRoleIds.add(readerRoleId);
             }
             // filter out the individual permissions to dashboards and streams
-            final ArrayList<String> dashboardStreamPermissions = Lists.newArrayList(
+            final List<String> dashboardStreamPermissions = Lists.newArrayList(
                     Sets.filter(permissionSet,
                                 new Predicate<String>() {
                                     @Override
-                                    public boolean apply(
-                                            String permission) {
-                                        return !basePermissions.contains(
-                                                permission) && !permission.equals(
-                                                "*");
+                                    public boolean apply(String permission) {
+                                        return !basePermissions.contains(permission) && !permission.equals("*");
                                     }
                                 }));
             // add the minimal permission set back to the user

--- a/graylog2-server/src/main/java/org/graylog2/periodical/UserPermissionMigrationPeriodical.java
+++ b/graylog2-server/src/main/java/org/graylog2/periodical/UserPermissionMigrationPeriodical.java
@@ -58,15 +58,6 @@ public class UserPermissionMigrationPeriodical extends Periodical {
 
     @Override
     public void doRun() {
-
-        final UserPermissionMigrationState migrationState =
-                clusterConfigService.getOrDefault(UserPermissionMigrationState.class,
-                                                  UserPermissionMigrationState.create(false));
-        if (migrationState.migrationDone()) {
-            log.debug("User permission migration already done, not running migration again.");
-            return;
-        }
-
         final List<User> users = userService.loadAll();
         final String adminRoleId = roleService.getAdminRoleObjectId();
         final String readerRoleId = roleService.getReaderRoleObjectId();
@@ -155,7 +146,11 @@ public class UserPermissionMigrationPeriodical extends Periodical {
 
     @Override
     public boolean startOnThisNode() {
-        return true;
+        final UserPermissionMigrationState migrationState =
+                clusterConfigService.getOrDefault(UserPermissionMigrationState.class,
+                                                  UserPermissionMigrationState.create(false));
+        // don't run again if the cluster config says we've already migrated the users
+        return !migrationState.migrationDone();
     }
 
     @Override


### PR DESCRIPTION
add periodical to migrate user's permissions to admin or reader roles during startup of the master

 - existing stream and dashboard permissions are preserved
 - existing other permissions set via the API are preserved
 - RestPermissions.readerPermissions are migrated to reader role
 - '*' is migrated to admin role

fixes #1382