### PR TITLE
Use UTC for embedded Date objects as well

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/jackson/MongoJodaDateTimeDeserializer.java
+++ b/graylog2-server/src/main/java/org/graylog2/jackson/MongoJodaDateTimeDeserializer.java
@@ -41,7 +41,7 @@ public final class MongoJodaDateTimeDeserializer extends StdScalarDeserializer<D
                 final Object embeddedObject = jsonParser.getEmbeddedObject();
                 if (embeddedObject instanceof Date) {
                     final Date date = (Date) embeddedObject;
-                    return new DateTime(date);
+                    return new DateTime(date, DateTimeZone.UTC);
                 } else {
                     throw new IllegalStateException("Unsupported token: " + jsonParser.currentToken());
                 }


### PR DESCRIPTION
The MongoDB driver creates Date objects when deserializing documents from the database. Without this, the converted DateTime object's time zone would depend on the JVM default zone.

We do the same in the `MongoZonedDateTimeDeserializer`.

This should be back-ported into 2.2.