### PR TITLE
Switching language level to Java 8.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 sudo: false
 language: java
 jdk:
-  - oraclejdk7
   - oraclejdk8
 cache:
   directories:
@@ -29,7 +28,7 @@ deploy:
   local-dir: target/assembly
   on:
     repo: Graylog2/graylog2-server
-    jdk: oraclejdk7
+    jdk: oraclejdk8
     branch:
       - master
       - 1.0

--- a/graylog2-server/src/test/java/org/graylog2/indexer/ranges/IndexRangeTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/indexer/ranges/IndexRangeTest.java
@@ -56,10 +56,10 @@ public class IndexRangeTest {
         String json = objectMapper.writeValueAsString(indexRange);
         Object document = Configuration.defaultConfiguration().jsonProvider().parse(json);
 
-        assertThat(JsonPath.read(document, "$." + IndexRange.FIELD_INDEX_NAME)).isEqualTo(indexName);
-        assertThat(JsonPath.read(document, "$." + IndexRange.FIELD_BEGIN)).asString().isEqualTo(begin.toString());
-        assertThat(JsonPath.read(document, "$." + IndexRange.FIELD_END)).isEqualTo(end.toString());
-        assertThat(JsonPath.read(document, "$." + IndexRange.FIELD_CALCULATED_AT)).isEqualTo(calculatedAt.toString());
-        assertThat(JsonPath.read(document, "$." + IndexRange.FIELD_TOOK_MS)).isEqualTo(calculationDuration);
+        assertThat((String)JsonPath.read(document, "$." + IndexRange.FIELD_INDEX_NAME)).isEqualTo(indexName);
+        assertThat((String)JsonPath.read(document, "$." + IndexRange.FIELD_BEGIN)).asString().isEqualTo(begin.toString());
+        assertThat((String)JsonPath.read(document, "$." + IndexRange.FIELD_END)).isEqualTo(end.toString());
+        assertThat((String)JsonPath.read(document, "$." + IndexRange.FIELD_CALCULATED_AT)).isEqualTo(calculatedAt.toString());
+        assertThat((int)JsonPath.read(document, "$." + IndexRange.FIELD_TOOK_MS)).isEqualTo(calculationDuration);
     }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -88,8 +88,8 @@
     <properties>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <maven.compiler.source>1.7</maven.compiler.source>
-        <maven.compiler.target>1.7</maven.compiler.target>
+        <maven.compiler.source>1.8</maven.compiler.source>
+        <maven.compiler.target>1.8</maven.compiler.target>
         <maven.compiler.useIncrementalCompilation>false</maven.compiler.useIncrementalCompilation>
 
         <maven.build.timestamp.format>yyyyMMddHHmmss</maven.build.timestamp.format>


### PR DESCRIPTION
This small changeset switches the compiler's source and target level to Java 8 for maven. You might need to switch your project's language level and SDK to Java 8 in IntelliJ as well.
