### PR TITLE
Use condition and notification placeholders

### DIFF
--- a/graylog2-web-interface/src/components/alarmcallbacks/AlarmCallbackHistory.jsx
+++ b/graylog2-web-interface/src/components/alarmcallbacks/AlarmCallbackHistory.jsx
@@ -18,7 +18,13 @@ const AlarmCallbackHistory = React.createClass({
     const hadError = history.result.type === 'error';
     const result = (hadError ? <Label bsStyle="danger">Error</Label> : <Label bsStyle="success">Sent</Label>);
 
-    const title = (type ? type.name : <span><em>Unknown notification</em> <small>({configuration.type})</small></span>);
+    const title = (
+      <span>
+        {type ? configuration.title || 'Untitled notification' : 'Unknown notification'}
+        {' '}
+        <small>({type ? type.name : configuration.type})</small>
+      </span>
+    );
     const description = (hadError ? `Error sending notification: ${history.result.error}` : 'Notification was sent successfully.');
 
     let configurationWell;

--- a/graylog2-web-interface/src/components/alerts/Alert.jsx
+++ b/graylog2-web-interface/src/components/alerts/Alert.jsx
@@ -33,14 +33,17 @@ const Alert = React.createClass({
     if (condition) {
       alertTitle = (
         <span>
-          <LinkContainer to={Routes.show_alert(alert.id)}><a>{condition.title}</a></LinkContainer>{' '}
+          <LinkContainer to={Routes.show_alert(alert.id)}>
+            <a>{condition.title || 'Untitled alert'}</a>
+          </LinkContainer>
+          {' '}
           <small>on stream <em>{stream.title}</em></small>
         </span>
       );
     } else {
       alertTitle = (
         <span>
-          <LinkContainer to={Routes.show_alert(alert.id)}><a><em>Unknown alert</em></a></LinkContainer>
+          <LinkContainer to={Routes.show_alert(alert.id)}><a>Unknown alert</a></LinkContainer>
         </span>
       );
     }

--- a/graylog2-web-interface/src/components/alerts/AlertTimeline.jsx
+++ b/graylog2-web-interface/src/components/alerts/AlertTimeline.jsx
@@ -46,7 +46,7 @@ const AlertTimeline = React.createClass({
         const type = this.state.availableNotifications[configuration.type];
         let title;
         if (type) {
-          title = <em>{type.name}</em>;
+          title = <span><em>{configuration.title || 'Untitled notification'}</em> ({type.name})</span>;
         } else {
           title = <span><em>Unknown notification</em> <small>({configuration.type})</small></span>;
         }

--- a/graylog2-web-interface/src/components/alerts/AlertTimeline.jsx
+++ b/graylog2-web-interface/src/components/alerts/AlertTimeline.jsx
@@ -94,13 +94,14 @@ const AlertTimeline = React.createClass({
     }
 
     const alert = this.props.alert;
-    const condition = this.props.condition;
+    const conditionExists = this.props.condition && Object.keys(this.props.condition).length > 0;
+    const condition = this.props.condition || {};
     const type = this.props.conditionType;
     const triggeredAtTimestamp = <Timestamp dateTime={alert.triggered_at} />;
 
     const title = (
       <span>
-        <em>{condition.title || 'Unknown alert'}</em>{' '}
+        <em>{conditionExists ? condition.title || 'Untitled condition' : 'Unknown condition'}</em>{' '}
         ({type.name || condition.type || 'Unknown condition type'})
       </span>
     );

--- a/graylog2-web-interface/src/pages/ShowAlertPage.jsx
+++ b/graylog2-web-interface/src/pages/ShowAlertPage.jsx
@@ -70,6 +70,7 @@ const ShowAlertPage = React.createClass({
 
     const alert = this.state.alert;
     const condition = this.state.alertCondition;
+    const conditionExists = Object.keys(condition).length > 0;
     const type = this.state.types[condition.type] || {};
     const stream = this.state.stream;
 
@@ -97,7 +98,7 @@ const ShowAlertPage = React.createClass({
     }
 
     const title = (
-      <span>{condition.title || <em>Unknown alert</em>}&nbsp;
+      <span>{conditionExists ? condition.title || 'Untitled alert' : 'Unknown alert'}&nbsp;
         <small>
           on stream <em>{stream.title}</em>&nbsp;
           <span className={style.alertStatusLabel}>{statusLabel}</span>
@@ -112,7 +113,7 @@ const ShowAlertPage = React.createClass({
     );
 
     return (
-      <DocumentTitle title={`${condition.title || 'Unknown alert'} on stream ${stream.title}`}>
+      <DocumentTitle title={`${conditionExists ? condition.title || 'Untitled alert' : 'Unknown alert'} on stream ${stream.title}`}>
         <div>
           <PageHeader title={title}>
             <span>
@@ -138,7 +139,7 @@ const ShowAlertPage = React.createClass({
             </span>
           </PageHeader>
 
-          <AlertDetails alert={alert} condition={condition} conditionType={type} stream={stream} />
+          <AlertDetails alert={alert} condition={conditionExists && condition} conditionType={type} stream={stream} />
         </div>
       </DocumentTitle>
     );


### PR DESCRIPTION
When condition or notification titles are not set, use placeholders instead of not showing anything at all.

These changes also make use of notification titles. They were introduced quite late and we forgot to modify the `AlertTimeline` component with that.

Fixes #3429
