### PR TITLE
Make use of bulk indices calls to save roundtrips.

### DIFF
--- a/graylog2-web-interface/src/routing/jsRoutes.js
+++ b/graylog2-web-interface/src/routing/jsRoutes.js
@@ -57,7 +57,7 @@ const jsRoutes = {
       IndicesApiController: {
         close: (indexName) => { return {url: '/system/indexer/indices/' + indexName + '/close'}; },
         delete: (indexName) => { return {url: '/system/indexer/indices/' + indexName}; },
-        list: () => { return {url: '/system/indexer/indices/all'}; },
+        list: () => { return {url: '/system/indexer/indices'}; },
         listClosed: () => { return {url: '/system/indexer/indices/closed'}; },
         reopen: (indexName) => { return {url: '/system/indexer/indices/' + indexName + '/reopen'}; },
       },

--- a/graylog2-web-interface/src/routing/jsRoutes.js
+++ b/graylog2-web-interface/src/routing/jsRoutes.js
@@ -57,7 +57,7 @@ const jsRoutes = {
       IndicesApiController: {
         close: (indexName) => { return {url: '/system/indexer/indices/' + indexName + '/close'}; },
         delete: (indexName) => { return {url: '/system/indexer/indices/' + indexName}; },
-        listOpen: () => { return {url: '/system/indexer/indices/open'}; },
+        list: () => { return {url: '/system/indexer/indices/all'}; },
         listClosed: () => { return {url: '/system/indexer/indices/closed'}; },
         reopen: (indexName) => { return {url: '/system/indexer/indices/' + indexName + '/reopen'}; },
       },

--- a/graylog2-web-interface/src/stores/indices/DeflectorStore.js
+++ b/graylog2-web-interface/src/stores/indices/DeflectorStore.js
@@ -14,20 +14,10 @@ const DeflectorStore = Reflux.createStore({
     info: undefined,
   },
   init() {
-    DeflectorActions.config();
     DeflectorActions.list();
   },
   getInitialState() {
     return { deflector: this.deflector };
-  },
-  config() {
-    const url = URLUtils.qualifyUrl(jsRoutes.controllers.api.DeflectorApiController.config().url);
-    const promise = fetch('GET', url).then((config) => {
-      this.deflector.config = config;
-      this.trigger({deflector: this.deflector});
-    });
-
-    DeflectorActions.config.promise(promise);
   },
   cycle() {
     const url = URLUtils.qualifyUrl(jsRoutes.controllers.api.DeflectorApiController.cycle().url);
@@ -43,6 +33,7 @@ const DeflectorStore = Reflux.createStore({
     const url = URLUtils.qualifyUrl(jsRoutes.controllers.api.DeflectorApiController.list().url);
     const promise = fetch('GET', url).then((info) => {
       this.deflector.info = info;
+      this.deflector.config = info.config;
       this.trigger({deflector: this.deflector});
     });
 

--- a/graylog2-web-interface/src/stores/indices/IndicesStore.js
+++ b/graylog2-web-interface/src/stores/indices/IndicesStore.js
@@ -20,23 +20,12 @@ const IndicesStore = Reflux.createStore({
     return { indices: this.indices, closedIndices: this.closedIndices };
   },
   list() {
-    const urlList = URLUtils.qualifyUrl(jsRoutes.controllers.api.IndicesApiController.listOpen().url);
-    const promiseList = fetch('GET', urlList).then((response) => {
-      this.indices = response.indices;
-      return { indices: response.indices };
-    });
-
-    const urlListClosed = URLUtils.qualifyUrl(jsRoutes.controllers.api.IndicesApiController.listClosed().url);
-    const promiseListClosed = fetch('GET', urlListClosed).then((response) => {
-      this.closedIndices = response.indices;
-      return { closedIndices: response.indices };
-    });
-
-    const promise = Promise.all([promiseList, promiseListClosed]).then((values) => {
-      const result = jQuery.extend(values[0], values[1]);
-      this.trigger(result);
-
-      return result;
+    const urlList = URLUtils.qualifyUrl(jsRoutes.controllers.api.IndicesApiController.list().url);
+    const promise = fetch('GET', urlList).then((response) => {
+      this.indices = response.all.indices;
+      this.closedIndices = response.closed.indices;
+      this.trigger({ indices: this.indices, closedIndices: this.closedIndices });
+      return { indices: this.indices, closedIndices: this.closedIndices };
     });
 
     IndicesActions.list.promise(promise);


### PR DESCRIPTION
Adapted from https://github.com/Graylog2/graylog2-web-interface/pull/1704

The changes look good to me, please merge along with #1597.
