### PR TITLE
Fix content pack extractor validation

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/bundles/BundleImporter.java
+++ b/graylog2-server/src/main/java/org/graylog2/bundles/BundleImporter.java
@@ -135,7 +135,7 @@ public class BundleImporter {
             createStreams(bundleId, bundle.getStreams(), userName);
             createDashboards(bundleId, bundle.getDashboards(), userName);
         } catch (Exception e) {
-            LOG.error("Error while creating dashboards. Starting rollback.", e);
+            LOG.error("Error while creating entities in content pack. Starting rollback.", e);
             if (!rollback()) {
                 LOG.error("Rollback unsuccessful.");
             }

--- a/graylog2-web-interface/src/components/source-tagging/ConfigurationBundles.jsx
+++ b/graylog2-web-interface/src/components/source-tagging/ConfigurationBundles.jsx
@@ -77,10 +77,15 @@ const ConfigurationBundles = React.createClass({
     reader.onload = (evt) => {
       const request = evt.target.result;
       ConfigurationBundlesActions.create.triggerPromise(request)
-        .then(() => {
-          UserNotification.success('Bundle added successfully', 'Success!');
-          ConfigurationBundlesActions.list();
-        });
+        .then(
+          () => {
+            UserNotification.success('Content pack imported successfully', 'Success!');
+            ConfigurationBundlesActions.list();
+          },
+          () => {
+            UserNotification.error('Error importing content pack, please ensure it is a valid JSON file. Check your ' +
+              'Graylog logs for more information.', 'Could not import content pack');
+          });
     };
 
     reader.readAsText(this.refs.uploadedFile.files[0]);


### PR DESCRIPTION
As described in #2663, applying content packs with a Grok or JSON extractors fail in the current master, as their `target_field` is empty but it is required in the code creating the extractors.

This PR fixes the validation of those extractors, and also adds a couple of cosmetic changes around it: corrects a typo in the logged error when the content pack could not be applied, and shows an error in the web interface if the content pack provided by the user could not be imported (i.e. is not valid JSON).

Fixes #2663.