### PR TITLE
Adding check is path is unset (or "/") for `web_listen_uri` parameter.

### DIFF
--- a/UPGRADING.rst
+++ b/UPGRADING.rst
@@ -284,3 +284,11 @@ The output ID key for the list of outputs in the ``/streams/*`` endpoints has be
       "title": "ALL",
       "content_pack": null
     }
+
+
+Web Interface Config Changes
+----------------------------
+
+The web interface is now integrated into the server and was rewritten in React. Therefore configuring it has changed fundamentally since the last version(s). Please see our `Online Documentation <http://docs.graylog.org/en/2.0/pages/configuring_webif.html>` for details.
+
+Please take note that the ``application.context`` configuration parameter present in 1.x is not existing anymore. The web interface must be served without a path prefix currently.

--- a/graylog2-server/src/main/java/org/graylog2/Configuration.java
+++ b/graylog2-server/src/main/java/org/graylog2/Configuration.java
@@ -24,6 +24,7 @@ import com.github.joschi.jadconfig.validators.PositiveDurationValidator;
 import com.github.joschi.jadconfig.validators.PositiveIntegerValidator;
 import com.github.joschi.jadconfig.validators.PositiveLongValidator;
 import com.github.joschi.jadconfig.validators.StringNotBlankValidator;
+import org.graylog2.configuration.WebListenUriValidator;
 import org.graylog2.plugin.BaseConfiguration;
 import org.joda.time.DateTimeZone;
 
@@ -51,7 +52,7 @@ public class Configuration extends BaseConfiguration {
     @Parameter(value = "rest_listen_uri", required = true)
     private URI restListenUri = URI.create("http://127.0.0.1:" + GRAYLOG_DEFAULT_PORT + "/");
 
-    @Parameter(value = "web_listen_uri", required = true)
+    @Parameter(value = "web_listen_uri", required = true, validator = WebListenUriValidator.class)
     private URI webListenUri = URI.create("http://127.0.0.1:" + GRAYLOG_DEFAULT_WEB_PORT + "/");
 
     @Parameter(value = "output_batch_size", required = true, validator = PositiveIntegerValidator.class)

--- a/graylog2-server/src/main/java/org/graylog2/configuration/WebListenUriValidator.java
+++ b/graylog2-server/src/main/java/org/graylog2/configuration/WebListenUriValidator.java
@@ -1,0 +1,31 @@
+/**
+ * This file is part of Graylog.
+ *
+ * Graylog is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.graylog2.configuration;
+
+import com.github.joschi.jadconfig.ValidationException;
+import com.github.joschi.jadconfig.Validator;
+
+import java.net.URI;
+
+public class WebListenUriValidator implements Validator<URI> {
+    @Override
+    public void validate(String name, URI value) throws ValidationException {
+        if (value != null && !value.getPath().equals("/")) {
+            throw new ValidationException("Parameter " + name + " must not contain a path prefix (found " + value + ")");
+        }
+    }
+}

--- a/graylog2-server/src/main/java/org/graylog2/configuration/WebListenUriValidator.java
+++ b/graylog2-server/src/main/java/org/graylog2/configuration/WebListenUriValidator.java
@@ -18,13 +18,14 @@ package org.graylog2.configuration;
 
 import com.github.joschi.jadconfig.ValidationException;
 import com.github.joschi.jadconfig.Validator;
+import com.google.common.base.Strings;
 
 import java.net.URI;
 
 public class WebListenUriValidator implements Validator<URI> {
     @Override
     public void validate(String name, URI value) throws ValidationException {
-        if (value != null && !value.getPath().equals("/")) {
+        if (value != null && !Strings.isNullOrEmpty(value.getPath()) && !value.getPath().equals("/")) {
             throw new ValidationException("Parameter " + name + " must not contain a path prefix (found " + value + ")");
         }
     }

--- a/misc/graylog.conf
+++ b/misc/graylog.conf
@@ -81,7 +81,7 @@ rest_listen_uri = http://127.0.0.1:12900/
 # Default: true
 #web_enable = false
 
-# Web interface listen URI
+# Web interface listen URI. It must not contain a path other than "/".
 #web_listen_uri = http://127.0.0.1:9000/
 
 # Web interface endpoint URI. This setting can be overriden on a per-request basis with the X-Graylog-Server-URL header.


### PR DESCRIPTION
Right now we cannot handle a path prefix for the web interface assets, because of the way they are bundled. The config parameter allows one, so we need to explicitly check for it and raise an error when it is set to prevent undefined/unexpected behavior.

Fixes #2191.