### PR TITLE
Replace Jersey GZipEncoder with Grizzly's GZipFilter

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/shared/initializers/JerseyService.java
+++ b/graylog2-server/src/main/java/org/graylog2/shared/initializers/JerseyService.java
@@ -23,15 +23,14 @@ import com.fasterxml.jackson.jaxrs.json.JacksonJaxbJsonProvider;
 import com.google.common.base.Strings;
 import com.google.common.util.concurrent.AbstractIdleService;
 import com.google.common.util.concurrent.ThreadFactoryBuilder;
+import org.glassfish.grizzly.http.CompressionConfig;
 import org.glassfish.grizzly.http.server.HttpServer;
 import org.glassfish.grizzly.http.server.NetworkListener;
 import org.glassfish.grizzly.ssl.SSLContextConfigurator;
 import org.glassfish.grizzly.ssl.SSLEngineConfigurator;
 import org.glassfish.jersey.grizzly2.httpserver.GrizzlyHttpServerFactory;
-import org.glassfish.jersey.message.GZipEncoder;
 import org.glassfish.jersey.server.ResourceConfig;
 import org.glassfish.jersey.server.ServerProperties;
-import org.glassfish.jersey.server.filter.EncodingFilter;
 import org.glassfish.jersey.server.model.Resource;
 import org.graylog2.Configuration;
 import org.graylog2.audit.PluginAuditEventTypes;
@@ -260,8 +259,7 @@ public class JerseyService extends AbstractIdleService {
     }
 
 
-    private ResourceConfig buildResourceConfig(final boolean enableGzip,
-                                               final boolean enableCors,
+    private ResourceConfig buildResourceConfig(final boolean enableCors,
                                                final Set<Resource> additionalResources,
                                                final String[] controllerPackages) {
         final Map<String, String> packagePrefixes = new HashMap<>();
@@ -302,10 +300,6 @@ public class JerseyService extends AbstractIdleService {
         containerResponseFilters.forEach(rc::registerClasses);
         additionalComponents.forEach(rc::registerClasses);
 
-        if (enableGzip) {
-            EncodingFilter.enableFor(rc, GZipEncoder.class);
-        }
-
         if (enableCors) {
             LOG.info("Enabling CORS for HTTP endpoint");
             rc.registerClasses(CORSFilter.class);
@@ -331,7 +325,6 @@ public class JerseyService extends AbstractIdleService {
                              String[] controllerPackages)
             throws GeneralSecurityException, IOException {
         final ResourceConfig resourceConfig = buildResourceConfig(
-                enableGzip,
                 enableCors,
                 additionalResources,
                 controllerPackages
@@ -358,6 +351,13 @@ public class JerseyService extends AbstractIdleService {
         // sense for Graylog because we are not mainly a web server.
         // See "Selector runners count" at https://grizzly.java.net/bestpractices.html for details.
         listener.getTransport().setSelectorRunnersCount(selectorRunnersCount);
+
+
+        if(enableGzip) {
+            final CompressionConfig compressionConfig = listener.getCompressionConfig();
+            compressionConfig.setCompressionMode(CompressionConfig.CompressionMode.ON);
+            compressionConfig.setCompressionMinSize(512);
+        }
 
         return httpServer;
     }


### PR DESCRIPTION
## Description

The Jersey GZipEncoder seems to have some problems delivering gzipped assets for the API browser.

In order to make this work again, this commit switches to the native Grizzly GzipFilter (which also works for non-Jersey resources).

Refs #2790

## How Has This Been Tested?

Before:
```
$ time curl --compressed --silent --output /dev/null http://127.0.0.1:9000/api/api-browser/

real	0m32.576s
user	0m0.004s
sys	0m0.006s
```

After:
```
$ time curl --compressed --silent --output /dev/null http://127.0.0.1:9000/api/api-browser/

real	0m0.010s
user	0m0.003s
sys	0m0.003s
```

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.