### PR TITLE
addField allows Date objects for timestamp fields

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/plugin/Message.java
+++ b/graylog2-server/src/main/java/org/graylog2/plugin/Message.java
@@ -257,7 +257,9 @@ public class Message implements Messages {
             return;
         }
 
-        if(value instanceof String) {
+        if (FIELD_TIMESTAMP.equals(key.trim()) && value != null && value instanceof Date) {
+            fields.put(FIELD_TIMESTAMP, new DateTime(value));
+        } else if(value instanceof String) {
             final String str = ((String) value).trim();
 
             if(!str.isEmpty()) {

--- a/graylog2-server/src/test/java/org/graylog2/plugin/MessageTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/plugin/MessageTest.java
@@ -29,6 +29,7 @@ import org.junit.runner.RunWith;
 import org.mockito.runners.MockitoJUnitRunner;
 
 import java.util.Collections;
+import java.util.Date;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -403,5 +404,16 @@ public class MessageTest {
         message.addField("__foo__", "bar");
 
         assertTrue(message.hasField("__foo__"));
+    }
+
+    @Test
+    public void testDateConvertedToDateTime() {
+        final Message message = new Message("", "source", Tools.nowUTC());
+
+        final Date dateObject = DateTime.parse("2010-07-30T16:03:25Z").toDate();
+        message.addField(Message.FIELD_TIMESTAMP, dateObject);
+
+        assertEquals(message.getTimestamp().toDate(), dateObject);
+        assertEquals(message.getField(Message.FIELD_TIMESTAMP).getClass(), DateTime.class);
     }
 }


### PR DESCRIPTION
this leads to all kind of sadness later on: we really depend on timestamp being a DateTime instance
Enforce a DateTime in case it was a Date