### PR TITLE
Fix backwards incompatibilities in ConfigurationRequest and NumberField

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/alerts/types/FieldContentValueAlertCondition.java
+++ b/graylog2-server/src/main/java/org/graylog2/alerts/types/FieldContentValueAlertCondition.java
@@ -75,10 +75,13 @@ public class FieldContentValueAlertCondition extends AbstractAlertCondition {
 
         @Override
         public ConfigurationRequest getRequestedConfiguration() {
-            return ConfigurationRequest.createWithFields(
-                new TextField("field", "Field", "", "Field name that should be checked", ConfigurationField.Optional.NOT_OPTIONAL),
-                new TextField("value", "Value", "", "Value that the field should be checked against", ConfigurationField.Optional.NOT_OPTIONAL)
-            ).addFields(AbstractAlertCondition.getDefaultConfigurationFields());
+            final ConfigurationRequest configurationRequest = ConfigurationRequest.createWithFields(
+                    new TextField("field", "Field", "", "Field name that should be checked", ConfigurationField.Optional.NOT_OPTIONAL),
+                    new TextField("value", "Value", "", "Value that the field should be checked against", ConfigurationField.Optional.NOT_OPTIONAL)
+            );
+            configurationRequest.addFields(AbstractAlertCondition.getDefaultConfigurationFields());
+
+            return configurationRequest;
         }
     }
 

--- a/graylog2-server/src/main/java/org/graylog2/alerts/types/FieldValueAlertCondition.java
+++ b/graylog2-server/src/main/java/org/graylog2/alerts/types/FieldValueAlertCondition.java
@@ -94,23 +94,26 @@ public class FieldValueAlertCondition extends AbstractAlertCondition {
 
         @Override
         public ConfigurationRequest getRequestedConfiguration() {
-            return ConfigurationRequest.createWithFields(
-                new TextField("field", "Field", "", "Field name that should be checked", ConfigurationField.Optional.NOT_OPTIONAL),
-                new NumberField("time", "Time Range", 0, "Time span in seconds to check", ConfigurationField.Optional.NOT_OPTIONAL),
-                new NumberField("threshold", "Threshold", 0.0, "Value which triggers an alert if crossed", ConfigurationField.Optional.NOT_OPTIONAL),
-                new DropdownField(
-                    "threshold_type",
-                    "Threshold Type",
-                    ThresholdType.HIGHER.toString(),
-                    DropdownField.ValueTemplates.valueMapFromEnum(ThresholdType.class, thresholdType -> thresholdType.name().toLowerCase(Locale.ENGLISH)),
-                    ConfigurationField.Optional.NOT_OPTIONAL),
-                new DropdownField(
-                    "type",
-                    "Check Type",
-                    CheckType.MAX.toString(),
-                    Arrays.stream(CheckType.values()).collect(Collectors.toMap(Enum::toString, CheckType::getDescription)),
-                    ConfigurationField.Optional.NOT_OPTIONAL)
-            ).addFields(AbstractAlertCondition.getDefaultConfigurationFields());
+            final ConfigurationRequest configurationRequest = ConfigurationRequest.createWithFields(
+                    new TextField("field", "Field", "", "Field name that should be checked", ConfigurationField.Optional.NOT_OPTIONAL),
+                    new NumberField("time", "Time Range", 0, "Time span in seconds to check", ConfigurationField.Optional.NOT_OPTIONAL),
+                    new NumberField("threshold", "Threshold", 0.0, "Value which triggers an alert if crossed", ConfigurationField.Optional.NOT_OPTIONAL),
+                    new DropdownField(
+                            "threshold_type",
+                            "Threshold Type",
+                            ThresholdType.HIGHER.toString(),
+                            DropdownField.ValueTemplates.valueMapFromEnum(ThresholdType.class, thresholdType -> thresholdType.name().toLowerCase(Locale.ENGLISH)),
+                            ConfigurationField.Optional.NOT_OPTIONAL),
+                    new DropdownField(
+                            "type",
+                            "Check Type",
+                            CheckType.MAX.toString(),
+                            Arrays.stream(CheckType.values()).collect(Collectors.toMap(Enum::toString, CheckType::getDescription)),
+                            ConfigurationField.Optional.NOT_OPTIONAL)
+            );
+            configurationRequest.addFields(AbstractAlertCondition.getDefaultConfigurationFields());
+
+            return configurationRequest;
         }
     }
 

--- a/graylog2-server/src/main/java/org/graylog2/alerts/types/MessageCountAlertCondition.java
+++ b/graylog2-server/src/main/java/org/graylog2/alerts/types/MessageCountAlertCondition.java
@@ -85,16 +85,19 @@ public class MessageCountAlertCondition extends AbstractAlertCondition {
 
         @Override
         public ConfigurationRequest getRequestedConfiguration() {
-            return ConfigurationRequest.createWithFields(
-                new NumberField("time", "Time Range", 0, "Time span in seconds to check", ConfigurationField.Optional.NOT_OPTIONAL),
-                new NumberField("threshold", "Threshold", 0.0, "Value which triggers an alert if crossed", ConfigurationField.Optional.NOT_OPTIONAL),
-                new DropdownField(
-                    "threshold_type",
-                    "Threshold Type",
-                    MessageCountAlertCondition.ThresholdType.MORE.toString(),
-                    Arrays.stream(MessageCountAlertCondition.ThresholdType.values()).collect(Collectors.toMap(Enum::toString, ThresholdType::getDescription)),
-                    ConfigurationField.Optional.NOT_OPTIONAL)
-            ).addFields(AbstractAlertCondition.getDefaultConfigurationFields());
+            final ConfigurationRequest configurationRequest = ConfigurationRequest.createWithFields(
+                    new NumberField("time", "Time Range", 0, "Time span in seconds to check", ConfigurationField.Optional.NOT_OPTIONAL),
+                    new NumberField("threshold", "Threshold", 0.0, "Value which triggers an alert if crossed", ConfigurationField.Optional.NOT_OPTIONAL),
+                    new DropdownField(
+                            "threshold_type",
+                            "Threshold Type",
+                            ThresholdType.MORE.toString(),
+                            Arrays.stream(ThresholdType.values()).collect(Collectors.toMap(Enum::toString, ThresholdType::getDescription)),
+                            ConfigurationField.Optional.NOT_OPTIONAL)
+            );
+            configurationRequest.addFields(AbstractAlertCondition.getDefaultConfigurationFields());
+
+            return configurationRequest;
         }
     }
 

--- a/graylog2-server/src/main/java/org/graylog2/plugin/configuration/ConfigurationRequest.java
+++ b/graylog2-server/src/main/java/org/graylog2/plugin/configuration/ConfigurationRequest.java
@@ -19,12 +19,15 @@ package org.graylog2.plugin.configuration;
 import com.fasterxml.jackson.annotation.JsonValue;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
-import org.graylog2.plugin.configuration.fields.*;
+import org.graylog2.plugin.configuration.fields.BooleanField;
+import org.graylog2.plugin.configuration.fields.ConfigurationField;
+import org.graylog2.plugin.configuration.fields.DropdownField;
+import org.graylog2.plugin.configuration.fields.NumberField;
+import org.graylog2.plugin.configuration.fields.TextField;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import javax.annotation.Nonnull;
-import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 
@@ -35,19 +38,16 @@ public class ConfigurationRequest {
 
     public ConfigurationRequest() {}
 
-    public ConfigurationRequest putAll(Map<String, ConfigurationField> fields) {
+    public void putAll(Map<String, ConfigurationField> fields) {
         this.fields.putAll(fields);
-        return this;
     }
 
-    public ConfigurationRequest addField(ConfigurationField f) {
+    public void addField(ConfigurationField f) {
         fields.put(f.getName(), f);
-        return this;
     }
 
-    public ConfigurationRequest addFields(List<ConfigurationField> fields) {
+    public void addFields(List<ConfigurationField> fields) {
         fields.forEach(this::addField);
-        return this;
     }
 
     public boolean containsField(String fieldName) {
@@ -60,6 +60,11 @@ public class ConfigurationRequest {
 
     public Map<String, ConfigurationField> getFields() {
         return fields;
+    }
+
+    @Deprecated
+    public boolean removeField(String fieldName) {
+        return fields.remove(fieldName) != null;
     }
 
     public static ConfigurationRequest createWithFields(ConfigurationField... fields) {

--- a/graylog2-server/src/main/java/org/graylog2/plugin/configuration/fields/NumberField.java
+++ b/graylog2-server/src/main/java/org/graylog2/plugin/configuration/fields/NumberField.java
@@ -36,26 +36,30 @@ public class NumberField extends AbstractConfigurationField {
     private final List<String> attributes;
 
     public NumberField(String name, String humanName, int defaultValue, String description, Optional isOptional) {
-        this(name, humanName, new Integer(defaultValue), description, isOptional);
+        this(name, humanName, defaultValue, description, isOptional, new Attribute[0]);
     }
 
-    public NumberField(String name, String humanName, Number defaultValue, String description, Optional isOptional) {
+    public NumberField(String name, String humanName, double defaultValue, String description, Optional isOptional) {
         this(name, humanName, defaultValue, description, isOptional, new Attribute[0]);
     }
 
     public NumberField(String name, String humanName, int defaultValue, String description, Attribute... attributes) {
-        this(name, humanName, new Integer(defaultValue), description, attributes);
+        this(name, humanName, defaultValue, description, Optional.NOT_OPTIONAL, attributes);
     }
 
-    public NumberField(String name, String humanName, Number defaultValue, String description, Attribute... attributes) {
+    public NumberField(String name, String humanName, double defaultValue, String description, Attribute... attributes) {
         this(name, humanName, defaultValue, description, Optional.NOT_OPTIONAL, attributes);
     }
 
     public NumberField(String name, String humanName, int defaultValue, String description, Optional isOptional, Attribute... attributes) {
-        this(name, humanName, new Integer(defaultValue), description, isOptional, attributes);
+        this(name, humanName, (Number) defaultValue, description, isOptional, attributes);
     }
 
-    public NumberField(String name, String humanName, Number defaultValue, String description, Optional isOptional, Attribute... attributes) {
+    public NumberField(String name, String humanName, double defaultValue, String description, Optional isOptional, Attribute... attributes) {
+        this(name, humanName, (Number) defaultValue, description, isOptional, attributes);
+    }
+
+    private NumberField(String name, String humanName, Number defaultValue, String description, Optional isOptional, Attribute... attributes) {
         super(FIELD_TYPE, name, humanName, description, isOptional);
         this.defaultValue = defaultValue;
 

--- a/graylog2-server/src/main/java/org/graylog2/plugin/configuration/fields/NumberField.java
+++ b/graylog2-server/src/main/java/org/graylog2/plugin/configuration/fields/NumberField.java
@@ -35,21 +35,33 @@ public class NumberField extends AbstractConfigurationField {
 
     private final List<String> attributes;
 
+    public NumberField(String name, String humanName, int defaultValue, String description, Optional isOptional) {
+        this(name, humanName, new Integer(defaultValue), description, isOptional);
+    }
+
     public NumberField(String name, String humanName, Number defaultValue, String description, Optional isOptional) {
         this(name, humanName, defaultValue, description, isOptional, new Attribute[0]);
+    }
+
+    public NumberField(String name, String humanName, int defaultValue, String description, Attribute... attributes) {
+        this(name, humanName, new Integer(defaultValue), description, attributes);
     }
 
     public NumberField(String name, String humanName, Number defaultValue, String description, Attribute... attributes) {
         this(name, humanName, defaultValue, description, Optional.NOT_OPTIONAL, attributes);
     }
 
-    public NumberField(String name, String humanName, Number defaultValue, String description, Optional isOptional, Attribute... attrs) {
+    public NumberField(String name, String humanName, int defaultValue, String description, Optional isOptional, Attribute... attributes) {
+        this(name, humanName, new Integer(defaultValue), description, isOptional, attributes);
+    }
+
+    public NumberField(String name, String humanName, Number defaultValue, String description, Optional isOptional, Attribute... attributes) {
         super(FIELD_TYPE, name, humanName, description, isOptional);
         this.defaultValue = defaultValue;
 
         this.attributes = Lists.newArrayList();
-        if (attrs != null) {
-            for (Attribute attribute : attrs) {
+        if (attributes != null) {
+            for (Attribute attribute : attributes) {
                 this.attributes.add(attribute.toString().toLowerCase(Locale.ENGLISH));
             }
         }


### PR DESCRIPTION
As described in #2973, we added some backwards incompatible changes in #2903, breaking plugins compiled against older versions of Graylog 2.x.

This PR fixes those incompatibilities by rolling back to the old methods used in `ConfigurationRequest`, and by adding backwards compatible constructors in `NumberField`.