### PR TITLE
Add support for non-string fields to "contains" stream rule

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/streams/matchers/ContainsMatcher.java
+++ b/graylog2-server/src/main/java/org/graylog2/streams/matchers/ContainsMatcher.java
@@ -24,12 +24,12 @@ public class ContainsMatcher implements StreamRuleMatcher {
     public boolean match(Message msg, StreamRule rule) {
         final boolean inverted = rule.getInverted();
         final Object field = msg.getField(rule.getField());
-        if (field instanceof String) {
-            final String value = (String) field;
+
+        if (field != null) {
+            final String value = field.toString();
             return inverted ^ value.contains(rule.getValue());
         } else {
             return inverted;
         }
     }
-
 }

--- a/graylog2-server/src/test/java/org/graylog2/streams/matchers/ContainsMatcherTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/streams/matchers/ContainsMatcherTest.java
@@ -22,6 +22,8 @@ import org.graylog2.plugin.streams.StreamRuleType;
 import org.junit.Before;
 import org.junit.Test;
 
+import java.util.Collections;
+
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
@@ -100,6 +102,14 @@ public class ContainsMatcherTest extends MatcherTest {
         msg.addField(fieldName, null);
 
         final StreamRuleMatcher matcher = getMatcher(rule);
+        assertTrue(matcher.match(msg, rule));
+    }
+
+    @Test
+    public void testSuccessfulMatchInArray() {
+        msg.addField("something", Collections.singleton("foobar"));
+
+        StreamRuleMatcher matcher = getMatcher(rule);
         assertTrue(matcher.match(msg, rule));
     }
 

--- a/graylog2-server/src/test/java/org/graylog2/streams/matchers/RegexMatcherTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/streams/matchers/RegexMatcherTest.java
@@ -21,6 +21,8 @@ import org.graylog2.plugin.streams.StreamRule;
 import org.graylog2.plugin.streams.StreamRuleType;
 import org.junit.Test;
 
+import java.util.Collections;
+
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
@@ -139,6 +141,18 @@ public class RegexMatcherTest extends MatcherTest {
 
         Message msg = getSampleMessage();
         msg.addField("some_field", "bar1foowat");
+
+        StreamRuleMatcher matcher = getMatcher(rule);
+        assertTrue(matcher.match(msg, rule));
+    }
+
+    @Test
+    public void testSuccessfulMatchInArray() {
+        StreamRule rule = getSampleRule();
+        rule.setValue("foobar");
+
+        Message msg = getSampleMessage();
+        msg.addField("something", Collections.singleton("foobar"));
 
         StreamRuleMatcher matcher = getMatcher(rule);
         assertTrue(matcher.match(msg, rule));


### PR DESCRIPTION
## Description

In contrast to most other stream rules, the "contains" stream rule worked exclusively
on strings which can lead to surprising results if users try to match the contents of
a numeric or an array field.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- Kind of both.