### PR TITLE
Remove unused "local mode"

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/commands/Server.java
+++ b/graylog2-server/src/main/java/org/graylog2/commands/Server.java
@@ -86,18 +86,11 @@ public class Server extends ServerBootstrap {
     @Option(name = {"-t", "--configtest"}, description = "Validate Graylog configuration and exit")
     private boolean configTest = false;
 
-    @Option(name = {"-l", "--local"}, description = "Run Graylog in local mode. Only interesting for Graylog developers.")
-    private boolean local = false;
-
     @Option(name = {"-r", "--no-retention"}, description = "Do not automatically remove messages from index that are older than the retention time")
     private boolean noRetention = false;
 
     public boolean isConfigTest() {
         return configTest;
-    }
-
-    public boolean isLocal() {
-        return local;
     }
 
     public boolean performRetention() {
@@ -152,7 +145,6 @@ public class Server extends ServerBootstrap {
                 configuration.isMaster(),
                 configuration.getRestTransportUri(),
                 Tools.getLocalCanonicalHostname());
-        serverStatus.setLocalMode(isLocal());
         if (configuration.isMaster() && !nodeService.isOnlyMaster(serverStatus.getNodeId())) {
             LOG.warn("Detected another master in the cluster. Retrying in {} seconds to make sure it is not "
                     + "an old stale instance.", TimeUnit.MILLISECONDS.toSeconds(configuration.getStaleMasterTimeout()));

--- a/graylog2-server/src/main/java/org/graylog2/periodical/VersionCheckThread.java
+++ b/graylog2-server/src/main/java/org/graylog2/periodical/VersionCheckThread.java
@@ -169,7 +169,7 @@ public class VersionCheckThread extends Periodical {
 
     @Override
     public boolean startOnThisNode() {
-        return config.isEnabled() && !serverStatus.hasCapability(ServerStatus.Capability.LOCALMODE);
+        return config.isEnabled();
     }
 
     @Override

--- a/graylog2-server/src/main/java/org/graylog2/plugin/ServerStatus.java
+++ b/graylog2-server/src/main/java/org/graylog2/plugin/ServerStatus.java
@@ -43,8 +43,7 @@ public class ServerStatus {
 
     public enum Capability {
         SERVER,
-        MASTER,
-        LOCALMODE
+        MASTER
     }
 
     private final EventBus eventBus;
@@ -199,19 +198,6 @@ public class ServerStatus {
 
     public void unlockProcessingPause() {
         processingPauseLocked.set(false);
-    }
-
-    private ServerStatus removeCapability(Capability capability) {
-        this.capabilitySet.remove(capability);
-        return this;
-    }
-
-    public void setLocalMode(boolean localMode) {
-        if (localMode) {
-            addCapability(Capability.LOCALMODE);
-        } else {
-            removeCapability(Capability.LOCALMODE);
-        }
     }
 
     public enum MessageDetailRecordingStrategy {

--- a/graylog2-server/src/test/java/org/graylog2/plugin/ServerStatusTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/plugin/ServerStatusTest.java
@@ -171,8 +171,8 @@ public class ServerStatusTest {
 
     @Test
     public void testAddCapabilities() throws Exception {
-        assertEquals(status.addCapabilities(ServerStatus.Capability.LOCALMODE), status);
-        assertTrue(status.hasCapabilities(ServerStatus.Capability.MASTER, ServerStatus.Capability.LOCALMODE));
+        assertEquals(status.addCapabilities(ServerStatus.Capability.SERVER), status);
+        assertTrue(status.hasCapabilities(ServerStatus.Capability.MASTER, ServerStatus.Capability.SERVER));
     }
 
     @Test
@@ -228,14 +228,5 @@ public class ServerStatusTest {
 
         status.unlockProcessingPause();
         assertFalse(status.processingPauseLocked());
-    }
-
-    @Test
-    public void testSetLocalMode() throws Exception {
-        status.setLocalMode(false);
-        assertFalse(status.hasCapability(ServerStatus.Capability.LOCALMODE));
-
-        status.setLocalMode(true);
-        assertTrue(status.hasCapability(ServerStatus.Capability.LOCALMODE));
     }
 }


### PR DESCRIPTION
Graylog supports the so called "local mode" which - in theory - should make it simpler to run local development setups of Graylog. In practice, this mode hasn't been used at all lately and the only consumer of the flag is `VersionCheckThread`.

Instead of dragging this along over the next few versions, this PR simply removes "local mode".