### PR TITLE
Delay requests for invalid session

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/rest/resources/system/SessionsResource.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/resources/system/SessionsResource.java
@@ -27,11 +27,11 @@ import org.apache.shiro.mgt.DefaultSecurityManager;
 import org.apache.shiro.session.UnknownSessionException;
 import org.apache.shiro.subject.Subject;
 import org.apache.shiro.util.ThreadContext;
+import org.graylog2.plugin.database.users.User;
 import org.graylog2.rest.models.system.sessions.requests.SessionCreateRequest;
 import org.graylog2.rest.models.system.sessions.responses.SessionResponse;
 import org.graylog2.shared.rest.resources.RestResource;
 import org.graylog2.shared.security.ShiroSecurityContext;
-import org.graylog2.plugin.database.users.User;
 import org.graylog2.shared.users.UserService;
 import org.joda.time.DateTime;
 import org.joda.time.DateTimeZone;
@@ -42,15 +42,14 @@ import javax.inject.Inject;
 import javax.validation.Valid;
 import javax.validation.constraints.NotNull;
 import javax.ws.rs.DELETE;
+import javax.ws.rs.GET;
 import javax.ws.rs.InternalServerErrorException;
 import javax.ws.rs.NotAuthorizedException;
-import javax.ws.rs.NotFoundException;
 import javax.ws.rs.POST;
 import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
 import javax.ws.rs.container.ContainerRequestContext;
 import javax.ws.rs.core.Context;
-import javax.ws.rs.core.Response;
 import javax.ws.rs.core.SecurityContext;
 import java.io.Serializable;
 import java.util.concurrent.TimeUnit;
@@ -119,6 +118,11 @@ public class SessionsResource extends RestResource {
         }
         throw new NotAuthorizedException("Invalid username or password", "Basic realm=\"Graylog Server session\"");
     }
+
+    @GET
+    @ApiOperation(value = "Validate an existing session", notes = "Checks the session with the given ID: return OK if session is valid.")
+    @RequiresAuthentication
+    public void validateSession() {}
 
     @DELETE
     @ApiOperation(value = "Terminate an existing session", notes = "Destroys the session with the given ID: the equivalent of logging out.")

--- a/graylog2-server/src/main/java/org/graylog2/rest/resources/system/SessionsResource.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/resources/system/SessionsResource.java
@@ -120,7 +120,8 @@ public class SessionsResource extends RestResource {
     }
 
     @GET
-    @ApiOperation(value = "Validate an existing session", notes = "Checks the session with the given ID: return OK if session is valid.")
+    @ApiOperation(value = "Validate an existing session",
+        notes = "Checks the session with the given ID: returns http status 204 (No Content) if session is valid.")
     @RequiresAuthentication
     public void validateSession() {}
 

--- a/graylog2-web-interface/src/logic/rest/FetchProvider.js
+++ b/graylog2-web-interface/src/logic/rest/FetchProvider.js
@@ -12,13 +12,15 @@ import history from 'util/History';
 export class FetchError extends Error {
   constructor(message, additional) {
     super(message);
-    this.message = message ? message : (additional.message ? additional.message : 'Undefined error.');
+    this.message = message || (additional.message || 'Undefined error.');
+    /* eslint-disable no-console */
     try {
       console.error(`There was an error fetching a resource: ${this.message}.`,
         `Additional information: ${additional.body && additional.body.message ? additional.body.message : 'Not available'}`);
     } catch (e) {
       console.error(`There was an error fetching a resource: ${this.message}. No additional information available.`);
     }
+    /* eslint-enable no-console */
 
     this.additional = additional;
   }
@@ -32,7 +34,12 @@ export class Builder {
   authenticated() {
     const SessionStore = StoreProvider.getStore('Session');
     const token = SessionStore.getSessionId();
-    this.request = this.request.auth(token, 'session');
+
+    return this.session(token);
+  }
+
+  session(sessionId) {
+    this.request = this.request.auth(sessionId, 'session');
 
     return this;
   }

--- a/graylog2-web-interface/src/routing/ApiRoutes.js
+++ b/graylog2-web-interface/src/routing/ApiRoutes.js
@@ -125,6 +125,9 @@ const ApiRoutes = {
     delete: (savedSearchId) => { return { url: `/search/saved/${savedSearchId}` }; },
     update: (savedSearchId) => { return { url: `/search/saved/${savedSearchId}` }; },
   },
+  SessionsApiController: {
+    validate: () => { return { url: '/system/sessions' }; },
+  },
   StreamAlertsApiController: {
     create: (streamId) => { return { url: `/streams/${streamId}/alerts/conditions` }; },
     delete: (streamId, alertConditionId) => { return { url: `/streams/${streamId}/alerts/conditions/${alertConditionId}` }; },


### PR DESCRIPTION
This PR adds a simple check during initialisation of the `SessionStore` which validates that a persisted session id is still valid. If it is not, then all requests coming in will be delayed while listening for the login event, just like in the case where no session id exists at all.

This fixes a number of problems related to stores doing initialisation only once and fail when the session id is stale.

Fixes #1891, #2059.