### PR TITLE
Sanitization of message field names

### DIFF
--- a/graylog2-plugin-interfaces/src/main/java/org/graylog2/plugin/Message.java
+++ b/graylog2-plugin-interfaces/src/main/java/org/graylog2/plugin/Message.java
@@ -38,6 +38,7 @@ import org.joda.time.DateTime;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import javax.annotation.Nullable;
 import java.net.InetAddress;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -249,24 +250,27 @@ public class Message implements Messages {
         fields.put(FIELD_SOURCE, source);
     }
 
-    public void addField(final String key, final Object value) {
+    @Nullable
+    public Object addField(final String key, final Object value) {
         // Don't accept protected keys. (some are allowed though lol)
         if (RESERVED_FIELDS.contains(key) && !RESERVED_SETTABLE_FIELDS.contains(key) || !validKey(key)) {
             if (LOG.isDebugEnabled()) {
                 LOG.debug("Ignoring invalid or reserved key {} for message {}", key, getId());
             }
-            return;
+            return null;
         }
 
-        if(value instanceof String) {
+        if (value instanceof String) {
             final String str = ((String) value).trim();
 
-            if(!str.isEmpty()) {
-                fields.put(key.trim(), str);
+            if (!str.isEmpty()) {
+                return fields.put(key.trim(), str);
             }
-        } else if(value != null) {
-            fields.put(key.trim(), value);
+        } else if (value != null) {
+            return fields.put(key.trim(), value);
         }
+
+        return null;
     }
 
     public static boolean validKey(final String key) {
@@ -313,10 +317,13 @@ public class Message implements Messages {
         }
     }
 
-    public void removeField(final String key) {
+    @Nullable
+    public Object removeField(final String key) {
         if (!RESERVED_FIELDS.contains(key)) {
-            fields.remove(key);
+            return fields.remove(key);
         }
+
+        return null;
     }
 
     public <T> T getFieldAs(final Class<T> T, final String key) throws ClassCastException {
@@ -452,6 +459,7 @@ public class Message implements Messages {
         public static Timing timing(String name, long elapsedNanos) {
             return new Timing(name, elapsedNanos);
         }
+
         public static Counter counter(String name, int counter) {
             return new Counter(name, counter);
         }

--- a/graylog2-plugin-interfaces/src/main/java/org/graylog2/plugin/filters/MessageFilter.java
+++ b/graylog2-plugin-interfaces/src/main/java/org/graylog2/plugin/filters/MessageFilter.java
@@ -24,10 +24,6 @@ package org.graylog2.plugin.filters;
 
 import org.graylog2.plugin.Message;
 
-/**
- * 
- * @author Lennart Koopmann <lennart@socketfeed.com>
- */
 public interface MessageFilter {
 
     /**
@@ -35,16 +31,16 @@ public interface MessageFilter {
      *
      * @return true if this message should not further be handled (for example for blacklisting purposes)
      */
-    public boolean filter(Message msg);
+    boolean filter(Message msg);
 
     /**
      * @return The name of this filter. Should not include whitespaces or special characters.
      */
-    public String getName();
+    String getName();
 
     /**
      * For determining the runtime order of the filter, specify a priority.
-     * Lower priorty values are run earlier, if two filters have the same priority, their name will be compared to
+     * Lower priority values are run earlier, if two filters have the same priority, their name will be compared to
      * guarantee a repeatable order.
      *
      * @return the priority

--- a/graylog2-plugin-interfaces/src/test/java/org/graylog2/plugin/MessageTest.java
+++ b/graylog2-plugin-interfaces/src/test/java/org/graylog2/plugin/MessageTest.java
@@ -99,6 +99,15 @@ public class MessageTest {
     }
 
     @Test
+    public void testAddFieldReturnsOldValue() throws Exception {
+        Message m = new Message("foo", "bar", Tools.iso8601());
+
+        assertNull(m.addField("something", 1));
+        assertEquals(1, m.addField("something", 2));
+        assertEquals(2, m.getField("something"));
+    }
+
+    @Test
     public void testAddFields() throws Exception {
         final Map<String, Object> map = Maps.newHashMap();
 
@@ -154,7 +163,8 @@ public class MessageTest {
     public void testRemoveField() throws Exception {
         message.addField("foo", "bar");
 
-        message.removeField("foo");
+        assertNull(message.removeField("test"));
+        assertEquals("bar", message.removeField("foo"));
         assertNull(message.getField("foo"));
     }
 
@@ -235,13 +245,13 @@ public class MessageTest {
         final DateTime dateTime = new DateTime(2015, 9, 8, 0, 0, DateTimeZone.UTC);
 
         message.addField(Message.FIELD_TIMESTAMP,
-                         dateTime.toDate());
+                dateTime.toDate());
 
         final Map<String, Object> elasticSearchObject = message.toElasticSearchObject();
         final Object esTimestampFormatted = elasticSearchObject.get(Message.FIELD_TIMESTAMP);
 
         assertEquals("Setting message timestamp as java.util.Date results in correct format for elasticsearch",
-                     Tools.buildElasticSearchTimeFormat(dateTime), esTimestampFormatted);
+                Tools.buildElasticSearchTimeFormat(dateTime), esTimestampFormatted);
     }
 
     @Test

--- a/graylog2-server/src/main/java/org/graylog2/configuration/ElasticsearchConfiguration.java
+++ b/graylog2-server/src/main/java/org/graylog2/configuration/ElasticsearchConfiguration.java
@@ -127,6 +127,12 @@ public class ElasticsearchConfiguration {
     @Parameter(value = "elasticsearch_request_timeout", validator = PositiveDurationValidator.class)
     private Duration requestTimeout = Duration.minutes(1L);
 
+    @Parameter(value = "elasticsearch_sanitize_field_names")
+    private boolean sanitizeFieldNames = true;
+
+    @Parameter(value = "elasticsearch_invalid_character_replacement")
+    private String invalidCharacterReplacement = "_";
+
     public String getClusterName() {
         return clusterName;
     }
@@ -261,5 +267,13 @@ public class ElasticsearchConfiguration {
 
     public Duration getRequestTimeout() {
         return requestTimeout;
+    }
+
+    public boolean isSanitizeFieldNames() {
+        return sanitizeFieldNames;
+    }
+
+    public String getInvalidCharacterReplacement() {
+        return invalidCharacterReplacement;
     }
 }

--- a/graylog2-server/src/main/java/org/graylog2/messageprocessors/MessageProcessorModule.java
+++ b/graylog2-server/src/main/java/org/graylog2/messageprocessors/MessageProcessorModule.java
@@ -16,14 +16,16 @@
  */
 package org.graylog2.messageprocessors;
 
+import com.google.inject.TypeLiteral;
 import org.graylog2.plugin.PluginModule;
+import org.graylog2.plugin.messageprocessors.MessageProcessor;
 
 public class MessageProcessorModule extends PluginModule {
     @Override
     protected void configure() {
         addMessageProcessor(MessageFilterChainProcessor.class);
 
-        bind(OrderedMessageProcessors.class).asEagerSingleton();
+        // TODO: Use marker interface?
+        bind(new TypeLiteral<Iterable<MessageProcessor>>() {}).to(OrderedMessageProcessors.class).asEagerSingleton();
     }
-
 }

--- a/graylog2-server/src/test/java/org/graylog2/buffers/processors/ServerProcessBufferProcessorTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/buffers/processors/ServerProcessBufferProcessorTest.java
@@ -1,0 +1,140 @@
+/**
+ * This file is part of Graylog.
+ *
+ * Graylog is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.graylog2.buffers.processors;
+
+import com.codahale.metrics.MetricRegistry;
+import com.google.common.collect.ImmutableList;
+import org.graylog2.buffers.OutputBuffer;
+import org.graylog2.plugin.Message;
+import org.graylog2.plugin.Messages;
+import org.graylog2.plugin.messageprocessors.MessageProcessor;
+import org.joda.time.DateTime;
+import org.joda.time.DateTimeZone;
+import org.junit.Rule;
+import org.junit.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnit;
+import org.mockito.junit.MockitoRule;
+
+import java.util.Collections;
+
+import static java.util.Objects.requireNonNull;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.verify;
+
+public class ServerProcessBufferProcessorTest {
+    @Rule
+    public final MockitoRule mockitoRule = MockitoJUnit.rule();
+
+    @Mock
+    private OutputBuffer outputBuffer;
+    @Captor
+    private ArgumentCaptor<Message> messageArgument;
+
+    @Test
+    public void handleMessageRenamesFieldNamesWithDotsIfSanitationIsEnabled() throws Exception {
+        final Message message = new Message("Test", "source", new DateTime(2016, 1, 1, 0, 0, DateTimeZone.UTC));
+        message.addField("field.string", "Foo");
+        message.addField("field.float", 1.0F);
+        message.addField("field.double", 1.0D);
+        message.addField("field.integer", 1_000);
+        message.addField("field.long", 1_000L);
+        message.addField("field.boolean", true);
+        message.addField("do-not-replace", "Foo");
+        final ServerProcessBufferProcessor processor =
+                new ServerProcessBufferProcessor(new MetricRegistry(), Collections.emptySet(), outputBuffer, true, "_");
+
+        processor.handleMessage(message);
+
+        verify(outputBuffer).insertBlocking(messageArgument.capture());
+        assertThat(messageArgument.getValue().getFieldNames()).containsOnly(
+                "_id",
+                "message",
+                "source",
+                "timestamp",
+                "field_string",
+                "field_float",
+                "field_double",
+                "field_integer",
+                "field_long",
+                "field_boolean",
+                "do-not-replace"
+        );
+    }
+
+    @Test
+    public void handleMessageDoesNotRenameFieldNamesWithDotsIfSanitationIsDisabled() throws Exception {
+        final Message message = new Message("Test", "source", new DateTime(2016, 1, 1, 0, 0, DateTimeZone.UTC));
+        message.addField("field.string", "Foo");
+        message.addField("field.float", 1.0F);
+        message.addField("field.double", 1.0D);
+        message.addField("field.integer", 1_000);
+        message.addField("field.long", 1_000L);
+        message.addField("field.boolean", true);
+        final ServerProcessBufferProcessor processor =
+                new ServerProcessBufferProcessor(new MetricRegistry(), Collections.emptySet(), outputBuffer, false, "_");
+
+        processor.handleMessage(message);
+
+        verify(outputBuffer).insertBlocking(messageArgument.capture());
+        assertThat(messageArgument.getValue().getFieldNames()).containsOnly(
+                "_id",
+                "message",
+                "source",
+                "timestamp",
+                "field.string",
+                "field.float",
+                "field.double",
+                "field.integer",
+                "field.long",
+                "field.boolean"
+        );
+    }
+
+    @Test
+    public void handleMessageRunsAllMessageProcessors() {
+        final Message message = new Message("Test", "source", new DateTime(2016, 1, 1, 0, 0, DateTimeZone.UTC));
+        final Iterable<MessageProcessor> messageProcessors = ImmutableList.of(
+                new TestMessageProcessor("foo"), new TestMessageProcessor("bar"));
+        final ServerProcessBufferProcessor processor =
+                new ServerProcessBufferProcessor(new MetricRegistry(), messageProcessors, outputBuffer, false, "");
+
+        processor.handleMessage(message);
+
+        verify(outputBuffer).insertBlocking(messageArgument.capture());
+        assertThat(messageArgument.getValue().getFieldNames()).contains("foo", "bar");
+    }
+
+    public static class TestMessageProcessor implements MessageProcessor {
+        private final String fieldName;
+
+        public TestMessageProcessor(String fieldName) {
+            this.fieldName = requireNonNull(fieldName);
+        }
+
+        @Override
+        public Messages process(Messages messages) {
+            for (Message message : messages) {
+                message.addField(fieldName, true);
+            }
+
+            return messages;
+        }
+    }
+}

--- a/misc/graylog.conf
+++ b/misc/graylog.conf
@@ -183,6 +183,15 @@ allow_highlighting = false
 # before giving up and declaring the current node master.
 #elasticsearch_discovery_initial_state_timeout = 3s
 
+# Sanitize field names in messages before trying to index them into Elasticsearch. If received messages are always
+# using valid field names (i. e. do not contain '.' and other invalid characters in field names) this can be disabled
+# to gain more processing performance. Also see the "elasticsearch_invalid_character_replacement" setting.
+#elasticsearch_sanitize_field_names = true
+
+# String to replace invalid characters like dots ('.') in message field names before they are being indexed into
+# Elasticsearch.
+#elasticsearch_invalid_character_replacement = _
+
 # Analyzer (tokenizer) to use for message and full_message field. The "standard" filter usually is a good idea.
 # All supported analyzers are: standard, simple, whitespace, stop, keyword, pattern, language, snowball, custom
 # Elasticsearch documentation: http://www.elasticsearch.org/guide/reference/index-modules/analysis/


### PR DESCRIPTION
Beginning with Elasticsearch 2.0.0, field names must not contain dots ('.') anymore.

In order to make migration to Elasticsearch 2.x simpler for Graylog users, invalid characters like dots will be automatically replaced in field names with a configurable string (default: `_`).

Refs #1667.