### PR TITLE
allow Message timestamp to be a java.util.Date and convert it properl…

### DIFF
--- a/graylog2-plugin-interfaces/src/main/java/org/graylog2/plugin/Message.java
+++ b/graylog2-plugin-interfaces/src/main/java/org/graylog2/plugin/Message.java
@@ -40,6 +40,7 @@ import org.slf4j.LoggerFactory;
 import java.net.InetAddress;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.Date;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -182,8 +183,15 @@ public class Message {
         obj.put(FIELD_SOURCE, getSource());
         obj.putAll(fields);
 
-        if (getField(FIELD_TIMESTAMP) instanceof DateTime) {
-            obj.put(FIELD_TIMESTAMP, buildElasticSearchTimeFormat(((DateTime) getField(FIELD_TIMESTAMP)).withZone(UTC)));
+        final Object timestampValue = getField(FIELD_TIMESTAMP);
+        DateTime dateTime = null;
+        if (timestampValue instanceof Date) {
+            dateTime = new DateTime(timestampValue);
+        } else if (timestampValue instanceof DateTime) {
+            dateTime = (DateTime) timestampValue;
+        }
+        if (dateTime != null) {
+            obj.put(FIELD_TIMESTAMP, buildElasticSearchTimeFormat(dateTime.withZone(UTC)));
         }
 
         // Manually converting stream ID to string - caused strange problems without it.

--- a/graylog2-plugin-interfaces/src/test/java/org/graylog2/plugin/MessageTest.java
+++ b/graylog2-plugin-interfaces/src/test/java/org/graylog2/plugin/MessageTest.java
@@ -27,6 +27,7 @@ import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
 import org.graylog2.plugin.streams.Stream;
 import org.joda.time.DateTime;
+import org.joda.time.DateTimeZone;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -227,6 +228,20 @@ public class MessageTest {
         } catch (ClassCastException e) {
             fail("timestamp wasn't a DateTime " + e.getMessage());
         }
+    }
+
+    @Test
+    public void testTimestampAsDate() {
+        final DateTime dateTime = new DateTime(2015, 9, 8, 0, 0, DateTimeZone.UTC);
+
+        message.addField(Message.FIELD_TIMESTAMP,
+                         dateTime.toDate());
+
+        final Map<String, Object> elasticSearchObject = message.toElasticSearchObject();
+        final Object esTimestampFormatted = elasticSearchObject.get(Message.FIELD_TIMESTAMP);
+
+        assertEquals("Setting message timestamp as java.util.Date results in correct format for elasticsearch",
+                     Tools.buildElasticSearchTimeFormat(dateTime), esTimestampFormatted);
     }
 
     @Test


### PR DESCRIPTION
…y to DateTime

 - this fixes output from java-grok, where we currently do not allow converters to run (because of UI limitations)
 - also applies to any plugin that accidentally sets timestamp to a java.util.Date

 fixes #1394