### PR TITLE
emit less logging noise when waiting for default stream to be created

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/bindings/providers/DefaultStreamProvider.java
+++ b/graylog2-server/src/main/java/org/graylog2/bindings/providers/DefaultStreamProvider.java
@@ -55,12 +55,16 @@ public class DefaultStreamProvider implements Provider<Stream> {
             if (defaultStream != null) {
                 return defaultStream;
             }
+            int i = 0;
             do {
                 try {
                     LOG.debug("Loading shared default stream instance");
                     defaultStream = service.load(Stream.DEFAULT_STREAM_ID);
                 } catch (NotFoundException ignored) {
-                    LOG.warn("Unable to load default stream, retrying. Processing is blocked until this succeeds.");
+                    if (i % 10 == 0) {
+                        LOG.warn("Unable to load default stream, tried {} times, retrying every 500ms. Processing is blocked until this succeeds.", i + 1);
+                    }
+                    i++;
                     Uninterruptibles.sleepUninterruptibly(500, TimeUnit.MILLISECONDS);
                 }
             } while (defaultStream == null);

--- a/graylog2-server/src/main/java/org/graylog2/periodical/DefaultStreamMigrationPeriodical.java
+++ b/graylog2-server/src/main/java/org/graylog2/periodical/DefaultStreamMigrationPeriodical.java
@@ -17,10 +17,10 @@
 package org.graylog2.periodical;
 
 import com.google.common.collect.ImmutableMap;
+
 import org.bson.types.ObjectId;
 import org.graylog2.database.NotFoundException;
 import org.graylog2.events.ClusterEventBus;
-import org.graylog2.plugin.cluster.ClusterConfigService;
 import org.graylog2.plugin.database.ValidationException;
 import org.graylog2.plugin.periodical.Periodical;
 import org.graylog2.plugin.streams.Stream;
@@ -32,9 +32,10 @@ import org.joda.time.DateTimeZone;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import javax.inject.Inject;
 import java.util.Collections;
 import java.util.Map;
+
+import javax.inject.Inject;
 
 /**
  * Periodical creating the default stream if it doesn't exist.
@@ -44,15 +45,12 @@ public class DefaultStreamMigrationPeriodical extends Periodical {
 
     private final StreamService streamService;
     private final ClusterEventBus clusterEventBus;
-    private final ClusterConfigService clusterConfigService;
 
     @Inject
     public DefaultStreamMigrationPeriodical(final StreamService streamService,
-                                            final ClusterEventBus clusterEventBus,
-                                            final ClusterConfigService clusterConfigService) {
+                                            final ClusterEventBus clusterEventBus) {
         this.streamService = streamService;
         this.clusterEventBus = clusterEventBus;
-        this.clusterConfigService = clusterConfigService;
     }
 
     @Override

--- a/graylog2-server/src/test/java/org/graylog2/periodical/DefaultStreamMigrationPeriodicalTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/periodical/DefaultStreamMigrationPeriodicalTest.java
@@ -48,12 +48,10 @@ public class DefaultStreamMigrationPeriodicalTest {
     private StreamService streamService;
     @Mock
     private ClusterEventBus clusterEventBus;
-    @Mock
-    private ClusterConfigService clusterConfigService;
 
     @Before
     public void setUpService() throws Exception {
-        periodical = new DefaultStreamMigrationPeriodical(streamService, clusterEventBus, clusterConfigService);
+        periodical = new DefaultStreamMigrationPeriodical(streamService, clusterEventBus);
     }
 
     @Test
@@ -94,15 +92,6 @@ public class DefaultStreamMigrationPeriodicalTest {
         periodical.doRun();
 
         verifyNoMoreInteractions(clusterEventBus);
-    }
-
-    @Test
-    public void doRunDoesNotSaveDefaultStreamCreatedClusterConfigIfStreamCreationFails() throws Exception {
-        when(streamService.save(any(Stream.class))).thenThrow(ValidationException.class);
-
-        periodical.doRun();
-
-        verifyNoMoreInteractions(clusterConfigService);
     }
 
     @Test


### PR DESCRIPTION
removes unused member
only log every 10th loop iteration (still shows something often enough should it fail) when waiting for default stream migration