### PR TITLE
Handle ElasticsearchException in Counts class

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/indexer/counts/Counts.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/counts/Counts.java
@@ -16,7 +16,7 @@
  */
 package org.graylog2.indexer.counts;
 
-import org.elasticsearch.action.search.SearchRequest;
+import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.client.Client;
 import org.graylog2.indexer.IndexSet;
 import org.graylog2.indexer.IndexSetRegistry;
@@ -50,9 +50,14 @@ public class Counts {
             return 0L;
         }
 
-        final SearchRequest request = c.prepareSearch(indexNames)
-                .setSize(0)
-                .request();
-        return c.search(request).actionGet().getHits().totalHits();
+        try {
+            return c.prepareSearch(indexNames)
+                    .setSize(0)
+                    .get()
+                    .getHits()
+                    .getTotalHits();
+        } catch (ElasticsearchException e) {
+            return -1L;
+        }
     }
 }

--- a/graylog2-server/src/test/java/org/graylog2/indexer/counts/CountsTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/indexer/counts/CountsTest.java
@@ -52,6 +52,7 @@ import static com.lordofthejars.nosqlunit.elasticsearch2.ElasticsearchRule.Elast
 import static com.lordofthejars.nosqlunit.elasticsearch2.EmbeddedElasticsearch.EmbeddedElasticsearchRuleBuilder.newEmbeddedElasticsearchRule;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assume.assumeTrue;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 public class CountsTest {
@@ -229,5 +230,12 @@ public class CountsTest {
         assertThat(counts.total()).isEqualTo(count1 + count2);
         assertThat(counts.total(indexSet1)).isEqualTo(count1);
         assertThat(counts.total(indexSet2)).isEqualTo(count2);
+    }
+
+    @Test
+    public void totalReturnsMinusOneIfIndexDoesNotExist() throws Exception {
+        final IndexSet indexSet = mock(IndexSet.class);
+        when(indexSet.getManagedIndicesNames()).thenReturn(new String[]{"does_not_exist"});
+        assertThat(counts.total(indexSet)).isEqualTo(-1L);
     }
 }


### PR DESCRIPTION
Instead of bubbling up the `ElasticsearchException` in `Counts#total()` or `Counts#total(IndexSet)`, it is now caught and the methods will return `-1`.

Closes #2381 