### PR TITLE
Fix load problems by setting __webpack_public_path__ early

### DIFF
--- a/graylog2-web-interface/src/index.jsx
+++ b/graylog2-web-interface/src/index.jsx
@@ -1,11 +1,20 @@
-import React from 'react';
-import ReactDOM from 'react-dom';
-import AppFacade from 'routing/AppFacade';
-import AppConfig from 'util/AppConfig';
-import Promise from 'bluebird';
-import Reflux from 'reflux';
+const AppConfig = require('util/AppConfig');
 
+// This needs to be set as early as possible to avoid problems with loading
+// CSS. If this is set after requiring AppFacade, everything required in the
+// AppFacade (like CSS) does not get the app path prefix and fails to load
+// if the URL is not /. (i.e. entering /system/overview in the browser
+// address bar works but the font-awesome icons are not loaded)
 __webpack_public_path__ = AppConfig.gl2AppPathPrefix() + '/';
+
+// We have to use require() here to ensure that __webpack_public_path__ is set
+// first. When using import the __webpack_public_path__ setting is moved after
+// all imports...
+const React = require('react');
+const ReactDOM = require('react-dom');
+const AppFacade = require('routing/AppFacade');
+const Promise = require('bluebird');
+const Reflux = require('reflux');
 
 Reflux.setPromiseFactory((handlers) => new Promise(handlers));
 


### PR DESCRIPTION
The __webpack_public_path__ needs to be set as early as possible to
ensure that all code injections into the web page know about it.

Use require() instead of import in src/index.jsx to avoid reordering of
the code.

**WARNING**: This fixes the issue in the core web interface, but plugins are still not getting the app path prefix because they are living in a separate webpack bundle. This needs to be fixed.