### PR TITLE
Use cluster event bus for grok pattern changes

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/bindings/ServerBindings.java
+++ b/graylog2-server/src/main/java/org/graylog2/bindings/ServerBindings.java
@@ -46,6 +46,7 @@ import org.graylog2.events.ClusterEventBus;
 import org.graylog2.bindings.providers.ClusterEventBusProvider;
 import org.graylog2.filters.FilterService;
 import org.graylog2.filters.FilterServiceImpl;
+import org.graylog2.grok.GrokPatternRegistry;
 import org.graylog2.indexer.SetIndexReadOnlyJob;
 import org.graylog2.indexer.healing.FixDeflectorByDeleteJob;
 import org.graylog2.indexer.healing.FixDeflectorByMoveJob;
@@ -155,6 +156,7 @@ public class ServerBindings extends Graylog2Module {
         bind(BundleExporterProvider.class).in(Scopes.SINGLETON);
         bind(ClusterStatsModule.class).asEagerSingleton();
         bind(ClusterConfigService.class).to(ClusterConfigServiceImpl.class).asEagerSingleton();
+        bind(GrokPatternRegistry.class).in(Scopes.SINGLETON);
 
         bind(String[].class).annotatedWith(named("RestControllerPackages")).toInstance(new String[]{
                 "org.graylog2.rest.resources",

--- a/graylog2-server/src/main/java/org/graylog2/grok/GrokPattern.java
+++ b/graylog2-server/src/main/java/org/graylog2/grok/GrokPattern.java
@@ -42,6 +42,18 @@ public class GrokPattern {
                 .toString();
     }
 
+    public static GrokPattern create(String name, String pattern) {
+        return create(null, name, pattern, null);
+    }
+    public static GrokPattern create(ObjectId id, String name, String pattern, String contentPack) {
+        final GrokPattern grokPattern = new GrokPattern();
+        grokPattern.id = id;
+        grokPattern.name = name;
+        grokPattern.pattern = pattern;
+        grokPattern.contentPack = contentPack;
+        return grokPattern;
+    }
+
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;

--- a/graylog2-server/src/main/java/org/graylog2/grok/GrokPattern.java
+++ b/graylog2-server/src/main/java/org/graylog2/grok/GrokPattern.java
@@ -32,6 +32,18 @@ public class GrokPattern {
     public String pattern;
     public String contentPack;
 
+    public String name() {
+        return name;
+    }
+
+    public String pattern() {
+        return pattern;
+    }
+
+    public String contentPack() {
+        return contentPack;
+    }
+
     @Override
     public String toString() {
         return MoreObjects.toStringHelper(this)

--- a/graylog2-server/src/main/java/org/graylog2/grok/GrokPatternRegistry.java
+++ b/graylog2-server/src/main/java/org/graylog2/grok/GrokPatternRegistry.java
@@ -1,0 +1,108 @@
+/**
+ * This file is part of Graylog.
+ *
+ * Graylog is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.graylog2.grok;
+
+import com.google.common.cache.CacheBuilder;
+import com.google.common.cache.CacheLoader;
+import com.google.common.cache.LoadingCache;
+import com.google.common.eventbus.EventBus;
+import com.google.common.eventbus.Subscribe;
+import oi.thekraken.grok.api.Grok;
+import org.graylog2.events.ClusterEventBus;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.annotation.Nonnull;
+import javax.inject.Inject;
+import javax.inject.Named;
+import javax.inject.Singleton;
+import java.util.Collections;
+import java.util.Set;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static com.google.common.base.Strings.isNullOrEmpty;
+import static com.google.common.cache.CacheLoader.asyncReloading;
+
+@Singleton
+public class GrokPatternRegistry {
+    private static final Logger log = LoggerFactory.getLogger(GrokPatternRegistry.class);
+
+    private final GrokPatternService grokPatternService;
+    private final ScheduledExecutorService daemonExecutor;
+
+    private final AtomicReference<Set<GrokPattern>> patterns = new AtomicReference<>(Collections.emptySet());
+    private final LoadingCache<String, Grok> grokCache;
+
+    @Inject
+    public GrokPatternRegistry(@ClusterEventBus EventBus clusterBus,
+                               GrokPatternService grokPatternService,
+                               @Named("daemonScheduler") ScheduledExecutorService daemonExecutor) {
+        this.grokPatternService = grokPatternService;
+        this.daemonExecutor = daemonExecutor;
+
+        grokCache = CacheBuilder.newBuilder()
+                .expireAfterAccess(1, TimeUnit.MINUTES) // prevent from hanging on to memory forever
+                .build(asyncReloading(new GrokReloader(), daemonExecutor));
+
+        // trigger initial loading
+        reload();
+
+        clusterBus.register(this);
+    }
+
+    @Subscribe
+    public void grokPatternsChanged(GrokPatternsChangedEvent event) {
+        // for now we simply reload everything and don't care what exactly has changed
+        daemonExecutor.execute(this::reload);
+    }
+
+    public Grok cachedGrokForPattern(String pattern) {
+        try {
+            return grokCache.get(pattern);
+        } catch (ExecutionException e) {
+            log.error("Unable to load grok pattern " + pattern + " into cache", e);
+            throw new RuntimeException(e);
+        }
+    }
+
+    private void reload() {
+        final Set<GrokPattern> grokPatterns = grokPatternService.loadAll();
+        patterns.set(grokPatterns);
+        grokCache.invalidateAll();
+    }
+
+    public Set<GrokPattern> patterns() {
+        return patterns.get();
+    }
+
+    private class GrokReloader extends CacheLoader<String, Grok> {
+        @Override
+        public Grok load(@Nonnull String pattern) throws Exception {
+            final Grok grok = new Grok();
+            for (GrokPattern grokPattern : patterns()) {
+                if (!isNullOrEmpty(grokPattern.name) || isNullOrEmpty(grokPattern.pattern)) {
+                    grok.addPattern(grokPattern.name, grokPattern.pattern);
+                }
+            }
+            grok.compile(pattern);
+            return grok;
+        }
+    }
+}

--- a/graylog2-server/src/main/java/org/graylog2/grok/GrokPatternRegistry.java
+++ b/graylog2-server/src/main/java/org/graylog2/grok/GrokPatternRegistry.java
@@ -44,7 +44,6 @@ public class GrokPatternRegistry {
     private static final Logger log = LoggerFactory.getLogger(GrokPatternRegistry.class);
 
     private final GrokPatternService grokPatternService;
-    private final ScheduledExecutorService daemonExecutor;
 
     private final AtomicReference<Set<GrokPattern>> patterns = new AtomicReference<>(Collections.emptySet());
     private final LoadingCache<String, Grok> grokCache;
@@ -54,7 +53,6 @@ public class GrokPatternRegistry {
                                GrokPatternService grokPatternService,
                                @Named("daemonScheduler") ScheduledExecutorService daemonExecutor) {
         this.grokPatternService = grokPatternService;
-        this.daemonExecutor = daemonExecutor;
 
         grokCache = CacheBuilder.newBuilder()
                 .expireAfterAccess(1, TimeUnit.MINUTES) // prevent from hanging on to memory forever
@@ -69,14 +67,14 @@ public class GrokPatternRegistry {
     @Subscribe
     public void grokPatternsChanged(GrokPatternsChangedEvent event) {
         // for now we simply reload everything and don't care what exactly has changed
-        daemonExecutor.schedule(this::reload, 0, TimeUnit.SECONDS);
+        reload();
     }
 
     public Grok cachedGrokForPattern(String pattern) {
         try {
             return grokCache.get(pattern);
         } catch (ExecutionException e) {
-            log.error("Unable to load grok pattern " + pattern + " into cache", e);
+            log.error("Unable to load grok pattern {} into cache", pattern, e);
             throw new RuntimeException(e);
         }
     }

--- a/graylog2-server/src/main/java/org/graylog2/grok/GrokPatternRegistry.java
+++ b/graylog2-server/src/main/java/org/graylog2/grok/GrokPatternRegistry.java
@@ -22,7 +22,6 @@ import com.google.common.cache.LoadingCache;
 import com.google.common.eventbus.EventBus;
 import com.google.common.eventbus.Subscribe;
 import oi.thekraken.grok.api.Grok;
-import org.graylog2.events.ClusterEventBus;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -51,7 +50,7 @@ public class GrokPatternRegistry {
     private final LoadingCache<String, Grok> grokCache;
 
     @Inject
-    public GrokPatternRegistry(@ClusterEventBus EventBus clusterBus,
+    public GrokPatternRegistry(EventBus serverEventBus,
                                GrokPatternService grokPatternService,
                                @Named("daemonScheduler") ScheduledExecutorService daemonExecutor) {
         this.grokPatternService = grokPatternService;
@@ -64,13 +63,13 @@ public class GrokPatternRegistry {
         // trigger initial loading
         reload();
 
-        clusterBus.register(this);
+        serverEventBus.register(this);
     }
 
     @Subscribe
     public void grokPatternsChanged(GrokPatternsChangedEvent event) {
         // for now we simply reload everything and don't care what exactly has changed
-        daemonExecutor.execute(this::reload);
+        daemonExecutor.schedule(this::reload, 0, TimeUnit.SECONDS);
     }
 
     public Grok cachedGrokForPattern(String pattern) {

--- a/graylog2-server/src/main/java/org/graylog2/grok/GrokPatternService.java
+++ b/graylog2-server/src/main/java/org/graylog2/grok/GrokPatternService.java
@@ -26,7 +26,7 @@ import java.util.Set;
 
 @ImplementedBy(GrokPatternServiceImpl.class)
 public interface GrokPatternService {
-    GrokPattern load(String patternName) throws NotFoundException;
+    GrokPattern load(String patternId) throws NotFoundException;
 
     Set<GrokPattern> loadAll();
 
@@ -36,7 +36,7 @@ public interface GrokPatternService {
 
     boolean validate(GrokPattern pattern);
 
-    int delete(String patternName);
+    int delete(String patternId);
 
     int deleteAll();
 }

--- a/graylog2-server/src/main/java/org/graylog2/grok/GrokPatternsChangedEvent.java
+++ b/graylog2-server/src/main/java/org/graylog2/grok/GrokPatternsChangedEvent.java
@@ -1,0 +1,40 @@
+/**
+ * This file is part of Graylog.
+ *
+ * Graylog is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.graylog2.grok;
+
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.auto.value.AutoValue;
+
+import java.util.Set;
+
+@JsonAutoDetect
+@AutoValue
+public abstract class GrokPatternsChangedEvent {
+
+    @JsonProperty
+    public abstract Set<String> deletedPatterns();
+
+    @JsonProperty
+    public abstract Set<String> updatedPatterns();
+
+    @JsonCreator
+    public static GrokPatternsChangedEvent create(@JsonProperty("deleted_patterns") Set<String> deletedPatterns, @JsonProperty("updated_patterns") Set<String> updatedPatterns) {
+        return new AutoValue_GrokPatternsChangedEvent(deletedPatterns, updatedPatterns);
+    }
+}

--- a/graylog2-server/src/main/java/org/graylog2/rest/resources/system/GrokResource.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/resources/system/GrokResource.java
@@ -115,6 +115,7 @@ public class GrokResource extends RestResource {
 
         final Set<String> updatedPatternNames = Sets.newHashSet();
         for (final GrokPatternSummary pattern : patternList.patterns()) {
+            updatedPatternNames.add(pattern.name);
             if (!grokPatternService.validate(GrokPatterns.fromSummary(pattern))) {
                 throw new ValidationException("Invalid pattern " + pattern + ". Did not save any patterns.");
             }
@@ -137,12 +138,13 @@ public class GrokResource extends RestResource {
 
         final GrokPattern oldPattern = grokPatternService.load(patternId);
 
-        final Set<String> updatedNames = Sets.newHashSet(pattern.name, oldPattern.name);
+        final Set<String> deletedNames = Sets.newHashSet(oldPattern.name);
+        final Set<String> updatedNames = Sets.newHashSet(pattern.name);
 
         oldPattern.name = pattern.name;
         oldPattern.pattern = pattern.pattern;
 
-        clusterBus.post(GrokPatternsChangedEvent.create(Collections.emptySet(), updatedNames));
+        clusterBus.post(GrokPatternsChangedEvent.create(deletedNames, updatedNames));
         return grokPatternService.save(oldPattern);
     }
 

--- a/graylog2-server/src/main/java/org/graylog2/rest/resources/system/GrokResource.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/resources/system/GrokResource.java
@@ -18,7 +18,6 @@ package org.graylog2.rest.resources.system;
 
 import com.codahale.metrics.annotation.Timed;
 import com.google.common.collect.Sets;
-import com.google.common.eventbus.EventBus;
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
 import io.swagger.annotations.ApiParam;
@@ -62,10 +61,10 @@ import java.util.Set;
 public class GrokResource extends RestResource {
 
     private final GrokPatternService grokPatternService;
-    private final EventBus clusterBus;
+    private final ClusterEventBus clusterBus;
 
     @Inject
-    public GrokResource(GrokPatternService grokPatternService, @ClusterEventBus EventBus clusterBus) {
+    public GrokResource(GrokPatternService grokPatternService, ClusterEventBus clusterBus) {
         this.grokPatternService = grokPatternService;
         this.clusterBus = clusterBus;
     }


### PR DESCRIPTION
Introduces new GrokPatternRegistry to hand out compile Grok patterns, instead of having consumers reload them themselves (which can cause stalls if not done properly).

This PR doesn't change the current extractors on purpose to minimize changes in legacy code.