### PR TITLE
Adding migration to make email alarm callbacks explicit.

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/alarmcallbacks/AlarmCallbackConfigurationServiceMJImpl.java
+++ b/graylog2-server/src/main/java/org/graylog2/alarmcallbacks/AlarmCallbackConfigurationServiceMJImpl.java
@@ -64,7 +64,7 @@ public class AlarmCallbackConfigurationServiceMJImpl implements AlarmCallbackCon
 
     @Override
     public AlarmCallbackConfiguration create(String streamId, CreateAlarmCallbackRequest request, String userId) {
-        return AlarmCallbackConfigurationAVImpl.create(new ObjectId().toHexString(), streamId, request.type, request.configuration, new Date(), userId);
+        return AlarmCallbackConfigurationAVImpl.create(new ObjectId().toHexString(), streamId, request.type(), request.configuration(), new Date(), userId);
     }
 
     @Override

--- a/graylog2-server/src/main/java/org/graylog2/alarmcallbacks/events/EmailAlarmCallbackMigrated.java
+++ b/graylog2-server/src/main/java/org/graylog2/alarmcallbacks/events/EmailAlarmCallbackMigrated.java
@@ -1,0 +1,23 @@
+package org.graylog2.alarmcallbacks.events;
+
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.auto.value.AutoValue;
+
+import java.util.Map;
+import java.util.Optional;
+
+@AutoValue
+@JsonAutoDetect
+public abstract class EmailAlarmCallbackMigrated {
+    private static final String FIELD_CALLBACK_IDS = "callback_ids";
+
+    @JsonProperty(FIELD_CALLBACK_IDS)
+    public abstract Map<String, Optional<String>> callbackIds();
+
+    @JsonCreator
+    public static EmailAlarmCallbackMigrated create(@JsonProperty(FIELD_CALLBACK_IDS) Map<String, Optional<String>> callbackIds) {
+        return new AutoValue_EmailAlarmCallbackMigrated(callbackIds);
+    }
+}

--- a/graylog2-server/src/main/java/org/graylog2/alarmcallbacks/events/EmailAlarmCallbackMigrated.java
+++ b/graylog2-server/src/main/java/org/graylog2/alarmcallbacks/events/EmailAlarmCallbackMigrated.java
@@ -1,3 +1,19 @@
+/**
+ * This file is part of Graylog.
+ *
+ * Graylog is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package org.graylog2.alarmcallbacks.events;
 
 import com.fasterxml.jackson.annotation.JsonAutoDetect;

--- a/graylog2-server/src/main/java/org/graylog2/bindings/PeriodicalBindings.java
+++ b/graylog2-server/src/main/java/org/graylog2/bindings/PeriodicalBindings.java
@@ -28,6 +28,7 @@ import org.graylog2.periodical.ClusterIdGeneratorPeriodical;
 import org.graylog2.periodical.ConfigurationManagementPeriodical;
 import org.graylog2.periodical.ContentPackLoaderPeriodical;
 import org.graylog2.periodical.DefaultStreamMigrationPeriodical;
+import org.graylog2.periodical.EmailAlarmCallbackMigrationPeriodical;
 import org.graylog2.periodical.GarbageCollectionWarningThread;
 import org.graylog2.periodical.IndexFailuresPeriodical;
 import org.graylog2.periodical.IndexRangesCleanupPeriodical;
@@ -68,5 +69,6 @@ public class PeriodicalBindings extends AbstractModule {
         periodicalBinder.addBinding().to(LdapGroupMappingMigration.class);
         periodicalBinder.addBinding().to(IndexFailuresPeriodical.class);
         periodicalBinder.addBinding().to(DefaultStreamMigrationPeriodical.class);
+        periodicalBinder.addBinding().to(EmailAlarmCallbackMigrationPeriodical.class);
     }
 }

--- a/graylog2-server/src/main/java/org/graylog2/periodical/EmailAlarmCallbackMigrationPeriodical.java
+++ b/graylog2-server/src/main/java/org/graylog2/periodical/EmailAlarmCallbackMigrationPeriodical.java
@@ -1,0 +1,144 @@
+package org.graylog2.periodical;
+
+import org.graylog2.alarmcallbacks.AlarmCallbackConfiguration;
+import org.graylog2.alarmcallbacks.AlarmCallbackConfigurationService;
+import org.graylog2.alarmcallbacks.EmailAlarmCallback;
+import org.graylog2.alarmcallbacks.events.EmailAlarmCallbackMigrated;
+import org.graylog2.plugin.cluster.ClusterConfigService;
+import org.graylog2.plugin.configuration.ConfigurationRequest;
+import org.graylog2.plugin.database.Persisted;
+import org.graylog2.plugin.database.ValidationException;
+import org.graylog2.plugin.database.users.User;
+import org.graylog2.plugin.periodical.Periodical;
+import org.graylog2.rest.models.alarmcallbacks.requests.CreateAlarmCallbackRequest;
+import org.graylog2.shared.users.UserService;
+import org.graylog2.streams.StreamService;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.inject.Inject;
+import java.util.Map;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+/**
+ * @
+ */
+public class EmailAlarmCallbackMigrationPeriodical extends Periodical {
+    private static final Logger LOG = LoggerFactory.getLogger(EmailAlarmCallbackMigrationPeriodical.class);
+    private final ClusterConfigService clusterConfigService;
+    private final StreamService streamService;
+    private final AlarmCallbackConfigurationService alarmCallbackService;
+    private final EmailAlarmCallback emailAlarmCallback;
+    private final User localAdminUser;
+
+    @Inject
+    public EmailAlarmCallbackMigrationPeriodical(ClusterConfigService clusterConfigService,
+                                                 StreamService streamService,
+                                                 AlarmCallbackConfigurationService alarmCallbackService,
+                                                 EmailAlarmCallback emailAlarmCallback,
+                                                 UserService userService) {
+        this.clusterConfigService = clusterConfigService;
+        this.streamService = streamService;
+        this.alarmCallbackService = alarmCallbackService;
+        this.emailAlarmCallback = emailAlarmCallback;
+        this.localAdminUser = userService.getAdminUser();
+    }
+
+    @Override
+    public boolean runsForever() {
+        return true;
+    }
+
+    @Override
+    public boolean stopOnGracefulShutdown() {
+        return false;
+    }
+
+    @Override
+    public boolean masterOnly() {
+        return true;
+    }
+
+    @Override
+    public boolean startOnThisNode() {
+        return this.clusterConfigService.get(EmailAlarmCallbackMigrated.class) == null;
+    }
+
+    @Override
+    public boolean isDaemon() {
+        return false;
+    }
+
+    @Override
+    public int getInitialDelaySeconds() {
+        return 0;
+    }
+
+    @Override
+    public int getPeriodSeconds() {
+        return 0;
+    }
+
+    @Override
+    protected Logger getLogger() {
+        return LOG;
+    }
+
+    @Override
+    public void doRun() {
+        final Map<String, Optional<String>> streamMigrations = this.streamService.loadAll()
+            .stream()
+            .filter(stream -> !stream.getAlertReceivers().isEmpty()
+                && !streamService.getAlertConditions(stream).isEmpty()
+                && alarmCallbackService.getForStream(stream).isEmpty())
+            .collect(Collectors.toMap(Persisted::getId, this::migrateStream));
+        final boolean allSucceeded = streamMigrations.values()
+            .stream()
+            .allMatch(Optional::isPresent);
+
+        final long count = streamMigrations.size();
+        if (allSucceeded) {
+            if (count > 0) {
+                LOG.info("Successfully migrated " + count + " streams to include explicit email alarm callback.");
+            } else {
+                LOG.info("No streams needed to be migrated.");
+            }
+            this.clusterConfigService.write(EmailAlarmCallbackMigrated.create(streamMigrations));
+        } else {
+            final long errors = streamMigrations.values()
+                .stream()
+                .filter(callbackId -> !callbackId.isPresent())
+                .count();
+            LOG.error("Failed migrating " + errors + "/" + count + " streams to include explicit email alarm callback.");
+        }
+    }
+
+    private Optional<String> migrateStream(org.graylog2.plugin.streams.Stream stream) {
+        final Map<String, Object> defaultConfig = this.getDefaultEmailAlarmCallbackConfig();
+        LOG.debug("Creating email alarm callback for stream <" + stream.getId() + ">");
+        final AlarmCallbackConfiguration alarmCallbackConfiguration = alarmCallbackService.create(stream.getId(),
+            CreateAlarmCallbackRequest.create(
+                EmailAlarmCallback.class.getCanonicalName(),
+                defaultConfig
+            ),
+            localAdminUser.getId()
+        );
+        try {
+            final String callbackId = this.alarmCallbackService.save(alarmCallbackConfiguration);
+            LOG.debug("Successfully created email alarm callback <" + callbackId + "> for stream <" + stream.getId() + ">.");
+            return Optional.of(callbackId);
+        } catch (ValidationException e) {
+            LOG.error("Unable to create email alarm callback for stream <" + stream.getId() + ">: ", e);
+        }
+        return Optional.empty();
+    }
+
+    private Map<String, Object> getDefaultEmailAlarmCallbackConfig() {
+        final ConfigurationRequest configurationRequest = this.emailAlarmCallback.getRequestedConfiguration();
+
+        return configurationRequest.getFields().entrySet()
+            .stream()
+            .collect(Collectors.toMap(Map.Entry::getKey, entry -> entry.getValue().getDefaultValue()));
+    }
+}

--- a/graylog2-server/src/main/java/org/graylog2/periodical/EmailAlarmCallbackMigrationPeriodical.java
+++ b/graylog2-server/src/main/java/org/graylog2/periodical/EmailAlarmCallbackMigrationPeriodical.java
@@ -16,6 +16,7 @@
  */
 package org.graylog2.periodical;
 
+import com.google.common.annotations.VisibleForTesting;
 import org.graylog2.alarmcallbacks.AlarmCallbackConfiguration;
 import org.graylog2.alarmcallbacks.AlarmCallbackConfigurationService;
 import org.graylog2.alarmcallbacks.EmailAlarmCallback;
@@ -150,7 +151,8 @@ public class EmailAlarmCallbackMigrationPeriodical extends Periodical {
         return Optional.empty();
     }
 
-    private Map<String, Object> getDefaultEmailAlarmCallbackConfig() {
+    @VisibleForTesting
+    Map<String, Object> getDefaultEmailAlarmCallbackConfig() {
         final ConfigurationRequest configurationRequest = this.emailAlarmCallback.getRequestedConfiguration();
 
         return configurationRequest.getFields().entrySet()

--- a/graylog2-server/src/main/java/org/graylog2/periodical/EmailAlarmCallbackMigrationPeriodical.java
+++ b/graylog2-server/src/main/java/org/graylog2/periodical/EmailAlarmCallbackMigrationPeriodical.java
@@ -38,9 +38,6 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.stream.Collectors;
 
-/**
- * @
- */
 public class EmailAlarmCallbackMigrationPeriodical extends Periodical {
     private static final Logger LOG = LoggerFactory.getLogger(EmailAlarmCallbackMigrationPeriodical.class);
     private final ClusterConfigService clusterConfigService;

--- a/graylog2-server/src/main/java/org/graylog2/periodical/EmailAlarmCallbackMigrationPeriodical.java
+++ b/graylog2-server/src/main/java/org/graylog2/periodical/EmailAlarmCallbackMigrationPeriodical.java
@@ -1,3 +1,19 @@
+/**
+ * This file is part of Graylog.
+ *
+ * Graylog is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package org.graylog2.periodical;
 
 import org.graylog2.alarmcallbacks.AlarmCallbackConfiguration;

--- a/graylog2-server/src/main/java/org/graylog2/rest/models/alarmcallbacks/requests/CreateAlarmCallbackRequest.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/models/alarmcallbacks/requests/CreateAlarmCallbackRequest.java
@@ -17,11 +17,32 @@
 package org.graylog2.rest.models.alarmcallbacks.requests;
 
 import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.auto.value.AutoValue;
+import org.graylog2.alarmcallbacks.AlarmCallbackConfiguration;
 
 import java.util.Map;
 
 @JsonAutoDetect
-public class CreateAlarmCallbackRequest {
-    public String type;
-    public Map<String, Object> configuration;
+@AutoValue
+public abstract class CreateAlarmCallbackRequest {
+    private static final String FIELD_TYPE = "type";
+    private static final String FIELD_CONFIGURATION = "configuration";
+
+    @JsonProperty(FIELD_TYPE)
+    public abstract String type();
+
+    @JsonProperty(FIELD_CONFIGURATION)
+    public abstract Map<String, Object> configuration();
+
+    @JsonCreator
+    public static CreateAlarmCallbackRequest create(@JsonProperty(FIELD_TYPE) String type,
+                                                    @JsonProperty(FIELD_CONFIGURATION) Map<String, Object> configuration) {
+        return new AutoValue_CreateAlarmCallbackRequest(type, configuration);
+    }
+
+    public static CreateAlarmCallbackRequest create(AlarmCallbackConfiguration alarmCallbackConfiguration) {
+        return create(alarmCallbackConfiguration.getType(), alarmCallbackConfiguration.getConfiguration());
+    }
 }

--- a/graylog2-server/src/main/java/org/graylog2/rest/resources/streams/StreamResource.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/resources/streams/StreamResource.java
@@ -390,9 +390,7 @@ public class StreamResource extends RestResource {
         }
 
         for (AlarmCallbackConfiguration alarmCallbackConfiguration : alarmCallbackConfigurationService.getForStream(sourceStream)) {
-            final CreateAlarmCallbackRequest request = new CreateAlarmCallbackRequest();
-            request.type = alarmCallbackConfiguration.getType();
-            request.configuration = alarmCallbackConfiguration.getConfiguration();
+            final CreateAlarmCallbackRequest request = CreateAlarmCallbackRequest.create(alarmCallbackConfiguration);
             final AlarmCallbackConfiguration alarmCallback = alarmCallbackConfigurationService.create(stream.getId(), request, getCurrentUser().getName());
             alarmCallbackConfigurationService.save(alarmCallback);
         }

--- a/graylog2-server/src/test/java/org/graylog2/alarmcallbacks/AlarmCallbackConfigurationServiceMJImplTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/alarmcallbacks/AlarmCallbackConfigurationServiceMJImplTest.java
@@ -146,9 +146,7 @@ public class AlarmCallbackConfigurationServiceMJImplTest extends MongoDBServiceT
     @Test
     @UsingDataSet(loadStrategy = LoadStrategyEnum.DELETE_ALL)
     public void testCreate() throws Exception {
-        final CreateAlarmCallbackRequest request = new CreateAlarmCallbackRequest();
-        request.type = "";
-        request.configuration = Collections.emptyMap();
+        final CreateAlarmCallbackRequest request = CreateAlarmCallbackRequest.create("", Collections.emptyMap());
 
         final String streamId = "54e3deadbeefdeadbeefaffe";
         final String userId = "someuser";

--- a/graylog2-server/src/test/java/org/graylog2/periodical/EmailAlarmCallbackMigrationPeriodicalTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/periodical/EmailAlarmCallbackMigrationPeriodicalTest.java
@@ -1,3 +1,19 @@
+/**
+ * This file is part of Graylog.
+ *
+ * Graylog is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package org.graylog2.periodical;
 
 import com.google.common.collect.ImmutableList;

--- a/graylog2-server/src/test/java/org/graylog2/periodical/EmailAlarmCallbackMigrationPeriodicalTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/periodical/EmailAlarmCallbackMigrationPeriodicalTest.java
@@ -1,0 +1,283 @@
+package org.graylog2.periodical;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import org.graylog2.alarmcallbacks.AlarmCallbackConfiguration;
+import org.graylog2.alarmcallbacks.AlarmCallbackConfigurationService;
+import org.graylog2.alarmcallbacks.EmailAlarmCallback;
+import org.graylog2.alarmcallbacks.events.EmailAlarmCallbackMigrated;
+import org.graylog2.alerts.Alert;
+import org.graylog2.plugin.alarms.AlertCondition;
+import org.graylog2.plugin.cluster.ClusterConfigService;
+import org.graylog2.plugin.configuration.ConfigurationRequest;
+import org.graylog2.plugin.configuration.fields.ConfigurationField;
+import org.graylog2.plugin.database.users.User;
+import org.graylog2.plugin.streams.Stream;
+import org.graylog2.rest.models.alarmcallbacks.requests.CreateAlarmCallbackRequest;
+import org.graylog2.shared.users.UserService;
+import org.graylog2.streams.StreamService;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnit;
+import org.mockito.junit.MockitoRule;
+
+import java.util.Collections;
+import java.util.Map;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+public class EmailAlarmCallbackMigrationPeriodicalTest {
+    @Rule
+    public final MockitoRule mockitoRule = MockitoJUnit.rule();
+
+    private EmailAlarmCallbackMigrationPeriodical emailAlarmCallbackMigrationPeriodical;
+
+    @Mock
+    private ClusterConfigService clusterConfigService;
+
+    @Mock
+    private StreamService streamService;
+
+    @Mock
+    private AlarmCallbackConfigurationService alarmCallbackConfigurationService;
+
+    @Mock
+    private EmailAlarmCallback emailAlarmCallback;
+
+    @Mock
+    private UserService userService;
+
+    private final static String localAdminId = "local:adminMock";
+
+    @Before
+    public void setUp() throws Exception {
+        final User localAdmin = mock(User.class);
+        when(localAdmin.getId()).thenReturn(localAdminId);
+        when(userService.getAdminUser()).thenReturn(localAdmin);
+
+        this.emailAlarmCallbackMigrationPeriodical = new EmailAlarmCallbackMigrationPeriodical(clusterConfigService,
+            streamService,
+            alarmCallbackConfigurationService,
+            emailAlarmCallback,
+            userService);
+    }
+
+    @Test
+    public void doRunIfNotRunBefore() throws Exception {
+        assertThat(this.emailAlarmCallbackMigrationPeriodical.startOnThisNode()).isTrue();
+    }
+
+    @Test
+    public void doNotRunMigrationTwice() throws Exception {
+        when(this.clusterConfigService.get(EmailAlarmCallbackMigrated.class)).thenReturn(EmailAlarmCallbackMigrated.create(Collections.emptyMap()));
+
+        assertThat(this.emailAlarmCallbackMigrationPeriodical.startOnThisNode()).isFalse();
+    }
+
+    @Test
+    public void doNotMigrateAnythingWithoutStreams() throws Exception {
+        when(this.streamService.loadAll()).thenReturn(Collections.emptyList());
+
+        this.emailAlarmCallbackMigrationPeriodical.doRun();
+
+        verify(this.alarmCallbackConfigurationService, never()).create(any(), any(), any());
+        verifyEmailAlarmCallbackMigratedWasPosted();
+    }
+
+    @Test
+    public void doNotMigrateAnythingWithoutQualifyingStreams() throws Exception {
+        final Stream stream1 = mock(Stream.class);
+        when(stream1.getAlertReceivers()).thenReturn(Collections.emptyMap());
+        final Stream stream2 = mock(Stream.class);
+        when(stream2.getAlertReceivers()).thenReturn(Collections.emptyMap());
+        when(this.streamService.loadAll()).thenReturn(ImmutableList.of(stream1, stream2));
+
+        this.emailAlarmCallbackMigrationPeriodical.doRun();
+
+        verify(this.alarmCallbackConfigurationService, never()).create(any(), any(), any());
+        verifyEmailAlarmCallbackMigratedWasPosted();
+    }
+
+    @Test
+    public void doMigrateSingleQualifyingStream() throws Exception {
+        final String matchingStreamId = "matchingStreamId";
+
+        final Stream stream1 = mock(Stream.class);
+        when(stream1.getAlertReceivers()).thenReturn(Collections.emptyMap());
+        final Stream stream2 = mock(Stream.class);
+        when(stream2.getAlertReceivers()).thenReturn(ImmutableMap.of(
+            "users", ImmutableList.of("foouser"),
+            "emails", ImmutableList.of("foo@bar.com")
+        ));
+        when(stream2.getId()).thenReturn(matchingStreamId);
+        when(this.streamService.loadAll()).thenReturn(ImmutableList.of(stream1, stream2));
+        final AlertCondition alertCondition = mock(AlertCondition.class);
+        when(this.streamService.getAlertConditions(eq(stream2))).thenReturn(ImmutableList.of(alertCondition));
+
+        final ConfigurationRequest configurationRequest = mock(ConfigurationRequest.class);
+        when(emailAlarmCallback.getRequestedConfiguration()).thenReturn(configurationRequest);
+        when(configurationRequest.getFields()).thenReturn(Collections.emptyMap());
+
+        final AlarmCallbackConfiguration newAlarmCallback = mock(AlarmCallbackConfiguration.class);
+        final String newAlarmCallbackId = "newAlarmCallbackId";
+        when(alarmCallbackConfigurationService.create(eq(matchingStreamId), any(CreateAlarmCallbackRequest.class), eq(localAdminId))).thenReturn(newAlarmCallback);
+        when(alarmCallbackConfigurationService.save(eq(newAlarmCallback))).thenReturn(newAlarmCallbackId);
+
+        this.emailAlarmCallbackMigrationPeriodical.doRun();
+
+        final ArgumentCaptor<String> streamIdCaptor = ArgumentCaptor.forClass(String.class);
+        final ArgumentCaptor<CreateAlarmCallbackRequest> createAlarmCallbackRequestCaptor = ArgumentCaptor.forClass(CreateAlarmCallbackRequest.class);
+        final ArgumentCaptor<String> userIdCaptor = ArgumentCaptor.forClass(String.class);
+
+        verify(this.alarmCallbackConfigurationService, times(1)).create(streamIdCaptor.capture(), createAlarmCallbackRequestCaptor.capture(), userIdCaptor.capture());
+        assertThat(streamIdCaptor.getValue())
+            .isNotNull()
+            .isNotEmpty()
+            .isEqualTo(matchingStreamId);
+        final CreateAlarmCallbackRequest createAlarmCallbackRequest = createAlarmCallbackRequestCaptor.getValue();
+        assertThat(createAlarmCallbackRequest.type()).isEqualTo(EmailAlarmCallback.class.getCanonicalName());
+
+        final ArgumentCaptor<AlarmCallbackConfiguration> alarmCallbackConfigurationCaptor = ArgumentCaptor.forClass(AlarmCallbackConfiguration.class);
+        verify(this.alarmCallbackConfigurationService, times(1)).save(alarmCallbackConfigurationCaptor.capture());
+        assertThat(alarmCallbackConfigurationCaptor.getValue()).isEqualTo(newAlarmCallback);
+
+        verifyEmailAlarmCallbackMigratedWasPosted(ImmutableMap.of(
+            matchingStreamId, Optional.of(newAlarmCallbackId)
+        ));
+    }
+
+    @Test
+    public void doMigrateMultipleQualifyingStreams() throws Exception {
+        final String matchingStreamId1 = "matchingStreamId1";
+        final String matchingStreamId2 = "matchingStreamId2";
+
+        final Stream stream1 = mock(Stream.class);
+        when(stream1.getAlertReceivers()).thenReturn(Collections.emptyMap());
+        final Stream stream2 = mock(Stream.class);
+        when(stream2.getAlertReceivers()).thenReturn(ImmutableMap.of(
+            "users", ImmutableList.of("foouser"),
+            "emails", ImmutableList.of("foo@bar.com")
+        ));
+        when(stream2.getId()).thenReturn(matchingStreamId1);
+        final Stream stream3 = mock(Stream.class);
+        when(stream3.getAlertReceivers()).thenReturn(ImmutableMap.of(
+            "users", ImmutableList.of("foouser2")
+        ));
+        when(stream3.getId()).thenReturn(matchingStreamId2);
+
+        when(this.streamService.loadAll()).thenReturn(ImmutableList.of(stream1, stream2, stream3));
+
+        final AlertCondition alertCondition1 = mock(AlertCondition.class);
+        final AlertCondition alertCondition2 = mock(AlertCondition.class);
+        when(this.streamService.getAlertConditions(eq(stream2))).thenReturn(ImmutableList.of(alertCondition1));
+        when(this.streamService.getAlertConditions(eq(stream3))).thenReturn(ImmutableList.of(alertCondition2));
+
+        final ConfigurationRequest configurationRequest = mock(ConfigurationRequest.class);
+        when(emailAlarmCallback.getRequestedConfiguration()).thenReturn(configurationRequest);
+        when(configurationRequest.getFields()).thenReturn(Collections.emptyMap());
+
+        final AlarmCallbackConfiguration newAlarmCallback1 = mock(AlarmCallbackConfiguration.class);
+        final String newAlarmCallbackId1 = "newAlarmCallbackId1";
+        final AlarmCallbackConfiguration newAlarmCallback2 = mock(AlarmCallbackConfiguration.class);
+        final String newAlarmCallbackId2 = "newAlarmCallbackId2";
+        when(alarmCallbackConfigurationService.create(eq(matchingStreamId1), any(CreateAlarmCallbackRequest.class), eq(localAdminId))).thenReturn(newAlarmCallback1);
+        when(alarmCallbackConfigurationService.create(eq(matchingStreamId2), any(CreateAlarmCallbackRequest.class), eq(localAdminId))).thenReturn(newAlarmCallback2);
+        when(alarmCallbackConfigurationService.save(eq(newAlarmCallback1))).thenReturn(newAlarmCallbackId1);
+        when(alarmCallbackConfigurationService.save(eq(newAlarmCallback2))).thenReturn(newAlarmCallbackId2);
+
+        this.emailAlarmCallbackMigrationPeriodical.doRun();
+
+        final ArgumentCaptor<String> streamIdCaptor = ArgumentCaptor.forClass(String.class);
+        final ArgumentCaptor<CreateAlarmCallbackRequest> createAlarmCallbackRequestCaptor = ArgumentCaptor.forClass(CreateAlarmCallbackRequest.class);
+        final ArgumentCaptor<String> userIdCaptor = ArgumentCaptor.forClass(String.class);
+
+        verify(this.alarmCallbackConfigurationService, times(2)).create(streamIdCaptor.capture(), createAlarmCallbackRequestCaptor.capture(), userIdCaptor.capture());
+        assertThat(streamIdCaptor.getAllValues())
+            .isNotNull()
+            .isNotEmpty()
+            .contains(matchingStreamId1)
+            .contains(matchingStreamId2);
+
+        createAlarmCallbackRequestCaptor.getAllValues()
+            .forEach(createAlarmCallbackRequest -> assertThat(createAlarmCallbackRequest.type()).isEqualTo(EmailAlarmCallback.class.getCanonicalName()));
+
+        final ArgumentCaptor<AlarmCallbackConfiguration> alarmCallbackConfigurationCaptor = ArgumentCaptor.forClass(AlarmCallbackConfiguration.class);
+        verify(this.alarmCallbackConfigurationService, times(2)).save(alarmCallbackConfigurationCaptor.capture());
+        assertThat(alarmCallbackConfigurationCaptor.getAllValues())
+            .isNotNull()
+            .isNotEmpty()
+            .hasSize(2)
+            .contains(newAlarmCallback1)
+            .contains(newAlarmCallback2);
+
+        verifyEmailAlarmCallbackMigratedWasPosted(ImmutableMap.of(
+            matchingStreamId1, Optional.of(newAlarmCallbackId1),
+            matchingStreamId2, Optional.of(newAlarmCallbackId2)
+        ));
+    }
+
+    @Test
+    public void extractEmptyDefaultValuesFromEmptyEmailAlarmCallbackConfiguration() throws Exception {
+        final ConfigurationRequest configurationRequest = mock(ConfigurationRequest.class);
+        when(emailAlarmCallback.getRequestedConfiguration()).thenReturn(configurationRequest);
+
+        final Map<String, Object> defaultConfig = this.emailAlarmCallbackMigrationPeriodical.getDefaultEmailAlarmCallbackConfig();
+
+        assertThat(defaultConfig).isNotNull().isEmpty();
+    }
+
+    @Test
+    public void extractDefaultValuesFromEmailAlarmCallbackConfiguration() throws Exception {
+        final ConfigurationRequest configurationRequest = mock(ConfigurationRequest.class);
+        when(emailAlarmCallback.getRequestedConfiguration()).thenReturn(configurationRequest);
+        final ConfigurationField configurationField1 = mock(ConfigurationField.class);
+        when(configurationField1.getDefaultValue()).thenReturn(42);
+        final ConfigurationField configurationField2 = mock(ConfigurationField.class);
+        when(configurationField2.getDefaultValue()).thenReturn("foobar");
+        final ConfigurationField configurationField3 = mock(ConfigurationField.class);
+        when(configurationField3.getDefaultValue()).thenReturn(true);
+        final Map<String, ConfigurationField> configurationFields = ImmutableMap.of(
+            "field1", configurationField1,
+            "field2", configurationField2,
+            "field3", configurationField3
+        );
+        when(configurationRequest.getFields()).thenReturn(configurationFields);
+
+        final Map<String, Object> defaultConfig = this.emailAlarmCallbackMigrationPeriodical.getDefaultEmailAlarmCallbackConfig();
+
+        assertThat(defaultConfig)
+            .isNotNull()
+            .isNotEmpty()
+            .hasSize(3)
+            .isEqualTo(ImmutableMap.of(
+                "field1", 42,
+                "field2", "foobar",
+                "field3", true
+            ));
+    }
+
+    private void verifyEmailAlarmCallbackMigratedWasPosted() {
+        verifyEmailAlarmCallbackMigratedWasPosted(Collections.emptyMap());
+    }
+
+    private void verifyEmailAlarmCallbackMigratedWasPosted(Map<String, Optional<String>> migratedStreams) {
+        final ArgumentCaptor<EmailAlarmCallbackMigrated> argumentCaptor = ArgumentCaptor.forClass(EmailAlarmCallbackMigrated.class);
+        verify(this.clusterConfigService, times(1)).write(argumentCaptor.capture());
+
+        final EmailAlarmCallbackMigrated emailAlarmCallbackMigrated = argumentCaptor.getValue();
+        assertThat(emailAlarmCallbackMigrated)
+            .isNotNull()
+            .isEqualTo(EmailAlarmCallbackMigrated.create(migratedStreams));
+    }
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description & Motivation

Since 8b15f35f5fef46b0c6b64ec7488e71019708696f, we do not call the email alarm callback if a stream's alert condition is triggered, but no callback exists. Therefore we need to explicitly create email alarm callbacks for streams like this, so existing users still get the behavior they expect.

Refs #2868, Graylog2/documentation#209

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
