### PR TITLE
Allow disabling embedded web interface with setting "web_enable"

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/bindings/WebInterfaceModule.java
+++ b/graylog2-server/src/main/java/org/graylog2/bindings/WebInterfaceModule.java
@@ -19,18 +19,12 @@ package org.graylog2.bindings;
 import com.google.common.util.concurrent.Service;
 import com.google.inject.AbstractModule;
 import com.google.inject.multibindings.Multibinder;
-import org.graylog2.initializers.BufferSynchronizerService;
-import org.graylog2.initializers.IndexerSetupService;
-import org.graylog2.initializers.MetricsReporterService;
-import org.graylog2.initializers.OutputSetupService;
+import org.graylog2.initializers.WebInterfaceService;
 
-public class InitializerBindings extends AbstractModule {
+public class WebInterfaceModule extends AbstractModule {
     @Override
     protected void configure() {
-        Multibinder<Service> serviceBinder = Multibinder.newSetBinder(binder(), Service.class);
-        serviceBinder.addBinding().to(MetricsReporterService.class);
-        serviceBinder.addBinding().to(IndexerSetupService.class);
-        serviceBinder.addBinding().to(BufferSynchronizerService.class);
-        serviceBinder.addBinding().to(OutputSetupService.class);
+        final Multibinder<Service> serviceBinder = Multibinder.newSetBinder(binder(), Service.class);
+        serviceBinder.addBinding().to(WebInterfaceService.class);
     }
 }

--- a/graylog2-server/src/main/java/org/graylog2/commands/Server.java
+++ b/graylog2-server/src/main/java/org/graylog2/commands/Server.java
@@ -16,6 +16,7 @@
  */
 package org.graylog2.commands;
 
+import com.google.common.collect.ImmutableList;
 import com.google.common.util.concurrent.ServiceManager;
 import com.google.inject.Injector;
 import com.google.inject.Module;
@@ -32,6 +33,7 @@ import org.graylog2.bindings.PasswordAlgorithmBindings;
 import org.graylog2.bindings.PeriodicalBindings;
 import org.graylog2.bindings.PersistenceServicesBindings;
 import org.graylog2.bindings.ServerBindings;
+import org.graylog2.bindings.WebInterfaceModule;
 import org.graylog2.bindings.WidgetStrategyBindings;
 import org.graylog2.bootstrap.Main;
 import org.graylog2.bootstrap.ServerBootstrap;
@@ -106,23 +108,30 @@ public class Server extends ServerBootstrap {
 
     @Override
     protected List<Module> getCommandBindings() {
-        return Arrays.<Module>asList(
-                new ServerBindings(configuration),
-                new PersistenceServicesBindings(),
-                new MessageFilterBindings(),
-                new MessageProcessorModule(),
-                new AlarmCallbackBindings(),
-                new InitializerBindings(),
-                new MessageOutputBindings(configuration),
-                new RotationStrategyBindings(),
-                new RetentionStrategyBindings(),
-                new PeriodicalBindings(),
-                new ObjectMapperModule(classLoader),
-                new RestApiBindings(),
-                new PasswordAlgorithmBindings(),
-                new WidgetStrategyBindings(),
-                new DashboardBindings()
+        final ImmutableList.Builder<Module> modules = ImmutableList.builder();
+        modules.add(
+            new ServerBindings(configuration),
+            new PersistenceServicesBindings(),
+            new MessageFilterBindings(),
+            new MessageProcessorModule(),
+            new AlarmCallbackBindings(),
+            new InitializerBindings(),
+            new MessageOutputBindings(configuration),
+            new RotationStrategyBindings(),
+            new RetentionStrategyBindings(),
+            new PeriodicalBindings(),
+            new ObjectMapperModule(classLoader),
+            new RestApiBindings(),
+            new PasswordAlgorithmBindings(),
+            new WidgetStrategyBindings(),
+            new DashboardBindings()
         );
+
+        if (configuration.isWebEnable()) {
+            modules.add(new WebInterfaceModule());
+        }
+
+        return modules.build();
     }
 
     @Override

--- a/graylog2-server/src/main/java/org/graylog2/plugin/BaseConfiguration.java
+++ b/graylog2-server/src/main/java/org/graylog2/plugin/BaseConfiguration.java
@@ -123,6 +123,9 @@ public abstract class BaseConfiguration {
     @Parameter(value = "installation_source", validator = StringNotBlankValidator.class)
     private String installationSource = "unknown";
 
+    @Parameter(value = "web_enable")
+    private boolean webEnable = true;
+
     @Parameter(value = "web_enable_cors")
     private boolean webEnableCors = false;
 
@@ -329,6 +332,10 @@ public abstract class BaseConfiguration {
 
     public String getInstallationSource() {
         return installationSource;
+    }
+
+    public boolean isWebEnable() {
+        return webEnable;
     }
 
     public boolean isWebEnableCors() {

--- a/misc/graylog.conf
+++ b/misc/graylog.conf
@@ -77,6 +77,10 @@ rest_listen_uri = http://127.0.0.1:12900/
 # The size of the thread pool used exclusively for serving the REST API.
 #rest_thread_pool_size = 16
 
+# Enable the embedded Graylog web interface.
+# Default: true
+#web_enable = false
+
 # Web interface listen URI
 #web_listen_uri = http://127.0.0.1:9000/
 


### PR DESCRIPTION
This PR adds the configuration setting `web_enable` which allows users to disable the embedded web interface on a Graylog node.