### PR TITLE
Removing production flag from build task.

### DIFF
--- a/graylog2-web-interface/package.json
+++ b/graylog2-web-interface/package.json
@@ -12,7 +12,7 @@
   "scripts": {
     "start": "webpack --config webpack.vendor.js && webpack-dev-server --config webpack.combined.config.js",
     "start-nohmr": "webpack --config webpack.vendor.js && webpack-dev-server --watch --config webpack.combined.config.js",
-    "build": "webpack -p --config webpack.vendor.js && webpack -p",
+    "build": "webpack -p --config webpack.vendor.js && webpack",
     "test": "webpack --config webpack.vendor.js && karma start karma.ci.conf.js",
     "prepare-dev": "./tools/prepare-dev"
   },


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Running webpack with -p/--optimize-minimize for the web interface leads
to mangling of variable names, which breaks rickshaw (as already noted
in ae731ec8e6a95465b8887e5ad86ba031949dcbbc). Therefore the more
specific addition of the UglifyJSPlugin was added to the production
config and -p is not necessary for the webpack run.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
