### PR TITLE
Do not cache widget plugins to avoid problems with external plugins

### DIFF
--- a/graylog2-web-interface/src/components/widgets/Widget.jsx
+++ b/graylog2-web-interface/src/components/widgets/Widget.jsx
@@ -45,13 +45,12 @@ const Widget = React.createClass({
     $(document).off('gridster:resizestop', () => this._calculateWidgetSize());
   },
 
-  widgetPlugins: PluginStore.exports('widgets'),
   DEFAULT_WIDGET_VALUE_REFRESH: 10 * 1000,
   WIDGET_HEADER_HEIGHT: 25,
   WIDGET_FOOTER_HEIGHT: 20,
 
   _getWidgetPlugin(widgetType) {
-    return this.widgetPlugins.filter(widget => widget.type.toUpperCase() === widgetType.toUpperCase())[0];
+    return PluginStore.exports('widgets').filter(widget => widget.type.toUpperCase() === widgetType.toUpperCase())[0];
   },
 
   _isBoundToStream() {

--- a/graylog2-web-interface/src/components/widgets/WidgetConfigModal.jsx
+++ b/graylog2-web-interface/src/components/widgets/WidgetConfigModal.jsx
@@ -15,8 +15,6 @@ const WidgetConfigModal = React.createClass({
     dashboardId: PropTypes.string.isRequired,
   },
 
-  widgetPlugins: PluginStore.exports('widgets'),
-
   open() {
     this.refs.configModal.open();
   },
@@ -25,7 +23,7 @@ const WidgetConfigModal = React.createClass({
   },
   _getBasicConfiguration() {
     let basicConfigurationMessage;
-    const widgetPlugin = this.widgetPlugins.filter(widget => widget.type.toUpperCase() === this.props.widget.type.toUpperCase())[0];
+    const widgetPlugin = PluginStore.exports('widgets').filter(widget => widget.type.toUpperCase() === this.props.widget.type.toUpperCase())[0];
     const widgetType = (widgetPlugin ? widgetPlugin.displayName : 'Not available');
     if (this.props.boundToStream) {
       basicConfigurationMessage = (

--- a/graylog2-web-interface/src/components/widgets/WidgetCreationModal.jsx
+++ b/graylog2-web-interface/src/components/widgets/WidgetCreationModal.jsx
@@ -30,10 +30,8 @@ const WidgetCreationModal = React.createClass({
     }
   },
 
-  widgetPlugins: PluginStore.exports('widgets'),
-
   _getWidgetPlugin(widgetType) {
-    return this.widgetPlugins.filter(widget => widget.type.toUpperCase() === widgetType.toUpperCase())[0];
+    return PluginStore.exports('widgets').filter(widget => widget.type.toUpperCase() === widgetType.toUpperCase())[0];
   },
 
   _getInitialConfiguration() {

--- a/graylog2-web-interface/src/components/widgets/WidgetEditConfigModal.jsx
+++ b/graylog2-web-interface/src/components/widgets/WidgetEditConfigModal.jsx
@@ -32,10 +32,8 @@ const WidgetEditConfigModal = React.createClass({
     this.widgetPlugin = this._getWidgetPlugin(nextProps.widget.type);
   },
 
-  widgetPlugins: PluginStore.exports('widgets'),
-
   _getWidgetPlugin(widgetType) {
-    return this.widgetPlugins.filter(widget => widget.type.toUpperCase() === widgetType.toUpperCase())[0];
+    return PluginStore.exports('widgets').filter(widget => widget.type.toUpperCase() === widgetType.toUpperCase())[0];
   },
 
   open() {

--- a/graylog2-web-interface/src/pages/ShowDashboardPage.jsx
+++ b/graylog2-web-interface/src/pages/ShowDashboardPage.jsx
@@ -36,7 +36,6 @@ const ShowDashboardPage = React.createClass({
       clearInterval(this.loadInterval);
     }
   },
-  widgetPlugins: PluginStore.exports('widgets'),
   DASHBOARDS_EDIT: 'dashboards:edit',
   loadData() {
     DashboardsStore.get(this.props.params.dashboardId)
@@ -72,7 +71,7 @@ const ShowDashboardPage = React.createClass({
   _defaultWidgetDimensions(widget) {
     const dimensions = {col: 0, row: 0};
 
-    const widgetPlugin = this.widgetPlugins.filter(plugin => plugin.type.toUpperCase() === widget.type.toUpperCase())[0];
+    const widgetPlugin = PluginStore.exports('widgets').filter(plugin => plugin.type.toUpperCase() === widget.type.toUpperCase())[0];
     dimensions.height = widgetPlugin.defaultHeight;
     dimensions.width = widgetPlugin.defaultWidth;
 


### PR DESCRIPTION
The global "plugins" variable might not be completely initialized yet because plugin JavaScript files have not been loaded.

Fixes an issue where a field analyzer/widget from a plugin does not work because the plugin widget is not in `plugins` yet.