### PR TITLE
Audit event cleanup

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/audit/AuditEventTypes.java
+++ b/graylog2-server/src/main/java/org/graylog2/audit/AuditEventTypes.java
@@ -59,8 +59,8 @@ public class AuditEventTypes implements PluginAuditEventTypes {
     public static final String ES_INDEX_RANGE_CREATE = PREFIX + "es_index_range:create";
     public static final String ES_INDEX_RANGE_DELETE = PREFIX + "es_index_range:delete";
     public static final String ES_INDEX_RANGE_UPDATE_JOB = PREFIX + "es_index_range_update_job:start";
-    public static final String ES_INDEX_RETENTION_COMPLETE = PREFIX + "es_index_retention:complete";
-    public static final String ES_INDEX_RETENTION_INITIATE = PREFIX + "es_index_retention:initiate";
+    public static final String ES_INDEX_RETENTION_CLOSE = PREFIX + "es_index_retention:close";
+    public static final String ES_INDEX_RETENTION_DELETE = PREFIX + "es_index_retention:delete";
     public static final String ES_INDEX_RETENTION_STRATEGY_UPDATE = PREFIX + "es_index_retention_strategy:update";
     public static final String ES_INDEX_ROTATION_COMPLETE = PREFIX + "es_index_rotation:complete";
     public static final String ES_INDEX_ROTATION_INITIATE = PREFIX + "es_index_rotation:initiate";
@@ -175,8 +175,8 @@ public class AuditEventTypes implements PluginAuditEventTypes {
             .add(ES_INDEX_RANGE_CREATE)
             .add(ES_INDEX_RANGE_DELETE)
             .add(ES_INDEX_RANGE_UPDATE_JOB)
-            .add(ES_INDEX_RETENTION_COMPLETE)
-            .add(ES_INDEX_RETENTION_INITIATE)
+            .add(ES_INDEX_RETENTION_CLOSE)
+            .add(ES_INDEX_RETENTION_DELETE)
             .add(ES_INDEX_RETENTION_STRATEGY_UPDATE)
             .add(ES_INDEX_ROTATION_COMPLETE)
             .add(ES_INDEX_ROTATION_INITIATE)

--- a/graylog2-server/src/main/java/org/graylog2/audit/AuditEventTypes.java
+++ b/graylog2-server/src/main/java/org/graylog2/audit/AuditEventTypes.java
@@ -63,7 +63,6 @@ public class AuditEventTypes implements PluginAuditEventTypes {
     public static final String ES_INDEX_RETENTION_DELETE = PREFIX + "es_index_retention:delete";
     public static final String ES_INDEX_RETENTION_STRATEGY_UPDATE = PREFIX + "es_index_retention_strategy:update";
     public static final String ES_INDEX_ROTATION_COMPLETE = PREFIX + "es_index_rotation:complete";
-    public static final String ES_INDEX_ROTATION_INITIATE = PREFIX + "es_index_rotation:initiate";
     public static final String ES_INDEX_ROTATION_STRATEGY_UPDATE = PREFIX + "es_index_rotation_strategy:update";
     public static final String ES_WRITE_INDEX_UPDATE = PREFIX + "es_write_index:update";
     public static final String ES_WRITE_INDEX_UPDATE_JOB_START = PREFIX + "es_write_index_update_job:start";
@@ -179,7 +178,6 @@ public class AuditEventTypes implements PluginAuditEventTypes {
             .add(ES_INDEX_RETENTION_DELETE)
             .add(ES_INDEX_RETENTION_STRATEGY_UPDATE)
             .add(ES_INDEX_ROTATION_COMPLETE)
-            .add(ES_INDEX_ROTATION_INITIATE)
             .add(ES_INDEX_ROTATION_STRATEGY_UPDATE)
             .add(ES_WRITE_INDEX_UPDATE)
             .add(ES_WRITE_INDEX_UPDATE_JOB_START)

--- a/graylog2-server/src/main/java/org/graylog2/audit/formatter/FormattedAuditEvent.java
+++ b/graylog2-server/src/main/java/org/graylog2/audit/formatter/FormattedAuditEvent.java
@@ -75,7 +75,7 @@ public interface FormattedAuditEvent {
     String action();
 
     /**
-     * The format string that will be used to present the audit event to humans.
+     * The message template string that will be used to present the audit event to humans.
      *
      * All data in {@link #attributes()} as well as the following fields can be used as variables.
      *
@@ -92,12 +92,12 @@ public interface FormattedAuditEvent {
      *
      * @return
      */
-    String formatString();
+    String messageTemplate();
 
     /**
      * The audit event attributes that will be stored in the database.
      *
-     * All information that is needed by the {@link #formatString()} should be in here.
+     * All information that is needed by the {@link #messageTemplate()} should be in here.
      *
      * Make sure you do not store any sensitive information like passwords and API tokens!
      *

--- a/graylog2-server/src/main/java/org/graylog2/indexer/retention/strategies/NoopRetentionStrategy.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/retention/strategies/NoopRetentionStrategy.java
@@ -16,11 +16,9 @@
  */
 package org.graylog2.indexer.retention.strategies;
 
-import org.graylog2.audit.AuditEventSender;
 import org.graylog2.indexer.Deflector;
 import org.graylog2.indexer.indices.Indices;
 import org.graylog2.plugin.indexer.retention.RetentionStrategyConfig;
-import org.graylog2.plugin.system.NodeId;
 import org.graylog2.shared.system.activities.ActivityWriter;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -32,9 +30,8 @@ public class NoopRetentionStrategy extends AbstractIndexCountBasedRetentionStrat
     private static final Logger LOG = LoggerFactory.getLogger(NoopRetentionStrategy.class);
 
     @Inject
-    public NoopRetentionStrategy(Deflector deflector, Indices indices, ActivityWriter activityWriter,
-                                 AuditEventSender auditEventSender, NodeId nodeId) {
-        super(deflector, indices, nodeId, activityWriter, auditEventSender);
+    public NoopRetentionStrategy(Deflector deflector, Indices indices, ActivityWriter activityWriter) {
+        super(deflector, indices, activityWriter);
     }
 
     @Override

--- a/graylog2-server/src/main/java/org/graylog2/indexer/rotation/strategies/AbstractRotationStrategy.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/rotation/strategies/AbstractRotationStrategy.java
@@ -28,11 +28,9 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import javax.annotation.Nullable;
-import java.util.Map;
 
 import static java.util.Objects.requireNonNull;
 import static org.graylog2.audit.AuditEventTypes.ES_INDEX_ROTATION_COMPLETE;
-import static org.graylog2.audit.AuditEventTypes.ES_INDEX_ROTATION_INITIATE;
 
 public abstract class AbstractRotationStrategy implements RotationStrategy {
     private static final Logger LOG = LoggerFactory.getLogger(AbstractRotationStrategy.class);
@@ -62,28 +60,23 @@ public abstract class AbstractRotationStrategy implements RotationStrategy {
         try {
             indexName = deflector.getNewestTargetName();
         } catch (NoTargetIndexException e) {
-            final ImmutableMap<String, Object> auditEventContext = ImmutableMap.of("rotation_strategy", strategyName);
-            auditEventSender.failure(AuditActor.system(nodeId), ES_INDEX_ROTATION_INITIATE, auditEventContext);
-
             LOG.error("Could not find current deflector target. Aborting.", e);
             return;
         }
 
-        final Map<String, Object> auditEventContext = ImmutableMap.of(
-            "index_name", indexName,
-            "rotation_strategy", strategyName);
         final Result rotate = shouldRotate(indexName);
         if (rotate == null) {
             LOG.error("Cannot perform rotation at this moment.");
-
-            auditEventSender.failure(AuditActor.system(nodeId), ES_INDEX_ROTATION_INITIATE, auditEventContext);
             return;
         }
         LOG.debug("Rotation strategy result: {}", rotate.getDescription());
         if (rotate.shouldRotate()) {
             LOG.info("Deflector index <{}> should be rotated, Pointing deflector to new index now!", indexName);
             deflector.cycle();
-            auditEventSender.success(AuditActor.system(nodeId), ES_INDEX_ROTATION_COMPLETE, auditEventContext);
+            auditEventSender.success(AuditActor.system(nodeId), ES_INDEX_ROTATION_COMPLETE, ImmutableMap.of(
+                    "index_name", indexName,
+                    "rotation_strategy", strategyName
+            ));
         } else {
             LOG.debug("Deflector index <{}> should not be rotated. Not doing anything.", indexName);
         }


### PR DESCRIPTION
Removes a few audit events when running index retention and rotation. Only emit events when indices are actually deleted/closed.