### PR TITLE
Add missing Guice modules for journal-related commands

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/bindings/ConfigurationModule.java
+++ b/graylog2-server/src/main/java/org/graylog2/bindings/ConfigurationModule.java
@@ -1,0 +1,38 @@
+/**
+ * This file is part of Graylog.
+ *
+ * Graylog is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.graylog2.bindings;
+
+import com.google.inject.Binder;
+import com.google.inject.Module;
+import org.graylog2.Configuration;
+import org.graylog2.plugin.BaseConfiguration;
+
+import static java.util.Objects.requireNonNull;
+
+public class ConfigurationModule implements Module {
+    private final Configuration configuration;
+
+    public ConfigurationModule(Configuration configuration) {
+        this.configuration = requireNonNull(configuration);
+    }
+
+    @Override
+    public void configure(Binder binder) {
+        binder.bind(Configuration.class).toInstance(configuration);
+        binder.bind(BaseConfiguration.class).toInstance(configuration);
+    }
+}

--- a/graylog2-server/src/main/java/org/graylog2/bindings/ServerBindings.java
+++ b/graylog2-server/src/main/java/org/graylog2/bindings/ServerBindings.java
@@ -139,9 +139,6 @@ public class ServerBindings extends Graylog2Module {
     }
 
     private void bindSingletons() {
-        bind(Configuration.class).toInstance(configuration);
-        bind(BaseConfiguration.class).toInstance(configuration);
-
         bind(MongoConnection.class).toProvider(MongoConnectionProvider.class);
 
         if (configuration.isMessageJournalEnabled()) {

--- a/graylog2-server/src/main/java/org/graylog2/commands/Server.java
+++ b/graylog2-server/src/main/java/org/graylog2/commands/Server.java
@@ -29,6 +29,7 @@ import org.graylog2.auditlog.AuditLogModule;
 import org.graylog2.auditlog.AuditLogStdOutConfiguration;
 import org.graylog2.auditlog.AuditLogger;
 import org.graylog2.bindings.AlarmCallbackBindings;
+import org.graylog2.bindings.ConfigurationModule;
 import org.graylog2.decorators.DecoratorBindings;
 import org.graylog2.bindings.InitializerBindings;
 import org.graylog2.bindings.MessageFilterBindings;
@@ -99,6 +100,7 @@ public class Server extends ServerBootstrap {
     protected List<Module> getCommandBindings() {
         final ImmutableList.Builder<Module> modules = ImmutableList.builder();
         modules.add(
+            new ConfigurationModule(configuration),
             new ServerBindings(configuration),
             new PersistenceServicesBindings(),
             new MessageFilterBindings(),

--- a/graylog2-server/src/main/java/org/graylog2/commands/journal/AbstractJournalCommand.java
+++ b/graylog2-server/src/main/java/org/graylog2/commands/journal/AbstractJournalCommand.java
@@ -18,16 +18,21 @@ package org.graylog2.commands.journal;
 
 import com.google.inject.Module;
 import org.graylog2.Configuration;
+import org.graylog2.bindings.ConfigurationModule;
 import org.graylog2.bootstrap.CmdLineTool;
 import org.graylog2.plugin.KafkaJournalConfiguration;
+import org.graylog2.plugin.ServerStatus;
 import org.graylog2.shared.bindings.SchedulerBindings;
+import org.graylog2.shared.bindings.ServerStatusBindings;
 import org.graylog2.shared.journal.KafkaJournal;
 import org.graylog2.shared.journal.KafkaJournalModule;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
+import java.util.Set;
 
 public abstract class AbstractJournalCommand extends CmdLineTool {
     protected static final Logger log = LoggerFactory.getLogger(AbstractJournalCommand.class);
@@ -45,8 +50,15 @@ public abstract class AbstractJournalCommand extends CmdLineTool {
 
     @Override
     protected List<Module> getCommandBindings() {
-        return Arrays.<Module>asList(new SchedulerBindings(),
-                                     new KafkaJournalModule());
+        return Arrays.asList(new ConfigurationModule(configuration),
+                             new ServerStatusBindings(capabilities()),
+                             new SchedulerBindings(),
+                             new KafkaJournalModule());
+    }
+
+    @Override
+    protected Set<ServerStatus.Capability> capabilities() {
+        return configuration.isMaster() ? Collections.singleton(ServerStatus.Capability.MASTER) : Collections.emptySet();
     }
 
     @Override


### PR DESCRIPTION
After merging #2312, the `KafkaJournal` class depends on more dependencies from the Graylog code base which were missing in the `AbstractJournalCommand`.

Fixes #2493