### PR TITLE
Revert "Dependency updates (#3672)"

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -88,9 +88,9 @@
 
         <!-- Dependencies -->
         <airline.version>2.2.0</airline.version>
-        <amqp-client.version>4.1.0</amqp-client.version>
+        <amqp-client.version>4.0.2</amqp-client.version>
         <apache-directory-version>1.0.0-RC2</apache-directory-version>
-        <auto-value.version>1.4</auto-value.version>
+        <auto-value.version>1.3</auto-value.version>
         <auto-value-extension-util.version>0.3.0</auto-value-extension-util.version>
         <commons-codec.version>1.10</commons-codec.version>
         <commons-email.version>1.4</commons-email.version>
@@ -104,7 +104,7 @@
         <guava.version>21.0</guava.version>
         <guice.version>4.1.0</guice.version>
         <HdrHistogram.version>2.1.9</HdrHistogram.version>
-        <hibernate-validator.version>5.4.1.Final</hibernate-validator.version>
+        <hibernate-validator.version>5.4.0.Final</hibernate-validator.version>
         <hk2.version>2.5.0-b32</hk2.version> <!-- The HK2 version should match the version being used by Jersey -->
         <jackson.version>2.8.7</jackson.version>
         <jadconfig.version>0.13.0</jadconfig.version>
@@ -114,16 +114,16 @@
         <javax.el-api.version>3.0.0</javax.el-api.version>
         <javax.inject.version>1</javax.inject.version>
         <javax.ws.rs-api.version>2.0.1</javax.ws.rs-api.version>
-        <jbcrypt.version>0.4</jbcrypt.version>
+        <jbcrypt.version>0.3m</jbcrypt.version>
         <jersey.version>2.25.1</jersey.version>
         <jmte.version>3.2.0</jmte.version>
         <jna.version>4.1.0</jna.version> <!-- for ES, make sure to use the version that ES uses -->
-        <joda-time.version>2.9.9</joda-time.version>
+        <joda-time.version>2.9.7</joda-time.version>
         <json-path.version>2.2.0</json-path.version>
         <jsr305.version>3.0.1</jsr305.version>
         <kafka.version>0.9.0.1</kafka.version>
-        <log4j.version>2.8.1</log4j.version>
-        <metrics.version>3.2.2</metrics.version>
+        <log4j.version>2.8</log4j.version>
+        <metrics.version>3.2.0</metrics.version>
         <mongodb-driver.version>3.4.2</mongodb-driver.version>
         <mongojack.version>2.6.1</mongojack.version>
         <natty.version>0.13</natty.version>
@@ -133,12 +133,12 @@
         <os-platform-finder.version>1.2.2</os-platform-finder.version>
         <protobuf.version>3.2.0</protobuf.version>
         <reflections.version>0.9.10</reflections.version>
-        <retrofit.version>2.2.0</retrofit.version>
+        <retrofit.version>2.1.0</retrofit.version>
         <scala.version>2.11.8</scala.version>
         <shiro.version>1.3.2</shiro.version>
         <sigar.version>1.6.4</sigar.version>
-        <slf4j.version>1.7.25</slf4j.version>
-        <swagger.version>1.5.13</swagger.version>
+        <slf4j.version>1.7.24</slf4j.version>
+        <swagger.version>1.5.12</swagger.version>
         <syslog4j.version>0.9.59</syslog4j.version>
         <uuid.version>3.2</uuid.version>
         <validation-api.version>1.1.0.Final</validation-api.version>


### PR DESCRIPTION
The update of auto-value from 1.4 introduced a breaking change that
disallows properties being nullable if a method exists, which returns a
builder for those. This breaks some existing plugin code which needs to
be fixed first.

This reverts commit 2a82ece7ed99d0a6fbc6894a69e12936e364f251.
