### PR TITLE
Use current search time configuration for CSV export

### DIFF
--- a/graylog2-web-interface/src/components/search/SearchSidebar.jsx
+++ b/graylog2-web-interface/src/components/search/SearchSidebar.jsx
@@ -84,10 +84,25 @@ const SearchSidebar = React.createClass({
     const streamId = this.props.searchInStream ? this.props.searchInStream.id : undefined;
     const query = searchParams.get('q') === '' ? '*' : searchParams.get('q');
     const fields = this.props.selectedFields;
-    const timeRange = SearchStore.rangeType === 'relative' ? { range: SearchStore.rangeParams.get('relative') } : SearchStore.rangeParams.toJS();
+    const rangeType = searchParams.get('rangetype');
+    const timeRange = {};
+    switch (rangeType) {
+      case 'relative':
+        timeRange.range = searchParams.get('relative');
+        break;
+      case 'absolute':
+        timeRange.from = searchParams.get('from');
+        timeRange.to = searchParams.get('to');
+        break;
+      case 'keyword':
+        timeRange.keyword = searchParams.get('keyword');
+        break;
+      default:
+        // Nothing to do here
+    }
 
     const url = new URI(URLUtils.qualifyUrl(
-      ApiRoutes.UniversalSearchApiController.export(SearchStore.rangeType, query, timeRange, streamId, 0, 0, fields.toJS()).url
+      ApiRoutes.UniversalSearchApiController.export(rangeType, query, timeRange, streamId, 0, 0, fields.toJS()).url
     ))
       .username(SessionStore.getSessionId())
       .password('session');

--- a/graylog2-web-interface/src/stores/search/SearchStore.ts
+++ b/graylog2-web-interface/src/stores/search/SearchStore.ts
@@ -347,12 +347,6 @@ class SearchStore {
         history.pushState(null, url);
     }
 
-    getCsvExportURL(): string {
-        var searchURLParams = this.getOriginalSearchURLParams();
-        searchURLParams = searchURLParams.delete('page');
-        return this.searchBaseLocation("exportAsCsv") + "?" + Qs.stringify(searchURLParams.toJS());
-    }
-
     searchSurroundingMessages(messageId: string, fromTime: string, toTime: string, filter: any) {
       var originalParams = this.getOriginalSearchParamsWithFields().toJS();
 


### PR DESCRIPTION
Generate search CSV export link using the time range of the current search, instead of the current value of the time range inputs.

Fixes #2795