### PR TITLE
Add support for plugins providing routes and (system) navigation elements.

### DIFF
--- a/graylog2-web-interface/package.json
+++ b/graylog2-web-interface/package.json
@@ -23,6 +23,7 @@
     "crossfilter": "1.3.x",
     "d3": "<=3.5.0",
     "dc": "2.0.0-beta.19",
+    "graylog-web-plugin": "~0.0.x",
     "history": "^1.17.0",
     "immutable": "^3.7.5",
     "javascript-natural-sort": "^0.7.1",

--- a/graylog2-web-interface/src/components/navigation/Navigation.jsx
+++ b/graylog2-web-interface/src/components/navigation/Navigation.jsx
@@ -92,6 +92,16 @@ const Navigation = React.createClass({
           </LinkContainer>
         );
       });
+
+    const pluginSystemNavigations = PluginStore.exports('systemnavigation')
+      .map((pluginRoute) => {
+        return (
+          <LinkContainer key={pluginRoute.path} to={pluginRoute.path}>
+            <NavItem>{pluginRoute.description}</NavItem>
+          </LinkContainer>
+        );
+      });
+
     return (
       <Navbar inverse fluid fixedTop>
         <Navbar.Header>
@@ -172,6 +182,7 @@ const Navigation = React.createClass({
                 <MenuItem>Grok Patterns</MenuItem>
               </LinkContainer>
               }
+              {pluginSystemNavigations}
             </NavDropdown>
           </Nav>
 

--- a/graylog2-web-interface/src/components/navigation/Navigation.jsx
+++ b/graylog2-web-interface/src/components/navigation/Navigation.jsx
@@ -7,6 +7,7 @@ import PermissionsMixin from 'util/PermissionsMixin';
 import Routes from 'routing/Routes';
 
 import NotificationsStore from 'stores/notifications/NotificationsStore';
+import { PluginStore } from 'graylog-web-plugin/plugin';
 
 import GlobalThroughput from 'components/throughput/GlobalThroughput';
 import UserMenu from 'components/navigation/UserMenu';
@@ -82,6 +83,15 @@ const Navigation = React.createClass({
         <a><img src={logoUrl}/></a>
       </LinkContainer>);
     // TODO: fix permission names
+
+    const pluginNavigations = PluginStore.exports('navigation')
+      .map((pluginRoute) => {
+        return (
+          <LinkContainer key={pluginRoute.path} to={pluginRoute.path}>
+            <NavItem>{pluginRoute.description}</NavItem>
+          </LinkContainer>
+        );
+      });
     return (
       <Navbar inverse fluid fixedTop>
         <Navbar.Header>
@@ -107,6 +117,9 @@ const Navigation = React.createClass({
                 <NavItem>Sources</NavItem>
               </LinkContainer>
             }
+
+            {pluginNavigations}
+
             <NavDropdown navItem title={this._systemTitle()} id="system-menu-dropdown">
               <LinkContainer to={Routes.SYSTEM.OVERVIEW}>
                 <MenuItem>Overview</MenuItem>

--- a/graylog2-web-interface/src/routing/AppRouter.jsx
+++ b/graylog2-web-interface/src/routing/AppRouter.jsx
@@ -3,7 +3,8 @@ import App from 'routing/App';
 import AppWithSearchBar from 'routing/AppWithSearchBar';
 import AppWithoutSearchBar from 'routing/AppWithoutSearchBar';
 import { IndexRoute, Router, Route } from 'react-router';
-import {createHistory} from 'history';
+import { createHistory } from 'history';
+import { PluginStore } from 'graylog-web-plugin/plugin';
 
 import Routes from 'routing/Routes';
 
@@ -43,6 +44,9 @@ import ShowNodePage from 'pages/ShowNodePage';
 
 const AppRouter = React.createClass({
   render() {
+    const pluginRoutes = PluginStore.exports('routes').map((pluginRoute) => {
+      return <Route key={pluginRoute.component.displayName} path={pluginRoute.path} component={pluginRoute.component} />;
+    });
     return (
       <Router history={createHistory()}>
         <Route path="/" component={App}>
@@ -83,6 +87,7 @@ const AppRouter = React.createClass({
             <Route path={Routes.SYSTEM.USERS.edit(':username')} component={EditUsersPage}/>
             <Route path={Routes.SYSTEM.USERS.LIST} component={UsersPage}/>
             <Route path={Routes.SYSTEM.OVERVIEW} component={SystemOverviewPage}/>
+            {pluginRoutes}
           </Route>
         </Route>
       </Router>


### PR DESCRIPTION
This PR adds support for routes to complete pages (embedded in the general layout of the web interface) and navigational elements. Usage of this is described in the default [`index.jsx`](https://github.com/Graylog2/graylog-plugin-archetype/blob/master/src/main/resources/archetype-resources/src/web/index.jsx) file generated by the maven plugin archetype.