### PR TITLE
Disabling a configured proxy for requests to localhost/127.0.0.1/::1.

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/shared/bindings/providers/OkHttpClientProvider.java
+++ b/graylog2-server/src/main/java/org/graylog2/shared/bindings/providers/OkHttpClientProvider.java
@@ -80,7 +80,7 @@ public class OkHttpClientProvider implements Provider<OkHttpClient> {
                 public List<Proxy> select(URI uri) {
                     switch (uri.getHost().toLowerCase(Locale.ENGLISH)) {
                         case "localhost":
-                        case "127.0.1":
+                        case "127.0.0.1":
                         case "::1":
                             return ImmutableList.of(Proxy.NO_PROXY);
                         default:


### PR DESCRIPTION
This PR adds a bit of code to disable the proxy in the provider if the target URI containcs `localhost`, `127.0.0.1` or `::1`, because we assume that these are meant to go against the Graylog server host itself and not the proxy host.