### PR TITLE
Adapt grace period to latest changes in alerts

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/alerts/AbstractAlertCondition.java
+++ b/graylog2-server/src/main/java/org/graylog2/alerts/AbstractAlertCondition.java
@@ -198,7 +198,7 @@ public abstract class AbstractAlertCondition implements EmbeddedPersistable, Ale
 
     public static List<ConfigurationField> getDefaultConfigurationFields() {
         return Lists.newArrayList(
-            new NumberField("grace", "Grace Period", 0, "Number of minutes to wait after an alert is triggered, to trigger another alert", ConfigurationField.Optional.NOT_OPTIONAL),
+            new NumberField("grace", "Grace Period", 0, "Number of minutes to wait after an alert is resolved, to trigger another alert", ConfigurationField.Optional.NOT_OPTIONAL),
             new NumberField("backlog", "Message Backlog", 0, "The number of messages to be included in alert notifications", ConfigurationField.Optional.NOT_OPTIONAL)
         );
     }

--- a/graylog2-server/src/main/java/org/graylog2/alerts/AlertService.java
+++ b/graylog2-server/src/main/java/org/graylog2/alerts/AlertService.java
@@ -35,8 +35,6 @@ public interface AlertService {
     List<Alert> loadRecentOfStreams(List<String> streamIds, DateTime since, int limit);
     List<Alert> loadRecentOfStream(String streamId, DateTime since, int limit);
 
-    int triggeredSecondsAgo(String streamId, String conditionId);
-
     Optional<Alert> getLastTriggeredAlert(String streamId, String conditionId);
 
     long totalCount();

--- a/graylog2-server/src/test/java/org/graylog2/alerts/AlertServiceImplTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/alerts/AlertServiceImplTest.java
@@ -95,11 +95,17 @@ public class AlertServiceImplTest extends MongoDBServiceTest {
 
     @Test
     @UsingDataSet(locations = "unresolved-alert.json")
-    public void triggeredSecondsAgoOnExistingAlert() throws Exception {
+    public void resolvedSecondsAgoOnExistingUnresolvedAlert() throws Exception {
+        assertThat(alertService.resolvedSecondsAgo(STREAM_ID, CONDITION_ID)).isEqualTo(-1);
+    }
+
+    @Test
+    @UsingDataSet(locations = "resolved-alert.json")
+    public void resolvedSecondsAgoOnExistingResolvedAlert() throws Exception {
         final Alert alert = alertService.load(ALERT_ID, STREAM_ID);
-        final int expectedResult = Seconds.secondsBetween(alert.getTriggeredAt(), Tools.nowUTC()).getSeconds();
+        final int expectedResult = Seconds.secondsBetween(alert.getResolvedAt(), Tools.nowUTC()).getSeconds();
         // Add a second threshold in case the clock changed since the previous call to Tools.nowUTC()
-        assertThat(alertService.triggeredSecondsAgo(STREAM_ID, CONDITION_ID)).isBetween(expectedResult, expectedResult + 1);
+        assertThat(alertService.resolvedSecondsAgo(STREAM_ID, CONDITION_ID)).isBetween(expectedResult, expectedResult + 1);
     }
 
     @Test
@@ -190,8 +196,8 @@ public class AlertServiceImplTest extends MongoDBServiceTest {
 
     @Test
     @UsingDataSet(loadStrategy = LoadStrategyEnum.DELETE_ALL)
-    public void triggeredSecondsAgoOnNonExistingAlert() throws Exception {
-        assertThat(alertService.triggeredSecondsAgo(STREAM_ID, CONDITION_ID)).isEqualTo(-1);
+    public void resolvedSecondsAgoOnNonExistingAlert() throws Exception {
+        assertThat(alertService.resolvedSecondsAgo(STREAM_ID, CONDITION_ID)).isEqualTo(-1);
     }
 
     @Test


### PR DESCRIPTION
As it is still not possible to mute alerts, we are keeping the grace period and updating the way it works:

Instead of calculating the grace period using the `triggered_at` time, we are changing it to use `resolved_at`. That means that the grace period will prevent to trigger a new alert once that alert is marked as resolved, helping to minimize the noise if a condition check is fluctuating too much.

Refs #3178