### PR TITLE
Fix cloning alert conditions with identical id when cloning stream.

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/rest/resources/streams/StreamResource.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/resources/streams/StreamResource.java
@@ -436,7 +436,7 @@ public class StreamResource extends RestResource {
                     stream,
                     creatorUser
                 );
-                streamService.addAlertCondition(stream, clonedAlertConditio n);
+                streamService.addAlertCondition(stream, clonedAlertCondition);
             } catch (ConfigurationException e) {
                 LOG.warn("Unable to clone alert condition <" + alertCondition + "> - skipping: ", e);
             }

--- a/graylog2-server/src/main/java/org/graylog2/rest/resources/streams/StreamResource.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/resources/streams/StreamResource.java
@@ -43,6 +43,7 @@ import org.graylog2.indexer.IndexSetRegistry;
 import org.graylog2.plugin.Message;
 import org.graylog2.plugin.Tools;
 import org.graylog2.plugin.alarms.AlertCondition;
+import org.graylog2.plugin.configuration.ConfigurationException;
 import org.graylog2.plugin.database.ValidationException;
 import org.graylog2.plugin.streams.Output;
 import org.graylog2.plugin.streams.Stream;
@@ -50,6 +51,7 @@ import org.graylog2.plugin.streams.StreamRule;
 import org.graylog2.rest.models.alarmcallbacks.requests.AlertReceivers;
 import org.graylog2.rest.models.alarmcallbacks.requests.CreateAlarmCallbackRequest;
 import org.graylog2.rest.models.streams.alerts.AlertConditionSummary;
+import org.graylog2.rest.models.streams.alerts.requests.CreateConditionRequest;
 import org.graylog2.rest.models.streams.requests.UpdateStreamRequest;
 import org.graylog2.rest.models.system.outputs.responses.OutputSummary;
 import org.graylog2.rest.resources.streams.requests.CloneStreamRequest;
@@ -71,6 +73,8 @@ import org.hibernate.validator.constraints.NotEmpty;
 import org.joda.time.DateTime;
 import org.joda.time.DateTimeZone;
 import org.joda.time.format.ISODateTimeFormat;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import javax.inject.Inject;
 import javax.validation.Valid;
@@ -105,6 +109,8 @@ import static com.google.common.base.MoreObjects.firstNonNull;
 @Api(value = "Streams", description = "Manage streams")
 @Path("/streams")
 public class StreamResource extends RestResource {
+    private static final Logger LOG = LoggerFactory.getLogger(StreamResource.class);
+
     private final StreamService streamService;
     private final StreamRuleService streamRuleService;
     private final StreamRouterEngine.Factory streamRouterEngineFactory;
@@ -391,12 +397,13 @@ public class StreamResource extends RestResource {
         checkNotDefaultStream(streamId, "The default stream cannot be cloned.");
 
         final Stream sourceStream = streamService.load(streamId);
+        final String creatorUser = getCurrentUser().getName();
 
         // Create stream.
         final Map<String, Object> streamData = Maps.newHashMap();
         streamData.put(StreamImpl.FIELD_TITLE, cr.title());
         streamData.put(StreamImpl.FIELD_DESCRIPTION, cr.description());
-        streamData.put(StreamImpl.FIELD_CREATOR_USER_ID, getCurrentUser().getName());
+        streamData.put(StreamImpl.FIELD_CREATOR_USER_ID, creatorUser);
         streamData.put(StreamImpl.FIELD_CREATED_AT, Tools.nowUTC());
         streamData.put(StreamImpl.FIELD_MATCHING_TYPE, sourceStream.getMatchingType().toString());
         streamData.put(StreamImpl.FIELD_REMOVE_MATCHES_FROM_DEFAULT_STREAM, cr.removeMatchesFromDefaultStream());
@@ -423,7 +430,16 @@ public class StreamResource extends RestResource {
         }
 
         for (AlertCondition alertCondition : streamService.getAlertConditions(sourceStream)) {
-            streamService.addAlertCondition(stream, alertCondition);
+            try {
+                final AlertCondition clonedAlertCondition = alertService.fromRequest(
+                    CreateConditionRequest.create(alertCondition.getType(), alertCondition.getTitle(), alertCondition.getParameters()),
+                    stream,
+                    creatorUser
+                );
+                streamService.addAlertCondition(stream, clonedAlertConditio n);
+            } catch (ConfigurationException e) {
+                LOG.warn("Unable to clone alert condition <" + alertCondition + "> - skipping: ", e);
+            }
         }
 
         for (AlarmCallbackConfiguration alarmCallbackConfiguration : alarmCallbackConfigurationService.getForStream(sourceStream)) {


### PR DESCRIPTION
Before this change, any alert conditions associated with a stream were
cloned identically (including using the same id) when cloning a stream.
This was leading to a bug, where the alert condition was shown as being
associated with the source of the clone process instead of the target.

With this change, the alert condition is recreated during cloning,
including generating a new id for it.

Fixes #3608.

(cherry picked from commit 0a9f75b31e5113149da4147322ddfbf3e9d49cfb)
