### PR TITLE
Correct documentation links in 'misc/graylog.conf'

### DIFF
--- a/misc/graylog.conf
+++ b/misc/graylog.conf
@@ -250,7 +250,7 @@ elasticsearch_index_prefix = graylog
 #elasticsearch_template_name = graylog-internal
 
 # Do you want to allow searches with leading wildcards? This can be extremely resource hungry and should only
-# be enabled with care. See also: https://www.graylog.org/documentation/general/queries/
+# be enabled with care. See also: http://docs.graylog.org/en/2.1/pages/queries.html
 allow_leading_wildcard_searches = false
 
 # Do you want to allow searches to be highlighted? Depending on the size of your messages this can be memory hungry and
@@ -449,7 +449,7 @@ mongodb_max_connections = 1000
 mongodb_threads_allowed_to_block_multiplier = 5
 
 # Drools Rule File (Use to rewrite incoming log messages)
-# See: https://www.graylog.org/documentation/general/rewriting/
+# See: http://docs.graylog.org/en/2.1/pages/drools.html
 #rules_file = /etc/graylog/server/rules.drl
 
 # Email transport


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
`misc/graylog.conf` has references to https://www.graylog.org/documentation/, which no longer exists.  This PR updates two links to what appear to be the closest matches on http://docs.graylog.org/.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fixing broken links.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Verified the new links work.

## Screenshots (if appropriate):
n/a

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

