### PR TITLE
Do not display login form while loading

### DIFF
--- a/graylog2-web-interface/public/stylesheets/disconnected.less
+++ b/graylog2-web-interface/public/stylesheets/disconnected.less
@@ -49,3 +49,7 @@ hr {
     margin-top: 10px;
     margin-bottom: 10px;
 }
+
+.loading-text {
+    font-size: 14px;
+}

--- a/graylog2-web-interface/src/pages/LoadingPage.jsx
+++ b/graylog2-web-interface/src/pages/LoadingPage.jsx
@@ -1,0 +1,48 @@
+import React from 'react';
+import { Col, Row } from 'react-bootstrap';
+
+import { Spinner } from 'components/common';
+
+import disconnectedStyle from '!style/useable!css!less!stylesheets/disconnected.less';
+import authStyle from '!style/useable!css!less!stylesheets/auth.less';
+
+const LoadingPage = React.createClass({
+  propTypes: {
+    text: React.PropTypes.string,
+  },
+
+  getDefaultProps() {
+    return {
+      text: 'Loading, please wait...',
+    };
+  },
+
+  componentDidMount() {
+    disconnectedStyle.use();
+    authStyle.use();
+  },
+
+  componentWillUnmount() {
+    disconnectedStyle.unuse();
+    authStyle.unuse();
+  },
+
+  render() {
+    return (
+      <div>
+        <div className="container" id="login-box">
+          <Row>
+            <Col md={4} mdOffset={4} className="well" id="login-box-content">
+              <legend><i className="fa fa-group"/> Welcome to Graylog</legend>
+              <p className="loading-text">
+                <Spinner text={this.props.text}/>
+              </p>
+            </Col>
+          </Row>
+        </div>
+      </div>
+    );
+  },
+});
+
+export default LoadingPage;

--- a/graylog2-web-interface/src/pages/LoadingPage.jsx
+++ b/graylog2-web-interface/src/pages/LoadingPage.jsx
@@ -29,17 +29,15 @@ const LoadingPage = React.createClass({
 
   render() {
     return (
-      <div>
-        <div className="container" id="login-box">
-          <Row>
-            <Col md={4} mdOffset={4} className="well" id="login-box-content">
-              <legend><i className="fa fa-group"/> Welcome to Graylog</legend>
-              <p className="loading-text">
-                <Spinner text={this.props.text}/>
-              </p>
-            </Col>
-          </Row>
-        </div>
+      <div className="container" id="login-box">
+        <Row>
+          <Col md={4} mdOffset={4} className="well" id="login-box-content">
+            <legend><i className="fa fa-group"/> Welcome to Graylog</legend>
+            <p className="loading-text">
+              <Spinner text={this.props.text}/>
+            </p>
+          </Col>
+        </Row>
       </div>
     );
   },

--- a/graylog2-web-interface/src/pages/LoginPage.jsx
+++ b/graylog2-web-interface/src/pages/LoginPage.jsx
@@ -2,6 +2,8 @@ import React from 'react';
 import Reflux from 'reflux';
 import { Row, Input, ButtonInput, Alert } from 'react-bootstrap';
 
+import LoadingPage from './LoadingPage';
+
 import StoreProvider from 'injection/StoreProvider';
 const SessionStore = StoreProvider.getStore('Session');
 import ActionsProvider from 'injection/ActionsProvider';
@@ -62,6 +64,12 @@ const LoginPage = React.createClass({
     this.setState({lastError: undefined});
   },
   render() {
+    if (this.state.validatingSession) {
+      return (
+        <LoadingPage />
+      );
+    }
+
     const alert = this.formatLastError(this.state.lastError);
     return (
       <div>

--- a/graylog2-web-interface/src/routing/AppFacade.jsx
+++ b/graylog2-web-interface/src/routing/AppFacade.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import Reflux from 'reflux';
 import LoginPage from 'react-proxy?name=LoginPage!pages/LoginPage';
+import LoadingPage from 'react-proxy?name=LoadingPage!pages/LoadingPage';
 import LoggedInPage from 'react-proxy?name=LoggedInPage!pages/LoggedInPage';
 import ServerUnavailablePage from 'pages/ServerUnavailablePage';
 
@@ -35,8 +36,11 @@ const AppFacade = React.createClass({
     if (!this.state.server.up) {
       return <ServerUnavailablePage server={this.state.server} />;
     }
-    if (!this.state.sessionId || !this.state.currentUser) {
+    if (!this.state.sessionId) {
       return <LoginPage />;
+    }
+    if (!this.state.currentUser) {
+      return <LoadingPage text="We are preparing Graylog for you..."/>;
     }
     return <LoggedInPage />;
   },


### PR DESCRIPTION
When loading Graylog, we currently display the login form while waiting for some resources to load, namely:
- Validate user session
- Load the current logged-in user

Those resources sometimes take a bit to load, and seeing the login form is confusing, as seen in #2770. This PR introduces a loading page that will avoid the confusion of seeing the login form on the screen.

I decided to use the same design used in our login page, as this provides a good transition between the loading and log-in page, which may be show directly before and/or after each other.

Fixes #2770.