### PR TITLE
Replace Atlassian IPMatcher with Netty IpSubnet

### DIFF
--- a/graylog2-server/pom.xml
+++ b/graylog2-server/pom.xml
@@ -278,10 +278,6 @@
             <groupId>org.graylog2.repackaged</groupId>
             <artifactId>grok</artifactId>
         </dependency>
-        <dependency>
-            <groupId>com.atlassian.ip</groupId>
-            <artifactId>atlassian-ip</artifactId>
-        </dependency>
 
         <dependency>
             <groupId>org.graylog2</groupId>

--- a/graylog2-server/src/main/java/org/graylog2/filters/blacklist/BlacklistIpMatcherCondition.java
+++ b/graylog2-server/src/main/java/org/graylog2/filters/blacklist/BlacklistIpMatcherCondition.java
@@ -16,24 +16,29 @@
  */
 package org.graylog2.filters.blacklist;
 
-import com.atlassian.ip.IPMatcher;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import org.jboss.netty.handler.ipfilter.IpSubnet;
 
 import java.net.InetAddress;
+import java.net.UnknownHostException;
 import java.util.Objects;
 
 public final class BlacklistIpMatcherCondition extends FilterDescription {
-    private IPMatcher ipMatcher;
+    private IpSubnet ipSubnet;
 
     @JsonProperty
     public void setPattern(String pattern) {
         this.pattern = pattern;
-        ipMatcher = IPMatcher.builder().addPatternOrHost(pattern).build();
+        try {
+            this.ipSubnet = new IpSubnet(pattern);
+        } catch (UnknownHostException e) {
+            throw new IllegalArgumentException("Invalid IP subnet pattern", e);
+        }
     }
 
     public boolean matchesInetAddress(InetAddress otherSource) {
         try {
-            return ipMatcher.matches(otherSource);
+            return ipSubnet.contains(otherSource);
         } catch (IllegalArgumentException e) {
             return false;
         }

--- a/graylog2-server/src/test/java/org/graylog2/filters/blacklist/BlacklistIpMatcherConditionTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/filters/blacklist/BlacklistIpMatcherConditionTest.java
@@ -1,0 +1,58 @@
+/**
+ * This file is part of Graylog.
+ *
+ * Graylog is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.graylog2.filters.blacklist;
+
+import com.google.common.net.InetAddresses;
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class BlacklistIpMatcherConditionTest {
+    @Test
+    public void matchesInetAddressIPv4() throws Exception {
+        final BlacklistIpMatcherCondition condition = new BlacklistIpMatcherCondition();
+        condition.setPattern("192.0.2.0/24");
+
+        assertThat(condition.matchesInetAddress(InetAddresses.forString("192.0.2.0"))).isTrue();
+        assertThat(condition.matchesInetAddress(InetAddresses.forString("192.0.2.42"))).isTrue();
+        assertThat(condition.matchesInetAddress(InetAddresses.forString("192.0.2.255"))).isTrue();
+        assertThat(condition.matchesInetAddress(InetAddresses.forString("192.0.3.0"))).isFalse();
+        assertThat(condition.matchesInetAddress(InetAddresses.forString("192.0.4.0"))).isFalse();
+        assertThat(condition.matchesInetAddress(InetAddresses.forString("::1"))).isFalse();
+        assertThat(condition.matchesInetAddress(InetAddresses.forString("127.0.0.1"))).isFalse();
+    }
+
+    @Test
+    public void matchesInetAddressIPv6() throws Exception {
+        final BlacklistIpMatcherCondition condition = new BlacklistIpMatcherCondition();
+        condition.setPattern("2001:DB8::/32");
+
+        assertThat(condition.matchesInetAddress(InetAddresses.forString("2001:DB8::0"))).isTrue();
+        assertThat(condition.matchesInetAddress(InetAddresses.forString("2001:DB8::42"))).isTrue();
+        assertThat(condition.matchesInetAddress(InetAddresses.forString("2001:0db8:ffff:ffff:ffff:ffff:ffff:ffff"))).isTrue();
+        assertThat(condition.matchesInetAddress(InetAddresses.forString("2001:DB9::0"))).isFalse();
+        assertThat(condition.matchesInetAddress(InetAddresses.forString("2001:0db7:ffff:ffff:ffff:ffff:ffff:ffff"))).isFalse();
+        assertThat(condition.matchesInetAddress(InetAddresses.forString("::1"))).isFalse();
+        assertThat(condition.matchesInetAddress(InetAddresses.forString("127.0.0.1"))).isFalse();
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void matchesInetAddressWithInvalidPattern() throws Exception {
+        final BlacklistIpMatcherCondition condition = new BlacklistIpMatcherCondition();
+        condition.setPattern("foobar");
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -133,18 +133,6 @@
                 <enabled>false</enabled>
             </snapshots>
         </repository>
-
-        <repository>
-            <id>atlassian-m2-repository</id>
-            <name>Atlassian Public Repository</name>
-            <url>https://maven.atlassian.com/public</url>
-            <releases>
-                <enabled>true</enabled>
-            </releases>
-            <snapshots>
-                <enabled>false</enabled>
-            </snapshots>
-        </repository>
     </repositories>
 
     <!-- Every dependency of the entire project is defined here. It will not be automatically inluded in the projects,
@@ -584,12 +572,6 @@
                 <groupId>com.floreysoft</groupId>
                 <artifactId>jmte</artifactId>
                 <version>3.2.0</version>
-            </dependency>
-
-            <dependency>
-                <groupId>com.atlassian.ip</groupId>
-                <artifactId>atlassian-ip</artifactId>
-                <version>3.1</version>
             </dependency>
 
             <dependency>


### PR DESCRIPTION
Since the license of the [`com.atlassian.ip:atlassian-ip`](https://www.versioneye.com/java/com.atlassian.ip:atlassian-ip/3.1) artifact is unclear, we'll take the safe route and use the IpSubnet from Netty.