### PR TITLE
Fix bluebird runaway promises warnings

### DIFF
--- a/graylog2-web-interface/src/components/outputs/OutputsComponent.jsx
+++ b/graylog2-web-interface/src/components/outputs/OutputsComponent.jsx
@@ -47,12 +47,14 @@ const OutputsComponent = React.createClass({
     OutputsStore.save(data, (result) => {
       this.setState({typeName: "placeholder"});
       if (this.props.streamId) {
-        StreamsStore.addOutput(this.props.streamId, result.id, () => {
+        StreamsStore.addOutput(this.props.streamId, result.id, response => {
           this._handleUpdate();
+          return response;
         });
       } else {
         this._handleUpdate();
       }
+      return result;
     });
   },
   _fetchAssignableOutputs(outputs) {
@@ -65,23 +67,26 @@ const OutputsComponent = React.createClass({
     });
   },
   _handleAssignOutput(outputId) {
-    StreamsStore.addOutput(this.props.streamId, outputId, () => {
+    StreamsStore.addOutput(this.props.streamId, outputId, response => {
       this._handleUpdate();
+      return response;
     });
   },
   _removeOutputGlobally(outputId) {
     if (window.confirm("Do you really want to terminate this output?")) {
-      OutputsStore.remove(outputId, (jqXHR, textStatus, errorThrown) => {
+      OutputsStore.remove(outputId, response => {
         UserNotification.success("Output was terminated.", "Success");
         this._handleUpdate();
+        return response;
       });
     }
   },
   _removeOutputFromStream(outputId, streamId) {
     if (window.confirm("Do you really want to remove this output from the stream?")) {
-      StreamsStore.removeOutput(streamId, outputId, (jqXHR, textStatus, errorThrown) => {
+      StreamsStore.removeOutput(streamId, outputId, response => {
         UserNotification.success("Output was removed from stream.", "Success");
         this._handleUpdate();
+        return response;
       });
     }
   },

--- a/graylog2-web-interface/src/components/streams/MatchingTypeSwitcher.jsx
+++ b/graylog2-web-interface/src/components/streams/MatchingTypeSwitcher.jsx
@@ -36,10 +36,11 @@ class MatchingTypeSwitcher extends Component {
 
   handleTypeChange(newValue) {
     if (window.confirm('You are about to change how rules are applied to this stream, do you want to continue? Changes will take effect immediately.')) {
-      StreamsStore.update(this.props.stream.id, {'matching_type': newValue}, () => {
+      StreamsStore.update(this.props.stream.id, { matching_type: newValue }, response => {
         this.props.onChange();
         UserNotification.success(`Messages will now be routed into the stream when ${newValue === 'AND' ? 'all' : 'any'} rules are matched`,
           'Success');
+        return response;
       });
     }
   }

--- a/graylog2-web-interface/src/components/streams/Stream.jsx
+++ b/graylog2-web-interface/src/components/streams/Stream.jsx
@@ -48,24 +48,33 @@ const Stream = React.createClass({
   },
   _onDelete(stream) {
     if (window.confirm('Do you really want to remove this stream?')) {
-      StreamsStore.remove(stream.id, () => UserNotification.success(`Stream '${stream.title}' was deleted successfully.`, 'Success'));
+      StreamsStore.remove(stream.id, response => {
+        UserNotification.success(`Stream '${stream.title}' was deleted successfully.`, 'Success');
+        return response;
+      });
     }
   },
   _onResume() {
     this.setState({ loading: true });
-    StreamsStore.resume(this.props.stream.id, () => {})
+    StreamsStore.resume(this.props.stream.id, response => response)
       .finally(() => this.setState({ loading: false }));
   },
   _onUpdate(streamId, stream) {
-    StreamsStore.update(streamId, stream, () => UserNotification.success(`Stream '${stream.title}' was updated successfully.`, 'Success'));
+    StreamsStore.update(streamId, stream, response => {
+      UserNotification.success(`Stream '${stream.title}' was updated successfully.`, 'Success');
+      return response;
+    });
   },
   _onClone(streamId, stream) {
-    StreamsStore.cloneStream(streamId, stream, () => UserNotification.success(`Stream was successfully cloned as '${stream.title}'.`, 'Success'));
+    StreamsStore.cloneStream(streamId, stream, response => {
+      UserNotification.success(`Stream was successfully cloned as '${stream.title}'.`, 'Success');
+      return response;
+    });
   },
   _onPause() {
     if (window.confirm(`Do you really want to pause stream '${this.props.stream.title}'?`)) {
       this.setState({ loading: true });
-      StreamsStore.pause(this.props.stream.id, () => {})
+      StreamsStore.pause(this.props.stream.id, response => response)
         .finally(() => this.setState({ loading: false }));
     }
   },

--- a/graylog2-web-interface/src/pages/SearchPage.jsx
+++ b/graylog2-web-interface/src/pages/SearchPage.jsx
@@ -99,8 +99,13 @@ const SearchPage = React.createClass({
 
           this.setState({ updatingHistogram: true });
           UniversalSearchStore.histogram(SearchStore.rangeType, query, SearchStore.rangeParams.toJS(), interval, streamId)
-            .then((histogram) => this.setState({ histogram: histogram }))
+            .then(histogram => {
+              this.setState({ histogram: histogram });
+              return histogram;
+            })
             .finally(() => this.setState({ updatingHistogram: false }));
+
+          return response;
         },
         error => {
           // Treat searches with a malformed query

--- a/graylog2-web-interface/src/pages/ThreadDumpPage.jsx
+++ b/graylog2-web-interface/src/pages/ThreadDumpPage.jsx
@@ -44,7 +44,9 @@ const ThreadDumpPage = React.createClass({
     return (
       <DocumentTitle title={`Thread dump of node ${this.state.node.short_node_id} / ${this.state.node.hostname}`}>
         <div>
-          <PageHeader title={title}/>
+          <PageHeader title={title}>
+            <span/>
+          </PageHeader>
           <Row className="content input-list">
             <Col md={12}>
               {threadDump}

--- a/graylog2-web-interface/src/stores/authentication/AuthenticationStore.js
+++ b/graylog2-web-interface/src/stores/authentication/AuthenticationStore.js
@@ -25,6 +25,7 @@ const AuthenticationStore = Reflux.createStore({
       .then(
         (response) => {
           this.trigger({ authenticators: response });
+          return response;
         },
         (error) => UserNotification.error(`Unable to load authentication configuration: ${error}`, 'Could not load authenticators')
       );
@@ -40,6 +41,7 @@ const AuthenticationStore = Reflux.createStore({
           (response) => {
             this.trigger({ authenticators: response });
             UserNotification.success('Configuration updated successfully');
+            return response;
           },
           (error) => UserNotification.error(`Unable to save authentication provider configuration: ${error}`, 'Could not save configuration')
         );

--- a/graylog2-web-interface/src/stores/gettingstarted/GettingStartedStore.js
+++ b/graylog2-web-interface/src/stores/gettingstarted/GettingStartedStore.js
@@ -28,11 +28,14 @@ const GettingStartedStore = Reflux.createStore({
   getStatus() {
     const promise = fetch('GET', URLUtils.qualifyUrl(this.sourceUrl));
     promise
-      .then(response => {
-        this.status = response;
-        this.trigger({status: this.status});
-      })
-      .catch(console.error);
+      .then(
+        response => {
+          this.status = response;
+          this.trigger({ status: this.status });
+          return response;
+        },
+        error => console.error(error)
+      );
 
     GettingStartedActions.getStatus.promise(promise);
   },
@@ -40,11 +43,15 @@ const GettingStartedStore = Reflux.createStore({
   dismiss() {
     const promise = fetch('POST', URLUtils.qualifyUrl(`${this.sourceUrl}/dismiss`), '{}');
     promise
-      .then(() => this.getStatus())
-      .catch((error) => {
-        UserNotification.error('Dismissing Getting Started Guide failed with status: ' + error,
-          'Could not dismiss guide');
-      });
+      .then(
+        response => {
+          this.getStatus();
+          return response;
+        },
+        error => {
+          UserNotification.error(`Dismissing Getting Started Guide failed with status: ${error}`,
+            'Could not dismiss guide');
+        });
 
     GettingStartedActions.dismiss.promise(promise);
   },

--- a/graylog2-web-interface/src/stores/grok-patterns/GrokPatternsStore.ts
+++ b/graylog2-web-interface/src/stores/grok-patterns/GrokPatternsStore.ts
@@ -18,13 +18,16 @@ const GrokPatternsStore = {
         "Could not load Grok patterns");
     };
     // get the current list of patterns and sort it by name
-    fetch('GET', this.URL).then((resp: any) => {
-      const patterns = resp.patterns;
-      patterns.sort((pattern1: GrokPattern, pattern2: GrokPattern) => {
-        return pattern1.name.toLowerCase().localeCompare(pattern2.name.toLowerCase());
-      });
-      callback(patterns);
-    }, failCallback);
+    fetch('GET', this.URL).then(
+      (resp: any) => {
+        const patterns = resp.patterns;
+        patterns.sort((pattern1: GrokPattern, pattern2: GrokPattern) => {
+          return pattern1.name.toLowerCase().localeCompare(pattern2.name.toLowerCase());
+        });
+        callback(patterns);
+        return resp;
+      },
+      failCallback);
   },
 
   savePattern(pattern: GrokPattern, callback: () => void) {
@@ -48,12 +51,17 @@ const GrokPatternsStore = {
       url += '/' + pattern.id;
       method = 'PUT';
     }
-    fetch(method, url, requestPattern).then(() => {
-      callback();
-      var action = pattern.id === "" ? "created" : "updated";
-      var message = "Grok pattern \"" + pattern.name + "\" successfully " + action;
-      UserNotification.success(message);
-    }).catch(failCallback);
+    fetch(method, url, requestPattern)
+      .then(
+        response => {
+          callback();
+          const action = pattern.id === "" ? "created" : "updated";
+          const message = "Grok pattern \"" + pattern.name + "\" successfully " + action;
+          UserNotification.success(message);
+          return response;
+        },
+        failCallback
+      );
   },
 
   deletePattern(pattern: GrokPattern, callback: () => void) {
@@ -61,10 +69,15 @@ const GrokPatternsStore = {
       UserNotification.error("Deleting Grok pattern \"" + pattern.name + "\" failed with status: " + error.message,
         "Could not delete Grok pattern");
     };
-    fetch('DELETE', this.URL + "/" + pattern.id).then(() => {
-      callback();
-      UserNotification.success("Grok pattern \"" + pattern.name + "\" successfully deleted");
-    }).catch(failCallback);
+    fetch('DELETE', this.URL + "/" + pattern.id)
+      .then(
+        response => {
+          callback();
+          UserNotification.success("Grok pattern \"" + pattern.name + "\" successfully deleted");
+          return response;
+        },
+        failCallback
+      );
   },
 
   bulkImport(patterns: string[], replaceAll: boolean) {

--- a/graylog2-web-interface/src/stores/inputs/InputStatesStore.js
+++ b/graylog2-web-interface/src/stores/inputs/InputStatesStore.js
@@ -59,9 +59,10 @@ const InputStatesStore = Reflux.createStore({
     const url = URLUtils.qualifyUrl(ApiRoutes.ClusterInputStatesController.start(input.id).url);
     return fetch('PUT', url)
       .then(
-        (response) => {
+        response => {
           this._checkInputStateChangeResponse(input, response, 'START');
           this.list();
+          return response;
         },
         error => {
           UserNotification.error(`Error starting input '${input.title}': ${error}`, `Input '${input.title}' could not be started`);
@@ -72,9 +73,10 @@ const InputStatesStore = Reflux.createStore({
     const url = URLUtils.qualifyUrl(ApiRoutes.ClusterInputStatesController.stop(input.id).url);
     return fetch('DELETE', url)
       .then(
-        (response) => {
+        response => {
           this._checkInputStateChangeResponse(input, response, 'STOP');
           this.list();
+          return response;
         },
         error => {
           UserNotification.error(`Error stopping input '${input.title}': ${error}`, `Input '${input.title}' could not be stopped`);

--- a/graylog2-web-interface/src/stores/inputs/InputStaticFieldsStore.js
+++ b/graylog2-web-interface/src/stores/inputs/InputStaticFieldsStore.js
@@ -13,14 +13,16 @@ const InputStaticFieldsStore = Reflux.createStore({
     const url = URLUtils.qualifyUrl(this.sourceUrl(input.id));
     const promise = fetch('POST', url, {key: name, value: value});
     promise
-      .then(() => {
-        this.trigger({});
-        UserNotification.success(`Static field '${name}' added to '${input.title}' successfully`);
-      })
-      .catch(error => {
-        UserNotification.error(`Adding static field to input failed with: ${error}`,
-          `Could not add static field to input '${input.title}'`);
-      });
+      .then(
+        response => {
+          this.trigger({});
+          UserNotification.success(`Static field '${name}' added to '${input.title}' successfully`);
+          return response;
+        },
+        error => {
+          UserNotification.error(`Adding static field to input failed with: ${error}`,
+            `Could not add static field to input '${input.title}'`);
+        });
 
     return promise;
   },
@@ -29,14 +31,16 @@ const InputStaticFieldsStore = Reflux.createStore({
     const url = URLUtils.qualifyUrl(`${this.sourceUrl(input.id)}/${name}`);
     const promise = fetch('DELETE', url);
     promise
-      .then(() => {
-        this.trigger({});
-        UserNotification.success(`Static field '${name}' removed from '${input.title}' successfully`);
-      })
-      .catch(error => {
-        UserNotification.error(`Removing static field from input failed with: ${error}`,
-          `Could not remove static field '${name} from input '${input.title}'`);
-      });
+      .then(
+        response => {
+          this.trigger({});
+          UserNotification.success(`Static field '${name}' removed from '${input.title}' successfully`);
+          return response;
+        },
+        error => {
+          UserNotification.error(`Removing static field from input failed with: ${error}`,
+            `Could not remove static field '${name} from input '${input.title}'`);
+        });
 
     return promise;
   },

--- a/graylog2-web-interface/src/stores/search/SavedSearchesStore.js
+++ b/graylog2-web-interface/src/stores/search/SavedSearchesStore.js
@@ -25,14 +25,16 @@ const SavedSearchesStore = Reflux.createStore({
 
   list() {
     const promise = fetch('GET', URLUtils.qualifyUrl(URLUtils.concatURLPath(this.sourceUrl)))
-      .then(response => {
-        this.savedSearches = response.searches;
-        this.trigger({savedSearches: this.savedSearches});
-      })
-      .catch(error => {
-        UserNotification.error('Fetching saved searches failed with status: ' + error,
-          'Could not get saved searches');
-      });
+      .then(
+        response => {
+          this.savedSearches = response.searches;
+          this.trigger({ savedSearches: this.savedSearches });
+          return response;
+        },
+        error => {
+          UserNotification.error(`Fetching saved searches failed with status: ${error}`,
+            'Could not get saved searches');
+        });
 
     SavedSearchesActions.list.promise(promise);
   },
@@ -110,14 +112,16 @@ const SavedSearchesStore = Reflux.createStore({
   create(title) {
     const promise = this._createOrUpdate(title);
     promise
-      .then(() => {
-        UserNotification.success(`Search criteria saved as "${title}".`);
-        SavedSearchesActions.list.triggerPromise();
-      })
-      .catch(error => {
-        UserNotification.error('Saving search criteria failed with status: ' + error,
-          'Could not save search criteria');
-      });
+      .then(
+        response => {
+          UserNotification.success(`Search criteria saved as "${title}".`);
+          SavedSearchesActions.list.triggerPromise();
+          return response;
+        },
+        error => {
+          UserNotification.error(`Saving search criteria failed with status: ${error}`,
+            'Could not save search criteria');
+        });
 
     SavedSearchesActions.create.promise(promise);
   },
@@ -125,14 +129,16 @@ const SavedSearchesStore = Reflux.createStore({
   update(searchId, title) {
     const promise = this._createOrUpdate(title, searchId);
     promise
-      .then(() => {
-        UserNotification.success(`Saved search "${title}" was updated.`);
-        SavedSearchesActions.list.triggerPromise();
-      })
-      .catch(error => {
-        UserNotification.error(`Updating saved search "${title}" failed with status: ${error}`,
-          'Could not update saved search');
-      });
+      .then(
+        response => {
+          UserNotification.success(`Saved search "${title}" was updated.`);
+          SavedSearchesActions.list.triggerPromise();
+          return response;
+        },
+        error => {
+          UserNotification.error(`Updating saved search "${title}" failed with status: ${error}`,
+            'Could not update saved search');
+        });
 
     SavedSearchesActions.update.promise(promise);
   },
@@ -141,14 +147,16 @@ const SavedSearchesStore = Reflux.createStore({
     const url = ApiRoutes.SavedSearchesApiController.delete(searchId).url;
     const promise = fetch('DELETE', URLUtils.qualifyUrl(url));
     promise
-      .then(() => {
-        UserNotification.success(`Saved search "${this.savedSearches[searchId]}" was deleted successfully.`);
-        SearchStore.savedSearchDeleted(searchId);
-      })
-      .catch(error => {
-        UserNotification.error(`Deleting saved search "${this.savedSearches[searchId]}" failed with status: ${error}`,
-          'Could not delete saved search');
-      });
+      .then(
+        response => {
+          UserNotification.success(`Saved search "${this.savedSearches[searchId]}" was deleted successfully.`);
+          SearchStore.savedSearchDeleted(searchId);
+          return response;
+        },
+        error => {
+          UserNotification.error(`Deleting saved search "${this.savedSearches[searchId]}" failed with status: ${error}`,
+            'Could not delete saved search');
+        });
 
     SavedSearchesActions.delete.promise(promise);
   },

--- a/graylog2-web-interface/src/stores/streams/StreamsStore.ts
+++ b/graylog2-web-interface/src/stores/streams/StreamsStore.ts
@@ -70,7 +70,12 @@ class StreamsStore {
     };
 
     const url = URLUtils.qualifyUrl(ApiRoutes.StreamsApiController.pause(streamId).url);
-    return fetch('POST', url).then(callback, failCallback).then(this._emitChange.bind(this));
+    return fetch('POST', url)
+      .then(callback, failCallback)
+      .then(response => {
+        this._emitChange();
+        return response;
+      });
   }
   resume(streamId: string, callback: (() => void)) {
     const failCallback = (errorThrown) => {
@@ -80,7 +85,11 @@ class StreamsStore {
 
     const url = URLUtils.qualifyUrl(ApiRoutes.StreamsApiController.resume(streamId).url);
     return fetch('POST', url)
-      .then(callback, failCallback).then(this._emitChange.bind(this));
+      .then(callback, failCallback)
+      .then(response => {
+        this._emitChange();
+        return response;
+      });
   }
   save(stream: any, callback: ((streamId: string) => void)) {
     const failCallback = (errorThrown) => {
@@ -112,7 +121,7 @@ class StreamsStore {
     fetch('POST', url, data)
       .then(callback, failCallback).then(this._emitChange.bind(this));
   }
-  removeOutput(streamId: string, outputId: string, callback: (errorThrown) => void) {
+  removeOutput(streamId: string, outputId: string, callback: (reponse) => void) {
     const url = URLUtils.qualifyUrl(ApiRoutes.StreamOutputsApiController.delete(streamId, outputId).url);
 
     fetch('DELETE', url).then(callback, (errorThrown) => {
@@ -138,8 +147,11 @@ class StreamsStore {
     const url = URLUtils.qualifyUrl(ApiRoutes.StreamAlertsApiController.sendDummyAlert(streamId).url);
     const promise = fetch('POST', url);
     promise.then(
-      () => UserNotification.success('Test notification was sent successfully'),
-      (error) => UserNotification.error('Could not send test notification')
+      response => {
+        UserNotification.success('Test notification was sent successfully');
+        return response;
+      },
+      error => UserNotification.error('Could not send test notification')
     );
     return promise;
   }

--- a/graylog2-web-interface/src/stores/users/StartpageStore.js
+++ b/graylog2-web-interface/src/stores/users/StartpageStore.js
@@ -14,16 +14,15 @@ const StartpageStore = Reflux.createStore({
       payload.type = type;
       payload.id = id;
     }
-    const promise = fetch('PUT', url, {startpage: payload})
+    return fetch('PUT', url, {startpage: payload})
       .then(
-        () => {
+        response => {
           this.trigger();
-          UserNotification.success('Your start page was changed successfully')
+          UserNotification.success('Your start page was changed successfully');
+          return response;
         },
-        (error) => UserNotification.error(`Changing your start page failed with error: ${error}`, 'Could not change your start page')
+        error => UserNotification.error(`Changing your start page failed with error: ${error}`, 'Could not change your start page')
       );
-
-    return promise;
   },
 });
 

--- a/graylog2-web-interface/src/stores/widgets/WidgetsStore.ts
+++ b/graylog2-web-interface/src/stores/widgets/WidgetsStore.ts
@@ -37,13 +37,17 @@ const WidgetsStore = Reflux.createStore({
         var url = URLUtils.qualifyUrl(ApiRoutes.DashboardsApiController.addWidget(dashboardId).url);
         var promise = fetch('POST', url, widgetData);
 
-        promise.then(() => UserNotification.success("Widget created successfully"),
-        (error) => {
-            if (error.additional.status !== 404) {
-                UserNotification.error("Creating widget failed with status: " + error,
+        promise.then(
+          response => {
+              UserNotification.success("Widget created successfully");
+              return response;
+          },
+          error => {
+              if (error.additional.status !== 404) {
+                  UserNotification.error("Creating widget failed with status: " + error,
                     "Could not create widget");
-            }
-        });
+              }
+          });
 
         return promise;
     },
@@ -70,8 +74,11 @@ const WidgetsStore = Reflux.createStore({
         var promise = fetch('PUT', url, this._serializeWidgetForUpdate(widget));
 
         promise.then(
-          () => UserNotification.success("Widget updated successfully"),
-          (error) => {
+          response => {
+              UserNotification.success("Widget updated successfully");
+              return response;
+          },
+          error => {
               UserNotification.error("Updating widget \"" + widget.description + "\" failed with status: " + error.message,
                 "Could not update widget");
           }
@@ -93,8 +100,9 @@ const WidgetsStore = Reflux.createStore({
     removeWidget(dashboardId: string, widgetId: string): Promise<string[]> {
         const url = URLUtils.qualifyUrl(ApiRoutes.DashboardsApiController.removeWidget(dashboardId, widgetId).url);
 
-        const promise = fetch('DELETE', url).then(() => {
+        const promise = fetch('DELETE', url).then(response => {
             this.trigger({delete: widgetId});
+            return response;
         });
         WidgetsActions.removeWidget.promise(promise);
 


### PR DESCRIPTION
Since #2800, bluebird is showing warnings when promises are not returning a value in the `then`
handler. This PR fixes all the occurrences I could find, and also replaces some of the `catch` handlers with the failure function in the `then` handler, which is recommended to avoid swallowing application exceptions.