### PR TITLE
Install a Graylog index template instead of set mappings on index creation

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/indexer/IndexMapping.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/IndexMapping.java
@@ -33,6 +33,15 @@ import java.util.Map;
 public class IndexMapping {
     public static final String TYPE_MESSAGE = "message";
 
+    public Map<String, Object> messageTemplate(final String template, final String analyzer) {
+        final ImmutableMap<String, Object> map = ImmutableMap.<String, Object>of(TYPE_MESSAGE, messageMapping(analyzer));
+
+        return ImmutableMap.<String, Object>of(
+                "template", template,
+                "mappings", map
+        );
+    }
+
     public Map<String, Object> messageMapping(final String analyzer) {
         return ImmutableMap.of(
                 "properties", partFieldProperties(analyzer),

--- a/graylog2-server/src/main/java/org/graylog2/indexer/indices/Indices.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/indices/Indices.java
@@ -46,6 +46,7 @@ import org.elasticsearch.action.admin.indices.stats.IndexStats;
 import org.elasticsearch.action.admin.indices.stats.IndicesStatsRequest;
 import org.elasticsearch.action.admin.indices.stats.IndicesStatsResponse;
 import org.elasticsearch.action.admin.indices.stats.ShardStats;
+import org.elasticsearch.action.admin.indices.template.put.PutIndexTemplateRequest;
 import org.elasticsearch.action.bulk.BulkRequestBuilder;
 import org.elasticsearch.action.bulk.BulkResponse;
 import org.elasticsearch.action.index.IndexRequest;
@@ -98,6 +99,8 @@ import static org.elasticsearch.index.query.QueryBuilders.matchAllQuery;
 public class Indices implements IndexManagement {
 
     private static final Logger LOG = LoggerFactory.getLogger(Indices.class);
+
+    private static final String GRAYLOG_INTERNAL_TEMPLATE_NAME = "graylog-internal";
 
     private final Client c;
     private final ElasticsearchConfiguration configuration;
@@ -211,6 +214,26 @@ public class Indices implements IndexManagement {
         return response.getAliases().isEmpty() ? null : response.getAliases().keysIt().next();
     }
 
+    public boolean createIndexTemplate() {
+        final Map<String, Object> template = indexMapping.messageTemplate(allIndicesAlias(), configuration.getAnalyzer());
+        final PutIndexTemplateRequest itr = c.admin().indices().preparePutTemplate(GRAYLOG_INTERNAL_TEMPLATE_NAME)
+                .setOrder(-99) // Make sure templates with "order: 0" are applied after our template!
+                .setSource(template)
+                .request();
+
+        try {
+            final boolean acknowledged = c.admin().indices().putTemplate(itr).actionGet().isAcknowledged();
+            if (acknowledged) {
+                LOG.info("Created Graylog index template \"{}\" in Elasticsearch.", GRAYLOG_INTERNAL_TEMPLATE_NAME);
+            }
+            return acknowledged;
+        } catch (Exception e) {
+            LOG.error("Unable to create the Graylog index template: " + GRAYLOG_INTERNAL_TEMPLATE_NAME, e);
+        }
+
+        return false;
+    }
+
     public boolean create(String indexName) {
         final Map<String, String> keywordLowercase = ImmutableMap.of(
                 "tokenizer", "keyword",
@@ -219,11 +242,9 @@ public class Indices implements IndexManagement {
                 "number_of_shards", configuration.getShards(),
                 "number_of_replicas", configuration.getReplicas(),
                 "index.analysis.analyzer.analyzer_keyword", keywordLowercase);
-        final Map<String, Object> messageMapping = indexMapping.messageMapping(configuration.getAnalyzer());
 
         final CreateIndexRequest cir = c.admin().indices().prepareCreate(indexName)
                 .setSettings(settings)
-                .addMapping(IndexMapping.TYPE_MESSAGE, messageMapping)
                 .request();
 
         return c.admin().indices().create(cir).actionGet().isAcknowledged();

--- a/graylog2-server/src/main/java/org/graylog2/indexer/indices/Indices.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/indices/Indices.java
@@ -217,7 +217,7 @@ public class Indices implements IndexManagement {
     public boolean createIndexTemplate() {
         final Map<String, Object> template = indexMapping.messageTemplate(allIndicesAlias(), configuration.getAnalyzer());
         final PutIndexTemplateRequest itr = c.admin().indices().preparePutTemplate(GRAYLOG_INTERNAL_TEMPLATE_NAME)
-                .setOrder(-99) // Make sure templates with "order: 0" are applied after our template!
+                .setOrder(Integer.MIN_VALUE) // Make sure templates with "order: 0" are applied after our template!
                 .setSource(template)
                 .request();
 

--- a/graylog2-server/src/main/java/org/graylog2/initializers/IndexerSetupService.java
+++ b/graylog2-server/src/main/java/org/graylog2/initializers/IndexerSetupService.java
@@ -36,7 +36,6 @@ import org.elasticsearch.action.admin.cluster.health.ClusterHealthStatus;
 import org.elasticsearch.client.Client;
 import org.elasticsearch.node.Node;
 import org.graylog2.configuration.ElasticsearchConfiguration;
-import org.graylog2.indexer.indices.Indices;
 import org.graylog2.notifications.Notification;
 import org.graylog2.notifications.NotificationService;
 import org.graylog2.plugin.DocsHelper;
@@ -70,7 +69,6 @@ public class IndexerSetupService extends AbstractIdleService {
     private final NotificationService notificationService;
     private final OkHttpClient httpClient;
     private final ObjectMapper objectMapper;
-    private final Indices indices;
 
     @Inject
     public IndexerSetupService(final Node node,
@@ -78,9 +76,8 @@ public class IndexerSetupService extends AbstractIdleService {
                                final BufferSynchronizerService bufferSynchronizerService,
                                final NotificationService notificationService,
                                @Named("systemHttpClient") final OkHttpClient httpClient,
-                               final MetricRegistry metricRegistry,
-                               final Indices indices) {
-        this(node, configuration, bufferSynchronizerService, notificationService, httpClient, new ObjectMapper(), metricRegistry, indices);
+                               final MetricRegistry metricRegistry) {
+        this(node, configuration, bufferSynchronizerService, notificationService, httpClient, new ObjectMapper(), metricRegistry);
     }
 
     @VisibleForTesting
@@ -90,14 +87,12 @@ public class IndexerSetupService extends AbstractIdleService {
                         final NotificationService notificationService,
                         final OkHttpClient httpClient,
                         final ObjectMapper objectMapper,
-                        final MetricRegistry metricRegistry,
-                        final Indices indices) {
+                        final MetricRegistry metricRegistry) {
         this.node = node;
         this.configuration = configuration;
         this.notificationService = notificationService;
         this.httpClient = httpClient;
         this.objectMapper = objectMapper;
-        this.indices = indices;
 
         // Shutdown after the BufferSynchronizerService has stopped to avoid shutting down ES too early.
         bufferSynchronizerService.addListener(new ShutdownListener(this.node), executorService(metricRegistry));
@@ -145,9 +140,6 @@ public class IndexerSetupService extends AbstractIdleService {
                 LOG.warn("The Elasticsearch cluster state is RED which means shards are unassigned.");
                 LOG.info("This usually indicates a crashed and corrupt cluster and needs to be investigated. Graylog will write into the local disk journal.");
                 LOG.info("See {} for details.", DocsHelper.PAGE_ES_CONFIGURATION);
-            } else {
-                // Install our internal Elasticsearch template as early as possible.
-                indices.createIndexTemplate();
             }
         } catch (ElasticsearchTimeoutException e) {
             final String hosts = node.settings().get("discovery.zen.ping.unicast.hosts");

--- a/graylog2-server/src/test/java/org/graylog2/indexer/indices/IndicesTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/indexer/indices/IndicesTest.java
@@ -56,7 +56,7 @@ public class IndicesTest {
     public static final EmbeddedElasticsearch EMBEDDED_ELASTICSEARCH = newEmbeddedElasticsearchRule().build();
 
     private static final long ES_TIMEOUT = TimeUnit.SECONDS.toMillis(1L);
-    private static final String INDEX_NAME = "graylog";
+    private static final String INDEX_NAME = "graylog_0";
     private static final ElasticsearchConfiguration CONFIG = new ElasticsearchConfiguration() {
         @Override
         public String getIndexPrefix() {
@@ -73,7 +73,7 @@ public class IndicesTest {
 
     public IndicesTest() {
         this.elasticsearchRule = newElasticsearchRule().defaultEmbeddedElasticsearch();
-        this.elasticsearchRule.setLoadStrategyFactory(new IndexCreatingLoadStrategyFactory(Collections.singleton(INDEX_NAME)));
+        this.elasticsearchRule.setLoadStrategyFactory(new IndexCreatingLoadStrategyFactory(CONFIG, Collections.singleton(INDEX_NAME)));
     }
 
     @Before
@@ -143,7 +143,7 @@ public class IndicesTest {
     @Test
     @UsingDataSet(loadStrategy = LoadStrategyEnum.CLEAN_INSERT)
     public void testTimestampStatsOfIndex() throws Exception {
-        TimestampStats stats = indices.timestampStatsOfIndex("graylog");
+        TimestampStats stats = indices.timestampStatsOfIndex(INDEX_NAME);
 
         assertThat(stats.min()).isEqualTo(new DateTime(2015, 1, 1, 1, 0, DateTimeZone.UTC));
         assertThat(stats.max()).isEqualTo(new DateTime(2015, 1, 1, 5, 0, DateTimeZone.UTC));
@@ -152,7 +152,7 @@ public class IndicesTest {
     @Test
     @UsingDataSet(locations = "IndicesTest-EmptyIndex.json", loadStrategy = LoadStrategyEnum.CLEAN_INSERT)
     public void testTimestampStatsOfIndexWithEmptyIndex() throws Exception {
-        TimestampStats stats = indices.timestampStatsOfIndex("graylog");
+        TimestampStats stats = indices.timestampStatsOfIndex(INDEX_NAME);
 
         assertThat(stats.min()).isEqualTo(new DateTime(0L, DateTimeZone.UTC));
         assertThat(stats.max()).isEqualTo(new DateTime(0L, DateTimeZone.UTC));

--- a/graylog2-server/src/test/java/org/graylog2/indexer/nosqlunit/IndexCreatingDatabaseOperation.java
+++ b/graylog2-server/src/test/java/org/graylog2/indexer/nosqlunit/IndexCreatingDatabaseOperation.java
@@ -58,8 +58,6 @@ public class IndexCreatingDatabaseOperation implements DatabaseOperation<Client>
             }
 
             Indices indices = new Indices(client, config, new IndexMapping());
-            indices.createIndexTemplate();
-            log.info("Create index {}", index);
             if (!indices.create(index)) {
                 throw new IllegalStateException("Couldn't create index " + index);
             }

--- a/graylog2-server/src/test/java/org/graylog2/indexer/nosqlunit/IndexCreatingLoadStrategyFactory.java
+++ b/graylog2-server/src/test/java/org/graylog2/indexer/nosqlunit/IndexCreatingLoadStrategyFactory.java
@@ -22,14 +22,17 @@ import com.lordofthejars.nosqlunit.core.LoadStrategyEnum;
 import com.lordofthejars.nosqlunit.core.LoadStrategyFactory;
 import com.lordofthejars.nosqlunit.core.LoadStrategyOperation;
 import com.lordofthejars.nosqlunit.core.ReflectionLoadStrategyFactory;
+import org.graylog2.configuration.ElasticsearchConfiguration;
 
 import java.util.Set;
 
 public class IndexCreatingLoadStrategyFactory implements LoadStrategyFactory {
     private final LoadStrategyFactory loadStrategyFactory;
     private final Set<String> indexNames;
+    private final ElasticsearchConfiguration config;
 
-    public IndexCreatingLoadStrategyFactory(Set<String> indexNames) {
+    public IndexCreatingLoadStrategyFactory(ElasticsearchConfiguration config, Set<String> indexNames) {
+        this.config = config;
         this.loadStrategyFactory = new ReflectionLoadStrategyFactory();
         this.indexNames = ImmutableSet.copyOf(indexNames);
     }
@@ -39,6 +42,6 @@ public class IndexCreatingLoadStrategyFactory implements LoadStrategyFactory {
     public LoadStrategyOperation getLoadStrategyInstance(LoadStrategyEnum loadStrategyEnum, DatabaseOperation databaseOperation) {
         return loadStrategyFactory.getLoadStrategyInstance(
                 loadStrategyEnum,
-                new IndexCreatingDatabaseOperation(databaseOperation, indexNames));
+                new IndexCreatingDatabaseOperation(databaseOperation, config, indexNames));
     }
 }

--- a/graylog2-server/src/test/java/org/graylog2/indexer/ranges/EsIndexRangeServiceTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/indexer/ranges/EsIndexRangeServiceTest.java
@@ -78,7 +78,7 @@ public class EsIndexRangeServiceTest {
 
     public EsIndexRangeServiceTest() {
         this.elasticsearchRule = newElasticsearchRule().defaultEmbeddedElasticsearch();
-        this.elasticsearchRule.setLoadStrategyFactory(new IndexCreatingLoadStrategyFactory(INDEX_NAMES));
+        this.elasticsearchRule.setLoadStrategyFactory(new IndexCreatingLoadStrategyFactory(ELASTICSEARCH_CONFIGURATION, INDEX_NAMES));
     }
 
     @Before

--- a/graylog2-server/src/test/java/org/graylog2/indexer/searches/SearchesTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/indexer/searches/SearchesTest.java
@@ -26,6 +26,7 @@ import com.lordofthejars.nosqlunit.elasticsearch.ElasticsearchRule;
 import com.lordofthejars.nosqlunit.elasticsearch.EmbeddedElasticsearch;
 import org.elasticsearch.client.Client;
 import org.graylog2.Configuration;
+import org.graylog2.configuration.ElasticsearchConfiguration;
 import org.graylog2.indexer.Deflector;
 import org.graylog2.indexer.nosqlunit.IndexCreatingLoadStrategyFactory;
 import org.graylog2.indexer.ranges.IndexRange;
@@ -68,7 +69,7 @@ public class SearchesTest {
     @Rule
     public ElasticsearchRule elasticsearchRule;
 
-    private static final String INDEX_NAME = "graylog";
+    private static final String INDEX_NAME = "graylog_0";
     private static final SortedSet<IndexRange> INDEX_RANGES = ImmutableSortedSet
             .orderedBy(new IndexRangeComparator())
             .add(new IndexRange() {
@@ -98,6 +99,13 @@ public class SearchesTest {
                 }
             }).build();
 
+    private static final ElasticsearchConfiguration CONFIG = new ElasticsearchConfiguration() {
+        @Override
+        public String getIndexPrefix() {
+            return "graylog";
+        }
+    };
+
     @Mock
     private Deflector deflector;
     @Mock
@@ -111,7 +119,7 @@ public class SearchesTest {
 
     public SearchesTest() {
         this.elasticsearchRule = newElasticsearchRule().defaultEmbeddedElasticsearch();
-        this.elasticsearchRule.setLoadStrategyFactory(new IndexCreatingLoadStrategyFactory(Collections.singleton(INDEX_NAME)));
+        this.elasticsearchRule.setLoadStrategyFactory(new IndexCreatingLoadStrategyFactory(CONFIG, Collections.singleton(INDEX_NAME)));
     }
 
     @Before

--- a/graylog2-server/src/test/resources/org/graylog2/indexer/indices/IndicesTest-EmptyIndex.json
+++ b/graylog2-server/src/test/resources/org/graylog2/indexer/indices/IndicesTest-EmptyIndex.json
@@ -4,7 +4,7 @@
       "document": [
         {
           "index": {
-            "indexName": "graylog",
+            "indexName": "graylog_0",
             "indexType": "message",
             "indexId": "0"
           }

--- a/graylog2-server/src/test/resources/org/graylog2/indexer/indices/IndicesTest.json
+++ b/graylog2-server/src/test/resources/org/graylog2/indexer/indices/IndicesTest.json
@@ -4,7 +4,7 @@
       "document": [
         {
           "index": {
-            "indexName": "graylog",
+            "indexName": "graylog_0",
             "indexType": "message",
             "indexId": "0"
           }
@@ -22,7 +22,7 @@
       "document": [
         {
           "index": {
-            "indexName": "graylog",
+            "indexName": "graylog_0",
             "indexType": "message",
             "indexId": "1"
           }
@@ -41,7 +41,7 @@
       "document": [
         {
           "index": {
-            "indexName": "graylog",
+            "indexName": "graylog_0",
             "indexType": "message",
             "indexId": "2"
           }
@@ -60,7 +60,7 @@
       "document": [
         {
           "index": {
-            "indexName": "graylog",
+            "indexName": "graylog_0",
             "indexType": "message",
             "indexId": "3"
           }
@@ -79,7 +79,7 @@
       "document": [
         {
           "index": {
-            "indexName": "graylog",
+            "indexName": "graylog_0",
             "indexType": "message",
             "indexId": "4"
           }
@@ -98,7 +98,7 @@
       "document": [
         {
           "index": {
-            "indexName": "graylog",
+            "indexName": "graylog_0",
             "indexType": "message",
             "indexId": "5"
           }
@@ -116,7 +116,7 @@
       "document": [
         {
           "index": {
-            "indexName": "graylog",
+            "indexName": "graylog_0",
             "indexType": "message",
             "indexId": "6"
           }
@@ -135,7 +135,7 @@
       "document": [
         {
           "index": {
-            "indexName": "graylog",
+            "indexName": "graylog_0",
             "indexType": "message",
             "indexId": "7"
           }
@@ -154,7 +154,7 @@
       "document": [
         {
           "index": {
-            "indexName": "graylog",
+            "indexName": "graylog_0",
             "indexType": "message",
             "indexId": "8"
           }
@@ -173,7 +173,7 @@
       "document": [
         {
           "index": {
-            "indexName": "graylog",
+            "indexName": "graylog_0",
             "indexType": "message",
             "indexId": "9"
           }

--- a/graylog2-server/src/test/resources/org/graylog2/indexer/searches/SearchesTest.json
+++ b/graylog2-server/src/test/resources/org/graylog2/indexer/searches/SearchesTest.json
@@ -4,7 +4,7 @@
       "document": [
         {
           "index": {
-            "indexName": "graylog",
+            "indexName": "graylog_0",
             "indexType": "message",
             "indexId": "0"
           }
@@ -22,7 +22,7 @@
       "document": [
         {
           "index": {
-            "indexName": "graylog",
+            "indexName": "graylog_0",
             "indexType": "message",
             "indexId": "1"
           }
@@ -41,7 +41,7 @@
       "document": [
         {
           "index": {
-            "indexName": "graylog",
+            "indexName": "graylog_0",
             "indexType": "message",
             "indexId": "2"
           }
@@ -60,7 +60,7 @@
       "document": [
         {
           "index": {
-            "indexName": "graylog",
+            "indexName": "graylog_0",
             "indexType": "message",
             "indexId": "3"
           }
@@ -79,7 +79,7 @@
       "document": [
         {
           "index": {
-            "indexName": "graylog",
+            "indexName": "graylog_0",
             "indexType": "message",
             "indexId": "4"
           }
@@ -98,7 +98,7 @@
       "document": [
         {
           "index": {
-            "indexName": "graylog",
+            "indexName": "graylog_0",
             "indexType": "message",
             "indexId": "5"
           }
@@ -116,7 +116,7 @@
       "document": [
         {
           "index": {
-            "indexName": "graylog",
+            "indexName": "graylog_0",
             "indexType": "message",
             "indexId": "6"
           }
@@ -135,7 +135,7 @@
       "document": [
         {
           "index": {
-            "indexName": "graylog",
+            "indexName": "graylog_0",
             "indexType": "message",
             "indexId": "7"
           }
@@ -154,7 +154,7 @@
       "document": [
         {
           "index": {
-            "indexName": "graylog",
+            "indexName": "graylog_0",
             "indexType": "message",
             "indexId": "8"
           }
@@ -173,7 +173,7 @@
       "document": [
         {
           "index": {
-            "indexName": "graylog",
+            "indexName": "graylog_0",
             "indexType": "message",
             "indexId": "9"
           }


### PR DESCRIPTION
In commit edf0d8b we changed the index creation process from "create index" + "install index mapping" to one operation to avoid race conditions.

This broke setups where users had installed custom Elasticsearch index templates because the user templates where applied after our mapping was installed into the index. Before edf0d8b the user templates have been applied before we installed our mapping because the index creation was split into two steps.

We now install a "graylog-internal" index template into Elasticsearch with a "order" or -99 to make sure user templates are able to override our settings.

Fixes #1624