### PR TITLE
Turn streams List into Set

### DIFF
--- a/graylog2-plugin-interfaces/src/main/java/org/graylog2/plugin/Message.java
+++ b/graylog2-plugin-interfaces/src/main/java/org/graylog2/plugin/Message.java
@@ -41,7 +41,6 @@ import org.slf4j.LoggerFactory;
 
 import java.net.InetAddress;
 import java.util.ArrayList;
-import java.util.Collection;
 import java.util.Collections;
 import java.util.Date;
 import java.util.Iterator;
@@ -354,20 +353,38 @@ public class Message implements Messages {
         this.streams = Sets.newHashSet(streams);
     }
 
-    public List<Stream> getStreams() {
-        return Lists.newArrayList(this.streams);
+    /**
+     * Get the streams this message is currently routed to.
+     * @return an immutable copy of the current set of assigned streams, empty if no streams have been assigned
+     */
+    public Set<Stream> getStreams() {
+        return ImmutableSet.copyOf(this.streams);
     }
 
+    /**
+     * Assign the given stream to this message.
+     *
+     * @param stream the stream to route this message into
+     */
     public void addStream(Stream stream) {
         streams.add(stream);
     }
 
-    public void addStreams(Collection<Stream> newStreams) {
-        streams.addAll(newStreams);
+    /**
+     * Assign all of the streams to this message.
+     * @param newStreams an iterable of Stream objects
+     */
+    public void addStreams(Iterable<Stream> newStreams) {
+        Iterables.addAll(streams, newStreams);
     }
 
-    public void removeStream(Stream stream) {
-        streams.remove(stream);
+    /**
+     * Remove the stream assignment from this message.
+     * @param stream the stream assignment to remove this message from
+     * @return <tt>true</tt> if this message was assigned to the stream
+     */
+    public boolean removeStream(Stream stream) {
+        return streams.remove(stream);
     }
 
     @SuppressWarnings("unchecked")

--- a/graylog2-plugin-interfaces/src/main/java/org/graylog2/plugin/Message.java
+++ b/graylog2-plugin-interfaces/src/main/java/org/graylog2/plugin/Message.java
@@ -32,6 +32,7 @@ import com.google.common.collect.Iterables;
 import com.google.common.collect.Iterators;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
+import com.google.common.collect.Sets;
 import com.google.common.net.InetAddresses;
 import org.graylog2.plugin.streams.Stream;
 import org.joda.time.DateTime;
@@ -40,6 +41,7 @@ import org.slf4j.LoggerFactory;
 
 import java.net.InetAddress;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.Date;
 import java.util.Iterator;
@@ -114,7 +116,7 @@ public class Message implements Messages {
     public static final Function<Message, String> ID_FUNCTION = new MessageIdFunction();
 
     private final Map<String, Object> fields = Maps.newHashMap();
-    private List<Stream> streams = Lists.newArrayList();
+    private Set<Stream> streams = Sets.newHashSet();
     private String sourceInputId;
 
     // Used for drools to filter out messages.
@@ -347,12 +349,25 @@ public class Message implements Messages {
         return Collections.unmodifiableSet(fields.keySet());
     }
 
+    @Deprecated
     public void setStreams(final List<Stream> streams) {
-        this.streams = Lists.newArrayList(streams);
+        this.streams = Sets.newHashSet(streams);
     }
 
     public List<Stream> getStreams() {
-        return this.streams;
+        return Lists.newArrayList(this.streams);
+    }
+
+    public void addStream(Stream stream) {
+        streams.add(stream);
+    }
+
+    public void addStreams(Collection<Stream> newStreams) {
+        streams.addAll(newStreams);
+    }
+
+    public void removeStream(Stream stream) {
+        streams.remove(stream);
     }
 
     @SuppressWarnings("unchecked")

--- a/graylog2-plugin-interfaces/src/main/java/org/graylog2/plugin/Message.java
+++ b/graylog2-plugin-interfaces/src/main/java/org/graylog2/plugin/Message.java
@@ -357,6 +357,9 @@ public class Message implements Messages {
 
     @SuppressWarnings("unchecked")
     public List<String> getStreamIds() {
+        if (!hasField(FIELD_STREAMS)) {
+            return Collections.emptyList();
+        }
         try {
             return Lists.<String>newArrayList(getFieldAs(List.class, FIELD_STREAMS));
         } catch (ClassCastException e) {

--- a/graylog2-plugin-interfaces/src/main/java/org/graylog2/plugin/MessageCollection.java
+++ b/graylog2-plugin-interfaces/src/main/java/org/graylog2/plugin/MessageCollection.java
@@ -1,0 +1,42 @@
+/**
+ * The MIT License
+ * Copyright (c) 2012 Graylog, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.graylog2.plugin;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Iterators;
+
+import java.util.Iterator;
+
+public class MessageCollection implements Messages  {
+
+    private final ImmutableList<Message> messages;
+
+    public MessageCollection(Iterable<Message> other) {
+        messages = ImmutableList.copyOf(other);
+    }
+
+    @Override
+    public Iterator<Message> iterator() {
+        return Iterators.filter(messages.iterator(), e -> !e.getFilterOut());
+    }
+}

--- a/graylog2-plugin-interfaces/src/test/java/org/graylog2/plugin/MessageTest.java
+++ b/graylog2-plugin-interfaces/src/test/java/org/graylog2/plugin/MessageTest.java
@@ -25,6 +25,7 @@ package org.graylog2.plugin;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
+import org.assertj.core.api.Assertions;
 import org.graylog2.plugin.streams.Stream;
 import org.joda.time.DateTime;
 import org.joda.time.DateTimeZone;
@@ -191,9 +192,7 @@ public class MessageTest {
         message.addStreams(Lists.newArrayList(stream2, stream1));
 
         // make sure all streams we've added are being returned. Internally it's a set, so don't check the order, it doesn't matter anyway.
-        assertEquals(0,
-                     symmetricDifference(Sets.newHashSet(stream1, stream2),
-                                         Sets.newHashSet(message.getStreams())).size());
+        Assertions.assertThat(message.getStreams()).containsOnly(stream1, stream2);
     }
 
     @Test

--- a/graylog2-plugin-interfaces/src/test/java/org/graylog2/plugin/MessageTest.java
+++ b/graylog2-plugin-interfaces/src/test/java/org/graylog2/plugin/MessageTest.java
@@ -39,6 +39,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.regex.Pattern;
 
+import static com.google.common.collect.Sets.symmetricDifference;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
@@ -187,9 +188,12 @@ public class MessageTest {
         final Stream stream1 = mock(Stream.class);
         final Stream stream2 = mock(Stream.class);
 
-        message.setStreams(Lists.newArrayList(stream1, stream2));
+        message.addStreams(Lists.newArrayList(stream2, stream1));
 
-        assertEquals(Lists.newArrayList(stream1, stream2), message.getStreams());
+        // make sure all streams we've added are being returned. Internally it's a set, so don't check the order, it doesn't matter anyway.
+        assertEquals(0,
+                     symmetricDifference(Sets.newHashSet(stream1, stream2),
+                                         Sets.newHashSet(message.getStreams())).size());
     }
 
     @Test
@@ -357,11 +361,11 @@ public class MessageTest {
 
     @Test
     public void testGetFieldNames() throws Exception {
-        assertTrue("Missing fields in set!", Sets.symmetricDifference(message.getFieldNames(), Sets.newHashSet("_id", "timestamp", "source", "message")).isEmpty());
+        assertTrue("Missing fields in set!", symmetricDifference(message.getFieldNames(), Sets.newHashSet("_id", "timestamp", "source", "message")).isEmpty());
 
         message.addField("testfield", "testvalue");
 
-        assertTrue("Missing fields in set!", Sets.symmetricDifference(message.getFieldNames(), Sets.newHashSet("_id", "timestamp", "source", "message", "testfield")).isEmpty());
+        assertTrue("Missing fields in set!", symmetricDifference(message.getFieldNames(), Sets.newHashSet("_id", "timestamp", "source", "message", "testfield")).isEmpty());
     }
 
     @Test(expected = UnsupportedOperationException.class)

--- a/graylog2-plugin-interfaces/src/test/java/org/graylog2/plugin/MessageTest.java
+++ b/graylog2-plugin-interfaces/src/test/java/org/graylog2/plugin/MessageTest.java
@@ -196,6 +196,33 @@ public class MessageTest {
     }
 
     @Test
+    public void testStreamMutators() {
+        final Stream stream1 = mock(Stream.class);
+        final Stream stream2 = mock(Stream.class);
+        final Stream stream3 = mock(Stream.class);
+
+        Assertions.assertThat(message.getStreams()).isNotNull();
+        Assertions.assertThat(message.getStreams()).isEmpty();
+
+        message.addStream(stream1);
+
+        final Set<Stream> onlyWithStream1 = message.getStreams();
+        Assertions.assertThat(onlyWithStream1).containsOnly(stream1);
+
+        message.addStreams(Sets.newHashSet(stream3, stream2));
+        Assertions.assertThat(message.getStreams()).containsOnly(stream1, stream2, stream3);
+
+        // getStreams is a copy and doesn't change after mutations
+        Assertions.assertThat(onlyWithStream1).containsOnly(stream1);
+
+        // stream2 was assigned
+        Assertions.assertThat(message.removeStream(stream2)).isTrue();
+        // streams2 is no longer assigned
+        Assertions.assertThat(message.removeStream(stream2)).isFalse();
+        Assertions.assertThat(message.getStreams()).containsOnly(stream1, stream3);
+    }
+
+    @Test
     public void testGetStreamIds() throws Exception {
         message.addField("streams", Lists.newArrayList("stream-id"));
 

--- a/graylog2-server/src/main/java/org/graylog2/filters/StreamMatcherFilter.java
+++ b/graylog2-server/src/main/java/org/graylog2/filters/StreamMatcherFilter.java
@@ -51,7 +51,7 @@ public class StreamMatcherFilter implements MessageFilter {
         for (Stream stream : streams) {
             throughputStats.incrementStreamThroughput(stream.getId());
         }
-        msg.setStreams(streams);
+        msg.addStreams(streams);
 
         LOG.debug("Routed message <{}> to {} streams.", msg.getId(), streams.size());
 

--- a/graylog2-server/src/test/java/org/graylog2/outputs/OutputRouterTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/outputs/OutputRouterTest.java
@@ -16,6 +16,7 @@
  */
 package org.graylog2.outputs;
 
+import com.google.common.collect.ImmutableSet;
 import org.graylog2.plugin.Message;
 import org.graylog2.plugin.outputs.MessageOutput;
 import org.graylog2.plugin.streams.Output;
@@ -26,10 +27,8 @@ import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.runners.MockitoJUnitRunner;
 
-import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashSet;
-import java.util.List;
 import java.util.Set;
 
 import static org.junit.Assert.assertEquals;
@@ -117,11 +116,8 @@ public class OutputRouterTest {
     @Test
     public void testGetOutputFromSingleStreams() throws Exception {
         final Stream stream = mock(Stream.class);
-        List<Stream> streamList = new ArrayList<Stream>() {{
-            add(stream);
-        }};
         final Message message = mock(Message.class);
-        when(message.getStreams()).thenReturn(streamList);
+        when(message.getStreams()).thenReturn(ImmutableSet.of(stream));
 
         final MessageOutput messageOutput = mock(MessageOutput.class);
         final Set<MessageOutput> messageOutputList = new HashSet<MessageOutput>() {{
@@ -153,11 +149,7 @@ public class OutputRouterTest {
             add(messageOutput2);
         }};
         final Message message = mock(Message.class);
-        final List<Stream> streamList = new ArrayList<Stream>() {{
-            add(stream1);
-            add(stream2);
-        }};
-        when(message.getStreams()).thenReturn(streamList);
+        when(message.getStreams()).thenReturn(ImmutableSet.of(stream1, stream2));
 
         OutputRouter outputRouter = Mockito.spy(new OutputRouter(defaultMessageOutput, outputRegistry));
         doReturn(messageOutputSet1).when(outputRouter).getMessageOutputsForStream(eq(stream1));
@@ -180,11 +172,7 @@ public class OutputRouterTest {
             add(messageOutput);
         }};
         final Message message = mock(Message.class);
-        final List<Stream> streamList = new ArrayList<Stream>() {{
-            add(stream1);
-            add(stream2);
-        }};
-        when(message.getStreams()).thenReturn(streamList);
+        when(message.getStreams()).thenReturn(ImmutableSet.of(stream1, stream2));
 
         OutputRouter outputRouter = Mockito.spy(new OutputRouter(defaultMessageOutput, outputRegistry));
         doReturn(messageOutputSet).when(outputRouter).getMessageOutputsForStream(eq(stream1));


### PR DESCRIPTION
To support iteratively building up the set of assigned streams for a message we don't want filters to overwrite the entire collection all the time, thus `setStreams()` is deprecated.

Instead expose `addStream()`, `addStreams()`, `removeStream()` and turn the internal field into a `Set<Stream>`.

`getStreamIds()` would cause NPEs if the streams field wasn't set, which is counter-intuitive. In fact, its behavior is plain wrong, but I haven't changed it in this PR yet.

To allow other `MessageProcessor` instances to change the stream assignments, don't let `StreamMatcherFilter` blindly overwrite all streams, but add to the set.