### PR TITLE
Switch message filters from polling to subscribing to change events

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/filters/ExtractorFilter.java
+++ b/graylog2-server/src/main/java/org/graylog2/filters/ExtractorFilter.java
@@ -16,39 +16,52 @@
  */
 package org.graylog2.filters;
 
-import com.google.common.cache.Cache;
-import com.google.common.cache.CacheBuilder;
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
+import com.google.common.eventbus.EventBus;
+import com.google.common.eventbus.Subscribe;
 import org.graylog2.database.NotFoundException;
 import org.graylog2.inputs.Input;
 import org.graylog2.inputs.InputService;
 import org.graylog2.plugin.Message;
 import org.graylog2.plugin.filters.MessageFilter;
 import org.graylog2.plugin.inputs.Extractor;
+import org.graylog2.rest.models.system.inputs.responses.InputCreated;
+import org.graylog2.rest.models.system.inputs.responses.InputDeleted;
+import org.graylog2.rest.models.system.inputs.responses.InputUpdated;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import javax.inject.Inject;
+import javax.inject.Named;
 import java.util.Collections;
-import java.util.Comparator;
 import java.util.List;
-import java.util.concurrent.Callable;
-import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 
 public class ExtractorFilter implements MessageFilter {
     private static final Logger LOG = LoggerFactory.getLogger(ExtractorFilter.class);
     private static final String NAME = "Extractor";
+    private static final List<Extractor> EMPTY_LIST = ImmutableList.of();
 
-    private Cache<String, List<Extractor>> cache = CacheBuilder.newBuilder()
-            .expireAfterWrite(1, TimeUnit.SECONDS)
-            .build();
+    private final ConcurrentMap<String, List<Extractor>> extractors = new ConcurrentHashMap<>();
 
     private final InputService inputService;
+    private final ScheduledExecutorService scheduler;
 
     @Inject
-    public ExtractorFilter(InputService inputService) {
+    public ExtractorFilter(InputService inputService,
+                           EventBus serverEventBus,
+                           @Named("daemonScheduler") ScheduledExecutorService scheduler) {
         this.inputService = inputService;
+        this.scheduler = scheduler;
+
+        loadAllExtractors();
+
+        // TODO: This class needs lifecycle management to avoid leaking objects in the EventBus
+        serverEventBus.register(this);
     }
 
     @Override
@@ -57,7 +70,7 @@ public class ExtractorFilter implements MessageFilter {
             return false;
         }
 
-        for (final Extractor extractor : loadExtractors(msg.getSourceInputId())) {
+        for (final Extractor extractor : extractors.getOrDefault(msg.getSourceInputId(), EMPTY_LIST)) {
             try {
                 extractor.runExtractor(msg);
             } catch (Exception e) {
@@ -70,34 +83,43 @@ public class ExtractorFilter implements MessageFilter {
         return false;
     }
 
-    private List<Extractor> loadExtractors(final String inputId) {
+    @Subscribe
+    public void handleInputCreate(final InputCreated event) {
+        LOG.debug("Load extractors for input <{}>", event.id());
+        scheduler.schedule(() -> loadExtractors(event.id()), 0, TimeUnit.SECONDS);
+    }
+
+    @Subscribe
+    public void handleInputDelete(final InputDeleted event) {
+        LOG.debug("Removing input from extractors cache <{}>", event.id());
+        extractors.remove(event.id());
+    }
+
+    @Subscribe
+    public void handleInputUpdate(final InputUpdated event) {
+        scheduler.schedule(() -> loadExtractors(event.id()), 0, TimeUnit.SECONDS);
+    }
+
+    private void loadAllExtractors() {
         try {
-            return cache.get(inputId, new Callable<List<Extractor>>() {
-                @Override
-                public List<Extractor> call() throws Exception {
-                    LOG.debug("Re-loading extractors for input <{}> into cache.", inputId);
+            inputService.all().forEach(input -> loadExtractors(input.getId()));
+        } catch (Exception e) {
+            LOG.error("Unable to load extractors for all inputs", e);
+        }
+    }
 
-                    try {
-                        Input input = inputService.find(inputId);
+    private void loadExtractors(final String inputId) {
+        LOG.debug("Re-loading extractors for input <{}>", inputId);
 
-                        List<Extractor> sorted = Lists.newArrayList(inputService.getExtractors(input));
+        try {
+            final Input input = inputService.find(inputId);
+            final List<Extractor> sorted = Lists.newArrayList(inputService.getExtractors(input));
 
-                        Collections.sort(sorted, new Comparator<Extractor>() {
-                            public int compare(Extractor e1, Extractor e2) {
-                                return e1.getOrder().intValue() - e2.getOrder().intValue();
-                            }
-                        });
+            Collections.sort(sorted, (e1, e2) -> e1.getOrder().intValue() - e2.getOrder().intValue());
 
-                        return sorted;
-                    } catch (NotFoundException e) {
-                        LOG.warn("Unable to load input: {}", e.getMessage());
-                        return Collections.emptyList();
-                    }
-                }
-            });
-        } catch (ExecutionException e) {
-            LOG.error("Could not load extractors into cache. Returning empty list.", e);
-            return Collections.emptyList();
+            extractors.put(inputId, ImmutableList.copyOf(sorted));
+        } catch (NotFoundException e) {
+            LOG.warn("Unable to load input <{}>: {}", inputId, e.getMessage());
         }
     }
 

--- a/graylog2-server/src/main/java/org/graylog2/filters/ExtractorFilter.java
+++ b/graylog2-server/src/main/java/org/graylog2/filters/ExtractorFilter.java
@@ -44,7 +44,6 @@ import java.util.concurrent.TimeUnit;
 public class ExtractorFilter implements MessageFilter {
     private static final Logger LOG = LoggerFactory.getLogger(ExtractorFilter.class);
     private static final String NAME = "Extractor";
-    private static final List<Extractor> EMPTY_LIST = ImmutableList.of();
 
     private final ConcurrentMap<String, List<Extractor>> extractors = new ConcurrentHashMap<>();
 
@@ -70,7 +69,7 @@ public class ExtractorFilter implements MessageFilter {
             return false;
         }
 
-        for (final Extractor extractor : extractors.getOrDefault(msg.getSourceInputId(), EMPTY_LIST)) {
+        for (final Extractor extractor : extractors.getOrDefault(msg.getSourceInputId(), Collections.emptyList())) {
             try {
                 extractor.runExtractor(msg);
             } catch (Exception e) {

--- a/graylog2-server/src/main/java/org/graylog2/filters/ExtractorFilter.java
+++ b/graylog2-server/src/main/java/org/graylog2/filters/ExtractorFilter.java
@@ -38,7 +38,6 @@ import java.util.List;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.ScheduledExecutorService;
-import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 
 public class ExtractorFilter implements MessageFilter {
@@ -86,7 +85,7 @@ public class ExtractorFilter implements MessageFilter {
     @SuppressWarnings("unused")
     public void handleInputCreate(final InputCreated event) {
         LOG.debug("Load extractors for input <{}>", event.id());
-        scheduler.schedule(() -> loadExtractors(event.id()), 0, TimeUnit.SECONDS);
+        scheduler.submit(() -> loadExtractors(event.id()));
     }
 
     @Subscribe
@@ -99,7 +98,7 @@ public class ExtractorFilter implements MessageFilter {
     @Subscribe
     @SuppressWarnings("unused")
     public void handleInputUpdate(final InputUpdated event) {
-        scheduler.schedule(() -> loadExtractors(event.id()), 0, TimeUnit.SECONDS);
+        scheduler.submit(() -> loadExtractors(event.id()));
     }
 
     private void loadAllExtractors() {

--- a/graylog2-server/src/main/java/org/graylog2/filters/ExtractorFilter.java
+++ b/graylog2-server/src/main/java/org/graylog2/filters/ExtractorFilter.java
@@ -83,18 +83,21 @@ public class ExtractorFilter implements MessageFilter {
     }
 
     @Subscribe
+    @SuppressWarnings("unused")
     public void handleInputCreate(final InputCreated event) {
         LOG.debug("Load extractors for input <{}>", event.id());
         scheduler.schedule(() -> loadExtractors(event.id()), 0, TimeUnit.SECONDS);
     }
 
     @Subscribe
+    @SuppressWarnings("unused")
     public void handleInputDelete(final InputDeleted event) {
         LOG.debug("Removing input from extractors cache <{}>", event.id());
         extractors.remove(event.id());
     }
 
     @Subscribe
+    @SuppressWarnings("unused")
     public void handleInputUpdate(final InputUpdated event) {
         scheduler.schedule(() -> loadExtractors(event.id()), 0, TimeUnit.SECONDS);
     }

--- a/graylog2-server/src/main/java/org/graylog2/filters/RulesFilter.java
+++ b/graylog2-server/src/main/java/org/graylog2/filters/RulesFilter.java
@@ -16,10 +16,10 @@
  */
 package org.graylog2.filters;
 
-import com.google.common.cache.Cache;
-import com.google.common.cache.CacheBuilder;
-import com.google.common.collect.Sets;
-import org.graylog2.filters.blacklist.FilterDescription;
+import com.google.common.eventbus.EventBus;
+import com.google.common.eventbus.Subscribe;
+import org.graylog2.database.NotFoundException;
+import org.graylog2.filters.events.FilterDescriptionUpdateEvent;
 import org.graylog2.plugin.Message;
 import org.graylog2.plugin.RulesEngine;
 import org.graylog2.plugin.filters.MessageFilter;
@@ -27,10 +27,10 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import javax.inject.Inject;
-import java.util.Set;
-import java.util.concurrent.Callable;
-import java.util.concurrent.ExecutionException;
+import javax.inject.Named;
+import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
 
 /**
  * @author Lennart Koopmann <lennart@socketfeed.com>
@@ -38,66 +38,55 @@ import java.util.concurrent.TimeUnit;
 public class RulesFilter implements MessageFilter {
     private static final Logger LOG = LoggerFactory.getLogger(RulesFilter.class);
 
+    private final RulesEngine rulesEngine;
     private final FilterService filterService;
-    private final RulesEngine.RulesSession privateSession;
-    private final Cache<String, Set<FilterDescription>> cache;
-    private Set<FilterDescription> currentFilterSet;
+    private final ScheduledExecutorService scheduler;
+    private final AtomicReference<RulesEngine.RulesSession> privateSession = new AtomicReference<>(null);
 
     @Inject
-    public RulesFilter(RulesEngine rulesEngine, final FilterService filterService) {
+    public RulesFilter(final RulesEngine rulesEngine,
+                       final FilterService filterService,
+                       final EventBus serverEventBus,
+                       @Named("daemonScheduler") ScheduledExecutorService scheduler) {
+        this.rulesEngine = rulesEngine;
         this.filterService = filterService;
+        this.scheduler = scheduler;
 
-        currentFilterSet = Sets.newHashSet();
-        cache = CacheBuilder.newBuilder()
-                .expireAfterWrite(1, TimeUnit.SECONDS)
-                .build();
-        privateSession = rulesEngine.createPrivateSession();
+        loadRules();
+
+        // TODO: This class needs lifecycle management to avoid leaking objects in the EventBus
+        serverEventBus.register(this);
     }
 
     @Override
     public boolean filter(Message msg) {
-        final Set<FilterDescription> filters;
-        try {
-            filters = cache.get("filters", new Callable<Set<FilterDescription>>() {
-                @Override
-                public Set<FilterDescription> call() throws Exception {
-                    // TODO this should be improved by computing the difference between the filter sets
-                    // most of the time nothing changes at all.
-                    final Set<FilterDescription> newFilters = filterService.loadAll();
-                    final Sets.SetView<FilterDescription> difference =
-                            Sets.symmetricDifference(currentFilterSet, newFilters);
-                    if (difference.isEmpty()) {
-                        // there wasn't any change, simply return the current filter set
-                        LOG.debug("Filter sets are identical, not updating rules engine.");
-                        return currentFilterSet;
-                    }
-
-                    // something changed, we simply update everything, not trying to do the minimal changes yet
-                    // should this become too expensive we need to do something smarter
-                    LOG.debug("Updating rules engine, filter sets differ: {}", difference);
-                    // retract all current filter facts
-                    for (FilterDescription filterDescription : currentFilterSet) {
-                        privateSession.deleteFact(filterDescription);
-                    }
-                    // state all new filter facts
-                    for (FilterDescription filterDescription : newFilters) {
-                        privateSession.insertFact(filterDescription);
-                    }
-                    currentFilterSet.clear();
-                    // remember currently stated facts
-                    currentFilterSet.addAll(newFilters);
-                    return currentFilterSet;
-                }
-            });
-        } catch (ExecutionException ignored) {
-            return false;
-        }
-
         // Always run the rules engine to make sure rules from the external rules file will be run.
-        privateSession.evaluate(msg, true);
+        privateSession.get().evaluate(msg, true);
 
         // false if not explicitly set to true in the rules.
         return msg.getFilterOut();
+    }
+
+    @Subscribe
+    public void handleRulesUpdate(FilterDescriptionUpdateEvent ignored) {
+        LOG.info("Updating filter descriptions: {}", ignored);
+        scheduler.schedule(this::loadRules, 0, TimeUnit.SECONDS);
+    }
+
+    private void loadRules() {
+        LOG.debug("Loading rule filters");
+        try {
+            final RulesEngine.RulesSession newSession = rulesEngine.createPrivateSession();
+
+            filterService.loadAll().forEach(filterDescription -> {
+                LOG.debug("Insert filter description: {}", filterDescription);
+                newSession.insertFact(filterDescription);
+            });
+
+            privateSession.set(newSession);
+        } catch (NotFoundException e) {
+            LOG.error("No filters found", e);
+        }
     }
 
     @Override

--- a/graylog2-server/src/main/java/org/graylog2/filters/RulesFilter.java
+++ b/graylog2-server/src/main/java/org/graylog2/filters/RulesFilter.java
@@ -68,6 +68,7 @@ public class RulesFilter implements MessageFilter {
     }
 
     @Subscribe
+    @SuppressWarnings("unused")
     public void handleRulesUpdate(FilterDescriptionUpdateEvent ignored) {
         LOG.debug("Updating filter descriptions: {}", ignored);
         scheduler.schedule(this::loadRules, 0, TimeUnit.SECONDS);

--- a/graylog2-server/src/main/java/org/graylog2/filters/RulesFilter.java
+++ b/graylog2-server/src/main/java/org/graylog2/filters/RulesFilter.java
@@ -69,7 +69,7 @@ public class RulesFilter implements MessageFilter {
 
     @Subscribe
     public void handleRulesUpdate(FilterDescriptionUpdateEvent ignored) {
-        LOG.info("Updating filter descriptions: {}", ignored);
+        LOG.debug("Updating filter descriptions: {}", ignored);
         scheduler.schedule(this::loadRules, 0, TimeUnit.SECONDS);
     }
 

--- a/graylog2-server/src/main/java/org/graylog2/filters/RulesFilter.java
+++ b/graylog2-server/src/main/java/org/graylog2/filters/RulesFilter.java
@@ -29,7 +29,6 @@ import org.slf4j.LoggerFactory;
 import javax.inject.Inject;
 import javax.inject.Named;
 import java.util.concurrent.ScheduledExecutorService;
-import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 
 /**
@@ -71,7 +70,7 @@ public class RulesFilter implements MessageFilter {
     @SuppressWarnings("unused")
     public void handleRulesUpdate(FilterDescriptionUpdateEvent ignored) {
         LOG.debug("Updating filter descriptions: {}", ignored);
-        scheduler.schedule(this::loadRules, 0, TimeUnit.SECONDS);
+        scheduler.submit(this::loadRules);
     }
 
     private void loadRules() {

--- a/graylog2-server/src/main/java/org/graylog2/filters/StaticFieldFilter.java
+++ b/graylog2-server/src/main/java/org/graylog2/filters/StaticFieldFilter.java
@@ -32,6 +32,7 @@ import org.slf4j.LoggerFactory;
 
 import javax.inject.Inject;
 import javax.inject.Named;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
@@ -47,8 +48,6 @@ public class StaticFieldFilter implements MessageFilter {
     private static final Logger LOG = LoggerFactory.getLogger(StaticFieldFilter.class);
 
     private static final String NAME = "Static field appender";
-
-    private static final List<Map.Entry<String, String>> EMPTY = ImmutableList.of();
 
     private final ConcurrentMap<String, List<Map.Entry<String, String>>> staticFields = new ConcurrentHashMap<>();
 
@@ -73,7 +72,7 @@ public class StaticFieldFilter implements MessageFilter {
         if (msg.getSourceInputId() == null)
             return false;
 
-        for(final Map.Entry<String, String> field : staticFields.getOrDefault(msg.getSourceInputId(), EMPTY)) {
+        for(final Map.Entry<String, String> field : staticFields.getOrDefault(msg.getSourceInputId(), Collections.emptyList())) {
             if(!msg.hasField(field.getKey())) {
                 msg.addField(field.getKey(), field.getValue());
             } else {

--- a/graylog2-server/src/main/java/org/graylog2/filters/StaticFieldFilter.java
+++ b/graylog2-server/src/main/java/org/graylog2/filters/StaticFieldFilter.java
@@ -38,7 +38,6 @@ import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.ScheduledExecutorService;
-import java.util.concurrent.TimeUnit;
 
 /**
  * @author Lennart Koopmann <lennart@torch.sh>
@@ -87,7 +86,7 @@ public class StaticFieldFilter implements MessageFilter {
     @SuppressWarnings("unused")
     public void handleInputCreate(final InputCreated event) {
         LOG.debug("Load static fields for input <{}>", event.id());
-        scheduler.schedule(() -> loadStaticFields(event.id()), 0, TimeUnit.SECONDS);
+        scheduler.submit(() -> loadStaticFields(event.id()));
     }
 
     @Subscribe
@@ -100,7 +99,7 @@ public class StaticFieldFilter implements MessageFilter {
     @Subscribe
     @SuppressWarnings("unused")
     public void handleInputUpdate(final InputUpdated event) {
-        scheduler.schedule(() -> loadStaticFields(event.id()), 0, TimeUnit.SECONDS);
+        scheduler.submit(() -> loadStaticFields(event.id()));
     }
 
     private void loadAllStaticFields() {

--- a/graylog2-server/src/main/java/org/graylog2/filters/StaticFieldFilter.java
+++ b/graylog2-server/src/main/java/org/graylog2/filters/StaticFieldFilter.java
@@ -84,18 +84,21 @@ public class StaticFieldFilter implements MessageFilter {
     }
 
     @Subscribe
+    @SuppressWarnings("unused")
     public void handleInputCreate(final InputCreated event) {
         LOG.debug("Load static fields for input <{}>", event.id());
         scheduler.schedule(() -> loadStaticFields(event.id()), 0, TimeUnit.SECONDS);
     }
 
     @Subscribe
+    @SuppressWarnings("unused")
     public void handleInputDelete(final InputDeleted event) {
         LOG.debug("Removing input from static fields cache <{}>", event.id());
         staticFields.remove(event.id());
     }
 
     @Subscribe
+    @SuppressWarnings("unused")
     public void handleInputUpdate(final InputUpdated event) {
         scheduler.schedule(() -> loadStaticFields(event.id()), 0, TimeUnit.SECONDS);
     }

--- a/graylog2-server/src/main/java/org/graylog2/filters/StaticFieldFilter.java
+++ b/graylog2-server/src/main/java/org/graylog2/filters/StaticFieldFilter.java
@@ -16,22 +16,27 @@
  */
 package org.graylog2.filters;
 
-import com.google.common.cache.Cache;
-import com.google.common.cache.CacheBuilder;
+import com.google.common.collect.ImmutableList;
+import com.google.common.eventbus.EventBus;
+import com.google.common.eventbus.Subscribe;
 import org.graylog2.database.NotFoundException;
 import org.graylog2.inputs.Input;
 import org.graylog2.inputs.InputService;
 import org.graylog2.plugin.Message;
 import org.graylog2.plugin.filters.MessageFilter;
+import org.graylog2.rest.models.system.inputs.responses.InputCreated;
+import org.graylog2.rest.models.system.inputs.responses.InputDeleted;
+import org.graylog2.rest.models.system.inputs.responses.InputUpdated;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import javax.inject.Inject;
-import java.util.Collections;
+import javax.inject.Named;
 import java.util.List;
 import java.util.Map;
-import java.util.concurrent.Callable;
-import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 
 /**
@@ -43,15 +48,24 @@ public class StaticFieldFilter implements MessageFilter {
 
     private static final String NAME = "Static field appender";
 
-    private final Cache<String, List<Map.Entry<String, String>>> cache = CacheBuilder.newBuilder()
-            .expireAfterWrite(1, TimeUnit.SECONDS)
-            .build();
+    private static final List<Map.Entry<String, String>> EMPTY = ImmutableList.of();
+
+    private final ConcurrentMap<String, List<Map.Entry<String, String>>> staticFields = new ConcurrentHashMap<>();
 
     private final InputService inputService;
+    private final ScheduledExecutorService scheduler;
 
     @Inject
-    public StaticFieldFilter(InputService inputService) {
+    public StaticFieldFilter(InputService inputService,
+                             EventBus serverEventBus,
+                             @Named("daemonScheduler") ScheduledExecutorService scheduler) {
         this.inputService = inputService;
+        this.scheduler = scheduler;
+
+        loadAllStaticFields();
+
+        // TODO: This class needs lifecycle management to avoid leaking objects in the EventBus
+        serverEventBus.register(this);
     }
 
     @Override
@@ -59,7 +73,7 @@ public class StaticFieldFilter implements MessageFilter {
         if (msg.getSourceInputId() == null)
             return false;
 
-        for(final Map.Entry<String, String> field : loadStaticFields(msg.getSourceInputId())) {
+        for(final Map.Entry<String, String> field : staticFields.getOrDefault(msg.getSourceInputId(), EMPTY)) {
             if(!msg.hasField(field.getKey())) {
                 msg.addField(field.getKey(), field.getValue());
             } else {
@@ -70,24 +84,38 @@ public class StaticFieldFilter implements MessageFilter {
         return false;
     }
 
-    private List<Map.Entry<String, String>> loadStaticFields(final String inputId) {
+    @Subscribe
+    public void handleInputCreate(final InputCreated event) {
+        LOG.debug("Load static fields for input <{}>", event.id());
+        scheduler.schedule(() -> loadStaticFields(event.id()), 0, TimeUnit.SECONDS);
+    }
+
+    @Subscribe
+    public void handleInputDelete(final InputDeleted event) {
+        LOG.debug("Removing input from static fields cache <{}>", event.id());
+        staticFields.remove(event.id());
+    }
+
+    @Subscribe
+    public void handleInputUpdate(final InputUpdated event) {
+        scheduler.schedule(() -> loadStaticFields(event.id()), 0, TimeUnit.SECONDS);
+    }
+
+    private void loadAllStaticFields() {
         try {
-            return cache.get(inputId, new Callable<List<Map.Entry<String, String>>>() {
-                @Override
-                public List<Map.Entry<String, String>> call() throws Exception {
-                    LOG.debug("Re-loading static fields for input <{}> into cache.", inputId);
-                    try {
-                        final Input input = inputService.find(inputId);
-                        return inputService.getStaticFields(input);
-                    } catch (NotFoundException e) {
-                        LOG.warn("Unable to load input: {}", e.getMessage());
-                        return Collections.emptyList();
-                    }
-                }
-            });
-        } catch (ExecutionException e) {
-            LOG.error("Could not load static fields into cache. Returning empty list.", e);
-            return Collections.emptyList();
+            inputService.all().forEach(input -> loadStaticFields(input.getId()));
+        } catch (Exception e) {
+            LOG.error("Unable to load static fields for all inputs", e);
+        }
+    }
+
+    private void loadStaticFields(final String inputId) {
+        LOG.debug("Re-loading static fields for input <{}> into cache.", inputId);
+        try {
+            final Input input = inputService.find(inputId);
+            staticFields.put(inputId, ImmutableList.copyOf(inputService.getStaticFields(input)));
+        } catch (NotFoundException e) {
+            LOG.warn("Unable to load input: {}", e.getMessage());
         }
     }
 

--- a/graylog2-server/src/main/java/org/graylog2/filters/events/FilterDescriptionUpdateEvent.java
+++ b/graylog2-server/src/main/java/org/graylog2/filters/events/FilterDescriptionUpdateEvent.java
@@ -1,3 +1,19 @@
+/**
+ * This file is part of Graylog.
+ *
+ * Graylog is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package org.graylog2.filters.events;
 
 import com.fasterxml.jackson.annotation.JsonAutoDetect;

--- a/graylog2-server/src/main/java/org/graylog2/filters/events/FilterDescriptionUpdateEvent.java
+++ b/graylog2-server/src/main/java/org/graylog2/filters/events/FilterDescriptionUpdateEvent.java
@@ -1,0 +1,20 @@
+package org.graylog2.filters.events;
+
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.auto.value.AutoValue;
+
+@JsonAutoDetect
+@AutoValue
+public abstract class FilterDescriptionUpdateEvent {
+    private static final String FIELD_ID = "id";
+
+    @JsonProperty(FIELD_ID)
+    public abstract String id();
+
+    @JsonCreator
+    public static FilterDescriptionUpdateEvent create(@JsonProperty(FIELD_ID) String id) {
+        return new AutoValue_FilterDescriptionUpdateEvent(id);
+    }
+}

--- a/graylog2-server/src/main/java/org/graylog2/inputs/InputServiceImpl.java
+++ b/graylog2-server/src/main/java/org/graylog2/inputs/InputServiceImpl.java
@@ -200,6 +200,7 @@ public class InputServiceImpl extends PersistedServiceImpl implements InputServi
         };
 
         embed(input, InputImpl.EMBEDDED_STATIC_FIELDS, obj);
+        publishChange(InputUpdated.create(input.getId()));
     }
 
     @Override
@@ -317,6 +318,7 @@ public class InputServiceImpl extends PersistedServiceImpl implements InputServi
     @Override
     public void removeStaticField(Input input, String key) {
         removeEmbedded(input, InputImpl.FIELD_STATIC_FIELD_KEY, InputImpl.EMBEDDED_STATIC_FIELDS, key);
+        publishChange(InputUpdated.create(input.getId()));
     }
 
     @Override

--- a/graylog2-server/src/main/java/org/graylog2/inputs/InputServiceImpl.java
+++ b/graylog2-server/src/main/java/org/graylog2/inputs/InputServiceImpl.java
@@ -33,6 +33,7 @@ import org.graylog2.database.NotFoundException;
 import org.graylog2.database.PersistedServiceImpl;
 import org.graylog2.events.ClusterEventBus;
 import org.graylog2.inputs.converters.ConverterFactory;
+import org.graylog2.rest.models.system.inputs.responses.InputUpdated;
 import org.graylog2.inputs.extractors.ExtractorFactory;
 import org.graylog2.plugin.configuration.Configuration;
 import org.graylog2.plugin.database.EmbeddedPersistable;
@@ -184,6 +185,7 @@ public class InputServiceImpl extends PersistedServiceImpl implements InputServi
     @Override
     public void addExtractor(Input input, Extractor extractor) throws ValidationException {
         embed(input, InputImpl.EMBEDDED_EXTRACTORS, extractor);
+        publishChange(InputUpdated.create(input.getId()));
     }
 
     @Override
@@ -309,6 +311,7 @@ public class InputServiceImpl extends PersistedServiceImpl implements InputServi
     @Override
     public void removeExtractor(Input input, String extractorId) {
         removeEmbedded(input, InputImpl.EMBEDDED_EXTRACTORS, extractorId);
+        publishChange(InputUpdated.create(input.getId()));
     }
 
     @Override

--- a/graylog2-server/src/main/java/org/graylog2/rest/models/system/inputs/responses/InputUpdated.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/models/system/inputs/responses/InputUpdated.java
@@ -1,0 +1,34 @@
+/**
+ * This file is part of Graylog.
+ *
+ * Graylog is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.graylog2.rest.models.system.inputs.responses;
+
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.auto.value.AutoValue;
+
+@JsonAutoDetect
+@AutoValue
+public abstract class InputUpdated {
+    @JsonProperty
+    public abstract String id();
+
+    @JsonCreator
+    public static InputUpdated create(@JsonProperty("id") String inputId) {
+        return new AutoValue_InputUpdated(inputId);
+    }
+}

--- a/graylog2-server/src/main/java/org/graylog2/rest/resources/streams/outputs/StreamOutputResource.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/resources/streams/outputs/StreamOutputResource.java
@@ -26,6 +26,7 @@ import org.apache.shiro.authz.annotation.RequiresAuthentication;
 import org.apache.shiro.authz.annotation.RequiresPermissions;
 import org.graylog2.auditlog.jersey.AuditLog;
 import org.graylog2.database.NotFoundException;
+import org.graylog2.events.ClusterEventBus;
 import org.graylog2.outputs.OutputRegistry;
 import org.graylog2.plugin.database.ValidationException;
 import org.graylog2.plugin.streams.Output;
@@ -37,6 +38,7 @@ import org.graylog2.shared.rest.resources.RestResource;
 import org.graylog2.shared.security.RestPermissions;
 import org.graylog2.streams.OutputService;
 import org.graylog2.streams.StreamService;
+import org.graylog2.streams.events.StreamsChangedEvent;
 import org.joda.time.DateTime;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -66,12 +68,17 @@ public class StreamOutputResource extends RestResource {
     private final OutputService outputService;
     private final StreamService streamService;
     private final OutputRegistry outputRegistry;
+    private final ClusterEventBus clusterEventBus;
 
     @Inject
-    public StreamOutputResource(OutputService outputService, StreamService streamService, OutputRegistry outputRegistry) {
+    public StreamOutputResource(OutputService outputService,
+                                StreamService streamService,
+                                OutputRegistry outputRegistry,
+                                ClusterEventBus clusterEventBus) {
         this.outputService = outputService;
         this.streamService = streamService;
         this.outputRegistry = outputRegistry;
+        this.clusterEventBus = clusterEventBus;
     }
 
     @GET
@@ -143,6 +150,7 @@ public class StreamOutputResource extends RestResource {
         for (String outputId : aor.outputs()) {
             final Output output = outputService.load(outputId);
             streamService.addOutput(stream, output);
+            clusterEventBus.post(StreamsChangedEvent.create(stream.getId()));
         }
 
         return Response.accepted().build();
@@ -167,5 +175,6 @@ public class StreamOutputResource extends RestResource {
 
         streamService.removeOutput(stream, output);
         outputRegistry.removeOutput(output);
+        clusterEventBus.post(StreamsChangedEvent.create(stream.getId()));
     }
 }

--- a/graylog2-server/src/main/java/org/graylog2/streams/StreamRouter.java
+++ b/graylog2-server/src/main/java/org/graylog2/streams/StreamRouter.java
@@ -33,7 +33,6 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ThreadFactory;
-import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 
 /**
@@ -69,7 +68,7 @@ public class StreamRouter {
     @Subscribe
     @SuppressWarnings("unused")
     public void handleStreamsUpdate(StreamsChangedEvent event) {
-        scheduler.schedule(engineUpdater, 0, TimeUnit.SECONDS);
+        scheduler.submit(engineUpdater);
     }
 
     private ExecutorService executorService() {

--- a/graylog2-server/src/main/java/org/graylog2/streams/StreamRouter.java
+++ b/graylog2-server/src/main/java/org/graylog2/streams/StreamRouter.java
@@ -16,15 +16,18 @@
  */
 package org.graylog2.streams;
 
+import com.google.common.eventbus.EventBus;
+import com.google.common.eventbus.Subscribe;
 import com.google.common.util.concurrent.ThreadFactoryBuilder;
-import javax.inject.Named;
 import org.graylog2.plugin.Message;
 import org.graylog2.plugin.ServerStatus;
 import org.graylog2.plugin.streams.Stream;
+import org.graylog2.streams.events.StreamsChangedEvent;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import javax.inject.Inject;
+import javax.inject.Named;
 import java.util.List;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
@@ -39,24 +42,33 @@ import java.util.concurrent.atomic.AtomicReference;
 public class StreamRouter {
     private static final Logger LOG = LoggerFactory.getLogger(StreamRouter.class);
 
-    private static final long ENGINE_UPDATE_INTERVAL = 1L;
-
     protected final StreamService streamService;
     private final ServerStatus serverStatus;
+    private final ScheduledExecutorService scheduler;
 
     private final AtomicReference<StreamRouterEngine> routerEngine = new AtomicReference<>(null);
+    private final StreamRouterEngineUpdater engineUpdater;
 
     @Inject
     public StreamRouter(StreamService streamService,
                         ServerStatus serverStatus,
                         StreamRouterEngine.Factory routerEngineFactory,
+                        EventBus serverEventBus,
                         @Named("daemonScheduler") ScheduledExecutorService scheduler) {
         this.streamService = streamService;
         this.serverStatus = serverStatus;
+        this.scheduler = scheduler;
 
-        final StreamRouterEngineUpdater streamRouterEngineUpdater = new StreamRouterEngineUpdater(routerEngine, routerEngineFactory, streamService, executorService());
-        this.routerEngine.set(streamRouterEngineUpdater.getNewEngine());
-        scheduler.scheduleAtFixedRate(streamRouterEngineUpdater, 0, ENGINE_UPDATE_INTERVAL, TimeUnit.SECONDS);
+        this.engineUpdater = new StreamRouterEngineUpdater(routerEngine, routerEngineFactory, streamService, executorService());
+        this.routerEngine.set(engineUpdater.getNewEngine());
+
+        // TODO: This class needs lifecycle management to avoid leaking objects in the EventBus
+        serverEventBus.register(this);
+    }
+
+    @Subscribe
+    public void handleStreamsUpdate(StreamsChangedEvent event) {
+        scheduler.schedule(engineUpdater, 0, TimeUnit.SECONDS);
     }
 
     private ExecutorService executorService() {

--- a/graylog2-server/src/main/java/org/graylog2/streams/StreamRouter.java
+++ b/graylog2-server/src/main/java/org/graylog2/streams/StreamRouter.java
@@ -67,6 +67,7 @@ public class StreamRouter {
     }
 
     @Subscribe
+    @SuppressWarnings("unused")
     public void handleStreamsUpdate(StreamsChangedEvent event) {
         scheduler.schedule(engineUpdater, 0, TimeUnit.SECONDS);
     }

--- a/graylog2-server/src/main/java/org/graylog2/streams/events/StreamsChangedEvent.java
+++ b/graylog2-server/src/main/java/org/graylog2/streams/events/StreamsChangedEvent.java
@@ -1,0 +1,63 @@
+/**
+ * This file is part of Graylog.
+ *
+ * Graylog is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.graylog2.streams.events;
+
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.google.auto.value.AutoValue;
+import com.google.common.collect.ImmutableSet;
+
+import java.util.Set;
+
+@JsonAutoDetect
+@JsonDeserialize(builder = AutoValue_StreamsChangedEvent.Builder.class)
+@AutoValue
+public abstract class StreamsChangedEvent {
+    private static final String FIELD_STREAM_IDS = "stream_ids";
+
+    @JsonProperty(FIELD_STREAM_IDS)
+    public abstract ImmutableSet<String> streamIds();
+
+    public static StreamsChangedEvent create(String streamId) {
+        return builder().addStreamId(streamId).build();
+    }
+
+    public static Builder builder() {
+        return new AutoValue_StreamsChangedEvent.Builder();
+    }
+
+    public abstract Builder toBuilder();
+
+    @AutoValue.Builder
+    public static abstract class Builder {
+        @JsonProperty(FIELD_STREAM_IDS)
+        public Builder addStreamIds(Set<String> streamIds) {
+            streamIdsBuilder().addAll(streamIds);
+            return this;
+        }
+
+        public Builder addStreamId(String streamId) {
+            streamIdsBuilder().add(streamId);
+            return this;
+        }
+
+        abstract ImmutableSet.Builder<String> streamIdsBuilder();
+
+        public abstract StreamsChangedEvent build();
+    }
+}

--- a/graylog2-server/src/main/java/org/graylog2/streams/events/StreamsChangedEvent.java
+++ b/graylog2-server/src/main/java/org/graylog2/streams/events/StreamsChangedEvent.java
@@ -17,15 +17,12 @@
 package org.graylog2.streams.events;
 
 import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.google.auto.value.AutoValue;
 import com.google.common.collect.ImmutableSet;
 
-import java.util.Set;
-
 @JsonAutoDetect
-@JsonDeserialize(builder = AutoValue_StreamsChangedEvent.Builder.class)
 @AutoValue
 public abstract class StreamsChangedEvent {
     private static final String FIELD_STREAM_IDS = "stream_ids";
@@ -33,31 +30,12 @@ public abstract class StreamsChangedEvent {
     @JsonProperty(FIELD_STREAM_IDS)
     public abstract ImmutableSet<String> streamIds();
 
+    @JsonCreator
+    public static StreamsChangedEvent create(@JsonProperty(FIELD_STREAM_IDS) ImmutableSet<String> streamIds) {
+        return new AutoValue_StreamsChangedEvent(streamIds);
+    }
+
     public static StreamsChangedEvent create(String streamId) {
-        return builder().addStreamId(streamId).build();
-    }
-
-    public static Builder builder() {
-        return new AutoValue_StreamsChangedEvent.Builder();
-    }
-
-    public abstract Builder toBuilder();
-
-    @AutoValue.Builder
-    public static abstract class Builder {
-        @JsonProperty(FIELD_STREAM_IDS)
-        public Builder addStreamIds(Set<String> streamIds) {
-            streamIdsBuilder().addAll(streamIds);
-            return this;
-        }
-
-        public Builder addStreamId(String streamId) {
-            streamIdsBuilder().add(streamId);
-            return this;
-        }
-
-        abstract ImmutableSet.Builder<String> streamIdsBuilder();
-
-        public abstract StreamsChangedEvent build();
+        return create(ImmutableSet.of(streamId));
     }
 }

--- a/graylog2-server/src/test/java/org/graylog2/filters/StaticFieldFilterTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/filters/StaticFieldFilterTest.java
@@ -18,6 +18,7 @@ package org.graylog2.filters;
 
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
+import com.google.common.eventbus.EventBus;
 import org.graylog2.inputs.Input;
 import org.graylog2.inputs.InputService;
 import org.graylog2.plugin.Message;
@@ -26,6 +27,8 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
+
+import java.util.concurrent.Executors;
 
 import static org.junit.Assert.assertEquals;
 import static org.mockito.Matchers.eq;
@@ -43,11 +46,13 @@ public class StaticFieldFilterTest {
         Message msg = new Message("hello", "junit", Tools.nowUTC());
         msg.setSourceInputId("someid");
 
+        when(input.getId()).thenReturn("someid");
+        when(inputService.all()).thenReturn(Lists.newArrayList(input));
         when(inputService.find(eq("someid"))).thenReturn(input);
         when(inputService.getStaticFields(eq(input)))
                 .thenReturn(Lists.newArrayList(Maps.immutableEntry("foo", "bar")));
 
-        final StaticFieldFilter filter = new StaticFieldFilter(inputService);
+        final StaticFieldFilter filter = new StaticFieldFilter(inputService, new EventBus(), Executors.newSingleThreadScheduledExecutor());
         filter.filter(msg);
 
         assertEquals("hello", msg.getMessage());
@@ -64,7 +69,7 @@ public class StaticFieldFilterTest {
         when(inputService.getStaticFields(eq(input)))
                 .thenReturn(Lists.newArrayList(Maps.immutableEntry("foo", "bar")));
 
-        final StaticFieldFilter filter = new StaticFieldFilter(inputService);
+        final StaticFieldFilter filter = new StaticFieldFilter(inputService, new EventBus(), Executors.newSingleThreadScheduledExecutor());
         filter.filter(msg);
 
         assertEquals("hello", msg.getMessage());


### PR DESCRIPTION
Switch all `MessageFilter` implementations from polling for changes every second to subscribing to change events.

This avoids unneeded load on the Graylog and MongoDB servers.

Fixes #2391 