### PR TITLE
Fix issue from https://issues.apache.org/jira/browse/MASSEMBLY-728

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1059,6 +1059,7 @@
                     <appendAssemblyId>false</appendAssemblyId>
                     <!-- we don't care about assembling the parent, just run the goal on the project, pretty please -->
                     <ignoreMissingDescriptor>true</ignoreMissingDescriptor>
+                    <tarLongFileMode>posix</tarLongFileMode>
                 </configuration>
             </plugin>
             <plugin>


### PR DESCRIPTION
Running into the issue described here: https://issues.apache.org/jira/browse/MASSEMBLY-728

Applying fix described here: https://maven.apache.org/plugins/maven-assembly-plugin/faq.html#tarFileModes

**Error**:
```shell
...
INFO] --- maven-assembly-plugin:2.6:single (default-cli) @ graylog2-server ---
[INFO] Reading assembly descriptor: src/main/assembly/graylog.xml
[WARNING] The assembly descriptor contains a filesystem-root relative reference, which is not cross platform compatible /
[WARNING] The assembly descriptor contains a filesystem-root relative reference, which is not cross platform compatible /
[WARNING] The assembly descriptor contains a filesystem-root relative reference, which is not cross platform compatible /lib/sigar
[WARNING] The assembly descriptor contains a filesystem-root relative reference, which is not cross platform compatible /data/contentpacks
[WARNING] The assembly descriptor contains a filesystem-root relative reference, which is not cross platform compatible /log
[INFO] Building tar: /Users/X/devel/github/graylog2-server/target/assembly/graylog-2.0.0-alpha.6-SNAPSHOT-20160304190714-graylog-server-tarball.tar.gz
[INFO] ------------------------------------------------------------------------
[INFO] Reactor Summary:
[INFO]
[INFO] Graylog ............................................ SUCCESS [  3.159 s]
[INFO] graylog2-server .................................... FAILURE [04:01 min]
[INFO] integration-tests .................................. SKIPPED
[INFO] ------------------------------------------------------------------------
[INFO] BUILD FAILURE
[INFO] ------------------------------------------------------------------------
[INFO] Total time: 04:05 min
[INFO] Finished at: 2016-03-04T11:11:20-08:00
[INFO] Final Memory: 142M/1308M
[INFO] ------------------------------------------------------------------------
[ERROR] Failed to execute goal org.apache.maven.plugins:maven-assembly-plugin:2.6:single (default-cli) on project graylog2-server: Execution default-cli of goal org.apache.maven.plugins:maven-assembly-plugin:2.6:single failed: group id '74715970' is too big ( > 2097151 ). Use STAR or POSIX extensions to overcome this limit -> [Help 1]
```

**Environment**:
$ mvn -v
Apache Maven 3.3.9 (bb52d8502b132ec0a5a3f4c09453c07478323dc5; 2015-11-10T08:41:47-08:00)
Maven home: /usr/local/Cellar/maven/3.3.9/libexec
Java version: 1.8.0_73, vendor: Oracle Corporation
Java home: /Library/Java/JavaVirtualMachines/jdk1.8.0_73.jdk/Contents/Home/jre
Default locale: en_US, platform encoding: UTF-8
OS name: "mac os x", version: "10.10.5", arch: "x86_64", family: "mac"

