### PR TITLE
Messageprocessor refactor

### DIFF
--- a/graylog2-plugin-interfaces/src/main/java/org/graylog2/plugin/EmptyMessages.java
+++ b/graylog2-plugin-interfaces/src/main/java/org/graylog2/plugin/EmptyMessages.java
@@ -1,0 +1,35 @@
+/**
+ * The MIT License
+ * Copyright (c) 2012 Graylog, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.graylog2.plugin;
+
+import java.util.Collections;
+import java.util.Iterator;
+
+public class EmptyMessages implements Messages {
+    private static final EmptyMessages EMPTY_MESSAGES = new EmptyMessages();
+
+    @Override
+    public Iterator<Message> iterator() {
+        return Collections.emptyIterator();
+    }
+}

--- a/graylog2-plugin-interfaces/src/main/java/org/graylog2/plugin/Message.java
+++ b/graylog2-plugin-interfaces/src/main/java/org/graylog2/plugin/Message.java
@@ -29,6 +29,7 @@ import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Iterables;
+import com.google.common.collect.Iterators;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.google.common.net.InetAddresses;
@@ -41,6 +42,7 @@ import java.net.InetAddress;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Date;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -52,7 +54,7 @@ import static com.google.common.base.Predicates.not;
 import static org.graylog2.plugin.Tools.buildElasticSearchTimeFormat;
 import static org.joda.time.DateTimeZone.UTC;
 
-public class Message {
+public class Message implements Messages {
     private static final Logger LOG = LoggerFactory.getLogger(Message.class);
 
     public static final String FIELD_ID = "_id";
@@ -436,6 +438,14 @@ public class Message {
 
     private boolean shouldNotRecord(ServerStatus serverStatus) {
         return !serverStatus.getDetailedMessageRecordingStrategy().shouldRecord(this);
+    }
+
+    @Override
+    public Iterator<Message> iterator() {
+        if (getFilterOut()) {
+            return Collections.emptyIterator();
+        }
+        return Iterators.singletonIterator(this);
     }
 
     public static abstract class Recording {

--- a/graylog2-plugin-interfaces/src/main/java/org/graylog2/plugin/Messages.java
+++ b/graylog2-plugin-interfaces/src/main/java/org/graylog2/plugin/Messages.java
@@ -1,0 +1,26 @@
+/**
+ * The MIT License
+ * Copyright (c) 2012 Graylog, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.graylog2.plugin;
+
+public interface Messages extends Iterable<Message> {
+}

--- a/graylog2-plugin-interfaces/src/main/java/org/graylog2/plugin/PluginModule.java
+++ b/graylog2-plugin-interfaces/src/main/java/org/graylog2/plugin/PluginModule.java
@@ -30,6 +30,7 @@ import org.graylog2.plugin.alarms.callbacks.AlarmCallback;
 import org.graylog2.plugin.filters.MessageFilter;
 import org.graylog2.plugin.indexer.retention.RetentionStrategy;
 import org.graylog2.plugin.indexer.rotation.RotationStrategy;
+import org.graylog2.plugin.messageprocessors.MessageProcessor;
 import org.graylog2.plugin.inject.Graylog2Module;
 import org.graylog2.plugin.inputs.MessageInput;
 import org.graylog2.plugin.inputs.codecs.Codec;
@@ -134,5 +135,13 @@ public abstract class PluginModule extends Graylog2Module {
 
     protected void addPasswordAlgorithm(String passwordAlgorithmName, Class<? extends PasswordAlgorithm> passwordAlgorithmClass) {
         passwordAlgorithmBinder().addBinding(passwordAlgorithmName).to(passwordAlgorithmClass);
+    }
+
+    protected Multibinder<MessageProcessor> processorBinder() {
+        return Multibinder.newSetBinder(binder(), MessageProcessor.class);
+    }
+
+    protected void addMessageProcessor(Class<? extends MessageProcessor> processorClass) {
+        processorBinder().addBinding().to(processorClass);
     }
 }

--- a/graylog2-plugin-interfaces/src/main/java/org/graylog2/plugin/SingletonMessages.java
+++ b/graylog2-plugin-interfaces/src/main/java/org/graylog2/plugin/SingletonMessages.java
@@ -1,0 +1,42 @@
+/**
+ * The MIT License
+ * Copyright (c) 2012 Graylog, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.graylog2.plugin;
+
+import com.google.common.collect.Iterators;
+
+import java.util.Iterator;
+
+public class SingletonMessages implements Messages {
+
+    private final Message message;
+
+    public SingletonMessages(Message message) {
+        this.message = message;
+    }
+
+    @Override
+    public Iterator<Message> iterator() {
+        return Iterators.singletonIterator(message);
+    }
+
+}

--- a/graylog2-plugin-interfaces/src/main/java/org/graylog2/plugin/messageprocessors/MessageProcessor.java
+++ b/graylog2-plugin-interfaces/src/main/java/org/graylog2/plugin/messageprocessors/MessageProcessor.java
@@ -1,0 +1,29 @@
+/**
+ * The MIT License
+ * Copyright (c) 2012 Graylog, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.graylog2.plugin.messageprocessors;
+
+import org.graylog2.plugin.Messages;
+
+public interface MessageProcessor {
+    Messages process(Messages messages);
+}

--- a/graylog2-server/src/main/java/org/graylog2/alerts/types/FieldContentValueAlertCondition.java
+++ b/graylog2-server/src/main/java/org/graylog2/alerts/types/FieldContentValueAlertCondition.java
@@ -97,7 +97,7 @@ public class FieldContentValueAlertCondition extends AbstractAlertCondition {
             if (backlogEnabled) {
                 summaries = Lists.newArrayListWithCapacity(result.getResults().size());
                 for (ResultMessage resultMessage : result.getResults()) {
-                    final Message msg = new Message(resultMessage.getMessage());
+                    final Message msg = resultMessage.getMessage();
                     searchHits.add(msg);
                     summaries.add(new MessageSummary(resultMessage.getIndex(), msg));
                 }

--- a/graylog2-server/src/main/java/org/graylog2/alerts/types/FieldValueAlertCondition.java
+++ b/graylog2-server/src/main/java/org/graylog2/alerts/types/FieldValueAlertCondition.java
@@ -161,7 +161,7 @@ public class FieldValueAlertCondition extends AbstractAlertCondition {
                     final List<ResultMessage> searchResult = fieldStatsResult.getSearchHits();
                     summaries = Lists.newArrayListWithCapacity(searchResult.size());
                     for (ResultMessage resultMessage : searchResult) {
-                        final Message msg = new Message(resultMessage.getMessage());
+                        final Message msg = resultMessage.getMessage();
                         this.searchHits.add(msg);
                         summaries.add(new MessageSummary(resultMessage.getIndex(), msg));
                     }

--- a/graylog2-server/src/main/java/org/graylog2/alerts/types/MessageCountAlertCondition.java
+++ b/graylog2-server/src/main/java/org/graylog2/alerts/types/MessageCountAlertCondition.java
@@ -103,7 +103,7 @@ public class MessageCountAlertCondition extends AbstractAlertCondition {
                 if (getBacklog() > 0) {
                     final SearchResult backlogResult = searches.search("*", filter, new RelativeRange(time * 60), getBacklog(), 0, new Sorting("timestamp", Sorting.Direction.DESC));
                     for (ResultMessage resultMessage : backlogResult.getResults()) {
-                        final Message msg = new Message(resultMessage.getMessage());
+                        final Message msg = resultMessage.getMessage();
                         summaries.add(new MessageSummary(resultMessage.getIndex(), msg));
                     }
                 }

--- a/graylog2-server/src/main/java/org/graylog2/buffers/processors/ServerProcessBufferProcessor.java
+++ b/graylog2-server/src/main/java/org/graylog2/buffers/processors/ServerProcessBufferProcessor.java
@@ -16,104 +16,49 @@
  */
 package org.graylog2.buffers.processors;
 
-import com.codahale.metrics.Meter;
 import com.codahale.metrics.MetricRegistry;
-import com.codahale.metrics.Timer;
-import com.google.common.collect.ComparisonChain;
-import com.google.common.collect.Ordering;
-import org.graylog2.Configuration;
 import org.graylog2.buffers.OutputBuffer;
+import org.graylog2.messageprocessors.OrderedMessageProcessors;
 import org.graylog2.plugin.Message;
-import org.graylog2.plugin.ServerStatus;
-import org.graylog2.plugin.filters.MessageFilter;
+import org.graylog2.plugin.Messages;
+import org.graylog2.plugin.messageprocessors.MessageProcessor;
 import org.graylog2.shared.buffers.processors.ProcessBufferProcessor;
-import org.graylog2.shared.journal.Journal;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import javax.annotation.Nonnull;
 import javax.inject.Inject;
-import java.util.Comparator;
-import java.util.List;
-import java.util.Set;
-
-import static com.codahale.metrics.MetricRegistry.name;
 
 /**
  * @author Dennis Oelkers <dennis@torch.sh>
  */
 public class ServerProcessBufferProcessor extends ProcessBufferProcessor {
-    private final Configuration configuration;
-    private final ServerStatus serverStatus;
-    private final Journal journal;
 
     private static final Logger LOG = LoggerFactory.getLogger(ServerProcessBufferProcessor.class);
-    private final OutputBuffer outputBuffer;
-    private final Meter filteredOutMessages;
-    private final List<MessageFilter> filterRegistry;
 
+    private final OrderedMessageProcessors orderedMessageProcessors;
+    private final OutputBuffer outputBuffer;
 
     @Inject
     public ServerProcessBufferProcessor(MetricRegistry metricRegistry,
-                                  Set<MessageFilter> filterRegistry,
-                                  Configuration configuration,
-                                  ServerStatus serverStatus,
-                                  OutputBuffer outputBuffer,
-                                  Journal journal) {
+                                        OrderedMessageProcessors orderedMessageProcessors,
+                                        OutputBuffer outputBuffer) {
         super(metricRegistry);
-        this.configuration = configuration;
-        this.serverStatus = serverStatus;
-        this.journal = journal;
-
-        // we need to keep this sorted properly, so that the filters run in the correct order
-        this.filterRegistry = Ordering.from(new Comparator<MessageFilter>() {
-            @Override
-            public int compare(MessageFilter filter1, MessageFilter filter2) {
-                return ComparisonChain.start()
-                        .compare(filter1.getPriority(), filter2.getPriority())
-                        .compare(filter1.getName(), filter2.getName())
-                        .result();
-            }
-        }).immutableSortedCopy(filterRegistry);
-
+        this.orderedMessageProcessors = orderedMessageProcessors;
         this.outputBuffer = outputBuffer;
-        this.filteredOutMessages = metricRegistry.meter(name(ProcessBufferProcessor.class, "filteredOutMessages"));
     }
 
     @Override
     protected void handleMessage(@Nonnull Message msg) {
+        Messages messages = msg;
 
-        if (filterRegistry.size() == 0)
-            throw new RuntimeException("Empty filter registry!");
-
-        for (final MessageFilter filter : filterRegistry) {
-            final String timerName = name(filter.getClass(), "executionTime");
-            final Timer timer = metricRegistry.timer(timerName);
-            final Timer.Context timerContext = timer.time();
-
-            try {
-                LOG.debug("Applying filter [{}] on message <{}>.", filter.getName(), msg.getId());
-
-                if (filter.filter(msg)) {
-                    LOG.debug("Filter [{}] marked message <{}> to be discarded. Dropping message.", filter.getName(), msg.getId());
-                    filteredOutMessages.mark();
-                    journal.markJournalOffsetCommitted(msg.getJournalOffset());
-                    return;
-                }
-            } catch (Exception e) {
-                LOG.error("Could not apply filter [" + filter.getName() +"] on message <" + msg.getId() +">: ", e);
-            } finally {
-                final long elapsedNanos = timerContext.stop();
-                msg.recordTiming(serverStatus, timerName, elapsedNanos);
-            }
+        for (MessageProcessor messageProcessor : orderedMessageProcessors) {
+            messages = messageProcessor.process(messages);
         }
-
-        LOG.debug("Finished processing message. Writing to output buffer.");
-        outputBuffer.insertBlocking(msg);
+        for (Message message : messages) {
+            LOG.debug("Finished processing message. Writing to output buffer.");
+            outputBuffer.insertBlocking(message);
+        }
     }
 
-    // default visibility for tests
-    List<MessageFilter> getFilterRegistry() {
-        return filterRegistry;
-    }
 }

--- a/graylog2-server/src/main/java/org/graylog2/commands/Server.java
+++ b/graylog2-server/src/main/java/org/graylog2/commands/Server.java
@@ -41,6 +41,7 @@ import org.graylog2.configuration.MongoDbConfiguration;
 import org.graylog2.configuration.VersionCheckConfiguration;
 import org.graylog2.indexer.retention.RetentionStrategyBindings;
 import org.graylog2.indexer.rotation.RotationStrategyBindings;
+import org.graylog2.messageprocessors.MessageProcessorModule;
 import org.graylog2.notifications.Notification;
 import org.graylog2.notifications.NotificationService;
 import org.graylog2.plugin.KafkaJournalConfiguration;
@@ -105,6 +106,7 @@ public class Server extends ServerBootstrap {
                 new ServerBindings(configuration),
                 new PersistenceServicesBindings(),
                 new MessageFilterBindings(),
+                new MessageProcessorModule(),
                 new AlarmCallbackBindings(),
                 new InitializerBindings(),
                 new MessageOutputBindings(configuration),

--- a/graylog2-server/src/main/java/org/graylog2/indexer/results/ResultMessage.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/results/ResultMessage.java
@@ -25,6 +25,7 @@ import org.elasticsearch.action.get.GetResponse;
 import org.elasticsearch.search.SearchHit;
 import org.elasticsearch.search.SearchHitField;
 import org.elasticsearch.search.highlight.HighlightField;
+import org.graylog2.plugin.Message;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -38,7 +39,7 @@ import static org.graylog2.plugin.Tools.ES_DATE_FORMAT_FORMATTER;
 public class ResultMessage {
     private static final Logger LOG = LoggerFactory.getLogger(ResultMessage.class);
 
-    private Map<String, Object> message;
+    private Message message;
     private String index;
 
     @JsonInclude(JsonInclude.Include.NON_NULL)
@@ -73,19 +74,19 @@ public class ResultMessage {
     }
 
     public void setMessage(String id, Map<String, Object> message) {
-        this.message = message;
-        this.message.put("_id", id);
-
-        if (this.message.containsKey("timestamp")) {
-            final Object tsField = this.message.get("timestamp");
+        Map<String, Object> tmp = Maps.newHashMap();
+        tmp.putAll(message);
+        tmp.put("_id", id);
+        if (tmp.containsKey("timestamp")) {
+            final Object tsField = tmp.get("timestamp");
             try {
-                this.message.put("timestamp",
-                        ES_DATE_FORMAT_FORMATTER.parseDateTime(String.valueOf(tsField)));
+                tmp.put("timestamp", ES_DATE_FORMAT_FORMATTER.parseDateTime(String.valueOf(tsField)));
             } catch (IllegalArgumentException e) {
                 // could not parse date string, this is likely a bug, but we will leave the original value alone
                 LOG.warn("Could not parse timestamp of message {}", message.get("id"), e);
             }
         }
+        this.message = new Message(tmp);
     }
 
     public void setHighlightRanges(Map<String, HighlightField> highlightFields) {
@@ -109,7 +110,7 @@ public class ResultMessage {
                     highlightRanges.put(hlEntry.getKey(), highlightPosition);
                 }
             }
-            LOG.debug("Highlight positions for message {}: {}", message.get("_id"), highlightRanges);
+            LOG.debug("Highlight positions for message {}: {}", message.getId(), highlightRanges);
         }
     }
 
@@ -117,7 +118,7 @@ public class ResultMessage {
         this.index = index;
     }
 
-    public Map<String, Object> getMessage() {
+    public Message getMessage() {
         return message;
     }
 

--- a/graylog2-server/src/main/java/org/graylog2/indexer/results/SearchResult.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/results/SearchResult.java
@@ -25,7 +25,6 @@ import org.graylog2.plugin.Message;
 
 import java.util.Iterator;
 import java.util.List;
-import java.util.Map;
 import java.util.Set;
 
 /**
@@ -65,10 +64,10 @@ public class SearchResult extends IndexQueryResult {
 
         Iterator<ResultMessage> i = hits.iterator();
         while(i.hasNext()) {
-            final Map<String, Object> message = i.next().getMessage();
-            allFields.addAll(message.keySet());
+            final Message message = i.next().getMessage();
+            allFields.addAll(message.getFieldNames());
 
-            for (String field : message.keySet()) {
+            for (String field : message.getFieldNames()) {
                 if (!Message.RESERVED_FIELDS.contains(field)) {
                     filteredFields.add(field);
                 }

--- a/graylog2-server/src/main/java/org/graylog2/messageprocessors/MessageFilterChainProcessor.java
+++ b/graylog2-server/src/main/java/org/graylog2/messageprocessors/MessageFilterChainProcessor.java
@@ -1,0 +1,113 @@
+/**
+ * This file is part of Graylog.
+ *
+ * Graylog is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.graylog2.messageprocessors;
+
+import com.codahale.metrics.Meter;
+import com.codahale.metrics.MetricRegistry;
+import com.codahale.metrics.Timer;
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.collect.ComparisonChain;
+import com.google.common.collect.Ordering;
+import org.graylog2.plugin.Message;
+import org.graylog2.plugin.Messages;
+import org.graylog2.plugin.ServerStatus;
+import org.graylog2.plugin.filters.MessageFilter;
+import org.graylog2.plugin.messageprocessors.MessageProcessor;
+import org.graylog2.shared.buffers.processors.ProcessBufferProcessor;
+import org.graylog2.shared.journal.Journal;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.inject.Inject;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Set;
+
+import static com.codahale.metrics.MetricRegistry.name;
+
+public class MessageFilterChainProcessor implements MessageProcessor {
+    private static final Logger LOG = LoggerFactory.getLogger(MessageFilterChainProcessor.class);
+
+    private final List<MessageFilter> filterRegistry;
+    private final MetricRegistry metricRegistry;
+    private final Journal journal;
+    private final ServerStatus serverStatus;
+    private final Meter filteredOutMessages;
+
+    @Inject
+    public MessageFilterChainProcessor(MetricRegistry metricRegistry,
+                                       Set<MessageFilter> filterRegistry,
+                                       Journal journal,
+                                       ServerStatus serverStatus) {
+        this.metricRegistry = metricRegistry;
+        this.journal = journal;
+        this.serverStatus = serverStatus;
+        // we need to keep this sorted properly, so that the filters run in the correct order
+        this.filterRegistry = Ordering.from(new Comparator<MessageFilter>() {
+            @Override
+            public int compare(MessageFilter filter1, MessageFilter filter2) {
+                return ComparisonChain.start()
+                        .compare(filter1.getPriority(), filter2.getPriority())
+                        .compare(filter1.getName(), filter2.getName())
+                        .result();
+            }
+        }).immutableSortedCopy(filterRegistry);
+
+        if (filterRegistry.size() == 0)
+            throw new RuntimeException("Empty filter registry!");
+
+        this.filteredOutMessages = metricRegistry.meter(name(ProcessBufferProcessor.class, "filteredOutMessages"));
+    }
+
+    @Override
+    public Messages process(Messages messages) {
+
+        for (Message msg : messages) {
+            for (final MessageFilter filter : filterRegistry) {
+                final String timerName = name(filter.getClass(), "executionTime");
+                final Timer timer = metricRegistry.timer(timerName);
+                final Timer.Context timerContext = timer.time();
+
+                try {
+                    LOG.debug("Applying filter [{}] on message <{}>.", filter.getName(), msg.getId());
+
+                    if (filter.filter(msg)) {
+                        LOG.debug("Filter [{}] marked message <{}> to be discarded. Dropping message.",
+                                  filter.getName(),
+                                  msg.getId());
+                        filteredOutMessages.mark();
+                        journal.markJournalOffsetCommitted(msg.getJournalOffset());
+                        continue;
+                    }
+                    return msg;
+                } catch (Exception e) {
+                    LOG.error("Could not apply filter [" + filter.getName() + "] on message <" + msg.getId() + ">: ",
+                              e);
+                } finally {
+                    final long elapsedNanos = timerContext.stop();
+                    msg.recordTiming(serverStatus, timerName, elapsedNanos);
+                }
+            }
+        }
+        return messages;
+    }
+
+    @VisibleForTesting
+    protected List<MessageFilter> getFilterRegistry() {
+        return filterRegistry;
+    }
+}

--- a/graylog2-server/src/main/java/org/graylog2/messageprocessors/MessageProcessorModule.java
+++ b/graylog2-server/src/main/java/org/graylog2/messageprocessors/MessageProcessorModule.java
@@ -1,0 +1,29 @@
+/**
+ * This file is part of Graylog.
+ *
+ * Graylog is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.graylog2.messageprocessors;
+
+import org.graylog2.plugin.PluginModule;
+
+public class MessageProcessorModule extends PluginModule {
+    @Override
+    protected void configure() {
+        addMessageProcessor(MessageFilterChainProcessor.class);
+
+        bind(OrderedMessageProcessors.class).asEagerSingleton();
+    }
+
+}

--- a/graylog2-server/src/main/java/org/graylog2/messageprocessors/MessageProcessorOrder.java
+++ b/graylog2-server/src/main/java/org/graylog2/messageprocessors/MessageProcessorOrder.java
@@ -1,0 +1,51 @@
+/**
+ * This file is part of Graylog.
+ *
+ * Graylog is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.graylog2.messageprocessors;
+
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.auto.value.AutoValue;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Set;
+
+@AutoValue
+@JsonAutoDetect
+public abstract class MessageProcessorOrder {
+
+    @JsonProperty
+    public abstract long changeVersion();
+
+    @JsonProperty
+    public abstract List<String> classOrder();
+
+    @JsonProperty
+    public abstract Set<String> disabledMessageProcessors();
+
+    @JsonCreator
+    public static MessageProcessorOrder create(@JsonProperty("change_version") long changeVersion,
+                                               @JsonProperty("class_order") List<String> classOrder,
+                                               @JsonProperty("disabled_message_processors") Set<String> disabledMessageProcessors) {
+        return new AutoValue_MessageProcessorOrder(changeVersion, classOrder, disabledMessageProcessors);
+    }
+
+    public static MessageProcessorOrder create(long changeVersion, List<String> classOrder) {
+        return create(changeVersion, classOrder, Collections.emptySet());
+    }
+}

--- a/graylog2-server/src/main/java/org/graylog2/rest/ScrollChunkWriter.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/ScrollChunkWriter.java
@@ -85,7 +85,7 @@ public class ScrollChunkWriter implements MessageBodyWriter<ScrollResult.ScrollC
             int idx = 0;
             // first collect all values from the current message
             for (String fieldName : fields) {
-                final Object val = message.getMessage().get(fieldName);
+                final Object val = message.getMessage().getField(fieldName);
                 if (val == null) {
                     fieldValues[idx] = null;
                 } else {

--- a/graylog2-server/src/main/java/org/graylog2/rest/resources/messages/MessageResource.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/resources/messages/MessageResource.java
@@ -75,7 +75,7 @@ public class MessageResource extends RestResource {
         checkPermission(RestPermissions.MESSAGES_READ, messageId);
         try {
             final ResultMessage resultMessage = messages.get(messageId, index);
-            final Message message = new Message(resultMessage.getMessage());
+            final Message message = resultMessage.getMessage();
             checkMessageReadPermission(message);
 
             return resultMessage;

--- a/graylog2-server/src/main/java/org/graylog2/rest/resources/search/SearchResource.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/resources/search/SearchResource.java
@@ -180,7 +180,8 @@ public abstract class SearchResource extends RestResource {
         final List<ResultMessageSummary> result = Lists.newArrayListWithCapacity(resultMessages.size());
 
         for (ResultMessage resultMessage : resultMessages) {
-            result.add(ResultMessageSummary.create(resultMessage.highlightRanges, resultMessage.getMessage(), resultMessage.getIndex()));
+            // TODO module merge: migrate to resultMessage.getMessage() instead of Map<String, Object> via getFields()
+            result.add(ResultMessageSummary.create(resultMessage.highlightRanges, resultMessage.getMessage().getFields(), resultMessage.getIndex()));
         }
 
         return result;

--- a/graylog2-server/src/test/java/org/graylog2/alerts/types/FieldContentValueAlertConditionTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/alerts/types/FieldContentValueAlertConditionTest.java
@@ -74,6 +74,7 @@ public class FieldContentValueAlertConditionTest extends AlertConditionTest {
         final HashMap<String, Object> source = Maps.newHashMap();
         source.put("message", "something is in here");
 
+        when(searchHit.getId()).thenReturn("some id");
         when(searchHit.getSource()).thenReturn(source);
         when(searchHit.getIndex()).thenReturn("graylog_test");
         when(searchHits.iterator()).thenReturn(Iterators.singletonIterator(searchHit));

--- a/graylog2-server/src/test/java/org/graylog2/messageprocessors/OrderedMessageProcessorsTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/messageprocessors/OrderedMessageProcessorsTest.java
@@ -1,0 +1,89 @@
+/**
+ * This file is part of Graylog.
+ *
+ * Graylog is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.graylog2.messageprocessors;
+
+import com.google.common.collect.Lists;
+import com.google.common.collect.Sets;
+import com.google.common.eventbus.EventBus;
+import org.graylog2.plugin.Messages;
+import org.graylog2.plugin.cluster.ClusterConfigService;
+import org.graylog2.plugin.messageprocessors.MessageProcessor;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.Iterator;
+import java.util.Set;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.mockito.Mockito.mock;
+
+public class OrderedMessageProcessorsTest {
+
+    private OrderedMessageProcessors orderedMessageProcessors;
+
+    @Before
+    public void setUp() throws Exception {
+        Set<MessageProcessor> processors = Sets.newHashSet();
+        processors.add(new A());
+        processors.add(new B());
+        orderedMessageProcessors = new OrderedMessageProcessors(processors,
+                                                                mock(ClusterConfigService.class),
+                                                                mock(EventBus.class));
+    }
+
+    @Test
+    public void testIterator() throws Exception {
+        final Iterator<MessageProcessor> iterator = orderedMessageProcessors.iterator();
+        assertEquals("A is first", A.class, iterator.next().getClass());
+        assertEquals("B is last", B.class, iterator.next().getClass());
+        assertFalse("Iterator exhausted", iterator.hasNext());
+
+        orderedMessageProcessors.handleOrderingUpdate(
+                MessageProcessorOrder.create(1, Lists.newArrayList(B.class.getCanonicalName(),
+                                                                   A.class.getCanonicalName())));
+
+        final Iterator<MessageProcessor> it2 = orderedMessageProcessors.iterator();
+        assertEquals("B is first", B.class, it2.next().getClass());
+        assertEquals("A is last", A.class, it2.next().getClass());
+        assertFalse("Iterator exhausted", it2.hasNext());
+
+
+        orderedMessageProcessors.handleOrderingUpdate(
+                MessageProcessorOrder.create(1, Lists.newArrayList(B.class.getCanonicalName(),
+                                                                   A.class.getCanonicalName()),
+                                             Sets.newHashSet(B.class.getCanonicalName())));
+
+        final Iterator<MessageProcessor> it3 = orderedMessageProcessors.iterator();
+        assertEquals("A is only element", A.class, it3.next().getClass());
+        assertFalse("Iterator exhausted", it3.hasNext());
+    }
+
+    private static class A implements MessageProcessor {
+        @Override
+        public Messages process(Messages messages) {
+            return null;
+        }
+    }
+
+    private static class B implements MessageProcessor {
+        @Override
+        public Messages process(Messages messages) {
+            return null;
+        }
+    }
+}


### PR DESCRIPTION
Refactor ProcessBufferProcessors to use MessageProcessor instead of MessageFilter instances

 - Message processors transform Messages into Messages, iterating over each registered processor passing single messages.
 - Existing MessageFilters are being handled by the MessageFilterChainProcessor to preserve backwards compatiblity with existing filter plugins.
 - MessageProcessor is pluggable, and their order can be controlled at runtime through a MessageProcessorOrder cluster configuration.
 - ResultMessage now directly contains Message objects, as a first step to unify the two views onto a Message.