### PR TITLE
Add list of stream IDs to Message#toElasticSearchObject()

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/plugin/Message.java
+++ b/graylog2-server/src/main/java/org/graylog2/plugin/Message.java
@@ -25,7 +25,6 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Iterators;
-import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
 import com.google.common.net.InetAddresses;
@@ -38,7 +37,6 @@ import org.slf4j.LoggerFactory;
 import javax.annotation.Nonnull;
 import java.net.InetAddress;
 import java.util.ArrayList;
-import java.util.Collection;
 import java.util.Collections;
 import java.util.Date;
 import java.util.Iterator;
@@ -47,7 +45,6 @@ import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
 import java.util.regex.Pattern;
-import java.util.stream.Collectors;
 
 import static com.google.common.base.Predicates.equalTo;
 import static com.google.common.base.Predicates.not;
@@ -459,7 +456,11 @@ public class Message implements Messages {
 
     public List<String> getStreamIds() {
         if (!hasField(FIELD_STREAMS)) {
-            return streams.stream().map(Stream::getId).collect(Collectors.toList());
+            final List<String> streamIds = new ArrayList<>(streams.size());
+            for (Stream stream : streams) {
+                streamIds.add(stream.getId());
+            }
+            return streamIds;
         }
         try {
             @SuppressWarnings("unchecked")

--- a/graylog2-server/src/main/java/org/graylog2/plugin/Message.java
+++ b/graylog2-server/src/main/java/org/graylog2/plugin/Message.java
@@ -39,6 +39,7 @@ import java.net.InetAddress;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Date;
+import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
@@ -454,22 +455,22 @@ public class Message implements Messages {
         return ImmutableSet.copyOf(this.indexSets);
     }
 
+    @SuppressWarnings("unchecked")
     public List<String> getStreamIds() {
-        if (!hasField(FIELD_STREAMS)) {
-            final List<String> streamIds = new ArrayList<>(streams.size());
-            for (Stream stream : streams) {
-                streamIds.add(stream.getId());
-            }
-            return streamIds;
-        }
+        List<String> streamField;
         try {
-            @SuppressWarnings("unchecked")
-            final List<String> streamIds = getFieldAs(List.class, FIELD_STREAMS);
-            return new ArrayList<>(streamIds);
+            streamField = getFieldAs(List.class, FIELD_STREAMS);
         } catch (ClassCastException e) {
             LOG.trace("Couldn't cast {} to List", FIELD_STREAMS, e);
-            return Collections.emptyList();
+            streamField = Collections.emptyList();
         }
+
+        final Set<String> streamIds = streamField == null ? new HashSet<>(streams.size()) : new HashSet<>(streamField);
+        for (Stream stream : streams) {
+            streamIds.add(stream.getId());
+        }
+
+        return new ArrayList<>(streamIds);
     }
 
     public void setFilterOut(final boolean filterOut) {

--- a/graylog2-server/src/main/java/org/graylog2/plugin/Message.java
+++ b/graylog2-server/src/main/java/org/graylog2/plugin/Message.java
@@ -37,6 +37,7 @@ import org.slf4j.LoggerFactory;
 import javax.annotation.Nonnull;
 import java.net.InetAddress;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.Date;
 import java.util.HashSet;
@@ -456,13 +457,13 @@ public class Message implements Messages {
     }
 
     @SuppressWarnings("unchecked")
-    public List<String> getStreamIds() {
-        List<String> streamField;
+    public Collection<String> getStreamIds() {
+        Collection<String> streamField;
         try {
-            streamField = getFieldAs(List.class, FIELD_STREAMS);
+            streamField = getFieldAs(Collection.class, FIELD_STREAMS);
         } catch (ClassCastException e) {
             LOG.trace("Couldn't cast {} to List", FIELD_STREAMS, e);
-            streamField = Collections.emptyList();
+            streamField = Collections.emptySet();
         }
 
         final Set<String> streamIds = streamField == null ? new HashSet<>(streams.size()) : new HashSet<>(streamField);
@@ -470,7 +471,7 @@ public class Message implements Messages {
             streamIds.add(stream.getId());
         }
 
-        return new ArrayList<>(streamIds);
+        return streamIds;
     }
 
     public void setFilterOut(final boolean filterOut) {

--- a/graylog2-server/src/main/java/org/graylog2/plugin/Message.java
+++ b/graylog2-server/src/main/java/org/graylog2/plugin/Message.java
@@ -38,6 +38,7 @@ import org.slf4j.LoggerFactory;
 import javax.annotation.Nonnull;
 import java.net.InetAddress;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.Date;
 import java.util.Iterator;
@@ -216,6 +217,7 @@ public class Message implements Messages {
 
         obj.put(FIELD_MESSAGE, getMessage());
         obj.put(FIELD_SOURCE, getSource());
+        obj.put(FIELD_STREAMS, getStreamIds());
 
         final Object timestampValue = getField(FIELD_TIMESTAMP);
         DateTime dateTime;
@@ -241,17 +243,6 @@ public class Message implements Messages {
         }
         if (dateTime != null) {
             obj.put(FIELD_TIMESTAMP, buildElasticSearchTimeFormat(dateTime.withZone(UTC)));
-        }
-
-        // Manually converting stream ID to string - caused strange problems without it.
-        if (getStreams().isEmpty()) {
-            obj.put(FIELD_STREAMS, Collections.emptyList());
-        } else {
-            final List<String> streamIds = Lists.newArrayListWithCapacity(streams.size());
-            for (Stream stream : streams) {
-                streamIds.add(stream.getId());
-            }
-            obj.put(FIELD_STREAMS, streamIds);
         }
 
         return obj;

--- a/graylog2-server/src/main/java/org/graylog2/plugin/MessageSummary.java
+++ b/graylog2-server/src/main/java/org/graylog2/plugin/MessageSummary.java
@@ -22,8 +22,8 @@ import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
 import org.joda.time.DateTime;
 
+import java.util.Collection;
 import java.util.HashSet;
-import java.util.List;
 import java.util.Map;
 
 /**
@@ -73,7 +73,7 @@ public class MessageSummary {
     }
 
     @JsonProperty
-    public List<String> getStreamIds() {
+    public Collection<String> getStreamIds() {
         return message.getStreamIds();
     }
 

--- a/graylog2-server/src/test/java/org/graylog2/plugin/MessageSummaryTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/plugin/MessageSummaryTest.java
@@ -30,6 +30,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNull;
@@ -76,7 +77,7 @@ public class MessageSummaryTest {
 
     @Test
     public void testGetStreamIds() throws Exception {
-        assertEquals(messageSummary.getStreamIds(), STREAM_IDS);
+        assertThat(messageSummary.getStreamIds()).containsAll(STREAM_IDS);
     }
 
     @Test

--- a/graylog2-server/src/test/java/org/graylog2/plugin/MessageTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/plugin/MessageTest.java
@@ -33,6 +33,7 @@ import org.junit.Test;
 import org.mockito.junit.MockitoJUnit;
 import org.mockito.junit.MockitoRule;
 
+import java.util.Collection;
 import java.util.Collections;
 import java.util.Date;
 import java.util.List;
@@ -287,7 +288,7 @@ public class MessageTest {
     public void testGetStreamIds() throws Exception {
         message.addField("streams", Lists.newArrayList("stream-id"));
 
-        assertEquals(Lists.newArrayList("stream-id"), message.getStreamIds());
+        assertThat(message.getStreamIds()).containsOnly("stream-id");
     }
 
     @Test
@@ -374,7 +375,10 @@ public class MessageTest {
         assertEquals("wat", object.get("field1"));
         assertEquals("that", object.get("field2"));
         assertEquals(Tools.buildElasticSearchTimeFormat((DateTime) message.getField("timestamp")), object.get("timestamp"));
-        assertEquals(Collections.singletonList("test-stream"), object.get("streams"));
+
+        @SuppressWarnings("unchecked")
+        final Collection<String> streams = (Collection<String>) object.get("streams");
+        assertThat(streams).containsOnly("test-stream");
     }
 
     @Test
@@ -390,7 +394,10 @@ public class MessageTest {
         assertEquals("foo", object.get("message"));
         assertEquals("bar", object.get("source"));
         assertEquals(Tools.buildElasticSearchTimeFormat((DateTime) message.getField("timestamp")), object.get("timestamp"));
-        assertEquals(Collections.emptyList(), object.get("streams"));
+
+        @SuppressWarnings("unchecked")
+        final Collection<String> streams = (Collection<String>) object.get("streams");
+        assertThat(streams).isEmpty();
     }
 
     @Test
@@ -414,7 +421,9 @@ public class MessageTest {
 
         final Map<String, Object> object = message.toElasticSearchObject(invalidTimestampMeter);
 
-        assertEquals(Lists.newArrayList("stream-id"), object.get("streams"));
+        @SuppressWarnings("unchecked")
+        final Collection<String> streams = (Collection<String>) object.get("streams");
+        assertThat(streams).containsOnly("stream-id");
     }
 
     @Test

--- a/graylog2-server/src/test/java/org/graylog2/plugin/MessageTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/plugin/MessageTest.java
@@ -365,6 +365,7 @@ public class MessageTest {
     public void testToElasticSearchObject() throws Exception {
         message.addField("field1", "wat");
         message.addField("field2", "that");
+        message.addField(Message.FIELD_STREAMS, Collections.singletonList("test-stream"));
 
         final Map<String, Object> object = message.toElasticSearchObject(invalidTimestampMeter);
 
@@ -373,7 +374,7 @@ public class MessageTest {
         assertEquals("wat", object.get("field1"));
         assertEquals("that", object.get("field2"));
         assertEquals(Tools.buildElasticSearchTimeFormat((DateTime) message.getField("timestamp")), object.get("timestamp"));
-        assertEquals(Collections.emptyList(), object.get("streams"));
+        assertEquals(Collections.singletonList("test-stream"), object.get("streams"));
     }
 
     @Test
@@ -406,10 +407,10 @@ public class MessageTest {
     @Test
     public void testToElasticSearchObjectWithStreams() throws Exception {
         final Stream stream = mock(Stream.class);
-
         when(stream.getId()).thenReturn("stream-id");
+        when(stream.getIndexSet()).thenReturn(mock(IndexSet.class));
 
-        message.setStreams(Lists.newArrayList(stream));
+        message.addStream(stream);
 
         final Map<String, Object> object = message.toElasticSearchObject(invalidTimestampMeter);
 

--- a/graylog2-server/src/test/java/org/graylog2/plugin/MessageTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/plugin/MessageTest.java
@@ -517,10 +517,11 @@ public class MessageTest {
     public void getStreamIdsReturnsStreamsFieldContentsIfFieldDoesExist() {
         final Message message = new Message("", "source", Tools.nowUTC());
         final Stream stream = mock(Stream.class);
+        when(stream.getId()).thenReturn("test1");
         message.addField("streams", Collections.singletonList("test2"));
         message.addStream(stream);
 
-        assertThat(message.getStreamIds()).containsOnly("test2");
+        assertThat(message.getStreamIds()).containsOnly("test1", "test2");
 
     }
 }


### PR DESCRIPTION
The `Message#toElasticSearchObject()` only populated the `streams` field of the generated Elasticsearch document if the `Message.streams` field was filled, but not if the `streams` field in the `Message.fields` map was being used.

This lead to inconsistent "exports" of the internal `Message` representation.