### PR TITLE
Print - instead of null when client did not provide user agent header

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/shared/rest/RestAccessLogFilter.java
+++ b/graylog2-server/src/main/java/org/graylog2/shared/rest/RestAccessLogFilter.java
@@ -55,6 +55,7 @@ public class RestAccessLogFilter implements ContainerResponseFilter {
                 final Date requestDate = requestContext.getDate();
                 final String userName = RestTools.getUserNameFromRequest(requestContext);
                 final String remoteAddress = RestTools.getRemoteAddrFromRequest(response.getRequest(), trustedProxies);
+                final String userAgent = requestContext.getHeaderString(HttpHeaders.USER_AGENT);
 
                 LOG.debug("{} {} [{}] \"{} {}{}\" {} {} {}",
                         remoteAddress,
@@ -63,7 +64,7 @@ public class RestAccessLogFilter implements ContainerResponseFilter {
                         requestContext.getMethod(),
                         requestContext.getUriInfo().getPath(),
                         (rawQuery == null ? "" : "?" + rawQuery),
-                        requestContext.getHeaderString(HttpHeaders.USER_AGENT),
+                        (userAgent == null ? "-" : userAgent),
                         responseContext.getStatus(),
                         responseContext.getLength());
             } catch (Exception e) {


### PR DESCRIPTION
HTTP clients not providing user agent header cause "null" to be printed in logs. Found this out when a braindead load balancer product started hammering /system/lbstatus... Just a cosmetic fix.

By the way, responseContext.getLength() can never work at RestAccessLogFilter, because Jersey has not produced the body yet - thus there is no Content-Length available. I think counting responseContext.getEntityStream() might work, that seemed like heavy to me.