### PR TITLE
Bundling/streamlining requests for indices page.

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/rest/models/system/indexer/requests/IndicesReadRequest.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/models/system/indexer/requests/IndicesReadRequest.java
@@ -1,3 +1,19 @@
+/**
+ * This file is part of Graylog.
+ *
+ * Graylog is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package org.graylog2.rest.models.system.indexer.requests;
 
 import com.fasterxml.jackson.annotation.JsonAutoDetect;

--- a/graylog2-server/src/main/java/org/graylog2/rest/models/system/indexer/requests/IndicesReadRequest.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/models/system/indexer/requests/IndicesReadRequest.java
@@ -1,0 +1,20 @@
+package org.graylog2.rest.models.system.indexer.requests;
+
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.auto.value.AutoValue;
+
+import java.util.List;
+
+@AutoValue
+@JsonAutoDetect
+public abstract class IndicesReadRequest {
+    @JsonProperty("indices")
+    public abstract List<String> indices();
+
+    @JsonCreator
+    public static IndicesReadRequest create(@JsonProperty("indices") List<String> indices) {
+        return new AutoValue_IndicesReadRequest(indices);
+    }
+}

--- a/graylog2-server/src/main/java/org/graylog2/rest/models/system/indexer/responses/IndexSizeSummary.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/models/system/indexer/responses/IndexSizeSummary.java
@@ -1,3 +1,19 @@
+/**
+ * This file is part of Graylog.
+ *
+ * Graylog is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package org.graylog2.rest.models.system.indexer.responses;
 
 import com.fasterxml.jackson.annotation.JsonAutoDetect;

--- a/graylog2-server/src/main/java/org/graylog2/rest/models/system/indexer/responses/IndexSizeSummary.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/models/system/indexer/responses/IndexSizeSummary.java
@@ -1,0 +1,26 @@
+package org.graylog2.rest.models.system.indexer.responses;
+
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.auto.value.AutoValue;
+
+@AutoValue
+@JsonAutoDetect
+public abstract class IndexSizeSummary {
+    @JsonProperty("events")
+    public abstract long events();
+
+    @JsonProperty("deleted")
+    public abstract long deleted();
+
+    @JsonProperty("bytes")
+    public abstract long bytes();
+
+    @JsonCreator
+    public static IndexSizeSummary create(@JsonProperty("events") long events,
+                                          @JsonProperty("deleted") long deleted,
+                                          @JsonProperty("bytes") long bytes) {
+        return new AutoValue_IndexSizeSummary(events, deleted, bytes);
+    }
+}

--- a/graylog2-server/src/main/java/org/graylog2/rest/models/system/indexer/responses/IndexSummary.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/models/system/indexer/responses/IndexSummary.java
@@ -1,3 +1,19 @@
+/**
+ * This file is part of Graylog.
+ *
+ * Graylog is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package org.graylog2.rest.models.system.indexer.responses;
 
 import com.fasterxml.jackson.annotation.JsonAutoDetect;

--- a/graylog2-server/src/main/java/org/graylog2/rest/models/system/indexer/responses/IndexSummary.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/models/system/indexer/responses/IndexSummary.java
@@ -1,0 +1,38 @@
+package org.graylog2.rest.models.system.indexer.responses;
+
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.auto.value.AutoValue;
+
+import javax.annotation.Nullable;
+
+@AutoValue
+@JsonAutoDetect
+public abstract class IndexSummary {
+    @JsonProperty("size")
+    @Nullable
+    public abstract IndexSizeSummary size();
+
+    @JsonProperty("range")
+    @Nullable
+    public abstract IndexRangeSummary range();
+
+    @JsonProperty("is_deflector")
+    public abstract boolean isDeflector();
+
+    @JsonProperty("is_closed")
+    public abstract boolean isClosed();
+
+    @JsonProperty("is_reopened")
+    public abstract boolean isReopened();
+
+    @JsonCreator
+    public static IndexSummary create(@JsonProperty("size") @Nullable IndexSizeSummary size,
+                                      @JsonProperty("range") @Nullable IndexRangeSummary range,
+                                      @JsonProperty("is_deflector") boolean isDeflector,
+                                      @JsonProperty("is_closed") boolean isClosed,
+                                      @JsonProperty("is_reopened") boolean isReopened) {
+        return new AutoValue_IndexSummary(size, range, isDeflector, isClosed, isReopened);
+    }
+}

--- a/graylog2-server/src/main/java/org/graylog2/rest/models/system/indexer/responses/IndexerClusterOverview.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/models/system/indexer/responses/IndexerClusterOverview.java
@@ -1,3 +1,19 @@
+/**
+ * This file is part of Graylog.
+ *
+ * Graylog is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package org.graylog2.rest.models.system.indexer.responses;
 
 import com.fasterxml.jackson.annotation.JsonAutoDetect;

--- a/graylog2-server/src/main/java/org/graylog2/rest/models/system/indexer/responses/IndexerClusterOverview.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/models/system/indexer/responses/IndexerClusterOverview.java
@@ -1,0 +1,22 @@
+package org.graylog2.rest.models.system.indexer.responses;
+
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.auto.value.AutoValue;
+
+@AutoValue
+@JsonAutoDetect
+public abstract class IndexerClusterOverview {
+    @JsonProperty("health")
+    public abstract ClusterHealth health();
+
+    @JsonProperty("name")
+    public abstract String name();
+
+    @JsonCreator
+    public static IndexerClusterOverview create(@JsonProperty("health") ClusterHealth health,
+                                                @JsonProperty("name") String name) {
+        return new AutoValue_IndexerClusterOverview(health, name);
+    }
+}

--- a/graylog2-server/src/main/java/org/graylog2/rest/models/system/indexer/responses/IndexerOverview.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/models/system/indexer/responses/IndexerOverview.java
@@ -1,3 +1,19 @@
+/**
+ * This file is part of Graylog.
+ *
+ * Graylog is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package org.graylog2.rest.models.system.indexer.responses;
 
 import com.fasterxml.jackson.annotation.JsonAutoDetect;

--- a/graylog2-server/src/main/java/org/graylog2/rest/models/system/indexer/responses/IndexerOverview.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/models/system/indexer/responses/IndexerOverview.java
@@ -1,0 +1,35 @@
+package org.graylog2.rest.models.system.indexer.responses;
+
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.auto.value.AutoValue;
+import org.graylog2.rest.models.count.responses.MessageCountResponse;
+import org.graylog2.rest.models.system.deflector.responses.DeflectorSummary;
+
+import java.util.List;
+import java.util.Map;
+
+@AutoValue
+@JsonAutoDetect
+public abstract class IndexerOverview {
+    @JsonProperty("deflector")
+    public abstract DeflectorSummary deflectorSummary();
+
+    @JsonProperty("indexer_cluster")
+    public abstract IndexerClusterOverview indexerCluster();
+
+    @JsonProperty("counts")
+    public abstract MessageCountResponse messageCountResponse();
+
+    @JsonProperty("indices")
+    public abstract Map<String, IndexSummary> indices();
+
+    @JsonCreator
+    public static IndexerOverview create(@JsonProperty("deflector_summary") DeflectorSummary deflectorSummary,
+                                         @JsonProperty("indexer_cluster") IndexerClusterOverview indexerCluster,
+                                         @JsonProperty("counts") MessageCountResponse messageCountResponse,
+                                         @JsonProperty("indices") Map<String, IndexSummary> indices) {
+        return new AutoValue_IndexerOverview(deflectorSummary, indexerCluster, messageCountResponse, indices);
+    }
+}

--- a/graylog2-server/src/main/java/org/graylog2/rest/resources/system/indexer/IndexerOverviewResource.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/resources/system/indexer/IndexerOverviewResource.java
@@ -1,0 +1,86 @@
+package org.graylog2.rest.resources.system.indexer;
+
+import com.codahale.metrics.annotation.Timed;
+import io.swagger.annotations.Api;
+import io.swagger.annotations.ApiOperation;
+import org.apache.shiro.authz.annotation.RequiresAuthentication;
+import org.elasticsearch.action.admin.indices.stats.IndexStats;
+import org.graylog2.indexer.indices.Indices;
+import org.graylog2.rest.models.system.deflector.responses.DeflectorSummary;
+import org.graylog2.rest.models.system.indexer.responses.IndexRangeSummary;
+import org.graylog2.rest.models.system.indexer.responses.IndexSizeSummary;
+import org.graylog2.rest.models.system.indexer.responses.IndexSummary;
+import org.graylog2.rest.models.system.indexer.responses.IndexerClusterOverview;
+import org.graylog2.rest.models.system.indexer.responses.IndexerOverview;
+import org.graylog2.rest.resources.count.CountResource;
+import org.graylog2.rest.resources.system.DeflectorResource;
+import org.graylog2.rest.resources.system.IndexRangesResource;
+import org.graylog2.shared.rest.resources.RestResource;
+
+import javax.inject.Inject;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+@RequiresAuthentication
+@Api(value = "Indexer/Overview", description = "Indexing overview")
+@Path("/system/indexer/overview")
+public class IndexerOverviewResource extends RestResource {
+    private final DeflectorResource deflectorResource;
+    private final IndexerClusterResource indexerClusterResource;
+    private final IndexRangesResource indexRangesResource;
+    private final CountResource countResource;
+    private final Indices indices;
+
+    @Inject
+    public IndexerOverviewResource(DeflectorResource deflectorResource,
+                                   IndexerClusterResource indexerClusterResource,
+                                   IndexRangesResource indexRangesResource,
+                                   CountResource countResource,
+                                   Indices indices) {
+        this.deflectorResource = deflectorResource;
+        this.indexerClusterResource = indexerClusterResource;
+        this.indexRangesResource = indexRangesResource;
+        this.countResource = countResource;
+        this.indices = indices;
+    }
+
+    @GET
+    @Timed
+    @ApiOperation(value = "Get overview of current indexing state, including deflector config, cluster state, index rnages & message counts.")
+    @Produces(MediaType.APPLICATION_JSON)
+    public IndexerOverview index() throws ClassNotFoundException {
+        final DeflectorSummary deflectorSummary = deflectorResource.deflector();
+        final List<IndexRangeSummary> indexRanges = indexRangesResource.list().ranges();
+        final Map<String, IndexSummary> indicesSummaries = indices.getAll().values()
+            .stream()
+            .collect(Collectors.toMap(IndexStats::getIndex,
+                (indexStats) -> IndexSummary.create(
+                    IndexSizeSummary.create(indexStats.getPrimaries().getDocs().getCount(),
+                        indexStats.getPrimaries().getDocs().getDeleted(),
+                        indexStats.getPrimaries().getStore().sizeInBytes()),
+                    indexRanges.stream().filter((indexRangeSummary) -> indexRangeSummary.indexName().equals(indexStats.getIndex())).findFirst().orElse(null),
+                    deflectorSummary.currentTarget().equals(indexStats.getIndex()),
+                    false,
+                    indices.isReopened(indexStats.getIndex()))
+            ));
+
+        indices.getClosedIndices().stream().forEach((indexName) -> {
+            indicesSummaries.put(indexName, IndexSummary.create(
+                null,
+                indexRanges.stream().filter((indexRangeSummary) -> indexRangeSummary.indexName().equals(indexName)).findFirst().orElse(null),
+                deflectorSummary.currentTarget().equals(indexName),
+                true,
+                indices.isReopened(indexName)
+            ));
+        });
+
+        return IndexerOverview.create(deflectorSummary,
+            IndexerClusterOverview.create(indexerClusterResource.clusterHealth(), indexerClusterResource.clusterName().name()),
+            countResource.total(),indicesSummaries);
+    }
+}

--- a/graylog2-server/src/main/java/org/graylog2/rest/resources/system/indexer/IndexerOverviewResource.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/resources/system/indexer/IndexerOverviewResource.java
@@ -91,7 +91,7 @@ public class IndexerOverviewResource extends RestResource {
                 indexRanges.stream().filter((indexRangeSummary) -> indexRangeSummary.indexName().equals(indexName)).findFirst().orElse(null),
                 deflectorSummary.currentTarget().equals(indexName),
                 true,
-                indices.isReopened(indexName)
+                false
             ));
         });
 

--- a/graylog2-server/src/main/java/org/graylog2/rest/resources/system/indexer/IndexerOverviewResource.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/resources/system/indexer/IndexerOverviewResource.java
@@ -67,7 +67,7 @@ public class IndexerOverviewResource extends RestResource {
 
     @GET
     @Timed
-    @ApiOperation(value = "Get overview of current indexing state, including deflector config, cluster state, index rnages & message counts.")
+    @ApiOperation(value = "Get overview of current indexing state, including deflector config, cluster state, index ranges & message counts.")
     @Produces(MediaType.APPLICATION_JSON)
     public IndexerOverview index() throws ClassNotFoundException {
         final DeflectorSummary deflectorSummary = deflectorResource.deflector();

--- a/graylog2-server/src/main/java/org/graylog2/rest/resources/system/indexer/IndexerOverviewResource.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/resources/system/indexer/IndexerOverviewResource.java
@@ -1,3 +1,19 @@
+/**
+ * This file is part of Graylog.
+ *
+ * Graylog is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package org.graylog2.rest.resources.system.indexer;
 
 import com.codahale.metrics.annotation.Timed;

--- a/graylog2-server/src/main/java/org/graylog2/rest/resources/system/indexer/IndexerOverviewResource.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/resources/system/indexer/IndexerOverviewResource.java
@@ -23,7 +23,6 @@ import org.apache.shiro.authz.annotation.RequiresAuthentication;
 import org.elasticsearch.action.admin.indices.stats.IndexStats;
 import org.graylog2.indexer.indices.Indices;
 import org.graylog2.rest.models.system.deflector.responses.DeflectorSummary;
-import org.graylog2.rest.models.system.indexer.responses.ClusterHealth;
 import org.graylog2.rest.models.system.indexer.responses.IndexRangeSummary;
 import org.graylog2.rest.models.system.indexer.responses.IndexSizeSummary;
 import org.graylog2.rest.models.system.indexer.responses.IndexSummary;

--- a/graylog2-server/src/main/java/org/graylog2/rest/resources/system/indexer/IndicesResource.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/resources/system/indexer/IndicesResource.java
@@ -17,9 +17,7 @@
 package org.graylog2.rest.resources.system.indexer;
 
 import com.codahale.metrics.annotation.Timed;
-import com.google.common.base.Predicate;
 import com.google.common.collect.ImmutableList;
-import com.google.common.collect.Sets;
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
 import io.swagger.annotations.ApiParam;
@@ -51,7 +49,6 @@ import javax.ws.rs.BadRequestException;
 import javax.ws.rs.DELETE;
 import javax.ws.rs.ForbiddenException;
 import javax.ws.rs.GET;
-import javax.ws.rs.InternalServerErrorException;
 import javax.ws.rs.NotFoundException;
 import javax.ws.rs.POST;
 import javax.ws.rs.Path;
@@ -109,7 +106,7 @@ public class IndicesResource extends RestResource {
         }
 
         return IndexInfo.create(indexStats(stats.primaries()), indexStats(stats.total()),
-                routing.build(), indices.isReopened(index));
+            routing.build(), indices.isReopened(index));
     }
 
     @POST
@@ -118,7 +115,7 @@ public class IndicesResource extends RestResource {
     @ApiOperation(value = "Get information of all specified indices and their shards.")
     @Produces(MediaType.APPLICATION_JSON)
     public Map<String, IndexInfo> multiple(@ApiParam(name = "Requested indices", required = true)
-                                  @Valid @NotNull IndicesReadRequest request) {
+                                           @Valid @NotNull IndicesReadRequest request) {
         if (request.indices() != null)
             return request.indices().stream().collect(Collectors.toMap(Function.identity(), this::single));
 
@@ -143,10 +140,10 @@ public class IndicesResource extends RestResource {
             }
 
             final IndexInfo indexInfo = IndexInfo.create(
-                    indexStats(indexStatistics.primaries()),
-                    indexStats(indexStatistics.total()),
-                    routing.build(),
-                    areReopened.get(indexStatistics.indexName()));
+                indexStats(indexStatistics.primaries()),
+                indexStats(indexStatistics.total()),
+                routing.build(),
+                areReopened.get(indexStatistics.indexName()));
 
             indexInfos.put(indexStatistics.indexName(), indexInfo);
         }
@@ -189,7 +186,7 @@ public class IndicesResource extends RestResource {
     public AllIndices all() {
         return AllIndices.create(this.closed(), this.reopened(), this.open());
     }
-    
+
     @POST
     @Timed
     @Path("/{index}/reopen")
@@ -212,7 +209,7 @@ public class IndicesResource extends RestResource {
     @ApiOperation(value = "Close an index. This will also trigger an index ranges rebuild job.")
     @Produces(MediaType.APPLICATION_JSON)
     @ApiResponses(value = {
-            @ApiResponse(code = 403, message = "You cannot close the current deflector target index.")
+        @ApiResponse(code = 403, message = "You cannot close the current deflector target index.")
     })
     public void close(@ApiParam(name = "index") @PathParam("index") @NotNull String index) {
         checkPermission(RestPermissions.INDICES_CHANGESTATE, index);
@@ -236,7 +233,7 @@ public class IndicesResource extends RestResource {
     @ApiOperation(value = "Delete an index. This will also trigger an index ranges rebuild job.")
     @Produces(MediaType.APPLICATION_JSON)
     @ApiResponses(value = {
-            @ApiResponse(code = 403, message = "You cannot delete the current deflector target index.")
+        @ApiResponse(code = 403, message = "You cannot delete the current deflector target index.")
     })
     public void delete(@ApiParam(name = "index") @PathParam("index") @NotNull String index) {
         checkPermission(RestPermissions.INDICES_DELETE, index);
@@ -257,28 +254,28 @@ public class IndicesResource extends RestResource {
 
     private ShardRouting shardRouting(org.elasticsearch.cluster.routing.ShardRouting route) {
         return ShardRouting.create(route.shardId().getId(),
-                route.state().name().toLowerCase(Locale.ENGLISH),
-                route.active(),
-                route.primary(),
-                route.currentNodeId(),
-                cluster.nodeIdToName(route.currentNodeId()),
-                cluster.nodeIdToHostName(route.currentNodeId()),
-                route.relocatingNodeId());
+            route.state().name().toLowerCase(Locale.ENGLISH),
+            route.active(),
+            route.primary(),
+            route.currentNodeId(),
+            cluster.nodeIdToName(route.currentNodeId()),
+            cluster.nodeIdToHostName(route.currentNodeId()),
+            route.relocatingNodeId());
     }
 
     private IndexStats indexStats(final CommonStats stats) {
         return IndexStats.create(
-                IndexStats.TimeAndTotalStats.create(stats.getFlush().getTotal(), stats.getFlush().getTotalTime().getSeconds()),
-                IndexStats.TimeAndTotalStats.create(stats.getGet().getCount(), stats.getGet().getTime().getSeconds()),
-                IndexStats.TimeAndTotalStats.create(stats.getIndexing().getTotal().getIndexCount(), stats.getIndexing().getTotal().getIndexTime().getSeconds()),
-                IndexStats.TimeAndTotalStats.create(stats.getMerge().getTotal(), stats.getMerge().getTotalTime().getSeconds()),
-                IndexStats.TimeAndTotalStats.create(stats.getRefresh().getTotal(), stats.getRefresh().getTotalTime().getSeconds()),
-                IndexStats.TimeAndTotalStats.create(stats.getSearch().getTotal().getQueryCount(), stats.getSearch().getTotal().getQueryTime().getSeconds()),
-                IndexStats.TimeAndTotalStats.create(stats.getSearch().getTotal().getFetchCount(), stats.getSearch().getTotal().getFetchTime().getSeconds()),
-                stats.getSearch().getOpenContexts(),
-                stats.getStore().getSize().getBytes(),
-                stats.getSegments().getCount(),
-                IndexStats.DocsStats.create(stats.getDocs().getCount(), stats.getDocs().getDeleted())
+            IndexStats.TimeAndTotalStats.create(stats.getFlush().getTotal(), stats.getFlush().getTotalTime().getSeconds()),
+            IndexStats.TimeAndTotalStats.create(stats.getGet().getCount(), stats.getGet().getTime().getSeconds()),
+            IndexStats.TimeAndTotalStats.create(stats.getIndexing().getTotal().getIndexCount(), stats.getIndexing().getTotal().getIndexTime().getSeconds()),
+            IndexStats.TimeAndTotalStats.create(stats.getMerge().getTotal(), stats.getMerge().getTotalTime().getSeconds()),
+            IndexStats.TimeAndTotalStats.create(stats.getRefresh().getTotal(), stats.getRefresh().getTotalTime().getSeconds()),
+            IndexStats.TimeAndTotalStats.create(stats.getSearch().getTotal().getQueryCount(), stats.getSearch().getTotal().getQueryTime().getSeconds()),
+            IndexStats.TimeAndTotalStats.create(stats.getSearch().getTotal().getFetchCount(), stats.getSearch().getTotal().getFetchTime().getSeconds()),
+            stats.getSearch().getOpenContexts(),
+            stats.getStore().getSize().getBytes(),
+            stats.getSegments().getCount(),
+            IndexStats.DocsStats.create(stats.getDocs().getCount(), stats.getDocs().getDeleted())
         );
     }
 }

--- a/graylog2-web-interface/src/actions/indexers/IndexerOverviewActions.jsx
+++ b/graylog2-web-interface/src/actions/indexers/IndexerOverviewActions.jsx
@@ -1,0 +1,7 @@
+import Reflux from 'reflux';
+
+const IndexerOverviewActions = Reflux.createActions({
+  list: { asyncResult: true },
+});
+
+export default IndexerOverviewActions;

--- a/graylog2-web-interface/src/actions/indices/IndicesActions.jsx
+++ b/graylog2-web-interface/src/actions/indices/IndicesActions.jsx
@@ -1,10 +1,13 @@
 import Reflux from 'reflux';
 
 const IndicesActions = Reflux.createActions({
-  'list': {asyncResult: true },
-  'close': { asyncResult: true },
-  'delete': { asyncResult: true },
-  'reopen': { asyncResult: true },
+  list: { asyncResult: true },
+  close: { asyncResult: true },
+  delete: { asyncResult: true },
+  multiple: { asyncResult: true },
+  reopen: { asyncResult: true },
+  subscribe: { asyncResult: false },
+  unsubscribe: { asyncResult: false },
 });
 
 export default IndicesActions;

--- a/graylog2-web-interface/src/components/indices/ClosedIndexDetails.jsx
+++ b/graylog2-web-interface/src/components/indices/ClosedIndexDetails.jsx
@@ -19,7 +19,7 @@ const ClosedIndexDetails = React.createClass({
         <Alert bsStyle="info"><i className="fa fa-info-circle"/> This index is closed. Index information is not available{' '}
           at the moment, please reopen the index and try again.</Alert>
 
-        <hr style={{marginBottom: '5', marginTop: '10'}}/>
+        <hr style={{ marginBottom: '5', marginTop: '10' }}/>
 
         <Button bsStyle="warning" bsSize="xs" onClick={() => { IndicesActions.reopen(indexName)}}>Reopen index</Button>{' '}
       </div>

--- a/graylog2-web-interface/src/components/indices/ClosedIndexDetails.jsx
+++ b/graylog2-web-interface/src/components/indices/ClosedIndexDetails.jsx
@@ -11,8 +11,11 @@ const ClosedIndexDetails = React.createClass({
     indexName: React.PropTypes.string.isRequired,
     indexRange: React.PropTypes.object.isRequired,
   },
+  _onReopen() {
+    IndicesActions.reopen(this.props.indexName);
+  },
   render() {
-    const { indexName, indexRange } = this.props;
+    const { indexRange } = this.props;
     return (
       <div className="index-info">
         <IndexRangeSummary indexRange={indexRange} />
@@ -21,7 +24,7 @@ const ClosedIndexDetails = React.createClass({
 
         <hr style={{ marginBottom: '5', marginTop: '10' }}/>
 
-        <Button bsStyle="warning" bsSize="xs" onClick={() => { IndicesActions.reopen(indexName)}}>Reopen index</Button>{' '}
+        <Button bsStyle="warning" bsSize="xs" onClick={this._onReopen}>Reopen index</Button>{' '}
       </div>
     );
   },

--- a/graylog2-web-interface/src/components/indices/ClosedIndexDetails.jsx
+++ b/graylog2-web-interface/src/components/indices/ClosedIndexDetails.jsx
@@ -9,7 +9,7 @@ import { IndexRangeSummary } from 'components/indices';
 const ClosedIndexDetails = React.createClass({
   propTypes: {
     indexName: React.PropTypes.string.isRequired,
-    indexRange: React.PropTypes.object.isRequired,
+    indexRange: React.PropTypes.object,
   },
   _onReopen() {
     IndicesActions.reopen(this.props.indexName);

--- a/graylog2-web-interface/src/components/indices/IndexDetails.jsx
+++ b/graylog2-web-interface/src/components/indices/IndexDetails.jsx
@@ -42,17 +42,17 @@ const IndexDetails = React.createClass({
     );
   },
   _onRecalculateIndex() {
-    if (window.confirm('Really recalculate the index ranges for index ' + this.props.indexName + '?')) {
+    if (window.confirm(`Really recalculate the index ranges for index ${this.props.indexName}?`)) {
       IndexRangesActions.recalculateIndex(this.props.indexName);
     }
   },
   _onCloseIndex() {
-    if (window.confirm('Really close index ' + this.props.indexName + '?')) {
+    if (window.confirm(`Really close index ${this.props.indexName}?`)) {
       IndicesActions.close(this.props.indexName);
     }
   },
   _onDeleteIndex() {
-    if (window.confirm('Really delete index ' + this.props.indexName + '?')) {
+    if (window.confirm(`Really delete index ${this.props.indexName}?`)) {
       IndicesActions.delete(this.props.indexName);
     }
   },
@@ -69,7 +69,7 @@ const IndexDetails = React.createClass({
         {index.all_shards.open_search_contexts} open search contexts,{' '}
         {index.all_shards.documents.deleted} deleted messages
 
-        <Row style={{marginBottom: '10'}}>
+        <Row style={{ marginBottom: '10' }}>
           <Col md={4} className="shard-meters">
             <ShardMeter title="Primary shard operations" shardMeter={index.primary_shards} />
           </Col>
@@ -80,7 +80,7 @@ const IndexDetails = React.createClass({
 
         <ShardRoutingOverview routing={index.routing} indexName={indexName} />
 
-        <hr style={{marginBottom: '5', marginTop: '10'}}/>
+        <hr style={{ marginBottom: '5', marginTop: '10' }}/>
 
         {this._formatActionButtons()}
       </div>

--- a/graylog2-web-interface/src/components/indices/IndexDetails.jsx
+++ b/graylog2-web-interface/src/components/indices/IndexDetails.jsx
@@ -1,6 +1,8 @@
 import React from 'react';
 import { Button, Col, Row } from 'react-bootstrap';
 
+import { Spinner } from 'components/common';
+
 import ActionsProvider from 'injection/ActionsProvider';
 const IndicesActions = ActionsProvider.getActions('Indices');
 const IndexRangesActions = ActionsProvider.getActions('IndexRanges');
@@ -10,9 +12,17 @@ import { IndexRangeSummary, ShardMeter, ShardRoutingOverview } from 'components/
 const IndexDetails = React.createClass({
   propTypes: {
     index: React.PropTypes.object.isRequired,
+    indexName: React.PropTypes.string.isRequired,
     indexRange: React.PropTypes.object.isRequired,
     isDeflector: React.PropTypes.bool.isRequired,
   },
+  componentDidMount() {
+    IndicesActions.subscribe(this.props.indexName);
+  },
+  componentWillUnmount() {
+    IndicesActions.unsubscribe(this.props.indexName);
+  },
+
   _formatActionButtons() {
     if (this.props.isDeflector) {
       return (
@@ -32,22 +42,25 @@ const IndexDetails = React.createClass({
     );
   },
   _onRecalculateIndex() {
-    if (window.confirm('Really recalculate the index ranges for index ' + this.props.index.name + '?')) {
-      IndexRangesActions.recalculateIndex(this.props.index.name);
+    if (window.confirm('Really recalculate the index ranges for index ' + this.props.indexName + '?')) {
+      IndexRangesActions.recalculateIndex(this.props.indexName);
     }
   },
   _onCloseIndex() {
-    if (window.confirm('Really close index ' + this.props.index.name + '?')) {
-      IndicesActions.close(this.props.index.name);
+    if (window.confirm('Really close index ' + this.props.indexName + '?')) {
+      IndicesActions.close(this.props.indexName);
     }
   },
   _onDeleteIndex() {
-    if (window.confirm('Really delete index ' + this.props.index.name + '?')) {
-      IndicesActions.delete(this.props.index.name);
+    if (window.confirm('Really delete index ' + this.props.indexName + '?')) {
+      IndicesActions.delete(this.props.indexName);
     }
   },
   render() {
-    const { index, indexRange } = this.props;
+    if (!this.props.index || !this.props.index.all_shards || !this.props.indexRange) {
+      return <Spinner />;
+    }
+    const { index, indexRange, indexName } = this.props;
     return (
       <div className="index-info">
         <IndexRangeSummary indexRange={indexRange} />{' '}
@@ -65,7 +78,7 @@ const IndexDetails = React.createClass({
           </Col>
         </Row>
 
-        <ShardRoutingOverview routing={index.routing} indexName={index.name} />
+        <ShardRoutingOverview routing={index.routing} indexName={indexName} />
 
         <hr style={{marginBottom: '5', marginTop: '10'}}/>
 

--- a/graylog2-web-interface/src/components/indices/IndexRangeSummary.jsx
+++ b/graylog2-web-interface/src/components/indices/IndexRangeSummary.jsx
@@ -3,7 +3,7 @@ import {Timestamp} from 'components/common';
 
 const IndexRangeSummary = React.createClass({
   propTypes: {
-    indexRange: React.PropTypes.object.isRequired,
+    indexRange: React.PropTypes.object,
   },
   render() {
     const { indexRange } = this.props;

--- a/graylog2-web-interface/src/components/indices/IndexSizeSummary.jsx
+++ b/graylog2-web-interface/src/components/indices/IndexSizeSummary.jsx
@@ -7,10 +7,10 @@ const IndexSizeSummary = React.createClass({
   },
   render() {
     const { index } = this.props;
-    if (index.all_shards) {
+    if (index.size) {
       return (
-        <span>({numeral(index.all_shards.store_size_bytes).format('0.0b')}
-          / {numeral(index.all_shards.documents.count).format('0,0')} messages){' '}</span>
+        <span>({numeral(index.size.bytes).format('0.0b')}{' '}
+          / {numeral(index.size.events).format('0,0')} messages){' '}</span>
       );
     }
 

--- a/graylog2-web-interface/src/components/indices/IndexSummary.jsx
+++ b/graylog2-web-interface/src/components/indices/IndexSummary.jsx
@@ -1,4 +1,6 @@
 import React from 'react';
+import { Label } from 'react-bootstrap';
+
 import DateTime from 'logic/datetimes/DateTime';
 
 import { IndexSizeSummary } from 'components/indices';
@@ -13,24 +15,32 @@ const IndexSummary = React.createClass({
   getInitialState() {
     return { showDetails: this.props.isDeflector };
   },
-  _deflectorBadge() {
-    if (this.props.isDeflector) {
-      return <i className="fa fa-bolt" title="Write-active index"/>;
-    }
-  },
-  _reopenedBadged(index) {
-    if (index.reopened) {
-      return <i className="fa fa-retweet" title="Reopened index"/>;
-    }
-  },
-  _formatIndexRange() {
-    if (this.props.isDeflector) {
-      return 'Contains messages up to ' + new DateTime().toRelativeString();
+  _formatLabels(index) {
+    const labels = [];
+    if (index.is_deflector) {
+      labels.push(<Label key={`${index.name}-deflector-label`} bsStyle="primary">deflector</Label>);
     }
 
-    if (this.props.index.all_shards) {
-      const count = this.props.index.all_shards.documents.count;
-      const deleted = this.props.index.all_shards.documents.deleted;
+    if (index.is_closed) {
+      labels.push(<Label key={`${index.name}-closed-label`} bsStyle="warning">closed</Label>);
+    }
+
+    if (index.is_reopened) {
+      labels.push(<Label key={`${index.name}-reopened-label`} bsStyle="success">reopened</Label>);
+    }
+
+    return <span>{labels}</span>;
+  },
+
+  _formatIndexRange() {
+    if (this.props.isDeflector) {
+      return `Contains messages up to ${new DateTime().toRelativeString()}`;
+    }
+
+    const sizes = this.props.index.size;
+    if (sizes) {
+      const count = sizes.count;
+      const deleted = sizes.deleted;
       if (count === 0 || count - deleted === 0) {
         return 'Index does not contain any messages.';
       }
@@ -41,10 +51,10 @@ const IndexSummary = React.createClass({
     }
 
     if (this.props.indexRange.begin === 0) {
-      return 'Contains messages up to ' + new DateTime(this.props.indexRange.end).toRelativeString();
+      return `Contains messages up to ${new DateTime(this.props.indexRange.end).toRelativeString()}`;
     }
 
-    return 'Contains messages from ' + new DateTime(this.props.indexRange.begin).toRelativeString() + ' up to ' + new DateTime(this.props.indexRange.end).toRelativeString();
+    return `Contains messages from ${new DateTime(this.props.indexRange.begin).toRelativeString()} up to ${new DateTime(this.props.indexRange.end).toRelativeString()}`;
   },
   _formatShowDetailsLink() {
     if (this.state.showDetails) {
@@ -61,13 +71,10 @@ const IndexSummary = React.createClass({
     return (
       <span>
         <h2>
-          {this._deflectorBadge()}{' '}
-
           {index.name}{' '}
 
-          {this._reopenedBadged(index)}{' '}
-
           <small>
+            {this._formatLabels(index)}{' '}
             {this._formatIndexRange(index)}{' '}
 
             <IndexSizeSummary index={index} />

--- a/graylog2-web-interface/src/components/indices/IndexSummary.jsx
+++ b/graylog2-web-interface/src/components/indices/IndexSummary.jsx
@@ -9,7 +9,7 @@ const IndexSummary = React.createClass({
   propTypes: {
     children: React.PropTypes.node.isRequired,
     index: React.PropTypes.object.isRequired,
-    indexRange: React.PropTypes.object.isRequired,
+    indexRange: React.PropTypes.object,
     isDeflector: React.PropTypes.bool.isRequired,
     name: React.PropTypes.string.isRequired,
   },

--- a/graylog2-web-interface/src/components/indices/IndexSummary.jsx
+++ b/graylog2-web-interface/src/components/indices/IndexSummary.jsx
@@ -11,6 +11,7 @@ const IndexSummary = React.createClass({
     index: React.PropTypes.object.isRequired,
     indexRange: React.PropTypes.object.isRequired,
     isDeflector: React.PropTypes.bool.isRequired,
+    name: React.PropTypes.string.isRequired,
   },
   getInitialState() {
     return { showDetails: this.props.isDeflector };
@@ -18,15 +19,15 @@ const IndexSummary = React.createClass({
   _formatLabels(index) {
     const labels = [];
     if (index.is_deflector) {
-      labels.push(<Label key={`${index.name}-deflector-label`} bsStyle="primary">deflector</Label>);
+      labels.push(<Label key={`${this.props.name}-deflector-label`} bsStyle="primary">deflector</Label>);
     }
 
     if (index.is_closed) {
-      labels.push(<Label key={`${index.name}-closed-label`} bsStyle="warning">closed</Label>);
+      labels.push(<Label key={`${this.props.name}-closed-label`} bsStyle="warning">closed</Label>);
     }
 
     if (index.is_reopened) {
-      labels.push(<Label key={`${index.name}-reopened-label`} bsStyle="success">reopened</Label>);
+      labels.push(<Label key={`${this.props.name}-reopened-label`} bsStyle="success">reopened</Label>);
     }
 
     return <span>{labels}</span>;
@@ -71,7 +72,7 @@ const IndexSummary = React.createClass({
     return (
       <span>
         <h2>
-          {index.name}{' '}
+          {this.props.name}{' '}
 
           <small>
             {this._formatLabels(index)}{' '}

--- a/graylog2-web-interface/src/components/indices/IndexSummary.jsx
+++ b/graylog2-web-interface/src/components/indices/IndexSummary.jsx
@@ -40,7 +40,7 @@ const IndexSummary = React.createClass({
 
     const sizes = this.props.index.size;
     if (sizes) {
-      const count = sizes.count;
+      const count = sizes.events;
       const deleted = sizes.deleted;
       if (count === 0 || count - deleted === 0) {
         return 'Index does not contain any messages.';

--- a/graylog2-web-interface/src/components/indices/IndicesMaintenanceDropdown.jsx
+++ b/graylog2-web-interface/src/components/indices/IndicesMaintenanceDropdown.jsx
@@ -6,7 +6,7 @@ const DeflectorActions = ActionsProvider.getActions('Deflector');
 const IndexRangesActions = ActionsProvider.getActions('IndexRanges');
 
 import StoreProvider from 'injection/StoreProvider';
-const DeflectorStore = StoreProvider.getStore('Deflector');
+const DeflectorStore = StoreProvider.getStore('Deflector'); // eslint-disable-line no-unused-vars
 
 const IndicesMaintenanceDropdown = React.createClass({
   _onRecalculateIndexRange() {

--- a/graylog2-web-interface/src/components/indices/IndicesMaintenanceDropdown.jsx
+++ b/graylog2-web-interface/src/components/indices/IndicesMaintenanceDropdown.jsx
@@ -5,6 +5,9 @@ import ActionsProvider from 'injection/ActionsProvider';
 const DeflectorActions = ActionsProvider.getActions('Deflector');
 const IndexRangesActions = ActionsProvider.getActions('IndexRanges');
 
+import StoreProvider from 'injection/StoreProvider';
+const DeflectorStore = StoreProvider.getStore('Deflector');
+
 const IndicesMaintenanceDropdown = React.createClass({
   _onRecalculateIndexRange() {
     if (window.confirm('This will trigger a background system job. Go on?')) {

--- a/graylog2-web-interface/src/components/indices/IndicesOverview.jsx
+++ b/graylog2-web-interface/src/components/indices/IndicesOverview.jsx
@@ -17,11 +17,11 @@ const IndicesOverview = React.createClass({
   _formatIndex(indexName, index) {
     const indexSummary = this.props.indices[indexName];
     const indexRange = indexSummary && indexSummary.range ? indexSummary.range : null;
-    index.name = indexName;
     return (
       <Row key={`index-summary-${indexName}`} className="content index-description">
         <Col md={12}>
-          <IndexSummary index={index} count={indexSummary.size} indexRange={indexRange} isDeflector={indexSummary.is_deflector}>
+          <IndexSummary index={index} name={indexName} count={indexSummary.size}
+                        indexRange={indexRange} isDeflector={indexSummary.is_deflector}>
             <span>
               <IndexDetails index={this.props.indexDetails[indexName]}
                             indexName={indexName}
@@ -35,11 +35,10 @@ const IndicesOverview = React.createClass({
   },
   _formatClosedIndex(indexName, index) {
     const indexRange = index.range;
-    index.name = indexName;
     return (
       <Row key={`index-summary-${indexName}`} className="content index-description">
         <Col md={12}>
-          <IndexSummary index={index} indexRange={indexRange} isDeflector={index.is_deflector}>
+          <IndexSummary index={index} name={indexName} indexRange={indexRange} isDeflector={index.is_deflector}>
             <span>
               <ClosedIndexDetails indexName={indexName} indexRange={indexRange} />
             </span>

--- a/graylog2-web-interface/src/components/indices/IndicesOverview.jsx
+++ b/graylog2-web-interface/src/components/indices/IndicesOverview.jsx
@@ -11,9 +11,6 @@ const IndicesOverview = React.createClass({
     indexDetails: React.PropTypes.object.isRequired,
     indices: React.PropTypes.object.isRequired,
   },
-  _isDeflector(index) {
-    return index.name === this.props.deflector.current_target;
-  },
   _formatIndex(indexName, index) {
     const indexSummary = this.props.indices[indexName];
     const indexRange = indexSummary && indexSummary.range ? indexSummary.range : null;

--- a/graylog2-web-interface/src/components/indices/IndicesOverview.jsx
+++ b/graylog2-web-interface/src/components/indices/IndicesOverview.jsx
@@ -8,21 +8,25 @@ const IndicesOverview = React.createClass({
   propTypes: {
     closedIndices: React.PropTypes.array.isRequired,
     deflector: React.PropTypes.object.isRequired,
-    indexRanges: React.PropTypes.array.isRequired,
+    indexDetails: React.PropTypes.object.isRequired,
     indices: React.PropTypes.object.isRequired,
   },
   _isDeflector(index) {
-    return index.name === this.props.deflector.info.current_target;
+    return index.name === this.props.deflector.current_target;
   },
   _formatIndex(indexName, index) {
-    const indexRange = this.props.indexRanges.filter((indexRange) => indexRange.index_name === indexName)[0];
+    const indexSummary = this.props.indices[indexName];
+    const indexRange = indexSummary && indexSummary.range ? indexSummary.range : null;
     index.name = indexName;
     return (
-      <Row key={'index-summary-' + index.name} className="content index-description">
+      <Row key={`index-summary-${indexName}`} className="content index-description">
         <Col md={12}>
-          <IndexSummary index={index} indexRange={indexRange} isDeflector={this._isDeflector(index)}>
+          <IndexSummary index={index} count={indexSummary.size} indexRange={indexRange} isDeflector={indexSummary.is_deflector}>
             <span>
-              <IndexDetails index={index} indexRange={indexRange} isDeflector={this._isDeflector(index)}/>
+              <IndexDetails index={this.props.indexDetails[indexName]}
+                            indexName={indexName}
+                            indexRange={indexRange}
+                            isDeflector={indexSummary.is_deflector}/>
             </span>
           </IndexSummary>
         </Col>
@@ -30,11 +34,12 @@ const IndicesOverview = React.createClass({
     );
   },
   _formatClosedIndex(indexName, index) {
-    const indexRange = this.props.indexRanges.filter((indexRange) => indexRange.index_name === indexName)[0];
+    const indexRange = index.range;
+    index.name = indexName;
     return (
-      <Row key={'index-summary-' + indexName} className="content index-description">
+      <Row key={`index-summary-${indexName}`} className="content index-description">
         <Col md={12}>
-          <IndexSummary index={index} indexRange={indexRange} isDeflector={this._isDeflector(index)}>
+          <IndexSummary index={index} indexRange={indexRange} isDeflector={index.is_deflector}>
             <span>
               <ClosedIndexDetails indexName={indexName} indexRange={indexRange} />
             </span>
@@ -44,8 +49,10 @@ const IndicesOverview = React.createClass({
     );
   },
   render() {
-    const indices = Object.keys(this.props.indices).map((indexName) => this._formatIndex(indexName, this.props.indices[indexName]));
-    this.props.closedIndices.forEach((closedIndex) => indices.push(this._formatClosedIndex(closedIndex, { name: closedIndex })));
+    const indices = Object.keys(this.props.indices).map((indexName) => {
+      return !this.props.indices[indexName].is_closed ?
+        this._formatIndex(indexName, this.props.indices[indexName]) : this._formatClosedIndex(indexName, this.props.indices[indexName]);
+    });
     return (
       <span>
         {indices.sort((index1, index2) => naturalSort(index2.key, index1.key))}

--- a/graylog2-web-interface/src/injection/ActionsProvider.jsx
+++ b/graylog2-web-interface/src/injection/ActionsProvider.jsx
@@ -15,6 +15,7 @@ class ActionsProvider {
       GettingStarted: () => require('actions/gettingstarted/GettingStartedActions'),
       HistogramData: () => require('actions/sources/HistogramDataActions'),
       IndexerCluster: () => require('actions/indexers/IndexerClusterActions'),
+      IndexerOverview: () => require('actions/indexers/IndexerOverviewActions'),
       IndexRanges: () => require('actions/indices/IndexRangesActions'),
       Indices: () => require('actions/indices/IndicesActions'),
       IndicesConfiguration: () => require('actions/indices/IndicesConfigurationActions'),

--- a/graylog2-web-interface/src/injection/StoreProvider.jsx
+++ b/graylog2-web-interface/src/injection/StoreProvider.jsx
@@ -26,6 +26,7 @@ class StoreProvider {
       HistogramData: () => require('stores/sources/HistogramDataStore'),
       IndexerCluster: () => require('stores/indexers/IndexerClusterStore'),
       IndexerFailures: () => require('stores/indexers/IndexerFailuresStore'),
+      IndexerOverview: () => require('stores/indexers/IndexerOverviewStore'),
       IndexRanges: () => require('stores/indices/IndexRangesStore'),
       Indices: () => require('stores/indices/IndicesStore'),
       IndicesConfiguration: () => require('stores/indices/IndicesConfigurationStore'),

--- a/graylog2-web-interface/src/pages/IndicesPage.jsx
+++ b/graylog2-web-interface/src/pages/IndicesPage.jsx
@@ -38,13 +38,13 @@ const IndicesPage = React.createClass({
   },
   REFRESH_INTERVAL: 2000,
   _totalIndexCount() {
-    return (Object.keys(this.state.indices).length + this.state.indexDetails.closedIndices.length);
+    return (Object.keys(this.state.indexerOverview.indices).length + this.state.indexDetails.closedIndices.length);
   },
   render() {
-    if (!this.state.indices || !this.state.deflector || !this.state.indexer_cluster || !this.state.counts) {
+    if (!this.state.indexerOverview) {
       return <Spinner />;
     }
-    const deflectorInfo = this.state.deflector;
+    const deflectorInfo = this.state.indexerOverview.deflector;
     return (
       <span>
         <PageHeader title="Indices">
@@ -71,17 +71,17 @@ const IndicesPage = React.createClass({
           <Col md={12}>
             <Alert bsStyle="success" style={{ marginTop: '10' }}>
               <i className="fa fa-th"/> &nbsp;{this._totalIndexCount()} indices with a total of{' '}
-              {numeral(this.state.counts.events).format('0,0')} messages under management,
+              {numeral(this.state.indexerOverview.counts.events).format('0,0')} messages under management,
               current write-active index is <i>{deflectorInfo.current_target}</i>.
             </Alert>
-            <IndexerClusterHealthSummary health={this.state.indexer_cluster.health} />
+            <IndexerClusterHealthSummary health={this.state.indexerOverview.indexer_cluster.health} />
           </Col>
         </Row>
 
-        <IndicesOverview indices={this.state.indices}
+        <IndicesOverview indices={this.state.indexerOverview.indices}
                          indexDetails={this.state.indexDetails.indices}
                          closedIndices={this.state.indexDetails.closedIndices}
-                         deflector={this.state.deflector}/>
+                         deflector={this.state.indexerOverview.deflector}/>
       </span>
     );
   },

--- a/graylog2-web-interface/src/pages/IndicesPage.jsx
+++ b/graylog2-web-interface/src/pages/IndicesPage.jsx
@@ -4,18 +4,12 @@ import { Alert, Col, Row } from 'react-bootstrap';
 import numeral from 'numeral';
 
 import ActionsProvider from 'injection/ActionsProvider';
-const IndexerClusterActions = ActionsProvider.getActions('IndexerCluster');
-const DeflectorActions = ActionsProvider.getActions('Deflector');
-const IndexRangesActions = ActionsProvider.getActions('IndexRanges');
+const IndexerOverviewActions = ActionsProvider.getActions('IndexerOverview');
 const IndicesActions = ActionsProvider.getActions('Indices');
-const MessageCountsActions = ActionsProvider.getActions('MessageCounts');
 
 import StoreProvider from 'injection/StoreProvider';
-const IndexerClusterStore = StoreProvider.getStore('IndexerCluster');
-const DeflectorStore = StoreProvider.getStore('Deflector');
-const IndexRangesStore = StoreProvider.getStore('IndexRanges');
+const IndexerOverviewStore = StoreProvider.getStore('IndexerOverview');
 const IndicesStore = StoreProvider.getStore('Indices');
-const MessageCountsStore = StoreProvider.getStore('MessageCounts');
 
 import DocsHelper from 'util/DocsHelper';
 import { PageHeader, Spinner } from 'components/common';
@@ -25,20 +19,16 @@ import { IndicesMaintenanceDropdown, IndicesOverview } from 'components/indices'
 import IndicesConfiguration from 'components/indices/IndicesConfiguration';
 
 const IndicesPage = React.createClass({
-  mixins: [Reflux.connect(IndicesStore), Reflux.connect(DeflectorStore),
-    Reflux.connect(IndexRangesStore), Reflux.connect(MessageCountsStore), Reflux.connect(IndexerClusterStore)],
+  mixins: [
+    Reflux.connect(IndicesStore, 'indexDetails'),
+    Reflux.connect(IndexerOverviewStore),
+  ],
   componentDidMount() {
+    IndicesActions.list();
+
     this.timerId = setInterval(() => {
-      DeflectorActions.list();
-
-      IndexRangesActions.list();
-
-      IndicesActions.list();
-
-      MessageCountsActions.total();
-
-      IndexerClusterActions.health();
-      IndexerClusterActions.name();
+      IndicesActions.multiple();
+      IndexerOverviewActions.list();
     }, this.REFRESH_INTERVAL);
   },
   componentWillUnmount() {
@@ -48,13 +38,13 @@ const IndicesPage = React.createClass({
   },
   REFRESH_INTERVAL: 2000,
   _totalIndexCount() {
-    return (Object.keys(this.state.indices).length + this.state.closedIndices.length);
+    return (Object.keys(this.state.indices).length + this.state.indexDetails.closedIndices.length);
   },
   render() {
-    if (!this.state.indices || !this.state.indexRanges || !this.state.deflector || !this.state.health) {
+    if (!this.state.indices || !this.state.deflector || !this.state.indexer_cluster || !this.state.counts) {
       return <Spinner />;
     }
-    const deflectorInfo = this.state.deflector.info;
+    const deflectorInfo = this.state.deflector;
     return (
       <span>
         <PageHeader title="Indices">
@@ -81,15 +71,17 @@ const IndicesPage = React.createClass({
           <Col md={12}>
             <Alert bsStyle="success" style={{marginTop: '10'}}>
               <i className="fa fa-th"/> &nbsp;{this._totalIndexCount()} indices with a total of{' '}
-              {numeral(this.state.events).format('0,0')} messages under management,
-              current write-active index is <i>{deflectorInfo ? deflectorInfo.current_target : <Spinner />}</i>.
+              {numeral(this.state.counts.events).format('0,0')} messages under management,
+              current write-active index is <i>{deflectorInfo.current_target}</i>.
             </Alert>
-            <IndexerClusterHealthSummary health={this.state.health} />
+            <IndexerClusterHealthSummary health={this.state.indexer_cluster.health} />
           </Col>
         </Row>
 
-        <IndicesOverview indices={this.state.indices} closedIndices={this.state.closedIndices}
-                         deflector={this.state.deflector} indexRanges={this.state.indexRanges} />
+        <IndicesOverview indices={this.state.indices}
+                         indexDetails={this.state.indexDetails.indices}
+                         closedIndices={this.state.indexDetails.closedIndices}
+                         deflector={this.state.deflector}/>
       </span>
     );
   },

--- a/graylog2-web-interface/src/pages/IndicesPage.jsx
+++ b/graylog2-web-interface/src/pages/IndicesPage.jsx
@@ -25,7 +25,6 @@ const IndicesPage = React.createClass({
   ],
   componentDidMount() {
     IndicesActions.list();
-
     this.timerId = setInterval(() => {
       IndicesActions.multiple();
       IndexerOverviewActions.list();
@@ -41,7 +40,7 @@ const IndicesPage = React.createClass({
     return (Object.keys(this.state.indexerOverview.indices).length + this.state.indexDetails.closedIndices.length);
   },
   render() {
-    if (!this.state.indexerOverview) {
+    if (!this.state.indexerOverview || !this.state.indexDetails.closedIndices) {
       return <Spinner />;
     }
     const deflectorInfo = this.state.indexerOverview.deflector;

--- a/graylog2-web-interface/src/pages/IndicesPage.jsx
+++ b/graylog2-web-interface/src/pages/IndicesPage.jsx
@@ -69,7 +69,7 @@ const IndicesPage = React.createClass({
 
         <Row className="content">
           <Col md={12}>
-            <Alert bsStyle="success" style={{marginTop: '10'}}>
+            <Alert bsStyle="success" style={{ marginTop: '10' }}>
               <i className="fa fa-th"/> &nbsp;{this._totalIndexCount()} indices with a total of{' '}
               {numeral(this.state.counts.events).format('0,0')} messages under management,
               current write-active index is <i>{deflectorInfo.current_target}</i>.

--- a/graylog2-web-interface/src/routing/ApiRoutes.js
+++ b/graylog2-web-interface/src/routing/ApiRoutes.js
@@ -55,7 +55,7 @@ const ApiRoutes = {
     list: (limit, offset) => { return { url: `/system/indexer/failures?limit=${limit}&offset=${offset}` }; },
   },
   IndexerOverviewApiResource: {
-    list: () => { return { url: '/system/indexer/overview' }},
+    list: () => { return { url: '/system/indexer/overview' }; },
   },
   IndexRangesApiController: {
     list: () => { return { url: '/system/indices/ranges' }; },
@@ -85,9 +85,9 @@ const ApiRoutes = {
     stop: (inputId) => { return { url: `/cluster/inputstates/${inputId}` }; },
   },
   ClusterLoggersResource: {
-    loggers: () => { return {url: '/cluster/system/loggers'}; },
-    subsystems: () => { return {url: '/cluster/system/loggers/subsystems'}; },
-    setSubsystemLoggerLevel: (nodeId, subsystem, loglevel) => { return {url: '/cluster/system/loggers/' + nodeId + '/subsystems/' + subsystem + '/level/' + loglevel}; },
+    loggers: () => { return { url: '/cluster/system/loggers' }; },
+    subsystems: () => { return { url: '/cluster/system/loggers/subsystems' }; },
+    setSubsystemLoggerLevel: (nodeId, subsystem, loglevel) => { return { url: `/cluster/system/loggers/${nodeId}/subsystems/${subsystem}/level/${loglevel}` }; },
   },
   MessageFieldsApiController: {
     list: () => { return { url: '/system/fields' }; },
@@ -98,7 +98,7 @@ const ApiRoutes = {
   },
   ClusterMetricsApiController: {
     multiple: (nodeId) => { return { url: `/cluster/${nodeId}/metrics/multiple` }; },
-    multipleAllNodes: () => { return { url: `/cluster/metrics/multiple` }; },
+    multipleAllNodes: () => { return { url: '/cluster/metrics/multiple' }; },
     byNamespace: (nodeId, namespace) => { return { url: `/cluster/${nodeId}/metrics/namespace/${namespace}` }; },
   },
   NotificationsApiController: {

--- a/graylog2-web-interface/src/routing/ApiRoutes.js
+++ b/graylog2-web-interface/src/routing/ApiRoutes.js
@@ -54,6 +54,9 @@ const ApiRoutes = {
     count: (since) => { return { url: `/system/indexer/failures/count?since=${since}` }; },
     list: (limit, offset) => { return { url: `/system/indexer/failures?limit=${limit}&offset=${offset}` }; },
   },
+  IndexerOverviewApiResource: {
+    list: () => { return { url: '/system/indexer/overview' }},
+  },
   IndexRangesApiController: {
     list: () => { return { url: '/system/indices/ranges' }; },
     rebuild: () => { return { url: '/system/indices/ranges/rebuild' }; },
@@ -64,6 +67,7 @@ const ApiRoutes = {
     delete: (indexName) => { return { url: `/system/indexer/indices/${indexName}` }; },
     list: () => { return { url: '/system/indexer/indices' }; },
     listClosed: () => { return { url: '/system/indexer/indices/closed' }; },
+    multiple: () => { return { url: '/system/indexer/indices/multiple' }; },
     reopen: (indexName) => { return { url: `/system/indexer/indices/${indexName}/reopen` }; },
   },
   InputsApiController: {

--- a/graylog2-web-interface/src/stores/indexers/IndexerOverviewStore.js
+++ b/graylog2-web-interface/src/stores/indexers/IndexerOverviewStore.js
@@ -13,7 +13,7 @@ const IndexerOverviewStore = Reflux.createStore({
     const url = URLUtils.qualifyUrl(ApiRoutes.IndexerOverviewApiResource.list().url);
     const promise = fetch('GET', url);
     promise.then((response) => {
-      this.trigger(response);
+      this.trigger({ indexerOverview: response });
     });
 
     IndexerOverviewActions.list.promise(promise);

--- a/graylog2-web-interface/src/stores/indexers/IndexerOverviewStore.js
+++ b/graylog2-web-interface/src/stores/indexers/IndexerOverviewStore.js
@@ -1,0 +1,25 @@
+import Reflux from 'reflux';
+
+import URLUtils from 'util/URLUtils';
+import ApiRoutes from 'routing/ApiRoutes';
+import fetch from 'logic/rest/FetchProvider';
+
+import ActionsProvider from 'injection/ActionsProvider';
+const IndexerOverviewActions = ActionsProvider.getActions('IndexerOverview');
+
+const IndexerOverviewStore = Reflux.createStore({
+  listenables: [IndexerOverviewActions],
+  list() {
+    const url = URLUtils.qualifyUrl(ApiRoutes.IndexerOverviewApiResource.list().url);
+    const promise = fetch('GET', url);
+    promise.then((response) => {
+      this.trigger(response);
+    });
+
+    IndexerOverviewActions.list.promise(promise);
+
+    return promise;
+  },
+});
+
+export default IndexerOverviewStore;

--- a/graylog2-web-interface/src/stores/indices/IndicesStore.js
+++ b/graylog2-web-interface/src/stores/indices/IndicesStore.js
@@ -49,7 +49,7 @@ const IndicesStore = Reflux.createStore({
       return { indices: this.indices, closedIndices: this.closedIndices };
     });
 
-    IndicesActions.list.promise(promise);
+    IndicesActions.multiple.promise(promise);
   },
   close(indexName) {
     const url = URLUtils.qualifyUrl(ApiRoutes.IndicesApiController.close(indexName).url);


### PR DESCRIPTION
* Add endpoints for indices overview and multiple index details.
* Add new store/actions which make use of new index/indices overview.
* Allows components to (un-)/register for index details.
* Use new index subscriptions and index/indices overview in components.

Fixes #1959, #1960 