### PR TITLE
Actually use the bluebird promise in FetchProvider

### DIFF
--- a/graylog2-web-interface/src/logic/rest/FetchProvider.js
+++ b/graylog2-web-interface/src/logic/rest/FetchProvider.js
@@ -1,4 +1,5 @@
 import request from 'superagent-bluebird-promise';
+import BluebirdPromise from 'bluebird';
 
 import StoreProvider from 'injection/StoreProvider';
 
@@ -98,7 +99,7 @@ export default function fetch(method, url, body) {
   const SessionStore = StoreProvider.getStore('Session');
 
   if (!SessionStore.isLoggedIn()) {
-    return new Promise((resolve, reject) => {
+    return new BluebirdPromise((resolve, reject) => {
       const SessionActions = ActionsProvider.getActions('Session');
       SessionActions.login.completed.listen(() => {
         promise().then(resolve, reject);


### PR DESCRIPTION
Previously this was returning a native Promise when SessionStore.isLoggedIn() returned false.

Fixes NodesStore which failed when trying to call finally() on a native 

![pasted image at 2016_08_31 16_21](https://cloud.githubusercontent.com/assets/461/18135433/31c54588-6fa2-11e6-83d7-fa30e9066e42.png)
promise.