### PR TITLE
Do not allow overwriting the Message timestamp with a non Date object

### DIFF
--- a/graylog2-plugin-interfaces/src/main/java/org/graylog2/plugin/Message.java
+++ b/graylog2-plugin-interfaces/src/main/java/org/graylog2/plugin/Message.java
@@ -256,6 +256,12 @@ public class Message {
             return;
         }
 
+        if (FIELD_TIMESTAMP.equals(key) && !(value instanceof DateTime) && !(value instanceof Date)) {
+            LOG.warn("Field [{}] must be of value Date or DateTime. Make sure to apply a date converter when using extractors. Not overwriting field.",
+                    FIELD_TIMESTAMP);
+            return;
+        }
+
         if(value instanceof String) {
             final String str = ((String) value).trim();
 

--- a/graylog2-plugin-interfaces/src/test/java/org/graylog2/plugin/MessageTest.java
+++ b/graylog2-plugin-interfaces/src/test/java/org/graylog2/plugin/MessageTest.java
@@ -22,6 +22,7 @@
  */
 package org.graylog2.plugin;
 
+import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
@@ -34,11 +35,13 @@ import org.junit.runner.RunWith;
 import org.mockito.runners.MockitoJUnitRunner;
 
 import java.util.Collections;
+import java.util.Date;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.regex.Pattern;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
@@ -245,6 +248,39 @@ public class MessageTest {
     }
 
     @Test
+    public void testDoesNotOverwriteTimestampWithBadValue() throws Exception {
+        final DateTime dateTime = new DateTime(2015, 9, 8, 0, 0, DateTimeZone.UTC);
+        final Date date = new DateTime(2014, 3, 10, 0, 0, DateTimeZone.UTC).toDate();
+
+        message.addField(Message.FIELD_TIMESTAMP, dateTime);
+        assertThat(message.getField(Message.FIELD_TIMESTAMP)).isEqualTo(dateTime);
+
+        message.addField(Message.FIELD_TIMESTAMP, "foo");
+        assertThat(message.getField(Message.FIELD_TIMESTAMP)).isEqualTo(dateTime);
+
+        message.addField(Message.FIELD_TIMESTAMP, 123);
+        assertThat(message.getField(Message.FIELD_TIMESTAMP)).isEqualTo(dateTime);
+
+        message.addField(Message.FIELD_TIMESTAMP, 123L);
+        assertThat(message.getField(Message.FIELD_TIMESTAMP)).isEqualTo(dateTime);
+
+        message.addField(Message.FIELD_TIMESTAMP, true);
+        assertThat(message.getField(Message.FIELD_TIMESTAMP)).isEqualTo(dateTime);
+
+        message.addField(Message.FIELD_TIMESTAMP, new Object());
+        assertThat(message.getField(Message.FIELD_TIMESTAMP)).isEqualTo(dateTime);
+
+        message.addFields(ImmutableMap.<String, Object>of(Message.FIELD_TIMESTAMP, "foo"));
+        assertThat(message.getField(Message.FIELD_TIMESTAMP)).isEqualTo(dateTime);
+
+        message.addStringFields(ImmutableMap.<String, String>of(Message.FIELD_TIMESTAMP, "foo"));
+        assertThat(message.getField(Message.FIELD_TIMESTAMP)).isEqualTo(dateTime);
+
+        message.addField(Message.FIELD_TIMESTAMP, date);
+        assertThat(message.getField(Message.FIELD_TIMESTAMP)).isEqualTo(date);
+    }
+
+    @Test
     public void testGetMessage() throws Exception {
         assertEquals("foo", message.getMessage());
     }
@@ -282,15 +318,6 @@ public class MessageTest {
         assertEquals("that", object.get("field2"));
         assertEquals(Tools.buildElasticSearchTimeFormat((DateTime) message.getField("timestamp")), object.get("timestamp"));
         assertEquals(Collections.EMPTY_LIST, object.get("streams"));
-    }
-
-    @Test
-    public void testToElasticSearchObjectWithoutDateTimeTimestamp() throws Exception {
-        message.addField("timestamp", "time!");
-
-        final Map<String, Object> object = message.toElasticSearchObject();
-
-        assertEquals("time!", object.get("timestamp"));
     }
 
     @Test


### PR DESCRIPTION
This is a sign of bad extractors/converters.

Fixes #1556