### PR TITLE
Fix group membership lookup if DN contains whitespace

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/security/ldap/LdapConnector.java
+++ b/graylog2-server/src/main/java/org/graylog2/security/ldap/LdapConnector.java
@@ -318,6 +318,7 @@ public class LdapConnector {
      * @param dn denormalized DN string
      * @return normalized DN string
      */
+    @Nullable
     private String normalizedDn(String dn) {
         if (isNullOrEmpty(dn)) {
             return dn;

--- a/graylog2-server/src/test/java/org/graylog2/security/ldap/LdapConnectorTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/security/ldap/LdapConnectorTest.java
@@ -163,7 +163,7 @@ public class LdapConnectorTest extends AbstractLdapTestUnit {
                 .isNotNull()
                 .isEqualTo("cn=John Doe,ou=users,dc=example,dc=com");
 
-        assertThat(entry.getGroups()).hasSize(1).contains("Engineers");
+        assertThat(entry.getGroups()).hasSize(2).contains("Engineers", "Whitespace Engineers");
     }
 
     @Test
@@ -204,8 +204,8 @@ public class LdapConnectorTest extends AbstractLdapTestUnit {
                 .isEqualTo("cn=John Doe,ou=users,dc=example,dc=com");
 
         assertThat(entry.getGroups())
-                .hasSize(3)
-                .contains("Developers", "QA", "Engineers");
+                .hasSize(4)
+                .contains("Developers", "QA", "Engineers", "Whitespace Engineers");
     }
 
     @Test
@@ -213,8 +213,8 @@ public class LdapConnectorTest extends AbstractLdapTestUnit {
         final Set<String> groups = connector.listGroups(connection, "ou=groups,dc=example,dc=com", "(objectClass=top)", "cn");
 
         assertThat(groups)
-                .hasSize(3)
-                .contains("Developers", "QA", "Engineers");
+                .hasSize(4)
+                .contains("Developers", "QA", "Engineers", "Whitespace Engineers");
     }
 
     @Test

--- a/graylog2-server/src/test/java/org/graylog2/security/ldap/LdapConnectorTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/security/ldap/LdapConnectorTest.java
@@ -218,6 +218,31 @@ public class LdapConnectorTest extends AbstractLdapTestUnit {
     }
 
     @Test
+    public void testFindGroupsWithWhitespace() throws Exception {
+        final LdapEntry ldapEntry1 = new LdapEntry();
+        ldapEntry1.setDn("cn=John Doe,ou=users,dc=example,dc=com");
+        ldapEntry1.put("uid", "john");
+
+        final LdapEntry ldapEntry2 = new LdapEntry();
+        ldapEntry2.setDn("cn=John Doe,  ou=users, dc=example, dc=com");
+        ldapEntry2.put("uid", "john");
+
+        final Set<String> groups1 = connector.findGroups(connection,
+                "ou=groups,dc=example,dc=com",
+                "(objectClass=groupOfUniqueNames)",
+                "cn",
+                ldapEntry1);
+        final Set<String> groups2 = connector.findGroups(connection,
+                "ou=groups,dc=example,dc=com",
+                "(objectClass=groupOfUniqueNames)",
+                "cn",
+                ldapEntry2);
+
+        assertThat(groups1).hasSize(2).containsOnly("Whitespace Engineers", "Engineers");
+        assertThat(groups2).hasSize(2).containsOnly("Whitespace Engineers", "Engineers");
+    }
+
+    @Test
     public void authenticateThrowsIllegalArgumentExceptionIfPrincipalIsNull() throws LdapException {
         expectedException.expect(IllegalArgumentException.class);
         expectedException.expectMessage("Binding with empty principal is forbidden.");

--- a/graylog2-server/src/test/resources/org/graylog2/security/ldap/base.ldif
+++ b/graylog2-server/src/test/resources/org/graylog2/security/ldap/base.ldif
@@ -35,6 +35,12 @@ objectClass: top
 cn: Engineers
 uniqueMember: cn=John Doe,ou=users,dc=example,dc=com
 
+dn: cn=Whitespace Engineers,ou=groups,dc=example,dc=com
+objectClass: groupOfUniqueNames
+objectClass: top
+cn: Whitespace Engineers
+uniqueMember: cn=John Doe, ou=users, dc=example, dc=com
+
 dn: cn=QA,ou=groups,dc=example,dc=com
 objectClass: groupOfNames
 objectClass: top


### PR DESCRIPTION
Normalize the DN before comparing the strings to avoid mapping problems if the DNs have different whitespace formatting.

Fixes #1790