### PR TITLE
Upgrade moment-timezone to 0.5.7

### DIFF
--- a/graylog2-web-interface/packages/graylog-web-plugin/package.json
+++ b/graylog2-web-interface/packages/graylog-web-plugin/package.json
@@ -32,7 +32,7 @@
     "javascript-natural-sort": "^0.7.1",
     "jquery": "2.1.x",
     "moment": "2.14.1",
-    "moment-timezone": "0.5.5",
+    "moment-timezone": "0.5.7",
     "react": "^0.14.5",
     "react-addons-linked-state-mixin": "0.14.8",
     "react-addons-pure-render-mixin": "0.14.8",


### PR DESCRIPTION
We also need to update moment-timezone to fix the issue mentioned in #3056 in the web interface.

This change should also be backported to 2.1.