### PR TITLE
Allow disabling TLS certificate check in REST client

### DIFF
--- a/graylog2-rest-client/src/main/java/org/graylog2/restclient/lib/ApiClientImpl.java
+++ b/graylog2-rest-client/src/main/java/org/graylog2/restclient/lib/ApiClientImpl.java
@@ -83,12 +83,15 @@ class ApiClientImpl implements ApiClient {
     private AsyncHttpClient client;
     private final ServerNodes serverNodes;
     private final Long defaultTimeout;
+    private final boolean acceptAnyCertificate;
     private final ObjectMapper objectMapper;
     private Thread shutdownHook;
 
     @Inject
-    private ApiClientImpl(ServerNodes serverNodes, @Named("Default Timeout") Long defaultTimeout) {
-        this(serverNodes, defaultTimeout,
+    private ApiClientImpl(ServerNodes serverNodes,
+                          @Named("Default Timeout") Long defaultTimeout,
+                          @Named("client.accept-any-certificate") boolean acceptAnyCertificate) {
+        this(serverNodes, defaultTimeout, acceptAnyCertificate,
                 new ObjectMapper()
                         .setPropertyNamingStrategy(PropertyNamingStrategy.CAMEL_CASE_TO_LOWER_CASE_WITH_UNDERSCORES)
                         .disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES)
@@ -97,9 +100,10 @@ class ApiClientImpl implements ApiClient {
                         .registerModule(new JodaModule()));
     }
 
-    private ApiClientImpl(ServerNodes serverNodes, Long defaultTimeout, ObjectMapper objectMapper) {
+    private ApiClientImpl(ServerNodes serverNodes, Long defaultTimeout, boolean acceptAnyCertificate, ObjectMapper objectMapper) {
         this.serverNodes = serverNodes;
         this.defaultTimeout = defaultTimeout;
+        this.acceptAnyCertificate = acceptAnyCertificate;
         this.objectMapper = objectMapper;
     }
 
@@ -107,6 +111,8 @@ class ApiClientImpl implements ApiClient {
     public void start() {
         AsyncHttpClientConfig.Builder builder = new AsyncHttpClientConfig.Builder();
         builder.setAllowPoolingConnections(false);
+        builder.setAllowPoolingSslConnections(false);
+        builder.setAcceptAnyCertificate(acceptAnyCertificate);
         builder.setUserAgent("graylog2-web/" + Version.VERSION);
         client = new AsyncHttpClient(builder.build());
 

--- a/graylog2-rest-client/src/test/java/org/graylog2/restclient/lib/BaseApiTest.java
+++ b/graylog2-rest-client/src/test/java/org/graylog2/restclient/lib/BaseApiTest.java
@@ -50,6 +50,7 @@ public class BaseApiTest {
             protected void configure() {
                 bind(URI[].class).annotatedWith(Names.named("Initial Nodes")).toInstance(initialNodes.toArray(new URI[initialNodes.size()]));
                 bind(Long.class).annotatedWith(Names.named("Default Timeout")).toInstance(TimeUnit.SECONDS.toMillis(5));
+                bind(Boolean.class).annotatedWith(Names.named("client.accept-any-certificate")).toInstance(true);
             }
         });
         return Guice.createInjector(modules);

--- a/pom.xml
+++ b/pom.xml
@@ -296,7 +296,7 @@
             <dependency>
                 <groupId>com.ning</groupId>
                 <artifactId>async-http-client</artifactId>
-                <version>1.9.29</version>
+                <version>1.9.31</version>
             </dependency>
             <dependency>
                 <groupId>com.squareup.okhttp</groupId>


### PR DESCRIPTION
AsyncHttpClient is verifying SSL server certificates since version 1.9.x. Previous versions did also accept untrusted/unknown certificates.

This PR adds a configuration option to configure the behavior, with the pre-1.9.x behavior being default.