### PR TITLE
Fix GelfChunkAggregator.ChunkEntry#equals() and #hashCode()

### DIFF
--- a/graylog2-inputs/src/main/java/org/graylog2/inputs/codecs/GelfCodec.java
+++ b/graylog2-inputs/src/main/java/org/graylog2/inputs/codecs/GelfCodec.java
@@ -105,7 +105,7 @@ public class GelfCodec extends AbstractCodec {
     @Nullable
     @Override
     public Message decode(@Nonnull final RawMessage rawMessage) {
-        final GELFMessage gelfMessage = new GELFMessage(rawMessage.getPayload());
+        final GELFMessage gelfMessage = new GELFMessage(rawMessage.getPayload(), rawMessage.getRemoteAddress());
         final String json = gelfMessage.getJSON();
 
         final JsonNode node;

--- a/graylog2-inputs/src/main/java/org/graylog2/inputs/codecs/gelf/GELFMessage.java
+++ b/graylog2-inputs/src/main/java/org/graylog2/inputs/codecs/gelf/GELFMessage.java
@@ -16,45 +16,91 @@
  */
 package org.graylog2.inputs.codecs.gelf;
 
+import org.graylog2.plugin.ResolvableInetSocketAddress;
 import org.graylog2.plugin.Tools;
 
+import javax.annotation.Nullable;
 import java.io.IOException;
-import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 
-/**
- * @author Lennart Koopmann <lennart@socketfeed.com>
- */
 public class GELFMessage {
 
     private final byte[] payload;
+    private final ResolvableInetSocketAddress sourceAddress;
 
-    public static final String ADDITIONAL_FIELD_PREFIX = "_";
+    /**
+     * @param payload Compressed or uncompressed
+     * @see GELFMessage.Type
+     */
+    public GELFMessage(final byte[] payload) {
+        this(payload, null);
+    }
 
-    private static final Charset UTF8_CHARSET = Charset.forName("UTF-8");
+    public GELFMessage(final byte[] payload, ResolvableInetSocketAddress sourceAddress) {
+        this.payload = payload;
+        this.sourceAddress = sourceAddress;
+    }
+
+    public Type getGELFType() {
+        if (payload.length < Type.HEADER_SIZE) {
+            throw new IllegalStateException("GELF message is too short. Not even the type header would fit.");
+        }
+        return Type.determineType(payload[0], payload[1]);
+    }
+
+    public String getJSON() {
+        try {
+            switch (getGELFType()) {
+                case ZLIB:
+                    return Tools.decompressZlib(payload);
+                case GZIP:
+                    return Tools.decompressGzip(payload);
+                case UNCOMPRESSED:
+                    return new String(payload, StandardCharsets.UTF_8);
+                case CHUNKED:
+                case UNSUPPORTED:
+                    throw new IllegalStateException("Unknown GELF type. Not supported.");
+            }
+        } catch (final IOException e) {
+            // Note that the UnsupportedEncodingException thrown by 'new String' can never happen because UTF-8
+            // is a mandatory JRE encoding which is always present. So we only need to mention the decompress exceptions here.
+            throw new IllegalStateException("Failed to decompress the GELF message payload", e);
+        }
+        return null;
+    }
+
+    public byte[] getPayload() {
+        return payload;
+    }
+
+    @Nullable
+    public ResolvableInetSocketAddress getSourceAddress() {
+        return sourceAddress;
+    }
 
     public enum Type {
 
-        UNSUPPORTED( (byte) 0x00, (byte) 0x00),
+        UNSUPPORTED((byte) 0x00, (byte) 0x00),
 
         /**
          * A ZLIB compressed message (RFC 1950)
          */
-        ZLIB( (byte) 0x78, (byte) 0x9c ),
+        ZLIB((byte) 0x78, (byte) 0x9c),
 
         /**
          * A GZIP compressed message (RFC 1952)
          */
-        GZIP( (byte) 0x1f, (byte) 0x8b ),
+        GZIP((byte) 0x1f, (byte) 0x8b),
 
         /**
          * A chunked GELF message
          */
-        CHUNKED( (byte) 0x1e, (byte) 0x0f ),
+        CHUNKED((byte) 0x1e, (byte) 0x0f),
 
         /**
          * An uncompressed message, the byte values are not used.
          */
-        UNCOMPRESSED( (byte) 0xff, (byte) 0xff);
+        UNCOMPRESSED((byte) 0xff, (byte) 0xff);
 
         private static final int HEADER_SIZE = 2;
 
@@ -108,47 +154,5 @@ public class GELFMessage {
         public byte second() {
             return bytes[1];
         }
-    }
-
-    /**
-     *
-     * @param payload Compressed or uncompressed
-     * @see GELFMessage.Type
-     */
-    public GELFMessage(final byte[] payload) {
-        this.payload = payload;
-    }
-
-    public Type getGELFType() {
-        if (payload.length < Type.HEADER_SIZE) {
-            throw new IllegalStateException("GELF message is too short. Not even the type header would fit.");
-        }
-        return Type.determineType(payload[0], payload[1]);
-    }
-
-    public String getJSON(){
-        try {
-            switch(getGELFType()) {
-                case ZLIB:
-                    return Tools.decompressZlib(payload);
-                case GZIP:
-                    return Tools.decompressGzip(payload);
-                case UNCOMPRESSED:
-                    return new String(payload, UTF8_CHARSET);
-                case CHUNKED:
-                case UNSUPPORTED:
-                    throw new IllegalStateException("Unknown GELF type. Not supported.");
-            }
-        }
-        catch (final IOException e) {
-            // Note that the UnsupportedEncodingException thrown by 'new String' can never happen because UTF-8
-            // is a mandatory JRE encoding which is always present. So we only need to mention the decompress exceptions here.
-            throw new IllegalStateException("Failed to decompress the GELF message payload", e);
-        }
-        return null;
-    }
-
-    public byte[] getPayload() {
-        return payload;
     }
 }

--- a/graylog2-plugin-interfaces/src/main/java/org/graylog2/plugin/ResolvableInetSocketAddress.java
+++ b/graylog2-plugin-interfaces/src/main/java/org/graylog2/plugin/ResolvableInetSocketAddress.java
@@ -22,24 +22,31 @@
  */
 package org.graylog2.plugin;
 
+import com.google.common.annotations.VisibleForTesting;
+
 import java.net.InetAddress;
 import java.net.InetSocketAddress;
 
+import static java.util.Objects.requireNonNull;
+
 /**
- * InetSocketAddress does not support finding out whether an IP address has been reverse looked up or not.<br/>
- * However, we need to avoid triggering a name service lookup unless specifically asked to.<br/>
+ * {@link InetSocketAddress} does not support finding out whether an IP address has been reverse looked up or not.
+ * However, we need to avoid triggering a name service lookup unless specifically asked to.
  * This class exists to make the reverse lookup step explicit in the code.
  */
 public class ResolvableInetSocketAddress {
     private final InetSocketAddress inetSocketAddress;
     private boolean reverseLookedUp = false;
 
-    public ResolvableInetSocketAddress(InetSocketAddress inetSocketAddress) {
-        this.inetSocketAddress = inetSocketAddress;
+    @VisibleForTesting
+    protected ResolvableInetSocketAddress(InetSocketAddress inetSocketAddress) {
+        this.inetSocketAddress = requireNonNull(inetSocketAddress);
     }
 
     public static ResolvableInetSocketAddress wrap(InetSocketAddress socketAddress) {
-        if (socketAddress == null) return null;
+        if (socketAddress == null) {
+            return null;
+        }
         return new ResolvableInetSocketAddress(socketAddress);
     }
 
@@ -78,5 +85,14 @@ public class ResolvableInetSocketAddress {
 
     public InetSocketAddress getInetSocketAddress() {
         return inetSocketAddress;
+    }
+
+    @Override
+    public String toString() {
+        if (isReverseLookedUp()) {
+            return getHostName() + ":" + getPort();
+        } else {
+            return getAddress().getHostAddress() + ":" + getPort();
+        }
     }
 }

--- a/graylog2-plugin-interfaces/src/test/java/org/graylog2/plugin/ResolvableInetSocketAddressTest.java
+++ b/graylog2-plugin-interfaces/src/test/java/org/graylog2/plugin/ResolvableInetSocketAddressTest.java
@@ -1,0 +1,134 @@
+/**
+ * The MIT License
+ * Copyright (c) 2012 Graylog, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.graylog2.plugin;
+
+import org.junit.Test;
+
+import java.net.Inet4Address;
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class ResolvableInetSocketAddressTest {
+
+    @Test
+    public void testWrapWithNull() throws Exception {
+        assertThat(ResolvableInetSocketAddress.wrap(null)).isNull();
+    }
+
+    @Test
+    public void testWrap() throws Exception {
+        final InetSocketAddress inetSocketAddress = new InetSocketAddress(Inet4Address.getLoopbackAddress(), 12345);
+        final ResolvableInetSocketAddress address = ResolvableInetSocketAddress.wrap(inetSocketAddress);
+
+        assertThat(address.getInetSocketAddress()).isSameAs(inetSocketAddress);
+    }
+
+    @Test
+    public void testReverseLookup() throws Exception {
+        final InetSocketAddress inetSocketAddress = new InetSocketAddress(Inet4Address.getLoopbackAddress(), 12345);
+        final ResolvableInetSocketAddress address = new ResolvableInetSocketAddress(inetSocketAddress);
+
+        assertThat(address.isReverseLookedUp()).isFalse();
+        assertThat(address.reverseLookup()).isEqualTo(inetSocketAddress.getHostName());
+        assertThat(address.isReverseLookedUp()).isTrue();
+    }
+
+    @Test
+    public void testIsReverseLookedUp() throws Exception {
+        final InetSocketAddress inetSocketAddress = new InetSocketAddress(Inet4Address.getLoopbackAddress(), 12345);
+        final ResolvableInetSocketAddress address = new ResolvableInetSocketAddress(inetSocketAddress);
+
+        assertThat(address.isReverseLookedUp()).isFalse();
+
+        address.reverseLookup();
+
+        assertThat(address.isReverseLookedUp()).isTrue();
+    }
+
+    @Test
+    public void testIsUnresolved() throws Exception {
+        final InetSocketAddress inetSocketAddress = new InetSocketAddress(Inet4Address.getLoopbackAddress(), 12345);
+        final ResolvableInetSocketAddress address = new ResolvableInetSocketAddress(inetSocketAddress);
+
+        assertThat(address.isUnresolved()).isEqualTo(inetSocketAddress.isUnresolved());
+    }
+
+    @Test
+    public void testGetAddress() throws Exception {
+        final InetSocketAddress inetSocketAddress = new InetSocketAddress(Inet4Address.getLoopbackAddress(), 12345);
+        final ResolvableInetSocketAddress address = new ResolvableInetSocketAddress(inetSocketAddress);
+
+        assertThat(address.getAddress()).isEqualTo(inetSocketAddress.getAddress());
+    }
+
+    @Test
+    public void testGetAddressBytes() throws Exception {
+        final InetSocketAddress inetSocketAddress = new InetSocketAddress(Inet4Address.getLoopbackAddress(), 12345);
+        final ResolvableInetSocketAddress address = new ResolvableInetSocketAddress(inetSocketAddress);
+
+        assertThat(address.getAddressBytes()).isEqualTo(inetSocketAddress.getAddress().getAddress());
+    }
+
+    @Test
+    public void testGetPort() throws Exception {
+        final InetSocketAddress inetSocketAddress = new InetSocketAddress(Inet4Address.getLoopbackAddress(), 12345);
+        final ResolvableInetSocketAddress address = new ResolvableInetSocketAddress(inetSocketAddress);
+
+        assertThat(address.getPort()).isEqualTo(inetSocketAddress.getPort());
+    }
+
+    @Test
+    public void testGetHostName() throws Exception {
+        final InetSocketAddress inetSocketAddress = new InetSocketAddress(Inet4Address.getLoopbackAddress(), 12345);
+        final ResolvableInetSocketAddress address = new ResolvableInetSocketAddress(inetSocketAddress);
+
+        assertThat(address.getHostName()).isNull();
+
+        address.reverseLookup();
+
+        assertThat(address.getHostName()).isEqualTo(inetSocketAddress.getHostName());
+    }
+
+    @Test
+    public void testGetInetSocketAddress() throws Exception {
+        final InetSocketAddress inetSocketAddress = new InetSocketAddress(Inet4Address.getLoopbackAddress(), 12345);
+        final ResolvableInetSocketAddress address = new ResolvableInetSocketAddress(inetSocketAddress);
+
+        assertThat(address.getInetSocketAddress()).isEqualTo(inetSocketAddress);
+    }
+
+    @Test
+    public void testToString() throws Exception {
+        final InetAddress localHost = Inet4Address.getLoopbackAddress();
+        final InetSocketAddress inetSocketAddress = new InetSocketAddress(localHost, 12345);
+        final ResolvableInetSocketAddress address = new ResolvableInetSocketAddress(inetSocketAddress);
+
+        assertThat(address.toString()).isEqualTo(address.getAddress().getHostAddress() + ":" + address.getPort());
+
+        address.reverseLookup();
+
+        assertThat(address.toString()).isEqualTo(address.getHostName() + ":" + address.getPort());
+    }
+}


### PR DESCRIPTION
This PR fixes the implementations of `GelfChunkAggregator.ChunkEntry#equals()` and `GelfChunkAggregator.ChunkEntry#hashCode()`.

The previous implementations didn't take into account that `AtomicInteger` and `AtomicReferenceArray<T>` do not override `Object#equals()` and `Object#hashCode()` and thus are never equal and the hash code is never the same.

While the new implementations are slower (citation needed…), they are at least *correct*.

Refs #1561, specifically https://github.com/Graylog2/graylog2-server/issues/1561#issuecomment-156433533