### PR TITLE
Allow URI for X-Graylog-Server-URL to be relative.

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/web/resources/AppConfigResource.java
+++ b/graylog2-server/src/main/java/org/graylog2/web/resources/AppConfigResource.java
@@ -17,6 +17,7 @@
 package org.graylog2.web.resources;
 
 import com.floreysoft.jmte.Engine;
+import com.google.common.base.Strings;
 import com.google.common.io.Resources;
 import org.graylog2.Configuration;
 import org.graylog2.rest.MoreMediaTypes;
@@ -28,7 +29,8 @@ import javax.ws.rs.Produces;
 import javax.ws.rs.core.Context;
 import javax.ws.rs.core.HttpHeaders;
 import java.io.IOException;
-import java.net.MalformedURLException;
+import java.net.URI;
+import java.net.URISyntaxException;
 import java.net.URL;
 import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
@@ -72,15 +74,20 @@ public class AppConfigResource {
         if (headers != null && !headers.isEmpty()) {
             endpointUri = headers.stream().filter(s -> {
                 try {
-                    final URL url = new URL(s);
-                    switch (url.getProtocol()) {
+                    if (Strings.isNullOrEmpty(s)) {
+                        return false;
+                    }
+                    final URI uri = new URI(s);
+                    if (!uri.isAbsolute()) {
+                        return true;
+                    }
+                    switch (uri.getScheme()) {
                         case "http":
                         case "https":
                             return true;
-                        default:
-                            return false;
                     }
-                } catch (MalformedURLException e) {
+                    return false;
+                } catch (URISyntaxException e) {
                     return false;
                 }
             }).findFirst();


### PR DESCRIPTION
This helps us to not rely on having a properly configured, publicly
visible, consistent absolute URL for the Graylog server. This makes
configuration a lot simpler for example for setups where both the web and
the REST port are exposed on a single port with a URL prefix for the
latter ("/api" for example), because in this case we can set
`X-Graylog-Server-URL` to a relative URI, regardless of the hostname.