### PR TITLE
Read-Only Index Set "Active write index" Rendering (#3483)

### DIFF
--- a/graylog2-web-interface/src/pages/IndexSetPage.jsx
+++ b/graylog2-web-interface/src/pages/IndexSetPage.jsx
@@ -132,12 +132,16 @@ const IndexSetPage = React.createClass({
     if (this.state.indexerOverview && this.state.indexDetails.closedIndices) {
       const deflectorInfo = this.state.indexerOverview.deflector;
 
+      let activeIndex = ".";
+      if (indexSet.writable) {
+        activeIndex = ", current write-active index is <i>{deflectorInfo.current_target}</i>";
+      }
+
       indicesInfo = (
         <span>
           <Alert bsStyle="success" style={{ marginTop: '10' }}>
             <i className="fa fa-th"/> &nbsp;{this._totalIndexCount()} indices with a total of{' '}
-            {numeral(this.state.indexerOverview.counts.events).format('0,0')} messages under management,
-            current write-active index is <i>{deflectorInfo.current_target}</i>.
+            {numeral(this.state.indexerOverview.counts.events).format('0,0')} messages under management{activeIndex}
           </Alert>
           <IndexerClusterHealthSummary health={this.state.indexerOverview.indexer_cluster.health} />
         </span>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Updates src/pages/IndexSetPage.jsx to take into account the use of read-only indexsets as reported in issue #3483 

## Description
Does a check to see if the indexset is writeable. If not, ensures that rendering output is modified from the default state.

## Motivation and Context
The change is required to fix a cosmetic bug report in #3483 

## How Has This Been Tested?
I have been unable to test the change as I do not have archiving available.

## Screenshots (if appropriate):
N/A

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.