### PR TITLE
Modified to pass in target instead of text (#3548)

### DIFF
--- a/graylog2-web-interface/src/components/search/ShowQueryModal.jsx
+++ b/graylog2-web-interface/src/components/search/ShowQueryModal.jsx
@@ -23,22 +23,22 @@ var ShowQueryModal = React.createClass({
         this.refs.modal.close();
     },
 
-    render () {
-        var queryText = JSON.stringify(JSON.parse(this.props.builtQuery), null, '  ');
-        return (
-          <BootstrapModalWrapper ref="modal">
-              <Modal.Header closeButton>
-                  <Modal.Title>Elasticsearch Query</Modal.Title>
-              </Modal.Header>
-              <Modal.Body>
-                  <pre>{queryText}</pre>
-              </Modal.Body>
-              <Modal.Footer>
-                <ClipboardButton title="Copy query" text={queryText}/>
-              </Modal.Footer>
-          </BootstrapModalWrapper>
-        );
-    }
+  render() {
+    var queryText = JSON.stringify(JSON.parse(this.props.builtQuery), null, '  ');
+    return (
+      <BootstrapModalWrapper ref="modal">
+        <Modal.Header closeButton>
+          <Modal.Title>Elasticsearch Query</Modal.Title>
+        </Modal.Header>
+        <Modal.Body>
+          <pre>{queryText}</pre>
+        </Modal.Body>
+        <Modal.Footer>
+          <ClipboardButton title="Copy query" target=".modal-body pre" />
+        </Modal.Footer>
+      </BootstrapModalWrapper>
+    );
+  }
 });
 
 module.exports = ShowQueryModal;


### PR DESCRIPTION
This is a port of #3548 for `2.2`, fixing the "copy query to clipboard" functionality from the search screen for non-Safari browsers.

(cherry picked from commit a27339383d3349d5128e7767b3cd1fe4c59cfeb9)
