### PR TITLE
Fix NPE in Indices#numberOfMessages(String)

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/indexer/indices/Indices.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/indices/Indices.java
@@ -66,6 +66,7 @@ import org.elasticsearch.common.collect.ImmutableOpenMap;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.unit.TimeValue;
 import org.elasticsearch.index.query.QueryBuilders;
+import org.elasticsearch.index.shard.DocsStats;
 import org.elasticsearch.indices.IndexClosedException;
 import org.elasticsearch.search.SearchHit;
 import org.elasticsearch.search.aggregations.AggregationBuilders;
@@ -186,7 +187,9 @@ public class Indices {
             throw new IndexNotFoundException("Couldn't find index " + indexName);
         }
 
-        return index.getPrimaries().getDocs().getCount();
+        final DocsStats docsStats = index.getPrimaries().getDocs();
+
+        return docsStats == null ? 0L : docsStats.getCount();
     }
 
     public Map<String, IndexStats> getAll() {


### PR DESCRIPTION
## Description

[`CommonStats#getDocs()`](https://static.javadoc.io/org.elasticsearch/elasticsearch/2.4.0/org/elasticsearch/action/admin/indices/stats/CommonStats.html#getDocs()) might be `null` but the `Indices#numberOfMessages(String)` method didn't take this into account, leading to a `NullPointerException` in rare cases.

Refs https://groups.google.com/d/msg/graylog2/wrvs1jW40wI/ao8Xw-73AwAJ

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.