### PR TITLE
Add periodical for index ranges cleanup

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/Configuration.java
+++ b/graylog2-server/src/main/java/org/graylog2/Configuration.java
@@ -149,6 +149,9 @@ public class Configuration extends BaseConfiguration {
     @Parameter(value = "content_packs_auto_load", converter = TrimmedStringSetConverter.class)
     private Set<String> contentPacksAutoLoad = Collections.emptySet();
 
+    @Parameter(value = "index_ranges_cleanup_interval", validator = PositiveDurationValidator.class)
+    private Duration indexRangesCleanupInterval = Duration.hours(1L);
+
     public boolean isMaster() {
         return isMaster;
     }
@@ -296,5 +299,9 @@ public class Configuration extends BaseConfiguration {
 
     public Set<String> getContentPacksAutoLoad() {
         return contentPacksAutoLoad;
+    }
+
+    public Duration getIndexRangesCleanupInterval() {
+        return indexRangesCleanupInterval;
     }
 }

--- a/graylog2-server/src/main/java/org/graylog2/bindings/PeriodicalBindings.java
+++ b/graylog2-server/src/main/java/org/graylog2/bindings/PeriodicalBindings.java
@@ -28,6 +28,7 @@ import org.graylog2.periodical.ClusterIdGeneratorPeriodical;
 import org.graylog2.periodical.ContentPackLoaderPeriodical;
 import org.graylog2.periodical.DeadLetterThread;
 import org.graylog2.periodical.GarbageCollectionWarningThread;
+import org.graylog2.periodical.IndexRangesCleanupPeriodical;
 import org.graylog2.periodical.IndexRangesMigrationPeriodical;
 import org.graylog2.periodical.IndexRetentionThread;
 import org.graylog2.periodical.IndexRotationThread;
@@ -62,6 +63,7 @@ public class PeriodicalBindings extends AbstractModule {
         periodicalBinder.addBinding().to(ClusterIdGeneratorPeriodical.class);
         periodicalBinder.addBinding().to(PurgeExpiredCollectorsThread.class);
         periodicalBinder.addBinding().to(IndexRangesMigrationPeriodical.class);
+        periodicalBinder.addBinding().to(IndexRangesCleanupPeriodical.class);
         periodicalBinder.addBinding().to(UserPermissionMigrationPeriodical.class);
         periodicalBinder.addBinding().to(AlarmCallbacksMigrationPeriodical.class);
     }

--- a/graylog2-server/src/main/java/org/graylog2/periodical/IndexRangesCleanupPeriodical.java
+++ b/graylog2-server/src/main/java/org/graylog2/periodical/IndexRangesCleanupPeriodical.java
@@ -84,7 +84,7 @@ public class IndexRangesCleanupPeriodical extends Periodical {
         }
 
         if (!removedIndices.isEmpty()) {
-            LOG.info("Removing index range information for non-existing indices: {}", removedIndices);
+            LOG.info("Removing index range information for unavailable indices: {}", removedIndices);
             eventBus.post(IndicesDeletedEvent.create(removedIndices));
         }
     }

--- a/graylog2-server/src/main/java/org/graylog2/periodical/IndexRangesCleanupPeriodical.java
+++ b/graylog2-server/src/main/java/org/graylog2/periodical/IndexRangesCleanupPeriodical.java
@@ -1,0 +1,131 @@
+/**
+ * This file is part of Graylog.
+ *
+ * Graylog is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.graylog2.periodical;
+
+import com.github.joschi.jadconfig.util.Duration;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.eventbus.EventBus;
+import com.google.common.primitives.Ints;
+import com.google.inject.name.Named;
+import org.graylog2.indexer.Deflector;
+import org.graylog2.indexer.cluster.Cluster;
+import org.graylog2.indexer.esplugin.IndicesDeletedEvent;
+import org.graylog2.indexer.ranges.IndexRange;
+import org.graylog2.indexer.ranges.IndexRangeService;
+import org.graylog2.plugin.periodical.Periodical;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.inject.Inject;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+import java.util.SortedSet;
+
+import static java.util.Objects.requireNonNull;
+
+/**
+ * A {@link Periodical} to clean up stale index ranges (e. g. because the index has been deleted externally)
+ *
+ * @since 1.3.0
+ */
+public class IndexRangesCleanupPeriodical extends Periodical {
+    private static final Logger LOG = LoggerFactory.getLogger(IndexRangesCleanupPeriodical.class);
+
+    private final Cluster cluster;
+    private final Deflector deflector;
+    private final IndexRangeService indexRangeService;
+    private final EventBus eventBus;
+    private final int periodSeconds;
+
+    @Inject
+    public IndexRangesCleanupPeriodical(final Cluster cluster,
+                                        final Deflector deflector,
+                                        final IndexRangeService indexRangeService,
+                                        final EventBus eventBus,
+                                        @Named("index_ranges_cleanup_interval") final Duration indexRangesCleanupInterval) {
+        this.cluster = requireNonNull(cluster);
+        this.deflector = requireNonNull(deflector);
+        this.indexRangeService = requireNonNull(indexRangeService);
+        this.eventBus = requireNonNull(eventBus);
+        this.periodSeconds = Ints.saturatedCast(indexRangesCleanupInterval.toSeconds());
+
+    }
+
+    @Override
+    public void doRun() {
+        if (!cluster.isConnected() || !cluster.isHealthy()) {
+            LOG.info("Skipping index range cleanup because the Elasticsearch cluster is unreachable or unhealthy");
+            return;
+        }
+
+        final Set<String> indexNames = ImmutableSet.copyOf(deflector.getAllDeflectorIndexNames());
+        final SortedSet<IndexRange> indexRanges = indexRangeService.findAll();
+
+        final List<String> removedIndices = new ArrayList<>();
+        for (IndexRange indexRange : indexRanges) {
+            if (!indexNames.contains(indexRange.indexName())) {
+                removedIndices.add(indexRange.indexName());
+            }
+        }
+
+        if (!removedIndices.isEmpty()) {
+            LOG.info("Removing index range information for non-existing indices: {}", removedIndices);
+            eventBus.post(IndicesDeletedEvent.create(removedIndices));
+        }
+    }
+
+    @Override
+    public boolean runsForever() {
+        return false;
+    }
+
+    @Override
+    public boolean stopOnGracefulShutdown() {
+        return true;
+    }
+
+    @Override
+    public boolean masterOnly() {
+        return true;
+    }
+
+    @Override
+    public boolean startOnThisNode() {
+        return true;
+    }
+
+    @Override
+    public boolean isDaemon() {
+        return true;
+    }
+
+    @Override
+    public int getInitialDelaySeconds() {
+        return 15;
+    }
+
+    @Override
+    public int getPeriodSeconds() {
+        return periodSeconds;
+    }
+
+    @Override
+    protected Logger getLogger() {
+        return LOG;
+    }
+}

--- a/misc/graylog2.conf
+++ b/misc/graylog2.conf
@@ -196,6 +196,11 @@ elasticsearch_analyzer = standard
 # Default: 1m
 #elasticsearch_request_timeout = 1m
 
+# Time interval for index range information cleanups. This setting defines how often stale index range information
+# is being purged from the database.
+# Default: 1h
+#index_ranges_cleanup_interval = 1h
+
 # Batch size for the Elasticsearch output. This is the maximum (!) number of messages the Elasticsearch output
 # module will get at once and write to Elasticsearch in a batch call. If the configured batch size has not been
 # reached within output_flush_interval seconds, everything that is available will be flushed at once. Remember


### PR DESCRIPTION
This PR adds a periodical which checks for stale index range information in the database and removes all index range information for non-existing indices in a configurable interval (`index_ranges_cleanup_interval`).

Fixes #1511