### PR TITLE
Add Content-Type and X-Graylog2-No-Session-Extension to CORS headers

### DIFF
--- a/graylog2-shared/src/main/java/org/graylog2/shared/rest/CORSFilter.java
+++ b/graylog2-shared/src/main/java/org/graylog2/shared/rest/CORSFilter.java
@@ -31,6 +31,7 @@ public class CORSFilter implements ContainerResponseFilter {
             responseContext.getHeaders().add("Access-Control-Allow-Origin", origin);
             responseContext.getHeaders().add("Access-Control-Allow-Credentials", true);
             responseContext.getHeaders().add("Access-Control-Allow-Headers", "Authorization, Content-Type, X-Graylog2-No-Session-Extension");
+            responseContext.getHeaders().add("Access-Control-Allow-Methods", "GET, POST, PUT, DELETE, OPTIONS");
         }
     }
 }

--- a/graylog2-shared/src/main/java/org/graylog2/shared/rest/CORSFilter.java
+++ b/graylog2-shared/src/main/java/org/graylog2/shared/rest/CORSFilter.java
@@ -19,19 +19,18 @@ package org.graylog2.shared.rest;
 import javax.ws.rs.container.ContainerRequestContext;
 import javax.ws.rs.container.ContainerResponseContext;
 import javax.ws.rs.container.ContainerResponseFilter;
+import javax.ws.rs.core.MultivaluedMap;
 import java.io.IOException;
 
-/**
- * @author Dennis Oelkers <dennis@torch.sh>
- */
 public class CORSFilter implements ContainerResponseFilter {
     @Override
     public void filter(ContainerRequestContext requestContext, ContainerResponseContext responseContext) throws IOException {
-        String origin = requestContext.getHeaders().getFirst("Origin");
+        final MultivaluedMap<String, String> headers = requestContext.getHeaders();
+        final String origin = headers.getFirst("Origin");
         if (origin != null && !origin.isEmpty()) {
             responseContext.getHeaders().add("Access-Control-Allow-Origin", origin);
             responseContext.getHeaders().add("Access-Control-Allow-Credentials", true);
-            responseContext.getHeaders().add("Access-Control-Allow-Headers", "Authorization");
+            responseContext.getHeaders().add("Access-Control-Allow-Headers", "Authorization, Content-Type, X-Graylog2-No-Session-Extension");
         }
     }
 }

--- a/graylog2-shared/src/test/java/org/graylog2/shared/rest/CORSFilterTest.java
+++ b/graylog2-shared/src/test/java/org/graylog2/shared/rest/CORSFilterTest.java
@@ -44,6 +44,8 @@ public class CORSFilterTest {
         assertThat(responseHeaders.getFirst("Access-Control-Allow-Credentials")).isEqualTo(true);
         assertThat((String) responseHeaders.getFirst("Access-Control-Allow-Headers"))
                 .contains("Authorization", "Content-Type", "X-Graylog2-No-Session-Extension");
+        assertThat((String) responseHeaders.getFirst("Access-Control-Allow-Methods"))
+                .contains("GET", "POST", "PUT", "DELETE", "OPTIONS");
     }
 
     @Test

--- a/graylog2-shared/src/test/java/org/graylog2/shared/rest/CORSFilterTest.java
+++ b/graylog2-shared/src/test/java/org/graylog2/shared/rest/CORSFilterTest.java
@@ -1,0 +1,63 @@
+/**
+ * This file is part of Graylog.
+ *
+ * Graylog is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.graylog2.shared.rest;
+
+import org.junit.Test;
+
+import javax.ws.rs.container.ContainerRequestContext;
+import javax.ws.rs.container.ContainerResponseContext;
+import javax.ws.rs.core.MultivaluedHashMap;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class CORSFilterTest {
+    @Test
+    public void testFilterWithOrigin() throws Exception {
+        final MultivaluedHashMap<String, String> requestHeaders = new MultivaluedHashMap<>();
+        requestHeaders.add("Origin", "example.com");
+        final ContainerRequestContext requestContext = mock(ContainerRequestContext.class);
+        when(requestContext.getHeaders()).thenReturn(requestHeaders);
+        final ContainerResponseContext responseContext = mock(ContainerResponseContext.class);
+        final MultivaluedHashMap<String, Object> responseHeaders = new MultivaluedHashMap<>();
+        when(responseContext.getHeaders()).thenReturn(responseHeaders);
+        final CORSFilter corsFilter = new CORSFilter();
+
+        corsFilter.filter(requestContext, responseContext);
+
+        assertThat(responseHeaders.getFirst("Access-Control-Allow-Origin")).isEqualTo("example.com");
+        assertThat(responseHeaders.getFirst("Access-Control-Allow-Credentials")).isEqualTo(true);
+        assertThat((String) responseHeaders.getFirst("Access-Control-Allow-Headers"))
+                .contains("Authorization", "Content-Type", "X-Graylog2-No-Session-Extension");
+    }
+
+    @Test
+    public void testFilterWithoutOrigin() throws Exception {
+        final MultivaluedHashMap<String, String> requestHeaders = new MultivaluedHashMap<>();
+        final ContainerRequestContext requestContext = mock(ContainerRequestContext.class);
+        when(requestContext.getHeaders()).thenReturn(requestHeaders);
+        final ContainerResponseContext responseContext = mock(ContainerResponseContext.class);
+        final MultivaluedHashMap<String, Object> responseHeaders = new MultivaluedHashMap<>();
+        when(responseContext.getHeaders()).thenReturn(responseHeaders);
+        final CORSFilter corsFilter = new CORSFilter();
+
+        corsFilter.filter(requestContext, responseContext);
+
+        assertThat(responseHeaders).isEmpty();
+    }
+}


### PR DESCRIPTION
The `Content-Type` and `X-Graylog2-No-Session-Extension` headers are being used when accessing the Graylog REST API from within a web-browser (or generally any HTTP client that sticks to CORS).

Fixes #1682