### PR TITLE
Prevent useless session validation when no id or username is present.

### DIFF
--- a/graylog2-web-interface/src/stores/sessions/SessionStore.js
+++ b/graylog2-web-interface/src/stores/sessions/SessionStore.js
@@ -48,6 +48,9 @@ const SessionStore = Reflux.createStore({
   validate() {
     const sessionId = Store.get('sessionId');
     const username = Store.get('username');
+    if (sessionId === undefined || username === undefined) {
+      return;
+    }
     this.validatingSession = true;
     this._propagateState();
     this._validateSession(sessionId)


### PR DESCRIPTION
This change checks for the presence of a session id or username before
validating the session. This has two benefits:

  1) A round trip to the server is saved upon initial login, showing the
login dialog much faster.
  2) A race condition is prevented in automated testing when the session
id is added to localStorage between two page visits. The code does not
check if a validation is currently in progress before triggering a new
one, which leads to inconsistent session propagation.

Also needs to be merged into `2.2`.