### PR TITLE
Run WebAppNotFoundResponseFilter later and for GET requests only.

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/rest/filter/WebAppNotFoundResponseFilter.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/filter/WebAppNotFoundResponseFilter.java
@@ -31,7 +31,7 @@ import java.io.IOException;
 import java.lang.annotation.Annotation;
 import java.util.List;
 
-@Priority(Priorities.USER)
+@Priority(Priorities.ENTITY_CODER)
 public class WebAppNotFoundResponseFilter implements ContainerResponseFilter {
     private final String webAppPrefix;
     private final IndexHtmlGenerator indexHtmlGenerator;
@@ -48,8 +48,10 @@ public class WebAppNotFoundResponseFilter implements ContainerResponseFilter {
         final String requestPath = requestContext.getUriInfo().getAbsolutePath().getPath();
         final List<MediaType> acceptableMediaTypes = requestContext.getAcceptableMediaTypes();
         final boolean acceptsHtml = acceptableMediaTypes.contains(MediaType.TEXT_HTML_TYPE) || acceptableMediaTypes.contains(MediaType.APPLICATION_XHTML_XML_TYPE);
+        final boolean isGetRequest = requestContext.getMethod().equalsIgnoreCase("get");
 
-        if (responseStatus == Response.Status.NOT_FOUND
+        if (isGetRequest
+                && responseStatus == Response.Status.NOT_FOUND
                 && acceptsHtml
                 && requestPath.startsWith(webAppPrefix)) {
             final String entity = indexHtmlGenerator.get();

--- a/graylog2-server/src/test/java/org/graylog2/rest/filter/WebAppNotFoundResponseFilterTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/rest/filter/WebAppNotFoundResponseFilterTest.java
@@ -45,6 +45,7 @@ import static org.mockito.Mockito.when;
 
 public class WebAppNotFoundResponseFilterTest {
     private static final String CK_METHOD_GET = "GET";
+    private static final String CK_METHOD_POST = "POST";
 
     @Rule
     public final MockitoRule mockitoRule = MockitoJUnit.rule();
@@ -169,4 +170,18 @@ public class WebAppNotFoundResponseFilterTest {
         assertThat(responseHeaders).containsEntry("X-UA-Compatible", Collections.singletonList("IE=edge"));
     }
 
+    @Test
+    public void filterDoesNotFilterPostRequests() throws Exception {
+        final UriInfo uriInfo = mock(UriInfo.class);
+        final List<MediaType> mediaTypes = Collections.singletonList(MediaType.TEXT_HTML_TYPE);
+        when(uriInfo.getAbsolutePath()).thenReturn(URI.create("/web/nonexisting"));
+        when(requestContext.getMethod()).thenReturn(CK_METHOD_POST);
+        when(requestContext.getUriInfo()).thenReturn(uriInfo);
+        when(requestContext.getAcceptableMediaTypes()).thenReturn(mediaTypes);
+        when(responseContext.getStatusInfo()).thenReturn(Response.Status.NOT_FOUND);
+
+        filter.filter(requestContext, responseContext);
+
+        verify(responseContext, never()).setEntity("index.html", new Annotation[0], MediaType.TEXT_HTML_TYPE);
+    }
 }

--- a/graylog2-server/src/test/java/org/graylog2/rest/filter/WebAppNotFoundResponseFilterTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/rest/filter/WebAppNotFoundResponseFilterTest.java
@@ -44,6 +44,8 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 public class WebAppNotFoundResponseFilterTest {
+    private static final String CK_METHOD_GET = "GET";
+
     @Rule
     public final MockitoRule mockitoRule = MockitoJUnit.rule();
 
@@ -82,6 +84,7 @@ public class WebAppNotFoundResponseFilterTest {
         final UriInfo uriInfo = mock(UriInfo.class);
         final List<MediaType> mediaTypes = Collections.singletonList(MediaType.APPLICATION_JSON_TYPE);
         when(uriInfo.getAbsolutePath()).thenReturn(URI.create("/web/search"));
+        when(requestContext.getMethod()).thenReturn(CK_METHOD_GET);
         when(requestContext.getUriInfo()).thenReturn(uriInfo);
         when(requestContext.getAcceptableMediaTypes()).thenReturn(mediaTypes);
         when(responseContext.getStatusInfo()).thenReturn(Response.Status.NOT_FOUND);
@@ -96,6 +99,7 @@ public class WebAppNotFoundResponseFilterTest {
         final UriInfo uriInfo = mock(UriInfo.class);
         final List<MediaType> mediaTypes = Collections.singletonList(MediaType.TEXT_HTML_TYPE);
         when(uriInfo.getAbsolutePath()).thenReturn(URI.create("/web/search"));
+        when(requestContext.getMethod()).thenReturn(CK_METHOD_GET);
         when(requestContext.getUriInfo()).thenReturn(uriInfo);
         when(requestContext.getAcceptableMediaTypes()).thenReturn(mediaTypes);
         when(responseContext.getStatusInfo()).thenReturn(Response.Status.NOT_FOUND);
@@ -110,6 +114,7 @@ public class WebAppNotFoundResponseFilterTest {
         final UriInfo uriInfo = mock(UriInfo.class);
         final List<MediaType> mediaTypes = Collections.singletonList(MediaType.APPLICATION_XHTML_XML_TYPE);
         when(uriInfo.getAbsolutePath()).thenReturn(URI.create("/web/search"));
+        when(requestContext.getMethod()).thenReturn(CK_METHOD_GET);
         when(requestContext.getUriInfo()).thenReturn(uriInfo);
         when(requestContext.getAcceptableMediaTypes()).thenReturn(mediaTypes);
         when(responseContext.getStatusInfo()).thenReturn(Response.Status.NOT_FOUND);
@@ -124,6 +129,7 @@ public class WebAppNotFoundResponseFilterTest {
         final UriInfo uriInfo = mock(UriInfo.class);
         final List<MediaType> mediaTypes = Collections.singletonList(MediaType.TEXT_HTML_TYPE);
         when(uriInfo.getAbsolutePath()).thenReturn(URI.create("/api/search"));
+        when(requestContext.getMethod()).thenReturn(CK_METHOD_GET);
         when(requestContext.getUriInfo()).thenReturn(uriInfo);
         when(requestContext.getAcceptableMediaTypes()).thenReturn(mediaTypes);
         when(responseContext.getStatusInfo()).thenReturn(Response.Status.NOT_FOUND);
@@ -138,6 +144,7 @@ public class WebAppNotFoundResponseFilterTest {
         final UriInfo uriInfo = mock(UriInfo.class);
         final List<MediaType> mediaTypes = Collections.singletonList(MediaType.TEXT_HTML_TYPE);
         when(uriInfo.getAbsolutePath()).thenReturn(URI.create("/web/search"));
+        when(requestContext.getMethod()).thenReturn(CK_METHOD_GET);
         when(requestContext.getUriInfo()).thenReturn(uriInfo);
         when(requestContext.getAcceptableMediaTypes()).thenReturn(mediaTypes);
         when(responseContext.getStatusInfo()).thenReturn(Response.Status.OK);
@@ -152,6 +159,7 @@ public class WebAppNotFoundResponseFilterTest {
         final UriInfo uriInfo = mock(UriInfo.class);
         final List<MediaType> mediaTypes = Collections.singletonList(MediaType.TEXT_HTML_TYPE);
         when(uriInfo.getAbsolutePath()).thenReturn(URI.create("/web/search"));
+        when(requestContext.getMethod()).thenReturn(CK_METHOD_GET);
         when(requestContext.getUriInfo()).thenReturn(uriInfo);
         when(requestContext.getAcceptableMediaTypes()).thenReturn(mediaTypes);
         when(responseContext.getStatusInfo()).thenReturn(Response.Status.NOT_FOUND);


### PR DESCRIPTION
## Description

This change forces the CORSFilter to run before in the post phase,
so the CORS headers are added. It also skips the
WebAppNotFoundResponseFilter for non-get requests.

## Motivation and Context

The WebAppNotFoundResponseFilter running before the CORSFilter causes
the latter to skip adding CORS headers for OPTIONS requests.

## How Has This Been Tested?

Manually.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

Fixes #2657