### PR TITLE
use default session attribute for principal

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/rest/resources/system/SessionsResource.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/resources/system/SessionsResource.java
@@ -129,7 +129,6 @@ public class SessionsResource extends RestResource {
             final User user = userService.load(createRequest.username());
             if (user != null) {
                 long timeoutInMillis = user.getSessionTimeoutMs();
-                s.setAttribute("username", user.getName());
                 s.setTimeout(timeoutInMillis);
             } else {
                 // set a sane default. really we should be able to load the user from above.

--- a/graylog2-server/src/main/java/org/graylog2/security/MongoDbSession.java
+++ b/graylog2-server/src/main/java/org/graylog2/security/MongoDbSession.java
@@ -16,6 +16,7 @@
  */
 package org.graylog2.security;
 
+import org.apache.shiro.subject.support.DefaultSubjectContext;
 import org.bson.types.ObjectId;
 import org.graylog2.database.CollectionName;
 import org.graylog2.database.PersistedImpl;
@@ -92,7 +93,7 @@ public class MongoDbSession extends PersistedImpl {
         if (attributes == null) {
             return Optional.empty();
         }
-        return Optional.ofNullable(String.valueOf(attributes.get("username")));
+        return Optional.ofNullable(String.valueOf(attributes.get(DefaultSubjectContext.PRINCIPALS_SESSION_KEY)));
     }
 
     public String getHost() {


### PR DESCRIPTION
## Description
the SessionResource set a custom session attribute to find the name of the user owning the session, but the if auth plugins forced a session creation that wasn't set.
Instead of trying to fix the auth plugins, rely on a shiro framework attribute to get the principal

## Motivation and Context
fixes #2620 

## How Has This Been Tested?
Use the SSO plugin and a proxy setting a auth header.
Before the change users that logged in via the SSO plugin aren't show as having an active session in the Users list.
After the change the users' sessions can be found and they are shown as logged in.

## Screenshots (if appropriate):

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
