### PR TITLE
Allow access to MongoDatabase in MongoConnection

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/database/MongoConnection.java
+++ b/graylog2-server/src/main/java/org/graylog2/database/MongoConnection.java
@@ -23,7 +23,19 @@ import com.mongodb.client.MongoDatabase;
 public interface MongoConnection {
     Mongo connect();
 
+    /**
+     * Get instance of the configured MongoDB database.
+     *
+     * @return The configured MongoDB database.
+     * @deprecated Use {@link #getMongoDatabase()}.
+     */
+    @Deprecated
     DB getDatabase();
 
+    /**
+     * Get instance of the configured MongoDB database.
+     *
+     * @return The configured MongoDB database.
+     */
     MongoDatabase getMongoDatabase();
 }

--- a/graylog2-server/src/main/java/org/graylog2/database/MongoConnection.java
+++ b/graylog2-server/src/main/java/org/graylog2/database/MongoConnection.java
@@ -18,10 +18,12 @@ package org.graylog2.database;
 
 import com.mongodb.DB;
 import com.mongodb.Mongo;
-import com.mongodb.MongoClient;
+import com.mongodb.client.MongoDatabase;
 
 public interface MongoConnection {
     Mongo connect();
 
     DB getDatabase();
+
+    MongoDatabase getMongoDatabase();
 }

--- a/graylog2-server/src/main/java/org/graylog2/database/MongoConnectionForTests.java
+++ b/graylog2-server/src/main/java/org/graylog2/database/MongoConnectionForTests.java
@@ -18,13 +18,16 @@ package org.graylog2.database;
 
 import com.mongodb.DB;
 import com.mongodb.Mongo;
+import com.mongodb.client.MongoDatabase;
+
+import static java.util.Objects.requireNonNull;
 
 public class MongoConnectionForTests implements MongoConnection {
     private final Mongo mongoClient;
     private final DB db;
 
     public MongoConnectionForTests(Mongo mongoClient, String dbName) {
-        this.mongoClient = mongoClient;
+        this.mongoClient = requireNonNull(mongoClient);
         this.db = mongoClient.getDB(dbName);
     }
 
@@ -36,5 +39,10 @@ public class MongoConnectionForTests implements MongoConnection {
     @Override
     public DB getDatabase() {
         return db;
+    }
+
+    @Override
+    public MongoDatabase getMongoDatabase() {
+        throw new UnsupportedOperationException("Unsupported until NoSQLUnit updates its interfaces to use MongoClient.");
     }
 }

--- a/graylog2-server/src/main/java/org/graylog2/database/MongoConnectionImpl.java
+++ b/graylog2-server/src/main/java/org/graylog2/database/MongoConnectionImpl.java
@@ -26,6 +26,7 @@ import com.mongodb.MongoClientURI;
 import com.mongodb.MongoCommandException;
 import com.mongodb.MongoException;
 import com.mongodb.WriteConcern;
+import com.mongodb.client.MongoDatabase;
 import org.graylog2.configuration.MongoDbConfiguration;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -49,6 +50,7 @@ public class MongoConnectionImpl implements MongoConnection {
 
     private MongoClient m = null;
     private DB db = null;
+    private MongoDatabase mongoDatabase = null;
 
     @Inject
     public MongoConnectionImpl(final MongoDbConfiguration configuration) {
@@ -73,7 +75,9 @@ public class MongoConnectionImpl implements MongoConnection {
 
             m = new MongoClient(mongoClientURI);
             db = m.getDB(dbName);
-            db.setWriteConcern(WriteConcern.SAFE);
+            db.setWriteConcern(WriteConcern.ACKNOWLEDGED);
+
+            mongoDatabase = m.getDatabase(dbName).withWriteConcern(WriteConcern.ACKNOWLEDGED);
         }
 
         try {
@@ -123,5 +127,10 @@ public class MongoConnectionImpl implements MongoConnection {
     @Override
     public DB getDatabase() {
         return db;
+    }
+
+    @Override
+    public MongoDatabase getMongoDatabase() {
+        return mongoDatabase;
     }
 }


### PR DESCRIPTION
This PR adds a method to `MongoConnection` which allows using the `MongoDatabase` interface to access MongoDB instead of the deprecated `DB` interface.