### PR TITLE
Showing index set in stream listing only if user is permitted to.

### DIFF
--- a/graylog2-web-interface/src/components/streams/Stream.jsx
+++ b/graylog2-web-interface/src/components/streams/Stream.jsx
@@ -169,6 +169,7 @@ const Stream = React.createClass({
     );
 
     const indexSet = this.props.indexSets.find(is => is.id === stream.index_set_id) || this.props.indexSets.find(is => is.is_default);
+    const indexSetDetails = this.isPermitted(permissions, ['indexsets:read']) && <span>index set <em>{indexSet.title}</em> &nbsp;</span>;
 
     return (
       <li className="stream">
@@ -186,7 +187,7 @@ const Stream = React.createClass({
             <a>{stream.title}</a>
           </LinkContainer>
           {' '}
-          <small>index set <em>{indexSet.title}</em> &nbsp;<StreamStateBadge stream={stream} /></small>
+          <small>{indexSetDetails}<StreamStateBadge stream={stream} /></small>
         </h2>
 
         <div className="stream-data">


### PR DESCRIPTION
## Description

This PR adds a check for the permission and the presence of the index
set definition in the component showing the stream summary, rendering
index set details only if both are present.

## Motivation and Context

This is fixing an issue where it's implicitly assumed that a user
navigating to the streams page has the required permissions to list all
index sets. This might not be the case for non-admin users, leading to
the streams page breaking completely.

Fixes #3299.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
