### PR TITLE
Migrate from sun.security.* to Bouncycastle

### DIFF
--- a/graylog2-server/pom.xml
+++ b/graylog2-server/pom.xml
@@ -423,6 +423,16 @@
             <artifactId>system-rules</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.bouncycastle</groupId>
+            <artifactId>bcprov-jdk15on</artifactId>
+            <version>1.52</version>
+        </dependency>
+        <dependency>
+            <groupId>org.bouncycastle</groupId>
+            <artifactId>bcpkix-jdk15on</artifactId>
+            <version>1.52</version>
+        </dependency>
     </dependencies>
 
     <build>
@@ -478,6 +488,16 @@
                             <artifact>commons-collections:commons-collections</artifact>
                             <excludes>
                                 <exclude>org/apache/commons/collections/functors/InvokerTransformer.class</exclude>
+                            </excludes>
+                        </filter>
+                        <!-- Bouncycastle's JARs are signed. When building a shaded JAR, either remove the signatures, or
+                        add dependency to the main JAR's manifest. Otherwise running the application will fail. -->
+                        <filter>
+                            <artifact>org.bouncycastle:*</artifact>
+                            <excludes>
+                                <exclude>META-INF/*.SF</exclude>
+                                <exclude>META-INF/*.DSA</exclude>
+                                <exclude>META-INF/*.RSA</exclude>
                             </excludes>
                         </filter>
                     </filters>


### PR DESCRIPTION
Fixes issue #2132 

`sun.security.*` will probably not be available by default on Java 9, and Oracle does not seem to be going to provide replacement for all functionality. `Java.security.cert` is not able to perform certificate creation and signing. It is meant just for parsing already existing certificates.

Quick research shows that most projects depending on `sun.security.x509.*` have switched, or are in progress of switching, to Bouncycastle. Here's a quick implementation of that. I don't think it has to be really fancy, because self signed certificates should be used only for light testing.

Btw, running [jdeps](https://wiki.openjdk.java.net/display/JDK8/Java+Dependency+Analysis+Tool) on Graylog shows that these were the only JDK internal classes used, excluding 3rd party libraries.