### PR TITLE
Handle invalid IDs in InputsResource

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/plugin/rest/ApiError.java
+++ b/graylog2-server/src/main/java/org/graylog2/plugin/rest/ApiError.java
@@ -17,15 +17,43 @@
 package org.graylog2.plugin.rest;
 
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import com.google.common.base.MoreObjects;
 
-/**
- * @author Dennis Oelkers <dennis@torch.sh>
- */
-@JsonTypeInfo(use= JsonTypeInfo.Id.NAME, include= JsonTypeInfo.As.PROPERTY, property="type")
+import java.util.Objects;
+
+import static java.util.Objects.requireNonNull;
+
+@JsonTypeInfo(use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.PROPERTY, property = "type")
 public class ApiError {
     public final String message;
 
     public ApiError(String message) {
-        this.message = message;
+        this.message = requireNonNull(message);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+
+        final ApiError apiError = (ApiError) o;
+        return Objects.equals(message, apiError.message);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(message);
+    }
+
+    @Override
+    public String toString() {
+        return MoreObjects.toStringHelper(this)
+                .add("message", message)
+                .toString();
     }
 }

--- a/graylog2-server/src/main/java/org/graylog2/shared/initializers/AbstractJerseyService.java
+++ b/graylog2-server/src/main/java/org/graylog2/shared/initializers/AbstractJerseyService.java
@@ -39,6 +39,7 @@ import org.graylog2.shared.rest.PrintModelProcessor;
 import org.graylog2.shared.rest.RestAccessLogFilter;
 import org.graylog2.shared.rest.exceptionmappers.AnyExceptionClassMapper;
 import org.graylog2.shared.rest.exceptionmappers.BadRequestExceptionMapper;
+import org.graylog2.shared.rest.exceptionmappers.IllegalArgumentExceptionMapper;
 import org.graylog2.shared.rest.exceptionmappers.JacksonPropertyExceptionMapper;
 import org.graylog2.shared.rest.exceptionmappers.JsonProcessingExceptionMapper;
 import org.graylog2.shared.rest.exceptionmappers.WebApplicationExceptionMapper;
@@ -106,7 +107,8 @@ public abstract class AbstractJerseyService extends AbstractIdleService {
                         JacksonPropertyExceptionMapper.class,
                         AnyExceptionClassMapper.class,
                         WebApplicationExceptionMapper.class,
-                        BadRequestExceptionMapper.class)
+                        BadRequestExceptionMapper.class,
+                        IllegalArgumentExceptionMapper.class)
                 .register(new ContextResolver<ObjectMapper>() {
                     @Override
                     public ObjectMapper getContext(Class<?> type) {

--- a/graylog2-server/src/main/java/org/graylog2/shared/rest/exceptionmappers/IllegalArgumentExceptionMapper.java
+++ b/graylog2-server/src/main/java/org/graylog2/shared/rest/exceptionmappers/IllegalArgumentExceptionMapper.java
@@ -1,0 +1,35 @@
+/**
+ * This file is part of Graylog.
+ *
+ * Graylog is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.graylog2.shared.rest.exceptionmappers;
+
+import org.graylog2.plugin.rest.ApiError;
+
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.ext.ExceptionMapper;
+
+public class IllegalArgumentExceptionMapper implements ExceptionMapper<IllegalArgumentException> {
+    @Override
+    public Response toResponse(IllegalArgumentException e) {
+        final ApiError apiError = new ApiError(e.getMessage());
+
+        return Response.status(Response.Status.BAD_REQUEST)
+                .type(MediaType.APPLICATION_JSON_TYPE)
+                .entity(apiError)
+                .build();
+    }
+}

--- a/graylog2-server/src/test/java/org/graylog2/shared/rest/exceptionmappers/IllegalArgumentExceptionMapperTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/shared/rest/exceptionmappers/IllegalArgumentExceptionMapperTest.java
@@ -1,0 +1,46 @@
+/**
+ * This file is part of Graylog.
+ *
+ * Graylog is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.graylog2.shared.rest.exceptionmappers;
+
+import org.graylog2.plugin.rest.ApiError;
+import org.graylog2.shared.bindings.GuiceInjectorHolder;
+import org.junit.Test;
+
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+
+import java.util.Collections;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class IllegalArgumentExceptionMapperTest {
+
+    public IllegalArgumentExceptionMapperTest() {
+        GuiceInjectorHolder.createInjector(Collections.emptyList());
+    }
+
+    @Test
+    public void toResponseReturnsApiError() throws Exception {
+        final IllegalArgumentException exception = new IllegalArgumentException("test");
+        final IllegalArgumentExceptionMapper mapper = new IllegalArgumentExceptionMapper();
+        final Response response = mapper.toResponse(exception);
+
+        assertThat(response.getStatusInfo()).isEqualTo(Response.Status.BAD_REQUEST);
+        assertThat(response.getMediaType()).isEqualTo(MediaType.APPLICATION_JSON_TYPE);
+        assertThat(response.getEntity()).isEqualTo(new ApiError(exception.getMessage()));
+    }
+}


### PR DESCRIPTION
This is the second take on solving #1718 after the discussion in #1767.

This PR introduces an exception mapper which translates `InvalidArgumentException`s into HTTP responses with status code 400. Additionally it introduces quick validity checks to the methods in `InputServiceImpl` which are handling MongoDB `ObjectId`s as a precondition for those methods.

Contrary to https://github.com/Graylog2/graylog2-server/pull/1767#discussion_r52009588, this change set doesn't add serialization/deserialization for `ObjectId` in Jackson or Jersey because at least the JAX-RS resource classes shouldn't be "polluted" with details of the underlying database (and e. g. use `ObjectId` directly as `@PathParam`).

Fixes #1767.