### PR TITLE
Unregistering component callbacks from Stream(Rules)Store.

### DIFF
--- a/graylog2-web-interface/package.json
+++ b/graylog2-web-interface/package.json
@@ -30,6 +30,7 @@
     "immutable": "^3.7.5",
     "javascript-natural-sort": "^0.7.1",
     "jquery-ui": "1.12.x",
+    "lodash": "^4.17.4",
     "markdown": "^0.5.0",
     "md5": "^2.0.0",
     "moment-duration-format": "1.3.0",

--- a/graylog2-web-interface/src/components/streamrules/StreamRulesEditor.jsx
+++ b/graylog2-web-interface/src/components/streamrules/StreamRulesEditor.jsx
@@ -31,6 +31,10 @@ const StreamRulesEditor = React.createClass({
     StreamsStore.onChange(this.loadData);
     StreamRulesStore.onChange(this.loadData);
   },
+  componentWillUnmount() {
+    StreamsStore.unregister(this.loadData);
+    StreamRulesStore.unregister(this.loadData);
+  },
   onMessageLoaded(message) {
     this.setState({ message: message });
     if (message !== undefined) {

--- a/graylog2-web-interface/src/components/streams/StreamComponent.jsx
+++ b/graylog2-web-interface/src/components/streams/StreamComponent.jsx
@@ -30,6 +30,10 @@ const StreamComponent = React.createClass({
     StreamsStore.onChange(this.loadData);
     StreamRulesStore.onChange(this.loadData);
   },
+  componentWillUnmount() {
+    StreamsStore.unregister(this.loadData);
+    StreamRulesStore.unregister(this.loadData);
+  },
 
   loadData() {
     StreamsStore.load((streams) => {

--- a/graylog2-web-interface/src/stores/streams/StreamRulesStore.ts
+++ b/graylog2-web-interface/src/stores/streams/StreamRulesStore.ts
@@ -3,6 +3,7 @@ import ApiRoutes = require('routing/ApiRoutes');
 const UserNotification = require('util/UserNotification');
 const URLUtils = require('util/URLUtils');
 const fetch = require('logic/rest/FetchProvider').default;
+const lodash = require('lodash');
 
 interface StreamRuleType {
   id: number;
@@ -74,6 +75,9 @@ class StreamRulesStore {
   }
   _emitChange() {
     this.callbacks.forEach((callback) => callback());
+  }
+  unregister(callback: Callback) {
+    lodash.pull(this.callbacks, callback);
   }
 }
 

--- a/graylog2-web-interface/src/stores/streams/StreamsStore.ts
+++ b/graylog2-web-interface/src/stores/streams/StreamsStore.ts
@@ -2,6 +2,7 @@ const UserNotification = require('util/UserNotification');
 const URLUtils = require('util/URLUtils');
 import ApiRoutes = require('routing/ApiRoutes');
 const fetch = require('logic/rest/FetchProvider').default;
+const lodash = require('lodash');
 
 interface Stream {
   id: string;
@@ -148,6 +149,9 @@ class StreamsStore {
   }
   _emitChange() {
     this.callbacks.forEach((callback) => callback());
+  }
+  unregister(callback: Callback) {
+    lodash.pull(this.callbacks, callback);
   }
 }
 


### PR DESCRIPTION
## Description
## Motivation and Context

Before this change, the StreamComponent was registering callbacks to be
notified when the Stream(Rules)Store state changes. Unfortunately, there
was no way to unregister these callbacks, so after unmounting the
component its callbacks were still called.

After this change, there is now a way to unregister callbacks which is
consumed in the componentWillUnmount function of the StreamComponent.

Fixes #3374.

<!--- Provide a general summary of your changes in the Title above -->

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
