### PR TITLE
Fix unrequested refresh of configuration forms/Reset configuration forms on cancel.

### DIFF
--- a/graylog2-web-interface/src/components/bootstrap/BootstrapModalForm.jsx
+++ b/graylog2-web-interface/src/components/bootstrap/BootstrapModalForm.jsx
@@ -18,12 +18,12 @@ class BootstrapModalForm extends Component {
     this.open = this.open.bind(this);
     this.close = this.close.bind(this);
     this._submit = this._submit.bind(this);
-    this._onModalClose = this._onModalClose.bind(this);
+    this._onModalCancel = this._onModalCancel.bind(this);
   }
 
-  _onModalClose() {
-    if (typeof this.props.onModalClose === 'function') {
-      this.props.onModalClose();
+  _onModalCancel() {
+    if (typeof this.props.onCancel === 'function') {
+      this.props.onCancel();
     }
 
     this.close();
@@ -76,7 +76,7 @@ class BootstrapModalForm extends Component {
             {body}
           </Modal.Body>
           <Modal.Footer>
-            <Button type="button" onClick={this._onModalClose}>{this.props.cancelButtonText}</Button>
+            <Button type="button" onClick={this._onModalCancel}>{this.props.cancelButtonText}</Button>
             <Button type="submit" bsStyle="primary">{this.props.submitButtonText}</Button>
           </Modal.Footer>
         </form>
@@ -96,6 +96,7 @@ BootstrapModalForm.propTypes = {
   onModalOpen: PropTypes.func,
   onModalClose: PropTypes.func,
   onSubmitForm: PropTypes.func,
+  onCancel: PropTypes.func,
   /* Object with additional props to pass to the form */
   formProps: PropTypes.object,
   /* Text to use in the cancel button. "Cancel" is the default */

--- a/graylog2-web-interface/src/components/bootstrap/BootstrapModalForm.jsx
+++ b/graylog2-web-interface/src/components/bootstrap/BootstrapModalForm.jsx
@@ -67,7 +67,10 @@ class BootstrapModalForm extends Component {
     );
 
     return (
-      <BootstrapModalWrapper ref="modal" onOpen={this.props.onModalOpen} onClose={this.props.onModalClose}>
+      <BootstrapModalWrapper ref="modal"
+                             onOpen={this.props.onModalOpen}
+                             onClose={this.props.onModalClose}
+                             onCancel={this._onModalCancel}>
         <Modal.Header closeButton>
           <Modal.Title>{this.props.title}</Modal.Title>
         </Modal.Header>

--- a/graylog2-web-interface/src/components/bootstrap/BootstrapModalForm.jsx
+++ b/graylog2-web-interface/src/components/bootstrap/BootstrapModalForm.jsx
@@ -70,7 +70,7 @@ class BootstrapModalForm extends Component {
       <BootstrapModalWrapper ref="modal"
                              onOpen={this.props.onModalOpen}
                              onClose={this.props.onModalClose}
-                             onCancel={this._onModalCancel}>
+                             onHide={this._onModalCancel}>
         <Modal.Header closeButton>
           <Modal.Title>{this.props.title}</Modal.Title>
         </Modal.Header>

--- a/graylog2-web-interface/src/components/bootstrap/BootstrapModalForm.jsx
+++ b/graylog2-web-interface/src/components/bootstrap/BootstrapModalForm.jsx
@@ -1,6 +1,6 @@
-import React, {Component, PropTypes} from 'react';
+import React, { Component, PropTypes } from 'react';
 import ReactDOM from 'react-dom';
-import {Modal, Button} from 'react-bootstrap';
+import { Modal, Button } from 'react-bootstrap';
 import $ from 'jquery';
 
 import BootstrapModalWrapper from 'components/bootstrap/BootstrapModalWrapper';

--- a/graylog2-web-interface/src/components/bootstrap/BootstrapModalWrapper.jsx
+++ b/graylog2-web-interface/src/components/bootstrap/BootstrapModalWrapper.jsx
@@ -33,7 +33,6 @@ class BootstrapModalWrapper extends Component {
     if (typeof this.props.onCancel === 'function') {
       this.props.onCancel();
     }
-    this.onClose();
   }
 
   open() {

--- a/graylog2-web-interface/src/components/bootstrap/BootstrapModalWrapper.jsx
+++ b/graylog2-web-interface/src/components/bootstrap/BootstrapModalWrapper.jsx
@@ -10,7 +10,7 @@ class BootstrapModalWrapper extends Component {
 
     this.open = this.open.bind(this);
     this.close = this.close.bind(this);
-    this._cancel = this._cancel.bind(this);
+    this._hide = this._hide.bind(this);
 
     this.state = {
       showModal: props.showModal || false,
@@ -29,9 +29,9 @@ class BootstrapModalWrapper extends Component {
     }
   }
 
-  onCancel() {
-    if (typeof this.props.onCancel === 'function') {
-      this.props.onCancel();
+  onHide() {
+    if (typeof this.props.onHide === 'function') {
+      this.props.onHide();
     }
   }
 
@@ -43,13 +43,13 @@ class BootstrapModalWrapper extends Component {
     this.setState({ showModal: false }, this.onClose);
   }
 
-  _cancel() {
-    this.setState({ showModal: false }, this.onCancel);
+  _hide() {
+    this.setState({ showModal: false }, this.onHide);
   }
 
   render() {
     return (
-      <Modal show={this.state.showModal} onHide={this._cancel}>
+      <Modal show={this.state.showModal} onHide={this._hide}>
         {this.props.children}
       </Modal>
     );
@@ -64,7 +64,7 @@ BootstrapModalWrapper.propTypes = {
   ]).isRequired,
   onOpen: PropTypes.func,
   onClose: PropTypes.func,
-  onCancel: PropTypes.func,
+  onHide: PropTypes.func,
 };
 
 export default BootstrapModalWrapper;

--- a/graylog2-web-interface/src/components/bootstrap/BootstrapModalWrapper.jsx
+++ b/graylog2-web-interface/src/components/bootstrap/BootstrapModalWrapper.jsx
@@ -10,6 +10,7 @@ class BootstrapModalWrapper extends Component {
 
     this.open = this.open.bind(this);
     this.close = this.close.bind(this);
+    this._cancel = this._cancel.bind(this);
 
     this.state = {
       showModal: props.showModal || false,
@@ -28,6 +29,13 @@ class BootstrapModalWrapper extends Component {
     }
   }
 
+  onCancel() {
+    if (typeof this.props.onCancel === 'function') {
+      this.props.onCancel();
+    }
+    this.onClose();
+  }
+
   open() {
     this.setState({ showModal: true }, this.onOpen);
   }
@@ -36,9 +44,13 @@ class BootstrapModalWrapper extends Component {
     this.setState({ showModal: false }, this.onClose);
   }
 
+  _cancel() {
+    this.setState({ showModal: false }, this.onCancel);
+  }
+
   render() {
     return (
-      <Modal show={this.state.showModal} onHide={this.close}>
+      <Modal show={this.state.showModal} onHide={this._cancel}>
         {this.props.children}
       </Modal>
     );
@@ -53,6 +65,7 @@ BootstrapModalWrapper.propTypes = {
   ]).isRequired,
   onOpen: PropTypes.func,
   onClose: PropTypes.func,
+  onCancel: PropTypes.func,
 };
 
 export default BootstrapModalWrapper;

--- a/graylog2-web-interface/src/components/bootstrap/BootstrapModalWrapper.jsx
+++ b/graylog2-web-interface/src/components/bootstrap/BootstrapModalWrapper.jsx
@@ -1,5 +1,5 @@
-import React, {Component, PropTypes} from 'react';
-import {Modal} from 'react-bootstrap';
+import React, { Component, PropTypes } from 'react';
+import { Modal } from 'react-bootstrap';
 
 /**
  * Encapsulates a react-bootstrap modal, hiding the state handling for the modal
@@ -29,11 +29,11 @@ class BootstrapModalWrapper extends Component {
   }
 
   open() {
-    this.setState({showModal: true}, this.onOpen);
+    this.setState({ showModal: true }, this.onOpen);
   }
 
   close() {
-    this.setState({showModal: false}, this.onClose);
+    this.setState({ showModal: false }, this.onClose);
   }
 
   render() {

--- a/graylog2-web-interface/src/components/configurationforms/ConfigurationForm.jsx
+++ b/graylog2-web-interface/src/components/configurationforms/ConfigurationForm.jsx
@@ -5,11 +5,23 @@ import BootstrapModalForm from 'components/bootstrap/BootstrapModalForm';
 import { BooleanField, DropdownField, NumberField, TextField } from 'components/configurationforms';
 
 const ConfigurationForm = React.createClass({
+  propTypes: {
+    cancelAction: React.PropTypes.func,
+    children: React.PropTypes.node,
+    helpBlock: React.PropTypes.node,
+    includeTitleField: React.PropTypes.bool,
+    submitAction: React.PropTypes.func.isRequired,
+    title: React.PropTypes.string,
+    titleValue: React.PropTypes.string,
+    typeName: React.PropTypes.string,
+    values: React.PropTypes.object,
+  },
+
   getDefaultProps() {
     return {
-      values: {},
       includeTitleField: true,
       titleValue: '',
+      values: {},
     };
   },
   getInitialState() {
@@ -30,7 +42,7 @@ const ConfigurationForm = React.createClass({
     data.type = this.props.typeName;
     data.configuration = {};
 
-    $.map(this.state.configFields, function(field, name) {
+    $.map(this.state.configFields, (field, name) => {
       // Replace undefined with null, as JSON.stringify will leave out undefined fields from the DTO sent to the server
       data.configuration[name] = (values[name] === undefined ? null : values[name]);
     });
@@ -82,37 +94,40 @@ const ConfigurationForm = React.createClass({
   _renderConfigField(configField, key, autoFocus) {
     const value = this.state.values[key];
     const typeName = this.props.typeName;
+    const elementKey = `${typeName}-${key}`;
 
-    switch(configField.type) {
-      case "text":
-        return (<TextField key={typeName + "-" + key} typeName={typeName} title={key} field={configField}
+    switch (configField.type) {
+      case 'text':
+        return (<TextField key={elementKey} typeName={typeName} title={key} field={configField}
                            value={value} onChange={this._handleChange} autoFocus={autoFocus} />);
-      case "number":
-        return (<NumberField key={typeName + "-" + key} typeName={typeName} title={key} field={configField}
+      case 'number':
+        return (<NumberField key={elementKey} typeName={typeName} title={key} field={configField}
                              value={value} onChange={this._handleChange} autoFocus={autoFocus} />);
-      case "boolean":
-        return (<BooleanField key={typeName + "-" + key} typeName={typeName} title={key} field={configField}
+      case 'boolean':
+        return (<BooleanField key={elementKey} typeName={typeName} title={key} field={configField}
                               value={value} onChange={this._handleChange} autoFocus={autoFocus} />);
-      case "dropdown":
-        return (<DropdownField key={typeName + "-" + key} typeName={typeName} title={key} field={configField}
+      case 'dropdown':
+        return (<DropdownField key={elementKey} typeName={typeName} title={key} field={configField}
                                value={value} onChange={this._handleChange} autoFocus={autoFocus} />);
+      default:
+        return null;
     }
   },
   render() {
     const typeName = this.props.typeName;
     const title = this.props.title;
     const helpBlock = this.props.helpBlock;
-    const titleField = {is_optional: false, attributes: [], human_name: 'Title', description: helpBlock};
+    const titleField = { is_optional: false, attributes: [], human_name: 'Title', description: helpBlock };
 
     let shouldAutoFocus = true;
     let titleElement;
     if (this.props.includeTitleField) {
-      titleElement = (<TextField key={typeName + "-title"} typeName={typeName} title="title" field={titleField}
+      titleElement = (<TextField key={`${typeName}-title`} typeName={typeName} title="title" field={titleField}
                                  value={this.state.titleValue} onChange={this._handleTitleChange} autoFocus />);
       shouldAutoFocus = false;
     }
 
-    const configFieldKeys = $.map(this.state.configFields, (v,k) => {return k;}).sort(this._sortByOptionality);
+    const configFieldKeys = $.map(this.state.configFields, (v, k) => k).sort(this._sortByOptionality);
     const configFields = configFieldKeys.map((key) => {
       const configField = this._renderConfigField(this.state.configFields[key], key, shouldAutoFocus);
       if (shouldAutoFocus) {

--- a/graylog2-web-interface/src/components/configurationforms/ConfigurationForm.jsx
+++ b/graylog2-web-interface/src/components/configurationforms/ConfigurationForm.jsx
@@ -16,7 +16,10 @@ const ConfigurationForm = React.createClass({
     return this._copyStateFromProps(this.props);
   },
   componentWillReceiveProps(props) {
-    this.setState(this._copyStateFromProps(props));
+    const newState = this._copyStateFromProps(props);
+    const values = this.state ? this.state.values : {};
+    newState.values = $.extend(newState.values, values);
+    this.setState(newState);
   },
   getValue() {
     const data = {};
@@ -63,17 +66,18 @@ const ConfigurationForm = React.createClass({
     this.refs.modal.open();
   },
   _closeModal() {
+    this.setState(this.getInitialState());
     if (this.props.cancelAction) {
       this.props.cancelAction();
     }
   },
   _handleTitleChange(field, value) {
-    this.setState({titleValue: value});
+    this.setState({ titleValue: value });
   },
   _handleChange(field, value) {
     const values = this.state.values;
     values[field] = value;
-    this.setState({values: values});
+    this.setState({ values: values });
   },
   _renderConfigField(configField, key, autoFocus) {
     const value = this.state.values[key];
@@ -120,7 +124,7 @@ const ConfigurationForm = React.createClass({
     return (
       <BootstrapModalForm ref="modal"
                           title={title}
-                          onModalClose={this._closeModal}
+                          onCancel={this._closeModal}
                           onSubmitForm={this._save}
                           submitButtonText="Save">
         <fieldset>

--- a/graylog2-web-interface/src/components/configurationforms/ConfigurationForm.jsx
+++ b/graylog2-web-interface/src/components/configurationforms/ConfigurationForm.jsx
@@ -11,7 +11,7 @@ const ConfigurationForm = React.createClass({
     helpBlock: React.PropTypes.node,
     includeTitleField: React.PropTypes.bool,
     submitAction: React.PropTypes.func.isRequired,
-    title: React.PropTypes.string,
+    title: React.PropTypes.node,
     titleValue: React.PropTypes.string,
     typeName: React.PropTypes.string,
     values: React.PropTypes.object,
@@ -78,7 +78,7 @@ const ConfigurationForm = React.createClass({
     this.refs.modal.open();
   },
   _closeModal() {
-    this.setState(this.getInitialState());
+    this.setState($.extend(this.getInitialState(), { titleValue: this.props.titleValue }));
     if (this.props.cancelAction) {
       this.props.cancelAction();
     }


### PR DESCRIPTION
This PR fixes two issues with the configuration forms:

 * When they are refreshing their props (either because the form is reinitialized or because a plain re-render is triggered by a store refresh) the internal state is [reinitialized](https://github.com/Graylog2/graylog2-server/blob/b24d09d31227a7454d5eee115089bc7b878bc443/graylog2-web-interface/src/components/configurationforms/ConfigurationForm.jsx#L19) with a mixture of the default values and the passed props, but not the already existing state which included changes made by the user. The outcome is that configuration forms which are part of a DOM subtree which is refreshed by a store refresh, periodically snap back into their default values.

* The configuration form's internal state is set back to the default values when the form is closed. This prevents that when e.g. a new input form is opened and some changes are made, closing and reopening it will still show the old values.

Both of these are also proper fixes for #1870 and #1929, which were fixed by preventing their periodical refresh at that time.
