### PR TITLE
Make alert conditions pluggable

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/alerts/AbstractAlertCondition.java
+++ b/graylog2-server/src/main/java/org/graylog2/alerts/AbstractAlertCondition.java
@@ -76,8 +76,6 @@ public abstract class AbstractAlertCondition implements EmbeddedPersistable, Ale
         this.grace = getNumber(this.parameters.get("grace")).orElse(0).intValue();
     }
 
-    protected abstract AlertCondition.CheckResult runCheck();
-
     @Override
     public String getId() {
         return id;

--- a/graylog2-server/src/main/java/org/graylog2/alerts/AbstractAlertCondition.java
+++ b/graylog2-server/src/main/java/org/graylog2/alerts/AbstractAlertCondition.java
@@ -144,12 +144,6 @@ public abstract class AbstractAlertCondition implements EmbeddedPersistable, Ale
         return grace;
     }
 
-    public static class NoSuchAlertConditionTypeException extends Exception {
-        public NoSuchAlertConditionTypeException(String msg) {
-            super(msg);
-        }
-    }
-
     public static class CheckResult implements AlertCondition.CheckResult {
 
         private final boolean isTriggered;

--- a/graylog2-server/src/main/java/org/graylog2/alerts/AbstractAlertCondition.java
+++ b/graylog2-server/src/main/java/org/graylog2/alerts/AbstractAlertCondition.java
@@ -51,7 +51,7 @@ public abstract class AbstractAlertCondition implements EmbeddedPersistable, Ale
 
     protected final String id;
     protected final Stream stream;
-    protected final Type type;
+    protected final String type;
     protected final DateTime createdAt;
     protected final String creatorUserId;
     protected final int grace;
@@ -59,7 +59,7 @@ public abstract class AbstractAlertCondition implements EmbeddedPersistable, Ale
 
     private final Map<String, Object> parameters;
 
-    protected AbstractAlertCondition(Stream stream, String id, Type type, DateTime createdAt, String creatorUserId, Map<String, Object> parameters, String title) {
+    protected AbstractAlertCondition(Stream stream, String id, String type, DateTime createdAt, String creatorUserId, Map<String, Object> parameters, String title) {
         this.title = title;
         if (id == null) {
             this.id = UUID.randomUUID().toString();
@@ -83,7 +83,7 @@ public abstract class AbstractAlertCondition implements EmbeddedPersistable, Ale
         return id;
     }
 
-    public Type getType() {
+    public String getType() {
         return type;
     }
 

--- a/graylog2-server/src/main/java/org/graylog2/alerts/AlertConditionBindings.java
+++ b/graylog2-server/src/main/java/org/graylog2/alerts/AlertConditionBindings.java
@@ -16,27 +16,21 @@
  */
 package org.graylog2.alerts;
 
-import com.google.inject.multibindings.MapBinder;
 import org.graylog2.alerts.types.FieldContentValueAlertCondition;
 import org.graylog2.alerts.types.FieldValueAlertCondition;
 import org.graylog2.alerts.types.MessageCountAlertCondition;
-import org.graylog2.plugin.alarms.AlertCondition;
-import org.graylog2.plugin.inject.Graylog2Module;
+import org.graylog2.plugin.PluginModule;
 
-public class AlertConditionBindings extends Graylog2Module {
+public class AlertConditionBindings extends PluginModule {
     @Override
     protected void configure() {
-        MapBinder<String, AlertCondition.Factory> alertConditionBinder = alertConditionBinder();
-        installAlertConditionWithCustomName(alertConditionBinder,
-            AbstractAlertCondition.Type.FIELD_CONTENT_VALUE.toString(),
+        addAlertCondition(AbstractAlertCondition.Type.FIELD_CONTENT_VALUE.toString(),
             FieldContentValueAlertCondition.class,
             FieldContentValueAlertCondition.Factory.class);
-        installAlertConditionWithCustomName(alertConditionBinder,
-            AbstractAlertCondition.Type.FIELD_VALUE.toString(),
+        addAlertCondition(AbstractAlertCondition.Type.FIELD_VALUE.toString(),
             FieldValueAlertCondition.class,
             FieldValueAlertCondition.Factory.class);
-        installAlertConditionWithCustomName(alertConditionBinder,
-            AbstractAlertCondition.Type.MESSAGE_COUNT.toString(),
+        addAlertCondition(AbstractAlertCondition.Type.MESSAGE_COUNT.toString(),
             MessageCountAlertCondition.class,
             MessageCountAlertCondition.Factory.class);
     }

--- a/graylog2-server/src/main/java/org/graylog2/alerts/AlertConditionBindings.java
+++ b/graylog2-server/src/main/java/org/graylog2/alerts/AlertConditionBindings.java
@@ -1,0 +1,27 @@
+package org.graylog2.alerts;
+
+import com.google.inject.multibindings.MapBinder;
+import org.graylog2.alerts.types.FieldContentValueAlertCondition;
+import org.graylog2.alerts.types.FieldValueAlertCondition;
+import org.graylog2.alerts.types.MessageCountAlertCondition;
+import org.graylog2.plugin.alarms.AlertCondition;
+import org.graylog2.plugin.inject.Graylog2Module;
+
+public class AlertConditionBindings extends Graylog2Module {
+    @Override
+    protected void configure() {
+        MapBinder<String, AlertCondition.Factory> alertConditionBinder = alertConditionBinder();
+        installAlertConditionWithCustomName(alertConditionBinder,
+            AbstractAlertCondition.Type.FIELD_CONTENT_VALUE.toString(),
+            FieldContentValueAlertCondition.class,
+            FieldContentValueAlertCondition.Factory.class);
+        installAlertConditionWithCustomName(alertConditionBinder,
+            AbstractAlertCondition.Type.FIELD_VALUE.toString(),
+            FieldValueAlertCondition.class,
+            FieldValueAlertCondition.Factory.class);
+        installAlertConditionWithCustomName(alertConditionBinder,
+            AbstractAlertCondition.Type.MESSAGE_COUNT.toString(),
+            MessageCountAlertCondition.class,
+            MessageCountAlertCondition.Factory.class);
+    }
+}

--- a/graylog2-server/src/main/java/org/graylog2/alerts/AlertConditionBindings.java
+++ b/graylog2-server/src/main/java/org/graylog2/alerts/AlertConditionBindings.java
@@ -1,3 +1,19 @@
+/**
+ * This file is part of Graylog.
+ *
+ * Graylog is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package org.graylog2.alerts;
 
 import com.google.inject.multibindings.MapBinder;

--- a/graylog2-server/src/main/java/org/graylog2/alerts/AlertService.java
+++ b/graylog2-server/src/main/java/org/graylog2/alerts/AlertService.java
@@ -39,10 +39,10 @@ public interface AlertService extends PersistedService {
     long totalCount();
     long totalCountForStream(String streamId);
 
-    AlertCondition fromPersisted(Map<String, Object> conditionFields, Stream stream) throws AbstractAlertCondition.NoSuchAlertConditionTypeException;
-    AlertCondition fromRequest(CreateConditionRequest ccr, Stream stream, String userId) throws AbstractAlertCondition.NoSuchAlertConditionTypeException;
+    AlertCondition fromPersisted(Map<String, Object> conditionFields, Stream stream);
+    AlertCondition fromRequest(CreateConditionRequest ccr, Stream stream, String userId);
 
-    AlertCondition updateFromRequest(AlertCondition alertCondition, CreateConditionRequest ccr) throws AbstractAlertCondition.NoSuchAlertConditionTypeException;
+    AlertCondition updateFromRequest(AlertCondition alertCondition, CreateConditionRequest ccr);
 
     boolean inGracePeriod(AlertCondition alertCondition);
 

--- a/graylog2-server/src/main/java/org/graylog2/alerts/AlertServiceImpl.java
+++ b/graylog2-server/src/main/java/org/graylog2/alerts/AlertServiceImpl.java
@@ -129,7 +129,7 @@ public class AlertServiceImpl extends PersistedServiceImpl implements AlertServi
     }
 
     @Override
-    public AlertCondition fromPersisted(Map<String, Object> fields, Stream stream) throws AbstractAlertCondition.NoSuchAlertConditionTypeException {
+    public AlertCondition fromPersisted(Map<String, Object> fields, Stream stream) {
         final String type = (String)fields.get("type");
 
         return createAlertCondition(type,
@@ -147,7 +147,7 @@ public class AlertServiceImpl extends PersistedServiceImpl implements AlertServi
                                                 DateTime createdAt,
                                                 String creatorId,
                                                 Map<String, Object> parameters,
-                                                String title) throws AbstractAlertCondition.NoSuchAlertConditionTypeException {
+                                                String title) {
 
         final AlertCondition.Factory factory = this.alertConditionMap.get(type);
         checkArgument(factory != null, "Unknown alert condition type: " + type);
@@ -156,17 +156,15 @@ public class AlertServiceImpl extends PersistedServiceImpl implements AlertServi
     }
 
     @Override
-    public AlertCondition fromRequest(CreateConditionRequest ccr, Stream stream, String userId) throws AbstractAlertCondition.NoSuchAlertConditionTypeException {
+    public AlertCondition fromRequest(CreateConditionRequest ccr, Stream stream, String userId) {
         final String type = ccr.type();
-        if (type == null) {
-            throw new AbstractAlertCondition.NoSuchAlertConditionTypeException("Missing alert condition type");
-        }
+        checkArgument(type != null, "Milling alert condition type");
 
         return createAlertCondition(type, stream, null, Tools.nowUTC(), userId, ccr.parameters(), ccr.title());
     }
 
     @Override
-    public AlertCondition updateFromRequest(AlertCondition alertCondition, CreateConditionRequest ccr) throws AbstractAlertCondition.NoSuchAlertConditionTypeException {
+    public AlertCondition updateFromRequest(AlertCondition alertCondition, CreateConditionRequest ccr) {
         final String type = ((AbstractAlertCondition) alertCondition).getType();
 
         final Map<String, Object> parameters = ccr.parameters();

--- a/graylog2-server/src/main/java/org/graylog2/alerts/AlertServiceImpl.java
+++ b/graylog2-server/src/main/java/org/graylog2/alerts/AlertServiceImpl.java
@@ -130,14 +130,9 @@ public class AlertServiceImpl extends PersistedServiceImpl implements AlertServi
 
     @Override
     public AlertCondition fromPersisted(Map<String, Object> fields, Stream stream) throws AbstractAlertCondition.NoSuchAlertConditionTypeException {
-        AbstractAlertCondition.Type type;
-        try {
-            type = AbstractAlertCondition.Type.valueOf(((String) fields.get("type")).toUpperCase(Locale.ENGLISH));
-        } catch (IllegalArgumentException e) {
-            throw new AbstractAlertCondition.NoSuchAlertConditionTypeException("No such alert condition type: [" + fields.get("type") + "]");
-        }
+        final String type = (String)fields.get("type");
 
-        return createAlertCondition(type.toString(),
+        return createAlertCondition(type,
             stream,
             (String) fields.get("id"),
             DateTime.parse((String) fields.get("created_at")),

--- a/graylog2-server/src/main/java/org/graylog2/alerts/AlertServiceImpl.java
+++ b/graylog2-server/src/main/java/org/graylog2/alerts/AlertServiceImpl.java
@@ -44,22 +44,18 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 
+import static com.google.common.base.Preconditions.checkArgument;
+
 public class AlertServiceImpl extends PersistedServiceImpl implements AlertService {
     private static final Logger LOG = LoggerFactory.getLogger(AlertServiceImpl.class);
 
-    private final FieldValueAlertCondition.Factory fieldValueAlertFactory;
-    private final MessageCountAlertCondition.Factory messageCountAlertFactory;
-    private final FieldContentValueAlertCondition.Factory fieldContentValueAlertFactory;
+    private final Map<String, AlertCondition.Factory> alertConditionMap;
 
     @Inject
     public AlertServiceImpl(MongoConnection mongoConnection,
-                            FieldValueAlertCondition.Factory fieldValueAlertFactory,
-                            MessageCountAlertCondition.Factory messageCountAlertFactory,
-                            FieldContentValueAlertCondition.Factory fieldContentValueAlertFactory) {
+                            Map<String, AlertCondition.Factory> alertConditionMap) {
         super(mongoConnection);
-        this.fieldValueAlertFactory = fieldValueAlertFactory;
-        this.messageCountAlertFactory = messageCountAlertFactory;
-        this.fieldContentValueAlertFactory = fieldContentValueAlertFactory;
+        this.alertConditionMap = alertConditionMap;
     }
 
     @Override
@@ -141,7 +137,7 @@ public class AlertServiceImpl extends PersistedServiceImpl implements AlertServi
             throw new AbstractAlertCondition.NoSuchAlertConditionTypeException("No such alert condition type: [" + fields.get("type") + "]");
         }
 
-        return createAlertCondition(type,
+        return createAlertCondition(type.toString(),
             stream,
             (String) fields.get("id"),
             DateTime.parse((String) fields.get("created_at")),
@@ -150,45 +146,33 @@ public class AlertServiceImpl extends PersistedServiceImpl implements AlertServi
             (String) fields.get("title"));
     }
 
-    private AbstractAlertCondition createAlertCondition(AbstractAlertCondition.Type type,
-                                                        Stream stream,
-                                                        String id,
-                                                        DateTime createdAt,
-                                                        String creatorId,
-                                                        Map<String, Object> parameters,
-                                                        String title) throws AbstractAlertCondition.NoSuchAlertConditionTypeException {
-        switch (type) {
-            case MESSAGE_COUNT:
-                return messageCountAlertFactory.createAlertCondition(stream, id, createdAt, creatorId, parameters, title);
-            case FIELD_VALUE:
-                return fieldValueAlertFactory.createAlertCondition(stream, id, createdAt, creatorId, parameters, title);
-            case FIELD_CONTENT_VALUE:
-                return fieldContentValueAlertFactory.createAlertCondition(stream, id, createdAt, creatorId, parameters, title);
-            default:
-                throw new AbstractAlertCondition.NoSuchAlertConditionTypeException("Unhandled alert condition type: " + type);
-        }
+    private AlertCondition createAlertCondition(String type,
+                                                Stream stream,
+                                                String id,
+                                                DateTime createdAt,
+                                                String creatorId,
+                                                Map<String, Object> parameters,
+                                                String title) throws AbstractAlertCondition.NoSuchAlertConditionTypeException {
+
+        final AlertCondition.Factory factory = this.alertConditionMap.get(type);
+        checkArgument(factory != null, "Unknown alert condition type: " + type);
+
+        return factory.create(stream, id, createdAt, creatorId, parameters, title);
     }
 
     @Override
-    public AbstractAlertCondition fromRequest(CreateConditionRequest ccr, Stream stream, String userId) throws AbstractAlertCondition.NoSuchAlertConditionTypeException {
+    public AlertCondition fromRequest(CreateConditionRequest ccr, Stream stream, String userId) throws AbstractAlertCondition.NoSuchAlertConditionTypeException {
         final String type = ccr.type();
         if (type == null) {
             throw new AbstractAlertCondition.NoSuchAlertConditionTypeException("Missing alert condition type");
         }
 
-        final AbstractAlertCondition.Type alertConditionType;
-        try {
-            alertConditionType = AbstractAlertCondition.Type.valueOf(type.toUpperCase(Locale.ENGLISH));
-        } catch (IllegalArgumentException e) {
-            throw new AbstractAlertCondition.NoSuchAlertConditionTypeException("No such alert condition type: [" + type + "]");
-        }
-
-        return createAlertCondition(alertConditionType, stream, null, Tools.nowUTC(), userId, ccr.parameters(), ccr.title());
+        return createAlertCondition(type, stream, null, Tools.nowUTC(), userId, ccr.parameters(), ccr.title());
     }
 
     @Override
-    public AbstractAlertCondition updateFromRequest(AlertCondition alertCondition, CreateConditionRequest ccr) throws AbstractAlertCondition.NoSuchAlertConditionTypeException {
-        final AbstractAlertCondition.Type type = ((AbstractAlertCondition) alertCondition).getType();
+    public AlertCondition updateFromRequest(AlertCondition alertCondition, CreateConditionRequest ccr) throws AbstractAlertCondition.NoSuchAlertConditionTypeException {
+        final String type = ((AbstractAlertCondition) alertCondition).getType();
 
         final Map<String, Object> parameters = ccr.parameters();
         for (Map.Entry<String, Object> stringObjectEntry : alertCondition.getParameters().entrySet()) {

--- a/graylog2-server/src/main/java/org/graylog2/alerts/types/DummyAlertCondition.java
+++ b/graylog2-server/src/main/java/org/graylog2/alerts/types/DummyAlertCondition.java
@@ -27,7 +27,7 @@ public class DummyAlertCondition extends AbstractAlertCondition {
     final String description = "Dummy alert to test notifications";
 
     public DummyAlertCondition(Stream stream, String id, DateTime createdAt, String creatorUserId, Map<String, Object> parameters, String title) {
-        super(stream, id, Type.DUMMY, createdAt, creatorUserId, parameters, title);
+        super(stream, id, Type.DUMMY.toString(), createdAt, creatorUserId, parameters, title);
     }
 
     @Override

--- a/graylog2-server/src/main/java/org/graylog2/alerts/types/FieldContentValueAlertCondition.java
+++ b/graylog2-server/src/main/java/org/graylog2/alerts/types/FieldContentValueAlertCondition.java
@@ -83,7 +83,7 @@ public class FieldContentValueAlertCondition extends AbstractAlertCondition {
     }
 
     @Override
-    protected CheckResult runCheck() {
+    public CheckResult runCheck() {
         String filter = "streams:" + stream.getId();
         String query = field + ":\"" + value + "\"";
         Integer backlogSize = getBacklog();

--- a/graylog2-server/src/main/java/org/graylog2/alerts/types/FieldContentValueAlertCondition.java
+++ b/graylog2-server/src/main/java/org/graylog2/alerts/types/FieldContentValueAlertCondition.java
@@ -27,6 +27,7 @@ import org.graylog2.indexer.results.ResultMessage;
 import org.graylog2.indexer.results.SearchResult;
 import org.graylog2.indexer.searches.Searches;
 import org.graylog2.indexer.searches.Sorting;
+import org.graylog2.plugin.alarms.AlertCondition;
 import org.graylog2.plugin.indexer.searches.timeranges.InvalidRangeParametersException;
 import org.graylog2.plugin.indexer.searches.timeranges.RelativeRange;
 import org.graylog2.plugin.Message;
@@ -53,8 +54,8 @@ public class FieldContentValueAlertCondition extends AbstractAlertCondition {
     private final String field;
     private final String value;
 
-    public interface Factory {
-        FieldContentValueAlertCondition createAlertCondition(Stream stream,
+    public interface Factory extends AlertCondition.Factory {
+        FieldContentValueAlertCondition create(Stream stream,
                                                              @Assisted("id") String id,
                                                              DateTime createdAt,
                                                              @Assisted("userid") String creatorUserId,
@@ -71,7 +72,7 @@ public class FieldContentValueAlertCondition extends AbstractAlertCondition {
                                            @Assisted("userid") String creatorUserId,
                                            @Assisted Map<String, Object> parameters,
                                            @Assisted("title") @Nullable String title) {
-        super(stream, id, Type.FIELD_CONTENT_VALUE, createdAt, creatorUserId, parameters, title);
+        super(stream, id, Type.FIELD_CONTENT_VALUE.toString(), createdAt, creatorUserId, parameters, title);
         this.searches = searches;
         this.configuration = configuration;
         this.field = (String) parameters.get("field");

--- a/graylog2-server/src/main/java/org/graylog2/alerts/types/FieldContentValueAlertCondition.java
+++ b/graylog2-server/src/main/java/org/graylog2/alerts/types/FieldContentValueAlertCondition.java
@@ -56,11 +56,11 @@ public class FieldContentValueAlertCondition extends AbstractAlertCondition {
 
     public interface Factory extends AlertCondition.Factory {
         FieldContentValueAlertCondition create(Stream stream,
-                                                             @Assisted("id") String id,
-                                                             DateTime createdAt,
-                                                             @Assisted("userid") String creatorUserId,
-                                                             Map<String, Object> parameters,
-                                                             @Assisted("title") @Nullable String title);
+                                               @Assisted("id") String id,
+                                               DateTime createdAt,
+                                               @Assisted("userid") String creatorUserId,
+                                               Map<String, Object> parameters,
+                                               @Assisted("title") @Nullable String title);
     }
 
     @AssistedInject
@@ -97,12 +97,12 @@ public class FieldContentValueAlertCondition extends AbstractAlertCondition {
 
         try {
             SearchResult result = searches.search(
-                    query,
-                    filter,
-                    RelativeRange.create(configuration.getAlertCheckInterval()),
-                    searchLimit,
-                    0,
-                    new Sorting("timestamp", Sorting.Direction.DESC)
+                query,
+                filter,
+                RelativeRange.create(configuration.getAlertCheckInterval()),
+                searchLimit,
+                0,
+                new Sorting("timestamp", Sorting.Direction.DESC)
             );
 
             final List<MessageSummary> summaries;
@@ -119,7 +119,7 @@ public class FieldContentValueAlertCondition extends AbstractAlertCondition {
             final long count = result.getTotalResults();
 
             final String resultDescription = "Stream received messages matching <" + query + "> "
-                    + "(Current grace time: " + grace + " minutes)";
+                + "(Current grace time: " + grace + " minutes)";
 
             if (count > 0) {
                 LOG.debug("Alert check <{}> found [{}] messages.", id, count);

--- a/graylog2-server/src/main/java/org/graylog2/alerts/types/FieldValueAlertCondition.java
+++ b/graylog2-server/src/main/java/org/graylog2/alerts/types/FieldValueAlertCondition.java
@@ -108,7 +108,7 @@ public class FieldValueAlertCondition extends AbstractAlertCondition {
 
 
     @Override
-    protected CheckResult runCheck() {
+    public CheckResult runCheck() {
         try {
             final String filter = "streams:" + stream.getId();
             // TODO we don't support cardinality yet

--- a/graylog2-server/src/main/java/org/graylog2/alerts/types/FieldValueAlertCondition.java
+++ b/graylog2-server/src/main/java/org/graylog2/alerts/types/FieldValueAlertCondition.java
@@ -59,11 +59,11 @@ public class FieldValueAlertCondition extends AbstractAlertCondition {
 
     public interface Factory extends AlertCondition.Factory {
         FieldValueAlertCondition create(Stream stream,
-                                                      @Assisted("id") String id,
-                                                      DateTime createdAt,
-                                                      @Assisted("userid") String creatorUserId,
-                                                      Map<String, Object> parameters,
-                                                      @Assisted("title") @Nullable String title);
+                                        @Assisted("id") String id,
+                                        DateTime createdAt,
+                                        @Assisted("userid") String creatorUserId,
+                                        Map<String, Object> parameters,
+                                        @Assisted("title") @Nullable String title);
     }
 
     private final int time;
@@ -99,11 +99,11 @@ public class FieldValueAlertCondition extends AbstractAlertCondition {
     @Override
     public String getDescription() {
         return "time: " + time
-                + ", field: " + field
-                + ", check type: " + type.toString().toLowerCase(Locale.ENGLISH)
-                + ", threshold_type: " + thresholdType.toString().toLowerCase(Locale.ENGLISH)
-                + ", threshold: " + decimalFormat.format(threshold)
-                + ", grace: " + grace;
+            + ", field: " + field
+            + ", check type: " + type.toString().toLowerCase(Locale.ENGLISH)
+            + ", threshold_type: " + thresholdType.toString().toLowerCase(Locale.ENGLISH)
+            + ", threshold: " + decimalFormat.format(threshold)
+            + ", grace: " + grace;
     }
 
 
@@ -113,7 +113,7 @@ public class FieldValueAlertCondition extends AbstractAlertCondition {
             final String filter = "streams:" + stream.getId();
             // TODO we don't support cardinality yet
             final FieldStatsResult fieldStatsResult = searches.fieldStats(field, "*", filter,
-                                                                          RelativeRange.create(time * 60), false, true, false);
+                RelativeRange.create(time * 60), false, true, false);
 
             if (fieldStatsResult.getCount() == 0) {
                 LOG.debug("Alert check <{}> did not match any messages. Returning not triggered.", type);
@@ -164,9 +164,9 @@ public class FieldValueAlertCondition extends AbstractAlertCondition {
 
             if (triggered) {
                 final String resultDescription = "Field " + field + " had a " + type + " of "
-                        + decimalFormat.format(result) + " in the last " + time + " minutes with trigger condition "
-                        + thresholdType + " than " + decimalFormat.format(threshold) + ". "
-                        + "(Current grace time: " + grace + " minutes)";
+                    + decimalFormat.format(result) + " in the last " + time + " minutes with trigger condition "
+                    + thresholdType + " than " + decimalFormat.format(threshold) + ". "
+                    + "(Current grace time: " + grace + " minutes)";
 
                 final List<MessageSummary> summaries;
                 if (getBacklog() > 0) {

--- a/graylog2-server/src/main/java/org/graylog2/alerts/types/FieldValueAlertCondition.java
+++ b/graylog2-server/src/main/java/org/graylog2/alerts/types/FieldValueAlertCondition.java
@@ -24,6 +24,7 @@ import org.graylog2.indexer.InvalidRangeFormatException;
 import org.graylog2.indexer.results.FieldStatsResult;
 import org.graylog2.indexer.results.ResultMessage;
 import org.graylog2.indexer.searches.Searches;
+import org.graylog2.plugin.alarms.AlertCondition;
 import org.graylog2.plugin.indexer.searches.timeranges.InvalidRangeParametersException;
 import org.graylog2.plugin.indexer.searches.timeranges.RelativeRange;
 import org.graylog2.plugin.Message;
@@ -56,8 +57,8 @@ public class FieldValueAlertCondition extends AbstractAlertCondition {
         LOWER, HIGHER
     }
 
-    public interface Factory {
-        FieldValueAlertCondition createAlertCondition(Stream stream,
+    public interface Factory extends AlertCondition.Factory {
+        FieldValueAlertCondition create(Stream stream,
                                                       @Assisted("id") String id,
                                                       DateTime createdAt,
                                                       @Assisted("userid") String creatorUserId,
@@ -81,7 +82,7 @@ public class FieldValueAlertCondition extends AbstractAlertCondition {
                                     @Assisted("userid") String creatorUserId,
                                     @Assisted Map<String, Object> parameters,
                                     @Assisted("title") @Nullable String title) {
-        super(stream, id, Type.FIELD_VALUE, createdAt, creatorUserId, parameters, title);
+        super(stream, id, Type.FIELD_VALUE.toString(), createdAt, creatorUserId, parameters, title);
         this.searches = searches;
 
         this.decimalFormat = new DecimalFormat("#.###", DecimalFormatSymbols.getInstance(Locale.ENGLISH));

--- a/graylog2-server/src/main/java/org/graylog2/alerts/types/MessageCountAlertCondition.java
+++ b/graylog2-server/src/main/java/org/graylog2/alerts/types/MessageCountAlertCondition.java
@@ -89,7 +89,7 @@ public class MessageCountAlertCondition extends AbstractAlertCondition {
     }
 
     @Override
-    protected CheckResult runCheck() {
+    public CheckResult runCheck() {
         try {
             // Create an absolute range from the relative range to make sure it doesn't change during the two
             // search requests. (count and find messages)

--- a/graylog2-server/src/main/java/org/graylog2/alerts/types/MessageCountAlertCondition.java
+++ b/graylog2-server/src/main/java/org/graylog2/alerts/types/MessageCountAlertCondition.java
@@ -52,11 +52,11 @@ public class MessageCountAlertCondition extends AbstractAlertCondition {
 
     public interface Factory extends AlertCondition.Factory {
         MessageCountAlertCondition create(Stream stream,
-                                                        @Assisted("id") String id,
-                                                        DateTime createdAt,
-                                                        @Assisted("userid") String creatorUserId,
-                                                        Map<String, Object> parameters,
-                                                        @Assisted("title") @Nullable String title);
+                                          @Assisted("id") String id,
+                                          DateTime createdAt,
+                                          @Assisted("userid") String creatorUserId,
+                                          Map<String, Object> parameters,
+                                          @Assisted("title") @Nullable String title);
     }
 
     private final int time;
@@ -83,9 +83,9 @@ public class MessageCountAlertCondition extends AbstractAlertCondition {
     @Override
     public String getDescription() {
         return "time: " + time
-                + ", threshold_type: " + thresholdType.toString().toLowerCase(Locale.ENGLISH)
-                + ", threshold: " + threshold
-                + ", grace: " + grace;
+            + ", threshold_type: " + thresholdType.toString().toLowerCase(Locale.ENGLISH)
+            + ", threshold: " + threshold
+            + ", grace: " + grace;
     }
 
     @Override
@@ -121,7 +121,7 @@ public class MessageCountAlertCondition extends AbstractAlertCondition {
                 final List<MessageSummary> summaries = Lists.newArrayList();
                 if (getBacklog() > 0) {
                     final SearchResult backlogResult = searches.search("*", filter,
-                            range, getBacklog(), 0, new Sorting("timestamp", Sorting.Direction.DESC));
+                        range, getBacklog(), 0, new Sorting("timestamp", Sorting.Direction.DESC));
                     for (ResultMessage resultMessage : backlogResult.getResults()) {
                         final Message msg = resultMessage.getMessage();
                         summaries.add(new MessageSummary(resultMessage.getIndex(), msg));
@@ -129,8 +129,8 @@ public class MessageCountAlertCondition extends AbstractAlertCondition {
                 }
 
                 final String resultDescription = "Stream had " + count + " messages in the last " + time
-                        + " minutes with trigger condition " + thresholdType.toString().toLowerCase(Locale.ENGLISH)
-                        + " than " + threshold + " messages. " + "(Current grace time: " + grace + " minutes)";
+                    + " minutes with trigger condition " + thresholdType.toString().toLowerCase(Locale.ENGLISH)
+                    + " than " + threshold + " messages. " + "(Current grace time: " + grace + " minutes)";
                 return new CheckResult(true, this, resultDescription, Tools.nowUTC(), summaries);
             } else {
                 return new NegativeCheckResult(this);

--- a/graylog2-server/src/main/java/org/graylog2/alerts/types/MessageCountAlertCondition.java
+++ b/graylog2-server/src/main/java/org/graylog2/alerts/types/MessageCountAlertCondition.java
@@ -26,6 +26,7 @@ import org.graylog2.indexer.results.ResultMessage;
 import org.graylog2.indexer.results.SearchResult;
 import org.graylog2.indexer.searches.Searches;
 import org.graylog2.indexer.searches.Sorting;
+import org.graylog2.plugin.alarms.AlertCondition;
 import org.graylog2.plugin.indexer.searches.timeranges.AbsoluteRange;
 import org.graylog2.plugin.indexer.searches.timeranges.InvalidRangeParametersException;
 import org.graylog2.plugin.indexer.searches.timeranges.RelativeRange;
@@ -49,8 +50,8 @@ public class MessageCountAlertCondition extends AbstractAlertCondition {
         MORE, LESS
     }
 
-    public interface Factory {
-        MessageCountAlertCondition createAlertCondition(Stream stream,
+    public interface Factory extends AlertCondition.Factory {
+        MessageCountAlertCondition create(Stream stream,
                                                         @Assisted("id") String id,
                                                         DateTime createdAt,
                                                         @Assisted("userid") String creatorUserId,
@@ -71,7 +72,7 @@ public class MessageCountAlertCondition extends AbstractAlertCondition {
                                       @Assisted("userid") String creatorUserId,
                                       @Assisted Map<String, Object> parameters,
                                       @Nullable @Assisted("title") String title) {
-        super(stream, id, Type.MESSAGE_COUNT, createdAt, creatorUserId, parameters, title);
+        super(stream, id, Type.MESSAGE_COUNT.toString(), createdAt, creatorUserId, parameters, title);
 
         this.searches = searches;
         this.time = getNumber(parameters.get("time")).orElse(0).intValue();

--- a/graylog2-server/src/main/java/org/graylog2/bindings/ServerBindings.java
+++ b/graylog2-server/src/main/java/org/graylog2/bindings/ServerBindings.java
@@ -133,9 +133,6 @@ public class ServerBindings extends Graylog2Module {
         install(new FactoryModuleBuilder().build(SetIndexReadOnlyAndCalculateRangeJob.Factory.class));
 
         install(new FactoryModuleBuilder().build(LdapSettingsImpl.Factory.class));
-        install(new FactoryModuleBuilder().build(FieldValueAlertCondition.Factory.class));
-        install(new FactoryModuleBuilder().build(MessageCountAlertCondition.Factory.class));
-        install(new FactoryModuleBuilder().build(FieldContentValueAlertCondition.Factory.class));
         install(new FactoryModuleBuilder().build(WidgetCacheTime.Factory.class));
         install(new FactoryModuleBuilder().build(UserImpl.Factory.class));
     }

--- a/graylog2-server/src/main/java/org/graylog2/commands/Server.java
+++ b/graylog2-server/src/main/java/org/graylog2/commands/Server.java
@@ -25,6 +25,7 @@ import com.mongodb.MongoException;
 import io.airlift.airline.Command;
 import io.airlift.airline.Option;
 import org.graylog2.Configuration;
+import org.graylog2.alerts.AlertConditionBindings;
 import org.graylog2.audit.AuditActor;
 import org.graylog2.audit.AuditBindings;
 import org.graylog2.audit.AuditEventSender;
@@ -118,7 +119,8 @@ public class Server extends ServerBootstrap {
             new WidgetStrategyBindings(),
             new DashboardBindings(),
             new DecoratorBindings(),
-            new AuditBindings()
+            new AuditBindings(),
+            new AlertConditionBindings()
         );
 
         return modules.build();

--- a/graylog2-server/src/main/java/org/graylog2/plugin/PluginModule.java
+++ b/graylog2-server/src/main/java/org/graylog2/plugin/PluginModule.java
@@ -23,6 +23,7 @@ import com.google.inject.multibindings.Multibinder;
 import org.graylog2.audit.AuditEventType;
 import org.graylog2.audit.PluginAuditEventTypes;
 import org.graylog2.audit.formatter.AuditEventFormatter;
+import org.graylog2.plugin.alarms.AlertCondition;
 import org.graylog2.plugin.alarms.callbacks.AlarmCallback;
 import org.graylog2.plugin.dashboards.widgets.WidgetStrategy;
 import org.graylog2.plugin.filters.MessageFilter;
@@ -166,5 +167,11 @@ public abstract class PluginModule extends Graylog2Module {
 
     protected void addAuditEventFormatter(AuditEventType auditEventType, Class<? extends AuditEventFormatter> auditEventFormatterClass) {
         installAuditEventFormatter(auditEventFormatterMapBinder(), auditEventType, auditEventFormatterClass);
+    }
+
+    protected void addAlertCondition(String name,
+                                     Class<? extends AlertCondition> alertConditionClass,
+                                     Class<? extends AlertCondition.Factory> alertConditionFactoryClass) {
+        installAlertConditionWithCustomName(alertConditionBinder(), name, alertConditionClass, alertConditionFactoryClass);
     }
 }

--- a/graylog2-server/src/main/java/org/graylog2/plugin/alarms/AlertCondition.java
+++ b/graylog2-server/src/main/java/org/graylog2/plugin/alarms/AlertCondition.java
@@ -50,6 +50,8 @@ public interface AlertCondition {
 
     String getTitle();
 
+    AlertCondition.CheckResult runCheck();
+
     interface CheckResult {
         boolean isTriggered();
         String getResultDescription();

--- a/graylog2-server/src/main/java/org/graylog2/plugin/alarms/AlertCondition.java
+++ b/graylog2-server/src/main/java/org/graylog2/plugin/alarms/AlertCondition.java
@@ -21,6 +21,7 @@ import org.graylog2.plugin.MessageSummary;
 import org.graylog2.plugin.streams.Stream;
 import org.joda.time.DateTime;
 
+import javax.annotation.Nullable;
 import java.util.List;
 import java.util.Map;
 
@@ -61,5 +62,14 @@ public interface AlertCondition {
          * @return list of message summaries
          */
         List<MessageSummary> getMatchingMessages();
+    }
+
+    interface Factory {
+        AlertCondition create(Stream stream,
+                              String id,
+                              DateTime createdAt,
+                              String creatorUserId,
+                              Map<String, Object> parameters,
+                              @Nullable String title);
     }
 }

--- a/graylog2-server/src/main/java/org/graylog2/plugin/inject/Graylog2Module.java
+++ b/graylog2-server/src/main/java/org/graylog2/plugin/inject/Graylog2Module.java
@@ -30,6 +30,7 @@ import org.graylog2.audit.AuditEventSender;
 import org.graylog2.audit.AuditEventType;
 import org.graylog2.audit.PluginAuditEventTypes;
 import org.graylog2.audit.formatter.AuditEventFormatter;
+import org.graylog2.plugin.alarms.AlertCondition;
 import org.graylog2.plugin.dashboards.widgets.WidgetStrategy;
 import org.graylog2.plugin.decorators.SearchResponseDecorator;
 import org.graylog2.plugin.indexer.retention.RetentionStrategy;
@@ -351,6 +352,25 @@ public abstract class Graylog2Module extends AbstractModule {
                                            Class<? extends SearchResponseDecorator.Factory> searchResponseDecoratorFactoryClass) {
         install(new FactoryModuleBuilder().implement(SearchResponseDecorator.class, searchResponseDecoratorClass).build(searchResponseDecoratorFactoryClass));
         searchResponseDecoratorBinder.addBinding(searchResponseDecoratorClass.getCanonicalName()).to(searchResponseDecoratorFactoryClass);
+    }
+
+    protected MapBinder<String, AlertCondition.Factory> alertConditionBinder() {
+        return MapBinder.newMapBinder(binder(), String.class, AlertCondition.Factory.class);
+    }
+
+    protected void installAlertCondition(MapBinder<String, AlertCondition.Factory> alertConditionBinder,
+                                         Class<? extends AlertCondition> alertConditionClass,
+                                         Class<? extends AlertCondition.Factory> alertConditionFactoryClass) {
+        install(new FactoryModuleBuilder().implement(AlertCondition.class, alertConditionClass).build(alertConditionFactoryClass));
+        alertConditionBinder.addBinding(alertConditionClass.getCanonicalName()).to(alertConditionFactoryClass);
+    }
+
+    protected void installAlertConditionWithCustomName(MapBinder<String, AlertCondition.Factory> alertConditionBinder,
+                                                       String identifier,
+                                                       Class<? extends AlertCondition> alertConditionClass,
+                                                       Class<? extends AlertCondition.Factory> alertConditionFactoryClass) {
+        install(new FactoryModuleBuilder().implement(AlertCondition.class, alertConditionClass).build(alertConditionFactoryClass));
+        alertConditionBinder.addBinding(identifier).to(alertConditionFactoryClass);
     }
 
     private static class DynamicFeatureType extends TypeLiteral<Class<? extends DynamicFeature>> {}

--- a/graylog2-server/src/main/java/org/graylog2/rest/resources/streams/alerts/StreamAlertConditionResource.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/resources/streams/alerts/StreamAlertConditionResource.java
@@ -93,13 +93,7 @@ public class StreamAlertConditionResource extends RestResource {
         checkPermission(RestPermissions.STREAMS_EDIT, streamid);
 
         final Stream stream = streamService.load(streamid);
-        final AlertCondition alertCondition;
-        try {
-            alertCondition = alertService.fromRequest(ccr, stream, getCurrentUser().getName());
-        } catch (AbstractAlertCondition.NoSuchAlertConditionTypeException e) {
-            LOG.error("Invalid alarm condition type.", e);
-            throw new BadRequestException(e);
-        }
+        final AlertCondition alertCondition = alertService.fromRequest(ccr, stream, getCurrentUser().getName());
 
         streamService.addAlertCondition(stream, alertCondition);
 
@@ -131,13 +125,7 @@ public class StreamAlertConditionResource extends RestResource {
         final Stream stream = streamService.load(streamid);
         AlertCondition alertCondition = streamService.getAlertCondition(stream, conditionid);
 
-        final AlertCondition updatedCondition;
-        try {
-            updatedCondition = alertService.updateFromRequest(alertCondition, ccr);
-        } catch (AbstractAlertCondition.NoSuchAlertConditionTypeException e) {
-            LOG.error("Invalid alarm condition type.", e);
-            throw new BadRequestException(e);
-        }
+        final AlertCondition updatedCondition = alertService.updateFromRequest(alertCondition, ccr);
 
         streamService.updateAlertCondition(stream, updatedCondition);
     }

--- a/graylog2-server/src/main/java/org/graylog2/streams/StreamServiceImpl.java
+++ b/graylog2-server/src/main/java/org/graylog2/streams/StreamServiceImpl.java
@@ -236,12 +236,8 @@ public class StreamServiceImpl extends PersistedServiceImpl implements StreamSer
             for (BasicDBObject conditionFields : (List<BasicDBObject>) stream.getFields().get(StreamImpl.EMBEDDED_ALERT_CONDITIONS)) {
                 try {
                     conditions.add(alertService.fromPersisted(conditionFields, stream));
-                } catch (AbstractAlertCondition.NoSuchAlertConditionTypeException e) {
-                    LOG.error("Skipping unknown alert condition type.", e);
-                    continue;
                 } catch (Exception e) {
                     LOG.error("Skipping alert condition.", e);
-                    continue;
                 }
             }
         }
@@ -257,12 +253,8 @@ public class StreamServiceImpl extends PersistedServiceImpl implements StreamSer
                     if (conditionFields.get("id").equals(conditionId)) {
                         return alertService.fromPersisted(conditionFields, stream);
                     }
-                } catch (AbstractAlertCondition.NoSuchAlertConditionTypeException e) {
-                    LOG.error("Skipping unknown alert condition type.", e);
-                    continue;
                 } catch (Exception e) {
                     LOG.error("Skipping alert condition.", e);
-                    continue;
                 }
             }
         }

--- a/graylog2-server/src/test/java/org/graylog2/alerts/AbstractAlertConditionTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/alerts/AbstractAlertConditionTest.java
@@ -112,7 +112,7 @@ public class AbstractAlertConditionTest extends AlertConditionTest {
             }
 
             @Override
-            protected AlertCondition.CheckResult runCheck() {
+            public AlertCondition.CheckResult runCheck() {
                 return null;
             }
         };

--- a/graylog2-server/src/test/java/org/graylog2/alerts/AlertConditionTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/alerts/AlertConditionTest.java
@@ -16,6 +16,7 @@
  */
 package org.graylog2.alerts;
 
+import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Maps;
 import com.google.inject.assistedinject.Assisted;
 import org.graylog2.alerts.types.FieldContentValueAlertCondition;
@@ -65,10 +66,11 @@ public abstract class AlertConditionTest {
         searches = mock(Searches.class);
         mongoConnection = mock(MongoConnection.class);
         // TODO use injection please. this sucks so bad
-        alertService = spy(new AlertServiceImpl(mongoConnection,
+        final Map<String, AlertCondition.Factory> alertConditionBinder = ImmutableMap.of(
+            AbstractAlertCondition.Type.FIELD_VALUE.toString(),
             new FieldValueAlertCondition.Factory() {
                 @Override
-                public FieldValueAlertCondition createAlertCondition(Stream stream,
+                public FieldValueAlertCondition create(Stream stream,
                                                                      String id,
                                                                      DateTime createdAt,
                                                                      @Assisted("userid") String creatorUserId,
@@ -77,9 +79,10 @@ public abstract class AlertConditionTest {
                     return new FieldValueAlertCondition(searches, stream, id, createdAt, creatorUserId, parameters, title);
                 }
             },
+            AbstractAlertCondition.Type.MESSAGE_COUNT.toString(),
             new MessageCountAlertCondition.Factory() {
                 @Override
-                public MessageCountAlertCondition createAlertCondition(Stream stream,
+                public MessageCountAlertCondition create(Stream stream,
                                                                        String id,
                                                                        DateTime createdAt,
                                                                        @Assisted("userid") String creatorUserId,
@@ -88,9 +91,10 @@ public abstract class AlertConditionTest {
                     return new MessageCountAlertCondition(searches, stream, id, createdAt, creatorUserId, parameters, title);
                 }
             },
+            AbstractAlertCondition.Type.FIELD_CONTENT_VALUE.toString(),
             new FieldContentValueAlertCondition.Factory() {
                 @Override
-                public FieldContentValueAlertCondition createAlertCondition(Stream stream,
+                public FieldContentValueAlertCondition create(Stream stream,
                                                                             String id,
                                                                             DateTime createdAt,
                                                                             @Assisted("userid") String creatorUserId,
@@ -98,7 +102,9 @@ public abstract class AlertConditionTest {
                                                                             String title) {
                     return new FieldContentValueAlertCondition(searches, null, stream, id, createdAt, creatorUserId, parameters, title);
                 }
-            }));
+            }
+        );
+        alertService = spy(new AlertServiceImpl(mongoConnection, alertConditionBinder));
 
     }
 


### PR DESCRIPTION
This is the first preparatory step to make alert conditions pluggable. It does:

- introduce a binder for alert conditions
- introduce a common factory to instantiate alert conditions
- add legacy bindings for ootb conditions
- lookup and use alert conditions factory instances in binder during instantiation of persisted alert conditions
- adapt tests

Refs #2871, #2867