### PR TITLE
Fix bulk import of Grok patterns

### DIFF
--- a/graylog2-web-interface/src/components/grok-patterns/BulkLoadPatternModal.jsx
+++ b/graylog2-web-interface/src/components/grok-patterns/BulkLoadPatternModal.jsx
@@ -21,9 +21,9 @@ const BulkLoadPatternModal = React.createClass({
     reader.onload = (loaded) => {
       const request = loaded.target.result.split('\n').map((line) => {
         if (!line.startsWith('#')) {
-          const splitted = line.split(/\s+/, 2);
-          if (splitted.length > 1) {
-            return {name: splitted[0], pattern: splitted[1]};
+          const splitted = line.match(/^(\w+)\s+(.*)$/)
+          if (splitted != null && splitted.length === 3) {
+            return {name: splitted[1], pattern: splitted[2]};
           }
         }
       }).filter((elem) => elem !== undefined);


### PR DESCRIPTION
The original code didn't account for Grok patterns containing whitespaces which
lead to truncated patterns when using bulk import.

Fixes #2229