### PR TITLE
Add versions-maven-plugin version 2.3 to plugin management

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -254,6 +254,11 @@
                 </plugin>
                 <plugin>
                     <groupId>org.codehaus.mojo</groupId>
+                    <artifactId>versions-maven-plugin</artifactId>
+                    <version>2.3</version>
+                </plugin>
+                <plugin>
+                    <groupId>org.codehaus.mojo</groupId>
                     <artifactId>findbugs-maven-plugin</artifactId>
                     <version>3.0.4</version>
                 </plugin>


### PR DESCRIPTION
Needed to be able to use the `use-dep-version` goal.