### PR TITLE
Change way of exporting CSV search results

### DIFF
--- a/graylog2-web-interface/package.json
+++ b/graylog2-web-interface/package.json
@@ -47,6 +47,7 @@
     "superagent-bluebird-promise": "^4.1.0",
     "toastr": "^2.1.2",
     "typeahead.js": "^0.11.1",
+    "ua-parser-js": "^0.7.12",
     "urijs": "^1.17.0"
   },
   "devDependencies": {

--- a/graylog2-web-interface/src/components/search/SearchSidebar.jsx
+++ b/graylog2-web-interface/src/components/search/SearchSidebar.jsx
@@ -111,9 +111,13 @@ const SearchSidebar = React.createClass({
 
     const url = new URI(URLUtils.qualifyUrl(
       ApiRoutes.UniversalSearchApiController.export(rangeType, query, timeRange, streamId, 0, 0, fields.toJS()).url
-    ))
-      .username(SessionStore.getSessionId())
-      .password('session');
+    ));
+
+    if (URLUtils.areCredentialsInURLSupported()) {
+      url
+        .username(SessionStore.getSessionId())
+        .password('session');
+    }
 
     return url.toString();
   },
@@ -124,6 +128,32 @@ const SearchSidebar = React.createClass({
 
   _openModal(ref) {
     return () => this.refs[ref].open();
+  },
+
+  _getExportModal() {
+    const infoText = (URLUtils.areCredentialsInURLSupported() ?
+      'Please right click the download link below and choose "Save Link As..." to download the CSV file.' :
+      'Please click the download link below. Your browser may ask for your username and password to ' +
+      'download the CSV file.');
+    return (
+      <BootstrapModalWrapper ref="exportModal">
+        <Modal.Header closeButton>
+          <Modal.Title>Export search results as CSV</Modal.Title>
+        </Modal.Header>
+        <Modal.Body>
+          <p>{infoText}</p>
+          <p>
+            <a href={this._getURLForExportAsCSV()} target="_blank">
+              <i className="fa fa-cloud-download"/>&nbsp;
+              Download
+            </a>
+          </p>
+        </Modal.Body>
+        <Modal.Footer>
+          <Button onClick={this._closeModal('exportModal')}>Close</Button>
+        </Modal.Footer>
+      </BootstrapModalWrapper>
+    );
   },
 
   render() {
@@ -154,7 +184,7 @@ const SearchSidebar = React.createClass({
 
     let searchTitle = null;
     const moreActions = [
-      <MenuItem key="export" href={this._getURLForExportAsCSV()}>Export as CSV</MenuItem>,
+      <MenuItem key="export" onSelect={this._openModal('exportModal')}>Export as CSV</MenuItem>,
     ];
     if (this.props.searchInStream) {
       searchTitle = <span>{this.props.searchInStream.title}</span>;
@@ -198,6 +228,8 @@ const SearchSidebar = React.createClass({
                 <ShowQueryModal key="debugQuery" ref="showQueryModal" builtQuery={this.props.builtQuery}/>
               </div>
             </div>
+
+            {this._getExportModal()}
 
             <hr />
           </div>

--- a/graylog2-web-interface/src/components/search/SearchSidebar.jsx
+++ b/graylog2-web-interface/src/components/search/SearchSidebar.jsx
@@ -87,10 +87,6 @@ const SearchSidebar = React.createClass({
     this.setState({ availableHeight: maxHeight });
   },
 
-  _showIndicesModal(event) {
-    event.preventDefault();
-    this.refs.indicesModal.open();
-  },
   _getURLForExportAsCSV() {
     const searchParams = SearchStore.getOriginalSearchURLParams();
     const streamId = this.props.searchInStream ? this.props.searchInStream.id : undefined;
@@ -121,11 +117,13 @@ const SearchSidebar = React.createClass({
 
     return url.toString();
   },
-  _indicesModalClose() {
-    this.refs.indicesModal.close();
+
+  _closeModal(ref) {
+    return () => this.refs[ref].close();
   },
-  _showQueryModalOpen() {
-    this.refs.showQueryModal.open();
+
+  _openModal(ref) {
+    return () => this.refs[ref].open();
   },
 
   render() {
@@ -149,7 +147,7 @@ const SearchSidebar = React.createClass({
           </ul>
         </Modal.Body>
         <Modal.Footer>
-          <Button onClick={this._indicesModalClose}>Close</Button>
+          <Button onClick={this._closeModal('indicesModal')}>Close</Button>
         </Modal.Footer>
       </BootstrapModalWrapper>
     );
@@ -167,7 +165,7 @@ const SearchSidebar = React.createClass({
 
     // always add the debug query link as last elem
     moreActions.push(<MenuItem divider key="div2"/>);
-    moreActions.push(<MenuItem key="showQuery" onSelect={this._showQueryModalOpen}>Show query</MenuItem>);
+    moreActions.push(<MenuItem key="showQuery" onSelect={this._openModal('showQueryModal')}>Show query</MenuItem>);
 
     return (
       <AutoAffix affixClassName="affix">
@@ -180,7 +178,7 @@ const SearchSidebar = React.createClass({
             <p style={{ marginTop: 3 }}>
               Found <strong>{numeral(this.props.result.total_results).format('0,0')} messages</strong>{' '}
               in {numeral(this.props.result.time).format('0,0')} ms, searched in&nbsp;
-              <a href="#" onClick={this._showIndicesModal}>
+              <a href="#" onClick={this._openModal('indicesModal')}>
                 {this.props.result.used_indices.length}&nbsp;{this.props.result.used_indices.length === 1 ? 'index' : 'indices'}
               </a>.
               {indicesModal}

--- a/graylog2-web-interface/src/util/URLUtils.js
+++ b/graylog2-web-interface/src/util/URLUtils.js
@@ -1,8 +1,10 @@
 import Qs from 'qs';
 import URI from 'urijs';
 import AppConfig from 'util/AppConfig';
+import UAParser from 'ua-parser-js';
 
 const URLUtils = {
+  parser: new UAParser(),
   qualifyUrl(url) {
     return new URI(AppConfig.gl2ServerUrl() + url).normalizePathname().toString();
   },
@@ -45,6 +47,10 @@ const URLUtils = {
 
     const joinedPath = `/${args.join('/')}`;
     return joinedPath.replace(/[\/]+/g, '/');
+  },
+  areCredentialsInURLSupported() {
+    const browser = this.parser.getBrowser();
+    return browser.name !== 'IE' && browser.name !== 'Edge';
   },
 };
 


### PR DESCRIPTION
To export CSV search results, we use a URL including the user's session ID to do a HTTP basic authentication against the REST API. This has a couple of problems:

- IE/Edge do not support URLs containing the username and password parts due to security concerns (https://support.microsoft.com/en-us/kb/834489)
- Other browsers display scary warning messages when clicking on the Export CSV link, as they also consider the user may be in danger

To avoid those problems, this PR changes the procedure slightly and adds some more information in the process:
- IE/Edge users will see a modal dialogue asking them to click a download link, and informing them that their browser may ask them to provide their credentials for the download to proceed
- Other users will see a modal dialogue with a download link, and we ask them to download that file using right click -> Save link as. In this way browsers don't display any warnings, and the download procedure works as expected

Fixes #3090