### PR TITLE
Fix hot reloading for plugins.

### DIFF
--- a/graylog-plugin-archetype/src/main/resources/archetype-resources/src/web/index.jsx
+++ b/graylog-plugin-archetype/src/main/resources/archetype-resources/src/web/index.jsx
@@ -1,10 +1,11 @@
 // eslint-disable-next-line no-unused-vars
 import webpackEntry from 'webpack-entry';
 
-import packageJson from '../../package.json';
 import { PluginManifest, PluginStore } from 'graylog-web-plugin/plugin';
 
-PluginStore.register(new PluginManifest(packageJson, {
+import packageJson from '../../package.json';
+
+const manifest = new PluginManifest(packageJson, {
   /* This is the place where you define which entities you are providing to the web interface.
      Right now you can add routes and navigation elements to it.
 
@@ -21,4 +22,11 @@ PluginStore.register(new PluginManifest(packageJson, {
   // navigation: [
   //  { path: '/sample', description: 'Sample' },
   // ]
-}));
+});
+
+PluginStore.register(manifest);
+
+if (module.hot) {
+  module.hot.accept();
+  module.hot.dispose(() => PluginStore.unregister(manifest));
+}

--- a/graylog2-web-interface/packages/graylog-web-plugin/src/PluginStore.jsx
+++ b/graylog2-web-interface/packages/graylog-web-plugin/src/PluginStore.jsx
@@ -6,6 +6,18 @@ class PluginStore {
     window.plugins.push(plugin);
   }
 
+  static unregister(plugin) {
+    if (!window.plugins) {
+      return;
+    }
+
+    window.plugins.forEach((item, idx) => {
+      if (item.metadata && plugin.metadata && item.metadata.name === plugin.metadata.name) {
+        window.plugins.splice(idx, 1);
+      }
+    });
+  }
+
   static get() {
     if (!window.plugins) {
       window.plugins = [];


### PR DESCRIPTION
This small change intends to restore hot reloading functionality for plugins. Before, due to the different context of a plugin and the main app, hot update chunks for plugin were rejected. Therefore we need to [explicitly accept chunks](https://github.com/Graylog2/graylog2-server/commit/145a9cc4f7d3a1784ae540b98dc2992f70330f87#diff-651eef93a31b1188a48523e333d85921R30) in the entry point of a plugin, which is also the root of the update chain during hot reloading.

As the entry point (`index.jsx`) needs to be reloaded during a hot update, we also need to prevent multiple plugin registrations. Therefore the `PluginStore` now provides a [`unregister`](https://github.com/Graylog2/graylog2-server/commit/31e523bdf6ecbc2ee14ac1c92363c23b5c54e554#diff-2bdfbc2b1735841e980db9538ce9a561R9) method which allows unregistering a plugin's manifest. It is being used by the [`dispose` callback](https://github.com/Graylog2/graylog2-server/commit/145a9cc4f7d3a1784ae540b98dc2992f70330f87#diff-651eef93a31b1188a48523e333d85921R31) which is executed during the disposal of an old module.