### PR TITLE
Fix URL require on NotFoundPage.css

### DIFF
--- a/graylog2-web-interface/src/pages/NotFoundPage.css
+++ b/graylog2-web-interface/src/pages/NotFoundPage.css
@@ -1,5 +1,5 @@
 body {
-    background: url('~images/not-found-bg.jpg') no-repeat center center fixed;
+    background: url('../../public/images/not-found-bg.jpg') no-repeat center center fixed;
     -moz-background-size: cover;
     -webkit-background-size: cover;
     -o-background-size: cover;


### PR DESCRIPTION
Using `url('~images/not-found-bg.jpg')` fails to resolve the right directory when building the code from plugins in production mode.

The console error is during the build process is:
```
[INFO] ERROR in ../graylog2-server/graylog2-web-interface/~/css-loader!../graylog2-server/graylog2-web-interface/src/pages/NotFoundPage.css
[INFO] Module not found: Error: Cannot resolve module 'images/not-found-bg.jpg' in /foo/src/graylog2-server/graylog2-web-interface/src/pages
[INFO]  @ ../graylog2-server/graylog2-web-interface/~/css-loader!../graylog2-server/graylog2-web-interface/src/pages/NotFoundPage.css 6:58-92
```

Affected plugins fail to load in the browser on page load, as the image could not be resolved.

This is an issue with `NotFoundPage.css` since the file was first introduced, but it was never used from a plugin, so we didn't find it. Since a1dbc51, the file is required when doing a default import from `components/common`, and that's why we see the error now.