### PR TITLE
Reset users' startpages if referenced stream/dashboard is deleted.

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/bindings/ServerBindings.java
+++ b/graylog2-server/src/main/java/org/graylog2/bindings/ServerBindings.java
@@ -89,6 +89,7 @@ import org.graylog2.system.shutdown.GracefulShutdown;
 import org.graylog2.system.stats.ClusterStatsModule;
 import org.graylog2.users.RoleService;
 import org.graylog2.users.RoleServiceImpl;
+import org.graylog2.users.StartPageCleanupListener;
 import org.graylog2.users.UserImpl;
 
 import javax.ws.rs.container.DynamicFeature;
@@ -207,6 +208,7 @@ public class ServerBindings extends Graylog2Module {
         bind(InputEventListener.class).asEagerSingleton();
         bind(LocalDebugEventListener.class).asEagerSingleton();
         bind(ClusterDebugEventListener.class).asEagerSingleton();
+        bind(StartPageCleanupListener.class).asEagerSingleton();
     }
 
     private void bindSearchResponseDecorators() {

--- a/graylog2-server/src/main/java/org/graylog2/dashboards/events/DashboardDeletedEvent.java
+++ b/graylog2-server/src/main/java/org/graylog2/dashboards/events/DashboardDeletedEvent.java
@@ -1,3 +1,19 @@
+/**
+ * This file is part of Graylog.
+ *
+ * Graylog is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package org.graylog2.dashboards.events;
 
 import com.fasterxml.jackson.annotation.JsonAutoDetect;

--- a/graylog2-server/src/main/java/org/graylog2/dashboards/events/DashboardDeletedEvent.java
+++ b/graylog2-server/src/main/java/org/graylog2/dashboards/events/DashboardDeletedEvent.java
@@ -1,0 +1,20 @@
+package org.graylog2.dashboards.events;
+
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.auto.value.AutoValue;
+
+@AutoValue
+@JsonAutoDetect
+public abstract class DashboardDeletedEvent {
+    private static final String FIELD_DASHBOARD_ID = "dashboard_id";
+
+    @JsonProperty(FIELD_DASHBOARD_ID)
+    public abstract String dashboardId();
+
+    @JsonCreator
+    public static DashboardDeletedEvent create(@JsonProperty(FIELD_DASHBOARD_ID) String dashboardId) {
+        return new AutoValue_DashboardDeletedEvent(dashboardId);
+    }
+}

--- a/graylog2-server/src/main/java/org/graylog2/plugin/database/users/User.java
+++ b/graylog2-server/src/main/java/org/graylog2/plugin/database/users/User.java
@@ -17,6 +17,7 @@
 package org.graylog2.plugin.database.users;
 
 import org.graylog2.plugin.database.Persisted;
+import org.graylog2.rest.models.users.requests.Startpage;
 import org.joda.time.DateTimeZone;
 
 import javax.annotation.Nonnull;
@@ -47,7 +48,7 @@ public interface User extends Persisted {
 
     Map<String, Object> getPreferences();
 
-    Map<String, String> getStartpage();
+    Startpage getStartpage();
 
     long getSessionTimeoutMs();
 
@@ -78,6 +79,8 @@ public interface User extends Persisted {
     void setExternal(boolean external);
 
     void setStartpage(String type, String id);
+
+    void setStartpage(Startpage startpage);
 
     boolean isLocalAdmin();
 

--- a/graylog2-server/src/main/java/org/graylog2/rest/models/users/responses/UserSummary.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/models/users/responses/UserSummary.java
@@ -20,6 +20,7 @@ import com.fasterxml.jackson.annotation.JsonAutoDetect;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.auto.value.AutoValue;
+import org.graylog2.rest.models.users.requests.Startpage;
 
 import javax.annotation.Nullable;
 import java.util.Date;
@@ -67,7 +68,7 @@ public abstract class UserSummary {
 
     @JsonProperty
     @Nullable
-    public abstract Map<String, String> startpage();
+    public abstract Startpage startpage();
 
     @JsonProperty
     @Nullable
@@ -95,7 +96,7 @@ public abstract class UserSummary {
                                      @JsonProperty("session_timeout_ms") @Nullable Long sessionTimeoutMs,
                                      @JsonProperty("read_only") boolean readOnly,
                                      @JsonProperty("external") boolean external,
-                                     @JsonProperty("startpage") @Nullable Map<String, String> startpage,
+                                     @JsonProperty("startpage") @Nullable Startpage startpage,
                                      @JsonProperty("roles") @Nullable Set<String> roles,
                                      @JsonProperty("session_active") boolean sessionActive,
                                      @JsonProperty("last_activity") @Nullable Date lastActivity,

--- a/graylog2-server/src/main/java/org/graylog2/rest/resources/streams/StreamResource.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/resources/streams/StreamResource.java
@@ -62,6 +62,7 @@ import org.graylog2.streams.StreamRouterEngine;
 import org.graylog2.streams.StreamRuleImpl;
 import org.graylog2.streams.StreamRuleService;
 import org.graylog2.streams.StreamService;
+import org.graylog2.streams.events.StreamDeletedEvent;
 import org.graylog2.streams.events.StreamsChangedEvent;
 import org.hibernate.validator.constraints.NotEmpty;
 import org.joda.time.DateTime;
@@ -257,6 +258,7 @@ public class StreamResource extends RestResource {
         final Stream stream = streamService.load(streamId);
         streamService.destroy(stream);
         clusterEventBus.post(StreamsChangedEvent.create(stream.getId()));
+        clusterEventBus.post(StreamDeletedEvent.create(stream.getId()));
     }
 
     @POST

--- a/graylog2-server/src/main/java/org/graylog2/streams/events/StreamDeletedEvent.java
+++ b/graylog2-server/src/main/java/org/graylog2/streams/events/StreamDeletedEvent.java
@@ -1,0 +1,20 @@
+package org.graylog2.streams.events;
+
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.auto.value.AutoValue;
+
+@AutoValue
+@JsonAutoDetect
+public abstract class StreamDeletedEvent {
+    private static final String FIELD_STREAM_ID = "stream_id";
+
+    @JsonProperty(FIELD_STREAM_ID)
+    public abstract String streamId();
+
+    @JsonCreator
+    public static StreamDeletedEvent create(@JsonProperty(FIELD_STREAM_ID) String streamId) {
+        return new AutoValue_StreamDeletedEvent(streamId);
+    }
+}

--- a/graylog2-server/src/main/java/org/graylog2/streams/events/StreamDeletedEvent.java
+++ b/graylog2-server/src/main/java/org/graylog2/streams/events/StreamDeletedEvent.java
@@ -1,3 +1,19 @@
+/**
+ * This file is part of Graylog.
+ *
+ * Graylog is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package org.graylog2.streams.events;
 
 import com.fasterxml.jackson.annotation.JsonAutoDetect;

--- a/graylog2-server/src/main/java/org/graylog2/users/StartPageCleanupListener.java
+++ b/graylog2-server/src/main/java/org/graylog2/users/StartPageCleanupListener.java
@@ -1,3 +1,19 @@
+/**
+ * This file is part of Graylog.
+ *
+ * Graylog is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package org.graylog2.users;
 
 import com.google.common.eventbus.EventBus;

--- a/graylog2-server/src/main/java/org/graylog2/users/StartPageCleanupListener.java
+++ b/graylog2-server/src/main/java/org/graylog2/users/StartPageCleanupListener.java
@@ -1,0 +1,54 @@
+package org.graylog2.users;
+
+import com.google.common.eventbus.EventBus;
+import com.google.common.eventbus.Subscribe;
+import org.graylog2.dashboards.events.DashboardDeletedEvent;
+import org.graylog2.plugin.database.ValidationException;
+import org.graylog2.rest.models.users.requests.Startpage;
+import org.graylog2.shared.users.UserService;
+import org.graylog2.streams.events.StreamDeletedEvent;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.inject.Inject;
+
+public class StartPageCleanupListener {
+    private static final Logger LOG = LoggerFactory.getLogger(StartPageCleanupListener.class);
+
+    private final UserService userService;
+
+    @Inject
+    public StartPageCleanupListener(EventBus serverEventBus,
+                                    UserService userService) {
+        this.userService = userService;
+        serverEventBus.register(this);
+    }
+
+    @Subscribe
+    @SuppressWarnings("unused")
+    public void removeStartpageReferencesIfStreamDeleted(StreamDeletedEvent streamDeletedEvent) {
+        final Startpage deletedStartpage = Startpage.create("stream", streamDeletedEvent.streamId());
+        resetReferencesToStartpage(deletedStartpage);
+    }
+
+    @Subscribe
+    @SuppressWarnings("unused")
+    public void removeStartpageReferencesIfDashboardDeleted(DashboardDeletedEvent dashboardDeletedEvent) {
+        final Startpage deletedStartpage = Startpage.create("dashboard", dashboardDeletedEvent.dashboardId());
+        resetReferencesToStartpage(deletedStartpage);
+    }
+
+    private void resetReferencesToStartpage(Startpage deletedStartpage) {
+        this.userService.loadAll()
+            .stream()
+            .filter(user -> user.getStartpage() != null && user.getStartpage().equals(deletedStartpage))
+            .forEach(user -> {
+                user.setStartpage(null);
+                try {
+                    this.userService.save(user);
+                } catch (ValidationException e) {
+                    LOG.error("Unable to reset start page for user which references deleted start page: ", e);
+                }
+            });
+    }
+}

--- a/graylog2-server/src/main/java/org/graylog2/users/UserImpl.java
+++ b/graylog2-server/src/main/java/org/graylog2/users/UserImpl.java
@@ -35,6 +35,7 @@ import org.graylog2.database.validators.ListValidator;
 import org.graylog2.plugin.database.users.User;
 import org.graylog2.plugin.database.validators.Validator;
 import org.graylog2.plugin.security.PasswordAlgorithm;
+import org.graylog2.rest.models.users.requests.Startpage;
 import org.graylog2.security.PasswordAlgorithmFactory;
 import org.graylog2.shared.security.Permissions;
 import org.joda.time.DateTimeZone;
@@ -194,9 +195,7 @@ public class UserImpl extends PersistedImpl implements User {
     }
 
     @Override
-    public Map<String, String> getStartpage() {
-        final Map<String, String> startpage = new HashMap<>();
-
+    public Startpage getStartpage() {
         if (fields.containsKey(STARTPAGE)) {
             @SuppressWarnings("unchecked")
             final Map<String, String> obj = (Map<String, String>) fields.get(STARTPAGE);
@@ -204,12 +203,11 @@ public class UserImpl extends PersistedImpl implements User {
             final String id = obj.get("id");
 
             if (type != null && id != null) {
-                startpage.put("type", type);
-                startpage.put("id", id);
+                return Startpage.create(type, id);
             }
         }
 
-        return startpage;
+        return null;
     }
 
     @Override
@@ -317,14 +315,19 @@ public class UserImpl extends PersistedImpl implements User {
 
     @Override
     public void setStartpage(final String type, final String id) {
-        final Map<String, String> startpage = new HashMap<>();
-
         if (type != null && id != null) {
-            startpage.put("type", type);
-            startpage.put("id", id);
+            this.setStartpage(Startpage.create(type, id));
         }
+    }
 
-        this.fields.put(STARTPAGE, startpage);
+    @Override
+    public void setStartpage(Startpage startpage) {
+        final HashMap<String, String> startpageMap = new HashMap<>();
+        if (startpage != null) {
+            startpageMap.put("type", startpage.type());
+            startpageMap.put("id", startpage.id());
+        }
+        this.fields.put(STARTPAGE, startpageMap);
     }
 
     public static class LocalAdminUser extends UserImpl {

--- a/graylog2-web-interface/src/pages/StartPage.jsx
+++ b/graylog2-web-interface/src/pages/StartPage.jsx
@@ -1,4 +1,4 @@
-import React, {PropTypes} from 'react';
+import React from 'react';
 import Reflux from 'reflux';
 
 import { Spinner } from 'components/common';
@@ -15,9 +15,9 @@ const GettingStartedActions = ActionsProvider.getActions('GettingStarted');
 
 const StartPage = React.createClass({
   propTypes: {
-    history: PropTypes.object.isRequired,
+    history: React.PropTypes.object.isRequired,
   },
-  mixins: [Reflux.connect(CurrentUserStore), Reflux.listenTo(GettingStartedStore, 'onGettingStartedUpdate')],
+  mixins: [Reflux.listenTo(CurrentUserStore, 'onCurrentUserUpdate'), Reflux.listenTo(GettingStartedStore, 'onGettingStartedUpdate')],
   getInitialState() {
     return {
       gettingStarted: undefined,
@@ -25,6 +25,7 @@ const StartPage = React.createClass({
   },
   componentDidMount() {
     GettingStartedActions.getStatus();
+    CurrentUserStore.reload();
   },
   componentDidUpdate() {
     if (!this._isLoading()) {
@@ -32,7 +33,10 @@ const StartPage = React.createClass({
     }
   },
   onGettingStartedUpdate(state) {
-    this.setState({gettingStarted: state.status});
+    this.setState({ gettingStarted: state.status });
+  },
+  onCurrentUserUpdate(state) {
+    this.setState({ currentUser: state.currentUser });
   },
   _redirect(page) {
     this.props.history.pushState(null, page);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This change adds a listener and the necessary events, which are posted
when a stream or dashboard is deleted. The listener will then reset any
user's startpage if it references the deleted entity.

Also the `StartPage` component reloads the current user before redirecting, so the start page reset also affects logged in users.

## Motivation and Context
As described in #2400, when a user has set a dashboard/stream as start page and that entity is deleted, the user gets an error every login/click on the Graylog logo on the upper left.

Fixes #2400.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
