### PR TITLE
Fix change password form

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/rest/resources/users/UsersResource.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/resources/users/UsersResource.java
@@ -341,9 +341,9 @@ public class UsersResource extends RestResource {
     @ApiOperation("Update the password for a user.")
     @ApiResponses({
             @ApiResponse(code = 204, message = "The password was successfully updated. Subsequent requests must be made with the new password."),
-            @ApiResponse(code = 400, message = "If the old or new password is missing."),
-            @ApiResponse(code = 403, message = "If the requesting user has insufficient privileges to update the password for the given user or the old password was wrong."),
-            @ApiResponse(code = 404, message = "If the user does not exist.")
+            @ApiResponse(code = 400, message = "The new password is missing, or the old password is missing or incorrect."),
+            @ApiResponse(code = 403, message = "The requesting user has insufficient privileges to update the password for the given user."),
+            @ApiResponse(code = 404, message = "User does not exist.")
     })
     public void changePassword(
             @ApiParam(name = "username", value = "The name of the user whose password to change.", required = true)
@@ -391,7 +391,7 @@ public class UsersResource extends RestResource {
             user.setPassword(cr.password());
             userService.save(user);
         } else {
-            throw new ForbiddenException();
+            throw new BadRequestException("Old password is missing or incorrect.");
         }
     }
 

--- a/graylog2-web-interface/src/components/users/UserForm.jsx
+++ b/graylog2-web-interface/src/components/users/UserForm.jsx
@@ -173,7 +173,7 @@ const UserForm = React.createClass({
     let requiresOldPassword = true;
     if (this.isPermitted(permissions, 'users:passwordchange:*')) {
       // Ask for old password if user is editing their own account
-      requiresOldPassword = this.state.user.username === this.state.currentUser.username;
+      requiresOldPassword = this.props.user.username === this.state.currentUser.username;
     }
 
     const streamReadOptions = this.formatSelectedOptions(this.state.user.permissions, 'streams:read', this.state.streams);

--- a/graylog2-web-interface/src/components/users/UserForm.jsx
+++ b/graylog2-web-interface/src/components/users/UserForm.jsx
@@ -90,9 +90,9 @@ const UserForm = React.createClass({
     request.password = this.refs.password.getValue();
 
     UsersStore.changePassword(this.props.user.username, request).then(() => {
-      UserNotification.success('Password updated successfully.', 'Success!');
+      UserNotification.success('Password updated successfully.', 'Success');
     }, () => {
-      UserNotification.error('Updating password failed.', 'Error!');
+      UserNotification.error('Could not update password. Please verify that your current password is correct.', 'Updating password failed');
     });
   },
 
@@ -100,9 +100,9 @@ const UserForm = React.createClass({
     evt.preventDefault();
 
     UsersStore.update(this.props.user.username, this.state.user).then(() => {
-      UserNotification.success('User updated successfully.', 'Success!');
+      UserNotification.success('User updated successfully.', 'Success');
     }, () => {
-      UserNotification.error('Updating user failed.', 'Error!');
+      UserNotification.error('Could not update the user. Please check your logs for more information.', 'Updating user failed');
     });
   },
 


### PR DESCRIPTION
This PR addresses a couple of issues with the edit password form:

- Display the current (old) password input field when users edit their own profile]
- Change the response on the change password method, returning a 400 when the old password was missing or wrong, instead of a 403
- Improve error messages when there was an error updating the user or changing the password.

Fixes #2103 