### PR TITLE
Updating index sets store when stream form is opened.

### DIFF
--- a/graylog2-web-interface/src/components/streams/StreamForm.jsx
+++ b/graylog2-web-interface/src/components/streams/StreamForm.jsx
@@ -3,6 +3,9 @@ import LinkedStateMixin from 'react-addons-linked-state-mixin';
 import BootstrapModalForm from 'components/bootstrap/BootstrapModalForm';
 import { Input } from 'react-bootstrap';
 import { Select, Spinner } from 'components/common';
+import CombinedProvider from 'injection/CombinedProvider';
+
+const { IndexSetsActions } = CombinedProvider.get('IndexSets');
 
 const StreamForm = React.createClass({
   propTypes: {
@@ -60,6 +63,7 @@ const StreamForm = React.createClass({
 
   open() {
     this._resetValues();
+    IndexSetsActions.list(false);
     this.refs.modal.open();
   },
 


### PR DESCRIPTION
Before this change, a concurrent change of the index sets required a
visit to the indices page to reflect those changes in the stream form.

After this change, the index sets store is refreshed every time the
stream form is opened.

Fixes #3409

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
