### PR TITLE
Keep sort extractors while editing

### DIFF
--- a/graylog2-web-interface/src/pages/ExtractorsPage.jsx
+++ b/graylog2-web-interface/src/pages/ExtractorsPage.jsx
@@ -48,7 +48,9 @@ const ExtractorsPage = React.createClass({
       }
     }
 
-    this.setState({node: inputNode});
+    if (!this.state.node || this.state.node.node_id !== inputNode.node_id) {
+      this.setState({ node: inputNode });
+    }
   },
   _isLoading() {
     return !(this.state.input && this.state.node);


### PR DESCRIPTION
Avoid unnecessary re-renderings in the extractors page, which also helps keeping the extractor order while editing it.

Fixes #2086.