### PR TITLE
Normalize URIs

### DIFF
--- a/graylog2-web-interface/src/util/URLUtils.js
+++ b/graylog2-web-interface/src/util/URLUtils.js
@@ -1,9 +1,10 @@
 import Qs from 'qs';
+import URI from 'urijs';
 import AppConfig from 'util/AppConfig';
 
 const URLUtils = {
   qualifyUrl(url) {
-    return AppConfig.gl2ServerUrl() + this.appPrefixed(url);
+    return new URI(AppConfig.gl2ServerUrl() + this.appPrefixed(url)).normalizePathname().toString();
   },
   appPrefixed(url) {
     return this.concatURLPath(AppConfig.gl2AppPathPrefix(), url);


### PR DESCRIPTION
In some situations, the `gl2ServerUrl` configuration option may end in a slash. As we can't predict when that will happen, this commit is normalizing the path of generated URIs, avoiding URIs with duplicated slashes in their path (you can see an example in #2200).

I was able to reproduce the double slash issue in URIs by setting `rest_listen_uri` and `rest_transport_uri` to `http://127.0.0.1:12900/`. The most visible place to see them is the export CSV URL. Other URIs are also affected, but they are normalized by one of the network libraries we use.