### PR TITLE
Add noop index retention strategy

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/indexer/retention/RetentionStrategyBindings.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/retention/RetentionStrategyBindings.java
@@ -19,6 +19,7 @@ package org.graylog2.indexer.retention;
 
 import org.graylog2.indexer.retention.strategies.ClosingRetentionStrategy;
 import org.graylog2.indexer.retention.strategies.DeletionRetentionStrategy;
+import org.graylog2.indexer.retention.strategies.NoopRetentionStrategy;
 import org.graylog2.plugin.PluginModule;
 
 public class RetentionStrategyBindings extends PluginModule {
@@ -26,5 +27,6 @@ public class RetentionStrategyBindings extends PluginModule {
     protected void configure() {
         addRetentionStrategy(DeletionRetentionStrategy.class);
         addRetentionStrategy(ClosingRetentionStrategy.class);
+        addRetentionStrategy(NoopRetentionStrategy.class);
     }
 }

--- a/graylog2-server/src/main/java/org/graylog2/indexer/retention/strategies/NoopRetentionStrategy.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/retention/strategies/NoopRetentionStrategy.java
@@ -1,3 +1,19 @@
+/**
+ * This file is part of Graylog.
+ *
+ * Graylog is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package org.graylog2.indexer.retention.strategies;
 
 import com.google.common.base.Optional;

--- a/graylog2-server/src/main/java/org/graylog2/indexer/retention/strategies/NoopRetentionStrategy.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/retention/strategies/NoopRetentionStrategy.java
@@ -1,0 +1,40 @@
+package org.graylog2.indexer.retention.strategies;
+
+import com.google.common.base.Optional;
+import org.graylog2.indexer.Deflector;
+import org.graylog2.indexer.indices.Indices;
+import org.graylog2.plugin.indexer.retention.RetentionStrategyConfig;
+import org.graylog2.shared.system.activities.ActivityWriter;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.inject.Inject;
+
+public class NoopRetentionStrategy extends AbstractIndexCountBasedRetentionStrategy {
+    private static final Logger LOG = LoggerFactory.getLogger(NoopRetentionStrategy.class);
+
+    @Inject
+    public NoopRetentionStrategy(Deflector deflector, Indices indices, ActivityWriter activityWriter) {
+        super(deflector, indices, activityWriter);
+    }
+
+    @Override
+    protected Optional<Integer> getMaxNumberOfIndices() {
+        return Optional.of(Integer.MAX_VALUE);
+    }
+
+    @Override
+    protected void retain(String indexName) {
+        LOG.info("Not running any index retention. This is the no-op index rotation strategy.");
+    }
+
+    @Override
+    public Class<? extends RetentionStrategyConfig> configurationClass() {
+        return NoopRetentionStrategyConfig.class;
+    }
+
+    @Override
+    public RetentionStrategyConfig defaultConfiguration() {
+        return NoopRetentionStrategyConfig.createDefault();
+    }
+}

--- a/graylog2-server/src/main/java/org/graylog2/indexer/retention/strategies/NoopRetentionStrategyConfig.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/retention/strategies/NoopRetentionStrategyConfig.java
@@ -1,0 +1,50 @@
+/**
+ * This file is part of Graylog.
+ *
+ * Graylog is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.graylog2.indexer.retention.strategies;
+
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.auto.value.AutoValue;
+import org.graylog2.plugin.indexer.retention.RetentionStrategyConfig;
+
+import javax.validation.constraints.Min;
+
+@JsonAutoDetect
+@AutoValue
+public abstract class NoopRetentionStrategyConfig implements RetentionStrategyConfig {
+    private static final int DEFAULT_MAX_NUMBER_OF_INDICES = Integer.MAX_VALUE;
+
+    @JsonProperty("max_number_of_indices")
+    public abstract int maxNumberOfIndices();
+
+    @JsonCreator
+    public static NoopRetentionStrategyConfig create(@JsonProperty(TYPE_FIELD) String type,
+                                                     @JsonProperty("max_number_of_indices") @Min(1) int maxNumberOfIndices) {
+        return new AutoValue_NoopRetentionStrategyConfig(type, maxNumberOfIndices);
+    }
+
+    @JsonCreator
+    public static NoopRetentionStrategyConfig create(@JsonProperty("max_number_of_indices") @Min(1) int maxNumberOfIndices) {
+        return new AutoValue_NoopRetentionStrategyConfig(NoopRetentionStrategyConfig.class.getCanonicalName(), maxNumberOfIndices);
+    }
+
+    public static NoopRetentionStrategyConfig createDefault() {
+        return create(DEFAULT_MAX_NUMBER_OF_INDICES);
+    }
+}

--- a/graylog2-server/src/main/java/org/graylog2/periodical/IndexRetentionThread.java
+++ b/graylog2-server/src/main/java/org/graylog2/periodical/IndexRetentionThread.java
@@ -19,9 +19,12 @@ package org.graylog2.periodical;
 import org.graylog2.configuration.ElasticsearchConfiguration;
 import org.graylog2.indexer.cluster.Cluster;
 import org.graylog2.indexer.management.IndexManagementConfig;
+import org.graylog2.notifications.Notification;
+import org.graylog2.notifications.NotificationService;
 import org.graylog2.plugin.cluster.ClusterConfigService;
 import org.graylog2.plugin.indexer.retention.RetentionStrategy;
 import org.graylog2.plugin.periodical.Periodical;
+import org.graylog2.plugin.system.NodeId;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -37,16 +40,22 @@ public class IndexRetentionThread extends Periodical {
     private final ElasticsearchConfiguration configuration;
     private final Cluster cluster;
     private final ClusterConfigService clusterConfigService;
+    private final NodeId nodeId;
+    private final NotificationService notificationService;
     private final Map<String, Provider<RetentionStrategy>> retentionStrategyMap;
 
     @Inject
     public IndexRetentionThread(ElasticsearchConfiguration configuration,
                                 Cluster cluster,
                                 ClusterConfigService clusterConfigService,
+                                NodeId nodeId,
+                                NotificationService notificationService,
                                 Map<String, Provider<RetentionStrategy>> retentionStrategyMap) {
         this.configuration = configuration;
         this.cluster = cluster;
         this.clusterConfigService = clusterConfigService;
+        this.nodeId = nodeId;
+        this.notificationService = notificationService;
         this.retentionStrategyMap = retentionStrategyMap;
     }
 
@@ -61,6 +70,8 @@ public class IndexRetentionThread extends Periodical {
 
         if (config == null) {
             LOG.warn("No index management configuration found, not running index retention!");
+            retentionProblemNotification("Index Retention Problem!",
+                    "No index management configuration found, not running index retention! Please fix your index retention configuration!");
             return;
         }
 
@@ -68,12 +79,24 @@ public class IndexRetentionThread extends Periodical {
 
         if (retentionStrategyProvider == null) {
             LOG.warn("Retention strategy \"{}\" not found, not running index retention!", config.retentionStrategy());
+            retentionProblemNotification("Index Retention Problem!",
+                    "Index retention strategy " + config.retentionStrategy() + " not found! Please fix your index retention configuration!");
             return;
         }
 
         final RetentionStrategy retentionStrategy = retentionStrategyProvider.get();
 
         retentionStrategy.retain();
+    }
+
+    private void retentionProblemNotification(String title, String description) {
+        final Notification notification = notificationService.buildNow()
+                .addNode(nodeId.toString())
+                .addType(Notification.Type.GENERIC)
+                .addSeverity(Notification.Severity.URGENT)
+                .addDetail("title", title)
+                .addDetail("description", description);
+        notificationService.publishIfFirst(notification);
     }
 
     @Override

--- a/graylog2-server/src/test/java/org/graylog2/periodical/IndexRotationThreadTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/periodical/IndexRotationThreadTest.java
@@ -26,6 +26,7 @@ import org.graylog2.notifications.NotificationService;
 import org.graylog2.plugin.cluster.ClusterConfigService;
 import org.graylog2.plugin.indexer.rotation.RotationStrategy;
 import org.graylog2.plugin.indexer.rotation.RotationStrategyConfig;
+import org.graylog2.plugin.system.NodeId;
 import org.graylog2.shared.system.activities.NullActivityWriter;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -84,6 +85,7 @@ public class IndexRotationThreadTest {
                 deflector,
                 cluster,
                 new NullActivityWriter(),
+                mock(NodeId.class),
                 clusterConfigService,
                 ImmutableMap.<String, Provider<RotationStrategy>>builder().put("strategy", provider).build()
         );
@@ -125,6 +127,7 @@ public class IndexRotationThreadTest {
                 deflector,
                 cluster,
                 new NullActivityWriter(),
+                mock(NodeId.class),
                 clusterConfigService,
                 ImmutableMap.<String, Provider<RotationStrategy>>builder().put("strategy", provider).build()
         );
@@ -167,6 +170,7 @@ public class IndexRotationThreadTest {
                 deflector,
                 cluster,
                 new NullActivityWriter(),
+                mock(NodeId.class),
                 clusterConfigService,
                 ImmutableMap.<String, Provider<RotationStrategy>>builder().put("strategy", provider).build()
         );
@@ -191,6 +195,7 @@ public class IndexRotationThreadTest {
                 deflector,
                 cluster,
                 new NullActivityWriter(),
+                mock(NodeId.class),
                 clusterConfigService,
                 ImmutableMap.<String, Provider<RotationStrategy>>builder().put("strategy", provider).build()
         );

--- a/graylog2-web-interface/src/components/indices/retention/NoopRetentionStrategyConfiguration.jsx
+++ b/graylog2-web-interface/src/components/indices/retention/NoopRetentionStrategyConfiguration.jsx
@@ -1,0 +1,14 @@
+import React from 'react';
+import { Alert } from 'react-bootstrap';
+
+const NoopRetentionStrategyConfiguration = React.createClass({
+  render() {
+    return (
+      <Alert>
+        This retention strategy is not configurable because it does not do anything.
+      </Alert>
+    );
+  },
+});
+
+export default NoopRetentionStrategyConfiguration;

--- a/graylog2-web-interface/src/components/indices/retention/NoopRetentionStrategySummary.jsx
+++ b/graylog2-web-interface/src/components/indices/retention/NoopRetentionStrategySummary.jsx
@@ -1,0 +1,16 @@
+import React from 'react';
+
+const NoopRetentionStrategySummary = React.createClass({
+  render() {
+    return (
+      <div>
+        <dl className="deflist">
+          <dt>Index retention strategy:</dt>
+          <dd>Do nothing</dd>
+        </dl>
+      </div>
+    );
+  },
+});
+
+export default NoopRetentionStrategySummary;

--- a/graylog2-web-interface/src/components/indices/retention/index.js
+++ b/graylog2-web-interface/src/components/indices/retention/index.js
@@ -3,6 +3,8 @@ import DeletionRetentionStrategyConfiguration from './DeletionRetentionStrategyC
 import DeletionRetentionStrategySummary from './DeletionRetentionStrategySummary';
 import ClosingRetentionStrategyConfiguration from './ClosingRetentionStrategyConfiguration';
 import ClosingRetentionStrategySummary from './ClosingRetentionStrategySummary';
+import NoopRetentionStrategyConfiguration from './NoopRetentionStrategyConfiguration';
+import NoopRetentionStrategySummary from './NoopRetentionStrategySummary';
 
 PluginStore.register(new PluginManifest({}, {
   indexRetentionConfig: [
@@ -17,6 +19,12 @@ PluginStore.register(new PluginManifest({}, {
       displayName: 'Close Index',
       configComponent: ClosingRetentionStrategyConfiguration,
       summaryComponent: ClosingRetentionStrategySummary,
+    },
+    {
+      type: 'org.graylog2.indexer.retention.strategies.NoopRetentionStrategy',
+      displayName: 'Do nothing',
+      configComponent: NoopRetentionStrategyConfiguration,
+      summaryComponent: NoopRetentionStrategySummary,
     },
   ],
 }));


### PR DESCRIPTION
This will be used in case of a missing retention strategy plugin and makes it possible to update the retention configuration in that case.

Also add a system notification if index rotation/retention does not run because of problems.