### PR TITLE
Properly close OkHttp Response objects to avoid resource leaks

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/initializers/IndexerSetupService.java
+++ b/graylog2-server/src/main/java/org/graylog2/initializers/IndexerSetupService.java
@@ -155,14 +155,12 @@ public class IndexerSetupService extends AbstractIdleService {
                     final URI esUri = URI.create("http://" + HostAndPort.fromString(host).getHostText() + ":9200/");
 
                     LOG.info("Checking Elasticsearch HTTP API at {}", esUri);
-                    try {
-                        // Try the HTTP API endpoint
-                        final Request request = new Request.Builder()
-                                .get()
-                                .url(esUri.resolve("/_nodes").toString())
-                                .build();
-                        final Response response = httpClient.newCall(request).execute();
-
+                    // Try the HTTP API endpoint
+                    final Request request = new Request.Builder()
+                            .get()
+                            .url(esUri.resolve("/_nodes").toString())
+                            .build();
+                    try (final Response response = httpClient.newCall(request).execute()) {
                         if (response.isSuccessful()) {
                             final JsonNode resultTree = objectMapper.readTree(response.body().byteStream());
                             final JsonNode nodesList = resultTree.get("nodes");

--- a/graylog2-server/src/main/java/org/graylog2/inputs/transports/HttpPollTransport.java
+++ b/graylog2-server/src/main/java/org/graylog2/inputs/transports/HttpPollTransport.java
@@ -160,9 +160,7 @@ public class HttpPollTransport extends ThrottleableTransport {
                     .url(url)
                     .headers(Headers.of(headers));
 
-            try {
-                final Response r = httpClient.newCall(requestBuilder.build()).execute();
-
+            try (final Response r = httpClient.newCall(requestBuilder.build()).execute()) {
                 if (!r.isSuccessful()) {
                     throw new RuntimeException("Expected successful HTTP status code [2xx], got " + r.code());
                 }

--- a/graylog2-server/src/main/java/org/graylog2/periodical/VersionCheckThread.java
+++ b/graylog2-server/src/main/java/org/graylog2/periodical/VersionCheckThread.java
@@ -108,43 +108,31 @@ public class VersionCheckThread extends Periodical {
                 .url(versionCheckUri.toString())
                 .build();
 
-        final Response response;
-        try {
-            response = httpClient.newCall(request).execute();
+        try (final Response response = httpClient.newCall(request).execute()) {
+            if (response.isSuccessful()) {
+                final VersionCheckResponse versionCheckResponse = objectMapper.readValue(response.body().byteStream(), VersionCheckResponse.class);
+
+                final VersionResponse version = versionCheckResponse.version;
+                final com.github.zafarkhaja.semver.Version reportedVersion = com.github.zafarkhaja.semver.Version.forIntegers(version.major, version.minor, version.patch);
+
+                LOG.debug("Version check reports current version: " + versionCheckResponse);
+                if (reportedVersion.greaterThan(ServerVersion.VERSION.getVersion())) {
+                    LOG.debug("Reported version is higher than ours ({}). Writing notification.", ServerVersion.VERSION);
+
+                    Notification notification = notificationService.buildNow()
+                            .addSeverity(Notification.Severity.NORMAL)
+                            .addType(Notification.Type.OUTDATED_VERSION)
+                            .addDetail("current_version", versionCheckResponse.toString());
+                    notificationService.publishIfFirst(notification);
+                } else {
+                    LOG.debug("Reported version is not higher than ours ({}).", ServerVersion.VERSION);
+                    notificationService.fixed(Notification.Type.OUTDATED_VERSION);
+                }
+            } else {
+                LOG.error("Version check unsuccessful (response code {}).", response.code());
+            }
         } catch (IOException e) {
             LOG.error("Couldn't perform version check", e);
-            return;
-        }
-
-        if (response.isSuccessful()) {
-            final VersionCheckResponse versionCheckResponse;
-            try {
-                versionCheckResponse = objectMapper.readValue(response.body().byteStream(), VersionCheckResponse.class);
-            } catch (IOException e) {
-                LOG.error("Couldn't parse version check response", e);
-                return;
-            } finally {
-                response.close();
-            }
-
-            final VersionResponse version = versionCheckResponse.version;
-            final com.github.zafarkhaja.semver.Version reportedVersion = com.github.zafarkhaja.semver.Version.forIntegers(version.major, version.minor, version.patch);
-
-            LOG.debug("Version check reports current version: " + versionCheckResponse);
-            if (reportedVersion.greaterThan(ServerVersion.VERSION.getVersion())) {
-                LOG.debug("Reported version is higher than ours ({}). Writing notification.", ServerVersion.VERSION);
-
-                Notification notification = notificationService.buildNow()
-                        .addSeverity(Notification.Severity.NORMAL)
-                        .addType(Notification.Type.OUTDATED_VERSION)
-                        .addDetail("current_version", versionCheckResponse.toString());
-                notificationService.publishIfFirst(notification);
-            } else {
-                LOG.debug("Reported version is not higher than ours ({}).", ServerVersion.VERSION);
-                notificationService.fixed(Notification.Type.OUTDATED_VERSION);
-            }
-        } else {
-            LOG.error("Version check unsuccessful (response code {}).", response.code());
         }
     }
 

--- a/graylog2-server/src/test/java/org/graylog2/alarmcallbacks/HTTPAlarmCallbackTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/alarmcallbacks/HTTPAlarmCallbackTest.java
@@ -190,7 +190,7 @@ public class HTTPAlarmCallbackTest {
         );
 
         expectedException.expect(AlarmCallbackException.class);
-        expectedException.expectMessage("Malformed URL");
+        expectedException.expectMessage("Malformed URL: !FOOBAR");
 
         alarmCallback.call(stream, checkResult);
     }


### PR DESCRIPTION
OkHttp Responses must be closed properly: https://github.com/square/okhttp/blob/parent-3.4.1/okhttp/src/main/java/okhttp3/ResponseBody.java#L37-L39

Refs #2811