### PR TITLE
remove git-commit-id-plugin in favor of the simpler buildnumber helper

### DIFF
--- a/graylog2-bootstrap/pom.xml
+++ b/graylog2-bootstrap/pom.xml
@@ -80,6 +80,12 @@
     </dependencies>
 
     <build>
+        <resources>
+            <resource>
+                <directory>src/main/resources</directory>
+                <filtering>true</filtering>
+            </resource>
+        </resources>
         <plugins>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
@@ -94,25 +100,18 @@
                 </configuration>
             </plugin>
             <plugin>
-                <groupId>pl.project13.maven</groupId>
-                <artifactId>git-commit-id-plugin</artifactId>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>buildnumber-maven-plugin</artifactId>
                 <executions>
                     <execution>
+                        <phase>validate</phase>
                         <goals>
-                            <goal>revision</goal>
+                            <goal>create</goal>
                         </goals>
                     </execution>
                 </executions>
                 <configuration>
-                    <prefix>git</prefix>
-                    <dateFormat>dd.MM.yyyy '@' HH:mm:ss z</dateFormat>
-                    <verbose>false</verbose>
-                    <useNativeGit>true</useNativeGit>
-                    <dotGitDirectory>${project.parent.relativePath}/.git</dotGitDirectory>
-                    <skipPoms>true</skipPoms>
-                    <failOnNoGitDirectory>false</failOnNoGitDirectory>
-                    <abbrevLength>7</abbrevLength>
-                    <skip>false</skip>
+                    <maven.buildNumber.useLastCommittedRevision>true</maven.buildNumber.useLastCommittedRevision>
                 </configuration>
             </plugin>
             <plugin>

--- a/graylog2-bootstrap/pom.xml
+++ b/graylog2-bootstrap/pom.xml
@@ -80,12 +80,6 @@
     </dependencies>
 
     <build>
-        <resources>
-            <resource>
-                <directory>src/main/resources</directory>
-                <filtering>true</filtering>
-            </resource>
-        </resources>
         <plugins>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>

--- a/graylog2-bootstrap/src/main/resources/git.properties
+++ b/graylog2-bootstrap/src/main/resources/git.properties
@@ -1,15 +1,2 @@
-git.branch=${git.branch}
-
-git.commit.id.describe=${git.commit.id.describe}
-
-git.build.user.name=${git.build.user.name}
-git.build.user.email=${git.build.user.email}
-git.build.time=${git.build.time}
-
-git.commit.id=${git.commit.id}
-git.commit.id.abbrev=${git.commit.id.abbrev}
-git.commit.user.name=${git.commit.user.name}
-git.commit.user.email=${git.commit.user.email}
-git.commit.message.full=${git.commit.message.full}
-git.commit.message.short=${git.commit.message.short}
-git.commit.time=${git.commit.time}
+git.branch=${scmBranch}
+git.commit.id=${buildNumber}

--- a/graylog2-plugin-interfaces/src/main/java/org/graylog2/plugin/Version.java
+++ b/graylog2-plugin-interfaces/src/main/java/org/graylog2/plugin/Version.java
@@ -77,7 +77,11 @@ public class Version implements Comparable<Version> {
                 final URL gitResource = Resources.getResource("git.properties");
                 final String gitProperties = Resources.toString(gitResource, UTF_8);
                 git.load(new StringReader(gitProperties));
-                commitSha = git.getProperty("git.commit.id.abbrev");
+                commitSha = git.getProperty("git.commit.id");
+                // abbreviate if present and looks like a long sha
+                if (commitSha != null && commitSha.length() > 7) {
+                    commitSha = commitSha.substring(0, 7);
+                }
             } catch (Exception e) {
                 LOG.debug("Git commit details are not available, skipping.", e);
             }

--- a/pom.xml
+++ b/pom.xml
@@ -948,11 +948,6 @@
                     <version>2.8.2</version>
                 </plugin>
                 <plugin>
-                    <groupId>pl.project13.maven</groupId>
-                    <artifactId>git-commit-id-plugin</artifactId>
-                    <version>2.2.0</version>
-                </plugin>
-                <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-release-plugin</artifactId>
                     <version>2.5.2</version>
@@ -1029,6 +1024,11 @@
                     <groupId>de.thetaphi</groupId>
                     <artifactId>forbiddenapis</artifactId>
                     <version>2.0</version>
+                </plugin>
+                <plugin>
+                    <groupId>org.codehaus.mojo</groupId>
+                    <artifactId>buildnumber-maven-plugin</artifactId>
+                    <version>1.4</version>
                 </plugin>
             </plugins>
         </pluginManagement>


### PR DESCRIPTION
 - properly allows filtering resources
 - remove most unused git info which we didn't need in the first place
 - manually short sha1 for display purposes

this also enables using the bundle intellij maven3 because git-commit-id-plugin requires a more recent version without any direct benefit to us