### PR TITLE
Changing default to make REST API and web if to listen on same host/port

### DIFF
--- a/UPGRADING.rst
+++ b/UPGRADING.rst
@@ -22,15 +22,17 @@ Due to those shortcomings, the feature has been removed completely. Users need t
 Web Interface Listener
 ----------------------
 
-2.0.x was defaulting to separate listeners for the REST API and the web interface. The former defaulted to ``http://localhost:12900``, the latter to ``http://localhost:9000``.
-Beginning with 2.1.0 it is possible to run both the REST API and the web interface on the same host/port-combination and this is now the default. This means that the REST API is still running on ``http://localhost:12900`` per default, but the web interface is now running on ``http://localhost:12900/console``. Furthermore, all requests going to ``http://localhost:12900/`` requesting a content-type of ``text/html`` are redirected to the web interface, therefore making it even easier to set up Graylog and use it behind proxies, expose it externally, etc.
+Graylog 2.0.x has been using separate listeners for the REST API and the web interface by default. The Graylog REST API on ``http://127.0.0.1:12900``, the Graylog web interface on ``http://127.0.0.1:9000``.
+Beginning with Graylog 2.1.0 it is possible to run both the REST API and the web interface on the same host/port-combination and this is now the default. This means that the REST API is still running on ``http://127.0.0.1:12900`` per default, but the web interface is now running on ``http://127.0.0.1:12900/console``.
+Furthermore, all requests going to ``http://127.0.0.1:12900/`` requesting a content-type of ``text/html`` or ``application/xhtml+xml`` are redirected to the web interface, therefore making it even easier to set up Graylog and use it behind proxies, expose it externally etc.
 
-Please take not that you can still run the REST API and the web interface on two separate listeners. If you are running a 2.0 configuration specifying ``web_listen_uri`` explicitly and you want to keep that, you do not have to change anything.
+Please take not that you can still run the REST API and the web interface on two separate listeners. If you are running a Graylog 2.0.x configuration specifying ``web_listen_uri`` explicitly and you want to keep that, you do not have to change anything.
 
 Please also take note, that when you have configured ``rest_listen_uri`` and ``web_listen_uri`` to run on the same host/port-combination, the following configuration directives will have no effect:
 
   - ``web_enable_tls``, ``web_tls_cert_file``, ``web_tls_key_file``, ``web_tls_key_password`` (These will depend on the TLS configuration of the REST listener).
   - ``web_enable_cors``, ``web_enable_gzip``, ``web_thread_pool_size``, ``web_max_initial_line_length``, ``web_max_header_size`` (Those will depend on the corresponding settings of the REST listener).
+
 
 Internal Metrics to MongoDB
 ---------------------------

--- a/UPGRADING.rst
+++ b/UPGRADING.rst
@@ -19,6 +19,19 @@ Previous versions of Graylog were automatically generating a private key/certifi
 Due to those shortcomings, the feature has been removed completely. Users need to use proper certificates or generate their own self-signed certificates and configure them with the appropriate settings, see `Using HTTPS <http://docs.graylog.org/en/2.0/pages/configuration/https.html>`_ for reference.
 
 
+Web Interface Listener
+----------------------
+
+2.0.x was defaulting to separate listeners for the REST API and the web interface. The former defaulted to ``http://localhost:12900``, the latter to ``http://localhost:9000``.
+Beginning with 2.1.0 it is possible to run both the REST API and the web interface on the same host/port-combination and this is now the default. This means that the REST API is still running on ``http://localhost:12900`` per default, but the web interface is now running on ``http://localhost:12900/console``. Furthermore, all requests going to ``http://localhost:12900/`` requesting a content-type of ``text/html`` are redirected to the web interface, therefore making it even easier to set up Graylog and use it behind proxies, expose it externally, etc.
+
+Please take not that you can still run the REST API and the web interface on two separate listeners. If you are running a 2.0 configuration specifying ``web_listen_uri`` explicitly and you want to keep that, you do not have to change anything.
+
+Please also take note, that when you have configured ``rest_listen_uri`` and ``web_listen_uri`` to run on the same host/port-combination, the following configuration directives will have no effect:
+
+  - ``web_enable_tls``, ``web_tls_cert_file``, ``web_tls_key_file``, ``web_tls_key_password`` (These will depend on the TLS configuration of the REST listener).
+  - ``web_enable_cors``, ``web_enable_gzip``, ``web_thread_pool_size``, ``web_max_initial_line_length``, ``web_max_header_size`` (Those will depend on the corresponding settings of the REST listener).
+
 Internal Metrics to MongoDB
 ---------------------------
 

--- a/UPGRADING.rst
+++ b/UPGRADING.rst
@@ -23,7 +23,7 @@ Web Interface Listener
 ----------------------
 
 Graylog 2.0.x has been using separate listeners for the REST API and the web interface by default. The Graylog REST API on ``http://127.0.0.1:12900``, the Graylog web interface on ``http://127.0.0.1:9000``.
-Beginning with Graylog 2.1.0 it is possible to run both the REST API and the web interface on the same host/port-combination and this is now the default. This means that the REST API is still running on ``http://127.0.0.1:12900`` per default, but the web interface is now running on ``http://127.0.0.1:12900/console``.
+Beginning with Graylog 2.1.0 it is possible to run both the REST API and the web interface on the same host/port-combination and this is now the default. This means that the REST API is still running on ``http://127.0.0.1:12900`` per default, but the web interface is now running on ``http://127.0.0.1:12900/web``.
 Furthermore, all requests going to ``http://127.0.0.1:12900/`` requesting a content-type of ``text/html`` or ``application/xhtml+xml`` are redirected to the web interface, therefore making it even easier to set up Graylog and use it behind proxies, expose it externally etc.
 
 Please take not that you can still run the REST API and the web interface on two separate listeners. If you are running a Graylog 2.0.x configuration specifying ``web_listen_uri`` explicitly and you want to keep that, you do not have to change anything.

--- a/graylog2-server/src/main/java/org/graylog2/Configuration.java
+++ b/graylog2-server/src/main/java/org/graylog2/Configuration.java
@@ -54,7 +54,7 @@ public class Configuration extends BaseConfiguration {
     private URI restListenUri = URI.create("http://127.0.0.1:" + GRAYLOG_DEFAULT_PORT + "/");
 
     @Parameter(value = "web_listen_uri", required = true)
-    private URI webListenUri = URI.create("http://127.0.0.1:" + GRAYLOG_DEFAULT_WEB_PORT + "/");
+    private URI webListenUri = URI.create("http://127.0.0.1:" + GRAYLOG_DEFAULT_WEB_PORT + "/console");
 
     @Parameter(value = "output_batch_size", required = true, validator = PositiveIntegerValidator.class)
     private int outputBatchSize = 500;

--- a/graylog2-server/src/main/java/org/graylog2/Configuration.java
+++ b/graylog2-server/src/main/java/org/graylog2/Configuration.java
@@ -54,7 +54,7 @@ public class Configuration extends BaseConfiguration {
     private URI restListenUri = URI.create("http://127.0.0.1:" + GRAYLOG_DEFAULT_PORT + "/");
 
     @Parameter(value = "web_listen_uri", required = true)
-    private URI webListenUri = URI.create("http://127.0.0.1:" + GRAYLOG_DEFAULT_WEB_PORT + "/console");
+    private URI webListenUri = URI.create("http://127.0.0.1:" + GRAYLOG_DEFAULT_WEB_PORT + "/web");
 
     @Parameter(value = "output_batch_size", required = true, validator = PositiveIntegerValidator.class)
     private int outputBatchSize = 500;

--- a/graylog2-server/src/main/java/org/graylog2/plugin/BaseConfiguration.java
+++ b/graylog2-server/src/main/java/org/graylog2/plugin/BaseConfiguration.java
@@ -45,7 +45,7 @@ import java.nio.file.Path;
 public abstract class BaseConfiguration {
     private static final Logger LOG = LoggerFactory.getLogger(BaseConfiguration.class);
     protected static final int GRAYLOG_DEFAULT_PORT = 12900;
-    protected static final int GRAYLOG_DEFAULT_WEB_PORT = 9000;
+    protected static final int GRAYLOG_DEFAULT_WEB_PORT = 12900;
 
     @Parameter(value = "shutdown_timeout", validator = PositiveIntegerValidator.class)
     protected int shutdownTimeout = 30000;

--- a/misc/graylog.conf
+++ b/misc/graylog.conf
@@ -88,7 +88,7 @@ rest_listen_uri = http://127.0.0.1:12900/
 # Web interface listen URI.
 # Configuring a path for the URI here effectively prefixes all URIs in the web interface. This is a replacement
 # for the application.context configuration parameter in pre-2.0 versions of the Graylog web interface.
-#web_listen_uri = http://127.0.0.1:9000/
+#web_listen_uri = http://127.0.0.1:12900/console
 
 # Web interface endpoint URI. This setting can be overriden on a per-request basis with the X-Graylog-Server-URL header.
 # Default: $rest_transport_uri

--- a/misc/graylog.conf
+++ b/misc/graylog.conf
@@ -88,7 +88,7 @@ rest_listen_uri = http://127.0.0.1:12900/
 # Web interface listen URI.
 # Configuring a path for the URI here effectively prefixes all URIs in the web interface. This is a replacement
 # for the application.context configuration parameter in pre-2.0 versions of the Graylog web interface.
-#web_listen_uri = http://127.0.0.1:12900/console
+#web_listen_uri = http://127.0.0.1:12900/web
 
 # Web interface endpoint URI. This setting can be overriden on a per-request basis with the X-Graylog-Server-URL header.
 # Default: $rest_transport_uri


### PR DESCRIPTION
This PR changes the defaults of the configuration to make the web interface use the same listener as the default REST API.

Needs to be merged after #2515 

Fixes #2446 