### PR TITLE
Copy Query Button Fix (#3491)

### DIFF
--- a/graylog2-web-interface/src/components/search/ShowQueryModal.jsx
+++ b/graylog2-web-interface/src/components/search/ShowQueryModal.jsx
@@ -31,7 +31,7 @@ const ShowQueryModal = React.createClass({
           <pre>{queryText}</pre>
         </Modal.Body>
         <Modal.Footer>
-          <ClipboardButton title="Copy query" text={queryText} />
+          <ClipboardButton title="Copy query" target=".modal-body pre" />
         </Modal.Footer>
       </BootstrapModalWrapper>
     );


### PR DESCRIPTION
## Description
Changes behavior of ClipboardButton component to rely on the target instead of passing in text. For some reason, passing in text, does not cause the text to be copied to the clipboard. However, passing in target element does cause ClipBoard to work properly. This is related to bug report #3491.

## Motivation and Context
Fixes open issue #3491 which allows queries to be copied to the clipboard.

## How Has This Been Tested?
I test changes by running the web interface with the change. The changes worked as expected. I also did in depth troubleshooting on the text portion and do not understand the reason that it is not copying.

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.