### PR TITLE
Use right format when adding timestamp to search

### DIFF
--- a/graylog2-web-interface/src/stores/search/SearchStore.ts
+++ b/graylog2-web-interface/src/stores/search/SearchStore.ts
@@ -12,6 +12,7 @@ var Qs = require('qs');
 const URLUtils = require('util/URLUtils');
 const moment = require('moment');
 const history = require('util/History');
+const DateTime = require('logic/datetimes/DateTime');
 
 class SearchStore {
     static NOT_OPERATOR = "NOT";
@@ -230,7 +231,12 @@ class SearchStore {
     }
 
     addSearchTerm(field, value, operator) {
-        const term = `${field}:${SearchStore.escape(value)}`;
+        let effectiveValue = value;
+        if (field === 'timestamp') {
+            const dateTime = new DateTime(value).toTimeZone('UTC');
+            effectiveValue = dateTime.toString(DateTime.Formats.TIMESTAMP);
+        }
+        const term = `${field}:${SearchStore.escape(effectiveValue)}`;
         const effectiveOperator = operator || SearchStore.AND_OPERATOR;
         this.addQueryTerm(term, effectiveOperator);
     }


### PR DESCRIPTION
As formatting timestamps in the server would require to parse the whole search query and convert the timestamp field in there, composing a new query, we take a simpler approach by only formatting the field when adding it with the "add to search" button.

Fixes #3401