### PR TITLE
Fix issues with old dashboards

### DIFF
--- a/graylog2-web-interface/src/components/visualizations/QuickValuesVisualization.jsx
+++ b/graylog2-web-interface/src/components/visualizations/QuickValuesVisualization.jsx
@@ -260,7 +260,11 @@ const QuickValuesVisualization = React.createClass({
 
     let dataTableClassName;
 
-    if (this.props.config.show_data_table) {
+    /*
+     * Ensure we always render the data table when quickvalues config was created before introducing pie charts,
+     * or when neither the data table or the pie chart are selected for rendering.
+     */
+    if (this.props.config.show_data_table || !this.props.config.show_pie_chart) {
       dataTableClassName = this.props.horizontal ? 'col-md-8' : 'col-md-12';
     } else {
       dataTableClassName = 'hidden';

--- a/graylog2-web-interface/src/pages/ShowDashboardPage.jsx
+++ b/graylog2-web-interface/src/pages/ShowDashboardPage.jsx
@@ -95,7 +95,14 @@ const ShowDashboardPage = React.createClass({
 
     const positions = {};
     dashboard.widgets.forEach(widget => {
-      positions[widget.id] = dashboard.positions[widget.id] || this._defaultWidgetDimensions(widget);
+      const persistedDimensions = dashboard.positions[widget.id] || {};
+      const defaultDimensions = this._defaultWidgetDimensions(widget);
+      positions[widget.id] = {
+        col: (persistedDimensions.col === undefined ? defaultDimensions.col : persistedDimensions.col),
+        row: (persistedDimensions.row === undefined ? defaultDimensions.row : persistedDimensions.row),
+        height: (persistedDimensions.height === undefined ? defaultDimensions.height : persistedDimensions.height),
+        width: (persistedDimensions.width === undefined ? defaultDimensions.width : persistedDimensions.width),
+      };
     });
 
     const widgets = dashboard.widgets.sort((widget1, widget2) => {

--- a/graylog2-web-interface/src/pages/ShowDashboardPage.jsx
+++ b/graylog2-web-interface/src/pages/ShowDashboardPage.jsx
@@ -79,7 +79,7 @@ const ShowDashboardPage = React.createClass({
       dimensions.height = widgetPlugin.defaultHeight;
       dimensions.width = widgetPlugin.defaultWidth;
     } else {
-      dimensions.heigh = this.DEFAULT_HEIGHT;
+      dimensions.height = this.DEFAULT_HEIGHT;
       dimensions.width = this.DEFAULT_WIDTH;
     }
 


### PR DESCRIPTION
As I mentioned in #2163, I was able to reproduce two issues with old dashboards:
- The `positions` object may not contain `width` and `height` for a widget
- Quick value widgets created before pie charts were introduced will not render neither a data table, nor a pie chart

This PR fixes those two issues (and therefore #2163), and also corrects a typo in the default widget positioning.

The changes should be merged into master as well.