### PR TITLE
Reduce production .js files sizes by 51%

### DIFF
--- a/graylog2-web-interface/webpack.config.js
+++ b/graylog2-web-interface/webpack.config.js
@@ -28,7 +28,6 @@ const webpackConfig = {
     ],
     loaders: [
       { test: /\.json$/, loader: 'json-loader' },
-      { test: /\.js(x)?$/, loaders: ['react-hot', 'babel-loader'], exclude: /node_modules|\.node_cache/ },
       { test: /\.ts$/, loader: 'babel-loader!ts-loader', exclude: /node_modules|\.node_cache/ },
       { test: /\.(woff(2)?|svg|eot|ttf|gif|jpg)(\?.+)?$/, loader: 'file-loader' },
       { test: /\.png$/, loader: 'url-loader' },
@@ -44,7 +43,7 @@ const webpackConfig = {
   eslint: {
     configFile: '.eslintrc',
   },
-  devtool: 'eval',
+  devtool: 'source-map',
   plugins: [
     new webpack.DllReferencePlugin({ manifest: VENDOR_MANIFEST, context: ROOT_PATH }),
     new HtmlWebpackPlugin({
@@ -74,6 +73,18 @@ const commonConfigs = {
     ],
   },
 };
+
+// We use the react-hot loader when running "start" for development.
+// Any other target does not use it.
+if (TARGET === 'start') {
+  webpackConfig.module.loaders.unshift(
+    { test: /\.js(x)?$/, loaders: ['react-hot', 'babel-loader'], exclude: /node_modules|\.node_cache/ }
+  );
+} else {
+  webpackConfig.module.loaders.unshift(
+    { test: /\.js(x)?$/, loaders: ['babel-loader'], exclude: /node_modules|\.node_cache/ }
+  );
+}
 
 if (TARGET === 'start') {
   console.log('Running in development mode');
@@ -105,7 +116,7 @@ if (TARGET === 'build') {
     plugins: [
       new webpack.optimize.UglifyJsPlugin({
         minimize: true,
-        sourceMap: false,
+        sourceMap: true,
         compress: {
           warnings: false,
         },

--- a/graylog2-web-interface/webpack.config.js
+++ b/graylog2-web-interface/webpack.config.js
@@ -120,6 +120,9 @@ if (TARGET === 'build') {
         compress: {
           warnings: false,
         },
+        mangle: {
+          except: ['$super', '$', 'exports', 'require'],
+        },
       }),
       new webpack.optimize.DedupePlugin(),
       new webpack.optimize.OccurenceOrderPlugin(),


### PR DESCRIPTION
- Do not use the react-hot loader for production builds
- Use "source-map" instead of "eval" for "devtool" setting in production
  builds
- Enable source maps in the UglifyJsPlugin for production builds

By not using "eval" for the "devtool" setting we are getting much
smaller .js files. Using "source-map" for "devtool" and enabling source
maps for the UglifyJsPlugin increases the production build time, but also
produces higher quality source maps for debugging.

Before:

- Build time: 0m39.788s
- All .js files size: 7.9MB

After:

- Build time: 1m4.028s
- All .js files size: 3.8MB