### PR TITLE
Update documentation links

### DIFF
--- a/graylog2-web-interface/src/pages/StreamsPage.jsx
+++ b/graylog2-web-interface/src/pages/StreamsPage.jsx
@@ -46,20 +46,13 @@ const StreamsPage = React.createClass({
       <DocumentTitle title="Streams">
         <div>
           <PageHeader title="Streams">
-            <span>You can route incoming messages into streams by applying rules against them. If a
-              message
-              matches all rules of a stream it is routed into it. A message can be routed into
-              multiple
-              streams. You can for example create a stream that contains all SSH logins and configure
-              to be alerted whenever there are more logins than usual.
-
-              Read more about streams in the <DocumentationLink page={DocsHelper.PAGES.STREAMS} text="documentation" />.</span>
+            <span>
+              You can route incoming messages into streams by applying rules against them. Messages matching
+              the rules of a stream are routed into it. A message can also be routed into multiple streams.
+            </span>
 
             <span>
-              Take a look at the
-              {' '}<DocumentationLink page={DocsHelper.PAGES.EXTERNAL_DASHBOARDS}
-                                      text="Graylog stream dashboards" />{' '}
-              for wall-mounted displays or other integrations.
+              Read more about streams in the <DocumentationLink page={DocsHelper.PAGES.STREAMS} text="documentation" />.
             </span>
 
             <IfPermitted permissions="streams:create">

--- a/graylog2-web-interface/src/util/DocsHelper.js
+++ b/graylog2-web-interface/src/util/DocsHelper.js
@@ -2,7 +2,7 @@ import Version from './Version';
 
 class DocsHelper {
   PAGES = {
-    ALERTS: 'streams.html#alerts',
+    ALERTS: 'streams/alerts.html',
     CLUSTER_STATUS_EXPLAINED: 'configuration/elasticsearch.html#cluster-status-explained',
     COLLECTOR: 'collector.html',
     COLLECTOR_SIDECAR: 'collector_sidecar.html',
@@ -13,11 +13,9 @@ class DocsHelper {
     ES_CLUSTER_STATUS_RED: 'configuration/elasticsearch.html#cluster-status-explained',
     ES_CLUSTER_UNAVAILABLE: 'configuration/elasticsearch.html#configuration',
     ES_OPEN_FILE_LIMITS: 'configuration/elasticsearch.html#open-file-limits',
-    EXTERNAL_DASHBOARDS: 'external_dashboards.html',
     EXTRACTORS: 'extractors.html',
-    FLEXIBLE_DATE_CONVERTER: 'extractors.html#the-flexible-date-converter',
     INDEXER_FAILURES: 'indexer_failures.html',
-    INDEX_MODEL: 'index_model.html',
+    INDEX_MODEL: 'configuration/index_model.html',
     LOAD_BALANCERS: 'configuration/load_balancers.html',
     PAGE_FLEXIBLE_DATE_CONVERTER: 'extractors.html#the-flexible-date-converter',
     PAGE_STANDARD_DATE_CONVERTER: 'extractors.html#the-standard-date-converter',
@@ -25,7 +23,6 @@ class DocsHelper {
     PIPELINE_RULES: 'pipelines/rules.html',
     PIPELINES: 'pipelines.html',
     SEARCH_QUERY_LANGUAGE: 'queries.html',
-    STANDARD_DATE_CONVERTER: 'extractors.html#the-standard-date-converter',
     STREAMS: 'streams.html',
     STREAM_PROCESSING_RUNTIME_LIMITS: 'streams.html#stream-processing-runtime-limits',
     USERS_ROLES: 'users_and_roles.html',


### PR DESCRIPTION
This PR updates some links regarding documentation in the web interface:

- Remove reference to external dashboards in stream page, and slightly rework the description in there
- Update links to alerts and index model pages
- Remove duplicated documentation links