### PR TITLE
More decorator improvements

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/decorators/DecoratorProcessorImpl.java
+++ b/graylog2-server/src/main/java/org/graylog2/decorators/DecoratorProcessorImpl.java
@@ -16,6 +16,7 @@
  */
 package org.graylog2.decorators;
 
+import org.graylog2.plugin.Message;
 import org.graylog2.plugin.decorators.SearchResponseDecorator;
 import org.graylog2.rest.models.messages.responses.DecorationStats;
 import org.graylog2.rest.models.messages.responses.ResultMessageSummary;
@@ -87,8 +88,14 @@ public class DecoratorProcessorImpl implements DecoratorProcessor {
 
     private Set<String> extractFields(List<ResultMessageSummary> messages) {
         return messages.stream()
-            .map(message -> message.message().keySet())
-            .reduce(new HashSet<>(), (set1, set2) -> { set1.addAll(set2); return set1; });
+                .map(message -> message.message().keySet())
+                .reduce(new HashSet<>(), (set1, set2) -> {
+                    set1.addAll(set2);
+                    return set1;
+                })
+                .stream()
+                .filter(field -> !Message.RESERVED_FIELDS.contains(field))
+                .collect(Collectors.toSet());
     }
 
     private SearchDecorationStats getSearchDecoratorStats(List<ResultMessageSummary> decoratedMessages) {

--- a/graylog2-server/src/main/java/org/graylog2/decorators/DecoratorProcessorImpl.java
+++ b/graylog2-server/src/main/java/org/graylog2/decorators/DecoratorProcessorImpl.java
@@ -88,12 +88,7 @@ public class DecoratorProcessorImpl implements DecoratorProcessor {
 
     private Set<String> extractFields(List<ResultMessageSummary> messages) {
         return messages.stream()
-                .map(message -> message.message().keySet())
-                .reduce(new HashSet<>(), (set1, set2) -> {
-                    set1.addAll(set2);
-                    return set1;
-                })
-                .stream()
+                .flatMap(message -> message.message().keySet().stream())
                 .filter(field -> !Message.RESERVED_FIELDS.contains(field))
                 .collect(Collectors.toSet());
     }

--- a/graylog2-web-interface/src/components/search/Decorator.jsx
+++ b/graylog2-web-interface/src/components/search/Decorator.jsx
@@ -40,11 +40,29 @@ const Decorator = React.createClass({
       name: 'Unknown decorator type',
     };
   },
+  // Attempts to resolve ID values in the decorator configuration against the type definition.
+  // This allows users to see actual names for entities in drop-downs, instead of their IDs.
+  _resolveConfigurationIds(config) {
+    const typeConfig = this.props.typeDefinition.requested_configuration;
+    const resolvedConfig = {};
+    const configKeys = Object.keys(config);
+
+    configKeys.forEach(key => {
+      const configValues = (typeConfig[key] ? typeConfig[key].additional_info.values : undefined);
+      if (typeof configValues === 'object' && !Array.isArray(configValues)) {
+        const originalValue = config[key];
+        resolvedConfig[key] = configValues[originalValue] ? configValues[originalValue] : originalValue;
+      }
+    });
+
+    return Object.assign({}, config, resolvedConfig);
+  },
   render() {
     if (!this.state.types) {
       return <Spinner />;
     }
     const decorator = this.props.decorator;
+    const config = this._resolveConfigurationIds(decorator.config);
     const decoratorType = this.state.types[decorator.type] || this._decoratorTypeNotPresent();
     return (
       <span className={DecoratorStyles.fullWidth}>
@@ -58,7 +76,7 @@ const Decorator = React.createClass({
         </div>
         <ConfigurationWell key={`configuration-well-decorator-${decorator._id}`}
                            id={decorator._id}
-                           configuration={decorator.config}
+                           configuration={config}
                            typeDefinition={this.props.typeDefinition}/>
         <ConfigurationForm ref="editForm"
                            key="configuration-form-decorator"

--- a/graylog2-web-interface/src/components/search/Decorator.jsx
+++ b/graylog2-web-interface/src/components/search/Decorator.jsx
@@ -53,9 +53,11 @@ const Decorator = React.createClass({
 
     configKeys.forEach(key => {
       const configValues = (typeConfig[key] ? typeConfig[key].additional_info.values : undefined);
-      if (typeof configValues === 'object' && !Array.isArray(configValues)) {
-        const originalValue = config[key];
-        resolvedConfig[key] = configValues[originalValue] ? configValues[originalValue] : originalValue;
+      const originalValue = config[key];
+      if (configValues) {
+        if (configValues[originalValue]) {
+          resolvedConfig[key] = configValues[originalValue];
+        }
       }
     });
 

--- a/graylog2-web-interface/src/components/search/Decorator.jsx
+++ b/graylog2-web-interface/src/components/search/Decorator.jsx
@@ -33,7 +33,11 @@ const Decorator = React.createClass({
     this.refs.editForm.open();
   },
   _handleSubmit(data) {
-    DecoratorsActions.update(this.props.decorator._id, { type: data.type, config: data.configuration });
+    DecoratorsActions.update(this.props.decorator._id, {
+      type: data.type,
+      config: data.configuration,
+      order: this.props.decorator.order,
+    });
   },
   _decoratorTypeNotPresent() {
     return {

--- a/graylog2-web-interface/src/components/search/Decorator.jsx
+++ b/graylog2-web-interface/src/components/search/Decorator.jsx
@@ -37,7 +37,7 @@ const Decorator = React.createClass({
   },
   _decoratorTypeNotPresent() {
     return {
-      name: <strong>Unknown decorator type</strong>,
+      name: 'Unknown decorator type',
     };
   },
   render() {

--- a/graylog2-web-interface/src/components/search/DecoratorSidebar.jsx
+++ b/graylog2-web-interface/src/components/search/DecoratorSidebar.jsx
@@ -46,7 +46,7 @@ const DecoratorSidebar = React.createClass({
 
   _updateHeight() {
     const decoratorsContainer = ReactDOM.findDOMNode(this.refs.decoratorsContainer);
-    const maxHeight = this.props.maximumHeight - decoratorsContainer.getBoundingClientRect().top - 20;
+    const maxHeight = this.props.maximumHeight - decoratorsContainer.getBoundingClientRect().top;
 
     this.setState({ maxDecoratorsHeight: Math.max(maxHeight, this.MINIMUM_DECORATORS_HEIGHT) });
   },
@@ -93,7 +93,7 @@ const DecoratorSidebar = React.createClass({
           <Button bsStyle="link" className={DecoratorStyles.helpLink}>What are message decorators? <i className="fa fa-question-circle" /></Button>
         </OverlayTrigger>
         <AddDecoratorButton stream={this.props.stream} nextOrder={nextDecoratorOrder}/>
-        <div ref="decoratorsContainer" style={{ maxHeight: this.state.maxDecoratorsHeight, overflowY: 'scroll' }}>
+        <div ref="decoratorsContainer" className={DecoratorStyles.decoratorListContainer} style={{ maxHeight: this.state.maxDecoratorsHeight }}>
           <SortableList items={decoratorItems} onMoveItem={this._updateOrder} />
         </div>
       </div>

--- a/graylog2-web-interface/src/components/search/DecoratorSidebar.jsx
+++ b/graylog2-web-interface/src/components/search/DecoratorSidebar.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import ReactDOM from 'react-dom';
 import Reflux from 'reflux';
 import { Button, OverlayTrigger, Popover } from 'react-bootstrap';
 
@@ -17,8 +18,39 @@ import DecoratorStyles from '!style!css!components/search/decoratorStyles.css';
 const DecoratorSidebar = React.createClass({
   propTypes: {
     stream: React.PropTypes.string,
+    maximumHeight: React.PropTypes.number,
   },
   mixins: [Reflux.connect(DecoratorsStore)],
+  getInitialState() {
+    return {
+      maxDecoratorsHeight: 1000,
+    };
+  },
+
+  componentDidMount() {
+    this._updateHeight();
+    window.addEventListener('scroll', this._updateHeight);
+  },
+
+  componentDidUpdate(prevProps) {
+    if (this.props.maximumHeight !== prevProps.maximumHeight) {
+      this._updateHeight();
+    }
+  },
+
+  componentWillUnmount() {
+    window.removeEventListener('scroll', this._updateHeight);
+  },
+
+  MINIMUM_DECORATORS_HEIGHT: 50,
+
+  _updateHeight() {
+    const decoratorsContainer = ReactDOM.findDOMNode(this.refs.decoratorsContainer);
+    const maxHeight = this.props.maximumHeight - decoratorsContainer.getBoundingClientRect().top - 20;
+
+    this.setState({ maxDecoratorsHeight: Math.max(maxHeight, this.MINIMUM_DECORATORS_HEIGHT) });
+  },
+
   _formatDecorator(decorator) {
     const typeDefinition = this.state.types[decorator.type] || { requested_configuration: {}, name: `Unknown type: ${decorator.type}` };
     return ({ id: decorator._id, title: <Decorator key={`decorator-${decorator._id}`}
@@ -61,7 +93,9 @@ const DecoratorSidebar = React.createClass({
           <Button bsStyle="link" className={DecoratorStyles.helpLink}>What are message decorators? <i className="fa fa-question-circle" /></Button>
         </OverlayTrigger>
         <AddDecoratorButton stream={this.props.stream} nextOrder={nextDecoratorOrder}/>
-        <SortableList items={decoratorItems} onMoveItem={this._updateOrder} />
+        <div ref="decoratorsContainer" style={{ maxHeight: this.state.maxDecoratorsHeight, overflowY: 'scroll' }}>
+          <SortableList items={decoratorItems} onMoveItem={this._updateOrder} />
+        </div>
       </div>
     );
   },

--- a/graylog2-web-interface/src/components/search/FieldAnalizersSidebar.jsx
+++ b/graylog2-web-interface/src/components/search/FieldAnalizersSidebar.jsx
@@ -1,0 +1,179 @@
+import React from 'react';
+import ReactDOM from 'react-dom';
+import { Input } from 'react-bootstrap';
+
+import { DecoratedSidebarMessageField, SidebarMessageField } from 'components/search';
+
+const FieldAnalizersSidebar = React.createClass({
+  propTypes: {
+    fields: React.PropTypes.array,
+    fieldAnalyzers: React.PropTypes.array,
+    onFieldAnalyzer: React.PropTypes.func,
+    onFieldToggled: React.PropTypes.func,
+    maximumHeight: React.PropTypes.number,
+    predefinedFieldSelection: React.PropTypes.func,
+    result: React.PropTypes.object,
+    selectedFields: React.PropTypes.object,
+    shouldHighlight: React.PropTypes.bool,
+    showAllFields: React.PropTypes.bool,
+    showHighlightToggle: React.PropTypes.bool,
+    togglePageFields: React.PropTypes.func,
+    toggleShouldHighlight: React.PropTypes.func,
+  },
+
+  getInitialState() {
+    return {
+      fieldFilter: '',
+      maxFieldsHeight: 1000,
+    };
+  },
+
+  componentDidMount() {
+    this._updateHeight();
+    window.addEventListener('scroll', this._updateHeight);
+  },
+
+  componentDidUpdate(prevProps) {
+    if (this.props.showAllFields !== prevProps.showAllFields || this.props.maximumHeight !== prevProps.maximumHeight) {
+      this._updateHeight();
+    }
+  },
+
+  componentWillUnmount() {
+    window.removeEventListener('scroll', this._updateHeight);
+  },
+
+  MINIMUM_FIELDS_HEIGHT: 50,
+
+  _updateHeight() {
+    const fieldsContainer = ReactDOM.findDOMNode(this.refs.fields);
+
+    const footer = ReactDOM.findDOMNode(this.refs.footer);
+    const footerCss = window.getComputedStyle(footer);
+    const footerMargin = parseFloat(footerCss.getPropertyValue('margin-top'));
+
+    // Need to calculate this additionally, because margins are not included in the parent's height #computers
+    let highlightToggleMargins = 0;
+    if (this.refs.highlightToggle) {
+      const toggle = ReactDOM.findDOMNode(this.refs.highlightToggle);
+      const toggleCss = window.getComputedStyle(toggle);
+      highlightToggleMargins = parseFloat(toggleCss.getPropertyValue('margin-top')) +
+        parseFloat(toggleCss.getPropertyValue('margin-bottom'));
+    }
+
+    const maxHeight = this.props.maximumHeight -
+      fieldsContainer.getBoundingClientRect().top -
+      footerMargin -
+      footer.offsetHeight -
+      highlightToggleMargins;
+
+    this.setState({ maxFieldsHeight: Math.max(maxHeight, this.MINIMUM_FIELDS_HEIGHT) });
+  },
+
+  _filterFields(event) {
+    this.setState({ fieldFilter: event.target.value });
+  },
+
+  _showAllFields(event) {
+    event.preventDefault();
+    if (!this.props.showAllFields) {
+      this.props.togglePageFields();
+    }
+  },
+  _showPageFields(event) {
+    event.preventDefault();
+    if (this.props.showAllFields) {
+      this.props.togglePageFields();
+    }
+  },
+
+  _updateFieldSelection(setName) {
+    this.props.predefinedFieldSelection(setName);
+  },
+  _updateFieldSelectionToDefault() {
+    this._updateFieldSelection('default');
+  },
+  _updateFieldSelectionToAll() {
+    this._updateFieldSelection('all');
+  },
+  _updateFieldSelectionToNone() {
+    this._updateFieldSelection('none');
+  },
+
+  render() {
+    const decorationStats = this.props.result.decoration_stats;
+    const decoratedFields = decorationStats ? [].concat(decorationStats.added_fields || [], decorationStats.changed_fields || []) : [];
+    const messageFields = this.props.fields
+      .filter((field) => field.name.indexOf(this.state.fieldFilter) !== -1)
+      .sort((a, b) => a.name.localeCompare(b.name))
+      .map((field) => {
+        let messageField;
+        if (decoratedFields.includes(field.name)) {
+          messageField = (
+            <DecoratedSidebarMessageField key={field.name}
+                                          field={field}
+                                          onToggled={this.props.onFieldToggled}
+                                          selected={this.props.selectedFields.contains(field.name)} />
+          );
+        } else {
+          messageField = (
+            <SidebarMessageField key={field.name}
+                                 field={field}
+                                 fieldAnalyzers={this.props.fieldAnalyzers}
+                                 onToggled={this.props.onFieldToggled}
+                                 onFieldAnalyzer={this.props.onFieldAnalyzer}
+                                 selected={this.props.selectedFields.contains(field.name)} />
+          );
+        }
+        return messageField;
+      });
+
+    let shouldHighlightToggle;
+    if (this.props.showHighlightToggle) {
+      shouldHighlightToggle = (
+        <Input ref="highlightToggle" type="checkbox" bsSize="small" checked={this.props.shouldHighlight}
+               onChange={this.props.toggleShouldHighlight} label="Highlight results"
+               groupClassName="result-highlight-control" />
+      );
+    }
+
+    return (
+      <div>
+        <div ref="fieldsFilter" className="input-group input-group-sm" style={{ marginTop: 5, marginBottom: 5 }}>
+          <span className="input-group-btn">
+            <button type="button" className="btn btn-default"
+                    onClick={this._updateFieldSelectionToDefault}>Default
+            </button>
+            <button type="button" className="btn btn-default"
+                    onClick={this._updateFieldSelectionToAll}>All
+            </button>
+            <button type="button" className="btn btn-default"
+                    onClick={this._updateFieldSelectionToNone}>None
+            </button>
+          </span>
+          <input type="text" className="form-control" placeholder="Filter fields"
+                 onChange={this._filterFields}
+                 value={this.state.fieldFilter} />
+        </div>
+        <div ref="fields" style={{ maxHeight: this.state.maxFieldsHeight, overflowY: 'scroll' }}>
+          <ul className="search-result-fields">
+            {messageFields}
+          </ul>
+        </div>
+        <div ref="footer" style={{ marginTop: 13, marginBottom: 0 }}>
+          List{' '}
+          <span className="message-result-fields-range"> fields of&nbsp;
+            <a href="#" style={{ fontWeight: this.props.showAllFields ? 'normal' : 'bold' }}
+               onClick={this._showPageFields}>current page</a> or{' '}
+            <a href="#" style={{ fontWeight: this.props.showAllFields ? 'bold' : 'normal' }}
+               onClick={this._showAllFields}>all fields</a>.
+          </span>
+          <br />
+          {shouldHighlightToggle}
+        </div>
+      </div>
+    );
+  },
+});
+
+export default FieldAnalizersSidebar;

--- a/graylog2-web-interface/src/components/search/FieldAnalyzersSidebar.jsx
+++ b/graylog2-web-interface/src/components/search/FieldAnalyzersSidebar.jsx
@@ -4,7 +4,7 @@ import { Input } from 'react-bootstrap';
 
 import { DecoratedSidebarMessageField, SidebarMessageField } from 'components/search';
 
-const FieldAnalizersSidebar = React.createClass({
+const FieldAnalyzersSidebar = React.createClass({
   propTypes: {
     fields: React.PropTypes.array,
     fieldAnalyzers: React.PropTypes.array,
@@ -176,4 +176,4 @@ const FieldAnalizersSidebar = React.createClass({
   },
 });
 
-export default FieldAnalizersSidebar;
+export default FieldAnalyzersSidebar;

--- a/graylog2-web-interface/src/components/search/SearchSidebar.jsx
+++ b/graylog2-web-interface/src/components/search/SearchSidebar.jsx
@@ -188,7 +188,8 @@ const SearchSidebar = React.createClass({
             </Tab>
 
             <Tab eventKey={2} title={<h4>Decorators</h4>}>
-              <DecoratorSidebar stream={this.props.searchInStream ? this.props.searchInStream.id : undefined} />
+              <DecoratorSidebar stream={this.props.searchInStream ? this.props.searchInStream.id : undefined}
+                                maximumHeight={this.state.availableHeight} />
             </Tab>
           </Tabs>
         </div>

--- a/graylog2-web-interface/src/components/search/decoratorStyles.css
+++ b/graylog2-web-interface/src/components/search/decoratorStyles.css
@@ -44,3 +44,8 @@
     top: 3px;
     position: relative;
 }
+
+:local(.decoratorListContainer) {
+    overflow-y: scroll;
+    padding-bottom: 20px;
+}

--- a/graylog2-web-interface/src/components/search/index.jsx
+++ b/graylog2-web-interface/src/components/search/index.jsx
@@ -5,6 +5,7 @@ export { default as DecoratedMessageFieldMarker } from './DecoratedMessageFieldM
 export { default as DecoratedSidebarMessageField } from './DecoratedSidebarMessageField';
 export { default as Decorator } from './Decorator';
 export { default as DecoratorSidebar } from './DecoratorSidebar';
+export { default as FieldAnalyzersSidebar } from './FieldAnalizersSidebar';
 export { default as LegacyHistogram } from './LegacyHistogram';
 export { default as MalformedSearchQuery } from './MalformedSearchQuery';
 export { default as MessageDetail } from './MessageDetail';

--- a/graylog2-web-interface/src/components/search/index.jsx
+++ b/graylog2-web-interface/src/components/search/index.jsx
@@ -5,7 +5,7 @@ export { default as DecoratedMessageFieldMarker } from './DecoratedMessageFieldM
 export { default as DecoratedSidebarMessageField } from './DecoratedSidebarMessageField';
 export { default as Decorator } from './Decorator';
 export { default as DecoratorSidebar } from './DecoratorSidebar';
-export { default as FieldAnalyzersSidebar } from './FieldAnalizersSidebar';
+export { default as FieldAnalyzersSidebar } from './FieldAnalyzersSidebar';
 export { default as LegacyHistogram } from './LegacyHistogram';
 export { default as MalformedSearchQuery } from './MalformedSearchQuery';
 export { default as MessageDetail } from './MessageDetail';


### PR DESCRIPTION
Here are some other improvements in message decorators:

- Do not return internal fields in the field list. Fixes #2519
- Maintain decorators sort after editing one of them, by submitting the `order` field to the server
- Make decorator sidebar scrollable, allowing users to access all decorators if there are many or the screen height is not large enough
- Attempt to resolve configuration IDs from the type definition. This allows us to show names in the configuration values instead of IDs