### PR TITLE
Reloading `CurrentUserStore` when updated user is the current user.

### DIFF
--- a/graylog2-web-interface/src/components/users/UserForm.jsx
+++ b/graylog2-web-interface/src/components/users/UserForm.jsx
@@ -111,6 +111,9 @@ const UserForm = React.createClass({
       if (this.isPermitted(this.state.currentUser.permissions, ['users:list'])) {
         this.props.history.replaceState(null, Routes.SYSTEM.AUTHENTICATION.USERS.LIST);
       }
+      if (this.props.user.username === this.state.currentUser.username) {
+        CurrentUserStore.reload();
+      }
     }, () => {
       UserNotification.error('Could not update the user. Please check your logs for more information.', 'Updating user failed');
     });


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
The `UserForm` component now triggers a reload of the `CurrentUserStore` when it is updating the user which is currently logged in.

## Motivation and Context
Before this change, the current user object was stale after updating it.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

Fixes #2705.