### PR TITLE
Compile regex pattern for MetricFilter only once

### DIFF
--- a/graylog2-server/src/test/java/org/graylog2/periodical/ThroughputCalculatorTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/periodical/ThroughputCalculatorTest.java
@@ -1,0 +1,29 @@
+/**
+ * This file is part of Graylog.
+ *
+ * Graylog is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.graylog2.periodical;
+
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+public class ThroughputCalculatorTest {
+
+    @Test
+    public void testStreamMetricFilter() {
+        assertTrue("Filter should match stream incomingMessages", ThroughputCalculator.streamMetricFilter.matches("org.graylog2.plugin.streams.Stream.579657c468e16405f90345b0.incomingMessages", null));
+    }
+}


### PR DESCRIPTION
## Description
Noticed a static regex getting compiled 60 times per second on my system. Modified implementation so that it gets compiled only once. Also moved the anonymous class outside run() so that further tests are easier to implement.

## Motivation and Context

This tiny change frees whopping ~1 millisecond of CPU time every second for actual message processing duties.

## How Has This Been Tested?
Added a unit test for positive test case. 

## Screenshots (if appropriate):
![hello-sir](https://cloud.githubusercontent.com/assets/7376695/17491023/6eb1567c-5dae-11e6-9eb5-3dc02c69addf.jpg)

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

