### PR TITLE
Proposal to make document title dynamic

### DIFF
--- a/graylog2-web-interface/src/components/common/DocumentTitle.jsx
+++ b/graylog2-web-interface/src/components/common/DocumentTitle.jsx
@@ -1,0 +1,28 @@
+import React from 'react';
+
+const DocumentTitle = React.createClass({
+  propTypes: {
+    title: React.PropTypes.string.isRequired,
+    children: React.PropTypes.oneOfType([
+      React.PropTypes.arrayOf(React.PropTypes.element),
+      React.PropTypes.element,
+    ]).isRequired,
+  },
+
+  componentDidMount() {
+    this.originalTitle = document.title;
+    document.title = `${document.title} - ${this.props.title}`;
+  },
+
+  componentWillUnmount() {
+    document.title = this.originalTitle;
+  },
+
+  originalTitle: undefined,
+
+  render() {
+    return this.props.children;
+  },
+});
+
+export default DocumentTitle;

--- a/graylog2-web-interface/src/components/common/index.jsx
+++ b/graylog2-web-interface/src/components/common/index.jsx
@@ -3,6 +3,7 @@ export { default as ClipboardButton } from './ClipboardButton';
 export { default as DataFilter } from './DataFilter';
 export { default as DataTable } from './DataTable';
 export { default as DatePicker } from './DatePicker';
+export { default as DocumentTitle } from './DocumentTitle';
 export { default as EntityList } from './EntityList';
 export { default as EntityListItem } from './EntityListItem';
 export { default as GridsterContainer } from './GridsterContainer';

--- a/graylog2-web-interface/src/pages/NodesPage.jsx
+++ b/graylog2-web-interface/src/pages/NodesPage.jsx
@@ -4,25 +4,27 @@ import Reflux from 'reflux';
 import StoreProvider from 'injection/StoreProvider';
 const CurrentUserStore = StoreProvider.getStore('CurrentUser');
 
-import { PageHeader } from 'components/common';
+import { DocumentTitle, PageHeader } from 'components/common';
 import { NodesList } from 'components/nodes';
 
 const NodesPage = React.createClass({
   mixins: [Reflux.connect(CurrentUserStore)],
   render() {
     return (
-      <div>
-        <PageHeader title="Nodes">
-          <span>This page provides a real-time overview of the nodes in your Graylog cluster.</span>
+      <DocumentTitle title="Nodes">
+        <div>
+          <PageHeader title="Nodes">
+            <span>This page provides a real-time overview of the nodes in your Graylog cluster.</span>
 
-          <span>
-            You can pause message processing at any time. The process buffers will not accept any new messages until
-            you resume it. If the message journal is enabled for a node, which it is by default, incoming messages
-            will be persisted to disk, even when processing is disabled.
-          </span>
-        </PageHeader>
-        <NodesList permissions={this.state.currentUser.permissions}/>
-      </div>
+            <span>
+              You can pause message processing at any time. The process buffers will not accept any new messages until
+              you resume it. If the message journal is enabled for a node, which it is by default, incoming messages
+              will be persisted to disk, even when processing is disabled.
+            </span>
+          </PageHeader>
+          <NodesList permissions={this.state.currentUser.permissions}/>
+        </div>
+      </DocumentTitle>
     );
   },
 });


### PR DESCRIPTION
Introduce a component that takes care of modifying the document title (called `DocumentTitle` in a very original way). This component should be used in all pages that want to modify the original title, like in the example provided. The reason for doing this in the page level instead of `AppRouter`, is that sometimes we will need some data to display in the title that is only loaded with the page.

If we want to proceed with this, I can take care of modifying other pages to use `DocumentTitle`.

Refs #2834