### PR TITLE
Updating bluebird to 3.4.x and superagent to 2.2.x.

### DIFF
--- a/graylog2-web-interface/package.json
+++ b/graylog2-web-interface/package.json
@@ -17,7 +17,7 @@
     "prepare-dev": "./tools/prepare-dev"
   },
   "dependencies": {
-    "bluebird": "^2.10.2",
+    "bluebird": "^3.4.0",
     "c3": "^0.4.11-rc4",
     "classnames": "^2.2.0",
     "clipboard": "^1.5.5",
@@ -55,8 +55,8 @@
     "rickshaw": "^1.5.1",
     "sockjs-client": "1.1.x",
     "string": "^3.3.1",
-    "superagent": "^1.4.0",
-    "superagent-bluebird-promise": "^2.1.0",
+    "superagent": "^2.2.0",
+    "superagent-bluebird-promise": "^3.0.0",
     "toastr": "^2.1.2",
     "typeahead.js": "^0.11.1",
     "urijs": "^1.17.0"

--- a/graylog2-web-interface/src/stores/configurations/ConfigurationsStore.js
+++ b/graylog2-web-interface/src/stores/configurations/ConfigurationsStore.js
@@ -21,7 +21,8 @@ const ConfigurationsStore = Reflux.createStore({
     const promise = fetch('GET', this._url(`/${configType}`));
     promise.then((response) => {
       this.configuration[configType] = response;
-      this.trigger({configuration: this.configuration});
+      this.trigger({ configuration: this.configuration });
+      return response;
     });
 
     ConfigurationActions.list.promise(promise);
@@ -29,7 +30,8 @@ const ConfigurationsStore = Reflux.createStore({
 
   listSearchesClusterConfig() {
     const promise = fetch('GET', this._url('/org.graylog2.indexer.searches.SearchesClusterConfig')).then((response) => {
-      this.trigger({searchesClusterConfig: response});
+      this.trigger({ searchesClusterConfig: response });
+      return response;
     });
 
     ConfigurationActions.listSearchesClusterConfig.promise(promise);
@@ -38,7 +40,8 @@ const ConfigurationsStore = Reflux.createStore({
   listMessageProcessorsConfig(configType) {
     const promise = fetch('GET', URLUtils.qualifyUrl('/system/messageprocessors/config')).then((response) => {
       this.configuration[configType] = response;
-      this.trigger({configuration: this.configuration});
+      this.trigger({ configuration: this.configuration });
+      return response;
     });
 
     ConfigurationActions.listMessageProcessorsConfig.promise(promise);
@@ -50,8 +53,9 @@ const ConfigurationsStore = Reflux.createStore({
     promise.then(
       response => {
         this.configuration[configType] = response;
-        this.trigger({configuration: this.configuration});
+        this.trigger({ configuration: this.configuration });
         UserNotification.success('Configuration updated successfully');
+        return response;
       },
       error => {
         UserNotification.error(`Search config update failed: ${error}`, `Could not update search config: ${configType}`);
@@ -66,8 +70,9 @@ const ConfigurationsStore = Reflux.createStore({
     promise.then(
       response => {
         this.configuration[configType] = response;
-        this.trigger({configuration: this.configuration});
+        this.trigger({ configuration: this.configuration });
         UserNotification.success('Configuration updated successfully');
+        return response;
       },
       error => {
         UserNotification.error(`Message processors config update failed: ${error}`, `Could not update config: ${configType}`);

--- a/graylog2-web-interface/src/stores/nodes/NodesStore.js
+++ b/graylog2-web-interface/src/stores/nodes/NodesStore.js
@@ -40,6 +40,7 @@ const NodesStore = Reflux.createStore({
         this.clusterId = this._clusterId();
         this.nodeCount = this._nodeCount();
         this._propagateState();
+        return response;
       })
       .finally(() => delete this.promises.list);
 


### PR DESCRIPTION
This PR is updating bluebird and (as it depends on it) superagent.

As bluebird now has a check for runaway promises (promises with a `.then()` handler that does not return anything) a runaway promise in the `ConfigurationStore` was detected immediately, that I fixed (along with some linter hints), although it was of no harm.