### PR TITLE
Adding simple cache wrapper around index sets list in MongoIndexSetRegistry.

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/indexer/MongoIndexSetRegistry.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/MongoIndexSetRegistry.java
@@ -16,16 +16,24 @@
  */
 package org.graylog2.indexer;
 
+import com.google.common.base.Supplier;
+import com.google.common.base.Suppliers;
 import com.google.common.collect.ImmutableSet;
+import com.google.common.eventbus.EventBus;
+import com.google.common.eventbus.Subscribe;
 import org.graylog2.indexer.indexset.IndexSetConfig;
 import org.graylog2.indexer.indexset.IndexSetService;
+import org.graylog2.indexer.indexset.events.IndexSetCreatedEvent;
+import org.graylog2.indexer.indexset.events.IndexSetDeletedEvent;
 import org.graylog2.indexer.indices.TooManyAliasesException;
 
 import javax.inject.Inject;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
+import java.util.concurrent.atomic.AtomicReference;
 
 import static java.util.Objects.requireNonNull;
 
@@ -33,15 +41,49 @@ public class MongoIndexSetRegistry implements IndexSetRegistry {
     private final IndexSetService indexSetService;
     private final MongoIndexSet.Factory mongoIndexSetFactory;
 
+    class IndexSetsCache {
+        private final IndexSetService indexSetService;
+        private AtomicReference<Supplier<List<IndexSetConfig>>> indexSetConfigs;
+
+        IndexSetsCache(IndexSetService indexSetService,
+                       EventBus serverEventBus) {
+            this.indexSetService = requireNonNull(indexSetService);
+            this.indexSetConfigs = new AtomicReference<>(Suppliers.memoize(this.indexSetService::findAll));
+            serverEventBus.register(this);
+        }
+
+        List<IndexSetConfig> get() {
+            return indexSetConfigs.get().get();
+        }
+
+        void invalidate() {
+            this.indexSetConfigs.set(Suppliers.memoize(this.indexSetService::findAll));
+        }
+
+        @Subscribe
+        void handleIndexSetCreation(IndexSetCreatedEvent indexSetCreatedEvent) {
+            this.invalidate();
+        }
+
+        @Subscribe
+        void handleIndexSetDeletion(IndexSetDeletedEvent indexSetDeletedEvent) {
+            this.invalidate();
+        }
+    }
+
+    private final IndexSetsCache indexSetsCache;
+
     @Inject
     public MongoIndexSetRegistry(IndexSetService indexSetService,
-                                 MongoIndexSet.Factory mongoIndexSetFactory) {
-        this.indexSetService = requireNonNull(indexSetService);
+                                 MongoIndexSet.Factory mongoIndexSetFactory,
+                                 EventBus serverEventBus) {
+        this.indexSetService = indexSetService;
         this.mongoIndexSetFactory = requireNonNull(mongoIndexSetFactory);
+        this.indexSetsCache = new IndexSetsCache(indexSetService, serverEventBus);
     }
 
     private Set<MongoIndexSet> findAllMongoIndexSets() {
-        final List<IndexSetConfig> configs = indexSetService.findAll();
+        final List<IndexSetConfig> configs = this.indexSetsCache.get();
         final ImmutableSet.Builder<MongoIndexSet> mongoIndexSets = ImmutableSet.builder();
         for (IndexSetConfig config : configs) {
             final MongoIndexSet mongoIndexSet = mongoIndexSetFactory.create(config);
@@ -57,18 +99,20 @@ public class MongoIndexSetRegistry implements IndexSetRegistry {
 
     @Override
     public Optional<IndexSet> get(final String indexSetId) {
-        return indexSetService.get(indexSetId)
-                .flatMap(indexSetConfig -> Optional.of((IndexSet) mongoIndexSetFactory.create(indexSetConfig)));
+        return this.indexSetsCache.get()
+            .stream()
+            .filter(indexSet -> Objects.equals(indexSet.id(), indexSetId))
+            .map(indexSetConfig -> (IndexSet)mongoIndexSetFactory.create(indexSetConfig))
+            .findFirst();
     }
 
     @Override
     public Optional<IndexSet> getForIndex(String indexName) {
-        for (MongoIndexSet indexSet : findAllMongoIndexSets()) {
-            if (indexSet.isManagedIndex(indexName)) {
-                return Optional.of(indexSet);
-            }
-        }
-        return Optional.empty();
+        return findAllMongoIndexSets()
+            .stream()
+            .filter(indexSet -> indexSet.isManagedIndex(indexName))
+            .map(indexSet -> (IndexSet)indexSet)
+            .findFirst();
     }
 
     @Override
@@ -125,14 +169,9 @@ public class MongoIndexSetRegistry implements IndexSetRegistry {
 
     @Override
     public boolean isUp() {
-        boolean result = true;
-        for (MongoIndexSet indexSet : findAllMongoIndexSets()) {
-            if (indexSet.getConfig().isWritable()) {
-                result = result && indexSet.isUp();
-            }
-        }
-
-        return result;
+        return findAllMongoIndexSets().stream()
+            .filter(indexSet -> indexSet.getConfig().isWritable())
+            .allMatch(MongoIndexSet::isUp);
     }
 
     @Override

--- a/graylog2-server/src/main/java/org/graylog2/indexer/MongoIndexSetRegistry.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/MongoIndexSetRegistry.java
@@ -30,6 +30,7 @@ import org.graylog2.indexer.indices.TooManyAliasesException;
 
 import javax.inject.Inject;
 import javax.inject.Singleton;
+import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Objects;
@@ -57,7 +58,7 @@ public class MongoIndexSetRegistry implements IndexSetRegistry {
         }
 
         List<IndexSetConfig> get() {
-            return indexSetConfigs.get().get();
+            return Collections.unmodifiableList(indexSetConfigs.get().get());
         }
 
         @VisibleForTesting

--- a/graylog2-server/src/test/java/org/graylog2/indexer/MongoIndexSetRegistryTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/indexer/MongoIndexSetRegistryTest.java
@@ -1,3 +1,19 @@
+/**
+ * This file is part of Graylog.
+ *
+ * Graylog is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package org.graylog2.indexer;
 
 import com.google.common.eventbus.EventBus;

--- a/graylog2-server/src/test/java/org/graylog2/indexer/MongoIndexSetRegistryTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/indexer/MongoIndexSetRegistryTest.java
@@ -1,0 +1,211 @@
+package org.graylog2.indexer;
+
+import com.google.common.eventbus.EventBus;
+import org.graylog2.indexer.indexset.IndexSetConfig;
+import org.graylog2.indexer.indexset.IndexSetService;
+import org.graylog2.indexer.indexset.events.IndexSetCreatedEvent;
+import org.graylog2.indexer.indexset.events.IndexSetDeletedEvent;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnit;
+import org.mockito.junit.MockitoRule;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+public class MongoIndexSetRegistryTest {
+    @Rule
+    public final MockitoRule mockitoRule = MockitoJUnit.rule();
+
+    private IndexSetRegistry indexSetRegistry;
+    private MongoIndexSetRegistry.IndexSetsCache indexSetsCache;
+    @Mock
+    private IndexSetService indexSetService;
+    @Mock
+    private MongoIndexSet.Factory mongoIndexSetFactory;
+    @Mock
+    private EventBus serverEventBus;
+
+    @Before
+    public void setUp() throws Exception {
+        this.indexSetsCache = new MongoIndexSetRegistry.IndexSetsCache(indexSetService, serverEventBus);
+        this.indexSetRegistry = new MongoIndexSetRegistry(indexSetService, mongoIndexSetFactory, indexSetsCache);
+    }
+
+    @Test
+    public void indexSetsCacheShouldReturnCachedList() {
+        final IndexSetConfig indexSetConfig = mock(IndexSetConfig.class);
+        final List<IndexSetConfig> indexSetConfigs = new ArrayList<IndexSetConfig>() {{ add(indexSetConfig); }};
+        when(indexSetService.findAll()).thenReturn(indexSetConfigs);
+
+        final List<IndexSetConfig> result = this.indexSetsCache.get();
+        assertThat(result)
+            .isNotNull()
+            .hasSize(1)
+            .containsExactly(indexSetConfig);
+
+        final List<IndexSetConfig> cachedResult = this.indexSetsCache.get();
+        assertThat(cachedResult)
+            .isNotNull()
+            .hasSize(1)
+            .containsExactly(indexSetConfig);
+
+        verify(indexSetService, times(1)).findAll();
+    }
+
+    @Test
+    public void indexSetsCacheShouldReturnNewListAfterInvalidate() {
+        final IndexSetConfig indexSetConfig = mock(IndexSetConfig.class);
+        final List<IndexSetConfig> indexSetConfigs = new ArrayList<IndexSetConfig>() {{ add(indexSetConfig); }};
+        when(indexSetService.findAll()).thenReturn(indexSetConfigs);
+
+        final List<IndexSetConfig> result = this.indexSetsCache.get();
+        assertThat(result)
+            .isNotNull()
+            .hasSize(1)
+            .containsExactly(indexSetConfig);
+
+        this.indexSetsCache.invalidate();
+
+        final IndexSetConfig newIndexSetConfig = mock(IndexSetConfig.class);
+        final List<IndexSetConfig> newIndexSetConfigs = new ArrayList<IndexSetConfig>() {{ add(newIndexSetConfig); }};
+        when(indexSetService.findAll()).thenReturn(newIndexSetConfigs);
+
+
+        final List<IndexSetConfig> newResult = this.indexSetsCache.get();
+        assertThat(newResult)
+            .isNotNull()
+            .hasSize(1)
+            .containsExactly(newIndexSetConfig);
+
+        verify(indexSetService, times(2)).findAll();
+    }
+
+    @Test
+    public void indexSetsCacheShouldBeInvalidatedForIndexSetCreation() {
+        final IndexSetConfig indexSetConfig = mock(IndexSetConfig.class);
+        final List<IndexSetConfig> indexSetConfigs = new ArrayList<IndexSetConfig>() {{ add(indexSetConfig); }};
+        when(indexSetService.findAll()).thenReturn(indexSetConfigs);
+
+        final List<IndexSetConfig> result = this.indexSetsCache.get();
+        assertThat(result)
+            .isNotNull()
+            .hasSize(1)
+            .containsExactly(indexSetConfig);
+
+        this.indexSetsCache.handleIndexSetCreation(mock(IndexSetCreatedEvent.class));
+
+        final IndexSetConfig newIndexSetConfig = mock(IndexSetConfig.class);
+        final List<IndexSetConfig> newIndexSetConfigs = new ArrayList<IndexSetConfig>() {{ add(newIndexSetConfig); }};
+        when(indexSetService.findAll()).thenReturn(newIndexSetConfigs);
+
+
+        final List<IndexSetConfig> newResult = this.indexSetsCache.get();
+        assertThat(newResult)
+            .isNotNull()
+            .hasSize(1)
+            .containsExactly(newIndexSetConfig);
+
+        verify(indexSetService, times(2)).findAll();
+    }
+
+    @Test
+    public void indexSetsCacheShouldBeInvalidatedForIndexSetDeletion() {
+        final IndexSetConfig indexSetConfig = mock(IndexSetConfig.class);
+        final List<IndexSetConfig> indexSetConfigs = new ArrayList<IndexSetConfig>() {{ add(indexSetConfig); }};
+        when(indexSetService.findAll()).thenReturn(indexSetConfigs);
+
+        final List<IndexSetConfig> result = this.indexSetsCache.get();
+        assertThat(result)
+            .isNotNull()
+            .hasSize(1)
+            .containsExactly(indexSetConfig);
+
+        this.indexSetsCache.handleIndexSetDeletion(mock(IndexSetDeletedEvent.class));
+
+        final IndexSetConfig newIndexSetConfig = mock(IndexSetConfig.class);
+        final List<IndexSetConfig> newIndexSetConfigs = new ArrayList<IndexSetConfig>() {{ add(newIndexSetConfig); }};
+        when(indexSetService.findAll()).thenReturn(newIndexSetConfigs);
+
+
+        final List<IndexSetConfig> newResult = this.indexSetsCache.get();
+        assertThat(newResult)
+            .isNotNull()
+            .hasSize(1)
+            .containsExactly(newIndexSetConfig);
+
+        verify(indexSetService, times(2)).findAll();
+    }
+
+    @Test
+    public void getAllShouldBeCachedForEmptyList() {
+        final List<IndexSetConfig> indexSetConfigs = new ArrayList<>();
+        when(indexSetService.findAll()).thenReturn(indexSetConfigs);
+
+        assertThat(this.indexSetRegistry.getAll())
+            .isNotNull()
+            .isEmpty();
+
+        assertThat(this.indexSetRegistry.getAll())
+            .isNotNull()
+            .isEmpty();
+
+        verify(indexSetService, times(1)).findAll();
+    }
+
+    @Test
+    public void getAllShouldBeCachedForNonEmptyList() {
+        final IndexSetConfig indexSetConfig = mock(IndexSetConfig.class);
+        final List<IndexSetConfig> indexSetConfigs = new ArrayList<IndexSetConfig>() {{ add(indexSetConfig); }};
+        final MongoIndexSet indexSet = mock(MongoIndexSet.class);
+        when(mongoIndexSetFactory.create(indexSetConfig)).thenReturn(indexSet);
+        when(indexSetService.findAll()).thenReturn(indexSetConfigs);
+
+        assertThat(this.indexSetRegistry.getAll())
+            .isNotNull()
+            .isNotEmpty()
+            .hasSize(1)
+            .containsExactly(indexSet);
+
+        assertThat(this.indexSetRegistry.getAll())
+            .isNotNull()
+            .isNotEmpty()
+            .hasSize(1)
+            .containsExactly(indexSet);
+
+        verify(indexSetService, times(1)).findAll();
+    }
+
+    @Test
+    public void getAllShouldNotBeCachedForCallAfterInvalidate() {
+        final IndexSetConfig indexSetConfig = mock(IndexSetConfig.class);
+        final List<IndexSetConfig> indexSetConfigs = new ArrayList<IndexSetConfig>() {{ add(indexSetConfig); }};
+        final MongoIndexSet indexSet = mock(MongoIndexSet.class);
+        when(mongoIndexSetFactory.create(indexSetConfig)).thenReturn(indexSet);
+        when(indexSetService.findAll()).thenReturn(indexSetConfigs);
+
+        assertThat(this.indexSetRegistry.getAll())
+            .isNotNull()
+            .isNotEmpty()
+            .hasSize(1)
+            .containsExactly(indexSet);
+
+        this.indexSetsCache.invalidate();
+
+        assertThat(this.indexSetRegistry.getAll())
+            .isNotNull()
+            .isNotEmpty()
+            .hasSize(1)
+            .containsExactly(indexSet);
+
+        verify(indexSetService, times(2)).findAll();
+    }
+}


### PR DESCRIPTION
## Description
## Motivation and Context

Before this change, every flush of the batched ES output results in MongoDB hits twice, because of status checks for all writable targets of all index sets.

This change adds a simple single-element cache in the `MongoIndexSetRegistry` class, which keeps 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
