### PR TITLE
Improvements in proxied resources

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/rest/resources/cluster/ClusterInputStatesResource.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/resources/cluster/ClusterInputStatesResource.java
@@ -96,7 +96,7 @@ public class ClusterInputStatesResource extends ProxiedResource {
                             LOG.warn("Unable to fetch input states from node {}: {}", entry.getKey(), response.message());
                         }
                     } catch (IOException e) {
-                        LOG.warn("Unable to fetch input states from node {}: {}", entry.getKey(), e);
+                        LOG.warn("Unable to fetch input states from node {}:", entry.getKey(), e);
                     }
                     return Collections.emptySet();
                 }));
@@ -126,7 +126,7 @@ public class ClusterInputStatesResource extends ProxiedResource {
                             LOG.warn("Unable to start input on node {}: {}", entry.getKey(), response.message());
                         }
                     } catch (IOException e) {
-                        LOG.warn("Unable to start input on node {}: {}",entry.getKey(), e);
+                        LOG.warn("Unable to start input on node {}:",entry.getKey(), e);
                     }
                     return Optional.absent();
                 }));
@@ -156,7 +156,7 @@ public class ClusterInputStatesResource extends ProxiedResource {
                             LOG.warn("Unable to stop input on node {}: {}", entry.getKey(), response.message());
                         }
                     } catch (IOException e) {
-                        LOG.warn("Unable to stop input on node {}: {}", entry.getKey(), e);
+                        LOG.warn("Unable to stop input on node {}:", entry.getKey(), e);
                     }
                     return Optional.absent();
                 }));

--- a/graylog2-server/src/main/java/org/graylog2/rest/resources/cluster/ClusterInputStatesResource.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/resources/cluster/ClusterInputStatesResource.java
@@ -34,6 +34,7 @@ import org.graylog2.rest.models.system.inputs.responses.InputDeleted;
 import org.graylog2.rest.models.system.inputs.responses.InputStateSummary;
 import org.graylog2.rest.models.system.inputs.responses.InputStatesList;
 import org.graylog2.rest.resources.system.inputs.RemoteInputStatesResource;
+import org.graylog2.shared.rest.resources.ProxiedResource;
 import org.graylog2.shared.security.RestPermissions;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -51,7 +52,6 @@ import javax.ws.rs.core.HttpHeaders;
 import javax.ws.rs.core.MediaType;
 import java.io.IOException;
 import java.util.Collections;
-import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -60,26 +60,19 @@ import java.util.stream.Collectors;
 @Api(value = "Cluster/InputState", description = "Cluster-wide input states")
 @Path("/cluster/inputstates")
 @Produces(MediaType.APPLICATION_JSON)
-public class ClusterInputStatesResource {
+public class ClusterInputStatesResource extends ProxiedResource {
     private static final Logger LOG = LoggerFactory.getLogger(ClusterInputStatesResource.class);
 
     private final NodeService nodeService;
     private final RemoteInterfaceProvider remoteInterfaceProvider;
-    private final String authenticationToken;
 
     @Inject
     public ClusterInputStatesResource(NodeService nodeService,
                                       RemoteInterfaceProvider remoteInterfaceProvider,
                                       @Context HttpHeaders httpHeaders) throws NodeNotFoundException {
+        super(httpHeaders);
         this.nodeService = nodeService;
         this.remoteInterfaceProvider = remoteInterfaceProvider;
-
-        final List<String> authenticationTokens = httpHeaders.getRequestHeader("Authorization");
-        if (authenticationTokens != null && authenticationTokens.size() >= 1) {
-            this.authenticationToken = authenticationTokens.get(0);
-        } else {
-            this.authenticationToken = null;
-        }
     }
 
     @GET

--- a/graylog2-server/src/main/java/org/graylog2/rest/resources/cluster/ClusterInputStatesResource.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/resources/cluster/ClusterInputStatesResource.java
@@ -93,10 +93,10 @@ public class ClusterInputStatesResource extends ProxiedResource {
                         if (response.isSuccess()) {
                             return response.body().states();
                         } else {
-                            LOG.warn("Unable to fetch input states from node " + entry.getKey() + ": " + response.message());
+                            LOG.warn("Unable to fetch input states from node {}: {}", entry.getKey(), response.message());
                         }
                     } catch (IOException e) {
-                        LOG.warn("Unable to fetch input states from node " + entry.getKey() + ": ", e);
+                        LOG.warn("Unable to fetch input states from node {}: {}", entry.getKey(), e);
                     }
                     return Collections.emptySet();
                 }));
@@ -123,10 +123,10 @@ public class ClusterInputStatesResource extends ProxiedResource {
                         if (response.isSuccess()) {
                             return Optional.of(response.body());
                         } else {
-                            LOG.warn("Unable to start input on node " + entry.getKey() + ": " + response.message());
+                            LOG.warn("Unable to start input on node {}: {}", entry.getKey(), response.message());
                         }
                     } catch (IOException e) {
-                        LOG.warn("Unable to start input on node " + entry.getKey() + ": ", e);
+                        LOG.warn("Unable to start input on node {}: {}",entry.getKey(), e);
                     }
                     return Optional.absent();
                 }));
@@ -153,10 +153,10 @@ public class ClusterInputStatesResource extends ProxiedResource {
                         if (response.isSuccess()) {
                             return Optional.of(response.body());
                         } else {
-                            LOG.warn("Unable to stop input on node " + entry.getKey() + ": " + response.message());
+                            LOG.warn("Unable to stop input on node {}: {}", entry.getKey(), response.message());
                         }
                     } catch (IOException e) {
-                        LOG.warn("Unable to stop input on node " + entry.getKey() + ": ", e);
+                        LOG.warn("Unable to stop input on node {}: {}", entry.getKey(), e);
                     }
                     return Optional.absent();
                 }));

--- a/graylog2-server/src/main/java/org/graylog2/rest/resources/cluster/ClusterLoadBalancerStatusResource.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/resources/cluster/ClusterLoadBalancerStatusResource.java
@@ -39,10 +39,13 @@ import javax.ws.rs.PUT;
 import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
 import javax.ws.rs.Produces;
+import javax.ws.rs.WebApplicationException;
 import javax.ws.rs.core.Context;
 import javax.ws.rs.core.HttpHeaders;
 import javax.ws.rs.core.MediaType;
 import java.io.IOException;
+
+import static javax.ws.rs.core.Response.Status.BAD_GATEWAY;
 
 @RequiresAuthentication
 @Api(value = "Cluster/LoadBalancers", description = "Cluster-wide status propagation for LB")
@@ -80,7 +83,8 @@ public class ClusterLoadBalancerStatusResource extends ProxiedResource {
                 RemoteLoadBalancerStatusResource.class);
         final Response response = remoteLoadBalancerStatusResource.override(status).execute();
         if (!response.isSuccess()) {
-            LOG.warn("Unable to override load balancer status on node " + nodeId + ": " + response.message());
+            LOG.warn("Unable to override load balancer status on node {}: {}", nodeId, response.message());
+            throw new WebApplicationException(response.message(), BAD_GATEWAY);
         }
     }
 }

--- a/graylog2-server/src/main/java/org/graylog2/rest/resources/cluster/ClusterMetricsResource.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/resources/cluster/ClusterMetricsResource.java
@@ -50,6 +50,8 @@ import javax.ws.rs.core.HttpHeaders;
 import javax.ws.rs.core.MediaType;
 import java.io.IOException;
 
+import static javax.ws.rs.core.Response.Status.BAD_GATEWAY;
+
 @RequiresAuthentication
 @Api(value = "Cluster/Metrics", description = "Cluster-wide Internal Graylog metrics")
 @Path("/cluster/{nodeId}/metrics")
@@ -83,7 +85,7 @@ public class ClusterMetricsResource extends ProxiedResource {
         if (result.isSuccess()) {
             return result.body();
         } else {
-            throw new WebApplicationException(result.message(), 503);
+            throw new WebApplicationException(result.message(), BAD_GATEWAY);
         }
     }
 
@@ -102,7 +104,7 @@ public class ClusterMetricsResource extends ProxiedResource {
         if (result.isSuccess()) {
             return result.body();
         } else {
-            throw new WebApplicationException(result.message(), result.code());
+            throw new WebApplicationException(result.message(), BAD_GATEWAY);
         }
     }
 
@@ -121,7 +123,7 @@ public class ClusterMetricsResource extends ProxiedResource {
         if (result.isSuccess()) {
             return result.body();
         } else {
-            throw new WebApplicationException(result.message(), result.code());
+            throw new WebApplicationException(result.message(), BAD_GATEWAY);
         }
     }
 }

--- a/graylog2-server/src/main/java/org/graylog2/rest/resources/cluster/ClusterMetricsResource.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/resources/cluster/ClusterMetricsResource.java
@@ -31,7 +31,7 @@ import org.graylog2.rest.RemoteInterfaceProvider;
 import org.graylog2.rest.models.system.metrics.requests.MetricsReadRequest;
 import org.graylog2.rest.models.system.metrics.responses.MetricNamesResponse;
 import org.graylog2.rest.models.system.metrics.responses.MetricsSummaryResponse;
-import org.graylog2.shared.rest.resources.RestResource;
+import org.graylog2.shared.rest.resources.ProxiedResource;
 import org.graylog2.shared.rest.resources.system.RemoteMetricsResource;
 import org.graylog2.shared.security.RestPermissions;
 import retrofit2.Response;
@@ -49,32 +49,27 @@ import javax.ws.rs.core.Context;
 import javax.ws.rs.core.HttpHeaders;
 import javax.ws.rs.core.MediaType;
 import java.io.IOException;
-import java.util.List;
 
 @RequiresAuthentication
 @Api(value = "Cluster/Metrics", description = "Cluster-wide Internal Graylog metrics")
 @Path("/cluster/{nodeId}/metrics")
 @Produces(MediaType.APPLICATION_JSON)
-public class ClusterMetricsResource extends RestResource {
+public class ClusterMetricsResource extends ProxiedResource {
     private final NodeService nodeService;
     private final RemoteInterfaceProvider remoteInterfaceProvider;
 
     @Inject
     public ClusterMetricsResource(NodeService nodeService,
-                                  RemoteInterfaceProvider remoteInterfaceProvider) {
+                                  RemoteInterfaceProvider remoteInterfaceProvider,
+                                  @Context HttpHeaders httpHeaders) {
+        super(httpHeaders);
         this.nodeService = nodeService;
         this.remoteInterfaceProvider = remoteInterfaceProvider;
     }
 
-    private RemoteMetricsResource getResourceForNode(String nodeId, HttpHeaders httpHeaders) throws NodeNotFoundException {
+    private RemoteMetricsResource getResourceForNode(String nodeId) throws NodeNotFoundException {
         final Node targetNode = nodeService.byNodeId(nodeId);
-
-        final List<String> authenticationTokens = httpHeaders.getRequestHeader("Authorization");
-        if (authenticationTokens != null && authenticationTokens.size() >= 1) {
-            return remoteInterfaceProvider.get(targetNode, authenticationTokens.get(0), RemoteMetricsResource.class);
-        } else {
-            return remoteInterfaceProvider.get(targetNode, RemoteMetricsResource.class);
-        }
+        return remoteInterfaceProvider.get(targetNode, this.authenticationToken, RemoteMetricsResource.class);
     }
 
     @GET
@@ -83,9 +78,8 @@ public class ClusterMetricsResource extends RestResource {
     @ApiOperation(value = "Get all metrics keys/names from node")
     @RequiresPermissions(RestPermissions.METRICS_ALLKEYS)
     public MetricNamesResponse metricNames(@ApiParam(name = "nodeId", value = "The id of the node whose metrics we want.", required = true)
-                                           @PathParam("nodeId") String nodeId,
-                                           @Context HttpHeaders httpHeaders) throws IOException, NodeNotFoundException {
-        final Response<MetricNamesResponse> result = getResourceForNode(nodeId, httpHeaders).metricNames().execute();
+                                           @PathParam("nodeId") String nodeId) throws IOException, NodeNotFoundException {
+        final Response<MetricNamesResponse> result = getResourceForNode(nodeId).metricNames().execute();
         if (result.isSuccess()) {
             return result.body();
         } else {
@@ -103,9 +97,8 @@ public class ClusterMetricsResource extends RestResource {
     public MetricsSummaryResponse multipleMetrics(@ApiParam(name = "nodeId", value = "The id of the node whose metrics we want.", required = true)
                                                   @PathParam("nodeId") String nodeId,
                                                   @ApiParam(name = "Requested metrics", required = true)
-                                                  @Valid @NotNull MetricsReadRequest request,
-                                                  @Context HttpHeaders httpHeaders) throws IOException, NodeNotFoundException {
-        final Response<MetricsSummaryResponse> result = getResourceForNode(nodeId, httpHeaders).multipleMetrics(request).execute();
+                                                  @Valid @NotNull MetricsReadRequest request) throws IOException, NodeNotFoundException {
+        final Response<MetricsSummaryResponse> result = getResourceForNode(nodeId).multipleMetrics(request).execute();
         if (result.isSuccess()) {
             return result.body();
         } else {
@@ -123,9 +116,8 @@ public class ClusterMetricsResource extends RestResource {
     public MetricsSummaryResponse byNamespace(@ApiParam(name = "nodeId", value = "The id of the node whose metrics we want.", required = true)
                                               @PathParam("nodeId") String nodeId,
                                               @ApiParam(name = "namespace", required = true)
-                                              @PathParam("namespace") String namespace,
-                                              @Context HttpHeaders httpHeaders) throws IOException, NodeNotFoundException {
-        final Response<MetricsSummaryResponse> result = getResourceForNode(nodeId, httpHeaders).byNamespace(namespace).execute();
+                                              @PathParam("namespace") String namespace) throws IOException, NodeNotFoundException {
+        final Response<MetricsSummaryResponse> result = getResourceForNode(nodeId).byNamespace(namespace).execute();
         if (result.isSuccess()) {
             return result.body();
         } else {

--- a/graylog2-server/src/main/java/org/graylog2/rest/resources/cluster/ClusterSystemJobResource.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/resources/cluster/ClusterSystemJobResource.java
@@ -81,7 +81,7 @@ public class ClusterSystemJobResource extends ProxiedResource {
                     LOG.warn("Unable to fetch system jobs from node {}: {}", entry.getKey(), response);
                 }
             } catch (IOException e) {
-                LOG.warn("Unable to fetch system jobs from node {}: {}", entry.getKey(), e);
+                LOG.warn("Unable to fetch system jobs from node {}:", entry.getKey(), e);
             }
         });
 
@@ -105,7 +105,7 @@ public class ClusterSystemJobResource extends ProxiedResource {
                     LOG.warn("Unable to fetch system job {} from node {}: {}", jobId, entry.getKey(), response);
                 }
             } catch (IOException e) {
-                LOG.warn("Unable to fetch system jobs from node {}: {}", entry.getKey(), e);
+                LOG.warn("Unable to fetch system jobs from node {}:", entry.getKey(), e);
             }
         }
 

--- a/graylog2-server/src/main/java/org/graylog2/rest/resources/cluster/ClusterSystemJobResource.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/resources/cluster/ClusterSystemJobResource.java
@@ -27,7 +27,7 @@ import org.graylog2.cluster.NodeService;
 import org.graylog2.rest.RemoteInterfaceProvider;
 import org.graylog2.rest.models.system.SystemJobSummary;
 import org.graylog2.rest.resources.system.jobs.RemoteSystemJobResource;
-import org.graylog2.shared.rest.resources.RestResource;
+import org.graylog2.shared.rest.resources.ProxiedResource;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import retrofit2.Response;
@@ -49,26 +49,19 @@ import java.util.Map;
 @RequiresAuthentication
 @Api(value = "Cluster/Jobs", description = "Cluster-wide System Jobs")
 @Path("/cluster/jobs")
-public class ClusterSystemJobResource extends RestResource {
+public class ClusterSystemJobResource extends ProxiedResource {
     private static final Logger LOG = LoggerFactory.getLogger(ClusterSystemJobResource.class);
 
     private final NodeService nodeService;
     private final RemoteInterfaceProvider remoteInterfaceProvider;
-    private final String authenticationToken;
 
     @Inject
     public ClusterSystemJobResource(NodeService nodeService,
                                     RemoteInterfaceProvider remoteInterfaceProvider,
                                     @Context HttpHeaders httpHeaders) throws NodeNotFoundException {
+        super(httpHeaders);
         this.nodeService = nodeService;
         this.remoteInterfaceProvider = remoteInterfaceProvider;
-
-        final List<String> authenticationTokens = httpHeaders.getRequestHeader("Authorization");
-        if (authenticationTokens != null && authenticationTokens.size() >= 1) {
-            this.authenticationToken = authenticationTokens.get(0);
-        } else {
-            this.authenticationToken = null;
-        }
     }
 
     @GET

--- a/graylog2-server/src/main/java/org/graylog2/rest/resources/cluster/ClusterSystemJobResource.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/resources/cluster/ClusterSystemJobResource.java
@@ -78,10 +78,10 @@ public class ClusterSystemJobResource extends ProxiedResource {
                 if (response.isSuccess()) {
                     result.put(entry.getKey(), response.body());
                 } else {
-                    LOG.warn("Unable to fetch system jobs from node " + entry.getKey() + ": " + response);
+                    LOG.warn("Unable to fetch system jobs from node {}: {}", entry.getKey(), response);
                 }
             } catch (IOException e) {
-                LOG.warn("Unable to fetch system jobs from node " + entry.getKey() + ": ", e);
+                LOG.warn("Unable to fetch system jobs from node {}: {}", entry.getKey(), e);
             }
         });
 
@@ -102,10 +102,10 @@ public class ClusterSystemJobResource extends ProxiedResource {
                     // Return early because there can be only one job with the same ID in the cluster.
                     return response.body();
                 } else {
-                    LOG.warn("Unable to fetch system job " + jobId + " from node " + entry.getKey() + ": " + response);
+                    LOG.warn("Unable to fetch system job {} from node {}: {}", jobId, entry.getKey(), response);
                 }
             } catch (IOException e) {
-                LOG.warn("Unable to fetch system jobs from node " + entry.getKey() + ": ", e);
+                LOG.warn("Unable to fetch system jobs from node {}: {}", entry.getKey(), e);
             }
         }
 

--- a/graylog2-server/src/main/java/org/graylog2/rest/resources/cluster/ClusterSystemPluginResource.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/resources/cluster/ClusterSystemPluginResource.java
@@ -38,10 +38,13 @@ import javax.ws.rs.GET;
 import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
 import javax.ws.rs.Produces;
+import javax.ws.rs.WebApplicationException;
 import javax.ws.rs.core.Context;
 import javax.ws.rs.core.HttpHeaders;
 import javax.ws.rs.core.MediaType;
 import java.io.IOException;
+
+import static javax.ws.rs.core.Response.Status.BAD_GATEWAY;
 
 @RequiresAuthentication
 @Api(value = "Cluster/Plugins", description = "Plugin information for any node in the cluster")
@@ -76,9 +79,8 @@ public class ClusterSystemPluginResource extends ProxiedResource {
         if (response.isSuccess()) {
             return response.body();
         } else {
-            LOG.warn("Unable to get plugin list on node " + nodeId + ": " + response.message());
+            LOG.warn("Unable to get plugin list on node {}: {}", nodeId, response.message());
+            throw new WebApplicationException(response.message(), BAD_GATEWAY);
         }
-
-        return null;
     }
 }

--- a/graylog2-server/src/main/java/org/graylog2/rest/resources/cluster/ClusterSystemProcessingResource.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/resources/cluster/ClusterSystemProcessingResource.java
@@ -37,10 +37,13 @@ import javax.ws.rs.POST;
 import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
 import javax.ws.rs.Produces;
+import javax.ws.rs.WebApplicationException;
 import javax.ws.rs.core.Context;
 import javax.ws.rs.core.HttpHeaders;
 import javax.ws.rs.core.MediaType;
 import java.io.IOException;
+
+import static javax.ws.rs.core.Response.Status.BAD_GATEWAY;
 
 @RequiresAuthentication
 @Api(value = "Cluster/Processing", description = "Cluster-wide processing status control.")
@@ -79,7 +82,8 @@ public class ClusterSystemProcessingResource extends ProxiedResource {
                       @PathParam("nodeId") String nodeId) throws IOException, NodeNotFoundException {
         final Response response = this.getRemoteSystemProcessingResource(nodeId).pause().execute();
         if (!response.isSuccess()) {
-            LOG.warn("Unable to pause message processing on node " + nodeId + ": " + response.message());
+            LOG.warn("Unable to pause message processing on node {}: {}", nodeId, response.message());
+            throw new WebApplicationException(response.message(), BAD_GATEWAY);
         }
     }
 
@@ -91,7 +95,8 @@ public class ClusterSystemProcessingResource extends ProxiedResource {
                        @PathParam("nodeId") String nodeId) throws IOException, NodeNotFoundException {
         final Response response = this.getRemoteSystemProcessingResource(nodeId).resume().execute();
         if (!response.isSuccess()) {
-            LOG.warn("Unable to resume message processing on node " + nodeId + ": " + response.message());
+            LOG.warn("Unable to resume message processing on node {}: {}", nodeId, response.message());
+            throw new WebApplicationException(response.message(), BAD_GATEWAY);
         }
     }
 }

--- a/graylog2-server/src/main/java/org/graylog2/rest/resources/cluster/ClusterSystemResource.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/resources/cluster/ClusterSystemResource.java
@@ -92,7 +92,7 @@ public class ClusterSystemResource extends ProxiedResource {
                             LOG.warn("Unable to fetch system overview from node {}: {}", entry.getKey(), response.message());
                         }
                     } catch (IOException e) {
-                        LOG.warn("Unable to fetch system overview from node {}: {}", entry.getKey(), e);
+                        LOG.warn("Unable to fetch system overview from node {}:", entry.getKey(), e);
                     }
                     return Optional.absent();
                 }));

--- a/graylog2-server/src/main/java/org/graylog2/rest/resources/cluster/ClusterSystemResource.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/resources/cluster/ClusterSystemResource.java
@@ -43,12 +43,15 @@ import javax.ws.rs.GET;
 import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
 import javax.ws.rs.Produces;
+import javax.ws.rs.WebApplicationException;
 import javax.ws.rs.core.Context;
 import javax.ws.rs.core.HttpHeaders;
 import javax.ws.rs.core.MediaType;
 import java.io.IOException;
 import java.util.Map;
 import java.util.stream.Collectors;
+
+import static javax.ws.rs.core.Response.Status.BAD_GATEWAY;
 
 @RequiresAuthentication
 @Api(value = "Cluster", description = "System information of all nodes in the cluster")
@@ -86,10 +89,10 @@ public class ClusterSystemResource extends ProxiedResource {
                         if (response.isSuccess()) {
                             return Optional.of(response.body());
                         } else {
-                            LOG.warn("Unable to fetch system overview from node " + entry.getKey() + ": " + response.message());
+                            LOG.warn("Unable to fetch system overview from node {}: {}", entry.getKey(), response.message());
                         }
                     } catch (IOException e) {
-                        LOG.warn("Unable to fetch system overview from node " + entry.getKey() + ": ", e);
+                        LOG.warn("Unable to fetch system overview from node {}: {}", entry.getKey(), e);
                     }
                     return Optional.absent();
                 }));
@@ -110,10 +113,9 @@ public class ClusterSystemResource extends ProxiedResource {
         if (response.isSuccess()) {
             return response.body();
         } else {
-            LOG.warn("Unable to get jvm information on node " + nodeId + ": " + response.message());
+            LOG.warn("Unable to get jvm information on node {}: {}", nodeId, response.message());
+            throw new WebApplicationException(response.message(), BAD_GATEWAY);
         }
-
-        return null;
     }
 
     @GET
@@ -132,10 +134,9 @@ public class ClusterSystemResource extends ProxiedResource {
         if (response.isSuccess()) {
             return response.body();
         } else {
-            LOG.warn("Unable to get thread dump on node " + nodeId + ": " + response.message());
+            LOG.warn("Unable to get thread dump on node {}: {}", nodeId, response.message());
+            throw new WebApplicationException(response.message(), BAD_GATEWAY);
         }
-
-        return null;
     }
 }
 

--- a/graylog2-server/src/main/java/org/graylog2/rest/resources/cluster/ClusterSystemShutdownResource.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/resources/cluster/ClusterSystemShutdownResource.java
@@ -37,11 +37,13 @@ import javax.ws.rs.POST;
 import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
 import javax.ws.rs.Produces;
+import javax.ws.rs.WebApplicationException;
 import javax.ws.rs.core.Context;
 import javax.ws.rs.core.HttpHeaders;
 import javax.ws.rs.core.MediaType;
 import java.io.IOException;
 
+import static javax.ws.rs.core.Response.Status.BAD_GATEWAY;
 import static org.jboss.netty.handler.codec.http.HttpResponseStatus.ACCEPTED;
 
 @RequiresAuthentication
@@ -77,7 +79,8 @@ public class ClusterSystemShutdownResource extends ProxiedResource {
                 RemoteSystemShutdownResource.class);
         final Response response = remoteSystemShutdownResource.shutdown().execute();
         if (response.code() != ACCEPTED.getCode()) {
-            LOG.warn("Unable send shut down signal to node " + nodeId + ": " + response.message());
+            LOG.warn("Unable send shut down signal to node {}: {}", nodeId, response.message());
+            throw new WebApplicationException(response.message(), BAD_GATEWAY);
         }
     }
 }

--- a/graylog2-server/src/main/java/org/graylog2/shared/rest/resources/ProxiedResource.java
+++ b/graylog2-server/src/main/java/org/graylog2/shared/rest/resources/ProxiedResource.java
@@ -21,7 +21,7 @@ import javax.ws.rs.core.Context;
 import javax.ws.rs.core.HttpHeaders;
 import java.util.List;
 
-public abstract class ProxiedResource {
+public abstract class ProxiedResource extends RestResource {
     protected final String authenticationToken;
 
     public ProxiedResource(@Context HttpHeaders httpHeaders) {


### PR DESCRIPTION
Fix some of the issues seen on proxied resources:

- `ProxiedResource` class extends now `RestResource` to provide common functionality available in other REST resources
- Ensure all proxied resources inherit from `ProxiedResource`
- Throw `WebApplicationException` when accessing a resource in another node, and its response is not successful