### PR TITLE
Validate alarm callbacks before saving them

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/alarmcallbacks/EmailAlarmCallback.java
+++ b/graylog2-server/src/main/java/org/graylog2/alarmcallbacks/EmailAlarmCallback.java
@@ -232,7 +232,7 @@ public class EmailAlarmCallback implements AlarmCallback {
     public void checkConfiguration() throws ConfigurationException {
         final boolean missingSender = isNullOrEmpty(configuration.getString("sender")) && isNullOrEmpty(emailConfiguration.getFromEmail());
         if (missingSender || isNullOrEmpty(configuration.getString("subject"))) {
-            throw new ConfigurationException("Sender or subject are missing or invalid!");
+            throw new ConfigurationException("Sender or subject are missing or invalid.");
         }
     }
 }

--- a/graylog2-server/src/main/java/org/graylog2/alarmcallbacks/HTTPAlarmCallback.java
+++ b/graylog2-server/src/main/java/org/graylog2/alarmcallbacks/HTTPAlarmCallback.java
@@ -122,13 +122,13 @@ public class HTTPAlarmCallback implements AlarmCallback {
     public void checkConfiguration() throws ConfigurationException {
         final String url = configuration.getString(CK_URL);
         if (isNullOrEmpty(url)) {
-            throw new ConfigurationException("URL parameter is missing!");
+            throw new ConfigurationException("URL parameter is missing.");
         }
 
         try {
             new URL(url);
         } catch (MalformedURLException e) {
-            throw new ConfigurationException("Malformed URL", e);
+            throw new ConfigurationException("Malformed URL '" + url + "'", e);
         }
     }
 }

--- a/graylog2-server/src/test/java/org/graylog2/alarmcallbacks/EmailAlarmCallbackTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/alarmcallbacks/EmailAlarmCallbackTest.java
@@ -1,0 +1,107 @@
+package org.graylog2.alarmcallbacks;
+
+import com.google.common.collect.ImmutableMap;
+import org.graylog2.alerts.AlertSender;
+import org.graylog2.alerts.EmailRecipients;
+import org.graylog2.configuration.EmailConfiguration;
+import org.graylog2.notifications.NotificationService;
+import org.graylog2.plugin.alarms.callbacks.AlarmCallback;
+import org.graylog2.plugin.configuration.Configuration;
+import org.graylog2.plugin.configuration.ConfigurationException;
+import org.graylog2.plugin.system.NodeId;
+import org.graylog2.shared.users.UserService;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+import java.util.Collections;
+import java.util.Map;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class EmailAlarmCallbackTest {
+    @Rule
+    public ExpectedException expectedException = ExpectedException.none();
+
+    private AlertSender alertSender = mock(AlertSender.class);
+    private NotificationService notificationService = mock(NotificationService.class);
+    private NodeId nodeId = mock(NodeId.class);
+    private EmailRecipients.Factory emailRecipientsFactory = mock(EmailRecipients.Factory.class);
+    private UserService userService = mock(UserService.class);
+    private EmailConfiguration emailConfiguration = mock(EmailConfiguration.class);
+
+    private AlarmCallback alarmCallback;
+
+    @Before
+    public void setUp() throws Exception {
+        alarmCallback = new EmailAlarmCallback(alertSender, notificationService, nodeId, emailRecipientsFactory,
+                userService, emailConfiguration);
+    }
+
+    @Test
+    public void checkConfigurationSucceedsWithValidConfiguration() throws Exception {
+        final Map<String, Object> configMap = ImmutableMap.of(
+                "sender", "graylog@example.org",
+                "subject", "Graylog alert",
+                "body", "foobar",
+                "user_receivers", Collections.emptyList(),
+                "email_receivers", Collections.emptyList()
+        );
+        final Configuration configuration = new Configuration(configMap);
+        alarmCallback.initialize(configuration);
+        alarmCallback.checkConfiguration();
+    }
+
+    @Test
+    public void checkConfigurationSucceedsWithFallbackSender() throws Exception {
+        final Map<String, Object> configMap = ImmutableMap.of(
+                "subject", "Graylog alert",
+                "body", "foobar",
+                "user_receivers", Collections.emptyList(),
+                "email_receivers", Collections.emptyList()
+        );
+        final Configuration configuration = new Configuration(configMap);
+        when(emailConfiguration.getFromEmail()).thenReturn("default@sender.org");
+
+        alarmCallback.initialize(configuration);
+        alarmCallback.checkConfiguration();
+    }
+
+    @Test
+    public void checkConfigurationFailsWithoutSender() throws Exception {
+        final Map<String, Object> configMap = ImmutableMap.of(
+                "subject", "Graylog alert",
+                "body", "foobar",
+                "user_receivers", Collections.emptyList(),
+                "email_receivers", Collections.emptyList()
+        );
+        final Configuration configuration = new Configuration(configMap);
+        alarmCallback.initialize(configuration);
+
+        when(emailConfiguration.getFromEmail()).thenReturn("");
+
+        expectedException.expect(ConfigurationException.class);
+        expectedException.expectMessage("Sender or subject are missing or invalid.");
+
+        alarmCallback.checkConfiguration();
+    }
+
+    @Test
+    public void checkConfigurationFailsWithoutSubject() throws Exception {
+        final Map<String, Object> configMap = ImmutableMap.of(
+                "sender", "graylog@example.org",
+                "body", "foobar",
+                "user_receivers", Collections.emptyList(),
+                "email_receivers", Collections.emptyList()
+        );
+        final Configuration configuration = new Configuration(configMap);
+        alarmCallback.initialize(configuration);
+
+        expectedException.expect(ConfigurationException.class);
+        expectedException.expectMessage("Sender or subject are missing or invalid.");
+
+        alarmCallback.checkConfiguration();
+    }
+}

--- a/graylog2-server/src/test/java/org/graylog2/alarmcallbacks/EmailAlarmCallbackTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/alarmcallbacks/EmailAlarmCallbackTest.java
@@ -1,3 +1,19 @@
+/**
+ * This file is part of Graylog.
+ *
+ * Graylog is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package org.graylog2.alarmcallbacks;
 
 import com.google.common.collect.ImmutableMap;

--- a/graylog2-server/src/test/java/org/graylog2/alarmcallbacks/HTTPAlarmCallbackTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/alarmcallbacks/HTTPAlarmCallbackTest.java
@@ -252,7 +252,7 @@ public class HTTPAlarmCallbackTest {
         alarmCallback.initialize(configuration);
 
         expectedException.expect(ConfigurationException.class);
-        expectedException.expectMessage("URL parameter is missing!");
+        expectedException.expectMessage("URL parameter is missing.");
 
         alarmCallback.checkConfiguration();
     }
@@ -264,7 +264,7 @@ public class HTTPAlarmCallbackTest {
         alarmCallback.initialize(configuration);
 
         expectedException.expect(ConfigurationException.class);
-        expectedException.expectMessage("URL parameter is missing!");
+        expectedException.expectMessage("URL parameter is missing.");
 
         alarmCallback.checkConfiguration();
     }

--- a/graylog2-web-interface/src/components/alertnotifications/CreateAlertNotificationInput.jsx
+++ b/graylog2-web-interface/src/components/alertnotifications/CreateAlertNotificationInput.jsx
@@ -46,9 +46,12 @@ const CreateAlertNotificationInput = React.createClass({
       UserNotification.error('Please select the stream that the condition should check.', 'Could not save condition');
     }
 
-    AlarmCallbacksActions.save(this.state.selectedStream.id, data).then(() => {
-      history.pushState(null, Routes.ALERTS.NOTIFICATIONS);
-    });
+    AlarmCallbacksActions.save(this.state.selectedStream.id, data).then(
+      () => {
+        history.pushState(null, Routes.ALERTS.NOTIFICATIONS);
+      },
+      () => this.refs.configurationForm.open(),
+    );
   },
   _openForm() {
     this.refs.configurationForm.open();

--- a/graylog2-web-interface/src/components/alertnotifications/CreateAlertNotificationInput.jsx
+++ b/graylog2-web-interface/src/components/alertnotifications/CreateAlertNotificationInput.jsx
@@ -117,7 +117,7 @@ const CreateAlertNotificationInput = React.createClass({
               {notificationForm}
               {' '}
               <Button onClick={this._openForm} disabled={this.state.type === this.PLACEHOLDER} bsStyle="success">
-                Add alert notificaiton
+                Add alert notification
               </Button>
             </form>
           </Col>

--- a/graylog2-web-interface/src/stores/alarmcallbacks/AlarmCallbacksStore.js
+++ b/graylog2-web-interface/src/stores/alarmcallbacks/AlarmCallbacksStore.js
@@ -22,9 +22,11 @@ const AlarmCallbacksStore = Reflux.createStore({
     AlarmCallbacksActions.list.promise(promise);
   },
   save(streamId, alarmCallback) {
-    const failCallback = (error) =>
-      UserNotification.error(`Saving alert notification failed with status: ${error.message}`,
+    const failCallback = (error) => {
+      const errorMessage = (error.additional && error.additional.status === 400 ? error.additional.body.message : error.message);
+      UserNotification.error(`Saving alert notification failed with status: ${errorMessage}`,
         'Could not save alert notification');
+    };
 
     const url = URLUtils.qualifyUrl(ApiRoutes.AlarmCallbacksApiController.create(streamId).url);
 
@@ -52,9 +54,11 @@ const AlarmCallbacksStore = Reflux.createStore({
     AlarmCallbacksActions.delete.promise(promise);
   },
   update(streamId, alarmCallbackId, deltas) {
-    const failCallback = (error) =>
-      UserNotification.error(`Updating alert notification '${alarmCallbackId}' failed with status: ${error.message}`,
+    const failCallback = (error) => {
+      const errorMessage = (error.additional && error.additional.status === 400 ? error.additional.body.message : error.message);
+      UserNotification.error(`Updating alert notification '${alarmCallbackId}' failed with status: ${errorMessage}`,
         'Could not update alert notification');
+    };
 
     const url = URLUtils.qualifyUrl(ApiRoutes.AlarmCallbacksApiController.update(streamId, alarmCallbackId).url);
 


### PR DESCRIPTION
As described in #987 and #3236, we didn't validate alarm callbacks when created, so most errors were only displayed when the alarm callback was triggered.

This PR checks alarm callbacks when created or updated, ensuring the new alarm callbacks stored in MongoDB are valid.

To make this nicer for the user, we are also returning a more informative message in the API, and displaying that message in the web interface.

Fixes #987 and #3236