### PR TITLE
Upgrade Javascript dependencies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
-sudo: false
+sudo: required
+dist: trusty
 language: java
 jdk:
   - oraclejdk8

--- a/graylog2-server/pom.xml
+++ b/graylog2-server/pom.xml
@@ -561,7 +561,7 @@
                                     <goal>install-node-and-npm</goal>
                                 </goals>
                                 <configuration>
-                                    <nodeVersion>v0.12.5</nodeVersion>
+                                    <nodeVersion>v4.3.0</nodeVersion>
                                     <npmVersion>2.11.2</npmVersion>
                                 </configuration>
                             </execution>

--- a/graylog2-server/pom.xml
+++ b/graylog2-server/pom.xml
@@ -562,7 +562,7 @@
                                 </goals>
                                 <configuration>
                                     <nodeVersion>v4.3.0</nodeVersion>
-                                    <npmVersion>2.11.2</npmVersion>
+                                    <npmVersion>3.7.2</npmVersion>
                                 </configuration>
                             </execution>
 

--- a/graylog2-server/pom.xml
+++ b/graylog2-server/pom.xml
@@ -548,7 +548,7 @@
                     <plugin>
                         <groupId>com.github.eirslett</groupId>
                         <artifactId>frontend-maven-plugin</artifactId>
-                        <version>0.0.26</version>
+                        <version>0.0.28</version>
 
                         <configuration>
                             <workingDirectory>${webInterface.path}</workingDirectory>


### PR DESCRIPTION
This PR upgrades the primary Javascript dependencies to Node.js 4.3.0 LTS, npm 3.7.2, and frontend-maven-plugin 0.0.28.