### PR TITLE
Calculate cardinality on field graphs

### DIFF
--- a/graylog2-web-interface/src/legacy/analyzers/fieldcharts.js
+++ b/graylog2-web-interface/src/legacy/analyzers/fieldcharts.js
@@ -296,7 +296,8 @@ export const FieldChart = {
       opts.field,
       opts.interval,
       timeRangeParams,
-      opts.streamid
+      opts.streamid,
+      opts.valuetype === 'cardinality'
     ).url;
 
     return fetch('GET', URLUtils.qualifyUrl(url))

--- a/graylog2-web-interface/src/routing/ApiRoutes.js
+++ b/graylog2-web-interface/src/routing/ApiRoutes.js
@@ -253,11 +253,12 @@ const ApiRoutes = {
 
       return { url: this._buildUrl(url, queryString) };
     },
-    fieldHistogram(type, query, field, resolution, timerange, streamId) {
+    fieldHistogram(type, query, field, resolution, timerange, streamId, includeCardinality) {
       const url = `/search/universal/${type}/fieldhistogram`;
       const queryString = this._buildBaseQueryString(query, timerange, streamId);
       queryString.interval = resolution;
       queryString.field = field;
+      queryString.cardinality = includeCardinality;
       return { url: this._buildUrl(url, queryString) };
     },
     fieldStats(type, query, field, timerange, streamId) {


### PR DESCRIPTION
As cardinality is not calculated by default, we need to enable cardinality by hand when a user requests a cardinality field graph in the search page.

Fixes #2940