### PR TITLE
Add option to AMQP transports to bind the queue to the exchange

### DIFF
--- a/graylog2-inputs/src/main/java/org/graylog2/inputs/transports/AmqpConsumer.java
+++ b/graylog2-inputs/src/main/java/org/graylog2/inputs/transports/AmqpConsumer.java
@@ -54,6 +54,7 @@ public class AmqpConsumer {
 
     private final String queue;
     private final String exchange;
+    private final boolean exchangeBind;
     private final String routingKey;
     private final boolean requeueInvalid;
 
@@ -71,7 +72,7 @@ public class AmqpConsumer {
     private AtomicLong lastSecBytesReadTmp = new AtomicLong(0);
 
     public AmqpConsumer(String hostname, int port, String virtualHost, String username, String password,
-                        int prefetchCount, String queue, String exchange, String routingKey, int parallelQueues,
+                        int prefetchCount, String queue, String exchange, boolean exchangeBind, String routingKey,int parallelQueues,
                         boolean tls, boolean requeueInvalid, int heartbeatTimeout, MessageInput sourceInput,
                         ScheduledExecutorService scheduler, AmqpTransport amqpTransport) {
         this.hostname = hostname;
@@ -83,6 +84,7 @@ public class AmqpConsumer {
 
         this.queue = queue;
         this.exchange = exchange;
+        this.exchangeBind = exchangeBind;
         this.routingKey = routingKey;
         this.heartbeatTimeout = heartbeatTimeout;
 
@@ -108,6 +110,9 @@ public class AmqpConsumer {
         for (int i = 0; i < parallelQueues; i++) {
             final String queueName = String.format(queue, i);
             channel.queueDeclare(queueName, true, false, false, null);
+            if (exchangeBind) {
+                channel.queueBind(queueName, exchange, routingKey);
+            }
             channel.basicConsume(queueName, false, new DefaultConsumer(channel) {
                 @Override
                 public void handleDelivery(String consumerTag, Envelope envelope, AMQP.BasicProperties properties, byte[] body) throws IOException {

--- a/graylog2-inputs/src/main/java/org/graylog2/inputs/transports/AmqpTransport.java
+++ b/graylog2-inputs/src/main/java/org/graylog2/inputs/transports/AmqpTransport.java
@@ -53,6 +53,7 @@ public class AmqpTransport extends ThrottleableTransport {
     public static final String CK_PASSWORD = "broker_password";
     public static final String CK_PREFETCH = "prefetch";
     public static final String CK_EXCHANGE = "exchange";
+    public static final String CK_EXCHANGE_BIND = "exchange_bind";
     public static final String CK_QUEUE = "queue";
     public static final String CK_ROUTING_KEY = "routing_key";
     public static final String CK_PARALLEL_QUEUES = "parallel_queues";
@@ -160,6 +161,7 @@ public class AmqpTransport extends ThrottleableTransport {
                 configuration.getInt(CK_PREFETCH),
                 configuration.getString(CK_QUEUE),
                 configuration.getString(CK_EXCHANGE),
+                configuration.getBoolean(CK_EXCHANGE_BIND),
                 configuration.getString(CK_ROUTING_KEY),
                 configuration.getInt(CK_PARALLEL_QUEUES),
                 configuration.getBoolean(CK_TLS),
@@ -288,6 +290,15 @@ public class AmqpTransport extends ThrottleableTransport {
                             defaultExchangeName(),
                             "Name of exchange to bind to.",
                             ConfigurationField.Optional.NOT_OPTIONAL
+                    )
+            );
+
+            cr.addField(
+                    new BooleanField(
+                            CK_EXCHANGE_BIND,
+                            "Bind to exchange",
+                            false,
+                            "Binds the queue to the configured exchange. The exchange must already exist."
                     )
             );
 


### PR DESCRIPTION
This was missing before and the exchange and routing-key options were not used.

The binding option defaults to "false" to avoid existing setups to fail when the given exchange (there is a default) does not exist.

Fixes #1599