### PR TITLE
Let widget replay search button open in a new tab or window

### DIFF
--- a/graylog2-web-interface/src/components/inputs/InputListItem.jsx
+++ b/graylog2-web-interface/src/components/inputs/InputListItem.jsx
@@ -60,7 +60,7 @@ const InputListItem = React.createClass({
     if (this.isPermitted(this.props.permissions, ['searches:relative'])) {
       actions.push(
         <LinkContainer key={`received-messages-${this.props.input.id}`}
-                       to={Routes.search_with_query(`gl2_source_input:${this.props.input.id}`, 'relative', 28800)}>
+                       to={Routes.search(`gl2_source_input:${this.props.input.id}`, { relative: 28800 })}>
           <Button bsStyle="info">Show received messages</Button>
         </LinkContainer>
       );

--- a/graylog2-web-interface/src/components/widgets/Widget.jsx
+++ b/graylog2-web-interface/src/components/widgets/Widget.jsx
@@ -177,9 +177,6 @@ const Widget = React.createClass({
 
     return URLUtils.appPrefixed(path + '?' + queryString);
   },
-  _replaySearch(e) {
-    URLUtils.openLink(this.replayUrl(), e.metaKey || e.ctrlKey);
-  },
   _showConfig() {
     this.refs.configModal.open();
   },
@@ -226,10 +223,10 @@ const Widget = React.createClass({
 
         <WidgetFooter ref="widgetFooter"
                       locked={this.props.locked}
-                      onReplaySearch={this._replaySearch}
                       onShowConfig={this._showConfig}
                       onEditConfig={this._showEditConfig}
-                      onDelete={this.deleteWidget}/>
+                      onDelete={this.deleteWidget}
+                      replayHref={this.replayUrl()}/>
         {this.props.locked ? showConfigModal : editConfigModal}
       </div>
     );

--- a/graylog2-web-interface/src/components/widgets/Widget.jsx
+++ b/graylog2-web-interface/src/components/widgets/Widget.jsx
@@ -1,10 +1,7 @@
 import React, {PropTypes} from 'react';
 import ReactDOM from 'react-dom';
 import $ from 'jquery';
-import Qs from 'qs';
 import { PluginStore } from 'graylog-web-plugin/plugin';
-
-import URLUtils from 'util/URLUtils';
 
 import { WidgetConfigModal, WidgetEditConfigModal, WidgetFooter, WidgetHeader, WidgetVisualizationNotFound } from 'components/widgets';
 
@@ -13,6 +10,8 @@ const WidgetsStore = StoreProvider.getStore('Widgets');
 
 import ActionsProvider from 'injection/ActionsProvider';
 const WidgetsActions = ActionsProvider.getActions('Widgets');
+
+import Routes from 'routing/Routes';
 
 const Widget = React.createClass({
   propTypes: {
@@ -137,45 +136,37 @@ const Widget = React.createClass({
       computationTimeRange: this.state.computationTimeRange,
     });
   },
-  _getUrlPath() {
-    if (this._isBoundToStream()) {
-      return `/streams/${this.props.widget.config.stream_id}/search`;
-    }
-
-    return '/search';
-  },
-  _getUrlQueryString() {
+  _getTimeRange() {
     const config = this.props.widget.config;
     const rangeType = config.timerange.type;
 
-    const query = {
-      q: config.query,
+    const timeRange = {
       rangetype: rangeType,
-      interval: config.interval,
     };
     switch (rangeType) {
       case 'relative':
-        query[rangeType] = config.timerange.range;
+        timeRange[rangeType] = config.timerange.range;
         break;
       case 'absolute':
-        query.from = config.timerange.from;
-        query.to = config.timerange.to;
+        timeRange.from = config.timerange.from;
+        timeRange.to = config.timerange.to;
         break;
       case 'keyword':
-        query[rangeType] = config.timerange.keyword;
+        timeRange[rangeType] = config.timerange.keyword;
         break;
       default:
-        // do nothing
+      // do nothing
     }
 
-    return Qs.stringify(query);
+    return timeRange;
   },
   replayUrl() {
-    // TODO: replace with react router link
-    const path = this._getUrlPath();
-    const queryString = this._getUrlQueryString();
+    const config = this.props.widget.config;
+    if (this._isBoundToStream()) {
+      return Routes.stream_search(this.props.widget.config.stream_id, config.query, this._getTimeRange(), config.interval);
+    }
 
-    return URLUtils.appPrefixed(path + '?' + queryString);
+    return Routes.search(config.query, this._getTimeRange(), config.interval);
   },
   _showConfig() {
     this.refs.configModal.open();

--- a/graylog2-web-interface/src/components/widgets/WidgetFooter.jsx
+++ b/graylog2-web-interface/src/components/widgets/WidgetFooter.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { Button } from 'react-bootstrap';
 
 const WidgetFooter = React.createClass({
   propTypes: {
@@ -28,18 +29,14 @@ const WidgetFooter = React.createClass({
     const lockedActions = (
       <div className="actions">
         <div className="widget-replay">
-          <button className="btn btn-mini btn-link btn-text"
-                  title="Replay search"
-                  onClick={this._replaySearch}>
+          <Button bsStyle="link" className="btn-text" title="Replay search" onClick={this._replaySearch}>
             <i className="fa fa-play"/>
-          </button>
+          </Button>
         </div>
         <div className="widget-info">
-          <button className="btn btn-mini btn-link btn-text"
-                  title="Show widget configuration"
-                  onClick={this._showConfig}>
+          <Button bsStyle="link" className="btn-text" title="Show widget configuration" onClick={this._showConfig}>
             <i className="fa fa-info-circle"/>
-          </button>
+          </Button>
         </div>
       </div>
     );
@@ -47,18 +44,14 @@ const WidgetFooter = React.createClass({
     const unlockedActions = (
       <div className="actions">
         <div className="widget-delete">
-          <button className="btn btn-mini btn-link btn-text"
-                  title="Delete widget"
-                  onClick={this._delete}>
+          <Button bsStyle="link" className="btn-text" title="Delete widget" onClick={this._delete}>
             <i className="fa fa-trash"/>
-          </button>
+          </Button>
         </div>
         <div className="widget-edit">
-          <button className="btn btn-mini btn-link btn-text"
-                  title="Edit widget"
-                  onClick={this._editConfig}>
+          <Button bsStyle="link" className="btn-text" title="Edit widget" onClick={this._editConfig}>
             <i className="fa fa-pencil"/>
-          </button>
+          </Button>
         </div>
       </div>
     );

--- a/graylog2-web-interface/src/components/widgets/WidgetFooter.jsx
+++ b/graylog2-web-interface/src/components/widgets/WidgetFooter.jsx
@@ -6,12 +6,8 @@ const WidgetFooter = React.createClass({
     locked: React.PropTypes.bool.isRequired,
     onDelete: React.PropTypes.func.isRequired,
     onEditConfig: React.PropTypes.func.isRequired,
-    onReplaySearch: React.PropTypes.func.isRequired,
     onShowConfig: React.PropTypes.func.isRequired,
-  },
-  _replaySearch(e) {
-    e.preventDefault();
-    this.props.onReplaySearch(e);
+    replayHref: React.PropTypes.string.isRequired,
   },
   _showConfig(e) {
     e.preventDefault();
@@ -29,7 +25,7 @@ const WidgetFooter = React.createClass({
     const lockedActions = (
       <div className="actions">
         <div className="widget-replay">
-          <Button bsStyle="link" className="btn-text" title="Replay search" onClick={this._replaySearch}>
+          <Button bsStyle="link" className="btn-text" title="Replay search" href={this.props.replayHref}>
             <i className="fa fa-play"/>
           </Button>
         </div>

--- a/graylog2-web-interface/src/routing/Routes.jsx
+++ b/graylog2-web-interface/src/routing/Routes.jsx
@@ -98,12 +98,33 @@ const Routes = {
     route.query(queryParams);
     return route.resource();
   },
+  _common_search_url: (resource, query, timeRange, resolution) => {
+    const route = new URI(resource);
+    const queryParams = {
+      q: query,
+      interval: resolution,
+    };
+
+    if (timeRange) {
+      Object.keys(timeRange).forEach(key => {
+        queryParams[key] = timeRange[key];
+      });
+    }
+
+    route.query(queryParams);
+    return route.resource();
+  },
+  search: (query, timeRange, resolution) => {
+    return Routes._common_search_url(Routes.SEARCH, query, timeRange, resolution);
+  },
   message_show: (index, messageId) => `/messages/${index}/${messageId}`,
   stream_edit: (streamId) => `/streams/${streamId}/edit`,
   stream_edit_example: (streamId, index, messageId) => `${Routes.stream_edit(streamId)}?index=${index}&message_id=${messageId}`,
   stream_outputs: (streamId) => `/streams/${streamId}/outputs`,
   stream_alerts: (streamId) => `/streams/${streamId}/alerts`,
-  stream_search: (streamId) => `/streams/${streamId}/search`,
+  stream_search: (streamId, query, timeRange, resolution) => {
+    return Routes._common_search_url(`${Routes.STREAMS}/${streamId}/search`, query, timeRange, resolution);
+  },
   legacy_stream_search: (streamId) => `/streams/${streamId}/messages`,
 
   dashboard_show: (dashboardId) => `/dashboards/${dashboardId}`,


### PR DESCRIPTION
This PR fixes issue #2725, by changing the widget replay search button with a link, that allows to be opened in a new tab or window in a more standard way.

I also decided to take care of the long overdue task of moving the logic building the replay URL to the `Routes` object, which is a better place for it. This still needs a bit of clean up, as the incomplete (and now unnecessary) `Routes.search_with_query` is not needed any more, but is still used in the collector plugin. I'll take care of removing the call on the plugin and cleaning up the function afterwards.