### PR TITLE
Throttle LB status if journal utilization is too high

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/Configuration.java
+++ b/graylog2-server/src/main/java/org/graylog2/Configuration.java
@@ -105,6 +105,9 @@ public class Configuration extends BaseConfiguration {
     @Parameter(value = "lb_recognition_period_seconds", validator = PositiveIntegerValidator.class)
     private int loadBalancerRecognitionPeriodSeconds = 3;
 
+    @Parameter(value = "lb_throttle_threshold_percentage", validator = PositiveIntegerValidator.class)
+    private int loadBalancerThrottleThresholdPercentage = 100;
+
     @Parameter(value = "stream_processing_timeout", validator = PositiveLongValidator.class)
     private long streamProcessingTimeout = 2000;
 
@@ -313,5 +316,11 @@ public class Configuration extends BaseConfiguration {
         return indexRangesCleanupInterval;
     }
 
-    public Set<IpSubnet> getTrustedProxies() { return trustedProxies; }
+    public Set<IpSubnet> getTrustedProxies() {
+        return trustedProxies;
+    }
+
+    public int getLoadBalancerRequestThrottleJournalUsage() {
+        return loadBalancerThrottleThresholdPercentage;
+    }
 }

--- a/graylog2-server/src/main/java/org/graylog2/plugin/ServerStatus.java
+++ b/graylog2-server/src/main/java/org/graylog2/plugin/ServerStatus.java
@@ -121,12 +121,24 @@ public class ServerStatus {
         publishLifecycle(Lifecycle.FAILED);
     }
 
+    public void throttle() {
+        publishLifecycle(Lifecycle.THROTTLED);
+    }
+
+    public void running() {
+        publishLifecycle(Lifecycle.RUNNING);
+    }
+
     public void overrideLoadBalancerDead() {
         publishLifecycle(Lifecycle.OVERRIDE_LB_DEAD);
     }
 
     public void overrideLoadBalancerAlive() {
         publishLifecycle(Lifecycle.OVERRIDE_LB_ALIVE);
+    }
+
+    public void overrideLoadBalancerThrottled() {
+        publishLifecycle(Lifecycle.OVERRIDE_LB_THROTTLED);
     }
 
     public void awaitRunning(final Runnable runnable) {

--- a/graylog2-server/src/main/java/org/graylog2/plugin/lifecycles/Lifecycle.java
+++ b/graylog2-server/src/main/java/org/graylog2/plugin/lifecycles/Lifecycle.java
@@ -16,9 +16,6 @@
  */
 package org.graylog2.plugin.lifecycles;
 
-/**
- * @author Lennart Koopmann <lennart@torch.sh>
- */
 public enum Lifecycle {
 
     UNINITIALIZED("Uninitialized", LoadBalancerStatus.DEAD),
@@ -27,10 +24,12 @@ public enum Lifecycle {
     PAUSED("Paused", LoadBalancerStatus.ALIVE),
     HALTING("Halting", LoadBalancerStatus.DEAD),
     FAILED("Failed", LoadBalancerStatus.DEAD),
+    THROTTLED("Throttled", LoadBalancerStatus.THROTTLED),
 
     // Manual lifecycle override, usually set by REST calls.
     OVERRIDE_LB_DEAD("Override lb:DEAD", LoadBalancerStatus.DEAD),
-    OVERRIDE_LB_ALIVE("Override lb:ALIVE", LoadBalancerStatus.ALIVE);
+    OVERRIDE_LB_ALIVE("Override lb:ALIVE", LoadBalancerStatus.ALIVE),
+    OVERRIDE_LB_THROTTLED("Override lb:THROTTLED", LoadBalancerStatus.THROTTLED);
 
     private final String description;
     private final LoadBalancerStatus loadBalancerStatus;

--- a/graylog2-server/src/main/java/org/graylog2/rest/TooManyRequestsStatus.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/TooManyRequestsStatus.java
@@ -14,15 +14,26 @@
  * You should have received a copy of the GNU General Public License
  * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
  */
-package org.graylog2.plugin.lifecycles;
+package org.graylog2.rest;
+
+import javax.ws.rs.core.Response;
 
 /**
- * @author Lennart Koopmann <lennart@torch.sh>
+ * A {@link Response.StatusType} for HTTP status 429 (Too many requests).
  */
-public enum LoadBalancerStatus {
+public class TooManyRequestsStatus implements Response.StatusType {
+    @Override
+    public int getStatusCode() {
+        return 429;
+    }
 
-    DEAD,
-    ALIVE,
-    THROTTLED
+    @Override
+    public Response.Status.Family getFamily() {
+        return Response.Status.Family.CLIENT_ERROR;
+    }
 
+    @Override
+    public String getReasonPhrase() {
+        return "Too many requests";
+    }
 }

--- a/graylog2-server/src/main/java/org/graylog2/rest/resources/cluster/ClusterLoadBalancerStatusResource.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/resources/cluster/ClusterLoadBalancerStatusResource.java
@@ -66,7 +66,7 @@ public class ClusterLoadBalancerStatusResource extends ProxiedResource {
     @RequiresAuthentication
     @RequiresPermissions(RestPermissions.LBSTATUS_CHANGE)
     @ApiOperation(value = "Override load balancer status of this graylog2-server node. Next lifecycle " +
-            "change will override it again to its default. Set to ALIVE or DEAD.")
+            "change will override it again to its default. Set to ALIVE, DEAD, or THROTTLED.")
     @Path("/override/{status}")
     public void override(@ApiParam(name = "nodeId", value = "The id of the node whose LB status will be changed", required = true)
                          @PathParam("nodeId") String nodeId,

--- a/graylog2-server/src/main/java/org/graylog2/shared/journal/JournalReader.java
+++ b/graylog2-server/src/main/java/org/graylog2/shared/journal/JournalReader.java
@@ -24,8 +24,6 @@ import com.google.common.eventbus.EventBus;
 import com.google.common.eventbus.Subscribe;
 import com.google.common.util.concurrent.AbstractExecutionThreadService;
 import com.google.common.util.concurrent.Uninterruptibles;
-import javax.inject.Inject;
-import javax.inject.Named;
 import org.graylog2.plugin.journal.RawMessage;
 import org.graylog2.plugin.lifecycles.Lifecycle;
 import org.graylog2.shared.buffers.ProcessBuffer;
@@ -33,6 +31,8 @@ import org.graylog2.shared.metrics.HdrHistogram;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import javax.inject.Inject;
+import javax.inject.Named;
 import java.util.List;
 import java.util.concurrent.Semaphore;
 
@@ -96,6 +96,9 @@ public class JournalReader extends AbstractExecutionThreadService {
             case RUNNING:
                 shouldBeReading = true;
                 break;
+            case THROTTLED:
+                shouldBeReading = true;
+                break;
             case PAUSED:
                 shouldBeReading = false;
                 break;
@@ -106,9 +109,9 @@ public class JournalReader extends AbstractExecutionThreadService {
                 triggerShutdown();
                 break;
             case OVERRIDE_LB_DEAD:
-                // don't care, keep processing journal
-                break;
             case OVERRIDE_LB_ALIVE:
+            case OVERRIDE_LB_THROTTLED:
+            default:
                 // don't care, keep processing journal
                 break;
         }

--- a/misc/graylog.conf
+++ b/misc/graylog.conf
@@ -351,6 +351,10 @@ message_journal_dir = data/journal
 # shutdown process. Set to 0 if you have no status checking load balancers in front.
 lb_recognition_period_seconds = 3
 
+# Journal usage percentage that triggers requesting throttling for this server node from load balancers. The feature is
+# disabled if not set.
+#lb_throttle_threshold_percentage = 95
+
 # Every message is matched against the configured streams and it can happen that a stream contains rules which
 # take an unusual amount of time to run, for example if its using regular expressions that perform excessive backtracking.
 # This will impact the processing of the entire server. To keep such misbehaving stream rules from impacting other


### PR DESCRIPTION
This change set adds the load balancer status "THROTTLED", represented by HTTP status 429 (Too many requests).

The load balancer status will be changed to THROTTLED (HTTP 429) if the journal utilization exceeds a configured threshold, see `lb_throttle_threshold_percentage` setting, and will be changed to ALIVE (HTTP 200) if the utilization is lower again.

Originally written by Mikko Lehtisalo (https://github.com/mikkolehtisalo)

Closes #1100
Refs #1952