### PR TITLE
Change BundleService#update() to only return boolean for success

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/bundles/BundleService.java
+++ b/graylog2-server/src/main/java/org/graylog2/bundles/BundleService.java
@@ -87,9 +87,9 @@ public class BundleService {
         return bundles;
     }
 
-    public ConfigurationBundle update(final String bundleId, final ConfigurationBundle bundle) {
-        final WriteResult<ConfigurationBundle, ObjectId> writeResult = dbCollection.updateById(new ObjectId(bundleId), bundle);
-        return writeResult.getSavedObject();
+    public boolean update(final String bundleId, final ConfigurationBundle bundle) {
+        final WriteResult<ConfigurationBundle, ObjectId> result = dbCollection.updateById(new ObjectId(bundleId), bundle);
+        return result.getN() == 1;
     }
 
     public ConfigurationBundle insert(final ConfigurationBundle bundle) {

--- a/graylog2-server/src/main/java/org/graylog2/rest/resources/system/bundles/BundleResource.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/resources/system/bundles/BundleResource.java
@@ -19,16 +19,16 @@ package org.graylog2.rest.resources.system.bundles;
 import com.codahale.metrics.annotation.Timed;
 import com.google.common.collect.ImmutableSetMultimap;
 import com.google.common.collect.Multimap;
-import org.apache.shiro.authz.annotation.RequiresAuthentication;
-import org.graylog2.bundles.BundleService;
-import org.graylog2.bundles.ConfigurationBundle;
-import org.graylog2.bundles.ExportBundle;
-import org.graylog2.database.NotFoundException;
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
 import io.swagger.annotations.ApiParam;
 import io.swagger.annotations.ApiResponse;
 import io.swagger.annotations.ApiResponses;
+import org.apache.shiro.authz.annotation.RequiresAuthentication;
+import org.graylog2.bundles.BundleService;
+import org.graylog2.bundles.ConfigurationBundle;
+import org.graylog2.bundles.ExportBundle;
+import org.graylog2.database.NotFoundException;
 import org.graylog2.shared.rest.resources.RestResource;
 import org.graylog2.shared.security.RestPermissions;
 import org.slf4j.Logger;
@@ -40,6 +40,7 @@ import javax.validation.constraints.NotNull;
 import javax.ws.rs.Consumes;
 import javax.ws.rs.DELETE;
 import javax.ws.rs.GET;
+import javax.ws.rs.InternalServerErrorException;
 import javax.ws.rs.POST;
 import javax.ws.rs.PUT;
 import javax.ws.rs.Path;
@@ -136,7 +137,10 @@ public class BundleResource extends RestResource {
             @NotNull @Valid
             final ConfigurationBundle configurationBundle) {
         checkPermission(RestPermissions.BUNDLE_UPDATE, bundleId);
-        bundleService.update(bundleId, configurationBundle);
+        final boolean result = bundleService.update(bundleId, configurationBundle);
+        if (!result) {
+            throw new InternalServerErrorException("Couldn't update content pack \"" + bundleId + "\"");
+        }
     }
 
     @DELETE

--- a/graylog2-server/src/test/java/org/graylog2/bundles/BundleServiceTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/bundles/BundleServiceTest.java
@@ -1,0 +1,83 @@
+/**
+ * This file is part of Graylog.
+ *
+ * Graylog is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.graylog2.bundles;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.lordofthejars.nosqlunit.mongodb.InMemoryMongoDb;
+import org.graylog2.bindings.providers.BundleExporterProvider;
+import org.graylog2.bindings.providers.BundleImporterProvider;
+import org.graylog2.bindings.providers.MongoJackObjectMapperProvider;
+import org.graylog2.database.MongoConnectionRule;
+import org.graylog2.shared.bindings.providers.ObjectMapperProvider;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnit;
+import org.mockito.junit.MockitoRule;
+
+import static com.lordofthejars.nosqlunit.mongodb.InMemoryMongoDb.InMemoryMongoRuleBuilder.newInMemoryMongoDbRule;
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class BundleServiceTest {
+    @ClassRule
+    public static final InMemoryMongoDb IN_MEMORY_MONGO_DB = newInMemoryMongoDbRule().build();
+
+    @Rule
+    public final MongoConnectionRule mongoRule = MongoConnectionRule.build("test");
+
+    @Rule
+    public final MockitoRule mockitoRule = MockitoJUnit.rule();
+
+    @Mock
+    private BundleImporterProvider bundleImporterProvider;
+    @Mock
+    private BundleExporterProvider bundleExporterProvider;
+
+    private BundleService bundleService;
+
+    @Before
+    public void setUp() throws Exception {
+        final ObjectMapper objectMapper = new ObjectMapperProvider().get();
+        bundleService = new BundleService(
+            new MongoJackObjectMapperProvider(objectMapper),
+            mongoRule.getMongoConnection(),
+            bundleImporterProvider,
+            bundleExporterProvider);
+    }
+
+    @Test
+    public void updateSucceedsInUpdatingExistingBundle() throws Exception {
+        final ConfigurationBundle bundle = bundleService.insert(new ConfigurationBundle());
+        final ConfigurationBundle newBundle = new ConfigurationBundle();
+        newBundle.setName("Test");
+        assertThat(bundleService.update(bundle.getId(), newBundle)).isTrue();
+        final ConfigurationBundle updatedBundle = bundleService.load(bundle.getId());
+        assertThat(updatedBundle.getId()).isEqualTo(bundle.getId());
+        assertThat(updatedBundle.getName())
+            .isNotEqualTo(bundle.getName())
+            .isEqualTo(newBundle.getName());
+    }
+
+    @Test
+    public void updateFailsInUpdatingNonExistingBundle() throws Exception {
+        final ConfigurationBundle bundle = new ConfigurationBundle();
+        bundle.setName("Test");
+        assertThat(bundleService.update("571f1b5d35f5441210c5434e", bundle)).isFalse();
+    }
+}


### PR DESCRIPTION
The `WriteResult` returned by `JacksonDBCollection#updateById()` doesn't contain the updated object and thus `WriteResult#getSavedObject()` failed with "No objects to return".
The returned `WriteResult` does contain the number of changed documents, though, so simply comparing that number with the expected number of updated documents suffices as return value of
`BundleService#update()`.

Fixes #2138