### PR TITLE
Returning an explicit session validation response instead of http status

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/rest/models/system/sessions/responses/SessionValidationResponse.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/models/system/sessions/responses/SessionValidationResponse.java
@@ -1,0 +1,42 @@
+/**
+ * This file is part of Graylog.
+ *
+ * Graylog is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.graylog2.rest.models.system.sessions.responses;
+
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.auto.value.AutoValue;
+
+@AutoValue
+@JsonAutoDetect
+public abstract class SessionValidationResponse {
+    @JsonProperty("is_valid")
+    public abstract boolean isValid();
+
+    @JsonCreator
+    public static SessionValidationResponse create(@JsonProperty("is_valid") boolean isValid) {
+        return new AutoValue_SessionValidationResponse(isValid);
+    }
+
+    public static SessionValidationResponse valid() {
+        return new AutoValue_SessionValidationResponse(true);
+    }
+
+    public static SessionValidationResponse invalid() {
+        return new AutoValue_SessionValidationResponse(false);
+    }
+}

--- a/graylog2-server/src/main/java/org/graylog2/rest/resources/system/SessionsResource.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/resources/system/SessionsResource.java
@@ -21,16 +21,20 @@ import io.swagger.annotations.ApiOperation;
 import io.swagger.annotations.ApiParam;
 import org.apache.shiro.SecurityUtils;
 import org.apache.shiro.authc.AuthenticationException;
+import org.apache.shiro.authc.LockedAccountException;
 import org.apache.shiro.authc.UsernamePasswordToken;
 import org.apache.shiro.authz.annotation.RequiresAuthentication;
 import org.apache.shiro.mgt.DefaultSecurityManager;
+import org.apache.shiro.session.Session;
 import org.apache.shiro.session.UnknownSessionException;
 import org.apache.shiro.subject.Subject;
 import org.apache.shiro.util.ThreadContext;
 import org.graylog2.plugin.database.users.User;
 import org.graylog2.rest.models.system.sessions.requests.SessionCreateRequest;
 import org.graylog2.rest.models.system.sessions.responses.SessionResponse;
+import org.graylog2.rest.models.system.sessions.responses.SessionValidationResponse;
 import org.graylog2.shared.rest.resources.RestResource;
+import org.graylog2.shared.security.ShiroAuthenticationFilter;
 import org.graylog2.shared.security.ShiroSecurityContext;
 import org.graylog2.shared.users.UserService;
 import org.joda.time.DateTime;
@@ -48,10 +52,12 @@ import javax.ws.rs.NotAuthorizedException;
 import javax.ws.rs.POST;
 import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
+import javax.ws.rs.Produces;
 import javax.ws.rs.container.ContainerRequestContext;
 import javax.ws.rs.core.Context;
-import javax.ws.rs.core.Response;
+import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.SecurityContext;
+import java.io.IOException;
 import java.io.Serializable;
 import java.util.concurrent.TimeUnit;
 
@@ -62,12 +68,15 @@ public class SessionsResource extends RestResource {
 
     private final UserService userService;
     private final DefaultSecurityManager securityManager;
+    private final ShiroAuthenticationFilter authenticationFilter;
 
     @Inject
     public SessionsResource(UserService userService,
-                            DefaultSecurityManager securityManager) {
+                            DefaultSecurityManager securityManager,
+                            ShiroAuthenticationFilter authenticationFilter) {
         this.userService = userService;
         this.securityManager = securityManager;
+        this.authenticationFilter = authenticationFilter;
     }
 
     @POST
@@ -111,7 +120,7 @@ public class SessionsResource extends RestResource {
             subject.logout();
         }
         if (subject.isAuthenticated()) {
-            final org.apache.shiro.session.Session session = subject.getSession();
+            final Session session = subject.getSession();
             id = session.getId();
             // TODO is the validUntil attribute even used by anyone yet?
             return SessionResponse.create(new DateTime(session.getLastAccessTime(), DateTimeZone.UTC).plus(session.getTimeout()).toDate(),
@@ -125,9 +134,19 @@ public class SessionsResource extends RestResource {
         notes = "Checks the session with the given ID: returns http status 204 (No Content) if session is valid.",
         code = 204
     )
-    @RequiresAuthentication
-    public Response validateSession() {
-        return Response.noContent().build();
+    @Produces(MediaType.APPLICATION_JSON)
+    public SessionValidationResponse validateSession(@Context ContainerRequestContext requestContext) {
+        try {
+            this.authenticationFilter.filter(requestContext);
+        } catch (NotAuthorizedException | LockedAccountException | IOException e) {
+            return SessionValidationResponse.invalid();
+        }
+        final Subject subject = getSubject();
+        if (!subject.isAuthenticated()) {
+            return SessionValidationResponse.invalid();
+        }
+
+        return SessionValidationResponse.valid();
     }
 
     @DELETE

--- a/graylog2-web-interface/src/stores/sessions/SessionStore.js
+++ b/graylog2-web-interface/src/stores/sessions/SessionStore.js
@@ -17,10 +17,12 @@ const SessionStore = Reflux.createStore({
   init() {
     const sessionId = Store.get('sessionId');
     const username = Store.get('username');
-    this._validateSession(sessionId).then(() => {
-      this.sessionId = sessionId;
-      this.username = username;
-      this._propagateState();
+    this._validateSession(sessionId).then((response) => {
+      if (response.is_valid) {
+        this.sessionId = sessionId;
+        this.username = username;
+        this._propagateState();
+      }
     });
   },
   getInitialState() {
@@ -53,6 +55,7 @@ const SessionStore = Reflux.createStore({
   _validateSession(sessionId) {
     return new Builder('GET', URLUtils.qualifyUrl(ApiRoutes.SessionsApiController.validate().url))
       .session(sessionId)
+      .json()
       .build();
   },
 


### PR DESCRIPTION
This helps us to prevent basic auth popups showing up for the request,
because of browsers intercepting 401s for non-CORS requests. Helps a lot
when the web interface is served over a single port using a relative
server URL like proposed and enabled in #2156.