### PR TITLE
Fix date time JSON parsing

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/plugin/indexer/searches/timeranges/AbsoluteRange.java
+++ b/graylog2-server/src/main/java/org/graylog2/plugin/indexer/searches/timeranges/AbsoluteRange.java
@@ -23,6 +23,7 @@ import com.google.auto.value.AutoValue;
 import com.google.common.collect.ImmutableMap;
 import org.graylog2.plugin.Tools;
 import org.joda.time.DateTime;
+import org.joda.time.format.DateTimeFormatter;
 import org.joda.time.format.ISODateTimeFormat;
 
 import java.util.Map;
@@ -108,13 +109,14 @@ public abstract class AbsoluteRange extends TimeRange {
         }
 
         private DateTime parseDateTime(String to) {
-            DateTime ts;
+            final DateTimeFormatter formatter;
             if (to.contains("T")) {
-                ts = DateTime.parse(to, ISODateTimeFormat.dateTime());
+                formatter = ISODateTimeFormat.dateTime();
             } else {
-                ts = DateTime.parse(to, Tools.timeFormatterWithOptionalMilliseconds());
+                formatter = Tools.timeFormatterWithOptionalMilliseconds();
             }
-            return ts;
+            // Use withOffsetParsed() to keep the timezone!
+            return formatter.withOffsetParsed().parseDateTime(to);
         }
     }
 }

--- a/graylog2-server/src/main/java/org/graylog2/shared/bindings/providers/ObjectMapperProvider.java
+++ b/graylog2-server/src/main/java/org/graylog2/shared/bindings/providers/ObjectMapperProvider.java
@@ -17,6 +17,7 @@
 package org.graylog2.shared.bindings.providers;
 
 import com.codahale.metrics.json.MetricsModule;
+import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.PropertyNamingStrategy;
 import com.fasterxml.jackson.databind.SerializationFeature;
@@ -53,6 +54,7 @@ public class ObjectMapperProvider implements Provider<ObjectMapper> {
 
         this.objectMapper = mapper
                 .disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS)
+                .disable(DeserializationFeature.ADJUST_DATES_TO_CONTEXT_TIME_ZONE)
                 .setPropertyNamingStrategy(new PropertyNamingStrategy.LowerCaseWithUnderscoresStrategy())
                 .setTypeFactory(typeFactory)
                 .registerModule(new GuavaModule())

--- a/graylog2-server/src/test/java/org/graylog2/indexer/searches/SearchesTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/indexer/searches/SearchesTest.java
@@ -40,7 +40,6 @@ import org.graylog2.indexer.results.TermsResult;
 import org.graylog2.indexer.results.TermsStatsResult;
 import org.graylog2.plugin.indexer.searches.timeranges.AbsoluteRange;
 import org.joda.time.DateTime;
-import org.joda.time.DateTimeZone;
 import org.junit.Before;
 import org.junit.ClassRule;
 import org.junit.Rule;
@@ -57,6 +56,7 @@ import java.util.SortedSet;
 import static com.github.joschi.nosqlunit.elasticsearch2.ElasticsearchRule.ElasticsearchRuleBuilder.newElasticsearchRule;
 import static com.github.joschi.nosqlunit.elasticsearch2.EmbeddedElasticsearch.EmbeddedElasticsearchRuleBuilder.newEmbeddedElasticsearchRule;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.joda.time.DateTimeZone.UTC;
 import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.when;
 
@@ -81,12 +81,12 @@ public class SearchesTest {
 
                 @Override
                 public DateTime calculatedAt() {
-                    return DateTime.now(DateTimeZone.UTC);
+                    return DateTime.now(UTC);
                 }
 
                 @Override
                 public DateTime end() {
-                    return new DateTime(2015, 1, 1, 0, 0, DateTimeZone.UTC);
+                    return new DateTime(2015, 1, 1, 0, 0, UTC);
                 }
 
                 @Override
@@ -96,7 +96,7 @@ public class SearchesTest {
 
                 @Override
                 public DateTime begin() {
-                    return new DateTime(0L, DateTimeZone.UTC);
+                    return new DateTime(0L, UTC);
                 }
             }).build();
 
@@ -177,14 +177,14 @@ public class SearchesTest {
         final SortedSet<IndexRange> indexRanges = ImmutableSortedSet
                 .orderedBy(IndexRange.COMPARATOR)
                 .add(MongoIndexRange.create(INDEX_NAME,
-                        new DateTime(0L, DateTimeZone.UTC),
-                        new DateTime(2015, 1, 1, 0, 0, DateTimeZone.UTC),
-                        DateTime.now(DateTimeZone.UTC),
+                        new DateTime(0L, UTC),
+                        new DateTime(2015, 1, 1, 0, 0, UTC),
+                        DateTime.now(UTC),
                         0))
                 .add(MongoIndexRange.create("does-not-exist",
-                        new DateTime(0L, DateTimeZone.UTC),
-                        new DateTime(2015, 1, 1, 0, 0, DateTimeZone.UTC),
-                        DateTime.now(DateTimeZone.UTC),
+                        new DateTime(0L, UTC),
+                        new DateTime(2015, 1, 1, 0, 0, UTC),
+                        DateTime.now(UTC),
                         0))
                 .build();
         when(indexRangeService.find(any(DateTime.class), any(DateTime.class))).thenReturn(indexRanges);
@@ -296,18 +296,18 @@ public class SearchesTest {
     @UsingDataSet(loadStrategy = LoadStrategyEnum.CLEAN_INSERT)
     @SuppressWarnings("unchecked")
     public void testHistogram() throws Exception {
-        final AbsoluteRange range = AbsoluteRange.create(new DateTime(2015, 1, 1, 0, 0), new DateTime(2015, 1, 2, 0, 0));
+        final AbsoluteRange range = AbsoluteRange.create(new DateTime(2015, 1, 1, 0, 0).withZone(UTC), new DateTime(2015, 1, 2, 0, 0).withZone(UTC));
         HistogramResult h = searches.histogram("*", Searches.DateHistogramInterval.HOUR, range);
 
         assertThat(h.getInterval()).isEqualTo(Searches.DateHistogramInterval.HOUR);
         assertThat(h.getHistogramBoundaries()).isEqualTo(range);
         assertThat(h.getResults())
                 .hasSize(5)
-                .containsEntry(new DateTime(2015, 1, 1, 1, 0, DateTimeZone.UTC).getMillis() / 1000L, 2L)
-                .containsEntry(new DateTime(2015, 1, 1, 2, 0, DateTimeZone.UTC).getMillis() / 1000L, 2L)
-                .containsEntry(new DateTime(2015, 1, 1, 3, 0, DateTimeZone.UTC).getMillis() / 1000L, 2L)
-                .containsEntry(new DateTime(2015, 1, 1, 4, 0, DateTimeZone.UTC).getMillis() / 1000L, 2L)
-                .containsEntry(new DateTime(2015, 1, 1, 5, 0, DateTimeZone.UTC).getMillis() / 1000L, 2L);
+                .containsEntry(new DateTime(2015, 1, 1, 1, 0, UTC).getMillis() / 1000L, 2L)
+                .containsEntry(new DateTime(2015, 1, 1, 2, 0, UTC).getMillis() / 1000L, 2L)
+                .containsEntry(new DateTime(2015, 1, 1, 3, 0, UTC).getMillis() / 1000L, 2L)
+                .containsEntry(new DateTime(2015, 1, 1, 4, 0, UTC).getMillis() / 1000L, 2L)
+                .containsEntry(new DateTime(2015, 1, 1, 5, 0, UTC).getMillis() / 1000L, 2L);
     }
 
     @Test
@@ -317,30 +317,30 @@ public class SearchesTest {
         final SortedSet<IndexRange> indexRanges = ImmutableSortedSet
                 .orderedBy(IndexRange.COMPARATOR)
                 .add(MongoIndexRange.create(INDEX_NAME,
-                        new DateTime(0L, DateTimeZone.UTC),
-                        new DateTime(2015, 1, 1, 0, 0, DateTimeZone.UTC),
-                        DateTime.now(DateTimeZone.UTC),
+                        new DateTime(0L, UTC),
+                        new DateTime(2015, 1, 1, 0, 0, UTC),
+                        DateTime.now(UTC),
                         0))
                 .add(MongoIndexRange.create("does-not-exist",
-                        new DateTime(0L, DateTimeZone.UTC),
-                        new DateTime(2015, 1, 1, 0, 0, DateTimeZone.UTC),
-                        DateTime.now(DateTimeZone.UTC),
+                        new DateTime(0L, UTC),
+                        new DateTime(2015, 1, 1, 0, 0, UTC),
+                        DateTime.now(UTC),
                         0))
                 .build();
         when(indexRangeService.find(any(DateTime.class), any(DateTime.class))).thenReturn(indexRanges);
 
-        final AbsoluteRange range = AbsoluteRange.create(new DateTime(2015, 1, 1, 0, 0), new DateTime(2015, 1, 2, 0, 0));
+        final AbsoluteRange range = AbsoluteRange.create(new DateTime(2015, 1, 1, 0, 0).withZone(UTC), new DateTime(2015, 1, 2, 0, 0).withZone(UTC));
         HistogramResult h = searches.histogram("*", Searches.DateHistogramInterval.HOUR, range);
 
         assertThat(h.getInterval()).isEqualTo(Searches.DateHistogramInterval.HOUR);
         assertThat(h.getHistogramBoundaries()).isEqualTo(range);
         assertThat(h.getResults())
                 .hasSize(5)
-                .containsEntry(new DateTime(2015, 1, 1, 1, 0, DateTimeZone.UTC).getMillis() / 1000L, 2L)
-                .containsEntry(new DateTime(2015, 1, 1, 2, 0, DateTimeZone.UTC).getMillis() / 1000L, 2L)
-                .containsEntry(new DateTime(2015, 1, 1, 3, 0, DateTimeZone.UTC).getMillis() / 1000L, 2L)
-                .containsEntry(new DateTime(2015, 1, 1, 4, 0, DateTimeZone.UTC).getMillis() / 1000L, 2L)
-                .containsEntry(new DateTime(2015, 1, 1, 5, 0, DateTimeZone.UTC).getMillis() / 1000L, 2L);
+                .containsEntry(new DateTime(2015, 1, 1, 1, 0, UTC).getMillis() / 1000L, 2L)
+                .containsEntry(new DateTime(2015, 1, 1, 2, 0, UTC).getMillis() / 1000L, 2L)
+                .containsEntry(new DateTime(2015, 1, 1, 3, 0, UTC).getMillis() / 1000L, 2L)
+                .containsEntry(new DateTime(2015, 1, 1, 4, 0, UTC).getMillis() / 1000L, 2L)
+                .containsEntry(new DateTime(2015, 1, 1, 5, 0, UTC).getMillis() / 1000L, 2L);
     }
 
     @Test
@@ -365,16 +365,16 @@ public class SearchesTest {
     @UsingDataSet(loadStrategy = LoadStrategyEnum.CLEAN_INSERT)
     @SuppressWarnings("unchecked")
     public void testFieldHistogram() throws Exception {
-        final AbsoluteRange range = AbsoluteRange.create(new DateTime(2015, 1, 1, 0, 0), new DateTime(2015, 1, 2, 0, 0));
+        final AbsoluteRange range = AbsoluteRange.create(new DateTime(2015, 1, 1, 0, 0).withZone(UTC), new DateTime(2015, 1, 2, 0, 0).withZone(UTC));
         HistogramResult h = searches.fieldHistogram("*", "n", Searches.DateHistogramInterval.HOUR, null, range, false);
 
         assertThat(h.getInterval()).isEqualTo(Searches.DateHistogramInterval.HOUR);
         assertThat(h.getHistogramBoundaries()).isEqualTo(range);
         assertThat(h.getResults()).hasSize(5);
-        assertThat((Map<String, Number>) h.getResults().get(new DateTime(2015, 1, 1, 1, 0, DateTimeZone.UTC).getMillis() / 1000L))
+        assertThat((Map<String, Number>) h.getResults().get(new DateTime(2015, 1, 1, 1, 0, UTC).getMillis() / 1000L))
                 .containsEntry("total_count", 2L)
                 .containsEntry("total", 0.0);
-        assertThat((Map<String, Number>) h.getResults().get(new DateTime(2015, 1, 1, 2, 0, DateTimeZone.UTC).getMillis() / 1000L))
+        assertThat((Map<String, Number>) h.getResults().get(new DateTime(2015, 1, 1, 2, 0, UTC).getMillis() / 1000L))
                 .containsEntry("total_count", 2L)
                 .containsEntry("total", 4.0)
                 .containsEntry("mean", 2.0);

--- a/graylog2-server/src/test/java/org/graylog2/plugin/indexer/searches/timeranges/AbsoluteRangeTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/plugin/indexer/searches/timeranges/AbsoluteRangeTest.java
@@ -1,0 +1,42 @@
+/**
+ * This file is part of Graylog.
+ *
+ * Graylog is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.graylog2.plugin.indexer.searches.timeranges;
+
+import org.joda.time.format.ISODateTimeFormat;
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class AbsoluteRangeTest {
+    @Test
+    public void testStringParse() throws Exception {
+        final AbsoluteRange range1 = AbsoluteRange.create("2016-03-24T00:00:00.000Z", "2016-03-24T23:59:59.000Z");
+
+        assertThat(range1.from().toString(ISODateTimeFormat.dateTime()))
+                .isEqualTo("2016-03-24T00:00:00.000Z");
+        assertThat(range1.to().toString(ISODateTimeFormat.dateTime()))
+                .isEqualTo("2016-03-24T23:59:59.000Z");
+
+        final AbsoluteRange range2 = AbsoluteRange.create("2016-03-24T00:00:00.000+09:00", "2016-03-24T23:59:59.000+09:00");
+
+        // Check that time zone is kept while parsing.
+        assertThat(range2.from().toString(ISODateTimeFormat.dateTime()))
+                .isEqualTo("2016-03-24T00:00:00.000+09:00");
+        assertThat(range2.to().toString(ISODateTimeFormat.dateTime()))
+                .isEqualTo("2016-03-24T23:59:59.000+09:00");
+    }
+}


### PR DESCRIPTION
1. Disables the `ADJUST_DATES_TO_CONTEXT_TIME_ZONE` setting for the jackson `ObjectMapper`.
2. Fixes `AbsoluteRange#parseDateTime()` to not lose time zone information.

See commit messages for details.