### PR TITLE
Fix search results console warnings

### DIFF
--- a/graylog2-web-interface/src/components/search/MessageField.jsx
+++ b/graylog2-web-interface/src/components/search/MessageField.jsx
@@ -9,7 +9,7 @@ const MessageField = React.createClass({
     fieldName: React.PropTypes.string.isRequired,
     message: React.PropTypes.object.isRequired,
     possiblyHighlight: React.PropTypes.func.isRequired,
-    value: React.PropTypes.string.isRequired,
+    value: React.PropTypes.any.isRequired,
   },
   SPECIAL_FIELDS: ['full_message', 'level'],
   _decorationMarker(key) {

--- a/graylog2-web-interface/src/components/search/MessageFields.jsx
+++ b/graylog2-web-interface/src/components/search/MessageFields.jsx
@@ -19,7 +19,7 @@ const MessageFields = React.createClass({
 
   _formatFields(fields, showDecoration) {
     if (!showDecoration || !this.props.message.decoration_stats) {
-      return Object.keys(fields).sort().map(key => <MessageField {...this.props} fieldName={key} value={fields[key]} />);
+      return Object.keys(fields).sort().map(key => <MessageField {...this.props} fieldName={key} value={String(fields[key])} />);
     }
 
     const decorationStats = this.props.message.decoration_stats;
@@ -41,7 +41,7 @@ const MessageFields = React.createClass({
                                     originalValue={decorationStats.removed_fields[key]} />);
       }
 
-      return <MessageField {...this.props} fieldName={key} value={fields[key]} disableFieldActions={true} />;
+      return <MessageField {...this.props} fieldName={key} value={String(fields[key])} disableFieldActions={true} />;
     });
   },
   render() {

--- a/graylog2-web-interface/src/components/search/MessageFields.jsx
+++ b/graylog2-web-interface/src/components/search/MessageFields.jsx
@@ -19,7 +19,7 @@ const MessageFields = React.createClass({
 
   _formatFields(fields, showDecoration) {
     if (!showDecoration || !this.props.message.decoration_stats) {
-      return Object.keys(fields).sort().map(key => <MessageField {...this.props} fieldName={key} value={String(fields[key])} />);
+      return Object.keys(fields).sort().map(key => <MessageField key={key} {...this.props} fieldName={key} value={String(fields[key])} />);
     }
 
     const decorationStats = this.props.message.decoration_stats;
@@ -28,20 +28,22 @@ const MessageFields = React.createClass({
 
     return allKeys.map(key => {
       if (decorationStats.added_fields[key]) {
-        return <ChangedMessageField fieldName={key} newValue={fields[key]} />;
+        return <ChangedMessageField key={key} fieldName={key} newValue={fields[key]} />;
       }
       if (decorationStats.changed_fields[key]) {
-        return (<ChangedMessageField fieldName={key}
+        return (<ChangedMessageField key={key}
+                                     fieldName={key}
                                      originalValue={decorationStats.changed_fields[key]}
                                      newValue={fields[key]} />);
       }
 
       if (decorationStats.removed_fields[key]) {
-        return (<ChangedMessageField fieldName={key}
-                                    originalValue={decorationStats.removed_fields[key]} />);
+        return (<ChangedMessageField key={key}
+                                     fieldName={key}
+                                     originalValue={decorationStats.removed_fields[key]} />);
       }
 
-      return <MessageField {...this.props} fieldName={key} value={String(fields[key])} disableFieldActions={true} />;
+      return <MessageField key={key} {...this.props} fieldName={key} value={String(fields[key])} disableFieldActions={true} />;
     });
   },
   render() {

--- a/graylog2-web-interface/src/components/search/MessageFields.jsx
+++ b/graylog2-web-interface/src/components/search/MessageFields.jsx
@@ -19,7 +19,7 @@ const MessageFields = React.createClass({
 
   _formatFields(fields, showDecoration) {
     if (!showDecoration || !this.props.message.decoration_stats) {
-      return Object.keys(fields).sort().map(key => <MessageField key={key} {...this.props} fieldName={key} value={String(fields[key])} />);
+      return Object.keys(fields).sort().map(key => <MessageField key={key} {...this.props} fieldName={key} value={fields[key]} />);
     }
 
     const decorationStats = this.props.message.decoration_stats;
@@ -43,7 +43,7 @@ const MessageFields = React.createClass({
                                      originalValue={decorationStats.removed_fields[key]} />);
       }
 
-      return <MessageField key={key} {...this.props} fieldName={key} value={String(fields[key])} disableFieldActions={true} />;
+      return <MessageField key={key} {...this.props} fieldName={key} value={fields[key]} disableFieldActions />;
     });
   },
   render() {


### PR DESCRIPTION
Expanding the message details from a message in the search result may lead to two console warnings:

- `Failed propType: Invalid prop 'value' of type 'number' supplied to 'MessageField', expected 'string'. Check the render method of 'MessageFields'`: This one is triggered when one of the field values of the message is not a string. The PR fixes it by converting it into a string.

- `Each child in an array or iterator should have a unique "key" prop. Check the render method of 'MessageFields'`: There were some arrays of React nodes that did not provide unique keys, so I added them.