### PR TITLE
Bulk indices calls

### DIFF
--- a/graylog2-rest-models/src/main/java/org/graylog2/rest/models/system/deflector/responses/DeflectorSummary.java
+++ b/graylog2-rest-models/src/main/java/org/graylog2/rest/models/system/deflector/responses/DeflectorSummary.java
@@ -20,6 +20,7 @@ import com.fasterxml.jackson.annotation.JsonAutoDetect;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.auto.value.AutoValue;
+import org.graylog2.rest.models.system.responses.DeflectorConfigResponse;
 
 @AutoValue
 @JsonAutoDetect
@@ -30,9 +31,13 @@ public abstract class DeflectorSummary {
     @JsonProperty("current_target")
     public abstract String currentTarget();
 
+    @JsonProperty("config")
+    public abstract DeflectorConfigResponse config();
+
     @JsonCreator
     public static DeflectorSummary create(@JsonProperty("is_up") boolean isUp,
-                                          @JsonProperty("current_target") String currentTarget) {
-        return new AutoValue_DeflectorSummary(isUp, currentTarget);
+                                          @JsonProperty("current_target") String currentTarget,
+                                          @JsonProperty("config") DeflectorConfigResponse config) {
+        return new AutoValue_DeflectorSummary(isUp, currentTarget, config);
     }
 }

--- a/graylog2-rest-models/src/main/java/org/graylog2/rest/models/system/indexer/responses/AllIndices.java
+++ b/graylog2-rest-models/src/main/java/org/graylog2/rest/models/system/indexer/responses/AllIndices.java
@@ -23,7 +23,7 @@ import com.google.auto.value.AutoValue;
 
 @AutoValue
 @JsonAutoDetect
-public abstract class BulkIndices {
+public abstract class AllIndices {
     @JsonProperty("closed")
     public abstract ClosedIndices closed();
 
@@ -31,12 +31,12 @@ public abstract class BulkIndices {
     public abstract ClosedIndices reopened();
 
     @JsonProperty("all")
-    public abstract AllIndicesInfo all();
+    public abstract OpenIndicesInfo all();
 
     @JsonCreator
-    public static BulkIndices create(@JsonProperty("closed") ClosedIndices closed,
-                                     @JsonProperty("reopened") ClosedIndices reopened,
-                                     @JsonProperty("all") AllIndicesInfo all) {
-        return new AutoValue_BulkIndices(closed, reopened, all);
+    public static AllIndices create(@JsonProperty("closed") ClosedIndices closed,
+                                    @JsonProperty("reopened") ClosedIndices reopened,
+                                    @JsonProperty("all") OpenIndicesInfo all) {
+        return new AutoValue_AllIndices(closed, reopened, all);
     }
 }

--- a/graylog2-rest-models/src/main/java/org/graylog2/rest/models/system/indexer/responses/BulkIndices.java
+++ b/graylog2-rest-models/src/main/java/org/graylog2/rest/models/system/indexer/responses/BulkIndices.java
@@ -1,3 +1,19 @@
+/**
+ * This file is part of Graylog.
+ *
+ * Graylog is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package org.graylog2.rest.models.system.indexer.responses;
 
 import com.fasterxml.jackson.annotation.JsonAutoDetect;

--- a/graylog2-rest-models/src/main/java/org/graylog2/rest/models/system/indexer/responses/BulkIndices.java
+++ b/graylog2-rest-models/src/main/java/org/graylog2/rest/models/system/indexer/responses/BulkIndices.java
@@ -1,0 +1,26 @@
+package org.graylog2.rest.models.system.indexer.responses;
+
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.auto.value.AutoValue;
+
+@AutoValue
+@JsonAutoDetect
+public abstract class BulkIndices {
+    @JsonProperty("closed")
+    public abstract ClosedIndices closed();
+
+    @JsonProperty("reopened")
+    public abstract ClosedIndices reopened();
+
+    @JsonProperty("all")
+    public abstract AllIndicesInfo all();
+
+    @JsonCreator
+    public static BulkIndices create(@JsonProperty("closed") ClosedIndices closed,
+                                         @JsonProperty("reopened") ClosedIndices reopened,
+                                         @JsonProperty("all") AllIndicesInfo all) {
+        return new AutoValue_BulkIndices(closed, reopened, all);
+    }
+}

--- a/graylog2-rest-models/src/main/java/org/graylog2/rest/models/system/indexer/responses/BulkIndices.java
+++ b/graylog2-rest-models/src/main/java/org/graylog2/rest/models/system/indexer/responses/BulkIndices.java
@@ -35,8 +35,8 @@ public abstract class BulkIndices {
 
     @JsonCreator
     public static BulkIndices create(@JsonProperty("closed") ClosedIndices closed,
-                                         @JsonProperty("reopened") ClosedIndices reopened,
-                                         @JsonProperty("all") AllIndicesInfo all) {
+                                     @JsonProperty("reopened") ClosedIndices reopened,
+                                     @JsonProperty("all") AllIndicesInfo all) {
         return new AutoValue_BulkIndices(closed, reopened, all);
     }
 }

--- a/graylog2-rest-models/src/main/java/org/graylog2/rest/models/system/indexer/responses/OpenIndicesInfo.java
+++ b/graylog2-rest-models/src/main/java/org/graylog2/rest/models/system/indexer/responses/OpenIndicesInfo.java
@@ -25,12 +25,12 @@ import java.util.Map;
 
 @JsonAutoDetect
 @AutoValue
-public abstract class AllIndicesInfo {
+public abstract class OpenIndicesInfo {
     @JsonProperty
     public abstract Map<String, IndexInfo> indices();
 
     @JsonCreator
-    public static AllIndicesInfo create(@JsonProperty("indices") Map<String, IndexInfo> indices) {
-        return new AutoValue_AllIndicesInfo(indices);
+    public static OpenIndicesInfo create(@JsonProperty("indices") Map<String, IndexInfo> indices) {
+        return new AutoValue_OpenIndicesInfo(indices);
     }
 }

--- a/graylog2-server/src/main/java/org/graylog2/rest/resources/system/DeflectorResource.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/resources/system/DeflectorResource.java
@@ -78,7 +78,7 @@ public class DeflectorResource extends RestResource {
     @RequiresPermissions(RestPermissions.DEFLECTOR_READ)
     @Produces(MediaType.APPLICATION_JSON)
     public DeflectorSummary deflector() {
-        return DeflectorSummary.create(deflector.isUp(), deflector.getCurrentActualTargetIndex());
+        return DeflectorSummary.create(deflector.isUp(), deflector.getCurrentActualTargetIndex(), this.config());
     }
 
     @GET

--- a/graylog2-server/src/main/java/org/graylog2/rest/resources/system/indexer/IndicesResource.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/resources/system/indexer/IndicesResource.java
@@ -32,8 +32,8 @@ import org.graylog2.indexer.Deflector;
 import org.graylog2.indexer.cluster.Cluster;
 import org.graylog2.indexer.indices.IndexStatistics;
 import org.graylog2.indexer.indices.Indices;
-import org.graylog2.rest.models.system.indexer.responses.AllIndicesInfo;
-import org.graylog2.rest.models.system.indexer.responses.BulkIndices;
+import org.graylog2.rest.models.system.indexer.responses.OpenIndicesInfo;
+import org.graylog2.rest.models.system.indexer.responses.AllIndices;
 import org.graylog2.rest.models.system.indexer.responses.ClosedIndices;
 import org.graylog2.rest.models.system.indexer.responses.IndexInfo;
 import org.graylog2.rest.models.system.indexer.responses.IndexStats;
@@ -105,10 +105,10 @@ public class IndicesResource extends RestResource {
 
     @GET
     @Timed
-    @ApiOperation(value = "Get information of all indices managed by Graylog and their shards.")
+    @ApiOperation(value = "Get information of all open indices managed by Graylog and their shards.")
     @RequiresPermissions(RestPermissions.INDICES_READ)
     @Produces(MediaType.APPLICATION_JSON)
-    public AllIndicesInfo all() {
+    public OpenIndicesInfo open() {
         final Set<IndexStatistics> indicesStats = indices.getIndicesStats();
 
         final Map<String, IndexInfo> indexInfos = new HashMap<>();
@@ -127,7 +127,7 @@ public class IndicesResource extends RestResource {
             indexInfos.put(indexStatistics.indexName(), indexInfo);
         }
 
-        return AllIndicesInfo.create(indexInfos);
+        return OpenIndicesInfo.create(indexInfos);
     }
 
     @GET
@@ -179,8 +179,8 @@ public class IndicesResource extends RestResource {
     @Path("/all")
     @ApiOperation(value = "List all open, closed and reopened indices.")
     @Produces(MediaType.APPLICATION_JSON)
-    public BulkIndices bulk() {
-        return BulkIndices.create(this.closed(), this.reopened(), this.all());
+    public AllIndices all() {
+        return AllIndices.create(this.closed(), this.reopened(), this.open());
     }
 
 

--- a/graylog2-server/src/main/java/org/graylog2/rest/resources/system/indexer/IndicesResource.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/resources/system/indexer/IndicesResource.java
@@ -177,7 +177,7 @@ public class IndicesResource extends RestResource {
     @GET
     @Timed
     @Path("/all")
-    @ApiOperation(value = "Get a list of all indices, open, closed and reopened.")
+    @ApiOperation(value = "List all open, closed and reopened indices.")
     @Produces(MediaType.APPLICATION_JSON)
     public BulkIndices bulk() {
         return BulkIndices.create(this.closed(), this.reopened(), this.all());

--- a/graylog2-server/src/main/java/org/graylog2/rest/resources/system/indexer/IndicesResource.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/resources/system/indexer/IndicesResource.java
@@ -33,6 +33,7 @@ import org.graylog2.indexer.cluster.Cluster;
 import org.graylog2.indexer.indices.IndexStatistics;
 import org.graylog2.indexer.indices.Indices;
 import org.graylog2.rest.models.system.indexer.responses.AllIndicesInfo;
+import org.graylog2.rest.models.system.indexer.responses.BulkIndices;
 import org.graylog2.rest.models.system.indexer.responses.ClosedIndices;
 import org.graylog2.rest.models.system.indexer.responses.IndexInfo;
 import org.graylog2.rest.models.system.indexer.responses.IndexStats;
@@ -172,6 +173,16 @@ public class IndicesResource extends RestResource {
 
         return ClosedIndices.create(reopenedIndices, reopenedIndices.size());
     }
+
+    @GET
+    @Timed
+    @Path("/all")
+    @ApiOperation(value = "Get a list of all indices, open, closed and reopened.")
+    @Produces(MediaType.APPLICATION_JSON)
+    public BulkIndices bulk() {
+        return BulkIndices.create(this.closed(), this.reopened(), this.all());
+    }
+
 
     @POST
     @Timed


### PR DESCRIPTION
Add bulk call which returns all indices (open, closed, reopened), also includes the deflector config in the deflector index call. This helps reducing the number of round trips for the indices page in the web interface.
