### PR TITLE
Add installation_source configuration setting and log it on startup

### DIFF
--- a/graylog2-bootstrap/src/main/java/org/graylog2/bootstrap/ServerBootstrap.java
+++ b/graylog2-bootstrap/src/main/java/org/graylog2/bootstrap/ServerBootstrap.java
@@ -74,7 +74,8 @@ public abstract class ServerBootstrap extends CmdLineTool {
 
     @Override
     protected void startCommand() {
-        LOG.info("Graylog " + commandName + " {} starting up. (JRE: {})", version, Tools.getSystemInformation());
+        LOG.info("Graylog {} {} starting up (JRE: {}, installed from: {})", commandName, version,
+                Tools.getSystemInformation(), configuration.getInstallationSource());
 
         // Do not use a PID file if the user requested not to
         if (!isNoPidFile()) {

--- a/graylog2-plugin-interfaces/src/main/java/org/graylog2/plugin/BaseConfiguration.java
+++ b/graylog2-plugin-interfaces/src/main/java/org/graylog2/plugin/BaseConfiguration.java
@@ -27,6 +27,7 @@ import com.github.joschi.jadconfig.util.Duration;
 import com.github.joschi.jadconfig.validators.InetPortValidator;
 import com.github.joschi.jadconfig.validators.PositiveDurationValidator;
 import com.github.joschi.jadconfig.validators.PositiveIntegerValidator;
+import com.github.joschi.jadconfig.validators.StringNotBlankValidator;
 import com.lmax.disruptor.BlockingWaitStrategy;
 import com.lmax.disruptor.BusySpinWaitStrategy;
 import com.lmax.disruptor.SleepingWaitStrategy;
@@ -130,6 +131,9 @@ public abstract class BaseConfiguration {
 
     @Parameter(value = "http_read_timeout", validator = PositiveDurationValidator.class)
     private Duration httpReadTimeout = Duration.seconds(10L);
+
+    @Parameter(value = "installation_source", validator = StringNotBlankValidator.class)
+    private String installationSource = "unknown";
 
     public String getRestUriScheme() {
         return isRestEnableTls() ? "https" : "http";
@@ -304,5 +308,9 @@ public abstract class BaseConfiguration {
 
     public Duration getHttpReadTimeout() {
         return httpReadTimeout;
+    }
+
+    public String getInstallationSource() {
+        return installationSource;
     }
 }


### PR DESCRIPTION
The `installation_source` configuration setting (default: "unknown") can be overridden by an environment variable (`GRAYLOG2_INSTALLATION_SOURCE`) or a Java system property (`graylog2.installation_source`).

Example output on startup:
```
2015-11-09 17:24:50,503 INFO : org.graylog2.bootstrap.ServerBootstrap - Graylog server 1.3.0-SNAPSHOT (4489a5e) starting up (JRE: Oracle Corporation 1.8.0_66 on Mac OS X 10.10.5, installed from: unknown)
```
The `installation_source` setting could also be collected and transmitted by the Anonymous Usage Statistics plugin to get a better overview about our installation base and which type of distribution channel users have chosen.

Closes #1530