### PR TITLE
remove ldap settings check from authenticators

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/security/realm/AccessTokenAuthenticator.java
+++ b/graylog2-server/src/main/java/org/graylog2/security/realm/AccessTokenAuthenticator.java
@@ -37,15 +37,12 @@ public class AccessTokenAuthenticator extends AuthenticatingRealm {
 
     private final AccessTokenService accessTokenService;
     private final UserService userService;
-    private final LdapUserAuthenticator ldapAuthenticator;
 
     @Inject
     AccessTokenAuthenticator(AccessTokenService accessTokenService,
-                             UserService userService,
-                             LdapUserAuthenticator ldapAuthenticator) {
+                             UserService userService) {
         this.accessTokenService = accessTokenService;
         this.userService = userService;
-        this.ldapAuthenticator = ldapAuthenticator;
         setAuthenticationTokenClass(AccessTokenAuthToken.class);
         setCachingEnabled(false);
         // the presence of a valid access token is enough, we don't have any other credentials
@@ -63,9 +60,6 @@ public class AccessTokenAuthenticator extends AuthenticatingRealm {
         final User user = userService.load(accessToken.getUserName());
         if (user == null) {
             return null;
-        }
-        if (user.isExternalUser() && !ldapAuthenticator.isEnabled()) {
-            throw new LockedAccountException("LDAP authentication is currently disabled.");
         }
         if (LOG.isDebugEnabled()) {
             LOG.debug("Found user {} for access token.", user);

--- a/graylog2-server/src/main/java/org/graylog2/security/realm/SessionAuthenticator.java
+++ b/graylog2-server/src/main/java/org/graylog2/security/realm/SessionAuthenticator.java
@@ -19,7 +19,6 @@ package org.graylog2.security.realm;
 import org.apache.shiro.authc.AuthenticationException;
 import org.apache.shiro.authc.AuthenticationInfo;
 import org.apache.shiro.authc.AuthenticationToken;
-import org.apache.shiro.authc.LockedAccountException;
 import org.apache.shiro.authc.SimpleAccount;
 import org.apache.shiro.authc.credential.AllowAllCredentialsMatcher;
 import org.apache.shiro.realm.AuthenticatingRealm;
@@ -42,12 +41,10 @@ public class SessionAuthenticator extends AuthenticatingRealm {
     public static final String X_GRAYLOG_NO_SESSION_EXTENSION = "X-Graylog-No-Session-Extension";
 
     private final UserService userService;
-    private final LdapUserAuthenticator ldapAuthenticator;
 
     @Inject
-    SessionAuthenticator(UserService userService, LdapUserAuthenticator ldapAuthenticator) {
+    SessionAuthenticator(UserService userService) {
         this.userService = userService;
-        this.ldapAuthenticator = ldapAuthenticator;
         // this realm either rejects a session, or allows the associated user implicitly
         setCredentialsMatcher(new AllowAllCredentialsMatcher());
         setAuthenticationTokenClass(SessionIdToken.class);
@@ -69,9 +66,6 @@ public class SessionAuthenticator extends AuthenticatingRealm {
         if (user == null) {
             LOG.debug("No user named {} found for session {}", username, sessionIdToken.getSessionId());
             return null;
-        }
-        if (user.isExternalUser() && !ldapAuthenticator.isEnabled()) {
-            throw new LockedAccountException("LDAP authentication is currently disabled.");
         }
 
         if (LOG.isDebugEnabled()) {


### PR DESCRIPTION
we no longer lock external accounts when ldap is disabled because other authenticators can also create external users now
if people require this we need to track which authenticator created the account in the first place, but that's too large a change for a bug fix release

fixes #2817