### PR TITLE
Remove duplicated ID field from alarm callbacks

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/alarmcallbacks/AlarmCallbackConfigurationServiceMJImpl.java
+++ b/graylog2-server/src/main/java/org/graylog2/alarmcallbacks/AlarmCallbackConfigurationServiceMJImpl.java
@@ -17,7 +17,10 @@
 package org.graylog2.alarmcallbacks;
 
 import com.google.common.collect.Lists;
+import com.mongodb.BasicDBObject;
 import com.mongodb.DBCollection;
+import com.mongodb.DBObject;
+import com.mongodb.QueryBuilder;
 import org.bson.types.ObjectId;
 import org.graylog2.bindings.providers.MongoJackObjectMapperProvider;
 import org.graylog2.database.CollectionName;
@@ -33,13 +36,16 @@ import java.util.Date;
 import java.util.List;
 
 public class AlarmCallbackConfigurationServiceMJImpl implements AlarmCallbackConfigurationService {
+    private final static String DUPLICATED_ID = "id";
+
     private final JacksonDBCollection<AlarmCallbackConfigurationAVImpl, String> coll;
+    private final DBCollection dbCollection;
 
     @Inject
     public AlarmCallbackConfigurationServiceMJImpl(MongoConnection mongoConnection,
                                                    MongoJackObjectMapperProvider mapperProvider) {
         final String collectionName = AlarmCallbackConfigurationAVImpl.class.getAnnotation(CollectionName.class).value();
-        final DBCollection dbCollection = mongoConnection.getDatabase().getCollection(collectionName);
+        this.dbCollection = mongoConnection.getDatabase().getCollection(collectionName);
         this.coll = JacksonDBCollection.wrap(dbCollection, AlarmCallbackConfigurationAVImpl.class, String.class, mapperProvider.get());
     }
 
@@ -93,5 +99,14 @@ public class AlarmCallbackConfigurationServiceMJImpl implements AlarmCallbackCon
         } else {
             throw new IllegalArgumentException("Supplied output must be of implementation type AlarmCallbackConfigurationAVImpl, not " + callback.getClass());
         }
+    }
+
+    // Remove duplicated ID stored in `id` field to avoid MongoJack fetching it instead of `_id`.
+    // See https://github.com/Graylog2/graylog2-server/issues/1428 for more details.
+    public void migrate() {
+        final DBObject selection = QueryBuilder.start("id").exists(true).get();
+        final DBObject modifications = new BasicDBObject("$unset", new BasicDBObject(DUPLICATED_ID, ""));
+
+        this.dbCollection.updateMulti(selection, modifications);
     }
 }

--- a/graylog2-server/src/main/java/org/graylog2/bindings/PeriodicalBindings.java
+++ b/graylog2-server/src/main/java/org/graylog2/bindings/PeriodicalBindings.java
@@ -20,6 +20,7 @@ import com.google.inject.AbstractModule;
 import com.google.inject.multibindings.Multibinder;
 import org.graylog2.events.ClusterEventCleanupPeriodical;
 import org.graylog2.events.ClusterEventPeriodical;
+import org.graylog2.periodical.AlarmCallbacksMigrationPeriodical;
 import org.graylog2.periodical.AlertScannerThread;
 import org.graylog2.periodical.BatchedElasticSearchOutputFlushThread;
 import org.graylog2.periodical.ClusterHealthCheckThread;
@@ -62,5 +63,6 @@ public class PeriodicalBindings extends AbstractModule {
         periodicalBinder.addBinding().to(PurgeExpiredCollectorsThread.class);
         periodicalBinder.addBinding().to(IndexRangesMigrationPeriodical.class);
         periodicalBinder.addBinding().to(UserPermissionMigrationPeriodical.class);
+        periodicalBinder.addBinding().to(AlarmCallbacksMigrationPeriodical.class);
     }
 }

--- a/graylog2-server/src/main/java/org/graylog2/periodical/AlarmCallbacksMigrationPeriodical.java
+++ b/graylog2-server/src/main/java/org/graylog2/periodical/AlarmCallbacksMigrationPeriodical.java
@@ -1,0 +1,92 @@
+/**
+ * This file is part of Graylog.
+ *
+ * Graylog is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.graylog2.periodical;
+
+import org.graylog2.alarmcallbacks.AlarmCallbackConfigurationService;
+import org.graylog2.alarmcallbacks.AlarmCallbackConfigurationServiceMJImpl;
+import org.graylog2.plugin.periodical.Periodical;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.inject.Inject;
+
+/**
+ * This periodical migrates alert callbacks created on version <= 1.0, which contained two ID fields: `_id` and `id`,
+ * both with different types, and confused MongoJack when loading them. Here we remove the `id` field, which
+ * is the string representation of `_id`, the actual object id.
+ *
+ * See https://github.com/Graylog2/graylog2-server/issues/1428 for more details.
+ *
+ */
+public class AlarmCallbacksMigrationPeriodical extends Periodical {
+    private static final Logger LOG = LoggerFactory.getLogger(AlarmCallbacksMigrationPeriodical.class);
+
+    private final AlarmCallbackConfigurationService alarmCallbackConfigurationService;
+
+    @Inject
+    public AlarmCallbacksMigrationPeriodical(AlarmCallbackConfigurationService alarmCallbackConfigurationService) {
+        this.alarmCallbackConfigurationService = alarmCallbackConfigurationService;
+    }
+
+    @Override
+    public void doRun() {
+        LOG.debug("Starting alarm callbacks migration");
+        ((AlarmCallbackConfigurationServiceMJImpl)this.alarmCallbackConfigurationService).migrate();
+        LOG.debug("Done with alarm callbacks migration");
+    }
+
+    @Override
+    public boolean runsForever() {
+        return true;
+    }
+
+    @Override
+    public boolean stopOnGracefulShutdown() {
+        return false;
+    }
+
+    @Override
+    public boolean masterOnly() {
+        return true;
+    }
+
+    @Override
+    public boolean startOnThisNode() {
+        return true;
+    }
+
+    @Override
+    public boolean isDaemon() {
+        return false;
+    }
+
+    @Override
+    public int getInitialDelaySeconds() {
+        return 0;
+    }
+
+    @Override
+    public int getPeriodSeconds() {
+        return 0;
+    }
+
+    @Override
+    protected Logger getLogger() {
+        return LOG;
+    }
+}

--- a/graylog2-server/src/main/java/org/graylog2/periodical/AlarmCallbacksMigrationPeriodical.java
+++ b/graylog2-server/src/main/java/org/graylog2/periodical/AlarmCallbacksMigrationPeriodical.java
@@ -17,8 +17,13 @@
 
 package org.graylog2.periodical;
 
-import org.graylog2.alarmcallbacks.AlarmCallbackConfigurationService;
-import org.graylog2.alarmcallbacks.AlarmCallbackConfigurationServiceMJImpl;
+import com.mongodb.BasicDBObject;
+import com.mongodb.DBCollection;
+import com.mongodb.DBObject;
+import com.mongodb.QueryBuilder;
+import org.graylog2.alarmcallbacks.AlarmCallbackConfigurationAVImpl;
+import org.graylog2.database.CollectionName;
+import org.graylog2.database.MongoConnection;
 import org.graylog2.plugin.periodical.Periodical;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -35,18 +40,24 @@ import javax.inject.Inject;
  */
 public class AlarmCallbacksMigrationPeriodical extends Periodical {
     private static final Logger LOG = LoggerFactory.getLogger(AlarmCallbacksMigrationPeriodical.class);
+    private static final String DUPLICATED_ID = "id";
 
-    private final AlarmCallbackConfigurationService alarmCallbackConfigurationService;
+    private final DBCollection dbCollection;
 
     @Inject
-    public AlarmCallbacksMigrationPeriodical(AlarmCallbackConfigurationService alarmCallbackConfigurationService) {
-        this.alarmCallbackConfigurationService = alarmCallbackConfigurationService;
+    public AlarmCallbacksMigrationPeriodical(MongoConnection mongoConnection) {
+        final String collectionName = AlarmCallbackConfigurationAVImpl.class.getAnnotation(CollectionName.class).value();
+        this.dbCollection = mongoConnection.getDatabase().getCollection(collectionName);
     }
 
     @Override
     public void doRun() {
         LOG.debug("Starting alarm callbacks migration");
-        ((AlarmCallbackConfigurationServiceMJImpl)this.alarmCallbackConfigurationService).migrate();
+
+        final DBObject selection = QueryBuilder.start("id").exists(true).get();
+        final DBObject modifications = new BasicDBObject("$unset", new BasicDBObject(DUPLICATED_ID, ""));
+        this.dbCollection.updateMulti(selection, modifications);
+
         LOG.debug("Done with alarm callbacks migration");
     }
 

--- a/graylog2-server/src/main/java/org/graylog2/periodical/AlarmCallbacksMigrationPeriodical.java
+++ b/graylog2-server/src/main/java/org/graylog2/periodical/AlarmCallbacksMigrationPeriodical.java
@@ -40,7 +40,6 @@ import javax.inject.Inject;
  */
 public class AlarmCallbacksMigrationPeriodical extends Periodical {
     private static final Logger LOG = LoggerFactory.getLogger(AlarmCallbacksMigrationPeriodical.class);
-    private static final String DUPLICATED_ID = "id";
 
     private final DBCollection dbCollection;
 
@@ -55,7 +54,7 @@ public class AlarmCallbacksMigrationPeriodical extends Periodical {
         LOG.debug("Starting alarm callbacks migration");
 
         final DBObject selection = QueryBuilder.start("id").exists(true).get();
-        final DBObject modifications = new BasicDBObject("$unset", new BasicDBObject(DUPLICATED_ID, ""));
+        final DBObject modifications = new BasicDBObject("$unset", new BasicDBObject("id", ""));
         this.dbCollection.updateMulti(selection, modifications);
 
         LOG.debug("Done with alarm callbacks migration");


### PR DESCRIPTION
This fixes issue #1428. In order to migrate old alarm callbacks and be able to load them, I added a periodical that will remove the duplicated ID.

Here is an example of alarm callback with the problem described in the issue:
```
{
    "_id": ObjectId("5464af3a24acdd8389e0f577"),
    "id": "5464af3a24acdd8389e0f577",
    "created_at": ISODate("2014-11-13T13:16:42.690Z"),
    "stream_id": "55fabc4fbee88fa9e9b2350c",
    "creator_user_id": "admin",
    "configuration": {
        "sender": "foo@bar",
        "body": "##########\r\nDate: ${check_result.triggeredAt}\r\nStream ID: ${stream.id}\r\nStream title: ${stream.title}\r\nStream URL: ${stream_url}\r\n\r\nTriggered condition: ${check_result.triggeredCondition}\r\n##########\r\n\r\nLast messages accounting for this alert:\r\n${if backlog_size > 0}${foreach backlog message}\r\n${message}\r\n${end}\r\n${else}<No backlog.>${end}\r\n\r\n",
        "subject": "Graylog2 alert for stream: ${stream.title}"
    },
    "type": "org.graylog2.alarmcallbacks.EmailAlarmCallback"
}
```