### PR TITLE
Update reader base permissions

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/shared/security/RestPermissions.java
+++ b/graylog2-server/src/main/java/org/graylog2/shared/security/RestPermissions.java
@@ -235,7 +235,8 @@ public class RestPermissions implements PluginPermissions {
             THROUGHPUT_READ,
             SAVEDSEARCHES_CREATE,
             SAVEDSEARCHES_EDIT,
-            SAVEDSEARCHES_READ
+            SAVEDSEARCHES_READ,
+            CLUSTER_CONFIG_ENTRY_READ
     ).build();
 
     protected static final Set<Permission> READER_BASE_PERMISSIONS = PERMISSIONS.stream()


### PR DESCRIPTION
Reader base permissions now include `clusterconfigentry:read`.

Without the fix:
* Create stream
* Create role granting access to the stream
* Assign new role to reader user
* As reader user try to search in stream
* User is logged out and sees error notification

After fix:
* Restart server
* With the same reader user try to access stream
* User can search in stream

fix #1887