### PR TITLE
update assembly for use with graylog-project

### DIFF
--- a/graylog2-server/pom.xml
+++ b/graylog2-server/pom.xml
@@ -432,7 +432,7 @@
                 <artifactId>maven-assembly-plugin</artifactId>
                 <configuration>
                     <attach>true</attach>
-                    <appendAssemblyId>false</appendAssemblyId>
+                    <appendAssemblyId>true</appendAssemblyId>
                     <descriptors>
                         <descriptor>src/main/assembly/graylog.xml</descriptor>
                     </descriptors>

--- a/graylog2-server/pom.xml
+++ b/graylog2-server/pom.xml
@@ -289,11 +289,6 @@
             <artifactId>gelfclient</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.graylog.plugins</groupId>
-            <artifactId>usage-statistics</artifactId>
-        </dependency>
-
-        <dependency>
             <groupId>com.wordnik</groupId>
             <artifactId>swagger-annotations</artifactId>
         </dependency>
@@ -436,7 +431,7 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-assembly-plugin</artifactId>
                 <configuration>
-                    <attach>false</attach>
+                    <attach>true</attach>
                     <appendAssemblyId>false</appendAssemblyId>
                     <descriptors>
                         <descriptor>src/main/assembly/graylog.xml</descriptor>

--- a/graylog2-server/src/main/assembly/graylog.xml
+++ b/graylog2-server/src/main/assembly/graylog.xml
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <assembly
-        xmlns="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.2"
+        xmlns="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.3"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-        xsi:schemaLocation="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.2 http://maven.apache.org/xsd/assembly-1.1.2.xsd">
-    <id>graylog</id>
+        xsi:schemaLocation="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.3 http://maven.apache.org/xsd/assembly-1.1.3.xsd">
+    <id>graylog-server-tarball</id>
     <formats>
         <format>tar.gz</format>
     </formats>
-    <includeBaseDirectory>true</includeBaseDirectory>
+    <includeBaseDirectory>false</includeBaseDirectory>
     <fileSets>
         <fileSet>
             <directory>${project.basedir}/..</directory>
@@ -64,13 +64,4 @@
             <outputDirectory>/</outputDirectory>
         </file>
     </files>
-    <dependencySets>
-        <dependencySet>
-            <scope>provided</scope>
-            <outputDirectory>/plugin</outputDirectory>
-            <includes>
-                <include>org.graylog.plugins:usage-statistics</include>
-            </includes>
-        </dependencySet>
-    </dependencySets>
 </assembly>

--- a/pom.xml
+++ b/pom.xml
@@ -1057,7 +1057,7 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-assembly-plugin</artifactId>
                 <configuration>
-                    <attach>false</attach>
+                    <attach>true</attach>
                     <appendAssemblyId>false</appendAssemblyId>
                     <!-- we don't care about assembling the parent, just run the goal on the project, pretty please -->
                     <ignoreMissingDescriptor>true</ignoreMissingDescriptor>

--- a/pom.xml
+++ b/pom.xml
@@ -769,12 +769,6 @@
                 </exclusions>
             </dependency>
             <dependency>
-                <groupId>org.graylog.plugins</groupId>
-                <artifactId>usage-statistics</artifactId>
-                <version>2.0.0-SNAPSHOT</version>
-                <scope>provided</scope>
-            </dependency>
-            <dependency>
                 <groupId>org.mindrot</groupId>
                 <artifactId>jbcrypt</artifactId>
                 <version>0.3m</version>


### PR DESCRIPTION
 - attach artifact to build
 - don't put assembled archive into wrapper directory (this might break some workflows!)
 - don't depend on usage-statistics plugin anymore, graylog-project does this now

How to test:
1) create a new workspace
2) clone this repo into graylog2-server
3) clone https://github.com/Graylog2/graylog-plugin-anonymous-usage-statistics
4) clone https://github.com/Graylog2/graylog-project
5) mvn compile package assembly:single in graylog-project

Project artifact should be as before the change.