### PR TITLE
Missing scala dependency in graylog2-server/pom.xml causing compilati…

### DIFF
--- a/graylog2-server/pom.xml
+++ b/graylog2-server/pom.xml
@@ -392,6 +392,10 @@
             <artifactId>amqp-client</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.scala-lang</groupId>
+            <artifactId>scala-library</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.apache.kafka</groupId>
             <artifactId>kafka_2.11</artifactId>
         </dependency>


### PR DESCRIPTION
…on failure.


**Environment/Tool info**:

$ mvn -v
Apache Maven 3.3.9 (bb52d8502b132ec0a5a3f4c09453c07478323dc5; 2015-11-10T08:41:47-08:00)
Maven home: /usr/local/Cellar/maven/3.3.9/libexec
Java version: 1.8.0_73, vendor: Oracle Corporation
Java home: /Library/Java/JavaVirtualMachines/jdk1.8.0_73.jdk/Contents/Home/jre
Default locale: en_US, platform encoding: UTF-8
OS name: "mac os x", version: "10.10.5", arch: "x86_64", family: "mac"


**Dependency Missing**

Running "mvn dependency:tree" does not include "org.scala-lang:scala-library" without this dependency added into graylog2-server/pom.xml .


**Compilation Failure**
```shell
[INFO] --- maven-resources-plugin:2.7:resources (default-resources) @ graylog2-server ---
[INFO] Using 'UTF-8' encoding to copy filtered resources.
[INFO] Copying 66 resources to web-interface/assets
[INFO] Copying 26 resources
[INFO] Copying 3 resources
[INFO]
[INFO] --- maven-compiler-plugin:3.3:compile (default-compile) @ graylog2-server ---
[INFO] Compiling 966 source files to /Users/X/devel/github/graylog2-server/graylog2-server/target/classes

....


[INFO] Reactor Summary:
[INFO]
[INFO] Graylog ............................................ SUCCESS [ 14.643 s]
[INFO] graylog2-server .................................... FAILURE [04:55 min]
[INFO] integration-tests .................................. SKIPPED
[INFO] ------------------------------------------------------------------------
[INFO] BUILD FAILURE
[INFO] ------------------------------------------------------------------------
[INFO] Total time: 05:10 min
[INFO] Finished at: 2016-03-04T10:06:43-08:00
[INFO] Final Memory: 55M/422M
[INFO] ------------------------------------------------------------------------
[ERROR] Failed to execute goal org.apache.maven.plugins:maven-compiler-plugin:3.3:compile (default-compile) on project graylog2-server: Compilation failure: Compilation failure:
[ERROR] /Users/X/devel/github/graylog2-server/graylog2-server/src/main/java/org/graylog2/shared/journal/KafkaJournal.java:[59,13] package scala does not exist
[ERROR] /Users/X/devel/github/graylog2-server/graylog2-server/src/main/java/org/graylog2/shared/journal/KafkaJournal.java:[60,24] package scala.collection does not exist
[ERROR] /Users/X/devel/github/graylog2-server/graylog2-server/src/main/java/org/graylog2/shared/journal/KafkaJournal.java:[61,24] package scala.collection does not exist
[ERROR] /Users/X/devel/github/graylog2-server/graylog2-server/src/main/java/org/graylog2/shared/journal/KafkaJournal.java:[62,24] package scala.collection does not exist
[ERROR] /Users/X/devel/github/graylog2-server/graylog2-server/src/main/java/org/graylog2/shared/journal/KafkaJournal.java:[63,21] package scala.runtime does not exist
[ERROR] -> [Help 1]
```
