### PR TITLE
Remove more TODO comments for 2.2

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/indexer/IndexSetRegistry.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/IndexSetRegistry.java
@@ -86,8 +86,6 @@ public interface IndexSetRegistry extends Iterable<IndexSet> {
     /**
      * Checks if all deflector aliases exist.
      *
-     * TODO 2.2: Check if we can get rid of this method or create a good implementation.
-     *
      * @return if all aliases exist
      */
     boolean isUp();

--- a/graylog2-server/src/main/java/org/graylog2/indexer/MongoIndexSet.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/MongoIndexSet.java
@@ -63,6 +63,7 @@ public class MongoIndexSet implements IndexSet {
     public static final String DEFLECTOR_SUFFIX = "deflector";
 
     // TODO: Hardcoded archive suffix. See: https://github.com/Graylog2/graylog2-server/issues/2058
+    // TODO 3.0: Remove this in 3.0, only used for pre 2.2 backwards compatibility.
     public static final String RESTORED_ARCHIVE_SUFFIX = "_restored_archive";
 
     public interface Factory {
@@ -102,10 +103,11 @@ public class MongoIndexSet implements IndexSet {
 
         // Part of the pattern can be configured in IndexSetConfig. If set we use the indexMatchPattern from the config.
         if (isNullOrEmpty(config.indexMatchPattern())) {
-            // TODO 2.2: Is this strict enough? What happens if an index set with a prefix of "foo_0" is created?
+            // This pattern requires that we check that each index prefix is unique and unambiguous to avoid false matches.
             this.indexPattern = Pattern.compile("^" + config.indexPrefix() + SEPARATOR + "\\d+(?:" + RESTORED_ARCHIVE_SUFFIX + ")?");
             this.deflectorIndexPattern = Pattern.compile("^" + config.indexPrefix() + SEPARATOR + "\\d+");
         } else {
+            // This pattern requires that we check that each index prefix is unique and unambiguous to avoid false matches.
             this.indexPattern = Pattern.compile("^" + config.indexMatchPattern() + SEPARATOR + "\\d+(?:" + RESTORED_ARCHIVE_SUFFIX + ")?");
             this.deflectorIndexPattern = Pattern.compile("^" + config.indexMatchPattern() + SEPARATOR + "\\d+");
         }


### PR DESCRIPTION
- The `IndexSetRegistry#isUp()` is going to stay for now
- Add TODO for 3.0 to remove the RESTORED_ARCHIVE_SUFFIX
- Replace TODO with a comment about the pattern