### PR TITLE
Changing conditional to check for presence of index set definition.

### DIFF
--- a/graylog2-web-interface/src/components/streams/Stream.jsx
+++ b/graylog2-web-interface/src/components/streams/Stream.jsx
@@ -169,7 +169,7 @@ const Stream = React.createClass({
     );
 
     const indexSet = this.props.indexSets.find(is => is.id === stream.index_set_id) || this.props.indexSets.find(is => is.is_default);
-    const indexSetDetails = this.isPermitted(permissions, ['indexsets:read']) && <span>index set <em>{indexSet.title}</em> &nbsp;</span>;
+    const indexSetDetails = this.isPermitted(permissions, ['indexsets:read']) && indexSet ? <span>index set <em>{indexSet.title}</em> &nbsp;</span> : null;
 
     return (
       <li className="stream">


### PR DESCRIPTION
This is a quick addition left out during commit of #3300, adding an additional check for presence of index set definition, not showing it when it is absent.