### PR TITLE
Add documentation to rest_listen_uri

### DIFF
--- a/misc/graylog.conf
+++ b/misc/graylog.conf
@@ -34,7 +34,7 @@ root_password_sha2 =
 plugin_dir = plugin
 
 # REST API listen URI. Must be reachable by other graylog2-server nodes if you run a cluster.
-# This must also be reachable by collectors so that hearbeat messages can be received.
+# When using Graylog Collectors, this address is used to receive heartbeat messages and must be reachable by all collectors.
 rest_listen_uri = http://127.0.0.1:12900/
 
 # REST API transport address. Defaults to the value of rest_listen_uri. Exception: If rest_listen_uri

--- a/misc/graylog.conf
+++ b/misc/graylog.conf
@@ -33,7 +33,8 @@ root_password_sha2 =
 # Set plugin directory here (relative or absolute)
 plugin_dir = plugin
 
-# REST API listen URI. Must be reachable by other Graylog server nodes if you run a cluster.
+# REST API listen URI. Must be reachable by other graylog2-server nodes if you run a cluster.
+# This must also be reachable by collectors so that hearbeat messages can be received.
 rest_listen_uri = http://127.0.0.1:12900/
 
 # REST API transport address. Defaults to the value of rest_listen_uri. Exception: If rest_listen_uri


### PR DESCRIPTION
rest_listen_uri is also applicable to collectors connecting to the server. The collectors send PUT hearbeat messages to the server's rest interface. (as of v1.3.3 and collector v0.4.2)