### PR TITLE
Upgrade to Mockito 2.7.20

### DIFF
--- a/graylog2-server/src/test/java/org/graylog2/alarmcallbacks/HTTPAlarmCallbackTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/alarmcallbacks/HTTPAlarmCallbackTest.java
@@ -48,6 +48,7 @@ import org.mockito.junit.MockitoJUnit;
 import org.mockito.junit.MockitoRule;
 
 import java.io.IOException;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
@@ -151,15 +152,21 @@ public class HTTPAlarmCallbackTest {
         alarmCallback.initialize(configuration);
         alarmCallback.checkConfiguration();
 
-        final Stream stream = mock(Stream.class);
-        final AlertCondition alertCondition = mock(AlertCondition.class);
-        final List<MessageSummary> messageSummaries = ImmutableList.of();
+        final Stream stream = new StreamMock(Collections.singletonMap("_id", "stream-id"));
+        final AlertCondition alertCondition = new DummyAlertCondition(
+                stream,
+                "alert-id",
+                new DateTime(2017, 3, 29, 12, 0, DateTimeZone.UTC),
+                "user",
+                Collections.emptyMap(),
+                "title"
+        );
         final AlertCondition.CheckResult checkResult = new AbstractAlertCondition.CheckResult(
                 true,
                 alertCondition,
                 "Result Description",
                 new DateTime(2016, 9, 6, 17, 0, DateTimeZone.UTC),
-                messageSummaries
+                Collections.emptyList()
         );
 
         expectedException.expect(AlarmCallbackException.class);
@@ -178,15 +185,21 @@ public class HTTPAlarmCallbackTest {
         final Configuration configuration = new Configuration(ImmutableMap.of("url", "!FOOBAR"));
         alarmCallback.initialize(configuration);
 
-        final Stream stream = mock(Stream.class);
-        final AlertCondition alertCondition = mock(AlertCondition.class);
-        final List<MessageSummary> messageSummaries = ImmutableList.of();
+        final Stream stream = new StreamMock(Collections.singletonMap("_id", "stream-id"));
+        final AlertCondition alertCondition = new DummyAlertCondition(
+                stream,
+                "alert-id",
+                new DateTime(2017, 3, 29, 12, 0, DateTimeZone.UTC),
+                "user",
+                Collections.emptyMap(),
+                "title"
+        );
         final AlertCondition.CheckResult checkResult = new AbstractAlertCondition.CheckResult(
                 true,
                 alertCondition,
                 "Result Description",
                 new DateTime(2016, 9, 6, 17, 0, DateTimeZone.UTC),
-                messageSummaries
+                Collections.emptyList()
         );
 
         expectedException.expect(AlarmCallbackException.class);

--- a/graylog2-server/src/test/java/org/graylog2/streams/StreamMock.java
+++ b/graylog2-server/src/test/java/org/graylog2/streams/StreamMock.java
@@ -21,11 +21,19 @@ import com.google.common.base.MoreObjects;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
 import org.graylog2.indexer.IndexSet;
+import org.graylog2.indexer.TestIndexSet;
+import org.graylog2.indexer.indexset.IndexSetConfig;
+import org.graylog2.indexer.retention.strategies.NoopRetentionStrategy;
+import org.graylog2.indexer.retention.strategies.NoopRetentionStrategyConfig;
+import org.graylog2.indexer.rotation.strategies.MessageCountRotationStrategy;
+import org.graylog2.indexer.rotation.strategies.MessageCountRotationStrategyConfig;
 import org.graylog2.plugin.database.validators.Validator;
 import org.graylog2.plugin.streams.Output;
 import org.graylog2.plugin.streams.Stream;
 import org.graylog2.plugin.streams.StreamRule;
 
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -44,6 +52,7 @@ public class StreamMock implements Stream {
     private MatchingType matchingType;
     private boolean defaultStream;
     private boolean removeMatchesFromDefaultStream;
+    private IndexSet indexSet;
 
     public StreamMock(Map<String, Object> stream) {
         this(stream, Collections.emptyList());
@@ -61,6 +70,23 @@ public class StreamMock implements Stream {
         this.matchingType = (MatchingType) stream.getOrDefault(StreamImpl.FIELD_MATCHING_TYPE, MatchingType.AND);
         this.defaultStream = (boolean) stream.getOrDefault(StreamImpl.FIELD_DEFAULT_STREAM, false);
         this.removeMatchesFromDefaultStream = (boolean) stream.getOrDefault(StreamImpl.FIELD_REMOVE_MATCHES_FROM_DEFAULT_STREAM, false);
+        this.indexSet = new TestIndexSet(IndexSetConfig.create(
+                "index-set-id",
+                "title",
+                "description",
+                true,
+                "prefix",
+                1,
+                0,
+                MessageCountRotationStrategy.class.getCanonicalName(),
+                MessageCountRotationStrategyConfig.createDefault(),
+                NoopRetentionStrategy.class.getCanonicalName(),
+                NoopRetentionStrategyConfig.createDefault(),
+                ZonedDateTime.of(2017, 3, 29, 12, 0, 0, 0, ZoneOffset.UTC),
+                "standard",
+                "template",
+                1,
+                false));
     }
 
     @Override
@@ -222,7 +248,7 @@ public class StreamMock implements Stream {
 
     @Override
     public String getIndexSetId() {
-        return null;
+        return "index-set-id";
     }
 
     @Override
@@ -231,6 +257,6 @@ public class StreamMock implements Stream {
 
     @Override
     public IndexSet getIndexSet() {
-        return mock(IndexSet.class);
+        return indexSet;
     }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -154,7 +154,7 @@
         <fongo.version>2.0.12</fongo.version>
         <jukito.version>1.5</jukito.version>
         <junit.version>4.12</junit.version>
-        <mockito.version>2.3.10</mockito.version>
+        <mockito.version>2.7.20</mockito.version>
         <nosqlunit.version>0.10.0</nosqlunit.version>
         <restassured.version>2.9.0</restassured.version>
         <system-rules.version>1.16.1</system-rules.version>


### PR DESCRIPTION
Release notes: https://github.com/mockito/mockito/blob/9b98d71fa2444b0ebc35265d79458e5432cb5396/doc/release-notes/official.md#2720-2017-03-29-1723-utc

This changeset also fixes some issues with Jackson being unable to serialize
the mocked IndexSet used in 2 tests in HTTPAlarmCallbackTest.