### PR TITLE
ClusterEventPeriodical must use MongoJackObjectMapper

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/cluster/ClusterConfigServiceImpl.java
+++ b/graylog2-server/src/main/java/org/graylog2/cluster/ClusterConfigServiceImpl.java
@@ -16,12 +16,14 @@
  */
 package org.graylog2.cluster;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.eventbus.EventBus;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.mongodb.DBCollection;
 import com.mongodb.WriteConcern;
+
 import org.graylog2.bindings.providers.MongoJackObjectMapperProvider;
 import org.graylog2.database.MongoConnection;
 import org.graylog2.events.ClusterEventBus;
@@ -39,8 +41,9 @@ import org.mongojack.WriteResult;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import javax.inject.Inject;
 import java.util.Set;
+
+import javax.inject.Inject;
 
 import static com.google.common.base.MoreObjects.firstNonNull;
 import static com.google.common.base.Preconditions.checkNotNull;
@@ -61,18 +64,17 @@ public class ClusterConfigServiceImpl implements ClusterConfigService {
     public ClusterConfigServiceImpl(final MongoJackObjectMapperProvider mapperProvider,
                                     final MongoConnection mongoConnection,
                                     final NodeId nodeId,
-                                    final ObjectMapper objectMapper,
                                     final ChainingClassLoader chainingClassLoader,
                                     final ClusterEventBus clusterEventBus) {
         this(JacksonDBCollection.wrap(prepareCollection(mongoConnection), ClusterConfig.class, String.class, mapperProvider.get()),
-                nodeId, objectMapper, chainingClassLoader, clusterEventBus);
+                nodeId, mapperProvider.get(), chainingClassLoader, clusterEventBus);
     }
 
-    ClusterConfigServiceImpl(final JacksonDBCollection<ClusterConfig, String> dbCollection,
-                             final NodeId nodeId,
-                             final ObjectMapper objectMapper,
-                             final ChainingClassLoader chainingClassLoader,
-                             final EventBus clusterEventBus) {
+    private ClusterConfigServiceImpl(final JacksonDBCollection<ClusterConfig, String> dbCollection,
+                                     final NodeId nodeId,
+                                     final ObjectMapper objectMapper,
+                                     final ChainingClassLoader chainingClassLoader,
+                                     final EventBus clusterEventBus) {
         this.nodeId = checkNotNull(nodeId);
         this.dbCollection = checkNotNull(dbCollection);
         this.objectMapper = checkNotNull(objectMapper);

--- a/graylog2-server/src/main/java/org/graylog2/events/ClusterEventPeriodical.java
+++ b/graylog2-server/src/main/java/org/graylog2/events/ClusterEventPeriodical.java
@@ -16,11 +16,12 @@
  */
 package org.graylog2.events;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.eventbus.DeadEvent;
 import com.google.common.eventbus.EventBus;
 import com.google.common.eventbus.Subscribe;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.mongodb.BasicDBList;
 import com.mongodb.BasicDBObject;
 import com.mongodb.DB;
@@ -28,6 +29,7 @@ import com.mongodb.DBCollection;
 import com.mongodb.DBObject;
 import com.mongodb.MongoException;
 import com.mongodb.WriteConcern;
+
 import org.graylog2.bindings.providers.MongoJackObjectMapperProvider;
 import org.graylog2.database.MongoConnection;
 import org.graylog2.plugin.periodical.Periodical;
@@ -62,15 +64,14 @@ public class ClusterEventPeriodical extends Periodical {
     public ClusterEventPeriodical(final MongoJackObjectMapperProvider mapperProvider,
                                   final MongoConnection mongoConnection,
                                   final NodeId nodeId,
-                                  final ObjectMapper objectMapper,
                                   final ChainingClassLoader chainingClassLoader,
                                   final EventBus serverEventBus,
                                   final ClusterEventBus clusterEventBus) {
         this(JacksonDBCollection.wrap(prepareCollection(mongoConnection), ClusterEvent.class, String.class, mapperProvider.get()),
-                nodeId, objectMapper, chainingClassLoader, serverEventBus, clusterEventBus);
+                nodeId, mapperProvider.get(), chainingClassLoader, serverEventBus, clusterEventBus);
     }
 
-    ClusterEventPeriodical(final JacksonDBCollection<ClusterEvent, String> dbCollection,
+    private ClusterEventPeriodical(final JacksonDBCollection<ClusterEvent, String> dbCollection,
                            final NodeId nodeId,
                            final ObjectMapper objectMapper,
                            final ChainingClassLoader chainingClassLoader,

--- a/graylog2-server/src/test/java/org/graylog2/cluster/ClusterConfigServiceImplTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/cluster/ClusterConfigServiceImplTest.java
@@ -16,8 +16,9 @@
  */
 package org.graylog2.cluster;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.eventbus.Subscribe;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.lordofthejars.nosqlunit.annotation.UsingDataSet;
 import com.lordofthejars.nosqlunit.core.LoadStrategyEnum;
 import com.lordofthejars.nosqlunit.mongodb.InMemoryMongoDb;
@@ -25,6 +26,7 @@ import com.mongodb.BasicDBObjectBuilder;
 import com.mongodb.DBCollection;
 import com.mongodb.DBObject;
 import com.mongodb.WriteConcern;
+
 import org.graylog2.bindings.providers.MongoJackObjectMapperProvider;
 import org.graylog2.database.MongoConnection;
 import org.graylog2.database.MongoConnectionRule;
@@ -84,7 +86,6 @@ public class ClusterConfigServiceImplTest {
                 provider,
                 mongoRule.getMongoConnection(),
                 nodeId,
-                objectMapper,
                 new ChainingClassLoader(getClass().getClassLoader()),
                 clusterEventBus
         );

--- a/graylog2-server/src/test/java/org/graylog2/events/ClusterEventPeriodicalTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/events/ClusterEventPeriodicalTest.java
@@ -16,11 +16,12 @@
  */
 package org.graylog2.events;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.eventbus.DeadEvent;
 import com.google.common.eventbus.EventBus;
 import com.google.common.eventbus.Subscribe;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.lordofthejars.nosqlunit.annotation.UsingDataSet;
 import com.lordofthejars.nosqlunit.core.LoadStrategyEnum;
 import com.lordofthejars.nosqlunit.mongodb.InMemoryMongoDb;
@@ -28,6 +29,7 @@ import com.mongodb.BasicDBObjectBuilder;
 import com.mongodb.DBCollection;
 import com.mongodb.DBObject;
 import com.mongodb.WriteConcern;
+
 import org.graylog2.bindings.providers.MongoJackObjectMapperProvider;
 import org.graylog2.database.MongoConnection;
 import org.graylog2.database.MongoConnectionRule;
@@ -93,7 +95,6 @@ public class ClusterEventPeriodicalTest {
                 provider,
                 mongoRule.getMongoConnection(),
                 nodeId,
-                objectMapper,
                 new ChainingClassLoader(getClass().getClassLoader()),
                 serverEventBus,
                 clusterEventBus

--- a/graylog2-server/src/test/java/org/graylog2/indexer/indexset/MongoIndexSetServiceTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/indexer/indexset/MongoIndexSetServiceTest.java
@@ -16,11 +16,13 @@
  */
 package org.graylog2.indexer.indexset;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.eventbus.Subscribe;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.lordofthejars.nosqlunit.annotation.UsingDataSet;
 import com.lordofthejars.nosqlunit.core.LoadStrategyEnum;
 import com.lordofthejars.nosqlunit.mongodb.InMemoryMongoDb;
+
 import org.bson.types.ObjectId;
 import org.graylog2.bindings.providers.MongoJackObjectMapperProvider;
 import org.graylog2.buffers.processors.fakestreams.FakeStream;
@@ -84,7 +86,7 @@ public class MongoIndexSetServiceTest {
     public void setUp() throws Exception {
         clusterEventBus = new ClusterEventBus();
         clusterConfigService = new ClusterConfigServiceImpl(objectMapperProvider, mongoRule.getMongoConnection(),
-                nodeId, objectMapper, new ChainingClassLoader(getClass().getClassLoader()), clusterEventBus);
+                nodeId, new ChainingClassLoader(getClass().getClassLoader()), clusterEventBus);
         indexSetService = new MongoIndexSetService(mongoRule.getMongoConnection(), objectMapperProvider, streamService, clusterConfigService, clusterEventBus);
     }
 

--- a/graylog2-server/src/test/java/org/graylog2/migrations/V20161215163900_MoveIndexSetDefaultConfigTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/migrations/V20161215163900_MoveIndexSetDefaultConfigTest.java
@@ -70,7 +70,7 @@ public class V20161215163900_MoveIndexSetDefaultConfigTest {
     @Before
     public void setUp() throws Exception {
         this.clusterConfigService = spy(new ClusterConfigServiceImpl(objectMapperProvider,
-                fongoRule.getConnection(), nodeId, objectMapper,
+                fongoRule.getConnection(), nodeId,
                 new ChainingClassLoader(getClass().getClassLoader()), new ClusterEventBus()));
 
         this.collection = fongoRule.getDatabase().getCollection("index_sets");


### PR DESCRIPTION
previously reading from the database used the wrong object mapper configuration

fixes #3216

