### PR TITLE
Implement cluster metrics endpoint to fetch from all nodes

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/rest/resources/cluster/ClusterMetricsResource.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/resources/cluster/ClusterMetricsResource.java
@@ -23,28 +23,20 @@ import io.swagger.annotations.ApiParam;
 import io.swagger.annotations.ApiResponse;
 import io.swagger.annotations.ApiResponses;
 import org.apache.shiro.authz.annotation.RequiresAuthentication;
-import org.apache.shiro.authz.annotation.RequiresPermissions;
-import org.graylog2.cluster.Node;
 import org.graylog2.cluster.NodeNotFoundException;
 import org.graylog2.cluster.NodeService;
 import org.graylog2.rest.RemoteInterfaceProvider;
 import org.graylog2.rest.models.system.metrics.requests.MetricsReadRequest;
-import org.graylog2.rest.models.system.metrics.responses.MetricNamesResponse;
 import org.graylog2.rest.models.system.metrics.responses.MetricsSummaryResponse;
 import org.graylog2.shared.rest.resources.ProxiedResource;
 import org.graylog2.shared.rest.resources.system.RemoteMetricsResource;
-import org.graylog2.shared.security.RestPermissions;
-import retrofit2.Response;
 
 import javax.inject.Inject;
 import javax.validation.Valid;
 import javax.validation.constraints.NotNull;
-import javax.ws.rs.GET;
 import javax.ws.rs.POST;
 import javax.ws.rs.Path;
-import javax.ws.rs.PathParam;
 import javax.ws.rs.Produces;
-import javax.ws.rs.WebApplicationException;
 import javax.ws.rs.core.Context;
 import javax.ws.rs.core.HttpHeaders;
 import javax.ws.rs.core.MediaType;
@@ -52,13 +44,12 @@ import java.io.IOException;
 import java.util.Map;
 import java.util.Optional;
 
-import static javax.ws.rs.core.Response.Status.BAD_GATEWAY;
-
 @RequiresAuthentication
 @Api(value = "Cluster/Metrics", description = "Cluster-wide Internal Graylog metrics")
-@Path("/cluster")
+@Path("/cluster/metrics")
 @Produces(MediaType.APPLICATION_JSON)
 public class ClusterMetricsResource extends ProxiedResource {
+
     @Inject
     public ClusterMetricsResource(NodeService nodeService,
                                   RemoteInterfaceProvider remoteInterfaceProvider,
@@ -66,73 +57,15 @@ public class ClusterMetricsResource extends ProxiedResource {
         super(httpHeaders, nodeService, remoteInterfaceProvider);
     }
 
-    private RemoteMetricsResource getResourceForNode(String nodeId) throws NodeNotFoundException {
-        final Node targetNode = nodeService.byNodeId(nodeId);
-        return remoteInterfaceProvider.get(targetNode, this.authenticationToken, RemoteMetricsResource.class);
-    }
-
-    @GET
-    @Timed
-    @Path("/{nodeId}/metrics/names")
-    @ApiOperation(value = "Get all metrics keys/names from node")
-    @RequiresPermissions(RestPermissions.METRICS_ALLKEYS)
-    public MetricNamesResponse metricNames(@ApiParam(name = "nodeId", value = "The id of the node whose metrics we want.", required = true)
-                                           @PathParam("nodeId") String nodeId) throws IOException, NodeNotFoundException {
-        final Response<MetricNamesResponse> result = getResourceForNode(nodeId).metricNames().execute();
-        if (result.isSuccessful()) {
-            return result.body();
-        } else {
-            throw new WebApplicationException(result.message(), BAD_GATEWAY);
-        }
-    }
-
     @POST
     @Timed
-    @Path("/{nodeId}/metrics/multiple")
-    @ApiOperation("Get the values of multiple metrics at once from node")
-    @ApiResponses(value = {
-            @ApiResponse(code = 400, message = "Malformed body")
-    })
-    public MetricsSummaryResponse multipleMetrics(@ApiParam(name = "nodeId", value = "The id of the node whose metrics we want.", required = true)
-                                                  @PathParam("nodeId") String nodeId,
-                                                  @ApiParam(name = "Requested metrics", required = true)
-                                                  @Valid @NotNull MetricsReadRequest request) throws IOException, NodeNotFoundException {
-        final Response<MetricsSummaryResponse> result = getResourceForNode(nodeId).multipleMetrics(request).execute();
-        if (result.isSuccessful()) {
-            return result.body();
-        } else {
-            throw new WebApplicationException(result.message(), BAD_GATEWAY);
-        }
-    }
-
-    @GET
-    @Timed
-    @Path("/{nodeId}/metrics/namespace/{namespace}")
-    @ApiOperation(value = "Get all metrics of a namespace from node")
-    @ApiResponses(value = {
-            @ApiResponse(code = 404, message = "No such metric namespace")
-    })
-    public MetricsSummaryResponse byNamespace(@ApiParam(name = "nodeId", value = "The id of the node whose metrics we want.", required = true)
-                                              @PathParam("nodeId") String nodeId,
-                                              @ApiParam(name = "namespace", required = true)
-                                              @PathParam("namespace") String namespace) throws IOException, NodeNotFoundException {
-        final Response<MetricsSummaryResponse> result = getResourceForNode(nodeId).byNamespace(namespace).execute();
-        if (result.isSuccessful()) {
-            return result.body();
-        } else {
-            throw new WebApplicationException(result.message(), BAD_GATEWAY);
-        }
-    }
-
-    @POST
-    @Timed
-    @Path("/metrics/multiple")
+    @Path("/multiple")
     @ApiOperation(value = "Get all metrics of all nodes in the cluster")
     @ApiResponses(value = {
             @ApiResponse(code = 400, message = "Malformed body")
     })
     public Map<String, Optional<MetricsSummaryResponse>> multipleMetricsAllNodes(@ApiParam(name = "Requested metrics", required = true)
-                                                          @Valid @NotNull MetricsReadRequest request) throws IOException, NodeNotFoundException {
+                                                                                 @Valid @NotNull MetricsReadRequest request) throws IOException, NodeNotFoundException {
         return getForAllNodes(remoteMetricsResource -> remoteMetricsResource.multipleMetrics(request), createRemoteInterfaceProvider(RemoteMetricsResource.class));
     }
 }

--- a/graylog2-server/src/main/java/org/graylog2/rest/resources/cluster/ClusterNodeMetricsResource.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/resources/cluster/ClusterNodeMetricsResource.java
@@ -1,0 +1,124 @@
+/**
+ * This file is part of Graylog.
+ *
+ * Graylog is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.graylog2.rest.resources.cluster;
+
+import com.codahale.metrics.annotation.Timed;
+import io.swagger.annotations.Api;
+import io.swagger.annotations.ApiOperation;
+import io.swagger.annotations.ApiParam;
+import io.swagger.annotations.ApiResponse;
+import io.swagger.annotations.ApiResponses;
+import org.apache.shiro.authz.annotation.RequiresAuthentication;
+import org.apache.shiro.authz.annotation.RequiresPermissions;
+import org.graylog2.cluster.Node;
+import org.graylog2.cluster.NodeNotFoundException;
+import org.graylog2.cluster.NodeService;
+import org.graylog2.rest.RemoteInterfaceProvider;
+import org.graylog2.rest.models.system.metrics.requests.MetricsReadRequest;
+import org.graylog2.rest.models.system.metrics.responses.MetricNamesResponse;
+import org.graylog2.rest.models.system.metrics.responses.MetricsSummaryResponse;
+import org.graylog2.shared.rest.resources.ProxiedResource;
+import org.graylog2.shared.rest.resources.system.RemoteMetricsResource;
+import org.graylog2.shared.security.RestPermissions;
+import retrofit2.Response;
+
+import javax.inject.Inject;
+import javax.validation.Valid;
+import javax.validation.constraints.NotNull;
+import javax.ws.rs.GET;
+import javax.ws.rs.POST;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+import javax.ws.rs.Produces;
+import javax.ws.rs.WebApplicationException;
+import javax.ws.rs.core.Context;
+import javax.ws.rs.core.HttpHeaders;
+import javax.ws.rs.core.MediaType;
+import java.io.IOException;
+
+import static javax.ws.rs.core.Response.Status.BAD_GATEWAY;
+
+@RequiresAuthentication
+@Api(value = "Cluster/Node/Metrics", description = "Cluster-wide Internal Graylog node metrics")
+@Path("/cluster/{nodeId}/metrics")
+@Produces(MediaType.APPLICATION_JSON)
+public class ClusterNodeMetricsResource extends ProxiedResource {
+    @Inject
+    public ClusterNodeMetricsResource(NodeService nodeService,
+                                      RemoteInterfaceProvider remoteInterfaceProvider,
+                                      @Context HttpHeaders httpHeaders) {
+        super(httpHeaders, nodeService, remoteInterfaceProvider);
+    }
+
+    private RemoteMetricsResource getResourceForNode(String nodeId) throws NodeNotFoundException {
+        final Node targetNode = nodeService.byNodeId(nodeId);
+        return remoteInterfaceProvider.get(targetNode, this.authenticationToken, RemoteMetricsResource.class);
+    }
+
+    @GET
+    @Timed
+    @Path("/names")
+    @ApiOperation(value = "Get all metrics keys/names from node")
+    @RequiresPermissions(RestPermissions.METRICS_ALLKEYS)
+    public MetricNamesResponse metricNames(@ApiParam(name = "nodeId", value = "The id of the node whose metrics we want.", required = true)
+                                           @PathParam("nodeId") String nodeId) throws IOException, NodeNotFoundException {
+        final Response<MetricNamesResponse> result = getResourceForNode(nodeId).metricNames().execute();
+        if (result.isSuccessful()) {
+            return result.body();
+        } else {
+            throw new WebApplicationException(result.message(), BAD_GATEWAY);
+        }
+    }
+
+    @POST
+    @Timed
+    @Path("/multiple")
+    @ApiOperation("Get the values of multiple metrics at once from node")
+    @ApiResponses(value = {
+            @ApiResponse(code = 400, message = "Malformed body")
+    })
+    public MetricsSummaryResponse multipleMetrics(@ApiParam(name = "nodeId", value = "The id of the node whose metrics we want.", required = true)
+                                                  @PathParam("nodeId") String nodeId,
+                                                  @ApiParam(name = "Requested metrics", required = true)
+                                                  @Valid @NotNull MetricsReadRequest request) throws IOException, NodeNotFoundException {
+        final Response<MetricsSummaryResponse> result = getResourceForNode(nodeId).multipleMetrics(request).execute();
+        if (result.isSuccessful()) {
+            return result.body();
+        } else {
+            throw new WebApplicationException(result.message(), BAD_GATEWAY);
+        }
+    }
+
+    @GET
+    @Timed
+    @Path("/namespace/{namespace}")
+    @ApiOperation(value = "Get all metrics of a namespace from node")
+    @ApiResponses(value = {
+            @ApiResponse(code = 404, message = "No such metric namespace")
+    })
+    public MetricsSummaryResponse byNamespace(@ApiParam(name = "nodeId", value = "The id of the node whose metrics we want.", required = true)
+                                              @PathParam("nodeId") String nodeId,
+                                              @ApiParam(name = "namespace", required = true)
+                                              @PathParam("namespace") String namespace) throws IOException, NodeNotFoundException {
+        final Response<MetricsSummaryResponse> result = getResourceForNode(nodeId).byNamespace(namespace).execute();
+        if (result.isSuccessful()) {
+            return result.body();
+        } else {
+            throw new WebApplicationException(result.message(), BAD_GATEWAY);
+        }
+    }
+}

--- a/graylog2-web-interface/src/routing/ApiRoutes.js
+++ b/graylog2-web-interface/src/routing/ApiRoutes.js
@@ -94,6 +94,7 @@ const ApiRoutes = {
   },
   ClusterMetricsApiController: {
     multiple: (nodeId) => { return { url: `/cluster/${nodeId}/metrics/multiple` }; },
+    multipleAllNodes: () => { return { url: `/cluster/metrics/multiple` }; },
     byNamespace: (nodeId, namespace) => { return { url: `/cluster/${nodeId}/metrics/namespace/${namespace}` }; },
   },
   NotificationsApiController: {

--- a/graylog2-web-interface/src/stores/metrics/MetricsStore.js
+++ b/graylog2-web-interface/src/stores/metrics/MetricsStore.js
@@ -1,6 +1,5 @@
 import Reflux from 'reflux';
 
-import UserNotification from 'util/UserNotification';
 import URLUtils from 'util/URLUtils';
 import ApiRoutes from 'routing/ApiRoutes';
 import fetch from 'logic/rest/FetchProvider';
@@ -88,7 +87,7 @@ const MetricsStore = Reflux.createStore({
     const promise = this._allResults(Object.keys(this.nodes).map((nodeId) => {
       const url = URLUtils.qualifyUrl(ApiRoutes.ClusterMetricsApiController.byNamespace(nodeId, this.namespace).url);
       return fetch('GET', url).then((response) => {
-        return {nodeId: nodeId, names: response.metrics};
+        return { nodeId: nodeId, names: response.metrics };
       });
     })).then((responses) => {
       const metricsNames = {};
@@ -97,7 +96,7 @@ const MetricsStore = Reflux.createStore({
           metricsNames[response.nodeId] = response.names;
         }
       });
-      this.trigger({metricsNames: metricsNames});
+      this.trigger({ metricsNames: metricsNames });
       this.metricsNames = metricsNames;
       return metricsNames;
     });

--- a/graylog2-web-interface/src/stores/metrics/MetricsStore.js
+++ b/graylog2-web-interface/src/stores/metrics/MetricsStore.js
@@ -43,46 +43,41 @@ const MetricsStore = Reflux.createStore({
       return;
     }
     const metricsToFetch = {};
+
+    // First collect all node metric registrations
     Object.keys(this.registrations)
-      .filter((nodeId) => Object.keys(this.registrations[nodeId]).length > 0)
-      .forEach(nodeId => {
-        metricsToFetch[nodeId] = Object.keys(this.registrations[nodeId]).filter(metricName => this.registrations[nodeId][metricName] > 0);
-      });
-    const globalMetrics = Object.keys(this.globalRegistrations).filter(metricName => this.globalRegistrations[metricName] > 0);
-
-    if (this.nodes) {
-      Object.keys(this.nodes).forEach(nodeId => {
-        globalMetrics.forEach(metricName => {
-          if (!metricsToFetch[nodeId]) {
-            metricsToFetch[nodeId] = [];
-          }
-          if (metricsToFetch[nodeId].indexOf(metricName) == -1) {
-            metricsToFetch[nodeId].push(metricName);
-          }
-        });
-      });
-    }
-
-    const promises = Object.keys(metricsToFetch)
-      .map((nodeId) => {
-        const url = URLUtils.qualifyUrl(ApiRoutes.ClusterMetricsApiController.multiple(nodeId).url);
-        const body = {metrics: metricsToFetch[nodeId]};
-        return fetch('POST', url, body).then((response) => {
-          const metrics = {};
-          response.metrics.forEach((metric) => metrics[metric.full_name] = metric);
-          return {nodeId: nodeId, metrics: metrics};
-        });
+      .filter((nodeId) => Object.keys(this.registrations[nodeId].length > 0))
+      .forEach((nodeId) => {
+        Object.keys(this.registrations[nodeId])
+          .filter((metricName) => this.registrations[nodeId][metricName] > 0)
+          .forEach((metricName) => {
+            metricsToFetch[metricName] = 1;
+          });
       });
 
-    const promise = this._allResults(promises).then((responses) => {
+    // Then collect all global metric registrations
+    Object.keys(this.globalRegistrations)
+      .filter((metricName) => this.globalRegistrations[metricName] > 0)
+      .forEach((metricName) => {
+        metricsToFetch[metricName] = 1;
+      });
+
+    const url = URLUtils.qualifyUrl(ApiRoutes.ClusterMetricsApiController.multipleAllNodes().url);
+    const promise = fetch('POST', url, { metrics: Object.keys(metricsToFetch) });
+
+    promise.then((response) => {
       const metrics = {};
-      responses.forEach((response) => {
-        if (response.nodeId) {
-          metrics[response.nodeId] = response.metrics;
-        }
-      });
+      Object.keys(response)
+        .forEach((nodeId) => {
+          const nodeMetrics = {};
 
-      this.trigger({metrics: metrics});
+          response[nodeId].metrics.forEach((metric) => {
+            nodeMetrics[metric.full_name] = metric;
+          });
+
+          metrics[nodeId] = nodeMetrics;
+        });
+      this.trigger({ metrics: metrics });
       this.metrics = metrics;
       return metrics;
     });


### PR DESCRIPTION
Adjust frontend MetricsStore to use the new endpoint. Saves `nodes - 1` requests in a multi node setup.

Fixes #1974