### PR TITLE
Add help text for session's client address

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/rest/RemoteInterfaceProvider.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/RemoteInterfaceProvider.java
@@ -22,6 +22,7 @@ import com.google.common.net.MediaType;
 import okhttp3.OkHttpClient;
 import okhttp3.Request;
 import org.graylog2.cluster.Node;
+import org.graylog2.security.realm.SessionAuthenticator;
 import retrofit2.Retrofit;
 import retrofit2.converter.jackson.JacksonConverterFactory;
 
@@ -48,7 +49,11 @@ public class RemoteInterfaceProvider {
                             .method(original.method(), original.body());
 
                     if (authorizationToken != null) {
-                        builder = builder.header(HttpHeaders.AUTHORIZATION, authorizationToken);
+                        builder = builder
+                                // forward the authentication information of the current user
+                                .header(HttpHeaders.AUTHORIZATION, authorizationToken)
+                                // do not extend the users session with proxied requests
+                                .header(SessionAuthenticator.X_GRAYLOG_NO_SESSION_EXTENSION, "true");
                     }
 
                     return chain.proceed(builder.build());

--- a/graylog2-server/src/main/java/org/graylog2/security/realm/SessionAuthenticator.java
+++ b/graylog2-server/src/main/java/org/graylog2/security/realm/SessionAuthenticator.java
@@ -16,14 +16,19 @@
  */
 package org.graylog2.security.realm;
 
-import org.apache.shiro.authc.*;
+import org.apache.shiro.authc.AuthenticationException;
+import org.apache.shiro.authc.AuthenticationInfo;
+import org.apache.shiro.authc.AuthenticationToken;
+import org.apache.shiro.authc.LockedAccountException;
+import org.apache.shiro.authc.SimpleAccount;
 import org.apache.shiro.authc.credential.AllowAllCredentialsMatcher;
 import org.apache.shiro.realm.AuthenticatingRealm;
 import org.apache.shiro.session.Session;
 import org.apache.shiro.subject.Subject;
 import org.apache.shiro.util.ThreadContext;
-import org.graylog2.shared.security.SessionIdToken;
 import org.graylog2.plugin.database.users.User;
+import org.graylog2.shared.security.SessionIdToken;
+import org.graylog2.shared.security.ShiroSecurityContextFilter;
 import org.graylog2.shared.users.UserService;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -34,6 +39,7 @@ import javax.ws.rs.core.MultivaluedMap;
 public class SessionAuthenticator extends AuthenticatingRealm {
     private static final Logger LOG = LoggerFactory.getLogger(SessionAuthenticator.class);
     public static final String NAME = "mongodb-session";
+    public static final String X_GRAYLOG_NO_SESSION_EXTENSION = "X-Graylog-No-Session-Extension";
 
     private final UserService userService;
     private final LdapUserAuthenticator ldapAuthenticator;
@@ -74,9 +80,9 @@ public class SessionAuthenticator extends AuthenticatingRealm {
 
         @SuppressWarnings("unchecked")
         final MultivaluedMap<String, String> requestHeaders = (MultivaluedMap<String, String>) ThreadContext.get(
-                "REQUEST_HEADERS");
+                ShiroSecurityContextFilter.REQUEST_HEADERS);
         // extend session unless the relevant header was passed.
-        if (requestHeaders == null || !"true".equalsIgnoreCase(requestHeaders.getFirst("X-Graylog-No-Session-Extension"))) {
+        if (requestHeaders != null && !"true".equalsIgnoreCase(requestHeaders.getFirst(X_GRAYLOG_NO_SESSION_EXTENSION))) {
             session.touch();
         } else {
             LOG.debug("Not extending session because the request indicated not to.");

--- a/graylog2-server/src/main/java/org/graylog2/shared/security/ShiroSecurityContextFilter.java
+++ b/graylog2-server/src/main/java/org/graylog2/shared/security/ShiroSecurityContextFilter.java
@@ -50,8 +50,6 @@ public class ShiroSecurityContextFilter implements ContainerRequestFilter {
     private Provider<Request> grizzlyRequestProvider;
     private final Set<IpSubnet> trustedProxies;
 
-    public static final String X_GRAYLOG_REMOTE_ADDRESS = "x-graylog-remote-address";
-
     @Inject
     public ShiroSecurityContextFilter(DefaultSecurityManager securityManager,
                                       Provider<Request> grizzlyRequestProvider,

--- a/graylog2-server/src/main/java/org/graylog2/shared/security/ShiroSecurityContextFilter.java
+++ b/graylog2-server/src/main/java/org/graylog2/shared/security/ShiroSecurityContextFilter.java
@@ -20,6 +20,7 @@ import org.apache.shiro.authc.AuthenticationToken;
 import org.apache.shiro.authc.UsernamePasswordToken;
 import org.apache.shiro.mgt.DefaultSecurityManager;
 import org.apache.shiro.subject.Subject;
+import org.apache.shiro.util.ThreadContext;
 import org.glassfish.grizzly.http.server.Request;
 import org.graylog2.rest.RestTools;
 import org.jboss.netty.handler.ipfilter.IpSubnet;
@@ -44,9 +45,12 @@ import static java.util.Objects.requireNonNull;
 
 @Priority(Priorities.AUTHENTICATION)
 public class ShiroSecurityContextFilter implements ContainerRequestFilter {
+    public static final String REQUEST_HEADERS = "REQUEST_HEADERS";
     private final DefaultSecurityManager securityManager;
     private Provider<Request> grizzlyRequestProvider;
     private final Set<IpSubnet> trustedProxies;
+
+    public static final String X_GRAYLOG_REMOTE_ADDRESS = "x-graylog-remote-address";
 
     @Inject
     public ShiroSecurityContextFilter(DefaultSecurityManager securityManager,
@@ -65,6 +69,9 @@ public class ShiroSecurityContextFilter implements ContainerRequestFilter {
 
         final String host = RestTools.getRemoteAddrFromRequest(grizzlyRequest, trustedProxies);
         final String authHeader = headers.getFirst(HttpHeaders.AUTHORIZATION);
+
+        // make headers available to authenticators, which otherwise have no access to them
+        ThreadContext.put(REQUEST_HEADERS, headers);
 
         final SecurityContext securityContext;
         if (authHeader != null && authHeader.startsWith("Basic")) {

--- a/graylog2-web-interface/src/components/users/UserList.css
+++ b/graylog2-web-interface/src/components/users/UserList.css
@@ -20,3 +20,9 @@
 :local(.help) {
     cursor: help;
 }
+
+:local(.helpHeaderRow) {
+    cursor: help;
+    padding: 0 0 0 2px;
+    display: inline-flex;
+}

--- a/graylog2-web-interface/src/components/users/UserList.jsx
+++ b/graylog2-web-interface/src/components/users/UserList.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { LinkContainer } from 'react-router-bootstrap';
-import { Button, Label, OverlayTrigger, Popover, Tooltip } from 'react-bootstrap';
+import { Button, OverlayTrigger, Popover, Tooltip } from 'react-bootstrap';
 
 import PermissionsMixin from 'util/PermissionsMixin';
 import Routes from 'routing/Routes';
@@ -66,6 +66,21 @@ const UserList = React.createClass({
       case '':
         formattedHeaderCell = <th className="user-type">{header}</th>;
         break;
+      case 'client address': {
+        const popover = (<Popover id="decorators-help" className={UserListStyle.sessionBadgeDetails}>
+          <p className="description">
+            The address of the client used to initially establish the session, not necessarily its current address.
+          </p>
+        </Popover>);
+
+        formattedHeaderCell = (<th>
+          {header}
+          <OverlayTrigger trigger="click" rootClose placement="top" overlay={popover}>
+            <Button bsStyle="link" className={UserListStyle.helpHeaderRow}><i className="fa fa-fw fa-question-circle"/></Button>
+          </OverlayTrigger>
+        </th>);
+        break;
+      }
       case 'actions':
         formattedHeaderCell = <th className="actions">{header}</th>;
         break;
@@ -81,7 +96,7 @@ const UserList = React.createClass({
     if (user.session_active) {
       const popover = (
         <Popover id="session-badge-details" title="Logged in" className={UserListStyle.sessionBadgeDetails}>
-          <div>Last activity: <Timestamp dateTime={user.last_activity} relative /></div>
+          <div>Last activity: <Timestamp dateTime={user.last_activity} relative/></div>
           <div>Client address: {user.client_address}</div>
         </Popover>
       );
@@ -90,11 +105,13 @@ const UserList = React.createClass({
       </OverlayTrigger>);
     }
 
-    const roleBadges = user.roles.map((role) => <span key={role} className={`${UserListStyle.roleBadgeFixes} label label-${role === 'Admin' ? 'info' : 'default'}`} >{role}</span>);
+    const roleBadges = user.roles.map((role) => <span key={role}
+                                                      className={`${UserListStyle.roleBadgeFixes} label label-${role === 'Admin' ? 'info' : 'default'}`}>{role}</span>);
 
     let actions = null;
     if (user.read_only) {
-      const tooltip = <Tooltip id="system-user">System users can only be modified in the Graylog configuration file.</Tooltip>;
+      const tooltip = <Tooltip id="system-user">System users can only be modified in the Graylog configuration
+        file.</Tooltip>;
       actions = (
         <OverlayTrigger placement="left" overlay={tooltip}>
           <span className={UserListStyle.help}>

--- a/graylog2-web-interface/src/components/users/UserList.jsx
+++ b/graylog2-web-interface/src/components/users/UserList.jsx
@@ -105,13 +105,11 @@ const UserList = React.createClass({
       </OverlayTrigger>);
     }
 
-    const roleBadges = user.roles.map((role) => <span key={role}
-                                                      className={`${UserListStyle.roleBadgeFixes} label label-${role === 'Admin' ? 'info' : 'default'}`}>{role}</span>);
+    const roleBadges = user.roles.map((role) => <span key={role} className={`${UserListStyle.roleBadgeFixes} label label-${role === 'Admin' ? 'info' : 'default'}`}>{role}</span>);
 
     let actions = null;
     if (user.read_only) {
-      const tooltip = <Tooltip id="system-user">System users can only be modified in the Graylog configuration
-        file.</Tooltip>;
+      const tooltip = <Tooltip id="system-user">System users can only be modified in the Graylog configuration file.</Tooltip>;
       actions = (
         <OverlayTrigger placement="left" overlay={tooltip}>
           <span className={UserListStyle.help}>


### PR DESCRIPTION
The auth framework does not support updating sessions beyond the last used timestamp.
Especially the host is not resettable after creation.

Users might expect the address to change, but if we want to expose that we need to save this information separately in the future.

This change merely informs the user about this circumstance and makes the headers available internally for some optimization regarding session extension (less DB requests).

Refs #2656