### PR TITLE
Creating Mongo indices in services which do conditional queries.

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/alarmcallbacks/AlarmCallbackConfigurationImpl.java
+++ b/graylog2-server/src/main/java/org/graylog2/alarmcallbacks/AlarmCallbackConfigurationImpl.java
@@ -30,59 +30,67 @@ import java.util.Map;
 @AutoValue
 @JsonAutoDetect
 @CollectionName("alarmcallbackconfigurations")
-public abstract class AlarmCallbackConfigurationAVImpl implements AlarmCallbackConfiguration {
-    @JsonProperty("_id")
+public abstract class AlarmCallbackConfigurationImpl implements AlarmCallbackConfiguration {
+    static final String FIELD_ID = "_id";
+    static final String FIELD_STREAM_ID = "stream_id";
+    static final String FIELD_TYPE = "type";
+    static final String FIELD_TITLE = "title";
+    static final String FIELD_CONFIGURATION = "configuration";
+    static final String FIELD_CREATED_AT = "created_at";
+    static final String FIELD_CREATOR_USER_ID = "creator_user_id";
+
+    @JsonProperty(FIELD_ID)
     @ObjectId
     @Override
     public abstract String getId();
 
-    @JsonProperty("stream_id")
+    @JsonProperty(FIELD_STREAM_ID)
     @Override
     public abstract String getStreamId();
 
-    @JsonProperty("type")
+    @JsonProperty(FIELD_TYPE)
     @Override
     public abstract String getType();
 
-    @JsonProperty("title")
+    @JsonProperty(FIELD_TITLE)
     @Override
     @Nullable
     public abstract String getTitle();
 
-    @JsonProperty("configuration")
+    @JsonProperty(FIELD_CONFIGURATION)
     @Override
     public abstract Map<String, Object> getConfiguration();
 
-    @JsonProperty("created_at")
+    @JsonProperty(FIELD_CREATED_AT)
     @Override
     public abstract Date getCreatedAt();
 
-    @JsonProperty("creator_user_id")
+    @JsonProperty(FIELD_CREATOR_USER_ID)
     @Override
     public abstract String getCreatorUserId();
 
     public abstract Builder toBuilder();
 
     @JsonCreator
-    public static AlarmCallbackConfigurationAVImpl create(@JsonProperty("_id") String id,
-                                                          @JsonProperty("stream_id") String streamId,
-                                                          @JsonProperty("type") String type,
-                                                          @JsonProperty("title") @Nullable String title,
-                                                          @JsonProperty("configuration") Map<String, Object> configuration,
-                                                          @JsonProperty("created_at") Date createdAt,
-                                                          @JsonProperty("creator_user_id") String creatorUserId,
-                                                          @Nullable @JsonProperty("id") String redundantId) {
+    public static AlarmCallbackConfigurationImpl create(@JsonProperty(FIELD_ID) String id,
+                                                        @JsonProperty(FIELD_STREAM_ID) String streamId,
+                                                        @JsonProperty(FIELD_TYPE) String type,
+                                                        @JsonProperty(FIELD_TITLE) @Nullable String title,
+                                                        @JsonProperty(FIELD_CONFIGURATION) Map<String, Object> configuration,
+                                                        @JsonProperty(FIELD_CREATED_AT) Date createdAt,
+                                                        @JsonProperty(FIELD_CREATOR_USER_ID) String creatorUserId,
+                                                        @Nullable @JsonProperty("id") String redundantId) {
         return create(id, streamId, type, title, configuration, createdAt, creatorUserId);
     }
 
-    public static AlarmCallbackConfigurationAVImpl create(@JsonProperty("_id") String id,
-                                                          @JsonProperty("stream_id") String streamId,
-                                                          @JsonProperty("type") String type,
-                                                          @JsonProperty("title") @Nullable String title,
-                                                          @JsonProperty("configuration") Map<String, Object> configuration,
-                                                          @JsonProperty("created_at") Date createdAt,
-                                                          @JsonProperty("creator_user_id") String creatorUserId) {
-        return new AutoValue_AlarmCallbackConfigurationAVImpl.Builder()
+    public static AlarmCallbackConfigurationImpl create(@JsonProperty(FIELD_ID) String id,
+                                                        @JsonProperty(FIELD_STREAM_ID) String streamId,
+                                                        @JsonProperty(FIELD_TYPE) String type,
+                                                        @JsonProperty(FIELD_TITLE) @Nullable String title,
+                                                        @JsonProperty(FIELD_CONFIGURATION) Map<String, Object> configuration,
+                                                        @JsonProperty(FIELD_CREATED_AT) Date createdAt,
+                                                        @JsonProperty(FIELD_CREATOR_USER_ID) String creatorUserId) {
+        return new AutoValue_AlarmCallbackConfigurationImpl.Builder()
                 .setId(id)
                 .setStreamId(streamId)
                 .setType(type)
@@ -109,6 +117,6 @@ public abstract class AlarmCallbackConfigurationAVImpl implements AlarmCallbackC
 
         public abstract Builder setCreatorUserId(String creatorUserId);
 
-        public abstract AlarmCallbackConfigurationAVImpl build();
+        public abstract AlarmCallbackConfigurationImpl build();
     }
 }

--- a/graylog2-server/src/main/java/org/graylog2/alarmcallbacks/AlarmCallbackConfigurationService.java
+++ b/graylog2-server/src/main/java/org/graylog2/alarmcallbacks/AlarmCallbackConfigurationService.java
@@ -24,7 +24,7 @@ import org.graylog2.rest.models.alarmcallbacks.requests.CreateAlarmCallbackReque
 import java.util.List;
 import java.util.Map;
 
-@ImplementedBy(AlarmCallbackConfigurationServiceMJImpl.class)
+@ImplementedBy(AlarmCallbackConfigurationServiceImpl.class)
 public interface AlarmCallbackConfigurationService {
     List<AlarmCallbackConfiguration> getForStreamId(String streamId);
     List<AlarmCallbackConfiguration> getForStream(Stream stream);

--- a/graylog2-server/src/main/java/org/graylog2/alarmcallbacks/AlarmCallbackHistoryServiceImpl.java
+++ b/graylog2-server/src/main/java/org/graylog2/alarmcallbacks/AlarmCallbackHistoryServiceImpl.java
@@ -42,6 +42,7 @@ public class AlarmCallbackHistoryServiceImpl implements AlarmCallbackHistoryServ
         final String collectionName = AlarmCallbackHistoryImpl.class.getAnnotation(CollectionName.class).value();
         final DBCollection dbCollection = mongoConnection.getDatabase().getCollection(collectionName);
         this.coll = JacksonDBCollection.wrap(dbCollection, AlarmCallbackHistoryImpl.class, String.class, mapperProvider.get());
+        dbCollection.createIndex(AlarmCallbackHistoryImpl.FIELD_ALERTID);
     }
 
     @Override

--- a/graylog2-server/src/main/java/org/graylog2/alerts/AlertServiceImpl.java
+++ b/graylog2-server/src/main/java/org/graylog2/alerts/AlertServiceImpl.java
@@ -17,6 +17,8 @@
 package org.graylog2.alerts;
 
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.mongodb.BasicDBObject;
 import com.mongodb.DBCollection;
 import org.graylog2.alerts.Alert.AlertState;
 import org.graylog2.bindings.providers.MongoJackObjectMapperProvider;
@@ -57,6 +59,12 @@ public class AlertServiceImpl implements AlertService {
         this.alertConditionFactory = alertConditionFactory;
         final String collectionName = AlertImpl.class.getAnnotation(CollectionName.class).value();
         final DBCollection dbCollection = mongoConnection.getDatabase().getCollection(collectionName);
+
+        dbCollection.createIndex(new BasicDBObject(ImmutableMap.of(
+            AlertImpl.FIELD_TRIGGERED_AT, -1,
+            AlertImpl.FIELD_STREAM_ID, 1
+        )));
+
         this.coll = JacksonDBCollection.wrap(dbCollection, AlertImpl.class, String.class, mapperProvider.get());
     }
 

--- a/graylog2-server/src/main/java/org/graylog2/migrations/V20161125161400_AlertReceiversMigration.java
+++ b/graylog2-server/src/main/java/org/graylog2/migrations/V20161125161400_AlertReceiversMigration.java
@@ -25,7 +25,7 @@ import com.mongodb.BasicDBObject;
 import com.mongodb.DBCollection;
 import org.bson.types.ObjectId;
 import org.graylog2.alarmcallbacks.AlarmCallbackConfiguration;
-import org.graylog2.alarmcallbacks.AlarmCallbackConfigurationAVImpl;
+import org.graylog2.alarmcallbacks.AlarmCallbackConfigurationImpl;
 import org.graylog2.alarmcallbacks.AlarmCallbackConfigurationService;
 import org.graylog2.alarmcallbacks.EmailAlarmCallback;
 import org.graylog2.database.CollectionName;
@@ -157,7 +157,7 @@ public class V20161125161400_AlertReceiversMigration extends Migration {
             configuration.put(EmailAlarmCallback.CK_EMAIL_RECEIVERS, emails);
         }
 
-        final AlarmCallbackConfigurationAVImpl updatedConfiguration = ((AlarmCallbackConfigurationAVImpl) callbackConfiguration).toBuilder()
+        final AlarmCallbackConfigurationImpl updatedConfiguration = ((AlarmCallbackConfigurationImpl) callbackConfiguration).toBuilder()
                 .setConfiguration(configuration).build();
 
         try {

--- a/graylog2-server/src/main/java/org/graylog2/notifications/NotificationImpl.java
+++ b/graylog2-server/src/main/java/org/graylog2/notifications/NotificationImpl.java
@@ -37,6 +37,11 @@ import java.util.Map;
 public class NotificationImpl extends PersistedImpl implements Notification {
 
     private static final Logger LOG = LoggerFactory.getLogger(NotificationImpl.class);
+    static final String FIELD_TYPE = "type";
+    static final String FIELD_SEVERITY = "severity";
+    static final String FIELD_TIMESTAMP = "timestamp";
+    static final String FIELD_NODE_ID = "node_id";
+    static final String FIELD_DETAILS = "details";
 
     private Type type;
     private Severity severity;
@@ -46,19 +51,19 @@ public class NotificationImpl extends PersistedImpl implements Notification {
     protected NotificationImpl(ObjectId id, Map<String, Object> fields) {
         super(id, fields);
 
-        this.type = Type.valueOf(((String) fields.get("type")).toUpperCase(Locale.ENGLISH));
-        this.severity = Severity.valueOf(((String) fields.get("severity")).toUpperCase(Locale.ENGLISH));
-        this.timestamp = new DateTime(fields.get("timestamp"), DateTimeZone.UTC);
-        this.node_id = (String) fields.get("node_id");
+        this.type = Type.valueOf(((String) fields.get(FIELD_TYPE)).toUpperCase(Locale.ENGLISH));
+        this.severity = Severity.valueOf(((String) fields.get(FIELD_SEVERITY)).toUpperCase(Locale.ENGLISH));
+        this.timestamp = new DateTime(fields.get(FIELD_TIMESTAMP), DateTimeZone.UTC);
+        this.node_id = (String) fields.get(FIELD_NODE_ID);
     }
 
     protected NotificationImpl(Map<String, Object> fields) {
         super(fields);
 
-        this.type = Type.valueOf(((String) fields.get("type")).toUpperCase(Locale.ENGLISH));
-        this.severity = Severity.valueOf(((String) fields.get("severity")).toUpperCase(Locale.ENGLISH));
-        this.timestamp = new DateTime(fields.get("timestamp"), DateTimeZone.UTC);
-        this.node_id = (String) fields.get("node_id");
+        this.type = Type.valueOf(((String) fields.get(FIELD_TYPE)).toUpperCase(Locale.ENGLISH));
+        this.severity = Severity.valueOf(((String) fields.get(FIELD_SEVERITY)).toUpperCase(Locale.ENGLISH));
+        this.timestamp = new DateTime(fields.get(FIELD_TIMESTAMP), DateTimeZone.UTC);
+        this.node_id = (String) fields.get(FIELD_NODE_ID);
     }
 
     public NotificationImpl() {
@@ -68,14 +73,14 @@ public class NotificationImpl extends PersistedImpl implements Notification {
     @Override
     public Notification addType(Type type) {
         this.type = type;
-        fields.put("type", type.toString().toLowerCase(Locale.ENGLISH));
+        fields.put(FIELD_TYPE, type.toString().toLowerCase(Locale.ENGLISH));
         return this;
     }
 
     @Override
     public Notification addTimestamp(DateTime timestamp) {
         this.timestamp = timestamp;
-        fields.put("timestamp", Tools.getISO8601String(timestamp));
+        fields.put(FIELD_TIMESTAMP, Tools.getISO8601String(timestamp));
 
         return this;
     }
@@ -83,7 +88,7 @@ public class NotificationImpl extends PersistedImpl implements Notification {
     @Override
     public Notification addSeverity(Severity severity) {
         this.severity = severity;
-        fields.put("severity", severity.toString().toLowerCase(Locale.ENGLISH));
+        fields.put(FIELD_SEVERITY, severity.toString().toLowerCase(Locale.ENGLISH));
         return this;
     }
 
@@ -115,17 +120,17 @@ public class NotificationImpl extends PersistedImpl implements Notification {
     @Override
     public Notification addDetail(String key, Object value) {
         Map<String, Object> details;
-        if (fields.get("details") == null)
-            fields.put("details", new HashMap<String, Object>());
+        if (fields.get(FIELD_DETAILS) == null)
+            fields.put(FIELD_DETAILS, new HashMap<String, Object>());
 
-        details = (Map<String, Object>) fields.get("details");
+        details = (Map<String, Object>) fields.get(FIELD_DETAILS);
         details.put(key, value);
         return this;
     }
 
     @Override
     public Object getDetail(String key) {
-        final Map<String, Object> details = (Map<String, Object>) fields.get("details");
+        final Map<String, Object> details = (Map<String, Object>) fields.get(FIELD_DETAILS);
         if (details == null)
             return null;
 
@@ -142,7 +147,7 @@ public class NotificationImpl extends PersistedImpl implements Notification {
 
     @Override
     public Notification addNode(String nodeId) {
-        fields.put("node_id", nodeId);
+        fields.put(FIELD_NODE_ID, nodeId);
         return this;  //To change body of created methods use File | Settings | File Templates.
     }
 

--- a/graylog2-server/src/main/java/org/graylog2/notifications/NotificationServiceImpl.java
+++ b/graylog2-server/src/main/java/org/graylog2/notifications/NotificationServiceImpl.java
@@ -51,6 +51,7 @@ public class NotificationServiceImpl extends PersistedServiceImpl implements Not
         super(mongoConnection);
         this.nodeId = checkNotNull(nodeId);
         this.auditEventSender = auditEventSender;
+        collection(NotificationImpl.class).createIndex(NotificationImpl.FIELD_TYPE);
     }
 
     @Override
@@ -74,9 +75,9 @@ public class NotificationServiceImpl extends PersistedServiceImpl implements Not
     @Override
     public boolean fixed(NotificationImpl.Type type, Node node) {
         BasicDBObject qry = new BasicDBObject();
-        qry.put("type", type.toString().toLowerCase(Locale.ENGLISH));
+        qry.put(NotificationImpl.FIELD_TYPE, type.toString().toLowerCase(Locale.ENGLISH));
         if (node != null) {
-            qry.put("node_id", node.getNodeId());
+            qry.put(NotificationImpl.FIELD_NODE_ID, node.getNodeId());
         }
 
         final boolean removed = destroyAll(NotificationImpl.class, qry) > 0;
@@ -88,18 +89,18 @@ public class NotificationServiceImpl extends PersistedServiceImpl implements Not
 
     @Override
     public boolean isFirst(NotificationImpl.Type type) {
-        return (findOne(NotificationImpl.class, new BasicDBObject("type", type.toString().toLowerCase(Locale.ENGLISH))) == null);
+        return (findOne(NotificationImpl.class, new BasicDBObject(NotificationImpl.FIELD_TYPE, type.toString().toLowerCase(Locale.ENGLISH))) == null);
     }
 
     @Override
     public List<Notification> all() {
-        final List<DBObject> dbObjects = query(NotificationImpl.class, new BasicDBObject(), new BasicDBObject("timestamp", -1));
+        final List<DBObject> dbObjects = query(NotificationImpl.class, new BasicDBObject(), new BasicDBObject(NotificationImpl.FIELD_TIMESTAMP, -1));
         final List<Notification> notifications = Lists.newArrayListWithCapacity(dbObjects.size());
         for (DBObject obj : dbObjects) {
             try {
                 notifications.add(new NotificationImpl(new ObjectId(obj.get("_id").toString()), obj.toMap()));
             } catch (IllegalArgumentException e) {
-                LOG.warn("There is a notification type we can't handle: [{}]", obj.get("type"));
+                LOG.warn("There is a notification type we can't handle: [{}]", obj.get(NotificationImpl.FIELD_TYPE));
             }
         }
 
@@ -142,6 +143,6 @@ public class NotificationServiceImpl extends PersistedServiceImpl implements Not
 
     @Override
     public int destroyAllByType(Notification.Type type) {
-        return destroyAll(NotificationImpl.class, new BasicDBObject("type", type.toString().toLowerCase(Locale.ENGLISH)));
+        return destroyAll(NotificationImpl.class, new BasicDBObject(NotificationImpl.FIELD_TYPE, type.toString().toLowerCase(Locale.ENGLISH)));
     }
 }

--- a/graylog2-server/src/main/java/org/graylog2/periodical/AlarmCallbacksMigrationPeriodical.java
+++ b/graylog2-server/src/main/java/org/graylog2/periodical/AlarmCallbacksMigrationPeriodical.java
@@ -21,7 +21,7 @@ import com.mongodb.BasicDBObject;
 import com.mongodb.DBCollection;
 import com.mongodb.DBObject;
 import com.mongodb.QueryBuilder;
-import org.graylog2.alarmcallbacks.AlarmCallbackConfigurationAVImpl;
+import org.graylog2.alarmcallbacks.AlarmCallbackConfigurationImpl;
 import org.graylog2.database.CollectionName;
 import org.graylog2.database.MongoConnection;
 import org.graylog2.plugin.periodical.Periodical;
@@ -45,7 +45,7 @@ public class AlarmCallbacksMigrationPeriodical extends Periodical {
 
     @Inject
     public AlarmCallbacksMigrationPeriodical(MongoConnection mongoConnection) {
-        final String collectionName = AlarmCallbackConfigurationAVImpl.class.getAnnotation(CollectionName.class).value();
+        final String collectionName = AlarmCallbackConfigurationImpl.class.getAnnotation(CollectionName.class).value();
         this.dbCollection = mongoConnection.getDatabase().getCollection(collectionName);
     }
 

--- a/graylog2-server/src/main/java/org/graylog2/rest/resources/alarmcallbacks/StreamAlarmCallbackResource.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/resources/alarmcallbacks/StreamAlarmCallbackResource.java
@@ -25,7 +25,7 @@ import io.swagger.annotations.ApiResponse;
 import io.swagger.annotations.ApiResponses;
 import org.apache.shiro.authz.annotation.RequiresAuthentication;
 import org.graylog2.alarmcallbacks.AlarmCallbackConfiguration;
-import org.graylog2.alarmcallbacks.AlarmCallbackConfigurationAVImpl;
+import org.graylog2.alarmcallbacks.AlarmCallbackConfigurationImpl;
 import org.graylog2.alarmcallbacks.AlarmCallbackConfigurationService;
 import org.graylog2.alarmcallbacks.AlarmCallbackFactory;
 import org.graylog2.audit.AuditEventTypes;
@@ -230,7 +230,7 @@ public class StreamAlarmCallbackResource extends RestResource {
 
         final Map<String, Object> configuration = convertConfigurationValues(alarmCallbackRequest);
 
-        final AlarmCallbackConfiguration updatedConfig = ((AlarmCallbackConfigurationAVImpl) callbackConfiguration).toBuilder()
+        final AlarmCallbackConfiguration updatedConfig = ((AlarmCallbackConfigurationImpl) callbackConfiguration).toBuilder()
                 .setTitle(alarmCallbackRequest.title())
                 .setConfiguration(configuration)
                 .build();

--- a/graylog2-server/src/main/java/org/graylog2/streams/StreamRuleServiceImpl.java
+++ b/graylog2-server/src/main/java/org/graylog2/streams/StreamRuleServiceImpl.java
@@ -41,6 +41,7 @@ public class StreamRuleServiceImpl extends PersistedServiceImpl implements Strea
     @Inject
     public StreamRuleServiceImpl(MongoConnection mongoConnection) {
         super(mongoConnection);
+        collection(StreamRuleImpl.class).createIndex(StreamRuleImpl.FIELD_STREAM_ID);
     }
 
     @Override

--- a/graylog2-server/src/main/java/org/graylog2/streams/StreamServiceImpl.java
+++ b/graylog2-server/src/main/java/org/graylog2/streams/StreamServiceImpl.java
@@ -23,7 +23,7 @@ import com.mongodb.BasicDBObject;
 import com.mongodb.DBObject;
 import org.bson.types.ObjectId;
 import org.graylog2.alarmcallbacks.AlarmCallbackConfiguration;
-import org.graylog2.alarmcallbacks.AlarmCallbackConfigurationAVImpl;
+import org.graylog2.alarmcallbacks.AlarmCallbackConfigurationImpl;
 import org.graylog2.alarmcallbacks.AlarmCallbackConfigurationService;
 import org.graylog2.alarmcallbacks.EmailAlarmCallback;
 import org.graylog2.alerts.Alert;
@@ -368,7 +368,7 @@ public class StreamServiceImpl extends PersistedServiceImpl implements StreamSer
                     }
                     configuration.put(key, recipients);
 
-                    final AlarmCallbackConfiguration updatedConfig = ((AlarmCallbackConfigurationAVImpl) callback).toBuilder()
+                    final AlarmCallbackConfiguration updatedConfig = ((AlarmCallbackConfigurationImpl) callback).toBuilder()
                             .setConfiguration(configuration)
                             .build();
                     try {

--- a/graylog2-server/src/test/java/org/graylog2/alarmcallbacks/AlarmCallbackConfigurationServiceImplTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/alarmcallbacks/AlarmCallbackConfigurationServiceImplTest.java
@@ -35,7 +35,7 @@ import static org.junit.Assert.assertNull;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-public class AlarmCallbackConfigurationServiceMJImplTest extends MongoDBServiceTest {
+public class AlarmCallbackConfigurationServiceImplTest extends MongoDBServiceTest {
     private AlarmCallbackConfigurationService alarmCallbackConfigurationService;
 
     @Before

--- a/graylog2-server/src/test/java/org/graylog2/alarmcallbacks/AlarmCallbackConfigurationServiceMJImplTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/alarmcallbacks/AlarmCallbackConfigurationServiceMJImplTest.java
@@ -40,7 +40,7 @@ public class AlarmCallbackConfigurationServiceMJImplTest extends MongoDBServiceT
 
     @Before
     public void setUpService() throws Exception {
-        this.alarmCallbackConfigurationService = new AlarmCallbackConfigurationServiceMJImpl(mongoRule.getMongoConnection(), mapperProvider);
+        this.alarmCallbackConfigurationService = new AlarmCallbackConfigurationServiceImpl(mongoRule.getMongoConnection(), mapperProvider);
     }
 
     @Test

--- a/graylog2-server/src/test/java/org/graylog2/migrations/V20161125161400_AlertReceiversMigrationTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/migrations/V20161125161400_AlertReceiversMigrationTest.java
@@ -24,7 +24,7 @@ import com.mongodb.DBCollection;
 import com.mongodb.WriteResult;
 import org.bson.types.ObjectId;
 import org.graylog2.alarmcallbacks.AlarmCallbackConfiguration;
-import org.graylog2.alarmcallbacks.AlarmCallbackConfigurationAVImpl;
+import org.graylog2.alarmcallbacks.AlarmCallbackConfigurationImpl;
 import org.graylog2.alarmcallbacks.AlarmCallbackConfigurationService;
 import org.graylog2.alarmcallbacks.EmailAlarmCallback;
 import org.graylog2.alarmcallbacks.HTTPAlarmCallback;
@@ -143,7 +143,7 @@ public class V20161125161400_AlertReceiversMigrationTest {
         when(this.streamService.getAlertConditions(eq(stream2))).thenReturn(ImmutableList.of(alertCondition));
 
         final String alarmCallbackId = new ObjectId().toHexString();
-        final AlarmCallbackConfiguration alarmCallback = AlarmCallbackConfigurationAVImpl.create(
+        final AlarmCallbackConfiguration alarmCallback = AlarmCallbackConfigurationImpl.create(
                 alarmCallbackId,
                 matchingStreamId,
                 EmailAlarmCallback.class.getCanonicalName(),
@@ -207,7 +207,7 @@ public class V20161125161400_AlertReceiversMigrationTest {
         when(this.streamService.getAlertConditions(eq(stream3))).thenReturn(ImmutableList.of(alertCondition2));
 
         final String alarmCallbackId1 = new ObjectId().toHexString();
-        final AlarmCallbackConfiguration alarmCallback1 = AlarmCallbackConfigurationAVImpl.create(
+        final AlarmCallbackConfiguration alarmCallback1 = AlarmCallbackConfigurationImpl.create(
                 alarmCallbackId1,
                 matchingStreamId1,
                 EmailAlarmCallback.class.getCanonicalName(),
@@ -217,7 +217,7 @@ public class V20161125161400_AlertReceiversMigrationTest {
                 "admin"
         );
         final String alarmCallbackId2 = new ObjectId().toHexString();
-        final AlarmCallbackConfiguration alarmCallback2 = AlarmCallbackConfigurationAVImpl.create(
+        final AlarmCallbackConfiguration alarmCallback2 = AlarmCallbackConfigurationImpl.create(
                 alarmCallbackId2,
                 matchingStreamId2,
                 EmailAlarmCallback.class.getCanonicalName(),
@@ -227,7 +227,7 @@ public class V20161125161400_AlertReceiversMigrationTest {
                 "admin"
         );
         final String alarmCallbackId3 = new ObjectId().toHexString();
-        final AlarmCallbackConfiguration alarmCallback3 = AlarmCallbackConfigurationAVImpl.create(
+        final AlarmCallbackConfiguration alarmCallback3 = AlarmCallbackConfigurationImpl.create(
                 alarmCallbackId3,
                 matchingStreamId2,
                 EmailAlarmCallback.class.getCanonicalName(),
@@ -237,7 +237,7 @@ public class V20161125161400_AlertReceiversMigrationTest {
                 "admin"
         );
         final String alarmCallbackId4 = new ObjectId().toHexString();
-        final AlarmCallbackConfiguration alarmCallback4 = AlarmCallbackConfigurationAVImpl.create(
+        final AlarmCallbackConfiguration alarmCallback4 = AlarmCallbackConfigurationImpl.create(
                 alarmCallbackId4,
                 matchingStreamId2,
                 HTTPAlarmCallback.class.getCanonicalName(),


### PR DESCRIPTION
In this PR, I am trying to create some MongoDB indices for services
doing conditional queries. I also took the chance and renamed the
alarm callback value/service class implementations and extracted field
constants being reused in several places.

This is probably not a complete fix for #2821, but it already helps a
bit.

<!--- Provide a general summary of your changes in the Title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
