### PR TITLE
Fix Html serialization

### DIFF
--- a/graylog2-rest-client/src/main/java/org/graylog2/restclient/models/FieldMapper.java
+++ b/graylog2-rest-client/src/main/java/org/graylog2/restclient/models/FieldMapper.java
@@ -17,9 +17,8 @@
 package org.graylog2.restclient.models;
 
 import com.google.common.collect.Lists;
-import org.graylog2.restclient.lib.Tools;
 import org.apache.commons.lang3.StringEscapeUtils;
-import play.twirl.api.Html;
+import org.graylog2.restclient.lib.Tools;
 
 import java.util.List;
 
@@ -58,14 +57,14 @@ public class FieldMapper {
         return value;
     }
 
-    private static Html convertNewlinesToBr(Object fullMessage) {
+    private static String convertNewlinesToBr(Object fullMessage) {
         if (fullMessage == null) {
             return null;
         }
 
         String s = StringEscapeUtils.escapeHtml4(fullMessage.toString());
         s = s.replaceAll("\\n", "<br>");
-        return Html.apply(s);
+        return s;
     }
 
     private static String mapSyslogLevel(Object level) {


### PR DESCRIPTION
The JSON serialization of the formatted `full_message` field is not working properly, returning an empty object (`{}`). As we render those fields in Javascript, we can safely return the string representation of that
Html.

I don't feel really strong about the change, so please let me know if you know a better way of fixing the serialization of `play.twirl.api.Html` objects. 

Refs Graylog2/graylog2-web-interface#1686