### PR TITLE
Adding index to `system_messages` collection.

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/system/activities/SystemMessageServiceImpl.java
+++ b/graylog2-server/src/main/java/org/graylog2/system/activities/SystemMessageServiceImpl.java
@@ -16,12 +16,15 @@
  */
 package org.graylog2.system.activities;
 
+import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Lists;
 import com.mongodb.BasicDBObject;
+import com.mongodb.DBCollection;
 import com.mongodb.DBObject;
 import org.bson.types.ObjectId;
 import org.graylog2.database.MongoConnection;
 import org.graylog2.database.PersistedServiceImpl;
+import org.mongojack.DBSort;
 
 import javax.inject.Inject;
 import java.util.List;
@@ -33,6 +36,8 @@ public class SystemMessageServiceImpl extends PersistedServiceImpl implements Sy
     @Inject
     public SystemMessageServiceImpl(MongoConnection mongoConnection) {
         super(mongoConnection);
+        final DBCollection collection = this.collection(SystemMessageImpl.class);
+        collection.createIndex(DBSort.desc("timestamp"));
     }
 
     @Override

--- a/graylog2-server/src/main/java/org/graylog2/system/activities/SystemMessageServiceImpl.java
+++ b/graylog2-server/src/main/java/org/graylog2/system/activities/SystemMessageServiceImpl.java
@@ -16,7 +16,6 @@
  */
 package org.graylog2.system.activities;
 
-import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Lists;
 import com.mongodb.BasicDBObject;
 import com.mongodb.DBCollection;


### PR DESCRIPTION
## Description
## Motivation and Context

When no index is defined for the `system_messages` collection, a user
visiting the System/Overview page generates COLLSCANs on this
collection, possibly leading to a performance degradation.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
