### PR TITLE
Update jQuery UI

### DIFF
--- a/graylog2-web-interface/package.json
+++ b/graylog2-web-interface/package.json
@@ -28,7 +28,7 @@
     "immutable": "^3.7.5",
     "javascript-natural-sort": "^0.7.1",
     "jquery": "2.1.x",
-    "jquery-ui": "^1.10.5",
+    "jquery-ui": "1.12.x",
     "markdown": "^0.5.0",
     "md5": "^2.0.0",
     "moment": "2.10.6",

--- a/graylog2-web-interface/src/components/sources/SourceLineChart.jsx
+++ b/graylog2-web-interface/src/components/sources/SourceLineChart.jsx
@@ -1,4 +1,4 @@
-import React, {PropTypes} from 'react';
+import React from 'react';
 import $ from 'jquery';
 import {} from 'jquery-ui/ui/effects/effect-bounce';
 import dc from 'dc';
@@ -12,10 +12,10 @@ import graphHelper from 'legacy/graphHelper';
 
 const SourceLineChart = React.createClass({
   propTypes: {
-    histogramDataAvailable: PropTypes.bool.isRequired,
-    reloadingHistogram: PropTypes.bool.isRequired,
-    resetFilters: PropTypes.func.isRequired,
-    resolution: PropTypes.string.isRequired,
+    histogramDataAvailable: React.PropTypes.bool.isRequired,
+    reloadingHistogram: React.PropTypes.bool.isRequired,
+    resetFilters: React.PropTypes.func.isRequired,
+    resolution: React.PropTypes.string.isRequired,
   },
 
   getInitialState() {
@@ -38,7 +38,7 @@ const SourceLineChart = React.createClass({
 
   _configureWidth(lineChartWidth) {
     this._lineChart.width(lineChartWidth);
-    this.setState({lineChartWidth: String(lineChartWidth) + 'px'});
+    this.setState({ lineChartWidth: `${String(lineChartWidth)}px` });
   },
 
   updateWidth() {
@@ -63,7 +63,7 @@ const SourceLineChart = React.createClass({
     this._lineChart = dc.lineChart(lineChartDomNode);
     this._lineChart
       .height(200)
-      .margins({left: 35, right: 20, top: 20, bottom: 20})
+      .margins({ left: 35, right: 20, top: 20, bottom: 20 })
       .dimension(dimension)
       .group(group)
       .x(d3.time.scale())

--- a/graylog2-web-interface/src/components/sources/SourceLineChart.jsx
+++ b/graylog2-web-interface/src/components/sources/SourceLineChart.jsx
@@ -1,6 +1,6 @@
 import React, {PropTypes} from 'react';
 import $ from 'jquery';
-import {} from 'jquery-ui';
+import {} from 'jquery-ui/ui/effects/effect-bounce';
 import dc from 'dc';
 import d3 from 'd3';
 

--- a/graylog2-web-interface/src/legacy/Rickshaw.Graph.Graylog2Selector.js
+++ b/graylog2-web-interface/src/legacy/Rickshaw.Graph.Graylog2Selector.js
@@ -1,5 +1,5 @@
 import $ from 'jquery';
-import {} from 'jquery-ui';
+import {} from 'jquery-ui/ui/effects/effect-bounce';
 import Rickshaw from 'rickshaw';
 import NumberUtils from 'util/NumberUtils';
 import DateTime from 'logic/datetimes/DateTime';

--- a/graylog2-web-interface/src/legacy/analyzers/fieldcharts.js
+++ b/graylog2-web-interface/src/legacy/analyzers/fieldcharts.js
@@ -1,5 +1,6 @@
 import jQuery from 'jquery';
-import jQueryUI from 'jquery-ui';
+import {} from 'jquery-ui/ui/widgets/draggable';
+import {} from 'jquery-ui/ui/widgets/droppable';
 import moment from 'moment';
 import numeral from 'numeral';
 import Rickshaw from 'rickshaw';


### PR DESCRIPTION
After reinstalling my local node modules, I got a new jQuery UI version installed (1.12.0), and that broke the creation of field charts, as there have been [several changes in the npm package](http://blog.jqueryui.com/2016/04/jquery-ui-1-12-0-release-candidate-2/). TLDR:
> npm/browserify/webpack support: The jquery-ui package on npm is now owned and maintained by the jQuery UI team. In addition, we’ve updated package.json and changed the directory structure to work better with tools like browserify and webpack. See Jörn Zaefferer’s demo for webpack usage information.

As we don't use jQuery UI that much, I decided the best way to go was to fix the imports and pin the new version in our `package.json`.