### PR TITLE
Ignore deprecated "default" field in IndexSetConfig

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/indexer/indexset/IndexSetConfig.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/indexset/IndexSetConfig.java
@@ -18,6 +18,7 @@ package org.graylog2.indexer.indexset;
 
 import com.fasterxml.jackson.annotation.JsonAutoDetect;
 import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.auto.value.AutoValue;
 import com.google.common.collect.ComparisonChain;
@@ -38,6 +39,9 @@ import static com.google.common.base.Strings.isNullOrEmpty;
 @AutoValue
 @WithBeanGetter
 @JsonAutoDetect
+// Ignore deprecated "default" message field. Only relevant for Graylog 2.2.0-beta.[12] users.
+// TODO: Remove in Graylog 3.0.0
+@JsonIgnoreProperties({"default"})
 public abstract class IndexSetConfig implements Comparable<IndexSetConfig> {
     public static final String FIELD_INDEX_PREFIX = "index_prefix";
     public static final String FIELD_CREATION_DATE = "creation_date";


### PR DESCRIPTION
Due to the object graph construction in Guice, the migration removing the "default"
message field (V20161215163900_MoveIndexSetDefaultConfig) is being run *after* the
IndexSetConfig class has been created and some MongoDB queries have been run.

Since MongoJack is strict on the document fields, it will thus fail with an error
message such as:

    Caused by: com.fasterxml.jackson.databind.exc.UnrecognizedPropertyException: Unrecognized field "default" (class org.graylog2.indexer.indexset.AutoValue_IndexSetConfig), not marked as ignorable (17 known properties: "index_optimization_disabled", "index_template_name", "index_wildcard", "index_match_pattern", "rotation_strategy_class", "creation_date", "index_analyzer", "rotation_strategy", "shards", "title", "index_optimization_max_num_segments", "_id", "replicas", "description", "index_prefix", "retention_strategy_class", "retention_strategy"])
      at [Source: de.undercouch.bson4jackson.io.LittleEndianInputStream@deadbeef; pos: 683] (through reference chain: org.graylog2.indexer.indexset.AutoValue_IndexSetConfig["default"])

Fixes #3267