### PR TITLE
Refactor IndexSet and IndexSetRegistry interface naming

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/indexer/IndexHelper.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/IndexHelper.java
@@ -18,22 +18,20 @@ package org.graylog2.indexer;
 
 import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
-
 import org.elasticsearch.index.query.QueryBuilder;
 import org.elasticsearch.index.query.QueryBuilders;
 import org.graylog2.plugin.Tools;
 import org.graylog2.plugin.indexer.searches.timeranges.TimeRange;
 
+import javax.annotation.Nullable;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Set;
 
-import javax.annotation.Nullable;
-
 public class IndexHelper {
     public static Set<String> getOldestIndices(IndexSet indexSet, int count) {
-        final String[] managedIndicesNames = indexSet.getManagedIndicesNames();
+        final String[] managedIndicesNames = indexSet.getManagedIndices();
         if (count <= 0 || managedIndicesNames.length <= count) {
             return Collections.emptySet();
         }

--- a/graylog2-server/src/main/java/org/graylog2/indexer/IndexSet.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/IndexSet.java
@@ -29,37 +29,145 @@ import java.util.Set;
 import static java.util.Objects.requireNonNull;
 
 public interface IndexSet extends Comparable<IndexSet> {
-    String[] getManagedIndicesNames();
+    /**
+     * Returns an array with all managed indices in this index set.
+     * <p>
+     * Example: {@code ["graylog_0", "graylog_1", "graylog_2"]}
+     *
+     * @return array of index names
+     */
+    String[] getManagedIndices();
 
+    /**
+     * Returns the write index alias name for this index set.
+     * <p>
+     * The write index alias always points to the newest index.
+     * <p>
+     * Example: {@code "graylog_deflector"}
+     *
+     * @return the write index alias name
+     */
     String getWriteIndexAlias();
 
-    String getWriteIndexWildcard();
+    /**
+     * Returns the index wildcard for this index set.
+     * <p>
+     * This can be used in Elasticsearch queries to match all managed indices in this index set.
+     * <p>
+     * Example: {@code "graylog_*"}
+     *
+     * @return the index wildcard
+     */
+    String getIndexWildcard();
 
-    String getNewestTargetName() throws NoTargetIndexException;
+    /**
+     * Returns the newest index.
+     * <p>
+     * Example: {@code "graylog_42"}
+     *
+     * @return the newest index
+     * @throws NoTargetIndexException if there are no indices in this index set yet
+     */
+    String getNewestIndex() throws NoTargetIndexException;
 
+    /**
+     * Returns the active write index.
+     * <p>
+     * Incoming messages for this index set will be written into this index.
+     * <p>
+     * Example: {@code "graylog_42"}
+     *
+     * @return the active write index
+     * @throws TooManyAliasesException if the write index alias points to more than one index
+     */
     @Nullable
-    String getCurrentActualTargetIndex() throws TooManyAliasesException;
+    String getActiveWriteIndex() throws TooManyAliasesException;
 
-    Map<String,Set<String>> getAllDeflectorAliases();
+    /**
+     * Returns a map where the key is an index name and the value a set of aliases for this index.
+     * <p>
+     * Only the active write index should have an alias, the other values should be empty.
+     * <p>
+     * Example: {@code {graylog_0=[], graylog_1=[], graylog_2=[graylog_deflector}}
+     *
+     * @return map of index names to index aliases
+     */
+    Map<String, Set<String>> getAllIndexAliases();
 
+    /**
+     * Returns the index prefix for this index set.
+     * <p>
+     * Example: {@code "graylog"}
+     *
+     * @return index prefix for this index set
+     */
     String getIndexPrefix();
 
+    /**
+     * Checks if the write index alias exists.
+     *
+     * @return true if the write index alias exists, false if not
+     */
     boolean isUp();
 
-    boolean isDeflectorAlias(String index);
+    /**
+     * Checks if the given index name is equals to the write index alias.
+     *
+     * @param index index name to check
+     * @return true if given index name is the write index alias, false if not
+     */
+    boolean isWriteIndexAlias(String index);
 
+    /**
+     * Checks if the given index name is part of this index set.
+     *
+     * @param index index name to check
+     * @return true if part of index set, false if not
+     */
     boolean isManagedIndex(String index);
 
+    /**
+     * Prepares this index set to receive new messages.
+     */
     void setUp();
 
+    /**
+     * Creates a new index and points the write index alias to it.
+     */
     void cycle();
 
+    /**
+     * This ensures that the write index alias only points to the newest index.
+     * <p>
+     * Can be used to fix the aliases in this index set when a {@link TooManyAliasesException} has been thrown.
+     *
+     * @param indices list of indices where the index alias points to
+     */
     void cleanupAliases(Set<String> indices);
 
-    void pointTo(String shouldBeTarget, String currentTarget);
+    /**
+     * Changes the write index alias from the old index to the new one.
+     *
+     * @param newIndexName index to add the write index alias to
+     * @param oldIndexName index to remove the write index alias from
+     */
+    void pointTo(String newIndexName, String oldIndexName);
 
+    /**
+     * Extracts the index number from an index name.
+     * <p>
+     * Example: {@code "graylog_42" => 42}
+     *
+     * @param index index name
+     * @return a filled {@link Optional} with the extracted index number, an empty one if the number couldn't be parsed
+     */
     Optional<Integer> extractIndexNumber(String index);
 
+    /**
+     * The configuration for this index set.
+     *
+     * @return index set configuration object
+     */
     IndexSetConfig getConfig();
 
     class IndexNameComparator implements Comparator<String> {

--- a/graylog2-server/src/main/java/org/graylog2/indexer/IndexSetRegistry.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/IndexSetRegistry.java
@@ -27,7 +27,7 @@ public interface IndexSetRegistry extends Iterable<IndexSet> {
      *
      * @return list of index sets
      */
-    Set<IndexSet> getAllIndexSets();
+    Set<IndexSet> getAll();
 
     /**
      * Returns the {@link IndexSet} for the given ID.
@@ -38,12 +38,12 @@ public interface IndexSetRegistry extends Iterable<IndexSet> {
     Optional<IndexSet> get(String indexSetId);
 
     /**
-     * Returns the {@link IndexSet} for the given index name.
+     * Returns the {@link IndexSet} for the given index.
      *
-     * @param indexName name of the index
+     * @param index name of the index
      * @return index set that manages the given index
      */
-    Optional<IndexSet> getForIndexName(String indexName);
+    Optional<IndexSet> getForIndex(String index);
 
     /**
      * Returns the {@link IndexSet} that is marked as default.
@@ -55,33 +55,33 @@ public interface IndexSetRegistry extends Iterable<IndexSet> {
     IndexSet getDefault();
 
     /**
-     * Returns a list with the names of all managed indices.
+     * Returns a list of all managed indices.
      *
-     * @return list with names of managed indices
+     * @return list of managed indices
      */
-    String[] getManagedIndicesNames();
+    String[] getManagedIndices();
 
     /**
-     * Checks if the given index name is managed by Graylog.
+     * Checks if the given index is managed by any index set.
      *
-     * @param indexName the index name to check
-     * @return true when index is managed by Graylog, false otherwise
+     * @param index the index name to check
+     * @return true when index is managed by any index set, false otherwise
      */
-    boolean isManagedIndex(String indexName);
+    boolean isManagedIndex(String index);
 
     /**
-     * Returns the list of all write index wildcards.
+     * Returns the list of all index wildcards.
      *
      * @return list of wildcards
      */
-    String[] getWriteIndexWildcards();
+    String[] getIndexWildcards();
 
     /**
-     * Returns the list of all write index names.
+     * Returns the list of all write index aliases.
      *
      * @return list of names
      */
-    String[] getWriteIndexNames();
+    String[] getWriteIndexAliases();
 
     /**
      * Checks if all deflector aliases exist.
@@ -99,11 +99,11 @@ public interface IndexSetRegistry extends Iterable<IndexSet> {
     boolean isCurrentWriteIndexAlias(String indexName);
 
     /**
-     * Checks if the given index name is a current write index in any {@link IndexSet}.
+     * Checks if the given index is a current write index in any {@link IndexSet}.
      *
-     * @param indexName the index name to check
+     * @param index the index name to check
      * @return true when index is a current write index, false otherwise
      * @throws TooManyAliasesException
      */
-    boolean isCurrentWriteIndex(String indexName) throws TooManyAliasesException;
+    boolean isCurrentWriteIndex(String index) throws TooManyAliasesException;
 }

--- a/graylog2-server/src/main/java/org/graylog2/indexer/MongoIndexSetRegistry.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/MongoIndexSetRegistry.java
@@ -51,7 +51,7 @@ public class MongoIndexSetRegistry implements IndexSetRegistry {
     }
 
     @Override
-    public Set<IndexSet> getAllIndexSets() {
+    public Set<IndexSet> getAll() {
         return ImmutableSet.copyOf(findAllMongoIndexSets());
     }
 
@@ -62,7 +62,7 @@ public class MongoIndexSetRegistry implements IndexSetRegistry {
     }
 
     @Override
-    public Optional<IndexSet> getForIndexName(String indexName) {
+    public Optional<IndexSet> getForIndex(String indexName) {
         for (MongoIndexSet indexSet : findAllMongoIndexSets()) {
             if (indexSet.isManagedIndex(indexName)) {
                 return Optional.of(indexSet);
@@ -77,10 +77,10 @@ public class MongoIndexSetRegistry implements IndexSetRegistry {
     }
 
     @Override
-    public String[] getManagedIndicesNames() {
+    public String[] getManagedIndices() {
         final ImmutableSet.Builder<String> indexNamesBuilder = ImmutableSet.builder();
         for (MongoIndexSet indexSet : findAllMongoIndexSets()) {
-            indexNamesBuilder.add(indexSet.getManagedIndicesNames());
+            indexNamesBuilder.add(indexSet.getManagedIndices());
         }
 
         final ImmutableSet<String> indexNames = indexNamesBuilder.build();
@@ -98,11 +98,11 @@ public class MongoIndexSetRegistry implements IndexSetRegistry {
     }
 
     @Override
-    public String[] getWriteIndexWildcards() {
+    public String[] getIndexWildcards() {
         final ImmutableSet.Builder<String> wildcardsBuilder = ImmutableSet.builder();
         for (MongoIndexSet indexSet : findAllMongoIndexSets()) {
             if (indexSet.getConfig().isWritable()) {
-                wildcardsBuilder.add(indexSet.getWriteIndexWildcard());
+                wildcardsBuilder.add(indexSet.getIndexWildcard());
             }
         }
 
@@ -111,7 +111,7 @@ public class MongoIndexSetRegistry implements IndexSetRegistry {
     }
 
     @Override
-    public String[] getWriteIndexNames() {
+    public String[] getWriteIndexAliases() {
         final ImmutableSet.Builder<String> indexNamesBuilder = ImmutableSet.builder();
         for (MongoIndexSet indexSet : findAllMongoIndexSets()) {
             if (indexSet.getConfig().isWritable()) {
@@ -138,7 +138,7 @@ public class MongoIndexSetRegistry implements IndexSetRegistry {
     @Override
     public boolean isCurrentWriteIndexAlias(String indexName) {
         for (MongoIndexSet indexSet : findAllMongoIndexSets()) {
-            if (indexSet.isDeflectorAlias(indexName)) {
+            if (indexSet.isWriteIndexAlias(indexName)) {
                 return true;
             }
         }
@@ -149,7 +149,7 @@ public class MongoIndexSetRegistry implements IndexSetRegistry {
     @Override
     public boolean isCurrentWriteIndex(String indexName) throws TooManyAliasesException {
         for (MongoIndexSet indexSet : findAllMongoIndexSets()) {
-            if (indexSet.getCurrentActualTargetIndex() != null && indexSet.getCurrentActualTargetIndex().equals(indexName)) {
+            if (indexSet.getActiveWriteIndex() != null && indexSet.getActiveWriteIndex().equals(indexName)) {
                 return true;
             }
         }
@@ -159,6 +159,6 @@ public class MongoIndexSetRegistry implements IndexSetRegistry {
 
     @Override
     public Iterator<IndexSet> iterator() {
-        return getAllIndexSets().iterator();
+        return getAll().iterator();
     }
 }

--- a/graylog2-server/src/main/java/org/graylog2/indexer/SetIndexReadOnlyJob.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/SetIndexReadOnlyJob.java
@@ -62,7 +62,7 @@ public class SetIndexReadOnlyJob extends SystemJob {
 
     @Override
     public void execute() {
-        final Optional<IndexSet> indexSet = indexSetRegistry.getForIndexName(index);
+        final Optional<IndexSet> indexSet = indexSetRegistry.getForIndex(index);
 
         if (!indexSet.isPresent()) {
             log.error("Couldn't find index set for index <{}>", index);

--- a/graylog2-server/src/main/java/org/graylog2/indexer/TestIndexSet.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/TestIndexSet.java
@@ -36,7 +36,7 @@ public class TestIndexSet implements IndexSet {
     }
 
     @Override
-    public String[] getManagedIndicesNames() {
+    public String[] getManagedIndices() {
         return new String[0];
     }
 
@@ -46,22 +46,22 @@ public class TestIndexSet implements IndexSet {
     }
 
     @Override
-    public String getWriteIndexWildcard() {
+    public String getIndexWildcard() {
         return config.indexPrefix() + SEPARATOR + "*";
     }
 
     @Override
-    public String getNewestTargetName() throws NoTargetIndexException {
+    public String getNewestIndex() throws NoTargetIndexException {
         return null;
     }
 
     @Override
-    public String getCurrentActualTargetIndex() throws TooManyAliasesException {
+    public String getActiveWriteIndex() throws TooManyAliasesException {
         return null;
     }
 
     @Override
-    public Map<String, Set<String>> getAllDeflectorAliases() {
+    public Map<String, Set<String>> getAllIndexAliases() {
         return null;
     }
 
@@ -76,7 +76,7 @@ public class TestIndexSet implements IndexSet {
     }
 
     @Override
-    public boolean isDeflectorAlias(String index) {
+    public boolean isWriteIndexAlias(String index) {
         return false;
     }
 

--- a/graylog2-server/src/main/java/org/graylog2/indexer/cluster/Cluster.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/cluster/Cluster.java
@@ -78,7 +78,7 @@ public class Cluster {
      * @return the cluster health response
      */
     public ClusterHealthResponse health() {
-        ClusterHealthRequest request = new ClusterHealthRequest(indexSetRegistry.getWriteIndexWildcards());
+        ClusterHealthRequest request = new ClusterHealthRequest(indexSetRegistry.getIndexWildcards());
         return c.admin().cluster().health(request).actionGet();
     }
 
@@ -91,7 +91,7 @@ public class Cluster {
      * @return the cluster health response
      */
     public ClusterHealthResponse deflectorHealth() {
-        ClusterHealthRequest request = new ClusterHealthRequest(indexSetRegistry.getWriteIndexNames());
+        ClusterHealthRequest request = new ClusterHealthRequest(indexSetRegistry.getWriteIndexAliases());
         return c.admin().cluster().health(request).actionGet();
     }
 

--- a/graylog2-server/src/main/java/org/graylog2/indexer/counts/Counts.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/counts/Counts.java
@@ -36,11 +36,11 @@ public class Counts {
     }
 
     public long total() {
-        return totalCount(indexSetRegistry.getManagedIndicesNames());
+        return totalCount(indexSetRegistry.getManagedIndices());
     }
 
     public long total(final IndexSet indexSet) {
-        return totalCount(indexSet.getManagedIndicesNames());
+        return totalCount(indexSet.getManagedIndices());
     }
 
     private long totalCount(final String[] indexNames) {

--- a/graylog2-server/src/main/java/org/graylog2/indexer/healing/FixDeflectorByMoveJob.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/healing/FixDeflectorByMoveJob.java
@@ -94,7 +94,7 @@ public class FixDeflectorByMoveJob extends SystemJob {
             // Copy messages to new index.
             String newTarget = null;
             try {
-                newTarget = indexSet.getNewestTargetName();
+                newTarget = indexSet.getNewestIndex();
 
                 LOG.info("Starting to move <{}> to <{}>.", indexSet.getWriteIndexAlias(), newTarget);
                 indices.move(indexSet.getWriteIndexAlias(), newTarget);

--- a/graylog2-server/src/main/java/org/graylog2/indexer/indices/Indices.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/indices/Indices.java
@@ -197,7 +197,7 @@ public class Indices {
     }
 
     public Map<String, IndexStats> getAll(final IndexSet indexSet) {
-        final IndicesStatsRequest request = c.admin().indices().prepareStats(indexSet.getWriteIndexWildcard()).request();
+        final IndicesStatsRequest request = c.admin().indices().prepareStats(indexSet.getIndexWildcard()).request();
         final IndicesStatsResponse response = c.admin().indices().stats(request).actionGet();
 
         if (response.getFailedShards() > 0) {
@@ -207,7 +207,7 @@ public class Indices {
     }
 
     public Map<String, IndexStats> getAllDocCounts(final IndexSet indexSet) {
-        final IndicesStatsRequest request = c.admin().indices().prepareStats(indexSet.getWriteIndexWildcard()).setDocs(true).request();
+        final IndicesStatsRequest request = c.admin().indices().prepareStats(indexSet.getIndexWildcard()).setDocs(true).request();
         final IndicesStatsResponse response = c.admin().indices().stats(request).actionGet();
 
         return response.getIndices();
@@ -276,7 +276,7 @@ public class Indices {
     }
 
     private void ensureIndexTemplate(IndexSet indexSet) {
-        final Map<String, Object> template = indexMapping.messageTemplate(indexSet.getWriteIndexWildcard(), indexSet.getConfig().indexAnalyzer());
+        final Map<String, Object> template = indexMapping.messageTemplate(indexSet.getIndexWildcard(), indexSet.getConfig().indexAnalyzer());
         final PutIndexTemplateRequest itr = c.admin().indices().preparePutTemplate(indexSet.getConfig().indexTemplateName())
                 .setOrder(Integer.MIN_VALUE) // Make sure templates with "order: 0" are applied after our template!
                 .setSource(template)

--- a/graylog2-server/src/main/java/org/graylog2/indexer/indices/jobs/IndexSetCleanupJob.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/indices/jobs/IndexSetCleanupJob.java
@@ -55,7 +55,7 @@ public class IndexSetCleanupJob extends SystemJob {
     @Override
     public void execute() {
         final IndexSetConfig config = indexSet.getConfig();
-        final String[] managedIndices = indexSet.getManagedIndicesNames();
+        final String[] managedIndices = indexSet.getManagedIndices();
 
         this.total = managedIndices.length;
 

--- a/graylog2-server/src/main/java/org/graylog2/indexer/indices/jobs/SetIndexReadOnlyAndCalculateRangeJob.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/indices/jobs/SetIndexReadOnlyAndCalculateRangeJob.java
@@ -49,7 +49,7 @@ public class SetIndexReadOnlyAndCalculateRangeJob extends SystemJob {
     public void execute() {
         final SystemJob setIndexReadOnlyJob = setIndexReadOnlyJobFactory.create(indexName);
         setIndexReadOnlyJob.execute();
-        final SystemJob createNewSingleIndexRangeJob = createNewSingleIndexRangeJobFactory.create(indexSetRegistry.getAllIndexSets(), indexName);
+        final SystemJob createNewSingleIndexRangeJob = createNewSingleIndexRangeJobFactory.create(indexSetRegistry.getAll(), indexName);
         createNewSingleIndexRangeJob.execute();
 
     }

--- a/graylog2-server/src/main/java/org/graylog2/indexer/ranges/EsIndexRangeService.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/ranges/EsIndexRangeService.java
@@ -160,7 +160,7 @@ public class EsIndexRangeService implements IndexRangeService {
     @Override
     public SortedSet<IndexRange> findAll() {
         final ImmutableSortedSet.Builder<IndexRange> indexRanges = ImmutableSortedSet.orderedBy(IndexRange.COMPARATOR);
-        for (String index : indexSetRegistry.getManagedIndicesNames()) {
+        for (String index : indexSetRegistry.getManagedIndices()) {
             try {
                 indexRanges.add(cache.get(index));
             } catch (ExecutionException e) {

--- a/graylog2-server/src/main/java/org/graylog2/indexer/ranges/RebuildIndexRangesJob.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/ranges/RebuildIndexRangesJob.java
@@ -86,7 +86,7 @@ public class RebuildIndexRangesJob extends SystemJob {
         // for each index set we know about
         final ListMultimap<IndexSet, String> indexSets = MultimapBuilder.hashKeys().arrayListValues().build();
         for (IndexSet indexSet : this.indexSets) {
-            final String[] managedIndicesNames = indexSet.getManagedIndicesNames();
+            final String[] managedIndicesNames = indexSet.getManagedIndices();
             for (String name : managedIndicesNames) {
                 indexSets.put(indexSet, name);
             }
@@ -102,11 +102,11 @@ public class RebuildIndexRangesJob extends SystemJob {
         for (IndexSet indexSet : indexSets.keySet()) {
             LOG.info("Recalculating index ranges for index set {} ({}): {} indices affected.",
                     indexSet.getConfig().title(),
-                    indexSet.getWriteIndexWildcard(),
+                    indexSet.getIndexWildcard(),
                     indexSets.get(indexSet).size());
             for (String index : indexSets.get(indexSet)) {
                 try {
-                    if (index.equals(indexSet.getCurrentActualTargetIndex())) {
+                    if (index.equals(indexSet.getActiveWriteIndex())) {
                         LOG.debug("{} is current write target, do not calculate index range for it", index);
                         final IndexRange emptyRange = indexRangeService.createUnknownRange(index);
                         try {

--- a/graylog2-server/src/main/java/org/graylog2/indexer/retention/strategies/AbstractIndexCountBasedRetentionStrategy.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/retention/strategies/AbstractIndexCountBasedRetentionStrategy.java
@@ -52,7 +52,7 @@ public abstract class AbstractIndexCountBasedRetentionStrategy implements Retent
 
     @Override
     public void retain(IndexSet indexSet) {
-        final Map<String, Set<String>> deflectorIndices = indexSet.getAllDeflectorAliases();
+        final Map<String, Set<String>> deflectorIndices = indexSet.getAllIndexAliases();
         final int indexCount = (int)deflectorIndices.keySet()
             .stream()
             .filter(indexName -> !indices.isReopened(indexName))
@@ -83,7 +83,7 @@ public abstract class AbstractIndexCountBasedRetentionStrategy implements Retent
     }
 
     private void runRetention(IndexSet indexSet, Map<String, Set<String>> deflectorIndices, int removeCount) {
-        final Set<String> orderedIndices = Arrays.stream(indexSet.getManagedIndicesNames())
+        final Set<String> orderedIndices = Arrays.stream(indexSet.getManagedIndices())
             .filter(indexName -> !indices.isReopened(indexName))
             .filter(indexName -> !(deflectorIndices.get(indexName).contains(indexSet.getWriteIndexAlias())))
             .sorted((indexName1, indexName2) -> indexSet.extractIndexNumber(indexName2).orElse(0).compareTo(indexSet.extractIndexNumber(indexName1).orElse(0)))

--- a/graylog2-server/src/main/java/org/graylog2/indexer/rotation/strategies/AbstractRotationStrategy.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/rotation/strategies/AbstractRotationStrategy.java
@@ -56,7 +56,7 @@ public abstract class AbstractRotationStrategy implements RotationStrategy {
         final String strategyName = this.getClass().getCanonicalName();
         final String indexName;
         try {
-            indexName = indexSet.getNewestTargetName();
+            indexName = indexSet.getNewestIndex();
         } catch (NoTargetIndexException e) {
             LOG.error("Could not find current deflector target. Aborting.", e);
             return;

--- a/graylog2-server/src/main/java/org/graylog2/migrations/V20161130141500_DefaultStreamRecalcIndexRanges.java
+++ b/graylog2-server/src/main/java/org/graylog2/migrations/V20161130141500_DefaultStreamRecalcIndexRanges.java
@@ -105,12 +105,12 @@ public class V20161130141500_DefaultStreamRecalcIndexRanges extends Migration {
 
         final String currentWriteTarget;
         try {
-            currentWriteTarget = defaultIndexSet.getCurrentActualTargetIndex();
+            currentWriteTarget = defaultIndexSet.getActiveWriteIndex();
         } catch (TooManyAliasesException e) {
             LOG.error("Multiple write targets found for write alias. Cannot continue to assign streams to older indices", e);
             return;
         }
-        for (String indexName : defaultIndexSet.getManagedIndicesNames()) {
+        for (String indexName : defaultIndexSet.getManagedIndices()) {
             if (indexName.equals(currentWriteTarget)) {
                 // do not recalculate for current write target
                 continue;
@@ -120,7 +120,7 @@ public class V20161130141500_DefaultStreamRecalcIndexRanges extends Migration {
                 continue;
             }
             LOG.info("Recalculating streams in index {}", indexName);
-            final CreateNewSingleIndexRangeJob createNewSingleIndexRangeJob = rebuildIndexRangeJobFactory.create(indexSetRegistry.getAllIndexSets(), indexName);
+            final CreateNewSingleIndexRangeJob createNewSingleIndexRangeJob = rebuildIndexRangeJobFactory.create(indexSetRegistry.getAll(), indexName);
             createNewSingleIndexRangeJob.execute();
         }
 

--- a/graylog2-server/src/main/java/org/graylog2/periodical/IndexRangesCleanupPeriodical.java
+++ b/graylog2-server/src/main/java/org/graylog2/periodical/IndexRangesCleanupPeriodical.java
@@ -72,7 +72,7 @@ public class IndexRangesCleanupPeriodical extends Periodical {
             return;
         }
 
-        final Set<String> indexNames = ImmutableSet.copyOf(indexSetRegistry.getManagedIndicesNames());
+        final Set<String> indexNames = ImmutableSet.copyOf(indexSetRegistry.getManagedIndices());
         final SortedSet<IndexRange> indexRanges = indexRangeService.findAll();
 
         final Set<String> removedIndices = new HashSet<>();

--- a/graylog2-server/src/main/java/org/graylog2/periodical/IndexRangesMigrationPeriodical.java
+++ b/graylog2-server/src/main/java/org/graylog2/periodical/IndexRangesMigrationPeriodical.java
@@ -87,7 +87,7 @@ public class IndexRangesMigrationPeriodical extends Periodical {
             Uninterruptibles.sleepUninterruptibly(5, TimeUnit.SECONDS);
         }
 
-        final Set<String> indexNames = ImmutableSet.copyOf(indexSetRegistry.getManagedIndicesNames());
+        final Set<String> indexNames = ImmutableSet.copyOf(indexSetRegistry.getManagedIndices());
 
         // Migrate old MongoDB index ranges
         final SortedSet<IndexRange> mongoIndexRanges = legacyMongoIndexRangeService.findAll();

--- a/graylog2-server/src/main/java/org/graylog2/periodical/IndexRotationThread.java
+++ b/graylog2-server/src/main/java/org/graylog2/periodical/IndexRotationThread.java
@@ -141,19 +141,19 @@ public class IndexRotationThread extends Periodical {
             try {
                 String currentTarget;
                 try {
-                    currentTarget = indexSet.getCurrentActualTargetIndex();
+                    currentTarget = indexSet.getActiveWriteIndex();
                 } catch (TooManyAliasesException e) {
                     // If we get this exception, there are multiple indices which have the deflector alias set.
                     // We try to cleanup the alias and try again. This should not happen, but might under certain
                     // circumstances.
                     indexSet.cleanupAliases(e.getIndices());
                     try {
-                        currentTarget = indexSet.getCurrentActualTargetIndex();
+                        currentTarget = indexSet.getActiveWriteIndex();
                     } catch (TooManyAliasesException e1) {
                         throw new IllegalStateException(e1);
                     }
                 }
-                String shouldBeTarget = indexSet.getNewestTargetName();
+                String shouldBeTarget = indexSet.getNewestIndex();
 
                 if (!shouldBeTarget.equals(currentTarget)) {
                     String msg = "Deflector is pointing to [" + currentTarget + "], not the newest one: [" + shouldBeTarget + "]. Re-pointing.";

--- a/graylog2-server/src/main/java/org/graylog2/rest/resources/messages/MessageResource.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/resources/messages/MessageResource.java
@@ -204,7 +204,7 @@ public class MessageResource extends RestResource {
             @ApiParam(name = "string", value = "The string to analyze.", required = true)
             @QueryParam("string") @NotEmpty String string) {
 
-        final String indexAnalyzer = indexSetRegistry.getForIndexName(index)
+        final String indexAnalyzer = indexSetRegistry.getForIndex(index)
                 .map(indexSet -> indexSet.getConfig().indexAnalyzer())
                 .orElse("standard");
         final String messageAnalyzer = analyzer == null ? indexAnalyzer : analyzer;

--- a/graylog2-server/src/main/java/org/graylog2/rest/resources/system/DeflectorResource.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/resources/system/DeflectorResource.java
@@ -70,7 +70,7 @@ public class DeflectorResource extends RestResource {
     @Deprecated
     public DeflectorSummary deprecatedDeflector() throws TooManyAliasesException {
         final IndexSet indexSet = indexSetRegistry.getDefault();
-        return DeflectorSummary.create(indexSet.isUp(), indexSet.getCurrentActualTargetIndex());
+        return DeflectorSummary.create(indexSet.isUp(), indexSet.getActiveWriteIndex());
     }
 
     @GET
@@ -82,7 +82,7 @@ public class DeflectorResource extends RestResource {
     public DeflectorSummary deflector(@ApiParam(name = "indexSetId") @PathParam("indexSetId") String indexSetId) throws TooManyAliasesException {
         final IndexSet indexSet = getIndexSet(indexSetRegistry, indexSetId);
 
-        return DeflectorSummary.create(indexSet.isUp(), indexSet.getCurrentActualTargetIndex());
+        return DeflectorSummary.create(indexSet.isUp(), indexSet.getActiveWriteIndex());
     }
 
     @POST

--- a/graylog2-server/src/main/java/org/graylog2/rest/resources/system/IndexRangesResource.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/resources/system/IndexRangesResource.java
@@ -147,7 +147,7 @@ public class IndexRangesResource extends RestResource {
     @Produces(MediaType.APPLICATION_JSON)
     @AuditEvent(type = AuditEventTypes.ES_INDEX_RANGE_UPDATE_JOB)
     public Response rebuild() {
-        submitIndexRangesJob(indexSetRegistry.getAllIndexSets());
+        submitIndexRangesJob(indexSetRegistry.getAll());
 
         return Response.accepted().build();
     }
@@ -194,7 +194,7 @@ public class IndexRangesResource extends RestResource {
         }
         checkPermission(RestPermissions.INDEXRANGES_REBUILD, index);
 
-        final SystemJob rebuildJob = singleIndexRangeJobFactory.create(indexSetRegistry.getAllIndexSets(), index);
+        final SystemJob rebuildJob = singleIndexRangeJobFactory.create(indexSetRegistry.getAll(), index);
         try {
             this.systemJobManager.submit(rebuildJob);
         } catch (SystemJobConcurrencyException e) {

--- a/graylog2-server/src/main/java/org/graylog2/rest/resources/system/SystemFieldsResource.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/resources/system/SystemFieldsResource.java
@@ -62,7 +62,7 @@ public class SystemFieldsResource extends RestResource {
                                            @QueryParam("limit") int limit) {
         boolean unlimited = limit <= 0;
 
-        final String[] writeIndexWildcards = indexSetRegistry.getWriteIndexWildcards();
+        final String[] writeIndexWildcards = indexSetRegistry.getIndexWildcards();
 
         final Set<String> fields;
         if (unlimited) {

--- a/graylog2-server/src/main/java/org/graylog2/rest/resources/system/indexer/IndexSetsResource.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/resources/system/indexer/IndexSetsResource.java
@@ -144,7 +144,7 @@ public class IndexSetsResource extends RestResource {
 
         final Map<String, IndexSetStats> stats;
         if (computeStats) {
-            stats = indexSetRegistry.getAllIndexSets().stream()
+            stats = indexSetRegistry.getAll().stream()
                     .collect(Collectors.toMap(indexSet -> indexSet.getConfig().id(), indexSetStatsCreator::getForIndexSet));
         } else {
             stats = Collections.emptyMap();

--- a/graylog2-server/src/main/java/org/graylog2/rest/resources/system/indexer/IndicesResource.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/resources/system/indexer/IndicesResource.java
@@ -138,7 +138,7 @@ public class IndicesResource extends RestResource {
     @RequiresPermissions(RestPermissions.INDICES_READ)
     @Produces(MediaType.APPLICATION_JSON)
     public OpenIndicesInfo open() {
-        final Set<IndexStatistics> indicesStats = indexSetRegistry.getAllIndexSets().stream()
+        final Set<IndexStatistics> indicesStats = indexSetRegistry.getAll().stream()
                 .flatMap(indexSet -> indices.getIndicesStats(indexSet).stream())
                 .collect(Collectors.toSet());
 
@@ -151,7 +151,7 @@ public class IndicesResource extends RestResource {
     @ApiOperation(value = "Get a list of closed indices that can be reopened.")
     @Produces(MediaType.APPLICATION_JSON)
     public ClosedIndices closed() {
-        final Set<String> closedIndices = indexSetRegistry.getAllIndexSets().stream()
+        final Set<String> closedIndices = indexSetRegistry.getAll().stream()
                 .flatMap(indexSet -> indices.getClosedIndices(indexSet).stream())
                 .filter((indexName) -> isPermitted(RestPermissions.INDICES_READ, indexName) && indexSetRegistry.isManagedIndex(indexName))
                 .collect(Collectors.toSet());
@@ -165,7 +165,7 @@ public class IndicesResource extends RestResource {
     @ApiOperation(value = "Get a list of reopened indices, which will not be cleaned by retention cleaning")
     @Produces(MediaType.APPLICATION_JSON)
     public ClosedIndices reopened() {
-        final Set<String> reopenedIndices = indexSetRegistry.getAllIndexSets().stream()
+        final Set<String> reopenedIndices = indexSetRegistry.getAll().stream()
                 .flatMap(indexSet -> indices.getReopenedIndices(indexSet).stream())
                 .filter((indexName) -> isPermitted(RestPermissions.INDICES_READ, indexName) && indexSetRegistry.isManagedIndex(indexName))
                 .collect(Collectors.toSet());

--- a/graylog2-server/src/main/java/org/graylog2/system/stats/elasticsearch/ElasticsearchProbe.java
+++ b/graylog2-server/src/main/java/org/graylog2/system/stats/elasticsearch/ElasticsearchProbe.java
@@ -72,7 +72,7 @@ public class ElasticsearchProbe {
             pendingTasksTimeInQueue.add(pendingClusterTask.getTimeInQueueInMillis());
         }
 
-        final ClusterHealthResponse clusterHealthResponse = adminClient.health(new ClusterHealthRequest(indexSetRegistry.getWriteIndexWildcards())).actionGet();
+        final ClusterHealthResponse clusterHealthResponse = adminClient.health(new ClusterHealthRequest(indexSetRegistry.getIndexWildcards())).actionGet();
         final ClusterHealth clusterHealth = ClusterHealth.create(
                 clusterHealthResponse.getNumberOfNodes(),
                 clusterHealthResponse.getNumberOfDataNodes(),

--- a/graylog2-server/src/test/java/org/graylog2/indexer/IndexHelperTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/indexer/IndexHelperTest.java
@@ -78,7 +78,7 @@ public class IndexHelperTest {
         final IndexSet indexSet = mock(IndexSet.class);
         when(indexSet.extractIndexNumber(anyString())).thenAnswer(
                 invocationOnMock -> Optional.ofNullable(indexNumbers.get(invocationOnMock.<String>getArgument(0))));
-        when(indexSet.getManagedIndicesNames()).thenReturn(indexNumbers.keySet().toArray(new String[0]));
+        when(indexSet.getManagedIndices()).thenReturn(indexNumbers.keySet().toArray(new String[0]));
         when(indexSet.getIndexPrefix()).thenReturn("graylog_production");
 
         assertThat(IndexHelper.getOldestIndices(indexSet, 7)).containsOnly(
@@ -95,7 +95,7 @@ public class IndexHelperTest {
     @Test
     public void testGetOldestIndicesWithEmptySetAndTooHighOffset() {
         final IndexSet indexSet = mock(IndexSet.class);
-        when(indexSet.getManagedIndicesNames()).thenReturn(new String[0]);
+        when(indexSet.getManagedIndices()).thenReturn(new String[0]);
         assertThat(IndexHelper.getOldestIndices(indexSet, 9001)).isEmpty();
     }
 }

--- a/graylog2-server/src/test/java/org/graylog2/indexer/MongoIndexSetTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/indexer/MongoIndexSetTest.java
@@ -124,22 +124,22 @@ public class MongoIndexSetTest {
 
     @Test
     public void nullIndexerDoesNotThrow() {
-        final Map<String, Set<String>> deflectorIndices = mongoIndexSet.getAllDeflectorAliases();
+        final Map<String, Set<String>> deflectorIndices = mongoIndexSet.getAllIndexAliases();
         assertThat(deflectorIndices).isEmpty();
     }
 
     @Test
     public void nullIndexerDoesNotThrowOnIndexName() {
-        final String[] indicesNames = mongoIndexSet.getManagedIndicesNames();
+        final String[] indicesNames = mongoIndexSet.getManagedIndices();
         assertThat(indicesNames).isEmpty();
     }
 
     @Test
     public void testIsDeflectorAlias() {
-        assertTrue(mongoIndexSet.isDeflectorAlias("graylog_deflector"));
-        assertFalse(mongoIndexSet.isDeflectorAlias("graylog_foobar"));
-        assertFalse(mongoIndexSet.isDeflectorAlias("graylog_123"));
-        assertFalse(mongoIndexSet.isDeflectorAlias("HAHA"));
+        assertTrue(mongoIndexSet.isWriteIndexAlias("graylog_deflector"));
+        assertFalse(mongoIndexSet.isWriteIndexAlias("graylog_foobar"));
+        assertFalse(mongoIndexSet.isWriteIndexAlias("graylog_123"));
+        assertFalse(mongoIndexSet.isWriteIndexAlias("HAHA"));
     }
 
     @Test
@@ -193,7 +193,7 @@ public class MongoIndexSetTest {
         when(indices.getIndexNamesAndAliases(anyString())).thenReturn(indexNameAliases);
         final MongoIndexSet mongoIndexSet = new MongoIndexSet(config, indices, nodeId, indexRangeService, auditEventSender, systemJobManager, jobFactory, activityWriter);
 
-        final int number = mongoIndexSet.getNewestTargetNumber();
+        final int number = mongoIndexSet.getNewestIndexNumber();
         assertEquals(3, number);
     }
 
@@ -210,7 +210,7 @@ public class MongoIndexSetTest {
         final MongoIndexSet mongoIndexSet = new MongoIndexSet(config, indices, nodeId, indexRangeService, auditEventSender, systemJobManager, jobFactory, activityWriter);
 
 
-        final String[] allGraylogIndexNames = mongoIndexSet.getManagedIndicesNames();
+        final String[] allGraylogIndexNames = mongoIndexSet.getManagedIndices();
         assertThat(allGraylogIndexNames).containsExactlyElementsOf(indexNameAliases.keySet());
     }
 
@@ -226,7 +226,7 @@ public class MongoIndexSetTest {
         when(indices.getIndexNamesAndAliases(anyString())).thenReturn(indexNameAliases);
 
         final MongoIndexSet mongoIndexSet = new MongoIndexSet(config, indices, nodeId, indexRangeService, auditEventSender, systemJobManager, jobFactory, activityWriter);
-        final Map<String, Set<String>> deflectorIndices = mongoIndexSet.getAllDeflectorAliases();
+        final Map<String, Set<String>> deflectorIndices = mongoIndexSet.getAllIndexAliases();
 
         assertThat(deflectorIndices).containsOnlyKeys("graylog_1", "graylog_2", "graylog_3", "graylog_5");
     }

--- a/graylog2-server/src/test/java/org/graylog2/indexer/counts/CountsTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/indexer/counts/CountsTest.java
@@ -149,11 +149,11 @@ public class CountsTest {
                 .indexOptimizationDisabled(false)
                 .build();
 
-        when(indexSetRegistry.getManagedIndicesNames()).thenReturn(new String[]{INDEX_NAME_1, INDEX_NAME_2});
+        when(indexSetRegistry.getManagedIndices()).thenReturn(new String[]{INDEX_NAME_1, INDEX_NAME_2});
         when(indexSetRegistry.get(indexSetConfig1.id())).thenReturn(Optional.of(indexSet1));
         when(indexSetRegistry.get(indexSetConfig2.id())).thenReturn(Optional.of(indexSet2));
-        when(indexSet1.getManagedIndicesNames()).thenReturn(new String[]{INDEX_NAME_1});
-        when(indexSet2.getManagedIndicesNames()).thenReturn(new String[]{INDEX_NAME_2});
+        when(indexSet1.getManagedIndices()).thenReturn(new String[]{INDEX_NAME_1});
+        when(indexSet2.getManagedIndices()).thenReturn(new String[]{INDEX_NAME_2});
     }
 
     @After
@@ -193,13 +193,13 @@ public class CountsTest {
         }
 
         // Simulate no indices for the second index set.
-        when(indexSet2.getManagedIndicesNames()).thenReturn(new String[0]);
+        when(indexSet2.getManagedIndices()).thenReturn(new String[0]);
 
         assertThat(counts.total(indexSet1)).isEqualTo(10L);
         assertThat(counts.total(indexSet2)).isEqualTo(0L);
 
         // Simulate no indices for all index sets.
-        when(indexSetRegistry.getManagedIndicesNames()).thenReturn(new String[0]);
+        when(indexSetRegistry.getManagedIndices()).thenReturn(new String[0]);
 
         assertThat(counts.total()).isEqualTo(0L);
     }
@@ -235,7 +235,7 @@ public class CountsTest {
     @Test
     public void totalReturnsMinusOneIfIndexDoesNotExist() throws Exception {
         final IndexSet indexSet = mock(IndexSet.class);
-        when(indexSet.getManagedIndicesNames()).thenReturn(new String[]{"does_not_exist"});
+        when(indexSet.getManagedIndices()).thenReturn(new String[]{"does_not_exist"});
         assertThat(counts.total(indexSet)).isEqualTo(-1L);
     }
 }

--- a/graylog2-server/src/test/java/org/graylog2/indexer/indices/IndicesTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/indexer/indices/IndicesTest.java
@@ -241,7 +241,7 @@ public class IndicesTest {
                     "type", "string",
                     "index", "not_analyzed")));
         assertThat(client.preparePutTemplate(templateName)
-                .setTemplate(indexSet.getWriteIndexWildcard())
+                .setTemplate(indexSet.getIndexWildcard())
                 .addMapping(IndexMapping.TYPE_MESSAGE, beforeMapping)
                 .get()
                 .isAcknowledged())
@@ -263,7 +263,7 @@ public class IndicesTest {
         assertThat(templateMetaData.getMappings().keysIt()).containsExactly(IndexMapping.TYPE_MESSAGE);
 
         final Map<String, Object> mapping = mapper.readValue(templateMetaData.getMappings().get(IndexMapping.TYPE_MESSAGE).uncompressed(), new TypeReference<Map<String, Object>>() {});
-        final Map<String, Object> expectedTemplate = new IndexMapping().messageTemplate(indexSet.getWriteIndexWildcard(), indexSetConfig.indexAnalyzer());
+        final Map<String, Object> expectedTemplate = new IndexMapping().messageTemplate(indexSet.getIndexWildcard(), indexSetConfig.indexAnalyzer());
         assertThat(mapping).isEqualTo(expectedTemplate.get("mappings"));
 
         final DeleteIndexTemplateRequest deleteRequest = client.prepareDeleteTemplate(templateName).request();

--- a/graylog2-server/src/test/java/org/graylog2/indexer/ranges/EsIndexRangeServiceTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/indexer/ranges/EsIndexRangeServiceTest.java
@@ -110,7 +110,7 @@ public class EsIndexRangeServiceTest {
 
     @Before
     public void setUp() throws Exception {
-        when(indexSetRegistry.getManagedIndicesNames()).thenReturn(new String[]{
+        when(indexSetRegistry.getManagedIndices()).thenReturn(new String[]{
                 "graylog_1", "graylog_2", "graylog_3", "graylog_4", "graylog_5"});
        indexRangeService = new EsIndexRangeService(client, indexSetRegistry, localEventBus, new MetricRegistry());
     }

--- a/graylog2-server/src/test/java/org/graylog2/indexer/retention/strategies/AbstractIndexCountBasedRetentionStrategyTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/indexer/retention/strategies/AbstractIndexCountBasedRetentionStrategyTest.java
@@ -72,8 +72,8 @@ public class AbstractIndexCountBasedRetentionStrategyTest {
             put("index6", Collections.emptySet());
         }};
 
-        when(indexSet.getAllDeflectorAliases()).thenReturn(indexMap);
-        when(indexSet.getManagedIndicesNames()).thenReturn(indexMap.keySet().stream().toArray(String[]::new));
+        when(indexSet.getAllIndexAliases()).thenReturn(indexMap);
+        when(indexSet.getManagedIndices()).thenReturn(indexMap.keySet().stream().toArray(String[]::new));
         when(indexSet.extractIndexNumber(anyString())).then(this::extractIndexNumber);
 
         retentionStrategy = spy(new AbstractIndexCountBasedRetentionStrategy(indices, activityWriter) {

--- a/graylog2-server/src/test/java/org/graylog2/indexer/rotation/strategies/MessageCountRotationStrategyTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/indexer/rotation/strategies/MessageCountRotationStrategyTest.java
@@ -58,7 +58,7 @@ public class MessageCountRotationStrategyTest {
     @Test
     public void testRotate() throws Exception {
         when(indices.numberOfMessages("name")).thenReturn(10L);
-        when(indexSet.getNewestTargetName()).thenReturn("name");
+        when(indexSet.getNewestIndex()).thenReturn("name");
         when(indexSet.getConfig()).thenReturn(indexSetConfig);
         when(indexSetConfig.rotationStrategy()).thenReturn(MessageCountRotationStrategyConfig.create(5));
 
@@ -72,7 +72,7 @@ public class MessageCountRotationStrategyTest {
     @Test
     public void testDontRotate() throws Exception {
         when(indices.numberOfMessages("name")).thenReturn(1L);
-        when(indexSet.getNewestTargetName()).thenReturn("name");
+        when(indexSet.getNewestIndex()).thenReturn("name");
         when(indexSet.getConfig()).thenReturn(indexSetConfig);
         when(indexSetConfig.rotationStrategy()).thenReturn(MessageCountRotationStrategyConfig.create(5));
 
@@ -87,7 +87,7 @@ public class MessageCountRotationStrategyTest {
     @Test
     public void testIndexUnavailable() throws Exception {
         doThrow(IndexNotFoundException.class).when(indices).numberOfMessages("name");
-        when(indexSet.getNewestTargetName()).thenReturn("name");
+        when(indexSet.getNewestIndex()).thenReturn("name");
         when(indexSet.getConfig()).thenReturn(indexSetConfig);
         when(indexSetConfig.rotationStrategy()).thenReturn(MessageCountRotationStrategyConfig.create(5));
 

--- a/graylog2-server/src/test/java/org/graylog2/indexer/rotation/strategies/SizeBasedRotationStrategyTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/indexer/rotation/strategies/SizeBasedRotationStrategyTest.java
@@ -66,7 +66,7 @@ public class SizeBasedRotationStrategyTest {
         final IndexStatistics stats = IndexStatistics.create("name", commonStats, commonStats, Collections.<ShardRouting>emptyList());
 
         when(indices.getIndexStats("name")).thenReturn(stats);
-        when(indexSet.getNewestTargetName()).thenReturn("name");
+        when(indexSet.getNewestIndex()).thenReturn("name");
         when(indexSet.getConfig()).thenReturn(indexSetConfig);
         when(indexSetConfig.rotationStrategy()).thenReturn(SizeBasedRotationStrategyConfig.create(100L));
 
@@ -85,7 +85,7 @@ public class SizeBasedRotationStrategyTest {
         final IndexStatistics stats = IndexStatistics.create("name", commonStats, commonStats, Collections.<ShardRouting>emptyList());
 
         when(indices.getIndexStats("name")).thenReturn(stats);
-        when(indexSet.getNewestTargetName()).thenReturn("name");
+        when(indexSet.getNewestIndex()).thenReturn("name");
         when(indexSet.getConfig()).thenReturn(indexSetConfig);
         when(indexSetConfig.rotationStrategy()).thenReturn(SizeBasedRotationStrategyConfig.create(100000L));
 
@@ -100,7 +100,7 @@ public class SizeBasedRotationStrategyTest {
     @Test
     public void testRotateFailed() throws Exception {
         when(indices.getIndexStats("name")).thenReturn(null);
-        when(indexSet.getNewestTargetName()).thenReturn("name");
+        when(indexSet.getNewestIndex()).thenReturn("name");
         when(indexSet.getConfig()).thenReturn(indexSetConfig);
         when(indexSetConfig.rotationStrategy()).thenReturn(SizeBasedRotationStrategyConfig.create(100L));
 

--- a/graylog2-server/src/test/java/org/graylog2/indexer/rotation/strategies/TimeBasedRotationStrategyTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/indexer/rotation/strategies/TimeBasedRotationStrategyTest.java
@@ -147,7 +147,7 @@ public class TimeBasedRotationStrategyTest {
         when(indices.indexCreationDate(anyString())).thenReturn(initialTime.minus(minutes(5)));
 
         // Should not rotate the first index.
-        when(indexSet.getNewestTargetName()).thenReturn("ignored");
+        when(indexSet.getNewestIndex()).thenReturn("ignored");
         rotationStrategy.rotate(indexSet);
         verify(indexSet, never()).cycle();
         reset(indexSet);
@@ -155,7 +155,7 @@ public class TimeBasedRotationStrategyTest {
         clock.tick(seconds(2));
 
         // Crossed rotation period.
-        when(indexSet.getNewestTargetName()).thenReturn("ignored");
+        when(indexSet.getNewestIndex()).thenReturn("ignored");
         when(indexSet.getConfig()).thenReturn(indexSetConfig);
         when(indexSetConfig.rotationStrategy()).thenReturn(TimeBasedRotationStrategyConfig.create(period));
         rotationStrategy.rotate(indexSet);
@@ -165,7 +165,7 @@ public class TimeBasedRotationStrategyTest {
         clock.tick(seconds(2));
 
         // Did not cross rotation period.
-        when(indexSet.getNewestTargetName()).thenReturn("ignored");
+        when(indexSet.getNewestIndex()).thenReturn("ignored");
         when(indexSet.getConfig()).thenReturn(indexSetConfig);
         when(indexSetConfig.rotationStrategy()).thenReturn(TimeBasedRotationStrategyConfig.create(period));
         rotationStrategy.rotate(indexSet);
@@ -187,7 +187,7 @@ public class TimeBasedRotationStrategyTest {
 
         // Should rotate the first index.
         // time is 01:55:00, index was created at 01:44:00, so we missed one period, and should rotate
-        when(indexSet.getNewestTargetName()).thenReturn("ignored");
+        when(indexSet.getNewestIndex()).thenReturn("ignored");
         when(indexSet.getConfig()).thenReturn(indexSetConfig);
         when(indexSetConfig.rotationStrategy()).thenReturn(TimeBasedRotationStrategyConfig.create(period));
         rotationStrategy.rotate(indexSet);
@@ -198,7 +198,7 @@ public class TimeBasedRotationStrategyTest {
         clock.tick(seconds(1));
 
         // Did not cross rotation period.
-        when(indexSet.getNewestTargetName()).thenReturn("ignored");
+        when(indexSet.getNewestIndex()).thenReturn("ignored");
         when(indexSet.getConfig()).thenReturn(indexSetConfig);
         when(indexSetConfig.rotationStrategy()).thenReturn(TimeBasedRotationStrategyConfig.create(period));
         rotationStrategy.rotate(indexSet);
@@ -209,7 +209,7 @@ public class TimeBasedRotationStrategyTest {
         clock.tick(minutes(4).withSeconds(59));
 
         // Crossed rotation period.
-        when(indexSet.getNewestTargetName()).thenReturn("ignored");
+        when(indexSet.getNewestIndex()).thenReturn("ignored");
         when(indexSet.getConfig()).thenReturn(indexSetConfig);
         when(indexSetConfig.rotationStrategy()).thenReturn(TimeBasedRotationStrategyConfig.create(period));
         rotationStrategy.rotate(indexSet);
@@ -221,7 +221,7 @@ public class TimeBasedRotationStrategyTest {
         clock.tick(minutes(51));
 
         // Crossed multiple rotation periods.
-        when(indexSet.getNewestTargetName()).thenReturn("ignored");
+        when(indexSet.getNewestIndex()).thenReturn("ignored");
         when(indexSet.getConfig()).thenReturn(indexSetConfig);
         when(indexSetConfig.rotationStrategy()).thenReturn(TimeBasedRotationStrategyConfig.create(period));
         rotationStrategy.rotate(indexSet);
@@ -231,7 +231,7 @@ public class TimeBasedRotationStrategyTest {
         // move time to 2:52:00
         // this should not cycle again, because next valid rotation time is 3:00:00
         clock.tick(minutes(1));
-        when(indexSet.getNewestTargetName()).thenReturn("ignored");
+        when(indexSet.getNewestIndex()).thenReturn("ignored");
         when(indexSet.getConfig()).thenReturn(indexSetConfig);
         when(indexSetConfig.rotationStrategy()).thenReturn(TimeBasedRotationStrategyConfig.create(period));
         rotationStrategy.rotate(indexSet);
@@ -242,7 +242,7 @@ public class TimeBasedRotationStrategyTest {
     @Test
     public void shouldRotateThrowsNPEIfIndexSetConfigIsNull() throws Exception {
         when(indexSet.getConfig()).thenReturn(null);
-        when(indexSet.getNewestTargetName()).thenReturn("ignored");
+        when(indexSet.getNewestIndex()).thenReturn("ignored");
 
         expectedException.expect(NullPointerException.class);
         expectedException.expectMessage("Index set configuration must not be null");
@@ -253,7 +253,7 @@ public class TimeBasedRotationStrategyTest {
     @Test
     public void shouldRotateThrowsISEIfIndexIsNull() throws Exception {
         when(indexSet.getConfig()).thenReturn(indexSetConfig);
-        when(indexSet.getNewestTargetName()).thenReturn(null);
+        when(indexSet.getNewestIndex()).thenReturn(null);
 
         expectedException.expect(IllegalStateException.class);
         expectedException.expectMessage("Index name must not be null or empty");
@@ -264,7 +264,7 @@ public class TimeBasedRotationStrategyTest {
     @Test
     public void shouldRotateThrowsISEIfIndexIsEmpty() throws Exception {
         when(indexSet.getConfig()).thenReturn(indexSetConfig);
-        when(indexSet.getNewestTargetName()).thenReturn("");
+        when(indexSet.getNewestIndex()).thenReturn("");
 
         expectedException.expect(IllegalStateException.class);
         expectedException.expectMessage("Index name must not be null or empty");
@@ -276,7 +276,7 @@ public class TimeBasedRotationStrategyTest {
     public void shouldRotateThrowsISEIfIndexSetIdIsNull() throws Exception {
         when(indexSet.getConfig()).thenReturn(indexSetConfig);
         when(indexSetConfig.id()).thenReturn(null);
-        when(indexSet.getNewestTargetName()).thenReturn("ignored");
+        when(indexSet.getNewestIndex()).thenReturn("ignored");
 
         expectedException.expect(IllegalStateException.class);
         expectedException.expectMessage("Index set ID must not be null or empty");
@@ -288,7 +288,7 @@ public class TimeBasedRotationStrategyTest {
     public void shouldRotateThrowsISEIfIndexSetIdIsEmpty() throws Exception {
         when(indexSet.getConfig()).thenReturn(indexSetConfig);
         when(indexSetConfig.id()).thenReturn("");
-        when(indexSet.getNewestTargetName()).thenReturn("ignored");
+        when(indexSet.getNewestIndex()).thenReturn("ignored");
 
         expectedException.expect(IllegalStateException.class);
         expectedException.expectMessage("Index set ID must not be null or empty");
@@ -299,7 +299,7 @@ public class TimeBasedRotationStrategyTest {
     @Test
     public void shouldRotateThrowsISEIfRotationStrategyHasIncorrectType() throws Exception {
         when(indexSet.getConfig()).thenReturn(indexSetConfig);
-        when(indexSet.getNewestTargetName()).thenReturn("ignored");
+        when(indexSet.getNewestIndex()).thenReturn("ignored");
         when(indexSetConfig.rotationStrategy()).thenReturn(MessageCountRotationStrategyConfig.createDefault());
 
         expectedException.expect(IllegalStateException.class);
@@ -333,12 +333,12 @@ public class TimeBasedRotationStrategyTest {
         when(indices.indexCreationDate(anyString())).thenReturn(initialTime.minus(minutes(5)));
 
         // Should not rotate the initial index.
-        when(indexSet1.getNewestTargetName()).thenReturn("index1");
+        when(indexSet1.getNewestIndex()).thenReturn("index1");
         rotationStrategy.rotate(indexSet1);
         verify(indexSet1, never()).cycle();
         reset(indexSet1);
 
-        when(indexSet2.getNewestTargetName()).thenReturn("index2");
+        when(indexSet2.getNewestIndex()).thenReturn("index2");
         rotationStrategy.rotate(indexSet2);
         verify(indexSet2, never()).cycle();
         reset(indexSet2);
@@ -346,14 +346,14 @@ public class TimeBasedRotationStrategyTest {
         clock.tick(seconds(2));
 
         // Crossed rotation period.
-        when(indexSet1.getNewestTargetName()).thenReturn("index1");
+        when(indexSet1.getNewestIndex()).thenReturn("index1");
         when(indexSet1.getConfig()).thenReturn(indexSetConfig1);
         when(indexSetConfig1.rotationStrategy()).thenReturn(TimeBasedRotationStrategyConfig.create(period));
         rotationStrategy.rotate(indexSet1);
         verify(indexSet1, times(1)).cycle();
         reset(indexSet1);
 
-        when(indexSet2.getNewestTargetName()).thenReturn("index2");
+        when(indexSet2.getNewestIndex()).thenReturn("index2");
         when(indexSet2.getConfig()).thenReturn(indexSetConfig2);
         when(indexSetConfig2.rotationStrategy()).thenReturn(TimeBasedRotationStrategyConfig.create(period));
         rotationStrategy.rotate(indexSet2);
@@ -363,14 +363,14 @@ public class TimeBasedRotationStrategyTest {
         clock.tick(seconds(2));
 
         // Did not cross rotation period.
-        when(indexSet1.getNewestTargetName()).thenReturn("index1");
+        when(indexSet1.getNewestIndex()).thenReturn("index1");
         when(indexSet1.getConfig()).thenReturn(indexSetConfig1);
         when(indexSetConfig1.rotationStrategy()).thenReturn(TimeBasedRotationStrategyConfig.create(period));
         rotationStrategy.rotate(indexSet1);
         verify(indexSet1, never()).cycle();
         reset(indexSet1);
 
-        when(indexSet2.getNewestTargetName()).thenReturn("index2");
+        when(indexSet2.getNewestIndex()).thenReturn("index2");
         when(indexSet2.getConfig()).thenReturn(indexSetConfig2);
         when(indexSetConfig2.rotationStrategy()).thenReturn(TimeBasedRotationStrategyConfig.create(period));
         rotationStrategy.rotate(indexSet2);


### PR DESCRIPTION
- Rename several methods to make them easier to understand
- Add missing documentation for the `IndexSet` interface

Refs #2880
