### PR TITLE
Effectively change user permissions when listing inputs.

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/rest/resources/system/inputs/InputsResource.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/resources/system/inputs/InputsResource.java
@@ -104,7 +104,8 @@ public class InputsResource extends RestResource {
     @ApiOperation(value = "Get all inputs")
     public InputsList list() {
         final Set<InputSummary> inputs = inputService.all().stream()
-                .map(input -> getInputSummary(input))
+                .filter(input -> isPermitted(RestPermissions.INPUTS_READ, input.getId()))
+                .map(this::getInputSummary)
                 .collect(Collectors.toSet());
 
         return InputsList.create(inputs);


### PR DESCRIPTION
Before this change, all inputs were listed upon a `GET /system/inputs`,
regardless of the user's permission set.
This change puts a permission check back in place when listing all
system inputs.
