### PR TITLE
Only reacalculate index set ranges in index set maintenance menu

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/indexer/indices/jobs/SetIndexReadOnlyAndCalculateRangeJob.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/indices/jobs/SetIndexReadOnlyAndCalculateRangeJob.java
@@ -49,7 +49,7 @@ public class SetIndexReadOnlyAndCalculateRangeJob extends SystemJob {
     public void execute() {
         final SystemJob setIndexReadOnlyJob = setIndexReadOnlyJobFactory.create(indexName);
         setIndexReadOnlyJob.execute();
-        final SystemJob createNewSingleIndexRangeJob = createNewSingleIndexRangeJobFactory.create(indexSetRegistry, indexName);
+        final SystemJob createNewSingleIndexRangeJob = createNewSingleIndexRangeJobFactory.create(indexSetRegistry.getAllIndexSets(), indexName);
         createNewSingleIndexRangeJob.execute();
 
     }

--- a/graylog2-server/src/main/java/org/graylog2/indexer/ranges/CreateNewSingleIndexRangeJob.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/ranges/CreateNewSingleIndexRangeJob.java
@@ -18,10 +18,12 @@ package org.graylog2.indexer.ranges;
 
 import com.google.inject.assistedinject.Assisted;
 import com.google.inject.assistedinject.AssistedInject;
-import org.graylog2.indexer.IndexSetRegistry;
+import org.graylog2.indexer.IndexSet;
 import org.graylog2.shared.system.activities.ActivityWriter;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import java.util.Set;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
@@ -30,15 +32,15 @@ public class CreateNewSingleIndexRangeJob extends RebuildIndexRangesJob {
     private final String indexName;
 
     public interface Factory {
-        CreateNewSingleIndexRangeJob create(IndexSetRegistry indexSetRegistry, String indexName);
+        CreateNewSingleIndexRangeJob create(Set<IndexSet> indexSets, String indexName);
     }
 
     @AssistedInject
-    public CreateNewSingleIndexRangeJob(@Assisted IndexSetRegistry indexSetRegistry,
+    public CreateNewSingleIndexRangeJob(@Assisted Set<IndexSet> indexSets,
                                         @Assisted String indexName,
                                         ActivityWriter activityWriter,
                                         IndexRangeService indexRangeService) {
-        super(indexSetRegistry, activityWriter, indexRangeService);
+        super(indexSets, activityWriter, indexRangeService);
         this.indexName = checkNotNull(indexName);
     }
 

--- a/graylog2-server/src/main/java/org/graylog2/migrations/V20161130141500_DefaultStreamRecalcIndexRanges.java
+++ b/graylog2-server/src/main/java/org/graylog2/migrations/V20161130141500_DefaultStreamRecalcIndexRanges.java
@@ -120,7 +120,7 @@ public class V20161130141500_DefaultStreamRecalcIndexRanges extends Migration {
                 continue;
             }
             LOG.info("Recalculating streams in index {}", indexName);
-            final CreateNewSingleIndexRangeJob createNewSingleIndexRangeJob = rebuildIndexRangeJobFactory.create(indexSetRegistry, indexName);
+            final CreateNewSingleIndexRangeJob createNewSingleIndexRangeJob = rebuildIndexRangeJobFactory.create(indexSetRegistry.getAllIndexSets(), indexName);
             createNewSingleIndexRangeJob.execute();
         }
 

--- a/graylog2-server/src/main/java/org/graylog2/rest/resources/system/IndexRangesResource.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/resources/system/IndexRangesResource.java
@@ -28,6 +28,7 @@ import org.apache.shiro.authz.annotation.RequiresPermissions;
 import org.graylog2.audit.AuditEventTypes;
 import org.graylog2.audit.jersey.AuditEvent;
 import org.graylog2.database.NotFoundException;
+import org.graylog2.indexer.IndexSet;
 import org.graylog2.indexer.IndexSetRegistry;
 import org.graylog2.indexer.ranges.CreateNewSingleIndexRangeJob;
 import org.graylog2.indexer.ranges.IndexRange;
@@ -40,6 +41,7 @@ import org.graylog2.shared.security.RestPermissions;
 import org.graylog2.system.jobs.SystemJob;
 import org.graylog2.system.jobs.SystemJobConcurrencyException;
 import org.graylog2.system.jobs.SystemJobManager;
+import org.hibernate.validator.constraints.NotBlank;
 import org.hibernate.validator.constraints.NotEmpty;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -54,7 +56,9 @@ import javax.ws.rs.PathParam;
 import javax.ws.rs.Produces;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
+import java.util.Collections;
 import java.util.List;
+import java.util.Set;
 import java.util.SortedSet;
 
 @RequiresAuthentication
@@ -143,14 +147,29 @@ public class IndexRangesResource extends RestResource {
     @Produces(MediaType.APPLICATION_JSON)
     @AuditEvent(type = AuditEventTypes.ES_INDEX_RANGE_UPDATE_JOB)
     public Response rebuild() {
-        final SystemJob rebuildJob = rebuildIndexRangesJobFactory.create(indexSetRegistry);
-        try {
-            this.systemJobManager.submit(rebuildJob);
-        } catch (SystemJobConcurrencyException e) {
-            final String errorMsg = "Concurrency level of this job reached: " + e.getMessage();
-            LOG.error(errorMsg, e);
-            throw new ForbiddenException(errorMsg);
-        }
+        submitIndexRangesJob(indexSetRegistry.getAllIndexSets());
+
+        return Response.accepted().build();
+    }
+
+    @POST
+    @Timed
+    @Path("/index_set/{indexSetId}/rebuild")
+    @RequiresPermissions(RestPermissions.INDEXRANGES_REBUILD)
+    @ApiOperation(value = "Rebuild/sync index range information for the given index set.",
+            notes = "This triggers a systemjob that scans every index in the given index set and stores meta information " +
+                    "about what indices contain messages in what timeranges. It atomically overwrites " +
+                    "already existing meta information.")
+    @ApiResponses(value = {
+            @ApiResponse(code = 202, message = "Rebuild/sync systemjob triggered.")
+    })
+    @Produces(MediaType.APPLICATION_JSON)
+    @AuditEvent(type = AuditEventTypes.ES_INDEX_RANGE_UPDATE_JOB)
+    public Response rebuildIndexSet(@ApiParam(name = "indexSetId") @PathParam("indexSetId") @NotBlank final String indexSetId) {
+        final IndexSet indexSet = indexSetRegistry.get(indexSetId)
+                .orElseThrow(() -> new javax.ws.rs.NotFoundException("Index set <" + indexSetId + "> not found!"));
+
+        submitIndexRangesJob(Collections.singleton(indexSet));
 
         return Response.accepted().build();
     }
@@ -175,7 +194,7 @@ public class IndexRangesResource extends RestResource {
         }
         checkPermission(RestPermissions.INDEXRANGES_REBUILD, index);
 
-        final SystemJob rebuildJob = singleIndexRangeJobFactory.create(indexSetRegistry, index);
+        final SystemJob rebuildJob = singleIndexRangeJobFactory.create(indexSetRegistry.getAllIndexSets(), index);
         try {
             this.systemJobManager.submit(rebuildJob);
         } catch (SystemJobConcurrencyException e) {
@@ -186,4 +205,16 @@ public class IndexRangesResource extends RestResource {
 
         return Response.accepted().build();
     }
+
+    private void submitIndexRangesJob(final Set<IndexSet> indexSets) {
+        final SystemJob rebuildJob = rebuildIndexRangesJobFactory.create(indexSets);
+        try {
+            this.systemJobManager.submit(rebuildJob);
+        } catch (SystemJobConcurrencyException e) {
+            final String errorMsg = "Concurrency level of this job reached: " + e.getMessage();
+            LOG.error(errorMsg, e);
+            throw new ForbiddenException(errorMsg);
+        }
+    }
+
 }

--- a/graylog2-web-interface/src/components/indices/IndicesMaintenanceDropdown.jsx
+++ b/graylog2-web-interface/src/components/indices/IndicesMaintenanceDropdown.jsx
@@ -15,7 +15,7 @@ const IndicesMaintenanceDropdown = React.createClass({
   },
 
   _onRecalculateIndexRange() {
-    if (window.confirm('This will recalculate index ranges for ALL index sets using a background system job. Do you want to proceed?')) {
+    if (window.confirm('This will recalculate index ranges for this index set using a background system job. Do you want to proceed?')) {
       IndexRangesActions.recalculate(this.props.indexSetId);
     }
   },
@@ -34,7 +34,7 @@ const IndicesMaintenanceDropdown = React.createClass({
     return (
       <ButtonGroup>
         <DropdownButton bsStyle="info" title="Maintenance" id="indices-maintenance-actions" pullRight>
-          <MenuItem eventKey="1" onClick={this._onRecalculateIndexRange}>Recalculate all index ranges</MenuItem>
+          <MenuItem eventKey="1" onClick={this._onRecalculateIndexRange}>Recalculate index ranges</MenuItem>
           {cycleButton}
         </DropdownButton>
       </ButtonGroup>

--- a/graylog2-web-interface/src/components/indices/IndicesMaintenanceDropdown.jsx
+++ b/graylog2-web-interface/src/components/indices/IndicesMaintenanceDropdown.jsx
@@ -16,8 +16,7 @@ const IndicesMaintenanceDropdown = React.createClass({
 
   _onRecalculateIndexRange() {
     if (window.confirm('This will recalculate index ranges for ALL index sets using a background system job. Do you want to proceed?')) {
-      // TODO 2.2: Only rebuild index set here? It currently rebuilds all index ranges!
-      IndexRangesActions.recalculate();
+      IndexRangesActions.recalculate(this.props.indexSetId);
     }
   },
   _onCycleDeflector() {

--- a/graylog2-web-interface/src/routing/ApiRoutes.js
+++ b/graylog2-web-interface/src/routing/ApiRoutes.js
@@ -79,7 +79,7 @@ const ApiRoutes = {
   },
   IndexRangesApiController: {
     list: () => { return { url: '/system/indices/ranges' }; },
-    rebuild: () => { return { url: '/system/indices/ranges/rebuild' }; },
+    rebuild: (indexSetId) => { return { url: `/system/indices/ranges/index_set/${indexSetId}/rebuild` }; },
     rebuildSingle: (index) => { return { url: `/system/indices/ranges/${index}/rebuild` }; },
   },
   IndexSetsApiController: {

--- a/graylog2-web-interface/src/stores/indices/IndexRangesStore.js
+++ b/graylog2-web-interface/src/stores/indices/IndexRangesStore.js
@@ -28,9 +28,9 @@ const IndexRangesStore = Reflux.createStore({
 
     IndexRangesActions.list.promise(promise);
   },
-  recalculate() {
-    const url = URLUtils.qualifyUrl(ApiRoutes.IndexRangesApiController.rebuild().url);
-    const promise = fetch ('POST', url);
+  recalculate(indexSetId) {
+    const url = URLUtils.qualifyUrl(ApiRoutes.IndexRangesApiController.rebuild(indexSetId).url);
+    const promise = fetch('POST', url);
     promise
       .then(UserNotification.success('Index ranges will be recalculated shortly'))
       .catch((error) => {


### PR DESCRIPTION
Instead of triggering a recalc job for all indices in all index sets, only trigger a index range recalc for the current index set.