### PR TITLE
Metrics improvements

### DIFF
--- a/graylog2-web-interface/src/components/metrics/MetricsComponent.jsx
+++ b/graylog2-web-interface/src/components/metrics/MetricsComponent.jsx
@@ -21,9 +21,14 @@ const MetricsComponent = React.createClass({
     return { filter: '' };
   },
   render() {
-    const filter = new RegExp(this.state.filter, 'i');
-    const filteredNames = this.props.names
-      .filter((metric) => String(metric.full_name).match(filter));
+    let filteredNames;
+    try {
+      const filter = new RegExp(this.state.filter, 'i');
+      filteredNames = this.props.names
+        .filter((metric) => String(metric.full_name).match(filter));
+    } catch (e) {
+      filteredNames = [];
+    }
     return (
       <Row className="content">
         <Col md={12}>

--- a/graylog2-web-interface/src/components/metrics/MetricsList.jsx
+++ b/graylog2-web-interface/src/components/metrics/MetricsList.jsx
@@ -1,6 +1,5 @@
 import React from 'react';
 
-import { Spinner } from 'components/common';
 import { Metric } from 'components/metrics';
 
 const MetricsList = React.createClass({
@@ -17,10 +16,13 @@ const MetricsList = React.createClass({
     );
   },
   render() {
+    const metrics = this.props.names
+      .sort((m1, m2) => m1.full_name.localeCompare(m2.full_name))
+      .map((metric) => this._formatMetric(metric));
+
     return (
       <ul className="metric-list">
-        {this.props.names.sort((m1, m2) => m1.full_name.localeCompare(m2.full_name))
-          .map((metric) => this._formatMetric(metric))}
+        {metrics.length > 0 ? metrics : <li>No metrics match the given filter. Please ensure you use a valid regular expression</li>}
       </ul>
     );
   },

--- a/graylog2-web-interface/src/components/nodes/BufferUsage.jsx
+++ b/graylog2-web-interface/src/components/nodes/BufferUsage.jsx
@@ -29,7 +29,7 @@ const BufferUsage = React.createClass({
     metricNames.forEach((metricName) => MetricsActions.add(this.props.nodeId, metricName));
   },
   _metricPrefix() {
-    return 'org.graylog2.buffers.' + this.props.bufferType + '.';
+    return `org\\.graylog2\\.buffers\\.${this.props.bufferType}\\.|${this.props.bufferType}buffer`;
   },
   render() {
     if (!this.state.metrics) {

--- a/graylog2-web-interface/src/pages/ShowMetricsPage.jsx
+++ b/graylog2-web-interface/src/pages/ShowMetricsPage.jsx
@@ -16,10 +16,12 @@ const ShowMetricsPage = React.createClass({
     location: PropTypes.object.isRequired,
     params: PropTypes.object.isRequired,
   },
-  mixins: [Reflux.connect(MetricsStore), Reflux.connect(NodesStore)],
-  componentDidMount() {
+  mixins: [Reflux.connect(NodesStore), Reflux.connect(MetricsStore), Reflux.listenTo(NodesStore, '_getMetrics')],
+
+  _getMetrics() {
     MetricsActions.names();
   },
+
   render() {
     if (!this.state.nodes || !this.state.metricsNames) {
       return <Spinner />;

--- a/graylog2-web-interface/src/stores/metrics/MetricsStore.js
+++ b/graylog2-web-interface/src/stores/metrics/MetricsStore.js
@@ -87,6 +87,11 @@ const MetricsStore = Reflux.createStore({
     MetricsActions.list.promise(promise);
   },
   names() {
+    if (!this.nodes) {
+      console.warn('Node list not yet available, not fetching metrics.');
+      return;
+    }
+
     const promise = this._allResults(Object.keys(this.nodes).map((nodeId) => {
       const url = URLUtils.qualifyUrl(ApiRoutes.ClusterMetricsApiController.byNamespace(nodeId, this.namespace).url);
       return fetch('GET', url).then((response) => {


### PR DESCRIPTION
While looking into #2250, I found a couple of issues with the metrics page:

- Doing a full page refresh on the metrics page raised an exception, as MetricsStore.name() was being called before the store had initialised the node list
- Writing an invalid regex in the metrics filter would raise an exception, and also break the page

This PR fixes those two issues, and also updates the filters to node buffers.