### PR TITLE
disable shutdown hooks for log4j

### DIFF
--- a/graylog2-server/src/main/resources/log4j2.xml
+++ b/graylog2-server/src/main/resources/log4j2.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<Configuration packages="org.graylog2.log4j">
+<Configuration packages="org.graylog2.log4j" shutdownHook="disable">
     <Appenders>
         <Console name="STDOUT" target="SYSTEM_OUT">
             <PatternLayout pattern="%d %-5p: %c - %m%n"/>


### PR DESCRIPTION
once we stop the process is going to exit anyway, so there's no real use in unregistering logger context mbeans etc.
this might change if we ever wanted to support unloading plugins, but that's so much more work than just this, we might as well fix the exceptions during shutdown the easy way

fix #1795 