### PR TITLE
Improve Grizzly web server setup

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/plugin/BaseConfiguration.java
+++ b/graylog2-server/src/main/java/org/graylog2/plugin/BaseConfiguration.java
@@ -82,6 +82,9 @@ public abstract class BaseConfiguration {
     @Parameter(value = "rest_thread_pool_size", required = true, validator = PositiveIntegerValidator.class)
     private int restThreadPoolSize = 16;
 
+    @Parameter(value = "rest_selector_runners_count", required = true, validator = PositiveIntegerValidator.class)
+    private int restSelectorRunnersCount = 1;
+
     @Parameter(value = "rest_enable_tls")
     private boolean restEnableTls = false;
 
@@ -153,6 +156,9 @@ public abstract class BaseConfiguration {
 
     @Parameter(value = "web_thread_pool_size", required = true, validator = PositiveIntegerValidator.class)
     private int webThreadPoolSize = 16;
+
+    @Parameter(value = "web_selector_runners_count", required = true, validator = PositiveIntegerValidator.class)
+    private int webSelectorRunnersCount = 1;
 
     @Parameter(value = "web_tls_cert_file")
     private Path webTlsCertFile;
@@ -289,6 +295,10 @@ public abstract class BaseConfiguration {
         return restThreadPoolSize;
     }
 
+    public int getRestSelectorRunnersCount() {
+        return restSelectorRunnersCount;
+    }
+
     public boolean isRestEnableTls() {
         return restEnableTls;
     }
@@ -405,6 +415,10 @@ public abstract class BaseConfiguration {
 
     public int getWebThreadPoolSize() {
         return webThreadPoolSize;
+    }
+
+    public int getWebSelectorRunnersCount() {
+        return webSelectorRunnersCount;
     }
 
     public Path getWebTlsCertFile() {

--- a/graylog2-server/src/main/java/org/graylog2/shared/initializers/JerseyService.java
+++ b/graylog2-server/src/main/java/org/graylog2/shared/initializers/JerseyService.java
@@ -160,6 +160,7 @@ public class JerseyService extends AbstractIdleService {
                 listenUri,
                 sslEngineConfigurator,
                 configuration.getWebThreadPoolSize(),
+                configuration.getWebSelectorRunnersCount(),
                 configuration.getWebMaxInitialLineLength(),
                 configuration.getWebMaxHeaderSize(),
                 configuration.isWebEnableGzip(),
@@ -216,6 +217,7 @@ public class JerseyService extends AbstractIdleService {
                 listenUri,
                 sslEngineConfigurator,
                 configuration.getRestThreadPoolSize(),
+                configuration.getRestSelectorRunnersCount(),
                 configuration.getRestMaxInitialLineLength(),
                 configuration.getRestMaxHeaderSize(),
                 configuration.isRestEnableGzip(),
@@ -320,6 +322,7 @@ public class JerseyService extends AbstractIdleService {
                              URI listenUri,
                              SSLEngineConfigurator sslEngineConfigurator,
                              int threadPoolSize,
+                             int selectorRunnersCount,
                              int maxInitialLineLength,
                              int maxHeaderSize,
                              boolean enableGzip,
@@ -338,7 +341,8 @@ public class JerseyService extends AbstractIdleService {
                 listenUri,
                 resourceConfig,
                 sslEngineConfigurator != null,
-                sslEngineConfigurator);
+                sslEngineConfigurator,
+                false);
 
         final NetworkListener listener = httpServer.getListener("grizzly");
         listener.setMaxHttpHeaderSize(maxInitialLineLength);
@@ -349,6 +353,11 @@ public class JerseyService extends AbstractIdleService {
                 namePrefix + "-worker-%d",
                 threadPoolSize);
         listener.getTransport().setWorkerThreadPool(workerThreadPoolExecutor);
+
+        // The Grizzly default value is equal to `Runtime.getRuntime().availableProcessors()` which doesn't make
+        // sense for Graylog because we are not mainly a web server.
+        // See "Selector runners count" at https://grizzly.java.net/bestpractices.html for details.
+        listener.getTransport().setSelectorRunnersCount(selectorRunnersCount);
 
         return httpServer;
     }


### PR DESCRIPTION
- Do not start Grizzly immediately when creating a new HttpServer instance to avoid the creation of a dangling thread pool
- Reduce default transport selector runners to 1

We used to start the Grizzly server when calling GrizzlyHttpServerFactory.createHttpServer(), then modified the thread pool settings and then started the server again. This resulted in a dangling thread pool that isn't used at all.

The default transport selector runners is equal to the number of CPU cores in the system. This might make sense for pure web server work loads but not for Graylog where we have tons of other work besides serving the API/web. Change the default to 1 and make the setting configurable.