### PR TITLE
Fix REST API browser after changes to the PluginRestResource injection

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/shared/plugins/PluginRestResourceClasses.java
+++ b/graylog2-server/src/main/java/org/graylog2/shared/plugins/PluginRestResourceClasses.java
@@ -1,0 +1,47 @@
+/**
+ * This file is part of Graylog.
+ *
+ * Graylog is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.graylog2.shared.plugins;
+
+import org.graylog2.plugin.rest.PluginRestResource;
+
+import javax.inject.Inject;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * This class provides the map of {@link PluginRestResource} classes that are available through the Guice mapbinder.
+ *
+ * We need this wrapper class to be able to inject the {@literal Set<Class<? extends PluginRestResource>>} into
+ * a Jersey REST resource. HK2 does not allow to inject this directly into the resource class.
+ */
+public class PluginRestResourceClasses {
+    private final Map<String, Set<Class<? extends PluginRestResource>>> pluginRestResources;
+
+    @Inject
+    public PluginRestResourceClasses(final Map<String, Set<Class<? extends PluginRestResource>>> pluginRestResources) {
+        this.pluginRestResources = pluginRestResources;
+    }
+
+    /**
+     * Returns a map of plugin packge names to Sets of {@link PluginRestResource} classes.
+     *
+     * @return the map
+     */
+    public Map<String, Set<Class<? extends PluginRestResource>>> getMap() {
+        return pluginRestResources;
+    }
+}

--- a/graylog2-server/src/main/java/org/graylog2/shared/rest/resources/documentation/DocumentationResource.java
+++ b/graylog2-server/src/main/java/org/graylog2/shared/rest/resources/documentation/DocumentationResource.java
@@ -23,6 +23,7 @@ import io.swagger.annotations.ApiParam;
 import org.graylog2.plugin.BaseConfiguration;
 import org.graylog2.plugin.rest.PluginRestResource;
 import org.graylog2.rest.RestTools;
+import org.graylog2.shared.plugins.PluginRestResourceClasses;
 import org.graylog2.shared.rest.documentation.generator.Generator;
 import org.graylog2.shared.rest.resources.RestResource;
 
@@ -55,19 +56,19 @@ public class DocumentationResource extends RestResource {
     @Inject
     public DocumentationResource(BaseConfiguration configuration,
                                  @Named("RestControllerPackages") String[] restControllerPackages,
-                                 Map<String, Set<PluginRestResource>> pluginRestResources) {
+                                 PluginRestResourceClasses pluginRestResourceClasses) {
 
         this.configuration = configuration;
 
         this.restControllerPackages.addAll(Arrays.asList(restControllerPackages));
 
         // All plugin resources get the plugin prefix + the plugin package.
-        for (Map.Entry<String, Set<PluginRestResource>> entry : pluginRestResources.entrySet()) {
+        for (Map.Entry<String, Set<Class<? extends PluginRestResource>>> entry : pluginRestResourceClasses.getMap().entrySet()) {
             final String pluginPackage = entry.getKey();
             this.restControllerPackages.add(pluginPackage);
 
-            for (PluginRestResource pluginRestResource : entry.getValue()) {
-                this.pluginRestControllerMapping.put(pluginRestResource.getClass(), pluginPackage);
+            for (Class<? extends PluginRestResource> pluginRestResource : entry.getValue()) {
+                this.pluginRestControllerMapping.put(pluginRestResource, pluginPackage);
             }
         }
     }


### PR DESCRIPTION
Create a wrapper class for the map of PluginRestResource classes to make
it injectable into Jersey resources.

Fallout from #2492.