### PR TITLE
redirect to overview after editing index set configuration

### DIFF
--- a/graylog2-web-interface/src/pages/IndexSetConfigurationPage.jsx
+++ b/graylog2-web-interface/src/pages/IndexSetConfigurationPage.jsx
@@ -44,7 +44,9 @@ const IndexSetConfigurationPage = React.createClass({
   },
 
   _saveConfiguration(indexSet) {
-    IndexSetsActions.update(indexSet);
+    IndexSetsActions.update(indexSet).then(() => {
+      this.props.history.pushState(null, Routes.SYSTEM.INDICES.LIST);
+    });
   },
 
   _isLoading() {

--- a/graylog2-web-interface/src/stores/indices/IndexSetsStore.jsx
+++ b/graylog2-web-interface/src/stores/indices/IndexSetsStore.jsx
@@ -69,7 +69,7 @@ const IndexSetsStore = Reflux.createStore({
     const promise = fetch('PUT', url, indexSet);
     promise.then(
       response => {
-        UserNotification.success(`Successfully updated index set '${indexSet.id}'`, 'Success');
+        UserNotification.success(`Successfully updated index set '${indexSet.title}'`, 'Success');
         this.trigger({ indexSet: response });
         return response;
       },
@@ -86,7 +86,7 @@ const IndexSetsStore = Reflux.createStore({
     const promise = fetch('POST', url, indexSet);
     promise.then(
       response => {
-        UserNotification.success(`Successfully created index set '${response.id}'`, 'Success');
+        UserNotification.success(`Successfully created index set '${indexSet.title}'`, 'Success');
         this.trigger({ indexSet: response });
         return response;
       },


### PR DESCRIPTION
otherwise the component's state would prevent further editing, which is confusing. Other pages also redirect to their respective overview pages on success
improve notifications a bit, showing the title instead of the internal ID for success notifications

fixes #3435