### PR TITLE
Fix user custom startpage

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/users/UserImpl.java
+++ b/graylog2-server/src/main/java/org/graylog2/users/UserImpl.java
@@ -185,8 +185,13 @@ public class UserImpl extends PersistedImpl implements User {
         if (fields.containsKey(STARTPAGE)) {
             @SuppressWarnings("unchecked")
             final Map<String, String> obj = (Map<String, String>) fields.get(STARTPAGE);
-            startpage.put("type", obj.get("type"));
-            startpage.put("id", obj.get("id"));
+            final String type = obj.get("type");
+            final String id = obj.get("id");
+
+            if (type != null && id != null) {
+                startpage.put("type", type);
+                startpage.put("id", id);
+            }
         }
 
         return startpage;

--- a/graylog2-web-interface/src/components/dashboard/Dashboard.jsx
+++ b/graylog2-web-interface/src/components/dashboard/Dashboard.jsx
@@ -1,11 +1,14 @@
 import React from 'react';
+import Reflux from 'reflux';
 import { DropdownButton, MenuItem } from 'react-bootstrap';
 import { LinkContainer } from 'react-router-bootstrap';
 
 import EditDashboardModalTrigger from './EditDashboardModalTrigger';
 import PermissionsMixin from 'util/PermissionsMixin';
 
+import CurrentUserStore from 'stores/users/CurrentUserStore';
 import DashboardsStore from 'stores/dashboards/DashboardsStore';
+import StartpageStore from 'stores/users/StartpageStore';
 
 import Routes from 'routing/Routes';
 import jsRoutes from 'routing/jsRoutes';
@@ -15,7 +18,15 @@ const Dashboard = React.createClass({
     dashboard: React.PropTypes.object,
     permissions: React.PropTypes.arrayOf(React.PropTypes.string),
   },
-  mixins: [PermissionsMixin],
+  mixins: [PermissionsMixin, Reflux.connect(CurrentUserStore)],
+  _setStartpage() {
+    StartpageStore.set(this.state.currentUser.username, 'dashboard', this.props.dashboard.id);
+  },
+  _onDashboardDelete() {
+    if (window.confirm(`Do you really want to delete the dashboard ${this.props.dashboard.title}?`)) {
+      DashboardsStore.remove(this.props.dashboard);
+    }
+  },
   _getDashboardActions() {
     let dashboardActions;
 
@@ -26,9 +37,7 @@ const Dashboard = React.createClass({
                                      description={this.props.dashboard.description} buttonClass="btn-info"/>
           &nbsp;
           <DropdownButton title="More actions" pullRight id={`more-actions-dropdown-${this.props.dashboard.id}`}>
-            <LinkContainer to={Routes.startpage_set('dashboard', this.props.dashboard.id)}>
-              <MenuItem>Set as startpage</MenuItem>
-            </LinkContainer>
+            <MenuItem onSelect={this._setStartpage} disabled={this.state.currentUser.read_only}>Set as startpage</MenuItem>
             <MenuItem divider/>
             <MenuItem onSelect={this._onDashboardDelete}>Delete this dashboard</MenuItem>
           </DropdownButton>
@@ -68,11 +77,6 @@ const Dashboard = React.createClass({
         </div>
       </li>
     );
-  },
-  _onDashboardDelete() {
-    if (window.confirm(`Do you really want to delete the dashboard ${this.props.dashboard.title}?`)) {
-      DashboardsStore.remove(this.props.dashboard);
-    }
   },
 });
 

--- a/graylog2-web-interface/src/components/dashboard/DashboardList.jsx
+++ b/graylog2-web-interface/src/components/dashboard/DashboardList.jsx
@@ -13,6 +13,11 @@ const DashboardList = React.createClass({
     permissions: React.PropTypes.arrayOf(React.PropTypes.string),
   },
   mixins: [PermissionsMixin],
+  _formatDashboard(dashboard) {
+    return (
+      <Dashboard key={`dashboard-${dashboard.id}`} dashboard={dashboard} permissions={this.props.permissions}/>
+    );
+  },
   render() {
     if (this.props.dashboards.isEmpty()) {
       let createDashboardButton;
@@ -42,11 +47,6 @@ const DashboardList = React.createClass({
       <ul className="streams">
         {dashboardList}
       </ul>
-    );
-  },
-  _formatDashboard(dashboard) {
-    return (
-      <Dashboard key={`dashboard-${dashboard.id}`} dashboard={dashboard} permissions={this.props.permissions}/>
     );
   },
 });

--- a/graylog2-web-interface/src/components/streams/StreamControls.jsx
+++ b/graylog2-web-interface/src/components/streams/StreamControls.jsx
@@ -5,6 +5,8 @@ import { IfPermitted } from 'components/common';
 import StreamForm from './StreamForm';
 import PermissionsMixin from 'util/PermissionsMixin';
 
+import StartpageStore from 'stores/users/StartpageStore';
+
 const StreamControls = React.createClass({
   propTypes: {
     stream: PropTypes.object.isRequired,
@@ -37,6 +39,10 @@ const StreamControls = React.createClass({
     event.preventDefault();
     this.props.onQuickAdd(this.props.stream.id);
   },
+  _setStartpage(event) {
+    event.preventDefault();
+    StartpageStore.set(this.props.user.username, 'stream', this.props.stream.id);
+  },
   render() {
     const stream = this.props.stream;
 
@@ -53,7 +59,7 @@ const StreamControls = React.createClass({
             <IfPermitted permissions={['streams:create', `streams:read:${stream.id}`]}>
               <MenuItem key={`cloneStream-${stream.id}`} onSelect={this._onClone}>Clone this stream</MenuItem>
             </IfPermitted>
-            <MenuItem key={`setAsStartpage-${stream.id}`} disabled={this.props.user.readonly}>
+            <MenuItem key={`setAsStartpage-${stream.id}`} onSelect={this._setStartpage} disabled={this.props.user.read_only}>
               Set as startpage
             </MenuItem>
             <IfPermitted permissions={`streams:edit:${stream.id}`}>

--- a/graylog2-web-interface/src/components/streams/StreamControls.jsx
+++ b/graylog2-web-interface/src/components/streams/StreamControls.jsx
@@ -1,77 +1,75 @@
-/* global jsRoutes */
+import React, {PropTypes} from 'react';
+import { DropdownButton, MenuItem } from 'react-bootstrap';
 
-'use strict';
+import { IfPermitted } from 'components/common';
+import StreamForm from './StreamForm';
+import PermissionsMixin from 'util/PermissionsMixin';
 
-var React = require('react');
-var DropdownButton = require('react-bootstrap').DropdownButton;
-var MenuItem = require('react-bootstrap').MenuItem;
-var StreamForm = require('./StreamForm');
-var PermissionsMixin = require('../../util/PermissionsMixin');
-import { LinkContainer } from 'react-router-bootstrap';
-import Routes from 'routing/Routes';
+const StreamControls = React.createClass({
+  propTypes: {
+    stream: PropTypes.object.isRequired,
+    user: PropTypes.object.isRequired,
+    onDelete: PropTypes.func.isRequired,
+    onClone: PropTypes.func.isRequired,
+    onQuickAdd: PropTypes.func.isRequired,
+    onUpdate: PropTypes.func.isRequired,
+  },
+  mixins: [PermissionsMixin],
+  getInitialState() {
+    return {};
+  },
+  _onDelete(event) {
+    event.preventDefault();
+    this.props.onDelete(this.props.stream);
+  },
+  _onEdit(event) {
+    event.preventDefault();
+    this.refs.streamForm.open();
+  },
+  _onClone(event) {
+    event.preventDefault();
+    this.refs.cloneForm.open();
+  },
+  _onCloneSubmit(_, stream) {
+    this.props.onClone(this.props.stream.id, stream);
+  },
+  _onQuickAdd(event) {
+    event.preventDefault();
+    this.props.onQuickAdd(this.props.stream.id);
+  },
+  render() {
+    const stream = this.props.stream;
 
-var StreamControls = React.createClass({
-    mixins: [PermissionsMixin],
-    getInitialState() {
-        return {};
-    },
-    _onDelete(event) {
-        event.preventDefault();
-        this.props.onDelete(this.props.stream);
-    },
-    _onEdit(event) {
-        event.preventDefault();
-        this.refs.streamForm.open();
-    },
-    _onClone(event) {
-        event.preventDefault();
-        this.refs.cloneForm.open();
-    },
-    _onCloneSubmit(streamId, stream) {
-        this.props.onClone(this.props.stream.id, stream);
-    },
-    _onQuickAdd(event) {
-        event.preventDefault();
-        this.props.onQuickAdd(this.props.stream.id);
-    },
-    render() {
-        var permissions = this.props.permissions;
-        var stream = this.props.stream;
-
-        var menuItems = [];
-
-        if (this.isPermitted(permissions, ['streams:edit:' + stream.id])) {
-            menuItems.push(<MenuItem key={"editStreams-" + stream.id} onSelect={this._onEdit}>Edit stream</MenuItem>);
-            menuItems.push(<MenuItem key={"quickAddRule-" + stream.id} onSelect={this._onQuickAdd}>Quick add rule</MenuItem>);
-        }
-
-        if (this.isPermitted(permissions, ["streams:create", "streams:read:" + stream.id])) {
-            menuItems.push(<MenuItem key={"cloneStream-" + stream.id} onSelect={this._onClone}>Clone this stream</MenuItem>);
-        }
-
-        if (this.props.user) {
-            menuItems.push(<LinkContainer key={'setAsStartpage-' + stream.id} to={Routes.startpage_set('stream', stream.id)}>
-              <MenuItem disabled={this.props.user.readonly}>
-                Set as startpage
+    return (
+      <span>
+          <DropdownButton title="More actions" ref="dropdownButton" pullRight
+                          id={`more-actions-dropdown-${stream.id}`}>
+            <IfPermitted permissions={`streams:edit:${stream.id}`}>
+              <MenuItem key={`editStreams-${stream.id}`} onSelect={this._onEdit}>Edit stream</MenuItem>
+            </IfPermitted>
+            <IfPermitted permissions={`streams:edit:${stream.id}`}>
+              <MenuItem key={`quickAddRule-${stream.id}`} onSelect={this._onQuickAdd}>Quick add rule</MenuItem>
+            </IfPermitted>
+            <IfPermitted permissions={['streams:create', `streams:read:${stream.id}`]}>
+              <MenuItem key={`cloneStream-${stream.id}`} onSelect={this._onClone}>Clone this stream</MenuItem>
+            </IfPermitted>
+            <MenuItem key={`setAsStartpage-${stream.id}`} disabled={this.props.user.readonly}>
+              Set as startpage
+            </MenuItem>
+            <IfPermitted permissions={`streams:edit:${stream.id}`}>
+              <MenuItem key={`divider-${stream.id}`} divider/>
+            </IfPermitted>
+            <IfPermitted permissions={`streams:edit:${stream.id}`}>
+              <MenuItem key={`deleteStream-${stream.id}`} onSelect={this._onDelete}>
+                Delete this stream
               </MenuItem>
-            </LinkContainer>);
-        }
-
-        if (this.isPermitted(permissions, ['streams:edit:' + stream.id])) {
-            menuItems.push(<MenuItem key={'divider-' + stream.id} divider />);
-            menuItems.push(<MenuItem key={'deleteStream-' + stream.id} onSelect={this._onDelete}>Delete this stream</MenuItem>);
-        }
-
-        return (
-            <span>
-                <DropdownButton title='More actions' ref='dropdownButton' pullRight={true} id={`more-actions-dropdown-${stream.id}`}>
-                    {menuItems}
-                </DropdownButton>
-                <StreamForm ref='streamForm' title="Editing Stream" onSubmit={this.props.onUpdate} stream={stream}/>
-                <StreamForm ref='cloneForm' title="Cloning Stream" onSubmit={this._onCloneSubmit}/>
-            </span>
-        );
-    }
+            </IfPermitted>
+          </DropdownButton>
+          <StreamForm ref="streamForm" title="Editing Stream" onSubmit={this.props.onUpdate} stream={stream}/>
+          <StreamForm ref="cloneForm" title="Cloning Stream" onSubmit={this._onCloneSubmit}/>
+      </span>
+    );
+  },
 });
 
-module.exports = StreamControls;
+export default StreamControls;

--- a/graylog2-web-interface/src/pages/EditUsersPage.jsx
+++ b/graylog2-web-interface/src/pages/EditUsersPage.jsx
@@ -1,6 +1,8 @@
 import React from 'react';
+import {Button} from 'react-bootstrap';
 
 import UsersStore from 'stores/users/UsersStore';
+import StartpageStore from 'stores/users/StartpageStore';
 
 import PageHeader from 'components/common/PageHeader';
 import Spinner from 'components/common/Spinner';
@@ -16,9 +18,17 @@ const EditUsersPage = React.createClass({
     };
   },
   componentDidMount() {
+    this._loadUser();
+  },
+  _loadUser() {
     UsersStore.load(this.props.params.username).then((user) => {
       this.setState({user: user});
     });
+  },
+  _resetStartpage() {
+    if (window.confirm('Are you sure you want to reset your current start page?')) {
+      StartpageStore.set(this.props.params.username).then(() => this._loadUser());
+    }
   },
   render() {
     if (!this.state.user) {
@@ -26,11 +36,11 @@ const EditUsersPage = React.createClass({
     }
 
     const user = this.state.user;
-    const resetStartpageButton = (!user.read_only && user.startpage !== null && Object.keys(user.startpage).length > 0) ?
-      <button type="submit" className="btn btn-info" data-confirm="Really reset startpage?">
-        Reset custom startpage
-      </button>
-      : null;
+    let resetStartpageButton;
+    if (!user.read_only && user.startpage !== null && Object.keys(user.startpage).length > 0) {
+      resetStartpageButton = <Button bsStyle="info" onClick={this._resetStartpage}>Reset custom startpage</Button>;
+    }
+
     const userPreferencesButton = !user.read_only ?
       <span id="react-user-preferences-button" data-user-name={this.props.params.username}>
         <UserPreferencesButton userName={user.username}/>

--- a/graylog2-web-interface/src/pages/EditUsersPage.jsx
+++ b/graylog2-web-interface/src/pages/EditUsersPage.jsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, {PropTypes} from 'react';
 import {Button} from 'react-bootstrap';
 
 import UsersStore from 'stores/users/UsersStore';
@@ -8,10 +8,12 @@ import PageHeader from 'components/common/PageHeader';
 import Spinner from 'components/common/Spinner';
 import UserForm from 'components/users/UserForm';
 
-import UserPreferencesModal from 'components/users/UserPreferencesModal';
 import UserPreferencesButton from 'components/users/UserPreferencesButton';
 
 const EditUsersPage = React.createClass({
+  propTypes: {
+    username: PropTypes.string.isRequired,
+  },
   getInitialState() {
     return {
       user: undefined,
@@ -60,7 +62,7 @@ const EditUsersPage = React.createClass({
 
         <UserForm user={this.state.user} />
       </span>
-    )
+    );
   },
 });
 

--- a/graylog2-web-interface/src/pages/StartPage.jsx
+++ b/graylog2-web-interface/src/pages/StartPage.jsx
@@ -24,6 +24,11 @@ const StartPage = React.createClass({
   componentDidMount() {
     GettingStartedActions.getStatus();
   },
+  componentDidUpdate() {
+    if (!this._isLoading()) {
+      this._redirect();
+    }
+  },
   onGettingStartedUpdate(state) {
     this.setState({gettingStarted: state.status});
   },
@@ -41,9 +46,6 @@ const StartPage = React.createClass({
     return !this.state.currentUser || !this.state.gettingStarted;
   },
   render() {
-    if (!this._isLoading()) {
-      this._redirect();
-    }
     return <Spinner/>;
   },
 });

--- a/graylog2-web-interface/src/routing/Routes.jsx
+++ b/graylog2-web-interface/src/routing/Routes.jsx
@@ -37,7 +37,6 @@ const Routes = {
   stream_outputs: (streamId) => '/streams/' + streamId + '/outputs',
   stream_alerts: (streamId) => '/streams/' + streamId + '/alerts',
   stream_search: (streamId) => '/streams/' + streamId + '/search',
-  startpage_set: (type, id) => '/startpage/set/' + type + '/' + id,
 
   dashboard_show: (dashboardId) => '/dashboards/' + dashboardId,
 

--- a/graylog2-web-interface/src/stores/users/CurrentUserStore.jsx
+++ b/graylog2-web-interface/src/stores/users/CurrentUserStore.jsx
@@ -5,6 +5,7 @@ import fetch from 'logic/rest/FetchProvider';
 
 import SessionActions from 'actions/sessions/SessionActions';
 import SessionStore from 'stores/sessions/SessionStore';
+import StartpageStore from 'stores/users/StartpageStore';
 
 const CurrentUserStore = Reflux.createStore({
   listenable: [SessionActions],
@@ -12,7 +13,8 @@ const CurrentUserStore = Reflux.createStore({
   currentUser: undefined,
 
   init() {
-    this.listenTo(SessionStore, this.update, this.update);
+    this.listenTo(SessionStore, this.sessionUpdate, this.sessionUpdate);
+    this.listenTo(StartpageStore, this.reload, this.reload);
   },
 
   getInitialState() {
@@ -23,16 +25,25 @@ const CurrentUserStore = Reflux.createStore({
     return this.currentUser;
   },
 
-  update(sessionInfo) {
+  sessionUpdate(sessionInfo) {
     if (sessionInfo.sessionId && sessionInfo.username) {
       const username = sessionInfo.username;
-
-      fetch('GET', URLUtils.qualifyUrl(this.sourceUrl + '/' + username))
-        .then((resp) => {
-          this.currentUser = resp;
-          this.trigger({currentUser: this.currentUser});
-        });
+      this.update(username);
     }
+  },
+
+  reload() {
+    if (this.currentUser !== undefined) {
+      this.update(this.currentUser.username);
+    }
+  },
+
+  update(username) {
+    fetch('GET', URLUtils.qualifyUrl(this.sourceUrl + '/' + username))
+      .then((resp) => {
+        this.currentUser = resp;
+        this.trigger({currentUser: this.currentUser});
+      });
   },
 });
 

--- a/graylog2-web-interface/src/stores/users/StartpageStore.js
+++ b/graylog2-web-interface/src/stores/users/StartpageStore.js
@@ -16,7 +16,10 @@ const StartpageStore = Reflux.createStore({
     }
     const promise = fetch('PUT', url, {startpage: payload})
       .then(
-        () => UserNotification.success('Your start page was changed successfully'),
+        () => {
+          this.trigger();
+          UserNotification.success('Your start page was changed successfully')
+        },
         (error) => UserNotification.error(`Changing your start page failed with error: ${error}`, 'Could not change your start page')
       );
 

--- a/graylog2-web-interface/src/stores/users/StartpageStore.js
+++ b/graylog2-web-interface/src/stores/users/StartpageStore.js
@@ -1,0 +1,27 @@
+import Reflux from 'reflux';
+import UserNotification from 'util/UserNotification';
+import URLUtils from 'util/URLUtils';
+import fetch from 'logic/rest/FetchProvider';
+
+const StartpageStore = Reflux.createStore({
+  listenables: [],
+  sourceUrl: (username) => `/users/${username}`,
+
+  set(username, type, id) {
+    const url = URLUtils.qualifyUrl(this.sourceUrl(username));
+    const payload = {};
+    if (type && id) {
+      payload.type = type;
+      payload.id = id;
+    }
+    const promise = fetch('PUT', url, {startpage: payload})
+      .then(
+        () => UserNotification.success('Your start page was changed successfully'),
+        (error) => UserNotification.error(`Changing your start page failed with error: ${error}`, 'Could not change your start page')
+      );
+
+    return promise;
+  },
+});
+
+export default StartpageStore;


### PR DESCRIPTION
These changes fix the menus to set a stream search or dashboard as a start page, and take that into consideration when deciding which page to render as start page.

The button to reset the custom start page is also working, although reader users cannot load the user form at the moment (will address that out of this PR).