### PR TITLE
Reformatting component, adding error handler for fetching dashboard.

### DIFF
--- a/graylog2-web-interface/src/pages/ShowDashboardPage.jsx
+++ b/graylog2-web-interface/src/pages/ShowDashboardPage.jsx
@@ -63,7 +63,7 @@ const ShowDashboardPage = React.createClass({
         }
       }, (response) => {
         if (response.additional && response.additional.status === 404) {
-          UserNotification.error(`Unable to find a dashboard with the id <${dashboardId}>. Maybe it was deleted in the mean time.`);
+          UserNotification.error(`Unable to find a dashboard with the id <${dashboardId}>. Maybe it was deleted in the meantime.`);
           this.props.history.pushState(null, Routes.DASHBOARDS);
         }
       });


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This change adds an error handler for the `DashboardsStore.get()` call in the `ShowDashboardPage` which shows an error message and redirects to the dashboard list, if the call returns a 404.

## Motivation and Context
Before this change, going to a nonexisting dashboard link, the page would just show a spinner.

Fixes #2576 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
