### PR TITLE
Fix field analyzers loading when search changes

### DIFF
--- a/graylog2-web-interface/src/components/field-analyzers/FieldQuickValues.jsx
+++ b/graylog2-web-interface/src/components/field-analyzers/FieldQuickValues.jsx
@@ -15,6 +15,10 @@ const RefreshStore = StoreProvider.getStore('Refresh');
 const FieldQuickValues = React.createClass({
   propTypes: {
     permissions: PropTypes.arrayOf(PropTypes.string).isRequired,
+    query: React.PropTypes.string.isRequired,
+    rangeType: React.PropTypes.string.isRequired,
+    rangeParams: React.PropTypes.object.isRequired,
+    stream: PropTypes.object,
   },
   mixins: [Reflux.listenTo(RefreshStore, '_setupTimer', '_setupTimer')],
   getInitialState() {
@@ -26,6 +30,15 @@ const FieldQuickValues = React.createClass({
 
   componentDidMount() {
     this._loadQuickValuesData();
+  },
+  componentWillReceiveProps(nextProps) {
+    // Reload values when executed search changes
+    if (this.props.query !== nextProps.query ||
+        this.props.rangeType !== nextProps.rangeType ||
+        JSON.stringify(this.props.rangeParams) !== JSON.stringify(nextProps.rangeParams) ||
+        this.props.stream !== nextProps.stream) {
+      this._loadQuickValuesData();
+    }
   },
   componentDidUpdate(oldProps, oldState) {
     if (this.state.field !== oldState.field) {

--- a/graylog2-web-interface/src/components/field-analyzers/FieldStatistics.jsx
+++ b/graylog2-web-interface/src/components/field-analyzers/FieldStatistics.jsx
@@ -15,6 +15,10 @@ import UserNotification from 'util/UserNotification';
 const FieldStatistics = React.createClass({
   propTypes: {
     permissions: PropTypes.arrayOf(PropTypes.string).isRequired,
+    query: React.PropTypes.string.isRequired,
+    rangeType: React.PropTypes.string.isRequired,
+    rangeParams: React.PropTypes.object.isRequired,
+    stream: PropTypes.object,
   },
   mixins: [Reflux.listenTo(RefreshStore, '_setupTimer', '_setupTimer')],
 
@@ -25,6 +29,16 @@ const FieldStatistics = React.createClass({
       sortBy: 'field',
       sortDescending: false,
     };
+  },
+
+  componentWillReceiveProps(nextProps) {
+    // Reload values when executed search changes
+    if (this.props.query !== nextProps.query ||
+        this.props.rangeType !== nextProps.rangeType ||
+        JSON.stringify(this.props.rangeParams) !== JSON.stringify(nextProps.rangeParams) ||
+        this.props.stream !== nextProps.stream) {
+      this._reloadAllStatistics();
+    }
   },
 
   WIDGET_TYPE: 'STATS_COUNT',

--- a/graylog2-web-interface/src/components/search/SearchResult.jsx
+++ b/graylog2-web-interface/src/components/search/SearchResult.jsx
@@ -104,16 +104,25 @@ const SearchResult = React.createClass({
   },
 
   _fieldAnalyzerComponents(filter) {
+    // Get params used in the last executed search.
+    const searchParams = SearchStore.getOriginalSearchURLParams().toJS();
+    const rangeParams = {};
+    ['relative', 'from', 'to', 'keyword'].forEach(param => {
+      if (searchParams[param]) {
+        rangeParams[param] = searchParams[param];
+      }
+    });
+
     return this._fieldAnalyzers(filter)
       .map((analyzer, idx) => {
         return React.createElement(analyzer.component, {
           key: idx,
           ref: analyzer.refId,
           permissions: this.props.permissions,
-          query: SearchStore.query,
-          page: SearchStore.page,
-          rangeType: SearchStore.rangeType,
-          rangeParams: SearchStore.rangeParams.toJS(),
+          query: searchParams.q,
+          page: searchParams.page,
+          rangeType: searchParams.rangetype,
+          rangeParams: rangeParams,
           stream: this.props.searchInStream,
           resolution: this.props.histogram.interval,
           from: this.props.histogram.histogram_boundaries.from,


### PR DESCRIPTION
Before this PR, quick values and field statistics analyzers didn't update when a new search was executed, something that was confusing, as described in #2908.

This PR makes those components to fetch new data when any search parameter changes, keeping the data in sync with the current search.

Field graphs do not require any changes, as they were already updating when the search histogram was refreshed. 

Fixes #2908