### PR TITLE
Enhance alert data model

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/alerts/Alert.java
+++ b/graylog2-server/src/main/java/org/graylog2/alerts/Alert.java
@@ -28,6 +28,7 @@ public interface Alert {
     String getStreamId();
     String getConditionId();
     DateTime getTriggeredAt();
+    DateTime getResolvedAt();
     String getDescription();
     Map<String, Object> getConditionParameters();
 
@@ -35,6 +36,7 @@ public interface Alert {
         Builder streamId(String streamId);
         Builder conditionId(String conditionId);
         Builder triggeredAt(DateTime triggeredAt);
+        Builder resolvedAt(DateTime resolvedAt);
         Builder description(String description);
         Builder conditionParameters(Map<String, Object> conditionParameters);
 

--- a/graylog2-server/src/main/java/org/graylog2/alerts/Alert.java
+++ b/graylog2-server/src/main/java/org/graylog2/alerts/Alert.java
@@ -31,6 +31,7 @@ public interface Alert {
     DateTime getResolvedAt();
     String getDescription();
     Map<String, Object> getConditionParameters();
+    boolean isInterval();
 
     interface Builder {
         Builder streamId(String streamId);
@@ -39,6 +40,7 @@ public interface Alert {
         Builder resolvedAt(DateTime resolvedAt);
         Builder description(String description);
         Builder conditionParameters(Map<String, Object> conditionParameters);
+        Builder interval(boolean isInterval);
 
         Alert build();
     }

--- a/graylog2-server/src/main/java/org/graylog2/alerts/Alert.java
+++ b/graylog2-server/src/main/java/org/graylog2/alerts/Alert.java
@@ -20,9 +20,6 @@ import org.joda.time.DateTime;
 
 import java.util.Map;
 
-/**
- * @author Dennis Oelkers <dennis@torch.sh>
- */
 public interface Alert {
     String getId();
     String getStreamId();
@@ -32,16 +29,4 @@ public interface Alert {
     String getDescription();
     Map<String, Object> getConditionParameters();
     boolean isInterval();
-
-    interface Builder {
-        Builder streamId(String streamId);
-        Builder conditionId(String conditionId);
-        Builder triggeredAt(DateTime triggeredAt);
-        Builder resolvedAt(DateTime resolvedAt);
-        Builder description(String description);
-        Builder conditionParameters(Map<String, Object> conditionParameters);
-        Builder interval(boolean isInterval);
-
-        Alert build();
-    }
 }

--- a/graylog2-server/src/main/java/org/graylog2/alerts/AlertImpl.java
+++ b/graylog2-server/src/main/java/org/graylog2/alerts/AlertImpl.java
@@ -55,11 +55,9 @@ public abstract class AlertImpl implements Alert {
     @Override
     public abstract String getConditionId();
 
-    @JsonProperty(FIELD_TRIGGERED_AT)
     @Override
     public abstract DateTime getTriggeredAt();
 
-    @JsonProperty(FIELD_RESOLVED_AT)
     @Override
     @Nullable
     public abstract DateTime getResolvedAt();
@@ -72,6 +70,17 @@ public abstract class AlertImpl implements Alert {
     @Override
     public abstract Map<String, Object> getConditionParameters();
 
+    @JsonProperty(FIELD_TRIGGERED_AT)
+    private Date getTriggeredAtDate() {
+        return getTriggeredAt().toDate();
+    }
+
+    @JsonProperty(FIELD_RESOLVED_AT)
+    @Nullable
+    private Date getResolvedAtDate() {
+        return getResolvedAt() == null ? null : getResolvedAt().toDate();
+    }
+
     static Builder builder() {
         return new AutoValue_AlertImpl.Builder();
     }
@@ -80,16 +89,28 @@ public abstract class AlertImpl implements Alert {
     public static AlertImpl create(@JsonProperty(FIELD_ID) @ObjectId @Id String id,
                                    @JsonProperty(FIELD_STREAM_ID) String streamId,
                                    @JsonProperty(FIELD_CONDITION_ID) String conditionId,
-                                   @JsonProperty(FIELD_TRIGGERED_AT) Date triggeredAt,
-                                   @JsonProperty(FIELD_RESOLVED_AT) Date resolvedAt,
+                                   @JsonProperty(FIELD_TRIGGERED_AT) Date triggeredAtDate,
+                                   @JsonProperty(FIELD_RESOLVED_AT) Date resolvedAtDate,
                                    @JsonProperty(FIELD_DESCRIPTION) String description,
                                    @JsonProperty(FIELD_CONDITION_PARAMETERS) Map<String, Object> conditionParameters) {
+        final DateTime triggeredAt = new DateTime(triggeredAtDate);
+        final DateTime resolvedAt = resolvedAtDate == null ? null : new DateTime(resolvedAtDate);
+        return create(id, streamId, conditionId, triggeredAt, resolvedAt, description, conditionParameters);
+    }
+
+    public static AlertImpl create(String id,
+                                   String streamId,
+                                   String conditionId,
+                                   DateTime triggeredAt,
+                                   DateTime resolvedAt,
+                                   String description,
+                                   Map<String, Object> conditionParameters) {
         return builder()
             .id(id)
             .streamId(streamId)
             .conditionId(conditionId)
-            .triggeredAt(new DateTime(triggeredAt))
-            .resolvedAt(resolvedAt == null ? null : new DateTime(resolvedAt))
+            .triggeredAt(triggeredAt)
+            .resolvedAt(resolvedAt)
             .description(description)
             .conditionParameters(conditionParameters)
             .build();

--- a/graylog2-server/src/main/java/org/graylog2/alerts/AlertImpl.java
+++ b/graylog2-server/src/main/java/org/graylog2/alerts/AlertImpl.java
@@ -40,6 +40,7 @@ public abstract class AlertImpl implements Alert {
     static final String FIELD_CONDITION_PARAMETERS = "condition_parameters";
     static final String FIELD_TRIGGERED_AT = "triggered_at";
     static final String FIELD_RESOLVED_AT = "resolved_at";
+    static final String FIELD_IS_INTERVAL = "is_interval";
 
     @JsonProperty(FIELD_ID)
     @Override
@@ -70,6 +71,10 @@ public abstract class AlertImpl implements Alert {
     @Override
     public abstract Map<String, Object> getConditionParameters();
 
+    @JsonProperty(FIELD_IS_INTERVAL)
+    @Override
+    public abstract boolean isInterval();
+
     @JsonProperty(FIELD_TRIGGERED_AT)
     private Date getTriggeredAtDate() {
         return getTriggeredAt().toDate();
@@ -92,10 +97,11 @@ public abstract class AlertImpl implements Alert {
                                    @JsonProperty(FIELD_TRIGGERED_AT) Date triggeredAtDate,
                                    @JsonProperty(FIELD_RESOLVED_AT) Date resolvedAtDate,
                                    @JsonProperty(FIELD_DESCRIPTION) String description,
-                                   @JsonProperty(FIELD_CONDITION_PARAMETERS) Map<String, Object> conditionParameters) {
+                                   @JsonProperty(FIELD_CONDITION_PARAMETERS) Map<String, Object> conditionParameters,
+                                   @JsonProperty(FIELD_IS_INTERVAL) boolean isInterval) {
         final DateTime triggeredAt = new DateTime(triggeredAtDate);
         final DateTime resolvedAt = resolvedAtDate == null ? null : new DateTime(resolvedAtDate);
-        return create(id, streamId, conditionId, triggeredAt, resolvedAt, description, conditionParameters);
+        return create(id, streamId, conditionId, triggeredAt, resolvedAt, description, conditionParameters, isInterval);
     }
 
     public static AlertImpl create(String id,
@@ -105,6 +111,17 @@ public abstract class AlertImpl implements Alert {
                                    DateTime resolvedAt,
                                    String description,
                                    Map<String, Object> conditionParameters) {
+        return create(id, streamId, conditionId, triggeredAt, resolvedAt, description, conditionParameters, true);
+    }
+
+    public static AlertImpl create(String id,
+                                   String streamId,
+                                   String conditionId,
+                                   DateTime triggeredAt,
+                                   DateTime resolvedAt,
+                                   String description,
+                                   Map<String, Object> conditionParameters,
+                                   boolean isInterval) {
         return builder()
             .id(id)
             .streamId(streamId)
@@ -113,6 +130,7 @@ public abstract class AlertImpl implements Alert {
             .resolvedAt(resolvedAt)
             .description(description)
             .conditionParameters(conditionParameters)
+            .interval(isInterval)
             .build();
     }
 
@@ -131,6 +149,8 @@ public abstract class AlertImpl implements Alert {
         Builder description(String description);
         @Override
         Builder conditionParameters(Map<String, Object> conditionParameters);
+        @Override
+        Builder interval(boolean isInterval);
 
         @Override
         AlertImpl build();

--- a/graylog2-server/src/main/java/org/graylog2/alerts/AlertImpl.java
+++ b/graylog2-server/src/main/java/org/graylog2/alerts/AlertImpl.java
@@ -25,6 +25,7 @@ import org.joda.time.DateTime;
 import org.mongojack.Id;
 import org.mongojack.ObjectId;
 
+import javax.annotation.Nullable;
 import java.util.Date;
 import java.util.Map;
 
@@ -38,6 +39,7 @@ public abstract class AlertImpl implements Alert {
     static final String FIELD_DESCRIPTION = "description";
     static final String FIELD_CONDITION_PARAMETERS = "condition_parameters";
     static final String FIELD_TRIGGERED_AT = "triggered_at";
+    static final String FIELD_RESOLVED_AT = "resolved_at";
 
     @JsonProperty(FIELD_ID)
     @Override
@@ -57,6 +59,11 @@ public abstract class AlertImpl implements Alert {
     @Override
     public abstract DateTime getTriggeredAt();
 
+    @JsonProperty(FIELD_RESOLVED_AT)
+    @Override
+    @Nullable
+    public abstract DateTime getResolvedAt();
+
     @JsonProperty(FIELD_DESCRIPTION)
     @Override
     public abstract String getDescription();
@@ -74,6 +81,7 @@ public abstract class AlertImpl implements Alert {
                                    @JsonProperty(FIELD_STREAM_ID) String streamId,
                                    @JsonProperty(FIELD_CONDITION_ID) String conditionId,
                                    @JsonProperty(FIELD_TRIGGERED_AT) Date triggeredAt,
+                                   @JsonProperty(FIELD_RESOLVED_AT) Date resolvedAt,
                                    @JsonProperty(FIELD_DESCRIPTION) String description,
                                    @JsonProperty(FIELD_CONDITION_PARAMETERS) Map<String, Object> conditionParameters) {
         return builder()
@@ -81,6 +89,7 @@ public abstract class AlertImpl implements Alert {
             .streamId(streamId)
             .conditionId(conditionId)
             .triggeredAt(new DateTime(triggeredAt))
+            .resolvedAt(resolvedAt == null ? null : new DateTime(resolvedAt))
             .description(description)
             .conditionParameters(conditionParameters)
             .build();
@@ -95,6 +104,8 @@ public abstract class AlertImpl implements Alert {
         Builder conditionId(String conditionId);
         @Override
         Builder triggeredAt(DateTime triggeredAt);
+        @Override
+        Builder resolvedAt(DateTime resolvedAt);
         @Override
         Builder description(String description);
         @Override

--- a/graylog2-server/src/main/java/org/graylog2/alerts/AlertImpl.java
+++ b/graylog2-server/src/main/java/org/graylog2/alerts/AlertImpl.java
@@ -92,6 +92,8 @@ public abstract class AlertImpl implements Alert {
         return new AutoValue_AlertImpl.Builder();
     }
 
+    public abstract Builder toBuilder();
+
     @JsonCreator
     public static AlertImpl create(@JsonProperty(FIELD_ID) @ObjectId @Id String id,
                                    @JsonProperty(FIELD_STREAM_ID) String streamId,
@@ -116,16 +118,6 @@ public abstract class AlertImpl implements Alert {
                 checkResult.getResultDescription(),
                 ImmutableMap.copyOf(checkResult.getTriggeredCondition().getParameters()),
                 true);
-    }
-
-    public static AlertImpl create(String id,
-                                   String streamId,
-                                   String conditionId,
-                                   DateTime triggeredAt,
-                                   DateTime resolvedAt,
-                                   String description,
-                                   Map<String, Object> conditionParameters) {
-        return create(id, streamId, conditionId, triggeredAt, resolvedAt, description, conditionParameters, true);
     }
 
     public static AlertImpl create(String id,

--- a/graylog2-server/src/main/java/org/graylog2/alerts/AlertImpl.java
+++ b/graylog2-server/src/main/java/org/graylog2/alerts/AlertImpl.java
@@ -20,7 +20,9 @@ import com.fasterxml.jackson.annotation.JsonAutoDetect;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.auto.value.AutoValue;
+import com.google.common.collect.ImmutableMap;
 import org.graylog2.database.CollectionName;
+import org.graylog2.plugin.alarms.AlertCondition;
 import org.joda.time.DateTime;
 import org.mongojack.Id;
 import org.mongojack.ObjectId;
@@ -104,6 +106,17 @@ public abstract class AlertImpl implements Alert {
         return create(id, streamId, conditionId, triggeredAt, resolvedAt, description, conditionParameters, isInterval);
     }
 
+    public static AlertImpl fromCheckResult(AlertCondition.CheckResult checkResult) {
+        return create(new org.bson.types.ObjectId().toHexString(),
+                checkResult.getTriggeredCondition().getStream().getId(),
+                checkResult.getTriggeredCondition().getId(),
+                checkResult.getTriggeredAt(),
+                null,
+                checkResult.getResultDescription(),
+                ImmutableMap.copyOf(checkResult.getTriggeredCondition().getParameters()),
+                true);
+    }
+
     public static AlertImpl create(String id,
                                    String streamId,
                                    String conditionId,
@@ -135,24 +148,23 @@ public abstract class AlertImpl implements Alert {
     }
 
     @AutoValue.Builder
-    public interface Builder extends Alert.Builder {
+    public interface Builder {
         Builder id(String id);
-        @Override
+
         Builder streamId(String streamId);
-        @Override
+
         Builder conditionId(String conditionId);
-        @Override
+
         Builder triggeredAt(DateTime triggeredAt);
-        @Override
+
         Builder resolvedAt(DateTime resolvedAt);
-        @Override
+
         Builder description(String description);
-        @Override
+
         Builder conditionParameters(Map<String, Object> conditionParameters);
-        @Override
+
         Builder interval(boolean isInterval);
 
-        @Override
         AlertImpl build();
     }
 }

--- a/graylog2-server/src/main/java/org/graylog2/alerts/AlertImpl.java
+++ b/graylog2-server/src/main/java/org/graylog2/alerts/AlertImpl.java
@@ -97,11 +97,12 @@ public abstract class AlertImpl implements Alert {
                                    @JsonProperty(FIELD_STREAM_ID) String streamId,
                                    @JsonProperty(FIELD_CONDITION_ID) String conditionId,
                                    @JsonProperty(FIELD_TRIGGERED_AT) Date triggeredAtDate,
-                                   @JsonProperty(FIELD_RESOLVED_AT) Date resolvedAtDate,
+                                   @JsonProperty(FIELD_RESOLVED_AT) @Nullable Date resolvedAtDate,
                                    @JsonProperty(FIELD_DESCRIPTION) String description,
                                    @JsonProperty(FIELD_CONDITION_PARAMETERS) Map<String, Object> conditionParameters,
                                    @JsonProperty(FIELD_IS_INTERVAL) boolean isInterval) {
         final DateTime triggeredAt = new DateTime(triggeredAtDate);
+        // We need to ensure that Alerts with a non-existing or null resolvedAt do not set the field to the current time.
         final DateTime resolvedAt = resolvedAtDate == null ? null : new DateTime(resolvedAtDate);
         return create(id, streamId, conditionId, triggeredAt, resolvedAt, description, conditionParameters, isInterval);
     }

--- a/graylog2-server/src/main/java/org/graylog2/alerts/AlertService.java
+++ b/graylog2-server/src/main/java/org/graylog2/alerts/AlertService.java
@@ -25,6 +25,7 @@ import org.joda.time.DateTime;
 
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 
 public interface AlertService {
     Alert factory(AlertCondition.CheckResult checkResult);
@@ -32,6 +33,8 @@ public interface AlertService {
     List<Alert> loadRecentOfStream(String streamId, DateTime since, int limit);
 
     int triggeredSecondsAgo(String streamId, String conditionId);
+
+    Optional<Alert> getLastTriggeredAlert(String streamId, String conditionId);
 
     long totalCount();
     long totalCountForStream(String streamId);
@@ -47,4 +50,6 @@ public interface AlertService {
     Alert load(String alertId, String streamId) throws NotFoundException;
     String save(Alert alert) throws ValidationException;
 
+    Alert resolveAlert(Alert alert);
+    boolean isResolved(Alert alert);
 }

--- a/graylog2-server/src/main/java/org/graylog2/alerts/AlertService.java
+++ b/graylog2-server/src/main/java/org/graylog2/alerts/AlertService.java
@@ -30,6 +30,7 @@ import java.util.Optional;
 public interface AlertService {
     Alert factory(AlertCondition.CheckResult checkResult);
 
+    List<Alert> loadRecentOfStreams(DateTime since, int limit);
     List<Alert> loadRecentOfStream(String streamId, DateTime since, int limit);
 
     int triggeredSecondsAgo(String streamId, String conditionId);

--- a/graylog2-server/src/main/java/org/graylog2/alerts/AlertService.java
+++ b/graylog2-server/src/main/java/org/graylog2/alerts/AlertService.java
@@ -26,9 +26,6 @@ import org.joda.time.DateTime;
 import java.util.List;
 import java.util.Map;
 
-/**
- * @author Dennis Oelkers <dennis@torch.sh>
- */
 public interface AlertService {
     Alert factory(AlertCondition.CheckResult checkResult);
 
@@ -50,5 +47,4 @@ public interface AlertService {
     Alert load(String alertId, String streamId) throws NotFoundException;
     String save(Alert alert) throws ValidationException;
 
-    Alert.Builder builder();
 }

--- a/graylog2-server/src/main/java/org/graylog2/alerts/AlertService.java
+++ b/graylog2-server/src/main/java/org/graylog2/alerts/AlertService.java
@@ -30,7 +30,7 @@ import java.util.Optional;
 public interface AlertService {
     Alert factory(AlertCondition.CheckResult checkResult);
 
-    List<Alert> loadRecentOfStreams(DateTime since, int limit);
+    List<Alert> loadRecentOfStreams(List<String> streamIds, DateTime since, int limit);
     List<Alert> loadRecentOfStream(String streamId, DateTime since, int limit);
 
     int triggeredSecondsAgo(String streamId, String conditionId);

--- a/graylog2-server/src/main/java/org/graylog2/alerts/AlertServiceImpl.java
+++ b/graylog2-server/src/main/java/org/graylog2/alerts/AlertServiceImpl.java
@@ -28,6 +28,7 @@ import org.graylog2.plugin.database.ValidationException;
 import org.graylog2.plugin.streams.Stream;
 import org.graylog2.rest.models.streams.alerts.requests.CreateConditionRequest;
 import org.joda.time.DateTime;
+import org.joda.time.DateTimeZone;
 import org.joda.time.Seconds;
 import org.mongojack.DBQuery;
 import org.mongojack.DBSort;
@@ -64,10 +65,11 @@ public class AlertServiceImpl implements AlertService {
 
     @Override
     public List<Alert> loadRecentOfStream(String streamId, DateTime since, int limit) {
+        final DateTime effectiveSince = (since == null ? new DateTime(0L, DateTimeZone.UTC) : since);
         return Collections.unmodifiableList(this.coll.find(
             DBQuery.and(
                 DBQuery.is(AlertImpl.FIELD_STREAM_ID, streamId),
-                DBQuery.greaterThanEquals(AlertImpl.FIELD_TRIGGERED_AT, since)
+                DBQuery.greaterThanEquals(AlertImpl.FIELD_TRIGGERED_AT, effectiveSince.toDate())
             )
         )
             .limit(limit)

--- a/graylog2-server/src/main/java/org/graylog2/alerts/AlertServiceImpl.java
+++ b/graylog2-server/src/main/java/org/graylog2/alerts/AlertServiceImpl.java
@@ -16,10 +16,8 @@
  */
 package org.graylog2.alerts;
 
-import com.google.common.collect.ImmutableMap;
 import com.mongodb.BasicDBObject;
 import com.mongodb.DBCollection;
-import org.bson.types.ObjectId;
 import org.graylog2.bindings.providers.MongoJackObjectMapperProvider;
 import org.graylog2.database.CollectionName;
 import org.graylog2.database.MongoConnection;
@@ -58,22 +56,9 @@ public class AlertServiceImpl implements AlertService {
     }
 
     @Override
-    public Alert.Builder builder() {
-        return AlertImpl.builder()
-            .id(new ObjectId().toHexString());
-    }
-
-    @Override
     public Alert factory(AlertCondition.CheckResult checkResult) {
         checkArgument(checkResult.isTriggered(), "Unable to create alert for CheckResult which is not triggered.");
-        return builder()
-            .streamId(checkResult.getTriggeredCondition().getStream().getId())
-            .conditionId(checkResult.getTriggeredCondition().getId())
-            .description(checkResult.getResultDescription())
-            .conditionParameters(ImmutableMap.copyOf(checkResult.getTriggeredCondition().getParameters()))
-            .triggeredAt(checkResult.getTriggeredAt())
-            .interval(true)
-            .build();
+        return AlertImpl.fromCheckResult(checkResult);
     }
 
     @Override

--- a/graylog2-server/src/main/java/org/graylog2/alerts/AlertServiceImpl.java
+++ b/graylog2-server/src/main/java/org/graylog2/alerts/AlertServiceImpl.java
@@ -209,14 +209,7 @@ public class AlertServiceImpl implements AlertService {
             return alert;
         }
 
-        final AlertImpl updatedAlert = AlertImpl.create(
-                alert.getId(),
-                alert.getStreamId(),
-                alert.getConditionId(),
-                alert.getTriggeredAt(),
-                Tools.nowUTC(),
-                alert.getDescription(),
-                alert.getConditionParameters());
+        final AlertImpl updatedAlert = ((AlertImpl) alert).toBuilder().resolvedAt(Tools.nowUTC()).build();
         this.coll.save(updatedAlert);
 
         return updatedAlert;

--- a/graylog2-server/src/main/java/org/graylog2/alerts/AlertServiceImpl.java
+++ b/graylog2-server/src/main/java/org/graylog2/alerts/AlertServiceImpl.java
@@ -40,7 +40,6 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.stream.Collectors;
 
 import static com.google.common.base.Preconditions.checkArgument;
 
@@ -73,6 +72,7 @@ public class AlertServiceImpl implements AlertService {
             .description(checkResult.getResultDescription())
             .conditionParameters(ImmutableMap.copyOf(checkResult.getTriggeredCondition().getParameters()))
             .triggeredAt(checkResult.getTriggeredAt())
+            .interval(true)
             .build();
     }
 

--- a/graylog2-server/src/main/java/org/graylog2/rest/models/streams/alerts/AlertSummary.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/models/streams/alerts/AlertSummary.java
@@ -22,6 +22,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.auto.value.AutoValue;
 import org.joda.time.DateTime;
 
+import javax.annotation.Nullable;
 import java.util.Map;
 
 @AutoValue
@@ -45,13 +46,22 @@ public abstract class AlertSummary {
     @JsonProperty("triggered_at")
     public abstract DateTime triggeredAt();
 
+    @JsonProperty("resolved_at")
+    @Nullable
+    public abstract DateTime resolvedAt();
+
+    @JsonProperty("is_interval")
+    public abstract boolean isInterval();
+
     @JsonCreator
     public static AlertSummary create(@JsonProperty("id") String id,
                                       @JsonProperty("condition_id") String conditionId,
                                       @JsonProperty("stream_id") String streamId,
                                       @JsonProperty("description") String description,
                                       @JsonProperty("condition_parameters") Map<String, Object> conditionParameters,
-                                      @JsonProperty("triggered_at") DateTime triggeredAt) {
-        return new AutoValue_AlertSummary(id, conditionId, streamId, description, conditionParameters, triggeredAt);
+                                      @JsonProperty("triggered_at") DateTime triggeredAt,
+                                      @JsonProperty("resolved_at") DateTime resolvedAt,
+                                      @JsonProperty("is_interval") boolean isInterval) {
+        return new AutoValue_AlertSummary(id, conditionId, streamId, description, conditionParameters, triggeredAt, resolvedAt, isInterval);
     }
 }

--- a/graylog2-server/src/main/java/org/graylog2/rest/resources/alerts/AlertResource.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/resources/alerts/AlertResource.java
@@ -24,7 +24,6 @@ import io.swagger.annotations.ApiResponse;
 import io.swagger.annotations.ApiResponses;
 import org.apache.shiro.authz.annotation.RequiresAuthentication;
 import org.apache.shiro.authz.annotation.RequiresPermissions;
-import org.graylog2.alerts.Alert;
 import org.graylog2.alerts.AlertService;
 import org.graylog2.database.NotFoundException;
 import org.graylog2.rest.models.streams.alerts.AlertListSummary;
@@ -78,7 +77,15 @@ public class AlertResource extends RestResource {
         final List<AlertSummary> alerts = streamService.loadAll().stream()
                 .filter(stream -> isPermitted(RestPermissions.STREAMS_READ, stream.getId()))
                 .flatMap(stream -> alertService.loadRecentOfStream(stream.getId(), since, limit).stream())
-                .map(alert -> AlertSummary.create(alert.getId(), alert.getConditionId(), alert.getStreamId(), alert.getDescription(), alert.getConditionParameters(), alert.getTriggeredAt()))
+                .map(alert -> AlertSummary.create(
+                        alert.getId(),
+                        alert.getConditionId(),
+                        alert.getStreamId(),
+                        alert.getDescription(),
+                        alert.getConditionParameters(),
+                        alert.getTriggeredAt(),
+                        alert.getResolvedAt(),
+                        alert.isInterval()))
                 .collect(Collectors.toList());
 
         return AlertListSummary.create(alerts.size(), alerts);

--- a/graylog2-server/src/main/java/org/graylog2/rest/resources/alerts/AlertResource.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/resources/alerts/AlertResource.java
@@ -23,9 +23,9 @@ import io.swagger.annotations.ApiParam;
 import io.swagger.annotations.ApiResponse;
 import io.swagger.annotations.ApiResponses;
 import org.apache.shiro.authz.annotation.RequiresAuthentication;
-import org.apache.shiro.authz.annotation.RequiresPermissions;
 import org.graylog2.alerts.AlertService;
 import org.graylog2.database.NotFoundException;
+import org.graylog2.plugin.database.Persisted;
 import org.graylog2.rest.models.streams.alerts.AlertListSummary;
 import org.graylog2.rest.models.streams.alerts.AlertSummary;
 import org.graylog2.shared.rest.resources.RestResource;
@@ -49,7 +49,6 @@ import java.util.stream.Collectors;
 @Api(value = "Alerts", description = "Manage stream alerts for all streams")
 @Path("/streams/alerts")
 public class AlertResource extends RestResource {
-    private static final int DEFAULT_MAX_LIST_COUNT = 300;
     private final StreamService streamService;
     private final AlertService alertService;
 
@@ -63,7 +62,6 @@ public class AlertResource extends RestResource {
     @GET
     @Timed
     @ApiOperation(value = "Get the most recent alarms of all streams.")
-    @RequiresPermissions(RestPermissions.STREAMS_READ)
     @Produces(MediaType.APPLICATION_JSON)
     @ApiResponses(value = {
             @ApiResponse(code = 400, message = "Invalid ObjectId.")
@@ -74,9 +72,12 @@ public class AlertResource extends RestResource {
                                     @QueryParam("limit") @DefaultValue("300") @Min(1) int limit) throws NotFoundException {
         final DateTime since = new DateTime(sinceTs * 1000L, DateTimeZone.UTC);
 
-        final List<AlertSummary> alerts = streamService.loadAll().stream()
+        final List<String> allowedStreamIds = streamService.loadAll().stream()
                 .filter(stream -> isPermitted(RestPermissions.STREAMS_READ, stream.getId()))
-                .flatMap(stream -> alertService.loadRecentOfStreams(since, limit).stream())
+                .map(Persisted::getId)
+                .collect(Collectors.toList());
+
+        final List<AlertSummary> alerts = alertService.loadRecentOfStreams(allowedStreamIds, since, limit).stream()
                 .map(alert -> AlertSummary.create(
                         alert.getId(),
                         alert.getConditionId(),

--- a/graylog2-server/src/main/java/org/graylog2/rest/resources/alerts/AlertResource.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/resources/alerts/AlertResource.java
@@ -76,7 +76,7 @@ public class AlertResource extends RestResource {
 
         final List<AlertSummary> alerts = streamService.loadAll().stream()
                 .filter(stream -> isPermitted(RestPermissions.STREAMS_READ, stream.getId()))
-                .flatMap(stream -> alertService.loadRecentOfStream(stream.getId(), since, limit).stream())
+                .flatMap(stream -> alertService.loadRecentOfStreams(since, limit).stream())
                 .map(alert -> AlertSummary.create(
                         alert.getId(),
                         alert.getConditionId(),

--- a/graylog2-server/src/main/java/org/graylog2/rest/resources/streams/alerts/StreamAlertResource.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/resources/streams/alerts/StreamAlertResource.java
@@ -322,7 +322,9 @@ public class StreamAlertResource extends RestResource {
                         alert.getStreamId(),
                         alert.getDescription(),
                         alert.getConditionParameters(),
-                        alert.getTriggeredAt()))
+                        alert.getTriggeredAt(),
+                        alert.getResolvedAt(),
+                        alert.isInterval()))
                 .collect(Collectors.toList());
     }
 }

--- a/graylog2-server/src/test/java/org/graylog2/alerts/AlertServiceImplTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/alerts/AlertServiceImplTest.java
@@ -21,10 +21,14 @@ import com.lordofthejars.nosqlunit.annotation.UsingDataSet;
 import com.lordofthejars.nosqlunit.core.LoadStrategyEnum;
 import org.graylog2.database.MongoDBServiceTest;
 import org.graylog2.plugin.Tools;
+import org.joda.time.DateTime;
+import org.joda.time.DateTimeZone;
 import org.joda.time.Seconds;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mock;
+
+import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -40,6 +44,20 @@ public class AlertServiceImplTest extends MongoDBServiceTest {
     @Before
     public void setUpService() throws Exception {
         this.alertService = new AlertServiceImpl(mongoRule.getMongoConnection(), mapperProvider, alertConditionFactory);
+    }
+
+    @Test
+    @UsingDataSet(locations = "multiple-alerts.json")
+    public void loadRecentOfStreamQueriesByDate() throws Exception {
+        final List<Alert> alerts = alertService.loadRecentOfStream(STREAM_ID, new DateTime(0L, DateTimeZone.UTC), 300);
+        assertThat(alerts.size()).isEqualTo(2);
+    }
+
+    @Test
+    @UsingDataSet(locations = "multiple-alerts.json")
+    public void loadRecentOfStreamLimitResults() throws Exception {
+        final List<Alert> alerts = alertService.loadRecentOfStream(STREAM_ID, new DateTime(0L, DateTimeZone.UTC), 1);
+        assertThat(alerts.size()).isEqualTo(1);
     }
 
     @Test

--- a/graylog2-server/src/test/java/org/graylog2/alerts/AlertServiceImplTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/alerts/AlertServiceImplTest.java
@@ -1,3 +1,20 @@
+/**
+ * This file is part of Graylog.
+ *
+ * Graylog is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
 package org.graylog2.alerts;
 
 import com.lordofthejars.nosqlunit.annotation.UsingDataSet;

--- a/graylog2-server/src/test/java/org/graylog2/alerts/AlertServiceImplTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/alerts/AlertServiceImplTest.java
@@ -61,6 +61,13 @@ public class AlertServiceImplTest extends MongoDBServiceTest {
     }
 
     @Test
+    @UsingDataSet(locations = "multiple-alerts.json")
+    public void loadRecentOfStreamLimitsResults() throws Exception {
+        final List<Alert> alerts = alertService.loadRecentOfStreams(new DateTime(0L, DateTimeZone.UTC), 1);
+        assertThat(alerts.size()).isEqualTo(1);
+    }
+
+    @Test
     @UsingDataSet(locations = "unresolved-alert.json")
     public void triggeredSecondsAgoOnExistingAlert() throws Exception {
         final Alert alert = alertService.load(ALERT_ID, STREAM_ID);

--- a/graylog2-server/src/test/java/org/graylog2/alerts/AlertServiceImplTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/alerts/AlertServiceImplTest.java
@@ -17,6 +17,7 @@
 
 package org.graylog2.alerts;
 
+import com.google.common.collect.ImmutableList;
 import com.lordofthejars.nosqlunit.annotation.UsingDataSet;
 import com.lordofthejars.nosqlunit.core.LoadStrategyEnum;
 import org.graylog2.database.MongoDBServiceTest;
@@ -62,8 +63,33 @@ public class AlertServiceImplTest extends MongoDBServiceTest {
 
     @Test
     @UsingDataSet(locations = "multiple-alerts.json")
-    public void loadRecentOfStreamLimitsResults() throws Exception {
-        final List<Alert> alerts = alertService.loadRecentOfStreams(new DateTime(0L, DateTimeZone.UTC), 1);
+    public void loadRecentOfStreamsIsEmptyIfNoStreams() throws Exception {
+        final List<Alert> alerts = alertService.loadRecentOfStreams(
+                ImmutableList.of(),
+                new DateTime(0L, DateTimeZone.UTC),
+                300);
+        assertThat(alerts.size()).isEqualTo(0);
+    }
+
+    @Test
+    @UsingDataSet(locations = "multiple-alerts.json")
+    public void loadRecentOfStreamsFiltersByStream() throws Exception {
+        final List<Alert> alerts = alertService.loadRecentOfStreams(
+                ImmutableList.of("5666df42bee80072613ce14d", "5666df42bee80072613ce14f"),
+                new DateTime(0L, DateTimeZone.UTC),
+                300);
+        assertThat(alerts.size()).isEqualTo(2);
+        assertThat(alerts.get(0).getStreamId()).isNotEqualTo(STREAM_ID);
+        assertThat(alerts.get(1).getStreamId()).isNotEqualTo(STREAM_ID);
+    }
+
+    @Test
+    @UsingDataSet(locations = "multiple-alerts.json")
+    public void loadRecentOfStreamsLimitsResults() throws Exception {
+        final List<Alert> alerts = alertService.loadRecentOfStreams(
+                ImmutableList.of("5666df42bee80072613ce14d", "5666df42bee80072613ce14e", "5666df42bee80072613ce14f"),
+                new DateTime(0L, DateTimeZone.UTC),
+                1);
         assertThat(alerts.size()).isEqualTo(1);
     }
 

--- a/graylog2-server/src/test/java/org/graylog2/alerts/AlertServiceImplTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/alerts/AlertServiceImplTest.java
@@ -1,0 +1,99 @@
+package org.graylog2.alerts;
+
+import com.lordofthejars.nosqlunit.annotation.UsingDataSet;
+import com.lordofthejars.nosqlunit.core.LoadStrategyEnum;
+import org.graylog2.database.MongoDBServiceTest;
+import org.graylog2.plugin.Tools;
+import org.joda.time.Seconds;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mock;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class AlertServiceImplTest extends MongoDBServiceTest {
+    private final String ALERT_ID = "581b3bff8e4dc4270055dfca";
+    private final String STREAM_ID = "5666df42bee80072613ce14e";
+    private final String CONDITION_ID = "ae7fbc4e-81b1-41b3-bbe6-eaf58d89bff7";
+
+    private AlertServiceImpl alertService;
+    @Mock
+    private AlertConditionFactory alertConditionFactory;
+
+    @Before
+    public void setUpService() throws Exception {
+        this.alertService = new AlertServiceImpl(mongoRule.getMongoConnection(), mapperProvider, alertConditionFactory);
+    }
+
+    @Test
+    @UsingDataSet(locations = "unresolved-alert.json")
+    public void triggeredSecondsAgoOnExistingAlert() throws Exception {
+        final Alert alert = alertService.load(ALERT_ID, STREAM_ID);
+        final int expectedResult = Seconds.secondsBetween(alert.getTriggeredAt(), Tools.nowUTC()).getSeconds();
+        // Add a second threshold in case the clock changed since the previous call to Tools.nowUTC()
+        assertThat(alertService.triggeredSecondsAgo(STREAM_ID, CONDITION_ID)).isBetween(expectedResult, expectedResult + 1);
+    }
+
+    @Test
+    @UsingDataSet(loadStrategy = LoadStrategyEnum.DELETE_ALL)
+    public void triggeredSecondsAgoOnNonExistingAlert() throws Exception {
+        assertThat(alertService.triggeredSecondsAgo(STREAM_ID, CONDITION_ID)).isEqualTo(-1);
+    }
+
+    @Test
+    @UsingDataSet(locations = "unresolved-alert.json")
+    public void resolveUnresolvedAlert() throws Exception {
+        final Alert originalAlert = alertService.load(ALERT_ID, STREAM_ID);
+        assertThat(originalAlert.getResolvedAt()).isNull();
+        final Alert alert = alertService.resolveAlert(originalAlert);
+        assertThat(alertService.load(ALERT_ID, STREAM_ID).getResolvedAt().isEqual(alert.getResolvedAt())).isTrue();
+        assertThat(alertService.load(ALERT_ID, STREAM_ID).getResolvedAt()).isNotNull();
+    }
+
+    @Test
+    @UsingDataSet(locations = "resolved-alert.json")
+    public void resolveNoopInResolvedAlert() throws Exception {
+        final Alert originalAlert = alertService.load(ALERT_ID, STREAM_ID);
+        assertThat(originalAlert.getResolvedAt()).isNotNull();
+        final Alert alert = alertService.resolveAlert(originalAlert);
+        assertThat(alert.getResolvedAt()).isEqualTo(originalAlert.getResolvedAt());
+    }
+
+    @Test
+    @UsingDataSet(loadStrategy = LoadStrategyEnum.DELETE_ALL)
+    public void resolveNoopIfNoAlert() throws Exception {
+        final Alert alert = alertService.resolveAlert(null);
+        assertThat(alert).isNull();
+    }
+
+    @Test
+    @UsingDataSet(locations = "non-interval-alert.json")
+    public void resolveNoopIfNonIntervalAlert() throws Exception {
+        final Alert originalAlert = alertService.load(ALERT_ID, STREAM_ID);
+        final Alert alert = alertService.resolveAlert(originalAlert);
+        assertThat(alert.isInterval()).isFalse();
+        assertThat(alert.getResolvedAt()).isNull();
+    }
+
+    @Test
+    @UsingDataSet(locations = "resolved-alert.json")
+    public void resolvedAlertIsResolved() throws Exception {
+        final Alert alert = alertService.load(ALERT_ID, STREAM_ID);
+        assertThat(alertService.isResolved(alert)).isTrue();
+    }
+
+    @Test
+    @UsingDataSet(locations = "non-interval-alert.json")
+    public void nonIntervalAlertIsResolved() throws Exception {
+        final Alert alert = alertService.load(ALERT_ID, STREAM_ID);
+        assertThat(alertService.isResolved(alert)).isTrue();
+    }
+
+    @Test
+    @UsingDataSet(locations = "unresolved-alert.json")
+    public void unresolvedAlertIsUnresolved() throws Exception {
+        final Alert alert = alertService.load(ALERT_ID, STREAM_ID);
+        assertThat(alertService.isResolved(alert)).isFalse();
+    }
+
+}

--- a/graylog2-server/src/test/resources/org/graylog2/alerts/multiple-alerts.json
+++ b/graylog2-server/src/test/resources/org/graylog2/alerts/multiple-alerts.json
@@ -59,6 +59,28 @@
         "backlog": 0
       },
       "is_interval": true
+    },
+    {
+      "_id": {
+        "$oid": "581b3bff8e4dc4270055dfcd"
+      },
+      "triggered_at": {
+        "$date": "2016-11-03T15:30:39Z"
+      },
+      "resolved_at": {
+        "$date": "2016-11-03T15:35:39Z"
+      },
+      "stream_id": "5666df42bee80072613ce14d",
+      "condition_id": "ae7fbc4e-81b1-41b3-bbe6-eaf58d89bff7",
+      "description": "Stream had 199 messages in the last 1 minutes with trigger condition more than 5 messages. (Current grace time: 0 minutes)",
+      "condition_parameters": {
+        "grace": 0,
+        "threshold": "5",
+        "threshold_type": "MORE",
+        "time": "1",
+        "backlog": 0
+      },
+      "is_interval": true
     }
   ]
 }

--- a/graylog2-server/src/test/resources/org/graylog2/alerts/multiple-alerts.json
+++ b/graylog2-server/src/test/resources/org/graylog2/alerts/multiple-alerts.json
@@ -1,0 +1,64 @@
+{
+  "alerts": [
+    {
+      "_id": {
+        "$oid": "581b3bff8e4dc4270055dfca"
+      },
+      "triggered_at": {
+        "$date": "2016-11-03T15:30:39Z"
+      },
+      "stream_id": "5666df42bee80072613ce14e",
+      "condition_id": "ae7fbc4e-81b1-41b3-bbe6-eaf58d89bff7",
+      "description": "Stream had 199 messages in the last 1 minutes with trigger condition more than 5 messages. (Current grace time: 0 minutes)",
+      "condition_parameters": {
+        "grace": 0,
+        "threshold": "5",
+        "threshold_type": "MORE",
+        "time": "1",
+        "backlog": 0
+      },
+      "is_interval": true
+    },
+    {
+      "_id": {
+        "$oid": "581b3bff8e4dc4270055dfcb"
+      },
+      "triggered_at": {
+        "$date": "2016-11-03T15:30:39Z"
+      },
+      "stream_id": "5666df42bee80072613ce14e",
+      "condition_id": "ae7fbc4e-81b1-41b3-bbe6-eaf58d89bff7",
+      "description": "Stream had 199 messages in the last 1 minutes with trigger condition more than 5 messages. (Current grace time: 0 minutes)",
+      "condition_parameters": {
+        "grace": 0,
+        "threshold": "5",
+        "threshold_type": "MORE",
+        "time": "1",
+        "backlog": 0
+      },
+      "is_interval": false
+    },
+    {
+      "_id": {
+        "$oid": "581b3bff8e4dc4270055dfcc"
+      },
+      "triggered_at": {
+        "$date": "2016-11-03T15:30:39Z"
+      },
+      "resolved_at": {
+        "$date": "2016-11-03T15:35:39Z"
+      },
+      "stream_id": "5666df42bee80072613ce14f",
+      "condition_id": "ae7fbc4e-81b1-41b3-bbe6-eaf58d89bff7",
+      "description": "Stream had 199 messages in the last 1 minutes with trigger condition more than 5 messages. (Current grace time: 0 minutes)",
+      "condition_parameters": {
+        "grace": 0,
+        "threshold": "5",
+        "threshold_type": "MORE",
+        "time": "1",
+        "backlog": 0
+      },
+      "is_interval": true
+    }
+  ]
+}

--- a/graylog2-server/src/test/resources/org/graylog2/alerts/non-interval-alert.json
+++ b/graylog2-server/src/test/resources/org/graylog2/alerts/non-interval-alert.json
@@ -1,0 +1,23 @@
+{
+  "alerts": [
+    {
+      "_id": {
+        "$oid": "581b3bff8e4dc4270055dfca"
+      },
+      "triggered_at": {
+        "$date": "2016-11-03T15:30:39Z"
+      },
+      "stream_id": "5666df42bee80072613ce14e",
+      "condition_id": "ae7fbc4e-81b1-41b3-bbe6-eaf58d89bff7",
+      "description": "Stream had 199 messages in the last 1 minutes with trigger condition more than 5 messages. (Current grace time: 0 minutes)",
+      "condition_parameters": {
+        "grace": 0,
+        "threshold": "5",
+        "threshold_type": "MORE",
+        "time": "1",
+        "backlog": 0
+      },
+      "is_interval": false
+    }
+  ]
+}

--- a/graylog2-server/src/test/resources/org/graylog2/alerts/resolved-alert.json
+++ b/graylog2-server/src/test/resources/org/graylog2/alerts/resolved-alert.json
@@ -1,0 +1,26 @@
+{
+  "alerts": [
+    {
+      "_id": {
+        "$oid": "581b3bff8e4dc4270055dfca"
+      },
+      "triggered_at": {
+        "$date": "2016-11-03T15:30:39Z"
+      },
+      "resolved_at": {
+        "$date": "2016-11-03T15:35:39Z"
+      },
+      "stream_id": "5666df42bee80072613ce14e",
+      "condition_id": "ae7fbc4e-81b1-41b3-bbe6-eaf58d89bff7",
+      "description": "Stream had 199 messages in the last 1 minutes with trigger condition more than 5 messages. (Current grace time: 0 minutes)",
+      "condition_parameters": {
+        "grace": 0,
+        "threshold": "5",
+        "threshold_type": "MORE",
+        "time": "1",
+        "backlog": 0
+      },
+      "is_interval": true
+    }
+  ]
+}

--- a/graylog2-server/src/test/resources/org/graylog2/alerts/unresolved-alert.json
+++ b/graylog2-server/src/test/resources/org/graylog2/alerts/unresolved-alert.json
@@ -1,0 +1,23 @@
+{
+  "alerts": [
+    {
+      "_id": {
+        "$oid": "581b3bff8e4dc4270055dfca"
+      },
+      "triggered_at": {
+        "$date": "2016-11-03T15:30:39Z"
+      },
+      "stream_id": "5666df42bee80072613ce14e",
+      "condition_id": "ae7fbc4e-81b1-41b3-bbe6-eaf58d89bff7",
+      "description": "Stream had 199 messages in the last 1 minutes with trigger condition more than 5 messages. (Current grace time: 0 minutes)",
+      "condition_parameters": {
+        "grace": 0,
+        "threshold": "5",
+        "threshold_type": "MORE",
+        "time": "1",
+        "backlog": 0
+      },
+      "is_interval": true
+    }
+  ]
+}


### PR DESCRIPTION
This PR covers part of the changes required in #2869 and fixes some issues introduced in previous refactorings. In summary:

- Store `triggered_at` as a Date objects in MongoDB, avoiding sorting problems with old `Alert`s
- Add `resolved_at` and `is_interval` to `Alert` model
- Add support for resolving `Alert`s once the condition is not triggered
- Simplify `Alert` and `AlertService` interfaces
- Use a `Date` object to query `Alert` objects by the `triggered_at` field, avoiding problems with `MongoJack`
- Honour `limit` parameter in `AlertResource`
- Add some tests to ensure modified and new code works as expected™