### PR TITLE
Append Graylog node ID to Elasticsearch node name

### DIFF
--- a/UPGRADING.asciidoc
+++ b/UPGRADING.asciidoc
@@ -44,14 +44,15 @@ Some settings, which have been deprecated in previous versions, have finally bee
 
 .Removed configuration settings
 |===
-| Setting name       | Replacement
+| Setting name              | Replacement
 
-| `mongodb_host`     | `mongodb_uri`
-| `mongodb_port`     | `mongodb_uri`
-| `mongodb_database` | `mongodb_uri`
-| `mongodb_useauth`  | `mongodb_uri`
-| `mongodb_user`     | `mongodb_uri`
-| `mongodb_password` | `mongodb_uri`
+| `mongodb_host`            | `mongodb_uri`
+| `mongodb_port`            | `mongodb_uri`
+| `mongodb_database`        | `mongodb_uri`
+| `mongodb_useauth`         | `mongodb_uri`
+| `mongodb_user`            | `mongodb_uri`
+| `mongodb_password`        | `mongodb_uri`
+| `elasticsearch_node_name` | `elasticsearch_node_name_prefix`
 |===
 
 
@@ -78,8 +79,8 @@ For better consistency, these prefixes have been changed after the project has b
 
 .Configuration override prefixes
 |===
-| Override                 | Old prefix       | New prefix | Example
+| Override              | Old prefix  | New prefix | Example
 
-| Environment variables | `GRAYLOG2_`        | `GRAYLOG_` | `GRAYLOG_IS_MASTER`
-| System properties | `graylog2.`        | `graylog.` | `graylog.is_master`
+| Environment variables | `GRAYLOG2_` | `GRAYLOG_` | `GRAYLOG_IS_MASTER`
+| System properties     | `graylog2.` | `graylog.` | `graylog.is_master`
 |===

--- a/graylog2-server/src/main/java/org/graylog2/configuration/ElasticsearchConfiguration.java
+++ b/graylog2-server/src/main/java/org/graylog2/configuration/ElasticsearchConfiguration.java
@@ -34,8 +34,8 @@ public class ElasticsearchConfiguration {
     @Parameter(value = "elasticsearch_cluster_name")
     private String clusterName = "graylog";
 
-    @Parameter(value = "elasticsearch_node_name")
-    private String nodeName = "graylog-server";
+    @Parameter(value = "elasticsearch_node_name_prefix")
+    private String nodeNamePrefix = "graylog-";
 
     @Parameter(value = "elasticsearch_node_master")
     private boolean masterNode = false;
@@ -131,8 +131,8 @@ public class ElasticsearchConfiguration {
         return clusterName;
     }
 
-    public String getNodeName() {
-        return nodeName;
+    public String getNodeNamePrefix() {
+        return nodeNamePrefix;
     }
 
     public boolean isMasterNode() {

--- a/misc/graylog.conf
+++ b/misc/graylog.conf
@@ -184,8 +184,11 @@ allow_highlighting = false
 # this must be the same as for your Elasticsearch cluster
 #elasticsearch_cluster_name = graylog
 
-# you could also leave this out, but makes it easier to identify the Graylog embedded Elasticsearch instance
-#elasticsearch_node_name = graylog-server
+# The prefix being used to generate the Elasticsearch node name which makes it easier to identify the specific Graylog
+# server running the embedded Elasticsearch instance. The node name will be constructed by concatenating this prefix
+# and the Graylog node ID (see node_id_file), for example "graylog-17052010-1234-5678-abcd-1337cafebabe".
+# Default: graylog-
+#elasticsearch_node_name_prefix = graylog-
 
 # we don't want the Graylog server to store any data, or be master node
 #elasticsearch_node_master = false


### PR DESCRIPTION
In order for users to quickly identify the Graylog server nodes running a specific embedded Elasticsearch instance, the Graylog node ID is now being used to generate the Elasticsearch node name.

The old `elasticsearch_node_name` setting has been replaced with the new `elasticsearch_node_name_prefix` setting which is `graylog-` by default, leading to Elasticsearch node names like `graylog-17052010-1234-5678-abcd-1337cafebabe`.