### PR TITLE
Go back in history instead to users page when canceling user form.

### DIFF
--- a/graylog2-web-interface/src/components/users/UserForm.jsx
+++ b/graylog2-web-interface/src/components/users/UserForm.jsx
@@ -176,7 +176,7 @@ const UserForm = React.createClass({
   },
 
   _onCancel() {
-    this.props.history.pushState(null, Routes.SYSTEM.AUTHENTICATION.USERS.LIST);
+    this.props.history.goBack();
   },
 
   render() {


### PR DESCRIPTION
## Description
## Motivation and Context

The user form component is used in two distinct places:

  * when editing users from the users list
  * when editing the own profile from the top menu

Before this change, when canceling the user form, the user was
redirected to the user list. When missing the required permissions for
this, this fails.

After this change, we are going back one step in the user's history
instead, which goes back to the users page in the first and the place
where the user came from in the second case, which is much more
unsurprising.

Fixes #3075

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
