### PR TITLE
Remove quotation on string fields

### DIFF
--- a/graylog2-web-interface/src/components/search/MessageShow.jsx
+++ b/graylog2-web-interface/src/components/search/MessageShow.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { Col, Row } from 'react-bootstrap';
 import Immutable from 'immutable';
 import MessageDetail from './MessageDetail';
+import StringUtils from 'util/StringUtils';
 
 const MessageShow = React.createClass({
   propTypes: {
@@ -28,8 +29,7 @@ const MessageShow = React.createClass({
 
   possiblyHighlight(fieldName) {
     // No highlighting for the message details view.
-    const value = this.props.message.fields[fieldName];
-    return (typeof value === 'object' ? JSON.stringify(value) : String(value));
+    return StringUtils.stringify(this.props.message.fields[fieldName]);
   },
   render() {
     return (

--- a/graylog2-web-interface/src/components/search/MessageShow.jsx
+++ b/graylog2-web-interface/src/components/search/MessageShow.jsx
@@ -28,7 +28,8 @@ const MessageShow = React.createClass({
 
   possiblyHighlight(fieldName) {
     // No highlighting for the message details view.
-    return JSON.stringify(this.props.message.fields[fieldName]) || '';
+    const value = this.props.message.fields[fieldName];
+    return (typeof value === 'object' ? JSON.stringify(value) : String(value));
   },
   render() {
     return (

--- a/graylog2-web-interface/src/components/search/MessageTableEntry.jsx
+++ b/graylog2-web-interface/src/components/search/MessageTableEntry.jsx
@@ -1,7 +1,8 @@
 import React from 'react';
 import MessageDetail from './MessageDetail';
 import Immutable from 'immutable';
-import {Timestamp} from 'components/common';
+import { Timestamp } from 'components/common';
+import StringUtils from 'util/StringUtils';
 
 const MessageTableEntry = React.createClass({
   shouldComponentUpdate(newProps) {
@@ -31,7 +32,7 @@ const MessageTableEntry = React.createClass({
       return '';
     }
     // Ensure the field is a string for later processing
-    const fullStringOrigValue = (typeof fullOrigValue === 'object' ? JSON.stringify(fullOrigValue) : String(fullOrigValue));
+    const fullStringOrigValue = StringUtils.stringify(fullOrigValue);
 
     // Truncate the field to 2048 characters if requested. This is for performance reasons to avoid hogging the CPU.
     // It's not optimal, more like a workaround to at least being able to show the page...

--- a/graylog2-web-interface/src/components/search/MessageTableEntry.jsx
+++ b/graylog2-web-interface/src/components/search/MessageTableEntry.jsx
@@ -30,7 +30,8 @@ const MessageTableEntry = React.createClass({
     if (fullOrigValue === undefined) {
       return '';
     }
-    const fullStringOrigValue = JSON.stringify(fullOrigValue); // Ensure the field is a string for later processing
+    // Ensure the field is a string for later processing
+    const fullStringOrigValue = (typeof fullOrigValue === 'object' ? JSON.stringify(fullOrigValue) : String(fullOrigValue));
 
     // Truncate the field to 2048 characters if requested. This is for performance reasons to avoid hogging the CPU.
     // It's not optimal, more like a workaround to at least being able to show the page...

--- a/graylog2-web-interface/src/pages/CreateExtractorsPage.jsx
+++ b/graylog2-web-interface/src/pages/CreateExtractorsPage.jsx
@@ -7,6 +7,7 @@ import DocumentationLink from 'components/support/DocumentationLink';
 import EditExtractor from 'components/extractors/EditExtractor';
 
 import DocsHelper from 'util/DocsHelper';
+import StringUtils from 'util/StringUtils';
 import Routes from 'routing/Routes';
 
 import StoreProvider from 'injection/StoreProvider';
@@ -62,8 +63,7 @@ const CreateExtractorsPage = React.createClass({
       return <Spinner/>;
     }
 
-    const value = this.state.exampleMessage.fields[this.state.field];
-    const exampleMessage = (typeof value === 'object' ? JSON.stringify(value) : String(value));
+    const exampleMessage = StringUtils.stringify(this.state.exampleMessage.fields[this.state.field]);
 
     return (
       <div>

--- a/graylog2-web-interface/src/pages/CreateExtractorsPage.jsx
+++ b/graylog2-web-interface/src/pages/CreateExtractorsPage.jsx
@@ -62,6 +62,9 @@ const CreateExtractorsPage = React.createClass({
       return <Spinner/>;
     }
 
+    const value = this.state.exampleMessage.fields[this.state.field];
+    const exampleMessage = (typeof value === 'object' ? JSON.stringify(value) : String(value));
+
     return (
       <div>
         <PageHeader title={<span>New extractor for input <em>{this.state.input.title}</em></span>}>
@@ -78,7 +81,7 @@ const CreateExtractorsPage = React.createClass({
         <EditExtractor action="create"
                        extractor={this.state.extractor}
                        inputId={this.state.input.id}
-                       exampleMessage={JSON.stringify(this.state.exampleMessage.fields[this.state.field]) || ''}
+                       exampleMessage={exampleMessage}
                        onSave={this._extractorSaved}/>
       </div>
     );

--- a/graylog2-web-interface/src/stores/messages/MessagesStore.js
+++ b/graylog2-web-interface/src/stores/messages/MessagesStore.js
@@ -31,7 +31,8 @@ const MessagesStore = Reflux.createStore({
   },
 
   fieldTerms(index, string) {
-    const url = ApiRoutes.MessagesController.analyze(index, JSON.stringify(string)).url;
+    const value = (typeof string === 'object' ? JSON.stringify(string) : String(string));
+    const url = ApiRoutes.MessagesController.analyze(index, value).url;
     const promise = fetch('GET', URLUtils.qualifyUrl(url))
       .then(
         response => response.tokens,

--- a/graylog2-web-interface/src/stores/messages/MessagesStore.js
+++ b/graylog2-web-interface/src/stores/messages/MessagesStore.js
@@ -5,6 +5,7 @@ import MessageFormatter from 'logic/message/MessageFormatter';
 import ApiRoutes from 'routing/ApiRoutes';
 import URLUtils from 'util/URLUtils';
 import UserNotification from 'util/UserNotification';
+import StringUtils from 'util/StringUtils';
 
 import ActionsProvider from 'injection/ActionsProvider';
 const MessagesActions = ActionsProvider.getActions('Messages');
@@ -31,8 +32,7 @@ const MessagesStore = Reflux.createStore({
   },
 
   fieldTerms(index, string) {
-    const value = (typeof string === 'object' ? JSON.stringify(string) : String(string));
-    const url = ApiRoutes.MessagesController.analyze(index, value).url;
+    const url = ApiRoutes.MessagesController.analyze(index, StringUtils.stringify(string)).url;
     const promise = fetch('GET', URLUtils.qualifyUrl(url))
       .then(
         response => response.tokens,

--- a/graylog2-web-interface/src/util/StringUtils.js
+++ b/graylog2-web-interface/src/util/StringUtils.js
@@ -14,6 +14,9 @@ const StringUtils = {
   pluralize(number, singular, plural) {
     return (number === 1 || number === '1' ? singular : plural);
   },
+  stringify(text) {
+    return (typeof text === 'object' ? JSON.stringify(text) : String(text)) || '';
+  },
 };
 
 export default StringUtils;


### PR DESCRIPTION
Only use `JSON.stringify()` to convert objects into strings, relying on `String()` for doing all other conversions. In this way we can properly display objects and arrays and not add any quotation on string fields.

Refs #3106, fixes #3155