### PR TITLE
Avoid ObjectMapper injection into every RestResource subclass

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/rest/resources/system/ClusterConfigResource.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/resources/system/ClusterConfigResource.java
@@ -18,6 +18,7 @@ package org.graylog2.rest.resources.system;
 
 import com.codahale.metrics.annotation.Timed;
 import com.fasterxml.jackson.databind.JsonMappingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.module.jsonSchema.JsonSchema;
 import com.fasterxml.jackson.module.jsonSchema.factories.SchemaFactoryWrapper;
 import io.swagger.annotations.Api;
@@ -64,14 +65,18 @@ import static java.util.Objects.requireNonNull;
 @Produces(MediaType.APPLICATION_JSON)
 public class ClusterConfigResource extends RestResource {
     private static final Logger LOG = LoggerFactory.getLogger(ClusterConfigResource.class);
-    
+
     private final ClusterConfigService clusterConfigService;
     private final ChainingClassLoader chainingClassLoader;
+    private final ObjectMapper objectMapper;
 
     @Inject
-    public ClusterConfigResource(ClusterConfigService clusterConfigService, ChainingClassLoader chainingClassLoader) {
+    public ClusterConfigResource(ClusterConfigService clusterConfigService,
+                                 ChainingClassLoader chainingClassLoader,
+                                 ObjectMapper objectMapper) {
         this.clusterConfigService = requireNonNull(clusterConfigService);
         this.chainingClassLoader = chainingClassLoader;
+        this.objectMapper = objectMapper;
     }
 
     @GET

--- a/graylog2-server/src/main/java/org/graylog2/rest/resources/system/indices/RetentionStrategyResource.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/resources/system/indices/RetentionStrategyResource.java
@@ -18,6 +18,7 @@ package org.graylog2.rest.resources.system.indices;
 
 import com.codahale.metrics.annotation.Timed;
 import com.fasterxml.jackson.databind.JsonMappingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.module.jsonSchema.factories.SchemaFactoryWrapper;
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
@@ -66,12 +67,15 @@ public class RetentionStrategyResource extends RestResource {
     private static final Logger LOG = LoggerFactory.getLogger(RetentionStrategyResource.class);
 
     private final Map<String, Provider<RetentionStrategy>> retentionStrategies;
+    private final ObjectMapper objectMapper;
     private final ClusterConfigService clusterConfigService;
 
     @Inject
     public RetentionStrategyResource(Map<String, Provider<RetentionStrategy>> retentionStrategies,
+                                     ObjectMapper objectMapper,
                                      ClusterConfigService clusterConfigService) {
         this.retentionStrategies = requireNonNull(retentionStrategies);
+        this.objectMapper = objectMapper;
         this.clusterConfigService = requireNonNull(clusterConfigService);
     }
 

--- a/graylog2-server/src/main/java/org/graylog2/rest/resources/system/indices/RotationStrategyResource.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/resources/system/indices/RotationStrategyResource.java
@@ -18,6 +18,7 @@ package org.graylog2.rest.resources.system.indices;
 
 import com.codahale.metrics.annotation.Timed;
 import com.fasterxml.jackson.databind.JsonMappingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.module.jsonSchema.factories.SchemaFactoryWrapper;
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
@@ -60,12 +61,15 @@ import static java.util.Objects.requireNonNull;
 @RequiresAuthentication
 public class RotationStrategyResource extends RestResource {
     private final Map<String, Provider<RotationStrategy>> rotationStrategies;
+    private final ObjectMapper objectMapper;
     private final ClusterConfigService clusterConfigService;
 
     @Inject
     public RotationStrategyResource(Map<String, Provider<RotationStrategy>> rotationStrategies,
+                                    ObjectMapper objectMapper,
                                     ClusterConfigService clusterConfigService) {
         this.rotationStrategies = requireNonNull(rotationStrategies);
+        this.objectMapper = objectMapper;
         this.clusterConfigService = requireNonNull(clusterConfigService);
     }
 

--- a/graylog2-server/src/main/java/org/graylog2/shared/rest/resources/RestResource.java
+++ b/graylog2-server/src/main/java/org/graylog2/shared/rest/resources/RestResource.java
@@ -17,7 +17,6 @@
 package org.graylog2.shared.rest.resources;
 
 import com.fasterxml.jackson.core.JsonGenerator;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.ObjectWriter;
 import com.fasterxml.jackson.jaxrs.cfg.EndpointConfigBase;
 import com.fasterxml.jackson.jaxrs.cfg.ObjectWriterInjector;
@@ -47,9 +46,6 @@ import java.util.Arrays;
 
 public abstract class RestResource {
     private static final Logger LOG = LoggerFactory.getLogger(RestResource.class);
-
-    @Inject
-    protected ObjectMapper objectMapper;
 
     @Inject
     protected UserService userService;

--- a/graylog2-server/src/main/java/org/graylog2/shared/rest/resources/documentation/DocumentationResource.java
+++ b/graylog2-server/src/main/java/org/graylog2/shared/rest/resources/documentation/DocumentationResource.java
@@ -17,6 +17,7 @@
 package org.graylog2.shared.rest.resources.documentation;
 
 import com.codahale.metrics.annotation.Timed;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
 import io.swagger.annotations.ApiParam;
@@ -50,15 +51,18 @@ import static org.graylog2.shared.initializers.JerseyService.PLUGIN_PREFIX;
 public class DocumentationResource extends RestResource {
 
     private BaseConfiguration configuration;
+    private final ObjectMapper objectMapper;
     private final Set<String> restControllerPackages = new HashSet<>();
     private final Map<Class<?>, String> pluginRestControllerMapping = new HashMap<>();
 
     @Inject
     public DocumentationResource(BaseConfiguration configuration,
                                  @Named("RestControllerPackages") String[] restControllerPackages,
+                                 ObjectMapper objectMapper,
                                  PluginRestResourceClasses pluginRestResourceClasses) {
 
         this.configuration = configuration;
+        this.objectMapper = objectMapper;
 
         this.restControllerPackages.addAll(Arrays.asList(restControllerPackages));
 


### PR DESCRIPTION
This removes a field injection of `ObjectMapper` into every `RestResource` subclass to avoid the injection overhead. This was only used in a few resources.