### PR TITLE
Escaping username/roles parameters to allow usernames/roles with special characters.

### DIFF
--- a/graylog2-web-interface/src/components/authentication/AuthenticationComponent.jsx
+++ b/graylog2-web-interface/src/components/authentication/AuthenticationComponent.jsx
@@ -118,7 +118,7 @@ const AuthenticationComponent = React.createClass({
 
     if (authenticators.length === 0) {
       // special case, this is a user editing their own profile
-      authenticators = [<LinkContainer key="profile-edit" to={Routes.SYSTEM.AUTHENTICATION.USERS.edit(this.state.currentUser.username)}>
+      authenticators = [<LinkContainer key="profile-edit" to={Routes.SYSTEM.AUTHENTICATION.USERS.edit(encodeURIComponent(this.state.currentUser.username))}>
         <NavItem title="Edit User">Edit User</NavItem>
       </LinkContainer>];
     }

--- a/graylog2-web-interface/src/components/navigation/UserMenu.jsx
+++ b/graylog2-web-interface/src/components/navigation/UserMenu.jsx
@@ -24,7 +24,7 @@ const UserMenu = React.createClass({
   render() {
     return (
       <NavDropdown navItem title={this.props.fullName} id="user-menu-dropdown">
-        <LinkContainer to={Routes.SYSTEM.AUTHENTICATION.USERS.edit(this.props.loginName)}>
+        <LinkContainer to={Routes.SYSTEM.AUTHENTICATION.USERS.edit(encodeURIComponent(this.props.loginName))}>
           <MenuItem>Edit profile</MenuItem>
         </LinkContainer>
         <MenuItem divider />

--- a/graylog2-web-interface/src/components/users/UserList.jsx
+++ b/graylog2-web-interface/src/components/users/UserList.jsx
@@ -126,7 +126,7 @@ const UserList = React.createClass({
       );
 
       const editAction = (
-        <LinkContainer to={Routes.SYSTEM.AUTHENTICATION.USERS.edit(user.username)}>
+        <LinkContainer to={Routes.SYSTEM.AUTHENTICATION.USERS.edit(encodeURIComponent(user.username))}>
           <Button bsStyle="info" bsSize="xs" title={`Edit user ${user.username}`}>
             Edit
           </Button>

--- a/graylog2-web-interface/src/stores/users/CurrentUserStore.jsx
+++ b/graylog2-web-interface/src/stores/users/CurrentUserStore.jsx
@@ -2,17 +2,15 @@ import Reflux from 'reflux';
 
 import URLUtils from 'util/URLUtils';
 import fetch from 'logic/rest/FetchProvider';
+import ApiRoutes from 'routing/ApiRoutes';
 
-import StoreProvider from 'injection/StoreProvider';
-const SessionStore = StoreProvider.getStore('Session');
-const StartpageStore = StoreProvider.getStore('Startpage');
+import CombinedProvider from 'injection/CombinedProvider';
 
-import ActionsProvider from 'injection/ActionsProvider';
-const SessionActions = ActionsProvider.getActions('Session');
+const { SessionStore, SessionActions } = CombinedProvider.get('Session');
+const { StartpageStore } = CombinedProvider.get('Startpage');
 
 const CurrentUserStore = Reflux.createStore({
   listenables: [SessionActions],
-  sourceUrl: '/users',
   currentUser: undefined,
 
   init() {
@@ -45,7 +43,7 @@ const CurrentUserStore = Reflux.createStore({
   },
 
   update(username) {
-    fetch('GET', URLUtils.qualifyUrl(this.sourceUrl + '/' + username))
+    fetch('GET', URLUtils.qualifyUrl(ApiRoutes.UsersApiController.load(encodeURIComponent(username)).url))
       .then((resp) => {
         this.currentUser = resp;
         this.trigger({ currentUser: this.currentUser });

--- a/graylog2-web-interface/src/stores/users/RolesStore.ts
+++ b/graylog2-web-interface/src/stores/users/RolesStore.ts
@@ -51,7 +51,7 @@ const RolesStore = {
   },
 
   updateRole(rolename: string, role: Role): Promise<Role> {
-    const promise = fetch('PUT', URLUtils.qualifyUrl(ApiRoutes.RolesApiController.updateRole(rolename).url), role);
+    const promise = fetch('PUT', URLUtils.qualifyUrl(ApiRoutes.RolesApiController.updateRole(encodeURIComponent(rolename)).url), role);
 
     promise.then((newRole) => {
       UserNotification.success("Role \"" + newRole.name + "\" was updated successfully");
@@ -66,7 +66,7 @@ const RolesStore = {
   },
 
   deleteRole(rolename: string): Promise<string[]> {
-    const url = URLUtils.qualifyUrl(ApiRoutes.RolesApiController.deleteRole(rolename).url);
+    const url = URLUtils.qualifyUrl(ApiRoutes.RolesApiController.deleteRole(encodeURIComponent(rolename)).url);
     const promise = fetch('DELETE', url);
 
     promise.then(() => {
@@ -80,7 +80,7 @@ const RolesStore = {
     return promise;
   },
   getMembers(rolename: string): Promise<RoleMembership[]> {
-    const url = URLUtils.qualifyUrl(ApiRoutes.RolesApiController.loadMembers(rolename).url);
+    const url = URLUtils.qualifyUrl(ApiRoutes.RolesApiController.loadMembers(encodeURIComponent(rolename)).url);
     const promise = fetch('GET', url);
     promise.catch((error) => {
       if (error.additional.status !== 404) {

--- a/graylog2-web-interface/src/stores/users/UsersStore.ts
+++ b/graylog2-web-interface/src/stores/users/UsersStore.ts
@@ -69,7 +69,7 @@ export const UsersStore = {
   },
 
   deleteUser(username: string): Promise<string[]> {
-    const  url = URLUtils.qualifyUrl(ApiRoutes.UsersApiController.delete(username).url);
+    const  url = URLUtils.qualifyUrl(ApiRoutes.UsersApiController.delete(encodeURIComponent(username)).url);
     const  promise = fetch('DELETE', url);
 
     promise.then(() => {

--- a/graylog2-web-interface/src/stores/users/UsersStore.ts
+++ b/graylog2-web-interface/src/stores/users/UsersStore.ts
@@ -58,7 +58,7 @@ export const UsersStore = {
   },
 
   load(username: string): Promise<User> {
-    const url = URLUtils.qualifyUrl(ApiRoutes.UsersApiController.load(username).url);
+    const url = URLUtils.qualifyUrl(ApiRoutes.UsersApiController.load(encodeURIComponent(username)).url);
     const promise = fetch('GET', url);
     promise.catch((error) => {
       UserNotification.error("Loading user failed with status: " + error,
@@ -85,21 +85,21 @@ export const UsersStore = {
   },
 
   updateRoles(username: string, roles: string[]): void {
-    const url = URLUtils.qualifyUrl(ApiRoutes.UsersApiController.update(username).url);
+    const url = URLUtils.qualifyUrl(ApiRoutes.UsersApiController.update(encodeURIComponent(username)).url);
     const promise = fetch('PUT', url, {roles: roles});
 
     return promise;
   },
 
   changePassword(username: string, request: ChangePasswordRequest): void {
-    const url = URLUtils.qualifyUrl(ApiRoutes.UsersApiController.changePassword(username).url);
+    const url = URLUtils.qualifyUrl(ApiRoutes.UsersApiController.changePassword(encodeURIComponent(username)).url);
     const promise = fetch('PUT', url, request);
 
     return promise;
   },
 
   update(username: string, request: any): void {
-    const url = URLUtils.qualifyUrl(ApiRoutes.UsersApiController.update(username).url);
+    const url = URLUtils.qualifyUrl(ApiRoutes.UsersApiController.update(encodeURIComponent(username)).url);
     const promise = fetch('PUT', url, request);
 
     return promise;


### PR DESCRIPTION
## Description
## Motivation and Context
Before this change it was possible to create user/role names containing one or more slashes or other special characters, but it was not possible to delete them afterwards from the web interface.

After this change, the user/role name used to construct the URL to the backend is escaped properly, so deletions suceed even if the user/role name contains one or more special characters.

Fixes #3569. Should also be merged into `2.2`.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
