### PR TITLE
Ensure that password_secret is at least 16 characters long

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/Configuration.java
+++ b/graylog2-server/src/main/java/org/graylog2/Configuration.java
@@ -17,6 +17,8 @@
 package org.graylog2;
 
 import com.github.joschi.jadconfig.Parameter;
+import com.github.joschi.jadconfig.ValidationException;
+import com.github.joschi.jadconfig.ValidatorMethod;
 import com.github.joschi.jadconfig.converters.TrimmedStringSetConverter;
 import com.github.joschi.jadconfig.util.Duration;
 import com.github.joschi.jadconfig.validators.DirectoryPathReadableValidator;
@@ -316,5 +318,13 @@ public class Configuration extends BaseConfiguration {
 
     public int getLoadBalancerRequestThrottleJournalUsage() {
         return loadBalancerThrottleThresholdPercentage;
+    }
+
+    @ValidatorMethod
+    public void validatePasswordSecret() throws ValidationException {
+        final String passwordSecret = getPasswordSecret();
+        if (passwordSecret == null || passwordSecret.length() < 16) {
+            throw new ValidationException("The minimum length for \"password_secret\" is 16 characters.");
+        }
     }
 }

--- a/graylog2-server/src/test/java/org/graylog2/ConfigurationTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/ConfigurationTest.java
@@ -17,6 +17,7 @@
 package org.graylog2;
 
 import com.github.joschi.jadconfig.JadConfig;
+import com.github.joschi.jadconfig.ParameterException;
 import com.github.joschi.jadconfig.RepositoryException;
 import com.github.joschi.jadconfig.ValidationException;
 import com.github.joschi.jadconfig.repositories.InMemoryRepository;
@@ -122,5 +123,48 @@ public class ConfigurationTest {
         new JadConfig(new InMemoryRepository(validProperties), configuration).process();
 
         assertThat(configuration.getWebListenUri()).hasPort(9000);
+    }
+
+    @Test
+    public void testPasswordSecretIsTooShort() throws ValidationException, RepositoryException {
+        validProperties.put("password_secret", "too short");
+
+        expectedException.expect(ValidationException.class);
+        expectedException.expectMessage("The minimum length for \"password_secret\" is 16 characters.");
+
+        Configuration configuration = new Configuration();
+        new JadConfig(new InMemoryRepository(validProperties), configuration).process();
+    }
+
+    @Test
+    public void testPasswordSecretIsEmpty() throws ValidationException, RepositoryException {
+        validProperties.put("password_secret", "");
+
+        expectedException.expect(ValidationException.class);
+        expectedException.expectMessage("Parameter password_secret should not be blank");
+
+        Configuration configuration = new Configuration();
+        new JadConfig(new InMemoryRepository(validProperties), configuration).process();
+    }
+
+    @Test
+    public void testPasswordSecretIsNull() throws ValidationException, RepositoryException {
+        validProperties.put("password_secret", null);
+
+        expectedException.expect(ParameterException.class);
+        expectedException.expectMessage("Required parameter \"password_secret\" not found.");
+
+        Configuration configuration = new Configuration();
+        new JadConfig(new InMemoryRepository(validProperties), configuration).process();
+    }
+
+    @Test
+    public void testPasswordSecretIsValid() throws ValidationException, RepositoryException {
+        validProperties.put("password_secret", "abcdefghijklmnopqrstuvwxyz");
+
+        Configuration configuration = new Configuration();
+        new JadConfig(new InMemoryRepository(validProperties), configuration).process();
+
+        assertThat(configuration.getPasswordSecret()).isEqualTo("abcdefghijklmnopqrstuvwxyz");
     }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Saving LDAP settings will fail if `password_secret` is less than 16 characters long. Currently Graylog only ensures that `password_secret` is not blank.

Refs #2619

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.