### PR TITLE
Dashboard usability changes

### DIFF
--- a/graylog2-web-interface/public/stylesheets/graylog2.less
+++ b/graylog2-web-interface/public/stylesheets/graylog2.less
@@ -1040,9 +1040,9 @@ td.limited {
 .dashboard {
   color: #333333;
   height: 100%;
-  margin-left: -10px;
-  min-width: 860px;
-  overflow: hidden;
+  margin: 0;
+  overflow: auto;
+  width: 100%;
 }
 
 .dashboard .gridster .gs-w {
@@ -1167,7 +1167,7 @@ td.limited {
 }
 
 .dashboard .gridster {
-  margin: 0;
+  margin-left: -10px;
   transition: none;
 }
 

--- a/graylog2-web-interface/public/stylesheets/graylog2.less
+++ b/graylog2-web-interface/public/stylesheets/graylog2.less
@@ -1039,8 +1039,9 @@ td.limited {
 
 .dashboard {
   color: #333333;
-  margin-left: -10px;
   height: 100%;
+  margin-left: -10px;
+  min-width: 860px;
   overflow: hidden;
 }
 
@@ -1065,7 +1066,9 @@ td.limited {
 }
 
 .dashboard .widget {
-  margin: 15px;
+  height: inherit;
+  margin: 0;
+  padding: 15px;
 }
 
 .dashboard .widget .widget-top {
@@ -1144,8 +1147,6 @@ td.limited {
   display: none;
 }
 
-/* New widgets */
-
 .datatable-badge {
   border-radius: 2px;
   display: inline-block;
@@ -1165,7 +1166,7 @@ td.limited {
   color: #E3E5E5;
 }
 
-.dashboard .gridster ul {
+.dashboard .gridster {
   margin: 0;
   transition: none;
 }
@@ -1176,12 +1177,6 @@ td.limited {
 
 .dashboard .gridster.gs-resize-disabled .widget {
   cursor: default;
-}
-
-.dashboard .widget {
-  height: inherit;
-  margin: 0;
-  padding: 15px;
 }
 
 .dashboard .widget .dc-chart {
@@ -1298,8 +1293,6 @@ td.limited {
 .dashboard .widget .not-available .spinner {
   vertical-align: middle;
 }
-
-/* End new widgets */
 
 .configuration-field-optional {
   margin-left: 5px;

--- a/graylog2-web-interface/src/components/common/GridsterContainer.jsx
+++ b/graylog2-web-interface/src/components/common/GridsterContainer.jsx
@@ -1,4 +1,4 @@
-import React, {PropTypes} from 'react';
+import React, { PropTypes } from 'react';
 import ReactDOM from 'react-dom';
 
 import { GridsterWidget } from 'components/common';
@@ -12,21 +12,40 @@ const GridsterContainer = React.createClass({
     children: PropTypes.node.isRequired,
     onPositionsChange: PropTypes.func.isRequired,
   },
+
   getInitialState() {
     return { grid: undefined };
   },
+
   componentDidMount() {
+    this._initializeDashboard();
+  },
+
+  WIDGET_WIDTH: 410,
+  WIDGET_HEIGHT: 200,
+
+  _initializeDashboard() {
     const rootNode = ReactDOM.findDOMNode(this.refs.gridster);
     const grid = this._initGridster(rootNode);
 
     this._lockGrid(grid);
 
-    this.setState({grid: grid});
+    this.setState({ grid: grid });
   },
+
   _initGridster(rootNode) {
+    const minColumns = Object.keys(this.props.positions).reduce((max, current) => {
+      const position = this.props.positions[current];
+      // Column may be set to 0 as default, but the minimum effective column is 1
+      const effectiveColumn = Math.max(position.col, 1);
+      return Math.max(max, effectiveColumn + position.width - 1);
+    }, 0);
+
     return $(rootNode).gridster({
       widget_margins: [10, 10],
-      widget_base_dimensions: [410, 200],
+      widget_base_dimensions: [this.WIDGET_WIDTH, this.WIDGET_HEIGHT],
+      autogrow_cols: true,
+      min_cols: minColumns,
       resize: {
         enabled: true,
         stop: this._onPositionsChange,
@@ -63,14 +82,14 @@ const GridsterContainer = React.createClass({
   },
   _onPositionsChange() {
     const positions = this.state.grid.serialize().map((position) => {
-      return {id: position.id, col: position.col, row: position.row, width: position.size_x, height: position.size_y};
+      return { id: position.id, col: position.col, row: position.row, width: position.size_x, height: position.size_y };
     });
     this.props.onPositionsChange(positions);
   },
 
   render() {
     const children = (this.state.grid && React.Children.map(this.props.children, (child) => {
-      const position = this.props.positions[child.props.id] || {row: 0, col: 0, width: 1, height: 1};
+      const position = this.props.positions[child.props.id];
 
       return (
         <GridsterWidget grid={this.state.grid} position={position}>

--- a/graylog2-web-interface/src/components/common/GridsterContainer.jsx
+++ b/graylog2-web-interface/src/components/common/GridsterContainer.jsx
@@ -89,7 +89,7 @@ const GridsterContainer = React.createClass({
 
   render() {
     const children = (this.state.grid && React.Children.map(this.props.children, (child) => {
-      const position = this.props.positions[child.props.id];
+      const position = this.props.positions[child.props.id] || {row: 0, col: 0, width: 1, height: 1};
 
       return (
         <GridsterWidget grid={this.state.grid} position={position}>

--- a/graylog2-web-interface/src/pages/ShowDashboardPage.jsx
+++ b/graylog2-web-interface/src/pages/ShowDashboardPage.jsx
@@ -214,6 +214,7 @@ const ShowDashboardPage = React.createClass({
         </PageHeader>
 
         {this.formatDashboard(dashboard)}
+        <div className="clearfix"/>
       </span>
     );
   },


### PR DESCRIPTION
These changes address some issues with dashboards:

- It is hard to move widgets to a new empty row when there is not enough height for a new widget
- Action buttons look odd on `md` screen sizes
- Resizing the window may hide some widgets, putting them out of reach

One of the biggest changes is that these changes are removing the broken responsive widget positioning we were trying to use in previous versions.

The reason for this is that Gridster doesn't really support that, so it was working in a random way, and changing the ordering as it pleased. Integrating Gridster into React made this even a worse problem, as now it is quite hard to know who is changing the DOM in which way.

So, instead of trying to unsuccessfully do that, I have changed the behaviour to always respect the positioning users set, regardless of the resolution. It is still possible to see all widgets in a small screen by scrolling, but we won't try to be smart about resizes and re-arrange all widgets in a random way.

That is not the ideal way I would like to have, but I think it's at least consistent, and fixes some issues while we use Gridster and React together.