### PR TITLE
Fix plugin inter-dependencies by using one class loader for all plugins

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/shared/plugins/PluginLoader.java
+++ b/graylog2-server/src/main/java/org/graylog2/shared/plugins/PluginLoader.java
@@ -21,7 +21,6 @@ import com.google.common.collect.ComparisonChain;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.ImmutableSortedSet;
 import com.google.common.collect.Iterables;
-import com.google.common.collect.Lists;
 import org.graylog2.plugin.Plugin;
 import org.graylog2.plugin.PluginMetaData;
 import org.graylog2.plugin.PluginModule;
@@ -32,6 +31,7 @@ import java.io.File;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.net.URLClassLoader;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Comparator;
@@ -85,7 +85,7 @@ public class PluginLoader {
         }
 
         LOG.debug("Loading [{}] plugins", files.length);
-        final List<URL> urls = Lists.newArrayList(files).stream()
+        final List<URL> urls = Arrays.stream(files)
                 .filter(File::isFile)
                 .map(jar -> {
                     try {
@@ -105,7 +105,7 @@ public class PluginLoader {
 
         final ServiceLoader<Plugin> pluginServiceLoader = ServiceLoader.load(Plugin.class, classLoader);
 
-        return ImmutableSet.<Plugin>builder().addAll(pluginServiceLoader).build();
+        return ImmutableSet.copyOf(pluginServiceLoader);
     }
 
     public static class PluginComparator implements Comparator<Plugin> {

--- a/graylog2-server/src/main/java/org/graylog2/shared/plugins/PluginLoader.java
+++ b/graylog2-server/src/main/java/org/graylog2/shared/plugins/PluginLoader.java
@@ -21,6 +21,7 @@ import com.google.common.collect.ComparisonChain;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.ImmutableSortedSet;
 import com.google.common.collect.Iterables;
+import com.google.common.collect.Lists;
 import org.graylog2.plugin.Plugin;
 import org.graylog2.plugin.PluginMetaData;
 import org.graylog2.plugin.PluginModule;
@@ -34,9 +35,11 @@ import java.net.URLClassLoader;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Comparator;
+import java.util.List;
 import java.util.Objects;
 import java.util.ServiceLoader;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 import static java.util.Objects.requireNonNull;
@@ -82,25 +85,27 @@ public class PluginLoader {
         }
 
         LOG.debug("Loading [{}] plugins", files.length);
-        final ImmutableSet.Builder<Plugin> plugins = ImmutableSet.builder();
-        for (File jar : files) {
-            if (!jar.isFile()) {
-                LOG.debug("{} is not a file, skipping.", jar);
-            } else {
-                try {
-                    LOG.debug("Loading <" + jar.getAbsolutePath() + ">");
-                    final ClassLoader pluginClassLoader = URLClassLoader.newInstance(new URL[]{jar.toURI().toURL()});
-                    classLoader.addClassLoader(pluginClassLoader);
-                    final ServiceLoader<Plugin> pluginServiceLoader = ServiceLoader.load(Plugin.class, classLoader);
+        final List<URL> urls = Lists.newArrayList(files).stream()
+                .filter(File::isFile)
+                .map(jar -> {
+                    try {
+                        LOG.debug("Loading <" + jar.getAbsolutePath() + ">");
+                        return jar.toURI().toURL();
+                    } catch (MalformedURLException e) {
+                        LOG.error("Cannot open JAR file for discovering plugins", e);
+                        return null;
+                    }
+                })
+                .filter(Objects::nonNull)
+                .collect(Collectors.toList());
 
-                    plugins.addAll(pluginServiceLoader);
-                } catch (MalformedURLException e) {
-                    LOG.error("Cannot open JAR file for discovering plugins", e);
-                }
-            }
-        }
+        // Create one URL class loader for all plugins so they can see each other.
+        // This makes plugin inter-dependencies work.
+        classLoader.addClassLoader(URLClassLoader.newInstance(urls.toArray(new URL[urls.size()])));
 
-        return plugins.build();
+        final ServiceLoader<Plugin> pluginServiceLoader = ServiceLoader.load(Plugin.class, classLoader);
+
+        return ImmutableSet.<Plugin>builder().addAll(pluginServiceLoader).build();
     }
 
     public static class PluginComparator implements Comparator<Plugin> {


### PR DESCRIPTION
We used to create on URL class loader for each plugin. This broke
plugins which depend on classes from other plugins.

Now we are using one class loader for all plugins so they can see each
other. Plugins which need classes from other plugins are working now.