### PR TITLE
Adds basic garbage collection statistics to node info

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/shared/bindings/providers/MetricRegistryProvider.java
+++ b/graylog2-server/src/main/java/org/graylog2/shared/bindings/providers/MetricRegistryProvider.java
@@ -22,6 +22,7 @@ import com.codahale.metrics.jvm.ClassLoadingGaugeSet;
 import com.codahale.metrics.jvm.GarbageCollectorMetricSet;
 import com.codahale.metrics.jvm.MemoryUsageGaugeSet;
 import com.codahale.metrics.jvm.ThreadStatesGaugeSet;
+import org.graylog2.shared.utilities.AggregatedGarbageCollectorMetricSet;
 
 import javax.inject.Provider;
 import javax.inject.Singleton;
@@ -37,6 +38,7 @@ public class MetricRegistryProvider implements Provider<MetricRegistry> {
         metricRegistry.register("jvm.buffers", new BufferPoolMetricSet(ManagementFactory.getPlatformMBeanServer()));
         metricRegistry.register("jvm.cl", new ClassLoadingGaugeSet());
         metricRegistry.register("jvm.gc", new GarbageCollectorMetricSet());
+        metricRegistry.register("jvm.gc.summary", new AggregatedGarbageCollectorMetricSet());
         metricRegistry.register("jvm.memory", new MemoryUsageGaugeSet());
         metricRegistry.register("jvm.threads", new ThreadStatesGaugeSet());
     }

--- a/graylog2-server/src/main/java/org/graylog2/shared/utilities/AggregatedGarbageCollectorMetricSet.java
+++ b/graylog2-server/src/main/java/org/graylog2/shared/utilities/AggregatedGarbageCollectorMetricSet.java
@@ -1,0 +1,76 @@
+/**
+ * This file is part of Graylog.
+ *
+ * Graylog is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.graylog2.shared.utilities;
+
+import com.codahale.metrics.Gauge;
+import com.codahale.metrics.Metric;
+import com.codahale.metrics.MetricRegistry;
+import com.codahale.metrics.MetricSet;
+import java.lang.management.GarbageCollectorMXBean;
+import java.lang.management.ManagementFactory;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Returns aggregated GC status.
+ *
+ * {@link java.lang.management.ManagementFactory#getGarbageCollectorMXBeans()} typically returns several garbage
+ * collectors that must be queried separately. This class aggregates sums of the available statistics.
+ *
+ * Notes:
+ * <ul>
+ *     <li>GarbageCollectorMXBean does not report for how long the world has been stopped during GC</li>
+ *     <li>More detailed information is required for debugging memory management issues</li>
+ *     <li>verbosegc is probably still the best bet for getting detailed, and reliable information</li>
+ *     <li>It is not guaranteed that all nodes in Graylog cluster use the same garbage collector</li>
+ * </ul>
+ *
+ */
+public class AggregatedGarbageCollectorMetricSet implements MetricSet {
+    private final List<GarbageCollectorMXBean> garbageCollectors;
+
+    public AggregatedGarbageCollectorMetricSet() {
+        this(ManagementFactory.getGarbageCollectorMXBeans());
+    }
+
+    public AggregatedGarbageCollectorMetricSet(Collection<GarbageCollectorMXBean> garbageCollectors) {
+        this.garbageCollectors = new ArrayList(garbageCollectors);
+    }
+
+    public Map<String, Metric> getMetrics() {
+        HashMap gauges = new HashMap();
+
+        gauges.put(MetricRegistry.name("count"), new Gauge() {
+            public Long getValue() {
+                return garbageCollectors.stream().mapToLong(GarbageCollectorMXBean::getCollectionCount).sum();
+            }
+        });
+
+        gauges.put(MetricRegistry.name("time"), new Gauge() {
+            public Long getValue() {
+                return garbageCollectors.stream().mapToLong(GarbageCollectorMXBean::getCollectionTime).sum();
+            }
+        });
+
+        return Collections.unmodifiableMap(gauges);
+
+    }
+}

--- a/graylog2-web-interface/package.json
+++ b/graylog2-web-interface/package.json
@@ -25,6 +25,7 @@
     "dc": "2.0.0-beta.19",
     "graylog-web-plugin": "latest",
     "history": "^1.17.0",
+    "humanize-duration": "^3.9.0",
     "immutable": "^3.7.5",
     "javascript-natural-sort": "^0.7.1",
     "jquery": "2.1.x",

--- a/graylog2-web-interface/src/components/nodes/JvmHeapUsage.jsx
+++ b/graylog2-web-interface/src/components/nodes/JvmHeapUsage.jsx
@@ -4,6 +4,8 @@ import { ProgressBar } from 'react-bootstrap';
 
 import { Spinner } from 'components/common';
 
+import humanizeDuration from 'humanize-duration'
+
 import NumberUtils from 'util/NumberUtils';
 import MetricsExtractor from 'logic/metrics/MetricsExtractor';
 
@@ -23,6 +25,8 @@ const JvmHeapUsage = React.createClass({
       usedMemory: 'jvm.memory.heap.used',
       committedMemory: 'jvm.memory.heap.committed',
       maxMemory: 'jvm.memory.heap.max',
+      gcCount: 'jvm.gc.summary.count',
+      gcTime: 'jvm.gc.summary.time',
     };
 
     Object.keys(this.metricNames).forEach(metricShortName => MetricsActions.add(this.props.nodeId, this.metricNames[metricShortName]));
@@ -59,17 +63,26 @@ const JvmHeapUsage = React.createClass({
         );
 
         detail = (
-          <p>
-            The JVM is using{' '}
-            <span className="blob used-memory"/>
-            <strong> {NumberUtils.formatBytes(metrics.usedMemory)}</strong>
-            {' '}of{' '}
-            <span className="blob committed-memory"/>
-            <strong> {NumberUtils.formatBytes(metrics.committedMemory)}</strong>
-            {' '}heap space and will not attempt to use more than{' '}
-            <span className="blob max-memory" style={{border: '1px solid #ccc'}}/>
-            <strong> {NumberUtils.formatBytes(metrics.maxMemory)}</strong>
-          </p>
+          <div>
+            <p>
+              The JVM is using{' '}
+              <span className="blob used-memory"/>
+              <strong> {NumberUtils.formatBytes(metrics.usedMemory)}</strong>
+              {' '}of{' '}
+              <span className="blob committed-memory"/>
+              <strong> {NumberUtils.formatBytes(metrics.committedMemory)}</strong>
+              {' '}heap space and will not attempt to use more than{' '}
+              <span className="blob max-memory" style={{border: '1px solid #ccc'}}/>
+              <strong> {NumberUtils.formatBytes(metrics.maxMemory)}</strong>
+            </p>
+            <p>
+              Garbage collected
+              <strong> {metrics.gcCount} </strong>
+              times taking
+              <strong> {humanizeDuration(metrics.gcTime)} </strong>
+              in total
+            </p>
+          </div>
         );
       }
     } else {


### PR DESCRIPTION
Closes #154 by adding garbage collection counter and spent time to node information.

![feat](https://cloud.githubusercontent.com/assets/7376695/16925676/0648cbe6-4d2e-11e6-8bc1-4d513cfcfcf9.png)

The implementation aggregates information server side for the following reasons:

- The GC MXBean reports typically several garbage collectors that have to be queried separately
- The previous leads to Metrics like jvm.gc.ParNew.* and jvm.gc.ConcurrentMarkSweep.*
- Nodes are not guaranteed to use similar garbage collectors
- Aggregation server side is probably slightly less complex, and may be beneficial elsewhere

Lumped the client side implementation to JVM heap information, because it is closely related.

It should be noted that for detailed analysis enabling verbosegc is still probably the best tool available. Information obtainable from the GC MXBean may alert only to certain simple issues ("why is my GC running continuously?", or "why is my garbage collection time climbing up that fast?")

