### PR TITLE
Improve version.properties handling

### DIFF
--- a/graylog2-bootstrap/src/main/resources/version.properties
+++ b/graylog2-bootstrap/src/main/resources/version.properties
@@ -1,5 +1,1 @@
-version.major=${maven.majorVersion}
-version.minor=${maven.minorVersion}
-version.incremental=${maven.incrementalVersion}
-version.qualifier=${maven.qualifier}
-version.buildNumber=${maven.buildNumber}
+project.version=${project.version}

--- a/graylog2-plugin-interfaces/pom.xml
+++ b/graylog2-plugin-interfaces/pom.xml
@@ -39,6 +39,10 @@
             <artifactId>joda-time</artifactId>
         </dependency>
         <dependency>
+            <groupId>com.github.zafarkhaja</groupId>
+            <artifactId>java-semver</artifactId>
+        </dependency>
+        <dependency>
             <groupId>io.dropwizard.metrics</groupId>
             <artifactId>metrics-core</artifactId>
         </dependency>

--- a/graylog2-plugin-interfaces/src/main/java/org/graylog2/plugin/Version.java
+++ b/graylog2-plugin-interfaces/src/main/java/org/graylog2/plugin/Version.java
@@ -60,14 +60,16 @@ public class Version implements Comparable<Version> {
         Version tmpVersion;
         try {
             final URL resource = Resources.getResource("version.properties");
-            final String versionProperties = Resources.toString(resource, UTF_8);
-            final Properties version = new Properties();
-            version.load(new StringReader(versionProperties));
+            final String versionPropertiesString = Resources.toString(resource, UTF_8);
+            final Properties versionProperties = new Properties();
+            versionProperties.load(new StringReader(versionPropertiesString));
 
-            final int major = Integer.parseInt(version.getProperty("version.major", "0"));
-            final int minor = Integer.parseInt(version.getProperty("version.minor", "0"));
-            final int incremental = Integer.parseInt(version.getProperty("version.incremental", "0"));
-            final String qualifier = version.getProperty("version.qualifier", "unknown");
+            com.github.zafarkhaja.semver.Version version = com.github.zafarkhaja.semver.Version.valueOf(versionProperties.getProperty("project.version", "0.0.0"));
+
+            final int major = version.getMajorVersion();
+            final int minor = version.getMinorVersion();
+            final int incremental = version.getPatchVersion();
+            final String qualifier = version.getPreReleaseVersion();
 
             String commitSha = null;
             try {
@@ -83,7 +85,7 @@ public class Version implements Comparable<Version> {
             tmpVersion = new Version(major, minor, incremental, qualifier, commitSha);
         } catch (Exception e) {
             tmpVersion = new Version(0, 0, 0, "unknown");
-            LOG.error("Unable to read version.properties file, this build has no version number. If you get this message during development, you need to run 'Generate Sources' in IDEA or run 'mvn process-resources'.", e);
+            LOG.error("Unable to read version.properties file, this build has no version number.", e);
         }
         CURRENT_CLASSPATH = tmpVersion;
     }

--- a/integration-tests/pom.xml
+++ b/integration-tests/pom.xml
@@ -82,7 +82,6 @@
         <dependency>
             <groupId>com.github.zafarkhaja</groupId>
             <artifactId>java-semver</artifactId>
-            <version>0.9.0</version>
         </dependency>
         <dependency>
             <groupId>com.jayway.restassured</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -214,6 +214,11 @@
                 <artifactId>mongo-java-driver</artifactId>
                 <version>2.13.3</version>
             </dependency>
+            <dependency>
+                <groupId>com.github.zafarkhaja</groupId>
+                <artifactId>java-semver</artifactId>
+                <version>0.9.0</version>
+            </dependency>
 
             <dependency>
                 <groupId>org.mongojack</groupId>


### PR DESCRIPTION
Just use the project.version and parse it in the Version class to avoid requiring "mvn process-resources".