### PR TITLE
Make id field consistent for alarm callback histories.

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/alarmcallbacks/AlarmCallbackHistoryImpl.java
+++ b/graylog2-server/src/main/java/org/graylog2/alarmcallbacks/AlarmCallbackHistoryImpl.java
@@ -27,13 +27,14 @@ import org.graylog2.plugin.alarms.AlertCondition;
 import org.graylog2.rest.models.alarmcallbacks.AlarmCallbackResult;
 import org.graylog2.rest.models.alarmcallbacks.AlarmCallbackSummary;
 import org.joda.time.DateTime;
+import org.mongojack.Id;
 import org.mongojack.ObjectId;
 
 @AutoValue
 @JsonAutoDetect
 @CollectionName("alarmcallbackhistory")
 public abstract class AlarmCallbackHistoryImpl implements AlarmCallbackHistory {
-    static final String FIELD_ID = "_id";
+    static final String FIELD_ID = "id";
     static final String FIELD_ALARMCALLBACKCONFIGURATION = "alarmcallbackconfiguration";
     static final String FIELD_ALERTID = "alert_id";
     static final String FIELD_ALERTCONDITIONID = "alertcondition_id";
@@ -41,6 +42,7 @@ public abstract class AlarmCallbackHistoryImpl implements AlarmCallbackHistory {
     static final String FIELD_CREATED_AT = "created_at";
 
     @JsonProperty(FIELD_ID)
+    @Id
     @ObjectId
     @Override
     public abstract String id();
@@ -66,7 +68,7 @@ public abstract class AlarmCallbackHistoryImpl implements AlarmCallbackHistory {
     public abstract DateTime createdAt();
 
     @JsonCreator
-    public static AlarmCallbackHistoryImpl create(@JsonProperty(FIELD_ID) String id,
+    public static AlarmCallbackHistoryImpl create(@JsonProperty(FIELD_ID) @Id @ObjectId String id,
                                               @JsonProperty(FIELD_ALARMCALLBACKCONFIGURATION) AlarmCallbackSummary alarmcallbackConfiguration,
                                               @JsonProperty(FIELD_ALERTID) String alertId,
                                               @JsonProperty(FIELD_ALERTCONDITIONID) String alertConditionId,

--- a/graylog2-server/src/main/java/org/graylog2/rest/models/alarmcallbacks/AlarmCallbackHistorySummary.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/models/alarmcallbacks/AlarmCallbackHistorySummary.java
@@ -25,7 +25,7 @@ import org.joda.time.DateTime;
 @AutoValue
 @JsonAutoDetect
 public abstract class AlarmCallbackHistorySummary {
-    private static final String FIELD_ID = "_id";
+    private static final String FIELD_ID = "id";
     private static final String FIELD_ALARMCALLBACKCONFIGURATION = "alarmcallbackconfiguration";
     private static final String FIELD_ALERT_ID = "alert_id";
     private static final String FIELD_ALERTCONDITION_ID = "alertcondition_id";

--- a/graylog2-web-interface/src/components/alarmcallbacks/AlarmCallbackHistoryOverview.jsx
+++ b/graylog2-web-interface/src/components/alarmcallbacks/AlarmCallbackHistoryOverview.jsx
@@ -33,7 +33,7 @@ const AlarmCallbackHistoryOverview = React.createClass({
   },
   _formatHistory(history) {
     return (
-      <li key={history._id}>
+      <li key={history.id}>
         <AlarmCallbackHistory alarmCallbackHistory={history} types={this.state.types}/>
       </li>
     );


### PR DESCRIPTION
Changes id field in REST representation of alarm callback histories from
"_id" to "id" to make this more consistent with other entities.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.