### PR TITLE
Make alert conditions resilient against changing number formats.

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/alerts/AbstractAlertCondition.java
+++ b/graylog2-server/src/main/java/org/graylog2/alerts/AbstractAlertCondition.java
@@ -26,6 +26,7 @@ import org.graylog2.plugin.database.EmbeddedPersistable;
 import org.graylog2.plugin.streams.Stream;
 import org.joda.time.DateTime;
 
+import javax.annotation.Nullable;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Locale;
@@ -63,12 +64,7 @@ public abstract class AbstractAlertCondition implements EmbeddedPersistable, Ale
         this.creatorUserId = creatorUserId;
         this.parameters = parameters;
 
-        if (this.parameters.containsKey("grace")) {
-            this.grace = (Integer) this.parameters.get("grace");
-        } else {
-            this.grace = 0;
-        }
-
+        this.grace = getInt(this.parameters.get("grace"), 0);
     }
 
     protected abstract AlertCondition.CheckResult runCheck();
@@ -109,12 +105,7 @@ public abstract class AbstractAlertCondition implements EmbeddedPersistable, Ale
 
     @Override
     public Integer getBacklog() {
-        final Object rawParameter = getParameters().get("backlog");
-        if (rawParameter != null && rawParameter instanceof Number) {
-            return (Integer) rawParameter;
-        } else {
-            return 0;
-        }
+        return getInt(getParameters().get("backlog"), 0);
     }
 
     @Override
@@ -195,4 +186,21 @@ public abstract class AbstractAlertCondition implements EmbeddedPersistable, Ale
         }
     }
 
+    @Nullable
+    protected int getInt(Object o, Integer defaultValue) {
+        if (o == null) {
+            return defaultValue;
+        }
+
+        if (o instanceof Number) {
+            return ((Number)o).intValue();
+        }
+
+        return Double.valueOf(String.valueOf(o)).intValue();
+    }
+
+    @Nullable
+    protected Integer getInt(Object o) {
+        return getInt(o, null);
+    }
 }

--- a/graylog2-server/src/main/java/org/graylog2/alerts/AbstractAlertCondition.java
+++ b/graylog2-server/src/main/java/org/graylog2/alerts/AbstractAlertCondition.java
@@ -17,6 +17,7 @@
 package org.graylog2.alerts;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Lists;
 import org.graylog2.plugin.MessageSummary;
@@ -186,6 +187,7 @@ public abstract class AbstractAlertCondition implements EmbeddedPersistable, Ale
         }
     }
 
+    @VisibleForTesting
     protected Optional<Number> getNumber(Object o) {
         if (o instanceof Number) {
             return Optional.of((Number)o);

--- a/graylog2-server/src/main/java/org/graylog2/alerts/AbstractAlertCondition.java
+++ b/graylog2-server/src/main/java/org/graylog2/alerts/AbstractAlertCondition.java
@@ -187,7 +187,6 @@ public abstract class AbstractAlertCondition implements EmbeddedPersistable, Ale
         }
     }
 
-    @VisibleForTesting
     protected Optional<Number> getNumber(Object o) {
         if (o instanceof Number) {
             return Optional.of((Number)o);

--- a/graylog2-server/src/main/java/org/graylog2/alerts/AbstractAlertCondition.java
+++ b/graylog2-server/src/main/java/org/graylog2/alerts/AbstractAlertCondition.java
@@ -26,11 +26,11 @@ import org.graylog2.plugin.database.EmbeddedPersistable;
 import org.graylog2.plugin.streams.Stream;
 import org.joda.time.DateTime;
 
-import javax.annotation.Nullable;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Optional;
 import java.util.UUID;
 
 public abstract class AbstractAlertCondition implements EmbeddedPersistable, AlertCondition {
@@ -64,7 +64,7 @@ public abstract class AbstractAlertCondition implements EmbeddedPersistable, Ale
         this.creatorUserId = creatorUserId;
         this.parameters = parameters;
 
-        this.grace = getInt(this.parameters.get("grace"), 0);
+        this.grace = getNumber(this.parameters.get("grace")).orElse(0).intValue();
     }
 
     protected abstract AlertCondition.CheckResult runCheck();
@@ -105,7 +105,7 @@ public abstract class AbstractAlertCondition implements EmbeddedPersistable, Ale
 
     @Override
     public Integer getBacklog() {
-        return getInt(getParameters().get("backlog"), 0);
+        return getNumber(getParameters().get("backlog")).orElse(0).intValue();
     }
 
     @Override
@@ -186,21 +186,15 @@ public abstract class AbstractAlertCondition implements EmbeddedPersistable, Ale
         }
     }
 
-    @Nullable
-    protected int getInt(Object o, Integer defaultValue) {
-        if (o == null) {
-            return defaultValue;
-        }
-
+    protected Optional<Number> getNumber(Object o) {
         if (o instanceof Number) {
-            return ((Number)o).intValue();
+            return Optional.of((Number)o);
         }
 
-        return Double.valueOf(String.valueOf(o)).intValue();
-    }
-
-    @Nullable
-    protected Integer getInt(Object o) {
-        return getInt(o, null);
+        try {
+            return Optional.of(Double.valueOf(String.valueOf(o)));
+        } catch (NumberFormatException e) {
+            return Optional.empty();
+        }
     }
 }

--- a/graylog2-server/src/main/java/org/graylog2/alerts/types/FieldValueAlertCondition.java
+++ b/graylog2-server/src/main/java/org/graylog2/alerts/types/FieldValueAlertCondition.java
@@ -75,9 +75,9 @@ public class FieldValueAlertCondition extends AbstractAlertCondition {
 
         this.decimalFormat = new DecimalFormat("#.###", DecimalFormatSymbols.getInstance(Locale.ENGLISH));
 
-        this.time = getInt(parameters.get("time"), 0);
+        this.time = getNumber(parameters.get("time")).orElse(0).intValue();
         this.thresholdType = ThresholdType.valueOf(((String) parameters.get("threshold_type")).toUpperCase(Locale.ENGLISH));
-        this.threshold = getInt(parameters.get("threshold"), 0);
+        this.threshold = getNumber(parameters.get("threshold")).orElse(0.0).doubleValue();
         this.type = CheckType.valueOf(((String) parameters.get("type")).toUpperCase(Locale.ENGLISH));
         this.field = (String) parameters.get("field");
 

--- a/graylog2-server/src/main/java/org/graylog2/alerts/types/FieldValueAlertCondition.java
+++ b/graylog2-server/src/main/java/org/graylog2/alerts/types/FieldValueAlertCondition.java
@@ -75,9 +75,9 @@ public class FieldValueAlertCondition extends AbstractAlertCondition {
 
         this.decimalFormat = new DecimalFormat("#.###", DecimalFormatSymbols.getInstance(Locale.ENGLISH));
 
-        this.time = Integer.parseInt(String.valueOf(parameters.get("time")));
+        this.time = getInt(parameters.get("time"), 0);
         this.thresholdType = ThresholdType.valueOf(((String) parameters.get("threshold_type")).toUpperCase(Locale.ENGLISH));
-        this.threshold = Double.parseDouble(String.valueOf(parameters.get("threshold")));
+        this.threshold = getInt(parameters.get("threshold"), 0);
         this.type = CheckType.valueOf(((String) parameters.get("type")).toUpperCase(Locale.ENGLISH));
         this.field = (String) parameters.get("field");
 

--- a/graylog2-server/src/main/java/org/graylog2/alerts/types/MessageCountAlertCondition.java
+++ b/graylog2-server/src/main/java/org/graylog2/alerts/types/MessageCountAlertCondition.java
@@ -62,9 +62,9 @@ public class MessageCountAlertCondition extends AbstractAlertCondition {
         super(stream, id, Type.MESSAGE_COUNT, createdAt, creatorUserId, parameters);
 
         this.searches = searches;
-        this.time = Integer.parseInt(String.valueOf(parameters.get("time")));
+        this.time = getInt(parameters.get("time"), 0);
         this.thresholdType = ThresholdType.valueOf(((String) parameters.get("threshold_type")).toUpperCase(Locale.ENGLISH));
-        this.threshold = Integer.parseInt(String.valueOf(parameters.get("threshold")));
+        this.threshold = getInt(parameters.get("threshold"), 0);
     }
 
     @Override

--- a/graylog2-server/src/main/java/org/graylog2/alerts/types/MessageCountAlertCondition.java
+++ b/graylog2-server/src/main/java/org/graylog2/alerts/types/MessageCountAlertCondition.java
@@ -62,9 +62,9 @@ public class MessageCountAlertCondition extends AbstractAlertCondition {
         super(stream, id, Type.MESSAGE_COUNT, createdAt, creatorUserId, parameters);
 
         this.searches = searches;
-        this.time = getInt(parameters.get("time"), 0);
+        this.time = getNumber(parameters.get("time")).orElse(0).intValue();
         this.thresholdType = ThresholdType.valueOf(((String) parameters.get("threshold_type")).toUpperCase(Locale.ENGLISH));
-        this.threshold = getInt(parameters.get("threshold"), 0);
+        this.threshold = getNumber(parameters.get("threshold")).orElse(0).intValue();
     }
 
     @Override

--- a/graylog2-server/src/test/java/org/graylog2/alerts/AbstractAlertConditionTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/alerts/AbstractAlertConditionTest.java
@@ -16,6 +16,7 @@
  */
 package org.graylog2.alerts;
 
+import com.google.common.collect.ImmutableMap;
 import org.graylog2.plugin.Tools;
 import org.graylog2.plugin.alarms.AlertCondition;
 import org.junit.Before;
@@ -24,6 +25,7 @@ import org.junit.Test;
 
 import java.util.Map;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
@@ -60,6 +62,18 @@ public class AbstractAlertConditionTest extends AlertConditionTest {
         assertFalse("Should not be in grace period because grace is zero", alertService.inGracePeriod(alertConditionZeroGrace));
         alertLastTriggered(Integer.MAX_VALUE);
         assertFalse("Should not be in grace period because grace is zero", alertService.inGracePeriod(alertConditionZeroGrace));
+    }
+
+    @Test
+    public void testDifferingTypesForNumericalParameters() throws Exception {
+        final AlertCondition alertConditionWithDouble = getDummyAlertCondition(ImmutableMap.of("grace", 3.0));
+        assertEquals(alertConditionWithDouble.getGrace(), 3);
+        final AlertCondition alertConditionWithInteger = getDummyAlertCondition(ImmutableMap.of("grace", 3));
+        assertEquals(alertConditionWithInteger.getGrace(), 3);
+        final AlertCondition alertConditionWithStringDouble = getDummyAlertCondition(ImmutableMap.of("grace", "3.0"));
+        assertEquals(alertConditionWithStringDouble.getGrace(), 3);
+        final AlertCondition alertConditionWithStringInteger = getDummyAlertCondition(ImmutableMap.of("grace", "3"));
+        assertEquals(alertConditionWithStringInteger.getGrace(), 3);
     }
 
     protected AlertCondition getDummyAlertCondition(Map<String, Object> parameters) {

--- a/graylog2-server/src/test/java/org/graylog2/alerts/AbstractAlertConditionTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/alerts/AbstractAlertConditionTest.java
@@ -26,7 +26,10 @@ import org.junit.Test;
 import java.util.Map;
 import java.util.Optional;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
 
 public class AbstractAlertConditionTest extends AlertConditionTest {
     protected AlertCondition alertCondition;

--- a/graylog2-server/src/test/java/org/graylog2/alerts/AbstractAlertConditionTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/alerts/AbstractAlertConditionTest.java
@@ -24,10 +24,9 @@ import org.junit.Ignore;
 import org.junit.Test;
 
 import java.util.Map;
+import java.util.Optional;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.*;
 
 public class AbstractAlertConditionTest extends AlertConditionTest {
     protected AlertCondition alertCondition;
@@ -74,6 +73,32 @@ public class AbstractAlertConditionTest extends AlertConditionTest {
         assertEquals(alertConditionWithStringDouble.getGrace(), 3);
         final AlertCondition alertConditionWithStringInteger = getDummyAlertCondition(ImmutableMap.of("grace", "3"));
         assertEquals(alertConditionWithStringInteger.getGrace(), 3);
+    }
+
+    @Test
+    public void testGetNumberForDifferentFormats() throws Exception {
+        final AbstractAlertCondition alertCondition = (AbstractAlertCondition)getDummyAlertCondition(ImmutableMap.of("grace", 0));
+        final Optional<Number> optionalForInteger = alertCondition.getNumber(1);
+        assertEquals(optionalForInteger.orElse(null).intValue(), 1);
+        assertEquals(optionalForInteger.orElse(null).doubleValue(), 1.0, 0.0);
+
+        final Optional<Number> optionalForDouble = alertCondition.getNumber(42.23);
+        assertEquals(optionalForDouble.orElse(null).intValue(), 42);
+        assertEquals(optionalForDouble.orElse(null).doubleValue(), 42.23, 0.0);
+
+        final Optional<Number> optionalForStringInteger = alertCondition.getNumber("17");
+        assertEquals(optionalForStringInteger.orElse(null).intValue(), 17);
+        assertEquals(optionalForStringInteger.orElse(null).doubleValue(), 17.0, 0.0);
+
+        final Optional<Number> optionalForStringDouble = alertCondition.getNumber("23.42");
+        assertEquals(optionalForStringDouble.orElse(null).intValue(), 23);
+        assertEquals(optionalForStringDouble.orElse(null).doubleValue(), 23.42, 0.0);
+
+        final Optional<Number> optionalForNull = alertCondition.getNumber(null);
+        assertNull(optionalForNull.orElse(null));
+        assertNull(optionalForNull.orElse(null));
+        assertEquals(optionalForNull.orElse(1).intValue(), 1);
+        assertEquals(optionalForNull.orElse(1).doubleValue(), 1.0, 0.0);
     }
 
     protected AlertCondition getDummyAlertCondition(Map<String, Object> parameters) {


### PR DESCRIPTION
In 1.3.x numerical alert condition parameters were stored by MongoDB
(resp. the mongo java driver) in a way, that they are returned as
Doubles to the server, while alert conditions persisted in 2.0.0 return
numerical parameters as Integer. Therefore, 2.0.0 cannot handle alert
conditions stored in 1.3.x, so legacy installations upgraded to 2.0.0
do not check any alert conditions anymore.

This change allows to handle both formats by generally assuming they are
Number/Double types and returning their `intValue()`.

Fixes #2169