### PR TITLE
Allow users of MessageFields to disable field actions

### DIFF
--- a/graylog2-web-interface/src/components/search/MessageFields.jsx
+++ b/graylog2-web-interface/src/components/search/MessageFields.jsx
@@ -27,7 +27,7 @@ const MessageFields = React.createClass({
         .map(key => {
           return (
             <MessageField key={key} {...this.props} fieldName={key} value={fields[key]}
-                               disableFieldActions={decoratedFields.indexOf(key) !== -1} />
+                               disableFieldActions={this.props.disableFieldActions || decoratedFields.indexOf(key) !== -1} />
           );
         });
     }


### PR DESCRIPTION
Somewhere in the changes made for the message decorators, we forgot to check the `disableFieldActions` prop in `MessageFields` when deciding whether to show the field actions or not. This PR add that back.