### PR TITLE
Fix import of Graylog 1.x extractors and fix export format

### DIFF
--- a/graylog2-web-interface/src/components/extractors/ExportExtractors.jsx
+++ b/graylog2-web-interface/src/components/extractors/ExportExtractors.jsx
@@ -25,7 +25,30 @@ const ExportExtractors = React.createClass({
     }
 
     const extractorsExportObject = {
-      extractors: this.state.extractors,
+      extractors: this.state.extractors.map((extractor) => {
+        const copy = {};
+
+        // Create Graylog 1.x compatible export format.
+        // TODO: This should be done on the server.
+        Object.keys(extractor).forEach((key) => {
+          switch (key) {
+            case 'type':
+              // The import expects "extractor_type", not "type".
+              copy.extractor_type = extractor[key];
+              break;
+            case 'id':
+            case 'metrics':
+            case 'creator_user_id':
+            case 'exceptions':
+            case 'converter_exceptions':
+              break;
+            default:
+              copy[key] = extractor[key];
+          }
+        });
+
+        return copy;
+      }),
       version: Version.getFullVersion(),
     };
 

--- a/graylog2-web-interface/src/stores/extractors/ExtractorsStore.js
+++ b/graylog2-web-interface/src/stores/extractors/ExtractorsStore.js
@@ -21,7 +21,7 @@ function getExtractorDTO(extractor) {
     cut_or_copy: extractor.cursor_strategy || 'copy',
     source_field: extractor.source_field,
     target_field: extractor.target_field,
-    extractor_type: extractor.type,
+    extractor_type: extractor.type || extractor.extractor_type, // "extractor_type" needed for imports
     extractor_config: extractor.extractor_config,
     converters: converters,
     condition_type: extractor.condition_type || 'none',


### PR DESCRIPTION
The import/export format wrangling should be done on the server side instead of doing all of this in the browser.

This is a minimal fix because refactoring this is too much at the moment.

Fixes #1831