### PR TITLE
Fix document counts with an empty index set

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/indexer/counts/Counts.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/counts/Counts.java
@@ -24,8 +24,6 @@ import org.graylog2.indexer.IndexSetRegistry;
 import javax.inject.Inject;
 import javax.inject.Singleton;
 
-import static java.util.Objects.requireNonNull;
-
 @Singleton
 public class Counts {
     private final Client c;
@@ -48,7 +46,7 @@ public class Counts {
     private long totalCount(final String[] indexNames) {
         // Return 0 if there are no indices in the given index set. If we run the query with an empty index list,
         // Elasticsearch will count all documents in all indices and thus return a wrong count.
-        if (requireNonNull(indexNames).length == 0) {
+        if (indexNames.length == 0) {
             return 0L;
         }
 

--- a/graylog2-server/src/main/java/org/graylog2/indexer/counts/Counts.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/counts/Counts.java
@@ -45,6 +45,12 @@ public class Counts {
     public long total(final IndexSet indexSet) {
         final String[] names = indexSet.getManagedIndicesNames();
 
+        // Return 0 if there are no indices in the given index set. If we run the query with an empty index list,
+        // Elasticsearch will count all documents in all indices and thus return a wrong count.
+        if (names.length == 0) {
+            return 0L;
+        }
+
         final SearchRequest request = c.prepareSearch(names)
                 .setSize(0)
                 .request();

--- a/graylog2-server/src/main/java/org/graylog2/indexer/counts/Counts.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/counts/Counts.java
@@ -24,6 +24,8 @@ import org.graylog2.indexer.IndexSetRegistry;
 import javax.inject.Inject;
 import javax.inject.Singleton;
 
+import static java.util.Objects.requireNonNull;
+
 @Singleton
 public class Counts {
     private final Client c;
@@ -36,22 +38,21 @@ public class Counts {
     }
 
     public long total() {
-        final SearchRequest request = c.prepareSearch(indexSetRegistry.getManagedIndicesNames())
-                .setSize(0)
-                .request();
-        return c.search(request).actionGet().getHits().totalHits();
+        return totalCount(indexSetRegistry.getManagedIndicesNames());
     }
 
     public long total(final IndexSet indexSet) {
-        final String[] names = indexSet.getManagedIndicesNames();
+        return totalCount(indexSet.getManagedIndicesNames());
+    }
 
+    private long totalCount(final String[] indexNames) {
         // Return 0 if there are no indices in the given index set. If we run the query with an empty index list,
         // Elasticsearch will count all documents in all indices and thus return a wrong count.
-        if (names.length == 0) {
+        if (requireNonNull(indexNames).length == 0) {
             return 0L;
         }
 
-        final SearchRequest request = c.prepareSearch(names)
+        final SearchRequest request = c.prepareSearch(indexNames)
                 .setSize(0)
                 .request();
         return c.search(request).actionGet().getHits().totalHits();

--- a/graylog2-server/src/test/java/org/graylog2/indexer/counts/CountsTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/indexer/counts/CountsTest.java
@@ -196,6 +196,11 @@ public class CountsTest {
 
         assertThat(counts.total(indexSet1)).isEqualTo(10L);
         assertThat(counts.total(indexSet2)).isEqualTo(0L);
+
+        // Simulate no indices for all index sets.
+        when(indexSetRegistry.getManagedIndicesNames()).thenReturn(new String[0]);
+
+        assertThat(counts.total()).isEqualTo(0L);
     }
 
     @Test

--- a/graylog2-server/src/test/java/org/graylog2/indexer/counts/CountsTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/indexer/counts/CountsTest.java
@@ -180,6 +180,25 @@ public class CountsTest {
     }
 
     @Test
+    public void totalReturnsZeroWithNoIndices() throws Exception {
+        for (int i = 0; i < 10; i++) {
+            final IndexResponse indexResponse = client.prepareIndex()
+                    .setIndex(INDEX_NAME_1)
+                    .setRefresh(true)
+                    .setType("test")
+                    .setSource("foo", "bar", "counter", i)
+                    .execute().get();
+            assumeTrue(indexResponse.isCreated());
+        }
+
+        // Simulate no indices for the second index set.
+        when(indexSet2.getManagedIndicesNames()).thenReturn(new String[0]);
+
+        assertThat(counts.total(indexSet1)).isEqualTo(10L);
+        assertThat(counts.total(indexSet2)).isEqualTo(0L);
+    }
+
+    @Test
     public void totalReturnsNumberOfMessages() throws Exception {
         final int count1 = 10;
         final int count2 = 5;


### PR DESCRIPTION
Return 0 if there are no indices in the given index set. If we run the query with an empty index list, Elasticsearch will count all documents in all indices and thus return a wrong count.