### PR TITLE
Create PID file earlier in the startup process

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/bootstrap/CmdLineTool.java
+++ b/graylog2-server/src/main/java/org/graylog2/bootstrap/CmdLineTool.java
@@ -159,6 +159,10 @@ public abstract class CmdLineTool implements CliCommand {
 
     protected abstract List<Object> getCommandConfigurationBeans();
 
+    /**
+     * Things that have to run before the {@link #startCommand()} method is being called.
+     */
+    protected void beforeStart() {}
 
     @Override
     public void run() {
@@ -180,6 +184,8 @@ public abstract class CmdLineTool implements CliCommand {
             LOG.error("Validating configuration file failed - exiting.");
             System.exit(1);
         }
+
+        beforeStart();
 
         final List<String> arguments = ManagementFactory.getRuntimeMXBean().getInputArguments();
         LOG.info("Running with JVM arguments: {}", Joiner.on(' ').join(arguments));

--- a/graylog2-server/src/main/java/org/graylog2/bootstrap/ServerBootstrap.java
+++ b/graylog2-server/src/main/java/org/graylog2/bootstrap/ServerBootstrap.java
@@ -75,6 +75,16 @@ public abstract class ServerBootstrap extends CmdLineTool {
     }
 
     @Override
+    protected void beforeStart() {
+        super.beforeStart();
+
+        // Do not use a PID file if the user requested not to
+        if (!isNoPidFile()) {
+            savePidFile(getPidFile());
+        }
+    }
+
+    @Override
     protected void startCommand() {
         final OS os = OS.getOs();
 
@@ -83,11 +93,6 @@ public abstract class ServerBootstrap extends CmdLineTool {
         LOG.info("Deployment: {}", configuration.getInstallationSource());
         LOG.info("OS: {}", os.getPlatformName());
         LOG.info("Arch: {}", os.getArch());
-
-        // Do not use a PID file if the user requested not to
-        if (!isNoPidFile()) {
-            savePidFile(getPidFile());
-        }
 
         final ServerStatus serverStatus = injector.getInstance(ServerStatus.class);
         serverStatus.initialize();


### PR DESCRIPTION
The PID file of the Graylog server process is created rather late in the startup process (e. g. after the Guice injector has been created). If an error happened before but didn't shutdown the Graylog server process, the PID file might not have been created although the process keeps running which in turn might cause problems with external process monitors.

This PR moves the creation of the PID file to the earliest sensible moment in the startup process of Graylog.

Fixes #1969 
