### PR TITLE
Fix 404s on IE 11 using compatibility view

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/rest/filter/WebAppNotFoundResponseFilter.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/filter/WebAppNotFoundResponseFilter.java
@@ -47,7 +47,8 @@ public class WebAppNotFoundResponseFilter implements ContainerResponseFilter {
         final Response.StatusType responseStatus = responseContext.getStatusInfo();
         final String requestPath = requestContext.getUriInfo().getAbsolutePath().getPath();
         final List<MediaType> acceptableMediaTypes = requestContext.getAcceptableMediaTypes();
-        final boolean acceptsHtml = acceptableMediaTypes.contains(MediaType.TEXT_HTML_TYPE) || acceptableMediaTypes.contains(MediaType.APPLICATION_XHTML_XML_TYPE);
+        final boolean acceptsHtml = acceptableMediaTypes.stream()
+                .anyMatch(mediaType -> mediaType.isCompatible(MediaType.TEXT_HTML_TYPE) || mediaType.isCompatible(MediaType.APPLICATION_XHTML_XML_TYPE));
         final boolean isGetRequest = requestContext.getMethod().equalsIgnoreCase("get");
 
         if (isGetRequest

--- a/graylog2-server/src/test/java/org/graylog2/rest/filter/WebAppNotFoundResponseFilterTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/rest/filter/WebAppNotFoundResponseFilterTest.java
@@ -126,6 +126,21 @@ public class WebAppNotFoundResponseFilterTest {
     }
 
     @Test
+    public void filterDoesFilterCompatibleAcceptMimeTypes() throws Exception {
+        final UriInfo uriInfo = mock(UriInfo.class);
+        final List<MediaType> mediaTypes = Collections.singletonList(MediaType.WILDCARD_TYPE);
+        when(uriInfo.getAbsolutePath()).thenReturn(URI.create("/web/search"));
+        when(requestContext.getMethod()).thenReturn(CK_METHOD_GET);
+        when(requestContext.getUriInfo()).thenReturn(uriInfo);
+        when(requestContext.getAcceptableMediaTypes()).thenReturn(mediaTypes);
+        when(responseContext.getStatusInfo()).thenReturn(Response.Status.NOT_FOUND);
+
+        filter.filter(requestContext, responseContext);
+
+        verify(responseContext, times(1)).setEntity("index.html", new Annotation[0], MediaType.TEXT_HTML_TYPE);
+    }
+
+    @Test
     public void filterDoesNotFilterRestApiPrefix() throws Exception {
         final UriInfo uriInfo = mock(UriInfo.class);
         final List<MediaType> mediaTypes = Collections.singletonList(MediaType.TEXT_HTML_TYPE);


### PR DESCRIPTION
When Graylog is running on an intranet, IE 11 may be requesting the site in compatibility view, depending on the organization and user settings. That applies even when properly setting the X-UA-Compatible header and meta tags.

Making requests in compatibility view, IE does not include either `text/html` or `application/xhtml+xml` MIME types in the `Accept` header, which are the values we checked in order to deliver the web interface HTML document when requesting a resource that doesn't exist (i.e. when clicking on a page number on the search page).

Unfortunately, the way legacy IEs work is also odd in the way it includes `Accept` headers on requests, being `*/*` the only one that is always included. You can read more about it here:
https://blogs.msdn.microsoft.com/ieinternals/2009/07/01/ie-and-the-accept-header/

To solve this issue, these changes relax the media types comparison on `WebAppNotFoundResponseFilter`, by also serving the web interface HTML document if any of the request headers is compatible with `text/html` or `application/xhtml+xml`. In that way we also consider that requests with a wildcard MIME type will be able to handle the HTML document, but we still avoid serving HTML if the request specified another accepted MIME type.

Fixes #2768