### PR TITLE
Improve compatibility with different LDAP schemas

### DIFF
--- a/graylog2-server/pom.xml
+++ b/graylog2-server/pom.xml
@@ -327,6 +327,14 @@
             <groupId>org.jukito</groupId>
             <artifactId>jukito</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.apache.directory.server</groupId>
+            <artifactId>apacheds-test-framework</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.directory.server</groupId>
+            <artifactId>ldap-client-test</artifactId>
+        </dependency>
     </dependencies>
 
     <build>

--- a/graylog2-server/src/main/java/org/graylog2/security/ldap/LdapConnector.java
+++ b/graylog2-server/src/main/java/org/graylog2/security/ldap/LdapConnector.java
@@ -131,7 +131,7 @@ public class LdapConnector {
             entryCursor = connection.search(searchBase,
                                             filter,
                                             SearchScope.SUBTREE,
-                                            groupIdAttribute, displayNameAttribute, "dn", "userPrincipalName", "mail", "rfc822Mailbox", "memberOf");
+                                            groupIdAttribute, displayNameAttribute, "dn", "uid", "userPrincipalName", "mail", "rfc822Mailbox", "memberOf");
             final Iterator<Entry> it = entryCursor.iterator();
             if (it.hasNext()) {
                 final Entry e = it.next();

--- a/graylog2-server/src/main/java/org/graylog2/security/ldap/LdapConnector.java
+++ b/graylog2-server/src/main/java/org/graylog2/security/ldap/LdapConnector.java
@@ -241,7 +241,11 @@ public class LdapConnector {
                     } else if (e.hasObjectClass("groupOfNames") || e.hasObjectClass("group")) {
                         memberAttribute = ATTRIBUTE_MEMBER;
                     } else {
-                        memberAttribute = ATTRIBUTE_MEMBER;
+                        if (e.containsAttribute(ATTRIBUTE_UNIQUE_MEMBER)) {
+                            memberAttribute = ATTRIBUTE_UNIQUE_MEMBER;
+                        } else {
+                            memberAttribute = ATTRIBUTE_MEMBER;
+                        }
                         LOG.warn(
                                 "Unable to auto-detect the LDAP group object class, assuming '{}' is the correct attribute.",
                                 memberAttribute);

--- a/graylog2-server/src/main/java/org/graylog2/security/ldap/LdapConnector.java
+++ b/graylog2-server/src/main/java/org/graylog2/security/ldap/LdapConnector.java
@@ -57,6 +57,9 @@ import static com.google.common.base.Strings.isNullOrEmpty;
 public class LdapConnector {
     private static final Logger LOG = LoggerFactory.getLogger(LdapConnector.class);
 
+    private static final String ATTRIBUTE_UNIQUE_MEMBER = "uniqueMember";
+    private static final String ATTRIBUTE_MEMBER = "member";
+
     private final int connectionTimeout;
 
     @Inject
@@ -216,7 +219,7 @@ public class LdapConnector {
                     groupSearchBase,
                     groupSearchPattern,
                     SearchScope.SUBTREE,
-                    "objectClass", "uniqueMember", "member", groupIdAttribute);
+                    "objectClass", ATTRIBUTE_UNIQUE_MEMBER, ATTRIBUTE_MEMBER, groupIdAttribute);
             LOG.trace("LDAP search for groups: {} starting at {}", groupSearchPattern, groupSearchBase);
             for (Entry e : groupSearch) {
                 if (LOG.isTraceEnabled()) {
@@ -234,13 +237,14 @@ public class LdapConnector {
                     // test if the given dn parameter is actually member of any of the found groups
                     String memberAttribute;
                     if (e.hasObjectClass("groupOfUniqueNames")) {
-                        memberAttribute = "uniqueMember";
+                        memberAttribute = ATTRIBUTE_UNIQUE_MEMBER;
                     } else if (e.hasObjectClass("groupOfNames") || e.hasObjectClass("group")) {
-                        memberAttribute = "member";
+                        memberAttribute = ATTRIBUTE_MEMBER;
                     } else {
+                        memberAttribute = ATTRIBUTE_MEMBER;
                         LOG.warn(
-                                "Unable to auto-detect the LDAP group object class, assuming 'member' is the correct attribute.");
-                        memberAttribute = "member";
+                                "Unable to auto-detect the LDAP group object class, assuming '{}' is the correct attribute.",
+                                memberAttribute);
                     }
                     final Attribute members = e.get(memberAttribute);
                     if (members != null) {

--- a/graylog2-server/src/test/java/org/graylog2/security/ldap/LdapConnectorTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/security/ldap/LdapConnectorTest.java
@@ -21,7 +21,7 @@ import org.apache.directory.ldap.client.api.LdapConnectionConfig;
 import org.apache.directory.ldap.client.api.LdapNetworkConnection;
 import org.apache.directory.server.annotations.CreateLdapServer;
 import org.apache.directory.server.annotations.CreateTransport;
-import org.apache.directory.server.core.annotations.ApplyLdifs;
+import org.apache.directory.server.core.annotations.ApplyLdifFiles;
 import org.apache.directory.server.core.annotations.ContextEntry;
 import org.apache.directory.server.core.annotations.CreateDS;
 import org.apache.directory.server.core.annotations.CreateIndex;
@@ -71,50 +71,7 @@ import static org.assertj.core.api.Assertions.assertThat;
                 @LoadSchema(name = "nis", enabled = true)
         }
 )
-@ApplyLdifs(
-        {
-                "dn: ou=users,dc=example,dc=com",
-                "objectClass: organizationalUnit",
-                "objectClass: top",
-                "ou: users",
-
-                "dn: ou=groups,dc=example,dc=com",
-                "objectClass: organizationalUnit",
-                "objectClass: top",
-                "ou: groups",
-
-                "dn: cn=John Doe,ou=users,dc=example,dc=com",
-                "gidNumber: 1001",
-                "objectClass: posixAccount",
-                "objectClass: top",
-                "objectClass: person",
-                "uidNumber: 1001",
-                "uid: john",
-                "homeDirectory: /home/john",
-                "sn: Doe",
-                "cn: John Doe",
-                "userPassword:: dGVzdA==",
-
-                "dn: cn=Developers,ou=groups,dc=example,dc=com",
-                "gidNumber: 2000",
-                "objectClass: posixGroup",
-                "objectClass: top",
-                "cn: Developers",
-                "memberUid: john",
-
-                "dn: cn=Engineers,ou=groups,dc=example,dc=com",
-                "objectClass: groupOfUniqueNames",
-                "objectClass: top",
-                "cn: Engineers",
-                "uniqueMember: cn=John Doe,ou=users,dc=example,dc=com",
-
-                "dn: cn=QA,ou=groups,dc=example,dc=com",
-                "objectClass: groupOfNames",
-                "objectClass: top",
-                "cn: QA",
-                "member: cn=John Doe,ou=users,dc=example,dc=com"
-        }
-)
+@ApplyLdifFiles("org/graylog2/security/ldap/base.ldif")
 public class LdapConnectorTest extends AbstractLdapTestUnit {
     private static final String ADMIN_DN = "uid=admin,ou=system";
     private static final String ADMIN_PASSWORD = "secret";

--- a/graylog2-server/src/test/java/org/graylog2/security/ldap/LdapConnectorTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/security/ldap/LdapConnectorTest.java
@@ -1,0 +1,256 @@
+/**
+ * This file is part of Graylog.
+ *
+ * Graylog is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.graylog2.security.ldap;
+
+import org.apache.directory.ldap.client.api.LdapConnectionConfig;
+import org.apache.directory.ldap.client.api.LdapNetworkConnection;
+import org.apache.directory.server.annotations.CreateLdapServer;
+import org.apache.directory.server.annotations.CreateTransport;
+import org.apache.directory.server.core.annotations.ApplyLdifs;
+import org.apache.directory.server.core.annotations.ContextEntry;
+import org.apache.directory.server.core.annotations.CreateDS;
+import org.apache.directory.server.core.annotations.CreateIndex;
+import org.apache.directory.server.core.annotations.CreatePartition;
+import org.apache.directory.server.core.annotations.LoadSchema;
+import org.apache.directory.server.core.integ.AbstractLdapTestUnit;
+import org.apache.directory.server.core.integ.FrameworkRunner;
+import org.apache.directory.server.core.partition.impl.avl.AvlPartition;
+import org.apache.directory.server.ldap.LdapServer;
+import org.graylog2.shared.security.ldap.LdapEntry;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@RunWith(FrameworkRunner.class)
+@CreateLdapServer(transports = {
+        @CreateTransport(protocol = "LDAP")
+})
+@CreateDS(
+        name = "LdapConnectorTest",
+        partitions = {
+                @CreatePartition(
+                        name = "example.com",
+                        type = AvlPartition.class,
+                        suffix = "dc=example,dc=com",
+                        contextEntry = @ContextEntry(
+                                entryLdif = "dn: dc=example,dc=com\n" +
+                                            "dc: example\n" +
+                                            "objectClass: top\n" +
+                                            "objectClass: domain\n\n"
+
+                        ),
+                        indexes = {
+                                @CreateIndex(attribute = "objectClass"),
+                                @CreateIndex(attribute = "dc"),
+                                @CreateIndex(attribute = "ou")
+                        }
+
+                )
+        },
+        loadedSchemas = {
+                @LoadSchema(name = "nis", enabled = true)
+        }
+)
+@ApplyLdifs(
+        {
+                "dn: ou=users,dc=example,dc=com",
+                "objectClass: organizationalUnit",
+                "objectClass: top",
+                "ou: users",
+
+                "dn: ou=groups,dc=example,dc=com",
+                "objectClass: organizationalUnit",
+                "objectClass: top",
+                "ou: groups",
+
+                "dn: cn=John Doe,ou=users,dc=example,dc=com",
+                "gidNumber: 1001",
+                "objectClass: posixAccount",
+                "objectClass: top",
+                "objectClass: person",
+                "uidNumber: 1001",
+                "uid: john",
+                "homeDirectory: /home/john",
+                "sn: Doe",
+                "cn: John Doe",
+                "userPassword:: dGVzdA==",
+
+                "dn: cn=Developers,ou=groups,dc=example,dc=com",
+                "gidNumber: 2000",
+                "objectClass: posixGroup",
+                "objectClass: top",
+                "cn: Developers",
+                "memberUid: john",
+
+                "dn: cn=Engineers,ou=groups,dc=example,dc=com",
+                "objectClass: groupOfUniqueNames",
+                "objectClass: top",
+                "cn: Engineers",
+                "uniqueMember: cn=John Doe,ou=users,dc=example,dc=com",
+
+                "dn: cn=QA,ou=groups,dc=example,dc=com",
+                "objectClass: groupOfNames",
+                "objectClass: top",
+                "cn: QA",
+                "member: cn=John Doe,ou=users,dc=example,dc=com"
+        }
+)
+public class LdapConnectorTest extends AbstractLdapTestUnit {
+    private static final String ADMIN_DN = "uid=admin,ou=system";
+    private static final String ADMIN_PASSWORD = "secret";
+
+    private LdapConnector connector;
+    private LdapNetworkConnection connection;
+
+    @Before
+    public void setUp() throws Exception {
+        final LdapServer server = getLdapServer();
+        final LdapConnectionConfig config = new LdapConnectionConfig();
+
+        config.setLdapHost("localHost");
+        config.setLdapPort(server.getPort());
+        config.setName(ADMIN_DN);
+        config.setCredentials(ADMIN_PASSWORD);
+
+        connector = new LdapConnector(10000);
+        connection = connector.connect(config);
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        connection.close();
+    }
+
+    @Test
+    public void testUserLookup() throws Exception {
+        final LdapEntry entry = connector.search(connection,
+                "ou=users,dc=example,dc=com",
+                "(&(objectClass=posixAccount)(uid={0}))",
+                "cn",
+                "john",
+                false,
+                "ou=groups,dc=example,dc=com",
+                "cn",
+                "(|(objectClass=groupOfNames)(objectClass=posixGroup))");
+
+        assertThat(entry).isNotNull();
+        assertThat(entry.getDn())
+                .isNotNull()
+                .isEqualTo("cn=John Doe,ou=users,dc=example,dc=com");
+
+        assertThat(entry.getGroups())
+                .hasSize(2)
+                .contains("QA", "Developers");
+    }
+
+    @Test
+    public void testGroupOfNamesLookup() throws Exception {
+        final LdapEntry entry = connector.search(connection,
+                "ou=users,dc=example,dc=com",
+                "(&(objectClass=posixAccount)(uid={0}))",
+                "cn",
+                "john",
+                false,
+                "ou=groups,dc=example,dc=com",
+                "cn",
+                "(objectClass=groupOfNames)");
+
+        assertThat(entry).isNotNull();
+        assertThat(entry.getDn())
+                .isNotNull()
+                .isEqualTo("cn=John Doe,ou=users,dc=example,dc=com");
+
+        assertThat(entry.getGroups()).hasSize(1).contains("QA");
+    }
+
+    @Test
+    public void testGroupOfUniqueNamesLookup() throws Exception {
+        final LdapEntry entry = connector.search(connection,
+                "ou=users,dc=example,dc=com",
+                "(&(objectClass=posixAccount)(uid={0}))",
+                "cn",
+                "john",
+                false,
+                "ou=groups,dc=example,dc=com",
+                "cn",
+                "(objectClass=groupOfUniqueNames)");
+
+        assertThat(entry).isNotNull();
+        assertThat(entry.getDn())
+                .isNotNull()
+                .isEqualTo("cn=John Doe,ou=users,dc=example,dc=com");
+
+        assertThat(entry.getGroups()).hasSize(1).contains("Engineers");
+    }
+
+    @Test
+    public void testPosixGroupLookup() throws Exception {
+        final LdapEntry entry = connector.search(connection,
+                "ou=users,dc=example,dc=com",
+                "(&(objectClass=posixAccount)(uid={0}))",
+                "cn",
+                "john",
+                false,
+                "ou=groups,dc=example,dc=com",
+                "cn",
+                "(objectClass=posixGroup)");
+
+        assertThat(entry).isNotNull();
+        assertThat(entry.getDn())
+                .isNotNull()
+                .isEqualTo("cn=John Doe,ou=users,dc=example,dc=com");
+
+        assertThat(entry.getGroups()).hasSize(1).contains("Developers");
+    }
+
+    @Test
+    public void testAllGroupClassesLookup() throws Exception {
+        final LdapEntry entry = connector.search(connection,
+                "ou=users,dc=example,dc=com",
+                "(&(objectClass=posixAccount)(uid={0}))",
+                "cn",
+                "john",
+                false,
+                "ou=groups,dc=example,dc=com",
+                "cn",
+                "(|(objectClass=posixGroup)(objectClass=groupOfNames)(objectclass=groupOfUniqueNames))");
+
+        assertThat(entry).isNotNull();
+        assertThat(entry.getDn())
+                .isNotNull()
+                .isEqualTo("cn=John Doe,ou=users,dc=example,dc=com");
+
+        assertThat(entry.getGroups())
+                .hasSize(3)
+                .contains("Developers", "QA", "Engineers");
+    }
+
+    @Test
+    public void testListGroups() throws Exception {
+        final Set<String> groups = connector.listGroups(connection, "ou=groups,dc=example,dc=com", "(objectClass=top)", "cn");
+
+        assertThat(groups)
+                .hasSize(3)
+                .contains("Developers", "QA", "Engineers");
+    }
+}

--- a/graylog2-server/src/test/resources/org/graylog2/security/ldap/base.ldif
+++ b/graylog2-server/src/test/resources/org/graylog2/security/ldap/base.ldif
@@ -1,0 +1,42 @@
+# Make sure the "nis" schema is enabled in the LDAP server and the dc=example,dc=com context exists.
+
+dn: ou=users,dc=example,dc=com
+objectClass: organizationalUnit
+objectClass: top
+ou: users
+
+dn: ou=groups,dc=example,dc=com
+objectClass: organizationalUnit
+objectClass: top
+ou: groups
+
+dn: cn=John Doe,ou=users,dc=example,dc=com
+gidNumber: 1001
+objectClass: posixAccount
+objectClass: top
+objectClass: person
+uidNumber: 1001
+uid: john
+homeDirectory: /home/john
+sn: Doe
+cn: John Doe
+userPassword:: dGVzdA==
+
+dn: cn=Developers,ou=groups,dc=example,dc=com
+gidNumber: 2000
+objectClass: posixGroup
+objectClass: top
+cn: Developers
+memberUid: john
+
+dn: cn=Engineers,ou=groups,dc=example,dc=com
+objectClass: groupOfUniqueNames
+objectClass: top
+cn: Engineers
+uniqueMember: cn=John Doe,ou=users,dc=example,dc=com
+
+dn: cn=QA,ou=groups,dc=example,dc=com
+objectClass: groupOfNames
+objectClass: top
+cn: QA
+member: cn=John Doe,ou=users,dc=example,dc=com

--- a/pom.xml
+++ b/pom.xml
@@ -102,6 +102,7 @@
         <!-- The HK2 version should match the version being used by Jersey -->
         <glassfish-hk2.version>2.4.0-b25</glassfish-hk2.version>
         <apache-directory-version>1.0.0-M29</apache-directory-version>
+        <apacheds-server.version>2.0.0-M20</apacheds-server.version>
         <surefire.version>2.18.1</surefire.version>
         <guice.version>4.0</guice.version>
         <drools.version>6.2.0.Final</drools.version>
@@ -723,6 +724,32 @@
                 <artifactId>awaitility</artifactId>
                 <version>1.6.3</version>
                 <scope>test</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.directory.server</groupId>
+                <artifactId>apacheds-test-framework</artifactId>
+                <version>${apacheds-server.version}</version>
+                <scope>test</scope>
+                <exclusions>
+                    <!-- Exclude api-ldap-schema-data to avoid startup error with the embedded apache-ds -->
+                    <exclusion>
+                        <groupId>org.apache.directory.api</groupId>
+                        <artifactId>api-ldap-schema-data</artifactId>
+                    </exclusion>
+                </exclusions>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.directory.server</groupId>
+                <artifactId>ldap-client-test</artifactId>
+                <version>${apacheds-server.version}</version>
+                <scope>test</scope>
+                <exclusions>
+                    <!-- Exclude api-ldap-schema-data to avoid startup error with the embedded apache-ds -->
+                    <exclusion>
+                        <groupId>org.apache.directory.api</groupId>
+                        <artifactId>api-ldap-schema-data</artifactId>
+                    </exclusion>
+                </exclusions>
             </dependency>
             <dependency>
                 <groupId>org.graylog.plugins</groupId>


### PR DESCRIPTION
Improve the auto detection of the member attribute to support more LDAP setups out there. The member attribute should be configurable, but this will be done as a feature addition in the future because it's too much code for the stable release.

Also support `posixGroup` groups by checking for the `memberUid` attribute. The `memberUid` references a UID instead of a DN so we have to compare it against the UID of the LDAP entry.

Refs #1433