### PR TITLE
Add support for Cisco and FortiGate syslog messages

### DIFF
--- a/graylog2-server/src/test/java/org/graylog2/inputs/codecs/SyslogCodecTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/inputs/codecs/SyslogCodecTest.java
@@ -51,7 +51,7 @@ public class SyslogCodecTest {
     private static String STRUCTURED = "<165>1 2012-12-25T22:14:15.003Z mymachine.example.com evntslog - ID47 [exampleSDID@32473 iut=\"3\" eventSource=\"Application\" eventID=\"1011\"] BOMAn application event log entry";
     private static String STRUCTURED_ISSUE_845 = "<190>1 2015-01-06T20:56:33.287Z app-1 app - - [mdc@18060 ip=\"::ffff:132.123.15.30\" logger=\"{c.corp.Handler}\" session=\"4ot7\" user=\"user@example.com\" user-agent=\"Mozilla/5.0 (Macintosh; Intel Mac OS X 10_9_5) AppleWebKit/600.2.5 (KHTML, like Gecko) Version/7.1.2 Safari/537.85.11\"] User page 13 requested";
     private static String STRUCTURED_ISSUE_845_EMPTY = "<128>1 2015-01-11T16:35:21.335797+01:00 s000000.example.com - - - - tralala";
-    // The folowing message from issue 549 is from a Juniper SRX 240 device.
+    // The following message from issue 549 is from a Juniper SRX 240 device.
     private static String STRUCTURED_ISSUE_549 = "<14>1 2014-05-01T08:26:51.179Z fw01 RT_FLOW - RT_FLOW_SESSION_DENY [junos@2636.1.1.1.2.39 source-address=\"1.2.3.4\" source-port=\"56639\" destination-address=\"5.6.7.8\" destination-port=\"2003\" service-name=\"None\" protocol-id=\"6\" icmp-type=\"0\" policy-name=\"log-all-else\" source-zone-name=\"campus\" destination-zone-name=\"mngmt\" application=\"UNKNOWN\" nested-application=\"UNKNOWN\" username=\"N/A\" roles=\"N/A\" packet-incoming-interface=\"reth6.0\" encrypted=\"No\"]";
     private final String UNSTRUCTURED = "<45>Oct 21 12:09:37 c4dc57ba1ebb syslog-ng[7208]: syslog-ng starting up; version='3.5.3'";
 
@@ -352,6 +352,7 @@ public class SyslogCodecTest {
     }
 
     @Test
+    @SuppressForbidden("Deliberate invocation")
     public void testCiscoSyslogMessages() {
         final int year = ZonedDateTime.now().getYear();
         final Map<String, Map<String, Object>> messages = ImmutableMap.<String, Map<String, Object>>builder()

--- a/pom.xml
+++ b/pom.xml
@@ -139,7 +139,7 @@
         <sigar.version>1.6.4</sigar.version>
         <slf4j.version>1.7.24</slf4j.version>
         <swagger.version>1.5.12</swagger.version>
-        <syslog4j.version>0.9.59-SNAPSHOT</syslog4j.version>
+        <syslog4j.version>0.9.59</syslog4j.version>
         <uuid.version>3.2</uuid.version>
         <validation-api.version>1.1.0.Final</validation-api.version>
         <zkclient.version>0.7</zkclient.version>

--- a/pom.xml
+++ b/pom.xml
@@ -139,7 +139,7 @@
         <sigar.version>1.6.4</sigar.version>
         <slf4j.version>1.7.24</slf4j.version>
         <swagger.version>1.5.12</swagger.version>
-        <syslog4j.version>0.9.58</syslog4j.version>
+        <syslog4j.version>0.9.59-SNAPSHOT</syslog4j.version>
         <uuid.version>3.2</uuid.version>
         <validation-api.version>1.1.0.Final</validation-api.version>
         <zkclient.version>0.7</zkclient.version>


### PR DESCRIPTION
This PR adds support for (the most common) Cisco and FortiGate/FortiOS syslog messages.

This depends on merging and releasing changes in the syslog4j project: https://github.com/Graylog2/syslog4j-graylog2/pull/17

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
