### PR TITLE
make key_prefix configuration optional

### DIFF
--- a/graylog2-web-interface/src/components/extractors/extractors_configuration/JSONExtractorConfiguration.jsx
+++ b/graylog2-web-interface/src/components/extractors/extractors_configuration/JSONExtractorConfiguration.jsx
@@ -118,7 +118,6 @@ const JSONExtractorConfiguration = React.createClass({
                labelClassName="col-md-2"
                wrapperClassName="col-md-10"
                defaultValue={this.state.configuration.key_prefix}
-               required
                onChange={this._onChange('key_prefix')}
                help="Text to prepend to each key extracted from the JSON object."/>
 


### PR DESCRIPTION
The key_prefix defaults to an empty string so that the input field should not be required.

fixes #2755