### PR TITLE
Index set fixes

### DIFF
--- a/UPGRADING.rst
+++ b/UPGRADING.rst
@@ -29,6 +29,8 @@ It requires recalculation of the index ranges of the default stream's index set,
 
 Please be advised that this necessary migration can put additional load on your cluster.
 
+.. warning:: Make sure that all rotation and retention strategy plugins you had installed in 2.1 are updated to a version that is compatible with 2.2 before you start the Graylog 2.2 version for the first time. (e.g. Graylog Enterprise) This is needed so the required data migrations will run without problems.
+
 RotationStrategy & RetentionStrategy Interfaces
 -----------------------------------------------
 

--- a/graylog2-server/src/main/java/org/graylog2/indexer/IndexSetValidator.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/IndexSetValidator.java
@@ -30,11 +30,11 @@ public class IndexSetValidator {
         this.indexSetRegistry = indexSetRegistry;
     }
 
-    public Optional<Error> validate(IndexSetConfig newConfig) {
+    public Optional<Violation> validate(IndexSetConfig newConfig) {
         // Build an example index name with the new prefix and check if this would be managed by an existing index set
         final String indexName = newConfig.indexPrefix() + MongoIndexSet.SEPARATOR + "0";
         if (indexSetRegistry.isManagedIndex(indexName)) {
-            return Optional.of(Error.create("Index prefix \"" + newConfig.indexPrefix() + "\" would conflict with an existing index set!"));
+            return Optional.of(Violation.create("Index prefix \"" + newConfig.indexPrefix() + "\" would conflict with an existing index set!"));
         }
 
         // Check if an existing index set has a more generic index prefix.
@@ -42,7 +42,7 @@ public class IndexSetValidator {
         // This avoids problems with wildcard matching like "graylog_*".
         for (final IndexSet indexSet : indexSetRegistry) {
             if (newConfig.indexPrefix().startsWith(indexSet.getIndexPrefix())) {
-                return Optional.of(Error.create("Index prefix \"" + newConfig.indexPrefix() + "\" would conflict with existing index set prefix \"" + indexSet.getIndexPrefix() + "\""));
+                return Optional.of(Violation.create("Index prefix \"" + newConfig.indexPrefix() + "\" would conflict with existing index set prefix \"" + indexSet.getIndexPrefix() + "\""));
             }
         }
 
@@ -50,11 +50,11 @@ public class IndexSetValidator {
     }
 
     @AutoValue
-    public static abstract class Error {
+    public static abstract class Violation {
         public abstract String message();
 
-        public static Error create(String message) {
-            return new AutoValue_IndexSetValidator_Error(message);
+        public static Violation create(String message) {
+            return new AutoValue_IndexSetValidator_Violation(message);
         }
     }
 }

--- a/graylog2-server/src/main/java/org/graylog2/indexer/IndexSetValidator.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/IndexSetValidator.java
@@ -1,0 +1,60 @@
+/**
+ * This file is part of Graylog.
+ *
+ * Graylog is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.graylog2.indexer;
+
+import com.google.auto.value.AutoValue;
+import org.graylog2.indexer.indexset.IndexSetConfig;
+
+import javax.inject.Inject;
+import java.util.Optional;
+
+public class IndexSetValidator {
+    private final IndexSetRegistry indexSetRegistry;
+
+    @Inject
+    public IndexSetValidator(IndexSetRegistry indexSetRegistry) {
+        this.indexSetRegistry = indexSetRegistry;
+    }
+
+    public Optional<Error> validate(IndexSetConfig newConfig) {
+        // Build an example index name with the new prefix and check if this would be managed by an existing index set
+        final String indexName = newConfig.indexPrefix() + MongoIndexSet.SEPARATOR + "0";
+        if (indexSetRegistry.isManagedIndex(indexName)) {
+            return Optional.of(Error.create("Index prefix \"" + newConfig.indexPrefix() + "\" would conflict with an existing index set!"));
+        }
+
+        // Check if an existing index set has a more generic index prefix.
+        // Example: new=graylog_foo existing=graylog => graylog is more generic so this is an error
+        // This avoids problems with wildcard matching like "graylog_*".
+        for (final IndexSet indexSet : indexSetRegistry) {
+            if (newConfig.indexPrefix().startsWith(indexSet.getIndexPrefix())) {
+                return Optional.of(Error.create("Index prefix \"" + newConfig.indexPrefix() + "\" would conflict with existing index set prefix \"" + indexSet.getIndexPrefix() + "\""));
+            }
+        }
+
+        return Optional.empty();
+    }
+
+    @AutoValue
+    public static abstract class Error {
+        public abstract String message();
+
+        public static Error create(String message) {
+            return new AutoValue_IndexSetValidator_Error(message);
+        }
+    }
+}

--- a/graylog2-server/src/main/java/org/graylog2/indexer/indexset/IndexSetConfig.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/indexset/IndexSetConfig.java
@@ -38,6 +38,8 @@ import static java.util.Objects.requireNonNull;
 @AutoValue
 @JsonAutoDetect
 public abstract class IndexSetConfig implements Comparable<IndexSetConfig> {
+    public static final String FIELD_INDEX_PREFIX = "index_prefix";
+
     @JsonProperty("id")
     @Nullable
     @Id
@@ -58,7 +60,7 @@ public abstract class IndexSetConfig implements Comparable<IndexSetConfig> {
     @JsonProperty("writable")
     public abstract boolean isWritable();
 
-    @JsonProperty("index_prefix")
+    @JsonProperty(FIELD_INDEX_PREFIX)
     @NotBlank
     public abstract String indexPrefix();
 
@@ -133,7 +135,7 @@ public abstract class IndexSetConfig implements Comparable<IndexSetConfig> {
                                         @JsonProperty("description") @Nullable String description,
                                         @JsonProperty("default") @Nullable Boolean isDefault,
                                         @JsonProperty("writable") @Nullable Boolean isWritable,
-                                        @JsonProperty("index_prefix") @NotBlank String indexPrefix,
+                                        @JsonProperty(FIELD_INDEX_PREFIX) @NotBlank String indexPrefix,
                                         @JsonProperty("index_match_pattern") @Nullable String indexMatchPattern,
                                         @JsonProperty("index_wildcard") @Nullable String indexWildcard,
                                         @JsonProperty("shards") @Min(1) int shards,

--- a/graylog2-server/src/main/java/org/graylog2/indexer/indexset/IndexSetConfig.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/indexset/IndexSetConfig.java
@@ -39,6 +39,7 @@ import static java.util.Objects.requireNonNull;
 @JsonAutoDetect
 public abstract class IndexSetConfig implements Comparable<IndexSetConfig> {
     public static final String FIELD_INDEX_PREFIX = "index_prefix";
+    public static final String FIELD_CREATION_DATE = "creation_date";
 
     @JsonProperty("id")
     @Nullable
@@ -96,7 +97,7 @@ public abstract class IndexSetConfig implements Comparable<IndexSetConfig> {
     @NotNull
     public abstract RetentionStrategyConfig retentionStrategy();
 
-    @JsonProperty("creation_date")
+    @JsonProperty(FIELD_CREATION_DATE)
     @NotNull
     public abstract ZonedDateTime creationDate();
 
@@ -144,7 +145,7 @@ public abstract class IndexSetConfig implements Comparable<IndexSetConfig> {
                                         @JsonProperty("rotation_strategy") @NotNull RotationStrategyConfig rotationStrategy,
                                         @JsonProperty("retention_strategy_class") @Nullable String retentionStrategyClass,
                                         @JsonProperty("retention_strategy") @NotNull RetentionStrategyConfig retentionStrategy,
-                                        @JsonProperty("creation_date") @NotNull ZonedDateTime creationDate) {
+                                        @JsonProperty(FIELD_CREATION_DATE) @NotNull ZonedDateTime creationDate) {
         return AutoValue_IndexSetConfig.builder()
                 .id(id)
                 .title(title)

--- a/graylog2-server/src/main/java/org/graylog2/indexer/indexset/MongoIndexSetService.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/indexset/MongoIndexSetService.java
@@ -70,6 +70,7 @@ public class MongoIndexSetService implements IndexSetService {
         this.clusterEventBus = requireNonNull(clusterEventBus);
 
         this.collection.getDbCollection().createIndex(DBSort.asc(IndexSetConfig.FIELD_INDEX_PREFIX), null, true);
+        this.collection.getDbCollection().createIndex(DBSort.desc(IndexSetConfig.FIELD_CREATION_DATE));
     }
 
     /**

--- a/graylog2-server/src/main/java/org/graylog2/indexer/indexset/MongoIndexSetService.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/indexset/MongoIndexSetService.java
@@ -68,6 +68,8 @@ public class MongoIndexSetService implements IndexSetService {
         this.collection = requireNonNull(collection);
         this.streamService = streamService;
         this.clusterEventBus = requireNonNull(clusterEventBus);
+
+        this.collection.getDbCollection().createIndex(DBSort.asc(IndexSetConfig.FIELD_INDEX_PREFIX), null, true);
     }
 
     /**

--- a/graylog2-server/src/main/java/org/graylog2/rest/resources/system/indexer/IndexSetsResource.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/resources/system/indexer/IndexSetsResource.java
@@ -159,9 +159,9 @@ public class IndexSetsResource extends RestResource {
         try {
             final IndexSetConfig indexSetConfig = indexSet.toIndexSetConfig();
 
-            final Optional<IndexSetValidator.Error> error = indexSetValidator.validate(indexSetConfig);
-            if (error.isPresent()) {
-                throw new BadRequestException(error.get().message());
+            final Optional<IndexSetValidator.Violation> violation = indexSetValidator.validate(indexSetConfig);
+            if (violation.isPresent()) {
+                throw new BadRequestException(violation.get().message());
             }
 
             final IndexSetConfig savedObject = indexSetService.save(indexSetConfig);

--- a/graylog2-server/src/main/java/org/graylog2/rest/resources/system/indexer/IndexSetsResource.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/resources/system/indexer/IndexSetsResource.java
@@ -17,6 +17,7 @@
 package org.graylog2.rest.resources.system.indexer;
 
 import com.codahale.metrics.annotation.Timed;
+import com.mongodb.DuplicateKeyException;
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
 import io.swagger.annotations.ApiParam;
@@ -149,8 +150,12 @@ public class IndexSetsResource extends RestResource {
     })
     public IndexSetSummary save(@ApiParam(name = "Index set configuration", required = true)
                                 @Valid @NotNull IndexSetSummary indexSet) {
-        final IndexSetConfig savedObject = indexSetService.save(indexSet.toIndexSetConfig());
-        return IndexSetSummary.fromIndexSetConfig(savedObject);
+        try {
+            final IndexSetConfig savedObject = indexSetService.save(indexSet.toIndexSetConfig());
+            return IndexSetSummary.fromIndexSetConfig(savedObject);
+        } catch (DuplicateKeyException e) {
+            throw new BadRequestException(e.getMessage());
+        }
     }
 
     @PUT

--- a/graylog2-server/src/main/java/org/graylog2/rest/resources/system/indexer/requests/IndexSetUpdateRequest.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/resources/system/indexer/requests/IndexSetUpdateRequest.java
@@ -1,0 +1,128 @@
+/**
+ * This file is part of Graylog.
+ *
+ * Graylog is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.graylog2.rest.resources.system.indexer.requests;
+
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.auto.value.AutoValue;
+import org.graylog2.indexer.indexset.IndexSetConfig;
+import org.graylog2.plugin.indexer.retention.RetentionStrategyConfig;
+import org.graylog2.plugin.indexer.rotation.RotationStrategyConfig;
+import org.hibernate.validator.constraints.NotBlank;
+
+import javax.annotation.Nullable;
+import javax.validation.constraints.Min;
+import javax.validation.constraints.NotNull;
+
+@AutoValue
+@JsonAutoDetect
+@JsonIgnoreProperties(ignoreUnknown = true)
+public abstract class IndexSetUpdateRequest {
+    @JsonProperty("id")
+    public abstract String id();
+
+    @JsonProperty("title")
+    @NotBlank
+    public abstract String title();
+
+    @JsonProperty("description")
+    @Nullable
+    public abstract String description();
+
+    @JsonProperty("default")
+    public abstract boolean isDefault();
+
+    @JsonProperty("writable")
+    public abstract boolean isWritable();
+
+    @JsonProperty("shards")
+    @Min(1)
+    public abstract int shards();
+
+    @JsonProperty("replicas")
+    @Min(0)
+    public abstract int replicas();
+
+    @JsonProperty("rotation_strategy_class")
+    @NotNull
+    public abstract String rotationStrategyClass();
+
+    @JsonProperty("rotation_strategy")
+    @NotNull
+    public abstract RotationStrategyConfig rotationStrategy();
+
+    @JsonProperty("retention_strategy_class")
+    @NotNull
+    public abstract String retentionStrategyClass();
+
+    @JsonProperty("retention_strategy")
+    @NotNull
+    public abstract RetentionStrategyConfig retentionStrategy();
+
+    @JsonCreator
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public static IndexSetUpdateRequest create(@JsonProperty("id") String id,
+                                               @JsonProperty("title") @NotBlank String title,
+                                               @JsonProperty("description") @Nullable String description,
+                                               @JsonProperty("default") boolean isDefault,
+                                               @JsonProperty("writable") boolean isWritable,
+                                               @JsonProperty("shards") @Min(1) int shards,
+                                               @JsonProperty("replicas") @Min(0) int replicas,
+                                               @JsonProperty("rotation_strategy_class") @NotNull String rotationStrategyClass,
+                                               @JsonProperty("rotation_strategy") @NotNull RotationStrategyConfig rotationStrategy,
+                                               @JsonProperty("retention_strategy_class") @NotNull String retentionStrategyClass,
+                                               @JsonProperty("retention_strategy") @NotNull RetentionStrategyConfig retentionStrategy) {
+        return new AutoValue_IndexSetUpdateRequest(id, title, description, isDefault, isWritable, shards, replicas, rotationStrategyClass, rotationStrategy, retentionStrategyClass, retentionStrategy);
+    }
+
+    public static IndexSetUpdateRequest fromIndexSetConfig(IndexSetConfig indexSet) {
+        return create(
+                indexSet.id(),
+                indexSet.title(),
+                indexSet.description(),
+                indexSet.isDefault(),
+                indexSet.isWritable(),
+                indexSet.shards(),
+                indexSet.replicas(),
+                indexSet.rotationStrategyClass(),
+                indexSet.rotationStrategy(),
+                indexSet.retentionStrategyClass(),
+                indexSet.retentionStrategy());
+
+    }
+
+    public IndexSetConfig toIndexSetConfig(IndexSetConfig oldConfig) {
+        return IndexSetConfig.create(
+                id(),
+                title(),
+                description(),
+                isDefault(),
+                isWritable(),
+                oldConfig.indexPrefix(),
+                oldConfig.indexMatchPattern(),
+                oldConfig.indexWildcard(),
+                shards(),
+                replicas(),
+                rotationStrategyClass(),
+                rotationStrategy(),
+                retentionStrategyClass(),
+                retentionStrategy(),
+                oldConfig.creationDate());
+    }
+}

--- a/graylog2-server/src/test/java/org/graylog2/indexer/IndexSetValidatorTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/indexer/IndexSetValidatorTest.java
@@ -1,0 +1,96 @@
+/**
+ * This file is part of Graylog.
+ *
+ * Graylog is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.graylog2.indexer;
+
+import org.graylog2.indexer.indexset.IndexSetConfig;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnit;
+import org.mockito.junit.MockitoRule;
+
+import java.util.Collections;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class IndexSetValidatorTest {
+    @Rule
+    public final MockitoRule mockitoRule = MockitoJUnit.rule();
+    @Rule
+    public final ExpectedException expectedException = ExpectedException.none();
+
+    @Mock
+    private IndexSetRegistry indexSetRegistry;
+
+    private IndexSetValidator validator;
+
+    @Before
+    public void setUp() throws Exception {
+        this.validator = new IndexSetValidator(indexSetRegistry);
+    }
+
+    @Test
+    public void validate() throws Exception {
+        final String prefix = "graylog_index";
+        final IndexSetConfig newConfig = mock(IndexSetConfig.class);
+        final IndexSet indexSet = mock(IndexSet.class);
+
+        when(indexSet.getIndexPrefix()).thenReturn("foo");
+        when(indexSetRegistry.iterator()).thenReturn(Collections.singleton(indexSet).iterator());
+        when(newConfig.indexPrefix()).thenReturn(prefix);
+
+        final Optional<IndexSetValidator.Error> error = validator.validate(newConfig);
+
+        assertThat(error).isNotPresent();
+    }
+
+    @Test
+    public void validateWhenAlreadyManaged() throws Exception {
+        final String prefix = "graylog_index";
+        final IndexSetConfig newConfig = mock(IndexSetConfig.class);
+        final IndexSet indexSet = mock(IndexSet.class);
+
+        when(indexSet.getIndexPrefix()).thenReturn("foo");
+        when(indexSetRegistry.isManagedIndex("graylog_index_0")).thenReturn(true);
+        when(indexSetRegistry.iterator()).thenReturn(Collections.singleton(indexSet).iterator());
+        when(newConfig.indexPrefix()).thenReturn(prefix);
+
+        final Optional<IndexSetValidator.Error> error = validator.validate(newConfig);
+
+        assertThat(error).isPresent();
+    }
+
+    @Test
+    public void validateWithConflict() throws Exception {
+        final String prefix = "graylog_index";
+        final IndexSetConfig newConfig = mock(IndexSetConfig.class);
+        final IndexSet indexSet = mock(IndexSet.class);
+
+        when(indexSet.getIndexPrefix()).thenReturn("graylog");
+        when(indexSetRegistry.iterator()).thenReturn(Collections.singleton(indexSet).iterator());
+        when(newConfig.indexPrefix()).thenReturn(prefix);
+
+        final Optional<IndexSetValidator.Error> error = validator.validate(newConfig);
+
+        assertThat(error).isNotPresent();
+    }
+}

--- a/graylog2-server/src/test/java/org/graylog2/indexer/IndexSetValidatorTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/indexer/IndexSetValidatorTest.java
@@ -58,9 +58,9 @@ public class IndexSetValidatorTest {
         when(indexSetRegistry.iterator()).thenReturn(Collections.singleton(indexSet).iterator());
         when(newConfig.indexPrefix()).thenReturn(prefix);
 
-        final Optional<IndexSetValidator.Error> error = validator.validate(newConfig);
+        final Optional<IndexSetValidator.Violation> violation = validator.validate(newConfig);
 
-        assertThat(error).isNotPresent();
+        assertThat(violation).isNotPresent();
     }
 
     @Test
@@ -74,9 +74,9 @@ public class IndexSetValidatorTest {
         when(indexSetRegistry.iterator()).thenReturn(Collections.singleton(indexSet).iterator());
         when(newConfig.indexPrefix()).thenReturn(prefix);
 
-        final Optional<IndexSetValidator.Error> error = validator.validate(newConfig);
+        final Optional<IndexSetValidator.Violation> violation = validator.validate(newConfig);
 
-        assertThat(error).isPresent();
+        assertThat(violation).isPresent();
     }
 
     @Test
@@ -89,8 +89,8 @@ public class IndexSetValidatorTest {
         when(indexSetRegistry.iterator()).thenReturn(Collections.singleton(indexSet).iterator());
         when(newConfig.indexPrefix()).thenReturn(prefix);
 
-        final Optional<IndexSetValidator.Error> error = validator.validate(newConfig);
+        final Optional<IndexSetValidator.Violation> violation = validator.validate(newConfig);
 
-        assertThat(error).isPresent();
+        assertThat(violation).isPresent();
     }
 }

--- a/graylog2-server/src/test/java/org/graylog2/indexer/IndexSetValidatorTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/indexer/IndexSetValidatorTest.java
@@ -91,6 +91,6 @@ public class IndexSetValidatorTest {
 
         final Optional<IndexSetValidator.Error> error = validator.validate(newConfig);
 
-        assertThat(error).isNotPresent();
+        assertThat(error).isPresent();
     }
 }

--- a/graylog2-server/src/test/java/org/graylog2/rest/resources/system/indexer/IndexSetsResourceTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/rest/resources/system/indexer/IndexSetsResourceTest.java
@@ -26,6 +26,7 @@ import org.graylog2.indexer.retention.strategies.NoopRetentionStrategy;
 import org.graylog2.indexer.retention.strategies.NoopRetentionStrategyConfig;
 import org.graylog2.indexer.rotation.strategies.MessageCountRotationStrategy;
 import org.graylog2.indexer.rotation.strategies.MessageCountRotationStrategyConfig;
+import org.graylog2.rest.resources.system.indexer.requests.IndexSetUpdateRequest;
 import org.graylog2.rest.resources.system.indexer.responses.IndexSetResponse;
 import org.graylog2.rest.resources.system.indexer.responses.IndexSetSummary;
 import org.graylog2.shared.bindings.GuiceInjectorHolder;
@@ -287,10 +288,12 @@ public class IndexSetsResourceTest {
                 .title("new title")
                 .build();
 
+        when(indexSetService.get("id")).thenReturn(Optional.of(indexSetConfig));
         when(indexSetService.save(indexSetConfig)).thenReturn(updatedIndexSetConfig);
 
-        final IndexSetSummary summary = indexSetsResource.update("id", IndexSetSummary.fromIndexSetConfig(indexSetConfig));
+        final IndexSetSummary summary = indexSetsResource.update("id", IndexSetUpdateRequest.fromIndexSetConfig(indexSetConfig));
 
+        verify(indexSetService, times(1)).get("id");
         verify(indexSetService, times(1)).save(indexSetConfig);
         verifyNoMoreInteractions(indexSetService);
         assertThat(summary.toIndexSetConfig()).isEqualTo(updatedIndexSetConfig);
@@ -319,7 +322,7 @@ public class IndexSetsResourceTest {
         expectedException.expectMessage("Mismatch of IDs in URI path and payload");
 
         try {
-            indexSetsResource.update("wrong-id", IndexSetSummary.fromIndexSetConfig(indexSetConfig));
+            indexSetsResource.update("wrong-id", IndexSetUpdateRequest.fromIndexSetConfig(indexSetConfig));
         } finally {
             verifyZeroInteractions(indexSetService);
         }
@@ -348,7 +351,7 @@ public class IndexSetsResourceTest {
         expectedException.expectMessage("Not authorized to access resource id <wrong-id>");
 
         try {
-            indexSetsResource.update("wrong-id", IndexSetSummary.fromIndexSetConfig(indexSetConfig));
+            indexSetsResource.update("wrong-id", IndexSetUpdateRequest.fromIndexSetConfig(indexSetConfig));
         } finally {
             verifyZeroInteractions(indexSetService);
         }

--- a/graylog2-server/src/test/java/org/graylog2/rest/resources/system/indexer/IndexSetsResourceTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/rest/resources/system/indexer/IndexSetsResourceTest.java
@@ -19,6 +19,7 @@ package org.graylog2.rest.resources.system.indexer;
 import org.apache.shiro.subject.Subject;
 import org.graylog2.indexer.IndexSet;
 import org.graylog2.indexer.IndexSetRegistry;
+import org.graylog2.indexer.IndexSetValidator;
 import org.graylog2.indexer.indexset.IndexSetConfig;
 import org.graylog2.indexer.indexset.IndexSetService;
 import org.graylog2.indexer.indices.jobs.IndexSetCleanupJob;
@@ -70,6 +71,8 @@ public class IndexSetsResourceTest {
     @Mock
     private IndexSetRegistry indexSetRegistry;
     @Mock
+    private IndexSetValidator indexSetValidator;
+    @Mock
     private IndexSetCleanupJob.Factory indexSetCleanupJobFactory;
     @Mock
     private SystemJobManager systemJobManager;
@@ -80,7 +83,7 @@ public class IndexSetsResourceTest {
 
     @Test
     public void list() {
-        final IndexSetsResource indexSetsResource = new TestResource(indexSetService, indexSetRegistry, indexSetCleanupJobFactory, systemJobManager, true);
+        final IndexSetsResource indexSetsResource = new TestResource(indexSetService, indexSetRegistry, indexSetValidator, indexSetCleanupJobFactory, systemJobManager, true);
         final IndexSetConfig indexSetConfig = IndexSetConfig.create(
                 "id",
                 "title",
@@ -109,7 +112,7 @@ public class IndexSetsResourceTest {
 
     @Test
     public void listDenied() {
-        final IndexSetsResource indexSetsResource = new TestResource(indexSetService, indexSetRegistry, indexSetCleanupJobFactory, systemJobManager, false);
+        final IndexSetsResource indexSetsResource = new TestResource(indexSetService, indexSetRegistry, indexSetValidator, indexSetCleanupJobFactory, systemJobManager, false);
         final IndexSetConfig indexSetConfig = IndexSetConfig.create(
                 "id",
                 "title",
@@ -138,7 +141,7 @@ public class IndexSetsResourceTest {
 
     @Test
     public void list0() {
-        final IndexSetsResource indexSetsResource = new TestResource(indexSetService, indexSetRegistry, indexSetCleanupJobFactory, systemJobManager, true);
+        final IndexSetsResource indexSetsResource = new TestResource(indexSetService, indexSetRegistry, indexSetValidator, indexSetCleanupJobFactory, systemJobManager, true);
         when(indexSetService.findAll()).thenReturn(Collections.emptyList());
 
         final IndexSetResponse list = indexSetsResource.list(0, 0);
@@ -152,7 +155,7 @@ public class IndexSetsResourceTest {
 
     @Test
     public void get() {
-        final IndexSetsResource indexSetsResource = new TestResource(indexSetService, indexSetRegistry, indexSetCleanupJobFactory, systemJobManager, true);
+        final IndexSetsResource indexSetsResource = new TestResource(indexSetService, indexSetRegistry, indexSetValidator, indexSetCleanupJobFactory, systemJobManager, true);
         final IndexSetConfig indexSetConfig = IndexSetConfig.create(
                 "id",
                 "title",
@@ -179,7 +182,7 @@ public class IndexSetsResourceTest {
 
     @Test
     public void get0() {
-        final IndexSetsResource indexSetsResource = new TestResource(indexSetService, indexSetRegistry, indexSetCleanupJobFactory, systemJobManager, true);
+        final IndexSetsResource indexSetsResource = new TestResource(indexSetService, indexSetRegistry, indexSetValidator, indexSetCleanupJobFactory, systemJobManager, true);
         when(indexSetService.get("id")).thenReturn(Optional.empty());
 
         expectedException.expect(NotFoundException.class);
@@ -195,7 +198,7 @@ public class IndexSetsResourceTest {
 
     @Test
     public void getDenied() {
-        final IndexSetsResource indexSetsResource = new TestResource(indexSetService, indexSetRegistry, indexSetCleanupJobFactory, systemJobManager, false);
+        final IndexSetsResource indexSetsResource = new TestResource(indexSetService, indexSetRegistry, indexSetValidator, indexSetCleanupJobFactory, systemJobManager, false);
 
         expectedException.expect(ForbiddenException.class);
         expectedException.expectMessage("Not authorized to access resource id <id>");
@@ -209,7 +212,7 @@ public class IndexSetsResourceTest {
 
     @Test
     public void save() {
-        final IndexSetsResource indexSetsResource = new TestResource(indexSetService, indexSetRegistry, indexSetCleanupJobFactory, systemJobManager, true);
+        final IndexSetsResource indexSetsResource = new TestResource(indexSetService, indexSetRegistry, indexSetValidator, indexSetCleanupJobFactory, systemJobManager, true);
         final IndexSetConfig indexSetConfig = IndexSetConfig.create(
                 "title",
                 "description",
@@ -240,7 +243,7 @@ public class IndexSetsResourceTest {
     @Test
     @Ignore("Currently doesn't work with @RequiresPermissions")
     public void saveDenied() {
-        final IndexSetsResource indexSetsResource = new TestResource(indexSetService, indexSetRegistry, indexSetCleanupJobFactory, systemJobManager, false);
+        final IndexSetsResource indexSetsResource = new TestResource(indexSetService, indexSetRegistry, indexSetValidator, indexSetCleanupJobFactory, systemJobManager, false);
         final IndexSetConfig indexSetConfig = IndexSetConfig.create(
                 "title",
                 "description",
@@ -268,7 +271,7 @@ public class IndexSetsResourceTest {
 
     @Test
     public void update() {
-        final IndexSetsResource indexSetsResource = new TestResource(indexSetService, indexSetRegistry, indexSetCleanupJobFactory, systemJobManager, true);
+        final IndexSetsResource indexSetsResource = new TestResource(indexSetService, indexSetRegistry, indexSetValidator, indexSetCleanupJobFactory, systemJobManager, true);
         final IndexSetConfig indexSetConfig = IndexSetConfig.create(
                 "id",
                 "new title",
@@ -301,7 +304,7 @@ public class IndexSetsResourceTest {
 
     @Test
     public void updateIdMismatch() {
-        final IndexSetsResource indexSetsResource = new TestResource(indexSetService, indexSetRegistry, indexSetCleanupJobFactory, systemJobManager, true);
+        final IndexSetsResource indexSetsResource = new TestResource(indexSetService, indexSetRegistry, indexSetValidator, indexSetCleanupJobFactory, systemJobManager, true);
         final IndexSetConfig indexSetConfig = IndexSetConfig.create(
                 "id",
                 "new title",
@@ -330,7 +333,7 @@ public class IndexSetsResourceTest {
 
     @Test
     public void updateDenied() {
-        final IndexSetsResource indexSetsResource = new TestResource(indexSetService, indexSetRegistry, indexSetCleanupJobFactory, systemJobManager, false);
+        final IndexSetsResource indexSetsResource = new TestResource(indexSetService, indexSetRegistry, indexSetValidator, indexSetCleanupJobFactory, systemJobManager, false);
         final IndexSetConfig indexSetConfig = IndexSetConfig.create(
                 "id",
                 "title",
@@ -359,7 +362,7 @@ public class IndexSetsResourceTest {
 
     @Test
     public void delete() throws Exception {
-        final IndexSetsResource indexSetsResource = new TestResource(indexSetService, indexSetRegistry, indexSetCleanupJobFactory, systemJobManager, true);
+        final IndexSetsResource indexSetsResource = new TestResource(indexSetService, indexSetRegistry, indexSetValidator, indexSetCleanupJobFactory, systemJobManager, true);
         final IndexSet indexSet = mock(IndexSet.class);
         final IndexSetConfig indexSetConfig = mock(IndexSetConfig.class);
 
@@ -379,7 +382,7 @@ public class IndexSetsResourceTest {
 
     @Test
     public void delete0() throws Exception {
-        final IndexSetsResource indexSetsResource = new TestResource(indexSetService, indexSetRegistry, indexSetCleanupJobFactory, systemJobManager, true);
+        final IndexSetsResource indexSetsResource = new TestResource(indexSetService, indexSetRegistry, indexSetValidator, indexSetCleanupJobFactory, systemJobManager, true);
         final IndexSet indexSet = mock(IndexSet.class);
         final IndexSetConfig indexSetConfig = mock(IndexSetConfig.class);
 
@@ -401,7 +404,7 @@ public class IndexSetsResourceTest {
 
     @Test
     public void deleteDefaultIndexSet() throws Exception {
-        final IndexSetsResource indexSetsResource = new TestResource(indexSetService, indexSetRegistry, indexSetCleanupJobFactory, systemJobManager, true);
+        final IndexSetsResource indexSetsResource = new TestResource(indexSetService, indexSetRegistry, indexSetValidator, indexSetCleanupJobFactory, systemJobManager, true);
         final IndexSet indexSet = mock(IndexSet.class);
         final IndexSetConfig indexSetConfig = mock(IndexSetConfig.class);
 
@@ -423,7 +426,7 @@ public class IndexSetsResourceTest {
 
     @Test
     public void deleteDenied() {
-        final IndexSetsResource indexSetsResource = new TestResource(indexSetService, indexSetRegistry, indexSetCleanupJobFactory, systemJobManager, false);
+        final IndexSetsResource indexSetsResource = new TestResource(indexSetService, indexSetRegistry, indexSetValidator, indexSetCleanupJobFactory, systemJobManager, false);
 
         expectedException.expect(ForbiddenException.class);
         expectedException.expectMessage("Not authorized to access resource id <id>");
@@ -438,8 +441,8 @@ public class IndexSetsResourceTest {
     private static class TestResource extends IndexSetsResource {
         private final boolean permitted;
 
-        TestResource(IndexSetService indexSetService, IndexSetRegistry indexSetRegistry, IndexSetCleanupJob.Factory indexSetCleanupJobFactory, SystemJobManager systemJobManager, boolean permitted) {
-            super(indexSetService, indexSetRegistry, indexSetCleanupJobFactory, systemJobManager);
+        TestResource(IndexSetService indexSetService, IndexSetRegistry indexSetRegistry, IndexSetValidator indexSetValidator, IndexSetCleanupJob.Factory indexSetCleanupJobFactory, SystemJobManager systemJobManager, boolean permitted) {
+            super(indexSetService, indexSetRegistry, indexSetValidator, indexSetCleanupJobFactory, systemJobManager);
             this.permitted = permitted;
         }
 

--- a/graylog2-web-interface/src/stores/indices/IndexSetsStore.jsx
+++ b/graylog2-web-interface/src/stores/indices/IndexSetsStore.jsx
@@ -33,7 +33,7 @@ const IndexSetsStore = Reflux.createStore({
       .then(
         response => this.trigger({ indexSetsCount: response.total, indexSets: response.index_sets }),
         error => {
-          UserNotification.error(`Fetching index sets list failed: ${error.message}`,
+          UserNotification.error(`Fetching index sets list failed: ${this._errorMessage(error)}`,
             'Could not retrieve index sets.');
         });
 
@@ -49,7 +49,7 @@ const IndexSetsStore = Reflux.createStore({
         return response;
       },
       error => {
-        UserNotification.error(`Fetching index set '${indexSetId}' failed with status: ${error.message}`, 'Could not retrieve index set.');
+        UserNotification.error(`Fetching index set '${indexSetId}' failed with status: ${this._errorMessage(error)}`, 'Could not retrieve index set.');
       }
     );
 
@@ -66,7 +66,7 @@ const IndexSetsStore = Reflux.createStore({
         return response;
       },
       error => {
-        UserNotification.error(`Updating index set '${indexSet.id}' failed with status: ${error.message}`, 'Could not update index set.');
+        UserNotification.error(`Updating index set '${indexSet.title}' failed with status: ${this._errorMessage(error)}`, 'Could not update index set.');
       }
     );
 
@@ -83,7 +83,7 @@ const IndexSetsStore = Reflux.createStore({
         return response;
       },
       error => {
-        UserNotification.error(`Creating index set '${indexSet.id}' failed with status: ${error.message}`, 'Could not create index set.');
+        UserNotification.error(`Creating index set '${indexSet.title}' failed with status: ${this._errorMessage(error)}`, 'Could not create index set.');
       }
     );
 
@@ -98,11 +98,19 @@ const IndexSetsStore = Reflux.createStore({
         UserNotification.success(`Successfully deleted index set '${indexSet.title}'`, 'Success');
       },
       error => {
-        UserNotification.error(`Deleting index set '${indexSet.title}' failed with status: ${error.message}`, 'Could not delete index set.');
+        UserNotification.error(`Deleting index set '${indexSet.title}' failed with status: ${this._errorMessage(error)}`, 'Could not delete index set.');
       }
     );
 
     IndexSetsActions.delete.promise(promise);
+  },
+
+  _errorMessage(error) {
+    try {
+      return error.additional.body.message;
+    } catch (e) {
+      return error.message;
+    }
   },
 });
 


### PR DESCRIPTION
- Create an unique index on the `index_prefix` field in MongoDB
- Handle `DuplicateKeyException` in the index sets resource
- Add a warning to the UPGRADING file about rotation/retention plugins
- Implement some checks to avoid the creation of index sets with conflicting index prefixes