### PR TITLE
Reuse Generator instance in DocumentationResource

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/shared/rest/resources/documentation/DocumentationResource.java
+++ b/graylog2-server/src/main/java/org/graylog2/shared/rest/resources/documentation/DocumentationResource.java
@@ -18,6 +18,7 @@ package org.graylog2.shared.rest.resources.documentation;
 
 import com.codahale.metrics.annotation.Timed;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.collect.ImmutableSet;
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
 import io.swagger.annotations.ApiParam;
@@ -38,9 +39,7 @@ import javax.ws.rs.core.Context;
 import javax.ws.rs.core.HttpHeaders;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
-import java.util.Arrays;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 
@@ -50,10 +49,8 @@ import static org.graylog2.shared.initializers.JerseyService.PLUGIN_PREFIX;
 @Path("/api-docs")
 public class DocumentationResource extends RestResource {
 
-    private BaseConfiguration configuration;
-    private final ObjectMapper objectMapper;
-    private final Set<String> restControllerPackages = new HashSet<>();
-    private final Map<Class<?>, String> pluginRestControllerMapping = new HashMap<>();
+    private final Generator generator;
+    private final BaseConfiguration configuration;
 
     @Inject
     public DocumentationResource(BaseConfiguration configuration,
@@ -62,19 +59,22 @@ public class DocumentationResource extends RestResource {
                                  PluginRestResourceClasses pluginRestResourceClasses) {
 
         this.configuration = configuration;
-        this.objectMapper = objectMapper;
 
-        this.restControllerPackages.addAll(Arrays.asList(restControllerPackages));
+        final ImmutableSet.Builder<String> packageNames = ImmutableSet.<String>builder()
+                .add(restControllerPackages);
 
         // All plugin resources get the plugin prefix + the plugin package.
+        final Map<Class<?>, String> pluginRestControllerMapping = new HashMap<>();
         for (Map.Entry<String, Set<Class<? extends PluginRestResource>>> entry : pluginRestResourceClasses.getMap().entrySet()) {
             final String pluginPackage = entry.getKey();
-            this.restControllerPackages.add(pluginPackage);
+            packageNames.add(pluginPackage);
 
             for (Class<? extends PluginRestResource> pluginRestResource : entry.getValue()) {
-                this.pluginRestControllerMapping.put(pluginRestResource, pluginPackage);
+                pluginRestControllerMapping.put(pluginRestResource, pluginPackage);
             }
         }
+
+        this.generator = new Generator(packageNames.build(), pluginRestControllerMapping, PLUGIN_PREFIX, objectMapper);
     }
 
     @GET
@@ -82,7 +82,7 @@ public class DocumentationResource extends RestResource {
     @ApiOperation(value = "Get API documentation")
     @Produces(MediaType.APPLICATION_JSON)
     public Response overview() {
-        return buildSuccessfulCORSResponse(new Generator(restControllerPackages, pluginRestControllerMapping, PLUGIN_PREFIX, objectMapper).generateOverview());
+        return buildSuccessfulCORSResponse(generator.generateOverview());
     }
 
     @GET
@@ -94,9 +94,7 @@ public class DocumentationResource extends RestResource {
                           @PathParam("route") String route,
                           @Context HttpHeaders httpHeaders) {
         final String basePath = RestTools.buildEndpointUri(httpHeaders, configuration.getWebEndpointUri());
-        return buildSuccessfulCORSResponse(
-                new Generator(restControllerPackages, pluginRestControllerMapping, PLUGIN_PREFIX, objectMapper).generateForRoute(route, basePath)
-        );
+        return buildSuccessfulCORSResponse(generator.generateForRoute(route, basePath));
     }
 
     private Response buildSuccessfulCORSResponse(Map<String, Object> result) {


### PR DESCRIPTION
Instead of creating a new instance of `Generator` for every request to `DocumentationResource`, create the instance once and reuse it.