### PR TITLE
Use consistent case in old message count conditions

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/alerts/AbstractAlertCondition.java
+++ b/graylog2-server/src/main/java/org/graylog2/alerts/AbstractAlertCondition.java
@@ -59,7 +59,7 @@ public abstract class AbstractAlertCondition implements EmbeddedPersistable, Ale
     protected final int backlog;
     protected final String title;
 
-    private final Map<String, Object> parameters;
+    private Map<String, Object> parameters;
 
     protected AbstractAlertCondition(Stream stream, String id, String type, DateTime createdAt, String creatorUserId, Map<String, Object> parameters, String title) {
         this.title = title;
@@ -107,6 +107,10 @@ public abstract class AbstractAlertCondition implements EmbeddedPersistable, Ale
     @Override
     public Stream getStream() {
         return stream;
+    }
+
+    protected void setParameters(Map<String, Object> parameters) {
+        this.parameters = ImmutableMap.copyOf(parameters);
     }
 
     @Override

--- a/graylog2-server/src/test/java/org/graylog2/alerts/types/MessageCountAlertConditionTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/alerts/types/MessageCountAlertConditionTest.java
@@ -24,8 +24,10 @@ import org.graylog2.plugin.alarms.AlertCondition;
 import org.graylog2.plugin.indexer.searches.timeranges.TimeRange;
 import org.junit.Test;
 
+import java.util.Locale;
 import java.util.Map;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.anyString;
@@ -43,6 +45,23 @@ public class MessageCountAlertConditionTest extends AlertConditionTest {
 
         assertNotNull(messageCountAlertCondition);
         assertNotNull(messageCountAlertCondition.getDescription());
+        final String thresholdType = (String) messageCountAlertCondition.getParameters().get("threshold_type");
+        assertEquals(thresholdType, thresholdType.toUpperCase(Locale.ENGLISH));
+    }
+
+    /*
+     * Ensure MessageCountAlertCondition objects created before 2.2.0 and having a lowercase threshold_type,
+     * get converted to uppercase for consistency with new created alert conditions.
+     */
+    @Test
+    public void testConstructorOldObjects() throws Exception {
+        final Map<String, Object> parameters = getParametersMap(0, 0, MessageCountAlertCondition.ThresholdType.MORE, 0);
+        parameters.put("threshold_type", MessageCountAlertCondition.ThresholdType.MORE.toString().toLowerCase(Locale.ENGLISH));
+
+        final MessageCountAlertCondition messageCountAlertCondition = getMessageCountAlertCondition(parameters, alertConditionTitle);
+
+        final String thresholdType = (String) messageCountAlertCondition.getParameters().get("threshold_type");
+        assertEquals(thresholdType, thresholdType.toUpperCase(Locale.ENGLISH));
     }
 
     @Test

--- a/graylog2-web-interface/src/components/alertconditions/fieldvaluecondition/FieldValueConditionSummary.jsx
+++ b/graylog2-web-interface/src/components/alertconditions/fieldvaluecondition/FieldValueConditionSummary.jsx
@@ -13,7 +13,7 @@ const FieldValueConditionSummary = React.createClass({
     const field = alertCondition.parameters.field;
     const threshold = alertCondition.parameters.threshold;
     const thresholdType = alertCondition.parameters.threshold_type.toLowerCase();
-    const type = alertCondition.parameters.type;
+    const type = alertCondition.parameters.type.toLowerCase();
     const time = alertCondition.parameters.time;
 
     return (

--- a/graylog2-web-interface/src/components/alertconditions/messagecountcondition/MessageCountConditionSummary.jsx
+++ b/graylog2-web-interface/src/components/alertconditions/messagecountcondition/MessageCountConditionSummary.jsx
@@ -11,7 +11,7 @@ const MessageCountConditionSummary = React.createClass({
   render() {
     const alertCondition = this.props.alertCondition;
     const threshold = alertCondition.parameters.threshold;
-    const thresholdType = alertCondition.parameters.threshold_type;
+    const thresholdType = alertCondition.parameters.threshold_type.toLowerCase();
     const time = alertCondition.parameters.time;
 
     return (

--- a/graylog2-web-interface/src/components/configurationforms/DropdownField.jsx
+++ b/graylog2-web-interface/src/components/configurationforms/DropdownField.jsx
@@ -32,7 +32,7 @@ const DropdownField = React.createClass({
   },
   _formatOption(value, key, disabled) {
     return (
-      <option key={`${this.state.typeName}-${this.state.field}-${key}`} value={key} id={key} disabled={disabled}>{value}</option>
+      <option key={`${this.state.typeName}-${this.state.title}-${key}`} value={key} id={key} disabled={disabled}>{value}</option>
     );
   },
   handleChange(evt) {


### PR DESCRIPTION
Since 2.2.0, we are storing the message count `threshold_type` parameter in upper case, just like we do with other types in field value conditions. Previous Graylog versions were storing `threshold_type` in lower case, same case that were use in parameters when instantiating new
`MessageCountAlertCondition` objects. This resulted in case inconsistencies in objects from that class, which were propagated to the API and persistence layer.

This PR converts `threshold_type` to upper case, so we use that case when instantiating old conditions. I also included two other related small fixes: using consistent case in alert condition descriptions, and fixing the `option` keys in `DropdownField`s. Let me know if I crept too much in here 😉 

Fixes #3451