### PR TITLE
Rename "mdc" to "context" and "marker" to InternalLogMessage

### DIFF
--- a/graylog2-rest-models/src/main/java/org/graylog2/rest/models/system/loggers/responses/InternalLogMessage.java
+++ b/graylog2-rest-models/src/main/java/org/graylog2/rest/models/system/loggers/responses/InternalLogMessage.java
@@ -30,6 +30,10 @@ public abstract class InternalLogMessage {
     public abstract String level();
 
     @JsonProperty
+    @Nullable
+    public abstract String marker();
+
+    @JsonProperty
     @NotNull
     public abstract DateTime timestamp();
 
@@ -47,18 +51,19 @@ public abstract class InternalLogMessage {
 
     @JsonProperty
     @NotNull
-    public abstract Map<String, String> mdc();
+    public abstract Map<String, String> context();
 
     @JsonCreator
     public static InternalLogMessage create(@JsonProperty("message") @NotEmpty String message,
                                             @JsonProperty("class_name") @NotEmpty String className,
                                             @JsonProperty("level") @NotEmpty String level,
+                                            @JsonProperty("marker") @NotEmpty String marker,
                                             @JsonProperty("timestamp") @NotNull DateTime timestamp,
                                             @JsonProperty("throwable") @NotNull List<String> throwable,
                                             @JsonProperty("thread_name") @NotEmpty String threadName,
                                             @JsonProperty("ndc") @Nullable String ndc,
-                                            @JsonProperty("mdc") @NotNull Map<String, String> mdc) {
-        return new AutoValue_InternalLogMessage(message, className, level, timestamp, throwable, threadName, ndc, mdc);
+                                            @JsonProperty("context") @NotNull Map<String, String> context) {
+        return new AutoValue_InternalLogMessage(message, className, level, marker, timestamp, throwable, threadName, ndc, context);
     }
 
 }

--- a/graylog2-server/src/main/java/org/graylog2/rest/resources/system/logs/LoggersResource.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/resources/system/logs/LoggersResource.java
@@ -207,6 +207,7 @@ public class LoggersResource extends RestResource {
                     event.getRenderedMessage(),
                     event.getLoggerName(),
                     event.getLevel().toString(),
+                    null,
                     new DateTime(event.getTimeStamp(), DateTimeZone.UTC),
                     throwable,
                     event.getThreadName(),

--- a/graylog2-server/src/test/java/org/graylog2/logmessage/MessageTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/logmessage/MessageTest.java
@@ -29,7 +29,7 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
-public class InternalLogMessageTest {
+public class MessageTest {
 
     @Test
     public void testIdGetsSet() {


### PR DESCRIPTION
As preparation for the migration to Log4j 2 in Graylog 2.x, the old "mdc" field is being renamed to "context", as Log4j 2 only knows Thread Context and removes NDC and MDC (see https://logging.apache.org/log4j/2.x/manual/thread-context.html).

The "marker" field is always empty (null) in this implementation since Log4j 1.2 doesn't support this feature while SLF4J and Log4j 2.x does (see https://logging.apache.org/log4j/2.x/manual/markers.html).