### PR TITLE
Ensure we use the stream filter component when mounted

### DIFF
--- a/graylog2-web-interface/src/components/streams/StreamComponent.jsx
+++ b/graylog2-web-interface/src/components/streams/StreamComponent.jsx
@@ -30,6 +30,13 @@ const StreamComponent = React.createClass({
     StreamsStore.onChange(this.loadData);
     StreamRulesStore.onChange(this.loadData);
   },
+
+  componentDidUpdate() {
+    if (this.state.filteredStreams === null) {
+      this._filterStreams();
+    }
+  },
+
   componentWillUnmount() {
     StreamsStore.unregister(this.loadData);
     StreamRulesStore.unregister(this.loadData);
@@ -41,8 +48,13 @@ const StreamComponent = React.createClass({
         streams: streams,
         filteredStreams: null,
       });
-      this.refs.streamFilter.filterData();
     });
+  },
+
+  _filterStreams() {
+    if (this.refs.streamFilter) {
+      this.refs.streamFilter.filterData();
+    }
   },
 
   _updateFilteredStreams(filteredStreams) {


### PR DESCRIPTION
As the component mounted state is a bit tricky, check if we need to filter the list of streams after each update. Also ensure that the reference is available at the time.

Fixes #3389