### PR TITLE
Add "remove" method to ClusterConfigService

### DIFF
--- a/graylog2-plugin-interfaces/src/main/java/org/graylog2/plugin/cluster/ClusterConfigService.java
+++ b/graylog2-plugin-interfaces/src/main/java/org/graylog2/plugin/cluster/ClusterConfigService.java
@@ -53,4 +53,12 @@ public interface ClusterConfigService {
      * @param <T>     The type of the Java configuration bean.
      */
     <T> void write(T payload);
+
+    /**
+     * Remove a configuration bean from the cluster configuration.
+     *
+     * @param type The {@link Class} of the Java configuration bean to remove.
+     * @return The number of removed entries from the cluster configuration.
+     */
+    <T> int remove(Class<T> type);
 }

--- a/graylog2-server/src/main/java/org/graylog2/cluster/ClusterConfigServiceImpl.java
+++ b/graylog2-server/src/main/java/org/graylog2/cluster/ClusterConfigServiceImpl.java
@@ -32,6 +32,7 @@ import org.joda.time.DateTimeZone;
 import org.mongojack.DBQuery;
 import org.mongojack.DBSort;
 import org.mongojack.JacksonDBCollection;
+import org.mongojack.WriteResult;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -126,5 +127,12 @@ public class ClusterConfigServiceImpl implements ClusterConfigService {
         ClusterConfigChangedEvent event = ClusterConfigChangedEvent.create(
                 DateTime.now(DateTimeZone.UTC), nodeId.toString(), canonicalClassName);
         clusterEventBus.post(event);
+    }
+
+    @Override
+    public <T> int remove(Class<T> type) {
+        final String canonicalName = type.getCanonicalName();
+        final WriteResult<ClusterConfig, String> result = dbCollection.remove(DBQuery.is("type", canonicalName));
+        return result.getN();
     }
 }

--- a/graylog2-server/src/test/java/org/graylog2/cluster/ClusterConfigServiceImplTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/cluster/ClusterConfigServiceImplTest.java
@@ -313,6 +313,32 @@ public class ClusterConfigServiceImplTest {
         assertThat(collection.getWriteConcern()).isEqualTo(WriteConcern.FSYNCED);
     }
 
+    @Test
+    @UsingDataSet(loadStrategy = LoadStrategyEnum.DELETE_ALL)
+    public void removeDoesNothingIfConfigDoesNotExist() throws Exception {
+        final DBCollection collection = mongoConnection.getDatabase().getCollection(COLLECTION_NAME);
+
+        assertThat(collection.count()).isEqualTo(0L);
+        assertThat(clusterConfigService.remove(CustomConfig.class)).isEqualTo(0);
+    }
+
+    @Test
+    @UsingDataSet(loadStrategy = LoadStrategyEnum.DELETE_ALL)
+    public void removeSuccessfullyRemovesConfig() throws Exception {
+        DBObject dbObject = new BasicDBObjectBuilder()
+                .add("type", CustomConfig.class.getCanonicalName())
+                .add("payload", Collections.singletonMap("text", "TEST"))
+                .add("last_updated", TIME.toString())
+                .add("last_updated_by", "ID")
+                .get();
+        final DBCollection collection = mongoConnection.getDatabase().getCollection(COLLECTION_NAME);
+        collection.save(dbObject);
+
+        assertThat(collection.count()).isEqualTo(1L);
+        assertThat(clusterConfigService.remove(CustomConfig.class)).isEqualTo(1);
+        assertThat(collection.count()).isEqualTo(0L);
+    }
+
     public static class ClusterConfigChangedEventHandler {
         public volatile ClusterConfigChangedEvent event;
 


### PR DESCRIPTION
Add "remove" method to `ClusterConfigService` so that existing cluster configuration entries can not only be written and retrieved, but also be removed.