### PR TITLE
Simplify cluster calls in remote resources

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/rest/resources/cluster/ClusterInputStatesResource.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/resources/cluster/ClusterInputStatesResource.java
@@ -24,7 +24,6 @@ import com.wordnik.swagger.annotations.ApiResponse;
 import com.wordnik.swagger.annotations.ApiResponses;
 import org.apache.shiro.authz.annotation.RequiresAuthentication;
 import org.apache.shiro.authz.annotation.RequiresPermissions;
-import org.graylog2.cluster.Node;
 import org.graylog2.cluster.NodeNotFoundException;
 import org.graylog2.cluster.NodeService;
 import org.graylog2.rest.RemoteInterfaceProvider;
@@ -35,9 +34,6 @@ import org.graylog2.rest.models.system.inputs.responses.InputStatesList;
 import org.graylog2.rest.resources.system.inputs.RemoteInputStatesResource;
 import org.graylog2.shared.rest.resources.ProxiedResource;
 import org.graylog2.shared.security.RestPermissions;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-import retrofit2.Response;
 
 import javax.inject.Inject;
 import javax.ws.rs.DELETE;
@@ -49,19 +45,15 @@ import javax.ws.rs.Produces;
 import javax.ws.rs.core.Context;
 import javax.ws.rs.core.HttpHeaders;
 import javax.ws.rs.core.MediaType;
-import java.io.IOException;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
-import java.util.stream.Collectors;
 
 @RequiresAuthentication
 @Api(value = "Cluster/InputState", description = "Cluster-wide input states")
 @Path("/cluster/inputstates")
 @Produces(MediaType.APPLICATION_JSON)
 public class ClusterInputStatesResource extends ProxiedResource {
-    private static final Logger LOG = LoggerFactory.getLogger(ClusterInputStatesResource.class);
-
     @Inject
     public ClusterInputStatesResource(NodeService nodeService,
                                       RemoteInterfaceProvider remoteInterfaceProvider,
@@ -85,26 +77,7 @@ public class ClusterInputStatesResource extends ProxiedResource {
             @ApiResponse(code = 404, message = "No such input."),
     })
     public Map<String, Optional<InputCreated>> start(@ApiParam(name = "inputId", required = true) @PathParam("inputId") String inputId) {
-        final Map<String, Node> nodes = nodeService.allActive();
-        return nodes.entrySet()
-                .stream()
-                .parallel()
-                .collect(Collectors.toMap(Map.Entry::getKey, entry -> {
-                    final RemoteInputStatesResource remoteInputStatesResource = remoteInterfaceProvider.get(entry.getValue(),
-                            this.authenticationToken,
-                            RemoteInputStatesResource.class);
-                    try {
-                        final Response<InputCreated> response = remoteInputStatesResource.start(inputId).execute();
-                        if (response.isSuccess()) {
-                            return Optional.of(response.body());
-                        } else {
-                            LOG.warn("Unable to start input on node {}: {}", entry.getKey(), response.message());
-                        }
-                    } catch (IOException e) {
-                        LOG.warn("Unable to start input on node {}:",entry.getKey(), e);
-                    }
-                    return Optional.empty();
-                }));
+        return getForAllNodes(remoteResource -> remoteResource.start(inputId), createRemoteInterfaceProvider(RemoteInputStatesResource.class));
     }
 
     @DELETE
@@ -115,25 +88,6 @@ public class ClusterInputStatesResource extends ProxiedResource {
             @ApiResponse(code = 404, message = "No such input."),
     })
     public Map<String, Optional<InputDeleted>> stop(@ApiParam(name = "inputId", required = true) @PathParam("inputId") String inputId) {
-        final Map<String, Node> nodes = nodeService.allActive();
-        return nodes.entrySet()
-                .stream()
-                .parallel()
-                .collect(Collectors.toMap(Map.Entry::getKey, entry -> {
-                    final RemoteInputStatesResource remoteInputStatesResource = remoteInterfaceProvider.get(entry.getValue(),
-                            this.authenticationToken,
-                            RemoteInputStatesResource.class);
-                    try {
-                        final Response<InputDeleted> response = remoteInputStatesResource.stop(inputId).execute();
-                        if (response.isSuccess()) {
-                            return Optional.of(response.body());
-                        } else {
-                            LOG.warn("Unable to stop input on node {}: {}", entry.getKey(), response.message());
-                        }
-                    } catch (IOException e) {
-                        LOG.warn("Unable to stop input on node {}:", entry.getKey(), e);
-                    }
-                    return Optional.empty();
-                }));
+        return getForAllNodes(remoteResource -> remoteResource.stop(inputId), createRemoteInterfaceProvider(RemoteInputStatesResource.class));
     }
 }

--- a/graylog2-server/src/main/java/org/graylog2/rest/resources/cluster/ClusterJournalResource.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/resources/cluster/ClusterJournalResource.java
@@ -55,16 +55,11 @@ import static javax.ws.rs.core.Response.Status.BAD_GATEWAY;
 public class ClusterJournalResource extends ProxiedResource {
     private static final Logger LOG = LoggerFactory.getLogger(ClusterJournalResource.class);
 
-    private final NodeService nodeService;
-    private final RemoteInterfaceProvider remoteInterfaceProvider;
-
     @Inject
     public ClusterJournalResource(NodeService nodeService,
                                   RemoteInterfaceProvider remoteInterfaceProvider,
                                   @Context HttpHeaders httpHeaders) throws NodeNotFoundException {
-        super(httpHeaders);
-        this.nodeService = nodeService;
-        this.remoteInterfaceProvider = remoteInterfaceProvider;
+        super(httpHeaders, nodeService, remoteInterfaceProvider);
     }
 
     @GET

--- a/graylog2-server/src/main/java/org/graylog2/rest/resources/cluster/ClusterLoadBalancerStatusResource.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/resources/cluster/ClusterLoadBalancerStatusResource.java
@@ -54,16 +54,11 @@ import static javax.ws.rs.core.Response.Status.BAD_GATEWAY;
 public class ClusterLoadBalancerStatusResource extends ProxiedResource {
     private static final Logger LOG = LoggerFactory.getLogger(ClusterLoadBalancerStatusResource.class);
 
-    private final NodeService nodeService;
-    private final RemoteInterfaceProvider remoteInterfaceProvider;
-
     @Inject
     public ClusterLoadBalancerStatusResource(NodeService nodeService,
                                              RemoteInterfaceProvider remoteInterfaceProvider,
                                              @Context HttpHeaders httpHeaders) throws NodeNotFoundException {
-        super(httpHeaders);
-        this.nodeService = nodeService;
-        this.remoteInterfaceProvider = remoteInterfaceProvider;
+        super(httpHeaders, nodeService, remoteInterfaceProvider);
     }
 
     @PUT

--- a/graylog2-server/src/main/java/org/graylog2/rest/resources/cluster/ClusterMetricsResource.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/resources/cluster/ClusterMetricsResource.java
@@ -57,16 +57,11 @@ import static javax.ws.rs.core.Response.Status.BAD_GATEWAY;
 @Path("/cluster/{nodeId}/metrics")
 @Produces(MediaType.APPLICATION_JSON)
 public class ClusterMetricsResource extends ProxiedResource {
-    private final NodeService nodeService;
-    private final RemoteInterfaceProvider remoteInterfaceProvider;
-
     @Inject
     public ClusterMetricsResource(NodeService nodeService,
                                   RemoteInterfaceProvider remoteInterfaceProvider,
                                   @Context HttpHeaders httpHeaders) {
-        super(httpHeaders);
-        this.nodeService = nodeService;
-        this.remoteInterfaceProvider = remoteInterfaceProvider;
+        super(httpHeaders, nodeService, remoteInterfaceProvider);
     }
 
     private RemoteMetricsResource getResourceForNode(String nodeId) throws NodeNotFoundException {

--- a/graylog2-server/src/main/java/org/graylog2/rest/resources/cluster/ClusterSystemPluginResource.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/resources/cluster/ClusterSystemPluginResource.java
@@ -53,16 +53,11 @@ import static javax.ws.rs.core.Response.Status.BAD_GATEWAY;
 public class ClusterSystemPluginResource extends ProxiedResource {
     private static final Logger LOG = LoggerFactory.getLogger(ClusterSystemResource.class);
 
-    private final NodeService nodeService;
-    private final RemoteInterfaceProvider remoteInterfaceProvider;
-
     @Inject
     public ClusterSystemPluginResource(NodeService nodeService,
                                        RemoteInterfaceProvider remoteInterfaceProvider,
                                        @Context HttpHeaders httpHeaders) throws NodeNotFoundException {
-        super(httpHeaders);
-        this.nodeService = nodeService;
-        this.remoteInterfaceProvider = remoteInterfaceProvider;
+        super(httpHeaders, nodeService, remoteInterfaceProvider);
     }
 
     @GET

--- a/graylog2-server/src/main/java/org/graylog2/rest/resources/cluster/ClusterSystemProcessingResource.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/resources/cluster/ClusterSystemProcessingResource.java
@@ -52,16 +52,11 @@ import static javax.ws.rs.core.Response.Status.BAD_GATEWAY;
 public class ClusterSystemProcessingResource extends ProxiedResource {
     private static final Logger LOG = LoggerFactory.getLogger(ClusterSystemProcessingResource.class);
 
-    private final NodeService nodeService;
-    private final RemoteInterfaceProvider remoteInterfaceProvider;
-
     @Inject
     public ClusterSystemProcessingResource(NodeService nodeService,
                                            RemoteInterfaceProvider remoteInterfaceProvider,
                                            @Context HttpHeaders httpHeaders) throws NodeNotFoundException {
-        super(httpHeaders);
-        this.nodeService = nodeService;
-        this.remoteInterfaceProvider = remoteInterfaceProvider;
+        super(httpHeaders, nodeService, remoteInterfaceProvider);
     }
 
     private RemoteSystemProcessingResource getRemoteSystemProcessingResource(String nodeId) throws NodeNotFoundException {

--- a/graylog2-server/src/main/java/org/graylog2/rest/resources/cluster/ClusterSystemShutdownResource.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/resources/cluster/ClusterSystemShutdownResource.java
@@ -53,16 +53,11 @@ import static org.jboss.netty.handler.codec.http.HttpResponseStatus.ACCEPTED;
 public class ClusterSystemShutdownResource extends ProxiedResource {
     private static final Logger LOG = LoggerFactory.getLogger(ClusterSystemShutdownResource.class);
 
-    private final NodeService nodeService;
-    private final RemoteInterfaceProvider remoteInterfaceProvider;
-
     @Inject
     public ClusterSystemShutdownResource(NodeService nodeService,
                                          RemoteInterfaceProvider remoteInterfaceProvider,
                                          @Context HttpHeaders httpHeaders) throws NodeNotFoundException {
-        super(httpHeaders);
-        this.nodeService = nodeService;
-        this.remoteInterfaceProvider = remoteInterfaceProvider;
+        super(httpHeaders, nodeService, remoteInterfaceProvider);
     }
 
     @POST

--- a/graylog2-server/src/main/java/org/graylog2/shared/rest/resources/ProxiedResource.java
+++ b/graylog2-server/src/main/java/org/graylog2/shared/rest/resources/ProxiedResource.java
@@ -89,7 +89,7 @@ public abstract class ProxiedResource extends RestResource {
                 final Node targetNode = nodeService.byNodeId(nodeId);
                 return Optional.of(this.remoteInterfaceProvider.get(targetNode, this.authenticationToken, interfaceClass));
             } catch (NodeNotFoundException e) {
-                LOG.warn("Node <" + nodeId + "> not found while trying to call " + interfaceClass.getName() + " on it.")
+                LOG.warn("Node <" + nodeId + "> not found while trying to call " + interfaceClass.getName() + " on it.");
                 return Optional.empty();
             }
         };

--- a/graylog2-server/src/main/java/org/graylog2/shared/rest/resources/ProxiedResource.java
+++ b/graylog2-server/src/main/java/org/graylog2/shared/rest/resources/ProxiedResource.java
@@ -54,22 +54,22 @@ public abstract class ProxiedResource extends RestResource {
         }
     }
 
-    protected <T, K> Map<String, Optional<K>> getForAllNodes(Function<T, Call<K>> fn, Function<String, Optional<T>> interfaceProvider) {
+    protected <RemoteInterfaceType, RemoteCallResponseType> Map<String, Optional<RemoteCallResponseType>> getForAllNodes(Function<RemoteInterfaceType,Call<RemoteCallResponseType>> fn, Function<String, Optional<RemoteInterfaceType>> interfaceProvider) {
         return getForAllNodes(fn, interfaceProvider, Function.identity());
     }
 
-    protected <T, K, L> Map<String, Optional<K>> getForAllNodes(Function<T, Call<L>> fn, Function<String, Optional<T>> interfaceProvider, Function<L, K> transformer) {
+    protected <RemoteInterfaceType, FinalResponseType, RemoteCallResponseType> Map<String, Optional<FinalResponseType>> getForAllNodes(Function<RemoteInterfaceType, Call<RemoteCallResponseType>> fn, Function<String, Optional<RemoteInterfaceType>> interfaceProvider, Function<RemoteCallResponseType, FinalResponseType> transformer) {
         return this.nodeService.allActive()
             .entrySet()
             .stream()
             .collect(Collectors.toMap(Map.Entry::getKey, entry -> {
-                final Optional<T> remoteInterface = interfaceProvider.apply(entry.getKey());
+                final Optional<RemoteInterfaceType> remoteInterface = interfaceProvider.apply(entry.getKey());
                 if (!remoteInterface.isPresent()) {
                     return Optional.empty();
                 }
-                final Call<L> call = fn.apply(remoteInterface.get());
+                final Call<RemoteCallResponseType> call = fn.apply(remoteInterface.get());
                 try {
-                    final Response<L> response = call.execute();
+                    final Response<RemoteCallResponseType> response = call.execute();
                     if (response.isSuccess()) {
                         return Optional.of(transformer.apply(response.body()));
                     } else {
@@ -83,7 +83,7 @@ public abstract class ProxiedResource extends RestResource {
             }));
     }
 
-    protected <T> Function<String, Optional<T>> createRemoteInterfaceProvider(Class<T> interfaceClass) {
+    protected <RemoteInterfaceType> Function<String, Optional<RemoteInterfaceType>> createRemoteInterfaceProvider(Class<RemoteInterfaceType> interfaceClass) {
         return (nodeId) -> {
             try {
                 final Node targetNode = nodeService.byNodeId(nodeId);


### PR DESCRIPTION
This change set adds some helper methods to simplify writing resource methods that call the same remote resource method on all nodes in the cluster.