### PR TITLE
Close idle GELF HTTP connections after a timeout

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/inputs/transports/HttpTransport.java
+++ b/graylog2-server/src/main/java/org/graylog2/inputs/transports/HttpTransport.java
@@ -115,7 +115,7 @@ public class HttpTransport extends AbstractTcpTransport {
         this.timer = timer;
         int maxChunkSize = configuration.intIsSet(CK_MAX_CHUNK_SIZE) ? configuration.getInt(CK_MAX_CHUNK_SIZE) : DEFAULT_MAX_CHUNK_SIZE;
         this.maxChunkSize = maxChunkSize <= 0 ? DEFAULT_MAX_CHUNK_SIZE : maxChunkSize;
-        this.idleWriterTimeout = configuration.intIsSet(CK_MAX_CHUNK_SIZE) ? configuration.getInt(CK_IDLE_WRITER_TIMEOUT, DEFAULT_IDLE_WRITER_TIMEOUT) : DEFAULT_IDLE_WRITER_TIMEOUT;
+        this.idleWriterTimeout = configuration.intIsSet(CK_IDLE_WRITER_TIMEOUT) ? configuration.getInt(CK_IDLE_WRITER_TIMEOUT, DEFAULT_IDLE_WRITER_TIMEOUT) : DEFAULT_IDLE_WRITER_TIMEOUT;
     }
 
     private static Executor executorService(final String executorName, final String threadNameFormat, final MetricRegistry metricRegistry) {

--- a/graylog2-server/src/main/java/org/graylog2/inputs/transports/HttpTransport.java
+++ b/graylog2-server/src/main/java/org/graylog2/inputs/transports/HttpTransport.java
@@ -221,7 +221,8 @@ public class HttpTransport extends AbstractTcpTransport {
                                         "Idle writer timeout",
                                         DEFAULT_IDLE_WRITER_TIMEOUT,
                                         "The server closes the connection after the given time in seconds after the last client write request. (use 0 to disable)",
-                                        ConfigurationField.Optional.OPTIONAL));
+                                        ConfigurationField.Optional.OPTIONAL,
+                                        NumberField.Attribute.ONLY_POSITIVE));
             return r;
         }
     }


### PR DESCRIPTION
This introduces a new GELF HTTP input option to configure a timeout for idle HTTP connections.

Some clients (e.g. browsers) might not close the HTTP connection properly and effectively cause a file descriptor leak in the server. The default for all existing and new GELF HTTP inputs is 60 seconds.

Fixes #3223
