### PR TITLE
Fix issues editing reader users profile

### DIFF
--- a/graylog2-server/src/test/java/org/graylog2/users/UserServiceImplTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/users/UserServiceImplTest.java
@@ -154,12 +154,12 @@ public class UserServiceImplTest {
 
         @Override
         public UserImpl create(Map<String, Object> fields) {
-            return new UserImpl(passwordAlgorithmFactory, fields);
+            return new UserImpl(passwordAlgorithmFactory, null, fields);
         }
 
         @Override
         public UserImpl create(ObjectId id, Map<String, Object> fields) {
-            return new UserImpl(passwordAlgorithmFactory, id, fields);
+            return new UserImpl(passwordAlgorithmFactory, null, id, fields);
         }
 
         @Override

--- a/graylog2-server/src/test/java/org/graylog2/users/UserServiceImplTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/users/UserServiceImplTest.java
@@ -68,6 +68,8 @@ public class UserServiceImplTest {
     private RoleService roleService;
     @Mock
     private InMemoryRolePermissionResolver permissionsResolver;
+    @Mock
+    private Permissions permissions;
 
     @Before
     public void setUp() throws Exception {
@@ -154,12 +156,12 @@ public class UserServiceImplTest {
 
         @Override
         public UserImpl create(Map<String, Object> fields) {
-            return new UserImpl(passwordAlgorithmFactory, null, fields);
+            return new UserImpl(passwordAlgorithmFactory, permissions, fields);
         }
 
         @Override
         public UserImpl create(ObjectId id, Map<String, Object> fields) {
-            return new UserImpl(passwordAlgorithmFactory, null, id, fields);
+            return new UserImpl(passwordAlgorithmFactory, permissions, id, fields);
         }
 
         @Override
@@ -206,8 +208,10 @@ public class UserServiceImplTest {
         user.setRoleIds(Sets.newHashSet(role.getId()));
         user.setPermissions(Lists.newArrayList("hello:world"));
 
-        when(permissionsResolver.resolveStringPermission(role.getId())).thenReturn(Sets.newHashSet("foo:bar"));
 
-        assertThat(userService.getPermissionsForUser(user)).containsOnly("foo:bar", "hello:world");
+        when(permissionsResolver.resolveStringPermission(role.getId())).thenReturn(Sets.newHashSet("foo:bar"));
+        when(permissions.userSelfEditPermissions(user.getName())).thenReturn(Sets.newHashSet("foo:baz"));
+
+        assertThat(userService.getPermissionsForUser(user)).containsOnly("foo:bar", "hello:world", "foo:baz");
     }
 }

--- a/graylog2-web-interface/src/components/users/UserForm.jsx
+++ b/graylog2-web-interface/src/components/users/UserForm.jsx
@@ -77,11 +77,11 @@ const UserForm = React.createClass({
   _updateUser(evt) {
     evt.preventDefault();
     const request = {};
-    ['full_name',
-      'email',
-      'session_timeout_ms',
-      'timezone'].forEach((field) => {
-        request[field] = this.refs[field].getValue();
+    ['full_name', 'email', 'session_timeout_ms', 'timezone']
+      .forEach((field) => {
+        if (this.refs[field]) {
+          request[field] = this.refs[field].getValue();
+        }
       });
     UsersStore.update(this.props.user.username, request).then(() => {
       UserNotification.success('User updated successfully.', 'Success!');


### PR DESCRIPTION
This PR takes care of fixing the problem described in #1984. Additionally, it also fixes an issue getting reader users own permissions, which made impossible for new reader users to edit their profiles or change their passwords.