### PR TITLE
Allow fetching index statistics for all indices in bulk

### DIFF
--- a/graylog2-rest-client/src/main/java/org/graylog2/restclient/models/IndexService.java
+++ b/graylog2-rest-client/src/main/java/org/graylog2/restclient/models/IndexService.java
@@ -16,7 +16,10 @@
  */
 package org.graylog2.restclient.models;
 
+import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Lists;
+import org.graylog2.rest.models.system.indexer.responses.AllIndicesInfo;
+import org.graylog2.rest.models.system.indexer.responses.IndexInfo;
 import org.graylog2.rest.models.system.indexer.responses.IndexRangeSummary;
 import org.graylog2.rest.models.system.indexer.responses.IndexRangesResponse;
 import org.graylog2.restclient.lib.APIException;
@@ -29,6 +32,7 @@ import org.graylog2.restroutes.generated.routes;
 import javax.inject.Inject;
 import java.io.IOException;
 import java.util.List;
+import java.util.Map;
 import java.util.concurrent.TimeUnit;
 
 import static org.graylog2.restclient.lib.Configuration.apiTimeout;
@@ -55,6 +59,16 @@ public class IndexService {
         }
 
         return indices;
+    }
+
+    public IndexInfo indexInfo(String index) throws APIException, IOException {
+        return api.path(routes.IndicesResource().single(index), IndexInfo.class).execute();
+    }
+
+    public Map<String, IndexInfo> allIndicesInfo() throws APIException, IOException {
+        final AllIndicesInfo allIndicesInfo = api.path(routes.IndicesResource().all(), AllIndicesInfo.class).execute();
+
+        return ImmutableMap.copyOf(allIndicesInfo.indices());
     }
 
     public DeflectorInformationResponse getDeflectorInfo() throws APIException, IOException {

--- a/graylog2-rest-models/src/main/java/org/graylog2/rest/models/system/indexer/responses/AllIndicesInfo.java
+++ b/graylog2-rest-models/src/main/java/org/graylog2/rest/models/system/indexer/responses/AllIndicesInfo.java
@@ -1,0 +1,36 @@
+/**
+ * This file is part of Graylog.
+ *
+ * Graylog is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.graylog2.rest.models.system.indexer.responses;
+
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.auto.value.AutoValue;
+
+import java.util.Map;
+
+@JsonAutoDetect
+@AutoValue
+public abstract class AllIndicesInfo {
+    @JsonProperty
+    public abstract Map<String, IndexInfo> indices();
+
+    @JsonCreator
+    public static AllIndicesInfo create(@JsonProperty("indices") Map<String, IndexInfo> indices) {
+        return new AutoValue_AllIndicesInfo(indices);
+    }
+}

--- a/graylog2-rest-models/src/main/java/org/graylog2/rest/models/system/indexer/responses/IndexStats.java
+++ b/graylog2-rest-models/src/main/java/org/graylog2/rest/models/system/indexer/responses/IndexStats.java
@@ -17,70 +17,73 @@
 package org.graylog2.rest.models.system.indexer.responses;
 
 import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.auto.value.AutoValue;
 
 @JsonAutoDetect
 @AutoValue
 public abstract class IndexStats {
-    @JsonProperty
+    @JsonProperty("flush")
     public abstract TimeAndTotalStats flush();
 
-    @JsonProperty
+    @JsonProperty("get")
     public abstract TimeAndTotalStats get();
 
-    @JsonProperty
+    @JsonProperty("index")
     public abstract TimeAndTotalStats index();
 
-    @JsonProperty
+    @JsonProperty("merge")
     public abstract TimeAndTotalStats merge();
 
-    @JsonProperty
+    @JsonProperty("refresh")
     public abstract TimeAndTotalStats refresh();
 
-    @JsonProperty
+    @JsonProperty("search_query")
     public abstract TimeAndTotalStats searchQuery();
 
-    @JsonProperty
+    @JsonProperty("search_fetch")
     public abstract TimeAndTotalStats searchFetch();
 
-    @JsonProperty
+    @JsonProperty("open_search_contexts")
     public abstract long openSearchContexts();
 
-    @JsonProperty
-    public abstract long store_size_bytes();
+    @JsonProperty("store_size_bytes")
+    public abstract long storeSizeBytes();
 
-    @JsonProperty
+    @JsonProperty("segments")
     public abstract long segments();
 
-    @JsonProperty
+    @JsonProperty("documents")
     public abstract DocsStats documents();
 
-    public static IndexStats create(TimeAndTotalStats flush,
-                                    TimeAndTotalStats get,
-                                    TimeAndTotalStats index,
-                                    TimeAndTotalStats merge,
-                                    TimeAndTotalStats refresh,
-                                    TimeAndTotalStats searchQuery,
-                                    TimeAndTotalStats searchFetch,
-                                    long openSearchContexts,
-                                    long store_size_bytes,
-                                    long segments,
-                                    DocsStats documents) {
+    @JsonCreator
+    public static IndexStats create(@JsonProperty("flush") TimeAndTotalStats flush,
+                                    @JsonProperty("get") TimeAndTotalStats get,
+                                    @JsonProperty("index") TimeAndTotalStats index,
+                                    @JsonProperty("merge") TimeAndTotalStats merge,
+                                    @JsonProperty("refresh") TimeAndTotalStats refresh,
+                                    @JsonProperty("search_query") TimeAndTotalStats searchQuery,
+                                    @JsonProperty("search_fetch") TimeAndTotalStats searchFetch,
+                                    @JsonProperty("open_search_contexts") long openSearchContexts,
+                                    @JsonProperty("store_size_bytes") long storeSizeBytes,
+                                    @JsonProperty("segments") long segments,
+                                    @JsonProperty("documents") DocsStats documents) {
         return new AutoValue_IndexStats(flush, get, index, merge, refresh, searchQuery, searchFetch,
-                openSearchContexts, store_size_bytes, segments, documents);
+                openSearchContexts, storeSizeBytes, segments, documents);
     }
 
     @JsonAutoDetect
     @AutoValue
     public static abstract class DocsStats {
-        @JsonProperty
+        @JsonProperty("count")
         public abstract long count();
 
-        @JsonProperty
+        @JsonProperty("deleted")
         public abstract long deleted();
 
-        public static DocsStats create(long count, long deleted) {
+        @JsonCreator
+        public static DocsStats create(@JsonProperty("count") long count, @JsonProperty("deleted") long deleted) {
             return new AutoValue_IndexStats_DocsStats(count, deleted);
         }
     }
@@ -88,13 +91,14 @@ public abstract class IndexStats {
     @JsonAutoDetect
     @AutoValue
     public static abstract class TimeAndTotalStats {
-        @JsonProperty
+        @JsonProperty("total")
         public abstract long total();
 
-        @JsonProperty
+        @JsonProperty("time_seconds")
         public abstract long timeSeconds();
 
-        public static TimeAndTotalStats create(long total, long timeSeconds) {
+        @JsonCreator
+        public static TimeAndTotalStats create(@JsonProperty("total") long total, @JsonProperty("time_seconds") long timeSeconds) {
             return new AutoValue_IndexStats_TimeAndTotalStats(total, timeSeconds);
         }
     }

--- a/graylog2-rest-models/src/main/java/org/graylog2/rest/models/system/indexer/responses/ShardRouting.java
+++ b/graylog2-rest-models/src/main/java/org/graylog2/rest/models/system/indexer/responses/ShardRouting.java
@@ -17,6 +17,7 @@
 package org.graylog2.rest.models.system.indexer.responses;
 
 import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.auto.value.AutoValue;
 
@@ -25,39 +26,40 @@ import javax.annotation.Nullable;
 @JsonAutoDetect
 @AutoValue
 public abstract class ShardRouting {
-    @JsonProperty
+    @JsonProperty("id")
     public abstract int id();
 
-    @JsonProperty
+    @JsonProperty("state")
     public abstract String state();
 
-    @JsonProperty
+    @JsonProperty("active")
     public abstract boolean active();
 
-    @JsonProperty
+    @JsonProperty("primary")
     public abstract boolean primary();
 
-    @JsonProperty
+    @JsonProperty("node_id")
     public abstract String nodeId();
 
-    @JsonProperty
+    @JsonProperty("node_name")
     public abstract String nodeName();
 
-    @JsonProperty
+    @JsonProperty("node_hostname")
     public abstract String nodeHostname();
 
-    @JsonProperty
+    @JsonProperty("relocating_to")
     @Nullable
     public abstract String relocatingTo();
 
-    public static ShardRouting create(int id,
-                                      String state,
-                                      boolean active,
-                                      boolean primary,
-                                      String nodeId,
-                                      String nodeName,
-                                      String nodeHostname,
-                                      @Nullable String relocatingTo) {
+    @JsonCreator
+    public static ShardRouting create(@JsonProperty("id") int id,
+                                      @JsonProperty("state") String state,
+                                      @JsonProperty("active") boolean active,
+                                      @JsonProperty("primary") boolean primary,
+                                      @JsonProperty("node_id") String nodeId,
+                                      @JsonProperty("node_name") String nodeName,
+                                      @JsonProperty("node_hostname") String nodeHostname,
+                                      @JsonProperty("relocating_to") @Nullable String relocatingTo) {
         return new AutoValue_ShardRouting(id, state, active, primary, nodeId, nodeName, nodeHostname, relocatingTo);
     }
 }

--- a/graylog2-server/src/main/java/org/graylog2/indexer/indices/IndexStatistics.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/indices/IndexStatistics.java
@@ -16,43 +16,26 @@
  */
 package org.graylog2.indexer.indices;
 
-import com.google.common.collect.Lists;
+import com.google.auto.value.AutoValue;
 import org.elasticsearch.action.admin.indices.stats.CommonStats;
 import org.elasticsearch.cluster.routing.ShardRouting;
 
 import java.util.List;
 
-public class IndexStatistics {
-    private CommonStats primaries;
-    private CommonStats total;
+@AutoValue
+public abstract class IndexStatistics {
+    public abstract String indexName();
 
-    private List<ShardRouting> shardRoutingList;
+    public abstract CommonStats primaries();
 
-    public IndexStatistics() {
-        shardRoutingList = Lists.newArrayList();
-    }
+    public abstract CommonStats total();
 
-    public void setPrimaries(CommonStats primaries) {
-        this.primaries = primaries;
-    }
+    public abstract List<ShardRouting> shardRoutings();
 
-    public CommonStats getPrimaries() {
-        return primaries;
-    }
-
-    public void setTotal(CommonStats total) {
-        this.total = total;
-    }
-
-    public CommonStats getTotal() {
-        return total;
-    }
-
-    public void addShardRouting(ShardRouting shardRouting) {
-        shardRoutingList.add(shardRouting);
-    }
-
-    public List<ShardRouting> getShardRoutings() {
-        return shardRoutingList;
+    public static IndexStatistics create(String indexName,
+                                         CommonStats primaries,
+                                         CommonStats total,
+                                         List<ShardRouting> shardRoutings) {
+        return new AutoValue_IndexStatistics(indexName, primaries, total, shardRoutings);
     }
 }

--- a/graylog2-server/src/main/java/org/graylog2/indexer/indices/Indices.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/indices/Indices.java
@@ -387,7 +387,7 @@ public class Indices implements IndexManagement {
 
     @Nullable
     public IndexStatistics getIndexStats(String index) {
-        if (index.startsWith(configuration.getIndexPrefix())) {
+        if (!index.startsWith(configuration.getIndexPrefix())) {
             return null;
         }
 

--- a/graylog2-server/src/main/java/org/graylog2/indexer/rotation/SizeBasedRotationStrategy.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/rotation/SizeBasedRotationStrategy.java
@@ -47,7 +47,7 @@ public class SizeBasedRotationStrategy implements RotationStrategy {
             return null;
         }
 
-        final long sizeInBytes = indexStats.getPrimaries().store.getSizeInBytes();
+        final long sizeInBytes = indexStats.primaries().getStore().getSizeInBytes();
 
         final boolean shouldRotate = sizeInBytes > maxSize;
 

--- a/graylog2-server/src/main/java/org/graylog2/rest/resources/system/indexer/IndicesResource.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/resources/system/indexer/IndicesResource.java
@@ -26,17 +26,19 @@ import com.wordnik.swagger.annotations.ApiParam;
 import com.wordnik.swagger.annotations.ApiResponse;
 import com.wordnik.swagger.annotations.ApiResponses;
 import org.apache.shiro.authz.annotation.RequiresAuthentication;
+import org.apache.shiro.authz.annotation.RequiresPermissions;
 import org.elasticsearch.action.admin.indices.stats.CommonStats;
 import org.graylog2.indexer.Deflector;
 import org.graylog2.indexer.cluster.Cluster;
 import org.graylog2.indexer.indices.IndexStatistics;
 import org.graylog2.indexer.indices.Indices;
 import org.graylog2.indexer.ranges.RebuildIndexRangesJob;
-import org.graylog2.shared.rest.resources.RestResource;
+import org.graylog2.rest.models.system.indexer.responses.AllIndicesInfo;
 import org.graylog2.rest.models.system.indexer.responses.ClosedIndices;
 import org.graylog2.rest.models.system.indexer.responses.IndexInfo;
 import org.graylog2.rest.models.system.indexer.responses.IndexStats;
 import org.graylog2.rest.models.system.indexer.responses.ShardRouting;
+import org.graylog2.shared.rest.resources.RestResource;
 import org.graylog2.shared.security.RestPermissions;
 import org.graylog2.system.jobs.SystemJob;
 import org.graylog2.system.jobs.SystemJobConcurrencyException;
@@ -56,6 +58,8 @@ import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
 import javax.ws.rs.Produces;
 import javax.ws.rs.core.MediaType;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Set;
 
 @RequiresAuthentication
@@ -97,12 +101,39 @@ public class IndicesResource extends RestResource {
         }
 
         final ImmutableList.Builder<ShardRouting> routing = ImmutableList.builder();
-        for (org.elasticsearch.cluster.routing.ShardRouting shardRouting : stats.getShardRoutings()) {
+        for (org.elasticsearch.cluster.routing.ShardRouting shardRouting : stats.shardRoutings()) {
             routing.add(shardRouting(shardRouting));
         }
 
-        return IndexInfo.create(indexStats(stats.getPrimaries()), indexStats(stats.getTotal()),
+        return IndexInfo.create(indexStats(stats.primaries()), indexStats(stats.total()),
                 routing.build(), indices.isReopened(index));
+    }
+
+    @GET
+    @Timed
+    @ApiOperation(value = "Get information of all indices managed by Graylog and their shards.")
+    @RequiresPermissions(RestPermissions.INDICES_READ)
+    @Produces(MediaType.APPLICATION_JSON)
+    public AllIndicesInfo all() {
+        final Set<IndexStatistics> indicesStats = indices.getIndicesStats();
+
+        final Map<String, IndexInfo> indexInfos = new HashMap<>();
+        for(IndexStatistics indexStatistics : indicesStats) {
+            final ImmutableList.Builder<ShardRouting> routing = ImmutableList.builder();
+            for (org.elasticsearch.cluster.routing.ShardRouting shardRouting : indexStatistics.shardRoutings()) {
+                routing.add(shardRouting(shardRouting));
+            }
+
+            final IndexInfo indexInfo = IndexInfo.create(
+                    indexStats(indexStatistics.primaries()),
+                    indexStats(indexStatistics.total()),
+                    routing.build(),
+                    indices.isReopened(indexStatistics.indexName()));
+
+            indexInfos.put(indexStatistics.indexName(), indexInfo);
+        }
+
+        return AllIndicesInfo.create(indexInfos);
     }
 
     @GET

--- a/graylog2-server/src/test/java/org/graylog2/indexer/rotation/SizeBasedRotationStrategyTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/indexer/rotation/SizeBasedRotationStrategyTest.java
@@ -17,6 +17,7 @@
 package org.graylog2.indexer.rotation;
 
 import org.elasticsearch.action.admin.indices.stats.CommonStats;
+import org.elasticsearch.cluster.routing.ShardRouting;
 import org.elasticsearch.index.store.StoreStats;
 import org.graylog2.configuration.ElasticsearchConfiguration;
 import org.graylog2.indexer.IndexNotFoundException;
@@ -27,6 +28,8 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
+
+import java.util.Collections;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
@@ -44,10 +47,9 @@ public class SizeBasedRotationStrategyTest {
 
     @Test
     public void testRotate() throws IndexNotFoundException {
-        final IndexStatistics stats = new IndexStatistics();
         final CommonStats commonStats = new CommonStats();
         commonStats.store = new StoreStats(1000, 0);
-        stats.setPrimaries(commonStats);
+        final IndexStatistics stats = IndexStatistics.create("name", commonStats, commonStats, Collections.<ShardRouting>emptyList());
 
         when(indices.getIndexStats("name")).thenReturn(stats);
         when(configuration.getMaxSizePerIndex()).thenReturn(100L);
@@ -63,10 +65,9 @@ public class SizeBasedRotationStrategyTest {
 
     @Test
     public void testDontRotate() throws IndexNotFoundException {
-        final IndexStatistics stats = new IndexStatistics();
         final CommonStats commonStats = new CommonStats();
         commonStats.store = new StoreStats(1000, 0);
-        stats.setPrimaries(commonStats);
+        final IndexStatistics stats = IndexStatistics.create("name", commonStats, commonStats, Collections.<ShardRouting>emptyList());
 
         when(indices.getIndexStats("name")).thenReturn(stats);
         when(configuration.getMaxSizePerIndex()).thenReturn(100000L);


### PR DESCRIPTION
Instead of retrieving index statistics only for a single index (and even that in a very inefficient way) the Graylog REST API now provides a resource at `/system/indexer/indices` which returns the index statistics of all Elasticsearch indices managed by Graylog.