### PR TITLE
Ensure that {rest,web}_{listen,transport,endpoint}_uri settings are absolute URIs

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/Configuration.java
+++ b/graylog2-server/src/main/java/org/graylog2/Configuration.java
@@ -24,6 +24,7 @@ import com.github.joschi.jadconfig.validators.PositiveDurationValidator;
 import com.github.joschi.jadconfig.validators.PositiveIntegerValidator;
 import com.github.joschi.jadconfig.validators.PositiveLongValidator;
 import com.github.joschi.jadconfig.validators.StringNotBlankValidator;
+import com.github.joschi.jadconfig.validators.URIAbsoluteValidator;
 import org.graylog2.plugin.BaseConfiguration;
 import org.graylog2.utilities.IPSubnetConverter;
 import org.jboss.netty.handler.ipfilter.IpSubnet;
@@ -50,10 +51,10 @@ public class Configuration extends BaseConfiguration {
     @Parameter(value = "password_secret", required = true, validator = StringNotBlankValidator.class)
     private String passwordSecret;
 
-    @Parameter(value = "rest_listen_uri", required = true)
+    @Parameter(value = "rest_listen_uri", required = true, validator = URIAbsoluteValidator.class)
     private URI restListenUri = URI.create("http://127.0.0.1:" + GRAYLOG_DEFAULT_PORT + "/");
 
-    @Parameter(value = "web_listen_uri", required = true)
+    @Parameter(value = "web_listen_uri", required = true, validator = URIAbsoluteValidator.class)
     private URI webListenUri = URI.create("http://127.0.0.1:" + GRAYLOG_DEFAULT_WEB_PORT + "/web");
 
     @Parameter(value = "output_batch_size", required = true, validator = PositiveIntegerValidator.class)

--- a/graylog2-server/src/main/java/org/graylog2/plugin/BaseConfiguration.java
+++ b/graylog2-server/src/main/java/org/graylog2/plugin/BaseConfiguration.java
@@ -23,6 +23,7 @@ import com.github.joschi.jadconfig.util.Duration;
 import com.github.joschi.jadconfig.validators.PositiveDurationValidator;
 import com.github.joschi.jadconfig.validators.PositiveIntegerValidator;
 import com.github.joschi.jadconfig.validators.StringNotBlankValidator;
+import com.github.joschi.jadconfig.validators.URIAbsoluteValidator;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Strings;
 import com.lmax.disruptor.BlockingWaitStrategy;
@@ -34,9 +35,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.net.InetAddress;
-import java.net.MalformedURLException;
 import java.net.URI;
-import java.net.URL;
 import java.net.UnknownHostException;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -50,7 +49,7 @@ public abstract class BaseConfiguration {
     @Parameter(value = "shutdown_timeout", validator = PositiveIntegerValidator.class)
     protected int shutdownTimeout = 30000;
 
-    @Parameter(value = "rest_transport_uri")
+    @Parameter(value = "rest_transport_uri", validator = URIAbsoluteValidator.class)
     private URI restTransportUri;
 
     @Parameter(value = "processbuffer_processors", required = true, validator = PositiveIntegerValidator.class)
@@ -134,7 +133,7 @@ public abstract class BaseConfiguration {
     @Parameter(value = "web_enable")
     private boolean webEnable = true;
 
-    @Parameter(value = "web_endpoint_uri")
+    @Parameter(value = "web_endpoint_uri", validator = URIAbsoluteValidator.class)
     private URI webEndpointUri;
 
     @Parameter(value = "web_enable_cors")

--- a/graylog2-server/src/test/java/org/graylog2/ConfigurationTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/ConfigurationTest.java
@@ -1,0 +1,84 @@
+/**
+ * This file is part of Graylog.
+ *
+ * Graylog is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.graylog2;
+
+import com.github.joschi.jadconfig.JadConfig;
+import com.github.joschi.jadconfig.RepositoryException;
+import com.github.joschi.jadconfig.ValidationException;
+import com.github.joschi.jadconfig.repositories.InMemoryRepository;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class ConfigurationTest {
+    @Rule
+    public final ExpectedException expectedException = ExpectedException.none();
+
+    private Map<String, String> validProperties;
+
+    @Before
+    public void setUp() throws Exception {
+        validProperties = new HashMap<>();
+
+        // Required properties
+        validProperties.put("password_secret", "ipNUnWxmBLCxTEzXcyamrdy0Q3G7HxdKsAvyg30R9SCof0JydiZFiA3dLSkRsbLF");
+        // SHA-256 of "admin"
+        validProperties.put("root_password_sha2", "8c6976e5b5410415bde908bd4dee15dfb167a9c873fc4bb8a81f6f2ab448a918");
+    }
+
+    @Test
+    public void testRestListenUriIsRelativeURI() throws RepositoryException, ValidationException {
+        validProperties.put("rest_listen_uri", "/foo");
+
+        expectedException.expect(ValidationException.class);
+        expectedException.expectMessage("Parameter rest_listen_uri should be an absolute URI (found /foo)");
+
+        Configuration configuration = new Configuration();
+        new JadConfig(new InMemoryRepository(validProperties), configuration).process();
+    }
+
+    @Test
+    public void testWebListenUriIsRelativeURI() throws RepositoryException, ValidationException {
+        validProperties.put("web_listen_uri", "/foo");
+
+        expectedException.expect(ValidationException.class);
+        expectedException.expectMessage("Parameter web_listen_uri should be an absolute URI (found /foo)");
+
+        Configuration configuration = new Configuration();
+        new JadConfig(new InMemoryRepository(validProperties), configuration).process();
+    }
+
+    @Test
+    public void testRestListenUriIsAbsoluteURI() throws RepositoryException, ValidationException {
+        validProperties.put("rest_listen_uri", "http://www.example.com:12900/");
+
+        Configuration configuration = new Configuration();
+        new JadConfig(new InMemoryRepository(validProperties), configuration).process();
+    }
+
+    @Test
+    public void testWebListenUriIsAbsoluteURI() throws RepositoryException, ValidationException {
+        validProperties.put("rest_listen_uri", "http://www.example.com:12900/web");
+
+        Configuration configuration = new Configuration();
+        new JadConfig(new InMemoryRepository(validProperties), configuration).process();
+    }
+}

--- a/graylog2-server/src/test/java/org/graylog2/plugin/BaseConfigurationTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/plugin/BaseConfigurationTest.java
@@ -358,4 +358,42 @@ public class BaseConfigurationTest {
 
         new JadConfig(new InMemoryRepository(validProperties), new Configuration()).process();
     }
+
+    @Test
+    public void testRestTransportUriIsRelativeURI() throws RepositoryException, ValidationException {
+        validProperties.put("rest_transport_uri", "/foo");
+
+        expectedException.expect(ValidationException.class);
+        expectedException.expectMessage("Parameter rest_transport_uri should be an absolute URI (found /foo)");
+
+        Configuration configuration = new Configuration();
+        new JadConfig(new InMemoryRepository(validProperties), configuration).process();
+    }
+
+    @Test
+    public void testWebEndpointUriIsRelativeURI() throws RepositoryException, ValidationException {
+        validProperties.put("web_endpoint_uri", "/foo");
+
+        expectedException.expect(ValidationException.class);
+        expectedException.expectMessage("Parameter web_endpoint_uri should be an absolute URI (found /foo)");
+
+        Configuration configuration = new Configuration();
+        new JadConfig(new InMemoryRepository(validProperties), configuration).process();
+    }
+
+    @Test
+    public void testRestTransportUriIsAbsoluteURI() throws RepositoryException, ValidationException {
+        validProperties.put("rest_transport_uri", "http://www.example.com:12900/foo");
+
+        Configuration configuration = new Configuration();
+        new JadConfig(new InMemoryRepository(validProperties), configuration).process();
+    }
+
+    @Test
+    public void testWebEndpointUriIsAbsoluteURI() throws RepositoryException, ValidationException {
+        validProperties.put("web_endpoint_uri", "http://www.example.com:12900/foo");
+
+        Configuration configuration = new Configuration();
+        new JadConfig(new InMemoryRepository(validProperties), configuration).process();
+    }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -330,7 +330,7 @@
             <dependency>
                 <groupId>com.github.joschi</groupId>
                 <artifactId>jadconfig</artifactId>
-                <version>0.12.2</version>
+                <version>0.13.0</version>
             </dependency>
 
             <!-- Jersey and Glassfish -->


### PR DESCRIPTION
This PR ensures that all URI configuration settings in the Graylog configuration file are indeed absolute URIs.

Refs #2596, supersedes #2589.