### PR TITLE
Checking if LoginPage is mounted before updating loading indicator.

### DIFF
--- a/graylog2-web-interface/src/pages/LoginPage.jsx
+++ b/graylog2-web-interface/src/pages/LoginPage.jsx
@@ -47,7 +47,11 @@ const LoginPage = React.createClass({
         this.setState({lastError: 'Error - the server returned: ' + error.additional.status + ' - ' + error.message});
       }
     });
-    promise.finally(() => this.setState({ loading: false }));
+    promise.finally(() => {
+      if (this.isMounted()) {
+        this.setState({ loading: false });
+      }
+    });
   },
   formatLastError(error) {
     if (error) {


### PR DESCRIPTION
This change prevents a warning showing up in the console every login.

The loading indicator flag is updated from the promise when the
component was already unmounted. This is prevented by checking
`isMounted()` before calling `setState` from the promise handler.

Although this is considered to be an antipattern (see
https://facebook.github.io/react/blog/2015/12/16/ismounted-antipattern.html)
there is currently no real alternative.
