### PR TITLE
Add X-Forwarded-For support to HTTP GELF combination

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/rest/RestTools.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/RestTools.java
@@ -64,7 +64,11 @@ public class RestTools {
     public static String getRemoteAddrFromRequest(Request request, Set<IpSubnet> trustedSubnets) {
         final String remoteAddr = request.getRemoteAddr();
         final String XForwardedFor = request.getHeader("X-Forwarded-For");
-        if (XForwardedFor != null) {
+        return getAddrFromXForwardedFor(XForwardedFor, remoteAddr, trustedSubnets);
+    }
+
+    public static String getAddrFromXForwardedFor(String XForwardedFor, String remoteAddr, Set<IpSubnet> trustedSubnets) {
+        if (XForwardedFor != null && !"null".equals(XForwardedFor)) {
             for (IpSubnet s : trustedSubnets) {
                 try {
                     if (s.contains(remoteAddr)) {
@@ -76,7 +80,6 @@ public class RestTools {
                 }
             }
         }
-
         // Request did not come from a trusted source, or the X-Forwarded-For header was not set
         return remoteAddr;
     }

--- a/graylog2-server/src/main/java/org/graylog2/shared/bindings/PluginBindings.java
+++ b/graylog2-server/src/main/java/org/graylog2/shared/bindings/PluginBindings.java
@@ -23,6 +23,7 @@ import com.google.inject.multibindings.Multibinder;
 import org.graylog2.plugin.Plugin;
 import org.graylog2.plugin.PluginMetaData;
 import org.graylog2.plugin.PluginModule;
+import org.graylog2.plugin.inputs.transports.NettyTransport;
 import org.graylog2.plugin.rest.PluginRestResource;
 
 import java.util.Set;
@@ -53,5 +54,7 @@ public class PluginBindings extends AbstractModule {
 
             pluginMetaDataBinder.addBinding().toInstance(plugin.metadata());
         }
+
+        requestStaticInjection(NettyTransport.class);
     }
 }

--- a/graylog2-server/src/test/java/org/graylog2/inputs/transports/GELFHttpHandlerTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/inputs/transports/GELFHttpHandlerTest.java
@@ -230,4 +230,17 @@ public class GELFHttpHandlerTest {
         assertNull(response.headers().get(HttpHeaders.Names.ACCESS_CONTROL_ALLOW_CREDENTIALS));
         assertNull(response.headers().get(HttpHeaders.Names.ACCESS_CONTROL_ALLOW_HEADERS));
     }
+
+    @Test
+    public void testAddingXForwardedFor() throws Exception {
+        final HttpTransport.Handler handler = new HttpTransport.Handler(false);
+
+        String XForwardedFor = "192.168.122.60";
+        when(this.headers.get("X-Forwarded-For")).thenReturn(XForwardedFor);
+
+        handler.messageReceived(ctx, evt);
+
+        verify(channel).write(any(HttpResponse.class));
+        verify(ctx, atMost(1)).sendUpstream(any(ChannelEvent.class));
+    }
 }


### PR DESCRIPTION
## Description

Adds X-Forwarded-For support to HTTP GELF.

## Motivation and Context

Fixes issue #2413.

Couple comments:

- X-Forwarded-For does not convey port as expected by original implementation
- The logic from RestTools should probably be re-used
- I picked *some* location for the ChannelLocal, and the injected trusted_proxies (not breaking the API). 
- There doesn't seem to be any tests for NettyTransport - is this true? There probably should be, quite a few...
- I know the implementation does handle invalid inputs properly, but how to test?

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Added test case for HttpTransport. Would have added for NettyTransport, but couldn't find good spot. Might need more tests.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
