### PR TITLE
Ignore Content-Type in HttpTransport

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/inputs/transports/HttpTransport.java
+++ b/graylog2-server/src/main/java/org/graylog2/inputs/transports/HttpTransport.java
@@ -58,7 +58,6 @@ import org.jboss.netty.handler.timeout.ReadTimeoutHandler;
 import org.jboss.netty.util.HashedWheelTimer;
 
 import javax.inject.Named;
-import javax.ws.rs.core.MediaType;
 import java.util.LinkedHashMap;
 import java.util.concurrent.Callable;
 import java.util.concurrent.Executor;
@@ -67,7 +66,6 @@ import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.TimeUnit;
 
 import static com.codahale.metrics.MetricRegistry.name;
-import static com.google.common.base.Strings.isNullOrEmpty;
 import static org.jboss.netty.channel.Channels.fireMessageReceived;
 import static org.jboss.netty.handler.codec.http.HttpHeaders.Names;
 import static org.jboss.netty.handler.codec.http.HttpHeaders.Values;
@@ -76,7 +74,6 @@ import static org.jboss.netty.handler.codec.http.HttpResponseStatus.ACCEPTED;
 import static org.jboss.netty.handler.codec.http.HttpResponseStatus.METHOD_NOT_ALLOWED;
 import static org.jboss.netty.handler.codec.http.HttpResponseStatus.NOT_FOUND;
 import static org.jboss.netty.handler.codec.http.HttpResponseStatus.OK;
-import static org.jboss.netty.handler.codec.http.HttpResponseStatus.UNSUPPORTED_MEDIA_TYPE;
 
 public class HttpTransport extends AbstractTcpTransport {
     static final int DEFAULT_MAX_INITIAL_LINE_LENGTH = 4096;
@@ -214,15 +211,9 @@ public class HttpTransport extends AbstractTcpTransport {
             final ChannelBuffer buffer = request.getContent();
 
             final boolean correctPath = "/gelf".equals(request.getUri());
-            final String contentType = request.headers().get(Names.CONTENT_TYPE);
-            final boolean correctContentType = isNullOrEmpty(contentType)
-                    || MediaType.APPLICATION_JSON.equals(contentType)
-                    || MediaType.APPLICATION_FORM_URLENCODED.equals(contentType);
 
             if (!correctPath) {
                 writeResponse(channel, keepAlive, httpRequestVersion, NOT_FOUND, origin);
-            } else if (!correctContentType) {
-                writeResponse(channel, keepAlive, httpRequestVersion, UNSUPPORTED_MEDIA_TYPE, origin);
             } else {
                 // send on to raw message handler
                 writeResponse(channel, keepAlive, httpRequestVersion, ACCEPTED, origin);


### PR DESCRIPTION
Since there is no real point in checking the `Content-Type` HTTP request header in the GELF HTTP input but hinders adoption of that input by users, this PR simply removes the Content-Type check.

Fixes #3477