### PR TITLE
Use index and message_id as message identifier

### DIFF
--- a/graylog2-web-interface/src/components/search/MessageTableEntry.jsx
+++ b/graylog2-web-interface/src/components/search/MessageTableEntry.jsx
@@ -65,7 +65,7 @@ const MessageTableEntry = React.createClass({
     }
   },
   _toggleDetail() {
-    this.props.toggleDetail(this.props.message.id);
+    this.props.toggleDetail(`${this.props.message.index}-${this.props.message.id}`);
   },
   render() {
     const colSpanFixup = this.props.selectedFields.size + 1;

--- a/graylog2-web-interface/src/components/search/ResultTable.jsx
+++ b/graylog2-web-interface/src/components/search/ResultTable.jsx
@@ -78,7 +78,7 @@ const ResultTable = React.createClass({
     const expandedChangeRatio = (this.props.messages.length - this.state.expandedMessages.size) / 100;
     const renderLoadingIndicator = expandedChangeRatio > 0.3;
 
-    const newSet = Immutable.Set(this.props.messages.map((message) => message.id));
+    const newSet = Immutable.Set(this.props.messages.map((message) => `${message.index}-${message.id}`));
     this.setState({ expandedMessages: newSet, expandAllRenderAsync: renderLoadingIndicator });
   },
   collapseAll() {
@@ -160,11 +160,11 @@ const ResultTable = React.createClass({
                 </thead>
                 {this.props.messages.map((message) => {
                   return (
-                    <MessageTableEntry key={message.id}
+                    <MessageTableEntry key={`${message.index}-${message.id}`}
                                        message={message}
                                        showMessageRow={this.props.selectedFields.contains('message')}
                                        selectedFields={selectedColumns}
-                                       expanded={this.state.expandedMessages.contains(message.id)}
+                                       expanded={this.state.expandedMessages.contains(`${message.index}-${message.id}`)}
                                        toggleDetail={this._toggleMessageDetail}
                                        inputs={this.props.inputs}
                                        streams={this.props.streams}


### PR DESCRIPTION
These changes avoid hiding messages with the same message ID but in different indices. It also takes care of fixing expanding/collapsing messages.

Fixes #2801