### PR TITLE
Add regex replace extractor

### DIFF
--- a/graylog2-bootstrap/pom.xml
+++ b/graylog2-bootstrap/pom.xml
@@ -29,7 +29,7 @@
     <parent>
         <groupId>org.graylog2</groupId>
         <artifactId>graylog2-parent</artifactId>
-        <version>1.2.2-SNAPSHOT</version>
+        <version>1.3.0-SNAPSHOT</version>
     </parent>
 
     <name>graylog2-bootstrap</name>

--- a/graylog2-bootstrap/src/main/resources/log4j.xml
+++ b/graylog2-bootstrap/src/main/resources/log4j.xml
@@ -10,6 +10,11 @@
         </layout>
     </appender>
 
+    <!-- Internal Graylog log appender. Please do not disable. This makes internal log messages available via REST calls. -->
+    <appender name="graylog-internal-logs" class="org.graylog2.log4j.MemoryAppender">
+        <param name="BufferSize" value="500"/>
+    </appender>
+
     <!-- Application Loggers -->
     <logger name="org.graylog2">
         <level value="info"/>
@@ -48,5 +53,6 @@
     <root>
         <priority value="warn"/>
         <appender-ref ref="console"/>
+        <appender-ref ref="graylog-internal-logs" />
     </root>
 </log4j:configuration>

--- a/graylog2-inputs/pom.xml
+++ b/graylog2-inputs/pom.xml
@@ -29,7 +29,7 @@
     <parent>
         <groupId>org.graylog2</groupId>
         <artifactId>graylog2-parent</artifactId>
-        <version>1.2.2-SNAPSHOT</version>
+        <version>1.3.0-SNAPSHOT</version>
     </parent>
 
     <name>graylog2-inputs</name>

--- a/graylog2-plugin-interfaces/pom.xml
+++ b/graylog2-plugin-interfaces/pom.xml
@@ -11,7 +11,7 @@
     <parent>
         <groupId>org.graylog2</groupId>
         <artifactId>graylog2-parent</artifactId>
-        <version>1.2.2-SNAPSHOT</version>
+        <version>1.3.0-SNAPSHOT</version>
     </parent>
 
     <name>graylog2-plugin</name>

--- a/graylog2-plugin-interfaces/src/main/java/org/graylog2/plugin/inputs/Extractor.java
+++ b/graylog2-plugin-interfaces/src/main/java/org/graylog2/plugin/inputs/Extractor.java
@@ -67,6 +67,7 @@ public abstract class Extractor implements EmbeddedPersistable {
     public enum Type {
         SUBSTRING,
         REGEX,
+        REGEX_REPLACE,
         SPLIT_AND_INDEX,
         COPY_INPUT,
         GROK,

--- a/graylog2-radio/pom.xml
+++ b/graylog2-radio/pom.xml
@@ -29,7 +29,7 @@
     <parent>
         <groupId>org.graylog2</groupId>
         <artifactId>graylog2-parent</artifactId>
-        <version>1.2.2-SNAPSHOT</version>
+        <version>1.3.0-SNAPSHOT</version>
     </parent>
 
     <name>graylog2-radio</name>

--- a/graylog2-rest-client/pom.xml
+++ b/graylog2-rest-client/pom.xml
@@ -11,7 +11,7 @@
     <parent>
         <groupId>org.graylog2</groupId>
         <artifactId>graylog2-parent</artifactId>
-        <version>1.2.2-SNAPSHOT</version>
+        <version>1.3.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>graylog2-rest-client</artifactId>

--- a/graylog2-rest-client/pom.xml
+++ b/graylog2-rest-client/pom.xml
@@ -5,7 +5,7 @@
         <maven>3.0.1</maven>
     </prerequisites>
     <properties>
-        <play.version>2.3.9</play.version>
+        <play.version>2.3.10</play.version>
     </properties>
 
     <parent>

--- a/graylog2-rest-client/src/main/java/org/graylog2/restclient/models/Extractor.java
+++ b/graylog2-rest-client/src/main/java/org/graylog2/restclient/models/Extractor.java
@@ -51,6 +51,7 @@ public class Extractor {
     public enum Type {
         SUBSTRING("Substring"),
         REGEX("Regular expression"),
+        REGEX_REPLACE("Replace with regular expression"),
         SPLIT_AND_INDEX("Split & Index"),
         COPY_INPUT("Copy Input"),
         GROK("Grok pattern"),
@@ -175,6 +176,9 @@ public class Extractor {
                 break;
             case SPLIT_AND_INDEX:
                 loadSplitAndIndexConfig(form);
+                break;
+            case REGEX_REPLACE:
+                loadRegexReplaceConfig(form);
                 break;
             case GROK:
                 loadGrokConfig(form);
@@ -338,6 +342,19 @@ public class Extractor {
 
         extractorConfig.put("split_by", form.get("split_by")[0]);
         extractorConfig.put("index", Integer.parseInt(form.get("index")[0]));
+    }
+
+    private void loadRegexReplaceConfig(Map<String, String[]> form) {
+        if (!formFieldSet(form, "regex")) {
+            throw new RuntimeException("Missing extractor config: regex.");
+        }
+
+        extractorConfig.put("regex", form.get("regex")[0]);
+        extractorConfig.put("replace_all", form.containsKey("replace_all"));
+
+        if (formFieldSet(form, "replacement")) {
+            extractorConfig.put("replacement", form.get("replacement")[0]);
+        }
     }
 
     private void loadGrokConfig(Map<String, String[]> form) {

--- a/graylog2-rest-client/src/test/java/org/graylog2/restclient/models/ExtractorTest.java
+++ b/graylog2-rest-client/src/test/java/org/graylog2/restclient/models/ExtractorTest.java
@@ -93,6 +93,18 @@ public class ExtractorTest {
     }
 
     @Test
+    public void loadConfigFromImportSucceedsWithValidConfigForRegexReplaceExtractor() throws Exception {
+        extractor.loadConfigFromImport(
+                Extractor.Type.REGEX_REPLACE,
+                ImmutableMap.<String, Object>of(
+                        "regex", "foobar",
+                        "replacement", "***"
+                ));
+        assertEquals(extractor.getExtractorConfig().get("regex"), "foobar");
+        assertEquals(extractor.getExtractorConfig().get("replacement"), "***");
+    }
+
+    @Test
     public void loadConfigFromImportSucceedsWithValidConfigForSubstringExtractor() throws Exception {
         extractor.loadConfigFromImport(
                 Extractor.Type.SUBSTRING,
@@ -134,6 +146,14 @@ public class ExtractorTest {
         expectedException.expectMessage("Missing extractor config:");
 
         extractor.loadConfigFromImport(Extractor.Type.SUBSTRING, Collections.<String, Object>emptyMap());
+    }
+
+    @Test
+    public void loadConfigFromImportFailsWithEmptyConfigForRegexReplaceExtractor() throws Exception {
+        expectedException.expect(RuntimeException.class);
+        expectedException.expectMessage("Missing extractor config:");
+
+        extractor.loadConfigFromImport(Extractor.Type.REGEX_REPLACE, Collections.<String, Object>emptyMap());
     }
 
     @Test

--- a/graylog2-rest-models/pom.xml
+++ b/graylog2-rest-models/pom.xml
@@ -29,7 +29,7 @@
     <parent>
         <artifactId>graylog2-parent</artifactId>
         <groupId>org.graylog2</groupId>
-        <version>1.2.2-SNAPSHOT</version>
+        <version>1.3.0-SNAPSHOT</version>
     </parent>
 
     <name>graylog2-rest-models</name>

--- a/graylog2-rest-models/src/main/java/org/graylog2/rest/models/system/loggers/responses/InternalLogMessage.java
+++ b/graylog2-rest-models/src/main/java/org/graylog2/rest/models/system/loggers/responses/InternalLogMessage.java
@@ -1,0 +1,64 @@
+package org.graylog2.rest.models.system.loggers.responses;
+
+
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.auto.value.AutoValue;
+import org.hibernate.validator.constraints.NotEmpty;
+import org.joda.time.DateTime;
+
+import javax.annotation.Nullable;
+import javax.validation.constraints.NotNull;
+import java.util.List;
+import java.util.Map;
+
+@AutoValue
+@JsonAutoDetect
+public abstract class InternalLogMessage {
+
+    @JsonProperty
+    @NotEmpty
+    public abstract String message();
+
+    @JsonProperty("class_name")
+    @NotEmpty
+    public abstract String className();
+
+    @JsonProperty
+    @NotEmpty
+    public abstract String level();
+
+    @JsonProperty
+    @NotNull
+    public abstract DateTime timestamp();
+
+    @JsonProperty
+    @NotNull
+    public abstract List<String> throwable();
+
+    @JsonProperty("thread_name")
+    @NotEmpty
+    public abstract String threadName();
+
+    @JsonProperty
+    @Nullable
+    public abstract String ndc();
+
+    @JsonProperty
+    @NotNull
+    public abstract Map<String, String> mdc();
+
+    @JsonCreator
+    public static InternalLogMessage create(@JsonProperty("message") @NotEmpty String message,
+                                            @JsonProperty("class_name") @NotEmpty String className,
+                                            @JsonProperty("level") @NotEmpty String level,
+                                            @JsonProperty("timestamp") @NotNull DateTime timestamp,
+                                            @JsonProperty("throwable") @NotNull List<String> throwable,
+                                            @JsonProperty("thread_name") @NotEmpty String threadName,
+                                            @JsonProperty("ndc") @Nullable String ndc,
+                                            @JsonProperty("mdc") @NotNull Map<String, String> mdc) {
+        return new AutoValue_InternalLogMessage(message, className, level, timestamp, throwable, threadName, ndc, mdc);
+    }
+
+}

--- a/graylog2-rest-models/src/main/java/org/graylog2/rest/models/system/loggers/responses/InternalLogMessage.java
+++ b/graylog2-rest-models/src/main/java/org/graylog2/rest/models/system/loggers/responses/InternalLogMessage.java
@@ -30,6 +30,10 @@ public abstract class InternalLogMessage {
     public abstract String level();
 
     @JsonProperty
+    @Nullable
+    public abstract String marker();
+
+    @JsonProperty
     @NotNull
     public abstract DateTime timestamp();
 
@@ -47,18 +51,19 @@ public abstract class InternalLogMessage {
 
     @JsonProperty
     @NotNull
-    public abstract Map<String, String> mdc();
+    public abstract Map<String, String> context();
 
     @JsonCreator
     public static InternalLogMessage create(@JsonProperty("message") @NotEmpty String message,
                                             @JsonProperty("class_name") @NotEmpty String className,
                                             @JsonProperty("level") @NotEmpty String level,
+                                            @JsonProperty("marker") @NotEmpty String marker,
                                             @JsonProperty("timestamp") @NotNull DateTime timestamp,
                                             @JsonProperty("throwable") @NotNull List<String> throwable,
                                             @JsonProperty("thread_name") @NotEmpty String threadName,
                                             @JsonProperty("ndc") @Nullable String ndc,
-                                            @JsonProperty("mdc") @NotNull Map<String, String> mdc) {
-        return new AutoValue_InternalLogMessage(message, className, level, timestamp, throwable, threadName, ndc, mdc);
+                                            @JsonProperty("context") @NotNull Map<String, String> context) {
+        return new AutoValue_InternalLogMessage(message, className, level, marker, timestamp, throwable, threadName, ndc, context);
     }
 
 }

--- a/graylog2-rest-models/src/main/java/org/graylog2/rest/models/system/loggers/responses/LogMessagesSummary.java
+++ b/graylog2-rest-models/src/main/java/org/graylog2/rest/models/system/loggers/responses/LogMessagesSummary.java
@@ -1,0 +1,39 @@
+/**
+ * This file is part of Graylog.
+ *
+ * Graylog is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.graylog2.rest.models.system.loggers.responses;
+
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.auto.value.AutoValue;
+
+import java.util.Collection;
+
+@AutoValue
+@JsonAutoDetect
+public abstract class LogMessagesSummary {
+
+    @JsonProperty
+    public abstract Collection<InternalLogMessage> messages();
+
+    @JsonCreator
+    public static LogMessagesSummary create(@JsonProperty("messages") Collection<InternalLogMessage> messages) {
+        return new AutoValue_LogMessagesSummary(messages);
+    }
+
+}

--- a/graylog2-rest-models/src/main/java/org/graylog2/rest/models/tools/requests/RegexReplaceTestRequest.java
+++ b/graylog2-rest-models/src/main/java/org/graylog2/rest/models/tools/requests/RegexReplaceTestRequest.java
@@ -1,0 +1,53 @@
+/**
+ * This file is part of Graylog.
+ *
+ * Graylog is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.graylog2.rest.models.tools.requests;
+
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.auto.value.AutoValue;
+import org.hibernate.validator.constraints.NotEmpty;
+
+import javax.validation.constraints.NotNull;
+
+@JsonAutoDetect
+@AutoValue
+public abstract class RegexReplaceTestRequest {
+    @JsonProperty
+    @NotNull
+    public abstract String string();
+
+    @JsonProperty
+    @NotEmpty
+    public abstract String regex();
+
+    @JsonProperty
+    @NotNull
+    public abstract String replacement();
+
+    @JsonProperty("replace_all")
+    public abstract boolean replaceAll();
+
+    @JsonCreator
+    public static RegexReplaceTestRequest create(@JsonProperty("string") @NotNull String string,
+                                                 @JsonProperty("regex") @NotEmpty String regex,
+                                                 @JsonProperty("replacement") @NotNull String replacement,
+                                                 @JsonProperty("replace_all") boolean replaceAll) {
+        return new AutoValue_RegexReplaceTestRequest(string, regex, replacement, replaceAll);
+    }
+}

--- a/graylog2-rest-models/src/main/java/org/graylog2/rest/models/tools/responses/RegexReplaceTesterResponse.java
+++ b/graylog2-rest-models/src/main/java/org/graylog2/rest/models/tools/responses/RegexReplaceTesterResponse.java
@@ -1,0 +1,79 @@
+/**
+ * This file is part of Graylog.
+ *
+ * Graylog is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.graylog2.rest.models.tools.responses;
+
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.auto.value.AutoValue;
+
+import javax.annotation.Nullable;
+
+@JsonAutoDetect
+@AutoValue
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public abstract class RegexReplaceTesterResponse {
+    @JsonProperty
+    public abstract boolean matched();
+
+    @JsonProperty
+    @Nullable
+    public abstract Match match();
+
+    @JsonProperty
+    public abstract String regex();
+
+    @JsonProperty
+    public abstract String replacement();
+
+    @JsonProperty("replace_all")
+    public abstract boolean replaceAll();
+
+    @JsonProperty
+    public abstract String string();
+
+    @JsonCreator
+    public static RegexReplaceTesterResponse create(@JsonProperty("matched") boolean matched,
+                                                    @JsonProperty("match") @Nullable Match match,
+                                                    @JsonProperty("regex") String regex,
+                                                    @JsonProperty("replacement") String replacement,
+                                                    @JsonProperty("replace_all") boolean replaceAll,
+                                                    @JsonProperty("string") String string) {
+        return new AutoValue_RegexReplaceTesterResponse(matched, match, regex, replacement, replaceAll, string);
+    }
+
+    @JsonAutoDetect
+    @AutoValue
+    public static abstract class Match {
+        @JsonProperty
+        public abstract String match();
+
+        @JsonProperty
+        public abstract int start();
+
+        @JsonProperty
+        public abstract int end();
+
+        @JsonCreator
+        public static Match create(@JsonProperty("match") String match,
+                                   @JsonProperty("start") int start,
+                                   @JsonProperty("end") int end) {
+            return new AutoValue_RegexReplaceTesterResponse_Match(match, start, end);
+        }
+    }
+}

--- a/graylog2-rest-routes/pom.xml
+++ b/graylog2-rest-routes/pom.xml
@@ -29,7 +29,7 @@
     <parent>
         <groupId>org.graylog2</groupId>
         <artifactId>graylog2-parent</artifactId>
-        <version>1.2.2-SNAPSHOT</version>
+        <version>1.3.0-SNAPSHOT</version>
     </parent>
 
     <build>

--- a/graylog2-server/pom.xml
+++ b/graylog2-server/pom.xml
@@ -38,7 +38,7 @@
     <parent>
         <groupId>org.graylog2</groupId>
         <artifactId>graylog2-parent</artifactId>
-        <version>1.2.2-SNAPSHOT</version>
+        <version>1.3.0-SNAPSHOT</version>
     </parent>
 
     <properties>

--- a/graylog2-server/src/main/java/org/graylog2/indexer/Deflector.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/Deflector.java
@@ -24,7 +24,6 @@ import org.elasticsearch.indices.InvalidAliasNameException;
 import org.graylog2.configuration.ElasticsearchConfiguration;
 import org.graylog2.indexer.indices.Indices;
 import org.graylog2.indexer.ranges.CreateNewSingleIndexRangeJob;
-import org.graylog2.indexer.ranges.RebuildIndexRangesJob;
 import org.graylog2.shared.system.activities.Activity;
 import org.graylog2.shared.system.activities.ActivityWriter;
 import org.graylog2.system.jobs.SystemJob;
@@ -39,6 +38,8 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
+
+import static com.google.common.base.Strings.isNullOrEmpty;
 
 /**
  * Format of actual indexes behind the Deflector:
@@ -282,7 +283,6 @@ public class Deflector { // extends Ablenkblech
     }
 
     public boolean isGraylog2Index(final String indexName) {
-        return !isDeflectorAlias(indexName) && indexName.startsWith(indexPrefix + SEPARATOR);
+        return !isNullOrEmpty(indexName) && !isDeflectorAlias(indexName) && indexName.startsWith(indexPrefix + SEPARATOR);
     }
-
 }

--- a/graylog2-server/src/main/java/org/graylog2/inputs/extractors/ExtractorFactory.java
+++ b/graylog2-server/src/main/java/org/graylog2/inputs/extractors/ExtractorFactory.java
@@ -59,6 +59,8 @@ public class ExtractorFactory {
                 return new SplitAndIndexExtractor(metricRegistry, id, title, order, cursorStrategy, sourceField, targetField, extractorConfig, creatorUserId, converters, conditionType, conditionValue);
             case COPY_INPUT:
                 return new CopyInputExtractor(metricRegistry, id, title, order, cursorStrategy, sourceField, targetField, extractorConfig, creatorUserId, converters, conditionType, conditionValue);
+            case REGEX_REPLACE:
+                return new RegexReplaceExtractor(metricRegistry, id, title, order, cursorStrategy, sourceField, targetField, extractorConfig, creatorUserId, converters, conditionType, conditionValue);
             case GROK:
                 return new GrokExtractor(metricRegistry, grokPatternService.loadAll(), id, title, order, cursorStrategy, sourceField, targetField, extractorConfig, creatorUserId, converters, conditionType, conditionValue);
             case JSON:

--- a/graylog2-server/src/main/java/org/graylog2/inputs/extractors/RegexReplaceExtractor.java
+++ b/graylog2-server/src/main/java/org/graylog2/inputs/extractors/RegexReplaceExtractor.java
@@ -1,0 +1,106 @@
+/**
+ * This file is part of Graylog.
+ *
+ * Graylog is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.graylog2.inputs.extractors;
+
+import com.codahale.metrics.MetricRegistry;
+import org.graylog2.ConfigurationException;
+import org.graylog2.plugin.inputs.Converter;
+import org.graylog2.plugin.inputs.Extractor;
+
+import java.util.List;
+import java.util.Map;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import static com.google.common.base.Strings.isNullOrEmpty;
+
+public class RegexReplaceExtractor extends Extractor {
+    private static final String CONFIG_REGEX = "regex";
+    private static final String CONFIG_REPLACEMENT = "replacement";
+    private static final String CONFIG_REPLACE_ALL = "replace_all";
+    private static final String DEFAULT_REPLACE_VALUE = "$1";
+
+    private final Pattern pattern;
+    private final String replacement;
+    private final boolean replaceAll;
+
+    public RegexReplaceExtractor(final MetricRegistry metricRegistry,
+                                 final String id,
+                                 final String title,
+                                 final long order,
+                                 final CursorStrategy cursorStrategy,
+                                 final String sourceField,
+                                 final String targetField,
+                                 final Map<String, Object> extractorConfig,
+                                 final String creatorUserId,
+                                 final List<Converter> converters,
+                                 final ConditionType conditionType,
+                                 final String conditionValue) throws ReservedFieldException, ConfigurationException {
+        super(metricRegistry, id, title, order, Type.REGEX_REPLACE, cursorStrategy, sourceField, targetField, extractorConfig, creatorUserId, converters, conditionType, conditionValue);
+
+        if (extractorConfig == null || extractorConfig.isEmpty()) {
+            throw new ConfigurationException("Missing configuration");
+        }
+
+        final Object configRegexValue = extractorConfig.get(CONFIG_REGEX);
+        if (!(configRegexValue instanceof String) || ((String) configRegexValue).isEmpty()) {
+            throw new ConfigurationException("Missing configuration field: " + CONFIG_REGEX);
+        }
+
+        final Object configReplaceValue = extractorConfig.get(CONFIG_REPLACEMENT);
+        if (configReplaceValue != null && !(configReplaceValue instanceof String)) {
+            throw new ConfigurationException("Missing configuration field: " + CONFIG_REPLACEMENT);
+        }
+
+        final Object configReplaceAll = extractorConfig.get(CONFIG_REPLACE_ALL);
+        if (configReplaceAll != null && !(configReplaceAll instanceof Boolean)) {
+            throw new ConfigurationException("Missing configuration field: " + CONFIG_REPLACE_ALL);
+        }
+
+        this.pattern = Pattern.compile((String) configRegexValue, Pattern.DOTALL);
+        this.replacement = isNullOrEmpty((String) configReplaceValue) ? DEFAULT_REPLACE_VALUE : (String) configReplaceValue;
+        this.replaceAll = configReplaceAll == null ? false : (boolean) configReplaceAll;
+    }
+
+    @Override
+    protected Result[] run(String value) {
+        final Result result = runExtractor(value);
+        return result == null ? null : new Result[]{result};
+    }
+
+    public Result runExtractor(String value) {
+        final Matcher matcher = pattern.matcher(value);
+
+        final boolean found = matcher.find();
+        if (!found) {
+            return null;
+        }
+
+        final int start = matcher.groupCount() > 0 ? matcher.start(1) : -1;
+        final int end = matcher.groupCount() > 0 ? matcher.end(1) : -1;
+
+        final String s;
+        try {
+            s = replaceAll ? matcher.replaceAll(replacement) : matcher.replaceFirst(replacement);
+        } catch (Exception e) {
+            throw new RuntimeException("Error while trying to replace string", e);
+        }
+
+        return new Result(s, start, end);
+    }
+
+}

--- a/graylog2-server/src/main/java/org/graylog2/log4j/MemoryAppender.java
+++ b/graylog2-server/src/main/java/org/graylog2/log4j/MemoryAppender.java
@@ -1,0 +1,82 @@
+/**
+ * This file is part of Graylog.
+ *
+ * Graylog is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.graylog2.log4j;
+
+import org.apache.commons.collections.buffer.CircularFifoBuffer;
+import org.apache.log4j.AppenderSkeleton;
+import org.apache.log4j.spi.LoggingEvent;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static com.google.common.base.Preconditions.checkArgument;
+
+/**
+ * A Log4J appender that keeps a configurable number of messages in memory. Used to make recent internal log messages
+ * available via the REST API.
+ */
+public class MemoryAppender extends AppenderSkeleton {
+
+    private CircularFifoBuffer buffer;
+    private int bufferSize;
+
+    @Override
+    public void append(LoggingEvent e) {
+        buffer.add(e);
+    }
+
+    @Override
+    public void close() {
+        buffer.clear();
+    }
+
+    @Override
+    public void activateOptions() {
+        this.buffer = new CircularFifoBuffer(bufferSize);
+    }
+
+    @Override
+    public boolean requiresLayout() {
+        return false;
+    }
+
+    public List<LoggingEvent> getLogMessages(int max) {
+        if (buffer == null) {
+            throw new IllegalStateException("Cannot return log messages: Appender is not initialized.");
+        }
+
+        final List<LoggingEvent> result = new ArrayList<>(max);
+        final Object[] messages = buffer.toArray();
+        for(int i = messages.length - 1; i >= 0 && i >= messages.length - max; i--) {
+            result.add((LoggingEvent) messages[i]);
+        }
+
+        return result;
+    }
+
+    public int getBufferSize() {
+        return bufferSize;
+    }
+
+    public void setBufferSize(int bufferSize) {
+        checkArgument(bufferSize >= 0);
+
+        this.bufferSize = bufferSize;
+    }
+
+}

--- a/graylog2-server/src/main/java/org/graylog2/rest/resources/system/logs/LoggersResource.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/resources/system/logs/LoggersResource.java
@@ -207,6 +207,7 @@ public class LoggersResource extends RestResource {
                     event.getRenderedMessage(),
                     event.getLoggerName(),
                     event.getLevel().toString(),
+                    null,
                     new DateTime(event.getTimeStamp(), DateTimeZone.UTC),
                     throwable,
                     event.getThreadName(),

--- a/graylog2-server/src/main/java/org/graylog2/rest/resources/system/logs/LoggersResource.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/resources/system/logs/LoggersResource.java
@@ -17,6 +17,7 @@
 package org.graylog2.rest.resources.system.logs;
 
 import com.codahale.metrics.annotation.Timed;
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Maps;
 import com.wordnik.swagger.annotations.Api;
@@ -24,26 +25,42 @@ import com.wordnik.swagger.annotations.ApiOperation;
 import com.wordnik.swagger.annotations.ApiParam;
 import com.wordnik.swagger.annotations.ApiResponse;
 import com.wordnik.swagger.annotations.ApiResponses;
+import org.apache.log4j.Appender;
 import org.apache.log4j.Level;
 import org.apache.log4j.Logger;
+import org.apache.log4j.spi.LoggingEvent;
 import org.apache.shiro.authz.annotation.RequiresAuthentication;
+import org.graylog2.log4j.MemoryAppender;
+import org.graylog2.rest.models.system.loggers.responses.InternalLogMessage;
+import org.graylog2.rest.models.system.loggers.responses.LogMessagesSummary;
 import org.graylog2.rest.models.system.loggers.responses.LoggersSummary;
 import org.graylog2.rest.models.system.loggers.responses.SingleLoggerSummary;
 import org.graylog2.rest.models.system.loggers.responses.SingleSubsystemSummary;
 import org.graylog2.rest.models.system.loggers.responses.SubsystemSummary;
 import org.graylog2.shared.rest.resources.RestResource;
 import org.graylog2.shared.security.RestPermissions;
+import org.hibernate.validator.constraints.NotEmpty;
+import org.joda.time.DateTime;
+import org.joda.time.DateTimeZone;
 import org.slf4j.LoggerFactory;
 
+import javax.validation.constraints.Min;
+import javax.ws.rs.DefaultValue;
 import javax.ws.rs.GET;
+import javax.ws.rs.InternalServerErrorException;
 import javax.ws.rs.NotFoundException;
 import javax.ws.rs.PUT;
 import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
 import javax.ws.rs.Produces;
+import javax.ws.rs.QueryParam;
 import javax.ws.rs.core.MediaType;
+import java.util.ArrayList;
 import java.util.Enumeration;
+import java.util.List;
 import java.util.Map;
+
+import static com.google.common.base.MoreObjects.firstNonNull;
 
 @RequiresAuthentication
 @Api(value = "System/Loggers", description = "Internal Graylog loggers")
@@ -51,6 +68,8 @@ import java.util.Map;
 public class LoggersResource extends RestResource {
 
     private static final org.slf4j.Logger LOG = LoggerFactory.getLogger(LoggersResource.class);
+
+    private static final String MEMORY_APPENDER_NAME = "graylog-internal-logs";
 
     private static final Map<String, Subsystem> SUBSYSTEMS = ImmutableMap.<String, Subsystem>of(
             "graylog2", new Subsystem("Graylog2", "org.graylog2", "All messages from graylog2-owned systems."),
@@ -117,8 +136,8 @@ public class LoggersResource extends RestResource {
     })
     @Path("/subsystems/{subsystem}/level/{level}")
     public void setSubsystemLoggerLevel(
-            @ApiParam(name = "subsystem", required = true) @PathParam("subsystem") String subsystemTitle,
-            @ApiParam(name = "level", required = true) @PathParam("level") String level) {
+            @ApiParam(name = "subsystem", required = true) @PathParam("subsystem") @NotEmpty String subsystemTitle,
+            @ApiParam(name = "level", required = true) @PathParam("level") @NotEmpty String level) {
         if (!SUBSYSTEMS.containsKey(subsystemTitle)) {
             LOG.warn("No such subsystem: [{}]. Returning 404.", subsystemTitle);
             throw new NotFoundException();
@@ -140,8 +159,8 @@ public class LoggersResource extends RestResource {
             notes = "Provided level is falling back to DEBUG if it does not exist")
     @Path("/{loggerName}/level/{level}")
     public void setSingleLoggerLevel(
-            @ApiParam(name = "loggerName", required = true) @PathParam("loggerName") String loggerName,
-            @ApiParam(name = "level", required = true) @PathParam("level") String level) {
+            @ApiParam(name = "loggerName", required = true) @PathParam("loggerName") @NotEmpty String loggerName,
+            @ApiParam(name = "level", required = true) @NotEmpty @PathParam("level") String level) {
         checkPermission(RestPermissions.LOGGERS_EDIT, loggerName);
         // This is never null. Worst case is a logger that does not exist.
         Logger logger = Logger.getLogger(loggerName);
@@ -149,6 +168,65 @@ public class LoggersResource extends RestResource {
         // Setting the level falls back to DEBUG if provided level is invalid.
         Level newLevel = Level.toLevel(level.toUpperCase());
         logger.setLevel(newLevel);
+    }
+
+    @GET
+    @Timed
+    @ApiOperation(value = "Get recent internal log messages")
+    @ApiResponses(value = {
+            @ApiResponse(code = 404, message = "Memory appender is disabled."),
+            @ApiResponse(code = 500, message = "Memory appender is broken.")
+    })
+    @Path("/messages/recent")
+    @Produces(MediaType.APPLICATION_JSON)
+    public LogMessagesSummary messages(@ApiParam(name = "limit", value = "How many log messages should be returned", defaultValue = "500", allowableValues = "range[0, infinity]")
+                                       @QueryParam("limit") @DefaultValue("500") @Min(0L) int limit,
+                                       @ApiParam(name = "level", value = "Which log level (or higher) should the messages have", defaultValue = "ALL", allowableValues = "[OFF, FATAL, ERROR, WARN, INFO, DEBUG, TRACE, ALL]")
+                                       @QueryParam("level") @DefaultValue("ALL") @NotEmpty String level) {
+        final Appender appender = Logger.getRootLogger().getAppender(MEMORY_APPENDER_NAME);
+        if (appender == null) {
+            throw new NotFoundException("Memory appender is disabled. Please refer to the example log4j.xml file.");
+        }
+
+        if (!(appender instanceof MemoryAppender)) {
+            throw new InternalServerErrorException("Memory appender is not an instance of MemoryAppender. Please refer to the example log4j.xml file.");
+        }
+
+        final Level logLevel = Level.toLevel(level, Level.ALL);
+        final MemoryAppender memoryAppender = (MemoryAppender) appender;
+        final List<InternalLogMessage> messages = new ArrayList<>(memoryAppender.getBufferSize());
+        for (LoggingEvent event : memoryAppender.getLogMessages(limit)) {
+            if(!event.getLevel().isGreaterOrEqual(logLevel)) {
+                continue;
+            }
+
+            final String[] throwableStrRep = firstNonNull(event.getThrowableStrRep(), new String[0]);
+            final List<String> throwable = ImmutableList.copyOf(throwableStrRep);
+
+            messages.add(InternalLogMessage.create(
+                    event.getRenderedMessage(),
+                    event.getLoggerName(),
+                    event.getLevel().toString(),
+                    new DateTime(event.getTimeStamp(), DateTimeZone.UTC),
+                    throwable,
+                    event.getThreadName(),
+                    event.getNDC(),
+                    getMDC(event)
+            ));
+        }
+
+        return LogMessagesSummary.create(messages);
+    }
+
+    private Map<String, String> getMDC(LoggingEvent event) {
+        @SuppressWarnings("unchecked")
+        final Map<String, Object> originalMDC = event.getProperties();
+        final ImmutableMap.Builder<String, String> mdc = ImmutableMap.builder();
+        for (Map.Entry<String, Object> entry : originalMDC.entrySet()) {
+            mdc.put(entry.getKey(), String.valueOf(entry.getValue()));
+        }
+
+        return mdc.build();
     }
 
     private static class Subsystem {

--- a/graylog2-server/src/main/java/org/graylog2/rest/resources/tools/RegexReplaceTesterResource.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/resources/tools/RegexReplaceTesterResource.java
@@ -1,0 +1,91 @@
+/**
+ * This file is part of Graylog.
+ *
+ * Graylog is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.graylog2.rest.resources.tools;
+
+import com.codahale.metrics.MetricRegistry;
+import com.codahale.metrics.annotation.Timed;
+import com.google.common.collect.ImmutableMap;
+import org.apache.shiro.authz.annotation.RequiresAuthentication;
+import org.graylog2.ConfigurationException;
+import org.graylog2.inputs.extractors.RegexReplaceExtractor;
+import org.graylog2.plugin.inputs.Converter;
+import org.graylog2.plugin.inputs.Extractor;
+import org.graylog2.rest.models.tools.requests.RegexReplaceTestRequest;
+import org.graylog2.rest.models.tools.responses.RegexReplaceTesterResponse;
+import org.graylog2.shared.rest.resources.RestResource;
+import org.hibernate.validator.constraints.NotEmpty;
+
+import javax.validation.Valid;
+import javax.validation.constraints.NotNull;
+import javax.ws.rs.BadRequestException;
+import javax.ws.rs.Consumes;
+import javax.ws.rs.DefaultValue;
+import javax.ws.rs.GET;
+import javax.ws.rs.POST;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.QueryParam;
+import javax.ws.rs.core.MediaType;
+import java.util.Collections;
+import java.util.Map;
+
+@RequiresAuthentication
+@Path("/tools/regex_replace_tester")
+public class RegexReplaceTesterResource extends RestResource {
+    @GET
+    @Timed
+    @Produces(MediaType.APPLICATION_JSON)
+    public RegexReplaceTesterResponse regexTester(@QueryParam("regex") @NotEmpty String regex,
+                                                  @QueryParam("replacement") @NotNull String replacement,
+                                                  @QueryParam("replace_all") @DefaultValue("false") boolean replaceAll,
+                                                  @QueryParam("string") @NotNull String string) {
+        return testRegexReplaceExtractor(string, regex, replacement, replaceAll);
+    }
+
+    @POST
+    @Timed
+    @Consumes(MediaType.APPLICATION_JSON)
+    @Produces(MediaType.APPLICATION_JSON)
+    public RegexReplaceTesterResponse testRegex(@Valid @NotNull RegexReplaceTestRequest r) {
+        return testRegexReplaceExtractor(r.string(), r.regex(), r.replacement(), r.replaceAll());
+    }
+
+    private RegexReplaceTesterResponse testRegexReplaceExtractor(String example, String regex, String replacement, boolean replaceAll) {
+        final Map<String, Object> config = ImmutableMap.<String, Object>of(
+                "regex", regex,
+                "replacement", replacement,
+                "replace_all", replaceAll
+        );
+        final RegexReplaceExtractor extractor;
+        try {
+            extractor = new RegexReplaceExtractor(
+                    new MetricRegistry(), "test", "Test", 0L, Extractor.CursorStrategy.COPY, "test", "test",
+                    config, getCurrentUser().getName(), Collections.<Converter>emptyList(), Extractor.ConditionType.NONE, ""
+            );
+        } catch (Extractor.ReservedFieldException e) {
+            throw new BadRequestException("Trying to overwrite a reserved message field", e);
+        } catch (ConfigurationException e) {
+            throw new BadRequestException("Invalid extractor configuration", e);
+        }
+
+        final Extractor.Result result = extractor.runExtractor(example);
+        final RegexReplaceTesterResponse.Match match = result == null ? null :
+                RegexReplaceTesterResponse.Match.create(String.valueOf(result.getValue()), result.getBeginIndex(), result.getEndIndex());
+        return RegexReplaceTesterResponse.create(result != null, match, regex, replacement, replaceAll, example);
+    }
+}

--- a/graylog2-server/src/test/java/org/graylog2/MemoryAppenderTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/MemoryAppenderTest.java
@@ -1,0 +1,59 @@
+/**
+ * This file is part of Graylog.
+ *
+ * Graylog is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.graylog2;
+
+import org.apache.log4j.Level;
+import org.apache.log4j.Logger;
+import org.apache.log4j.spi.LoggingEvent;
+import org.graylog2.log4j.MemoryAppender;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class MemoryAppenderTest {
+
+    private MemoryAppender appender;
+
+    @Before
+    public void setUp() {
+        appender = new MemoryAppender();
+    }
+
+    @Test
+    public void testGetLogMessages() throws Exception {
+        final int bufferSize = 10;
+        appender.setBufferSize(bufferSize);
+        appender.activateOptions();
+
+        for (int i = 1; i <= bufferSize; i++) {
+            appender.append(new LoggingEvent("com.example", Logger.getRootLogger(), Level.INFO, "Message " + i, null));
+        }
+
+        assertThat(appender.getLogMessages(bufferSize * 2)).hasSize(bufferSize);
+        assertThat(appender.getLogMessages(bufferSize)).hasSize(bufferSize);
+        assertThat(appender.getLogMessages(bufferSize / 2)).hasSize(bufferSize / 2);
+        assertThat(appender.getLogMessages(0)).isEmpty();
+
+        final List<LoggingEvent> messages = appender.getLogMessages(5);
+        for (int i = 0; i < messages.size(); i++) {
+            assertThat(messages.get(i).getMessage()).isEqualTo("Message " + (bufferSize - i));
+        }
+    }
+}

--- a/graylog2-server/src/test/java/org/graylog2/inputs/extractors/RegexReplaceExtractorTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/inputs/extractors/RegexReplaceExtractorTest.java
@@ -1,0 +1,206 @@
+/**
+ * This file is part of Graylog.
+ *
+ * Graylog is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.graylog2.inputs.extractors;
+
+import org.elasticsearch.common.collect.ImmutableMap;
+import org.graylog2.ConfigurationException;
+import org.graylog2.plugin.Message;
+import org.graylog2.plugin.Tools;
+import org.graylog2.plugin.inputs.Converter;
+import org.graylog2.plugin.inputs.Extractor;
+import org.junit.Test;
+
+import java.util.Collections;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class RegexReplaceExtractorTest extends AbstractExtractorTest {
+    @Test(expected = ConfigurationException.class)
+    public void testConstructorWithMissingRegex() throws Exception {
+        new RegexReplaceExtractor(
+                metricRegistry,
+                "id",
+                "title",
+                0L,
+                Extractor.CursorStrategy.COPY,
+                "message",
+                "message",
+                ImmutableMap.<String, Object>of(),
+                "user",
+                Collections.<Converter>emptyList(),
+                Extractor.ConditionType.NONE,
+                null);
+    }
+
+    @Test(expected = ConfigurationException.class)
+    public void testConstructorWithNonStringRegex() throws Exception {
+        new RegexReplaceExtractor(
+                metricRegistry,
+                "id",
+                "title",
+                0L,
+                Extractor.CursorStrategy.COPY,
+                "message",
+                "message",
+                ImmutableMap.<String, Object>of("regex", 0L),
+                "user",
+                Collections.<Converter>emptyList(),
+                Extractor.ConditionType.NONE,
+                null);
+    }
+
+    @Test(expected = ConfigurationException.class)
+    public void testConstructorWithNonStringReplacement() throws Exception {
+        new RegexReplaceExtractor(
+                metricRegistry,
+                "id",
+                "title",
+                0L,
+                Extractor.CursorStrategy.COPY,
+                "message",
+                "message",
+                ImmutableMap.<String, Object>of("regex", "NO-MATCH", "replacement", 0L),
+                "user",
+                Collections.<Converter>emptyList(),
+                Extractor.ConditionType.NONE,
+                null);
+    }
+
+    @Test
+    public void testReplacementWithNoMatchAndDefaultReplacement() throws Exception {
+        final Message message = new Message("Test", "source", Tools.iso8601());
+        final RegexReplaceExtractor extractor = new RegexReplaceExtractor(
+                metricRegistry,
+                "id",
+                "title",
+                0L,
+                Extractor.CursorStrategy.COPY,
+                "message",
+                "message",
+                ImmutableMap.<String, Object>of("regex", "NO-MATCH"),
+                "user",
+                Collections.<Converter>emptyList(),
+                Extractor.ConditionType.NONE,
+                null);
+        extractor.runExtractor(message);
+
+        assertThat(message.getMessage()).isEqualTo("Test");
+    }
+
+    @Test
+    public void testReplacementWithOnePlaceholder() throws Exception {
+        final Message message = new Message("Test Foobar", "source", Tools.iso8601());
+        final RegexReplaceExtractor extractor = new RegexReplaceExtractor(
+                metricRegistry,
+                "id",
+                "title",
+                0L,
+                Extractor.CursorStrategy.COPY,
+                "message",
+                "message",
+                ImmutableMap.<String, Object>of("regex", "Test (\\w+)"),
+                "user",
+                Collections.<Converter>emptyList(),
+                Extractor.ConditionType.NONE,
+                null);
+        extractor.runExtractor(message);
+
+        assertThat(message.getMessage()).isEqualTo("Foobar");
+    }
+
+    @Test(expected = RuntimeException.class)
+    public void testReplacementWithTooManyPlaceholders() throws Exception {
+        final Message message = new Message("Foobar 123", "source", Tools.iso8601());
+        final RegexReplaceExtractor extractor = new RegexReplaceExtractor(
+                metricRegistry,
+                "id",
+                "title",
+                0L,
+                Extractor.CursorStrategy.COPY,
+                "message",
+                "message",
+                ImmutableMap.<String, Object>of("regex", "Foobar (\\d+)", "replacement", "$1 $2"),
+                "user",
+                Collections.<Converter>emptyList(),
+                Extractor.ConditionType.NONE,
+                null);
+        extractor.runExtractor(message);
+    }
+
+    @Test
+    public void testReplacementWithCustomReplacement() throws Exception {
+        final Message message = new Message("Foobar 123", "source", Tools.iso8601());
+        final RegexReplaceExtractor extractor = new RegexReplaceExtractor(
+                metricRegistry,
+                "id",
+                "title",
+                0L,
+                Extractor.CursorStrategy.COPY,
+                "message",
+                "message",
+                ImmutableMap.<String, Object>of("regex", "(Foobar) (\\d+)", "replacement", "$2/$1"),
+                "user",
+                Collections.<Converter>emptyList(),
+                Extractor.ConditionType.NONE,
+                null);
+        extractor.runExtractor(message);
+
+        assertThat(message.getMessage()).isEqualTo("123/Foobar");
+    }
+
+    @Test
+    public void testReplacementWithReplaceAll() throws Exception {
+        final Message message = new Message("Foobar 123 Foobaz 456", "source", Tools.iso8601());
+        final RegexReplaceExtractor extractor = new RegexReplaceExtractor(
+                metricRegistry,
+                "id",
+                "title",
+                0L,
+                Extractor.CursorStrategy.COPY,
+                "message",
+                "message",
+                ImmutableMap.<String, Object>of("regex", "(\\w+) (\\d+)", "replacement", "$2/$1", "replace_all", true),
+                "user",
+                Collections.<Converter>emptyList(),
+                Extractor.ConditionType.NONE,
+                null);
+        extractor.runExtractor(message);
+
+        assertThat(message.getMessage()).isEqualTo("123/Foobar 456/Foobaz");
+    }
+
+    @Test
+    public void testReplacementWithoutReplaceAll() throws Exception {
+        final Message message = new Message("Foobar 123 Foobaz 456", "source", Tools.iso8601());
+        final RegexReplaceExtractor extractor = new RegexReplaceExtractor(
+                metricRegistry,
+                "id",
+                "title",
+                0L,
+                Extractor.CursorStrategy.COPY,
+                "message",
+                "message",
+                ImmutableMap.<String, Object>of("regex", "(\\w+) (\\d+)", "replacement", "$2/$1", "replace_all", false),
+                "user",
+                Collections.<Converter>emptyList(),
+                Extractor.ConditionType.NONE,
+                null);
+        extractor.runExtractor(message);
+
+        assertThat(message.getMessage()).isEqualTo("123/Foobar Foobaz 456");
+    }
+}

--- a/graylog2-server/src/test/java/org/graylog2/logmessage/InternalLogMessageTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/logmessage/InternalLogMessageTest.java
@@ -29,7 +29,7 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
-public class LogMessageTest {
+public class InternalLogMessageTest {
 
     @Test
     public void testIdGetsSet() {

--- a/graylog2-server/src/test/java/org/graylog2/logmessage/MessageTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/logmessage/MessageTest.java
@@ -29,7 +29,7 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
-public class InternalLogMessageTest {
+public class MessageTest {
 
     @Test
     public void testIdGetsSet() {

--- a/graylog2-shared/pom.xml
+++ b/graylog2-shared/pom.xml
@@ -29,7 +29,7 @@
     <parent>
         <groupId>org.graylog2</groupId>
         <artifactId>graylog2-parent</artifactId>
-        <version>1.2.2-SNAPSHOT</version>
+        <version>1.3.0-SNAPSHOT</version>
     </parent>
 
     <name>graylog2-shared</name>

--- a/integration-tests/pom.xml
+++ b/integration-tests/pom.xml
@@ -29,7 +29,7 @@
     <parent>
         <groupId>org.graylog2</groupId>
         <artifactId>graylog2-parent</artifactId>
-        <version>1.2.2-SNAPSHOT</version>
+        <version>1.3.0-SNAPSHOT</version>
     </parent>
 
     <name>integration-tests</name>

--- a/integration-tests/src/test/java/integration/BaseRestTestHelper.java
+++ b/integration-tests/src/test/java/integration/BaseRestTestHelper.java
@@ -124,7 +124,7 @@ public class BaseRestTestHelper {
         return jsonResource(filename + ".json");
     }
 
-    private static class KeysPresentMatcher extends ResponseAwareMatcher<Response> {
+    private static class KeysPresentMatcher implements ResponseAwareMatcher<Response> {
         private final Set<String> keys = Sets.newHashSet();
         public KeysPresentMatcher(String... keys) {
             Collections.addAll(this.keys, keys);
@@ -161,7 +161,7 @@ public class BaseRestTestHelper {
         }
     }
 
-    private static class StrictKeysPresentMatcher extends ResponseAwareMatcher<Response> {
+    private static class StrictKeysPresentMatcher implements ResponseAwareMatcher<Response> {
         private final Set<String> keys = Sets.newHashSet();
         public StrictKeysPresentMatcher(String... keys) {
             Collections.addAll(this.keys, keys);

--- a/pom.xml
+++ b/pom.xml
@@ -25,7 +25,7 @@
 
     <groupId>org.graylog2</groupId>
     <artifactId>graylog2-parent</artifactId>
-    <version>1.2.2-SNAPSHOT</version>
+    <version>1.3.0-SNAPSHOT</version>
     <packaging>pom</packaging>
     <name>Graylog</name>
     <url>https://www.graylog.org/</url>

--- a/pom.xml
+++ b/pom.xml
@@ -97,18 +97,19 @@
         <build.timestamp>${maven.build.timestamp}</build.timestamp>
 
         <metrics.version>3.1.2</metrics.version>
-        <jackson.version>2.6.0</jackson.version>
-        <jersey.version>2.19</jersey.version>
+        <jackson.version>2.6.2</jackson.version>
+        <jersey.version>2.22.1</jersey.version>
         <!-- The HK2 version should match the version being used by Jersey -->
-        <glassfish-hk2.version>2.4.0-b25</glassfish-hk2.version>
-        <apache-directory-version>1.0.0-M29</apache-directory-version>
+        <glassfish-hk2.version>2.4.0-b31</glassfish-hk2.version>
+        <apache-directory-version>1.0.0-M31</apache-directory-version>
         <surefire.version>2.18.1</surefire.version>
         <guice.version>4.0</guice.version>
-        <drools.version>6.2.0.Final</drools.version>
+        <drools.version>6.3.0.Final</drools.version>
         <slf4j.version>1.7.12</slf4j.version>
         <mongojack.version>2.3.0</mongojack.version>
-        <swagger.version>1.3.11</swagger.version>
+        <swagger.version>1.3.12</swagger.version>
         <sigar.version>1.6.4</sigar.version>
+        <restassured.version>2.6.0</restassured.version>
     </properties>
 
     <repositories>
@@ -211,12 +212,12 @@
             <dependency>
                 <groupId>joda-time</groupId>
                 <artifactId>joda-time</artifactId>
-                <version>2.8.1</version>
+                <version>2.8.2</version>
             </dependency>
             <dependency>
                 <groupId>org.mongodb</groupId>
                 <artifactId>mongo-java-driver</artifactId>
-                <version>2.13.0</version>
+                <version>2.13.3</version>
             </dependency>
 
             <dependency>
@@ -228,7 +229,7 @@
             <dependency>
                 <groupId>org.elasticsearch</groupId>
                 <artifactId>elasticsearch</artifactId>
-                <version>1.7.1</version>
+                <version>1.7.2</version>
             </dependency>
 
             <dependency>
@@ -301,7 +302,7 @@
             <dependency>
                 <groupId>com.squareup.okhttp</groupId>
                 <artifactId>okhttp</artifactId>
-                <version>2.4.0</version>
+                <version>2.5.0</version>
             </dependency>
 
             <dependency>
@@ -360,7 +361,7 @@
             <dependency>
                 <groupId>com.beust</groupId>
                 <artifactId>jcommander</artifactId>
-                <version>1.47</version>
+                <version>1.48</version>
             </dependency>
             <dependency>
                 <groupId>com.github.joschi</groupId>
@@ -418,7 +419,7 @@
             <dependency>
                 <groupId>org.hibernate</groupId>
                 <artifactId>hibernate-validator</artifactId>
-                <version>5.1.3.Final</version>
+                <version>5.2.2.Final</version>
             </dependency>
             <dependency>
                 <groupId>org.graylog2</groupId>
@@ -486,7 +487,7 @@
             <dependency>
                 <groupId>org.apache.kafka</groupId>
                 <artifactId>kafka_2.11</artifactId>
-                <version>0.8.2.1</version>
+                <version>0.8.2.2</version>
                 <exclusions>
                     <exclusion>
                         <groupId>com.sun.jmx</groupId>
@@ -506,7 +507,7 @@
             <dependency>
                 <groupId>com.rabbitmq</groupId>
                 <artifactId>amqp-client</artifactId>
-                <version>3.5.3</version>
+                <version>3.5.6</version>
             </dependency>
 
             <dependency>
@@ -551,7 +552,7 @@
             <dependency>
                 <groupId>org.apache.shiro</groupId>
                 <artifactId>shiro-core</artifactId>
-                <version>1.2.3</version>
+                <version>1.2.4</version>
             </dependency>
 
             <dependency>
@@ -569,7 +570,7 @@
             <dependency>
                 <groupId>com.joestelmach</groupId>
                 <artifactId>natty</artifactId>
-                <version>0.11</version>
+                <version>0.12</version>
                 <exclusions>
                     <!-- Getting rid of commons-logging in a transitive dependency of com.joestelmach:natty -->
                     <exclusion>
@@ -582,7 +583,7 @@
             <dependency>
                 <groupId>com.floreysoft</groupId>
                 <artifactId>jmte</artifactId>
-                <version>3.1.1</version>
+                <version>3.2.0</version>
             </dependency>
 
             <dependency>
@@ -611,7 +612,7 @@
             <dependency>
                 <groupId>com.google.code.findbugs</groupId>
                 <artifactId>jsr305</artifactId>
-                <version>3.0.0</version>
+                <version>3.0.1</version>
             </dependency>
 
             <dependency>
@@ -628,7 +629,7 @@
             <dependency>
                 <groupId>org.hdrhistogram</groupId>
                 <artifactId>HdrHistogram</artifactId>
-                <version>2.1.4</version>
+                <version>2.1.7</version>
             </dependency>
             <dependency>
                 <groupId>com.google.auto.value</groupId>
@@ -666,13 +667,13 @@
             <dependency>
                 <groupId>com.jayway.restassured</groupId>
                 <artifactId>rest-assured</artifactId>
-                <version>2.4.1</version>
+                <version>${restassured.version}</version>
                 <scope>test</scope>
             </dependency>
             <dependency>
                 <groupId>com.jayway.restassured</groupId>
                 <artifactId>json-path</artifactId>
-                <version>2.4.1</version>
+                <version>${restassured.version}</version>
                 <scope>test</scope>
             </dependency>
 
@@ -685,7 +686,7 @@
             <dependency>
                 <groupId>org.assertj</groupId>
                 <artifactId>assertj-core</artifactId>
-                <version>2.0.0</version>
+                <version>2.2.0</version>
                 <scope>test</scope>
             </dependency>
             <dependency>
@@ -715,13 +716,13 @@
             <dependency>
                 <groupId>com.github.fakemongo</groupId>
                 <artifactId>fongo</artifactId>
-                <version>1.6.2</version>
+                <version>1.6.3</version>
                 <scope>test</scope>
             </dependency>
             <dependency>
                 <groupId>com.jayway.awaitility</groupId>
                 <artifactId>awaitility</artifactId>
-                <version>1.6.3</version>
+                <version>1.6.5</version>
                 <scope>test</scope>
             </dependency>
             <dependency>


### PR DESCRIPTION
This PR adds an extractor which supports replacing a message field with a constant value or the matches of a regular expression.

Similar to the already existing Regex extractor, this extractor tries to match a regular expression against a message field (see [`Pattern`](https://docs.oracle.com/javase/8/docs/api/java/util/regex/Pattern.html)) and replaces its value (or the value of the target field) with the string configured in the "replacement" setting (see [`Matcher#replaceAll()`](https://docs.oracle.com/javase/8/docs/api/java/util/regex/Matcher.html#replaceAll-java.lang.String-)). The extractor also allows to only replace the first match or all matches (default).