### PR TITLE
Only return deflector indices in Deflector#getAllDeflectorIndices()

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/indexer/Deflector.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/Deflector.java
@@ -212,7 +212,7 @@ public class Deflector { // extends Ablenkblech
      *
      * @return list of managed indices
      */
-    public String[] getAllIndexNames() {
+    public String[] getAllGraylogIndexNames() {
         final Map<String, IndexStats> indices = this.indices.getAll();
         final List<String> result = Lists.newArrayListWithExpectedSize(indices.size());
         for (String indexName : indices.keySet()) {
@@ -229,7 +229,7 @@ public class Deflector { // extends Ablenkblech
      *
      * @return index name and index stats
      */
-    public Map<String, IndexStats> getAllDeflectorIndices() {
+    public Map<String, IndexStats> getAllGraylogDeflectorIndices() {
         final ImmutableMap.Builder<String, IndexStats> result = ImmutableMap.builder();
         for (Map.Entry<String, IndexStats> e : indices.getAll().entrySet()) {
             final String name = e.getKey();

--- a/graylog2-server/src/main/java/org/graylog2/indexer/Deflector.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/Deflector.java
@@ -207,7 +207,12 @@ public class Deflector { // extends Ablenkblech
         return Collections.max(indexNumbers);
     }
 
-    public String[] getAllDeflectorIndexNames() {
+    /**
+     * Returns a list of all Graylog managed indices.
+     *
+     * @return list of managed indices
+     */
+    public String[] getAllIndexNames() {
         final Map<String, IndexStats> indices = this.indices.getAll();
         final List<String> result = Lists.newArrayListWithExpectedSize(indices.size());
         for (String indexName : indices.keySet()) {
@@ -219,12 +224,17 @@ public class Deflector { // extends Ablenkblech
         return result.toArray(new String[result.size()]);
     }
 
+    /**
+     * Returns all Graylog deflector indices.
+     *
+     * @return index name and index stats
+     */
     public Map<String, IndexStats> getAllDeflectorIndices() {
         final ImmutableMap.Builder<String, IndexStats> result = ImmutableMap.builder();
         for (Map.Entry<String, IndexStats> e : indices.getAll().entrySet()) {
             final String name = e.getKey();
 
-            if (isGraylogIndex(name)) {
+            if (isGraylogDeflectorIndex(name)) {
                 result.put(name, e.getValue());
             }
         }

--- a/graylog2-server/src/main/java/org/graylog2/indexer/counts/Counts.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/counts/Counts.java
@@ -35,7 +35,7 @@ public class Counts {
     }
 
     public long total() {
-        final SearchRequest request = c.prepareSearch(deflector.getAllIndexNames())
+        final SearchRequest request = c.prepareSearch(deflector.getAllGraylogIndexNames())
                 .setSize(0)
                 .request();
         return c.search(request).actionGet().getHits().totalHits();

--- a/graylog2-server/src/main/java/org/graylog2/indexer/counts/Counts.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/counts/Counts.java
@@ -35,7 +35,7 @@ public class Counts {
     }
 
     public long total() {
-        final SearchRequest request = c.prepareSearch(deflector.getAllDeflectorIndexNames())
+        final SearchRequest request = c.prepareSearch(deflector.getAllIndexNames())
                 .setSize(0)
                 .request();
         return c.search(request).actionGet().getHits().totalHits();

--- a/graylog2-server/src/main/java/org/graylog2/indexer/ranges/EsIndexRangeService.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/ranges/EsIndexRangeService.java
@@ -157,7 +157,7 @@ public class EsIndexRangeService implements IndexRangeService {
     @Override
     public SortedSet<IndexRange> findAll() {
         final ImmutableSortedSet.Builder<IndexRange> indexRanges = ImmutableSortedSet.orderedBy(IndexRange.COMPARATOR);
-        for (String index : deflector.getAllDeflectorIndexNames()) {
+        for (String index : deflector.getAllIndexNames()) {
             try {
                 indexRanges.add(cache.get(index));
             } catch (ExecutionException e) {

--- a/graylog2-server/src/main/java/org/graylog2/indexer/ranges/EsIndexRangeService.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/ranges/EsIndexRangeService.java
@@ -157,7 +157,7 @@ public class EsIndexRangeService implements IndexRangeService {
     @Override
     public SortedSet<IndexRange> findAll() {
         final ImmutableSortedSet.Builder<IndexRange> indexRanges = ImmutableSortedSet.orderedBy(IndexRange.COMPARATOR);
-        for (String index : deflector.getAllIndexNames()) {
+        for (String index : deflector.getAllGraylogIndexNames()) {
             try {
                 indexRanges.add(cache.get(index));
             } catch (ExecutionException e) {

--- a/graylog2-server/src/main/java/org/graylog2/indexer/ranges/RebuildIndexRangesJob.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/ranges/RebuildIndexRangesJob.java
@@ -77,7 +77,7 @@ public class RebuildIndexRangesJob extends SystemJob {
     public void execute() {
         info("Re-calculating index ranges.");
 
-        String[] indices = deflector.getAllDeflectorIndexNames();
+        String[] indices = deflector.getAllIndexNames();
         if (indices == null || indices.length == 0) {
             info("No indices, nothing to calculate.");
             return;

--- a/graylog2-server/src/main/java/org/graylog2/indexer/ranges/RebuildIndexRangesJob.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/ranges/RebuildIndexRangesJob.java
@@ -77,7 +77,7 @@ public class RebuildIndexRangesJob extends SystemJob {
     public void execute() {
         info("Re-calculating index ranges.");
 
-        String[] indices = deflector.getAllIndexNames();
+        String[] indices = deflector.getAllGraylogIndexNames();
         if (indices == null || indices.length == 0) {
             info("No indices, nothing to calculate.");
             return;

--- a/graylog2-server/src/main/java/org/graylog2/indexer/retention/strategies/AbstractIndexCountBasedRetentionStrategy.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/retention/strategies/AbstractIndexCountBasedRetentionStrategy.java
@@ -50,7 +50,7 @@ public abstract class AbstractIndexCountBasedRetentionStrategy implements Retent
 
     @Override
     public void retain() {
-        final Map<String, IndexStats> deflectorIndices = deflector.getAllDeflectorIndices();
+        final Map<String, IndexStats> deflectorIndices = deflector.getAllGraylogDeflectorIndices();
         final int indexCount = deflectorIndices.size();
         final Optional<Integer> maxIndices = getMaxNumberOfIndices();
 

--- a/graylog2-server/src/main/java/org/graylog2/periodical/IndexRangesCleanupPeriodical.java
+++ b/graylog2-server/src/main/java/org/graylog2/periodical/IndexRangesCleanupPeriodical.java
@@ -72,7 +72,7 @@ public class IndexRangesCleanupPeriodical extends Periodical {
             return;
         }
 
-        final Set<String> indexNames = ImmutableSet.copyOf(deflector.getAllDeflectorIndexNames());
+        final Set<String> indexNames = ImmutableSet.copyOf(deflector.getAllIndexNames());
         final SortedSet<IndexRange> indexRanges = indexRangeService.findAll();
 
         final Set<String> removedIndices = new HashSet<>();

--- a/graylog2-server/src/main/java/org/graylog2/periodical/IndexRangesCleanupPeriodical.java
+++ b/graylog2-server/src/main/java/org/graylog2/periodical/IndexRangesCleanupPeriodical.java
@@ -72,7 +72,7 @@ public class IndexRangesCleanupPeriodical extends Periodical {
             return;
         }
 
-        final Set<String> indexNames = ImmutableSet.copyOf(deflector.getAllIndexNames());
+        final Set<String> indexNames = ImmutableSet.copyOf(deflector.getAllGraylogIndexNames());
         final SortedSet<IndexRange> indexRanges = indexRangeService.findAll();
 
         final Set<String> removedIndices = new HashSet<>();

--- a/graylog2-server/src/main/java/org/graylog2/periodical/IndexRangesMigrationPeriodical.java
+++ b/graylog2-server/src/main/java/org/graylog2/periodical/IndexRangesMigrationPeriodical.java
@@ -19,9 +19,7 @@ package org.graylog2.periodical;
 import com.fasterxml.jackson.annotation.JsonAutoDetect;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.google.common.base.Predicate;
 import com.google.common.collect.ImmutableSet;
-import com.google.common.collect.Sets;
 import com.google.common.util.concurrent.Uninterruptibles;
 import org.graylog2.indexer.Deflector;
 import org.graylog2.indexer.cluster.Cluster;
@@ -89,7 +87,7 @@ public class IndexRangesMigrationPeriodical extends Periodical {
             Uninterruptibles.sleepUninterruptibly(5, TimeUnit.SECONDS);
         }
 
-        final Set<String> indexNames = ImmutableSet.copyOf(deflector.getAllDeflectorIndexNames());
+        final Set<String> indexNames = ImmutableSet.copyOf(deflector.getAllIndexNames());
 
         // Migrate old MongoDB index ranges
         final SortedSet<IndexRange> mongoIndexRanges = legacyMongoIndexRangeService.findAll();

--- a/graylog2-server/src/main/java/org/graylog2/periodical/IndexRangesMigrationPeriodical.java
+++ b/graylog2-server/src/main/java/org/graylog2/periodical/IndexRangesMigrationPeriodical.java
@@ -87,7 +87,7 @@ public class IndexRangesMigrationPeriodical extends Periodical {
             Uninterruptibles.sleepUninterruptibly(5, TimeUnit.SECONDS);
         }
 
-        final Set<String> indexNames = ImmutableSet.copyOf(deflector.getAllIndexNames());
+        final Set<String> indexNames = ImmutableSet.copyOf(deflector.getAllGraylogIndexNames());
 
         // Migrate old MongoDB index ranges
         final SortedSet<IndexRange> mongoIndexRanges = legacyMongoIndexRangeService.findAll();

--- a/graylog2-server/src/test/java/org/graylog2/indexer/DeflectorTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/indexer/DeflectorTest.java
@@ -90,14 +90,14 @@ public class DeflectorTest {
 
     @Test
     public void nullIndexerDoesNotThrow() {
-        final Map<String, IndexStats> deflectorIndices = deflector.getAllDeflectorIndices();
+        final Map<String, IndexStats> deflectorIndices = deflector.getAllGraylogDeflectorIndices();
         assertNotNull(deflectorIndices);
         assertEquals(0, deflectorIndices.size());
     }
 
     @Test
     public void nullIndexerDoesNotThrowOnIndexName() {
-        final String[] deflectorIndices = deflector.getAllIndexNames();
+        final String[] deflectorIndices = deflector.getAllGraylogIndexNames();
         assertNotNull(deflectorIndices);
         assertEquals(0, deflectorIndices.length);
     }

--- a/graylog2-server/src/test/java/org/graylog2/indexer/DeflectorTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/indexer/DeflectorTest.java
@@ -97,7 +97,7 @@ public class DeflectorTest {
 
     @Test
     public void nullIndexerDoesNotThrowOnIndexName() {
-        final String[] deflectorIndices = deflector.getAllDeflectorIndexNames();
+        final String[] deflectorIndices = deflector.getAllIndexNames();
         assertNotNull(deflectorIndices);
         assertEquals(0, deflectorIndices.length);
     }

--- a/graylog2-server/src/test/java/org/graylog2/indexer/counts/CountsTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/indexer/counts/CountsTest.java
@@ -81,7 +81,7 @@ public class CountsTest {
                 .get();
         assumeTrue(clusterHealthResponse.getStatus() == ClusterHealthStatus.GREEN);
 
-        when(deflector.getAllDeflectorIndexNames()).thenReturn(new String[]{INDEX_NAME});
+        when(deflector.getAllIndexNames()).thenReturn(new String[]{INDEX_NAME});
 
         counts = new Counts(client, deflector);
     }

--- a/graylog2-server/src/test/java/org/graylog2/indexer/counts/CountsTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/indexer/counts/CountsTest.java
@@ -81,7 +81,7 @@ public class CountsTest {
                 .get();
         assumeTrue(clusterHealthResponse.getStatus() == ClusterHealthStatus.GREEN);
 
-        when(deflector.getAllIndexNames()).thenReturn(new String[]{INDEX_NAME});
+        when(deflector.getAllGraylogIndexNames()).thenReturn(new String[]{INDEX_NAME});
 
         counts = new Counts(client, deflector);
     }


### PR DESCRIPTION
Unbreaks count based index retention (again).

Also rename `#getAllDeflectorIndexNames()` to `#getAllIndexNames()` for clarity.