### PR TITLE
Properly track replace-all flag and pass through to API

### DIFF
--- a/graylog2-web-interface/src/components/grok-patterns/BulkLoadPatternModal.jsx
+++ b/graylog2-web-interface/src/components/grok-patterns/BulkLoadPatternModal.jsx
@@ -12,11 +12,16 @@ const BulkLoadPatternModal = React.createClass({
   propTypes: {
     onSuccess: React.PropTypes.func.isRequired,
   },
+  getInitialState() {
+    return {
+      replacePatterns: false,
+    };
+  },
+
   _onSubmit(evt) {
     evt.preventDefault();
 
     const reader = new FileReader();
-    const replaceAll = this.refs['replace-patterns'].checked;
 
     reader.onload = (loaded) => {
       const request = loaded.target.result.split('\n').map((line) => {
@@ -27,7 +32,7 @@ const BulkLoadPatternModal = React.createClass({
           }
         }
       }).filter((elem) => elem !== undefined);
-      GrokPatternsStore.bulkImport(request, replaceAll).then(() => {
+      GrokPatternsStore.bulkImport(request, this.state.replacePatterns).then(() => {
         UserNotification.success('Grok Patterns imported successfully', 'Success!');
         this.refs.modal.close();
         this.props.onSuccess();
@@ -52,9 +57,10 @@ const BulkLoadPatternModal = React.createClass({
                    help="A file containing Grok patterns, one per line. Name and patterns should be separated by whitespace."
                    required />
             <Input type="checkbox"
-                   ref="replace-patterns"
                    name="replace"
-                   label="Replace all existing patterns?" />
+                   label="Replace all existing patterns?"
+                   onChange={(e) => this.setState({ replacePatterns: e.target.checked })}
+            />
           </BootstrapModalForm>
       </span>
     );

--- a/graylog2-web-interface/src/stores/grok-patterns/GrokPatternsStore.ts
+++ b/graylog2-web-interface/src/stores/grok-patterns/GrokPatternsStore.ts
@@ -33,7 +33,7 @@ const GrokPatternsStore = {
         "Could not save Grok pattern");
     };
 
-    const requestPatterb = {
+    const requestPattern = {
       id: pattern.id,
       pattern: pattern.pattern,
       name: pattern.name,
@@ -48,7 +48,7 @@ const GrokPatternsStore = {
       url += '/' + pattern.id;
       method = 'PUT';
     }
-    fetch(method, url, requestPatterb).then(() => {
+    fetch(method, url, requestPattern).then(() => {
       callback();
       var action = pattern.id === "" ? "created" : "updated";
       var message = "Grok pattern \"" + pattern.name + "\" successfully " + action;
@@ -73,7 +73,7 @@ const GrokPatternsStore = {
         "Could not load Grok patterns");
     };
 
-    const promise = fetch('PUT', this.URL, {patterns: patterns});
+    const promise = fetch('PUT', `${this.URL}?replace=${replaceAll}`, {patterns: patterns});
 
     promise.catch(failCallback);
 


### PR DESCRIPTION
Closes #3023

(cherry picked from commit a8bb7c05aec12cd7a3dc24b473e5d0a284f5f5d1)