### PR TITLE
suppress error notification when loading a potentially missing input

### DIFF
--- a/graylog2-web-interface/src/actions/inputs/InputsActions.js
+++ b/graylog2-web-interface/src/actions/inputs/InputsActions.js
@@ -3,6 +3,7 @@ import Reflux from 'reflux';
 const InputsActions = Reflux.createActions({
   'list': {asyncResult: true},
   'get': {asyncResult: true},
+  'getOptional': {asyncResult: true},
   'create': {asyncResult: true},
   'delete': {asyncResult: true},
   'update': {asyncResult: true},

--- a/graylog2-web-interface/src/pages/ShowMessagePage.jsx
+++ b/graylog2-web-interface/src/pages/ShowMessagePage.jsx
@@ -32,7 +32,7 @@ const ShowMessagePage = React.createClass({
   componentDidMount() {
     MessagesActions.loadMessage.triggerPromise(this.props.params.index, this.props.params.messageId).then(message => {
       this.setState({ message: message });
-      InputsActions.get.triggerPromise(message.source_input_id);
+      InputsActions.getOptional.triggerPromise(message.source_input_id);
     });
     StreamsStore.listStreams().then(streams => {
       const streamsMap = {};

--- a/graylog2-web-interface/src/stores/inputs/InputsStore.js
+++ b/graylog2-web-interface/src/stores/inputs/InputsStore.js
@@ -40,6 +40,10 @@ const InputsStore = Reflux.createStore({
   },
 
   get(inputId) {
+    return this.getOptional(inputId, true);
+  },
+
+  getOptional(inputId, showError) {
     const promise = fetch('GET', URLUtils.qualifyUrl(`${this.sourceUrl}/${inputId}`));
 
     promise
@@ -51,8 +55,12 @@ const InputsStore = Reflux.createStore({
           return this.input;
         },
         error => {
-          UserNotification.error(`Fetching input ${inputId} failed with status: ${error}`,
-            'Could not retrieve input');
+          if (showError) {
+            UserNotification.error(`Fetching input ${inputId} failed with status: ${error}`,
+                                   'Could not retrieve input');
+          } else {
+            this.trigger({ input: {} });
+          }
         });
 
     InputsActions.get.promise(promise);


### PR DESCRIPTION
when showing a single message we do not want to display an error about a missing input, we simply deal with the fact that it is no longer there
to avoid changing all the other clients (which need the input to be present), another action is added that allows suppressing the error and instead returns an empty input

fixes #3370
