### PR TITLE
Remove unused command line parameters

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/commands/Server.java
+++ b/graylog2-server/src/main/java/org/graylog2/commands/Server.java
@@ -83,25 +83,11 @@ public class Server extends ServerBootstrap {
         super("server", configuration);
     }
 
-    @Option(name = {"-t", "--configtest"}, description = "Validate Graylog configuration and exit")
-    private boolean configTest = false;
-
     @Option(name = {"-l", "--local"}, description = "Run Graylog in local mode. Only interesting for Graylog developers.")
     private boolean local = false;
 
-    @Option(name = {"-r", "--no-retention"}, description = "Do not automatically remove messages from index that are older than the retention time")
-    private boolean noRetention = false;
-
-    public boolean isConfigTest() {
-        return configTest;
-    }
-
     public boolean isLocal() {
         return local;
-    }
-
-    public boolean performRetention() {
-        return !noRetention;
     }
 
     @Override


### PR DESCRIPTION
This PR removes the unused command line parameters `--configtest`/`-t` and `--no-retention`/`-r`.