### PR TITLE
Forbid wildcard host (0.0.0.0) in rest_transport_uri

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/plugin/BaseConfiguration.java
+++ b/graylog2-server/src/main/java/org/graylog2/plugin/BaseConfiguration.java
@@ -173,6 +173,9 @@ public abstract class BaseConfiguration {
         if (restTransportUri == null) {
             LOG.debug("No rest_transport_uri set. Using default [{}].", getDefaultRestTransportUri());
             return getDefaultRestTransportUri();
+        } else if ("0.0.0.0".equals(restTransportUri.getHost())) {
+            LOG.warn("\"{}\" is not a valid setting for \"rest_transport_uri\". Using default [{}].", restTransportUri, getDefaultRestTransportUri());
+            return getDefaultRestTransportUri();
         } else {
             return Tools.getUriWithPort(restTransportUri, GRAYLOG_DEFAULT_PORT);
         }

--- a/graylog2-server/src/test/java/org/graylog2/plugin/BaseConfigurationTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/plugin/BaseConfigurationTest.java
@@ -94,7 +94,7 @@ public class BaseConfigurationTest {
     }
 
     @Test
-    public void testRestTransportUriWildcard() throws RepositoryException, ValidationException {
+    public void testRestListenUriWildcard() throws RepositoryException, ValidationException {
         validProperties.put("rest_listen_uri", "http://0.0.0.0:12900");
 
         Configuration configuration = new Configuration();
@@ -102,6 +102,17 @@ public class BaseConfigurationTest {
 
         Assert.assertNotEquals("http://0.0.0.0:12900", configuration.getDefaultRestTransportUri().toString());
         Assert.assertNotNull(configuration.getDefaultRestTransportUri());
+    }
+
+    @Test
+    public void testRestTransportUriWildcard() throws RepositoryException, ValidationException {
+        validProperties.put("rest_listen_uri", "http://0.0.0.0:12900");
+        validProperties.put("rest_transport_uri", "http://0.0.0.0:12900");
+
+        Configuration configuration = new Configuration();
+        new JadConfig(new InMemoryRepository(validProperties), configuration).process();
+
+        Assert.assertNotEquals(URI.create("http://0.0.0.0:12900"), configuration.getRestTransportUri());
     }
 
     @Test

--- a/misc/graylog.conf
+++ b/misc/graylog.conf
@@ -42,6 +42,7 @@ rest_listen_uri = http://127.0.0.1:12900/
 # this address and it is used to generate URLs addressing entities in the REST API. (see rest_listen_uri)
 # You will need to define this, if your Graylog server is running behind a HTTP proxy that is rewriting
 # the scheme, host name or URI.
+# This must not contain a wildcard address (0.0.0.0).
 #rest_transport_uri = http://192.168.1.1:12900/
 
 # Enable CORS headers for REST API. This is necessary for JS-clients accessing the server directly.


### PR DESCRIPTION
It's a common error for users to set `rest_transport_uri` to `http://0.0.0.0:12900` despite the documentation and comments advising not to.

The change in this PR explicitly checks that `rest_transport_uri` is in fact not the wildcard address, issues a warning if it is being used anyway, and falls back to the default transport address in this case.