### PR TITLE
Fixing slicing of alert notifications in pagination

### DIFF
--- a/graylog2-web-interface/src/components/alertnotifications/AlertNotificationsList.jsx
+++ b/graylog2-web-interface/src/components/alertnotifications/AlertNotificationsList.jsx
@@ -24,7 +24,7 @@ const AlertNotificationsList = React.createClass({
   },
 
   _paginatedNotifications() {
-    return this.props.alertNotifications.slice(this.state.currentPage, this.state.currentPage + this.PAGE_SIZE);
+    return this.props.alertNotifications.slice(this.state.currentPage * this.PAGE_SIZE, (this.state.currentPage + 1) * this.PAGE_SIZE);
   },
 
   _formatNotification(notification) {


### PR DESCRIPTION
Before this change, the slice of alert notifications shown in the paginated view was calculated incorrectly.

Fixes #3612.
