### PR TITLE
Change logging in normalizeDn() to debug to avoid noisy warnings

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/security/ldap/LdapConnector.java
+++ b/graylog2-server/src/main/java/org/graylog2/security/ldap/LdapConnector.java
@@ -306,12 +306,22 @@ public class LdapConnector {
     }
 
     /**
-     * Makes sure the given DN string is normalized so it can be used in string comparison.
+     * When the given string is a DN, the method ensures that the DN gets normalized so it can be used in string
+     * comparison.
      *
-     * Example:
+     * If the string is not a DN, the method just returns it.
      *
+     * Examples:
+     *
+     * String is a DN:
      *   input  = "cn=John Doe, ou=groups, ou=system"
      *   output = "cn=John Doe,ou=groups,ou=system"
+     *
+     * String is not a DN:
+     *   input  = "john"
+     *   output = "john"
+     *
+     * This behavior is needed because for some values we don't know if the value is a DN or not. (i.e. group member values)
      *
      * See: https://github.com/Graylog2/graylog2-server/issues/1790
      *

--- a/graylog2-server/src/main/java/org/graylog2/security/ldap/LdapConnector.java
+++ b/graylog2-server/src/main/java/org/graylog2/security/ldap/LdapConnector.java
@@ -275,7 +275,7 @@ public class LdapConnector {
 
                         for (Value<?> member : members) {
                             LOG.trace("DN {} == {} member?", dn, member.getString());
-                            if (dn.equalsIgnoreCase(normalizedDn(member.getString()))) {
+                            if (dn != null && dn.equalsIgnoreCase(normalizedDn(member.getString()))) {
                                 groups.add(groupId);
                             } else {
                                 // The posixGroup object class is using the memberUid attribute for group members.

--- a/graylog2-server/src/main/java/org/graylog2/security/ldap/LdapConnector.java
+++ b/graylog2-server/src/main/java/org/graylog2/security/ldap/LdapConnector.java
@@ -326,7 +326,7 @@ public class LdapConnector {
             try {
                 return new Dn(dn).getNormName();
             } catch (LdapInvalidDnException e) {
-                LOG.warn("Invalid DN", e);
+                LOG.debug("Invalid DN", e);
                 return dn;
             }
         }


### PR DESCRIPTION
Group entries might be invalid DNs, which is okay. This avoids noisy WARN logging when handling groups.

Example:

```
2016-08-03 12:24:34,114 WARN : org.graylog2.security.ldap.LdapConnector - Invalid DN
org.apache.directory.api.ldap.model.exception.LdapInvalidDnException: ERR_04202 A value is missing on some RDN
	at org.apache.directory.api.ldap.model.name.Dn.<init>(Dn.java:283) ~[api-all-1.0.0-RC1.jar:1.0.0-RC1]
	at org.apache.directory.api.ldap.model.name.Dn.<init>(Dn.java:215) ~[api-all-1.0.0-RC1.jar:1.0.0-RC1]
	at org.graylog2.security.ldap.LdapConnector.normalizedDn(LdapConnector.java:321) [classes/:?]
	at org.graylog2.security.ldap.LdapConnector.findGroups(LdapConnector.java:276) [classes/:?]
	at org.graylog2.security.ldap.LdapConnector.search(LdapConnector.java:200) [classes/:?]
	at org.graylog2.security.realm.LdapUserAuthenticator.doGetAuthenticationInfo(LdapUserAuthenticator.java:119) [classes/:?]
	at org.apache.shiro.realm.AuthenticatingRealm.getAuthenticationInfo(AuthenticatingRealm.java:568) [shiro-core-1.3.0.jar:1.3.0]
	at org.apache.shiro.authc.pam.ModularRealmAuthenticator.doMultiRealmAuthentication(ModularRealmAuthenticator.java:219) [shiro-core-1.3.0.jar:1.3.0]
	at org.apache.shiro.authc.pam.ModularRealmAuthenticator.doAuthenticate(ModularRealmAuthenticator.java:269) [shiro-core-1.3.0.jar:1.3.0]
	at org.apache.shiro.authc.AbstractAuthenticator.authenticate(AbstractAuthenticator.java:198) [shiro-core-1.3.0.jar:1.3.0]
	at org.apache.shiro.mgt.AuthenticatingSecurityManager.authenticate(AuthenticatingSecurityManager.java:106) [shiro-core-1.3.0.jar:1.3.0]
	at org.apache.shiro.mgt.DefaultSecurityManager.login(DefaultSecurityManager.java:270) [shiro-core-1.3.0.jar:1.3.0]
	at org.apache.shiro.subject.support.DelegatingSubject.login(DelegatingSubject.java:256) [shiro-core-1.3.0.jar:1.3.0]
	at org.graylog2.rest.resources.system.SessionsResource.newSession(SessionsResource.java:128) [classes/:?]
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method) ~[?:1.8.0_101]
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62) ~[?:1.8.0_101]
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43) ~[?:1.8.0_101]
	at java.lang.reflect.Method.invoke(Method.java:498) ~[?:1.8.0_101]
	at org.glassfish.jersey.server.model.internal.ResourceMethodInvocationHandlerFactory$1.invoke(ResourceMethodInvocationHandlerFactory.java:81) [jersey-server-2.22.1.jar:?]
	at org.glassfish.jersey.server.model.internal.AbstractJavaResourceMethodDispatcher$1.run(AbstractJavaResourceMethodDispatcher.java:144) [jersey-server-2.22.1.jar:?]
	at org.glassfish.jersey.server.model.internal.AbstractJavaResourceMethodDispatcher.invoke(AbstractJavaResourceMethodDispatcher.java:161) [jersey-server-2.22.1.jar:?]
	at org.glassfish.jersey.server.model.internal.JavaResourceMethodDispatcherProvider$TypeOutInvoker.doDispatch(JavaResourceMethodDispatcherProvider.java:205) [jersey-server-2.22.1.jar:?]
	at org.glassfish.jersey.server.model.internal.AbstractJavaResourceMethodDispatcher.dispatch(AbstractJavaResourceMethodDispatcher.java:99) [jersey-server-2.22.1.jar:?]
	at org.glassfish.jersey.server.model.ResourceMethodInvoker.invoke(ResourceMethodInvoker.java:389) [jersey-server-2.22.1.jar:?]
	at org.glassfish.jersey.server.model.ResourceMethodInvoker.apply(ResourceMethodInvoker.java:347) [jersey-server-2.22.1.jar:?]
	at org.glassfish.jersey.server.model.ResourceMethodInvoker.apply(ResourceMethodInvoker.java:102) [jersey-server-2.22.1.jar:?]
	at org.glassfish.jersey.server.ServerRuntime$2.run(ServerRuntime.java:326) [jersey-server-2.22.1.jar:?]
	at org.glassfish.jersey.internal.Errors$1.call(Errors.java:271) [jersey-common-2.22.1.jar:?]
	at org.glassfish.jersey.internal.Errors$1.call(Errors.java:267) [jersey-common-2.22.1.jar:?]
	at org.glassfish.jersey.internal.Errors.process(Errors.java:315) [jersey-common-2.22.1.jar:?]
	at org.glassfish.jersey.internal.Errors.process(Errors.java:297) [jersey-common-2.22.1.jar:?]
	at org.glassfish.jersey.internal.Errors.process(Errors.java:267) [jersey-common-2.22.1.jar:?]
	at org.glassfish.jersey.process.internal.RequestScope.runInScope(RequestScope.java:317) [jersey-common-2.22.1.jar:?]
	at org.glassfish.jersey.server.ServerRuntime.process(ServerRuntime.java:305) [jersey-server-2.22.1.jar:?]
	at org.glassfish.jersey.server.ApplicationHandler.handle(ApplicationHandler.java:1154) [jersey-server-2.22.1.jar:?]
	at org.glassfish.jersey.grizzly2.httpserver.GrizzlyHttpContainer.service(GrizzlyHttpContainer.java:384) [jersey-container-grizzly2-http-2.22.1.jar:?]
	at org.glassfish.grizzly.http.server.HttpHandler$1.run(HttpHandler.java:224) [grizzly-http-server-2.3.23.jar:2.3.23]
	at com.codahale.metrics.InstrumentedExecutorService$InstrumentedRunnable.run(InstrumentedExecutorService.java:176) [metrics-core-3.1.2.jar:3.1.2]
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1142) [?:1.8.0_101]
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:617) [?:1.8.0_101]
	at java.lang.Thread.run(Thread.java:745) [?:1.8.0_101]
```