### PR TITLE
Use chaining/delegating class loader for plugin classes

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/bootstrap/CmdLineTool.java
+++ b/graylog2-server/src/main/java/org/graylog2/bootstrap/CmdLineTool.java
@@ -58,6 +58,7 @@ import org.graylog2.plugin.system.NodeIdPersistenceException;
 import org.graylog2.shared.UI;
 import org.graylog2.shared.bindings.GuiceInjectorHolder;
 import org.graylog2.shared.bindings.PluginBindings;
+import org.graylog2.shared.plugins.ChainingClassLoader;
 import org.graylog2.shared.plugins.PluginLoader;
 import org.graylog2.shared.utilities.ExceptionUtils;
 import org.jboss.netty.logging.InternalLoggerFactory;
@@ -153,8 +154,10 @@ public abstract class CmdLineTool implements CliCommand {
     @Override
     public void run() {
         final Level logLevel = setupLogger();
+        final ClassLoader parentClassLoader = this.getClass().getClassLoader();
+        final ChainingClassLoader chainingClassLoader = new ChainingClassLoader(parentClassLoader);
 
-        final PluginBindings pluginBindings = installPluginConfigAndBindings(getPluginPath(configFile));
+        final PluginBindings pluginBindings = installPluginConfigAndBindings(getPluginPath(configFile), chainingClassLoader);
 
         if (isDumpDefaultConfig()) {
             dumpDefaultConfigAndExit();
@@ -249,8 +252,8 @@ public abstract class CmdLineTool implements CliCommand {
         dumpCurrentConfigAndExit();
     }
 
-    private PluginBindings installPluginConfigAndBindings(String pluginPath) {
-        final Set<Plugin> plugins = loadPlugins(pluginPath);
+    private PluginBindings installPluginConfigAndBindings(String pluginPath, ChainingClassLoader classLoader) {
+        final Set<Plugin> plugins = loadPlugins(pluginPath, classLoader);
         final PluginBindings pluginBindings = new PluginBindings(plugins);
         for (final Plugin plugin : plugins) {
             for (final PluginModule pluginModule : plugin.modules()) {
@@ -280,11 +283,11 @@ public abstract class CmdLineTool implements CliCommand {
         return pluginLoaderConfig.getPluginDir();
     }
 
-    protected Set<Plugin> loadPlugins(String pluginPath) {
+    protected Set<Plugin> loadPlugins(String pluginPath, ChainingClassLoader chainingClassLoader) {
         final File pluginDir = new File(pluginPath);
         final Set<Plugin> plugins = new HashSet<>();
 
-        final PluginLoader pluginLoader = new PluginLoader(pluginDir);
+        final PluginLoader pluginLoader = new PluginLoader(pluginDir, chainingClassLoader);
         for (Plugin plugin : pluginLoader.loadPlugins()) {
             final PluginMetaData metadata = plugin.metadata();
             if (capabilities().containsAll(metadata.getRequiredCapabilities())) {

--- a/graylog2-server/src/main/java/org/graylog2/commands/Server.java
+++ b/graylog2-server/src/main/java/org/graylog2/commands/Server.java
@@ -50,6 +50,7 @@ import org.graylog2.plugin.Tools;
 import org.graylog2.shared.UI;
 import org.graylog2.shared.bindings.ObjectMapperModule;
 import org.graylog2.shared.bindings.RestApiBindings;
+import org.graylog2.shared.plugins.ChainingClassLoader;
 import org.graylog2.shared.system.activities.Activity;
 import org.graylog2.shared.system.activities.ActivityWriter;
 import org.graylog2.system.shutdown.GracefulShutdown;
@@ -74,6 +75,7 @@ public class Server extends ServerBootstrap {
     private final MongoDbConfiguration mongoDbConfiguration = new MongoDbConfiguration();
     private final VersionCheckConfiguration versionCheckConfiguration = new VersionCheckConfiguration();
     private final KafkaJournalConfiguration kafkaJournalConfiguration = new KafkaJournalConfiguration();
+    private final ChainingClassLoader classLoader = new ChainingClassLoader(Server.class.getClassLoader());
 
     public Server() {
         super("server", configuration);
@@ -113,7 +115,7 @@ public class Server extends ServerBootstrap {
                 new RotationStrategyBindings(),
                 new RetentionStrategyBindings(),
                 new PeriodicalBindings(),
-                new ObjectMapperModule(),
+                new ObjectMapperModule(classLoader),
                 new RestApiBindings(),
                 new PasswordAlgorithmBindings()
         );

--- a/graylog2-server/src/main/java/org/graylog2/commands/journal/JournalDecode.java
+++ b/graylog2-server/src/main/java/org/graylog2/commands/journal/JournalDecode.java
@@ -17,7 +17,7 @@
 package org.graylog2.commands.journal;
 
 import com.google.common.base.Splitter;
-import com.google.common.collect.Lists;
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Range;
 import com.google.inject.Key;
 import com.google.inject.Module;
@@ -33,7 +33,6 @@ import org.graylog2.shared.bindings.ObjectMapperModule;
 import org.graylog2.shared.journal.Journal;
 import org.slf4j.helpers.MessageFormatter;
 
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
@@ -49,10 +48,11 @@ public class JournalDecode extends AbstractJournalCommand {
 
     @Override
     protected List<Module> getCommandBindings() {
-        final ArrayList<Module> modules = Lists.newArrayList(super.getCommandBindings());
-        modules.add(new CodecsModule());
-        modules.add(new ObjectMapperModule());
-        return modules;
+        return ImmutableList.<Module>builder()
+                .addAll(super.getCommandBindings())
+                .add(new CodecsModule())
+                .add(new ObjectMapperModule(getClass().getClassLoader()))
+                .build();
     }
 
     @Override
@@ -88,12 +88,12 @@ public class JournalDecode extends AbstractJournalCommand {
         final Long readOffset = range.lowerEndpoint();
         final long count = range.upperEndpoint() - range.lowerEndpoint() + 1;
         final List<Journal.JournalReadEntry> entries = journal.read(readOffset,
-                                                                    count);
+                count);
         for (final Journal.JournalReadEntry entry : entries) {
             final RawMessage raw = RawMessage.decode(entry.getPayload(), entry.getOffset());
             if (raw == null) {
                 System.err.println(MessageFormatter.format("Journal entry at offset {} failed to decode",
-                                                           entry.getOffset()));
+                        entry.getOffset()));
                 continue;
             }
 

--- a/graylog2-server/src/main/java/org/graylog2/shared/bindings/ObjectMapperModule.java
+++ b/graylog2-server/src/main/java/org/graylog2/shared/bindings/ObjectMapperModule.java
@@ -17,12 +17,28 @@
 package org.graylog2.shared.bindings;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.annotations.VisibleForTesting;
 import com.google.inject.AbstractModule;
 import org.graylog2.shared.bindings.providers.ObjectMapperProvider;
+import org.graylog2.shared.plugins.GraylogClassLoader;
+
+import static java.util.Objects.requireNonNull;
 
 public class ObjectMapperModule extends AbstractModule {
+    private final ClassLoader classLoader;
+
+    @VisibleForTesting
+    public ObjectMapperModule() {
+        this(ObjectMapperModule.class.getClassLoader());
+    }
+
+    public ObjectMapperModule(ClassLoader classLoader) {
+        this.classLoader = requireNonNull(classLoader);
+    }
+
     @Override
     protected void configure() {
+        bind(ClassLoader.class).annotatedWith(GraylogClassLoader.class).toInstance(classLoader);
         bind(ObjectMapper.class).toProvider(ObjectMapperProvider.class).asEagerSingleton();
     }
 }

--- a/graylog2-server/src/main/java/org/graylog2/shared/plugins/ChainingClassLoader.java
+++ b/graylog2-server/src/main/java/org/graylog2/shared/plugins/ChainingClassLoader.java
@@ -1,0 +1,124 @@
+/**
+ * This file is part of Graylog.
+ *
+ * Graylog is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.graylog2.shared.plugins;
+
+import com.google.common.collect.ImmutableList;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URL;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Enumeration;
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
+
+public class ChainingClassLoader extends ClassLoader {
+    public static final Logger LOG = LoggerFactory.getLogger(ChainingClassLoader.class);
+
+    private final List<ClassLoader> classLoaders = new CopyOnWriteArrayList<>();
+
+    public ChainingClassLoader(ClassLoader parent) {
+        classLoaders.add(parent);
+    }
+
+    @Override
+    protected Class<?> loadClass(String name, boolean resolve) throws ClassNotFoundException {
+        Class<?> cls = null;
+        for (ClassLoader classLoader : classLoaders) {
+            try {
+                cls = classLoader.loadClass(name);
+            } catch (ClassNotFoundException e) {
+                LOG.trace("Class " + name + " not found", e);
+            }
+
+            if (cls != null) {
+                break;
+            }
+        }
+
+        if (cls == null) {
+            throw new ClassNotFoundException("Class " + name + " not found.");
+        }
+
+        return cls;
+    }
+
+    @Override
+    public URL getResource(String name) {
+        URL url = null;
+        for (ClassLoader classLoader : classLoaders) {
+            url = classLoader.getResource(name);
+
+            if (url != null) {
+                break;
+            }
+        }
+
+        if (url == null && LOG.isTraceEnabled()) {
+            LOG.trace("Resource " + name + " not found.");
+        }
+
+        return url;
+    }
+
+    @Override
+    public Enumeration<URL> getResources(String name) throws IOException {
+        final List<URL> urls = new ArrayList<>();
+        for (ClassLoader classLoader : classLoaders) {
+            final Enumeration<URL> resources = classLoader.getResources(name);
+
+            if (resources.hasMoreElements()) {
+                urls.addAll(Collections.list(resources));
+            }
+        }
+
+        if (urls.isEmpty() && LOG.isTraceEnabled()) {
+            LOG.trace("Resource " + name + " not found.");
+        }
+
+        return Collections.enumeration(urls);
+    }
+
+    @Override
+    public InputStream getResourceAsStream(String name) {
+        InputStream stream = null;
+        for (ClassLoader classLoader : classLoaders) {
+            stream = classLoader.getResourceAsStream(name);
+
+            if (stream != null) {
+                break;
+            }
+        }
+
+        if (stream == null && LOG.isTraceEnabled()) {
+            LOG.trace("Resource " + name + " not found.");
+        }
+
+        return stream;
+    }
+
+    public List<ClassLoader> getClassLoaders() {
+        return ImmutableList.copyOf(classLoaders);
+    }
+
+    public boolean addClassLoader(ClassLoader classLoader) {
+        return classLoaders.add(classLoader);
+    }
+}

--- a/graylog2-server/src/main/java/org/graylog2/shared/plugins/GraylogClassLoader.java
+++ b/graylog2-server/src/main/java/org/graylog2/shared/plugins/GraylogClassLoader.java
@@ -1,0 +1,29 @@
+/**
+ * This file is part of Graylog.
+ *
+ * Graylog is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.graylog2.shared.plugins;
+
+import javax.inject.Qualifier;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.PARAMETER)
+@Qualifier
+public @interface GraylogClassLoader {
+}

--- a/graylog2-server/src/test/java/org/graylog2/shared/plugins/ChainingClassLoaderTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/shared/plugins/ChainingClassLoaderTest.java
@@ -1,0 +1,169 @@
+/**
+ * This file is part of Graylog.
+ *
+ * Graylog is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.graylog2.shared.plugins;
+
+import edu.emory.mathcs.backport.java.util.Collections;
+import org.junit.Test;
+
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
+import java.net.URL;
+import java.net.URLClassLoader;
+import java.nio.charset.StandardCharsets;
+import java.time.Instant;
+import java.util.Enumeration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class ChainingClassLoaderTest {
+    @Test(expected = ClassNotFoundException.class)
+    public void loadThrowsClassNotFoundExceptionIfClassDoesNotExist() throws Exception {
+        final ChainingClassLoader chainingClassLoader = new ChainingClassLoader(getClass().getClassLoader());
+        chainingClassLoader.loadClass("ThisClassHopeFullyDoesNotExist" + Instant.now().toEpochMilli());
+    }
+
+    @Test
+    public void loadReturnsClassFromParentClassLoader() throws Exception {
+        final ClassLoader parent = getClass().getClassLoader();
+        final ChainingClassLoader chainingClassLoader = new ChainingClassLoader(parent);
+        final String className = "org.graylog2.shared.plugins.ChainingClassLoaderTest$Dummy";
+        final Class<?> aClass = chainingClassLoader.loadClass(className);
+
+        assertThat(aClass).isNotNull();
+        assertThat(aClass.getSimpleName()).isEqualTo("Dummy");
+        assertThat(aClass.getClassLoader()).isSameAs(parent);
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    public void loadReturnsClassFromChildClassLoader() throws Exception {
+        final String className = "com.example.this.class.does.not.exist.Cls";
+        final ClassLoader parent = getClass().getClassLoader();
+        final ClassLoader child = mock(ClassLoader.class);
+        final Class<Dummy> dummyClass = Dummy.class;
+        when(child.loadClass(className)).thenReturn((Class) dummyClass);
+
+        final ChainingClassLoader chainingClassLoader = new ChainingClassLoader(parent);
+        chainingClassLoader.addClassLoader(child);
+
+        assertThat(chainingClassLoader.getClassLoaders())
+                .hasSize(2)
+                .containsExactly(parent, child);
+
+        final Class<?> aClass = chainingClassLoader.loadClass(className);
+        assertThat(aClass).isNotNull();
+        assertThat(aClass).isSameAs(dummyClass);
+    }
+
+    @Test
+    public void getResourceAsStreamReturnsNullIfResourceDoesNotExist() throws Exception {
+        final ChainingClassLoader chainingClassLoader = new ChainingClassLoader(getClass().getClassLoader());
+        final InputStream stream = chainingClassLoader.getResourceAsStream("ThisClassHopeFullyDoesNotExist" + Instant.now().toEpochMilli());
+        assertThat(stream).isNull();
+    }
+
+    @Test
+    public void getResourceAsStreamReturnsStreamFromChildClassLoader() throws Exception {
+        final ClassLoader parent = getClass().getClassLoader();
+        final ClassLoader child = mock(ClassLoader.class);
+        final ByteArrayInputStream inputStream = new ByteArrayInputStream("foobar".getBytes(StandardCharsets.UTF_8));
+        when(child.getResourceAsStream("name")).thenReturn(inputStream);
+
+        final ChainingClassLoader chainingClassLoader = new ChainingClassLoader(parent);
+        chainingClassLoader.addClassLoader(child);
+
+        final InputStream stream = chainingClassLoader.getResourceAsStream("name");
+        final ByteArrayInputStream expected = new ByteArrayInputStream("foobar".getBytes(StandardCharsets.UTF_8));
+        assertThat(stream).hasSameContentAs(expected);
+    }
+
+    @Test
+    public void getResourceReturnsNullIfResourceDoesNotExist() throws Exception {
+        final ChainingClassLoader chainingClassLoader = new ChainingClassLoader(getClass().getClassLoader());
+        final URL resource = chainingClassLoader.getResource("ThisClassHopeFullyDoesNotExist" + Instant.now().toEpochMilli());
+        assertThat(resource).isNull();
+    }
+
+    @Test
+    public void getResourceReturnsURLFromChildClassLoader() throws Exception {
+        final ClassLoader parent = getClass().getClassLoader();
+        final ClassLoader child = mock(ClassLoader.class);
+        final URL url = new URL("file://test");
+        when(child.getResource("name")).thenReturn(url);
+
+        final ChainingClassLoader chainingClassLoader = new ChainingClassLoader(parent);
+        chainingClassLoader.addClassLoader(child);
+
+        final URL resource = chainingClassLoader.getResource("name");
+        assertThat(resource).isEqualTo(url);
+    }
+
+    @Test
+    public void getResourcesReturnsEmptyEnumerationIfResourceDoesNotExist() throws Exception {
+        final ChainingClassLoader chainingClassLoader = new ChainingClassLoader(getClass().getClassLoader());
+        final Enumeration<URL> resources = chainingClassLoader.getResources("ThisClassHopeFullyDoesNotExist" + Instant.now().toEpochMilli());
+        assertThat(resources.hasMoreElements()).isFalse();
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    public void getResourcesReturnsEnumerationFromChildClassLoader() throws Exception {
+        final ClassLoader parent = getClass().getClassLoader();
+        final ClassLoader child = mock(ClassLoader.class);
+        final Enumeration<URL> urls = Collections.enumeration(Collections.singleton(new URL("file://test")));
+        when(child.getResources("name")).thenReturn(urls);
+
+        final ChainingClassLoader chainingClassLoader = new ChainingClassLoader(parent);
+        chainingClassLoader.addClassLoader(child);
+
+        final Enumeration<URL> resources = chainingClassLoader.getResources("name");
+        assertThat(Collections.list(resources)).containsExactly(new URL("file://test"));
+    }
+
+    @Test
+    public void getClassLoadersReturnsListOfClassLoaders() throws Exception {
+        final ClassLoader parent = getClass().getClassLoader();
+        final ClassLoader child = new URLClassLoader(new URL[0], parent);
+        final ChainingClassLoader chainingClassLoader = new ChainingClassLoader(parent);
+        chainingClassLoader.addClassLoader(child);
+
+        assertThat(chainingClassLoader.getClassLoaders())
+                .hasSize(2)
+                .containsExactly(parent, child);
+    }
+
+    @Test
+    public void addClassLoaderAddsClassLoaderToList() throws Exception {
+        final ClassLoader parent = getClass().getClassLoader();
+        final ClassLoader child = new URLClassLoader(new URL[0], parent);
+        final ChainingClassLoader chainingClassLoader = new ChainingClassLoader(parent);
+        assertThat(chainingClassLoader.getClassLoaders())
+                .hasSize(1)
+                .containsExactly(parent);
+
+        chainingClassLoader.addClassLoader(child);
+
+        assertThat(chainingClassLoader.getClassLoaders())
+                .hasSize(2)
+                .containsExactly(parent, child);
+    }
+
+    public static final class Dummy {
+    }
+}


### PR DESCRIPTION
In order to use [polymorphic deserialization with Jackson](http://wiki.fasterxml.com/JacksonPolymorphicDeserialization), the `ObjectMapper` must be able to access the classes loaded from plugins which live in their own class loaders.

The `ChainingClassLoader` class loader implementation queries all registered class loaders sequentially until the class/resource has been found in one of the child class loaders.