### PR TITLE
Update our eslint config

### DIFF
--- a/graylog2-web-interface/packages/eslint-config-graylog/index.js
+++ b/graylog2-web-interface/packages/eslint-config-graylog/index.js
@@ -11,6 +11,8 @@ module.exports = {
   ],
   rules: {
     'arrow-body-style': 0,
+    'import/extensions': 0,
+    'import/no-extraneous-dependencies': 0,
     'import/no-unresolved': 0,
     indent: [2, 2, { SwitchCase: 1 }],
     'max-len': 0,
@@ -19,6 +21,7 @@ module.exports = {
     'no-nested-ternary': 1,
     'no-underscore-dangle': 0,
     'object-shorthand': [2, 'methods'],
+    'react/forbid-prop-types': 0,
     'react/jsx-closing-bracket-location': 0,
     'react/jsx-first-prop-new-line': 0,
     'react/jsx-indent-props': 0,

--- a/graylog2-web-interface/packages/eslint-config-graylog/package.json
+++ b/graylog2-web-interface/packages/eslint-config-graylog/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-graylog",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "Graylog ESLint config for web interface plugin authors",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Disable "import/extensions" to avoid annoying error about inconsistent extension handling in imports.

Disable "import/no-extraneous-dependencies" to avoid warning about missing dependencies. We are having an unusual setup and import components from the server which are not pulled in via dependencies.

Disable "react/forbid-prop-types" because we are using object and any prop types all over the place.