### PR TITLE
Move finalName element into build section

### DIFF
--- a/graylog2-server/pom.xml
+++ b/graylog2-server/pom.xml
@@ -440,6 +440,7 @@
     </dependencies>
 
     <build>
+        <finalName>graylog</finalName>
         <resources>
             <resource>
                 <directory>${webInterface.path}/build</directory>
@@ -519,7 +520,6 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-jar-plugin</artifactId>
                 <configuration>
-                    <finalName>graylog</finalName>
                     <archive>
                         <manifest>
                             <mainClass>${mainClass}</mainClass>
@@ -561,15 +561,7 @@
         <profile>
             <id>release</id>
             <build>
-                <plugins>
-                    <plugin>
-                        <groupId>org.apache.maven.plugins</groupId>
-                        <artifactId>maven-assembly-plugin</artifactId>
-                        <configuration>
-                            <finalName>graylog-${project.version}</finalName>
-                        </configuration>
-                    </plugin>
-                </plugins>
+                <finalName>graylog-${project.version}</finalName>
             </build>
         </profile>
         <profile>


### PR DESCRIPTION
The `finalName` tag was incorrectly used inside the Maven JAR plugin configuration but belongs into the regular `build` section of the POM: https://maven.apache.org/pom.html#BaseBuild_Element