### PR TITLE
Update extractor example when message is loaded

### DIFF
--- a/graylog2-web-interface/src/components/extractors/EditExtractor.jsx
+++ b/graylog2-web-interface/src/components/extractors/EditExtractor.jsx
@@ -26,8 +26,20 @@ const EditExtractor = React.createClass({
     return {
       updatedExtractor: this.props.extractor,
       conditionTestResult: undefined,
+      exampleMessage: this.props.exampleMessage,
     };
   },
+
+  componentWillReceiveProps(nextProps) {
+    if (this.props.exampleMessage !== nextProps.exampleMessage) {
+      this._updateExampleMessage(nextProps.exampleMessage);
+    }
+  },
+
+  _updateExampleMessage(nextExample) {
+    this.setState({ exampleMessage: nextExample });
+  },
+
   // Ensures the target field only contains alphanumeric characters and underscores
   _onTargetFieldChange(event) {
     const value = event.target.value;
@@ -76,11 +88,11 @@ const EditExtractor = React.createClass({
     this.setState({updatedExtractor: updatedExtractor});
   },
   _testCondition() {
-    const promise = ToolsStore.testRegex(this.state.updatedExtractor.condition_value, this.props.exampleMessage);
+    const promise = ToolsStore.testRegex(this.state.updatedExtractor.condition_value, this.state.exampleMessage);
     promise.then(result => this.setState({conditionTestResult: result.matched}));
   },
   _tryButtonDisabled() {
-    return this.state.updatedExtractor.condition_value === '' || !this.props.exampleMessage;
+    return this.state.updatedExtractor.condition_value === '' || !this.state.exampleMessage;
   },
   _getExtractorConditionControls() {
     if (!this.state.updatedExtractor.condition_type || this.state.updatedExtractor.condition_type === 'none') {
@@ -162,7 +174,8 @@ const EditExtractor = React.createClass({
             <Row style={{marginTop: 5}}>
               <Col md={12}>
                 <ExtractorExampleMessage field={this.state.updatedExtractor.source_field}
-                                         example={this.props.exampleMessage}/>
+                                         example={this.state.exampleMessage}
+                                         onExampleLoad={this._updateExampleMessage}/>
               </Col>
             </Row>
             <h2>Extractor configuration</h2>
@@ -179,7 +192,7 @@ const EditExtractor = React.createClass({
                                               extractorType={this.state.updatedExtractor.type}
                                               configuration={this.state.updatedExtractor.extractor_config}
                                               onChange={this._onConfigurationChange}
-                                              exampleMessage={this.props.exampleMessage}/>
+                                              exampleMessage={this.state.exampleMessage}/>
 
                   <Input label="Condition" labelClassName="col-md-2" wrapperClassName="col-md-10"
                          help={conditionTypeHelpMessage}>

--- a/graylog2-web-interface/src/components/extractors/ExtractorExampleMessage.jsx
+++ b/graylog2-web-interface/src/components/extractors/ExtractorExampleMessage.jsx
@@ -1,41 +1,24 @@
-import React, {PropTypes} from 'react';
+import React, { PropTypes } from 'react';
 import MessageLoader from './MessageLoader';
 
 const ExtractorExampleMessage = React.createClass({
   propTypes: {
     field: PropTypes.string.isRequired,
     example: PropTypes.string,
+    onExampleLoad: PropTypes.func,
   },
-  getInitialState() {
-    return {
-      example: '',
-      field: '',
-      newMessageLoaded: false,
-    };
-  },
-  componentWillMount() {
-    this.setState({example: this.props.example});
-  },
-  componentWillReceiveProps(nextProps) {
-    if (!this.state.newMessageLoaded && this.state.example !== nextProps.example) {
-      this.setState({example: nextProps.example});
-    }
-  },
-  onExampleLoaded(message) {
+  _onExampleLoad(message) {
     const newExample = message.fields[this.props.field];
-
-    if (newExample) {
-      this.setState({example: newExample, newMessageLoaded: true});
-    }
+    this.props.onExampleLoad(newExample);
   },
   render() {
-    const originalMessage = <span id="xtrc-original-example" style={{display: 'none'}}>{this.state.example}</span>;
+    const originalMessage = <span id="xtrc-original-example" style={{display: 'none'}}>{this.props.example}</span>;
     let messagePreview;
 
-    if (this.state.example) {
+    if (this.props.example) {
       messagePreview = (
         <div className="well well-sm xtrc-new-example">
-          <span id="xtrc-example">{this.state.example}</span>
+          <span id="xtrc-example">{this.props.example}</span>
         </div>
       );
     } else {
@@ -51,7 +34,7 @@ const ExtractorExampleMessage = React.createClass({
       <div>
         {originalMessage}
         {messagePreview}
-        <MessageLoader onMessageLoaded={this.onExampleLoaded}/>
+        <MessageLoader onMessageLoaded={this._onExampleLoad}/>
       </div>
     );
   },


### PR DESCRIPTION
When a new message is loaded in the extractor page, not only update the example preview, but also in other components using the example message.

Fixes #1957.