### PR TITLE
Add handler for / in the Graylog REST API

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/rest/models/HelloWorldResponse.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/models/HelloWorldResponse.java
@@ -35,7 +35,7 @@ public abstract class HelloWorldResponse {
     @JsonProperty("tagline")
     public abstract String tagline();
 
-    public static HelloWorldResponse create(@JsonProperty("cluster_id") String clusterId, String nodeId, String version, String tagline) {
+    public static HelloWorldResponse create(String clusterId, String nodeId, String version, String tagline) {
         return new AutoValue_HelloWorldResponse(clusterId, nodeId, version, tagline);
     }
 }

--- a/graylog2-server/src/main/java/org/graylog2/rest/models/HelloWorldResponse.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/models/HelloWorldResponse.java
@@ -1,0 +1,41 @@
+/**
+ * This file is part of Graylog.
+ *
+ * Graylog is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.graylog2.rest.models;
+
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.auto.value.AutoValue;
+
+@AutoValue
+@JsonAutoDetect
+public abstract class HelloWorldResponse {
+    @JsonProperty("cluster_id")
+    public abstract String clusterId();
+
+    @JsonProperty("node_id")
+    public abstract String nodeId();
+
+    @JsonProperty("version")
+    public abstract String version();
+
+    @JsonProperty("tagline")
+    public abstract String tagline();
+
+    public static HelloWorldResponse create(@JsonProperty("cluster_id") String clusterId, String nodeId, String version, String tagline) {
+        return new AutoValue_HelloWorldResponse(clusterId, nodeId, version, tagline);
+    }
+}

--- a/graylog2-server/src/main/java/org/graylog2/rest/resources/HelloWorldResource.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/resources/HelloWorldResource.java
@@ -1,0 +1,63 @@
+/**
+ * This file is part of Graylog.
+ *
+ * Graylog is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.graylog2.rest.resources;
+
+import com.codahale.metrics.annotation.Timed;
+import io.swagger.annotations.Api;
+import io.swagger.annotations.ApiOperation;
+import org.apache.shiro.authz.annotation.RequiresAuthentication;
+import org.graylog2.plugin.Version;
+import org.graylog2.plugin.cluster.ClusterConfigService;
+import org.graylog2.plugin.cluster.ClusterId;
+import org.graylog2.plugin.system.NodeId;
+import org.graylog2.rest.models.HelloWorldResponse;
+import org.graylog2.shared.rest.resources.RestResource;
+
+import javax.inject.Inject;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
+
+import static java.util.Objects.requireNonNull;
+
+@Api(value = "Hello World", description = "A friendly hello world message")
+@Path("/")
+public class HelloWorldResource extends RestResource {
+    private final NodeId nodeId;
+    private final ClusterConfigService clusterConfigService;
+
+    @Inject
+    public HelloWorldResource(NodeId nodeId, ClusterConfigService clusterConfigService) {
+        this.nodeId = requireNonNull(nodeId);
+        this.clusterConfigService = requireNonNull(clusterConfigService);
+    }
+
+    @GET
+    @Timed
+    @ApiOperation(value = "A few details about the Graylog node.")
+    @Produces(MediaType.APPLICATION_JSON)
+    public HelloWorldResponse helloWorld() {
+        final ClusterId clusterId = clusterConfigService.getOrDefault(ClusterId.class, ClusterId.create("UNKNOWN"));
+        return HelloWorldResponse.create(
+            clusterId.clusterId(),
+            nodeId.toString(),
+            Version.CURRENT_CLASSPATH.toString(),
+            "Manage your logs in the dark and have lasers going and make it look like you're from space!"
+        );
+    }
+}


### PR DESCRIPTION
Some users seem to be confused about the root resource (`/`) returning a HTTP 404 response, so this PR adds a short (and in some cases even useful) "Hello World!" message:
```json
{
  "cluster_id" : "b1ce3a29-6845-4e00-bd8c-d4499dc9e95d",
  "node_id" : "cd03ee44-b2a7-4824-be16-bb7456149dbd",
  "version" : "2.1.0-SNAPSHOT",
  "tagline" : "Manage your logs in the dark and have lasers going and make it look like you're from space!"
}
```