### PR TITLE
Improve robustness for unreachable nodes

### DIFF
--- a/graylog2-web-interface/src/components/common/PageErrorOverview.jsx
+++ b/graylog2-web-interface/src/components/common/PageErrorOverview.jsx
@@ -1,0 +1,41 @@
+import React from 'react';
+import { Col, Jumbotron, Row } from 'react-bootstrap';
+
+import style from '!style/useable!css!pages/NotFoundPage.css';
+
+const PageErrorOverview = React.createClass({
+  propTypes: {
+    errors: React.PropTypes.array.isRequired,
+  },
+  componentDidMount() {
+    style.use();
+  },
+
+  componentWillUnmount() {
+    style.unuse();
+  },
+
+  _formatErrors(errors) {
+    const formattedErrors = errors ? errors.map((error) => <li>{error.toString()}</li>) : [];
+    return (
+      <ul>
+        {formattedErrors}
+      </ul>
+    );
+  },
+  render() {
+    return (
+      <Row className="jumbotron-container">
+        <Col mdOffset={2} md={8}>
+          <Jumbotron>
+            <h1>Error fetching data</h1>
+            <p>We had trouble fetching some data required to build this page.</p>
+            {this._formatErrors(this.props.errors)}
+          </Jumbotron>
+        </Col>
+      </Row>
+    );
+  },
+});
+
+export default PageErrorOverview;

--- a/graylog2-web-interface/src/components/common/PageErrorOverview.jsx
+++ b/graylog2-web-interface/src/components/common/PageErrorOverview.jsx
@@ -20,6 +20,7 @@ const PageErrorOverview = React.createClass({
     return (
       <ul>
         {formattedErrors}
+        <li>Check your Graylog logs for more information.</li>
       </ul>
     );
   },
@@ -28,8 +29,8 @@ const PageErrorOverview = React.createClass({
       <Row className="jumbotron-container">
         <Col mdOffset={2} md={8}>
           <Jumbotron>
-            <h1>Error fetching data</h1>
-            <p>We had trouble fetching some data required to build this page.</p>
+            <h1>Error getting data</h1>
+            <p>We had trouble fetching some data required to build this page, so here is a picture instead.</p>
             {this._formatErrors(this.props.errors)}
           </Jumbotron>
         </Col>

--- a/graylog2-web-interface/src/components/common/index.jsx
+++ b/graylog2-web-interface/src/components/common/index.jsx
@@ -13,6 +13,7 @@ export { default as LinkToNode } from './LinkToNode';
 export { default as KeyValueTable } from './KeyValueTable';
 export { default as MultiSelect } from './MultiSelect';
 export { default as Page } from './Page';
+export { default as PageErrorOverview } from './PageErrorOverview';
 export { default as PageHeader } from './PageHeader';
 export { default as PaginatedList } from './PaginatedList';
 export { default as Pluralize } from './Pluralize';

--- a/graylog2-web-interface/src/components/loggers/LoggerOverview.jsx
+++ b/graylog2-web-interface/src/components/loggers/LoggerOverview.jsx
@@ -13,10 +13,11 @@ const LoggerOverview = React.createClass({
     if (!this.state.loggers || !this.state.subsystems) {
       return <Spinner />;
     }
+    const subsystems = this.state.subsystems;
     const nodeLoggers = Object.keys(this.state.loggers)
-      .map((nodeId) => <NodeLoggers key={'node-loggers-' + nodeId}
+      .map((nodeId) => <NodeLoggers key={`node-loggers-${nodeId}`}
                                     nodeId={nodeId}
-                                    subsystems={this.state.subsystems[nodeId].subsystems}/>);
+                                    subsystems={subsystems[nodeId] ? subsystems[nodeId].subsystems : {}}/>);
     return (
       <span>
         {nodeLoggers}

--- a/graylog2-web-interface/src/components/systemjobs/SystemJobsComponent.jsx
+++ b/graylog2-web-interface/src/components/systemjobs/SystemJobsComponent.jsx
@@ -25,7 +25,9 @@ const SystemJobsComponent = React.createClass({
     if (!this.state.jobs) {
       return <Spinner />;
     }
-    const jobs = Object.keys(this.state.jobs).map((nodeId) => this.state.jobs[nodeId].jobs).reduce((a, b) => a.concat(b));
+    const jobs = Object.keys(this.state.jobs)
+      .map((nodeId) => this.state.jobs[nodeId] ? this.state.jobs[nodeId].jobs : [])
+      .reduce((a, b) => a.concat(b));
     return (
       <Row className="content">
         <Col md={12}>

--- a/graylog2-web-interface/src/pages/ShowNodePage.jsx
+++ b/graylog2-web-interface/src/pages/ShowNodePage.jsx
@@ -1,4 +1,4 @@
-import React, {PropTypes} from 'react';
+import React, { PropTypes } from 'react';
 import Reflux from 'reflux';
 
 import StoreProvider from 'injection/StoreProvider';
@@ -36,8 +36,8 @@ const ShowNodePage = React.createClass({
   },
   componentWillMount() {
     ClusterOverviewStore.jvm(this.props.params.nodeId)
-      .then(jvmInformation => this.setState({jvmInformation: jvmInformation}));
-    PluginsStore.list(this.props.params.nodeId).then(plugins => this.setState({plugins: plugins}));
+      .then(jvmInformation => this.setState({ jvmInformation: jvmInformation }));
+    PluginsStore.list(this.props.params.nodeId).then(plugins => this.setState({ plugins: plugins }));
     InputStatesStore.list().then(inputStates => {
       // We only want the input states for the current node
       const inputIds = Object.keys(inputStates);
@@ -49,7 +49,7 @@ const ShowNodePage = React.createClass({
         }
       });
 
-      this.setState({inputStates: filteredInputStates});
+      this.setState({ inputStates: filteredInputStates });
     });
   },
   _isLoading() {

--- a/graylog2-web-interface/src/pages/ShowNodePage.jsx
+++ b/graylog2-web-interface/src/pages/ShowNodePage.jsx
@@ -9,7 +9,7 @@ const InputStatesStore = StoreProvider.getStore('InputStates');
 const InputTypesStore = StoreProvider.getStore('InputTypes');
 
 import { NodeMaintenanceDropdown, NodeOverview } from 'components/nodes';
-import { PageHeader, Spinner } from 'components/common';
+import { PageErrorOverview, PageHeader, Spinner } from 'components/common';
 
 function nodeFilter(state) {
   return state.nodes ? state.nodes[this.props.params.nodeId] : state.nodes;
@@ -35,27 +35,32 @@ const ShowNodePage = React.createClass({
     };
   },
   componentWillMount() {
-    ClusterOverviewStore.jvm(this.props.params.nodeId)
-      .then(jvmInformation => this.setState({ jvmInformation: jvmInformation }));
-    PluginsStore.list(this.props.params.nodeId).then(plugins => this.setState({ plugins: plugins }));
-    InputStatesStore.list().then(inputStates => {
-      // We only want the input states for the current node
-      const inputIds = Object.keys(inputStates);
-      const filteredInputStates = [];
-      inputIds.forEach(inputId => {
-        const inputObject = inputStates[inputId][this.props.params.nodeId];
-        if (inputObject) {
-          filteredInputStates.push(inputObject);
-        }
-      });
+    Promise.all([
+      ClusterOverviewStore.jvm(this.props.params.nodeId)
+        .then(jvmInformation => this.setState({ jvmInformation: jvmInformation })),
+      PluginsStore.list(this.props.params.nodeId).then(plugins => this.setState({ plugins: plugins })),
+      InputStatesStore.list().then(inputStates => {
+        // We only want the input states for the current node
+        const inputIds = Object.keys(inputStates);
+        const filteredInputStates = [];
+        inputIds.forEach(inputId => {
+          const inputObject = inputStates[inputId][this.props.params.nodeId];
+          if (inputObject) {
+            filteredInputStates.push(inputObject);
+          }
+        });
 
-      this.setState({ inputStates: filteredInputStates });
-    });
+        this.setState({ inputStates: filteredInputStates });
+      }),
+    ]).then(() => {}, (errors) => this.setState({ errors: errors }));
   },
   _isLoading() {
     return !(this.state.node && this.state.systemOverview);
   },
   render() {
+    if (this.state.errors) {
+      return <PageErrorOverview errors={[this.state.errors]} />;
+    }
     if (this._isLoading()) {
       return <Spinner/>;
     }

--- a/graylog2-web-interface/src/stores/inputs/InputStatesStore.js
+++ b/graylog2-web-interface/src/stores/inputs/InputStatesStore.js
@@ -22,6 +22,9 @@ const InputStatesStore = Reflux.createStore({
       .then((response) => {
         const result = {};
         Object.keys(response).forEach((node) => {
+          if (!response[node]) {
+            return;
+          }
           response[node].forEach((input) => {
             if (!result[input.id]) {
               result[input.id] = {};
@@ -38,15 +41,12 @@ const InputStatesStore = Reflux.createStore({
 
   _checkInputStateChangeResponse(input, response, action) {
     const nodes = Object.keys(response).filter(node => input.global ? true : node === input.node);
-    let failedNodes = 0;
-    nodes.forEach(node => {
-      failedNodes = (response[node] === null ? failedNodes + 1 : failedNodes);
-    });
+    const failedNodes = nodes.filter((nodeId) => response[nodeId] === null);
 
-    if (failedNodes === 0) {
+    if (failedNodes.length === 0) {
       UserNotification.success(`Request to ${action.toLowerCase()} input '${input.title}' was sent successfully.`,
         `Input '${input.title}' will be ${action === 'START' ? 'started' : 'stopped'} shortly`);
-    } else if (failedNodes === nodes.length) {
+    } else if (failedNodes.length === nodes.length) {
       UserNotification.error(`Request to ${action.toLowerCase()} input '${input.title}' failed. Check your Graylog logs for more information.`,
         `Input '${input.title}' could not be ${action === 'START' ? 'started' : 'stopped'}`);
     } else {

--- a/graylog2-web-interface/src/stores/metrics/MetricsStore.js
+++ b/graylog2-web-interface/src/stores/metrics/MetricsStore.js
@@ -70,6 +70,9 @@ const MetricsStore = Reflux.createStore({
         .forEach((nodeId) => {
           const nodeMetrics = {};
 
+          if (!response[nodeId]) {
+            return;
+          }
           response[nodeId].metrics.forEach((metric) => {
             nodeMetrics[metric.full_name] = metric;
           });


### PR DESCRIPTION
Before this change, some pages were not loading when at least one node in the cluster was unreachable. With this change, information from reachable nodes is shown. Additionally, an error similar to the 404 page was created, which shows failed requests for pages which do not make sense to show at all when a node is not reachable.
