### PR TITLE
Ensure resolved at is non-null on resolvedSecondsAgo

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/alerts/AlertServiceImpl.java
+++ b/graylog2-server/src/main/java/org/graylog2/alerts/AlertServiceImpl.java
@@ -107,10 +107,11 @@ public class AlertServiceImpl implements AlertService {
 
         final Alert mostRecentAlert = lastTriggeredAlert.get();
 
-        if (!isResolved(mostRecentAlert)) {
+        final DateTime resolvedAt = mostRecentAlert.getResolvedAt();
+        if (resolvedAt == null || !isResolved(mostRecentAlert)) {
             return -1;
         }
-        return Seconds.secondsBetween(mostRecentAlert.getResolvedAt(), Tools.nowUTC()).getSeconds();
+        return Seconds.secondsBetween(resolvedAt, Tools.nowUTC()).getSeconds();
     }
 
     @Override

--- a/graylog2-server/src/test/java/org/graylog2/alerts/AlertServiceImplTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/alerts/AlertServiceImplTest.java
@@ -100,6 +100,12 @@ public class AlertServiceImplTest extends MongoDBServiceTest {
     }
 
     @Test
+    @UsingDataSet(locations = "non-interval-alert.json")
+    public void resolvedSecondsAgoOnExistingNonIntervalAlert() throws Exception {
+        assertThat(alertService.resolvedSecondsAgo(STREAM_ID, CONDITION_ID)).isEqualTo(-1);
+    }
+
+    @Test
     @UsingDataSet(locations = "resolved-alert.json")
     public void resolvedSecondsAgoOnExistingResolvedAlert() throws Exception {
         final Alert alert = alertService.load(ALERT_ID, STREAM_ID);


### PR DESCRIPTION
Ensures that `AlertService.resolvedSecondsAgo()` also works on legacy alerts.

Fixes #3375 
