### PR TITLE
Keep time zone information when creating widget

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/timeranges/TimeRangeFactory.java
+++ b/graylog2-server/src/main/java/org/graylog2/timeranges/TimeRangeFactory.java
@@ -17,7 +17,6 @@
 package org.graylog2.timeranges;
 
 import com.google.common.base.Strings;
-import org.graylog2.plugin.Tools;
 import org.graylog2.plugin.indexer.searches.timeranges.AbsoluteRange;
 import org.graylog2.plugin.indexer.searches.timeranges.InvalidRangeParametersException;
 import org.graylog2.plugin.indexer.searches.timeranges.KeywordRange;
@@ -40,8 +39,8 @@ public class TimeRangeFactory {
             case "keyword":
                 return KeywordRange.create((String) timerangeConfig.get("keyword"));
             case "absolute":
-                final String from = new DateTime(timerangeConfig.get("from"), DateTimeZone.UTC).toString(Tools.ES_DATE_FORMAT);
-                final String to = new DateTime(timerangeConfig.get("to"), DateTimeZone.UTC).toString(Tools.ES_DATE_FORMAT);
+                final String from = new DateTime(timerangeConfig.get("from"), DateTimeZone.UTC).toString();
+                final String to = new DateTime(timerangeConfig.get("to"), DateTimeZone.UTC).toString();
 
                 return AbsoluteRange.create(from, to);
             default:


### PR DESCRIPTION
Absolute time ranges in widgets were getting converted into `ES_DATE_FORMAT`, which converts the time into UTC, but loses the time zone information from the string representation. As `AbsoluteRange.create()` parses the date time and tries to keep the time zone information, that resulted in UTC times being converted into local time.

To fix the problem we avoid using `ES_DATE_FORMAT`, and use ISO8601 instead.

Fixes #2428