### PR TITLE
Add collector sidecar documentation page

### DIFF
--- a/graylog2-web-interface/src/util/DocsHelper.js
+++ b/graylog2-web-interface/src/util/DocsHelper.js
@@ -5,6 +5,7 @@ class DocsHelper {
     ALERTS: 'streams.html#alerts',
     CLUSTER_STATUS_EXPLAINED: 'configuring_es.html#cluster-status-explained',
     COLLECTOR: 'collector.html',
+    COLLECTOR_SIDECAR: 'collector_sidecar.html',
     CONFIGURING_ES: 'configuring_es.html',
     DASHBOARDS: 'dashboards.html',
     ES_CLUSTER_STATUS_RED: 'configuring_es.html#cluster-status-explained',


### PR DESCRIPTION
We need this to point to the url from the sidecar plugin.

Needs to be merged into master as well.