### PR TITLE
Set Cache-Control on rest resources

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/shared/initializers/AbstractJerseyService.java
+++ b/graylog2-server/src/main/java/org/graylog2/shared/initializers/AbstractJerseyService.java
@@ -37,6 +37,7 @@ import org.graylog2.shared.rest.CORSFilter;
 import org.graylog2.shared.rest.NodeIdResponseFilter;
 import org.graylog2.shared.rest.PrintModelProcessor;
 import org.graylog2.shared.rest.RestAccessLogFilter;
+import org.graylog2.shared.rest.XHRFilter;
 import org.graylog2.shared.rest.exceptionmappers.AnyExceptionClassMapper;
 import org.graylog2.shared.rest.exceptionmappers.BadRequestExceptionMapper;
 import org.graylog2.shared.rest.exceptionmappers.JacksonPropertyExceptionMapper;
@@ -116,7 +117,8 @@ public abstract class AbstractJerseyService extends AbstractIdleService {
                 .registerFinder(new PackageNamesScanner(controllerPackages, true))
                 .registerResources(additionalResources)
                 .register(RestAccessLogFilter.class)
-                .register(NodeIdResponseFilter.class);
+                .register(NodeIdResponseFilter.class)
+                .register(XHRFilter.class);
 
         exceptionMappers.forEach(rc::registerClasses);
         dynamicFeatures.forEach(rc::registerClasses);

--- a/graylog2-server/src/main/java/org/graylog2/shared/rest/CORSFilter.java
+++ b/graylog2-server/src/main/java/org/graylog2/shared/rest/CORSFilter.java
@@ -40,7 +40,7 @@ public class CORSFilter implements ContainerRequestFilter, ContainerResponseFilt
         if (origin != null && !origin.isEmpty()) {
             responseContext.getHeaders().add("Access-Control-Allow-Origin", origin);
             responseContext.getHeaders().add("Access-Control-Allow-Credentials", true);
-            responseContext.getHeaders().add("Access-Control-Allow-Headers", "Authorization, Content-Type, X-Graylog-No-Session-Extension");
+            responseContext.getHeaders().add("Access-Control-Allow-Headers", "Authorization, Content-Type, X-Graylog-No-Session-Extension, X-Requested-With");
             responseContext.getHeaders().add("Access-Control-Allow-Methods", "GET, POST, PUT, DELETE, OPTIONS");
             // In order to avoid redoing the preflight thingy for every request, see http://stackoverflow.com/a/12021982/1088469
             responseContext.getHeaders().add("Access-Control-Max-Age", "600"); // 10 minutes seems to be the maximum allowable value
@@ -57,7 +57,7 @@ public class CORSFilter implements ContainerRequestFilter, ContainerResponseFilt
                 options.header("Access-Control-Allow-Origin", origin);
                 options.header("Access-Control-Allow-Credentials", true);
                 options.header("Access-Control-Allow-Headers",
-                               "Authorization, Content-Type, X-Graylog-No-Session-Extension");
+                               "Authorization, Content-Type, X-Graylog-No-Session-Extension, X-Requested-With");
                 options.header("Access-Control-Allow-Methods", "GET, POST, PUT, DELETE, OPTIONS");
                 // In order to avoid redoing the preflight thingy for every request, see http://stackoverflow.com/a/12021982/1088469
                 options.header("Access-Control-Max-Age", "600"); // 10 minutes seems to be the maximum allowable value

--- a/graylog2-server/src/main/java/org/graylog2/shared/rest/XHRFilter.java
+++ b/graylog2-server/src/main/java/org/graylog2/shared/rest/XHRFilter.java
@@ -1,0 +1,34 @@
+/**
+ * This file is part of Graylog.
+ *
+ * Graylog is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.graylog2.shared.rest;
+
+import javax.ws.rs.container.ContainerRequestContext;
+import javax.ws.rs.container.ContainerResponseContext;
+import javax.ws.rs.container.ContainerResponseFilter;
+import java.io.IOException;
+
+public class XHRFilter implements ContainerResponseFilter {
+
+    @Override
+    public void filter(ContainerRequestContext requestContext, ContainerResponseContext responseContext) throws IOException {
+        // Add no-cache to XMLHttpRequests, to avoid browsers caching results
+        String requestedWith = requestContext.getHeaders().getFirst("X-Requested-With");
+        if (requestedWith != null && requestedWith.equals("XMLHttpRequest")) {
+            responseContext.getHeaders().add("Cache-Control", "no-cache");
+        }
+    }
+}

--- a/graylog2-web-interface/src/logic/rest/FetchProvider.js
+++ b/graylog2-web-interface/src/logic/rest/FetchProvider.js
@@ -28,7 +28,7 @@ export class FetchError extends Error {
 
 export class Builder {
   constructor(method, url) {
-    this.request = request(method, url.replace(/([^:])\/\//, '$1/'));
+    this.request = request(method, url.replace(/([^:])\/\//, '$1/')).set('X-Requested-With', 'XMLHttpRequest');
   }
 
   authenticated() {


### PR DESCRIPTION
Some browsers cache Ajax requests (like IE/Edge), so we need to set the `Cache-Control` header to `no-cache` to avoid caching issues.

In order to only set cache headers into requests coming from browsers, we now set the `X-Requested-With` header in all our XHR requests coming from the web interface.

Fixes #2243.

This PR should also be merged into master.