### PR TITLE
Report selected configuration variables via REST API

### DIFF
--- a/graylog2-bootstrap/src/main/resources/log4j.xml
+++ b/graylog2-bootstrap/src/main/resources/log4j.xml
@@ -10,6 +10,11 @@
         </layout>
     </appender>
 
+    <!-- Internal Graylog log appender. Please do not disable. This makes internal log messages available via REST calls. -->
+    <appender name="graylog-internal-logs" class="org.graylog2.log4j.MemoryAppender">
+        <param name="BufferSize" value="500"/>
+    </appender>
+
     <!-- Application Loggers -->
     <logger name="org.graylog2">
         <level value="info"/>
@@ -48,5 +53,6 @@
     <root>
         <priority value="warn"/>
         <appender-ref ref="console"/>
+        <appender-ref ref="graylog-internal-logs" />
     </root>
 </log4j:configuration>

--- a/graylog2-rest-models/src/main/java/org/graylog2/rest/models/system/configuration/ConfigurationList.java
+++ b/graylog2-rest-models/src/main/java/org/graylog2/rest/models/system/configuration/ConfigurationList.java
@@ -1,0 +1,22 @@
+package org.graylog2.rest.models.system.configuration;
+
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.auto.value.AutoValue;
+
+import java.util.List;
+
+@JsonAutoDetect
+@AutoValue
+public abstract class ConfigurationList {
+
+    @JsonProperty
+    public abstract List<ConfigurationVariable> variables();
+
+    @JsonCreator
+    public static ConfigurationList create(@JsonProperty("variables") List<ConfigurationVariable> variables) {
+        return new AutoValue_ConfigurationList(variables);
+    }
+
+}

--- a/graylog2-rest-models/src/main/java/org/graylog2/rest/models/system/configuration/ConfigurationList.java
+++ b/graylog2-rest-models/src/main/java/org/graylog2/rest/models/system/configuration/ConfigurationList.java
@@ -1,3 +1,20 @@
+/**
+ * This file is part of Graylog.
+ *
+ * Graylog is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
 package org.graylog2.rest.models.system.configuration;
 
 import com.fasterxml.jackson.annotation.JsonAutoDetect;

--- a/graylog2-rest-models/src/main/java/org/graylog2/rest/models/system/configuration/ConfigurationVariable.java
+++ b/graylog2-rest-models/src/main/java/org/graylog2/rest/models/system/configuration/ConfigurationVariable.java
@@ -1,0 +1,33 @@
+package org.graylog2.rest.models.system.configuration;
+
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.auto.value.AutoValue;
+
+@JsonAutoDetect
+@AutoValue
+public abstract class ConfigurationVariable {
+
+    @JsonProperty
+    public abstract String name();
+
+    @JsonProperty
+    public abstract Object value();
+
+    @JsonCreator
+    public static ConfigurationVariable create(@JsonProperty("name") String name, @JsonProperty("value") String x) {
+        return new AutoValue_ConfigurationVariable(name, x);
+    }
+
+    @JsonCreator
+    public static ConfigurationVariable create(@JsonProperty("name") String name, @JsonProperty("value") Number x) {
+        return new AutoValue_ConfigurationVariable(name, x);
+    }
+
+    @JsonCreator
+    public static ConfigurationVariable create(@JsonProperty("name") String name, @JsonProperty("value") Boolean x) {
+        return new AutoValue_ConfigurationVariable(name, x);
+    }
+
+}

--- a/graylog2-rest-models/src/main/java/org/graylog2/rest/models/system/configuration/ConfigurationVariable.java
+++ b/graylog2-rest-models/src/main/java/org/graylog2/rest/models/system/configuration/ConfigurationVariable.java
@@ -1,3 +1,20 @@
+/**
+ * This file is part of Graylog.
+ *
+ * Graylog is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
 package org.graylog2.rest.models.system.configuration;
 
 import com.fasterxml.jackson.annotation.JsonAutoDetect;

--- a/graylog2-rest-models/src/main/java/org/graylog2/rest/models/system/loggers/responses/InternalLogMessage.java
+++ b/graylog2-rest-models/src/main/java/org/graylog2/rest/models/system/loggers/responses/InternalLogMessage.java
@@ -1,0 +1,64 @@
+package org.graylog2.rest.models.system.loggers.responses;
+
+
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.auto.value.AutoValue;
+import org.hibernate.validator.constraints.NotEmpty;
+import org.joda.time.DateTime;
+
+import javax.annotation.Nullable;
+import javax.validation.constraints.NotNull;
+import java.util.List;
+import java.util.Map;
+
+@AutoValue
+@JsonAutoDetect
+public abstract class InternalLogMessage {
+
+    @JsonProperty
+    @NotEmpty
+    public abstract String message();
+
+    @JsonProperty("class_name")
+    @NotEmpty
+    public abstract String className();
+
+    @JsonProperty
+    @NotEmpty
+    public abstract String level();
+
+    @JsonProperty
+    @NotNull
+    public abstract DateTime timestamp();
+
+    @JsonProperty
+    @NotNull
+    public abstract List<String> throwable();
+
+    @JsonProperty("thread_name")
+    @NotEmpty
+    public abstract String threadName();
+
+    @JsonProperty
+    @Nullable
+    public abstract String ndc();
+
+    @JsonProperty
+    @NotNull
+    public abstract Map<String, String> mdc();
+
+    @JsonCreator
+    public static InternalLogMessage create(@JsonProperty("message") @NotEmpty String message,
+                                            @JsonProperty("class_name") @NotEmpty String className,
+                                            @JsonProperty("level") @NotEmpty String level,
+                                            @JsonProperty("timestamp") @NotNull DateTime timestamp,
+                                            @JsonProperty("throwable") @NotNull List<String> throwable,
+                                            @JsonProperty("thread_name") @NotEmpty String threadName,
+                                            @JsonProperty("ndc") @Nullable String ndc,
+                                            @JsonProperty("mdc") @NotNull Map<String, String> mdc) {
+        return new AutoValue_InternalLogMessage(message, className, level, timestamp, throwable, threadName, ndc, mdc);
+    }
+
+}

--- a/graylog2-rest-models/src/main/java/org/graylog2/rest/models/system/loggers/responses/LogMessagesSummary.java
+++ b/graylog2-rest-models/src/main/java/org/graylog2/rest/models/system/loggers/responses/LogMessagesSummary.java
@@ -1,0 +1,39 @@
+/**
+ * This file is part of Graylog.
+ *
+ * Graylog is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.graylog2.rest.models.system.loggers.responses;
+
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.auto.value.AutoValue;
+
+import java.util.Collection;
+
+@AutoValue
+@JsonAutoDetect
+public abstract class LogMessagesSummary {
+
+    @JsonProperty
+    public abstract Collection<InternalLogMessage> messages();
+
+    @JsonCreator
+    public static LogMessagesSummary create(@JsonProperty("messages") Collection<InternalLogMessage> messages) {
+        return new AutoValue_LogMessagesSummary(messages);
+    }
+
+}

--- a/graylog2-server/src/main/java/org/graylog2/indexer/Deflector.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/Deflector.java
@@ -24,7 +24,6 @@ import org.elasticsearch.indices.InvalidAliasNameException;
 import org.graylog2.configuration.ElasticsearchConfiguration;
 import org.graylog2.indexer.indices.Indices;
 import org.graylog2.indexer.ranges.CreateNewSingleIndexRangeJob;
-import org.graylog2.indexer.ranges.RebuildIndexRangesJob;
 import org.graylog2.shared.system.activities.Activity;
 import org.graylog2.shared.system.activities.ActivityWriter;
 import org.graylog2.system.jobs.SystemJob;
@@ -39,6 +38,8 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
+
+import static com.google.common.base.Strings.isNullOrEmpty;
 
 /**
  * Format of actual indexes behind the Deflector:
@@ -282,7 +283,6 @@ public class Deflector { // extends Ablenkblech
     }
 
     public boolean isGraylog2Index(final String indexName) {
-        return !isDeflectorAlias(indexName) && indexName.startsWith(indexPrefix + SEPARATOR);
+        return !isNullOrEmpty(indexName) && !isDeflectorAlias(indexName) && indexName.startsWith(indexPrefix + SEPARATOR);
     }
-
 }

--- a/graylog2-server/src/main/java/org/graylog2/log4j/MemoryAppender.java
+++ b/graylog2-server/src/main/java/org/graylog2/log4j/MemoryAppender.java
@@ -1,0 +1,82 @@
+/**
+ * This file is part of Graylog.
+ *
+ * Graylog is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.graylog2.log4j;
+
+import org.apache.commons.collections.buffer.CircularFifoBuffer;
+import org.apache.log4j.AppenderSkeleton;
+import org.apache.log4j.spi.LoggingEvent;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static com.google.common.base.Preconditions.checkArgument;
+
+/**
+ * A Log4J appender that keeps a configurable number of messages in memory. Used to make recent internal log messages
+ * available via the REST API.
+ */
+public class MemoryAppender extends AppenderSkeleton {
+
+    private CircularFifoBuffer buffer;
+    private int bufferSize;
+
+    @Override
+    public void append(LoggingEvent e) {
+        buffer.add(e);
+    }
+
+    @Override
+    public void close() {
+        buffer.clear();
+    }
+
+    @Override
+    public void activateOptions() {
+        this.buffer = new CircularFifoBuffer(bufferSize);
+    }
+
+    @Override
+    public boolean requiresLayout() {
+        return false;
+    }
+
+    public List<LoggingEvent> getLogMessages(int max) {
+        if (buffer == null) {
+            throw new IllegalStateException("Cannot return log messages: Appender is not initialized.");
+        }
+
+        final List<LoggingEvent> result = new ArrayList<>(max);
+        final Object[] messages = buffer.toArray();
+        for(int i = messages.length - 1; i >= 0 && i >= messages.length - max; i--) {
+            result.add((LoggingEvent) messages[i]);
+        }
+
+        return result;
+    }
+
+    public int getBufferSize() {
+        return bufferSize;
+    }
+
+    public void setBufferSize(int bufferSize) {
+        checkArgument(bufferSize >= 0);
+
+        this.bufferSize = bufferSize;
+    }
+
+}

--- a/graylog2-server/src/main/java/org/graylog2/rest/resources/system/ConfigurationResource.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/resources/system/ConfigurationResource.java
@@ -1,0 +1,80 @@
+package org.graylog2.rest.resources.system;
+
+import com.codahale.metrics.annotation.Timed;
+import com.wordnik.swagger.annotations.Api;
+import com.wordnik.swagger.annotations.ApiOperation;
+import org.apache.shiro.authz.annotation.RequiresAuthentication;
+import org.graylog2.Configuration;
+import org.graylog2.configuration.ElasticsearchConfiguration;
+import org.graylog2.rest.models.system.configuration.ConfigurationList;
+import org.graylog2.rest.models.system.configuration.ConfigurationVariable;
+import org.graylog2.shared.rest.resources.RestResource;
+
+import javax.inject.Inject;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import java.util.ArrayList;
+import java.util.List;
+
+@RequiresAuthentication
+@Api(value = "System/Configuration", description = "Read-only access to configuration variables")
+@Path("/system/configuration")
+public class ConfigurationResource extends RestResource  {
+
+    private final Configuration configuration;
+    private final ElasticsearchConfiguration esConfiguration;
+
+    @Inject
+    public ConfigurationResource(Configuration configuration, ElasticsearchConfiguration esConfiguration) {
+        this.configuration = configuration;
+        this.esConfiguration = esConfiguration;
+    }
+
+    /*
+     * This call is manually building a map of variables to return because we need to guarantee never to return any
+     * sensitive variables like passwords etc. - See this as a whitelist approach.
+     */
+    @GET
+    @Timed
+    @ApiOperation(value = "Get all reported configuration variables and their values")
+    public ConfigurationList getAll() {
+        List<ConfigurationVariable> config = new ArrayList<>();
+
+        config.add(ConfigurationVariable.create("inputbuffer_processors", configuration.getInputbufferProcessors()));
+        config.add(ConfigurationVariable.create("processbuffer_processors", configuration.getProcessBufferProcessors()));
+        config.add(ConfigurationVariable.create("outputbuffer_processors", configuration.getOutputBufferProcessors()));
+        config.add(ConfigurationVariable.create("processor_wait_strategy", configuration.getProcessorWaitStrategy().getClass().getName()));
+        config.add(ConfigurationVariable.create("inputbuffer_wait_strategy", configuration.getInputBufferWaitStrategy().getClass().getName()));
+        config.add(ConfigurationVariable.create("inputbuffer_ring_size", configuration.getInputBufferRingSize()));
+        config.add(ConfigurationVariable.create("ring_size", configuration.getRingSize()));
+
+        config.add(ConfigurationVariable.create("plugin_dir", configuration.getPluginDir()));
+        config.add(ConfigurationVariable.create("node_id_file", configuration.getNodeIdFile()));
+
+        config.add(ConfigurationVariable.create("allow_highlighting", configuration.isAllowHighlighting()));
+        config.add(ConfigurationVariable.create("allow_leading_wildcard_searches", configuration.isAllowLeadingWildcardSearches()));
+
+        config.add(ConfigurationVariable.create("rotation_strategy", esConfiguration.getRotationStrategy()));
+        config.add(ConfigurationVariable.create("retention_strategy", esConfiguration.getRetentionStrategy()));
+        config.add(ConfigurationVariable.create("elasticsearch_max_docs_per_index", esConfiguration.getMaxDocsPerIndex()));
+        config.add(ConfigurationVariable.create("elasticsearch_max_size_per_index", esConfiguration.getMaxSizePerIndex()));
+        config.add(ConfigurationVariable.create("elasticsearch_max_time_per_index", esConfiguration.getMaxTimePerIndex().toString()));
+        config.add(ConfigurationVariable.create("elasticsearch_max_number_of_indices", esConfiguration.getMaxNumberOfIndices()));
+        config.add(ConfigurationVariable.create("elasticsearch_shards", esConfiguration.getShards()));
+        config.add(ConfigurationVariable.create("elasticsearch_replicas", esConfiguration.getReplicas()));
+
+        config.add(ConfigurationVariable.create("stream_processing_timeout", configuration.getStreamProcessingTimeout()));
+        config.add(ConfigurationVariable.create("stream_processing_max_faults", configuration.getStreamProcessingMaxFaults()));
+
+        config.add(ConfigurationVariable.create("output_module_timeout", configuration.getOutputModuleTimeout()));
+        config.add(ConfigurationVariable.create("stale_master_timeout", configuration.getStaleMasterTimeout()));
+
+        config.add(ConfigurationVariable.create("disable_index_optimization", esConfiguration.isDisableIndexOptimization()));
+        config.add(ConfigurationVariable.create("index_optimization_max_num_segments", esConfiguration.getIndexOptimizationMaxNumSegments()));
+
+        config.add(ConfigurationVariable.create("gc_warning_threshold", configuration.getGcWarningThreshold().toString()));
+
+        return ConfigurationList.create(config);
+    }
+
+}

--- a/graylog2-server/src/main/java/org/graylog2/rest/resources/system/ConfigurationResource.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/resources/system/ConfigurationResource.java
@@ -1,3 +1,20 @@
+/**
+ * This file is part of Graylog.
+ *
+ * Graylog is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
 package org.graylog2.rest.resources.system;
 
 import com.codahale.metrics.annotation.Timed;

--- a/graylog2-server/src/main/java/org/graylog2/rest/resources/system/logs/LoggersResource.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/resources/system/logs/LoggersResource.java
@@ -17,6 +17,7 @@
 package org.graylog2.rest.resources.system.logs;
 
 import com.codahale.metrics.annotation.Timed;
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Maps;
 import com.wordnik.swagger.annotations.Api;
@@ -24,26 +25,42 @@ import com.wordnik.swagger.annotations.ApiOperation;
 import com.wordnik.swagger.annotations.ApiParam;
 import com.wordnik.swagger.annotations.ApiResponse;
 import com.wordnik.swagger.annotations.ApiResponses;
+import org.apache.log4j.Appender;
 import org.apache.log4j.Level;
 import org.apache.log4j.Logger;
+import org.apache.log4j.spi.LoggingEvent;
 import org.apache.shiro.authz.annotation.RequiresAuthentication;
+import org.graylog2.log4j.MemoryAppender;
+import org.graylog2.rest.models.system.loggers.responses.InternalLogMessage;
+import org.graylog2.rest.models.system.loggers.responses.LogMessagesSummary;
 import org.graylog2.rest.models.system.loggers.responses.LoggersSummary;
 import org.graylog2.rest.models.system.loggers.responses.SingleLoggerSummary;
 import org.graylog2.rest.models.system.loggers.responses.SingleSubsystemSummary;
 import org.graylog2.rest.models.system.loggers.responses.SubsystemSummary;
 import org.graylog2.shared.rest.resources.RestResource;
 import org.graylog2.shared.security.RestPermissions;
+import org.hibernate.validator.constraints.NotEmpty;
+import org.joda.time.DateTime;
+import org.joda.time.DateTimeZone;
 import org.slf4j.LoggerFactory;
 
+import javax.validation.constraints.Min;
+import javax.ws.rs.DefaultValue;
 import javax.ws.rs.GET;
+import javax.ws.rs.InternalServerErrorException;
 import javax.ws.rs.NotFoundException;
 import javax.ws.rs.PUT;
 import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
 import javax.ws.rs.Produces;
+import javax.ws.rs.QueryParam;
 import javax.ws.rs.core.MediaType;
+import java.util.ArrayList;
 import java.util.Enumeration;
+import java.util.List;
 import java.util.Map;
+
+import static com.google.common.base.MoreObjects.firstNonNull;
 
 @RequiresAuthentication
 @Api(value = "System/Loggers", description = "Internal Graylog loggers")
@@ -51,6 +68,8 @@ import java.util.Map;
 public class LoggersResource extends RestResource {
 
     private static final org.slf4j.Logger LOG = LoggerFactory.getLogger(LoggersResource.class);
+
+    private static final String MEMORY_APPENDER_NAME = "graylog-internal-logs";
 
     private static final Map<String, Subsystem> SUBSYSTEMS = ImmutableMap.<String, Subsystem>of(
             "graylog2", new Subsystem("Graylog2", "org.graylog2", "All messages from graylog2-owned systems."),
@@ -117,8 +136,8 @@ public class LoggersResource extends RestResource {
     })
     @Path("/subsystems/{subsystem}/level/{level}")
     public void setSubsystemLoggerLevel(
-            @ApiParam(name = "subsystem", required = true) @PathParam("subsystem") String subsystemTitle,
-            @ApiParam(name = "level", required = true) @PathParam("level") String level) {
+            @ApiParam(name = "subsystem", required = true) @PathParam("subsystem") @NotEmpty String subsystemTitle,
+            @ApiParam(name = "level", required = true) @PathParam("level") @NotEmpty String level) {
         if (!SUBSYSTEMS.containsKey(subsystemTitle)) {
             LOG.warn("No such subsystem: [{}]. Returning 404.", subsystemTitle);
             throw new NotFoundException();
@@ -140,8 +159,8 @@ public class LoggersResource extends RestResource {
             notes = "Provided level is falling back to DEBUG if it does not exist")
     @Path("/{loggerName}/level/{level}")
     public void setSingleLoggerLevel(
-            @ApiParam(name = "loggerName", required = true) @PathParam("loggerName") String loggerName,
-            @ApiParam(name = "level", required = true) @PathParam("level") String level) {
+            @ApiParam(name = "loggerName", required = true) @PathParam("loggerName") @NotEmpty String loggerName,
+            @ApiParam(name = "level", required = true) @NotEmpty @PathParam("level") String level) {
         checkPermission(RestPermissions.LOGGERS_EDIT, loggerName);
         // This is never null. Worst case is a logger that does not exist.
         Logger logger = Logger.getLogger(loggerName);
@@ -149,6 +168,65 @@ public class LoggersResource extends RestResource {
         // Setting the level falls back to DEBUG if provided level is invalid.
         Level newLevel = Level.toLevel(level.toUpperCase());
         logger.setLevel(newLevel);
+    }
+
+    @GET
+    @Timed
+    @ApiOperation(value = "Get recent internal log messages")
+    @ApiResponses(value = {
+            @ApiResponse(code = 404, message = "Memory appender is disabled."),
+            @ApiResponse(code = 500, message = "Memory appender is broken.")
+    })
+    @Path("/messages/recent")
+    @Produces(MediaType.APPLICATION_JSON)
+    public LogMessagesSummary messages(@ApiParam(name = "limit", value = "How many log messages should be returned", defaultValue = "500", allowableValues = "range[0, infinity]")
+                                       @QueryParam("limit") @DefaultValue("500") @Min(0L) int limit,
+                                       @ApiParam(name = "level", value = "Which log level (or higher) should the messages have", defaultValue = "ALL", allowableValues = "[OFF, FATAL, ERROR, WARN, INFO, DEBUG, TRACE, ALL]")
+                                       @QueryParam("level") @DefaultValue("ALL") @NotEmpty String level) {
+        final Appender appender = Logger.getRootLogger().getAppender(MEMORY_APPENDER_NAME);
+        if (appender == null) {
+            throw new NotFoundException("Memory appender is disabled. Please refer to the example log4j.xml file.");
+        }
+
+        if (!(appender instanceof MemoryAppender)) {
+            throw new InternalServerErrorException("Memory appender is not an instance of MemoryAppender. Please refer to the example log4j.xml file.");
+        }
+
+        final Level logLevel = Level.toLevel(level, Level.ALL);
+        final MemoryAppender memoryAppender = (MemoryAppender) appender;
+        final List<InternalLogMessage> messages = new ArrayList<>(memoryAppender.getBufferSize());
+        for (LoggingEvent event : memoryAppender.getLogMessages(limit)) {
+            if(!event.getLevel().isGreaterOrEqual(logLevel)) {
+                continue;
+            }
+
+            final String[] throwableStrRep = firstNonNull(event.getThrowableStrRep(), new String[0]);
+            final List<String> throwable = ImmutableList.copyOf(throwableStrRep);
+
+            messages.add(InternalLogMessage.create(
+                    event.getRenderedMessage(),
+                    event.getLoggerName(),
+                    event.getLevel().toString(),
+                    new DateTime(event.getTimeStamp(), DateTimeZone.UTC),
+                    throwable,
+                    event.getThreadName(),
+                    event.getNDC(),
+                    getMDC(event)
+            ));
+        }
+
+        return LogMessagesSummary.create(messages);
+    }
+
+    private Map<String, String> getMDC(LoggingEvent event) {
+        @SuppressWarnings("unchecked")
+        final Map<String, Object> originalMDC = event.getProperties();
+        final ImmutableMap.Builder<String, String> mdc = ImmutableMap.builder();
+        for (Map.Entry<String, Object> entry : originalMDC.entrySet()) {
+            mdc.put(entry.getKey(), String.valueOf(entry.getValue()));
+        }
+
+        return mdc.build();
     }
 
     private static class Subsystem {

--- a/graylog2-server/src/test/java/org/graylog2/MemoryAppenderTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/MemoryAppenderTest.java
@@ -1,0 +1,59 @@
+/**
+ * This file is part of Graylog.
+ *
+ * Graylog is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.graylog2;
+
+import org.apache.log4j.Level;
+import org.apache.log4j.Logger;
+import org.apache.log4j.spi.LoggingEvent;
+import org.graylog2.log4j.MemoryAppender;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class MemoryAppenderTest {
+
+    private MemoryAppender appender;
+
+    @Before
+    public void setUp() {
+        appender = new MemoryAppender();
+    }
+
+    @Test
+    public void testGetLogMessages() throws Exception {
+        final int bufferSize = 10;
+        appender.setBufferSize(bufferSize);
+        appender.activateOptions();
+
+        for (int i = 1; i <= bufferSize; i++) {
+            appender.append(new LoggingEvent("com.example", Logger.getRootLogger(), Level.INFO, "Message " + i, null));
+        }
+
+        assertThat(appender.getLogMessages(bufferSize * 2)).hasSize(bufferSize);
+        assertThat(appender.getLogMessages(bufferSize)).hasSize(bufferSize);
+        assertThat(appender.getLogMessages(bufferSize / 2)).hasSize(bufferSize / 2);
+        assertThat(appender.getLogMessages(0)).isEmpty();
+
+        final List<LoggingEvent> messages = appender.getLogMessages(5);
+        for (int i = 0; i < messages.size(); i++) {
+            assertThat(messages.get(i).getMessage()).isEqualTo("Message " + (bufferSize - i));
+        }
+    }
+}

--- a/graylog2-server/src/test/java/org/graylog2/logmessage/InternalLogMessageTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/logmessage/InternalLogMessageTest.java
@@ -29,7 +29,7 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
-public class LogMessageTest {
+public class InternalLogMessageTest {
 
     @Test
     public void testIdGetsSet() {


### PR DESCRIPTION
This pull request adds a REST resource that is reporting a selected list of configuration variables. This is important for Apollo but can on the longer term also be integrated into the web interface.

The `ConfigurationVariable` class might look a bit convoluted but I tried to make sure that only numbers, strings and booleans can be added to avoid weird `toString` behavior if somebody is not careful when adding a new configuration variable that is reported.

Please take a close look at the JSON structure in the response. I struggled with that one and could not really find one that satisfied me.