### PR TITLE
Refresh stream search when stream changes

### DIFF
--- a/graylog2-web-interface/src/pages/SearchPage.jsx
+++ b/graylog2-web-interface/src/pages/SearchPage.jsx
@@ -55,11 +55,11 @@ const SearchPage = React.createClass({
     const currentLocation = this.props.location || {};
     const nextLocation = nextProps.location || {};
 
-    if ((currentLocation !== nextLocation) || (currentLocation.search !== nextLocation.search)) {
+    if (currentLocation.search !== nextLocation.search || this.props.searchInStream !== nextProps.searchInStream) {
       if (this.promise) {
         this.promise.cancel();
       }
-      this._refreshData();
+      this._refreshData(nextProps.searchInStream);
     }
   },
   componentWillUnmount() {
@@ -79,9 +79,10 @@ const SearchPage = React.createClass({
   _getEffectiveQuery() {
     return SearchStore.query.length > 0 ? SearchStore.query : '*';
   },
-  _refreshData() {
+  _refreshData(searchInStream) {
     const query = this._getEffectiveQuery();
-    const streamId = this.props.searchInStream ? this.props.searchInStream.id : undefined;
+    const stream = searchInStream || this.props.searchInStream || {};
+    const streamId = stream.id;
     if (this.promise && !this.promise.isCancelled()) {
       return this.promise;
     }

--- a/graylog2-web-interface/src/pages/StreamSearchPage.jsx
+++ b/graylog2-web-interface/src/pages/StreamSearchPage.jsx
@@ -15,7 +15,15 @@ const StreamSearchPage = React.createClass({
     };
   },
   componentDidMount() {
-    StreamsStore.get(this.props.params.streamId, (stream) => this.setState({stream: stream}));
+    this._fetchStream(this.props.params.streamId);
+  },
+  componentWillReceiveProps(nextProps) {
+    if (this.props.params.streamId !== nextProps.params.streamId) {
+      this._fetchStream(nextProps.params.streamId);
+    }
+  },
+  _fetchStream(streamId) {
+    StreamsStore.get(streamId, (stream) => this.setState({stream: stream}));
   },
   render() {
     if (!this.state.stream) {


### PR DESCRIPTION
Most of the time, search results include links to other streams. When the user is currently searching on a stream, clicking on one of those links was not working properly: the stream didn't update and the search was still referring to the old stream.

These changes tackle that problem, by updating the stream when it changes, and reloading search results as well.

Fixes #2998