### PR TITLE
Use unique IDs in user list's delete buttons

### DIFF
--- a/graylog2-web-interface/src/components/users/UserList.jsx
+++ b/graylog2-web-interface/src/components/users/UserList.jsx
@@ -119,7 +119,7 @@ const UserList = React.createClass({
       );
     } else {
       const deleteAction = (
-        <Button id="delete-user" bsStyle="primary" bsSize="xs" title="Delete user"
+        <Button id={`delete-user-${user.username}`} bsStyle="primary" bsSize="xs" title="Delete user"
                 onClick={this._deleteUserFunction(user.username)}>
           Delete
         </Button>


### PR DESCRIPTION
Each delete button in the user list is sharing the same element ID, which is wrong, and also make it harder to create automated test. This PR changes the ID appending the user name, making each ID unique, and also making easier to find the right delete button given a user name.