### PR TITLE
Fix labels on field graphs

### DIFF
--- a/graylog2-web-interface/src/legacy/analyzers/fieldcharts.js
+++ b/graylog2-web-interface/src/legacy/analyzers/fieldcharts.js
@@ -364,6 +364,7 @@ export const FieldChart = {
         if (fieldGraph) {
           const series = fieldGraph.series.filter(aSeries => aSeries.name === seriesName)[0];
           if (series) {
+            series.valuetype = GraphVisualization.getReadableFieldChartStatisticalFunction(options.valuetype);
             series.data = data.values;
             fieldGraph.update();
           }

--- a/graylog2-web-interface/src/legacy/analyzers/fieldcharts.js
+++ b/graylog2-web-interface/src/legacy/analyzers/fieldcharts.js
@@ -453,7 +453,7 @@ export const FieldChart = {
         name: series.name,
         color: lineColor,
         gl2_query: query,
-        valuetype: GraphVisualization.getReadableFieldChartStatisticalFunction(series.valuetype),
+        valuetype: series.valuetype,
         field: series.field,
       };
 


### PR DESCRIPTION
This PR fixes two problems with the statistical functions displayed in field graphs:
- After merging two field graphs, one of the graphs may end up labelling the line with the wrong statistical function
- Changing the statistical function of a field graph is not correctly reflected in the hover information for that graph. To test this, you can create a field graph, change the statistical function, hover over the graph, and see that the function displayed there does not match the one previously selected

Fixes #3187