### PR TITLE
Resolves session id to username in RestAccessLogFilter

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/shared/rest/RestAccessLogFilter.java
+++ b/graylog2-server/src/main/java/org/graylog2/shared/rest/RestAccessLogFilter.java
@@ -45,7 +45,7 @@ public class RestAccessLogFilter implements ContainerResponseFilter {
     }
 
     private String getUsernameFromSession(String sessionID) {
-    	String result = "anonymous";
+    	String result = "-";
     	if (sessionID != null) {
     	    final DefaultSecurityManager securityManager = (DefaultSecurityManager) SecurityUtils.getSecurityManager();
             Subject.Builder builder = new Subject.Builder(securityManager);

--- a/graylog2-server/src/main/java/org/graylog2/shared/rest/RestAccessLogFilter.java
+++ b/graylog2-server/src/main/java/org/graylog2/shared/rest/RestAccessLogFilter.java
@@ -18,6 +18,9 @@ package org.graylog2.shared.rest;
 
 import org.glassfish.grizzly.http.server.Response;
 import org.graylog2.shared.security.ShiroSecurityContext;
+import org.apache.shiro.SecurityUtils;
+import org.apache.shiro.subject.Subject;
+import org.apache.shiro.mgt.DefaultSecurityManager;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -41,19 +44,33 @@ public class RestAccessLogFilter implements ContainerResponseFilter {
         this.response = requireNonNull(response);
     }
 
+    private String getUsernameFromSession(String sessionID) {
+    	String result = "anonymous";
+    	if (sessionID != null) {
+    	    final DefaultSecurityManager securityManager = (DefaultSecurityManager) SecurityUtils.getSecurityManager();
+            Subject.Builder builder = new Subject.Builder(securityManager);
+            builder.sessionId(sessionID);
+            Subject subject = builder.buildSubject();
+    	    result = subject.getPrincipal().toString();
+    	}
+    	return result;
+    
+    }
+    
     @Override
     public void filter(ContainerRequestContext requestContext, ContainerResponseContext responseContext) throws IOException {
         if (LOG.isDebugEnabled()) {
             try {
                 final String rawQuery = requestContext.getUriInfo().getRequestUri().getRawQuery();
                 final SecurityContext securityContext = requestContext.getSecurityContext();
-                final String remoteUser = securityContext instanceof ShiroSecurityContext ?
+                final String sessionID = securityContext instanceof ShiroSecurityContext ?
                         ((ShiroSecurityContext) securityContext).getUsername() : null;
+                final String userName = getUsernameFromSession(sessionID);
                 final Date requestDate = requestContext.getDate();
 
                 LOG.debug("{} {} [{}] \"{} {}{}\" {} {} {}",
                         response.getRequest().getRemoteAddr(),
-                        (remoteUser == null ? "-" : remoteUser),
+                        (userName == null ? "-" : userName),
                         (requestDate == null ? "-" : requestDate),
                         requestContext.getMethod(),
                         requestContext.getUriInfo().getPath(),

--- a/graylog2-server/src/main/java/org/graylog2/shared/rest/RestAccessLogFilter.java
+++ b/graylog2-server/src/main/java/org/graylog2/shared/rest/RestAccessLogFilter.java
@@ -45,18 +45,13 @@ public class RestAccessLogFilter implements ContainerResponseFilter {
     }
 
     private String getUsernameFromSession(String sessionID) {
-    	String result = "-";
-    	if (sessionID != null) {
-    	    final DefaultSecurityManager securityManager = (DefaultSecurityManager) SecurityUtils.getSecurityManager();
-            Subject.Builder builder = new Subject.Builder(securityManager);
-            builder.sessionId(sessionID);
-            Subject subject = builder.buildSubject();
-    	    result = subject.getPrincipal().toString();
-    	}
-    	return result;
-    
+        final DefaultSecurityManager securityManager = (DefaultSecurityManager) SecurityUtils.getSecurityManager();
+        Subject.Builder builder = new Subject.Builder(securityManager);
+        builder.sessionId(sessionID);
+        Subject subject = builder.buildSubject();
+        return subject.getPrincipal().toString();
     }
-    
+
     @Override
     public void filter(ContainerRequestContext requestContext, ContainerResponseContext responseContext) throws IOException {
         if (LOG.isDebugEnabled()) {
@@ -65,12 +60,11 @@ public class RestAccessLogFilter implements ContainerResponseFilter {
                 final SecurityContext securityContext = requestContext.getSecurityContext();
                 final String sessionID = securityContext instanceof ShiroSecurityContext ?
                         ((ShiroSecurityContext) securityContext).getUsername() : null;
-                final String userName = getUsernameFromSession(sessionID);
                 final Date requestDate = requestContext.getDate();
 
                 LOG.debug("{} {} [{}] \"{} {}{}\" {} {} {}",
                         response.getRequest().getRemoteAddr(),
-                        (userName == null ? "-" : userName),
+                        (sessionID == null ? "-" : getUsernameFromSession(sessionID)),
                         (requestDate == null ? "-" : requestDate),
                         requestContext.getMethod(),
                         requestContext.getUriInfo().getPath(),


### PR DESCRIPTION
2.x broke logging username in RestAccessLogFilter, the session id got logged instead. This change resolves the session id back to actual username for audit logging purposes.
