### PR TITLE
Fix VersionEye on Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,7 @@ notifications:
         KvkjCIM7gZy2DTRNUooQPXdJB3npbnlbQn4jNWqA7/fp434Sw5sdfSUMawGr
         XvemLvn0KxQxCO9GfN3wfmYxEWJwXO36Q29BnRWWgMQOXpFFD8A=
 after_success:
+  - curl -X GET https://letsencrypt.org/certs/lets-encrypt-x3-cross-signed.der -o lets-encrypt-x3-cross-signed.der && sudo keytool -trustcacerts -keystore $JAVA_HOME/jre/lib/security/cacerts -storepass changeit -noprompt -importcert -alias lets-encrypt-x3-cross-signed -file lets-encrypt-x3-cross-signed.der
   - mvn -B -Dmaven.test.skip=true -Dskip.web.build=true -pl graylog2-server versioneye:securityAndLicenseCheck
   - mvn -B -Dmaven.test.skip=true -Dskip.web.build=true assembly:single
   - mvn -B -Dmaven.test.skip=true -Dskip.web.build=true --settings config/settings.xml deploy


### PR DESCRIPTION
VersionEye was failing on Travis CI with the following message (due to LetsEncrypt not being supported by Java 8u65):
```
[ERROR] Failed to execute goal com.versioneye:versioneye-maven-plugin:3.10.2:securityAndLicenseCheck (default-cli) on project graylog2-server: Oh no! Something went wrong. Get in touch with the VersionEye guys and give them feedback. You find them on Twitter at https//twitter.com/VersionEye. sun.security.validator.ValidatorException: PKIX path building failed: sun.security.provider.certpath.SunCertPathBuilderException: unable to find valid certification path to requested target -> [Help 1]
```

See https://bitbucket.org/versioneye/versioneye/issues/275/ssl-certificate-issues-when-using-gradle#comment-30124371