### PR TITLE
Prevent setting default index set readonly.

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/rest/resources/system/indexer/IndexSetsResource.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/resources/system/indexer/IndexSetsResource.java
@@ -242,6 +242,10 @@ public class IndexSetsResource extends RestResource {
         final IndexSetConfig indexSet = indexSetService.get(id)
                 .orElseThrow(() -> new NotFoundException("Index set <" + id + "> does not exist"));
 
+        if (!indexSet.isWritable()) {
+            throw new ClientErrorException("Default index set must be writable.", Response.Status.CONFLICT);
+        }
+
         clusterConfigService.write(DefaultIndexSetConfig.create(indexSet.id()));
 
         final IndexSetConfig defaultIndexSet = indexSetService.getDefault();

--- a/graylog2-server/src/main/java/org/graylog2/rest/resources/system/indexer/IndexSetsResource.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/resources/system/indexer/IndexSetsResource.java
@@ -218,10 +218,16 @@ public class IndexSetsResource extends RestResource {
         final IndexSetConfig oldConfig = indexSetService.get(id)
                 .orElseThrow(() -> new NotFoundException("Index set <" + id + "> not found"));
 
-        final IndexSetConfig savedObject = indexSetService.save(updateRequest.toIndexSetConfig(oldConfig));
         final IndexSetConfig defaultIndexSet = indexSetService.getDefault();
+        final boolean isDefaultSet = oldConfig.equals(defaultIndexSet);
 
-        return IndexSetSummary.fromIndexSetConfig(savedObject, savedObject.equals(defaultIndexSet));
+        if (isDefaultSet && !updateRequest.isWritable()) {
+            throw new ClientErrorException("Default index set must be writable.", Response.Status.CONFLICT);
+        }
+
+        final IndexSetConfig savedObject = indexSetService.save(updateRequest.toIndexSetConfig(oldConfig));
+
+        return IndexSetSummary.fromIndexSetConfig(savedObject, isDefaultSet);
     }
 
     @PUT

--- a/graylog2-server/src/main/java/org/graylog2/rest/resources/system/indexer/IndexSetsResource.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/resources/system/indexer/IndexSetsResource.java
@@ -211,9 +211,6 @@ public class IndexSetsResource extends RestResource {
                                   @ApiParam(name = "Index set configuration", required = true)
                                   @Valid @NotNull IndexSetUpdateRequest updateRequest) {
         checkPermission(RestPermissions.INDEXSETS_EDIT, id);
-        if (!id.equals(updateRequest.id())) {
-            throw new ClientErrorException("Mismatch of IDs in URI path and payload", Response.Status.CONFLICT);
-        }
 
         final IndexSetConfig oldConfig = indexSetService.get(id)
                 .orElseThrow(() -> new NotFoundException("Index set <" + id + "> not found"));
@@ -225,7 +222,7 @@ public class IndexSetsResource extends RestResource {
             throw new ClientErrorException("Default index set must be writable.", Response.Status.CONFLICT);
         }
 
-        final IndexSetConfig savedObject = indexSetService.save(updateRequest.toIndexSetConfig(oldConfig));
+        final IndexSetConfig savedObject = indexSetService.save(updateRequest.toIndexSetConfig(id, oldConfig));
 
         return IndexSetSummary.fromIndexSetConfig(savedObject, isDefaultSet);
     }

--- a/graylog2-server/src/main/java/org/graylog2/rest/resources/system/indexer/requests/IndexSetUpdateRequest.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/resources/system/indexer/requests/IndexSetUpdateRequest.java
@@ -34,9 +34,6 @@ import javax.validation.constraints.NotNull;
 @JsonAutoDetect
 @JsonIgnoreProperties(ignoreUnknown = true)
 public abstract class IndexSetUpdateRequest {
-    @JsonProperty("id")
-    public abstract String id();
-
     @JsonProperty("title")
     @NotBlank
     public abstract String title();
@@ -81,8 +78,7 @@ public abstract class IndexSetUpdateRequest {
 
     @JsonCreator
     @JsonIgnoreProperties(ignoreUnknown = true)
-    public static IndexSetUpdateRequest create(@JsonProperty("id") String id,
-                                               @JsonProperty("title") @NotBlank String title,
+    public static IndexSetUpdateRequest create(@JsonProperty("title") @NotBlank String title,
                                                @JsonProperty("description") @Nullable String description,
                                                @JsonProperty("writable") boolean isWritable,
                                                @JsonProperty("shards") @Min(1) int shards,
@@ -93,14 +89,13 @@ public abstract class IndexSetUpdateRequest {
                                                @JsonProperty("retention_strategy") @NotNull RetentionStrategyConfig retentionStrategy,
                                                @JsonProperty("index_optimization_max_num_segments") @Min(1L) int indexOptimizationMaxNumSegments,
                                                @JsonProperty("index_optimization_disabled") boolean indexOptimizationDisabled) {
-        return new AutoValue_IndexSetUpdateRequest(id, title, description, isWritable, shards, replicas,
+        return new AutoValue_IndexSetUpdateRequest(title, description, isWritable, shards, replicas,
                 rotationStrategyClass, rotationStrategy, retentionStrategyClass, retentionStrategy,
                 indexOptimizationMaxNumSegments, indexOptimizationDisabled);
     }
 
     public static IndexSetUpdateRequest fromIndexSetConfig(IndexSetConfig indexSet) {
         return create(
-                indexSet.id(),
                 indexSet.title(),
                 indexSet.description(),
                 indexSet.isWritable(),
@@ -115,9 +110,9 @@ public abstract class IndexSetUpdateRequest {
 
     }
 
-    public IndexSetConfig toIndexSetConfig(IndexSetConfig oldConfig) {
+    public IndexSetConfig toIndexSetConfig(String id, IndexSetConfig oldConfig) {
         return IndexSetConfig.builder()
-                .id(id())
+                .id(id)
                 .title(title())
                 .description(description())
                 .isWritable(isWritable())

--- a/graylog2-server/src/test/java/org/graylog2/rest/resources/system/indexer/IndexSetsResourceTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/rest/resources/system/indexer/IndexSetsResourceTest.java
@@ -351,37 +351,6 @@ public class IndexSetsResourceTest {
     }
 
     @Test
-    public void updateIdMismatch() {
-        final IndexSetConfig indexSetConfig = IndexSetConfig.create(
-                "id",
-                "new title",
-                "description",
-                true,
-                "prefix",
-                1,
-                0,
-                MessageCountRotationStrategy.class.getCanonicalName(),
-                MessageCountRotationStrategyConfig.create(1000),
-                NoopRetentionStrategy.class.getCanonicalName(),
-                NoopRetentionStrategyConfig.create(1),
-                ZonedDateTime.of(2016, 10, 10, 12, 0, 0, 0, ZoneOffset.UTC),
-                "standard",
-                "index-template",
-                1,
-                false
-        );
-
-        expectedException.expect(ClientErrorException.class);
-        expectedException.expectMessage("Mismatch of IDs in URI path and payload");
-
-        try {
-            indexSetsResource.update("wrong-id", IndexSetUpdateRequest.fromIndexSetConfig(indexSetConfig));
-        } finally {
-            verifyZeroInteractions(indexSetService);
-        }
-    }
-
-    @Test
     public void updateDenied() {
         notPermitted();
         final IndexSetConfig indexSetConfig = IndexSetConfig.create(

--- a/graylog2-web-interface/src/components/indices/IndexSetsComponent.jsx
+++ b/graylog2-web-interface/src/components/indices/IndexSetsComponent.jsx
@@ -67,7 +67,9 @@ const IndexSetsComponent = React.createClass({
         </LinkContainer>
         {' '}
         <DropdownButton title="More Actions" id={`index-set-dropdown-${indexSet.id}`} pullRight>
-          <MenuItem onSelect={this._onSetDefault(indexSet)}>Set as default</MenuItem>
+          <MenuItem
+            onSelect={this._onSetDefault(indexSet)}
+            disabled={!indexSet.writable}>Set as default</MenuItem>
           <MenuItem divider />
           <MenuItem onSelect={this._onDelete(indexSet)}>Delete</MenuItem>
         </DropdownButton>
@@ -89,6 +91,7 @@ const IndexSetsComponent = React.createClass({
     );
 
     const isDefault = indexSet.default ? <Label key={`index-set-${indexSet.id}-default-label`} bsStyle="primary">default</Label> : '';
+    const isReadOnly = !indexSet.writable ? <Label key={`index-set-${indexSet.id}-readOnly-label`} bsStyle="info">read only</Label> : '';
     let description = indexSet.description;
     if (indexSet.default) {
       description += `${description.endsWith('.') ? '' : '.'} Graylog will use this index set by default.`;
@@ -107,7 +110,7 @@ const IndexSetsComponent = React.createClass({
     return (
       <EntityListItem key={`index-set-${indexSet.id}`}
                       title={indexSetTitle}
-                      titleSuffix={<span>{statsString} {isDefault}</span>}
+                      titleSuffix={<span>{statsString} {isDefault} {isReadOnly}</span>}
                       description={description}
                       actions={actions}
                       contentRow={content} />


### PR DESCRIPTION
## Description
## Motivation and Context
Without this change it was possible to update the default index set and make it read only, leading to unwanted behavior. After this change, when updating an index set we check if it is the default index set and kindly refuse setting it read only.
    
Fixes #3331.

Additionally:

Removing superfluous id property from IndexSetUpdateRequest.
    
The id property of the IndexSetUpdateRequest DTO is unneeded, as the id of the index set to update is already given in the URL. It is actually misleading and requires an additional unneeded check to see if the ids of the URL and the body are consistent. Therefore the id is removed from the IndexSetUpdateRequest and the one from the URL is used only.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
