### PR TITLE
Check if props actually contain configuration fields before copying them

### DIFF
--- a/graylog2-web-interface/src/components/configurationforms/ConfigurationForm.jsx
+++ b/graylog2-web-interface/src/components/configurationforms/ConfigurationForm.jsx
@@ -38,9 +38,11 @@ const ConfigurationForm = React.createClass({
     const effectiveTitleValue = (this.state && this.state.titleValue !== undefined ? this.state.titleValue : props.titleValue);
     const defaultValues = {};
 
-    Object.keys(props.configFields).forEach(field => {
-      defaultValues[field] = props.configFields[field].default_value;
-    });
+    if (props.configFields) {
+      Object.keys(props.configFields).forEach(field => {
+        defaultValues[field] = props.configFields[field].default_value;
+      });
+    }
 
     return {
       configFields: $.extend({}, props.configFields),


### PR DESCRIPTION
This helps against the dropdown breaking because of an unhandled
exception due to a deselected input type and the following nonpresence
of configuration fields in the on change handler.

Should also be merged into master.

Fixes #2297