### PR TITLE
Publish GrokPatternsChangedEvent when using content packs

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/bindings/providers/BundleImporterProvider.java
+++ b/graylog2-server/src/main/java/org/graylog2/bindings/providers/BundleImporterProvider.java
@@ -19,6 +19,7 @@ package org.graylog2.bindings.providers;
 import org.graylog2.bundles.BundleImporter;
 import org.graylog2.dashboards.DashboardService;
 import org.graylog2.dashboards.widgets.DashboardWidgetCreator;
+import org.graylog2.events.ClusterEventBus;
 import org.graylog2.grok.GrokPatternService;
 import org.graylog2.indexer.IndexSetRegistry;
 import org.graylog2.inputs.InputService;
@@ -51,6 +52,7 @@ public class BundleImporterProvider implements Provider<BundleImporter> {
     private final InputLauncher inputLauncher;
     private final GrokPatternService grokPatternService;
     private final TimeRangeFactory timeRangeFactory;
+    private final ClusterEventBus clusterBus;
 
     @Inject
     public BundleImporterProvider(final InputService inputService,
@@ -66,7 +68,8 @@ public class BundleImporterProvider implements Provider<BundleImporter> {
                                   final MessageInputFactory messageInputFactory,
                                   final InputLauncher inputLauncher,
                                   final GrokPatternService grokPatternService,
-                                  final TimeRangeFactory timeRangeFactory) {
+                                  final TimeRangeFactory timeRangeFactory,
+                                  final ClusterEventBus clusterBus) {
         this.inputService = inputService;
         this.inputRegistry = inputRegistry;
         this.extractorFactory = extractorFactory;
@@ -81,6 +84,7 @@ public class BundleImporterProvider implements Provider<BundleImporter> {
         this.inputLauncher = inputLauncher;
         this.grokPatternService = grokPatternService;
         this.timeRangeFactory = timeRangeFactory;
+        this.clusterBus = clusterBus;
     }
 
     @Override
@@ -88,6 +92,6 @@ public class BundleImporterProvider implements Provider<BundleImporter> {
         return new BundleImporter(inputService, inputRegistry, extractorFactory,
                 streamService, streamRuleService, indexSetRegistry, outputService, dashboardService,
                 dashboardWidgetCreator, serverStatus, messageInputFactory,
-                inputLauncher, grokPatternService, timeRangeFactory);
+                inputLauncher, grokPatternService, timeRangeFactory, clusterBus);
     }
 }

--- a/graylog2-server/src/main/java/org/graylog2/bundles/BundleImporter.java
+++ b/graylog2-server/src/main/java/org/graylog2/bundles/BundleImporter.java
@@ -25,7 +25,9 @@ import org.graylog2.dashboards.DashboardService;
 import org.graylog2.dashboards.widgets.DashboardWidgetCreator;
 import org.graylog2.dashboards.widgets.InvalidWidgetConfigurationException;
 import org.graylog2.database.NotFoundException;
+import org.graylog2.events.ClusterEventBus;
 import org.graylog2.grok.GrokPatternService;
+import org.graylog2.grok.GrokPatternsChangedEvent;
 import org.graylog2.indexer.IndexSet;
 import org.graylog2.indexer.IndexSetRegistry;
 import org.graylog2.inputs.InputService;
@@ -85,6 +87,7 @@ public class BundleImporter {
     private final InputLauncher inputLauncher;
     private final GrokPatternService grokPatternService;
     private final TimeRangeFactory timeRangeFactory;
+    private final ClusterEventBus clusterBus;
 
     private final Map<String, org.graylog2.grok.GrokPattern> createdGrokPatterns = new HashMap<>();
     private final Map<String, MessageInput> createdInputs = new HashMap<>();
@@ -108,7 +111,8 @@ public class BundleImporter {
                           final MessageInputFactory messageInputFactory,
                           final InputLauncher inputLauncher,
                           final GrokPatternService grokPatternService,
-                          final TimeRangeFactory timeRangeFactory) {
+                          final TimeRangeFactory timeRangeFactory,
+                          final ClusterEventBus clusterBus) {
         this.inputService = inputService;
         this.inputRegistry = inputRegistry;
         this.extractorFactory = extractorFactory;
@@ -123,6 +127,7 @@ public class BundleImporter {
         this.inputLauncher = inputLauncher;
         this.grokPatternService = grokPatternService;
         this.timeRangeFactory = timeRangeFactory;
+        this.clusterBus = clusterBus;
     }
 
     public void runImport(final ConfigurationBundle bundle, final String userName) {
@@ -236,6 +241,8 @@ public class BundleImporter {
             final org.graylog2.grok.GrokPattern createdGrokPattern = createGrokPattern(bundleId, grokPattern);
             createdGrokPatterns.put(grokPattern.name(), createdGrokPattern);
         }
+
+        clusterBus.post(GrokPatternsChangedEvent.create(Collections.emptySet(), createdGrokPatterns.keySet()));
     }
 
     private org.graylog2.grok.GrokPattern createGrokPattern(String bundleId, GrokPattern grokPattern) throws ValidationException {


### PR DESCRIPTION
The BundleImporter logic for creating Grok patterns from a content pack
wasn't publishing a GrokPatternsChangedEvent which caused the GrokService
to invalidate and reload its internal cache.

Fixes #3610
Refs #3621
(cherry picked from commit cdffb5387513f5fda84d25edcab949afea080018)