### PR TITLE
Keep modified search bar params when opening modal

### DIFF
--- a/graylog2-web-interface/src/components/search/SearchSidebar.jsx
+++ b/graylog2-web-interface/src/components/search/SearchSidebar.jsx
@@ -127,7 +127,12 @@ const SearchSidebar = React.createClass({
   },
 
   _openModal(ref) {
-    return () => this.refs[ref].open();
+    return (event) => {
+      if (event) {
+        event.preventDefault();
+      }
+      this.refs[ref].open();
+    };
   },
 
   _getExportModal() {


### PR DESCRIPTION
We now prevent the event propagation in the element opening the modal,
ensuring that if a link is used, the `onclick` event will not be propagated,
causing the browser to reset form inputs.

Fixes #3361