### PR TITLE
explicitly close okhttp response body, avoiding leak connection warning

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/periodical/VersionCheckThread.java
+++ b/graylog2-server/src/main/java/org/graylog2/periodical/VersionCheckThread.java
@@ -123,6 +123,8 @@ public class VersionCheckThread extends Periodical {
             } catch (IOException e) {
                 LOG.error("Couldn't parse version check response", e);
                 return;
+            } finally {
+                response.close();
             }
 
             final VersionResponse version = versionCheckResponse.version;


### PR DESCRIPTION
## Description
As title

## Motivation and Context
I got warning below sometimes after I upgrade to 2.1.0 (around once per day)
```
WARN : okhttp3.OkHttpClient - A connection to https://versioncheck.graylog.com/ was leaked. Did you forget to close a response body?
```

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
