### PR TITLE
Update search results when using search button

### DIFF
--- a/graylog2-web-interface/src/components/field-analyzers/FieldQuickValues.jsx
+++ b/graylog2-web-interface/src/components/field-analyzers/FieldQuickValues.jsx
@@ -19,6 +19,7 @@ const FieldQuickValues = React.createClass({
     rangeType: React.PropTypes.string.isRequired,
     rangeParams: React.PropTypes.object.isRequired,
     stream: PropTypes.object,
+    forceFetch: React.PropTypes.bool,
   },
   mixins: [Reflux.listenTo(RefreshStore, '_setupTimer', '_setupTimer')],
   getInitialState() {
@@ -36,7 +37,8 @@ const FieldQuickValues = React.createClass({
     if (this.props.query !== nextProps.query ||
         this.props.rangeType !== nextProps.rangeType ||
         JSON.stringify(this.props.rangeParams) !== JSON.stringify(nextProps.rangeParams) ||
-        this.props.stream !== nextProps.stream) {
+        this.props.stream !== nextProps.stream ||
+        nextProps.forceFetch) {
       this._loadQuickValuesData();
     }
   },

--- a/graylog2-web-interface/src/components/field-analyzers/FieldStatistics.jsx
+++ b/graylog2-web-interface/src/components/field-analyzers/FieldStatistics.jsx
@@ -19,6 +19,7 @@ const FieldStatistics = React.createClass({
     rangeType: React.PropTypes.string.isRequired,
     rangeParams: React.PropTypes.object.isRequired,
     stream: PropTypes.object,
+    forceFetch: React.PropTypes.bool,
   },
   mixins: [Reflux.listenTo(RefreshStore, '_setupTimer', '_setupTimer')],
 
@@ -36,7 +37,8 @@ const FieldStatistics = React.createClass({
     if (this.props.query !== nextProps.query ||
         this.props.rangeType !== nextProps.rangeType ||
         JSON.stringify(this.props.rangeParams) !== JSON.stringify(nextProps.rangeParams) ||
-        this.props.stream !== nextProps.stream) {
+        this.props.stream !== nextProps.stream ||
+        nextProps.forceFetch) {
       this._reloadAllStatistics();
     }
   },

--- a/graylog2-web-interface/src/components/search/SearchBar.jsx
+++ b/graylog2-web-interface/src/components/search/SearchBar.jsx
@@ -28,6 +28,7 @@ const SearchBar = React.createClass({
     savedSearches: React.PropTypes.arrayOf(React.PropTypes.object).isRequired,
     config: React.PropTypes.object,
     displayRefreshControls: React.PropTypes.bool,
+    onExecuteSearch: React.PropTypes.func,
   },
 
   getDefaultProps() {
@@ -204,7 +205,12 @@ const SearchBar = React.createClass({
     const searchForm = this.refs.searchForm;
     const searchQuery = $(searchForm).serialize();
     const searchURI = new URI(searchForm.action).search(searchQuery);
-    SearchStore.executeSearch(searchURI.resource());
+    const resource = searchURI.resource();
+
+    SearchStore.executeSearch(resource);
+    if (typeof this.props.onExecuteSearch === 'function') {
+      this.props.onExecuteSearch(resource);
+    }
   },
   _savedSearchSelected() {
     const selectedSavedSearch = this.refs.savedSearchesSelector.getValue();

--- a/graylog2-web-interface/src/components/search/SearchResult.jsx
+++ b/graylog2-web-interface/src/components/search/SearchResult.jsx
@@ -25,6 +25,7 @@ const SearchResult = React.createClass({
     permissions: React.PropTypes.array.isRequired,
     searchConfig: React.PropTypes.object.isRequired,
     loadingSearch: React.PropTypes.bool,
+    forceFetch: React.PropTypes.bool,
   },
 
   getDefaultProps() {
@@ -127,6 +128,7 @@ const SearchResult = React.createClass({
           resolution: this.props.histogram.interval,
           from: this.props.histogram.histogram_boundaries.from,
           to: this.props.histogram.histogram_boundaries.to,
+          forceFetch: this.props.forceFetch,
         });
       });
   },

--- a/graylog2-web-interface/src/pages/SearchPage.jsx
+++ b/graylog2-web-interface/src/pages/SearchPage.jsx
@@ -22,6 +22,7 @@ const SearchPage = React.createClass({
     location: PropTypes.object.isRequired,
     searchConfig: PropTypes.object.isRequired,
     searchInStream: PropTypes.object,
+    forceFetch: PropTypes.bool,
   },
   mixins: [
     Reflux.connect(NodesStore),
@@ -55,7 +56,7 @@ const SearchPage = React.createClass({
     const currentLocation = this.props.location || {};
     const nextLocation = nextProps.location || {};
 
-    if (currentLocation.search !== nextLocation.search || this.props.searchInStream !== nextProps.searchInStream) {
+    if (currentLocation.search !== nextLocation.search || this.props.searchInStream !== nextProps.searchInStream || nextProps.forceFetch) {
       if (this.promise) {
         this.promise.cancel();
       }
@@ -218,7 +219,8 @@ const SearchPage = React.createClass({
                     streams={this.state.streams} inputs={this.state.inputs} nodes={Immutable.Map(this.state.nodes)}
                     searchInStream={this.props.searchInStream} permissions={this.state.currentUser.permissions}
                     searchConfig={this.props.searchConfig}
-                    loadingSearch={this.state.updatingSearch || this.state.updatingHistogram} />
+                    loadingSearch={this.state.updatingSearch || this.state.updatingHistogram}
+                    forceFetch={this.props.forceFetch} />
     );
   },
 });

--- a/graylog2-web-interface/src/routing/AppWithSearchBar.jsx
+++ b/graylog2-web-interface/src/routing/AppWithSearchBar.jsx
@@ -47,6 +47,7 @@ const AppWithSearchBar = React.createClass({
   componentWillUnmount() {
     SearchStore.unload();
   },
+  forceFetch: false,
   _loadStream(streamId) {
     if (streamId) {
       StreamsStore.get(streamId, (stream) => this.setState({ stream: stream }, this._updateSearchParams));
@@ -65,13 +66,18 @@ const AppWithSearchBar = React.createClass({
     return !this.state.savedSearches || !this.state.searchesClusterConfig || (this.props.params.streamId && !this.state.stream);
   },
   _decorateChildren(children) {
-    return React.Children.map(children, (child) => {
-      return React.cloneElement(child, { searchConfig: this.state.searchesClusterConfig });
+    const decoratedChildren = React.Children.map(children, (child) => {
+      return React.cloneElement(child, { searchConfig: this.state.searchesClusterConfig, forceFetch: this.forceFetch });
     });
+    this.forceFetch = false;
+    return decoratedChildren;
   },
   _searchBarShouldDisplayRefreshControls() {
     // Hide refresh controls on sources page
     return this.props.location.pathname !== Routes.SOURCES;
+  },
+  _onExecuteSearch() {
+    this.forceFetch = true;
   },
   render() {
     if (this._isLoading()) {
@@ -87,7 +93,8 @@ const AppWithSearchBar = React.createClass({
         <SearchBar ref="searchBar" userPreferences={this.state.currentUser.preferences}
                    savedSearches={this.state.savedSearches}
                    config={this.state.searchesClusterConfig}
-                   displayRefreshControls={this._searchBarShouldDisplayRefreshControls()} />
+                   displayRefreshControls={this._searchBarShouldDisplayRefreshControls()}
+                   onExecuteSearch={this._onExecuteSearch} />
         <Row id="main-row">
           <Col md={12} id="main-content">
             {this._decorateChildren(this.props.children)}


### PR DESCRIPTION
When user requests a new search by pressing the search button in the search bar, force fetch search results, even if query didn't change.

Fixes #3061.

This should be backported into 2.1, as the issue is also there.