### PR TITLE
Upgrade to Drools 6.4.0.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -97,7 +97,7 @@
         <apacheds-server.version>2.0.0-M20</apacheds-server.version>
         <surefire.version>2.19.1</surefire.version>
         <guice.version>4.0</guice.version>
-        <drools.version>6.3.0.Final</drools.version>
+        <drools.version>6.4.0.Final</drools.version>
         <slf4j.version>1.7.21</slf4j.version>
         <log4j.version>2.5</log4j.version>
         <mongojack.version>2.5.1</mongojack.version>


### PR DESCRIPTION
Release notes: https://docs.jboss.org/drools/release/6.4.0.Final/drools-docs/html/ch02.html#drools.ReleaseNotesDrools.6.4.0

Optional for Graylog 2.0.0, could also be moved to Graylog 2.1.0.