### PR TITLE
Bump master versions

### DIFF
--- a/auto-value-javabean/pom.xml
+++ b/auto-value-javabean/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>org.graylog</groupId>
         <artifactId>graylog-project-parent</artifactId>
-        <version>2.2.1-SNAPSHOT</version>
+        <version>2.3.0-SNAPSHOT</version>
         <relativePath>../graylog-project-parent</relativePath>
     </parent>
 

--- a/graylog-plugin-archetype/pom.xml
+++ b/graylog-plugin-archetype/pom.xml
@@ -26,7 +26,7 @@
     <parent>
         <groupId>org.graylog</groupId>
         <artifactId>graylog-project-parent</artifactId>
-        <version>2.2.1-SNAPSHOT</version>
+        <version>2.3.0-SNAPSHOT</version>
         <relativePath>../graylog-project-parent</relativePath>
     </parent>
 

--- a/graylog-plugin-parent/graylog-plugin-web-parent/pom.xml
+++ b/graylog-plugin-parent/graylog-plugin-web-parent/pom.xml
@@ -26,7 +26,7 @@
     <parent>
         <groupId>org.graylog.plugins</groupId>
         <artifactId>graylog-plugin-parent</artifactId>
-        <version>2.2.1-SNAPSHOT</version>
+        <version>2.3.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>graylog-plugin-web-parent</artifactId>

--- a/graylog-plugin-parent/pom.xml
+++ b/graylog-plugin-parent/pom.xml
@@ -30,7 +30,7 @@
     <parent>
         <groupId>org.graylog</groupId>
         <artifactId>graylog-parent</artifactId>
-        <version>2.2.1-SNAPSHOT</version>
+        <version>2.3.0-SNAPSHOT</version>
     </parent>
 
     <groupId>org.graylog.plugins</groupId>

--- a/graylog-project-parent/pom.xml
+++ b/graylog-project-parent/pom.xml
@@ -32,7 +32,7 @@
     <parent>
         <groupId>org.graylog</groupId>
         <artifactId>graylog-parent</artifactId>
-        <version>2.2.1-SNAPSHOT</version>
+        <version>2.3.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>graylog-project-parent</artifactId>

--- a/graylog2-server/pom.xml
+++ b/graylog2-server/pom.xml
@@ -26,7 +26,7 @@
     <parent>
         <groupId>org.graylog</groupId>
         <artifactId>graylog-project-parent</artifactId>
-        <version>2.2.1-SNAPSHOT</version>
+        <version>2.3.0-SNAPSHOT</version>
         <relativePath>../graylog-project-parent</relativePath>
     </parent>
 

--- a/graylog2-web-interface/package.json
+++ b/graylog2-web-interface/package.json
@@ -1,6 +1,6 @@
 {
   "name": "graylog-web-interface",
-  "version": "2.2.0-SNAPSHOT",
+  "version": "2.3.0-SNAPSHOT",
   "description": "Graylog Web Interface",
   "author": "torch",
   "license": "GPL-3.0",

--- a/integration-tests/pom.xml
+++ b/integration-tests/pom.xml
@@ -26,7 +26,7 @@
     <parent>
         <groupId>org.graylog</groupId>
         <artifactId>graylog-project-parent</artifactId>
-        <version>2.2.1-SNAPSHOT</version>
+        <version>2.3.0-SNAPSHOT</version>
         <relativePath>../graylog-project-parent</relativePath>
     </parent>
 

--- a/pom.xml
+++ b/pom.xml
@@ -31,7 +31,7 @@
 
     <groupId>org.graylog</groupId>
     <artifactId>graylog-parent</artifactId>
-    <version>2.2.1-SNAPSHOT</version>
+    <version>2.3.0-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <name>Graylog Parent POM</name>


### PR DESCRIPTION
As we have a branch for maintenance work in 2.2, we need to bump the master versions to 2.3.0-SNAPSHOT.