### PR TITLE
Update dev config.js to new default

### DIFF
--- a/graylog2-web-interface/config.js
+++ b/graylog2-web-interface/config.js
@@ -1,5 +1,5 @@
 window.appConfig = {
-  gl2ServerUrl: 'http://localhost:12900',
+  gl2ServerUrl: 'http://localhost:9000/api',
   gl2AppPathPrefix: '',
   rootTimeZone: 'Europe/Berlin',
 };

--- a/graylog2-web-interface/src/components/navigation/Navigation.jsx
+++ b/graylog2-web-interface/src/components/navigation/Navigation.jsx
@@ -8,6 +8,7 @@ import naturalSort from 'javascript-natural-sort';
 import PermissionsMixin from 'util/PermissionsMixin';
 import Routes from 'routing/Routes';
 import URLUtils from 'util/URLUtils';
+import AppConfig from 'util/AppConfig';
 
 import StoreProvider from 'injection/StoreProvider';
 const NotificationsStore = StoreProvider.getStore('Notifications');
@@ -236,7 +237,7 @@ const Navigation = React.createClass({
             </li>
             <HelpMenu active={this._isActive(Routes.GETTING_STARTED)}/>
             <UserMenu fullName={this.props.fullName} loginName={this.props.loginName}/>
-            {typeof(DEVELOPMENT) !== 'undefined' && DEVELOPMENT ?
+            {AppConfig.gl2DevMode() ?
               <NavItem className="notification-badge-link">
               <span className="badge" style={{backgroundColor: '#ff3b00'}}>DEV</span>
               </NavItem>

--- a/graylog2-web-interface/src/util/AppConfig.js
+++ b/graylog2-web-interface/src/util/AppConfig.js
@@ -7,6 +7,12 @@ const AppConfig = {
     return window.appConfig.gl2AppPathPrefix;
   },
 
+  gl2DevMode() {
+    // The DEVELOPMENT variable will be set by webpack via the DefinePlugin.
+    // eslint-disable-next-line no-undef
+    return typeof(DEVELOPMENT) !== 'undefined' && DEVELOPMENT;
+  },
+
   rootTimeZone() {
     return window.appConfig.rootTimeZone;
   },

--- a/graylog2-web-interface/src/webpack-entry.js
+++ b/graylog2-web-interface/src/webpack-entry.js
@@ -1,5 +1,9 @@
 import URI from 'urijs';
 import AppConfig from 'util/AppConfig';
 
+// The webpack-dev-server serves the assets from "/"
+const assetPrefix = AppConfig.gl2DevMode() ? '/' : '/assets/';
+
 // If app prefix was not set, we need to tell webpack to load chunks from root instead of the relative URL path
-__webpack_public_path__ = URI.joinPaths(AppConfig.gl2AppPathPrefix(), '/assets/').path() || '/assets/';
+// eslint-disable-next-line camelcase, no-undef
+__webpack_public_path__ = URI.joinPaths(AppConfig.gl2AppPathPrefix(), assetPrefix).path() || assetPrefix;


### PR DESCRIPTION
Update dev config.js to new default

## Description
Merging #2634 changes the REST API default path

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

since merging #2634 the default config.js isn't working with npm start anymore