### PR TITLE
Allow version '0' for structured syslog messages

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/inputs/codecs/SyslogCodec.java
+++ b/graylog2-server/src/main/java/org/graylog2/inputs/codecs/SyslogCodec.java
@@ -59,7 +59,7 @@ import static com.google.common.base.Strings.isNullOrEmpty;
 @Codec(name = "syslog", displayName = "Syslog")
 public class SyslogCodec extends AbstractCodec {
     private static final Logger LOG = LoggerFactory.getLogger(SyslogCodec.class);
-    private static final Pattern STRUCTURED_SYSLOG_PATTERN = Pattern.compile("<\\d{1,3}>[1-9]\\d{0,2}\\s.*", Pattern.DOTALL);
+    private static final Pattern STRUCTURED_SYSLOG_PATTERN = Pattern.compile("<\\d{1,3}>[0-9]\\d{0,2}\\s.*", Pattern.DOTALL);
 
     static final String CK_FORCE_RDNS = "force_rdns";
     static final String CK_ALLOW_OVERRIDE_DATE = "allow_override_date";

--- a/graylog2-server/src/test/java/org/graylog2/inputs/codecs/SyslogCodecTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/inputs/codecs/SyslogCodecTest.java
@@ -48,11 +48,11 @@ import static org.mockito.Mockito.when;
 
 public class SyslogCodecTest {
     private static final int YEAR = Tools.nowUTC().getYear();
-    public static String STRUCTURED = "<165>1 2012-12-25T22:14:15.003Z mymachine.example.com evntslog - ID47 [exampleSDID@32473 iut=\"3\" eventSource=\"Application\" eventID=\"1011\"] BOMAn application event log entry";
-    public static String STRUCTURED_ISSUE_845 = "<190>1 2015-01-06T20:56:33.287Z app-1 app - - [mdc@18060 ip=\"::ffff:132.123.15.30\" logger=\"{c.corp.Handler}\" session=\"4ot7\" user=\"user@example.com\" user-agent=\"Mozilla/5.0 (Macintosh; Intel Mac OS X 10_9_5) AppleWebKit/600.2.5 (KHTML, like Gecko) Version/7.1.2 Safari/537.85.11\"] User page 13 requested";
-    public static String STRUCTURED_ISSUE_845_EMPTY = "<128>1 2015-01-11T16:35:21.335797+01:00 s000000.example.com - - - - tralala";
+    private static String STRUCTURED = "<165>1 2012-12-25T22:14:15.003Z mymachine.example.com evntslog - ID47 [exampleSDID@32473 iut=\"3\" eventSource=\"Application\" eventID=\"1011\"] BOMAn application event log entry";
+    private static String STRUCTURED_ISSUE_845 = "<190>1 2015-01-06T20:56:33.287Z app-1 app - - [mdc@18060 ip=\"::ffff:132.123.15.30\" logger=\"{c.corp.Handler}\" session=\"4ot7\" user=\"user@example.com\" user-agent=\"Mozilla/5.0 (Macintosh; Intel Mac OS X 10_9_5) AppleWebKit/600.2.5 (KHTML, like Gecko) Version/7.1.2 Safari/537.85.11\"] User page 13 requested";
+    private static String STRUCTURED_ISSUE_845_EMPTY = "<128>1 2015-01-11T16:35:21.335797+01:00 s000000.example.com - - - - tralala";
     // The folowing message from issue 549 is from a Juniper SRX 240 device.
-    public static String STRUCTURED_ISSUE_549 = "<14>1 2014-05-01T08:26:51.179Z fw01 RT_FLOW - RT_FLOW_SESSION_DENY [junos@2636.1.1.1.2.39 source-address=\"1.2.3.4\" source-port=\"56639\" destination-address=\"5.6.7.8\" destination-port=\"2003\" service-name=\"None\" protocol-id=\"6\" icmp-type=\"0\" policy-name=\"log-all-else\" source-zone-name=\"campus\" destination-zone-name=\"mngmt\" application=\"UNKNOWN\" nested-application=\"UNKNOWN\" username=\"N/A\" roles=\"N/A\" packet-incoming-interface=\"reth6.0\" encrypted=\"No\"]";
+    private static String STRUCTURED_ISSUE_549 = "<14>1 2014-05-01T08:26:51.179Z fw01 RT_FLOW - RT_FLOW_SESSION_DENY [junos@2636.1.1.1.2.39 source-address=\"1.2.3.4\" source-port=\"56639\" destination-address=\"5.6.7.8\" destination-port=\"2003\" service-name=\"None\" protocol-id=\"6\" icmp-type=\"0\" policy-name=\"log-all-else\" source-zone-name=\"campus\" destination-zone-name=\"mngmt\" application=\"UNKNOWN\" nested-application=\"UNKNOWN\" username=\"N/A\" roles=\"N/A\" packet-incoming-interface=\"reth6.0\" encrypted=\"No\"]";
     private final String UNSTRUCTURED = "<45>Oct 21 12:09:37 c4dc57ba1ebb syslog-ng[7208]: syslog-ng starting up; version='3.5.3'";
 
     @Rule
@@ -334,6 +334,21 @@ public class SyslogCodecTest {
         assertEquals("hostname", message.getSource());
         assertEquals(6, message.getField("level"));
         assertEquals("kernel", message.getField("facility"));
+    }
+
+    @Test
+    public void testIssue3502() throws Exception {
+        // https://github.com/Graylog2/graylog2-server/issues/3502
+        final RawMessage rawMessage = buildRawMessage("<6>0 2017-02-15T16:01:07.000+01:00 hostname test - - -  test 4");
+        final Message message = codec.decode(rawMessage);
+
+        assertNotNull(message);
+        assertEquals("test 4", message.getMessage());
+        assertEquals(new DateTime(2017, 2, 15, 15, 1, 7, DateTimeZone.UTC), message.getTimestamp());
+        assertEquals("hostname", message.getSource());
+        assertEquals(6, message.getField("level"));
+        assertEquals("kernel", message.getField("facility"));
+        assertEquals("test", message.getField("application_name"));
     }
 
     private RawMessage buildRawMessage(String message) {


### PR DESCRIPTION
Although RFC 5424 clearly states that '1' is the only valid version for structured syslog
messages, some syslog daemons are using '0' as a version identifier.

https://tools.ietf.org/html/rfc5424#section-9.1

Fixes #3502