### PR TITLE
Add configuration settings for timeout and concurrency of OptimizeIndexJob

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/configuration/ElasticsearchConfiguration.java
+++ b/graylog2-server/src/main/java/org/graylog2/configuration/ElasticsearchConfiguration.java
@@ -21,7 +21,6 @@ import com.github.joschi.jadconfig.ValidationException;
 import com.github.joschi.jadconfig.ValidatorMethod;
 import com.github.joschi.jadconfig.converters.StringListConverter;
 import com.github.joschi.jadconfig.util.Duration;
-import com.github.joschi.jadconfig.validators.DirectoryWritableValidator;
 import com.github.joschi.jadconfig.validators.FilePathReadableValidator;
 import com.github.joschi.jadconfig.validators.InetPortValidator;
 import com.github.joschi.jadconfig.validators.PositiveDurationValidator;
@@ -143,6 +142,12 @@ public class ElasticsearchConfiguration {
 
     @Parameter(value = "elasticsearch_request_timeout", validator = PositiveDurationValidator.class)
     private Duration requestTimeout = Duration.minutes(1L);
+
+    @Parameter(value = "elasticsearch_index_optimization_timeout", validator = PositiveDurationValidator.class)
+    private Duration indexOptimizationTimeout = Duration.hours(1L);
+
+    @Parameter(value = "elasticsearch_index_optimization_jobs", validator = PositiveIntegerValidator.class)
+    private int indexOptimizationJobs = 20;
 
     public String getClusterName() {
         return clusterName;
@@ -287,6 +292,14 @@ public class ElasticsearchConfiguration {
 
     public Duration getRequestTimeout() {
         return requestTimeout;
+    }
+
+    public Duration getIndexOptimizationTimeout() {
+        return indexOptimizationTimeout;
+    }
+
+    public int getIndexOptimizationJobs() {
+        return indexOptimizationJobs;
     }
 
     @ValidatorMethod

--- a/misc/graylog.conf
+++ b/misc/graylog.conf
@@ -325,6 +325,15 @@ elasticsearch_analyzer = standard
 # Default: 1m
 #elasticsearch_request_timeout = 1m
 
+# Global timeout for index optimization (force merge) requests.
+# Default: 1h
+#elasticsearch_index_optimization_timeout = 1h
+
+# Maximum number of concurrently running index optimization (force merge) jobs.
+# If you are using lots of different index sets, you might want to increase that number.
+# Default: 20
+#elasticsearch_index_optimization_jobs = 20
+
 # Time interval for index range information cleanups. This setting defines how often stale index range information
 # is being purged from the database.
 # Default: 1h


### PR DESCRIPTION
This PR adds the 2 configuration settings `elasticsearch_index_optimization_timeout` and `elasticsearch_index_optimization_jobs` for specifying the timeout and concurrency of `OptimizeIndexJob`.

Closes #3066 