### PR TITLE
Use min/max instead of stats aggregation for index timestamp stats

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/indexer/ranges/EsIndexRangeService.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/ranges/EsIndexRangeService.java
@@ -47,7 +47,8 @@ import org.elasticsearch.indices.IndexMissingException;
 import org.elasticsearch.search.aggregations.AggregationBuilders;
 import org.elasticsearch.search.aggregations.bucket.filter.Filter;
 import org.elasticsearch.search.aggregations.bucket.filter.FilterAggregationBuilder;
-import org.elasticsearch.search.aggregations.metrics.stats.Stats;
+import org.elasticsearch.search.aggregations.metrics.max.Max;
+import org.elasticsearch.search.aggregations.metrics.min.Min;
 import org.graylog2.database.NotFoundException;
 import org.graylog2.events.ClusterEventBus;
 import org.graylog2.indexer.Deflector;
@@ -231,7 +232,8 @@ public class EsIndexRangeService implements IndexRangeService {
     protected TimestampStats timestampStatsOfIndex(String index) {
         final FilterAggregationBuilder builder = AggregationBuilders.filter("agg")
                 .filter(FilterBuilders.existsFilter("timestamp"))
-                .subAggregation(AggregationBuilders.stats("ts_stats").field("timestamp"));
+                .subAggregation(AggregationBuilders.min("ts_min").field("timestamp"))
+                .subAggregation(AggregationBuilders.max("ts_max").field("timestamp"));
         final SearchRequestBuilder srb = client.prepareSearch()
                 .setIndices(index)
                 .setSearchType(SearchType.COUNT)
@@ -253,13 +255,12 @@ public class EsIndexRangeService implements IndexRangeService {
             return TimestampStats.EMPTY;
         }
 
-        final Stats stats = f.getAggregations().get("ts_stats");
-        final DateTimeFormatter formatter = DateTimeFormat.forPattern(Tools.ES_DATE_FORMAT).withZoneUTC();
-        final DateTime min = formatter.parseDateTime(stats.getMinAsString());
-        final DateTime max = formatter.parseDateTime(stats.getMaxAsString());
-        final DateTime avg = formatter.parseDateTime(stats.getAvgAsString());
+        final Min minAgg = f.getAggregations().get("ts_min");
+        final DateTime min = new DateTime((long) minAgg.getValue(), DateTimeZone.UTC);
+        final Max maxAgg = f.getAggregations().get("ts_max");
+        final DateTime max = new DateTime((long) maxAgg.getValue(), DateTimeZone.UTC);
 
-        return TimestampStats.create(min, max, avg);
+        return TimestampStats.create(min, max);
     }
 
     @Override

--- a/graylog2-server/src/main/java/org/graylog2/indexer/searches/TimestampStats.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/searches/TimestampStats.java
@@ -22,16 +22,13 @@ import org.joda.time.DateTimeZone;
 
 @AutoValue
 public abstract class TimestampStats {
-    public static final TimestampStats EMPTY =
-            create(new DateTime(0L, DateTimeZone.UTC), new DateTime(0L, DateTimeZone.UTC), new DateTime(0L, DateTimeZone.UTC));
+    public static final TimestampStats EMPTY = create(new DateTime(0L, DateTimeZone.UTC), new DateTime(0L, DateTimeZone.UTC));
 
     public abstract DateTime min();
 
     public abstract DateTime max();
 
-    public abstract DateTime avg();
-
-    public static TimestampStats create(DateTime min, DateTime max, DateTime avg) {
-        return new AutoValue_TimestampStats(min, max, avg);
+    public static TimestampStats create(DateTime min, DateTime max) {
+        return new AutoValue_TimestampStats(min, max);
     }
 }

--- a/graylog2-server/src/test/java/org/graylog2/indexer/ranges/EsIndexRangeServiceTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/indexer/ranges/EsIndexRangeServiceTest.java
@@ -55,8 +55,6 @@ import static com.lordofthejars.nosqlunit.elasticsearch.ElasticsearchRule.Elasti
 import static com.lordofthejars.nosqlunit.elasticsearch.EmbeddedElasticsearch.EmbeddedElasticsearchRuleBuilder.newEmbeddedElasticsearchRule;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assume.assumeTrue;
-import static org.mockito.Matchers.any;
-import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -277,7 +275,6 @@ public class EsIndexRangeServiceTest {
 
         assertThat(stats.min()).isEqualTo(new DateTime(2015, 1, 1, 1, 0, DateTimeZone.UTC));
         assertThat(stats.max()).isEqualTo(new DateTime(2015, 1, 1, 5, 0, DateTimeZone.UTC));
-        assertThat(stats.avg()).isEqualTo(new DateTime(2015, 1, 1, 3, 0, DateTimeZone.UTC));
     }
 
     @Test
@@ -287,7 +284,6 @@ public class EsIndexRangeServiceTest {
 
         assertThat(stats.min()).isEqualTo(new DateTime(0L, DateTimeZone.UTC));
         assertThat(stats.max()).isEqualTo(new DateTime(0L, DateTimeZone.UTC));
-        assertThat(stats.avg()).isEqualTo(new DateTime(0L, DateTimeZone.UTC));
     }
 
     @Test(expected = IndexMissingException.class)

--- a/graylog2-server/src/test/java/org/graylog2/indexer/searches/TimestampStatsTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/indexer/searches/TimestampStatsTest.java
@@ -27,18 +27,15 @@ public class TimestampStatsTest {
     public void testCreate() throws Exception {
         DateTime min = new DateTime(2015, 1, 1, 0, 0, DateTimeZone.UTC);
         DateTime max = new DateTime(2015, 1, 3, 0, 0, DateTimeZone.UTC);
-        DateTime avg = new DateTime(2015, 1, 2, 0, 0, DateTimeZone.UTC);
-        TimestampStats timestampStats = TimestampStats.create(min, max, avg);
+        TimestampStats timestampStats = TimestampStats.create(min, max);
 
         assertThat(timestampStats.min()).isEqualTo(min);
         assertThat(timestampStats.max()).isEqualTo(max);
-        assertThat(timestampStats.avg()).isEqualTo(avg);
     }
 
     @Test
     public void testEmptyInstance() throws Exception {
         assertThat(TimestampStats.EMPTY.min()).isEqualTo(new DateTime(0L, DateTimeZone.UTC));
         assertThat(TimestampStats.EMPTY.max()).isEqualTo(new DateTime(0L, DateTimeZone.UTC));
-        assertThat(TimestampStats.EMPTY.avg()).isEqualTo(new DateTime(0L, DateTimeZone.UTC));
     }
 }


### PR DESCRIPTION
Using the stats aggregation involved calculating unused values like sum and average. Additionally we changed the parsing of the min/max values from using the string representation to the numeric (double) representation which should eliminate some error conditions, especially with older Elasticsearch versions.

Fixes #1426