### PR TITLE
Styling of decorator list

### DIFF
--- a/graylog2-web-interface/src/components/search/DecoratorSidebar.jsx
+++ b/graylog2-web-interface/src/components/search/DecoratorSidebar.jsx
@@ -94,9 +94,11 @@ const DecoratorSidebar = React.createClass({
     return (
       <div>
         <AddDecoratorButton stream={this.props.stream} nextOrder={nextDecoratorOrder} disabled={!editPermissions}/>
-        <OverlayTrigger trigger="click" rootClose placement="right" overlay={popoverHelp}>
-          <Button bsStyle="link" className={DecoratorStyles.helpLink}>What are message decorators?</Button>
-        </OverlayTrigger>
+        <div className={DecoratorStyles.helpLinkContainer}>
+          <OverlayTrigger trigger="click" rootClose placement="right" overlay={popoverHelp}>
+            <Button bsStyle="link" className={DecoratorStyles.helpLink}>What are message decorators?</Button>
+          </OverlayTrigger>
+        </div>
         <div ref="decoratorsContainer" className={DecoratorStyles.decoratorListContainer} style={{ maxHeight: this.state.maxDecoratorsHeight }}>
           <DecoratorList decorators={decoratorItems} onReorder={this._updateOrder} disableDragging={!editPermissions}/>
         </div>

--- a/graylog2-web-interface/src/components/search/decoratorStyles.css
+++ b/graylog2-web-interface/src/components/search/decoratorStyles.css
@@ -52,8 +52,8 @@
 }
 
 :local(.decoratorListContainer) {
-    overflow-y: scroll;
-    display: inline;
+    display: inline-block;
+    overflow-y: auto;
 }
 
 :local(.noDecoratorsAlert) {

--- a/graylog2-web-interface/src/components/search/decoratorStyles.css
+++ b/graylog2-web-interface/src/components/search/decoratorStyles.css
@@ -47,10 +47,13 @@
     position: relative;
 }
 
+:local(.helpLinkContainer) {
+    height: 20px;
+}
+
 :local(.decoratorListContainer) {
     overflow-y: scroll;
     display: inline;
-    padding-bottom: 20px;
 }
 
 :local(.noDecoratorsAlert) {

--- a/graylog2-web-interface/src/components/search/decoratorStyles.css
+++ b/graylog2-web-interface/src/components/search/decoratorStyles.css
@@ -54,6 +54,7 @@
 :local(.decoratorListContainer) {
     display: inline-block;
     overflow-y: auto;
+    width: 100%;
 }
 
 :local(.noDecoratorsAlert) {


### PR DESCRIPTION
This PR includes two changes in the decorator sidebar styling:

- Allow scrolling when list of decorators overflows the screen height. Fixes #2743
- Do not include help link in the drag preview of the first decorator