### PR TITLE
Implement "contains" stream rule

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/plugin/streams/StreamRuleType.java
+++ b/graylog2-server/src/main/java/org/graylog2/plugin/streams/StreamRuleType.java
@@ -24,7 +24,8 @@ public enum StreamRuleType {
     REGEX(2, "match regular expression", "match regular expression"),
     GREATER(3, "greater than", "be greater than"),
     SMALLER(4, "smaller than", "be smaller than"),
-    PRESENCE(5, "field presence", "be present");
+    PRESENCE(5, "field presence", "be present"),
+    CONTAINS(6, "contain", "contain");
 
     private final int value;
     private final String shortDesc;

--- a/graylog2-server/src/main/java/org/graylog2/streams/StreamRouterEngine.java
+++ b/graylog2-server/src/main/java/org/graylog2/streams/StreamRouterEngine.java
@@ -117,14 +117,14 @@ public class StreamRouterEngine {
             }
         }
 
-        final int size = presenceRules.size() + exactRules.size() + greaterRules.size() + smallerRules.size() + regexRules.size() + containsRules.size();
+        final int size = presenceRules.size() + exactRules.size() + greaterRules.size() + smallerRules.size() + containsRules.size() + regexRules.size();
         this.rulesList = Lists.newArrayListWithCapacity(size);
         this.rulesList.addAll(presenceRules);
         this.rulesList.addAll(exactRules);
         this.rulesList.addAll(greaterRules);
         this.rulesList.addAll(smallerRules);
-        this.rulesList.addAll(regexRules);
         this.rulesList.addAll(containsRules);
+        this.rulesList.addAll(regexRules);
     }
 
     /**

--- a/graylog2-server/src/main/java/org/graylog2/streams/StreamRouterEngine.java
+++ b/graylog2-server/src/main/java/org/graylog2/streams/StreamRouterEngine.java
@@ -83,6 +83,7 @@ public class StreamRouterEngine {
         final List<Rule> greaterRules = Lists.newArrayList();
         final List<Rule> smallerRules = Lists.newArrayList();
         final List<Rule> regexRules = Lists.newArrayList();
+        final List<Rule> containsRules = Lists.newArrayList();
 
         for (Stream stream : streams) {
             for (StreamRule streamRule : stream.getStreamRules()) {
@@ -109,17 +110,21 @@ public class StreamRouterEngine {
                     case REGEX:
                         regexRules.add(rule);
                         break;
+                    case CONTAINS:
+                        containsRules.add(rule);
+                        break;
                 }
             }
         }
 
-        final int size = presenceRules.size() + exactRules.size() + greaterRules.size() + smallerRules.size() + regexRules.size();
+        final int size = presenceRules.size() + exactRules.size() + greaterRules.size() + smallerRules.size() + regexRules.size() + containsRules.size();
         this.rulesList = Lists.newArrayListWithCapacity(size);
         this.rulesList.addAll(presenceRules);
         this.rulesList.addAll(exactRules);
         this.rulesList.addAll(greaterRules);
         this.rulesList.addAll(smallerRules);
         this.rulesList.addAll(regexRules);
+        this.rulesList.addAll(containsRules);
     }
 
     /**

--- a/graylog2-server/src/main/java/org/graylog2/streams/StreamRuleMatcherFactory.java
+++ b/graylog2-server/src/main/java/org/graylog2/streams/StreamRuleMatcherFactory.java
@@ -17,36 +17,32 @@
 package org.graylog2.streams;
 
 import org.graylog2.plugin.streams.StreamRuleType;
-import org.graylog2.streams.matchers.*;
+import org.graylog2.streams.matchers.ContainsMatcher;
+import org.graylog2.streams.matchers.ExactMatcher;
+import org.graylog2.streams.matchers.FieldPresenceMatcher;
+import org.graylog2.streams.matchers.GreaterMatcher;
+import org.graylog2.streams.matchers.RegexMatcher;
+import org.graylog2.streams.matchers.SmallerMatcher;
+import org.graylog2.streams.matchers.StreamRuleMatcher;
 
-/**
- * @author Lennart Koopmann <lennart@socketfeed.com>
- */
 public class StreamRuleMatcherFactory {
 
     public static StreamRuleMatcher build(StreamRuleType ruleType) throws InvalidStreamRuleTypeException {
-        StreamRuleMatcher matcher = null;
-
         switch (ruleType) {
             case EXACT:
-                matcher = new ExactMatcher();
-                break;
+                return new ExactMatcher();
             case REGEX:
-                matcher = new RegexMatcher();
-                break;
+                return new RegexMatcher();
             case GREATER:
-                matcher = new GreaterMatcher();
-                break;
+                return new GreaterMatcher();
             case SMALLER:
-                matcher = new SmallerMatcher();
-                break;
+                return new SmallerMatcher();
             case PRESENCE:
-                matcher = new FieldPresenceMatcher();
-                break;
+                return new FieldPresenceMatcher();
+            case CONTAINS:
+                return new ContainsMatcher();
             default:
                 throw new InvalidStreamRuleTypeException();
         }
-
-        return matcher;
     }
 }

--- a/graylog2-server/src/main/java/org/graylog2/streams/matchers/ContainsMatcher.java
+++ b/graylog2-server/src/main/java/org/graylog2/streams/matchers/ContainsMatcher.java
@@ -1,0 +1,35 @@
+/**
+ * This file is part of Graylog.
+ *
+ * Graylog is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.graylog2.streams.matchers;
+
+import org.graylog2.plugin.Message;
+import org.graylog2.plugin.streams.StreamRule;
+
+public class ContainsMatcher implements StreamRuleMatcher {
+    @Override
+    public boolean match(Message msg, StreamRule rule) {
+        final boolean inverted = rule.getInverted();
+        final Object field = msg.getField(rule.getField());
+        if (field instanceof String) {
+            final String value = (String) field;
+            return inverted ^ value.contains(rule.getValue());
+        } else {
+            return inverted;
+        }
+    }
+
+}

--- a/graylog2-server/src/test/java/org/graylog2/streams/StreamRouterEngineTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/streams/StreamRouterEngineTest.java
@@ -126,6 +126,33 @@ public class StreamRouterEngineTest {
     }
 
     @Test
+    public void testContainsMatch() throws Exception {
+        final StreamMock stream = getStreamMock("test");
+        final StreamRuleMock rule = new StreamRuleMock(ImmutableMap.of(
+                "_id", new ObjectId(),
+                "field", "testfield",
+                "value", "testvalue",
+                "type", StreamRuleType.CONTAINS.toInteger(),
+                "stream_id", stream.getId()
+        ));
+
+        stream.setStreamRules(Lists.newArrayList(rule));
+
+        final StreamRouterEngine engine = newEngine(Lists.newArrayList(stream));
+        final Message message = getMessage();
+
+        // With wrong value for field.
+        message.addField("testfield", "no-foobar");
+
+        assertTrue(engine.match(message).isEmpty());
+
+        // With matching value for field.
+        message.addField("testfield", "hello testvalue");
+
+        assertEquals(engine.match(message), Lists.newArrayList(stream));
+    }
+
+    @Test
     public void testGreaterMatch() throws Exception {
         final StreamMock stream = getStreamMock("test");
         final StreamRuleMock rule = new StreamRuleMock(ImmutableMap.of(

--- a/graylog2-server/src/test/java/org/graylog2/streams/matchers/ContainsMatcherTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/streams/matchers/ContainsMatcherTest.java
@@ -1,0 +1,121 @@
+/**
+ * This file is part of Graylog.
+ *
+ * Graylog is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.graylog2.streams.matchers;
+
+import org.graylog2.plugin.Message;
+import org.graylog2.plugin.streams.StreamRule;
+import org.graylog2.plugin.streams.StreamRuleType;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class ContainsMatcherTest extends MatcherTest {
+    private StreamRule rule;
+    private Message msg;
+
+    @Before
+    public void setUp() {
+        rule = getSampleRule();
+        msg = getSampleMessage();
+    }
+
+    @Test
+    public void testSuccessfulMatch() {
+        msg.addField("something", "foobar");
+
+        StreamRuleMatcher matcher = getMatcher(rule);
+        assertTrue(matcher.match(msg, rule));
+    }
+
+    @Test
+    public void testMissedMatch() {
+        msg.addField("something", "nonono");
+
+        StreamRuleMatcher matcher = getMatcher(rule);
+        assertFalse(matcher.match(msg, rule));
+    }
+
+    @Test
+    public void testInvertedMatch() {
+        rule.setInverted(true);
+
+        msg.addField("something", "nonono");
+
+        StreamRuleMatcher matcher = getMatcher(rule);
+        assertTrue(matcher.match(msg, rule));
+    }
+
+    @Test
+    public void testNonExistentField() {
+        msg.addField("someother", "hello foo");
+
+        StreamRuleMatcher matcher = getMatcher(rule);
+        assertFalse(matcher.match(msg, rule));
+    }
+
+    @Test
+    public void testNonExistentFieldInverted() {
+        rule.setInverted(true);
+
+        msg.addField("someother", "hello foo");
+
+        StreamRuleMatcher matcher = getMatcher(rule);
+        assertTrue(matcher.match(msg, rule));
+    }
+
+    @Test
+    public void testNullFieldShouldNotMatch() {
+        final String fieldName = "nullfield";
+        rule.setField(fieldName);
+
+        msg.addField(fieldName, null);
+
+        final StreamRuleMatcher matcher = getMatcher(rule);
+        assertFalse(matcher.match(msg, rule));
+    }
+
+    @Test
+    public void testInvertedNullFieldShouldMatch() {
+        final String fieldName = "nullfield";
+        rule.setField(fieldName);
+        rule.setInverted(true);
+
+        msg.addField(fieldName, null);
+
+        final StreamRuleMatcher matcher = getMatcher(rule);
+        assertTrue(matcher.match(msg, rule));
+    }
+
+    protected StreamRule getSampleRule() {
+        final StreamRule rule = super.getSampleRule();
+        rule.setType(StreamRuleType.CONTAINS);
+        rule.setValue("foo");
+
+        return rule;
+    }
+
+    protected StreamRuleMatcher getMatcher(StreamRule rule) {
+        final StreamRuleMatcher matcher = super.getMatcher(rule);
+
+        assertEquals(matcher.getClass(), ContainsMatcher.class);
+
+        return matcher;
+    }
+}


### PR DESCRIPTION
## Description

Graylog contains a variety of stream rule types, such as exact match, field presence, or match against regular expressions.

It is, however, missing the very simple but immensely useful "contains" matcher, which this PR aims to provide.

## Motivation and Context

https://twitter.com/HenrikJohansen/status/779231109901062144 :trollface: 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.