### PR TITLE
Proxied cluster metrics

### DIFF
--- a/graylog2-server/pom.xml
+++ b/graylog2-server/pom.xml
@@ -348,6 +348,14 @@
             <groupId>org.apache.directory.server</groupId>
             <artifactId>ldap-client-test</artifactId>
         </dependency>
+        <dependency>
+            <groupId>com.squareup.retrofit</groupId>
+            <artifactId>retrofit</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.squareup.retrofit</groupId>
+            <artifactId>converter-jackson</artifactId>
+        </dependency>
     </dependencies>
 
     <build>

--- a/graylog2-server/src/main/java/org/graylog2/rest/RemoteInterfaceProvider.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/RemoteInterfaceProvider.java
@@ -1,0 +1,56 @@
+package org.graylog2.rest;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.squareup.okhttp.Interceptor;
+import com.squareup.okhttp.OkHttpClient;
+import com.squareup.okhttp.Request;
+import com.squareup.okhttp.Response;
+import org.graylog2.cluster.Node;
+import retrofit.JacksonConverterFactory;
+import retrofit.Retrofit;
+
+import javax.inject.Inject;
+import java.io.IOException;
+
+public class RemoteInterfaceProvider {
+    private final ObjectMapper objectMapper;
+    private final OkHttpClient okHttpClient;
+
+    @Inject
+    public RemoteInterfaceProvider(ObjectMapper objectMapper,
+                                   OkHttpClient okHttpClient) {
+        this.objectMapper = objectMapper;
+        this.okHttpClient = okHttpClient;
+    }
+
+    public <T> T get(Node node, final String authorizationToken, Class<T> interfaceClass) {
+        final OkHttpClient okHttpClient = this.okHttpClient.clone();
+        okHttpClient.interceptors().add(new Interceptor() {
+            @Override
+            public Response intercept(Interceptor.Chain chain) throws IOException {
+                final Request original = chain.request();
+
+                Request.Builder builder = original.newBuilder()
+                        .header("Accept", "application/json")
+                        .method(original.method(), original.body());
+
+                if (authorizationToken != null) {
+                    builder = builder.header("Authorization", authorizationToken);
+                }
+
+                return chain.proceed(builder.build());
+            }
+        });
+        final Retrofit retrofit = new Retrofit.Builder()
+                .baseUrl(node.getTransportAddress())
+                .addConverterFactory(JacksonConverterFactory.create(objectMapper))
+                .client(okHttpClient)
+                .build();
+
+        return retrofit.create(interfaceClass);
+    }
+
+    public <T> T get(Node node, Class<T> interfaceClass) {
+        return get(node, null, interfaceClass);
+    }
+}

--- a/graylog2-server/src/main/java/org/graylog2/rest/RemoteInterfaceProvider.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/RemoteInterfaceProvider.java
@@ -1,3 +1,19 @@
+/**
+ * This file is part of Graylog.
+ *
+ * Graylog is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package org.graylog2.rest;
 
 import com.fasterxml.jackson.databind.ObjectMapper;

--- a/graylog2-server/src/main/java/org/graylog2/rest/resources/cluster/ClusterMetricsResource.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/resources/cluster/ClusterMetricsResource.java
@@ -1,0 +1,108 @@
+package org.graylog2.rest.resources.cluster;
+
+import com.codahale.metrics.annotation.Timed;
+import com.wordnik.swagger.annotations.Api;
+import com.wordnik.swagger.annotations.ApiOperation;
+import com.wordnik.swagger.annotations.ApiParam;
+import com.wordnik.swagger.annotations.ApiResponse;
+import com.wordnik.swagger.annotations.ApiResponses;
+import org.apache.shiro.authz.UnauthorizedException;
+import org.apache.shiro.authz.annotation.RequiresAuthentication;
+import org.apache.shiro.authz.annotation.RequiresPermissions;
+import org.graylog2.cluster.Node;
+import org.graylog2.cluster.NodeNotFoundException;
+import org.graylog2.cluster.NodeService;
+import org.graylog2.rest.RemoteInterfaceProvider;
+import org.graylog2.rest.models.system.metrics.requests.MetricsReadRequest;
+import org.graylog2.rest.models.system.metrics.responses.MetricNamesResponse;
+import org.graylog2.rest.models.system.metrics.responses.MetricsSummaryResponse;
+import org.graylog2.shared.rest.resources.system.RemoteMetricsResource;
+import org.graylog2.shared.security.RestPermissions;
+import retrofit.Response;
+
+import javax.inject.Inject;
+import javax.validation.Valid;
+import javax.validation.constraints.NotNull;
+import javax.ws.rs.GET;
+import javax.ws.rs.POST;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+import javax.ws.rs.Produces;
+import javax.ws.rs.WebApplicationException;
+import javax.ws.rs.core.Context;
+import javax.ws.rs.core.HttpHeaders;
+import javax.ws.rs.core.MediaType;
+import java.io.IOException;
+import java.util.List;
+
+@RequiresAuthentication
+@Api(value = "Cluster/Metrics", description = "Cluster-wide Internal Graylog2 metrics")
+@Path("/cluster/{nodeId}/metrics")
+public class ClusterMetricsResource {
+    private final RemoteMetricsResource remoteMetricsResource;
+
+    @Inject
+    public ClusterMetricsResource(@PathParam("nodeId") String nodeId,
+                                  NodeService nodeService,
+                                  RemoteInterfaceProvider remoteInterfaceProvider,
+                                  @Context HttpHeaders httpHeaders) throws NodeNotFoundException {
+        final Node targetNode = nodeService.byNodeId(nodeId);
+
+        final List<String> authenticationTokens = httpHeaders.getRequestHeader("Authorization");
+        if (authenticationTokens != null && authenticationTokens.size() >= 1) {
+            this.remoteMetricsResource = remoteInterfaceProvider.get(targetNode, authenticationTokens.get(0), RemoteMetricsResource.class);
+        } else {
+            throw new UnauthorizedException();
+        }
+    }
+
+    @GET
+    @Timed
+    @Path("/names")
+    @ApiOperation(value = "Get all metrics keys/names from node")
+    @RequiresPermissions(RestPermissions.METRICS_ALLKEYS)
+    @Produces(MediaType.APPLICATION_JSON)
+    public MetricNamesResponse metricNames() throws IOException {
+        final Response<MetricNamesResponse> result =  remoteMetricsResource.metricNames().execute();
+        if (result.isSuccess()) {
+            return result.body();
+        } else {
+            throw new WebApplicationException(result.message(), result.code());
+        }
+    }
+
+    @POST
+    @Timed
+    @Path("/multiple")
+    @ApiOperation("Get the values of multiple metrics at once from node")
+    @ApiResponses(value = {
+            @ApiResponse(code = 400, message = "Malformed body")
+    })
+    public MetricsSummaryResponse multipleMetrics(@ApiParam(name = "Requested metrics", required = true)
+                                                  @Valid @NotNull MetricsReadRequest request) throws IOException {
+        final Response<MetricsSummaryResponse> result = remoteMetricsResource.multipleMetrics(request).execute();
+        if (result.isSuccess()) {
+            return result.body();
+        } else {
+            throw new WebApplicationException(result.message(), result.code());
+        }
+    }
+
+    @GET
+    @Timed
+    @Path("/namespace/{namespace}")
+    @ApiOperation(value = "Get all metrics of a namespace from node")
+    @ApiResponses(value = {
+            @ApiResponse(code = 404, message = "No such metric namespace")
+    })
+    @Produces(MediaType.APPLICATION_JSON)
+    public MetricsSummaryResponse byNamespace(@ApiParam(name = "namespace", required = true)
+                                              @PathParam("namespace") String namespace) throws IOException {
+        final Response<MetricsSummaryResponse> result = remoteMetricsResource.byNamespace(namespace).execute();
+        if (result.isSuccess()) {
+            return result.body();
+        } else {
+            throw new WebApplicationException(result.message(), result.code());
+        }
+    }
+}

--- a/graylog2-server/src/main/java/org/graylog2/rest/resources/cluster/ClusterMetricsResource.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/resources/cluster/ClusterMetricsResource.java
@@ -1,3 +1,19 @@
+/**
+ * This file is part of Graylog.
+ *
+ * Graylog is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package org.graylog2.rest.resources.cluster;
 
 import com.codahale.metrics.annotation.Timed;

--- a/graylog2-server/src/main/java/org/graylog2/rest/resources/cluster/ClusterMetricsResource.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/resources/cluster/ClusterMetricsResource.java
@@ -6,7 +6,6 @@ import com.wordnik.swagger.annotations.ApiOperation;
 import com.wordnik.swagger.annotations.ApiParam;
 import com.wordnik.swagger.annotations.ApiResponse;
 import com.wordnik.swagger.annotations.ApiResponses;
-import org.apache.shiro.authz.UnauthorizedException;
 import org.apache.shiro.authz.annotation.RequiresAuthentication;
 import org.apache.shiro.authz.annotation.RequiresPermissions;
 import org.graylog2.cluster.Node;
@@ -16,6 +15,7 @@ import org.graylog2.rest.RemoteInterfaceProvider;
 import org.graylog2.rest.models.system.metrics.requests.MetricsReadRequest;
 import org.graylog2.rest.models.system.metrics.responses.MetricNamesResponse;
 import org.graylog2.rest.models.system.metrics.responses.MetricsSummaryResponse;
+import org.graylog2.shared.rest.resources.RestResource;
 import org.graylog2.shared.rest.resources.system.RemoteMetricsResource;
 import org.graylog2.shared.security.RestPermissions;
 import retrofit.Response;
@@ -38,7 +38,7 @@ import java.util.List;
 @RequiresAuthentication
 @Api(value = "Cluster/Metrics", description = "Cluster-wide Internal Graylog2 metrics")
 @Path("/cluster/{nodeId}/metrics")
-public class ClusterMetricsResource {
+public class ClusterMetricsResource extends RestResource {
     private final RemoteMetricsResource remoteMetricsResource;
 
     @Inject
@@ -52,7 +52,7 @@ public class ClusterMetricsResource {
         if (authenticationTokens != null && authenticationTokens.size() >= 1) {
             this.remoteMetricsResource = remoteInterfaceProvider.get(targetNode, authenticationTokens.get(0), RemoteMetricsResource.class);
         } else {
-            throw new UnauthorizedException();
+            this.remoteMetricsResource = remoteInterfaceProvider.get(targetNode, RemoteMetricsResource.class);
         }
     }
 

--- a/graylog2-server/src/main/java/org/graylog2/rest/resources/cluster/ClusterMetricsResource.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/resources/cluster/ClusterMetricsResource.java
@@ -54,21 +54,26 @@ import java.util.List;
 @RequiresAuthentication
 @Api(value = "Cluster/Metrics", description = "Cluster-wide Internal Graylog2 metrics")
 @Path("/cluster/{nodeId}/metrics")
+@Produces(MediaType.APPLICATION_JSON)
 public class ClusterMetricsResource extends RestResource {
-    private final RemoteMetricsResource remoteMetricsResource;
+    private final NodeService nodeService;
+    private final RemoteInterfaceProvider remoteInterfaceProvider;
 
     @Inject
-    public ClusterMetricsResource(@PathParam("nodeId") String nodeId,
-                                  NodeService nodeService,
-                                  RemoteInterfaceProvider remoteInterfaceProvider,
-                                  @Context HttpHeaders httpHeaders) throws NodeNotFoundException {
+    public ClusterMetricsResource(NodeService nodeService,
+                                  RemoteInterfaceProvider remoteInterfaceProvider) {
+        this.nodeService = nodeService;
+        this.remoteInterfaceProvider = remoteInterfaceProvider;
+    }
+
+    private RemoteMetricsResource getResourceForNode(String nodeId, HttpHeaders httpHeaders) throws NodeNotFoundException {
         final Node targetNode = nodeService.byNodeId(nodeId);
 
         final List<String> authenticationTokens = httpHeaders.getRequestHeader("Authorization");
         if (authenticationTokens != null && authenticationTokens.size() >= 1) {
-            this.remoteMetricsResource = remoteInterfaceProvider.get(targetNode, authenticationTokens.get(0), RemoteMetricsResource.class);
+            return remoteInterfaceProvider.get(targetNode, authenticationTokens.get(0), RemoteMetricsResource.class);
         } else {
-            this.remoteMetricsResource = remoteInterfaceProvider.get(targetNode, RemoteMetricsResource.class);
+            return remoteInterfaceProvider.get(targetNode, RemoteMetricsResource.class);
         }
     }
 
@@ -77,9 +82,10 @@ public class ClusterMetricsResource extends RestResource {
     @Path("/names")
     @ApiOperation(value = "Get all metrics keys/names from node")
     @RequiresPermissions(RestPermissions.METRICS_ALLKEYS)
-    @Produces(MediaType.APPLICATION_JSON)
-    public MetricNamesResponse metricNames() throws IOException {
-        final Response<MetricNamesResponse> result =  remoteMetricsResource.metricNames().execute();
+    public MetricNamesResponse metricNames(@ApiParam(name = "nodeId", value = "The id of the node whose metrics we want.", required = true)
+                                           @PathParam("nodeId") String nodeId,
+                                           @Context HttpHeaders httpHeaders) throws IOException, NodeNotFoundException {
+        final Response<MetricNamesResponse> result = getResourceForNode(nodeId, httpHeaders).metricNames().execute();
         if (result.isSuccess()) {
             return result.body();
         } else {
@@ -94,9 +100,12 @@ public class ClusterMetricsResource extends RestResource {
     @ApiResponses(value = {
             @ApiResponse(code = 400, message = "Malformed body")
     })
-    public MetricsSummaryResponse multipleMetrics(@ApiParam(name = "Requested metrics", required = true)
-                                                  @Valid @NotNull MetricsReadRequest request) throws IOException {
-        final Response<MetricsSummaryResponse> result = remoteMetricsResource.multipleMetrics(request).execute();
+    public MetricsSummaryResponse multipleMetrics(@ApiParam(name = "nodeId", value = "The id of the node whose metrics we want.", required = true)
+                                                  @PathParam("nodeId") String nodeId,
+                                                  @ApiParam(name = "Requested metrics", required = true)
+                                                  @Valid @NotNull MetricsReadRequest request,
+                                                  @Context HttpHeaders httpHeaders) throws IOException, NodeNotFoundException {
+        final Response<MetricsSummaryResponse> result = getResourceForNode(nodeId, httpHeaders).multipleMetrics(request).execute();
         if (result.isSuccess()) {
             return result.body();
         } else {
@@ -111,10 +120,12 @@ public class ClusterMetricsResource extends RestResource {
     @ApiResponses(value = {
             @ApiResponse(code = 404, message = "No such metric namespace")
     })
-    @Produces(MediaType.APPLICATION_JSON)
-    public MetricsSummaryResponse byNamespace(@ApiParam(name = "namespace", required = true)
-                                              @PathParam("namespace") String namespace) throws IOException {
-        final Response<MetricsSummaryResponse> result = remoteMetricsResource.byNamespace(namespace).execute();
+    public MetricsSummaryResponse byNamespace(@ApiParam(name = "nodeId", value = "The id of the node whose metrics we want.", required = true)
+                                              @PathParam("nodeId") String nodeId,
+                                              @ApiParam(name = "namespace", required = true)
+                                              @PathParam("namespace") String namespace,
+                                              @Context HttpHeaders httpHeaders) throws IOException, NodeNotFoundException {
+        final Response<MetricsSummaryResponse> result = getResourceForNode(nodeId, httpHeaders).byNamespace(namespace).execute();
         if (result.isSuccess()) {
             return result.body();
         } else {

--- a/graylog2-server/src/main/java/org/graylog2/rest/resources/cluster/ClusterSystemJobResource.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/resources/cluster/ClusterSystemJobResource.java
@@ -1,0 +1,77 @@
+package org.graylog2.rest.resources.cluster;
+
+import com.codahale.metrics.annotation.Timed;
+import com.wordnik.swagger.annotations.Api;
+import com.wordnik.swagger.annotations.ApiOperation;
+import org.apache.shiro.authz.annotation.RequiresAuthentication;
+import org.graylog2.cluster.Node;
+import org.graylog2.cluster.NodeNotFoundException;
+import org.graylog2.cluster.NodeService;
+import org.graylog2.rest.RemoteInterfaceProvider;
+import org.graylog2.rest.models.system.SystemJobSummary;
+import org.graylog2.rest.resources.system.jobs.RemoteSystemJobResource;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import retrofit.Response;
+
+import javax.inject.Inject;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.Context;
+import javax.ws.rs.core.HttpHeaders;
+import javax.ws.rs.core.MediaType;
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+@RequiresAuthentication
+@Api(value = "Cluster/Jobs", description = "Cluster-wide System Jobs")
+@Path("/cluster/jobs")
+public class ClusterSystemJobResource {
+    private static final Logger LOG = LoggerFactory.getLogger(ClusterSystemJobResource.class);
+
+    private final NodeService nodeService;
+    private final RemoteInterfaceProvider remoteInterfaceProvider;
+    private final String authenticationToken;
+
+    @Inject
+    public ClusterSystemJobResource(NodeService nodeService,
+                                    RemoteInterfaceProvider remoteInterfaceProvider,
+                                    @Context HttpHeaders httpHeaders) throws NodeNotFoundException {
+        this.nodeService = nodeService;
+        this.remoteInterfaceProvider = remoteInterfaceProvider;
+
+        final List<String> authenticationTokens = httpHeaders.getRequestHeader("Authorization");
+        if (authenticationTokens != null && authenticationTokens.size() >= 1) {
+            this.authenticationToken = authenticationTokens.get(0);
+        } else {
+            this.authenticationToken = null;
+        }
+    }
+
+    @GET
+    @Timed
+    @ApiOperation(value = "List currently running jobs")
+    @Produces(MediaType.APPLICATION_JSON)
+    public Map<String, Map<String, List<SystemJobSummary>>> list() throws IOException {
+        final Map<String, Node> nodes = nodeService.allActive();
+        final Map<String, Map<String, List<SystemJobSummary>>> result = new HashMap<>(nodes.size());
+        nodes.entrySet().stream().forEach(entry -> {
+            final RemoteSystemJobResource remoteSystemJobResource = remoteInterfaceProvider.get(entry.getValue(), this.authenticationToken, RemoteSystemJobResource.class);
+            try {
+                final Response<Map<String, List<SystemJobSummary>>> response = remoteSystemJobResource.list().execute();
+                if (response.isSuccess()) {
+                    result.put(entry.getKey(), response.body());
+                } else {
+                    LOG.warn("Unable to fetch system jobs from node " + entry.getKey() + ": " + response);
+                }
+            } catch (IOException e) {
+                LOG.warn("Unable to fetch system jobs from node " + entry.getKey() + ": ", e);
+            }
+        });
+
+        return result;
+    }
+}

--- a/graylog2-server/src/main/java/org/graylog2/rest/resources/cluster/ClusterSystemJobResource.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/resources/cluster/ClusterSystemJobResource.java
@@ -1,3 +1,19 @@
+/**
+ * This file is part of Graylog.
+ *
+ * Graylog is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package org.graylog2.rest.resources.cluster;
 
 import com.codahale.metrics.annotation.Timed;

--- a/graylog2-server/src/main/java/org/graylog2/rest/resources/system/jobs/RemoteSystemJobResource.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/resources/system/jobs/RemoteSystemJobResource.java
@@ -1,0 +1,22 @@
+package org.graylog2.rest.resources.system.jobs;
+
+import org.graylog2.rest.models.system.SystemJobSummary;
+import org.graylog2.rest.models.system.jobs.requests.TriggerRequest;
+import retrofit.Call;
+import retrofit.http.Body;
+import retrofit.http.GET;
+import retrofit.http.POST;
+
+import java.util.List;
+import java.util.Map;
+
+public interface RemoteSystemJobResource {
+    @GET("/system/jobs")
+    Call<Map<String, List<SystemJobSummary>>> list();
+
+    @GET("/system/jobs/{jobId}")
+    Call<SystemJobSummary> get(String jobId);
+
+    @POST("/system/jobs")
+    Call trigger(@Body TriggerRequest tr);
+}

--- a/graylog2-server/src/main/java/org/graylog2/rest/resources/system/jobs/RemoteSystemJobResource.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/resources/system/jobs/RemoteSystemJobResource.java
@@ -1,3 +1,19 @@
+/**
+ * This file is part of Graylog.
+ *
+ * Graylog is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package org.graylog2.rest.resources.system.jobs;
 
 import org.graylog2.rest.models.system.SystemJobSummary;

--- a/graylog2-shared/pom.xml
+++ b/graylog2-shared/pom.xml
@@ -226,6 +226,10 @@
             <groupId>com.fasterxml.jackson.module</groupId>
             <artifactId>jackson-module-jsonSchema</artifactId>
         </dependency>
+        <dependency>
+            <groupId>com.squareup.retrofit</groupId>
+            <artifactId>retrofit</artifactId>
+        </dependency>
     </dependencies>
 
     <build>

--- a/graylog2-shared/src/main/java/org/graylog2/shared/rest/resources/system/RemoteMetricsResource.java
+++ b/graylog2-shared/src/main/java/org/graylog2/shared/rest/resources/system/RemoteMetricsResource.java
@@ -1,0 +1,24 @@
+package org.graylog2.shared.rest.resources.system;
+
+import org.graylog2.rest.models.system.metrics.requests.MetricsReadRequest;
+import org.graylog2.rest.models.system.metrics.responses.MetricNamesResponse;
+import org.graylog2.rest.models.system.metrics.responses.MetricsSummaryResponse;
+import retrofit.Call;
+import retrofit.http.Body;
+import retrofit.http.GET;
+import retrofit.http.POST;
+import retrofit.http.Path;
+
+import javax.validation.Valid;
+import javax.validation.constraints.NotNull;
+
+public interface RemoteMetricsResource {
+    @GET("/system/metrics/names")
+    Call<MetricNamesResponse> metricNames();
+
+    @POST("/system/metrics/multiple")
+    Call<MetricsSummaryResponse> multipleMetrics(@Body @Valid @NotNull MetricsReadRequest request);
+
+    @GET("/system/metrics/namespace/{namespace}")
+    Call<MetricsSummaryResponse> byNamespace(@Path("namespace") String namespace);
+}

--- a/graylog2-shared/src/main/java/org/graylog2/shared/rest/resources/system/RemoteMetricsResource.java
+++ b/graylog2-shared/src/main/java/org/graylog2/shared/rest/resources/system/RemoteMetricsResource.java
@@ -1,3 +1,19 @@
+/**
+ * This file is part of Graylog.
+ *
+ * Graylog is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package org.graylog2.shared.rest.resources.system;
 
 import org.graylog2.rest.models.system.metrics.requests.MetricsReadRequest;

--- a/pom.xml
+++ b/pom.xml
@@ -690,6 +690,16 @@
                 <artifactId>javax.el-api</artifactId>
                 <version>3.0.0</version>
             </dependency>
+            <dependency>
+                <groupId>com.squareup.retrofit</groupId>
+                <artifactId>retrofit</artifactId>
+                <version>2.0.0-beta2</version>
+            </dependency>
+            <dependency>
+                <groupId>com.squareup.retrofit</groupId>
+                <artifactId>converter-jackson</artifactId>
+                <version>2.0.0-beta2</version>
+            </dependency>
 
             <dependency>
                 <groupId>org.mockito</groupId>


### PR DESCRIPTION
Due to the web interface now talking to a single node only (in contrast to the play web interface component connecting to every node in the cluster) we need a mechanism to retrieve metrics (and other resources) from other nodes than the one we are talking to. Therefore a ClusterMetricsResource was created that proxies requests to other nodes for metrics retrieval.
