### PR TITLE
Decorator improvements

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/decorators/DecoratorProcessorImpl.java
+++ b/graylog2-server/src/main/java/org/graylog2/decorators/DecoratorProcessorImpl.java
@@ -98,9 +98,11 @@ public class DecoratorProcessorImpl implements DecoratorProcessor {
 
         decoratedMessages.forEach(message -> {
             final DecorationStats decorationStats = message.decorationStats();
-            addedFields.addAll(decorationStats.addedFields().keySet());
-            changedFields.addAll(decorationStats.changedFields().keySet());
-            removedFields.addAll(decorationStats.removedFields().keySet());
+            if (decoratedMessages != null) {
+                addedFields.addAll(decorationStats.addedFields().keySet());
+                changedFields.addAll(decorationStats.changedFields().keySet());
+                removedFields.addAll(decorationStats.removedFields().keySet());
+            }
         });
 
         return SearchDecorationStats.create(addedFields, changedFields, removedFields);

--- a/graylog2-server/src/main/java/org/graylog2/rest/resources/search/responses/SearchDecorationStats.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/resources/search/responses/SearchDecorationStats.java
@@ -27,13 +27,25 @@ import java.util.Set;
 @JsonAutoDetect
 public abstract class SearchDecorationStats {
     private static final String FIELD_ADDED_FIELDS = "added_fields";
+    private static final String FIELD_CHANGED_FIELDS = "changed_fields";
+    private static final String FIELD_REMOVED_FIELDS = "removed_fields";
 
     @SuppressWarnings("unused")
     @JsonProperty(FIELD_ADDED_FIELDS)
     public abstract Set<String> addedFields();
 
+    @SuppressWarnings("unused")
+    @JsonProperty(FIELD_CHANGED_FIELDS)
+    public abstract Set<String> changedFields();
+
+    @SuppressWarnings("unused")
+    @JsonProperty(FIELD_REMOVED_FIELDS)
+    public abstract Set<String> removedFields();
+
     @JsonCreator
-    public static SearchDecorationStats create(@JsonProperty(FIELD_ADDED_FIELDS) Set<String> addedFields) {
-        return new AutoValue_SearchDecorationStats(addedFields);
+    public static SearchDecorationStats create(@JsonProperty(FIELD_ADDED_FIELDS) Set<String> addedFields,
+                                               @JsonProperty(FIELD_CHANGED_FIELDS) Set<String> changedFields,
+                                               @JsonProperty(FIELD_REMOVED_FIELDS) Set<String> removedFields) {
+        return new AutoValue_SearchDecorationStats(addedFields, changedFields, removedFields);
     }
 }

--- a/graylog2-web-interface/public/stylesheets/graylog2.less
+++ b/graylog2-web-interface/public/stylesheets/graylog2.less
@@ -2316,7 +2316,7 @@ dl.message-details dd {
   margin-left: 1px; /* Ensures that italic text is not cut */
 }
 
-dl.message-details-fields dd:not(:last-child) {
+dl.message-details-fields span:not(:last-child) dd {
   border-bottom: 1px solid #ececec;
 }
 

--- a/graylog2-web-interface/src/components/common/SortableList.jsx
+++ b/graylog2-web-interface/src/components/common/SortableList.jsx
@@ -31,7 +31,7 @@ const SortableList = React.createClass({
   render() {
     const formattedItems = this.state.items.map((item, idx) => {
       return (
-        <SortableListItem key={`sortable-list-item-${item.id}`} index={idx} id={item.id} text={item.title}
+        <SortableListItem key={`sortable-list-item-${item.id}`} index={idx} id={item.id} content={item.title}
                           moveItem={this._moveItem}/>
       );
     });

--- a/graylog2-web-interface/src/components/common/SortableListItem.css
+++ b/graylog2-web-interface/src/components/common/SortableListItem.css
@@ -1,11 +1,9 @@
-:local(.fullWidth) {
+:local(.listGroupItem) {
+    display: inline-block;
     width: 100%;
 }
 
-:local(.inlineFlex) {
-    display: inline-flex;
-}
-
 :local(.itemHandle) {
+    float: left;
     margin-right: 10px;
 }

--- a/graylog2-web-interface/src/components/common/SortableListItem.jsx
+++ b/graylog2-web-interface/src/components/common/SortableListItem.jsx
@@ -87,11 +87,11 @@ const SortableListItem = React.createClass({
     isDragging: PropTypes.bool.isRequired,
     isOver: PropTypes.bool.isRequired,
     id: PropTypes.any.isRequired,
-    text: PropTypes.string.isRequired,
+    content: PropTypes.any.isRequired,
     moveItem: PropTypes.func.isRequired,
   },
   render() {
-    const { text, isDragging, isOver, connectDragSource, connectDropTarget } = this.props;
+    const { content, isDragging, isOver, connectDragSource, connectDropTarget } = this.props;
     const classes = [SortableListItemStyle.listGroupItem];
     if (isDragging) {
       classes.push('dragging');
@@ -105,7 +105,7 @@ const SortableListItem = React.createClass({
         <ListGroupItem className={classes.join(' ')}>
           <div>
             <span className={SortableListItemStyle.itemHandle}><i className="fa fa-sort" /></span>
-            {text}
+            {content}
           </div>
         </ListGroupItem>
       </div>

--- a/graylog2-web-interface/src/components/common/SortableListItem.jsx
+++ b/graylog2-web-interface/src/components/common/SortableListItem.jsx
@@ -92,7 +92,7 @@ const SortableListItem = React.createClass({
   },
   render() {
     const { text, isDragging, isOver, connectDragSource, connectDropTarget } = this.props;
-    const classes = [SortableListItemStyle.inlineFlex, SortableListItemStyle.fullWidth];
+    const classes = [SortableListItemStyle.listGroupItem];
     if (isDragging) {
       classes.push('dragging');
     }
@@ -103,7 +103,10 @@ const SortableListItem = React.createClass({
     return connectDragSource(connectDropTarget(
       <div className="sortable-list-item">
         <ListGroupItem className={classes.join(' ')}>
-          <div><i className={`fa fa-sort ${SortableListItemStyle.itemHandle}`}/> {text}</div>
+          <div>
+            <span className={SortableListItemStyle.itemHandle}><i className="fa fa-sort" /></span>
+            {text}
+          </div>
         </ListGroupItem>
       </div>
     ));

--- a/graylog2-web-interface/src/components/configurationforms/DropdownField.jsx
+++ b/graylog2-web-interface/src/components/configurationforms/DropdownField.jsx
@@ -55,7 +55,7 @@ const DropdownField = React.createClass({
 
         <select id={field.title} value={this.state.value}
                 className="input-xlarge form-control" onChange={this.handleChange}
-                autoFocus={this.props.autoFocus} disabled={this.props.disabled}>
+                autoFocus={this.props.autoFocus} disabled={this.props.disabled} required={!field.is_optional}>
           {options}
         </select>
         <p className="help-block">{field.description}</p>

--- a/graylog2-web-interface/src/components/search/AddDecoratorButton.jsx
+++ b/graylog2-web-interface/src/components/search/AddDecoratorButton.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import Reflux from 'reflux';
 import jQuery from 'jquery';
 import PureRenderMixin from 'react-addons-pure-render-mixin';
+import { Button, Col, Input, Row } from 'react-bootstrap';
 
 import { ConfigurationForm } from 'components/configurationforms';
 import { Select, Spinner } from 'components/common';
@@ -66,21 +67,16 @@ const AddDecoratorButton = React.createClass({
                          typeName={this.state.typeName} includeTitleField={false}
                          submitAction={this._handleSubmit} cancelAction={this._handleCancel} /> : null);
     return (
-      <div className={`form-inline ${DecoratorStyles.addDecoratorButtonContainer}`}>
-        <div className={`form-group ${DecoratorStyles.decoratorBox} ${DecoratorStyles.fullWidth}`}>
-          <div className={`form-group ${DecoratorStyles.addDecoratorSelect}`}>
-            <Select ref="select"
-                    placeholder="Select decorator"
-                    onValueChange={this._onTypeChange}
-                    options={decoratorTypes}
-                    matchProp="label"
-                    value={this.state.typeName} />
-          </div>
-          {' '}
-          <button className="btn btn-success form-control" disabled={!this.state.typeName}
-                  onClick={this._openModal}>Add</button>
-
+      <div className={`${DecoratorStyles.decoratorBox} ${DecoratorStyles.addDecoratorButtonContainer}`}>
+        <div className={DecoratorStyles.addDecoratorSelect}>
+          <Select ref="select"
+                  placeholder="Select decorator"
+                  onValueChange={this._onTypeChange}
+                  options={decoratorTypes}
+                  matchProp="label"
+                  value={this.state.typeName} />
         </div>
+        <Button bsStyle="success" disabled={!this.state.typeName} onClick={this._openModal}>Apply</Button>
         {this.state.typeName && configurationForm}
       </div>
     );

--- a/graylog2-web-interface/src/components/search/AddDecoratorButton.jsx
+++ b/graylog2-web-interface/src/components/search/AddDecoratorButton.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import Reflux from 'reflux';
 import jQuery from 'jquery';
 import PureRenderMixin from 'react-addons-pure-render-mixin';
-import { Button, Col, Input, Row } from 'react-bootstrap';
+import { Button } from 'react-bootstrap';
 
 import { ConfigurationForm } from 'components/configurationforms';
 import { Select, Spinner } from 'components/common';

--- a/graylog2-web-interface/src/components/search/DecoratedMessageFieldMarker.jsx
+++ b/graylog2-web-interface/src/components/search/DecoratedMessageFieldMarker.jsx
@@ -1,11 +1,18 @@
 import React from 'react';
 
+import DecoratorStyles from '!style!css!components/search/decoratorStyles.css';
+
 const DecoratedMessageFieldMarker = React.createClass({
   propTypes: {
-    title: React.PropTypes.string,
+    className: React.PropTypes.string,
   },
   render() {
-    return <i className="fa fa-pencil" title={this.props.title} />;
+    const classNames = [DecoratorStyles.decoratorMarker];
+    if (this.props.className) {
+      classNames.push(this.props.className);
+    }
+
+    return <small className={classNames.join(' ')}>(decorated)</small>;
   },
 });
 

--- a/graylog2-web-interface/src/components/search/DecoratedSidebarMessageField.jsx
+++ b/graylog2-web-interface/src/components/search/DecoratedSidebarMessageField.jsx
@@ -1,6 +1,10 @@
 import React from 'react';
 import { Input } from 'react-bootstrap';
 
+import { DecoratedMessageFieldMarker } from 'components/search';
+
+import DecoratorStyles from '!style!css!components/search/decoratorStyles.css';
+
 const DecoratedSidebarMessageField = React.createClass({
   propTypes: {
     field: React.PropTypes.object,
@@ -10,9 +14,6 @@ const DecoratedSidebarMessageField = React.createClass({
   render() {
     const label = (<span>
       {this.props.field.name}
-      {' '}
-      <i className="fa fa-pencil"
-         title="This field was added to the search result by a decorator and is not stored in any index. Therefore you cannot analyze it." />
     </span>);
     return (
       <li>
@@ -21,8 +22,10 @@ const DecoratedSidebarMessageField = React.createClass({
         <div className="field-selector">
           <Input type="checkbox"
                  label={label}
+                 groupClassName={DecoratorStyles.decoratorFieldWrapper}
                  checked={this.props.selected}
                  onChange={() => this.props.onToggled(this.props.field.name)}/>
+          <DecoratedMessageFieldMarker className={DecoratorStyles.decoratorMarkerSidebar}/>
         </div>
       </li>
     );

--- a/graylog2-web-interface/src/components/search/Decorator.jsx
+++ b/graylog2-web-interface/src/components/search/Decorator.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import Reflux from 'reflux';
 
-import { Button } from 'react-bootstrap';
+import { DropdownButton, MenuItem } from 'react-bootstrap';
 
 import { Spinner } from 'components/common';
 import { ConfigurationForm, ConfigurationWell } from 'components/configurationforms';
@@ -49,12 +49,12 @@ const Decorator = React.createClass({
     return (
       <span className={DecoratorStyles.fullWidth}>
         <div className={DecoratorStyles.decoratorBox}>
-          <strong>{decoratorType.name}</strong>
-          <span>
-            <Button bsStyle="primary" bsSize="xsmall" onClick={this._handleDeleteClick}>Delete</Button>
-            {' '}
-            <Button bsStyle="info" bsSize="xsmall" onClick={this._handleEditClick}>Edit</Button>
-          </span>
+          <h6 className={DecoratorStyles.decoratorType}>{decoratorType.name}</h6>
+          <DropdownButton id={`decorator-${decorator._id}-actions`} bsStyle="default" bsSize="xsmall" title="Actions" pullRight>
+            <MenuItem onSelect={this._handleEditClick}>Edit</MenuItem>
+            <MenuItem divider/>
+            <MenuItem onSelect={this._handleDeleteClick}>Delete</MenuItem>
+          </DropdownButton>
         </div>
         <ConfigurationWell key={`configuration-well-decorator-${decorator._id}`}
                            id={decorator._id}

--- a/graylog2-web-interface/src/components/search/Decorator.jsx
+++ b/graylog2-web-interface/src/components/search/Decorator.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import Reflux from 'reflux';
 
-import { Button, Col, Row } from 'react-bootstrap';
+import { Button } from 'react-bootstrap';
 
 import { Spinner } from 'components/common';
 import { ConfigurationForm, ConfigurationWell } from 'components/configurationforms';
@@ -48,14 +48,14 @@ const Decorator = React.createClass({
     const decoratorType = this.state.types[decorator.type] || this._decoratorTypeNotPresent();
     return (
       <span className={DecoratorStyles.fullWidth}>
-        <span className={DecoratorStyles.decoratorBox}>
+        <div className={DecoratorStyles.decoratorBox}>
           <strong>{decoratorType.name}</strong>
           <span>
             <Button bsStyle="primary" bsSize="xsmall" onClick={this._handleDeleteClick}>Delete</Button>
             {' '}
             <Button bsStyle="info" bsSize="xsmall" onClick={this._handleEditClick}>Edit</Button>
           </span>
-        </span>
+        </div>
         <ConfigurationWell key={`configuration-well-decorator-${decorator._id}`}
                            id={decorator._id}
                            configuration={decorator.config}

--- a/graylog2-web-interface/src/components/search/DecoratorSidebar.jsx
+++ b/graylog2-web-interface/src/components/search/DecoratorSidebar.jsx
@@ -1,16 +1,18 @@
 import React from 'react';
 import Reflux from 'reflux';
-import { Well } from 'react-bootstrap';
+import { Button, OverlayTrigger, Popover } from 'react-bootstrap';
 
-import { Spinner } from 'components/common';
+import { SortableList, Spinner } from 'components/common';
 import { AddDecoratorButton, Decorator } from 'components/search';
-import { SortableList } from 'components/common';
+import DocsHelper from 'util/DocsHelper';
 
 import StoreProvider from 'injection/StoreProvider';
 const DecoratorsStore = StoreProvider.getStore('Decorators');
 
 import ActionsProvider from 'injection/ActionsProvider';
 const DecoratorsActions = ActionsProvider.getActions('Decorators');
+
+import DecoratorStyles from '!style!css!components/search/decoratorStyles.css';
 
 const DecoratorSidebar = React.createClass({
   propTypes: {
@@ -24,7 +26,7 @@ const DecoratorSidebar = React.createClass({
                                                    typeDefinition={typeDefinition} /> });
   },
   _updateOrder(decorators) {
-    decorators.map((item, idx) => {
+    decorators.forEach((item, idx) => {
       const decorator = this.state.decorators.find((i) => i._id === item.id);
       decorator.order = idx;
       DecoratorsActions.update(decorator._id, decorator);
@@ -39,22 +41,28 @@ const DecoratorSidebar = React.createClass({
       .sort((d1, d2) => d1.order - d2.order);
     const nextDecoratorOrder = decorators.length > 0 ? decorators[decorators.length - 1].order + 1 : 0;
     const decoratorItems = decorators.map(this._formatDecorator);
+    const popoverHelp = (
+      <Popover id="decorators-help" className={DecoratorStyles.helpPopover}>
+        <p className="description">
+          Decorators can modify messages shown in the search results on the fly. These changes are not stored, but only
+          shown in the search results. Decorator config is stored <strong>per stream</strong>.
+        </p>
+        <p className="description">
+          Use drag and drop to modify the order in which decorators are processed.
+        </p>
+        <p>
+          Read more about message decorators in the <a href={DocsHelper.toString('decorators.html')}>documentation</a>.
+        </p>
+      </Popover>
+    );
     return (
-      <span>
+      <div>
+        <OverlayTrigger trigger="click" rootClose placement="right" overlay={popoverHelp}>
+          <Button bsStyle="link" className={DecoratorStyles.helpLink}>What are message decorators? <i className="fa fa-question-circle" /></Button>
+        </OverlayTrigger>
         <AddDecoratorButton stream={this.props.stream} nextOrder={nextDecoratorOrder}/>
         <SortableList items={decoratorItems} onMoveItem={this._updateOrder} />
-
-        <Well style={{ marginTop: '10px' }}>
-          <p className="description">
-            Decorators can modify messages shown in the search results on the fly. These changes are not stored, but only
-            shown in the search results. Decorator config is stored <strong>per stream</strong>.
-          </p>
-          <p className="description">
-            Decorators are processed in order, from top to bottom. If you want to change the order in which decorators are
-            processed, you can reorder them using drag and drop.
-          </p>
-        </Well>
-      </span>
+      </div>
     );
   },
 });

--- a/graylog2-web-interface/src/components/search/MessageDetail.jsx
+++ b/graylog2-web-interface/src/components/search/MessageDetail.jsx
@@ -133,9 +133,14 @@ const MessageDetail = React.createClass({
       );
     }
 
+    let showOriginal = null;
+    if (this.props.message.decoration_stats) {
+      showOriginal = <Button onClick={this._toggleShowOriginal} active={this.state.showOriginal}>Show Original</Button>;
+    }
+
     return (
       <ButtonGroup className="pull-right" bsSize="small">
-        <Button onClick={this._toggleShowOriginal} active={this.state.showOriginal}>Show Original</Button>
+        {showOriginal}
         <Button href={messageUrl}>Permalink</Button>
 
         <ClipboardButton title="Copy ID" text={this.props.message.id} />

--- a/graylog2-web-interface/src/components/search/MessageField.jsx
+++ b/graylog2-web-interface/src/components/search/MessageField.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import { DecoratedMessageFieldMarker, MessageFieldDescription } from 'components/search';
+import { MessageFieldDescription } from 'components/search';
 
 const MessageField = React.createClass({
   propTypes: {
@@ -12,17 +12,6 @@ const MessageField = React.createClass({
     value: React.PropTypes.any.isRequired,
   },
   SPECIAL_FIELDS: ['full_message', 'level'],
-  _decorationMarker(key) {
-    if (this._isAdded(key)) {
-      return <DecoratedMessageFieldMarker title="This field was added by a decorator. It was not present in the original message, so you cannot search for it." />;
-    }
-
-    if (this._isChanged(key)) {
-      return (<DecoratedMessageFieldMarker title="This field was modified by a decorator for the search result.." />);
-    }
-
-    return null;
-  },
   _isAdded(key) {
     const decorationStats = this.props.message.decoration_stats;
     return decorationStats && decorationStats.added_fields && decorationStats.added_fields[key] !== undefined;
@@ -30,6 +19,9 @@ const MessageField = React.createClass({
   _isChanged(key) {
     const decorationStats = this.props.message.decoration_stats;
     return decorationStats && decorationStats.changed_fields && decorationStats.changed_fields[key] !== undefined;
+  },
+  _isDecorated(key) {
+    return this._isAdded(key) || this._isChanged(key);
   },
   render() {
     let innerValue = this.props.value;
@@ -40,14 +32,15 @@ const MessageField = React.createClass({
 
     return (
       <span>
-        <dt key={`${key}Title`}>{key} {this._decorationMarker(key)}</dt>
+        <dt key={`${key}Title`}>{key}</dt>
         <MessageFieldDescription key={`${key}Description`}
                                  message={this.props.message}
                                  fieldName={key}
                                  fieldValue={innerValue}
                                  possiblyHighlight={this.props.possiblyHighlight}
                                  disableFieldActions={this._isAdded(key) || this.props.disableFieldActions}
-                                 customFieldActions={this.props.customFieldActions}/>
+                                 customFieldActions={this.props.customFieldActions}
+                                 isDecorated={this._isDecorated(key)} />
       </span>
     );
   },

--- a/graylog2-web-interface/src/components/search/MessageFieldDescription.jsx
+++ b/graylog2-web-interface/src/components/search/MessageFieldDescription.jsx
@@ -50,25 +50,31 @@ const MessageFieldDescription = React.createClass({
 
     return termsMarkup;
   },
+  _getFormattedFieldActions() {
+    if (this.props.disableFieldActions) {
+      return null;
+    }
+
+    let fieldActions;
+    if (this.props.customFieldActions) {
+      fieldActions = React.cloneElement(this.props.customFieldActions, {fieldName: this.props.fieldName, message: this.props.message});
+    } else {
+      fieldActions = (
+        <MessageFieldSearchActions fieldName={this.props.fieldName}
+                                   message={this.props.message}
+                                   onAddFieldToSearchBar={this.addFieldToSearchBar}
+                                   onLoadTerms={this.loadTerms}/>
+      );
+    }
+
+    return fieldActions;
+  },
   render() {
     const className = this.props.fieldName === 'message' || this.props.fieldName === 'full_message' ? 'message-field' : '';
-    let fieldActions;
-    if (!this.props.disableFieldActions) {
-      if (this.props.customFieldActions) {
-        fieldActions = React.cloneElement(this.props.customFieldActions, {fieldName: this.props.fieldName, message: this.props.message});
-      } else {
-        fieldActions = (
-          <MessageFieldSearchActions fieldName={this.props.fieldName}
-                                     message={this.props.message}
-                                     onAddFieldToSearchBar={this.addFieldToSearchBar}
-                                     onLoadTerms={this.loadTerms}/>
-        );
-      }
-    }
 
     return (
       <dd className={className} key={this.props.fieldName + 'dd'}>
-        {fieldActions}
+        {this._getFormattedFieldActions()}
         <div className="field-value">{this.props.possiblyHighlight(this.props.fieldName)}</div>
         {this._shouldShowTerms() &&
         <Alert bsStyle="info" onDismiss={() => this.setState({messageTerms: Immutable.Map()})}>

--- a/graylog2-web-interface/src/components/search/MessageFieldDescription.jsx
+++ b/graylog2-web-interface/src/components/search/MessageFieldDescription.jsx
@@ -12,6 +12,8 @@ const MessagesActions = ActionsProvider.getActions('Messages');
 
 import MessageFieldSearchActions from './MessageFieldSearchActions';
 
+import { DecoratedMessageFieldMarker } from 'components/search';
+
 const MessageFieldDescription = React.createClass({
   propTypes: {
     message: PropTypes.object.isRequired,
@@ -20,6 +22,7 @@ const MessageFieldDescription = React.createClass({
     possiblyHighlight: PropTypes.func.isRequired,
     disableFieldActions: PropTypes.bool,
     customFieldActions: PropTypes.node,
+    isDecorated: PropTypes.bool,
   },
   getInitialState() {
     return {
@@ -77,10 +80,11 @@ const MessageFieldDescription = React.createClass({
         {this._getFormattedFieldActions()}
         <div className="field-value">{this.props.possiblyHighlight(this.props.fieldName)}</div>
         {this._shouldShowTerms() &&
-        <Alert bsStyle="info" onDismiss={() => this.setState({messageTerms: Immutable.Map()})}>
+        <Alert bsStyle="info" onDismiss={() => this.setState({ messageTerms: Immutable.Map() })}>
           Field terms: &nbsp;{this._getFormattedTerms()}
         </Alert>
-          }
+        }
+        {this.props.isDecorated && <DecoratedMessageFieldMarker />}
       </dd>
     );
   },

--- a/graylog2-web-interface/src/components/search/MessageFields.jsx
+++ b/graylog2-web-interface/src/components/search/MessageFields.jsx
@@ -18,11 +18,19 @@ const MessageFields = React.createClass({
   },
 
   _formatFields(fields, showDecoration) {
-    if (!showDecoration || !this.props.message.decoration_stats) {
-      return Object.keys(fields).sort().map(key => <MessageField key={key} {...this.props} fieldName={key} value={fields[key]} />);
-    }
-
     const decorationStats = this.props.message.decoration_stats;
+
+    if (!showDecoration || !decorationStats) {
+      const decoratedFields = decorationStats ? Object.keys(decorationStats.changed_fields) : [];
+      return Object.keys(fields)
+        .sort()
+        .map(key => {
+          return (
+            <MessageField key={key} {...this.props} fieldName={key} value={fields[key]}
+                               disableFieldActions={decoratedFields.indexOf(key) !== -1} />
+          );
+        });
+    }
 
     const allKeys = Object.keys(decorationStats.removed_fields).concat(Object.keys(fields)).sort();
 

--- a/graylog2-web-interface/src/components/search/SearchSidebar.jsx
+++ b/graylog2-web-interface/src/components/search/SearchSidebar.jsx
@@ -174,14 +174,13 @@ const SearchSidebar = React.createClass({
       </BootstrapModalWrapper>
     );
 
-    const addedFields = this.props.result.decoration_stats && this.props.result.decoration_stats.added_fields ?
-      this.props.result.decoration_stats.added_fields : [];
+    const decorationStats = this.props.result.decoration_stats;
+    const decoratedFields = decorationStats ? [].concat(decorationStats.added_fields || [], decorationStats.changed_fields || []) : [];
     const messageFields = this.props.fields
       .filter((field) => field.name.indexOf(this.state.fieldFilter) !== -1)
       .sort((a, b) => a.name.localeCompare(b.name))
       .map((field) => {
-
-        return (addedFields.includes(field.name) ?
+        return (decoratedFields.includes(field.name) ?
             <DecoratedSidebarMessageField key={field.name}
                                           field={field}
                                           onToggled={this.props.onFieldToggled}

--- a/graylog2-web-interface/src/components/search/decoratorStyles.css
+++ b/graylog2-web-interface/src/components/search/decoratorStyles.css
@@ -7,6 +7,10 @@
     justify-content: space-between;
 }
 
+:local(.decoratorType) {
+    line-height: 1.5;
+}
+
 :local(.addDecoratorButtonContainer) {
     margin-bottom: 10px;
 }

--- a/graylog2-web-interface/src/components/search/decoratorStyles.css
+++ b/graylog2-web-interface/src/components/search/decoratorStyles.css
@@ -29,3 +29,18 @@
 :local(.helpPopover) {
     font-size: 12px;
 }
+
+:local(.decoratorMarker) {
+    color: #AAA;
+    font-weight: normal;
+}
+
+:local(.decoratorFieldWrapper) {
+    display: inline-block;
+}
+
+:local(.decoratorMarkerSidebar) {
+    margin-left: 5px;
+    top: 3px;
+    position: relative;
+}

--- a/graylog2-web-interface/src/components/search/decoratorStyles.css
+++ b/graylog2-web-interface/src/components/search/decoratorStyles.css
@@ -8,12 +8,12 @@
 }
 
 :local(.addDecoratorButtonContainer) {
-    margin: 4px;
-    display: flex;
+    margin-bottom: 10px;
 }
 
 :local(.addDecoratorSelect) {
-    width: 80%;
+    margin-right: 5px;
+    width: 100%;
 }
 
 :local(.helpLink) {

--- a/graylog2-web-interface/src/components/search/decoratorStyles.css
+++ b/graylog2-web-interface/src/components/search/decoratorStyles.css
@@ -15,3 +15,13 @@
 :local(.addDecoratorSelect) {
     width: 80%;
 }
+
+:local(.helpLink) {
+    font-size: 12px;
+    padding-left: 0;
+    padding-right: 0;
+}
+
+:local(.helpPopover) {
+    font-size: 12px;
+}

--- a/graylog2-web-interface/src/routing/AppRouter.jsx
+++ b/graylog2-web-interface/src/routing/AppRouter.jsx
@@ -6,7 +6,6 @@ import App from 'routing/App';
 import AppWithSearchBar from 'routing/AppWithSearchBar';
 import AppWithoutSearchBar from 'routing/AppWithoutSearchBar';
 import history from 'util/History';
-import AppConfig from 'util/AppConfig';
 import URLUtils from 'util/URLUtils';
 
 import Routes from 'routing/Routes';


### PR DESCRIPTION
This PR adds some improvements to decorators. I still have some open items in my list, but I think splitting them up will make the review process less annoying.

These are some of the changes included:
- Improve overall appearance, hiding some elements in the decorator sidebar to gain some space, changing other UI elements to make them more obvious to users, and doing some _margins and paddings_ work
- Enforce user to select a pipeline to create a decorator from a pipeline
- Only show "show original" button when message is decorated
- Search response includes a list of all fields added, modified or removed
- Hide field analysers and field value actions for all decorated fields, not only added field