### PR TITLE
Allow overriding web if server uri from X-Graylog-Server-URL header.

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/web/resources/AppConfigResource.java
+++ b/graylog2-server/src/main/java/org/graylog2/web/resources/AppConfigResource.java
@@ -17,8 +17,8 @@
 package org.graylog2.web.resources;
 
 import com.floreysoft.jmte.Engine;
+import com.google.common.base.Strings;
 import com.google.common.io.Resources;
-import org.apache.directory.api.util.Strings;
 import org.graylog2.Configuration;
 
 import javax.inject.Inject;
@@ -73,7 +73,7 @@ public class AppConfigResource {
         if (overrideServerUriHeaders != null && !overrideServerUriHeaders.isEmpty()) {
             Optional<String> firstHeader = overrideServerUriHeaders.stream().filter(s -> {
                 try {
-                    return s != null && Strings.isNotEmpty(s) && new URL(s) != null;
+                    return !Strings.isNullOrEmpty(s) && new URL(s) != null;
                 } catch (MalformedURLException e) {
                     return false;
                 }


### PR DESCRIPTION
This allows http clients (including proxies) to define the server uri
that is used by the web interface code to contact the REST API.

This is especially useful for reverse proxies exposing internal Graylog
servers to the outside. In the proxy configuration you can just set the
X-Graylog-Server-URL that is passed to the backend to a URL that is
visible from outside enabling access to the server from the web if.