### PR TITLE
Add missing authentication to ClusterResource and ClusterStatsResource

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/rest/resources/system/ClusterResource.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/resources/system/ClusterResource.java
@@ -23,6 +23,7 @@ import io.swagger.annotations.ApiOperation;
 import io.swagger.annotations.ApiParam;
 import io.swagger.annotations.ApiResponse;
 import io.swagger.annotations.ApiResponses;
+import org.apache.shiro.authz.annotation.RequiresAuthentication;
 import org.graylog2.cluster.Node;
 import org.graylog2.cluster.NodeNotFoundException;
 import org.graylog2.cluster.NodeService;
@@ -47,6 +48,7 @@ import java.util.Locale;
 import java.util.Map;
 
 @Api(value = "System/Cluster", description = "Node discovery")
+@RequiresAuthentication
 @Path("/system/cluster")
 @Produces(MediaType.APPLICATION_JSON)
 public class ClusterResource extends RestResource {

--- a/graylog2-server/src/main/java/org/graylog2/rest/resources/system/ClusterStatsResource.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/resources/system/ClusterStatsResource.java
@@ -19,6 +19,7 @@ package org.graylog2.rest.resources.system;
 import com.codahale.metrics.annotation.Timed;
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
+import org.apache.shiro.authz.annotation.RequiresAuthentication;
 import org.graylog2.shared.rest.resources.RestResource;
 import org.graylog2.system.stats.ClusterStats;
 import org.graylog2.system.stats.ClusterStatsService;
@@ -32,6 +33,7 @@ import javax.ws.rs.Produces;
 import javax.ws.rs.core.MediaType;
 
 @Api(value = "System/ClusterStats", description = "Cluster stats")
+@RequiresAuthentication
 @Path("/system/cluster/stats")
 @Produces(MediaType.APPLICATION_JSON)
 public class ClusterStatsResource extends RestResource {

--- a/graylog2-web-interface/src/routing/ApiRoutes.js
+++ b/graylog2-web-interface/src/routing/ApiRoutes.js
@@ -317,6 +317,7 @@ const ApiRoutes = {
     parse: () => { return { url: '/messages/parse' }; },
     single: (index, messageId) => { return { url: `/messages/${index}/${messageId}` }; },
   },
+  ping: () => { return { url: '/' }; },
 };
 
 export default ApiRoutes;

--- a/graylog2-web-interface/src/stores/sessions/ServerAvailabilityStore.js
+++ b/graylog2-web-interface/src/stores/sessions/ServerAvailabilityStore.js
@@ -17,7 +17,7 @@ const ServerAvailabilityStore = Reflux.createStore({
     return { server: this.server };
   },
   ping() {
-    return new Builder('GET', URLUtils.qualifyUrl(ApiRoutes.ClusterApiResource.node().url)).build().then(
+    return new Builder('GET', URLUtils.qualifyUrl(ApiRoutes.ping().url)).build().then(
       () => ServerAvailabilityActions.reportSuccess(),
       (error) => ServerAvailabilityActions.reportError(error)
     );


### PR DESCRIPTION
Instead of `/system/cluster/node`, the web interface will now use the root resource of the Graylog REST API to check whether a node is available or not.

Fixes #2749