### PR TITLE
Don't check private key/certificate if REST API and web interface on same port

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/plugin/BaseConfiguration.java
+++ b/graylog2-server/src/main/java/org/graylog2/plugin/BaseConfiguration.java
@@ -462,7 +462,7 @@ public abstract class BaseConfiguration {
     @ValidatorMethod
     @SuppressWarnings("unused")
     public void validateWebTlsConfig() throws ValidationException {
-        if(isWebEnableTls()) {
+        if(isWebEnableTls() && !isRestAndWebOnSamePort()) {
             if(!isRegularFileAndReadable(getWebTlsKeyFile())) {
                 throw new ValidationException("Unreadable or missing web interface private key: " + getWebTlsKeyFile());
             }

--- a/graylog2-server/src/test/java/org/graylog2/plugin/BaseConfigurationTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/plugin/BaseConfigurationTest.java
@@ -45,7 +45,7 @@ public class BaseConfigurationTest {
 
     private class Configuration extends BaseConfiguration {
         @Parameter(value = "rest_listen_uri", required = true)
-        private URI restListenUri = URI.create("http://127.0.0.1:9000/api/");
+        private URI restListenUri = URI.create("http://127.0.0.1:12900/");
 
         @Parameter(value = "web_listen_uri", required = true)
         private URI webListenUri = URI.create("http://127.0.0.1:9000/");
@@ -441,5 +441,26 @@ public class BaseConfigurationTest {
         new JadConfig(new InMemoryRepository(validProperties), configuration).process();
 
         assertThat(configuration.getRestTransportUri()).hasScheme("https");
+    }
+
+    @Test
+    public void testRestListenUriAndWebListenUriWithSameScheme() throws Exception {
+        final File privateKey = temporaryFolder.newFile("graylog.key");
+        final File certificate = temporaryFolder.newFile("graylog.crt");
+
+        validProperties.put("rest_listen_uri", "https://127.0.0.1:8000/api");
+        validProperties.put("rest_transport_uri", "https://127.0.0.1:8000/api");
+        validProperties.put("rest_enable_tls", "true");
+        validProperties.put("rest_tls_key_file", privateKey.getAbsolutePath());
+        validProperties.put("rest_tls_cert_file", certificate.getAbsolutePath());
+        validProperties.put("web_listen_uri", "https://127.0.0.1:8000/");
+        validProperties.put("web_enable_tls", "true");
+
+        org.graylog2.Configuration configuration = new org.graylog2.Configuration();
+        new JadConfig(new InMemoryRepository(validProperties), configuration).process();
+
+        assertThat(configuration.getRestListenUri()).hasScheme("https");
+        assertThat(configuration.getRestTransportUri()).hasScheme("https");
+        assertThat(configuration.getWebListenUri()).hasScheme("https");
     }
 }


### PR DESCRIPTION
While this PR doesn't resolve all problems of the referenced issue, it will enable users to run the Graylog REST API and the web interface on the same port with HTTPS if `rest_enable_tls` *and* `web_enable_tls` are set to `true`.

All other corner cases should be addressed by revamping the whole HTTP listener configuration in the next Graylog major release.

Closes #2810