### PR TITLE
additional statistics for alarm callbacks and alert counts

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/alarmcallbacks/AlarmCallbackConfigurationService.java
+++ b/graylog2-server/src/main/java/org/graylog2/alarmcallbacks/AlarmCallbackConfigurationService.java
@@ -22,6 +22,7 @@ import org.graylog2.plugin.streams.Stream;
 import org.graylog2.rest.models.alarmcallbacks.requests.CreateAlarmCallbackRequest;
 
 import java.util.List;
+import java.util.Map;
 
 @ImplementedBy(AlarmCallbackConfigurationServiceMJImpl.class)
 public interface AlarmCallbackConfigurationService {
@@ -30,6 +31,7 @@ public interface AlarmCallbackConfigurationService {
     AlarmCallbackConfiguration load(String alarmCallbackId);
     AlarmCallbackConfiguration create(String streamId, CreateAlarmCallbackRequest request, String userId);
     long count();
+    Map<String, Long> countPerType();
     String save(AlarmCallbackConfiguration model) throws ValidationException;
     int destroy(AlarmCallbackConfiguration model);
 }

--- a/graylog2-server/src/main/java/org/graylog2/alarmcallbacks/AlarmCallbackConfigurationServiceMJImpl.java
+++ b/graylog2-server/src/main/java/org/graylog2/alarmcallbacks/AlarmCallbackConfigurationServiceMJImpl.java
@@ -114,9 +114,4 @@ public class AlarmCallbackConfigurationServiceMJImpl implements AlarmCallbackCon
             throw new IllegalArgumentException("Supplied output must be of implementation type AlarmCallbackConfigurationAVImpl, not " + callback.getClass());
         }
     }
-
-    private static class CountAggrType {
-        public String _id;
-        public long total;
-    }
 }

--- a/graylog2-server/src/main/java/org/graylog2/alarmcallbacks/AlarmCallbackConfigurationServiceMJImpl.java
+++ b/graylog2-server/src/main/java/org/graylog2/alarmcallbacks/AlarmCallbackConfigurationServiceMJImpl.java
@@ -26,8 +26,7 @@ import org.graylog2.database.MongoConnection;
 import org.graylog2.plugin.database.ValidationException;
 import org.graylog2.plugin.streams.Stream;
 import org.graylog2.rest.models.alarmcallbacks.requests.CreateAlarmCallbackRequest;
-import org.mongojack.Aggregation;
-import org.mongojack.AggregationResult;
+import org.mongojack.DBCursor;
 import org.mongojack.DBQuery;
 import org.mongojack.JacksonDBCollection;
 
@@ -77,10 +76,13 @@ public class AlarmCallbackConfigurationServiceMJImpl implements AlarmCallbackCon
     public Map<String, Long> countPerType() {
         final HashMap<String, Long> result = Maps.newHashMap();
 
-        final Aggregation.Pipeline<?> perTypeCount = Aggregation.group("type").set("total", Aggregation.Group.count());
-        final AggregationResult<CountAggrType> aggregationResult = coll.aggregate(perTypeCount, CountAggrType.class);
-        for (CountAggrType type : aggregationResult.results()) {
-            result.put(type._id, type.total);
+        final DBCursor<AlarmCallbackConfigurationAVImpl> avs = coll.find();
+        for (AlarmCallbackConfigurationAVImpl av : avs) {
+            Long count = result.get(av.getType());
+            if (count == null) {
+                count = 0L;
+            }
+            result.put(av.getType(), count + 1);
         }
 
         return result;

--- a/graylog2-server/src/main/java/org/graylog2/system/stats/AlarmStats.java
+++ b/graylog2-server/src/main/java/org/graylog2/system/stats/AlarmStats.java
@@ -1,0 +1,38 @@
+/**
+ * This file is part of Graylog.
+ *
+ * Graylog is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.graylog2.system.stats;
+
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.auto.value.AutoValue;
+
+import java.util.Map;
+
+@JsonAutoDetect
+@AutoValue
+public abstract class AlarmStats {
+
+    @JsonProperty
+    public abstract long alertCount();
+
+    @JsonProperty
+    public abstract Map<String, Long> alarmcallbackCountByType();
+
+    public static AlarmStats create(long alertCount, Map<String, Long> alarmcallbackCountByType) {
+        return new AutoValue_AlarmStats(alertCount, alarmcallbackCountByType);
+    }
+}

--- a/graylog2-server/src/main/java/org/graylog2/system/stats/ClusterStats.java
+++ b/graylog2-server/src/main/java/org/graylog2/system/stats/ClusterStats.java
@@ -76,6 +76,9 @@ public abstract class ClusterStats {
     @JsonProperty
     public abstract LdapStats ldapStats();
 
+    @JsonProperty
+    public abstract AlarmStats alarmStats();
+
     public static ClusterStats create(ElasticsearchStats elasticsearchStats,
                                       MongoStats mongoStats,
                                       long streamCount,
@@ -91,7 +94,8 @@ public abstract class ClusterStats {
                                       long extractorCount,
                                       Map<Extractor.Type, Long> extractorCountByType,
                                       long contentPackCount,
-                                      LdapStats ldapStats) {
+                                      LdapStats ldapStats,
+                                      AlarmStats alarmStats) {
         return new AutoValue_ClusterStats(
                 elasticsearchStats,
                 mongoStats,
@@ -108,6 +112,7 @@ public abstract class ClusterStats {
                 extractorCount,
                 extractorCountByType,
                 contentPackCount,
-                ldapStats);
+                ldapStats,
+                alarmStats);
     }
 }


### PR DESCRIPTION
 - uses mongodb aggregation for group by, should be available starting with mongodb v2.2 but we need to verify