### PR TITLE
Use HTTP and HTTPS default ports for network settings

### DIFF
--- a/UPGRADING.rst
+++ b/UPGRADING.rst
@@ -42,6 +42,25 @@ Previous versions of Graylog included a (long deprecated) metrics reporter for w
 This feature has been removed completely and can be optionally pulled in by using the `Graylog Metrics Reporter Plugins <https://github.com/Graylog2/graylog-plugin-metrics-reporter>`_.
 
 
+Configuration file changes
+--------------------------
+
+Network settings
+^^^^^^^^^^^^^^^^
+
+The network settings in the Graylog configuration file (``rest_listen_uri``, ``rest_transport_uri``, and ``web_listen_uri``) are now using the default ports for the HTTP (80) and HTTPS (443) if no custom port was given. Previously those settings were using the custom ports 12900 (Graylog REST API) and 9000 (Graylog web interface) if no explicit port was given.
+
+Examples:
+
++-----------------------------------------------+------------------------------+-----------------------------+
+| Configurastion setting                        | Old effective URI            | New effective URI           |
++===============================================+==============================+=============================+
+| ``rest_listen_uri = http://127.0.0.1:12900/`` | ``http://127.0.0.1:12900/``  | ``http://127.0.0.1:12900/`` |
+| ``rest_listen_uri = http://127.0.0.1/``       | ``http://127.0.0.1:12900/``  | ``http://127.0.0.1:80/``    |
+| ``rest_listen_uri = https://127.0.0.1/``      | ``https://127.0.0.1:12900/`` | ``https://127.0.0.1:443/``  |
++-----------------------------------------------+------------------------------+-----------------------------+
+
+
 Graylog REST API
 ----------------
 

--- a/graylog2-server/src/main/java/org/graylog2/plugin/Tools.java
+++ b/graylog2-server/src/main/java/org/graylog2/plugin/Tools.java
@@ -464,11 +464,23 @@ public final class Tools {
 
         try {
             if (uri.getPort() == -1) {
+                final int realPort;
+                switch (uri.getScheme()) {
+                    case "http":
+                        realPort = 80;
+                        break;
+                    case "https":
+                        realPort = 443;
+                        break;
+                    default:
+                        realPort = port;
+                }
+
                 return new URI(
                         uri.getScheme(),
                         uri.getUserInfo(),
                         uri.getHost(),
-                        port,
+                        realPort,
                         uri.getPath(),
                         uri.getQuery(),
                         uri.getFragment());

--- a/graylog2-server/src/test/java/org/graylog2/ConfigurationTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/ConfigurationTest.java
@@ -28,6 +28,8 @@ import org.junit.rules.ExpectedException;
 import java.util.HashMap;
 import java.util.Map;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 public class ConfigurationTest {
     @Rule
     public final ExpectedException expectedException = ExpectedException.none();
@@ -80,5 +82,45 @@ public class ConfigurationTest {
 
         Configuration configuration = new Configuration();
         new JadConfig(new InMemoryRepository(validProperties), configuration).process();
+    }
+
+    @Test
+    public void testRestListenUriWithHttpDefaultPort() throws RepositoryException, ValidationException {
+        validProperties.put("rest_listen_uri", "http://example.com/");
+
+        Configuration configuration = new Configuration();
+        new JadConfig(new InMemoryRepository(validProperties), configuration).process();
+
+        assertThat(configuration.getRestListenUri()).hasPort(80);
+    }
+
+    @Test
+    public void testRestListenUriWithCustomPort() throws RepositoryException, ValidationException {
+        validProperties.put("rest_listen_uri", "http://example.com:12900/");
+
+        Configuration configuration = new Configuration();
+        new JadConfig(new InMemoryRepository(validProperties), configuration).process();
+
+        assertThat(configuration.getRestListenUri()).hasPort(12900);
+    }
+
+    @Test
+    public void testWebListenUriWithHttpDefaultPort() throws RepositoryException, ValidationException {
+        validProperties.put("web_listen_uri", "http://example.com/");
+
+        Configuration configuration = new Configuration();
+        new JadConfig(new InMemoryRepository(validProperties), configuration).process();
+
+        assertThat(configuration.getWebListenUri()).hasPort(80);
+    }
+
+    @Test
+    public void testWebListenUriWithCustomPort() throws RepositoryException, ValidationException {
+        validProperties.put("web_listen_uri", "http://example.com:9000/");
+
+        Configuration configuration = new Configuration();
+        new JadConfig(new InMemoryRepository(validProperties), configuration).process();
+
+        assertThat(configuration.getWebListenUri()).hasPort(9000);
     }
 }

--- a/graylog2-server/src/test/java/org/graylog2/plugin/BaseConfigurationTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/plugin/BaseConfigurationTest.java
@@ -21,6 +21,7 @@ import com.github.joschi.jadconfig.Parameter;
 import com.github.joschi.jadconfig.RepositoryException;
 import com.github.joschi.jadconfig.ValidationException;
 import com.github.joschi.jadconfig.repositories.InMemoryRepository;
+import org.graylog2.Configuration;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Rule;
@@ -395,5 +396,25 @@ public class BaseConfigurationTest {
 
         Configuration configuration = new Configuration();
         new JadConfig(new InMemoryRepository(validProperties), configuration).process();
+    }
+
+    @Test
+    public void testRestTransportUriWithHttpDefaultPort() throws RepositoryException, ValidationException {
+        validProperties.put("rest_transport_uri", "http://example.com/");
+
+        org.graylog2.Configuration configuration = new org.graylog2.Configuration();
+        new JadConfig(new InMemoryRepository(validProperties), configuration).process();
+
+        assertThat(configuration.getRestTransportUri()).hasPort(80);
+    }
+
+    @Test
+    public void testRestTransportUriWithCustomPort() throws RepositoryException, ValidationException {
+        validProperties.put("rest_transport_uri", "http://example.com:12900/");
+
+        org.graylog2.Configuration configuration = new org.graylog2.Configuration();
+        new JadConfig(new InMemoryRepository(validProperties), configuration).process();
+
+        assertThat(configuration.getRestTransportUri()).hasPort(12900);
     }
 }

--- a/graylog2-server/src/test/java/org/graylog2/plugin/ToolsTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/plugin/ToolsTest.java
@@ -44,10 +44,14 @@ public class ToolsTest {
     @Test
     public void testGetUriWithPort() throws Exception {
         final URI uriWithPort = new URI("http://example.com:12345");
-        final URI uriWithoutPort = new URI("http://example.com");
+        final URI httpUriWithoutPort = new URI("http://example.com");
+        final URI httpsUriWithoutPort = new URI("https://example.com");
+        final URI uriWithUnknownSchemeAndWithoutPort = new URI("foobar://example.com");
 
         assertEquals(Tools.getUriWithPort(uriWithPort, 1).getPort(), 12345);
-        assertEquals(Tools.getUriWithPort(uriWithoutPort, 1).getPort(), 1);
+        assertEquals(Tools.getUriWithPort(httpUriWithoutPort, 1).getPort(), 80);
+        assertEquals(Tools.getUriWithPort(httpsUriWithoutPort, 1).getPort(), 443);
+        assertEquals(Tools.getUriWithPort(uriWithUnknownSchemeAndWithoutPort, 1).getPort(), 1);
     }
 
     @Test


### PR DESCRIPTION
## Description

The network settings in the Graylog configuration should use the default ports for the configured URI scheme if no custom port was given.

## Motivation and Context

Currently users struggle with the non-standard handling of ports in the `rest_listen_uri`, `rest_transport_uri`, and `web_listen_uri` configuration settings. People are used to *not* type in the default ports for HTTP and HTTPS URIs, e. g. `http://www.example.com` instead of `http://www.example.com:80`.

Refs #2595

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [X] My code follows the code style of this project.
- [X] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.