### PR TITLE
Matching inverted exact/regex stream rules when field is not present

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/streams/StreamRouterEngine.java
+++ b/graylog2-server/src/main/java/org/graylog2/streams/StreamRouterEngine.java
@@ -36,6 +36,7 @@ import org.slf4j.LoggerFactory;
 
 import javax.annotation.Nullable;
 import javax.inject.Inject;
+import java.util.EnumSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -51,6 +52,7 @@ import java.util.concurrent.TimeUnit;
 public class StreamRouterEngine {
     private static final Logger LOG = LoggerFactory.getLogger(StreamRouterEngine.class);
 
+    private final EnumSet<StreamRuleType> ruleTypesNotNeedingFieldPresence = EnumSet.of(StreamRuleType.PRESENCE, StreamRuleType.EXACT, StreamRuleType.REGEX);
     private final List<Stream> streams;
     private final StreamFaultManager streamFaultManager;
     private final StreamMetrics streamMetrics;
@@ -156,7 +158,8 @@ public class StreamRouterEngine {
             final StreamRule streamRule = rule.getStreamRule();
             final StreamRuleType streamRuleType = streamRule.getType();
             final Stream.MatchingType matchingType = rule.getMatchingType();
-            if (streamRuleType != StreamRuleType.PRESENCE && !message.hasField(streamRule.getField())) {
+            if (!ruleTypesNotNeedingFieldPresence.contains(streamRuleType)
+                && !message.hasField(streamRule.getField())) {
                 if (matchingType == Stream.MatchingType.AND) {
                     result.remove(rule.getStream());
                     // blacklist stream because it can't match anymore

--- a/graylog2-server/src/main/java/org/graylog2/streams/matchers/ExactMatcher.java
+++ b/graylog2-server/src/main/java/org/graylog2/streams/matchers/ExactMatcher.java
@@ -26,17 +26,13 @@ public class ExactMatcher implements StreamRuleMatcher {
 
 	@Override
 	public boolean match(Message msg, StreamRule rule) {
-        if (!msg.hasField(rule.getField())) {
-            return false;
+        if (msg.getField(rule.getField()) == null) {
+            return rule.getInverted();
         }
 
-		Object value = msg.getField(rule.getField());
-		
-		if (value == null) {
-			return false;
-		}
-		
-		return rule.getInverted() ^ value.toString().trim().equals(rule.getValue());
+		final String value = msg.getField(rule.getField()).toString();
+
+		return rule.getInverted() ^ value.trim().equals(rule.getValue());
 	}
 
 }

--- a/graylog2-server/src/main/java/org/graylog2/streams/matchers/RegexMatcher.java
+++ b/graylog2-server/src/main/java/org/graylog2/streams/matchers/RegexMatcher.java
@@ -45,11 +45,11 @@ public class RegexMatcher implements StreamRuleMatcher {
     @Override
     public boolean match(Message msg, StreamRule rule) {
         if (msg.getField(rule.getField()) == null)
-            return false;
+            return rule.getInverted();
 
         try {
-            Pattern pattern = patternCache.get(rule.getValue());
-            CharSequence charSequence = new InterruptibleCharSequence(msg.getField(rule.getField()).toString());
+            final Pattern pattern = patternCache.get(rule.getValue());
+            final CharSequence charSequence = new InterruptibleCharSequence(msg.getField(rule.getField()).toString());
             return rule.getInverted() ^ pattern.matcher(charSequence).find();
         } catch (ExecutionException e) {
             LOG.error("Unable to get pattern from regex cache: ", e);

--- a/graylog2-server/src/test/java/org/graylog2/streams/matchers/ExactMatcherTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/streams/matchers/ExactMatcherTest.java
@@ -81,7 +81,34 @@ public class ExactMatcherTest extends MatcherTest {
         msg.addField("someother", "foo");
 
         StreamRuleMatcher matcher = getMatcher(rule);
+        assertTrue(matcher.match(msg, rule));
+    }
+
+    @Test
+    public void testNullFieldShouldNotMatch() {
+        final String fieldName = "nullfield";
+        final StreamRule rule = getSampleRule();
+        rule.setField(fieldName);
+
+        final Message msg = getSampleMessage();
+        msg.addField(fieldName, null);
+
+        final StreamRuleMatcher matcher = getMatcher(rule);
         assertFalse(matcher.match(msg, rule));
+    }
+
+    @Test
+    public void testInvertedNullFieldShouldMatch() {
+        final String fieldName = "nullfield";
+        final StreamRule rule = getSampleRule();
+        rule.setField(fieldName);
+        rule.setInverted(true);
+
+        final Message msg = getSampleMessage();
+        msg.addField(fieldName, null);
+
+        final StreamRuleMatcher matcher = getMatcher(rule);
+        assertTrue(matcher.match(msg, rule));
     }
 
     protected StreamRule getSampleRule() {

--- a/graylog2-server/src/test/java/org/graylog2/streams/matchers/RegexMatcherTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/streams/matchers/RegexMatcherTest.java
@@ -78,6 +78,60 @@ public class RegexMatcherTest extends MatcherTest {
     }
 
     @Test
+    public void testMissingFieldShouldNotMatch() throws Exception {
+        final StreamRule rule = getSampleRule();
+        rule.setField("nonexistingfield");
+        rule.setValue("^foo");
+
+        final Message msg = getSampleMessage();
+
+        final StreamRuleMatcher matcher = getMatcher(rule);
+        assertFalse(matcher.match(msg, rule));
+    }
+
+    @Test
+    public void testInvertedMissingFieldShouldMatch() throws Exception {
+        final StreamRule rule = getSampleRule();
+        rule.setField("nonexistingfield");
+        rule.setValue("^foo");
+        rule.setInverted(true);
+
+        final Message msg = getSampleMessage();
+
+        final StreamRuleMatcher matcher = getMatcher(rule);
+        assertTrue(matcher.match(msg, rule));
+    }
+
+    @Test
+    public void testNullFieldShouldNotMatch() throws Exception {
+        final String fieldName = "nullfield";
+        final StreamRule rule = getSampleRule();
+        rule.setField(fieldName);
+        rule.setValue("^foo");
+
+        final Message msg = getSampleMessage();
+        msg.addField(fieldName, null);
+
+        final StreamRuleMatcher matcher = getMatcher(rule);
+        assertFalse(matcher.match(msg, rule));
+    }
+
+    @Test
+    public void testInvertedNullFieldShouldMatch() throws Exception {
+        final String fieldName = "nullfield";
+        final StreamRule rule = getSampleRule();
+        rule.setField(fieldName);
+        rule.setValue("^foo");
+        rule.setInverted(true);
+
+        final Message msg = getSampleMessage();
+        msg.addField(fieldName, null);
+
+        final StreamRuleMatcher matcher = getMatcher(rule);
+        assertTrue(matcher.match(msg, rule));
+    }
+
+    @Test
     public void testSuccessfulComplexRegexMatch() {
         StreamRule rule = getSampleRule();
         rule.setField("some_field");


### PR DESCRIPTION
Before this change, inverted exact/regex stream rules did not match when the field was not present. This was counter intuitive and perceived as erroneus, this PR Is changing this behavior.

Fixes #2160 