### PR TITLE
Fix actions using custom events from SearchStore

### DIFF
--- a/graylog2-web-interface/src/components/search/MessageFieldDescription.jsx
+++ b/graylog2-web-interface/src/components/search/MessageFieldDescription.jsx
@@ -1,10 +1,10 @@
-import $ from 'jquery';
 import React, {PropTypes} from 'react';
 import {Alert} from 'react-bootstrap';
 import Immutable from 'immutable';
 
 import StoreProvider from 'injection/StoreProvider';
 const MessagesStore = StoreProvider.getStore('Messages');
+const SearchStore = StoreProvider.getStore('Search');
 
 import MessageFieldSearchActions from './MessageFieldSearchActions';
 
@@ -36,7 +36,7 @@ const MessageFieldDescription = React.createClass({
   },
   addFieldToSearchBar(event) {
     event.preventDefault();
-    $(document).trigger('add-search-term.graylog.search', {field: this.props.fieldName, value: this.props.fieldValue});
+    SearchStore.addSearchTerm(this.props.fieldName, this.props.fieldValue);
   },
   _getFormattedTerms() {
     const termsMarkup = [];

--- a/graylog2-web-interface/src/components/sources/SourceDataTable.jsx
+++ b/graylog2-web-interface/src/components/sources/SourceDataTable.jsx
@@ -8,6 +8,9 @@ import SourceTitle from './SourceTitle';
 import UniversalSearch from 'logic/search/UniversalSearch';
 import StringUtils from 'util/StringUtils';
 
+import StoreProvider from 'injection/StoreProvider';
+const SearchStore = StoreProvider.getStore('Search');
+
 const SourceDataTable = React.createClass({
   propTypes: {
     numberOfTopValues: PropTypes.number.isRequired,
@@ -60,11 +63,7 @@ const SourceDataTable = React.createClass({
   _addSourceToSearchBarListener(table) {
     table.selectAll('td.dc-table-column .dc-search-button').on('click', () => {
       const source = $(d3.event.target).closest('button').data('source');
-      $(document).trigger('add-search-term.graylog.search', {
-        field: 'source',
-        value: source,
-        operator: UniversalSearch.orOperator(),
-      });
+      SearchStore.addSearchTerm('source', source, UniversalSearch.orOperator());
     });
   },
 

--- a/graylog2-web-interface/src/components/visualizations/QuickValuesVisualization.jsx
+++ b/graylog2-web-interface/src/components/visualizations/QuickValuesVisualization.jsx
@@ -9,8 +9,9 @@ const D3Utils = require('../../util/D3Utils');
 const StringUtils = require('../../util/StringUtils');
 import NumberUtils from 'util/NumberUtils';
 
-// Need to import jQuery from node to be able to send events :grumpy:
-import jQuery from 'jquery';
+import StoreProvider from 'injection/StoreProvider';
+const SearchStore = StoreProvider.getStore('Search');
+
 require('!script!../../../public/javascripts/jquery-2.1.1.min.js');
 require('!script!../../../public/javascripts/bootstrap.min.js');
 
@@ -132,8 +133,8 @@ const QuickValuesVisualization = React.createClass({
       .on('renderlet', (table) => {
         table.selectAll('.dc-table-group').classed('info', true);
         table.selectAll('td.dc-table-column button').on('click', () => {
-          const $term = $(d3.event.target).closest('button').data('term');
-          jQuery(document).trigger('add-search-term.graylog.search', {field: this.props.id, value: $term});
+          const term = $(d3.event.target).closest('button').data('term');
+          SearchStore.addSearchTerm(this.props.id, term);
         });
       });
 

--- a/graylog2-web-interface/src/legacy/Rickshaw.Graph.Graylog2Selector.js
+++ b/graylog2-web-interface/src/legacy/Rickshaw.Graph.Graylog2Selector.js
@@ -1,7 +1,11 @@
 import $ from 'jquery';
+import {} from 'jquery-ui';
 import Rickshaw from 'rickshaw';
 import NumberUtils from 'util/NumberUtils';
 import DateTime from 'logic/datetimes/DateTime';
+
+import StoreProvider from 'injection/StoreProvider';
+const SearchStore = StoreProvider.getStore('Search');
 
 Rickshaw.namespace('Rickshaw.Graph.Graylog2Selector');
 
@@ -104,10 +108,7 @@ const Graylog2Selector = Rickshaw.Class.create({
             const fromDate = new DateTime((position.xMin) * 1000);
             const toDate = new DateTime((position.xMax) * 1000);
 
-            $(document).trigger('change-timerange.graylog.search', {
-                rangeType: 'absolute',
-                rangeParams: { from: fromDate.toString(), to: toDate.toString() },
-            });
+            SearchStore.changeTimeRange('absolute', { from: fromDate.toString(), to: toDate.toString() });
 
             $(".timerange-selector-container").effect("bounce", {
                 complete: function () {

--- a/graylog2-web-interface/src/legacy/analyzers/fieldcharts.js
+++ b/graylog2-web-interface/src/legacy/analyzers/fieldcharts.js
@@ -15,6 +15,9 @@ import UserNotification from 'util/UserNotification';
 import StringUtils from 'util/StringUtils';
 import HistogramFormatter from 'logic/graphs/HistogramFormatter';
 
+import StoreProvider from 'injection/StoreProvider';
+const SearchStore = StoreProvider.getStore('Search');
+
 function generateShortId() {
   return Math.random().toString(36).substr(2, 9);
 }
@@ -54,12 +57,7 @@ export const FieldChart = {
   },
 
   _getDefaultOptions(opts) {
-    let searchParams = {};
-    jQuery(document).trigger('get-original-search.graylog.search', {
-      callback(params) {
-        searchParams = params.toJS();
-      },
-    });
+    const searchParams = SearchStore.getOriginalSearchParams().toJS();
 
     // Options.
     if (opts.chartid === undefined) {

--- a/graylog2-web-interface/src/stores/search/SavedSearchesStore.js
+++ b/graylog2-web-interface/src/stores/search/SavedSearchesStore.js
@@ -1,5 +1,4 @@
 import Reflux from 'reflux';
-import $ from 'jquery';
 import Qs from 'qs';
 import fetch from 'logic/rest/FetchProvider';
 
@@ -144,7 +143,7 @@ const SavedSearchesStore = Reflux.createStore({
     promise
       .then(() => {
         UserNotification.success(`Saved search "${this.savedSearches[searchId]}" was deleted successfully.`);
-        $(document).trigger('deleted.graylog.saved-search', {savedSearchId: searchId});
+        SearchStore.savedSearchDeleted(searchId);
       })
       .catch(error => {
         UserNotification.error(`Deleting saved search "${this.savedSearches[searchId]}" failed with status: ${error}`,

--- a/graylog2-web-interface/src/stores/search/SearchStore.ts
+++ b/graylog2-web-interface/src/stores/search/SearchStore.ts
@@ -36,13 +36,7 @@ class SearchStore {
 
     constructor() {
         this.load(true);
-
         window.addEventListener('resize', () => this.width = window.innerWidth);
-        $(document).on('add-search-term.graylog.search', this._addSearchTerm.bind(this));
-        $(document).on('get-original-search.graylog.search', this._getOriginalSearchRequest.bind(this));
-        $(document).on('change-timerange.graylog.search', this._changeTimeRange.bind(this));
-        $(document).on('execute.graylog.search', this._submitSearch.bind(this));
-        $(document).on('deleted.graylog.saved-search', this._savedSearchDeleted.bind(this));
     }
 
     load(firstLoad) {
@@ -71,11 +65,6 @@ class SearchStore {
 
     unload() {
         window.removeEventListener('resize', () => this.width = window.innerWidth);
-        $(document).off('add-search-term.graylog.search', this._addSearchTerm.bind(this));
-        $(document).off('get-original-search.graylog.search', this._getOriginalSearchRequest.bind(this));
-        $(document).off('change-timerange.graylog.search', this._changeTimeRange.bind(this));
-        $(document).off('execute.graylog.search', this._submitSearch.bind(this));
-        $(document).off('deleted.graylog.saved-search', this._savedSearchDeleted.bind(this));
     }
 
     initializeFieldsFromHash() {
@@ -214,19 +203,10 @@ class SearchStore {
         return originalSearch.set('rangeParams', rangeParams);
     }
 
-    _addSearchTerm(event, data) {
-        var term = data.hasOwnProperty('field') ? data.field + ":" : "";
-        term += SearchStore.escape(data.value);
-        var operator = data.operator || SearchStore.AND_OPERATOR;
-        this.addQueryTerm(term, operator);
-    }
-
-    _getOriginalSearchRequest(event, data) {
-        data.callback(this.getOriginalSearchParams());
-    }
-
-    _changeTimeRange(event, data) {
-        this.changeTimeRange(data['rangeType'], data['rangeParams']);
+    addSearchTerm(field, value, operator) {
+        const term = `${field}:${SearchStore.escape(value)}`;
+        const effectiveOperator = operator || SearchStore.AND_OPERATOR;
+        this.addQueryTerm(term, effectiveOperator);
     }
 
     changeTimeRange(newRangeType: string, newRangeParams: Object) {
@@ -240,9 +220,9 @@ class SearchStore {
         }
     }
 
-    _savedSearchDeleted(event, data) {
-        if (data.savedSearchId === this.savedSearch) {
-            this._submitSearch(event);
+    savedSearchDeleted(savedSearchId) {
+        if (savedSearchId === this.savedSearch) {
+            this._submitSearch(null);
         }
     }
 


### PR DESCRIPTION
We added events to the SearchStore when only part of our code was React, and everything was disconnected. Now we don't need them any more, and they are source of some troubles since we made the stores global. In this commit I'm changing our current code to directly use the SearchStore.

By the way, the issue reported in #2040 (and other issues with the custom events used before this PR) is only visible when running in production mode, at least I couldn't reproduce it with webpack-dev-server.

Fixes #2040