### PR TITLE
Log error when a SystemJob throws an exception

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/system/jobs/SystemJobManager.java
+++ b/graylog2-server/src/main/java/org/graylog2/system/jobs/SystemJobManager.java
@@ -93,6 +93,8 @@ public class SystemJobManager {
                     LOG.info(msg);
                     activityWriter.write(new Activity(msg, SystemJobManager.class));
                 } catch (SystemJobConcurrencyException ignored) {
+                } catch (Exception e) {
+                    LOG.error("Unhandled error while running SystemJob <" + job.getId() + "> [" + jobClass + "]", e);
                 } finally {
                     jobs.remove(job.getId());
                 }


### PR DESCRIPTION
Before this there was no error indication if a SystemJob failed.