### PR TITLE
Improve IndexSetValidator

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/indexer/IndexSetValidator.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/IndexSetValidator.java
@@ -39,9 +39,10 @@ public class IndexSetValidator {
 
         // Check if an existing index set has a more generic index prefix.
         // Example: new=graylog_foo existing=graylog => graylog is more generic so this is an error
+        // Example: new=gray        existing=graylog => gray    is more generic so this is an error
         // This avoids problems with wildcard matching like "graylog_*".
         for (final IndexSet indexSet : indexSetRegistry) {
-            if (newConfig.indexPrefix().startsWith(indexSet.getIndexPrefix())) {
+            if (newConfig.indexPrefix().startsWith(indexSet.getIndexPrefix()) || indexSet.getIndexPrefix().startsWith(newConfig.indexPrefix())) {
                 return Optional.of(Violation.create("Index prefix \"" + newConfig.indexPrefix() + "\" would conflict with existing index set prefix \"" + indexSet.getIndexPrefix() + "\""));
             }
         }

--- a/graylog2-server/src/test/java/org/graylog2/indexer/IndexSetValidatorTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/indexer/IndexSetValidatorTest.java
@@ -81,13 +81,30 @@ public class IndexSetValidatorTest {
 
     @Test
     public void validateWithConflict() throws Exception {
-        final String prefix = "graylog_index";
         final IndexSetConfig newConfig = mock(IndexSetConfig.class);
         final IndexSet indexSet = mock(IndexSet.class);
 
-        when(indexSet.getIndexPrefix()).thenReturn("graylog");
         when(indexSetRegistry.iterator()).thenReturn(Collections.singleton(indexSet).iterator());
-        when(newConfig.indexPrefix()).thenReturn(prefix);
+
+        // New index prefix starts with existing index prefix
+        when(indexSet.getIndexPrefix()).thenReturn("graylog");
+        when(newConfig.indexPrefix()).thenReturn("graylog_index");
+
+        final Optional<IndexSetValidator.Violation> violation = validator.validate(newConfig);
+
+        assertThat(violation).isPresent();
+    }
+
+    @Test
+    public void validateWithConflict2() throws Exception {
+        final IndexSetConfig newConfig = mock(IndexSetConfig.class);
+        final IndexSet indexSet = mock(IndexSet.class);
+
+        when(indexSetRegistry.iterator()).thenReturn(Collections.singleton(indexSet).iterator());
+
+        // Existing index prefix starts with new index prefix
+        when(indexSet.getIndexPrefix()).thenReturn("graylog");
+        when(newConfig.indexPrefix()).thenReturn("gray");
 
         final Optional<IndexSetValidator.Violation> violation = validator.validate(newConfig);
 


### PR DESCRIPTION
A new index set prefix is also invalid if an existing index prefix starts with the new one.