### PR TITLE
Restore removal of role permissions upon permissions update.

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/users/UserImpl.java
+++ b/graylog2-server/src/main/java/org/graylog2/users/UserImpl.java
@@ -180,7 +180,7 @@ public class UserImpl extends PersistedImpl implements User {
         final List<String> perms = Lists.newArrayList(permissions);
         // Do not store the dynamic user self edit permissions
         perms.removeAll(this.permissions.userSelfEditPermissions(getName()));
-        fields.put(PERMISSIONS, permissions);
+        fields.put(PERMISSIONS, perms);
     }
 
     @Override


### PR DESCRIPTION
In #2529, while fixing #2516, persisting self editing permissions of a user was reintroduced (fixed in
35c9325525ad18284411ebdbd50d2c62eaed6732 before). This happened due to the introduction of a temporary variable that was not used effctively.

After this change, LDAP permissions are not modified blindly but the permission set of a user still stays denormalized when modified and saved.
