### PR TITLE
Make history global

### DIFF
--- a/graylog2-web-interface/src/util/History.js
+++ b/graylog2-web-interface/src/util/History.js
@@ -1,3 +1,7 @@
 import { createHistory } from 'history';
 
-export default createHistory();
+if (!window.graylogHistory) {
+  window.graylogHistory = createHistory();
+}
+
+export default window.graylogHistory;


### PR DESCRIPTION
As with the stores, history should be shared between plugins and the web application. Otherwise the results of handling the history object in plugins will not change the state in other plugins or the application.

Fixes #1985