### PR TITLE
Display original date time of index ranges on hover

### DIFF
--- a/graylog2-web-interface/src/components/indices/IndexSummary.jsx
+++ b/graylog2-web-interface/src/components/indices/IndexSummary.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { Label } from 'react-bootstrap';
 
+import { Timestamp } from 'components/common';
 import DateTime from 'logic/datetimes/DateTime';
 
 import { IndexSizeSummary } from 'components/indices';
@@ -35,7 +36,7 @@ const IndexSummary = React.createClass({
 
   _formatIndexRange() {
     if (this.props.isDeflector) {
-      return `Contains messages up to ${new DateTime().toRelativeString()}`;
+      return <span>Contains messages up to <Timestamp dateTime={new DateTime().toISOString()} relative /></span>;
     }
 
     const sizes = this.props.index.size;
@@ -52,10 +53,15 @@ const IndexSummary = React.createClass({
     }
 
     if (this.props.indexRange.begin === 0) {
-      return `Contains messages up to ${new DateTime(this.props.indexRange.end).toRelativeString()}`;
+      return <span>Contains messages up to <Timestamp dateTime={this.props.indexRange.end} relative /></span>;
     }
 
-    return `Contains messages from ${new DateTime(this.props.indexRange.begin).toRelativeString()} up to ${new DateTime(this.props.indexRange.end).toRelativeString()}`;
+    return (
+      <span>
+        Contains messages from <Timestamp dateTime={this.props.indexRange.begin} relative /> up to{' '}
+        <Timestamp dateTime={this.props.indexRange.end} relative />
+      </span>
+    );
   },
   _formatShowDetailsLink() {
     if (this.state.showDetails) {

--- a/graylog2-web-interface/src/logic/datetimes/DateTime.js
+++ b/graylog2-web-interface/src/logic/datetimes/DateTime.js
@@ -64,6 +64,10 @@ class DateTime {
   }
 
   constructor(dateTime) {
+    if (!dateTime) {
+      this.dateTime = DateTime.now();
+      return;
+    }
     // Always use user's local time
     this.dateTime = moment.tz(dateTime, DateTime.getUserTimezone());
   }


### PR DESCRIPTION
Before it was possible to see the actual date time of index ranges by hovering over the relative time displayed in the UI, but on 2.0.3 that was not possible any more. This PR brings back that functionality, fixing #2549.