### PR TITLE
Change defaults of elasticsearch_discovery_zen_* settings

### DIFF
--- a/UPGRADING.asciidoc
+++ b/UPGRADING.asciidoc
@@ -12,6 +12,13 @@ Please see https://www.elastic.co/guide/en/elasticsearch/reference/2.0/breaking-
 
 The blog article https://www.elastic.co/blog/key-point-to-be-aware-of-when-upgrading-from-elasticsearch-1-to-2[Key points to be aware of when upgrading from Elasticsearch 1.x to 2.x] also contains interesting information about the upgrade path from Elasticsearch 1.x to 2.x.
 
+#### Multicast Discovery
+
+Multicast discovery has been removed from Elasticsearch 2.x (although it is still provided as an Elasticsearch plugin for now).
+
+To reflect this change, the `elasticsearch_discovery_zen_ping_unicast_hosts` now has to contain the address of at least one Elasticsearch node in the cluster which Graylog can connect to.
+
+
 #### Graylog Index Template
 
 Graylog applies a custom https://www.elastic.co/guide/en/elasticsearch/reference/2.0/indices-templates.html[index template] to ensure that the indexed messages adhere to a specific schema.
@@ -79,12 +86,14 @@ For better consistency, the defaults of some configuration settings have been ch
 
 .Configuration defaults
 |===
-| Setting name                 | Old default                    | New default
+| Setting name                                         | Old default                    | New default
 
-| `elasticsearch_cluster_name` | `graylog2`                     | `graylog`
-| `elasticsearch_node_name`    | `graylog2-server`              | `graylog-server`
-| `elasticsearch_index_prefix` | `graylog2`                     | `graylog`
-| `mongodb_uri`                | `mongodb://127.0.0.1/graylog2` | `mongodb://localhost/graylog`
+| `elasticsearch_cluster_name`                         | `graylog2`                     | `graylog`
+| `elasticsearch_node_name`                            | `graylog2-server`              | `graylog-server`
+| `elasticsearch_index_prefix`                         | `graylog2`                     | `graylog`
+| `elasticsearch_discovery_zen_ping_unicast_hosts`     | empty                          | `127.0.0.1:9300`
+| `elasticsearch_discovery_zen_ping_multicast_enabled` | `true`                         | `false`
+| `mongodb_uri`                                        | `mongodb://127.0.0.1/graylog2` | `mongodb://localhost/graylog`
 |===
 
 

--- a/graylog2-server/src/main/java/org/graylog2/configuration/ElasticsearchConfiguration.java
+++ b/graylog2-server/src/main/java/org/graylog2/configuration/ElasticsearchConfiguration.java
@@ -27,6 +27,7 @@ import com.github.joschi.jadconfig.validators.PositiveLongValidator;
 import org.joda.time.Period;
 
 import java.nio.file.Path;
+import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
 
@@ -56,10 +57,10 @@ public class ElasticsearchConfiguration {
     private boolean httpEnabled = false;
 
     @Parameter(value = "elasticsearch_discovery_zen_ping_multicast_enabled")
-    private boolean multicastDiscovery = true;
+    private boolean multicastDiscovery = false;
 
     @Parameter(value = "elasticsearch_discovery_zen_ping_unicast_hosts", converter = StringListConverter.class)
-    private List<String> unicastHosts;
+    private List<String> unicastHosts = Collections.singletonList("127.0.0.1:9300");
 
     @Parameter(value = "elasticsearch_discovery_initial_state_timeout")
     private String initialStateTimeout = "3s";
@@ -80,7 +81,7 @@ public class ElasticsearchConfiguration {
     private boolean disableVersionCheck = false;
 
     @Parameter(value = "elasticsearch_config_file", validator = FilePathReadableValidator.class)
-    private Path configFile; // = "/etc/graylog/server/elasticsearch.yml";
+    private Path configFile;
 
     @Parameter(value = "elasticsearch_index_prefix", required = true)
     private String indexPrefix = "graylog";

--- a/misc/graylog.conf
+++ b/misc/graylog.conf
@@ -118,8 +118,9 @@ rest_listen_uri = http://127.0.0.1:12900/
 # The size of the thread pool used exclusively for serving the web interface.
 #web_thread_pool_size = 16
 
-# Embedded Elasticsearch configuration file
-# pay attention to the working directory of the server, maybe use an absolute path here
+# Configuration file for the embedded Elasticsearch instance in Graylog.
+# Pay attention to the working directory of the server, maybe use an absolute path here.
+# Default: empty
 #elasticsearch_config_file = /etc/graylog/server/elasticsearch.yml
 
 # Disable checking the version of Elasticsearch for being compatible with this Graylog release.
@@ -159,6 +160,11 @@ allow_highlighting = false
 # Default: graylog-
 #elasticsearch_node_name_prefix = graylog-
 
+# A comma-separated list of Elasticsearch nodes which Graylog is using to connect to the Elasticsearch cluster,
+# see https://www.elastic.co/guide/en/elasticsearch/reference/2.3/modules-discovery-zen.html for details.
+# Default: 127.0.0.1
+#elasticsearch_discovery_zen_ping_unicast_hosts = 127.0.0.1:9300, 127.0.0.2:9500
+
 # we don't want the Graylog server to store any data, or be master node
 #elasticsearch_node_master = false
 #elasticsearch_node_data = false
@@ -169,8 +175,10 @@ allow_highlighting = false
 # we don't need to run the embedded HTTP server here
 #elasticsearch_http_enabled = false
 
+# Enable Elasticsearch multicast discovery. This requires the installation of an Elasticsearch plugin,
+# see https://www.elastic.co/guide/en/elasticsearch/plugins/2.3/discovery-multicast.html for details.
+# Default: false
 #elasticsearch_discovery_zen_ping_multicast_enabled = false
-#elasticsearch_discovery_zen_ping_unicast_hosts = 127.0.0.1:9300
 
 # Change the following setting if you are running into problems with timeouts during Elasticsearch cluster discovery.
 # The setting is specified in milliseconds, the default is 5000ms (5 seconds).


### PR DESCRIPTION
Multicast discovery has been removed from Elasticsearch 2.x, so users have to provide the address of at least one Elasticsearch node for Graylog to connect to.

* https://www.elastic.co/guide/en/elasticsearch/reference/2.0/breaking_20_network_changes.html#_multicast_removed
* https://www.elastic.co/guide/en/elasticsearch/reference/2.3/modules-discovery-zen.html
* https://www.elastic.co/guide/en/elasticsearch/plugins/2.3/discovery-multicast.html