### PR TITLE
Fix SessionsResource / Add method to return stream rule types

### DIFF
--- a/graylog2-plugin-interfaces/src/main/java/org/graylog2/plugin/streams/StreamRuleType.java
+++ b/graylog2-plugin-interfaces/src/main/java/org/graylog2/plugin/streams/StreamRuleType.java
@@ -72,7 +72,6 @@ public enum StreamRuleType {
         throw new IllegalArgumentException("Invalid Stream Rule Type specified: " + name);
     }
 
-    @JsonValue
     public Map<String, Object> toMap() {
         final Map<String, Object> result = ImmutableMap.<String, Object>of(
                 "id", value,

--- a/graylog2-plugin-interfaces/src/main/java/org/graylog2/plugin/streams/StreamRuleType.java
+++ b/graylog2-plugin-interfaces/src/main/java/org/graylog2/plugin/streams/StreamRuleType.java
@@ -24,11 +24,6 @@ package org.graylog2.plugin.streams;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.annotation.JsonValue;
-import com.google.common.collect.ImmutableMap;
-
-import java.util.HashMap;
-import java.util.Map;
 
 public enum StreamRuleType {
     EXACT(1, "match exactly", "match exactly"),
@@ -51,7 +46,7 @@ public enum StreamRuleType {
         return value;
     }
 
-    public static StreamRuleType fromInteger(@JsonProperty("value") final int numeric) {
+    public static StreamRuleType fromInteger(final int numeric) {
         for (final StreamRuleType streamRuleType : StreamRuleType.values()) {
             if (streamRuleType.value == numeric) {
                 return streamRuleType;

--- a/graylog2-plugin-interfaces/src/main/java/org/graylog2/plugin/streams/StreamRuleType.java
+++ b/graylog2-plugin-interfaces/src/main/java/org/graylog2/plugin/streams/StreamRuleType.java
@@ -22,24 +22,36 @@
  */
 package org.graylog2.plugin.streams;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonValue;
+import com.google.common.collect.ImmutableMap;
+
+import java.util.HashMap;
+import java.util.Map;
+
 public enum StreamRuleType {
-    EXACT(1),
-    GREATER(3),
-    SMALLER(4),
-    REGEX(2),
-    PRESENCE(5);
+    EXACT(1, "match exactly", "match exactly"),
+    REGEX(2, "match regular expression", "match regular expression"),
+    GREATER(3, "greater than", "be greater than"),
+    SMALLER(4, "smaller than", "be smaller than"),
+    PRESENCE(5, "field presence", "be present");
 
     private final int value;
+    private final String shortDesc;
+    private final String longDesc;
 
-    StreamRuleType(final int value) {
+    StreamRuleType(final int value, final String shortDesc, final String longDesc) {
         this.value = value;
+        this.shortDesc = shortDesc;
+        this.longDesc = longDesc;
     }
 
     public int toInteger() {
         return value;
     }
 
-    public static StreamRuleType fromInteger(final int numeric) {
+    public static StreamRuleType fromInteger(@JsonProperty("value") final int numeric) {
         for (final StreamRuleType streamRuleType : StreamRuleType.values()) {
             if (streamRuleType.value == numeric) {
                 return streamRuleType;
@@ -47,5 +59,28 @@ public enum StreamRuleType {
         }
 
         return null;
+    }
+
+    @JsonCreator
+    public static StreamRuleType fromName(final String name) {
+        for (final StreamRuleType streamRuleType : StreamRuleType.values()) {
+            if (streamRuleType.name().equals(name)) {
+                return streamRuleType;
+            }
+        }
+
+        throw new IllegalArgumentException("Invalid Stream Rule Type specified: " + name);
+    }
+
+    @JsonValue
+    public Map<String, Object> toMap() {
+        final Map<String, Object> result = ImmutableMap.<String, Object>of(
+                "id", value,
+                "name", name(),
+                "short_desc", shortDesc,
+                "long_desc", longDesc
+        );
+
+        return result;
     }
 }

--- a/graylog2-plugin-interfaces/src/main/java/org/graylog2/plugin/streams/StreamRuleType.java
+++ b/graylog2-plugin-interfaces/src/main/java/org/graylog2/plugin/streams/StreamRuleType.java
@@ -72,14 +72,15 @@ public enum StreamRuleType {
         throw new IllegalArgumentException("Invalid Stream Rule Type specified: " + name);
     }
 
-    public Map<String, Object> toMap() {
-        final Map<String, Object> result = ImmutableMap.<String, Object>of(
-                "id", value,
-                "name", name(),
-                "short_desc", shortDesc,
-                "long_desc", longDesc
-        );
+    public int getValue() {
+        return value;
+    }
 
-        return result;
+    public String getShortDesc() {
+        return shortDesc;
+    }
+
+    public String getLongDesc() {
+        return longDesc;
     }
 }

--- a/graylog2-server/src/main/java/org/graylog2/rest/resources/streams/responses/StreamRuleTypeResponse.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/resources/streams/responses/StreamRuleTypeResponse.java
@@ -1,0 +1,30 @@
+package org.graylog2.rest.resources.streams.responses;
+
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.auto.value.AutoValue;
+
+@AutoValue
+@JsonAutoDetect
+public abstract class StreamRuleTypeResponse {
+    @JsonProperty
+    public abstract int id();
+
+    @JsonProperty
+    public abstract String name();
+
+    @JsonProperty("short_desc")
+    public abstract String shortDesc();
+
+    @JsonProperty("long_desc")
+    public abstract String longDesc();
+
+    @JsonCreator
+    public static StreamRuleTypeResponse create(@JsonProperty("id") int id,
+                                                @JsonProperty("name") String name,
+                                                @JsonProperty("short_desc") String shortDesc,
+                                                @JsonProperty("long_desc") String longDesc) {
+        return new AutoValue_StreamRuleTypeResponse(id, name, shortDesc, longDesc);
+    }
+}

--- a/graylog2-server/src/main/java/org/graylog2/rest/resources/streams/responses/StreamRuleTypeResponse.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/resources/streams/responses/StreamRuleTypeResponse.java
@@ -1,3 +1,19 @@
+/**
+ * This file is part of Graylog.
+ *
+ * Graylog is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package org.graylog2.rest.resources.streams.responses;
 
 import com.fasterxml.jackson.annotation.JsonAutoDetect;

--- a/graylog2-server/src/main/java/org/graylog2/rest/resources/streams/rules/StreamRuleResource.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/resources/streams/rules/StreamRuleResource.java
@@ -17,6 +17,7 @@
 package org.graylog2.rest.resources.streams.rules;
 
 import com.codahale.metrics.annotation.Timed;
+import com.google.common.collect.Lists;
 import com.wordnik.swagger.annotations.Api;
 import com.wordnik.swagger.annotations.ApiOperation;
 import com.wordnik.swagger.annotations.ApiParam;
@@ -52,6 +53,7 @@ import javax.ws.rs.Produces;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 import java.net.URI;
+import java.util.ArrayList;
 import java.util.List;
 
 @RequiresAuthentication
@@ -191,5 +193,20 @@ public class StreamRuleResource extends RestResource {
         } else {
             throw new NotFoundException();
         }
+    }
+
+    @GET
+    @Path("/types")
+    @Timed
+    @ApiOperation(value = "Get all available stream types")
+    @Produces(MediaType.APPLICATION_JSON)
+    public List<StreamRuleType> types(@ApiParam(name = "streamid", value = "The stream id this new rule belongs to.", required = true)
+                                          @PathParam("streamid") String streamid) {
+        final List<StreamRuleType> result = new ArrayList<>(StreamRuleType.values().length);
+        for (StreamRuleType type : StreamRuleType.values()) {
+            result.add(type);
+        }
+
+        return result;
     }
 }

--- a/graylog2-server/src/main/java/org/graylog2/rest/resources/streams/rules/StreamRuleResource.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/resources/streams/rules/StreamRuleResource.java
@@ -17,7 +17,6 @@
 package org.graylog2.rest.resources.streams.rules;
 
 import com.codahale.metrics.annotation.Timed;
-import com.google.common.collect.Lists;
 import com.wordnik.swagger.annotations.Api;
 import com.wordnik.swagger.annotations.ApiOperation;
 import com.wordnik.swagger.annotations.ApiParam;
@@ -29,10 +28,11 @@ import org.graylog2.plugin.database.ValidationException;
 import org.graylog2.plugin.streams.Stream;
 import org.graylog2.plugin.streams.StreamRule;
 import org.graylog2.plugin.streams.StreamRuleType;
-import org.graylog2.shared.rest.resources.RestResource;
 import org.graylog2.rest.resources.streams.responses.SingleStreamRuleSummaryResponse;
 import org.graylog2.rest.resources.streams.responses.StreamRuleListResponse;
+import org.graylog2.rest.resources.streams.responses.StreamRuleTypeResponse;
 import org.graylog2.rest.resources.streams.rules.requests.CreateStreamRuleRequest;
+import org.graylog2.shared.rest.resources.RestResource;
 import org.graylog2.shared.security.RestPermissions;
 import org.graylog2.streams.StreamRuleService;
 import org.graylog2.streams.StreamService;
@@ -55,7 +55,6 @@ import javax.ws.rs.core.Response;
 import java.net.URI;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Map;
 
 @RequiresAuthentication
 @Api(value = "StreamRules", description = "Manage stream rules")
@@ -201,11 +200,11 @@ public class StreamRuleResource extends RestResource {
     @Timed
     @ApiOperation(value = "Get all available stream types")
     @Produces(MediaType.APPLICATION_JSON)
-    public List<Map<String, Object>> types(@ApiParam(name = "streamid", value = "The stream id this new rule belongs to.", required = true)
+    public List<StreamRuleTypeResponse> types(@ApiParam(name = "streamid", value = "The stream id this new rule belongs to.", required = true)
                                           @PathParam("streamid") String streamid) {
-        final List<Map<String, Object>> result = new ArrayList<>(StreamRuleType.values().length);
+        final List<StreamRuleTypeResponse> result = new ArrayList<>(StreamRuleType.values().length);
         for (StreamRuleType type : StreamRuleType.values()) {
-            result.add(type.toMap());
+            result.add(StreamRuleTypeResponse.create(type.getValue(), type.name(), type.getShortDesc(), type.getLongDesc()));
         }
 
         return result;

--- a/graylog2-server/src/main/java/org/graylog2/rest/resources/streams/rules/StreamRuleResource.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/resources/streams/rules/StreamRuleResource.java
@@ -55,6 +55,7 @@ import javax.ws.rs.core.Response;
 import java.net.URI;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 
 @RequiresAuthentication
 @Api(value = "StreamRules", description = "Manage stream rules")
@@ -200,11 +201,11 @@ public class StreamRuleResource extends RestResource {
     @Timed
     @ApiOperation(value = "Get all available stream types")
     @Produces(MediaType.APPLICATION_JSON)
-    public List<StreamRuleType> types(@ApiParam(name = "streamid", value = "The stream id this new rule belongs to.", required = true)
+    public List<Map<String, Object>> types(@ApiParam(name = "streamid", value = "The stream id this new rule belongs to.", required = true)
                                           @PathParam("streamid") String streamid) {
-        final List<StreamRuleType> result = new ArrayList<>(StreamRuleType.values().length);
+        final List<Map<String, Object>> result = new ArrayList<>(StreamRuleType.values().length);
         for (StreamRuleType type : StreamRuleType.values()) {
-            result.add(type);
+            result.add(type.toMap());
         }
 
         return result;

--- a/graylog2-server/src/main/java/org/graylog2/rest/resources/streams/rules/StreamRuleResource.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/resources/streams/rules/StreamRuleResource.java
@@ -200,6 +200,7 @@ public class StreamRuleResource extends RestResource {
     @Timed
     @ApiOperation(value = "Get all available stream types")
     @Produces(MediaType.APPLICATION_JSON)
+    // TODO: Move this to a better place. This method is not related to a context that is bound to the instance of a stream.
     public List<StreamRuleTypeResponse> types(@ApiParam(name = "streamid", value = "The stream id this new rule belongs to.", required = true)
                                           @PathParam("streamid") String streamid) {
         final List<StreamRuleTypeResponse> result = new ArrayList<>(StreamRuleType.values().length);

--- a/graylog2-server/src/main/java/org/graylog2/rest/resources/system/SessionsResource.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/resources/system/SessionsResource.java
@@ -127,10 +127,5 @@ public class SessionsResource extends RestResource {
     public void terminateSession(@ApiParam(name = "sessionId", required = true) @PathParam("sessionId") String sessionId) {
         final Subject subject = getSubject();
         securityManager.logout(subject);
-
-        /*final org.apache.shiro.session.Session session = subject.getSession(false);
-        if (session == null || !session.getId().equals(sessionId)) {
-            throw new NotFoundException();
-        }*/
     }
 }

--- a/graylog2-server/src/main/java/org/graylog2/rest/resources/system/SessionsResource.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/resources/system/SessionsResource.java
@@ -50,6 +50,7 @@ import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
 import javax.ws.rs.container.ContainerRequestContext;
 import javax.ws.rs.core.Context;
+import javax.ws.rs.core.Response;
 import javax.ws.rs.core.SecurityContext;
 import java.io.Serializable;
 import java.util.concurrent.TimeUnit;
@@ -127,9 +128,9 @@ public class SessionsResource extends RestResource {
         final Subject subject = getSubject();
         securityManager.logout(subject);
 
-        final org.apache.shiro.session.Session session = subject.getSession(false);
+        /*final org.apache.shiro.session.Session session = subject.getSession(false);
         if (session == null || !session.getId().equals(sessionId)) {
             throw new NotFoundException();
-        }
+        }*/
     }
 }

--- a/graylog2-shared/src/main/java/org/graylog2/shared/rest/CORSFilter.java
+++ b/graylog2-shared/src/main/java/org/graylog2/shared/rest/CORSFilter.java
@@ -31,7 +31,8 @@ public class CORSFilter implements ContainerResponseFilter {
         if (origin != null && !origin.isEmpty()) {
             responseContext.getHeaders().add("Access-Control-Allow-Origin", origin);
             responseContext.getHeaders().add("Access-Control-Allow-Credentials", true);
-            responseContext.getHeaders().add("Access-Control-Allow-Headers", "Authorization");
+            responseContext.getHeaders().add("Access-Control-Allow-Headers", "Authorization, Content-Type");
+            responseContext.getHeaders().add("Access-Control-Allow-Methods", "GET, POST, PUT, DELETE, OPTIONS");
         }
     }
 }


### PR DESCRIPTION
This is a small collection of changes to support the current state of the react-only web interface. It includes:

* Add CORS flags required by browsers for cross domain requests to server's REST interface
* Remove code that results in returning 404 after successfull session removal
* Add resource method to return available stream rule types
