### PR TITLE
Improved journal resiliency

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/shared/journal/KafkaJournal.java
+++ b/graylog2-server/src/main/java/org/graylog2/shared/journal/KafkaJournal.java
@@ -437,9 +437,7 @@ public class KafkaJournal extends AbstractIdleService implements Journal {
 
     private long flushMessages(List<Message> messages, long payloadSize) {
         if (messages.isEmpty()) {
-            if (LOG.isDebugEnabled()) {
-                LOG.debug("No messages to flush, not trying to write an empty message set.");
-            }
+            LOG.debug("No messages to flush, not trying to write an empty message set.");
             return -1L;
         }
 

--- a/graylog2-server/src/main/java/org/graylog2/shared/journal/KafkaJournal.java
+++ b/graylog2-server/src/main/java/org/graylog2/shared/journal/KafkaJournal.java
@@ -21,7 +21,6 @@ import com.codahale.metrics.Meter;
 import com.codahale.metrics.MetricRegistry;
 import com.codahale.metrics.Timer;
 import com.github.joschi.jadconfig.util.Size;
-import com.google.common.base.Charsets;
 import com.google.common.base.Throwables;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Iterables;
@@ -398,7 +397,7 @@ public class KafkaJournal extends AbstractIdleService implements Journal {
 
                 if (newMessageSize > maxMessageSize) {
                     LOG.warn("Message with ID <{}> is too large to store in journal, skipping! (size: {} bytes / max: {} bytes)",
-                            new String(idBytes, Charsets.UTF_8), newMessageSize, maxMessageSize);
+                            new String(idBytes, StandardCharsets.UTF_8), newMessageSize, maxMessageSize);
                     payloadSize = 0;
                     continue;
                 }

--- a/graylog2-server/src/main/java/org/graylog2/shared/journal/KafkaJournal.java
+++ b/graylog2-server/src/main/java/org/graylog2/shared/journal/KafkaJournal.java
@@ -195,8 +195,8 @@ public class KafkaJournal extends AbstractIdleService implements Journal {
                 .put(LogConfig.RetentionBytesProp(), retentionSize.toBytes())
                 // retentionMs: The age approximate maximum age of the last segment that is retained
                 .put(LogConfig.RetentionMsProp(), retentionAge.getMillis())
-                // maxMessageSize: The maximum size of a message in the log
-                .put(LogConfig.MaxMessageBytesProp(), Integer.MAX_VALUE)
+                // maxMessageSize: The maximum size of a message in the log (ensure that it's not larger than the max segment size)
+                .put(LogConfig.MaxMessageBytesProp(), Math.min(Ints.saturatedCast(segmentSize.toBytes()), Integer.MAX_VALUE))
                 // maxIndexSize: The maximum size of an index file
                 .put(LogConfig.SegmentIndexBytesProp(), Ints.saturatedCast(Size.megabytes(1L).toBytes()))
                 // indexInterval: The approximate number of bytes between index entries

--- a/graylog2-server/src/main/java/org/graylog2/shared/journal/KafkaJournal.java
+++ b/graylog2-server/src/main/java/org/graylog2/shared/journal/KafkaJournal.java
@@ -390,7 +390,7 @@ public class KafkaJournal extends AbstractIdleService implements Journal {
 
                 final Message newMessage = new Message(messageBytes, idBytes);
                 // Calculate the size of the new message in the message set by including the overhead for the log entry.
-                final int newMessageSize = newMessage.size() + MessageSet.LogOverhead();
+                final int newMessageSize = MessageSet.entrySize(newMessage);
 
                 // If adding the new message to the message set would overflow the max segment size, flush the current
                 // list of message to avoid a MessageSetSizeTooLargeException.

--- a/graylog2-server/src/main/java/org/graylog2/shared/journal/KafkaJournal.java
+++ b/graylog2-server/src/main/java/org/graylog2/shared/journal/KafkaJournal.java
@@ -394,7 +394,7 @@ public class KafkaJournal extends AbstractIdleService implements Journal {
 
                 // If adding the new message to the message set would overflow the max segment size, flush the current
                 // list of message to avoid a MessageSetSizeTooLargeException.
-                if ((messageSetSize + newMessageSize) >= maxSegmentSize) {
+                if ((messageSetSize + newMessageSize) > maxSegmentSize) {
                     if (LOG.isDebugEnabled()) {
                         LOG.debug("Flushing {} bytes message set with {} messages to avoid overflowing segment with max size of {} bytes",
                                 messageSetSize, messages.size(), maxSegmentSize);
@@ -423,6 +423,13 @@ public class KafkaJournal extends AbstractIdleService implements Journal {
     }
 
     private long flushMessages(List<Message> messages, long payloadSize) {
+        if (messages.isEmpty()) {
+            if (LOG.isDebugEnabled()) {
+                LOG.debug("No messages to flush, not trying to write an empty message set.");
+            }
+            return -1L;
+        }
+
         final ByteBufferMessageSet messageSet = new ByteBufferMessageSet(JavaConversions.asScalaBuffer(messages).toSeq());
 
         if (LOG.isDebugEnabled()) {

--- a/graylog2-server/src/main/java/org/graylog2/shared/journal/KafkaJournal.java
+++ b/graylog2-server/src/main/java/org/graylog2/shared/journal/KafkaJournal.java
@@ -21,6 +21,7 @@ import com.codahale.metrics.Meter;
 import com.codahale.metrics.MetricRegistry;
 import com.codahale.metrics.Timer;
 import com.github.joschi.jadconfig.util.Size;
+import com.google.common.base.Charsets;
 import com.google.common.base.Throwables;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Iterables;
@@ -397,7 +398,7 @@ public class KafkaJournal extends AbstractIdleService implements Journal {
 
                 if (newMessageSize > maxMessageSize) {
                     LOG.warn("Message with ID <{}> is too large to store in journal, skipping! (size: {} bytes / max: {} bytes)",
-                            new String(idBytes), newMessageSize, maxMessageSize);
+                            new String(idBytes, Charsets.UTF_8), newMessageSize, maxMessageSize);
                     payloadSize = 0;
                     continue;
                 }

--- a/graylog2-server/src/main/java/org/graylog2/shared/journal/KafkaJournal.java
+++ b/graylog2-server/src/main/java/org/graylog2/shared/journal/KafkaJournal.java
@@ -172,7 +172,7 @@ public class KafkaJournal extends AbstractIdleService implements Journal {
         this.serverStatus = serverStatus;
         this.maxSegmentSize = segmentSize.toBytes();
         // Max message size should not be bigger than max segment size.
-        this.maxMessageSize = Math.min(Ints.saturatedCast(maxSegmentSize), Integer.MAX_VALUE);
+        this.maxMessageSize = Ints.saturatedCast(maxSegmentSize);
 
         this.writtenMessages = metricRegistry.meter(name(this.getClass(), "writtenMessages"));
         this.readMessages = metricRegistry.meter(name(this.getClass(), "readMessages"));


### PR DESCRIPTION
- Make sure the message set we want to write fits into a segment
- Max message size should not be larger than max segment size
- Do not try to write a message which is larger than max message size

Fixes #2659 