### PR TITLE
Improve logging of plugin list on server startup

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/bootstrap/CmdLineTool.java
+++ b/graylog2-server/src/main/java/org/graylog2/bootstrap/CmdLineTool.java
@@ -295,6 +295,7 @@ public abstract class CmdLineTool implements CliCommand {
             final PluginMetaData metadata = plugin.metadata();
             if (capabilities().containsAll(metadata.getRequiredCapabilities())) {
                 if (version.sameOrHigher(metadata.getRequiredVersion())) {
+                    LOG.info("Loaded plugin: {}", plugin);
                     plugins.add(plugin);
                 } else {
                     LOG.error("Plugin \"" + metadata.getName() + "\" requires version " + metadata.getRequiredVersion() + " - not loading!");
@@ -306,7 +307,6 @@ public abstract class CmdLineTool implements CliCommand {
             }
         }
 
-        LOG.info("Loaded plugins: " + plugins);
         return plugins;
     }
 


### PR DESCRIPTION
Avoid logging the loaded plugins in one line. Makes it way more readable.

```
2016-05-26 12:29:29,949 INFO : org.graylog2.bootstrap.CmdLineTool - Loaded plugin: Collector 1.0.1 [org.graylog.plugins.collector.CollectorPlugin]
2016-05-26 12:29:29,950 INFO : org.graylog2.bootstrap.CmdLineTool - Loaded plugin: Enterprise Integration Plugin 1.0.1 [org.graylog.plugins.enterprise_integration.EnterpriseIntegrationPlugin]
2016-05-26 12:29:29,950 INFO : org.graylog2.bootstrap.CmdLineTool - Loaded plugin: MapWidgetPlugin 1.0.1 [org.graylog.plugins.map.MapWidgetPlugin]
2016-05-26 12:29:29,950 INFO : org.graylog2.bootstrap.CmdLineTool - Loaded plugin: Pipeline Processor Plugin 1.0.0-beta.3 [org.graylog.plugins.pipelineprocessor.ProcessorPlugin]
2016-05-26 12:29:29,950 INFO : org.graylog2.bootstrap.CmdLineTool - Loaded plugin: Anonymous Usage Statistics 2.0.1 [org.graylog.plugins.usagestatistics.UsageStatsPlugin]
2016-05-26 12:29:30,614 INFO : org.graylog2.bootstrap.CmdLineTool - Running with JVM arguments: -agentlib:jdwp=transport=dt_socket,address=127.0.0.1:46361,suspend=y,server=n -Djava.library.path=lib/sigar-1.6.4 -Xmx1g -XX:NewRatio=1 -XX:+ResizeTLAB -XX:+UseConcMarkSweepGC -XX:+CMSConcurrentMTEnabled -XX:+CMSClassUnloadingEnabled -XX:+UseParNewGC -XX:-OmitStackTraceInFastThrow -Dfile.encoding=UTF-8
```