### PR TITLE
ignore empty authentication tokens in LdapUserAuthenticator

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/security/realm/LdapUserAuthenticator.java
+++ b/graylog2-server/src/main/java/org/graylog2/security/realm/LdapUserAuthenticator.java
@@ -16,6 +16,7 @@
  */
 package org.graylog2.security.realm;
 
+import com.google.common.base.Strings;
 import org.apache.directory.api.ldap.model.cursor.CursorException;
 import org.apache.directory.api.ldap.model.exception.LdapException;
 import org.apache.directory.ldap.client.api.LdapConnectionConfig;
@@ -79,6 +80,10 @@ public class LdapUserAuthenticator extends AuthenticatingRealm {
         config.setCredentials(ldapSettings.getSystemPassword());
 
         final String principal = (String) token.getPrincipal();
+        if (Strings.isNullOrEmpty(principal) || token.getPassword() == null) {
+            // do not try to look a token up in LDAP if there is no principal or password
+            return null;
+        }
         LdapNetworkConnection connection = null;
         try {
             connection = ldapConnector.connect(config);


### PR DESCRIPTION
unauthenticated requests and requests which use sessions in the URL rather than via HTTP headers can have a null UsernamePasswordToken associated with them
The Ldap authenticator didn't check for null values before looking up the account, which lead to a harmless, but noisy exception which was not logged in previous versions

add null checks before use the token

fixes #2111