### PR TITLE
Upgrade to HK2 2.5.0-b31

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -105,7 +105,7 @@
         <guice.version>4.1.0</guice.version>
         <HdrHistogram.version>2.1.9</HdrHistogram.version>
         <hibernate-validator.version>5.3.4.Final</hibernate-validator.version>
-        <hk2.version>2.5.0-b30</hk2.version> <!-- The HK2 version should match the version being used by Jersey -->
+        <hk2.version>2.5.0-b31</hk2.version> <!-- The HK2 version should match the version being used by Jersey -->
         <jackson.version>2.8.5</jackson.version>
         <jadconfig.version>0.13.0</jadconfig.version>
         <java-semver.version>0.9.0</java-semver.version>


### PR DESCRIPTION
Memory leak in versions before HK2 2.5.0-b31:

* https://github.com/hk2-project/hk2/issues/43
* https://github.com/hk2-project/hk2/commit/bb2621cdf58a7a1ba9ea739dd970c276a9002c82