### PR TITLE
Make "sender" optional in EmailAlarmCallback

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/alarmcallbacks/EmailAlarmCallback.java
+++ b/graylog2-server/src/main/java/org/graylog2/alarmcallbacks/EmailAlarmCallback.java
@@ -49,6 +49,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 
+import static com.google.common.base.Strings.isNullOrEmpty;
+
 public class EmailAlarmCallback implements AlarmCallback {
     private static final Logger LOG = LoggerFactory.getLogger(EmailAlarmCallback.class);
 
@@ -228,8 +230,9 @@ public class EmailAlarmCallback implements AlarmCallback {
 
     @Override
     public void checkConfiguration() throws ConfigurationException {
-        if (configuration.getString("sender") == null || configuration.getString("sender").isEmpty()
-                || configuration.getString("subject") == null || configuration.getString("subject").isEmpty())
+        final boolean missingSender = isNullOrEmpty(configuration.getString("sender")) && isNullOrEmpty(emailConfiguration.getFromEmail());
+        if (missingSender || isNullOrEmpty(configuration.getString("subject"))) {
             throw new ConfigurationException("Sender or subject are missing or invalid!");
+        }
     }
 }

--- a/graylog2-server/src/main/java/org/graylog2/alarmcallbacks/EmailAlarmCallback.java
+++ b/graylog2-server/src/main/java/org/graylog2/alarmcallbacks/EmailAlarmCallback.java
@@ -170,7 +170,7 @@ public class EmailAlarmCallback implements AlarmCallback {
                 "Sender",
                 "graylog@example.org",
                 "The sender of sent out mail alerts",
-                ConfigurationField.Optional.NOT_OPTIONAL));
+                ConfigurationField.Optional.OPTIONAL));
 
         configurationRequest.addField(new TextField("subject",
                 "E-Mail Subject",


### PR DESCRIPTION
The `sender` field in an email alert callback configuration should be optional. Graylog is using the email address configured in `` as fallback, is the `sender` field wasn't provided.

Fixes #1512