### PR TITLE
Modify actions in search page triggering a page reload

### DIFF
--- a/graylog2-web-interface/public/stylesheets/graylog2.less
+++ b/graylog2-web-interface/public/stylesheets/graylog2.less
@@ -2778,3 +2778,16 @@ ul.pill-list > li {
 .form-control.message-id-input {
   width: 300px;
 }
+
+.loading-indicator {
+  background-color: #FFF;
+  box-shadow: 2px 2px 10px #aaa;
+  position: fixed;
+  bottom: 0;
+  right: 0;
+  z-index: 2000;
+  padding: 5px 10px;
+  border-top: 1px solid #ccc;
+  border-left: 1px solid #ccc;
+  border-top-left-radius: 4px;
+}

--- a/graylog2-web-interface/public/stylesheets/graylog2.less
+++ b/graylog2-web-interface/public/stylesheets/graylog2.less
@@ -2778,16 +2778,3 @@ ul.pill-list > li {
 .form-control.message-id-input {
   width: 300px;
 }
-
-.loading-indicator {
-  background-color: #FFF;
-  box-shadow: 2px 2px 10px #aaa;
-  position: fixed;
-  bottom: 0;
-  right: 0;
-  z-index: 2000;
-  padding: 5px 10px;
-  border-top: 1px solid #ccc;
-  border-left: 1px solid #ccc;
-  border-top-left-radius: 4px;
-}

--- a/graylog2-web-interface/src/components/common/LoadingIndicator.css
+++ b/graylog2-web-interface/src/components/common/LoadingIndicator.css
@@ -1,0 +1,12 @@
+:local(.loadingIndicator) {
+    background-color: #FFF;
+    box-shadow: 2px 2px 10px #aaa;
+    position: fixed;
+    bottom: 0;
+    right: 0;
+    z-index: 2000;
+    padding: 5px 10px;
+    border-top: 1px solid #ccc;
+    border-left: 1px solid #ccc;
+    border-top-left-radius: 4px;
+}

--- a/graylog2-web-interface/src/components/common/LoadingIndicator.jsx
+++ b/graylog2-web-interface/src/components/common/LoadingIndicator.jsx
@@ -1,0 +1,23 @@
+import React from 'react';
+
+import { Spinner } from 'components/common';
+
+import loadingIndicatorStyle from './LoadingIndicator.css';
+
+const LoadingIndicator = React.createClass({
+  propTypes: {
+    text: React.PropTypes.string,
+  },
+
+  getDefaultProps() {
+    return {
+      text: 'Loading...',
+    };
+  },
+
+  render() {
+    return <div className={loadingIndicatorStyle.loadingIndicator}><Spinner text={this.props.text}/></div>;
+  },
+});
+
+export default LoadingIndicator;

--- a/graylog2-web-interface/src/components/common/index.jsx
+++ b/graylog2-web-interface/src/components/common/index.jsx
@@ -10,6 +10,7 @@ export { default as GridsterWidget } from './GridsterWidget';
 export { default as IfPermitted } from './IfPermitted';
 export { default as ISODurationInput } from './ISODurationInput';
 export { default as LinkToNode } from './LinkToNode';
+export { default as LoadingIndicator } from './LoadingIndicator';
 export { default as KeyValueTable } from './KeyValueTable';
 export { default as MultiSelect } from './MultiSelect';
 export { default as Page } from './Page';

--- a/graylog2-web-interface/src/components/dashboard/AddToDashboardMenu.jsx
+++ b/graylog2-web-interface/src/components/dashboard/AddToDashboardMenu.jsx
@@ -47,7 +47,6 @@ const AddToDashboardMenu = React.createClass({
 
   componentDidMount() {
     this._initializeDashboards();
-    this._setOriginalSearchParams();
   },
   _initializeDashboards() {
     DashboardsStore.addOnWritableDashboardsChangedCallback(dashboards => {
@@ -68,16 +67,13 @@ const AddToDashboardMenu = React.createClass({
   _updateDashboards(newDashboards) {
     this.setState({dashboards: newDashboards});
   },
-  _setOriginalSearchParams() {
-    this.searchParams = SearchStore.getOriginalSearchParams();
-  },
   _selectDashboard(event, dashboardId) {
     this.setState({selectedDashboard: dashboardId});
     this.refs.widgetModal.open();
   },
   _saveWidget(title, configuration) {
     let widgetConfig = Immutable.Map(this.props.configuration);
-    let searchParams = Immutable.Map(this.searchParams);
+    let searchParams = Immutable.Map(SearchStore.getOriginalSearchParams());
     if (searchParams.has('range_type')) {
       switch (searchParams.get('range_type')) {
         case 'relative':

--- a/graylog2-web-interface/src/components/search/SearchResult.jsx
+++ b/graylog2-web-interface/src/components/search/SearchResult.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import Immutable from 'immutable';
 import { Col, Row } from 'react-bootstrap';
 
+import { Spinner } from 'components/common';
 import { LegacyHistogram, NoSearchResults, ResultTable, SearchSidebar } from 'components/search';
 
 import StoreProvider from 'injection/StoreProvider';
@@ -23,6 +24,7 @@ const SearchResult = React.createClass({
     nodes: React.PropTypes.instanceOf(Immutable.Map),
     permissions: React.PropTypes.array.isRequired,
     searchConfig: React.PropTypes.object.isRequired,
+    loadingSearch: React.PropTypes.bool,
   },
 
   getDefaultProps() {
@@ -142,6 +144,12 @@ const SearchResult = React.createClass({
                          permissions={this.props.permissions} searchInStream={this.props.searchInStream} />
       );
     }
+
+    let loadingIndicator;
+    if (this.props.loadingSearch) {
+      loadingIndicator = <div className="loading-indicator"><Spinner text="Updating search results..."/></div>;
+    }
+
     return (
       <Row id="main-content-search">
         <Col ref="opa" md={3} sm={12} id="sidebar">
@@ -169,7 +177,7 @@ const SearchResult = React.createClass({
           <LegacyHistogram formattedHistogram={this.props.formattedHistogram}
                            histogram={this.props.histogram}
                            permissions={this.props.permissions}
-                           stream={this.props.searchInStream}/>
+                           stream={this.props.searchInStream} />
 
           {this._fieldAnalyzerComponents((analyzer) => this._shouldRenderBelowHistogram(analyzer))}
 
@@ -183,11 +191,12 @@ const SearchResult = React.createClass({
                        streams={this.props.streams}
                        nodes={this.props.nodes}
                        highlight={this.state.shouldHighlight}
-                       searchConfig={this.props.searchConfig}
-          />
+                       searchConfig={this.props.searchConfig} />
 
+          {loadingIndicator}
         </Col>
-      </Row>);
+      </Row>
+    );
   },
 });
 

--- a/graylog2-web-interface/src/components/search/SearchResult.jsx
+++ b/graylog2-web-interface/src/components/search/SearchResult.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import Immutable from 'immutable';
 import { Col, Row } from 'react-bootstrap';
 
-import { Spinner } from 'components/common';
+import { LoadingIndicator } from 'components/common';
 import { LegacyHistogram, NoSearchResults, ResultTable, SearchSidebar } from 'components/search';
 
 import StoreProvider from 'injection/StoreProvider';
@@ -147,7 +147,7 @@ const SearchResult = React.createClass({
 
     let loadingIndicator;
     if (this.props.loadingSearch) {
-      loadingIndicator = <div className="loading-indicator"><Spinner text="Updating search results..."/></div>;
+      loadingIndicator = <LoadingIndicator text="Updating search results..." />;
     }
 
     return (

--- a/graylog2-web-interface/src/components/search/SearchResult.jsx
+++ b/graylog2-web-interface/src/components/search/SearchResult.jsx
@@ -41,8 +41,6 @@ const SearchResult = React.createClass({
     const initialFields = SearchStore.fields;
     return {
       selectedFields: this.sortFields(initialFields),
-      sortField: SearchStore.sortField,
-      sortOrder: SearchStore.sortOrder,
       showAllFields: false,
       shouldHighlight: true,
     };
@@ -178,8 +176,8 @@ const SearchResult = React.createClass({
           <ResultTable messages={this.props.result.messages}
                        page={SearchStore.page}
                        selectedFields={this.state.selectedFields}
-                       sortField={this.state.sortField}
-                       sortOrder={this.state.sortOrder}
+                       sortField={SearchStore.sortField}
+                       sortOrder={SearchStore.sortOrder}
                        resultCount={this.props.result.total_results}
                        inputs={this.props.inputs}
                        streams={this.props.streams}

--- a/graylog2-web-interface/src/stores/search/SavedSearchesStore.js
+++ b/graylog2-web-interface/src/stores/search/SavedSearchesStore.js
@@ -85,7 +85,7 @@ const SavedSearchesStore = Reflux.createStore({
       url = Routes.SEARCH;
     }
     url = `${url}?${Qs.stringify(searchQuery)}`;
-    URLUtils.openLink(url, false);
+    SearchStore.executeSearch(url);
   },
 
   _createOrUpdate(title, searchId) {

--- a/graylog2-web-interface/src/stores/search/SearchStore.ts
+++ b/graylog2-web-interface/src/stores/search/SearchStore.ts
@@ -11,6 +11,7 @@ const Routes = require('routing/Routes');
 var Qs = require('qs');
 const URLUtils = require('util/URLUtils');
 const moment = require('moment');
+const history = require('util/History');
 
 class SearchStore {
     static NOT_OPERATOR = "NOT";
@@ -332,14 +333,18 @@ class SearchStore {
         var searchURLParams = this.getOriginalSearchURLParams();
         searchURLParams = searchURLParams.set("width", this.width);
         searchURLParams = searchURLParams.set(param, value);
-        URLUtils.openLink(this.searchBaseLocation("index") + "?" + Qs.stringify(searchURLParams.toJS()), false);
+        this.executeSearch(this.searchBaseLocation("index") + "?" + Qs.stringify(searchURLParams.toJS()));
     }
 
     _reloadSearchWithNewParams(newParams: Immutable.Map<string, any>) {
         var searchURLParams = this.getOriginalSearchURLParams();
         searchURLParams = searchURLParams.set("width", this.width);
         searchURLParams = searchURLParams.merge(newParams);
-        URLUtils.openLink(this.searchBaseLocation("index") + "?" + Qs.stringify(searchURLParams.toJS()), false);
+        this.executeSearch(this.searchBaseLocation("index") + "?" + Qs.stringify(searchURLParams.toJS()));
+    }
+
+    executeSearch(url) {
+        history.pushState(null, url);
     }
 
     getCsvExportURL(): string {

--- a/graylog2-web-interface/src/util/URLUtils.js
+++ b/graylog2-web-interface/src/util/URLUtils.js
@@ -9,13 +9,6 @@ const URLUtils = {
   appPrefixed(url) {
     return this.concatURLPath(AppConfig.gl2AppPathPrefix(), url);
   },
-  openLink(url, newWindow) {
-    if (newWindow) {
-      window.open(url);
-    } else {
-      window.location = url;
-    }
-  },
   getParsedSearch(location) {
     let search = {};
     let query = location.search;


### PR DESCRIPTION
## Description
Many actions in the search page trigger a full page reload, either because they use links to navigate to another page, or because they submit a form to the server.

That was needed in previous versions of the web interface (prior 2.0) but now can be replaced by a combination of react-router and a refresh of the reflux stores involved in the search. This has the advantage of avoiding the page reload, avoiding asking the server for the web interface assets (as described in #2488), and also avoiding flashes with the login page (as described in #2770).

This PR takes care of modifying some of those actions to avoid page reloads when:
- Executing searches
- Using search pagination
- Changing histogram resolution
- Selecting saved searches
- Changing message sorting

This PR intentionally does not take care of:
- Refactoring the code around searches (specially `SearchStore`), as it is too risky for a bugfix release. This is something we can move into 2.2
- Avoiding page reload when using surrounding searches. The main problem here is to reset the search view, e.g. scroll to top, reset page number, and collapse expanded message. Doing those things would require more changes that I don't think are worth pursuing right now. We can take care of fixing it in a follow-up task

## Motivation and Context
The changes were motivated by #2488, and they also fix that issue.

## How Has This Been Tested?
I have checked that these search elements still work after the changes:
- [X] Widgets use right search params
- [X] Save searches use right search params
- [X] CSV export uses right search params (but didn't solve the issue described in #2795)
- [X] Field analyzers use right params
- [X] Searching from sources tab works
- [X] Searching in streams works
- [X] Search live-loading works
- [X] Show surrounding messages works
- [X] Sorting works
- [X] Field selection works
