### PR TITLE
use memberOf query to retrieve a user's groups during login

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/rest/resources/system/ldap/LdapResource.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/resources/system/ldap/LdapResource.java
@@ -169,6 +169,7 @@ public class LdapResource extends RestResource {
                         connection,
                         request.searchBase(),
                         request.searchPattern(),
+                        "*",
                         request.principal(),
                         request.activeDirectory(),
                         request.groupSearchBase(),
@@ -300,9 +301,10 @@ public class LdapResource extends RestResource {
         try {
             LdapNetworkConnection connection = ldapConnector.connect(config);
             final Set<String> groups = ldapConnector.listGroups(connection,
-                                                               ldapSettings.getGroupSearchBase(),
-                                                               ldapSettings.getGroupSearchPattern(),
-                                                               ldapSettings.getGroupIdAttribute());
+                                                                ldapSettings.getGroupSearchBase(),
+                                                                ldapSettings.getGroupSearchPattern(),
+                                                                ldapSettings.getGroupIdAttribute()
+            );
             return groups;
         } catch (LdapException e) {
             LOG.error("Unable to retrieve available LDAP groups", e);

--- a/graylog2-server/src/main/java/org/graylog2/security/realm/LdapUserAuthenticator.java
+++ b/graylog2-server/src/main/java/org/graylog2/security/realm/LdapUserAuthenticator.java
@@ -93,6 +93,7 @@ public class LdapUserAuthenticator extends AuthenticatingRealm {
             final LdapEntry userEntry = ldapConnector.search(connection,
                                                              ldapSettings.getSearchBase(),
                                                              ldapSettings.getSearchPattern(),
+                                                             ldapSettings.getDisplayNameAttribute(),
                                                              principal,
                                                              ldapSettings.isActiveDirectory(),
                                                              ldapSettings.getGroupSearchBase(),

--- a/graylog2-server/src/main/java/org/graylog2/users/UserServiceImpl.java
+++ b/graylog2-server/src/main/java/org/graylog2/users/UserServiceImpl.java
@@ -186,12 +186,12 @@ public class UserServiceImpl extends PersistedServiceImpl implements UserService
                 for (String ldapGroupName : userEntry.getGroups()) {
                     final String roleName = ldapSettings.getGroupMapping().get(ldapGroupName);
                     if (roleName == null) {
-                        LOG.warn("User {}: No group mapping for ldap group <{}>", username, ldapGroupName);
+                        LOG.debug("User {}: No group mapping for ldap group <{}>", username, ldapGroupName);
                         continue;
                     }
                     final Role role = roleNameToRole.get(roleName.toLowerCase());
                     if (role != null) {
-                        LOG.warn("User {}: Mapping ldap group <{}> to role <{}>", username, ldapGroupName, role.getName());
+                        LOG.debug("User {}: Mapping ldap group <{}> to role <{}>", username, ldapGroupName, role.getName());
                         translatedRoleIds.add(role.getId());
                     } else {
                         LOG.warn("User {}: No role found for ldap group <{}>", username, ldapGroupName);


### PR DESCRIPTION
 - memberOf is only supported on ActiveDirectory, we still need to iterate over all groups for generic LDAP servers
 - the searches request only the attributes they know they will need, this should significantly reduce the time to request data
 - multi-valued attributes are now correctly displayed in the user entry preview
 - ActiveDirectory group information is retrieved via DN searches
 - lowered some log levels for group mapping warnings