### PR TITLE
Hide search refresh controls on sources page

### DIFF
--- a/graylog2-web-interface/src/components/search/SearchBar.jsx
+++ b/graylog2-web-interface/src/components/search/SearchBar.jsx
@@ -26,6 +26,13 @@ const SearchBar = React.createClass({
     userPreferences: React.PropTypes.object,
     savedSearches: React.PropTypes.arrayOf(React.PropTypes.object).isRequired,
     config: React.PropTypes.object,
+    displayRefreshControls: React.PropTypes.bool,
+  },
+
+  getDefaultProps() {
+    return {
+      displayRefreshControls: true,
+    };
   },
 
   getInitialState() {
@@ -392,9 +399,11 @@ const SearchBar = React.createClass({
                     <div className="col-md-6">
                       <div className="saved-searches-selector-container pull-right"
                            style={{ display: 'inline-flex', marginRight: 5 }}>
+                        {this.props.displayRefreshControls &&
                         <div style={{ marginRight: 5 }}>
                           <RefreshControls />
                         </div>
+                        }
                         <div style={{ width: 270 }}>
                           {this._getSavedSearchesSelector()}
                         </div>

--- a/graylog2-web-interface/src/routing/AppWithSearchBar.jsx
+++ b/graylog2-web-interface/src/routing/AppWithSearchBar.jsx
@@ -19,6 +19,7 @@ const ConfigurationActions = ActionsProvider.getActions('Configuration');
 const AppWithSearchBar = React.createClass({
   propTypes: {
     children: PropTypes.element.isRequired,
+    location: PropTypes.object,
     params: PropTypes.object,
   },
   mixins: [
@@ -66,6 +67,10 @@ const AppWithSearchBar = React.createClass({
       return React.cloneElement(child, { searchConfig: this.state.searchesClusterConfig });
     });
   },
+  _searchBarShouldDisplayRefreshControls() {
+    // Hide refresh controls on sources page
+    return this.props.location.pathname.indexOf('sources') !== 1;
+  },
   render() {
     if (this._isLoading()) {
       return <Spinner/>;
@@ -79,7 +84,8 @@ const AppWithSearchBar = React.createClass({
       <div className="container-fluid">
         <SearchBar ref="searchBar" userPreferences={this.state.currentUser.preferences}
                    savedSearches={this.state.savedSearches}
-                   config={this.state.searchesClusterConfig} />
+                   config={this.state.searchesClusterConfig}
+                   displayRefreshControls={this._searchBarShouldDisplayRefreshControls()} />
         <Row id="main-row">
           <Col md={12} id="main-content">
             {this._decorateChildren(this.props.children)}


### PR DESCRIPTION
For now we hide the refresh controls on the sources page. We could add them back in the future if we decide to allow refreshing the sources information.

Fixes #1821.