### PR TITLE
Removing unused prop type in StreamRuleList component.

### DIFF
--- a/graylog2-web-interface/src/components/streamrules/StreamRuleList.jsx
+++ b/graylog2-web-interface/src/components/streamrules/StreamRuleList.jsx
@@ -10,7 +10,6 @@ const StreamRuleList = React.createClass({
     onDelete: React.PropTypes.func,
     permissions: React.PropTypes.array.isRequired,
     stream: React.PropTypes.object.isRequired,
-    streamRule: React.PropTypes.object.isRequired,
     streamRuleTypes: React.PropTypes.array.isRequired,
   },
 


### PR DESCRIPTION
## Motivation and Context

There was an unused prop type defined in the StreamRuleList component,
which was not passed to it, therefore generating a warning in the
browser's console for every use of the component. This change removes
the prop type.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.