### PR TITLE
Upgrade to Jackson 2.7.4

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -89,7 +89,7 @@
         <build.timestamp>${maven.build.timestamp}</build.timestamp>
 
         <metrics.version>3.1.2</metrics.version>
-        <jackson.version>2.6.2</jackson.version>
+        <jackson.version>2.7.4</jackson.version>
         <jersey.version>2.22.1</jersey.version>
         <!-- The HK2 version should match the version being used by Jersey -->
         <glassfish-hk2.version>2.4.0-b31</glassfish-hk2.version>

--- a/pom.xml
+++ b/pom.xml
@@ -100,7 +100,7 @@
         <drools.version>6.4.0.Final</drools.version>
         <slf4j.version>1.7.21</slf4j.version>
         <log4j.version>2.6</log4j.version>
-        <mongojack.version>2.5.1</mongojack.version>
+        <mongojack.version>2.6.1</mongojack.version>
         <swagger.version>1.5.9</swagger.version>
         <sigar.version>1.6.4</sigar.version>
         <restassured.version>2.9.0</restassured.version>


### PR DESCRIPTION
Previous versions of MongoJack were prone to generating a `StackOverflowError` with Jackson 2.6.3 and higher.

Those problems were fixed in MongoJack 2.6.1 (see mongojack/mongojack#114), so that we finally can upgrade to an newer Jackson version.