### PR TITLE
Keep stream filter after editing stream.

### DIFF
--- a/graylog2-web-interface/src/components/streams/StreamComponent.jsx
+++ b/graylog2-web-interface/src/components/streams/StreamComponent.jsx
@@ -35,8 +35,9 @@ const StreamComponent = React.createClass({
     StreamsStore.load((streams) => {
       this.setState({
         streams: streams,
-        filteredStreams: streams.slice(),
+        filteredStreams: null,
       });
+      this.refs.streamFilter.filterData();
     });
   },
 
@@ -74,11 +75,16 @@ const StreamComponent = React.createClass({
       );
     }
 
+    const streamsList = this.state.filteredStreams ? (<StreamList streams={this.state.filteredStreams} streamRuleTypes={this.state.streamRuleTypes}
+                                                                  permissions={this.props.currentUser.permissions} user={this.props.currentUser}
+                                                                  onStreamSave={this.props.onStreamSave} indexSets={this.props.indexSets} />) : <Spinner/>;
+
     return (
       <div>
         <Row className="row-sm">
           <Col md={8}>
-            <TypeAheadDataFilter label="Filter streams"
+            <TypeAheadDataFilter ref="streamFilter"
+                                 label="Filter streams"
                                  data={this.state.streams}
                                  displayKey={'title'}
                                  filterSuggestions={[]}
@@ -88,9 +94,7 @@ const StreamComponent = React.createClass({
         </Row>
         <Row>
           <Col md={12}>
-            <StreamList streams={this.state.filteredStreams} streamRuleTypes={this.state.streamRuleTypes}
-                        permissions={this.props.currentUser.permissions} user={this.props.currentUser}
-                        onStreamSave={this.props.onStreamSave} indexSets={this.props.indexSets} />
+            {streamsList}
           </Col>
         </Row>
       </div>


### PR DESCRIPTION
## Description
## Motivation and Context

Before this change, whenever a stream was edited and the stream form
modal was closed, the full list of streams was shown again, even if a
filter had been entered. Getting the filtered view again required
pressing the "filter" button.

After this change, whenver the stream form modal is closed, the stream
filter is maintained.

Fixes #2545

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
