### PR TITLE
TestIndexSet needs to be importable, thus is shouldn't be moved to test/

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/indexer/TestIndexSet.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/TestIndexSet.java
@@ -25,6 +25,9 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 
+/**
+ * This class is being used in plugins for testing, DO NOT move it to the test/ directory without changing the plugins.
+ */
 public class TestIndexSet implements IndexSet {
     private static final String SEPARATOR = "_";
     private static final String DEFLECTOR_SUFFIX = "deflector";


### PR DESCRIPTION
This class needs to be visible in certain plugin tests so we need to move it back.