### PR TITLE
Add CSV export again.

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/rest/resources/search/RelativeSearchResource.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/resources/search/RelativeSearchResource.java
@@ -51,6 +51,7 @@ import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
 import javax.ws.rs.QueryParam;
 import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
 import java.util.List;
 import java.util.Locale;
 
@@ -132,16 +133,36 @@ public class RelativeSearchResource extends SearchResource {
         try {
             final ScrollResult scroll = searches
                     .scroll(query, timeRange, limit, offset, fieldList, filter);
-            final ChunkedOutput<ScrollResult.ScrollChunk> output = new ChunkedOutput<>(ScrollResult.ScrollChunk.class);
-
-            LOG.debug("[{}] Scroll result contains a total of {} messages", scroll.getQueryHash(), scroll.totalHits());
-            Runnable scrollIterationAction = createScrollChunkProducer(scroll, output, limit);
-            // TODO use a shared executor for async responses here instead of a single thread that's not limited
-            new Thread(scrollIterationAction).start();
-            return output;
+            return buildChunkedOutput(scroll, limit);
         } catch (SearchPhaseExecutionException e) {
             throw createRequestExceptionForParseFailure(query, e);
         }
+    }
+
+    @GET
+    @Path("/export")
+    @Timed
+    @ApiOperation(value = "Export message search with relative timerange.",
+            notes = "Search for messages in a relative timerange, specified as seconds from now. " +
+                    "Example: 300 means search from 5 minutes ago to now.")
+    @Produces(AdditionalMediaType.TEXT_CSV)
+    @ApiResponses(value = {
+            @ApiResponse(code = 400, message = "Invalid timerange parameters provided.")
+    })
+    public Response exportSearchRelativeChunked(
+            @ApiParam(name = "query", value = "Query (Lucene syntax)", required = true)
+            @QueryParam("query") @NotEmpty String query,
+            @ApiParam(name = "range", value = "Relative timeframe to search in. See method description.", required = true) @QueryParam("range") int range,
+            @ApiParam(name = "limit", value = "Maximum number of messages to return.", required = false) @QueryParam("limit") int limit,
+            @ApiParam(name = "offset", value = "Offset", required = false) @QueryParam("offset") int offset,
+            @ApiParam(name = "filter", value = "Filter", required = false) @QueryParam("filter") String filter,
+            @ApiParam(name = "fields", value = "Comma separated list of fields to return", required = true) @QueryParam("fields") String fields) {
+        checkSearchPermission(filter, RestPermissions.SEARCHES_RELATIVE);
+        final String filename = "graylog-search-result-relative-" + range + ".csv";
+        return Response
+            .ok(searchRelativeChunked(query, range, limit, offset, filter, fields))
+            .header("Content-Disposition", "attachment; filename=" + filename)
+            .build();
     }
 
     @GET

--- a/graylog2-server/src/main/java/org/graylog2/rest/resources/search/SearchResource.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/resources/search/SearchResource.java
@@ -223,6 +223,16 @@ public abstract class SearchResource extends RestResource {
         }
     }
 
+    protected ChunkedOutput<ScrollResult.ScrollChunk> buildChunkedOutput(final ScrollResult scroll, int limit) {
+        final ChunkedOutput<ScrollResult.ScrollChunk> output = new ChunkedOutput<>(ScrollResult.ScrollChunk.class);
+
+        LOG.debug("[{}] Scroll result contains a total of {} messages", scroll.getQueryHash(), scroll.totalHits());
+        Runnable scrollIterationAction = createScrollChunkProducer(scroll, output, limit);
+        // TODO use a shared executor for async responses here instead of a single thread that's not limited
+        new Thread(scrollIterationAction).start();
+        return output;
+    }
+
     protected BadRequestException createRequestExceptionForParseFailure(String query, SearchPhaseExecutionException e) {
         LOG.warn("Unable to execute search: {}", e.getMessage());
 

--- a/graylog2-web-interface/src/routing/jsRoutes.js
+++ b/graylog2-web-interface/src/routing/jsRoutes.js
@@ -196,6 +196,23 @@ const jsRoutes = {
 
           return {url: this._buildUrl(url, queryString)};
         },
+        export(type, query, timerange, streamId, limit, offset, fields) {
+          const url = `/search/universal/${type}/export`;
+          const queryString = this._buildBaseQueryString(query, timerange, streamId);
+
+          if (limit) {
+            queryString.limit = limit;
+          }
+          if (offset) {
+            queryString.offset = offset;
+          }
+
+          if (fields) {
+            queryString.fields = fields.join(',');
+          }
+
+          return {url: this._buildUrl(url, queryString)};
+        },
         histogram(type, query, resolution, timerange, streamId) {
           const url = `/search/universal/${type}/histogram`;
           const queryString = this._buildBaseQueryString(query, timerange, streamId);


### PR DESCRIPTION
This change set adds the CSV export functionality in the web interface
again. Due to the obsoletion of the play web interface middleware, we
need some more support from the backend, which now offers a separate
REST call for each search type which defaults to returning CSV and adds
the necessary headers to the response which indicate a file download and
a proper filename to the browser. All previously existing methods still
work the exact same way as before.