### PR TITLE
Handle indexer cluster down in web interface

### DIFF
--- a/graylog2-web-interface/src/components/indexers/IndexerClusterHealth.jsx
+++ b/graylog2-web-interface/src/components/indexers/IndexerClusterHealth.jsx
@@ -12,6 +12,11 @@ import { IndexerClusterHealthSummary } from 'components/indexers';
 
 const IndexerClusterHealth = React.createClass({
   mixins: [Reflux.connect(IndexerClusterStore)],
+
+  componentDidMount() {
+    IndexerClusterStore.update();
+  },
+
   render() {
     const health = this.state.health;
 

--- a/graylog2-web-interface/src/pages/IndicesPage.jsx
+++ b/graylog2-web-interface/src/pages/IndicesPage.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import Reflux from 'reflux';
-import { Alert, Col, Row } from 'react-bootstrap';
+import { Alert, Col, Row, Panel } from 'react-bootstrap';
 import numeral from 'numeral';
 
 import ActionsProvider from 'injection/ActionsProvider';
@@ -39,26 +39,62 @@ const IndicesPage = React.createClass({
   _totalIndexCount() {
     return Object.keys(this.state.indexerOverview.indices).length;
   },
+  _renderElasticsearchUnavailableInformation() {
+    return (
+      <Row className="content">
+        <Col md={8} mdOffset={2}>
+          <div className="top-margin">
+            <Panel bsStyle="danger"
+                   header={<span><i className="fa fa-exclamation-triangle" /> Indices overview unavailable</span>}>
+              <p>
+                We could not get the indices overview information. This usually means there was a problem
+                connecting to Elasticsearch, and <strong>you should ensure Elasticsearch is up and reachable from
+                Graylog</strong>.
+              </p>
+              <p>
+                Graylog will continue storing your messages in its journal, but you will not be able to search on them
+                until Elasticsearch is reachable again.
+              </p>
+            </Panel>
+          </div>
+        </Col>
+      </Row>
+    );
+  },
   render() {
+    const pageHeader = (
+      <PageHeader title="Indices">
+        <span>
+          This is an overview of all indices (message stores) Graylog is currently taking in account
+          for searches and analysis.
+        </span>
+
+        <span>
+          You can learn more about the index model in the{' '}
+          <DocumentationLink page={DocsHelper.PAGES.INDEX_MODEL} text="documentation" />
+        </span>
+
+        <IndicesMaintenanceDropdown />
+      </PageHeader>
+    );
+
+    if (this.state.indexerOverviewError) {
+      return (
+        <span>
+          {pageHeader}
+          {this._renderElasticsearchUnavailableInformation()}
+        </span>
+      );
+    }
+
     if (!this.state.indexerOverview || !this.state.indexDetails.closedIndices) {
       return <Spinner />;
     }
+
     const deflectorInfo = this.state.indexerOverview.deflector;
     return (
       <span>
-        <PageHeader title="Indices">
-          <span>
-            This is an overview of all indices (message stores) Graylog is currently taking in account
-            for searches and analysis.
-          </span>
-
-          <span>
-            You can learn more about the index model in the{' '}
-            <DocumentationLink page={DocsHelper.PAGES.INDEX_MODEL} text="documentation" />
-          </span>
-
-          <IndicesMaintenanceDropdown />
-        </PageHeader>
+        {pageHeader}
 
         <Row className="content">
           <Col md={12}>

--- a/graylog2-web-interface/src/stores/indexers/IndexerClusterStore.js
+++ b/graylog2-web-interface/src/stores/indexers/IndexerClusterStore.js
@@ -11,13 +11,16 @@ const IndexerClusterStore = Reflux.createStore({
   listenables: [IndexerClusterActions],
   state: {},
   init() {
+    this.update();
+  },
+  update() {
     Promise.all([
       this.health().then((health) => {
         this.state.health = health;
       }),
       this.name().then((response) => {
         this.state.name = response.name;
-      })
+      }),
     ]).then(() => this.trigger(this.state));
   },
   getInitialState() {

--- a/graylog2-web-interface/src/stores/indexers/IndexerOverviewStore.js
+++ b/graylog2-web-interface/src/stores/indexers/IndexerOverviewStore.js
@@ -12,9 +12,18 @@ const IndexerOverviewStore = Reflux.createStore({
   list() {
     const url = URLUtils.qualifyUrl(ApiRoutes.IndexerOverviewApiResource.list().url);
     const promise = fetch('GET', url);
-    promise.then((response) => {
-      this.trigger({ indexerOverview: response });
-    });
+    promise.then(
+      (response) => {
+        this.trigger({ indexerOverview: response, indexerOverviewError: undefined });
+      },
+      (error) => {
+        if (error.additional && error.additional.status === 503) {
+          const errorMessage = (error.additional.body && error.additional.body.message ?
+            error.additional.body.message :
+            'Elasticsearch is unavailable. Check your configuration and logs for more information.');
+          this.trigger({ indexerOverviewError: errorMessage });
+        }
+      });
 
     IndexerOverviewActions.list.promise(promise);
 


### PR DESCRIPTION
As described in #2623, when ES is not reachable, going to the indices page in the web interface only renders a grey page with a loading spinner.

This PR handles the situation when ES is not available and displays a warning dialogue with some information.

I also saw that the ES cluster health was not being refreshed in the system overview page, and now we update the information when the `IndexerClusterHealth` component is mounted.