### PR TITLE
Support all zlib compression levels for GELF messages

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/inputs/codecs/gelf/GELFMessage.java
+++ b/graylog2-server/src/main/java/org/graylog2/inputs/codecs/gelf/GELFMessage.java
@@ -134,8 +134,8 @@ public class GELFMessage {
             if (first == ZLIB.first()) {
                 // zlib's second byte is for flags and a checksum -
                 // make sure it is positive.
-                int secondInt = ZLIB.second();
-                if (second < 0) {
+                int secondInt = second;
+                if (secondInt < 0) {
                     secondInt += 256;
                 }
                 // the second byte is not constant for zlib, it


### PR DESCRIPTION
Support any zlib compression level

## Description
Currently, any message with zlib compression level less than 6 will be dropped, after this commit, any compression level should be fine.

## Motivation and Context
There is no document stating which zlib compression level is supported, so I suppose any compression level should be supported.

## How Has This Been Tested?
It's just a simple change.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

Before this commit, only information we are checking is the highest bit of second byte, thus effectively only support zlib compression level higher than 5.
This commit use caller provided second byte instead of constraint ZLIB.second(), and I believe that's a typo.