### PR TITLE
Allow "-" in the path pattern for the index range rebuild endpoint

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/rest/resources/system/IndexRangesResource.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/resources/system/IndexRangesResource.java
@@ -176,7 +176,7 @@ public class IndexRangesResource extends RestResource {
 
     @POST
     @Timed
-    @Path("/{index: [a-z_0-9]+}/rebuild")
+    @Path("/{index: [a-z_0-9-]+}/rebuild")
     @ApiOperation(value = "Rebuild/sync index range information.",
             notes = "This triggers a system job that scans an index and stores meta information " +
                     "about what indices contain messages in what time ranges. It atomically overwrites " +


### PR DESCRIPTION
Since the introduction of index sets, an index name can contain a "-" character.

Fixes index range rebuild for indices with "-" character in the index name.