### PR TITLE
Support changes for pipeline processor simulator

### DIFF
--- a/graylog2-web-interface/public/stylesheets/graylog2.less
+++ b/graylog2-web-interface/public/stylesheets/graylog2.less
@@ -2219,6 +2219,17 @@ table.messages tr.message-detail-row td {
   border-top: 0;
 }
 
+.message-details-title a {
+  color: #000;
+}
+
+.message-details-title .label {
+  font-size: 50%;
+  line-height: 200%;
+  margin-left: 5px;
+  vertical-align: bottom;
+}
+
 dl.message-details {
   margin-top: 10px;
   margin-bottom: 0;

--- a/graylog2-web-interface/src/components/messageloaders/LoaderTabs.jsx
+++ b/graylog2-web-interface/src/components/messageloaders/LoaderTabs.jsx
@@ -21,6 +21,7 @@ const LoaderTabs = React.createClass({
     onMessageLoaded: PropTypes.func,
     selectedInputId: PropTypes.string,
     customFieldActions: PropTypes.node,
+    disableMessagePreview: PropTypes.bool,
   },
   mixins: [Reflux.listenTo(InputsStore, '_formatInputs')],
   getInitialState() {
@@ -57,7 +58,7 @@ const LoaderTabs = React.createClass({
   },
   render() {
     let displayMessage;
-    if (this.state.message && this.state.inputs) {
+    if (this.state.message && this.state.inputs && !this.props.disableMessagePreview) {
       displayMessage = (
         <Col md={12}>
           <MessageShow message={this.state.message} inputs={this.state.inputs}

--- a/graylog2-web-interface/src/components/search/MessageDetail.jsx
+++ b/graylog2-web-interface/src/components/search/MessageDetail.jsx
@@ -30,6 +30,7 @@ const MessageDetail = React.createClass({
     streams: PropTypes.object,
     customFieldActions: PropTypes.node,
     searchConfig: PropTypes.object,
+    isSimulation: PropTypes.bool,
   },
 
   getInitialState() {
@@ -98,7 +99,7 @@ const MessageDetail = React.createClass({
       );
     }
 
-    const messageUrl = ApiRoutes.SearchController.showMessage(this.props.message.index, this.props.message.id).url;
+    const messageUrl = this.props.isSimulation ? '#' : ApiRoutes.SearchController.showMessage(this.props.message.index, this.props.message.id).url;
 
     let streamList = null;
     this._getAllStreams().forEach((stream) => {
@@ -178,23 +179,39 @@ const MessageDetail = React.createClass({
       );
     }
 
+    let messageActions;
+    if (!this.props.isSimulation) {
+      messageActions = (
+        <ButtonGroup className="pull-right" bsSize="small">
+          <Button href={messageUrl}>Permalink</Button>
+
+          <ClipboardButton title="Copy ID" text={this.props.message.id} />
+          {surroundingSearchButton}
+          {testAgainstStream}
+        </ButtonGroup>
+      );
+    }
+
+    let messageTitle;
+    if (this.props.isSimulation) {
+      messageTitle = `Simulation of processing ${this.props.message.id}`;
+    } else {
+      messageTitle = (
+        <LinkContainer to={Routes.message_show(this.props.message.index, this.props.message.id)}>
+          <a href="#" style={{ color: '#000' }}>{this.props.message.id}</a>
+        </LinkContainer>
+      );
+    }
+
     return (<div>
 
       <Row className="row-sm">
         <Col md={12}>
-          <ButtonGroup className="pull-right" bsSize="small">
-            <Button href={messageUrl}>Permalink</Button>
-
-            <ClipboardButton title="Copy ID" text={this.props.message.id} />
-            {surroundingSearchButton}
-            {testAgainstStream}
-          </ButtonGroup>
+          {messageActions}
           <h3>
             <i className="fa fa-envelope" />
             &nbsp;
-            <LinkContainer to={Routes.message_show(this.props.message.index, this.props.message.id)}>
-              <a href="#" style={{ color: '#000' }}>{this.props.message.id}</a>
-            </LinkContainer>
+            {messageTitle}
           </h3>
         </Col>
       </Row>
@@ -205,7 +222,7 @@ const MessageDetail = React.createClass({
             {receivedBy}
 
             <dt>Stored in index</dt>
-            <dd>{this.props.message.index}</dd>
+            <dd>{this.props.isSimulation ? 'Simulations are not stored' : this.props.message.index}</dd>
 
             { streamIds.size > 0 && <dt>Routed into streams</dt> }
             { streamIds.size > 0 &&

--- a/graylog2-web-interface/src/components/search/MessageDetail.jsx
+++ b/graylog2-web-interface/src/components/search/MessageDetail.jsx
@@ -1,5 +1,5 @@
 import React, { PropTypes } from 'react';
-import { ButtonGroup, Button, Row, Col, DropdownButton, MenuItem } from 'react-bootstrap';
+import { ButtonGroup, Button, Row, Col, DropdownButton, MenuItem, Label } from 'react-bootstrap';
 import Immutable from 'immutable';
 import { LinkContainer } from 'react-router-bootstrap';
 
@@ -30,7 +30,7 @@ const MessageDetail = React.createClass({
     streams: PropTypes.object,
     customFieldActions: PropTypes.node,
     searchConfig: PropTypes.object,
-    isSimulation: PropTypes.bool,
+    disableMessageActions: PropTypes.bool,
   },
 
   getInitialState() {
@@ -87,19 +87,10 @@ const MessageDetail = React.createClass({
     }
   },
 
-  render() {
-    // Short circuit when all messages are being expanded at the same time
-    if (this.props.expandAllRenderAsync) {
-      return (
-        <Row>
-          <Col md={12}>
-            <Spinner />
-          </Col>
-        </Row>
-      );
+  _getTestAgainstStreamButton() {
+    if (this.props.disableTestAgainstStream) {
+      return null;
     }
-
-    const messageUrl = this.props.isSimulation ? '#' : ApiRoutes.SearchController.showMessage(this.props.message.index, this.props.message.id).url;
 
     let streamList = null;
     this._getAllStreams().forEach((stream) => {
@@ -113,6 +104,57 @@ const MessageDetail = React.createClass({
         </LinkContainer>
       );
     });
+
+    return (
+      <DropdownButton ref="streamDropdown" pullRight bsSize="small" title="Test against stream"
+                      id="select-stream-dropdown">
+        { streamList }
+        { (!streamList && !this.props.allStreamsLoaded) && <MenuItem header><i className="fa fa-spin fa-spinner" />
+          Loading streams</MenuItem> }
+        { (!streamList && this.props.allStreamsLoaded) && <MenuItem header>No streams available</MenuItem> }
+      </DropdownButton>
+    );
+  },
+
+  _formatMessageActions() {
+    if (this.props.disableMessageActions) {
+      return <ButtonGroup className="pull-right" bsSize="small"/>;
+    }
+
+    const messageUrl = this.props.message.index ? ApiRoutes.SearchController.showMessage(this.props.message.index, this.props.message.id).url : '#';
+
+    let surroundingSearchButton;
+    if (!this.props.disableSurroundingSearch) {
+      surroundingSearchButton = (
+        <SurroundingSearchButton id={this.props.message.id}
+                                 timestamp={this.props.message.timestamp}
+                                 searchConfig={this.props.searchConfig}
+                                 messageFields={this.props.message.fields} />
+      );
+    }
+
+    return (
+      <ButtonGroup className="pull-right" bsSize="small">
+        <Button href={messageUrl}>Permalink</Button>
+
+        <ClipboardButton title="Copy ID" text={this.props.message.id} />
+        {surroundingSearchButton}
+        {this._getTestAgainstStreamButton()}
+      </ButtonGroup>
+    );
+  },
+
+  render() {
+    // Short circuit when all messages are being expanded at the same time
+    if (this.props.expandAllRenderAsync) {
+      return (
+        <Row>
+          <Col md={12}>
+            <Spinner />
+          </Col>
+        </Row>
+      );
+    }
 
     const streamIds = Immutable.Set(this.props.message.stream_ids);
     const streams = streamIds.map((id) => {
@@ -160,55 +202,22 @@ const MessageDetail = React.createClass({
       receivedBy = null;
     }
 
-    const testAgainstStream = (this.props.disableTestAgainstStream ? null :
-      <DropdownButton ref="streamDropdown" pullRight bsSize="small" title="Test against stream"
-                      id="select-stream-dropdown">
-        { streamList }
-        { (!streamList && !this.props.allStreamsLoaded) && <MenuItem header><i className="fa fa-spin fa-spinner" />
-          Loading streams</MenuItem> }
-        { (!streamList && this.props.allStreamsLoaded) && <MenuItem header>No streams available</MenuItem> }
-      </DropdownButton>);
-
-    let surroundingSearchButton;
-    if (!this.props.disableSurroundingSearch) {
-      surroundingSearchButton = (
-        <SurroundingSearchButton id={this.props.message.id}
-                                 timestamp={this.props.message.timestamp}
-                                 searchConfig={this.props.searchConfig}
-                                 messageFields={this.props.message.fields} />
-      );
-    }
-
-    let messageActions;
-    if (!this.props.isSimulation) {
-      messageActions = (
-        <ButtonGroup className="pull-right" bsSize="small">
-          <Button href={messageUrl}>Permalink</Button>
-
-          <ClipboardButton title="Copy ID" text={this.props.message.id} />
-          {surroundingSearchButton}
-          {testAgainstStream}
-        </ButtonGroup>
-      );
-    }
-
     let messageTitle;
-    if (this.props.isSimulation) {
-      messageTitle = `Simulation of processing ${this.props.message.id}`;
-    } else {
+    if (this.props.message.index) {
       messageTitle = (
         <LinkContainer to={Routes.message_show(this.props.message.index, this.props.message.id)}>
-          <a href="#" style={{ color: '#000' }}>{this.props.message.id}</a>
+          <a href="#">{this.props.message.id}</a>
         </LinkContainer>
       );
+    } else {
+      messageTitle = <span>{this.props.message.id} <Label bsStyle="warning">Not stored</Label></span>;
     }
 
     return (<div>
-
       <Row className="row-sm">
         <Col md={12}>
-          {messageActions}
-          <h3>
+          {this._formatMessageActions()}
+          <h3 className="message-details-title">
             <i className="fa fa-envelope" />
             &nbsp;
             {messageTitle}
@@ -222,7 +231,7 @@ const MessageDetail = React.createClass({
             {receivedBy}
 
             <dt>Stored in index</dt>
-            <dd>{this.props.isSimulation ? 'Simulations are not stored' : this.props.message.index}</dd>
+            <dd>{this.props.message.index ? this.props.message.index : 'Message is not stored'}</dd>
 
             { streamIds.size > 0 && <dt>Routed into streams</dt> }
             { streamIds.size > 0 &&

--- a/graylog2-web-interface/src/components/search/MessageDetail.jsx
+++ b/graylog2-web-interface/src/components/search/MessageDetail.jsx
@@ -121,7 +121,7 @@ const MessageDetail = React.createClass({
       return <ButtonGroup className="pull-right" bsSize="small"/>;
     }
 
-    const messageUrl = this.props.message.index ? ApiRoutes.SearchController.showMessage(this.props.message.index, this.props.message.id).url : '#';
+    const messageUrl = this.props.message.index ? Routes.message_show(this.props.message.index, this.props.message.id) : '#';
 
     let surroundingSearchButton;
     if (!this.props.disableSurroundingSearch) {

--- a/graylog2-web-interface/src/components/search/MessageShow.jsx
+++ b/graylog2-web-interface/src/components/search/MessageShow.jsx
@@ -1,13 +1,30 @@
-import React, {PropTypes} from 'react';
+import React from 'react';
+import Immutable from 'immutable';
 import MessageDetail from './MessageDetail';
 
 const MessageShow = React.createClass({
   propTypes: {
-    message: PropTypes.object,
-    inputs: PropTypes.object,
-    streams: PropTypes.object,
-    nodes: PropTypes.object,
+    message: React.PropTypes.object,
+    inputs: React.PropTypes.object,
+    streams: React.PropTypes.object,
+    nodes: React.PropTypes.object,
   },
+
+  getInitialState() {
+    return this._getImmutableProps(this.props);
+  },
+
+  componentWillReceiveProps(nextProps) {
+    this.setState(this._getImmutableProps(nextProps));
+  },
+
+  _getImmutableProps(props) {
+    return {
+      streams: props.streams ? Immutable.Map(props.streams) : props.streams,
+      nodes: props.nodes ? Immutable.Map(props.nodes) : props.nodes,
+    };
+  },
+
   possiblyHighlight(fieldName) {
     // No highlighting for the message details view.
     return this.props.message.fields[fieldName];
@@ -18,8 +35,8 @@ const MessageShow = React.createClass({
         <div className="col-md-12">
           <MessageDetail {...this.props} message={this.props.message}
                                          inputs={this.props.inputs}
-                                         streams={this.props.streams}
-                                         nodes={this.props.nodes}
+                                         streams={this.state.streams}
+                                         nodes={this.state.nodes}
                                          possiblyHighlight={this.possiblyHighlight}
                                          showTimestamp/>
         </div>

--- a/graylog2-web-interface/src/components/search/MessageShow.jsx
+++ b/graylog2-web-interface/src/components/search/MessageShow.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { Col, Row } from 'react-bootstrap';
 import Immutable from 'immutable';
 import MessageDetail from './MessageDetail';
 
@@ -31,16 +32,16 @@ const MessageShow = React.createClass({
   },
   render() {
     return (
-      <div className="row content">
-        <div className="col-md-12">
+      <Row className="content">
+        <Col md={12}>
           <MessageDetail {...this.props} message={this.props.message}
                                          inputs={this.props.inputs}
                                          streams={this.state.streams}
                                          nodes={this.state.nodes}
                                          possiblyHighlight={this.possiblyHighlight}
                                          showTimestamp/>
-        </div>
-      </div>
+        </Col>
+      </Row>
     );
   },
 });

--- a/graylog2-web-interface/src/components/search/MessageShow.jsx
+++ b/graylog2-web-interface/src/components/search/MessageShow.jsx
@@ -27,7 +27,7 @@ const MessageShow = React.createClass({
 
   possiblyHighlight(fieldName) {
     // No highlighting for the message details view.
-    return this.props.message.fields[fieldName];
+    return String(this.props.message.fields[fieldName]);
   },
   render() {
     return (

--- a/graylog2-web-interface/src/logic/message/MessageFormatter.js
+++ b/graylog2-web-interface/src/logic/message/MessageFormatter.js
@@ -1,0 +1,24 @@
+import moment from 'moment';
+import MessageFieldsFilter from 'logic/message/MessageFieldsFilter';
+
+const MessageFormatter = {
+  formatMessageSummary(messageSummary) {
+    const message = messageSummary.message;
+    const filteredFields = MessageFieldsFilter.filterFields(message);
+    const newMessage = {
+      id: message._id,
+      timestamp: moment(message.timestamp).unix(),
+      filtered_fields: filteredFields,
+      formatted_fields: filteredFields,
+      fields: message,
+      index: messageSummary.index,
+      source_node_id: message.gl2_source_node,
+      source_input_id: message.gl2_source_input,
+      stream_ids: message.streams,
+      highlight_ranges: messageSummary.highlight_ranges,
+    };
+    return newMessage;
+  },
+};
+
+export default MessageFormatter;

--- a/graylog2-web-interface/src/stores/search/UniversalSearchStore.js
+++ b/graylog2-web-interface/src/stores/search/UniversalSearchStore.js
@@ -1,10 +1,9 @@
 import Reflux from 'reflux';
 import jQuery from 'jquery';
-import moment from 'moment';
 import md5 from 'md5';
 
 import HistogramFormatter from 'logic/graphs/HistogramFormatter';
-import MessageFieldsFilter from 'logic/message/MessageFieldsFilter';
+import MessageFormatter from 'logic/message/MessageFormatter';
 
 import URLUtils from 'util/URLUtils';
 import ApiRoutes from 'routing/ApiRoutes';
@@ -32,23 +31,7 @@ const UniversalSearchStore = Reflux.createStore({
         };
       });
 
-      result.messages = result.messages.map((messageSummary) => {
-        const message = messageSummary.message;
-        const filteredFields = MessageFieldsFilter.filterFields(message);
-        const newMessage = {
-          id: message._id,
-          timestamp: moment(message.timestamp).unix(),
-          filtered_fields: filteredFields,
-          formatted_fields: filteredFields,
-          fields: message,
-          index: messageSummary.index,
-          source_node_id: message.gl2_source_node,
-          source_input_id: message.gl2_source_input,
-          stream_ids: message.streams,
-          highlight_ranges: messageSummary.highlight_ranges,
-        };
-        return newMessage;
-      });
+      result.messages = result.messages.map(MessageFormatter.formatMessageSummary);
 
       return result;
     });


### PR DESCRIPTION
These are required changes in common components being used in the first version of the message pipeline processor simulator, in summary:

- Add prop to `LoaderTabs` to control whether the loaded message should be display or not
- Add prop to `MessageDetail` to disable all links and buttons when showing message simulations
- Changes in `MessageShow` to ensure the props it receives are instances of immutable.js objects, so other components using it don't need to care about it
- Extract transformation of messages from the REST API into the internal object we use to it's own function, making it available in other places of the code

Changes required for https://github.com/Graylog2/graylog-plugin-pipeline-processor/pull/34