### PR TITLE
Avoid adding unnecessary credentials on URI for CSV export

### DIFF
--- a/graylog2-web-interface/src/components/search/SearchSidebar.jsx
+++ b/graylog2-web-interface/src/components/search/SearchSidebar.jsx
@@ -126,11 +126,9 @@ const SearchSidebar = React.createClass({
     const fields = this.props.selectedFields;
     const timeRange = SearchStore.rangeType === 'relative' ? { range: SearchStore.rangeParams.get('relative') } : SearchStore.rangeParams.toJS();
 
-    const url = new URI(URLUtils.qualifyUrl(
+    const url = URLUtils.qualifyUrl(
       ApiRoutes.UniversalSearchApiController.export(SearchStore.rangeType, query, timeRange, streamId, 0, 0, fields.toJS()).url
-    ))
-      .username(SessionStore.getSessionId())
-      .password('session');
+    );
 
     return url.toString();
   },


### PR DESCRIPTION
The web browser is already sending proper credentials via the `Authentication` request header and adding those will break the "qualified" URI if `web_endpoint_uri` was a relative path.

Fixes #2661