### PR TITLE
Fixing slicing of alert conditions in pagination

### DIFF
--- a/graylog2-web-interface/src/components/alertconditions/AlertConditionsList.jsx
+++ b/graylog2-web-interface/src/components/alertconditions/AlertConditionsList.jsx
@@ -22,7 +22,7 @@ const AlertConditionsList = React.createClass({
   },
 
   _paginatedConditions() {
-    return this.props.alertConditions.slice(this.state.currentPage, this.state.currentPage + this.PAGE_SIZE);
+    return this.props.alertConditions.slice(this.state.currentPage * this.PAGE_SIZE, (this.state.currentPage + 1) * this.PAGE_SIZE);
   },
 
   _formatCondition(condition) {


### PR DESCRIPTION
Before this change, the slice of alert conditions shown in the paginated
view was calculated incorrectly.

Fixes #3528
(cherry picked from commit 0e25b82f96b56cc3cd14df8ddb36c7e8a4d963c7)