### PR TITLE
Improve logging in DecodingProcessor

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/shared/buffers/processors/DecodingProcessor.java
+++ b/graylog2-server/src/main/java/org/graylog2/shared/buffers/processors/DecodingProcessor.java
@@ -146,7 +146,7 @@ public class DecodingProcessor implements EventHandler<MessageEvent> {
                 message = codec.decode(raw);
             }
         } catch (RuntimeException e) {
-            LOG.error("Unable to decode raw message on input <{}>.", raw, inputIdOnCurrentNode);
+            LOG.error("Unable to decode raw message {} on input <{}>.", raw, inputIdOnCurrentNode);
             metricRegistry.meter(name(baseMetricName, "failures")).mark();
             throw e;
         } finally {


### PR DESCRIPTION
## Description

Log messages written in `DecodingProcessor` didn't include enough information to identify the messages and their source inputs. This PR adds the missing information to several log messages.

Closes #2967

## Checklist:
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** document.
- [x] All new and existing tests passed.