### PR TITLE
Fix NPE in MongoProbe if MongoDB doesn't run with MMAPv1

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/system/stats/mongo/MongoProbe.java
+++ b/graylog2-server/src/main/java/org/graylog2/system/stats/mongo/MongoProbe.java
@@ -210,7 +210,7 @@ public class MongoProbe {
                     memoryMap.getInt("virtual"),
                     memoryMap.getBoolean("supported"),
                     memoryMap.getInt("mapped"),
-                    memoryMap.getInt("mappedWithJournal")
+                    memoryMap.getInt("mappedWithJournal", -1)
             );
 
             final BasicDBObject storageEngineMap = (BasicDBObject) serverStatusResult.get("storageEngine");


### PR DESCRIPTION
## Description

The `MongoProbe` data collector expects the `mem.mappedWithJournal` field to be present in the MongoDB `serverStatus` output.

As it turns out, this value is only available if the MMAPv1 storage engine is being used.

Refs https://docs.mongodb.com/v3.2/reference/command/serverStatus/#serverstatus.mem.mappedWithJournal
Refs https://groups.google.com/d/msg/graylog2/Zjfn2YA4QnY/OzGy1dZnBAAJ

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.