### PR TITLE
Generating a relative redirect URL for web interface in root resource.

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/rest/resources/HelloWorldResource.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/resources/HelloWorldResource.java
@@ -34,6 +34,8 @@ import javax.ws.rs.Produces;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 
+import java.net.URI;
+
 import static java.util.Objects.requireNonNull;
 
 @Api(value = "Hello World", description = "A friendly hello world message")
@@ -72,8 +74,9 @@ public class HelloWorldResource extends RestResource {
     @Produces({MediaType.TEXT_HTML, MediaType.APPLICATION_XHTML_XML})
     public Response redirectToWebConsole() {
         if (configuration.isRestAndWebOnSamePort()) {
+            final URI target = URI.create(configuration.getWebPrefix());
             return Response
-                .temporaryRedirect(configuration.getWebListenUri())
+                .temporaryRedirect(target)
                 .build();
         }
 

--- a/graylog2-server/src/test/java/org/graylog2/rest/resources/HelloWorldResourceTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/rest/resources/HelloWorldResourceTest.java
@@ -1,0 +1,74 @@
+package org.graylog2.rest.resources;
+
+import org.graylog2.Configuration;
+import org.graylog2.plugin.cluster.ClusterConfigService;
+import org.graylog2.plugin.cluster.ClusterId;
+import org.graylog2.plugin.system.NodeId;
+import org.graylog2.rest.models.HelloWorldResponse;
+import org.junit.Before;
+import org.junit.Test;
+
+import javax.ws.rs.core.Response;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class HelloWorldResourceTest extends RestResourceBaseTest {
+    private static final String CK_CLUSTER_ID = "dummyclusterid";
+    private static final String CK_NODE_ID = "dummynodeid";
+
+    private HelloWorldResource helloWorldResource;
+    private NodeId nodeId;
+    private ClusterConfigService clusterConfigService;
+    private Configuration configuration;
+
+    @Before
+    public void setUp() throws Exception {
+        this.nodeId = mock(NodeId.class);
+        this.clusterConfigService = mock(ClusterConfigService.class);
+        this.configuration = mock(Configuration.class);
+        this.helloWorldResource = new HelloWorldResource(nodeId, clusterConfigService, configuration);
+
+        when(clusterConfigService.getOrDefault(eq(ClusterId.class), any(ClusterId.class))).thenReturn(ClusterId.create(CK_CLUSTER_ID));
+        when(nodeId.toString()).thenReturn(CK_NODE_ID);
+    }
+
+    @Test
+    public void rootResourceShouldReturnGeneralStats() throws Exception {
+        final HelloWorldResponse helloWorldResponse = this.helloWorldResource.helloWorld();
+
+        assertThat(helloWorldResponse).isNotNull();
+
+        assertThat(helloWorldResponse.clusterId()).isEqualTo(CK_CLUSTER_ID);
+        assertThat(helloWorldResponse.nodeId()).isEqualTo(CK_NODE_ID);
+    }
+
+    @Test
+    public void rootResourceShouldRedirectToWebInterfaceIfHtmlIsRequested() throws Exception {
+        when(configuration.isRestAndWebOnSamePort()).thenReturn(true);
+        final String pathToWebIf = "/path_to_web_if";
+        when(configuration.getWebPrefix()).thenReturn(pathToWebIf);
+
+        final Response response = helloWorldResource.redirectToWebConsole();
+
+        assertThat(response).isNotNull();
+
+        final String locationHeader = response.getHeaderString("Location");
+        assertThat(locationHeader).isNotNull().isEqualTo(pathToWebIf);
+    }
+
+    @Test
+    public void rootResourceShouldNotRedirectToWebInterfaceIfNotRunningOnSamePort() throws Exception {
+        when(configuration.isRestAndWebOnSamePort()).thenReturn(false);
+
+        final Response response = helloWorldResource.redirectToWebConsole();
+
+        assertThat(response).isNotNull();
+
+        final String locationHeader = response.getHeaderString("Location");
+        assertThat(locationHeader).isNull();
+    }
+}

--- a/graylog2-server/src/test/java/org/graylog2/rest/resources/HelloWorldResourceTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/rest/resources/HelloWorldResourceTest.java
@@ -1,3 +1,19 @@
+/**
+ * This file is part of Graylog.
+ *
+ * Graylog is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package org.graylog2.rest.resources;
 
 import org.graylog2.Configuration;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Using the `web_listen_uri` to generate the redirect to the web interface
could lead to problems in case it is not accessible from the client.
Therefore we are generating a relative URL instead.

Fixes #2593.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.