### PR TITLE
Add migration job for index sets

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/configuration/ElasticsearchConfiguration.java
+++ b/graylog2-server/src/main/java/org/graylog2/configuration/ElasticsearchConfiguration.java
@@ -86,6 +86,7 @@ public class ElasticsearchConfiguration {
     @Parameter(value = "elasticsearch_config_file", validator = FilePathReadableValidator.class)
     private Path configFile;
 
+    @Deprecated // Should be removed in Graylog 3.0
     @Parameter(value = "elasticsearch_index_prefix", required = true)
     private String indexPrefix = "graylog";
 
@@ -105,9 +106,11 @@ public class ElasticsearchConfiguration {
     @Parameter(value = "elasticsearch_max_time_per_index", required = true)
     private Period maxTimePerIndex = Period.days(1);
 
+    @Deprecated // Should be removed in Graylog 3.0
     @Parameter(value = "elasticsearch_shards", validator = PositiveIntegerValidator.class, required = true)
     private int shards = 4;
 
+    @Deprecated // Should be removed in Graylog 3.0
     @Parameter(value = "elasticsearch_replicas", validator = PositiveIntegerValidator.class, required = true)
     private int replicas = 0;
 
@@ -197,6 +200,7 @@ public class ElasticsearchConfiguration {
         return configFile;
     }
 
+    @Deprecated // Should be removed in Graylog 3.0
     public String getIndexPrefix() {
         return indexPrefix.toLowerCase(Locale.ENGLISH);
     }
@@ -221,10 +225,12 @@ public class ElasticsearchConfiguration {
         return maxTimePerIndex;
     }
 
+    @Deprecated // Should be removed in Graylog 3.0
     public int getShards() {
         return shards;
     }
 
+    @Deprecated // Should be removed in Graylog 3.0
     public int getReplicas() {
         return replicas;
     }

--- a/graylog2-server/src/main/java/org/graylog2/periodical/IndexSetsMigrationPeriodical.java
+++ b/graylog2-server/src/main/java/org/graylog2/periodical/IndexSetsMigrationPeriodical.java
@@ -1,0 +1,165 @@
+/**
+ * This file is part of Graylog.
+ *
+ * Graylog is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.graylog2.periodical;
+
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.google.auto.value.AutoValue;
+import org.graylog2.configuration.ElasticsearchConfiguration;
+import org.graylog2.indexer.indexset.IndexSetConfig;
+import org.graylog2.indexer.indexset.IndexSetService;
+import org.graylog2.indexer.management.IndexManagementConfig;
+import org.graylog2.plugin.cluster.ClusterConfigService;
+import org.graylog2.plugin.indexer.retention.RetentionStrategy;
+import org.graylog2.plugin.indexer.retention.RetentionStrategyConfig;
+import org.graylog2.plugin.indexer.rotation.RotationStrategy;
+import org.graylog2.plugin.indexer.rotation.RotationStrategyConfig;
+import org.graylog2.plugin.periodical.Periodical;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.inject.Inject;
+import javax.inject.Provider;
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
+import java.util.Map;
+
+import static com.google.common.base.MoreObjects.firstNonNull;
+import static com.google.common.base.Preconditions.checkState;
+
+/**
+ * Periodical creating the default index set from the legacy settings.
+ */
+public class IndexSetsMigrationPeriodical extends Periodical {
+    private static final Logger LOG = LoggerFactory.getLogger(IndexSetsMigrationPeriodical.class);
+
+    private final ElasticsearchConfiguration elasticsearchConfiguration;
+    private final Map<String, Provider<RotationStrategy>> rotationStrategies;
+    private final Map<String, Provider<RetentionStrategy>> retentionStrategies;
+    private final IndexSetService indexSetService;
+    private final ClusterConfigService clusterConfigService;
+
+    @Inject
+    public IndexSetsMigrationPeriodical(final ElasticsearchConfiguration elasticsearchConfiguration,
+                                        final Map<String, Provider<RotationStrategy>> rotationStrategies,
+                                        final Map<String, Provider<RetentionStrategy>> retentionStrategies,
+                                        final IndexSetService indexSetService,
+                                        final ClusterConfigService clusterConfigService) {
+        this.elasticsearchConfiguration = elasticsearchConfiguration;
+        this.rotationStrategies = rotationStrategies;
+        this.retentionStrategies = retentionStrategies;
+        this.indexSetService = indexSetService;
+        this.clusterConfigService = clusterConfigService;
+    }
+
+    @Override
+    public void doRun() {
+        final IndexManagementConfig indexManagementConfig = clusterConfigService.get(IndexManagementConfig.class);
+        checkState(indexManagementConfig != null, "Couldn't find index management configuration");
+
+        final RotationStrategyConfig rotationStrategyConfig = getRotationStrategyConfig(indexManagementConfig);
+        final RetentionStrategyConfig retentionStrategyConfig = getRetentionStrategyConfig(indexManagementConfig);
+
+        final IndexSetConfig indexSetConfig = IndexSetConfig.builder()
+                .title("Default index set")
+                .description("The Graylog default index set")
+                .indexPrefix(elasticsearchConfiguration.getIndexPrefix())
+                .shards(elasticsearchConfiguration.getShards())
+                .replicas(elasticsearchConfiguration.getReplicas())
+                .rotationStrategy(rotationStrategyConfig)
+                .retentionStrategy(retentionStrategyConfig)
+                .creationDate(ZonedDateTime.now(ZoneOffset.UTC))
+                .build();
+
+        final IndexSetConfig savedConfig = indexSetService.save(indexSetConfig);
+        clusterConfigService.write(IndexSetMigrated.create());
+
+        LOG.info("Successfully migrated index settings (database ID <{}>)", savedConfig.id());
+    }
+
+    private RetentionStrategyConfig getRetentionStrategyConfig(IndexManagementConfig indexManagementConfig) {
+        final String strategyName = indexManagementConfig.retentionStrategy();
+        final Provider<RetentionStrategy> provider = retentionStrategies.get(strategyName);
+        checkState(provider != null, "Couldn't retrieve retention strategy provider for <" + strategyName + ">");
+        final RetentionStrategy strategy = provider.get();
+        @SuppressWarnings("unchecked")
+        final Class<RetentionStrategyConfig> configClass = (Class<RetentionStrategyConfig>) strategy.configurationClass();
+        final RetentionStrategyConfig config = clusterConfigService.get(configClass);
+        return firstNonNull(config, strategy.defaultConfiguration());
+    }
+
+    private RotationStrategyConfig getRotationStrategyConfig(IndexManagementConfig indexManagementConfig) {
+        final String strategyName = indexManagementConfig.rotationStrategy();
+        final Provider<RotationStrategy> provider = rotationStrategies.get(strategyName);
+        checkState(provider != null, "Couldn't retrieve rotation strategy provider for <" + strategyName + ">");
+        final RotationStrategy strategy = provider.get();
+        @SuppressWarnings("unchecked")
+        final Class<RotationStrategyConfig> configClass = (Class<RotationStrategyConfig>) strategy.configurationClass();
+        final RotationStrategyConfig config = clusterConfigService.get(configClass);
+        return firstNonNull(config, strategy.defaultConfiguration());
+    }
+
+    @Override
+    public boolean runsForever() {
+        return true;
+    }
+
+    @Override
+    public boolean stopOnGracefulShutdown() {
+        return false;
+    }
+
+    @Override
+    public boolean masterOnly() {
+        return true;
+    }
+
+    @Override
+    public boolean startOnThisNode() {
+        return clusterConfigService.get(IndexSetMigrated.class) == null;
+    }
+
+    @Override
+    public boolean isDaemon() {
+        return false;
+    }
+
+    @Override
+    public int getInitialDelaySeconds() {
+        return 0;
+    }
+
+    @Override
+    public int getPeriodSeconds() {
+        return 0;
+    }
+
+    @Override
+    protected Logger getLogger() {
+        return LOG;
+    }
+
+    @JsonAutoDetect
+    @AutoValue
+    static abstract class IndexSetMigrated {
+        @JsonCreator
+        public static IndexSetMigrated create() {
+            return new AutoValue_IndexSetsMigrationPeriodical_IndexSetMigrated();
+        }
+    }
+
+}

--- a/graylog2-server/src/test/java/org/graylog2/periodical/IndexSetsMigrationPeriodicalTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/periodical/IndexSetsMigrationPeriodicalTest.java
@@ -1,0 +1,260 @@
+/**
+ * This file is part of Graylog.
+ *
+ * Graylog is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.graylog2.periodical;
+
+import org.graylog2.configuration.ElasticsearchConfiguration;
+import org.graylog2.indexer.IndexSet;
+import org.graylog2.indexer.indexset.IndexSetConfig;
+import org.graylog2.indexer.indexset.IndexSetService;
+import org.graylog2.indexer.management.IndexManagementConfig;
+import org.graylog2.plugin.cluster.ClusterConfigService;
+import org.graylog2.plugin.indexer.retention.RetentionStrategy;
+import org.graylog2.plugin.indexer.retention.RetentionStrategyConfig;
+import org.graylog2.plugin.indexer.rotation.RotationStrategy;
+import org.graylog2.plugin.indexer.rotation.RotationStrategyConfig;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnit;
+import org.mockito.junit.MockitoRule;
+
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
+import java.util.Collections;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+public class IndexSetsMigrationPeriodicalTest {
+    @Rule
+    public final MockitoRule mockitoRule = MockitoJUnit.rule();
+    @Rule
+    public final ExpectedException expectedException = ExpectedException.none();
+
+    @Mock
+    private IndexSetService indexSetService;
+    @Mock
+    private ClusterConfigService clusterConfigService;
+
+    private final ElasticsearchConfiguration elasticsearchConfiguration = new ElasticsearchConfiguration();
+    private RotationStrategy rotationStrategy = new StubRotationStrategy();
+    private RetentionStrategy retentionStrategy = new StubRetentionStrategy();
+    private IndexSetsMigrationPeriodical periodical;
+
+
+    @Before
+    public void setUpService() throws Exception {
+        periodical = new IndexSetsMigrationPeriodical(
+                elasticsearchConfiguration,
+                Collections.singletonMap("test", () -> rotationStrategy),
+                Collections.singletonMap("test", () -> retentionStrategy),
+                indexSetService,
+                clusterConfigService);
+    }
+
+    @Test
+    public void doRunCreatesDefaultIndexSet() throws Exception {
+        final StubRotationStrategyConfig rotationStrategyConfig = new StubRotationStrategyConfig();
+        final StubRetentionStrategyConfig retentionStrategyConfig = new StubRetentionStrategyConfig();
+        final IndexSetConfig savedIndexSetConfig = IndexSetConfig.builder()
+                .id("id")
+                .title("title")
+                .indexPrefix("prefix")
+                .shards(1)
+                .replicas(0)
+                .rotationStrategy(rotationStrategyConfig)
+                .retentionStrategy(retentionStrategyConfig)
+                .creationDate(ZonedDateTime.of(2016, 10, 12, 0, 0, 0, 0, ZoneOffset.UTC))
+                .build();
+        when(clusterConfigService.get(IndexManagementConfig.class)).thenReturn(IndexManagementConfig.create("test", "test"));
+        when(clusterConfigService.get(StubRotationStrategyConfig.class)).thenReturn(rotationStrategyConfig);
+        when(clusterConfigService.get(StubRetentionStrategyConfig.class)).thenReturn(retentionStrategyConfig);
+        when(indexSetService.save(any(IndexSetConfig.class))).thenReturn(savedIndexSetConfig);
+
+        final ArgumentCaptor<IndexSetConfig> indexSetConfigCaptor = ArgumentCaptor.forClass(IndexSetConfig.class);
+
+        periodical.doRun();
+
+        verify(indexSetService).save(indexSetConfigCaptor.capture());
+        verify(clusterConfigService).write(IndexSetsMigrationPeriodical.IndexSetMigrated.create());
+
+        final IndexSetConfig capturedIndexSetConfig = indexSetConfigCaptor.getValue();
+        assertThat(capturedIndexSetConfig.id()).isNull();
+        assertThat(capturedIndexSetConfig.title()).isEqualTo("Default index set");
+        assertThat(capturedIndexSetConfig.description()).isEqualTo("The Graylog default index set");
+        assertThat(capturedIndexSetConfig.indexPrefix()).isEqualTo(elasticsearchConfiguration.getIndexPrefix());
+        assertThat(capturedIndexSetConfig.shards()).isEqualTo(elasticsearchConfiguration.getShards());
+        assertThat(capturedIndexSetConfig.replicas()).isEqualTo(elasticsearchConfiguration.getReplicas());
+        assertThat(capturedIndexSetConfig.rotationStrategy()).isInstanceOf(StubRotationStrategyConfig.class);
+        assertThat(capturedIndexSetConfig.retentionStrategy()).isInstanceOf(StubRetentionStrategyConfig.class);
+    }
+
+    @Test
+    public void doRunCreatesDefaultIndexSetWithDefaultRotationAndRetentionStrategyConfig() throws Exception {
+        final StubRotationStrategyConfig rotationStrategyConfig = new StubRotationStrategyConfig();
+        final StubRetentionStrategyConfig retentionStrategyConfig = new StubRetentionStrategyConfig();
+        final IndexSetConfig savedIndexSetConfig = IndexSetConfig.builder()
+                .id("id")
+                .title("title")
+                .indexPrefix("prefix")
+                .shards(1)
+                .replicas(0)
+                .rotationStrategy(rotationStrategyConfig)
+                .retentionStrategy(retentionStrategyConfig)
+                .creationDate(ZonedDateTime.of(2016, 10, 12, 0, 0, 0, 0, ZoneOffset.UTC))
+                .build();
+        when(clusterConfigService.get(IndexManagementConfig.class)).thenReturn(IndexManagementConfig.create("test", "test"));
+        when(clusterConfigService.get(StubRotationStrategyConfig.class)).thenReturn(null);
+        when(clusterConfigService.get(StubRetentionStrategyConfig.class)).thenReturn(null);
+        when(indexSetService.save(any(IndexSetConfig.class))).thenReturn(savedIndexSetConfig);
+
+        final ArgumentCaptor<IndexSetConfig> indexSetConfigCaptor = ArgumentCaptor.forClass(IndexSetConfig.class);
+
+        periodical.doRun();
+
+        verify(indexSetService).save(indexSetConfigCaptor.capture());
+        verify(clusterConfigService).write(IndexSetsMigrationPeriodical.IndexSetMigrated.create());
+
+        final IndexSetConfig capturedIndexSetConfig = indexSetConfigCaptor.getValue();
+        assertThat(capturedIndexSetConfig.rotationStrategy()).isInstanceOf(StubRotationStrategyConfig.class);
+        assertThat(capturedIndexSetConfig.retentionStrategy()).isInstanceOf(StubRetentionStrategyConfig.class);
+    }
+
+    @Test
+    public void doRunThrowsIllegalStateExceptionIfIndexManagementConfigIsMissing() throws Exception {
+        when(clusterConfigService.get(IndexManagementConfig.class)).thenReturn(null);
+
+        expectedException.expect(IllegalStateException.class);
+        expectedException.expectMessage("Couldn't find index management configuration");
+
+        periodical.doRun();
+    }
+
+    @Test
+    public void doRunThrowsIllegalStateExceptionIfRotationStrategyIsMissing() throws Exception {
+        when(clusterConfigService.get(IndexManagementConfig.class)).thenReturn(IndexManagementConfig.create("foobar", "test"));
+
+        expectedException.expect(IllegalStateException.class);
+        expectedException.expectMessage("Couldn't retrieve rotation strategy provider for <foobar>");
+
+        periodical.doRun();
+    }
+
+    @Test
+    public void doRunThrowsIllegalStateExceptionIfRetentionStrategyIsMissing() throws Exception {
+        when(clusterConfigService.get(IndexManagementConfig.class)).thenReturn(IndexManagementConfig.create("test", "foobar"));
+
+        expectedException.expect(IllegalStateException.class);
+        expectedException.expectMessage("Couldn't retrieve retention strategy provider for <foobar>");
+
+        periodical.doRun();
+    }
+
+
+    @Test
+    public void runsForeverReturnsTrue() throws Exception {
+        assertThat(periodical.runsForever()).isTrue();
+    }
+
+    @Test
+    public void stopOnGracefulShutdownReturnsFalse() throws Exception {
+        assertThat(periodical.stopOnGracefulShutdown()).isFalse();
+    }
+
+    @Test
+    public void masterOnlyReturnsTrue() throws Exception {
+        assertThat(periodical.masterOnly()).isTrue();
+    }
+
+    @Test
+    public void startOnThisNodeReturnsFalseIfMigrationWasSuccessfulBefore() throws Exception {
+        when(clusterConfigService.get(IndexSetsMigrationPeriodical.IndexSetMigrated.class))
+                .thenReturn(IndexSetsMigrationPeriodical.IndexSetMigrated.create());
+        assertThat(periodical.startOnThisNode()).isFalse();
+    }
+
+    @Test
+    public void isDaemonReturnsFalse() throws Exception {
+        assertThat(periodical.isDaemon()).isFalse();
+    }
+
+    @Test
+    public void getInitialDelaySecondsReturns0() throws Exception {
+        assertThat(periodical.getInitialDelaySeconds()).isEqualTo(0);
+    }
+
+    @Test
+    public void getPeriodSecondsReturns0() throws Exception {
+        assertThat(periodical.getPeriodSeconds()).isEqualTo(0);
+    }
+
+    @Test
+    public void getLoggerReturnsClassLogger() throws Exception {
+        assertThat(periodical.getLogger().getName()).isEqualTo(IndexSetsMigrationPeriodical.class.getCanonicalName());
+    }
+
+    private static class StubRotationStrategy implements RotationStrategy {
+        @Override
+        public void rotate(IndexSet indexSet) {
+        }
+
+        @Override
+        public Class<? extends RotationStrategyConfig> configurationClass() {
+            return StubRotationStrategyConfig.class;
+        }
+
+        @Override
+        public RotationStrategyConfig defaultConfiguration() {
+            return new StubRotationStrategyConfig();
+        }
+    }
+
+    private static class StubRotationStrategyConfig implements RotationStrategyConfig {
+        @Override
+        public String type() {
+            return StubRotationStrategy.class.getCanonicalName();
+        }
+    }
+
+    private static class StubRetentionStrategy implements RetentionStrategy {
+        @Override
+        public void retain(IndexSet indexSet) {
+        }
+
+        @Override
+        public Class<? extends RetentionStrategyConfig> configurationClass() {
+            return StubRetentionStrategyConfig.class;
+        }
+
+        @Override
+        public RetentionStrategyConfig defaultConfiguration() {
+            return new StubRetentionStrategyConfig();
+        }
+    }
+
+    private static class StubRetentionStrategyConfig implements RetentionStrategyConfig {
+        @Override
+        public String type() {
+            return StubRetentionStrategy.class.getCanonicalName();
+        }
+    }
+}


### PR DESCRIPTION
## Description

Add a migration periodical which will create the default index set configuration based on the legacy settings in Graylog.

Refs #2880

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] New feature (non-breaking change which adds functionality)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

