### PR TITLE
Move custom analyzer into index template

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/indexer/IndexMapping.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/IndexMapping.java
@@ -34,11 +34,17 @@ public class IndexMapping {
     public static final String TYPE_MESSAGE = "message";
 
     public Map<String, Object> messageTemplate(final String template, final String analyzer) {
-        final ImmutableMap<String, Object> map = ImmutableMap.<String, Object>of(TYPE_MESSAGE, messageMapping(analyzer));
+        final Map<String, Object> analyzerKeyword = ImmutableMap.of("analyzer_keyword", ImmutableMap.of(
+            "tokenizer", "keyword",
+            "filter", "lowercase"));
+        final Map<String, Object> analysis = ImmutableMap.of("analyzer", analyzerKeyword);
+        final Map<String, Object> settings = ImmutableMap.of("analysis", analysis);
+        final Map<String, Object> mappings = ImmutableMap.of(TYPE_MESSAGE, messageMapping(analyzer));
 
-        return ImmutableMap.<String, Object>of(
+        return ImmutableMap.of(
                 "template", template,
-                "mappings", map
+                "settings", settings,
+                "mappings", mappings
         );
     }
 

--- a/graylog2-server/src/main/java/org/graylog2/indexer/indices/Indices.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/indices/Indices.java
@@ -282,8 +282,6 @@ public class Indices {
         final Settings settings = Settings.builder()
                 .put("number_of_shards", numShards)
                 .put("number_of_replicas", numReplicas)
-                .put("analysis.analyzer.analyzer_keyword.tokenizer", "keyword")
-                .put("analysis.analyzer.analyzer_keyword.filter", "lowercase")
                 .put(customSettings)
                 .build();
 


### PR DESCRIPTION
The custom `analyzer_keyword` analyzer should be part of the index template so that newly created indices automatically know about it.

This PR doesn't change the behavior of Elasticsearch or Graylog but simply moves the index settings into one place for better code coherence.