### PR TITLE
Make MongoDatabase available in MongoConnectionForTests

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/database/MongoConnectionForTests.java
+++ b/graylog2-server/src/main/java/org/graylog2/database/MongoConnectionForTests.java
@@ -18,6 +18,7 @@ package org.graylog2.database;
 
 import com.mongodb.DB;
 import com.mongodb.Mongo;
+import com.mongodb.MongoClient;
 import com.mongodb.client.MongoDatabase;
 
 import static java.util.Objects.requireNonNull;
@@ -25,10 +26,18 @@ import static java.util.Objects.requireNonNull;
 public class MongoConnectionForTests implements MongoConnection {
     private final Mongo mongoClient;
     private final DB db;
+    private final MongoDatabase mongoDatabase;
 
     public MongoConnectionForTests(Mongo mongoClient, String dbName) {
         this.mongoClient = requireNonNull(mongoClient);
         this.db = mongoClient.getDB(dbName);
+        this.mongoDatabase = null;
+    }
+
+    public MongoConnectionForTests(MongoClient mongoClient, String dbName) {
+        this.mongoClient = requireNonNull(mongoClient);
+        this.db = mongoClient.getDB(dbName);
+        this.mongoDatabase = mongoClient.getDatabase(dbName);
     }
 
     @Override
@@ -43,6 +52,10 @@ public class MongoConnectionForTests implements MongoConnection {
 
     @Override
     public MongoDatabase getMongoDatabase() {
-        throw new UnsupportedOperationException("Unsupported until NoSQLUnit updates its interfaces to use MongoClient.");
+        if(mongoDatabase == null) {
+            throw new IllegalStateException("MongoDatabase is unavailable.");
+        }
+
+        return mongoDatabase;
     }
 }


### PR DESCRIPTION
While NoSQLUnit currently doesn't support the "new" MongoDB Java Driver interfaces like `MongoDatabase` and `MongoClient`, other libraries like Fongo do.

This change set makes `MongoDatabase` available in `MongoConnectionForTests` if it has been constructed with the right constructor.

It's not the best solution, but it's working for now and `MongoConnectionForTests` is only used internally.

On the long run, we might want to get rid of or at least refactor the `MongoConnection` interface.