### PR TITLE
Fix creation_date key.

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/indexer/indices/Indices.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/indices/Indices.java
@@ -525,7 +525,7 @@ public class Indices implements IndexManagement {
             if (settings == null) {
                 return null;
             }
-            return new DateTime(settings.getAsLong("creation_date", 0L), DateTimeZone.UTC);
+            return new DateTime(settings.getAsLong("index.creation_date", 0L), DateTimeZone.UTC);
         } catch (ElasticsearchException e) {
             LOG.warn("Unable to read creation_date for index " + index, e.getRootCause());
             return null;


### PR DESCRIPTION
I think this will fix https://github.com/Graylog2/graylog2-server/issues/725, in which the index is always rotated at startup when you're using TimeBasedRotationStrategy.

The settings key was wrong, so the creation_date always came up as 0L, which indicated that the index was overdue for rotation. Tested this patch in our setup and it works like a champ.