### PR TITLE
Make rest_transport_uri more similar to rest_listen_uri in example config

### DIFF
--- a/misc/graylog.conf
+++ b/misc/graylog.conf
@@ -87,7 +87,7 @@ rest_listen_uri = http://127.0.0.1:9000/api/
 # You will need to define this, if your Graylog server is running behind a HTTP proxy that is rewriting
 # the scheme, host name or URI.
 # This must not contain a wildcard address (0.0.0.0).
-#rest_transport_uri = http://192.168.1.1:12900/
+#rest_transport_uri = http://192.168.1.1:9000/api/
 
 # Enable CORS headers for REST API. This is necessary for JS-clients accessing the server directly.
 # If these are disabled, modern browsers will not be able to retrieve resources from the server.


### PR DESCRIPTION
Refs #2874, cherry picked from commit 2c1de80f8cf5fa1f3a3bab81e22690e4acc155d5.