### PR TITLE
Returning promise from handler.

### DIFF
--- a/graylog2-web-interface/src/stores/sessions/SessionStore.js
+++ b/graylog2-web-interface/src/stores/sessions/SessionStore.js
@@ -53,7 +53,7 @@ const SessionStore = Reflux.createStore({
     this._validateSession(sessionId)
       .then((response) => {
         if (response.is_valid) {
-          SessionActions.login.completed({
+          return SessionActions.login.completed({
             sessionId: sessionId || response.session_id,
             username: username || response.username,
           });


### PR DESCRIPTION
This prevents a reoccuring warning from bluebird about a runaway
promise. Although this is not really an issue, the warning spamming the
console should be avoided.
