### PR TITLE
Make internal logs accessible via REST API call (master branch)

### DIFF
--- a/graylog2-rest-models/src/main/java/org/graylog2/rest/models/system/loggers/responses/InternalLogMessage.java
+++ b/graylog2-rest-models/src/main/java/org/graylog2/rest/models/system/loggers/responses/InternalLogMessage.java
@@ -1,0 +1,62 @@
+package org.graylog2.rest.models.system.loggers.responses;
+
+
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.auto.value.AutoValue;
+import org.hibernate.validator.constraints.NotEmpty;
+import org.joda.time.DateTime;
+
+import javax.annotation.Nullable;
+import javax.validation.constraints.NotNull;
+import java.util.Map;
+
+@AutoValue
+@JsonAutoDetect
+public abstract class InternalLogMessage {
+    @JsonProperty
+    @NotEmpty
+    public abstract String message();
+
+    @JsonProperty("class_name")
+    @NotEmpty
+    public abstract String className();
+
+    @JsonProperty
+    @NotEmpty
+    public abstract String level();
+
+    @JsonProperty
+    @Nullable
+    public abstract String marker();
+
+    @JsonProperty
+    @NotNull
+    public abstract DateTime timestamp();
+
+    @JsonProperty
+    @Nullable
+    public abstract String throwable();
+
+    @JsonProperty("thread_name")
+    @NotEmpty
+    public abstract String threadName();
+
+    @JsonProperty
+    @NotNull
+    public abstract Map<String, String> context();
+
+    @JsonCreator
+    public static InternalLogMessage create(@JsonProperty("message") @NotEmpty String message,
+                                            @JsonProperty("class_name") @NotEmpty String className,
+                                            @JsonProperty("level") @NotEmpty String level,
+                                            @JsonProperty("marker") @Nullable String marker,
+                                            @JsonProperty("timestamp") @NotNull DateTime timestamp,
+                                            @JsonProperty("throwable") @Nullable String throwable,
+                                            @JsonProperty("thread_name") @NotEmpty String threadName,
+                                            @JsonProperty("context") @NotNull Map<String, String> context) {
+        return new AutoValue_InternalLogMessage(message, className, level, marker, timestamp, throwable, threadName, context);
+    }
+
+}

--- a/graylog2-rest-models/src/main/java/org/graylog2/rest/models/system/loggers/responses/LogMessagesSummary.java
+++ b/graylog2-rest-models/src/main/java/org/graylog2/rest/models/system/loggers/responses/LogMessagesSummary.java
@@ -1,0 +1,39 @@
+/**
+ * This file is part of Graylog.
+ *
+ * Graylog is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.graylog2.rest.models.system.loggers.responses;
+
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.auto.value.AutoValue;
+
+import java.util.Collection;
+
+@AutoValue
+@JsonAutoDetect
+public abstract class LogMessagesSummary {
+
+    @JsonProperty
+    public abstract Collection<InternalLogMessage> messages();
+
+    @JsonCreator
+    public static LogMessagesSummary create(@JsonProperty("messages") Collection<InternalLogMessage> messages) {
+        return new AutoValue_LogMessagesSummary(messages);
+    }
+
+}

--- a/graylog2-server/src/main/java/org/graylog2/log4j/MemoryAppender.java
+++ b/graylog2-server/src/main/java/org/graylog2/log4j/MemoryAppender.java
@@ -1,0 +1,102 @@
+/**
+ * This file is part of Graylog.
+ *
+ * Graylog is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.graylog2.log4j;
+
+import org.apache.commons.collections.buffer.CircularFifoBuffer;
+import org.apache.logging.log4j.core.Filter;
+import org.apache.logging.log4j.core.Layout;
+import org.apache.logging.log4j.core.LogEvent;
+import org.apache.logging.log4j.core.appender.AbstractAppender;
+import org.apache.logging.log4j.core.config.plugins.Plugin;
+import org.apache.logging.log4j.core.config.plugins.PluginAttribute;
+import org.apache.logging.log4j.core.config.plugins.PluginElement;
+import org.apache.logging.log4j.core.config.plugins.PluginFactory;
+import org.apache.logging.log4j.core.layout.PatternLayout;
+import org.apache.logging.log4j.core.util.Booleans;
+
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * A Log4J appender that keeps a configurable number of messages in memory. Used to make recent internal log messages
+ * available via the REST API.
+ */
+@Plugin(name = "Memory", category = "Core", elementType = "appender", printObject = true)
+public class MemoryAppender extends AbstractAppender {
+
+    private CircularFifoBuffer buffer;
+    private int bufferSize;
+
+    protected MemoryAppender(String name, Filter filter, Layout<? extends Serializable> layout, boolean ignoreExceptions, int bufferSize) {
+        super(name, filter, layout, ignoreExceptions);
+        this.bufferSize = bufferSize;
+        this.buffer = new CircularFifoBuffer(bufferSize);
+    }
+
+    @PluginFactory
+    public static MemoryAppender createAppender(
+            @PluginElement("Layout") Layout<? extends Serializable> layout,
+            @PluginElement("Filter") final Filter filter,
+            @PluginAttribute("name") final String name,
+            @PluginAttribute(value = "bufferSize", defaultInt = 500) final String bufferSize,
+            @PluginAttribute(value = "ignoreExceptions", defaultBoolean = true) final String ignore) {
+        if (name == null) {
+            LOGGER.error("No name provided for MemoryAppender");
+            return null;
+        }
+
+        if (layout == null) {
+            layout = PatternLayout.createDefaultLayout();
+        }
+
+        final int size = Integer.parseInt(bufferSize);
+        final boolean ignoreExceptions = Booleans.parseBoolean(ignore, true);
+        return new MemoryAppender(name, filter, layout, ignoreExceptions, size);
+    }
+
+
+    @Override
+    public void append(LogEvent event) {
+        buffer.add(event);
+    }
+
+    @Override
+    public void stop() {
+        super.stop();
+        buffer.clear();
+    }
+
+    public List<LogEvent> getLogMessages(int max) {
+        if (buffer == null) {
+            throw new IllegalStateException("Cannot return log messages: Appender is not initialized.");
+        }
+
+        final List<LogEvent> result = new ArrayList<>(max);
+        final Object[] messages = buffer.toArray();
+        for (int i = messages.length - 1; i >= 0 && i >= messages.length - max; i--) {
+            result.add((LogEvent) messages[i]);
+        }
+
+        return result;
+    }
+
+    public int getBufferSize() {
+        return bufferSize;
+    }
+}

--- a/graylog2-server/src/main/resources/log4j2.xml
+++ b/graylog2-server/src/main/resources/log4j2.xml
@@ -1,9 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<Configuration>
+<Configuration packages="org.graylog2.log4j">
     <Appenders>
         <Console name="STDOUT" target="SYSTEM_OUT">
             <PatternLayout pattern="%d %-5p: %c - %m%n"/>
         </Console>
+
+        <!-- Internal Graylog log appender. Please do not disable. This makes internal log messages available via REST calls. -->
+        <Memory name="graylog-internal-logs" bufferSize="500"/>
     </Appenders>
     <Loggers>
         <!-- Application Loggers -->
@@ -24,6 +27,7 @@
         <Logger name="kafka.log.OffsetIndex" level="warn"/>
         <Root level="warn">
             <AppenderRef ref="STDOUT"/>
+            <AppenderRef ref="graylog-internal-logs"/>
         </Root>
     </Loggers>
 </Configuration>

--- a/graylog2-server/src/test/java/org/graylog2/MemoryAppenderTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/MemoryAppenderTest.java
@@ -1,0 +1,58 @@
+/**
+ * This file is part of Graylog.
+ *
+ * Graylog is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.graylog2;
+
+import org.apache.logging.log4j.Level;
+import org.apache.logging.log4j.core.LogEvent;
+import org.apache.logging.log4j.core.impl.Log4jLogEvent;
+import org.apache.logging.log4j.message.SimpleMessage;
+import org.graylog2.log4j.MemoryAppender;
+import org.junit.Test;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class MemoryAppenderTest {
+    @Test
+    public void testGetLogMessages() throws Exception {
+        final int bufferSize = 10;
+        final MemoryAppender appender = MemoryAppender.createAppender(null, null, "memory", "10", "false");
+
+        for (int i = 1; i <= bufferSize; i++) {
+            final LogEvent logEvent = Log4jLogEvent.newBuilder()
+                    .setLevel(Level.INFO)
+                    .setLoggerName("test")
+                    .setLoggerFqcn("com.example.test")
+                    .setMessage(new SimpleMessage("Message " + i))
+                    .build();
+
+
+            appender.append(logEvent);
+        }
+
+        assertThat(appender.getLogMessages(bufferSize * 2)).hasSize(bufferSize);
+        assertThat(appender.getLogMessages(bufferSize)).hasSize(bufferSize);
+        assertThat(appender.getLogMessages(bufferSize / 2)).hasSize(bufferSize / 2);
+        assertThat(appender.getLogMessages(0)).isEmpty();
+
+        final List<LogEvent> messages = appender.getLogMessages(5);
+        for (int i = 0; i < messages.size(); i++) {
+            assertThat(messages.get(i).getMessage().getFormattedMessage()).isEqualTo("Message " + (bufferSize - i));
+        }
+    }
+}

--- a/graylog2-server/src/test/java/org/graylog2/logmessage/InternalLogMessageTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/logmessage/InternalLogMessageTest.java
@@ -29,7 +29,7 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
-public class LogMessageTest {
+public class InternalLogMessageTest {
 
     @Test
     public void testIdGetsSet() {
@@ -110,7 +110,7 @@ public class LogMessageTest {
 
         assertEquals(6, lm.getFieldCount());
     }
-    
+
     @Test
     public void testRemoveFieldDoesNotDeleteReservedFields() {
         DateTime time = Tools.iso8601();

--- a/graylog2-server/src/test/java/org/graylog2/logmessage/MessageTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/logmessage/MessageTest.java
@@ -29,7 +29,7 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
-public class InternalLogMessageTest {
+public class MessageTest {
 
     @Test
     public void testIdGetsSet() {


### PR DESCRIPTION
This PR is a port of #1452 to the current master branch with log4j 2.4.

(cherry picked from commit 866d6e3f9f4b4c1148cb20d252c442db5737f24f)

The format of `InternalLogMessage` had to be slightly changed (`ndc`, `mdc` => `context`, added `marker`) to match the capabilities of log4j 2.4.