### PR TITLE
Allow to define default instances for cluster configuration classes

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/bundles/ContentPackLoaderConfig.java
+++ b/graylog2-server/src/main/java/org/graylog2/bundles/ContentPackLoaderConfig.java
@@ -28,9 +28,6 @@ import java.util.Set;
 @AutoValue
 @JsonAutoDetect
 public abstract class ContentPackLoaderConfig {
-    public static final ContentPackLoaderConfig EMPTY =
-            create(Collections.<String>emptySet(), Collections.<String>emptySet(), Collections.<String, String>emptyMap());
-
     @JsonProperty("loaded_content_packs")
     public abstract Set<String> loadedContentPacks();
 
@@ -45,5 +42,9 @@ public abstract class ContentPackLoaderConfig {
                                                  @JsonProperty("applied_content_packs") Set<String> appliedContentPacks,
                                                  @JsonProperty("checksums") Map<String, String> checksums) {
         return new AutoValue_ContentPackLoaderConfig(loadedContentPacks, appliedContentPacks, checksums);
+    }
+
+    public static ContentPackLoaderConfig defaultConfig() {
+        return create(Collections.emptySet(), Collections.emptySet(), Collections.emptyMap());
     }
 }

--- a/graylog2-server/src/main/java/org/graylog2/cluster/UserPermissionMigrationState.java
+++ b/graylog2-server/src/main/java/org/graylog2/cluster/UserPermissionMigrationState.java
@@ -32,4 +32,8 @@ public abstract class UserPermissionMigrationState {
     public static UserPermissionMigrationState create(@JsonProperty("migration_done") boolean migrationDone) {
         return new AutoValue_UserPermissionMigrationState(migrationDone);
     }
+
+    public static UserPermissionMigrationState defaultConfig() {
+        return create(false);
+    }
 }

--- a/graylog2-server/src/main/java/org/graylog2/indexer/retention/strategies/AbstractIndexCountBasedRetentionStrategy.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/retention/strategies/AbstractIndexCountBasedRetentionStrategy.java
@@ -17,7 +17,6 @@
 
 package org.graylog2.indexer.retention.strategies;
 
-import com.google.common.base.Optional;
 import org.elasticsearch.action.admin.indices.stats.IndexStats;
 import org.graylog2.indexer.Deflector;
 import org.graylog2.indexer.IndexHelper;
@@ -31,6 +30,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.Map;
+import java.util.Optional;
 
 public abstract class AbstractIndexCountBasedRetentionStrategy implements RetentionStrategy {
     private static final Logger LOG = LoggerFactory.getLogger(AbstractIndexCountBasedRetentionStrategy.class);

--- a/graylog2-server/src/main/java/org/graylog2/indexer/retention/strategies/ClosingRetentionStrategy.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/retention/strategies/ClosingRetentionStrategy.java
@@ -16,7 +16,6 @@
  */
 package org.graylog2.indexer.retention.strategies;
 
-import com.google.common.base.Optional;
 import com.google.common.base.Stopwatch;
 import org.graylog2.indexer.Deflector;
 import org.graylog2.indexer.indices.Indices;
@@ -27,6 +26,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import javax.inject.Inject;
+import java.util.Optional;
 import java.util.concurrent.TimeUnit;
 
 public class ClosingRetentionStrategy extends AbstractIndexCountBasedRetentionStrategy {
@@ -47,13 +47,8 @@ public class ClosingRetentionStrategy extends AbstractIndexCountBasedRetentionSt
 
     @Override
     protected Optional<Integer> getMaxNumberOfIndices() {
-        final ClosingRetentionStrategyConfig config = clusterConfigService.get(ClosingRetentionStrategyConfig.class);
-
-        if (config != null) {
-            return Optional.of(config.maxNumberOfIndices());
-        } else {
-            return Optional.absent();
-        }
+        return clusterConfigService.get(ClosingRetentionStrategyConfig.class)
+                .flatMap(config -> Optional.of(config.maxNumberOfIndices()));
     }
 
     @Override

--- a/graylog2-server/src/main/java/org/graylog2/indexer/retention/strategies/ClosingRetentionStrategyConfig.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/retention/strategies/ClosingRetentionStrategyConfig.java
@@ -47,4 +47,8 @@ public abstract class ClosingRetentionStrategyConfig implements RetentionStrateg
     public static ClosingRetentionStrategyConfig createDefault() {
         return create(DEFAULT_MAX_NUMBER_OF_INDICES);
     }
+
+    public static ClosingRetentionStrategyConfig defaultConfig() {
+        return createDefault();
+    }
 }

--- a/graylog2-server/src/main/java/org/graylog2/indexer/retention/strategies/DeletionRetentionStrategy.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/retention/strategies/DeletionRetentionStrategy.java
@@ -16,7 +16,6 @@
  */
 package org.graylog2.indexer.retention.strategies;
 
-import com.google.common.base.Optional;
 import com.google.common.base.Stopwatch;
 import org.graylog2.indexer.Deflector;
 import org.graylog2.indexer.indices.Indices;
@@ -27,6 +26,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import javax.inject.Inject;
+import java.util.Optional;
 import java.util.concurrent.TimeUnit;
 
 public class DeletionRetentionStrategy extends AbstractIndexCountBasedRetentionStrategy {
@@ -47,13 +47,8 @@ public class DeletionRetentionStrategy extends AbstractIndexCountBasedRetentionS
 
     @Override
     protected Optional<Integer> getMaxNumberOfIndices() {
-        final DeletionRetentionStrategyConfig config = clusterConfigService.get(DeletionRetentionStrategyConfig.class);
-
-        if (config != null) {
-            return Optional.of(config.maxNumberOfIndices());
-        } else {
-            return Optional.absent();
-        }
+        return clusterConfigService.get(DeletionRetentionStrategyConfig.class)
+                .flatMap(config -> Optional.of(config.maxNumberOfIndices()));
     }
 
     @Override
@@ -73,6 +68,6 @@ public class DeletionRetentionStrategy extends AbstractIndexCountBasedRetentionS
 
     @Override
     public RetentionStrategyConfig defaultConfiguration() {
-        return DeletionRetentionStrategyConfig.createDefault();
+        return DeletionRetentionStrategyConfig.defaultConfig();
     }
 }

--- a/graylog2-server/src/main/java/org/graylog2/indexer/retention/strategies/DeletionRetentionStrategyConfig.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/retention/strategies/DeletionRetentionStrategyConfig.java
@@ -44,7 +44,7 @@ public abstract class DeletionRetentionStrategyConfig implements RetentionStrate
         return new AutoValue_DeletionRetentionStrategyConfig(DeletionRetentionStrategyConfig.class.getCanonicalName(), maxNumberOfIndices);
     }
 
-    public static DeletionRetentionStrategyConfig createDefault() {
+    public static DeletionRetentionStrategyConfig defaultConfig() {
         return create(DEFAULT_MAX_NUMBER_OF_INDICES);
     }
 }

--- a/graylog2-server/src/main/java/org/graylog2/indexer/rotation/strategies/MessageCountRotationStrategy.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/rotation/strategies/MessageCountRotationStrategy.java
@@ -29,6 +29,7 @@ import javax.annotation.Nullable;
 import javax.inject.Inject;
 import java.text.MessageFormat;
 import java.util.Locale;
+import java.util.Optional;
 
 public class MessageCountRotationStrategy extends AbstractRotationStrategy {
     private static final Logger log = LoggerFactory.getLogger(MessageCountRotationStrategy.class);
@@ -50,15 +51,15 @@ public class MessageCountRotationStrategy extends AbstractRotationStrategy {
 
     @Override
     public RotationStrategyConfig defaultConfiguration() {
-        return MessageCountRotationStrategyConfig.createDefault();
+        return MessageCountRotationStrategyConfig.defaultConfig();
     }
 
     @Nullable
     @Override
     protected Result shouldRotate(String index) {
-        final MessageCountRotationStrategyConfig config = clusterConfigService.get(MessageCountRotationStrategyConfig.class);
+        final Optional<MessageCountRotationStrategyConfig> config = clusterConfigService.get(MessageCountRotationStrategyConfig.class);
 
-        if (config == null) {
+        if (!config.isPresent()) {
             log.warn("No rotation strategy configuration found, not running index rotation!");
             return null;
         }
@@ -67,8 +68,8 @@ public class MessageCountRotationStrategy extends AbstractRotationStrategy {
             final long numberOfMessages = indices.numberOfMessages(index);
             return new Result(index,
                               numberOfMessages,
-                              config.maxDocsPerIndex(),
-                              numberOfMessages > config.maxDocsPerIndex());
+                              config.get().maxDocsPerIndex(),
+                              numberOfMessages > config.get().maxDocsPerIndex());
         } catch (IndexNotFoundException e) {
             log.error("Unknown index, cannot perform rotation", e);
             return null;

--- a/graylog2-server/src/main/java/org/graylog2/indexer/rotation/strategies/MessageCountRotationStrategyConfig.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/rotation/strategies/MessageCountRotationStrategyConfig.java
@@ -44,7 +44,7 @@ public abstract class MessageCountRotationStrategyConfig implements RotationStra
         return create(MessageCountRotationStrategyConfig.class.getCanonicalName(), maxDocsPerIndex);
     }
 
-    public static MessageCountRotationStrategyConfig createDefault() {
+    public static MessageCountRotationStrategyConfig defaultConfig() {
         return create(DEFAULT_MAX_DOCS_PER_INDEX);
     }
 }

--- a/graylog2-server/src/main/java/org/graylog2/indexer/rotation/strategies/SizeBasedRotationStrategyConfig.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/rotation/strategies/SizeBasedRotationStrategyConfig.java
@@ -45,7 +45,7 @@ public abstract class SizeBasedRotationStrategyConfig implements RotationStrateg
         return create(SizeBasedRotationStrategyConfig.class.getCanonicalName(), maxSize);
     }
 
-    public static SizeBasedRotationStrategyConfig createDefault() {
+    public static SizeBasedRotationStrategyConfig defaultConfig() {
         return create(DEFAULT_MAX_SIZE);
     }
 }

--- a/graylog2-server/src/main/java/org/graylog2/indexer/rotation/strategies/TimeBasedRotationStrategy.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/rotation/strategies/TimeBasedRotationStrategy.java
@@ -31,11 +31,11 @@ import org.joda.time.Period;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import javax.inject.Inject;
 import javax.inject.Singleton;
 import java.text.MessageFormat;
+import java.util.Optional;
 
 import static org.joda.time.DateTimeFieldType.dayOfMonth;
 import static org.joda.time.DateTimeFieldType.hourOfDay;
@@ -70,7 +70,7 @@ public class TimeBasedRotationStrategy extends AbstractRotationStrategy {
 
     @Override
     public RotationStrategyConfig defaultConfiguration() {
-        return TimeBasedRotationStrategyConfig.createDefault();
+        return TimeBasedRotationStrategyConfig.defaultConfig();
     }
 
     /**
@@ -132,17 +132,16 @@ public class TimeBasedRotationStrategy extends AbstractRotationStrategy {
         return new DateTime(newValue, DateTimeZone.UTC);
     }
 
-    @Nonnull
     @Override
     protected Result shouldRotate(String index) {
-        final TimeBasedRotationStrategyConfig config = clusterConfigService.get(TimeBasedRotationStrategyConfig.class);
+        final Optional<TimeBasedRotationStrategyConfig> config = clusterConfigService.get(TimeBasedRotationStrategyConfig.class);
 
-        if (config == null) {
+        if (!config.isPresent()) {
             log.warn("No rotation strategy configuration found, not running index rotation!");
             return null;
         }
 
-        final Period rotationPeriod = config.rotationPeriod().normalizedStandard();
+        final Period rotationPeriod = config.get().rotationPeriod().normalizedStandard();
         final DateTime now = Tools.nowUTC();
         // when first started, we might not know the last rotation time, look up the creation time of the index instead.
         if (lastRotation == null) {

--- a/graylog2-server/src/main/java/org/graylog2/indexer/rotation/strategies/TimeBasedRotationStrategyConfig.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/rotation/strategies/TimeBasedRotationStrategyConfig.java
@@ -45,7 +45,7 @@ public abstract class TimeBasedRotationStrategyConfig implements RotationStrateg
         return create(TimeBasedRotationStrategyConfig.class.getCanonicalName(), maxTimePerIndex);
     }
 
-    public static TimeBasedRotationStrategyConfig createDefault() {
+    public static TimeBasedRotationStrategyConfig defaultConfig() {
         return create(DEFAULT_DAYS);
     }
 }

--- a/graylog2-server/src/main/java/org/graylog2/indexer/searches/SearchesClusterConfig.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/searches/SearchesClusterConfig.java
@@ -60,7 +60,7 @@ public abstract class SearchesClusterConfig {
                 .build();
     }
 
-    public static SearchesClusterConfig createDefault() {
+    public static SearchesClusterConfig defaultConfig() {
         return builder()
                 .queryTimeRangeLimit(DEFAULT_QUERY_TIME_RANGE_LIMIT)
                 .relativeTimerangeOptions(DEFAULT_RELATIVE_TIMERANGE_OPTIONS)
@@ -76,6 +76,7 @@ public abstract class SearchesClusterConfig {
     @AutoValue.Builder
     public static abstract class Builder {
         public abstract Builder queryTimeRangeLimit(Period queryTimeRangeLimit);
+
         public abstract Builder relativeTimerangeOptions(Map<Period, String> relativeTimerangeOptions);
 
         public abstract SearchesClusterConfig build();

--- a/graylog2-server/src/main/java/org/graylog2/periodical/ConfigurationManagementPeriodical.java
+++ b/graylog2-server/src/main/java/org/graylog2/periodical/ConfigurationManagementPeriodical.java
@@ -38,6 +38,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import javax.inject.Inject;
+import java.util.Optional;
 
 public class ConfigurationManagementPeriodical extends Periodical {
     private static final Logger LOG = LoggerFactory.getLogger(ConfigurationManagementPeriodical.class);
@@ -54,45 +55,45 @@ public class ConfigurationManagementPeriodical extends Periodical {
     // Migrate old Elasticsearch config settings to new ClusterConfig based ones.
     public void migrateElasticsearchConfig() {
         // All default rotation strategy settings.
-        final MessageCountRotationStrategyConfig messageCountRotationStrategyConfig = clusterConfigService.get(MessageCountRotationStrategyConfig.class);
-        final SizeBasedRotationStrategyConfig sizeBasedRotationStrategyConfig = clusterConfigService.get(SizeBasedRotationStrategyConfig.class);
-        final TimeBasedRotationStrategyConfig timeBasedRotationStrategyConfig = clusterConfigService.get(TimeBasedRotationStrategyConfig.class);
+        final Optional<MessageCountRotationStrategyConfig> messageCountRotationStrategyConfig = clusterConfigService.get(MessageCountRotationStrategyConfig.class);
+        final Optional<SizeBasedRotationStrategyConfig> sizeBasedRotationStrategyConfig = clusterConfigService.get(SizeBasedRotationStrategyConfig.class);
+        final Optional<TimeBasedRotationStrategyConfig> timeBasedRotationStrategyConfig = clusterConfigService.get(TimeBasedRotationStrategyConfig.class);
 
-        if (messageCountRotationStrategyConfig == null) {
+        if (!messageCountRotationStrategyConfig.isPresent()) {
             final MessageCountRotationStrategyConfig countConfig = MessageCountRotationStrategyConfig.create(elasticsearchConfiguration.getMaxDocsPerIndex());
             clusterConfigService.write(countConfig);
             LOG.info("Migrated \"{}\" setting: {}", "elasticsearch_max_docs_per_index", countConfig);
         }
-        if (sizeBasedRotationStrategyConfig == null) {
+        if (!sizeBasedRotationStrategyConfig.isPresent()) {
             final SizeBasedRotationStrategyConfig sizeConfig = SizeBasedRotationStrategyConfig.create(elasticsearchConfiguration.getMaxSizePerIndex());
             clusterConfigService.write(sizeConfig);
             LOG.info("Migrated \"{}\" setting: {}", "elasticsearch_max_size_per_index", sizeConfig);
         }
-        if (timeBasedRotationStrategyConfig == null) {
+        if (!timeBasedRotationStrategyConfig.isPresent()) {
             final TimeBasedRotationStrategyConfig timeConfig = TimeBasedRotationStrategyConfig.create(elasticsearchConfiguration.getMaxTimePerIndex());
             clusterConfigService.write(timeConfig);
             LOG.info("Migrated \"{}\" setting: {}", "elasticsearch_max_time_per_index", timeConfig);
         }
 
         // All default retention strategy settings
-        final ClosingRetentionStrategyConfig closingRetentionStrategyConfig = clusterConfigService.get(ClosingRetentionStrategyConfig.class);
-        final DeletionRetentionStrategyConfig deletionRetentionStrategyConfig = clusterConfigService.get(DeletionRetentionStrategyConfig.class);
+        final Optional<ClosingRetentionStrategyConfig> closingRetentionStrategyConfig = clusterConfigService.get(ClosingRetentionStrategyConfig.class);
+        final Optional<DeletionRetentionStrategyConfig> deletionRetentionStrategyConfig = clusterConfigService.get(DeletionRetentionStrategyConfig.class);
 
-        if (closingRetentionStrategyConfig == null) {
+        if (!closingRetentionStrategyConfig.isPresent()) {
             final ClosingRetentionStrategyConfig closingConfig = ClosingRetentionStrategyConfig.create(elasticsearchConfiguration.getMaxNumberOfIndices());
             clusterConfigService.write(closingConfig);
             LOG.info("Migrated \"{}\" setting: {}", "elasticsearch_max_number_of_indices", closingConfig);
         }
 
-        if (deletionRetentionStrategyConfig == null) {
+        if (!deletionRetentionStrategyConfig.isPresent()) {
             final DeletionRetentionStrategyConfig deletionConfig = DeletionRetentionStrategyConfig.create(elasticsearchConfiguration.getMaxNumberOfIndices());
             clusterConfigService.write(deletionConfig);
             LOG.info("Migrated \"{}\" setting: {}", "elasticsearch_max_number_of_indices", deletionConfig);
         }
 
         // Selected rotation and retention strategies.
-        final IndexManagementConfig indexManagementConfig = clusterConfigService.get(IndexManagementConfig.class);
-        if (indexManagementConfig == null) {
+        final Optional<IndexManagementConfig> indexManagementConfig = clusterConfigService.get(IndexManagementConfig.class);
+        if (!indexManagementConfig.isPresent()) {
             final Class<? extends RotationStrategy> rotationStrategyClass;
             switch (elasticsearchConfiguration.getRotationStrategy()) {
                 case "size":
@@ -129,9 +130,9 @@ public class ConfigurationManagementPeriodical extends Periodical {
             LOG.info("Migrated \"{}\" and \"{}\" setting: {}", "rotation_strategy", "retention_strategy", config);
         }
 
-        final SearchesClusterConfig searchesClusterConfig = clusterConfigService.get(SearchesClusterConfig.class);
-        if (searchesClusterConfig == null) {
-            final SearchesClusterConfig config = SearchesClusterConfig.createDefault();
+        final Optional<SearchesClusterConfig> searchesClusterConfig = clusterConfigService.get(SearchesClusterConfig.class);
+        if (!searchesClusterConfig.isPresent()) {
+            final SearchesClusterConfig config = SearchesClusterConfig.defaultConfig();
             LOG.info("Creating searches cluster config: {}", config);
             clusterConfigService.write(config);
         }

--- a/graylog2-server/src/main/java/org/graylog2/periodical/ContentPackLoaderPeriodical.java
+++ b/graylog2-server/src/main/java/org/graylog2/periodical/ContentPackLoaderPeriodical.java
@@ -115,8 +115,8 @@ public class ContentPackLoaderPeriodical extends Periodical {
 
     @Override
     public void doRun() {
-        final ContentPackLoaderConfig contentPackLoaderConfig =
-                clusterConfigService.getOrDefault(ContentPackLoaderConfig.class, ContentPackLoaderConfig.EMPTY);
+        final ContentPackLoaderConfig contentPackLoaderConfig = clusterConfigService.getOrDefault(ContentPackLoaderConfig.class)
+                .orElseThrow(() -> new RuntimeException("Couldn't find content pack loader configuration in database"));
 
         final List<Path> files = getFiles(contentPacksDir, FILENAME_GLOB);
         final Map<String, ConfigurationBundle> contentPacks = new HashMap<>(files.size());

--- a/graylog2-server/src/main/java/org/graylog2/periodical/IndexRetentionThread.java
+++ b/graylog2-server/src/main/java/org/graylog2/periodical/IndexRetentionThread.java
@@ -28,6 +28,7 @@ import org.slf4j.LoggerFactory;
 import javax.inject.Inject;
 import javax.inject.Provider;
 import java.util.Map;
+import java.util.Optional;
 
 import static java.util.concurrent.TimeUnit.MINUTES;
 
@@ -57,13 +58,14 @@ public class IndexRetentionThread extends Periodical {
             return;
         }
 
-        final IndexManagementConfig config = clusterConfigService.get(IndexManagementConfig.class);
+        final Optional<IndexManagementConfig> indexManagementConfig = clusterConfigService.get(IndexManagementConfig.class);
 
-        if (config == null) {
+        if (!indexManagementConfig.isPresent()) {
             LOG.warn("No index management configuration found, not running index retention!");
             return;
         }
 
+        final IndexManagementConfig config = indexManagementConfig.get();
         final Provider<RetentionStrategy> retentionStrategyProvider = retentionStrategyMap.get(config.retentionStrategy());
 
         if (retentionStrategyProvider == null) {

--- a/graylog2-server/src/main/java/org/graylog2/periodical/IndexRotationThread.java
+++ b/graylog2-server/src/main/java/org/graylog2/periodical/IndexRotationThread.java
@@ -35,6 +35,7 @@ import org.slf4j.LoggerFactory;
 import javax.inject.Inject;
 import javax.inject.Provider;
 import java.util.Map;
+import java.util.Optional;
 
 public class IndexRotationThread extends Periodical {
     private static final Logger LOG = LoggerFactory.getLogger(IndexRotationThread.class);
@@ -85,17 +86,17 @@ public class IndexRotationThread extends Periodical {
     }
 
     protected void checkForRotation() {
-        final IndexManagementConfig config = clusterConfigService.get(IndexManagementConfig.class);
+        final Optional<IndexManagementConfig> config = clusterConfigService.get(IndexManagementConfig.class);
 
-        if (config == null) {
+        if (!config.isPresent()) {
             LOG.warn("No index management configuration found, not running index rotation!");
             return;
         }
 
-        final Provider<RotationStrategy> rotationStrategyProvider = rotationStrategyMap.get(config.rotationStrategy());
+        final Provider<RotationStrategy> rotationStrategyProvider = rotationStrategyMap.get(config.get().rotationStrategy());
 
         if (rotationStrategyProvider == null) {
-            LOG.warn("Rotation strategy \"{}\" not found, not running index rotation!", config.rotationStrategy());
+            LOG.warn("Rotation strategy \"{}\" not found, not running index rotation!", config.get().rotationStrategy());
             return;
         }
 

--- a/graylog2-server/src/main/java/org/graylog2/plugin/cluster/ClusterConfigService.java
+++ b/graylog2-server/src/main/java/org/graylog2/plugin/cluster/ClusterConfigService.java
@@ -16,6 +16,7 @@
  */
 package org.graylog2.plugin.cluster;
 
+import java.util.Optional;
 import java.util.Set;
 
 /**
@@ -27,20 +28,30 @@ public interface ClusterConfigService {
      *
      * @param type The {@link Class} of the Java configuration bean to retrieve.
      * @param <T>  The type of the Java configuration bean.
-     * @return An instance of the requested type or {@code null} if it couldn't be retrieved.
+     * @return An instance of the requested type wrapped in {@link Optional}.
      */
-    <T> T get(Class<T> type);
+    <T> Optional<T> get(Class<T> type);
 
     /**
-     * Retrieve Java class of a certain type from the cluster configuration or return a default value
-     * in case that failed.
+     * Retrieve Java class of a certain type from the cluster configuration or return the default value
+     * of the configuration class using a static method with signature {@code public static <T> T defaultConfig()}
+     * in case it wasn't found.
      *
-     * @param type         The {@link Class} of the Java configuration bean to retrieve.
-     * @param defaultValue An instance of {@code T} which is returned as default value.
-     * @param <T>          The type of the Java configuration bean.
-     * @return An instance of the requested type.
+     * @param type The {@link Class} of the Java configuration bean to retrieve.
+     * @param <T>  The type of the Java configuration bean.
+     * @return An instance of the requested type wrapped in {@link Optional}.
      */
-    <T> T getOrDefault(Class<T> type, T defaultValue);
+    <T> Optional<T> getOrDefault(Class<T> type);
+
+    /**
+     * Return the default config instance of a cluster config class using a static method with signature
+     * {@code public static <T> T defaultConfig()}.
+     *
+     * @param type The {@link Class} of the Java configuration bean to retrieve.
+     * @param <T>  The type of the Java configuration bean.
+     * @return An instance of the requested type wrapped in {@link Optional}.
+     */
+    <T> Optional<T> getDefault(Class<T> type);
 
     /**
      * Write a configuration bean to the cluster configuration.

--- a/graylog2-server/src/main/java/org/graylog2/plugin/cluster/ClusterId.java
+++ b/graylog2-server/src/main/java/org/graylog2/plugin/cluster/ClusterId.java
@@ -21,6 +21,8 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.auto.value.AutoValue;
 
+import java.util.UUID;
+
 @JsonAutoDetect
 @AutoValue
 public abstract class ClusterId {
@@ -30,5 +32,9 @@ public abstract class ClusterId {
     @JsonCreator
     public static ClusterId create(@JsonProperty("cluster_id") String clusterId) {
         return new AutoValue_ClusterId(clusterId);
+    }
+
+    public static ClusterId defaultConfig() {
+        return create(UUID.randomUUID().toString());
     }
 }

--- a/graylog2-server/src/main/java/org/graylog2/rest/resources/search/SearchResource.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/resources/search/SearchResource.java
@@ -60,6 +60,7 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Locale;
+import java.util.Optional;
 import java.util.Set;
 
 import static com.google.common.base.Strings.isNullOrEmpty;
@@ -354,12 +355,12 @@ public abstract class SearchResource extends RestResource {
         final DateTime to = timeRange.getTo();
         final DateTime from;
 
-        final SearchesClusterConfig config = clusterConfigService.get(SearchesClusterConfig.class);
+        final Optional<SearchesClusterConfig> config = clusterConfigService.get(SearchesClusterConfig.class);
 
-        if (config == null || Period.ZERO.equals(config.queryTimeRangeLimit())) {
+        if (!config.isPresent() || Period.ZERO.equals(config.get().queryTimeRangeLimit())) {
             from = originalFrom;
         } else {
-            final DateTime limitedFrom = to.minus(config.queryTimeRangeLimit());
+            final DateTime limitedFrom = to.minus(config.get().queryTimeRangeLimit());
             from = limitedFrom.isAfter(originalFrom) ? limitedFrom : originalFrom;
         }
 

--- a/graylog2-server/src/main/java/org/graylog2/rest/resources/system/ClusterConfigResource.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/resources/system/ClusterConfigResource.java
@@ -33,7 +33,6 @@ import org.graylog2.shared.rest.resources.RestResource;
 import org.graylog2.shared.security.RestPermissions;
 import org.hibernate.validator.constraints.NotBlank;
 
-import javax.annotation.Nullable;
 import javax.inject.Inject;
 import javax.validation.constraints.NotNull;
 import javax.ws.rs.Consumes;
@@ -49,6 +48,7 @@ import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 import java.io.IOException;
 import java.io.InputStream;
+import java.util.Optional;
 import java.util.Set;
 
 import static java.util.Objects.requireNonNull;
@@ -84,12 +84,9 @@ public class ClusterConfigResource extends RestResource {
     @RequiresPermissions(RestPermissions.CLUSTER_CONFIG_ENTRY_READ)
     public Object read(@ApiParam(name = "configClass", value = "The name of the cluster configuration class", required = true)
                        @PathParam("configClass") @NotBlank String configClass) {
-        final Class<?> cls = classFromName(configClass);
-        if (cls == null) {
-            throw new NotFoundException("Couldn't find configuration class \"" + configClass + "\"");
-        }
-
-        return clusterConfigService.get(cls);
+        return classFromName(configClass)
+                .flatMap(clusterConfigService::get)
+                .orElseThrow(() -> new NotFoundException("Couldn't find configuration class \"" + configClass + "\""));
     }
 
     @PUT
@@ -102,11 +99,8 @@ public class ClusterConfigResource extends RestResource {
                            @PathParam("configClass") @NotBlank String configClass,
                            @ApiParam(name = "body", value = "The payload of the cluster configuration", required = true)
                            @NotNull InputStream body) throws IOException {
-        final Class<?> cls = classFromName(configClass);
-        if (cls == null) {
-            throw new NotFoundException("Couldn't find configuration class \"" + configClass + "\"");
-        }
-
+        final Class<?> cls = classFromName(configClass)
+                .orElseThrow(() -> new NotFoundException("Couldn't find configuration class \"" + configClass + "\""));
         final Object o = objectMapper.readValue(body, cls);
         clusterConfigService.write(o);
 
@@ -120,10 +114,8 @@ public class ClusterConfigResource extends RestResource {
     @RequiresPermissions(RestPermissions.CLUSTER_CONFIG_ENTRY_DELETE)
     public void delete(@ApiParam(name = "configClass", value = "The name of the cluster configuration class", required = true)
                        @PathParam("configClass") @NotBlank String configClass) {
-        final Class<?> cls = classFromName(configClass);
-        if (cls == null) {
-            throw new NotFoundException("Couldn't find configuration class \"" + configClass + "\"");
-        }
+        final Class<?> cls = classFromName(configClass)
+                .orElseThrow(() -> new NotFoundException("Couldn't find configuration class \"" + configClass + "\""));
 
         clusterConfigService.remove(cls);
     }
@@ -136,11 +128,8 @@ public class ClusterConfigResource extends RestResource {
     @RequiresPermissions(RestPermissions.CLUSTER_CONFIG_ENTRY_READ)
     public JsonSchema schema(@ApiParam(name = "configClass", value = "The name of the cluster configuration class", required = true)
                              @PathParam("configClass") @NotBlank String configClass) {
-        final Class<?> cls = classFromName(configClass);
-        if (cls == null) {
-            throw new NotFoundException("Couldn't find configuration class \"" + configClass + "\"");
-        }
-
+        final Class<?> cls = classFromName(configClass)
+                .orElseThrow(() -> new NotFoundException("Couldn't find configuration class \"" + configClass + "\""));
         final SchemaFactoryWrapper visitor = new SchemaFactoryWrapper();
         try {
             objectMapper.acceptJsonFormatVisitor(objectMapper.constructType(cls), visitor);
@@ -151,12 +140,25 @@ public class ClusterConfigResource extends RestResource {
         return visitor.finalSchema();
     }
 
-    @Nullable
-    private Class<?> classFromName(String className) {
+    @GET
+    @Path("{configClass}/default")
+    @Produces(MediaType.APPLICATION_JSON)
+    @ApiOperation(value = "Get default value for given configuration class")
+    @Timed
+    @RequiresPermissions(RestPermissions.CLUSTER_CONFIG_ENTRY_READ)
+    public Object defaultValue(@ApiParam(name = "configClass", value = "The name of the cluster configuration class", required = true)
+                               @PathParam("configClass") @NotBlank String configClass) {
+        return classFromName(configClass)
+                .flatMap(clusterConfigService::getDefault)
+                .orElseThrow(() -> new NotFoundException("Couldn't find default for configuration class \"" + configClass + "\""));
+    }
+
+    @SuppressWarnings("unchecked")
+    private Optional<Class<?>> classFromName(String className) {
         try {
-            return chainingClassLoader.loadClass(className);
+            return Optional.of(chainingClassLoader.loadClass(className));
         } catch (ClassNotFoundException e) {
-            return null;
+            return Optional.empty();
         }
     }
 }

--- a/graylog2-server/src/main/java/org/graylog2/rest/resources/system/ClusterResource.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/resources/system/ClusterResource.java
@@ -17,7 +17,6 @@
 package org.graylog2.rest.resources.system;
 
 import com.codahale.metrics.annotation.Timed;
-import com.eaio.uuid.UUID;
 import com.wordnik.swagger.annotations.Api;
 import com.wordnik.swagger.annotations.ApiOperation;
 import com.wordnik.swagger.annotations.ApiParam;
@@ -60,7 +59,7 @@ public class ClusterResource extends RestResource {
                            NodeId nodeId) {
         this.nodeService = nodeService;
         this.nodeId = nodeId;
-        this.clusterId = clusterConfigService.getOrDefault(ClusterId.class, ClusterId.create(UUID.nilUUID().toString()));
+        this.clusterId = clusterConfigService.getOrDefault(ClusterId.class).get();
     }
 
     @GET

--- a/graylog2-server/src/main/java/org/graylog2/rest/resources/system/GettingStartedResource.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/resources/system/GettingStartedResource.java
@@ -32,6 +32,7 @@ import javax.ws.rs.POST;
 import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
 import javax.ws.rs.core.MediaType;
+import java.util.Optional;
 
 @RequiresAuthentication
 @Api(value = "System/GettingStartedGuides", description = "Getting Started guide")
@@ -49,11 +50,11 @@ public class GettingStartedResource extends RestResource {
     @GET
     @ApiOperation("Check whether to display the Getting started guide for this version")
     public DisplayGettingStarted displayGettingStarted() {
-        final GettingStartedState gettingStartedState = clusterConfigService.get(GettingStartedState.class);
-        if (gettingStartedState == null) {
-            return  DisplayGettingStarted.create(true);
+        final Optional<GettingStartedState> gettingStartedState = clusterConfigService.get(GettingStartedState.class);
+        if (!gettingStartedState.isPresent()) {
+            return DisplayGettingStarted.create(true);
         }
-        final boolean isDismissed = gettingStartedState.dismissedInVersions().contains(currentMinorVersionString());
+        final boolean isDismissed = gettingStartedState.get().dismissedInVersions().contains(currentMinorVersionString());
         return DisplayGettingStarted.create(!isDismissed);
     }
 
@@ -61,10 +62,10 @@ public class GettingStartedResource extends RestResource {
     @Path("dismiss")
     @ApiOperation("Dismiss auto-showing getting started guide for this version")
     public void dismissGettingStarted() {
-        final GettingStartedState gettingStartedState = clusterConfigService.getOrDefault(GettingStartedState.class,
-                                                                                GettingStartedState.create(Sets.<String>newHashSet()));
-        gettingStartedState.dismissedInVersions().add(currentMinorVersionString());
-        clusterConfigService.write(gettingStartedState);
+        final Optional<GettingStartedState> gettingStartedState = clusterConfigService.get(GettingStartedState.class);
+        final GettingStartedState state = gettingStartedState.orElse(GettingStartedState.create(Sets.<String>newHashSet()));
+        state.dismissedInVersions().add(currentMinorVersionString());
+        clusterConfigService.write(state);
 
     }
 

--- a/graylog2-server/src/main/java/org/graylog2/rest/resources/system/MessageProcessorsResource.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/resources/system/MessageProcessorsResource.java
@@ -33,6 +33,7 @@ import javax.ws.rs.PUT;
 import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
 import javax.ws.rs.core.MediaType;
+import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -61,10 +62,9 @@ public class MessageProcessorsResource extends RestResource {
     @ApiOperation(value = "Get message processor configuration")
     @Path("config")
     public MessageProcessorsConfigWithDescriptors config() {
-        final MessageProcessorsConfig config = clusterConfigService.getOrDefault(MessageProcessorsConfig.class,
-                MessageProcessorsConfig.defaultConfig());
+        final Optional<MessageProcessorsConfig> config = clusterConfigService.getOrDefault(MessageProcessorsConfig.class);
 
-        return MessageProcessorsConfigWithDescriptors.fromConfig(config.withProcessors(processorClassNames), processorDescriptors);
+        return MessageProcessorsConfigWithDescriptors.fromConfig(config.get().withProcessors(processorClassNames), processorDescriptors);
     }
 
     @PUT

--- a/graylog2-server/src/main/java/org/graylog2/shared/rest/resources/system/SystemResource.java
+++ b/graylog2-server/src/main/java/org/graylog2/shared/rest/resources/system/SystemResource.java
@@ -57,7 +57,7 @@ public class SystemResource extends RestResource {
     @Inject
     public SystemResource(ServerStatus serverStatus, ClusterConfigService clusterConfigService) {
         this.serverStatus = serverStatus;
-        this.clusterId = clusterConfigService.getOrDefault(ClusterId.class, ClusterId.create(UUID.nilUUID().toString()));
+        this.clusterId = clusterConfigService.getOrDefault(ClusterId.class).get();
     }
 
     @GET

--- a/graylog2-server/src/test/java/org/graylog2/cluster/CustomConfig.java
+++ b/graylog2-server/src/test/java/org/graylog2/cluster/CustomConfig.java
@@ -18,4 +18,11 @@ package org.graylog2.cluster;
 
 public class CustomConfig {
     public String text;
+
+    @SuppressWarnings("unused")
+    public static CustomConfig defaultConfig() {
+        final CustomConfig customConfig = new CustomConfig();
+        customConfig.text = "default";
+        return customConfig;
+    }
 }

--- a/graylog2-server/src/test/java/org/graylog2/indexer/rotation/strategies/MessageCountRotationStrategyTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/indexer/rotation/strategies/MessageCountRotationStrategyTest.java
@@ -26,6 +26,8 @@ import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
 
+import java.util.Optional;
+
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.reset;
@@ -48,7 +50,7 @@ public class MessageCountRotationStrategyTest {
     public void testRotate() throws Exception {
         when(indices.numberOfMessages("name")).thenReturn(10L);
         when(deflector.getNewestTargetName()).thenReturn("name");
-        when(clusterConfigService.get(MessageCountRotationStrategyConfig.class)).thenReturn(MessageCountRotationStrategyConfig.create(5));
+        when(clusterConfigService.get(MessageCountRotationStrategyConfig.class)).thenReturn(Optional.of(MessageCountRotationStrategyConfig.create(5)));
 
         final MessageCountRotationStrategy strategy = new MessageCountRotationStrategy(indices, deflector, clusterConfigService);
 
@@ -61,7 +63,7 @@ public class MessageCountRotationStrategyTest {
     public void testDontRotate() throws Exception {
         when(indices.numberOfMessages("name")).thenReturn(1L);
         when(deflector.getNewestTargetName()).thenReturn("name");
-        when(clusterConfigService.get(MessageCountRotationStrategyConfig.class)).thenReturn(MessageCountRotationStrategyConfig.create(5));
+        when(clusterConfigService.get(MessageCountRotationStrategyConfig.class)).thenReturn(Optional.of(MessageCountRotationStrategyConfig.create(5)));
 
         final MessageCountRotationStrategy strategy = new MessageCountRotationStrategy(indices, deflector, clusterConfigService);
 
@@ -75,7 +77,7 @@ public class MessageCountRotationStrategyTest {
     public void testIndexUnavailable() throws Exception {
         doThrow(IndexNotFoundException.class).when(indices).numberOfMessages("name");
         when(deflector.getNewestTargetName()).thenReturn("name");
-        when(clusterConfigService.get(MessageCountRotationStrategyConfig.class)).thenReturn(MessageCountRotationStrategyConfig.create(5));
+        when(clusterConfigService.get(MessageCountRotationStrategyConfig.class)).thenReturn(Optional.of(MessageCountRotationStrategyConfig.create(5)));
 
         final MessageCountRotationStrategy strategy = new MessageCountRotationStrategy(indices, deflector, clusterConfigService);
 

--- a/graylog2-server/src/test/java/org/graylog2/indexer/rotation/strategies/SizeBasedRotationStrategyTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/indexer/rotation/strategies/SizeBasedRotationStrategyTest.java
@@ -30,6 +30,7 @@ import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
 
 import java.util.Collections;
+import java.util.Optional;
 
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.reset;
@@ -56,7 +57,7 @@ public class SizeBasedRotationStrategyTest {
 
         when(indices.getIndexStats("name")).thenReturn(stats);
         when(deflector.getNewestTargetName()).thenReturn("name");
-        when(clusterConfigService.get(SizeBasedRotationStrategyConfig.class)).thenReturn(SizeBasedRotationStrategyConfig.create(100L));
+        when(clusterConfigService.get(SizeBasedRotationStrategyConfig.class)).thenReturn(Optional.of(SizeBasedRotationStrategyConfig.create(100L)));
 
         final SizeBasedRotationStrategy strategy = new SizeBasedRotationStrategy(indices, deflector, clusterConfigService);
 
@@ -74,7 +75,7 @@ public class SizeBasedRotationStrategyTest {
 
         when(indices.getIndexStats("name")).thenReturn(stats);
         when(deflector.getNewestTargetName()).thenReturn("name");
-        when(clusterConfigService.get(SizeBasedRotationStrategyConfig.class)).thenReturn(SizeBasedRotationStrategyConfig.create(100000L));
+        when(clusterConfigService.get(SizeBasedRotationStrategyConfig.class)).thenReturn(Optional.of(SizeBasedRotationStrategyConfig.create(100000L)));
 
         final SizeBasedRotationStrategy strategy = new SizeBasedRotationStrategy(indices, deflector, clusterConfigService);
 
@@ -88,7 +89,7 @@ public class SizeBasedRotationStrategyTest {
     public void testRotateFailed() throws Exception {
         when(indices.getIndexStats("name")).thenReturn(null);
         when(deflector.getNewestTargetName()).thenReturn("name");
-        when(clusterConfigService.get(SizeBasedRotationStrategyConfig.class)).thenReturn(SizeBasedRotationStrategyConfig.create(100));
+        when(clusterConfigService.get(SizeBasedRotationStrategyConfig.class)).thenReturn(Optional.of(SizeBasedRotationStrategyConfig.create(100)));
 
         final SizeBasedRotationStrategy strategy = new SizeBasedRotationStrategy(indices, deflector, clusterConfigService);
 

--- a/graylog2-server/src/test/java/org/graylog2/indexer/rotation/strategies/TimeBasedRotationStrategyTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/indexer/rotation/strategies/TimeBasedRotationStrategyTest.java
@@ -31,6 +31,8 @@ import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
 
+import java.util.Optional;
+
 import static org.joda.time.Period.minutes;
 import static org.joda.time.Period.seconds;
 import static org.junit.Assert.assertEquals;
@@ -119,7 +121,7 @@ public class TimeBasedRotationStrategyTest {
 
         when(indices.indexCreationDate(anyString())).thenReturn(initialTime.minus(Period.minutes(5)));
         when(deflector.getNewestTargetName()).thenReturn("ignored");
-        when(clusterConfigService.get(TimeBasedRotationStrategyConfig.class)).thenReturn(TimeBasedRotationStrategyConfig.create(period));
+        when(clusterConfigService.get(TimeBasedRotationStrategyConfig.class)).thenReturn(Optional.of(TimeBasedRotationStrategyConfig.create(period)));
 
         final TimeBasedRotationStrategy hourlyRotation = new TimeBasedRotationStrategy(indices, deflector, clusterConfigService);
 
@@ -153,7 +155,7 @@ public class TimeBasedRotationStrategyTest {
         DateTimeUtils.setCurrentMillisProvider(clock);
         when(indices.indexCreationDate(anyString())).thenReturn(initialTime.minus(Period.minutes(11)));
         when(deflector.getNewestTargetName()).thenReturn("ignored");
-        when(clusterConfigService.get(TimeBasedRotationStrategyConfig.class)).thenReturn(TimeBasedRotationStrategyConfig.create(period));
+        when(clusterConfigService.get(TimeBasedRotationStrategyConfig.class)).thenReturn(Optional.of(TimeBasedRotationStrategyConfig.create(period)));
 
         final TimeBasedRotationStrategy tenMinRotation = new TimeBasedRotationStrategy(indices, deflector, clusterConfigService);
 

--- a/graylog2-server/src/test/java/org/graylog2/periodical/IndexRotationThreadTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/periodical/IndexRotationThreadTest.java
@@ -33,6 +33,7 @@ import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
 
 import javax.inject.Provider;
+import java.util.Optional;
 
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
@@ -76,7 +77,7 @@ public class IndexRotationThreadTest {
             }
         };
 
-        when(clusterConfigService.get(IndexManagementConfig.class)).thenReturn(IndexManagementConfig.create("strategy", "retention"));
+        when(clusterConfigService.get(IndexManagementConfig.class)).thenReturn(Optional.of(IndexManagementConfig.create("strategy", "retention")));
 
         final IndexRotationThread rotationThread = new IndexRotationThread(
                 notificationService,
@@ -117,7 +118,7 @@ public class IndexRotationThreadTest {
             }
         };
 
-        when(clusterConfigService.get(IndexManagementConfig.class)).thenReturn(IndexManagementConfig.create("strategy", "retention"));
+        when(clusterConfigService.get(IndexManagementConfig.class)).thenReturn(Optional.of(IndexManagementConfig.create("strategy", "retention")));
 
         final IndexRotationThread rotationThread = new IndexRotationThread(
                 notificationService,
@@ -159,7 +160,7 @@ public class IndexRotationThreadTest {
             }
         };
 
-        when(clusterConfigService.get(IndexManagementConfig.class)).thenReturn(IndexManagementConfig.create("strategy", "retention"));
+        when(clusterConfigService.get(IndexManagementConfig.class)).thenReturn(Optional.of(IndexManagementConfig.create("strategy", "retention")));
 
         final IndexRotationThread rotationThread = new IndexRotationThread(
                 notificationService,
@@ -183,7 +184,7 @@ public class IndexRotationThreadTest {
         final Provider<RotationStrategy> provider = mock(Provider.class);
         when(cluster.isConnected()).thenReturn(false);
         when(cluster.isHealthy()).thenReturn(false);
-        when(clusterConfigService.get(IndexManagementConfig.class)).thenReturn(IndexManagementConfig.create("strategy", "retention"));
+        when(clusterConfigService.get(IndexManagementConfig.class)).thenReturn(Optional.of(IndexManagementConfig.create("strategy", "retention")));
 
         final IndexRotationThread rotationThread = new IndexRotationThread(
                 notificationService,

--- a/graylog2-server/src/test/java/org/graylog2/rest/resources/search/SearchResourceTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/rest/resources/search/SearchResourceTest.java
@@ -31,6 +31,8 @@ import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnit;
 import org.mockito.junit.MockitoRule;
 
+import java.util.Optional;
+
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.when;
 
@@ -53,18 +55,18 @@ public class SearchResourceTest {
         searchResource = new SearchResource(searches, clusterConfigService) {
         };
 
-        when(clusterConfigService.get(SearchesClusterConfig.class)).thenReturn(SearchesClusterConfig.createDefault()
+        when(clusterConfigService.get(SearchesClusterConfig.class)).thenReturn(Optional.of(SearchesClusterConfig.defaultConfig()
                 .toBuilder()
                 .queryTimeRangeLimit(queryLimitPeriod)
-                .build());
+                .build()));
     }
 
     @Test
     public void restrictTimeRangeReturnsGivenTimeRangeWithinLimit() {
-        when(clusterConfigService.get(SearchesClusterConfig.class)).thenReturn(SearchesClusterConfig.createDefault()
+        when(clusterConfigService.get(SearchesClusterConfig.class)).thenReturn(Optional.of(SearchesClusterConfig.defaultConfig()
                 .toBuilder()
                 .queryTimeRangeLimit(queryLimitPeriod)
-                .build());
+                .build()));
 
         final DateTime from = new DateTime(2015, 1, 15, 12, 0, DateTimeZone.UTC);
         final DateTime to = from.plusHours(1);
@@ -78,10 +80,10 @@ public class SearchResourceTest {
 
     @Test
     public void restrictTimeRangeReturnsGivenTimeRangeIfNoLimitHasBeenSet() {
-        when(clusterConfigService.get(SearchesClusterConfig.class)).thenReturn(SearchesClusterConfig.createDefault()
+        when(clusterConfigService.get(SearchesClusterConfig.class)).thenReturn(Optional.of(SearchesClusterConfig.defaultConfig()
                 .toBuilder()
                 .queryTimeRangeLimit(Period.ZERO)
-                .build());
+                .build()));
 
         final SearchResource resource = new SearchResource(searches, clusterConfigService) {
         };
@@ -98,10 +100,10 @@ public class SearchResourceTest {
 
     @Test
     public void restrictTimeRangeReturnsLimitedTimeRange() {
-        when(clusterConfigService.get(SearchesClusterConfig.class)).thenReturn(SearchesClusterConfig.createDefault()
+        when(clusterConfigService.get(SearchesClusterConfig.class)).thenReturn(Optional.of(SearchesClusterConfig.defaultConfig()
                 .toBuilder()
                 .queryTimeRangeLimit(queryLimitPeriod)
-                .build());
+                .build()));
 
         final DateTime from = new DateTime(2015, 1, 15, 12, 0, DateTimeZone.UTC);
         final DateTime to = from.plus(queryLimitPeriod.multipliedBy(2));


### PR DESCRIPTION
Cluster configuration classes are simple Jackson-annotated POJOs which are being handled by `ClusterConfigService`.
This change set introduces the possibility to define a default instance being used if there is no explicit instance in the database.

The default instance must be provided by a static method in the respective cluster configuration POJO with the following signature (with `T` being the specific cluster configuration class):

```java
public static T defaultConfig();
```