### PR TITLE
Do not init available alarm callback types, fetch them explicitly.

### DIFF
--- a/graylog2-web-interface/src/components/alarmcallbacks/AlarmCallbackHistoryOverview.jsx
+++ b/graylog2-web-interface/src/components/alarmcallbacks/AlarmCallbackHistoryOverview.jsx
@@ -6,6 +6,9 @@ import StoreProvider from 'injection/StoreProvider';
 const AlarmCallbackHistoryStore = StoreProvider.getStore('AlarmCallbackHistory');
 const AlarmCallbacksStore = StoreProvider.getStore('AlarmCallbacks');
 
+import ActionsProvider from 'injection/ActionsProvider';
+const AlarmCallbacksActions = ActionsProvider.getActions('AlarmCallbacks');
+
 import { Spinner } from 'components/common';
 import { AlarmCallbackHistory } from 'components/alarmcallbacks';
 
@@ -14,7 +17,6 @@ const AlarmCallbackHistoryOverview = React.createClass({
     alertId: React.PropTypes.string.isRequired,
     streamId: React.PropTypes.string.isRequired,
   },
-  mixins: [Reflux.connect(AlarmCallbacksStore)],
   getInitialState() {
     return {};
   },
@@ -22,6 +24,9 @@ const AlarmCallbackHistoryOverview = React.createClass({
     this.loadData();
   },
   loadData() {
+    AlarmCallbacksActions.available(this.props.streamId).then((types) => {
+      this.setState({ types: types });
+    });
     AlarmCallbackHistoryStore.listForAlert(this.props.streamId, this.props.alertId).done((histories) => {
       this.setState({histories: histories});
     });

--- a/graylog2-web-interface/src/components/alarmcallbacks/AlarmCallbackHistoryOverview.jsx
+++ b/graylog2-web-interface/src/components/alarmcallbacks/AlarmCallbackHistoryOverview.jsx
@@ -1,9 +1,9 @@
 import React from 'react';
-import Reflux from 'reflux';
 import { Row, Col } from 'react-bootstrap';
 
 import StoreProvider from 'injection/StoreProvider';
 const AlarmCallbackHistoryStore = StoreProvider.getStore('AlarmCallbackHistory');
+// eslint-disable-next-line no-unused-vars
 const AlarmCallbacksStore = StoreProvider.getStore('AlarmCallbacks');
 
 import ActionsProvider from 'injection/ActionsProvider';
@@ -28,7 +28,7 @@ const AlarmCallbackHistoryOverview = React.createClass({
       this.setState({ types: types });
     });
     AlarmCallbackHistoryStore.listForAlert(this.props.streamId, this.props.alertId).done((histories) => {
-      this.setState({histories: histories});
+      this.setState({ histories: histories });
     });
   },
   _formatHistory(history) {

--- a/graylog2-web-interface/src/pages/StreamAlertsPage.jsx
+++ b/graylog2-web-interface/src/pages/StreamAlertsPage.jsx
@@ -89,26 +89,28 @@ const StreamAlertsPage = React.createClass({
           </Col>
         </Row>
 
-        <Row className="content">
-          <Col md={12}>
-            <IfPermitted permissions={'streams:edit:' + stream.id}>
-              <div className="sendDummyAlert">
-                <Button className="pull-right" bsStyle="info" onClick={this._onSendDummyAlert}>Send test alert</Button>
-              </div>
-            </IfPermitted>
+        <IfPermitted permissions={'users:list'}>
+          <Row className="content">
+            <Col md={12}>
+              <IfPermitted permissions={'streams:edit:' + stream.id}>
+                <div className="sendDummyAlert">
+                  <Button className="pull-right" bsStyle="info" onClick={this._onSendDummyAlert}>Send test alert</Button>
+                </div>
+              </IfPermitted>
 
-            <h2>Receivers</h2>
+              <h2>Receivers</h2>
 
-            <p className="description">
-              The following Graylog users will be notified about alerts via email if they have configured
-              an email address in their profile. You can also add any other email address to the alert
-              receivers if it has no Graylog user associated.
-            </p>
+              <p className="description">
+                The following Graylog users will be notified about alerts via email if they have configured
+                an email address in their profile. You can also add any other email address to the alert
+                receivers if it has no Graylog user associated.
+              </p>
 
-            <AlertReceiversList receivers={stream.alert_receivers} streamId={stream.id}/>
+              <AlertReceiversList receivers={stream.alert_receivers} streamId={stream.id}/>
 
-          </Col>
-        </Row>
+            </Col>
+          </Row>
+        </IfPermitted>
 
         <AlertsComponent streamId={stream.id} />
       </span>

--- a/graylog2-web-interface/src/pages/StreamAlertsPage.jsx
+++ b/graylog2-web-interface/src/pages/StreamAlertsPage.jsx
@@ -37,20 +37,20 @@ const StreamAlertsPage = React.createClass({
     this.loadData();
   },
   onAlertConditionsList(response) {
-    this.setState({alertConditions: response.alertConditions.sort((a1, a2) => a1.id.localeCompare(a2.id))});
+    this.setState({ alertConditions: response.alertConditions.sort((a1, a2) => a1.id.localeCompare(a2.id)) });
   },
   _onSendDummyAlert() {
     const stream = this.state.stream;
     StreamsStore.sendDummyAlert(stream.id).then(() => {
-      UserNotification.success('Sent dummy alert for stream »' + stream.title + '«', 'Success!');
+      UserNotification.success(`Sent dummy alert for stream »${stream.title}«`, 'Success!');
     }, (error) => {
-      UserNotification.error('Unable to send dummy alert for stream »' + stream.title + '«: ' + error.message,
+      UserNotification.error(`Unable to send dummy alert for stream »${stream.title}«: ${error.message}`,
         'Sending dummy alert failed!');
     });
   },
   loadData() {
     StreamsStore.get(this.props.params.streamId, (stream) => {
-      this.setState({stream: stream});
+      this.setState({ stream: stream });
     });
 
     AlertConditionsActions.list(this.props.params.streamId);
@@ -62,7 +62,7 @@ const StreamAlertsPage = React.createClass({
     const stream = this.state.stream;
     return (
       <span>
-        <PageHeader title={'Alerts configuration for stream »' + stream.title + '«'}>
+        <PageHeader title={`Alerts configuration for stream »${stream.title}«`}>
           <span>You can define thresholds on any message field or message count of a stream and be alerted based on this definition.</span>
           <span>
             Learn more about alerts in the <DocumentationLink page={DocsHelper.PAGES.ALERTS} text="documentation"/>.</span>
@@ -72,7 +72,7 @@ const StreamAlertsPage = React.createClass({
 
         <Row className="content alert-conditions">
           <Col md={12}>
-            <h2 style={{marginBottom: '15px'}}>Configured alert conditions</h2>
+            <h2 style={{ marginBottom: '15px' }}>Configured alert conditions</h2>
 
             <AlertConditionsList alertConditions={this.state.alertConditions}/>
           </Col>
@@ -92,7 +92,7 @@ const StreamAlertsPage = React.createClass({
         <IfPermitted permissions={'users:list'}>
           <Row className="content">
             <Col md={12}>
-              <IfPermitted permissions={'streams:edit:' + stream.id}>
+              <IfPermitted permissions={`streams:edit:${stream.id}`}>
                 <div className="sendDummyAlert">
                   <Button className="pull-right" bsStyle="info" onClick={this._onSendDummyAlert}>Send test alert</Button>
                 </div>

--- a/graylog2-web-interface/src/stores/alarmcallbacks/AlarmCallbacksStore.js
+++ b/graylog2-web-interface/src/stores/alarmcallbacks/AlarmCallbacksStore.js
@@ -12,13 +12,6 @@ const AlarmCallbacksStore = Reflux.createStore({
   listenables: [AlarmCallbacksActions],
   types: undefined,
 
-  init() {
-    this.available(undefined).then((types) => {
-      this.types = types;
-      this.trigger({types: types});
-    });
-  },
-
   getInitialState() {
     return {
       types: this.types,

--- a/graylog2-web-interface/src/stores/alarmcallbacks/AlarmCallbacksStore.js
+++ b/graylog2-web-interface/src/stores/alarmcallbacks/AlarmCallbacksStore.js
@@ -10,13 +10,6 @@ import fetch from 'logic/rest/FetchProvider';
 
 const AlarmCallbacksStore = Reflux.createStore({
   listenables: [AlarmCallbacksActions],
-  types: undefined,
-
-  getInitialState() {
-    return {
-      types: this.types,
-    };
-  },
 
   available(streamId) {
     const failCallback = (error) =>

--- a/graylog2-web-interface/src/stores/alarmcallbacks/AlarmCallbacksStore.js
+++ b/graylog2-web-interface/src/stores/alarmcallbacks/AlarmCallbacksStore.js
@@ -19,10 +19,9 @@ const AlarmCallbacksStore = Reflux.createStore({
   },
 
   available(streamId) {
-    const failCallback = (error) => {
-      UserNotification.error('Fetching available AlarmCallback types failed with status: ' + error.message,
+    const failCallback = (error) =>
+      UserNotification.error(`Fetching available AlarmCallback types failed with status: ${error.message}`,
         'Could not retrieve available AlarmCallbacks');
-    };
 
     const url = URLUtils.qualifyUrl(ApiRoutes.AlarmCallbacksApiController.available(streamId).url);
     const promise = fetch('GET', url).then((response) => {
@@ -34,10 +33,9 @@ const AlarmCallbacksStore = Reflux.createStore({
     return promise;
   },
   list(streamId) {
-    const failCallback = (error) => {
-      UserNotification.error('Fetching AlarmCallbacks failed with status: ' + error.message,
+    const failCallback = (error) =>
+      UserNotification.error(`Fetching AlarmCallbacks failed with status: ${error.message}`,
         'Could not retrieve AlarmCallbacks');
-    };
 
     const url = URLUtils.qualifyUrl(ApiRoutes.AlarmCallbacksApiController.list(streamId).url);
     const promise = fetch('GET', url).then((response) => response.alarmcallbacks, failCallback);
@@ -45,10 +43,9 @@ const AlarmCallbacksStore = Reflux.createStore({
     AlarmCallbacksActions.list.promise(promise);
   },
   save(streamId, alarmCallback) {
-    const failCallback = (error) => {
-      UserNotification.error('Saving AlarmCallback failed with status: ' + error.message,
+    const failCallback = (error) =>
+      UserNotification.error(`Saving AlarmCallback failed with status: ${error.message}`,
         'Could not save AlarmCallback');
-    };
 
     const url = URLUtils.qualifyUrl(ApiRoutes.AlarmCallbacksApiController.create(streamId).url);
 
@@ -57,10 +54,9 @@ const AlarmCallbacksStore = Reflux.createStore({
     AlarmCallbacksActions.save.promise(promise);
   },
   delete(streamId, alarmCallbackId) {
-    const failCallback = (error) => {
-      UserNotification.error('Removing AlarmCallback failed with status: ' + error.message,
+    const failCallback = (error) =>
+      UserNotification.error(`Removing AlarmCallback failed with status: ${error.message}`,
         'Could not remove AlarmCallback');
-    };
 
     const url = URLUtils.qualifyUrl(ApiRoutes.AlarmCallbacksApiController.delete(streamId, alarmCallbackId).url);
 
@@ -69,10 +65,9 @@ const AlarmCallbacksStore = Reflux.createStore({
     AlarmCallbacksActions.delete.promise(promise);
   },
   update(streamId, alarmCallbackId, deltas) {
-    const failCallback = (error) => {
-      UserNotification.error('Updating Alarm Callback \'' + alarmCallbackId + '\' failed with status: ' + error.message,
+    const failCallback = (error) =>
+      UserNotification.error(`Updating Alarm Callback '${alarmCallbackId}' failed with status: ${error.message}`,
         'Could not update Alarm Callback');
-    };
 
     const url = URLUtils.qualifyUrl(ApiRoutes.AlarmCallbacksApiController.update(streamId, alarmCallbackId).url);
 


### PR DESCRIPTION
When we are fetching the available alarm callback types during init of
AlarmCallbacksStore, we don't have a stream id to fetch for yet.
Therefore we are running into permission problems in the backend
resource for non-admin users. This change replaces the init with an
explicit fetch of available alarm callback types in the consumer.

Fixes #2352