### PR TITLE
do not blindly override permission set of ldap users

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/security/realm/LdapUserAuthenticator.java
+++ b/graylog2-server/src/main/java/org/graylog2/security/realm/LdapUserAuthenticator.java
@@ -48,7 +48,6 @@ import org.slf4j.LoggerFactory;
 import javax.annotation.Nullable;
 import javax.inject.Inject;
 import javax.inject.Named;
-import java.util.Collections;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
@@ -250,7 +249,8 @@ public class LdapUserAuthenticator extends AuthenticatingRealm {
             translatedRoleIds.addAll(user.getRoleIds());
         }
         user.setRoleIds(translatedRoleIds);
-        user.setPermissions(Collections.emptyList());
+        // preserve the raw permissions (the ones without the synthetic self-edit permissions or the "*" admin one)
+        user.setPermissions(user.getPermissions());
     }
 
 }

--- a/graylog2-server/src/main/java/org/graylog2/users/UserImpl.java
+++ b/graylog2-server/src/main/java/org/graylog2/users/UserImpl.java
@@ -19,6 +19,7 @@ package org.graylog2.users;
 import com.google.common.collect.Collections2;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Lists;
 import com.google.inject.assistedinject.Assisted;
 import com.google.inject.assistedinject.AssistedInject;
 import org.bson.types.ObjectId;
@@ -172,8 +173,9 @@ public class UserImpl extends PersistedImpl implements User {
 
     @Override
     public void setPermissions(final List<String> permissions) {
+        final List<String> perms = Lists.newArrayList(permissions);
         // Do not store the dynamic user self edit permissions
-        permissions.removeAll(this.permissions.userSelfEditPermissions(getName()));
+        perms.removeAll(this.permissions.userSelfEditPermissions(getName()));
         fields.put(PERMISSIONS, permissions);
     }
 

--- a/graylog2-server/src/test/java/org/graylog2/users/UserImplTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/users/UserImplTest.java
@@ -16,6 +16,7 @@
  */
 package org.graylog2.users;
 
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import org.graylog2.security.PasswordAlgorithmFactory;
 import org.graylog2.shared.security.Permissions;
@@ -59,5 +60,18 @@ public class UserImplTest {
         assertThat(user.getPermissions())
             .containsAll(permissions.userSelfEditPermissions("foobar"))
             .contains("subject:action");
+    }
+
+    @Test
+    public void permissionsArentModified() {
+        final Permissions permissions = new Permissions(Collections.emptySet());
+        final Map<String, Object> fields = Collections.singletonMap(UserImpl.USERNAME, "foobar");
+        user = new UserImpl(passwordAlgorithmFactory, permissions, fields);
+
+        final List<String> newPermissions = ImmutableList.<String>builder()
+                .addAll(user.getPermissions())
+                .add("perm:1")
+                .build();
+        user.setPermissions(newPermissions);
     }
 }


### PR DESCRIPTION
when fixing #2045 we introduced a bug clearing the permission set for synced ldap accounts

this only shows up when not using roles but the permission sets directly

fixes #2516