### PR TITLE
Allow web_endpoint_uri to be a relative URI

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/plugin/BaseConfiguration.java
+++ b/graylog2-server/src/main/java/org/graylog2/plugin/BaseConfiguration.java
@@ -133,7 +133,7 @@ public abstract class BaseConfiguration {
     @Parameter(value = "web_enable")
     private boolean webEnable = true;
 
-    @Parameter(value = "web_endpoint_uri", validator = URIAbsoluteValidator.class)
+    @Parameter(value = "web_endpoint_uri")
     private URI webEndpointUri;
 
     @Parameter(value = "web_enable_cors")

--- a/graylog2-server/src/test/java/org/graylog2/ConfigurationTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/ConfigurationTest.java
@@ -25,6 +25,7 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 
+import java.net.URI;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -74,14 +75,18 @@ public class ConfigurationTest {
 
         Configuration configuration = new Configuration();
         new JadConfig(new InMemoryRepository(validProperties), configuration).process();
+
+        assertThat(configuration.getRestListenUri()).isEqualTo(URI.create("http://www.example.com:12900/"));
     }
 
     @Test
     public void testWebListenUriIsAbsoluteURI() throws RepositoryException, ValidationException {
-        validProperties.put("rest_listen_uri", "http://www.example.com:12900/web");
+        validProperties.put("web_listen_uri", "http://www.example.com:12900/web");
 
         Configuration configuration = new Configuration();
         new JadConfig(new InMemoryRepository(validProperties), configuration).process();
+
+        assertThat(configuration.getWebListenUri()).isEqualTo(URI.create("http://www.example.com:12900/web"));
     }
 
     @Test

--- a/graylog2-server/src/test/java/org/graylog2/plugin/BaseConfigurationTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/plugin/BaseConfigurationTest.java
@@ -387,6 +387,8 @@ public class BaseConfigurationTest {
 
         Configuration configuration = new Configuration();
         new JadConfig(new InMemoryRepository(validProperties), configuration).process();
+
+        assertEquals(URI.create("http://www.example.com:12900/foo"), configuration.getRestTransportUri());
     }
 
     @Test
@@ -395,6 +397,8 @@ public class BaseConfigurationTest {
 
         Configuration configuration = new Configuration();
         new JadConfig(new InMemoryRepository(validProperties), configuration).process();
+
+        assertEquals(URI.create("http://www.example.com:12900/foo"), configuration.getWebEndpointUri());
     }
 
     @Test

--- a/graylog2-server/src/test/java/org/graylog2/plugin/BaseConfigurationTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/plugin/BaseConfigurationTest.java
@@ -375,11 +375,10 @@ public class BaseConfigurationTest {
     public void testWebEndpointUriIsRelativeURI() throws RepositoryException, ValidationException {
         validProperties.put("web_endpoint_uri", "/foo");
 
-        expectedException.expect(ValidationException.class);
-        expectedException.expectMessage("Parameter web_endpoint_uri should be an absolute URI (found /foo)");
-
         Configuration configuration = new Configuration();
         new JadConfig(new InMemoryRepository(validProperties), configuration).process();
+
+        assertEquals(URI.create("/foo"), configuration.getWebEndpointUri());
     }
 
     @Test


### PR DESCRIPTION
The changes in PR #2600 restricted `web_endpoint_uri` to an absolute URI, which makes some use cases impossible to implement: https://github.com/Graylog2/graylog2-server/pull/2600#issuecomment-237304706

This PR reverts this specific validation for the `web_endpoint_uri` configuration setting.

