### PR TITLE
Handle situation where more than one index has the deflector alias

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/indexer/Deflector.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/Deflector.java
@@ -19,6 +19,7 @@ package org.graylog2.indexer;
 import org.elasticsearch.cluster.health.ClusterHealthStatus;
 import org.elasticsearch.indices.InvalidAliasNameException;
 import org.graylog2.indexer.indices.Indices;
+import org.graylog2.indexer.indices.TooManyAliasesException;
 import org.graylog2.indexer.indices.jobs.SetIndexReadOnlyAndCalculateRangeJob;
 import org.graylog2.indexer.ranges.IndexRange;
 import org.graylog2.indexer.ranges.IndexRangeService;
@@ -274,7 +275,7 @@ public class Deflector { // extends Ablenkblech
     }
 
     @Nullable
-    public String getCurrentActualTargetIndex() throws Indices.ESAliasesException {
+    public String getCurrentActualTargetIndex() throws TooManyAliasesException {
         return indices.aliasTarget(getName());
     }
 

--- a/graylog2-server/src/main/java/org/graylog2/indexer/IndexHelper.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/IndexHelper.java
@@ -22,11 +22,10 @@ import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
 import org.elasticsearch.index.query.QueryBuilder;
 import org.elasticsearch.index.query.QueryBuilders;
-import org.graylog2.database.NotFoundException;
 import org.graylog2.indexer.ranges.IndexRange;
 import org.graylog2.indexer.ranges.IndexRangeService;
-import org.graylog2.plugin.indexer.searches.timeranges.TimeRange;
 import org.graylog2.plugin.Tools;
+import org.graylog2.plugin.indexer.searches.timeranges.TimeRange;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -76,7 +75,7 @@ public class IndexHelper {
         return name.substring(0, name.lastIndexOf("_"));
     }
 
-    private static List<String> prependPrefixes(String prefix, List<Integer> numbers) {
+    public static List<String> prependPrefixes(String prefix, List<Integer> numbers) {
         List<String> r = Lists.newArrayList();
 
         for (int number : numbers) {

--- a/graylog2-server/src/main/java/org/graylog2/indexer/indices/Indices.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/indices/Indices.java
@@ -247,7 +247,7 @@ public class Indices {
     }
 
     @Nullable
-    public String aliasTarget(String alias) throws ESAliasesException {
+    public String aliasTarget(String alias) throws TooManyAliasesException {
         final IndicesAdminClient indicesAdminClient = c.admin().indices();
 
         final GetAliasesRequest request = indicesAdminClient.prepareGetAliases(alias).request();
@@ -257,7 +257,7 @@ public class Indices {
         final ImmutableOpenMap<String, List<AliasMetaData>> aliases = response.getAliases();
 
         if (aliases.size() > 1) {
-            throw new ESAliasesException(Sets.newHashSet(aliases.keysIt()));
+            throw new TooManyAliasesException(Sets.newHashSet(aliases.keysIt()));
         }
         return aliases.isEmpty() ? null : aliases.keysIt().next();
     }
@@ -595,22 +595,5 @@ public class Indices {
         final DateTime max = new DateTime((long) maxAgg.getValue(), DateTimeZone.UTC);
 
         return TimestampStats.create(min, max);
-    }
-
-    public static class ESAliasesException extends Exception {
-        private final Set<String> indices;
-
-        public ESAliasesException(final Set<String> indices) {
-            this.indices = indices;
-        }
-
-        @Override
-        public String getMessage() {
-            return "More than one index in deflector alias: " + indices.toString();
-        }
-
-        public Set<String> getIndices() {
-            return indices;
-        }
     }
 }

--- a/graylog2-server/src/main/java/org/graylog2/indexer/indices/Indices.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/indices/Indices.java
@@ -501,7 +501,7 @@ public class Indices {
 
     public boolean removeAliases(String alias, Set<String> indices) {
         return c.admin().indices().prepareAliases()
-                .removeAlias(indices.toArray(new String[]{}), alias)
+                .removeAlias(indices.toArray(new String[0]), alias)
                 .execute().actionGet().isAcknowledged();
     }
 

--- a/graylog2-server/src/main/java/org/graylog2/indexer/indices/TooManyAliasesException.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/indices/TooManyAliasesException.java
@@ -22,12 +22,8 @@ public class TooManyAliasesException extends Exception {
     private final Set<String> indices;
 
     public TooManyAliasesException(final Set<String> indices) {
+        super("More than one index in deflector alias: " + indices.toString());
         this.indices = indices;
-    }
-
-    @Override
-    public String getMessage() {
-        return "More than one index in deflector alias: " + indices.toString();
     }
 
     public Set<String> getIndices() {

--- a/graylog2-server/src/main/java/org/graylog2/indexer/indices/TooManyAliasesException.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/indices/TooManyAliasesException.java
@@ -1,0 +1,36 @@
+/**
+ * This file is part of Graylog.
+ *
+ * Graylog is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.graylog2.indexer.indices;
+
+import java.util.Set;
+
+public class TooManyAliasesException extends Exception {
+    private final Set<String> indices;
+
+    public TooManyAliasesException(final Set<String> indices) {
+        this.indices = indices;
+    }
+
+    @Override
+    public String getMessage() {
+        return "More than one index in deflector alias: " + indices.toString();
+    }
+
+    public Set<String> getIndices() {
+        return indices;
+    }
+}

--- a/graylog2-server/src/main/java/org/graylog2/periodical/IndexRotationThread.java
+++ b/graylog2-server/src/main/java/org/graylog2/periodical/IndexRotationThread.java
@@ -143,7 +143,20 @@ public class IndexRotationThread extends Periodical {
             }
         } else {
             try {
-                String currentTarget = deflector.getCurrentActualTargetIndex();
+                String currentTarget;
+                try {
+                    currentTarget = deflector.getCurrentActualTargetIndex();
+                } catch (Indices.ESAliasesException e) {
+                    // If we get this exception, there are multiple indices which have the deflector alias set.
+                    // We try to cleanup the alias and try again. This should not happen, but might under certain
+                    // circumstances.
+                    deflector.cleanupAliases(e.getIndices());
+                    try {
+                        currentTarget = deflector.getCurrentActualTargetIndex();
+                    } catch (Indices.ESAliasesException e1) {
+                        throw new IllegalStateException(e1);
+                    }
+                }
                 String shouldBeTarget = deflector.getNewestTargetName();
 
                 if (!shouldBeTarget.equals(currentTarget)) {

--- a/graylog2-server/src/main/java/org/graylog2/periodical/IndexRotationThread.java
+++ b/graylog2-server/src/main/java/org/graylog2/periodical/IndexRotationThread.java
@@ -21,6 +21,7 @@ import org.graylog2.indexer.Deflector;
 import org.graylog2.indexer.NoTargetIndexException;
 import org.graylog2.indexer.cluster.Cluster;
 import org.graylog2.indexer.indices.Indices;
+import org.graylog2.indexer.indices.TooManyAliasesException;
 import org.graylog2.indexer.management.IndexManagementConfig;
 import org.graylog2.notifications.Notification;
 import org.graylog2.notifications.NotificationService;
@@ -146,14 +147,14 @@ public class IndexRotationThread extends Periodical {
                 String currentTarget;
                 try {
                     currentTarget = deflector.getCurrentActualTargetIndex();
-                } catch (Indices.ESAliasesException e) {
+                } catch (TooManyAliasesException e) {
                     // If we get this exception, there are multiple indices which have the deflector alias set.
                     // We try to cleanup the alias and try again. This should not happen, but might under certain
                     // circumstances.
                     deflector.cleanupAliases(e.getIndices());
                     try {
                         currentTarget = deflector.getCurrentActualTargetIndex();
-                    } catch (Indices.ESAliasesException e1) {
+                    } catch (TooManyAliasesException e1) {
                         throw new IllegalStateException(e1);
                     }
                 }

--- a/graylog2-server/src/main/java/org/graylog2/rest/resources/system/DeflectorResource.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/resources/system/DeflectorResource.java
@@ -24,6 +24,7 @@ import org.apache.shiro.authz.annotation.RequiresPermissions;
 import org.graylog2.auditlog.jersey.AuditLog;
 import org.graylog2.configuration.ElasticsearchConfiguration;
 import org.graylog2.indexer.Deflector;
+import org.graylog2.indexer.indices.Indices;
 import org.graylog2.plugin.cluster.ClusterConfigService;
 import org.graylog2.plugin.indexer.rotation.RotationStrategy;
 import org.graylog2.rest.models.system.deflector.responses.DeflectorSummary;
@@ -75,7 +76,7 @@ public class DeflectorResource extends RestResource {
     @ApiOperation(value = "Get current deflector status")
     @RequiresPermissions(RestPermissions.DEFLECTOR_READ)
     @Produces(MediaType.APPLICATION_JSON)
-    public DeflectorSummary deflector() throws ClassNotFoundException {
+    public DeflectorSummary deflector() throws ClassNotFoundException, Indices.ESAliasesException {
         return DeflectorSummary.create(deflector.isUp(), deflector.getCurrentActualTargetIndex());
     }
 

--- a/graylog2-server/src/main/java/org/graylog2/rest/resources/system/DeflectorResource.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/resources/system/DeflectorResource.java
@@ -24,7 +24,7 @@ import org.apache.shiro.authz.annotation.RequiresPermissions;
 import org.graylog2.auditlog.jersey.AuditLog;
 import org.graylog2.configuration.ElasticsearchConfiguration;
 import org.graylog2.indexer.Deflector;
-import org.graylog2.indexer.indices.Indices;
+import org.graylog2.indexer.indices.TooManyAliasesException;
 import org.graylog2.plugin.cluster.ClusterConfigService;
 import org.graylog2.plugin.indexer.rotation.RotationStrategy;
 import org.graylog2.rest.models.system.deflector.responses.DeflectorSummary;
@@ -76,7 +76,7 @@ public class DeflectorResource extends RestResource {
     @ApiOperation(value = "Get current deflector status")
     @RequiresPermissions(RestPermissions.DEFLECTOR_READ)
     @Produces(MediaType.APPLICATION_JSON)
-    public DeflectorSummary deflector() throws ClassNotFoundException, Indices.ESAliasesException {
+    public DeflectorSummary deflector() throws ClassNotFoundException, TooManyAliasesException {
         return DeflectorSummary.create(deflector.isUp(), deflector.getCurrentActualTargetIndex());
     }
 

--- a/graylog2-server/src/main/java/org/graylog2/rest/resources/system/indexer/IndexerOverviewResource.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/resources/system/indexer/IndexerOverviewResource.java
@@ -73,7 +73,7 @@ public class IndexerOverviewResource extends RestResource {
     @Timed
     @ApiOperation(value = "Get overview of current indexing state, including deflector config, cluster state, index ranges & message counts.")
     @Produces(MediaType.APPLICATION_JSON)
-    public IndexerOverview index() throws ClassNotFoundException {
+    public IndexerOverview index() throws ClassNotFoundException, Indices.ESAliasesException {
         final DeflectorSummary deflectorSummary = deflectorResource.deflector();
         final List<IndexRangeSummary> indexRanges = indexRangesResource.list().ranges();
         final Map<String, IndexStats> allDocCounts = indices.getAllDocCounts().entrySet().stream()

--- a/graylog2-server/src/main/java/org/graylog2/rest/resources/system/indexer/IndexerOverviewResource.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/resources/system/indexer/IndexerOverviewResource.java
@@ -23,6 +23,7 @@ import org.apache.shiro.authz.annotation.RequiresAuthentication;
 import org.elasticsearch.action.admin.indices.stats.IndexStats;
 import org.graylog2.indexer.Deflector;
 import org.graylog2.indexer.indices.Indices;
+import org.graylog2.indexer.indices.TooManyAliasesException;
 import org.graylog2.rest.models.system.deflector.responses.DeflectorSummary;
 import org.graylog2.rest.models.system.indexer.responses.IndexRangeSummary;
 import org.graylog2.rest.models.system.indexer.responses.IndexSizeSummary;
@@ -73,7 +74,7 @@ public class IndexerOverviewResource extends RestResource {
     @Timed
     @ApiOperation(value = "Get overview of current indexing state, including deflector config, cluster state, index ranges & message counts.")
     @Produces(MediaType.APPLICATION_JSON)
-    public IndexerOverview index() throws ClassNotFoundException, Indices.ESAliasesException {
+    public IndexerOverview index() throws ClassNotFoundException, TooManyAliasesException {
         final DeflectorSummary deflectorSummary = deflectorResource.deflector();
         final List<IndexRangeSummary> indexRanges = indexRangesResource.list().ranges();
         final Map<String, IndexStats> allDocCounts = indices.getAllDocCounts().entrySet().stream()

--- a/graylog2-server/src/main/java/org/graylog2/rest/resources/system/indexer/IndicesResource.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/resources/system/indexer/IndicesResource.java
@@ -219,7 +219,7 @@ public class IndicesResource extends RestResource {
         @ApiResponse(code = 403, message = "You cannot close the current deflector target index.")
     })
     @AuditLog(action = "closed", object = "index")
-    public void close(@ApiParam(name = "index") @PathParam("index") @NotNull String index) {
+    public void close(@ApiParam(name = "index") @PathParam("index") @NotNull String index) throws Indices.ESAliasesException {
         checkPermission(RestPermissions.INDICES_CHANGESTATE, index);
 
         if (!deflector.isGraylogIndex(index)) {
@@ -244,7 +244,7 @@ public class IndicesResource extends RestResource {
         @ApiResponse(code = 403, message = "You cannot delete the current deflector target index.")
     })
     @AuditLog(object = "index")
-    public void delete(@ApiParam(name = "index") @PathParam("index") @NotNull String index) {
+    public void delete(@ApiParam(name = "index") @PathParam("index") @NotNull String index) throws Indices.ESAliasesException {
         checkPermission(RestPermissions.INDICES_DELETE, index);
 
         if (!deflector.isGraylogIndex(index)) {

--- a/graylog2-server/src/main/java/org/graylog2/rest/resources/system/indexer/IndicesResource.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/resources/system/indexer/IndicesResource.java
@@ -31,6 +31,7 @@ import org.graylog2.indexer.Deflector;
 import org.graylog2.indexer.cluster.Cluster;
 import org.graylog2.indexer.indices.IndexStatistics;
 import org.graylog2.indexer.indices.Indices;
+import org.graylog2.indexer.indices.TooManyAliasesException;
 import org.graylog2.rest.models.system.indexer.requests.IndicesReadRequest;
 import org.graylog2.rest.models.system.indexer.responses.AllIndices;
 import org.graylog2.rest.models.system.indexer.responses.ClosedIndices;
@@ -219,7 +220,7 @@ public class IndicesResource extends RestResource {
         @ApiResponse(code = 403, message = "You cannot close the current deflector target index.")
     })
     @AuditLog(action = "closed", object = "index")
-    public void close(@ApiParam(name = "index") @PathParam("index") @NotNull String index) throws Indices.ESAliasesException {
+    public void close(@ApiParam(name = "index") @PathParam("index") @NotNull String index) throws TooManyAliasesException {
         checkPermission(RestPermissions.INDICES_CHANGESTATE, index);
 
         if (!deflector.isGraylogIndex(index)) {
@@ -244,7 +245,7 @@ public class IndicesResource extends RestResource {
         @ApiResponse(code = 403, message = "You cannot delete the current deflector target index.")
     })
     @AuditLog(object = "index")
-    public void delete(@ApiParam(name = "index") @PathParam("index") @NotNull String index) throws Indices.ESAliasesException {
+    public void delete(@ApiParam(name = "index") @PathParam("index") @NotNull String index) throws TooManyAliasesException {
         checkPermission(RestPermissions.INDICES_DELETE, index);
 
         if (!deflector.isGraylogIndex(index)) {

--- a/graylog2-server/src/test/java/org/graylog2/indexer/DeflectorTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/indexer/DeflectorTest.java
@@ -247,6 +247,7 @@ public class DeflectorTest {
         indexNameAliases.put("graylog_1", Collections.emptySet());
         indexNameAliases.put("graylog_2", Collections.singleton("graylog_deflector"));
         indexNameAliases.put("graylog_3", Collections.singleton("graylog_deflector"));
+        indexNameAliases.put("foobar", Collections.singleton("graylog_deflector"));
 
         when(indices.getIndexNamesAndAliases(anyString())).thenReturn(indexNameAliases);
         final Deflector deflector = new Deflector(systemJobManager,
@@ -256,8 +257,8 @@ public class DeflectorTest {
                 indexRangeService,
                 setIndexReadOnlyAndCalculateRangeJobFactory);
 
-        deflector.cleanupAliases(Sets.newHashSet("graylog_2", "graylog_3"));
+        deflector.cleanupAliases(Sets.newHashSet("graylog_2", "graylog_3", "foobar"));
 
-        verify(indices).removeAliases("graylog_deflector", Sets.newHashSet("graylog_2"));
+        verify(indices).removeAliases("graylog_deflector", Sets.newHashSet("graylog_2", "foobar"));
     }
 }


### PR DESCRIPTION
This can happen when some ES nodes are down and index rotation/retention kicks in. Once the absent nodes are back, they might bring back an already deleted index including the deflector alias.

Once we detect more than one index for the deflector alias, we throw an exception. In that case the index rotation thread tries to cleanup the aliases by removing it from all indices but the latest one.