### PR TITLE
Fixing failing updates of alert conditions.

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/alerts/AlertServiceImpl.java
+++ b/graylog2-server/src/main/java/org/graylog2/alerts/AlertServiceImpl.java
@@ -37,6 +37,7 @@ import org.mongojack.JacksonDBCollection;
 
 import javax.inject.Inject;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -142,10 +143,9 @@ public class AlertServiceImpl implements AlertService {
 
     @Override
     public AlertCondition updateFromRequest(AlertCondition alertCondition, CreateConditionRequest ccr) {
-        final Map<String, Object> parameters = ImmutableMap.<String, Object>builder()
-            .putAll(alertCondition.getParameters())
-            .putAll(ccr.parameters())
-            .build();
+        final Map<String, Object> parameters = new HashMap<>();
+        parameters.putAll(alertCondition.getParameters());
+        parameters.putAll(ccr.parameters());
 
         return this.alertConditionFactory.createAlertCondition(
             alertCondition.getType(),


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Before this change, updating an alert condition failed, because the
ImmutableMap builder which was used to merge previous and new states
does not accept duplicate values.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
