### PR TITLE
Ensure that plugin RPMs will be built for Linux

### DIFF
--- a/graylog-plugin-parent/pom.xml
+++ b/graylog-plugin-parent/pom.xml
@@ -154,6 +154,8 @@
                 <artifactId>rpm-maven-plugin</artifactId>
                 <configuration>
                     <group>Application/Internet</group>
+                    <needarch>noarch</needarch>
+                    <targetOS>linux</targetOS>
                     <prefixes>
                         <prefix>/usr</prefix>
                     </prefixes>


### PR DESCRIPTION
RPM packages built using the `graylog-plugin-parent` POM were using the build OS's name for the `%{OS}` attribute in the RPM, e. g. "mac os x" if the package was built on Mac OS X.

This lead to problems when trying to install these packages on Linux, where `rpm` complained with:
```
package $NAME is intended for a different operating system
```

Setting the [`targetOS`](http://www.mojohaus.org/rpm-maven-plugin/rpm-mojo.html#targetOS) attribute of the `rpm-maven-plugin` to `linux` solves the issue.

Fixes #3657