### PR TITLE
Do not log an error with stack trace when content pack dir is missing

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/periodical/ContentPackLoaderPeriodical.java
+++ b/graylog2-server/src/main/java/org/graylog2/periodical/ContentPackLoaderPeriodical.java
@@ -224,7 +224,7 @@ public class ContentPackLoaderPeriodical extends Periodical {
                 files.add(path);
             }
         } catch (IOException e) {
-            LOG.error("Couldn't list content packs", e);
+            LOG.warn("Couldn't list content packs: {}", e.getMessage());
         }
 
         return files.build();


### PR DESCRIPTION
A warning should be enough.