### PR TITLE
Fix memory problems with webpack-dev-server in development mode

### DIFF
--- a/graylog2-web-interface/webpack.config.js
+++ b/graylog2-web-interface/webpack.config.js
@@ -85,6 +85,13 @@ if (TARGET === 'start') {
       inline: true,
       progress: true,
     },
+    output: {
+      path: BUILD_PATH,
+      filename: '[name].js',
+      publicPath: '/',
+      hotUpdateChunkFilename: "[id].hot-update.js",
+      hotUpdateMainFilename: "hot-update.json",
+    },
     plugins: [
       new webpack.HotModuleReplacementPlugin(),
       new webpack.DefinePlugin({DEVELOPMENT: true}),


### PR DESCRIPTION
I am frequently running into webpack-dev-server memory problems in my development setup. Either my machine starts swapping or the node process dies with an out of memory error.

After some research I found a [similar problem report](https://github.com/webpack/webpack/issues/1914) in the webpack issue tracker. The problem is that our current dev setup uses hashes in filenames which means that on every change new files are built by webpack and served from memory. Since there is no mechanism to delete old ones, all files stay in memory and memory gets full eventually.

You can see this when you look at http://localhost:8080/webpack-dev-server. On every change to the javascript code, new files are appearing. In my case 104 files have been added on every change.

This change disables the usage of hashes in file names when running the webpack-dev-server in development mode. I have been running with this for one day and didn't run into any issues yet.