### PR TITLE
Fixing session validation propagation.

### DIFF
--- a/graylog2-web-interface/src/stores/sessions/SessionStore.js
+++ b/graylog2-web-interface/src/stores/sessions/SessionStore.js
@@ -49,7 +49,7 @@ const SessionStore = Reflux.createStore({
     const username = Store.get('username');
     this._validateSession(sessionId).then((response) => {
       if (response.is_valid) {
-        this.loginCompleted({
+        SessionActions.login.completed({
           sessionId: sessionId || response.session_id,
           username: username || response.username,
         });


### PR DESCRIPTION
When a store is initialising before the `SessionStore` is finished validating an existing session, it is listening on `SessionActions.login.completed`. Unfortunately this was not working in certain cases when there was a race between the promise validating the session and the initial call to `SessionStore.isLoggedIn()` in `FetchProvider.json()`.

This is fixed by explicitly triggering the `loginCompleted` action, which is also taking over the state propagation in the store.