### PR TITLE
Pluggable index management UI

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/rest/models/system/indices/RetentionStrategies.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/models/system/indices/RetentionStrategies.java
@@ -30,11 +30,11 @@ public abstract class RetentionStrategies {
     public abstract int total();
 
     @JsonProperty
-    public abstract Set<String> strategies();
+    public abstract Set<RetentionStrategyDescription> strategies();
 
     @JsonCreator
     public static RetentionStrategies create(@JsonProperty("total") int total,
-                                             @JsonProperty("strategies") Set<String> strategies) {
+                                             @JsonProperty("strategies") Set<RetentionStrategyDescription> strategies) {
         return new AutoValue_RetentionStrategies(total, strategies);
     }
 }

--- a/graylog2-server/src/main/java/org/graylog2/rest/models/system/indices/RetentionStrategyDescription.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/models/system/indices/RetentionStrategyDescription.java
@@ -19,22 +19,26 @@ package org.graylog2.rest.models.system.indices;
 import com.fasterxml.jackson.annotation.JsonAutoDetect;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.module.jsonSchema.JsonSchema;
 import com.google.auto.value.AutoValue;
+import org.graylog2.plugin.indexer.retention.RetentionStrategyConfig;
 
-import java.util.Set;
-
-@AutoValue
 @JsonAutoDetect
-public abstract class RotationStrategies {
-    @JsonProperty
-    public abstract int total();
+@AutoValue
+public abstract class RetentionStrategyDescription {
+    @JsonProperty("type")
+    public abstract String type();
 
-    @JsonProperty
-    public abstract Set<RotationStrategyDescription> strategies();
+    @JsonProperty("default_config")
+    public abstract RetentionStrategyConfig defaultConfig();
+
+    @JsonProperty("json_schema")
+    public abstract JsonSchema jsonSchema();
 
     @JsonCreator
-    public static RotationStrategies create(@JsonProperty("total") int total,
-                                            @JsonProperty("strategies") Set<RotationStrategyDescription> strategies) {
-        return new AutoValue_RotationStrategies(total, strategies);
+    public static RetentionStrategyDescription create(@JsonProperty("type") String type,
+                                                      @JsonProperty("default_config") RetentionStrategyConfig defaultConfig,
+                                                      @JsonProperty("json_schema") JsonSchema jsonSchema) {
+        return new AutoValue_RetentionStrategyDescription(type, defaultConfig, jsonSchema);
     }
 }

--- a/graylog2-server/src/main/java/org/graylog2/rest/models/system/indices/RotationStrategyDescription.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/models/system/indices/RotationStrategyDescription.java
@@ -19,22 +19,26 @@ package org.graylog2.rest.models.system.indices;
 import com.fasterxml.jackson.annotation.JsonAutoDetect;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.module.jsonSchema.JsonSchema;
 import com.google.auto.value.AutoValue;
+import org.graylog2.plugin.indexer.rotation.RotationStrategyConfig;
 
-import java.util.Set;
-
-@AutoValue
 @JsonAutoDetect
-public abstract class RotationStrategies {
-    @JsonProperty
-    public abstract int total();
+@AutoValue
+public abstract class RotationStrategyDescription {
+    @JsonProperty("type")
+    public abstract String type();
 
-    @JsonProperty
-    public abstract Set<RotationStrategyDescription> strategies();
+    @JsonProperty("default_config")
+    public abstract RotationStrategyConfig defaultConfig();
+
+    @JsonProperty("json_schema")
+    public abstract JsonSchema jsonSchema();
 
     @JsonCreator
-    public static RotationStrategies create(@JsonProperty("total") int total,
-                                            @JsonProperty("strategies") Set<RotationStrategyDescription> strategies) {
-        return new AutoValue_RotationStrategies(total, strategies);
+    public static RotationStrategyDescription create(@JsonProperty("type") String type,
+                                                     @JsonProperty("default_config") RotationStrategyConfig defaultConfig,
+                                                     @JsonProperty("json_schema") JsonSchema jsonSchema) {
+        return new AutoValue_RotationStrategyDescription(type, defaultConfig, jsonSchema);
     }
 }

--- a/graylog2-server/src/main/java/org/graylog2/rest/resources/system/indices/RetentionStrategyResource.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/resources/system/indices/RetentionStrategyResource.java
@@ -18,7 +18,6 @@ package org.graylog2.rest.resources.system.indices;
 
 import com.codahale.metrics.annotation.Timed;
 import com.fasterxml.jackson.databind.JsonMappingException;
-import com.fasterxml.jackson.module.jsonSchema.JsonSchema;
 import com.fasterxml.jackson.module.jsonSchema.factories.SchemaFactoryWrapper;
 import com.wordnik.swagger.annotations.Api;
 import com.wordnik.swagger.annotations.ApiOperation;
@@ -29,6 +28,7 @@ import org.graylog2.plugin.indexer.retention.RetentionStrategyConfig;
 import org.graylog2.plugin.cluster.ClusterConfigService;
 import org.graylog2.plugin.indexer.retention.RetentionStrategy;
 import org.graylog2.rest.models.system.indices.RetentionStrategies;
+import org.graylog2.rest.models.system.indices.RetentionStrategyDescription;
 import org.graylog2.rest.models.system.indices.RetentionStrategySummary;
 import org.graylog2.shared.rest.resources.RestResource;
 import org.hibernate.validator.constraints.NotEmpty;
@@ -48,6 +48,7 @@ import javax.ws.rs.Produces;
 import javax.ws.rs.core.MediaType;
 import java.util.Map;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 import static java.util.Objects.requireNonNull;
 
@@ -123,7 +124,10 @@ public class RetentionStrategyResource extends RestResource {
     @ApiOperation(value = "List available retention strategies",
             notes = "This resource returns a list of all available retention strategies on this Graylog node.")
     public RetentionStrategies list() {
-        final Set<String> strategies = retentionStrategies.keySet();
+        final Set<RetentionStrategyDescription> strategies = retentionStrategies.keySet()
+                .stream()
+                .map(this::getRetentionStrategyDescription)
+                .collect(Collectors.toSet());
 
         return RetentionStrategies.create(strategies.size(), strategies);
     }
@@ -133,14 +137,19 @@ public class RetentionStrategyResource extends RestResource {
     @Timed
     @ApiOperation(value = "Show JSON schema for configuration of given retention strategies",
             notes = "This resource returns a JSON schema for the configuration of the given retention strategy.")
-    public JsonSchema configSchema(@ApiParam(name = "strategy", value = "The name of the retention strategy", required = true)
+    public RetentionStrategyDescription configSchema(@ApiParam(name = "strategy", value = "The name of the retention strategy", required = true)
                                    @PathParam("strategy") @NotEmpty String strategyName) {
+        return getRetentionStrategyDescription(strategyName);
+    }
+
+    private RetentionStrategyDescription getRetentionStrategyDescription(@ApiParam(name = "strategy", value = "The name of the retention strategy", required = true) @PathParam("strategy") @NotEmpty String strategyName) {
         final Provider<RetentionStrategy> provider = retentionStrategies.get(strategyName);
         if (provider == null) {
             throw new NotFoundException("Couldn't find retention strategy for given type " + strategyName);
         }
 
         final RetentionStrategy retentionStrategy = provider.get();
+        final RetentionStrategyConfig defaultConfig = retentionStrategy.defaultConfiguration();
         final SchemaFactoryWrapper visitor = new SchemaFactoryWrapper();
         try {
             objectMapper.acceptJsonFormatVisitor(objectMapper.constructType(retentionStrategy.configurationClass()), visitor);
@@ -148,6 +157,6 @@ public class RetentionStrategyResource extends RestResource {
             throw new InternalServerErrorException("Couldn't generate JSON schema for retention strategy " + strategyName, e);
         }
 
-        return visitor.finalSchema();
+        return RetentionStrategyDescription.create(strategyName, defaultConfig, visitor.finalSchema());
     }
 }

--- a/graylog2-server/src/main/java/org/graylog2/rest/resources/system/indices/RetentionStrategyResource.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/resources/system/indices/RetentionStrategyResource.java
@@ -98,7 +98,7 @@ public class RetentionStrategyResource extends RestResource {
     @Timed
     @ApiOperation(value = "Configuration of the current retention strategy",
             notes = "This resource stores the configuration of the currently used retention strategy.")
-    public void config(@ApiParam(value = "The description of the retention strategy and its configuration", required = true)
+    public RetentionStrategySummary config(@ApiParam(value = "The description of the retention strategy and its configuration", required = true)
                        @Valid @NotNull RetentionStrategySummary retentionStrategySummary) {
         if (!retentionStrategies.containsKey(retentionStrategySummary.strategy())) {
             throw new NotFoundException("Couldn't find retention strategy for given type " + retentionStrategySummary.strategy());
@@ -116,6 +116,8 @@ public class RetentionStrategyResource extends RestResource {
 
         clusterConfigService.write(retentionStrategySummary.config());
         clusterConfigService.write(indexManagementConfig);
+
+        return retentionStrategySummary;
     }
 
     @GET

--- a/graylog2-server/src/main/java/org/graylog2/rest/resources/system/indices/RotationStrategyResource.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/resources/system/indices/RotationStrategyResource.java
@@ -98,7 +98,7 @@ public class RotationStrategyResource extends RestResource {
     @Timed
     @ApiOperation(value = "Configuration of the current rotation strategy",
             notes = "This resource stores the configuration of the currently used rotation strategy.")
-    public void config(@ApiParam(value = "The description of the rotation strategy and its configuration", required = true)
+    public RotationStrategySummary config(@ApiParam(value = "The description of the rotation strategy and its configuration", required = true)
                        @Valid @NotNull RotationStrategySummary rotationStrategySummary) {
         if (!rotationStrategies.containsKey(rotationStrategySummary.strategy())) {
             throw new NotFoundException("Couldn't find rotation strategy for given type " + rotationStrategySummary.strategy());
@@ -116,6 +116,8 @@ public class RotationStrategyResource extends RestResource {
 
         clusterConfigService.write(rotationStrategySummary.config());
         clusterConfigService.write(indexManagementConfig);
+
+        return rotationStrategySummary;
     }
 
     @GET

--- a/graylog2-web-interface/src/actions/indices/IndicesConfigurationActions.js
+++ b/graylog2-web-interface/src/actions/indices/IndicesConfigurationActions.js
@@ -1,0 +1,12 @@
+import Reflux from 'reflux';
+
+const IndicesConfigurationActions = Reflux.createActions({
+  'loadRotationConfig': {asyncResult: true},
+  'loadRotationStrategies': {asyncResult: true},
+  'loadRetentionConfig': {asyncResult: true},
+  'loadRetentionStrategies': {asyncResult: true},
+  'updateRotationConfiguration': {asyncResult: true},
+  'updateRetentionConfiguration': {asyncResult: true},
+});
+
+export default IndicesConfigurationActions;

--- a/graylog2-web-interface/src/actions/indices/index.jsx
+++ b/graylog2-web-interface/src/actions/indices/index.jsx
@@ -1,3 +1,4 @@
 export { default as DeflectorActions } from './DeflectorActions';
 export { default as IndexRangesActions } from './IndexRangesActions';
 export { default as IndicesActions } from './IndicesActions';
+export { default as IndicesConfigurationActions } from './IndicesConfigurationActions';

--- a/graylog2-web-interface/src/components/indices/IndexMaintenanceStrategiesConfiguration.jsx
+++ b/graylog2-web-interface/src/components/indices/IndexMaintenanceStrategiesConfiguration.jsx
@@ -2,6 +2,8 @@ import React from 'react';
 
 import { Select } from 'components/common';
 
+import style from '!style!css!./IndicesConfiguration.css';
+
 const IndexMaintenanceStrategiesConfiguration = React.createClass({
   propTypes: {
     title: React.PropTypes.string.isRequired,
@@ -61,26 +63,26 @@ const IndexMaintenanceStrategiesConfiguration = React.createClass({
 
   _availableSelectOptions() {
     return this.props.pluginExports.map((config) => {
-      return {value: config.type, label: config.displayName}
+      return {value: config.type, label: config.displayName};
     });
   },
 
   _getConfigurationComponent(selectedStrategy) {
     if (!selectedStrategy || selectedStrategy.length < 1) {
-      return;
+      return null;
     }
 
-    const strategy = this.props.pluginExports.find((strategy) => strategy.type === selectedStrategy);
+    const strategy = this.props.pluginExports.find((exportedStrategy) => exportedStrategy.type === selectedStrategy);
 
     if (!strategy) {
-      return undefined;
+      return null;
     }
 
     const strategyConfig = this._getStrategyConfig(selectedStrategy);
     const element = React.createElement(strategy.configComponent, {
       config: strategyConfig,
       jsonSchema: this._getStrategyJsonSchema(selectedStrategy),
-      updateConfig: this._onConfigUpdate
+      updateConfig: this._onConfigUpdate,
     });
 
     return (<span key={strategy.type}>{element}</span>);
@@ -94,22 +96,22 @@ const IndexMaintenanceStrategiesConfiguration = React.createClass({
     return (
       <span>
         <h3>{this.props.title}</h3>
-        <div style={{marginTop: 10}}>
+        <div className={style.topMargin}>
           <p>{this.props.description}</p>
         </div>
-        <div style={{marginTop: 10}}>
+        <div className={style.topMargin}>
           <Select placeholder={this.props.selectPlaceholder}
                   options={this._availableSelectOptions()}
-                  matchProp='value'
+                  matchProp="value"
                   value={this._activeSelection()}
                   onValueChange={this._onSelect}/>
         </div>
-        <div style={{marginTop: 10}}>
+        <div className={style.topMargin}>
           {this._getConfigurationComponent(this._activeSelection())}
         </div>
       </span>
     );
-  }
+  },
 });
 
 export default IndexMaintenanceStrategiesConfiguration;

--- a/graylog2-web-interface/src/components/indices/IndexMaintenanceStrategiesConfiguration.jsx
+++ b/graylog2-web-interface/src/components/indices/IndexMaintenanceStrategiesConfiguration.jsx
@@ -1,0 +1,115 @@
+import React from 'react';
+
+import { Select } from 'components/common';
+
+const IndexMaintenanceStrategiesConfiguration = React.createClass({
+  propTypes: {
+    title: React.PropTypes.string.isRequired,
+    description: React.PropTypes.string.isRequired,
+    selectPlaceholder: React.PropTypes.string.isRequired,
+    pluginExports: React.PropTypes.array.isRequired,
+    strategies: React.PropTypes.array.isRequired,
+    activeConfig: React.PropTypes.object.isRequired,
+    updateState: React.PropTypes.func.isRequired,
+  },
+
+  getInitialState() {
+    return {
+      activeStrategy: this.props.activeConfig.strategy,
+      activeConfig: this.props.activeConfig.config,
+      newStrategy: this.props.activeConfig.strategy,
+      newConfig: this.props.activeConfig.config,
+    };
+  },
+
+  _getDefaultStrategyConfig(selectedStrategy) {
+    const result = this.props.strategies.find((strategy) => strategy.type === selectedStrategy);
+    return result ? result.default_config : undefined;
+  },
+
+  _getStrategyJsonSchema(selectedStrategy) {
+    const result = this.props.strategies.find((strategy) => strategy.type === selectedStrategy);
+    return result ? result.json_schema : undefined;
+  },
+
+  _getStrategyConfig(selectedStrategy) {
+    if (this.state.activeStrategy === selectedStrategy) {
+      // If the newly selected strategy is the current active strategy, we use the active configuration.
+      return this.state.activeConfig;
+    } else {
+      // If the newly selected strategy is not the current active strategy, we use the selected strategy's default config.
+      return this._getDefaultStrategyConfig(selectedStrategy);
+    }
+  },
+
+  _onSelect(newStrategy) {
+    if (!newStrategy || newStrategy.length < 1) {
+      this.setState({newStrategy: undefined});
+      return;
+    }
+
+    const newConfig = this._getStrategyConfig(newStrategy);
+
+    this.setState({newStrategy: newStrategy, newConfig: newConfig});
+    this.props.updateState(newStrategy, newConfig);
+  },
+
+  _onConfigUpdate(newConfig) {
+    this.setState({newConfig: newConfig});
+    this.props.updateState(this.state.newStrategy, newConfig);
+  },
+
+  _availableSelectOptions() {
+    return this.props.pluginExports.map((config) => {
+      return {value: config.type, label: config.displayName}
+    });
+  },
+
+  _getConfigurationComponent(selectedStrategy) {
+    if (!selectedStrategy || selectedStrategy.length < 1) {
+      return;
+    }
+
+    const strategy = this.props.pluginExports.find((strategy) => strategy.type === selectedStrategy);
+
+    if (!strategy) {
+      return undefined;
+    }
+
+    const strategyConfig = this._getStrategyConfig(selectedStrategy);
+    const element = React.createElement(strategy.configComponent, {
+      config: strategyConfig,
+      jsonSchema: this._getStrategyJsonSchema(selectedStrategy),
+      updateConfig: this._onConfigUpdate
+    });
+
+    return (<span key={strategy.type}>{element}</span>);
+  },
+
+  _activeSelection() {
+    return this.state.newStrategy;
+  },
+
+  render() {
+    return (
+      <span>
+        <h3>{this.props.title}</h3>
+        <div style={{marginTop: 10}}>
+          <p>{this.props.description}</p>
+        </div>
+        <div style={{marginTop: 10}}>
+          <Select placeholder={this.props.selectPlaceholder}
+                  options={this._availableSelectOptions()}
+                  matchProp='value'
+                  value={this._activeSelection()}
+                  onValueChange={this._onSelect}/>
+        </div>
+        <div style={{marginTop: 10}}>
+          {this._getConfigurationComponent(this._activeSelection())}
+        </div>
+      </span>
+    );
+  }
+});
+
+export default IndexMaintenanceStrategiesConfiguration;

--- a/graylog2-web-interface/src/components/indices/IndexMaintenanceStrategiesSummary.jsx
+++ b/graylog2-web-interface/src/components/indices/IndexMaintenanceStrategiesSummary.jsx
@@ -5,6 +5,7 @@ import Spinner from 'components/common/Spinner';
 const IndexMaintenanceStrategiesSummary = React.createClass({
   propTypes: {
     config: React.PropTypes.object.isRequired,
+    pluginExports: React.PropTypes.array.isRequired,
   },
 
   render() {
@@ -13,10 +14,10 @@ const IndexMaintenanceStrategiesSummary = React.createClass({
     }
 
     const activeStrategy = this.props.config.strategy;
-    const strategy = this.props.pluginExports.find((strategy) => strategy.type === activeStrategy);
+    const strategy = this.props.pluginExports.find((exportedStrategy) => exportedStrategy.type === activeStrategy);
 
     if (!strategy || !strategy.summaryComponent) {
-      return (<Alert bsStyle='danger'>Summary for strategy {activeStrategy} not found!</Alert>);
+      return (<Alert bsStyle="danger">Summary for strategy {activeStrategy} not found!</Alert>);
     }
 
     const element = React.createElement(strategy.summaryComponent, {config: this.props.config.config});

--- a/graylog2-web-interface/src/components/indices/IndexMaintenanceStrategiesSummary.jsx
+++ b/graylog2-web-interface/src/components/indices/IndexMaintenanceStrategiesSummary.jsx
@@ -1,0 +1,28 @@
+import React from 'react';
+import { Alert } from 'react-bootstrap';
+import Spinner from 'components/common/Spinner';
+
+const IndexMaintenanceStrategiesSummary = React.createClass({
+  propTypes: {
+    config: React.PropTypes.object.isRequired,
+  },
+
+  render() {
+    if (!this.props.config) {
+      return (<Spinner />);
+    }
+
+    const activeStrategy = this.props.config.strategy;
+    const strategy = this.props.pluginExports.find((strategy) => strategy.type === activeStrategy);
+
+    if (!strategy || !strategy.summaryComponent) {
+      return (<Alert bsStyle='danger'>Summary for strategy {activeStrategy} not found!</Alert>);
+    }
+
+    const element = React.createElement(strategy.summaryComponent, {config: this.props.config.config});
+
+    return (<span key={strategy.type}>{element}</span>);
+  },
+});
+
+export default IndexMaintenanceStrategiesSummary;

--- a/graylog2-web-interface/src/components/indices/IndicesConfiguration.css
+++ b/graylog2-web-interface/src/components/indices/IndicesConfiguration.css
@@ -14,3 +14,12 @@
 :local(.deflistWide) dd {
     margin-left: 200px;
 }
+
+:local(.topMargin) {
+    margin-top: 10px;
+}
+
+hr:local(.separator) {
+    margin-top: 10px;
+    margin-bottom: 5px;
+}

--- a/graylog2-web-interface/src/components/indices/IndicesConfiguration.css
+++ b/graylog2-web-interface/src/components/indices/IndicesConfiguration.css
@@ -1,0 +1,16 @@
+:local(.deflist) {
+    margin-top: 10px;
+}
+
+:local(.deflist) dt {
+    float: left;
+    clear: left;
+}
+
+:local(.deflist) dd {
+    margin-left: 150px;
+}
+
+:local(.deflistWide) dd {
+    margin-left: 200px;
+}

--- a/graylog2-web-interface/src/components/indices/IndicesConfiguration.jsx
+++ b/graylog2-web-interface/src/components/indices/IndicesConfiguration.jsx
@@ -1,9 +1,8 @@
 import React from 'react';
 import Reflux from 'reflux';
 
-import { Button, Input, Row, Col } from 'react-bootstrap';
+import { Button, Row, Col } from 'react-bootstrap';
 import BootstrapModalForm from 'components/bootstrap/BootstrapModalForm';
-import { Select } from 'components/common';
 import Spinner from 'components/common/Spinner';
 import { PluginStore } from 'graylog-web-plugin/plugin';
 
@@ -56,7 +55,7 @@ const IndicesConfiguration = React.createClass({
       newRotationConfig: {
         strategy: strategy,
         config: config,
-      }
+      },
     });
   },
 
@@ -65,7 +64,7 @@ const IndicesConfiguration = React.createClass({
       newRetentionConfig: {
         strategy: strategy,
         config: config,
-      }
+      },
     });
   },
 
@@ -88,9 +87,9 @@ const IndicesConfiguration = React.createClass({
 
     let rotationConfig;
     if (this.state.activeRotationConfig && this.state.rotationStrategies) {
-      rotationConfig = (<IndexMaintenanceStrategiesConfiguration title='Index Rotation Configuration'
-                                                                 description='Please select an index rotation strategy'
-                                                                 selectPlaceholder='Select rotation strategy'
+      rotationConfig = (<IndexMaintenanceStrategiesConfiguration title="Index Rotation Configuration"
+                                                                 description="Please select an index rotation strategy"
+                                                                 selectPlaceholder="Select rotation strategy"
                                                                  pluginExports={PluginStore.exports('indexRotationConfig')}
                                                                  strategies={this.state.rotationStrategies}
                                                                  activeConfig={this.state.activeRotationConfig}
@@ -101,9 +100,9 @@ const IndicesConfiguration = React.createClass({
 
     let retentionConfig;
     if (this.state.activeRetentionConfig && this.state.retentionStrategies) {
-      retentionConfig = (<IndexMaintenanceStrategiesConfiguration title='Index Retention Configuration'
-                                                                  description='Please select an index retention strategy'
-                                                                  selectPlaceholder='Select retention strategy'
+      retentionConfig = (<IndexMaintenanceStrategiesConfiguration title="Index Retention Configuration"
+                                                                  description="Please select an index retention strategy"
+                                                                  selectPlaceholder="Select retention strategy"
                                                                   pluginExports={PluginStore.exports('indexRetentionConfig')}
                                                                   strategies={this.state.retentionStrategies}
                                                                   activeConfig={this.state.activeRetentionConfig}
@@ -116,7 +115,7 @@ const IndicesConfiguration = React.createClass({
       <div>
         <h2>Settings</h2>
 
-        <div style={{marginTop: 10}}>
+        <div className={style.topMargin}>
           <Row>
             <Col md={6}>
               {rotationSummary}
@@ -125,12 +124,12 @@ const IndicesConfiguration = React.createClass({
               {retentionSummary}
             </Col>
           </Row>
-          <hr style={{marginBottom: '5', marginTop: '10'}}/>
-          <Button bsStyle='info' bsSize='xs' onClick={() => this._openModal()}>Update configuration</Button>{' '}
+          <hr className={style.separator}/>
+          <Button bsStyle="info" bsSize="xs" onClick={() => this._openModal()}>Update configuration</Button>{' '}
         </div>
 
-        <BootstrapModalForm ref='indicesConfigurationModal'
-                            title='Update Index Settings'
+        <BootstrapModalForm ref="indicesConfigurationModal"
+                            title="Update Index Settings"
                             onSubmitForm={this._saveConfiguration}
                             submitButtonText="Save">
           {rotationConfig}

--- a/graylog2-web-interface/src/components/indices/IndicesConfiguration.jsx
+++ b/graylog2-web-interface/src/components/indices/IndicesConfiguration.jsx
@@ -1,0 +1,145 @@
+import React from 'react';
+import Reflux from 'reflux';
+
+import { Button, Input, Row, Col } from 'react-bootstrap';
+import BootstrapModalForm from 'components/bootstrap/BootstrapModalForm';
+import { Select } from 'components/common';
+import Spinner from 'components/common/Spinner';
+import { PluginStore } from 'graylog-web-plugin/plugin';
+
+import IndicesConfigurationActions from 'actions/indices/IndicesConfigurationActions';
+import IndicesConfigurationStore from 'stores/indices/IndicesConfigurationStore';
+import IndexMaintenanceStrategiesConfiguration from 'components/indices/IndexMaintenanceStrategiesConfiguration';
+import IndexMaintenanceStrategiesSummary from 'components/indices/IndexMaintenanceStrategiesSummary';
+import {} from 'components/indices/rotation'; // Load rotation plugin UI plugins from core.
+import {} from 'components/indices/retention'; // Load rotation plugin UI plugins from core.
+
+import style from '!style!css!./IndicesConfiguration.css';
+
+const IndicesConfiguration = React.createClass({
+  mixins: [Reflux.connect(IndicesConfigurationStore)],
+
+  componentDidMount() {
+    IndicesConfigurationActions.loadRotationConfig();
+    IndicesConfigurationActions.loadRotationStrategies();
+    IndicesConfigurationActions.loadRetentionConfig();
+    IndicesConfigurationActions.loadRetentionStrategies();
+  },
+
+  _saveConfiguration() {
+    const promises = [];
+
+    if (this.state.newRotationConfig) {
+      const promise = IndicesConfigurationActions.updateRotationConfiguration(this.state.newRotationConfig);
+      promises.push(promise);
+      // Delete the new state once it has been saved
+      promise.then(() => this.setState({newRotationConfig: undefined}));
+    }
+    if (this.state.newRetentionConfig) {
+      const promise = IndicesConfigurationActions.updateRetentionConfiguration(this.state.newRetentionConfig);
+      promises.push(promise);
+      // Delete the new state once it has been saved
+      promise.then(() => this.setState({newRetentionConfig: undefined}));
+    }
+
+    Promise.all(promises).then(() => {
+      this.refs.indicesConfigurationModal.close();
+    });
+  },
+
+  _openModal() {
+    this.refs.indicesConfigurationModal.open();
+  },
+
+  _updateRotationConfigState(strategy, config) {
+    this.setState({
+      newRotationConfig: {
+        strategy: strategy,
+        config: config,
+      }
+    });
+  },
+
+  _updateRetentionConfigState(strategy, config) {
+    this.setState({
+      newRetentionConfig: {
+        strategy: strategy,
+        config: config,
+      }
+    });
+  },
+
+  render() {
+    let rotationSummary;
+    if (this.state.activeRotationConfig) {
+      rotationSummary = (<IndexMaintenanceStrategiesSummary config={this.state.activeRotationConfig}
+                                                            pluginExports={PluginStore.exports('indexRotationConfig')} />);
+    } else {
+      rotationSummary = (<Spinner />);
+    }
+
+    let retentionSummary;
+    if (this.state.activeRetentionConfig) {
+      retentionSummary = (<IndexMaintenanceStrategiesSummary config={this.state.activeRetentionConfig}
+                                                             pluginExports={PluginStore.exports('indexRetentionConfig')} />);
+    } else {
+      retentionSummary = (<Spinner />);
+    }
+
+    let rotationConfig;
+    if (this.state.activeRotationConfig && this.state.rotationStrategies) {
+      rotationConfig = (<IndexMaintenanceStrategiesConfiguration title='Index Rotation Configuration'
+                                                                 description='Please select an index rotation strategy'
+                                                                 selectPlaceholder='Select rotation strategy'
+                                                                 pluginExports={PluginStore.exports('indexRotationConfig')}
+                                                                 strategies={this.state.rotationStrategies}
+                                                                 activeConfig={this.state.activeRotationConfig}
+                                                                 updateState={this._updateRotationConfigState} />);
+    } else {
+      rotationConfig = (<Spinner />);
+    }
+
+    let retentionConfig;
+    if (this.state.activeRetentionConfig && this.state.retentionStrategies) {
+      retentionConfig = (<IndexMaintenanceStrategiesConfiguration title='Index Retention Configuration'
+                                                                  description='Please select an index retention strategy'
+                                                                  selectPlaceholder='Select retention strategy'
+                                                                  pluginExports={PluginStore.exports('indexRetentionConfig')}
+                                                                  strategies={this.state.retentionStrategies}
+                                                                  activeConfig={this.state.activeRetentionConfig}
+                                                                  updateState={this._updateRetentionConfigState} />);
+    } else {
+      retentionConfig = (<Spinner />);
+    }
+
+    return (
+      <div>
+        <h2>Settings</h2>
+
+        <div style={{marginTop: 10}}>
+          <Row>
+            <Col md={6}>
+              {rotationSummary}
+            </Col>
+            <Col md={6}>
+              {retentionSummary}
+            </Col>
+          </Row>
+          <hr style={{marginBottom: '5', marginTop: '10'}}/>
+          <Button bsStyle='info' bsSize='xs' onClick={() => this._openModal()}>Update configuration</Button>{' '}
+        </div>
+
+        <BootstrapModalForm ref='indicesConfigurationModal'
+                            title='Update Index Settings'
+                            onSubmitForm={this._saveConfiguration}
+                            submitButtonText="Save">
+          {rotationConfig}
+          <hr/>
+          {retentionConfig}
+        </BootstrapModalForm>
+      </div>
+    );
+  },
+});
+
+export default IndicesConfiguration;

--- a/graylog2-web-interface/src/components/indices/retention/ClosingRetentionStrategyConfiguration.jsx
+++ b/graylog2-web-interface/src/components/indices/retention/ClosingRetentionStrategyConfiguration.jsx
@@ -1,0 +1,45 @@
+import React from 'react';
+import { Input } from 'react-bootstrap';
+
+const ClosingRetentionStrategyConfiguration = React.createClass({
+  propTypes: {
+    config: React.PropTypes.object.isRequired,
+    jsonSchema: React.PropTypes.object.isRequired,
+    updateConfig: React.PropTypes.func.isRequired,
+  },
+
+  getInitialState() {
+    return {
+      max_number_of_indices: this.props.config.max_number_of_indices,
+    }
+  },
+
+  _onInputUpdate(field) {
+    return (e) => {
+      const update = {};
+      update[field] = e.target.value;
+
+      this.setState(update);
+      this.props.updateConfig(update);
+    };
+  },
+
+  render() {
+    return (
+      <div>
+        <fieldset>
+          <Input type='number'
+                 id='max-number-of-indices'
+                 label='Max number of indices'
+                 onChange={this._onInputUpdate('max_number_of_indices')}
+                 value={this.state.max_number_of_indices}
+                 help={<span>Maximum number of indices to keep before <strong>closing</strong> the oldest ones</span>}
+                 autoFocus
+                 required />
+        </fieldset>
+      </div>
+    );
+  },
+});
+
+export default ClosingRetentionStrategyConfiguration;

--- a/graylog2-web-interface/src/components/indices/retention/ClosingRetentionStrategyConfiguration.jsx
+++ b/graylog2-web-interface/src/components/indices/retention/ClosingRetentionStrategyConfiguration.jsx
@@ -11,7 +11,7 @@ const ClosingRetentionStrategyConfiguration = React.createClass({
   getInitialState() {
     return {
       max_number_of_indices: this.props.config.max_number_of_indices,
-    }
+    };
   },
 
   _onInputUpdate(field) {
@@ -28,9 +28,9 @@ const ClosingRetentionStrategyConfiguration = React.createClass({
     return (
       <div>
         <fieldset>
-          <Input type='number'
-                 id='max-number-of-indices'
-                 label='Max number of indices'
+          <Input type="number"
+                 id="max-number-of-indices"
+                 label="Max number of indices"
                  onChange={this._onInputUpdate('max_number_of_indices')}
                  value={this.state.max_number_of_indices}
                  help={<span>Maximum number of indices to keep before <strong>closing</strong> the oldest ones</span>}

--- a/graylog2-web-interface/src/components/indices/retention/ClosingRetentionStrategySummary.jsx
+++ b/graylog2-web-interface/src/components/indices/retention/ClosingRetentionStrategySummary.jsx
@@ -1,0 +1,24 @@
+import React from 'react';
+
+import style from '!style!css!../IndicesConfiguration.css';
+
+const ClosingRetentionStrategySummary = React.createClass({
+  propTypes: {
+    config: React.PropTypes.object.isRequired,
+  },
+
+  render() {
+    return (
+      <div>
+        <dl className={style.deflist}>
+          <dt>Index rotation strategy:</dt>
+          <dd>Close</dd>
+          <dt>Max number of indices:</dt>
+          <dd>{this.props.config.max_number_of_indices}</dd>
+        </dl>
+      </div>
+    );
+  },
+});
+
+export default ClosingRetentionStrategySummary;

--- a/graylog2-web-interface/src/components/indices/retention/DeletionRetentionStrategyConfiguration.jsx
+++ b/graylog2-web-interface/src/components/indices/retention/DeletionRetentionStrategyConfiguration.jsx
@@ -11,7 +11,7 @@ const DeletionRetentionStrategyConfiguration = React.createClass({
   getInitialState() {
     return {
       max_number_of_indices: this.props.config.max_number_of_indices,
-    }
+    };
   },
 
   _onInputUpdate(field) {
@@ -28,9 +28,9 @@ const DeletionRetentionStrategyConfiguration = React.createClass({
     return (
       <div>
         <fieldset>
-          <Input type='number'
-                 id='max-number-of-indices'
-                 label='Max number of indices'
+          <Input type="number"
+                 id="max-number-of-indices"
+                 label="Max number of indices"
                  onChange={this._onInputUpdate('max_number_of_indices')}
                  value={this.state.max_number_of_indices}
                  help={<span>Maximum number of indices to keep before <strong>deleting</strong> the oldest ones</span>}

--- a/graylog2-web-interface/src/components/indices/retention/DeletionRetentionStrategyConfiguration.jsx
+++ b/graylog2-web-interface/src/components/indices/retention/DeletionRetentionStrategyConfiguration.jsx
@@ -1,0 +1,45 @@
+import React from 'react';
+import { Input } from 'react-bootstrap';
+
+const DeletionRetentionStrategyConfiguration = React.createClass({
+  propTypes: {
+    config: React.PropTypes.object.isRequired,
+    jsonSchema: React.PropTypes.object.isRequired,
+    updateConfig: React.PropTypes.func.isRequired,
+  },
+
+  getInitialState() {
+    return {
+      max_number_of_indices: this.props.config.max_number_of_indices,
+    }
+  },
+
+  _onInputUpdate(field) {
+    return (e) => {
+      const update = {};
+      update[field] = e.target.value;
+
+      this.setState(update);
+      this.props.updateConfig(update);
+    };
+  },
+
+  render() {
+    return (
+      <div>
+        <fieldset>
+          <Input type='number'
+                 id='max-number-of-indices'
+                 label='Max number of indices'
+                 onChange={this._onInputUpdate('max_number_of_indices')}
+                 value={this.state.max_number_of_indices}
+                 help={<span>Maximum number of indices to keep before <strong>deleting</strong> the oldest ones</span>}
+                 autoFocus
+                 required />
+        </fieldset>
+      </div>
+    );
+  },
+});
+
+export default DeletionRetentionStrategyConfiguration;

--- a/graylog2-web-interface/src/components/indices/retention/DeletionRetentionStrategySummary.jsx
+++ b/graylog2-web-interface/src/components/indices/retention/DeletionRetentionStrategySummary.jsx
@@ -1,0 +1,24 @@
+import React from 'react';
+
+import style from '!style!css!../IndicesConfiguration.css';
+
+const DeletionRetentionStrategySummary = React.createClass({
+  propTypes: {
+    config: React.PropTypes.object.isRequired,
+  },
+
+  render() {
+    return (
+      <div>
+        <dl className={style.deflist}>
+          <dt>Index rotation strategy:</dt>
+          <dd>Delete</dd>
+          <dt>Max number of indices:</dt>
+          <dd>{this.props.config.max_number_of_indices}</dd>
+        </dl>
+      </div>
+    );
+  },
+});
+
+export default DeletionRetentionStrategySummary;

--- a/graylog2-web-interface/src/components/indices/retention/index.js
+++ b/graylog2-web-interface/src/components/indices/retention/index.js
@@ -1,0 +1,22 @@
+import { PluginManifest, PluginStore } from 'graylog-web-plugin/plugin';
+import DeletionRetentionStrategyConfiguration from './DeletionRetentionStrategyConfiguration';
+import DeletionRetentionStrategySummary from './DeletionRetentionStrategySummary';
+import ClosingRetentionStrategyConfiguration from './ClosingRetentionStrategyConfiguration';
+import ClosingRetentionStrategySummary from './ClosingRetentionStrategySummary';
+
+PluginStore.register(new PluginManifest({}, {
+  indexRetentionConfig: [
+    {
+      type: 'org.graylog2.indexer.retention.strategies.DeletionRetentionStrategy',
+      displayName: 'Delete Index',
+      configComponent: DeletionRetentionStrategyConfiguration,
+      summaryComponent: DeletionRetentionStrategySummary,
+    },
+    {
+      type: 'org.graylog2.indexer.retention.strategies.ClosingRetentionStrategy',
+      displayName: 'Close Index',
+      configComponent: ClosingRetentionStrategyConfiguration,
+      summaryComponent: ClosingRetentionStrategySummary,
+    },
+  ],
+}));

--- a/graylog2-web-interface/src/components/indices/rotation/MessageCountRotationStrategyConfiguration.jsx
+++ b/graylog2-web-interface/src/components/indices/rotation/MessageCountRotationStrategyConfiguration.jsx
@@ -11,7 +11,7 @@ const MessageCountRotationStrategyConfiguration = React.createClass({
   getInitialState() {
     return {
       max_docs_per_index: this.props.config.max_docs_per_index,
-    }
+    };
   },
 
   _onInputUpdate(field) {
@@ -28,12 +28,12 @@ const MessageCountRotationStrategyConfiguration = React.createClass({
     return (
       <div>
         <fieldset>
-          <Input type='number'
-                 id='max-docs-per-index'
-                 label='Max documents per index'
+          <Input type="number"
+                 id="max-docs-per-index"
+                 label="Max documents per index"
                  onChange={this._onInputUpdate('max_docs_per_index')}
                  value={this.state.max_docs_per_index}
-                 help='Maximum number of documents in an index before it gets rotated'
+                 help="Maximum number of documents in an index before it gets rotated"
                  autoFocus
                  required />
         </fieldset>

--- a/graylog2-web-interface/src/components/indices/rotation/MessageCountRotationStrategyConfiguration.jsx
+++ b/graylog2-web-interface/src/components/indices/rotation/MessageCountRotationStrategyConfiguration.jsx
@@ -1,0 +1,45 @@
+import React from 'react';
+import { Input } from 'react-bootstrap';
+
+const MessageCountRotationStrategyConfiguration = React.createClass({
+  propTypes: {
+    config: React.PropTypes.object.isRequired,
+    jsonSchema: React.PropTypes.object.isRequired,
+    updateConfig: React.PropTypes.func.isRequired,
+  },
+
+  getInitialState() {
+    return {
+      max_docs_per_index: this.props.config.max_docs_per_index,
+    }
+  },
+
+  _onInputUpdate(field) {
+    return (e) => {
+      const update = {};
+      update[field] = e.target.value;
+
+      this.setState(update);
+      this.props.updateConfig(update);
+    };
+  },
+
+  render() {
+    return (
+      <div>
+        <fieldset>
+          <Input type='number'
+                 id='max-docs-per-index'
+                 label='Max documents per index'
+                 onChange={this._onInputUpdate('max_docs_per_index')}
+                 value={this.state.max_docs_per_index}
+                 help='Maximum number of documents in an index before it gets rotated'
+                 autoFocus
+                 required />
+        </fieldset>
+      </div>
+    );
+  },
+});
+
+export default MessageCountRotationStrategyConfiguration;

--- a/graylog2-web-interface/src/components/indices/rotation/MessageCountRotationStrategySummary.jsx
+++ b/graylog2-web-interface/src/components/indices/rotation/MessageCountRotationStrategySummary.jsx
@@ -1,0 +1,24 @@
+import React from 'react';
+
+import style from '!style!css!../IndicesConfiguration.css';
+
+const MessageCountRotationStrategySummary = React.createClass({
+  propTypes: {
+    config: React.PropTypes.object.isRequired,
+  },
+
+  render() {
+    return (
+      <div>
+        <dl className={style.deflist}>
+          <dt>Index rotation strategy:</dt>
+          <dd>Message Count</dd>
+          <dt>Max docs per index:</dt>
+          <dd>{this.props.config.max_docs_per_index}</dd>
+        </dl>
+      </div>
+    );
+  },
+});
+
+export default MessageCountRotationStrategySummary;

--- a/graylog2-web-interface/src/components/indices/rotation/SizeBasedRotationStrategyConfiguration.jsx
+++ b/graylog2-web-interface/src/components/indices/rotation/SizeBasedRotationStrategyConfiguration.jsx
@@ -1,0 +1,52 @@
+import React from 'react';
+import { Input } from 'react-bootstrap';
+
+import numeral from 'numeral';
+
+const SizeBasedRotationStrategyConfiguration = React.createClass({
+  propTypes: {
+    config: React.PropTypes.object.isRequired,
+    jsonSchema: React.PropTypes.object.isRequired,
+    updateConfig: React.PropTypes.func.isRequired,
+  },
+
+  getInitialState() {
+    return {
+      max_size: this.props.config.max_size,
+    }
+  },
+
+  _onInputUpdate(field) {
+    return (e) => {
+      const update = {};
+      update[field] = e.target.value;
+
+      this.setState(update);
+      this.props.updateConfig(update);
+    };
+  },
+
+  _formatSize() {
+    return numeral(this.state.max_size).format('0.0b');
+  },
+
+  render() {
+    return (
+      <div>
+        <fieldset>
+          <Input type='number'
+                 id='max-size'
+                 label='Max size per index (in bytes)'
+                 onChange={this._onInputUpdate('max_size')}
+                 value={this.state.max_size}
+                 help='Maximum size of an index before it gets rotated'
+                 addonAfter={this._formatSize()}
+                 autoFocus
+                 required />
+        </fieldset>
+      </div>
+    );
+  },
+});
+
+export default SizeBasedRotationStrategyConfiguration;

--- a/graylog2-web-interface/src/components/indices/rotation/SizeBasedRotationStrategyConfiguration.jsx
+++ b/graylog2-web-interface/src/components/indices/rotation/SizeBasedRotationStrategyConfiguration.jsx
@@ -13,7 +13,7 @@ const SizeBasedRotationStrategyConfiguration = React.createClass({
   getInitialState() {
     return {
       max_size: this.props.config.max_size,
-    }
+    };
   },
 
   _onInputUpdate(field) {
@@ -34,12 +34,12 @@ const SizeBasedRotationStrategyConfiguration = React.createClass({
     return (
       <div>
         <fieldset>
-          <Input type='number'
-                 id='max-size'
-                 label='Max size per index (in bytes)'
+          <Input type="number"
+                 id="max-size"
+                 label="Max size per index (in bytes)"
                  onChange={this._onInputUpdate('max_size')}
                  value={this.state.max_size}
-                 help='Maximum size of an index before it gets rotated'
+                 help="Maximum size of an index before it gets rotated"
                  addonAfter={this._formatSize()}
                  autoFocus
                  required />

--- a/graylog2-web-interface/src/components/indices/rotation/SizeBasedRotationStrategySummary.jsx
+++ b/graylog2-web-interface/src/components/indices/rotation/SizeBasedRotationStrategySummary.jsx
@@ -1,0 +1,25 @@
+import React from 'react';
+
+import numeral from 'numeral';
+import style from '!style!css!../IndicesConfiguration.css';
+
+const SizeBasedRotationStrategySummary = React.createClass({
+  propTypes: {
+    config: React.PropTypes.object.isRequired,
+  },
+
+  render() {
+    return (
+      <div>
+        <dl className={style.deflist}>
+          <dt>Index rotation strategy:</dt>
+          <dd>Index Size</dd>
+          <dt>Max index size:</dt>
+          <dd>{this.props.config.max_size} bytes ({numeral(this.props.config.max_size).format('0.0b')})</dd>
+        </dl>
+      </div>
+    );
+  },
+});
+
+export default SizeBasedRotationStrategySummary;

--- a/graylog2-web-interface/src/components/indices/rotation/TimeBasedRotationStrategyConfiguration.jsx
+++ b/graylog2-web-interface/src/components/indices/rotation/TimeBasedRotationStrategyConfiguration.jsx
@@ -12,7 +12,7 @@ const TimeBasedRotationStrategyConfiguration = React.createClass({
   getInitialState() {
     return {
       rotation_period: this.props.config.rotation_period,
-    }
+    };
   },
 
   _onPeriodUpdate(field) {
@@ -55,12 +55,12 @@ const TimeBasedRotationStrategyConfiguration = React.createClass({
   render() {
     return (
       <div>
-        <Input type='text'
-               ref='rotation_period'
-               label='Rotation period (ISO8601 Duration)'
+        <Input type="text"
+               ref="rotation_period"
+               label="Rotation period (ISO8601 Duration)"
                onChange={this._onPeriodUpdate('rotation_period')}
                value={this.state.rotation_period}
-               help='How long an index gets written to before it is rotated. (i.e. "P1D" for 1 day, "PT6H" for 6 hours)'
+               help={'How long an index gets written to before it is rotated. (i.e. "P1D" for 1 day, "PT6H" for 6 hours)'}
                addonAfter={this._formatDuration()}
                bsStyle={this._validationState()}
                autofocus

--- a/graylog2-web-interface/src/components/indices/rotation/TimeBasedRotationStrategyConfiguration.jsx
+++ b/graylog2-web-interface/src/components/indices/rotation/TimeBasedRotationStrategyConfiguration.jsx
@@ -1,0 +1,73 @@
+import React from 'react';
+import { Input } from 'react-bootstrap';
+import moment from 'moment';
+
+const TimeBasedRotationStrategyConfiguration = React.createClass({
+  propTypes: {
+    config: React.PropTypes.object.isRequired,
+    jsonSchema: React.PropTypes.object.isRequired,
+    updateConfig: React.PropTypes.func.isRequired,
+  },
+
+  getInitialState() {
+    return {
+      rotation_period: this.props.config.rotation_period,
+    }
+  },
+
+  _onPeriodUpdate(field) {
+    return () => {
+      const update = {};
+      let period = this.refs[field].getValue().toUpperCase();
+
+      if (!period.startsWith('P')) {
+        period = `P${period}`;
+      }
+
+      update[field] = period;
+
+      this.setState(update);
+
+      if (this._isValidPeriod(update[field])) {
+        // Only propagate state if the config is valid.
+        this.props.updateConfig(update);
+      }
+    };
+  },
+
+  _isValidPeriod(duration) {
+    const check = duration || this.state.rotation_period;
+    return moment.duration(check).asMilliseconds() >= 3600000;
+  },
+
+  _validationState() {
+    if (this._isValidPeriod()) {
+      return undefined;
+    } else {
+      return 'error';
+    }
+  },
+
+  _formatDuration() {
+    return this._isValidPeriod() ? moment.duration(this.state.rotation_period).humanize() : 'invalid (min 1 hour)';
+  },
+
+  render() {
+    return (
+      <div>
+        <Input type='text'
+               ref='rotation_period'
+               label='Rotation period (ISO8601 Duration)'
+               onChange={this._onPeriodUpdate('rotation_period')}
+               value={this.state.rotation_period}
+               help='How long an index gets written to before it is rotated. (i.e. "P1D" for 1 day, "PT6H" for 6 hours)'
+               addonAfter={this._formatDuration()}
+               bsStyle={this._validationState()}
+               autofocus
+               required />
+      </div>
+    );
+  },
+});
+
+export default TimeBasedRotationStrategyConfiguration;

--- a/graylog2-web-interface/src/components/indices/rotation/TimeBasedRotationStrategySummary.jsx
+++ b/graylog2-web-interface/src/components/indices/rotation/TimeBasedRotationStrategySummary.jsx
@@ -1,0 +1,31 @@
+import React from 'react';
+
+import moment from 'moment';
+import style from '!style!css!../IndicesConfiguration.css';
+
+const TimeBasedRotationStrategySummary = React.createClass({
+  propTypes: {
+    config: React.PropTypes.object.isRequired,
+  },
+
+  _humanizedPeriod() {
+    const duration = moment.duration(this.props.config.rotation_period);
+
+    return `${duration.format()}, ${duration.humanize()}`;
+  },
+
+  render() {
+    return (
+      <div>
+        <dl className={style.deflist}>
+          <dt>Index rotation strategy:</dt>
+          <dd>Index Time</dd>
+          <dt>Rotation period:</dt>
+          <dd>{this.props.config.rotation_period} ({this._humanizedPeriod()})</dd>
+        </dl>
+      </div>
+    );
+  },
+});
+
+export default TimeBasedRotationStrategySummary;

--- a/graylog2-web-interface/src/components/indices/rotation/TimeBasedRotationStrategySummary.jsx
+++ b/graylog2-web-interface/src/components/indices/rotation/TimeBasedRotationStrategySummary.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 
 import moment from 'moment';
+import {} from 'moment-duration-format';
 import style from '!style!css!../IndicesConfiguration.css';
 
 const TimeBasedRotationStrategySummary = React.createClass({

--- a/graylog2-web-interface/src/components/indices/rotation/index.js
+++ b/graylog2-web-interface/src/components/indices/rotation/index.js
@@ -1,0 +1,31 @@
+import { PluginManifest, PluginStore } from 'graylog-web-plugin/plugin';
+
+import MessageCountRotationStrategyConfiguration from './MessageCountRotationStrategyConfiguration';
+import MessageCountRotationStrategySummary from './MessageCountRotationStrategySummary';
+import SizeBasedRotationStrategyConfiguration from './SizeBasedRotationStrategyConfiguration';
+import SizeBasedRotationStrategySummary from './SizeBasedRotationStrategySummary';
+import TimeBasedRotationStrategyConfiguration from './TimeBasedRotationStrategyConfiguration';
+import TimeBasedRotationStrategySummary from './TimeBasedRotationStrategySummary';
+
+PluginStore.register(new PluginManifest({}, {
+  indexRotationConfig: [
+    {
+      type: 'org.graylog2.indexer.rotation.strategies.MessageCountRotationStrategy',
+      displayName: 'Index Message Count',
+      configComponent: MessageCountRotationStrategyConfiguration,
+      summaryComponent: MessageCountRotationStrategySummary,
+    },
+    {
+      type: 'org.graylog2.indexer.rotation.strategies.SizeBasedRotationStrategy',
+      displayName: 'Index Size',
+      configComponent: SizeBasedRotationStrategyConfiguration,
+      summaryComponent: SizeBasedRotationStrategySummary,
+    },
+    {
+      type: 'org.graylog2.indexer.rotation.strategies.TimeBasedRotationStrategy',
+      displayName: 'Index Time',
+      configComponent: TimeBasedRotationStrategyConfiguration,
+      summaryComponent: TimeBasedRotationStrategySummary,
+    },
+  ],
+}));

--- a/graylog2-web-interface/src/pages/IndicesPage.jsx
+++ b/graylog2-web-interface/src/pages/IndicesPage.jsx
@@ -16,6 +16,7 @@ import { PageHeader, Spinner } from 'components/common';
 import { DocumentationLink } from 'components/support';
 import { IndexerClusterHealthSummary } from 'components/indexers';
 import { IndicesMaintenanceDropdown, IndicesOverview } from 'components/indices';
+import IndicesConfiguration from 'components/indices/IndicesConfiguration';
 
 const IndicesPage = React.createClass({
   componentDidMount() {
@@ -60,6 +61,12 @@ const IndicesPage = React.createClass({
 
           <IndicesMaintenanceDropdown />
         </PageHeader>
+
+        <Row className="content">
+          <Col md={12}>
+            <IndicesConfiguration />
+          </Col>
+        </Row>
 
         <Row className="content">
           <Col md={12}>

--- a/graylog2-web-interface/src/stores/indices/IndicesConfigurationStore.js
+++ b/graylog2-web-interface/src/stores/indices/IndicesConfigurationStore.js
@@ -1,0 +1,120 @@
+import Reflux from 'reflux';
+
+import UserNotification from 'util/UserNotification';
+import URLUtils from 'util/URLUtils';
+import fetch from 'logic/rest/FetchProvider';
+
+import IndicesConfigurationActions from 'actions/indices/IndicesConfigurationActions';
+
+const urlPrefix = '/system/indices';
+
+const IndicesConfigurationStore = Reflux.createStore({
+  listenables: [IndicesConfigurationActions],
+
+  rotationStrategies: undefined,
+  retentionStrategies: undefined,
+
+  getInitialState() {
+    return {
+      activeRotationConfig: undefined,
+      rotationStrategies: undefined,
+      activeRetentionConfig: undefined,
+      retentionStrategies: undefined,
+    };
+  },
+
+  _url(path) {
+    return URLUtils.qualifyUrl(urlPrefix + path);
+  },
+
+  _addConfigType(strategies, data) {
+    // The config object needs to have the "type" field set to the "default_config.type" to make the REST call work.
+    const result = strategies.find((strategy) => strategy.type === data.strategy);
+
+    if (result) {
+      data.config.type = result.default_config.type;
+    }
+  },
+
+  loadRotationConfig() {
+    const promise = fetch('GET', this._url('/rotation/config'));
+
+    promise.then((response) => {
+      this.trigger({activeRotationConfig: response});
+    }, this._errorHandler('Fetching rotation config failed', 'Could not retrieve rotation config'));
+
+    IndicesConfigurationActions.loadRotationConfig.promise(promise);
+  },
+
+  loadRotationStrategies() {
+    const promise = fetch('GET', this._url('/rotation/strategies'));
+
+    promise.then((response) => {
+      this.rotationStrategies = response.strategies;
+      this.trigger({rotationStrategies: response.strategies});
+    }, this._errorHandler('Fetching rotation strategies failed', 'Could not retrieve rotation strategies'));
+
+    IndicesConfigurationActions.loadRotationStrategies.promise(promise);
+  },
+
+  loadRetentionConfig() {
+    const promise = fetch('GET', this._url('/retention/config'));
+
+    promise.then((response) => {
+      this.trigger({activeRetentionConfig: response});
+    }, this._errorHandler('Fetching retention config failed', 'Could not retrieve retention config'));
+
+    IndicesConfigurationActions.loadRetentionConfig.promise(promise);
+  },
+
+  loadRetentionStrategies() {
+    const promise = fetch('GET', this._url('/retention/strategies'));
+
+    promise.then((response) => {
+      this.retentionStrategies = response.strategies;
+      this.trigger({retentionStrategies: response.strategies});
+    }, this._errorHandler('Fetching retention strategies failed', 'Could not retrieve retention strategies'));
+
+    IndicesConfigurationActions.loadRetentionStrategies.promise(promise);
+  },
+
+  updateRotationConfiguration(data) {
+    this._addConfigType(this.rotationStrategies, data);
+
+    const promise = fetch('PUT', this._url('/rotation/config'), data);
+
+    promise.then((response) => {
+      this.trigger({activeRotationConfig: response});
+      UserNotification.success('Index rotation configuration updated successfully');
+    }, this._errorHandler('Updating index rotation config failed', 'Unable to update index rotation config'));
+
+    IndicesConfigurationActions.updateRotationConfiguration.promise(promise);
+  },
+
+  updateRetentionConfiguration(data) {
+    this._addConfigType(this.retentionStrategies, data);
+
+    const promise = fetch('PUT', this._url('/retention/config'), data);
+
+    promise.then((response) => {
+      this.trigger({activeRetentionConfig: response});
+      UserNotification.success('Index retention configuration updated successfully');
+    }, this._errorHandler('Updating index retention config failed', 'Unable to update index retention config'));
+
+    IndicesConfigurationActions.updateRetentionConfiguration.promise(promise);
+  },
+
+  _errorHandler(message, title) {
+    return (error) => {
+      let errorMessage;
+      try {
+        errorMessage = error.additional.body.message
+      } catch (e) {
+        errorMessage = error.message;
+      }
+      UserNotification.error(`${message}: ${errorMessage}`, title);
+    }
+  },
+});
+
+export default IndicesConfigurationStore;

--- a/graylog2-web-interface/src/stores/indices/IndicesConfigurationStore.js
+++ b/graylog2-web-interface/src/stores/indices/IndicesConfigurationStore.js
@@ -108,12 +108,12 @@ const IndicesConfigurationStore = Reflux.createStore({
     return (error) => {
       let errorMessage;
       try {
-        errorMessage = error.additional.body.message
+        errorMessage = error.additional.body.message;
       } catch (e) {
         errorMessage = error.message;
       }
       UserNotification.error(`${message}: ${errorMessage}`, title);
-    }
+    };
   },
 });
 

--- a/graylog2-web-interface/src/stores/indices/index.jsx
+++ b/graylog2-web-interface/src/stores/indices/index.jsx
@@ -1,3 +1,4 @@
 export { default as DeflectorStore } from './DeflectorStore';
 export { default as IndexRangesStore } from './IndexRangesStore';
 export { default as IndicesStore } from './IndicesStore';
+export { default as IndicesConfigurationStore } from './IndicesConfigurationStore';


### PR DESCRIPTION
Adds UI plugin hooks for index rotation and retention configuration components and UI plugins for all core retention and rotation strategies.

~~Includes two new pieces of infrastructure.~~

#### ~~GraylogWebState~~

~~This provides an API to store global state in a controlled way. All state is stored in a single field in the `document` as a ES6 `Map`. (currently `document.GRAYLOG_WEB_STATE`)~~

~~Trying to overwrite an existing k/v throws an error to avoid accidental state mutations. A k/v needs to be removed before it can be set again.~~

~~Using global state should be avoided, but is sometimes needed to share state between the core and plugins. We might also migrate our existing usage of global state in our application over to this to avoid global namespace pollution. (i.e. `window.appConfig`, `window.plugins`)~~

#### ~~WebEvents~~

~~In `WebEvents.js` I introduced an implementation independent event bus API for the web app which is also usable from plugins. For the pluggable retention/rotation UI this is needed to have child components listen to state changes in a parent component.~~

~~It currently uses the `eventemitter3` library, which is also used by Reflux.~~