### PR TITLE
Add support for OPTIONS request to HttpTransport

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/inputs/transports/HttpTransport.java
+++ b/graylog2-server/src/main/java/org/graylog2/inputs/transports/HttpTransport.java
@@ -236,7 +236,7 @@ public class HttpTransport extends AbstractTcpTransport {
                 if (origin != null && !origin.isEmpty()) {
                     response.headers().set(Names.ACCESS_CONTROL_ALLOW_ORIGIN, origin);
                     response.headers().set(Names.ACCESS_CONTROL_ALLOW_CREDENTIALS, true);
-                    response.headers().set(Names.ACCESS_CONTROL_ALLOW_HEADERS, "Authorization");
+                    response.headers().set(Names.ACCESS_CONTROL_ALLOW_HEADERS, "Authorization, Content-Type");
                 }
             }
 

--- a/graylog2-server/src/main/java/org/graylog2/inputs/transports/HttpTransport.java
+++ b/graylog2-server/src/main/java/org/graylog2/inputs/transports/HttpTransport.java
@@ -70,6 +70,7 @@ import static org.jboss.netty.handler.codec.http.HttpHeaders.isKeepAlive;
 import static org.jboss.netty.handler.codec.http.HttpResponseStatus.ACCEPTED;
 import static org.jboss.netty.handler.codec.http.HttpResponseStatus.METHOD_NOT_ALLOWED;
 import static org.jboss.netty.handler.codec.http.HttpResponseStatus.NOT_FOUND;
+import static org.jboss.netty.handler.codec.http.HttpResponseStatus.OK;
 
 public class HttpTransport extends AbstractTcpTransport {
     static final int DEFAULT_MAX_INITIAL_LINE_LENGTH = 4096;
@@ -200,7 +201,10 @@ public class HttpTransport extends AbstractTcpTransport {
             final String origin = request.headers().get(Names.ORIGIN);
 
             // to allow for future changes, let's be at least a little strict in what we accept here.
-            if (!HttpMethod.POST.equals(request.getMethod())) {
+            if (HttpMethod.OPTIONS.equals(request.getMethod())) {
+                writeResponse(channel, keepAlive, httpRequestVersion, OK, origin);
+                return;
+            } else if (!HttpMethod.POST.equals(request.getMethod())) {
                 writeResponse(channel, keepAlive, httpRequestVersion, METHOD_NOT_ALLOWED, origin);
                 return;
             }

--- a/graylog2-server/src/test/java/org/graylog2/inputs/transports/GELFHttpHandlerTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/inputs/transports/GELFHttpHandlerTest.java
@@ -190,7 +190,7 @@ public class GELFHttpHandlerTest {
         HttpResponse response = argument.getValue();
         assertEquals(response.headers().get(HttpHeaders.Names.ACCESS_CONTROL_ALLOW_ORIGIN), origin);
         assertEquals(response.headers().get(HttpHeaders.Names.ACCESS_CONTROL_ALLOW_CREDENTIALS), "true");
-        assertEquals(response.headers().get(HttpHeaders.Names.ACCESS_CONTROL_ALLOW_HEADERS), "Authorization");
+        assertEquals(response.headers().get(HttpHeaders.Names.ACCESS_CONTROL_ALLOW_HEADERS), "Authorization, Content-Type");
     }
 
     @Test
@@ -208,7 +208,7 @@ public class GELFHttpHandlerTest {
         HttpResponse response = argument.getValue();
         assertEquals(response.headers().get(HttpHeaders.Names.ACCESS_CONTROL_ALLOW_ORIGIN), origin);
         assertEquals(response.headers().get(HttpHeaders.Names.ACCESS_CONTROL_ALLOW_CREDENTIALS), "true");
-        assertEquals(response.headers().get(HttpHeaders.Names.ACCESS_CONTROL_ALLOW_HEADERS), "Authorization");
+        assertEquals(response.headers().get(HttpHeaders.Names.ACCESS_CONTROL_ALLOW_HEADERS), "Authorization, Content-Type");
     }
 
     @Test

--- a/graylog2-server/src/test/java/org/graylog2/inputs/transports/HttpTransportHandlerTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/inputs/transports/HttpTransportHandlerTest.java
@@ -1,0 +1,123 @@
+/**
+ * This file is part of Graylog.
+ *
+ * Graylog is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.graylog2.inputs.transports;
+
+import org.jboss.netty.buffer.ChannelBuffers;
+import org.jboss.netty.channel.SimpleChannelHandler;
+import org.jboss.netty.handler.codec.embedder.DecoderEmbedder;
+import org.jboss.netty.handler.codec.http.DefaultHttpRequest;
+import org.jboss.netty.handler.codec.http.HttpHeaders;
+import org.jboss.netty.handler.codec.http.HttpMethod;
+import org.jboss.netty.handler.codec.http.HttpRequest;
+import org.jboss.netty.handler.codec.http.HttpResponse;
+import org.jboss.netty.handler.codec.http.HttpResponseStatus;
+import org.jboss.netty.handler.codec.http.HttpVersion;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.nio.charset.StandardCharsets;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class HttpTransportHandlerTest {
+    private DecoderEmbedder<HttpResponse> channel;
+
+    @Before
+    public void setUp() throws Exception {
+        final SimpleChannelHandler channelHandler = new HttpTransport.Handler(true);
+        channel = new DecoderEmbedder<>(channelHandler);
+    }
+
+    @Test
+    public void messageReceivedSuccessfullyProcessesPOSTRequest() throws Exception {
+        final HttpRequest httpRequest = new DefaultHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.POST, "/gelf");
+        httpRequest.headers().add("Host", "localhost");
+        httpRequest.headers().add("Origin", "http://example.com");
+        httpRequest.headers().add("Connection", "close");
+
+        final String gelfMessage = "{\"version\":\"1.1\",\"short_message\":\"Foo\",\"host\":\"localhost\"}";
+        httpRequest.setContent(ChannelBuffers.copiedBuffer(gelfMessage.toCharArray(), StandardCharsets.UTF_8));
+
+        channel.offer(httpRequest);
+        channel.finish();
+
+        final HttpResponse httpResponse = channel.poll();
+        assertThat(httpResponse.getStatus()).isEqualTo(HttpResponseStatus.ACCEPTED);
+        final HttpHeaders headers = httpResponse.headers();
+        assertThat(headers.get(HttpHeaders.Names.CONTENT_LENGTH)).isEqualTo("0");
+        assertThat(headers.get(HttpHeaders.Names.ACCESS_CONTROL_ALLOW_ORIGIN)).isEqualTo("http://example.com");
+        assertThat(headers.get(HttpHeaders.Names.ACCESS_CONTROL_ALLOW_CREDENTIALS)).isEqualTo("true");
+        assertThat(headers.get(HttpHeaders.Names.ACCESS_CONTROL_ALLOW_HEADERS)).isEqualTo("Authorization");
+    }
+
+    @Test
+    public void messageReceivedSuccessfullyProcessesOPTIONSRequest() throws Exception {
+        final HttpRequest httpRequest = new DefaultHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.OPTIONS, "/gelf");
+        httpRequest.headers().add("Host", "localhost");
+        httpRequest.headers().add("Origin", "http://example.com");
+        httpRequest.headers().add("Connection", "close");
+
+        channel.offer(httpRequest);
+        channel.finish();
+
+        final HttpResponse httpResponse = channel.poll();
+        assertThat(httpResponse.getStatus()).isEqualTo(HttpResponseStatus.OK);
+        final HttpHeaders headers = httpResponse.headers();
+        assertThat(headers.get(HttpHeaders.Names.CONTENT_LENGTH)).isEqualTo("0");
+        assertThat(headers.get(HttpHeaders.Names.ACCESS_CONTROL_ALLOW_ORIGIN)).isEqualTo("http://example.com");
+        assertThat(headers.get(HttpHeaders.Names.ACCESS_CONTROL_ALLOW_CREDENTIALS)).isEqualTo("true");
+        assertThat(headers.get(HttpHeaders.Names.ACCESS_CONTROL_ALLOW_HEADERS)).isEqualTo("Authorization");
+    }
+
+    @Test
+    public void messageReceivedReturns404ForWrongPath() throws Exception {
+        final HttpRequest httpRequest = new DefaultHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.POST, "/");
+        httpRequest.headers().add("Host", "localhost");
+        httpRequest.headers().add("Origin", "http://example.com");
+        httpRequest.headers().add("Connection", "close");
+
+        channel.offer(httpRequest);
+        channel.finish();
+
+        final HttpResponse httpResponse = channel.poll();
+        assertThat(httpResponse.getStatus()).isEqualTo(HttpResponseStatus.NOT_FOUND);
+        final HttpHeaders headers = httpResponse.headers();
+        assertThat(headers.get(HttpHeaders.Names.CONTENT_LENGTH)).isEqualTo("0");
+        assertThat(headers.get(HttpHeaders.Names.ACCESS_CONTROL_ALLOW_ORIGIN)).isEqualTo("http://example.com");
+        assertThat(headers.get(HttpHeaders.Names.ACCESS_CONTROL_ALLOW_CREDENTIALS)).isEqualTo("true");
+        assertThat(headers.get(HttpHeaders.Names.ACCESS_CONTROL_ALLOW_HEADERS)).isEqualTo("Authorization");
+    }
+
+    @Test
+    public void messageReceivedReturns405ForInvalidMethod() throws Exception {
+        final HttpRequest httpRequest = new DefaultHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.GET, "/");
+        httpRequest.headers().add("Host", "localhost");
+        httpRequest.headers().add("Origin", "http://example.com");
+        httpRequest.headers().add("Connection", "close");
+
+        channel.offer(httpRequest);
+        channel.finish();
+
+        final HttpResponse httpResponse = channel.poll();
+        assertThat(httpResponse.getStatus()).isEqualTo(HttpResponseStatus.METHOD_NOT_ALLOWED);
+        final HttpHeaders headers = httpResponse.headers();
+        assertThat(headers.get(HttpHeaders.Names.CONTENT_LENGTH)).isEqualTo("0");
+        assertThat(headers.get(HttpHeaders.Names.ACCESS_CONTROL_ALLOW_ORIGIN)).isEqualTo("http://example.com");
+        assertThat(headers.get(HttpHeaders.Names.ACCESS_CONTROL_ALLOW_CREDENTIALS)).isEqualTo("true");
+        assertThat(headers.get(HttpHeaders.Names.ACCESS_CONTROL_ALLOW_HEADERS)).isEqualTo("Authorization");
+    }
+}

--- a/graylog2-server/src/test/java/org/graylog2/inputs/transports/HttpTransportHandlerTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/inputs/transports/HttpTransportHandlerTest.java
@@ -61,7 +61,7 @@ public class HttpTransportHandlerTest {
         assertThat(headers.get(HttpHeaders.Names.CONTENT_LENGTH)).isEqualTo("0");
         assertThat(headers.get(HttpHeaders.Names.ACCESS_CONTROL_ALLOW_ORIGIN)).isEqualTo("http://example.com");
         assertThat(headers.get(HttpHeaders.Names.ACCESS_CONTROL_ALLOW_CREDENTIALS)).isEqualTo("true");
-        assertThat(headers.get(HttpHeaders.Names.ACCESS_CONTROL_ALLOW_HEADERS)).isEqualTo("Authorization");
+        assertThat(headers.get(HttpHeaders.Names.ACCESS_CONTROL_ALLOW_HEADERS)).isEqualTo("Authorization, Content-Type");
     }
 
     @Test
@@ -80,7 +80,7 @@ public class HttpTransportHandlerTest {
         assertThat(headers.get(HttpHeaders.Names.CONTENT_LENGTH)).isEqualTo("0");
         assertThat(headers.get(HttpHeaders.Names.ACCESS_CONTROL_ALLOW_ORIGIN)).isEqualTo("http://example.com");
         assertThat(headers.get(HttpHeaders.Names.ACCESS_CONTROL_ALLOW_CREDENTIALS)).isEqualTo("true");
-        assertThat(headers.get(HttpHeaders.Names.ACCESS_CONTROL_ALLOW_HEADERS)).isEqualTo("Authorization");
+        assertThat(headers.get(HttpHeaders.Names.ACCESS_CONTROL_ALLOW_HEADERS)).isEqualTo("Authorization, Content-Type");
     }
 
     @Test
@@ -99,7 +99,7 @@ public class HttpTransportHandlerTest {
         assertThat(headers.get(HttpHeaders.Names.CONTENT_LENGTH)).isEqualTo("0");
         assertThat(headers.get(HttpHeaders.Names.ACCESS_CONTROL_ALLOW_ORIGIN)).isEqualTo("http://example.com");
         assertThat(headers.get(HttpHeaders.Names.ACCESS_CONTROL_ALLOW_CREDENTIALS)).isEqualTo("true");
-        assertThat(headers.get(HttpHeaders.Names.ACCESS_CONTROL_ALLOW_HEADERS)).isEqualTo("Authorization");
+        assertThat(headers.get(HttpHeaders.Names.ACCESS_CONTROL_ALLOW_HEADERS)).isEqualTo("Authorization, Content-Type");
     }
 
     @Test
@@ -118,6 +118,6 @@ public class HttpTransportHandlerTest {
         assertThat(headers.get(HttpHeaders.Names.CONTENT_LENGTH)).isEqualTo("0");
         assertThat(headers.get(HttpHeaders.Names.ACCESS_CONTROL_ALLOW_ORIGIN)).isEqualTo("http://example.com");
         assertThat(headers.get(HttpHeaders.Names.ACCESS_CONTROL_ALLOW_CREDENTIALS)).isEqualTo("true");
-        assertThat(headers.get(HttpHeaders.Names.ACCESS_CONTROL_ALLOW_HEADERS)).isEqualTo("Authorization");
+        assertThat(headers.get(HttpHeaders.Names.ACCESS_CONTROL_ALLOW_HEADERS)).isEqualTo("Authorization, Content-Type");
     }
 }


### PR DESCRIPTION
## Description

The `HttpTransport` handler (used by the GELF HTTP input) currently doesn't support HTTP `OPTIONS` requests which are required for proper [CORS](https://developer.mozilla.org/en-US/docs/Web/HTTP/Access_control_CORS) handling (preflight requests).

This PR adds support for the `OPTIONS` HTTP request method.

Fixes #3232

## Motivation and Context

If web applications want to log messages to Graylog, the user's web browser will send preflight requests to the GELF HTTP input. If these preflight requests fail, the web browser will refuse to send anything to that URI.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
