### PR TITLE
Simple query time range limit

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/Configuration.java
+++ b/graylog2-server/src/main/java/org/graylog2/Configuration.java
@@ -26,6 +26,7 @@ import com.github.joschi.jadconfig.validators.PositiveLongValidator;
 import org.graylog2.plugin.BaseConfiguration;
 import org.joda.time.DateTimeZone;
 
+import javax.annotation.Nullable;
 import java.net.URI;
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -157,6 +158,9 @@ public class Configuration extends BaseConfiguration {
 
     @Parameter(value = "index_ranges_cleanup_interval", validator = PositiveDurationValidator.class)
     private Duration indexRangesCleanupInterval = Duration.hours(1L);
+
+    @Parameter(value = "query_time_range_limit")
+    private org.joda.time.Duration queryTimeRangeLimit = null;
 
     public boolean isMaster() {
         return isMaster;
@@ -318,5 +322,10 @@ public class Configuration extends BaseConfiguration {
 
     public Duration getIndexRangesCleanupInterval() {
         return indexRangesCleanupInterval;
+    }
+
+    @Nullable
+    public org.joda.time.Duration getQueryTimeRangeLimit() {
+        return queryTimeRangeLimit;
     }
 }

--- a/graylog2-server/src/main/java/org/graylog2/Configuration.java
+++ b/graylog2-server/src/main/java/org/graylog2/Configuration.java
@@ -26,7 +26,6 @@ import com.github.joschi.jadconfig.validators.PositiveLongValidator;
 import org.graylog2.plugin.BaseConfiguration;
 import org.joda.time.DateTimeZone;
 
-import javax.annotation.Nullable;
 import java.net.URI;
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -158,9 +157,6 @@ public class Configuration extends BaseConfiguration {
 
     @Parameter(value = "index_ranges_cleanup_interval", validator = PositiveDurationValidator.class)
     private Duration indexRangesCleanupInterval = Duration.hours(1L);
-
-    @Parameter(value = "query_time_range_limit")
-    private org.joda.time.Duration queryTimeRangeLimit = null;
 
     public boolean isMaster() {
         return isMaster;
@@ -322,10 +318,5 @@ public class Configuration extends BaseConfiguration {
 
     public Duration getIndexRangesCleanupInterval() {
         return indexRangesCleanupInterval;
-    }
-
-    @Nullable
-    public org.joda.time.Duration getQueryTimeRangeLimit() {
-        return queryTimeRangeLimit;
     }
 }

--- a/graylog2-server/src/main/java/org/graylog2/indexer/searches/SearchesClusterConfig.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/searches/SearchesClusterConfig.java
@@ -1,0 +1,58 @@
+/**
+ * This file is part of Graylog.
+ *
+ * Graylog is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.graylog2.indexer.searches;
+
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.auto.value.AutoValue;
+import org.joda.time.Period;
+
+@JsonAutoDetect
+@AutoValue
+public abstract class SearchesClusterConfig {
+    private static final Period DEFAULT_QUERY_TIME_RANGE_LIMIT = Period.ZERO;
+
+    @JsonProperty("query_time_range_limit")
+    public abstract Period queryTimeRangeLimit();
+
+    @JsonCreator
+    public static SearchesClusterConfig create(@JsonProperty("query_time_range_limit") Period queryTimeRangeLimit) {
+        return builder()
+                .queryTimeRangeLimit(queryTimeRangeLimit)
+                .build();
+    }
+
+    public static SearchesClusterConfig createDefault() {
+        return builder()
+                .queryTimeRangeLimit(DEFAULT_QUERY_TIME_RANGE_LIMIT)
+                .build();
+    }
+
+    public static Builder builder() {
+        return new AutoValue_SearchesClusterConfig.Builder();
+    }
+
+    public abstract Builder toBuilder();
+
+    @AutoValue.Builder
+    public static abstract class Builder {
+        public abstract Builder queryTimeRangeLimit(Period queryTimeRangeLimit);
+
+        public abstract SearchesClusterConfig build();
+    }
+}

--- a/graylog2-server/src/main/java/org/graylog2/indexer/searches/SearchesClusterConfig.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/searches/SearchesClusterConfig.java
@@ -20,26 +20,53 @@ import com.fasterxml.jackson.annotation.JsonAutoDetect;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.auto.value.AutoValue;
+import com.google.common.collect.ImmutableMap;
 import org.joda.time.Period;
+import org.joda.time.format.ISOPeriodFormat;
+
+import java.util.Map;
 
 @JsonAutoDetect
 @AutoValue
 public abstract class SearchesClusterConfig {
+    private static final org.joda.time.format.PeriodFormatter ISO_PERIOD_FORMAT = ISOPeriodFormat.standard();
+
     private static final Period DEFAULT_QUERY_TIME_RANGE_LIMIT = Period.ZERO;
+    private static final Map<Period, String> DEFAULT_RELATIVE_TIMERANGE_OPTIONS = ImmutableMap.<Period, String>builder()
+            .put(ISO_PERIOD_FORMAT.parsePeriod("PT5M"), "Search in the last 5 minutes")
+            .put(ISO_PERIOD_FORMAT.parsePeriod("PT15M"), "Search in the last 15 minutes")
+            .put(ISO_PERIOD_FORMAT.parsePeriod("PT30M"), "Search in the last 30 minutes")
+            .put(ISO_PERIOD_FORMAT.parsePeriod("PT1H"), "Search in the last 1 hour")
+            .put(ISO_PERIOD_FORMAT.parsePeriod("PT2H"), "Search in the last 2 hours")
+            .put(ISO_PERIOD_FORMAT.parsePeriod("PT8H"), "Search in the last 8 hours")
+            .put(ISO_PERIOD_FORMAT.parsePeriod("P1D"), "Search in the last 1 day")
+            .put(ISO_PERIOD_FORMAT.parsePeriod("P2D"), "Search in the last 2 days")
+            .put(ISO_PERIOD_FORMAT.parsePeriod("P5D"), "Search in the last 5 days")
+            .put(ISO_PERIOD_FORMAT.parsePeriod("P7D"), "Search in the last 7 days")
+            .put(ISO_PERIOD_FORMAT.parsePeriod("P14D"), "Search in the last 14 days")
+            .put(ISO_PERIOD_FORMAT.parsePeriod("P30D"), "Search in the last 30 days")
+            .put(Period.ZERO, "Search in all messages")
+            .build();
 
     @JsonProperty("query_time_range_limit")
     public abstract Period queryTimeRangeLimit();
 
+    @JsonProperty("relative_timerange_options")
+    public abstract Map<Period, String> relativeTimerangeOptions();
+
     @JsonCreator
-    public static SearchesClusterConfig create(@JsonProperty("query_time_range_limit") Period queryTimeRangeLimit) {
+    public static SearchesClusterConfig create(@JsonProperty("query_time_range_limit") Period queryTimeRangeLimit,
+                                               @JsonProperty("relative_timerange_options") Map<Period, String> relativeTimerangeOptions) {
         return builder()
                 .queryTimeRangeLimit(queryTimeRangeLimit)
+                .relativeTimerangeOptions(relativeTimerangeOptions)
                 .build();
     }
 
     public static SearchesClusterConfig createDefault() {
         return builder()
                 .queryTimeRangeLimit(DEFAULT_QUERY_TIME_RANGE_LIMIT)
+                .relativeTimerangeOptions(DEFAULT_RELATIVE_TIMERANGE_OPTIONS)
                 .build();
     }
 
@@ -52,6 +79,7 @@ public abstract class SearchesClusterConfig {
     @AutoValue.Builder
     public static abstract class Builder {
         public abstract Builder queryTimeRangeLimit(Period queryTimeRangeLimit);
+        public abstract Builder relativeTimerangeOptions(Map<Period, String> relativeTimerangeOptions);
 
         public abstract SearchesClusterConfig build();
     }

--- a/graylog2-server/src/main/java/org/graylog2/indexer/searches/SearchesClusterConfig.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/searches/SearchesClusterConfig.java
@@ -22,29 +22,26 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.auto.value.AutoValue;
 import com.google.common.collect.ImmutableMap;
 import org.joda.time.Period;
-import org.joda.time.format.ISOPeriodFormat;
 
 import java.util.Map;
 
 @JsonAutoDetect
 @AutoValue
 public abstract class SearchesClusterConfig {
-    private static final org.joda.time.format.PeriodFormatter ISO_PERIOD_FORMAT = ISOPeriodFormat.standard();
-
     private static final Period DEFAULT_QUERY_TIME_RANGE_LIMIT = Period.ZERO;
     private static final Map<Period, String> DEFAULT_RELATIVE_TIMERANGE_OPTIONS = ImmutableMap.<Period, String>builder()
-            .put(ISO_PERIOD_FORMAT.parsePeriod("PT5M"), "Search in the last 5 minutes")
-            .put(ISO_PERIOD_FORMAT.parsePeriod("PT15M"), "Search in the last 15 minutes")
-            .put(ISO_PERIOD_FORMAT.parsePeriod("PT30M"), "Search in the last 30 minutes")
-            .put(ISO_PERIOD_FORMAT.parsePeriod("PT1H"), "Search in the last 1 hour")
-            .put(ISO_PERIOD_FORMAT.parsePeriod("PT2H"), "Search in the last 2 hours")
-            .put(ISO_PERIOD_FORMAT.parsePeriod("PT8H"), "Search in the last 8 hours")
-            .put(ISO_PERIOD_FORMAT.parsePeriod("P1D"), "Search in the last 1 day")
-            .put(ISO_PERIOD_FORMAT.parsePeriod("P2D"), "Search in the last 2 days")
-            .put(ISO_PERIOD_FORMAT.parsePeriod("P5D"), "Search in the last 5 days")
-            .put(ISO_PERIOD_FORMAT.parsePeriod("P7D"), "Search in the last 7 days")
-            .put(ISO_PERIOD_FORMAT.parsePeriod("P14D"), "Search in the last 14 days")
-            .put(ISO_PERIOD_FORMAT.parsePeriod("P30D"), "Search in the last 30 days")
+            .put(Period.minutes(5), "Search in the last 5 minutes")
+            .put(Period.minutes(15), "Search in the last 15 minutes")
+            .put(Period.minutes(30), "Search in the last 30 minutes")
+            .put(Period.hours(1), "Search in the last 1 hour")
+            .put(Period.hours(2), "Search in the last 2 hours")
+            .put(Period.hours(8), "Search in the last 8 hours")
+            .put(Period.days(1), "Search in the last 1 day")
+            .put(Period.days(2), "Search in the last 2 days")
+            .put(Period.days(5), "Search in the last 5 days")
+            .put(Period.days(7), "Search in the last 7 days")
+            .put(Period.days(14), "Search in the last 14 days")
+            .put(Period.days(30), "Search in the last 30 days")
             .put(Period.ZERO, "Search in all messages")
             .build();
 

--- a/graylog2-server/src/main/java/org/graylog2/jackson/JodaTimePeriodKeyDeserializer.java
+++ b/graylog2-server/src/main/java/org/graylog2/jackson/JodaTimePeriodKeyDeserializer.java
@@ -1,0 +1,33 @@
+/**
+ * This file is part of Graylog.
+ *
+ * Graylog is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.graylog2.jackson;
+
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.KeyDeserializer;
+import org.joda.time.format.ISOPeriodFormat;
+
+import java.io.IOException;
+
+public class JodaTimePeriodKeyDeserializer extends KeyDeserializer {
+    @Override
+    public Object deserializeKey(String key, DeserializationContext ctxt) throws IOException {
+        if (key.length() == 0) {
+            return null;
+        }
+        return ISOPeriodFormat.standard().parsePeriod(key);
+    }
+}

--- a/graylog2-server/src/main/java/org/graylog2/periodical/ConfigurationManagementPeriodical.java
+++ b/graylog2-server/src/main/java/org/graylog2/periodical/ConfigurationManagementPeriodical.java
@@ -29,6 +29,7 @@ import org.graylog2.indexer.rotation.strategies.SizeBasedRotationStrategy;
 import org.graylog2.indexer.rotation.strategies.SizeBasedRotationStrategyConfig;
 import org.graylog2.indexer.rotation.strategies.TimeBasedRotationStrategy;
 import org.graylog2.indexer.rotation.strategies.TimeBasedRotationStrategyConfig;
+import org.graylog2.indexer.searches.SearchesClusterConfig;
 import org.graylog2.plugin.cluster.ClusterConfigService;
 import org.graylog2.plugin.indexer.retention.RetentionStrategy;
 import org.graylog2.plugin.indexer.rotation.RotationStrategy;
@@ -126,6 +127,13 @@ public class ConfigurationManagementPeriodical extends Periodical {
                     retentionStrategyClass.getCanonicalName());
             clusterConfigService.write(config);
             LOG.info("Migrated \"{}\" and \"{}\" setting: {}", "rotation_strategy", "retention_strategy", config);
+        }
+
+        final SearchesClusterConfig searchesClusterConfig = clusterConfigService.get(SearchesClusterConfig.class);
+        if (searchesClusterConfig == null) {
+            final SearchesClusterConfig config = SearchesClusterConfig.createDefault();
+            LOG.info("Creating searches cluster config: {}", config);
+            clusterConfigService.write(config);
         }
     }
 

--- a/graylog2-server/src/main/java/org/graylog2/rest/resources/search/AbsoluteSearchResource.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/resources/search/AbsoluteSearchResource.java
@@ -40,10 +40,13 @@ import org.graylog2.rest.resources.search.responses.SearchResponse;
 import org.graylog2.shared.rest.AdditionalMediaType;
 import org.graylog2.shared.security.RestPermissions;
 import org.hibernate.validator.constraints.NotEmpty;
+import org.joda.time.Duration;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import javax.annotation.Nullable;
 import javax.inject.Inject;
+import javax.inject.Named;
 import javax.ws.rs.BadRequestException;
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
@@ -60,8 +63,8 @@ public class AbsoluteSearchResource extends SearchResource {
     private static final Logger LOG = LoggerFactory.getLogger(AbsoluteSearchResource.class);
 
     @Inject
-    public AbsoluteSearchResource(Searches searches) {
-        super(searches);
+    public AbsoluteSearchResource(Searches searches, @Named("query_time_range_limit") @Nullable Duration timeRangeLimit) {
+        super(searches, timeRangeLimit);
     }
 
     @GET
@@ -310,7 +313,7 @@ public class AbsoluteSearchResource extends SearchResource {
 
     private TimeRange buildAbsoluteTimeRange(String from, String to) {
         try {
-            return AbsoluteRange.create(from, to);
+            return restrictTimeRange(AbsoluteRange.create(from, to));
         } catch (InvalidRangeParametersException e) {
             LOG.warn("Invalid timerange parameters provided. Returning HTTP 400.");
             throw new BadRequestException("Invalid timerange parameters provided", e);

--- a/graylog2-server/src/main/java/org/graylog2/rest/resources/search/AbsoluteSearchResource.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/resources/search/AbsoluteSearchResource.java
@@ -32,6 +32,7 @@ import org.graylog2.indexer.searches.Sorting;
 import org.graylog2.indexer.searches.timeranges.AbsoluteRange;
 import org.graylog2.indexer.searches.timeranges.InvalidRangeParametersException;
 import org.graylog2.indexer.searches.timeranges.TimeRange;
+import org.graylog2.plugin.cluster.ClusterConfigService;
 import org.graylog2.rest.models.search.responses.FieldStatsResult;
 import org.graylog2.rest.models.search.responses.HistogramResult;
 import org.graylog2.rest.models.search.responses.TermsResult;
@@ -40,13 +41,10 @@ import org.graylog2.rest.resources.search.responses.SearchResponse;
 import org.graylog2.shared.rest.AdditionalMediaType;
 import org.graylog2.shared.security.RestPermissions;
 import org.hibernate.validator.constraints.NotEmpty;
-import org.joda.time.Duration;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import javax.annotation.Nullable;
 import javax.inject.Inject;
-import javax.inject.Named;
 import javax.ws.rs.BadRequestException;
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
@@ -63,8 +61,8 @@ public class AbsoluteSearchResource extends SearchResource {
     private static final Logger LOG = LoggerFactory.getLogger(AbsoluteSearchResource.class);
 
     @Inject
-    public AbsoluteSearchResource(Searches searches, @Named("query_time_range_limit") @Nullable Duration timeRangeLimit) {
-        super(searches, timeRangeLimit);
+    public AbsoluteSearchResource(Searches searches, ClusterConfigService clusterConfigService) {
+        super(searches, clusterConfigService);
     }
 
     @GET

--- a/graylog2-server/src/main/java/org/graylog2/rest/resources/search/KeywordSearchResource.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/resources/search/KeywordSearchResource.java
@@ -40,10 +40,13 @@ import org.graylog2.rest.resources.search.responses.SearchResponse;
 import org.graylog2.shared.rest.AdditionalMediaType;
 import org.graylog2.shared.security.RestPermissions;
 import org.hibernate.validator.constraints.NotEmpty;
+import org.joda.time.Duration;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import javax.annotation.Nullable;
 import javax.inject.Inject;
+import javax.inject.Named;
 import javax.ws.rs.BadRequestException;
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
@@ -61,8 +64,8 @@ public class KeywordSearchResource extends SearchResource {
     private static final Logger LOG = LoggerFactory.getLogger(KeywordSearchResource.class);
 
     @Inject
-    public KeywordSearchResource(Searches searches) {
-        super(searches);
+    public KeywordSearchResource(Searches searches, @Named("query_time_range_limit") @Nullable Duration timeRangeLimit) {
+        super(searches, timeRangeLimit);
     }
 
     @GET
@@ -295,7 +298,7 @@ public class KeywordSearchResource extends SearchResource {
 
     private TimeRange buildKeywordTimeRange(String keyword) {
         try {
-            return KeywordRange.create(keyword);
+            return restrictTimeRange(KeywordRange.create(keyword));
         } catch (InvalidRangeParametersException e) {
             LOG.warn("Invalid timerange parameters provided. Returning HTTP 400.");
             throw new BadRequestException("Invalid timerange parameters provided", e);

--- a/graylog2-server/src/main/java/org/graylog2/rest/resources/search/KeywordSearchResource.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/resources/search/KeywordSearchResource.java
@@ -32,6 +32,7 @@ import org.graylog2.indexer.searches.Sorting;
 import org.graylog2.indexer.searches.timeranges.InvalidRangeParametersException;
 import org.graylog2.indexer.searches.timeranges.KeywordRange;
 import org.graylog2.indexer.searches.timeranges.TimeRange;
+import org.graylog2.plugin.cluster.ClusterConfigService;
 import org.graylog2.rest.models.search.responses.FieldStatsResult;
 import org.graylog2.rest.models.search.responses.HistogramResult;
 import org.graylog2.rest.models.search.responses.TermsResult;
@@ -40,13 +41,10 @@ import org.graylog2.rest.resources.search.responses.SearchResponse;
 import org.graylog2.shared.rest.AdditionalMediaType;
 import org.graylog2.shared.security.RestPermissions;
 import org.hibernate.validator.constraints.NotEmpty;
-import org.joda.time.Duration;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import javax.annotation.Nullable;
 import javax.inject.Inject;
-import javax.inject.Named;
 import javax.ws.rs.BadRequestException;
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
@@ -64,8 +62,8 @@ public class KeywordSearchResource extends SearchResource {
     private static final Logger LOG = LoggerFactory.getLogger(KeywordSearchResource.class);
 
     @Inject
-    public KeywordSearchResource(Searches searches, @Named("query_time_range_limit") @Nullable Duration timeRangeLimit) {
-        super(searches, timeRangeLimit);
+    public KeywordSearchResource(Searches searches, ClusterConfigService clusterConfigService) {
+        super(searches, clusterConfigService);
     }
 
     @GET

--- a/graylog2-server/src/main/java/org/graylog2/rest/resources/search/RelativeSearchResource.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/resources/search/RelativeSearchResource.java
@@ -40,10 +40,13 @@ import org.graylog2.rest.resources.search.responses.SearchResponse;
 import org.graylog2.shared.rest.AdditionalMediaType;
 import org.graylog2.shared.security.RestPermissions;
 import org.hibernate.validator.constraints.NotEmpty;
+import org.joda.time.Duration;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import javax.annotation.Nullable;
 import javax.inject.Inject;
+import javax.inject.Named;
 import javax.ws.rs.BadRequestException;
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
@@ -61,8 +64,8 @@ public class RelativeSearchResource extends SearchResource {
     private static final Logger LOG = LoggerFactory.getLogger(RelativeSearchResource.class);
 
     @Inject
-    public RelativeSearchResource(Searches searches) {
-        super(searches);
+    public RelativeSearchResource(Searches searches, @Named("query_time_range_limit") @Nullable Duration timeRangeLimit) {
+        super(searches, timeRangeLimit);
     }
 
     @GET
@@ -297,7 +300,7 @@ public class RelativeSearchResource extends SearchResource {
 
     private TimeRange buildRelativeTimeRange(int range) {
         try {
-            return RelativeRange.create(range);
+            return restrictTimeRange(RelativeRange.create(range));
         } catch (InvalidRangeParametersException e) {
             LOG.warn("Invalid timerange parameters provided. Returning HTTP 400.");
             throw new BadRequestException(e);

--- a/graylog2-server/src/main/java/org/graylog2/rest/resources/search/RelativeSearchResource.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/resources/search/RelativeSearchResource.java
@@ -32,6 +32,7 @@ import org.graylog2.indexer.searches.Sorting;
 import org.graylog2.indexer.searches.timeranges.InvalidRangeParametersException;
 import org.graylog2.indexer.searches.timeranges.RelativeRange;
 import org.graylog2.indexer.searches.timeranges.TimeRange;
+import org.graylog2.plugin.cluster.ClusterConfigService;
 import org.graylog2.rest.models.search.responses.FieldStatsResult;
 import org.graylog2.rest.models.search.responses.HistogramResult;
 import org.graylog2.rest.models.search.responses.TermsResult;
@@ -40,13 +41,10 @@ import org.graylog2.rest.resources.search.responses.SearchResponse;
 import org.graylog2.shared.rest.AdditionalMediaType;
 import org.graylog2.shared.security.RestPermissions;
 import org.hibernate.validator.constraints.NotEmpty;
-import org.joda.time.Duration;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import javax.annotation.Nullable;
 import javax.inject.Inject;
-import javax.inject.Named;
 import javax.ws.rs.BadRequestException;
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
@@ -64,8 +62,8 @@ public class RelativeSearchResource extends SearchResource {
     private static final Logger LOG = LoggerFactory.getLogger(RelativeSearchResource.class);
 
     @Inject
-    public RelativeSearchResource(Searches searches, @Named("query_time_range_limit") @Nullable Duration timeRangeLimit) {
-        super(searches, timeRangeLimit);
+    public RelativeSearchResource(Searches searches, ClusterConfigService clusterConfigService) {
+        super(searches, clusterConfigService);
     }
 
     @GET

--- a/graylog2-server/src/main/java/org/graylog2/rest/resources/search/SavedSearchesResource.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/resources/search/SavedSearchesResource.java
@@ -34,8 +34,11 @@ import org.graylog2.rest.resources.search.requests.CreateSavedSearchRequest;
 import org.graylog2.savedsearches.SavedSearch;
 import org.graylog2.savedsearches.SavedSearchService;
 import org.graylog2.shared.security.RestPermissions;
+import org.joda.time.Duration;
 
+import javax.annotation.Nullable;
 import javax.inject.Inject;
+import javax.inject.Named;
 import javax.validation.Valid;
 import javax.ws.rs.BadRequestException;
 import javax.ws.rs.Consumes;
@@ -60,8 +63,9 @@ public class SavedSearchesResource extends SearchResource {
 
     @Inject
     public SavedSearchesResource(Searches searches,
-                                 SavedSearchService savedSearchService) {
-        super(searches);
+                                 SavedSearchService savedSearchService,
+                                 @Named("query_time_range_limit") @Nullable Duration timeRangeLimit) {
+        super(searches, timeRangeLimit);
         this.savedSearchService = savedSearchService;
     }
 

--- a/graylog2-server/src/main/java/org/graylog2/rest/resources/search/SavedSearchesResource.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/resources/search/SavedSearchesResource.java
@@ -29,16 +29,14 @@ import org.apache.shiro.authz.annotation.RequiresPermissions;
 import org.graylog2.database.NotFoundException;
 import org.graylog2.indexer.searches.Searches;
 import org.graylog2.plugin.Tools;
+import org.graylog2.plugin.cluster.ClusterConfigService;
 import org.graylog2.plugin.database.ValidationException;
 import org.graylog2.rest.resources.search.requests.CreateSavedSearchRequest;
 import org.graylog2.savedsearches.SavedSearch;
 import org.graylog2.savedsearches.SavedSearchService;
 import org.graylog2.shared.security.RestPermissions;
-import org.joda.time.Duration;
 
-import javax.annotation.Nullable;
 import javax.inject.Inject;
-import javax.inject.Named;
 import javax.validation.Valid;
 import javax.ws.rs.BadRequestException;
 import javax.ws.rs.Consumes;
@@ -64,8 +62,8 @@ public class SavedSearchesResource extends SearchResource {
     @Inject
     public SavedSearchesResource(Searches searches,
                                  SavedSearchService savedSearchService,
-                                 @Named("query_time_range_limit") @Nullable Duration timeRangeLimit) {
-        super(searches, timeRangeLimit);
+                                 ClusterConfigService clusterConfigService) {
+        super(searches, clusterConfigService);
         this.savedSearchService = savedSearchService;
     }
 

--- a/graylog2-server/src/main/java/org/graylog2/shared/bindings/providers/ObjectMapperProvider.java
+++ b/graylog2-server/src/main/java/org/graylog2/shared/bindings/providers/ObjectMapperProvider.java
@@ -25,9 +25,11 @@ import com.fasterxml.jackson.databind.type.TypeFactory;
 import com.fasterxml.jackson.datatype.guava.GuavaModule;
 import com.fasterxml.jackson.datatype.joda.JodaModule;
 import org.graylog2.database.ObjectIdSerializer;
+import org.graylog2.jackson.JodaTimePeriodKeyDeserializer;
 import org.graylog2.shared.jackson.SizeSerializer;
 import org.graylog2.shared.plugins.GraylogClassLoader;
 import org.graylog2.shared.rest.RangeJsonSerializer;
+import org.joda.time.Period;
 
 import javax.inject.Inject;
 import javax.inject.Provider;
@@ -55,6 +57,7 @@ public class ObjectMapperProvider implements Provider<ObjectMapper> {
                 .registerModule(new GuavaModule())
                 .registerModule(new MetricsModule(TimeUnit.SECONDS, TimeUnit.SECONDS, false))
                 .registerModule(new SimpleModule("Graylog")
+                        .addKeyDeserializer(Period.class, new JodaTimePeriodKeyDeserializer())
                         .addSerializer(new RangeJsonSerializer())
                         .addSerializer(new SizeSerializer())
                         .addSerializer(new ObjectIdSerializer()));

--- a/graylog2-server/src/test/java/org/graylog2/indexer/IndexHelperTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/indexer/IndexHelperTest.java
@@ -18,6 +18,7 @@ package org.graylog2.indexer;
 
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.ImmutableSortedSet;
+import org.elasticsearch.index.query.RangeQueryBuilder;
 import org.graylog2.indexer.ranges.IndexRange;
 import org.graylog2.indexer.ranges.IndexRangeService;
 import org.graylog2.indexer.ranges.MongoIndexRange;
@@ -25,9 +26,11 @@ import org.graylog2.indexer.searches.timeranges.AbsoluteRange;
 import org.graylog2.indexer.searches.timeranges.KeywordRange;
 import org.graylog2.indexer.searches.timeranges.RelativeRange;
 import org.graylog2.indexer.searches.timeranges.TimeRange;
+import org.graylog2.plugin.Tools;
 import org.joda.time.DateTime;
 import org.joda.time.DateTimeUtils;
 import org.joda.time.DateTimeZone;
+import org.joda.time.Duration;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Rule;
@@ -201,5 +204,23 @@ public class IndexHelperTest {
                 .containsOnly(indexRange0.indexName(), indexRange1.indexName());
         assertThat(IndexHelper.determineAffectedIndices(indexRangeService, deflector, relativeRange))
                 .containsOnly(indexRange0.indexName(), indexRange1.indexName());
+    }
+
+    @Test
+    public void getTimestampRangeFilterReturnsNullIfTimeRangeIsNull() {
+        assertThat(IndexHelper.getTimestampRangeFilter(null)).isNull();
+    }
+
+    @Test
+    public void getTimestampRangeFilterReturnsRangeQueryWithGivenTimeRange() {
+        final DateTime from = new DateTime(2016, 1, 15, 12, 0, DateTimeZone.UTC);
+        final DateTime to = from.plusHours(1);
+        final TimeRange timeRange = AbsoluteRange.create(from, to);
+        final RangeQueryBuilder queryBuilder = (RangeQueryBuilder) IndexHelper.getTimestampRangeFilter(timeRange);
+        assertThat(queryBuilder)
+                .isNotNull()
+                .hasFieldOrPropertyWithValue("name", "timestamp")
+                .hasFieldOrPropertyWithValue("from", Tools.buildElasticSearchTimeFormat(from))
+                .hasFieldOrPropertyWithValue("to", Tools.buildElasticSearchTimeFormat(to));
     }
 }

--- a/graylog2-server/src/test/java/org/graylog2/rest/resources/search/SearchResourceTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/rest/resources/search/SearchResourceTest.java
@@ -1,0 +1,89 @@
+/**
+ * This file is part of Graylog.
+ *
+ * Graylog is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.graylog2.rest.resources.search;
+
+import org.graylog2.indexer.searches.Searches;
+import org.graylog2.indexer.searches.timeranges.AbsoluteRange;
+import org.graylog2.indexer.searches.timeranges.TimeRange;
+import org.joda.time.DateTime;
+import org.joda.time.DateTimeZone;
+import org.joda.time.Duration;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnit;
+import org.mockito.junit.MockitoRule;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class SearchResourceTest {
+    @Rule
+    public final MockitoRule mockitoRule = MockitoJUnit.rule();
+
+    @Mock
+    private Searches searches;
+
+    private SearchResource searchResource;
+    private Duration timeRangeLimit;
+
+    @Before
+    public void setUp() {
+        timeRangeLimit = Duration.standardDays(1L);
+        searchResource = new SearchResource(searches, timeRangeLimit) {
+        };
+    }
+
+    @Test
+    public void restrictTimeRangeReturnsGivenTimeRangeWithinLimit() {
+        final DateTime from = new DateTime(2015, 1, 15, 12, 0, DateTimeZone.UTC);
+        final DateTime to = from.plusHours(1);
+        final TimeRange timeRange = AbsoluteRange.create(from, to);
+
+        final TimeRange restrictedTimeRange = searchResource.restrictTimeRange(timeRange);
+        assertThat(restrictedTimeRange).isNotNull();
+        assertThat(restrictedTimeRange.getFrom()).isEqualTo(from);
+        assertThat(restrictedTimeRange.getTo()).isEqualTo(to);
+    }
+
+    @Test
+    public void restrictTimeRangeReturnsGivenTimeRangeIfNoLimitHasBeenSet() {
+        final SearchResource resource = new SearchResource(searches, null) {
+        };
+
+        final DateTime from = new DateTime(2015, 1, 15, 12, 0, DateTimeZone.UTC);
+        final DateTime to = from.plusYears(1);
+        final TimeRange timeRange = AbsoluteRange.create(from, to);
+
+        final TimeRange restrictedTimeRange = resource.restrictTimeRange(timeRange);
+        assertThat(restrictedTimeRange).isNotNull();
+        assertThat(restrictedTimeRange.getFrom()).isEqualTo(from);
+        assertThat(restrictedTimeRange.getTo()).isEqualTo(to);
+    }
+
+    @Test
+    public void restrictTimeRangeReturnsLimitedTimeRange() {
+        final DateTime from = new DateTime(2015, 1, 15, 12, 0, DateTimeZone.UTC);
+        final DateTime to = from.plus(timeRangeLimit.multipliedBy(2L));
+        final TimeRange timeRange = AbsoluteRange.create(from, to);
+        final TimeRange restrictedTimeRange = searchResource.restrictTimeRange(timeRange);
+
+        assertThat(restrictedTimeRange).isNotNull();
+        assertThat(restrictedTimeRange.getFrom()).isEqualTo(to.minus(timeRangeLimit));
+        assertThat(restrictedTimeRange.getTo()).isEqualTo(to);
+    }
+}

--- a/graylog2-web-interface/src/actions/configurations/ConfigurationActions.js
+++ b/graylog2-web-interface/src/actions/configurations/ConfigurationActions.js
@@ -1,0 +1,8 @@
+import Reflux from 'reflux';
+
+const ConfigurationActions = Reflux.createActions({
+  'list': { asyncResult: true },
+  'update': { asyncResult: true },
+});
+
+export default ConfigurationActions;

--- a/graylog2-web-interface/src/actions/configurations/ConfigurationActions.js
+++ b/graylog2-web-interface/src/actions/configurations/ConfigurationActions.js
@@ -2,6 +2,7 @@ import Reflux from 'reflux';
 
 const ConfigurationActions = Reflux.createActions({
   'list': { asyncResult: true },
+  'listSearchesClusterConfig': { asyncResult: true },
   'update': { asyncResult: true },
 });
 

--- a/graylog2-web-interface/src/components/common/PageHeader.jsx
+++ b/graylog2-web-interface/src/components/common/PageHeader.jsx
@@ -27,9 +27,11 @@ const PageHeader = React.createClass({
             <h1>
               {this.props.title}
             </h1>
+            {children[0] &&
             <p className="description">
               {children[0]}
             </p>
+            }
 
             {children[1] &&
             <SupportLink>

--- a/graylog2-web-interface/src/components/configurations/ConfigurationStyles.css
+++ b/graylog2-web-interface/src/components/configurations/ConfigurationStyles.css
@@ -1,0 +1,25 @@
+:local(.deflist) {
+    margin-top: 10px;
+}
+
+:local(.deflist) dt {
+    float: left;
+    clear: left;
+}
+
+:local(.deflist) dd {
+    margin-left: 150px;
+}
+
+:local(.deflistWide) dd {
+    margin-left: 200px;
+}
+
+:local(.topMargin) {
+    margin-top: 10px;
+}
+
+hr:local(.separator) {
+    margin-top: 10px;
+    margin-bottom: 5px;
+}

--- a/graylog2-web-interface/src/components/configurations/SearchesConfig.jsx
+++ b/graylog2-web-interface/src/components/configurations/SearchesConfig.jsx
@@ -1,0 +1,111 @@
+import React from 'react';
+import { Row, Col, Input, Button } from 'react-bootstrap';
+import BootstrapModalForm from 'components/bootstrap/BootstrapModalForm';
+
+import moment from 'moment';
+import {} from 'moment-duration-format';
+
+import style from '!style!css!components/configurations/ConfigurationStyles.css';
+
+const SearchesConfig = React.createClass({
+  propTypes: {
+    config: React.PropTypes.object.isRequired,
+    updateConfig: React.PropTypes.func.isRequired,
+  },
+
+  getInitialState() {
+    return {
+      query_time_range_limit: this._getConfigValue('query_time_range_limit'),
+    };
+  },
+
+  _getConfigValue(field) {
+    return this.props.config ? this.props.config[field] : null;
+  },
+
+  _isValidPeriod(duration) {
+    const check = duration || this.state.query_time_range_limit;
+    return moment.duration(check).asMilliseconds() > 0;
+  },
+
+  _validationState() {
+    if (this._isValidPeriod()) {
+      return undefined;
+    } else {
+      return 'error';
+    }
+  },
+
+  _formatDuration() {
+    return this._isValidPeriod() ? moment.duration(this.state.query_time_range_limit).humanize() : 'invalid';
+  },
+
+  _onPeriodUpdate(field) {
+    return () => {
+      const update = {};
+      let period = this.refs[field].getValue().toUpperCase();
+
+      if (!period.startsWith('P')) {
+        period = `P${period}`;
+      }
+
+      update[field] = period;
+
+      this.setState(update);
+    };
+  },
+
+  _saveConfig() {
+    this.props.updateConfig(this.state).then(() => {
+      this._closeModal();
+    });
+  },
+
+  _openModal() {
+    this.refs.searchesConfigModal.open();
+  },
+
+  _closeModal() {
+    this.refs.searchesConfigModal.close();
+  },
+
+  render() {
+    const config = this.props.config;
+    const duration = moment.duration(config.query_time_range_limit);
+
+    return (
+      <Row>
+        <Col md={12}>
+          <h2>Search Configuration</h2>
+
+          <dl className={style.deflist}>
+            <dt>Query time range limit</dt>
+            <dd>{config.query_time_range_limit} ({duration.format()})</dd>
+          </dl>
+
+          <Button onClick={this._openModal}>Update config</Button>
+
+          <BootstrapModalForm ref="searchesConfigModal"
+                              title="Update Search Configuration"
+                              onSubmitForm={this._saveConfig}
+                              submitButtonText="Save">
+            <fieldset>
+              <Input type="text"
+                     ref="query_time_range_limit"
+                     label="Query time range limit (ISO8601 Duration)"
+                     onChange={this._onPeriodUpdate('query_time_range_limit')}
+                     value={this.state.query_time_range_limit}
+                     help={'The maximum time range for searches. (i.e. "P30D" for 30 days, "PT24H" for 24 hours)'}
+                     addonAfter={this._formatDuration()}
+                     bsStyle={this._validationState()}
+                     autofocus
+                     required />
+            </fieldset>
+          </BootstrapModalForm>
+        </Col>
+      </Row>
+    );
+  },
+});
+
+export default SearchesConfig;

--- a/graylog2-web-interface/src/components/configurations/SearchesConfig.jsx
+++ b/graylog2-web-interface/src/components/configurations/SearchesConfig.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
-import { Row, Col, Input, Button } from 'react-bootstrap';
+import { Input, Button } from 'react-bootstrap';
 import BootstrapModalForm from 'components/bootstrap/BootstrapModalForm';
+import { IfPermitted } from 'components/common';
 
 import moment from 'moment';
 import {} from 'moment-duration-format';
@@ -74,36 +75,38 @@ const SearchesConfig = React.createClass({
     const duration = moment.duration(config.query_time_range_limit);
 
     return (
-      <Row>
-        <Col md={12}>
-          <h2>Search Configuration</h2>
+      <div>
+        <h2>Search Configuration</h2>
 
-          <dl className={style.deflist}>
-            <dt>Query time range limit</dt>
-            <dd>{config.query_time_range_limit} ({duration.format()})</dd>
-          </dl>
+        <dl className={style.deflist}>
+          <dt>Query time range limit</dt>
+          <dd>{config.query_time_range_limit} ({duration.format()})</dd>
+          <dd>The maximum time users can query data in the past. This prevents users from accidentally creating queries which
+            span a lot of data and would need a long time and many resources to complete (if at all).</dd>
+        </dl>
 
-          <Button onClick={this._openModal}>Update config</Button>
+        <IfPermitted permissions="clusterconfigentry:edit">
+          <Button bsStyle="info" bsSize="xs" onClick={this._openModal}>Update</Button>
+        </IfPermitted>
 
-          <BootstrapModalForm ref="searchesConfigModal"
-                              title="Update Search Configuration"
-                              onSubmitForm={this._saveConfig}
-                              submitButtonText="Save">
-            <fieldset>
-              <Input type="text"
-                     ref="query_time_range_limit"
-                     label="Query time range limit (ISO8601 Duration)"
-                     onChange={this._onPeriodUpdate('query_time_range_limit')}
-                     value={this.state.query_time_range_limit}
-                     help={'The maximum time range for searches. (i.e. "P30D" for 30 days, "PT24H" for 24 hours)'}
-                     addonAfter={this._formatDuration()}
-                     bsStyle={this._validationState()}
-                     autofocus
-                     required />
-            </fieldset>
-          </BootstrapModalForm>
-        </Col>
-      </Row>
+        <BootstrapModalForm ref="searchesConfigModal"
+                            title="Update Search Configuration"
+                            onSubmitForm={this._saveConfig}
+                            submitButtonText="Save">
+          <fieldset>
+            <Input type="text"
+                   ref="query_time_range_limit"
+                   label="Query time range limit (ISO8601 Duration)"
+                   onChange={this._onPeriodUpdate('query_time_range_limit')}
+                   value={this.state.query_time_range_limit}
+                   help={'The maximum time range for searches. (i.e. "P30D" for 30 days, "PT24H" for 24 hours)'}
+                   addonAfter={this._formatDuration()}
+                   bsStyle={this._validationState()}
+                   autofocus
+                   required />
+          </fieldset>
+        </BootstrapModalForm>
+      </div>
     );
   },
 });

--- a/graylog2-web-interface/src/components/configurations/SearchesConfig.jsx
+++ b/graylog2-web-interface/src/components/configurations/SearchesConfig.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Input, Button } from 'react-bootstrap';
+import { Input, Button, Row, Col } from 'react-bootstrap';
 import BootstrapModalForm from 'components/bootstrap/BootstrapModalForm';
 import { IfPermitted } from 'components/common';
 
@@ -15,18 +15,52 @@ const SearchesConfig = React.createClass({
   },
 
   getInitialState() {
+    const queryTimeRangeLimit = this._getPropConfigValue('query_time_range_limit');
+    const relativeTimerangeOptions = this._getPropConfigValue('relative_timerange_options');
+
     return {
-      query_time_range_limit: this._getConfigValue('query_time_range_limit'),
+      config: {
+        query_time_range_limit: queryTimeRangeLimit,
+        relative_timerange_options: relativeTimerangeOptions,
+      },
+      timerangeOptionsList: this._createTimerangeOptionsState(relativeTimerangeOptions),
+      limitEnabled: moment.duration(queryTimeRangeLimit).asMilliseconds() > 0,
     };
   },
 
-  _getConfigValue(field) {
+  _getPropConfigValue(field) {
     return this.props.config ? this.props.config[field] : null;
   },
 
+  // Converts the object to a list of objects to make form handling easier.
+  _createTimerangeOptionsState(options) {
+    let optionsList = null;
+
+    if (options) {
+      optionsList = Object.keys(options).map((key) => {
+        return {period: key, description: options[key]};
+      });
+    }
+
+    return optionsList;
+  },
+
+  _updateTimerangeOptionsState(options) {
+    const config = this.state.config;
+    const newTimerangeOptions = {};
+
+    options.forEach((option) => {
+      newTimerangeOptions[option.period] = option.description;
+    });
+
+    config.relative_timerange_options = newTimerangeOptions;
+
+    this.setState({config: config, timerangeOptionsList: options});
+  },
+
   _isValidPeriod(duration) {
-    const check = duration || this.state.query_time_range_limit;
-    return moment.duration(check).asMilliseconds() > 0;
+    const check = duration || this.state.config.query_time_range_limit;
+    return moment.duration(check).asMilliseconds() >= 0;
   },
 
   _validationState() {
@@ -37,13 +71,13 @@ const SearchesConfig = React.createClass({
     }
   },
 
-  _formatDuration() {
-    return this._isValidPeriod() ? moment.duration(this.state.query_time_range_limit).humanize() : 'invalid';
+  _formatDuration(duration) {
+    return this._isValidPeriod() ? moment.duration(duration).humanize() : 'invalid';
   },
 
   _onPeriodUpdate(field) {
     return () => {
-      const update = {};
+      const update = this.state.config;
       let period = this.refs[field].getValue().toUpperCase();
 
       if (!period.startsWith('P')) {
@@ -52,14 +86,80 @@ const SearchesConfig = React.createClass({
 
       update[field] = period;
 
-      this.setState(update);
+      this.setState({config: update});
     };
   },
 
+  _onChecked() {
+    const config = this.state.config;
+
+    if (this.state.limitEnabled) {
+      // If currently enabled, disable by setting the limit to 0 seconds.
+      config.query_time_range_limit = 'PT0S';
+    } else {
+      // If currently not enabled, set a default of 30 days.
+      config.query_time_range_limit = 'P30D';
+    }
+
+    this.setState({config: config, limitEnabled: !this.state.limitEnabled});
+  },
+
+  _onTimerangeOptionRemove(removedIdx) {
+    return () => {
+      const options = this.state.timerangeOptionsList;
+
+      // Remove element at index
+      options.splice(removedIdx, 1);
+
+      this._updateTimerangeOptionsState(options);
+    };
+  },
+
+  _onTimerangeOptionAdd() {
+    const options = this.state.timerangeOptionsList;
+
+    if (options) {
+      options.push({period: 'PT1S', description: ''});
+      this._updateTimerangeOptionsState(options);
+    }
+  },
+
+  _onTimerangeOptionChange(changedIdx, field) {
+    return (e) => {
+      const options = this.state.timerangeOptionsList;
+
+      options.forEach((o, idx) => {
+        if (idx === changedIdx) {
+          let value = e.target.value;
+
+          if (field === 'period') {
+            value = value.toUpperCase();
+            if (!value.startsWith('P')) {
+              value = `P${value}`;
+            }
+          }
+
+          options[idx][field] = value;
+        }
+      });
+
+      this._updateTimerangeOptionsState(options);
+    };
+  },
+
+  _isEnabled() {
+    return this.state.limitEnabled;
+  },
+
   _saveConfig() {
-    this.props.updateConfig(this.state).then(() => {
+    this.props.updateConfig(this.state.config).then(() => {
       this._closeModal();
     });
+  },
+
+  _resetConfig() {
+    // Reset to initial state when the modal is closed without saving.
+    this.setState(this.getInitialState());
   },
 
   _openModal() {
@@ -71,8 +171,59 @@ const SearchesConfig = React.createClass({
   },
 
   render() {
-    const config = this.props.config;
+    const config = this.state.config;
     const duration = moment.duration(config.query_time_range_limit);
+    const limit = this._isEnabled() ? `${config.query_time_range_limit} (${duration.format()})` : 'disabled';
+
+    let timerangeOptions = null;
+    let timerangeOptionsSummary = null;
+    if (this.state.timerangeOptionsList) {
+      timerangeOptions = this.state.timerangeOptionsList.map((option, idx) => {
+        const period = option.period;
+        const description = option.description;
+
+        return (
+          <div key={'timerange-option-' + idx}>
+            <Row>
+              <Col xs={4}>
+                <div className="input-group">
+                  <input type="text"
+                         className="form-control"
+                         value={period}
+                         onChange={this._onTimerangeOptionChange(idx, 'period')} />
+                  <span className="input-group-addon">
+                    {moment.duration(period).format()}
+                  </span>
+                </div>
+              </Col>
+              <Col xs={8}>
+                <div className="input-group">
+                  <input type="text"
+                         className="form-control"
+                         placeholder="Add description..."
+                         value={description}
+                         onChange={this._onTimerangeOptionChange(idx, 'description')} />
+                  <span className="input-group-addon">
+                    <i className="fa fa-trash" style={{cursor: 'pointer'}} onClick={this._onTimerangeOptionRemove(idx)} />
+                  </span>
+                </div>
+              </Col>
+            </Row>
+          </div>
+        );
+      });
+      timerangeOptionsSummary = this.state.timerangeOptionsList.map((option, idx) => {
+        const period = option.period;
+        const description = option.description;
+
+        return (
+          <span key={'timerange-options-summary-' + idx}>
+            <dt>{period}</dt>
+            <dd>{description}</dd>
+          </span>
+        );
+      });
+    }
 
     return (
       <div>
@@ -80,9 +231,15 @@ const SearchesConfig = React.createClass({
 
         <dl className={style.deflist}>
           <dt>Query time range limit</dt>
-          <dd>{config.query_time_range_limit} ({duration.format()})</dd>
+          <dd>{limit}</dd>
           <dd>The maximum time users can query data in the past. This prevents users from accidentally creating queries which
             span a lot of data and would need a long time and many resources to complete (if at all).</dd>
+        </dl>
+
+        <strong>Relative time range options</strong>
+
+        <dl className={style.deflist}>
+          {timerangeOptionsSummary}
         </dl>
 
         <IfPermitted permissions="clusterconfigentry:edit">
@@ -92,18 +249,35 @@ const SearchesConfig = React.createClass({
         <BootstrapModalForm ref="searchesConfigModal"
                             title="Update Search Configuration"
                             onSubmitForm={this._saveConfig}
+                            onModalClose={this._resetConfig}
                             submitButtonText="Save">
           <fieldset>
+            <Input type="checkbox" label="Enable query limit"
+                   name="enabled"
+                   checked={this._isEnabled()}
+                   onChange={this._onChecked}/>
+            {this._isEnabled() &&
             <Input type="text"
                    ref="query_time_range_limit"
                    label="Query time range limit (ISO8601 Duration)"
                    onChange={this._onPeriodUpdate('query_time_range_limit')}
-                   value={this.state.query_time_range_limit}
+                   value={config.query_time_range_limit}
                    help={'The maximum time range for searches. (i.e. "P30D" for 30 days, "PT24H" for 24 hours)'}
-                   addonAfter={this._formatDuration()}
+                   addonAfter={this._formatDuration(this.state.config.query_time_range_limit)}
                    bsStyle={this._validationState()}
-                   autofocus
-                   required />
+                   required/>
+            }
+
+            <div className="form-group">
+              <label className="control-label">Relative Timerange Options</label>
+              <span className="help-block">
+                Configure the available options for the <strong>relative</strong> time range selector as <strong>ISO8601 duration</strong>.
+              </span>
+              <div className="wrapper">
+                {timerangeOptions}
+              </div>
+              <Button bsSize="xs" onClick={this._onTimerangeOptionAdd}>Add option</Button>
+            </div>
           </fieldset>
         </BootstrapModalForm>
       </div>

--- a/graylog2-web-interface/src/components/configurations/SearchesConfig.jsx
+++ b/graylog2-web-interface/src/components/configurations/SearchesConfig.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { Input, Button, Row, Col } from 'react-bootstrap';
 import BootstrapModalForm from 'components/bootstrap/BootstrapModalForm';
 import { IfPermitted } from 'components/common';
+import ObjectUtils from 'util/ObjectUtils';
 
 import moment from 'moment';
 import {} from 'moment-duration-format';
@@ -46,7 +47,7 @@ const SearchesConfig = React.createClass({
   },
 
   _updateTimerangeOptionsState(options) {
-    const config = this.state.config;
+    const config = ObjectUtils.clone(this.state.config);
     const newTimerangeOptions = {};
 
     options.forEach((option) => {
@@ -77,7 +78,7 @@ const SearchesConfig = React.createClass({
 
   _onPeriodUpdate(field) {
     return () => {
-      const update = this.state.config;
+      const update = ObjectUtils.clone(this.state.config);
       let period = this.refs[field].getValue().toUpperCase();
 
       if (!period.startsWith('P')) {
@@ -91,7 +92,7 @@ const SearchesConfig = React.createClass({
   },
 
   _onChecked() {
-    const config = this.state.config;
+    const config = ObjectUtils.clone(this.state.config);
 
     if (this.state.limitEnabled) {
       // If currently enabled, disable by setting the limit to 0 seconds.
@@ -106,7 +107,7 @@ const SearchesConfig = React.createClass({
 
   _onTimerangeOptionRemove(removedIdx) {
     return () => {
-      const options = this.state.timerangeOptionsList;
+      const options = ObjectUtils.clone(this.state.timerangeOptionsList);
 
       // Remove element at index
       options.splice(removedIdx, 1);
@@ -116,7 +117,7 @@ const SearchesConfig = React.createClass({
   },
 
   _onTimerangeOptionAdd() {
-    const options = this.state.timerangeOptionsList;
+    const options = ObjectUtils.clone(this.state.timerangeOptionsList);
 
     if (options) {
       options.push({period: 'PT1S', description: ''});
@@ -126,7 +127,7 @@ const SearchesConfig = React.createClass({
 
   _onTimerangeOptionChange(changedIdx, field) {
     return (e) => {
-      const options = this.state.timerangeOptionsList;
+      const options = ObjectUtils.clone(this.state.timerangeOptionsList);
 
       options.forEach((o, idx) => {
         if (idx === changedIdx) {

--- a/graylog2-web-interface/src/components/navigation/Navigation.jsx
+++ b/graylog2-web-interface/src/components/navigation/Navigation.jsx
@@ -72,6 +72,9 @@ const Navigation = React.createClass({
     if (this._isActive('/system/collectors')) {
       return prefix + ' / Collectors';
     }
+    if (this._isActive('/system/configurations')) {
+      return prefix + ' / Configurations';
+    }
 
     const pluginRoute = PluginStore.exports('systemnavigation').find((pluginRoute) => this._isActive(pluginRoute.path));
     if (pluginRoute) {
@@ -149,6 +152,11 @@ const Navigation = React.createClass({
               <LinkContainer to={Routes.SYSTEM.OVERVIEW}>
                 <MenuItem>Overview</MenuItem>
               </LinkContainer>
+              {this.isPermitted(this.props.permissions, ['CLUSTER_CONFIG_ENTRY_READ']) &&
+              <LinkContainer to={Routes.SYSTEM.CONFIGURATIONS}>
+                <MenuItem>Configurations</MenuItem>
+              </LinkContainer>
+              }
               <LinkContainer to={Routes.SYSTEM.NODES.LIST}>
                 <MenuItem>Nodes</MenuItem>
               </LinkContainer>

--- a/graylog2-web-interface/src/components/search/SearchBar.jsx
+++ b/graylog2-web-interface/src/components/search/SearchBar.jsx
@@ -198,12 +198,19 @@ const SearchBar = React.createClass({
     switch (this.state.rangeType) {
       case 'relative':
         const availableOptions = this.props.config ? this.props.config.relative_timerange_options : null;
+        const timeRangeLimit = this.props.config ? moment.duration(this.props.config.query_time_range_limit) : null;
         let options;
 
         if (availableOptions) {
           let all = null;
           options = Object.keys(availableOptions).map((key) => {
-            const option = (<option key={'relative-option-' + key} value={moment.duration(key).asSeconds()}>{availableOptions[key]}</option>);
+            const seconds = moment.duration(key).asSeconds();
+
+            if (timeRangeLimit > 0 && (seconds > timeRangeLimit.asSeconds() || seconds === 0)) {
+              return null;
+            }
+
+            const option = (<option key={'relative-option-' + key} value={seconds}>{availableOptions[key]}</option>);
 
             // The "search in all messages" option should be the last one.
             if (key === 'PT0S') {

--- a/graylog2-web-interface/src/components/search/SearchBar.jsx
+++ b/graylog2-web-interface/src/components/search/SearchBar.jsx
@@ -17,6 +17,7 @@ import SavedSearchesActions from 'actions/search/SavedSearchesActions';
 import UIUtils from 'util/UIUtils';
 
 import DateTime from 'logic/datetimes/DateTime';
+import moment from 'moment';
 
 const SearchBar = React.createClass({
   propTypes: {
@@ -202,10 +203,10 @@ const SearchBar = React.createClass({
         if (availableOptions) {
           let all = null;
           options = Object.keys(availableOptions).map((key) => {
-            const option = (<option key={'relative-option-' + key} value={key}>{availableOptions[key]}</option>);
+            const option = (<option key={'relative-option-' + key} value={moment.duration(key).asSeconds()}>{availableOptions[key]}</option>);
 
             // The "search in all messages" option should be the last one.
-            if (key === '0') {
+            if (key === 'PT0S') {
               all = option;
               return null;
             } else {

--- a/graylog2-web-interface/src/components/search/SearchBar.jsx
+++ b/graylog2-web-interface/src/components/search/SearchBar.jsx
@@ -22,6 +22,7 @@ const SearchBar = React.createClass({
   propTypes: {
     userPreferences: PropTypes.object,
     savedSearches: PropTypes.arrayOf(PropTypes.object).isRequired,
+    config: PropTypes.object,
   },
 
   getInitialState() {
@@ -195,6 +196,30 @@ const SearchBar = React.createClass({
 
     switch (this.state.rangeType) {
       case 'relative':
+        const availableOptions = this.props.config ? this.props.config.relative_timerange_options : null;
+        let options;
+
+        if (availableOptions) {
+          let all = null;
+          options = Object.keys(availableOptions).map((key) => {
+            const option = (<option key={'relative-option-' + key} value={key}>{availableOptions[key]}</option>);
+
+            // The "search in all messages" option should be the last one.
+            if (key === '0') {
+              all = option;
+              return null;
+            } else {
+              return option;
+            }
+          });
+
+          if (all) {
+            options.push(all);
+          }
+        } else {
+          options = (<option value="300">Loading...</option>);
+        }
+
         selector = (
           <div className="timerange-selector relative"
                style={{width: 270, marginLeft: 50}}>
@@ -205,19 +230,7 @@ const SearchBar = React.createClass({
                    name="relative"
                    onChange={this._rangeParamsChanged('relative')}
                    className="input-sm">
-              <option value="300">Search in the last 5 minutes</option>
-              <option value="900">Search in the last 15 minutes</option>
-              <option value="1800">Search in the last 30 minutes</option>
-              <option value="3600">Search in the last 1 hour</option>
-              <option value="7200">Search in the last 2 hours</option>
-              <option value="28800">Search in the last 8 hours</option>
-              <option value="86400">Search in the last 1 day</option>
-              <option value="172800">Search in the last 2 days</option>
-              <option value="432000">Search in the last 5 days</option>
-              <option value="604800">Search in the last 7 days</option>
-              <option value="1209600">Search in the last 14 days</option>
-              <option value="2592000">Search in the last 30 days</option>
-              <option value="0">Search in all messages</option>
+              {options}
             </Input>
           </div>
         );

--- a/graylog2-web-interface/src/pages/ConfigurationsPage.jsx
+++ b/graylog2-web-interface/src/pages/ConfigurationsPage.jsx
@@ -1,0 +1,62 @@
+import React from 'react';
+import Reflux from 'reflux';
+import { Row, Col } from 'react-bootstrap';
+import { Spinner } from 'components/common';
+
+import ConfigurationsStore from 'stores/configurations/ConfigurationsStore';
+import ConfigurationActions from 'actions/configurations/ConfigurationActions';
+
+import SearchesConfig from 'components/configurations/SearchesConfig';
+
+const ConfigurationsPage = React.createClass({
+  mixins: [Reflux.connect(ConfigurationsStore)],
+
+  getInitialState() {
+    return {
+      configuration: null,
+    };
+  },
+
+  componentDidMount() {
+    ConfigurationActions.list(this.SEARCHES_CLUSTER_CONFIG);
+  },
+
+  SEARCHES_CLUSTER_CONFIG: 'org.graylog2.indexer.searches.SearchesClusterConfig',
+
+  _getConfig(configType) {
+    if (this.state.configuration && this.state.configuration[configType]) {
+      return this.state.configuration[configType];
+    } else {
+      return null;
+    }
+  },
+
+  _onUpdate(configType) {
+    return (config) => {
+      return ConfigurationActions.update(configType, config);
+    };
+  },
+
+  render() {
+    const searchesConfig = this._getConfig(this.SEARCHES_CLUSTER_CONFIG);
+    let searchesConfigComponent;
+    if (searchesConfig) {
+      searchesConfigComponent = (
+        <SearchesConfig config={searchesConfig}
+                        updateConfig={this._onUpdate(this.SEARCHES_CLUSTER_CONFIG)} />
+      );
+    } else {
+      searchesConfigComponent = (<Spinner />);
+    }
+
+    return (
+      <Row className="content">
+        <Col md={12}>
+          {searchesConfigComponent}
+        </Col>
+      </Row>
+    );
+  },
+});
+
+export default ConfigurationsPage;

--- a/graylog2-web-interface/src/pages/ConfigurationsPage.jsx
+++ b/graylog2-web-interface/src/pages/ConfigurationsPage.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import Reflux from 'reflux';
 import { Row, Col } from 'react-bootstrap';
-import { Spinner } from 'components/common';
+import { PageHeader, Spinner } from 'components/common';
 
 import ConfigurationsStore from 'stores/configurations/ConfigurationsStore';
 import ConfigurationActions from 'actions/configurations/ConfigurationActions';
@@ -50,11 +50,19 @@ const ConfigurationsPage = React.createClass({
     }
 
     return (
-      <Row className="content">
-        <Col md={12}>
-          {searchesConfigComponent}
-        </Col>
-      </Row>
+      <span>
+        <PageHeader title="Configurations">
+          <span>
+            You can configure system settings for different sub systems on this page.
+          </span>
+        </PageHeader>
+
+        <Row className="content">
+          <Col md={12}>
+            {searchesConfigComponent}
+          </Col>
+        </Row>
+      </span>
     );
   },
 });

--- a/graylog2-web-interface/src/routing/AppRouter.jsx
+++ b/graylog2-web-interface/src/routing/AppRouter.jsx
@@ -46,6 +46,7 @@ import NodesPage from 'pages/NodesPage';
 import ThreadDumpPage from 'pages/ThreadDumpPage';
 import LdapPage from 'pages/LdapPage';
 import LdapGroupsPage from 'pages/LdapGroupsPage';
+import ConfigurationsPage from 'pages/ConfigurationsPage';
 
 const AppRouter = React.createClass({
   render() {
@@ -79,6 +80,7 @@ const AppRouter = React.createClass({
             <Route path={Routes.import_extractors(':nodeId', ':inputId')} component={ImportExtractorsPage}/>
             <Route path={Routes.export_extractors(':nodeId', ':inputId')} component={ExportExtractorsPage}/>
             <Route path={Routes.SYSTEM.COLLECTORS} component={CollectorsPage}/>
+            <Route path={Routes.SYSTEM.CONFIGURATIONS} component={ConfigurationsPage}/>
             <Route path={Routes.SYSTEM.CONTENTPACKS.LIST} component={ContentPacksPage}/>
             <Route path={Routes.SYSTEM.CONTENTPACKS.EXPORT} component={ExportContentPackPage}/>
             <Route path={Routes.SYSTEM.GROKPATTERNS} component={GrokPatternsPage}/>

--- a/graylog2-web-interface/src/routing/AppWithSearchBar.jsx
+++ b/graylog2-web-interface/src/routing/AppWithSearchBar.jsx
@@ -9,23 +9,31 @@ import SearchStore from 'stores/search/SearchStore';
 import SavedSearchesStore from 'stores/search/SavedSearchesStore';
 import CurrentUserStore from 'stores/users/CurrentUserStore';
 import StreamsStore from 'stores/streams/StreamsStore';
+import ConfigurationsStore from 'stores/configurations/ConfigurationsStore';
 
 import SavedSearchesActions from 'actions/search/SavedSearchesActions';
+import ConfigurationActions from 'actions/configurations/ConfigurationActions';
 
 const AppWithSearchBar = React.createClass({
   propTypes: {
     children: PropTypes.element.isRequired,
     params: PropTypes.object,
   },
-  mixins: [Reflux.connect(CurrentUserStore), Reflux.connect(SavedSearchesStore)],
+  mixins: [
+    Reflux.connect(CurrentUserStore),
+    Reflux.connect(SavedSearchesStore),
+    Reflux.connect(ConfigurationsStore),
+  ],
   getInitialState() {
     return {
       savedSearches: undefined,
       stream: undefined,
+      searchesClusterConfig: undefined,
     };
   },
   componentDidMount() {
     SavedSearchesActions.list.triggerPromise();
+    ConfigurationActions.listSearchesClusterConfig();
     this._loadStream(this.props.params.streamId);
   },
   componentWillReceiveProps(nextProps) {
@@ -63,7 +71,9 @@ const AppWithSearchBar = React.createClass({
 
     return (
       <div className="container-fluid">
-        <SearchBar ref="searchBar" userPreferences={this.state.currentUser.preferences} savedSearches={this.state.savedSearches}/>
+        <SearchBar ref="searchBar" userPreferences={this.state.currentUser.preferences}
+                   savedSearches={this.state.savedSearches}
+                   config={this.state.searchesClusterConfig} />
         <Row id="main-row">
           <Col md={12} id="main-content">
             {this.props.children}

--- a/graylog2-web-interface/src/routing/Routes.jsx
+++ b/graylog2-web-interface/src/routing/Routes.jsx
@@ -7,6 +7,7 @@ const Routes = {
   GETTING_STARTED: '/gettingstarted',
   SYSTEM: {
     COLLECTORS: '/system/collectors',
+    CONFIGURATIONS: '/system/configurations',
     CONTENTPACKS: {
       LIST: '/system/contentpacks',
       EXPORT: '/system/contentpacks/export',

--- a/graylog2-web-interface/src/stores/configurations/ConfigurationsStore.js
+++ b/graylog2-web-interface/src/stores/configurations/ConfigurationsStore.js
@@ -1,0 +1,52 @@
+import Reflux from 'reflux';
+import URLUtils from 'util/URLUtils';
+import fetch from 'logic/rest/FetchProvider';
+import UserNotification from 'util/UserNotification';
+
+import ConfigurationActions from 'actions/configurations/ConfigurationActions';
+
+const urlPrefix = '/system/cluster_config';
+
+const ConfigurationsStore = Reflux.createStore({
+  listenables: [ConfigurationActions],
+
+  _url(path) {
+    return URLUtils.qualifyUrl(urlPrefix + path);
+  },
+
+  list(configType) {
+    const promise = fetch('GET', this._url(`/${configType}`)).then((response) => {
+      const configuration = {};
+      configuration[configType] = response;
+      this.trigger({configuration: configuration});
+    });
+
+    ConfigurationActions.list.promise(promise);
+  },
+
+  update(configType, config) {
+    const promise = fetch('PUT', this._url(`/${configType}`), config);
+
+    promise.then((response) => {
+      const configuration = {};
+      configuration[configType] = response;
+      this.trigger({configuration: configuration});
+    }, this._errorHandler('Search config update failed', `Could not update search config: ${configType}`));
+
+    ConfigurationActions.update.promise(promise);
+  },
+
+  _errorHandler(message, title) {
+    return (error) => {
+      let errorMessage;
+      try {
+        errorMessage = error.additional.body.message;
+      } catch (e) {
+        errorMessage = error.message;
+      }
+      UserNotification.error(`${message}: ${errorMessage}`, title);
+    };
+  },
+});
+
+export default ConfigurationsStore;

--- a/graylog2-web-interface/src/stores/configurations/ConfigurationsStore.js
+++ b/graylog2-web-interface/src/stores/configurations/ConfigurationsStore.js
@@ -24,6 +24,14 @@ const ConfigurationsStore = Reflux.createStore({
     ConfigurationActions.list.promise(promise);
   },
 
+  listSearchesClusterConfig() {
+    const promise = fetch('GET', this._url('/org.graylog2.indexer.searches.SearchesClusterConfig')).then((response) => {
+      this.trigger({searchesClusterConfig: response});
+    });
+
+    ConfigurationActions.listSearchesClusterConfig.promise(promise);
+  },
+
   update(configType, config) {
     const promise = fetch('PUT', this._url(`/${configType}`), config);
 
@@ -31,6 +39,7 @@ const ConfigurationsStore = Reflux.createStore({
       const configuration = {};
       configuration[configType] = response;
       this.trigger({configuration: configuration});
+      UserNotification.success('Configuration updated successfully');
     }, this._errorHandler('Search config update failed', `Could not update search config: ${configType}`));
 
     ConfigurationActions.update.promise(promise);

--- a/misc/graylog.conf
+++ b/misc/graylog.conf
@@ -231,6 +231,11 @@ elasticsearch_analyzer = standard
 # Default: 1m
 #elasticsearch_request_timeout = 1m
 
+# The maximum time users can query data in the past. This prevents users from accidentally creating queries which
+# span a lot of data and would need a long time and many resources to complete (if at all).
+# Default: none
+#query_time_range_limit = 30d
+
 # Time interval for index range information cleanups. This setting defines how often stale index range information
 # is being purged from the database.
 # Default: 1h

--- a/misc/graylog.conf
+++ b/misc/graylog.conf
@@ -231,11 +231,6 @@ elasticsearch_analyzer = standard
 # Default: 1m
 #elasticsearch_request_timeout = 1m
 
-# The maximum time users can query data in the past. This prevents users from accidentally creating queries which
-# span a lot of data and would need a long time and many resources to complete (if at all).
-# Default: none
-#query_time_range_limit = 30d
-
 # Time interval for index range information cleanups. This setting defines how often stale index range information
 # is being purged from the database.
 # Default: 1h


### PR DESCRIPTION
In order to guard the system against accidental queries covering a large time range, the `query_time_range_limit` setting now provides a limit for those queries.

If a search query exceeds the time range given in ´query_time_range_limit`, the query is modified to fit within that limit by adjusting the starting time.