### PR TITLE
Keep calling convention of SearchPage._refreshData consistent.

### DIFF
--- a/graylog2-web-interface/src/pages/SearchPage.jsx
+++ b/graylog2-web-interface/src/pages/SearchPage.jsx
@@ -39,7 +39,10 @@ const SearchPage = React.createClass({
     };
   },
   componentDidMount() {
-    [DecoratorsActions.create.completed, DecoratorsActions.remove.completed, DecoratorsActions.update.completed].forEach((action) => action.listen(this._refreshData));
+    [DecoratorsActions.create.completed, DecoratorsActions.remove.completed, DecoratorsActions.update.completed].forEach((action) => action.listen(() => {
+      const searchInStream = this.props.searchInStream;
+      this._refreshData(searchInStream);
+    }));
     this._refreshData();
     InputsActions.list.triggerPromise();
 


### PR DESCRIPTION
SearchPage._refreshData is called from several places, internally from
the component and when actions of the Decorator dispatcher complete. In
the latter case, the parameter passed to _refreshData is wrong, it's the
decorator id instead of the stream id which scopes the current search.

This change wraps calling _refreshData from the dispatcher so the
parameter is correct.

Fixes #3355.

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
