### PR TITLE
Make sure that index ranges get deleted when an index set is removed

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/indexer/ranges/EsIndexRangeService.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/ranges/EsIndexRangeService.java
@@ -16,6 +16,7 @@
  */
 package org.graylog2.indexer.ranges;
 
+import com.codahale.metrics.MetricRegistry;
 import com.google.common.cache.CacheBuilder;
 import com.google.common.cache.CacheLoader;
 import com.google.common.cache.LoadingCache;
@@ -24,9 +25,6 @@ import com.google.common.eventbus.AllowConcurrentEvents;
 import com.google.common.eventbus.EventBus;
 import com.google.common.eventbus.Subscribe;
 import com.google.common.util.concurrent.UncheckedExecutionException;
-
-import com.codahale.metrics.MetricRegistry;
-
 import org.bson.types.ObjectId;
 import org.elasticsearch.action.NoShardAvailableActionException;
 import org.elasticsearch.action.get.GetRequest;
@@ -43,13 +41,12 @@ import org.mongojack.WriteResult;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.util.Map;
-import java.util.SortedSet;
-import java.util.concurrent.ExecutionException;
-
 import javax.annotation.Nullable;
 import javax.inject.Inject;
 import javax.inject.Singleton;
+import java.util.Map;
+import java.util.SortedSet;
+import java.util.concurrent.ExecutionException;
 
 import static java.util.Objects.requireNonNull;
 
@@ -191,6 +188,11 @@ public class EsIndexRangeService implements IndexRangeService {
 
     @Override
     public WriteResult<MongoIndexRange, ObjectId> save(IndexRange indexRange) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public boolean remove(String index) {
         throw new UnsupportedOperationException();
     }
 

--- a/graylog2-server/src/main/java/org/graylog2/indexer/ranges/IndexRangeService.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/ranges/IndexRangeService.java
@@ -32,6 +32,8 @@ public interface IndexRangeService {
 
     WriteResult<MongoIndexRange, ObjectId> save(IndexRange indexRange);
 
+    boolean remove(String index);
+
     IndexRange calculateRange(String index);
     IndexRange createUnknownRange(String index);
 }

--- a/graylog2-server/src/main/java/org/graylog2/indexer/ranges/LegacyMongoIndexRangeService.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/ranges/LegacyMongoIndexRangeService.java
@@ -17,11 +17,9 @@
 package org.graylog2.indexer.ranges;
 
 import com.google.common.collect.ImmutableSortedSet;
-
 import com.mongodb.BasicDBList;
 import com.mongodb.BasicDBObject;
 import com.mongodb.DBObject;
-
 import org.bson.types.ObjectId;
 import org.graylog2.database.MongoConnection;
 import org.graylog2.database.NotFoundException;
@@ -32,10 +30,9 @@ import org.mongojack.WriteResult;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import javax.inject.Inject;
 import java.util.List;
 import java.util.SortedSet;
-
-import javax.inject.Inject;
 
 import static com.google.common.base.MoreObjects.firstNonNull;
 
@@ -104,6 +101,11 @@ public class LegacyMongoIndexRangeService extends PersistedServiceImpl implement
 
     @Override
     public WriteResult<MongoIndexRange, ObjectId> save(IndexRange indexRange) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public boolean remove(String index) {
         throw new UnsupportedOperationException();
     }
 

--- a/graylog2-server/src/main/java/org/graylog2/indexer/ranges/MongoIndexRangeService.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/ranges/MongoIndexRangeService.java
@@ -160,7 +160,7 @@ public class MongoIndexRangeService implements IndexRangeService {
 
     @Override
     public WriteResult<MongoIndexRange, ObjectId> save(IndexRange indexRange) {
-        collection.remove(DBQuery.in(IndexRange.FIELD_INDEX_NAME, indexRange.indexName()));
+        remove(indexRange.indexName());
         final WriteResult<MongoIndexRange, ObjectId> save = collection.save(MongoIndexRange.create(indexRange));
         return save;
     }
@@ -195,8 +195,7 @@ public class MongoIndexRangeService implements IndexRangeService {
                 continue;
             }
             LOG.debug("Index \"{}\" has been closed. Removing index range.");
-            final WriteResult<MongoIndexRange, ObjectId> remove = collection.remove(DBQuery.in(IndexRange.FIELD_INDEX_NAME, index));
-            if (remove.getN() > 0) {
+            if (remove(index)) {
                 auditEventSender.success(AuditActor.system(nodeId), ES_INDEX_RANGE_DELETE, ImmutableMap.of("index_name", index));
             }
         }

--- a/graylog2-server/src/main/java/org/graylog2/indexer/ranges/MongoIndexRangeService.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/ranges/MongoIndexRangeService.java
@@ -165,6 +165,12 @@ public class MongoIndexRangeService implements IndexRangeService {
         return save;
     }
 
+    @Override
+    public boolean remove(String index) {
+        final WriteResult<MongoIndexRange, ObjectId> remove = collection.remove(DBQuery.in(IndexRange.FIELD_INDEX_NAME, index));
+        return remove.getN() > 0;
+    }
+
     @Subscribe
     @AllowConcurrentEvents
     public void handleIndexDeletion(IndicesDeletedEvent event) {
@@ -174,8 +180,7 @@ public class MongoIndexRangeService implements IndexRangeService {
                 continue;
             }
             LOG.debug("Index \"{}\" has been deleted. Removing index range.");
-            final WriteResult<MongoIndexRange, ObjectId> remove = collection.remove(DBQuery.in(IndexRange.FIELD_INDEX_NAME, index));
-            if (remove.getN() > 0) {
+            if (remove(index)) {
                 auditEventSender.success(AuditActor.system(nodeId), ES_INDEX_RANGE_DELETE, ImmutableMap.of("index_name", index));
             }
         }

--- a/graylog2-server/src/test/java/org/graylog2/indexer/ranges/MongoIndexRangeServiceTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/indexer/ranges/MongoIndexRangeServiceTest.java
@@ -245,6 +245,17 @@ public class MongoIndexRangeServiceTest {
 
     @Test
     @UsingDataSet(loadStrategy = LoadStrategyEnum.CLEAN_INSERT)
+    public void remove() throws Exception {
+        assertThat(indexRangeService.findAll()).hasSize(2);
+
+        assertThat(indexRangeService.remove("graylog_1")).isTrue();
+        assertThat(indexRangeService.remove("graylog_1")).isFalse();
+
+        assertThat(indexRangeService.findAll()).hasSize(1);
+    }
+
+    @Test
+    @UsingDataSet(loadStrategy = LoadStrategyEnum.CLEAN_INSERT)
     public void testHandleIndexDeletion() throws Exception {
         when(indexSetRegistry.isManagedIndex("graylog_1")).thenReturn(true);
 


### PR DESCRIPTION
The old index set cleanup job left the index ranges for the deleted indices behind.

Fixes #3308 