### PR TITLE
Update Terms Method to Support Ascending and Descending Ordering

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/indexer/searches/Searches.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/searches/Searches.java
@@ -263,9 +263,17 @@ public class Searches {
         return new SearchResult(r.getHits(), indices, config.query(), request.source(), r.getTook());
     }
 
-    public TermsResult terms(String field, int size, String query, String filter, TimeRange range) {
+    public TermsResult terms(String field, int size, String query, String filter, TimeRange range, String sorting) {
+        Terms.Order termsOrder;
+
         if (size == 0) {
             size = 50;
+        }
+
+        if (sorting.equals("descending")){
+            termsOrder = Terms.Order.count(false);
+        } else {
+            termsOrder = Terms.Order.count(true);
         }
 
         SearchRequestBuilder srb;
@@ -279,7 +287,8 @@ public class Searches {
                 .subAggregation(
                         AggregationBuilders.terms(AGG_TERMS)
                                 .field(field)
-                                .size(size))
+                                .size(size)
+                                .order(termsOrder))
                 .subAggregation(
                         AggregationBuilders.missing("missing")
                                 .field(field))
@@ -302,8 +311,12 @@ public class Searches {
         );
     }
 
+    public TermsResult terms(String field, int size, String query, String filter, TimeRange range) {
+        return terms(field, size, query, filter, range, "descending");
+    }
+
     public TermsResult terms(String field, int size, String query, TimeRange range) {
-        return terms(field, size, query, null, range);
+        return terms(field, size, query, null, range, "descending");
     }
 
     public TermsStatsResult termsStats(String keyField, String valueField, TermsStatsOrder order, int size, String query, String filter, TimeRange range) {

--- a/graylog2-server/src/main/java/org/graylog2/indexer/searches/Searches.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/searches/Searches.java
@@ -263,14 +263,14 @@ public class Searches {
         return new SearchResult(r.getHits(), indices, config.query(), request.source(), r.getTook());
     }
 
-    public TermsResult terms(String field, int size, String query, String filter, TimeRange range, String sorting) {
+    public TermsResult terms(String field, int size, String query, String filter, TimeRange range, Sorting.Direction sorting) {
         Terms.Order termsOrder;
 
         if (size == 0) {
             size = 50;
         }
 
-        if (sorting.equals("descending")){
+        if (sorting == Sorting.Direction.DESC){
             termsOrder = Terms.Order.count(false);
         } else {
             termsOrder = Terms.Order.count(true);
@@ -312,11 +312,11 @@ public class Searches {
     }
 
     public TermsResult terms(String field, int size, String query, String filter, TimeRange range) {
-        return terms(field, size, query, filter, range, "descending");
+        return terms(field, size, query, filter, range, Sorting.Direction.DESC);
     }
 
     public TermsResult terms(String field, int size, String query, TimeRange range) {
-        return terms(field, size, query, null, range, "descending");
+        return terms(field, size, query, null, range, Sorting.Direction.DESC);
     }
 
     public TermsStatsResult termsStats(String keyField, String valueField, TermsStatsOrder order, int size, String query, String filter, TimeRange range) {

--- a/graylog2-server/src/test/java/org/graylog2/indexer/searches/SearchesTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/indexer/searches/SearchesTest.java
@@ -267,6 +267,20 @@ public class SearchesTest {
 
     @Test
     @UsingDataSet(loadStrategy = LoadStrategyEnum.CLEAN_INSERT)
+    public void testTermsAscending() throws Exception {
+        TermsResult result = searches.terms("n", 1, "*", null, AbsoluteRange.create(
+            new DateTime(2015, 1, 1, 0, 0, DateTimeZone.UTC),
+            new DateTime(2015, 1, 2, 0, 0, DateTimeZone.UTC)), Sorting.Direction.ASC);
+
+        assertThat(result.getTotal()).isEqualTo(10L);
+        assertThat(result.getMissing()).isEqualTo(2L);
+        assertThat(result.getTerms())
+            .hasSize(1)
+            .containsEntry("4", 1L);
+    }
+
+    @Test
+    @UsingDataSet(loadStrategy = LoadStrategyEnum.CLEAN_INSERT)
     public void testTermsStats() throws Exception {
         TermsStatsResult r = searches.termsStats("message", "n", Searches.TermsStatsOrder.COUNT, 25, "*",
                 AbsoluteRange.create(


### PR DESCRIPTION
Add sort order to the terms method (org.graylog2.indexer.searches.Searches) in order to provide support for ascending and descending Terms aggregation results. Relying on widgets to conduct the ascending order does not provide a "true bottom" value, it only provides the most ascending result based on a descending pull; if the possible results are greater than the size of the pull (e.g. 50) this will result in an inaccurate and misleading result.

## Description
The changes provide a sorting variable to the terms method. Subsequent functions for the method were modified to pass a default value of "descending" into the method in order to assure backwards compatibility. The changes passed the "testTerms" Test.

## Motivation and Context
This change is required to provide true ascending, or bottom, values for term based aggregations.
Relates to Issue #2459

## How Has This Been Tested?
- The same changes are employed in my plugin, the Quick Values Plus Widget, which provides ascending and descending ordering options.
- The testTerms test (based on the same method) successfully passed.
- The changes should have no impact as methods were created to ensure backwards compatibility

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [X] All new and existing tests passed.