### PR TITLE
Add hostname to periodic cluster node registration record.

### DIFF
--- a/graylog2-rest-models/src/main/java/org/graylog2/rest/models/system/cluster/responses/NodeSummary.java
+++ b/graylog2-rest-models/src/main/java/org/graylog2/rest/models/system/cluster/responses/NodeSummary.java
@@ -36,6 +36,8 @@ public abstract class NodeSummary {
     public abstract String lastSeen();
     @JsonProperty
     public abstract String shortNodeId();
+    @JsonProperty
+    public abstract String hostname();
 
     @JsonCreator
     public static NodeSummary create(@JsonProperty("cluster_id") String clusterId,
@@ -44,7 +46,8 @@ public abstract class NodeSummary {
                                      @JsonProperty("is_master") boolean isMaster,
                                      @JsonProperty("transport_address") String transportAddress,
                                      @JsonProperty("last_seen") String lastSeen,
-                                     @JsonProperty("short_node_id") String shortNodeId) {
-        return new AutoValue_NodeSummary(clusterId, nodeId, type, isMaster, transportAddress, lastSeen, shortNodeId);
+                                     @JsonProperty("short_node_id") String shortNodeId,
+                                     @JsonProperty("hostname") String hostname) {
+        return new AutoValue_NodeSummary(clusterId, nodeId, type, isMaster, transportAddress, lastSeen, shortNodeId, hostname);
     }
 }

--- a/graylog2-server/src/main/java/org/graylog2/cluster/Node.java
+++ b/graylog2-server/src/main/java/org/graylog2/cluster/Node.java
@@ -35,4 +35,6 @@ public interface Node extends Persisted {
     String getShortNodeId();
 
     Node.Type getType();
+
+    String getHostname();
 }

--- a/graylog2-server/src/main/java/org/graylog2/cluster/NodeImpl.java
+++ b/graylog2-server/src/main/java/org/graylog2/cluster/NodeImpl.java
@@ -76,6 +76,11 @@ public class NodeImpl extends PersistedImpl implements Node {
     }
 
     @Override
+    public String getHostname() {
+        return (String)fields.get("hostname");
+    }
+
+    @Override
     @JsonIgnore
     public Map<String, Validator> getValidations() {
         return Collections.emptyMap();

--- a/graylog2-server/src/main/java/org/graylog2/cluster/NodeService.java
+++ b/graylog2-server/src/main/java/org/graylog2/cluster/NodeService.java
@@ -23,7 +23,7 @@ import java.net.URI;
 import java.util.Map;
 
 public interface NodeService extends PersistedService {
-    String registerServer(String nodeId, boolean isMaster, URI restTransportUri);
+    String registerServer(String nodeId, boolean isMaster, URI restTransportUri, String hostname);
 
     Node byNodeId(String nodeId) throws NodeNotFoundException;
 

--- a/graylog2-server/src/main/java/org/graylog2/cluster/NodeServiceImpl.java
+++ b/graylog2-server/src/main/java/org/graylog2/cluster/NodeServiceImpl.java
@@ -42,13 +42,14 @@ public class NodeServiceImpl extends PersistedServiceImpl implements NodeService
     }
 
     @Override
-    public String registerServer(String nodeId, boolean isMaster, URI restTransportUri) {
+    public String registerServer(String nodeId, boolean isMaster, URI restTransportUri, String hostname) {
         Map<String, Object> fields = Maps.newHashMap();
         fields.put("last_seen", Tools.getUTCTimestamp());
         fields.put("node_id", nodeId);
         fields.put("type", Node.Type.SERVER.toString());
         fields.put("is_master", isMaster);
         fields.put("transport_address", restTransportUri.toString());
+        fields.put("hostname", hostname);
 
         try {
             return save(new NodeImpl(fields));

--- a/graylog2-server/src/main/java/org/graylog2/commands/Server.java
+++ b/graylog2-server/src/main/java/org/graylog2/commands/Server.java
@@ -45,6 +45,7 @@ import org.graylog2.notifications.Notification;
 import org.graylog2.notifications.NotificationService;
 import org.graylog2.plugin.KafkaJournalConfiguration;
 import org.graylog2.plugin.ServerStatus;
+import org.graylog2.plugin.Tools;
 import org.graylog2.shared.UI;
 import org.graylog2.shared.bindings.RestApiBindings;
 import org.graylog2.shared.system.activities.Activity;
@@ -130,7 +131,10 @@ public class Server extends ServerBootstrap {
         final NodeService nodeService = injector.getInstance(NodeService.class);
         final ServerStatus serverStatus = injector.getInstance(ServerStatus.class);
         final ActivityWriter activityWriter = injector.getInstance(ActivityWriter.class);
-        nodeService.registerServer(serverStatus.getNodeId().toString(), configuration.isMaster(), configuration.getRestTransportUri());
+        nodeService.registerServer(serverStatus.getNodeId().toString(),
+                configuration.isMaster(),
+                configuration.getRestTransportUri(),
+                Tools.getLocalCanonicalHostname());
         serverStatus.setLocalMode(isLocal());
         if (configuration.isMaster() && !nodeService.isOnlyMaster(serverStatus.getNodeId())) {
             LOG.warn("Detected another master in the cluster. Retrying in {} seconds to make sure it is not "

--- a/graylog2-server/src/main/java/org/graylog2/periodical/NodePingThread.java
+++ b/graylog2-server/src/main/java/org/graylog2/periodical/NodePingThread.java
@@ -24,6 +24,7 @@ import org.graylog2.cluster.NodeService;
 import org.graylog2.notifications.Notification;
 import org.graylog2.notifications.NotificationImpl;
 import org.graylog2.notifications.NotificationService;
+import org.graylog2.plugin.Tools;
 import org.graylog2.plugin.periodical.Periodical;
 import org.graylog2.plugin.ServerStatus;
 import org.graylog2.shared.system.activities.Activity;
@@ -64,7 +65,10 @@ public class NodePingThread extends Periodical {
             nodeService.markAsAlive(node, isMaster, configuration.getRestTransportUri());
         } catch (NodeNotFoundException e) {
             LOG.warn("Did not find meta info of this node. Re-registering.");
-            nodeService.registerServer(serverStatus.getNodeId().toString(), isMaster, configuration.getRestTransportUri());
+            nodeService.registerServer(serverStatus.getNodeId().toString(),
+                    isMaster,
+                    configuration.getRestTransportUri(),
+                    Tools.getLocalCanonicalHostname());
         }
         try {
             // Remove old nodes that are no longer running. (Just some housekeeping)

--- a/graylog2-server/src/main/java/org/graylog2/rest/resources/system/ClusterResource.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/resources/system/ClusterResource.java
@@ -119,7 +119,8 @@ public class ClusterResource extends RestResource {
                 node.isMaster(),
                 node.getTransportAddress(),
                 Tools.getISO8601String(node.getLastSeen()),
-                node.getShortNodeId()
+                node.getShortNodeId(),
+                Tools.getLocalCanonicalHostname()
         );
     }
 }

--- a/graylog2-web-interface/src/components/common/LinkToNode.jsx
+++ b/graylog2-web-interface/src/components/common/LinkToNode.jsx
@@ -21,7 +21,7 @@ const LinkToNode = React.createClass({
     return (
       <Link to={Routes.SYSTEM.NODES.SHOW(this.props.nodeId)}>
         <i class="fa fa-code-fork"/>
-        {node.short_node_id} / @node.getHostname
+        {node.short_node_id} / {node.hostname}
       </Link>
     );
   },


### PR DESCRIPTION
This is done to avoid additional roundtrips to the server for displaying
a node's hostname, which was available only when querying the
SystemResource of that specific node directly.
The hostname is used when linking to nodes to show it along with the
short node id, trying to help the user identifying specific nodes.

Right now the hostname is determined only when the initial node
registration is created. If this turns out to be a problem, we can do it
everytime the node records is touched.