### PR TITLE
Fix display of total count of indices.

### DIFF
--- a/graylog2-web-interface/src/pages/IndicesPage.jsx
+++ b/graylog2-web-interface/src/pages/IndicesPage.jsx
@@ -37,7 +37,7 @@ const IndicesPage = React.createClass({
   },
   REFRESH_INTERVAL: 2000,
   _totalIndexCount() {
-    return (Object.keys(this.state.indexerOverview.indices).length + this.state.indexDetails.closedIndices.length);
+    return Object.keys(this.state.indexerOverview.indices).length;
   },
   render() {
     if (!this.state.indexerOverview || !this.state.indexDetails.closedIndices) {


### PR DESCRIPTION
The indices overview includes closed indices too, but they were added
separately in the display of total indices. This was fixed now to
correct the number of total indices.

FIxes #2359

Should be merged into `master` as well.