### PR TITLE
Close search query auto-completion on enter

### DIFF
--- a/graylog2-web-interface/src/components/search/SearchBar.jsx
+++ b/graylog2-web-interface/src/components/search/SearchBar.jsx
@@ -87,6 +87,12 @@ const SearchBar = React.createClass({
       $(queryDOMElement).off('typeahead:change');
     }
   },
+  _closeSearchQueryAutoCompletion() {
+    if (this.props.userPreferences.enableSmartSearch) {
+      const queryDOMElement = ReactDOM.findDOMNode(this.refs.query.getInputDOMNode());
+      $(queryDOMElement).typeahead('close');
+    }
+  },
   _animateQueryChange() {
     UIUtils.scrollToHint(ReactDOM.findDOMNode(this.refs.universalSearch));
     $(ReactDOM.findDOMNode(this.refs.query)).effect('bounce');
@@ -179,6 +185,8 @@ const SearchBar = React.createClass({
     if (event) {
       event.preventDefault();
     }
+
+    this._closeSearchQueryAutoCompletion();
 
     // Convert from and to values to UTC
     if (this.state.rangeType === 'absolute') {


### PR DESCRIPTION
This PR closes the search query auto-completion suggestions when performing a new search, avoiding the annoyance of unfocus the input to make the suggestions go away.

Fixes #2878