### PR TITLE
Make id of help menu item unique.

### DIFF
--- a/graylog2-web-interface/src/components/navigation/HelpMenu.jsx
+++ b/graylog2-web-interface/src/components/navigation/HelpMenu.jsx
@@ -11,7 +11,7 @@ const HelpMenu = React.createClass({
   },
   render() {
     return (
-      <NavDropdown navItem title="Help" id="user-menu-dropdown" active={this.props.active}>
+      <NavDropdown navItem title="Help" id="help-menu-dropdown" active={this.props.active}>
         <LinkContainer to={Routes.getting_started(true)}>
           <MenuItem>Getting Started</MenuItem>
         </LinkContainer>


### PR DESCRIPTION
This small change remedies the (copy & paste?) error of the help
dropdown in the navigation bar having the same id ('user-menu-dropdown')
as the actual user menu by changing it to 'help-menu-dropdown'.

Needs to be merged into `2.2` as well.
