### PR TITLE
Improved feedback

### DIFF
--- a/graylog2-web-interface/src/components/extractors/MessageLoader.jsx
+++ b/graylog2-web-interface/src/components/extractors/MessageLoader.jsx
@@ -16,6 +16,7 @@ const MessageLoader = React.createClass({
   getInitialState() {
     return ({
       hidden: this.props.hidden,
+      loading: false,
     });
   },
 
@@ -33,8 +34,10 @@ const MessageLoader = React.createClass({
     if (messageId === '' || index === '') {
       return;
     }
+    this.setState({ loading: true });
     const promise = MessagesStore.loadMessage(index, messageId);
     promise.then(data => this.props.onMessageLoaded(data));
+    promise.finally(() => this.setState({ loading: false }));
 
     event.preventDefault();
   },
@@ -58,8 +61,8 @@ const MessageLoader = React.createClass({
         <form className="form-inline message-loader-form" onSubmit={this.loadMessage}>
           <input type="text" ref="messageId" className="form-control" placeholder="Message ID" required/>
           <input type="text" ref="index" className="form-control" placeholder="Index" required/>
-          <button ref="submitButton" type="submit" className="btn btn-info">
-            Load message
+          <button ref="submitButton" type="submit" className="btn btn-info" disabled={this.state.loading}>
+            {this.state.loading ? 'Loading message...' : 'Load message'}
           </button>
         </form>
       </div>

--- a/graylog2-web-interface/src/components/inputs/InputDropdown.jsx
+++ b/graylog2-web-interface/src/components/inputs/InputDropdown.jsx
@@ -10,6 +10,7 @@ const InputDropdown = React.createClass({
     title: PropTypes.string,
     preselectedInputId: PropTypes.string,
     onLoadMessage: PropTypes.func,
+    disabled: PropTypes.bool,
   },
   mixins: [LinkedStateMixin],
   getInitialState() {
@@ -57,7 +58,7 @@ const InputDropdown = React.createClass({
             {inputs.toArray()}
           </Input>
 
-          <Button bsStyle="info" disabled={this.state.selectedInput === this.PLACEHOLDER}
+          <Button bsStyle="info" disabled={this.props.disabled || this.state.selectedInput === this.PLACEHOLDER}
              onClick={this._onLoadMessage}>{this.props.title}</Button>
         </div>
       );

--- a/graylog2-web-interface/src/components/inputs/InputStateControl.jsx
+++ b/graylog2-web-interface/src/components/inputs/InputStateControl.jsx
@@ -14,6 +14,13 @@ const InputStateControl = React.createClass({
     input: PropTypes.object.isRequired,
   },
   mixins: [Reflux.connectFilter(InputStatesStore, 'inputState', inputStateFilter)],
+
+  getInitialState() {
+    return {
+      loading: false,
+    };
+  },
+
   _isInputRunning() {
     if (!this.state.inputState) {
       return false;
@@ -29,18 +36,33 @@ const InputStateControl = React.createClass({
       return nodeState.state === 'RUNNING';
     });
   },
+
   _startInput() {
-    InputStatesStore.start(this.props.input);
+    this.setState({ loading: true });
+    InputStatesStore.start(this.props.input)
+      .finally(() => this.setState({ loading: false }));
   },
+
   _stopInput() {
-    InputStatesStore.stop(this.props.input);
+    this.setState({ loading: true });
+    InputStatesStore.stop(this.props.input)
+      .finally(() => this.setState({ loading: false }));
   },
+
   render() {
     if (this._isInputRunning()) {
-      return <Button bsStyle="primary" onClick={this._stopInput}>Stop input</Button>;
+      return (
+        <Button bsStyle="primary" onClick={this._stopInput} disabled={this.state.loading}>
+          {this.state.loading ? 'Stopping...' : 'Stop input'}
+        </Button>
+      );
     }
 
-    return <Button bsStyle="success" onClick={this._startInput}>Start input</Button>;
+    return (
+      <Button bsStyle="success" onClick={this._startInput} disabled={this.state.loading}>
+        {this.state.loading ? 'Starting...' : 'Start input'}
+      </Button>
+    );
   },
 });
 

--- a/graylog2-web-interface/src/components/streams/Stream.jsx
+++ b/graylog2-web-interface/src/components/streams/Stream.jsx
@@ -25,6 +25,13 @@ const Stream = React.createClass({
     };
   },
   mixins: [PermissionsMixin],
+
+  getInitialState() {
+    return {
+      loading: false,
+    };
+  },
+
   _formatNumberOfStreamRules(stream) {
     let verbalMatchingType;
     switch (stream.matching_type) {
@@ -41,8 +48,9 @@ const Stream = React.createClass({
     }
   },
   _onResume() {
-    StreamsStore.resume(this.props.stream.id, () => {
-    });
+    this.setState({ loading: true });
+    StreamsStore.resume(this.props.stream.id, () => {})
+      .finally(() => this.setState({ loading: false }));
   },
   _onUpdate(streamId, stream) {
     StreamsStore.update(streamId, stream, () => UserNotification.success(`Stream '${stream.title}' was updated successfully.`, 'Success'));
@@ -52,8 +60,9 @@ const Stream = React.createClass({
   },
   _onPause() {
     if (window.confirm(`Do you really want to pause stream '${this.props.stream.title}'?`)) {
-      StreamsStore.pause(this.props.stream.id, () => {
-      });
+      this.setState({ loading: true });
+      StreamsStore.pause(this.props.stream.id, () => {})
+        .finally(() => this.setState({ loading: false }));
     }
   },
   _onQuickAdd() {
@@ -94,11 +103,15 @@ const Stream = React.createClass({
     if (this.isAnyPermitted(permissions, [`streams:changestate:${stream.id}`, `streams:edit:${stream.id}`])) {
       if (stream.disabled) {
         toggleStreamLink = (
-          <a className="btn btn-success toggle-stream-button" onClick={this._onResume}>Start Stream</a>
+          <Button bsStyle="success" className="toggle-stream-button" onClick={this._onResume} disabled={this.state.loading}>
+            {this.state.loading ? 'Starting...' : 'Start Stream'}
+          </Button>
         );
       } else {
         toggleStreamLink = (
-          <a className="btn btn-primary toggle-stream-button" onClick={this._onPause}>Pause Stream</a>
+          <Button bsStyle="primary" className="toggle-stream-button" onClick={this._onPause} disabled={this.state.loading}>
+            {this.state.loading ? 'Pausing...' : 'Pause Stream'}
+          </Button>
         );
       }
     }

--- a/graylog2-web-interface/src/index.jsx
+++ b/graylog2-web-interface/src/index.jsx
@@ -1,6 +1,10 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
 import AppFacade from 'routing/AppFacade';
+import Promise from 'bluebird';
+import Reflux from 'reflux';
+
+Reflux.setPromiseFactory((handlers) => new Promise(handlers));
 
 window.onload = () => {
   const appContainer = document.createElement('div');

--- a/graylog2-web-interface/src/stores/streams/StreamsStore.ts
+++ b/graylog2-web-interface/src/stores/streams/StreamsStore.ts
@@ -68,7 +68,7 @@ class StreamsStore {
     };
 
     const url = URLUtils.qualifyUrl(ApiRoutes.StreamsApiController.pause(streamId).url);
-    fetch('POST', url).then(callback, failCallback).then(this._emitChange.bind(this));
+    return fetch('POST', url).then(callback, failCallback).then(this._emitChange.bind(this));
   }
   resume(streamId: string, callback: (() => void)) {
     const failCallback = (errorThrown) => {
@@ -77,7 +77,7 @@ class StreamsStore {
     };
 
     const url = URLUtils.qualifyUrl(ApiRoutes.StreamsApiController.resume(streamId).url);
-    fetch('POST', url)
+    return fetch('POST', url)
       .then(callback, failCallback).then(this._emitChange.bind(this));
   }
   save(stream: any, callback: ((streamId: string) => void)) {


### PR DESCRIPTION
This PR adds feedback to buttons triggering actions that may take some time to receive a response from the server. In that way, the user can see the action is being processed and doesn't have to wonder if the click worked or not.

In order to use [`finally`](http://bluebirdjs.com/docs/api/finally.html) in our promises to reset the loading status, I had to set bluebird as the default promise factory in Reflux. I wrote a bit more about it in  	1ae78c0's commit message.