### PR TITLE
Comply with grace condition when repeat alert notifications is enabled

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/alerts/AlertScanner.java
+++ b/graylog2-server/src/main/java/org/graylog2/alerts/AlertScanner.java
@@ -69,11 +69,12 @@ public class AlertScanner {
                     LOG.debug("Alert condition [{}] is triggered. Sending alerts.", alertCondition);
                     handleTriggeredAlert(result, stream, alertCondition);
                 } else {
+                    final Alert triggeredAlert = alert.get();
                     // There is already an alert for this condition and is unresolved
-                    if (alertCondition.shouldRepeatNotifications()) {
+                    if (alertService.shouldRepeatNotifications(alertCondition, triggeredAlert)) {
                         // Repeat notifications because user wants to do that
                         LOG.debug("Alert condition [{}] is triggered and configured to repeat alert notifications. Sending alerts.", alertCondition);
-                        handleRepeatedAlert(stream, alertCondition, result, alert.get());
+                        handleRepeatedAlert(stream, alertCondition, result, triggeredAlert);
                     } else {
                         LOG.debug("Alert condition [{}] is triggered but alerts were already sent. Nothing to do.", alertCondition);
                     }

--- a/graylog2-server/src/main/java/org/graylog2/alerts/AlertScanner.java
+++ b/graylog2-server/src/main/java/org/graylog2/alerts/AlertScanner.java
@@ -70,7 +70,7 @@ public class AlertScanner {
                     handleTriggeredAlert(result, stream, alertCondition);
                 } else {
                     // There is already an alert for this condition and is unresolved
-                    if (alert.isPresent() && alertCondition.shouldRepeatNotifications()) {
+                    if (alertCondition.shouldRepeatNotifications()) {
                         // Repeat notifications because user wants to do that
                         LOG.debug("Alert condition [{}] is triggered and configured to repeat alert notifications. Sending alerts.", alertCondition);
                         handleRepeatedAlert(stream, alertCondition, result, alert.get());

--- a/graylog2-server/src/main/java/org/graylog2/alerts/AlertService.java
+++ b/graylog2-server/src/main/java/org/graylog2/alerts/AlertService.java
@@ -47,6 +47,7 @@ public interface AlertService {
     AlertCondition updateFromRequest(AlertCondition alertCondition, CreateConditionRequest ccr) throws ConfigurationException;
 
     boolean inGracePeriod(AlertCondition alertCondition);
+    boolean shouldRepeatNotifications(AlertCondition alertCondition, Alert alert);
 
     List<Alert> listForStreamId(String streamId, int skip, int limit);
     List<Alert> listForStreamIds(List<String> streamIds, AlertState state, int skip, int limit);

--- a/graylog2-server/src/test/java/org/graylog2/alerts/AlertScannerTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/alerts/AlertScannerTest.java
@@ -158,6 +158,7 @@ public class AlertScannerTest {
 
         when(alertService.getLastTriggeredAlert(stream.getId(), alertCondition.getId())).thenReturn(Optional.of(alert));
         when(alertService.isResolved(alert)).thenReturn(false);
+        when(alertService.shouldRepeatNotifications(alertCondition, alert)).thenReturn(true);
         assertThat(this.alertScanner.checkAlertCondition(stream, alertCondition)).isTrue();
 
         verify(alertCondition, times(2)).runCheck();

--- a/graylog2-server/src/test/java/org/graylog2/alerts/AlertServiceImplTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/alerts/AlertServiceImplTest.java
@@ -299,12 +299,12 @@ public class AlertServiceImplTest extends MongoDBServiceTest {
         assertThat(alertService.shouldRepeatNotifications(alertCondition, alert)).isTrue();
 
         final AlarmCallbackHistory alarmCallbackHistory = mock(AlarmCallbackHistory.class);
-        when(alarmCallbackHistory.createdAt()).thenReturn(DateTime.now().minusMinutes(14));
+        when(alarmCallbackHistory.createdAt()).thenReturn(DateTime.now(DateTimeZone.UTC).minusMinutes(14));
         when(alarmCallbackHistoryService.getForAlertId(ALERT_ID)).thenReturn(ImmutableList.of(alarmCallbackHistory));
         // Should not repeat notification if a notification was sent during grace period
         assertThat(alertService.shouldRepeatNotifications(alertCondition, alert)).isFalse();
 
-        when(alarmCallbackHistory.createdAt()).thenReturn(DateTime.now().minusMinutes(15));
+        when(alarmCallbackHistory.createdAt()).thenReturn(DateTime.now(DateTimeZone.UTC).minusMinutes(15));
         when(alarmCallbackHistoryService.getForAlertId(ALERT_ID)).thenReturn(ImmutableList.of(alarmCallbackHistory));
         // Should repeat notification after grace period passed
         assertThat(alertService.shouldRepeatNotifications(alertCondition, alert)).isTrue();

--- a/graylog2-server/src/test/java/org/graylog2/alerts/AlertServiceImplTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/alerts/AlertServiceImplTest.java
@@ -20,8 +20,11 @@ package org.graylog2.alerts;
 import com.google.common.collect.ImmutableList;
 import com.lordofthejars.nosqlunit.annotation.UsingDataSet;
 import com.lordofthejars.nosqlunit.core.LoadStrategyEnum;
+import org.graylog2.alarmcallbacks.AlarmCallbackHistory;
+import org.graylog2.alarmcallbacks.AlarmCallbackHistoryService;
 import org.graylog2.database.MongoDBServiceTest;
 import org.graylog2.plugin.Tools;
+import org.graylog2.plugin.alarms.AlertCondition;
 import org.joda.time.DateTime;
 import org.joda.time.DateTimeZone;
 import org.joda.time.Seconds;
@@ -32,6 +35,8 @@ import org.mockito.Mock;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 public class AlertServiceImplTest extends MongoDBServiceTest {
     private final String ALERT_ID = "581b3bff8e4dc4270055dfca";
@@ -41,10 +46,13 @@ public class AlertServiceImplTest extends MongoDBServiceTest {
     private AlertServiceImpl alertService;
     @Mock
     private AlertConditionFactory alertConditionFactory;
+    @Mock
+    private AlarmCallbackHistoryService alarmCallbackHistoryService;
 
     @Before
     public void setUpService() throws Exception {
-        this.alertService = new AlertServiceImpl(mongoRule.getMongoConnection(), mapperProvider, alertConditionFactory);
+        this.alarmCallbackHistoryService = mock(AlarmCallbackHistoryService.class);
+        this.alertService = new AlertServiceImpl(mongoRule.getMongoConnection(), mapperProvider, alertConditionFactory, alarmCallbackHistoryService);
     }
 
     @Test
@@ -262,4 +270,52 @@ public class AlertServiceImplTest extends MongoDBServiceTest {
         assertThat(alertService.isResolved(alert)).isFalse();
     }
 
+    @Test
+    @UsingDataSet(locations = "non-interval-alert.json")
+    public void nonIntervalAlertShouldNotRepeatNotifications() throws Exception {
+        final AlertCondition alertCondition = mock(AlertCondition.class);
+        when(alertCondition.shouldRepeatNotifications()).thenReturn(true);
+        final Alert alert = alertService.load(ALERT_ID, STREAM_ID);
+        assertThat(alertService.shouldRepeatNotifications(alertCondition, alert)).isFalse();
+    }
+
+    @Test
+    @UsingDataSet(locations = "unresolved-alert.json")
+    public void shouldNotRepeatNotificationsWhenOptionIsDisabled() throws Exception {
+        final AlertCondition alertCondition = mock(AlertCondition.class);
+        when(alertCondition.shouldRepeatNotifications()).thenReturn(false);
+        final Alert alert = alertService.load(ALERT_ID, STREAM_ID);
+        assertThat(alertService.shouldRepeatNotifications(alertCondition, alert)).isFalse();
+    }
+
+    @Test
+    @UsingDataSet(locations = "unresolved-alert.json")
+    public void repeatNotificationsOptionShouldComplyWithGracePeriod() throws Exception {
+        final AlertCondition alertCondition = mock(AlertCondition.class);
+        when(alertCondition.getGrace()).thenReturn(15);
+        when(alertCondition.shouldRepeatNotifications()).thenReturn(true);
+        final Alert alert = alertService.load(ALERT_ID, STREAM_ID);
+        // Should repeat notification when there was no previous alert
+        assertThat(alertService.shouldRepeatNotifications(alertCondition, alert)).isTrue();
+
+        final AlarmCallbackHistory alarmCallbackHistory = mock(AlarmCallbackHistory.class);
+        when(alarmCallbackHistory.createdAt()).thenReturn(DateTime.now().minusMinutes(14));
+        when(alarmCallbackHistoryService.getForAlertId(ALERT_ID)).thenReturn(ImmutableList.of(alarmCallbackHistory));
+        // Should not repeat notification if a notification was sent during grace period
+        assertThat(alertService.shouldRepeatNotifications(alertCondition, alert)).isFalse();
+
+        when(alarmCallbackHistory.createdAt()).thenReturn(DateTime.now().minusMinutes(15));
+        when(alarmCallbackHistoryService.getForAlertId(ALERT_ID)).thenReturn(ImmutableList.of(alarmCallbackHistory));
+        // Should repeat notification after grace period passed
+        assertThat(alertService.shouldRepeatNotifications(alertCondition, alert)).isTrue();
+    }
+
+    @Test
+    @UsingDataSet(locations = "unresolved-alert.json")
+    public void shouldRepeatNotificationsWhenOptionIsEnabled() throws Exception {
+        final AlertCondition alertCondition = mock(AlertCondition.class);
+        when(alertCondition.shouldRepeatNotifications()).thenReturn(true);
+        final Alert alert = alertService.load(ALERT_ID, STREAM_ID);
+        assertThat(alertService.shouldRepeatNotifications(alertCondition, alert)).isTrue();
+    }
 }


### PR DESCRIPTION
On 2.2.2 we added the possibility to repeat alert notifications, allowing users to keep the old behaviour in their alerts while still having some features of the new stateful alerts.

Unfortunately this option was not taking into account the grace period, so users got notified way too many times, as explained in #3579.

This PR checks the alert history to see when was the last time notifications were send for the alert, and verify that the defined grace period has elapsed before notifying again.

I'm also adding some tests to ensure that all cases (or all I though of) are covered and we don't break any other case by mistake.

Fixes #3579.