### PR TITLE
Wait until notification types are loaded

### DIFF
--- a/graylog2-web-interface/src/components/alertnotifications/AlertNotification.jsx
+++ b/graylog2-web-interface/src/components/alertnotifications/AlertNotification.jsx
@@ -9,7 +9,7 @@ const { AlertNotificationsStore } = CombinedProvider.get('AlertNotifications');
 const { AlarmCallbacksActions } = CombinedProvider.get('AlarmCallbacks');
 const { CurrentUserStore } = CombinedProvider.get('CurrentUser');
 
-import { EntityListItem } from 'components/common';
+import { EntityListItem, Spinner } from 'components/common';
 import { UnknownAlertNotification } from 'components/alertnotifications';
 import { ConfigurationForm, ConfigurationWell } from 'components/configurationforms';
 
@@ -59,6 +59,10 @@ const AlertNotification = React.createClass({
   },
 
   render() {
+    if (!this.state.availableNotifications) {
+      return <Spinner />;
+    }
+
     const notification = this.props.alertNotification;
     const stream = this.props.stream;
     const typeDefinition = this.state.availableNotifications[notification.type];


### PR DESCRIPTION
In order to easily reproduce the issue, I manually added a `Thread.sleep(1000)` in `org.graylog2.rest.resources.alarmcallbacks.AlarmCallbacksResource#available`.

Fixes #3534 

This needs to be merged into the 2.2 branch as well.