### PR TITLE
add messages:analyze permission to reader permission set

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/shared/security/RestPermissions.java
+++ b/graylog2-server/src/main/java/org/graylog2/shared/security/RestPermissions.java
@@ -248,6 +248,7 @@ public class RestPermissions implements PluginPermissions {
         JOURNAL_READ,
         JVMSTATS_READ,
         MESSAGECOUNT_READ,
+        MESSAGES_ANALYZE,
         MESSAGES_READ,
         METRICS_READ,
         SAVEDSEARCHES_CREATE,


### PR DESCRIPTION
without this permission a user cannot see which terms a field is indexed into

fixes #2882
