### PR TITLE
Fix quickvalues and field statistics refresh

### DIFF
--- a/graylog2-web-interface/src/routing/AppWithSearchBar.jsx
+++ b/graylog2-web-interface/src/routing/AppWithSearchBar.jsx
@@ -31,6 +31,7 @@ const AppWithSearchBar = React.createClass({
   ],
   getInitialState() {
     return {
+      forceFetch: false,
       savedSearches: undefined,
       stream: undefined,
       searchesClusterConfig: undefined,
@@ -47,7 +48,6 @@ const AppWithSearchBar = React.createClass({
   componentWillUnmount() {
     SearchStore.unload();
   },
-  forceFetch: false,
   _loadStream(streamId) {
     if (streamId) {
       StreamsStore.get(streamId, (stream) => this.setState({ stream: stream }, this._updateSearchParams));
@@ -67,9 +67,11 @@ const AppWithSearchBar = React.createClass({
   },
   _decorateChildren(children) {
     const decoratedChildren = React.Children.map(children, (child) => {
-      return React.cloneElement(child, { searchConfig: this.state.searchesClusterConfig, forceFetch: this.forceFetch });
+      return React.cloneElement(child, { searchConfig: this.state.searchesClusterConfig, forceFetch: this.state.forceFetch });
     });
-    this.forceFetch = false;
+    if (this.state.forceFetch) {
+      this.setState({ forceFetch: false });
+    }
     return decoratedChildren;
   },
   _searchBarShouldDisplayRefreshControls() {
@@ -77,7 +79,7 @@ const AppWithSearchBar = React.createClass({
     return this.props.location.pathname !== Routes.SOURCES;
   },
   _onExecuteSearch() {
-    this.forceFetch = true;
+    this.setState({ forceFetch: true });
   },
   render() {
     if (this._isLoading()) {


### PR DESCRIPTION
Before this change, resetting `forceFetch` to `false` in `AppWithSearchBar` had no immediate effect, as it required a re-render for the new value to be passed to all children. The effect was that we were fetching data more times than needed.

This PR moves `forceFetch` to the state of `AppWithSearchBar`, so once we reset the value to `false`, all children will see the new value and stop refreshing their data.

Fixes #3086