### PR TITLE
Prevent NPE and verbose logging if converter returns null

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/plugin/inputs/Extractor.java
+++ b/graylog2-server/src/main/java/org/graylog2/plugin/inputs/Extractor.java
@@ -239,15 +239,14 @@ public abstract class Extractor implements EmbeddedPersistable {
                     continue;
                 }
 
+                final Object convertedValue = converter.convert((String) msg.getField(targetField));
                 if (!converter.buildsMultipleFields()) {
-                    final Object converted = converter.convert((String) msg.getField(targetField));
-
                     // We have arrived here if no exception was thrown and can safely replace the original field.
                     msg.removeField(targetField);
-                    msg.addField(targetField, converted);
-                } else {
+                    msg.addField(targetField, convertedValue);
+                } else if (convertedValue instanceof Map) {
                     @SuppressWarnings("unchecked")
-                    final Map<String, Object> additionalFields = new HashMap<>((Map<String, Object>) converter.convert((String) msg.getField(targetField)));
+                    final Map<String, Object> additionalFields = new HashMap<>((Map<String, Object>) convertedValue);
                     for (final String reservedField : Message.RESERVED_FIELDS) {
                         if (additionalFields.containsKey(reservedField)) {
                             if (LOG.isDebugEnabled()) {

--- a/graylog2-server/src/test/java/org/graylog2/plugin/inputs/ExtractorTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/plugin/inputs/ExtractorTest.java
@@ -893,6 +893,32 @@ public class ExtractorTest {
         assertThat(extractor.getConverterExceptionCount()).isEqualTo(1);
     }
 
+    @Test
+    public void testConvertersWithMultipleFieldsAndNull() throws Exception {
+        final Converter converter = new TestConverter.Builder()
+                .multiple(true)
+                .callback(new Function<Object, Object>() {
+                    @Nullable
+                    @Override
+                    public Object apply(Object input) {
+                        return null;
+                    }
+                })
+                .build();
+
+        final TestExtractor extractor = new TestExtractor.Builder()
+                .converters(Collections.singletonList(converter))
+                .callback(() -> new Result[]{new Result("1", -1, -1)})
+                .build();
+
+        final Message msg = createMessage("the message");
+
+        extractor.runExtractor(msg);
+
+        assertThat(msg.getField("message")).isEqualTo("the message");
+        assertThat(extractor.getConverterExceptionCount()).isEqualTo(0L);
+    }
+
     private Message createMessage(String message) {
         return new Message(message, "localhost", DateTime.now(UTC));
     }


### PR DESCRIPTION
Converters can return `null` which should be properly handled by the `Extractor` class instead of just catching the "exception" (which really isn't one).

Refs #2717