### PR TITLE
Fix permission checks for non admin users

### DIFF
--- a/graylog2-web-interface/src/components/navigation/Navigation.jsx
+++ b/graylog2-web-interface/src/components/navigation/Navigation.jsx
@@ -15,6 +15,7 @@ import { PluginStore } from 'graylog-web-plugin/plugin';
 import GlobalThroughput from 'components/throughput/GlobalThroughput';
 import UserMenu from 'components/navigation/UserMenu';
 import HelpMenu from 'components/navigation/HelpMenu';
+import { IfPermitted } from 'components/common';
 
 const Navigation = React.createClass({
   propTypes: {
@@ -94,7 +95,6 @@ const Navigation = React.createClass({
       <LinkContainer to={Routes.STARTPAGE}>
         <a><img src={logoUrl}/></a>
       </LinkContainer>);
-    // TODO: fix permission names
 
     let notificationBadge;
 
@@ -142,11 +142,11 @@ const Navigation = React.createClass({
         </Navbar.Header>
         <Navbar.Collapse eventKey={0}>
           <Nav navbar>
-            {this.isPermitted(this.props.permissions, ['searches:absolute', 'searches:relative', 'searches:keyword']) &&
+            <IfPermitted permissions={['searches:absolute', 'searches:relative', 'searches:keyword']}>
               <LinkContainer to={Routes.SEARCH}>
                 <NavItem to="search">Search</NavItem>
               </LinkContainer>
-            }
+            </IfPermitted>
             <LinkContainer to={Routes.STREAMS}>
               <NavItem>Streams</NavItem>
             </LinkContainer>
@@ -155,14 +155,19 @@ const Navigation = React.createClass({
               <NavItem >Dashboards</NavItem>
             </LinkContainer>
 
-            {this.isPermitted(this.props.permissions, ['sources:read']) &&
+            <IfPermitted permissions="sources:read">
               <LinkContainer to={Routes.SOURCES}>
                 <NavItem>Sources</NavItem>
               </LinkContainer>
-            }
+            </IfPermitted>
 
             {pluginNavigations}
 
+            {/*
+             * We cannot use IfPermitted in the dropdown unless we modify it to clone children elements and pass
+             * props down to them. NavDropdown is passing some props needed in MenuItems that are being blocked
+             * by IfPermitted.
+             */}
             <NavDropdown navItem title={this._systemTitle()} id="system-menu-dropdown">
               <LinkContainer to={Routes.SYSTEM.OVERVIEW}>
                 <MenuItem>Overview</MenuItem>

--- a/graylog2-web-interface/src/components/navigation/Navigation.jsx
+++ b/graylog2-web-interface/src/components/navigation/Navigation.jsx
@@ -142,7 +142,7 @@ const Navigation = React.createClass({
         </Navbar.Header>
         <Navbar.Collapse eventKey={0}>
           <Nav navbar>
-            {this.isPermitted(this.props.permissions, ['SEARCHES_ABSOLUTE', 'SEARCHES_RELATIVE', 'SEARCHES_KEYWORD']) &&
+            {this.isPermitted(this.props.permissions, ['searches:absolute', 'searches:relative', 'searches:keyword']) &&
               <LinkContainer to={Routes.SEARCH}>
                 <NavItem to="search">Search</NavItem>
               </LinkContainer>
@@ -155,7 +155,7 @@ const Navigation = React.createClass({
               <NavItem >Dashboards</NavItem>
             </LinkContainer>
 
-            {this.isPermitted(this.props.permissions, ['SOURCES_READ']) &&
+            {this.isPermitted(this.props.permissions, ['sources:read']) &&
               <LinkContainer to={Routes.SOURCES}>
                 <NavItem>Sources</NavItem>
               </LinkContainer>
@@ -167,7 +167,7 @@ const Navigation = React.createClass({
               <LinkContainer to={Routes.SYSTEM.OVERVIEW}>
                 <MenuItem>Overview</MenuItem>
               </LinkContainer>
-              {this.isPermitted(this.props.permissions, ['CLUSTER_CONFIG_ENTRY_READ']) &&
+              {this.isPermitted(this.props.permissions, ['clusterconfigentry:read']) &&
               <LinkContainer to={Routes.SYSTEM.CONFIGURATIONS}>
                 <MenuItem>Configurations</MenuItem>
               </LinkContainer>
@@ -175,42 +175,42 @@ const Navigation = React.createClass({
               <LinkContainer to={Routes.SYSTEM.NODES.LIST}>
                 <MenuItem>Nodes</MenuItem>
               </LinkContainer>
-              {this.isPermitted(this.props.permissions, ['INPUTS_READ']) &&
+              {this.isPermitted(this.props.permissions, ['inputs:read']) &&
                 <LinkContainer to={Routes.SYSTEM.INPUTS}>
                   <MenuItem>Inputs</MenuItem>
                 </LinkContainer>
               }
-              {this.isPermitted(this.props.permissions, ['OUTPUTS_READ']) &&
+              {this.isPermitted(this.props.permissions, ['outputs:read']) &&
                 <LinkContainer to={Routes.SYSTEM.OUTPUTS}>
                   <MenuItem>Outputs</MenuItem>
                 </LinkContainer>
               }
-              {this.isPermitted(this.props.permissions, ['INDICES_READ']) &&
+              {this.isPermitted(this.props.permissions, ['indices:read']) &&
                 <LinkContainer to={Routes.SYSTEM.INDICES.LIST}>
                   <MenuItem>Indices</MenuItem>
                 </LinkContainer>
               }
-              {this.isPermitted(this.props.permissions, ['LOGGERS_READ']) &&
+              {this.isPermitted(this.props.permissions, ['loggers:read']) &&
                 <LinkContainer to={Routes.SYSTEM.LOGGING}>
                   <MenuItem>Logging</MenuItem>
                 </LinkContainer>
               }
-              {this.isPermitted(this.props.permissions, ['USERS_READ']) &&
+              {this.isPermitted(this.props.permissions, ['users:list']) &&
                 <LinkContainer to={Routes.SYSTEM.USERS.LIST}>
                   <MenuItem>Users</MenuItem>
                 </LinkContainer>
               }
-              {this.isPermitted(this.props.permissions, ['ROLES_READ']) &&
+              {this.isPermitted(this.props.permissions, ['roles:read']) &&
                 <LinkContainer to={Routes.SYSTEM.ROLES}>
                   <MenuItem>Roles</MenuItem>
                 </LinkContainer>
               }
-              {this.isPermitted(this.props.permissions, ['DASHBOARDS_CREATE', 'INPUTS_CREATE', 'STREAMS_CREATE']) &&
+              {this.isPermitted(this.props.permissions, ['dashboards:create', 'inputs:create', 'streams:create']) &&
               <LinkContainer to={Routes.SYSTEM.CONTENTPACKS.LIST}>
                 <MenuItem>Content Packs</MenuItem>
               </LinkContainer>
               }
-              {this.isPermitted(this.props.permissions, ['INPUTS_EDIT']) &&
+              {this.isPermitted(this.props.permissions, ['inputs:edit']) &&
               <LinkContainer to={Routes.SYSTEM.GROKPATTERNS}>
                 <MenuItem>Grok Patterns</MenuItem>
               </LinkContainer>

--- a/graylog2-web-interface/src/components/users/UserForm.jsx
+++ b/graylog2-web-interface/src/components/users/UserForm.jsx
@@ -209,7 +209,7 @@ const UserForm = React.createClass({
                        onChange={this._bindValue} labelClassName="col-sm-3" wrapperClassName="col-sm-9"
                        label="Email Address" help="Give the contact email address." required />
 
-                {this.isPermitted(permissions, 'users:edit') &&
+                <IfPermitted permissions="users:edit">
                   <span>
                     <div className="form-group">
                       <Col sm={9} smOffset={3}>
@@ -252,11 +252,11 @@ const UserForm = React.createClass({
                       </Col>
                     </div>
                   </span>
-                }
-                {this.isPermitted(permissions, '*') &&
-                <TimeoutInput ref="session_timeout_ms" value={user.session_timeout_ms} labelSize={3} controlSize={9}
-                              onChange={this._onFieldChange('session_timeout_ms')} />
-                }
+                </IfPermitted>
+                <IfPermitted permissions="*">
+                  <TimeoutInput ref="session_timeout_ms" value={user.session_timeout_ms} labelSize={3} controlSize={9}
+                                onChange={this._onFieldChange('session_timeout_ms')} />
+                </IfPermitted>
 
                 <Input label="Time Zone"
                        help="Choose your local time zone or leave it as it is to use the system's default."

--- a/graylog2-web-interface/src/components/users/UserForm.jsx
+++ b/graylog2-web-interface/src/components/users/UserForm.jsx
@@ -209,7 +209,7 @@ const UserForm = React.createClass({
                        onChange={this._bindValue} labelClassName="col-sm-3" wrapperClassName="col-sm-9"
                        label="Email Address" help="Give the contact email address." required />
 
-                {this.isPermitted(permissions, 'USERS_EDIT') &&
+                {this.isPermitted(permissions, 'users:edit') &&
                   <span>
                     <div className="form-group">
                       <Col sm={9} smOffset={3}>

--- a/graylog2-web-interface/src/components/users/UserForm.jsx
+++ b/graylog2-web-interface/src/components/users/UserForm.jsx
@@ -321,7 +321,7 @@ const UserForm = React.createClass({
             }
           </Col>
         </Row>
-        <IfPermitted permissions="USERS_ROLESEDIT">
+        <IfPermitted permissions="users:rolesedit">
           <EditRolesForm user={this.props.user} />
         </IfPermitted>
       </div>

--- a/graylog2-web-interface/src/pages/LdapGroupsPage.jsx
+++ b/graylog2-web-interface/src/pages/LdapGroupsPage.jsx
@@ -60,13 +60,13 @@ const LdapGroupsPage = React.createClass({
           </span>
 
           <span>
-            <IfPermitted permissions="LDAP_EDIT">
+            <IfPermitted permissions="ldap:edit">
               <LinkContainer to={Routes.SYSTEM.LDAP.SETTINGS}>
                 <Button bsStyle="info">Configure LDAP</Button>
               </LinkContainer>
             </IfPermitted>
             &nbsp;
-            <IfPermitted permissions="USERS_LIST">
+            <IfPermitted permissions="users:list">
               <LinkContainer to={Routes.SYSTEM.USERS.LIST}>
                 <Button bsStyle="info">Manage users</Button>
               </LinkContainer>

--- a/graylog2-web-interface/src/pages/StartPage.jsx
+++ b/graylog2-web-interface/src/pages/StartPage.jsx
@@ -39,7 +39,7 @@ const StartPage = React.createClass({
   },
   _redirectToStartpage() {
     // Show getting started page if user is an admin and getting started wasn't dismissed
-    if (PermissionsMixin.isPermitted(this.state.currentUser.permissions, ['INPUTS_CREATE'])) {
+    if (PermissionsMixin.isPermitted(this.state.currentUser.permissions, ['inputs:create'])) {
       if (!!this.state.gettingStarted.show) {
         this._redirect(Routes.GETTING_STARTED);
         return;
@@ -58,7 +58,7 @@ const StartPage = React.createClass({
     }
 
     // Show search page if permitted, or streams page in other case
-    if (PermissionsMixin.isAnyPermitted(this.state.currentUser.permissions, ['SEARCHES_ABSOLUTE', 'SEARCHES_RELATIVE', 'SEARCHES_KEYWORD'])) {
+    if (PermissionsMixin.isAnyPermitted(this.state.currentUser.permissions, ['searches:absolute', 'searches:keyword', 'searches:relative'])) {
       this._redirect(Routes.SEARCH);
     } else {
       this._redirect(Routes.STREAMS);

--- a/graylog2-web-interface/src/pages/UsersPage.jsx
+++ b/graylog2-web-interface/src/pages/UsersPage.jsx
@@ -26,19 +26,19 @@ const UsersPage = React.createClass({
 
           <span>Read more about user management in the <DocumentationLink page={DocsHelper.PAGES.USERS_ROLES} text="documentation"/>.</span>
           <span>
-            {this.isPermitted(permissions, 'LDAP_EDIT') &&
+            {this.isPermitted(permissions, 'ldap:edit') &&
               <LinkContainer to={Routes.SYSTEM.LDAP.SETTINGS}>
                 <Button bsStyle="info">Configure LDAP</Button>
               </LinkContainer>
             }
             {' '}
-            {this.isPermitted(permissions, 'LDAPGROUPS_EDIT') &&
+            {this.isPermitted(permissions, 'ldapgroups:edit') &&
               <LinkContainer to={Routes.SYSTEM.LDAP.GROUPS}>
                 <Button bsStyle="info">LDAP Group Mapping</Button>
               </LinkContainer>
             }
             {' '}
-            {this.isPermitted(permissions, 'USERS_CREATE') &&
+            {this.isPermitted(permissions, 'users:create') &&
               <LinkContainer to={Routes.SYSTEM.USERS.CREATE}>
                 <Button bsStyle="success">Add new user</Button>
               </LinkContainer>

--- a/graylog2-web-interface/src/pages/UsersPage.jsx
+++ b/graylog2-web-interface/src/pages/UsersPage.jsx
@@ -10,15 +10,13 @@ import Routes from 'routing/Routes';
 import StoreProvider from 'injection/StoreProvider';
 const CurrentUserStore = StoreProvider.getStore('CurrentUser');
 
-import PageHeader from 'components/common/PageHeader';
+import { IfPermitted, PageHeader } from 'components/common';
 import DocumentationLink from 'components/support/DocumentationLink';
 import UserList from 'components/users/UserList';
 
 const UsersPage = React.createClass({
   mixins: [Reflux.connect(CurrentUserStore), PermissionsMixin],
   render() {
-    const permissions = this.state.currentUser.permissions;
-    // TODO: fix permission names
     return (
       <span>
         <PageHeader title="User accounts">
@@ -26,23 +24,23 @@ const UsersPage = React.createClass({
 
           <span>Read more about user management in the <DocumentationLink page={DocsHelper.PAGES.USERS_ROLES} text="documentation"/>.</span>
           <span>
-            {this.isPermitted(permissions, 'ldap:edit') &&
+            <IfPermitted permissions="ldap:edit">
               <LinkContainer to={Routes.SYSTEM.LDAP.SETTINGS}>
                 <Button bsStyle="info">Configure LDAP</Button>
               </LinkContainer>
-            }
+            </IfPermitted>
             {' '}
-            {this.isPermitted(permissions, 'ldapgroups:edit') &&
+            <IfPermitted permissions="ldapgroups:edit">
               <LinkContainer to={Routes.SYSTEM.LDAP.GROUPS}>
                 <Button bsStyle="info">LDAP Group Mapping</Button>
               </LinkContainer>
-            }
+            </IfPermitted>
             {' '}
-            {this.isPermitted(permissions, 'users:create') &&
+            <IfPermitted permissions="users:create">
               <LinkContainer to={Routes.SYSTEM.USERS.CREATE}>
                 <Button bsStyle="success">Add new user</Button>
               </LinkContainer>
-            }
+            </IfPermitted>
           </span>
         </PageHeader>
 


### PR DESCRIPTION
Some components were using wrong permission values in checks, so non-admin users could never get to do those actions.

Original issue: #2358

The changes should also be merged into 2.0, I already checked they apply cleanly.