### PR TITLE
Increase interval of ClusterEventCleanupPeriodical to 1 day

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/events/ClusterEventCleanupPeriodical.java
+++ b/graylog2-server/src/main/java/org/graylog2/events/ClusterEventCleanupPeriodical.java
@@ -40,7 +40,7 @@ public class ClusterEventCleanupPeriodical extends Periodical {
     private static final String COLLECTION_NAME = ClusterEventPeriodical.COLLECTION_NAME;
 
     @VisibleForTesting
-    static final long DEFAULT_MAX_EVENT_AGE = TimeUnit.HOURS.toMillis(1L);
+    static final long DEFAULT_MAX_EVENT_AGE = TimeUnit.DAYS.toMillis(1L);
 
     private final JacksonDBCollection<ClusterEvent, String> dbCollection;
     private final long maxEventAge;
@@ -89,7 +89,7 @@ public class ClusterEventCleanupPeriodical extends Periodical {
 
     @Override
     public int getPeriodSeconds() {
-        return Ints.saturatedCast(TimeUnit.MINUTES.toSeconds(5L));
+        return Ints.saturatedCast(TimeUnit.DAYS.toSeconds(1L));
     }
 
     @Override


### PR DESCRIPTION
In order to give Graylog nodes a longer time to actually receive and process events sent over the cluster event bus™, this PR increases the maximum TTL of events from 5 minutes (run interval) 1 hour (max age) to 1 day.