### PR TITLE
Handle user email values with multiple addresses

### DIFF
--- a/graylog2-plugin-interfaces/src/main/java/org/graylog2/plugin/database/users/User.java
+++ b/graylog2-plugin-interfaces/src/main/java/org/graylog2/plugin/database/users/User.java
@@ -55,6 +55,14 @@ public interface User extends Persisted {
 
     void setName(String username);
 
+    /**
+     * Returns the email address of the user.
+     *
+     * Depending on how the user has been created, it is possible that the returned string contains multiple email
+     * addresses separated by a "," character. (i.e. LDAP users)
+     *
+     * @return the email address
+     */
     String getEmail();
 
     List<String> getPermissions();


### PR DESCRIPTION
LDAP users can have multiple addresses in the email field. Split the email field on the "," character and add all addresses as recipient.

Convert recipients to a Set to avoid sending duplicate emails.

Fixes #1439