### PR TITLE
Removing output to STDERR for default profile, it irritates IntelliJ.

### DIFF
--- a/graylog2-web-interface/webpack.config.js
+++ b/graylog2-web-interface/webpack.config.js
@@ -171,6 +171,5 @@ if (TARGET === 'test') {
 }
 
 if (Object.keys(module.exports).length === 0) {
-  console.error('Running in default mode');
   module.exports = webpackConfig;
 }


### PR DESCRIPTION
Before this change, IntelliJ interpreted the output to STDERR from
ESLint sourcing the webpack config as an error. This change removes the
output for the default profile to fix this.
