### PR TITLE
Rename "server_id" attribute to "node_id" in /system

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/rest/models/system/responses/SystemOverviewResponse.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/models/system/responses/SystemOverviewResponse.java
@@ -29,7 +29,7 @@ public abstract class SystemOverviewResponse {
     @JsonProperty
     public abstract String codename();
     @JsonProperty
-    public abstract String serverId();
+    public abstract String nodeId();
     @JsonProperty
     public abstract String clusterId();
     @JsonProperty
@@ -52,7 +52,7 @@ public abstract class SystemOverviewResponse {
     @JsonCreator
     public static SystemOverviewResponse create(@JsonProperty("facility") String facility,
                                                 @JsonProperty("codename") String codename,
-                                                @JsonProperty("server_id") String serverId,
+                                                @JsonProperty("node_id") String nodeId,
                                                 @JsonProperty("cluster_id") String clusterId,
                                                 @JsonProperty("version") String version,
                                                 @JsonProperty("started_at") String startedAt,
@@ -62,6 +62,6 @@ public abstract class SystemOverviewResponse {
                                                 @JsonProperty("lb_status") String lbStatis,
                                                 @JsonProperty("timezone") String timezone,
                                                 @JsonProperty("operating_system") String operatingSystem) {
-        return new AutoValue_SystemOverviewResponse(facility, codename, serverId, clusterId, version, startedAt, isProcessing, hostname, lifecycle, lbStatis, timezone, operatingSystem);
+        return new AutoValue_SystemOverviewResponse(facility, codename, nodeId, clusterId, version, startedAt, isProcessing, hostname, lifecycle, lbStatis, timezone, operatingSystem);
     }
 }

--- a/integration-tests/src/test/java/integration/system/SystemTest.java
+++ b/integration-tests/src/test/java/integration/system/SystemTest.java
@@ -39,8 +39,8 @@ public class SystemTest extends BaseRestTest {
                             "is_processing",
                             "lb_status",
                             "lifecycle",
+                            "node_id",
                             "operating_system",
-                            "server_id",
                             "started_at",
                             "timezone",
                             "version"

--- a/integration-tests/src/test/java/integration/util/graylog/ServerHelper.java
+++ b/integration-tests/src/test/java/integration/util/graylog/ServerHelper.java
@@ -49,7 +49,7 @@ public class ServerHelper {
 
             InputStream inputStream = connection.getInputStream();
             JsonNode json = mapper.readTree(inputStream);
-            return json.get("server_id").toString();
+            return json.get("node_id").toString();
         } catch (IOException e) {
             e.printStackTrace();
         }


### PR DESCRIPTION
For consistency reasons, the `server_id` attribute in the JSON response of the `/system` resource shall be named `node_id`.