### PR TITLE
Remove "_ttl" in index mapping

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/indexer/IndexMapping.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/IndexMapping.java
@@ -52,9 +52,7 @@ public class IndexMapping {
         return ImmutableMap.of(
                 "properties", partFieldProperties(analyzer),
                 "dynamic_templates", partDefaultAllInDynamicTemplate(),
-                "_source", enabled(),
-                // Enable purging by TTL
-                "_ttl", enabled());
+                "_source", enabled());
     }
 
     /*


### PR DESCRIPTION
The [`_ttl` field](https://www.elastic.co/guide/en/elasticsearch/reference/current/mapping-ttl-field.html) isn't being used by Graylog, has been deprecated in Elasticsearch 2.0.0 and will be removed in Elasticsearch 5.0.0.

Refs elastic/elasticsearch#19031