### PR TITLE
Update single permissions in user edit form

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/rest/resources/users/UsersResource.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/resources/users/UsersResource.java
@@ -229,7 +229,7 @@ public class UsersResource extends RestResource {
         }
         final boolean permitted = isPermitted(USERS_PERMISSIONSEDIT, user.getName());
         if (permitted && cr.permissions() != null) {
-            user.setPermissions(cr.permissions());
+            user.setPermissions(getEffectiveUserPermissions(user, cr.permissions()));
         }
 
         if (isPermitted(USERS_ROLESEDIT, user.getName())) {
@@ -294,7 +294,7 @@ public class UsersResource extends RestResource {
             throw new NotFoundException();
         }
 
-        user.setPermissions(permissionRequest.permissions());
+        user.setPermissions(getEffectiveUserPermissions(user, permissionRequest.permissions()));
         userService.save(user);
     }
 
@@ -482,5 +482,12 @@ public class UsersResource extends RestResource {
                 user.getStartpage(),
                 roleNames
         );
+    }
+
+    // Filter the permissions granted by roles from the permissions list
+    private List<String> getEffectiveUserPermissions(final User user, final List<String> permissions) {
+        final List<String> effectivePermissions = Lists.newArrayList(permissions);
+        effectivePermissions.removeAll(userService.getUserPermissionsFromRoles(user));
+        return effectivePermissions;
     }
 }

--- a/graylog2-server/src/main/java/org/graylog2/shared/users/UserService.java
+++ b/graylog2-server/src/main/java/org/graylog2/shared/users/UserService.java
@@ -48,5 +48,7 @@ public interface UserService extends PersistedService {
 
     List<String> getPermissionsForUser(User user);
 
+    Set<String> getUserPermissionsFromRoles(User user);
+
     void dissociateAllUsersFromRole(Role role);
 }

--- a/graylog2-server/src/main/java/org/graylog2/users/UserImpl.java
+++ b/graylog2-server/src/main/java/org/graylog2/users/UserImpl.java
@@ -170,6 +170,8 @@ public class UserImpl extends PersistedImpl implements User {
 
     @Override
     public void setPermissions(final List<String> permissions) {
+        // Do not store the dynamic user self edit permissions
+        permissions.removeAll(this.permissions.userSelfEditPermissions(getName()));
         fields.put(PERMISSIONS, permissions);
     }
 

--- a/graylog2-server/src/main/java/org/graylog2/users/UserServiceImpl.java
+++ b/graylog2-server/src/main/java/org/graylog2/users/UserServiceImpl.java
@@ -298,13 +298,22 @@ public class UserServiceImpl extends PersistedServiceImpl implements UserService
 
     @Override
     public List<String> getPermissionsForUser(User user) {
-        final ImmutableSet.Builder<String> permSet = ImmutableSet.<String>builder().addAll(user.getPermissions());
+        final ImmutableSet.Builder<String> permSet = ImmutableSet.<String>builder()
+                .addAll(user.getPermissions())
+                .addAll(getUserPermissionsFromRoles(user));
+
+        return permSet.build().asList();
+    }
+
+    @Override
+    public Set<String> getUserPermissionsFromRoles(User user) {
+        final ImmutableSet.Builder<String> permSet = ImmutableSet.builder();
 
         for (String roleId : user.getRoleIds()) {
             permSet.addAll(inMemoryRolePermissionResolver.resolveStringPermission(roleId));
         }
 
-        return permSet.build().asList();
+        return permSet.build();
     }
 
     @Override

--- a/graylog2-web-interface/src/components/common/TimezoneSelect.jsx
+++ b/graylog2-web-interface/src/components/common/TimezoneSelect.jsx
@@ -44,7 +44,7 @@ const TimezoneSelect = React.createClass({
     const timezones = this._formatTimezones();
     return (
       <Select ref="timezone" {...this.props}
-              placeholder="Pick your time zone"
+              placeholder="Pick a time zone"
               options={timezones}
               optionRenderer={this._renderOption}/>
     );

--- a/graylog2-web-interface/src/components/common/TimezoneSelect.jsx
+++ b/graylog2-web-interface/src/components/common/TimezoneSelect.jsx
@@ -5,6 +5,10 @@ import jQuery from 'jquery';
 import Select from 'components/common/Select';
 
 const TimezoneSelect = React.createClass({
+  propTypes: {
+    onChange: React.PropTypes.func,
+  },
+
   getValue() {
     return this.refs.timezone.getValue();
   },

--- a/graylog2-web-interface/src/components/users/EditRolesForm.jsx
+++ b/graylog2-web-interface/src/components/users/EditRolesForm.jsx
@@ -73,7 +73,7 @@ const EditRolesForm = React.createClass({
     );
     return (
       <Row className="content">
-        <Col lg={8}>
+        <Col md={8}>
           <h2>Change user role</h2>
           {editUserForm}
         </Col>

--- a/graylog2-web-interface/src/components/users/NewUserForm.jsx
+++ b/graylog2-web-interface/src/components/users/NewUserForm.jsx
@@ -101,7 +101,7 @@ const NewUserForm = React.createClass({
 
         <TimeoutInput ref="session_timeout_ms" />
 
-        <Input label="Time Zone" help="Choose your local time zone or leave it as it is to use the system's default."
+        <Input label="Time Zone" help="Choose the timezone to use to display times, or leave it as it is to use the system's default."
                labelClassName="col-sm-2" wrapperClassName="col-sm-10">
           <TimezoneSelect ref="timezone" className="timezone-select" />
         </Input>

--- a/graylog2-web-interface/src/components/users/TimeoutInput.jsx
+++ b/graylog2-web-interface/src/components/users/TimeoutInput.jsx
@@ -8,7 +8,9 @@ const TimeoutInput = React.createClass({
     controlSize: React.PropTypes.number,
     labelSize: React.PropTypes.number,
     value: React.PropTypes.number,
+    onChange: React.PropTypes.func,
   },
+
   getDefaultProps() {
     return {
       value: 60 * 60 * 1000,
@@ -54,13 +56,18 @@ const TimeoutInput = React.createClass({
     return this.MS_SECOND;
   },
   _onClick(evt) {
-    this.setState({ sessionTimeoutNever: evt.target.checked });
+    this.setState({ sessionTimeoutNever: evt.target.checked }, this._notifyChange);
   },
   _onChangeValue(evt) {
-    this.setState({ value: evt.target.value });
+    this.setState({ value: evt.target.value }, this._notifyChange);
   },
   _onChangeUnit(evt) {
-    this.setState({ unit: evt.target.value });
+    this.setState({ unit: evt.target.value }, this._notifyChange);
+  },
+  _notifyChange() {
+    if (typeof this.props.onChange === 'function') {
+      this.props.onChange(this.getValue());
+    }
   },
   render() {
     return (

--- a/graylog2-web-interface/src/pages/EditUsersPage.jsx
+++ b/graylog2-web-interface/src/pages/EditUsersPage.jsx
@@ -21,10 +21,17 @@ const EditUsersPage = React.createClass({
     };
   },
   componentDidMount() {
-    this._loadUser();
+    this._loadUser(this.props.params.username);
   },
-  _loadUser() {
-    UsersStore.load(this.props.params.username).then((user) => {
+
+  componentWillReceiveProps(nextProps) {
+    if (this.props.params.username !== nextProps.params.username) {
+      this._loadUser(nextProps.params.username);
+    }
+  },
+
+  _loadUser(username) {
+    UsersStore.load(username).then((user) => {
       this.setState({ user: user });
     });
   },


### PR DESCRIPTION
This PR takes care of submitting and storing single stream/dashboard permissions for users (#1989). It also takes care of properly refreshing the user, fixing #2000.