### PR TITLE
Add config setting to override web interface endpoint URI

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/bootstrap/CmdLineTool.java
+++ b/graylog2-server/src/main/java/org/graylog2/bootstrap/CmdLineTool.java
@@ -343,11 +343,6 @@ public abstract class CmdLineTool implements CliCommand {
         LOG.debug("Loading configuration from config file: {}", configFile);
         processConfiguration(jadConfig);
 
-        if (configuration.getRestTransportUri() == null) {
-            configuration.setRestTransportUri(configuration.getDefaultRestTransportUri());
-            LOG.debug("No rest_transport_uri set. Using default [{}].", configuration.getRestTransportUri());
-        }
-
         return new NamedConfigParametersModule(jadConfig.getConfigurationBeans());
     }
 

--- a/graylog2-server/src/main/java/org/graylog2/plugin/BaseConfiguration.java
+++ b/graylog2-server/src/main/java/org/graylog2/plugin/BaseConfiguration.java
@@ -21,6 +21,7 @@ import com.github.joschi.jadconfig.util.Duration;
 import com.github.joschi.jadconfig.validators.PositiveDurationValidator;
 import com.github.joschi.jadconfig.validators.PositiveIntegerValidator;
 import com.github.joschi.jadconfig.validators.StringNotBlankValidator;
+import com.google.common.annotations.VisibleForTesting;
 import com.lmax.disruptor.BlockingWaitStrategy;
 import com.lmax.disruptor.BusySpinWaitStrategy;
 import com.lmax.disruptor.SleepingWaitStrategy;
@@ -126,6 +127,9 @@ public abstract class BaseConfiguration {
     @Parameter(value = "web_enable")
     private boolean webEnable = true;
 
+    @Parameter(value = "web_endpoint_uri")
+    private URI webEndpointUri;
+
     @Parameter(value = "web_enable_cors")
     private boolean webEnableCors = false;
 
@@ -166,14 +170,20 @@ public abstract class BaseConfiguration {
     }
 
     public URI getRestTransportUri() {
-        return Tools.getUriWithPort(restTransportUri, GRAYLOG_DEFAULT_PORT);
+        if (restTransportUri == null) {
+            LOG.debug("No rest_transport_uri set. Using default [{}].", getDefaultRestTransportUri());
+            return getDefaultRestTransportUri();
+        } else {
+            return Tools.getUriWithPort(restTransportUri, GRAYLOG_DEFAULT_PORT);
+        }
     }
 
     public void setRestTransportUri(final URI restTransportUri) {
         this.restTransportUri = restTransportUri;
     }
 
-    public URI getDefaultRestTransportUri() {
+    @VisibleForTesting
+    protected URI getDefaultRestTransportUri() {
         final URI transportUri;
         final URI listenUri = getRestListenUri();
 
@@ -372,5 +382,9 @@ public abstract class BaseConfiguration {
 
     public String getWebTlsKeyPassword() {
         return webTlsKeyPassword;
+    }
+
+    public URI getWebEndpointUri() {
+        return webEndpointUri == null ? getRestTransportUri() : webEndpointUri;
     }
 }

--- a/misc/graylog.conf
+++ b/misc/graylog.conf
@@ -83,6 +83,10 @@ rest_listen_uri = http://127.0.0.1:12900/
 # Web interface listen URI
 #web_listen_uri = http://127.0.0.1:9000/
 
+# Web interface endpoint URI. This setting can be overriden on a per-request basis with the X-Graylog-Server-URL header.
+# Default: $rest_transport_uri
+#web_endpoint_uri =
+
 # Enable CORS headers for the web interface. This is necessary for JS-clients accessing the server directly.
 # If these are disabled, modern browsers will not be able to retrieve resources from the server.
 #web_enable_cors = false


### PR DESCRIPTION
This PR adds the configuration setting `web_endpoint_uri` which allows to set the URI of the Graylog REST API used by the Graylog web interface.

By default, the `rest_transport_uri` is being used which might not work in more complicated network setups (e. g. on AWS using ELB and multiple Graylog server instances). The URI of the Graylog REST API can still be overridden on a per-request basis using the `X-Graylog-Server-URL` HTTP request header (see #1808).