### PR TITLE
Fix threshold type display in message count condition form.

### DIFF
--- a/graylog2-web-interface/src/components/alertconditions/messagecountcondition/MessageCountConditionForm.jsx
+++ b/graylog2-web-interface/src/components/alertconditions/messagecountcondition/MessageCountConditionForm.jsx
@@ -39,13 +39,13 @@ const MessageCountConditionForm = React.createClass({
         <span className="threshold-type">
             <label className="radio-inline">
               <input ref="threshold_type" type="radio" name="threshold_type" onChange={this._onChange} value="more"
-                     checked={this.state.thresholdType === 'more'}/>
+                     checked={this.state.threshold_type.toLowerCase() === 'more'}/>
               more
             </label>
 
             <label className="radio-inline">
               <input ref="threshold_type" type="radio" name="threshold_type" onChange={this._onChange} value="less"
-                     checked={this.state.thresholdType === 'less'}/>
+                     checked={this.state.threshold_type.toLowerCase() === 'less'}/>
               less
             </label>
           </span>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This changes fixed the way the threshold type input determines which
type is selecting, by lowercasing the value before the comparison.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
