### PR TITLE
Add whitespace replacement and prefix options to JSON extractor

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/inputs/extractors/JsonExtractor.java
+++ b/graylog2-server/src/main/java/org/graylog2/inputs/extractors/JsonExtractor.java
@@ -47,6 +47,8 @@ public class JsonExtractor extends Extractor {
     private static final String CK_LIST_SEPARATOR = "list_separator";
     private static final String CK_KEY_SEPARATOR = "key_separator";
     private static final String CK_KV_SEPARATOR = "kv_separator";
+    private static final String CK_REPLACE_KEY_WHITESPACE = "replace_key_whitespace";
+    private static final String CK_KEY_WHITESPACE_REPLACEMENT = "key_whitespace_replacement";
     private static final RemoveNullPredicate REMOVE_NULL_PREDICATE = new RemoveNullPredicate();
 
     private final ObjectMapper mapper = new ObjectMapper();
@@ -54,6 +56,8 @@ public class JsonExtractor extends Extractor {
     private final String listSeparator;
     private final String keySeparator;
     private final String kvSeparator;
+    private final boolean replaceKeyWhitespace;
+    private final String keyWhitespaceReplacement;
 
     public JsonExtractor(final MetricRegistry metricRegistry,
                          final String id,
@@ -77,6 +81,8 @@ public class JsonExtractor extends Extractor {
         this.listSeparator = firstNonNull((String) extractorConfig.get(CK_LIST_SEPARATOR), ", ");
         this.keySeparator = firstNonNull((String) extractorConfig.get(CK_KEY_SEPARATOR), "_");
         this.kvSeparator = firstNonNull((String) extractorConfig.get(CK_KV_SEPARATOR), "=");
+        this.replaceKeyWhitespace = firstNonNull((Boolean) extractorConfig.get(CK_REPLACE_KEY_WHITESPACE), false);
+        this.keyWhitespaceReplacement = firstNonNull((String) extractorConfig.get(CK_KEY_WHITESPACE_REPLACEMENT), "_");
     }
 
     @Override
@@ -105,7 +111,17 @@ public class JsonExtractor extends Extractor {
 
         final Map<String, Object> results = new HashMap<>(json.size());
         for (Map.Entry<String, Object> mapEntry : json.entrySet()) {
-            for (Entry entry : parseValue(mapEntry.getKey(), mapEntry.getValue())) {
+            String key = mapEntry.getKey();
+            if (replaceKeyWhitespace && key.contains(" ")) {
+                key = key.replace(" ", keyWhitespaceReplacement);
+            } else {
+                if (LOG.isDebugEnabled()) {
+                    if (key.contains(" ")) {
+                        LOG.debug("Invalid key \"{}\" in JSON object!", key);
+                    }
+                }
+            }
+            for (Entry entry : parseValue(key, mapEntry.getValue())) {
                 results.put(entry.key(), entry.value());
             }
         }

--- a/graylog2-server/src/main/java/org/graylog2/inputs/extractors/JsonExtractor.java
+++ b/graylog2-server/src/main/java/org/graylog2/inputs/extractors/JsonExtractor.java
@@ -49,6 +49,7 @@ public class JsonExtractor extends Extractor {
     private static final String CK_KV_SEPARATOR = "kv_separator";
     private static final String CK_REPLACE_KEY_WHITESPACE = "replace_key_whitespace";
     private static final String CK_KEY_WHITESPACE_REPLACEMENT = "key_whitespace_replacement";
+    private static final String CK_KEY_PREFIX = "key_prefix";
     private static final RemoveNullPredicate REMOVE_NULL_PREDICATE = new RemoveNullPredicate();
 
     private final ObjectMapper mapper = new ObjectMapper();
@@ -58,6 +59,7 @@ public class JsonExtractor extends Extractor {
     private final String kvSeparator;
     private final boolean replaceKeyWhitespace;
     private final String keyWhitespaceReplacement;
+    private final String keyPrefix;
 
     public JsonExtractor(final MetricRegistry metricRegistry,
                          final String id,
@@ -83,6 +85,7 @@ public class JsonExtractor extends Extractor {
         this.kvSeparator = firstNonNull((String) extractorConfig.get(CK_KV_SEPARATOR), "=");
         this.replaceKeyWhitespace = firstNonNull((Boolean) extractorConfig.get(CK_REPLACE_KEY_WHITESPACE), false);
         this.keyWhitespaceReplacement = firstNonNull((String) extractorConfig.get(CK_KEY_WHITESPACE_REPLACEMENT), "_");
+        this.keyPrefix = firstNonNull((String) extractorConfig.get(CK_KEY_PREFIX), "");
     }
 
     @Override
@@ -111,7 +114,7 @@ public class JsonExtractor extends Extractor {
 
         final Map<String, Object> results = new HashMap<>(json.size());
         for (Map.Entry<String, Object> mapEntry : json.entrySet()) {
-            String key = mapEntry.getKey();
+            String key = keyPrefix + mapEntry.getKey();
             if (replaceKeyWhitespace && key.contains(" ")) {
                 key = key.replace(" ", keyWhitespaceReplacement);
             } else {

--- a/graylog2-server/src/main/java/org/graylog2/rest/models/tools/requests/JsonTestRequest.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/models/tools/requests/JsonTestRequest.java
@@ -46,6 +46,9 @@ public abstract class JsonTestRequest {
     @JsonProperty("key_whitespace_replacement")
     public abstract String keyWhitespaceReplacement();
 
+    @JsonProperty("key_prefix")
+    public abstract String keyPrefix();
+
     @JsonProperty("string")
     @NotEmpty
     public abstract String string();
@@ -57,7 +60,8 @@ public abstract class JsonTestRequest {
                                          @JsonProperty("kv_separator") @NotEmpty String kvSeparator,
                                          @JsonProperty("replace_key_whitespace") boolean replaceKeyWhitespace,
                                          @JsonProperty("key_whitespace_replacement") String keyWhitespaceReplacement,
+                                         @JsonProperty("key_prefix") String keyPrefix,
                                          @JsonProperty("string") @NotEmpty String string) {
-        return new AutoValue_JsonTestRequest(flatten, listSeparator, keySeparator, kvSeparator, replaceKeyWhitespace, keyWhitespaceReplacement, string);
+        return new AutoValue_JsonTestRequest(flatten, listSeparator, keySeparator, kvSeparator, replaceKeyWhitespace, keyWhitespaceReplacement, keyPrefix, string);
     }
 }

--- a/graylog2-server/src/main/java/org/graylog2/rest/models/tools/requests/JsonTestRequest.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/models/tools/requests/JsonTestRequest.java
@@ -40,6 +40,12 @@ public abstract class JsonTestRequest {
     @NotEmpty
     public abstract String kvSeparator();
 
+    @JsonProperty("replace_key_whitespace")
+    public abstract boolean replaceKeyWhitespace();
+
+    @JsonProperty("key_whitespace_replacement")
+    public abstract String keyWhitespaceReplacement();
+
     @JsonProperty("string")
     @NotEmpty
     public abstract String string();
@@ -49,7 +55,9 @@ public abstract class JsonTestRequest {
                                          @JsonProperty("list_separator") @NotEmpty String listSeparator,
                                          @JsonProperty("key_separator") @NotEmpty String keySeparator,
                                          @JsonProperty("kv_separator") @NotEmpty String kvSeparator,
+                                         @JsonProperty("replace_key_whitespace") boolean replaceKeyWhitespace,
+                                         @JsonProperty("key_whitespace_replacement") String keyWhitespaceReplacement,
                                          @JsonProperty("string") @NotEmpty String string) {
-        return new AutoValue_JsonTestRequest(flatten, listSeparator, keySeparator, kvSeparator, string);
+        return new AutoValue_JsonTestRequest(flatten, listSeparator, keySeparator, kvSeparator, replaceKeyWhitespace, keyWhitespaceReplacement, string);
     }
 }

--- a/graylog2-server/src/main/java/org/graylog2/rest/resources/tools/JsonTesterResource.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/resources/tools/JsonTesterResource.java
@@ -55,15 +55,16 @@ public class JsonTesterResource extends RestResource {
                                   @QueryParam("key_separator") @NotEmpty String keySeparator,
                                   @QueryParam("replace_key_whitespace") boolean replaceKeyWhitespace,
                                   @QueryParam("key_whitespace_replacement") String keyWhitespaceReplacement,
+                                  @QueryParam("key_prefix") String keyPrefix,
                                   @QueryParam("kv_separator") @NotEmpty String kvSeparator) {
-        return testJsonExtractor(string, flatten, listSeparator, keySeparator, kvSeparator, replaceKeyWhitespace, keyWhitespaceReplacement);
+        return testJsonExtractor(string, flatten, listSeparator, keySeparator, kvSeparator, replaceKeyWhitespace, keyWhitespaceReplacement, keyPrefix);
     }
 
     @POST
     @Timed
     @Consumes(MediaType.APPLICATION_JSON)
     public JsonTesterResponse post(@Valid @NotNull JsonTestRequest r) {
-        return testJsonExtractor(r.string(), r.flatten(), r.listSeparator(), r.keySeparator(), r.kvSeparator(), r.replaceKeyWhitespace(), r.keyWhitespaceReplacement());
+        return testJsonExtractor(r.string(), r.flatten(), r.listSeparator(), r.keySeparator(), r.kvSeparator(), r.replaceKeyWhitespace(), r.keyWhitespaceReplacement(), r.keyPrefix());
     }
 
     private JsonTesterResponse testJsonExtractor(String testString,
@@ -72,7 +73,8 @@ public class JsonTesterResource extends RestResource {
                                                  String keySeparator,
                                                  String kvSeparator,
                                                  boolean replaceKeyWhitespace,
-                                                 String keyWhitespaceReplacement) {
+                                                 String keyWhitespaceReplacement,
+                                                 String keyPrefix) {
         final Map<String, Object> config = ImmutableMap.<String, Object>builder()
                 .put("flatten", flatten)
                 .put("list_separator", listSeparator)
@@ -80,6 +82,7 @@ public class JsonTesterResource extends RestResource {
                 .put("kv_separator", kvSeparator)
                 .put("replace_key_whitespace", replaceKeyWhitespace)
                 .put("key_whitespace_replacement", keyWhitespaceReplacement)
+                .put("key_prefix", keyPrefix)
                 .build();
         final JsonExtractor extractor;
         try {

--- a/graylog2-server/src/main/java/org/graylog2/rest/resources/tools/JsonTesterResource.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/resources/tools/JsonTesterResource.java
@@ -53,28 +53,34 @@ public class JsonTesterResource extends RestResource {
                                   @QueryParam("flatten") @DefaultValue("false") boolean flatten,
                                   @QueryParam("list_separator") @NotEmpty String listSeparator,
                                   @QueryParam("key_separator") @NotEmpty String keySeparator,
+                                  @QueryParam("replace_key_whitespace") boolean replaceKeyWhitespace,
+                                  @QueryParam("key_whitespace_replacement") String keyWhitespaceReplacement,
                                   @QueryParam("kv_separator") @NotEmpty String kvSeparator) {
-        return testJsonExtractor(string, flatten, listSeparator, keySeparator, kvSeparator);
+        return testJsonExtractor(string, flatten, listSeparator, keySeparator, kvSeparator, replaceKeyWhitespace, keyWhitespaceReplacement);
     }
 
     @POST
     @Timed
     @Consumes(MediaType.APPLICATION_JSON)
     public JsonTesterResponse post(@Valid @NotNull JsonTestRequest r) {
-        return testJsonExtractor(r.string(), r.flatten(), r.listSeparator(), r.keySeparator(), r.kvSeparator());
+        return testJsonExtractor(r.string(), r.flatten(), r.listSeparator(), r.keySeparator(), r.kvSeparator(), r.replaceKeyWhitespace(), r.keyWhitespaceReplacement());
     }
 
     private JsonTesterResponse testJsonExtractor(String testString,
                                                  boolean flatten,
                                                  String listSeparator,
                                                  String keySeparator,
-                                                 String kvSeparator) {
-        final Map<String, Object> config = ImmutableMap.<String, Object>of(
-                "flatten", flatten,
-                "list_separator", listSeparator,
-                "key_separator", keySeparator,
-                "kv_separator", kvSeparator
-        );
+                                                 String kvSeparator,
+                                                 boolean replaceKeyWhitespace,
+                                                 String keyWhitespaceReplacement) {
+        final Map<String, Object> config = ImmutableMap.<String, Object>builder()
+                .put("flatten", flatten)
+                .put("list_separator", listSeparator)
+                .put("key_separator", keySeparator)
+                .put("kv_separator", kvSeparator)
+                .put("replace_key_whitespace", replaceKeyWhitespace)
+                .put("key_whitespace_replacement", keyWhitespaceReplacement)
+                .build();
         final JsonExtractor extractor;
         try {
             extractor = new JsonExtractor(

--- a/graylog2-server/src/test/java/org/graylog2/inputs/extractors/JsonExtractorTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/inputs/extractors/JsonExtractorTest.java
@@ -194,4 +194,19 @@ public class JsonExtractorTest {
                 new Extractor.Result(true, "bool", -1, -1)
         );
     }
+
+    @Test
+    public void testRunWithKeyPrefix() throws Exception {
+        final String value = "{\"text string\": \"foobar\", \"num   b er\": 1234.5678, \"bool\": true, \"null\": null}";
+
+        final JsonExtractor jsonExtractor1 = new JsonExtractor(new MetricRegistry(), "json", "title", 0L, Extractor.CursorStrategy.COPY,
+                "source", "target", ImmutableMap.of("key_prefix", "test_"), "user", Collections.emptyList(), Extractor.ConditionType.NONE,
+                "");
+
+        assertThat(jsonExtractor1.run(value)).contains(
+                new Extractor.Result("foobar", "test_text string", -1, -1),
+                new Extractor.Result(1234.5678, "test_num   b er", -1, -1),
+                new Extractor.Result(true, "test_bool", -1, -1)
+        );
+    }
 }

--- a/graylog2-server/src/test/java/org/graylog2/inputs/extractors/JsonExtractorTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/inputs/extractors/JsonExtractorTest.java
@@ -161,4 +161,37 @@ public class JsonExtractorTest {
             new Extractor.Result("Purge Vector", "Target_Data_Attribute Name", -1, -1)
         );
     }
+
+    @Test
+    public void testRunWithWhitespaceInKey() throws Exception {
+        final String value = "{\"text string\": \"foobar\", \"num   b er\": 1234.5678, \"bool\": true, \"null\": null}";
+
+        final JsonExtractor jsonExtractor1 = new JsonExtractor(new MetricRegistry(), "json", "title", 0L, Extractor.CursorStrategy.COPY,
+                "source", "target", Collections.emptyMap(), "user", Collections.emptyList(), Extractor.ConditionType.NONE,
+                "");
+
+        final JsonExtractor jsonExtractor2 = new JsonExtractor(new MetricRegistry(), "json", "title", 0L, Extractor.CursorStrategy.COPY,
+                "source", "target", ImmutableMap.of("replace_key_whitespace", true), "user", Collections.emptyList(), Extractor.ConditionType.NONE,
+                "");
+
+        final JsonExtractor jsonExtractor3 = new JsonExtractor(new MetricRegistry(), "json", "title", 0L, Extractor.CursorStrategy.COPY,
+                "source", "target", ImmutableMap.of("replace_key_whitespace", true, "key_whitespace_replacement", ":"), "user", Collections.emptyList(), Extractor.ConditionType.NONE,
+                "");
+
+        assertThat(jsonExtractor1.run(value)).contains(
+                new Extractor.Result("foobar", "text string", -1, -1),
+                new Extractor.Result(1234.5678, "num   b er", -1, -1),
+                new Extractor.Result(true, "bool", -1, -1)
+        );
+        assertThat(jsonExtractor2.run(value)).contains(
+                new Extractor.Result("foobar", "text_string", -1, -1),
+                new Extractor.Result(1234.5678, "num___b_er", -1, -1),
+                new Extractor.Result(true, "bool", -1, -1)
+        );
+        assertThat(jsonExtractor3.run(value)).contains(
+                new Extractor.Result("foobar", "text:string", -1, -1),
+                new Extractor.Result(1234.5678, "num:::b:er", -1, -1),
+                new Extractor.Result(true, "bool", -1, -1)
+        );
+    }
 }

--- a/graylog2-web-interface/src/components/extractors/extractors_configuration/JSONExtractorConfiguration.jsx
+++ b/graylog2-web-interface/src/components/extractors/extractors_configuration/JSONExtractorConfiguration.jsx
@@ -26,7 +26,13 @@ const JSONExtractorConfiguration = React.createClass({
   componentWillReceiveProps(nextProps) {
     this.setState({configuration: this._getEffectiveConfiguration(nextProps.configuration)});
   },
-  DEFAULT_CONFIGURATION: {list_separator: ', ', key_separator: '_', kv_separator: '='},
+  DEFAULT_CONFIGURATION: {
+    list_separator: ', ',
+    key_separator: '_',
+    kv_separator: '=',
+    replace_key_whitespace: false,
+    key_whitespace_replacement: '_',
+  },
   _getEffectiveConfiguration(configuration) {
     return ExtractorUtils.getEffectiveConfiguration(this.DEFAULT_CONFIGURATION, configuration);
   },
@@ -43,7 +49,8 @@ const JSONExtractorConfiguration = React.createClass({
 
     const configuration = this.state.configuration;
     const promise = ToolsStore.testJSON(configuration.flatten, configuration.list_separator,
-      configuration.key_separator, configuration.kv_separator, this.props.exampleMessage);
+      configuration.key_separator, configuration.kv_separator, configuration.replace_key_whitespace,
+      configuration.key_whitespace_replacement, this.props.exampleMessage);
 
     promise.then(result => {
       const matches = [];
@@ -103,6 +110,24 @@ const JSONExtractorConfiguration = React.createClass({
                required
                onChange={this._onChange('kv_separator')}
                help="What string to use when concatenating key/value pairs of a JSON object (only used if flattened)."/>
+
+        <Input type="checkbox"
+               id="replace_key_whitespace"
+               label="Replace whitespace in keys"
+               wrapperClassName="col-md-offset-2 col-md-10"
+               defaultChecked={this.state.configuration.replace_key_whitespace}
+               onChange={this._onChange('replace_key_whitespace')}
+               help="Whether to replace whitespace in message keys."/>
+
+        <Input type="text"
+               id="key_whitespace_replacement"
+               label="Key whitespace replacement"
+               labelClassName="col-md-2"
+               wrapperClassName="col-md-10"
+               defaultValue={this.state.configuration.key_whitespace_replacement}
+               required
+               onChange={this._onChange('key_whitespace_replacement')}
+               help="What character to use when replacing whitespace in message keys. Make sure the replacement is valid in Lucene! (i.e. '-' or '_')"/>
 
         <Input wrapperClassName="col-md-offset-2 col-md-10">
           <Button bsStyle="info" onClick={this._onTryClick} disabled={this._isTryButtonDisabled()}>

--- a/graylog2-web-interface/src/components/extractors/extractors_configuration/JSONExtractorConfiguration.jsx
+++ b/graylog2-web-interface/src/components/extractors/extractors_configuration/JSONExtractorConfiguration.jsx
@@ -120,15 +120,15 @@ const JSONExtractorConfiguration = React.createClass({
                defaultValue={this.state.configuration.key_prefix}
                required
                onChange={this._onChange('key_prefix')}
-               help="Add the configured prefix to each key in the message."/>
+               help="Text to prepend to each key extracted from the JSON object."/>
 
         <Input type="checkbox"
                id="replace_key_whitespace"
-               label="Replace whitespace in keys"
+               label="Replace whitespaces in keys"
                wrapperClassName="col-md-offset-2 col-md-10"
                defaultChecked={this.state.configuration.replace_key_whitespace}
                onChange={this._onChange('replace_key_whitespace')}
-               help="Whether to replace whitespace in message keys."/>
+               help="Field keys containing whitespaces will be discarded when storing the extracted message. Check this box to replace whitespaces in JSON keys with another character."/>
 
         <Input type="text"
                id="key_whitespace_replacement"
@@ -139,7 +139,7 @@ const JSONExtractorConfiguration = React.createClass({
                disabled={!this.state.configuration.replace_key_whitespace}
                required
                onChange={this._onChange('key_whitespace_replacement')}
-               help="What character to use when replacing whitespace in message keys. Make sure the replacement is valid in Lucene! (i.e. '-' or '_')"/>
+               help="What character to use when replacing whitespaces in message keys. Please ensure the replacement character is valid in Lucene, e.g. '-' or '_'."/>
 
         <Input wrapperClassName="col-md-offset-2 col-md-10">
           <Button bsStyle="info" onClick={this._onTryClick} disabled={this._isTryButtonDisabled()}>

--- a/graylog2-web-interface/src/components/extractors/extractors_configuration/JSONExtractorConfiguration.jsx
+++ b/graylog2-web-interface/src/components/extractors/extractors_configuration/JSONExtractorConfiguration.jsx
@@ -136,6 +136,7 @@ const JSONExtractorConfiguration = React.createClass({
                labelClassName="col-md-2"
                wrapperClassName="col-md-10"
                defaultValue={this.state.configuration.key_whitespace_replacement}
+               disabled={!this.state.configuration.replace_key_whitespace}
                required
                onChange={this._onChange('key_whitespace_replacement')}
                help="What character to use when replacing whitespace in message keys. Make sure the replacement is valid in Lucene! (i.e. '-' or '_')"/>

--- a/graylog2-web-interface/src/components/extractors/extractors_configuration/JSONExtractorConfiguration.jsx
+++ b/graylog2-web-interface/src/components/extractors/extractors_configuration/JSONExtractorConfiguration.jsx
@@ -30,6 +30,7 @@ const JSONExtractorConfiguration = React.createClass({
     list_separator: ', ',
     key_separator: '_',
     kv_separator: '=',
+    key_prefix: '',
     replace_key_whitespace: false,
     key_whitespace_replacement: '_',
   },
@@ -50,7 +51,7 @@ const JSONExtractorConfiguration = React.createClass({
     const configuration = this.state.configuration;
     const promise = ToolsStore.testJSON(configuration.flatten, configuration.list_separator,
       configuration.key_separator, configuration.kv_separator, configuration.replace_key_whitespace,
-      configuration.key_whitespace_replacement, this.props.exampleMessage);
+      configuration.key_whitespace_replacement, configuration.key_prefix, this.props.exampleMessage);
 
     promise.then(result => {
       const matches = [];
@@ -110,6 +111,16 @@ const JSONExtractorConfiguration = React.createClass({
                required
                onChange={this._onChange('kv_separator')}
                help="What string to use when concatenating key/value pairs of a JSON object (only used if flattened)."/>
+
+        <Input type="text"
+               id="key_prefix"
+               label="Key prefix"
+               labelClassName="col-md-2"
+               wrapperClassName="col-md-10"
+               defaultValue={this.state.configuration.key_prefix}
+               required
+               onChange={this._onChange('key_prefix')}
+               help="Add the configured prefix to each key in the message."/>
 
         <Input type="checkbox"
                id="replace_key_whitespace"

--- a/graylog2-web-interface/src/stores/tools/ToolsStore.ts
+++ b/graylog2-web-interface/src/stores/tools/ToolsStore.ts
@@ -30,13 +30,15 @@ const ToolsStore = {
 
         return promise;
     },
-    testJSON(flatten: boolean, listSeparator: string, keySeparator: string, kvSeparator: string, string: string): Promise<Object> {
+    testJSON(flatten: boolean, listSeparator: string, keySeparator: string, kvSeparator: string, replaceKeyWhitespace: boolean, keyWhitespaceReplacement: string, string: string): Promise<Object> {
         const url = ApiRoutes.ToolsApiController.jsonTest().url;
         const payload = {
             flatten: flatten,
             list_separator: listSeparator,
             key_separator: keySeparator,
             kv_separator: kvSeparator,
+            replace_key_whitespace: replaceKeyWhitespace,
+            key_whitespace_replacement: keyWhitespaceReplacement,
             string: string,
         };
 

--- a/graylog2-web-interface/src/stores/tools/ToolsStore.ts
+++ b/graylog2-web-interface/src/stores/tools/ToolsStore.ts
@@ -30,7 +30,7 @@ const ToolsStore = {
 
         return promise;
     },
-    testJSON(flatten: boolean, listSeparator: string, keySeparator: string, kvSeparator: string, replaceKeyWhitespace: boolean, keyWhitespaceReplacement: string, string: string): Promise<Object> {
+    testJSON(flatten: boolean, listSeparator: string, keySeparator: string, kvSeparator: string, replaceKeyWhitespace: boolean, keyWhitespaceReplacement: string, keyPrefix: string, string: string): Promise<Object> {
         const url = ApiRoutes.ToolsApiController.jsonTest().url;
         const payload = {
             flatten: flatten,
@@ -39,6 +39,7 @@ const ToolsStore = {
             kv_separator: kvSeparator,
             replace_key_whitespace: replaceKeyWhitespace,
             key_whitespace_replacement: keyWhitespaceReplacement,
+            key_prefix: keyPrefix,
             string: string,
         };
 


### PR DESCRIPTION
This adds two new options to the JSON extractor.

- Allow replacement of whitespace in the message keys (#2434)
- Add key prefix option (#1646)

Fixes #2434
Fixes #1646