### PR TITLE
Fix stream and default stream creation

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/migrations/MigrationsModule.java
+++ b/graylog2-server/src/main/java/org/graylog2/migrations/MigrationsModule.java
@@ -24,8 +24,8 @@ public class MigrationsModule extends AbstractModule {
     protected void configure() {
         final Multibinder<Migration> binder = Multibinder.newSetBinder(binder(), Migration.class);
         binder.addBinding().to(V20151210140600_ElasticsearchConfigMigration.class);
-        binder.addBinding().to(V20160929120500_CreateDefaultStreamMigration.class);
         binder.addBinding().to(V20161116172100_DefaultIndexSetMigration.class);
+        binder.addBinding().to(V20161116172200_CreateDefaultStreamMigration.class);
         binder.addBinding().to(V20161122174500_AssignIndexSetsToStreamsMigration.class);
         binder.addBinding().to(V20161124104700_AddRetentionRotationAndDefaultFlagToIndexSetMigration.class);
         binder.addBinding().to(V20161125142400_EmailAlarmCallbackMigration.class);

--- a/graylog2-server/src/main/java/org/graylog2/migrations/V20161116172200_CreateDefaultStreamMigration.java
+++ b/graylog2-server/src/main/java/org/graylog2/migrations/V20161116172200_CreateDefaultStreamMigration.java
@@ -58,7 +58,7 @@ public class V20161116172200_CreateDefaultStreamMigration extends Migration {
 
     @Override
     public ZonedDateTime createdAt() {
-        return ZonedDateTime.parse("2016-09-29T12:05:00Z");
+        return ZonedDateTime.parse("2016-11-16T17:22:00Z");
     }
 
     @Override

--- a/graylog2-server/src/main/java/org/graylog2/streams/StreamImpl.java
+++ b/graylog2-server/src/main/java/org/graylog2/streams/StreamImpl.java
@@ -73,6 +73,13 @@ public class StreamImpl extends PersistedImpl implements Stream {
         this.indexSet = null;
     }
 
+    public StreamImpl(Map<String, Object> fields, IndexSet indexSet) {
+        super(fields);
+        this.streamRules = null;
+        this.outputs = null;
+        this.indexSet = indexSet;
+    }
+
     protected StreamImpl(ObjectId id, Map<String, Object> fields) {
         super(id, fields);
         this.streamRules = null;

--- a/graylog2-server/src/main/java/org/graylog2/streams/StreamServiceImpl.java
+++ b/graylog2-server/src/main/java/org/graylog2/streams/StreamServiceImpl.java
@@ -60,6 +60,8 @@ import java.util.Set;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.stream.Collectors;
 
+import static com.google.common.base.Strings.isNullOrEmpty;
+
 public class StreamServiceImpl extends PersistedServiceImpl implements StreamService {
     private static final Logger LOG = LoggerFactory.getLogger(StreamServiceImpl.class);
     private final StreamRuleService streamRuleService;
@@ -91,8 +93,12 @@ public class StreamServiceImpl extends PersistedServiceImpl implements StreamSer
 
     @Nullable
     private IndexSet getIndexSet(DBObject dbObject) {
-        final String id = (String) dbObject.get(StreamImpl.FIELD_INDEX_SET_ID);
-        if (id == null) {
+        return getIndexSet((String) dbObject.get(StreamImpl.FIELD_INDEX_SET_ID));
+    }
+
+    @Nullable
+    private IndexSet getIndexSet(String id) {
+        if (isNullOrEmpty(id)) {
             return null;
         }
         final Optional<IndexSetConfig> indexSetConfig = indexSetService.get(id);
@@ -117,7 +123,7 @@ public class StreamServiceImpl extends PersistedServiceImpl implements StreamSer
 
     @Override
     public Stream create(Map<String, Object> fields) {
-        return new StreamImpl(fields);
+        return new StreamImpl(fields, getIndexSet((String) fields.get(StreamImpl.FIELD_INDEX_SET_ID)));
     }
 
     @Override


### PR DESCRIPTION
The default stream couldn't be created in a new installation because the required `index_set_id` field was missing.

Change order of migrations so the default stream migration runs after the default index set has been created.

Also avoid using the `Persisted#saveWithoutValidation()` method because it doesn't do what it says. It just ignores the validation exception thrown by `#save()`.