### PR TITLE
Improve search with no results page

### DIFF
--- a/graylog2-web-interface/src/components/search/NoSearchResults.css
+++ b/graylog2-web-interface/src/components/search/NoSearchResults.css
@@ -1,0 +1,15 @@
+.search-actions h2 {
+    line-height: 30px;
+}
+
+.search-actions .actions {
+    text-align: right;
+}
+
+.search-actions .actions > div {
+    margin-left: 5px;
+}
+
+.search-actions p {
+    margin-top: 5px;
+}

--- a/graylog2-web-interface/src/components/search/NoSearchResults.jsx
+++ b/graylog2-web-interface/src/components/search/NoSearchResults.jsx
@@ -1,17 +1,32 @@
 import React from 'react';
 import { Col, Row } from 'react-bootstrap';
 
-import { AddSearchCountToDashboard, ShowQueryModal } from 'components/search';
+import { AddSearchCountToDashboard, SavedSearchControls, ShowQueryModal } from 'components/search';
+import AddToDashboardMenu from 'components/dashboard/AddToDashboardMenu';
 import DocumentationLink from 'components/support/DocumentationLink';
 
 import DocsHelper from 'util/DocsHelper';
 
+import StoreProvider from 'injection/StoreProvider';
+const SearchStore = StoreProvider.getStore('Search');
+
 const NoSearchResults = React.createClass({
   propTypes: {
     builtQuery: React.PropTypes.string,
+    histogram: React.PropTypes.object.isRequired,
     permissions: React.PropTypes.array.isRequired,
     searchInStream: React.PropTypes.object,
   },
+
+  componentDidMount() {
+    this.style.use();
+  },
+
+  componentWillUnmount() {
+    this.style.unuse();
+  },
+
+  style: require('!style/useable!css!./NoSearchResults.css'),
 
   _showQueryModal(event) {
     event.preventDefault();
@@ -28,12 +43,7 @@ const NoSearchResults = React.createClass({
       <div>
         <Row className="content content-head">
           <Col md={12}>
-            <h1>
-              <span className="pull-right">
-                <AddSearchCountToDashboard searchInStream={this.props.searchInStream} permissions={this.props.permissions} pullRight/>
-              </span>
-              <span>Nothing found {streamDescription}</span>
-            </h1>
+            <h1>Nothing found {streamDescription}</h1>
 
             <p className="description">
               Your search returned no results, try changing the used time range or the search query.{' '}
@@ -45,6 +55,32 @@ const NoSearchResults = React.createClass({
                 <DocumentationLink page={DocsHelper.PAGES.SEARCH_QUERY_LANGUAGE} text="documentation" />{' '}
                 if you need help with the search syntax or the time range selector.
               </strong>
+            </p>
+          </Col>
+        </Row>
+        <Row className="content search-actions">
+          <Col md={12}>
+            <Row className="row-sm">
+              <Col md={4}>
+                <h2>Search Actions</h2>
+              </Col>
+              <Col md={8}>
+                <div className="actions">
+                  <AddSearchCountToDashboard searchInStream={this.props.searchInStream}
+                                             permissions={this.props.permissions} pullRight />
+                  <AddToDashboardMenu title="Add histogram to dashboard"
+                                      widgetType="SEARCH_RESULT_CHART"
+                                      configuration={{ interval: this.props.histogram.interval }}
+                                      pullRight
+                                      permissions={this.props.permissions} />
+                  <SavedSearchControls currentSavedSearch={SearchStore.savedSearch} pullRight />
+                </div>
+              </Col>
+            </Row>
+
+            <p>
+              In case you expect this search to return results in the future, you can add search widgets to
+              dashboards, and manage your saved searches from here.
             </p>
           </Col>
         </Row>

--- a/graylog2-web-interface/src/components/search/NoSearchResults.jsx
+++ b/graylog2-web-interface/src/components/search/NoSearchResults.jsx
@@ -1,0 +1,74 @@
+import React from 'react';
+import { Col, Row } from 'react-bootstrap';
+
+import { AddSearchCountToDashboard, ShowQueryModal } from 'components/search';
+import DocumentationLink from 'components/support/DocumentationLink';
+
+import DocsHelper from 'util/DocsHelper';
+
+const NoSearchResults = React.createClass({
+  propTypes: {
+    builtQuery: React.PropTypes.string,
+    permissions: React.PropTypes.array.isRequired,
+    searchInStream: React.PropTypes.object,
+  },
+
+  _showQueryModal(event) {
+    event.preventDefault();
+    this.refs.showQueryModal.open();
+  },
+
+  render() {
+    let streamDescription = null;
+    if (this.props.searchInStream) {
+      streamDescription = <span>in stream <em>{this.props.searchInStream.title}</em></span>;
+    }
+
+    return (
+      <div>
+        <Row className="content content-head">
+          <Col md={12}>
+            <h1>
+              <span className="pull-right">
+                <AddSearchCountToDashboard searchInStream={this.props.searchInStream} permissions={this.props.permissions} pullRight/>
+              </span>
+              <span>Nothing found {streamDescription}</span>
+            </h1>
+
+            <p className="description">
+              Your search returned no results.&nbsp;
+              <a href="#" onClick={this._showQueryModal}>Show the Elasticsearch query.</a>
+              <ShowQueryModal key="debugQuery" ref="showQueryModal" builtQuery={this.props.builtQuery}/>
+              <strong>&nbsp;Take a look at the&nbsp;<DocumentationLink page={DocsHelper.PAGES.SEARCH_QUERY_LANGUAGE}
+                                                                       text="documentation"/>
+                &nbsp;if you need help with the search syntax.</strong>
+            </p>
+          </Col>
+        </Row>
+        <Row className="content">
+          <Col md={12}>
+            <div className="support-sources">
+              <h2>Need help?</h2>
+              Do not hesitate to consult the Graylog community if your questions are not answered in the&nbsp;
+              <DocumentationLink page={DocsHelper.PAGES.WELCOME} text="documentation"/>.
+
+              <ul>
+                <li><i className="fa fa-group" /> <a href="https://www.graylog.org/community-support/"
+                                                     target="_blank">Community support</a></li>
+                <li><i className="fa fa-github-alt" /> <a
+                  href="https://github.com/Graylog2/graylog2-server/issues" target="_blank">Issue tracker</a>
+                </li>
+                <li><i className="fa fa-heart" /> <a href="https://www.graylog.org/professional-support" target="_blank">
+                  Professional support
+                </a></li>
+              </ul>
+            </div>
+
+          </Col>
+        </Row>
+      </div>
+    );
+  },
+});
+
+export default NoSearchResults;

--- a/graylog2-web-interface/src/components/search/NoSearchResults.jsx
+++ b/graylog2-web-interface/src/components/search/NoSearchResults.jsx
@@ -36,12 +36,15 @@ const NoSearchResults = React.createClass({
             </h1>
 
             <p className="description">
-              Your search returned no results.&nbsp;
-              <a href="#" onClick={this._showQueryModal}>Show the Elasticsearch query.</a>
-              <ShowQueryModal key="debugQuery" ref="showQueryModal" builtQuery={this.props.builtQuery}/>
-              <strong>&nbsp;Take a look at the&nbsp;<DocumentationLink page={DocsHelper.PAGES.SEARCH_QUERY_LANGUAGE}
-                                                                       text="documentation"/>
-                &nbsp;if you need help with the search syntax.</strong>
+              Your search returned no results, try changing the used time range or the search query.{' '}
+              Do you want more details? <a href="#" onClick={this._showQueryModal}>Show the Elasticsearch query</a>.
+              <ShowQueryModal key="debugQuery" ref="showQueryModal" builtQuery={this.props.builtQuery} />
+              <br />
+              <strong>
+                Take a look at the{' '}
+                <DocumentationLink page={DocsHelper.PAGES.SEARCH_QUERY_LANGUAGE} text="documentation" />{' '}
+                if you need help with the search syntax or the time range selector.
+              </strong>
             </p>
           </Col>
         </Row>
@@ -49,18 +52,24 @@ const NoSearchResults = React.createClass({
           <Col md={12}>
             <div className="support-sources">
               <h2>Need help?</h2>
-              Do not hesitate to consult the Graylog community if your questions are not answered in the&nbsp;
-              <DocumentationLink page={DocsHelper.PAGES.WELCOME} text="documentation"/>.
+              <p>
+                Do not hesitate to consult the Graylog community if your questions are not answered in the{' '}
+                <DocumentationLink page={DocsHelper.PAGES.WELCOME} text="documentation" />.
+              </p>
 
               <ul>
-                <li><i className="fa fa-group" /> <a href="https://www.graylog.org/community-support/"
-                                                     target="_blank">Community support</a></li>
-                <li><i className="fa fa-github-alt" /> <a
-                  href="https://github.com/Graylog2/graylog2-server/issues" target="_blank">Issue tracker</a>
+                <li>
+                  <i className="fa fa-group"/>&nbsp;
+                  <a href="https://www.graylog.org/community-support/" target="_blank">Community support</a>
                 </li>
-                <li><i className="fa fa-heart" /> <a href="https://www.graylog.org/professional-support" target="_blank">
-                  Professional support
-                </a></li>
+                <li>
+                  <i className="fa fa-github-alt"/>&nbsp;
+                  <a href="https://github.com/Graylog2/graylog2-server/issues" target="_blank">Issue tracker</a>
+                </li>
+                <li>
+                  <i className="fa fa-heart"/>&nbsp;
+                  <a href="https://www.graylog.org/professional-support" target="_blank">Professional support</a>
+                </li>
               </ul>
             </div>
 

--- a/graylog2-web-interface/src/components/search/SavedSearchControls.jsx
+++ b/graylog2-web-interface/src/components/search/SavedSearchControls.jsx
@@ -13,6 +13,7 @@ const SavedSearchesActions = ActionsProvider.getActions('SavedSearches');
 const SavedSearchControls = React.createClass({
   propTypes: {
     currentSavedSearch: React.PropTypes.string,
+    pullRight: React.PropTypes.bool,
   },
   mixins: [Reflux.listenTo(SavedSearchesStore, '_updateTitle')],
   getInitialState() {
@@ -70,7 +71,7 @@ const SavedSearchControls = React.createClass({
   },
   _getEditSavedSearchControls() {
     return (
-      <DropdownButton bsSize="small" title="Saved search" id="saved-search-actions-dropdown">
+      <DropdownButton bsSize="small" title="Saved search" id="saved-search-actions-dropdown" pullRight={this.props.pullRight}>
         <MenuItem onSelect={this._openModal}>Update search criteria</MenuItem>
         <MenuItem divider/>
         <MenuItem onSelect={this._deleteSavedSearch}>Delete saved search</MenuItem>

--- a/graylog2-web-interface/src/components/search/SavedSearchControls.jsx
+++ b/graylog2-web-interface/src/components/search/SavedSearchControls.jsx
@@ -1,6 +1,6 @@
-import React, {PropTypes} from 'react';
+import React from 'react';
 import Reflux from 'reflux';
-import {Button, DropdownButton, MenuItem, Input} from 'react-bootstrap';
+import { Button, DropdownButton, MenuItem, Input } from 'react-bootstrap';
 
 import BootstrapModalForm from 'components/bootstrap/BootstrapModalForm';
 
@@ -12,7 +12,7 @@ const SavedSearchesActions = ActionsProvider.getActions('SavedSearches');
 
 const SavedSearchControls = React.createClass({
   propTypes: {
-    currentSavedSearch: PropTypes.string,
+    currentSavedSearch: React.PropTypes.string,
   },
   mixins: [Reflux.listenTo(SavedSearchesStore, '_updateTitle')],
   getInitialState() {
@@ -34,7 +34,7 @@ const SavedSearchControls = React.createClass({
 
     const currentSavedSearch = SavedSearchesStore.getSavedSearch(this.props.currentSavedSearch);
     if (currentSavedSearch !== undefined) {
-      this.setState({title: currentSavedSearch.title});
+      this.setState({ title: currentSavedSearch.title });
     }
   },
   _openModal() {
@@ -63,7 +63,7 @@ const SavedSearchControls = React.createClass({
     }
   },
   _titleChanged() {
-    this.setState({error: !SavedSearchesStore.isValidTitle(this.props.currentSavedSearch, this.refs.title.getValue())});
+    this.setState({ error: !SavedSearchesStore.isValidTitle(this.props.currentSavedSearch, this.refs.title.getValue()) });
   },
   _getNewSavedSearchButtons() {
     return <Button bsStyle="success" bsSize="small" onClick={this._openModal}>Save search criteria</Button>;
@@ -79,7 +79,7 @@ const SavedSearchControls = React.createClass({
   },
   render() {
     return (
-      <div style={{display: 'inline-block'}}>
+      <div style={{ display: 'inline-block' }}>
         {this._isSearchSaved() ? this._getEditSavedSearchControls() : this._getNewSavedSearchButtons()}
         <BootstrapModalForm ref="saveSearchModal"
                             title={this._isSearchSaved() ? 'Update saved search' : 'Save search criteria'}

--- a/graylog2-web-interface/src/components/search/SearchResult.jsx
+++ b/graylog2-web-interface/src/components/search/SearchResult.jsx
@@ -1,8 +1,8 @@
-import React, { PropTypes } from 'react';
+import React from 'react';
 import Immutable from 'immutable';
 import { Col, Row } from 'react-bootstrap';
 
-import { LegacyHistogram, NoSearchResults, ResultTable, SearchSidebar, ShowQueryModal } from 'components/search';
+import { LegacyHistogram, NoSearchResults, ResultTable, SearchSidebar } from 'components/search';
 
 import StoreProvider from 'injection/StoreProvider';
 const SearchStore = StoreProvider.getStore('Search');
@@ -12,17 +12,17 @@ import {} from 'components/field-analyzers'; // Make sure to load all field anal
 
 const SearchResult = React.createClass({
   propTypes: {
-    query: PropTypes.string,
-    builtQuery: PropTypes.string,
-    result: PropTypes.object.isRequired,
-    histogram: PropTypes.object.isRequired,
-    formattedHistogram: PropTypes.array,
-    searchInStream: PropTypes.object,
-    streams: PropTypes.instanceOf(Immutable.Map),
-    inputs: PropTypes.instanceOf(Immutable.Map),
-    nodes: PropTypes.instanceOf(Immutable.Map),
-    permissions: PropTypes.array.isRequired,
-    searchConfig: PropTypes.object.isRequired,
+    query: React.PropTypes.string,
+    builtQuery: React.PropTypes.string,
+    result: React.PropTypes.object.isRequired,
+    histogram: React.PropTypes.object.isRequired,
+    formattedHistogram: React.PropTypes.array,
+    searchInStream: React.PropTypes.object,
+    streams: React.PropTypes.instanceOf(Immutable.Map),
+    inputs: React.PropTypes.instanceOf(Immutable.Map),
+    nodes: React.PropTypes.instanceOf(Immutable.Map),
+    permissions: React.PropTypes.array.isRequired,
+    searchConfig: React.PropTypes.object.isRequired,
   },
 
   getDefaultProps() {
@@ -60,7 +60,7 @@ const SearchResult = React.createClass({
   },
 
   togglePageFields() {
-    this.setState({showAllFields: !this.state.showAllFields});
+    this.setState({ showAllFields: !this.state.showAllFields });
   },
 
   predefinedFieldSelection(setName) {
@@ -76,7 +76,7 @@ const SearchResult = React.createClass({
   updateSelectedFields(fieldSelection) {
     const selectedFields = this.sortFields(fieldSelection);
     SearchStore.fields = selectedFields;
-    this.setState({selectedFields: selectedFields});
+    this.setState({ selectedFields: selectedFields });
   },
   _fields() {
     return this.props.result[this.state.showAllFields ? 'all_fields' : 'fields'];
@@ -125,8 +125,13 @@ const SearchResult = React.createClass({
   _shouldRenderAboveHistogram(analyzer) {
     return analyzer.displayPriority > 0;
   },
+
   _shouldRenderBelowHistogram(analyzer) {
     return analyzer.displayPriority <= 0;
+  },
+
+  _toggleShouldHighlight() {
+    this.setState({ shouldHighlight: !this.state.shouldHighlight });
   },
 
   render() {
@@ -154,7 +159,7 @@ const SearchResult = React.createClass({
                          predefinedFieldSelection={this.predefinedFieldSelection}
                          showHighlightToggle={anyHighlightRanges}
                          shouldHighlight={this.state.shouldHighlight}
-                         toggleShouldHighlight={() => this.setState({shouldHighlight: !this.state.shouldHighlight})}
+                         toggleShouldHighlight={this._toggleShouldHighlight}
                          currentSavedSearch={SearchStore.savedSearch}
                          searchInStream={this.props.searchInStream}
                          permissions={this.props.permissions}

--- a/graylog2-web-interface/src/components/search/SearchResult.jsx
+++ b/graylog2-web-interface/src/components/search/SearchResult.jsx
@@ -2,14 +2,10 @@ import React, { PropTypes } from 'react';
 import Immutable from 'immutable';
 import { Col, Row } from 'react-bootstrap';
 
-import { AddSearchCountToDashboard, LegacyHistogram, ResultTable, SearchSidebar, ShowQueryModal } from 'components/search';
-
-import DocumentationLink from 'components/support/DocumentationLink';
+import { LegacyHistogram, NoSearchResults, ResultTable, SearchSidebar, ShowQueryModal } from 'components/search';
 
 import StoreProvider from 'injection/StoreProvider';
 const SearchStore = StoreProvider.getStore('Search');
-
-import DocsHelper from 'util/DocsHelper';
 
 import { PluginStore } from 'graylog-web-plugin/plugin';
 import {} from 'components/field-analyzers'; // Make sure to load all field analyzer plugins!
@@ -101,10 +97,6 @@ const SearchResult = React.createClass({
   addFieldAnalyzer(ref, field) {
     this.refs[ref].addField(field);
   },
-  _showQueryModal(event) {
-    event.preventDefault();
-    this.refs.showQueryModal.open();
-  },
 
   _fieldAnalyzers(filter) {
     return PluginStore.exports('fieldAnalyzers')
@@ -142,53 +134,10 @@ const SearchResult = React.createClass({
 
     // short circuit if the result turned up empty
     if (this.props.result.total_results === 0) {
-      let streamDescription = null;
-      if (this.props.searchInStream) {
-        streamDescription = <span>in stream <em>{this.props.searchInStream.title}</em></span>;
-      }
       return (
-        <div>
-          <Row className="content content-head">
-            <Col md={12}>
-              <h1>
-                <span className="pull-right">
-                  <AddSearchCountToDashboard searchInStream={this.props.searchInStream} permissions={this.props.permissions} pullRight/>
-                </span>
-                <span>Nothing found {streamDescription}</span>
-              </h1>
-
-              <p className="description">
-                Your search returned no results.&nbsp;
-                <a href="#" onClick={this._showQueryModal}>Show the Elasticsearch query.</a>
-                <ShowQueryModal key="debugQuery" ref="showQueryModal" builtQuery={this.props.builtQuery}/>
-                <strong>&nbsp;Take a look at the&nbsp;<DocumentationLink page={DocsHelper.PAGES.SEARCH_QUERY_LANGUAGE}
-                                                                         text="documentation"/>
-                  &nbsp;if you need help with the search syntax.</strong>
-              </p>
-            </Col>
-          </Row>
-          <Row className="content">
-            <Col md={12}>
-              <div className="support-sources">
-                <h2>Need help?</h2>
-                Do not hesitate to consult the Graylog community if your questions are not answered in the&nbsp;
-                <DocumentationLink page={DocsHelper.PAGES.WELCOME} text="documentation"/>.
-
-                <ul>
-                  <li><i className="fa fa-group" /> <a href="https://www.graylog.org/community-support/"
-                                                         target="_blank">Community support</a></li>
-                  <li><i className="fa fa-github-alt" /> <a
-                    href="https://github.com/Graylog2/graylog2-server/issues" target="_blank">Issue tracker</a>
-                  </li>
-                  <li><i className="fa fa-heart" /> <a href="https://www.graylog.org/professional-support" target="_blank">
-                    Professional support
-                  </a></li>
-                </ul>
-              </div>
-
-            </Col>
-          </Row>
-        </div>);
+        <NoSearchResults builtQuery={this.props.builtQuery} permissions={this.props.permissions}
+                         searchInStream={this.props.searchInStream} />
+      );
     }
     return (
       <Row id="main-content-search">

--- a/graylog2-web-interface/src/components/search/SearchResult.jsx
+++ b/graylog2-web-interface/src/components/search/SearchResult.jsx
@@ -135,8 +135,8 @@ const SearchResult = React.createClass({
     // short circuit if the result turned up empty
     if (this.props.result.total_results === 0) {
       return (
-        <NoSearchResults builtQuery={this.props.builtQuery} permissions={this.props.permissions}
-                         searchInStream={this.props.searchInStream} />
+        <NoSearchResults builtQuery={this.props.builtQuery} histogram={this.props.histogram}
+                         permissions={this.props.permissions} searchInStream={this.props.searchInStream} />
       );
     }
     return (

--- a/graylog2-web-interface/src/components/search/index.jsx
+++ b/graylog2-web-interface/src/components/search/index.jsx
@@ -9,6 +9,7 @@ export { default as MessageFieldSearchActions } from './MessageFieldSearchAction
 export { default as MessageShow } from './MessageShow';
 export { default as MessageTableEntry } from './MessageTableEntry';
 export { default as MessageTablePaginator } from './MessageTablePaginator';
+export { default as NoSearchResults } from './NoSearchResults';
 export { default as RefreshControls } from './RefreshControls';
 export { default as ResultTable } from './ResultTable';
 export { default as SavedSearchControls } from './SavedSearchControls';


### PR DESCRIPTION
This PR adds some actions to the page rendered when searches do not have any results. After the changes, these actions are available:

- Add count to dashboard
- Add histogram to dashboard
- Save search, or update/delete saved search if search was already saved

I also worked a bit in some texts, and reformatted the affected components.

Fixes https://github.com/Graylog2/graylog2-web-interface/issues/1639, and https://github.com/Graylog2/graylog2-web-interface/issues/1158.