### PR TITLE
Add separator and header to system menu if plugins are present

### DIFF
--- a/graylog2-web-interface/src/components/navigation/Navigation.jsx
+++ b/graylog2-web-interface/src/components/navigation/Navigation.jsx
@@ -12,6 +12,7 @@ import { PluginStore } from 'graylog-web-plugin/plugin';
 import GlobalThroughput from 'components/throughput/GlobalThroughput';
 import UserMenu from 'components/navigation/UserMenu';
 import HelpMenu from 'components/navigation/HelpMenu';
+import naturalSort from 'javascript-natural-sort';
 
 const Navigation = React.createClass({
   propTypes: {
@@ -112,6 +113,7 @@ const Navigation = React.createClass({
       });
 
     const pluginSystemNavigations = PluginStore.exports('systemnavigation')
+      .sort((a, b) => naturalSort(a.description, b.description))
       .map((pluginRoute) => {
         return (
           <LinkContainer key={pluginRoute.path} to={pluginRoute.path}>
@@ -205,6 +207,12 @@ const Navigation = React.createClass({
                 <MenuItem>Grok Patterns</MenuItem>
               </LinkContainer>
               }
+              {pluginSystemNavigations.length > 0 && (
+                <span>
+                  <MenuItem divider />
+                  <MenuItem header>Plugins</MenuItem>
+                </span>
+              )}
               {pluginSystemNavigations}
             </NavDropdown>
           </Nav>


### PR DESCRIPTION
This adds a separator and header to the system menu to make it easy to see which menu entries are from plugins.

Do we want this? Please comment!

![l5ruzoopraaaaaabjru5erkjggg](https://cloud.githubusercontent.com/assets/461/13321051/1615e720-dbcd-11e5-9779-a12465a67515.png)
