### PR TITLE
Using a kinda awkward way to build web assets in production mode.

### DIFF
--- a/graylog2-web-interface/package.json
+++ b/graylog2-web-interface/package.json
@@ -10,10 +10,10 @@
   },
   "readme": "../README.md",
   "scripts": {
-    "start": "./node_modules/.bin/webpack --config webpack.vendor.js && ./node_modules/.bin/webpack-dev-server --config webpack.combined.config.js",
-    "start-nohmr": "./node_modules/.bin/webpack --config webpack.vendor.js && ./node_modules/.bin/webpack-dev-server --watch --config webpack.combined.config.js",
-    "build": "./node_modules/.bin/webpack -p --config webpack.vendor.js && ./node_modules/.bin/webpack",
-    "test": "./node_modules/.bin/webpack --config webpack.vendor.js && ./node_modules/karma/bin/karma start karma.ci.conf.js",
+    "start": "webpack --config webpack.vendor.js && webpack-dev-server --config webpack.combined.config.js",
+    "start-nohmr": "webpack --config webpack.vendor.js && webpack-dev-server --watch --config webpack.combined.config.js",
+    "build": "webpack -p --config webpack.vendor.js && webpack -p",
+    "test": "webpack --config webpack.vendor.js && karma start karma.ci.conf.js",
     "prepare-dev": "./tools/prepare-dev"
   },
   "dependencies": {

--- a/graylog2-web-interface/webpack.config.js
+++ b/graylog2-web-interface/webpack.config.js
@@ -129,8 +129,14 @@ if (TARGET === 'start-nohmr') {
 
 if (TARGET === 'build') {
   console.log('Running in production mode');
+  process.env.NODE_ENV = 'production';
   module.exports = merge(webpackConfig, {
     plugins: [
+      new webpack.DefinePlugin({
+        'process.env': {
+          NODE_ENV: JSON.stringify('production'),
+        },
+      }),
       new webpack.optimize.UglifyJsPlugin({
         minimize: true,
         sourceMap: true,


### PR DESCRIPTION
This also prevents react-hot-loader from complaining about missing module.
Also cleaning up the webpack/karma calls, relative paths are not necessary here.