### PR TITLE
Escape curly braces in Swagger resource URIs for challenged browsers

### DIFF
--- a/graylog2-server/src/main/resources/swagger/lib/swagger.js
+++ b/graylog2-server/src/main/resources/swagger/lib/swagger.js
@@ -289,12 +289,9 @@
         if (this.path == null) {
           this.api.fail("SwaggerResources must have a path.");
         }
-        // I seriously cannot be bothered by this browser stuff anymore. Chrome this way, Safari that. WTF.
-        if (navigator.userAgent.toLowerCase().indexOf('safari/') > -1) {
-            if (this.path.indexOf("{") != -1) {
-                this.path = this.path.replace("{", "%7B");
-                this.path = this.path.replace("}", "%7D");
-            }
+        if (this.path.indexOf("{") != -1) {
+            this.path = this.path.replace(/\{/g, "%7B");
+            this.path = this.path.replace(/\}/g, "%7D");
         }
         if (this.path.substring(0, 4) === 'http') {
           this.url = this.path.replace('{format}', 'json');


### PR DESCRIPTION
Fixes #2710