### PR TITLE
Add option to only use named captures in Grok extractor

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/inputs/extractors/GrokExtractor.java
+++ b/graylog2-server/src/main/java/org/graylog2/inputs/extractors/GrokExtractor.java
@@ -33,8 +33,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
-import static com.google.common.base.MoreObjects.firstNonNull;
-
 public class GrokExtractor extends Extractor {
     private static final Logger log = LoggerFactory.getLogger(GrokExtractor.class);
 
@@ -70,7 +68,7 @@ public class GrokExtractor extends Extractor {
             throw new ConfigurationException("grok_pattern not set");
         }
 
-        final boolean namedCapturesOnly = firstNonNull((Boolean) extractorConfig.get("named_captures_only"), false);
+        final boolean namedCapturesOnly = (boolean) extractorConfig.getOrDefault("named_captures_only", false);
 
         try {
             // TODO we should really share this somehow, but unfortunately the extractors are reloaded every second.

--- a/graylog2-server/src/main/java/org/graylog2/inputs/extractors/GrokExtractor.java
+++ b/graylog2-server/src/main/java/org/graylog2/inputs/extractors/GrokExtractor.java
@@ -33,6 +33,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
+import static com.google.common.base.MoreObjects.firstNonNull;
+
 public class GrokExtractor extends Extractor {
     private static final Logger log = LoggerFactory.getLogger(GrokExtractor.class);
 
@@ -68,13 +70,15 @@ public class GrokExtractor extends Extractor {
             throw new ConfigurationException("grok_pattern not set");
         }
 
+        final boolean namedCapturesOnly = firstNonNull((Boolean) extractorConfig.get("named_captures_only"), false);
+
         try {
             // TODO we should really share this somehow, but unfortunately the extractors are reloaded every second.
             for (final GrokPattern grokPattern : grokPatterns) {
                 grok.addPattern(grokPattern.name, grokPattern.pattern);
             }
 
-            grok.compile((String) extractorConfig.get("grok_pattern"));
+            grok.compile((String) extractorConfig.get("grok_pattern"), namedCapturesOnly);
         } catch (GrokException e) {
             log.error("Unable to parse grok patterns", e);
             throw new ConfigurationException("Unable to parse grok patterns");

--- a/graylog2-server/src/main/java/org/graylog2/rest/models/tools/requests/GrokTestRequest.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/models/tools/requests/GrokTestRequest.java
@@ -31,9 +31,13 @@ public abstract class GrokTestRequest {
     @JsonProperty
     public abstract String pattern();
 
+    @JsonProperty("named_captures_only")
+    public abstract boolean namedCapturesOnly();
+
     @JsonCreator
     public static GrokTestRequest create(@JsonProperty("string") String string,
-                                         @JsonProperty("pattern") String pattern) {
-        return new AutoValue_GrokTestRequest(string, pattern);
+                                         @JsonProperty("pattern") String pattern,
+                                         @JsonProperty("named_captures_only") boolean namedCapturesOnly) {
+        return new AutoValue_GrokTestRequest(string, pattern, namedCapturesOnly);
     }
 }

--- a/graylog2-server/src/main/java/org/graylog2/rest/resources/tools/GrokTesterResource.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/resources/tools/GrokTesterResource.java
@@ -59,9 +59,10 @@ public class GrokTesterResource extends RestResource {
     @GET
     @Timed
     public GrokTesterResponse grokTest(@QueryParam("pattern") @NotEmpty String pattern,
-                                       @QueryParam("string") @NotNull String string) throws GrokException {
+                                       @QueryParam("string") @NotNull String string,
+                                       @QueryParam("named_captures_only") @NotNull boolean namedCapturesOnly) throws GrokException {
 
-        return doTestGrok(string, pattern);
+        return doTestGrok(string, pattern, namedCapturesOnly);
     }
 
     @POST
@@ -69,10 +70,10 @@ public class GrokTesterResource extends RestResource {
     @Consumes(MediaType.APPLICATION_JSON)
     @Produces(MediaType.APPLICATION_JSON)
     public GrokTesterResponse testGrok(@Valid @NotNull GrokTestRequest grokTestRequest) throws GrokException {
-        return doTestGrok(grokTestRequest.string(), grokTestRequest.pattern());
+        return doTestGrok(grokTestRequest.string(), grokTestRequest.pattern(), grokTestRequest.namedCapturesOnly());
     }
 
-    private GrokTesterResponse doTestGrok(String string, String pattern) throws GrokException {
+    private GrokTesterResponse doTestGrok(String string, String pattern, boolean namedCapturesOnly) throws GrokException {
         final Set<GrokPattern> grokPatterns = grokPatternService.loadAll();
 
         final Grok grok = new Grok();
@@ -80,7 +81,7 @@ public class GrokTesterResource extends RestResource {
             grok.addPattern(grokPattern.name, grokPattern.pattern);
         }
 
-        grok.compile(pattern);
+        grok.compile(pattern, namedCapturesOnly);
         final Match match = grok.match(string);
         match.captures();
         final Map<String, Object> matches = match.toMap();

--- a/graylog2-web-interface/src/components/extractors/extractors_configuration/GrokExtractorConfiguration.jsx
+++ b/graylog2-web-interface/src/components/extractors/extractors_configuration/GrokExtractorConfiguration.jsx
@@ -32,7 +32,7 @@ const GrokExtractorConfiguration = React.createClass({
   _onTryClick() {
     this.setState({trying: true});
 
-    const promise = ToolsStore.testGrok(this.props.configuration.grok_pattern, this.props.exampleMessage);
+    const promise = ToolsStore.testGrok(this.props.configuration.grok_pattern, this.props.configuration.named_captures_only, this.props.exampleMessage);
     promise.then(result => {
       if (!result.matched) {
         UserNotification.warning('We were not able to run the grok extraction. Please check your parameters.');
@@ -64,6 +64,14 @@ const GrokExtractorConfiguration = React.createClass({
 
     return (
       <div>
+        <Input type="checkbox"
+               id="named_captures_only"
+               label="Named captures only"
+               wrapperClassName="col-md-offset-2 col-md-10"
+               defaultChecked={this.props.configuration.named_captures_only}
+               onChange={this._onChange('named_captures_only')}
+               help="Only put the explicitly named captures into the message."/>
+
         <Input id="grok_pattern"
                label="Grok pattern"
                labelClassName="col-md-2"

--- a/graylog2-web-interface/src/stores/tools/ToolsStore.ts
+++ b/graylog2-web-interface/src/stores/tools/ToolsStore.ts
@@ -19,9 +19,9 @@ const ToolsStore = {
 
         return promise;
     },
-    testGrok(pattern: string, string: string): Promise<Object> {
+    testGrok(pattern: string, namedCapturesOnly: boolean, string: string): Promise<Object> {
         const url = ApiRoutes.ToolsApiController.grokTest().url;
-        const promise = fetch('POST', URLUtils.qualifyUrl(url), {pattern: pattern, string: string});
+        const promise = fetch('POST', URLUtils.qualifyUrl(url), {pattern: pattern, string: string, named_captures_only: namedCapturesOnly});
 
         promise.catch((errorThrown) => {
             UserNotification.error('Details: ' + errorThrown,

--- a/pom.xml
+++ b/pom.xml
@@ -641,7 +641,13 @@
             <dependency>
                 <groupId>org.graylog2.repackaged</groupId>
                 <artifactId>grok</artifactId>
-                <version>0.1.3-graylog</version>
+                <version>0.1.6-graylog</version>
+            </dependency>
+            <dependency>
+                <groupId>com.github.tony19</groupId>
+                <artifactId>named-regexp</artifactId>
+                <version>0.2.3</version>
+                <scope>compile</scope>
             </dependency>
             <dependency>
                 <groupId>io.swagger</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -644,12 +644,6 @@
                 <version>0.1.6-graylog</version>
             </dependency>
             <dependency>
-                <groupId>com.github.tony19</groupId>
-                <artifactId>named-regexp</artifactId>
-                <version>0.2.3</version>
-                <scope>compile</scope>
-            </dependency>
-            <dependency>
                 <groupId>io.swagger</groupId>
                 <artifactId>swagger-annotations</artifactId>
                 <version>${swagger.version}</version>


### PR DESCRIPTION
Update to the latest version of our java-grok port which adds support for this via upstream.

The option is disabled by default.

Fixes #1486 

Example screenshots:

![screenshot from 2016-07-19 16 12 54](https://cloud.githubusercontent.com/assets/461/16953222/8d6244b0-4dcc-11e6-94a1-96e845378343.png)
![screenshot from 2016-07-19 16 12 36](https://cloud.githubusercontent.com/assets/461/16953227/9120c202-4dcc-11e6-98d1-43b7cc80c364.png)
