### PR TITLE
Fixing slicing of alert conditions in pagination.

### DIFF
--- a/graylog2-web-interface/src/components/alertconditions/AlertConditionsList.jsx
+++ b/graylog2-web-interface/src/components/alertconditions/AlertConditionsList.jsx
@@ -22,7 +22,7 @@ const AlertConditionsList = React.createClass({
   },
 
   _paginatedConditions() {
-    return this.props.alertConditions.slice(this.state.currentPage, this.state.currentPage + this.PAGE_SIZE);
+    return this.props.alertConditions.slice(this.state.currentPage * this.PAGE_SIZE, (this.state.currentPage + 1) * this.PAGE_SIZE);
   },
 
   _formatCondition(condition) {


### PR DESCRIPTION
## Description
## Motivation and Context
Before this change, the slice of alert conditions shown in the paginated
view was calculated incorrectly.

Fixes #3528.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
