### PR TITLE
Upgrade to Kafka 0.10.0.1

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/shared/journal/KafkaJournal.java
+++ b/graylog2-server/src/main/java/org/graylog2/shared/journal/KafkaJournal.java
@@ -383,7 +383,7 @@ public class KafkaJournal extends AbstractIdleService implements Journal {
                 final byte[] idBytes = entry.getIdBytes();
 
                 payloadSize += messageBytes.length;
-                messages.add(new Message(messageBytes, idBytes));
+                messages.add(new Message(messageBytes, idBytes, Message.NoTimestamp(), Message.MagicValue_V0()));
 
                 if (LOG.isTraceEnabled()) {
                     LOG.trace("Message {} contains bytes {}", bytesToHex(idBytes), bytesToHex(messageBytes));

--- a/graylog2-server/src/test/java/org/graylog2/shared/journal/KafkaJournalTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/shared/journal/KafkaJournalTest.java
@@ -152,7 +152,7 @@ public class KafkaJournalTest {
 
     private int createBulkChunks(KafkaJournal journal, Size segmentSize, int bulkCount) {
         // Magic numbers deduced by magic…
-        int bulkSize = Ints.saturatedCast(segmentSize.toBytes() / (2L * 16L));
+        int bulkSize = Ints.saturatedCast(segmentSize.toBytes() / (2L * 32L));
         // perform multiple writes to make multiple segments
         for (int currentBulk = 0; currentBulk < bulkCount; currentBulk++) {
             final List<Journal.Entry> entries = Lists.newArrayListWithExpectedSize(bulkSize);
@@ -376,7 +376,7 @@ public class KafkaJournalTest {
     public void serverStatusThrottledIfJournalUtilizationIsHigherThanThreshold() throws Exception {
         serverStatus.running();
 
-        final Size segmentSize = Size.kilobytes(1L);
+        final Size segmentSize = Size.kilobytes(2L);
         final KafkaJournal journal = new KafkaJournal(journalDirectory,
             scheduler,
             segmentSize,

--- a/pom.xml
+++ b/pom.xml
@@ -453,7 +453,7 @@
             <dependency>
                 <groupId>org.apache.kafka</groupId>
                 <artifactId>kafka_2.11</artifactId>
-                <version>0.9.0.1</version>
+                <version>0.10.0.1</version>
                 <exclusions>
                     <exclusion>
                         <groupId>com.sun.jmx</groupId>


### PR DESCRIPTION
This PR upgrades Kafka to version 0.10.0.0 and adapts `KafkaJournal` accordingly.

Unfortunately, the on-disk format of the Kafka Log changed so that this is not backward-compatible with old disk journal files.

On the positive side, the Kafka Log now supports adding an additional timestamp to entries and different compression algorithms can be configured (not supported by `KafkaJournal`).

On the long run, we should probably extract the Kafka Log (and rewrite it in Java, /cc @bernd) to get independent of the Apache Kafka update cycles.
