### PR TITLE
Allow surrounding search to be opened in new tab

### DIFF
--- a/graylog2-web-interface/src/components/search/SurroundingSearchButton.jsx
+++ b/graylog2-web-interface/src/components/search/SurroundingSearchButton.jsx
@@ -37,15 +37,11 @@ const SurroundingSearchButton = React.createClass({
     return fields;
   },
 
-  _onClick(range) {
-    return (e) => {
-      e.preventDefault();
+  _searchLink(range) {
+    const fromTime = moment.unix(this.props.timestamp - Number(range)).toISOString();
+    const toTime = moment.unix(this.props.timestamp + Number(range)).toISOString();
 
-      const fromTime = moment.unix(this.props.timestamp - Number(range)).toISOString();
-      const toTime = moment.unix(this.props.timestamp + Number(range)).toISOString();
-
-      SearchStore.searchSurroundingMessages(this.props.id, fromTime, toTime, this._buildFilterFields());
-    };
+    return SearchStore.searchSurroundingMessages(this.props.id, fromTime, toTime, this._buildFilterFields());
   },
 
   render() {
@@ -54,7 +50,7 @@ const SurroundingSearchButton = React.createClass({
       .sort((a, b) => naturalSort(a, b))
       .map((key, idx) => {
         return (
-          <MenuItem key={idx} onClick={this._onClick(key)}>{timeRangeOptions[key]}</MenuItem>
+          <MenuItem key={idx} href={this._searchLink(key)}>{timeRangeOptions[key]}</MenuItem>
         );
       });
 

--- a/graylog2-web-interface/src/stores/search/SearchStore.ts
+++ b/graylog2-web-interface/src/stores/search/SearchStore.ts
@@ -365,7 +365,7 @@ class SearchStore {
         fields: originalParams.fields,
       };
 
-      URLUtils.openLink(this.searchBaseLocation('index') + '?' + Qs.stringify(params))
+      return this.searchBaseLocation('index') + '?' + Qs.stringify(params);
     }
 }
 


### PR DESCRIPTION
Use links in show surrounding messages dropdown, allowing users to open
those searches in new tabs or windows.

Fixes #2531