### PR TITLE
Report syntax error when search query contains unescaped slash

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/rest/resources/search/SearchResource.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/resources/search/SearchResource.java
@@ -250,7 +250,8 @@ public abstract class SearchResource extends RestResource {
                     final ParseException exception = queryParser.generateParseException();
                     currentToken = exception.currentToken;
                 } catch (NullPointerException npe) {
-                    LOG.warn("Exception thrown while generating parse exception.", npe);
+                    // "Normal" exception and no need to spam the logs with it.
+                    LOG.debug("Exception thrown while generating parse exception.", npe);
                 }
 
                 if (currentToken == null) {

--- a/graylog2-server/src/main/java/org/graylog2/rest/resources/search/SearchResource.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/resources/search/SearchResource.java
@@ -244,9 +244,15 @@ public abstract class SearchResource extends RestResource {
             try {
                 queryParser.parse(query);
             } catch (ParseException parseException) {
-                // FIXME I have no idea why this is necessary but without that call currentToken will be null.
-                final ParseException exception = queryParser.generateParseException();
-                Token currentToken = exception.currentToken;
+                Token currentToken = null;
+                try {
+                    // FIXME I have no idea why this is necessary but without that call currentToken will be null.
+                    final ParseException exception = queryParser.generateParseException();
+                    currentToken = exception.currentToken;
+                } catch (NullPointerException npe) {
+                    LOG.warn("Exception thrown while generating parse exception.", npe);
+                }
+
                 if (currentToken == null) {
                     LOG.warn("No position/token available for ParseException.", parseException);
                     errorMessage = QueryParseError.create(


### PR DESCRIPTION
When a search query contains an unescaped slash, calling to `queryParser.generateParseException()` throws a `NullPointerException`, so the REST API returns a 500 error instead of 400.

Fixes #2372