### PR TITLE
Show overlay when server connection is not working

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/shared/rest/CORSFilter.java
+++ b/graylog2-server/src/main/java/org/graylog2/shared/rest/CORSFilter.java
@@ -29,7 +29,7 @@ public class CORSFilter implements ContainerRequestFilter, ContainerResponseFilt
     public void filter(ContainerRequestContext requestContext, ContainerResponseContext responseContext) throws IOException {
         // we have already added the necessary headers for OPTIONS requests below
         if (requestContext.getRequest().getMethod().equalsIgnoreCase("options")) {
-            if(Response.Status.Family.familyOf(responseContext.getStatus()) == Response.Status.Family.INFORMATIONAL) {
+            if(Response.Status.Family.familyOf(responseContext.getStatus()) == Response.Status.Family.SUCCESSFUL) {
                 return;
             }
             responseContext.setStatus(Response.Status.NO_CONTENT.getStatusCode());

--- a/graylog2-server/src/main/java/org/graylog2/shared/rest/CORSFilter.java
+++ b/graylog2-server/src/main/java/org/graylog2/shared/rest/CORSFilter.java
@@ -29,7 +29,11 @@ public class CORSFilter implements ContainerRequestFilter, ContainerResponseFilt
     public void filter(ContainerRequestContext requestContext, ContainerResponseContext responseContext) throws IOException {
         // we have already added the necessary headers for OPTIONS requests below
         if (requestContext.getRequest().getMethod().equalsIgnoreCase("options")) {
-            return;
+            if(Response.Status.Family.familyOf(responseContext.getStatus()) == Response.Status.Family.INFORMATIONAL) {
+                return;
+            }
+            responseContext.setStatus(Response.Status.NO_CONTENT.getStatusCode());
+            responseContext.setEntity("");
         }
 
         String origin = requestContext.getHeaders().getFirst("Origin");

--- a/graylog2-web-interface/public/stylesheets/disconnected.less
+++ b/graylog2-web-interface/public/stylesheets/disconnected.less
@@ -44,3 +44,8 @@ body {
 #nodes-box {
     margin-top: 10px;
 }
+
+hr {
+    margin-top: 10px;
+    margin-bottom: 10px;
+}

--- a/graylog2-web-interface/src/actions/sessions/ServerAvailabilityActions.jsx
+++ b/graylog2-web-interface/src/actions/sessions/ServerAvailabilityActions.jsx
@@ -1,0 +1,8 @@
+import Reflux from 'reflux';
+
+const ServerAvailabilityActions = Reflux.createActions([
+  'reportError',
+  'reportSuccess',
+]);
+
+export default ServerAvailabilityActions;

--- a/graylog2-web-interface/src/pages/ServerUnavailablePage.jsx
+++ b/graylog2-web-interface/src/pages/ServerUnavailablePage.jsx
@@ -91,10 +91,11 @@ const ServerUnavailablePage = React.createClass({
           <div>
             <p>
               We are experiencing problems connecting to the Graylog server running on <i>{URLUtils.qualifyUrl('')}</i>.
+              Please verify that the server is healthy and working correctly.
             </p>
             <p>You will be automatically redirected to the previous page once we can connect to the server.</p>
             <p>
-              Please verify that the server is healthy and it is working correctly. Do you need a hand?{' '}
+              Do you need a hand?{' '}
               <a href="https://www.graylog.org/community-support" target="_blank">We can help you</a>.
             </p>
             <div>

--- a/graylog2-web-interface/src/pages/ServerUnavailablePage.jsx
+++ b/graylog2-web-interface/src/pages/ServerUnavailablePage.jsx
@@ -1,0 +1,22 @@
+import React from 'react';
+import { Modal } from 'react-bootstrap';
+
+import URLUtils from 'util/URLUtils';
+
+const ServerUnavailablePage = React.createClass({
+  render() {
+    return (
+      <Modal show>
+        <Modal.Header>
+          <Modal.Title>Server currently unavailable</Modal.Title>
+        </Modal.Header>
+        <Modal.Body>
+          The Graylog server is currenlly not available or returning an invalid response. Please make sure that
+          the server running on <i>{URLUtils.qualifyUrl('')}</i> is working correctly.
+        </Modal.Body>
+      </Modal>
+    );
+  },
+});
+
+export default ServerUnavailablePage;

--- a/graylog2-web-interface/src/pages/ServerUnavailablePage.jsx
+++ b/graylog2-web-interface/src/pages/ServerUnavailablePage.jsx
@@ -1,18 +1,109 @@
 import React from 'react';
-import { Modal } from 'react-bootstrap';
+import { Modal, Well } from 'react-bootstrap';
 
 import URLUtils from 'util/URLUtils';
 
+import disconnectedStyle from '!style/useable!css!less!stylesheets/disconnected.less';
+
 const ServerUnavailablePage = React.createClass({
+  propTypes: {
+    server: React.PropTypes.object,
+  },
+
+  getInitialState() {
+    return {
+      showDetails: false,
+    };
+  },
+
+  componentDidMount() {
+    disconnectedStyle.use();
+  },
+
+  componentWillUnmount() {
+    disconnectedStyle.unuse();
+  },
+
+  _toggleDetails() {
+    this.setState({showDetails: !this.state.showDetails});
+  },
+
+  _formatErrorMessage() {
+    if (!this.state.showDetails) {
+      return null;
+    }
+
+    const noInformationMessage = (
+      <div>
+        <hr/>
+        <p>There is no information available.</p>
+      </div>
+    );
+
+    if (!this.props.server || !this.props.server.error) {
+      return noInformationMessage;
+    }
+
+    const error = this.props.server.error;
+
+    const errorDetails = [];
+    if (error.message) {
+      errorDetails.push(<dt key="error-title">Error message</dt>, <dd key="error-desc">{error.message}</dd>);
+    }
+    if (error.originalError) {
+      errorDetails.push(
+        <dt key="status-code-title">Status code</dt>,
+        <dd key="status-code-desc">{String(error.originalError.status)}</dd>
+      );
+
+      if (typeof error.originalError.toString === 'function') {
+        errorDetails.push(
+          <dt key="full-error-title">Full error message</dt>,
+          <dd key="full-error-desc">{error.originalError.toString()}</dd>
+        );
+      }
+    }
+
+    if (errorDetails.length === 0) {
+      return noInformationMessage;
+    }
+
+    return (
+      <div>
+        <hr style={{marginTop: 10, marginBottom: 10}}/>
+        <p>This is the last response we received from the server:</p>
+        <Well bsSize="small" style={{whiteSpace: 'pre-line'}}>
+          <dl style={{marginBottom: 0}}>
+            {errorDetails}
+          </dl>
+        </Well>
+      </div>
+    );
+  },
+
   render() {
     return (
       <Modal show>
         <Modal.Header>
-          <Modal.Title>Server currently unavailable</Modal.Title>
+          <Modal.Title><i className="fa fa-exclamation-triangle"/> Server currently unavailable</Modal.Title>
         </Modal.Header>
         <Modal.Body>
-          The Graylog server is currenlly not available or returning an invalid response. Please make sure that
-          the server running on <i>{URLUtils.qualifyUrl('')}</i> is working correctly.
+          <div>
+            <p>
+              We are experiencing problems connecting to the Graylog server running on <i>{URLUtils.qualifyUrl('')}</i>.
+            </p>
+            <p>You will be automatically redirected to the previous page once we can connect to the server.</p>
+            <p>
+              Please verify that the server is healthy and it is working correctly. Do you need a hand?{' '}
+              <a href="https://www.graylog.org/community-support" target="_blank">We can help you</a>.
+            </p>
+            <div>
+              <a href="#" onClick={this._toggleDetails}>
+                {this.state.showDetails ? 'Less details' : 'More details'}
+              </a>
+              {this._formatErrorMessage()}
+            </div>
+          </div>
         </Modal.Body>
       </Modal>
     );

--- a/graylog2-web-interface/src/pages/ServerUnavailablePage.jsx
+++ b/graylog2-web-interface/src/pages/ServerUnavailablePage.jsx
@@ -51,15 +51,20 @@ const ServerUnavailablePage = React.createClass({
       errorDetails.push(<dt key="error-title">Error message</dt>, <dd key="error-desc">{error.message}</dd>);
     }
     if (error.originalError) {
+      const originalError = error.originalError;
+      errorDetails.push(
+        <dt key="status-original-request-title">Original Request</dt>,
+        <dd key="status-original-request-content">{String(originalError.method)} {String(originalError.url)}</dd>
+      );
       errorDetails.push(
         <dt key="status-code-title">Status code</dt>,
-        <dd key="status-code-desc">{String(error.originalError.status)}</dd>
+        <dd key="status-code-desc">{String(originalError.status)}</dd>
       );
 
-      if (typeof error.originalError.toString === 'function') {
+      if (typeof originalError.toString === 'function') {
         errorDetails.push(
           <dt key="full-error-title">Full error message</dt>,
-          <dd key="full-error-desc">{error.originalError.toString()}</dd>
+          <dd key="full-error-desc">{originalError.toString()}</dd>
         );
       }
     }

--- a/graylog2-web-interface/src/routing/AppFacade.jsx
+++ b/graylog2-web-interface/src/routing/AppFacade.jsx
@@ -2,7 +2,9 @@ import React from 'react';
 import Reflux from 'reflux';
 import LoginPage from 'react-proxy?name=LoginPage!pages/LoginPage';
 import LoggedInPage from 'react-proxy?name=LoggedInPage!pages/LoggedInPage';
+import ServerUnavailablePage from 'react-proxy?name=ServerUnavailablePage!pages/ServerUnavailablePage';
 import SessionStore from 'stores/sessions/SessionStore';
+import ServerAvailabilityStore from 'stores/sessions/ServerAvailabilityStore';
 
 import 'javascripts/shims/styles/shim.css';
 import 'stylesheets/bootstrap.min.css';
@@ -24,7 +26,7 @@ const AppFacade = React.createClass({
     actionsProvider: React.PropTypes.object,
   },
 
-  mixins: [Reflux.connect(SessionStore)],
+  mixins: [Reflux.connect(SessionStore), Reflux.connect(ServerAvailabilityStore)],
 
   getChildContext() {
     return {
@@ -33,7 +35,20 @@ const AppFacade = React.createClass({
     };
   },
 
+  componentDidMount() {
+    this.interval = setInterval(ServerAvailabilityStore.ping, 20000);
+  },
+
+  componentWillUnmount() {
+    if (this.interval) {
+      clearInterval(this.interval);
+    }
+  },
+
   render() {
+    if (!this.state.server.up) {
+      return <ServerUnavailablePage />;
+    }
     if (!this.state.sessionId) {
       return <LoginPage />;
     }

--- a/graylog2-web-interface/src/routing/AppFacade.jsx
+++ b/graylog2-web-interface/src/routing/AppFacade.jsx
@@ -47,7 +47,7 @@ const AppFacade = React.createClass({
 
   render() {
     if (!this.state.server.up) {
-      return <ServerUnavailablePage />;
+      return <ServerUnavailablePage server={this.state.server} />;
     }
     if (!this.state.sessionId) {
       return <LoginPage />;

--- a/graylog2-web-interface/src/routing/jsRoutes.js
+++ b/graylog2-web-interface/src/routing/jsRoutes.js
@@ -24,6 +24,9 @@ const jsRoutes = {
       CountsApiController: {
         total: () => { return {url: '/count/total'}; },
       },
+      ClusterApiResource: {
+        node: () => { return {url: '/system/cluster/node'}; },
+      },
       DashboardsApiController: {
         create: () => { return {url: '/dashboards' }; },
         index: () => { return {url: '/dashboards' }; },

--- a/graylog2-web-interface/src/stores/sessions/ServerAvailabilityStore.js
+++ b/graylog2-web-interface/src/stores/sessions/ServerAvailabilityStore.js
@@ -24,7 +24,7 @@ const ServerAvailabilityStore = Reflux.createStore({
       (error) => {
         this.server = { up: false, error: error };
         this.trigger({ server: this.server });
-      },
+      }
     );
 
     return promise;

--- a/graylog2-web-interface/src/stores/sessions/ServerAvailabilityStore.js
+++ b/graylog2-web-interface/src/stores/sessions/ServerAvailabilityStore.js
@@ -33,7 +33,7 @@ const ServerAvailabilityStore = Reflux.createStore({
     this.server = { up: false, error: error };
     this.trigger({ server: this.server });
   },
-  reportSucess() {
+  reportSuccess() {
     this.server = { up: true };
     this.trigger({ server: this.server });
   },

--- a/graylog2-web-interface/src/stores/sessions/ServerAvailabilityStore.js
+++ b/graylog2-web-interface/src/stores/sessions/ServerAvailabilityStore.js
@@ -1,0 +1,42 @@
+import Reflux from 'reflux';
+
+import URLUtils from 'util/URLUtils';
+import jsRoutes from 'routing/jsRoutes';
+import { Builder } from 'logic/rest/FetchProvider';
+
+import ServerAvailabilityActions from 'actions/sessions/ServerAvailabilityActions';
+
+const ServerAvailabilityStore = Reflux.createStore({
+  listenables: [ServerAvailabilityActions],
+  server: { up: true },
+  init() {
+    this.ping();
+  },
+  getInitialState() {
+    return { server: this.server };
+  },
+  ping() {
+    const promise = new Builder('GET', URLUtils.qualifyUrl(jsRoutes.controllers.api.ClusterApiResource.node().url)).build().then(
+      () => {
+        this.server = {up: true};
+        this.trigger({ server: this.server });
+      },
+      (error) => {
+        this.server = { up: false, error: error };
+        this.trigger({ server: this.server });
+      },
+    );
+
+    return promise;
+  },
+  reportError(error) {
+    this.server = { up: false, error: error };
+    this.trigger({ server: this.server });
+  },
+  reportSucess() {
+    this.server = { up: true };
+    this.trigger({ server: this.server });
+  },
+});
+
+export default ServerAvailabilityStore;


### PR DESCRIPTION
Before this change, a non-working server connection was indicated only
by javascript errors in the browser console and neverending spinners.
With this change, whenever requests are unsuccessfull in a fundamental
way, or the occasional polling for the server does not succeed, an
overlay will be rendered indicating the error.

When the server connection is restored, no browser refresh is necessary, the web interface will restore to the previous state automatically.

Right now the design is very basic and questionable, additional styling
and displaying of the error can be added later.
