### PR TITLE
Disable alarm notification controls if user is not permitted to edit.

### DIFF
--- a/graylog2-web-interface/src/components/alertnotifications/AlertNotification.jsx
+++ b/graylog2-web-interface/src/components/alertnotifications/AlertNotification.jsx
@@ -2,9 +2,12 @@ import React from 'react';
 import Reflux from 'reflux';
 import { Button, Col, DropdownButton, MenuItem } from 'react-bootstrap';
 
+import PermissionsMixin from 'util/PermissionsMixin';
+
 import CombinedProvider from 'injection/CombinedProvider';
 const { AlertNotificationsStore, AlertNotificationsActions } = CombinedProvider.get('AlertNotifications');
 const { AlarmCallbacksActions } = CombinedProvider.get('AlarmCallbacks');
+const { CurrentUserStore } = CombinedProvider.get('CurrentUser');
 
 import { EntityListItem } from 'components/common';
 import { UnknownAlertNotification } from 'components/alertnotifications';
@@ -15,7 +18,7 @@ const AlertNotification = React.createClass({
     alertNotification: React.PropTypes.object.isRequired,
     stream: React.PropTypes.object,
   },
-  mixins: [Reflux.connect(AlertNotificationsStore)],
+  mixins: [Reflux.connect(AlertNotificationsStore), Reflux.connect(CurrentUserStore), PermissionsMixin],
 
   getInitialState() {
     return {
@@ -58,7 +61,7 @@ const AlertNotification = React.createClass({
       <span>Executed once per triggered alert condition in stream <em>{stream.title}</em></span>
       : 'Not executed, as it is not connected to a stream');
 
-    const actions = [
+    const actions = this.isPermitted(this.state.currentUser.permissions, [`streams:edit:${stream.id}`]) && [
       <Button key="test-button" bsStyle="info" disabled={this.state.isTestingAlert} onClick={this._onTestNotification}>
         {this.state.isTestingAlert ? 'Testing...' : 'Test'}
       </Button>,


### PR DESCRIPTION
This PR checks for the stream edit permission on the stream an alarm
notification belongs to and disables functionality it is required for
(test/edit/delete buttons).

Fixes #3302, #2502.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.