### PR TITLE
Prevent n+1 query loading for Stream Rules

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/streams/StreamRuleService.java
+++ b/graylog2-server/src/main/java/org/graylog2/streams/StreamRuleService.java
@@ -22,6 +22,7 @@ import org.graylog2.plugin.streams.Stream;
 import org.graylog2.plugin.streams.StreamRule;
 import org.graylog2.rest.resources.streams.rules.requests.CreateStreamRuleRequest;
 
+import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 
@@ -32,9 +33,11 @@ public interface StreamRuleService extends PersistedService {
 
     StreamRule create(Map<String, Object> data);
 
-    StreamRule create(String streamid, CreateStreamRuleRequest request);
+    StreamRule create(String streamId, CreateStreamRuleRequest request);
 
     List<StreamRule> loadForStreamId(String streamId) throws NotFoundException;
+
+    Map<String, List<StreamRule>> loadForStreamIds(Collection<String> streamIds);
 
     /**
      * @return the total number of stream rules


### PR DESCRIPTION
## Description

The issue is descriped in Graylog2/graylog2-server#2805. Stream Rules are ineffienently loaded, by doing a query pro stream and then a query pro rule.

## Motivation and Context

This tries to fix this by loading all Rules for a given list of steram ids.

## How Has This Been Tested?

Tested the resulted jar file and integration tests are also still running.

## Screenshots (if appropriate):

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

Add StreamRuleService.loadForStreamIds method for efficiently loading
all Rules for a given list of streams.

**This is not the final verson. This is to get early feedback on the suggested implementation**