### PR TITLE
Make exceptions more useful by providing messages and context

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/bundles/BundleService.java
+++ b/graylog2-server/src/main/java/org/graylog2/bundles/BundleService.java
@@ -65,7 +65,7 @@ public class BundleService {
         final ConfigurationBundle bundle = dbCollection.findOneById(new ObjectId(bundleId));
 
         if (bundle == null) {
-            throw new NotFoundException();
+            throw new NotFoundException("Couldn't find content pack with ID " + bundleId);
         }
 
         return bundle;

--- a/graylog2-server/src/main/java/org/graylog2/dashboards/DashboardServiceImpl.java
+++ b/graylog2-server/src/main/java/org/graylog2/dashboards/DashboardServiceImpl.java
@@ -88,7 +88,7 @@ public class DashboardServiceImpl extends PersistedServiceImpl implements Dashbo
         final BasicDBObject o = (BasicDBObject) get(DashboardImpl.class, id);
 
         if (o == null) {
-            throw new NotFoundException();
+            throw new NotFoundException("Couldn't find dashboard with ID " + id);
         }
 
         final Dashboard dashboard = this.create((ObjectId) o.get("_id"), o.toMap());

--- a/graylog2-server/src/main/java/org/graylog2/filters/FilterServiceImpl.java
+++ b/graylog2-server/src/main/java/org/graylog2/filters/FilterServiceImpl.java
@@ -56,7 +56,7 @@ public class FilterServiceImpl implements FilterService {
         final FilterDescription filter = dbCollection.findOneById(new ObjectId(filterId));
 
         if (filter == null) {
-            throw new NotFoundException();
+            throw new NotFoundException("Couldn't find filter with ID " + filterId);
         }
         return filter;
     }

--- a/graylog2-server/src/main/java/org/graylog2/grok/GrokPatternServiceImpl.java
+++ b/graylog2-server/src/main/java/org/graylog2/grok/GrokPatternServiceImpl.java
@@ -60,7 +60,7 @@ public class GrokPatternServiceImpl implements GrokPatternService {
     public GrokPattern load(String patternId) throws NotFoundException {
         final GrokPattern pattern = dbCollection.findOneById(new ObjectId(patternId));
         if (pattern == null) {
-            throw new NotFoundException();
+            throw new NotFoundException("Couldn't find Grok pattern with ID " + patternId);
         }
         return pattern;
     }

--- a/graylog2-server/src/main/java/org/graylog2/indexer/IndexNotFoundException.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/IndexNotFoundException.java
@@ -16,16 +16,12 @@
  */
 package org.graylog2.indexer;
 
-/**
- * @author Lennart Koopmann <lennart@socketfeed.com>
- */
 public class IndexNotFoundException extends Exception {
-    
-    /**
-     * Re-generate if you modify the class structure.
-     */
-	private static final long serialVersionUID = 1332856399663575545L;
+    public IndexNotFoundException() {
+        super();
+    }
 
-	public IndexNotFoundException() {}
-    
+    public IndexNotFoundException(String message) {
+        super(message);
+    }
 }

--- a/graylog2-server/src/main/java/org/graylog2/indexer/indices/Indices.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/indices/Indices.java
@@ -173,7 +173,7 @@ public class Indices {
     public long numberOfMessages(String indexName) throws IndexNotFoundException {
         final IndexStats index = indexStats(indexName);
         if (index == null) {
-            throw new IndexNotFoundException();
+            throw new IndexNotFoundException("Couldn't find index " + indexName);
         }
 
         return index.getPrimaries().getDocs().getCount();

--- a/graylog2-server/src/main/java/org/graylog2/inputs/InputServiceImpl.java
+++ b/graylog2-server/src/main/java/org/graylog2/inputs/InputServiceImpl.java
@@ -175,7 +175,7 @@ public class InputServiceImpl extends PersistedServiceImpl implements InputServi
 
         final DBObject o = findOne(InputImpl.class, new BasicDBObject("$and", query));
         if (o == null) {
-            throw new NotFoundException();
+            throw new NotFoundException("Couldn't find input " + id + " on Graylog node " + nodeId);
         } else {
             return new InputImpl((ObjectId) o.get("_id"), o.toMap());
         }

--- a/graylog2-server/src/main/java/org/graylog2/plugin/indexer/searches/timeranges/AbsoluteRange.java
+++ b/graylog2-server/src/main/java/org/graylog2/plugin/indexer/searches/timeranges/AbsoluteRange.java
@@ -75,9 +75,9 @@ public abstract class AbsoluteRange extends TimeRange {
     @Override
     public Map<String, Object> getPersistedConfig() {
         return ImmutableMap.<String, Object>of(
-                "type", ABSOLUTE,
-                "from", getFrom(),
-                "to", getTo());
+            "type", ABSOLUTE,
+            "from", getFrom(),
+            "to", getTo());
     }
 
     @AutoValue.Builder
@@ -95,7 +95,7 @@ public abstract class AbsoluteRange extends TimeRange {
             try {
                 return to(parseDateTime(to));
             } catch (IllegalArgumentException e) {
-                throw new InvalidRangeParametersException();
+                throw new InvalidRangeParametersException("Invalid end of range: " + to, e);
             }
         }
 
@@ -104,7 +104,7 @@ public abstract class AbsoluteRange extends TimeRange {
             try {
                 return from(parseDateTime(from));
             } catch (IllegalArgumentException e) {
-                throw new InvalidRangeParametersException();
+                throw new InvalidRangeParametersException("Invalid start of range: " + from, e);
             }
         }
 

--- a/graylog2-server/src/main/java/org/graylog2/plugin/indexer/searches/timeranges/InvalidRangeParametersException.java
+++ b/graylog2-server/src/main/java/org/graylog2/plugin/indexer/searches/timeranges/InvalidRangeParametersException.java
@@ -16,11 +16,7 @@
  */
 package org.graylog2.plugin.indexer.searches.timeranges;
 
-/**
- * @author Lennart Koopmann <lennart@torch.sh>
- */
 public class InvalidRangeParametersException extends Exception {
-
     public InvalidRangeParametersException() {
         super();
     }
@@ -29,5 +25,8 @@ public class InvalidRangeParametersException extends Exception {
         super(msg);
     }
 
+    public InvalidRangeParametersException(String message, Throwable cause) {
+        super(message, cause);
+    }
 }
 

--- a/graylog2-server/src/main/java/org/graylog2/plugin/indexer/searches/timeranges/RelativeRange.java
+++ b/graylog2-server/src/main/java/org/graylog2/plugin/indexer/searches/timeranges/RelativeRange.java
@@ -93,7 +93,7 @@ public abstract class RelativeRange extends TimeRange {
         // TODO replace with custom build()
         public Builder checkRange(int range) throws InvalidRangeParametersException {
             if (range < 0) {
-                throw new InvalidRangeParametersException();
+                throw new InvalidRangeParametersException("Range must not be negative");
             }
             return range(range);
         }

--- a/graylog2-server/src/main/java/org/graylog2/plugin/utilities/date/NaturalDateParser.java
+++ b/graylog2-server/src/main/java/org/graylog2/plugin/utilities/date/NaturalDateParser.java
@@ -51,7 +51,7 @@ public class NaturalDateParser {
                 to = dates.get(1);
             }
         } else {
-            throw new DateNotParsableException();
+            throw new DateNotParsableException("Unparsable date: " + string);
         }
 
         return new Result(from, to);
@@ -98,6 +98,9 @@ public class NaturalDateParser {
     }
 
     public static class DateNotParsableException extends Exception {
+        public DateNotParsableException(String message) {
+            super(message);
+        }
     }
 
 }

--- a/graylog2-server/src/main/java/org/graylog2/rest/resources/alarmcallbacks/AlarmCallbackResource.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/resources/alarmcallbacks/AlarmCallbackResource.java
@@ -128,7 +128,7 @@ public class AlarmCallbackResource extends RestResource {
 
         final AlarmCallbackConfiguration result = alarmCallbackConfigurationService.load(alarmCallbackId);
         if (result == null || !result.getStreamId().equals(stream.getId())) {
-            throw new javax.ws.rs.NotFoundException();
+            throw new javax.ws.rs.NotFoundException("Couldn't find alarm callback " + alarmCallbackId + " in for steam " + streamid);
         }
 
         return AlarmCallbackSummary.create(result.getId(), result.getStreamId(), result.getType(), result.getConfiguration(), result.getCreatedAt(), result.getCreatorUserId());
@@ -206,12 +206,13 @@ public class AlarmCallbackResource extends RestResource {
 
         final AlarmCallbackConfiguration result = alarmCallbackConfigurationService.load(alarmCallbackId);
         if (result == null || !result.getStreamId().equals(stream.getId())) {
-            throw new javax.ws.rs.NotFoundException();
+            throw new javax.ws.rs.NotFoundException("Couldn't find alarm callback " + alarmCallbackId + " in for steam " + streamid);
         }
 
         if (alarmCallbackConfigurationService.destroy(result) == 0) {
-            LOG.error("Couldn't remove alarm callback with id {}", result.getId());
-            throw new InternalServerErrorException();
+            final String msg = "Couldn't remove alarm callback with ID " + result.getId();
+            LOG.error(msg);
+            throw new InternalServerErrorException(msg);
         }
     }
 

--- a/graylog2-server/src/main/java/org/graylog2/rest/resources/dashboards/DashboardWidgetsResource.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/resources/dashboards/DashboardWidgetsResource.java
@@ -202,8 +202,9 @@ public class DashboardWidgetsResource extends RestResource {
 
         final DashboardWidget widget = dashboard.getWidget(widgetId);
         if (widget == null) {
-            LOG.error("Widget not found.");
-            throw new javax.ws.rs.NotFoundException();
+            final String msg = "Widget " + widgetId + " on dashboard " + dashboardId + " not found.";
+            LOG.error(msg);
+            throw new javax.ws.rs.NotFoundException(msg);
         }
 
         return widgetResultCache.getComputationResultForDashboardWidget(widget).asMap();
@@ -231,8 +232,9 @@ public class DashboardWidgetsResource extends RestResource {
 
         final DashboardWidget widget = dashboard.getWidget(widgetId);
         if (widget == null) {
-            LOG.error("Widget not found.");
-            throw new javax.ws.rs.NotFoundException();
+            final String msg = "Widget " + widgetId + " on dashboard " + dashboardId + " not found.";
+            LOG.error(msg);
+            throw new javax.ws.rs.NotFoundException(msg);
         }
 
         try {
@@ -279,8 +281,9 @@ public class DashboardWidgetsResource extends RestResource {
 
         final DashboardWidget widget = dashboard.getWidget(widgetId);
         if (widget == null) {
-            LOG.error("Widget not found.");
-            throw new javax.ws.rs.NotFoundException();
+            final String msg = "Widget " + widgetId + " on dashboard " + dashboardId + " not found.";
+            LOG.error(msg);
+            throw new javax.ws.rs.NotFoundException(msg);
         }
 
         dashboardService.updateWidgetDescription(dashboard, widget, uwr.description());
@@ -311,8 +314,9 @@ public class DashboardWidgetsResource extends RestResource {
 
         final DashboardWidget widget = dashboard.getWidget(widgetId);
         if (widget == null) {
-            LOG.error("Widget not found.");
-            throw new javax.ws.rs.NotFoundException();
+            final String msg = "Widget " + widgetId + " on dashboard " + dashboardId + " not found.";
+            LOG.error(msg);
+            throw new javax.ws.rs.NotFoundException(msg);
         }
 
         dashboardService.updateWidgetCacheTime(dashboard, widget, uwr.cacheTime());

--- a/graylog2-server/src/main/java/org/graylog2/rest/resources/filters/BlacklistSourceResource.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/resources/filters/BlacklistSourceResource.java
@@ -152,7 +152,7 @@ public class BlacklistSourceResource extends RestResource {
     public void delete(@ApiParam(name = "filterId", required = true)
                        @PathParam("filterId") String filterId) {
         if (filterService.delete(filterId) == 0) {
-            throw new NotFoundException();
+            throw new NotFoundException("Couldn't find filter with ID "+ filterId);
         }
     }
 }

--- a/graylog2-server/src/main/java/org/graylog2/rest/resources/roles/RolesResource.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/resources/roles/RolesResource.java
@@ -170,7 +170,7 @@ public class RolesResource extends RestResource {
         userService.dissociateAllUsersFromRole(role);
 
         if (roleService.delete(name) == 0) {
-            throw new NotFoundException();
+            throw new NotFoundException("Couldn't find role " + name);
         }
     }
 

--- a/graylog2-server/src/main/java/org/graylog2/rest/resources/search/SearchResource.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/resources/search/SearchResource.java
@@ -155,8 +155,9 @@ public abstract class SearchResource extends RestResource {
                 timeRange,
                 includeCardinality);
         } catch (Searches.FieldTypeException e) {
-            LOG.error("Field histogram query failed. Make sure that field [{}] is a numeric type.", field);
-            throw new BadRequestException();
+            final String msg = "Field histogram query failed. Make sure that field [" + field + "] is a numeric type.";
+            LOG.error(msg);
+            throw new BadRequestException(msg, e);
         }
     }
 
@@ -328,8 +329,9 @@ public abstract class SearchResource extends RestResource {
 
             for (String streamId : streams) {
                 if (!isPermitted(RestPermissions.STREAMS_READ, streamId)) {
-                    LOG.warn("Not allowed to search with filter: [" + filter + "]. (Forbidden stream: " + streamId + ")");
-                    throw new ForbiddenException();
+                    final String msg = "Not allowed to search with filter: [" + filter + "]. (Forbidden stream: " + streamId + ")";
+                    LOG.warn(msg);
+                    throw new ForbiddenException(msg);
                 }
             }
         }

--- a/graylog2-server/src/main/java/org/graylog2/rest/resources/streams/alerts/StreamAlertReceiverResource.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/resources/streams/alerts/StreamAlertReceiverResource.java
@@ -104,8 +104,9 @@ public class StreamAlertReceiverResource extends RestResource {
         checkArgument(!Strings.isNullOrEmpty(entity));
 
         if (type == null || (!type.equals("users") && !type.equals("emails"))) {
-            LOG.warn("No such type: [{}]", type);
-            throw new BadRequestException();
+            final String msg = "No such type: [" + type + "]";
+            LOG.warn(msg);
+            throw new BadRequestException(msg);
         }
 
         final Stream stream = streamService.load(streamid);
@@ -140,9 +141,10 @@ public class StreamAlertReceiverResource extends RestResource {
             @ApiParam(name = "type", value = "Type: users or emails", required = true) @QueryParam("type") String type) throws NotFoundException {
         checkPermission(RestPermissions.STREAMS_EDIT, streamid);
 
-        if (!type.equals("users") && !type.equals("emails")) {
-            LOG.warn("No such type: [{}]", type);
-            throw new BadRequestException();
+        if (!"users".equals(type) && !"emails".equals(type)) {
+            final String msg = "No such type: [" + type + "]";
+            LOG.warn(msg);
+            throw new BadRequestException(msg);
         }
 
         final Stream stream = streamService.load(streamid);

--- a/graylog2-server/src/main/java/org/graylog2/rest/resources/streams/rules/StreamRuleResource.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/resources/streams/rules/StreamRuleResource.java
@@ -119,7 +119,7 @@ public class StreamRuleResource extends RestResource {
         streamRule = streamRuleService.load(streamRuleId);
 
         if (!streamRule.getStreamId().equals(streamid)) {
-            throw new NotFoundException();
+            throw new NotFoundException("Couldn'T update stream rule " + streamRuleId + "in stream " + streamid);
         }
 
         final StreamRuleType streamRuleType = StreamRuleType.fromInteger(cr.type());
@@ -197,7 +197,7 @@ public class StreamRuleResource extends RestResource {
         if (streamRule.getStreamId().equals(streamid)) {
             streamRuleService.destroy(streamRule);
         } else {
-            throw new NotFoundException();
+            throw new NotFoundException("Couldn't delete stream rule " + streamRuleId + "in stream " + streamid);
         }
     }
 

--- a/graylog2-server/src/main/java/org/graylog2/rest/resources/streams/rules/StreamRuleResource.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/resources/streams/rules/StreamRuleResource.java
@@ -119,7 +119,7 @@ public class StreamRuleResource extends RestResource {
         streamRule = streamRuleService.load(streamRuleId);
 
         if (!streamRule.getStreamId().equals(streamid)) {
-            throw new NotFoundException("Couldn'T update stream rule " + streamRuleId + "in stream " + streamid);
+            throw new NotFoundException("Couldn't update stream rule " + streamRuleId + "in stream " + streamid);
         }
 
         final StreamRuleType streamRuleType = StreamRuleType.fromInteger(cr.type());

--- a/graylog2-server/src/main/java/org/graylog2/rest/resources/system/GrokResource.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/resources/system/GrokResource.java
@@ -164,7 +164,7 @@ public class GrokResource extends RestResource {
         clusterBus.post(GrokPatternsChangedEvent.create(Sets.newHashSet(pattern.name), Collections.emptySet()));
 
         if (grokPatternService.delete(patternId) == 0) {
-            throw new javax.ws.rs.NotFoundException();
+            throw new javax.ws.rs.NotFoundException("Couldn't remove Grok pattern with ID " + patternId);
         }
     }
 }

--- a/graylog2-server/src/main/java/org/graylog2/rest/resources/system/IndexRangesResource.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/resources/system/IndexRangesResource.java
@@ -178,8 +178,9 @@ public class IndexRangesResource extends RestResource {
         try {
             this.systemJobManager.submit(rebuildJob);
         } catch (SystemJobConcurrencyException e) {
-            LOG.error("Concurrency level of this job reached: " + e.getMessage());
-            throw new ForbiddenException();
+            final String msg = "Concurrency level of this job reached: " + e.getMessage();
+            LOG.error(msg);
+            throw new ForbiddenException(msg, e);
         }
 
         return Response.accepted().build();

--- a/graylog2-server/src/main/java/org/graylog2/rest/resources/system/indexer/IndicesResource.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/resources/system/indexer/IndicesResource.java
@@ -204,8 +204,9 @@ public class IndicesResource extends RestResource {
         checkPermission(RestPermissions.INDICES_CHANGESTATE, index);
 
         if (!deflector.isGraylogIndex(index)) {
-            LOG.info("Index [{}] doesn't look like an index managed by Graylog.", index);
-            throw new NotFoundException();
+            final String msg = "Index [" + index + "] doesn't look like an index managed by Graylog.";
+            LOG.info(msg);
+            throw new NotFoundException(msg);
         }
 
         indices.reopenIndex(index);
@@ -224,8 +225,9 @@ public class IndicesResource extends RestResource {
         checkPermission(RestPermissions.INDICES_CHANGESTATE, index);
 
         if (!deflector.isGraylogIndex(index)) {
-            LOG.info("Index [{}] doesn't look like an index managed by Graylog.", index);
-            throw new NotFoundException();
+            final String msg = "Index [" + index + "] doesn't look like an index managed by Graylog.";
+            LOG.info(msg);
+            throw new NotFoundException(msg);
         }
 
         if (index.equals(deflector.getCurrentActualTargetIndex())) {

--- a/graylog2-server/src/main/java/org/graylog2/rest/resources/system/inputs/ExtractorsResource.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/resources/system/inputs/ExtractorsResource.java
@@ -122,8 +122,9 @@ public class ExtractorsResource extends RestResource {
 
         final MessageInput input = inputs.getRunningInput(inputId);
         if (input == null) {
-            LOG.error("Input <{}> not found.", inputId);
-            throw new javax.ws.rs.NotFoundException();
+            final String msg = "Input <" + inputId + "> not found.";
+            LOG.error(msg);
+            throw new javax.ws.rs.NotFoundException(msg);
         }
 
         final Input mongoInput = inputService.find(input.getPersistId());
@@ -133,8 +134,9 @@ public class ExtractorsResource extends RestResource {
         try {
             inputService.addExtractor(mongoInput, extractor);
         } catch (ValidationException e) {
-            LOG.error("Extractor persist validation failed.", e);
-            throw new BadRequestException(e);
+            final String msg = "Extractor persist validation failed.";
+            LOG.error(msg, e);
+            throw new BadRequestException(msg, e);
         }
 
         final String msg = "Added extractor <" + id + "> of type [" + cer.extractorType() + "] to input <" + inputId + ">.";
@@ -209,8 +211,9 @@ public class ExtractorsResource extends RestResource {
 
         final Input input = inputService.find(inputId);
         if (input == null) {
-            LOG.error("Input <{}> not found.", inputId);
-            throw new javax.ws.rs.NotFoundException();
+            final String msg = "Input <" + inputId + "> not found.";
+            LOG.error(msg);
+            throw new javax.ws.rs.NotFoundException(msg);
         }
 
         final List<ExtractorSummary> extractors = Lists.newArrayList();

--- a/graylog2-server/src/main/java/org/graylog2/rest/resources/system/inputs/StaticFieldsResource.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/resources/system/inputs/StaticFieldsResource.java
@@ -88,8 +88,9 @@ public class StaticFieldsResource extends RestResource {
         final MessageInput input = inputs.getRunningInput(inputId);
 
         if (input == null) {
-            LOG.error("Input <{}> not found.", inputId);
-            throw new javax.ws.rs.NotFoundException();
+            final String msg = "Input <" + inputId + "> not found.";
+            LOG.error(msg);
+            throw new javax.ws.rs.NotFoundException(msg);
         }
 
         // Check if key is a valid message key.
@@ -141,13 +142,15 @@ public class StaticFieldsResource extends RestResource {
         MessageInput input = inputs.getRunningInput(inputId);
 
         if (input == null) {
-            LOG.error("Input <{}> not found.", inputId);
-            throw new javax.ws.rs.NotFoundException();
+            final String msg = "Input <" + inputId + "> not found.";
+            LOG.error(msg);
+            throw new javax.ws.rs.NotFoundException(msg);
         }
 
         if (!input.getStaticFields().containsKey(key)) {
-            LOG.error("No such static field [{}] on input <{}>.", key, inputId);
-            throw new javax.ws.rs.NotFoundException();
+            final String msg = "No such static field [" + key + "] on input <" + inputId + ">.";
+            LOG.error(msg);
+            throw new javax.ws.rs.NotFoundException(msg);
         }
 
         input.getStaticFields().remove(key);

--- a/graylog2-server/src/main/java/org/graylog2/rest/resources/system/logs/LoggersResource.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/resources/system/logs/LoggersResource.java
@@ -174,8 +174,9 @@ public class LoggersResource extends RestResource {
         @ApiParam(name = "subsystem", required = true) @PathParam("subsystem") @NotEmpty String subsystemTitle,
         @ApiParam(name = "level", required = true) @PathParam("level") @NotEmpty String level) {
         if (!SUBSYSTEMS.containsKey(subsystemTitle)) {
-            LOG.warn("No such subsystem: [{}]. Returning 404.", subsystemTitle);
-            throw new NotFoundException();
+            final String msg = "No such logging subsystem: [" + subsystemTitle + "]";
+            LOG.warn(msg);
+            throw new NotFoundException(msg);
         }
         checkPermission(RestPermissions.LOGGERS_EDITSUBSYSTEM, subsystemTitle);
 

--- a/graylog2-server/src/main/java/org/graylog2/rest/resources/users/UsersResource.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/resources/users/UsersResource.java
@@ -117,7 +117,7 @@ public class UsersResource extends RestResource {
                            @PathParam("username") String username) {
         final org.graylog2.plugin.database.users.User user = userService.load(username);
         if (user == null) {
-            throw new NotFoundException();
+            throw new NotFoundException("Couldn't find user " + username);
         }
         // if the requested username does not match the authenticated user, then we don't return permission information
         final boolean allowedToSeePermissions = isPermitted(RestPermissions.USERS_PERMISSIONSEDIT, username);
@@ -217,7 +217,7 @@ public class UsersResource extends RestResource {
 
         final org.graylog2.plugin.database.users.User user = userService.load(username);
         if (user == null) {
-            throw new NotFoundException();
+            throw new NotFoundException("Couldn't find user " + username);
         }
 
         if (user.isReadOnly()) {
@@ -278,7 +278,7 @@ public class UsersResource extends RestResource {
     public void deleteUser(@ApiParam(name = "username", value = "The name of the user to delete.", required = true)
                            @PathParam("username") String username) {
         if (userService.delete(username) == 0) {
-            throw new NotFoundException();
+            throw new NotFoundException("Couldn't find user " + username);
         }
     }
 
@@ -296,7 +296,7 @@ public class UsersResource extends RestResource {
                                 @Valid @NotNull PermissionEditRequest permissionRequest) throws ValidationException {
         final org.graylog2.plugin.database.users.User user = userService.load(username);
         if (user == null) {
-            throw new NotFoundException();
+            throw new NotFoundException("Couldn't find user " + username);
         }
 
         user.setPermissions(getEffectiveUserPermissions(user, permissionRequest.permissions()));
@@ -318,7 +318,7 @@ public class UsersResource extends RestResource {
         checkPermission(RestPermissions.USERS_EDIT, username);
 
         if (user == null) {
-            throw new NotFoundException();
+            throw new NotFoundException("Couldn't find user " + username);
         }
 
         user.setPreferences(preferencesRequest.preferences());
@@ -337,7 +337,7 @@ public class UsersResource extends RestResource {
                                   @PathParam("username") String username) throws ValidationException {
         final org.graylog2.plugin.database.users.User user = userService.load(username);
         if (user == null) {
-            throw new NotFoundException();
+            throw new NotFoundException("Couldn't find user " + username);
         }
         user.setPermissions(Collections.<String>emptyList());
         userService.save(user);
@@ -361,11 +361,11 @@ public class UsersResource extends RestResource {
 
         final org.graylog2.plugin.database.users.User user = userService.load(username);
         if (user == null) {
-            throw new NotFoundException();
+            throw new NotFoundException("Couldn't find user " + username);
         }
 
         if (!getSubject().isPermitted(RestPermissions.USERS_PASSWORDCHANGE + ":" + user.getName())) {
-            throw new ForbiddenException();
+            throw new ForbiddenException("Not allowed to change password for user " + username);
         }
         if (user.isExternalUser()) {
             final String msg = "Cannot change password for LDAP user.";
@@ -447,7 +447,7 @@ public class UsersResource extends RestResource {
         if (accessToken != null) {
             accessTokenService.destroy(accessToken);
         } else {
-            throw new NotFoundException();
+            throw new NotFoundException("Couldn't find access token for user " + username);
         }
     }
 

--- a/graylog2-server/src/main/java/org/graylog2/savedsearches/SavedSearchServiceImpl.java
+++ b/graylog2-server/src/main/java/org/graylog2/savedsearches/SavedSearchServiceImpl.java
@@ -57,7 +57,7 @@ public class SavedSearchServiceImpl extends PersistedServiceImpl implements Save
         BasicDBObject o = (BasicDBObject) get(SavedSearchImpl.class, id);
 
         if (o == null) {
-            throw new NotFoundException();
+            throw new NotFoundException("Couldn't find saved search with ID " + id);
         }
 
         return new SavedSearchImpl((ObjectId) o.get("_id"), o.toMap());

--- a/graylog2-server/src/main/java/org/graylog2/shared/UI.java
+++ b/graylog2-server/src/main/java/org/graylog2/shared/UI.java
@@ -28,12 +28,12 @@ public class UI {
     private static final Logger LOG = LoggerFactory.getLogger(UI.class);
 
     public static void exitHardWithWall(String msg) {
-        exitHardWithWall(msg, new String[]{});
+        exitHardWithWall(msg, new String[0]);
     }
 
     public static void exitHardWithWall(String msg, String... docLinks) {
         LOG.error(wallString(msg, docLinks));
-        throw new IllegalStateException();
+        throw new IllegalStateException(msg);
     }
 
     public static String wallString(String msg, String... docLinks) {

--- a/graylog2-server/src/main/java/org/graylog2/shared/rest/resources/RestResource.java
+++ b/graylog2-server/src/main/java/org/graylog2/shared/rest/resources/RestResource.java
@@ -84,8 +84,9 @@ public abstract class RestResource {
 
         final Principal p = securityContext.getUserPrincipal();
         if (!(p instanceof ShiroPrincipal)) {
-            LOG.error("Unknown SecurityContext class {}, cannot continue.", securityContext);
-            throw new IllegalStateException();
+            final String msg = "Unknown SecurityContext class " + securityContext + ", cannot continue.";
+            LOG.error(msg);
+            throw new IllegalStateException(msg);
         }
 
         final ShiroPrincipal principal = (ShiroPrincipal) p;

--- a/graylog2-server/src/main/java/org/graylog2/shared/rest/resources/documentation/DocumentationBrowserResource.java
+++ b/graylog2-server/src/main/java/org/graylog2/shared/rest/resources/documentation/DocumentationBrowserResource.java
@@ -53,7 +53,7 @@ public class DocumentationBrowserResource extends RestResource {
     public Response asset(@PathParam("route") String route) {
         // Directory traversal should not be possible but just to make sure..
         if (route.contains("..")) {
-            throw new BadRequestException();
+            throw new BadRequestException("Not allowed to access parent directory");
         }
 
         if (route.trim().equals("")) {
@@ -69,10 +69,10 @@ public class DocumentationBrowserResource extends RestResource {
                         .header("Content-Length", resourceBytes.length)
                         .build();
             } catch (IOException e) {
-                throw new NotFoundException(e);
+                throw new NotFoundException("Couldn't load " + resource, e);
             }
         } else {
-            throw new NotFoundException();
+            throw new NotFoundException("Couldn't find " + route);
         }
     }
 }

--- a/graylog2-server/src/main/java/org/graylog2/streams/StreamRuleServiceImpl.java
+++ b/graylog2-server/src/main/java/org/graylog2/streams/StreamRuleServiceImpl.java
@@ -45,7 +45,7 @@ public class StreamRuleServiceImpl extends PersistedServiceImpl implements Strea
         BasicDBObject o = (BasicDBObject) get(StreamRuleImpl.class, new ObjectId(id));
 
         if (o == null) {
-            throw new NotFoundException();
+            throw new NotFoundException("Couldn't find stream rule with ID" + id);
         }
 
         return new StreamRuleImpl((ObjectId) o.get("_id"), o.toMap());

--- a/graylog2-server/src/main/java/org/graylog2/users/RoleServiceImpl.java
+++ b/graylog2-server/src/main/java/org/graylog2/users/RoleServiceImpl.java
@@ -95,8 +95,9 @@ public class RoleServiceImpl implements RoleService {
         try {
             previousRole = load(roleName);
             if (!previousRole.isReadOnly() || !expectedPermissions.equals(previousRole.getPermissions()))  {
-                log.error("Invalid role '{}', fixing it.", roleName);
-                throw new IllegalArgumentException(); // jump to fix code
+                final String msg = "Invalid role '" + roleName + "', fixing it.";
+                log.error(msg);
+                throw new IllegalArgumentException(msg); // jump to fix code
             }
         } catch (NotFoundException | IllegalArgumentException | NoSuchElementException ignored) {
             log.info("{} role is missing or invalid, re-adding it as a built-in role.", roleName);

--- a/graylog2-server/src/main/java/org/graylog2/web/resources/WebInterfaceAssetsResource.java
+++ b/graylog2-server/src/main/java/org/graylog2/web/resources/WebInterfaceAssetsResource.java
@@ -104,14 +104,14 @@ public class WebInterfaceAssetsResource {
                         @PathParam("filename") String filename) {
         final Optional<Plugin> plugin = getPluginForName(pluginName);
         if (!plugin.isPresent()) {
-            throw new NotFoundException();
+            throw new NotFoundException("Couldn't find plugin " + pluginName);
         }
 
         try {
             final URL resourceUrl = getResourceUri(true, filename, plugin.get().metadata().getClass());
             return getResponse(request, filename, resourceUrl, true);
         } catch (URISyntaxException | IOException e) {
-            throw new NotFoundException();
+            throw new NotFoundException("Couldn't find " + filename + " in plugin " + pluginName, e);
         }
     }
 


### PR DESCRIPTION
Some exceptions were missing a proper message and lost context (e. g. by not using the original exception for its stack trace).

Especially with exceptions thrown in JAX-RS resource classes, this leaves users with an error response without mentioning the reason for the failing request.