### PR TITLE
Proxied requests query other nodes in parallel

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/plugin/BaseConfiguration.java
+++ b/graylog2-server/src/main/java/org/graylog2/plugin/BaseConfiguration.java
@@ -163,6 +163,10 @@ public abstract class BaseConfiguration {
     @Parameter(value = "web_tls_key_password")
     private String webTlsKeyPassword;
 
+    @Parameter(value = "proxied_requests_max_threads", required = true, validator = PositiveIntegerValidator.class)
+    // TODO: this is a totally abitrary number. this needs a better default based on ... something.
+    private int proxiedRequestsMaxThreads = 64;
+
     public String getRestUriScheme() {
         return getUriScheme(isRestEnableTls());
     }

--- a/graylog2-server/src/main/java/org/graylog2/plugin/BaseConfiguration.java
+++ b/graylog2-server/src/main/java/org/graylog2/plugin/BaseConfiguration.java
@@ -163,9 +163,8 @@ public abstract class BaseConfiguration {
     @Parameter(value = "web_tls_key_password")
     private String webTlsKeyPassword;
 
-    @Parameter(value = "proxied_requests_max_threads", required = true, validator = PositiveIntegerValidator.class)
-    // TODO: this is a totally abitrary number. this needs a better default based on ... something.
-    private int proxiedRequestsMaxThreads = 64;
+    @Parameter(value = "proxied_requests_thread_pool_size", required = true, validator = PositiveIntegerValidator.class)
+    private int proxiedRequestsThreadPoolSize = 32;
 
     public String getRestUriScheme() {
         return getUriScheme(isRestEnableTls());

--- a/graylog2-server/src/main/java/org/graylog2/rest/resources/cluster/ClusterDeflectorResource.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/resources/cluster/ClusterDeflectorResource.java
@@ -28,6 +28,7 @@ import org.graylog2.shared.rest.resources.ProxiedResource;
 import org.graylog2.shared.rest.resources.system.RemoteDeflectorResource;
 
 import javax.inject.Inject;
+import javax.inject.Named;
 import javax.ws.rs.InternalServerErrorException;
 import javax.ws.rs.POST;
 import javax.ws.rs.Path;
@@ -38,6 +39,7 @@ import javax.ws.rs.core.HttpHeaders;
 import javax.ws.rs.core.MediaType;
 import java.io.IOException;
 import java.util.Optional;
+import java.util.concurrent.ExecutorService;
 import java.util.function.Function;
 
 @RequiresAuthentication
@@ -48,8 +50,9 @@ public class ClusterDeflectorResource extends ProxiedResource {
     @Inject
     public ClusterDeflectorResource(@Context HttpHeaders httpHeaders,
                                     NodeService nodeService,
-                                    RemoteInterfaceProvider remoteInterfaceProvider) {
-        super(httpHeaders, nodeService, remoteInterfaceProvider);
+                                    RemoteInterfaceProvider remoteInterfaceProvider,
+                                    @Named("proxiedRequestsExecutorService") ExecutorService executorService) {
+        super(httpHeaders, nodeService, remoteInterfaceProvider, executorService);
     }
 
     @POST

--- a/graylog2-server/src/main/java/org/graylog2/rest/resources/cluster/ClusterInputStatesResource.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/resources/cluster/ClusterInputStatesResource.java
@@ -38,6 +38,7 @@ import org.graylog2.shared.rest.resources.ProxiedResource;
 import org.graylog2.shared.security.RestPermissions;
 
 import javax.inject.Inject;
+import javax.inject.Named;
 import javax.ws.rs.DELETE;
 import javax.ws.rs.GET;
 import javax.ws.rs.PUT;
@@ -50,6 +51,7 @@ import javax.ws.rs.core.MediaType;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+import java.util.concurrent.ExecutorService;
 
 @RequiresAuthentication
 @Api(value = "Cluster/InputState", description = "Cluster-wide input states")
@@ -59,8 +61,9 @@ public class ClusterInputStatesResource extends ProxiedResource {
     @Inject
     public ClusterInputStatesResource(NodeService nodeService,
                                       RemoteInterfaceProvider remoteInterfaceProvider,
-                                      @Context HttpHeaders httpHeaders) throws NodeNotFoundException {
-        super(httpHeaders, nodeService, remoteInterfaceProvider);
+                                      @Context HttpHeaders httpHeaders,
+                                      @Named("proxiedRequestsExecutorService") ExecutorService executorService) throws NodeNotFoundException {
+        super(httpHeaders, nodeService, remoteInterfaceProvider, executorService);
     }
 
     @GET

--- a/graylog2-server/src/main/java/org/graylog2/rest/resources/cluster/ClusterJournalResource.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/resources/cluster/ClusterJournalResource.java
@@ -36,6 +36,7 @@ import org.slf4j.LoggerFactory;
 import retrofit2.Response;
 
 import javax.inject.Inject;
+import javax.inject.Named;
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
@@ -45,6 +46,7 @@ import javax.ws.rs.core.Context;
 import javax.ws.rs.core.HttpHeaders;
 import javax.ws.rs.core.MediaType;
 import java.io.IOException;
+import java.util.concurrent.ExecutorService;
 
 import static javax.ws.rs.core.Response.Status.BAD_GATEWAY;
 
@@ -58,8 +60,9 @@ public class ClusterJournalResource extends ProxiedResource {
     @Inject
     public ClusterJournalResource(NodeService nodeService,
                                   RemoteInterfaceProvider remoteInterfaceProvider,
-                                  @Context HttpHeaders httpHeaders) throws NodeNotFoundException {
-        super(httpHeaders, nodeService, remoteInterfaceProvider);
+                                  @Context HttpHeaders httpHeaders,
+                                  @Named("proxiedRequestsExecutorService") ExecutorService executorService) throws NodeNotFoundException {
+        super(httpHeaders, nodeService, remoteInterfaceProvider, executorService);
     }
 
     @GET

--- a/graylog2-server/src/main/java/org/graylog2/rest/resources/cluster/ClusterLoadBalancerStatusResource.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/resources/cluster/ClusterLoadBalancerStatusResource.java
@@ -36,6 +36,7 @@ import org.slf4j.LoggerFactory;
 import retrofit2.Response;
 
 import javax.inject.Inject;
+import javax.inject.Named;
 import javax.ws.rs.PUT;
 import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
@@ -45,6 +46,7 @@ import javax.ws.rs.core.Context;
 import javax.ws.rs.core.HttpHeaders;
 import javax.ws.rs.core.MediaType;
 import java.io.IOException;
+import java.util.concurrent.ExecutorService;
 
 import static javax.ws.rs.core.Response.Status.BAD_GATEWAY;
 
@@ -58,8 +60,9 @@ public class ClusterLoadBalancerStatusResource extends ProxiedResource {
     @Inject
     public ClusterLoadBalancerStatusResource(NodeService nodeService,
                                              RemoteInterfaceProvider remoteInterfaceProvider,
-                                             @Context HttpHeaders httpHeaders) throws NodeNotFoundException {
-        super(httpHeaders, nodeService, remoteInterfaceProvider);
+                                             @Context HttpHeaders httpHeaders,
+                                             @Named("proxiedRequestsExecutorService") ExecutorService executorService) throws NodeNotFoundException {
+        super(httpHeaders, nodeService, remoteInterfaceProvider, executorService);
     }
 
     @PUT

--- a/graylog2-server/src/main/java/org/graylog2/rest/resources/cluster/ClusterLoggersResource.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/resources/cluster/ClusterLoggersResource.java
@@ -35,6 +35,7 @@ import org.graylog2.shared.rest.resources.ProxiedResource;
 import org.hibernate.validator.constraints.NotEmpty;
 
 import javax.inject.Inject;
+import javax.inject.Named;
 import javax.ws.rs.GET;
 import javax.ws.rs.PUT;
 import javax.ws.rs.Path;
@@ -46,6 +47,7 @@ import javax.ws.rs.core.MediaType;
 import java.io.IOException;
 import java.util.Map;
 import java.util.Optional;
+import java.util.concurrent.ExecutorService;
 
 @RequiresAuthentication
 @Api(value = "Cluster/System/Loggers", description = "Cluster-wide access to internal Graylog loggers")
@@ -54,8 +56,9 @@ public class ClusterLoggersResource extends ProxiedResource {
     @Inject
     public ClusterLoggersResource(NodeService nodeService,
                                     RemoteInterfaceProvider remoteInterfaceProvider,
-                                    @Context HttpHeaders httpHeaders) throws NodeNotFoundException {
-        super(httpHeaders, nodeService, remoteInterfaceProvider);
+                                    @Context HttpHeaders httpHeaders,
+                                    @Named("proxiedRequestsExecutorService") ExecutorService executorService) throws NodeNotFoundException {
+        super(httpHeaders, nodeService, remoteInterfaceProvider, executorService);
     }
 
     @GET

--- a/graylog2-server/src/main/java/org/graylog2/rest/resources/cluster/ClusterMetricsResource.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/resources/cluster/ClusterMetricsResource.java
@@ -33,6 +33,7 @@ import org.graylog2.shared.rest.resources.ProxiedResource;
 import org.graylog2.shared.rest.resources.system.RemoteMetricsResource;
 
 import javax.inject.Inject;
+import javax.inject.Named;
 import javax.validation.Valid;
 import javax.validation.constraints.NotNull;
 import javax.ws.rs.POST;
@@ -44,6 +45,7 @@ import javax.ws.rs.core.MediaType;
 import java.io.IOException;
 import java.util.Map;
 import java.util.Optional;
+import java.util.concurrent.ExecutorService;
 
 @RequiresAuthentication
 @Api(value = "Cluster/Metrics", description = "Cluster-wide Internal Graylog metrics")
@@ -54,8 +56,9 @@ public class ClusterMetricsResource extends ProxiedResource {
     @Inject
     public ClusterMetricsResource(NodeService nodeService,
                                   RemoteInterfaceProvider remoteInterfaceProvider,
-                                  @Context HttpHeaders httpHeaders) {
-        super(httpHeaders, nodeService, remoteInterfaceProvider);
+                                  @Context HttpHeaders httpHeaders,
+                                  @Named("proxiedRequestsExecutorService") ExecutorService executorService) {
+        super(httpHeaders, nodeService, remoteInterfaceProvider, executorService);
     }
 
     @POST

--- a/graylog2-server/src/main/java/org/graylog2/rest/resources/cluster/ClusterNodeMetricsResource.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/resources/cluster/ClusterNodeMetricsResource.java
@@ -38,6 +38,7 @@ import org.graylog2.shared.security.RestPermissions;
 import retrofit2.Response;
 
 import javax.inject.Inject;
+import javax.inject.Named;
 import javax.validation.Valid;
 import javax.validation.constraints.NotNull;
 import javax.ws.rs.GET;
@@ -50,6 +51,7 @@ import javax.ws.rs.core.Context;
 import javax.ws.rs.core.HttpHeaders;
 import javax.ws.rs.core.MediaType;
 import java.io.IOException;
+import java.util.concurrent.ExecutorService;
 
 import static javax.ws.rs.core.Response.Status.BAD_GATEWAY;
 
@@ -61,8 +63,9 @@ public class ClusterNodeMetricsResource extends ProxiedResource {
     @Inject
     public ClusterNodeMetricsResource(NodeService nodeService,
                                       RemoteInterfaceProvider remoteInterfaceProvider,
-                                      @Context HttpHeaders httpHeaders) {
-        super(httpHeaders, nodeService, remoteInterfaceProvider);
+                                      @Context HttpHeaders httpHeaders,
+                                      @Named("proxiedRequestsExecutorService") ExecutorService executorService) {
+        super(httpHeaders, nodeService, remoteInterfaceProvider, executorService);
     }
 
     private RemoteMetricsResource getResourceForNode(String nodeId) throws NodeNotFoundException {

--- a/graylog2-server/src/main/java/org/graylog2/rest/resources/cluster/ClusterSystemJobResource.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/resources/cluster/ClusterSystemJobResource.java
@@ -36,6 +36,7 @@ import org.slf4j.LoggerFactory;
 import retrofit2.Response;
 
 import javax.inject.Inject;
+import javax.inject.Named;
 import javax.ws.rs.DELETE;
 import javax.ws.rs.GET;
 import javax.ws.rs.NotFoundException;
@@ -49,6 +50,7 @@ import java.io.IOException;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.concurrent.ExecutorService;
 
 @RequiresAuthentication
 @Api(value = "Cluster/Jobs", description = "Cluster-wide System Jobs")
@@ -59,8 +61,9 @@ public class ClusterSystemJobResource extends ProxiedResource {
     @Inject
     public ClusterSystemJobResource(NodeService nodeService,
                                     RemoteInterfaceProvider remoteInterfaceProvider,
-                                    @Context HttpHeaders httpHeaders) throws NodeNotFoundException {
-        super(httpHeaders, nodeService, remoteInterfaceProvider);
+                                    @Context HttpHeaders httpHeaders,
+                                    @Named("proxiedRequestsExecutorService") ExecutorService executorService) throws NodeNotFoundException {
+        super(httpHeaders, nodeService, remoteInterfaceProvider, executorService);
     }
 
     @GET

--- a/graylog2-server/src/main/java/org/graylog2/rest/resources/cluster/ClusterSystemPluginResource.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/resources/cluster/ClusterSystemPluginResource.java
@@ -34,6 +34,7 @@ import org.slf4j.LoggerFactory;
 import retrofit2.Response;
 
 import javax.inject.Inject;
+import javax.inject.Named;
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
@@ -43,6 +44,7 @@ import javax.ws.rs.core.Context;
 import javax.ws.rs.core.HttpHeaders;
 import javax.ws.rs.core.MediaType;
 import java.io.IOException;
+import java.util.concurrent.ExecutorService;
 
 import static javax.ws.rs.core.Response.Status.BAD_GATEWAY;
 
@@ -56,8 +58,9 @@ public class ClusterSystemPluginResource extends ProxiedResource {
     @Inject
     public ClusterSystemPluginResource(NodeService nodeService,
                                        RemoteInterfaceProvider remoteInterfaceProvider,
-                                       @Context HttpHeaders httpHeaders) throws NodeNotFoundException {
-        super(httpHeaders, nodeService, remoteInterfaceProvider);
+                                       @Context HttpHeaders httpHeaders,
+                                       @Named("proxiedRequestsExecutorService") ExecutorService executorService) throws NodeNotFoundException {
+        super(httpHeaders, nodeService, remoteInterfaceProvider, executorService);
     }
 
     @GET

--- a/graylog2-server/src/main/java/org/graylog2/rest/resources/cluster/ClusterSystemProcessingResource.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/resources/cluster/ClusterSystemProcessingResource.java
@@ -34,6 +34,7 @@ import org.slf4j.LoggerFactory;
 import retrofit2.Response;
 
 import javax.inject.Inject;
+import javax.inject.Named;
 import javax.ws.rs.POST;
 import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
@@ -43,6 +44,7 @@ import javax.ws.rs.core.Context;
 import javax.ws.rs.core.HttpHeaders;
 import javax.ws.rs.core.MediaType;
 import java.io.IOException;
+import java.util.concurrent.ExecutorService;
 
 import static javax.ws.rs.core.Response.Status.BAD_GATEWAY;
 
@@ -56,8 +58,9 @@ public class ClusterSystemProcessingResource extends ProxiedResource {
     @Inject
     public ClusterSystemProcessingResource(NodeService nodeService,
                                            RemoteInterfaceProvider remoteInterfaceProvider,
-                                           @Context HttpHeaders httpHeaders) throws NodeNotFoundException {
-        super(httpHeaders, nodeService, remoteInterfaceProvider);
+                                           @Context HttpHeaders httpHeaders,
+                                           @Named("proxiedRequestsExecutorService") ExecutorService executorService) throws NodeNotFoundException {
+        super(httpHeaders, nodeService, remoteInterfaceProvider, executorService);
     }
 
     private RemoteSystemProcessingResource getRemoteSystemProcessingResource(String nodeId) throws NodeNotFoundException {

--- a/graylog2-server/src/main/java/org/graylog2/rest/resources/cluster/ClusterSystemResource.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/resources/cluster/ClusterSystemResource.java
@@ -38,6 +38,7 @@ import org.slf4j.LoggerFactory;
 import retrofit2.Response;
 
 import javax.inject.Inject;
+import javax.inject.Named;
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
@@ -49,6 +50,7 @@ import javax.ws.rs.core.MediaType;
 import java.io.IOException;
 import java.util.Map;
 import java.util.Optional;
+import java.util.concurrent.ExecutorService;
 
 import static javax.ws.rs.core.Response.Status.BAD_GATEWAY;
 
@@ -62,8 +64,9 @@ public class ClusterSystemResource extends ProxiedResource {
     @Inject
     public ClusterSystemResource(NodeService nodeService,
                                  RemoteInterfaceProvider remoteInterfaceProvider,
-                                 @Context HttpHeaders httpHeaders) throws NodeNotFoundException {
-        super(httpHeaders, nodeService, remoteInterfaceProvider);
+                                 @Context HttpHeaders httpHeaders,
+                                 @Named("proxiedRequestsExecutorService") ExecutorService executorService) throws NodeNotFoundException {
+        super(httpHeaders, nodeService, remoteInterfaceProvider, executorService);
     }
 
     @GET

--- a/graylog2-server/src/main/java/org/graylog2/rest/resources/cluster/ClusterSystemShutdownResource.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/resources/cluster/ClusterSystemShutdownResource.java
@@ -35,6 +35,7 @@ import org.slf4j.LoggerFactory;
 import retrofit2.Response;
 
 import javax.inject.Inject;
+import javax.inject.Named;
 import javax.ws.rs.POST;
 import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
@@ -44,6 +45,7 @@ import javax.ws.rs.core.Context;
 import javax.ws.rs.core.HttpHeaders;
 import javax.ws.rs.core.MediaType;
 import java.io.IOException;
+import java.util.concurrent.ExecutorService;
 
 import static javax.ws.rs.core.Response.Status.BAD_GATEWAY;
 import static org.jboss.netty.handler.codec.http.HttpResponseStatus.ACCEPTED;
@@ -58,8 +60,9 @@ public class ClusterSystemShutdownResource extends ProxiedResource {
     @Inject
     public ClusterSystemShutdownResource(NodeService nodeService,
                                          RemoteInterfaceProvider remoteInterfaceProvider,
-                                         @Context HttpHeaders httpHeaders) throws NodeNotFoundException {
-        super(httpHeaders, nodeService, remoteInterfaceProvider);
+                                         @Context HttpHeaders httpHeaders,
+                                         @Named("proxiedRequestsExecutorService") ExecutorService executorService) throws NodeNotFoundException {
+        super(httpHeaders, nodeService, remoteInterfaceProvider, executorService);
     }
 
     @POST

--- a/graylog2-server/src/main/java/org/graylog2/shared/bindings/GenericBindings.java
+++ b/graylog2-server/src/main/java/org/graylog2/shared/bindings/GenericBindings.java
@@ -35,6 +35,7 @@ import org.graylog2.shared.bindings.providers.EventBusProvider;
 import org.graylog2.shared.bindings.providers.MetricRegistryProvider;
 import org.graylog2.shared.bindings.providers.NodeIdProvider;
 import org.graylog2.shared.bindings.providers.OkHttpClientProvider;
+import org.graylog2.shared.bindings.providers.ProxiedRequestsExecutorService;
 import org.graylog2.shared.bindings.providers.ServiceManagerProvider;
 import org.graylog2.shared.bindings.providers.SystemOkHttpClientProvider;
 import org.graylog2.shared.buffers.InputBufferImpl;
@@ -44,6 +45,7 @@ import org.graylog2.shared.inputs.InputRegistry;
 import org.jboss.netty.util.HashedWheelTimer;
 
 import javax.activation.MimetypesFileTypeMap;
+import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Semaphore;
 
 public class GenericBindings extends AbstractModule {
@@ -77,5 +79,7 @@ public class GenericBindings extends AbstractModule {
         bind(OkHttpClient.class).annotatedWith(Names.named("systemHttpClient")).toProvider(SystemOkHttpClientProvider.class).asEagerSingleton();
 
         bind(MimetypesFileTypeMap.class).toInstance(new MimetypesFileTypeMap());
+
+        bind(ExecutorService.class).annotatedWith(Names.named("proxiedRequestsExecutorService")).toProvider(ProxiedRequestsExecutorService.class).asEagerSingleton();
     }
 }

--- a/graylog2-server/src/main/java/org/graylog2/shared/bindings/providers/ProxiedRequestsExecutorService.java
+++ b/graylog2-server/src/main/java/org/graylog2/shared/bindings/providers/ProxiedRequestsExecutorService.java
@@ -1,3 +1,19 @@
+/**
+ * This file is part of Graylog.
+ *
+ * Graylog is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package org.graylog2.shared.bindings.providers;
 
 import com.google.common.util.concurrent.ThreadFactoryBuilder;

--- a/graylog2-server/src/main/java/org/graylog2/shared/bindings/providers/ProxiedRequestsExecutorService.java
+++ b/graylog2-server/src/main/java/org/graylog2/shared/bindings/providers/ProxiedRequestsExecutorService.java
@@ -1,0 +1,34 @@
+package org.graylog2.shared.bindings.providers;
+
+import com.google.common.util.concurrent.ThreadFactoryBuilder;
+import org.graylog2.plugin.Tools;
+import org.graylog2.shared.rest.resources.ProxiedResource;
+import org.slf4j.LoggerFactory;
+
+import javax.inject.Inject;
+import javax.inject.Named;
+import javax.inject.Provider;
+import javax.inject.Singleton;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+
+@Singleton
+public class ProxiedRequestsExecutorService implements Provider<ExecutorService> {
+    private final int proxiedRequestsMaxThreads;
+
+    @Inject
+    public ProxiedRequestsExecutorService(@Named("proxied_requests_max_threads") int proxiedRequestsMaxThreads) {
+        this.proxiedRequestsMaxThreads = proxiedRequestsMaxThreads;
+    }
+
+    @Override
+    public ExecutorService get() {
+        return Executors.newFixedThreadPool(proxiedRequestsMaxThreads,
+            new ThreadFactoryBuilder()
+                .setNameFormat("proxied-requests-pool-%d")
+                .setDaemon(true)
+                .setUncaughtExceptionHandler(new Tools.LogUncaughtExceptionHandler(LoggerFactory.getLogger(ProxiedResource.class.getName())))
+                .build()
+        );
+    }
+}

--- a/graylog2-server/src/main/java/org/graylog2/shared/bindings/providers/ProxiedRequestsExecutorService.java
+++ b/graylog2-server/src/main/java/org/graylog2/shared/bindings/providers/ProxiedRequestsExecutorService.java
@@ -33,7 +33,7 @@ public class ProxiedRequestsExecutorService implements Provider<ExecutorService>
     private final int proxiedRequestsMaxThreads;
 
     @Inject
-    public ProxiedRequestsExecutorService(@Named("proxied_requests_max_threads") int proxiedRequestsMaxThreads) {
+    public ProxiedRequestsExecutorService(@Named("proxied_requests_thread_pool_size") int proxiedRequestsMaxThreads) {
         this.proxiedRequestsMaxThreads = proxiedRequestsMaxThreads;
     }
 

--- a/graylog2-server/src/main/java/org/graylog2/shared/rest/resources/ProxiedResource.java
+++ b/graylog2-server/src/main/java/org/graylog2/shared/rest/resources/ProxiedResource.java
@@ -63,46 +63,42 @@ public abstract class ProxiedResource extends RestResource {
         }
     }
 
-    protected <RemoteInterfaceType, RemoteCallResponseType> Map<String, Optional<RemoteCallResponseType>> getForAllNodes(Function<RemoteInterfaceType,Call<RemoteCallResponseType>> fn, Function<String, Optional<RemoteInterfaceType>> interfaceProvider) {
+    protected <RemoteInterfaceType, RemoteCallResponseType> Map<String, Optional<RemoteCallResponseType>> getForAllNodes(Function<RemoteInterfaceType, Call<RemoteCallResponseType>> fn, Function<String, Optional<RemoteInterfaceType>> interfaceProvider) {
         return getForAllNodes(fn, interfaceProvider, Function.identity());
     }
 
     protected <RemoteInterfaceType, FinalResponseType, RemoteCallResponseType> Map<String, Optional<FinalResponseType>> getForAllNodes(Function<RemoteInterfaceType, Call<RemoteCallResponseType>> fn, Function<String, Optional<RemoteInterfaceType>> interfaceProvider, Function<RemoteCallResponseType, FinalResponseType> transformer) {
-        final Map<String, Future<Optional<FinalResponseType>>> futures = this.nodeService.allActive()
-            .entrySet()
-            .stream()
-            .collect(Collectors.toMap(Map.Entry::getKey, entry -> {
-                final Optional<RemoteInterfaceType> remoteInterface = interfaceProvider.apply(entry.getKey());
-                if (!remoteInterface.isPresent()) {
-                    return CompletableFuture.completedFuture(Optional.empty());
-                }
-                return this.executor.submit(() -> {
-                    final Call<RemoteCallResponseType> call = fn.apply(remoteInterface.get());
-                    try {
-                        final Response<RemoteCallResponseType> response = call.execute();
-                        if (response.isSuccessful()) {
-                            return Optional.of(transformer.apply(response.body()));
-                        } else {
-                            LOG.warn("Unable to call " + call.request().url().toString() + " on node <" + entry.getKey() + ">, result: " + response.message());
-                            return Optional.empty();
-                        }
-                    } catch (IOException e) {
-                        LOG.warn("Unable to call " + call.request().url().toString() + " on node <" + entry.getKey() + ">, caught exception: {} ({})", e.getMessage(), e.getClass());
-                        return Optional.empty();
-                    }
-                });
-            }));
+        final Map<String, Future<Optional<FinalResponseType>>> futures = this.nodeService.allActive().keySet().stream()
+                .collect(Collectors.toMap(Function.identity(), node -> interfaceProvider.apply(node)
+                        .map(r -> executor.submit(() -> {
+                            final Call<RemoteCallResponseType> call = fn.apply(r);
+                            try {
+                                final Response<RemoteCallResponseType> response = call.execute();
+                                if (response.isSuccessful()) {
+                                    return Optional.of(transformer.apply(response.body()));
+                                } else {
+                                    LOG.warn("Unable to call {} on node <{}>, result: {}", call.request().url(), node, response.message());
+                                    return Optional.<FinalResponseType>empty();
+                                }
+                            } catch (IOException e) {
+                                LOG.warn("Unable to call {} on node <{}>", call.request().url(), node, e);
+                                return Optional.<FinalResponseType>empty();
+                            }
+                        }))
+                        .orElse(CompletableFuture.completedFuture(Optional.empty()))
+                ));
 
         return futures
-            .entrySet()
-            .stream()
-            .collect(Collectors.toMap(Map.Entry::getKey, entry -> {
-                try {
-                    return entry.getValue().get();
-                } catch (InterruptedException | ExecutionException e) {
-                    return Optional.empty();
-                }
-            }));
+                .entrySet()
+                .stream()
+                .collect(Collectors.toMap(Map.Entry::getKey, entry -> {
+                    try {
+                        return entry.getValue().get();
+                    } catch (InterruptedException | ExecutionException e) {
+                        LOG.debug("Couldn't retrieve future", e);
+                        return Optional.empty();
+                    }
+                }));
     }
 
     protected <RemoteInterfaceType> Function<String, Optional<RemoteInterfaceType>> createRemoteInterfaceProvider(Class<RemoteInterfaceType> interfaceClass) {

--- a/graylog2-server/src/main/java/org/graylog2/shared/rest/resources/ProxiedResource.java
+++ b/graylog2-server/src/main/java/org/graylog2/shared/rest/resources/ProxiedResource.java
@@ -35,7 +35,6 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.function.Function;
 import java.util.stream.Collectors;

--- a/graylog2-server/src/main/java/org/graylog2/shared/rest/resources/ProxiedResource.java
+++ b/graylog2-server/src/main/java/org/graylog2/shared/rest/resources/ProxiedResource.java
@@ -17,7 +17,6 @@
 
 package org.graylog2.shared.rest.resources;
 
-import org.apache.commons.lang3.concurrent.ConcurrentUtils;
 import org.graylog2.cluster.Node;
 import org.graylog2.cluster.NodeNotFoundException;
 import org.graylog2.cluster.NodeService;
@@ -33,6 +32,7 @@ import java.io.IOException;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Future;
@@ -74,7 +74,7 @@ public abstract class ProxiedResource extends RestResource {
             .collect(Collectors.toMap(Map.Entry::getKey, entry -> {
                 final Optional<RemoteInterfaceType> remoteInterface = interfaceProvider.apply(entry.getKey());
                 if (!remoteInterface.isPresent()) {
-                    return ConcurrentUtils.constantFuture(Optional.empty());
+                    return CompletableFuture.completedFuture(Optional.empty());
                 }
                 return this.executor.submit(() -> {
                     final Call<RemoteCallResponseType> call = fn.apply(remoteInterface.get());

--- a/graylog2-server/src/main/java/org/graylog2/shared/rest/resources/ProxiedResource.java
+++ b/graylog2-server/src/main/java/org/graylog2/shared/rest/resources/ProxiedResource.java
@@ -51,10 +51,11 @@ public abstract class ProxiedResource extends RestResource {
 
     protected ProxiedResource(@Context HttpHeaders httpHeaders,
                               NodeService nodeService,
-                              RemoteInterfaceProvider remoteInterfaceProvider) {
+                              RemoteInterfaceProvider remoteInterfaceProvider,
+                              ExecutorService executorService) {
         this.nodeService = nodeService;
         this.remoteInterfaceProvider = remoteInterfaceProvider;
-        this.executor = Executors.newCachedThreadPool();
+        this.executor = executorService;
         final List<String> authenticationTokens = httpHeaders.getRequestHeader("Authorization");
         if (authenticationTokens != null && authenticationTokens.size() >= 1) {
             this.authenticationToken = authenticationTokens.get(0);

--- a/misc/graylog.conf
+++ b/misc/graylog.conf
@@ -518,3 +518,7 @@ mongodb_threads_allowed_to_block_multiplier = 5
 # the first start of Graylog.
 # Default: empty
 content_packs_auto_load = grok-patterns.json
+
+# For some cluster-related REST requests, the node must query all other nodes in the cluster. This is the maximum number
+# of threads available for this.
+proxied_requests_max_threads = 64

--- a/misc/graylog.conf
+++ b/misc/graylog.conf
@@ -520,5 +520,6 @@ mongodb_threads_allowed_to_block_multiplier = 5
 content_packs_auto_load = grok-patterns.json
 
 # For some cluster-related REST requests, the node must query all other nodes in the cluster. This is the maximum number
-# of threads available for this.
-proxied_requests_max_threads = 64
+# of threads available for this. Increase it, if '/cluster/*' requests take long to complete.
+# Should be rest_thread_pool_size * average_cluster_size if you have a high number of concurrent users.
+proxied_requests_thread_pool_size = 32


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This change makes the `ProxiedResource` base class perform requests to other nodes in the cluster in parallel, when all nodes are supposed to be queried. This reduces the increase of round trip times with growing cluster sizes, which was growing linearly before (due to requests being executed in a single thread).

The HTTP requests are being executed on a shared thread pool, which has a maximum size, defined by the `proxied_requests_max_threads` config setting. The default for this is 64, which *is rather arbitrary*. Coming up with a sane default for this is hard, as it is not related to the number of available CPUs (as most of the time the threads will be sleeping/blocked on IO, so overprovisioning of CPUs is desired to achieve good performance) and the number of nodes in the cluster is dynamically changing during runtime (and maybe not available during startup). Any recommendations for a good default are welcome.

## Motivation and Context
For large cluster sizes,  performing proxied requests sequentially could lead to large round trip times, which might exceed the defined timeout. This could lead to functionality being unavailable or even an overloaded Graylog server.

## How Has This Been Tested?
Node cleanup was disabled and different ranges of dummy node table entries were created, with transport addresses pointing to a local http stub returning dummy metrics responses. Then, a cluster metrics request was sent to the Graylog server and round trip times were measured.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
