### PR TITLE
Use UTC for embedded Date objects as well

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/jackson/MongoJodaDateTimeDeserializer.java
+++ b/graylog2-server/src/main/java/org/graylog2/jackson/MongoJodaDateTimeDeserializer.java
@@ -43,7 +43,7 @@ public final class MongoJodaDateTimeDeserializer extends StdScalarDeserializer<D
                 final Object embeddedObject = jsonParser.getEmbeddedObject();
                 if (embeddedObject instanceof Date) {
                     final Date date = (Date) embeddedObject;
-                    return new DateTime(date);
+                    return new DateTime(date, DateTimeZone.UTC);
                 } else {
                     throw new IllegalStateException("Unsupported token: " + jsonParser.currentToken());
                 }


### PR DESCRIPTION
The MongoDB driver creates Date objects when deserializing documents
from the database. Without this, the converted DateTime object's time
zone would depend on the JVM default zone.

Refs #3626
(cherry picked from commit 3f6543ba890d532daef23d4d522093d99ab4795d)