### PR TITLE
Use mutable HashMap in TokenizerConverter

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/inputs/converters/TokenizerConverter.java
+++ b/graylog2-server/src/main/java/org/graylog2/inputs/converters/TokenizerConverter.java
@@ -16,10 +16,10 @@
  */
 package org.graylog2.inputs.converters;
 
-import com.google.common.collect.ImmutableMap;
 import org.graylog2.plugin.inputs.Converter;
 
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.Map;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -41,7 +41,7 @@ public class TokenizerConverter extends Converter {
         }
 
         if (value.contains("=")) {
-            final ImmutableMap.Builder<String, String> fields = ImmutableMap.builder();
+            final Map<String, String> fields = new HashMap<>();
 
             Matcher m = PATTERN.matcher(value);
             while (m.find()) {
@@ -52,7 +52,7 @@ public class TokenizerConverter extends Converter {
                 fields.put(removeQuotes(m.group(1)), removeQuotes(m.group(2)));
             }
 
-            return fields.build();
+            return fields;
         } else {
             return Collections.emptyMap();
         }

--- a/graylog2-server/src/test/java/org/graylog2/inputs/converters/TokenizerConverterTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/inputs/converters/TokenizerConverterTest.java
@@ -257,7 +257,7 @@ public class TokenizerConverterTest {
                 .containsEntry("k3", " 'v3' ");
     }
     
-        @Test 
+    @Test
     public void testFilterRetainsNestedDoubleQuotesInSingleQuotedValues() {
         TokenizerConverter f = new TokenizerConverter(new HashMap<String, Object>());
         @SuppressWarnings("unchecked")
@@ -268,5 +268,15 @@ public class TokenizerConverterTest {
                 .containsEntry("k1", "v1")
                 .containsEntry("k2", " \"v2\"")
                 .containsEntry("k3", " \"v3\" ");
+    }
+
+    @Test
+    public void testFilterSupportsMultipleIdenticalKeys() {
+        TokenizerConverter f = new TokenizerConverter(new HashMap<String, Object>());
+        @SuppressWarnings("unchecked")
+        Map<String, String> result = (Map<String, String>) f.convert("Ohai I am a message k1=v1 k1=v2 Awesome!");
+
+        assertEquals(1, result.size());
+        assertEquals("v2", result.get("k1"));
     }
 }


### PR DESCRIPTION
The usage of an immutable map in TokenizerConverter prevented it from overwriting
keys if there were mutlitple identical keys in the input string.

Fixes #1663