### PR TITLE
Show stats for each index set on the index sets overview page

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/indexer/IndexSetStatsCreator.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/IndexSetStatsCreator.java
@@ -1,0 +1,49 @@
+/**
+ * This file is part of Graylog.
+ *
+ * Graylog is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.graylog2.indexer;
+
+import org.elasticsearch.action.admin.indices.stats.IndexStats;
+import org.graylog2.indexer.indices.Indices;
+import org.graylog2.rest.resources.system.indexer.responses.IndexSetStats;
+
+import javax.inject.Inject;
+import java.util.Map;
+import java.util.Set;
+
+public class IndexSetStatsCreator {
+    private final Indices indices;
+
+    @Inject
+    public IndexSetStatsCreator(final Indices indices) {
+        this.indices = indices;
+    }
+
+    public IndexSetStats getForIndexSet(final IndexSet indexSet) {
+        final Map<String, IndexStats> docCounts = indices.getAllDocCounts(indexSet);
+        final Set<String> closedIndices = indices.getClosedIndices(indexSet);
+        final long documents = docCounts.values()
+                .stream()
+                .mapToLong(indexStats -> indexStats.getPrimaries().getDocs().getCount())
+                .sum();
+        final long size = docCounts.values()
+                .stream()
+                .mapToLong(indexStats -> indexStats.getPrimaries().getStore().sizeInBytes())
+                .sum();
+
+        return IndexSetStats.create(docCounts.size() + closedIndices.size(), documents, size);
+    }
+}

--- a/graylog2-server/src/main/java/org/graylog2/rest/resources/system/indexer/IndexSetsResource.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/resources/system/indexer/IndexSetsResource.java
@@ -29,6 +29,7 @@ import org.graylog2.audit.AuditEventTypes;
 import org.graylog2.audit.jersey.AuditEvent;
 import org.graylog2.indexer.IndexSet;
 import org.graylog2.indexer.IndexSetRegistry;
+import org.graylog2.indexer.IndexSetStatsCreator;
 import org.graylog2.indexer.IndexSetValidator;
 import org.graylog2.indexer.indexset.DefaultIndexSetConfig;
 import org.graylog2.indexer.indexset.IndexSetConfig;
@@ -37,6 +38,7 @@ import org.graylog2.indexer.indices.jobs.IndexSetCleanupJob;
 import org.graylog2.plugin.cluster.ClusterConfigService;
 import org.graylog2.rest.resources.system.indexer.requests.IndexSetUpdateRequest;
 import org.graylog2.rest.resources.system.indexer.responses.IndexSetResponse;
+import org.graylog2.rest.resources.system.indexer.responses.IndexSetStats;
 import org.graylog2.rest.resources.system.indexer.responses.IndexSetSummary;
 import org.graylog2.shared.rest.resources.RestResource;
 import org.graylog2.shared.security.RestPermissions;
@@ -63,7 +65,9 @@ import javax.ws.rs.Produces;
 import javax.ws.rs.QueryParam;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
+import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -81,6 +85,7 @@ public class IndexSetsResource extends RestResource {
     private final IndexSetRegistry indexSetRegistry;
     private final IndexSetValidator indexSetValidator;
     private final IndexSetCleanupJob.Factory indexSetCleanupJobFactory;
+    private final IndexSetStatsCreator indexSetStatsCreator;
     private final ClusterConfigService clusterConfigService;
     private final SystemJobManager systemJobManager;
 
@@ -89,12 +94,14 @@ public class IndexSetsResource extends RestResource {
                              final IndexSetRegistry indexSetRegistry,
                              final IndexSetValidator indexSetValidator,
                              final IndexSetCleanupJob.Factory indexSetCleanupJobFactory,
+                             final IndexSetStatsCreator indexSetStatsCreator,
                              final ClusterConfigService clusterConfigService,
                              final SystemJobManager systemJobManager) {
         this.indexSetService = requireNonNull(indexSetService);
         this.indexSetRegistry = indexSetRegistry;
         this.indexSetValidator = indexSetValidator;
         this.indexSetCleanupJobFactory = requireNonNull(indexSetCleanupJobFactory);
+        this.indexSetStatsCreator = indexSetStatsCreator;
         this.clusterConfigService = clusterConfigService;
         this.systemJobManager = systemJobManager;
     }
@@ -108,7 +115,9 @@ public class IndexSetsResource extends RestResource {
     public IndexSetResponse list(@ApiParam(name = "skip", value = "The number of elements to skip (offset).", required = true)
                                  @QueryParam("skip") @DefaultValue("0") int skip,
                                  @ApiParam(name = "limit", value = "The maximum number of elements to return.", required = true)
-                                 @QueryParam("limit") @DefaultValue("0") int limit) {
+                                 @QueryParam("limit") @DefaultValue("0") int limit,
+                                 @ApiParam(name = "stats", value = "Include index set stats.")
+                                 @QueryParam("stats") @DefaultValue("false") boolean computeStats) {
         final IndexSetConfig defaultIndexSet = indexSetService.getDefault();
 
         List<IndexSetSummary> indexSets;
@@ -133,7 +142,15 @@ public class IndexSetsResource extends RestResource {
             count = indexSets.size();
         }
 
-        return IndexSetResponse.create(count, indexSets);
+        final Map<String, IndexSetStats> stats;
+        if (computeStats) {
+            stats = indexSetRegistry.getAllIndexSets().stream()
+                    .collect(Collectors.toMap(indexSet -> indexSet.getConfig().id(), indexSetStatsCreator::getForIndexSet));
+        } else {
+            stats = Collections.emptyMap();
+        }
+
+        return IndexSetResponse.create(count, indexSets, stats);
     }
 
     @GET

--- a/graylog2-server/src/main/java/org/graylog2/rest/resources/system/indexer/responses/IndexSetStats.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/resources/system/indexer/responses/IndexSetStats.java
@@ -20,28 +20,27 @@ import com.fasterxml.jackson.annotation.JsonAutoDetect;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.auto.value.AutoValue;
-import org.graylog.autovalue.WithBeanGetter;
-
-import java.util.List;
-import java.util.Map;
 
 @JsonAutoDetect
 @AutoValue
-@WithBeanGetter
-public abstract class IndexSetResponse {
-    @JsonProperty("total")
-    public abstract int total();
+public abstract class IndexSetStats {
+    private static final String FIELD_INDICES = "indices";
+    private static final String FIELD_DOCUMENTS = "documents";
+    private static final String FIELD_SIZE = "size";
 
-    @JsonProperty("index_sets")
-    public abstract List<IndexSetSummary> indexSets();
+    @JsonProperty(FIELD_INDICES)
+    public abstract long indices();
 
-    @JsonProperty("stats")
-    public abstract Map<String, IndexSetStats> stats();
+    @JsonProperty(FIELD_DOCUMENTS)
+    public abstract long documents();
+
+    @JsonProperty(FIELD_SIZE)
+    public abstract long size();
 
     @JsonCreator
-    public static IndexSetResponse create(@JsonProperty("total") int total,
-                                          @JsonProperty("index_sets") List<IndexSetSummary> ranges,
-                                          @JsonProperty("stats") Map<String, IndexSetStats> stats) {
-        return new AutoValue_IndexSetResponse(total, ranges, stats);
+    public static IndexSetStats create(@JsonProperty(FIELD_INDICES) long indices,
+                                       @JsonProperty(FIELD_DOCUMENTS) long documents,
+                                       @JsonProperty(FIELD_SIZE) long size) {
+        return new AutoValue_IndexSetStats(indices, documents, size);
     }
 }

--- a/graylog2-server/src/test/java/org/graylog2/rest/resources/system/indexer/IndexSetsResourceTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/rest/resources/system/indexer/IndexSetsResourceTest.java
@@ -19,6 +19,7 @@ package org.graylog2.rest.resources.system.indexer;
 import org.apache.shiro.subject.Subject;
 import org.graylog2.indexer.IndexSet;
 import org.graylog2.indexer.IndexSetRegistry;
+import org.graylog2.indexer.IndexSetStatsCreator;
 import org.graylog2.indexer.IndexSetValidator;
 import org.graylog2.indexer.indexset.IndexSetConfig;
 import org.graylog2.indexer.indexset.IndexSetService;
@@ -76,6 +77,8 @@ public class IndexSetsResourceTest {
     @Mock
     private IndexSetCleanupJob.Factory indexSetCleanupJobFactory;
     @Mock
+    private IndexSetStatsCreator indexSetStatsCreator;
+    @Mock
     private SystemJobManager systemJobManager;
     @Mock
     private ClusterConfigService clusterConfigService;
@@ -86,7 +89,7 @@ public class IndexSetsResourceTest {
 
     @Test
     public void list() {
-        final IndexSetsResource indexSetsResource = new TestResource(indexSetService, indexSetRegistry, indexSetValidator, indexSetCleanupJobFactory, clusterConfigService, systemJobManager, true);
+        final IndexSetsResource indexSetsResource = new TestResource(indexSetService, indexSetRegistry, indexSetValidator, indexSetCleanupJobFactory, indexSetStatsCreator, clusterConfigService, systemJobManager, true);
         final IndexSetConfig indexSetConfig = IndexSetConfig.create(
                 "id",
                 "title",
@@ -107,7 +110,7 @@ public class IndexSetsResourceTest {
         );
         when(indexSetService.findAll()).thenReturn(Collections.singletonList(indexSetConfig));
 
-        final IndexSetResponse list = indexSetsResource.list(0, 0);
+        final IndexSetResponse list = indexSetsResource.list(0, 0, false);
 
         verify(indexSetService, times(1)).findAll();
         verify(indexSetService, times(1)).getDefault();
@@ -119,7 +122,7 @@ public class IndexSetsResourceTest {
 
     @Test
     public void listDenied() {
-        final IndexSetsResource indexSetsResource = new TestResource(indexSetService, indexSetRegistry, indexSetValidator, indexSetCleanupJobFactory, clusterConfigService, systemJobManager, false);
+        final IndexSetsResource indexSetsResource = new TestResource(indexSetService, indexSetRegistry, indexSetValidator, indexSetCleanupJobFactory, indexSetStatsCreator, clusterConfigService, systemJobManager, false);
         final IndexSetConfig indexSetConfig = IndexSetConfig.create(
                 "id",
                 "title",
@@ -140,7 +143,7 @@ public class IndexSetsResourceTest {
         );
         when(indexSetService.findAll()).thenReturn(Collections.singletonList(indexSetConfig));
 
-        final IndexSetResponse list = indexSetsResource.list(0, 0);
+        final IndexSetResponse list = indexSetsResource.list(0, 0, false);
 
         verify(indexSetService, times(1)).findAll();
         verify(indexSetService, times(1)).getDefault();
@@ -152,10 +155,10 @@ public class IndexSetsResourceTest {
 
     @Test
     public void list0() {
-        final IndexSetsResource indexSetsResource = new TestResource(indexSetService, indexSetRegistry, indexSetValidator, indexSetCleanupJobFactory, clusterConfigService, systemJobManager, true);
+        final IndexSetsResource indexSetsResource = new TestResource(indexSetService, indexSetRegistry, indexSetValidator, indexSetCleanupJobFactory, indexSetStatsCreator, clusterConfigService, systemJobManager, true);
         when(indexSetService.findAll()).thenReturn(Collections.emptyList());
 
-        final IndexSetResponse list = indexSetsResource.list(0, 0);
+        final IndexSetResponse list = indexSetsResource.list(0, 0, false);
 
         verify(indexSetService, times(1)).findAll();
         verify(indexSetService, times(1)).getDefault();
@@ -167,7 +170,7 @@ public class IndexSetsResourceTest {
 
     @Test
     public void get() {
-        final IndexSetsResource indexSetsResource = new TestResource(indexSetService, indexSetRegistry, indexSetValidator, indexSetCleanupJobFactory, clusterConfigService, systemJobManager, true);
+        final IndexSetsResource indexSetsResource = new TestResource(indexSetService, indexSetRegistry, indexSetValidator, indexSetCleanupJobFactory, indexSetStatsCreator, clusterConfigService, systemJobManager, true);
         final IndexSetConfig indexSetConfig = IndexSetConfig.create(
                 "id",
                 "title",
@@ -198,7 +201,7 @@ public class IndexSetsResourceTest {
 
     @Test
     public void get0() {
-        final IndexSetsResource indexSetsResource = new TestResource(indexSetService, indexSetRegistry, indexSetValidator, indexSetCleanupJobFactory, clusterConfigService, systemJobManager, true);
+        final IndexSetsResource indexSetsResource = new TestResource(indexSetService, indexSetRegistry, indexSetValidator, indexSetCleanupJobFactory, indexSetStatsCreator, clusterConfigService, systemJobManager, true);
         when(indexSetService.get("id")).thenReturn(Optional.empty());
 
         expectedException.expect(NotFoundException.class);
@@ -215,7 +218,7 @@ public class IndexSetsResourceTest {
 
     @Test
     public void getDenied() {
-        final IndexSetsResource indexSetsResource = new TestResource(indexSetService, indexSetRegistry, indexSetValidator, indexSetCleanupJobFactory, clusterConfigService, systemJobManager, false);
+        final IndexSetsResource indexSetsResource = new TestResource(indexSetService, indexSetRegistry, indexSetValidator, indexSetCleanupJobFactory, indexSetStatsCreator, clusterConfigService, systemJobManager, false);
 
         expectedException.expect(ForbiddenException.class);
         expectedException.expectMessage("Not authorized to access resource id <id>");
@@ -229,7 +232,7 @@ public class IndexSetsResourceTest {
 
     @Test
     public void save() {
-        final IndexSetsResource indexSetsResource = new TestResource(indexSetService, indexSetRegistry, indexSetValidator, indexSetCleanupJobFactory, clusterConfigService, systemJobManager, true);
+        final IndexSetsResource indexSetsResource = new TestResource(indexSetService, indexSetRegistry, indexSetValidator, indexSetCleanupJobFactory, indexSetStatsCreator, clusterConfigService, systemJobManager, true);
         final IndexSetConfig indexSetConfig = IndexSetConfig.create(
                 "title",
                 "description",
@@ -264,7 +267,7 @@ public class IndexSetsResourceTest {
     @Test
     @Ignore("Currently doesn't work with @RequiresPermissions")
     public void saveDenied() {
-        final IndexSetsResource indexSetsResource = new TestResource(indexSetService, indexSetRegistry, indexSetValidator, indexSetCleanupJobFactory, clusterConfigService, systemJobManager, false);
+        final IndexSetsResource indexSetsResource = new TestResource(indexSetService, indexSetRegistry, indexSetValidator, indexSetCleanupJobFactory, indexSetStatsCreator, clusterConfigService, systemJobManager, false);
         final IndexSetConfig indexSetConfig = IndexSetConfig.create(
                 "title",
                 "description",
@@ -295,7 +298,7 @@ public class IndexSetsResourceTest {
 
     @Test
     public void update() {
-        final IndexSetsResource indexSetsResource = new TestResource(indexSetService, indexSetRegistry, indexSetValidator, indexSetCleanupJobFactory, clusterConfigService, systemJobManager, true);
+        final IndexSetsResource indexSetsResource = new TestResource(indexSetService, indexSetRegistry, indexSetValidator, indexSetCleanupJobFactory, indexSetStatsCreator, clusterConfigService, systemJobManager, true);
         final IndexSetConfig indexSetConfig = IndexSetConfig.create(
                 "id",
                 "new title",
@@ -337,7 +340,7 @@ public class IndexSetsResourceTest {
 
     @Test
     public void updateIdMismatch() {
-        final IndexSetsResource indexSetsResource = new TestResource(indexSetService, indexSetRegistry, indexSetValidator, indexSetCleanupJobFactory, clusterConfigService, systemJobManager, true);
+        final IndexSetsResource indexSetsResource = new TestResource(indexSetService, indexSetRegistry, indexSetValidator, indexSetCleanupJobFactory, indexSetStatsCreator, clusterConfigService, systemJobManager, true);
         final IndexSetConfig indexSetConfig = IndexSetConfig.create(
                 "id",
                 "new title",
@@ -369,7 +372,7 @@ public class IndexSetsResourceTest {
 
     @Test
     public void updateDenied() {
-        final IndexSetsResource indexSetsResource = new TestResource(indexSetService, indexSetRegistry, indexSetValidator, indexSetCleanupJobFactory, clusterConfigService, systemJobManager, false);
+        final IndexSetsResource indexSetsResource = new TestResource(indexSetService, indexSetRegistry, indexSetValidator, indexSetCleanupJobFactory, indexSetStatsCreator, clusterConfigService, systemJobManager, false);
         final IndexSetConfig indexSetConfig = IndexSetConfig.create(
                 "id",
                 "title",
@@ -401,7 +404,7 @@ public class IndexSetsResourceTest {
 
     @Test
     public void delete() throws Exception {
-        final IndexSetsResource indexSetsResource = new TestResource(indexSetService, indexSetRegistry, indexSetValidator, indexSetCleanupJobFactory, clusterConfigService, systemJobManager, true);
+        final IndexSetsResource indexSetsResource = new TestResource(indexSetService, indexSetRegistry, indexSetValidator, indexSetCleanupJobFactory, indexSetStatsCreator, clusterConfigService, systemJobManager, true);
         final IndexSet indexSet = mock(IndexSet.class);
         final IndexSetConfig indexSetConfig = mock(IndexSetConfig.class);
 
@@ -422,7 +425,7 @@ public class IndexSetsResourceTest {
 
     @Test
     public void delete0() throws Exception {
-        final IndexSetsResource indexSetsResource = new TestResource(indexSetService, indexSetRegistry, indexSetValidator, indexSetCleanupJobFactory, clusterConfigService, systemJobManager, true);
+        final IndexSetsResource indexSetsResource = new TestResource(indexSetService, indexSetRegistry, indexSetValidator, indexSetCleanupJobFactory, indexSetStatsCreator, clusterConfigService, systemJobManager, true);
         final IndexSet indexSet = mock(IndexSet.class);
         final IndexSetConfig indexSetConfig = mock(IndexSetConfig.class);
 
@@ -445,7 +448,7 @@ public class IndexSetsResourceTest {
 
     @Test
     public void deleteDefaultIndexSet() throws Exception {
-        final IndexSetsResource indexSetsResource = new TestResource(indexSetService, indexSetRegistry, indexSetValidator, indexSetCleanupJobFactory, clusterConfigService, systemJobManager, true);
+        final IndexSetsResource indexSetsResource = new TestResource(indexSetService, indexSetRegistry, indexSetValidator, indexSetCleanupJobFactory, indexSetStatsCreator, clusterConfigService, systemJobManager, true);
         final IndexSet indexSet = mock(IndexSet.class);
         final IndexSetConfig indexSetConfig = mock(IndexSetConfig.class);
 
@@ -467,7 +470,7 @@ public class IndexSetsResourceTest {
 
     @Test
     public void deleteDenied() {
-        final IndexSetsResource indexSetsResource = new TestResource(indexSetService, indexSetRegistry, indexSetValidator, indexSetCleanupJobFactory, clusterConfigService, systemJobManager, false);
+        final IndexSetsResource indexSetsResource = new TestResource(indexSetService, indexSetRegistry, indexSetValidator, indexSetCleanupJobFactory, indexSetStatsCreator, clusterConfigService, systemJobManager, false);
 
         expectedException.expect(ForbiddenException.class);
         expectedException.expectMessage("Not authorized to access resource id <id>");
@@ -482,8 +485,8 @@ public class IndexSetsResourceTest {
     private static class TestResource extends IndexSetsResource {
         private final boolean permitted;
 
-        TestResource(IndexSetService indexSetService, IndexSetRegistry indexSetRegistry, IndexSetValidator indexSetValidator, IndexSetCleanupJob.Factory indexSetCleanupJobFactory, ClusterConfigService clusterConfigService, SystemJobManager systemJobManager, boolean permitted) {
-            super(indexSetService, indexSetRegistry, indexSetValidator, indexSetCleanupJobFactory, clusterConfigService, systemJobManager);
+        TestResource(IndexSetService indexSetService, IndexSetRegistry indexSetRegistry, IndexSetValidator indexSetValidator, IndexSetCleanupJob.Factory indexSetCleanupJobFactory, IndexSetStatsCreator indexSetStatsCreator, ClusterConfigService clusterConfigService, SystemJobManager systemJobManager, boolean permitted) {
+            super(indexSetService, indexSetRegistry, indexSetValidator, indexSetCleanupJobFactory, indexSetStatsCreator, clusterConfigService, systemJobManager);
             this.permitted = permitted;
         }
 

--- a/graylog2-web-interface/src/components/indices/IndexSetsComponent.jsx
+++ b/graylog2-web-interface/src/components/indices/IndexSetsComponent.jsx
@@ -5,6 +5,8 @@ import { Col, Button, Label, DropdownButton, MenuItem } from 'react-bootstrap';
 
 import { EntityList, EntityListItem, PaginatedList, Spinner } from 'components/common';
 import Routes from 'routing/Routes';
+import StringUtils from 'util/StringUtils';
+import NumberUtils from 'util/NumberUtils';
 
 import { IndexSetDeletionForm, IndexSetDetails } from 'components/indices';
 
@@ -22,7 +24,7 @@ const IndexSetsComponent = React.createClass({
   loadData(pageNo, limit) {
     this.currentPageNo = pageNo;
     this.currentPageSize = limit;
-    IndexSetsActions.listPaginated((pageNo - 1) * limit, limit);
+    IndexSetsActions.listPaginated((pageNo - 1) * limit, limit, true);
   },
 
   // Stores the current page and page size to be able to reload the current page
@@ -92,10 +94,20 @@ const IndexSetsComponent = React.createClass({
       description += `${description.endsWith('.') ? '' : '.'} Graylog will use this index set by default.`;
     }
 
+    let statsString;
+    const stats = this.state.indexSetStats[indexSet.id];
+    if (stats) {
+      const indices = `${NumberUtils.formatNumber(stats.indices)} ${StringUtils.pluralize(stats.indices, 'index', 'indices')}`;
+      const documents = `${NumberUtils.formatNumber(stats.documents)} ${StringUtils.pluralize(stats.documents, 'document', 'documents')}`;
+      const size = NumberUtils.formatBytes(stats.size);
+
+      statsString = `${indices}, ${documents}, ${size}`;
+    }
+
     return (
       <EntityListItem key={`index-set-${indexSet.id}`}
                       title={indexSetTitle}
-                      titleSuffix={isDefault}
+                      titleSuffix={<span>{statsString} {isDefault}</span>}
                       description={description}
                       actions={actions}
                       contentRow={content} />

--- a/graylog2-web-interface/src/pages/StreamsPage.jsx
+++ b/graylog2-web-interface/src/pages/StreamsPage.jsx
@@ -27,7 +27,7 @@ const StreamsPage = React.createClass({
     };
   },
   componentDidMount() {
-    IndexSetsActions.list();
+    IndexSetsActions.list(false);
   },
   _isLoading() {
     return !this.state.currentUser || !this.state.indexSets;

--- a/graylog2-web-interface/src/routing/ApiRoutes.js
+++ b/graylog2-web-interface/src/routing/ApiRoutes.js
@@ -83,8 +83,8 @@ const ApiRoutes = {
     rebuildSingle: (index) => { return { url: `/system/indices/ranges/${index}/rebuild` }; },
   },
   IndexSetsApiController: {
-    list: () => { return { url: '/system/indices/index_sets' }; },
-    listPaginated: (skip, limit) => { return { url: `/system/indices/index_sets?skip=${skip}&limit=${limit}` }; },
+    list: (stats) => { return { url: `/system/indices/index_sets?stats=${stats}` }; },
+    listPaginated: (skip, limit, stats) => { return { url: `/system/indices/index_sets?skip=${skip}&limit=${limit}&stats=${stats}` }; },
     get: (indexSetId) => { return { url: `/system/indices/index_sets/${indexSetId}` }; },
     create: () => { return { url: '/system/indices/index_sets' }; },
     delete: (indexSetId, deleteIndices) => { return { url: `/system/indices/index_sets/${indexSetId}?delete_indices=${deleteIndices}` }; },

--- a/graylog2-web-interface/src/stores/indices/IndexSetsStore.jsx
+++ b/graylog2-web-interface/src/stores/indices/IndexSetsStore.jsx
@@ -12,12 +12,16 @@ const IndexSetsActions = ActionsProvider.getActions('IndexSets');
 const IndexSetsStore = Reflux.createStore({
   listenables: [IndexSetsActions],
 
-  list() {
-    const url = URLUtils.qualifyUrl(ApiRoutes.IndexSetsApiController.list().url);
+  list(stats) {
+    const url = URLUtils.qualifyUrl(ApiRoutes.IndexSetsApiController.list(stats).url);
     const promise = fetch('GET', url);
     promise
       .then(
-        response => this.trigger({ indexSetsCount: response.total, indexSets: response.index_sets }),
+        response => this.trigger({
+          indexSetsCount: response.total,
+          indexSets: response.index_sets,
+          indexSetStats: response.stats,
+        }),
         error => {
           UserNotification.error(`Fetching index sets list failed: ${error.message}`,
             'Could not retrieve index sets.');
@@ -26,12 +30,16 @@ const IndexSetsStore = Reflux.createStore({
     IndexSetsActions.list.promise(promise);
   },
 
-  listPaginated(skip, limit) {
-    const url = URLUtils.qualifyUrl(ApiRoutes.IndexSetsApiController.listPaginated(skip, limit).url);
+  listPaginated(skip, limit, stats) {
+    const url = URLUtils.qualifyUrl(ApiRoutes.IndexSetsApiController.listPaginated(skip, limit, stats).url);
     const promise = fetch('GET', url);
     promise
       .then(
-        response => this.trigger({ indexSetsCount: response.total, indexSets: response.index_sets }),
+        response => this.trigger({
+          indexSetsCount: response.total,
+          indexSets: response.index_sets,
+          indexSetStats: response.stats,
+        }),
         error => {
           UserNotification.error(`Fetching index sets list failed: ${this._errorMessage(error)}`,
             'Could not retrieve index sets.');


### PR DESCRIPTION
Introduce a `stats` parameter in the `IndexSetsResource#list()` method to enable index set stats computation.

Switch UI code to use the `stats` flag where needed.

Refs #2880

![image](https://cloud.githubusercontent.com/assets/461/21777310/8f720f00-d69e-11e6-8d0d-ceea4e30c2a9.png)