### PR TITLE
Not fetching/checking unnecessary streams in AlertScannerThread.

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/periodical/AlertScannerThread.java
+++ b/graylog2-server/src/main/java/org/graylog2/periodical/AlertScannerThread.java
@@ -17,12 +17,7 @@
 package org.graylog2.periodical;
 
 import org.graylog2.Configuration;
-import org.graylog2.alarmcallbacks.AlarmCallbackConfigurationService;
-import org.graylog2.alarmcallbacks.AlarmCallbackFactory;
-import org.graylog2.alarmcallbacks.AlarmCallbackHistoryService;
-import org.graylog2.alarmcallbacks.EmailAlarmCallback;
 import org.graylog2.alerts.AlertScanner;
-import org.graylog2.alerts.AlertService;
 import org.graylog2.initializers.IndexerSetupService;
 import org.graylog2.plugin.periodical.Periodical;
 import org.graylog2.plugin.streams.Stream;
@@ -42,14 +37,9 @@ public class AlertScannerThread extends Periodical {
     private final AlertScanner alertScanner;
 
     @Inject
-    public AlertScannerThread(final AlertService alertService,
-                              final StreamService streamService,
-                              final AlarmCallbackConfigurationService alarmCallbackConfigurationService,
-                              final AlarmCallbackFactory alarmCallbackFactory,
-                              final EmailAlarmCallback emailAlarmCallback,
+    public AlertScannerThread(final StreamService streamService,
                               final IndexerSetupService indexerSetupService,
                               final Configuration configuration,
-                              final AlarmCallbackHistoryService alarmCallbackHistoryService,
                               final AlertScanner alertScanner) {
         this.streamService = streamService;
         this.indexerSetupService = indexerSetupService;

--- a/graylog2-server/src/test/java/org/graylog2/streams/StreamServiceImplTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/streams/StreamServiceImplTest.java
@@ -1,3 +1,19 @@
+/**
+ * This file is part of Graylog.
+ *
+ * Graylog is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package org.graylog2.streams;
 
 import com.lordofthejars.nosqlunit.annotation.UsingDataSet;

--- a/graylog2-server/src/test/java/org/graylog2/streams/StreamServiceImplTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/streams/StreamServiceImplTest.java
@@ -1,0 +1,86 @@
+package org.graylog2.streams;
+
+import com.lordofthejars.nosqlunit.annotation.UsingDataSet;
+import com.lordofthejars.nosqlunit.core.LoadStrategyEnum;
+import com.lordofthejars.nosqlunit.mongodb.InMemoryMongoDb;
+import org.graylog2.alarmcallbacks.AlarmCallbackConfigurationService;
+import org.graylog2.alerts.AlertService;
+import org.graylog2.database.MongoConnectionRule;
+import org.graylog2.indexer.MongoIndexSet;
+import org.graylog2.indexer.indexset.IndexSetService;
+import org.graylog2.notifications.NotificationService;
+import org.graylog2.plugin.streams.Stream;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnit;
+import org.mockito.junit.MockitoRule;
+
+import java.util.List;
+
+import static com.lordofthejars.nosqlunit.mongodb.InMemoryMongoDb.InMemoryMongoRuleBuilder.newInMemoryMongoDbRule;
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class StreamServiceImplTest {
+    @ClassRule
+    public static final InMemoryMongoDb IN_MEMORY_MONGO_DB = newInMemoryMongoDbRule().build();
+
+    @Rule
+    public MongoConnectionRule mongoRule = MongoConnectionRule.build("test");
+    @Rule
+    public final MockitoRule mockitoRule = MockitoJUnit.rule();
+
+    @Mock
+    private StreamRuleService streamRuleService;
+    @Mock
+    private AlertService alertService;
+    @Mock
+    private OutputService outputService;
+    @Mock
+    private IndexSetService indexSetService;
+    @Mock
+    private MongoIndexSet.Factory factory;
+    @Mock
+    private NotificationService notificationService;
+    @Mock
+    private AlarmCallbackConfigurationService alarmCallbackConfigurationService;
+
+    private StreamService streamService;
+
+    @Before
+    public void setUp() throws Exception {
+        this.streamService = new StreamServiceImpl(mongoRule.getMongoConnection(), streamRuleService, alertService,
+            outputService, indexSetService, factory, notificationService, alarmCallbackConfigurationService);
+    }
+
+    @Test
+    @UsingDataSet(loadStrategy = LoadStrategyEnum.DELETE_ALL)
+    public void loadAllWithConfiguredAlertConditionsShouldNotFailWhenNoStreamsArePresent() {
+        final List<Stream> alertableStreams = this.streamService.loadAllWithConfiguredAlertConditions();
+
+        assertThat(alertableStreams)
+            .isNotNull()
+            .isEmpty();
+    }
+
+    @Test
+    @UsingDataSet(locations = "someStreamsWithoutAlertConditions.json", loadStrategy = LoadStrategyEnum.CLEAN_INSERT)
+    public void loadAllWithConfiguredAlertConditionsShouldReturnNoStreams() {
+        final List<Stream> alertableStreams = this.streamService.loadAllWithConfiguredAlertConditions();
+
+        assertThat(alertableStreams)
+            .isEmpty();
+    }
+
+    @Test
+    @UsingDataSet(locations = {"someStreamsWithoutAlertConditions.json", "someStreamsWithAlertConditions.json"}, loadStrategy = LoadStrategyEnum.CLEAN_INSERT)
+    public void loadAllWithConfiguredAlertConditionsShouldReturnStreams() {
+        final List<Stream> alertableStreams = this.streamService.loadAllWithConfiguredAlertConditions();
+
+        assertThat(alertableStreams)
+            .isNotEmpty()
+            .hasSize(2);
+    }
+}

--- a/graylog2-server/src/test/resources/org/graylog2/streams/someStreamsWithAlertConditions.json
+++ b/graylog2-server/src/test/resources/org/graylog2/streams/someStreamsWithAlertConditions.json
@@ -1,0 +1,65 @@
+{
+  "streams": [
+    {
+      "_id" : { "$oid" :"565f02223b0c25a537197af2" },
+      "creator_user_id" : "admin",
+      "index_set_id" : "586bb9288e82bf5e2c9ab68d",
+      "matching_type" : "AND",
+      "description" : "all logins",
+      "created_at" : { "$date" :"2015-12-02T14:37:22.252Z" },
+      "disabled" : true,
+      "alert_conditions" : [
+        {
+          "creator_user_id" : "admin",
+          "created_at" : "2016-03-11T13:43:11.536Z",
+          "id" : "fb501cf0-0be1-403e-9dda-b0a91bdf860b",
+          "type" : "message_count",
+          "parameters" : {
+            "grace" : 0,
+            "threshold_type" : "more",
+            "threshold" : 1,
+            "time" : 1,
+            "backlog" : 0
+          }
+        }
+      ],
+      "title" : "Logins",
+      "content_pack" : null
+    },
+    {
+      "_id" : { "$oid" :"559d14663b0cf26a15ee0f01" },
+      "creator_user_id" : "admin",
+      "outputs" : [
+        { "$oid" :"56d46466e3f1980e598b690c" }
+      ],
+      "index_set_id" : "586bb9288e82bf5e2c9ab68d",
+      "alert_receivers" : {
+        "users" : [
+          "dennis"
+        ]
+      },
+      "matching_type" : "AND",
+      "description" : "foodescription",
+      "created_at" : { "$date" :"2015-07-08T12:15:34.725Z" },
+      "disabled" : true,
+      "alert_conditions" : [
+        {
+          "creator_user_id" : "admin",
+          "created_at" : "2017-01-10T10:37:08.293Z",
+          "id" : "9afc875e-73b2-42fc-baf2-6c86e1eb2814",
+          "type" : "message_count",
+          "title" : "Max Messages",
+          "parameters" : {
+            "grace" : 0,
+            "threshold_type" : "MORE",
+            "threshold" : 100,
+            "time" : 5,
+            "backlog" : 0
+          }
+        }
+      ],
+      "title" : "footitle",
+      "content_pack" : null
+    }
+  ]
+}

--- a/graylog2-server/src/test/resources/org/graylog2/streams/someStreamsWithoutAlertConditions.json
+++ b/graylog2-server/src/test/resources/org/graylog2/streams/someStreamsWithoutAlertConditions.json
@@ -1,0 +1,38 @@
+{
+  "streams": [
+    {
+      "_id" : { "$oid": "5628f4503b0c5756a8eebc4d" },
+      "creator_user_id" : "admin",
+      "index_set_id" : "586bb9288e82bf5e2c9ab68d",
+      "matching_type" : "AND",
+      "description" : "All requests that were logged into the nginx access_log",
+      "created_at" : { "$date" : "2015-10-22T14:36:00.812Z" },
+      "disabled" : true,
+      "title" : "nginx requests",
+      "content_pack" : "552b90f6e4b08fd819039288"
+    },
+    {
+      "_id" : { "$oid": "5628f4503b0c5756a8eebc4f" },
+      "creator_user_id" : "admin",
+      "index_set_id" : "586bb9288e82bf5e2c9ab68d",
+      "matching_type" : "AND",
+      "description" : "All requests that were logged into the nginx access_log or nginx_error_log",
+      "created_at" : { "$date" : "2015-10-22T14:36:00.812Z" },
+      "disabled" : true,
+      "title" : "nginx",
+      "content_pack" : "552b90f6e4b08fd819039288"
+    },
+    {
+      "_id" : { "$oid": "5628f4503b0c5756a8eebc51" },
+      "creator_user_id" : "admin",
+      "index_set_id" : "586bb9288e82bf5e2c9ab68d",
+      "matching_type" : "AND",
+      "description" : "All requests that were answered with a HTTP code in the 400 range by nginx",
+      "created_at" : { "$date" : "2015-10-22T14:36:00.812Z" },
+      "disabled" : true,
+      "title" : "nginx HTTP 4XXs",
+      "content_pack" : "552b90f6e4b08fd819039288",
+      "alert_conditions" : []
+    }
+  ]
+}


### PR DESCRIPTION
## Description
## Motivation and Context
With this change, StreamService#loadAllWithConfiguredAlertConditions does not fetch streams without configured alert conditions, therefore AlertScannerThread does not check streams unnecessarily.

## How Has This Been Tested?
Added fixtures and unit tests for `StreamServiceImpl`.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
