### PR TITLE
Allow RawMessage's payload to be empty (but not null)

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/plugin/inputs/transports/NettyTransport.java
+++ b/graylog2-server/src/main/java/org/graylog2/plugin/inputs/transports/NettyTransport.java
@@ -191,10 +191,22 @@ public abstract class NettyTransport implements Transport {
             @Override
             public ChannelHandler call() throws Exception {
                 return new SimpleChannelUpstreamHandler() {
+                    @SuppressWarnings("ThrowableResultOfMethodCallIgnored")
                     @Override
                     public void exceptionCaught(ChannelHandlerContext ctx, ExceptionEvent e) throws Exception {
-                        log.error("Error on Input [" + input.getName() + "/" + input.getId() + "] (channel "
-                                + e.getChannel().toString() + ")", e.getCause());
+                        if ("Connection reset by peer".equals(e.getCause().getMessage())) {
+                            log.trace("{} in Input [{}/{}] (channel {})",
+                                      e.getCause().getMessage(),
+                                      input.getName(),
+                                      input.getId(),
+                                      e.getChannel());
+                        } else {
+                            log.error("Error in Input [{}/{}] (channel {})",
+                                      input.getName(),
+                                      input.getId(),
+                                      e.getChannel(),
+                                      e.getCause());
+                        }
                         super.exceptionCaught(ctx, e);
                     }
                 };

--- a/graylog2-server/src/main/java/org/graylog2/plugin/journal/RawMessage.java
+++ b/graylog2-server/src/main/java/org/graylog2/plugin/journal/RawMessage.java
@@ -30,6 +30,7 @@ import org.joda.time.DateTimeZone;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import java.io.IOException;
 import java.io.Serializable;
@@ -68,26 +69,31 @@ public class RawMessage implements Serializable {
     private final long journalOffset;
     private Configuration codecConfig;
 
-    public RawMessage(byte[] payload) {
+    public RawMessage(@Nonnull byte[] payload) {
         this(payload, (ResolvableInetSocketAddress)null);
     }
 
-    public RawMessage(byte[] payload, InetSocketAddress remoteAddress) {
+    public RawMessage(@Nonnull byte[] payload, @Nullable InetSocketAddress remoteAddress) {
         this(Long.MIN_VALUE, new UUID(), Tools.nowUTC(), ResolvableInetSocketAddress.wrap(remoteAddress), payload);
     }
 
-    public RawMessage(byte[] payload, ResolvableInetSocketAddress remoteAddress) {
+    public RawMessage(@Nonnull byte[] payload, @Nullable ResolvableInetSocketAddress remoteAddress) {
         this(Long.MIN_VALUE, new UUID(), Tools.nowUTC(), remoteAddress, payload);
     }
 
     public RawMessage(long journalOffset,
-                      UUID id,
+                      @Nonnull UUID id,
                       DateTime timestamp,
-                      ResolvableInetSocketAddress remoteAddress,
-                      byte[] payload) {
+                      @Nullable ResolvableInetSocketAddress remoteAddress,
+                      @Nonnull byte[] payload) {
         checkNotNull(id, "The message id must not be null!");
         checkNotNull(payload, "The message payload must not be null!");
-        checkArgument(payload.length > 0, "The message payload must not be empty!");
+        if (payload.length == 0 && log.isTraceEnabled()) {
+            log.trace("The message payload should not be empty, message {} from {} will be discarded.",
+                      id,
+                      remoteAddress == null ? "unknown" : remoteAddress,
+                      new Throwable());
+        }
 
         msgBuilder = JournalMessage.newBuilder();
 

--- a/graylog2-server/src/test/java/org/graylog2/inputs/codecs/GelfCodecTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/inputs/codecs/GelfCodecTest.java
@@ -45,8 +45,9 @@ public class GelfCodecTest {
         codec = new GelfCodec(new Configuration(Collections.emptyMap()), aggregator);
     }
 
-    @Test(expected = IllegalArgumentException.class)
-    public void decodeThrowsIllegalArgumentExceptionIfJsonIsInvalid() throws Exception {
+    @Test(expected = IllegalStateException.class)
+    public void decodeDoesNotThrowIllegalArgumentExceptionIfJsonIsInvalid() throws Exception {
+        // this fails gelf parsing, but empty Payloads are now ok.
         final RawMessage rawMessage = new RawMessage(new byte[0]);
         codec.decode(rawMessage);
     }

--- a/graylog2-web-interface/src/components/inputs/InputThroughput.jsx
+++ b/graylog2-web-interface/src/components/inputs/InputThroughput.jsx
@@ -29,6 +29,7 @@ const InputThroughput = React.createClass({
   _metricNames() {
     return [
       this._prefix('incomingMessages'),
+      this._prefix('emptyMessages'),
       this._prefix('open_connections'),
       this._prefix('total_connections'),
       this._prefix('written_bytes_1sec'),
@@ -51,6 +52,8 @@ const InputThroughput = React.createClass({
         return metric.metric.rate.mean;
       case 'gauge':
         return metric.metric.value;
+      case 'counter':
+        return metric.metric.count;
       default:
         return undefined;
     }
@@ -130,6 +133,7 @@ const InputThroughput = React.createClass({
   _formatNodeDetails(nodeId, metrics) {
     const openConnections = this._getValueFromMetric(metrics[this._prefix('open_connections')]);
     const totalConnections = this._getValueFromMetric(metrics[this._prefix('total_connections')]);
+    const emptyMessages = this._getValueFromMetric(metrics[this._prefix('emptyMessages')]);
     const writtenBytes1Sec = this._getValueFromMetric(metrics[this._prefix('written_bytes_1sec')]);
     const writtenBytesTotal = this._getValueFromMetric(metrics[this._prefix('written_bytes_total')]);
     const readBytes1Sec = this._getValueFromMetric(metrics[this._prefix('read_bytes_1sec')]);
@@ -142,6 +146,7 @@ const InputThroughput = React.createClass({
         <br/>
         {!isNaN(writtenBytes1Sec) && this._formatNetworkStats(writtenBytes1Sec, writtenBytesTotal, readBytes1Sec, readBytesTotal)}
         {!isNaN(openConnections) && this._formatConnections(openConnections, totalConnections)}
+        {!isNaN(emptyMessages) && <span>Empty messages discarded: {this._formatCount(emptyMessages)}<br/></span>}
         {isNaN(writtenBytes1Sec) && isNaN(openConnections) && <span>No metrics available for this node</span>}
         <br/>
       </span>
@@ -157,6 +162,7 @@ const InputThroughput = React.createClass({
     }
     const metrics = this._calculateMetrics(this.state.metrics);
     const incomingMessages = metrics[this._prefix('incomingMessages')];
+    const emptyMessages = metrics[this._prefix('emptyMessages')];
     const openConnections = metrics[this._prefix('open_connections')];
     const totalConnections = metrics[this._prefix('total_connections')];
     const writtenBytes1Sec = metrics[this._prefix('written_bytes_1sec')];
@@ -171,6 +177,7 @@ const InputThroughput = React.createClass({
           {!isNaN(incomingMessages) && <span>1 minute average rate: {this._formatCount(incomingMessages)} msg/s<br/></span>}
           {!isNaN(writtenBytes1Sec) && this._formatNetworkStats(writtenBytes1Sec, writtenBytesTotal, readBytes1Sec, readBytesTotal)}
           {!isNaN(openConnections) && this._formatConnections(openConnections, totalConnections)}
+          {!isNaN(emptyMessages) && <span>Empty messages discarded: {this._formatCount(emptyMessages)}<br/></span>}
           {!isNaN(writtenBytes1Sec) && this.props.input.global && <a href="" onClick={this._toggleShowDetails}>{this.state.showDetails ? 'Hide' : 'Show'} details</a>}
           {!isNaN(writtenBytes1Sec) && this.state.showDetails && this._formatAllNodeDetails(this.state.metrics)}
         </span>


### PR DESCRIPTION
RawMessage previously threw an exception when the payload was empty during construction. This lead to errors in the call sites, which, depending on the input, could cause connections and/or threads to be closed, e.g. the Kafka consumer would be shut down.

With this change we accept empty payloads, but discard them before inserting them into the input buffer. Since this happens in a central place we should cover all available inputs.
We also track the number of discarded empty messages and show this with each input next to the throughput metrics. Empty payloads usually indicate a sender error but can be safely ignored for now. Discarded messages do not count towards the local or global incoming messages as they are discarded before being journaled and processed by Graylog.

 This change also improved the exception logging in the NettyTransport, where we now are way less verbose when faced with a "Connection reset by peer". We don't currently write significant information back to the client so we don't need to log the entire (meaningless) stacktrace here. The information is still available on TRACE.

fix #1584
fix #1546 