### PR TITLE
Fix isMatched results for OR streams

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/streams/StreamRouterEngine.java
+++ b/graylog2-server/src/main/java/org/graylog2/streams/StreamRouterEngine.java
@@ -319,7 +319,7 @@ public class StreamRouterEngine {
         public boolean isMatched() {
             switch (matchingType) {
                 case OR:
-                    return matches.values().contains(false);
+                    return matches.values().contains(true);
                 case AND:
                 default:
                     return matches.size() > 0 && !matches.values().contains(false);

--- a/graylog2-server/src/test/java/org/graylog2/streams/StreamRouterEngineTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/streams/StreamRouterEngineTest.java
@@ -28,7 +28,6 @@ import org.graylog2.plugin.streams.StreamRule;
 import org.graylog2.plugin.streams.StreamRuleType;
 import org.graylog2.streams.matchers.StreamRuleMock;
 import org.joda.time.DateTime;
-import org.joda.time.DateTimeZone;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -412,6 +411,63 @@ public class StreamRouterEngineTest {
     }
 
     @Test
+    public void testOrTestMatch() throws Exception {
+        final StreamMock stream = getStreamMock("test", Stream.MatchingType.OR);
+        final StreamRuleMock rule1 = new StreamRuleMock(ImmutableMap.<String, Object>of(
+                "_id", new ObjectId(),
+                "field", "testfield1",
+                "type", StreamRuleType.PRESENCE.toInteger(),
+                "stream_id", stream.getId()
+        ));
+        final StreamRuleMock rule2 = new StreamRuleMock(ImmutableMap.<String, Object>of(
+                "_id", new ObjectId(),
+                "field", "testfield2",
+                "value", "^test",
+                "type", StreamRuleType.REGEX.toInteger(),
+                "stream_id", stream.getId()
+        ));
+
+        stream.setStreamRules(Lists.<StreamRule>newArrayList(rule1, rule2));
+
+        final StreamRouterEngine engine = newEngine(Lists.<Stream>newArrayList(stream));
+
+
+        // Without testfield1 and testfield2 in the message.
+        final Message message1 = getMessage();
+
+        final StreamRouterEngine.StreamTestMatch testMatch1 = engine.testMatch(message1).get(0);
+        final Map<StreamRule, Boolean> matches1 = testMatch1.getMatches();
+
+        assertFalse(testMatch1.isMatched());
+        assertFalse(matches1.get(rule1));
+        assertFalse(matches1.get(rule2));
+
+        // With testfield1 but no-matching testfield2 in the message.
+        final Message message2 = getMessage();
+        message2.addField("testfield1", "testvalue");
+        message2.addField("testfield2", "no-testvalue");
+
+        final StreamRouterEngine.StreamTestMatch testMatch2 = engine.testMatch(message2).get(0);
+        final Map<StreamRule, Boolean> matches2 = testMatch2.getMatches();
+
+        assertTrue(testMatch2.isMatched());
+        assertTrue(matches2.get(rule1));
+        assertFalse(matches2.get(rule2));
+
+        // With testfield1 and matching testfield2 in the message.
+        final Message message3 = getMessage();
+        message3.addField("testfield1", "testvalue");
+        message3.addField("testfield2", "testvalue2");
+
+        final StreamRouterEngine.StreamTestMatch testMatch3 = engine.testMatch(message3).get(0);
+        final Map<StreamRule, Boolean> matches3 = testMatch3.getMatches();
+
+        assertTrue(testMatch3.isMatched());
+        assertTrue(matches3.get(rule1));
+        assertTrue(matches3.get(rule2));
+    }
+
+    @Test
     public void testGetFingerprint() {
         final StreamMock stream1 = getStreamMock("test");
         final StreamRuleMock rule1 = new StreamRuleMock(ImmutableMap.<String, Object>of(
@@ -624,7 +680,11 @@ public class StreamRouterEngineTest {
     }
 
     private StreamMock getStreamMock(String title) {
-        return new StreamMock(ImmutableMap.<String, Object>of("_id", new ObjectId(), "title", title));
+        return getStreamMock(title, Stream.MatchingType.AND);
+    }
+
+    private StreamMock getStreamMock(String title, Stream.MatchingType matchingType) {
+        return new StreamMock(ImmutableMap.<String, Object>of("_id", new ObjectId(), "title", title, "matching_type", matchingType));
     }
 
     private StreamRule getStreamRuleMock(String id, StreamRuleType type, String field, String value) {


### PR DESCRIPTION
When testing a stream using an OR operator, check if any of the values for the rules is true instead of false. I also added some tests for this case.

Fixes #1417