### PR TITLE
override timestamp to now for bad timestamp values

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/plugin/Tools.java
+++ b/graylog2-server/src/main/java/org/graylog2/plugin/Tools.java
@@ -279,7 +279,7 @@ public final class Tools {
     }
 
     public static String buildElasticSearchTimeFormat(DateTime timestamp) {
-        return timestamp.toString(DateTimeFormat.forPattern(ES_DATE_FORMAT).withZoneUTC());
+        return timestamp.toString(ES_DATE_FORMAT_FORMATTER);
     }
 
     /**

--- a/graylog2-server/src/test/java/org/graylog2/indexer/indices/IndicesTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/indexer/indices/IndicesTest.java
@@ -16,6 +16,7 @@
  */
 package org.graylog2.indexer.indices;
 
+import com.codahale.metrics.MetricRegistry;
 import com.github.joschi.nosqlunit.elasticsearch2.ElasticsearchRule;
 import com.github.joschi.nosqlunit.elasticsearch2.EmbeddedElasticsearch;
 import com.lordofthejars.nosqlunit.annotation.UsingDataSet;
@@ -84,7 +85,7 @@ public class IndicesTest {
 
     @Before
     public void setUp() throws Exception {
-        indices = new Indices(client, CONFIG, new IndexMapping(), new Messages(client, CONFIG));
+        indices = new Indices(client, CONFIG, new IndexMapping(), new Messages(client, CONFIG, new MetricRegistry()));
     }
 
     @Test

--- a/graylog2-server/src/test/java/org/graylog2/indexer/nosqlunit/IndexCreatingDatabaseOperation.java
+++ b/graylog2-server/src/test/java/org/graylog2/indexer/nosqlunit/IndexCreatingDatabaseOperation.java
@@ -16,6 +16,7 @@
  */
 package org.graylog2.indexer.nosqlunit;
 
+import com.codahale.metrics.MetricRegistry;
 import com.google.common.collect.ImmutableSet;
 import com.lordofthejars.nosqlunit.core.DatabaseOperation;
 import org.elasticsearch.action.admin.indices.exists.indices.IndicesExistsResponse;
@@ -54,7 +55,7 @@ public class IndexCreatingDatabaseOperation implements DatabaseOperation<Client>
                 client.admin().indices().prepareDelete(index).execute().actionGet();
             }
 
-            final Messages messages = new Messages(client, config);
+            final Messages messages = new Messages(client, config, new MetricRegistry());
             final Indices indices = new Indices(client, config, new IndexMapping(), messages);
 
             if (!indices.create(index)) {

--- a/graylog2-server/src/test/java/org/graylog2/indexer/ranges/EsIndexRangeServiceTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/indexer/ranges/EsIndexRangeServiceTest.java
@@ -82,7 +82,7 @@ public class EsIndexRangeServiceTest {
 
     @Before
     public void setUp() throws Exception {
-        final Messages messages = new Messages(client, ELASTICSEARCH_CONFIGURATION);
+        final Messages messages = new Messages(client, ELASTICSEARCH_CONFIGURATION, new MetricRegistry());
         indices = new Indices(client, ELASTICSEARCH_CONFIGURATION, new IndexMapping(), messages);
         final Deflector deflector = new Deflector(null, ELASTICSEARCH_CONFIGURATION.getIndexPrefix(), new NullActivityWriter(), null, null, indices);
         indexRangeService = new EsIndexRangeService(client, deflector, localEventBus, new MetricRegistry());


### PR DESCRIPTION
If the timestamp field of a message is incompatible to the ES format we are using, or an unknown data type (non Date, DateTime or String), force the timestamp to be "now".

This prevents bad extractors or inputs from causing these malformed messages to be discarded.

fix #2064