### PR TITLE
Refreshing saved searches store after deleting one.

### DIFF
--- a/graylog2-web-interface/src/stores/search/SavedSearchesStore.js
+++ b/graylog2-web-interface/src/stores/search/SavedSearchesStore.js
@@ -151,6 +151,7 @@ const SavedSearchesStore = Reflux.createStore({
         response => {
           UserNotification.success(`Saved search "${this.savedSearches[searchId]}" was deleted successfully.`);
           SearchStore.savedSearchDeleted(searchId);
+          SavedSearchesActions.list.triggerPromise();
           return response;
         },
         error => {


### PR DESCRIPTION
Before this change, the saved searches store was not automatically
refreshed after triggering a successfull deletion. This lead to the
saved searches dropdown in the search bar being inconsistent.

This change triggers a refresh after a successfull deletion, so the
store and therefore the saved searches dropdown is accurate.

Fixes #2841.
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
