### PR TITLE
Handle search execution errors

### DIFF
--- a/graylog2-web-interface/src/components/search/MalformedSearchQuery.jsx
+++ b/graylog2-web-interface/src/components/search/MalformedSearchQuery.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { Col, Panel, Row } from 'react-bootstrap';
 
-import DocumentationLink from 'components/support/DocumentationLink';
+import { ContactUs, DocumentationLink } from 'components/support';
 import DocsHelper from 'util/DocsHelper';
 
 const MalformedSearchQuery = React.createClass({
@@ -90,32 +90,7 @@ const MalformedSearchQuery = React.createClass({
           </Col>
         </Row>
 
-        <Row className="content">
-          <Col md={12}>
-            <div className="support-sources">
-              <h2>Need help?</h2>
-              <p>
-                Do not hesitate to consult the Graylog community if your questions are not answered in the{' '}
-                <DocumentationLink page={DocsHelper.PAGES.WELCOME} text="documentation" />.
-              </p>
-
-              <ul>
-                <li>
-                  <i className="fa fa-group" />&nbsp;
-                  <a href="https://www.graylog.org/community-support/" target="_blank">Community support</a>
-                </li>
-                <li>
-                  <i className="fa fa-github-alt" />&nbsp;
-                  <a href="https://github.com/Graylog2/graylog2-server/issues" target="_blank">Issue tracker</a>
-                </li>
-                <li>
-                  <i className="fa fa-heart" />&nbsp;
-                  <a href="https://www.graylog.org/professional-support" target="_blank">Professional support</a>
-                </li>
-              </ul>
-            </div>
-          </Col>
-        </Row>
+        <ContactUs />
       </div>
     );
   },

--- a/graylog2-web-interface/src/components/search/MalformedSearchQuery.jsx
+++ b/graylog2-web-interface/src/components/search/MalformedSearchQuery.jsx
@@ -44,20 +44,22 @@ const MalformedSearchQuery = React.createClass({
   },
 
   render() {
+    const error = this.props.error.body;
+
     let explanation;
-    if (this._isGenericError(this.props.error)) {
+    if (this._isGenericError(error)) {
       explanation = (
         <div>
           <p>The given query was malformed, and executing it caused the following error:</p>
-          {this._getFormattedErrorDescription(this.props.error)}
+          {this._getFormattedErrorDescription(error)}
         </div>
       );
     } else {
       explanation = (
         <div>
           <p>The given query was malformed at the following position:</p>
-          <pre>{this._highlightQueryError(this.props.error)}</pre>
-          {this._getFormattedErrorDescription(this.props.error)}
+          <pre>{this._highlightQueryError(error)}</pre>
+          {this._getFormattedErrorDescription(error)}
         </div>
       );
     }

--- a/graylog2-web-interface/src/components/search/NoSearchResults.jsx
+++ b/graylog2-web-interface/src/components/search/NoSearchResults.jsx
@@ -3,7 +3,7 @@ import { Col, Row } from 'react-bootstrap';
 
 import { AddSearchCountToDashboard, SavedSearchControls, ShowQueryModal } from 'components/search';
 import AddToDashboardMenu from 'components/dashboard/AddToDashboardMenu';
-import DocumentationLink from 'components/support/DocumentationLink';
+import { ContactUs, DocumentationLink } from 'components/support';
 
 import DocsHelper from 'util/DocsHelper';
 
@@ -84,33 +84,7 @@ const NoSearchResults = React.createClass({
             </p>
           </Col>
         </Row>
-        <Row className="content">
-          <Col md={12}>
-            <div className="support-sources">
-              <h2>Need help?</h2>
-              <p>
-                Do not hesitate to consult the Graylog community if your questions are not answered in the{' '}
-                <DocumentationLink page={DocsHelper.PAGES.WELCOME} text="documentation" />.
-              </p>
-
-              <ul>
-                <li>
-                  <i className="fa fa-group"/>&nbsp;
-                  <a href="https://www.graylog.org/community-support/" target="_blank">Community support</a>
-                </li>
-                <li>
-                  <i className="fa fa-github-alt"/>&nbsp;
-                  <a href="https://github.com/Graylog2/graylog2-server/issues" target="_blank">Issue tracker</a>
-                </li>
-                <li>
-                  <i className="fa fa-heart"/>&nbsp;
-                  <a href="https://www.graylog.org/professional-support" target="_blank">Professional support</a>
-                </li>
-              </ul>
-            </div>
-
-          </Col>
-        </Row>
+        <ContactUs />
       </div>
     );
   },

--- a/graylog2-web-interface/src/components/search/SearchExecutionError.jsx
+++ b/graylog2-web-interface/src/components/search/SearchExecutionError.jsx
@@ -1,0 +1,68 @@
+import React from 'react';
+import { Col, Panel, Row } from 'react-bootstrap';
+
+import DocumentationLink from 'components/support/DocumentationLink';
+import DocsHelper from 'util/DocsHelper';
+
+const SearchExecutionError = React.createClass({
+  propTypes: {
+    error: React.PropTypes.object.isRequired,
+  },
+
+  render() {
+    const error = this.props.error;
+    return (
+      <div>
+        <Row className="content content-head">
+          <Col md={12}>
+
+            <h1>
+              Could not execute search
+            </h1>
+
+            <div>
+              <p>There was an error executing your search. Please check your Graylog server logs for more information.</p>
+              <Panel bsStyle="danger">
+                <dl style={{ marginBottom: 0 }}>
+                  <dt>Error Message:</dt>
+                  <dd>{error.body.message ? `${error.body.message}: ` : ''}{error.message}</dd>
+                  <dt>Search status code:</dt>
+                  <dd>{error.status}</dd>
+                </dl>
+              </Panel>
+            </div>
+          </Col>
+        </Row>
+
+        <Row className="content">
+          <Col md={12}>
+            <div className="support-sources">
+              <h2>Need help?</h2>
+              <p>
+                Do not hesitate to consult the Graylog community if your questions are not answered in the{' '}
+                <DocumentationLink page={DocsHelper.PAGES.WELCOME} text="documentation" />.
+              </p>
+
+              <ul>
+                <li>
+                  <i className="fa fa-group" />&nbsp;
+                  <a href="https://www.graylog.org/community-support/" target="_blank">Community support</a>
+                </li>
+                <li>
+                  <i className="fa fa-github-alt" />&nbsp;
+                  <a href="https://github.com/Graylog2/graylog2-server/issues" target="_blank">Issue tracker</a>
+                </li>
+                <li>
+                  <i className="fa fa-heart" />&nbsp;
+                  <a href="https://www.graylog.org/professional-support" target="_blank">Professional support</a>
+                </li>
+              </ul>
+            </div>
+          </Col>
+        </Row>
+      </div>
+    );
+  },
+});
+
+export default SearchExecutionError;

--- a/graylog2-web-interface/src/components/search/SearchExecutionError.jsx
+++ b/graylog2-web-interface/src/components/search/SearchExecutionError.jsx
@@ -1,8 +1,7 @@
 import React from 'react';
 import { Col, Panel, Row } from 'react-bootstrap';
 
-import DocumentationLink from 'components/support/DocumentationLink';
-import DocsHelper from 'util/DocsHelper';
+import { ContactUs } from 'components/support';
 
 const SearchExecutionError = React.createClass({
   propTypes: {
@@ -34,32 +33,7 @@ const SearchExecutionError = React.createClass({
           </Col>
         </Row>
 
-        <Row className="content">
-          <Col md={12}>
-            <div className="support-sources">
-              <h2>Need help?</h2>
-              <p>
-                Do not hesitate to consult the Graylog community if your questions are not answered in the{' '}
-                <DocumentationLink page={DocsHelper.PAGES.WELCOME} text="documentation" />.
-              </p>
-
-              <ul>
-                <li>
-                  <i className="fa fa-group" />&nbsp;
-                  <a href="https://www.graylog.org/community-support/" target="_blank">Community support</a>
-                </li>
-                <li>
-                  <i className="fa fa-github-alt" />&nbsp;
-                  <a href="https://github.com/Graylog2/graylog2-server/issues" target="_blank">Issue tracker</a>
-                </li>
-                <li>
-                  <i className="fa fa-heart" />&nbsp;
-                  <a href="https://www.graylog.org/professional-support" target="_blank">Professional support</a>
-                </li>
-              </ul>
-            </div>
-          </Col>
-        </Row>
+        <ContactUs />
       </div>
     );
   },

--- a/graylog2-web-interface/src/components/search/index.jsx
+++ b/graylog2-web-interface/src/components/search/index.jsx
@@ -23,6 +23,7 @@ export { default as RefreshControls } from './RefreshControls';
 export { default as ResultTable } from './ResultTable';
 export { default as SavedSearchControls } from './SavedSearchControls';
 export { default as SearchBar } from './SearchBar';
+export { default as SearchExecutionError } from './SearchExecutionError';
 export { default as SearchResult } from './SearchResult';
 export { default as SearchSidebar } from './SearchSidebar';
 export { default as ShowQueryModal } from './ShowQueryModal';

--- a/graylog2-web-interface/src/components/support/ContactUs.jsx
+++ b/graylog2-web-interface/src/components/support/ContactUs.jsx
@@ -1,0 +1,40 @@
+import React from 'react';
+import { Col, Row } from 'react-bootstrap';
+
+import DocumentationLink from 'components/support/DocumentationLink';
+import DocsHelper from 'util/DocsHelper';
+
+const ContactUs = React.createClass({
+  render() {
+    return (
+      <Row className="content">
+        <Col md={12}>
+          <div className="support-sources">
+            <h2>Need help?</h2>
+            <p>
+              Do not hesitate to consult the Graylog community if your questions are not answered in the{' '}
+              <DocumentationLink page={DocsHelper.PAGES.WELCOME} text="documentation" />.
+            </p>
+
+            <ul>
+              <li>
+                <i className="fa fa-group" />&nbsp;
+                <a href="https://www.graylog.org/community-support/" target="_blank">Community support</a>
+              </li>
+              <li>
+                <i className="fa fa-github-alt" />&nbsp;
+                <a href="https://github.com/Graylog2/graylog2-server/issues" target="_blank">Issue tracker</a>
+              </li>
+              <li>
+                <i className="fa fa-heart" />&nbsp;
+                <a href="https://www.graylog.org/professional-support" target="_blank">Professional support</a>
+              </li>
+            </ul>
+          </div>
+        </Col>
+      </Row>
+    );
+  },
+});
+
+export default ContactUs;

--- a/graylog2-web-interface/src/components/support/index.jsx
+++ b/graylog2-web-interface/src/components/support/index.jsx
@@ -1,3 +1,4 @@
+export { default as ContactUs } from './ContactUs';
 export { default as DocumentationLink } from './DocumentationLink';
 export { default as SmallSupportLink } from './SmallSupportLink';
 export { default as SupportLink } from './SupportLink';

--- a/graylog2-web-interface/src/pages/SearchPage.jsx
+++ b/graylog2-web-interface/src/pages/SearchPage.jsx
@@ -15,7 +15,7 @@ const { SearchStore } = CombinedProvider.get('Search');
 const { DecoratorsActions } = CombinedProvider.get('Decorators');
 
 import { Spinner } from 'components/common';
-import { MalformedSearchQuery, SearchResult } from 'components/search';
+import { MalformedSearchQuery, SearchExecutionError, SearchResult } from 'components/search';
 
 const SearchPage = React.createClass({
   propTypes: {
@@ -102,8 +102,10 @@ const SearchPage = React.createClass({
         },
         error => {
           // Treat searches with a malformed query
-          if (error.additional && error.additional.status === 400) {
-            this.setState({ error: error.additional.body });
+          if (error.additional) {
+            if (error.additional.status) {
+              this.setState({ error: error.additional });
+            }
           }
         }
       )
@@ -194,7 +196,12 @@ const SearchPage = React.createClass({
 
   render() {
     if (this.state.error) {
-      return <MalformedSearchQuery error={this.state.error} />;
+      switch (this.state.error.status) {
+        case 400:
+          return <MalformedSearchQuery error={this.state.error} />;
+        default:
+          return <SearchExecutionError error={this.state.error} />;
+      }
     }
 
     if (this._isLoading()) {


### PR DESCRIPTION
Add a component to handle search execution errors. That component will be used every time the search API resource fails, but does not return a 400 error, which is used for malformed search queries.

Fixes #2988.