### PR TITLE
Create separate shaded artifact of graylog2-server

### DIFF
--- a/graylog2-server/pom.xml
+++ b/graylog2-server/pom.xml
@@ -376,6 +376,7 @@
                             <mainClass>${mainClass}</mainClass>
                         </transformer>
                     </transformers>
+                    <shadedArtifactAttached>true</shadedArtifactAttached>
                     <minimizeJar>false</minimizeJar>
                     <filters>
                         <filter>

--- a/graylog2-server/src/main/assembly/graylog2.xml
+++ b/graylog2-server/src/main/assembly/graylog2.xml
@@ -49,7 +49,7 @@
     </fileSets>
     <files>
         <file>
-            <source>${project.build.directory}/graylog2-server-${project.version}.jar</source>
+            <source>${project.build.directory}/graylog2-server-${project.version}-shaded.jar</source>
             <destName>graylog.jar</destName>
             <outputDirectory>/</outputDirectory>
         </file>


### PR DESCRIPTION
This PR changes the POM of graylog2-server so that the Maven Shade plugin will create a separate shaded artifact instead of replacing the original (unshaded) artifact.

This enables plugin authors to depend on the unshaded version of the graylog2-server artifact during development (1.3 MiB vs 73 MiB) and thus save some bandwidth (chances are good that other transitive dependencies are already in their local Maven caches).