### PR TITLE
Validate that Elasticsearch home/data paths are readable

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/configuration/ElasticsearchConfiguration.java
+++ b/graylog2-server/src/main/java/org/graylog2/configuration/ElasticsearchConfiguration.java
@@ -17,8 +17,11 @@
 package org.graylog2.configuration;
 
 import com.github.joschi.jadconfig.Parameter;
+import com.github.joschi.jadconfig.ValidationException;
+import com.github.joschi.jadconfig.ValidatorMethod;
 import com.github.joschi.jadconfig.converters.StringListConverter;
 import com.github.joschi.jadconfig.util.Duration;
+import com.github.joschi.jadconfig.validators.DirectoryWritableValidator;
 import com.github.joschi.jadconfig.validators.FilePathReadableValidator;
 import com.github.joschi.jadconfig.validators.InetPortValidator;
 import com.github.joschi.jadconfig.validators.PositiveDurationValidator;
@@ -26,7 +29,10 @@ import com.github.joschi.jadconfig.validators.PositiveIntegerValidator;
 import com.github.joschi.jadconfig.validators.PositiveLongValidator;
 import org.joda.time.Period;
 
+import javax.validation.constraints.NotNull;
+import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
@@ -267,5 +273,42 @@ public class ElasticsearchConfiguration {
 
     public Duration getRequestTimeout() {
         return requestTimeout;
+    }
+
+    @ValidatorMethod
+    @SuppressWarnings("unused")
+    public void validateElasticsearchHomePath() throws ValidationException {
+        if (getPathHome() != null) {
+            final Path homePath = Paths.get(getPathHome());
+            validateElasticsearchPath(homePath);
+        }
+    }
+
+    @ValidatorMethod
+    @SuppressWarnings("unused")
+    public void validateElasticsearchDataPath() throws ValidationException {
+        if (getPathData() != null) {
+            final Path dataPath = Paths.get(getPathData());
+            validateElasticsearchPath(dataPath);
+        }
+    }
+
+    private void validateElasticsearchPath(@NotNull Path path) throws ValidationException {
+        final Path parent = path.getParent();
+        if (Files.exists(parent) && !Files.isDirectory(parent)) {
+            throw new ValidationException("Path " + parent.toAbsolutePath() + " is not a directory.");
+        }
+
+        if (Files.exists(parent) && !Files.isReadable(parent)) {
+            throw new ValidationException("Path " + parent.toAbsolutePath() + " cannot be read.");
+        }
+
+        if (Files.exists(path) && !Files.isDirectory(path)) {
+            throw new ValidationException("Path " + path.toAbsolutePath() + " is not a directory.");
+        }
+
+        if (Files.exists(path) && !Files.isReadable(path)) {
+            throw new ValidationException("Path " + path.toAbsolutePath() + " cannot be read.");
+        }
     }
 }

--- a/graylog2-server/src/test/java/org/graylog2/configuration/ElasticsearchConfigurationTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/configuration/ElasticsearchConfigurationTest.java
@@ -20,16 +20,24 @@ import com.github.joschi.jadconfig.JadConfig;
 import com.github.joschi.jadconfig.RepositoryException;
 import com.github.joschi.jadconfig.ValidationException;
 import com.github.joschi.jadconfig.repositories.InMemoryRepository;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
 
+import java.io.File;
+import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assume.assumeTrue;
 
 public class ElasticsearchConfigurationTest {
+    @Rule
+    public final TemporaryFolder temporaryFolder = new TemporaryFolder();
+
     @Test
     public void testGetElasticSearchIndexPrefix() throws RepositoryException, ValidationException {
         ElasticsearchConfiguration configuration = new ElasticsearchConfiguration();
@@ -74,5 +82,91 @@ public class ElasticsearchConfigurationTest {
         new JadConfig(new InMemoryRepository(props), configuration3).process();
 
         assertFalse(configuration3.isClientNode());
+    }
+
+    @Test(expected = ValidationException.class)
+    public void throwValidationExceptionIfHomePathIsNotReadable() throws Exception {
+        final File path = temporaryFolder.newFolder("elasticsearch-home");
+        assumeTrue(path.setReadable(false));
+
+        final ElasticsearchConfiguration configuration = new ElasticsearchConfiguration() {
+            @Override
+            public String getPathHome() {
+                return path.getAbsolutePath();
+            }
+        };
+        new JadConfig(new InMemoryRepository(), configuration).process();
+    }
+
+    @Test(expected = ValidationException.class)
+    public void throwValidationExceptionIfDataPathIsNotReadable() throws Exception {
+        final File path = temporaryFolder.newFolder("elasticsearch-data");
+        assumeTrue(path.setReadable(false));
+
+        final ElasticsearchConfiguration configuration = new ElasticsearchConfiguration() {
+            @Override
+            public String getPathData() {
+                return path.getAbsolutePath();
+            }
+        };
+        new JadConfig(new InMemoryRepository(), configuration).process();
+    }
+
+    @Test(expected = ValidationException.class)
+    public void throwValidationExceptionIfHomePathParentIsNotReadable() throws Exception {
+        final File parent = temporaryFolder.newFolder("elasticsearch");
+        final File path = new File(parent, "home");
+        assumeTrue(path.mkdir());
+        assumeTrue(parent.setReadable(false));
+
+        final ElasticsearchConfiguration configuration = new ElasticsearchConfiguration() {
+            @Override
+            public String getPathHome() {
+                return path.getAbsolutePath();
+            }
+        };
+        new JadConfig(new InMemoryRepository(), configuration).process();
+    }
+
+    @Test(expected = ValidationException.class)
+    public void throwValidationExceptionIfDataPathParentIsNotReadable() throws Exception {
+        final File parent = temporaryFolder.newFolder("elasticsearch");
+        final File path = new File(parent, "data");
+        assumeTrue(path.mkdir());
+        assumeTrue(parent.setReadable(false));
+
+        final ElasticsearchConfiguration configuration = new ElasticsearchConfiguration() {
+            @Override
+            public String getPathData() {
+                return path.getAbsolutePath();
+            }
+        };
+        new JadConfig(new InMemoryRepository(), configuration).process();
+    }
+
+    @Test(expected = ValidationException.class)
+    public void throwValidationExceptionIfHomePathIsNotADirectory() throws Exception {
+        final File path = temporaryFolder.newFile("elasticsearch-home");
+
+        final ElasticsearchConfiguration configuration = new ElasticsearchConfiguration() {
+            @Override
+            public String getPathHome() {
+                return path.getAbsolutePath();
+            }
+        };
+        new JadConfig(new InMemoryRepository(), configuration).process();
+    }
+
+    @Test(expected = ValidationException.class)
+    public void throwValidationExceptionIfDataPathIsNotADirectory() throws Exception {
+        final File path = temporaryFolder.newFile("elasticsearch-data");
+
+        final ElasticsearchConfiguration configuration = new ElasticsearchConfiguration() {
+            @Override
+            public String getPathData() {
+                return path.getAbsolutePath();
+            }
+        };
+        new JadConfig(new InMemoryRepository(), configuration).process();
     }
 }


### PR DESCRIPTION
These validations will ensure that cases like #2536 result in a better error message.