### PR TITLE
Update search query on auto refresh

### DIFF
--- a/graylog2-web-interface/src/pages/SearchPage.jsx
+++ b/graylog2-web-interface/src/pages/SearchPage.jsx
@@ -36,7 +36,6 @@ const SearchPage = React.createClass({
   getInitialState() {
     return {
       selectedFields: ['message', 'source'],
-      query: SearchStore.query.length > 0 ? SearchStore.query : '*',
       error: undefined,
     };
   },
@@ -66,8 +65,11 @@ const SearchPage = React.createClass({
       clearInterval(this.timer);
     }
   },
+  _getEffectiveQuery() {
+    return SearchStore.query.length > 0 ? SearchStore.query : '*';
+  },
   _refreshData() {
-    const query = this.state.query;
+    const query = this._getEffectiveQuery();
     const streamId = this.props.searchInStream ? this.props.searchInStream.id : undefined;
     UniversalSearchStore.search(SearchStore.rangeType, query, SearchStore.rangeParams.toJS(), streamId, null, SearchStore.page, SearchStore.sortField, SearchStore.sortOrder)
       .then(

--- a/graylog2-web-interface/src/pages/SearchPage.jsx
+++ b/graylog2-web-interface/src/pages/SearchPage.jsx
@@ -51,6 +51,14 @@ const SearchPage = React.createClass({
 
     NodesActions.list();
   },
+  componentWillReceiveProps(nextProps) {
+    const currentLocation = this.props.location || {};
+    const nextLocation = nextProps.location || {};
+
+    if ((currentLocation !== nextLocation) || (currentLocation.search !== nextLocation.search)) {
+      this._refreshData();
+    }
+  },
   componentWillUnmount() {
     this._stopTimer();
   },


### PR DESCRIPTION
When a search did not return results, clicking on the "Search" navigation menu, does not reset the search query used for auto-refresh.

Removing the query from the `SearchPage` state fixes the problem, as the search query is properly updated in the `SearchStore`.

Fixes #2379.

These changes should also be merged into master.