### PR TITLE
Micro batch loading grace periods - WIP -> Feedback requested

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/alerts/AlertService.java
+++ b/graylog2-server/src/main/java/org/graylog2/alerts/AlertService.java
@@ -25,6 +25,7 @@ import org.graylog2.plugin.streams.Stream;
 import org.graylog2.rest.models.streams.alerts.requests.CreateConditionRequest;
 import org.joda.time.DateTime;
 
+import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -34,6 +35,8 @@ public interface AlertService {
 
     List<Alert> loadRecentOfStreams(List<String> streamIds, DateTime since, int limit);
     List<Alert> loadRecentOfStream(String streamId, DateTime since, int limit);
+
+    Map<String, Map<String, DateTime>> getLastTriggeredAt(Collection<String> streamIds, Collection<String> conditionIds);
 
     Optional<Alert> getLastTriggeredAlert(String streamId, String conditionId);
 
@@ -47,6 +50,7 @@ public interface AlertService {
     AlertCondition updateFromRequest(AlertCondition alertCondition, CreateConditionRequest ccr) throws ConfigurationException;
 
     boolean inGracePeriod(AlertCondition alertCondition);
+    boolean inGracePeriod(AlertCondition alertCondition, Map<String, Map<String,DateTime>> lastTriggeredAts);
 
     List<Alert> listForStreamId(String streamId, int skip, int limit);
     List<Alert> listForStreamIds(List<String> streamIds, AlertState state, int skip, int limit);

--- a/graylog2-server/src/main/java/org/graylog2/rest/resources/streams/StreamResource.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/resources/streams/StreamResource.java
@@ -27,6 +27,7 @@ import io.swagger.annotations.ApiOperation;
 import io.swagger.annotations.ApiParam;
 import io.swagger.annotations.ApiResponse;
 import io.swagger.annotations.ApiResponses;
+import org.apache.commons.lang3.time.StopWatch;
 import org.apache.shiro.authz.annotation.RequiresAuthentication;
 import org.apache.shiro.authz.annotation.RequiresPermissions;
 import org.bson.types.ObjectId;
@@ -169,6 +170,8 @@ public class StreamResource extends RestResource {
     @ApiOperation(value = "Get a list of all streams")
     @Produces(MediaType.APPLICATION_JSON)
     public StreamListResponse get() {
+        final StopWatch stopWatch = new StopWatch();
+        stopWatch.start();
         final List<Stream> allStreams = streamService.loadAll();
         final List<Stream> streams = new ArrayList<>(allStreams.size());
         for (Stream stream : allStreams) {
@@ -177,7 +180,12 @@ public class StreamResource extends RestResource {
             }
         }
 
-        return StreamListResponse.create(streams.size(), streams.stream().map(this::streamToResponse).collect(Collectors.toSet()));
+        final StreamListResponse streamListResponse = streamsToResponse(streams);
+        stopWatch.stop();
+
+        System.out.println("StreamResource get: " + stopWatch.getTime());
+
+        return streamListResponse;
     }
 
     @GET
@@ -444,6 +452,61 @@ public class StreamResource extends RestResource {
             .build(id);
 
         return Response.created(streamUri).entity(result).build();
+    }
+
+    private StreamListResponse streamsToResponse(Collection<Stream> streams) {
+        Collection<String> streamIds = Lists.newArrayList();
+        Collection<String> conditionIds = Lists.newArrayList();
+
+        streams.forEach(stream -> {
+            streamIds.add(stream.getId());
+
+            streamService.getAlertConditions(stream)
+                .forEach(alertCondition -> {
+                    conditionIds.add(alertCondition.getId());
+                });
+        });
+
+        final Map<String, Map<String, DateTime>> lastTriggeredAts = alertService.getLastTriggeredAt(streamIds, conditionIds);
+
+        final List<StreamResponse> streamResponses = streams.stream().map(stream -> {
+            final List<String> emailAlertReceivers = stream.getAlertReceivers().get("emails");
+            final List<String> usersAlertReceivers = stream.getAlertReceivers().get("users");
+            final Collection<AlertConditionSummary> alertConditions = streamService.getAlertConditions(stream)
+                .stream()
+                .map((alertCondition) -> AlertConditionSummary.create(
+                    alertCondition.getId(),
+                    alertCondition.getType(),
+                    alertCondition.getCreatorUserId(),
+                    alertCondition.getCreatedAt().toDate(),
+                    alertCondition.getParameters(),
+                    alertService.inGracePeriod(alertCondition, lastTriggeredAts),
+                    alertCondition.getTitle()))
+                .collect(Collectors.toList());
+            return StreamResponse.create(
+                stream.getId(),
+                (String) stream.getFields().get(StreamImpl.FIELD_CREATOR_USER_ID),
+                outputsToSummaries(stream.getOutputs()),
+                stream.getMatchingType().name(),
+                stream.getDescription(),
+                stream.getFields().get(StreamImpl.FIELD_CREATED_AT).toString(),
+                stream.getDisabled(),
+                stream.getStreamRules(),
+                alertConditions,
+                AlertReceivers.create(
+                    firstNonNull(emailAlertReceivers, Collections.emptyList()),
+                    firstNonNull(usersAlertReceivers, Collections.emptyList())
+                ),
+                stream.getTitle(),
+                stream.getContentPack(),
+                stream.isDefaultStream(),
+                stream.getRemoveMatchesFromDefaultStream(),
+                stream.getIndexSetId()
+            );
+        })
+            .collect(Collectors.toList());
+
+        return StreamListResponse.create(streamResponses.size(), streamResponses);
     }
 
     private StreamResponse streamToResponse(Stream stream) {

--- a/graylog2-server/src/test/java/org/graylog2/migrations/V20161125142400_EmailAlarmCallbackMigrationTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/migrations/V20161125142400_EmailAlarmCallbackMigrationTest.java
@@ -110,7 +110,7 @@ public class V20161125142400_EmailAlarmCallbackMigrationTest {
 
         this.emailAlarmCallbackMigrationPeriodical.upgrade();
 
-        verify(this.streamService, never()).getAlertConditions(any());
+        verify(this.streamService, never()).getAlertConditions(any(Stream.class));
         verify(this.alarmCallbackConfigurationService, never()).getForStream(any());
         verify(this.alarmCallbackConfigurationService, never()).create(any(), any(), any());
         verifyMigrationCompletedWasPosted();

--- a/graylog2-server/src/test/java/org/graylog2/migrations/V20161125161400_AlertReceiversMigrationTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/migrations/V20161125161400_AlertReceiversMigrationTest.java
@@ -114,7 +114,7 @@ public class V20161125161400_AlertReceiversMigrationTest {
 
         this.alertReceiversMigration.upgrade();
 
-        verify(this.streamService, never()).getAlertConditions(any());
+        verify(this.streamService, never()).getAlertConditions(any(Stream.class));
         verify(this.alarmCallbackConfigurationService, never()).getForStream(any());
         verify(this.alarmCallbackConfigurationService, never()).save(any());
         verify(this.dbCollection, never()).update(any(), any());


### PR DESCRIPTION
## Description

In #2972 we made the stream page loading much faster, but it in our
setup it is still slow (3-10 seconds). After some benchmarking I figured
that most of the time is spent in the "in grace period" check.

I tried to see if that field is anywhere used, but I found not usage for
it. Nonetheless removing it from the API seems a little bit too much for
me.

Therefore I started to implement a "micro" batching for this. So, in the
first step load all "last triggered_at" datetime for all given
conditions and streams and than calculate the "in grace" from that.

## Motivation and Context

Prevent slow loading of the "streams" page and also the "streams" api.

## How Has This Been Tested?

Not really yet. Tests will also fail. I wanted to get early feedback on this before proceeding. 
## Screenshots (if appropriate):

Before:
<img width="1411" alt="screen shot 2016-12-30 at 17 48 18" src="https://cloud.githubusercontent.com/assets/1449155/21568917/99ebae98-ceb8-11e6-8189-d5c79fb0414c.png">

After:

<img width="1411" alt="screen shot 2016-12-30 at 17 44 52" src="https://cloud.githubusercontent.com/assets/1449155/21568912/8c0eb248-ceb8-11e6-8a0d-767a68ecf6f6.png">

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.