### PR TITLE
Make Message#getStreamIds() more reliable

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/plugin/Message.java
+++ b/graylog2-server/src/main/java/org/graylog2/plugin/Message.java
@@ -45,6 +45,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
 import java.util.regex.Pattern;
+import java.util.stream.Collectors;
 
 import static com.google.common.base.Predicates.equalTo;
 import static com.google.common.base.Predicates.not;
@@ -433,14 +434,16 @@ public class Message implements Messages {
         return streams.remove(stream);
     }
 
-    @SuppressWarnings("unchecked")
     public List<String> getStreamIds() {
         if (!hasField(FIELD_STREAMS)) {
-            return Collections.emptyList();
+            return streams.stream().map(Stream::getId).collect(Collectors.toList());
         }
         try {
-            return Lists.<String>newArrayList(getFieldAs(List.class, FIELD_STREAMS));
+            @SuppressWarnings("unchecked")
+            final List<String> streamIds = getFieldAs(List.class, FIELD_STREAMS);
+            return new ArrayList<>(streamIds);
         } catch (ClassCastException e) {
+            LOG.trace("Couldn't cast {} to List", FIELD_STREAMS, e);
             return Collections.emptyList();
         }
     }

--- a/graylog2-server/src/test/java/org/graylog2/plugin/MessageTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/plugin/MessageTest.java
@@ -38,6 +38,7 @@ import java.util.Set;
 import java.util.regex.Pattern;
 
 import static com.google.common.collect.Sets.symmetricDifference;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotEquals;
@@ -194,7 +195,7 @@ public class MessageTest {
         message.addStreams(Lists.newArrayList(stream2, stream1));
 
         // make sure all streams we've added are being returned. Internally it's a set, so don't check the order, it doesn't matter anyway.
-        Assertions.assertThat(message.getStreams()).containsOnly(stream1, stream2);
+        assertThat(message.getStreams()).containsOnly(stream1, stream2);
     }
 
     @Test
@@ -203,25 +204,25 @@ public class MessageTest {
         final Stream stream2 = mock(Stream.class);
         final Stream stream3 = mock(Stream.class);
 
-        Assertions.assertThat(message.getStreams()).isNotNull();
-        Assertions.assertThat(message.getStreams()).isEmpty();
+        assertThat(message.getStreams()).isNotNull();
+        assertThat(message.getStreams()).isEmpty();
 
         message.addStream(stream1);
 
         final Set<Stream> onlyWithStream1 = message.getStreams();
-        Assertions.assertThat(onlyWithStream1).containsOnly(stream1);
+        assertThat(onlyWithStream1).containsOnly(stream1);
 
         message.addStreams(Sets.newHashSet(stream3, stream2));
-        Assertions.assertThat(message.getStreams()).containsOnly(stream1, stream2, stream3);
+        assertThat(message.getStreams()).containsOnly(stream1, stream2, stream3);
 
         // getStreams is a copy and doesn't change after mutations
-        Assertions.assertThat(onlyWithStream1).containsOnly(stream1);
+        assertThat(onlyWithStream1).containsOnly(stream1);
 
         // stream2 was assigned
-        Assertions.assertThat(message.removeStream(stream2)).isTrue();
+        assertThat(message.removeStream(stream2)).isTrue();
         // streams2 is no longer assigned
-        Assertions.assertThat(message.removeStream(stream2)).isFalse();
-        Assertions.assertThat(message.getStreams()).containsOnly(stream1, stream3);
+        assertThat(message.removeStream(stream2)).isFalse();
+        assertThat(message.getStreams()).containsOnly(stream1, stream3);
     }
 
     @Test
@@ -440,5 +441,28 @@ public class MessageTest {
 
         assertEquals(message.getTimestamp().toDate(), dateObject);
         assertEquals(message.getField(Message.FIELD_TIMESTAMP).getClass(), DateTime.class);
+    }
+
+    @Test
+    public void getStreamIdsReturnsStreamsIdsIfFieldDoesNotExist() {
+        final Message message = new Message("", "source", Tools.nowUTC());
+        final Stream stream = mock(Stream.class);
+        when(stream.getId()).thenReturn("test");
+        message.addStream(stream);
+
+        assertThat(message.getStreamIds()).containsOnly("test");
+
+    }
+
+    @Test
+    public void getStreamIdsReturnsStreamsFieldContentsIfFieldDoesExist() {
+        final Message message = new Message("", "source", Tools.nowUTC());
+        final Stream stream = mock(Stream.class);
+        when(stream.getId()).thenReturn("test1");
+        message.addField("streams", Collections.singletonList("test2"));
+        message.addStream(stream);
+
+        assertThat(message.getStreamIds()).containsOnly("test2");
+
     }
 }


### PR DESCRIPTION
The `Message#getStreamIds()` method only checked for the existence of the "streams" message field and returned it. This only works for messages which have already been indexed and have that field.

For messages in-flight, the method always returned an empty list, even if `StreamMatcherFilter` had run before.

This commit extends `Message#getStreamIds()` to also query the internal "streams" list which is being populated by the `StreamMatcherFilter` if the "streams" message field doesn't exist.