### PR TITLE
Simple JAX-RS resource for CRUD operations on cluster configuration

### DIFF
--- a/graylog2-plugin-interfaces/src/main/java/org/graylog2/plugin/cluster/ClusterConfigService.java
+++ b/graylog2-plugin-interfaces/src/main/java/org/graylog2/plugin/cluster/ClusterConfigService.java
@@ -22,6 +22,8 @@
  */
 package org.graylog2.plugin.cluster;
 
+import java.util.Set;
+
 /**
  * Service to save and retrieve cluster configuration beans.
  */
@@ -61,4 +63,11 @@ public interface ClusterConfigService {
      * @return The number of removed entries from the cluster configuration.
      */
     <T> int remove(Class<T> type);
+
+    /**
+     * List all classes of configuration beans in the database.
+     *
+     * @return The list of Java classes being used in the database.
+     */
+    Set<Class<?>> list();
 }

--- a/graylog2-server/src/main/java/org/graylog2/rest/MoreMediaTypes.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/MoreMediaTypes.java
@@ -1,0 +1,32 @@
+/**
+ * This file is part of Graylog.
+ *
+ * Graylog is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.graylog2.rest;
+
+import javax.ws.rs.core.MediaType;
+
+public abstract class MoreMediaTypes {
+    /**
+     * A {@code String} constant representing {@value #APPLICATION_SCHEMA_JSON} media type.
+     */
+    public final static String APPLICATION_SCHEMA_JSON = "application/schema+json";
+    /**
+     * A {@link MediaType} constant representing {@value #APPLICATION_SCHEMA_JSON} media type.
+     *
+     * @see <a href="http://json-schema.org/latest/json-schema-core.html">JSON Schema</a>
+     */
+    public final static MediaType APPLICATION_SCHEMA_JSON_TYPE = new MediaType("application", "schema+json");
+}

--- a/graylog2-server/src/main/java/org/graylog2/rest/models/system/config/ClusterConfigList.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/models/system/config/ClusterConfigList.java
@@ -1,0 +1,44 @@
+/**
+ * This file is part of Graylog.
+ *
+ * Graylog is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.graylog2.rest.models.system.config;
+
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.auto.value.AutoValue;
+import com.google.common.collect.ImmutableSet;
+
+import java.util.Collection;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+@JsonAutoDetect
+@AutoValue
+public abstract class ClusterConfigList {
+    @JsonProperty
+    public abstract int total();
+
+    @JsonProperty
+    public abstract Set<String> classes();
+
+    public static ClusterConfigList create(Collection<String> classes) {
+        return new AutoValue_ClusterConfigList(classes.size(), ImmutableSet.copyOf(classes));
+    }
+
+    public static ClusterConfigList createFromClass(Collection<Class<?>> classes) {
+        return create(classes.stream().map(Class::getCanonicalName).collect(Collectors.toSet()));
+    }
+}

--- a/graylog2-server/src/main/java/org/graylog2/rest/resources/system/ClusterConfigResource.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/resources/system/ClusterConfigResource.java
@@ -1,0 +1,152 @@
+/**
+ * This file is part of Graylog.
+ *
+ * Graylog is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.graylog2.rest.resources.system;
+
+import com.codahale.metrics.annotation.Timed;
+import com.fasterxml.jackson.databind.JsonMappingException;
+import com.fasterxml.jackson.module.jsonSchema.JsonSchema;
+import com.fasterxml.jackson.module.jsonSchema.factories.SchemaFactoryWrapper;
+import com.wordnik.swagger.annotations.Api;
+import com.wordnik.swagger.annotations.ApiOperation;
+import com.wordnik.swagger.annotations.ApiParam;
+import org.apache.shiro.authz.annotation.RequiresAuthentication;
+import org.graylog2.plugin.cluster.ClusterConfigService;
+import org.graylog2.rest.MoreMediaTypes;
+import org.graylog2.rest.models.system.config.ClusterConfigList;
+import org.graylog2.shared.rest.resources.RestResource;
+import org.hibernate.validator.constraints.NotBlank;
+
+import javax.annotation.Nullable;
+import javax.inject.Inject;
+import javax.validation.constraints.NotNull;
+import javax.ws.rs.Consumes;
+import javax.ws.rs.DELETE;
+import javax.ws.rs.GET;
+import javax.ws.rs.InternalServerErrorException;
+import javax.ws.rs.NotFoundException;
+import javax.ws.rs.PUT;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Set;
+
+import static java.util.Objects.requireNonNull;
+
+@Api(value = "System/ClusterConfig", description = "Graylog Cluster Configuration")
+@RequiresAuthentication
+@Path("/system/cluster_config")
+@Produces(MediaType.APPLICATION_JSON)
+public class ClusterConfigResource extends RestResource {
+    private final ClusterConfigService clusterConfigService;
+
+    @Inject
+    public ClusterConfigResource(ClusterConfigService clusterConfigService) {
+        this.clusterConfigService = requireNonNull(clusterConfigService);
+    }
+
+    @GET
+    @ApiOperation(value = "List all configuration classes")
+    @Timed
+    public ClusterConfigList list() {
+        final Set<Class<?>> classes = clusterConfigService.list();
+
+        return ClusterConfigList.createFromClass(classes);
+    }
+
+    @GET
+    @Path("{configClass}")
+    @ApiOperation(value = "Get configuration settings from database")
+    @Timed
+    public Object read(@ApiParam(name = "configClass", value = "The name of the cluster configuration class", required = true)
+                       @PathParam("configClass") @NotBlank String configClass) {
+        final Class<?> cls = classFromName(configClass);
+        if (cls == null) {
+            throw new NotFoundException("Couldn't find configuration class \"" + configClass + "\"");
+        }
+
+        return clusterConfigService.get(cls);
+    }
+
+    @PUT
+    @Timed
+    @Path("{configClass}")
+    @Consumes(MediaType.APPLICATION_JSON)
+    @ApiOperation(value = "Update configuration in database")
+    public Response update(@ApiParam(name = "configClass", value = "The name of the cluster configuration class", required = true)
+                           @PathParam("configClass") @NotBlank String configClass,
+                           @ApiParam(name = "body", value = "The payload of the cluster configuration", required = true)
+                           @NotNull InputStream body) throws IOException {
+        final Class<?> cls = classFromName(configClass);
+        if (cls == null) {
+            throw new NotFoundException("Couldn't find configuration class \"" + configClass + "\"");
+        }
+
+        final Object o = objectMapper.readValue(body, cls);
+        clusterConfigService.write(o);
+
+        return Response.accepted(o).build();
+    }
+
+    @DELETE
+    @Path("{configClass}")
+    @ApiOperation(value = "Delete configuration settings from database")
+    @Timed
+    public void delete(@ApiParam(name = "configClass", value = "The name of the cluster configuration class", required = true)
+                       @PathParam("configClass") @NotBlank String configClass) {
+        final Class<?> cls = classFromName(configClass);
+        if (cls == null) {
+            throw new NotFoundException("Couldn't find configuration class \"" + configClass + "\"");
+        }
+
+        clusterConfigService.remove(cls);
+    }
+
+    @GET
+    @Path("{configClass}")
+    @Produces(MoreMediaTypes.APPLICATION_SCHEMA_JSON)
+    @ApiOperation(value = "Get JSON schema of configuration class")
+    @Timed
+    public JsonSchema schema(@ApiParam(name = "configClass", value = "The name of the cluster configuration class", required = true)
+                             @PathParam("configClass") @NotBlank String configClass) {
+        final Class<?> cls = classFromName(configClass);
+        if (cls == null) {
+            throw new NotFoundException("Couldn't find configuration class \"" + configClass + "\"");
+        }
+
+        final SchemaFactoryWrapper visitor = new SchemaFactoryWrapper();
+        try {
+            objectMapper.acceptJsonFormatVisitor(objectMapper.constructType(cls), visitor);
+        } catch (JsonMappingException e) {
+            throw new InternalServerErrorException("Couldn't generate JSON schema for configuration class " + configClass, e);
+        }
+
+        return visitor.finalSchema();
+    }
+
+    @Nullable
+    private Class<?> classFromName(String className) {
+        try {
+            return Class.forName(className);
+        } catch (ClassNotFoundException e) {
+            return null;
+        }
+    }
+}

--- a/graylog2-server/src/main/java/org/graylog2/rest/resources/system/ClusterConfigResource.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/resources/system/ClusterConfigResource.java
@@ -24,10 +24,12 @@ import com.wordnik.swagger.annotations.Api;
 import com.wordnik.swagger.annotations.ApiOperation;
 import com.wordnik.swagger.annotations.ApiParam;
 import org.apache.shiro.authz.annotation.RequiresAuthentication;
+import org.apache.shiro.authz.annotation.RequiresPermissions;
 import org.graylog2.plugin.cluster.ClusterConfigService;
 import org.graylog2.rest.MoreMediaTypes;
 import org.graylog2.rest.models.system.config.ClusterConfigList;
 import org.graylog2.shared.rest.resources.RestResource;
+import org.graylog2.shared.security.RestPermissions;
 import org.hibernate.validator.constraints.NotBlank;
 
 import javax.annotation.Nullable;
@@ -65,6 +67,7 @@ public class ClusterConfigResource extends RestResource {
     @GET
     @ApiOperation(value = "List all configuration classes")
     @Timed
+    @RequiresPermissions(RestPermissions.CLUSTER_CONFIG_ENTRY_READ)
     public ClusterConfigList list() {
         final Set<Class<?>> classes = clusterConfigService.list();
 
@@ -75,6 +78,7 @@ public class ClusterConfigResource extends RestResource {
     @Path("{configClass}")
     @ApiOperation(value = "Get configuration settings from database")
     @Timed
+    @RequiresPermissions(RestPermissions.CLUSTER_CONFIG_ENTRY_READ)
     public Object read(@ApiParam(name = "configClass", value = "The name of the cluster configuration class", required = true)
                        @PathParam("configClass") @NotBlank String configClass) {
         final Class<?> cls = classFromName(configClass);
@@ -90,6 +94,7 @@ public class ClusterConfigResource extends RestResource {
     @Path("{configClass}")
     @Consumes(MediaType.APPLICATION_JSON)
     @ApiOperation(value = "Update configuration in database")
+    @RequiresPermissions({RestPermissions.CLUSTER_CONFIG_ENTRY_CREATE, RestPermissions.CLUSTER_CONFIG_ENTRY_EDIT})
     public Response update(@ApiParam(name = "configClass", value = "The name of the cluster configuration class", required = true)
                            @PathParam("configClass") @NotBlank String configClass,
                            @ApiParam(name = "body", value = "The payload of the cluster configuration", required = true)
@@ -109,6 +114,7 @@ public class ClusterConfigResource extends RestResource {
     @Path("{configClass}")
     @ApiOperation(value = "Delete configuration settings from database")
     @Timed
+    @RequiresPermissions(RestPermissions.CLUSTER_CONFIG_ENTRY_DELETE)
     public void delete(@ApiParam(name = "configClass", value = "The name of the cluster configuration class", required = true)
                        @PathParam("configClass") @NotBlank String configClass) {
         final Class<?> cls = classFromName(configClass);
@@ -124,6 +130,7 @@ public class ClusterConfigResource extends RestResource {
     @Produces(MoreMediaTypes.APPLICATION_SCHEMA_JSON)
     @ApiOperation(value = "Get JSON schema of configuration class")
     @Timed
+    @RequiresPermissions(RestPermissions.CLUSTER_CONFIG_ENTRY_READ)
     public JsonSchema schema(@ApiParam(name = "configClass", value = "The name of the cluster configuration class", required = true)
                              @PathParam("configClass") @NotBlank String configClass) {
         final Class<?> cls = classFromName(configClass);

--- a/graylog2-server/src/test/java/org/graylog2/cluster/AnotherCustomConfig.java
+++ b/graylog2-server/src/test/java/org/graylog2/cluster/AnotherCustomConfig.java
@@ -1,0 +1,21 @@
+/**
+ * This file is part of Graylog.
+ *
+ * Graylog is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.graylog2.cluster;
+
+public class AnotherCustomConfig {
+    public String text;
+}


### PR DESCRIPTION
This PR adds a relatively simple JAX-RS resource for performing CRUD operations on the Graylog cluster configuration.