### PR TITLE
Handling "." characters in message field names with ES 2.0

### DIFF
--- a/graylog2-plugin-interfaces/src/main/java/org/graylog2/plugin/Message.java
+++ b/graylog2-plugin-interfaces/src/main/java/org/graylog2/plugin/Message.java
@@ -65,7 +65,7 @@ public class Message implements Messages {
     public static final String FIELD_LEVEL = "level";
     public static final String FIELD_STREAMS = "streams";
 
-    private static final Pattern VALID_KEY_CHARS = Pattern.compile("^[\\w\\.\\-@]*$");
+    private static final Pattern VALID_KEY_CHARS = Pattern.compile("^[\\w\\-@]*$");
 
     public static final ImmutableSet<String> RESERVED_FIELDS = ImmutableSet.of(
             // ElasticSearch fields.
@@ -254,6 +254,9 @@ public class Message implements Messages {
         if (RESERVED_FIELDS.contains(key) && !RESERVED_SETTABLE_FIELDS.contains(key) || !validKey(key)) {
             if (LOG.isDebugEnabled()) {
                 LOG.debug("Ignoring invalid or reserved key {} for message {}", key, getId());
+            }
+            if (key != null && key.contains(".")) {
+                LOG.warn("Keys must not contain a \".\" character! Ignoring field \"{}\"=\"{}\" in message [{}].", key, value, getId());
             }
             return;
         }

--- a/graylog2-plugin-interfaces/src/test/java/org/graylog2/plugin/MessageTest.java
+++ b/graylog2-plugin-interfaces/src/test/java/org/graylog2/plugin/MessageTest.java
@@ -259,13 +259,14 @@ public class MessageTest {
         assertTrue(Message.validKey("foo123"));
         assertTrue(Message.validKey("foo-bar123"));
         assertTrue(Message.validKey("foo_bar123"));
-        assertTrue(Message.validKey("foo.bar123"));
+        assertTrue(Message.validKey("foo@bar"));
         assertTrue(Message.validKey("123"));
         assertTrue(Message.validKey(""));
 
         assertFalse(Message.validKey("foo bar"));
         assertFalse(Message.validKey("foo+bar"));
         assertFalse(Message.validKey("foo$bar"));
+        assertFalse(Message.validKey("foo.bar123"));
         assertFalse(Message.validKey(" "));
     }
 

--- a/graylog2-server/src/main/java/org/graylog2/inputs/extractors/JsonExtractor.java
+++ b/graylog2-server/src/main/java/org/graylog2/inputs/extractors/JsonExtractor.java
@@ -75,7 +75,7 @@ public class JsonExtractor extends Extractor {
 
         this.flatten = firstNonNull((Boolean) extractorConfig.get(CK_FLATTEN), false);
         this.listSeparator = firstNonNull((String) extractorConfig.get(CK_LIST_SEPARATOR), ", ");
-        this.keySeparator = firstNonNull((String) extractorConfig.get(CK_KEY_SEPARATOR), ".");
+        this.keySeparator = firstNonNull((String) extractorConfig.get(CK_KEY_SEPARATOR), "_");
         this.kvSeparator = firstNonNull((String) extractorConfig.get(CK_KV_SEPARATOR), "=");
     }
 

--- a/graylog2-server/src/test/java/org/graylog2/inputs/extractors/JsonExtractorTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/inputs/extractors/JsonExtractorTest.java
@@ -94,10 +94,10 @@ public class JsonExtractorTest {
         final Extractor.Result[] results = jsonExtractor.run(value);
 
         assertThat(results).contains(
-                new Extractor.Result("foobar", "object.text", -1, -1),
-                new Extractor.Result(1234.5678, "object.number", -1, -1),
-                new Extractor.Result(true, "object.bool", -1, -1),
-                new Extractor.Result("foobar", "object.nested.text", -1, -1)
+                new Extractor.Result("foobar", "object_text", -1, -1),
+                new Extractor.Result(1234.5678, "object_number", -1, -1),
+                new Extractor.Result(true, "object_bool", -1, -1),
+                new Extractor.Result("foobar", "object_nested_text", -1, -1)
         );
     }
 


### PR DESCRIPTION
Elasticsearch 2.0 does not allow "." characters in keys anymore. We have to decide what to do.

I see the following options:

1. Ignore fields with `.` in the key name
1. Convert the `.` character to something else (problem if the converted key already exists)
1. Encode the `.` to something that can be stored in ES before writing it and decode it when reading from ES

I implemented the first option in this PR as a start for the discussion.

There are some more ES changes that we might have to take into account.

Example: https://www.elastic.co/guide/en/elasticsearch/reference/2.0/breaking_20_mapping_changes.html#_type_names_may_not_be_longer_than_255_characters