### PR TITLE
properly remove roles from users when the role is deleted

### DIFF
--- a/graylog2-radio/src/main/java/org/graylog2/radio/users/NullUserServiceImpl.java
+++ b/graylog2-radio/src/main/java/org/graylog2/radio/users/NullUserServiceImpl.java
@@ -119,6 +119,10 @@ public class NullUserServiceImpl implements UserService {
     }
 
     @Override
+    public void dissociateAllUsersFromRole(Role role) {
+    }
+
+    @Override
     public Set<String> getRoleNames(User user) {
         return Collections.emptySet();
     }

--- a/graylog2-server/src/main/java/org/graylog2/rest/resources/roles/RolesResource.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/resources/roles/RolesResource.java
@@ -155,10 +155,30 @@ public class RolesResource extends RestResource {
 
     @DELETE
     @Path("{rolename}")
-    @ApiOperation(value = "Remove the named role")
+    @ApiOperation(value = "Remove the named role and unassign any users from it")
     public void delete(@ApiParam(name = "rolename", required = true) @PathParam("rolename") String name) throws NotFoundException {
         checkPermission(RestPermissions.ROLES_DELETE, name);
-        // TODO unassign roles from current role members
+
+        final Role role = roleService.load(name);
+        if (role.isReadOnly()) {
+            throw new BadRequestException("Cannot delete read only system role " + name);
+        }
+        final Collection<User> usersInRole = userService.loadAllForRole(role);
+        // remove role from any user still assigned
+        for (User user : usersInRole) {
+            if (user.isLocalAdmin()) {
+                continue;
+            }
+            final HashSet<String> roles = Sets.newHashSet(user.getRoleIds());
+            roles.remove(role.getId());
+            user.setRoleIds(roles);
+            try {
+                userService.save(user);
+            } catch (ValidationException e) {
+                log.error("Unable to remove role {} from user {}", name, user);
+            }
+        }
+
         if (roleService.delete(name) == 0) {
             throw new NotFoundException();
         }

--- a/graylog2-server/src/main/java/org/graylog2/rest/resources/users/UsersResource.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/resources/users/UsersResource.java
@@ -466,7 +466,6 @@ public class UsersResource extends RestResource {
 
             if (roleNames.isEmpty()) {
                 LOG.error("Unable to load role names for role IDs {} for user {}", roleIds, user);
-                throw new InternalServerErrorException("Unable to load role names");
             }
         }
 

--- a/graylog2-shared/src/main/java/org/graylog2/shared/users/UserService.java
+++ b/graylog2-shared/src/main/java/org/graylog2/shared/users/UserService.java
@@ -47,4 +47,6 @@ public interface UserService extends PersistedService {
     Set<String> getRoleNames(User user);
 
     List<String> getPermissionsForUser(User user);
+
+    void dissociateAllUsersFromRole(Role role);
 }

--- a/integration-tests/src/test/java/integration/BaseRestTestHelper.java
+++ b/integration-tests/src/test/java/integration/BaseRestTestHelper.java
@@ -24,6 +24,8 @@ import com.jayway.restassured.response.Response;
 import org.hamcrest.BaseMatcher;
 import org.hamcrest.Description;
 import org.hamcrest.Matcher;
+import org.hamcrest.core.IsCollectionContaining;
+import org.mockito.internal.matchers.Not;
 
 import java.io.IOException;
 import java.net.URL;
@@ -86,6 +88,23 @@ public class BaseRestTestHelper {
         return new KeysPresentMatcher(keys);
     }
 
+    public static ResponseAwareMatcher<Response> setContainsEntry(final String entry) {
+        return new ResponseAwareMatcher<Response>() {
+            @Override
+            public Matcher<?> matcher(Response response) throws Exception {
+                return IsCollectionContaining.hasItem(entry);
+            }
+        };
+    }
+
+    public static ResponseAwareMatcher<Response> setDoesNotContain(final String entry) {
+        return new ResponseAwareMatcher<Response>() {
+            @Override
+            public Matcher<?> matcher(Response response) throws Exception {
+                return new Not(IsCollectionContaining.hasItem(entry));
+            }
+        };
+    }
     /**
      * Use this method to load a json file from the classpath.
      * <p>

--- a/integration-tests/src/test/java/integration/roles/RolesResourceTest.java
+++ b/integration-tests/src/test/java/integration/roles/RolesResourceTest.java
@@ -1,3 +1,19 @@
+/**
+ * This file is part of Graylog.
+ *
+ * Graylog is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package integration.roles;
 
 import integration.BaseRestTest;

--- a/integration-tests/src/test/java/integration/roles/RolesResourceTest.java
+++ b/integration-tests/src/test/java/integration/roles/RolesResourceTest.java
@@ -1,0 +1,49 @@
+package integration.roles;
+
+import integration.BaseRestTest;
+import integration.RequiresAuthentication;
+import org.junit.Test;
+
+import static com.jayway.restassured.RestAssured.given;
+
+@RequiresAuthentication
+public class RolesResourceTest extends BaseRestTest {
+
+    @Test
+    public void deleteRolesTest() {
+        try {
+            given().when()
+                    .body(jsonResource("create-role.json")).post("/roles")
+                    .then()
+                    .statusCode(201);
+
+            given().when()
+                    .body(jsonResource("create-user-with-role.json")).post("/users")
+                    .then()
+                    .statusCode(201);
+
+            given().when()
+                    .get("/users/{name}", "john")
+                    .then()
+                    .statusCode(200)
+                    .body("roles", setContainsEntry("Test"));
+
+            given().when()
+                    .delete("/roles/{name}", "Test")
+                    .then()
+                    .statusCode(204);
+
+            given().when()
+                    .get("/users/{name}", "john")
+                    .then()
+                    .statusCode(200)
+                    .body("roles", setDoesNotContain("Test"));
+        } finally {
+            // still remove the user even though it's not technically necessary
+            given().when()
+                    .delete("/users/{name}", "john")
+                    .then()
+                    .statusCode(204);
+        }
+    }
+}

--- a/integration-tests/src/test/resources/integration/roles/create-role.json
+++ b/integration-tests/src/test/resources/integration/roles/create-role.json
@@ -1,0 +1,5 @@
+{
+  "name": "Test",
+  "description": "A test role",
+  "permissions": ["*"]
+}

--- a/integration-tests/src/test/resources/integration/roles/create-user-with-role.json
+++ b/integration-tests/src/test/resources/integration/roles/create-user-with-role.json
@@ -1,0 +1,30 @@
+{
+  "username": "john",
+  "email": "john@example.com",
+  "full_name": "John Doe",
+  "password": "123456",
+  "permissions": [
+    "users:edit:john",
+    "users:passwordchange:john",
+    "indexercluster:read",
+    "messagecount:read",
+    "journal:read",
+    "inputs:read",
+    "metrics:read",
+    "savedsearches:edit",
+    "fieldnames:read",
+    "buffers:read",
+    "system:read",
+    "savedsearches:create",
+    "jvmstats:read",
+    "throughput:read",
+    "savedsearches:read",
+    "messages:read"
+  ],
+  "timezone": "Europe/Berlin",
+  "session_timeout_ms": -1,
+  "startpage": {},
+  "roles": [
+    "Test"
+  ]
+}


### PR DESCRIPTION
 - local admin users are not touched
 - when resolving roles of a user do not throw an exception for missing roles, it prevented the user from being editable
 - integration tests for role removal

fixes #1608