### PR TITLE
Use a better default for ring sizes

### DIFF
--- a/misc/graylog2.conf
+++ b/misc/graylog2.conf
@@ -242,9 +242,9 @@ processor_wait_strategy = blocking
 # For optimum performance your LogMessage objects in the ring buffer should fit in your CPU L3 cache.
 # Start server with --statistics flag to see buffer utilization.
 # Must be a power of 2. (512, 1024, 2048, ...)
-ring_size = 65536
+ring_size = 4096
 
-inputbuffer_ring_size = 65536
+inputbuffer_ring_size = 4096
 inputbuffer_processors = 2
 inputbuffer_wait_strategy = blocking
 


### PR DESCRIPTION
I just realized that our ring sizes are still having a default size that comes from the pre-journal age when they acted as buffers in case of backing up messages. When messages queue up, the rings will fill up before the journal starts backing up. This can lead to the objects in there being promoted down the memory pool chain and really funky GC behavior with stop the worlds that make the existing problems (why the journal is backing up) even worse.

Also all that memory is pre-allocated at the start and just eats up tons of heap for nothing. I have not yet seen a setup processing so many messages to reasonably use so many slots in the rings.

4096 seems to be a reasonable default for me. 

Do our packages use this config file or would we have to update those, too? (cc @mariussturm @bernd)