### PR TITLE
Add regex replace extractor

### DIFF
--- a/graylog2-plugin-interfaces/src/main/java/org/graylog2/plugin/inputs/Extractor.java
+++ b/graylog2-plugin-interfaces/src/main/java/org/graylog2/plugin/inputs/Extractor.java
@@ -67,6 +67,7 @@ public abstract class Extractor implements EmbeddedPersistable {
     public enum Type {
         SUBSTRING,
         REGEX,
+        REGEX_REPLACE,
         SPLIT_AND_INDEX,
         COPY_INPUT,
         GROK,

--- a/graylog2-rest-client/src/main/java/org/graylog2/restclient/models/Extractor.java
+++ b/graylog2-rest-client/src/main/java/org/graylog2/restclient/models/Extractor.java
@@ -51,6 +51,7 @@ public class Extractor {
     public enum Type {
         SUBSTRING("Substring"),
         REGEX("Regular expression"),
+        REGEX_REPLACE("Replace with regular expression"),
         SPLIT_AND_INDEX("Split & Index"),
         COPY_INPUT("Copy Input"),
         GROK("Grok pattern"),
@@ -175,6 +176,9 @@ public class Extractor {
                 break;
             case SPLIT_AND_INDEX:
                 loadSplitAndIndexConfig(form);
+                break;
+            case REGEX_REPLACE:
+                loadRegexReplaceConfig(form);
                 break;
             case GROK:
                 loadGrokConfig(form);
@@ -338,6 +342,19 @@ public class Extractor {
 
         extractorConfig.put("split_by", form.get("split_by")[0]);
         extractorConfig.put("index", Integer.parseInt(form.get("index")[0]));
+    }
+
+    private void loadRegexReplaceConfig(Map<String, String[]> form) {
+        if (!formFieldSet(form, "regex")) {
+            throw new RuntimeException("Missing extractor config: regex.");
+        }
+
+        extractorConfig.put("regex", form.get("regex")[0]);
+        extractorConfig.put("replace_all", form.containsKey("replace_all"));
+
+        if (formFieldSet(form, "replacement")) {
+            extractorConfig.put("replacement", form.get("replacement")[0]);
+        }
     }
 
     private void loadGrokConfig(Map<String, String[]> form) {

--- a/graylog2-rest-client/src/test/java/org/graylog2/restclient/models/ExtractorTest.java
+++ b/graylog2-rest-client/src/test/java/org/graylog2/restclient/models/ExtractorTest.java
@@ -93,6 +93,18 @@ public class ExtractorTest {
     }
 
     @Test
+    public void loadConfigFromImportSucceedsWithValidConfigForRegexReplaceExtractor() throws Exception {
+        extractor.loadConfigFromImport(
+                Extractor.Type.REGEX_REPLACE,
+                ImmutableMap.<String, Object>of(
+                        "regex", "foobar",
+                        "replacement", "***"
+                ));
+        assertEquals(extractor.getExtractorConfig().get("regex"), "foobar");
+        assertEquals(extractor.getExtractorConfig().get("replacement"), "***");
+    }
+
+    @Test
     public void loadConfigFromImportSucceedsWithValidConfigForSubstringExtractor() throws Exception {
         extractor.loadConfigFromImport(
                 Extractor.Type.SUBSTRING,
@@ -134,6 +146,14 @@ public class ExtractorTest {
         expectedException.expectMessage("Missing extractor config:");
 
         extractor.loadConfigFromImport(Extractor.Type.SUBSTRING, Collections.<String, Object>emptyMap());
+    }
+
+    @Test
+    public void loadConfigFromImportFailsWithEmptyConfigForRegexReplaceExtractor() throws Exception {
+        expectedException.expect(RuntimeException.class);
+        expectedException.expectMessage("Missing extractor config:");
+
+        extractor.loadConfigFromImport(Extractor.Type.REGEX_REPLACE, Collections.<String, Object>emptyMap());
     }
 
     @Test

--- a/graylog2-rest-models/src/main/java/org/graylog2/rest/models/tools/requests/RegexReplaceTestRequest.java
+++ b/graylog2-rest-models/src/main/java/org/graylog2/rest/models/tools/requests/RegexReplaceTestRequest.java
@@ -1,0 +1,53 @@
+/**
+ * This file is part of Graylog.
+ *
+ * Graylog is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.graylog2.rest.models.tools.requests;
+
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.auto.value.AutoValue;
+import org.hibernate.validator.constraints.NotEmpty;
+
+import javax.validation.constraints.NotNull;
+
+@JsonAutoDetect
+@AutoValue
+public abstract class RegexReplaceTestRequest {
+    @JsonProperty
+    @NotNull
+    public abstract String string();
+
+    @JsonProperty
+    @NotEmpty
+    public abstract String regex();
+
+    @JsonProperty
+    @NotNull
+    public abstract String replacement();
+
+    @JsonProperty("replace_all")
+    public abstract boolean replaceAll();
+
+    @JsonCreator
+    public static RegexReplaceTestRequest create(@JsonProperty("string") @NotNull String string,
+                                                 @JsonProperty("regex") @NotEmpty String regex,
+                                                 @JsonProperty("replacement") @NotNull String replacement,
+                                                 @JsonProperty("replace_all") boolean replaceAll) {
+        return new AutoValue_RegexReplaceTestRequest(string, regex, replacement, replaceAll);
+    }
+}

--- a/graylog2-rest-models/src/main/java/org/graylog2/rest/models/tools/responses/RegexReplaceTesterResponse.java
+++ b/graylog2-rest-models/src/main/java/org/graylog2/rest/models/tools/responses/RegexReplaceTesterResponse.java
@@ -1,0 +1,79 @@
+/**
+ * This file is part of Graylog.
+ *
+ * Graylog is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.graylog2.rest.models.tools.responses;
+
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.auto.value.AutoValue;
+
+import javax.annotation.Nullable;
+
+@JsonAutoDetect
+@AutoValue
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public abstract class RegexReplaceTesterResponse {
+    @JsonProperty
+    public abstract boolean matched();
+
+    @JsonProperty
+    @Nullable
+    public abstract Match match();
+
+    @JsonProperty
+    public abstract String regex();
+
+    @JsonProperty
+    public abstract String replacement();
+
+    @JsonProperty("replace_all")
+    public abstract boolean replaceAll();
+
+    @JsonProperty
+    public abstract String string();
+
+    @JsonCreator
+    public static RegexReplaceTesterResponse create(@JsonProperty("matched") boolean matched,
+                                                    @JsonProperty("match") @Nullable Match match,
+                                                    @JsonProperty("regex") String regex,
+                                                    @JsonProperty("replacement") String replacement,
+                                                    @JsonProperty("replace_all") boolean replaceAll,
+                                                    @JsonProperty("string") String string) {
+        return new AutoValue_RegexReplaceTesterResponse(matched, match, regex, replacement, replaceAll, string);
+    }
+
+    @JsonAutoDetect
+    @AutoValue
+    public static abstract class Match {
+        @JsonProperty
+        public abstract String match();
+
+        @JsonProperty
+        public abstract int start();
+
+        @JsonProperty
+        public abstract int end();
+
+        @JsonCreator
+        public static Match create(@JsonProperty("match") String match,
+                                   @JsonProperty("start") int start,
+                                   @JsonProperty("end") int end) {
+            return new AutoValue_RegexReplaceTesterResponse_Match(match, start, end);
+        }
+    }
+}

--- a/graylog2-server/src/main/java/org/graylog2/inputs/extractors/ExtractorFactory.java
+++ b/graylog2-server/src/main/java/org/graylog2/inputs/extractors/ExtractorFactory.java
@@ -59,6 +59,8 @@ public class ExtractorFactory {
                 return new SplitAndIndexExtractor(metricRegistry, id, title, order, cursorStrategy, sourceField, targetField, extractorConfig, creatorUserId, converters, conditionType, conditionValue);
             case COPY_INPUT:
                 return new CopyInputExtractor(metricRegistry, id, title, order, cursorStrategy, sourceField, targetField, extractorConfig, creatorUserId, converters, conditionType, conditionValue);
+            case REGEX_REPLACE:
+                return new RegexReplaceExtractor(metricRegistry, id, title, order, cursorStrategy, sourceField, targetField, extractorConfig, creatorUserId, converters, conditionType, conditionValue);
             case GROK:
                 return new GrokExtractor(metricRegistry, grokPatternService.loadAll(), id, title, order, cursorStrategy, sourceField, targetField, extractorConfig, creatorUserId, converters, conditionType, conditionValue);
             case JSON:

--- a/graylog2-server/src/main/java/org/graylog2/inputs/extractors/RegexReplaceExtractor.java
+++ b/graylog2-server/src/main/java/org/graylog2/inputs/extractors/RegexReplaceExtractor.java
@@ -1,0 +1,106 @@
+/**
+ * This file is part of Graylog.
+ *
+ * Graylog is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.graylog2.inputs.extractors;
+
+import com.codahale.metrics.MetricRegistry;
+import org.graylog2.ConfigurationException;
+import org.graylog2.plugin.inputs.Converter;
+import org.graylog2.plugin.inputs.Extractor;
+
+import java.util.List;
+import java.util.Map;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import static com.google.common.base.Strings.isNullOrEmpty;
+
+public class RegexReplaceExtractor extends Extractor {
+    private static final String CONFIG_REGEX = "regex";
+    private static final String CONFIG_REPLACEMENT = "replacement";
+    private static final String CONFIG_REPLACE_ALL = "replace_all";
+    private static final String DEFAULT_REPLACE_VALUE = "$1";
+
+    private final Pattern pattern;
+    private final String replacement;
+    private final boolean replaceAll;
+
+    public RegexReplaceExtractor(final MetricRegistry metricRegistry,
+                                 final String id,
+                                 final String title,
+                                 final long order,
+                                 final CursorStrategy cursorStrategy,
+                                 final String sourceField,
+                                 final String targetField,
+                                 final Map<String, Object> extractorConfig,
+                                 final String creatorUserId,
+                                 final List<Converter> converters,
+                                 final ConditionType conditionType,
+                                 final String conditionValue) throws ReservedFieldException, ConfigurationException {
+        super(metricRegistry, id, title, order, Type.REGEX_REPLACE, cursorStrategy, sourceField, targetField, extractorConfig, creatorUserId, converters, conditionType, conditionValue);
+
+        if (extractorConfig == null || extractorConfig.isEmpty()) {
+            throw new ConfigurationException("Missing configuration");
+        }
+
+        final Object configRegexValue = extractorConfig.get(CONFIG_REGEX);
+        if (!(configRegexValue instanceof String) || ((String) configRegexValue).isEmpty()) {
+            throw new ConfigurationException("Missing configuration field: " + CONFIG_REGEX);
+        }
+
+        final Object configReplaceValue = extractorConfig.get(CONFIG_REPLACEMENT);
+        if (configReplaceValue != null && !(configReplaceValue instanceof String)) {
+            throw new ConfigurationException("Missing configuration field: " + CONFIG_REPLACEMENT);
+        }
+
+        final Object configReplaceAll = extractorConfig.get(CONFIG_REPLACE_ALL);
+        if (configReplaceAll != null && !(configReplaceAll instanceof Boolean)) {
+            throw new ConfigurationException("Missing configuration field: " + CONFIG_REPLACE_ALL);
+        }
+
+        this.pattern = Pattern.compile((String) configRegexValue, Pattern.DOTALL);
+        this.replacement = isNullOrEmpty((String) configReplaceValue) ? DEFAULT_REPLACE_VALUE : (String) configReplaceValue;
+        this.replaceAll = configReplaceAll == null ? false : (boolean) configReplaceAll;
+    }
+
+    @Override
+    protected Result[] run(String value) {
+        final Result result = runExtractor(value);
+        return result == null ? null : new Result[]{result};
+    }
+
+    public Result runExtractor(String value) {
+        final Matcher matcher = pattern.matcher(value);
+
+        final boolean found = matcher.find();
+        if (!found) {
+            return null;
+        }
+
+        final int start = matcher.groupCount() > 0 ? matcher.start(1) : -1;
+        final int end = matcher.groupCount() > 0 ? matcher.end(1) : -1;
+
+        final String s;
+        try {
+            s = replaceAll ? matcher.replaceAll(replacement) : matcher.replaceFirst(replacement);
+        } catch (Exception e) {
+            throw new RuntimeException("Error while trying to replace string", e);
+        }
+
+        return new Result(s, start, end);
+    }
+
+}

--- a/graylog2-server/src/main/java/org/graylog2/rest/resources/tools/RegexReplaceTesterResource.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/resources/tools/RegexReplaceTesterResource.java
@@ -1,0 +1,91 @@
+/**
+ * This file is part of Graylog.
+ *
+ * Graylog is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.graylog2.rest.resources.tools;
+
+import com.codahale.metrics.MetricRegistry;
+import com.codahale.metrics.annotation.Timed;
+import com.google.common.collect.ImmutableMap;
+import org.apache.shiro.authz.annotation.RequiresAuthentication;
+import org.graylog2.ConfigurationException;
+import org.graylog2.inputs.extractors.RegexReplaceExtractor;
+import org.graylog2.plugin.inputs.Converter;
+import org.graylog2.plugin.inputs.Extractor;
+import org.graylog2.rest.models.tools.requests.RegexReplaceTestRequest;
+import org.graylog2.rest.models.tools.responses.RegexReplaceTesterResponse;
+import org.graylog2.shared.rest.resources.RestResource;
+import org.hibernate.validator.constraints.NotEmpty;
+
+import javax.validation.Valid;
+import javax.validation.constraints.NotNull;
+import javax.ws.rs.BadRequestException;
+import javax.ws.rs.Consumes;
+import javax.ws.rs.DefaultValue;
+import javax.ws.rs.GET;
+import javax.ws.rs.POST;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.QueryParam;
+import javax.ws.rs.core.MediaType;
+import java.util.Collections;
+import java.util.Map;
+
+@RequiresAuthentication
+@Path("/tools/regex_replace_tester")
+public class RegexReplaceTesterResource extends RestResource {
+    @GET
+    @Timed
+    @Produces(MediaType.APPLICATION_JSON)
+    public RegexReplaceTesterResponse regexTester(@QueryParam("regex") @NotEmpty String regex,
+                                                  @QueryParam("replacement") @NotNull String replacement,
+                                                  @QueryParam("replace_all") @DefaultValue("false") boolean replaceAll,
+                                                  @QueryParam("string") @NotNull String string) {
+        return testRegexReplaceExtractor(string, regex, replacement, replaceAll);
+    }
+
+    @POST
+    @Timed
+    @Consumes(MediaType.APPLICATION_JSON)
+    @Produces(MediaType.APPLICATION_JSON)
+    public RegexReplaceTesterResponse testRegex(@Valid @NotNull RegexReplaceTestRequest r) {
+        return testRegexReplaceExtractor(r.string(), r.regex(), r.replacement(), r.replaceAll());
+    }
+
+    private RegexReplaceTesterResponse testRegexReplaceExtractor(String example, String regex, String replacement, boolean replaceAll) {
+        final Map<String, Object> config = ImmutableMap.<String, Object>of(
+                "regex", regex,
+                "replacement", replacement,
+                "replace_all", replaceAll
+        );
+        final RegexReplaceExtractor extractor;
+        try {
+            extractor = new RegexReplaceExtractor(
+                    new MetricRegistry(), "test", "Test", 0L, Extractor.CursorStrategy.COPY, "test", "test",
+                    config, getCurrentUser().getName(), Collections.<Converter>emptyList(), Extractor.ConditionType.NONE, ""
+            );
+        } catch (Extractor.ReservedFieldException e) {
+            throw new BadRequestException("Trying to overwrite a reserved message field", e);
+        } catch (ConfigurationException e) {
+            throw new BadRequestException("Invalid extractor configuration", e);
+        }
+
+        final Extractor.Result result = extractor.runExtractor(example);
+        final RegexReplaceTesterResponse.Match match = result == null ? null :
+                RegexReplaceTesterResponse.Match.create(String.valueOf(result.getValue()), result.getBeginIndex(), result.getEndIndex());
+        return RegexReplaceTesterResponse.create(result != null, match, regex, replacement, replaceAll, example);
+    }
+}

--- a/graylog2-server/src/test/java/org/graylog2/inputs/extractors/RegexReplaceExtractorTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/inputs/extractors/RegexReplaceExtractorTest.java
@@ -1,0 +1,206 @@
+/**
+ * This file is part of Graylog.
+ *
+ * Graylog is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.graylog2.inputs.extractors;
+
+import org.elasticsearch.common.collect.ImmutableMap;
+import org.graylog2.ConfigurationException;
+import org.graylog2.plugin.Message;
+import org.graylog2.plugin.Tools;
+import org.graylog2.plugin.inputs.Converter;
+import org.graylog2.plugin.inputs.Extractor;
+import org.junit.Test;
+
+import java.util.Collections;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class RegexReplaceExtractorTest extends AbstractExtractorTest {
+    @Test(expected = ConfigurationException.class)
+    public void testConstructorWithMissingRegex() throws Exception {
+        new RegexReplaceExtractor(
+                metricRegistry,
+                "id",
+                "title",
+                0L,
+                Extractor.CursorStrategy.COPY,
+                "message",
+                "message",
+                ImmutableMap.<String, Object>of(),
+                "user",
+                Collections.<Converter>emptyList(),
+                Extractor.ConditionType.NONE,
+                null);
+    }
+
+    @Test(expected = ConfigurationException.class)
+    public void testConstructorWithNonStringRegex() throws Exception {
+        new RegexReplaceExtractor(
+                metricRegistry,
+                "id",
+                "title",
+                0L,
+                Extractor.CursorStrategy.COPY,
+                "message",
+                "message",
+                ImmutableMap.<String, Object>of("regex", 0L),
+                "user",
+                Collections.<Converter>emptyList(),
+                Extractor.ConditionType.NONE,
+                null);
+    }
+
+    @Test(expected = ConfigurationException.class)
+    public void testConstructorWithNonStringReplacement() throws Exception {
+        new RegexReplaceExtractor(
+                metricRegistry,
+                "id",
+                "title",
+                0L,
+                Extractor.CursorStrategy.COPY,
+                "message",
+                "message",
+                ImmutableMap.<String, Object>of("regex", "NO-MATCH", "replacement", 0L),
+                "user",
+                Collections.<Converter>emptyList(),
+                Extractor.ConditionType.NONE,
+                null);
+    }
+
+    @Test
+    public void testReplacementWithNoMatchAndDefaultReplacement() throws Exception {
+        final Message message = new Message("Test", "source", Tools.iso8601());
+        final RegexReplaceExtractor extractor = new RegexReplaceExtractor(
+                metricRegistry,
+                "id",
+                "title",
+                0L,
+                Extractor.CursorStrategy.COPY,
+                "message",
+                "message",
+                ImmutableMap.<String, Object>of("regex", "NO-MATCH"),
+                "user",
+                Collections.<Converter>emptyList(),
+                Extractor.ConditionType.NONE,
+                null);
+        extractor.runExtractor(message);
+
+        assertThat(message.getMessage()).isEqualTo("Test");
+    }
+
+    @Test
+    public void testReplacementWithOnePlaceholder() throws Exception {
+        final Message message = new Message("Test Foobar", "source", Tools.iso8601());
+        final RegexReplaceExtractor extractor = new RegexReplaceExtractor(
+                metricRegistry,
+                "id",
+                "title",
+                0L,
+                Extractor.CursorStrategy.COPY,
+                "message",
+                "message",
+                ImmutableMap.<String, Object>of("regex", "Test (\\w+)"),
+                "user",
+                Collections.<Converter>emptyList(),
+                Extractor.ConditionType.NONE,
+                null);
+        extractor.runExtractor(message);
+
+        assertThat(message.getMessage()).isEqualTo("Foobar");
+    }
+
+    @Test(expected = RuntimeException.class)
+    public void testReplacementWithTooManyPlaceholders() throws Exception {
+        final Message message = new Message("Foobar 123", "source", Tools.iso8601());
+        final RegexReplaceExtractor extractor = new RegexReplaceExtractor(
+                metricRegistry,
+                "id",
+                "title",
+                0L,
+                Extractor.CursorStrategy.COPY,
+                "message",
+                "message",
+                ImmutableMap.<String, Object>of("regex", "Foobar (\\d+)", "replacement", "$1 $2"),
+                "user",
+                Collections.<Converter>emptyList(),
+                Extractor.ConditionType.NONE,
+                null);
+        extractor.runExtractor(message);
+    }
+
+    @Test
+    public void testReplacementWithCustomReplacement() throws Exception {
+        final Message message = new Message("Foobar 123", "source", Tools.iso8601());
+        final RegexReplaceExtractor extractor = new RegexReplaceExtractor(
+                metricRegistry,
+                "id",
+                "title",
+                0L,
+                Extractor.CursorStrategy.COPY,
+                "message",
+                "message",
+                ImmutableMap.<String, Object>of("regex", "(Foobar) (\\d+)", "replacement", "$2/$1"),
+                "user",
+                Collections.<Converter>emptyList(),
+                Extractor.ConditionType.NONE,
+                null);
+        extractor.runExtractor(message);
+
+        assertThat(message.getMessage()).isEqualTo("123/Foobar");
+    }
+
+    @Test
+    public void testReplacementWithReplaceAll() throws Exception {
+        final Message message = new Message("Foobar 123 Foobaz 456", "source", Tools.iso8601());
+        final RegexReplaceExtractor extractor = new RegexReplaceExtractor(
+                metricRegistry,
+                "id",
+                "title",
+                0L,
+                Extractor.CursorStrategy.COPY,
+                "message",
+                "message",
+                ImmutableMap.<String, Object>of("regex", "(\\w+) (\\d+)", "replacement", "$2/$1", "replace_all", true),
+                "user",
+                Collections.<Converter>emptyList(),
+                Extractor.ConditionType.NONE,
+                null);
+        extractor.runExtractor(message);
+
+        assertThat(message.getMessage()).isEqualTo("123/Foobar 456/Foobaz");
+    }
+
+    @Test
+    public void testReplacementWithoutReplaceAll() throws Exception {
+        final Message message = new Message("Foobar 123 Foobaz 456", "source", Tools.iso8601());
+        final RegexReplaceExtractor extractor = new RegexReplaceExtractor(
+                metricRegistry,
+                "id",
+                "title",
+                0L,
+                Extractor.CursorStrategy.COPY,
+                "message",
+                "message",
+                ImmutableMap.<String, Object>of("regex", "(\\w+) (\\d+)", "replacement", "$2/$1", "replace_all", false),
+                "user",
+                Collections.<Converter>emptyList(),
+                Extractor.ConditionType.NONE,
+                null);
+        extractor.runExtractor(message);
+
+        assertThat(message.getMessage()).isEqualTo("123/Foobar Foobaz 456");
+    }
+}


### PR DESCRIPTION
This PR adds an extractor which supports replacing a message field with a constant value or the matches of a regular expression.

Similar to the already existing Regex extractor, this extractor tries to match a regular expression against a message field (see [`Pattern`](https://docs.oracle.com/javase/8/docs/api/java/util/regex/Pattern.html)) and replaces its value (or the value of the target field) with the string configured in the "replacement" setting (see [`Matcher#replaceAll()`](https://docs.oracle.com/javase/8/docs/api/java/util/regex/Matcher.html#replaceAll-java.lang.String-)). The extractor also allows to only replace the first match or all matches (default).

Supersedes #1466.