### PR TITLE
Escape search query when using surrounding search

### DIFF
--- a/graylog2-web-interface/src/stores/search/SearchStore.ts
+++ b/graylog2-web-interface/src/stores/search/SearchStore.ts
@@ -352,7 +352,7 @@ class SearchStore {
 
       var query = Object.keys(filter)
         .filter((key) => filter[key])
-        .map((key) => `${key}:"${filter[key]}"`)
+        .map((key) => `${key}:"${SearchStore.escape(filter[key])}"`)
         .join(' AND ');
 
       var params = {


### PR DESCRIPTION
Fixes problems when using file paths that need to be escaped.

Fixes #3287
