### PR TITLE
Use right metrics to display buffer usage

### DIFF
--- a/graylog2-web-interface/src/components/nodes/BufferUsage.jsx
+++ b/graylog2-web-interface/src/components/nodes/BufferUsage.jsx
@@ -22,13 +22,17 @@ const BufferUsage = React.createClass({
   },
   mixins: [Reflux.connect(MetricsStore)],
   componentWillMount() {
+    const prefix = this._metricPrefix();
     const metricNames = [
-      this._metricPrefix() + 'usage',
-      this._metricPrefix() + 'size',
+      `${prefix}.usage`,
+      `${prefix}.size`,
     ];
     metricNames.forEach((metricName) => MetricsActions.add(this.props.nodeId, metricName));
   },
   _metricPrefix() {
+    return `org.graylog2.buffers.${this.props.bufferType}`;
+  },
+  _metricFilter() {
     return `org\\.graylog2\\.buffers\\.${this.props.bufferType}\\.|${this.props.bufferType}buffer`;
   },
   render() {
@@ -36,16 +40,17 @@ const BufferUsage = React.createClass({
       return <Spinner />;
     }
     const nodeId = this.props.nodeId;
-    const usageMetric = this.state.metrics[nodeId][this._metricPrefix() + 'usage'];
+    const prefix = this._metricPrefix();
+    const usageMetric = this.state.metrics[nodeId][`${prefix}.usage`];
     const usage = usageMetric ? usageMetric.metric.value : NaN;
-    const sizeMetric = this.state.metrics[nodeId][this._metricPrefix() + 'size'];
+    const sizeMetric = this.state.metrics[nodeId][`${prefix}.size`];
     const size = sizeMetric ? sizeMetric.metric.value : NaN;
     const usagePercentage = (!isNaN(usage) && !isNaN(size) ? usage / size : 0);
     const percentLabel = NumberUtils.formatPercentage(usagePercentage);
 
     return (
       <div>
-        <LinkContainer to={Routes.filtered_metrics(nodeId, this._metricPrefix())}>
+        <LinkContainer to={Routes.filtered_metrics(nodeId, this._metricFilter())}>
           <Button bsSize="xsmall" className="pull-right">Metrics</Button>
         </LinkContainer>
         <h3>{this.props.title}</h3>


### PR DESCRIPTION
This got broken while fixing #2250. The problem is that the metrics we use to get data to display buffer usage, and the ones we use to filter in the metrics page are different, and that's what we do now.

Fixes #2299

The change should also go into master.