### PR TITLE
Add ClusterConfigService#get(String, Class<T>) method

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/cluster/ClusterConfigServiceImpl.java
+++ b/graylog2-server/src/main/java/org/graylog2/cluster/ClusterConfigServiceImpl.java
@@ -100,6 +100,22 @@ public class ClusterConfigServiceImpl implements ClusterConfigService {
 
     @Override
     public <T> T get(Class<T> type) {
+        final Object payload = getPayload(type);
+
+        if (payload == null) {
+            return null;
+        }
+
+        T result = extractPayload(payload, type);
+        if (result == null) {
+            LOG.error("Couldn't extract payload from cluster config (type: {})", type.getCanonicalName());
+        }
+
+        return result;
+    }
+
+    @Override
+    public <T> Object getPayload(Class<T> type) {
         ClusterConfig config = dbCollection.findOne(DBQuery.is("type", type.getCanonicalName()));
 
         if (config == null) {
@@ -107,12 +123,7 @@ public class ClusterConfigServiceImpl implements ClusterConfigService {
             return null;
         }
 
-        T result = extractPayload(config.payload(), type);
-        if (result == null) {
-            LOG.error("Couldn't extract payload from cluster config (type: {})", type.getCanonicalName());
-        }
-
-        return result;
+        return config.payload();
     }
 
     @Override

--- a/graylog2-server/src/main/java/org/graylog2/cluster/ClusterConfigServiceImpl.java
+++ b/graylog2-server/src/main/java/org/graylog2/cluster/ClusterConfigServiceImpl.java
@@ -99,31 +99,25 @@ public class ClusterConfigServiceImpl implements ClusterConfigService {
     }
 
     @Override
-    public <T> T get(Class<T> type) {
-        final Object payload = getPayload(type);
+    public <T> T get(String key, Class<T> type) {
+        ClusterConfig config = dbCollection.findOne(DBQuery.is("type", key));
 
-        if (payload == null) {
+        if (config == null) {
+            LOG.debug("Couldn't find cluster config of type {}", key);
             return null;
         }
 
-        T result = extractPayload(payload, type);
+        T result = extractPayload(config.payload(), type);
         if (result == null) {
-            LOG.error("Couldn't extract payload from cluster config (type: {})", type.getCanonicalName());
+            LOG.error("Couldn't extract payload from cluster config (type: {})", key);
         }
 
         return result;
     }
 
     @Override
-    public <T> Object getPayload(Class<T> type) {
-        ClusterConfig config = dbCollection.findOne(DBQuery.is("type", type.getCanonicalName()));
-
-        if (config == null) {
-            LOG.debug("Couldn't find cluster config of type {}", type.getCanonicalName());
-            return null;
-        }
-
-        return config.payload();
+    public <T> T get(Class<T> type) {
+        return get(type.getCanonicalName(), type);
     }
 
     @Override

--- a/graylog2-server/src/main/java/org/graylog2/plugin/cluster/ClusterConfigService.java
+++ b/graylog2-server/src/main/java/org/graylog2/plugin/cluster/ClusterConfigService.java
@@ -32,6 +32,17 @@ public interface ClusterConfigService {
     <T> T get(Class<T> type);
 
     /**
+     * Retrieve config payload of a certain type from the cluster configuration.
+     *
+     * Useful for custom handling of the config payload.
+     *
+     * @param type The {@link Class} of the Java configuration bean to retrieve.
+     * @param <T>  The type of the Java configuration bean.
+     * @return The payload of the requested type or {@code null} if it couldn't be retrieved.
+     */
+    <T> Object getPayload(Class<T> type);
+
+    /**
      * Retrieve Java class of a certain type from the cluster configuration or return a default value
      * in case that failed.
      *

--- a/graylog2-server/src/main/java/org/graylog2/plugin/cluster/ClusterConfigService.java
+++ b/graylog2-server/src/main/java/org/graylog2/plugin/cluster/ClusterConfigService.java
@@ -32,15 +32,14 @@ public interface ClusterConfigService {
     <T> T get(Class<T> type);
 
     /**
-     * Retrieve config payload of a certain type from the cluster configuration.
+     * Retrieve Java class of a certain type for the given key from the cluster configuration.
      *
-     * Useful for custom handling of the config payload.
-     *
+     * @param key  The key that is used to find the cluster config object in the database.
      * @param type The {@link Class} of the Java configuration bean to retrieve.
      * @param <T>  The type of the Java configuration bean.
-     * @return The payload of the requested type or {@code null} if it couldn't be retrieved.
+     * @return An instance of the requested type or {@code null} if it couldn't be retrieved.
      */
-    <T> Object getPayload(Class<T> type);
+    <T> T get(String key, Class<T> type);
 
     /**
      * Retrieve Java class of a certain type from the cluster configuration or return a default value

--- a/graylog2-server/src/test/java/org/graylog2/cluster/ClusterConfigServiceImplTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/cluster/ClusterConfigServiceImplTest.java
@@ -141,6 +141,34 @@ public class ClusterConfigServiceImplTest {
 
     @Test
     @UsingDataSet(loadStrategy = LoadStrategyEnum.DELETE_ALL)
+    public void getAsObjectReturnsExistingConfig() throws Exception {
+        DBObject dbObject = new BasicDBObjectBuilder()
+                .add("type", CustomConfig.class.getCanonicalName())
+                .add("payload", Collections.singletonMap("text", "TEST"))
+                .add("last_updated", TIME.toString())
+                .add("last_updated_by", "ID")
+                .get();
+        final DBCollection collection = mongoConnection.getDatabase().getCollection(COLLECTION_NAME);
+        collection.save(dbObject);
+
+        assertThat(collection.count()).isEqualTo(1L);
+
+        Object customConfig = clusterConfigService.getPayload(CustomConfig.class);
+        assertThat(customConfig).isInstanceOf(Map.class);
+        assertThat(((Map) customConfig).get("text")).isEqualTo("TEST");
+    }
+
+    @Test
+    @UsingDataSet(loadStrategy = LoadStrategyEnum.DELETE_ALL)
+    public void getAsObjectReturnsNullOnNonExistingConfig() throws Exception {
+        final DBCollection collection = mongoConnection.getDatabase().getCollection(COLLECTION_NAME);
+        assertThat(collection.count()).isEqualTo(0L);
+
+        assertThat(clusterConfigService.getPayload(CustomConfig.class)).isNull();
+    }
+
+    @Test
+    @UsingDataSet(loadStrategy = LoadStrategyEnum.DELETE_ALL)
     public void getOrDefaultReturnsExistingConfig() throws Exception {
         DBObject dbObject = new BasicDBObjectBuilder()
                 .add("type", CustomConfig.class.getCanonicalName())

--- a/graylog2-server/src/test/java/org/graylog2/cluster/ClusterConfigServiceImplTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/cluster/ClusterConfigServiceImplTest.java
@@ -141,9 +141,9 @@ public class ClusterConfigServiceImplTest {
 
     @Test
     @UsingDataSet(loadStrategy = LoadStrategyEnum.DELETE_ALL)
-    public void getAsObjectReturnsExistingConfig() throws Exception {
+    public void getWithKeyReturnsExistingConfig() throws Exception {
         DBObject dbObject = new BasicDBObjectBuilder()
-                .add("type", CustomConfig.class.getCanonicalName())
+                .add("type", "foo")
                 .add("payload", Collections.singletonMap("text", "TEST"))
                 .add("last_updated", TIME.toString())
                 .add("last_updated_by", "ID")
@@ -153,18 +153,18 @@ public class ClusterConfigServiceImplTest {
 
         assertThat(collection.count()).isEqualTo(1L);
 
-        Object customConfig = clusterConfigService.getPayload(CustomConfig.class);
-        assertThat(customConfig).isInstanceOf(Map.class);
-        assertThat(((Map) customConfig).get("text")).isEqualTo("TEST");
+        CustomConfig customConfig = clusterConfigService.get("foo", CustomConfig.class);
+        assertThat(customConfig).isInstanceOf(CustomConfig.class);
+        assertThat(customConfig.text).isEqualTo("TEST");
     }
 
     @Test
     @UsingDataSet(loadStrategy = LoadStrategyEnum.DELETE_ALL)
-    public void getAsObjectReturnsNullOnNonExistingConfig() throws Exception {
+    public void getWithKeyReturnsNullOnNonExistingConfig() throws Exception {
         final DBCollection collection = mongoConnection.getDatabase().getCollection(COLLECTION_NAME);
         assertThat(collection.count()).isEqualTo(0L);
 
-        assertThat(clusterConfigService.getPayload(CustomConfig.class)).isNull();
+        assertThat(clusterConfigService.get("foo", CustomConfig.class)).isNull();
     }
 
     @Test


### PR DESCRIPTION
## Description

This adds a `getPayload()` method to the `ClusterConfigService` interface. It's needed if you have to convert the config payload on your own and cannot rely on the cluster config to convert it to an object.

## Motivation and Context

Using `@JsonSubTypes` does not work with `ClusterConfigService#get()` because we have to pass the concrete class to the method but the object mapper needs the super type.