### PR TITLE
Always include index range of deflector target index

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/indexer/IndexHelper.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/IndexHelper.java
@@ -16,6 +16,8 @@
  */
 package org.graylog2.indexer;
 
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.ImmutableSortedSet;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
 import org.elasticsearch.index.query.FilterBuilder;
@@ -23,7 +25,6 @@ import org.elasticsearch.index.query.FilterBuilders;
 import org.graylog2.database.NotFoundException;
 import org.graylog2.indexer.ranges.IndexRange;
 import org.graylog2.indexer.ranges.IndexRangeService;
-import org.graylog2.indexer.searches.timeranges.RelativeRange;
 import org.graylog2.indexer.searches.timeranges.TimeRange;
 import org.graylog2.plugin.Tools;
 import org.slf4j.Logger;
@@ -88,33 +89,26 @@ public class IndexHelper {
     public static Set<String> determineAffectedIndices(IndexRangeService indexRangeService,
                                                        Deflector deflector,
                                                        TimeRange range) {
-        Set<String> indices = Sets.newHashSet();
-
-        for (IndexRange indexRange : indexRangeService.find(range.getFrom(), range.getTo())) {
+        final Set<IndexRange> indexRanges = determineAffectedIndicesWithRanges(indexRangeService, deflector, range);
+        final ImmutableSet.Builder<String> indices = ImmutableSet.builder();
+        for (IndexRange indexRange : indexRanges) {
             indices.add(indexRange.indexName());
         }
 
-        // Always include the most recent index in some cases.
-        final String targetIndex = deflector.getCurrentActualTargetIndex();
-        if (targetIndex != null && (indices.isEmpty() || range instanceof RelativeRange)) {
-            indices.add(targetIndex);
-        }
-
-        return indices;
+        return indices.build();
     }
 
     public static Set<IndexRange> determineAffectedIndicesWithRanges(IndexRangeService indexRangeService,
                                                                      Deflector deflector,
                                                                      TimeRange range) {
-        Set<IndexRange> indices = Sets.newTreeSet(IndexRange.COMPARATOR);
-
+        final ImmutableSortedSet.Builder<IndexRange> indices = ImmutableSortedSet.orderedBy(IndexRange.COMPARATOR);
         for (IndexRange indexRange : indexRangeService.find(range.getFrom(), range.getTo())) {
             indices.add(indexRange);
         }
 
-        // Always include the most recent index in some cases.
+        // Always include the deflector target
         final String targetIndex = deflector.getCurrentActualTargetIndex();
-        if (targetIndex != null && (indices.isEmpty() || range instanceof RelativeRange)) {
+        if (targetIndex != null) {
             try {
                 final IndexRange deflectorIndexRange = indexRangeService.get(targetIndex);
                 indices.add(deflectorIndexRange);
@@ -123,7 +117,6 @@ public class IndexHelper {
             }
         }
 
-        return indices;
+        return indices.build();
     }
-
 }

--- a/graylog2-server/src/test/java/org/graylog2/indexer/IndexHelperTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/indexer/IndexHelperTest.java
@@ -16,59 +16,190 @@
  */
 package org.graylog2.indexer;
 
-import com.google.common.collect.Sets;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.ImmutableSortedSet;
+import org.graylog2.indexer.ranges.IndexRange;
+import org.graylog2.indexer.ranges.IndexRangeService;
+import org.graylog2.indexer.ranges.MongoIndexRange;
+import org.graylog2.indexer.searches.timeranges.AbsoluteRange;
+import org.graylog2.indexer.searches.timeranges.KeywordRange;
+import org.graylog2.indexer.searches.timeranges.RelativeRange;
+import org.graylog2.indexer.searches.timeranges.TimeRange;
+import org.joda.time.DateTime;
+import org.joda.time.DateTimeUtils;
+import org.joda.time.DateTimeZone;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Rule;
 import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnit;
+import org.mockito.junit.MockitoRule;
 
+import java.util.Collections;
 import java.util.Set;
+import java.util.SortedSet;
 
-import static org.junit.Assert.assertEquals;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.when;
 
-/**
- * @author lennart.koopmann
- */
 public class IndexHelperTest {
+    @Rule
+    public MockitoRule mockitoRule = MockitoJUnit.rule();
+
+    @Mock
+    private IndexRangeService indexRangeService;
+    @Mock
+    private Deflector deflector;
+
+    @BeforeClass
+    public static void initialize() {
+        DateTimeUtils.setCurrentMillisFixed(new DateTime(2016, 1, 1, 0, 0, DateTimeZone.UTC).getMillis());
+    }
+
+    @AfterClass
+    public static void shutdown() {
+        DateTimeUtils.setCurrentMillisSystem();
+    }
 
     @Test
     public void testGetOldestIndices() {
-        Set<String> indices = Sets.newHashSet();
-        indices.add("graylog2_production_1");
-        indices.add("graylog2_production_7");
-        indices.add("graylog2_production_0");
-        indices.add("graylog2_production_2");
-        indices.add("graylog2_production_4");
-        indices.add("graylog2_production_6");
-        indices.add("graylog2_production_3");
-        indices.add("graylog2_production_5");
-        indices.add("graylog2_production_8");
-        indices.add("graylog2_production_9");
-        indices.add("graylog2_production_10");
-        indices.add("graylog2_production_110");
-        indices.add("graylog2_production_125");
-        indices.add("graylog2_production_20");
-        indices.add("graylog2_production_21");
+        final Set<String> indices = ImmutableSet.<String>builder()
+                .add("graylog2_production_1")
+                .add("graylog2_production_7")
+                .add("graylog2_production_0")
+                .add("graylog2_production_2")
+                .add("graylog2_production_4")
+                .add("graylog2_production_6")
+                .add("graylog2_production_3")
+                .add("graylog2_production_5")
+                .add("graylog2_production_8")
+                .add("graylog2_production_9")
+                .add("graylog2_production_10")
+                .add("graylog2_production_110")
+                .add("graylog2_production_125")
+                .add("graylog2_production_20")
+                .add("graylog2_production_21")
+                .build();
 
-        Set<String> expected1 = Sets.newHashSet();
-        expected1.add("graylog2_production_0");
-        expected1.add("graylog2_production_1");
-        expected1.add("graylog2_production_2");
-        expected1.add("graylog2_production_3");
-        expected1.add("graylog2_production_4");
-        expected1.add("graylog2_production_5");
-        expected1.add("graylog2_production_6");
-        
-        Set<String> expected2 = Sets.newHashSet();
-        expected2.add("graylog2_production_0");
-
-        assertEquals(expected1, IndexHelper.getOldestIndices(indices, 7));
-        assertEquals(expected2, IndexHelper.getOldestIndices(indices, 1));
+        assertThat(IndexHelper.getOldestIndices(indices, 7)).containsOnly(
+                "graylog2_production_0",
+                "graylog2_production_1",
+                "graylog2_production_2",
+                "graylog2_production_3",
+                "graylog2_production_4",
+                "graylog2_production_5",
+                "graylog2_production_6");
+        assertThat(IndexHelper.getOldestIndices(indices, 1)).containsOnly("graylog2_production_0");
     }
-    
+
     @Test
     public void testGetOldestIndicesWithEmptySetAndTooHighOffset() {
-        Set<String> empty = Sets.newHashSet();
-        Set<String> expected = Sets.newHashSet();
-
-        assertEquals(expected, IndexHelper.getOldestIndices(empty, 9001));
+        assertThat(IndexHelper.getOldestIndices(Collections.<String>emptySet(), 9001)).isEmpty();
     }
-    
+
+    @Test
+    public void determineAffectedIndicesWithRangesIncludesDeflectorTarget() throws Exception {
+        final DateTime now = DateTime.now();
+        final MongoIndexRange indexRange0 = MongoIndexRange.create("graylog_0", now, now.plusDays(1), now, 0);
+        final MongoIndexRange indexRange1 = MongoIndexRange.create("graylog_1", now.plusDays(1), now.plusDays(2), now, 0);
+        final MongoIndexRange indexRangeLatest = MongoIndexRange.create("graylog_2", new DateTime(0L), new DateTime(0L), now, 0);
+        final SortedSet<IndexRange> indices = ImmutableSortedSet.orderedBy(IndexRange.COMPARATOR)
+                .add(indexRange0)
+                .add(indexRange1)
+                .build();
+
+        when(indexRangeService.find(any(DateTime.class), any(DateTime.class))).thenReturn(indices);
+        when(indexRangeService.get("graylog_2")).thenReturn(indexRangeLatest);
+        when(deflector.getCurrentActualTargetIndex()).thenReturn("graylog_2");
+
+        final TimeRange absoluteRange = new AbsoluteRange(now.minusDays(1), now.plusDays(1));
+        final TimeRange keywordRange = new KeywordRange("1 day ago");
+        final TimeRange relativeRange = new RelativeRange(3600);
+
+        assertThat(IndexHelper.determineAffectedIndicesWithRanges(indexRangeService, deflector, absoluteRange))
+                .containsExactly(indexRangeLatest, indexRange0, indexRange1);
+        assertThat(IndexHelper.determineAffectedIndicesWithRanges(indexRangeService, deflector, keywordRange))
+                .containsExactly(indexRangeLatest, indexRange0, indexRange1);
+        assertThat(IndexHelper.determineAffectedIndicesWithRanges(indexRangeService, deflector, relativeRange))
+                .containsExactly(indexRangeLatest, indexRange0, indexRange1);
+    }
+
+    @Test
+    public void determineAffectedIndicesWithRangesDoesNotIncludesDeflectorTargetIfMissing() throws Exception {
+        final DateTime now = DateTime.now();
+        final MongoIndexRange indexRange0 = MongoIndexRange.create("graylog_0", now, now.plusDays(1), now, 0);
+        final MongoIndexRange indexRange1 = MongoIndexRange.create("graylog_1", now.plusDays(1), now.plusDays(2), now, 0);
+        final SortedSet<IndexRange> indices = ImmutableSortedSet.orderedBy(IndexRange.COMPARATOR)
+                .add(indexRange0)
+                .add(indexRange1)
+                .build();
+
+        when(indexRangeService.find(any(DateTime.class), any(DateTime.class))).thenReturn(indices);
+        when(deflector.getCurrentActualTargetIndex()).thenReturn(null);
+
+        final TimeRange absoluteRange = new AbsoluteRange(now.minusDays(1), now.plusDays(1));
+        final TimeRange keywordRange = new KeywordRange("1 day ago");
+        final TimeRange relativeRange = new RelativeRange(3600);
+
+        assertThat(IndexHelper.determineAffectedIndicesWithRanges(indexRangeService, deflector, absoluteRange))
+                .containsExactly(indexRange0, indexRange1);
+        assertThat(IndexHelper.determineAffectedIndicesWithRanges(indexRangeService, deflector, keywordRange))
+                .containsExactly(indexRange0, indexRange1);
+        assertThat(IndexHelper.determineAffectedIndicesWithRanges(indexRangeService, deflector, relativeRange))
+                .containsExactly(indexRange0, indexRange1);
+    }
+
+    @Test
+    public void determineAffectedIndicesIncludesDeflectorTarget() throws Exception {
+        final DateTime now = DateTime.now();
+        final MongoIndexRange indexRange0 = MongoIndexRange.create("graylog_0", now, now.plusDays(1), now, 0);
+        final MongoIndexRange indexRange1 = MongoIndexRange.create("graylog_1", now.plusDays(1), now.plusDays(2), now, 0);
+        final MongoIndexRange indexRangeLatest = MongoIndexRange.create("graylog_2", new DateTime(0L), new DateTime(0L), now, 0);
+        final SortedSet<IndexRange> indices = ImmutableSortedSet.orderedBy(IndexRange.COMPARATOR)
+                .add(indexRange0)
+                .add(indexRange1)
+                .build();
+
+        when(indexRangeService.find(any(DateTime.class), any(DateTime.class))).thenReturn(indices);
+        when(indexRangeService.get("graylog_2")).thenReturn(indexRangeLatest);
+        when(deflector.getCurrentActualTargetIndex()).thenReturn("graylog_2");
+
+        final TimeRange absoluteRange = new AbsoluteRange(now.minusDays(1), now.plusDays(1));
+        final TimeRange keywordRange = new KeywordRange("1 day ago");
+        final TimeRange relativeRange = new RelativeRange(3600);
+
+        assertThat(IndexHelper.determineAffectedIndices(indexRangeService, deflector, absoluteRange))
+                .containsExactly(indexRangeLatest.indexName(), indexRange0.indexName(), indexRange1.indexName());
+        assertThat(IndexHelper.determineAffectedIndices(indexRangeService, deflector, keywordRange))
+                .containsExactly(indexRangeLatest.indexName(), indexRange0.indexName(), indexRange1.indexName());
+        assertThat(IndexHelper.determineAffectedIndices(indexRangeService, deflector, relativeRange))
+                .containsExactly(indexRangeLatest.indexName(), indexRange0.indexName(), indexRange1.indexName());
+    }
+
+    @Test
+    public void determineAffectedIndicesDoesNotIncludesDeflectorTargetIfMissing() throws Exception {
+        final DateTime now = DateTime.now();
+        final MongoIndexRange indexRange0 = MongoIndexRange.create("graylog_0", now, now.plusDays(1), now, 0);
+        final MongoIndexRange indexRange1 = MongoIndexRange.create("graylog_1", now.plusDays(1), now.plusDays(2), now, 0);
+        final SortedSet<IndexRange> indices = ImmutableSortedSet.orderedBy(IndexRange.COMPARATOR)
+                .add(indexRange0)
+                .add(indexRange1)
+                .build();
+
+        when(indexRangeService.find(any(DateTime.class), any(DateTime.class))).thenReturn(indices);
+        when(deflector.getCurrentActualTargetIndex()).thenReturn(null);
+
+        final TimeRange absoluteRange = new AbsoluteRange(now.minusDays(1), now.plusDays(1));
+        final TimeRange keywordRange = new KeywordRange("1 day ago");
+        final TimeRange relativeRange = new RelativeRange(3600);
+
+        assertThat(IndexHelper.determineAffectedIndices(indexRangeService, deflector, absoluteRange))
+                .containsOnly(indexRange0.indexName(), indexRange1.indexName());
+        assertThat(IndexHelper.determineAffectedIndices(indexRangeService, deflector, keywordRange))
+                .containsOnly(indexRange0.indexName(), indexRange1.indexName());
+        assertThat(IndexHelper.determineAffectedIndices(indexRangeService, deflector, relativeRange))
+                .containsOnly(indexRange0.indexName(), indexRange1.indexName());
+    }
 }


### PR DESCRIPTION
The index range of the deflector target index can't be calculated until the index has been rotated, so a dummy range is being used. For this reason, the latest index *always* has to be included in searches and not only in the case of searches with relative time range.

Fixes #1672