### PR TITLE
Node journal

### DIFF
--- a/graylog2-plugin-interfaces/pom.xml
+++ b/graylog2-plugin-interfaces/pom.xml
@@ -110,7 +110,6 @@
         <dependency>
             <groupId>javax.validation</groupId>
             <artifactId>validation-api</artifactId>
-            <version>1.1.0.Final</version>
         </dependency>
     </dependencies>
 

--- a/graylog2-plugin-interfaces/pom.xml
+++ b/graylog2-plugin-interfaces/pom.xml
@@ -106,6 +106,12 @@
             <groupId>com.github.joschi</groupId>
             <artifactId>jadconfig</artifactId>
         </dependency>
+
+        <dependency>
+            <groupId>javax.validation</groupId>
+            <artifactId>validation-api</artifactId>
+            <version>1.1.0.Final</version>
+        </dependency>
     </dependencies>
 
     <build>

--- a/graylog2-plugin-interfaces/src/main/java/org/graylog2/plugin/KafkaJournalConfiguration.java
+++ b/graylog2-plugin-interfaces/src/main/java/org/graylog2/plugin/KafkaJournalConfiguration.java
@@ -27,9 +27,9 @@ import com.fasterxml.jackson.annotation.JsonFormat;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.github.joschi.jadconfig.Parameter;
 import com.github.joschi.jadconfig.util.Size;
-import com.sun.istack.internal.NotNull;
 import org.joda.time.Duration;
 
+import javax.validation.constraints.NotNull;
 import java.io.File;
 import java.util.Objects;
 

--- a/graylog2-plugin-interfaces/src/main/java/org/graylog2/plugin/KafkaJournalConfiguration.java
+++ b/graylog2-plugin-interfaces/src/main/java/org/graylog2/plugin/KafkaJournalConfiguration.java
@@ -22,6 +22,7 @@
  */
 package org.graylog2.plugin;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonFormat;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.github.joschi.jadconfig.Parameter;
@@ -31,6 +32,25 @@ import org.joda.time.Duration;
 import java.io.File;
 
 public class KafkaJournalConfiguration {
+
+    public KafkaJournalConfiguration() { }
+
+    @JsonCreator
+    public KafkaJournalConfiguration(@JsonProperty("directory") File messageJournalDir,
+                                     @JsonProperty("segment_size") long messageJournalSegmentSize,
+                                     @JsonProperty("segment_age") Duration messageJournalSegmentAge,
+                                     @JsonProperty("max_size") long messageJournalMaxSize,
+                                     @JsonProperty("max_age") Duration messageJournalMaxAge,
+                                     @JsonProperty("flush_interval") long messageJournalFlushInterval,
+                                     @JsonProperty("flush_age") Duration messageJournalFlushAge) {
+        this.messageJournalDir = messageJournalDir;
+        this.messageJournalSegmentSize = Size.bytes(messageJournalSegmentSize);
+        this.messageJournalSegmentAge = messageJournalSegmentAge;
+        this.messageJournalMaxSize = Size.bytes(messageJournalMaxSize);
+        this.messageJournalMaxAge = messageJournalMaxAge;
+        this.messageJournalFlushInterval = messageJournalFlushInterval;
+        this.messageJournalFlushAge = messageJournalFlushAge;
+    }
 
     @Parameter(value = "message_journal_dir", required = true)
     @JsonProperty("directory")

--- a/graylog2-plugin-interfaces/src/main/java/org/graylog2/plugin/KafkaJournalConfiguration.java
+++ b/graylog2-plugin-interfaces/src/main/java/org/graylog2/plugin/KafkaJournalConfiguration.java
@@ -27,23 +27,25 @@ import com.fasterxml.jackson.annotation.JsonFormat;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.github.joschi.jadconfig.Parameter;
 import com.github.joschi.jadconfig.util.Size;
+import com.sun.istack.internal.NotNull;
 import org.joda.time.Duration;
 
 import java.io.File;
+import java.util.Objects;
 
 public class KafkaJournalConfiguration {
 
     public KafkaJournalConfiguration() { }
 
     @JsonCreator
-    public KafkaJournalConfiguration(@JsonProperty("directory") File messageJournalDir,
+    public KafkaJournalConfiguration(@NotNull @JsonProperty("directory") File messageJournalDir,
                                      @JsonProperty("segment_size") long messageJournalSegmentSize,
                                      @JsonProperty("segment_age") Duration messageJournalSegmentAge,
                                      @JsonProperty("max_size") long messageJournalMaxSize,
                                      @JsonProperty("max_age") Duration messageJournalMaxAge,
                                      @JsonProperty("flush_interval") long messageJournalFlushInterval,
                                      @JsonProperty("flush_age") Duration messageJournalFlushAge) {
-        this.messageJournalDir = messageJournalDir;
+        this.messageJournalDir = Objects.requireNonNull(messageJournalDir);
         this.messageJournalSegmentSize = Size.bytes(messageJournalSegmentSize);
         this.messageJournalSegmentAge = messageJournalSegmentAge;
         this.messageJournalMaxSize = Size.bytes(messageJournalMaxSize);

--- a/graylog2-server/src/main/java/org/graylog2/rest/resources/cluster/ClusterJournalResource.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/resources/cluster/ClusterJournalResource.java
@@ -1,0 +1,89 @@
+/**
+ * This file is part of Graylog.
+ *
+ * Graylog is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.graylog2.rest.resources.cluster;
+
+import com.codahale.metrics.annotation.Timed;
+import com.wordnik.swagger.annotations.Api;
+import com.wordnik.swagger.annotations.ApiOperation;
+import com.wordnik.swagger.annotations.ApiParam;
+import org.apache.shiro.authz.annotation.RequiresAuthentication;
+import org.apache.shiro.authz.annotation.RequiresPermissions;
+import org.graylog2.cluster.Node;
+import org.graylog2.cluster.NodeNotFoundException;
+import org.graylog2.cluster.NodeService;
+import org.graylog2.rest.RemoteInterfaceProvider;
+import org.graylog2.rest.resources.system.RemoteJournalResource;
+import org.graylog2.rest.resources.system.responses.JournalSummaryResponse;
+import org.graylog2.shared.rest.resources.ProxiedResource;
+import org.graylog2.shared.security.RestPermissions;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import retrofit2.Response;
+
+import javax.inject.Inject;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.Context;
+import javax.ws.rs.core.HttpHeaders;
+import javax.ws.rs.core.MediaType;
+import java.io.IOException;
+
+@RequiresAuthentication
+@Api(value = "Cluster", description = "Journal information of any nodes in the cluster")
+@Path("/cluster/journal")
+@Produces(MediaType.APPLICATION_JSON)
+public class ClusterJournalResource extends ProxiedResource {
+    private static final Logger LOG = LoggerFactory.getLogger(ClusterJournalResource.class);
+
+    private final NodeService nodeService;
+    private final RemoteInterfaceProvider remoteInterfaceProvider;
+
+    @Inject
+    public ClusterJournalResource(NodeService nodeService,
+                                  RemoteInterfaceProvider remoteInterfaceProvider,
+                                  @Context HttpHeaders httpHeaders) throws NodeNotFoundException {
+        super(httpHeaders);
+        this.nodeService = nodeService;
+        this.remoteInterfaceProvider = remoteInterfaceProvider;
+    }
+
+    @GET
+    @Timed
+    @ApiOperation(value = "Get message journal information of a given node")
+    @RequiresPermissions(RestPermissions.JOURNAL_READ)
+    @Path("{nodeId}")
+    public JournalSummaryResponse get(@ApiParam(name = "nodeId", value = "The id of the node to get message journal information.", required = true)
+                                      @PathParam("nodeId") String nodeId) throws IOException, NodeNotFoundException {
+        final Node targetNode = nodeService.byNodeId(nodeId);
+
+        final RemoteJournalResource remoteJournalResource = remoteInterfaceProvider.get(targetNode,
+                this.authenticationToken,
+                RemoteJournalResource.class);
+        final Response<JournalSummaryResponse> response = remoteJournalResource.get().execute();
+        if (response.isSuccess()) {
+            return response.body();
+        } else {
+            LOG.warn("Unable to get message journal information on node " + nodeId + ": " + response.message());
+        }
+
+        return null;
+    }
+}
+

--- a/graylog2-server/src/main/java/org/graylog2/rest/resources/cluster/ClusterJournalResource.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/resources/cluster/ClusterJournalResource.java
@@ -47,7 +47,7 @@ import javax.ws.rs.core.MediaType;
 import java.io.IOException;
 
 @RequiresAuthentication
-@Api(value = "Cluster", description = "Journal information of any nodes in the cluster")
+@Api(value = "Cluster/Journal", description = "Journal information of any nodes in the cluster")
 @Path("/cluster/journal")
 @Produces(MediaType.APPLICATION_JSON)
 public class ClusterJournalResource extends ProxiedResource {

--- a/graylog2-server/src/main/java/org/graylog2/rest/resources/cluster/ClusterJournalResource.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/resources/cluster/ClusterJournalResource.java
@@ -40,6 +40,7 @@ import javax.ws.rs.GET;
 import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
 import javax.ws.rs.Produces;
+import javax.ws.rs.WebApplicationException;
 import javax.ws.rs.core.Context;
 import javax.ws.rs.core.HttpHeaders;
 import javax.ws.rs.core.MediaType;
@@ -80,10 +81,9 @@ public class ClusterJournalResource extends ProxiedResource {
         if (response.isSuccess()) {
             return response.body();
         } else {
-            LOG.warn("Unable to get message journal information on node " + nodeId + ": " + response.message());
+            LOG.warn("Unable to get message journal information on node {}: {}", nodeId, response.message());
+            throw new WebApplicationException(response.message(), response.code());
         }
-
-        return null;
     }
 }
 

--- a/graylog2-server/src/main/java/org/graylog2/rest/resources/cluster/ClusterJournalResource.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/resources/cluster/ClusterJournalResource.java
@@ -48,7 +48,7 @@ import java.io.IOException;
 
 @RequiresAuthentication
 @Api(value = "Cluster/Journal", description = "Journal information of any nodes in the cluster")
-@Path("/cluster/journal")
+@Path("/cluster/{nodeId}/journal")
 @Produces(MediaType.APPLICATION_JSON)
 public class ClusterJournalResource extends ProxiedResource {
     private static final Logger LOG = LoggerFactory.getLogger(ClusterJournalResource.class);
@@ -69,7 +69,6 @@ public class ClusterJournalResource extends ProxiedResource {
     @Timed
     @ApiOperation(value = "Get message journal information of a given node")
     @RequiresPermissions(RestPermissions.JOURNAL_READ)
-    @Path("{nodeId}")
     public JournalSummaryResponse get(@ApiParam(name = "nodeId", value = "The id of the node to get message journal information.", required = true)
                                       @PathParam("nodeId") String nodeId) throws IOException, NodeNotFoundException {
         final Node targetNode = nodeService.byNodeId(nodeId);

--- a/graylog2-server/src/main/java/org/graylog2/rest/resources/cluster/ClusterJournalResource.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/resources/cluster/ClusterJournalResource.java
@@ -46,6 +46,8 @@ import javax.ws.rs.core.HttpHeaders;
 import javax.ws.rs.core.MediaType;
 import java.io.IOException;
 
+import static javax.ws.rs.core.Response.Status.BAD_GATEWAY;
+
 @RequiresAuthentication
 @Api(value = "Cluster/Journal", description = "Journal information of any nodes in the cluster")
 @Path("/cluster/{nodeId}/journal")
@@ -81,7 +83,7 @@ public class ClusterJournalResource extends ProxiedResource {
             return response.body();
         } else {
             LOG.warn("Unable to get message journal information on node {}: {}", nodeId, response.message());
-            throw new WebApplicationException(response.message(), response.code());
+            throw new WebApplicationException(response.message(), BAD_GATEWAY);
         }
     }
 }

--- a/graylog2-server/src/main/java/org/graylog2/rest/resources/system/RemoteJournalResource.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/resources/system/RemoteJournalResource.java
@@ -1,0 +1,27 @@
+/**
+ * This file is part of Graylog.
+ *
+ * Graylog is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.graylog2.rest.resources.system;
+
+import org.graylog2.rest.resources.system.responses.JournalSummaryResponse;
+import retrofit2.Call;
+import retrofit2.http.GET;
+
+public interface RemoteJournalResource {
+    @GET("/system/journal")
+    Call<JournalSummaryResponse> get();
+}

--- a/graylog2-server/src/main/java/org/graylog2/rest/resources/system/responses/JournalSummaryResponse.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/resources/system/responses/JournalSummaryResponse.java
@@ -17,6 +17,7 @@
 package org.graylog2.rest.resources.system.responses;
 
 import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.github.joschi.jadconfig.util.Size;
 import com.google.auto.value.AutoValue;
@@ -30,7 +31,7 @@ import javax.annotation.Nullable;
 public abstract class JournalSummaryResponse {
 
     public static JournalSummaryResponse createDisabled() {
-        return new AutoValue_JournalSummaryResponse(false, 0, 0, 0, Size.bytes(0), Size.bytes(0), 0, null, null);
+        return JournalSummaryResponse.create(false, 0, 0, 0, Size.bytes(0), Size.bytes(0), 0, null, null);
     }
 
     public static JournalSummaryResponse createEnabled(long appendEventsPerSec,
@@ -41,15 +42,56 @@ public abstract class JournalSummaryResponse {
                                                        int numberOfSegments,
                                                        DateTime oldestSegment,
                                                        KafkaJournalConfiguration kafkaJournalConfiguration) {
-        return new AutoValue_JournalSummaryResponse(true,
-                                                    appendEventsPerSec,
-                                                    readEventsPerSec,
-                                                    uncommittedJournalEntries,
-                                                    journalSize,
-                                                    journalSizeLimit,
-                                                    numberOfSegments,
-                                                    oldestSegment,
-                                                    kafkaJournalConfiguration);
+        return JournalSummaryResponse.create(true,
+                appendEventsPerSec,
+                readEventsPerSec,
+                uncommittedJournalEntries,
+                journalSize,
+                journalSizeLimit,
+                numberOfSegments,
+                oldestSegment,
+                kafkaJournalConfiguration);
+    }
+
+    @JsonCreator
+    public static JournalSummaryResponse create(@JsonProperty("enabled") boolean enabled,
+                                                @JsonProperty("append_events_per_second") long appendEventsPerSec,
+                                                @JsonProperty("read_events_per_second") long readEventsPerSec,
+                                                @JsonProperty("uncommitted_journal_entries") long uncommittedJournalEntries,
+                                                @JsonProperty("journal_size") long journalSize,
+                                                @JsonProperty("journal_size_limit") long journalSizeLimit,
+                                                @JsonProperty("number_of_segments") int numberOfSegments,
+                                                @JsonProperty("oldest_segment") DateTime oldestSegment,
+                                                @JsonProperty("journal_config") KafkaJournalConfiguration kafkaJournalConfiguration) {
+        return JournalSummaryResponse.create(enabled,
+                appendEventsPerSec,
+                readEventsPerSec,
+                uncommittedJournalEntries,
+                Size.bytes(journalSize),
+                Size.bytes(journalSizeLimit),
+                numberOfSegments,
+                oldestSegment,
+                kafkaJournalConfiguration);
+    }
+
+    public static JournalSummaryResponse create(boolean enabled,
+                                                long appendEventsPerSec,
+                                                long readEventsPerSec,
+                                                long uncommittedJournalEntries,
+                                                Size journalSize,
+                                                Size journalSizeLimit,
+                                                int numberOfSegments,
+                                                DateTime oldestSegment,
+                                                KafkaJournalConfiguration kafkaJournalConfiguration) {
+        return new AutoValue_JournalSummaryResponse(enabled,
+                appendEventsPerSec,
+                readEventsPerSec,
+                uncommittedJournalEntries,
+                journalSize,
+                journalSizeLimit,
+                numberOfSegments,
+                oldestSegment,
+                kafkaJournalConfiguration);
     }
 
     // keep the fields in the same order as the auto value constructor params!

--- a/graylog2-web-interface/public/stylesheets/graylog2.less
+++ b/graylog2-web-interface/public/stylesheets/graylog2.less
@@ -1400,7 +1400,7 @@ td.limited {
   margin-bottom: 7px;
 }
 
-.node-buffer-usage .progress-bar {
+.node-buffer-usage .progress-bar, .journal-details-usage .progress-bar {
   text-shadow: 0 1px 2px rgba(0,0,0,0.4), 2px -1px 3px rgba(255,255,255,0.5);
 
   span {
@@ -2312,15 +2312,15 @@ div.row-sm {
   margin-bottom: 5px;
 }
 
-.graylog-node-heap .progress, .react-buffer-usage .progress, #react-journal-info .progress {
+.graylog-node-heap .progress, .node-buffer-usage .progress, .journal-details-usage .progress {
   margin-bottom: 5px;
 }
 
-#react-journal-info .progress {
+.journal-details-usage .progress {
   margin-top: 10px;
 }
 
-#react-journal-info .progress .progress-bar {
+.journal-details-usage .progress .progress-bar {
   min-width: 3em;
 }
 

--- a/graylog2-web-interface/src/components/nodes/JournalDetails.jsx
+++ b/graylog2-web-interface/src/components/nodes/JournalDetails.jsx
@@ -1,151 +1,129 @@
 import React, {PropTypes} from 'react';
+import Reflux from 'reflux';
 import { ProgressBar, Row, Col } from 'react-bootstrap';
 import numeral from 'numeral';
 import moment from 'moment';
 import {} from 'moment-duration-format';
 
-import MetricsStore from 'stores/metrics/MetricsStore';
-import { Timestamp } from 'components/common';
-import jsRoutes from 'routing/jsRoutes';
+import MetricsExtractor from 'logic/metrics/MetricsExtractor';
+import MetricsActions from 'actions/metrics/MetricsActions';
 
-const metricsStore = MetricsStore.instance;
+import MetricsStore from 'stores/metrics/MetricsStore';
+import JournalStore from 'stores/journal/JournalStore';
+
+import { Spinner, Timestamp } from 'components/common';
+
+import NumberUtils from 'util/NumberUtils';
+import jsRoutes from 'routing/jsRoutes';
 
 const JournalDetails = React.createClass({
   propTypes: {
     nodeId: PropTypes.string.isRequired,
-    enabled: PropTypes.boolean,
-    directory: PropTypes.string.isRequired,
-    maxSize: PropTypes.number.isRequired,
-    maxAge: PropTypes.string.isRequired,
-    flushInterval: PropTypes.number.isRequired,
-    flushAge: PropTypes.string.isRequired,
   },
+  mixins: [Reflux.connect(MetricsStore)],
+
   getInitialState() {
-    return ({
-      initialized: false,
-      hasError: false,
-      append: 0,
-      read: 0,
-      segments: 0,
-      entriesUncommitted: 0,
-      size: 0,
-      sizeLimit: 0,
-      utilizationRatio: 0,
-      oldestSegment: moment(),
+    return {
+      journalInformation: undefined,
+    };
+  },
+
+  componentDidMount() {
+    JournalStore.get(this.props.nodeId).then(journalInformation => {
+      this.setState({journalInformation: journalInformation}, this._listenToMetrics);
     });
   },
 
-  componentWillMount() {
-    // only listen for updates if the journal is actually turned on
-    if (this.props.enabled) {
-      const metricNames = [
-        'org.graylog2.journal.append.1-sec-rate',
-        'org.graylog2.journal.read.1-sec-rate',
-        'org.graylog2.journal.segments',
-        'org.graylog2.journal.entries-uncommitted',
-        'org.graylog2.journal.size',
-        'org.graylog2.journal.size-limit',
-        'org.graylog2.journal.utilization-ratio',
-        'org.graylog2.journal.oldest-segment',
-      ];
-      metricsStore.listen({
-        nodeId: this.props.nodeId,
-        metricNames: metricNames,
-        callback: (update, hasError) => {
-          if (hasError) {
-            this.setState({hasError: hasError});
-            return;
-          }
-          // update is [{nodeId, values: [{name, value: {metric}}]} ...]
-          // metric can be various different things, depending on metric {type: "GAUGE"|"COUNTER"|"METER"|"TIMER"}
-
-          const newState = {
-            initialized: true,
-            hasError: hasError,
-          };
-          // we will only get one result, because we ask for only one node
-          // get the base name from the metric name, and put the gauge metrics into our new state.
-          update[0].values.forEach((namedMetric) => {
-            const baseName = namedMetric.name.replace('org.graylog2.journal.', '').replace('.1-sec-rate', '');
-            const camelCase = this.camelCase(baseName);
-            newState[camelCase] = namedMetric.metric.value;
-          });
-          this.setState(newState);
-        },
-      });
+  componentWillUnmount() {
+    if (this.metricNames) {
+      Object.keys(this.metricNames).forEach(metricShortName => MetricsActions.remove(this.props.nodeId, this.metricNames[metricShortName]));
     }
   },
 
-  camelCase(input) {
-    return input.toLowerCase().replace(/-(.)/g, (match, group1) => group1.toUpperCase());
+  _listenToMetrics() {
+    // only listen for updates if the journal is actually turned on
+    if (this.state.journalInformation.enabled) {
+      this.metricNames = {
+        append: 'org.graylog2.journal.append.1-sec-rate',
+        read: 'org.graylog2.journal.read.1-sec-rate',
+        segments: 'org.graylog2.journal.segments',
+        entriesUncommitted: 'org.graylog2.journal.entries-uncommitted',
+        utilizationRatio: 'org.graylog2.journal.utilization-ratio',
+        oldestSegment: 'org.graylog2.journal.oldest-segment',
+      };
+      Object.keys(this.metricNames).forEach(metricShortName => MetricsActions.add(this.props.nodeId, this.metricNames[metricShortName]));
+    }
+  },
+
+  _isLoading() {
+    return !(this.state.metrics && this.state.journalInformation);
   },
 
   render() {
-    let content = null;
-    if (this.props.enabled) {
-      const oldestSegment = moment(this.state.oldestSegment);
-      let overcommittedWarning = null;
-      if (this.state.initialized && (this.state.utilizationRatio >= 1)) {
-        overcommittedWarning = (
-          <span>
-            <strong>Warning!</strong> The journal utilization is exceeding the maximum size defined.
-            <a href={jsRoutes.controllers.SystemController.index().url}> Click here</a> for more information.<br/>
-          </span>
-        );
-      }
-
-      content = (
-        <div>
-          <p className="description">Incoming messages are written to the disk journal to ensure they are kept safe in
-            case of a server failure. The journal also helps keeping Graylog working if any of the outputs is too slow
-            to keep up with the message rate
-            or whenever there is a peak in incoming messages. It makes sure that Graylog does not buffer all of those
-            messages in main memory and avoids overly long garbage collection pauses that way.
-          </p>
-          <Row className="row-sm">
-            <Col md={6}>
-              <h3>Configuration</h3>
-              <dl className="system-journal">
-                <dt>Path:</dt>
-                <dd>{this.props.directory}</dd>
-                <dt>Earliest entry:</dt>
-                <dd><Timestamp dateTime={oldestSegment} relative/></dd>
-                <dt>Maximum size:</dt>
-                <dd>{numeral(this.props.maxSize).format('0,0 b')}</dd>
-                <dt>Maximum age:</dt>
-                <dd>{moment.duration(this.props.maxAge).format('d [days] h [hours] m [minutes]')}</dd>
-                <dt>Flush policy:</dt>
-                <dd>
-                  Every {numeral(this.props.flushInterval).format('0,0')} messages
-                  {' '}or {moment.duration(this.props.flushAge).format('h [hours] m [minutes] s [seconds]')}
-                </dd>
-              </dl>
-            </Col>
-            <Col md={6}>
-              <h3>Utilization</h3>
-
-              <ProgressBar now={this.state.utilizationRatio * 100}
-                           label={numeral(this.state.utilizationRatio).format('0.0 %')}/>
-
-              {overcommittedWarning}
-
-              <strong>{numeral(this.state.entriesUncommitted).format('0,0')} unprocessed messages</strong>
-              {' '}are currently in the journal, in {this.state.segments} segments.<br/>
-              <strong>{numeral(this.state.append).format('0,0')} messages</strong>
-              {' '}have been appended in the last second,{' '}
-              <strong>{numeral(this.state.read).format('0,0')} messages</strong> have been read in the last second.
-            </Col>
-          </Row>
-        </div>
-      );
-    } else {
-      content = (<span>The disk journal is disabled for this node.</span>);
+    if (this._isLoading()) {
+      return <Spinner text="Loading journal metrics..."/>;
     }
 
-    return (<div>
-      <h2>Disk Journal</h2>
-      {content}
-    </div>);
+    const nodeId = this.props.nodeId;
+    const nodeMetrics = this.state.metrics[nodeId];
+    const journalInformation = this.state.journalInformation;
+    const metrics = MetricsExtractor.getValuesForNode(nodeMetrics, this.metricNames);
+
+    if (Object.keys(metrics).length === 0) {
+      return <span>Journal metrics unavailable.</span>;
+    }
+
+    if (!journalInformation.enabled) {
+      return <span>The disk journal is disabled for this node.</span>;
+    }
+
+    const oldestSegment = moment(metrics.oldestSegment);
+    let overcommittedWarning;
+    if (metrics.utilizationRatio >= 1) {
+      overcommittedWarning = (
+        <span>
+          <strong>Warning!</strong> The journal utilization is exceeding the maximum size defined.
+          <a href={jsRoutes.controllers.SystemController.index().url}> Click here</a> for more information.<br/>
+        </span>
+      );
+    }
+
+    return (
+      <Row className="row-sm">
+        <Col md={6}>
+          <h3>Configuration</h3>
+          <dl className="system-journal">
+            <dt>Path:</dt>
+            <dd>{journalInformation.journal_config.directory}</dd>
+            <dt>Earliest entry:</dt>
+            <dd><Timestamp dateTime={oldestSegment} relative/></dd>
+            <dt>Maximum size:</dt>
+            <dd>{numeral(journalInformation.journal_config.max_size).format('0,0 b')}</dd>
+            <dt>Maximum age:</dt>
+            <dd>{moment.duration(journalInformation.journal_config.max_age).format('d [days] h [hours] m [minutes]')}</dd>
+            <dt>Flush policy:</dt>
+            <dd>
+              Every {numeral(journalInformation.journal_config.flush_interval).format('0,0')} messages
+              {' '}or {moment.duration(journalInformation.journal_config.flush_age).format('h [hours] m [minutes] s [seconds]')}
+            </dd>
+          </dl>
+        </Col>
+        <Col md={6} className="journal-details-usage">
+          <h3>Utilization</h3>
+
+          <ProgressBar now={metrics.utilizationRatio * 100}
+                       label={NumberUtils.formatPercentage(metrics.utilizationRatio)}/>
+
+          {overcommittedWarning}
+
+          <strong>{numeral(metrics.entriesUncommitted).format('0,0')} unprocessed messages</strong>
+          {' '}are currently in the journal, in {metrics.segments} segments.<br/>
+          <strong>{numeral(metrics.append).format('0,0')} messages</strong>
+          {' '}have been appended in the last second,{' '}
+          <strong>{numeral(metrics.read).format('0,0')} messages</strong> have been read in the last second.
+        </Col>
+      </Row>
+    );
   },
 });
 

--- a/graylog2-web-interface/src/components/nodes/JournalDetails.jsx
+++ b/graylog2-web-interface/src/components/nodes/JournalDetails.jsx
@@ -1,5 +1,6 @@
 import React, {PropTypes} from 'react';
 import Reflux from 'reflux';
+import { LinkContainer } from 'react-router-bootstrap';
 import { ProgressBar, Row, Col } from 'react-bootstrap';
 import numeral from 'numeral';
 import moment from 'moment';
@@ -14,7 +15,7 @@ import JournalStore from 'stores/journal/JournalStore';
 import { Spinner, Timestamp } from 'components/common';
 
 import NumberUtils from 'util/NumberUtils';
-import jsRoutes from 'routing/jsRoutes';
+import Routes from 'routing/Routes';
 
 const JournalDetails = React.createClass({
   propTypes: {
@@ -83,7 +84,7 @@ const JournalDetails = React.createClass({
       overcommittedWarning = (
         <span>
           <strong>Warning!</strong> The journal utilization is exceeding the maximum size defined.
-          <a href={jsRoutes.controllers.SystemController.index().url}> Click here</a> for more information.<br/>
+          {' '}<LinkContainer to={Routes.SYSTEM.OVERVIEW}><a>Click here</a></LinkContainer> for more information.<br/>
         </span>
       );
     }

--- a/graylog2-web-interface/src/components/nodes/JournalDetails.jsx
+++ b/graylog2-web-interface/src/components/nodes/JournalDetails.jsx
@@ -1,7 +1,7 @@
 import React, {PropTypes} from 'react';
 import Reflux from 'reflux';
 import { LinkContainer } from 'react-router-bootstrap';
-import { ProgressBar, Row, Col } from 'react-bootstrap';
+import { ProgressBar, Row, Col, Alert } from 'react-bootstrap';
 import numeral from 'numeral';
 import moment from 'moment';
 import {} from 'moment-duration-format';
@@ -68,14 +68,23 @@ const JournalDetails = React.createClass({
     const nodeId = this.props.nodeId;
     const nodeMetrics = this.state.metrics[nodeId];
     const journalInformation = this.state.journalInformation;
-    const metrics = MetricsExtractor.getValuesForNode(nodeMetrics, this.metricNames);
-
-    if (Object.keys(metrics).length === 0) {
-      return <span>Journal metrics unavailable.</span>;
-    }
 
     if (!journalInformation.enabled) {
-      return <span>The disk journal is disabled for this node.</span>;
+      return (
+        <Alert bsStyle="warning">
+          <i className="fa fa-exclamation-triangle"/>&nbsp; The disk journal is disabled on this node.
+        </Alert>
+      );
+    }
+
+    const metrics = this.metricNames ? MetricsExtractor.getValuesForNode(nodeMetrics, this.metricNames) : {};
+
+    if (Object.keys(metrics).length === 0) {
+      return (
+        <Alert bsStyle="warning">
+          <i className="fa fa-exclamation-triangle"/>&nbsp; Journal metrics unavailable.
+        </Alert>
+      );
     }
 
     const oldestSegment = moment(metrics.oldestSegment);

--- a/graylog2-web-interface/src/components/nodes/JournalDetails.jsx
+++ b/graylog2-web-interface/src/components/nodes/JournalDetails.jsx
@@ -121,7 +121,7 @@ const JournalDetails = React.createClass({
         <Col md={6} className="journal-details-usage">
           <h3>Utilization</h3>
 
-          <ProgressBar now={metrics.utilizationRatio * 100}
+          <ProgressBar now={Math.min(metrics.utilizationRatio * 100, 100)}
                        label={NumberUtils.formatPercentage(metrics.utilizationRatio)}/>
 
           {overcommittedWarning}

--- a/graylog2-web-interface/src/components/nodes/NodeOverview.jsx
+++ b/graylog2-web-interface/src/components/nodes/NodeOverview.jsx
@@ -5,6 +5,7 @@ import { Row, Col, Button } from 'react-bootstrap';
 import BufferUsage from './BufferUsage';
 import SystemOverviewDetails from './SystemOverviewDetails';
 import JvmHeapUsage from './JvmHeapUsage';
+import JournalDetails from './JournalDetails';
 import SystemInformation from './SystemInformation';
 import RestApiOverview from './RestApiOverview';
 import PluginsDataTable from './PluginsDataTable';
@@ -69,6 +70,20 @@ const NodeOverview = React.createClass({
                 <BufferUsage nodeId={node.node_id} title="Output buffer" bufferType="output"/>
               </Col>
             </Row>
+          </Col>
+        </Row>
+
+        <Row className="content">
+          <Col md={12}>
+            <h2>Disk Journal</h2>
+            <p className="description">
+              Incoming messages are written to the disk journal to ensure they are kept safe in case of a server
+              failure. The journal also helps keeping Graylog working if any of the outputs is too slow to keep
+              up with the message rate or whenever there is a peak in incoming messages. It makes sure that
+              Graylog does not buffer all of those messages in main memory and avoids overly long garbage
+              collection pauses that way.
+            </p>
+            <JournalDetails nodeId={node.node_id}/>
           </Col>
         </Row>
 

--- a/graylog2-web-interface/src/stores/journal/JournalStore.js
+++ b/graylog2-web-interface/src/stores/journal/JournalStore.js
@@ -4,7 +4,7 @@ import UserNotification from 'util/UserNotification';
 import fetch from 'logic/rest/FetchProvider';
 
 const JournalStore = Reflux.createStore({
-  sourceUrl: (nodeId) => `/cluster/journal/${nodeId}`,
+  sourceUrl: (nodeId) => `/cluster/${nodeId}/journal`,
 
   get(nodeId) {
     const promise = fetch('GET', URLUtils.qualifyUrl(this.sourceUrl(nodeId)));

--- a/graylog2-web-interface/src/stores/journal/JournalStore.js
+++ b/graylog2-web-interface/src/stores/journal/JournalStore.js
@@ -1,0 +1,19 @@
+import Reflux from 'reflux';
+import URLUtils from 'util/URLUtils';
+import UserNotification from 'util/UserNotification';
+import fetch from 'logic/rest/FetchProvider';
+
+const JournalStore = Reflux.createStore({
+  sourceUrl: (nodeId) => `/cluster/journal/${nodeId}`,
+
+  get(nodeId) {
+    const promise = fetch('GET', URLUtils.qualifyUrl(this.sourceUrl(nodeId)));
+    promise.catch(error => {
+      UserNotification.error(`Getting journal information on node ${nodeId} failed: ${error}`, 'Could not get journal information');
+    });
+
+    return promise;
+  },
+});
+
+export default JournalStore;

--- a/pom.xml
+++ b/pom.xml
@@ -773,6 +773,11 @@
                 <artifactId>jbcrypt</artifactId>
                 <version>0.3m</version>
             </dependency>
+            <dependency>
+                <groupId>javax.validation</groupId>
+                <artifactId>validation-api</artifactId>
+                <version>1.1.0.Final</version>
+            </dependency>
         </dependencies>
     </dependencyManagement>
 


### PR DESCRIPTION
Working on a proxied resource for the journal information, I saw that `JournalSummaryResponse` and `KafkaJournalConfiguration` were not playing nice when deserialising their JSON responses. Here I fix the issue and add back the journal configuration to the node overview page, but I'm not entirely sure I did it in the _right way_. I would appreciate if someone take a look. Thank you!