### PR TITLE
Add start-nohmr script to run webpack without HMR

### DIFF
--- a/graylog2-web-interface/.babelrc
+++ b/graylog2-web-interface/.babelrc
@@ -17,6 +17,11 @@
           ]
         }
       }
+    },
+    "start-nohmr": {
+      "plugins": [
+        "react-auto-display-name"
+      ]
     }
   }
 }

--- a/graylog2-web-interface/package.json
+++ b/graylog2-web-interface/package.json
@@ -11,6 +11,7 @@
   "readme": "../README.md",
   "scripts": {
     "start": "./node_modules/.bin/webpack --config webpack.vendor.js && ./node_modules/.bin/webpack-dev-server --config webpack.combined.config.js",
+    "start-nohmr": "./node_modules/.bin/webpack --config webpack.vendor.js && ./node_modules/.bin/webpack-dev-server --watch --config webpack.combined.config.js",
     "build": "./node_modules/.bin/webpack -p --config webpack.vendor.js && ./node_modules/.bin/webpack",
     "test": "./node_modules/.bin/webpack --config webpack.vendor.js && ./node_modules/karma/bin/karma start karma.ci.conf.js",
     "prepare-dev": "./tools/prepare-dev"

--- a/graylog2-web-interface/webpack.config.js
+++ b/graylog2-web-interface/webpack.config.js
@@ -110,6 +110,27 @@ if (TARGET === 'start') {
   });
 }
 
+if (TARGET === 'start-nohmr') {
+  console.log('Running in development (no HMR) mode');
+  module.exports = merge(webpackConfig, {
+    devtool: 'eval',
+    devServer: {
+      historyApiFallback: true,
+      hot: false,
+      inline: true,
+      progress: true,
+    },
+    output: {
+      path: BUILD_PATH,
+      filename: '[name].js',
+      publicPath: '/',
+    },
+    plugins: [
+      new webpack.DefinePlugin({DEVELOPMENT: true}),
+    ],
+  });
+}
+
 if (TARGET === 'build') {
   console.log('Running in production mode');
   module.exports = merge(webpackConfig, {


### PR DESCRIPTION
Makes it possible to run the development server without hot module reload.