### PR TITLE
Move Error Prone into default build profile 

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/Configuration.java
+++ b/graylog2-server/src/main/java/org/graylog2/Configuration.java
@@ -198,6 +198,7 @@ public class Configuration extends BaseConfiguration {
         return droolsRulesFile;
     }
 
+    @Override
     public String getNodeIdFile() {
         return nodeIdFile;
     }

--- a/graylog2-server/src/main/java/org/graylog2/alarmcallbacks/EmailAlarmCallback.java
+++ b/graylog2-server/src/main/java/org/graylog2/alarmcallbacks/EmailAlarmCallback.java
@@ -58,6 +58,7 @@ public class EmailAlarmCallback implements AlarmCallback {
         this.nodeId = nodeId;
     }
 
+    @Override
     public void call(Stream stream, AlertCondition.CheckResult result) {
         // Send alerts.
         AlertCondition alertCondition = result.getTriggeredCondition();

--- a/graylog2-server/src/main/java/org/graylog2/alerts/AbstractAlertCondition.java
+++ b/graylog2-server/src/main/java/org/graylog2/alerts/AbstractAlertCondition.java
@@ -43,6 +43,7 @@ public abstract class AbstractAlertCondition implements EmbeddedPersistable, Ale
         DUMMY;
 
         @JsonValue
+        @Override
         public String toString() {
             return super.toString().toLowerCase(Locale.ENGLISH);
         }
@@ -107,6 +108,7 @@ public abstract class AbstractAlertCondition implements EmbeddedPersistable, Ale
     }
 
     @JsonIgnore
+    @Override
     public Stream getStream() {
         return stream;
     }
@@ -172,18 +174,22 @@ public abstract class AbstractAlertCondition implements EmbeddedPersistable, Ale
             }
         }
 
+        @Override
         public boolean isTriggered() {
             return isTriggered;
         }
 
+        @Override
         public String getResultDescription() {
             return resultDescription;
         }
 
+        @Override
         public AlertCondition getTriggeredCondition() {
             return triggeredCondition;
         }
 
+        @Override
         public DateTime getTriggeredAt() {
             return triggeredAt;
         }

--- a/graylog2-server/src/main/java/org/graylog2/alerts/AlertServiceImpl.java
+++ b/graylog2-server/src/main/java/org/graylog2/alerts/AlertServiceImpl.java
@@ -164,9 +164,9 @@ public class AlertServiceImpl extends PersistedServiceImpl implements AlertServi
                 return fieldValueAlertFactory.createAlertCondition(stream, id, createdAt, creatorId, parameters, title);
             case FIELD_CONTENT_VALUE:
                 return fieldContentValueAlertFactory.createAlertCondition(stream, id, createdAt, creatorId, parameters, title);
+            default:
+                throw new AbstractAlertCondition.NoSuchAlertConditionTypeException("Unhandled alert condition type: " + type);
         }
-
-        throw new AbstractAlertCondition.NoSuchAlertConditionTypeException("Unhandled alert condition type: " + type);
     }
 
     @Override

--- a/graylog2-server/src/main/java/org/graylog2/dashboards/Dashboard.java
+++ b/graylog2-server/src/main/java/org/graylog2/dashboards/Dashboard.java
@@ -43,6 +43,4 @@ public interface Dashboard extends Persisted {
     DashboardWidget removeWidget(DashboardWidget widget);
 
     Map<String, DashboardWidget> getWidgets();
-
-    Map<String, Object> asMap();
 }

--- a/graylog2-server/src/main/java/org/graylog2/dashboards/widgets/DashboardWidget.java
+++ b/graylog2-server/src/main/java/org/graylog2/dashboards/widgets/DashboardWidget.java
@@ -89,6 +89,7 @@ public final class DashboardWidget implements EmbeddedPersistable {
         return creatorUserId;
     }
 
+    @Override
     public Map<String, Object> getPersistedFields() {
         return ImmutableMap.<String, Object>builder()
                 .put(FIELD_ID, id)

--- a/graylog2-server/src/main/java/org/graylog2/dashboards/widgets/WidgetResultCache.java
+++ b/graylog2-server/src/main/java/org/graylog2/dashboards/widgets/WidgetResultCache.java
@@ -70,7 +70,7 @@ public class WidgetResultCache {
         counter.dec();
     }
 
-    private class ComputationResultSupplier implements Supplier<ComputationResult> {
+    private static class ComputationResultSupplier implements Supplier<ComputationResult> {
         private final MetricRegistry metricRegistry;
         private final DashboardWidget dashboardWidget;
         private final WidgetStrategy widgetStrategy;

--- a/graylog2-server/src/main/java/org/graylog2/decorators/DecoratorImpl.java
+++ b/graylog2-server/src/main/java/org/graylog2/decorators/DecoratorImpl.java
@@ -50,6 +50,7 @@ public abstract class DecoratorImpl implements Decorator, Comparable {
     @JsonProperty(FIELD_ID)
     @ObjectId
     @Nullable
+    @Override
     public abstract String id();
 
     @JsonProperty(FIELD_TYPE)

--- a/graylog2-server/src/main/java/org/graylog2/indexer/IndexFailure.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/IndexFailure.java
@@ -18,11 +18,5 @@ package org.graylog2.indexer;
 
 import org.graylog2.plugin.database.Persisted;
 
-import java.util.Map;
-
-/**
- * @author Dennis Oelkers <dennis@torch.sh>
- */
 public interface IndexFailure extends Persisted {
-    Map<String, Object> asMap();
 }

--- a/graylog2-server/src/main/java/org/graylog2/indexer/indices/jobs/SetIndexReadOnlyAndCalculateRangeJob.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/indices/jobs/SetIndexReadOnlyAndCalculateRangeJob.java
@@ -45,6 +45,7 @@ public class SetIndexReadOnlyAndCalculateRangeJob extends SystemJob {
         this.indexName = indexName;
     }
 
+    @Override
     public void execute() {
         final SystemJob setIndexReadOnlyJob = setIndexReadOnlyJobFactory.create(indexName);
         setIndexReadOnlyJob.execute();

--- a/graylog2-server/src/main/java/org/graylog2/indexer/ranges/EsIndexRange.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/ranges/EsIndexRange.java
@@ -33,18 +33,23 @@ public abstract class EsIndexRange implements IndexRange {
     public static final String FIELD_INDEX_NAME = PREFIX + "index_name";
 
     @JsonProperty(FIELD_INDEX_NAME)
+    @Override
     public abstract String indexName();
 
     @JsonProperty(FIELD_BEGIN)
+    @Override
     public abstract DateTime begin();
 
     @JsonProperty(FIELD_END)
+    @Override
     public abstract DateTime end();
 
     @JsonProperty(FIELD_CALCULATED_AT)
+    @Override
     public abstract DateTime calculatedAt();
 
     @JsonProperty(FIELD_TOOK_MS)
+    @Override
     public abstract int calculationDuration();
 
     public static EsIndexRange create(String indexName,

--- a/graylog2-server/src/main/java/org/graylog2/indexer/ranges/MongoIndexRange.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/ranges/MongoIndexRange.java
@@ -37,15 +37,20 @@ public abstract class MongoIndexRange implements IndexRange {
     public abstract ObjectId id();
 
     @JsonProperty(FIELD_INDEX_NAME)
+    @Override
     public abstract String indexName();
 
+    @Override
     public abstract DateTime begin();
 
+    @Override
     public abstract DateTime end();
 
+    @Override
     public abstract DateTime calculatedAt();
 
     @JsonProperty(FIELD_TOOK_MS)
+    @Override
     public abstract int calculationDuration();
 
     @JsonProperty(FIELD_BEGIN)

--- a/graylog2-server/src/main/java/org/graylog2/indexer/results/FieldHistogramResult.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/results/FieldHistogramResult.java
@@ -51,10 +51,12 @@ public class FieldHistogramResult extends HistogramResult {
         this.interval = interval;
     }
 
+    @Override
     public Searches.DateHistogramInterval getInterval() {
         return interval;
     }
 
+    @Override
     public Map<Long, Map<String, Number>> getResults() {
         if (result.getBuckets().isEmpty()) {
             return Collections.emptyMap();

--- a/graylog2-server/src/main/java/org/graylog2/inputs/codecs/CodecsModule.java
+++ b/graylog2-server/src/main/java/org/graylog2/inputs/codecs/CodecsModule.java
@@ -28,6 +28,7 @@ import org.graylog2.plugin.inject.Graylog2Module;
 import org.graylog2.plugin.inputs.codecs.Codec;
 
 public class CodecsModule extends Graylog2Module {
+    @Override
     protected void configure() {
         final MapBinder<String, Codec.Factory<? extends Codec>> mapBinder = codecMapBinder();
 

--- a/graylog2-server/src/main/java/org/graylog2/inputs/syslog/tcp/SyslogTCPInput.java
+++ b/graylog2-server/src/main/java/org/graylog2/inputs/syslog/tcp/SyslogTCPInput.java
@@ -65,6 +65,7 @@ public class SyslogTCPInput extends MessageInput {
     }
 
     public interface Factory extends MessageInput.Factory<SyslogTCPInput> {
+        @Override
         SyslogTCPInput create(Configuration configuration);
 
         @Override

--- a/graylog2-server/src/main/java/org/graylog2/inputs/transports/HttpTransport.java
+++ b/graylog2-server/src/main/java/org/graylog2/inputs/transports/HttpTransport.java
@@ -200,7 +200,7 @@ public class HttpTransport extends AbstractTcpTransport {
             final String origin = request.headers().get(Names.ORIGIN);
 
             // to allow for future changes, let's be at least a little strict in what we accept here.
-            if (request.getMethod() != HttpMethod.POST) {
+            if (!HttpMethod.POST.equals(request.getMethod())) {
                 writeResponse(channel, keepAlive, httpRequestVersion, METHOD_NOT_ALLOWED, origin);
                 return;
             }

--- a/graylog2-server/src/main/java/org/graylog2/inputs/transports/KafkaTransport.java
+++ b/graylog2-server/src/main/java/org/graylog2/inputs/transports/KafkaTransport.java
@@ -201,6 +201,7 @@ public class KafkaTransport extends ThrottleableTransport {
 
         for (final KafkaStream<byte[], byte[]> stream : streams) {
             executor.submit(new Runnable() {
+                @Override
                 public void run() {
                     final ConsumerIterator<byte[], byte[]> consumerIterator = stream.iterator();
                     boolean retry;

--- a/graylog2-server/src/main/java/org/graylog2/inputs/transports/SyslogTcpTransport.java
+++ b/graylog2-server/src/main/java/org/graylog2/inputs/transports/SyslogTcpTransport.java
@@ -23,11 +23,11 @@ import com.google.common.util.concurrent.ThreadFactoryBuilder;
 import com.google.inject.assistedinject.Assisted;
 import com.google.inject.assistedinject.AssistedInject;
 import org.graylog2.inputs.syslog.tcp.SyslogTCPFramingRouterHandler;
-import org.graylog2.plugin.inputs.annotations.ConfigClass;
-import org.graylog2.plugin.inputs.annotations.FactoryClass;
 import org.graylog2.plugin.LocalMetricRegistry;
 import org.graylog2.plugin.configuration.Configuration;
 import org.graylog2.plugin.inputs.MessageInput;
+import org.graylog2.plugin.inputs.annotations.ConfigClass;
+import org.graylog2.plugin.inputs.annotations.FactoryClass;
 import org.graylog2.plugin.inputs.transports.Transport;
 import org.graylog2.plugin.inputs.util.ConnectionCounter;
 import org.graylog2.plugin.inputs.util.ThroughputCounter;
@@ -85,11 +85,11 @@ public class SyslogTcpTransport extends TcpTransport {
 
     @FactoryClass
     public interface Factory extends Transport.Factory<SyslogTcpTransport> {
+        @Override
         SyslogTcpTransport create(Configuration configuration);
     }
 
     @ConfigClass
     public static class Config extends TcpTransport.Config {
-
     }
 }

--- a/graylog2-server/src/main/java/org/graylog2/inputs/transports/TcpTransport.java
+++ b/graylog2-server/src/main/java/org/graylog2/inputs/transports/TcpTransport.java
@@ -110,6 +110,7 @@ public class TcpTransport extends AbstractTcpTransport {
 
     @FactoryClass
     public interface Factory extends Transport.Factory<TcpTransport> {
+        @Override
         TcpTransport create(Configuration configuration);
 
         @Override

--- a/graylog2-server/src/main/java/org/graylog2/inputs/transports/TransportsModule.java
+++ b/graylog2-server/src/main/java/org/graylog2/inputs/transports/TransportsModule.java
@@ -26,6 +26,7 @@ import java.util.concurrent.Executor;
 import java.util.concurrent.Executors;
 
 public class TransportsModule extends Graylog2Module {
+    @Override
     protected void configure() {
         final MapBinder<String, Transport.Factory<? extends Transport>> mapBinder = transportMapBinder();
 

--- a/graylog2-server/src/main/java/org/graylog2/notifications/Notification.java
+++ b/graylog2-server/src/main/java/org/graylog2/notifications/Notification.java
@@ -20,8 +20,6 @@ import org.graylog2.cluster.Node;
 import org.graylog2.plugin.database.Persisted;
 import org.joda.time.DateTime;
 
-import java.util.Map;
-
 public interface Notification extends Persisted {
     Notification addType(Type type);
 
@@ -42,8 +40,6 @@ public interface Notification extends Persisted {
     Notification addDetail(String key, Object value);
 
     Object getDetail(String key);
-
-    Map<String, Object> asMap();
 
     Notification addNode(String nodeId);
 

--- a/graylog2-server/src/main/java/org/graylog2/outputs/BenchmarkOutput.java
+++ b/graylog2-server/src/main/java/org/graylog2/outputs/BenchmarkOutput.java
@@ -128,7 +128,7 @@ public class BenchmarkOutput implements MessageOutput {
         }
     }
 
-    private class CsvMetricFilter implements MetricFilter {
+    private static class CsvMetricFilter implements MetricFilter {
         private final List<String> prefixes;
 
         public CsvMetricFilter(List<String> prefixes) {

--- a/graylog2-server/src/main/java/org/graylog2/plugin/configuration/fields/AbstractConfigurationField.java
+++ b/graylog2-server/src/main/java/org/graylog2/plugin/configuration/fields/AbstractConfigurationField.java
@@ -35,30 +35,37 @@ public abstract class AbstractConfigurationField implements ConfigurationField {
         this.optional = optional1;
     }
 
+    @Override
     public String getFieldType() {
         return field_type;
     }
 
+    @Override
     public ConfigurationField.Optional isOptional() {
         return optional;
     }
 
+    @Override
     public String getName() {
         return name;
     }
 
+    @Override
     public String getHumanName() {
         return humanName;
     }
 
+    @Override
     public String getDescription() {
         return description;
     }
 
+    @Override
     public List<String> getAttributes() {
         return Collections.emptyList();
     }
 
+    @Override
     public Map<String, Map<String, String>> getAdditionalInformation() {
         return Collections.emptyMap();
     }

--- a/graylog2-server/src/main/java/org/graylog2/plugin/indexer/searches/timeranges/AbsoluteRange.java
+++ b/graylog2-server/src/main/java/org/graylog2/plugin/indexer/searches/timeranges/AbsoluteRange.java
@@ -35,6 +35,7 @@ public abstract class AbsoluteRange extends TimeRange {
     public static final String ABSOLUTE = "absolute";
 
     @JsonProperty
+    @Override
     public abstract String type();
 
     @JsonProperty

--- a/graylog2-server/src/main/java/org/graylog2/plugin/indexer/searches/timeranges/KeywordRange.java
+++ b/graylog2-server/src/main/java/org/graylog2/plugin/indexer/searches/timeranges/KeywordRange.java
@@ -36,6 +36,7 @@ public abstract class KeywordRange extends TimeRange {
     public static final String KEYWORD = "keyword";
 
     @JsonProperty
+    @Override
     public abstract String type();
 
     @JsonProperty
@@ -67,6 +68,7 @@ public abstract class KeywordRange extends TimeRange {
     }
 
     @JsonIgnore
+    @Override
     public DateTime getFrom() {
         try {
             return parseResult(keyword()).getFrom();
@@ -76,6 +78,7 @@ public abstract class KeywordRange extends TimeRange {
     }
 
     @JsonIgnore
+    @Override
     public DateTime getTo() {
         try {
             return parseResult(keyword()).getTo();

--- a/graylog2-server/src/main/java/org/graylog2/plugin/indexer/searches/timeranges/RelativeRange.java
+++ b/graylog2-server/src/main/java/org/graylog2/plugin/indexer/searches/timeranges/RelativeRange.java
@@ -36,6 +36,7 @@ public abstract class RelativeRange extends TimeRange {
     public static final String RELATIVE = "relative";
 
     @JsonProperty
+    @Override
     public abstract String type();
 
     @JsonProperty

--- a/graylog2-server/src/main/java/org/graylog2/plugin/inputs/Extractor.java
+++ b/graylog2-server/src/main/java/org/graylog2/plugin/inputs/Extractor.java
@@ -325,6 +325,7 @@ public abstract class Extractor implements EmbeddedPersistable {
         return conditionType;
     }
 
+    @Override
     public Map<String, Object> getPersistedFields() {
         return ImmutableMap.<String, Object>builder()
                 .put(FIELD_ID, id)

--- a/graylog2-server/src/main/java/org/graylog2/plugin/inputs/MessageInput.java
+++ b/graylog2-server/src/main/java/org/graylog2/plugin/inputs/MessageInput.java
@@ -157,6 +157,7 @@ public abstract class MessageInput implements Stoppable {
         }
     }
 
+    @Override
     public void stop() {
         transport.stop();
         cleanupMetrics();

--- a/graylog2-server/src/main/java/org/graylog2/plugin/inputs/transports/NettyTransport.java
+++ b/graylog2-server/src/main/java/org/graylog2/plugin/inputs/transports/NettyTransport.java
@@ -319,7 +319,7 @@ public abstract class NettyTransport implements Transport {
         }
     }
 
-    private class RawMessageHandler extends SimpleChannelHandler {
+    private static class RawMessageHandler extends SimpleChannelHandler {
         private final MessageInput input;
 
         public RawMessageHandler(MessageInput input) {

--- a/graylog2-server/src/main/java/org/graylog2/plugin/journal/JournalMessages.java
+++ b/graylog2-server/src/main/java/org/graylog2/plugin/journal/JournalMessages.java
@@ -179,6 +179,7 @@ public final class JournalMessages {
       return defaultInstance;
     }
 
+    @java.lang.Override
     public JournalMessage getDefaultInstanceForType() {
       return defaultInstance;
     }
@@ -291,6 +292,7 @@ public final class JournalMessages {
       return org.graylog2.plugin.journal.JournalMessages.internal_static_org_graylog2_plugin_journal_JournalMessage_descriptor;
     }
 
+    @java.lang.Override
     protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
         internalGetFieldAccessorTable() {
       return org.graylog2.plugin.journal.JournalMessages.internal_static_org_graylog2_plugin_journal_JournalMessage_fieldAccessorTable
@@ -300,7 +302,8 @@ public final class JournalMessages {
 
     public static com.google.protobuf.Parser<JournalMessage> PARSER =
         new com.google.protobuf.AbstractParser<JournalMessage>() {
-      public JournalMessage parsePartialFrom(
+    @java.lang.Override
+    public JournalMessage parsePartialFrom(
           com.google.protobuf.CodedInputStream input,
           com.google.protobuf.ExtensionRegistryLite extensionRegistry)
           throws com.google.protobuf.InvalidProtocolBufferException {
@@ -319,12 +322,14 @@ public final class JournalMessages {
     /**
      * <code>optional uint32 version = 1;</code>
      */
+    @java.lang.Override
     public boolean hasVersion() {
       return ((bitField0_ & 0x00000001) == 0x00000001);
     }
     /**
      * <code>optional uint32 version = 1;</code>
      */
+    @java.lang.Override
     public int getVersion() {
       return version_;
     }
@@ -338,6 +343,7 @@ public final class JournalMessages {
      * uuid, time is upper 64 bits, clockseq is lower 64 bits of the 128 bit uuid value
      * </pre>
      */
+    @java.lang.Override
     public boolean hasUuidTime() {
       return ((bitField0_ & 0x00000002) == 0x00000002);
     }
@@ -348,6 +354,7 @@ public final class JournalMessages {
      * uuid, time is upper 64 bits, clockseq is lower 64 bits of the 128 bit uuid value
      * </pre>
      */
+    @java.lang.Override
     public long getUuidTime() {
       return uuidTime_;
     }
@@ -357,12 +364,14 @@ public final class JournalMessages {
     /**
      * <code>optional fixed64 uuid_clockseq = 3;</code>
      */
+    @java.lang.Override
     public boolean hasUuidClockseq() {
       return ((bitField0_ & 0x00000004) == 0x00000004);
     }
     /**
      * <code>optional fixed64 uuid_clockseq = 3;</code>
      */
+    @java.lang.Override
     public long getUuidClockseq() {
       return uuidClockseq_;
     }
@@ -376,6 +385,7 @@ public final class JournalMessages {
      * milliseconds since Java epoch (1970/01/01 00:00:00.000)
      * </pre>
      */
+    @java.lang.Override
     public boolean hasTimestamp() {
       return ((bitField0_ & 0x00000008) == 0x00000008);
     }
@@ -386,6 +396,7 @@ public final class JournalMessages {
      * milliseconds since Java epoch (1970/01/01 00:00:00.000)
      * </pre>
      */
+    @java.lang.Override
     public long getTimestamp() {
       return timestamp_;
     }
@@ -395,18 +406,21 @@ public final class JournalMessages {
     /**
      * <code>optional .org.graylog2.plugin.journal.CodecInfo codec = 5;</code>
      */
+    @java.lang.Override
     public boolean hasCodec() {
       return ((bitField0_ & 0x00000010) == 0x00000010);
     }
     /**
      * <code>optional .org.graylog2.plugin.journal.CodecInfo codec = 5;</code>
      */
+    @java.lang.Override
     public org.graylog2.plugin.journal.JournalMessages.CodecInfo getCodec() {
       return codec_;
     }
     /**
      * <code>optional .org.graylog2.plugin.journal.CodecInfo codec = 5;</code>
      */
+    @java.lang.Override
     public org.graylog2.plugin.journal.JournalMessages.CodecInfoOrBuilder getCodecOrBuilder() {
       return codec_;
     }
@@ -420,6 +434,7 @@ public final class JournalMessages {
      * the list of graylog2 nodes which have handled the message (radios, servers) in receive order
      * </pre>
      */
+    @java.lang.Override
     public java.util.List<org.graylog2.plugin.journal.JournalMessages.SourceNode> getSourceNodesList() {
       return sourceNodes_;
     }
@@ -430,7 +445,8 @@ public final class JournalMessages {
      * the list of graylog2 nodes which have handled the message (radios, servers) in receive order
      * </pre>
      */
-    public java.util.List<? extends org.graylog2.plugin.journal.JournalMessages.SourceNodeOrBuilder> 
+    @java.lang.Override
+    public java.util.List<? extends org.graylog2.plugin.journal.JournalMessages.SourceNodeOrBuilder>
         getSourceNodesOrBuilderList() {
       return sourceNodes_;
     }
@@ -441,6 +457,7 @@ public final class JournalMessages {
      * the list of graylog2 nodes which have handled the message (radios, servers) in receive order
      * </pre>
      */
+    @java.lang.Override
     public int getSourceNodesCount() {
       return sourceNodes_.size();
     }
@@ -451,6 +468,7 @@ public final class JournalMessages {
      * the list of graylog2 nodes which have handled the message (radios, servers) in receive order
      * </pre>
      */
+    @java.lang.Override
     public org.graylog2.plugin.journal.JournalMessages.SourceNode getSourceNodes(int index) {
       return sourceNodes_.get(index);
     }
@@ -461,6 +479,7 @@ public final class JournalMessages {
      * the list of graylog2 nodes which have handled the message (radios, servers) in receive order
      * </pre>
      */
+    @java.lang.Override
     public org.graylog2.plugin.journal.JournalMessages.SourceNodeOrBuilder getSourceNodesOrBuilder(
         int index) {
       return sourceNodes_.get(index);
@@ -471,18 +490,21 @@ public final class JournalMessages {
     /**
      * <code>optional .org.graylog2.plugin.journal.RemoteAddress remote = 7;</code>
      */
+    @java.lang.Override
     public boolean hasRemote() {
       return ((bitField0_ & 0x00000020) == 0x00000020);
     }
     /**
      * <code>optional .org.graylog2.plugin.journal.RemoteAddress remote = 7;</code>
      */
+    @java.lang.Override
     public org.graylog2.plugin.journal.JournalMessages.RemoteAddress getRemote() {
       return remote_;
     }
     /**
      * <code>optional .org.graylog2.plugin.journal.RemoteAddress remote = 7;</code>
      */
+    @java.lang.Override
     public org.graylog2.plugin.journal.JournalMessages.RemoteAddressOrBuilder getRemoteOrBuilder() {
       return remote_;
     }
@@ -492,12 +514,14 @@ public final class JournalMessages {
     /**
      * <code>optional bytes payload = 8;</code>
      */
+    @java.lang.Override
     public boolean hasPayload() {
       return ((bitField0_ & 0x00000040) == 0x00000040);
     }
     /**
      * <code>optional bytes payload = 8;</code>
      */
+    @java.lang.Override
     public com.google.protobuf.ByteString getPayload() {
       return payload_;
     }
@@ -513,6 +537,7 @@ public final class JournalMessages {
       payload_ = com.google.protobuf.ByteString.EMPTY;
     }
     private byte memoizedIsInitialized = -1;
+    @java.lang.Override
     public final boolean isInitialized() {
       byte isInitialized = memoizedIsInitialized;
       if (isInitialized == 1) return true;
@@ -522,6 +547,7 @@ public final class JournalMessages {
       return true;
     }
 
+    @java.lang.Override
     public void writeTo(com.google.protobuf.CodedOutputStream output)
                         throws java.io.IOException {
       getSerializedSize();
@@ -553,6 +579,7 @@ public final class JournalMessages {
     }
 
     private int memoizedSerializedSize = -1;
+    @java.lang.Override
     public int getSerializedSize() {
       int size = memoizedSerializedSize;
       if (size != -1) return size;
@@ -656,10 +683,12 @@ public final class JournalMessages {
     }
 
     public static Builder newBuilder() { return Builder.create(); }
+    @java.lang.Override
     public Builder newBuilderForType() { return newBuilder(); }
     public static Builder newBuilder(org.graylog2.plugin.journal.JournalMessages.JournalMessage prototype) {
       return newBuilder().mergeFrom(prototype);
     }
+    @java.lang.Override
     public Builder toBuilder() { return newBuilder(this); }
 
     @java.lang.Override
@@ -680,6 +709,7 @@ public final class JournalMessages {
         return org.graylog2.plugin.journal.JournalMessages.internal_static_org_graylog2_plugin_journal_JournalMessage_descriptor;
       }
 
+      @java.lang.Override
       protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
           internalGetFieldAccessorTable() {
         return org.graylog2.plugin.journal.JournalMessages.internal_static_org_graylog2_plugin_journal_JournalMessage_fieldAccessorTable
@@ -708,6 +738,7 @@ public final class JournalMessages {
         return new Builder();
       }
 
+      @java.lang.Override
       public Builder clear() {
         super.clear();
         version_ = 0;
@@ -741,19 +772,23 @@ public final class JournalMessages {
         return this;
       }
 
+      @java.lang.Override
       public Builder clone() {
         return create().mergeFrom(buildPartial());
       }
 
+      @java.lang.Override
       public com.google.protobuf.Descriptors.Descriptor
           getDescriptorForType() {
         return org.graylog2.plugin.journal.JournalMessages.internal_static_org_graylog2_plugin_journal_JournalMessage_descriptor;
       }
 
+      @java.lang.Override
       public org.graylog2.plugin.journal.JournalMessages.JournalMessage getDefaultInstanceForType() {
         return org.graylog2.plugin.journal.JournalMessages.JournalMessage.getDefaultInstance();
       }
 
+      @java.lang.Override
       public org.graylog2.plugin.journal.JournalMessages.JournalMessage build() {
         org.graylog2.plugin.journal.JournalMessages.JournalMessage result = buildPartial();
         if (!result.isInitialized()) {
@@ -762,6 +797,7 @@ public final class JournalMessages {
         return result;
       }
 
+      @java.lang.Override
       public org.graylog2.plugin.journal.JournalMessages.JournalMessage buildPartial() {
         org.graylog2.plugin.journal.JournalMessages.JournalMessage result = new org.graylog2.plugin.journal.JournalMessages.JournalMessage(this);
         int from_bitField0_ = bitField0_;
@@ -816,6 +852,7 @@ public final class JournalMessages {
         return result;
       }
 
+      @java.lang.Override
       public Builder mergeFrom(com.google.protobuf.Message other) {
         if (other instanceof org.graylog2.plugin.journal.JournalMessages.JournalMessage) {
           return mergeFrom((org.graylog2.plugin.journal.JournalMessages.JournalMessage)other);
@@ -878,10 +915,12 @@ public final class JournalMessages {
         return this;
       }
 
+      @java.lang.Override
       public final boolean isInitialized() {
         return true;
       }
 
+      @java.lang.Override
       public Builder mergeFrom(
           com.google.protobuf.CodedInputStream input,
           com.google.protobuf.ExtensionRegistryLite extensionRegistry)
@@ -905,12 +944,14 @@ public final class JournalMessages {
       /**
        * <code>optional uint32 version = 1;</code>
        */
+      @java.lang.Override
       public boolean hasVersion() {
         return ((bitField0_ & 0x00000001) == 0x00000001);
       }
       /**
        * <code>optional uint32 version = 1;</code>
        */
+      @java.lang.Override
       public int getVersion() {
         return version_;
       }
@@ -941,6 +982,7 @@ public final class JournalMessages {
        * uuid, time is upper 64 bits, clockseq is lower 64 bits of the 128 bit uuid value
        * </pre>
        */
+      @java.lang.Override
       public boolean hasUuidTime() {
         return ((bitField0_ & 0x00000002) == 0x00000002);
       }
@@ -951,6 +993,7 @@ public final class JournalMessages {
        * uuid, time is upper 64 bits, clockseq is lower 64 bits of the 128 bit uuid value
        * </pre>
        */
+      @java.lang.Override
       public long getUuidTime() {
         return uuidTime_;
       }
@@ -985,12 +1028,14 @@ public final class JournalMessages {
       /**
        * <code>optional fixed64 uuid_clockseq = 3;</code>
        */
+      @java.lang.Override
       public boolean hasUuidClockseq() {
         return ((bitField0_ & 0x00000004) == 0x00000004);
       }
       /**
        * <code>optional fixed64 uuid_clockseq = 3;</code>
        */
+      @java.lang.Override
       public long getUuidClockseq() {
         return uuidClockseq_;
       }
@@ -1021,6 +1066,7 @@ public final class JournalMessages {
        * milliseconds since Java epoch (1970/01/01 00:00:00.000)
        * </pre>
        */
+      @java.lang.Override
       public boolean hasTimestamp() {
         return ((bitField0_ & 0x00000008) == 0x00000008);
       }
@@ -1031,6 +1077,7 @@ public final class JournalMessages {
        * milliseconds since Java epoch (1970/01/01 00:00:00.000)
        * </pre>
        */
+      @java.lang.Override
       public long getTimestamp() {
         return timestamp_;
       }
@@ -1067,12 +1114,14 @@ public final class JournalMessages {
       /**
        * <code>optional .org.graylog2.plugin.journal.CodecInfo codec = 5;</code>
        */
+      @java.lang.Override
       public boolean hasCodec() {
         return ((bitField0_ & 0x00000010) == 0x00000010);
       }
       /**
        * <code>optional .org.graylog2.plugin.journal.CodecInfo codec = 5;</code>
        */
+      @java.lang.Override
       public org.graylog2.plugin.journal.JournalMessages.CodecInfo getCodec() {
         if (codecBuilder_ == null) {
           return codec_;
@@ -1153,6 +1202,7 @@ public final class JournalMessages {
       /**
        * <code>optional .org.graylog2.plugin.journal.CodecInfo codec = 5;</code>
        */
+      @java.lang.Override
       public org.graylog2.plugin.journal.JournalMessages.CodecInfoOrBuilder getCodecOrBuilder() {
         if (codecBuilder_ != null) {
           return codecBuilder_.getMessageOrBuilder();
@@ -1196,6 +1246,7 @@ public final class JournalMessages {
        * the list of graylog2 nodes which have handled the message (radios, servers) in receive order
        * </pre>
        */
+      @java.lang.Override
       public java.util.List<org.graylog2.plugin.journal.JournalMessages.SourceNode> getSourceNodesList() {
         if (sourceNodesBuilder_ == null) {
           return java.util.Collections.unmodifiableList(sourceNodes_);
@@ -1210,6 +1261,7 @@ public final class JournalMessages {
        * the list of graylog2 nodes which have handled the message (radios, servers) in receive order
        * </pre>
        */
+      @java.lang.Override
       public int getSourceNodesCount() {
         if (sourceNodesBuilder_ == null) {
           return sourceNodes_.size();
@@ -1224,6 +1276,7 @@ public final class JournalMessages {
        * the list of graylog2 nodes which have handled the message (radios, servers) in receive order
        * </pre>
        */
+      @java.lang.Override
       public org.graylog2.plugin.journal.JournalMessages.SourceNode getSourceNodes(int index) {
         if (sourceNodesBuilder_ == null) {
           return sourceNodes_.get(index);
@@ -1418,6 +1471,7 @@ public final class JournalMessages {
        * the list of graylog2 nodes which have handled the message (radios, servers) in receive order
        * </pre>
        */
+      @java.lang.Override
       public org.graylog2.plugin.journal.JournalMessages.SourceNodeOrBuilder getSourceNodesOrBuilder(
           int index) {
         if (sourceNodesBuilder_ == null) {
@@ -1432,7 +1486,8 @@ public final class JournalMessages {
        * the list of graylog2 nodes which have handled the message (radios, servers) in receive order
        * </pre>
        */
-      public java.util.List<? extends org.graylog2.plugin.journal.JournalMessages.SourceNodeOrBuilder> 
+      @java.lang.Override
+      public java.util.List<? extends org.graylog2.plugin.journal.JournalMessages.SourceNodeOrBuilder>
            getSourceNodesOrBuilderList() {
         if (sourceNodesBuilder_ != null) {
           return sourceNodesBuilder_.getMessageOrBuilderList();
@@ -1495,12 +1550,14 @@ public final class JournalMessages {
       /**
        * <code>optional .org.graylog2.plugin.journal.RemoteAddress remote = 7;</code>
        */
+      @java.lang.Override
       public boolean hasRemote() {
         return ((bitField0_ & 0x00000040) == 0x00000040);
       }
       /**
        * <code>optional .org.graylog2.plugin.journal.RemoteAddress remote = 7;</code>
        */
+      @java.lang.Override
       public org.graylog2.plugin.journal.JournalMessages.RemoteAddress getRemote() {
         if (remoteBuilder_ == null) {
           return remote_;
@@ -1581,6 +1638,7 @@ public final class JournalMessages {
       /**
        * <code>optional .org.graylog2.plugin.journal.RemoteAddress remote = 7;</code>
        */
+      @java.lang.Override
       public org.graylog2.plugin.journal.JournalMessages.RemoteAddressOrBuilder getRemoteOrBuilder() {
         if (remoteBuilder_ != null) {
           return remoteBuilder_.getMessageOrBuilder();
@@ -1609,12 +1667,14 @@ public final class JournalMessages {
       /**
        * <code>optional bytes payload = 8;</code>
        */
+      @java.lang.Override
       public boolean hasPayload() {
         return ((bitField0_ & 0x00000080) == 0x00000080);
       }
       /**
        * <code>optional bytes payload = 8;</code>
        */
+      @java.lang.Override
       public com.google.protobuf.ByteString getPayload() {
         return payload_;
       }
@@ -1734,6 +1794,7 @@ public final class JournalMessages {
       return defaultInstance;
     }
 
+    @java.lang.Override
     public RemoteAddress getDefaultInstanceForType() {
       return defaultInstance;
     }
@@ -1800,6 +1861,7 @@ public final class JournalMessages {
       return org.graylog2.plugin.journal.JournalMessages.internal_static_org_graylog2_plugin_journal_RemoteAddress_descriptor;
     }
 
+    @java.lang.Override
     protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
         internalGetFieldAccessorTable() {
       return org.graylog2.plugin.journal.JournalMessages.internal_static_org_graylog2_plugin_journal_RemoteAddress_fieldAccessorTable
@@ -1809,6 +1871,7 @@ public final class JournalMessages {
 
     public static com.google.protobuf.Parser<RemoteAddress> PARSER =
         new com.google.protobuf.AbstractParser<RemoteAddress>() {
+      @java.lang.Override
       public RemoteAddress parsePartialFrom(
           com.google.protobuf.CodedInputStream input,
           com.google.protobuf.ExtensionRegistryLite extensionRegistry)
@@ -1832,6 +1895,7 @@ public final class JournalMessages {
      * the original remote (IP) address of the message sender, unresolved
      * </pre>
      */
+    @java.lang.Override
     public boolean hasAddress() {
       return ((bitField0_ & 0x00000001) == 0x00000001);
     }
@@ -1842,6 +1906,7 @@ public final class JournalMessages {
      * the original remote (IP) address of the message sender, unresolved
      * </pre>
      */
+    @java.lang.Override
     public com.google.protobuf.ByteString getAddress() {
       return address_;
     }
@@ -1855,6 +1920,7 @@ public final class JournalMessages {
      * the port of the sender, if available/applicable
      * </pre>
      */
+    @java.lang.Override
     public boolean hasPort() {
       return ((bitField0_ & 0x00000002) == 0x00000002);
     }
@@ -1865,6 +1931,7 @@ public final class JournalMessages {
      * the port of the sender, if available/applicable
      * </pre>
      */
+    @java.lang.Override
     public int getPort() {
       return port_;
     }
@@ -1878,6 +1945,7 @@ public final class JournalMessages {
      * a processing node can optionally resolve the address early
      * </pre>
      */
+    @java.lang.Override
     public boolean hasResolved() {
       return ((bitField0_ & 0x00000004) == 0x00000004);
     }
@@ -1888,6 +1956,7 @@ public final class JournalMessages {
      * a processing node can optionally resolve the address early
      * </pre>
      */
+    @java.lang.Override
     public java.lang.String getResolved() {
       java.lang.Object ref = resolved_;
       if (ref instanceof java.lang.String) {
@@ -1909,6 +1978,7 @@ public final class JournalMessages {
      * a processing node can optionally resolve the address early
      * </pre>
      */
+    @java.lang.Override
     public com.google.protobuf.ByteString
         getResolvedBytes() {
       java.lang.Object ref = resolved_;
@@ -1929,6 +1999,7 @@ public final class JournalMessages {
       resolved_ = "";
     }
     private byte memoizedIsInitialized = -1;
+    @java.lang.Override
     public final boolean isInitialized() {
       byte isInitialized = memoizedIsInitialized;
       if (isInitialized == 1) return true;
@@ -1938,6 +2009,7 @@ public final class JournalMessages {
       return true;
     }
 
+    @java.lang.Override
     public void writeTo(com.google.protobuf.CodedOutputStream output)
                         throws java.io.IOException {
       getSerializedSize();
@@ -1954,6 +2026,7 @@ public final class JournalMessages {
     }
 
     private int memoizedSerializedSize = -1;
+    @java.lang.Override
     public int getSerializedSize() {
       int size = memoizedSerializedSize;
       if (size != -1) return size;
@@ -2037,10 +2110,12 @@ public final class JournalMessages {
     }
 
     public static Builder newBuilder() { return Builder.create(); }
+    @java.lang.Override
     public Builder newBuilderForType() { return newBuilder(); }
     public static Builder newBuilder(org.graylog2.plugin.journal.JournalMessages.RemoteAddress prototype) {
       return newBuilder().mergeFrom(prototype);
     }
+    @java.lang.Override
     public Builder toBuilder() { return newBuilder(this); }
 
     @java.lang.Override
@@ -2061,6 +2136,7 @@ public final class JournalMessages {
         return org.graylog2.plugin.journal.JournalMessages.internal_static_org_graylog2_plugin_journal_RemoteAddress_descriptor;
       }
 
+      @java.lang.Override
       protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
           internalGetFieldAccessorTable() {
         return org.graylog2.plugin.journal.JournalMessages.internal_static_org_graylog2_plugin_journal_RemoteAddress_fieldAccessorTable
@@ -2086,6 +2162,7 @@ public final class JournalMessages {
         return new Builder();
       }
 
+      @java.lang.Override
       public Builder clear() {
         super.clear();
         address_ = com.google.protobuf.ByteString.EMPTY;
@@ -2097,19 +2174,23 @@ public final class JournalMessages {
         return this;
       }
 
+      @java.lang.Override
       public Builder clone() {
         return create().mergeFrom(buildPartial());
       }
 
+      @java.lang.Override
       public com.google.protobuf.Descriptors.Descriptor
           getDescriptorForType() {
         return org.graylog2.plugin.journal.JournalMessages.internal_static_org_graylog2_plugin_journal_RemoteAddress_descriptor;
       }
 
+      @java.lang.Override
       public org.graylog2.plugin.journal.JournalMessages.RemoteAddress getDefaultInstanceForType() {
         return org.graylog2.plugin.journal.JournalMessages.RemoteAddress.getDefaultInstance();
       }
 
+      @java.lang.Override
       public org.graylog2.plugin.journal.JournalMessages.RemoteAddress build() {
         org.graylog2.plugin.journal.JournalMessages.RemoteAddress result = buildPartial();
         if (!result.isInitialized()) {
@@ -2118,6 +2199,7 @@ public final class JournalMessages {
         return result;
       }
 
+      @java.lang.Override
       public org.graylog2.plugin.journal.JournalMessages.RemoteAddress buildPartial() {
         org.graylog2.plugin.journal.JournalMessages.RemoteAddress result = new org.graylog2.plugin.journal.JournalMessages.RemoteAddress(this);
         int from_bitField0_ = bitField0_;
@@ -2139,6 +2221,7 @@ public final class JournalMessages {
         return result;
       }
 
+      @java.lang.Override
       public Builder mergeFrom(com.google.protobuf.Message other) {
         if (other instanceof org.graylog2.plugin.journal.JournalMessages.RemoteAddress) {
           return mergeFrom((org.graylog2.plugin.journal.JournalMessages.RemoteAddress)other);
@@ -2165,10 +2248,12 @@ public final class JournalMessages {
         return this;
       }
 
+      @java.lang.Override
       public final boolean isInitialized() {
         return true;
       }
 
+      @java.lang.Override
       public Builder mergeFrom(
           com.google.protobuf.CodedInputStream input,
           com.google.protobuf.ExtensionRegistryLite extensionRegistry)
@@ -2196,6 +2281,7 @@ public final class JournalMessages {
        * the original remote (IP) address of the message sender, unresolved
        * </pre>
        */
+      @java.lang.Override
       public boolean hasAddress() {
         return ((bitField0_ & 0x00000001) == 0x00000001);
       }
@@ -2206,6 +2292,7 @@ public final class JournalMessages {
        * the original remote (IP) address of the message sender, unresolved
        * </pre>
        */
+      @java.lang.Override
       public com.google.protobuf.ByteString getAddress() {
         return address_;
       }
@@ -2247,6 +2334,7 @@ public final class JournalMessages {
        * the port of the sender, if available/applicable
        * </pre>
        */
+      @java.lang.Override
       public boolean hasPort() {
         return ((bitField0_ & 0x00000002) == 0x00000002);
       }
@@ -2257,6 +2345,7 @@ public final class JournalMessages {
        * the port of the sender, if available/applicable
        * </pre>
        */
+      @java.lang.Override
       public int getPort() {
         return port_;
       }
@@ -2295,6 +2384,7 @@ public final class JournalMessages {
        * a processing node can optionally resolve the address early
        * </pre>
        */
+      @java.lang.Override
       public boolean hasResolved() {
         return ((bitField0_ & 0x00000004) == 0x00000004);
       }
@@ -2305,6 +2395,7 @@ public final class JournalMessages {
        * a processing node can optionally resolve the address early
        * </pre>
        */
+      @java.lang.Override
       public java.lang.String getResolved() {
         java.lang.Object ref = resolved_;
         if (!(ref instanceof java.lang.String)) {
@@ -2326,6 +2417,7 @@ public final class JournalMessages {
        * a processing node can optionally resolve the address early
        * </pre>
        */
+      @java.lang.Override
       public com.google.protobuf.ByteString
           getResolvedBytes() {
         java.lang.Object ref = resolved_;
@@ -2464,6 +2556,7 @@ public final class JournalMessages {
       return defaultInstance;
     }
 
+    @java.lang.Override
     public CodecInfo getDefaultInstanceForType() {
       return defaultInstance;
     }
@@ -2526,6 +2619,7 @@ public final class JournalMessages {
       return org.graylog2.plugin.journal.JournalMessages.internal_static_org_graylog2_plugin_journal_CodecInfo_descriptor;
     }
 
+    @java.lang.Override
     protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
         internalGetFieldAccessorTable() {
       return org.graylog2.plugin.journal.JournalMessages.internal_static_org_graylog2_plugin_journal_CodecInfo_fieldAccessorTable
@@ -2535,6 +2629,7 @@ public final class JournalMessages {
 
     public static com.google.protobuf.Parser<CodecInfo> PARSER =
         new com.google.protobuf.AbstractParser<CodecInfo>() {
+      @java.lang.Override
       public CodecInfo parsePartialFrom(
           com.google.protobuf.CodedInputStream input,
           com.google.protobuf.ExtensionRegistryLite extensionRegistry)
@@ -2554,12 +2649,14 @@ public final class JournalMessages {
     /**
      * <code>optional string name = 1;</code>
      */
+    @java.lang.Override
     public boolean hasName() {
       return ((bitField0_ & 0x00000001) == 0x00000001);
     }
     /**
      * <code>optional string name = 1;</code>
      */
+    @java.lang.Override
     public java.lang.String getName() {
       java.lang.Object ref = name_;
       if (ref instanceof java.lang.String) {
@@ -2577,6 +2674,7 @@ public final class JournalMessages {
     /**
      * <code>optional string name = 1;</code>
      */
+    @java.lang.Override
     public com.google.protobuf.ByteString
         getNameBytes() {
       java.lang.Object ref = name_;
@@ -2601,6 +2699,7 @@ public final class JournalMessages {
      * for optimal performance make sure the serialization is stable, i.e. same config == same serialization bytes
      * </pre>
      */
+    @java.lang.Override
     public boolean hasConfig() {
       return ((bitField0_ & 0x00000002) == 0x00000002);
     }
@@ -2612,6 +2711,7 @@ public final class JournalMessages {
      * for optimal performance make sure the serialization is stable, i.e. same config == same serialization bytes
      * </pre>
      */
+    @java.lang.Override
     public java.lang.String getConfig() {
       java.lang.Object ref = config_;
       if (ref instanceof java.lang.String) {
@@ -2634,6 +2734,7 @@ public final class JournalMessages {
      * for optimal performance make sure the serialization is stable, i.e. same config == same serialization bytes
      * </pre>
      */
+    @java.lang.Override
     public com.google.protobuf.ByteString
         getConfigBytes() {
       java.lang.Object ref = config_;
@@ -2653,6 +2754,7 @@ public final class JournalMessages {
       config_ = "";
     }
     private byte memoizedIsInitialized = -1;
+    @java.lang.Override
     public final boolean isInitialized() {
       byte isInitialized = memoizedIsInitialized;
       if (isInitialized == 1) return true;
@@ -2662,6 +2764,7 @@ public final class JournalMessages {
       return true;
     }
 
+    @java.lang.Override
     public void writeTo(com.google.protobuf.CodedOutputStream output)
                         throws java.io.IOException {
       getSerializedSize();
@@ -2675,6 +2778,7 @@ public final class JournalMessages {
     }
 
     private int memoizedSerializedSize = -1;
+    @java.lang.Override
     public int getSerializedSize() {
       int size = memoizedSerializedSize;
       if (size != -1) return size;
@@ -2754,10 +2858,12 @@ public final class JournalMessages {
     }
 
     public static Builder newBuilder() { return Builder.create(); }
+    @java.lang.Override
     public Builder newBuilderForType() { return newBuilder(); }
     public static Builder newBuilder(org.graylog2.plugin.journal.JournalMessages.CodecInfo prototype) {
       return newBuilder().mergeFrom(prototype);
     }
+    @java.lang.Override
     public Builder toBuilder() { return newBuilder(this); }
 
     @java.lang.Override
@@ -2778,6 +2884,7 @@ public final class JournalMessages {
         return org.graylog2.plugin.journal.JournalMessages.internal_static_org_graylog2_plugin_journal_CodecInfo_descriptor;
       }
 
+      @java.lang.Override
       protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
           internalGetFieldAccessorTable() {
         return org.graylog2.plugin.journal.JournalMessages.internal_static_org_graylog2_plugin_journal_CodecInfo_fieldAccessorTable
@@ -2803,6 +2910,7 @@ public final class JournalMessages {
         return new Builder();
       }
 
+      @java.lang.Override
       public Builder clear() {
         super.clear();
         name_ = "";
@@ -2812,19 +2920,23 @@ public final class JournalMessages {
         return this;
       }
 
+      @java.lang.Override
       public Builder clone() {
         return create().mergeFrom(buildPartial());
       }
 
+      @java.lang.Override
       public com.google.protobuf.Descriptors.Descriptor
           getDescriptorForType() {
         return org.graylog2.plugin.journal.JournalMessages.internal_static_org_graylog2_plugin_journal_CodecInfo_descriptor;
       }
 
+      @java.lang.Override
       public org.graylog2.plugin.journal.JournalMessages.CodecInfo getDefaultInstanceForType() {
         return org.graylog2.plugin.journal.JournalMessages.CodecInfo.getDefaultInstance();
       }
 
+      @java.lang.Override
       public org.graylog2.plugin.journal.JournalMessages.CodecInfo build() {
         org.graylog2.plugin.journal.JournalMessages.CodecInfo result = buildPartial();
         if (!result.isInitialized()) {
@@ -2833,6 +2945,7 @@ public final class JournalMessages {
         return result;
       }
 
+      @java.lang.Override
       public org.graylog2.plugin.journal.JournalMessages.CodecInfo buildPartial() {
         org.graylog2.plugin.journal.JournalMessages.CodecInfo result = new org.graylog2.plugin.journal.JournalMessages.CodecInfo(this);
         int from_bitField0_ = bitField0_;
@@ -2850,6 +2963,7 @@ public final class JournalMessages {
         return result;
       }
 
+      @java.lang.Override
       public Builder mergeFrom(com.google.protobuf.Message other) {
         if (other instanceof org.graylog2.plugin.journal.JournalMessages.CodecInfo) {
           return mergeFrom((org.graylog2.plugin.journal.JournalMessages.CodecInfo)other);
@@ -2875,10 +2989,12 @@ public final class JournalMessages {
         return this;
       }
 
+      @java.lang.Override
       public final boolean isInitialized() {
         return true;
       }
 
+      @java.lang.Override
       public Builder mergeFrom(
           com.google.protobuf.CodedInputStream input,
           com.google.protobuf.ExtensionRegistryLite extensionRegistry)
@@ -2902,12 +3018,14 @@ public final class JournalMessages {
       /**
        * <code>optional string name = 1;</code>
        */
+      @java.lang.Override
       public boolean hasName() {
         return ((bitField0_ & 0x00000001) == 0x00000001);
       }
       /**
        * <code>optional string name = 1;</code>
        */
+      @java.lang.Override
       public java.lang.String getName() {
         java.lang.Object ref = name_;
         if (!(ref instanceof java.lang.String)) {
@@ -2925,6 +3043,7 @@ public final class JournalMessages {
       /**
        * <code>optional string name = 1;</code>
        */
+      @java.lang.Override
       public com.google.protobuf.ByteString
           getNameBytes() {
         java.lang.Object ref = name_;
@@ -2983,6 +3102,7 @@ public final class JournalMessages {
        * for optimal performance make sure the serialization is stable, i.e. same config == same serialization bytes
        * </pre>
        */
+      @java.lang.Override
       public boolean hasConfig() {
         return ((bitField0_ & 0x00000002) == 0x00000002);
       }
@@ -2994,6 +3114,7 @@ public final class JournalMessages {
        * for optimal performance make sure the serialization is stable, i.e. same config == same serialization bytes
        * </pre>
        */
+      @java.lang.Override
       public java.lang.String getConfig() {
         java.lang.Object ref = config_;
         if (!(ref instanceof java.lang.String)) {
@@ -3016,6 +3137,7 @@ public final class JournalMessages {
        * for optimal performance make sure the serialization is stable, i.e. same config == same serialization bytes
        * </pre>
        */
+      @java.lang.Override
       public com.google.protobuf.ByteString
           getConfigBytes() {
         java.lang.Object ref = config_;
@@ -3151,6 +3273,7 @@ public final class JournalMessages {
       return defaultInstance;
     }
 
+    @java.lang.Override
     public SourceNode getDefaultInstanceForType() {
       return defaultInstance;
     }
@@ -3224,6 +3347,7 @@ public final class JournalMessages {
       return org.graylog2.plugin.journal.JournalMessages.internal_static_org_graylog2_plugin_journal_SourceNode_descriptor;
     }
 
+    @java.lang.Override
     protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
         internalGetFieldAccessorTable() {
       return org.graylog2.plugin.journal.JournalMessages.internal_static_org_graylog2_plugin_journal_SourceNode_fieldAccessorTable
@@ -3233,6 +3357,7 @@ public final class JournalMessages {
 
     public static com.google.protobuf.Parser<SourceNode> PARSER =
         new com.google.protobuf.AbstractParser<SourceNode>() {
+      @java.lang.Override
       public SourceNode parsePartialFrom(
           com.google.protobuf.CodedInputStream input,
           com.google.protobuf.ExtensionRegistryLite extensionRegistry)
@@ -3271,6 +3396,7 @@ public final class JournalMessages {
       public static final int RADIO_VALUE = 1;
 
 
+      @java.lang.Override
       public final int getNumber() { return value; }
 
       public static Type valueOf(int value) {
@@ -3288,15 +3414,18 @@ public final class JournalMessages {
       private static com.google.protobuf.Internal.EnumLiteMap<Type>
           internalValueMap =
             new com.google.protobuf.Internal.EnumLiteMap<Type>() {
+              @java.lang.Override
               public Type findValueByNumber(int number) {
                 return Type.valueOf(number);
               }
             };
 
+      @java.lang.Override
       public final com.google.protobuf.Descriptors.EnumValueDescriptor
           getValueDescriptor() {
         return getDescriptor().getValues().get(index);
       }
+      @java.lang.Override
       public final com.google.protobuf.Descriptors.EnumDescriptor
           getDescriptorForType() {
         return getDescriptor();
@@ -3334,12 +3463,14 @@ public final class JournalMessages {
     /**
      * <code>optional string id = 1;</code>
      */
+    @java.lang.Override
     public boolean hasId() {
       return ((bitField0_ & 0x00000001) == 0x00000001);
     }
     /**
      * <code>optional string id = 1;</code>
      */
+    @java.lang.Override
     public java.lang.String getId() {
       java.lang.Object ref = id_;
       if (ref instanceof java.lang.String) {
@@ -3357,6 +3488,7 @@ public final class JournalMessages {
     /**
      * <code>optional string id = 1;</code>
      */
+    @java.lang.Override
     public com.google.protobuf.ByteString
         getIdBytes() {
       java.lang.Object ref = id_;
@@ -3376,12 +3508,14 @@ public final class JournalMessages {
     /**
      * <code>optional .org.graylog2.plugin.journal.SourceNode.Type type = 2 [default = SERVER];</code>
      */
+    @java.lang.Override
     public boolean hasType() {
       return ((bitField0_ & 0x00000002) == 0x00000002);
     }
     /**
      * <code>optional .org.graylog2.plugin.journal.SourceNode.Type type = 2 [default = SERVER];</code>
      */
+    @java.lang.Override
     public org.graylog2.plugin.journal.JournalMessages.SourceNode.Type getType() {
       return type_;
     }
@@ -3391,12 +3525,14 @@ public final class JournalMessages {
     /**
      * <code>optional string input_id = 3;</code>
      */
+    @java.lang.Override
     public boolean hasInputId() {
       return ((bitField0_ & 0x00000004) == 0x00000004);
     }
     /**
      * <code>optional string input_id = 3;</code>
      */
+    @java.lang.Override
     public java.lang.String getInputId() {
       java.lang.Object ref = inputId_;
       if (ref instanceof java.lang.String) {
@@ -3414,6 +3550,7 @@ public final class JournalMessages {
     /**
      * <code>optional string input_id = 3;</code>
      */
+    @java.lang.Override
     public com.google.protobuf.ByteString
         getInputIdBytes() {
       java.lang.Object ref = inputId_;
@@ -3434,6 +3571,7 @@ public final class JournalMessages {
       inputId_ = "";
     }
     private byte memoizedIsInitialized = -1;
+    @java.lang.Override
     public final boolean isInitialized() {
       byte isInitialized = memoizedIsInitialized;
       if (isInitialized == 1) return true;
@@ -3443,6 +3581,7 @@ public final class JournalMessages {
       return true;
     }
 
+    @java.lang.Override
     public void writeTo(com.google.protobuf.CodedOutputStream output)
                         throws java.io.IOException {
       getSerializedSize();
@@ -3459,6 +3598,7 @@ public final class JournalMessages {
     }
 
     private int memoizedSerializedSize = -1;
+    @java.lang.Override
     public int getSerializedSize() {
       int size = memoizedSerializedSize;
       if (size != -1) return size;
@@ -3542,10 +3682,12 @@ public final class JournalMessages {
     }
 
     public static Builder newBuilder() { return Builder.create(); }
+    @java.lang.Override
     public Builder newBuilderForType() { return newBuilder(); }
     public static Builder newBuilder(org.graylog2.plugin.journal.JournalMessages.SourceNode prototype) {
       return newBuilder().mergeFrom(prototype);
     }
+    @java.lang.Override
     public Builder toBuilder() { return newBuilder(this); }
 
     @java.lang.Override
@@ -3566,6 +3708,7 @@ public final class JournalMessages {
         return org.graylog2.plugin.journal.JournalMessages.internal_static_org_graylog2_plugin_journal_SourceNode_descriptor;
       }
 
+      @java.lang.Override
       protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
           internalGetFieldAccessorTable() {
         return org.graylog2.plugin.journal.JournalMessages.internal_static_org_graylog2_plugin_journal_SourceNode_fieldAccessorTable
@@ -3591,6 +3734,7 @@ public final class JournalMessages {
         return new Builder();
       }
 
+      @java.lang.Override
       public Builder clear() {
         super.clear();
         id_ = "";
@@ -3602,19 +3746,23 @@ public final class JournalMessages {
         return this;
       }
 
+      @java.lang.Override
       public Builder clone() {
         return create().mergeFrom(buildPartial());
       }
 
+      @java.lang.Override
       public com.google.protobuf.Descriptors.Descriptor
           getDescriptorForType() {
         return org.graylog2.plugin.journal.JournalMessages.internal_static_org_graylog2_plugin_journal_SourceNode_descriptor;
       }
 
+      @java.lang.Override
       public org.graylog2.plugin.journal.JournalMessages.SourceNode getDefaultInstanceForType() {
         return org.graylog2.plugin.journal.JournalMessages.SourceNode.getDefaultInstance();
       }
 
+      @java.lang.Override
       public org.graylog2.plugin.journal.JournalMessages.SourceNode build() {
         org.graylog2.plugin.journal.JournalMessages.SourceNode result = buildPartial();
         if (!result.isInitialized()) {
@@ -3623,6 +3771,7 @@ public final class JournalMessages {
         return result;
       }
 
+      @java.lang.Override
       public org.graylog2.plugin.journal.JournalMessages.SourceNode buildPartial() {
         org.graylog2.plugin.journal.JournalMessages.SourceNode result = new org.graylog2.plugin.journal.JournalMessages.SourceNode(this);
         int from_bitField0_ = bitField0_;
@@ -3644,6 +3793,7 @@ public final class JournalMessages {
         return result;
       }
 
+      @java.lang.Override
       public Builder mergeFrom(com.google.protobuf.Message other) {
         if (other instanceof org.graylog2.plugin.journal.JournalMessages.SourceNode) {
           return mergeFrom((org.graylog2.plugin.journal.JournalMessages.SourceNode)other);
@@ -3672,10 +3822,12 @@ public final class JournalMessages {
         return this;
       }
 
+      @java.lang.Override
       public final boolean isInitialized() {
         return true;
       }
 
+      @java.lang.Override
       public Builder mergeFrom(
           com.google.protobuf.CodedInputStream input,
           com.google.protobuf.ExtensionRegistryLite extensionRegistry)
@@ -3699,12 +3851,14 @@ public final class JournalMessages {
       /**
        * <code>optional string id = 1;</code>
        */
+      @java.lang.Override
       public boolean hasId() {
         return ((bitField0_ & 0x00000001) == 0x00000001);
       }
       /**
        * <code>optional string id = 1;</code>
        */
+      @java.lang.Override
       public java.lang.String getId() {
         java.lang.Object ref = id_;
         if (!(ref instanceof java.lang.String)) {
@@ -3722,6 +3876,7 @@ public final class JournalMessages {
       /**
        * <code>optional string id = 1;</code>
        */
+      @java.lang.Override
       public com.google.protobuf.ByteString
           getIdBytes() {
         java.lang.Object ref = id_;
@@ -3775,12 +3930,14 @@ public final class JournalMessages {
       /**
        * <code>optional .org.graylog2.plugin.journal.SourceNode.Type type = 2 [default = SERVER];</code>
        */
+      @java.lang.Override
       public boolean hasType() {
         return ((bitField0_ & 0x00000002) == 0x00000002);
       }
       /**
        * <code>optional .org.graylog2.plugin.journal.SourceNode.Type type = 2 [default = SERVER];</code>
        */
+      @java.lang.Override
       public org.graylog2.plugin.journal.JournalMessages.SourceNode.Type getType() {
         return type_;
       }
@@ -3810,12 +3967,14 @@ public final class JournalMessages {
       /**
        * <code>optional string input_id = 3;</code>
        */
+      @java.lang.Override
       public boolean hasInputId() {
         return ((bitField0_ & 0x00000004) == 0x00000004);
       }
       /**
        * <code>optional string input_id = 3;</code>
        */
+      @java.lang.Override
       public java.lang.String getInputId() {
         java.lang.Object ref = inputId_;
         if (!(ref instanceof java.lang.String)) {
@@ -3833,6 +3992,7 @@ public final class JournalMessages {
       /**
        * <code>optional string input_id = 3;</code>
        */
+      @java.lang.Override
       public com.google.protobuf.ByteString
           getInputIdBytes() {
         java.lang.Object ref = inputId_;
@@ -3942,6 +4102,7 @@ public final class JournalMessages {
     };
     com.google.protobuf.Descriptors.FileDescriptor.InternalDescriptorAssigner assigner =
         new com.google.protobuf.Descriptors.FileDescriptor.    InternalDescriptorAssigner() {
+          @java.lang.Override
           public com.google.protobuf.ExtensionRegistry assignDescriptors(
               com.google.protobuf.Descriptors.FileDescriptor root) {
             descriptor = root;

--- a/graylog2-server/src/main/java/org/graylog2/plugin/outputs/MessageOutput.java
+++ b/graylog2-server/src/main/java/org/graylog2/plugin/outputs/MessageOutput.java
@@ -55,7 +55,6 @@ public interface MessageOutput extends Stoppable {
         }
     }
 
-    void stop();
     boolean isRunning();
     void write(Message message) throws Exception;
     void write(List<Message> messages) throws Exception;

--- a/graylog2-server/src/main/java/org/graylog2/plugin/streams/Stream.java
+++ b/graylog2-server/src/main/java/org/graylog2/plugin/streams/Stream.java
@@ -17,10 +17,8 @@
 package org.graylog2.plugin.streams;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
-import org.graylog2.plugin.alarms.AlertCondition;
 import org.graylog2.plugin.database.Persisted;
 
-import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -39,8 +37,6 @@ public interface Stream extends Persisted {
             return (emptyToNull(name) == null ? DEFAULT : valueOf(name));
         }
     }
-
-    String getId();
 
     String getTitle();
 
@@ -65,8 +61,6 @@ public interface Stream extends Persisted {
     Map<String, List<String>> getAlertReceivers();
 
     Map<String, Object> asMap(List<StreamRule> streamRules);
-
-    String toString();
 
     List<StreamRule> getStreamRules();
 

--- a/graylog2-server/src/main/java/org/graylog2/plugin/streams/StreamRule.java
+++ b/graylog2-server/src/main/java/org/graylog2/plugin/streams/StreamRule.java
@@ -23,6 +23,7 @@ import java.util.Map;
 
 @JsonAutoDetect
 public interface StreamRule extends Persisted {
+    @Override
     String getId();
 
     StreamRuleType getType();
@@ -51,5 +52,6 @@ public interface StreamRule extends Persisted {
 
     void setDescription(String description);
 
+    @Override
     Map<String, Object> asMap();
 }

--- a/graylog2-server/src/main/java/org/graylog2/rest/models/alarmcallbacks/AlarmCallbackError.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/models/alarmcallbacks/AlarmCallbackError.java
@@ -26,6 +26,7 @@ import com.google.common.base.Strings;
 @JsonAutoDetect
 public abstract class AlarmCallbackError extends AlarmCallbackResult {
     @JsonProperty("type")
+    @Override
     public String type() { return "error"; }
 
     @JsonProperty("error")

--- a/graylog2-server/src/main/java/org/graylog2/rest/models/alarmcallbacks/AlarmCallbackSuccess.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/models/alarmcallbacks/AlarmCallbackSuccess.java
@@ -25,6 +25,7 @@ import com.google.auto.value.AutoValue;
 @JsonAutoDetect
 public abstract class AlarmCallbackSuccess extends AlarmCallbackResult {
     @JsonProperty("type")
+    @Override
     public String type() { return "success"; }
 
     @JsonCreator

--- a/graylog2-server/src/main/java/org/graylog2/savedsearches/SavedSearch.java
+++ b/graylog2-server/src/main/java/org/graylog2/savedsearches/SavedSearch.java
@@ -18,10 +18,6 @@ package org.graylog2.savedsearches;
 
 import org.graylog2.plugin.database.Persisted;
 
-import java.util.Map;
-
 public interface SavedSearch extends Persisted {
-    Map<String,Object> asMap();
-
     String getTitle();
 }

--- a/graylog2-server/src/main/java/org/graylog2/savedsearches/SavedSearchImpl.java
+++ b/graylog2-server/src/main/java/org/graylog2/savedsearches/SavedSearchImpl.java
@@ -60,6 +60,7 @@ public class SavedSearchImpl extends PersistedImpl implements SavedSearch {
         return Collections.emptyMap();
     }
 
+    @Override
     public Map<String, Object> asMap() {
         return ImmutableMap.<String, Object>builder()
                 .put("id", ((ObjectId) fields.get("_id")).toHexString())

--- a/graylog2-server/src/main/java/org/graylog2/shared/bindings/Hk2GuiceBridgeJitInjector.java
+++ b/graylog2-server/src/main/java/org/graylog2/shared/bindings/Hk2GuiceBridgeJitInjector.java
@@ -86,6 +86,7 @@ public class Hk2GuiceBridgeJitInjector implements InvocationHandler {
     /**
      * {@inheritDoc}
      */
+    @Override
     public Object invoke(final Object proxy, final Method method, final Object[] args) throws Throwable {
         final Object result = method.invoke(injector, args);
         if (result == null && method.equals(getExistingBindingMethod)) {

--- a/graylog2-server/src/main/java/org/graylog2/shared/buffers/InputBufferImpl.java
+++ b/graylog2-server/src/main/java/org/graylog2/shared/buffers/InputBufferImpl.java
@@ -97,6 +97,7 @@ public class InputBufferImpl implements InputBuffer {
                 numberOfHandlers);
     }
 
+    @Override
     public void insert(RawMessage message) {
         ringBuffer.publishEvent(RawMessageEvent.TRANSLATOR, message);
         incomingMessages.mark();

--- a/graylog2-server/src/main/java/org/graylog2/streams/StreamImpl.java
+++ b/graylog2-server/src/main/java/org/graylog2/streams/StreamImpl.java
@@ -139,11 +139,13 @@ public class StreamImpl extends PersistedImpl implements Stream {
         fields.put(FIELD_CONTENT_PACK, contentPack);
     }
 
+    @Override
     public Boolean isPaused() {
         Boolean disabled = getDisabled();
         return (disabled != null && disabled);
     }
 
+    @Override
     public Map<String, Object> asMap(List<StreamRule> streamRules) {
         Map<String, Object> result = asMap();
 
@@ -159,6 +161,7 @@ public class StreamImpl extends PersistedImpl implements Stream {
     }
 
     @JsonValue
+    @Override
     public Map<String, Object> asMap() {
         // We work on the result a bit to allow correct JSON serializing.
         Map<String, Object> result = Maps.newHashMap(fields);
@@ -172,6 +175,7 @@ public class StreamImpl extends PersistedImpl implements Stream {
         return result;
     }
 
+    @Override
     public Map<String, Validator> getValidations() {
         return ImmutableMap.<String, Validator>builder()
                 .put(FIELD_TITLE, new FilledStringValidator())
@@ -192,6 +196,7 @@ public class StreamImpl extends PersistedImpl implements Stream {
         return Collections.emptyMap();
     }
 
+    @Override
     public Map<String, List<String>> getAlertReceivers() {
         if (!fields.containsKey(FIELD_ALERT_RECEIVERS)) {
             return Collections.emptyMap();

--- a/graylog2-server/src/main/java/org/graylog2/streams/StreamRouter.java
+++ b/graylog2-server/src/main/java/org/graylog2/streams/StreamRouter.java
@@ -87,7 +87,7 @@ public class StreamRouter {
         return engine.match(msg);
     }
 
-    private class StreamRouterEngineUpdater implements Runnable {
+    private static class StreamRouterEngineUpdater implements Runnable {
         private final AtomicReference<StreamRouterEngine> routerEngine;
         private final StreamRouterEngine.Factory engineFactory;
         private final StreamService streamService;

--- a/graylog2-server/src/main/java/org/graylog2/streams/StreamRuleImpl.java
+++ b/graylog2-server/src/main/java/org/graylog2/streams/StreamRuleImpl.java
@@ -61,6 +61,7 @@ public class StreamRuleImpl extends PersistedImpl implements StreamRule {
         return StreamRuleType.fromInteger((Integer) fields.get(FIELD_TYPE));
     }
 
+    @Override
     public void setType(StreamRuleType type) {
         fields.put(FIELD_TYPE, type.toInteger());
     }
@@ -70,6 +71,7 @@ public class StreamRuleImpl extends PersistedImpl implements StreamRule {
         return (String) fields.get(FIELD_VALUE);
     }
 
+    @Override
     public void setValue(String value) {
         fields.put(FIELD_VALUE, value);
     }
@@ -79,18 +81,22 @@ public class StreamRuleImpl extends PersistedImpl implements StreamRule {
         return (String) fields.get(FIELD_FIELD);
     }
 
+    @Override
     public void setField(String field) {
         fields.put(FIELD_FIELD, field);
     }
 
+    @Override
     public Boolean getInverted() {
         return (Boolean) firstNonNull(fields.get(FIELD_INVERTED), false);
     }
 
+    @Override
     public void setInverted(Boolean inverted) {
         fields.put(FIELD_INVERTED, inverted);
     }
 
+    @Override
     public String getStreamId() {
         return ((ObjectId) fields.get(FIELD_STREAM_ID)).toHexString();
     }
@@ -115,6 +121,7 @@ public class StreamRuleImpl extends PersistedImpl implements StreamRule {
         fields.put(FIELD_DESCRIPTION, description);
     }
 
+    @Override
     public Map<String, Validator> getValidations() {
         final ImmutableMap.Builder<String, Validator> validators = ImmutableMap.builder();
         validators.put(FIELD_TYPE, new IntegerValidator());
@@ -135,6 +142,7 @@ public class StreamRuleImpl extends PersistedImpl implements StreamRule {
     }
 
     @JsonValue
+    @Override
     public Map<String, Object> asMap() {
         // We work on the result a bit to allow correct JSON serializing.
         Map<String, Object> result = Maps.newHashMap(fields);

--- a/graylog2-server/src/main/java/org/graylog2/streams/StreamServiceImpl.java
+++ b/graylog2-server/src/main/java/org/graylog2/streams/StreamServiceImpl.java
@@ -281,6 +281,7 @@ public class StreamServiceImpl extends PersistedServiceImpl implements StreamSer
         addAlertCondition(stream, condition);
     }
 
+    @Override
     public void removeAlertCondition(Stream stream, String conditionId) {
         removeEmbedded(stream, StreamImpl.EMBEDDED_ALERT_CONDITIONS, conditionId);
     }

--- a/graylog2-server/src/main/java/org/graylog2/users/UserImpl.java
+++ b/graylog2-server/src/main/java/org/graylog2/users/UserImpl.java
@@ -114,6 +114,7 @@ public class UserImpl extends PersistedImpl implements User {
         return false;
     }
 
+    @Override
     public Map<String, Validator> getValidations() {
         return ImmutableMap.<String, Validator>builder()
                 .put(USERNAME, new LimitedStringValidator(1, MAX_USERNAME_LENGTH))
@@ -349,6 +350,7 @@ public class UserImpl extends PersistedImpl implements User {
             return "Administrator";
         }
 
+        @Override
         public String getEmail() {
             return configuration.getRootEmail();
         }

--- a/graylog2-server/src/main/java/org/graylog2/users/UserServiceImpl.java
+++ b/graylog2-server/src/main/java/org/graylog2/users/UserServiceImpl.java
@@ -106,6 +106,7 @@ public class UserServiceImpl extends PersistedServiceImpl implements UserService
         return userFactory.create((ObjectId) userId, userObject.toMap());
     }
 
+    @Override
     public int delete(final String username) {
         LOG.debug("Deleting user(s) with username \"{}\"", username);
         final DBObject query = BasicDBObjectBuilder.start(UserImpl.USERNAME, username).get();

--- a/graylog2-server/src/main/java/org/graylog2/utilities/IPSubnetConverter.java
+++ b/graylog2-server/src/main/java/org/graylog2/utilities/IPSubnetConverter.java
@@ -30,6 +30,7 @@ import java.util.Set;
  * Converts a comma separated list of IP addresses / sub nets to set of {@link IpSubnet}.
  */
 public class IPSubnetConverter implements Converter<Set<IpSubnet>> {
+    @Override
     public Set<IpSubnet> convertFrom(String value) {
         final Set<IpSubnet> converted = new HashSet<>();
         if (value != null) {
@@ -45,6 +46,7 @@ public class IPSubnetConverter implements Converter<Set<IpSubnet>> {
         return converted;
     }
 
+    @Override
     public String convertTo(Set<IpSubnet> value) {
         if (value == null) {
             throw new ParameterException("Couldn't convert IP subnets <null> to string.");

--- a/graylog2-server/src/main/java/org/graylog2/utilities/InterruptibleCharSequence.java
+++ b/graylog2-server/src/main/java/org/graylog2/utilities/InterruptibleCharSequence.java
@@ -16,30 +16,28 @@
  */
 package org.graylog2.utilities;
 
-/**
- * @author Dennis Oelkers <dennis@torch.sh>
- */
 public class InterruptibleCharSequence implements CharSequence {
-    CharSequence inner;
-    // public long counter = 0;
+    private CharSequence inner;
 
     public InterruptibleCharSequence(CharSequence inner) {
         super();
         this.inner = inner;
     }
 
+    @Override
     public char charAt(int index) {
         if (Thread.interrupted()) { // clears flag if set
             throw new RuntimeException(new InterruptedException());
         }
-        // counter++;
         return inner.charAt(index);
     }
 
+    @Override
     public int length() {
         return inner.length();
     }
 
+    @Override
     public CharSequence subSequence(int start, int end) {
         return new InterruptibleCharSequence(inner.subSequence(start, end));
     }

--- a/pom.xml
+++ b/pom.xml
@@ -1017,11 +1017,26 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
                 <configuration>
-                    <useIncrementalCompilation>false</useIncrementalCompilation>
+                    <showWarnings>true</showWarnings>
+                    <showDeprecation>true</showDeprecation>
+                    <compilerId>javac-with-errorprone</compilerId>
+                    <forceJavacCompilerUse>true</forceJavacCompilerUse>
                     <annotationProcessors>
                         <annotationProcessor>com.google.auto.value.processor.AutoValueProcessor</annotationProcessor>
                     </annotationProcessors>
                 </configuration>
+                <dependencies>
+                    <dependency>
+                        <groupId>org.codehaus.plexus</groupId>
+                        <artifactId>plexus-compiler-javac-errorprone</artifactId>
+                        <version>2.8</version>
+                    </dependency>
+                    <dependency>
+                        <groupId>com.google.errorprone</groupId>
+                        <artifactId>error_prone_core</artifactId>
+                        <version>2.0.11</version>
+                    </dependency>
+                </dependencies>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
@@ -1193,33 +1208,6 @@
             <id>edantic</id>
             <build>
                 <plugins>
-                    <plugin>
-                        <groupId>org.apache.maven.plugins</groupId>
-                        <artifactId>maven-compiler-plugin</artifactId>
-                        <configuration>
-                            <showWarnings>true</showWarnings>
-                            <showDeprecation>true</showDeprecation>
-                            <compilerId>javac-with-errorprone</compilerId>
-                            <forceJavacCompilerUse>true</forceJavacCompilerUse>
-                            <annotationProcessors>
-                                <annotationProcessor>com.google.auto.value.processor.AutoValueProcessor</annotationProcessor>
-                            </annotationProcessors>
-                        </configuration>
-                        <dependencies>
-                            <dependency>
-                                <groupId>org.codehaus.plexus</groupId>
-                                <artifactId>plexus-compiler-javac-errorprone</artifactId>
-                                <version>2.7</version>
-                            </dependency>
-                            <!-- override plexus-compiler-javac-errorprone's dependency on
-                                 Error Prone with the latest version -->
-                            <dependency>
-                                <groupId>com.google.errorprone</groupId>
-                                <artifactId>error_prone_core</artifactId>
-                                <version>2.0.9</version>
-                            </dependency>
-                        </dependencies>
-                    </plugin>
                     <plugin>
                         <groupId>org.codehaus.mojo</groupId>
                         <artifactId>findbugs-maven-plugin</artifactId>


### PR DESCRIPTION
This PR moves the [Error Prone](http://errorprone.info/) compile checks into the default build profile (was in the `(P)edantic` profile before).

Additionally, this PR fixes many [Error Prone](http://errorprone.info/) warnings in the current Graylog codebase.