### PR TITLE
Set indices options to lenient for search queries

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/indexer/esplugin/IndicesClosedEvent.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/esplugin/IndicesClosedEvent.java
@@ -22,10 +22,10 @@ import com.google.common.collect.ImmutableSet;
 import java.util.Set;
 
 @AutoValue
-public abstract class IndicesDeletedEvent {
+public abstract class IndicesClosedEvent {
     public abstract Set<String> indices();
 
-    public static IndicesDeletedEvent create(Set<String> indices) {
-        return new AutoValue_IndicesDeletedEvent(ImmutableSet.copyOf(indices));
+    public static IndicesClosedEvent create(Set<String> indices) {
+        return new AutoValue_IndicesClosedEvent(ImmutableSet.copyOf(indices));
     }
 }

--- a/graylog2-server/src/main/java/org/graylog2/indexer/esplugin/IndicesReopenedEvent.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/esplugin/IndicesReopenedEvent.java
@@ -22,10 +22,10 @@ import com.google.common.collect.ImmutableSet;
 import java.util.Set;
 
 @AutoValue
-public abstract class IndicesDeletedEvent {
+public abstract class IndicesReopenedEvent {
     public abstract Set<String> indices();
 
-    public static IndicesDeletedEvent create(Set<String> indices) {
-        return new AutoValue_IndicesDeletedEvent(ImmutableSet.copyOf(indices));
+    public static IndicesReopenedEvent create(Set<String> indices) {
+        return new AutoValue_IndicesReopenedEvent(ImmutableSet.copyOf(indices));
     }
 }

--- a/graylog2-server/src/main/java/org/graylog2/indexer/ranges/EsIndexRangeService.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/ranges/EsIndexRangeService.java
@@ -17,7 +17,6 @@
 package org.graylog2.indexer.ranges;
 
 import com.codahale.metrics.MetricRegistry;
-import com.google.common.base.Stopwatch;
 import com.google.common.cache.CacheBuilder;
 import com.google.common.cache.CacheLoader;
 import com.google.common.cache.LoadingCache;
@@ -25,7 +24,6 @@ import com.google.common.collect.ImmutableSortedSet;
 import com.google.common.eventbus.AllowConcurrentEvents;
 import com.google.common.eventbus.EventBus;
 import com.google.common.eventbus.Subscribe;
-import com.google.common.primitives.Ints;
 import org.elasticsearch.action.NoShardAvailableActionException;
 import org.elasticsearch.action.get.GetRequest;
 import org.elasticsearch.action.get.GetRequestBuilder;
@@ -36,12 +34,9 @@ import org.graylog2.database.NotFoundException;
 import org.graylog2.events.ClusterEventBus;
 import org.graylog2.indexer.Deflector;
 import org.graylog2.indexer.esplugin.IndicesDeletedEvent;
-import org.graylog2.indexer.indices.Indices;
-import org.graylog2.indexer.searches.TimestampStats;
 import org.graylog2.metrics.CacheStatsSet;
 import org.graylog2.shared.metrics.MetricUtils;
 import org.joda.time.DateTime;
-import org.joda.time.DateTimeZone;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -51,7 +46,6 @@ import javax.inject.Singleton;
 import java.util.Map;
 import java.util.SortedSet;
 import java.util.concurrent.ExecutionException;
-import java.util.concurrent.TimeUnit;
 
 import static java.util.Objects.requireNonNull;
 
@@ -63,18 +57,15 @@ public class EsIndexRangeService implements IndexRangeService {
     private final LoadingCache<String, IndexRange> cache;
     private final Client client;
     private final Deflector deflector;
-    private final Indices indices;
 
     @Inject
     public EsIndexRangeService(Client client,
                                Deflector deflector,
-                               Indices indices,
                                EventBus eventBus,
                                @ClusterEventBus EventBus clusterEventBus,
                                MetricRegistry metricRegistry) {
         this.client = requireNonNull(client);
         this.deflector = requireNonNull(deflector);
-        this.indices = requireNonNull(indices);
 
         final CacheLoader<String, IndexRange> cacheLoader = new CacheLoader<String, IndexRange>() {
             @Override
@@ -190,13 +181,7 @@ public class EsIndexRangeService implements IndexRangeService {
 
     @Override
     public IndexRange calculateRange(String index) {
-        final Stopwatch sw = Stopwatch.createStarted();
-        final DateTime now = DateTime.now(DateTimeZone.UTC);
-        final TimestampStats stats = indices.timestampStatsOfIndex(index);
-        final int duration = Ints.saturatedCast(sw.stop().elapsed(TimeUnit.MILLISECONDS));
-
-        LOG.info("Calculated range of [{}] in [{}ms].", index, duration);
-        return EsIndexRange.create(index, stats.min(), stats.max(), now, duration);
+        throw new UnsupportedOperationException();
     }
 
     @Override

--- a/graylog2-server/src/main/java/org/graylog2/indexer/searches/Searches.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/searches/Searches.java
@@ -24,6 +24,7 @@ import org.elasticsearch.action.search.SearchRequest;
 import org.elasticsearch.action.search.SearchRequestBuilder;
 import org.elasticsearch.action.search.SearchResponse;
 import org.elasticsearch.action.search.SearchType;
+import org.elasticsearch.action.support.IndicesOptions;
 import org.elasticsearch.client.Client;
 import org.elasticsearch.common.unit.TimeValue;
 import org.elasticsearch.common.xcontent.XContentHelper;
@@ -457,11 +458,11 @@ public class Searches {
         QueryStringQueryBuilder qs = queryStringQuery(query);
         qs.allowLeadingWildcard(configuration.isAllowLeadingWildcardSearches());
 
-        SearchRequestBuilder srb = c.prepareSearch();
         final Set<String> affectedIndices = IndexHelper.determineAffectedIndices(indexRangeService, deflector, range);
-        srb.setIndices(affectedIndices.toArray(new String[affectedIndices.size()]));
-        srb.setQuery(qs);
-        srb.addAggregation(builder);
+        final SearchRequestBuilder srb = c.prepareSearch(affectedIndices.toArray(new String[affectedIndices.size()]))
+                .setIndicesOptions(IndicesOptions.lenientExpandOpen())
+                .setQuery(qs)
+                .addAggregation(builder);
 
         final SearchRequest request = srb.request();
         SearchResponse r = c.search(request).actionGet();
@@ -584,8 +585,8 @@ public class Searches {
             query = "*";
         }
 
-        SearchRequestBuilder srb = c.prepareSearch();
-        srb.setIndices(indices.toArray(new String[indices.size()]));
+        final SearchRequestBuilder srb = c.prepareSearch(indices.toArray(new String[indices.size()]))
+                .setIndicesOptions(IndicesOptions.lenientExpandOpen());
 
         final QueryBuilder queryBuilder;
 

--- a/graylog2-server/src/main/java/org/graylog2/rest/resources/system/indexer/IndicesResource.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/resources/system/indexer/IndicesResource.java
@@ -32,7 +32,6 @@ import org.graylog2.indexer.Deflector;
 import org.graylog2.indexer.cluster.Cluster;
 import org.graylog2.indexer.indices.IndexStatistics;
 import org.graylog2.indexer.indices.Indices;
-import org.graylog2.indexer.ranges.CreateNewSingleIndexRangeJob;
 import org.graylog2.rest.models.system.indexer.responses.AllIndicesInfo;
 import org.graylog2.rest.models.system.indexer.responses.ClosedIndices;
 import org.graylog2.rest.models.system.indexer.responses.IndexInfo;
@@ -40,9 +39,6 @@ import org.graylog2.rest.models.system.indexer.responses.IndexStats;
 import org.graylog2.rest.models.system.indexer.responses.ShardRouting;
 import org.graylog2.shared.rest.resources.RestResource;
 import org.graylog2.shared.security.RestPermissions;
-import org.graylog2.system.jobs.SystemJob;
-import org.graylog2.system.jobs.SystemJobConcurrencyException;
-import org.graylog2.system.jobs.SystemJobManager;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -69,15 +65,11 @@ public class IndicesResource extends RestResource {
     private static final Logger LOG = LoggerFactory.getLogger(IndicesResource.class);
 
     @Inject
-    private CreateNewSingleIndexRangeJob.Factory rebuildIndexRangesJobFactory;
-    @Inject
     private Indices indices;
     @Inject
     private Cluster cluster;
     @Inject
     private Deflector deflector;
-    @Inject
-    private SystemJobManager systemJobManager;
 
     @GET
     @Timed
@@ -194,16 +186,6 @@ public class IndicesResource extends RestResource {
         }
 
         indices.reopenIndex(index);
-
-        // Trigger index ranges rebuild job.
-        final SystemJob rebuildJob = rebuildIndexRangesJobFactory.create(deflector, index);
-        try {
-            systemJobManager.submit(rebuildJob);
-        } catch (SystemJobConcurrencyException e) {
-            final String msg = "Concurrency level of this job reached: " + e.getMessage();
-            LOG.error(msg);
-            throw new ForbiddenException(msg);
-        }
     }
 
     @POST

--- a/graylog2-server/src/test/java/org/graylog2/indexer/searches/SearchesTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/indexer/searches/SearchesTest.java
@@ -164,6 +164,79 @@ public class SearchesTest {
 
     @Test
     @UsingDataSet(loadStrategy = LoadStrategyEnum.CLEAN_INSERT)
+    public void testTermsWithNonExistingIndex() throws Exception {
+        final SortedSet<IndexRange> indexRanges = ImmutableSortedSet
+                .orderedBy(new IndexRangeComparator())
+                .add(new IndexRange() {
+                    @Override
+                    public String indexName() {
+                        return INDEX_NAME;
+                    }
+
+                    @Override
+                    public DateTime calculatedAt() {
+                        return DateTime.now();
+                    }
+
+                    @Override
+                    public DateTime end() {
+                        return new DateTime(2015, 1, 1, 0, 0, DateTimeZone.UTC);
+                    }
+
+                    @Override
+                    public int calculationDuration() {
+                        return 0;
+                    }
+
+                    @Override
+                    public DateTime begin() {
+                        return new DateTime(0L, DateTimeZone.UTC);
+                    }
+                })
+                .add(new IndexRange() {
+                    @Override
+                    public String indexName() {
+                        return "does-not-exist";
+                    }
+
+                    @Override
+                    public DateTime calculatedAt() {
+                        return DateTime.now();
+                    }
+
+                    @Override
+                    public DateTime end() {
+                        return new DateTime(2015, 1, 1, 0, 0, DateTimeZone.UTC);
+                    }
+
+                    @Override
+                    public int calculationDuration() {
+                        return 0;
+                    }
+
+                    @Override
+                    public DateTime begin() {
+                        return new DateTime(0L, DateTimeZone.UTC);
+                    }
+                }).build();
+        when(indexRangeService.find(any(DateTime.class), any(DateTime.class))).thenReturn(indexRanges);
+
+        TermsResult result = searches.terms("n", 25, "*", new AbsoluteRange(
+                new DateTime(2015, 1, 1, 0, 0),
+                new DateTime(2015, 1, 2, 0, 0)));
+
+        assertThat(result.getTotal()).isEqualTo(10L);
+        assertThat(result.getMissing()).isEqualTo(2L);
+        assertThat(result.getTerms())
+                .hasSize(4)
+                .containsEntry("1", 2L)
+                .containsEntry("2", 2L)
+                .containsEntry("3", 3L)
+                .containsEntry("4", 1L);
+    }
+
+    @Test
+    @UsingDataSet(loadStrategy = LoadStrategyEnum.CLEAN_INSERT)
     public void termsRecordsMetrics() throws Exception {
         TermsResult result = searches.terms("n", 25, "*", new AbsoluteRange(
                 new DateTime(2015, 1, 1, 0, 0),
@@ -269,6 +342,80 @@ public class SearchesTest {
                 .containsEntry(new DateTime(2015, 1, 1, 5, 0, DateTimeZone.UTC).getMillis() / 1000L, 2L);
     }
 
+    @Test
+    @UsingDataSet(loadStrategy = LoadStrategyEnum.CLEAN_INSERT)
+    @SuppressWarnings("unchecked")
+    public void testHistogramWithNonExistingIndex() throws Exception {
+        final SortedSet<IndexRange> indexRanges = ImmutableSortedSet
+                .orderedBy(new IndexRangeComparator())
+                .add(new IndexRange() {
+                    @Override
+                    public String indexName() {
+                        return INDEX_NAME;
+                    }
+
+                    @Override
+                    public DateTime calculatedAt() {
+                        return DateTime.now();
+                    }
+
+                    @Override
+                    public DateTime end() {
+                        return new DateTime(2015, 1, 1, 0, 0, DateTimeZone.UTC);
+                    }
+
+                    @Override
+                    public int calculationDuration() {
+                        return 0;
+                    }
+
+                    @Override
+                    public DateTime begin() {
+                        return new DateTime(0L, DateTimeZone.UTC);
+                    }
+                })
+                .add(new IndexRange() {
+                    @Override
+                    public String indexName() {
+                        return "does-not-exist";
+                    }
+
+                    @Override
+                    public DateTime calculatedAt() {
+                        return DateTime.now();
+                    }
+
+                    @Override
+                    public DateTime end() {
+                        return new DateTime(2015, 1, 1, 0, 0, DateTimeZone.UTC);
+                    }
+
+                    @Override
+                    public int calculationDuration() {
+                        return 0;
+                    }
+
+                    @Override
+                    public DateTime begin() {
+                        return new DateTime(0L, DateTimeZone.UTC);
+                    }
+                }).build();
+        when(indexRangeService.find(any(DateTime.class), any(DateTime.class))).thenReturn(indexRanges);
+
+        final AbsoluteRange range = new AbsoluteRange(new DateTime(2015, 1, 1, 0, 0), new DateTime(2015, 1, 2, 0, 0));
+        HistogramResult h = searches.histogram("*", Searches.DateHistogramInterval.MINUTE, range);
+
+        assertThat(h.getInterval()).isEqualTo(Searches.DateHistogramInterval.MINUTE);
+        assertThat(h.getHistogramBoundaries()).isEqualTo(range);
+        assertThat(h.getResults())
+                .hasSize(5)
+                .containsEntry(new DateTime(2015, 1, 1, 1, 0, DateTimeZone.UTC).getMillis() / 1000L, 2L)
+                .containsEntry(new DateTime(2015, 1, 1, 2, 0, DateTimeZone.UTC).getMillis() / 1000L, 2L)
+                .containsEntry(new DateTime(2015, 1, 1, 3, 0, DateTimeZone.UTC).getMillis() / 1000L, 2L)
+                .containsEntry(new DateTime(2015, 1, 1, 4, 0, DateTimeZone.UTC).getMillis() / 1000L, 2L)
+                .containsEntry(new DateTime(2015, 1, 1, 5, 0, DateTimeZone.UTC).getMillis() / 1000L, 2L);
+    }
+    
     @Test
     @UsingDataSet(loadStrategy = LoadStrategyEnum.CLEAN_INSERT)
     @SuppressWarnings("unchecked")


### PR DESCRIPTION
Using `IndicesOptions#lenientExpandOpen()` in a search request for Elasticsearch prevents (quite unnecessary) exceptions because of closed or non-existent indices:

> indices options that ignores unavailable indices, expands wildcards only to open indices and allows that no indices are resolved from wildcard expressions (not returning an error).

Fixes #1533