### PR TITLE
Handle decorator creation and execution errors

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/decorators/DecoratorResolver.java
+++ b/graylog2-server/src/main/java/org/graylog2/decorators/DecoratorResolver.java
@@ -18,6 +18,8 @@ package org.graylog2.decorators;
 
 import com.google.inject.Singleton;
 import org.graylog2.plugin.decorators.SearchResponseDecorator;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import javax.annotation.Nullable;
 import javax.inject.Inject;
@@ -28,6 +30,8 @@ import java.util.stream.Collectors;
 
 @Singleton
 public class DecoratorResolver {
+    private static final Logger LOG = LoggerFactory.getLogger(DecoratorResolver.class);
+
     private final DecoratorService decoratorService;
     private final Map<String, SearchResponseDecorator.Factory> searchResponseDecoratorsMap;
 
@@ -60,7 +64,11 @@ public class DecoratorResolver {
     private SearchResponseDecorator instantiateSearchResponseDecorator(Decorator decorator) {
         final SearchResponseDecorator.Factory factory = this.searchResponseDecoratorsMap.get(decorator.type());
         if (factory != null) {
-            return factory.create(decorator);
+            try {
+                return factory.create(decorator);
+            } catch(Exception e) {
+                LOG.error("Unable to create <{}> decorator", factory.getDescriptor().getName(), e);
+            }
         }
         return null;
     }


### PR DESCRIPTION
When the decoration creation or exection fails, the search request should not fail but return the undecorated result.

Turns this unhandled exception that returns a 500 for a search request and leaves the UI in a bad state ...

```
2016-08-03 10:04:22,240 ERROR: org.graylog2.shared.rest.exceptionmappers.AnyExceptionClassMapper - Unhandled exception in REST resource
java.lang.NullPointerException: source_field cannot be null
	at java.util.Objects.requireNonNull(Objects.java:228) ~[?:1.8.0_101]
	at org.graylog2.decorators.SyslogSeverityMapperDecorator.<init>(SyslogSeverityMapperDecorator.java:96) ~[classes/:?]
	at org.graylog2.decorators.SyslogSeverityMapperDecorator$$FastClassByGuice$$ec295563.newInstance(<generated>) ~[classes/:?]
	at com.google.inject.internal.DefaultConstructionProxyFactory$FastClassProxy.newInstance(DefaultConstructionProxyFactory.java:89) ~[guice-4.1.0.jar:?]
	at com.google.inject.internal.ConstructorInjector.provision(ConstructorInjector.java:111) ~[guice-4.1.0.jar:?]
	at com.google.inject.internal.ConstructorInjector.construct(ConstructorInjector.java:90) ~[guice-4.1.0.jar:?]
	at com.google.inject.internal.ConstructorBindingImpl$Factory.get(ConstructorBindingImpl.java:268) ~[guice-4.1.0.jar:?]
	at com.google.inject.internal.InjectorImpl$2$1.call(InjectorImpl.java:1019) ~[guice-4.1.0.jar:?]
	at com.google.inject.internal.InjectorImpl.callInContext(InjectorImpl.java:1085) ~[guice-4.1.0.jar:?]
	at com.google.inject.internal.InjectorImpl$2.get(InjectorImpl.java:1015) ~[guice-4.1.0.jar:?]
	at com.google.inject.assistedinject.FactoryProvider2.invoke(FactoryProvider2.java:776) ~[guice-assistedinject-4.1.0.jar:?]
	at com.sun.proxy.$Proxy99.create(Unknown Source) ~[?:?]
	at org.graylog2.decorators.DecoratorResolver.instantiateSearchResponseDecorator(DecoratorResolver.java:63) ~[classes/:?]
	at java.util.stream.ReferencePipeline$3$1.accept(ReferencePipeline.java:193) ~[?:1.8.0_101]
	at java.util.stream.SortedOps$SizedRefSortingSink.end(SortedOps.java:352) ~[?:1.8.0_101]
	at java.util.stream.AbstractPipeline.copyInto(AbstractPipeline.java:482) ~[?:1.8.0_101]
	at java.util.stream.AbstractPipeline.wrapAndCopyInto(AbstractPipeline.java:471) ~[?:1.8.0_101]
	at java.util.stream.ReduceOps$ReduceOp.evaluateSequential(ReduceOps.java:708) ~[?:1.8.0_101]
	at java.util.stream.AbstractPipeline.evaluate(AbstractPipeline.java:234) ~[?:1.8.0_101]
	at java.util.stream.ReferencePipeline.collect(ReferencePipeline.java:499) ~[?:1.8.0_101]
	at org.graylog2.decorators.DecoratorResolver.searchResponseDecoratorsForGlobal(DecoratorResolver.java:56) ~[classes/:?]
	at org.graylog2.decorators.DecoratorProcessorImpl.decorate(DecoratorProcessorImpl.java:47) ~[classes/:?]
	at org.graylog2.rest.resources.search.SearchResource.buildSearchResponse(SearchResource.java:184) ~[classes/:?]
	at org.graylog2.rest.resources.search.RelativeSearchResource.searchRelative(RelativeSearchResource.java:113) ~[classes/:?]
```

... into an error log message and returns the undecorated search result.

```
2016-08-03 10:09:26,643 ERROR: org.graylog2.decorators.DecoratorResolver - Unable to create <Syslog Severity Mapper> decorator
java.lang.NullPointerException: source_field cannot be null
	at java.util.Objects.requireNonNull(Objects.java:228) ~[?:1.8.0_101]
	at org.graylog2.decorators.SyslogSeverityMapperDecorator.<init>(SyslogSeverityMapperDecorator.java:96) ~[classes/:?]
	at org.graylog2.decorators.SyslogSeverityMapperDecorator$$FastClassByGuice$$ec295563.newInstance(<generated>) ~[classes/:?]
	at com.google.inject.internal.DefaultConstructionProxyFactory$FastClassProxy.newInstance(DefaultConstructionProxyFactory.java:89) ~[guice-4.1.0.jar:?]
	at com.google.inject.internal.ConstructorInjector.provision(ConstructorInjector.java:111) ~[guice-4.1.0.jar:?]
	at com.google.inject.internal.ConstructorInjector.construct(ConstructorInjector.java:90) ~[guice-4.1.0.jar:?]
	at com.google.inject.internal.ConstructorBindingImpl$Factory.get(ConstructorBindingImpl.java:268) ~[guice-4.1.0.jar:?]
	at com.google.inject.internal.InjectorImpl$2$1.call(InjectorImpl.java:1019) ~[guice-4.1.0.jar:?]
	at com.google.inject.internal.InjectorImpl.callInContext(InjectorImpl.java:1085) ~[guice-4.1.0.jar:?]
	at com.google.inject.internal.InjectorImpl$2.get(InjectorImpl.java:1015) ~[guice-4.1.0.jar:?]
	at com.google.inject.assistedinject.FactoryProvider2.invoke(FactoryProvider2.java:776) ~[guice-assistedinject-4.1.0.jar:?]
	at com.sun.proxy.$Proxy99.create(Unknown Source) ~[?:?]
	at org.graylog2.decorators.DecoratorResolver.instantiateSearchResponseDecorator(DecoratorResolver.java:68) ~[classes/:?]
	at java.util.stream.ReferencePipeline$3$1.accept(ReferencePipeline.java:193) [?:1.8.0_101]
	at java.util.stream.SortedOps$SizedRefSortingSink.end(SortedOps.java:352) [?:1.8.0_101]
	at java.util.stream.AbstractPipeline.copyInto(AbstractPipeline.java:482) [?:1.8.0_101]
	at java.util.stream.AbstractPipeline.wrapAndCopyInto(AbstractPipeline.java:471) [?:1.8.0_101]
	at java.util.stream.ReduceOps$ReduceOp.evaluateSequential(ReduceOps.java:708) [?:1.8.0_101]
	at java.util.stream.AbstractPipeline.evaluate(AbstractPipeline.java:234) [?:1.8.0_101]
	at java.util.stream.ReferencePipeline.collect(ReferencePipeline.java:499) [?:1.8.0_101]
	at org.graylog2.decorators.DecoratorResolver.searchResponseDecoratorsForGlobal(DecoratorResolver.java:60) [classes/:?]
	at org.graylog2.decorators.DecoratorProcessorImpl.decorate(DecoratorProcessorImpl.java:52) [classes/:?]
	at org.graylog2.rest.resources.search.SearchResource.buildSearchResponse(SearchResource.java:184) [classes/:?]
	at org.graylog2.rest.resources.search.RelativeSearchResource.searchRelative(RelativeSearchResource.java:113) [classes/:?]
```