### PR TITLE
do not allow testing a message against the default stream

### DIFF
--- a/graylog2-web-interface/src/components/search/MessageDetail.jsx
+++ b/graylog2-web-interface/src/components/search/MessageDetail.jsx
@@ -99,7 +99,7 @@ const MessageDetail = React.createClass({
       }
       if (stream.is_default) {
         streamList.push(
-          <MenuItem key={stream.id} disabled={true} title="Cannot test against the default stream">{stream.title}</MenuItem>
+          <MenuItem key={stream.id} disabled title="Cannot test against the default stream">{stream.title}</MenuItem>
         );
       } else {
         streamList.push(

--- a/graylog2-web-interface/src/components/search/MessageDetail.jsx
+++ b/graylog2-web-interface/src/components/search/MessageDetail.jsx
@@ -97,12 +97,19 @@ const MessageDetail = React.createClass({
       if (!streamList) {
         streamList = [];
       }
-      streamList.push(
-        <LinkContainer key={stream.id}
-                       to={Routes.stream_edit_example(stream.id, this.props.message.index, this.props.message.id)}>
-          <MenuItem>{stream.title}</MenuItem>
-        </LinkContainer>
-      );
+      if (stream.is_default) {
+        streamList.push(
+          <MenuItem key={stream.id} disabled={true} title="Cannot test against the default stream">{stream.title}</MenuItem>
+        );
+      } else {
+        streamList.push(
+          <LinkContainer key={stream.id}
+                         to={Routes.stream_edit_example(stream.id, this.props.message.index,
+                                                        this.props.message.id)}>
+            <MenuItem>{stream.title}</MenuItem>
+          </LinkContainer>
+        );
+      }
     });
 
     return (

--- a/graylog2-web-interface/src/pages/StreamEditPage.jsx
+++ b/graylog2-web-interface/src/pages/StreamEditPage.jsx
@@ -1,5 +1,6 @@
 import React, { PropTypes } from 'react';
 import Reflux from 'reflux';
+import { Alert, Row, Col } from 'react-bootstrap';
 
 import StreamRulesEditor from 'components/streamrules/StreamRulesEditor';
 import { DocumentTitle, PageHeader, Spinner } from 'components/common';
@@ -30,6 +31,19 @@ const StreamEditPage = React.createClass({
       return <Spinner />;
     }
 
+    let content = <StreamRulesEditor currentUser={this.state.currentUser} streamId={this.props.params.streamId}
+                                 messageId={this.props.location.query.message_id} index={this.props.location.query.index} />;
+    if (this.state.stream.is_default) {
+      content = (
+        <div className="row content">
+          <div className="col-md-12">
+            <Alert bsStyle="danger">
+              The default stream cannot be edited.
+            </Alert>
+          </div>
+        </div>
+      );
+    }
     return (
       <DocumentTitle title={`Rules of Stream ${this.state.stream.title}`}>
         <div>
@@ -40,8 +54,7 @@ const StreamEditPage = React.createClass({
             </span>
           </PageHeader>
 
-          <StreamRulesEditor currentUser={this.state.currentUser} streamId={this.props.params.streamId}
-                             messageId={this.props.location.query.message_id} index={this.props.location.query.index} />
+          {content}
         </div>
       </DocumentTitle>
     );

--- a/graylog2-web-interface/src/pages/StreamEditPage.jsx
+++ b/graylog2-web-interface/src/pages/StreamEditPage.jsx
@@ -31,8 +31,8 @@ const StreamEditPage = React.createClass({
       return <Spinner />;
     }
 
-    let content = <StreamRulesEditor currentUser={this.state.currentUser} streamId={this.props.params.streamId}
-                                 messageId={this.props.location.query.message_id} index={this.props.location.query.index} />;
+    let content = (<StreamRulesEditor currentUser={this.state.currentUser} streamId={this.props.params.streamId}
+                                 messageId={this.props.location.query.message_id} index={this.props.location.query.index} />);
     if (this.state.stream.is_default) {
       content = (
         <div className="row content">


### PR DESCRIPTION
 * the default stream is disabled in the menu and has a title explaining that it cannot be used (as title for hover)
 * going to `/streams/000000000000000000000001/edit` now displays an error message (this page should not be reachable other than manually via that path)

fixes #3369
