### PR TITLE
Revert removal of DashboardRegistry in Graylog 1.3.x

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/bindings/InitializerBindings.java
+++ b/graylog2-server/src/main/java/org/graylog2/bindings/InitializerBindings.java
@@ -20,6 +20,7 @@ import com.google.common.util.concurrent.Service;
 import com.google.inject.AbstractModule;
 import com.google.inject.multibindings.Multibinder;
 import org.graylog2.initializers.BufferSynchronizerService;
+import org.graylog2.initializers.DashboardRegistryService;
 import org.graylog2.initializers.IndexerSetupService;
 import org.graylog2.initializers.MetricsReporterService;
 import org.graylog2.initializers.OutputSetupService;
@@ -29,6 +30,7 @@ public class InitializerBindings extends AbstractModule {
     protected void configure() {
         Multibinder<Service> serviceBinder = Multibinder.newSetBinder(binder(), Service.class);
         serviceBinder.addBinding().to(MetricsReporterService.class);
+        serviceBinder.addBinding().to(DashboardRegistryService.class);
         serviceBinder.addBinding().to(IndexerSetupService.class);
         serviceBinder.addBinding().to(BufferSynchronizerService.class);
         serviceBinder.addBinding().to(OutputSetupService.class);

--- a/graylog2-server/src/main/java/org/graylog2/bindings/providers/BundleImporterProvider.java
+++ b/graylog2-server/src/main/java/org/graylog2/bindings/providers/BundleImporterProvider.java
@@ -17,6 +17,7 @@
 package org.graylog2.bindings.providers;
 
 import org.graylog2.bundles.BundleImporter;
+import org.graylog2.dashboards.DashboardRegistry;
 import org.graylog2.dashboards.DashboardService;
 import org.graylog2.dashboards.widgets.DashboardWidgetCreator;
 import org.graylog2.grok.GrokPatternService;
@@ -43,6 +44,7 @@ public class BundleImporterProvider implements Provider<BundleImporter> {
     private final StreamRuleService streamRuleService;
     private final OutputService outputService;
     private final DashboardService dashboardService;
+    private final DashboardRegistry dashboardRegistry;
     private final DashboardWidgetCreator dashboardWidgetCreator;
     private final ServerStatus serverStatus;
     private final Searches searches;
@@ -58,6 +60,7 @@ public class BundleImporterProvider implements Provider<BundleImporter> {
                                   final StreamRuleService streamRuleService,
                                   final OutputService outputService,
                                   final DashboardService dashboardService,
+                                  final DashboardRegistry dashboardRegistry,
                                   final DashboardWidgetCreator dashboardWidgetCreator,
                                   final ServerStatus serverStatus,
                                   final Searches searches,
@@ -71,6 +74,7 @@ public class BundleImporterProvider implements Provider<BundleImporter> {
         this.streamRuleService = streamRuleService;
         this.outputService = outputService;
         this.dashboardService = dashboardService;
+        this.dashboardRegistry = dashboardRegistry;
         this.dashboardWidgetCreator = dashboardWidgetCreator;
         this.serverStatus = serverStatus;
         this.searches = searches;
@@ -83,7 +87,7 @@ public class BundleImporterProvider implements Provider<BundleImporter> {
     public BundleImporter get() {
         return new BundleImporter(inputService, inputRegistry, extractorFactory,
                 streamService, streamRuleService, outputService, dashboardService,
-                dashboardWidgetCreator, serverStatus, searches,
+                dashboardRegistry, dashboardWidgetCreator, serverStatus, searches,
                 messageInputFactory, inputLauncher, grokPatternService);
     }
 }

--- a/graylog2-server/src/main/java/org/graylog2/bundles/BundleImporter.java
+++ b/graylog2-server/src/main/java/org/graylog2/bundles/BundleImporter.java
@@ -21,6 +21,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import org.bson.types.ObjectId;
 import org.graylog2.dashboards.DashboardImpl;
+import org.graylog2.dashboards.DashboardRegistry;
 import org.graylog2.dashboards.DashboardService;
 import org.graylog2.dashboards.widgets.DashboardWidgetCreator;
 import org.graylog2.dashboards.widgets.InvalidWidgetConfigurationException;
@@ -77,6 +78,7 @@ public class BundleImporter {
     private final StreamRuleService streamRuleService;
     private final OutputService outputService;
     private final DashboardService dashboardService;
+    private final DashboardRegistry dashboardRegistry;
     private final DashboardWidgetCreator dashboardWidgetCreator;
     private final ServerStatus serverStatus;
     private final Searches searches;
@@ -100,6 +102,7 @@ public class BundleImporter {
                           final StreamRuleService streamRuleService,
                           final OutputService outputService,
                           final DashboardService dashboardService,
+                          final DashboardRegistry dashboardRegistry,
                           final DashboardWidgetCreator dashboardWidgetCreator,
                           final ServerStatus serverStatus,
                           final Searches searches,
@@ -113,6 +116,7 @@ public class BundleImporter {
         this.streamRuleService = streamRuleService;
         this.outputService = outputService;
         this.dashboardService = dashboardService;
+        this.dashboardRegistry = dashboardRegistry;
         this.dashboardWidgetCreator = dashboardWidgetCreator;
         this.serverStatus = serverStatus;
         this.searches = searches;
@@ -221,6 +225,8 @@ public class BundleImporter {
     private void deleteCreatedDashboards() {
         for (Map.Entry<String, org.graylog2.dashboards.Dashboard> entry : createdDashboards.entrySet()) {
             final String dashboardId = entry.getKey();
+            LOG.debug("Removing dashboard {} from registry", dashboardId);
+            dashboardRegistry.remove(dashboardId);
 
             LOG.debug("Deleting dashboard {} from database", dashboardId);
             dashboardService.destroy(entry.getValue());
@@ -520,6 +526,8 @@ public class BundleImporter {
         } catch (NotFoundException e) {
             LOG.error("Failed to load dashboard with id " + dashboardId, e);
         }
+
+        dashboardRegistry.add(dashboard);
 
         return dashboard;
     }

--- a/graylog2-server/src/main/java/org/graylog2/dashboards/DashboardRegistry.java
+++ b/graylog2-server/src/main/java/org/graylog2/dashboards/DashboardRegistry.java
@@ -1,0 +1,61 @@
+/**
+ * This file is part of Graylog.
+ *
+ * Graylog is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.graylog2.dashboards;
+
+import com.google.common.collect.Maps;
+import javax.inject.Inject;
+
+import javax.inject.Singleton;
+import java.util.Map;
+
+/**
+ * @author Lennart Koopmann <lennart@torch.sh>
+ */
+@Singleton
+public class DashboardRegistry {
+
+    private final DashboardService dashboardService;
+    private final Map<String, Dashboard> dashboards = Maps.newHashMap();
+
+    @Inject
+    public DashboardRegistry(DashboardService dashboardService) {
+        this.dashboardService = dashboardService;
+    }
+
+    public void loadPersisted() {
+        for (Dashboard dashboard : dashboardService.all()) {
+            dashboards.put(dashboard.getId(), dashboard);
+        }
+    }
+
+    public void add(Dashboard dashboard) {
+        dashboards.put(dashboard.getId(), dashboard);
+    }
+
+    public Dashboard get(String dashboardId) {
+        return dashboards.get(dashboardId);
+    }
+
+    public Map<String, Dashboard> getAll() {
+        return Maps.newHashMap(dashboards);
+    }
+
+    public void remove(String dashboardId) {
+        dashboards.remove(dashboardId);
+    }
+
+}

--- a/graylog2-server/src/main/java/org/graylog2/dashboards/DashboardServiceImpl.java
+++ b/graylog2-server/src/main/java/org/graylog2/dashboards/DashboardServiceImpl.java
@@ -16,7 +16,7 @@
  */
 package org.graylog2.dashboards;
 
-import com.google.common.base.Function;
+import com.codahale.metrics.MetricRegistry;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.mongodb.BasicDBObject;
@@ -36,21 +36,23 @@ import org.joda.time.DateTime;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import javax.annotation.Nullable;
 import javax.inject.Inject;
 import java.util.List;
 import java.util.Map;
 
 public class DashboardServiceImpl extends PersistedServiceImpl implements DashboardService {
     private static final Logger LOG = LoggerFactory.getLogger(DashboardServiceImpl.class);
+    private final MetricRegistry metricRegistry;
     private final Searches searches;
     private final DashboardWidgetCreator dashboardWidgetCreator;
 
     @Inject
     public DashboardServiceImpl(MongoConnection mongoConnection,
+                                MetricRegistry metricRegistry,
                                 Searches searches,
                                 DashboardWidgetCreator dashboardWidgetCreator) {
         super(mongoConnection);
+        this.metricRegistry = metricRegistry;
         this.searches = searches;
         this.dashboardWidgetCreator = dashboardWidgetCreator;
     }
@@ -66,57 +68,51 @@ public class DashboardServiceImpl extends PersistedServiceImpl implements Dashbo
         return new DashboardImpl(dashboardData);
     }
 
-    private Dashboard create(ObjectId id, Map<String, Object> fields) {
-        final Dashboard dashboard = new DashboardImpl(id, fields);
-        // Add all widgets of this dashboard.
-        if (fields.containsKey(DashboardImpl.EMBEDDED_WIDGETS)) {
-            if (fields.get(DashboardImpl.EMBEDDED_WIDGETS) instanceof List) {
-                //noinspection unchecked
-                for (BasicDBObject widgetFields : (List<BasicDBObject>) fields.get(DashboardImpl.EMBEDDED_WIDGETS)) {
-                    try {
-                        final DashboardWidget widget = dashboardWidgetCreator.fromPersisted(searches, widgetFields);
-                        dashboard.addPersistedWidget(widget);
-                    } catch (DashboardWidget.NoSuchWidgetTypeException e) {
-                        LOG.error("No such widget type: [" + widgetFields.get("type") + "] - Dashboard: [" + dashboard.getId() + "]", e);
-                    } catch (InvalidRangeParametersException e) {
-                        LOG.error("Invalid range parameters of widget in dashboard: [" + dashboard.getId() + "]", e);
-                    } catch (InvalidWidgetConfigurationException e) {
-                        LOG.error("Invalid configuration of widget in dashboard: [" + dashboard.getId() + "]", e);
-                    }
-                }
-            }
-        }
-
-        return dashboard;
-    }
-
     @Override
     public Dashboard load(String id) throws NotFoundException {
-        final BasicDBObject o = (BasicDBObject) get(DashboardImpl.class, id);
+        BasicDBObject o = (BasicDBObject) get(DashboardImpl.class, id);
 
         if (o == null) {
             throw new NotFoundException();
         }
 
-        //noinspection unchecked
-        return this.create((ObjectId) o.get("_id"), o.toMap());
+        return new DashboardImpl((ObjectId) o.get("_id"), o.toMap());
     }
 
     @Override
     public List<Dashboard> all() {
-        final List<DBObject> results = query(DashboardImpl.class, new BasicDBObject());
+        List<Dashboard> dashboards = Lists.newArrayList();
 
-        return Lists.transform(results, new Function<DBObject, Dashboard>() {
-            @Nullable
-            @Override
-            public Dashboard apply(@Nullable DBObject input) {
-                if (input == null) {
-                    throw new NullPointerException("Database object is null, this should never happen.");
+        List<DBObject> results = query(DashboardImpl.class, new BasicDBObject());
+        for (DBObject o : results) {
+            Map<String, Object> fields = o.toMap();
+            Dashboard dashboard = new DashboardImpl((ObjectId) o.get("_id"), fields);
+
+            // Add all widgets of this dashboard.
+            if (fields.containsKey(DashboardImpl.EMBEDDED_WIDGETS)) {
+                for (BasicDBObject widgetFields : (List<BasicDBObject>) fields.get(DashboardImpl.EMBEDDED_WIDGETS)) {
+                    DashboardWidget widget = null;
+                    try {
+                        widget = dashboardWidgetCreator.fromPersisted(searches, widgetFields);
+                    } catch (DashboardWidget.NoSuchWidgetTypeException e) {
+                        LOG.error("No such widget type: [" + widgetFields.get("type") + "] - Dashboard: [" + dashboard.getId() + "]", e);
+                        continue;
+                    } catch (InvalidRangeParametersException e) {
+                        LOG.error("Invalid range parameters of widget in dashboard: [" + dashboard.getId() + "]", e);
+                        continue;
+                    } catch (InvalidWidgetConfigurationException e) {
+                        LOG.error("Invalid configuration of widget in dashboard: [" + dashboard.getId() + "]", e);
+                        continue;
+                    }
+                    dashboard.addPersistedWidget(widget);
                 }
-                //noinspection unchecked
-                return new DashboardImpl((ObjectId) input.get("_id"), input.toMap());
             }
-        });
+
+
+            dashboards.add(dashboard);
+        }
+
+        return dashboards;
     }
 
     @Override

--- a/graylog2-server/src/main/java/org/graylog2/initializers/DashboardRegistryService.java
+++ b/graylog2-server/src/main/java/org/graylog2/initializers/DashboardRegistryService.java
@@ -1,0 +1,52 @@
+/**
+ * This file is part of Graylog.
+ *
+ * Graylog is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.graylog2.initializers;
+
+import com.google.common.util.concurrent.AbstractIdleService;
+import javax.inject.Inject;
+import org.graylog2.dashboards.DashboardRegistry;
+import org.graylog2.plugin.ServerStatus;
+
+import javax.inject.Singleton;
+
+/**
+ * @author Dennis Oelkers <dennis@torch.sh>
+ */
+@Singleton
+public class DashboardRegistryService extends AbstractIdleService {
+    private final DashboardRegistry dashboardRegistry;
+    private final ServerStatus serverStatus;
+
+    @Inject
+    public DashboardRegistryService(DashboardRegistry dashboardRegistry,
+                                    ServerStatus serverStatus) {
+        this.dashboardRegistry = dashboardRegistry;
+        this.serverStatus = serverStatus;
+    }
+
+    @Override
+    protected void startUp() throws Exception {
+        if (serverStatus.hasCapability(ServerStatus.Capability.MASTER)) {
+            dashboardRegistry.loadPersisted();
+        }
+
+    }
+
+    @Override
+    protected void shutDown() throws Exception {
+    }
+}

--- a/graylog2-server/src/main/java/org/graylog2/rest/resources/dashboards/DashboardsResource.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/resources/dashboards/DashboardsResource.java
@@ -28,6 +28,7 @@ import com.wordnik.swagger.annotations.ApiResponses;
 import org.apache.shiro.authz.annotation.RequiresAuthentication;
 import org.apache.shiro.authz.annotation.RequiresPermissions;
 import org.graylog2.dashboards.Dashboard;
+import org.graylog2.dashboards.DashboardRegistry;
 import org.graylog2.dashboards.DashboardService;
 import org.graylog2.dashboards.widgets.DashboardWidget;
 import org.graylog2.dashboards.widgets.DashboardWidgetCreator;
@@ -78,18 +79,24 @@ public class DashboardsResource extends RestResource {
     private static final Logger LOG = LoggerFactory.getLogger(DashboardsResource.class);
 
     private DashboardService dashboardService;
+    private DashboardRegistry dashboardRegistry;
     private final DashboardWidgetCreator dashboardWidgetCreator;
     private ActivityWriter activityWriter;
+    private MetricRegistry metricRegistry;
     private final Searches searches;
 
     @Inject
     public DashboardsResource(DashboardService dashboardService,
+                              DashboardRegistry dashboardRegistry,
                               DashboardWidgetCreator dashboardWidgetCreator,
                               ActivityWriter activityWriter,
+                              MetricRegistry metricRegistry,
                               Searches searches) {
         this.dashboardService = dashboardService;
+        this.dashboardRegistry = dashboardRegistry;
         this.dashboardWidgetCreator = dashboardWidgetCreator;
         this.activityWriter = activityWriter;
+        this.metricRegistry = metricRegistry;
         this.searches = searches;
     }
 
@@ -99,10 +106,16 @@ public class DashboardsResource extends RestResource {
     @RequiresPermissions(RestPermissions.DASHBOARDS_CREATE)
     @Consumes(MediaType.APPLICATION_JSON)
     @Produces(MediaType.APPLICATION_JSON)
+    @ApiResponses(value = {
+            @ApiResponse(code = 403, message = "Request must be performed against master node.")
+    })
+    @RestrictToMaster
     public Response create(@ApiParam(name = "JSON body", required = true) CreateDashboardRequest cr) throws ValidationException {
         // Create dashboard.
         final Dashboard dashboard = dashboardService.create(cr.title(), cr.description(), getCurrentUser().getName(), Tools.iso8601());
         final String id = dashboardService.save(dashboard);
+
+        dashboardRegistry.add(dashboard);
 
         final Map<String, String> result = ImmutableMap.of("dashboard_id", id);
         final URI dashboardUri = getUriBuilderToSelf().path(DashboardsResource.class)
@@ -116,6 +129,10 @@ public class DashboardsResource extends RestResource {
     @Timed
     @ApiOperation(value = "Get a list of all dashboards and all configurations of their widgets.")
     @Produces(MediaType.APPLICATION_JSON)
+    @ApiResponses(value = {
+            @ApiResponse(code = 403, message = "Request must be performed against master node.")
+    })
+    @RestrictToMaster
     public DashboardList list() {
         final List<Map<String, Object>> dashboards = Lists.newArrayList();
         for (Dashboard dashboard : dashboardService.all()) {
@@ -133,8 +150,10 @@ public class DashboardsResource extends RestResource {
     @Path("/{dashboardId}")
     @ApiResponses(value = {
             @ApiResponse(code = 404, message = "Dashboard not found."),
+            @ApiResponse(code = 403, message = "Request must be performed against master node.")
     })
     @Produces(MediaType.APPLICATION_JSON)
+    @RestrictToMaster
     public Map<String, Object> get(@ApiParam(name = "dashboardId", required = true)
                                    @PathParam("dashboardId") String dashboardId) throws NotFoundException {
         checkPermission(RestPermissions.DASHBOARDS_READ, dashboardId);
@@ -149,12 +168,15 @@ public class DashboardsResource extends RestResource {
     @Path("/{dashboardId}")
     @ApiResponses(value = {
             @ApiResponse(code = 404, message = "Dashboard not found."),
+            @ApiResponse(code = 403, message = "Request must be performed against master node.")
     })
+    @RestrictToMaster
     public void delete(@ApiParam(name = "dashboardId", required = true)
                        @PathParam("dashboardId") String dashboardId) throws NotFoundException {
         checkPermission(RestPermissions.DASHBOARDS_EDIT, dashboardId);
 
         final Dashboard dashboard = dashboardService.load(dashboardId);
+        dashboardRegistry.remove(dashboardId);
         dashboardService.destroy(dashboard);
 
         final String msg = "Deleted dashboard <" + dashboard.getId() + ">. Reason: REST request.";
@@ -216,12 +238,14 @@ public class DashboardsResource extends RestResource {
             @ApiResponse(code = 404, message = "Dashboard not found."),
             @ApiResponse(code = 400, message = "Validation error."),
             @ApiResponse(code = 400, message = "No such widget type."),
+            @ApiResponse(code = 403, message = "Request must be performed against master node.")
     })
     @Path("/{dashboardId}/widgets")
+    @RestrictToMaster
     public Response addWidget(
             @ApiParam(name = "dashboardId", required = true)
             @PathParam("dashboardId") String dashboardId,
-            @ApiParam(name = "JSON body", required = true) AddWidgetRequest awr) throws ValidationException, NotFoundException {
+            @ApiParam(name = "JSON body", required = true) AddWidgetRequest awr) throws ValidationException {
         checkPermission(RestPermissions.DASHBOARDS_EDIT, dashboardId);
 
         // Bind to streams for reader users and check stream permission.
@@ -237,7 +261,12 @@ public class DashboardsResource extends RestResource {
         try {
             widget = dashboardWidgetCreator.fromRequest(searches, awr, getCurrentUser().getName());
 
-            final Dashboard dashboard = dashboardService.load(dashboardId);
+            final Dashboard dashboard = dashboardRegistry.get(dashboardId);
+
+            if (dashboard == null) {
+                LOG.error("Dashboard [{}] not found.", dashboardId);
+                throw new WebApplicationException("Dashboard [" + dashboardId + "] not found.", 404);
+            }
 
             dashboardService.addWidget(dashboard, widget);
         } catch (DashboardWidget.NoSuchWidgetTypeException e2) {
@@ -266,16 +295,22 @@ public class DashboardsResource extends RestResource {
     @ApiResponses(value = {
             @ApiResponse(code = 404, message = "Dashboard not found."),
             @ApiResponse(code = 404, message = "Widget not found."),
+            @ApiResponse(code = 403, message = "Request must be performed against master node.")
     })
     @Produces(MediaType.APPLICATION_JSON)
+    @RestrictToMaster
     public void remove(
             @ApiParam(name = "dashboardId", required = true)
             @PathParam("dashboardId") String dashboardId,
             @ApiParam(name = "widgetId", required = true)
-            @PathParam("widgetId") String widgetId) throws NotFoundException {
+            @PathParam("widgetId") String widgetId) {
         checkPermission(RestPermissions.DASHBOARDS_EDIT, dashboardId);
 
-        final Dashboard dashboard = dashboardService.load(dashboardId);
+        final Dashboard dashboard = dashboardRegistry.get(dashboardId);
+        if (dashboard == null) {
+            LOG.error("Dashboard not found.");
+            throw new javax.ws.rs.NotFoundException();
+        }
 
         final DashboardWidget widget = dashboard.getWidget(widgetId);
         dashboardService.removeWidget(dashboard, widget);
@@ -292,16 +327,23 @@ public class DashboardsResource extends RestResource {
     @ApiResponses(value = {
             @ApiResponse(code = 404, message = "Dashboard not found."),
             @ApiResponse(code = 404, message = "Widget not found."),
+            @ApiResponse(code = 403, message = "Request must be performed against master node."),
             @ApiResponse(code = 504, message = "Computation failed on indexer side.")
     })
     @Produces(MediaType.APPLICATION_JSON)
+    @RestrictToMaster
     public Map<String, Object> widgetValue(@ApiParam(name = "dashboardId", required = true)
                                            @PathParam("dashboardId") String dashboardId,
                                            @ApiParam(name = "widgetId", required = true)
-                                           @PathParam("widgetId") String widgetId) throws NotFoundException {
+                                           @PathParam("widgetId") String widgetId) {
         checkPermission(RestPermissions.DASHBOARDS_READ, dashboardId);
 
-        final Dashboard dashboard = dashboardService.load(dashboardId);
+        Dashboard dashboard = dashboardRegistry.get(dashboardId);
+
+        if (dashboard == null) {
+            LOG.error("Dashboard not found.");
+            throw new javax.ws.rs.NotFoundException();
+        }
 
         final DashboardWidget widget = dashboard.getWidget(widgetId);
         if (widget == null) {
@@ -324,17 +366,23 @@ public class DashboardsResource extends RestResource {
     @ApiResponses(value = {
             @ApiResponse(code = 404, message = "Dashboard not found."),
             @ApiResponse(code = 404, message = "Widget not found."),
+            @ApiResponse(code = 403, message = "Request must be performed against master node.")
     })
     @Produces(MediaType.APPLICATION_JSON)
+    @RestrictToMaster
     public void updateWidget(@ApiParam(name = "dashboardId", required = true)
                              @PathParam("dashboardId") String dashboardId,
                              @ApiParam(name = "widgetId", required = true)
                              @PathParam("widgetId") String widgetId,
                              @ApiParam(name = "JSON body", required = true)
-                             @Valid @NotNull AddWidgetRequest awr) throws ValidationException, NotFoundException {
+                             @Valid @NotNull AddWidgetRequest awr) throws ValidationException {
         checkPermission(RestPermissions.DASHBOARDS_EDIT, dashboardId);
 
-        final Dashboard dashboard = dashboardService.load(dashboardId);
+        final Dashboard dashboard = dashboardRegistry.get(dashboardId);
+        if (dashboard == null) {
+            LOG.error("Dashboard not found.");
+            throw new javax.ws.rs.NotFoundException();
+        }
 
         final DashboardWidget widget = dashboard.getWidget(widgetId);
         if (widget == null) {
@@ -371,17 +419,23 @@ public class DashboardsResource extends RestResource {
     @ApiResponses(value = {
             @ApiResponse(code = 404, message = "Dashboard not found."),
             @ApiResponse(code = 404, message = "Widget not found."),
+            @ApiResponse(code = 403, message = "Request must be performed against master node.")
     })
     @Produces(MediaType.APPLICATION_JSON)
+    @RestrictToMaster
     public void updateDescription(@ApiParam(name = "dashboardId", required = true)
                                   @PathParam("dashboardId") String dashboardId,
                                   @ApiParam(name = "widgetId", required = true)
                                   @PathParam("widgetId") String widgetId,
                                   @ApiParam(name = "JSON body", required = true)
-                                  @Valid UpdateWidgetRequest uwr) throws ValidationException, NotFoundException {
+                                  @Valid UpdateWidgetRequest uwr) throws ValidationException {
         checkPermission(RestPermissions.DASHBOARDS_EDIT, dashboardId);
 
-        final Dashboard dashboard = dashboardService.load(dashboardId);
+        final Dashboard dashboard = dashboardRegistry.get(dashboardId);
+        if (dashboard == null) {
+            LOG.error("Dashboard not found.");
+            throw new javax.ws.rs.NotFoundException();
+        }
 
         final DashboardWidget widget = dashboard.getWidget(widgetId);
         if (widget == null) {
@@ -402,17 +456,23 @@ public class DashboardsResource extends RestResource {
     @ApiResponses(value = {
             @ApiResponse(code = 404, message = "Dashboard not found."),
             @ApiResponse(code = 404, message = "Widget not found."),
+            @ApiResponse(code = 403, message = "Request must be performed against master node.")
     })
     @Produces(MediaType.APPLICATION_JSON)
+    @RestrictToMaster
     public void updateCacheTime(@ApiParam(name = "dashboardId", required = true)
                                 @PathParam("dashboardId") String dashboardId,
                                 @ApiParam(name = "widgetId", required = true)
                                 @PathParam("widgetId") String widgetId,
                                 @ApiParam(name = "JSON body", required = true)
-                                @Valid UpdateWidgetRequest uwr) throws ValidationException, NotFoundException {
+                                @Valid UpdateWidgetRequest uwr) throws ValidationException {
         checkPermission(RestPermissions.DASHBOARDS_EDIT, dashboardId);
 
-        final Dashboard dashboard = dashboardService.load(dashboardId);
+        final Dashboard dashboard = dashboardRegistry.get(dashboardId);
+        if (dashboard == null) {
+            LOG.error("Dashboard not found.");
+            throw new javax.ws.rs.NotFoundException();
+        }
 
         final DashboardWidget widget = dashboard.getWidget(widgetId);
         if (widget == null) {

--- a/graylog2-server/src/test/java/org/graylog2/dashboards/DashboardServiceImplTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/dashboards/DashboardServiceImplTest.java
@@ -60,8 +60,7 @@ public class DashboardServiceImplTest {
 
     @Before
     public void setUpService() throws Exception {
-        this.dashboardService = new DashboardServiceImpl(mongoRule.getMongoConnection(),
-                                                         searches, dashboardWidgetCreator);
+        this.dashboardService = new DashboardServiceImpl(mongoRule.getMongoConnection(), metricRegistry, searches, dashboardWidgetCreator);
     }
 
     @Test


### PR DESCRIPTION
This reverts commit 8336a8d973b177b574948b704d4756f284f49166 and f997da6f335a8927eae54701ab5d8239b1869150. The removal of `DashboardRegistry` effectively disabled the caching of the computation results of dashboard widgets so that every request would access Elasticsearch to calculate the widget's value.

Fixes #1640, refs #1588, refs #1542