### PR TITLE
Properly generating link to node's api browser.

### DIFF
--- a/graylog2-web-interface/src/components/nodes/NodesActions.jsx
+++ b/graylog2-web-interface/src/components/nodes/NodesActions.jsx
@@ -1,6 +1,7 @@
 import React, {PropTypes} from 'react';
 import { LinkContainer } from 'react-router-bootstrap';
 import { Button, DropdownButton, MenuItem } from 'react-bootstrap';
+import URI from 'urijs';
 
 import { IfPermitted } from 'components/common';
 
@@ -38,6 +39,7 @@ const NodesActions = React.createClass({
     }
   },
   render() {
+    const apiBrowserURI = new URI(this.props.node.transport_address).directory('api-browser');
     return (
       <div className="item-actions">
         <LinkContainer to={Routes.SYSTEM.NODES.SHOW(this.props.node.node_id)}>
@@ -48,7 +50,7 @@ const NodesActions = React.createClass({
           <Button bsStyle="info">Metrics</Button>
         </LinkContainer>
 
-        <Button bsStyle="info" href={`${this.props.node.transport_address}api-browser`} target="_blank">
+        <Button bsStyle="info" href={apiBrowserURI} target="_blank">
           <i className="fa fa-external-link"/>&nbsp; API browser
         </Button>
 

--- a/graylog2-web-interface/src/components/nodes/NodesActions.jsx
+++ b/graylog2-web-interface/src/components/nodes/NodesActions.jsx
@@ -39,7 +39,7 @@ const NodesActions = React.createClass({
     }
   },
   render() {
-    const apiBrowserURI = new URI(this.props.node.transport_address).directory('api-browser');
+    const apiBrowserURI = new URI(`${this.props.node.transport_address}/api-browser`).normalizePathname();
     return (
       <div className="item-actions">
         <LinkContainer to={Routes.SYSTEM.NODES.SHOW(this.props.node.node_id)}>


### PR DESCRIPTION
We are now using URI.js to make sure that there is a good number of slashes (more than 0 and less than 2 between host/port and directory) included in the generated link target.

Fixes #2131 