### PR TITLE
Dependency updates

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -114,7 +114,7 @@
         <javax.el-api.version>3.0.0</javax.el-api.version>
         <javax.inject.version>1</javax.inject.version>
         <javax.ws.rs-api.version>2.0.1</javax.ws.rs-api.version>
-        <jbcrypt.version>0.3m</jbcrypt.version>
+        <jbcrypt.version>0.4</jbcrypt.version>
         <jersey.version>2.25.1</jersey.version>
         <jmte.version>3.2.0</jmte.version>
         <jna.version>4.1.0</jna.version> <!-- for ES, make sure to use the version that ES uses -->

--- a/pom.xml
+++ b/pom.xml
@@ -122,7 +122,7 @@
         <json-path.version>2.2.0</json-path.version>
         <jsr305.version>3.0.1</jsr305.version>
         <kafka.version>0.9.0.1</kafka.version>
-        <log4j.version>2.8</log4j.version>
+        <log4j.version>2.8.1</log4j.version>
         <metrics.version>3.2.2</metrics.version>
         <mongodb-driver.version>3.4.2</mongodb-driver.version>
         <mongojack.version>2.6.1</mongojack.version>

--- a/pom.xml
+++ b/pom.xml
@@ -133,7 +133,7 @@
         <os-platform-finder.version>1.2.2</os-platform-finder.version>
         <protobuf.version>3.2.0</protobuf.version>
         <reflections.version>0.9.10</reflections.version>
-        <retrofit.version>2.1.0</retrofit.version>
+        <retrofit.version>2.2.0</retrofit.version>
         <scala.version>2.11.8</scala.version>
         <shiro.version>1.3.2</shiro.version>
         <sigar.version>1.6.4</sigar.version>

--- a/pom.xml
+++ b/pom.xml
@@ -88,7 +88,7 @@
 
         <!-- Dependencies -->
         <airline.version>2.2.0</airline.version>
-        <amqp-client.version>4.0.2</amqp-client.version>
+        <amqp-client.version>4.1.0</amqp-client.version>
         <apache-directory-version>1.0.0-RC2</apache-directory-version>
         <auto-value.version>1.4</auto-value.version>
         <auto-value-extension-util.version>0.3.0</auto-value-extension-util.version>

--- a/pom.xml
+++ b/pom.xml
@@ -104,7 +104,7 @@
         <guava.version>21.0</guava.version>
         <guice.version>4.1.0</guice.version>
         <HdrHistogram.version>2.1.9</HdrHistogram.version>
-        <hibernate-validator.version>5.4.0.Final</hibernate-validator.version>
+        <hibernate-validator.version>5.4.1.Final</hibernate-validator.version>
         <hk2.version>2.5.0-b32</hk2.version> <!-- The HK2 version should match the version being used by Jersey -->
         <jackson.version>2.8.7</jackson.version>
         <jadconfig.version>0.13.0</jadconfig.version>

--- a/pom.xml
+++ b/pom.xml
@@ -90,7 +90,7 @@
         <airline.version>2.2.0</airline.version>
         <amqp-client.version>4.0.2</amqp-client.version>
         <apache-directory-version>1.0.0-RC2</apache-directory-version>
-        <auto-value.version>1.3</auto-value.version>
+        <auto-value.version>1.4</auto-value.version>
         <auto-value-extension-util.version>0.3.0</auto-value-extension-util.version>
         <commons-codec.version>1.10</commons-codec.version>
         <commons-email.version>1.4</commons-email.version>

--- a/pom.xml
+++ b/pom.xml
@@ -123,7 +123,7 @@
         <jsr305.version>3.0.1</jsr305.version>
         <kafka.version>0.9.0.1</kafka.version>
         <log4j.version>2.8</log4j.version>
-        <metrics.version>3.2.0</metrics.version>
+        <metrics.version>3.2.2</metrics.version>
         <mongodb-driver.version>3.4.2</mongodb-driver.version>
         <mongojack.version>2.6.1</mongojack.version>
         <natty.version>0.13</natty.version>

--- a/pom.xml
+++ b/pom.xml
@@ -118,7 +118,7 @@
         <jersey.version>2.25.1</jersey.version>
         <jmte.version>3.2.0</jmte.version>
         <jna.version>4.1.0</jna.version> <!-- for ES, make sure to use the version that ES uses -->
-        <joda-time.version>2.9.7</joda-time.version>
+        <joda-time.version>2.9.9</joda-time.version>
         <json-path.version>2.2.0</json-path.version>
         <jsr305.version>3.0.1</jsr305.version>
         <kafka.version>0.9.0.1</kafka.version>

--- a/pom.xml
+++ b/pom.xml
@@ -137,7 +137,7 @@
         <scala.version>2.11.8</scala.version>
         <shiro.version>1.3.2</shiro.version>
         <sigar.version>1.6.4</sigar.version>
-        <slf4j.version>1.7.24</slf4j.version>
+        <slf4j.version>1.7.25</slf4j.version>
         <swagger.version>1.5.12</swagger.version>
         <syslog4j.version>0.9.59</syslog4j.version>
         <uuid.version>3.2</uuid.version>

--- a/pom.xml
+++ b/pom.xml
@@ -138,7 +138,7 @@
         <shiro.version>1.3.2</shiro.version>
         <sigar.version>1.6.4</sigar.version>
         <slf4j.version>1.7.25</slf4j.version>
-        <swagger.version>1.5.12</swagger.version>
+        <swagger.version>1.5.13</swagger.version>
         <syslog4j.version>0.9.59</syslog4j.version>
         <uuid.version>3.2</uuid.version>
         <validation-api.version>1.1.0.Final</validation-api.version>


### PR DESCRIPTION
Regular dependency updates:

* Upgrade to Hibernate Validator 5.4.1.Final: http://in.relation.to/2017/03/23/hibernate-validator-541-final-out/
* Upgrade to Swagger Annotations 1.5.13
* Upgrade to RabbitMQ AMQP Client 4.1.0: https://github.com/rabbitmq/rabbitmq-java-client/releases/tag/v4.1.0
* Upgrade to Joda-Time 2.9.9:
  * http://www.joda.org/joda-time/changes-report.html#a2.9.8
  * http://www.joda.org/joda-time/changes-report.html#a2.9.9
* Upgrade to jBCrypt 0.4: http://www.mindrot.org/projects/jBCrypt/news/rel04.html
* Upgrade to Retrofit 2.2.0: https://github.com/square/retrofit/blob/bd8e38d406fff637ed69b1b312a8e439aa28b012/CHANGELOG.md#version-220-2017-02-21
* Upgrade to Log4j 2.8.1: https://logging.apache.org/log4j/2.x/changes-report.html#a2.8.1
* Upgrade to Dropwizard Metrics 3.2.2:
  * http://metrics.dropwizard.io/3.2.2/about/release-notes.html#v3-2-1-mar-10-2017
  * http://metrics.dropwizard.io/3.2.2/about/release-notes.html#v3-2-2-mar-20-2017
* Upgrade to SLF4J 1.7.25: https://www.slf4j.org/news.html
* Upgrade to Google Auto Value 1.4: https://github.com/google/auto/blob/55155e1f7252560b16d7235728c710bb8ce9ec26/value/CHANGES.md#13--14