### PR TITLE
Add graylog.version property to graylog-plugin-parent

### DIFF
--- a/graylog-plugin-parent/pom.xml
+++ b/graylog-plugin-parent/pom.xml
@@ -42,6 +42,7 @@
 
     <properties>
         <graylog.plugin-dir>/usr/share/graylog-server/plugin</graylog.plugin-dir>
+        <graylog.version>${project.parent.version}</graylog.version>
 
         <!-- Dependencies -->
         <auto-service.version>1.0-rc2</auto-service.version>


### PR DESCRIPTION
This is used in the graylog-plugin.properties file.