### PR TITLE
More fixes with prefixed URLs

### DIFF
--- a/graylog2-web-interface/src/components/dashboard/Dashboard.jsx
+++ b/graylog2-web-interface/src/components/dashboard/Dashboard.jsx
@@ -12,7 +12,6 @@ const DashboardsStore = StoreProvider.getStore('Dashboards');
 const StartpageStore = StoreProvider.getStore('Startpage');
 
 import Routes from 'routing/Routes';
-import ApiRoutes from 'routing/ApiRoutes';
 
 const Dashboard = React.createClass({
   propTypes: {

--- a/graylog2-web-interface/src/components/inputs/InputListItem.jsx
+++ b/graylog2-web-interface/src/components/inputs/InputListItem.jsx
@@ -7,7 +7,6 @@ import { EntityListItem, IfPermitted, LinkToNode, Spinner } from 'components/com
 import { ConfigurationWell } from 'components/configurationforms';
 
 import PermissionsMixin from 'util/PermissionsMixin';
-import ApiRoutes from 'routing/ApiRoutes';
 import Routes from 'routing/Routes';
 
 import StoreProvider from 'injection/StoreProvider';
@@ -61,7 +60,7 @@ const InputListItem = React.createClass({
     if (this.isPermitted(this.props.permissions, ['searches:relative'])) {
       actions.push(
         <LinkContainer key={`received-messages-${this.props.input.id}`}
-                       to={ApiRoutes.SearchController.index(`gl2_source_input:${this.props.input.id}`, 'relative', 28800).url}>
+                       to={Routes.search_with_query(`gl2_source_input:${this.props.input.id}`, 'relative', 28800)}>
           <Button bsStyle="info">Show received messages</Button>
         </LinkContainer>
       );

--- a/graylog2-web-interface/src/components/navigation/Navigation.jsx
+++ b/graylog2-web-interface/src/components/navigation/Navigation.jsx
@@ -40,7 +40,7 @@ const Navigation = React.createClass({
   POLL_INTERVAL: 3000,
 
   _isActive(prefix) {
-    return this.props.requestPath.indexOf(prefix) === 0;
+    return this.props.requestPath.indexOf(URLUtils.appPrefixed(prefix)) === 0;
   },
 
   _systemTitle() {

--- a/graylog2-web-interface/src/components/search/MessageDetail.jsx
+++ b/graylog2-web-interface/src/components/search/MessageDetail.jsx
@@ -11,7 +11,6 @@ import MessageFields from 'components/search/MessageFields';
 import { Spinner, ClipboardButton, Timestamp } from 'components/common';
 import SurroundingSearchButton from 'components/search/SurroundingSearchButton';
 
-import ApiRoutes from 'routing/ApiRoutes';
 import Routes from 'routing/Routes';
 
 const MessageDetail = React.createClass({
@@ -65,7 +64,7 @@ const MessageDetail = React.createClass({
     let nodeInformation;
 
     if (node) {
-      const nodeURL = ApiRoutes.NodesController.node(nodeId).url;
+      const nodeURL = Routes.node(nodeId);
       nodeInformation = (
         <a href={nodeURL}>
           <i className="fa fa-code-fork" />

--- a/graylog2-web-interface/src/routing/ApiRoutes.js
+++ b/graylog2-web-interface/src/routing/ApiRoutes.js
@@ -285,32 +285,13 @@ const ApiRoutes = {
   ExtractorsController: {
     create: (inputId) => { return { url: `/system/inputs/${inputId}/extractors` }; },
     delete: (inputId, extractorId) => { return { url: `/system/inputs/${inputId}/extractors/${extractorId}` }; },
-    newExtractor: (nodeId, inputId, extractorType, fieldName, index, messageId) => {
-      return { url: `/system/inputs/${nodeId}/${inputId}/extractors/new?extractor_type=${extractorType}&field=${fieldName}&example_index=${index}&example_id=${messageId}` };
-    },
     order: (inputId) => { return { url: `/system/inputs/${inputId}/extractors/order` }; },
     update: (inputId, extractorId) => { return { url: `/system/inputs/${inputId}/extractors/${extractorId}` }; },
   },
   MessagesController: {
     analyze: (index, string) => { return { url: `/messages/${index}/analyze?string=${string}` }; },
-    parse: () => { return { url: `/messages/parse` }; },
+    parse: () => { return { url: '/messages/parse' }; },
     single: (index, messageId) => { return { url: `/messages/${index}/${messageId}` }; },
-  },
-  NodesController: {
-    node: (nodeId) => { return { url: `/system/nodes/${nodeId}` }; },
-  },
-  SearchController: {
-    index: (query, rangetype, timerange) => {
-      let route;
-      if (query && rangetype && timerange) {
-        route = { url: `/search?q=${query}&${rangetype}=${timerange}` };
-      } else {
-        route = { url: '/search' };
-      }
-
-      return route;
-    },
-    showMessage: (index, messageId) => { return { url: `/messages/${index}/${messageId}` }; },
   },
 };
 

--- a/graylog2-web-interface/src/routing/Routes.jsx
+++ b/graylog2-web-interface/src/routing/Routes.jsx
@@ -87,6 +87,17 @@ const Routes = {
       },
     },
   },
+  search_with_query: (query, rangeType, timeRange) => {
+    const route = new URI(Routes.SEARCH);
+    const queryParams = {
+      q: query,
+    };
+    if (rangeType && timeRange) {
+      queryParams[rangeType] = timeRange;
+    }
+    route.query(queryParams);
+    return route.resource();
+  },
   message_show: (index, messageId) => `/messages/${index}/${messageId}`,
   stream_edit: (streamId) => `/streams/${streamId}/edit`,
   stream_edit_example: (streamId, index, messageId) => `${Routes.stream_edit(streamId)}?index=${index}&message_id=${messageId}`,
@@ -104,8 +115,17 @@ const Routes = {
   local_input_extractors: (nodeId, inputId) => `/system/inputs/${nodeId}/${inputId}/extractors`,
   export_extractors: (nodeId, inputId) => `${Routes.local_input_extractors(nodeId, inputId)}/export`,
   import_extractors: (nodeId, inputId) => `${Routes.local_input_extractors(nodeId, inputId)}/import`,
-  new_extractor: (nodeId, inputId) => {
-    return `/system/inputs/${nodeId}/${inputId}/extractors/new`;
+  new_extractor: (nodeId, inputId, extractorType, fieldName, index, messageId) => {
+    const route = new URI(`/system/inputs/${nodeId}/${inputId}/extractors/new`);
+    const queryParams = {
+      extractor_type: extractorType,
+      field: fieldName,
+      example_index: index,
+      example_id: messageId,
+    };
+    route.search(queryParams);
+
+    return route.resource();
   },
   edit_extractor: (nodeId, inputId, extractorId) => `/system/inputs/${nodeId}/${inputId}/extractors/${extractorId}/edit`,
 

--- a/graylog2-web-interface/src/util/ExtractorUtils.jsx
+++ b/graylog2-web-interface/src/util/ExtractorUtils.jsx
@@ -1,4 +1,4 @@
-import ApiRoutes from 'routing/ApiRoutes';
+import Routes from 'routing/Routes';
 
 const ExtractorTypes = Object.freeze({
   COPY_INPUT: 'copy_input',
@@ -31,7 +31,7 @@ const ExtractorUtils = {
   getNewExtractorRoutes(sourceNodeId, sourceInputId, fieldName, messageIndex, messageId) {
     const routes = {};
     this.EXTRACTOR_TYPES.forEach(extractorType => {
-      routes[extractorType] = ApiRoutes.ExtractorsController.newExtractor(sourceNodeId, sourceInputId, extractorType, fieldName, messageIndex, messageId).url;
+      routes[extractorType] = Routes.new_extractor(sourceNodeId, sourceInputId, extractorType, fieldName, messageIndex, messageId);
     });
 
     return routes;


### PR DESCRIPTION
This PR includes fixes for these issues:

- Some components use routes from `ApiRoutes`, which is not the right place for them, as they are not properly prefixed
- Adding an app prefix breaks the selected system page that is displayed in the navigation bar