### PR TITLE
Add dependency on jna to fix chatty Elasticseach log message

### DIFF
--- a/graylog2-server/pom.xml
+++ b/graylog2-server/pom.xml
@@ -244,6 +244,10 @@
             <groupId>org.elasticsearch</groupId>
             <artifactId>elasticsearch</artifactId>
         </dependency>
+        <dependency>
+            <groupId>net.java.dev.jna</groupId>
+            <artifactId>jna</artifactId>
+        </dependency>
 
         <dependency>
             <groupId>org.kie</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -105,6 +105,7 @@
         <sigar.version>1.6.4</sigar.version>
         <restassured.version>2.9.0</restassured.version>
         <elasticsearch.version>2.3.3</elasticsearch.version>
+        <jna.version>4.1.0</jna.version> <!-- for ES, make sure to use the version that ES uses -->
         <retrofit.version>2.0.2</retrofit.version>
         <forbiddenapis.version>2.0</forbiddenapis.version>
     </properties>
@@ -186,6 +187,12 @@
                 <artifactId>elasticsearch</artifactId>
                 <version>${elasticsearch.version}</version>
             </dependency>
+            <dependency>
+                <groupId>net.java.dev.jna</groupId>
+                <artifactId>jna</artifactId>
+                <version>${jna.version}</version>
+            </dependency>
+
 
             <dependency>
                 <groupId>org.kie</groupId>


### PR DESCRIPTION
Since Elasticsearch 2.3.3, Elasticsearch logs a warning with a huge backtrace if jna is not available.

```
2016-06-08 17:30:23,909 WARN : org.elasticsearch.bootstrap - JNA not found. native methods will be disabled.
java.lang.ClassNotFoundException: com.sun.jna.Native
  at java.net.URLClassLoader.findClass(URLClassLoader.java:381) ~[?:1.8.0_91]
  at java.lang.ClassLoader.loadClass(ClassLoader.java:424) ~[?:1.8.0_91]
  at sun.misc.Launcher$AppClassLoader.loadClass(Launcher.java:331) ~[?:1.8.0_91]
  at java.lang.ClassLoader.loadClass(ClassLoader.java:357) ~[?:1.8.0_91]
  at java.lang.Class.forName0(Native Method) ~[?:1.8.0_91]
  at java.lang.Class.forName(Class.java:264) ~[?:1.8.0_91]
  at org.elasticsearch.bootstrap.Natives.<clinit>(Natives.java:45) [elasticsearch-2.3.3.jar:2.3.3]
  at org.elasticsearch.bootstrap.BootstrapInfo.isMemoryLocked(BootstrapInfo.java:44) [elasticsearch-2.3.3.jar:2.3.3]
  at org.elasticsearch.monitor.process.ProcessProbe.processInfo(ProcessProbe.java:130) [elasticsearch-2.3.3.jar:2.3.3]
  at org.elasticsearch.monitor.process.ProcessService.<init>(ProcessService.java:44) [elasticsearch-2.3.3.jar:2.3.3]
  at sun.reflect.NativeConstructorAccessorImpl.newInstance0(Native Method) ~[?:1.8.0_91]
  at sun.reflect.NativeConstructorAccessorImpl.newInstance(NativeConstructorAccessorImpl.java:62) [?:1.8.0_91]
  at sun.reflect.DelegatingConstructorAccessorImpl.newInstance(DelegatingConstructorAccessorImpl.java:45) [?:1.8.0_91]
  at java.lang.reflect.Constructor.newInstance(Constructor.java:423) [?:1.8.0_91]
  at org.elasticsearch.common.inject.DefaultConstructionProxyFactory$1.newInstance(DefaultConstructionProxyFactory.java:50) [elasticsearch-2.3.3.jar:2.3.3]
  at org.elasticsearch.common.inject.ConstructorInjector.construct(ConstructorInjector.java:86) [elasticsearch-2.3.3.jar:2.3.3]
  at org.elasticsearch.common.inject.ConstructorBindingImpl$Factory.get(ConstructorBindingImpl.java:104) [elasticsearch-2.3.3.jar:2.3.3]
  at org.elasticsearch.common.inject.ProviderToInternalFactoryAdapter$1.call(ProviderToInternalFactoryAdapter.java:47) [elasticsearch-2.3.3.jar:2.3.3]
  at org.elasticsearch.common.inject.InjectorImpl.callInContext(InjectorImpl.java:886) [elasticsearch-2.3.3.jar:2.3.3]
  at org.elasticsearch.common.inject.ProviderToInternalFactoryAdapter.get(ProviderToInternalFactoryAdapter.java:43) [elasticsearch-2.3.3.jar:2.3.3]
  at org.elasticsearch.common.inject.Scopes$1$1.get(Scopes.java:59) [elasticsearch-2.3.3.jar:2.3.3]
  at org.elasticsearch.common.inject.InternalFactoryToProviderAdapter.get(InternalFactoryToProviderAdapter.java:46) [elasticsearch-2.3.3.jar:2.3.3]
  at org.elasticsearch.common.inject.SingleParameterInjector.inject(SingleParameterInjector.java:42) [elasticsearch-2.3.3.jar:2.3.3]
  at org.elasticsearch.common.inject.SingleParameterInjector.getAll(SingleParameterInjector.java:66) [elasticsearch-2.3.3.jar:2.3.3]
  at org.elasticsearch.common.inject.ConstructorInjector.construct(ConstructorInjector.java:85) [elasticsearch-2.3.3.jar:2.3.3]
  at org.elasticsearch.common.inject.ConstructorBindingImpl$Factory.get(ConstructorBindingImpl.java:104) [elasticsearch-2.3.3.jar:2.3.3]
  at org.elasticsearch.common.inject.SingleParameterInjector.inject(SingleParameterInjector.java:42) [elasticsearch-2.3.3.jar:2.3.3]
  at org.elasticsearch.common.inject.SingleParameterInjector.getAll(SingleParameterInjector.java:66) [elasticsearch-2.3.3.jar:2.3.3]
  at org.elasticsearch.common.inject.ConstructorInjector.construct(ConstructorInjector.java:85) [elasticsearch-2.3.3.jar:2.3.3]
  at org.elasticsearch.common.inject.ConstructorBindingImpl$Factory.get(ConstructorBindingImpl.java:104) [elasticsearch-2.3.3.jar:2.3.3]
  at org.elasticsearch.common.inject.ProviderToInternalFactoryAdapter$1.call(ProviderToInternalFactoryAdapter.java:47) [elasticsearch-2.3.3.jar:2.3.3]
  at org.elasticsearch.common.inject.InjectorImpl.callInContext(InjectorImpl.java:886) [elasticsearch-2.3.3.jar:2.3.3]
  at org.elasticsearch.common.inject.ProviderToInternalFactoryAdapter.get(ProviderToInternalFactoryAdapter.java:43) [elasticsearch-2.3.3.jar:2.3.3]
  at org.elasticsearch.common.inject.Scopes$1$1.get(Scopes.java:59) [elasticsearch-2.3.3.jar:2.3.3]
  at org.elasticsearch.common.inject.InternalFactoryToProviderAdapter.get(InternalFactoryToProviderAdapter.java:46) [elasticsearch-2.3.3.jar:2.3.3]
  at org.elasticsearch.common.inject.InjectorBuilder$1.call(InjectorBuilder.java:201) [elasticsearch-2.3.3.jar:2.3.3]
  at org.elasticsearch.common.inject.InjectorBuilder$1.call(InjectorBuilder.java:193) [elasticsearch-2.3.3.jar:2.3.3]
  at org.elasticsearch.common.inject.InjectorImpl.callInContext(InjectorImpl.java:879) [elasticsearch-2.3.3.jar:2.3.3]
  at org.elasticsearch.common.inject.InjectorBuilder.loadEagerSingletons(InjectorBuilder.java:193) [elasticsearch-2.3.3.jar:2.3.3]
  at org.elasticsearch.common.inject.InjectorBuilder.injectDynamically(InjectorBuilder.java:175) [elasticsearch-2.3.3.jar:2.3.3]
  at org.elasticsearch.common.inject.InjectorBuilder.build(InjectorBuilder.java:110) [elasticsearch-2.3.3.jar:2.3.3]
  at org.elasticsearch.common.inject.Guice.createInjector(Guice.java:96) [elasticsearch-2.3.3.jar:2.3.3]
  at org.elasticsearch.common.inject.Guice.createInjector(Guice.java:70) [elasticsearch-2.3.3.jar:2.3.3]
  at org.elasticsearch.common.inject.ModulesBuilder.createInjector(ModulesBuilder.java:46) [elasticsearch-2.3.3.jar:2.3.3]
  at org.elasticsearch.node.Node.<init>(Node.java:213) [elasticsearch-2.3.3.jar:2.3.3]
  at org.elasticsearch.node.GraylogNode.<init>(GraylogNode.java:37) [classes/:2.3.3]
  at org.graylog2.bindings.providers.EsNodeProvider.get(EsNodeProvider.java:57) [classes/:?]
```

We are adding the dependency instead of silencing the log message because it adds useful features like mlockall.