### PR TITLE
do not let LDAP referral exception bubble out, this prevented authent…

### DIFF
--- a/graylog2-plugin-interfaces/src/main/java/org/graylog2/plugin/DocsHelper.java
+++ b/graylog2-plugin-interfaces/src/main/java/org/graylog2/plugin/DocsHelper.java
@@ -25,7 +25,8 @@ package org.graylog2.plugin;
 
 public enum DocsHelper {
     PAGE_SENDING_JSONPATH("sending_data.html#json-path-from-http-api-input"),
-    PAGE_ES_CONFIGURATION("configuring_es.html");
+    PAGE_ES_CONFIGURATION("configuring_es.html"),
+    PAGE_LDAP_TROUBLESHOOTING("users_roles.html#troubleshooting");
 
     private static final String DOCS_URL = "http://docs.graylog.org/en/";
 

--- a/graylog2-server/src/main/java/org/graylog2/rest/resources/system/ldap/LdapResource.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/resources/system/ldap/LdapResource.java
@@ -306,7 +306,7 @@ public class LdapResource extends RestResource {
             );
         } catch (IOException | LdapException e) {
             LOG.error("Unable to retrieve available LDAP groups", e);
-            throw new InternalServerErrorException(e);
+            throw new InternalServerErrorException("Unable to retrieve available LDAP groups", e);
         }
     }
 }

--- a/graylog2-server/src/main/java/org/graylog2/rest/resources/system/ldap/LdapResource.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/resources/system/ldap/LdapResource.java
@@ -298,15 +298,13 @@ public class LdapResource extends RestResource {
             config.setCredentials(ldapSettings.getSystemPassword());
         }
 
-        try {
-            LdapNetworkConnection connection = ldapConnector.connect(config);
-            final Set<String> groups = ldapConnector.listGroups(connection,
-                                                                ldapSettings.getGroupSearchBase(),
-                                                                ldapSettings.getGroupSearchPattern(),
-                                                                ldapSettings.getGroupIdAttribute()
+        try (LdapNetworkConnection connection = ldapConnector.connect(config)) {
+            return ldapConnector.listGroups(connection,
+                                            ldapSettings.getGroupSearchBase(),
+                                            ldapSettings.getGroupSearchPattern(),
+                                            ldapSettings.getGroupIdAttribute()
             );
-            return groups;
-        } catch (LdapException e) {
+        } catch (IOException | LdapException e) {
             LOG.error("Unable to retrieve available LDAP groups", e);
             throw new InternalServerErrorException(e);
         }

--- a/graylog2-server/src/main/java/org/graylog2/security/ldap/LdapConnector.java
+++ b/graylog2-server/src/main/java/org/graylog2/security/ldap/LdapConnector.java
@@ -33,7 +33,9 @@ import org.apache.directory.api.ldap.model.message.ResultCodeEnum;
 import org.apache.directory.api.ldap.model.message.SearchScope;
 import org.apache.directory.ldap.client.api.LdapConnectionConfig;
 import org.apache.directory.ldap.client.api.LdapNetworkConnection;
+import org.graylog2.plugin.DocsHelper;
 import org.graylog2.shared.security.ldap.LdapEntry;
+import org.graylog2.shared.utilities.ExceptionUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -205,7 +207,7 @@ public class LdapConnector {
                                   String groupSearchBase,
                                   String groupSearchPattern,
                                   String groupIdAttribute,
-                                  String dn) throws LdapException {
+                                  String dn) {
         final Set<String> groups = Sets.newHashSet();
 
         EntryCursor groupSearch = null;
@@ -251,6 +253,12 @@ public class LdapConnector {
                     }
                 }
             }
+        } catch (Exception e) {
+            LOG.warn(
+                    "Unable to iterate over user's groups, unable to perform group mapping. Graylog does not support " +
+                            "LDAP referrals at the moment. Please see " +
+                            DocsHelper.PAGE_LDAP_TROUBLESHOOTING.toString() + " for more information.",
+                    ExceptionUtils.getRootCause(e));
         } finally {
             if (groupSearch != null) {
                 groupSearch.close();
@@ -263,7 +271,7 @@ public class LdapConnector {
     public Set<String> listGroups(LdapNetworkConnection connection,
                                   String groupSearchBase,
                                   String groupSearchPattern,
-                                  String groupIdAttribute) throws LdapException {
+                                  String groupIdAttribute) {
         return findGroups(connection, groupSearchBase, groupSearchPattern, groupIdAttribute, null);
     }
 


### PR DESCRIPTION
…icated users from logging if their groups could not be resolved

  - the user was fine, but group mapping is not possible in this scenario until we figure out how to support LDAP referrals
  - group mapping can be done manually, warning log message links to proper documentation page

 fixes #1410