### PR TITLE
Only show extractor actions on string fields

### DIFF
--- a/graylog2-web-interface/src/components/search/MessageFieldExtractorActions.jsx
+++ b/graylog2-web-interface/src/components/search/MessageFieldExtractorActions.jsx
@@ -39,7 +39,19 @@ const MessageFieldExtractorActions = React.createClass({
           </div>
         );
     } else {
-      return (<div className="message-field-actions pull-right"/>);
+        return (
+            <div className="message-field-actions pull-right">
+              <DropdownButton pullRight
+                              bsSize="xsmall"
+                              title="Select extractor type"
+                              key={1}
+                              id={`select-extractor-type-dropdown-field-${this.props.fieldName}`}>
+                <MenuItem key={`menu-item-disabled`} disabled={true}>
+                    Extractors can only be used with string fields.
+                </MenuItem>
+              </DropdownButton>
+            </div>
+        );
     }
   },
 });

--- a/graylog2-web-interface/src/components/search/MessageFieldExtractorActions.jsx
+++ b/graylog2-web-interface/src/components/search/MessageFieldExtractorActions.jsx
@@ -25,17 +25,22 @@ const MessageFieldExtractorActions = React.createClass({
     );
   },
   render() {
-    return (
-      <div className="message-field-actions pull-right">
-        <DropdownButton pullRight
-                     bsSize="xsmall"
-                     title="Select extractor type"
-                     key={1}
-                     id={`select-extractor-type-dropdown-field-${this.props.fieldName}`}>
-          {ExtractorUtils.EXTRACTOR_TYPES.map(extractorType => this._formatExtractorMenuItem(extractorType))}
-        </DropdownButton>
-      </div>
-    );
+    let messageField = this.props.message.fields[this.props.fieldName];
+    if(typeof messageField === 'string') {
+      return (
+          <div className="message-field-actions pull-right">
+            <DropdownButton pullRight
+                            bsSize="xsmall"
+                            title="Select extractor type"
+                            key={1}
+                            id={`select-extractor-type-dropdown-field-${this.props.fieldName}`}>
+                {ExtractorUtils.EXTRACTOR_TYPES.map(extractorType => this._formatExtractorMenuItem(extractorType))}
+            </DropdownButton>
+          </div>
+        );
+    } else {
+      return (<div className="message-field-actions pull-right"/>);
+    }
   },
 });
 

--- a/graylog2-web-interface/src/components/search/MessageFieldExtractorActions.jsx
+++ b/graylog2-web-interface/src/components/search/MessageFieldExtractorActions.jsx
@@ -25,7 +25,7 @@ const MessageFieldExtractorActions = React.createClass({
     );
   },
   render() {
-    let messageField = this.props.message.fields[this.props.fieldName];
+    const messageField = this.props.message.fields[this.props.fieldName];
     if(typeof messageField === 'string') {
       return (
           <div className="message-field-actions pull-right">
@@ -46,7 +46,7 @@ const MessageFieldExtractorActions = React.createClass({
                               title="Select extractor type"
                               key={1}
                               id={`select-extractor-type-dropdown-field-${this.props.fieldName}`}>
-                <MenuItem key={`menu-item-disabled`} disabled={true}>
+                <MenuItem key="select-extractor-type-disabled" disabled>
                     Extractors can only be used with string fields.
                 </MenuItem>
               </DropdownButton>

--- a/graylog2-web-interface/src/components/search/MessageFieldSearchActions.jsx
+++ b/graylog2-web-interface/src/components/search/MessageFieldSearchActions.jsx
@@ -23,7 +23,7 @@ const MessageFieldSearchActions = React.createClass({
     );
   },
   render() {
-    let messageField = this.props.message.fields[this.props.fieldName];
+    const messageField = this.props.message.fields[this.props.fieldName];
     let extractors;
     if(typeof messageField === 'string') {
       extractors = (<li className="dropdown-submenu left-submenu">
@@ -33,7 +33,7 @@ const MessageFieldSearchActions = React.createClass({
         </ul>
       </li>);
     } else {
-        extractors = (<MenuItem disabled={true}>Extractors can only be used with string fields</MenuItem>);
+        extractors = (<MenuItem disabled>Extractors can only be used with string fields</MenuItem>);
     }
     return (
       <div className="message-field-actions pull-right">

--- a/graylog2-web-interface/src/components/search/MessageFieldSearchActions.jsx
+++ b/graylog2-web-interface/src/components/search/MessageFieldSearchActions.jsx
@@ -1,6 +1,6 @@
-import React, {PropTypes} from 'react';
-import {SplitButton, MenuItem} from 'react-bootstrap';
-import ExtractorUtils from 'util/ExtractorUtils';
+import React, {PropTypes} from "react";
+import {SplitButton, MenuItem} from "react-bootstrap";
+import ExtractorUtils from "util/ExtractorUtils";
 
 const MessageFieldSearchActions = React.createClass({
   propTypes: {
@@ -23,6 +23,18 @@ const MessageFieldSearchActions = React.createClass({
     );
   },
   render() {
+    let messageField = this.props.message.fields[this.props.fieldName];
+    let extractors;
+    if(typeof messageField === 'string') {
+      extractors = (<li className="dropdown-submenu left-submenu">
+        <a href="#">Create extractor for field {this.props.fieldName}</a>
+        <ul className="dropdown-menu">
+            {ExtractorUtils.EXTRACTOR_TYPES.map(extractorType => this._formatExtractorMenuItem(extractorType))}
+        </ul>
+      </li>);
+    } else {
+        extractors = (<MenuItem disabled={true}>Extractors can only be used with string fields</MenuItem>);
+    }
     return (
       <div className="message-field-actions pull-right">
         <SplitButton pullRight
@@ -31,13 +43,9 @@ const MessageFieldSearchActions = React.createClass({
                      key={1}
                      onClick={this.props.onAddFieldToSearchBar}
                      id={`more-actions-dropdown-field-${this.props.fieldName}`}>
-          <li className="dropdown-submenu left-submenu">
-            <a href="#">Create extractor for field {this.props.fieldName}</a>
-            <ul className="dropdown-menu">
-              {ExtractorUtils.EXTRACTOR_TYPES.map(extractorType => this._formatExtractorMenuItem(extractorType))}
-            </ul>
-          </li>
-          <MenuItem onSelect={this.props.onLoadTerms(this.props.fieldName)}>Show terms of {this.props.fieldName}</MenuItem>
+          {extractors}
+          <MenuItem onSelect={this.props.onLoadTerms(this.props.fieldName)}>Show terms
+            of <em>{this.props.fieldName}</em></MenuItem>
         </SplitButton>
       </div>
     );


### PR DESCRIPTION
Extractors only work on strings, so the web interface should only show the extractor actions for message fields of type "string" and hide them for all other types.

Fixes #3396