### PR TITLE
MessageProcessors must be instantiated per processing thread

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/buffers/processors/ServerProcessBufferProcessor.java
+++ b/graylog2-server/src/main/java/org/graylog2/buffers/processors/ServerProcessBufferProcessor.java
@@ -28,7 +28,6 @@ import org.slf4j.LoggerFactory;
 
 import javax.annotation.Nonnull;
 import javax.inject.Inject;
-import javax.inject.Provider;
 
 /**
  * @author Dennis Oelkers <dennis@torch.sh>
@@ -42,10 +41,10 @@ public class ServerProcessBufferProcessor extends ProcessBufferProcessor {
 
     @Inject
     public ServerProcessBufferProcessor(MetricRegistry metricRegistry,
-                                        Provider<OrderedMessageProcessors> orderedMessageProcessorsProvider,
+                                        OrderedMessageProcessors orderedMessageProcessors,
                                         OutputBuffer outputBuffer) {
         super(metricRegistry);
-        this.orderedMessageProcessors = orderedMessageProcessorsProvider.get();
+        this.orderedMessageProcessors = orderedMessageProcessors;
         this.outputBuffer = outputBuffer;
     }
 

--- a/graylog2-server/src/main/java/org/graylog2/buffers/processors/ServerProcessBufferProcessor.java
+++ b/graylog2-server/src/main/java/org/graylog2/buffers/processors/ServerProcessBufferProcessor.java
@@ -28,6 +28,7 @@ import org.slf4j.LoggerFactory;
 
 import javax.annotation.Nonnull;
 import javax.inject.Inject;
+import javax.inject.Provider;
 
 /**
  * @author Dennis Oelkers <dennis@torch.sh>
@@ -41,10 +42,10 @@ public class ServerProcessBufferProcessor extends ProcessBufferProcessor {
 
     @Inject
     public ServerProcessBufferProcessor(MetricRegistry metricRegistry,
-                                        OrderedMessageProcessors orderedMessageProcessors,
+                                        Provider<OrderedMessageProcessors> orderedMessageProcessorsProvider,
                                         OutputBuffer outputBuffer) {
         super(metricRegistry);
-        this.orderedMessageProcessors = orderedMessageProcessors;
+        this.orderedMessageProcessors = orderedMessageProcessorsProvider.get();
         this.outputBuffer = outputBuffer;
     }
 

--- a/graylog2-server/src/main/java/org/graylog2/messageprocessors/MessageProcessorModule.java
+++ b/graylog2-server/src/main/java/org/graylog2/messageprocessors/MessageProcessorModule.java
@@ -22,8 +22,8 @@ public class MessageProcessorModule extends PluginModule {
     @Override
     protected void configure() {
         addMessageProcessor(MessageFilterChainProcessor.class, MessageFilterChainProcessor.Descriptor.class);
-
-        bind(OrderedMessageProcessors.class).asEagerSingleton();
+        // must not be a singleton, because each thread should get an isolated copy of the processors
+        bind(OrderedMessageProcessors.class);
     }
 
 }

--- a/graylog2-server/src/main/java/org/graylog2/messageprocessors/MessageProcessorModule.java
+++ b/graylog2-server/src/main/java/org/graylog2/messageprocessors/MessageProcessorModule.java
@@ -16,6 +16,7 @@
  */
 package org.graylog2.messageprocessors;
 
+import com.google.inject.Scopes;
 import org.graylog2.plugin.PluginModule;
 
 public class MessageProcessorModule extends PluginModule {
@@ -23,7 +24,7 @@ public class MessageProcessorModule extends PluginModule {
     protected void configure() {
         addMessageProcessor(MessageFilterChainProcessor.class, MessageFilterChainProcessor.Descriptor.class);
         // must not be a singleton, because each thread should get an isolated copy of the processors
-        bind(OrderedMessageProcessors.class);
+        bind(OrderedMessageProcessors.class).in(Scopes.NO_SCOPE);
     }
 
 }


### PR DESCRIPTION
When introducing the MessageProcessor interface, the processing threads accidentally shared the instances (and by induction the MessageFilter instances as well).
That posed no problem for most of the filters, because they do not rely on shared state, but the Drools filter does and could skip messages (because of Drools itself returning early)

This change uses a Provider to get the OrderedMessageProcessor instances explicitly and those do not get shared across threads.

fixes #2119
fixes #2188