### PR TITLE
Fix problems rendering object field values

### DIFF
--- a/graylog2-web-interface/src/components/search/MessageShow.jsx
+++ b/graylog2-web-interface/src/components/search/MessageShow.jsx
@@ -28,7 +28,7 @@ const MessageShow = React.createClass({
 
   possiblyHighlight(fieldName) {
     // No highlighting for the message details view.
-    return String(this.props.message.fields[fieldName]);
+    return JSON.stringify(this.props.message.fields[fieldName]) || '';
   },
   render() {
     return (

--- a/graylog2-web-interface/src/components/search/MessageTableEntry.jsx
+++ b/graylog2-web-interface/src/components/search/MessageTableEntry.jsx
@@ -30,7 +30,7 @@ const MessageTableEntry = React.createClass({
     if (fullOrigValue === undefined) {
       return '';
     }
-    const fullStringOrigValue = String(fullOrigValue); // Ensure the field is a string for later processing
+    const fullStringOrigValue = JSON.stringify(fullOrigValue); // Ensure the field is a string for later processing
 
     // Truncate the field to 2048 characters if requested. This is for performance reasons to avoid hogging the CPU.
     // It's not optimal, more like a workaround to at least being able to show the page...

--- a/graylog2-web-interface/src/pages/CreateExtractorsPage.jsx
+++ b/graylog2-web-interface/src/pages/CreateExtractorsPage.jsx
@@ -78,7 +78,7 @@ const CreateExtractorsPage = React.createClass({
         <EditExtractor action="create"
                        extractor={this.state.extractor}
                        inputId={this.state.input.id}
-                       exampleMessage={this.state.exampleMessage.fields[this.state.field]}
+                       exampleMessage={JSON.stringify(this.state.exampleMessage.fields[this.state.field]) || ''}
                        onSave={this._extractorSaved}/>
       </div>
     );

--- a/graylog2-web-interface/src/stores/messages/MessagesStore.js
+++ b/graylog2-web-interface/src/stores/messages/MessagesStore.js
@@ -31,7 +31,7 @@ const MessagesStore = Reflux.createStore({
   },
 
   fieldTerms(index, string) {
-    const url = ApiRoutes.MessagesController.analyze(index, string).url;
+    const url = ApiRoutes.MessagesController.analyze(index, JSON.stringify(string)).url;
     const promise = fetch('GET', URLUtils.qualifyUrl(url))
       .then(
         response => response.tokens,


### PR DESCRIPTION
Some messages may contain objects as field values and we need to properly convert them into strings that can be rendered by react.

This commit changes the way we convert values into strings, relying on `JSON.stringify()` to do it.

Refs Graylog2/graylog-plugin-beats#3. It may also be related to #2946.

**Update**: As @joschi pointed out, this only fixes part of the problem in Graylog2/graylog-plugin-beats#3: being able to display messages with a hierarchical structure. The change does not affect how Graylog internally handles those messages.