### PR TITLE
Add contains string tester

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/rest/models/tools/requests/ContainsStringTestRequest.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/models/tools/requests/ContainsStringTestRequest.java
@@ -1,0 +1,39 @@
+/**
+ * This file is part of Graylog.
+ *
+ * Graylog is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.graylog2.rest.models.tools.requests;
+
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.auto.value.AutoValue;
+
+@JsonAutoDetect
+@AutoValue
+public abstract class ContainsStringTestRequest {
+    @JsonProperty("search_string")
+    public abstract String searchString();
+
+    @JsonProperty("string")
+    public abstract String string();
+
+    @JsonCreator
+    public static ContainsStringTestRequest create(@JsonProperty("search_string") String searchString,
+                                                   @JsonProperty("string") String string) {
+        return new AutoValue_ContainsStringTestRequest(searchString, string);
+    }
+}

--- a/graylog2-server/src/main/java/org/graylog2/rest/models/tools/responses/ContainsStringTesterResponse.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/models/tools/responses/ContainsStringTesterResponse.java
@@ -1,0 +1,67 @@
+/**
+ * This file is part of Graylog.
+ *
+ * Graylog is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.graylog2.rest.models.tools.responses;
+
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.auto.value.AutoValue;
+
+import javax.annotation.Nullable;
+
+@JsonAutoDetect
+@AutoValue
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public abstract class ContainsStringTesterResponse {
+    @JsonProperty("matched")
+    public abstract boolean matched();
+
+    @JsonProperty("match")
+    @Nullable
+    public abstract Match match();
+
+    @JsonProperty("search_string")
+    public abstract String searchString();
+
+    @JsonProperty("string")
+    public abstract String string();
+
+    @JsonCreator
+    public static ContainsStringTesterResponse create(@JsonProperty("matched") boolean matched,
+                                                      @JsonProperty("match") @Nullable Match match,
+                                                      @JsonProperty("search_string") String searchString,
+                                                      @JsonProperty("string") String string) {
+        return new AutoValue_ContainsStringTesterResponse(matched, match, searchString, string);
+    }
+
+    @JsonAutoDetect
+    @AutoValue
+    public static abstract class Match {
+        @JsonProperty
+        public abstract int start();
+
+        @JsonProperty
+        public abstract int end();
+
+        @JsonCreator
+        public static Match create(@JsonProperty("start") int start,
+                                   @JsonProperty("end") int end) {
+            return new AutoValue_ContainsStringTesterResponse_Match(start, end);
+        }
+    }
+}

--- a/graylog2-server/src/main/java/org/graylog2/rest/resources/tools/ContainsStringTesterResource.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/resources/tools/ContainsStringTesterResource.java
@@ -1,0 +1,72 @@
+/**
+ * This file is part of Graylog.
+ *
+ * Graylog is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.graylog2.rest.resources.tools;
+
+import com.codahale.metrics.annotation.Timed;
+import org.apache.shiro.authz.annotation.RequiresAuthentication;
+import org.graylog2.audit.jersey.NoAuditEvent;
+import org.graylog2.rest.models.tools.requests.ContainsStringTestRequest;
+import org.graylog2.rest.models.tools.responses.ContainsStringTesterResponse;
+import org.graylog2.shared.rest.resources.RestResource;
+import org.hibernate.validator.constraints.NotEmpty;
+
+import javax.validation.Valid;
+import javax.validation.constraints.NotNull;
+import javax.ws.rs.Consumes;
+import javax.ws.rs.GET;
+import javax.ws.rs.POST;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.QueryParam;
+
+import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
+
+@RequiresAuthentication
+@Path("/tools/contains_string_tester")
+@Consumes(APPLICATION_JSON)
+@Produces(APPLICATION_JSON)
+public class ContainsStringTesterResource extends RestResource {
+
+    @GET
+    @Timed
+    public ContainsStringTesterResponse containsStringTest(@QueryParam("string") @NotEmpty String string,
+                                      @QueryParam("search_string") @NotEmpty String searchString) {
+        return doTestContainsString(string, searchString);
+    }
+
+
+    @POST
+    @Timed
+    @NoAuditEvent("only used to test if field contains a string")
+    public ContainsStringTesterResponse testContainsString(@Valid @NotNull ContainsStringTestRequest request) {
+        return doTestContainsString(request.string(), request.searchString());
+    }
+
+    private ContainsStringTesterResponse doTestContainsString(String string, String searchString) {
+        final int index = string.indexOf(searchString);
+        final boolean contains = index != -1;
+        final ContainsStringTesterResponse.Match match;
+        if (contains) {
+            match = ContainsStringTesterResponse.Match.create(index, index + searchString.length());
+        } else {
+            match = null;
+        }
+
+        return ContainsStringTesterResponse.create(contains, match, searchString, string);
+    }
+}

--- a/graylog2-web-interface/src/components/extractors/EditExtractor.jsx
+++ b/graylog2-web-interface/src/components/extractors/EditExtractor.jsx
@@ -88,8 +88,10 @@ const EditExtractor = React.createClass({
     this.setState({updatedExtractor: updatedExtractor});
   },
   _testCondition() {
-    const promise = ToolsStore.testRegex(this.state.updatedExtractor.condition_value, this.state.exampleMessage);
-    promise.then(result => this.setState({conditionTestResult: result.matched}));
+    const updatedExtractor = this.state.updatedExtractor;
+    const tester = (updatedExtractor.condition_type === 'string' ? ToolsStore.testContainsString : ToolsStore.testRegex);
+    const promise = tester(updatedExtractor.condition_value, this.state.exampleMessage);
+    promise.then(result => this.setState({ conditionTestResult: result.matched }));
   },
   _tryButtonDisabled() {
     return this.state.updatedExtractor.condition_value === '' || this.state.updatedExtractor.condition_value === undefined || !this.state.exampleMessage;

--- a/graylog2-web-interface/src/routing/ApiRoutes.js
+++ b/graylog2-web-interface/src/routing/ApiRoutes.js
@@ -204,6 +204,7 @@ const ApiRoutes = {
     regexReplaceTest: () => { return { url: '/tools/regex_replace_tester' };},
     splitAndIndexTest: () => { return { url: '/tools/split_and_index_tester' };},
     substringTest: () => { return { url: '/tools/substring_tester' };},
+    containsStringTest: () => { return { url: '/tools/contains_string_tester' }; },
   },
   UniversalSearchApiController: {
     _streamFilter(streamId) {

--- a/graylog2-web-interface/src/stores/tools/ToolsStore.ts
+++ b/graylog2-web-interface/src/stores/tools/ToolsStore.ts
@@ -114,6 +114,17 @@ const ToolsStore = {
 
         return promise;
     },
+    testContainsString(searchString: string, string: string): Promise<Object> {
+        const url = ApiRoutes.ToolsApiController.containsStringTest().url;
+        const promise = fetch('POST', URLUtils.qualifyUrl(url), { search_string: searchString, string: string });
+
+        promise.catch((errorThrown) => {
+            UserNotification.error('Details: ' + errorThrown,
+              'Could not check if field contains the string');
+        });
+
+        return promise;
+    },
 };
 
 export = ToolsStore;


### PR DESCRIPTION
Introducing a new contains string tester that let us check if an extractor would run against a message when it contains a string. So far we were using the regex tester, but that requires to escape some characters.

Fixes #3134