### PR TITLE
Address open TODOs for Graylog 2.2.0

### DIFF
--- a/UPGRADING.rst
+++ b/UPGRADING.rst
@@ -21,7 +21,7 @@ Due to the extensive rework done in alerting, this behaviour has been modified t
 To easy the transition to people relying on this behaviour, we have added a migration step that will create an Email alarm callback for each stream that has alert conditions, has alert receivers, but has no associated alarm callbacks.
 
 Default stream/Index Sets
----------------------------
+-------------------------
 
 With the introduction of index sets, and the ability to change a stream's write target, the default stream needs additional information, which is calculated when starting a new Graylog 2.2 master node.
 
@@ -37,3 +37,13 @@ RotationStrategy & RetentionStrategy Interfaces
 The Java interfaces for ``RetentionStrategy`` and ``RotationStrategy`` changed in 2.2. The ``#rotate()`` and ``#retain()`` methods are now getting an ``IndexSet`` as first parameter.
 
 This only affects you if you are using custom rotation or retention strategies.
+
+Changes in Exposed Configuration
+--------------------------------
+
+The exposed configuration settings on the ``/system/configuration`` resource of the Graylog REST API doesn't contain the following (deprecated) Elasticsearch-related settings anymore:
+
+* ``elasticsearch_shards``
+* ``elasticsearch_replicas``
+* ``index_optimization_max_num_segments``
+* ``disable_index_optimization``

--- a/graylog2-server/src/main/java/org/graylog2/configuration/ElasticsearchConfiguration.java
+++ b/graylog2-server/src/main/java/org/graylog2/configuration/ElasticsearchConfiguration.java
@@ -114,9 +114,11 @@ public class ElasticsearchConfiguration {
     @Parameter(value = "elasticsearch_replicas", validator = PositiveIntegerValidator.class, required = true)
     private int replicas = 0;
 
+    @Deprecated // Should be removed in Graylog 3.0
     @Parameter(value = "elasticsearch_analyzer", required = true)
     private String analyzer = "standard";
 
+    @Deprecated // Should be removed in Graylog 3.0
     @Parameter(value = "elasticsearch_template_name")
     private String templateName = "graylog-internal";
 
@@ -131,9 +133,11 @@ public class ElasticsearchConfiguration {
     @Parameter(value = "rotation_strategy")
     private String rotationStrategy = "count";
 
+    @Deprecated // Should be removed in Graylog 3.0
     @Parameter(value = "disable_index_optimization")
     private boolean disableIndexOptimization = false;
 
+    @Deprecated // Should be removed in Graylog 3.0
     @Parameter(value = "index_optimization_max_num_segments", validator = PositiveIntegerValidator.class)
     private int indexOptimizationMaxNumSegments = 1;
 
@@ -235,10 +239,12 @@ public class ElasticsearchConfiguration {
         return replicas;
     }
 
+    @Deprecated // Should be removed in Graylog 3.0
     public String getAnalyzer() {
         return analyzer;
     }
 
+    @Deprecated // Should be removed in Graylog 3.0
     public String getTemplateName() {
         return templateName;
     }
@@ -261,10 +267,12 @@ public class ElasticsearchConfiguration {
         return retentionStrategy;
     }
 
+    @Deprecated // Should be removed in Graylog 3.0
     public int getIndexOptimizationMaxNumSegments() {
         return indexOptimizationMaxNumSegments;
     }
 
+    @Deprecated // Should be removed in Graylog 3.0
     public boolean isDisableIndexOptimization() {
         return disableIndexOptimization;
     }

--- a/graylog2-server/src/main/java/org/graylog2/configuration/ExposedConfiguration.java
+++ b/graylog2-server/src/main/java/org/graylog2/configuration/ExposedConfiguration.java
@@ -65,12 +65,6 @@ public abstract class ExposedConfiguration {
     @JsonProperty("allow_leading_wildcard_searches")
     public abstract boolean allowLeadingWildcardSearches();
 
-    @JsonProperty("elasticsearch_shards")
-    public abstract int shards();
-
-    @JsonProperty("elasticsearch_replicas")
-    public abstract int replicas();
-
     @JsonProperty("stream_processing_timeout")
     public abstract long streamProcessingTimeout();
 
@@ -83,16 +77,10 @@ public abstract class ExposedConfiguration {
     @JsonProperty("stale_master_timeout")
     public abstract int staleMasterTimeout();
 
-    @JsonProperty("disable_index_optimization")
-    public abstract boolean disableIndexOptimization();
-
-    @JsonProperty("index_optimization_max_num_segments")
-    public abstract int indexOptimizationMaxSegments();
-
     @JsonProperty("gc_warning_threshold")
     public abstract String gcWarningThreshold();
 
-    public static ExposedConfiguration create(Configuration configuration, ElasticsearchConfiguration esConfiguration) {
+    public static ExposedConfiguration create(Configuration configuration) {
         return create(
                 configuration.getInputbufferProcessors(),
                 configuration.getProcessBufferProcessors(),
@@ -105,14 +93,10 @@ public abstract class ExposedConfiguration {
                 configuration.getNodeIdFile(),
                 configuration.isAllowHighlighting(),
                 configuration.isAllowLeadingWildcardSearches(),
-                esConfiguration.getShards(),
-                esConfiguration.getReplicas(),
                 configuration.getStreamProcessingTimeout(),
                 configuration.getStreamProcessingMaxFaults(),
                 configuration.getOutputModuleTimeout(),
                 configuration.getStaleMasterTimeout(),
-                esConfiguration.isDisableIndexOptimization(),
-                esConfiguration.getIndexOptimizationMaxNumSegments(),
                 configuration.getGcWarningThreshold().toString());
     }
 
@@ -129,14 +113,10 @@ public abstract class ExposedConfiguration {
             @JsonProperty("node_id_file") String nodeIdFile,
             @JsonProperty("allow_highlighting") boolean allowHighlighting,
             @JsonProperty("allow_leading_wildcard_searches") boolean allowLeadingWildcardSearches,
-            @JsonProperty("elasticsearch_shards") int shards,
-            @JsonProperty("elasticsearch_replicas") int replicas,
             @JsonProperty("stream_processing_timeout") long streamProcessingTimeout,
             @JsonProperty("stream_processing_max_faults") int streamProcessingMaxFaults,
             @JsonProperty("output_module_timeout") long outputModuleTimeout,
             @JsonProperty("stale_master_timeout") int staleMasterTimeout,
-            @JsonProperty("disable_index_optimization") boolean disableIndexOptimization,
-            @JsonProperty("index_optimization_max_num_segments") int indexOptimizationMaxSegments,
             @JsonProperty("gc_warning_threshold") String gcWarningThreshold) {
         return new AutoValue_ExposedConfiguration(
                 inputBufferProcessors,
@@ -150,14 +130,10 @@ public abstract class ExposedConfiguration {
                 nodeIdFile,
                 allowHighlighting,
                 allowLeadingWildcardSearches,
-                shards,
-                replicas,
                 streamProcessingTimeout,
                 streamProcessingMaxFaults,
                 outputModuleTimeout,
                 staleMasterTimeout,
-                disableIndexOptimization,
-                indexOptimizationMaxSegments,
                 gcWarningThreshold);
     }
 

--- a/graylog2-server/src/main/java/org/graylog2/indexer/indexset/IndexSetConfig.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/indexset/IndexSetConfig.java
@@ -21,8 +21,8 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.auto.value.AutoValue;
-import org.graylog.autovalue.WithBeanGetter;
 import com.google.common.collect.ComparisonChain;
+import org.graylog.autovalue.WithBeanGetter;
 import org.graylog2.plugin.indexer.retention.RetentionStrategyConfig;
 import org.graylog2.plugin.indexer.rotation.RotationStrategyConfig;
 import org.hibernate.validator.constraints.NotBlank;
@@ -128,7 +128,6 @@ public abstract class IndexSetConfig implements Comparable<IndexSetConfig> {
         return false;
     }
 
-    // TODO 2.2: creation_date is a string but needs to be a date - look at AlertImpl for example
     @JsonCreator
     public static IndexSetConfig create(@Id @ObjectId @JsonProperty("_id") @Nullable String id,
                                         @JsonProperty("title") @NotBlank String title,

--- a/graylog2-server/src/main/java/org/graylog2/indexer/indexset/IndexSetConfig.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/indexset/IndexSetConfig.java
@@ -18,7 +18,6 @@ package org.graylog2.indexer.indexset;
 
 import com.fasterxml.jackson.annotation.JsonAutoDetect;
 import com.fasterxml.jackson.annotation.JsonCreator;
-import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.auto.value.AutoValue;
 import com.google.common.collect.ComparisonChain;
@@ -33,8 +32,6 @@ import javax.annotation.Nullable;
 import javax.validation.constraints.Min;
 import javax.validation.constraints.NotNull;
 import java.time.ZonedDateTime;
-
-import static java.util.Objects.requireNonNull;
 
 @AutoValue
 @WithBeanGetter
@@ -100,40 +97,25 @@ public abstract class IndexSetConfig implements Comparable<IndexSetConfig> {
     @NotNull
     public abstract ZonedDateTime creationDate();
 
-    // TODO 2.2: Migrate config setting to index set!
     @JsonProperty("index_analyzer")
-    @JsonIgnore
-    public String indexAnalyzer() {
-        return "standard";
-    }
+    @NotBlank
+    public abstract String indexAnalyzer();
 
-    // TODO 2.2: Migrate config setting to index set!
     @JsonProperty("index_template_name")
-    @JsonIgnore
-    public String indexTemplateName() {
-        return "graylog-internal-" + requireNonNull(id());
-    }
+    @NotBlank
+    public abstract String indexTemplateName();
 
-    // TODO 2.2: Migrate config setting to index set!
     @JsonProperty("index_optimization_max_num_segments")
-    @JsonIgnore
-    public int indexOptimizationMaxNumSegments() {
-        return 1;
-    }
+    @Min(1L)
+    public abstract int indexOptimizationMaxNumSegments();
 
-    // TODO 2.2: Migrate config setting to index set!
     @JsonProperty("index_optimization_disabled")
-    @JsonIgnore
-    public boolean indexOptimizationDisabled() {
-        return false;
-    }
+    public abstract boolean indexOptimizationDisabled();
 
     @JsonCreator
     public static IndexSetConfig create(@Id @ObjectId @JsonProperty("_id") @Nullable String id,
                                         @JsonProperty("title") @NotBlank String title,
                                         @JsonProperty("description") @Nullable String description,
-                                        // TODO 3.0: Remove "default" field here. A migration in 2.2 removed it.
-                                        @JsonProperty("default") @Nullable Boolean isDefault, // Ignored, older objects might still have it
                                         @JsonProperty("writable") @Nullable Boolean isWritable,
                                         @JsonProperty(FIELD_INDEX_PREFIX) @NotBlank String indexPrefix,
                                         @JsonProperty("index_match_pattern") @Nullable String indexMatchPattern,
@@ -144,7 +126,11 @@ public abstract class IndexSetConfig implements Comparable<IndexSetConfig> {
                                         @JsonProperty("rotation_strategy") @NotNull RotationStrategyConfig rotationStrategy,
                                         @JsonProperty("retention_strategy_class") @Nullable String retentionStrategyClass,
                                         @JsonProperty("retention_strategy") @NotNull RetentionStrategyConfig retentionStrategy,
-                                        @JsonProperty(FIELD_CREATION_DATE) @NotNull ZonedDateTime creationDate) {
+                                        @JsonProperty(FIELD_CREATION_DATE) @NotNull ZonedDateTime creationDate,
+                                        @JsonProperty("index_analyzer") @NotBlank String indexAnalyzer,
+                                        @JsonProperty("index_template_name") @NotBlank String indexTemplateName,
+                                        @JsonProperty("index_optimization_max_num_segments") @Min(1L) int indexOptimizationMaxNumSegments,
+                                        @JsonProperty("index_optimization_disabled") boolean indexOptimizationDisabled) {
         return AutoValue_IndexSetConfig.builder()
                 .id(id)
                 .title(title)
@@ -160,6 +146,10 @@ public abstract class IndexSetConfig implements Comparable<IndexSetConfig> {
                 .retentionStrategyClass(retentionStrategyClass)
                 .retentionStrategy(retentionStrategy)
                 .creationDate(creationDate)
+                .indexAnalyzer(indexAnalyzer)
+                .indexTemplateName(indexTemplateName)
+                .indexOptimizationMaxNumSegments(indexOptimizationMaxNumSegments)
+                .indexOptimizationDisabled(indexOptimizationDisabled)
                 .build();
     }
 
@@ -174,8 +164,14 @@ public abstract class IndexSetConfig implements Comparable<IndexSetConfig> {
                                         RotationStrategyConfig rotationStrategy,
                                         String retentionStrategyClass,
                                         RetentionStrategyConfig retentionStrategy,
-                                        ZonedDateTime creationDate) {
-        return create(id, title, description, null, isWritable, indexPrefix, null, null, shards, replicas, rotationStrategyClass, rotationStrategy, retentionStrategyClass, retentionStrategy, creationDate);
+                                        ZonedDateTime creationDate,
+                                        String indexAnalyzer,
+                                        String indexTemplateName,
+                                        int indexOptimizationMaxNumSegments,
+                                        boolean indexOptimizationDisabled) {
+        return create(id, title, description, isWritable, indexPrefix, null, null, shards, replicas,
+                rotationStrategyClass, rotationStrategy, retentionStrategyClass, retentionStrategy, creationDate,
+                indexAnalyzer, indexTemplateName, indexOptimizationMaxNumSegments, indexOptimizationDisabled);
     }
 
     public static IndexSetConfig create(String title,
@@ -188,8 +184,14 @@ public abstract class IndexSetConfig implements Comparable<IndexSetConfig> {
                                         RotationStrategyConfig rotationStrategy,
                                         String retentionStrategyClass,
                                         RetentionStrategyConfig retentionStrategy,
-                                        ZonedDateTime creationDate) {
-        return create(null, title, description, null, isWritable, indexPrefix, null, null, shards, replicas, rotationStrategyClass, rotationStrategy, retentionStrategyClass, retentionStrategy, creationDate);
+                                        ZonedDateTime creationDate,
+                                        String indexAnalyzer,
+                                        String indexTemplateName,
+                                        int indexOptimizationMaxNumSegments,
+                                        boolean indexOptimizationDisabled) {
+        return create(null, title, description, isWritable, indexPrefix, null, null, shards, replicas,
+                rotationStrategyClass, rotationStrategy, retentionStrategyClass, retentionStrategy, creationDate,
+                indexAnalyzer, indexTemplateName, indexOptimizationMaxNumSegments, indexOptimizationDisabled);
     }
 
     @Override
@@ -237,6 +239,14 @@ public abstract class IndexSetConfig implements Comparable<IndexSetConfig> {
         public abstract Builder retentionStrategy(RetentionStrategyConfig retentionStrategy);
 
         public abstract Builder creationDate(ZonedDateTime creationDate);
+
+        public abstract Builder indexAnalyzer(String analyzer);
+
+        public abstract Builder indexTemplateName(String templateName);
+
+        public abstract Builder indexOptimizationMaxNumSegments(int indexOptimizationMaxNumSegments);
+
+        public abstract Builder indexOptimizationDisabled(boolean indexOptimizationDisabled);
 
         public abstract IndexSetConfig build();
     }

--- a/graylog2-server/src/main/java/org/graylog2/indexer/indexset/IndexSetConfig.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/indexset/IndexSetConfig.java
@@ -18,6 +18,7 @@ package org.graylog2.indexer.indexset;
 
 import com.fasterxml.jackson.annotation.JsonAutoDetect;
 import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.auto.value.AutoValue;
 import com.google.common.collect.ComparisonChain;
@@ -36,6 +37,7 @@ import java.time.ZonedDateTime;
 @AutoValue
 @WithBeanGetter
 @JsonAutoDetect
+@JsonIgnoreProperties(ignoreUnknown = true)
 public abstract class IndexSetConfig implements Comparable<IndexSetConfig> {
     public static final String FIELD_INDEX_PREFIX = "index_prefix";
     public static final String FIELD_CREATION_DATE = "creation_date";

--- a/graylog2-server/src/main/java/org/graylog2/indexer/indexset/IndexSetConfig.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/indexset/IndexSetConfig.java
@@ -98,19 +98,20 @@ public abstract class IndexSetConfig implements Comparable<IndexSetConfig> {
     public abstract ZonedDateTime creationDate();
 
     @JsonProperty("index_analyzer")
-    @NotBlank
+    @Nullable
     public abstract String indexAnalyzer();
 
     @JsonProperty("index_template_name")
-    @NotBlank
+    @Nullable
     public abstract String indexTemplateName();
 
     @JsonProperty("index_optimization_max_num_segments")
-    @Min(1L)
-    public abstract int indexOptimizationMaxNumSegments();
+    @Nullable
+    public abstract Integer indexOptimizationMaxNumSegments();
 
     @JsonProperty("index_optimization_disabled")
-    public abstract boolean indexOptimizationDisabled();
+    @Nullable
+    public abstract Boolean indexOptimizationDisabled();
 
     @JsonCreator
     public static IndexSetConfig create(@Id @ObjectId @JsonProperty("_id") @Nullable String id,
@@ -127,10 +128,10 @@ public abstract class IndexSetConfig implements Comparable<IndexSetConfig> {
                                         @JsonProperty("retention_strategy_class") @Nullable String retentionStrategyClass,
                                         @JsonProperty("retention_strategy") @NotNull RetentionStrategyConfig retentionStrategy,
                                         @JsonProperty(FIELD_CREATION_DATE) @NotNull ZonedDateTime creationDate,
-                                        @JsonProperty("index_analyzer") @NotBlank String indexAnalyzer,
-                                        @JsonProperty("index_template_name") @NotBlank String indexTemplateName,
-                                        @JsonProperty("index_optimization_max_num_segments") @Min(1L) int indexOptimizationMaxNumSegments,
-                                        @JsonProperty("index_optimization_disabled") boolean indexOptimizationDisabled) {
+                                        @JsonProperty("index_analyzer") @Nullable String indexAnalyzer,
+                                        @JsonProperty("index_template_name") @Nullable String indexTemplateName,
+                                        @JsonProperty("index_optimization_max_num_segments") @Nullable Integer  maxNumSegments,
+                                        @JsonProperty("index_optimization_disabled") @Nullable Boolean indexOptimizationDisabled) {
         return AutoValue_IndexSetConfig.builder()
                 .id(id)
                 .title(title)
@@ -148,8 +149,8 @@ public abstract class IndexSetConfig implements Comparable<IndexSetConfig> {
                 .creationDate(creationDate)
                 .indexAnalyzer(indexAnalyzer)
                 .indexTemplateName(indexTemplateName)
-                .indexOptimizationMaxNumSegments(indexOptimizationMaxNumSegments)
-                .indexOptimizationDisabled(indexOptimizationDisabled)
+                .indexOptimizationMaxNumSegments(maxNumSegments == null ? 1 : maxNumSegments)
+                .indexOptimizationDisabled(indexOptimizationDisabled == null ? false : indexOptimizationDisabled)
                 .build();
     }
 
@@ -244,9 +245,9 @@ public abstract class IndexSetConfig implements Comparable<IndexSetConfig> {
 
         public abstract Builder indexTemplateName(String templateName);
 
-        public abstract Builder indexOptimizationMaxNumSegments(int indexOptimizationMaxNumSegments);
+        public abstract Builder indexOptimizationMaxNumSegments(Integer indexOptimizationMaxNumSegments);
 
-        public abstract Builder indexOptimizationDisabled(boolean indexOptimizationDisabled);
+        public abstract Builder indexOptimizationDisabled(Boolean indexOptimizationDisabled);
 
         public abstract IndexSetConfig build();
     }

--- a/graylog2-server/src/main/java/org/graylog2/indexer/indexset/IndexSetConfig.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/indexset/IndexSetConfig.java
@@ -34,6 +34,8 @@ import javax.validation.constraints.Min;
 import javax.validation.constraints.NotNull;
 import java.time.ZonedDateTime;
 
+import static com.google.common.base.Strings.isNullOrEmpty;
+
 @AutoValue
 @WithBeanGetter
 @JsonAutoDetect
@@ -100,20 +102,19 @@ public abstract class IndexSetConfig implements Comparable<IndexSetConfig> {
     public abstract ZonedDateTime creationDate();
 
     @JsonProperty("index_analyzer")
-    @Nullable
+    @NotBlank
     public abstract String indexAnalyzer();
 
     @JsonProperty("index_template_name")
-    @Nullable
+    @NotBlank
     public abstract String indexTemplateName();
 
     @JsonProperty("index_optimization_max_num_segments")
-    @Nullable
-    public abstract Integer indexOptimizationMaxNumSegments();
+    @Min(1L)
+    public abstract int indexOptimizationMaxNumSegments();
 
     @JsonProperty("index_optimization_disabled")
-    @Nullable
-    public abstract Boolean indexOptimizationDisabled();
+    public abstract boolean indexOptimizationDisabled();
 
     @JsonCreator
     public static IndexSetConfig create(@Id @ObjectId @JsonProperty("_id") @Nullable String id,
@@ -132,7 +133,7 @@ public abstract class IndexSetConfig implements Comparable<IndexSetConfig> {
                                         @JsonProperty(FIELD_CREATION_DATE) @NotNull ZonedDateTime creationDate,
                                         @JsonProperty("index_analyzer") @Nullable String indexAnalyzer,
                                         @JsonProperty("index_template_name") @Nullable String indexTemplateName,
-                                        @JsonProperty("index_optimization_max_num_segments") @Nullable Integer  maxNumSegments,
+                                        @JsonProperty("index_optimization_max_num_segments") @Nullable Integer maxNumSegments,
                                         @JsonProperty("index_optimization_disabled") @Nullable Boolean indexOptimizationDisabled) {
         return AutoValue_IndexSetConfig.builder()
                 .id(id)
@@ -149,8 +150,8 @@ public abstract class IndexSetConfig implements Comparable<IndexSetConfig> {
                 .retentionStrategyClass(retentionStrategyClass)
                 .retentionStrategy(retentionStrategy)
                 .creationDate(creationDate)
-                .indexAnalyzer(indexAnalyzer)
-                .indexTemplateName(indexTemplateName)
+                .indexAnalyzer(isNullOrEmpty(indexAnalyzer) ? "standard" : indexAnalyzer)
+                .indexTemplateName(isNullOrEmpty(indexTemplateName) ? indexPrefix + "-template" : indexTemplateName)
                 .indexOptimizationMaxNumSegments(maxNumSegments == null ? 1 : maxNumSegments)
                 .indexOptimizationDisabled(indexOptimizationDisabled == null ? false : indexOptimizationDisabled)
                 .build();
@@ -247,9 +248,9 @@ public abstract class IndexSetConfig implements Comparable<IndexSetConfig> {
 
         public abstract Builder indexTemplateName(String templateName);
 
-        public abstract Builder indexOptimizationMaxNumSegments(Integer indexOptimizationMaxNumSegments);
+        public abstract Builder indexOptimizationMaxNumSegments(int indexOptimizationMaxNumSegments);
 
-        public abstract Builder indexOptimizationDisabled(Boolean indexOptimizationDisabled);
+        public abstract Builder indexOptimizationDisabled(boolean indexOptimizationDisabled);
 
         public abstract IndexSetConfig build();
     }

--- a/graylog2-server/src/main/java/org/graylog2/indexer/indexset/IndexSetConfig.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/indexset/IndexSetConfig.java
@@ -18,7 +18,6 @@ package org.graylog2.indexer.indexset;
 
 import com.fasterxml.jackson.annotation.JsonAutoDetect;
 import com.fasterxml.jackson.annotation.JsonCreator;
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.auto.value.AutoValue;
 import com.google.common.collect.ComparisonChain;
@@ -39,7 +38,6 @@ import static com.google.common.base.Strings.isNullOrEmpty;
 @AutoValue
 @WithBeanGetter
 @JsonAutoDetect
-@JsonIgnoreProperties(ignoreUnknown = true)
 public abstract class IndexSetConfig implements Comparable<IndexSetConfig> {
     public static final String FIELD_INDEX_PREFIX = "index_prefix";
     public static final String FIELD_CREATION_DATE = "creation_date";

--- a/graylog2-server/src/main/java/org/graylog2/indexer/indexset/V20161216123500_Succeeded.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/indexset/V20161216123500_Succeeded.java
@@ -1,0 +1,30 @@
+/**
+ * This file is part of Graylog.
+ *
+ * Graylog is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.graylog2.indexer.indexset;
+
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.google.auto.value.AutoValue;
+
+@JsonAutoDetect
+@AutoValue
+public abstract class V20161216123500_Succeeded {
+    @JsonCreator
+    public static V20161216123500_Succeeded create() {
+        return new AutoValue_V20161216123500_Succeeded();
+    }
+}

--- a/graylog2-server/src/main/java/org/graylog2/migrations/MigrationsModule.java
+++ b/graylog2-server/src/main/java/org/graylog2/migrations/MigrationsModule.java
@@ -32,5 +32,6 @@ public class MigrationsModule extends AbstractModule {
         binder.addBinding().to(V20161125161400_AlertReceiversMigration.class);
         binder.addBinding().to(V20161130141500_DefaultStreamRecalcIndexRanges.class);
         binder.addBinding().to(V20161215163900_MoveIndexSetDefaultConfig.class);
+        binder.addBinding().to(V20161216123500_DefaultIndexSetMigration.class);
     }
 }

--- a/graylog2-server/src/main/java/org/graylog2/migrations/V20161116172100_DefaultIndexSetMigration.java
+++ b/graylog2-server/src/main/java/org/graylog2/migrations/V20161116172100_DefaultIndexSetMigration.java
@@ -94,6 +94,10 @@ public class V20161116172100_DefaultIndexSetMigration extends Migration {
                 .rotationStrategy(getRotationStrategyConfig(indexManagementConfig))
                 .retentionStrategy(getRetentionStrategyConfig(indexManagementConfig))
                 .creationDate(ZonedDateTime.now(ZoneOffset.UTC))
+                .indexAnalyzer(elasticsearchConfiguration.getAnalyzer())
+                .indexTemplateName(elasticsearchConfiguration.getTemplateName())
+                .indexOptimizationMaxNumSegments(elasticsearchConfiguration.getIndexOptimizationMaxNumSegments())
+                .indexOptimizationDisabled(elasticsearchConfiguration.isDisableIndexOptimization())
                 .build();
 
         final IndexSetConfig savedConfig = indexSetService.save(config);

--- a/graylog2-server/src/main/java/org/graylog2/migrations/V20161116172100_DefaultIndexSetMigration.java
+++ b/graylog2-server/src/main/java/org/graylog2/migrations/V20161116172100_DefaultIndexSetMigration.java
@@ -94,10 +94,6 @@ public class V20161116172100_DefaultIndexSetMigration extends Migration {
                 .rotationStrategy(getRotationStrategyConfig(indexManagementConfig))
                 .retentionStrategy(getRetentionStrategyConfig(indexManagementConfig))
                 .creationDate(ZonedDateTime.now(ZoneOffset.UTC))
-                .indexAnalyzer(elasticsearchConfiguration.getAnalyzer())
-                .indexTemplateName(elasticsearchConfiguration.getTemplateName())
-                .indexOptimizationMaxNumSegments(elasticsearchConfiguration.getIndexOptimizationMaxNumSegments())
-                .indexOptimizationDisabled(elasticsearchConfiguration.isDisableIndexOptimization())
                 .build();
 
         final IndexSetConfig savedConfig = indexSetService.save(config);

--- a/graylog2-server/src/main/java/org/graylog2/migrations/V20161216123500_DefaultIndexSetMigration.java
+++ b/graylog2-server/src/main/java/org/graylog2/migrations/V20161216123500_DefaultIndexSetMigration.java
@@ -1,0 +1,89 @@
+/**
+ * This file is part of Graylog.
+ *
+ * Graylog is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.graylog2.migrations;
+
+import org.graylog2.configuration.ElasticsearchConfiguration;
+import org.graylog2.events.ClusterEventBus;
+import org.graylog2.indexer.indexset.DefaultIndexSetCreated;
+import org.graylog2.indexer.indexset.IndexSetConfig;
+import org.graylog2.indexer.indexset.IndexSetService;
+import org.graylog2.indexer.indexset.V20161216123500_Succeeded;
+import org.graylog2.indexer.indexset.events.IndexSetCreatedEvent;
+import org.graylog2.plugin.cluster.ClusterConfigService;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.inject.Inject;
+import java.time.ZonedDateTime;
+
+import static com.google.common.base.Preconditions.checkState;
+
+/**
+ * Migration for moving indexing settings into default index set.
+ */
+public class V20161216123500_DefaultIndexSetMigration extends Migration {
+    private static final Logger LOG = LoggerFactory.getLogger(V20161216123500_DefaultIndexSetMigration.class);
+
+    private final ElasticsearchConfiguration elasticsearchConfiguration;
+    private final IndexSetService indexSetService;
+    private final ClusterConfigService clusterConfigService;
+    private final ClusterEventBus clusterEventBus;
+
+    @Inject
+    public V20161216123500_DefaultIndexSetMigration(final ElasticsearchConfiguration elasticsearchConfiguration,
+                                                    final IndexSetService indexSetService,
+                                                    final ClusterConfigService clusterConfigService,
+                                                    final ClusterEventBus clusterEventBus) {
+        this.elasticsearchConfiguration = elasticsearchConfiguration;
+        this.indexSetService = indexSetService;
+        this.clusterConfigService = clusterConfigService;
+        this.clusterEventBus = clusterEventBus;
+    }
+
+    @Override
+    public ZonedDateTime createdAt() {
+        return ZonedDateTime.parse("2016-12-12:35:00Z");
+    }
+
+    @Override
+    public void upgrade() {
+        if (clusterConfigService.get(V20161216123500_Succeeded.class) != null) {
+            return;
+        }
+
+        // The default index set must have been created first.
+        checkState(clusterConfigService.get(DefaultIndexSetCreated.class) != null, "The default index set hasn't been created yet. This is a bug!");
+
+        // TODO: Migrate to new method once it's been merged
+        final IndexSetConfig indexSetConfig = indexSetService.getDefault();
+
+        final IndexSetConfig updatedConfig = indexSetConfig.toBuilder()
+                .indexAnalyzer(elasticsearchConfiguration.getAnalyzer())
+                .indexTemplateName(elasticsearchConfiguration.getTemplateName())
+                .indexOptimizationMaxNumSegments(elasticsearchConfiguration.getIndexOptimizationMaxNumSegments())
+                .indexOptimizationDisabled(elasticsearchConfiguration.isDisableIndexOptimization())
+                .build();
+
+        final IndexSetConfig savedConfig = indexSetService.save(updatedConfig);
+        clusterConfigService.write(V20161216123500_Succeeded.create());
+
+        // Publish event to cluster event bus so the stream router will reload.
+        clusterEventBus.post(IndexSetCreatedEvent.create(savedConfig));
+
+        LOG.debug("Successfully updated default index set: {}", savedConfig);
+    }
+}

--- a/graylog2-server/src/main/java/org/graylog2/migrations/V20161216123500_DefaultIndexSetMigration.java
+++ b/graylog2-server/src/main/java/org/graylog2/migrations/V20161216123500_DefaultIndexSetMigration.java
@@ -73,7 +73,7 @@ public class V20161216123500_DefaultIndexSetMigration extends Migration {
             final String analyzer = elasticsearchConfiguration.getAnalyzer();
             final IndexSetConfig updatedConfig = indexSetConfig.toBuilder()
                     .indexAnalyzer(analyzer)
-                    .indexTemplateName(elasticsearchConfiguration.getTemplateName())
+                    .indexTemplateName(indexSetConfig.indexPrefix() + "-template")
                     .indexOptimizationMaxNumSegments(elasticsearchConfiguration.getIndexOptimizationMaxNumSegments())
                     .indexOptimizationDisabled(elasticsearchConfiguration.isDisableIndexOptimization())
                     .build();

--- a/graylog2-server/src/main/java/org/graylog2/migrations/V20161216123500_DefaultIndexSetMigration.java
+++ b/graylog2-server/src/main/java/org/graylog2/migrations/V20161216123500_DefaultIndexSetMigration.java
@@ -28,6 +28,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import javax.inject.Inject;
+import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
 
 import static com.google.common.base.Preconditions.checkState;
@@ -56,7 +57,7 @@ public class V20161216123500_DefaultIndexSetMigration extends Migration {
 
     @Override
     public ZonedDateTime createdAt() {
-        return ZonedDateTime.parse("2016-12-12:35:00Z");
+        return ZonedDateTime.of(2016, 12, 16, 12, 35, 0, 0, ZoneOffset.UTC);
     }
 
     @Override

--- a/graylog2-server/src/main/java/org/graylog2/rest/resources/system/ConfigurationResource.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/resources/system/ConfigurationResource.java
@@ -22,7 +22,6 @@ import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
 import org.apache.shiro.authz.annotation.RequiresAuthentication;
 import org.graylog2.Configuration;
-import org.graylog2.configuration.ElasticsearchConfiguration;
 import org.graylog2.configuration.ExposedConfiguration;
 import org.graylog2.shared.rest.resources.RestResource;
 
@@ -37,20 +36,17 @@ import javax.ws.rs.core.MediaType;
 @Path("/system/configuration")
 @Produces(MediaType.APPLICATION_JSON)
 public class ConfigurationResource extends RestResource {
-
     private final Configuration configuration;
-    private final ElasticsearchConfiguration esConfiguration;
 
     @Inject
-    public ConfigurationResource(Configuration configuration, ElasticsearchConfiguration esConfiguration) {
+    public ConfigurationResource(Configuration configuration) {
         this.configuration = configuration;
-        this.esConfiguration = esConfiguration;
     }
 
     @GET
     @Timed
     @ApiOperation(value = "Get relevant configuration settings and their values")
     public ExposedConfiguration getRelevant() {
-        return ExposedConfiguration.create(configuration, esConfiguration);
+        return ExposedConfiguration.create(configuration);
     }
 }

--- a/graylog2-server/src/main/java/org/graylog2/rest/resources/system/indexer/requests/IndexSetUpdateRequest.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/resources/system/indexer/requests/IndexSetUpdateRequest.java
@@ -72,10 +72,6 @@ public abstract class IndexSetUpdateRequest {
     @NotNull
     public abstract RetentionStrategyConfig retentionStrategy();
 
-    @JsonProperty("index_analyzer")
-    @NotBlank
-    public abstract String indexAnalyzer();
-
     @JsonProperty("index_optimization_max_num_segments")
     @Min(1L)
     public abstract int indexOptimizationMaxNumSegments();
@@ -95,12 +91,11 @@ public abstract class IndexSetUpdateRequest {
                                                @JsonProperty("rotation_strategy") @NotNull RotationStrategyConfig rotationStrategy,
                                                @JsonProperty("retention_strategy_class") @NotNull String retentionStrategyClass,
                                                @JsonProperty("retention_strategy") @NotNull RetentionStrategyConfig retentionStrategy,
-                                               @JsonProperty("index_analyzer") @NotBlank String indexAnalyzer,
                                                @JsonProperty("index_optimization_max_num_segments") @Min(1L) int indexOptimizationMaxNumSegments,
                                                @JsonProperty("index_optimization_disabled") boolean indexOptimizationDisabled) {
         return new AutoValue_IndexSetUpdateRequest(id, title, description, isWritable, shards, replicas,
                 rotationStrategyClass, rotationStrategy, retentionStrategyClass, retentionStrategy,
-                indexAnalyzer, indexOptimizationMaxNumSegments, indexOptimizationDisabled);
+                indexOptimizationMaxNumSegments, indexOptimizationDisabled);
     }
 
     public static IndexSetUpdateRequest fromIndexSetConfig(IndexSetConfig indexSet) {
@@ -115,7 +110,6 @@ public abstract class IndexSetUpdateRequest {
                 indexSet.rotationStrategy(),
                 indexSet.retentionStrategyClass(),
                 indexSet.retentionStrategy(),
-                indexSet.indexAnalyzer(),
                 indexSet.indexOptimizationMaxNumSegments(),
                 indexSet.indexOptimizationDisabled());
 
@@ -137,7 +131,7 @@ public abstract class IndexSetUpdateRequest {
                 retentionStrategyClass(),
                 retentionStrategy(),
                 oldConfig.creationDate(),
-                indexAnalyzer(),
+                oldConfig.indexAnalyzer(),
                 oldConfig.indexTemplateName(),
                 indexOptimizationMaxNumSegments(),
                 indexOptimizationDisabled());

--- a/graylog2-server/src/main/java/org/graylog2/rest/resources/system/indexer/requests/IndexSetUpdateRequest.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/resources/system/indexer/requests/IndexSetUpdateRequest.java
@@ -76,10 +76,6 @@ public abstract class IndexSetUpdateRequest {
     @NotBlank
     public abstract String indexAnalyzer();
 
-    @JsonProperty("index_template_name")
-    @NotBlank
-    public abstract String indexTemplateName();
-
     @JsonProperty("index_optimization_max_num_segments")
     @Min(1L)
     public abstract int indexOptimizationMaxNumSegments();
@@ -100,12 +96,11 @@ public abstract class IndexSetUpdateRequest {
                                                @JsonProperty("retention_strategy_class") @NotNull String retentionStrategyClass,
                                                @JsonProperty("retention_strategy") @NotNull RetentionStrategyConfig retentionStrategy,
                                                @JsonProperty("index_analyzer") @NotBlank String indexAnalyzer,
-                                               @JsonProperty("index_template_name") @NotBlank String indexTemplateName,
                                                @JsonProperty("index_optimization_max_num_segments") @Min(1L) int indexOptimizationMaxNumSegments,
                                                @JsonProperty("index_optimization_disabled") boolean indexOptimizationDisabled) {
         return new AutoValue_IndexSetUpdateRequest(id, title, description, isWritable, shards, replicas,
                 rotationStrategyClass, rotationStrategy, retentionStrategyClass, retentionStrategy,
-                indexAnalyzer, indexTemplateName, indexOptimizationMaxNumSegments, indexOptimizationDisabled);
+                indexAnalyzer, indexOptimizationMaxNumSegments, indexOptimizationDisabled);
     }
 
     public static IndexSetUpdateRequest fromIndexSetConfig(IndexSetConfig indexSet) {
@@ -121,7 +116,6 @@ public abstract class IndexSetUpdateRequest {
                 indexSet.retentionStrategyClass(),
                 indexSet.retentionStrategy(),
                 indexSet.indexAnalyzer(),
-                indexSet.indexTemplateName(),
                 indexSet.indexOptimizationMaxNumSegments(),
                 indexSet.indexOptimizationDisabled());
 
@@ -144,7 +138,7 @@ public abstract class IndexSetUpdateRequest {
                 retentionStrategy(),
                 oldConfig.creationDate(),
                 indexAnalyzer(),
-                indexTemplateName(),
+                oldConfig.indexTemplateName(),
                 indexOptimizationMaxNumSegments(),
                 indexOptimizationDisabled());
     }

--- a/graylog2-server/src/main/java/org/graylog2/rest/resources/system/indexer/requests/IndexSetUpdateRequest.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/resources/system/indexer/requests/IndexSetUpdateRequest.java
@@ -72,6 +72,21 @@ public abstract class IndexSetUpdateRequest {
     @NotNull
     public abstract RetentionStrategyConfig retentionStrategy();
 
+    @JsonProperty("index_analyzer")
+    @NotBlank
+    public abstract String indexAnalyzer();
+
+    @JsonProperty("index_template_name")
+    @NotBlank
+    public abstract String indexTemplateName();
+
+    @JsonProperty("index_optimization_max_num_segments")
+    @Min(1L)
+    public abstract int indexOptimizationMaxNumSegments();
+
+    @JsonProperty("index_optimization_disabled")
+    public abstract boolean indexOptimizationDisabled();
+
     @JsonCreator
     @JsonIgnoreProperties(ignoreUnknown = true)
     public static IndexSetUpdateRequest create(@JsonProperty("id") String id,
@@ -83,8 +98,14 @@ public abstract class IndexSetUpdateRequest {
                                                @JsonProperty("rotation_strategy_class") @NotNull String rotationStrategyClass,
                                                @JsonProperty("rotation_strategy") @NotNull RotationStrategyConfig rotationStrategy,
                                                @JsonProperty("retention_strategy_class") @NotNull String retentionStrategyClass,
-                                               @JsonProperty("retention_strategy") @NotNull RetentionStrategyConfig retentionStrategy) {
-        return new AutoValue_IndexSetUpdateRequest(id, title, description, isWritable, shards, replicas, rotationStrategyClass, rotationStrategy, retentionStrategyClass, retentionStrategy);
+                                               @JsonProperty("retention_strategy") @NotNull RetentionStrategyConfig retentionStrategy,
+                                               @JsonProperty("index_analyzer") @NotBlank String indexAnalyzer,
+                                               @JsonProperty("index_template_name") @NotBlank String indexTemplateName,
+                                               @JsonProperty("index_optimization_max_num_segments") @Min(1L) int indexOptimizationMaxNumSegments,
+                                               @JsonProperty("index_optimization_disabled") boolean indexOptimizationDisabled) {
+        return new AutoValue_IndexSetUpdateRequest(id, title, description, isWritable, shards, replicas,
+                rotationStrategyClass, rotationStrategy, retentionStrategyClass, retentionStrategy,
+                indexAnalyzer, indexTemplateName, indexOptimizationMaxNumSegments, indexOptimizationDisabled);
     }
 
     public static IndexSetUpdateRequest fromIndexSetConfig(IndexSetConfig indexSet) {
@@ -98,26 +119,33 @@ public abstract class IndexSetUpdateRequest {
                 indexSet.rotationStrategyClass(),
                 indexSet.rotationStrategy(),
                 indexSet.retentionStrategyClass(),
-                indexSet.retentionStrategy());
+                indexSet.retentionStrategy(),
+                indexSet.indexAnalyzer(),
+                indexSet.indexTemplateName(),
+                indexSet.indexOptimizationMaxNumSegments(),
+                indexSet.indexOptimizationDisabled());
 
     }
 
     public IndexSetConfig toIndexSetConfig(IndexSetConfig oldConfig) {
-        return IndexSetConfig.builder()
-                .id(id())
-                .title(title())
-                .description(description())
-                .isWritable(isWritable())
-                .indexPrefix(oldConfig.indexPrefix())
-                .indexMatchPattern(oldConfig.indexMatchPattern())
-                .indexWildcard(oldConfig.indexWildcard())
-                .shards(shards())
-                .replicas(replicas())
-                .rotationStrategyClass(rotationStrategyClass())
-                .rotationStrategy(rotationStrategy())
-                .retentionStrategyClass(retentionStrategyClass())
-                .retentionStrategy(retentionStrategy())
-                .creationDate(oldConfig.creationDate())
-                .build();
+        return IndexSetConfig.create(
+                id(),
+                title(),
+                description(),
+                isWritable(),
+                oldConfig.indexPrefix(),
+                oldConfig.indexMatchPattern(),
+                oldConfig.indexWildcard(),
+                shards(),
+                replicas(),
+                rotationStrategyClass(),
+                rotationStrategy(),
+                retentionStrategyClass(),
+                retentionStrategy(),
+                oldConfig.creationDate(),
+                indexAnalyzer(),
+                indexTemplateName(),
+                indexOptimizationMaxNumSegments(),
+                indexOptimizationDisabled());
     }
 }

--- a/graylog2-server/src/main/java/org/graylog2/rest/resources/system/indexer/requests/IndexSetUpdateRequest.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/resources/system/indexer/requests/IndexSetUpdateRequest.java
@@ -116,24 +116,25 @@ public abstract class IndexSetUpdateRequest {
     }
 
     public IndexSetConfig toIndexSetConfig(IndexSetConfig oldConfig) {
-        return IndexSetConfig.create(
-                id(),
-                title(),
-                description(),
-                isWritable(),
-                oldConfig.indexPrefix(),
-                oldConfig.indexMatchPattern(),
-                oldConfig.indexWildcard(),
-                shards(),
-                replicas(),
-                rotationStrategyClass(),
-                rotationStrategy(),
-                retentionStrategyClass(),
-                retentionStrategy(),
-                oldConfig.creationDate(),
-                oldConfig.indexAnalyzer(),
-                oldConfig.indexTemplateName(),
-                indexOptimizationMaxNumSegments(),
-                indexOptimizationDisabled());
+        return IndexSetConfig.builder()
+                .id(id())
+                .title(title())
+                .description(description())
+                .isWritable(isWritable())
+                .indexPrefix(oldConfig.indexPrefix())
+                .indexMatchPattern(oldConfig.indexMatchPattern())
+                .indexWildcard(oldConfig.indexWildcard())
+                .shards(shards())
+                .replicas(replicas())
+                .rotationStrategyClass(rotationStrategyClass())
+                .rotationStrategy(rotationStrategy())
+                .retentionStrategyClass(retentionStrategyClass())
+                .retentionStrategy(retentionStrategy())
+                .creationDate(oldConfig.creationDate())
+                .indexAnalyzer(oldConfig.indexAnalyzer())
+                .indexTemplateName(oldConfig.indexTemplateName())
+                .indexOptimizationMaxNumSegments(indexOptimizationMaxNumSegments())
+                .indexOptimizationDisabled(indexOptimizationDisabled())
+                .build();
     }
 }

--- a/graylog2-server/src/main/java/org/graylog2/rest/resources/system/indexer/responses/IndexSetSummary.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/resources/system/indexer/responses/IndexSetSummary.java
@@ -89,10 +89,6 @@ public abstract class IndexSetSummary {
     @NotBlank
     public abstract String indexAnalyzer();
 
-    @JsonProperty("index_template_name")
-    @NotBlank
-    public abstract String indexTemplateName();
-
     @JsonProperty("index_optimization_max_num_segments")
     @Min(1L)
     public abstract int indexOptimizationMaxNumSegments();
@@ -115,12 +111,11 @@ public abstract class IndexSetSummary {
                                          @JsonProperty("retention_strategy") @NotNull RetentionStrategyConfig retentionStrategy,
                                          @JsonProperty("creation_date") @NotNull ZonedDateTime creationDate,
                                          @JsonProperty("index_analyzer") @NotBlank String indexAnalyzer,
-                                         @JsonProperty("index_template_name") @NotBlank String indexTemplateName,
                                          @JsonProperty("index_optimization_max_num_segments") @Min(1L) int indexOptimizationMaxNumSegments,
                                          @JsonProperty("index_optimization_disabled") boolean indexOptimizationDisabled) {
         return new AutoValue_IndexSetSummary(id, title, description, isDefault, isWritable, indexPrefix, shards, replicas,
                 rotationStrategyClass, rotationStrategy, retentionStrategyClass, retentionStrategy, creationDate,
-                indexAnalyzer, indexTemplateName, indexOptimizationMaxNumSegments, indexOptimizationDisabled);
+                indexAnalyzer, indexOptimizationMaxNumSegments, indexOptimizationDisabled);
     }
 
     public static IndexSetSummary fromIndexSetConfig(IndexSetConfig indexSet, boolean isDefault) {
@@ -139,7 +134,6 @@ public abstract class IndexSetSummary {
                 indexSet.retentionStrategy(),
                 indexSet.creationDate(),
                 indexSet.indexAnalyzer(),
-                indexSet.indexTemplateName(),
                 indexSet.indexOptimizationMaxNumSegments(),
                 indexSet.indexOptimizationDisabled());
 
@@ -160,7 +154,7 @@ public abstract class IndexSetSummary {
                 retentionStrategy(),
                 creationDate(),
                 indexAnalyzer(),
-                indexTemplateName(),
+                indexPrefix() + "-" + id(),
                 indexOptimizationMaxNumSegments(),
                 indexOptimizationDisabled());
     }

--- a/graylog2-server/src/main/java/org/graylog2/rest/resources/system/indexer/responses/IndexSetSummary.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/resources/system/indexer/responses/IndexSetSummary.java
@@ -140,22 +140,23 @@ public abstract class IndexSetSummary {
     }
 
     public IndexSetConfig toIndexSetConfig() {
-        return IndexSetConfig.create(
-                id(),
-                title(),
-                description(),
-                isWritable(),
-                indexPrefix(),
-                shards(),
-                replicas(),
-                rotationStrategyClass(),
-                rotationStrategy(),
-                retentionStrategyClass(),
-                retentionStrategy(),
-                creationDate(),
-                indexAnalyzer(),
-                indexPrefix() + "-template",
-                indexOptimizationMaxNumSegments(),
-                indexOptimizationDisabled());
+        return IndexSetConfig.builder()
+                .id(id())
+                .title(title())
+                .description(description())
+                .isWritable(isWritable())
+                .indexPrefix(indexPrefix())
+                .shards(shards())
+                .replicas(replicas())
+                .rotationStrategyClass(rotationStrategyClass())
+                .rotationStrategy(rotationStrategy())
+                .retentionStrategyClass(retentionStrategyClass())
+                .retentionStrategy(retentionStrategy())
+                .creationDate(creationDate())
+                .indexAnalyzer(indexAnalyzer())
+                .indexTemplateName(indexPrefix() + "-template")
+                .indexOptimizationMaxNumSegments(indexOptimizationMaxNumSegments())
+                .indexOptimizationDisabled(indexOptimizationDisabled())
+                .build();
     }
 }

--- a/graylog2-server/src/main/java/org/graylog2/rest/resources/system/indexer/responses/IndexSetSummary.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/resources/system/indexer/responses/IndexSetSummary.java
@@ -85,6 +85,21 @@ public abstract class IndexSetSummary {
     @NotNull
     public abstract ZonedDateTime creationDate();
 
+    @JsonProperty("index_analyzer")
+    @NotBlank
+    public abstract String indexAnalyzer();
+
+    @JsonProperty("index_template_name")
+    @NotBlank
+    public abstract String indexTemplateName();
+
+    @JsonProperty("index_optimization_max_num_segments")
+    @Min(1L)
+    public abstract int indexOptimizationMaxNumSegments();
+
+    @JsonProperty("index_optimization_disabled")
+    public abstract boolean indexOptimizationDisabled();
+
     @JsonCreator
     public static IndexSetSummary create(@JsonProperty("id") @Nullable String id,
                                          @JsonProperty("title") @NotBlank String title,
@@ -98,8 +113,14 @@ public abstract class IndexSetSummary {
                                          @JsonProperty("rotation_strategy") @NotNull RotationStrategyConfig rotationStrategy,
                                          @JsonProperty("retention_strategy_class") @NotNull String retentionStrategyClass,
                                          @JsonProperty("retention_strategy") @NotNull RetentionStrategyConfig retentionStrategy,
-                                         @JsonProperty("creation_date") @NotNull ZonedDateTime creationDate) {
-        return new AutoValue_IndexSetSummary(id, title, description, isDefault, isWritable, indexPrefix, shards, replicas, rotationStrategyClass, rotationStrategy, retentionStrategyClass, retentionStrategy, creationDate);
+                                         @JsonProperty("creation_date") @NotNull ZonedDateTime creationDate,
+                                         @JsonProperty("index_analyzer") @NotBlank String indexAnalyzer,
+                                         @JsonProperty("index_template_name") @NotBlank String indexTemplateName,
+                                         @JsonProperty("index_optimization_max_num_segments") @Min(1L) int indexOptimizationMaxNumSegments,
+                                         @JsonProperty("index_optimization_disabled") boolean indexOptimizationDisabled) {
+        return new AutoValue_IndexSetSummary(id, title, description, isDefault, isWritable, indexPrefix, shards, replicas,
+                rotationStrategyClass, rotationStrategy, retentionStrategyClass, retentionStrategy, creationDate,
+                indexAnalyzer, indexTemplateName, indexOptimizationMaxNumSegments, indexOptimizationDisabled);
     }
 
     public static IndexSetSummary fromIndexSetConfig(IndexSetConfig indexSet, boolean isDefault) {
@@ -116,24 +137,31 @@ public abstract class IndexSetSummary {
                 indexSet.rotationStrategy(),
                 indexSet.retentionStrategyClass(),
                 indexSet.retentionStrategy(),
-                indexSet.creationDate());
+                indexSet.creationDate(),
+                indexSet.indexAnalyzer(),
+                indexSet.indexTemplateName(),
+                indexSet.indexOptimizationMaxNumSegments(),
+                indexSet.indexOptimizationDisabled());
 
     }
 
     public IndexSetConfig toIndexSetConfig() {
-        return IndexSetConfig.builder()
-                .id(id())
-                .title(title())
-                .description(description())
-                .isWritable(isWritable())
-                .indexPrefix(indexPrefix())
-                .shards(shards())
-                .replicas(replicas())
-                .rotationStrategyClass(rotationStrategyClass())
-                .rotationStrategy(rotationStrategy())
-                .retentionStrategyClass(retentionStrategyClass())
-                .retentionStrategy(retentionStrategy())
-                .creationDate(creationDate())
-                .build();
+        return IndexSetConfig.create(
+                id(),
+                title(),
+                description(),
+                isWritable(),
+                indexPrefix(),
+                shards(),
+                replicas(),
+                rotationStrategyClass(),
+                rotationStrategy(),
+                retentionStrategyClass(),
+                retentionStrategy(),
+                creationDate(),
+                indexAnalyzer(),
+                indexTemplateName(),
+                indexOptimizationMaxNumSegments(),
+                indexOptimizationDisabled());
     }
 }

--- a/graylog2-server/src/main/java/org/graylog2/rest/resources/system/indexer/responses/IndexSetSummary.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/resources/system/indexer/responses/IndexSetSummary.java
@@ -154,7 +154,7 @@ public abstract class IndexSetSummary {
                 retentionStrategy(),
                 creationDate(),
                 indexAnalyzer(),
-                indexPrefix() + "-" + id(),
+                indexPrefix() + "-template",
                 indexOptimizationMaxNumSegments(),
                 indexOptimizationDisabled());
     }

--- a/graylog2-server/src/test/java/org/graylog2/configuration/ExposedConfigurationTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/configuration/ExposedConfigurationTest.java
@@ -30,8 +30,7 @@ public class ExposedConfigurationTest {
     @Test
     public void testCreateWithConfiguration() throws Exception {
         final Configuration configuration = new Configuration();
-        final ElasticsearchConfiguration elasticsearchConfiguration = new ElasticsearchConfiguration();
-        final ExposedConfiguration c = ExposedConfiguration.create(configuration, elasticsearchConfiguration);
+        final ExposedConfiguration c = ExposedConfiguration.create(configuration);
 
         assertThat(c.inputBufferProcessors()).isEqualTo(configuration.getInputbufferProcessors());
         assertThat(c.processBufferProcessors()).isEqualTo(configuration.getProcessBufferProcessors());
@@ -44,22 +43,17 @@ public class ExposedConfigurationTest {
         assertThat(c.nodeIdFile()).isEqualTo(configuration.getNodeIdFile());
         assertThat(c.allowHighlighting()).isEqualTo(configuration.isAllowHighlighting());
         assertThat(c.allowLeadingWildcardSearches()).isEqualTo(configuration.isAllowLeadingWildcardSearches());
-        assertThat(c.shards()).isEqualTo(elasticsearchConfiguration.getShards());
-        assertThat(c.replicas()).isEqualTo(elasticsearchConfiguration.getReplicas());
         assertThat(c.streamProcessingTimeout()).isEqualTo(configuration.getStreamProcessingTimeout());
         assertThat(c.streamProcessingMaxFaults()).isEqualTo(configuration.getStreamProcessingMaxFaults());
         assertThat(c.outputModuleTimeout()).isEqualTo(configuration.getOutputModuleTimeout());
         assertThat(c.staleMasterTimeout()).isEqualTo(configuration.getStaleMasterTimeout());
-        assertThat(c.disableIndexOptimization()).isEqualTo(elasticsearchConfiguration.isDisableIndexOptimization());
-        assertThat(c.indexOptimizationMaxSegments()).isEqualTo(elasticsearchConfiguration.getIndexOptimizationMaxNumSegments());
         assertThat(c.gcWarningThreshold()).isEqualTo(configuration.getGcWarningThreshold().toString());
     }
 
     @Test
     public void testSerialization() throws Exception {
         final Configuration configuration = new Configuration();
-        final ElasticsearchConfiguration elasticsearchConfiguration = new ElasticsearchConfiguration();
-        final ExposedConfiguration c = ExposedConfiguration.create(configuration, elasticsearchConfiguration);
+        final ExposedConfiguration c = ExposedConfiguration.create(configuration);
 
         final String json = objectMapper.writeValueAsString(c);
         assertThat((int) JsonPath.read(json, "$.inputbuffer_processors")).isEqualTo(c.inputBufferProcessors());
@@ -73,14 +67,10 @@ public class ExposedConfigurationTest {
         assertThat((String) JsonPath.read(json, "$.node_id_file")).isEqualTo(c.nodeIdFile());
         assertThat((boolean) JsonPath.read(json, "$.allow_highlighting")).isEqualTo(c.allowHighlighting());
         assertThat((boolean) JsonPath.read(json, "$.allow_leading_wildcard_searches")).isEqualTo(c.allowLeadingWildcardSearches());
-        assertThat((int) JsonPath.read(json, "$.elasticsearch_shards")).isEqualTo(c.shards());
-        assertThat((int) JsonPath.read(json, "$.elasticsearch_replicas")).isEqualTo(c.replicas());
         assertThat((int) JsonPath.read(json, "$.stream_processing_timeout")).isEqualTo((int) c.streamProcessingTimeout());
         assertThat((int) JsonPath.read(json, "$.stream_processing_max_faults")).isEqualTo(c.streamProcessingMaxFaults());
         assertThat((int) JsonPath.read(json, "$.output_module_timeout")).isEqualTo((int) c.outputModuleTimeout());
         assertThat((int) JsonPath.read(json, "$.stale_master_timeout")).isEqualTo(c.staleMasterTimeout());
-        assertThat((boolean) JsonPath.read(json, "$.disable_index_optimization")).isEqualTo(c.disableIndexOptimization());
-        assertThat((int) JsonPath.read(json, "$.index_optimization_max_num_segments")).isEqualTo(c.indexOptimizationMaxSegments());
         assertThat((String) JsonPath.read(json, "$.gc_warning_threshold")).isEqualTo(c.gcWarningThreshold());
     }
 
@@ -98,14 +88,10 @@ public class ExposedConfigurationTest {
                 "  \"node_id_file\": \"/etc/graylog/server/node-id\"," +
                 "  \"allow_highlighting\": false," +
                 "  \"allow_leading_wildcard_searches\": false," +
-                "  \"elasticsearch_shards\": 4," +
-                "  \"elasticsearch_replicas\": 0," +
                 "  \"stream_processing_timeout\": 2000," +
                 "  \"stream_processing_max_faults\": 3," +
                 "  \"output_module_timeout\": 10000," +
                 "  \"stale_master_timeout\": 2000," +
-                "  \"disable_index_optimization\": false," +
-                "  \"index_optimization_max_num_segments\": 1," +
                 "  \"gc_warning_threshold\": \"1 second\"" +
                 "}";
 
@@ -122,14 +108,10 @@ public class ExposedConfigurationTest {
         assertThat(c.nodeIdFile()).isEqualTo(JsonPath.read(json, "$.node_id_file"));
         assertThat(c.allowHighlighting()).isEqualTo(JsonPath.read(json, "$.allow_highlighting"));
         assertThat(c.allowLeadingWildcardSearches()).isEqualTo(JsonPath.read(json, "$.allow_leading_wildcard_searches"));
-        assertThat(c.shards()).isEqualTo(JsonPath.read(json, "$.elasticsearch_shards"));
-        assertThat(c.replicas()).isEqualTo(JsonPath.read(json, "$.elasticsearch_replicas"));
         assertThat((int) c.streamProcessingTimeout()).isEqualTo(JsonPath.read(json, "$.stream_processing_timeout"));
         assertThat(c.streamProcessingMaxFaults()).isEqualTo(JsonPath.read(json, "$.stream_processing_max_faults"));
         assertThat((int) c.outputModuleTimeout()).isEqualTo(JsonPath.read(json, "$.output_module_timeout"));
         assertThat(c.staleMasterTimeout()).isEqualTo(JsonPath.read(json, "$.stale_master_timeout"));
-        assertThat(c.disableIndexOptimization()).isEqualTo(JsonPath.read(json, "$.disable_index_optimization"));
-        assertThat(c.indexOptimizationMaxSegments()).isEqualTo(JsonPath.read(json, "$.index_optimization_max_num_segments"));
         assertThat(c.gcWarningThreshold()).isEqualTo(JsonPath.read(json, "$.gc_warning_threshold"));
     }
 }

--- a/graylog2-server/src/test/java/org/graylog2/indexer/MongoIndexSetTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/indexer/MongoIndexSetTest.java
@@ -89,7 +89,11 @@ public class MongoIndexSetTest {
             MessageCountRotationStrategyConfig.createDefault(),
             NoopRetentionStrategy.class.getCanonicalName(),
             NoopRetentionStrategyConfig.createDefault(),
-            ZonedDateTime.of(2016, 11, 8, 0, 0, 0, 0, ZoneOffset.UTC)
+            ZonedDateTime.of(2016, 11, 8, 0, 0, 0, 0, ZoneOffset.UTC),
+            "standard",
+            "index-template",
+            1,
+            false
     );
 
     private MongoIndexSet mongoIndexSet;

--- a/graylog2-server/src/test/java/org/graylog2/indexer/counts/CountsTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/indexer/counts/CountsTest.java
@@ -125,6 +125,10 @@ public class CountsTest {
                 .retentionStrategyClass(DeletionRetentionStrategy.class.getCanonicalName())
                 .retentionStrategy(DeletionRetentionStrategyConfig.createDefault())
                 .creationDate(ZonedDateTime.of(2016, 10, 12, 0, 0, 0, 0, ZoneOffset.UTC))
+                .indexAnalyzer("standard")
+                .indexTemplateName("template-1")
+                .indexOptimizationMaxNumSegments(1)
+                .indexOptimizationDisabled(false)
                 .build();
 
         indexSetConfig2 = IndexSetConfig.builder()
@@ -138,6 +142,10 @@ public class CountsTest {
                 .retentionStrategyClass(DeletionRetentionStrategy.class.getCanonicalName())
                 .retentionStrategy(DeletionRetentionStrategyConfig.createDefault())
                 .creationDate(ZonedDateTime.of(2016, 10, 13, 0, 0, 0, 0, ZoneOffset.UTC))
+                .indexAnalyzer("standard")
+                .indexTemplateName("template-2")
+                .indexOptimizationMaxNumSegments(1)
+                .indexOptimizationDisabled(false)
                 .build();
 
         when(indexSetRegistry.getManagedIndicesNames()).thenReturn(new String[]{INDEX_NAME_1, INDEX_NAME_2});

--- a/graylog2-server/src/test/java/org/graylog2/indexer/indexset/MongoIndexSetServiceTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/indexer/indexset/MongoIndexSetServiceTest.java
@@ -109,7 +109,11 @@ public class MongoIndexSetServiceTest {
                                 MessageCountRotationStrategyConfig.create(1000),
                                 NoopRetentionStrategy.class.getCanonicalName(),
                                 NoopRetentionStrategyConfig.create(10),
-                                ZonedDateTime.of(2016, 10, 4, 17, 0, 0, 0, ZoneOffset.UTC)
+                                ZonedDateTime.of(2016, 10, 4, 17, 0, 0, 0, ZoneOffset.UTC),
+                                "standard",
+                                "test_1",
+                                1,
+                                false
                         )
                 );
     }
@@ -133,7 +137,11 @@ public class MongoIndexSetServiceTest {
                                 MessageCountRotationStrategyConfig.create(1000),
                                 NoopRetentionStrategy.class.getCanonicalName(),
                                 NoopRetentionStrategyConfig.create(10),
-                                ZonedDateTime.of(2016, 10, 4, 17, 0, 0, 0, ZoneOffset.UTC)
+                                ZonedDateTime.of(2016, 10, 4, 17, 0, 0, 0, ZoneOffset.UTC),
+                                "standard",
+                                "test_1",
+                                1,
+                                false
                         )
                 );
     }
@@ -193,7 +201,11 @@ public class MongoIndexSetServiceTest {
                                 MessageCountRotationStrategyConfig.create(1000),
                                 NoopRetentionStrategy.class.getCanonicalName(),
                                 NoopRetentionStrategyConfig.create(10),
-                                ZonedDateTime.of(2016, 10, 4, 17, 0, 0, 0, ZoneOffset.UTC)
+                                ZonedDateTime.of(2016, 10, 4, 17, 0, 0, 0, ZoneOffset.UTC),
+                                "standard",
+                                "test_1",
+                                1,
+                                false
                         ),
                         IndexSetConfig.create(
                                 "57f3d721a43c2d59cb750002",
@@ -207,7 +219,11 @@ public class MongoIndexSetServiceTest {
                                 MessageCountRotationStrategyConfig.create(2500),
                                 NoopRetentionStrategy.class.getCanonicalName(),
                                 NoopRetentionStrategyConfig.create(25),
-                                ZonedDateTime.of(2016, 10, 4, 18, 0, 0, 0, ZoneOffset.UTC)
+                                ZonedDateTime.of(2016, 10, 4, 18, 0, 0, 0, ZoneOffset.UTC),
+                                "standard",
+                                "test_2",
+                                1,
+                                false
                         )
                 );
     }
@@ -228,7 +244,11 @@ public class MongoIndexSetServiceTest {
                 MessageCountRotationStrategyConfig.create(10000),
                 NoopRetentionStrategy.class.getCanonicalName(),
                 NoopRetentionStrategyConfig.create(5),
-                ZonedDateTime.of(2016, 10, 4, 12, 0, 0, 0, ZoneOffset.UTC)
+                ZonedDateTime.of(2016, 10, 4, 12, 0, 0, 0, ZoneOffset.UTC),
+                "standard",
+                "index-template",
+                1,
+                false
         );
 
         final IndexSetConfig savedIndexSetConfig = indexSetService.save(indexSetConfig);

--- a/graylog2-server/src/test/java/org/graylog2/indexer/indices/IndicesTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/indexer/indices/IndicesTest.java
@@ -106,6 +106,10 @@ public class IndicesTest {
                 .rotationStrategy(MessageCountRotationStrategyConfig.createDefault())
                 .retentionStrategyClass(DeletionRetentionStrategy.class.getCanonicalName())
                 .retentionStrategy(DeletionRetentionStrategyConfig.createDefault())
+                .indexAnalyzer("standard")
+                .indexTemplateName("template-1")
+                .indexOptimizationMaxNumSegments(1)
+                .indexOptimizationDisabled(false)
                 .build();
         this.indexSet = new TestIndexSet(indexSetConfig);
         this.elasticsearchRule = newElasticsearchRule().defaultEmbeddedElasticsearch();

--- a/graylog2-server/src/test/java/org/graylog2/indexer/ranges/EsIndexRangeServiceTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/indexer/ranges/EsIndexRangeServiceTest.java
@@ -98,6 +98,10 @@ public class EsIndexRangeServiceTest {
                 .rotationStrategy(MessageCountRotationStrategyConfig.createDefault())
                 .retentionStrategyClass(DeletionRetentionStrategy.class.getCanonicalName())
                 .retentionStrategy(DeletionRetentionStrategyConfig.createDefault())
+                .indexAnalyzer("standard")
+                .indexTemplateName("template-1")
+                .indexOptimizationMaxNumSegments(1)
+                .indexOptimizationDisabled(false)
                 .build();
         this.indexSet = new TestIndexSet(indexSetConfig);
         this.elasticsearchRule = newElasticsearchRule().defaultEmbeddedElasticsearch();

--- a/graylog2-server/src/test/java/org/graylog2/indexer/searches/SearchesTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/indexer/searches/SearchesTest.java
@@ -58,9 +58,9 @@ import org.junit.Before;
 import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
-import org.junit.runner.RunWith;
 import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnit;
+import org.mockito.junit.MockitoRule;
 
 import javax.inject.Inject;
 import java.time.ZonedDateTime;
@@ -79,7 +79,6 @@ import static org.mockito.ArgumentMatchers.startsWith;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-@RunWith(MockitoJUnitRunner.class)
 public class SearchesTest {
     @ClassRule
     public static final EmbeddedElasticsearch EMBEDDED_ELASTICSEARCH = newEmbeddedElasticsearchRule().build();
@@ -87,7 +86,10 @@ public class SearchesTest {
     private static final String RANGES_HISTOGRAM_NAME = "org.graylog2.indexer.searches.Searches.elasticsearch.ranges";
 
     @Rule
-    public ElasticsearchRule elasticsearchRule;
+    public final ElasticsearchRule elasticsearchRule;
+
+    @Rule
+    public final MockitoRule mockitoRule = MockitoJUnit.rule();
 
     private static final String INDEX_NAME = "graylog_0";
     private static final SortedSet<IndexRange> INDEX_RANGES = ImmutableSortedSet
@@ -152,6 +154,10 @@ public class SearchesTest {
                 .rotationStrategy(MessageCountRotationStrategyConfig.createDefault())
                 .retentionStrategyClass(DeletionRetentionStrategy.class.getCanonicalName())
                 .retentionStrategy(DeletionRetentionStrategyConfig.createDefault())
+                .indexAnalyzer("standard")
+                .indexTemplateName("template-1")
+                .indexOptimizationMaxNumSegments(1)
+                .indexOptimizationDisabled(false)
                 .build();
         this.indexSet = new TestIndexSet(indexSetConfig);
         this.elasticsearchRule = newElasticsearchRule().defaultEmbeddedElasticsearch();

--- a/graylog2-server/src/test/java/org/graylog2/migrations/V20161116172100_DefaultIndexSetMigrationTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/migrations/V20161116172100_DefaultIndexSetMigrationTest.java
@@ -47,6 +47,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.verifyZeroInteractions;
 import static org.mockito.Mockito.when;
 
 public class V20161116172100_DefaultIndexSetMigrationTest {
@@ -92,10 +94,6 @@ public class V20161116172100_DefaultIndexSetMigrationTest {
                 .rotationStrategy(rotationStrategyConfig)
                 .retentionStrategy(retentionStrategyConfig)
                 .creationDate(ZonedDateTime.of(2016, 10, 12, 0, 0, 0, 0, ZoneOffset.UTC))
-                .indexAnalyzer("standard")
-                .indexTemplateName("template-1")
-                .indexOptimizationMaxNumSegments(1)
-                .indexOptimizationDisabled(false)
                 .build();
         when(clusterConfigService.get(IndexManagementConfig.class)).thenReturn(IndexManagementConfig.create("test", "test"));
         when(clusterConfigService.get(StubRotationStrategyConfig.class)).thenReturn(rotationStrategyConfig);
@@ -120,10 +118,10 @@ public class V20161116172100_DefaultIndexSetMigrationTest {
         assertThat(capturedIndexSetConfig.replicas()).isEqualTo(elasticsearchConfiguration.getReplicas());
         assertThat(capturedIndexSetConfig.rotationStrategy()).isInstanceOf(StubRotationStrategyConfig.class);
         assertThat(capturedIndexSetConfig.retentionStrategy()).isInstanceOf(StubRetentionStrategyConfig.class);
-        assertThat(capturedIndexSetConfig.indexAnalyzer()).isEqualTo(elasticsearchConfiguration.getAnalyzer());
-        assertThat(capturedIndexSetConfig.indexTemplateName()).isEqualTo(elasticsearchConfiguration.getTemplateName());
-        assertThat(capturedIndexSetConfig.indexOptimizationMaxNumSegments()).isEqualTo(elasticsearchConfiguration.getIndexOptimizationMaxNumSegments());
-        assertThat(capturedIndexSetConfig.indexOptimizationDisabled()).isEqualTo(elasticsearchConfiguration.isDisableIndexOptimization());
+        assertThat(capturedIndexSetConfig.indexAnalyzer()).isNull();
+        assertThat(capturedIndexSetConfig.indexTemplateName()).isNull();
+        assertThat(capturedIndexSetConfig.indexOptimizationMaxNumSegments()).isNull();
+        assertThat(capturedIndexSetConfig.indexOptimizationDisabled()).isNull();
     }
 
     @Test
@@ -158,12 +156,14 @@ public class V20161116172100_DefaultIndexSetMigrationTest {
     }
 
     @Test
-    public void startOnThisNodeReturnsFalseIfMigrationWasSuccessfulBefore() throws Exception {
-        when(clusterConfigService.get(DefaultIndexSetCreated.class))
-                .thenReturn(DefaultIndexSetCreated.create());
+    public void migrationDoesNotRunAgainIfMigrationWasSuccessfulBefore() throws Exception {
+        when(clusterConfigService.get(DefaultIndexSetCreated.class)).thenReturn(DefaultIndexSetCreated.create());
+        migration.upgrade();
 
-        verify(indexSetService, never()).save(any(IndexSetConfig.class));
-        verify(clusterConfigService, never()).write(any(DefaultIndexSetCreated.class));
+        verify(clusterConfigService).get(DefaultIndexSetCreated.class);
+        verifyNoMoreInteractions(clusterConfigService);
+        verifyZeroInteractions(clusterEventBus);
+        verifyZeroInteractions(indexSetService);
     }
 
     private static class StubRotationStrategy implements RotationStrategy {

--- a/graylog2-server/src/test/java/org/graylog2/migrations/V20161116172100_DefaultIndexSetMigrationTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/migrations/V20161116172100_DefaultIndexSetMigrationTest.java
@@ -92,6 +92,10 @@ public class V20161116172100_DefaultIndexSetMigrationTest {
                 .rotationStrategy(rotationStrategyConfig)
                 .retentionStrategy(retentionStrategyConfig)
                 .creationDate(ZonedDateTime.of(2016, 10, 12, 0, 0, 0, 0, ZoneOffset.UTC))
+                .indexAnalyzer("standard")
+                .indexTemplateName("template-1")
+                .indexOptimizationMaxNumSegments(1)
+                .indexOptimizationDisabled(false)
                 .build();
         when(clusterConfigService.get(IndexManagementConfig.class)).thenReturn(IndexManagementConfig.create("test", "test"));
         when(clusterConfigService.get(StubRotationStrategyConfig.class)).thenReturn(rotationStrategyConfig);
@@ -116,6 +120,10 @@ public class V20161116172100_DefaultIndexSetMigrationTest {
         assertThat(capturedIndexSetConfig.replicas()).isEqualTo(elasticsearchConfiguration.getReplicas());
         assertThat(capturedIndexSetConfig.rotationStrategy()).isInstanceOf(StubRotationStrategyConfig.class);
         assertThat(capturedIndexSetConfig.retentionStrategy()).isInstanceOf(StubRetentionStrategyConfig.class);
+        assertThat(capturedIndexSetConfig.indexAnalyzer()).isEqualTo(elasticsearchConfiguration.getAnalyzer());
+        assertThat(capturedIndexSetConfig.indexTemplateName()).isEqualTo(elasticsearchConfiguration.getTemplateName());
+        assertThat(capturedIndexSetConfig.indexOptimizationMaxNumSegments()).isEqualTo(elasticsearchConfiguration.getIndexOptimizationMaxNumSegments());
+        assertThat(capturedIndexSetConfig.indexOptimizationDisabled()).isEqualTo(elasticsearchConfiguration.isDisableIndexOptimization());
     }
 
     @Test

--- a/graylog2-server/src/test/java/org/graylog2/migrations/V20161116172100_DefaultIndexSetMigrationTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/migrations/V20161116172100_DefaultIndexSetMigrationTest.java
@@ -94,6 +94,10 @@ public class V20161116172100_DefaultIndexSetMigrationTest {
                 .rotationStrategy(rotationStrategyConfig)
                 .retentionStrategy(retentionStrategyConfig)
                 .creationDate(ZonedDateTime.of(2016, 10, 12, 0, 0, 0, 0, ZoneOffset.UTC))
+                .indexAnalyzer("standard")
+                .indexTemplateName("prefix-template")
+                .indexOptimizationMaxNumSegments(1)
+                .indexOptimizationDisabled(false)
                 .build();
         when(clusterConfigService.get(IndexManagementConfig.class)).thenReturn(IndexManagementConfig.create("test", "test"));
         when(clusterConfigService.get(StubRotationStrategyConfig.class)).thenReturn(rotationStrategyConfig);
@@ -118,10 +122,10 @@ public class V20161116172100_DefaultIndexSetMigrationTest {
         assertThat(capturedIndexSetConfig.replicas()).isEqualTo(elasticsearchConfiguration.getReplicas());
         assertThat(capturedIndexSetConfig.rotationStrategy()).isInstanceOf(StubRotationStrategyConfig.class);
         assertThat(capturedIndexSetConfig.retentionStrategy()).isInstanceOf(StubRetentionStrategyConfig.class);
-        assertThat(capturedIndexSetConfig.indexAnalyzer()).isNull();
-        assertThat(capturedIndexSetConfig.indexTemplateName()).isNull();
-        assertThat(capturedIndexSetConfig.indexOptimizationMaxNumSegments()).isNull();
-        assertThat(capturedIndexSetConfig.indexOptimizationDisabled()).isNull();
+        assertThat(capturedIndexSetConfig.indexAnalyzer()).isEqualTo(elasticsearchConfiguration.getAnalyzer());
+        assertThat(capturedIndexSetConfig.indexTemplateName()).isEqualTo(elasticsearchConfiguration.getTemplateName());
+        assertThat(capturedIndexSetConfig.indexOptimizationMaxNumSegments()).isEqualTo(elasticsearchConfiguration.getIndexOptimizationMaxNumSegments());
+        assertThat(capturedIndexSetConfig.indexOptimizationDisabled()).isEqualTo(elasticsearchConfiguration.isDisableIndexOptimization());
     }
 
     @Test

--- a/graylog2-server/src/test/java/org/graylog2/migrations/V20161124104700_AddRetentionRotationAndDefaultFlagToIndexSetMigrationTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/migrations/V20161124104700_AddRetentionRotationAndDefaultFlagToIndexSetMigrationTest.java
@@ -89,6 +89,10 @@ public class V20161124104700_AddRetentionRotationAndDefaultFlagToIndexSetMigrati
                 .rotationStrategy(rotationStrategy)
                 .retentionStrategy(retentionStrategy)
                 .creationDate(ZonedDateTime.of(2016, 10, 12, 0, 0, 0, 0, ZoneOffset.UTC))
+                .indexAnalyzer("standard")
+                .indexTemplateName("template-1")
+                .indexOptimizationMaxNumSegments(1)
+                .indexOptimizationDisabled(false)
                 .build();
         final IndexSetConfig config2 = IndexSetConfig.builder()
                 .id("id-2")
@@ -99,6 +103,10 @@ public class V20161124104700_AddRetentionRotationAndDefaultFlagToIndexSetMigrati
                 .rotationStrategy(rotationStrategy)
                 .retentionStrategy(retentionStrategy)
                 .creationDate(ZonedDateTime.of(2016, 10, 10, 0, 0, 0, 0, ZoneOffset.UTC))
+                .indexAnalyzer("standard")
+                .indexTemplateName("template-2")
+                .indexOptimizationMaxNumSegments(1)
+                .indexOptimizationDisabled(false)
                 .build();
 
         when(clusterConfigService.get(IndexManagementConfig.class)).thenReturn(IndexManagementConfig.create(rotationStrategyClass , retentionStrategyClass));
@@ -138,6 +146,10 @@ public class V20161124104700_AddRetentionRotationAndDefaultFlagToIndexSetMigrati
                 .retentionStrategyClass(retentionStrategyClass)
                 .retentionStrategy(retentionStrategy)
                 .creationDate(ZonedDateTime.of(2016, 10, 12, 0, 0, 0, 0, ZoneOffset.UTC))
+                .indexAnalyzer("standard")
+                .indexTemplateName("template-1")
+                .indexOptimizationMaxNumSegments(1)
+                .indexOptimizationDisabled(false)
                 .build();
         final IndexSetConfig config2 = IndexSetConfig.builder()
                 .id("id-2")
@@ -150,6 +162,10 @@ public class V20161124104700_AddRetentionRotationAndDefaultFlagToIndexSetMigrati
                 .retentionStrategyClass(retentionStrategyClass)
                 .retentionStrategy(retentionStrategy)
                 .creationDate(ZonedDateTime.of(2016, 10, 13, 0, 0, 0, 0, ZoneOffset.UTC))
+                .indexAnalyzer("standard")
+                .indexTemplateName("template-2")
+                .indexOptimizationMaxNumSegments(1)
+                .indexOptimizationDisabled(false)
                 .build();
 
         when(clusterConfigService.get(IndexManagementConfig.class)).thenReturn(IndexManagementConfig.create(rotationStrategyClass, retentionStrategyClass));
@@ -194,6 +210,10 @@ public class V20161124104700_AddRetentionRotationAndDefaultFlagToIndexSetMigrati
                 .rotationStrategy(rotationStrategy)
                 .retentionStrategy(retentionStrategy)
                 .creationDate(ZonedDateTime.of(2016, 10, 12, 0, 0, 0, 0, ZoneOffset.UTC))
+                .indexAnalyzer("standard")
+                .indexTemplateName("template-1")
+                .indexOptimizationMaxNumSegments(1)
+                .indexOptimizationDisabled(false)
                 .build();
         final IndexSetConfig config2 = IndexSetConfig.builder()
                 .id("id-2")
@@ -204,6 +224,10 @@ public class V20161124104700_AddRetentionRotationAndDefaultFlagToIndexSetMigrati
                 .rotationStrategy(rotationStrategy)
                 .retentionStrategy(retentionStrategy)
                 .creationDate(ZonedDateTime.of(2016, 10, 13, 0, 0, 0, 0, ZoneOffset.UTC))
+                .indexAnalyzer("standard")
+                .indexTemplateName("template-2")
+                .indexOptimizationMaxNumSegments(1)
+                .indexOptimizationDisabled(false)
                 .build();
 
         when(clusterConfigService.get(IndexManagementConfig.class)).thenReturn(IndexManagementConfig.create(rotationStrategyClass , retentionStrategyClass));
@@ -235,6 +259,10 @@ public class V20161124104700_AddRetentionRotationAndDefaultFlagToIndexSetMigrati
                 .rotationStrategy(rotationStrategy)
                 .retentionStrategy(retentionStrategy)
                 .creationDate(ZonedDateTime.of(2016, 10, 12, 0, 0, 0, 0, ZoneOffset.UTC))
+                .indexAnalyzer("standard")
+                .indexTemplateName("template-1")
+                .indexOptimizationMaxNumSegments(1)
+                .indexOptimizationDisabled(false)
                 .build();
         final IndexSetConfig config2 = IndexSetConfig.builder()
                 .id("id-2")
@@ -245,6 +273,10 @@ public class V20161124104700_AddRetentionRotationAndDefaultFlagToIndexSetMigrati
                 .rotationStrategy(rotationStrategy)
                 .retentionStrategy(retentionStrategy)
                 .creationDate(ZonedDateTime.of(2016, 10, 13, 0, 0, 0, 0, ZoneOffset.UTC))
+                .indexAnalyzer("standard")
+                .indexTemplateName("template-2")
+                .indexOptimizationMaxNumSegments(1)
+                .indexOptimizationDisabled(false)
                 .build();
 
         when(clusterConfigService.get(IndexManagementConfig.class)).thenReturn(IndexManagementConfig.create(rotationStrategyClass , retentionStrategyClass));
@@ -275,6 +307,10 @@ public class V20161124104700_AddRetentionRotationAndDefaultFlagToIndexSetMigrati
                 .rotationStrategy(rotationStrategy)
                 .retentionStrategy(retentionStrategy)
                 .creationDate(ZonedDateTime.of(2016, 10, 12, 0, 0, 0, 0, ZoneOffset.UTC))
+                .indexAnalyzer("standard")
+                .indexTemplateName("template-1")
+                .indexOptimizationMaxNumSegments(1)
+                .indexOptimizationDisabled(false)
                 .build();
         final IndexSetConfig config2 = IndexSetConfig.builder()
                 .id("id-2")
@@ -285,6 +321,10 @@ public class V20161124104700_AddRetentionRotationAndDefaultFlagToIndexSetMigrati
                 .rotationStrategy(rotationStrategy)
                 .retentionStrategy(retentionStrategy)
                 .creationDate(ZonedDateTime.of(2016, 10, 13, 0, 0, 0, 0, ZoneOffset.UTC))
+                .indexAnalyzer("standard")
+                .indexTemplateName("template-2")
+                .indexOptimizationMaxNumSegments(1)
+                .indexOptimizationDisabled(false)
                 .build();
 
         when(clusterConfigService.get(IndexManagementConfig.class)).thenReturn(IndexManagementConfig.create(rotationStrategyClass , retentionStrategyClass));

--- a/graylog2-server/src/test/java/org/graylog2/migrations/V20161216123500_DefaultIndexSetMigrationTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/migrations/V20161216123500_DefaultIndexSetMigrationTest.java
@@ -120,7 +120,7 @@ public class V20161216123500_DefaultIndexSetMigrationTest {
         assertThat(capturedIndexSetConfig.rotationStrategy()).isEqualTo(rotationStrategyConfig);
         assertThat(capturedIndexSetConfig.retentionStrategy()).isEqualTo(retentionStrategyConfig);
         assertThat(capturedIndexSetConfig.indexAnalyzer()).isEqualTo(elasticsearchConfiguration.getAnalyzer());
-        assertThat(capturedIndexSetConfig.indexTemplateName()).isEqualTo(elasticsearchConfiguration.getTemplateName());
+        assertThat(capturedIndexSetConfig.indexTemplateName()).isEqualTo("prefix-template");
         assertThat(capturedIndexSetConfig.indexOptimizationMaxNumSegments()).isEqualTo(elasticsearchConfiguration.getIndexOptimizationMaxNumSegments());
         assertThat(capturedIndexSetConfig.indexOptimizationDisabled()).isEqualTo(elasticsearchConfiguration.isDisableIndexOptimization());
     }

--- a/graylog2-server/src/test/java/org/graylog2/migrations/V20161216123500_DefaultIndexSetMigrationTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/migrations/V20161216123500_DefaultIndexSetMigrationTest.java
@@ -37,6 +37,7 @@ import org.mockito.junit.MockitoRule;
 
 import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
+import java.util.Collections;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
@@ -86,6 +87,10 @@ public class V20161216123500_DefaultIndexSetMigrationTest {
                 .rotationStrategy(rotationStrategyConfig)
                 .retentionStrategy(retentionStrategyConfig)
                 .creationDate(ZonedDateTime.of(2016, 10, 12, 0, 0, 0, 0, ZoneOffset.UTC))
+                .indexAnalyzer("standard")
+                .indexTemplateName("prefix-template")
+                .indexOptimizationMaxNumSegments(1)
+                .indexOptimizationDisabled(false)
                 .build();
         final IndexSetConfig savedConfig = defaultConfig.toBuilder()
                 .indexAnalyzer(elasticsearchConfiguration.getAnalyzer())
@@ -95,7 +100,7 @@ public class V20161216123500_DefaultIndexSetMigrationTest {
                 .build();
         when(indexSetService.save(any(IndexSetConfig.class))).thenReturn(savedConfig);
         when(clusterConfigService.get(DefaultIndexSetCreated.class)).thenReturn(DefaultIndexSetCreated.create());
-        when(indexSetService.getDefault()).thenReturn(defaultConfig);
+        when(indexSetService.findAll()).thenReturn(Collections.singletonList(defaultConfig));
 
         final ArgumentCaptor<IndexSetConfig> indexSetConfigCaptor = ArgumentCaptor.forClass(IndexSetConfig.class);
 

--- a/graylog2-server/src/test/java/org/graylog2/migrations/V20161216123500_DefaultIndexSetMigrationTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/migrations/V20161216123500_DefaultIndexSetMigrationTest.java
@@ -1,0 +1,142 @@
+/**
+ * This file is part of Graylog.
+ *
+ * Graylog is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.graylog2.migrations;
+
+import org.graylog2.configuration.ElasticsearchConfiguration;
+import org.graylog2.events.ClusterEventBus;
+import org.graylog2.indexer.indexset.DefaultIndexSetCreated;
+import org.graylog2.indexer.indexset.IndexSetConfig;
+import org.graylog2.indexer.indexset.IndexSetService;
+import org.graylog2.indexer.indexset.V20161216123500_Succeeded;
+import org.graylog2.indexer.indexset.events.IndexSetCreatedEvent;
+import org.graylog2.plugin.cluster.ClusterConfigService;
+import org.graylog2.plugin.indexer.retention.RetentionStrategyConfig;
+import org.graylog2.plugin.indexer.rotation.RotationStrategyConfig;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnit;
+import org.mockito.junit.MockitoRule;
+
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.verifyZeroInteractions;
+import static org.mockito.Mockito.when;
+
+public class V20161216123500_DefaultIndexSetMigrationTest {
+    @Rule
+    public final MockitoRule mockitoRule = MockitoJUnit.rule();
+    @Rule
+    public final ExpectedException expectedException = ExpectedException.none();
+
+    @Mock
+    private IndexSetService indexSetService;
+    @Mock
+    private ClusterConfigService clusterConfigService;
+    @Mock
+    private ClusterEventBus clusterEventBus;
+
+    private final ElasticsearchConfiguration elasticsearchConfiguration = new ElasticsearchConfiguration();
+    private Migration migration;
+
+
+    @Before
+    public void setUpService() throws Exception {
+        migration = new V20161216123500_DefaultIndexSetMigration(
+                elasticsearchConfiguration,
+                indexSetService,
+                clusterConfigService,
+                clusterEventBus);
+    }
+
+    @Test
+    public void upgradeCreatesDefaultIndexSet() throws Exception {
+        final RotationStrategyConfig rotationStrategyConfig = mock(RotationStrategyConfig.class);
+        final RetentionStrategyConfig retentionStrategyConfig = mock(RetentionStrategyConfig.class);
+        final IndexSetConfig defaultConfig = IndexSetConfig.builder()
+                .id("id")
+                .title("title")
+                .description("description")
+                .indexPrefix("prefix")
+                .shards(1)
+                .replicas(0)
+                .rotationStrategy(rotationStrategyConfig)
+                .retentionStrategy(retentionStrategyConfig)
+                .creationDate(ZonedDateTime.of(2016, 10, 12, 0, 0, 0, 0, ZoneOffset.UTC))
+                .build();
+        final IndexSetConfig savedConfig = defaultConfig.toBuilder()
+                .indexAnalyzer(elasticsearchConfiguration.getAnalyzer())
+                .indexTemplateName(elasticsearchConfiguration.getTemplateName())
+                .indexOptimizationMaxNumSegments(elasticsearchConfiguration.getIndexOptimizationMaxNumSegments())
+                .indexOptimizationDisabled(elasticsearchConfiguration.isDisableIndexOptimization())
+                .build();
+        when(indexSetService.save(any(IndexSetConfig.class))).thenReturn(savedConfig);
+        when(clusterConfigService.get(DefaultIndexSetCreated.class)).thenReturn(DefaultIndexSetCreated.create());
+        when(indexSetService.getDefault()).thenReturn(defaultConfig);
+
+        final ArgumentCaptor<IndexSetConfig> indexSetConfigCaptor = ArgumentCaptor.forClass(IndexSetConfig.class);
+
+        migration.upgrade();
+
+        verify(indexSetService).save(indexSetConfigCaptor.capture());
+        verify(clusterConfigService).write(V20161216123500_Succeeded.create());
+        verify(clusterEventBus).post(IndexSetCreatedEvent.create(savedConfig));
+
+        final IndexSetConfig capturedIndexSetConfig = indexSetConfigCaptor.getValue();
+        assertThat(capturedIndexSetConfig.id()).isEqualTo("id");
+        assertThat(capturedIndexSetConfig.title()).isEqualTo("title");
+        assertThat(capturedIndexSetConfig.description()).isEqualTo("description");
+        assertThat(capturedIndexSetConfig.indexPrefix()).isEqualTo("prefix");
+        assertThat(capturedIndexSetConfig.shards()).isEqualTo(1);
+        assertThat(capturedIndexSetConfig.replicas()).isEqualTo(0);
+        assertThat(capturedIndexSetConfig.rotationStrategy()).isEqualTo(rotationStrategyConfig);
+        assertThat(capturedIndexSetConfig.retentionStrategy()).isEqualTo(retentionStrategyConfig);
+        assertThat(capturedIndexSetConfig.indexAnalyzer()).isEqualTo(elasticsearchConfiguration.getAnalyzer());
+        assertThat(capturedIndexSetConfig.indexTemplateName()).isEqualTo(elasticsearchConfiguration.getTemplateName());
+        assertThat(capturedIndexSetConfig.indexOptimizationMaxNumSegments()).isEqualTo(elasticsearchConfiguration.getIndexOptimizationMaxNumSegments());
+        assertThat(capturedIndexSetConfig.indexOptimizationDisabled()).isEqualTo(elasticsearchConfiguration.isDisableIndexOptimization());
+    }
+
+    @Test
+    public void upgradeFailsIfDefaultIndexSetHasNotBeenCreated() throws Exception {
+        when(clusterConfigService.get(DefaultIndexSetCreated.class)).thenReturn(null);
+        expectedException.expect(IllegalStateException.class);
+        expectedException.expectMessage("The default index set hasn't been created yet. This is a bug!");
+
+        migration.upgrade();
+    }
+
+    @Test
+    public void migrationDoesNotRunAgainIfMigrationWasSuccessfulBefore() throws Exception {
+        when(clusterConfigService.get(V20161216123500_Succeeded.class)).thenReturn(V20161216123500_Succeeded.create());
+        migration.upgrade();
+
+        verify(clusterConfigService).get(V20161216123500_Succeeded.class);
+        verifyNoMoreInteractions(clusterConfigService);
+        verifyZeroInteractions(clusterEventBus);
+        verifyZeroInteractions(indexSetService);
+    }
+}

--- a/graylog2-server/src/test/java/org/graylog2/rest/resources/system/indexer/IndexSetsResourceTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/rest/resources/system/indexer/IndexSetsResourceTest.java
@@ -99,7 +99,11 @@ public class IndexSetsResourceTest {
                 MessageCountRotationStrategyConfig.create(1000),
                 NoopRetentionStrategy.class.getCanonicalName(),
                 NoopRetentionStrategyConfig.create(1),
-                ZonedDateTime.of(2016, 10, 10, 12, 0, 0, 0, ZoneOffset.UTC)
+                ZonedDateTime.of(2016, 10, 10, 12, 0, 0, 0, ZoneOffset.UTC),
+                "standard",
+                "index-template",
+                1,
+                false
         );
         when(indexSetService.findAll()).thenReturn(Collections.singletonList(indexSetConfig));
 
@@ -128,7 +132,11 @@ public class IndexSetsResourceTest {
                 MessageCountRotationStrategyConfig.create(1000),
                 NoopRetentionStrategy.class.getCanonicalName(),
                 NoopRetentionStrategyConfig.create(1),
-                ZonedDateTime.of(2016, 10, 10, 12, 0, 0, 0, ZoneOffset.UTC)
+                ZonedDateTime.of(2016, 10, 10, 12, 0, 0, 0, ZoneOffset.UTC),
+                "standard",
+                "index-template",
+                1,
+                false
         );
         when(indexSetService.findAll()).thenReturn(Collections.singletonList(indexSetConfig));
 
@@ -172,7 +180,11 @@ public class IndexSetsResourceTest {
                 MessageCountRotationStrategyConfig.create(1000),
                 NoopRetentionStrategy.class.getCanonicalName(),
                 NoopRetentionStrategyConfig.create(1),
-                ZonedDateTime.of(2016, 10, 10, 12, 0, 0, 0, ZoneOffset.UTC)
+                ZonedDateTime.of(2016, 10, 10, 12, 0, 0, 0, ZoneOffset.UTC),
+                "standard",
+                "index-template",
+                1,
+                false
         );
         when(indexSetService.get("id")).thenReturn(Optional.of(indexSetConfig));
 
@@ -229,7 +241,11 @@ public class IndexSetsResourceTest {
                 MessageCountRotationStrategyConfig.create(1000),
                 NoopRetentionStrategy.class.getCanonicalName(),
                 NoopRetentionStrategyConfig.create(1),
-                ZonedDateTime.of(2016, 10, 10, 12, 0, 0, 0, ZoneOffset.UTC)
+                ZonedDateTime.of(2016, 10, 10, 12, 0, 0, 0, ZoneOffset.UTC),
+                "standard",
+                "index-template",
+                1,
+                false
         );
         final IndexSetConfig savedIndexSetConfig = indexSetConfig.toBuilder()
                 .id("id")
@@ -260,7 +276,11 @@ public class IndexSetsResourceTest {
                 MessageCountRotationStrategyConfig.create(1000),
                 NoopRetentionStrategy.class.getCanonicalName(),
                 NoopRetentionStrategyConfig.create(1),
-                ZonedDateTime.of(2016, 10, 10, 12, 0, 0, 0, ZoneOffset.UTC)
+                ZonedDateTime.of(2016, 10, 10, 12, 0, 0, 0, ZoneOffset.UTC),
+                "standard",
+                "index-template",
+                1,
+                false
         );
 
         expectedException.expect(ForbiddenException.class);
@@ -288,7 +308,11 @@ public class IndexSetsResourceTest {
                 MessageCountRotationStrategyConfig.create(1000),
                 NoopRetentionStrategy.class.getCanonicalName(),
                 NoopRetentionStrategyConfig.create(1),
-                ZonedDateTime.of(2016, 10, 10, 12, 0, 0, 0, ZoneOffset.UTC)
+                ZonedDateTime.of(2016, 10, 10, 12, 0, 0, 0, ZoneOffset.UTC),
+                "standard",
+                "index-template",
+                1,
+                false
         );
         final IndexSetConfig updatedIndexSetConfig = indexSetConfig.toBuilder()
                 .title("new title")
@@ -321,7 +345,11 @@ public class IndexSetsResourceTest {
                 MessageCountRotationStrategyConfig.create(1000),
                 NoopRetentionStrategy.class.getCanonicalName(),
                 NoopRetentionStrategyConfig.create(1),
-                ZonedDateTime.of(2016, 10, 10, 12, 0, 0, 0, ZoneOffset.UTC)
+                ZonedDateTime.of(2016, 10, 10, 12, 0, 0, 0, ZoneOffset.UTC),
+                "standard",
+                "index-template",
+                1,
+                false
         );
 
         expectedException.expect(ClientErrorException.class);
@@ -349,7 +377,11 @@ public class IndexSetsResourceTest {
                 MessageCountRotationStrategyConfig.create(1000),
                 NoopRetentionStrategy.class.getCanonicalName(),
                 NoopRetentionStrategyConfig.create(1),
-                ZonedDateTime.of(2016, 10, 10, 12, 0, 0, 0, ZoneOffset.UTC)
+                ZonedDateTime.of(2016, 10, 10, 12, 0, 0, 0, ZoneOffset.UTC),
+                "standard",
+                "index-template",
+                1,
+                false
         );
 
         expectedException.expect(ForbiddenException.class);

--- a/graylog2-server/src/test/java/org/graylog2/rest/resources/system/indexer/IndexSetsResourceTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/rest/resources/system/indexer/IndexSetsResourceTest.java
@@ -243,7 +243,7 @@ public class IndexSetsResourceTest {
                 NoopRetentionStrategyConfig.create(1),
                 ZonedDateTime.of(2016, 10, 10, 12, 0, 0, 0, ZoneOffset.UTC),
                 "standard",
-                "index-template",
+                "prefix-template",
                 1,
                 false
         );
@@ -327,7 +327,12 @@ public class IndexSetsResourceTest {
         verify(indexSetService, times(1)).save(indexSetConfig);
         verify(indexSetService, times(1)).getDefault();
         verifyNoMoreInteractions(indexSetService);
-        assertThat(summary.toIndexSetConfig()).isEqualTo(updatedIndexSetConfig);
+
+        // The real update wouldn't replace the index template name…
+        final IndexSetConfig actual = summary.toIndexSetConfig().toBuilder()
+                .indexTemplateName("index-template")
+                .build();
+        assertThat(actual).isEqualTo(updatedIndexSetConfig);
     }
 
     @Test

--- a/graylog2-server/src/test/resources/org/graylog2/indexer/indexset/MongoIndexSetServiceTest.json
+++ b/graylog2-server/src/test/resources/org/graylog2/indexer/indexset/MongoIndexSetServiceTest.json
@@ -21,7 +21,11 @@
       },
       "creation_date": {
         "$date": "2016-10-04T17:00:00Z"
-      }
+      },
+      "index_analyzer": "standard",
+      "index_template_name": "test_1",
+      "index_optimization_max_num_segments": 1,
+      "index_optimization_disabled": false
     },
     {
       "_id": {
@@ -43,7 +47,11 @@
       },
       "creation_date": {
         "$date": "2016-10-04T18:00:00Z"
-      }
+      },
+      "index_analyzer": "standard",
+      "index_template_name": "test_2",
+      "index_optimization_max_num_segments": 1,
+      "index_optimization_disabled": false
     }
   ]
 }

--- a/graylog2-web-interface/src/components/indices/IndexSetConfigurationForm.jsx
+++ b/graylog2-web-interface/src/components/indices/IndexSetConfigurationForm.jsx
@@ -169,14 +169,6 @@ const IndexSetConfigurationForm = React.createClass({
                  value={indexSet.index_analyzer}
                  help="Elasticsearch analyzer for this index set."
                  required />
-          <Input type="text"
-                 id="index-set-index-template"
-                 label="Index Template"
-                 name="index_template_name"
-                 onChange={this._onInputChange}
-                 value={indexSet.index_template_name}
-                 help="Elasticsearch index template."
-                 required />
         </span>
       );
     }

--- a/graylog2-web-interface/src/components/indices/IndexSetConfigurationForm.jsx
+++ b/graylog2-web-interface/src/components/indices/IndexSetConfigurationForm.jsx
@@ -60,6 +60,10 @@ const IndexSetConfigurationForm = React.createClass({
     this._updateConfig(event.target.name, event.target.value);
   },
 
+  _onDisableOptimizationClick(event) {
+      this._updateConfig(event.target.name, event.target.checked);
+  },
+
   _saveConfiguration(event) {
     event.preventDefault();
 
@@ -205,6 +209,7 @@ const IndexSetConfigurationForm = React.createClass({
                        id="index-set-max-num-segments"
                        label="Max. number of segments"
                        name="index_optimization_max_num_segments"
+                       min="1"
                        onChange={this._onInputChange}
                        value={indexSet.index_optimization_max_num_segments}
                        help="Maximum number of segments per Elasticsearch index after optimization (force merge)."
@@ -213,7 +218,7 @@ const IndexSetConfigurationForm = React.createClass({
                        id="index-set-disable-optimization"
                        label="Disable index optimization after rotation"
                        name="index_optimization_disabled"
-                       onChange={this._onInputChange}
+                       onChange={this._onDisableOptimizationClick}
                        checked={indexSet.index_optimization_disabled}
                        help="Disable Elasticsearch index optimization (force merge) after rotation." />
               </Col>

--- a/graylog2-web-interface/src/components/indices/IndexSetConfigurationForm.jsx
+++ b/graylog2-web-interface/src/components/indices/IndexSetConfigurationForm.jsx
@@ -157,6 +157,22 @@ const IndexSetConfigurationForm = React.createClass({
                  value={indexSet.replicas}
                  help="Number of Elasticsearch replicas used per index in this index set."
                  required />
+          <Input type="text"
+                 id="index-set-index-analyzer"
+                 label="Analyzer"
+                 name="index_analyzer"
+                 onChange={this._onInputChange}
+                 value={indexSet.index_analyzer}
+                 help="Elasticsearch analyzer for this index set."
+                 required />
+          <Input type="text"
+                 id="index-set-index-template"
+                 label="Index Template"
+                 name="index_template_name"
+                 onChange={this._onInputChange}
+                 value={indexSet.index_template_name}
+                 help="Elasticsearch index template."
+                 required />
         </span>
       );
     }
@@ -185,6 +201,21 @@ const IndexSetConfigurationForm = React.createClass({
                        help="Add a description of this index set."
                        required />
                 {readOnlyconfig}
+                <Input type="number"
+                       id="index-set-max-num-segments"
+                       label="Max. number of segments"
+                       name="index_optimization_max_num_segments"
+                       onChange={this._onInputChange}
+                       value={indexSet.index_optimization_max_num_segments}
+                       help="Maximum number of segments per Elasticsearch index after optimization (force merge)."
+                       required />
+                <Input type="checkbox"
+                       id="index-set-disable-optimization"
+                       label="Disable index optimization after rotation"
+                       name="index_optimization_disabled"
+                       onChange={this._onInputChange}
+                       checked={indexSet.index_optimization_disabled}
+                       help="Disable Elasticsearch index optimization (force merge) after rotation." />
               </Col>
             </Row>
             <Row>

--- a/graylog2-web-interface/src/pages/IndexSetCreationPage.jsx
+++ b/graylog2-web-interface/src/pages/IndexSetCreationPage.jsx
@@ -42,6 +42,10 @@ const IndexSetCreationPage = React.createClass({
           max_docs_per_index: 20000000,
           type: 'org.graylog2.indexer.rotation.strategies.MessageCountRotationStrategyConfig',
         },
+        index_analyzer: 'standard',
+        index_template_name: '',
+        index_optimization_max_num_segments: 1,
+        index_optimization_disabled: false
       },
     };
   },

--- a/graylog2-web-interface/src/pages/IndexSetCreationPage.jsx
+++ b/graylog2-web-interface/src/pages/IndexSetCreationPage.jsx
@@ -43,7 +43,6 @@ const IndexSetCreationPage = React.createClass({
           type: 'org.graylog2.indexer.rotation.strategies.MessageCountRotationStrategyConfig',
         },
         index_analyzer: 'standard',
-        index_template_name: '',
         index_optimization_max_num_segments: 1,
         index_optimization_disabled: false
       },

--- a/misc/graylog.conf
+++ b/misc/graylog.conf
@@ -239,14 +239,22 @@ elasticsearch_max_number_of_indices = 20
 retention_strategy = delete
 
 # How many Elasticsearch shards and replicas should be used per index? Note that this only applies to newly created indices.
+# ATTENTION: These settings have been moved to the database in Graylog 2.2.0. When you upgrade, make sure to set these
+#            to your previous settings so they will be migrated to the database!
 elasticsearch_shards = 4
 elasticsearch_replicas = 0
 
 # Prefix for all Elasticsearch indices and index aliases managed by Graylog.
+#
+# ATTENTION: These settings have been moved to the database in Graylog 2.2.0. When you upgrade, make sure to set these
+#            to your previous settings so they will be migrated to the database!
 elasticsearch_index_prefix = graylog
 
 # Name of the Elasticsearch index template used by Graylog to apply the mandatory index mapping.
-# # Default: graylog-internal
+# Default: graylog-internal
+#
+# ATTENTION: These settings have been moved to the database in Graylog 2.2.0. When you upgrade, make sure to set these
+#            to your previous settings so they will be migrated to the database!
 #elasticsearch_template_name = graylog-internal
 
 # Do you want to allow searches with leading wildcards? This can be extremely resource hungry and should only
@@ -307,6 +315,9 @@ allow_highlighting = false
 # All supported analyzers are: standard, simple, whitespace, stop, keyword, pattern, language, snowball, custom
 # Elasticsearch documentation: https://www.elastic.co/guide/en/elasticsearch/reference/2.3/analysis.html
 # Note that this setting only takes effect on newly created indices.
+#
+# ATTENTION: These settings have been moved to the database in Graylog 2.2.0. When you upgrade, make sure to set these
+#            to your previous settings so they will be migrated to the database!
 elasticsearch_analyzer = standard
 
 # Global request timeout for Elasticsearch requests (e. g. during search, index creation, or index time-range
@@ -492,10 +503,16 @@ mongodb_threads_allowed_to_block_multiplier = 5
 # Disable the optimization of Elasticsearch indices after index cycling. This may take some load from Elasticsearch
 # on heavily used systems with large indices, but it will decrease search performance. The default is to optimize
 # cycled indices.
+#
+# ATTENTION: These settings have been moved to the database in Graylog 2.2.0. When you upgrade, make sure to set these
+#            to your previous settings so they will be migrated to the database!
 #disable_index_optimization = true
 
 # Optimize the index down to <= index_optimization_max_num_segments. A higher number may take some load from Elasticsearch
 # on heavily used systems with large indices, but it will decrease search performance. The default is 1.
+#
+# ATTENTION: These settings have been moved to the database in Graylog 2.2.0. When you upgrade, make sure to set these
+#            to your previous settings so they will be migrated to the database!
 #index_optimization_max_num_segments = 1
 
 # The threshold of the garbage collection runs. If GC runs take longer than this threshold, a system notification


### PR DESCRIPTION
This PR addresses some open TODOs:

* Remove TODO about `ZonedDateTime` in `IndexSetConfig`
* Migrate remaining index settings from config file to `IndexSetConfig`
* Allow overriding analyzer in `MessageResource#analyze()`