### PR TITLE
Improved search indicators

### DIFF
--- a/graylog2-web-interface/src/components/common/LoadingIndicator.css
+++ b/graylog2-web-interface/src/components/common/LoadingIndicator.css
@@ -1,12 +1,12 @@
 :local(.loadingIndicator) {
-    background-color: #FFF;
-    box-shadow: 2px 2px 10px #aaa;
+    box-shadow: 0 2px 10px rgba(0,0,0,.2);
     position: fixed;
-    bottom: 0;
-    right: 0;
-    z-index: 2000;
+    top: 60px;
+    left: 50%;
+    height: 32px;
+    width: 200px;
+    margin-left: -100px; /* half of the element width */
     padding: 5px 10px;
-    border-top: 1px solid #ccc;
-    border-left: 1px solid #ccc;
-    border-top-left-radius: 4px;
+    text-align: center;
+    z-index: 2000;
 }

--- a/graylog2-web-interface/src/components/common/LoadingIndicator.jsx
+++ b/graylog2-web-interface/src/components/common/LoadingIndicator.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { Alert } from 'react-bootstrap';
 
 import { Spinner } from 'components/common';
 
@@ -16,7 +17,7 @@ const LoadingIndicator = React.createClass({
   },
 
   render() {
-    return <div className={loadingIndicatorStyle.loadingIndicator}><Spinner text={this.props.text}/></div>;
+    return <Alert bsStyle="info" className={loadingIndicatorStyle.loadingIndicator}><Spinner text={this.props.text}/></Alert>;
   },
 });
 

--- a/graylog2-web-interface/src/components/search/SearchResult.jsx
+++ b/graylog2-web-interface/src/components/search/SearchResult.jsx
@@ -169,6 +169,7 @@ const SearchResult = React.createClass({
                          currentSavedSearch={SearchStore.savedSearch}
                          searchInStream={this.props.searchInStream}
                          permissions={this.props.permissions}
+                         loadingSearch={this.props.loadingSearch}
           />
         </Col>
         <Col md={9} sm={12} id="main-content-sidebar">

--- a/graylog2-web-interface/src/components/search/SearchSidebar.jsx
+++ b/graylog2-web-interface/src/components/search/SearchSidebar.jsx
@@ -5,6 +5,9 @@ import { AutoAffix } from 'react-overlays';
 import numeral from 'numeral';
 import URI from 'urijs';
 
+import { Timestamp } from 'components/common';
+import DateTime from 'logic/datetimes/DateTime';
+
 import StoreProvider from 'injection/StoreProvider';
 const SessionStore = StoreProvider.getStore('Session');
 const SearchStore = StoreProvider.getStore('Search');
@@ -39,17 +42,25 @@ const SearchSidebar = React.createClass({
     showHighlightToggle: React.PropTypes.bool,
     togglePageFields: React.PropTypes.func,
     toggleShouldHighlight: React.PropTypes.func,
+    loadingSearch: React.PropTypes.bool,
   },
 
   getInitialState() {
     return {
       availableHeight: 1000,
+      lastResultsUpdate: DateTime.now().toISOString(),
     };
   },
 
   componentDidMount() {
     this._updateHeight();
     window.addEventListener('resize', this._resizeCallback);
+  },
+
+  componentWillReceiveProps(nextProps) {
+    if (this.props.loadingSearch && !nextProps.loadingSearch) {
+      this.setState({ lastResultsUpdate: DateTime.now().toISOString() });
+    }
   },
 
   componentWillUnmount() {
@@ -162,12 +173,14 @@ const SearchSidebar = React.createClass({
             </h2>
 
             <p style={{ marginTop: 3 }}>
-              Found <strong>{numeral(this.props.result.total_results).format('0,0')} messages</strong>&nbsp;
+              Found <strong>{numeral(this.props.result.total_results).format('0,0')} messages</strong>{' '}
               in {numeral(this.props.result.time).format('0,0')} ms, searched in&nbsp;
               <a href="#" onClick={this._showIndicesModal}>
                 {this.props.result.used_indices.length}&nbsp;{this.props.result.used_indices.length === 1 ? 'index' : 'indices'}
               </a>.
               {indicesModal}
+              <br/>
+              Results retrieved at <Timestamp dateTime={this.state.lastResultsUpdate} format={DateTime.Formats.DATETIME}/>.
             </p>
 
             <div className="actions">


### PR DESCRIPTION
This PR modifies the search indications according to some of the feedback received:

- The search update indicator is now shown centred on the top part of the screen. The colour also changed to make it more visible in different types of background. This should help with #2840
- Add the time where the search was retrieved in the search sidebar, helping with #2843