### PR TITLE
Remove disable_index_range_calculation setting

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/configuration/ElasticsearchConfiguration.java
+++ b/graylog2-server/src/main/java/org/graylog2/configuration/ElasticsearchConfiguration.java
@@ -114,9 +114,6 @@ public class ElasticsearchConfiguration {
     @Parameter(value = "disable_index_optimization")
     private boolean disableIndexOptimization = false;
 
-    @Parameter(value = "disable_index_range_calculation")
-    private boolean disableIndexRangeCalculation = true;
-
     @Parameter(value = "index_optimization_max_num_segments", validator = PositiveIntegerValidator.class)
     private int indexOptimizationMaxNumSegments = 1;
 
@@ -241,10 +238,6 @@ public class ElasticsearchConfiguration {
 
     public boolean isDisableIndexOptimization() {
         return disableIndexOptimization;
-    }
-
-    public boolean isDisableIndexRangeCalculation() {
-        return disableIndexRangeCalculation;
     }
 
     public String getPathData() {

--- a/graylog2-server/src/test/java/org/graylog2/indexer/DeflectorTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/indexer/DeflectorTest.java
@@ -24,7 +24,6 @@ import org.elasticsearch.action.admin.indices.stats.IndexStats;
 import org.graylog2.configuration.ElasticsearchConfiguration;
 import org.graylog2.indexer.indices.Indices;
 import org.graylog2.indexer.ranges.CreateNewSingleIndexRangeJob;
-import org.graylog2.indexer.ranges.RebuildIndexRangesJob;
 import org.graylog2.system.activities.SystemMessageActivityWriter;
 import org.graylog2.system.jobs.SystemJobManager;
 import org.junit.Before;
@@ -50,7 +49,6 @@ public class DeflectorTest {
                 mock(SystemJobManager.class),
                 new ElasticsearchConfiguration(),
                 mock(SystemMessageActivityWriter.class),
-                mock(RebuildIndexRangesJob.Factory.class),
                 mock(SetIndexReadOnlyJob.Factory.class),
                 mock(CreateNewSingleIndexRangeJob.Factory.class),
                 mock(Indices.class));
@@ -81,7 +79,6 @@ public class DeflectorTest {
         Deflector d = new Deflector(mock(SystemJobManager.class),
                 mock(ElasticsearchConfiguration.class),
                 mock(SystemMessageActivityWriter.class),
-                mock(RebuildIndexRangesJob.Factory.class),
                 mock(SetIndexReadOnlyJob.Factory.class),
                 mock(CreateNewSingleIndexRangeJob.Factory.class),
                 mock(Indices.class));
@@ -101,7 +98,6 @@ public class DeflectorTest {
         Deflector d = new Deflector(mock(SystemJobManager.class),
                 mock(ElasticsearchConfiguration.class),
                 mock(SystemMessageActivityWriter.class),
-                mock(RebuildIndexRangesJob.Factory.class),
                 mock(SetIndexReadOnlyJob.Factory.class),
                 mock(CreateNewSingleIndexRangeJob.Factory.class),
                 mock(Indices.class));
@@ -116,7 +112,6 @@ public class DeflectorTest {
         Deflector d = new Deflector(mock(SystemJobManager.class),
                 mock(ElasticsearchConfiguration.class),
                 mock(SystemMessageActivityWriter.class),
-                mock(RebuildIndexRangesJob.Factory.class),
                 mock(SetIndexReadOnlyJob.Factory.class),
                 mock(CreateNewSingleIndexRangeJob.Factory.class),
                 mock(Indices.class));

--- a/graylog2-server/src/test/java/org/graylog2/indexer/ranges/EsIndexRangeServiceTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/indexer/ranges/EsIndexRangeServiceTest.java
@@ -87,7 +87,7 @@ public class EsIndexRangeServiceTest {
     @Before
     public void setUp() throws Exception {
         indices = new Indices(client, ELASTICSEARCH_CONFIGURATION, new IndexMapping(client));
-        final Deflector deflector = new Deflector(null, ELASTICSEARCH_CONFIGURATION, new NullActivityWriter(), null, null, null, indices);
+        final Deflector deflector = new Deflector(null, ELASTICSEARCH_CONFIGURATION, new NullActivityWriter(), null, null, indices);
         indexRangeService = new EsIndexRangeService(client, objectMapper, indices, deflector,
                 new EventBus("local"), new EventBus("cluster"), new MetricRegistry());
     }

--- a/misc/graylog2.conf
+++ b/misc/graylog2.conf
@@ -375,14 +375,6 @@ mongodb_threads_allowed_to_block_multiplier = 5
 # on heavily used systems with large indices, but it will decrease search performance. The default is 1.
 #index_optimization_max_num_segments = 1
 
-# Disable the index range calculation on all open/available indices and only calculate the range for the latest
-# index.
-# This may speed up index cycling on systems with large indices but it might lead to wrong search results
-# in regard to the time range of the messages (i. e. messages within a certain range may not be found) if the indices
-# have been modified after Graylog rotated them.
-# Default: true
-#disable_index_range_calculation = true
-
 # The threshold of the garbage collection runs. If GC runs take longer than this threshold, a system notification
 # will be generated to warn the administrator about possible problems with the system. Default is 1 second.
 #gc_warning_threshold = 1s


### PR DESCRIPTION
This PR removes the `disable_index_range_calculation` setting from Graylog since recalculating all index ranges after index rotation/retention is completely unnecessary now.

It is still possible to manually trigger a system job to recalculate index ranges if necessary.

Closes #1409