### PR TITLE
Always trim message field values on Message class

### DIFF
--- a/UPGRADING.rst
+++ b/UPGRADING.rst
@@ -62,3 +62,10 @@ Changed Elasticsearch Cluster Status Behavior
 In previous versions Graylog stopped indexing into the current write index if the `Elasticsearch cluster status <http://docs.graylog.org/en/2.1/pages/configuration/elasticsearch.html#cluster-status-explained>`_ turned RED. Since 2.1 Graylog only checks the status of the current write index when it tries to index messages.
 
 If the current write index is GREEN or YELLOW, Graylog will continue to index messages even though the overall cluster status is RED. This avoids Graylog downtimes when doing Elasticsearch maintenance or when older indices have problems.
+
+Changes in message field values trimming
+----------------------------------------
+
+Previous versions of Graylog were trimming message field values inconsistently, depending on the codec used. We have changed that behaviour in 2.1, so all message field values are trimmed by default.
+
+**Important**: This change will break your existing stream rules, extractors, and Drool rules if you are expecting leading or trailing white spaces in them. Please adapt them so they do not require those white spaces.

--- a/UPGRADING.rst
+++ b/UPGRADING.rst
@@ -66,6 +66,6 @@ If the current write index is GREEN or YELLOW, Graylog will continue to index me
 Changes in message field values trimming
 ----------------------------------------
 
-Previous versions of Graylog were trimming message field values inconsistently, depending on the codec used. We have changed that behaviour in 2.1, so all message field values are trimmed by default.
+Previous versions of Graylog were trimming message field values inconsistently, depending on the codec used. We have changed that behaviour in 2.1, so all message field values are trimmed by default. This means that leading or trailing whitespace of every field is removed during ingestion.
 
 **Important**: This change will break your existing stream rules, extractors, and Drool rules if you are expecting leading or trailing white spaces in them. Please adapt them so they do not require those white spaces.

--- a/graylog2-server/src/main/java/org/graylog2/plugin/Message.java
+++ b/graylog2-server/src/main/java/org/graylog2/plugin/Message.java
@@ -129,7 +129,6 @@ public class Message implements Messages {
     private ArrayList<Recording> recordings;
 
     public Message(final String message, final String source, final DateTime timestamp) {
-        // Adding the fields directly because they would not be accepted as a reserved fields.
         fields.put(FIELD_ID, new UUID().toString());
         addRequiredField(FIELD_MESSAGE, message);
         addRequiredField(FIELD_SOURCE, source);
@@ -304,24 +303,26 @@ public class Message implements Messages {
     }
 
     private void addField(final String key, final Object value, final boolean isRequiredField) {
+        final String trimmedKey = key.trim();
+
         // Don't accept protected keys. (some are allowed though lol)
-        if (RESERVED_FIELDS.contains(key) && !RESERVED_SETTABLE_FIELDS.contains(key) || !validKey(key)) {
+        if (RESERVED_FIELDS.contains(trimmedKey) && !RESERVED_SETTABLE_FIELDS.contains(trimmedKey) || !validKey(trimmedKey)) {
             if (LOG.isDebugEnabled()) {
-                LOG.debug("Ignoring invalid or reserved key {} for message {}", key, getId());
+                LOG.debug("Ignoring invalid or reserved key {} for message {}", trimmedKey, getId());
             }
             return;
         }
 
-        if (FIELD_TIMESTAMP.equals(key.trim()) && value != null && value instanceof Date) {
+        if (FIELD_TIMESTAMP.equals(trimmedKey) && value != null && value instanceof Date) {
             fields.put(FIELD_TIMESTAMP, new DateTime(value));
-        } else if(value instanceof String) {
+        } else if (value instanceof String) {
             final String str = ((String) value).trim();
 
             if (isRequiredField || !str.isEmpty()) {
-                fields.put(key.trim(), str);
+                fields.put(trimmedKey, str);
             }
-        } else if(value != null) {
-            fields.put(key.trim(), value);
+        } else if (value != null) {
+            fields.put(trimmedKey, value);
         }
     }
 

--- a/graylog2-server/src/main/java/org/graylog2/plugin/Message.java
+++ b/graylog2-server/src/main/java/org/graylog2/plugin/Message.java
@@ -131,9 +131,9 @@ public class Message implements Messages {
     public Message(final String message, final String source, final DateTime timestamp) {
         // Adding the fields directly because they would not be accepted as a reserved fields.
         fields.put(FIELD_ID, new UUID().toString());
-        fields.put(FIELD_MESSAGE, message);
-        fields.put(FIELD_SOURCE, source);
-        fields.put(FIELD_TIMESTAMP, timestamp);
+        addRequiredField(FIELD_MESSAGE, message);
+        addRequiredField(FIELD_SOURCE, source);
+        addRequiredField(FIELD_TIMESTAMP, timestamp);
     }
 
     public Message(final Map<String, Object> fields) {
@@ -296,6 +296,14 @@ public class Message implements Messages {
     }
 
     public void addField(final String key, final Object value) {
+        addField(key, value, false);
+    }
+
+    private void addRequiredField(final String key, final Object value) {
+        addField(key, value, true);
+    }
+
+    private void addField(final String key, final Object value, final boolean isRequiredField) {
         // Don't accept protected keys. (some are allowed though lol)
         if (RESERVED_FIELDS.contains(key) && !RESERVED_SETTABLE_FIELDS.contains(key) || !validKey(key)) {
             if (LOG.isDebugEnabled()) {
@@ -309,7 +317,7 @@ public class Message implements Messages {
         } else if(value instanceof String) {
             final String str = ((String) value).trim();
 
-            if(!str.isEmpty()) {
+            if (isRequiredField || !str.isEmpty()) {
                 fields.put(key.trim(), str);
             }
         } else if(value != null) {

--- a/graylog2-server/src/test/java/org/graylog2/plugin/MessageTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/plugin/MessageTest.java
@@ -18,10 +18,11 @@ package org.graylog2.plugin;
 
 import com.codahale.metrics.Meter;
 import com.codahale.metrics.MetricRegistry;
+import com.eaio.uuid.UUID;
+import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
-import org.assertj.core.api.Assertions;
 import org.graylog2.plugin.streams.Stream;
 import org.joda.time.DateTime;
 import org.joda.time.DateTimeZone;
@@ -94,6 +95,27 @@ public class MessageTest {
 
         m.addField("something3", "bar ");
         assertEquals("bar", m.getField("something3"));
+    }
+
+    @Test
+    public void testConstructorsTrimValues() throws Exception {
+        final Map<String, Object> messageFields = ImmutableMap.of(
+                Message.FIELD_ID, new UUID().toString(),
+                Message.FIELD_MESSAGE, " foo ",
+                Message.FIELD_SOURCE, " bar ",
+                "something", " awesome ",
+                "something_else", " "
+        );
+
+        Message m = new Message((String) messageFields.get(Message.FIELD_MESSAGE), (String) messageFields.get(Message.FIELD_SOURCE), Tools.nowUTC());
+        assertEquals("foo", m.getMessage());
+        assertEquals("bar", m.getSource());
+
+        Message m2 = new Message(messageFields);
+        assertEquals("foo", m2.getMessage());
+        assertEquals("bar", m2.getSource());
+        assertEquals("awesome", m2.getField("something"));
+        assertNull(m2.getField("something_else"));
     }
 
     @Test


### PR DESCRIPTION
Before this change, one of the public constructors of `Message` was using `addField()` to add fields in the `Message` object, while the other was adding the fields by hand to the internal `Map` used to store message fields.

That created an inconsistency, as the constructor using `addField()` trims all `String` field values by default, unlike the other constructor. It lead to the issue mentioned in: #1936, and it also affected to extractors and drool rules. Basically, every filter used in the `MessageFilterChainProcessor`.

This commit ensures both constructors trim `String` values, while still ensuring `Message(final String message, final String source, final DateTime timestamp)` will create a `Message` object containing the required fields given as arguments.

Making this change will break stream rules, extractors, and drool rules checking for one or more leading or trailing whitespaces in message fields.

I am still working on some documentation around this PR, that's why it is missing the `ready-to-review` tag, but feel free to add any concerns or comments 😄 

Fixes #1936.