### PR TITLE
properly track stream throughput for the default stream

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/streams/StreamRouterEngine.java
+++ b/graylog2-server/src/main/java/org/graylog2/streams/StreamRouterEngine.java
@@ -226,6 +226,11 @@ public class StreamRouterEngine {
                 }
             }
         }
+        // either the message stayed on the default stream, in which case we mark that stream's throughput,
+        // or someone removed it, in which case we don't mark it.
+        if (!alreadyRemovedDefaultStream) {
+            streamMetrics.markIncomingMeter(defaultStream.getId());
+        }
 
         return ImmutableList.copyOf(result);
     }


### PR DESCRIPTION
The default stream's throughput wasn't tracked during stream routing.

This change marks a message on the default stream's meter if it hasn't been removed by any other stream during normal routing.
Should a pipeline function manually route the message again, then the counter will be incremented twice, which is a known issue (and has existed prior to this change).

Best tested by a random message generator and two additional streams: "took_ms > 50" and "took_ms < 51". Both should remove the message from the default stream.
Selectively pausing the streams you will see the throughput numbers shift from the default stream (which wasn't working before) to each of the streams. If both are enabled, the default stream should not have any throughput anymore.

fixes #3184