### PR TITLE
Do not enforce grok patterns field in content packs

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/bundles/ConfigurationBundle.java
+++ b/graylog2-server/src/main/java/org/graylog2/bundles/ConfigurationBundle.java
@@ -55,7 +55,6 @@ public class ConfigurationBundle {
     @NotNull
     private Set<Dashboard> dashboards = Collections.emptySet();
     @JsonProperty
-    @NotNull
     private Set<GrokPattern> grokPatterns = Collections.emptySet();
 
     public String getId() {


### PR DESCRIPTION
Content packs created with older Graylog version will not contain that field, but we still need to be able to import them.

Fixes Graylog2/graylog2-web-interface#1605.