### PR TITLE
Use custom Grizzly error page to prevent XSS

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/rest/GraylogErrorPageGenerator.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/GraylogErrorPageGenerator.java
@@ -1,0 +1,73 @@
+/**
+ * This file is part of Graylog.
+ *
+ * Graylog is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.graylog2.rest;
+
+import com.floreysoft.jmte.Engine;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.io.Resources;
+import org.apache.commons.lang3.StringEscapeUtils;
+import org.glassfish.grizzly.http.server.ErrorPageGenerator;
+import org.glassfish.grizzly.http.server.Request;
+
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.io.StringWriter;
+import java.nio.charset.StandardCharsets;
+
+import static java.util.Objects.requireNonNull;
+
+public class GraylogErrorPageGenerator implements ErrorPageGenerator {
+    private final String template;
+    private final Engine engine;
+
+    public GraylogErrorPageGenerator() throws IOException {
+        this(Resources.toString(Resources.getResource("error.html.template"), StandardCharsets.UTF_8), new Engine());
+    }
+
+    public GraylogErrorPageGenerator(String template, Engine engine) {
+        this.template = requireNonNull(template);
+        this.engine = requireNonNull(engine);
+    }
+
+    @Override
+    public String generate(Request request, int status, String reasonPhrase, String description, Throwable exception) {
+        final ImmutableMap.Builder<String, Object> modelBuilder = ImmutableMap.builder();
+        modelBuilder.put("reason", StringEscapeUtils.escapeHtml4(reasonPhrase));
+
+        if (description != null) {
+            modelBuilder.put("description", StringEscapeUtils.escapeHtml4(description));
+        }
+
+        if (exception != null) {
+            String stacktrace = "";
+            try (final StringWriter stringWriter = new StringWriter();
+                 final PrintWriter printWriter = new PrintWriter(stringWriter)) {
+                exception.printStackTrace(printWriter);
+                printWriter.flush();
+                stringWriter.flush();
+                stacktrace = stringWriter.toString();
+            } catch (IOException ignored) {
+                // Ignore
+            }
+            modelBuilder
+                    .put("exception", StringEscapeUtils.escapeHtml4(exception.getMessage()))
+                    .put("stacktrace", StringEscapeUtils.escapeHtml4(stacktrace));
+        }
+
+        return engine.transform(template, modelBuilder.build());
+    }
+}

--- a/graylog2-server/src/main/java/org/graylog2/shared/initializers/JerseyService.java
+++ b/graylog2-server/src/main/java/org/graylog2/shared/initializers/JerseyService.java
@@ -37,6 +37,7 @@ import org.graylog2.audit.PluginAuditEventTypes;
 import org.graylog2.audit.jersey.AuditEventModelProcessor;
 import org.graylog2.jersey.PrefixAddingModelProcessor;
 import org.graylog2.plugin.rest.PluginRestResource;
+import org.graylog2.rest.GraylogErrorPageGenerator;
 import org.graylog2.rest.filter.WebAppNotFoundResponseFilter;
 import org.graylog2.shared.rest.CORSFilter;
 import org.graylog2.shared.rest.NodeIdResponseFilter;
@@ -352,6 +353,7 @@ public class JerseyService extends AbstractIdleService {
         // See "Selector runners count" at https://grizzly.java.net/bestpractices.html for details.
         listener.getTransport().setSelectorRunnersCount(selectorRunnersCount);
 
+        listener.setDefaultErrorPageGenerator(new GraylogErrorPageGenerator());
 
         if(enableGzip) {
             final CompressionConfig compressionConfig = listener.getCompressionConfig();

--- a/graylog2-server/src/main/resources/error.html.template
+++ b/graylog2-server/src/main/resources/error.html.template
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta name="robots" content="noindex, nofollow">
+<meta charset="UTF-8">
+<title>Graylog - ${reason}</title>
+</head>
+<body>
+<h1>${description(Internal Server Error)}</h1>
+${if exception}
+<h2>Reason</h2>
+<p>${exception}</p>
+<h2>Stacktrace</h2>
+<p><pre>
+${stacktrace}
+</pre></p>
+${end}
+</body>
+</html>


### PR DESCRIPTION
## Description

The default Grizzly error page is prone to XSS, see:

* https://java.net/jira/browse/GRIZZLY-1718
* https://java.net/jira/browse/JERSEY-3050

This PR replaces the default error page with a custom one which is escaping inputs properly.

Fixes #3171

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** document.
- [x] All new and existing tests passed.