### PR TITLE
Improved alarm callback testing

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/rest/resources/streams/alerts/StreamAlertResource.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/resources/streams/alerts/StreamAlertResource.java
@@ -295,14 +295,14 @@ public class StreamAlertResource extends RestResource {
             @ApiResponse(code = 400, message = "Stream has no alarm callbacks")
     })
     @NoAuditEvent("only used to test alert emails")
-    public void sendDummyAlert(@ApiParam(name = "streamId", value = "The stream id the dummy alert should be sent for.", required = true)
+    public void sendDummyAlert(@ApiParam(name = "streamId", value = "The stream id the test alert should be sent for.", required = true)
                                @PathParam("streamId") String streamId)
             throws TransportConfigurationException, EmailException, NotFoundException {
         checkPermission(RestPermissions.STREAMS_EDIT, streamId);
 
         final Stream stream = streamService.load(streamId);
 
-        final DummyAlertCondition dummyAlertCondition = new DummyAlertCondition(stream, null, Tools.nowUTC(), getSubject().getPrincipal().toString(), Collections.emptyMap(), "Dummy Alert");
+        final DummyAlertCondition dummyAlertCondition = new DummyAlertCondition(stream, null, Tools.nowUTC(), getSubject().getPrincipal().toString(), Collections.emptyMap(), "Test Alert");
         try {
             AbstractAlertCondition.CheckResult checkResult = dummyAlertCondition.runCheck();
             List<AlarmCallbackConfiguration> callConfigurations = alarmCallbackConfigurationService.getForStream(stream);

--- a/graylog2-web-interface/src/actions/alertnotifications/AlertNotificationsActions.jsx
+++ b/graylog2-web-interface/src/actions/alertnotifications/AlertNotificationsActions.jsx
@@ -3,6 +3,7 @@ import Reflux from 'reflux';
 const AlertNotificationsActions = Reflux.createActions({
   available: { asyncResult: true },
   listAll: { asyncResult: true },
+  testAlert: { asyncResult: true },
 });
 
 export default AlertNotificationsActions;

--- a/graylog2-web-interface/src/components/alertnotifications/AlertNotification.jsx
+++ b/graylog2-web-interface/src/components/alertnotifications/AlertNotification.jsx
@@ -17,8 +17,16 @@ const AlertNotification = React.createClass({
   },
   mixins: [Reflux.connect(AlertNotificationsStore)],
 
+  getInitialState() {
+    return {
+      isTestingAlert: false,
+    };
+  },
+
   _onTestNotification() {
-    AlertNotificationsActions.testAlert(this.props.alertNotification.id);
+    this.setState({ isTestingAlert: true });
+    AlertNotificationsStore.testAlert(this.props.alertNotification.id)
+      .finally(() => this.setState({ isTestingAlert: false }));
   },
 
   _onEdit() {
@@ -51,7 +59,9 @@ const AlertNotification = React.createClass({
       : 'Not executed, as it is not connected to a stream');
 
     const actions = [
-      <Button key="test-button" bsStyle="info" onClick={this._onTestNotification}>Test</Button>,
+      <Button key="test-button" bsStyle="info" disabled={this.state.isTestingAlert} onClick={this._onTestNotification}>
+        {this.state.isTestingAlert ? 'Testing...' : 'Test'}
+      </Button>,
       <DropdownButton key="more-actions-button" title="More actions" pullRight
                       id={`more-actions-dropdown-${notification.id}`}>
         <MenuItem onSelect={this._onEdit}>Edit</MenuItem>

--- a/graylog2-web-interface/src/components/alertnotifications/AlertNotification.jsx
+++ b/graylog2-web-interface/src/components/alertnotifications/AlertNotification.jsx
@@ -5,7 +5,6 @@ import { Button, Col, DropdownButton, MenuItem } from 'react-bootstrap';
 import CombinedProvider from 'injection/CombinedProvider';
 const { AlertNotificationsStore, AlertNotificationsActions } = CombinedProvider.get('AlertNotifications');
 const { AlarmCallbacksActions } = CombinedProvider.get('AlarmCallbacks');
-const { StreamsStore } = CombinedProvider.get('Streams');
 
 import { EntityListItem } from 'components/common';
 import { UnknownAlertNotification } from 'components/alertnotifications';
@@ -19,7 +18,7 @@ const AlertNotification = React.createClass({
   mixins: [Reflux.connect(AlertNotificationsStore)],
 
   _onTestNotification() {
-    StreamsStore.sendDummyAlert(this.props.alertNotification.stream_id);
+    AlertNotificationsActions.testAlert(this.props.alertNotification.id);
   },
 
   _onEdit() {

--- a/graylog2-web-interface/src/routing/ApiRoutes.js
+++ b/graylog2-web-interface/src/routing/ApiRoutes.js
@@ -7,6 +7,7 @@ const ApiRoutes = {
     delete: (streamId, alarmCallbackId) => { return { url: `/streams/${streamId}/alarmcallbacks/${alarmCallbackId}` }; },
     listAll: () => { return { url: '/alerts/callbacks' }; },
     list: (streamId) => { return { url: `/streams/${streamId}/alarmcallbacks` }; },
+    testAlert: (alarmCallbackId) => { return { url: `/alerts/callbacks/${alarmCallbackId}/test` }; },
     update: (streamId, alarmCallbackId) => { return { url: `/streams/${streamId}/alarmcallbacks/${alarmCallbackId}` }; },
   },
   AlarmCallbackHistoryApiController: {

--- a/graylog2-web-interface/src/stores/alertnotifications/AlertNotificationsStore.js
+++ b/graylog2-web-interface/src/stores/alertnotifications/AlertNotificationsStore.js
@@ -69,6 +69,9 @@ const AlertNotificationsStore = Reflux.createStore({
     );
 
     AlertNotificationsActions.testAlert.promise(promise);
+
+    // Need to do this to handle possible concurrent calls to this method
+    return promise;
   },
 });
 

--- a/graylog2-web-interface/src/stores/alertnotifications/AlertNotificationsStore.js
+++ b/graylog2-web-interface/src/stores/alertnotifications/AlertNotificationsStore.js
@@ -37,6 +37,7 @@ const AlertNotificationsStore = Reflux.createStore({
 
     AlertNotificationsActions.available.promise(promise);
   },
+
   listAll() {
     const url = URLUtils.qualifyUrl(ApiRoutes.AlarmCallbacksApiController.listAll().url);
     const promise = fetch('GET', url);
@@ -52,6 +53,22 @@ const AlertNotificationsStore = Reflux.createStore({
       });
 
     AlertNotificationsActions.listAll.promise(promise);
+  },
+
+  testAlert(alarmCallbackId) {
+    const url = URLUtils.qualifyUrl(ApiRoutes.AlarmCallbacksApiController.testAlert(alarmCallbackId).url);
+
+    const promise = fetch('POST', url);
+    promise.then(
+      () => UserNotification.success('Test notification was sent successfully'),
+      (error) => {
+        const message = (error.additional && error.additional.body && error.additional.body.message ? error.additional.body.message : error.message);
+        UserNotification.error(`Sending test alert notification failed with message: ${message}`,
+          'Could not send test alert notification');
+      }
+    );
+
+    AlertNotificationsActions.testAlert.promise(promise);
   },
 });
 


### PR DESCRIPTION
This PR fixes two of the open tasks for alerting #3178:
- Ensures that testing an `EmailAlarmCallback` is throwing exceptions when there are errors, that can be displayed to the user when testing a callback
- Adds a new REST resource, allowing users to test single alarm callbacks