### PR TITLE
The retention strategy defaults to "Do nothing" unless an other strategy was explicitly configured

### DIFF
--- a/UPGRADING.rst
+++ b/UPGRADING.rst
@@ -101,6 +101,7 @@ The retention and rotation configuration settings can be retrieved using the fol
 * ``/system/indices/rotation/config``
 * ``/system/indices/retention/config``
 
+The retention strategy defaults to "Do nothing" unless an other strategy was explicitly configured. Please check the setting after upgrading.
 
 For Plugin Authors
 ------------------

--- a/graylog2-server/src/main/java/org/graylog2/configuration/ElasticsearchConfiguration.java
+++ b/graylog2-server/src/main/java/org/graylog2/configuration/ElasticsearchConfiguration.java
@@ -122,7 +122,7 @@ public class ElasticsearchConfiguration {
 
     @Deprecated // Should be removed in Graylog 3.0
     @Parameter(value = "retention_strategy", required = true)
-    private String retentionStrategy = "delete";
+    private String retentionStrategy = "noop";
 
     @Deprecated // Should be removed in Graylog 3.0
     @Parameter(value = "rotation_strategy")

--- a/graylog2-server/src/test/java/org/graylog2/indexer/retention/strategies/NoopRetentionStrategyConfigTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/indexer/retention/strategies/NoopRetentionStrategyConfigTest.java
@@ -1,0 +1,60 @@
+/**
+ * This file is part of Graylog.
+ *
+ * Graylog is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.graylog2.indexer.retention.strategies;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.jayway.jsonpath.Configuration;
+import com.jayway.jsonpath.JsonPath;
+import org.graylog2.plugin.indexer.retention.RetentionStrategyConfig;
+import org.graylog2.shared.bindings.providers.ObjectMapperProvider;
+import org.junit.Test;
+
+import java.io.IOException;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class NoopRetentionStrategyConfigTest {
+    @Test
+    public void testCreate() throws Exception {
+        final NoopRetentionStrategyConfig config = NoopRetentionStrategyConfig.create(12);
+
+        assertThat(config.maxNumberOfIndices()).isEqualTo(12);
+    }
+
+    @Test
+    public void testSerialization() throws JsonProcessingException {
+        final NoopRetentionStrategyConfig config = NoopRetentionStrategyConfig.create(20);
+        final ObjectMapper objectMapper = new ObjectMapperProvider().get();
+        final String json = objectMapper.writeValueAsString(config);
+
+        final Object document = Configuration.defaultConfiguration().jsonProvider().parse(json);
+        assertThat((String) JsonPath.read(document, "$.type")).isEqualTo("org.graylog2.indexer.retention.strategies.NoopRetentionStrategyConfig");
+        assertThat((Integer) JsonPath.read(document, "$.max_number_of_indices")).isEqualTo(20);
+    }
+
+    @Test
+    public void testDeserialization() throws IOException {
+        final ObjectMapper objectMapper = new ObjectMapperProvider().get();
+        final String json = "{ \"type\": \"org.graylog2.indexer.retention.strategies.NoopRetentionStrategyConfig\", \"max_number_of_indices\": 25}";
+        final RetentionStrategyConfig config = objectMapper.readValue(json, RetentionStrategyConfig.class);
+
+        assertThat(config).isInstanceOf(NoopRetentionStrategyConfig.class);
+        assertThat(((NoopRetentionStrategyConfig) config).maxNumberOfIndices()).isEqualTo(25);
+    }
+}

--- a/graylog2-web-interface/src/components/indices/retention/index.js
+++ b/graylog2-web-interface/src/components/indices/retention/index.js
@@ -9,10 +9,10 @@ import NoopRetentionStrategySummary from './NoopRetentionStrategySummary';
 PluginStore.register(new PluginManifest({}, {
   indexRetentionConfig: [
     {
-      type: 'org.graylog2.indexer.retention.strategies.DeletionRetentionStrategy',
-      displayName: 'Delete Index',
-      configComponent: DeletionRetentionStrategyConfiguration,
-      summaryComponent: DeletionRetentionStrategySummary,
+      type: 'org.graylog2.indexer.retention.strategies.NoopRetentionStrategy',
+      displayName: 'Do nothing',
+      configComponent: NoopRetentionStrategyConfiguration,
+      summaryComponent: NoopRetentionStrategySummary,
     },
     {
       type: 'org.graylog2.indexer.retention.strategies.ClosingRetentionStrategy',
@@ -21,10 +21,10 @@ PluginStore.register(new PluginManifest({}, {
       summaryComponent: ClosingRetentionStrategySummary,
     },
     {
-      type: 'org.graylog2.indexer.retention.strategies.NoopRetentionStrategy',
-      displayName: 'Do nothing',
-      configComponent: NoopRetentionStrategyConfiguration,
-      summaryComponent: NoopRetentionStrategySummary,
+      type: 'org.graylog2.indexer.retention.strategies.DeletionRetentionStrategy',
+      displayName: 'Delete Index',
+      configComponent: DeletionRetentionStrategyConfiguration,
+      summaryComponent: DeletionRetentionStrategySummary,
     },
   ],
 }));


### PR DESCRIPTION
## Description

Index retention strategy has defaulted to "delete". That is not fail-safe default value, because with a certain type of issue with the configuration database, or a bug, might lead to the default value being used. That could lead to unwanted index deletion, and data loss.

This PR changes "noop" to be the new default unless if something else has been explicitly defined. Also reordered the selection list in the UI from least destructive to most destructive option so that it takes more conscious effort to select "delete" (it's not the first / default if nothing is set). 

## Motivation and Context

Fail-safe defaults should be used for potentially destructive configuration options. 

## How Has This Been Tested?

Added basic unit test for NoopRetentionStrategy. 

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

People upgrading from 1.x to 2.x should probably check the setting after upgrading. There might be some edge case that would change the expected value for some setup? That's the primary potential breakage, added a note about that to `UPGRADING.rst`.

## Checklist:
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
