### PR TITLE
Stricter pattern to check for Graylog-managed index

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/indexer/Deflector.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/Deflector.java
@@ -182,7 +182,7 @@ public class Deflector { // extends Ablenkblech
 
         final List<Integer> indexNumbers = Lists.newArrayListWithExpectedSize(indices.size());
         for (String indexName : indices.keySet()) {
-            if (!isGraylog2Index(indexName)) {
+            if (!isGraylogIndex(indexName)) {
                 continue;
             }
 
@@ -204,7 +204,7 @@ public class Deflector { // extends Ablenkblech
         final Map<String, IndexStats> indices = this.indices.getAll();
         final List<String> result = Lists.newArrayListWithExpectedSize(indices.size());
         for (String indexName : indices.keySet()) {
-            if (isGraylog2Index(indexName)) {
+            if (isGraylogIndex(indexName)) {
                 result.add(indexName);
             }
         }
@@ -217,7 +217,7 @@ public class Deflector { // extends Ablenkblech
         for (Map.Entry<String, IndexStats> e : indices.getAll().entrySet()) {
             final String name = e.getKey();
 
-            if (isGraylog2Index(name)) {
+            if (isGraylogIndex(name)) {
                 result.put(name, e.getValue());
             }
         }
@@ -282,7 +282,7 @@ public class Deflector { // extends Ablenkblech
         return getName().equals(indexName);
     }
 
-    public boolean isGraylog2Index(final String indexName) {
+    public boolean isGraylogIndex(final String indexName) {
         return !isNullOrEmpty(indexName) && !isDeflectorAlias(indexName) && indexName.startsWith(indexPrefix + SEPARATOR);
     }
 }

--- a/graylog2-server/src/main/java/org/graylog2/rest/resources/system/IndexRangesResource.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/resources/system/IndexRangesResource.java
@@ -112,7 +112,7 @@ public class IndexRangesResource extends RestResource {
     public IndexRangeSummary show(
             @ApiParam(name = "index", value = "The name of the Graylog-managed Elasticsearch index", required = true)
             @PathParam("index") @NotEmpty String index) throws NotFoundException {
-        if (!deflector.isGraylog2Index(index)) {
+        if (!deflector.isGraylogIndex(index)) {
             throw new BadRequestException(index + " is not a Graylog-managed Elasticsearch index.");
         }
         checkPermission(RestPermissions.INDEXRANGES_READ, index);
@@ -165,7 +165,7 @@ public class IndexRangesResource extends RestResource {
     public Response rebuildIndex(
             @ApiParam(name = "index", value = "The name of the Graylog-managed Elasticsearch index", required = true)
             @PathParam("index") @NotEmpty String index) {
-        if (!deflector.isGraylog2Index(index)) {
+        if (!deflector.isGraylogIndex(index)) {
             throw new BadRequestException(index + " is not a Graylog-managed Elasticsearch index.");
         }
         checkPermission(RestPermissions.INDEXRANGES_REBUILD, index);

--- a/graylog2-server/src/main/java/org/graylog2/rest/resources/system/indexer/IndicesResource.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/resources/system/indexer/IndicesResource.java
@@ -81,7 +81,7 @@ public class IndicesResource extends RestResource {
     public IndexInfo single(@ApiParam(name = "index") @PathParam("index") String index) {
         checkPermission(RestPermissions.INDICES_READ, index);
 
-        if (!deflector.isGraylog2Index(index)) {
+        if (!deflector.isGraylogIndex(index)) {
             final String msg = "Index [" + index + "] doesn't look like an index managed by Graylog.";
             LOG.info(msg);
             throw new NotFoundException(msg);
@@ -192,7 +192,7 @@ public class IndicesResource extends RestResource {
     public void reopen(@ApiParam(name = "index") @PathParam("index") String index) {
         checkPermission(RestPermissions.INDICES_CHANGESTATE, index);
 
-        if (!deflector.isGraylog2Index(index)) {
+        if (!deflector.isGraylogIndex(index)) {
             LOG.info("Index [{}] doesn't look like an index managed by Graylog.", index);
             throw new NotFoundException();
         }
@@ -211,7 +211,7 @@ public class IndicesResource extends RestResource {
     public void close(@ApiParam(name = "index") @PathParam("index") @NotNull String index) {
         checkPermission(RestPermissions.INDICES_CHANGESTATE, index);
 
-        if (!deflector.isGraylog2Index(index)) {
+        if (!deflector.isGraylogIndex(index)) {
             LOG.info("Index [{}] doesn't look like an index managed by Graylog.", index);
             throw new NotFoundException();
         }
@@ -235,7 +235,7 @@ public class IndicesResource extends RestResource {
     public void delete(@ApiParam(name = "index") @PathParam("index") @NotNull String index) {
         checkPermission(RestPermissions.INDICES_DELETE, index);
 
-        if (!deflector.isGraylog2Index(index)) {
+        if (!deflector.isGraylogIndex(index)) {
             final String msg = "Index [" + index + "] doesn't look like an index managed by Graylog.";
             LOG.info(msg);
             throw new NotFoundException(msg);

--- a/graylog2-server/src/test/java/org/graylog2/indexer/DeflectorTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/indexer/DeflectorTest.java
@@ -21,7 +21,6 @@
 package org.graylog2.indexer;
 
 import org.elasticsearch.action.admin.indices.stats.IndexStats;
-import org.graylog2.configuration.ElasticsearchConfiguration;
 import org.graylog2.indexer.indices.Indices;
 import org.graylog2.indexer.ranges.CreateNewSingleIndexRangeJob;
 import org.graylog2.system.activities.SystemMessageActivityWriter;
@@ -29,6 +28,7 @@ import org.graylog2.system.jobs.SystemJobManager;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
 
 import java.util.Map;
@@ -41,17 +41,21 @@ import static org.mockito.Mockito.mock;
 
 @RunWith(MockitoJUnitRunner.class)
 public class DeflectorTest {
+    @Mock
+    private SystemJobManager systemJobManager;
+    @Mock
+    private SystemMessageActivityWriter activityWriter;
+    @Mock
+    private SetIndexReadOnlyJob.Factory indexReadOnlyJobFactory;
+    @Mock
+    private CreateNewSingleIndexRangeJob.Factory singleIndexRangeJobFactory;
+    @Mock
+    private Indices indices;
     private Deflector deflector;
 
     @Before
     public void setUp() {
-        deflector = new Deflector(
-                mock(SystemJobManager.class),
-                new ElasticsearchConfiguration(),
-                mock(SystemMessageActivityWriter.class),
-                mock(SetIndexReadOnlyJob.Factory.class),
-                mock(CreateNewSingleIndexRangeJob.Factory.class),
-                mock(Indices.class));
+        deflector = new Deflector(systemJobManager, "graylog", activityWriter, indexReadOnlyJobFactory, singleIndexRangeJobFactory, indices);
     }
 
     @Test
@@ -75,14 +79,6 @@ public class DeflectorTest {
 
     @Test
     public void testBuildIndexName() {
-
-        Deflector d = new Deflector(mock(SystemJobManager.class),
-                mock(ElasticsearchConfiguration.class),
-                mock(SystemMessageActivityWriter.class),
-                mock(SetIndexReadOnlyJob.Factory.class),
-                mock(CreateNewSingleIndexRangeJob.Factory.class),
-                mock(Indices.class));
-
         assertEquals("graylog2_0", Deflector.buildIndexName("graylog2", 0));
         assertEquals("graylog2_1", Deflector.buildIndexName("graylog2", 1));
         assertEquals("graylog2_9001", Deflector.buildIndexName("graylog2", 9001));
@@ -95,27 +91,14 @@ public class DeflectorTest {
 
     @Test
     public void nullIndexerDoesNotThrow() {
-        Deflector d = new Deflector(mock(SystemJobManager.class),
-                mock(ElasticsearchConfiguration.class),
-                mock(SystemMessageActivityWriter.class),
-                mock(SetIndexReadOnlyJob.Factory.class),
-                mock(CreateNewSingleIndexRangeJob.Factory.class),
-                mock(Indices.class));
-
-        final Map<String, IndexStats> deflectorIndices = d.getAllDeflectorIndices();
+        final Map<String, IndexStats> deflectorIndices = deflector.getAllDeflectorIndices();
         assertNotNull(deflectorIndices);
         assertEquals(0, deflectorIndices.size());
     }
 
     @Test
     public void nullIndexerDoesNotThrowOnIndexName() {
-        Deflector d = new Deflector(mock(SystemJobManager.class),
-                mock(ElasticsearchConfiguration.class),
-                mock(SystemMessageActivityWriter.class),
-                mock(SetIndexReadOnlyJob.Factory.class),
-                mock(CreateNewSingleIndexRangeJob.Factory.class),
-                mock(Indices.class));
-        final String[] deflectorIndices = d.getAllDeflectorIndexNames();
+        final String[] deflectorIndices = deflector.getAllDeflectorIndexNames();
         assertNotNull(deflectorIndices);
         assertEquals(0, deflectorIndices.length);
     }
@@ -133,8 +116,11 @@ public class DeflectorTest {
         assertTrue(deflector.isGraylogIndex("graylog_1"));
         assertTrue(deflector.isGraylogIndex("graylog_42"));
         assertTrue(deflector.isGraylogIndex("graylog_100000000"));
+        assertFalse(deflector.isGraylogIndex(null));
+        assertFalse(deflector.isGraylogIndex(""));
         assertFalse(deflector.isGraylogIndex("graylog_deflector"));
         assertFalse(deflector.isGraylogIndex("graylog2beta_1"));
+        assertFalse(deflector.isGraylogIndex("graylog_1_suffix"));
         assertFalse(deflector.isGraylogIndex("HAHA"));
     }
 }

--- a/graylog2-server/src/test/java/org/graylog2/indexer/DeflectorTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/indexer/DeflectorTest.java
@@ -129,12 +129,12 @@ public class DeflectorTest {
     }
 
     @Test
-    public void testIsGraylog2Index() {
-        assertTrue(deflector.isGraylog2Index("graylog_1"));
-        assertTrue(deflector.isGraylog2Index("graylog_42"));
-        assertTrue(deflector.isGraylog2Index("graylog_100000000"));
-        assertFalse(deflector.isGraylog2Index("graylog_deflector"));
-        assertFalse(deflector.isGraylog2Index("graylog2beta_1"));
-        assertFalse(deflector.isGraylog2Index("HAHA"));
+    public void testIsGraylogIndex() {
+        assertTrue(deflector.isGraylogIndex("graylog_1"));
+        assertTrue(deflector.isGraylogIndex("graylog_42"));
+        assertTrue(deflector.isGraylogIndex("graylog_100000000"));
+        assertFalse(deflector.isGraylogIndex("graylog_deflector"));
+        assertFalse(deflector.isGraylogIndex("graylog2beta_1"));
+        assertFalse(deflector.isGraylogIndex("HAHA"));
     }
 }

--- a/graylog2-server/src/test/java/org/graylog2/indexer/ranges/EsIndexRangeServiceTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/indexer/ranges/EsIndexRangeServiceTest.java
@@ -86,7 +86,7 @@ public class EsIndexRangeServiceTest {
     public void setUp() throws Exception {
         final Messages messages = new Messages(client, ELASTICSEARCH_CONFIGURATION);
         indices = new Indices(client, ELASTICSEARCH_CONFIGURATION, new IndexMapping(), messages);
-        final Deflector deflector = new Deflector(null, ELASTICSEARCH_CONFIGURATION, new NullActivityWriter(), null, null, indices);
+        final Deflector deflector = new Deflector(null, ELASTICSEARCH_CONFIGURATION.getIndexPrefix(), new NullActivityWriter(), null, null, indices);
         indexRangeService = new EsIndexRangeService(client, deflector, localEventBus, clusterEventBus, new MetricRegistry());
     }
 


### PR DESCRIPTION
The previous implementation of `Deflector#isGraylog2Index(String)` didn't account for index names resembling a Graylog-managed index but having a suffix, e. g. `graylog_123_suffix`, and accidentally returned `true` for those.

This PR makes the index name check more strict and should fix the error reported in #1882.

Fixes #1882