### PR TITLE
Add migration to fix parameter value types for alert conditions

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/migrations/MigrationsModule.java
+++ b/graylog2-server/src/main/java/org/graylog2/migrations/MigrationsModule.java
@@ -33,5 +33,6 @@ public class MigrationsModule extends AbstractModule {
         binder.addBinding().to(V20161130141500_DefaultStreamRecalcIndexRanges.class);
         binder.addBinding().to(V20161215163900_MoveIndexSetDefaultConfig.class);
         binder.addBinding().to(V20161216123500_DefaultIndexSetMigration.class);
+        binder.addBinding().to(V20170110150100_FixAlertConditionsMigration.class);
     }
 }

--- a/graylog2-server/src/main/java/org/graylog2/migrations/V20170110150100_FixAlertConditionsMigration.java
+++ b/graylog2-server/src/main/java/org/graylog2/migrations/V20170110150100_FixAlertConditionsMigration.java
@@ -1,0 +1,150 @@
+/**
+ * This file is part of Graylog.
+ *
+ * Graylog is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.graylog2.migrations;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.auto.value.AutoValue;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.primitives.Ints;
+import com.mongodb.client.MongoCollection;
+import com.mongodb.client.result.UpdateResult;
+import org.bson.Document;
+import org.graylog2.cluster.ClusterConfigServiceImpl;
+import org.graylog2.database.MongoConnection;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.inject.Inject;
+import java.time.ZonedDateTime;
+import java.util.List;
+import java.util.Set;
+
+import static com.mongodb.client.model.Filters.eq;
+import static com.mongodb.client.model.Sorts.ascending;
+import static com.mongodb.client.model.Updates.set;
+
+public class V20170110150100_FixAlertConditionsMigration extends Migration {
+    private static final Logger LOG = LoggerFactory.getLogger(V20170110150100_FixAlertConditionsMigration.class);
+
+    private static final String FIELD_ID = "_id";
+    private static final String FIELD_CREATED_AT = "created_at";
+    private static final String FIELD_ALERT_CONDITIONS = "alert_conditions";
+    private static final String FIELD_ALERT_CONDITIONS_ID = "alert_conditions.id";
+    private static final String ALERT_CONDITIONS_PARAMETERS_PREFIX = "alert_conditions.$.parameters.";
+
+    private final MongoCollection<Document> collection;
+    private final ClusterConfigServiceImpl clusterConfigService;
+
+    @Inject
+    public V20170110150100_FixAlertConditionsMigration(final MongoConnection mongoConnection,
+                                                       final ClusterConfigServiceImpl clusterConfigService) {
+        this.collection = mongoConnection.getMongoDatabase().getCollection("streams");
+        this.clusterConfigService = clusterConfigService;
+    }
+
+    @Override
+    public ZonedDateTime createdAt() {
+        return ZonedDateTime.parse("2017-01-10T15:01:00Z");
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public void upgrade() {
+        if (clusterConfigService.get(MigrationCompleted.class) != null) {
+            LOG.debug("Migration already done.");
+            return;
+        }
+
+        final ImmutableSet.Builder<String> modifiedStreams = ImmutableSet.builder();
+        final ImmutableSet.Builder<String> modifiedAlertConditions = ImmutableSet.builder();
+
+        for (Document document : collection.find().sort(ascending(FIELD_CREATED_AT))) {
+
+            final String streamId = document.getObjectId(FIELD_ID).toHexString();
+
+            if (!document.containsKey(FIELD_ALERT_CONDITIONS)) {
+                continue;
+            }
+
+            final List<Document> alertConditions = (List<Document>) document.get(FIELD_ALERT_CONDITIONS);
+
+            // Need to check if the following fields are integers:
+            //
+            // FieldContentValue: grace, backlog
+            // FieldValue:        grace, backlog, time, threshold
+            // MessageCount:      grace, backlog, time, threshold
+            final Set<String> intFields = ImmutableSet.of("grace", "backlog", "time", "threshold");
+
+            for (Document alertCondition : alertConditions) {
+                final String alertConditionId = alertCondition.get("id", String.class);
+                final Document parameters = alertCondition.get("parameters", Document.class);
+
+                for (String field : intFields) {
+                    final Object fieldValue = parameters.get(field);
+
+                    // No need to convert anything if the field does not exist or is already an integer
+                    if (fieldValue == null || fieldValue instanceof Integer) {
+                        continue;
+                    }
+
+                    if (!(fieldValue instanceof String)) {
+                        LOG.warn("Field <{}> in alert condition <{}> of stream <{}> is not a string but a <{}>, not trying to convert it!",
+                                field, alertConditionId, streamId, fieldValue.getClass().getCanonicalName());
+                        return;
+                    }
+
+                    final String stringValue = parameters.get(field, String.class);
+                    final Integer intValue = Ints.tryParse(stringValue);
+
+                    LOG.info("Converting value for field <{}> from string to integer in alert condition <{}> of stream <{}>", field, alertConditionId, streamId);
+
+                    if (intValue == null) {
+                        LOG.error("Unable to parse \"{}\" into integer!", fieldValue);
+                    }
+
+                    final UpdateResult result = collection.updateOne(eq(FIELD_ALERT_CONDITIONS_ID, alertConditionId), set(ALERT_CONDITIONS_PARAMETERS_PREFIX + field, intValue));
+
+                    // Use UpdateResult#getMatchedCount() instead of #getModifiedCount() to make it work on MongoDB 2.4
+                    if (result.getMatchedCount() > 0) {
+                        modifiedStreams.add(streamId);
+                        modifiedAlertConditions.add(alertConditionId);
+                    } else {
+                        LOG.warn("No document modified for alert condition <{}>", alertConditionId);
+                    }
+                }
+            }
+        }
+
+        clusterConfigService.write(MigrationCompleted.create(modifiedStreams.build(), modifiedAlertConditions.build()));
+    }
+
+    @AutoValue
+    public static abstract class MigrationCompleted {
+        @JsonProperty("stream_ids")
+        public abstract Set<String> streamIds();
+
+        @JsonProperty("alert_condition_ids")
+        public abstract Set<String> alertConditionIds();
+
+        @JsonCreator
+        public static MigrationCompleted create(@JsonProperty("stream_ids") Set<String> streamIds,
+                                                @JsonProperty("alert_condition_ids") Set<String> alertConditionIds) {
+            return new AutoValue_V20170110150100_FixAlertConditionsMigration_MigrationCompleted(streamIds, alertConditionIds);
+        }
+    }
+}

--- a/graylog2-server/src/main/java/org/graylog2/migrations/V20170110150100_FixAlertConditionsMigration.java
+++ b/graylog2-server/src/main/java/org/graylog2/migrations/V20170110150100_FixAlertConditionsMigration.java
@@ -92,6 +92,7 @@ public class V20170110150100_FixAlertConditionsMigration extends Migration {
 
             for (Document alertCondition : alertConditions) {
                 final String alertConditionId = alertCondition.get("id", String.class);
+                final String alertConditionTitle = alertCondition.get("title", String.class);
                 final Document parameters = alertCondition.get("parameters", Document.class);
 
                 for (String field : intFields) {
@@ -103,15 +104,17 @@ public class V20170110150100_FixAlertConditionsMigration extends Migration {
                     }
 
                     if (!(fieldValue instanceof String)) {
-                        LOG.warn("Field <{}> in alert condition <{}> of stream <{}> is not a string but a <{}>, not trying to convert it!",
-                                field, alertConditionId, streamId, fieldValue.getClass().getCanonicalName());
+                        LOG.warn("Field <{}> in alert condition <{}> ({}) of stream <{}> is not a string but a <{}>, not trying to convert it!",
+                                field, alertConditionId, alertConditionTitle, streamId,
+                                fieldValue.getClass().getCanonicalName());
                         return;
                     }
 
                     final String stringValue = parameters.get(field, String.class);
                     final Integer intValue = Ints.tryParse(stringValue);
 
-                    LOG.info("Converting value for field <{}> from string to integer in alert condition <{}> of stream <{}>", field, alertConditionId, streamId);
+                    LOG.info("Converting value for field <{}> from string to integer in alert condition <{}> ({}) of stream <{}>",
+                            field, alertConditionId, alertConditionTitle, streamId);
 
                     if (intValue == null) {
                         LOG.error("Unable to parse \"{}\" into integer!", fieldValue);
@@ -124,7 +127,7 @@ public class V20170110150100_FixAlertConditionsMigration extends Migration {
                         modifiedStreams.add(streamId);
                         modifiedAlertConditions.add(alertConditionId);
                     } else {
-                        LOG.warn("No document modified for alert condition <{}>", alertConditionId);
+                        LOG.warn("No document modified for alert condition <{}> ({})", alertConditionId, alertConditionTitle);
                     }
                 }
             }

--- a/graylog2-server/src/main/java/org/graylog2/migrations/V20170110150100_FixAlertConditionsMigration.java
+++ b/graylog2-server/src/main/java/org/graylog2/migrations/V20170110150100_FixAlertConditionsMigration.java
@@ -107,7 +107,7 @@ public class V20170110150100_FixAlertConditionsMigration extends Migration {
                         LOG.warn("Field <{}> in alert condition <{}> ({}) of stream <{}> is not a string but a <{}>, not trying to convert it!",
                                 field, alertConditionId, alertConditionTitle, streamId,
                                 fieldValue.getClass().getCanonicalName());
-                        return;
+                        continue;
                     }
 
                     final String stringValue = parameters.get(field, String.class);

--- a/graylog2-server/src/test/java/org/graylog2/migrations/V20170110150100_FixAlertConditionsMigrationTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/migrations/V20170110150100_FixAlertConditionsMigrationTest.java
@@ -1,0 +1,210 @@
+/**
+ * This file is part of Graylog.
+ *
+ * Graylog is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.graylog2.migrations;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.mongodb.client.MongoCollection;
+import com.mongodb.client.MongoDatabase;
+import org.assertj.core.api.AbstractAssert;
+import org.assertj.core.api.Assertions;
+import org.bson.Document;
+import org.graylog2.bindings.providers.MongoJackObjectMapperProvider;
+import org.graylog2.cluster.ClusterConfigServiceImpl;
+import org.graylog2.database.MongoConnection;
+import org.graylog2.events.ClusterEventBus;
+import org.graylog2.fongo.SeedingFongoRule;
+import org.graylog2.migrations.V20170110150100_FixAlertConditionsMigration.MigrationCompleted;
+import org.graylog2.plugin.system.NodeId;
+import org.graylog2.shared.bindings.providers.ObjectMapperProvider;
+import org.graylog2.shared.plugins.ChainingClassLoader;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnit;
+import org.mockito.junit.MockitoRule;
+
+import java.time.ZonedDateTime;
+import java.util.Collections;
+import java.util.List;
+
+import static com.mongodb.client.model.Filters.eq;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.reset;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+public class V20170110150100_FixAlertConditionsMigrationTest {
+    @Rule
+    public SeedingFongoRule fongoRule = SeedingFongoRule.create("graylog_test")
+            .addSeed("org/graylog2/migrations/V20170110150100_FixAlertConditionsMigration.json");
+    @Rule
+    public final MockitoRule mockitoRule = MockitoJUnit.rule();
+
+    @Mock
+    public NodeId nodeId;
+
+    private final ObjectMapper objectMapper = new ObjectMapperProvider().get();
+    private final MongoJackObjectMapperProvider objectMapperProvider = new MongoJackObjectMapperProvider(objectMapper);
+
+    private ClusterConfigServiceImpl clusterConfigService;
+    private Migration migration;
+    private MongoCollection<Document> collection;
+
+    @Before
+    public void setUp() throws Exception {
+        this.clusterConfigService = spy(new ClusterConfigServiceImpl(objectMapperProvider,
+                fongoRule.getConnection(), nodeId,
+                new ChainingClassLoader(getClass().getClassLoader()), new ClusterEventBus()));
+
+        final MongoConnection mongoConnection = spy(fongoRule.getConnection());
+        final MongoDatabase mongoDatabase = spy(fongoRule.getDatabase());
+
+        when(mongoConnection.getMongoDatabase()).thenReturn(mongoDatabase);
+
+        this.collection = spy(mongoDatabase.getCollection("streams"));
+
+        when(mongoDatabase.getCollection("streams")).thenReturn(collection);
+
+        this.migration = new V20170110150100_FixAlertConditionsMigration(mongoConnection, clusterConfigService);
+    }
+
+    @Test
+    public void createdAt() throws Exception {
+        assertThat(migration.createdAt()).isEqualTo(ZonedDateTime.parse("2017-01-10T15:01:00Z"));
+    }
+
+    @Test
+    public void upgrade() throws Exception {
+        // First check all types of the existing documents
+        AlertConditionAssertions.assertThat(getAlertCondition("2fa6a415-ce0c-4a36-accc-dd9519eb06d9"))
+                .hasParameter("backlog", 2)
+                .hasParameter("grace", 1)
+                .hasParameter("threshold_type", "MORE")
+                .hasParameter("threshold", "5")
+                .hasParameter("time", "1");
+
+        AlertConditionAssertions.assertThat(getAlertCondition("393fd8b2-9b17-42d3-86b0-6e55d0f5343a"))
+                .hasParameter("backlog", 0)
+                .hasParameter("field", "bar")
+                .hasParameter("grace", "0")
+                .hasParameter("value", "baz");
+
+        AlertConditionAssertions.assertThat(getAlertCondition("0e75404f-c0ee-40b0-8872-b1aec441ba1c"))
+                .hasParameter("backlog", "0")
+                .hasParameter("field", "foo")
+                .hasParameter("grace", "0")
+                .hasParameter("threshold_type", "HIGHER")
+                .hasParameter("threshold", "0")
+                .hasParameter("time", "5")
+                .hasParameter("type", "MAX");
+
+        // Run the migration that should convert all affected fields to integers
+        migration.upgrade();
+
+        // Check all types again
+        AlertConditionAssertions.assertThat(getAlertCondition("2fa6a415-ce0c-4a36-accc-dd9519eb06d9"))
+                .hasParameter("backlog", 2)
+                .hasParameter("grace", 1)
+                .hasParameter("threshold_type", "MORE")
+                .hasParameter("threshold", 5)
+                .hasParameter("time", 1);
+
+        AlertConditionAssertions.assertThat(getAlertCondition("393fd8b2-9b17-42d3-86b0-6e55d0f5343a"))
+                .hasParameter("backlog", 0)
+                .hasParameter("field", "bar")
+                .hasParameter("grace", 0)
+                .hasParameter("value", "baz");
+
+        AlertConditionAssertions.assertThat(getAlertCondition("0e75404f-c0ee-40b0-8872-b1aec441ba1c"))
+                .hasParameter("backlog", 0)
+                .hasParameter("field", "foo")
+                .hasParameter("grace", 0)
+                .hasParameter("threshold_type", "HIGHER")
+                .hasParameter("threshold", 0)
+                .hasParameter("time", 5)
+                .hasParameter("type", "MAX");
+
+        final MigrationCompleted migrationCompleted = clusterConfigService.get(MigrationCompleted.class);
+
+        assertThat(migrationCompleted).isNotNull();
+
+        assertThat(migrationCompleted.streamIds()).containsOnly("58458e442f857c314491344e", "58458e442f857c314491345e");
+        assertThat(migrationCompleted.alertConditionIds()).containsOnly("2fa6a415-ce0c-4a36-accc-dd9519eb06d9", "393fd8b2-9b17-42d3-86b0-6e55d0f5343a", "0e75404f-c0ee-40b0-8872-b1aec441ba1c");
+    }
+
+    @Test
+    public void upgradeWhenMigrationCompleted() throws Exception {
+        clusterConfigService.write(MigrationCompleted.create(Collections.emptySet(), Collections.emptySet()));
+
+        // Reset the spy to be able to verify that there wasn't a write
+        reset(clusterConfigService);
+
+        migration.upgrade();
+
+        verify(collection, never()).updateOne(any(), any());
+        verify(clusterConfigService, never()).write(any(MigrationCompleted.class));
+    }
+
+    @SuppressWarnings("unchecked")
+    private Document getAlertCondition(String id) {
+        final Document stream = collection.find(eq("alert_conditions.id", id)).first();
+        final List<Document> alertConditions = (List<Document>) stream.get("alert_conditions");
+
+        return alertConditions.stream()
+                .filter(alertCondition -> alertCondition.get("id", String.class).equals(id))
+                .findFirst().orElse(null);
+    }
+
+    private static class AlertConditionAssertions extends AbstractAssert<AlertConditionAssertions, Document> {
+
+        public static AlertConditionAssertions assertThat(Document actual) {
+            return new AlertConditionAssertions(actual);
+        }
+
+        private final String id;
+        private final Document parameters;
+
+        AlertConditionAssertions(Document actual) {
+            super(actual, AlertConditionAssertions.class);
+
+            this.id = actual.get("id", String.class);
+            this.parameters = actual.get("parameters", Document.class);
+        }
+
+        AlertConditionAssertions hasParameter(String field, Object expected) {
+            isNotNull();
+
+            if (!parameters.containsKey(field)) {
+                failWithMessage("Parameters do not contain field <%s>", field);
+            }
+
+            final Object actual = parameters.get(field);
+
+            Assertions.assertThat(actual)
+                    .withFailMessage("Value of field <%s> in alert condition <%s>\nExpected: <%s> (%s)\nActual:   <%s> (%s)",
+                            field, id, expected, expected.getClass().getCanonicalName(), actual,
+                            actual.getClass().getCanonicalName())
+                    .isEqualTo(expected);
+
+            return this;
+        }
+    }
+}

--- a/graylog2-server/src/test/resources/org/graylog2/migrations/V20170110150100_FixAlertConditionsMigration.json
+++ b/graylog2-server/src/test/resources/org/graylog2/migrations/V20170110150100_FixAlertConditionsMigration.json
@@ -1,0 +1,115 @@
+{
+  "streams": [
+    {
+      "_id": {
+        "$oid": "58458e442f857c314491344e"
+      },
+      "title": "Stream 1",
+      "description": "The first stream",
+      "alert_conditions": [
+        {
+          "creator_user_id": "admin",
+          "created_at": "2016-12-27T17:19:53.172Z",
+          "id": "2fa6a415-ce0c-4a36-accc-dd9519eb06d9",
+          "type": "message_count",
+          "title": "message count condition 1",
+          "parameters": {
+            "backlog": 2,
+            "grace": 1,
+            "threshold_type": "MORE",
+            "threshold": "5",
+            "time": "1"
+          }
+        }
+      ],
+      "content_pack": null,
+      "created_at": {
+        "$date": "2016-12-05T15:56:52.162Z"
+      },
+      "creator_user_id": "admin",
+      "disabled": false,
+      "index_set_id": "584589ca2f857c1c2799a77e",
+      "matching_type": "AND",
+      "remove_matches_from_default_stream": true
+    },
+    {
+      "_id": {
+        "$oid": "58458e442f857c314491345e"
+      },
+      "title": "Stream 2",
+      "description": "The second stream",
+      "alert_conditions": [
+        {
+          "creator_user_id": "admin",
+          "created_at": "2017-01-10T16:01:46.880Z",
+          "id": "393fd8b2-9b17-42d3-86b0-6e55d0f5343a",
+          "type": "field_content_value",
+          "title": "field content value condition",
+          "parameters": {
+            "backlog": 0,
+            "field": "bar",
+            "grace": "0",
+            "value": "baz"
+          }
+        },
+        {
+          "creator_user_id": "admin",
+          "created_at": "2017-01-10T16:39:09.514Z",
+          "id": "0e75404f-c0ee-40b0-8872-b1aec441ba1c",
+          "type": "field_value",
+          "title": "field value condition",
+          "parameters": {
+            "backlog": "0",
+            "field": "foo",
+            "grace": "0",
+            "threshold_type": "HIGHER",
+            "threshold": "0",
+            "time": "5",
+            "type": "MAX"
+          }
+        }
+      ],
+      "content_pack": null,
+      "created_at": {
+        "$date": "2016-12-06T14:46:52.162Z"
+      },
+      "creator_user_id": "admin",
+      "disabled": false,
+      "index_set_id": "584589ca2f857c1c2799a77e",
+      "matching_type": "AND",
+      "remove_matches_from_default_stream": true
+    },
+    {
+      "_id": {
+        "$oid": "58458e442f857c314491346e"
+      },
+      "title": "Stream 3",
+      "description": "The third stream",
+      "alert_conditions": [
+        {
+          "creator_user_id": "admin",
+          "created_at": "2016-12-27T17:19:53.172Z",
+          "id": "1eb51c5f-780d-4337-ae0c-9c5a37a395ba",
+          "type": "message_count",
+          "title": "message count condition 1 (this one does not need any conversion)",
+          "parameters": {
+            "grace": 1,
+            "threshold_type": "MORE",
+            "threshold": 5,
+            "time": 1,
+            "backlog": 2
+          }
+        }
+      ],
+      "content_pack": null,
+      "created_at": {
+        "$date": "2016-12-05T15:56:52.162Z"
+      },
+      "creator_user_id": "admin",
+      "disabled": false,
+      "index_set_id": "584589ca2f857c1c2799a77e",
+      "matching_type": "AND",
+      "remove_matches_from_default_stream": true
+    }
+  ]
+}


### PR DESCRIPTION
At one point at the beginning of the 2.2 development the values for integer parameters have been stored as strings in MongoDB. This has been fixed but existing broken documents need to be fixed.
