### PR TITLE
Disable editing controls for decorator if user lacks permissions.

### DIFF
--- a/graylog2-web-interface/public/stylesheets/graylog2.less
+++ b/graylog2-web-interface/public/stylesheets/graylog2.less
@@ -2733,9 +2733,10 @@ ul.pill-list > li {
   height: 1000px;
 }
 
-.sortable-list {
+.sortable-list-cursor {
   cursor: move;
-
+}
+.sortable-list {
   .dragging {
     opacity: 0.5;
   }

--- a/graylog2-web-interface/src/components/common/SortableList.jsx
+++ b/graylog2-web-interface/src/components/common/SortableList.jsx
@@ -7,9 +7,16 @@ import SortableListItem from './SortableListItem';
 
 const SortableList = React.createClass({
   propTypes: {
+    disableDragging: React.PropTypes.bool,
     items: PropTypes.arrayOf(PropTypes.object).isRequired,
     onMoveItem: PropTypes.func,
   },
+  getDefaultProps() {
+    return {
+      disableDragging: false,
+    };
+  },
+
   getInitialState() {
     return {
       items: this.props.items,
@@ -31,13 +38,17 @@ const SortableList = React.createClass({
   render() {
     const formattedItems = this.state.items.map((item, idx) => {
       return (
-        <SortableListItem key={`sortable-list-item-${item.id}`} index={idx} id={item.id} content={item.title}
+        <SortableListItem key={`sortable-list-item-${item.id}`}
+                          disableDragging={this.props.disableDragging}
+                          index={idx}
+                          id={item.id}
+                          content={item.title}
                           moveItem={this._moveItem}/>
       );
     });
 
     return (
-      <ListGroup className="sortable-list">
+      <ListGroup className={ this.props.disableDragging ? "sortable-list" : "sortable-list sortable-list-cursor"}>
         {formattedItems}
       </ListGroup>
     );

--- a/graylog2-web-interface/src/components/common/SortableListItem.jsx
+++ b/graylog2-web-interface/src/components/common/SortableListItem.jsx
@@ -1,6 +1,6 @@
-import React, {PropTypes} from 'react';
+import React from 'react';
 import ReactDOM from 'react-dom';
-import {ListGroupItem} from 'react-bootstrap';
+import { ListGroupItem } from 'react-bootstrap';
 import { DragSource, DropTarget } from 'react-dnd';
 
 import SortableListItemStyle from '!style!css!components/common/SortableListItem.css';
@@ -81,15 +81,22 @@ function collectTarget(connect, monitor) {
 
 const SortableListItem = React.createClass({
   propTypes: {
-    connectDragSource: PropTypes.func.isRequired,
-    connectDropTarget: PropTypes.func.isRequired,
-    index: PropTypes.number.isRequired,
-    isDragging: PropTypes.bool.isRequired,
-    isOver: PropTypes.bool.isRequired,
-    id: PropTypes.any.isRequired,
-    content: PropTypes.any.isRequired,
-    moveItem: PropTypes.func.isRequired,
+    connectDragSource: React.PropTypes.func.isRequired,
+    connectDropTarget: React.PropTypes.func.isRequired,
+    content: React.PropTypes.any.isRequired,
+    disableDragging: React.PropTypes.bool,
+    index: React.PropTypes.number.isRequired,
+    isDragging: React.PropTypes.bool.isRequired,
+    isOver: React.PropTypes.bool.isRequired,
+    id: React.PropTypes.any.isRequired,
+    moveItem: React.PropTypes.func.isRequired,
   },
+  getDefaultProps() {
+    return {
+      disableDragging: false,
+    };
+  },
+
   render() {
     const { content, isDragging, isOver, connectDragSource, connectDropTarget } = this.props;
     const classes = [SortableListItemStyle.listGroupItem];
@@ -100,16 +107,20 @@ const SortableListItem = React.createClass({
       classes.push('over');
     }
 
-    return connectDragSource(connectDropTarget(
+    const handle = <span className={SortableListItemStyle.itemHandle}><i className="fa fa-sort" /></span>;
+
+    const component = (
       <div className="sortable-list-item">
         <ListGroupItem className={classes.join(' ')}>
           <div>
-            <span className={SortableListItemStyle.itemHandle}><i className="fa fa-sort" /></span>
+            {this.props.disableDragging ? null : handle}
             {content}
           </div>
         </ListGroupItem>
       </div>
-    ));
+    );
+
+    return this.props.disableDragging ? component : connectDragSource(connectDropTarget(component));
   },
 });
 

--- a/graylog2-web-interface/src/components/search/AddDecoratorButton.jsx
+++ b/graylog2-web-interface/src/components/search/AddDecoratorButton.jsx
@@ -18,16 +18,15 @@ import DecoratorStyles from '!style!css!components/search/decoratorStyles.css';
 const AddDecoratorButton = React.createClass({
   propTypes: {
     nextOrder: React.PropTypes.number.isRequired,
-    stream: React.PropTypes.string.isRequired,
+    stream: React.PropTypes.string,
     disabled: React.PropTypes.bool,
   },
+  mixins: [Reflux.connect(DecoratorsStore), PureRenderMixin],
   getDefaultProps() {
     return {
       disabled: false,
     };
   },
-
-  mixins: [Reflux.connect(DecoratorsStore), PureRenderMixin],
   getInitialState() {
     return {
       typeDefinition: {},

--- a/graylog2-web-interface/src/components/search/AddDecoratorButton.jsx
+++ b/graylog2-web-interface/src/components/search/AddDecoratorButton.jsx
@@ -17,9 +17,16 @@ import DecoratorStyles from '!style!css!components/search/decoratorStyles.css';
 
 const AddDecoratorButton = React.createClass({
   propTypes: {
-    nextOrder: React.PropTypes.number,
-    stream: React.PropTypes.string,
+    nextOrder: React.PropTypes.number.isRequired,
+    stream: React.PropTypes.string.isRequired,
+    disabled: React.PropTypes.bool,
   },
+  getDefaultProps() {
+    return {
+      disabled: false,
+    };
+  },
+
   mixins: [Reflux.connect(DecoratorsStore), PureRenderMixin],
   getInitialState() {
     return {
@@ -74,9 +81,10 @@ const AddDecoratorButton = React.createClass({
                   onValueChange={this._onTypeChange}
                   options={decoratorTypes}
                   matchProp="label"
+                  disabled={this.props.disabled}
                   value={this.state.typeName} />
         </div>
-        <Button bsStyle="success" disabled={!this.state.typeName} onClick={this._openModal}>Apply</Button>
+        <Button bsStyle="success" disabled={!this.state.typeName || this.props.disabled} onClick={this._openModal}>Apply</Button>
         {this.state.typeName && configurationForm}
       </div>
     );

--- a/graylog2-web-interface/src/components/search/DecoratorList.jsx
+++ b/graylog2-web-interface/src/components/search/DecoratorList.jsx
@@ -1,0 +1,34 @@
+import React from 'react';
+import { Alert } from 'react-bootstrap';
+
+import { SortableList } from 'components/common';
+
+import DecoratorStyles from '!style!css!components/search/decoratorStyles.css';
+
+const DecoratorList = React.createClass({
+  propTypes: {
+    decorators: React.PropTypes.arrayOf(React.PropTypes.object).isRequired,
+    disableDragging: React.PropTypes.bool,
+    onReorder: React.PropTypes.func,
+  },
+
+  _onReorderWrapper(...args) {
+    if (this.props.onReorder) {
+      this.props.onReorder(...args);
+    }
+  },
+  render() {
+    if (!this.props.decorators || this.props.decorators.length === 0) {
+      return (
+        <Alert bsStyle="info" className={DecoratorStyles.noDecoratorsAlert}>
+          <i className="fa fa-info-circle"/>&nbsp;No decorators configured.
+        </Alert>
+      );
+    }
+    return (
+      <SortableList items={this.props.decorators} onMoveItem={this._onReorder} disableDragging={this.props.disableDragging}/>
+    );
+  },
+});
+
+export default DecoratorList;

--- a/graylog2-web-interface/src/components/search/DecoratorList.jsx
+++ b/graylog2-web-interface/src/components/search/DecoratorList.jsx
@@ -26,7 +26,7 @@ const DecoratorList = React.createClass({
       );
     }
     return (
-      <SortableList items={this.props.decorators} onMoveItem={this._onReorder} disableDragging={this.props.disableDragging}/>
+      <SortableList items={this.props.decorators} onMoveItem={this._onReorderWrapper} disableDragging={this.props.disableDragging}/>
     );
   },
 });

--- a/graylog2-web-interface/src/components/search/DecoratorSidebar.jsx
+++ b/graylog2-web-interface/src/components/search/DecoratorSidebar.jsx
@@ -3,12 +3,14 @@ import ReactDOM from 'react-dom';
 import Reflux from 'reflux';
 import { Button, OverlayTrigger, Popover } from 'react-bootstrap';
 
-import { SortableList, Spinner } from 'components/common';
-import { AddDecoratorButton, Decorator } from 'components/search';
+import { Spinner } from 'components/common';
+import { AddDecoratorButton, Decorator, DecoratorList } from 'components/search';
 import DocsHelper from 'util/DocsHelper';
+import PermissionsMixin from 'util/PermissionsMixin';
 
 import StoreProvider from 'injection/StoreProvider';
 const DecoratorsStore = StoreProvider.getStore('Decorators');
+const CurrentUserStore = StoreProvider.getStore('CurrentUser');
 
 import ActionsProvider from 'injection/ActionsProvider';
 const DecoratorsActions = ActionsProvider.getActions('Decorators');
@@ -20,7 +22,7 @@ const DecoratorSidebar = React.createClass({
     stream: React.PropTypes.string,
     maximumHeight: React.PropTypes.number,
   },
-  mixins: [Reflux.connect(DecoratorsStore)],
+  mixins: [Reflux.connect(DecoratorsStore), Reflux.connect(CurrentUserStore), PermissionsMixin],
   getInitialState() {
     return {
       maxDecoratorsHeight: 1000,
@@ -87,14 +89,16 @@ const DecoratorSidebar = React.createClass({
         </p>
       </Popover>
     );
+
+    const editPermissions = this.isPermitted(this.state.currentUser.permissions, `decorators:edit:${this.props.stream}`);
     return (
       <div>
-        <AddDecoratorButton stream={this.props.stream} nextOrder={nextDecoratorOrder}/>
+        <AddDecoratorButton stream={this.props.stream} nextOrder={nextDecoratorOrder} disabled={!editPermissions}/>
         <OverlayTrigger trigger="click" rootClose placement="right" overlay={popoverHelp}>
           <Button bsStyle="link" className={DecoratorStyles.helpLink}>What are message decorators?</Button>
         </OverlayTrigger>
         <div ref="decoratorsContainer" className={DecoratorStyles.decoratorListContainer} style={{ maxHeight: this.state.maxDecoratorsHeight }}>
-          <SortableList items={decoratorItems} onMoveItem={this._updateOrder} />
+          <DecoratorList decorators={decoratorItems} onReorder={this._updateOrder} disableDragging={!editPermissions}/>
         </div>
       </div>
     );

--- a/graylog2-web-interface/src/components/search/decoratorStyles.css
+++ b/graylog2-web-interface/src/components/search/decoratorStyles.css
@@ -52,3 +52,7 @@
     display: inline;
     padding-bottom: 20px;
 }
+
+:local(.noDecoratorsAlert) {
+    margin-top: 2em;
+}

--- a/graylog2-web-interface/src/components/search/index.jsx
+++ b/graylog2-web-interface/src/components/search/index.jsx
@@ -4,6 +4,7 @@ export { default as ChangedMessageField } from './ChangedMessageField';
 export { default as DecoratedMessageFieldMarker } from './DecoratedMessageFieldMarker';
 export { default as DecoratedSidebarMessageField } from './DecoratedSidebarMessageField';
 export { default as Decorator } from './Decorator';
+export { default as DecoratorList } from './DecoratorList';
 export { default as DecoratorSidebar } from './DecoratorSidebar';
 export { default as FieldAnalyzersSidebar } from './FieldAnalyzersSidebar';
 export { default as LegacyHistogram } from './LegacyHistogram';


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This change does the following when a user lacks the
'decorators:edit:${streamId}' permission:

  * disables items in action menu, when user lacks
  * disables controls to create decorator
  * disables ability to reorder decorators by drag & drop

Fixes #2730.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
