### PR TITLE
Complete support for stream matching types

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/bundles/BundleExporter.java
+++ b/graylog2-server/src/main/java/org/graylog2/bundles/BundleExporter.java
@@ -218,6 +218,7 @@ public class BundleExporter {
         streamDescription.setTitle(stream.getTitle());
         streamDescription.setDescription(stream.getDescription());
         streamDescription.setDisabled(stream.getDisabled());
+        streamDescription.setMatchingType(stream.getMatchingType());
         streamDescription.setOutputs(exportOutputReferences(stream.getOutputs()));
         streamDescription.setStreamRules(exportStreamRules(stream.getStreamRules()));
 

--- a/graylog2-server/src/main/java/org/graylog2/bundles/BundleImporter.java
+++ b/graylog2-server/src/main/java/org/graylog2/bundles/BundleImporter.java
@@ -452,6 +452,7 @@ public class BundleImporter {
         streamData.put(StreamImpl.FIELD_TITLE, streamDescription.getTitle());
         streamData.put(StreamImpl.FIELD_DESCRIPTION, streamDescription.getDescription());
         streamData.put(StreamImpl.FIELD_DISABLED, streamDescription.isDisabled());
+        streamData.put(StreamImpl.FIELD_MATCHING_TYPE, streamDescription.getMatchingType());
         streamData.put(StreamImpl.FIELD_CREATOR_USER_ID, userName);
         streamData.put(StreamImpl.FIELD_CREATED_AT, Tools.iso8601());
         streamData.put(StreamImpl.FIELD_CONTENT_PACK, bundleId);

--- a/graylog2-server/src/main/java/org/graylog2/bundles/Stream.java
+++ b/graylog2-server/src/main/java/org/graylog2/bundles/Stream.java
@@ -37,6 +37,8 @@ public class Stream {
     @JsonProperty
     private boolean disabled = false;
     @JsonProperty
+    private org.graylog2.plugin.streams.Stream.MatchingType matchingType = org.graylog2.plugin.streams.Stream.MatchingType.DEFAULT;
+    @JsonProperty
     @NotNull
     private List<StreamRule> streamRules = Collections.emptyList();
     @JsonProperty
@@ -73,6 +75,14 @@ public class Stream {
 
     public void setDisabled(boolean disabled) {
         this.disabled = disabled;
+    }
+
+    public org.graylog2.plugin.streams.Stream.MatchingType getMatchingType() {
+        return matchingType;
+    }
+
+    public void setMatchingType(org.graylog2.plugin.streams.Stream.MatchingType matchingType) {
+        this.matchingType = matchingType;
     }
 
     public List<StreamRule> getStreamRules() {

--- a/graylog2-server/src/main/java/org/graylog2/rest/resources/streams/StreamResource.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/resources/streams/StreamResource.java
@@ -50,6 +50,7 @@ import org.graylog2.rest.resources.streams.responses.TestMatchResponse;
 import org.graylog2.rest.resources.streams.rules.requests.CreateStreamRuleRequest;
 import org.graylog2.shared.security.RestPermissions;
 import org.graylog2.shared.stats.ThroughputStats;
+import org.graylog2.streams.StreamImpl;
 import org.graylog2.streams.StreamRouterEngine;
 import org.graylog2.streams.StreamRuleService;
 import org.graylog2.streams.StreamService;
@@ -318,10 +319,11 @@ public class StreamResource extends RestResource {
 
         // Create stream.
         final Map<String, Object> streamData = Maps.newHashMap();
-        streamData.put("title", cr.title());
-        streamData.put("description", cr.description());
-        streamData.put("creator_user_id", getCurrentUser().getName());
-        streamData.put("created_at", Tools.iso8601());
+        streamData.put(StreamImpl.FIELD_TITLE, cr.title());
+        streamData.put(StreamImpl.FIELD_DESCRIPTION, cr.description());
+        streamData.put(StreamImpl.FIELD_CREATOR_USER_ID, getCurrentUser().getName());
+        streamData.put(StreamImpl.FIELD_CREATED_AT, Tools.iso8601());
+        streamData.put(StreamImpl.FIELD_MATCHING_TYPE, sourceStream.getMatchingType().toString());
 
         final Stream stream = streamService.create(streamData);
         streamService.pause(stream);


### PR DESCRIPTION
This PR adds support for stream matching types (AND, OR) to content packs and the stream clone feature.

Closes #1414