### PR TITLE
Introduce IndexSet and IndexSetRegistry to wrap Deflector

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/commands/Server.java
+++ b/graylog2-server/src/main/java/org/graylog2/commands/Server.java
@@ -48,6 +48,7 @@ import org.graylog2.configuration.MongoDbConfiguration;
 import org.graylog2.configuration.VersionCheckConfiguration;
 import org.graylog2.dashboards.DashboardBindings;
 import org.graylog2.decorators.DecoratorBindings;
+import org.graylog2.indexer.IndexerBindings;
 import org.graylog2.indexer.retention.RetentionStrategyBindings;
 import org.graylog2.indexer.rotation.RotationStrategyBindings;
 import org.graylog2.messageprocessors.MessageProcessorModule;
@@ -120,7 +121,8 @@ public class Server extends ServerBootstrap {
             new DashboardBindings(),
             new DecoratorBindings(),
             new AuditBindings(),
-            new AlertConditionBindings()
+            new AlertConditionBindings(),
+            new IndexerBindings()
         );
 
         return modules.build();

--- a/graylog2-server/src/main/java/org/graylog2/indexer/IndexSet.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/IndexSet.java
@@ -22,7 +22,7 @@ import java.util.Map;
 import java.util.Set;
 
 public interface IndexSet {
-    String[] getAllGraylogIndexNames();
+    String[] getManagedIndicesNames();
 
     String getWriteIndexAlias();
 
@@ -32,13 +32,13 @@ public interface IndexSet {
 
     String getCurrentActualTargetIndex() throws TooManyAliasesException;
 
-    Map<String,Set<String>> getAllGraylogDeflectorIndices();
+    Map<String,Set<String>> getAllDeflectorAliases();
 
     boolean isUp();
 
     boolean isDeflectorAlias(String index);
 
-    boolean isGraylogIndex(String index);
+    boolean isManagedIndex(String index);
 
     void setUp();
 

--- a/graylog2-server/src/main/java/org/graylog2/indexer/IndexSet.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/IndexSet.java
@@ -1,0 +1,50 @@
+/**
+ * This file is part of Graylog.
+ *
+ * Graylog is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.graylog2.indexer;
+
+import org.graylog2.indexer.indices.TooManyAliasesException;
+
+import java.util.Map;
+import java.util.Set;
+
+public interface IndexSet {
+    String[] getAllGraylogIndexNames();
+
+    String getWriteIndexAlias();
+
+    String getWriteIndexWildcard();
+
+    String getNewestTargetName() throws NoTargetIndexException;
+
+    String getCurrentActualTargetIndex() throws TooManyAliasesException;
+
+    Map<String,Set<String>> getAllGraylogDeflectorIndices();
+
+    boolean isUp();
+
+    boolean isDeflectorAlias(String indexName);
+
+    boolean isGraylogIndex(String index);
+
+    void setUp();
+
+    void cycle();
+
+    void cleanupAliases(Set<String> indices);
+
+    void pointTo(String shouldBeTarget, String currentTarget);
+}

--- a/graylog2-server/src/main/java/org/graylog2/indexer/IndexSet.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/IndexSet.java
@@ -36,7 +36,7 @@ public interface IndexSet {
 
     boolean isUp();
 
-    boolean isDeflectorAlias(String indexName);
+    boolean isDeflectorAlias(String index);
 
     boolean isGraylogIndex(String index);
 

--- a/graylog2-server/src/main/java/org/graylog2/indexer/IndexSetRegistry.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/IndexSetRegistry.java
@@ -21,20 +21,13 @@ import org.graylog2.indexer.indices.TooManyAliasesException;
 import java.util.List;
 import java.util.function.Consumer;
 
-public interface IndexSetRegistry {
+public interface IndexSetRegistry extends Iterable<IndexSet> {
     /**
      * Returns a list of all {@link IndexSet} instances.
      *
      * @return list of index sets
      */
     List<IndexSet> getAllIndexSets();
-
-    /**
-     * Executes the given consumer function for every {@link IndexSet}.
-     *
-     * @param action the consumer function
-     */
-    void forEach(Consumer<IndexSet> action);
 
     /**
      * Returns a list of all Graylog managed indices.

--- a/graylog2-server/src/main/java/org/graylog2/indexer/IndexSetRegistry.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/IndexSetRegistry.java
@@ -18,9 +18,7 @@ package org.graylog2.indexer;
 
 import org.graylog2.indexer.indices.TooManyAliasesException;
 
-import java.util.List;
 import java.util.Set;
-import java.util.function.Consumer;
 
 public interface IndexSetRegistry extends Iterable<IndexSet> {
     /**
@@ -31,11 +29,11 @@ public interface IndexSetRegistry extends Iterable<IndexSet> {
     Set<IndexSet> getAllIndexSets();
 
     /**
-     * Returns a list of all Graylog managed indices.
+     * Returns a list with the names of all managed indices.
      *
-     * @return list of managed indices
+     * @return list with names of managed indices
      */
-    String[] getAllGraylogIndexNames();
+    String[] getManagedIndicesNames();
 
     /**
      * Checks if the given index name is managed by Graylog.
@@ -43,7 +41,7 @@ public interface IndexSetRegistry extends Iterable<IndexSet> {
      * @param indexName the index name to check
      * @return true when index is managed by Graylog, false otherwise
      */
-    boolean isGraylogIndex(String indexName);
+    boolean isManagedIndex(String indexName);
 
     /**
      * Returns the list of all write index wildcards.

--- a/graylog2-server/src/main/java/org/graylog2/indexer/IndexSetRegistry.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/IndexSetRegistry.java
@@ -19,6 +19,7 @@ package org.graylog2.indexer;
 import org.graylog2.indexer.indices.TooManyAliasesException;
 
 import java.util.List;
+import java.util.Set;
 import java.util.function.Consumer;
 
 public interface IndexSetRegistry extends Iterable<IndexSet> {
@@ -27,7 +28,7 @@ public interface IndexSetRegistry extends Iterable<IndexSet> {
      *
      * @return list of index sets
      */
-    List<IndexSet> getAllIndexSets();
+    Set<IndexSet> getAllIndexSets();
 
     /**
      * Returns a list of all Graylog managed indices.

--- a/graylog2-server/src/main/java/org/graylog2/indexer/IndexSetRegistry.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/IndexSetRegistry.java
@@ -1,0 +1,93 @@
+/**
+ * This file is part of Graylog.
+ *
+ * Graylog is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.graylog2.indexer;
+
+import org.graylog2.indexer.indices.TooManyAliasesException;
+
+import java.util.List;
+import java.util.function.Consumer;
+
+public interface IndexSetRegistry {
+    /**
+     * Returns a list of all {@link IndexSet} instances.
+     *
+     * @return list of index sets
+     */
+    List<IndexSet> getAllIndexSets();
+
+    /**
+     * Executes the given consumer function for every {@link IndexSet}.
+     *
+     * @param action the consumer function
+     */
+    void forEach(Consumer<IndexSet> action);
+
+    /**
+     * Returns a list of all Graylog managed indices.
+     *
+     * @return list of managed indices
+     */
+    String[] getAllGraylogIndexNames();
+
+    /**
+     * Checks if the given index name is managed by Graylog.
+     *
+     * @param indexName the index name to check
+     * @return true when index is managed by Graylog, false otherwise
+     */
+    boolean isGraylogIndex(String indexName);
+
+    /**
+     * Returns the list of all write index wildcards.
+     *
+     * @return list of wildcards
+     */
+    String[] getWriteIndexWildcards();
+
+    /**
+     * Returns the list of all write index names.
+     *
+     * @return list of names
+     */
+    String[] getWriteIndexNames();
+
+    /**
+     * Checks if all deflector aliases exist.
+     *
+     * TODO 2.2: Check if we can get rid of this method or create a good implementation.
+     *
+     * @return if all aliases exist
+     */
+    boolean isUp();
+
+    /**
+     * Checks if the given index name is a current write index alias in any {@link IndexSet}.
+     *
+     * @param indexName the name of the index to check
+     * @return true when given index name is a current write index, false otherwise
+     */
+    boolean isCurrentWriteIndexAlias(String indexName);
+
+    /**
+     * Checks if the given index name is a current write index in any {@link IndexSet}.
+     *
+     * @param indexName the index name to check
+     * @return true when index is a current write index, false otherwise
+     * @throws TooManyAliasesException
+     */
+    boolean isCurrentWriteIndex(String indexName) throws TooManyAliasesException;
+}

--- a/graylog2-server/src/main/java/org/graylog2/indexer/IndexerBindings.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/IndexerBindings.java
@@ -14,14 +14,14 @@
  * You should have received a copy of the GNU General Public License
  * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
  */
-package org.graylog2.plugin.indexer.retention;
+package org.graylog2.indexer;
 
-import org.graylog2.indexer.IndexSet;
+import org.graylog2.plugin.inject.Graylog2Module;
 
-public interface RetentionStrategy {
-    void retain(IndexSet indexSet);
-
-    Class<? extends RetentionStrategyConfig> configurationClass();
-
-    RetentionStrategyConfig defaultConfiguration();
+public class IndexerBindings extends Graylog2Module {
+    @Override
+    protected void configure() {
+        bind(IndexSetRegistry.class).to(LegacyDeflectorRegistry.class);
+        bind(IndexSet.class).to(LegacyDeflectorIndexSet.class);
+    }
 }

--- a/graylog2-server/src/main/java/org/graylog2/indexer/LegacyDeflectorIndexSet.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/LegacyDeflectorIndexSet.java
@@ -67,8 +67,8 @@ public class LegacyDeflectorIndexSet implements IndexSet {
     }
 
     @Override
-    public boolean isDeflectorAlias(String indexName) {
-        return deflector.getName().equals(indexName);
+    public boolean isDeflectorAlias(String index) {
+        return deflector.getName().equals(index);
     }
 
     @Override

--- a/graylog2-server/src/main/java/org/graylog2/indexer/LegacyDeflectorIndexSet.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/LegacyDeflectorIndexSet.java
@@ -1,0 +1,105 @@
+/**
+ * This file is part of Graylog.
+ *
+ * Graylog is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.graylog2.indexer;
+
+import com.google.common.base.MoreObjects;
+import org.graylog2.indexer.indices.TooManyAliasesException;
+
+import javax.inject.Inject;
+import java.util.Map;
+import java.util.Set;
+
+public class LegacyDeflectorIndexSet implements IndexSet {
+    private final Deflector deflector;
+
+    @Inject
+    public LegacyDeflectorIndexSet(Deflector deflector) {
+        this.deflector = deflector;
+    }
+
+    @Override
+    public String[] getAllGraylogIndexNames() {
+        return deflector.getAllGraylogIndexNames();
+    }
+
+    @Override
+    public String getWriteIndexAlias() {
+        return deflector.getName();
+    }
+
+    @Override
+    public String getWriteIndexWildcard() {
+        return deflector.getDeflectorWildcard();
+    }
+
+    @Override
+    public String getNewestTargetName() throws NoTargetIndexException {
+        return deflector.getNewestTargetName();
+    }
+
+    @Override
+    public String getCurrentActualTargetIndex() throws TooManyAliasesException {
+        return deflector.getCurrentActualTargetIndex();
+    }
+
+    @Override
+    public Map<String,Set<String>> getAllGraylogDeflectorIndices() {
+        return deflector.getAllGraylogDeflectorIndices();
+    }
+
+    @Override
+    public boolean isUp() {
+        return deflector.isUp();
+    }
+
+    @Override
+    public boolean isDeflectorAlias(String indexName) {
+        return deflector.getName().equals(indexName);
+    }
+
+    @Override
+    public boolean isGraylogIndex(String index) {
+        return deflector.isGraylogIndex(index);
+    }
+
+    @Override
+    public void setUp() {
+        deflector.setUp();
+    }
+
+    @Override
+    public void cycle() {
+        deflector.cycle();
+    }
+
+    @Override
+    public void cleanupAliases(Set<String> indices) {
+        deflector.cleanupAliases(indices);
+    }
+
+    @Override
+    public void pointTo(String shouldBeTarget, String currentTarget) {
+        deflector.pointTo(shouldBeTarget, currentTarget);
+    }
+
+    @Override
+    public String toString() {
+        return MoreObjects.toStringHelper(this)
+                .add("indexPrefix", deflector.getName())
+                .toString();
+    }
+}

--- a/graylog2-server/src/main/java/org/graylog2/indexer/LegacyDeflectorIndexSet.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/LegacyDeflectorIndexSet.java
@@ -32,7 +32,7 @@ public class LegacyDeflectorIndexSet implements IndexSet {
     }
 
     @Override
-    public String[] getAllGraylogIndexNames() {
+    public String[] getManagedIndicesNames() {
         return deflector.getAllGraylogIndexNames();
     }
 
@@ -57,7 +57,7 @@ public class LegacyDeflectorIndexSet implements IndexSet {
     }
 
     @Override
-    public Map<String,Set<String>> getAllGraylogDeflectorIndices() {
+    public Map<String,Set<String>> getAllDeflectorAliases() {
         return deflector.getAllGraylogDeflectorIndices();
     }
 
@@ -72,7 +72,7 @@ public class LegacyDeflectorIndexSet implements IndexSet {
     }
 
     @Override
-    public boolean isGraylogIndex(String index) {
+    public boolean isManagedIndex(String index) {
         return deflector.isGraylogIndex(index);
     }
 

--- a/graylog2-server/src/main/java/org/graylog2/indexer/LegacyDeflectorRegistry.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/LegacyDeflectorRegistry.java
@@ -22,7 +22,7 @@ import org.graylog2.indexer.indices.TooManyAliasesException;
 import javax.inject.Inject;
 import java.util.Collections;
 import java.util.Iterator;
-import java.util.List;
+import java.util.Set;
 import java.util.Spliterator;
 import java.util.Spliterators;
 import java.util.function.Consumer;
@@ -38,8 +38,8 @@ public class LegacyDeflectorRegistry implements IndexSetRegistry {
     }
 
     @Override
-    public List<IndexSet> getAllIndexSets() {
-        return Collections.singletonList(indexSet);
+    public Set<IndexSet> getAllIndexSets() {
+        return Collections.singleton(indexSet);
     }
 
     @Override

--- a/graylog2-server/src/main/java/org/graylog2/indexer/LegacyDeflectorRegistry.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/LegacyDeflectorRegistry.java
@@ -16,34 +16,45 @@
  */
 package org.graylog2.indexer;
 
-import com.google.common.collect.Lists;
+import com.google.common.collect.Iterators;
 import org.graylog2.indexer.indices.TooManyAliasesException;
 
 import javax.inject.Inject;
+import java.util.Collections;
+import java.util.Iterator;
 import java.util.List;
+import java.util.Spliterator;
+import java.util.Spliterators;
 import java.util.function.Consumer;
 
 import static java.util.Objects.requireNonNull;
 
 public class LegacyDeflectorRegistry implements IndexSetRegistry {
     private final IndexSet indexSet;
-    private final List<IndexSet> indexSetRegistry;
 
     @Inject
     public LegacyDeflectorRegistry(IndexSet indexSet) {
         this.indexSet = requireNonNull(indexSet);
-        this.indexSetRegistry = Lists.newArrayList(indexSet);
     }
 
     @Override
     public List<IndexSet> getAllIndexSets() {
-        return indexSetRegistry;
+        return Collections.singletonList(indexSet);
     }
 
     @Override
-    public void forEach(Consumer<IndexSet> action) {
-        requireNonNull(action);
-        indexSetRegistry.forEach(action);
+    public Iterator<IndexSet> iterator() {
+        return Iterators.singletonIterator(indexSet);
+    }
+
+    @Override
+    public void forEach(Consumer<? super IndexSet> action) {
+        action.accept(indexSet);
+    }
+
+    @Override
+    public Spliterator<IndexSet> spliterator() {
+        return Spliterators.spliterator(iterator(), 1, Spliterator.SIZED | Spliterator.NONNULL | Spliterator.IMMUTABLE);
     }
 
     @Override

--- a/graylog2-server/src/main/java/org/graylog2/indexer/LegacyDeflectorRegistry.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/LegacyDeflectorRegistry.java
@@ -1,0 +1,86 @@
+/**
+ * This file is part of Graylog.
+ *
+ * Graylog is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.graylog2.indexer;
+
+import com.google.common.collect.Lists;
+import org.graylog2.indexer.indices.TooManyAliasesException;
+
+import javax.inject.Inject;
+import java.util.List;
+import java.util.function.Consumer;
+
+import static java.util.Objects.requireNonNull;
+
+public class LegacyDeflectorRegistry implements IndexSetRegistry {
+    private final IndexSet indexSet;
+    private final List<IndexSet> indexSetRegistry;
+
+    @Inject
+    public LegacyDeflectorRegistry(IndexSet indexSet) {
+        this.indexSet = requireNonNull(indexSet);
+        this.indexSetRegistry = Lists.newArrayList(indexSet);
+    }
+
+    @Override
+    public List<IndexSet> getAllIndexSets() {
+        return indexSetRegistry;
+    }
+
+    @Override
+    public void forEach(Consumer<IndexSet> action) {
+        requireNonNull(action);
+        indexSetRegistry.forEach(action);
+    }
+
+    @Override
+    public String[] getAllGraylogIndexNames() {
+        return indexSet.getAllGraylogIndexNames();
+    }
+
+    @Override
+    public boolean isGraylogIndex(String indexName) {
+        return indexSet.isGraylogIndex(indexName);
+    }
+
+    @Override
+    public String[] getWriteIndexWildcards() {
+        return new String[]{indexSet.getWriteIndexWildcard()};
+    }
+
+    @Override
+    public String[] getWriteIndexNames() {
+        return new String[]{indexSet.getWriteIndexAlias()};
+    }
+
+    @Override
+    public boolean isUp() {
+        // TODO 2.2: Replace with a real implementation or check if we can get rid of it.
+        return indexSet.isUp();
+    }
+
+    @Override
+    public boolean isCurrentWriteIndexAlias(String indexName) {
+        return indexSet.isDeflectorAlias(indexName);
+    }
+
+    @Override
+    public boolean isCurrentWriteIndex(String indexName) throws TooManyAliasesException {
+        final String currentWriteIndex = indexSet.getCurrentActualTargetIndex();
+
+        return currentWriteIndex != null && currentWriteIndex.equals(indexName);
+    }
+}

--- a/graylog2-server/src/main/java/org/graylog2/indexer/LegacyDeflectorRegistry.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/LegacyDeflectorRegistry.java
@@ -58,13 +58,13 @@ public class LegacyDeflectorRegistry implements IndexSetRegistry {
     }
 
     @Override
-    public String[] getAllGraylogIndexNames() {
-        return indexSet.getAllGraylogIndexNames();
+    public String[] getManagedIndicesNames() {
+        return indexSet.getManagedIndicesNames();
     }
 
     @Override
-    public boolean isGraylogIndex(String indexName) {
-        return indexSet.isGraylogIndex(indexName);
+    public boolean isManagedIndex(String indexName) {
+        return indexSet.isManagedIndex(indexName);
     }
 
     @Override

--- a/graylog2-server/src/main/java/org/graylog2/indexer/counts/Counts.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/counts/Counts.java
@@ -18,7 +18,7 @@ package org.graylog2.indexer.counts;
 
 import org.elasticsearch.action.search.SearchRequest;
 import org.elasticsearch.client.Client;
-import org.graylog2.indexer.Deflector;
+import org.graylog2.indexer.IndexSetRegistry;
 
 import javax.inject.Inject;
 import javax.inject.Singleton;
@@ -26,16 +26,16 @@ import javax.inject.Singleton;
 @Singleton
 public class Counts {
     private final Client c;
-    private final Deflector deflector;
+    private final IndexSetRegistry indexSetRegistry;
 
     @Inject
-    public Counts(Client client, Deflector deflector) {
+    public Counts(Client client, IndexSetRegistry indexSetRegistry) {
         this.c = client;
-        this.deflector = deflector;
+        this.indexSetRegistry = indexSetRegistry;
     }
 
     public long total() {
-        final SearchRequest request = c.prepareSearch(deflector.getAllGraylogIndexNames())
+        final SearchRequest request = c.prepareSearch(indexSetRegistry.getAllGraylogIndexNames())
                 .setSize(0)
                 .request();
         return c.search(request).actionGet().getHits().totalHits();

--- a/graylog2-server/src/main/java/org/graylog2/indexer/counts/Counts.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/counts/Counts.java
@@ -35,7 +35,7 @@ public class Counts {
     }
 
     public long total() {
-        final SearchRequest request = c.prepareSearch(indexSetRegistry.getAllGraylogIndexNames())
+        final SearchRequest request = c.prepareSearch(indexSetRegistry.getManagedIndicesNames())
                 .setSize(0)
                 .request();
         return c.search(request).actionGet().getHits().totalHits();

--- a/graylog2-server/src/main/java/org/graylog2/indexer/healing/FixDeflectorByDeleteJob.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/healing/FixDeflectorByDeleteJob.java
@@ -18,7 +18,8 @@ package org.graylog2.indexer.healing;
 
 import com.google.inject.assistedinject.AssistedInject;
 import org.graylog2.buffers.Buffers;
-import org.graylog2.indexer.Deflector;
+import org.graylog2.indexer.IndexSet;
+import org.graylog2.indexer.IndexSetRegistry;
 import org.graylog2.indexer.indices.Indices;
 import org.graylog2.notifications.Notification;
 import org.graylog2.notifications.NotificationService;
@@ -38,11 +39,12 @@ public class FixDeflectorByDeleteJob extends SystemJob {
 
         FixDeflectorByDeleteJob create();
     }
+
     private static final Logger LOG = LoggerFactory.getLogger(FixDeflectorByDeleteJob.class);
 
     public static final int MAX_CONCURRENCY = 1;
 
-    private final Deflector deflector;
+    private final IndexSetRegistry indexSetRegistry;
     private final Indices indices;
     private final ServerStatus serverStatus;
     private final ActivityWriter activityWriter;
@@ -52,13 +54,13 @@ public class FixDeflectorByDeleteJob extends SystemJob {
     private int progress = 0;
 
     @AssistedInject
-    public FixDeflectorByDeleteJob(Deflector deflector,
+    public FixDeflectorByDeleteJob(IndexSetRegistry indexSetRegistry,
                                    Indices indices,
                                    ServerStatus serverStatus,
                                    ActivityWriter activityWriter,
                                    Buffers bufferSynchronizer,
                                    NotificationService notificationService) {
-        this.deflector = deflector;
+        this.indexSetRegistry = indexSetRegistry;
         this.indices = indices;
         this.serverStatus = serverStatus;
         this.activityWriter = activityWriter;
@@ -68,8 +70,12 @@ public class FixDeflectorByDeleteJob extends SystemJob {
 
     @Override
     public void execute() {
-        if (deflector.isUp() || !indices.exists(deflector.getName())) {
-            LOG.error("There is no index <{}>. No need to run this job. Aborting.", deflector.getName());
+        indexSetRegistry.forEach(this::doExecute);
+    }
+
+    public void doExecute(IndexSet indexSet) {
+        if (indexSet.isUp() || !indices.exists(indexSet.getWriteIndexAlias())) {
+            LOG.error("There is no index <{}>. No need to run this job. Aborting.", indexSet.getWriteIndexAlias());
             return;
         }
 
@@ -84,12 +90,12 @@ public class FixDeflectorByDeleteJob extends SystemJob {
         progress = 25;
 
         // Delete deflector index.
-        LOG.info("Deleting <{}> index.", deflector.getName());
-        indices.delete(deflector.getName());
+        LOG.info("Deleting <{}> index.", indexSet.getWriteIndexAlias());
+        indices.delete(indexSet.getWriteIndexAlias());
         progress = 70;
 
         // Set up deflector.
-        deflector.setUp();
+        indexSet.setUp();
         progress = 80;
 
         // Start message processing again.

--- a/graylog2-server/src/main/java/org/graylog2/indexer/indices/jobs/SetIndexReadOnlyAndCalculateRangeJob.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/indices/jobs/SetIndexReadOnlyAndCalculateRangeJob.java
@@ -17,7 +17,7 @@
 package org.graylog2.indexer.indices.jobs;
 
 import com.google.inject.assistedinject.Assisted;
-import org.graylog2.indexer.Deflector;
+import org.graylog2.indexer.IndexSetRegistry;
 import org.graylog2.indexer.SetIndexReadOnlyJob;
 import org.graylog2.indexer.ranges.CreateNewSingleIndexRangeJob;
 import org.graylog2.system.jobs.SystemJob;
@@ -31,17 +31,17 @@ public class SetIndexReadOnlyAndCalculateRangeJob extends SystemJob {
 
     private final SetIndexReadOnlyJob.Factory setIndexReadOnlyJobFactory;
     private final CreateNewSingleIndexRangeJob.Factory createNewSingleIndexRangeJobFactory;
-    private final Deflector deflector;
+    private final IndexSetRegistry indexSetRegistry;
     private final String indexName;
 
     @Inject
     public SetIndexReadOnlyAndCalculateRangeJob(SetIndexReadOnlyJob.Factory setIndexReadOnlyJobFactory,
                                                 CreateNewSingleIndexRangeJob.Factory createNewSingleIndexRangeJobFactory,
-                                                Deflector deflector,
+                                                IndexSetRegistry indexSetRegistry,
                                                 @Assisted String indexName) {
         this.setIndexReadOnlyJobFactory = setIndexReadOnlyJobFactory;
         this.createNewSingleIndexRangeJobFactory = createNewSingleIndexRangeJobFactory;
-        this.deflector = deflector;
+        this.indexSetRegistry = indexSetRegistry;
         this.indexName = indexName;
     }
 
@@ -49,7 +49,7 @@ public class SetIndexReadOnlyAndCalculateRangeJob extends SystemJob {
     public void execute() {
         final SystemJob setIndexReadOnlyJob = setIndexReadOnlyJobFactory.create(indexName);
         setIndexReadOnlyJob.execute();
-        final SystemJob createNewSingleIndexRangeJob = createNewSingleIndexRangeJobFactory.create(deflector, indexName);
+        final SystemJob createNewSingleIndexRangeJob = createNewSingleIndexRangeJobFactory.create(indexSetRegistry, indexName);
         createNewSingleIndexRangeJob.execute();
 
     }

--- a/graylog2-server/src/main/java/org/graylog2/indexer/ranges/CreateNewSingleIndexRangeJob.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/ranges/CreateNewSingleIndexRangeJob.java
@@ -18,7 +18,7 @@ package org.graylog2.indexer.ranges;
 
 import com.google.inject.assistedinject.Assisted;
 import com.google.inject.assistedinject.AssistedInject;
-import org.graylog2.indexer.Deflector;
+import org.graylog2.indexer.IndexSetRegistry;
 import org.graylog2.shared.system.activities.ActivityWriter;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -30,15 +30,15 @@ public class CreateNewSingleIndexRangeJob extends RebuildIndexRangesJob {
     private final String indexName;
 
     public interface Factory {
-        CreateNewSingleIndexRangeJob create(Deflector deflector, String indexName);
+        CreateNewSingleIndexRangeJob create(IndexSetRegistry indexSetRegistry, String indexName);
     }
 
     @AssistedInject
-    public CreateNewSingleIndexRangeJob(@Assisted Deflector deflector,
+    public CreateNewSingleIndexRangeJob(@Assisted IndexSetRegistry indexSetRegistry,
                                         @Assisted String indexName,
                                         ActivityWriter activityWriter,
                                         IndexRangeService indexRangeService) {
-        super(deflector, activityWriter, indexRangeService);
+        super(indexSetRegistry, activityWriter, indexRangeService);
         this.indexName = checkNotNull(indexName);
     }
 

--- a/graylog2-server/src/main/java/org/graylog2/indexer/ranges/EsIndexRangeService.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/ranges/EsIndexRangeService.java
@@ -31,7 +31,7 @@ import org.elasticsearch.action.get.GetResponse;
 import org.elasticsearch.client.Client;
 import org.elasticsearch.index.IndexNotFoundException;
 import org.graylog2.database.NotFoundException;
-import org.graylog2.indexer.Deflector;
+import org.graylog2.indexer.IndexSetRegistry;
 import org.graylog2.indexer.esplugin.IndicesDeletedEvent;
 import org.graylog2.metrics.CacheStatsSet;
 import org.graylog2.shared.metrics.MetricUtils;
@@ -55,15 +55,15 @@ public class EsIndexRangeService implements IndexRangeService {
 
     private final LoadingCache<String, IndexRange> cache;
     private final Client client;
-    private final Deflector deflector;
+    private final IndexSetRegistry indexSetRegistry;
 
     @Inject
     public EsIndexRangeService(Client client,
-                               Deflector deflector,
+                               IndexSetRegistry indexSetRegistry,
                                EventBus eventBus,
                                MetricRegistry metricRegistry) {
         this.client = requireNonNull(client);
-        this.deflector = requireNonNull(deflector);
+        this.indexSetRegistry = requireNonNull(indexSetRegistry);
 
         final CacheLoader<String, IndexRange> cacheLoader = new CacheLoader<String, IndexRange>() {
             @Override
@@ -157,7 +157,7 @@ public class EsIndexRangeService implements IndexRangeService {
     @Override
     public SortedSet<IndexRange> findAll() {
         final ImmutableSortedSet.Builder<IndexRange> indexRanges = ImmutableSortedSet.orderedBy(IndexRange.COMPARATOR);
-        for (String index : deflector.getAllGraylogIndexNames()) {
+        for (String index : indexSetRegistry.getAllGraylogIndexNames()) {
             try {
                 indexRanges.add(cache.get(index));
             } catch (ExecutionException e) {

--- a/graylog2-server/src/main/java/org/graylog2/indexer/ranges/EsIndexRangeService.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/ranges/EsIndexRangeService.java
@@ -157,7 +157,7 @@ public class EsIndexRangeService implements IndexRangeService {
     @Override
     public SortedSet<IndexRange> findAll() {
         final ImmutableSortedSet.Builder<IndexRange> indexRanges = ImmutableSortedSet.orderedBy(IndexRange.COMPARATOR);
-        for (String index : indexSetRegistry.getAllGraylogIndexNames()) {
+        for (String index : indexSetRegistry.getManagedIndicesNames()) {
             try {
                 indexRanges.add(cache.get(index));
             } catch (ExecutionException e) {

--- a/graylog2-server/src/main/java/org/graylog2/indexer/ranges/RebuildIndexRangesJob.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/ranges/RebuildIndexRangesJob.java
@@ -19,19 +19,18 @@ package org.graylog2.indexer.ranges;
 import com.google.common.base.Stopwatch;
 import com.google.inject.assistedinject.Assisted;
 import com.google.inject.assistedinject.AssistedInject;
-import org.graylog2.indexer.Deflector;
+import org.graylog2.indexer.IndexSetRegistry;
 import org.graylog2.shared.system.activities.Activity;
 import org.graylog2.shared.system.activities.ActivityWriter;
 import org.graylog2.system.jobs.SystemJob;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.util.Arrays;
 import java.util.concurrent.TimeUnit;
 
 public class RebuildIndexRangesJob extends SystemJob {
     public interface Factory {
-        RebuildIndexRangesJob create(Deflector deflector);
+        RebuildIndexRangesJob create(IndexSetRegistry indexSetRegistry);
     }
 
     private static final Logger LOG = LoggerFactory.getLogger(RebuildIndexRangesJob.class);
@@ -41,15 +40,15 @@ public class RebuildIndexRangesJob extends SystemJob {
     private volatile int indicesToCalculate = 0;
     private volatile int indicesCalculated = 0;
 
-    protected final Deflector deflector;
+    protected final IndexSetRegistry indexSetRegistry;
     private final ActivityWriter activityWriter;
     protected final IndexRangeService indexRangeService;
 
     @AssistedInject
-    public RebuildIndexRangesJob(@Assisted Deflector deflector,
+    public RebuildIndexRangesJob(@Assisted IndexSetRegistry indexSetRegistry,
                                  ActivityWriter activityWriter,
                                  IndexRangeService indexRangeService) {
-        this.deflector = deflector;
+        this.indexSetRegistry = indexSetRegistry;
         this.activityWriter = activityWriter;
         this.indexRangeService = indexRangeService;
     }
@@ -78,7 +77,7 @@ public class RebuildIndexRangesJob extends SystemJob {
     public void execute() {
         info("Re-calculating index ranges.");
 
-        String[] indices = deflector.getAllGraylogIndexNames();
+        String[] indices = indexSetRegistry.getAllGraylogIndexNames();
         if (indices == null || indices.length == 0) {
             info("No indices, nothing to calculate.");
             return;
@@ -86,9 +85,8 @@ public class RebuildIndexRangesJob extends SystemJob {
         indicesToCalculate = indices.length;
 
         Stopwatch sw = Stopwatch.createStarted();
-        final String deflectorIndexName = deflector.getName();
         for (String index : indices) {
-            if (deflectorIndexName.equals(index)) {
+            if (indexSetRegistry.isCurrentWriteIndexAlias(index)) {
                 continue;
             }
             if (cancelRequested) {

--- a/graylog2-server/src/main/java/org/graylog2/indexer/ranges/RebuildIndexRangesJob.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/ranges/RebuildIndexRangesJob.java
@@ -77,7 +77,7 @@ public class RebuildIndexRangesJob extends SystemJob {
     public void execute() {
         info("Re-calculating index ranges.");
 
-        String[] indices = indexSetRegistry.getAllGraylogIndexNames();
+        String[] indices = indexSetRegistry.getManagedIndicesNames();
         if (indices == null || indices.length == 0) {
             info("No indices, nothing to calculate.");
             return;

--- a/graylog2-server/src/main/java/org/graylog2/indexer/retention/strategies/AbstractIndexCountBasedRetentionStrategy.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/retention/strategies/AbstractIndexCountBasedRetentionStrategy.java
@@ -50,7 +50,7 @@ public abstract class AbstractIndexCountBasedRetentionStrategy implements Retent
 
     @Override
     public void retain(IndexSet indexSet) {
-        final Map<String, Set<String>> deflectorIndices = indexSet.getAllGraylogDeflectorIndices();
+        final Map<String, Set<String>> deflectorIndices = indexSet.getAllDeflectorAliases();
         final int indexCount = deflectorIndices.size();
         final Optional<Integer> maxIndices = getMaxNumberOfIndices();
 

--- a/graylog2-server/src/main/java/org/graylog2/indexer/retention/strategies/AbstractIndexCountBasedRetentionStrategy.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/retention/strategies/AbstractIndexCountBasedRetentionStrategy.java
@@ -17,8 +17,8 @@
 
 package org.graylog2.indexer.retention.strategies;
 
-import org.graylog2.indexer.Deflector;
 import org.graylog2.indexer.IndexHelper;
+import org.graylog2.indexer.IndexSet;
 import org.graylog2.indexer.indices.Indices;
 import org.graylog2.periodical.IndexRetentionThread;
 import org.graylog2.plugin.indexer.retention.RetentionStrategy;
@@ -36,13 +36,11 @@ import static java.util.Objects.requireNonNull;
 public abstract class AbstractIndexCountBasedRetentionStrategy implements RetentionStrategy {
     private static final Logger LOG = LoggerFactory.getLogger(AbstractIndexCountBasedRetentionStrategy.class);
 
-    private final Deflector deflector;
     private final Indices indices;
     private final ActivityWriter activityWriter;
 
-    public AbstractIndexCountBasedRetentionStrategy(Deflector deflector, Indices indices,
+    public AbstractIndexCountBasedRetentionStrategy(Indices indices,
                                                     ActivityWriter activityWriter) {
-        this.deflector = requireNonNull(deflector);
         this.indices = requireNonNull(indices);
         this.activityWriter = requireNonNull(activityWriter);
     }
@@ -51,8 +49,8 @@ public abstract class AbstractIndexCountBasedRetentionStrategy implements Retent
     protected abstract void retain(String indexName);
 
     @Override
-    public void retain() {
-        final Map<String, Set<String>> deflectorIndices = deflector.getAllGraylogDeflectorIndices();
+    public void retain(IndexSet indexSet) {
+        final Map<String, Set<String>> deflectorIndices = indexSet.getAllGraylogDeflectorIndices();
         final int indexCount = deflectorIndices.size();
         final Optional<Integer> maxIndices = getMaxNumberOfIndices();
 
@@ -75,13 +73,13 @@ public abstract class AbstractIndexCountBasedRetentionStrategy implements Retent
         LOG.info(msg);
         activityWriter.write(new Activity(msg, IndexRetentionThread.class));
 
-        runRetention(deflectorIndices, removeCount);
+        runRetention(indexSet, deflectorIndices, removeCount);
     }
 
-    private void runRetention(Map<String, Set<String>> deflectorIndices, int removeCount) {
+    private void runRetention(IndexSet indexSet, Map<String, Set<String>> deflectorIndices, int removeCount) {
         for (String indexName : IndexHelper.getOldestIndices(deflectorIndices.keySet(), removeCount)) {
             // Never run against the current deflector target.
-            if (deflectorIndices.get(indexName).contains(deflector.getName())) {
+            if (deflectorIndices.get(indexName).contains(indexSet.getWriteIndexAlias())) {
                 LOG.info("Not running retention against current deflector target <{}>.", indexName);
                 continue;
             }

--- a/graylog2-server/src/main/java/org/graylog2/indexer/retention/strategies/ClosingRetentionStrategy.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/retention/strategies/ClosingRetentionStrategy.java
@@ -20,7 +20,6 @@ import com.google.common.base.Stopwatch;
 import com.google.common.collect.ImmutableMap;
 import org.graylog2.audit.AuditActor;
 import org.graylog2.audit.AuditEventSender;
-import org.graylog2.indexer.Deflector;
 import org.graylog2.indexer.indices.Indices;
 import org.graylog2.plugin.cluster.ClusterConfigService;
 import org.graylog2.plugin.indexer.retention.RetentionStrategyConfig;
@@ -44,13 +43,12 @@ public class ClosingRetentionStrategy extends AbstractIndexCountBasedRetentionSt
     private final AuditEventSender auditEventSender;
 
     @Inject
-    public ClosingRetentionStrategy(Deflector deflector,
-                                    Indices indices,
+    public ClosingRetentionStrategy(Indices indices,
                                     ActivityWriter activityWriter,
                                     NodeId nodeId,
                                     ClusterConfigService clusterConfigService,
                                     AuditEventSender auditEventSender) {
-        super(deflector, indices, activityWriter);
+        super(indices, activityWriter);
         this.indices = indices;
         this.nodeId = nodeId;
         this.clusterConfigService = clusterConfigService;
@@ -59,6 +57,7 @@ public class ClosingRetentionStrategy extends AbstractIndexCountBasedRetentionSt
 
     @Override
     protected Optional<Integer> getMaxNumberOfIndices() {
+        // TODO 2.2: Retention strategy config is per write target, not global.
         final ClosingRetentionStrategyConfig config = clusterConfigService.get(ClosingRetentionStrategyConfig.class);
 
         if (config != null) {

--- a/graylog2-server/src/main/java/org/graylog2/indexer/retention/strategies/DeletionRetentionStrategy.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/retention/strategies/DeletionRetentionStrategy.java
@@ -20,7 +20,6 @@ import com.google.common.base.Stopwatch;
 import com.google.common.collect.ImmutableMap;
 import org.graylog2.audit.AuditActor;
 import org.graylog2.audit.AuditEventSender;
-import org.graylog2.indexer.Deflector;
 import org.graylog2.indexer.indices.Indices;
 import org.graylog2.plugin.cluster.ClusterConfigService;
 import org.graylog2.plugin.indexer.retention.RetentionStrategyConfig;
@@ -44,13 +43,12 @@ public class DeletionRetentionStrategy extends AbstractIndexCountBasedRetentionS
     private final AuditEventSender auditEventSender;
 
     @Inject
-    public DeletionRetentionStrategy(Deflector deflector,
-                                     Indices indices,
+    public DeletionRetentionStrategy(Indices indices,
                                      ActivityWriter activityWriter,
                                      ClusterConfigService clusterConfigService,
                                      NodeId nodeId,
                                      AuditEventSender auditEventSender) {
-        super(deflector, indices, activityWriter);
+        super(indices, activityWriter);
         this.indices = indices;
         this.clusterConfigService = clusterConfigService;
         this.nodeId = nodeId;
@@ -59,6 +57,7 @@ public class DeletionRetentionStrategy extends AbstractIndexCountBasedRetentionS
 
     @Override
     protected Optional<Integer> getMaxNumberOfIndices() {
+        // TODO 2.2: Retention strategy config is per write target, not global.
         final DeletionRetentionStrategyConfig config = clusterConfigService.get(DeletionRetentionStrategyConfig.class);
 
         if (config != null) {

--- a/graylog2-server/src/main/java/org/graylog2/indexer/retention/strategies/NoopRetentionStrategy.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/retention/strategies/NoopRetentionStrategy.java
@@ -16,7 +16,6 @@
  */
 package org.graylog2.indexer.retention.strategies;
 
-import org.graylog2.indexer.Deflector;
 import org.graylog2.indexer.indices.Indices;
 import org.graylog2.plugin.indexer.retention.RetentionStrategyConfig;
 import org.graylog2.shared.system.activities.ActivityWriter;
@@ -30,8 +29,8 @@ public class NoopRetentionStrategy extends AbstractIndexCountBasedRetentionStrat
     private static final Logger LOG = LoggerFactory.getLogger(NoopRetentionStrategy.class);
 
     @Inject
-    public NoopRetentionStrategy(Deflector deflector, Indices indices, ActivityWriter activityWriter) {
-        super(deflector, indices, activityWriter);
+    public NoopRetentionStrategy(Indices indices, ActivityWriter activityWriter) {
+        super(indices, activityWriter);
     }
 
     @Override

--- a/graylog2-server/src/main/java/org/graylog2/indexer/rotation/strategies/MessageCountRotationStrategy.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/rotation/strategies/MessageCountRotationStrategy.java
@@ -18,7 +18,6 @@
 package org.graylog2.indexer.rotation.strategies;
 
 import org.graylog2.audit.AuditEventSender;
-import org.graylog2.indexer.Deflector;
 import org.graylog2.indexer.IndexNotFoundException;
 import org.graylog2.indexer.indices.Indices;
 import org.graylog2.plugin.cluster.ClusterConfigService;
@@ -39,9 +38,9 @@ public class MessageCountRotationStrategy extends AbstractRotationStrategy {
     private final ClusterConfigService clusterConfigService;
 
     @Inject
-    public MessageCountRotationStrategy(Indices indices, Deflector deflector, NodeId nodeId,
+    public MessageCountRotationStrategy(Indices indices, NodeId nodeId,
                                         ClusterConfigService clusterConfigService, AuditEventSender auditEventSender) {
-        super(deflector, auditEventSender, nodeId);
+        super(auditEventSender, nodeId);
         this.indices = indices;
         this.clusterConfigService = clusterConfigService;
     }
@@ -59,6 +58,7 @@ public class MessageCountRotationStrategy extends AbstractRotationStrategy {
     @Nullable
     @Override
     protected Result shouldRotate(String index) {
+        // TODO 2.2: Rotation strategy config is per write target, not global.
         final MessageCountRotationStrategyConfig config = clusterConfigService.get(MessageCountRotationStrategyConfig.class);
 
         if (config == null) {

--- a/graylog2-server/src/main/java/org/graylog2/indexer/rotation/strategies/SizeBasedRotationStrategy.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/rotation/strategies/SizeBasedRotationStrategy.java
@@ -18,7 +18,6 @@
 package org.graylog2.indexer.rotation.strategies;
 
 import org.graylog2.audit.AuditEventSender;
-import org.graylog2.indexer.Deflector;
 import org.graylog2.indexer.indices.IndexStatistics;
 import org.graylog2.indexer.indices.Indices;
 import org.graylog2.plugin.cluster.ClusterConfigService;
@@ -40,11 +39,10 @@ public class SizeBasedRotationStrategy extends AbstractRotationStrategy {
 
     @Inject
     public SizeBasedRotationStrategy(Indices indices,
-                                     Deflector deflector,
                                      ClusterConfigService clusterConfigService,
                                      NodeId nodeId,
                                      AuditEventSender auditEventSender) {
-        super(deflector, auditEventSender, nodeId);
+        super(auditEventSender, nodeId);
         this.indices = indices;
         this.clusterConfigService = clusterConfigService;
     }
@@ -62,6 +60,7 @@ public class SizeBasedRotationStrategy extends AbstractRotationStrategy {
     @Nullable
     @Override
     protected Result shouldRotate(final String index) {
+        // TODO 2.2: Rotation strategy config is per write target, not global.
         final SizeBasedRotationStrategyConfig config = clusterConfigService.get(SizeBasedRotationStrategyConfig.class);
 
         if (config == null) {

--- a/graylog2-server/src/main/java/org/graylog2/indexer/rotation/strategies/TimeBasedRotationStrategy.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/rotation/strategies/TimeBasedRotationStrategy.java
@@ -19,7 +19,6 @@ package org.graylog2.indexer.rotation.strategies;
 
 import com.google.common.base.MoreObjects;
 import org.graylog2.audit.AuditEventSender;
-import org.graylog2.indexer.Deflector;
 import org.graylog2.indexer.indices.Indices;
 import org.graylog2.plugin.Tools;
 import org.graylog2.plugin.cluster.ClusterConfigService;
@@ -57,9 +56,9 @@ public class TimeBasedRotationStrategy extends AbstractRotationStrategy {
     private DateTime anchor;
 
     @Inject
-    public TimeBasedRotationStrategy(Indices indices, Deflector deflector, NodeId nodeId,
+    public TimeBasedRotationStrategy(Indices indices, NodeId nodeId,
                                      ClusterConfigService clusterConfigService, AuditEventSender auditEventSender) {
-        super(deflector, auditEventSender, nodeId);
+        super(auditEventSender, nodeId);
         this.clusterConfigService = clusterConfigService;
         this.anchor = null;
         this.lastRotation = null;
@@ -138,6 +137,7 @@ public class TimeBasedRotationStrategy extends AbstractRotationStrategy {
     @Nullable
     @Override
     protected Result shouldRotate(String index) {
+        // TODO 2.2: Rotation strategy config is per write target, not global.
         final TimeBasedRotationStrategyConfig config = clusterConfigService.get(TimeBasedRotationStrategyConfig.class);
 
         if (config == null) {

--- a/graylog2-server/src/main/java/org/graylog2/periodical/IndexRangesCleanupPeriodical.java
+++ b/graylog2-server/src/main/java/org/graylog2/periodical/IndexRangesCleanupPeriodical.java
@@ -21,7 +21,7 @@ import com.google.common.collect.ImmutableSet;
 import com.google.common.eventbus.EventBus;
 import com.google.common.primitives.Ints;
 import com.google.inject.name.Named;
-import org.graylog2.indexer.Deflector;
+import org.graylog2.indexer.IndexSetRegistry;
 import org.graylog2.indexer.cluster.Cluster;
 import org.graylog2.indexer.esplugin.IndicesDeletedEvent;
 import org.graylog2.indexer.ranges.IndexRange;
@@ -46,19 +46,19 @@ public class IndexRangesCleanupPeriodical extends Periodical {
     private static final Logger LOG = LoggerFactory.getLogger(IndexRangesCleanupPeriodical.class);
 
     private final Cluster cluster;
-    private final Deflector deflector;
+    private final IndexSetRegistry indexSetRegistry;
     private final IndexRangeService indexRangeService;
     private final EventBus eventBus;
     private final int periodSeconds;
 
     @Inject
     public IndexRangesCleanupPeriodical(final Cluster cluster,
-                                        final Deflector deflector,
+                                        final IndexSetRegistry indexSetRegistry,
                                         final IndexRangeService indexRangeService,
                                         final EventBus eventBus,
                                         @Named("index_ranges_cleanup_interval") final Duration indexRangesCleanupInterval) {
         this.cluster = requireNonNull(cluster);
-        this.deflector = requireNonNull(deflector);
+        this.indexSetRegistry = requireNonNull(indexSetRegistry);
         this.indexRangeService = requireNonNull(indexRangeService);
         this.eventBus = requireNonNull(eventBus);
         this.periodSeconds = Ints.saturatedCast(indexRangesCleanupInterval.toSeconds());
@@ -72,7 +72,7 @@ public class IndexRangesCleanupPeriodical extends Periodical {
             return;
         }
 
-        final Set<String> indexNames = ImmutableSet.copyOf(deflector.getAllGraylogIndexNames());
+        final Set<String> indexNames = ImmutableSet.copyOf(indexSetRegistry.getAllGraylogIndexNames());
         final SortedSet<IndexRange> indexRanges = indexRangeService.findAll();
 
         final Set<String> removedIndices = new HashSet<>();

--- a/graylog2-server/src/main/java/org/graylog2/periodical/IndexRangesCleanupPeriodical.java
+++ b/graylog2-server/src/main/java/org/graylog2/periodical/IndexRangesCleanupPeriodical.java
@@ -72,7 +72,7 @@ public class IndexRangesCleanupPeriodical extends Periodical {
             return;
         }
 
-        final Set<String> indexNames = ImmutableSet.copyOf(indexSetRegistry.getAllGraylogIndexNames());
+        final Set<String> indexNames = ImmutableSet.copyOf(indexSetRegistry.getManagedIndicesNames());
         final SortedSet<IndexRange> indexRanges = indexRangeService.findAll();
 
         final Set<String> removedIndices = new HashSet<>();

--- a/graylog2-server/src/main/java/org/graylog2/periodical/IndexRangesMigrationPeriodical.java
+++ b/graylog2-server/src/main/java/org/graylog2/periodical/IndexRangesMigrationPeriodical.java
@@ -87,7 +87,7 @@ public class IndexRangesMigrationPeriodical extends Periodical {
             Uninterruptibles.sleepUninterruptibly(5, TimeUnit.SECONDS);
         }
 
-        final Set<String> indexNames = ImmutableSet.copyOf(indexSetRegistry.getAllGraylogIndexNames());
+        final Set<String> indexNames = ImmutableSet.copyOf(indexSetRegistry.getManagedIndicesNames());
 
         // Migrate old MongoDB index ranges
         final SortedSet<IndexRange> mongoIndexRanges = legacyMongoIndexRangeService.findAll();

--- a/graylog2-server/src/main/java/org/graylog2/periodical/IndexRangesMigrationPeriodical.java
+++ b/graylog2-server/src/main/java/org/graylog2/periodical/IndexRangesMigrationPeriodical.java
@@ -21,7 +21,7 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.util.concurrent.Uninterruptibles;
-import org.graylog2.indexer.Deflector;
+import org.graylog2.indexer.IndexSetRegistry;
 import org.graylog2.indexer.cluster.Cluster;
 import org.graylog2.indexer.ranges.EsIndexRangeService;
 import org.graylog2.indexer.ranges.IndexRange;
@@ -51,7 +51,7 @@ public class IndexRangesMigrationPeriodical extends Periodical {
     private static final Logger LOG = LoggerFactory.getLogger(IndexRangesMigrationPeriodical.class);
 
     private final Cluster cluster;
-    private final Deflector deflector;
+    private final IndexSetRegistry indexSetRegistry;
     private final IndexRangeService indexRangeService;
     private final NotificationService notificationService;
     private final LegacyMongoIndexRangeService legacyMongoIndexRangeService;
@@ -60,14 +60,14 @@ public class IndexRangesMigrationPeriodical extends Periodical {
 
     @Inject
     public IndexRangesMigrationPeriodical(final Cluster cluster,
-                                          final Deflector deflector,
+                                          final IndexSetRegistry indexSetRegistry,
                                           final IndexRangeService indexRangeService,
                                           final NotificationService notificationService,
                                           final LegacyMongoIndexRangeService legacyMongoIndexRangeService,
                                           final EsIndexRangeService esIndexRangeService,
                                           final ClusterConfigService clusterConfigService) {
         this.cluster = checkNotNull(cluster);
-        this.deflector = checkNotNull(deflector);
+        this.indexSetRegistry = checkNotNull(indexSetRegistry);
         this.indexRangeService = checkNotNull(indexRangeService);
         this.notificationService = checkNotNull(notificationService);
         this.legacyMongoIndexRangeService = checkNotNull(legacyMongoIndexRangeService);
@@ -87,7 +87,7 @@ public class IndexRangesMigrationPeriodical extends Periodical {
             Uninterruptibles.sleepUninterruptibly(5, TimeUnit.SECONDS);
         }
 
-        final Set<String> indexNames = ImmutableSet.copyOf(deflector.getAllGraylogIndexNames());
+        final Set<String> indexNames = ImmutableSet.copyOf(indexSetRegistry.getAllGraylogIndexNames());
 
         // Migrate old MongoDB index ranges
         final SortedSet<IndexRange> mongoIndexRanges = legacyMongoIndexRangeService.findAll();

--- a/graylog2-server/src/main/java/org/graylog2/plugin/indexer/rotation/RotationStrategy.java
+++ b/graylog2-server/src/main/java/org/graylog2/plugin/indexer/rotation/RotationStrategy.java
@@ -16,8 +16,10 @@
  */
 package org.graylog2.plugin.indexer.rotation;
 
+import org.graylog2.indexer.IndexSet;
+
 public interface RotationStrategy {
-    void rotate();
+    void rotate(IndexSet indexSet);
 
     Class<? extends RotationStrategyConfig> configurationClass();
 

--- a/graylog2-server/src/main/java/org/graylog2/rest/resources/system/IndexRangesResource.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/resources/system/IndexRangesResource.java
@@ -28,7 +28,7 @@ import org.apache.shiro.authz.annotation.RequiresPermissions;
 import org.graylog2.audit.AuditEventTypes;
 import org.graylog2.audit.jersey.AuditEvent;
 import org.graylog2.database.NotFoundException;
-import org.graylog2.indexer.Deflector;
+import org.graylog2.indexer.IndexSetRegistry;
 import org.graylog2.indexer.ranges.CreateNewSingleIndexRangeJob;
 import org.graylog2.indexer.ranges.IndexRange;
 import org.graylog2.indexer.ranges.IndexRangeService;
@@ -66,19 +66,19 @@ public class IndexRangesResource extends RestResource {
     private final IndexRangeService indexRangeService;
     private final RebuildIndexRangesJob.Factory rebuildIndexRangesJobFactory;
     private final CreateNewSingleIndexRangeJob.Factory singleIndexRangeJobFactory;
-    private final Deflector deflector;
+    private final IndexSetRegistry indexSetRegistry;
     private final SystemJobManager systemJobManager;
 
     @Inject
     public IndexRangesResource(IndexRangeService indexRangeService,
                                RebuildIndexRangesJob.Factory rebuildIndexRangesJobFactory,
                                CreateNewSingleIndexRangeJob.Factory singleIndexRangeJobFactory,
-                               Deflector deflector,
+                               IndexSetRegistry indexSetRegistry,
                                SystemJobManager systemJobManager) {
         this.indexRangeService = indexRangeService;
         this.rebuildIndexRangesJobFactory = rebuildIndexRangesJobFactory;
         this.singleIndexRangeJobFactory = singleIndexRangeJobFactory;
-        this.deflector = deflector;
+        this.indexSetRegistry = indexSetRegistry;
         this.systemJobManager = systemJobManager;
     }
 
@@ -114,7 +114,7 @@ public class IndexRangesResource extends RestResource {
     public IndexRangeSummary show(
             @ApiParam(name = "index", value = "The name of the Graylog-managed Elasticsearch index", required = true)
             @PathParam("index") @NotEmpty String index) throws NotFoundException {
-        if (!deflector.isGraylogIndex(index)) {
+        if (!indexSetRegistry.isGraylogIndex(index)) {
             throw new BadRequestException(index + " is not a Graylog-managed Elasticsearch index.");
         }
         checkPermission(RestPermissions.INDEXRANGES_READ, index);
@@ -143,7 +143,7 @@ public class IndexRangesResource extends RestResource {
     @Produces(MediaType.APPLICATION_JSON)
     @AuditEvent(type = AuditEventTypes.ES_INDEX_RANGE_UPDATE_JOB)
     public Response rebuild() {
-        final SystemJob rebuildJob = rebuildIndexRangesJobFactory.create(this.deflector);
+        final SystemJob rebuildJob = rebuildIndexRangesJobFactory.create(indexSetRegistry);
         try {
             this.systemJobManager.submit(rebuildJob);
         } catch (SystemJobConcurrencyException e) {
@@ -170,12 +170,12 @@ public class IndexRangesResource extends RestResource {
     public Response rebuildIndex(
             @ApiParam(name = "index", value = "The name of the Graylog-managed Elasticsearch index", required = true)
             @PathParam("index") @NotEmpty String index) {
-        if (!deflector.isGraylogIndex(index)) {
+        if (!indexSetRegistry.isGraylogIndex(index)) {
             throw new BadRequestException(index + " is not a Graylog-managed Elasticsearch index.");
         }
         checkPermission(RestPermissions.INDEXRANGES_REBUILD, index);
 
-        final SystemJob rebuildJob = singleIndexRangeJobFactory.create(deflector, index);
+        final SystemJob rebuildJob = singleIndexRangeJobFactory.create(indexSetRegistry, index);
         try {
             this.systemJobManager.submit(rebuildJob);
         } catch (SystemJobConcurrencyException e) {

--- a/graylog2-server/src/main/java/org/graylog2/rest/resources/system/IndexRangesResource.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/resources/system/IndexRangesResource.java
@@ -114,7 +114,7 @@ public class IndexRangesResource extends RestResource {
     public IndexRangeSummary show(
             @ApiParam(name = "index", value = "The name of the Graylog-managed Elasticsearch index", required = true)
             @PathParam("index") @NotEmpty String index) throws NotFoundException {
-        if (!indexSetRegistry.isGraylogIndex(index)) {
+        if (!indexSetRegistry.isManagedIndex(index)) {
             throw new BadRequestException(index + " is not a Graylog-managed Elasticsearch index.");
         }
         checkPermission(RestPermissions.INDEXRANGES_READ, index);
@@ -170,7 +170,7 @@ public class IndexRangesResource extends RestResource {
     public Response rebuildIndex(
             @ApiParam(name = "index", value = "The name of the Graylog-managed Elasticsearch index", required = true)
             @PathParam("index") @NotEmpty String index) {
-        if (!indexSetRegistry.isGraylogIndex(index)) {
+        if (!indexSetRegistry.isManagedIndex(index)) {
             throw new BadRequestException(index + " is not a Graylog-managed Elasticsearch index.");
         }
         checkPermission(RestPermissions.INDEXRANGES_REBUILD, index);

--- a/graylog2-server/src/main/java/org/graylog2/rest/resources/system/indexer/IndexerOverviewResource.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/resources/system/indexer/IndexerOverviewResource.java
@@ -88,7 +88,7 @@ public class IndexerOverviewResource extends RestResource {
         final DeflectorSummary deflectorSummary = deflectorResource.deflector();
         final List<IndexRangeSummary> indexRanges = indexRangesResource.list().ranges();
         final Map<String, IndexStats> allDocCounts = indices.getAllDocCounts().entrySet().stream()
-                .filter(entry -> indexSetRegistry.isGraylogIndex(entry.getKey()))
+                .filter(entry -> indexSetRegistry.isManagedIndex(entry.getKey()))
                 .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
         final Map<String, Boolean> areReopened = indices.areReopened(allDocCounts.keySet());
         final Map<String, IndexSummary> indicesSummaries = allDocCounts.values()

--- a/graylog2-server/src/main/java/org/graylog2/rest/resources/system/indexer/IndicesResource.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/resources/system/indexer/IndicesResource.java
@@ -234,7 +234,7 @@ public class IndicesResource extends RestResource {
             throw new NotFoundException(msg);
         }
 
-        if (index.equals(indexSetRegistry.getAllIndexSets().get(0).getCurrentActualTargetIndex())) {
+        if (indexSetRegistry.isCurrentWriteIndex(index)) {
             throw new ForbiddenException("The current deflector target index (" + index + ") cannot be closed");
         }
 
@@ -260,7 +260,7 @@ public class IndicesResource extends RestResource {
             throw new NotFoundException(msg);
         }
 
-        if (index.equals(indexSetRegistry.getAllIndexSets().get(0).getCurrentActualTargetIndex())) {
+        if (indexSetRegistry.isCurrentWriteIndex(index)) {
             throw new ForbiddenException("The current deflector target index (" + index + ") cannot be deleted");
         }
 

--- a/graylog2-server/src/main/java/org/graylog2/rest/resources/system/indexer/IndicesResource.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/resources/system/indexer/IndicesResource.java
@@ -92,7 +92,7 @@ public class IndicesResource extends RestResource {
     public IndexInfo single(@ApiParam(name = "index") @PathParam("index") String index) {
         checkPermission(RestPermissions.INDICES_READ, index);
 
-        if (!indexSetRegistry.isGraylogIndex(index)) {
+        if (!indexSetRegistry.isManagedIndex(index)) {
             final String msg = "Index [" + index + "] doesn't look like an index managed by Graylog.";
             LOG.info(msg);
             throw new NotFoundException(msg);
@@ -124,7 +124,7 @@ public class IndicesResource extends RestResource {
                                            @Valid @NotNull IndicesReadRequest request) {
         if (request.indices() != null) {
             return request.indices().stream()
-                    .filter(indexSetRegistry::isGraylogIndex)
+                    .filter(indexSetRegistry::isManagedIndex)
                     .collect(Collectors.toMap(Function.identity(), this::single));
         }
 
@@ -139,7 +139,7 @@ public class IndicesResource extends RestResource {
     @Produces(MediaType.APPLICATION_JSON)
     public OpenIndicesInfo open() {
         final Set<IndexStatistics> indicesStats = indices.getIndicesStats().stream()
-                .filter(indexStats -> indexSetRegistry.isGraylogIndex(indexStats.indexName()))
+                .filter(indexStats -> indexSetRegistry.isManagedIndex(indexStats.indexName()))
                 .collect(Collectors.toSet());
 
         final Map<String, IndexInfo> indexInfos = new HashMap<>();
@@ -170,7 +170,7 @@ public class IndicesResource extends RestResource {
     public ClosedIndices closed() {
         final Set<String> closedIndices = indices.getClosedIndices()
             .stream()
-            .filter((indexName) -> isPermitted(RestPermissions.INDICES_READ, indexName) && indexSetRegistry.isGraylogIndex(indexName))
+            .filter((indexName) -> isPermitted(RestPermissions.INDICES_READ, indexName) && indexSetRegistry.isManagedIndex(indexName))
             .collect(Collectors.toSet());
 
         return ClosedIndices.create(closedIndices, closedIndices.size());
@@ -184,7 +184,7 @@ public class IndicesResource extends RestResource {
     public ClosedIndices reopened() {
         final Set<String> reopenedIndices = indices.getReopenedIndices()
             .stream()
-            .filter((indexName) -> isPermitted(RestPermissions.INDICES_READ, indexName) && indexSetRegistry.isGraylogIndex(indexName))
+            .filter((indexName) -> isPermitted(RestPermissions.INDICES_READ, indexName) && indexSetRegistry.isManagedIndex(indexName))
             .collect(Collectors.toSet());
 
         return ClosedIndices.create(reopenedIndices, reopenedIndices.size());
@@ -207,7 +207,7 @@ public class IndicesResource extends RestResource {
     public void reopen(@ApiParam(name = "index") @PathParam("index") String index) {
         checkPermission(RestPermissions.INDICES_CHANGESTATE, index);
 
-        if (!indexSetRegistry.isGraylogIndex(index)) {
+        if (!indexSetRegistry.isManagedIndex(index)) {
             final String msg = "Index [" + index + "] doesn't look like an index managed by Graylog.";
             LOG.info(msg);
             throw new NotFoundException(msg);
@@ -228,7 +228,7 @@ public class IndicesResource extends RestResource {
     public void close(@ApiParam(name = "index") @PathParam("index") @NotNull String index) throws TooManyAliasesException {
         checkPermission(RestPermissions.INDICES_CHANGESTATE, index);
 
-        if (!indexSetRegistry.isGraylogIndex(index)) {
+        if (!indexSetRegistry.isManagedIndex(index)) {
             final String msg = "Index [" + index + "] doesn't look like an index managed by Graylog.";
             LOG.info(msg);
             throw new NotFoundException(msg);
@@ -254,7 +254,7 @@ public class IndicesResource extends RestResource {
     public void delete(@ApiParam(name = "index") @PathParam("index") @NotNull String index) throws TooManyAliasesException {
         checkPermission(RestPermissions.INDICES_DELETE, index);
 
-        if (!indexSetRegistry.isGraylogIndex(index)) {
+        if (!indexSetRegistry.isManagedIndex(index)) {
             final String msg = "Index [" + index + "] doesn't look like an index managed by Graylog.";
             LOG.info(msg);
             throw new NotFoundException(msg);

--- a/graylog2-server/src/main/java/org/graylog2/rest/resources/system/indexer/IndicesResource.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/resources/system/indexer/IndicesResource.java
@@ -29,7 +29,7 @@ import org.elasticsearch.action.admin.indices.stats.CommonStats;
 import org.graylog2.audit.AuditEventTypes;
 import org.graylog2.audit.jersey.AuditEvent;
 import org.graylog2.audit.jersey.NoAuditEvent;
-import org.graylog2.indexer.Deflector;
+import org.graylog2.indexer.IndexSetRegistry;
 import org.graylog2.indexer.cluster.Cluster;
 import org.graylog2.indexer.indices.IndexStatistics;
 import org.graylog2.indexer.indices.Indices;
@@ -74,13 +74,14 @@ public class IndicesResource extends RestResource {
 
     private final Indices indices;
     private final Cluster cluster;
-    private final Deflector deflector;
+    private final IndexSetRegistry indexSetRegistry;
 
+    // TODO 2.2: Resource needs to be adjusted to handle a specific write target
     @Inject
-    public IndicesResource(Indices indices, Cluster cluster, Deflector deflector) {
+    public IndicesResource(Indices indices, Cluster cluster, IndexSetRegistry indexSetRegistry) {
         this.indices = indices;
         this.cluster = cluster;
-        this.deflector = deflector;
+        this.indexSetRegistry = indexSetRegistry;
     }
 
     @GET
@@ -91,7 +92,7 @@ public class IndicesResource extends RestResource {
     public IndexInfo single(@ApiParam(name = "index") @PathParam("index") String index) {
         checkPermission(RestPermissions.INDICES_READ, index);
 
-        if (!deflector.isGraylogIndex(index)) {
+        if (!indexSetRegistry.isGraylogIndex(index)) {
             final String msg = "Index [" + index + "] doesn't look like an index managed by Graylog.";
             LOG.info(msg);
             throw new NotFoundException(msg);
@@ -123,7 +124,7 @@ public class IndicesResource extends RestResource {
                                            @Valid @NotNull IndicesReadRequest request) {
         if (request.indices() != null) {
             return request.indices().stream()
-                    .filter(deflector::isGraylogIndex)
+                    .filter(indexSetRegistry::isGraylogIndex)
                     .collect(Collectors.toMap(Function.identity(), this::single));
         }
 
@@ -138,7 +139,7 @@ public class IndicesResource extends RestResource {
     @Produces(MediaType.APPLICATION_JSON)
     public OpenIndicesInfo open() {
         final Set<IndexStatistics> indicesStats = indices.getIndicesStats().stream()
-                .filter(indexStats -> deflector.isGraylogIndex(indexStats.indexName()))
+                .filter(indexStats -> indexSetRegistry.isGraylogIndex(indexStats.indexName()))
                 .collect(Collectors.toSet());
 
         final Map<String, IndexInfo> indexInfos = new HashMap<>();
@@ -169,7 +170,7 @@ public class IndicesResource extends RestResource {
     public ClosedIndices closed() {
         final Set<String> closedIndices = indices.getClosedIndices()
             .stream()
-            .filter((indexName) -> isPermitted(RestPermissions.INDICES_READ, indexName) && deflector.isGraylogIndex(indexName))
+            .filter((indexName) -> isPermitted(RestPermissions.INDICES_READ, indexName) && indexSetRegistry.isGraylogIndex(indexName))
             .collect(Collectors.toSet());
 
         return ClosedIndices.create(closedIndices, closedIndices.size());
@@ -183,7 +184,7 @@ public class IndicesResource extends RestResource {
     public ClosedIndices reopened() {
         final Set<String> reopenedIndices = indices.getReopenedIndices()
             .stream()
-            .filter((indexName) -> isPermitted(RestPermissions.INDICES_READ, indexName) && deflector.isGraylogIndex(indexName))
+            .filter((indexName) -> isPermitted(RestPermissions.INDICES_READ, indexName) && indexSetRegistry.isGraylogIndex(indexName))
             .collect(Collectors.toSet());
 
         return ClosedIndices.create(reopenedIndices, reopenedIndices.size());
@@ -206,7 +207,7 @@ public class IndicesResource extends RestResource {
     public void reopen(@ApiParam(name = "index") @PathParam("index") String index) {
         checkPermission(RestPermissions.INDICES_CHANGESTATE, index);
 
-        if (!deflector.isGraylogIndex(index)) {
+        if (!indexSetRegistry.isGraylogIndex(index)) {
             final String msg = "Index [" + index + "] doesn't look like an index managed by Graylog.";
             LOG.info(msg);
             throw new NotFoundException(msg);
@@ -227,13 +228,13 @@ public class IndicesResource extends RestResource {
     public void close(@ApiParam(name = "index") @PathParam("index") @NotNull String index) throws TooManyAliasesException {
         checkPermission(RestPermissions.INDICES_CHANGESTATE, index);
 
-        if (!deflector.isGraylogIndex(index)) {
+        if (!indexSetRegistry.isGraylogIndex(index)) {
             final String msg = "Index [" + index + "] doesn't look like an index managed by Graylog.";
             LOG.info(msg);
             throw new NotFoundException(msg);
         }
 
-        if (index.equals(deflector.getCurrentActualTargetIndex())) {
+        if (index.equals(indexSetRegistry.getAllIndexSets().get(0).getCurrentActualTargetIndex())) {
             throw new ForbiddenException("The current deflector target index (" + index + ") cannot be closed");
         }
 
@@ -253,13 +254,13 @@ public class IndicesResource extends RestResource {
     public void delete(@ApiParam(name = "index") @PathParam("index") @NotNull String index) throws TooManyAliasesException {
         checkPermission(RestPermissions.INDICES_DELETE, index);
 
-        if (!deflector.isGraylogIndex(index)) {
+        if (!indexSetRegistry.isGraylogIndex(index)) {
             final String msg = "Index [" + index + "] doesn't look like an index managed by Graylog.";
             LOG.info(msg);
             throw new NotFoundException(msg);
         }
 
-        if (index.equals(deflector.getCurrentActualTargetIndex())) {
+        if (index.equals(indexSetRegistry.getAllIndexSets().get(0).getCurrentActualTargetIndex())) {
             throw new ForbiddenException("The current deflector target index (" + index + ") cannot be deleted");
         }
 

--- a/graylog2-server/src/test/java/org/graylog2/indexer/counts/CountsTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/indexer/counts/CountsTest.java
@@ -26,7 +26,8 @@ import org.elasticsearch.action.index.IndexResponse;
 import org.elasticsearch.client.Client;
 import org.elasticsearch.cluster.health.ClusterHealthStatus;
 import org.elasticsearch.common.unit.TimeValue;
-import org.graylog2.indexer.Deflector;
+import org.graylog2.indexer.LegacyDeflectorRegistry;
+import org.graylog2.indexer.IndexSet;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.ClassRule;
@@ -58,7 +59,7 @@ public class CountsTest {
     private Client client;
 
     @Mock
-    private Deflector deflector;
+    private IndexSet indexSet;
     private Counts counts;
 
     @Before
@@ -81,9 +82,9 @@ public class CountsTest {
                 .get();
         assumeTrue(clusterHealthResponse.getStatus() == ClusterHealthStatus.GREEN);
 
-        when(deflector.getAllGraylogIndexNames()).thenReturn(new String[]{INDEX_NAME});
+        when(indexSet.getAllGraylogIndexNames()).thenReturn(new String[]{INDEX_NAME});
 
-        counts = new Counts(client, deflector);
+        counts = new Counts(client, new LegacyDeflectorRegistry(indexSet));
     }
 
     @After

--- a/graylog2-server/src/test/java/org/graylog2/indexer/counts/CountsTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/indexer/counts/CountsTest.java
@@ -82,7 +82,7 @@ public class CountsTest {
                 .get();
         assumeTrue(clusterHealthResponse.getStatus() == ClusterHealthStatus.GREEN);
 
-        when(indexSet.getAllGraylogIndexNames()).thenReturn(new String[]{INDEX_NAME});
+        when(indexSet.getManagedIndicesNames()).thenReturn(new String[]{INDEX_NAME});
 
         counts = new Counts(client, new LegacyDeflectorRegistry(indexSet));
     }

--- a/graylog2-server/src/test/java/org/graylog2/indexer/ranges/EsIndexRangeServiceTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/indexer/ranges/EsIndexRangeServiceTest.java
@@ -30,6 +30,8 @@ import org.graylog2.audit.NullAuditEventSender;
 import org.graylog2.configuration.ElasticsearchConfiguration;
 import org.graylog2.database.NotFoundException;
 import org.graylog2.indexer.Deflector;
+import org.graylog2.indexer.LegacyDeflectorIndexSet;
+import org.graylog2.indexer.LegacyDeflectorRegistry;
 import org.graylog2.indexer.IndexMapping;
 import org.graylog2.indexer.indices.Indices;
 import org.graylog2.indexer.messages.Messages;
@@ -94,7 +96,7 @@ public class EsIndexRangeServiceTest {
         indices = new Indices(client, ELASTICSEARCH_CONFIGURATION, new IndexMapping(), messages, mock(NodeId.class), new NullAuditEventSender());
         final Deflector deflector = new Deflector(null, ELASTICSEARCH_CONFIGURATION.getIndexPrefix(), new NullActivityWriter(),
             indices, null, auditEventSender, nodeId, null);
-        indexRangeService = new EsIndexRangeService(client, deflector, localEventBus, new MetricRegistry());
+        indexRangeService = new EsIndexRangeService(client, new LegacyDeflectorRegistry(new LegacyDeflectorIndexSet(deflector)), localEventBus, new MetricRegistry());
     }
 
     @Test

--- a/graylog2-server/src/test/java/org/graylog2/indexer/rotation/strategies/MessageCountRotationStrategyTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/indexer/rotation/strategies/MessageCountRotationStrategyTest.java
@@ -18,8 +18,8 @@
 package org.graylog2.indexer.rotation.strategies;
 
 import org.graylog2.audit.AuditEventSender;
-import org.graylog2.indexer.Deflector;
 import org.graylog2.indexer.IndexNotFoundException;
+import org.graylog2.indexer.IndexSet;
 import org.graylog2.indexer.indices.Indices;
 import org.graylog2.plugin.cluster.ClusterConfigService;
 import org.graylog2.plugin.system.NodeId;
@@ -41,7 +41,7 @@ public class MessageCountRotationStrategyTest {
     private ClusterConfigService clusterConfigService;
 
     @Mock
-    private Deflector deflector;
+    private IndexSet indexSet;
 
     @Mock
     private Indices indices;
@@ -55,40 +55,40 @@ public class MessageCountRotationStrategyTest {
     @Test
     public void testRotate() throws Exception {
         when(indices.numberOfMessages("name")).thenReturn(10L);
-        when(deflector.getNewestTargetName()).thenReturn("name");
+        when(indexSet.getNewestTargetName()).thenReturn("name");
         when(clusterConfigService.get(MessageCountRotationStrategyConfig.class)).thenReturn(MessageCountRotationStrategyConfig.create(5));
 
-        final MessageCountRotationStrategy strategy = new MessageCountRotationStrategy(indices, deflector, nodeId, clusterConfigService, auditEventSender);
+        final MessageCountRotationStrategy strategy = new MessageCountRotationStrategy(indices, nodeId, clusterConfigService, auditEventSender);
 
-        strategy.rotate();
-        verify(deflector, times(1)).cycle();
-        reset(deflector);
+        strategy.rotate(indexSet);
+        verify(indexSet, times(1)).cycle();
+        reset(indexSet);
     }
 
     @Test
     public void testDontRotate() throws Exception {
         when(indices.numberOfMessages("name")).thenReturn(1L);
-        when(deflector.getNewestTargetName()).thenReturn("name");
+        when(indexSet.getNewestTargetName()).thenReturn("name");
         when(clusterConfigService.get(MessageCountRotationStrategyConfig.class)).thenReturn(MessageCountRotationStrategyConfig.create(5));
 
-        final MessageCountRotationStrategy strategy = new MessageCountRotationStrategy(indices, deflector, nodeId, clusterConfigService, auditEventSender);
+        final MessageCountRotationStrategy strategy = new MessageCountRotationStrategy(indices, nodeId, clusterConfigService, auditEventSender);
 
-        strategy.rotate();
-        verify(deflector, never()).cycle();
-        reset(deflector);
+        strategy.rotate(indexSet);
+        verify(indexSet, never()).cycle();
+        reset(indexSet);
     }
 
 
     @Test
     public void testIndexUnavailable() throws Exception {
         doThrow(IndexNotFoundException.class).when(indices).numberOfMessages("name");
-        when(deflector.getNewestTargetName()).thenReturn("name");
+        when(indexSet.getNewestTargetName()).thenReturn("name");
         when(clusterConfigService.get(MessageCountRotationStrategyConfig.class)).thenReturn(MessageCountRotationStrategyConfig.create(5));
 
-        final MessageCountRotationStrategy strategy = new MessageCountRotationStrategy(indices, deflector, nodeId, clusterConfigService , auditEventSender);
+        final MessageCountRotationStrategy strategy = new MessageCountRotationStrategy(indices, nodeId, clusterConfigService, auditEventSender);
 
-        strategy.rotate();
-        verify(deflector, never()).cycle();
-        reset(deflector);
+        strategy.rotate(indexSet);
+        verify(indexSet, never()).cycle();
+        reset(indexSet);
     }
 }

--- a/graylog2-server/src/test/java/org/graylog2/indexer/rotation/strategies/SizeBasedRotationStrategyTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/indexer/rotation/strategies/SizeBasedRotationStrategyTest.java
@@ -21,7 +21,7 @@ import org.elasticsearch.action.admin.indices.stats.CommonStats;
 import org.elasticsearch.cluster.routing.ShardRouting;
 import org.elasticsearch.index.store.StoreStats;
 import org.graylog2.audit.AuditEventSender;
-import org.graylog2.indexer.Deflector;
+import org.graylog2.indexer.IndexSet;
 import org.graylog2.indexer.indices.IndexStatistics;
 import org.graylog2.indexer.indices.Indices;
 import org.graylog2.plugin.cluster.ClusterConfigService;
@@ -45,7 +45,7 @@ public class SizeBasedRotationStrategyTest {
     private ClusterConfigService clusterConfigService;
 
     @Mock
-    private Deflector deflector;
+    private IndexSet indexSet;
 
     @Mock
     private Indices indices;
@@ -63,14 +63,14 @@ public class SizeBasedRotationStrategyTest {
         final IndexStatistics stats = IndexStatistics.create("name", commonStats, commonStats, Collections.<ShardRouting>emptyList());
 
         when(indices.getIndexStats("name")).thenReturn(stats);
-        when(deflector.getNewestTargetName()).thenReturn("name");
+        when(indexSet.getNewestTargetName()).thenReturn("name");
         when(clusterConfigService.get(SizeBasedRotationStrategyConfig.class)).thenReturn(SizeBasedRotationStrategyConfig.create(100L));
 
-        final SizeBasedRotationStrategy strategy = new SizeBasedRotationStrategy(indices, deflector, clusterConfigService, nodeId, auditEventSender);
+        final SizeBasedRotationStrategy strategy = new SizeBasedRotationStrategy(indices, clusterConfigService, nodeId, auditEventSender);
 
-        strategy.rotate();
-        verify(deflector, times(1)).cycle();
-        reset(deflector);
+        strategy.rotate(indexSet);
+        verify(indexSet, times(1)).cycle();
+        reset(indexSet);
     }
 
 
@@ -81,27 +81,27 @@ public class SizeBasedRotationStrategyTest {
         final IndexStatistics stats = IndexStatistics.create("name", commonStats, commonStats, Collections.<ShardRouting>emptyList());
 
         when(indices.getIndexStats("name")).thenReturn(stats);
-        when(deflector.getNewestTargetName()).thenReturn("name");
+        when(indexSet.getNewestTargetName()).thenReturn("name");
         when(clusterConfigService.get(SizeBasedRotationStrategyConfig.class)).thenReturn(SizeBasedRotationStrategyConfig.create(100000L));
 
-        final SizeBasedRotationStrategy strategy = new SizeBasedRotationStrategy(indices, deflector, clusterConfigService, nodeId, auditEventSender);
+        final SizeBasedRotationStrategy strategy = new SizeBasedRotationStrategy(indices, clusterConfigService, nodeId, auditEventSender);
 
-        strategy.rotate();
-        verify(deflector, never()).cycle();
-        reset(deflector);
+        strategy.rotate(indexSet);
+        verify(indexSet, never()).cycle();
+        reset(indexSet);
     }
 
 
     @Test
     public void testRotateFailed() throws Exception {
         when(indices.getIndexStats("name")).thenReturn(null);
-        when(deflector.getNewestTargetName()).thenReturn("name");
+        when(indexSet.getNewestTargetName()).thenReturn("name");
         when(clusterConfigService.get(SizeBasedRotationStrategyConfig.class)).thenReturn(SizeBasedRotationStrategyConfig.create(100));
 
-        final SizeBasedRotationStrategy strategy = new SizeBasedRotationStrategy(indices, deflector, clusterConfigService, nodeId, auditEventSender);
+        final SizeBasedRotationStrategy strategy = new SizeBasedRotationStrategy(indices, clusterConfigService, nodeId, auditEventSender);
 
-        strategy.rotate();
-        verify(deflector, never()).cycle();
-        reset(deflector);
+        strategy.rotate(indexSet);
+        verify(indexSet, never()).cycle();
+        reset(indexSet);
     }
 }


### PR DESCRIPTION
This replaces direct Deflector usage with IndexSetRegistry and IndexSet usage.

Add legacy implementations of both new interfaces that just use the current Deflector class for now.

Refs #2880