### PR TITLE
fix wrong default of limit search parameter

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/indexer/searches/SearchesConfig.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/searches/SearchesConfig.java
@@ -26,7 +26,7 @@ import java.util.List;
 
 @AutoValue
 public abstract class SearchesConfig {
-    private final static int LIMIT = 150;
+    public final static int DEFAULT_LIMIT = 150;
 
     @JsonProperty
     public abstract String query();
@@ -65,14 +65,14 @@ public abstract class SearchesConfig {
                 .filter(filter)
                 .fields(fields)
                 .range(timeRange)
-                .limit(limit > 0 ? limit : LIMIT)
+                .limit(limit)
                 .offset(offset)
                 .sorting(sorting)
                 .build();
     }
 
     public static Builder builder() {
-        return new AutoValue_SearchesConfig.Builder().limit(LIMIT);
+        return new AutoValue_SearchesConfig.Builder();
     }
 
     @AutoValue.Builder
@@ -87,10 +87,19 @@ public abstract class SearchesConfig {
 
         public abstract Builder limit(int limit);
 
+        public abstract int limit();
+
         public abstract Builder offset(int offset);
 
         public abstract Builder sorting(Sorting sorting);
 
-        public abstract SearchesConfig build();
+        abstract SearchesConfig autoBuild();
+
+        public SearchesConfig build() {
+            if (limit() == 0) {
+                limit(DEFAULT_LIMIT);
+            }
+            return autoBuild();
+        }
     }
 }

--- a/graylog2-server/src/main/java/org/graylog2/indexer/searches/SearchesConfig.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/searches/SearchesConfig.java
@@ -96,7 +96,7 @@ public abstract class SearchesConfig {
         abstract SearchesConfig autoBuild();
 
         public SearchesConfig build() {
-            if (limit() == 0) {
+            if (limit() <= 0) {
                 limit(DEFAULT_LIMIT);
             }
             return autoBuild();

--- a/graylog2-server/src/test/java/org/graylog2/indexer/searches/SearchesConfigTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/indexer/searches/SearchesConfigTest.java
@@ -1,0 +1,23 @@
+package org.graylog2.indexer.searches;
+
+import org.graylog2.indexer.searches.timeranges.InvalidRangeParametersException;
+import org.graylog2.indexer.searches.timeranges.RelativeRange;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+public class SearchesConfigTest {
+
+    @Test
+    public void limit() throws InvalidRangeParametersException {
+        final SearchesConfig config = SearchesConfig.builder()
+                .query("")
+                .range(RelativeRange.create(5))
+                .limit(0)
+                .offset(0)
+                .build();
+
+        assertEquals("Limit should default", SearchesConfig.DEFAULT_LIMIT, config.limit());
+    }
+
+}

--- a/graylog2-server/src/test/java/org/graylog2/indexer/searches/SearchesConfigTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/indexer/searches/SearchesConfigTest.java
@@ -1,3 +1,19 @@
+/**
+ * This file is part of Graylog.
+ *
+ * Graylog is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package org.graylog2.indexer.searches;
 
 import org.graylog2.indexer.searches.timeranges.InvalidRangeParametersException;

--- a/graylog2-server/src/test/java/org/graylog2/indexer/searches/SearchesConfigTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/indexer/searches/SearchesConfigTest.java
@@ -25,7 +25,7 @@ import static org.junit.Assert.assertEquals;
 public class SearchesConfigTest {
 
     @Test
-    public void limit() throws InvalidRangeParametersException {
+    public void defaultLimit() throws InvalidRangeParametersException {
         final SearchesConfig config = SearchesConfig.builder()
                 .query("")
                 .range(RelativeRange.create(5))
@@ -34,6 +34,30 @@ public class SearchesConfigTest {
                 .build();
 
         assertEquals("Limit should default", SearchesConfig.DEFAULT_LIMIT, config.limit());
+    }
+
+    @Test
+    public void negativeLimit() throws InvalidRangeParametersException {
+        final SearchesConfig config = SearchesConfig.builder()
+                .query("")
+                .range(RelativeRange.create(5))
+                .limit(-100)
+                .offset(0)
+                .build();
+
+        assertEquals("Limit should default", SearchesConfig.DEFAULT_LIMIT, config.limit());
+    }
+
+    @Test
+    public void explicitLimit() throws InvalidRangeParametersException {
+        final SearchesConfig config = SearchesConfig.builder()
+                .query("")
+                .range(RelativeRange.create(5))
+                .limit(23)
+                .offset(0)
+                .build();
+
+        assertEquals("Limit should not default", 23, config.limit());
     }
 
 }


### PR DESCRIPTION
the builder didn't properly default a 0 value to the actual default

fixes issue #1775