### PR TITLE
Add custom Jackson (de-) serializer for ZonedDateTime

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/bindings/providers/MongoJackObjectMapperProvider.java
+++ b/graylog2-server/src/main/java/org/graylog2/bindings/providers/MongoJackObjectMapperProvider.java
@@ -25,9 +25,12 @@ import com.fasterxml.jackson.databind.jsontype.TypeIdResolver;
 import com.fasterxml.jackson.databind.module.SimpleModule;
 import com.fasterxml.jackson.databind.type.SimpleType;
 import org.graylog2.indexer.retention.strategies.UnknownRetentionStrategyConfig;
+import org.graylog2.jackson.MongoJodaDateTimeDeserializer;
+import org.graylog2.jackson.MongoJodaDateTimeSerializer;
 import org.graylog2.jackson.MongoZonedDateTimeDeserializer;
 import org.graylog2.jackson.MongoZonedDateTimeSerializer;
 import org.graylog2.plugin.indexer.retention.RetentionStrategyConfig;
+import org.joda.time.DateTime;
 import org.mongojack.internal.MongoJackModule;
 
 import javax.inject.Inject;
@@ -46,7 +49,9 @@ public class MongoJackObjectMapperProvider implements Provider<ObjectMapper> {
                 .setPropertyNamingStrategy(new PreserveLeadingUnderscoreStrategy())
                 .registerModule(new SimpleModule("JSR-310-MongoJack")
                         .addSerializer(ZonedDateTime.class, new MongoZonedDateTimeSerializer())
-                        .addDeserializer(ZonedDateTime.class, new MongoZonedDateTimeDeserializer()));
+                        .addDeserializer(ZonedDateTime.class, new MongoZonedDateTimeDeserializer())
+                        .addSerializer(DateTime.class, new MongoJodaDateTimeSerializer())
+                        .addDeserializer(DateTime.class, new MongoJodaDateTimeDeserializer()));
 
         MongoJackModule.configure(this.objectMapper);
     }

--- a/graylog2-server/src/main/java/org/graylog2/jackson/MongoJodaDateTimeDeserializer.java
+++ b/graylog2-server/src/main/java/org/graylog2/jackson/MongoJodaDateTimeDeserializer.java
@@ -1,0 +1,57 @@
+/**
+ * This file is part of Graylog.
+ *
+ * Graylog is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.graylog2.jackson;
+
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.deser.std.StdScalarDeserializer;
+import org.joda.time.DateTime;
+import org.joda.time.DateTimeZone;
+import org.joda.time.format.DateTimeFormat;
+import org.joda.time.format.DateTimeFormatter;
+import org.joda.time.format.ISODateTimeFormat;
+
+import java.io.IOException;
+import java.util.Date;
+import java.util.Locale;
+
+public final class MongoJodaDateTimeDeserializer extends StdScalarDeserializer<DateTime> {
+    private static final DateTimeFormatter FORMATTER = ISODateTimeFormat.dateTime();
+
+    public MongoJodaDateTimeDeserializer() {
+        super(DateTime.class);
+    }
+
+    @Override
+    public DateTime deserialize(JsonParser jsonParser, DeserializationContext deserializationContext) throws IOException {
+        switch (jsonParser.currentToken()) {
+            case VALUE_EMBEDDED_OBJECT:
+                final Object embeddedObject = jsonParser.getEmbeddedObject();
+                if (embeddedObject instanceof Date) {
+                    final Date date = (Date) embeddedObject;
+                    return new DateTime(date);
+                } else {
+                    throw new IllegalStateException("Unsupported token: " + jsonParser.currentToken());
+                }
+            case VALUE_STRING:
+                final String text = jsonParser.getText();
+                return DateTime.parse(text, FORMATTER).withZone(DateTimeZone.UTC);
+            default:
+                throw new IllegalStateException("Unsupported token: " + jsonParser.currentToken());
+        }
+    }
+}

--- a/graylog2-server/src/main/java/org/graylog2/jackson/MongoJodaDateTimeSerializer.java
+++ b/graylog2-server/src/main/java/org/graylog2/jackson/MongoJodaDateTimeSerializer.java
@@ -1,0 +1,40 @@
+/**
+ * This file is part of Graylog.
+ *
+ * Graylog is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.graylog2.jackson;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.SerializerProvider;
+import com.fasterxml.jackson.databind.ser.std.StdScalarSerializer;
+import org.joda.time.DateTime;
+import org.joda.time.DateTimeZone;
+
+import java.io.IOException;
+import java.util.Date;
+
+public final class MongoJodaDateTimeSerializer extends StdScalarSerializer<DateTime> {
+    public MongoJodaDateTimeSerializer() {
+        super(DateTime.class);
+    }
+
+    @Override
+    public void serialize(DateTime dateTime,
+                          JsonGenerator jsonGenerator,
+                          SerializerProvider serializerProvider) throws IOException {
+        final Date date = dateTime.withZone(DateTimeZone.UTC).toDate();
+        jsonGenerator.writeObject(date);
+    }
+}

--- a/graylog2-server/src/main/java/org/graylog2/jackson/MongoZonedDateTimeDeserializer.java
+++ b/graylog2-server/src/main/java/org/graylog2/jackson/MongoZonedDateTimeDeserializer.java
@@ -1,0 +1,59 @@
+/**
+ * This file is part of Graylog.
+ *
+ * Graylog is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.graylog2.jackson;
+
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.deser.std.StdScalarDeserializer;
+
+import java.io.IOException;
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeFormatterBuilder;
+import java.util.Date;
+
+public final class MongoZonedDateTimeDeserializer extends StdScalarDeserializer<ZonedDateTime> {
+    private static final DateTimeFormatter FORMATTER = new DateTimeFormatterBuilder()
+            .parseCaseInsensitive()
+            .append(DateTimeFormatter.ISO_LOCAL_DATE_TIME)
+            .appendOffset("+HHmm", "Z")
+            .toFormatter();
+
+    public MongoZonedDateTimeDeserializer() {
+        super(ZonedDateTime.class);
+    }
+
+    @Override
+    public ZonedDateTime deserialize(JsonParser jsonParser, DeserializationContext deserializationContext) throws IOException {
+        switch (jsonParser.currentToken()) {
+            case VALUE_EMBEDDED_OBJECT:
+                final Object embeddedObject = jsonParser.getEmbeddedObject();
+                if (embeddedObject instanceof Date) {
+                    final Date date = (Date) embeddedObject;
+                    return ZonedDateTime.ofInstant(date.toInstant(), ZoneOffset.UTC);
+                } else {
+                    throw new IllegalStateException("Unsupported token: " + jsonParser.currentToken());
+                }
+            case VALUE_STRING:
+                final String text = jsonParser.getText();
+                return ZonedDateTime.parse(text, FORMATTER).withZoneSameInstant(ZoneOffset.UTC);
+            default:
+                throw new IllegalStateException("Unsupported token: " + jsonParser.currentToken());
+        }
+    }
+}

--- a/graylog2-server/src/main/java/org/graylog2/jackson/MongoZonedDateTimeSerializer.java
+++ b/graylog2-server/src/main/java/org/graylog2/jackson/MongoZonedDateTimeSerializer.java
@@ -1,0 +1,42 @@
+/**
+ * This file is part of Graylog.
+ *
+ * Graylog is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.graylog2.jackson;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.SerializerProvider;
+import com.fasterxml.jackson.databind.ser.std.StdScalarSerializer;
+
+import java.io.IOException;
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
+import java.util.Date;
+
+public final class MongoZonedDateTimeSerializer extends StdScalarSerializer<ZonedDateTime> {
+    public MongoZonedDateTimeSerializer() {
+        super(ZonedDateTime.class);
+    }
+
+    @Override
+    public void serialize(ZonedDateTime zonedDateTime,
+                          JsonGenerator jsonGenerator,
+                          SerializerProvider serializerProvider) throws IOException {
+        final Instant instant = zonedDateTime.withZoneSameInstant(ZoneOffset.UTC).toInstant();
+        final Date date = Date.from(instant);
+        jsonGenerator.writeObject(date);
+    }
+}

--- a/graylog2-server/src/test/java/org/graylog2/jackson/MongoJodaDateTimeDeserializerTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/jackson/MongoJodaDateTimeDeserializerTest.java
@@ -1,0 +1,49 @@
+/**
+ * This file is part of Graylog.
+ *
+ * Graylog is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.graylog2.jackson;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import org.graylog2.shared.bindings.providers.ObjectMapperProvider;
+import org.joda.time.DateTime;
+import org.joda.time.DateTimeZone;
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class MongoJodaDateTimeDeserializerTest {
+    private final ObjectMapper objectMapper = new ObjectMapperProvider().get();
+
+    @Test
+    public void deserializeDateTime() throws Exception {
+        final String json = "{\"date_time\":\"2016-12-13T16:00:00.000+0200\"}";
+        final TestBean value = objectMapper.readValue(json, TestBean.class);
+        assertThat(value.dateTime).isEqualTo(new DateTime(2016, 12, 13, 14, 0, DateTimeZone.UTC));
+    }
+
+    @Test
+    public void deserializeNull() throws Exception {
+        final String json = "{\"date_time\":null}";
+        final TestBean value = objectMapper.readValue(json, TestBean.class);
+        assertThat(value.dateTime).isNull();
+    }
+
+    static class TestBean {
+        @JsonDeserialize(using = MongoJodaDateTimeDeserializer.class)
+        DateTime dateTime;
+    }
+}

--- a/graylog2-server/src/test/java/org/graylog2/jackson/MongoJodaDateTimeSerializerTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/jackson/MongoJodaDateTimeSerializerTest.java
@@ -1,0 +1,57 @@
+/**
+ * This file is part of Graylog.
+ *
+ * Graylog is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.graylog2.jackson;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import org.graylog2.shared.bindings.providers.ObjectMapperProvider;
+import org.joda.time.DateTime;
+import org.joda.time.DateTimeZone;
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class MongoJodaDateTimeSerializerTest {
+    private final ObjectMapper objectMapper = new ObjectMapperProvider().get();
+
+    @Test
+    public void serializeZonedDateTime() throws Exception {
+        final TestBean testBean = new TestBean(new DateTime(2016, 12, 13, 16, 0, DateTimeZone.forOffsetHours(2)));
+        final String valueAsString = objectMapper.writeValueAsString(testBean);
+        assertThat(valueAsString)
+                .isNotNull()
+                .isEqualTo("{\"date_time\":\"2016-12-13T14:00:00.000+0000\"}");
+    }
+
+    @Test
+    public void serializeNull() throws Exception {
+        final TestBean testBean = new TestBean(null);
+        final String valueAsString = objectMapper.writeValueAsString(testBean);
+        assertThat(valueAsString)
+                .isNotNull()
+                .isEqualTo("{\"date_time\":null}");
+    }
+
+    static class TestBean {
+        @JsonSerialize(using = MongoJodaDateTimeSerializer.class)
+        DateTime dateTime;
+
+        public TestBean(DateTime dateTime) {
+            this.dateTime = dateTime;
+        }
+    }
+}

--- a/graylog2-server/src/test/java/org/graylog2/jackson/MongoZonedDateTimeDeserializerTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/jackson/MongoZonedDateTimeDeserializerTest.java
@@ -1,0 +1,50 @@
+/**
+ * This file is part of Graylog.
+ *
+ * Graylog is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.graylog2.jackson;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import org.graylog2.shared.bindings.providers.ObjectMapperProvider;
+import org.junit.Test;
+
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class MongoZonedDateTimeDeserializerTest {
+    private final ObjectMapper objectMapper = new ObjectMapperProvider().get();
+
+    @Test
+    public void deserializeZonedDateTime() throws Exception {
+        final String json = "{\"date_time\":\"2016-12-13T16:00:00.000+0200\"}";
+        final TestBean value = objectMapper.readValue(json, TestBean.class);
+        assertThat(value.dateTime).isEqualTo(ZonedDateTime.of(2016, 12, 13, 14, 0, 0, 0, ZoneOffset.UTC));
+    }
+
+    @Test
+    public void deserializeNull() throws Exception {
+        final String json = "{\"date_time\":null}";
+        final TestBean value = objectMapper.readValue(json, TestBean.class);
+        assertThat(value.dateTime).isNull();
+    }
+
+    static class TestBean {
+        @JsonDeserialize(using = MongoZonedDateTimeDeserializer.class)
+        ZonedDateTime dateTime;
+    }
+}

--- a/graylog2-server/src/test/java/org/graylog2/jackson/MongoZonedDateTimeSerializerTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/jackson/MongoZonedDateTimeSerializerTest.java
@@ -1,0 +1,58 @@
+/**
+ * This file is part of Graylog.
+ *
+ * Graylog is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.graylog2.jackson;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import org.graylog2.shared.bindings.providers.ObjectMapperProvider;
+import org.junit.Test;
+
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class MongoZonedDateTimeSerializerTest {
+    private final ObjectMapper objectMapper = new ObjectMapperProvider().get();
+
+    @Test
+    public void serializeZonedDateTime() throws Exception {
+        final TestBean testBean = new TestBean(ZonedDateTime.of(2016, 12, 13, 16, 0, 0, 0, ZoneOffset.ofHours(2)));
+        final String valueAsString = objectMapper.writeValueAsString(testBean);
+        assertThat(valueAsString)
+                .isNotNull()
+                .isEqualTo("{\"date_time\":\"2016-12-13T14:00:00.000+0000\"}");
+    }
+
+    @Test
+    public void serializeNull() throws Exception {
+        final TestBean testBean = new TestBean(null);
+        final String valueAsString = objectMapper.writeValueAsString(testBean);
+        assertThat(valueAsString)
+                .isNotNull()
+                .isEqualTo("{\"date_time\":null}");
+    }
+
+    static class TestBean {
+        @JsonSerialize(using = MongoZonedDateTimeSerializer.class)
+        ZonedDateTime dateTime;
+
+        public TestBean(ZonedDateTime dateTime) {
+            this.dateTime = dateTime;
+        }
+    }
+}

--- a/graylog2-server/src/test/resources/org/graylog2/indexer/indexset/MongoIndexSetServiceTest.json
+++ b/graylog2-server/src/test/resources/org/graylog2/indexer/indexset/MongoIndexSetServiceTest.json
@@ -20,7 +20,9 @@
         "type": "org.graylog2.indexer.retention.strategies.NoopRetentionStrategyConfig",
         "max_number_of_indices": 10
       },
-      "creation_date": "2016-10-04T17:00:00Z"
+      "creation_date": {
+        "$date": "2016-10-04T17:00:00Z"
+      }
     },
     {
       "_id": {
@@ -41,7 +43,9 @@
         "type": "org.graylog2.indexer.retention.strategies.NoopRetentionStrategyConfig",
         "max_number_of_indices": 25
       },
-      "creation_date": "2016-10-04T18:00:00Z"
+      "creation_date": {
+        "$date": "2016-10-04T18:00:00Z"
+      }
     }
   ]
 }


### PR DESCRIPTION
## Description

This PR adds a custom serializer and deserializer for `ZonedDateTime` to the `ObjectMapper` used by MongoJack, so that properties with type `ZonedDateTime` are properly serialized as a MongoDB date field.


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.