### PR TITLE
Fix accidental imports of org.elasticsearch.common.Strings

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/audit/AuditActor.java
+++ b/graylog2-server/src/main/java/org/graylog2/audit/AuditActor.java
@@ -22,8 +22,8 @@ import org.graylog2.plugin.system.NodeId;
 
 import javax.annotation.Nonnull;
 
+import static com.google.common.base.Strings.isNullOrEmpty;
 import static java.util.Objects.requireNonNull;
-import static org.elasticsearch.common.Strings.isNullOrEmpty;
 
 @AutoValue
 @WithBeanGetter

--- a/graylog2-server/src/main/java/org/graylog2/audit/AuditEventType.java
+++ b/graylog2-server/src/main/java/org/graylog2/audit/AuditEventType.java
@@ -27,7 +27,7 @@ import org.graylog.autovalue.WithBeanGetter;
 import javax.annotation.Nonnull;
 import java.util.List;
 
-import static org.elasticsearch.common.Strings.isNullOrEmpty;
+import static com.google.common.base.Strings.isNullOrEmpty;
 
 /**
  * Represents an audit event with namespace, object and action.

--- a/graylog2-server/src/main/java/org/graylog2/rest/resources/streams/alerts/StreamAlertResource.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/resources/streams/alerts/StreamAlertResource.java
@@ -17,6 +17,7 @@
 package org.graylog2.rest.resources.streams.alerts;
 
 import com.codahale.metrics.annotation.Timed;
+import com.google.common.base.Strings;
 import com.google.common.base.Throwables;
 import com.google.common.cache.Cache;
 import com.google.common.cache.CacheBuilder;
@@ -28,7 +29,6 @@ import io.swagger.annotations.ApiResponse;
 import io.swagger.annotations.ApiResponses;
 import org.apache.commons.mail.EmailException;
 import org.apache.shiro.authz.annotation.RequiresAuthentication;
-import org.elasticsearch.common.Strings;
 import org.graylog2.alarmcallbacks.AlarmCallbackConfiguration;
 import org.graylog2.alarmcallbacks.AlarmCallbackConfigurationService;
 import org.graylog2.alarmcallbacks.AlarmCallbackFactory;


### PR DESCRIPTION
Some classes accidentally have been using `org.elasticsearch.common.Strings` instead of Guava's `com.google.common.base.Strings` class.

This PR replaces the imports with the correct versions.