### PR TITLE
Allow indexing when cluster state is red but write index state is healthy

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/indexer/cluster/Cluster.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/cluster/Cluster.java
@@ -200,13 +200,13 @@ public class Cluster {
      * @throws TimeoutException
      */
     public void waitForConnectedAndDeflectorHealthy(long timeout, TimeUnit unit) throws InterruptedException, TimeoutException {
-        LOG.debug("Waiting until cluster connection comes back and the write index is healthy, checking once per second.");
+        LOG.debug("Waiting until the write-active index is healthy again, checking once per second.");
 
         final CountDownLatch latch = new CountDownLatch(1);
         final ScheduledFuture<?> scheduledFuture = scheduler.scheduleAtFixedRate(() -> {
             try {
                 if (isConnected() && isDeflectorHealthy()) {
-                    LOG.debug("Cluster and write index is healthy again, unblocking waiting threads.");
+                    LOG.debug("Write-active index is healthy again, unblocking waiting threads.");
                     latch.countDown();
                 }
             } catch (Exception ignore) {
@@ -217,7 +217,7 @@ public class Cluster {
         scheduledFuture.cancel(true); // Make sure to cancel the task to avoid task leaks!
 
         if (!waitSuccess) {
-            throw new TimeoutException("Elasticsearch cluster or write index didn't get healthy within timeout");
+            throw new TimeoutException("Write-active index didn't get healthy within timeout");
         }
     }
 

--- a/graylog2-server/src/main/java/org/graylog2/initializers/BufferSynchronizerService.java
+++ b/graylog2-server/src/main/java/org/graylog2/initializers/BufferSynchronizerService.java
@@ -62,7 +62,7 @@ public class BufferSynchronizerService extends AbstractIdleService {
     @Override
     protected void shutDown() throws Exception {
         LOG.debug("Stopping BufferSynchronizerService");
-        if (cluster.isConnected() && cluster.isHealthy()) {
+        if (cluster.isConnected() && cluster.isDeflectorHealthy()) {
             final ExecutorService executorService = executorService(metricRegistry);
 
             executorService.submit(new Runnable() {

--- a/graylog2-server/src/main/java/org/graylog2/outputs/BlockingBatchedESOutput.java
+++ b/graylog2-server/src/main/java/org/graylog2/outputs/BlockingBatchedESOutput.java
@@ -107,9 +107,9 @@ public class BlockingBatchedESOutput extends ElasticSearchOutput {
     }
 
     private void flush(List<Message> messages) {
-        if (!cluster.isConnected() || !cluster.isHealthy()) {
+        if (!cluster.isConnected() || !cluster.isDeflectorHealthy()) {
             try {
-                cluster.waitForConnectedAndHealthy();
+                cluster.waitForConnectedAndDeflectorHealthy();
             } catch (TimeoutException | InterruptedException e) {
                 log.warn("Error while waiting for healthy Elasticsearch cluster. Not flushing.", e);
                 return;
@@ -136,7 +136,7 @@ public class BlockingBatchedESOutput extends ElasticSearchOutput {
     }
 
     public void forceFlushIfTimedout() {
-        if (!cluster.isConnected() || !cluster.isHealthy()) {
+        if (!cluster.isConnected() || !cluster.isDeflectorHealthy()) {
             // do not actually try to flush, because that will block until the cluster comes back.
             // simply check and return.
             log.debug("Cluster unavailable, but not blocking for periodic flush attempt. This will try again.");

--- a/graylog2-server/src/test/java/org/graylog2/outputs/BlockingBatchedESOutputTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/outputs/BlockingBatchedESOutputTest.java
@@ -66,7 +66,7 @@ public class BlockingBatchedESOutputTest {
     @Test
     public void write() throws Exception {
         when(cluster.isConnected()).thenReturn(true);
-        when(cluster.isHealthy()).thenReturn(true);
+        when(cluster.isDeflectorHealthy()).thenReturn(true);
 
         final BlockingBatchedESOutput output = new BlockingBatchedESOutput(metricRegistry, messages, cluster, config, journal);
 
@@ -82,7 +82,7 @@ public class BlockingBatchedESOutputTest {
     @Test
     public void writeDoesNotFlushIfClusterIsNotConnected() throws Exception {
         when(cluster.isConnected()).thenReturn(false);
-        when(cluster.isHealthy()).thenReturn(true);
+        when(cluster.isDeflectorHealthy()).thenReturn(true);
 
         doThrow(RuntimeException.class).when(cluster).waitForConnectedAndDeflectorHealthy();
 
@@ -103,7 +103,7 @@ public class BlockingBatchedESOutputTest {
     @Test
     public void writeDoesNotFlushIfClusterIsUnhealthy() throws Exception {
         when(cluster.isConnected()).thenReturn(true);
-        when(cluster.isHealthy()).thenReturn(false);
+        when(cluster.isDeflectorHealthy()).thenReturn(false);
 
         doThrow(RuntimeException.class).when(cluster).waitForConnectedAndDeflectorHealthy();
 
@@ -124,7 +124,7 @@ public class BlockingBatchedESOutputTest {
     @Test
     public void forceFlushIfTimedOut() throws Exception {
         when(cluster.isConnected()).thenReturn(true);
-        when(cluster.isHealthy()).thenReturn(true);
+        when(cluster.isDeflectorHealthy()).thenReturn(true);
 
         final BlockingBatchedESOutput output = new BlockingBatchedESOutput(metricRegistry, messages, cluster, config, journal);
 

--- a/graylog2-server/src/test/java/org/graylog2/outputs/BlockingBatchedESOutputTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/outputs/BlockingBatchedESOutputTest.java
@@ -84,7 +84,7 @@ public class BlockingBatchedESOutputTest {
         when(cluster.isConnected()).thenReturn(false);
         when(cluster.isHealthy()).thenReturn(true);
 
-        doThrow(RuntimeException.class).when(cluster).waitForConnectedAndHealthy();
+        doThrow(RuntimeException.class).when(cluster).waitForConnectedAndDeflectorHealthy();
 
         final BlockingBatchedESOutput output = new BlockingBatchedESOutput(metricRegistry, messages, cluster, config, journal);
 
@@ -105,7 +105,7 @@ public class BlockingBatchedESOutputTest {
         when(cluster.isConnected()).thenReturn(true);
         when(cluster.isHealthy()).thenReturn(false);
 
-        doThrow(RuntimeException.class).when(cluster).waitForConnectedAndHealthy();
+        doThrow(RuntimeException.class).when(cluster).waitForConnectedAndDeflectorHealthy();
 
         final BlockingBatchedESOutput output = new BlockingBatchedESOutput(metricRegistry, messages, cluster, config, journal);
 


### PR DESCRIPTION
The cluster state can turn red even though the current write index is green. This might happen when running rotation/retention during an ES maintenance window where not all nodes are present.

For index related tasks we are now checking the state of the current write index (deflector) instead of the state for all Graylog managed indices.

The logs and UI are still showing the red cluster state to make sure the admin will be notified.

Refs #2429
Fixes #2371