### PR TITLE
Assign index sets to streams

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/bundles/BundleImporter.java
+++ b/graylog2-server/src/main/java/org/graylog2/bundles/BundleImporter.java
@@ -466,7 +466,7 @@ public class BundleImporter {
                     streamData.build(),
                     Collections.emptyList(),
                     Collections.emptySet(),
-                    Collections.emptySet());
+                    null);
         } else {
             stream = streamService.create(streamData.build());
         }

--- a/graylog2-server/src/main/java/org/graylog2/migrations/MigrationsModule.java
+++ b/graylog2-server/src/main/java/org/graylog2/migrations/MigrationsModule.java
@@ -26,5 +26,6 @@ public class MigrationsModule extends AbstractModule {
         binder.addBinding().to(V20151210140600_ElasticsearchConfigMigration.class);
         binder.addBinding().to(V20160929120500_CreateDefaultStreamMigration.class);
         binder.addBinding().to(V20161116172100_DefaultIndexSetMigration.class);
+        binder.addBinding().to(V20161122174500_AssignIndexSetsToStreamsMigration.class);
     }
 }

--- a/graylog2-server/src/main/java/org/graylog2/migrations/V20160929120500_CreateDefaultStreamMigration.java
+++ b/graylog2-server/src/main/java/org/graylog2/migrations/V20160929120500_CreateDefaultStreamMigration.java
@@ -76,7 +76,7 @@ public class V20160929120500_CreateDefaultStreamMigration extends Migration {
                 .put(StreamImpl.FIELD_REMOVE_MATCHES_FROM_DEFAULT_STREAM, false)
                 .put(StreamImpl.FIELD_DEFAULT_STREAM, true)
                 .build();
-        final Stream stream = new StreamImpl(id, fields, Collections.emptyList(), Collections.emptySet(), Collections.emptySet());
+        final Stream stream = new StreamImpl(id, fields, Collections.emptyList(), Collections.emptySet(), null);
 
         try {
             streamService.save(stream);

--- a/graylog2-server/src/main/java/org/graylog2/migrations/V20160929120500_CreateDefaultStreamMigration.java
+++ b/graylog2-server/src/main/java/org/graylog2/migrations/V20160929120500_CreateDefaultStreamMigration.java
@@ -20,7 +20,6 @@ import com.google.common.collect.ImmutableMap;
 import org.bson.types.ObjectId;
 import org.graylog2.database.NotFoundException;
 import org.graylog2.events.ClusterEventBus;
-import org.graylog2.plugin.database.ValidationException;
 import org.graylog2.plugin.streams.Stream;
 import org.graylog2.streams.StreamImpl;
 import org.graylog2.streams.StreamService;
@@ -78,13 +77,11 @@ public class V20160929120500_CreateDefaultStreamMigration extends Migration {
                 .build();
         final Stream stream = new StreamImpl(id, fields, Collections.emptyList(), Collections.emptySet(), null);
 
-        try {
-            streamService.save(stream);
-            LOG.info("Successfully created default stream: {}", stream.getTitle());
+        // Save without validations here to avoid failing the index set validation which has been added at a later
+        // point in time.
+        streamService.saveWithoutValidation(stream);
+        LOG.info("Successfully created default stream: {}", stream.getTitle());
 
-            clusterEventBus.post(StreamsChangedEvent.create(stream.getId()));
-        } catch (ValidationException e) {
-            LOG.error("Couldn't create default stream", e);
-        }
+        clusterEventBus.post(StreamsChangedEvent.create(stream.getId()));
     }
 }

--- a/graylog2-server/src/main/java/org/graylog2/migrations/V20161122174500_AssignIndexSetsToStreamsMigration.java
+++ b/graylog2-server/src/main/java/org/graylog2/migrations/V20161122174500_AssignIndexSetsToStreamsMigration.java
@@ -1,0 +1,134 @@
+/**
+ * This file is part of Graylog.
+ *
+ * Graylog is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.graylog2.migrations;
+
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.auto.value.AutoValue;
+import com.google.common.collect.ImmutableSet;
+import org.graylog2.events.ClusterEventBus;
+import org.graylog2.indexer.indexset.IndexSetConfig;
+import org.graylog2.indexer.indexset.IndexSetService;
+import org.graylog2.plugin.cluster.ClusterConfigService;
+import org.graylog2.plugin.database.ValidationException;
+import org.graylog2.plugin.streams.Stream;
+import org.graylog2.streams.StreamService;
+import org.graylog2.streams.events.StreamsChangedEvent;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.inject.Inject;
+import java.time.ZonedDateTime;
+import java.util.Set;
+
+import static com.google.common.base.Preconditions.checkState;
+import static com.google.common.base.Strings.isNullOrEmpty;
+
+public class V20161122174500_AssignIndexSetsToStreamsMigration extends Migration {
+    private static final Logger LOG = LoggerFactory.getLogger(V20161122174500_AssignIndexSetsToStreamsMigration.class);
+
+    private final StreamService streamService;
+    private final IndexSetService indexSetService;
+    private final ClusterConfigService clusterConfigService;
+    private final ClusterEventBus clusterEventBus;
+
+    @Inject
+    public V20161122174500_AssignIndexSetsToStreamsMigration(final StreamService streamService,
+                                                             final IndexSetService indexSetService,
+                                                             final ClusterConfigService clusterConfigService,
+                                                             final ClusterEventBus clusterEventBus) {
+        this.streamService = streamService;
+        this.indexSetService = indexSetService;
+        this.clusterConfigService = clusterConfigService;
+        this.clusterEventBus = clusterEventBus;
+    }
+
+    @Override
+    public ZonedDateTime createdAt() {
+        return ZonedDateTime.parse("2016-11-22T17:45:00Z");
+    }
+
+    @Override
+    public void upgrade() {
+        // Only run this migration once.
+        if (clusterConfigService.get(MigrationCompleted.class) != null) {
+            LOG.debug("Migration already completed.");
+            return;
+        }
+
+        final IndexSetConfig indexSetConfig = findDefaultIndexSet();
+        final ImmutableSet.Builder<String> completedStreamIds = ImmutableSet.builder();
+        final ImmutableSet.Builder<String> failedStreamIds = ImmutableSet.builder();
+
+        // Assign the "default index set" to all existing streams. Until now, there was no way to manually create
+        // index sets, so the only one that exists is the "default" one created by an earlier migration.
+        for (Stream stream : streamService.loadAll()) {
+            if (isNullOrEmpty(stream.getIndexSetId())) {
+                LOG.info("Assigning index set <{}> ({}) to stream <{}> ({})", indexSetConfig.id(),
+                        indexSetConfig.title(), stream.getId(), stream.getTitle());
+                stream.setIndexSetId(indexSetConfig.id());
+                try {
+                    streamService.save(stream);
+                    completedStreamIds.add(stream.getId());
+                } catch (ValidationException e) {
+                    LOG.error("Unable to save stream <{}>", stream.getId(), e);
+                    failedStreamIds.add(stream.getId());
+                }
+            }
+        }
+
+        // Mark this migration as done.
+        clusterConfigService.write(MigrationCompleted.create(indexSetConfig.id(), completedStreamIds.build(), failedStreamIds.build()));
+
+        // Make sure the stream router will reload the changed streams.
+        clusterEventBus.post(StreamsChangedEvent.create(completedStreamIds.build()));
+    }
+
+    private IndexSetConfig findDefaultIndexSet() {
+        final Set<IndexSetConfig> indexSetConfigs = indexSetService.findAll();
+
+        // If there is more than one index set, we have a problem. Since there wasn't a way to create index sets
+        // manually until now, this should not happen.
+        checkState(indexSetConfigs.size() < 2, "Found more than one index set config!");
+
+        // If there is no index set, a previous migration didn't work.
+        return indexSetConfigs.stream()
+                .findFirst()
+                .orElseThrow(() -> new IllegalStateException("Couldn't find any index set config!"));
+    }
+
+    @JsonAutoDetect
+    @AutoValue
+    public static abstract class MigrationCompleted {
+        @JsonProperty("index_set_id")
+        public abstract String indexSetId();
+
+        @JsonProperty("completed_stream_ids")
+        public abstract Set<String> completedStreamIds();
+
+        @JsonProperty("failed_stream_ids")
+        public abstract Set<String> failedStreamIds();
+
+        @JsonCreator
+        public static MigrationCompleted create(@JsonProperty("index_set_id") String indexSetId,
+                                                @JsonProperty("completed_stream_ids") Set<String> completedStreamIds,
+                                                @JsonProperty("failed_stream_ids") Set<String> failedStreamIds) {
+            return new AutoValue_V20161122174500_AssignIndexSetsToStreamsMigration_MigrationCompleted(indexSetId, completedStreamIds, failedStreamIds);
+        }
+    }
+}

--- a/graylog2-server/src/main/java/org/graylog2/plugin/Message.java
+++ b/graylog2-server/src/main/java/org/graylog2/plugin/Message.java
@@ -425,7 +425,7 @@ public class Message implements Messages {
      * @param stream the stream to route this message into
      */
     public void addStream(Stream stream) {
-        indexSets.addAll(stream.getIndexSets());
+        indexSets.add(stream.getIndexSet());
         streams.add(stream);
     }
 
@@ -450,7 +450,7 @@ public class Message implements Messages {
         if (removed) {
             indexSets.clear();
             for (Stream s : streams) {
-                indexSets.addAll(s.getIndexSets());
+                indexSets.add(s.getIndexSet());
             }
         }
 

--- a/graylog2-server/src/main/java/org/graylog2/plugin/streams/Stream.java
+++ b/graylog2-server/src/main/java/org/graylog2/plugin/streams/Stream.java
@@ -79,5 +79,9 @@ public interface Stream extends Persisted {
 
     void setRemoveMatchesFromDefaultStream(boolean removeMatchesFromDefaultStream);
 
-    Set<IndexSet> getIndexSets();
+    IndexSet getIndexSet();
+
+    String getIndexSetId();
+
+    void setIndexSetId(String indexSetId);
 }

--- a/graylog2-server/src/test/java/org/graylog2/migrations/V20160929120500_CreateDefaultStreamMigrationTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/migrations/V20160929120500_CreateDefaultStreamMigrationTest.java
@@ -61,7 +61,7 @@ public class V20160929120500_CreateDefaultStreamMigrationTest {
 
         migration.upgrade();
 
-        verify(streamService).save(streamArgumentCaptor.capture());
+        verify(streamService).saveWithoutValidation(streamArgumentCaptor.capture());
 
         final Stream stream = streamArgumentCaptor.getValue();
         assertThat(stream.getTitle()).isEqualTo("All messages");

--- a/graylog2-server/src/test/java/org/graylog2/migrations/V20161122174500_AssignIndexSetsToStreamsMigrationTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/migrations/V20161122174500_AssignIndexSetsToStreamsMigrationTest.java
@@ -1,0 +1,188 @@
+/**
+ * This file is part of Graylog.
+ *
+ * Graylog is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.graylog2.migrations;
+
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Lists;
+import com.google.common.collect.Sets;
+import org.graylog2.events.ClusterEventBus;
+import org.graylog2.indexer.indexset.IndexSetConfig;
+import org.graylog2.indexer.indexset.IndexSetService;
+import org.graylog2.plugin.cluster.ClusterConfigService;
+import org.graylog2.plugin.database.ValidationException;
+import org.graylog2.plugin.streams.Stream;
+import org.graylog2.streams.StreamService;
+import org.graylog2.streams.events.StreamsChangedEvent;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnit;
+import org.mockito.junit.MockitoRule;
+
+import java.time.ZonedDateTime;
+import java.util.Collections;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+public class V20161122174500_AssignIndexSetsToStreamsMigrationTest {
+    @Rule
+    public final MockitoRule mockitoRule = MockitoJUnit.rule();
+    @Rule
+    public final ExpectedException expectedException = ExpectedException.none();
+
+    @Mock
+    private IndexSetService indexSetService;
+    @Mock
+    private StreamService streamService;
+    @Mock
+    private ClusterConfigService clusterConfigService;
+    @Mock
+    private ClusterEventBus clusterEventBus;
+
+    private Migration migration;
+
+    @Before
+    public void setUp() throws Exception {
+        migration = new V20161122174500_AssignIndexSetsToStreamsMigration(streamService, indexSetService, clusterConfigService, clusterEventBus);
+    }
+
+    @Test
+    public void createdAt() throws Exception {
+        // Test the date to detect accidental changes to it.
+        assertThat(migration.createdAt()).isEqualTo(ZonedDateTime.parse("2016-11-22T17:45:00Z"));
+    }
+
+    @Test
+    public void upgrade() throws Exception {
+        final Stream stream1 = mock(Stream.class);
+        final Stream stream2 = mock(Stream.class);
+        final IndexSetConfig indexSetConfig = mock(IndexSetConfig.class);
+
+        when(indexSetService.findAll()).thenReturn(Collections.singleton(indexSetConfig));
+        when(indexSetConfig.id()).thenReturn("abc123");
+        when(stream1.getId()).thenReturn("stream1");
+        when(stream2.getId()).thenReturn("stream2");
+        when(streamService.loadAll()).thenReturn(Lists.newArrayList(stream1, stream2));
+
+        migration.upgrade();
+
+        verify(stream1).setIndexSetId(indexSetConfig.id());
+        verify(stream2).setIndexSetId(indexSetConfig.id());
+        verify(streamService, times(1)).save(stream1);
+        verify(streamService, times(1)).save(stream2);
+        verify(clusterConfigService, times(1)).write(
+                V20161122174500_AssignIndexSetsToStreamsMigration.MigrationCompleted.create(
+                        indexSetConfig.id(), Sets.newHashSet("stream1", "stream2"), Collections.emptySet()));
+        verify(clusterEventBus, times(1)).post(StreamsChangedEvent.create(ImmutableSet.of("stream1", "stream2")));
+    }
+
+    @Test
+    public void upgradeWithAlreadyAssignedIndexSet() throws Exception {
+        final Stream stream1 = mock(Stream.class);
+        final Stream stream2 = mock(Stream.class);
+        final IndexSetConfig indexSetConfig = mock(IndexSetConfig.class);
+
+        when(indexSetService.findAll()).thenReturn(Collections.singleton(indexSetConfig));
+        when(indexSetConfig.id()).thenReturn("abc123");
+        when(stream1.getId()).thenReturn("stream1");
+        when(stream2.getId()).thenReturn("stream2");
+        when(streamService.loadAll()).thenReturn(Lists.newArrayList(stream1, stream2));
+        when(stream2.getIndexSetId()).thenReturn("abc123");
+
+        migration.upgrade();
+
+        verify(stream1).setIndexSetId(indexSetConfig.id());
+        verify(stream2, never()).setIndexSetId(indexSetConfig.id());
+        verify(streamService, times(1)).save(stream1);
+        verify(streamService, never()).save(stream2);
+        verify(clusterConfigService, times(1)).write(
+                V20161122174500_AssignIndexSetsToStreamsMigration.MigrationCompleted.create(
+                        indexSetConfig.id(), Sets.newHashSet("stream1"), Collections.emptySet()));
+        verify(clusterEventBus, times(1)).post(StreamsChangedEvent.create(ImmutableSet.of("stream1")));
+    }
+
+    @Test
+    public void upgradeWithFailedStreamUpdate() throws Exception {
+        final Stream stream1 = mock(Stream.class);
+        final Stream stream2 = mock(Stream.class);
+        final IndexSetConfig indexSetConfig = mock(IndexSetConfig.class);
+
+        when(indexSetService.findAll()).thenReturn(Collections.singleton(indexSetConfig));
+        when(indexSetConfig.id()).thenReturn("abc123");
+        when(stream1.getId()).thenReturn("stream1");
+        when(stream2.getId()).thenReturn("stream2");
+        when(streamService.loadAll()).thenReturn(Lists.newArrayList(stream1, stream2));
+
+        // Updating stream1 should fail!
+        when(streamService.save(stream1)).thenThrow(ValidationException.class);
+
+        migration.upgrade();
+
+        verify(stream1).setIndexSetId(indexSetConfig.id());
+        verify(stream2).setIndexSetId(indexSetConfig.id());
+        verify(streamService, times(1)).save(stream1);
+        verify(streamService, times(1)).save(stream2);
+
+        // Check that the failed stream1 will be recorded as failed!
+        verify(clusterConfigService, times(1)).write(
+                V20161122174500_AssignIndexSetsToStreamsMigration.MigrationCompleted.create(
+                        indexSetConfig.id(), Sets.newHashSet("stream2"), Sets.newHashSet("stream1")));
+        verify(clusterEventBus, times(1)).post(StreamsChangedEvent.create(ImmutableSet.of("stream2")));
+    }
+
+    @Test
+    public void upgradeWithoutAnyIndexSetConfig() throws Exception {
+        when(indexSetService.findAll()).thenReturn(Collections.emptySet());
+
+        expectedException.expect(IllegalStateException.class);
+
+        migration.upgrade();
+    }
+
+    @Test
+    public void upgradeWithMoreThanOneIndexSetConfig() throws Exception {
+        when(indexSetService.findAll()).thenReturn(Sets.newHashSet(mock(IndexSetConfig.class), mock(IndexSetConfig.class)));
+
+        expectedException.expect(IllegalStateException.class);
+
+        migration.upgrade();
+    }
+
+    @Test
+    public void upgradeWhenAlreadyCompleted() throws Exception {
+        final IndexSetConfig indexSetConfig = mock(IndexSetConfig.class);
+
+        when(indexSetService.findAll()).thenReturn(Collections.singleton(indexSetConfig));
+        when(indexSetConfig.id()).thenReturn("abc123");
+        when(clusterConfigService.get(V20161122174500_AssignIndexSetsToStreamsMigration.MigrationCompleted.class))
+                .thenReturn(V20161122174500_AssignIndexSetsToStreamsMigration.MigrationCompleted.create("1", Collections.emptySet(), Collections.emptySet()));
+
+        migration.upgrade();
+
+        verify(streamService, never()).save(any(Stream.class));
+        verify(clusterConfigService, never()).write(any(V20161122174500_AssignIndexSetsToStreamsMigration.MigrationCompleted.class));
+        verify(clusterEventBus, never()).post(any(StreamsChangedEvent.class));
+    }
+}

--- a/graylog2-server/src/test/java/org/graylog2/plugin/MessageTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/plugin/MessageTest.java
@@ -259,9 +259,9 @@ public class MessageTest {
 
         assertThat(message.getIndexSets()).isEmpty();
 
-        when(stream1.getIndexSets()).thenReturn(Collections.singleton(indexSet1));
-        when(stream2.getIndexSets()).thenReturn(Collections.emptySet());
-        when(stream3.getIndexSets()).thenReturn(Sets.newHashSet(indexSet1, indexSet2));
+        when(stream1.getIndexSet()).thenReturn(indexSet1);
+        when(stream2.getIndexSet()).thenReturn(indexSet1);
+        when(stream3.getIndexSet()).thenReturn(indexSet2);
 
         message.addStream(stream1);
         message.addStreams(Sets.newHashSet(stream2, stream3));

--- a/graylog2-server/src/test/java/org/graylog2/streams/StreamListFingerprintTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/streams/StreamListFingerprintTest.java
@@ -74,7 +74,7 @@ public class StreamListFingerprintTest {
         final HashMap<String, Object> fields = Maps.newHashMap();
         fields.put(StreamImpl.FIELD_TITLE, title);
         return new StreamImpl(new ObjectId(String.format(Locale.ENGLISH, "%024d", id)), fields, Lists.newArrayList(rules), Sets.newHashSet(
-                outputs), Collections.emptySet());
+                outputs), null);
     }
 
     private static StreamRule makeStreamRule(int id, String field) {

--- a/graylog2-server/src/test/java/org/graylog2/streams/StreamMock.java
+++ b/graylog2-server/src/test/java/org/graylog2/streams/StreamMock.java
@@ -32,6 +32,8 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 
+import static org.mockito.Mockito.mock;
+
 public class StreamMock implements Stream {
     private String id;
     private String title;
@@ -219,7 +221,16 @@ public class StreamMock implements Stream {
     }
 
     @Override
-    public Set<IndexSet> getIndexSets() {
-        return Collections.emptySet();
+    public String getIndexSetId() {
+        return null;
+    }
+
+    @Override
+    public void setIndexSetId(String indexSetId) {
+    }
+
+    @Override
+    public IndexSet getIndexSet() {
+        return mock(IndexSet.class);
     }
 }


### PR DESCRIPTION
- Change stream from having multiple index sets to only one
- Store index set ID in the stream document in MongoDB
- Add migration to assign the "default" index set to all existing streams