### PR TITLE
Set empty stream list for index ranges of empty indices

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/indexer/searches/IndexRangeStats.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/searches/IndexRangeStats.java
@@ -21,13 +21,14 @@ import com.google.auto.value.AutoValue;
 import org.joda.time.DateTime;
 import org.joda.time.DateTimeZone;
 
+import java.util.Collections;
 import java.util.List;
 
 import javax.annotation.Nullable;
 
 @AutoValue
 public abstract class IndexRangeStats {
-    public static final IndexRangeStats EMPTY = create(new DateTime(0L, DateTimeZone.UTC), new DateTime(0L, DateTimeZone.UTC), null);
+    public static final IndexRangeStats EMPTY = create(new DateTime(0L, DateTimeZone.UTC), new DateTime(0L, DateTimeZone.UTC), Collections.emptyList());
 
     public abstract DateTime min();
 


### PR DESCRIPTION
This avoids running the stream list migration at every start for these indices (which is harmless but annoying).