### PR TITLE
Fix GrokPatternRegistry.GrokReloader#load()

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/grok/GrokPatternRegistry.java
+++ b/graylog2-server/src/main/java/org/graylog2/grok/GrokPatternRegistry.java
@@ -16,6 +16,7 @@
  */
 package org.graylog2.grok;
 
+import com.google.common.base.Throwables;
 import com.google.common.cache.CacheBuilder;
 import com.google.common.cache.CacheLoader;
 import com.google.common.cache.LoadingCache;
@@ -36,7 +37,6 @@ import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 
-import static com.google.common.base.Strings.isNullOrEmpty;
 import static com.google.common.cache.CacheLoader.asyncReloading;
 
 @Singleton
@@ -78,6 +78,7 @@ public class GrokPatternRegistry {
     public Grok cachedGrokForPattern(String pattern) {
         return cachedGrokForPattern(pattern, false);
     }
+
     public Grok cachedGrokForPattern(String pattern, boolean namedCapturesOnly) {
         try {
             if (namedCapturesOnly) {
@@ -86,8 +87,9 @@ public class GrokPatternRegistry {
                 return grokCache.get(pattern);
             }
         } catch (ExecutionException e) {
-            log.error("Unable to load grok pattern {} into cache", pattern, e);
-            throw new RuntimeException(e);
+            final Throwable rootCause = Throwables.getRootCause(e);
+            log.error("Unable to load grok pattern {} into cache", pattern, rootCause);
+            throw new RuntimeException(rootCause);
         }
     }
 
@@ -113,9 +115,7 @@ public class GrokPatternRegistry {
         public Grok load(@Nonnull String pattern) throws Exception {
             final Grok grok = new Grok();
             for (GrokPattern grokPattern : patterns()) {
-                if (!isNullOrEmpty(grokPattern.name) || isNullOrEmpty(grokPattern.pattern)) {
-                    grok.addPattern(grokPattern.name, grokPattern.pattern);
-                }
+                grok.addPattern(grokPattern.name, grokPattern.pattern);
             }
             grok.compile(pattern, namedCapturesOnly);
             return grok;

--- a/graylog2-server/src/test/java/org/graylog2/grok/GrokPatternRegistryTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/grok/GrokPatternRegistryTest.java
@@ -1,0 +1,114 @@
+/**
+ * This file is part of Graylog.
+ *
+ * Graylog is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.graylog2.grok;
+
+import com.google.common.eventbus.EventBus;
+import oi.thekraken.grok.api.Grok;
+import oi.thekraken.grok.api.exception.GrokException;
+import org.hamcrest.Matchers;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnit;
+import org.mockito.junit.MockitoRule;
+
+import java.util.Collections;
+import java.util.Set;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+
+public class GrokPatternRegistryTest {
+    private static final GrokPattern GROK_PATTERN = GrokPattern.create("TESTNUM", "[0-9]+");
+    private static final Set<GrokPattern> GROK_PATTERNS = Collections.singleton(GROK_PATTERN);
+
+    @Rule
+    public final MockitoRule mockitoRule = MockitoJUnit.rule();
+
+    @Rule
+    public final ExpectedException expectedException = ExpectedException.none();
+
+    private GrokPatternRegistry grokPatternRegistry;
+    private EventBus eventBus;
+    private ScheduledExecutorService executor;
+    @Mock
+    private GrokPatternService grokPatternService;
+
+    @Before
+    public void setUp() {
+        eventBus = new EventBus("Test");
+        executor = Executors.newSingleThreadScheduledExecutor();
+        when(grokPatternService.loadAll()).thenReturn(GROK_PATTERNS);
+        grokPatternRegistry = new GrokPatternRegistry(eventBus, grokPatternService, executor);
+    }
+
+    @Test
+    public void grokPatternsChanged() throws Exception {
+        final Set<GrokPattern> newPatterns = Collections.singleton(GrokPattern.create("NEW_PATTERN", "\\w+"));
+        when(grokPatternService.loadAll()).thenReturn(newPatterns);
+        eventBus.post(GrokPatternsChangedEvent.create(Collections.emptySet(), Collections.singleton("NEW_PATTERN")));
+
+        assertThat(grokPatternRegistry.patterns()).isEqualTo(newPatterns);
+    }
+
+    @Test
+    public void cachedGrokForPattern() throws Exception {
+        final Grok grok = grokPatternRegistry.cachedGrokForPattern("%{TESTNUM}");
+        assertThat(grok.getPatterns()).containsEntry(GROK_PATTERN.name(), GROK_PATTERN.pattern());
+    }
+
+    @Test
+    public void cachedGrokForPatternThrowsRuntimeException() throws Exception {
+        expectedException.expectMessage("Invalid Pattern");
+        expectedException.expect(RuntimeException.class);
+        expectedException.expectCause(Matchers.any(GrokException.class));
+
+        final Set<GrokPattern> newPatterns = Collections.singleton(GrokPattern.create("EMPTY", ""));
+        when(grokPatternService.loadAll()).thenReturn(newPatterns);
+        eventBus.post(GrokPatternsChangedEvent.create(Collections.emptySet(), Collections.singleton("EMPTY")));
+
+        grokPatternRegistry.cachedGrokForPattern("%{EMPTY}");
+    }
+
+    @Test
+    public void cachedGrokForPatternWithNamedCaptureOnly() throws Exception {
+        final Grok grok = grokPatternRegistry.cachedGrokForPattern("%{TESTNUM}", true);
+        assertThat(grok.getPatterns()).containsEntry(GROK_PATTERN.name(), GROK_PATTERN.pattern());
+    }
+
+    @Test
+    public void cachedGrokForPatternWithNamedCaptureOnlyThrowsRuntimeException() throws Exception {
+        expectedException.expectMessage("Invalid Pattern");
+        expectedException.expect(RuntimeException.class);
+        expectedException.expectCause(Matchers.any(GrokException.class));
+
+        final Set<GrokPattern> newPatterns = Collections.singleton(GrokPattern.create("EMPTY", ""));
+        when(grokPatternService.loadAll()).thenReturn(newPatterns);
+        eventBus.post(GrokPatternsChangedEvent.create(Collections.emptySet(), Collections.singleton("EMPTY")));
+
+        grokPatternRegistry.cachedGrokForPattern("%{EMPTY}", true);
+    }
+
+    @Test
+    public void patterns() throws Exception {
+        assertThat(grokPatternRegistry.patterns()).isEqualTo(GROK_PATTERNS);
+    }
+}


### PR DESCRIPTION
`GrokPatternRegistry.GrokReloader#load()` used to run an unnecessary yet incorrect check whether the Grok pattern's name or the pattern itself was `null` or empty.

This check is already done by `Grok` itself and will throw a detailed exception which can be caught further up the stack.

Additionally this PR extracts the root cause of exceptions happening in the `cachedGrokForPattern()` method instead of simply propagating the wrapped `ExecutionException` and even adds a test for this.

Refs #2566