### PR TITLE
Make version comparison more lenient with pre-release versions

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/plugin/Version.java
+++ b/graylog2-server/src/main/java/org/graylog2/plugin/Version.java
@@ -278,7 +278,14 @@ public class Version implements Comparable<Version> {
      * @see com.github.zafarkhaja.semver.Version#greaterThanOrEqualTo(com.github.zafarkhaja.semver.Version)
      */
     public boolean sameOrHigher(Version other) {
-        return version.greaterThanOrEqualTo(other.getVersion());
+        if (isNullOrEmpty(version.getPreReleaseVersion())) {
+            return version.greaterThanOrEqualTo(other.getVersion());
+        } else {
+            // If this is a pre-release version, use the major.minor.patch version for comparison with the other.
+            // This allows plugins to require a server version of 2.1.0 and it still gets loaded on a 2.1.0-beta.2 server.
+            // See: https://github.com/Graylog2/graylog2-server/issues/2462
+            return com.github.zafarkhaja.semver.Version.valueOf(version.getNormalVersion()).greaterThanOrEqualTo(other.getVersion());
+        }
     }
 
     /**

--- a/graylog2-server/src/test/java/org/graylog2/plugin/VersionTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/plugin/VersionTest.java
@@ -122,6 +122,16 @@ public class VersionTest {
         assertFalse(v.sameOrHigher(Version.from(2, 19, 0, "rc.1")));
         assertTrue(v.sameOrHigher(Version.from(0, 0, 0)));
         assertFalse(v.sameOrHigher(Version.from(Integer.MAX_VALUE, Integer.MAX_VALUE, Integer.MAX_VALUE)));
+
+        // See https://github.com/Graylog2/graylog2-server/issues/2462
+        v = Version.from(2, 1, 0, "beta.2");
+
+        assertTrue(v.sameOrHigher(Version.from(2, 1, 0, "alpha.1")));
+        assertTrue(v.sameOrHigher(Version.from(2, 1, 0, "beta.1")));
+        assertTrue(v.sameOrHigher(Version.from(2, 1, 0, "beta.2")));
+        assertTrue(v.sameOrHigher(Version.from(2, 1, 0))); // This needs to work!
+        assertFalse(v.sameOrHigher(Version.from(2, 2, 0, "alpha.1")));
+        assertFalse(v.sameOrHigher(Version.from(2, 2, 0)));
     }
 
     @Test


### PR DESCRIPTION
Use the normal version without pre-release and build suffixes to compare
against the other when this a pre-release version.

Makes plugin loading work in a 2.1.0-beta.1 server where the plugin
requires 2.1.0.

Fixes #2462