### PR TITLE
Give an option to repeat alert notifications (#3536)

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/alerts/AbstractAlertCondition.java
+++ b/graylog2-server/src/main/java/org/graylog2/alerts/AbstractAlertCondition.java
@@ -23,6 +23,7 @@ import com.google.common.collect.Lists;
 import org.graylog2.plugin.MessageSummary;
 import org.graylog2.plugin.Tools;
 import org.graylog2.plugin.alarms.AlertCondition;
+import org.graylog2.plugin.configuration.fields.BooleanField;
 import org.graylog2.plugin.configuration.fields.ConfigurationField;
 import org.graylog2.plugin.configuration.fields.NumberField;
 import org.graylog2.plugin.database.EmbeddedPersistable;
@@ -57,6 +58,7 @@ public abstract class AbstractAlertCondition implements EmbeddedPersistable, Ale
     protected final String creatorUserId;
     protected final int grace;
     protected final int backlog;
+    protected final boolean repeatNotifications;
     protected final String title;
 
     private Map<String, Object> parameters;
@@ -76,7 +78,8 @@ public abstract class AbstractAlertCondition implements EmbeddedPersistable, Ale
         this.parameters = ImmutableMap.copyOf(parameters);
 
         this.grace = Tools.getNumber(this.parameters.get("grace"), 0).intValue();
-        this.backlog = Tools.getNumber(getParameters().get("backlog"), 0).intValue();
+        this.backlog = Tools.getNumber(this.parameters.get("backlog"), 0).intValue();
+        this.repeatNotifications = (boolean) this.parameters.getOrDefault("repeat_notifications", false);
     }
 
     @Override
@@ -146,6 +149,11 @@ public abstract class AbstractAlertCondition implements EmbeddedPersistable, Ale
         return grace;
     }
 
+    @Override
+    public boolean shouldRepeatNotifications() {
+        return repeatNotifications;
+    }
+
     public static class CheckResult implements AlertCondition.CheckResult {
 
         private final boolean isTriggered;
@@ -203,7 +211,8 @@ public abstract class AbstractAlertCondition implements EmbeddedPersistable, Ale
     public static List<ConfigurationField> getDefaultConfigurationFields() {
         return Lists.newArrayList(
             new NumberField("grace", "Grace Period", 0, "Number of minutes to wait after an alert is resolved, to trigger another alert", ConfigurationField.Optional.NOT_OPTIONAL),
-            new NumberField("backlog", "Message Backlog", 0, "The number of messages to be included in alert notifications", ConfigurationField.Optional.NOT_OPTIONAL)
+            new NumberField("backlog", "Message Backlog", 0, "The number of messages to be included in alert notifications", ConfigurationField.Optional.NOT_OPTIONAL),
+            new BooleanField("repeat_notifications", "Repeat notifications", false, "Check this box to send notifications every time the alert condition is evaluated and satisfied regardless of its state.")
         );
     }
 }

--- a/graylog2-server/src/main/java/org/graylog2/alerts/AlertNotificationsSender.java
+++ b/graylog2-server/src/main/java/org/graylog2/alerts/AlertNotificationsSender.java
@@ -1,0 +1,76 @@
+/**
+ * This file is part of Graylog.
+ *
+ * Graylog is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.graylog2.alerts;
+
+import org.graylog2.alarmcallbacks.AlarmCallbackConfiguration;
+import org.graylog2.alarmcallbacks.AlarmCallbackConfigurationService;
+import org.graylog2.alarmcallbacks.AlarmCallbackFactory;
+import org.graylog2.alarmcallbacks.AlarmCallbackHistory;
+import org.graylog2.alarmcallbacks.AlarmCallbackHistoryService;
+import org.graylog2.plugin.alarms.AlertCondition;
+import org.graylog2.plugin.alarms.callbacks.AlarmCallback;
+import org.graylog2.plugin.streams.Stream;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.inject.Inject;
+import java.util.List;
+
+public class AlertNotificationsSender {
+    private static final Logger LOG = LoggerFactory.getLogger(AlertNotificationsSender.class);
+
+    private final AlarmCallbackConfigurationService alarmCallbackConfigurationService;
+    private final AlarmCallbackFactory alarmCallbackFactory;
+    private final AlarmCallbackHistoryService alarmCallbackHistoryService;
+
+    @Inject
+    public AlertNotificationsSender(AlarmCallbackConfigurationService alarmCallbackConfigurationService,
+                                    AlarmCallbackFactory alarmCallbackFactory,
+                                    AlarmCallbackHistoryService alarmCallbackHistoryService) {
+        this.alarmCallbackConfigurationService = alarmCallbackConfigurationService;
+        this.alarmCallbackFactory = alarmCallbackFactory;
+        this.alarmCallbackHistoryService = alarmCallbackHistoryService;
+    }
+
+    public void send(AlertCondition.CheckResult result, Stream stream, Alert alert, AlertCondition alertCondition) {
+        final List<AlarmCallbackConfiguration> callConfigurations = alarmCallbackConfigurationService.getForStream(stream);
+
+        // Checking if alarm callbacks have been defined
+        for (AlarmCallbackConfiguration configuration : callConfigurations) {
+            AlarmCallbackHistory alarmCallbackHistory;
+            AlarmCallback alarmCallback = null;
+            try {
+                alarmCallback = alarmCallbackFactory.create(configuration);
+                alarmCallback.call(stream, result);
+                alarmCallbackHistory = alarmCallbackHistoryService.success(configuration, alert, alertCondition);
+            } catch (Exception e) {
+                if (alarmCallback != null) {
+                    LOG.warn("Alarm callback <" + alarmCallback.getName() + "> failed. Skipping.", e);
+                } else {
+                    LOG.warn("Alarm callback with id " + configuration.getId() + " failed. Skipping.", e);
+                }
+                alarmCallbackHistory = alarmCallbackHistoryService.error(configuration, alert, alertCondition, e.getMessage());
+            }
+
+            try {
+                alarmCallbackHistoryService.save(alarmCallbackHistory);
+            } catch (Exception e) {
+                LOG.warn("Unable to save history of alarm callback run: ", e);
+            }
+        }
+    }
+}

--- a/graylog2-server/src/main/java/org/graylog2/alerts/AlertScanner.java
+++ b/graylog2-server/src/main/java/org/graylog2/alerts/AlertScanner.java
@@ -16,71 +16,39 @@
  */
 package org.graylog2.alerts;
 
-import org.graylog2.alarmcallbacks.AlarmCallbackConfiguration;
-import org.graylog2.alarmcallbacks.AlarmCallbackConfigurationService;
-import org.graylog2.alarmcallbacks.AlarmCallbackFactory;
-import org.graylog2.alarmcallbacks.AlarmCallbackHistory;
-import org.graylog2.alarmcallbacks.AlarmCallbackHistoryService;
 import org.graylog2.plugin.alarms.AlertCondition;
-import org.graylog2.plugin.alarms.callbacks.AlarmCallback;
 import org.graylog2.plugin.database.ValidationException;
 import org.graylog2.plugin.streams.Stream;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import javax.inject.Inject;
-import java.util.List;
 import java.util.Optional;
 
 public class AlertScanner {
     private static final Logger LOG = LoggerFactory.getLogger(AlertScanner.class);
+
     private final AlertService alertService;
-    private final AlarmCallbackConfigurationService alarmCallbackConfigurationService;
-    private final AlarmCallbackFactory alarmCallbackFactory;
-    private final AlarmCallbackHistoryService alarmCallbackHistoryService;
+    private final AlertNotificationsSender alertNotificationsSender;
 
     @Inject
-    public AlertScanner(AlertService alertService,
-                        AlarmCallbackConfigurationService alarmCallbackConfigurationService,
-                        AlarmCallbackFactory alarmCallbackFactory,
-                        AlarmCallbackHistoryService alarmCallbackHistoryService) {
+    public AlertScanner(AlertService alertService, AlertNotificationsSender alertNotificationsSender) {
         this.alertService = alertService;
-        this.alarmCallbackConfigurationService = alarmCallbackConfigurationService;
-        this.alarmCallbackFactory = alarmCallbackFactory;
-        this.alarmCallbackHistoryService = alarmCallbackHistoryService;
+        this.alertNotificationsSender = alertNotificationsSender;
     }
 
-    private Alert handleTriggeredCheckResult(AlertCondition.CheckResult result, Stream stream, AlertCondition alertCondition) throws ValidationException {
+    private Alert handleTriggeredAlert(AlertCondition.CheckResult result, Stream stream, AlertCondition alertCondition) throws ValidationException {
         // Persist alert.
         final Alert alert = alertService.factory(result);
         alertService.save(alert);
 
-        final List<AlarmCallbackConfiguration> callConfigurations = alarmCallbackConfigurationService.getForStream(stream);
+        alertNotificationsSender.send(result, stream, alert, alertCondition);
 
-        // Checking if alarm callbacks have been defined
-        for (AlarmCallbackConfiguration configuration : callConfigurations) {
-            AlarmCallbackHistory alarmCallbackHistory;
-            AlarmCallback alarmCallback = null;
-            try {
-                alarmCallback = alarmCallbackFactory.create(configuration);
-                alarmCallback.call(stream, result);
-                alarmCallbackHistory = alarmCallbackHistoryService.success(configuration, alert, alertCondition);
-            } catch (Exception e) {
-                if (alarmCallback != null) {
-                    LOG.warn("Alarm callback <" + alarmCallback.getName() + "> failed. Skipping.", e);
-                } else {
-                    LOG.warn("Alarm callback with id " + configuration.getId() + " failed. Skipping.", e);
-                }
-                alarmCallbackHistory = alarmCallbackHistoryService.error(configuration, alert, alertCondition, e.getMessage());
-            }
-
-            try {
-                alarmCallbackHistoryService.save(alarmCallbackHistory);
-            } catch (Exception e) {
-                LOG.warn("Unable to save history of alarm callback run: ", e);
-            }
-        }
         return alert;
+    }
+
+    private void handleRepeatedAlert(Stream stream, AlertCondition alertCondition, AlertCondition.CheckResult result, Alert alert2) {
+        alertNotificationsSender.send(result, stream, alert2, alertCondition);
     }
 
     private void handleResolveAlert(Alert alert) {
@@ -97,10 +65,18 @@ public class AlertScanner {
             final Optional<Alert> alert = alertService.getLastTriggeredAlert(stream.getId(), alertCondition.getId());
             if (result.isTriggered()) {
                 if (!alert.isPresent() || alertService.isResolved(alert.get())) {
+                    // Alert is triggered for the first time
                     LOG.debug("Alert condition [{}] is triggered. Sending alerts.", alertCondition);
-                    handleTriggeredCheckResult(result, stream, alertCondition);
+                    handleTriggeredAlert(result, stream, alertCondition);
                 } else {
-                    LOG.debug("Alert condition [{}] is triggered but alerts were already sent. Nothing to do.", alertCondition);
+                    // There is already an alert for this condition and is unresolved
+                    if (alert.isPresent() && alertCondition.shouldRepeatNotifications()) {
+                        // Repeat notifications because user wants to do that
+                        LOG.debug("Alert condition [{}] is triggered and configured to repeat alert notifications. Sending alerts.", alertCondition);
+                        handleRepeatedAlert(stream, alertCondition, result, alert.get());
+                    } else {
+                        LOG.debug("Alert condition [{}] is triggered but alerts were already sent. Nothing to do.", alertCondition);
+                    }
                 }
                 return true;
             } else {

--- a/graylog2-server/src/main/java/org/graylog2/alerts/types/FieldContentValueAlertCondition.java
+++ b/graylog2-server/src/main/java/org/graylog2/alerts/types/FieldContentValueAlertCondition.java
@@ -167,6 +167,9 @@ public class FieldContentValueAlertCondition extends AbstractAlertCondition {
 
     @Override
     public String getDescription() {
-        return "field: " + field + ", value: " + value;
+        return "field: " + field
+                + ", value: " + value
+                + ", grace: " + grace
+                + ", repeat notifications: " + repeatNotifications;
     }
 }

--- a/graylog2-server/src/main/java/org/graylog2/alerts/types/FieldValueAlertCondition.java
+++ b/graylog2-server/src/main/java/org/graylog2/alerts/types/FieldValueAlertCondition.java
@@ -162,7 +162,8 @@ public class FieldValueAlertCondition extends AbstractAlertCondition {
             + ", check type: " + type.toString().toLowerCase(Locale.ENGLISH)
             + ", threshold_type: " + thresholdType.toString().toLowerCase(Locale.ENGLISH)
             + ", threshold: " + decimalFormat.format(threshold)
-            + ", grace: " + grace;
+            + ", grace: " + grace
+            + ", repeat notifications: " + repeatNotifications;
     }
 
 

--- a/graylog2-server/src/main/java/org/graylog2/alerts/types/MessageCountAlertCondition.java
+++ b/graylog2-server/src/main/java/org/graylog2/alerts/types/MessageCountAlertCondition.java
@@ -155,7 +155,8 @@ public class MessageCountAlertCondition extends AbstractAlertCondition {
         return "time: " + time
             + ", threshold_type: " + thresholdType.toString().toLowerCase(Locale.ENGLISH)
             + ", threshold: " + threshold
-            + ", grace: " + grace;
+            + ", grace: " + grace
+            + ", repeat notifications: " + repeatNotifications;
     }
 
     @Override

--- a/graylog2-server/src/main/java/org/graylog2/plugin/alarms/AlertCondition.java
+++ b/graylog2-server/src/main/java/org/graylog2/plugin/alarms/AlertCondition.java
@@ -51,6 +51,8 @@ public interface AlertCondition {
 
     String getTitle();
 
+    boolean shouldRepeatNotifications();
+
     AlertCondition.CheckResult runCheck();
 
     interface CheckResult {

--- a/graylog2-server/src/test/java/org/graylog2/alerts/AlertNotificationsSenderTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/alerts/AlertNotificationsSenderTest.java
@@ -1,0 +1,93 @@
+/**
+ * This file is part of Graylog.
+ *
+ * Graylog is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.graylog2.alerts;
+
+import com.google.common.collect.ImmutableList;
+import org.graylog2.alarmcallbacks.AlarmCallbackConfiguration;
+import org.graylog2.alarmcallbacks.AlarmCallbackConfigurationService;
+import org.graylog2.alarmcallbacks.AlarmCallbackFactory;
+import org.graylog2.alarmcallbacks.AlarmCallbackHistoryService;
+import org.graylog2.plugin.Tools;
+import org.graylog2.plugin.alarms.AlertCondition;
+import org.graylog2.plugin.alarms.callbacks.AlarmCallback;
+import org.graylog2.plugin.streams.Stream;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnit;
+import org.mockito.junit.MockitoRule;
+
+import java.util.Collections;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+public class AlertNotificationsSenderTest {
+    @Rule
+    public final MockitoRule mockitoRule = MockitoJUnit.rule();
+
+    private AlertNotificationsSender alertNotificationsSender;
+
+    @Mock
+    private AlarmCallbackConfigurationService alarmCallbackConfigurationService;
+    @Mock
+    private AlarmCallbackFactory alarmCallbackFactory;
+    @Mock
+    private AlarmCallbackHistoryService alarmCallbackHistoryService;
+
+    @Before
+    public void setUp() throws Exception {
+        this.alertNotificationsSender = new AlertNotificationsSender(alarmCallbackConfigurationService, alarmCallbackFactory, alarmCallbackHistoryService);
+    }
+
+    @Test
+    public void executeStreamWithNotifications() throws Exception {
+        final Stream stream = mock(Stream.class);
+        final Alert alert = mock(Alert.class);
+        final AlertCondition alertCondition = mock(AlertCondition.class);
+        final AlertCondition.CheckResult positiveCheckResult = new AbstractAlertCondition.CheckResult(true, alertCondition, "Mocked positive CheckResult", Tools.nowUTC(), Collections.emptyList());
+
+        final AlarmCallbackConfiguration alarmCallbackConfiguration = mock(AlarmCallbackConfiguration.class);
+        when(alarmCallbackConfigurationService.getForStream(eq(stream))).thenReturn(ImmutableList.of(alarmCallbackConfiguration));
+        final AlarmCallback alarmCallback = mock(AlarmCallback.class);
+        when(alarmCallbackFactory.create(eq(alarmCallbackConfiguration))).thenReturn(alarmCallback);
+
+        alertNotificationsSender.send(positiveCheckResult, stream, alert, alertCondition);
+
+        final ArgumentCaptor<Stream> streamCaptor = ArgumentCaptor.forClass(Stream.class);
+        final ArgumentCaptor<AlertCondition.CheckResult> checkResultCaptor = ArgumentCaptor.forClass(AlertCondition.CheckResult.class);
+        verify(alarmCallback, times(1)).call(streamCaptor.capture(), checkResultCaptor.capture());
+        assertThat(streamCaptor.getValue()).isEqualTo(stream);
+        assertThat(checkResultCaptor.getValue()).isEqualTo(positiveCheckResult);
+
+        final ArgumentCaptor<AlarmCallbackConfiguration> alarmCallbackConfigurationCaptor = ArgumentCaptor.forClass(AlarmCallbackConfiguration.class);
+        final ArgumentCaptor<Alert> alertCaptor = ArgumentCaptor.forClass(Alert.class);
+        final ArgumentCaptor<AlertCondition> alertConditionCaptor = ArgumentCaptor.forClass(AlertCondition.class);
+        verify(alarmCallbackHistoryService, times(1)).success(alarmCallbackConfigurationCaptor.capture(), alertCaptor.capture(), alertConditionCaptor.capture());
+
+        assertThat(alarmCallbackConfigurationCaptor.getValue()).isEqualTo(alarmCallbackConfiguration);
+        assertThat(alertCaptor.getValue()).isEqualTo(alert);
+        assertThat(alertConditionCaptor.getValue()).isEqualTo(alertCondition);
+    }
+
+}

--- a/graylog2-web-interface/src/components/alarmcallbacks/AlarmCallbackHistory.jsx
+++ b/graylog2-web-interface/src/components/alarmcallbacks/AlarmCallbackHistory.jsx
@@ -1,8 +1,9 @@
 import React from 'react';
 import { Alert, Col, Label } from 'react-bootstrap';
 
-import { EntityListItem } from 'components/common';
+import { EntityListItem, Timestamp } from 'components/common';
 import { ConfigurationWell } from 'components/configurationforms';
+import DateTime from 'logic/datetimes/DateTime';
 
 const AlarmCallbackHistory = React.createClass({
   propTypes: {
@@ -25,7 +26,9 @@ const AlarmCallbackHistory = React.createClass({
         <small>({type ? type.name : configuration.type})</small>
       </span>
     );
-    const description = (hadError ? `Error sending notification: ${history.result.error}` : 'Notification was sent successfully.');
+    const description = (hadError ?
+      <span>Error sending notification at <Timestamp dateTime={history.created_at} format={DateTime.Formats.DATETIME} />: {history.result.error}</span> :
+      <span>Notification was sent successfully at <Timestamp dateTime={history.created_at} format={DateTime.Formats.DATETIME} />.</span>);
 
     let configurationWell;
     let configurationInfo;

--- a/graylog2-web-interface/src/components/alarmcallbacks/AlarmCallbackHistoryOverview.jsx
+++ b/graylog2-web-interface/src/components/alarmcallbacks/AlarmCallbackHistoryOverview.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import Reflux from 'reflux';
+import moment from 'moment';
 import { Row, Col } from 'react-bootstrap';
 
 import CombinedProvider from 'injection/CombinedProvider';
@@ -30,7 +31,14 @@ const AlarmCallbackHistoryOverview = React.createClass({
       return <Spinner />;
     }
 
-    const histories = this.state.histories.map(this._formatHistory);
+    const histories = this.state.histories
+      .sort((h1, h2) => {
+        const h1Time = moment(h1.created_at);
+        const h2Time = moment(h2.created_at);
+
+        return (h1Time.isBefore(h2Time) ? -1 : h2Time.isBefore(h1Time) ? 1 : 0);
+      })
+      .map(this._formatHistory);
     return (
       <Row>
         <Col md={12}>

--- a/graylog2-web-interface/src/components/alertconditions/RepeatNotificationsSummary.jsx
+++ b/graylog2-web-interface/src/components/alertconditions/RepeatNotificationsSummary.jsx
@@ -1,0 +1,15 @@
+import React from 'react';
+
+const RepeatNotificationsSummary = React.createClass({
+  propTypes: {
+    alertCondition: React.PropTypes.object.isRequired,
+  },
+  render() {
+    const repeatNotifications = this.props.alertCondition.parameters.repeat_notifications || false;
+    return (
+      <span>Configured to {!repeatNotifications && <b>not</b>} repeat notifications.</span>
+    );
+  },
+});
+
+export default RepeatNotificationsSummary;

--- a/graylog2-web-interface/src/components/alertconditions/fieldcontentcondition/FieldContentConditionSummary.jsx
+++ b/graylog2-web-interface/src/components/alertconditions/fieldcontentcondition/FieldContentConditionSummary.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 
 import GracePeriodSummary from 'components/alertconditions/GracePeriodSummary';
 import BacklogSummary from 'components/alertconditions/BacklogSummary';
+import RepeatNotificationsSummary from 'components/alertconditions/RepeatNotificationsSummary';
 
 const FieldContentConditionSummary = React.createClass({
   propTypes: {
@@ -22,6 +23,8 @@ const FieldContentConditionSummary = React.createClass({
         <GracePeriodSummary alertCondition={alertCondition} />
         {' '}
         <BacklogSummary alertCondition={alertCondition}/>
+        {' '}
+        <RepeatNotificationsSummary alertCondition={alertCondition} />
       </span>
     );
   },

--- a/graylog2-web-interface/src/components/alertconditions/fieldvaluecondition/FieldValueConditionSummary.jsx
+++ b/graylog2-web-interface/src/components/alertconditions/fieldvaluecondition/FieldValueConditionSummary.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 
 import GracePeriodSummary from 'components/alertconditions/GracePeriodSummary';
 import BacklogSummary from 'components/alertconditions/BacklogSummary';
+import RepeatNotificationsSummary from 'components/alertconditions/RepeatNotificationsSummary';
 import { Pluralize } from 'components/common';
 
 const FieldValueConditionSummary = React.createClass({
@@ -26,6 +27,8 @@ const FieldValueConditionSummary = React.createClass({
         <GracePeriodSummary alertCondition={alertCondition} />
         {' '}
         <BacklogSummary alertCondition={alertCondition}/>
+        {' '}
+        <RepeatNotificationsSummary alertCondition={alertCondition} />
       </span>
     );
   },

--- a/graylog2-web-interface/src/components/alertconditions/messagecountcondition/MessageCountConditionSummary.jsx
+++ b/graylog2-web-interface/src/components/alertconditions/messagecountcondition/MessageCountConditionSummary.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 
 import GracePeriodSummary from 'components/alertconditions/GracePeriodSummary';
 import BacklogSummary from 'components/alertconditions/BacklogSummary';
+import RepeatNotificationsSummary from 'components/alertconditions/RepeatNotificationsSummary';
 import { Pluralize } from 'components/common';
 
 const MessageCountConditionSummary = React.createClass({
@@ -26,6 +27,8 @@ const MessageCountConditionSummary = React.createClass({
         <GracePeriodSummary alertCondition={alertCondition} />
         {' '}
         <BacklogSummary alertCondition={alertCondition} />
+        {' '}
+        <RepeatNotificationsSummary alertCondition={alertCondition} />
       </span>
     );
   },

--- a/graylog2-web-interface/src/components/alerts/AlertTimeline.jsx
+++ b/graylog2-web-interface/src/components/alerts/AlertTimeline.jsx
@@ -78,7 +78,15 @@ const AlertTimeline = React.createClass({
           <dd key="resolution-desc">Condition is no longer satisfied, alert is marked as resolved</dd>,
         );
       } else {
+        const conditionParameters = this.props.alert.condition_parameters || {};
+        const repeatNotifications = conditionParameters.repeat_notifications || false;
+        const notificationsText = (repeatNotifications ?
+          'Condition is configured to repeat notifications, Graylog will send notifications when evaluating the condition until it is no longer satisfied' :
+          'Condition is configured to not repeat notifications');
+
         formattedResolution.push(
+          <dt key="notifications-title"><Timestamp dateTime={new Date()} /></dt>,
+          <dd key="notifications-desc">{notificationsText}</dd>,
           <dt key="resolution-title"><Timestamp dateTime={new Date()} /></dt>,
           <dd key="resolution-desc">Condition is still satisfied, <strong>alert is unresolved</strong></dd>,
         );


### PR DESCRIPTION
This is a port of #3536 to the `2.2` branch.

* Add option to repeat notifications

Refs #3511

* Resend notifications when user sets the flag

When user sets the `repeat_notifications` flag in the alert condition,
resend the notifications regardless of the alert state. The alert will
continue to have a state anyway, and all sent notifications will be
visible in the web interface on the alerts detail page.

Refs #3511

* Add repetition setting to alert summaries

* Add repetition setting to alert timeline

* Add date to notification histories

- Sort histories by creation datetime
- Add the time were the notification was sent, to help seeing the order
and also that the attempts sending the notification are different

* Do not include ms in history datetime

* Add license header

* Rename variable

* Fix import

* Use moment to sort notifications by date

(cherry picked from commit 003bea90a4e67c15fca557c96fcd2665c23f90cc)
