### PR TITLE
Use "order": -1 in default index template to allow override

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/indexer/indices/Indices.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/indices/Indices.java
@@ -278,7 +278,7 @@ public class Indices {
     private void ensureIndexTemplate(IndexSet indexSet) {
         final Map<String, Object> template = indexMapping.messageTemplate(indexSet.getIndexWildcard(), indexSet.getConfig().indexAnalyzer());
         final PutIndexTemplateRequest itr = c.admin().indices().preparePutTemplate(indexSet.getConfig().indexTemplateName())
-                .setOrder(Integer.MIN_VALUE) // Make sure templates with "order: 0" are applied after our template!
+                .setOrder(-1) // Make sure templates with "order: 0" and higher are applied after our template!
                 .setSource(template)
                 .request();
 


### PR DESCRIPTION
## Description

The old "order" of Integer.MIN_VALUE didn't let users override index mappings
on their own because Elasticsearch seems to merge the templates in the wrong order.

Fun fact: Integer.MIN_VALUE and Integer.MIN_VALUE+1 don't work,
but Integer.MIN_VALUE+2 and higher do. Go figure.

The new value of "-1" seems a good compromise between working without breaking changes (like using `"order": 0`) and without too arbitrary magic numbers (like `Integer.MIN_VALUE+2`).

Fixes #3421

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
