### PR TITLE
Improve cluster event bus API

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/bindings/ServerBindings.java
+++ b/graylog2-server/src/main/java/org/graylog2/bindings/ServerBindings.java
@@ -16,7 +16,6 @@
  */
 package org.graylog2.bindings;
 
-import com.google.common.eventbus.EventBus;
 import com.google.inject.Scopes;
 import com.google.inject.assistedinject.FactoryModuleBuilder;
 import com.google.inject.multibindings.Multibinder;
@@ -31,7 +30,6 @@ import org.graylog2.alerts.types.FieldValueAlertCondition;
 import org.graylog2.alerts.types.MessageCountAlertCondition;
 import org.graylog2.bindings.providers.BundleExporterProvider;
 import org.graylog2.bindings.providers.BundleImporterProvider;
-import org.graylog2.bindings.providers.ClusterEventBusProvider;
 import org.graylog2.bindings.providers.DefaultSecurityManagerProvider;
 import org.graylog2.bindings.providers.EsClientProvider;
 import org.graylog2.bindings.providers.EsNodeProvider;
@@ -45,6 +43,7 @@ import org.graylog2.cluster.ClusterConfigServiceImpl;
 import org.graylog2.dashboards.widgets.WidgetCacheTime;
 import org.graylog2.database.MongoConnection;
 import org.graylog2.events.ClusterEventBus;
+import org.graylog2.bindings.providers.ClusterEventBusProvider;
 import org.graylog2.filters.FilterService;
 import org.graylog2.filters.FilterServiceImpl;
 import org.graylog2.indexer.SetIndexReadOnlyJob;
@@ -86,7 +85,6 @@ import org.graylog2.system.stats.ClusterStatsModule;
 import org.graylog2.users.RoleService;
 import org.graylog2.users.RoleServiceImpl;
 import org.graylog2.users.UserImpl;
-import org.graylog2.web.IndexHtmlGenerator;
 
 import javax.ws.rs.container.DynamicFeature;
 import javax.ws.rs.ext.ExceptionMapper;
@@ -113,7 +111,7 @@ public class ServerBindings extends Graylog2Module {
     }
 
     private void bindProviders() {
-        bind(EventBus.class).annotatedWith(ClusterEventBus.class).toProvider(ClusterEventBusProvider.class).asEagerSingleton();
+        bind(ClusterEventBus.class).toProvider(ClusterEventBusProvider.class).asEagerSingleton();
     }
 
     private void bindFactoryModules() {

--- a/graylog2-server/src/main/java/org/graylog2/bindings/providers/ClusterEventBusProvider.java
+++ b/graylog2-server/src/main/java/org/graylog2/bindings/providers/ClusterEventBusProvider.java
@@ -18,10 +18,8 @@ package org.graylog2.bindings.providers;
 
 import com.codahale.metrics.InstrumentedExecutorService;
 import com.codahale.metrics.MetricRegistry;
-import com.google.common.eventbus.AsyncEventBus;
-import com.google.common.eventbus.EventBus;
 import com.google.common.util.concurrent.ThreadFactoryBuilder;
-import org.graylog2.plugin.BaseConfiguration;
+import org.graylog2.events.ClusterEventBus;
 import org.graylog2.shared.events.DeadEventLoggingListener;
 
 import javax.inject.Inject;
@@ -33,7 +31,7 @@ import java.util.concurrent.ThreadFactory;
 
 import static com.codahale.metrics.MetricRegistry.name;
 
-public class ClusterEventBusProvider implements Provider<EventBus> {
+public class ClusterEventBusProvider implements Provider<ClusterEventBus> {
     private final int asyncEventbusProcessors;
     private final MetricRegistry metricRegistry;
 
@@ -45,9 +43,9 @@ public class ClusterEventBusProvider implements Provider<EventBus> {
     }
 
     @Override
-    public EventBus get() {
-        final EventBus eventBus = new AsyncEventBus("cluster-eventbus", executorService(asyncEventbusProcessors));
-        eventBus.register(new DeadEventLoggingListener());
+    public ClusterEventBus get() {
+        final ClusterEventBus eventBus = new ClusterEventBus("cluster-eventbus", executorService(asyncEventbusProcessors));
+        eventBus.registerClusterEventSubscriber(new DeadEventLoggingListener());
 
         return eventBus;
     }

--- a/graylog2-server/src/main/java/org/graylog2/cluster/ClusterConfigServiceImpl.java
+++ b/graylog2-server/src/main/java/org/graylog2/cluster/ClusterConfigServiceImpl.java
@@ -63,7 +63,7 @@ public class ClusterConfigServiceImpl implements ClusterConfigService {
                                     final NodeId nodeId,
                                     final ObjectMapper objectMapper,
                                     final ChainingClassLoader chainingClassLoader,
-                                    @ClusterEventBus final EventBus clusterEventBus) {
+                                    final ClusterEventBus clusterEventBus) {
         this(JacksonDBCollection.wrap(prepareCollection(mongoConnection), ClusterConfig.class, String.class, mapperProvider.get()),
                 nodeId, objectMapper, chainingClassLoader, clusterEventBus);
     }

--- a/graylog2-server/src/main/java/org/graylog2/events/ClusterEventBus.java
+++ b/graylog2-server/src/main/java/org/graylog2/events/ClusterEventBus.java
@@ -16,17 +16,39 @@
  */
 package org.graylog2.events;
 
-import javax.inject.Qualifier;
-import java.lang.annotation.Retention;
-import java.lang.annotation.Target;
+import com.google.common.eventbus.AsyncEventBus;
+import com.google.common.eventbus.SubscriberExceptionHandler;
+import com.google.common.util.concurrent.MoreExecutors;
 
-import static java.lang.annotation.ElementType.FIELD;
-import static java.lang.annotation.ElementType.METHOD;
-import static java.lang.annotation.ElementType.PARAMETER;
-import static java.lang.annotation.RetentionPolicy.RUNTIME;
+import java.util.concurrent.Executor;
 
-@Qualifier
-@Target({FIELD, PARAMETER, METHOD})
-@Retention(RUNTIME)
-public @interface ClusterEventBus {
+public class ClusterEventBus extends AsyncEventBus {
+    public ClusterEventBus () {
+        this(MoreExecutors.directExecutor());
+    }
+
+    public ClusterEventBus(Executor executor) {
+        super(executor);
+    }
+
+    public ClusterEventBus(Executor executor, SubscriberExceptionHandler subscriberExceptionHandler) {
+        super(executor, subscriberExceptionHandler);
+    }
+
+    public ClusterEventBus(String identifier, Executor executor) {
+        super(identifier, executor);
+    }
+
+    @Override
+    public void register(Object object) {
+        throw new IllegalStateException("Do not use ClusterEventBus for regular subscriptions. You probably want to use the regular EventBus.");
+    }
+
+    /**
+     * Only use this if you maintain the cluster event bus! Use regular EventBus to receive cluster event updates.
+     * @param object
+     */
+    public void registerClusterEventSubscriber(Object object) {
+        super.register(object);
+    }
 }

--- a/graylog2-server/src/main/java/org/graylog2/events/ClusterEventPeriodical.java
+++ b/graylog2-server/src/main/java/org/graylog2/events/ClusterEventPeriodical.java
@@ -65,7 +65,7 @@ public class ClusterEventPeriodical extends Periodical {
                                   final ObjectMapper objectMapper,
                                   final ChainingClassLoader chainingClassLoader,
                                   final EventBus serverEventBus,
-                                  @ClusterEventBus final EventBus clusterEventBus) {
+                                  final ClusterEventBus clusterEventBus) {
         this(JacksonDBCollection.wrap(prepareCollection(mongoConnection), ClusterEvent.class, String.class, mapperProvider.get()),
                 nodeId, objectMapper, chainingClassLoader, serverEventBus, clusterEventBus);
     }
@@ -75,14 +75,14 @@ public class ClusterEventPeriodical extends Periodical {
                            final ObjectMapper objectMapper,
                            final ChainingClassLoader chainingClassLoader,
                            final EventBus serverEventBus,
-                           final EventBus clusterEventBus) {
+                           final ClusterEventBus clusterEventBus) {
         this.nodeId = checkNotNull(nodeId);
         this.dbCollection = checkNotNull(dbCollection);
         this.objectMapper = checkNotNull(objectMapper);
         this.chainingClassLoader = chainingClassLoader;
         this.serverEventBus = checkNotNull(serverEventBus);
 
-        checkNotNull(clusterEventBus).register(this);
+        checkNotNull(clusterEventBus).registerClusterEventSubscriber(this);
     }
 
     @VisibleForTesting
@@ -190,14 +190,9 @@ public class ClusterEventPeriodical extends Periodical {
 
     private DBCursor<ClusterEvent> eventCursor(NodeId nodeId) {
         // Resorting to ugly MongoDB Java Client because of https://github.com/devbliss/mongojack/issues/88
-        final DBObject producerClause = new BasicDBObject("producer", new BasicDBObject("$ne", nodeId.toString()));
         final BasicDBList consumersList = new BasicDBList();
         consumersList.add(nodeId.toString());
-        final DBObject consumersClause = new BasicDBObject("consumers", new BasicDBObject("$nin", consumersList));
-        final BasicDBList and = new BasicDBList();
-        and.add(producerClause);
-        and.add(consumersClause);
-        final DBObject query = new BasicDBObject("$and", and);
+        final DBObject query = new BasicDBObject("consumers", new BasicDBObject("$nin", consumersList));
 
         return dbCollection.find(query).sort(DBSort.asc("timestamp"));
     }

--- a/graylog2-server/src/main/java/org/graylog2/indexer/ranges/EsIndexRangeService.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/ranges/EsIndexRangeService.java
@@ -31,7 +31,6 @@ import org.elasticsearch.action.get.GetResponse;
 import org.elasticsearch.client.Client;
 import org.elasticsearch.index.IndexNotFoundException;
 import org.graylog2.database.NotFoundException;
-import org.graylog2.events.ClusterEventBus;
 import org.graylog2.indexer.Deflector;
 import org.graylog2.indexer.esplugin.IndicesDeletedEvent;
 import org.graylog2.metrics.CacheStatsSet;
@@ -62,7 +61,6 @@ public class EsIndexRangeService implements IndexRangeService {
     public EsIndexRangeService(Client client,
                                Deflector deflector,
                                EventBus eventBus,
-                               @ClusterEventBus EventBus clusterEventBus,
                                MetricRegistry metricRegistry) {
         this.client = requireNonNull(client);
         this.deflector = requireNonNull(deflector);
@@ -86,7 +84,6 @@ public class EsIndexRangeService implements IndexRangeService {
         MetricUtils.safelyRegisterAll(metricRegistry, new CacheStatsSet(MetricRegistry.name(this.getClass(), "cache"), cache));
 
         eventBus.register(this);
-        clusterEventBus.register(this);
     }
 
     @Override

--- a/graylog2-server/src/main/java/org/graylog2/indexer/ranges/MongoIndexRangeService.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/ranges/MongoIndexRangeService.java
@@ -66,7 +66,7 @@ public class MongoIndexRangeService implements IndexRangeService {
                                   MongoJackObjectMapperProvider objectMapperProvider,
                                   Indices indices,
                                   EventBus eventBus,
-                                  @ClusterEventBus EventBus clusterEventBus) {
+                                  ClusterEventBus clusterEventBus) {
         this.indices = indices;
         this.collection = JacksonDBCollection.wrap(
                 mongoConnection.getDatabase().getCollection(COLLECTION_NAME),
@@ -78,7 +78,6 @@ public class MongoIndexRangeService implements IndexRangeService {
         // This sucks. We need to bridge Elasticsearch's and our own Guice injector.
         IndexChangeMonitor.setEventBus(eventBus);
         eventBus.register(this);
-        clusterEventBus.register(this);
 
         collection.createIndex(new BasicDBObject(MongoIndexRange.FIELD_INDEX_NAME, 1));
         collection.createIndex(BasicDBObjectBuilder.start()

--- a/graylog2-server/src/main/java/org/graylog2/inputs/InputServiceImpl.java
+++ b/graylog2-server/src/main/java/org/graylog2/inputs/InputServiceImpl.java
@@ -61,19 +61,16 @@ public class InputServiceImpl extends PersistedServiceImpl implements InputServi
     private final ExtractorFactory extractorFactory;
     private final MessageInputFactory messageInputFactory;
     private final EventBus clusterEventBus;
-    private final EventBus serverEventBus;
 
     @Inject
     public InputServiceImpl(MongoConnection mongoConnection,
                             ExtractorFactory extractorFactory,
                             MessageInputFactory messageInputFactory,
-                            @ClusterEventBus EventBus clusterEventBus,
-                            EventBus serverEventBus) {
+                            ClusterEventBus clusterEventBus) {
         super(mongoConnection);
         this.extractorFactory = extractorFactory;
         this.messageInputFactory = messageInputFactory;
         this.clusterEventBus = clusterEventBus;
-        this.serverEventBus = serverEventBus;
     }
 
     @Override
@@ -429,6 +426,5 @@ public class InputServiceImpl extends PersistedServiceImpl implements InputServi
 
     private void publishChange(Object event) {
         this.clusterEventBus.post(event);
-        this.serverEventBus.post(event);
     }
 }

--- a/graylog2-server/src/main/java/org/graylog2/messageprocessors/OrderedMessageProcessors.java
+++ b/graylog2-server/src/main/java/org/graylog2/messageprocessors/OrderedMessageProcessors.java
@@ -23,7 +23,6 @@ import com.google.common.collect.Ordering;
 import com.google.common.eventbus.EventBus;
 import com.google.common.eventbus.Subscribe;
 import org.graylog2.cluster.ClusterConfigChangedEvent;
-import org.graylog2.events.ClusterEventBus;
 import org.graylog2.plugin.cluster.ClusterConfigService;
 import org.graylog2.plugin.messageprocessors.MessageProcessor;
 import org.slf4j.Logger;
@@ -56,10 +55,10 @@ public class OrderedMessageProcessors implements Iterable<MessageProcessor> {
     @Inject
     public OrderedMessageProcessors(Set<MessageProcessor> processors,
                                     ClusterConfigService clusterConfigService,
-                                    @ClusterEventBus EventBus clusterEventBus) {
+                                    EventBus eventBus) {
         this.processors = processors;
         this.clusterConfigService = clusterConfigService;
-        clusterEventBus.register(this);
+        eventBus.register(this);
         // TODO by default sort on class name this is probably not the best idea, but for now works.
         this.classNameOrdering = Ordering.from(String.CASE_INSENSITIVE_ORDER);
 

--- a/graylog2-server/src/main/java/org/graylog2/periodical/ThrottleStateUpdaterThread.java
+++ b/graylog2-server/src/main/java/org/graylog2/periodical/ThrottleStateUpdaterThread.java
@@ -232,9 +232,6 @@ public class ThrottleStateUpdaterThread extends Periodical {
         // the journal needs this to provide information to rest clients
         journal.setThrottleState(throttleState);
         
-        // publish to interested parties
-        eventBus.post(throttleState);
-
         // Abusing the current thread to send notifications from KafkaJournal in the graylog2-shared module
         final double journalUtilizationPercentage = throttleState.journalSizeLimit > 0 ? (throttleState.journalSize * 100) / throttleState.journalSizeLimit : 0.0;
 

--- a/graylog2-server/src/main/java/org/graylog2/rest/resources/system/debug/DebugEventsResource.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/resources/system/debug/DebugEventsResource.java
@@ -52,7 +52,7 @@ public class DebugEventsResource extends RestResource {
     @Inject
     public DebugEventsResource(NodeId nodeId,
                                EventBus serverEventBus,
-                               @ClusterEventBus EventBus clusterEventBus) {
+                               ClusterEventBus clusterEventBus) {
         this.nodeId = checkNotNull(nodeId);
         this.serverEventBus = checkNotNull(serverEventBus);
         this.clusterEventBus = checkNotNull(clusterEventBus);

--- a/graylog2-server/src/main/java/org/graylog2/shared/events/DeadEventLoggingListener.java
+++ b/graylog2-server/src/main/java/org/graylog2/shared/events/DeadEventLoggingListener.java
@@ -26,7 +26,8 @@ public class DeadEventLoggingListener {
 
     @Subscribe
     public void handleDeadEvent(DeadEvent event) {
-        LOGGER.debug("Received unhandled event of type <{}>", event.getEvent().getClass().getCanonicalName());
-        LOGGER.trace("Dead event contents: {}", event.getEvent());
+        LOGGER.warn("Received unhandled event of type <{}> from event bus <{}>", event.getEvent().getClass().getCanonicalName(),
+                event.getSource().toString());
+        LOGGER.debug("Dead event contents: {}", event.getEvent());
     }
 }

--- a/graylog2-server/src/main/java/org/graylog2/system/debug/ClusterDebugEventListener.java
+++ b/graylog2-server/src/main/java/org/graylog2/system/debug/ClusterDebugEventListener.java
@@ -16,7 +16,6 @@
  */
 package org.graylog2.system.debug;
 
-import com.google.common.eventbus.EventBus;
 import com.google.common.eventbus.Subscribe;
 import org.graylog2.events.ClusterEventBus;
 import org.slf4j.Logger;
@@ -30,8 +29,8 @@ public class ClusterDebugEventListener {
     private static final Logger LOG = LoggerFactory.getLogger(ClusterDebugEventListener.class);
 
     @Inject
-    public ClusterDebugEventListener(@ClusterEventBus EventBus clusterEventBus) {
-        checkNotNull(clusterEventBus).register(this);
+    public ClusterDebugEventListener(ClusterEventBus clusterEventBus) {
+        checkNotNull(clusterEventBus).registerClusterEventSubscriber(this);
     }
 
     @Subscribe

--- a/graylog2-server/src/test/java/org/graylog2/cluster/ClusterConfigServiceImplTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/cluster/ClusterConfigServiceImplTest.java
@@ -23,7 +23,6 @@ import com.fasterxml.jackson.databind.SerializationFeature;
 import com.fasterxml.jackson.databind.module.SimpleModule;
 import com.fasterxml.jackson.datatype.guava.GuavaModule;
 import com.fasterxml.jackson.datatype.joda.JodaModule;
-import com.google.common.eventbus.EventBus;
 import com.google.common.eventbus.Subscribe;
 import com.lordofthejars.nosqlunit.annotation.UsingDataSet;
 import com.lordofthejars.nosqlunit.core.LoadStrategyEnum;
@@ -36,6 +35,7 @@ import org.graylog2.bindings.providers.MongoJackObjectMapperProvider;
 import org.graylog2.database.MongoConnection;
 import org.graylog2.database.MongoConnectionRule;
 import org.graylog2.database.ObjectIdSerializer;
+import org.graylog2.events.ClusterEventBus;
 import org.graylog2.plugin.cluster.ClusterConfigService;
 import org.graylog2.plugin.system.NodeId;
 import org.graylog2.shared.jackson.SizeSerializer;
@@ -84,7 +84,7 @@ public class ClusterConfigServiceImplTest {
     @Mock
     private NodeId nodeId;
     @Spy
-    private EventBus clusterEventBus;
+    private ClusterEventBus clusterEventBus;
     private MongoConnection mongoConnection;
     private ClusterConfigService clusterConfigService;
 
@@ -275,7 +275,7 @@ public class ClusterConfigServiceImplTest {
         customConfig.text = "TEST";
 
         final ClusterConfigChangedEventHandler eventHandler = new ClusterConfigChangedEventHandler();
-        clusterEventBus.register(eventHandler);
+        clusterEventBus.registerClusterEventSubscriber(eventHandler);
 
         final DBCollection collection = mongoConnection.getDatabase().getCollection(COLLECTION_NAME);
         assertThat(collection.count()).isEqualTo(0L);

--- a/graylog2-server/src/test/java/org/graylog2/events/ClusterEventPeriodicalTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/events/ClusterEventPeriodicalTest.java
@@ -93,7 +93,7 @@ public class ClusterEventPeriodicalTest {
     @Spy
     private EventBus serverEventBus;
     @Spy
-    private EventBus clusterEventBus;
+    private ClusterEventBus clusterEventBus;
     private MongoConnection mongoConnection;
     private ClusterEventPeriodical clusterEventPeriodical;
 
@@ -124,7 +124,7 @@ public class ClusterEventPeriodicalTest {
 
     @Test
     public void clusterEventServiceRegistersItselfWithClusterEventBus() throws Exception {
-        verify(clusterEventBus, times(1)).register(clusterEventPeriodical);
+        verify(clusterEventBus, times(1)).registerClusterEventSubscriber(clusterEventPeriodical);
     }
 
     @Test

--- a/graylog2-server/src/test/java/org/graylog2/indexer/ranges/EsIndexRangeServiceTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/indexer/ranges/EsIndexRangeServiceTest.java
@@ -73,8 +73,6 @@ public class EsIndexRangeServiceTest {
     private Indices indices;
     @Mock
     private EventBus localEventBus;
-    @Mock
-    private EventBus clusterEventBus;
     private EsIndexRangeService indexRangeService;
 
     public EsIndexRangeServiceTest() {
@@ -87,7 +85,7 @@ public class EsIndexRangeServiceTest {
         final Messages messages = new Messages(client, ELASTICSEARCH_CONFIGURATION);
         indices = new Indices(client, ELASTICSEARCH_CONFIGURATION, new IndexMapping(), messages);
         final Deflector deflector = new Deflector(null, ELASTICSEARCH_CONFIGURATION.getIndexPrefix(), new NullActivityWriter(), null, null, indices);
-        indexRangeService = new EsIndexRangeService(client, deflector, localEventBus, clusterEventBus, new MetricRegistry());
+        indexRangeService = new EsIndexRangeService(client, deflector, localEventBus, new MetricRegistry());
     }
 
     @Test

--- a/graylog2-server/src/test/java/org/graylog2/indexer/ranges/MongoIndexRangeServiceTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/indexer/ranges/MongoIndexRangeServiceTest.java
@@ -27,6 +27,7 @@ import org.elasticsearch.index.IndexNotFoundException;
 import org.graylog2.bindings.providers.MongoJackObjectMapperProvider;
 import org.graylog2.database.MongoConnectionRule;
 import org.graylog2.database.NotFoundException;
+import org.graylog2.events.ClusterEventBus;
 import org.graylog2.indexer.esplugin.IndicesClosedEvent;
 import org.graylog2.indexer.esplugin.IndicesDeletedEvent;
 import org.graylog2.indexer.esplugin.IndicesReopenedEvent;
@@ -68,7 +69,7 @@ public class MongoIndexRangeServiceTest {
     private Indices indices;
     private EventBus localEventBus;
     @Mock
-    private EventBus clusterEventBus;
+    private ClusterEventBus clusterEventBus;
     private MongoIndexRangeService indexRangeService;
 
     @Before

--- a/graylog2-server/src/test/java/org/graylog2/system/debug/ClusterDebugEventListenerTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/system/debug/ClusterDebugEventListenerTest.java
@@ -16,8 +16,7 @@
  */
 package org.graylog2.system.debug;
 
-import com.google.common.eventbus.EventBus;
-import org.graylog2.events.ClusterEvent;
+import org.graylog2.events.ClusterEventBus;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -29,7 +28,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 @RunWith(MockitoJUnitRunner.class)
 public class ClusterDebugEventListenerTest {
     @Spy
-    private EventBus clusterEventBus;
+    private ClusterEventBus clusterEventBus;
 
     @Before
     public void setUp() {


### PR DESCRIPTION
Previously you had to publish cluster events on the cluster-event-bus and the internal server-event-bus to make sure the producer also received the event. This was unintuitive and lead to wrong usage where objects subscribed to the cluster-event-bus where they should have subscribed to the server-event-bus instead and thus not getting cluster events when running on a different server node.

With this change, the cluster event bus should be used as follows:

- If an object needs to publish cluster events, it uses the `ClusterEventBus` implementation to publish the events. It does NOT have to publish the event on the internal server event bus!
- If an object needs to receive cluster events, it registers with the internal server event bus.
- The `ClusterEventBus#register()` method throws an exception and should not be used by regular event subscribers. There is a `#registerClusterEventSubscriber()` method to actually subscribe to the cluster event bus events. This should only be used by the cluster event system internals.

Previously the event producer got the event via its internal server event bus and not from the database. (that's why a cluster event had to be published on the cluster-event-bus AND the server-event-bus)
The event producer is now the events the same way as any other nodes, it gets the event via the database.

Other changes:

- The DeadEvent handler is now logging to WARN to make sure we see unhandled events.
- Do not publish ThrottleState events in ThrottleStateUpdater because no object is subscribed to them.