### PR TITLE
Remove deprecated MongoDB configuration settings

### DIFF
--- a/graylog2-plugin-interfaces/src/test/java/org/graylog2/plugin/BaseConfigurationTest.java
+++ b/graylog2-plugin-interfaces/src/test/java/org/graylog2/plugin/BaseConfigurationTest.java
@@ -77,12 +77,6 @@ public class BaseConfigurationTest {
         // Required properties
         validProperties.put("password_secret", "ipNUnWxmBLCxTEzXcyamrdy0Q3G7HxdKsAvyg30R9SCof0JydiZFiA3dLSkRsbLF");
         validProperties.put("elasticsearch_config_file", tempFile.getAbsolutePath());
-        validProperties.put("mongodb_useauth", "true");
-        validProperties.put("mongodb_user", "user");
-        validProperties.put("mongodb_password", "pass");
-        validProperties.put("mongodb_database", "test");
-        validProperties.put("mongodb_host", "localhost");
-        validProperties.put("mongodb_port", "27017");
         validProperties.put("use_gelf", "true");
         validProperties.put("gelf_listen_port", "12201");
         validProperties.put("root_password_sha2", "8c6976e5b5410415bde908bd4dee15dfb167a9c873fc4bb8a81f6f2ab448a918"); // sha2 of admin

--- a/graylog2-server/src/main/java/org/graylog2/configuration/MongoDbConfiguration.java
+++ b/graylog2-server/src/main/java/org/graylog2/configuration/MongoDbConfiguration.java
@@ -19,94 +19,23 @@ package org.graylog2.configuration;
 import com.github.joschi.jadconfig.Parameter;
 import com.github.joschi.jadconfig.ValidationException;
 import com.github.joschi.jadconfig.ValidatorMethod;
-import com.github.joschi.jadconfig.converters.StringListConverter;
-import com.github.joschi.jadconfig.validators.InetPortValidator;
 import com.github.joschi.jadconfig.validators.PositiveIntegerValidator;
-import com.google.common.base.Joiner;
-import com.google.common.net.HostAndPort;
+import com.github.joschi.jadconfig.validators.StringNotBlankValidator;
 import com.mongodb.MongoClientOptions;
 import com.mongodb.MongoClientURI;
-import com.mongodb.ServerAddress;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
-import java.net.InetAddress;
-import java.net.UnknownHostException;
-import java.util.ArrayList;
-import java.util.List;
-
-import static com.google.common.base.Strings.isNullOrEmpty;
+import static com.google.common.base.Preconditions.checkArgument;
 
 public class MongoDbConfiguration {
-    private static final Logger LOG = LoggerFactory.getLogger(MongoDbConfiguration.class);
-
-    @Parameter("mongodb_useauth")
-    @Deprecated
-    private boolean useAuth = false;
-
-    @Parameter("mongodb_user")
-    @Deprecated
-    private String user;
-
-    @Parameter("mongodb_password")
-    @Deprecated
-    private String password;
-
-    @Parameter("mongodb_database")
-    @Deprecated
-    private String database = "graylog2";
-
-    @Parameter("mongodb_host")
-    @Deprecated
-    private String host = "127.0.0.1";
-
-    @Parameter(value = "mongodb_port", validator = InetPortValidator.class)
-    @Deprecated
-    private int port = 27017;
-
     @Parameter(value = "mongodb_max_connections", validator = PositiveIntegerValidator.class)
     private int maxConnections = 1000;
 
     @Parameter(value = "mongodb_threads_allowed_to_block_multiplier", validator = PositiveIntegerValidator.class)
     private int threadsAllowedToBlockMultiplier = 5;
 
-    @Parameter(value = "mongodb_replica_set", converter = StringListConverter.class)
-    @Deprecated
-    private List<String> replicaSet;
+    @Parameter(value = "mongodb_uri", required = true, validator = StringNotBlankValidator.class)
+    private String uri = "mongodb://localhost/graylog";
 
-    @Parameter("mongodb_uri")
-    private String uri = null;
-
-
-    @Deprecated
-    public boolean isUseAuth() {
-        return useAuth;
-    }
-
-    @Deprecated
-    public String getUser() {
-        return user;
-    }
-
-    @Deprecated
-    public String getPassword() {
-        return password;
-    }
-
-    @Deprecated
-    public String getDatabase() {
-        return database;
-    }
-
-    @Deprecated
-    public int getPort() {
-        return port;
-    }
-
-    @Deprecated
-    public String getHost() {
-        return host;
-    }
 
     public int getMaxConnections() {
         return maxConnections;
@@ -121,24 +50,6 @@ public class MongoDbConfiguration {
     }
 
     public MongoClientURI getMongoClientURI() {
-        if(isNullOrEmpty(uri)) {
-            final StringBuilder sb = new StringBuilder("mongodb://");
-
-            if(isUseAuth()) {
-                sb.append(getUser()).append(':').append(getPassword()).append('@');
-            }
-
-            final List<ServerAddress> replicas = getReplicaSet();
-            if(replicas == null) {
-                sb.append(getHost()).append(':').append(getPort());
-            } else {
-                Joiner.on(',').skipNulls().appendTo(sb, replicas);
-            }
-
-            sb.append('/').append(getDatabase());
-            uri = sb.toString();
-        }
-
         final MongoClientOptions.Builder mongoClientOptionsBuilder = MongoClientOptions.builder()
                 .connectionsPerHost(getMaxConnections())
                 .threadsAllowedToBlockForConnectionMultiplier(getThreadsAllowedToBlockMultiplier());
@@ -146,44 +57,10 @@ public class MongoDbConfiguration {
         return new MongoClientURI(uri, mongoClientOptionsBuilder);
     }
 
-    @Deprecated
-    public List<ServerAddress> getReplicaSet() {
-        if (replicaSet == null || replicaSet.isEmpty()) {
-            return null;
-        }
-
-        final List<ServerAddress> replicaServers = new ArrayList<>(replicaSet.size());
-        for (String host : replicaSet) {
-            try {
-                final HostAndPort hostAndPort = HostAndPort.fromString(host)
-                        .withDefaultPort(27017);
-                replicaServers.add(new ServerAddress(
-                        InetAddress.getByName(hostAndPort.getHostText()), hostAndPort.getPort()));
-            } catch (IllegalArgumentException e) {
-                LOG.error("Malformed mongodb_replica_set configuration.", e);
-                return null;
-            } catch (UnknownHostException e) {
-                LOG.error("Unknown host in mongodb_replica_set", e);
-                return null;
-            }
-        }
-
-        return replicaServers;
-    }
-
     @ValidatorMethod
     public void validate() throws ValidationException {
-        if ((isNullOrEmpty(getHost()) && (getReplicaSet() == null || getReplicaSet().isEmpty()) || isNullOrEmpty(getDatabase()) && isNullOrEmpty(getUri()))) {
-            throw new ValidationException("Either mongodb_uri OR mongodb_host/mongodb_replica_set and mongodb_database must not be empty");
-        }
-
-        if (isNullOrEmpty(getUri())) {
-            LOG.info("You're using deprecated configuration options for MongoDB. Please use mongodb_uri.");
-            LOG.info("Suggested value for mongodb_uri = {}", getMongoClientURI());
-        }
-
-        if (isUseAuth() && (isNullOrEmpty(getUser()) || isNullOrEmpty(getPassword()))) {
-            throw new ValidationException("mongodb_user and mongodb_password have to be set if mongodb_useauth is true");
+        if(getMongoClientURI() == null) {
+            throw new ValidationException("mongodb_uri is not a valid MongoDB connection string");
         }
     }
 }

--- a/graylog2-server/src/main/java/org/graylog2/configuration/MongoDbConfiguration.java
+++ b/graylog2-server/src/main/java/org/graylog2/configuration/MongoDbConfiguration.java
@@ -24,8 +24,6 @@ import com.github.joschi.jadconfig.validators.StringNotBlankValidator;
 import com.mongodb.MongoClientOptions;
 import com.mongodb.MongoClientURI;
 
-import static com.google.common.base.Preconditions.checkArgument;
-
 public class MongoDbConfiguration {
     @Parameter(value = "mongodb_max_connections", validator = PositiveIntegerValidator.class)
     private int maxConnections = 1000;

--- a/graylog2-server/src/main/java/org/graylog2/database/MongoConnectionImpl.java
+++ b/graylog2-server/src/main/java/org/graylog2/database/MongoConnectionImpl.java
@@ -16,7 +16,6 @@
  */
 package org.graylog2.database;
 
-import com.mongodb.CommandFailureException;
 import com.mongodb.DB;
 import com.mongodb.Mongo;
 import com.mongodb.MongoClient;


### PR DESCRIPTION
This PR removes the following deprecated MongoDB configuration settings which have been superseded by `mongodb_uri`:
* `mongodb_useauth`
* `mongodb_user`,
* `mongodb_password`
* `mongodb_database`
* `mongodb_host`
* `mongodb_port`