### PR TITLE
Remove remains of Graylog Radio

### DIFF
--- a/graylog2-plugin-interfaces/src/main/java/org/graylog2/plugin/Message.java
+++ b/graylog2-plugin-interfaces/src/main/java/org/graylog2/plugin/Message.java
@@ -84,13 +84,14 @@ public class Message implements Messages {
             FIELD_TIMESTAMP,
             "gl2_source_node",
             "gl2_source_input",
-            "gl2_source_radio",
-            "gl2_source_radio_input",
             "gl2_source_collector",
             "gl2_source_collector_input",
             "gl2_remote_ip",
             "gl2_remote_port",
-            "gl2_remote_hostname"
+            "gl2_remote_hostname",
+            // TODO Due to be removed in Graylog 3.x
+            "gl2_source_radio",
+            "gl2_source_radio_input"
     );
 
     public static final ImmutableSet<String> RESERVED_SETTABLE_FIELDS = ImmutableSet.of(

--- a/graylog2-plugin-interfaces/src/main/java/org/graylog2/plugin/inputs/MessageInput.java
+++ b/graylog2-plugin-interfaces/src/main/java/org/graylog2/plugin/inputs/MessageInput.java
@@ -330,7 +330,7 @@ public abstract class MessageInput implements Stoppable {
         // add the common message metadata for this input/codec
         rawMessage.setCodecName(codec.getName());
         rawMessage.setCodecConfig(codecConfig);
-        rawMessage.addSourceNode(getId(), serverStatus.getNodeId(), serverStatus.hasCapability(ServerStatus.Capability.SERVER));
+        rawMessage.addSourceNode(getId(), serverStatus.getNodeId());
 
         inputBuffer.insert(rawMessage);
 

--- a/graylog2-plugin-interfaces/src/main/java/org/graylog2/plugin/journal/RawMessage.java
+++ b/graylog2-plugin-interfaces/src/main/java/org/graylog2/plugin/journal/RawMessage.java
@@ -112,11 +112,11 @@ public class RawMessage implements Serializable {
         msgBuilder.setPayload(ByteString.copyFrom(payload));
     }
 
-    public void addSourceNode(String sourceInputId, NodeId nodeId, boolean isServer) {
+    public void addSourceNode(String sourceInputId, NodeId nodeId) {
         msgBuilder.addSourceNodesBuilder()
                   .setInputId(sourceInputId)
                   .setId(nodeId.toString())
-                  .setType(isServer ? JournalMessages.SourceNode.Type.SERVER : JournalMessages.SourceNode.Type.RADIO)
+                  .setType(JournalMessages.SourceNode.Type.SERVER)
                   .build();
     }
 

--- a/graylog2-plugin-interfaces/src/test/java/org/graylog2/plugin/journal/RawMessageTest.java
+++ b/graylog2-plugin-interfaces/src/test/java/org/graylog2/plugin/journal/RawMessageTest.java
@@ -35,13 +35,11 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 
 public class RawMessageTest {
-
     @Test
     public void minimalEncodeDecode() throws IOException {
-
         final RawMessage rawMessage = new RawMessage("testmessage".getBytes(Charsets.UTF_8));
         final File tempFile = File.createTempFile("node", "test");
-        rawMessage.addSourceNode("inputid", new NodeId(tempFile.getAbsolutePath()), true);
+        rawMessage.addSourceNode("inputid", new NodeId(tempFile.getAbsolutePath()));
         rawMessage.setCodecName("raw");
         rawMessage.setCodecConfig(Configuration.EMPTY_CONFIGURATION);
 
@@ -51,7 +49,5 @@ public class RawMessageTest {
         assertNotNull(decodedMsg);
         assertArrayEquals("testmessage".getBytes(Charsets.UTF_8), decodedMsg.getPayload());
         assertEquals("raw", decodedMsg.getCodecName());
-
     }
-
 }

--- a/graylog2-server/src/main/java/org/graylog2/shared/buffers/processors/DecodingProcessor.java
+++ b/graylog2-server/src/main/java/org/graylog2/shared/buffers/processors/DecodingProcessor.java
@@ -194,6 +194,7 @@ public class DecodingProcessor implements EventHandler<MessageEvent> {
                     message.addField("gl2_source_input", node.inputId);
                     message.addField("gl2_source_node", node.nodeId);
                     break;
+                // TODO Due to be removed in Graylog 3.x
                 case RADIO:
                     // Always use the last source node.
                     if (message.getField("gl2_source_radio_input") != null) {

--- a/graylog2-server/src/main/java/org/graylog2/shared/system/stats/fs/JmxFsProbe.java
+++ b/graylog2-server/src/main/java/org/graylog2/shared/system/stats/fs/JmxFsProbe.java
@@ -16,12 +16,13 @@
  */
 package org.graylog2.shared.system.stats.fs;
 
+import com.google.common.collect.ImmutableSet;
+
 import javax.annotation.Nullable;
 import javax.inject.Inject;
 import javax.inject.Named;
 import java.io.File;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 
@@ -29,13 +30,8 @@ public class JmxFsProbe implements FsProbe {
     private final Set<File> locations;
 
     @Inject
-    public JmxFsProbe(@Named("message_journal_dir") @Nullable File journalDirectory) {
-        this.locations = new HashSet<>();
-
-        // this is nullable for radio support, where this configuration object isn't present and thus not bound
-        if (journalDirectory != null) {
-            locations.add(journalDirectory);
-        }
+    public JmxFsProbe(@Named("message_journal_dir") File journalDirectory) {
+        this.locations = ImmutableSet.of(journalDirectory);
     }
 
     @Override

--- a/graylog2-server/src/main/java/org/graylog2/shared/system/stats/fs/SigarFsProbe.java
+++ b/graylog2-server/src/main/java/org/graylog2/shared/system/stats/fs/SigarFsProbe.java
@@ -16,6 +16,7 @@
  */
 package org.graylog2.shared.system.stats.fs;
 
+import com.google.common.collect.ImmutableSet;
 import org.graylog2.shared.system.stats.SigarService;
 import org.hyperic.sigar.FileSystem;
 import org.hyperic.sigar.FileSystemMap;
@@ -38,14 +39,9 @@ public class SigarFsProbe implements FsProbe {
     private final Map<File, FileSystem> sigarFileSystems = new HashMap<>();
 
     @Inject
-    public SigarFsProbe(SigarService sigarService, @Named("message_journal_dir") @Nullable File journalDirectory) {
+    public SigarFsProbe(SigarService sigarService, @Named("message_journal_dir") File journalDirectory) {
         this.sigarService = sigarService;
-        this.locations = new HashSet<>();
-        
-        // nullable for radio bindings where we don't have journalling.
-        if (journalDirectory != null) {
-            locations.add(journalDirectory);
-        }
+        this.locations = ImmutableSet.of(journalDirectory);
     }
 
     @Override

--- a/graylog2-web-interface/src/components/search/MessageDetail.jsx
+++ b/graylog2-web-interface/src/components/search/MessageDetail.jsx
@@ -59,7 +59,7 @@ const MessageDetail = React.createClass({
     let nodeInformation;
 
     if (node) {
-      const nodeURL = node.radio ? jsRoutes.controllers.RadiosController.show(nodeId).url : jsRoutes.controllers.NodesController.node(nodeId).url;
+      const nodeURL = jsRoutes.controllers.NodesController.node(nodeId).url;
       nodeInformation = (
         <a href={nodeURL}>
           <i className="fa fa-code-fork"/>
@@ -115,6 +115,7 @@ const MessageDetail = React.createClass({
       }
     });
 
+    // Legacy
     let viaRadio = this.props.message.source_radio_id;
     if (viaRadio) {
       viaRadio = (

--- a/graylog2-web-interface/src/logic/message/MessageFieldsFilter.js
+++ b/graylog2-web-interface/src/logic/message/MessageFieldsFilter.js
@@ -12,14 +12,15 @@ const MessageFieldsFilter = {
     // Our reserved fields.
     'gl2_source_node',
     'gl2_source_input',
-    'gl2_source_radio',
-    'gl2_source_radio_input',
     'gl2_source_collector',
     'gl2_source_collector_input',
     'gl2_remote_ip',
     'gl2_remote_port',
     'gl2_remote_hostname',
     'streams',
+    // TODO Due to be removed in Graylog 3.x
+    'gl2_source_radio',
+    'gl2_source_radio_input',
   ],
   filterFields(fields) {
     const result = {};

--- a/graylog2-web-interface/src/routing/jsRoutes.js
+++ b/graylog2-web-interface/src/routing/jsRoutes.js
@@ -255,9 +255,6 @@ const jsRoutes = {
     NodesController: {
       node: (nodeId) => { return {url: `/system/nodes/${nodeId}`}; },
     },
-    RadiosController: {
-      show: (nodeId) => { return {url: `/system/radios/${nodeId}`}; },
-    },
     SearchController: {
       index: (query, rangetype, timerange) => {
         let route;

--- a/graylog2-web-interface/src/util/DocsHelper.js
+++ b/graylog2-web-interface/src/util/DocsHelper.js
@@ -18,7 +18,6 @@ class DocsHelper {
     LOAD_BALANCERS: 'load_balancers.html',
     PAGE_FLEXIBLE_DATE_CONVERTER: 'extractors.html#the-flexible-date-converter',
     PAGE_STANDARD_DATE_CONVERTER: 'extractors.html#the-standard-date-converter',
-    RADIO_ARCHITECTURE: 'architecture.html#highly-available-setup-with-graylog-radio',
     SEARCH_QUERY_LANGUAGE: 'queries.html',
     STANDARD_DATE_CONVERTER: 'extractors.html#the-standard-date-converter',
     STREAMS: 'streams.html',


### PR DESCRIPTION
This PR removes some remaining artifacts of Graylog Radio.

The Protocol Buffers definition of [`JournalMessage`](https://github.com/Graylog2/graylog2-server/blob/1.3.3/graylog2-plugin-interfaces/src/main/resources/org/graylog2/plugin/journal/raw_message.proto) hasn't been touched for compatibility reasons.