### PR TITLE
Enable gzip per default for REST API listener.

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/plugin/BaseConfiguration.java
+++ b/graylog2-server/src/main/java/org/graylog2/plugin/BaseConfiguration.java
@@ -71,7 +71,7 @@ public abstract class BaseConfiguration {
     private boolean restEnableCors = true;
 
     @Parameter(value = "rest_enable_gzip")
-    private boolean restEnableGzip = false;
+    private boolean restEnableGzip = true;
 
     @Parameter(value = "rest_max_initial_line_length", required = true, validator = PositiveIntegerValidator.class)
     private int restMaxInitialLineLength = 4096;

--- a/misc/graylog.conf
+++ b/misc/graylog.conf
@@ -95,8 +95,8 @@ rest_listen_uri = http://127.0.0.1:9000/api/
 #rest_enable_cors = false
 
 # Enable GZIP support for REST API. This compresses API responses and therefore helps to reduce
-# overall round trip times. This is disabled by default. Uncomment the next line to enable it.
-#rest_enable_gzip = true
+# overall round trip times. This is enabled by default. Uncomment the next line to disable it.
+#rest_enable_gzip = false
 
 # Enable HTTPS support for the REST API. This secures the communication with the REST API with
 # TLS to prevent request forgery and eavesdropping. This is disabled by default. Uncomment the


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Due to the consolidation of the web and REST API listeners, this setting
is now becoming much more relevant for the performance of the web
interface. GZIP was disabled per default for the REST API in past
versions, which was a very conservative decision. Now that in certain
configurations the REST API listener also serves the web interface, this
setting is very important for performance, as the web interface assets
are quite big when delivering them uncompressed.

As there is no reason (and no negative experience with GZIP in the
past), it is now enabled per default.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

Fixes #2670