### PR TITLE
treat meters as counters for the purpose of showing per second rates

### DIFF
--- a/graylog2-web-interface/src/logic/metrics/MetricsExtractor.js
+++ b/graylog2-web-interface/src/logic/metrics/MetricsExtractor.js
@@ -18,6 +18,8 @@ const MetricsExtractor = {
           metrics[metricShortName] = metricObject.metric.value;
         } else if (metricObject.type === 'counter') {
           metrics[metricShortName] = metricObject.metric.count;
+        } else if (metricObject.type === 'meter') {
+          metrics[metricShortName] = metricObject.metric.rate.total;
         } else {
           metrics[metricShortName] = null;
         }


### PR DESCRIPTION
when the ui is requesting total values to display per second rates, metrics that change from counters to meters will break because our internal representation is different.
this extends the ability to display custom rates in the ui (and not only 1/5/15 min rates coming out of meters)

fixes Graylog2/graylog-plugin-pipeline-processor#122