### PR TITLE
Fix broken decorator with duplicate messages

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/decorators/DecoratorProcessorImpl.java
+++ b/graylog2-server/src/main/java/org/graylog2/decorators/DecoratorProcessorImpl.java
@@ -100,7 +100,7 @@ public class DecoratorProcessorImpl implements DecoratorProcessor {
 
         decoratedMessages.forEach(message -> {
             final DecorationStats decorationStats = message.decorationStats();
-            if (decoratedMessages != null) {
+            if (decorationStats != null) {
                 addedFields.addAll(decorationStats.addedFields().keySet());
                 changedFields.addAll(decorationStats.changedFields().keySet());
                 removedFields.addAll(decorationStats.removedFields().keySet());

--- a/graylog2-server/src/main/java/org/graylog2/decorators/DecoratorProcessorImpl.java
+++ b/graylog2-server/src/main/java/org/graylog2/decorators/DecoratorProcessorImpl.java
@@ -54,14 +54,14 @@ public class DecoratorProcessorImpl implements DecoratorProcessor {
             if (metaDecorator.isPresent()) {
                 final Map<String, ResultMessageSummary> originalMessages = searchResponse.messages()
                         .stream()
-                        .collect(Collectors.toMap(message -> message.message().get("_id").toString(), Function.identity()));
+                        .collect(Collectors.toMap(this::getMessageKey, Function.identity()));
                 final SearchResponse newSearchResponse = metaDecorator.get().apply(searchResponse);
                 final Set<String> newFields = extractFields(newSearchResponse.messages());
 
                 final List<ResultMessageSummary> decoratedMessages = newSearchResponse.messages()
                         .stream()
                         .map(resultMessage -> {
-                            final ResultMessageSummary originalMessage = originalMessages.get(resultMessage.message().get("_id").toString());
+                            final ResultMessageSummary originalMessage = originalMessages.get(getMessageKey(resultMessage));
                             if (originalMessage != null) {
                                 return resultMessage
                                         .toBuilder()
@@ -84,6 +84,12 @@ public class DecoratorProcessorImpl implements DecoratorProcessor {
         }
 
         return searchResponse;
+    }
+
+    private String getMessageKey(ResultMessageSummary messageSummary) {
+        // Use index and message ID as key to allow the same message ID from different indices.
+        // This will happen when the same message is indexed into different index sets.
+        return messageSummary.index() + "-" + messageSummary.message().get("_id").toString();
     }
 
     private Set<String> extractFields(List<ResultMessageSummary> messages) {


### PR DESCRIPTION
Use compound key when mapping messages in the decorator.

The same message with the same ID can be stored in two different index sets so to avoid duplicate keys when mapping messages, we have to use a compound key of the index name and the message ID.

Fixes #3399