### PR TITLE
Unconditionally overwrite Graylog index template

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/indexer/indices/Indices.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/indices/Indices.java
@@ -45,7 +45,6 @@ import org.elasticsearch.action.admin.indices.stats.IndexStats;
 import org.elasticsearch.action.admin.indices.stats.IndicesStatsRequest;
 import org.elasticsearch.action.admin.indices.stats.IndicesStatsResponse;
 import org.elasticsearch.action.admin.indices.stats.ShardStats;
-import org.elasticsearch.action.admin.indices.template.get.GetIndexTemplatesResponse;
 import org.elasticsearch.action.admin.indices.template.put.PutIndexTemplateRequest;
 import org.elasticsearch.action.bulk.BulkRequestBuilder;
 import org.elasticsearch.action.bulk.BulkResponse;
@@ -57,7 +56,6 @@ import org.elasticsearch.client.IndicesAdminClient;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.health.ClusterHealthStatus;
 import org.elasticsearch.cluster.metadata.IndexMetaData;
-import org.elasticsearch.cluster.metadata.IndexTemplateMetaData;
 import org.elasticsearch.cluster.metadata.MappingMetaData;
 import org.elasticsearch.cluster.routing.ShardRouting;
 import org.elasticsearch.common.collect.ImmutableOpenMap;
@@ -88,7 +86,6 @@ import javax.inject.Inject;
 import javax.inject.Singleton;
 import java.util.Collection;
 import java.util.Collections;
-import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
@@ -224,25 +221,6 @@ public class Indices {
 
     private void ensureIndexTemplate() {
         final Map<String, Object> template = indexMapping.messageTemplate(allIndicesAlias(), configuration.getAnalyzer());
-
-        // First check if we have to install the index template. If the template exists, we do not install it again.
-        // We do not compare the installed template in Elasticsearch with our template to avoid overwriting changes
-        // done by users.
-        try {
-            final GetIndexTemplatesResponse getIndexTemplatesResponse = c.admin().indices()
-                    .prepareGetTemplates(configuration.getTemplateName())
-                    .get();
-
-            final List<IndexTemplateMetaData> existingTemplate = getIndexTemplatesResponse.getIndexTemplates();
-
-            if (existingTemplate.size() > 0) {
-                LOG.debug("Index template \"{}\" exists, not installing it again.", configuration.getTemplateName());
-                return;
-            }
-        } catch (Exception e) {
-            LOG.error("Unable to get index template \"" + configuration.getTemplateName() + "\" from Elasticsearch.", e);
-        }
-
         final PutIndexTemplateRequest itr = c.admin().indices().preparePutTemplate(configuration.getTemplateName())
                 .setOrder(Integer.MIN_VALUE) // Make sure templates with "order: 0" are applied after our template!
                 .setSource(template)


### PR DESCRIPTION
Instead of checking for the existence of the internal Graylog index template in Elasticsearch and only writing the index template if none exists, this PR changes the behavior to unconditionally write (and overwrite) the index template.

Users should use their own index templates which are being merged with the existing Graylog index template prior to index creation.

Fixes #2089 