### PR TITLE
Dependency updates

### DIFF
--- a/graylog-project-parent/pom.xml
+++ b/graylog-project-parent/pom.xml
@@ -59,7 +59,7 @@
                 <scope>import</scope>
             </dependency>
             <dependency>
-                <groupId>com.github.joschi.jackson</groupId>
+                <groupId>com.fasterxml.jackson</groupId>
                 <artifactId>jackson-bom</artifactId>
                 <version>${jackson.version}</version>
                 <type>pom</type>

--- a/pom.xml
+++ b/pom.xml
@@ -97,7 +97,7 @@
         <commons-io.version>2.5</commons-io.version>
         <disruptor.version>3.3.6</disruptor.version>
         <drools.version>6.5.0.Final</drools.version>
-        <elasticsearch.version>2.4.3</elasticsearch.version>
+        <elasticsearch.version>2.4.4</elasticsearch.version>
         <gelfclient.version>1.4.1</gelfclient.version>
         <grok.version>0.1.6-graylog</grok.version>
         <guava-retrying.version>2.0.0</guava-retrying.version>

--- a/pom.xml
+++ b/pom.xml
@@ -150,7 +150,7 @@
         <assertj-core.version>3.6.2</assertj-core.version>
         <assertj-joda-time.version>2.0.0</assertj-joda-time.version>
         <awaitility.version>1.7.0</awaitility.version>
-        <equalsverifier.version>2.1.8</equalsverifier.version>
+        <equalsverifier.version>2.2</equalsverifier.version>
         <fongo.version>2.0.11</fongo.version>
         <jukito.version>1.5</jukito.version>
         <junit.version>4.12</junit.version>

--- a/pom.xml
+++ b/pom.xml
@@ -152,7 +152,7 @@
         <awaitility.version>1.7.0</awaitility.version>
         <equalsverifier.version>2.1.8</equalsverifier.version>
         <fongo.version>2.0.11</fongo.version>
-        <jukito.version>1.4.1</jukito.version>
+        <jukito.version>1.5</jukito.version>
         <junit.version>4.12</junit.version>
         <mockito.version>2.3.10</mockito.version>
         <nosqlunit.version>0.10.0</nosqlunit.version>

--- a/pom.xml
+++ b/pom.xml
@@ -88,7 +88,7 @@
 
         <!-- Dependencies -->
         <airline.version>0.7</airline.version>
-        <amqp-client.version>4.0.0</amqp-client.version>
+        <amqp-client.version>4.0.2</amqp-client.version>
         <apache-directory-version>1.0.0-RC2</apache-directory-version>
         <auto-value.version>1.3</auto-value.version>
         <auto-value-extension-util.version>0.3.0</auto-value-extension-util.version>

--- a/pom.xml
+++ b/pom.xml
@@ -101,7 +101,7 @@
         <gelfclient.version>1.4.1</gelfclient.version>
         <grok.version>0.1.6-graylog</grok.version>
         <guava-retrying.version>2.0.0</guava-retrying.version>
-        <guava.version>20.0</guava.version>
+        <guava.version>21.0</guava.version>
         <guice.version>4.1.0</guice.version>
         <HdrHistogram.version>2.1.9</HdrHistogram.version>
         <hibernate-validator.version>5.3.4.Final</hibernate-validator.version>

--- a/pom.xml
+++ b/pom.xml
@@ -106,7 +106,7 @@
         <HdrHistogram.version>2.1.9</HdrHistogram.version>
         <hibernate-validator.version>5.3.4.Final</hibernate-validator.version>
         <hk2.version>2.5.0-b31</hk2.version> <!-- The HK2 version should match the version being used by Jersey -->
-        <jackson.version>2.8.5</jackson.version>
+        <jackson.version>2.8.6</jackson.version>
         <jadconfig.version>0.13.0</jadconfig.version>
         <java-semver.version>0.9.0</java-semver.version>
         <javapoet.version>1.8.0</javapoet.version>

--- a/pom.xml
+++ b/pom.xml
@@ -151,7 +151,7 @@
         <assertj-joda-time.version>2.0.0</assertj-joda-time.version>
         <awaitility.version>1.7.0</awaitility.version>
         <equalsverifier.version>2.2</equalsverifier.version>
-        <fongo.version>2.0.11</fongo.version>
+        <fongo.version>2.0.12</fongo.version>
         <jukito.version>1.5</jukito.version>
         <junit.version>4.12</junit.version>
         <mockito.version>2.3.10</mockito.version>

--- a/pom.xml
+++ b/pom.xml
@@ -147,7 +147,7 @@
 
         <!-- Test dependencies -->
         <apacheds-server.version>2.0.0-M23</apacheds-server.version>
-        <assertj-core.version>3.6.1</assertj-core.version>
+        <assertj-core.version>3.6.2</assertj-core.version>
         <assertj-joda-time.version>2.0.0</assertj-joda-time.version>
         <awaitility.version>1.7.0</awaitility.version>
         <equalsverifier.version>2.1.8</equalsverifier.version>


### PR DESCRIPTION
* https://www.elastic.co/guide/en/elasticsearch/reference/2.4/release-notes-2.4.4.html
* https://github.com/google/guava/wiki/Release21
* https://github.com/FasterXML/jackson/wiki/Jackson-Release-2.8.6
* https://github.com/rabbitmq/rabbitmq-java-client/releases/tag/v4.0.2
* https://github.com/rabbitmq/rabbitmq-java-client/releases/tag/v4.0.1

Test dependencies:
* https://joel-costigliola.github.io/assertj/assertj-core-news.html#assertj-core-3.6.2
* http://jqno.nl/equalsverifier/changelog/#version-22
* https://github.com/ArcBees/Jukito/releases/tag/jukito-parent-1.5