### PR TITLE
Hide "store as field" in Grok and JSON extractors

### DIFF
--- a/graylog2-web-interface/src/components/extractors/EditExtractor.jsx
+++ b/graylog2-web-interface/src/components/extractors/EditExtractor.jsx
@@ -166,6 +166,20 @@ const EditExtractor = React.createClass({
       </span>
     );
 
+    let storeAsFieldInput;
+    // Grok and JSON extractors create their required fields, so no need to add an input for them
+    if (this.state.updatedExtractor.type !== ExtractorUtils.ExtractorTypes.GROK && this.state.updatedExtractor.type !== ExtractorUtils.ExtractorTypes.JSON) {
+      storeAsFieldInput = (
+        <Input type="text" ref="targetField" id="target_field" label="Store as field"
+               defaultValue={this.state.updatedExtractor.target_field}
+               labelClassName="col-md-2"
+               wrapperClassName="col-md-10"
+               onChange={this._onTargetFieldChange}
+               required
+               help={targetFieldHelpMessage} />
+      );
+    }
+
     return (
       <div>
         <Row className="content extractor-list">
@@ -223,14 +237,7 @@ const EditExtractor = React.createClass({
                   </Input>
                   {this._getExtractorConditionControls()}
 
-                  <Input type="text" ref="targetField" id="target_field" label="Store as field"
-                         defaultValue={this.state.updatedExtractor.target_field}
-                         labelClassName="col-md-2"
-                         wrapperClassName="col-md-10"
-                         onChange={this._onTargetFieldChange}
-                         required
-                         help={targetFieldHelpMessage}/>
-
+                  {storeAsFieldInput}
 
                   <Input label="Extraction strategy" labelClassName="col-md-2" wrapperClassName="col-md-10"
                          help={cursorStrategyHelpMessage}>

--- a/graylog2-web-interface/src/stores/extractors/ExtractorsStore.js
+++ b/graylog2-web-interface/src/stores/extractors/ExtractorsStore.js
@@ -64,6 +64,7 @@ const ExtractorsStore = Reflux.createStore({
       source_field: field,
       converters: [],
       extractor_config: {},
+      target_field: '',
     };
   },
 


### PR DESCRIPTION
Grok and JSON extractors do not use the "store as field" input in the create/edit extractor form. Fixes issue #1883.