### PR TITLE
Let specific stores reuse promises if request is in progress.

### DIFF
--- a/graylog2-web-interface/src/routing/ApiRoutes.js
+++ b/graylog2-web-interface/src/routing/ApiRoutes.js
@@ -30,6 +30,7 @@ const ApiRoutes = {
     total: () => { return { url: '/count/total' }; },
   },
   ClusterApiResource: {
+    list: () => { return { url: '/system/cluster/nodes' }; },
     node: () => { return { url: '/system/cluster/node' }; },
   },
   DashboardsApiController: {

--- a/graylog2-web-interface/src/stores/metrics/MetricsStore.js
+++ b/graylog2-web-interface/src/stores/metrics/MetricsStore.js
@@ -17,6 +17,7 @@ const MetricsStore = Reflux.createStore({
   namespace: 'org',
   registrations: {},
   globalRegistrations: {},
+  promises: {},
 
   init() {
     this.listenTo(NodesStore, this.updateNodes);
@@ -37,54 +38,67 @@ const MetricsStore = Reflux.createStore({
 
     return result.then(() => accumulator);
   },
-  list() {
-    if (!SessionStore.isLoggedIn()) {
-      return;
-    }
+  _metricsToFetch(localRegistrations, globalRegistrations) {
     const metricsToFetch = {};
 
     // First collect all node metric registrations
-    Object.keys(this.registrations)
-      .filter((nodeId) => Object.keys(this.registrations[nodeId].length > 0))
+    Object.keys(localRegistrations)
+      .filter((nodeId) => Object.keys(localRegistrations[nodeId].length > 0))
       .forEach((nodeId) => {
-        Object.keys(this.registrations[nodeId])
-          .filter((metricName) => this.registrations[nodeId][metricName] > 0)
+        Object.keys(localRegistrations[nodeId])
+          .filter((metricName) => localRegistrations[nodeId][metricName] > 0)
           .forEach((metricName) => {
             metricsToFetch[metricName] = 1;
           });
       });
 
     // Then collect all global metric registrations
-    Object.keys(this.globalRegistrations)
-      .filter((metricName) => this.globalRegistrations[metricName] > 0)
+    Object.keys(globalRegistrations)
+      .filter((metricName) => globalRegistrations[metricName] > 0)
       .forEach((metricName) => {
         metricsToFetch[metricName] = 1;
       });
+    return metricsToFetch;
+  },
+  _buildMetricsFromResponse(response) {
+    const metrics = {};
+    Object.keys(response)
+      .forEach((nodeId) => {
+        const nodeMetrics = {};
 
-    const url = URLUtils.qualifyUrl(ApiRoutes.ClusterMetricsApiController.multipleAllNodes().url);
-    const promise = fetch('POST', url, { metrics: Object.keys(metricsToFetch) });
-
-    promise.then((response) => {
-      const metrics = {};
-      Object.keys(response)
-        .forEach((nodeId) => {
-          const nodeMetrics = {};
-
-          if (!response[nodeId]) {
-            return;
-          }
-          response[nodeId].metrics.forEach((metric) => {
-            nodeMetrics[metric.full_name] = metric;
-          });
-
-          metrics[nodeId] = nodeMetrics;
+        if (!response[nodeId]) {
+          return;
+        }
+        response[nodeId].metrics.forEach((metric) => {
+          nodeMetrics[metric.full_name] = metric;
         });
-      this.trigger({ metrics: metrics });
-      this.metrics = metrics;
-      return metrics;
-    });
 
-    MetricsActions.list.promise(promise);
+        metrics[nodeId] = nodeMetrics;
+      });
+
+    return metrics;
+  },
+  list() {
+    if (!SessionStore.isLoggedIn()) {
+      return;
+    }
+
+    const metricsToFetch = this._metricsToFetch(this.registrations, this.globalRegistrations);
+    const url = URLUtils.qualifyUrl(ApiRoutes.ClusterMetricsApiController.multipleAllNodes().url);
+
+    if (!this.promises.list) {
+      const promise = fetch('POST', url, { metrics: Object.keys(metricsToFetch) }).finally(() => delete this.promises.list);
+
+      promise.then((response) => {
+        this.metrics = this._buildMetricsFromResponse(response);
+        this.trigger({ metrics: this.metrics });
+        return this.metrics;
+      });
+      this.promises.list = promise;
+    }
+
+    MetricsActions.list.promise(this.promises.list);
+    return this.promises.list;
   },
   names() {
     if (!this.nodes) {

--- a/graylog2-web-interface/src/stores/notifications/NotificationsStore.js
+++ b/graylog2-web-interface/src/stores/notifications/NotificationsStore.js
@@ -10,6 +10,7 @@ const NotificationsActions = ActionsProvider.getActions('Notifications');
 const NotificationsStore = Reflux.createStore({
   listenables: [NotificationsActions],
   notifications: undefined,
+  promises: {},
 
   init() {
     this.list();
@@ -23,11 +24,14 @@ const NotificationsStore = Reflux.createStore({
   },
   list() {
     const url = URLUtils.qualifyUrl(ApiRoutes.NotificationsApiController.list().url);
-    const promise = new Builder('GET', url)
-      .authenticated()
-      .setHeader('X-Graylog-No-Session-Extension', 'true')
-      .json()
-      .build();
+    const promise = this.promises.list || new Builder('GET', url)
+        .authenticated()
+        .setHeader('X-Graylog-No-Session-Extension', 'true')
+        .json()
+        .build()
+        .finally(() => delete this.promises.list);
+
+    this.promises.list = promise;
 
     NotificationsActions.list.promise(promise);
   },


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This prevents buildup of requests to server if mttr is too high, which
could lead to overload of server. Instead just wait for the current
request to finish and reuse the currently running one for response
handling.

Fixes #2625.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
