### PR TITLE
Improve base-line memory usage

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/buffers/processors/OutputBufferProcessor.java
+++ b/graylog2-server/src/main/java/org/graylog2/buffers/processors/OutputBufferProcessor.java
@@ -16,15 +16,17 @@
  */
 package org.graylog2.buffers.processors;
 
+import com.google.common.util.concurrent.Futures;
+import com.google.common.util.concurrent.ThreadFactoryBuilder;
+import com.google.common.util.concurrent.Uninterruptibles;
+
 import com.codahale.metrics.Counter;
 import com.codahale.metrics.InstrumentedExecutorService;
 import com.codahale.metrics.Meter;
 import com.codahale.metrics.MetricRegistry;
 import com.codahale.metrics.Timer;
-import com.google.common.util.concurrent.Futures;
-import com.google.common.util.concurrent.ThreadFactoryBuilder;
-import com.google.common.util.concurrent.Uninterruptibles;
 import com.lmax.disruptor.WorkHandler;
+
 import org.graylog2.Configuration;
 import org.graylog2.outputs.DefaultMessageOutput;
 import org.graylog2.outputs.OutputRouter;
@@ -36,7 +38,6 @@ import org.graylog2.plugin.outputs.MessageOutput;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import javax.inject.Inject;
 import java.util.Set;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
@@ -45,6 +46,8 @@ import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
+
+import javax.inject.Inject;
 
 import static com.codahale.metrics.MetricRegistry.name;
 
@@ -160,6 +163,8 @@ public class OutputBufferProcessor implements WorkHandler<MessageEvent> {
         outputThroughput.inc();
 
         LOG.debug("Wrote message <{}> to all outputs. Finished handling.", msg.getId());
+
+        event.clearMessages();
     }
 
     private Future<?> processMessage(final Message msg, final MessageOutput defaultMessageOutput) {

--- a/graylog2-server/src/main/java/org/graylog2/shared/buffers/processors/ProcessBufferProcessor.java
+++ b/graylog2-server/src/main/java/org/graylog2/shared/buffers/processors/ProcessBufferProcessor.java
@@ -72,23 +72,27 @@ public class ProcessBufferProcessor implements WorkHandler<MessageEvent> {
 
     @Override
     public void onEvent(MessageEvent event) throws Exception {
-        // Decode the RawMessage to a Message object. The DecodingProcessor used to be a separate handler in the
-        // ProcessBuffer. Due to performance problems discovered during 1.0.0 testing, we decided to move this here.
-        // TODO The DecodingProcessor does not need to be a EventHandler. We decided to do it like this to keep the change as small as possible for 1.0.0.
-        decodingProcessor.onEvent(event, 0L, false);
+        try {
+            // Decode the RawMessage to a Message object. The DecodingProcessor used to be a separate handler in the
+            // ProcessBuffer. Due to performance problems discovered during 1.0.0 testing, we decided to move this here.
+            // TODO The DecodingProcessor does not need to be a EventHandler. We decided to do it like this to keep the change as small as possible for 1.0.0.
+            decodingProcessor.onEvent(event, 0L, false);
 
-        if (event.isSingleMessage()) {
-            dispatchMessage(event.getMessage());
-        } else {
-            final Collection<Message> messageList = event.getMessages();
-            if (messageList == null) {
-                // skip message events which could not be decoded properly
-                return;
-            }
+            if (event.isSingleMessage()) {
+                dispatchMessage(event.getMessage());
+            } else {
+                final Collection<Message> messageList = event.getMessages();
+                if (messageList == null) {
+                    // skip message events which could not be decoded properly
+                    return;
+                }
 
-            for (final Message message : messageList) {
-                dispatchMessage(message);
+                for (final Message message : messageList) {
+                    dispatchMessage(message);
+                }
             }
+        } finally {
+            event.clearMessages();
         }
     }
 


### PR DESCRIPTION
This change addresses both the changed memory profile of grizzly/jersey by switching back to its previous default as well as clearing out references to Message objects as early as possible during processing, to aid the garbage collector and preventing growing the old gen unnessarily.

Fixes #3423