### PR TITLE
Prevent unwanted session extension

### DIFF
--- a/graylog2-web-interface/src/stores/dashboards/DashboardsStore.ts
+++ b/graylog2-web-interface/src/stores/dashboards/DashboardsStore.ts
@@ -7,6 +7,7 @@ const UserNotification = require('util/UserNotification');
 import ApiRoutes = require('routing/ApiRoutes');
 const URLUtils = require('util/URLUtils');
 const Builder = require('logic/rest/FetchProvider').Builder;
+const fetchPeriodically = require('logic/rest/FetchProvider').fetchPeriodically;
 const fetch = require('logic/rest/FetchProvider').default;
 const PermissionsMixin = require('util/PermissionsMixin');
 
@@ -108,11 +109,7 @@ class DashboardsStore {
 
   get(id: string): Promise<Dashboard> {
     const url = URLUtils.qualifyUrl(ApiRoutes.DashboardsApiController.get(id).url);
-    const promise = new Builder('GET', url)
-      .authenticated()
-      .setHeader('X-Graylog-No-Session-Extension', 'true')
-      .json()
-      .build();
+    const promise = fetchPeriodically('GET', url);
 
     promise.catch((error) => {
       if (error.additional.status !== 404) {

--- a/graylog2-web-interface/src/stores/metrics/MetricsStore.js
+++ b/graylog2-web-interface/src/stores/metrics/MetricsStore.js
@@ -2,7 +2,7 @@ import Reflux from 'reflux';
 
 import URLUtils from 'util/URLUtils';
 import ApiRoutes from 'routing/ApiRoutes';
-import fetch, { Builder } from 'logic/rest/FetchProvider';
+import fetch, { Builder, fetchPeriodically } from 'logic/rest/FetchProvider';
 
 import StoreProvider from 'injection/StoreProvider';
 const SessionStore = StoreProvider.getStore('Session');
@@ -87,11 +87,7 @@ const MetricsStore = Reflux.createStore({
     const url = URLUtils.qualifyUrl(ApiRoutes.ClusterMetricsApiController.multipleAllNodes().url);
 
     if (!this.promises.list) {
-      const promise = new Builder('POST', url)
-        .authenticated()
-        .setHeader('X-Graylog-No-Session-Extension', 'true')
-        .json({ metrics: Object.keys(metricsToFetch) })
-        .build()
+      const promise = fetchPeriodically('POST', url, { metrics: Object.keys(metricsToFetch) })
         .finally(() => delete this.promises.list);
 
       promise.then((response) => {

--- a/graylog2-web-interface/src/stores/metrics/MetricsStore.js
+++ b/graylog2-web-interface/src/stores/metrics/MetricsStore.js
@@ -2,7 +2,7 @@ import Reflux from 'reflux';
 
 import URLUtils from 'util/URLUtils';
 import ApiRoutes from 'routing/ApiRoutes';
-import fetch from 'logic/rest/FetchProvider';
+import fetch, { Builder } from 'logic/rest/FetchProvider';
 
 import StoreProvider from 'injection/StoreProvider';
 const SessionStore = StoreProvider.getStore('Session');
@@ -87,7 +87,12 @@ const MetricsStore = Reflux.createStore({
     const url = URLUtils.qualifyUrl(ApiRoutes.ClusterMetricsApiController.multipleAllNodes().url);
 
     if (!this.promises.list) {
-      const promise = fetch('POST', url, { metrics: Object.keys(metricsToFetch) }).finally(() => delete this.promises.list);
+      const promise = new Builder('POST', url)
+        .authenticated()
+        .setHeader('X-Graylog-No-Session-Extension', 'true')
+        .json({ metrics: Object.keys(metricsToFetch) })
+        .build()
+        .finally(() => delete this.promises.list);
 
       promise.then((response) => {
         this.metrics = this._buildMetricsFromResponse(response);

--- a/graylog2-web-interface/src/stores/nodes/NodesStore.js
+++ b/graylog2-web-interface/src/stores/nodes/NodesStore.js
@@ -1,6 +1,6 @@
 import Reflux from 'reflux';
 import URLUtils from 'util/URLUtils';
-import fetch from 'logic/rest/FetchProvider';
+import fetch, { Builder } from 'logic/rest/FetchProvider';
 
 import ActionsProvider from 'injection/ActionsProvider';
 const NodesActions = ActionsProvider.getActions('Nodes');
@@ -32,7 +32,11 @@ const NodesStore = Reflux.createStore({
 
   list() {
     const promise = this.promises.list || fetch('GET', URLUtils.qualifyUrl(ApiRoutes.ClusterApiResource.list().url))
-      .then((response) => {
+      .authenticated()
+      .setHeader('X-Graylog-No-Session-Extension', 'true')
+      .json()
+      .build()
+      .then(response => {
         this.nodes = {};
         response.nodes.forEach((node) => {
           this.nodes[node.node_id] = node;

--- a/graylog2-web-interface/src/stores/nodes/NodesStore.js
+++ b/graylog2-web-interface/src/stores/nodes/NodesStore.js
@@ -1,11 +1,12 @@
 import Reflux from 'reflux';
 import URLUtils from 'util/URLUtils';
-import fetch, { Builder } from 'logic/rest/FetchProvider';
-
-import ActionsProvider from 'injection/ActionsProvider';
-const NodesActions = ActionsProvider.getActions('Nodes');
+import { Builder } from 'logic/rest/FetchProvider';
 
 import ApiRoutes from 'routing/ApiRoutes';
+import CombinedProvider from 'injection/CombinedProvider';
+
+const { NodesActions } = CombinedProvider.get('Nodes');
+const { SessionStore } = CombinedProvider.get('Session');
 
 const NodesStore = Reflux.createStore({
   listenables: [NodesActions],
@@ -17,8 +18,14 @@ const NodesStore = Reflux.createStore({
 
   init() {
     if (this.nodes === undefined) {
+      this._triggerList();
+      setInterval(this._triggerList, this.INTERVAL);
+    }
+  },
+
+  _triggerList() {
+    if (SessionStore.isLoggedIn()) {
       NodesActions.list();
-      setInterval(NodesActions.list, this.INTERVAL);
     }
   },
 

--- a/graylog2-web-interface/src/stores/nodes/NodesStore.js
+++ b/graylog2-web-interface/src/stores/nodes/NodesStore.js
@@ -1,6 +1,6 @@
 import Reflux from 'reflux';
 import URLUtils from 'util/URLUtils';
-import { Builder } from 'logic/rest/FetchProvider';
+import { Builder, fetchPeriodically } from 'logic/rest/FetchProvider';
 
 import ApiRoutes from 'routing/ApiRoutes';
 import CombinedProvider from 'injection/CombinedProvider';
@@ -38,11 +38,7 @@ const NodesStore = Reflux.createStore({
   },
 
   list() {
-    const promise = this.promises.list || fetch('GET', URLUtils.qualifyUrl(ApiRoutes.ClusterApiResource.list().url))
-      .authenticated()
-      .setHeader('X-Graylog-No-Session-Extension', 'true')
-      .json()
-      .build()
+    const promise = this.promises.list || fetchPeriodically('GET', URLUtils.qualifyUrl(ApiRoutes.ClusterApiResource.list().url))
       .then(response => {
         this.nodes = {};
         response.nodes.forEach((node) => {

--- a/graylog2-web-interface/src/stores/notifications/NotificationsStore.js
+++ b/graylog2-web-interface/src/stores/notifications/NotificationsStore.js
@@ -2,7 +2,7 @@ import Reflux from 'reflux';
 
 import URLUtils from 'util/URLUtils';
 import ApiRoutes from 'routing/ApiRoutes';
-import fetch, { Builder } from 'logic/rest/FetchProvider';
+import fetch, { Builder, fetchPeriodically } from 'logic/rest/FetchProvider';
 
 import ActionsProvider from 'injection/ActionsProvider';
 const NotificationsActions = ActionsProvider.getActions('Notifications');
@@ -24,11 +24,7 @@ const NotificationsStore = Reflux.createStore({
   },
   list() {
     const url = URLUtils.qualifyUrl(ApiRoutes.NotificationsApiController.list().url);
-    const promise = this.promises.list || new Builder('GET', url)
-        .authenticated()
-        .setHeader('X-Graylog-No-Session-Extension', 'true')
-        .json()
-        .build()
+    const promise = this.promises.list || fetchPeriodically('GET', url)
         .finally(() => delete this.promises.list);
 
     this.promises.list = promise;

--- a/graylog2-web-interface/src/stores/sessions/ServerAvailabilityStore.js
+++ b/graylog2-web-interface/src/stores/sessions/ServerAvailabilityStore.js
@@ -20,6 +20,7 @@ const ServerAvailabilityStore = Reflux.createStore({
     return new Builder('GET', URLUtils.qualifyUrl(ApiRoutes.ping().url))
       // Make sure to request JSON to avoid a redirect which breaks in Firefox (see https://github.com/Graylog2/graylog2-server/issues/3312)
       .setHeader('Accept', 'application/json')
+      .setHeader('X-Graylog-No-Session-Extension', 'true')
       .build()
       .then(
         () => ServerAvailabilityActions.reportSuccess(),

--- a/graylog2-web-interface/src/stores/widgets/WidgetsStore.ts
+++ b/graylog2-web-interface/src/stores/widgets/WidgetsStore.ts
@@ -5,7 +5,7 @@ const Reflux = require('reflux');
 const UserNotification = require('util/UserNotification');
 import ApiRoutes = require('routing/ApiRoutes');
 const URLUtils = require('util/URLUtils');
-const Builder = require('logic/rest/FetchProvider').Builder;
+const fetchPeriodically = require('logic/rest/FetchProvider').fetchPeriodically;
 const fetch = require('logic/rest/FetchProvider').default;
 
 const ActionsProvider = require('injection/ActionsProvider');
@@ -54,11 +54,7 @@ const WidgetsStore = Reflux.createStore({
 
     loadWidget(dashboardId: string, widgetId: string): Promise<string[]> {
         var url = URLUtils.qualifyUrl(ApiRoutes.DashboardsApiController.widget(dashboardId, widgetId).url);
-        const promise = new Builder('GET', url)
-            .authenticated()
-            .setHeader('X-Graylog-No-Session-Extension', 'true')
-            .json()
-            .build();
+        const promise = fetchPeriodically('GET', url);
 
         promise.catch((error) => {
             if (error.additional.status !== 404) {
@@ -90,11 +86,7 @@ const WidgetsStore = Reflux.createStore({
     loadValue(dashboardId: string, widgetId: string, resolution: number): Promise<string[]> {
         var url = URLUtils.qualifyUrl(ApiRoutes.DashboardsApiController.widgetValue(dashboardId, widgetId, resolution).url);
 
-        return new Builder('GET', url)
-            .authenticated()
-            .setHeader('X-Graylog-No-Session-Extension', 'true')
-            .json()
-            .build();
+        return fetchPeriodically('GET', url);
     },
 
     removeWidget(dashboardId: string, widgetId: string): Promise<string[]> {


### PR DESCRIPTION
## Description
## Motivation and Context

Without this change, there are some periodical calls to the backend which extend the user's session every call, so user session expiration never kicks in.

This change sets the `X-Graylog-No-Session-Extension` header to true for those calls, prevent unnecessary session extension. As this happens in several parts of the code, a helper method is create doing this, which can be easily used in the future when there are more periodical calls added.

Fixes #3565. Should also be merged in `2.2`.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
