### PR TITLE
Properly handle PatternSyntaxException in RegexTesterResource

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/rest/resources/tools/RegexTesterResource.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/resources/tools/RegexTesterResource.java
@@ -19,13 +19,14 @@ package org.graylog2.rest.resources.tools;
 
 import com.codahale.metrics.annotation.Timed;
 import org.apache.shiro.authz.annotation.RequiresAuthentication;
-import org.graylog2.shared.rest.resources.RestResource;
-import org.graylog2.rest.models.tools.responses.RegexTesterResponse;
 import org.graylog2.rest.models.tools.requests.RegexTestRequest;
+import org.graylog2.rest.models.tools.responses.RegexTesterResponse;
+import org.graylog2.shared.rest.resources.RestResource;
 import org.hibernate.validator.constraints.NotEmpty;
 
 import javax.validation.Valid;
 import javax.validation.constraints.NotNull;
+import javax.ws.rs.BadRequestException;
 import javax.ws.rs.Consumes;
 import javax.ws.rs.GET;
 import javax.ws.rs.POST;
@@ -35,6 +36,7 @@ import javax.ws.rs.QueryParam;
 import javax.ws.rs.core.MediaType;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+import java.util.regex.PatternSyntaxException;
 
 @RequiresAuthentication
 @Path("/tools/regex_tester")
@@ -56,7 +58,14 @@ public class RegexTesterResource extends RestResource {
     }
 
     private RegexTesterResponse doTestRegex(String example, String regex) {
-        final Matcher matcher = Pattern.compile(regex, Pattern.DOTALL).matcher(example);
+        final Pattern pattern;
+        try {
+            pattern = Pattern.compile(regex, Pattern.DOTALL);
+        } catch (PatternSyntaxException e) {
+            throw new BadRequestException("Invalid regular expression: " + e.getMessage());
+        }
+
+        final Matcher matcher = pattern.matcher(example);
         boolean matched = matcher.find();
 
         // Get the first matched group.

--- a/graylog2-server/src/main/java/org/graylog2/rest/resources/tools/RegexTesterResource.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/resources/tools/RegexTesterResource.java
@@ -62,7 +62,7 @@ public class RegexTesterResource extends RestResource {
         try {
             pattern = Pattern.compile(regex, Pattern.DOTALL);
         } catch (PatternSyntaxException e) {
-            throw new BadRequestException("Invalid regular expression: " + e.getMessage());
+            throw new BadRequestException("Invalid regular expression: " + e.getMessage(), e);
         }
 
         final Matcher matcher = pattern.matcher(example);

--- a/graylog2-server/src/test/java/org/graylog2/rest/resources/tools/RegexTesterResourceTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/rest/resources/tools/RegexTesterResourceTest.java
@@ -1,0 +1,96 @@
+/**
+ * This file is part of Graylog.
+ *
+ * Graylog is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.graylog2.rest.resources.tools;
+
+import org.graylog2.rest.models.tools.requests.RegexTestRequest;
+import org.graylog2.rest.models.tools.responses.RegexTesterResponse;
+import org.graylog2.shared.bindings.GuiceInjectorHolder;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+import javax.ws.rs.BadRequestException;
+import java.util.Collections;
+
+import static org.assertj.core.api.Java6Assertions.assertThat;
+
+public class RegexTesterResourceTest {
+    @Rule
+    public final ExpectedException expectedException = ExpectedException.none();
+
+    private RegexTesterResource resource;
+
+    public RegexTesterResourceTest() {
+        GuiceInjectorHolder.createInjector(Collections.emptyList());
+    }
+
+    @Before
+    public void setUp() throws Exception {
+        resource = new RegexTesterResource();
+    }
+
+    @Test
+    public void regexTesterReturns400WithInvalidRegularExpression() throws Exception {
+        expectedException.expect(BadRequestException.class);
+        expectedException.expectMessage("Invalid regular expression: Dangling meta character '?' near index 0");
+        resource.regexTester("?*foo", "test");
+    }
+
+    @Test
+    public void regexTesterReturnsValidResponseIfRegExMatches() throws Exception {
+        final RegexTesterResponse response = resource.regexTester("([a-z]+)", "test");
+        assertThat(response.matched()).isTrue();
+        assertThat(response.regex()).isEqualTo("([a-z]+)");
+        assertThat(response.string()).isEqualTo("test");
+        assertThat(response.match()).isEqualTo(RegexTesterResponse.Match.create("test", 0, 4));
+    }
+
+    @Test
+    public void regexTesterReturnsValidResponseIfRegExDoesNotMatch() throws Exception {
+        final RegexTesterResponse response = resource.regexTester("([0-9]+)", "test");
+        assertThat(response.matched()).isFalse();
+        assertThat(response.regex()).isEqualTo("([0-9]+)");
+        assertThat(response.string()).isEqualTo("test");
+        assertThat(response.match()).isNull();
+    }
+
+    @Test
+    public void testRegexReturns400WithInvalidRegularExpression() throws Exception {
+        expectedException.expect(BadRequestException.class);
+        expectedException.expectMessage("Invalid regular expression: Dangling meta character '?' near index 0");
+        resource.testRegex(RegexTestRequest.create("test", "?*foo"));
+    }
+
+    @Test
+    public void testRegexReturnsValidResponseIfRegExMatches() throws Exception {
+        final RegexTesterResponse response = resource.testRegex(RegexTestRequest.create("test", "([a-z]+)"));
+        assertThat(response.matched()).isTrue();
+        assertThat(response.regex()).isEqualTo("([a-z]+)");
+        assertThat(response.string()).isEqualTo("test");
+        assertThat(response.match()).isEqualTo(RegexTesterResponse.Match.create("test", 0, 4));
+    }
+
+    @Test
+    public void testRegexReturnsValidResponseIfRegExDoesNotMatch() throws Exception {
+        final RegexTesterResponse response = resource.testRegex(RegexTestRequest.create("test", "([0-9]+)"));
+        assertThat(response.matched()).isFalse();
+        assertThat(response.regex()).isEqualTo("([0-9]+)");
+        assertThat(response.string()).isEqualTo("test");
+        assertThat(response.match()).isNull();
+    }
+}


### PR DESCRIPTION
Fixes #2471