### PR TITLE
Fix NPE in MongoProbe if MongoDB doesn't run with MMAPv1

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/system/stats/mongo/MongoProbe.java
+++ b/graylog2-server/src/main/java/org/graylog2/system/stats/mongo/MongoProbe.java
@@ -210,7 +210,7 @@ public class MongoProbe {
                     memoryMap.getInt("virtual"),
                     memoryMap.getBoolean("supported"),
                     memoryMap.getInt("mapped"),
-                    memoryMap.getInt("mappedWithJournal")
+                    memoryMap.getInt("mappedWithJournal", -1)
             );
 
             final BasicDBObject storageEngineMap = (BasicDBObject) serverStatusResult.get("storageEngine");


### PR DESCRIPTION
Closes #3018

(cherry picked from commit 2fd21d4ed2cf9215c30b5c3a6c3bf4c34087cde9)