### PR TITLE
Fix eslint dependency to use 3.x and the latest eslint-config-graylog

### DIFF
--- a/graylog2-web-interface/package.json
+++ b/graylog2-web-interface/package.json
@@ -68,7 +68,6 @@
     "css-loader": "^0.26.1",
     "enzyme": "^2.0.0",
     "eslint": "^3.16.1",
-    "eslint-config-graylog": "file:packages/eslint-config-graylog",
     "eslint-loader": "^1.6.3",
     "estraverse-fb": "^1.3.1",
     "extract-text-webpack-plugin": "^2.0.0-rc.2",

--- a/graylog2-web-interface/packages/graylog-web-plugin/package.json
+++ b/graylog2-web-interface/packages/graylog-web-plugin/package.json
@@ -25,8 +25,8 @@
   "homepage": "https://github.com/Graylog2/graylog-web-plugin#readme",
   "dependencies": {
     "babel-eslint": "^6.1.0",
-    "eslint": "^2.13.1",
-    "eslint-config-graylog": "^1.0.2",
+    "eslint": "^3.16.1",
+    "eslint-config-graylog": "file:../eslint-config-graylog",
     "history": "^1.17.0",
     "html-webpack-plugin": "^2.22.0",
     "javascript-natural-sort": "^0.7.1",


### PR DESCRIPTION
Ensures we use the latest eslint-config-graylog in server and plugins.