### PR TITLE
add format string message decorator

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/decorators/DecoratorBindings.java
+++ b/graylog2-server/src/main/java/org/graylog2/decorators/DecoratorBindings.java
@@ -16,6 +16,7 @@
  */
 package org.graylog2.decorators;
 
+import com.google.inject.multibindings.MapBinder;
 import com.google.inject.multibindings.Multibinder;
 import org.graylog2.plugin.decorators.SearchResponseDecorator;
 import org.graylog2.plugin.inject.Graylog2Module;
@@ -25,8 +26,13 @@ public class DecoratorBindings extends Graylog2Module {
     protected void configure() {
         Multibinder<SearchResponseDecorator> searchResponseDecoratorMultibinder = Multibinder.newSetBinder(binder(), SearchResponseDecorator.class);
 
-        installSearchResponseDecorator(searchResponseDecoratorBinder(),
-                SyslogSeverityMapperDecorator.class,
-                SyslogSeverityMapperDecorator.Factory.class);
+        final MapBinder<String, SearchResponseDecorator.Factory> searchResponseDecoratorBinder = searchResponseDecoratorBinder();
+        installSearchResponseDecorator(searchResponseDecoratorBinder,
+                                       SyslogSeverityMapperDecorator.class,
+                                       SyslogSeverityMapperDecorator.Factory.class);
+
+        installSearchResponseDecorator(searchResponseDecoratorBinder,
+                                       FormatStringDecorator.class,
+                                       FormatStringDecorator.Factory.class);
     }
 }

--- a/graylog2-server/src/main/java/org/graylog2/decorators/FormatStringDecorator.java
+++ b/graylog2-server/src/main/java/org/graylog2/decorators/FormatStringDecorator.java
@@ -1,0 +1,130 @@
+/**
+ * This file is part of Graylog.
+ *
+ * Graylog is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.graylog2.decorators;
+
+import com.floreysoft.jmte.Engine;
+import com.floreysoft.jmte.template.Template;
+import com.google.common.collect.ImmutableMap;
+import com.google.inject.assistedinject.Assisted;
+import org.graylog2.plugin.Message;
+import org.graylog2.plugin.configuration.ConfigurationRequest;
+import org.graylog2.plugin.configuration.fields.BooleanField;
+import org.graylog2.plugin.configuration.fields.TextField;
+import org.graylog2.plugin.decorators.SearchResponseDecorator;
+import org.graylog2.rest.models.messages.responses.ResultMessageSummary;
+import org.graylog2.rest.resources.search.responses.SearchResponse;
+
+import javax.inject.Inject;
+import java.util.List;
+import java.util.Locale;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import static java.util.Objects.requireNonNull;
+
+public class FormatStringDecorator implements SearchResponseDecorator {
+
+    private static final String CK_FORMAT_STRING = "format_string";
+    private static final String CK_REQUIRE_ALL_FIELDS = "require_all_fields";
+    private static final String CK_TARGET_FIELD = "target_field";
+
+    private final String targetField;
+    private final Template template;
+    private final boolean requireAllFields;
+    private final Set<String> usedVariables;
+
+    public interface Factory extends SearchResponseDecorator.Factory {
+        @Override
+        FormatStringDecorator create(Decorator decorator);
+
+        @Override
+        FormatStringDecorator.Config getConfig();
+
+        @Override
+        FormatStringDecorator.Descriptor getDescriptor();
+    }
+
+    public static class Config implements SearchResponseDecorator.Config {
+
+        @Override
+        public ConfigurationRequest getRequestedConfiguration() {
+            return new ConfigurationRequest() {
+                {
+                    addField(new TextField(
+                            CK_FORMAT_STRING,
+                            "Format String",
+                            "${source} - ${message}",
+                            "The format string used to create the concatenated field."
+                    ));
+                    addField(new BooleanField(
+                            CK_REQUIRE_ALL_FIELDS,
+                            "Require all fields",
+                            false,
+                            "Check this if all fields in the format string need to be present in order to apply this decorator."));
+                    addField(new TextField(
+                            CK_TARGET_FIELD,
+                            "Target field",
+                            "message",
+                            "The message field that will be created with the formatted string."
+                    ));
+                }
+            };
+        }
+    }
+
+    public static class Descriptor extends SearchResponseDecorator.Descriptor {
+        public Descriptor() {
+            super("Format String", "http://docs.graylog.org/", "Format string");
+        }
+    }
+
+    @Inject
+    public FormatStringDecorator(@Assisted Decorator decorator) {
+        final String formatString = (String) requireNonNull(decorator.config().get(CK_FORMAT_STRING),
+                                                            CK_FORMAT_STRING + " cannot be null");
+        this.targetField = (String) requireNonNull(decorator.config().get(CK_TARGET_FIELD),
+                                                   CK_TARGET_FIELD + " cannot be null");
+        requireAllFields = (boolean) requireNonNull(decorator.config().get(CK_REQUIRE_ALL_FIELDS),
+                                                    CK_REQUIRE_ALL_FIELDS + " cannot be null");
+        template = Engine.createDefaultEngine().getTemplate(formatString);
+        usedVariables = template.getUsedVariables();
+    }
+
+    @Override
+    public SearchResponse apply(SearchResponse searchResponse) {
+        final List<ResultMessageSummary> summaries = searchResponse.messages().stream()
+                .map(summary -> {
+                    if (requireAllFields) {
+                        if (!usedVariables.stream().allMatch(variable -> summary.message().containsKey(variable))) {
+                            return summary;
+                        }
+                    }
+                    final String formattedString = template.transform(summary.message(), Locale.ENGLISH);
+
+                    if (formattedString == null) {
+                        return summary;
+                    }
+
+                    final Message message = new Message(ImmutableMap.copyOf(summary.message()));
+                    message.addField(targetField, formattedString);
+                    return summary.toBuilder().message(message.getFields()).build();
+                })
+                .collect(Collectors.toList());
+
+        return searchResponse.toBuilder().messages(summaries).build();
+    }
+}

--- a/graylog2-server/src/test/java/org/graylog2/decorators/FormatStringDecoratorTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/decorators/FormatStringDecoratorTest.java
@@ -1,0 +1,107 @@
+/**
+ * This file is part of Graylog.
+ *
+ * Graylog is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.graylog2.decorators;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableMultimap;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Range;
+import org.graylog2.plugin.Tools;
+import org.graylog2.rest.models.messages.responses.ResultMessageSummary;
+import org.graylog2.rest.models.system.indexer.responses.IndexRangeSummary;
+import org.graylog2.rest.resources.search.responses.SearchResponse;
+import org.junit.Test;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.graylog2.rest.models.messages.responses.ResultMessageSummary.create;
+
+public class FormatStringDecoratorTest {
+
+    @Test
+    public void testFormat() {
+
+        final DecoratorImpl decorator = getDecoratorConfig("${field_a}: ${field_b}", "message", true);
+
+        final FormatStringDecorator formatStringDecorator = new FormatStringDecorator(decorator);
+        final SearchResponse searchResponse = getSearchResponse();
+
+        final SearchResponse response = formatStringDecorator.apply(searchResponse);
+
+        assertThat(response.messages().size()).isEqualTo(4);
+        assertThat(response.messages().get(0).message().get("message")).isEqualTo("1: b");
+        assertThat(response.messages().get(1).message().containsKey("message")).isFalse();
+        assertThat(response.messages().get(2).message().containsKey("message")).isFalse();
+        assertThat(response.messages().get(3).message().containsKey("message")).isFalse();
+    }
+
+    @Test
+    public void formatAllowEmptyValues() {
+        final DecoratorImpl decorator = getDecoratorConfig("${field_a}: ${field_b}", "message", false);
+
+        final FormatStringDecorator formatStringDecorator = new FormatStringDecorator(decorator);
+        final SearchResponse searchResponse = getSearchResponse();
+
+        final SearchResponse response = formatStringDecorator.apply(searchResponse);
+
+        assertThat(response.messages().size()).isEqualTo(4);
+        assertThat(response.messages().get(0).message().get("message")).isEqualTo("1: b");
+        assertThat(response.messages().get(1).message().get("message")).isEqualTo("1:");
+        assertThat(response.messages().get(2).message().get("message")).isEqualTo(": b");
+        assertThat(response.messages().get(3).message().get("message")).isEqualTo(":");
+    }
+
+    private SearchResponse getSearchResponse() {
+        final IndexRangeSummary indexRangeSummary = IndexRangeSummary.create("graylog_0",
+                                                                             Tools.nowUTC().minusDays(1),
+                                                                             Tools.nowUTC(),
+                                                                             null,
+                                                                             100);
+
+        final ImmutableMultimap<String, Range<Integer>> hlRanges = ImmutableMultimap.of();
+        final List<ResultMessageSummary> messages = ImmutableList.of(
+                create(hlRanges, ImmutableMap.of("_id", "h", "field_a", "1", "field_b", "b"), "graylog_0"),
+                create(hlRanges, ImmutableMap.of("_id", "h", "field_a", "1"), "graylog_0"),
+                create(hlRanges, ImmutableMap.of("_id", "h", "field_b", "b"), "graylog_0"),
+                create(hlRanges, ImmutableMap.of("_id", "i", "foo", "1"), "graylog_0")
+        );
+
+        return SearchResponse.builder()
+                .query("foo")
+                .builtQuery("foo")
+                .usedIndices(ImmutableSet.of(indexRangeSummary))
+                .messages(messages)
+                .fields(ImmutableSet.of("field_a", "field_b", "foo"))
+                .time(100L)
+                .totalResults(messages.size())
+                .from(Tools.nowUTC().minusHours(1))
+                .to(Tools.nowUTC()).build();
+    }
+
+    private DecoratorImpl getDecoratorConfig(String formatString, String targetField, boolean requireAllField) {
+        return DecoratorImpl.create(
+                "id",
+                FormatStringDecorator.class.getCanonicalName(),
+                ImmutableMap.of("format_string",
+                                formatString, "target_field", targetField, "require_all_fields", requireAllField),
+                Optional.empty(),
+                1);
+    }
+}


### PR DESCRIPTION
this uses the JMTE template engine to create synthetic fields at search time
useful for scenarios where the messages are fully decomposed, but a nicer human readable name is required during presentation