### PR TITLE
Restore custom bootstrap theme after using stock version.

### DIFF
--- a/graylog2-web-interface/public/stylesheets/bootstrap-config.json
+++ b/graylog2-web-interface/public/stylesheets/bootstrap-config.json
@@ -8,7 +8,7 @@
     "@gray-lighter": "lighten(@gray-base, 93.5%)",
     "@brand-primary": "#9E1F63",
     "@brand-success": "#8DC63F",
-    "@brand-info": "#D7DF23",
+    "@brand-info": "#16ACE3",
     "@brand-warning": "#F7941E",
     "@brand-danger": "#FF3B00",
     "@body-bg": "#fff",
@@ -63,9 +63,9 @@
     "@table-bg-active": "@table-bg-hover",
     "@table-border-color": "#ddd",
     "@btn-font-weight": "normal",
-    "@btn-default-color": "#fff",
-    "@btn-default-bg": "#16ACE3",
-    "@btn-default-border": "#16ACE3",
+    "@btn-default-color": "#333",
+    "@btn-default-bg": "#F1F2F2",
+    "@btn-default-border": "#E3E5E5",
     "@btn-primary-color": "#fff",
     "@btn-primary-bg": "@brand-primary",
     "@btn-primary-border": "darken(@btn-primary-bg, 5%)",
@@ -423,6 +423,6 @@
     "collapse.js",
     "scrollspy.js",
     "transition.js"
-  ],
-  "customizerUrl": "http://getbootstrap.com/customize/?id=c670c5cc02d61d0493f1"
+  ]
 }
+

--- a/graylog2-web-interface/src/routing/AppFacade.jsx
+++ b/graylog2-web-interface/src/routing/AppFacade.jsx
@@ -10,7 +10,7 @@ const SessionStore = StoreProvider.getStore('Session');
 const ServerAvailabilityStore = StoreProvider.getStore('ServerAvailability');
 const CurrentUserStore = StoreProvider.getStore('CurrentUser');
 
-import 'bootstrap/dist/css/bootstrap.css';
+import 'bootstrap/less/bootstrap.less';
 import 'font-awesome/css/font-awesome.css';
 import 'stylesheets/newfonts.less';
 import 'stylesheets/bootstrap-submenus.less';

--- a/graylog2-web-interface/webpack.config.js
+++ b/graylog2-web-interface/webpack.config.js
@@ -21,6 +21,8 @@ const BABELOPTIONS = {
 
 const BABELLOADER = { loader: 'babel-loader', options: BABELOPTIONS };
 
+const BOOTSTRAPVARS = require(path.resolve(ROOT_PATH, 'public', 'stylesheets', 'bootstrap-config.json')).vars;
+
 const webpackConfig = {
   entry: {
     app: APP_PATH,
@@ -37,7 +39,17 @@ const webpackConfig = {
       { test: /\.ts$/, use: [BABELLOADER, { loader: 'ts-loader' }], exclude: /node_modules|\.node_cache/ },
       { test: /\.(woff(2)?|svg|eot|ttf|gif|jpg)(\?.+)?$/, use: 'file-loader' },
       { test: /\.png$/, use: 'url-loader' },
-      { test: /\.less$/, use: ['style-loader', 'css-loader', 'less-loader'] },
+      { test: /bootstrap\.less$/, use: [
+        'style-loader',
+        'css-loader',
+        {
+          loader: 'less-loader',
+          options: {
+            modifyVars: BOOTSTRAPVARS,
+          },
+        },
+      ] },
+      { test: /\.less$/, use: ['style-loader', 'css-loader', 'less-loader'], exclude: /bootstrap\.less$/ },
       { test: /\.css$/, use: ['style-loader', 'css-loader'] },
     ],
   },


### PR DESCRIPTION
## Description
## Motivation and Context
Today I noticed that the colors in the web interface are "slightly" off,
after removing static assets and using the npm module version of
bootstrap. I found out that we were using a customized version of
bootstrap, generated by the bootstrap customizer
(http://getbootstrap.com/customize/). I also found out, that the
`bootstrap-config.json` file is from a completely different
customization and looks even weirder.

With this change, we are now switching over to the less-version of the
bootstrap stylesheets and using the less-loader to override customized
variables extracted from the
[customization run](https://github.com/Graylog2/graylog2-server/blob/2.2/graylog2-web-interface/public/stylesheets/bootstrap.min.css#L8-L9).

## Screenshots (if appropriate):
Before (streams page, incorrect colors):
![screen shot 2017-02-27 at 12 49 24](https://cloud.githubusercontent.com/assets/41929/23360379/447875d4-fceb-11e6-9912-9f51144001fd.png)

After (streams page, correct colors):
![screen shot 2017-02-27 at 12 48 21](https://cloud.githubusercontent.com/assets/41929/23360384/4ac1b36a-fceb-11e6-9ab5-7133439b0af6.png)

Before (login dialog, incorrect colors):
![screen shot 2017-02-27 at 12 50 25](https://cloud.githubusercontent.com/assets/41929/23360411/6879aa02-fceb-11e6-9954-9245b80d14a6.png)

After (login dialog, correct colors):
![screen shot 2017-02-27 at 12 51 53](https://cloud.githubusercontent.com/assets/41929/23360439/8fddda82-fceb-11e6-8674-36ca4f241c07.png)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
