### PR TITLE
Convert configuration values in Alarmcallback Config update

### DIFF
--- a/graylog2-rest-models/src/main/java/org/graylog2/rest/models/alarmcallbacks/AlarmCallbackError.java
+++ b/graylog2-rest-models/src/main/java/org/graylog2/rest/models/alarmcallbacks/AlarmCallbackError.java
@@ -20,6 +20,7 @@ import com.fasterxml.jackson.annotation.JsonAutoDetect;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.auto.value.AutoValue;
+import com.google.common.base.Strings;
 
 @AutoValue
 @JsonAutoDetect
@@ -32,6 +33,6 @@ public abstract class AlarmCallbackError extends AlarmCallbackResult {
 
     @JsonCreator
     public static AlarmCallbackError create(@JsonProperty("error") String error) {
-        return new AutoValue_AlarmCallbackError(error);
+        return new AutoValue_AlarmCallbackError(Strings.nullToEmpty(error));
     }
 }

--- a/graylog2-rest-models/src/main/java/org/graylog2/rest/models/alarmcallbacks/requests/CreateAlarmCallbackRequest.java
+++ b/graylog2-rest-models/src/main/java/org/graylog2/rest/models/alarmcallbacks/requests/CreateAlarmCallbackRequest.java
@@ -16,8 +16,11 @@
  */
 package org.graylog2.rest.models.alarmcallbacks.requests;
 
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+
 import java.util.Map;
 
+@JsonAutoDetect
 public class CreateAlarmCallbackRequest {
     public String type;
     public Map<String, Object> configuration;

--- a/graylog2-server/src/main/java/org/graylog2/alarmcallbacks/AlarmCallbackConfiguration.java
+++ b/graylog2-server/src/main/java/org/graylog2/alarmcallbacks/AlarmCallbackConfiguration.java
@@ -19,9 +19,6 @@ package org.graylog2.alarmcallbacks;
 import java.util.Date;
 import java.util.Map;
 
-/**
- * @author Dennis Oelkers <dennis@torch.sh>
- */
 public interface AlarmCallbackConfiguration {
     String getId();
     String getStreamId();

--- a/graylog2-server/src/main/java/org/graylog2/alarmcallbacks/AlarmCallbackConfigurationService.java
+++ b/graylog2-server/src/main/java/org/graylog2/alarmcallbacks/AlarmCallbackConfigurationService.java
@@ -22,11 +22,7 @@ import org.graylog2.plugin.streams.Stream;
 import org.graylog2.rest.models.alarmcallbacks.requests.CreateAlarmCallbackRequest;
 
 import java.util.List;
-import java.util.Map;
 
-/**
- * @author Dennis Oelkers <dennis@torch.sh>
- */
 @ImplementedBy(AlarmCallbackConfigurationServiceMJImpl.class)
 public interface AlarmCallbackConfigurationService {
     List<AlarmCallbackConfiguration> getForStreamId(String streamId);
@@ -34,7 +30,6 @@ public interface AlarmCallbackConfigurationService {
     AlarmCallbackConfiguration load(String alarmCallbackId);
     AlarmCallbackConfiguration create(String streamId, CreateAlarmCallbackRequest request, String userId);
     long count();
-    AlarmCallbackConfiguration update(String streamId, String alarmCallbackId, Map<String, Object> deltas);
     String save(AlarmCallbackConfiguration model) throws ValidationException;
     int destroy(AlarmCallbackConfiguration model);
 }

--- a/graylog2-server/src/main/java/org/graylog2/alarmcallbacks/AlarmCallbackConfigurationServiceMJImpl.java
+++ b/graylog2-server/src/main/java/org/graylog2/alarmcallbacks/AlarmCallbackConfigurationServiceMJImpl.java
@@ -26,13 +26,11 @@ import org.graylog2.plugin.database.ValidationException;
 import org.graylog2.plugin.streams.Stream;
 import org.graylog2.rest.models.alarmcallbacks.requests.CreateAlarmCallbackRequest;
 import org.mongojack.DBQuery;
-import org.mongojack.DBUpdate;
 import org.mongojack.JacksonDBCollection;
 
 import javax.inject.Inject;
 import java.util.Date;
 import java.util.List;
-import java.util.Map;
 
 public class AlarmCallbackConfigurationServiceMJImpl implements AlarmCallbackConfigurationService {
     private final JacksonDBCollection<AlarmCallbackConfigurationAVImpl, String> coll;
@@ -68,15 +66,6 @@ public class AlarmCallbackConfigurationServiceMJImpl implements AlarmCallbackCon
     @Override
     public long count() {
         return coll.count();
-    }
-
-    @Override
-    public AlarmCallbackConfiguration update(String streamId, String alarmCallbackId, Map<String, Object> deltas) {
-        DBUpdate.Builder update = new DBUpdate.Builder();
-        for (Map.Entry<String, Object> fields : deltas.entrySet())
-            update = update.set(fields.getKey(), fields.getValue());
-
-        return coll.findAndModify(DBQuery.is("_id", alarmCallbackId), update);
     }
 
     @Override

--- a/graylog2-server/src/main/java/org/graylog2/rest/resources/alarmcallbacks/AlarmCallbackResource.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/resources/alarmcallbacks/AlarmCallbackResource.java
@@ -26,20 +26,24 @@ import com.wordnik.swagger.annotations.ApiResponse;
 import com.wordnik.swagger.annotations.ApiResponses;
 import org.apache.shiro.authz.annotation.RequiresAuthentication;
 import org.graylog2.alarmcallbacks.AlarmCallbackConfiguration;
+import org.graylog2.alarmcallbacks.AlarmCallbackConfigurationAVImpl;
 import org.graylog2.alarmcallbacks.AlarmCallbackConfigurationService;
-import org.graylog2.rest.models.alarmcallbacks.requests.CreateAlarmCallbackRequest;
+import org.graylog2.alarmcallbacks.AlarmCallbackFactory;
 import org.graylog2.database.NotFoundException;
-import org.graylog2.plugin.database.ValidationException;
 import org.graylog2.plugin.alarms.callbacks.AlarmCallback;
+import org.graylog2.plugin.configuration.ConfigurationRequest;
+import org.graylog2.plugin.database.ValidationException;
 import org.graylog2.plugin.streams.Stream;
 import org.graylog2.rest.models.alarmcallbacks.AlarmCallbackListSummary;
 import org.graylog2.rest.models.alarmcallbacks.AlarmCallbackSummary;
-import org.graylog2.rest.models.alarmcallbacks.responses.CreateAlarmCallbackResponse;
-import org.graylog2.rest.models.alarmcallbacks.responses.AvailableAlarmCallbacksResponse;
+import org.graylog2.rest.models.alarmcallbacks.requests.CreateAlarmCallbackRequest;
 import org.graylog2.rest.models.alarmcallbacks.responses.AvailableAlarmCallbackSummaryResponse;
+import org.graylog2.rest.models.alarmcallbacks.responses.AvailableAlarmCallbacksResponse;
+import org.graylog2.rest.models.alarmcallbacks.responses.CreateAlarmCallbackResponse;
 import org.graylog2.shared.rest.resources.RestResource;
 import org.graylog2.shared.security.RestPermissions;
 import org.graylog2.streams.StreamService;
+import org.graylog2.utilities.ConfigurationMapConverter;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -70,14 +74,17 @@ public class AlarmCallbackResource extends RestResource {
     private final AlarmCallbackConfigurationService alarmCallbackConfigurationService;
     private final StreamService streamService;
     private final Set<AlarmCallback> availableAlarmCallbacks;
+    private final AlarmCallbackFactory alarmCallbackFactory;
 
     @Inject
     public AlarmCallbackResource(AlarmCallbackConfigurationService alarmCallbackConfigurationService,
                                  StreamService streamService,
-                                 Set<AlarmCallback> availableAlarmCallbacks) {
+                                 Set<AlarmCallback> availableAlarmCallbacks,
+                                 AlarmCallbackFactory alarmCallbackFactory) {
         this.alarmCallbackConfigurationService = alarmCallbackConfigurationService;
         this.streamService = streamService;
         this.availableAlarmCallbacks = availableAlarmCallbacks;
+        this.alarmCallbackFactory = alarmCallbackFactory;
     }
 
     // TODO: add permission checks
@@ -207,17 +214,50 @@ public class AlarmCallbackResource extends RestResource {
     @PUT
     @Path("/{alarmCallbackId}")
     @Timed
-    @ApiOperation(value = "Update an alarm callback",
-            response = CreateAlarmCallbackResponse.class)
+    @ApiOperation(value = "Update an alarm callback")
     @Consumes(MediaType.APPLICATION_JSON)
     @Produces(MediaType.APPLICATION_JSON)
     public void update(@ApiParam(name = "streamid", value = "The stream id this alarm callback belongs to.", required = true)
                        @PathParam("streamid") String streamid,
                        @ApiParam(name = "alarmCallbackId", required = true)
                        @PathParam("alarmCallbackId") String alarmCallbackId,
-                       @ApiParam(name = "JSON body", required = true) Map<String, Object> deltas) throws NotFoundException {
+                       @ApiParam(name = "JSON body", required = true) CreateAlarmCallbackRequest alarmCallbackRequest) throws NotFoundException {
         checkPermission(RestPermissions.STREAMS_EDIT, streamid);
 
-        this.alarmCallbackConfigurationService.update(streamid, alarmCallbackId, deltas);
+        final AlarmCallbackConfiguration aCC = alarmCallbackConfigurationService.load(alarmCallbackId);
+        if (aCC == null) {
+            throw new NotFoundException("Unable to find alarm callback configuration " + alarmCallbackId);
+        }
+
+        final ConfigurationRequest requestedConfiguration;
+        try {
+            final AlarmCallback alarmCallback = alarmCallbackFactory.create(alarmCallbackRequest.type);
+            requestedConfiguration = alarmCallback.getRequestedConfiguration();
+        } catch (ClassNotFoundException e) {
+            throw new BadRequestException("Unable to load alarm callback of type " + alarmCallbackRequest.type, e);
+        }
+
+        // coerce the configuration to their correct types according to the alarmcallback's requested config
+        final Map<String, Object> configuration;
+        try {
+            configuration = ConfigurationMapConverter.convertValues(alarmCallbackRequest.configuration,
+                                                                    requestedConfiguration);
+        } catch (ValidationException e) {
+            throw new BadRequestException("Invalid configuration map", e);
+        }
+
+        final AlarmCallbackConfigurationAVImpl newConfig = AlarmCallbackConfigurationAVImpl.create(
+                alarmCallbackId,
+                aCC.getStreamId(),
+                aCC.getType(),
+                configuration,
+                aCC.getCreatedAt(),
+                aCC.getCreatorUserId());
+
+        try {
+             alarmCallbackConfigurationService.save(newConfig);
+        } catch (ValidationException e) {
+            throw new BadRequestException("Unable to save alarm callback configuration", e);
+        }
     }
 }

--- a/graylog2-server/src/main/java/org/graylog2/rest/resources/alarmcallbacks/AlarmCallbackResource.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/resources/alarmcallbacks/AlarmCallbackResource.java
@@ -247,7 +247,7 @@ public class AlarmCallbackResource extends RestResource {
         }
     }
 
-    private Map<String, Object> convertConfigurationValues(@ApiParam(name = "JSON body", required = true) CreateAlarmCallbackRequest alarmCallbackRequest) {
+    private Map<String, Object> convertConfigurationValues(final CreateAlarmCallbackRequest alarmCallbackRequest) {
         final ConfigurationRequest requestedConfiguration;
         try {
             final AlarmCallback alarmCallback = alarmCallbackFactory.create(alarmCallbackRequest.type);

--- a/graylog2-server/src/test/java/org/graylog2/alarmcallbacks/AlarmCallbackConfigurationServiceMJImplTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/alarmcallbacks/AlarmCallbackConfigurationServiceMJImplTest.java
@@ -16,7 +16,6 @@
  */
 package org.graylog2.alarmcallbacks;
 
-import com.lordofthejars.nosqlunit.annotation.ShouldMatchDataSet;
 import com.lordofthejars.nosqlunit.annotation.UsingDataSet;
 import com.lordofthejars.nosqlunit.core.LoadStrategyEnum;
 import org.bson.types.ObjectId;
@@ -28,11 +27,11 @@ import org.junit.Before;
 import org.junit.Test;
 
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -171,15 +170,5 @@ public class AlarmCallbackConfigurationServiceMJImplTest extends MongoDBServiceT
         alarmCallbackConfigurationService.destroy(alarmCallback);
 
         assertEquals("After deletion, there should be only one document left in the collection", 1, alarmCallbackConfigurationService.count());
-    }
-
-    @Test
-    @UsingDataSet(locations = {"alarmCallbackConfigurationsSingleDocument.json", "alarmCallbackConfigurationsSingleDocument2.json"}, loadStrategy = LoadStrategyEnum.CLEAN_INSERT)
-    @ShouldMatchDataSet(location = "alarmCallbackConfigurationsSingleDocumentAfterUpdate.json")
-    public void testDocumentUpdate() throws Exception {
-        final Map<String, Object> configuration = new HashMap<String, Object>() {{ put("foo", "bar"); }};
-        final Map<String, Object> deltas = new HashMap<String, Object>() {{ put("configuration", configuration); }};
-
-        alarmCallbackConfigurationService.update("5400deadbeefdeadbeefaffe", "54e3deadbeefdeadbeefaffe", deltas);
     }
 }

--- a/graylog2-shared/src/main/java/org/graylog2/shared/rest/resources/system/inputs/InputsResource.java
+++ b/graylog2-shared/src/main/java/org/graylog2/shared/rest/resources/system/inputs/InputsResource.java
@@ -183,6 +183,7 @@ public class InputsResource extends RestResource {
             else
                 nodeId = serverStatus.getNodeId().toString();
 
+            // TODO Configuration type values need to be checked. See ConfigurationMapConverter.convertValues()
             input = messageInputFactory.create(lr, getCurrentUser().getName(), nodeId);
 
             input.checkConfiguration();
@@ -260,6 +261,7 @@ public class InputsResource extends RestResource {
         final MessageInput oldInput = persistedInputs.get(inputId);
         final MessageInput messageInput;
         try {
+            // TODO Configuration type values need to be checked. See ConfigurationMapConverter.convertValues()
             messageInput = messageInputFactory.create(lr, getCurrentUser().getName(), oldInput.getNodeId());
             persistedInputs.update(inputId, messageInput);
         } catch (NoSuchInputTypeException e) {


### PR DESCRIPTION
ensure that alarm callback configurations conform to the declared types in the requested plugin config

 - the web interface had a bug where integers were treated as strings on updates causing the wrong config to be stored
 - also fix an NPE that could happen with exceptions having a null message
 - remove AlarmCallbackConfigurationService#update in favor of load/update object/save to allow for sanitizing the configuration
 - removed various author javadocs which we don't use in our codebase

fixes #1399