### PR TITLE
Replace SLF4JBridgeHandler with Log4j2 JDK Logging Adapter

### DIFF
--- a/graylog2-bootstrap/pom.xml
+++ b/graylog2-bootstrap/pom.xml
@@ -74,6 +74,10 @@
             <artifactId>log4j-core</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-jul</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.graylog.repackaged</groupId>
             <artifactId>os-platform-finder</artifactId>
         </dependency>

--- a/graylog2-bootstrap/src/main/java/org/graylog2/bootstrap/CmdLineTool.java
+++ b/graylog2-bootstrap/src/main/java/org/graylog2/bootstrap/CmdLineTool.java
@@ -79,6 +79,11 @@ import java.util.Set;
 import static com.google.common.base.Strings.nullToEmpty;
 
 public abstract class CmdLineTool implements CliCommand {
+    static {
+        // Set up JDK Logging adapter, https://logging.apache.org/log4j/2.x/log4j-jul/index.html
+        System.setProperty("java.util.logging.manager", "org.apache.logging.log4j.jul.LogManager");
+    }
+
     private static final Logger LOG = LoggerFactory.getLogger(CmdLineTool.class);
 
     protected static final String ENVIRONMENT_PREFIX = "GRAYLOG2_";

--- a/graylog2-server/pom.xml
+++ b/graylog2-server/pom.xml
@@ -306,10 +306,6 @@
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>
-            <artifactId>jul-to-slf4j</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.slf4j</groupId>
             <artifactId>jcl-over-slf4j</artifactId>
         </dependency>
         <dependency>

--- a/graylog2-server/src/main/resources/logging.properties
+++ b/graylog2-server/src/main/resources/logging.properties
@@ -1,3 +1,0 @@
-# Register SLF4JBridgeHandler as handler for the j.u.l. root logger.
-# See http://www.slf4j.org/api/org/slf4j/bridge/SLF4JBridgeHandler.html
-handlers = org.slf4j.bridge.SLF4JBridgeHandler

--- a/integration-tests/pom.xml
+++ b/integration-tests/pom.xml
@@ -64,10 +64,6 @@
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>
-            <artifactId>jul-to-slf4j</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.slf4j</groupId>
             <artifactId>jcl-over-slf4j</artifactId>
         </dependency>
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -425,11 +425,6 @@
             <!-- SLF4J Legacy Bridges -->
             <dependency>
                 <groupId>org.slf4j</groupId>
-                <artifactId>jul-to-slf4j</artifactId>
-                <version>${slf4j.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.slf4j</groupId>
                 <artifactId>jcl-over-slf4j</artifactId>
                 <version>${slf4j.version}</version>
             </dependency>
@@ -452,6 +447,11 @@
             <dependency>
                 <groupId>org.apache.logging.log4j</groupId>
                 <artifactId>log4j-slf4j-impl</artifactId>
+                <version>${log4j.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.logging.log4j</groupId>
+                <artifactId>log4j-jul</artifactId>
                 <version>${log4j.version}</version>
             </dependency>
             <dependency>
@@ -858,11 +858,6 @@
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-slf4j-impl</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.slf4j</groupId>
-            <artifactId>jul-to-slf4j</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>


### PR DESCRIPTION
The SLF4JBridgeHandler didn't work as intended as the `java.util.logging.LogManager` only reads its configuration from regular files ("logging.properties") but not from the class path.

Since both variants, the SLF4J Bridge Handler and the Log4j2 LogManager has to be installed programmatically, this PR chooses the more performant variant.

* https://logging.apache.org/log4j/log4j-2.4/log4j-jul/index.html
* http://www.slf4j.org/api/org/slf4j/bridge/SLF4JBridgeHandler.html