### PR TITLE
Only create new LdapConnectionConfig if LDAP is enabled

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/security/realm/LdapUserAuthenticator.java
+++ b/graylog2-server/src/main/java/org/graylog2/security/realm/LdapUserAuthenticator.java
@@ -87,12 +87,12 @@ public class LdapUserAuthenticator extends AuthenticatingRealm {
         // safe, we only handle this type
         final UsernamePasswordToken token = (UsernamePasswordToken) authtoken;
 
-        final LdapConnectionConfig config = new LdapConnectionConfig();
         final LdapSettings ldapSettings = ldapSettingsService.load();
         if (ldapSettings == null || !ldapSettings.isEnabled()) {
             LOG.trace("LDAP is disabled, skipping");
             return null;
         }
+        final LdapConnectionConfig config = new LdapConnectionConfig();
         config.setLdapHost(ldapSettings.getUri().getHost());
         config.setLdapPort(ldapSettings.getUri().getPort());
         config.setUseSsl(ldapSettings.getUri().getScheme().startsWith("ldaps"));


### PR DESCRIPTION
Improves throughput with a benchmark testing the /system endpoint from 2079 req/s to 4208 req/s.

```
Running 1m test @ http://192.168.178.56:9000/api/system
  50 threads and 60 connections
  Thread Stats   Avg      Stdev     Max   +/- Stdev
    Latency    24.03ms    3.70ms  85.41ms   79.08%
    Req/Sec    41.62      4.94    50.00     73.33%
  124907 requests in 1.00m, 71.21MB read
Requests/sec:   2079.82
Transfer/sec:      1.19MB

Running 1m test @ http://192.168.178.56:9000/api/system
  50 threads and 60 connections
  Thread Stats   Avg      Stdev     Max   +/- Stdev
    Latency    11.88ms    2.28ms  81.38ms   81.08%
    Req/Sec    84.25      7.69   150.00     88.03%
  252744 requests in 1.00m, 143.92MB read
Requests/sec:   4208.64
Transfer/sec:      2.40MB
```