### PR TITLE
Allow to get a thread dump as plain text

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/shared/rest/resources/system/SystemResource.java
+++ b/graylog2-server/src/main/java/org/graylog2/shared/rest/resources/system/SystemResource.java
@@ -40,6 +40,7 @@ import javax.ws.rs.GET;
 import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
 import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.StreamingOutput;
 import java.io.ByteArrayOutputStream;
 import java.lang.management.ManagementFactory;
 import java.nio.charset.StandardCharsets;
@@ -112,6 +113,16 @@ public class SystemResource extends RestResource {
 
         threadDump.dump(output);
         return SystemThreadDumpResponse.create(new String(output.toByteArray(), StandardCharsets.UTF_8));
+    }
+
+    @GET
+    @Path("/threaddump")
+    @Produces(MediaType.TEXT_PLAIN)
+    @Timed
+    @ApiOperation(value = "Get a thread dump as plain text")
+    public StreamingOutput threadDumpAsText() {
+        checkPermission(RestPermissions.THREADS_DUMP, serverStatus.getNodeId().toString());
+        return output -> new ThreadDump(ManagementFactory.getThreadMXBean()).dump(output);
     }
 
     private Map<String, Long> bytesToValueMap(long bytes) {


### PR DESCRIPTION
The JSON format of the `/system/threaddump` resource is a bit unfortunate to consume with anything but the Graylog web interface (see https://groups.google.com/d/msg/graylog2/GS5rJubNRBg/gGqZZyQwEgAJ for an example).

This PR simply adds the possibility to retrieve the same thread dump from `/system/threaddump` in plain text (including formatting).