### PR TITLE
THROTTLED status when journal utilization is over threshold

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/Configuration.java
+++ b/graylog2-server/src/main/java/org/graylog2/Configuration.java
@@ -105,6 +105,9 @@ public class Configuration extends BaseConfiguration {
     @Parameter(value = "lb_recognition_period_seconds", validator = PositiveIntegerValidator.class)
     private int loadBalancerRecognitionPeriodSeconds = 3;
 
+    @Parameter(value = "lb_throttle_threshold_percentage", validator = PositiveIntegerValidator.class)
+    private int loadBalancerThrottleThresholdPercentage = 100; // 100% or over is effectively disabled
+
     @Parameter(value = "stream_processing_timeout", validator = PositiveLongValidator.class)
     private long streamProcessingTimeout = 2000;
 
@@ -314,4 +317,7 @@ public class Configuration extends BaseConfiguration {
     }
 
     public Set<IpSubnet> getTrustedProxies() { return trustedProxies; }
+
+    public int getLoadBalancerRequestThrottleJournalUsage() { return loadBalancerThrottleThresholdPercentage; }
+
 }

--- a/graylog2-server/src/main/java/org/graylog2/plugin/ServerStatus.java
+++ b/graylog2-server/src/main/java/org/graylog2/plugin/ServerStatus.java
@@ -129,6 +129,10 @@ public class ServerStatus {
         publishLifecycle(Lifecycle.OVERRIDE_LB_ALIVE);
     }
 
+    public void overrideLoadBalancerThrottled() {
+        publishLifecycle(Lifecycle.OVERRIDE_LB_THROTTLED);
+    }
+
     public void awaitRunning(final Runnable runnable) {
         LOG.debug("Waiting for server to enter RUNNING state");
         Uninterruptibles.awaitUninterruptibly(runningLatch);

--- a/graylog2-server/src/main/java/org/graylog2/plugin/lifecycles/Lifecycle.java
+++ b/graylog2-server/src/main/java/org/graylog2/plugin/lifecycles/Lifecycle.java
@@ -30,7 +30,8 @@ public enum Lifecycle {
 
     // Manual lifecycle override, usually set by REST calls.
     OVERRIDE_LB_DEAD("Override lb:DEAD", LoadBalancerStatus.DEAD),
-    OVERRIDE_LB_ALIVE("Override lb:ALIVE", LoadBalancerStatus.ALIVE);
+    OVERRIDE_LB_ALIVE("Override lb:ALIVE", LoadBalancerStatus.ALIVE),
+    OVERRIDE_LB_THROTTLED("Override lb:THROTTLED", LoadBalancerStatus.THROTTLED);
 
     private final String description;
     private final LoadBalancerStatus loadBalancerStatus;

--- a/graylog2-server/src/main/java/org/graylog2/rest/TooManyRequestsStatus.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/TooManyRequestsStatus.java
@@ -14,15 +14,21 @@
  * You should have received a copy of the GNU General Public License
  * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
  */
-package org.graylog2.plugin.lifecycles;
+package org.graylog2.rest;
+
+import javax.ws.rs.core.Response;
 
 /**
- * @author Lennart Koopmann <lennart@torch.sh>
+ * Implementing StatusType for 429 TOO MANY REQUEST (the most suitable HTTP status code for
+ * requesting throttling), because javax.ws.rs.core.Response.Status does not implement it.
  */
-public enum LoadBalancerStatus {
+public class TooManyRequestsStatus implements Response.StatusType {
+    @Override
+    public int getStatusCode() { return 429; }
 
-    DEAD,
-    ALIVE,
-    THROTTLED
+    @Override
+    public Response.Status.Family getFamily() { return Response.Status.Family.CLIENT_ERROR; }
 
+    @Override
+    public String getReasonPhrase() { return "Too many requests"; }
 }

--- a/graylog2-server/src/main/java/org/graylog2/rest/resources/cluster/ClusterLoadBalancerStatusResource.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/resources/cluster/ClusterLoadBalancerStatusResource.java
@@ -66,7 +66,7 @@ public class ClusterLoadBalancerStatusResource extends ProxiedResource {
     @RequiresAuthentication
     @RequiresPermissions(RestPermissions.LBSTATUS_CHANGE)
     @ApiOperation(value = "Override load balancer status of this graylog2-server node. Next lifecycle " +
-            "change will override it again to its default. Set to ALIVE or DEAD.")
+            "change will override it again to its default. Set to ALIVE, DEAD, or THROTTLED.")
     @Path("/override/{status}")
     public void override(@ApiParam(name = "nodeId", value = "The id of the node whose LB status will be changed", required = true)
                          @PathParam("nodeId") String nodeId,

--- a/graylog2-server/src/main/java/org/graylog2/shared/journal/JournalReader.java
+++ b/graylog2-server/src/main/java/org/graylog2/shared/journal/JournalReader.java
@@ -111,6 +111,9 @@ public class JournalReader extends AbstractExecutionThreadService {
             case OVERRIDE_LB_ALIVE:
                 // don't care, keep processing journal
                 break;
+            case OVERRIDE_LB_THROTTLED:
+                // don't care, keep processing journal
+                break;
         }
     }
 

--- a/misc/graylog.conf
+++ b/misc/graylog.conf
@@ -351,6 +351,10 @@ message_journal_dir = data/journal
 # shutdown process. Set to 0 if you have no status checking load balancers in front.
 lb_recognition_period_seconds = 3
 
+# Journal usage percentage that triggers requesting throttling for this server node from load balancers. The feature is
+# disabled if not set.
+#lb_throttle_threshold_percentage = 95
+
 # Every message is matched against the configured streams and it can happen that a stream contains rules which
 # take an unusual amount of time to run, for example if its using regular expressions that perform excessive backtracking.
 # This will impact the processing of the entire server. To keep such misbehaving stream rules from impacting other


### PR DESCRIPTION
Implementation of #1100. 

Quick notes:
- The feature is disabled by default
- Adds THROTTLED load balancer status with 429 TOO MANY REQUESTS (meant for throttling purposes).
- Evaluates the need to throttle at journal cleanups (alternatively could be also at metrics)
- Threshold percentage configured via new configuration value lb_throttle_threshold_percentage
- Should not break existing load balancer configurations, because they commonly consider anything besides ALIVE response as DEAD
- Needs to be documented [here](https://github.com/Graylog2/documentation/blob/master/pages/load_balancers.rst), if gets accepted

Please review and comment :)
