### PR TITLE
Get field stats for indices only, which contain field.

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/indexer/indices/Indices.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/indices/Indices.java
@@ -358,7 +358,9 @@ public class Indices {
                 @SuppressWarnings("unchecked")
                 final Map<String, Object> mapping = (Map<String, Object>) mmd.getSourceAsMap().get("properties");
 
-                fields.put(m.key, mapping.keySet());
+                if (mapping != null) {
+                    fields.put(m.key, mapping.keySet());
+                }
             } catch (Exception e) {
                 LOG.error("Error while trying to get fields of <" + m.index + ">", e);
             }

--- a/graylog2-server/src/test/java/org/graylog2/indexer/indices/IndicesGetAllMessageFieldsTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/indexer/indices/IndicesGetAllMessageFieldsTest.java
@@ -1,3 +1,19 @@
+/**
+ * This file is part of Graylog.
+ *
+ * Graylog is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package org.graylog2.indexer.indices;
 
 import com.codahale.metrics.MetricRegistry;

--- a/graylog2-server/src/test/java/org/graylog2/indexer/indices/IndicesGetAllMessageFieldsTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/indexer/indices/IndicesGetAllMessageFieldsTest.java
@@ -1,0 +1,189 @@
+package org.graylog2.indexer.indices;
+
+import com.codahale.metrics.MetricRegistry;
+import com.lordofthejars.nosqlunit.annotation.UsingDataSet;
+import com.lordofthejars.nosqlunit.core.LoadStrategyEnum;
+import com.lordofthejars.nosqlunit.elasticsearch2.ElasticsearchRule;
+import com.lordofthejars.nosqlunit.elasticsearch2.EmbeddedElasticsearch;
+import org.elasticsearch.action.admin.indices.delete.DeleteIndexRequest;
+import org.elasticsearch.action.admin.indices.exists.indices.IndicesExistsRequest;
+import org.elasticsearch.action.admin.indices.exists.indices.IndicesExistsResponse;
+import org.elasticsearch.action.admin.indices.get.GetIndexRequest;
+import org.elasticsearch.action.admin.indices.get.GetIndexResponse;
+import org.elasticsearch.client.Client;
+import org.graylog2.audit.NullAuditEventSender;
+import org.graylog2.indexer.IndexMapping;
+import org.graylog2.indexer.messages.Messages;
+import org.graylog2.plugin.system.NodeId;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.mockito.junit.MockitoJUnit;
+import org.mockito.junit.MockitoRule;
+
+import javax.inject.Inject;
+import java.util.Map;
+import java.util.Set;
+
+import static com.lordofthejars.nosqlunit.elasticsearch2.ElasticsearchRule.ElasticsearchRuleBuilder.newElasticsearchRule;
+import static com.lordofthejars.nosqlunit.elasticsearch2.EmbeddedElasticsearch.EmbeddedElasticsearchRuleBuilder.newEmbeddedElasticsearchRule;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+
+public class IndicesGetAllMessageFieldsTest {
+    @ClassRule
+    public static final EmbeddedElasticsearch EMBEDDED_ELASTICSEARCH = newEmbeddedElasticsearchRule().build();
+
+    @Rule
+    public final MockitoRule mockitoRule = MockitoJUnit.rule();
+    @Rule
+    public ElasticsearchRule elasticsearchRule = newElasticsearchRule().defaultEmbeddedElasticsearch();
+
+    @Inject
+    private Client client;
+    private Indices indices;
+
+    @Before
+    public void setUp() throws Exception {
+        elasticsearchRule.getDatabaseOperation().deleteAll();
+        indices = new Indices(client, new IndexMapping(), new Messages(client, new MetricRegistry()), mock(NodeId.class), new NullAuditEventSender());
+    }
+
+    @Test
+    @UsingDataSet(loadStrategy = LoadStrategyEnum.DELETE_ALL)
+    public void GetAllMessageFieldsForNonexistingIndexShouldReturnEmptySet() throws Exception {
+        final String[] indexNames = new String[] { "graylog_0" };
+        final Set<String> result = indices.getAllMessageFields(indexNames);
+
+        assertThat(result).isNotNull().isEmpty();
+    }
+
+    @Test
+    @UsingDataSet(locations = "IndicesTest-EmptyIndex.json", loadStrategy = LoadStrategyEnum.CLEAN_INSERT)
+    public void GetAllMessageFieldsForEmptyIndexShouldReturnEmptySet() throws Exception {
+        final String[] indexNames = new String[] { "graylog_0" };
+        final Set<String> result = indices.getAllMessageFields(indexNames);
+
+        assertThat(result).isNotNull().isEmpty();
+    }
+
+    @Test
+    @UsingDataSet(locations = "IndicesGetAllMessageFieldsTest-MultipleIndices.json", loadStrategy = LoadStrategyEnum.CLEAN_INSERT)
+    public void GetAllMessageFieldsForSingleIndexShouldReturnCompleteList() throws Exception {
+        final String[] indexNames = new String[] { "graylog_0" };
+        final Set<String> result = indices.getAllMessageFields(indexNames);
+
+        assertThat(result)
+            .isNotNull()
+            .hasSize(5)
+            .containsOnly("fieldonlypresenthere", "message", "n", "source", "timestamp");
+
+        final String[] otherIndexName = new String[] { "otherindexset_0" };
+
+        final Set<String> otherResult = indices.getAllMessageFields(otherIndexName);
+
+        assertThat(otherResult)
+            .isNotNull()
+            .hasSize(5)
+            .containsOnly("message", "n", "source", "timestamp", "someotherfield");
+    }
+
+    @Test
+    @UsingDataSet(locations = "IndicesGetAllMessageFieldsTest-MultipleIndices.json", loadStrategy = LoadStrategyEnum.CLEAN_INSERT)
+    public void GetAllMessageFieldsForMultipleIndicesShouldReturnCompleteList() throws Exception {
+        final String[] indexNames = new String[] { "graylog_0", "otherindexset_0" };
+        final Set<String> result = indices.getAllMessageFields(indexNames);
+
+        assertThat(result)
+            .isNotNull()
+            .hasSize(6)
+            .containsOnly("message", "n", "source", "timestamp", "fieldonlypresenthere", "someotherfield");
+    }
+
+    @Test
+    @UsingDataSet(loadStrategy = LoadStrategyEnum.DELETE_ALL)
+    public void GetAllMessageFieldsForIndicesForNonexistingIndexShouldReturnEmptySet() throws Exception {
+        final String[] indexNames = new String[] { "graylog_0" };
+        final IndicesExistsResponse response = client.admin().indices().exists(new IndicesExistsRequest("graylog_0")).get();
+        assertThat(response.isExists()).isFalse();
+        final Map<String, Set<String>> result = indices.getAllMessageFieldsForIndices(indexNames);
+
+        assertThat(result).isNotNull().isEmpty();
+    }
+
+    @Test
+    @UsingDataSet(locations = "IndicesTest-EmptyIndex.json", loadStrategy = LoadStrategyEnum.CLEAN_INSERT)
+    public void GetAllMessageFieldsForIndicesForEmptyIndexShouldReturnEmptySet() throws Exception {
+        final String[] indexNames = new String[] { "graylog_0" };
+        final Map<String, Set<String>> result = indices.getAllMessageFieldsForIndices(indexNames);
+
+        assertThat(result)
+            .isNotNull()
+            .isEmpty();
+    }
+
+    @Test
+    @UsingDataSet(locations = "IndicesGetAllMessageFieldsTest-MultipleIndices.json", loadStrategy = LoadStrategyEnum.CLEAN_INSERT)
+    public void GetAllMessageFieldsForIndicesForSingleIndexShouldReturnCompleteList() throws Exception {
+        final String indexName = "graylog_0";
+        final String[] indexNames = new String[] { indexName };
+        final Map<String, Set<String>> result = indices.getAllMessageFieldsForIndices(indexNames);
+
+        assertThat(result)
+            .isNotNull()
+            .hasSize(1)
+            .containsOnlyKeys(indexName);
+
+        assertThat(result.get(indexName))
+            .isNotNull()
+            .hasSize(5)
+            .containsOnly("fieldonlypresenthere", "message", "n", "source", "timestamp");
+
+        final String otherIndexName = "otherindexset_0";
+        final String[] otherIndexNames = new String[] { otherIndexName };
+
+        final Map<String, Set<String>> otherResult = indices.getAllMessageFieldsForIndices(otherIndexNames);
+
+        assertThat(otherResult)
+            .isNotNull()
+            .hasSize(1)
+            .containsOnlyKeys(otherIndexName);
+
+        assertThat(otherResult.get(otherIndexName))
+            .isNotNull()
+            .hasSize(5)
+            .containsOnly("someotherfield", "message", "n", "source", "timestamp");
+    }
+
+    @Test
+    @UsingDataSet(locations = "IndicesGetAllMessageFieldsTest-MultipleIndices.json", loadStrategy = LoadStrategyEnum.CLEAN_INSERT)
+    public void GetAllMessageFieldsForIndicesForMultipleIndicesShouldReturnCompleteList() throws Exception {
+        final String[] indexNames = new String[] { "graylog_0", "otherindexset_0" };
+        final Map<String, Set<String>> result = indices.getAllMessageFieldsForIndices(indexNames);
+
+        assertThat(result)
+            .isNotNull()
+            .hasSize(2)
+            .containsOnlyKeys("graylog_0", "otherindexset_0");
+
+        assertThat(result.get("graylog_0"))
+            .isNotNull()
+            .hasSize(5)
+            .containsOnly("message", "n", "source", "timestamp", "fieldonlypresenthere");
+
+        assertThat(result.get("otherindexset_0"))
+            .isNotNull()
+            .hasSize(5)
+            .containsOnly("message", "n", "source", "timestamp", "someotherfield");
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        final GetIndexResponse response = client.admin().indices().getIndex(new GetIndexRequest()).get();
+        for (String index : response.indices()) {
+            client.admin().indices().delete(new DeleteIndexRequest(index)).get();
+        }
+    }
+}

--- a/graylog2-server/src/test/java/org/graylog2/indexer/searches/SearchesTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/indexer/searches/SearchesTest.java
@@ -31,6 +31,7 @@ import org.graylog2.indexer.IndexHelper;
 import org.graylog2.indexer.IndexSet;
 import org.graylog2.indexer.TestIndexSet;
 import org.graylog2.indexer.indexset.IndexSetConfig;
+import org.graylog2.indexer.indices.Indices;
 import org.graylog2.indexer.nosqlunit.IndexCreatingLoadStrategyFactory;
 import org.graylog2.indexer.ranges.IndexRange;
 import org.graylog2.indexer.ranges.IndexRangeComparator;
@@ -168,7 +169,7 @@ public class SearchesTest {
     public void setUp() throws Exception {
         when(indexRangeService.find(any(DateTime.class), any(DateTime.class))).thenReturn(INDEX_RANGES);
         metricRegistry = new MetricRegistry();
-        searches = new Searches(new Configuration(), indexRangeService, client, metricRegistry, streamService);
+        searches = new Searches(new Configuration(), indexRangeService, client, metricRegistry, streamService, mock(Indices.class));
     }
 
     @Test

--- a/graylog2-server/src/test/resources/org/graylog2/indexer/indices/IndicesGetAllMessageFieldsTest-MultipleIndices.json
+++ b/graylog2-server/src/test/resources/org/graylog2/indexer/indices/IndicesGetAllMessageFieldsTest-MultipleIndices.json
@@ -1,0 +1,137 @@
+{
+  "documents": [
+    {
+      "document": [
+        {
+          "index": {
+            "indexName": "graylog_0",
+            "indexType": "message",
+            "indexId": "0"
+          }
+        },
+        {
+          "data": {
+            "source": "example.org",
+            "message": "Hi",
+            "timestamp": "2015-01-01 01:00:00.000",
+            "fieldonlypresenthere": "somevalue"
+          }
+        }
+      ]
+    },
+    {
+      "document": [
+        {
+          "index": {
+            "indexName": "otherindexset_0",
+            "indexType": "message",
+            "indexId": "1"
+          }
+        },
+        {
+          "data": {
+            "source": "example.org",
+            "message": "Ho",
+            "timestamp": "2015-01-01 02:00:00.000",
+            "n": 1
+          }
+        }
+      ]
+    },
+    {
+      "document": [
+        {
+          "index": {
+            "indexName": "graylog_0",
+            "indexType": "message",
+            "indexId": "2"
+          }
+        },
+        {
+          "data": {
+            "source": "example.org",
+            "message": "Hi",
+            "timestamp": "2015-01-01 03:00:00.000",
+            "n": 1
+          }
+        }
+      ]
+    },
+    {
+      "document": [
+        {
+          "index": {
+            "indexName": "graylog_0",
+            "indexType": "message",
+            "indexId": "3"
+          }
+        },
+        {
+          "data": {
+            "source": "example.org",
+            "message": "Ho",
+            "timestamp": "2015-01-01 04:00:00.000",
+            "n": 2
+          }
+        }
+      ]
+    },
+    {
+      "document": [
+        {
+          "index": {
+            "indexName": "graylog_0",
+            "indexType": "message",
+            "indexId": "4"
+          }
+        },
+        {
+          "data": {
+            "source": "example.org",
+            "message": "Hi",
+            "timestamp": "2015-01-01 05:00:00.000",
+            "n": 2
+          }
+        }
+      ]
+    },
+    {
+      "document": [
+        {
+          "index": {
+            "indexName": "graylog_0",
+            "indexType": "message",
+            "indexId": "5"
+          }
+        },
+        {
+          "data": {
+            "source": "example.com",
+            "message": "Ho",
+            "timestamp": "2015-01-01 01:00:00.000"
+          }
+        }
+      ]
+    },
+    {
+      "document": [
+        {
+          "index": {
+            "indexName": "otherindexset_0",
+            "indexType": "message",
+            "indexId": "6"
+          }
+        },
+        {
+          "data": {
+            "source": "example.com",
+            "message": "Hi",
+            "timestamp": "2015-01-01 02:00:00.000",
+            "n": 3,
+            "someotherfield": "someothervalue"
+          }
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## Description
## Motivation and Context

Before this change, field stats for fields failed on shards of indices,
which do not contain the field. The error was buried in the result set
(instead of an explicit "all shards failed" error) when indices were
included in the query, which contain messages with the specified field,
but the aggregations (total, cardinality) failed and returned 0.

After this change, the field stats request checks which indices contain
the specified field and use those indices only.

There are also other places in the code which would probably require this check (histogram/terms stats), this needs verification and probably the creation of additional PRs.

Fixes #3402.

<!--- Provide a general summary of your changes in the Title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
