### PR TITLE
Fix dashboards loading

### DIFF
--- a/graylog2-web-interface/src/components/dashboard/AddToDashboardMenu.jsx
+++ b/graylog2-web-interface/src/components/dashboard/AddToDashboardMenu.jsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, {PropTypes} from 'react';
 import { ButtonGroup, DropdownButton, MenuItem } from 'react-bootstrap';
 import Immutable from 'immutable';
 import $ from 'jquery';
@@ -11,13 +11,39 @@ import { WidgetCreationModal } from 'components/widgets';
 import { EditDashboardModal } from 'components/dashboard';
 
 const AddToDashboardMenu = React.createClass({
+  propTypes: {
+    widgetType: PropTypes.string.isRequired,
+    title: PropTypes.string.isRequired,
+    permissions: PropTypes.arrayOf(PropTypes.string).isRequired,
+    bsStyle: PropTypes.string,
+    configuration: PropTypes.object,
+    fields: PropTypes.array,
+    hidden: PropTypes.bool,
+    pullRight: PropTypes.bool,
+    children: PropTypes.oneOfType([
+      PropTypes.arrayOf(PropTypes.element),
+      PropTypes.element,
+    ]),
+  },
+
   mixins: [PermissionsMixin],
+
   getInitialState() {
     return {
       dashboards: DashboardsStore.writableDashboards,
       selectedDashboard: '',
     };
   },
+
+  getDefaultProps() {
+    return {
+      bsStyle: 'info',
+      configuration: {},
+      hidden: false,
+      pullRight: false,
+    };
+  },
+
   componentDidMount() {
     DashboardsStore.addOnWritableDashboardsChangedCallback(dashboards => {
       if (this.isMounted()) {
@@ -100,7 +126,7 @@ const AddToDashboardMenu = React.createClass({
       });
 
     return (
-      <DropdownButton bsStyle={this.props.bsStyle || 'info'}
+      <DropdownButton bsStyle={this.props.bsStyle}
                       bsSize="small"
                       title={this.props.title}
                       pullRight={this.props.pullRight}
@@ -121,7 +147,7 @@ const AddToDashboardMenu = React.createClass({
 
     return (
       <div style={{display: 'inline'}}>
-        <DropdownButton bsStyle={this.props.bsStyle || 'info'}
+        <DropdownButton bsStyle={this.props.bsStyle}
                         bsSize="small"
                         title={this.props.title}
                         pullRight={this.props.pullRight}
@@ -144,11 +170,8 @@ const AddToDashboardMenu = React.createClass({
         </ButtonGroup>
         <WidgetCreationModal ref="widgetModal"
                              widgetType={this.props.widgetType}
-                             supportsTrending
-                             configuration={this.props.configuration}
                              onConfigurationSaved={this._saveWidget}
-                             fields={this.props.fields}
-                             isStreamSearch={this.props.isStreamSearch}/>
+                             fields={this.props.fields}/>
       </div>
     );
   },

--- a/graylog2-web-interface/src/components/field-analyzers/FieldStatistics.jsx
+++ b/graylog2-web-interface/src/components/field-analyzers/FieldStatistics.jsx
@@ -141,7 +141,6 @@ const FieldStatistics = React.createClass({
           <div className="pull-right">
             <AddToDashboardMenu title="Add to dashboard"
                                 widgetType={this.WIDGET_TYPE}
-                                configuration={{}}
                                 bsStyle="default"
                                 fields={this.state.fieldStatistics.keySeq().toJS()}
                                 pullRight

--- a/graylog2-web-interface/src/components/search/SearchResult.jsx
+++ b/graylog2-web-interface/src/components/search/SearchResult.jsx
@@ -6,7 +6,6 @@ import { AddSearchCountToDashboard, LegacyHistogram, ResultTable, SearchSidebar,
 
 import DocumentationLink from 'components/support/DocumentationLink';
 
-import DashboardsStore from 'stores/dashboards/DashboardsStore';
 import SearchStore from 'stores/search/SearchStore';
 import DocsHelper from 'util/DocsHelper';
 
@@ -48,10 +47,6 @@ const SearchResult = React.createClass({
       showAllFields: false,
       shouldHighlight: true,
     };
-  },
-
-  componentDidMount() {
-    DashboardsStore.updateWritableDashboards();
   },
 
   onFieldToggled(fieldName) {

--- a/graylog2-web-interface/src/pages/SearchPage.jsx
+++ b/graylog2-web-interface/src/pages/SearchPage.jsx
@@ -4,7 +4,6 @@ import Immutable from 'immutable';
 import moment from 'moment';
 
 import CurrentUserStore from 'stores/users/CurrentUserStore';
-import DashboardsStore from 'stores/dashboards/DashboardsStore';
 import InputsActions from 'actions/inputs/InputsActions';
 import InputsStore from 'stores/inputs/InputsStore';
 import MessageFieldsStore from 'stores/messages/MessageFieldsStore';
@@ -49,7 +48,6 @@ const SearchPage = React.createClass({
     });
 
     NodesActions.list();
-    DashboardsStore.updateWritableDashboards();
   },
   componentWillUnmount() {
     this._stopTimer();

--- a/graylog2-web-interface/src/stores/dashboards/DashboardsStore.ts
+++ b/graylog2-web-interface/src/stores/dashboards/DashboardsStore.ts
@@ -65,21 +65,23 @@ class DashboardsStore {
 
   updateWritableDashboards() {
     const permissions = CurrentUserStore.get().permissions;
-    const dashboards = {};
-    this.updateDashboards();
-    this.getWritableDashboardList(permissions).forEach((dashboard) => {
-      dashboards[dashboard.id] = dashboard;
+    const promise = this.updateDashboards();
+    promise.then(() => {
+      const dashboards = {};
+      this.getWritableDashboardList(permissions).forEach((dashboard) => {
+        dashboards[dashboard.id] = dashboard;
+      });
+      this.writableDashboards = Immutable.Map<string, Dashboard>(dashboards);
     });
-    this.writableDashboards = Immutable.Map<string, Dashboard>(dashboards);
   }
 
   updateDashboards() {
-    this.listDashboards()
-      .then((dashboardList) => {
-        this.dashboards = dashboardList;
+    const promise = this.listDashboards();
+    promise.then((dashboardList) => {
+      this.dashboards = dashboardList;
+    });
 
-        return dashboardList;
-      });
+    return promise;
   }
 
   listDashboards(): Promise<Immutable.List<Dashboard>> {
@@ -105,10 +107,10 @@ class DashboardsStore {
   get(id: string): Promise<Dashboard> {
     const url = URLUtils.qualifyUrl(jsRoutes.controllers.api.DashboardsApiController.get(id).url);
     const promise = new Builder('GET', url)
-        .authenticated()
-        .setHeader('X-Graylog-No-Session-Extension', 'true')
-        .json()
-        .build();
+      .authenticated()
+      .setHeader('X-Graylog-No-Session-Extension', 'true')
+      .json()
+      .build();
 
     promise.catch((error) => {
       if (error.additional.status !== 404) {
@@ -184,7 +186,7 @@ class DashboardsStore {
     const url = URLUtils.qualifyUrl(jsRoutes.controllers.api.DashboardsApiController.updatePositions(dashboard.id).url);
     const promise = fetch('PUT', url, {positions: positions}).catch((error) => {
       UserNotification.error("Updating widget positions for dashboard \"" + dashboard.title + "\" failed with status: " + error.message,
-          "Could not update dashboard");
+        "Could not update dashboard");
     });
 
     return promise;


### PR DESCRIPTION
Make sure that field analysers loaded from plugins also render a list of dashboards. In the long term we should move `DashboardsStore` (and other "ancient" stores) into Reflux, but this should fix the issue for now.