### PR TITLE
Logging run profile name to STDERR instead of STDOUT.

### DIFF
--- a/graylog2-web-interface/webpack.config.js
+++ b/graylog2-web-interface/webpack.config.js
@@ -84,7 +84,7 @@ const webpackConfig = {
 };
 
 if (TARGET === 'start') {
-  console.log('Running in development mode');
+  console.error('Running in development mode');
   module.exports = merge(webpackConfig, {
     entry: {
       reacthot: 'react-hot-loader/patch',
@@ -115,7 +115,7 @@ if (TARGET === 'start') {
 }
 
 if (TARGET === 'start-nohmr') {
-  console.log('Running in development (no HMR) mode');
+  console.error('Running in development (no HMR) mode');
   module.exports = merge(webpackConfig, {
     devtool: 'eval',
     devServer: {
@@ -138,7 +138,7 @@ if (TARGET === 'start-nohmr') {
 }
 
 if (TARGET === 'build') {
-  console.log('Running in production mode');
+  console.error('Running in production mode');
   process.env.NODE_ENV = 'production';
   module.exports = merge(webpackConfig, {
     plugins: [
@@ -160,7 +160,7 @@ if (TARGET === 'build') {
 }
 
 if (TARGET === 'test') {
-  console.log('Running test/ci mode');
+  console.error('Running test/ci mode');
   module.exports = merge(webpackConfig, {
     module: {
       rules: [
@@ -171,6 +171,6 @@ if (TARGET === 'test') {
 }
 
 if (Object.keys(module.exports).length === 0) {
-  console.log('Running in default mode');
+  console.error('Running in default mode');
   module.exports = webpackConfig;
 }

--- a/graylog2-web-interface/webpack.vendor.js
+++ b/graylog2-web-interface/webpack.vendor.js
@@ -9,7 +9,7 @@ const MANIFESTS_PATH = path.resolve(ROOT_PATH, 'manifests');
 
 const vendorModules = require('./vendor.modules');
 
-console.log('Building vendor bundle.');
+console.error('Building vendor bundle.');
 
 const webpackConfig = {
   entry: {


### PR DESCRIPTION
This is a very small change that makes the webpack (and therefore eslint, which is using the webpack config to resolve imports) configs log their status line to STDERR instead of STDOUT. This helps us to pipe their output to another tool consuming it. Use cases for this are:

  * eslint using the checkstyle formatter, piping the results into a file picked up by jenkins (in case of the `graylog-pr-linter-check` job)
  * piping the json output of webpack into a file or [webpack-bundle-analyzer](https://www.npmjs.com/package/webpack-bundle-analyzer) for analysis

Both cases would result in invalid JSON/XML files without manually removing the status lines without this fix.
