### PR TITLE
Add classForName to ChainableClassLoader and make it injectable

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/bindings/MessageOutputBindings.java
+++ b/graylog2-server/src/main/java/org/graylog2/bindings/MessageOutputBindings.java
@@ -26,6 +26,7 @@ import org.graylog2.outputs.GelfOutput;
 import org.graylog2.outputs.LoggingOutput;
 import org.graylog2.plugin.inject.Graylog2Module;
 import org.graylog2.plugin.outputs.MessageOutput;
+import org.graylog2.shared.plugins.ChainingClassLoader;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -36,9 +37,11 @@ public class MessageOutputBindings extends Graylog2Module {
     private static final Logger LOG = LoggerFactory.getLogger(MessageOutputBindings.class);
 
     private final Configuration configuration;
+    private final ChainingClassLoader chainingClassLoader;
 
-    public MessageOutputBindings(final Configuration configuration) {
+    public MessageOutputBindings(final Configuration configuration, ChainingClassLoader chainingClassLoader) {
         this.configuration = configuration;
+        this.chainingClassLoader = chainingClassLoader;
     }
 
     @Override
@@ -60,7 +63,7 @@ public class MessageOutputBindings extends Graylog2Module {
 
         try {
             @SuppressWarnings("unchecked")
-            final Class<? extends MessageOutput> defaultMessageOutputClass = (Class<? extends MessageOutput>) Class.forName(configuration.getDefaultMessageOutputClass());
+            final Class<? extends MessageOutput> defaultMessageOutputClass = (Class<? extends MessageOutput>) chainingClassLoader.loadClass(configuration.getDefaultMessageOutputClass());
 
             if (MessageOutput.class.isAssignableFrom(defaultMessageOutputClass)) {
                 LOG.info("Using {} as default message output", defaultMessageOutputClass.getCanonicalName());

--- a/graylog2-server/src/main/java/org/graylog2/commands/Server.java
+++ b/graylog2-server/src/main/java/org/graylog2/commands/Server.java
@@ -114,7 +114,7 @@ public class Server extends ServerBootstrap {
             new MessageProcessorModule(),
             new AlarmCallbackBindings(),
             new InitializerBindings(),
-            new MessageOutputBindings(configuration),
+            new MessageOutputBindings(configuration, chainingClassLoader),
             new RotationStrategyBindings(),
             new RetentionStrategyBindings(),
             new PeriodicalBindings(),

--- a/graylog2-server/src/main/java/org/graylog2/commands/Server.java
+++ b/graylog2-server/src/main/java/org/graylog2/commands/Server.java
@@ -54,7 +54,6 @@ import org.graylog2.plugin.Tools;
 import org.graylog2.shared.UI;
 import org.graylog2.shared.bindings.ObjectMapperModule;
 import org.graylog2.shared.bindings.RestApiBindings;
-import org.graylog2.shared.plugins.ChainingClassLoader;
 import org.graylog2.shared.system.activities.Activity;
 import org.graylog2.shared.system.activities.ActivityWriter;
 import org.graylog2.system.shutdown.GracefulShutdown;
@@ -79,7 +78,6 @@ public class Server extends ServerBootstrap {
     private final MongoDbConfiguration mongoDbConfiguration = new MongoDbConfiguration();
     private final VersionCheckConfiguration versionCheckConfiguration = new VersionCheckConfiguration();
     private final KafkaJournalConfiguration kafkaJournalConfiguration = new KafkaJournalConfiguration();
-    private final ChainingClassLoader classLoader = new ChainingClassLoader(Server.class.getClassLoader());
 
     public Server() {
         super("server", configuration);
@@ -120,7 +118,7 @@ public class Server extends ServerBootstrap {
             new RotationStrategyBindings(),
             new RetentionStrategyBindings(),
             new PeriodicalBindings(),
-            new ObjectMapperModule(classLoader),
+            new ObjectMapperModule(chainingClassLoader),
             new RestApiBindings(),
             new PasswordAlgorithmBindings(),
             new WidgetStrategyBindings(),

--- a/graylog2-server/src/main/java/org/graylog2/rest/resources/system/ClusterConfigResource.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/resources/system/ClusterConfigResource.java
@@ -28,6 +28,7 @@ import org.apache.shiro.authz.annotation.RequiresPermissions;
 import org.graylog2.plugin.cluster.ClusterConfigService;
 import org.graylog2.rest.MoreMediaTypes;
 import org.graylog2.rest.models.system.config.ClusterConfigList;
+import org.graylog2.shared.plugins.ChainingClassLoader;
 import org.graylog2.shared.rest.resources.RestResource;
 import org.graylog2.shared.security.RestPermissions;
 import org.hibernate.validator.constraints.NotBlank;
@@ -58,10 +59,12 @@ import static java.util.Objects.requireNonNull;
 @Produces(MediaType.APPLICATION_JSON)
 public class ClusterConfigResource extends RestResource {
     private final ClusterConfigService clusterConfigService;
+    private final ChainingClassLoader chainingClassLoader;
 
     @Inject
-    public ClusterConfigResource(ClusterConfigService clusterConfigService) {
+    public ClusterConfigResource(ClusterConfigService clusterConfigService, ChainingClassLoader chainingClassLoader) {
         this.clusterConfigService = requireNonNull(clusterConfigService);
+        this.chainingClassLoader = chainingClassLoader;
     }
 
     @GET
@@ -151,7 +154,7 @@ public class ClusterConfigResource extends RestResource {
     @Nullable
     private Class<?> classFromName(String className) {
         try {
-            return Class.forName(className);
+            return chainingClassLoader.classForName(className);
         } catch (ClassNotFoundException e) {
             return null;
         }

--- a/graylog2-server/src/main/java/org/graylog2/rest/resources/system/ClusterConfigResource.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/resources/system/ClusterConfigResource.java
@@ -154,7 +154,7 @@ public class ClusterConfigResource extends RestResource {
     @Nullable
     private Class<?> classFromName(String className) {
         try {
-            return chainingClassLoader.classForName(className);
+            return chainingClassLoader.loadClass(className);
         } catch (ClassNotFoundException e) {
             return null;
         }

--- a/graylog2-server/src/main/java/org/graylog2/shared/plugins/ChainingClassLoader.java
+++ b/graylog2-server/src/main/java/org/graylog2/shared/plugins/ChainingClassLoader.java
@@ -121,8 +121,4 @@ public class ChainingClassLoader extends ClassLoader {
     public boolean addClassLoader(ClassLoader classLoader) {
         return classLoaders.add(classLoader);
     }
-
-    public Class<?> classForName(String className) throws ClassNotFoundException {
-        return Class.forName(className, true, this);
-    }
 }

--- a/graylog2-server/src/main/java/org/graylog2/shared/plugins/ChainingClassLoader.java
+++ b/graylog2-server/src/main/java/org/graylog2/shared/plugins/ChainingClassLoader.java
@@ -121,4 +121,8 @@ public class ChainingClassLoader extends ClassLoader {
     public boolean addClassLoader(ClassLoader classLoader) {
         return classLoaders.add(classLoader);
     }
+
+    public Class<?> classForName(String className) throws ClassNotFoundException {
+        return Class.forName(className, true, this);
+    }
 }

--- a/graylog2-server/src/test/java/org/graylog2/cluster/ClusterConfigServiceImplTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/cluster/ClusterConfigServiceImplTest.java
@@ -39,6 +39,7 @@ import org.graylog2.database.ObjectIdSerializer;
 import org.graylog2.plugin.cluster.ClusterConfigService;
 import org.graylog2.plugin.system.NodeId;
 import org.graylog2.shared.jackson.SizeSerializer;
+import org.graylog2.shared.plugins.ChainingClassLoader;
 import org.graylog2.shared.rest.RangeJsonSerializer;
 import org.joda.time.DateTime;
 import org.joda.time.DateTimeUtils;
@@ -101,6 +102,7 @@ public class ClusterConfigServiceImplTest {
                 mongoRule.getMongoConnection(),
                 nodeId,
                 objectMapper,
+                new ChainingClassLoader(getClass().getClassLoader()),
                 clusterEventBus
         );
     }

--- a/graylog2-server/src/test/java/org/graylog2/events/ClusterEventPeriodicalTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/events/ClusterEventPeriodicalTest.java
@@ -30,7 +30,6 @@ import com.google.common.eventbus.Subscribe;
 import com.lordofthejars.nosqlunit.annotation.UsingDataSet;
 import com.lordofthejars.nosqlunit.core.LoadStrategyEnum;
 import com.lordofthejars.nosqlunit.mongodb.InMemoryMongoDb;
-import com.mongodb.BasicDBObject;
 import com.mongodb.BasicDBObjectBuilder;
 import com.mongodb.DBCollection;
 import com.mongodb.DBObject;
@@ -41,6 +40,7 @@ import org.graylog2.database.MongoConnectionRule;
 import org.graylog2.database.ObjectIdSerializer;
 import org.graylog2.plugin.system.NodeId;
 import org.graylog2.shared.jackson.SizeSerializer;
+import org.graylog2.shared.plugins.ChainingClassLoader;
 import org.graylog2.shared.rest.RangeJsonSerializer;
 import org.graylog2.system.debug.DebugEvent;
 import org.joda.time.DateTime;
@@ -111,6 +111,7 @@ public class ClusterEventPeriodicalTest {
                 mongoRule.getMongoConnection(),
                 nodeId,
                 objectMapper,
+                new ChainingClassLoader(getClass().getClassLoader()),
                 serverEventBus,
                 clusterEventBus
         );


### PR DESCRIPTION
This is needed to make `Class.forName()` with classes from external plugins work. For example cluster config classes from external jar plugins.