### PR TITLE
Merge ES index and mapping creation in Indices#create()

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/indexer/IndexMapping.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/IndexMapping.java
@@ -18,20 +18,12 @@ package org.graylog2.indexer;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
-import org.elasticsearch.action.ActionFuture;
-import org.elasticsearch.action.admin.indices.mapping.put.PutMappingRequest;
-import org.elasticsearch.action.admin.indices.mapping.put.PutMappingResponse;
-import org.elasticsearch.client.Client;
-import org.graylog2.indexer.ranges.IndexRange;
 import org.graylog2.plugin.Tools;
 
-import javax.inject.Inject;
 import javax.inject.Singleton;
 import java.io.Serializable;
 import java.util.List;
 import java.util.Map;
-
-import static com.google.common.base.Preconditions.checkNotNull;
 
 /**
  * Representing the message type mapping in ElasticSearch. This is giving ES more
@@ -40,24 +32,6 @@ import static com.google.common.base.Preconditions.checkNotNull;
 @Singleton
 public class IndexMapping {
     public static final String TYPE_MESSAGE = "message";
-
-    private final Client client;
-
-    @Inject
-    public IndexMapping(Client client) {
-        this.client = checkNotNull(client);
-    }
-
-    public ActionFuture<PutMappingResponse> createMapping(final String index, final String type, final Map<String, Object> mapping) {
-        return client.admin().indices().putMapping(mappingRequest(index, type, mapping));
-    }
-
-    private PutMappingRequest mappingRequest(final String index, final String type, final Map<String, Object> mapping) {
-        return client.admin().indices().preparePutMapping(index)
-                .setType(type)
-                .setSource(ImmutableMap.of(type, mapping))
-                .request();
-    }
 
     public Map<String, Object> messageMapping(final String analyzer) {
         return ImmutableMap.of(

--- a/graylog2-server/src/test/java/org/graylog2/indexer/indices/IndicesTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/indexer/indices/IndicesTest.java
@@ -78,7 +78,7 @@ public class IndicesTest {
 
     @Before
     public void setUp() throws Exception {
-        indices = new Indices(client, CONFIG, new IndexMapping(client));
+        indices = new Indices(client, CONFIG, new IndexMapping());
     }
 
     @Test

--- a/graylog2-server/src/test/java/org/graylog2/indexer/nosqlunit/IndexCreatingDatabaseOperation.java
+++ b/graylog2-server/src/test/java/org/graylog2/indexer/nosqlunit/IndexCreatingDatabaseOperation.java
@@ -51,7 +51,7 @@ public class IndexCreatingDatabaseOperation implements DatabaseOperation<Client>
                 client.admin().indices().prepareDelete(index).execute().actionGet();
             }
 
-            Indices indices = new Indices(client, new ElasticsearchConfiguration(), new IndexMapping(client));
+            Indices indices = new Indices(client, new ElasticsearchConfiguration(), new IndexMapping());
             if (!indices.create(index)) {
                 throw new IllegalStateException("Couldn't create index " + index);
             }

--- a/graylog2-server/src/test/java/org/graylog2/indexer/ranges/EsIndexRangeServiceTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/indexer/ranges/EsIndexRangeServiceTest.java
@@ -85,7 +85,7 @@ public class EsIndexRangeServiceTest {
 
     @Before
     public void setUp() throws Exception {
-        indices = new Indices(client, ELASTICSEARCH_CONFIGURATION, new IndexMapping(client));
+        indices = new Indices(client, ELASTICSEARCH_CONFIGURATION, new IndexMapping());
         final Deflector deflector = new Deflector(null, ELASTICSEARCH_CONFIGURATION, new NullActivityWriter(), null, null, indices);
         indexRangeService = new EsIndexRangeService(client, deflector, indices, localEventBus, clusterEventBus, new MetricRegistry());
     }


### PR DESCRIPTION
When creating an Elasticsearch index and putting the respective mapping in separate operations, the mapping creation might fail (e. g. due to a timeout) and lead to invalid messages being indexed into Elasticsearch (e. g. with a wrong type for "timestamp" or other important message fields). Merging these operations should at least solve some of those error situations.

Refs #1502