### PR TITLE
Use rotation/retention config of index set instead of cluster config

### DIFF
--- a/UPGRADING.rst
+++ b/UPGRADING.rst
@@ -28,3 +28,10 @@ With the introduction of index sets, and the ability to change a stream's write 
 It requires recalculation of the index ranges of the default stream's index set, which when updating from pre-2.2 versions is stored in the `graylog_` index. This is potentially expensive, because it has to calculate three aggregations across every open index to detect which streams are stored in which index.
 
 Please be advised that this necessary migration can put additional load on your cluster.
+
+RotationStrategy & RetentionStrategy Interfaces
+-----------------------------------------------
+
+The Java interfaces for ``RetentionStrategy`` and ``RotationStrategy`` changed in 2.2. The ``#rotate()`` and ``#retain()`` methods are now getting an ``IndexSet`` as first parameter.
+
+This only affects you if you are using custom rotation or retention strategies.

--- a/graylog2-server/src/main/java/org/graylog2/indexer/retention/strategies/AbstractIndexCountBasedRetentionStrategy.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/retention/strategies/AbstractIndexCountBasedRetentionStrategy.java
@@ -45,14 +45,14 @@ public abstract class AbstractIndexCountBasedRetentionStrategy implements Retent
         this.activityWriter = requireNonNull(activityWriter);
     }
 
-    protected abstract Optional<Integer> getMaxNumberOfIndices();
-    protected abstract void retain(String indexName);
+    protected abstract Optional<Integer> getMaxNumberOfIndices(IndexSet indexSet);
+    protected abstract void retain(String indexName, IndexSet indexSet);
 
     @Override
     public void retain(IndexSet indexSet) {
         final Map<String, Set<String>> deflectorIndices = indexSet.getAllDeflectorAliases();
         final int indexCount = deflectorIndices.size();
-        final Optional<Integer> maxIndices = getMaxNumberOfIndices();
+        final Optional<Integer> maxIndices = getMaxNumberOfIndices(indexSet);
 
         if (!maxIndices.isPresent()) {
             LOG.warn("No retention strategy configuration found, not running index retention!");
@@ -99,7 +99,7 @@ public abstract class AbstractIndexCountBasedRetentionStrategy implements Retent
             activityWriter.write(new Activity(msg, IndexRetentionThread.class));
 
             // Sorry if this should ever go mad. Run retention strategy!
-            retain(indexName);
+            retain(indexName, indexSet);
         }
     }
 }

--- a/graylog2-server/src/main/java/org/graylog2/indexer/retention/strategies/NoopRetentionStrategy.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/retention/strategies/NoopRetentionStrategy.java
@@ -16,6 +16,7 @@
  */
 package org.graylog2.indexer.retention.strategies;
 
+import org.graylog2.indexer.IndexSet;
 import org.graylog2.indexer.indices.Indices;
 import org.graylog2.plugin.indexer.retention.RetentionStrategyConfig;
 import org.graylog2.shared.system.activities.ActivityWriter;
@@ -34,12 +35,12 @@ public class NoopRetentionStrategy extends AbstractIndexCountBasedRetentionStrat
     }
 
     @Override
-    protected Optional<Integer> getMaxNumberOfIndices() {
+    protected Optional<Integer> getMaxNumberOfIndices(IndexSet indexSet) {
         return Optional.of(Integer.MAX_VALUE);
     }
 
     @Override
-    protected void retain(String indexName) {
+    protected void retain(String indexName, IndexSet indexSet) {
         LOG.info("Not running any index retention. This is the no-op index rotation strategy.");
     }
 

--- a/graylog2-server/src/main/java/org/graylog2/indexer/retention/strategies/UnknownRetentionStrategyConfig.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/retention/strategies/UnknownRetentionStrategyConfig.java
@@ -1,0 +1,47 @@
+/**
+ * This file is part of Graylog.
+ *
+ * Graylog is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.graylog2.indexer.retention.strategies;
+
+import com.google.auto.value.AutoValue;
+
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+import org.graylog2.plugin.indexer.retention.RetentionStrategyConfig;
+
+/**
+ * This is being used as the fallback {@link RetentionStrategyConfig} if the requested class is not
+ * available (usually because it was contributed by a plugin which is not loaded).
+ * <p>
+ * By itself it does nothing useful except accepting all properties but not exposing them.
+ */
+@JsonAutoDetect
+@AutoValue
+@JsonIgnoreProperties(ignoreUnknown = true)
+public abstract class UnknownRetentionStrategyConfig implements RetentionStrategyConfig {
+
+    @JsonCreator
+    public static UnknownRetentionStrategyConfig create() {
+        return new AutoValue_UnknownRetentionStrategyConfig(UnknownRetentionStrategyConfig.class.getCanonicalName());
+    }
+
+
+    public static UnknownRetentionStrategyConfig createDefault() {
+        return create();
+    }
+}

--- a/graylog2-server/src/main/java/org/graylog2/indexer/rotation/strategies/AbstractRotationStrategy.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/rotation/strategies/AbstractRotationStrategy.java
@@ -49,7 +49,7 @@ public abstract class AbstractRotationStrategy implements RotationStrategy {
     }
 
     @Nullable
-    protected abstract Result shouldRotate(String indexName);
+    protected abstract Result shouldRotate(String indexName, IndexSet indexSet);
 
     @Override
     public void rotate(IndexSet indexSet) {
@@ -62,7 +62,7 @@ public abstract class AbstractRotationStrategy implements RotationStrategy {
             return;
         }
 
-        final Result rotate = shouldRotate(indexName);
+        final Result rotate = shouldRotate(indexName, indexSet);
         if (rotate == null) {
             LOG.error("Cannot perform rotation at this moment.");
             return;

--- a/graylog2-server/src/main/java/org/graylog2/periodical/IndexRetentionThread.java
+++ b/graylog2-server/src/main/java/org/graylog2/periodical/IndexRetentionThread.java
@@ -17,12 +17,12 @@
 package org.graylog2.periodical;
 
 import org.graylog2.configuration.ElasticsearchConfiguration;
+import org.graylog2.indexer.IndexSet;
 import org.graylog2.indexer.IndexSetRegistry;
 import org.graylog2.indexer.cluster.Cluster;
-import org.graylog2.indexer.management.IndexManagementConfig;
+import org.graylog2.indexer.indexset.IndexSetConfig;
 import org.graylog2.notifications.Notification;
 import org.graylog2.notifications.NotificationService;
-import org.graylog2.plugin.cluster.ClusterConfigService;
 import org.graylog2.plugin.indexer.retention.RetentionStrategy;
 import org.graylog2.plugin.periodical.Periodical;
 import org.graylog2.plugin.system.NodeId;
@@ -41,7 +41,6 @@ public class IndexRetentionThread extends Periodical {
     private final ElasticsearchConfiguration configuration;
     private final IndexSetRegistry indexSetRegistry;
     private final Cluster cluster;
-    private final ClusterConfigService clusterConfigService;
     private final NodeId nodeId;
     private final NotificationService notificationService;
     private final Map<String, Provider<RetentionStrategy>> retentionStrategyMap;
@@ -50,14 +49,12 @@ public class IndexRetentionThread extends Periodical {
     public IndexRetentionThread(ElasticsearchConfiguration configuration,
                                 IndexSetRegistry indexSetRegistry,
                                 Cluster cluster,
-                                ClusterConfigService clusterConfigService,
                                 NodeId nodeId,
                                 NotificationService notificationService,
                                 Map<String, Provider<RetentionStrategy>> retentionStrategyMap) {
         this.configuration = configuration;
         this.indexSetRegistry = indexSetRegistry;
         this.cluster = cluster;
-        this.clusterConfigService = clusterConfigService;
         this.nodeId = nodeId;
         this.notificationService = notificationService;
         this.retentionStrategyMap = retentionStrategyMap;
@@ -70,28 +67,19 @@ public class IndexRetentionThread extends Periodical {
             return;
         }
 
-        // TODO 2.2: Retention strategy config is per write target, not global.
-        final IndexManagementConfig config = clusterConfigService.get(IndexManagementConfig.class);
+        for (final IndexSet indexSet : indexSetRegistry) {
+            final IndexSetConfig config = indexSet.getConfig();
+            final Provider<RetentionStrategy> retentionStrategyProvider = retentionStrategyMap.get(config.retentionStrategyClass());
 
-        if (config == null) {
-            LOG.warn("No index management configuration found, not running index retention!");
-            retentionProblemNotification("Index Retention Problem!",
-                    "No index management configuration found, not running index retention! Please fix your index retention configuration!");
-            return;
+            if (retentionStrategyProvider == null) {
+                LOG.warn("Retention strategy \"{}\" not found, not running index retention!", config.retentionStrategyClass());
+                retentionProblemNotification("Index Retention Problem!",
+                        "Index retention strategy " + config.retentionStrategyClass() + " not found! Please fix your index retention configuration!");
+                return;
+            }
+
+            retentionStrategyProvider.get().retain(indexSet);
         }
-
-        final Provider<RetentionStrategy> retentionStrategyProvider = retentionStrategyMap.get(config.retentionStrategy());
-
-        if (retentionStrategyProvider == null) {
-            LOG.warn("Retention strategy \"{}\" not found, not running index retention!", config.retentionStrategy());
-            retentionProblemNotification("Index Retention Problem!",
-                    "Index retention strategy " + config.retentionStrategy() + " not found! Please fix your index retention configuration!");
-            return;
-        }
-
-        final RetentionStrategy retentionStrategy = retentionStrategyProvider.get();
-
-        indexSetRegistry.forEach(retentionStrategy::retain);
     }
 
     private void retentionProblemNotification(String title, String description) {

--- a/graylog2-server/src/test/java/org/graylog2/indexer/rotation/strategies/MessageCountRotationStrategyTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/indexer/rotation/strategies/MessageCountRotationStrategyTest.java
@@ -20,8 +20,8 @@ package org.graylog2.indexer.rotation.strategies;
 import org.graylog2.audit.AuditEventSender;
 import org.graylog2.indexer.IndexNotFoundException;
 import org.graylog2.indexer.IndexSet;
+import org.graylog2.indexer.indexset.IndexSetConfig;
 import org.graylog2.indexer.indices.Indices;
-import org.graylog2.plugin.cluster.ClusterConfigService;
 import org.graylog2.plugin.system.NodeId;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -38,10 +38,10 @@ import static org.mockito.Mockito.when;
 @RunWith(MockitoJUnitRunner.class)
 public class MessageCountRotationStrategyTest {
     @Mock
-    private ClusterConfigService clusterConfigService;
+    private IndexSet indexSet;
 
     @Mock
-    private IndexSet indexSet;
+    private IndexSetConfig indexSetConfig;
 
     @Mock
     private Indices indices;
@@ -56,9 +56,10 @@ public class MessageCountRotationStrategyTest {
     public void testRotate() throws Exception {
         when(indices.numberOfMessages("name")).thenReturn(10L);
         when(indexSet.getNewestTargetName()).thenReturn("name");
-        when(clusterConfigService.get(MessageCountRotationStrategyConfig.class)).thenReturn(MessageCountRotationStrategyConfig.create(5));
+        when(indexSet.getConfig()).thenReturn(indexSetConfig);
+        when(indexSetConfig.rotationStrategy()).thenReturn(MessageCountRotationStrategyConfig.create(5));
 
-        final MessageCountRotationStrategy strategy = new MessageCountRotationStrategy(indices, nodeId, clusterConfigService, auditEventSender);
+        final MessageCountRotationStrategy strategy = new MessageCountRotationStrategy(indices, nodeId, auditEventSender);
 
         strategy.rotate(indexSet);
         verify(indexSet, times(1)).cycle();
@@ -69,9 +70,10 @@ public class MessageCountRotationStrategyTest {
     public void testDontRotate() throws Exception {
         when(indices.numberOfMessages("name")).thenReturn(1L);
         when(indexSet.getNewestTargetName()).thenReturn("name");
-        when(clusterConfigService.get(MessageCountRotationStrategyConfig.class)).thenReturn(MessageCountRotationStrategyConfig.create(5));
+        when(indexSet.getConfig()).thenReturn(indexSetConfig);
+        when(indexSetConfig.rotationStrategy()).thenReturn(MessageCountRotationStrategyConfig.create(5));
 
-        final MessageCountRotationStrategy strategy = new MessageCountRotationStrategy(indices, nodeId, clusterConfigService, auditEventSender);
+        final MessageCountRotationStrategy strategy = new MessageCountRotationStrategy(indices, nodeId, auditEventSender);
 
         strategy.rotate(indexSet);
         verify(indexSet, never()).cycle();
@@ -83,9 +85,10 @@ public class MessageCountRotationStrategyTest {
     public void testIndexUnavailable() throws Exception {
         doThrow(IndexNotFoundException.class).when(indices).numberOfMessages("name");
         when(indexSet.getNewestTargetName()).thenReturn("name");
-        when(clusterConfigService.get(MessageCountRotationStrategyConfig.class)).thenReturn(MessageCountRotationStrategyConfig.create(5));
+        when(indexSet.getConfig()).thenReturn(indexSetConfig);
+        when(indexSetConfig.rotationStrategy()).thenReturn(MessageCountRotationStrategyConfig.create(5));
 
-        final MessageCountRotationStrategy strategy = new MessageCountRotationStrategy(indices, nodeId, clusterConfigService, auditEventSender);
+        final MessageCountRotationStrategy strategy = new MessageCountRotationStrategy(indices, nodeId, auditEventSender);
 
         strategy.rotate(indexSet);
         verify(indexSet, never()).cycle();

--- a/graylog2-server/src/test/java/org/graylog2/indexer/rotation/strategies/SizeBasedRotationStrategyTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/indexer/rotation/strategies/SizeBasedRotationStrategyTest.java
@@ -22,9 +22,9 @@ import org.elasticsearch.cluster.routing.ShardRouting;
 import org.elasticsearch.index.store.StoreStats;
 import org.graylog2.audit.AuditEventSender;
 import org.graylog2.indexer.IndexSet;
+import org.graylog2.indexer.indexset.IndexSetConfig;
 import org.graylog2.indexer.indices.IndexStatistics;
 import org.graylog2.indexer.indices.Indices;
-import org.graylog2.plugin.cluster.ClusterConfigService;
 import org.graylog2.plugin.system.NodeId;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -42,10 +42,10 @@ import static org.mockito.Mockito.when;
 @RunWith(MockitoJUnitRunner.class)
 public class SizeBasedRotationStrategyTest {
     @Mock
-    private ClusterConfigService clusterConfigService;
+    private IndexSet indexSet;
 
     @Mock
-    private IndexSet indexSet;
+    private IndexSetConfig indexSetConfig;
 
     @Mock
     private Indices indices;
@@ -64,9 +64,10 @@ public class SizeBasedRotationStrategyTest {
 
         when(indices.getIndexStats("name")).thenReturn(stats);
         when(indexSet.getNewestTargetName()).thenReturn("name");
-        when(clusterConfigService.get(SizeBasedRotationStrategyConfig.class)).thenReturn(SizeBasedRotationStrategyConfig.create(100L));
+        when(indexSet.getConfig()).thenReturn(indexSetConfig);
+        when(indexSetConfig.rotationStrategy()).thenReturn(SizeBasedRotationStrategyConfig.create(100L));
 
-        final SizeBasedRotationStrategy strategy = new SizeBasedRotationStrategy(indices, clusterConfigService, nodeId, auditEventSender);
+        final SizeBasedRotationStrategy strategy = new SizeBasedRotationStrategy(indices, nodeId, auditEventSender);
 
         strategy.rotate(indexSet);
         verify(indexSet, times(1)).cycle();
@@ -82,9 +83,10 @@ public class SizeBasedRotationStrategyTest {
 
         when(indices.getIndexStats("name")).thenReturn(stats);
         when(indexSet.getNewestTargetName()).thenReturn("name");
-        when(clusterConfigService.get(SizeBasedRotationStrategyConfig.class)).thenReturn(SizeBasedRotationStrategyConfig.create(100000L));
+        when(indexSet.getConfig()).thenReturn(indexSetConfig);
+        when(indexSetConfig.rotationStrategy()).thenReturn(SizeBasedRotationStrategyConfig.create(100000L));
 
-        final SizeBasedRotationStrategy strategy = new SizeBasedRotationStrategy(indices, clusterConfigService, nodeId, auditEventSender);
+        final SizeBasedRotationStrategy strategy = new SizeBasedRotationStrategy(indices, nodeId, auditEventSender);
 
         strategy.rotate(indexSet);
         verify(indexSet, never()).cycle();
@@ -96,9 +98,10 @@ public class SizeBasedRotationStrategyTest {
     public void testRotateFailed() throws Exception {
         when(indices.getIndexStats("name")).thenReturn(null);
         when(indexSet.getNewestTargetName()).thenReturn("name");
-        when(clusterConfigService.get(SizeBasedRotationStrategyConfig.class)).thenReturn(SizeBasedRotationStrategyConfig.create(100));
+        when(indexSet.getConfig()).thenReturn(indexSetConfig);
+        when(indexSetConfig.rotationStrategy()).thenReturn(SizeBasedRotationStrategyConfig.create(100L));
 
-        final SizeBasedRotationStrategy strategy = new SizeBasedRotationStrategy(indices, clusterConfigService, nodeId, auditEventSender);
+        final SizeBasedRotationStrategy strategy = new SizeBasedRotationStrategy(indices, nodeId, auditEventSender);
 
         strategy.rotate(indexSet);
         verify(indexSet, never()).cycle();


### PR DESCRIPTION
Until now, the rotation and retention threads were still using the old cluster config objects to get their settings. This switches them over to use the rotation/retention config of each index set.