### PR TITLE
Fix issues with app prefix

### DIFF
--- a/graylog2-web-interface/src/index.jsx
+++ b/graylog2-web-interface/src/index.jsx
@@ -1,11 +1,12 @@
+// We need to set the app prefix before doing anything else, so it applies to styles too.
+// eslint-disable-next-line no-unused-vars
+import webpackEntry from 'webpack-entry';
+
 import React from 'react';
 import ReactDOM from 'react-dom';
 import AppFacade from 'routing/AppFacade';
-import AppConfig from 'util/AppConfig';
 import Promise from 'bluebird';
 import Reflux from 'reflux';
-
-__webpack_public_path__ = AppConfig.gl2AppPathPrefix() + '/';
 
 Reflux.setPromiseFactory((handlers) => new Promise(handlers));
 

--- a/graylog2-web-interface/src/routing/Routes.jsx
+++ b/graylog2-web-interface/src/routing/Routes.jsx
@@ -124,8 +124,8 @@ const qualifyUrls = (routes, appPrefix) => {
         qualifiedRoutes[routeName] = `${appPrefix}${routes[routeName]}`;
         break;
       case 'function':
-        qualifiedRoutes[routeName] = function () {
-          const result = routes[routeName](...arguments);
+        qualifiedRoutes[routeName] = (...params) => {
+          const result = routes[routeName](...params);
           return `${appPrefix}${result}`;
         };
         break;

--- a/graylog2-web-interface/src/routing/Routes.jsx
+++ b/graylog2-web-interface/src/routing/Routes.jsx
@@ -144,6 +144,13 @@ const defaultExport = AppConfig.gl2AppPathPrefix() ? qualifyUrls(Routes, AppConf
 window.pluginRoutes = AppConfig.gl2AppPathPrefix() ? qualifyUrls(pluginRoutes, AppConfig.gl2AppPathPrefix()) : pluginRoutes;
 
 // Plugin routes need to be prefixed separately, so we add them to the Routes object just at the end.
-defaultExport.pluginRoute = (key) => window.pluginRoutes[key];
+defaultExport.pluginRoute = (key) => {
+  const route = window.pluginRoutes[key];
+  if (!route) {
+    console.error(`Could not find plugin route '${key}'.`);
+  }
+
+  return route;
+};
 
 export default defaultExport;

--- a/graylog2-web-interface/src/routing/Routes.jsx
+++ b/graylog2-web-interface/src/routing/Routes.jsx
@@ -28,7 +28,7 @@ PluginStore.exports('routes').forEach(pluginRoute => {
   if (paramNames.length > 0) {
     pluginRoutes[key] = (...paramValues) => {
       paramNames.forEach((param, idx) => {
-        const value = paramValues[idx];
+        const value = String(paramValues[idx]);
         uri.segment(segments.indexOf(param), value);
       });
 

--- a/graylog2-web-interface/src/routing/Routes.jsx
+++ b/graylog2-web-interface/src/routing/Routes.jsx
@@ -41,8 +41,6 @@ PluginStore.exports('routes').forEach(pluginRoute => {
   pluginRoutes[key] = pluginRoute.path;
 });
 
-window.pluginRoutes = pluginRoutes;
-
 const Routes = {
   STARTPAGE: '/',
   SEARCH: '/search',
@@ -114,8 +112,6 @@ const Routes = {
   edit_input_extractor: (nodeId, inputId, extractorId) => `/system/inputs/${nodeId}/${inputId}/extractors/${extractorId}/edit`,
   getting_started: (fromMenu) => `${Routes.GETTING_STARTED}?menu=${fromMenu}`,
   filtered_metrics: (nodeId, filter) => `${Routes.SYSTEM.METRICS(nodeId)}?filter=${filter}`,
-
-  pluginRoute: (key) => window.pluginRoutes[key],
 };
 
 
@@ -144,7 +140,10 @@ const qualifyUrls = (routes, appPrefix) => {
   return qualifiedRoutes;
 };
 
-
 const defaultExport = AppConfig.gl2AppPathPrefix() ? qualifyUrls(Routes, AppConfig.gl2AppPathPrefix()) : Routes;
+window.pluginRoutes = AppConfig.gl2AppPathPrefix() ? qualifyUrls(pluginRoutes, AppConfig.gl2AppPathPrefix()) : pluginRoutes;
+
+// Plugin routes need to be prefixed separately, so we add them to the Routes object just at the end.
+defaultExport.pluginRoute = (key) => window.pluginRoutes[key];
 
 export default defaultExport;

--- a/graylog2-web-interface/src/routing/Routes.jsx
+++ b/graylog2-web-interface/src/routing/Routes.jsx
@@ -1,4 +1,47 @@
 import AppConfig from 'util/AppConfig';
+import { PluginStore } from 'graylog-web-plugin/plugin';
+import URI from 'urijs';
+
+/*
+ * Global registry of plugin routes. Route names are generated automatically from the route path, by removing
+ * any colons, replacing slashes with underscores, and making the string uppercase. Below there is an example of how
+ * to access the routes.
+ *
+ * Plugin register example:
+ * routes: [
+ *           { path: '/system/pipelines', component: Foo },
+ *           { path: '/system/pipelines/:pipelineId', component: Bar },
+ * ]
+ *
+ * Using routes on plugin components:
+ * <LinkContainer to={Routes.pluginRoutes('SYSTEM_PIPELINES')}>...</LinkContainer>
+ * <LinkContainer to={Routes.pluginRoutes('SYSTEM_PIPELINES_PIPELINEID')(123)}>...</LinkContainer>
+ *
+ */
+const pluginRoutes = {};
+PluginStore.exports('routes').forEach(pluginRoute => {
+  const uri = new URI(pluginRoute.path);
+  const segments = uri.segment();
+  const key = segments.map(segment => segment.replace(':', '')).join('_').toUpperCase();
+  const paramNames = segments.filter(segment => segment.startsWith(':'));
+
+  if (paramNames.length > 0) {
+    pluginRoutes[key] = (...paramValues) => {
+      paramNames.forEach((param, idx) => {
+        const value = paramValues[idx];
+        uri.segment(segments.indexOf(param), value);
+      });
+
+      return uri.pathname();
+    };
+
+    return;
+  }
+
+  pluginRoutes[key] = pluginRoute.path;
+});
+
+window.pluginRoutes = pluginRoutes;
 
 const Routes = {
   STARTPAGE: '/',
@@ -71,7 +114,10 @@ const Routes = {
   edit_input_extractor: (nodeId, inputId, extractorId) => `/system/inputs/${nodeId}/${inputId}/extractors/${extractorId}/edit`,
   getting_started: (fromMenu) => `${Routes.GETTING_STARTED}?menu=${fromMenu}`,
   filtered_metrics: (nodeId, filter) => `${Routes.SYSTEM.METRICS(nodeId)}?filter=${filter}`,
+
+  pluginRoute: (key) => window.pluginRoutes[key],
 };
+
 
 const qualifyUrls = (routes, appPrefix) => {
   const qualifiedRoutes = {};
@@ -82,7 +128,7 @@ const qualifyUrls = (routes, appPrefix) => {
         qualifiedRoutes[routeName] = `${appPrefix}${routes[routeName]}`;
         break;
       case 'function':
-        qualifiedRoutes[routeName] = function() {
+        qualifiedRoutes[routeName] = function () {
           const result = routes[routeName](...arguments);
           return `${appPrefix}${result}`;
         };
@@ -97,6 +143,7 @@ const qualifyUrls = (routes, appPrefix) => {
 
   return qualifiedRoutes;
 };
+
 
 const defaultExport = AppConfig.gl2AppPathPrefix() ? qualifyUrls(Routes, AppConfig.gl2AppPathPrefix()) : Routes;
 

--- a/graylog2-web-interface/src/webpack-entry.js
+++ b/graylog2-web-interface/src/webpack-entry.js
@@ -1,0 +1,4 @@
+import URI from 'urijs';
+import AppConfig from 'util/AppConfig';
+
+__webpack_public_path__ = URI.joinPaths(AppConfig.gl2AppPathPrefix(), '/').path();

--- a/graylog2-web-interface/src/webpack-entry.js
+++ b/graylog2-web-interface/src/webpack-entry.js
@@ -1,4 +1,5 @@
 import URI from 'urijs';
 import AppConfig from 'util/AppConfig';
 
-__webpack_public_path__ = URI.joinPaths(AppConfig.gl2AppPathPrefix(), '/').path();
+// If app prefix was not set, we need to tell webpack to load chunks from root instead of the relative URL path
+__webpack_public_path__ = URI.joinPaths(AppConfig.gl2AppPathPrefix(), '/').path() || '/';


### PR DESCRIPTION
The current implementation handling an app prefix has some issues:

1. Reloading a page in a subdirectory, e.g. `/system/overview`, is not able to fetch fonts and other assets. This is fixed by setting `__webpack_public_path__` earlier, and falling back to `/` when no app prefix is set
1. Routes used in plugins are not adding the app prefix set, making navigation within the plugin impossible if the application prefix is set. This is partially fixed, by adding a registry of plugin routes that are automatically prefixed if needed. Plugins need to use that registry to fix their navigation
1. Plugins do not know about the `__webpack_public_path__` setting, so they may use a wrong public path. This needs to be fixed in the plugins directly
