### PR TITLE
Fix token creation via API browser

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/rest/resources/roles/RolesResource.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/resources/roles/RolesResource.java
@@ -215,7 +215,7 @@ public class RolesResource extends RestResource {
     @AuditLog(object = "role membership", captureResponseEntity = true)
     public Response addMember(@ApiParam(name = "rolename") @PathParam("rolename") String rolename,
                               @ApiParam(name = "username") @PathParam("username") String username,
-                              @ApiParam(name = "JSON Body", value = "Placeholder because PUT requests should have a body. Set to '{}', the content will be ignored.") String body) throws NotFoundException {
+                              @ApiParam(name = "JSON Body", value = "Placeholder because PUT requests should have a body. Set to '{}', the content will be ignored.", defaultValue = "{}") String body) throws NotFoundException {
         checkPermission(RestPermissions.ROLES_EDIT, username);
 
         final User user = userService.load(username);

--- a/graylog2-server/src/main/java/org/graylog2/rest/resources/users/UsersResource.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/resources/users/UsersResource.java
@@ -442,7 +442,8 @@ public class UsersResource extends RestResource {
     @AuditLog(object = "user access token")
     public Token generateNewToken(
             @ApiParam(name = "username", required = true) @PathParam("username") String username,
-            @ApiParam(name = "name", value = "Descriptive name for this token (e.g. 'cronjob') ", required = true) @PathParam("name") String name) {
+            @ApiParam(name = "name", value = "Descriptive name for this token (e.g. 'cronjob') ", required = true) @PathParam("name") String name,
+            @ApiParam(name = "JSON Body", value = "Placeholder because POST requests should have a body. Set to '{}', the content will be ignored.", defaultValue = "{}") String body) {
         final User user = _tokensCheckAndLoadUser(username);
         final AccessToken accessToken = accessTokenService.create(user.getName(), name);
 

--- a/graylog2-server/src/main/java/org/graylog2/shared/rest/documentation/generator/Generator.java
+++ b/graylog2-server/src/main/java/org/graylog2/shared/rest/documentation/generator/Generator.java
@@ -42,6 +42,7 @@ import org.slf4j.LoggerFactory;
 
 import javax.annotation.Nullable;
 import javax.ws.rs.DELETE;
+import javax.ws.rs.DefaultValue;
 import javax.ws.rs.FormParam;
 import javax.ws.rs.GET;
 import javax.ws.rs.HEAD;
@@ -65,6 +66,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
 
+import static com.google.common.base.Strings.isNullOrEmpty;
 import static com.google.common.base.Strings.nullToEmpty;
 
 /**
@@ -308,6 +310,19 @@ public class Generator {
                     param.setDescription(apiParam.value());
                     param.setIsRequired(apiParam.required());
                     param.setType(method.getGenericParameterTypes()[i]);
+
+                    if (!isNullOrEmpty(apiParam.defaultValue())) {
+                        param.setDefaultValue(apiParam.defaultValue());
+                    }
+                }
+
+                if (annotation instanceof DefaultValue) {
+                    final DefaultValue defaultValueAnnotation = (DefaultValue) annotation;
+
+                    // Only set if empty to make sure ApiParam's defaultValue has precedence!
+                    if (isNullOrEmpty(param.getDefaultValue()) && !isNullOrEmpty(defaultValueAnnotation.value())) {
+                        param.setDefaultValue(defaultValueAnnotation.value());
+                    }
                 }
 
                 if (annotation instanceof QueryParam) {
@@ -398,6 +413,7 @@ public class Generator {
         private boolean isRequired;
         private Class type;
         private Kind kind;
+        private String defaultValue;
 
         public void setName(String name) {
             this.name = name;
@@ -460,6 +476,15 @@ public class Generator {
         @JsonProperty("paramType")
         public String getKind() {
             return kind.toString().toLowerCase(Locale.ENGLISH);
+        }
+
+        public void setDefaultValue(String defaultValue) {
+            this.defaultValue = defaultValue;
+        }
+
+        @JsonProperty("defaultValue")
+        public String getDefaultValue() {
+            return this.defaultValue;
         }
 
         public enum Kind {


### PR DESCRIPTION
Add a placholder API param to the token creation resource method.

Fixes #2668 