### PR TITLE
Move decorator help link to bottom

### DIFF
--- a/graylog2-web-interface/src/components/search/DecoratorSidebar.jsx
+++ b/graylog2-web-interface/src/components/search/DecoratorSidebar.jsx
@@ -91,7 +91,7 @@ const DecoratorSidebar = React.createClass({
       <div>
         <AddDecoratorButton stream={this.props.stream} nextOrder={nextDecoratorOrder}/>
         <OverlayTrigger trigger="click" rootClose placement="right" overlay={popoverHelp}>
-          <Button bsStyle="link" className={DecoratorStyles.helpLink}>What are message decorators? <i className="fa fa-question-circle" /></Button>
+          <Button bsStyle="link" className={DecoratorStyles.helpLink}>What are message decorators?</Button>
         </OverlayTrigger>
         <div ref="decoratorsContainer" className={DecoratorStyles.decoratorListContainer} style={{ maxHeight: this.state.maxDecoratorsHeight }}>
           <SortableList items={decoratorItems} onMoveItem={this._updateOrder} />

--- a/graylog2-web-interface/src/components/search/DecoratorSidebar.jsx
+++ b/graylog2-web-interface/src/components/search/DecoratorSidebar.jsx
@@ -89,10 +89,10 @@ const DecoratorSidebar = React.createClass({
     );
     return (
       <div>
+        <AddDecoratorButton stream={this.props.stream} nextOrder={nextDecoratorOrder}/>
         <OverlayTrigger trigger="click" rootClose placement="right" overlay={popoverHelp}>
           <Button bsStyle="link" className={DecoratorStyles.helpLink}>What are message decorators? <i className="fa fa-question-circle" /></Button>
         </OverlayTrigger>
-        <AddDecoratorButton stream={this.props.stream} nextOrder={nextDecoratorOrder}/>
         <div ref="decoratorsContainer" className={DecoratorStyles.decoratorListContainer} style={{ maxHeight: this.state.maxDecoratorsHeight }}>
           <SortableList items={decoratorItems} onMoveItem={this._updateOrder} />
         </div>

--- a/graylog2-web-interface/src/components/search/decoratorStyles.css
+++ b/graylog2-web-interface/src/components/search/decoratorStyles.css
@@ -24,7 +24,6 @@
 :local(.helpLink) {
     font-size: 12px;
     padding-top: 0px;
-    padding-bottom: 0px;
     float: right;
 }
 

--- a/graylog2-web-interface/src/components/search/decoratorStyles.css
+++ b/graylog2-web-interface/src/components/search/decoratorStyles.css
@@ -24,6 +24,7 @@
 :local(.helpLink) {
     font-size: 12px;
     padding-top: 0px;
+    padding-right: 0px;
     float: right;
 }
 

--- a/graylog2-web-interface/src/components/search/decoratorStyles.css
+++ b/graylog2-web-interface/src/components/search/decoratorStyles.css
@@ -12,7 +12,8 @@
 }
 
 :local(.addDecoratorButtonContainer) {
-    margin-bottom: 10px;
+    margin-top: 5px;
+    margin-bottom: 5px;
 }
 
 :local(.addDecoratorSelect) {
@@ -22,8 +23,9 @@
 
 :local(.helpLink) {
     font-size: 12px;
-    padding-left: 0;
-    padding-right: 0;
+    padding-top: 0px;
+    padding-bottom: 0px;
+    float: right;
 }
 
 :local(.helpPopover) {
@@ -47,5 +49,6 @@
 
 :local(.decoratorListContainer) {
     overflow-y: scroll;
+    display: inline;
     padding-bottom: 20px;
 }


### PR DESCRIPTION
## Description

This PR moves the decorator help link below the select box used to create decorators and lets it float to the right. It also removes the glyph in the help link and aligns it with the right border of the other elements.

## Motivation and Context

Without the change the help link looked misplaced.

## Screenshots (if appropriate):
Before:
![screen shot 2016-08-11 at 16 03 44](https://cloud.githubusercontent.com/assets/41929/17591206/7686fa10-5fdd-11e6-970b-bea29b986c7f.png)

After:
<img width="356" alt="screen shot 2016-08-16 at 13 54 23" src="https://cloud.githubusercontent.com/assets/41929/17698033/f9df6d6e-63b8-11e6-953d-015b77378644.png">

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
