### PR TITLE
Introduce CombinedProvider to sync actions and stores initialization.

### DIFF
--- a/graylog2-web-interface/src/injection/ActionsProvider.jsx
+++ b/graylog2-web-interface/src/injection/ActionsProvider.jsx
@@ -1,54 +1,14 @@
+import CombinedProvider from 'injection/CombinedProvider';
+
 /* global actionsProvider */
 
 class ActionsProvider {
-  constructor() {
-    /* eslint-disable import/no-require */
-    this.actions = {
-      AlarmCallbacks: () => require('actions/alarmcallbacks/AlarmCallbacksActions'),
-      AlertConditions: () => require('actions/alertconditions/AlertConditionsActions'),
-      AlertReceivers: () => require('actions/alertreceivers/AlertReceiversActions'),
-      Alerts: () => require('actions/alerts/AlertsActions'),
-      CodecTypes: () => require('actions/codecs/CodecTypesActions'),
-      Authentication: () => require('actions/authentication/AuthenticationActions'),
-      Configuration: () => require('actions/configurations/ConfigurationActions'),
-      ConfigurationBundles: () => require('actions/configuration-bundles/ConfigurationBundlesActions'),
-      Decorators: () => require('actions/decorators/DecoratorsActions'),
-      Deflector: () => require('actions/indices/DeflectorActions'),
-      Extractors: () => require('actions/extractors/ExtractorsActions'),
-      GettingStarted: () => require('actions/gettingstarted/GettingStartedActions'),
-      HistogramData: () => require('actions/sources/HistogramDataActions'),
-      IndexerCluster: () => require('actions/indexers/IndexerClusterActions'),
-      IndexerOverview: () => require('actions/indexers/IndexerOverviewActions'),
-      IndexRanges: () => require('actions/indices/IndexRangesActions'),
-      Indices: () => require('actions/indices/IndicesActions'),
-      IndicesConfiguration: () => require('actions/indices/IndicesConfigurationActions'),
-      Inputs: () => require('actions/inputs/InputsActions'),
-      InputTypes: () => require('actions/inputs/InputTypesActions'),
-      Ldap: () => require('actions/ldap/LdapActions'),
-      LdapGroups: () => require('actions/ldap/LdapGroupsActions'),
-      Loggers: () => require('actions/system/LoggersActions'),
-      MessageCounts: () => require('actions/messages/MessageCountsActions'),
-      Messages: () => require('actions/messages/MessagesActions'),
-      Metrics: () => require('actions/metrics/MetricsActions'),
-      Nodes: () => require('actions/nodes/NodesActions'),
-      Notifications: () => require('actions/notifications/NotificationsActions'),
-      Refresh: () => require('actions/tools/RefreshActions'),
-      SavedSearches: () => require('actions/search/SavedSearchesActions'),
-      ServerAvailability: () => require('actions/sessions/ServerAvailabilityActions'),
-      Session: () => require('actions/sessions/SessionActions'),
-      SingleNode: () => require('actions/nodes/SingleNodeActions'),
-      Streams: () => require('actions/streams/StreamsActions'),
-      SystemJobs: () => require('actions/systemjobs/SystemJobsActions'),
-      Widgets: () => require('actions/widgets/WidgetsActions'),
-    };
-    /* eslint-enable import/no-require */
-  }
-
   getActions(actionsName) {
-    if (!this.actions[actionsName]) {
+    const result = CombinedProvider.get(actionsName);
+    if (!result[`${actionsName}Actions`]) {
       throw new Error(`Requested actions "${actionsName}" is not registered.`);
     }
-    return this.actions[actionsName]();
+    return result[`${actionsName}Actions`];
   }
 }
 

--- a/graylog2-web-interface/src/injection/CombinedProvider.js
+++ b/graylog2-web-interface/src/injection/CombinedProvider.js
@@ -1,0 +1,131 @@
+class CombinedProvider {
+  constructor() {
+    /* eslint-disable import/no-require */
+    this.actions = {
+      AlarmCallbacks: () => require('actions/alarmcallbacks/AlarmCallbacksActions'),
+      AlertConditions: () => require('actions/alertconditions/AlertConditionsActions'),
+      AlertReceivers: () => require('actions/alertreceivers/AlertReceiversActions'),
+      Alerts: () => require('actions/alerts/AlertsActions'),
+      CodecTypes: () => require('actions/codecs/CodecTypesActions'),
+      Authentication: () => require('actions/authentication/AuthenticationActions'),
+      Configuration: () => require('actions/configurations/ConfigurationActions'),
+      ConfigurationBundles: () => require('actions/configuration-bundles/ConfigurationBundlesActions'),
+      Decorators: () => require('actions/decorators/DecoratorsActions'),
+      Deflector: () => require('actions/indices/DeflectorActions'),
+      Extractors: () => require('actions/extractors/ExtractorsActions'),
+      GettingStarted: () => require('actions/gettingstarted/GettingStartedActions'),
+      HistogramData: () => require('actions/sources/HistogramDataActions'),
+      IndexerCluster: () => require('actions/indexers/IndexerClusterActions'),
+      IndexerOverview: () => require('actions/indexers/IndexerOverviewActions'),
+      IndexRanges: () => require('actions/indices/IndexRangesActions'),
+      Indices: () => require('actions/indices/IndicesActions'),
+      IndicesConfiguration: () => require('actions/indices/IndicesConfigurationActions'),
+      Inputs: () => require('actions/inputs/InputsActions'),
+      InputTypes: () => require('actions/inputs/InputTypesActions'),
+      Ldap: () => require('actions/ldap/LdapActions'),
+      LdapGroups: () => require('actions/ldap/LdapGroupsActions'),
+      Loggers: () => require('actions/system/LoggersActions'),
+      MessageCounts: () => require('actions/messages/MessageCountsActions'),
+      Messages: () => require('actions/messages/MessagesActions'),
+      Metrics: () => require('actions/metrics/MetricsActions'),
+      Nodes: () => require('actions/nodes/NodesActions'),
+      Notifications: () => require('actions/notifications/NotificationsActions'),
+      Refresh: () => require('actions/tools/RefreshActions'),
+      SavedSearches: () => require('actions/search/SavedSearchesActions'),
+      ServerAvailability: () => require('actions/sessions/ServerAvailabilityActions'),
+      Session: () => require('actions/sessions/SessionActions'),
+      SingleNode: () => require('actions/nodes/SingleNodeActions'),
+      Streams: () => require('actions/streams/StreamsActions'),
+      SystemJobs: () => require('actions/systemjobs/SystemJobsActions'),
+      Widgets: () => require('actions/widgets/WidgetsActions'),
+    };
+    this.stores = {
+      AlarmCallbackHistory: () => require('stores/alarmcallbacks/AlarmCallbackHistoryStore'),
+      AlarmCallbacks: () => require('stores/alarmcallbacks/AlarmCallbacksStore'),
+      AlertConditions: () => require('stores/alertconditions/AlertConditionsStore'),
+      Alerts: () => require('stores/alerts/AlertsStore'),
+      Authentication: () => require('stores/authentication/AuthenticationStore'),
+      ClusterOverview: () => require('stores/cluster/ClusterOverviewStore'),
+      CodecTypes: () => require('stores/codecs/CodecTypesStore'),
+      ConfigurationBundles: () => require('stores/configuration-bundles/ConfigurationBundlesStore'),
+      Configurations: () => require('stores/configurations/ConfigurationsStore'),
+      CurrentUser: () => require('stores/users/CurrentUserStore'),
+      Dashboards: () => require('stores/dashboards/DashboardsStore'),
+      Decorators: () => require('stores/decorators/DecoratorsStore'),
+      Deflector: () => require('stores/indices/DeflectorStore'),
+      Extractors: () => require('stores/extractors/ExtractorsStore'),
+      FieldGraphs: () => require('stores/field-analyzers/FieldGraphsStore'),
+      FieldQuickValues: () => require('stores/field-analyzers/FieldQuickValuesStore'),
+      Fields: () => require('stores/fields/FieldsStore'),
+      FieldStatistics: () => require('stores/field-analyzers/FieldStatisticsStore'),
+      Focus: () => require('stores/tools/FocusStore'),
+      GettingStarted: () => require('stores/gettingstarted/GettingStartedStore'),
+      GlobalThroughput: () => require('stores/metrics/GlobalThroughputStore'),
+      GrokPatterns: () => require('stores/grok-patterns/GrokPatternsStore'),
+      HistogramData: () => require('stores/sources/HistogramDataStore'),
+      IndexerCluster: () => require('stores/indexers/IndexerClusterStore'),
+      IndexerFailures: () => require('stores/indexers/IndexerFailuresStore'),
+      IndexerOverview: () => require('stores/indexers/IndexerOverviewStore'),
+      IndexRanges: () => require('stores/indices/IndexRangesStore'),
+      Indices: () => require('stores/indices/IndicesStore'),
+      IndicesConfiguration: () => require('stores/indices/IndicesConfigurationStore'),
+      Inputs: () => require('stores/inputs/InputsStore'),
+      InputStates: () => require('stores/inputs/InputStatesStore'),
+      InputStaticFields: () => require('stores/inputs/InputStaticFieldsStore'),
+      InputTypes: () => require('stores/inputs/InputTypesStore'),
+      Journal: () => require('stores/journal/JournalStore'),
+      LdapGroups: () => require('stores/ldap/LdapGroupsStore'),
+      Ldap: () => require('stores/ldap/LdapStore'),
+      Loggers: () => require('stores/system/LoggersStore'),
+      MessageCounts: () => require('stores/messages/MessageCountsStore'),
+      MessageFields: () => require('stores/messages/MessageFieldsStore'),
+      Messages: () => require('stores/messages/MessagesStore'),
+      Metrics: () => require('stores/metrics/MetricsStore'),
+      Nodes: () => require('stores/nodes/NodesStore'),
+      Notifications: () => require('stores/notifications/NotificationsStore'),
+      Outputs: () => require('stores/outputs/OutputsStore'),
+      Plugins: () => require('stores/plugins/PluginsStore'),
+      Preferences: () => require('stores/users/PreferencesStore'),
+      Refresh: () => require('stores/tools/RefreshStore'),
+      Roles: () => require('stores/users/RolesStore'),
+      SavedSearches: () => require('stores/search/SavedSearchesStore'),
+      Search: () => require('stores/search/SearchStore'),
+      ServerAvailability: () => require('stores/sessions/ServerAvailabilityStore'),
+      Session: () => require('stores/sessions/SessionStore'),
+      SingleNode: () => require('stores/nodes/SingleNodeStore'),
+      Sources: () => require('stores/sources/SourcesStore'),
+      Startpage: () => require('stores/users/StartpageStore'),
+      StreamRules: () => require('stores/streams/StreamRulesStore'),
+      Streams: () => require('stores/streams/StreamsStore'),
+      System: () => require('stores/system/SystemStore'),
+      SystemJobs: () => require('stores/systemjobs/SystemJobsStore'),
+      SystemLoadBalancer: () => require('stores/load-balancer/SystemLoadBalancerStore'),
+      SystemMessages: () => require('stores/systemmessages/SystemMessagesStore'),
+      SystemProcessing: () => require('stores/system-processing/SystemProcessingStore'),
+      SystemShutdown: () => require('stores/system-shutdown/SystemShutdownStore'),
+      Tools: () => require('stores/tools/ToolsStore'),
+      UniversalSearch: () => require('stores/search/UniversalSearchStore'),
+      UsageStatsOptOut: () => require('stores/usagestats/UsageStatsOptOutStore'),
+      Users: () => require('stores/users/UsersStore'),
+      Widgets: () => require('stores/widgets/WidgetsStore'),
+    };
+    /* eslint-enable import/no-require */
+  }
+
+  get(name) {
+    const result = {};
+    if (this.stores[name]) {
+      result[`${name}Store`] = this.stores[name]();
+    }
+    if (this.actions[name]) {
+      result[`${name}Actions`] = this.actions[name]();
+    }
+    return result;
+  }
+}
+
+if (typeof window.combinedProvider === 'undefined') {
+  window.combinedProvider = new CombinedProvider();
+}
+
+export default window.combinedProvider;

--- a/graylog2-web-interface/src/injection/StoreProvider.jsx
+++ b/graylog2-web-interface/src/injection/StoreProvider.jsx
@@ -1,86 +1,14 @@
+import CombinedProvider from 'injection/CombinedProvider';
+
 /* global storeProvider */
 
 class StoreProvider {
-  constructor() {
-    /* eslint-disable import/no-require */
-    this.stores = {
-      AlarmCallbackHistory: () => require('stores/alarmcallbacks/AlarmCallbackHistoryStore'),
-      AlarmCallbacks: () => require('stores/alarmcallbacks/AlarmCallbacksStore'),
-      AlertConditions: () => require('stores/alertconditions/AlertConditionsStore'),
-      Alerts: () => require('stores/alerts/AlertsStore'),
-      Authentication: () => require('stores/authentication/AuthenticationStore'),
-      ClusterOverview: () => require('stores/cluster/ClusterOverviewStore'),
-      CodecTypes: () => require('stores/codecs/CodecTypesStore'),
-      ConfigurationBundles: () => require('stores/configuration-bundles/ConfigurationBundlesStore'),
-      Configurations: () => require('stores/configurations/ConfigurationsStore'),
-      CurrentUser: () => require('stores/users/CurrentUserStore'),
-      Dashboards: () => require('stores/dashboards/DashboardsStore'),
-      Decorators: () => require('stores/decorators/DecoratorsStore'),
-      Deflector: () => require('stores/indices/DeflectorStore'),
-      Extractors: () => require('stores/extractors/ExtractorsStore'),
-      FieldGraphs: () => require('stores/field-analyzers/FieldGraphsStore'),
-      FieldQuickValues: () => require('stores/field-analyzers/FieldQuickValuesStore'),
-      Fields: () => require('stores/fields/FieldsStore'),
-      FieldStatistics: () => require('stores/field-analyzers/FieldStatisticsStore'),
-      Focus: () => require('stores/tools/FocusStore'),
-      GettingStarted: () => require('stores/gettingstarted/GettingStartedStore'),
-      GlobalThroughput: () => require('stores/metrics/GlobalThroughputStore'),
-      GrokPatterns: () => require('stores/grok-patterns/GrokPatternsStore'),
-      HistogramData: () => require('stores/sources/HistogramDataStore'),
-      IndexerCluster: () => require('stores/indexers/IndexerClusterStore'),
-      IndexerFailures: () => require('stores/indexers/IndexerFailuresStore'),
-      IndexerOverview: () => require('stores/indexers/IndexerOverviewStore'),
-      IndexRanges: () => require('stores/indices/IndexRangesStore'),
-      Indices: () => require('stores/indices/IndicesStore'),
-      IndicesConfiguration: () => require('stores/indices/IndicesConfigurationStore'),
-      Inputs: () => require('stores/inputs/InputsStore'),
-      InputStates: () => require('stores/inputs/InputStatesStore'),
-      InputStaticFields: () => require('stores/inputs/InputStaticFieldsStore'),
-      InputTypes: () => require('stores/inputs/InputTypesStore'),
-      Journal: () => require('stores/journal/JournalStore'),
-      LdapGroups: () => require('stores/ldap/LdapGroupsStore'),
-      Ldap: () => require('stores/ldap/LdapStore'),
-      Loggers: () => require('stores/system/LoggersStore'),
-      MessageCounts: () => require('stores/messages/MessageCountsStore'),
-      MessageFields: () => require('stores/messages/MessageFieldsStore'),
-      Messages: () => require('stores/messages/MessagesStore'),
-      Metrics: () => require('stores/metrics/MetricsStore'),
-      Nodes: () => require('stores/nodes/NodesStore'),
-      Notifications: () => require('stores/notifications/NotificationsStore'),
-      Outputs: () => require('stores/outputs/OutputsStore'),
-      Plugins: () => require('stores/plugins/PluginsStore'),
-      Preferences: () => require('stores/users/PreferencesStore'),
-      Refresh: () => require('stores/tools/RefreshStore'),
-      Roles: () => require('stores/users/RolesStore'),
-      SavedSearches: () => require('stores/search/SavedSearchesStore'),
-      Search: () => require('stores/search/SearchStore'),
-      ServerAvailability: () => require('stores/sessions/ServerAvailabilityStore'),
-      Session: () => require('stores/sessions/SessionStore'),
-      SingleNode: () => require('stores/nodes/SingleNodeStore'),
-      Sources: () => require('stores/sources/SourcesStore'),
-      Startpage: () => require('stores/users/StartpageStore'),
-      StreamRules: () => require('stores/streams/StreamRulesStore'),
-      Streams: () => require('stores/streams/StreamsStore'),
-      System: () => require('stores/system/SystemStore'),
-      SystemJobs: () => require('stores/systemjobs/SystemJobsStore'),
-      SystemLoadBalancer: () => require('stores/load-balancer/SystemLoadBalancerStore'),
-      SystemMessages: () => require('stores/systemmessages/SystemMessagesStore'),
-      SystemProcessing: () => require('stores/system-processing/SystemProcessingStore'),
-      SystemShutdown: () => require('stores/system-shutdown/SystemShutdownStore'),
-      Tools: () => require('stores/tools/ToolsStore'),
-      UniversalSearch: () => require('stores/search/UniversalSearchStore'),
-      UsageStatsOptOut: () => require('stores/usagestats/UsageStatsOptOutStore'),
-      Users: () => require('stores/users/UsersStore'),
-      Widgets: () => require('stores/widgets/WidgetsStore'),
-    };
-    /* eslint-enable import/no-require */
-  }
-
   getStore(storeName) {
-    if (!this.stores[storeName]) {
+    const result = CombinedProvider.get(storeName);
+    if (!result[`${storeName}Store`]) {
       throw new Error(`Requested store "${storeName}" is not registered.`);
     }
-    return this.stores[storeName]();
+    return result[`${storeName}Store`];
   }
 }
 

--- a/graylog2-web-interface/src/logic/rest/FetchProvider.js
+++ b/graylog2-web-interface/src/logic/rest/FetchProvider.js
@@ -3,8 +3,6 @@ import request from 'superagent-bluebird-promise';
 import StoreProvider from 'injection/StoreProvider';
 
 import ActionsProvider from 'injection/ActionsProvider';
-const SessionActions = ActionsProvider.getActions('Session');
-const ServerAvailabilityActions = ActionsProvider.getActions('ServerAvailability');
 
 import Routes from 'routing/Routes';
 import history from 'util/History';
@@ -57,6 +55,7 @@ export class Builder {
       .accept('json')
       .then((resp) => {
         if (resp.ok) {
+          const ServerAvailabilityActions = ActionsProvider.getActions('ServerAvailability');
           ServerAvailabilityActions.reportSuccess();
           return resp.body;
         }
@@ -65,6 +64,7 @@ export class Builder {
       }, (error) => {
         const SessionStore = StoreProvider.getStore('Session');
         if (SessionStore.isLoggedIn() && error.status === 401) {
+          const SessionActions = ActionsProvider.getActions('Session');
           SessionActions.logout(SessionStore.getSessionId());
         }
 
@@ -74,6 +74,7 @@ export class Builder {
         }
 
         if (error.originalError && !error.originalError.status) {
+          const ServerAvailabilityActions = ActionsProvider.getActions('ServerAvailability');
           ServerAvailabilityActions.reportError(error);
         }
 
@@ -98,6 +99,7 @@ export default function fetch(method, url, body) {
 
   if (!SessionStore.isLoggedIn()) {
     return new Promise((resolve, reject) => {
+      const SessionActions = ActionsProvider.getActions('Session');
       SessionActions.login.completed.listen(() => {
         promise().then(resolve, reject);
       });

--- a/graylog2-web-interface/src/pages/SearchPage.jsx
+++ b/graylog2-web-interface/src/pages/SearchPage.jsx
@@ -3,21 +3,16 @@ import Reflux from 'reflux';
 import Immutable from 'immutable';
 import moment from 'moment';
 
-import StoreProvider from 'injection/StoreProvider';
-const NodesStore = StoreProvider.getStore('Nodes');
-const CurrentUserStore = StoreProvider.getStore('CurrentUser');
-const InputsStore = StoreProvider.getStore('Inputs');
-const MessageFieldsStore = StoreProvider.getStore('MessageFields');
-const RefreshStore = StoreProvider.getStore('Refresh');
-const StreamsStore = StoreProvider.getStore('Streams');
-const UniversalSearchStore = StoreProvider.getStore('UniversalSearch');
-const SearchStore = StoreProvider.getStore('Search');
-const DecoratorsStore = StoreProvider.getStore('Decorators');
-
-import ActionsProvider from 'injection/ActionsProvider';
-const NodesActions = ActionsProvider.getActions('Nodes');
-const InputsActions = ActionsProvider.getActions('Inputs');
-const DecoratorsActions = ActionsProvider.getActions('Decorators');
+import CombinedProvider from 'injection/CombinedProvider';
+const { NodesStore, NodesActions } = CombinedProvider.get('Nodes');
+const { CurrentUserStore } = CombinedProvider.get('CurrentUser');
+const { InputsStore, InputsActions } = CombinedProvider.get('Inputs');
+const { MessageFieldsStore } = CombinedProvider.get('MessageFields');
+const { RefreshStore } = CombinedProvider.get('Refresh');
+const { StreamsStore } = CombinedProvider.get('Streams');
+const { UniversalSearchStore } = CombinedProvider.get('UniversalSearch');
+const { SearchStore } = CombinedProvider.get('Search');
+const { DecoratorsActions } = CombinedProvider.get('Decorators');
 
 import { Spinner } from 'components/common';
 import { MalformedSearchQuery, SearchResult } from 'components/search';


### PR DESCRIPTION
When using separate providers for actions and stores, there is the
possibility that only actions need to be imported in a component. Using
the actions then would have no effect though, if the corresponding store
listening to those actions was not initialized already. So there are
cases where the store is imported in components although it is unused.

This PR introduced the CombinedProvider which syncs actions and store
initializations. It can be used to import stores and actions separately
or combined in a component. Usage of it is shown in the SearchPage
component, which is shorted and more concise due to it. It can be used
as a blueprint for future conversions to using the CombinedProvider, but
usage of Actions/StoreProvider is still possible and benefits from
syncing the imports.