### PR TITLE
Wait for es cluster green

### DIFF
--- a/graylog2-server/src/test/java/org/graylog2/indexer/searches/SearchesTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/indexer/searches/SearchesTest.java
@@ -106,6 +106,16 @@ public class SearchesTest {
         public String getIndexPrefix() {
             return "graylog";
         }
+
+        @Override
+        public int getShards() {
+            return 1;
+        }
+
+        @Override
+        public int getReplicas() {
+            return 0;
+        }
     };
 
     @Mock


### PR DESCRIPTION
This PR addresses the problem described in #2888 which was caused by `IndexCreatingDatabaseOperation` running too fast (when the ES cluster health state wasn't GREEN).

This replaces #2888.