### PR TITLE
Remove "elasticsearch_discovery_zen_ping_multicast_enabled" setting

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/bindings/providers/EsNodeProvider.java
+++ b/graylog2-server/src/main/java/org/graylog2/bindings/providers/EsNodeProvider.java
@@ -80,7 +80,6 @@ public class EsNodeProvider implements Provider<Node> {
         settings.put("transport.tcp.port", conf.getTransportTcpPort());
 
         settings.put("discovery.initial_state_timeout", conf.getInitialStateTimeout());
-        settings.put("discovery.zen.ping.multicast.enabled", conf.isMulticastDiscovery());
 
         final List<String> unicastHosts = conf.getUnicastHosts();
         if (unicastHosts != null && !unicastHosts.isEmpty()) {

--- a/graylog2-server/src/main/java/org/graylog2/configuration/ElasticsearchConfiguration.java
+++ b/graylog2-server/src/main/java/org/graylog2/configuration/ElasticsearchConfiguration.java
@@ -56,9 +56,6 @@ public class ElasticsearchConfiguration {
     @Parameter(value = "elasticsearch_http_enabled")
     private boolean httpEnabled = false;
 
-    @Parameter(value = "elasticsearch_discovery_zen_ping_multicast_enabled")
-    private boolean multicastDiscovery = false;
-
     @Parameter(value = "elasticsearch_discovery_zen_ping_unicast_hosts", converter = StringListConverter.class)
     private List<String> unicastHosts = Collections.singletonList("127.0.0.1:9300");
 
@@ -160,10 +157,6 @@ public class ElasticsearchConfiguration {
 
     public boolean isHttpEnabled() {
         return httpEnabled;
-    }
-
-    public boolean isMulticastDiscovery() {
-        return multicastDiscovery;
     }
 
     public List<String> getUnicastHosts() {

--- a/graylog2-server/src/test/java/org/graylog2/bindings/providers/EsNodeProviderTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/bindings/providers/EsNodeProviderTest.java
@@ -85,7 +85,6 @@ public class EsNodeProviderTest {
         assertEquals(defaultConfig.isHttpEnabled(), nodeSettings.getAsBoolean("http.enabled", false));
         assertEquals(defaultConfig.getTransportTcpPort(), nodeSettings.getAsInt("transport.tcp.port", 0).intValue());
         assertEquals(defaultConfig.getInitialStateTimeout(), nodeSettings.get("discovery.initial_state_timeout"));
-        assertEquals(defaultConfig.isMulticastDiscovery(), nodeSettings.getAsBoolean("discovery.zen.ping.multicast.enabled", false));
         assertEquals(false, nodeSettings.getAsBoolean("action.auto_create_index", true));
 
     }
@@ -105,11 +104,6 @@ public class EsNodeProviderTest {
         addEsConfig(esPropNames, settings, "path.data", "elasticsearch_path_data", "data/elasticsearch");
         addEsConfig(esPropNames, settings, "transport.tcp.port", "elasticsearch_transport_tcp_port", "9999");
         addEsConfig(esPropNames, settings, "http.enabled", "elasticsearch_http_enabled", "true");
-        addEsConfig(esPropNames,
-                settings,
-                "discovery.zen.ping.multicast.enabled",
-                "elasticsearch_discovery_zen_ping_multicast_enabled",
-                "false");
         addEsConfig(esPropNames,
                 settings,
                 "discovery.zen.ping.unicast.hosts.0",
@@ -163,8 +157,6 @@ public class EsNodeProviderTest {
         assertNotEquals("http.enabled", config.isHttpEnabled(), nodeSettings.get("http.enabled"));
         assertNotEquals("transport.tcp.port", config.getTransportTcpPort(), nodeSettings.get("transport.tcp.port"));
         assertNotEquals("discovery.initial_state_timeout", config.getInitialStateTimeout(), nodeSettings.get("discovery.initial_state_timeout"));
-        assertNotEquals("discovery.zen.ping.multicast.enabled", config.isMulticastDiscovery(),
-                nodeSettings.get("discovery.zen.ping.multicast.enabled"));
         assertNotEquals("discovery.zen.ping.unicast.hosts", config.getUnicastHosts(),
                 Lists.newArrayList(nodeSettings.getAsArray("discovery.zen.ping.unicast.hosts")));
     }

--- a/misc/graylog.conf
+++ b/misc/graylog.conf
@@ -237,11 +237,6 @@ allow_highlighting = false
 # we don't need to run the embedded HTTP server here
 #elasticsearch_http_enabled = false
 
-# Enable Elasticsearch multicast discovery. This requires the installation of an Elasticsearch plugin,
-# see https://www.elastic.co/guide/en/elasticsearch/plugins/2.3/discovery-multicast.html for details.
-# Default: false
-#elasticsearch_discovery_zen_ping_multicast_enabled = false
-
 # Change the following setting if you are running into problems with timeouts during Elasticsearch cluster discovery.
 # The setting is specified in milliseconds, the default is 5000ms (5 seconds).
 #elasticsearch_cluster_discovery_timeout = 5000


### PR DESCRIPTION
ES multicast discovery has been moved into a plugin in Elasticsearch 2.0.0, been deprecated in Elasticsearch 2.2.0, and will be removed in Elasticsearch 5.0.0.

Additionally, the plugin (https://www.elastic.co/guide/en/elasticsearch/plugins/2.3/discovery-multicast.html) cannot be used with Graylog, so the `elasticsearch_discovery_zen_ping_multicast_enabled` setting is useless and should be removed.