### PR TITLE
Use the root user's timezone for LDAP users by default

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/users/UserServiceImpl.java
+++ b/graylog2-server/src/main/java/org/graylog2/users/UserServiceImpl.java
@@ -166,6 +166,10 @@ public class UserServiceImpl extends PersistedServiceImpl implements UserService
         user.setFullName(fullName);
         user.setExternal(true);
 
+        if (user.getTimeZone() == null) {
+            user.setTimeZone(configuration.getRootTimeZone());
+        }
+
         final String email = userEntry.getEmail();
         if (isNullOrEmpty(email)) {
             LOG.debug("No email address found for user {} in LDAP. Using {}@localhost", username, username);


### PR DESCRIPTION
Ideally we would use the timezone configured in the web interface, but we do not have access to that from the server.

Fixes #1000