### PR TITLE
Update eslint dependencies

### DIFF
--- a/graylog2-web-interface/.eslintrc
+++ b/graylog2-web-interface/.eslintrc
@@ -7,5 +7,18 @@
   "extends": [
     "graylog",
   ],
+  "settings": {
+    "import/resolver": {
+      "webpack": {
+        "config": "webpack.config.js"
+      }
+    }
+  },
+  "rules": {
+    "import/no-extraneous-dependencies": 0,
+  },
+  "env": {
+    "browser": true
+  }
 }
 

--- a/graylog2-web-interface/package.json
+++ b/graylog2-web-interface/package.json
@@ -65,7 +65,7 @@
     "enzyme": "^2.0.0",
     "eslint": "^3.16.1",
     "eslint-config-graylog": "file:packages/eslint-config-graylog",
-    "eslint-loader": "^1.0.0",
+    "eslint-loader": "^1.6.3",
     "estraverse-fb": "^1.3.1",
     "extract-text-webpack-plugin": "^2.0.0-rc.2",
     "file-loader": "^0.10.0",

--- a/graylog2-web-interface/package.json
+++ b/graylog2-web-interface/package.json
@@ -63,7 +63,7 @@
     "clean-webpack-plugin": "^0.1.3",
     "css-loader": "^0.26.1",
     "enzyme": "^2.0.0",
-    "eslint": "^2.2.0",
+    "eslint": "^3.16.1",
     "eslint-config-graylog": "file:packages/eslint-config-graylog",
     "eslint-loader": "^1.0.0",
     "estraverse-fb": "^1.3.1",

--- a/graylog2-web-interface/packages/eslint-config-graylog/index.js
+++ b/graylog2-web-interface/packages/eslint-config-graylog/index.js
@@ -2,6 +2,12 @@ module.exports = {
   extends: [
     'eslint:recommended',
     'airbnb',
+    'plugin:import/errors',
+    'plugin:import/warnings',
+    'plugin:import/react',
+  ],
+  plugins: [
+    'import',
   ],
   rules: {
     'arrow-body-style': 0,
@@ -19,5 +25,5 @@ module.exports = {
     'react/jsx-space-before-closing': 0,
     'react/prefer-es6-class': 0,
     'react/prefer-stateless-function': 1,
-  },
+  }
 };

--- a/graylog2-web-interface/packages/eslint-config-graylog/package.json
+++ b/graylog2-web-interface/packages/eslint-config-graylog/package.json
@@ -15,11 +15,13 @@
   "dependencies": {
     "eslint": "^3.16.1",
     "eslint-config-airbnb": "^14.1.0",
+    "eslint-import-resolver-webpack": "^0.8.1",
     "eslint-plugin-import": "^2.2.0",
     "eslint-plugin-jsx-a11y": "^4.0.0",
     "eslint-plugin-react": "^6.10.0"
   },
   "peerDependencies": {
-    "eslint": "^3.16.1"
+    "eslint": "^3.16.1",
+    "webpack": "^2.2.0"
   }
 }

--- a/graylog2-web-interface/packages/eslint-config-graylog/package.json
+++ b/graylog2-web-interface/packages/eslint-config-graylog/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-graylog",
-  "version": "1.0.2",
+  "version": "1.1.0",
   "description": "Graylog ESLint config for web interface plugin authors",
   "main": "index.js",
   "scripts": {
@@ -13,13 +13,13 @@
   "author": "Graylog, Inc. <hello@graylog.com>",
   "license": "MIT",
   "dependencies": {
-    "eslint": "^2.10.2",
-    "eslint-config-airbnb": "^9.0.1",
-    "eslint-plugin-import": "^1.10.0",
-    "eslint-plugin-jsx-a11y": "^1.5.3",
-    "eslint-plugin-react": "^5.2.2"
+    "eslint": "^3.16.1",
+    "eslint-config-airbnb": "^14.1.0",
+    "eslint-plugin-import": "^2.2.0",
+    "eslint-plugin-jsx-a11y": "^4.0.0",
+    "eslint-plugin-react": "^6.10.0"
   },
   "peerDependencies": {
-    "eslint": "^2.10.2"
+    "eslint": "^3.16.1"
   }
 }


### PR DESCRIPTION
This change is doing the following:

  * Bumping the versions of the dependencies of our config package
  * Adding new presets for the [eslint-plugin-import](https://www.npmjs.com/package/eslint-plugin-import) plugin
  * Making use of the webpack resolver in eslint
  * Switching to the browser environment (preventing complaining about undeclared window/document symbols)

The `import/no-extraneous-dependencies` rule was disabled, because it returns some false positives for us at the moment. We might consider reenabling it in the future.
