### PR TITLE
Dashboard improvements

### DIFF
--- a/graylog2-web-interface/package.json
+++ b/graylog2-web-interface/package.json
@@ -23,6 +23,7 @@
     "crossfilter": "1.3.x",
     "d3": "<=3.5.0",
     "dc": "2.0.0-beta.19",
+    "deep-equal": "^1.0.1",
     "graylog-web-plugin": "latest",
     "history": "^1.17.0",
     "immutable": "^3.7.5",

--- a/graylog2-web-interface/src/components/visualizations/GraphVisualization.jsx
+++ b/graylog2-web-interface/src/components/visualizations/GraphVisualization.jsx
@@ -4,7 +4,9 @@ import numeral from 'numeral';
 import crossfilter from 'crossfilter';
 import dc from 'dc';
 import d3 from 'd3';
+// eslint-disable-next-line no-unused-vars
 import jQuery from 'jquery';
+import deepEqual from 'deep-equal';
 
 import DateTime from 'logic/datetimes/DateTime';
 import HistogramFormatter from 'logic/graphs/HistogramFormatter';
@@ -93,6 +95,10 @@ const GraphVisualization = React.createClass({
     this._updateData(this.props.data, this.props.config);
   },
   componentWillReceiveProps(nextProps) {
+    if (deepEqual(this.props, nextProps)) {
+      return;
+    }
+
     if (nextProps.height !== this.props.height || nextProps.width !== this.props.width) {
       this._resizeVisualization(nextProps.width, nextProps.height);
     }

--- a/graylog2-web-interface/src/components/visualizations/HistogramVisualization.jsx
+++ b/graylog2-web-interface/src/components/visualizations/HistogramVisualization.jsx
@@ -4,6 +4,7 @@ import numeral from 'numeral';
 import crossfilter from 'crossfilter';
 import dc from 'dc';
 import d3 from 'd3';
+import deepEqual from 'deep-equal';
 
 import DateTime from 'logic/datetimes/DateTime';
 import HistogramFormatter from 'logic/graphs/HistogramFormatter';
@@ -39,6 +40,10 @@ const HistogramVisualization = React.createClass({
     this._updateData(this.props.data);
   },
   componentWillReceiveProps(nextProps) {
+    if (deepEqual(this.props, nextProps)) {
+      return;
+    }
+
     if (nextProps.height !== this.props.height || nextProps.width !== this.props.width) {
       this._resizeVisualization(nextProps.width, nextProps.height);
     }

--- a/graylog2-web-interface/src/components/visualizations/NumericVisualization.jsx
+++ b/graylog2-web-interface/src/components/visualizations/NumericVisualization.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import deepEqual from 'deep-equal';
 
 import NumberUtils from 'util/NumberUtils';
 
@@ -25,8 +26,12 @@ const NumericVisualization = React.createClass({
     const state = this._normalizeStateFromProps(this.props.data);
     this.setState(state);
   },
-  componentWillReceiveProps(newProps) {
-    const state = this._normalizeStateFromProps(newProps.data);
+  componentWillReceiveProps(nextProps) {
+    if (deepEqual(this.props, nextProps)) {
+      return;
+    }
+
+    const state = this._normalizeStateFromProps(nextProps.data);
     this.setState(state);
   },
   DEFAULT_VALUE_FONT_SIZE: '70px',

--- a/graylog2-web-interface/src/components/visualizations/QuickValuesVisualization.jsx
+++ b/graylog2-web-interface/src/components/visualizations/QuickValuesVisualization.jsx
@@ -4,6 +4,7 @@ import {Panel, ListGroup, ListGroupItem} from 'react-bootstrap';
 import crossfilter from 'crossfilter';
 import dc from 'dc';
 import d3 from 'd3';
+import deepEqual from 'deep-equal';
 
 const D3Utils = require('../../util/D3Utils');
 const StringUtils = require('../../util/StringUtils');
@@ -47,9 +48,13 @@ const QuickValuesVisualization = React.createClass({
     this._renderDataTable();
     this._renderPieChart();
   },
-  componentWillReceiveProps(newProps) {
-    this._resizeVisualization(newProps.width, newProps.height, newProps.config.show_data_table);
-    this._formatProps(newProps);
+  componentWillReceiveProps(nextProps) {
+    if (deepEqual(this.props, nextProps)) {
+      return;
+    }
+
+    this._resizeVisualization(nextProps.width, nextProps.height, nextProps.config.show_data_table);
+    this._formatProps(nextProps);
   },
   NUMBER_OF_TOP_VALUES: 5,
   DEFAULT_PIE_CHART_SIZE: 200,

--- a/graylog2-web-interface/src/components/visualizations/StackedGraphVisualization.jsx
+++ b/graylog2-web-interface/src/components/visualizations/StackedGraphVisualization.jsx
@@ -4,6 +4,7 @@ import Immutable from 'immutable';
 import numeral from 'numeral';
 import c3 from 'c3';
 import d3 from 'd3';
+import deepEqual from 'deep-equal';
 
 import D3Utils from 'util/D3Utils';
 import DateTime from 'logic/datetimes/DateTime';
@@ -34,6 +35,10 @@ const StackedGraphVisualization = React.createClass({
     this.drawData();
   },
   componentWillReceiveProps(nextProps) {
+    if (deepEqual(this.props, nextProps)) {
+      return;
+    }
+
     if (nextProps.height !== this.props.height || nextProps.width !== this.props.width) {
       this._resizeVisualization(nextProps.width, nextProps.height);
     }

--- a/graylog2-web-interface/src/components/widgets/Widget.jsx
+++ b/graylog2-web-interface/src/components/widgets/Widget.jsx
@@ -63,7 +63,7 @@ const Widget = React.createClass({
     return ReactDOM.findDOMNode(this.refs.widget);
   },
   _loadValue() {
-    if (this.state.result !== undefined && !this.props.shouldUpdate) {
+    if (this.state.deleted || (this.state.result !== undefined && !this.props.shouldUpdate)) {
       return;
     }
 

--- a/graylog2-web-interface/src/components/widgets/Widget.jsx
+++ b/graylog2-web-interface/src/components/widgets/Widget.jsx
@@ -70,6 +70,11 @@ const Widget = React.createClass({
     const width = this.refs.widget.clientWidth;
 
     WidgetsStore.loadValue(this.props.dashboardId, this.props.widget.id, width).then((value) => {
+      // Avoid updating state if the result didn't change
+      if (value.calculated_at === this.state.calculatedAt) {
+        return;
+      }
+
       const newState = {
         result: value.result,
         calculatedAt: value.calculated_at,

--- a/graylog2-web-interface/src/components/widgets/Widget.jsx
+++ b/graylog2-web-interface/src/components/widgets/Widget.jsx
@@ -63,7 +63,7 @@ const Widget = React.createClass({
     return ReactDOM.findDOMNode(this.refs.widget);
   },
   _loadValue() {
-    if (!this.props.shouldUpdate) {
+    if (this.state.result !== undefined && !this.props.shouldUpdate) {
       return;
     }
 

--- a/graylog2-web-interface/src/components/widgets/types/index.js
+++ b/graylog2-web-interface/src/components/widgets/types/index.js
@@ -48,7 +48,7 @@ PluginStore.register(new PluginManifest({}, {
       type: 'SEARCH_RESULT_CHART',
       displayName: 'Search result graph',
       defaultHeight: 1,
-      defaultWidth: 1,
+      defaultWidth: 2,
       visualizationComponent: HistogramVisualization,
     },
     {

--- a/graylog2-web-interface/src/pages/ShowDashboardPage.jsx
+++ b/graylog2-web-interface/src/pages/ShowDashboardPage.jsx
@@ -32,6 +32,8 @@ const ShowDashboardPage = React.createClass({
     this.loadData();
     this.listenTo(WidgetsStore, this.removeWidget);
     this.loadInterval = setInterval(this.loadData, 2000);
+    // eslint-disable-next-line react/no-did-mount-set-state
+    this.setState({ forceUpdateInBackground: this.state.currentUser.preferences.updateUnfocussed });
   },
   componentWillUnmount() {
     if (this.loadInterval) {
@@ -56,11 +58,8 @@ const ShowDashboardPage = React.createClass({
         }
       });
   },
-  updateUnFocussed() {
-    return this.state.currentUser.preferences.updateUnfocussed;
-  },
   shouldUpdate() {
-    return Boolean(this.updateUnFocussed() || this.state.forceUpdateInBackground || this.state.focus);
+    return Boolean(this.state.forceUpdateInBackground || this.state.focus);
   },
   removeWidget(props) {
     if (props.delete) {

--- a/graylog2-web-interface/src/pages/ShowDashboardPage.jsx
+++ b/graylog2-web-interface/src/pages/ShowDashboardPage.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import Reflux from 'reflux';
 import { Row, Col, Button, Alert } from 'react-bootstrap';
 import { PluginStore } from 'graylog-web-plugin/plugin';
+import deepEqual from 'deep-equal';
 
 import StoreProvider from 'injection/StoreProvider';
 const CurrentUserStore = StoreProvider.getStore('CurrentUser');
@@ -43,8 +44,15 @@ const ShowDashboardPage = React.createClass({
   loadData() {
     DashboardsStore.get(this.props.params.dashboardId)
       .then((dashboard) => {
-        if (this.isMounted()) {
-          this.setState({dashboard: dashboard});
+        if (!this.isMounted()) {
+          return;
+        }
+
+        // Compare dashboard in state with the one received, need to sort widgets to avoid that they come in
+        // a different order, affecting the comparison.
+        dashboard.widgets.sort((w1, w2) => w1.id.localeCompare(w2.id));
+        if (!this.state.dashboard || !deepEqual(this.state.dashboard, dashboard)) {
+          this.setState({ dashboard: dashboard });
         }
       });
   },


### PR DESCRIPTION
This PR brings some improvements to dashboards:

- Improve CPU usage by avoiding unnecessary re-renders. Fixes #2281
- Get value once for widgets added in the background. Fixes #2084
- Set initial widget refresh state by using the `updateUnfocussed` user preference. The button to "Update in the background/foreground" lets now override that preference temporarily, no matter what it initial value is
- Avoid loading widget value once it is deleted, which could return a 404 and an error message