### PR TITLE
Correctly handle null values in nested structures in JsonExtractor

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/filters/ExtractorFilter.java
+++ b/graylog2-server/src/main/java/org/graylog2/filters/ExtractorFilter.java
@@ -62,7 +62,8 @@ public class ExtractorFilter implements MessageFilter {
                 extractor.runExtractor(msg);
             } catch (Exception e) {
                 extractor.incrementExceptions();
-                LOG.error("Could not apply extractor " + extractor.getTitle() + " (id=" + extractor.getId() + ")", e);
+                LOG.error("Could not apply extractor \"" + extractor.getTitle() + "\" (id=" + extractor.getId() + ") "
+                        + "to message " + msg.getId(), e);
             }
         }
 

--- a/graylog2-server/src/main/java/org/graylog2/inputs/extractors/JsonExtractor.java
+++ b/graylog2-server/src/main/java/org/graylog2/inputs/extractors/JsonExtractor.java
@@ -21,6 +21,8 @@ import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.auto.value.AutoValue;
 import com.google.common.base.Joiner;
+import com.google.common.base.Predicate;
+import com.google.common.collect.Maps;
 import org.graylog2.ConfigurationException;
 import org.graylog2.plugin.inputs.Converter;
 import org.graylog2.plugin.inputs.Extractor;
@@ -45,6 +47,7 @@ public class JsonExtractor extends Extractor {
     private static final String CK_LIST_SEPARATOR = "list_separator";
     private static final String CK_KEY_SEPARATOR = "key_separator";
     private static final String CK_KV_SEPARATOR = "kv_separator";
+    private static final RemoveNullPredicate REMOVE_NULL_PREDICATE = new RemoveNullPredicate();
 
     private final ObjectMapper mapper = new ObjectMapper();
     private final boolean flatten;
@@ -94,14 +97,15 @@ public class JsonExtractor extends Extractor {
 
         final Map<String, Object> json;
         try {
-            json = mapper.readValue(value, new TypeReference<Map<String, Object>>() {});
+            json = mapper.readValue(value, new TypeReference<Map<String, Object>>() {
+            });
         } catch (IOException e) {
             return Collections.emptyMap();
         }
 
         final Map<String, Object> results = new HashMap<>(json.size());
         for (Map.Entry<String, Object> mapEntry : json.entrySet()) {
-            for(Entry entry : parseValue(mapEntry.getKey(), mapEntry.getValue())) {
+            for (Entry entry : parseValue(mapEntry.getKey(), mapEntry.getValue())) {
                 results.put(entry.key(), entry.value());
             }
         }
@@ -117,13 +121,15 @@ public class JsonExtractor extends Extractor {
         } else if (value instanceof String) {
             return Collections.singleton(Entry.create(key, value));
         } else if (value instanceof Map) {
+            @SuppressWarnings("unchecked")
+            final Map<String, Object> map = (Map<String, Object>) value;
+            final Map<String, Object> withoutNull = Maps.filterEntries(map, REMOVE_NULL_PREDICATE);
             if (flatten) {
-                return Collections.singleton(Entry.create(key, Joiner.on(listSeparator).withKeyValueSeparator(kvSeparator).join((Map) value)));
+                final Joiner.MapJoiner joiner = Joiner.on(listSeparator).withKeyValueSeparator(kvSeparator);
+                return Collections.singleton(Entry.create(key, joiner.join(withoutNull)));
             } else {
-                @SuppressWarnings("unchecked")
-                final Map<String, Object> map = (Map<String, Object>) value;
-                final List<Entry> result = new ArrayList<>();
-                for(Map.Entry<String, Object> entry : map.entrySet()) {
+                final List<Entry> result = new ArrayList<>(map.size());
+                for (Map.Entry<String, Object> entry : map.entrySet()) {
                     result.addAll(parseValue(key + keySeparator + entry.getKey(), entry.getValue()));
                 }
 
@@ -131,8 +137,9 @@ public class JsonExtractor extends Extractor {
             }
         } else if (value instanceof List) {
             final List values = (List) value;
-            return Collections.singleton(Entry.create(key, Joiner.on(listSeparator).join(values)));
-        } else if(value == null) {
+            final Joiner joiner = Joiner.on(listSeparator).skipNulls();
+            return Collections.singleton(Entry.create(key, joiner.join(values)));
+        } else if (value == null) {
             // Ignore null values so we don't try to create fields for that in the message.
             return Collections.emptySet();
         } else {
@@ -144,11 +151,19 @@ public class JsonExtractor extends Extractor {
     @AutoValue
     protected abstract static class Entry {
         public abstract String key();
+
         @Nullable
         public abstract Object value();
 
         public static Entry create(String key, @Nullable Object value) {
             return new AutoValue_JsonExtractor_Entry(key, value);
+        }
+    }
+
+    protected final static class RemoveNullPredicate implements Predicate<Map.Entry> {
+        @Override
+        public boolean apply(@Nullable Map.Entry input) {
+            return input != null && input.getKey() != null && input.getValue() != null;
         }
     }
 }

--- a/graylog2-server/src/test/java/org/graylog2/inputs/extractors/JsonExtractorTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/inputs/extractors/JsonExtractorTest.java
@@ -71,7 +71,7 @@ public class JsonExtractorTest {
 
     @Test
     public void testRunWithArray() throws Exception {
-        final String value = "{\"array\": [\"foobar\", \"foobaz\"]}";
+        final String value = "{\"array\": [\"foobar\", \"foobaz\", null]}";
         final Extractor.Result[] results = jsonExtractor.run(value);
 
         assertThat(results).contains(new Extractor.Result("foobar, foobaz", "array", -1, -1));
@@ -106,7 +106,15 @@ public class JsonExtractorTest {
         final JsonExtractor jsonExtractor = new JsonExtractor(new MetricRegistry(), "json", "title", 0L, Extractor.CursorStrategy.COPY,
                 "source", "target", ImmutableMap.<String, Object>of("flatten", true), "user", Collections.<Converter>emptyList(), Extractor.ConditionType.NONE,
                 "");
-        final String value = "{\"object\": {\"text\": \"foobar\", \"number\": 1234.5678, \"bool\": true, \"nested\": {\"text\": \"foobar\"}}}";
+        final String value = "{"
+                + "\"object\": {"
+                + "\"text\": \"foobar\", "
+                + "\"number\": 1234.5678, "
+                + "\"bool\": true, "
+                + "\"null\": null, "
+                + "\"nested\": {\"text\": \"foobar\"}"
+                + "}"
+                + "}";
         final Extractor.Result[] results = jsonExtractor.run(value);
 
         assertThat(results).contains(


### PR DESCRIPTION
The JSON extractor currently fails to handle `null` values in nested structures like arrays or objects and throws a NullPointerException instead.

This PR changes the behavior to simply ignore the `null` values in those cases (array item, dictionary key and value).

Fixes #1676