### PR TITLE
Add Expect: 100-Continue support to HTTP input

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/inputs/transports/HttpTransport.java
+++ b/graylog2-server/src/main/java/org/graylog2/inputs/transports/HttpTransport.java
@@ -45,6 +45,7 @@ import org.jboss.netty.channel.ChannelHandlerContext;
 import org.jboss.netty.channel.MessageEvent;
 import org.jboss.netty.channel.SimpleChannelHandler;
 import org.jboss.netty.handler.codec.http.DefaultHttpResponse;
+import org.jboss.netty.handler.codec.http.HttpChunkAggregator;
 import org.jboss.netty.handler.codec.http.HttpContentDecompressor;
 import org.jboss.netty.handler.codec.http.HttpMethod;
 import org.jboss.netty.handler.codec.http.HttpRequest;
@@ -117,6 +118,12 @@ public class HttpTransport extends AbstractTcpTransport {
             @Override
             public ChannelHandler call() throws Exception {
                 return new HttpRequestDecoder(DEFAULT_MAX_INITIAL_LINE_LENGTH, DEFAULT_MAX_HEADER_SIZE, maxChunkSize);
+            }
+        });
+        baseChannelHandlers.put("aggregator", new Callable<ChannelHandler>() {
+            @Override
+            public ChannelHandler call() throws Exception {
+                return new HttpChunkAggregator(maxChunkSize);
             }
         });
         baseChannelHandlers.put("encoder", new Callable<ChannelHandler>() {


### PR DESCRIPTION
Previously the input blindly answered with 202 Accepted but instead it should properly support the Expect header.
Failing to respond correctly resulted in loss of messages because the client's expectation was broken.

Adding a HttpChunkAggregator fixes the issue while still allowing non-chunked requests to be sent.

fix #1939