### PR TITLE
Unify serialization of outputs.

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/plugin/streams/Stream.java
+++ b/graylog2-server/src/main/java/org/graylog2/plugin/streams/Stream.java
@@ -17,8 +17,10 @@
 package org.graylog2.plugin.streams;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
+import org.graylog2.plugin.alarms.AlertCondition;
 import org.graylog2.plugin.database.Persisted;
 
+import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -47,6 +49,8 @@ public interface Stream extends Persisted {
     Boolean getDisabled();
 
     String getContentPack();
+
+    Collection<AlertCondition> getAlertConditions();
 
     void setTitle(String title);
 

--- a/graylog2-server/src/main/java/org/graylog2/rest/resources/streams/StreamResource.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/resources/streams/StreamResource.java
@@ -429,6 +429,7 @@ public class StreamResource extends RestResource {
 
     private StreamResponse streamToResponse(Stream stream) {
         return StreamResponse.create(
+            stream.getId(),
             (String)stream.getFields().get(StreamImpl.FIELD_CREATOR_USER_ID),
             outputsToSummaries(stream.getOutputs()),
             stream.getMatchingType().name(),
@@ -436,6 +437,7 @@ public class StreamResource extends RestResource {
             stream.getFields().get(StreamImpl.FIELD_CREATED_AT).toString(),
             stream.getDisabled(),
             stream.getStreamRules(),
+            stream.getAlertConditions(),
             stream.getTitle(),
             stream.getContentPack()
         );

--- a/graylog2-server/src/main/java/org/graylog2/rest/resources/streams/responses/StreamListResponse.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/resources/streams/responses/StreamListResponse.java
@@ -20,7 +20,6 @@ import com.fasterxml.jackson.annotation.JsonAutoDetect;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.auto.value.AutoValue;
-import org.graylog2.plugin.streams.Stream;
 
 import java.util.Collection;
 
@@ -31,10 +30,10 @@ public abstract class StreamListResponse {
     public abstract long total();
 
     @JsonProperty
-    public abstract Collection<Stream> streams();
+    public abstract Collection<StreamResponse> streams();
 
     @JsonCreator
-    public static StreamListResponse create(@JsonProperty("total") long total, @JsonProperty("streams") Collection<Stream> streams) {
+    public static StreamListResponse create(@JsonProperty("total") long total, @JsonProperty("streams") Collection<StreamResponse> streams) {
         return new AutoValue_StreamListResponse(total, streams);
     }
 }

--- a/graylog2-server/src/main/java/org/graylog2/rest/resources/streams/responses/StreamResponse.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/resources/streams/responses/StreamResponse.java
@@ -1,0 +1,56 @@
+package org.graylog2.rest.resources.streams.responses;
+
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.auto.value.AutoValue;
+import org.graylog2.plugin.streams.StreamRule;
+import org.graylog2.rest.models.system.outputs.responses.OutputSummary;
+
+import javax.annotation.Nullable;
+import java.util.Collection;
+
+@AutoValue
+@JsonAutoDetect
+public abstract class StreamResponse {
+    @JsonProperty("creator_user_id")
+    public abstract String creatorUserId();
+
+    @JsonProperty("outputs")
+    public abstract Collection<OutputSummary> outputs();
+
+    @JsonProperty("matching_type")
+    public abstract String matchingType();
+
+    @JsonProperty("description")
+    public abstract String description();
+
+    @JsonProperty("created_at")
+    public abstract String createdAt();
+
+    @JsonProperty("disabled")
+    public abstract boolean disabled();
+
+    @JsonProperty("rules")
+    public abstract Collection<StreamRule> rules();
+
+    @JsonProperty("title")
+    public abstract String title();
+
+    @JsonProperty("content_pack")
+    @Nullable
+    public abstract String contentPack();
+
+    @JsonCreator
+    public static StreamResponse create(@JsonProperty("creator_user_id") String creatorUserId,
+                                        @JsonProperty("outputs") Collection<OutputSummary> outputs,
+                                        @JsonProperty("matching_type") String matchingType,
+                                        @JsonProperty("description") String description,
+                                        @JsonProperty("created_at") String createdAt,
+                                        @JsonProperty("disabled") boolean disabled,
+                                        @JsonProperty("rules") Collection<StreamRule> rules,
+                                        @JsonProperty("title") String title,
+                                        @JsonProperty("content_pack") @Nullable String contentPack) {
+        return new AutoValue_StreamResponse(creatorUserId, outputs, matchingType, description, createdAt, disabled, rules, title, contentPack);
+    }
+}

--- a/graylog2-server/src/main/java/org/graylog2/rest/resources/streams/responses/StreamResponse.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/resources/streams/responses/StreamResponse.java
@@ -39,6 +39,7 @@ public abstract class StreamResponse {
     public abstract String matchingType();
 
     @JsonProperty("description")
+    @Nullable
     public abstract String description();
 
     @JsonProperty("created_at")
@@ -61,7 +62,7 @@ public abstract class StreamResponse {
     public static StreamResponse create(@JsonProperty("creator_user_id") String creatorUserId,
                                         @JsonProperty("outputs") Collection<OutputSummary> outputs,
                                         @JsonProperty("matching_type") String matchingType,
-                                        @JsonProperty("description") String description,
+                                        @JsonProperty("description") @Nullable String description,
                                         @JsonProperty("created_at") String createdAt,
                                         @JsonProperty("disabled") boolean disabled,
                                         @JsonProperty("rules") Collection<StreamRule> rules,

--- a/graylog2-server/src/main/java/org/graylog2/rest/resources/streams/responses/StreamResponse.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/resources/streams/responses/StreamResponse.java
@@ -20,6 +20,7 @@ import com.fasterxml.jackson.annotation.JsonAutoDetect;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.auto.value.AutoValue;
+import org.graylog2.plugin.alarms.AlertCondition;
 import org.graylog2.plugin.streams.StreamRule;
 import org.graylog2.rest.models.system.outputs.responses.OutputSummary;
 
@@ -29,6 +30,9 @@ import java.util.Collection;
 @AutoValue
 @JsonAutoDetect
 public abstract class StreamResponse {
+    @JsonProperty("id")
+    public abstract String id();
+
     @JsonProperty("creator_user_id")
     public abstract String creatorUserId();
 
@@ -51,6 +55,9 @@ public abstract class StreamResponse {
     @JsonProperty("rules")
     public abstract Collection<StreamRule> rules();
 
+    @JsonProperty("alert_conditions")
+    public abstract Collection<AlertCondition> alertConditions();
+
     @JsonProperty("title")
     public abstract String title();
 
@@ -59,15 +66,18 @@ public abstract class StreamResponse {
     public abstract String contentPack();
 
     @JsonCreator
-    public static StreamResponse create(@JsonProperty("creator_user_id") String creatorUserId,
+    public static StreamResponse create(@JsonProperty("id") String id,
+                                        @JsonProperty("creator_user_id") String creatorUserId,
                                         @JsonProperty("outputs") Collection<OutputSummary> outputs,
                                         @JsonProperty("matching_type") String matchingType,
                                         @JsonProperty("description") @Nullable String description,
                                         @JsonProperty("created_at") String createdAt,
                                         @JsonProperty("disabled") boolean disabled,
                                         @JsonProperty("rules") Collection<StreamRule> rules,
+                                        @JsonProperty("alert_conditions") Collection<AlertCondition> alertConditions,
                                         @JsonProperty("title") String title,
                                         @JsonProperty("content_pack") @Nullable String contentPack) {
-        return new AutoValue_StreamResponse(creatorUserId, outputs, matchingType, description, createdAt, disabled, rules, title, contentPack);
+        return new AutoValue_StreamResponse(id, creatorUserId, outputs, matchingType, description, createdAt, disabled,
+            rules, alertConditions, title, contentPack);
     }
 }

--- a/graylog2-server/src/main/java/org/graylog2/rest/resources/streams/responses/StreamResponse.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/resources/streams/responses/StreamResponse.java
@@ -1,3 +1,19 @@
+/**
+ * This file is part of Graylog.
+ *
+ * Graylog is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package org.graylog2.rest.resources.streams.responses;
 
 import com.fasterxml.jackson.annotation.JsonAutoDetect;

--- a/graylog2-server/src/main/java/org/graylog2/streams/StreamImpl.java
+++ b/graylog2-server/src/main/java/org/graylog2/streams/StreamImpl.java
@@ -29,12 +29,14 @@ import org.graylog2.database.validators.FilledStringValidator;
 import org.graylog2.database.validators.MapValidator;
 import org.graylog2.database.validators.OptionalStringValidator;
 import org.graylog2.plugin.Tools;
+import org.graylog2.plugin.alarms.AlertCondition;
 import org.graylog2.plugin.database.validators.Validator;
 import org.graylog2.plugin.streams.Output;
 import org.graylog2.plugin.streams.Stream;
 import org.graylog2.plugin.streams.StreamRule;
 import org.joda.time.DateTime;
 
+import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -88,6 +90,15 @@ public class StreamImpl extends PersistedImpl implements Stream {
     @Override
     public List<StreamRule> getStreamRules() {
         return this.streamRules;
+    }
+
+    @Override
+    public Collection<AlertCondition> getAlertConditions() {
+        if (!this.fields.containsKey(EMBEDDED_ALERT_CONDITIONS)) {
+            return Collections.emptyList();
+        } else {
+            return (Collection<AlertCondition>)this.fields.get(EMBEDDED_ALERT_CONDITIONS);
+        }
     }
 
     @Override

--- a/graylog2-server/src/test/java/org/graylog2/streams/StreamMock.java
+++ b/graylog2-server/src/test/java/org/graylog2/streams/StreamMock.java
@@ -20,11 +20,14 @@ package org.graylog2.streams;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
+import edu.emory.mathcs.backport.java.util.Collections;
+import org.graylog2.plugin.alarms.AlertCondition;
 import org.graylog2.plugin.database.validators.Validator;
 import org.graylog2.plugin.streams.Output;
 import org.graylog2.plugin.streams.Stream;
 import org.graylog2.plugin.streams.StreamRule;
 
+import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -128,6 +131,11 @@ public class StreamMock implements Stream {
     @Override
     public Map<String, List<String>> getAlertReceivers() {
         return Maps.newHashMap();
+    }
+
+    @Override
+    public Collection<AlertCondition> getAlertConditions() {
+        return Collections.emptyList();
     }
 
     @Override

--- a/graylog2-server/src/test/java/org/graylog2/streams/StreamMock.java
+++ b/graylog2-server/src/test/java/org/graylog2/streams/StreamMock.java
@@ -20,7 +20,6 @@ package org.graylog2.streams;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
-import edu.emory.mathcs.backport.java.util.Collections;
 import org.graylog2.plugin.alarms.AlertCondition;
 import org.graylog2.plugin.database.validators.Validator;
 import org.graylog2.plugin.streams.Output;
@@ -28,6 +27,7 @@ import org.graylog2.plugin.streams.Stream;
 import org.graylog2.plugin.streams.StreamRule;
 
 import java.util.Collection;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;


### PR DESCRIPTION
This changeset unifies serialization of outputs by using the same representation for `StreamOutputResource`, `StreamResource` and `OutputResource`.

Fixes #1248 