### PR TITLE
Invalidate dashboards data after logout

### DIFF
--- a/graylog2-web-interface/src/stores/dashboards/DashboardsStore.ts
+++ b/graylog2-web-interface/src/stores/dashboards/DashboardsStore.ts
@@ -13,6 +13,7 @@ const PermissionsMixin = require('util/PermissionsMixin');
 
 const StoreProvider = require('injection/StoreProvider');
 const CurrentUserStore = StoreProvider.getStore('CurrentUser');
+const SessionStore = StoreProvider.getStore('Session');
 
 interface Dashboard {
   id: string;
@@ -28,8 +29,19 @@ class DashboardsStore {
   private _onDashboardsChanged: {(dashboards: Immutable.List<Dashboard>): void; }[] = [];
 
   constructor() {
+    this._initializeDashboards();
+    SessionStore.listen(this.onSessionChange, this);
+  }
+
+  _initializeDashboards() {
     this._dashboards = Immutable.List<Dashboard>();
     this._writableDashboards = Immutable.Map<string, Dashboard>();
+  }
+
+  onSessionChange() {
+    if (!SessionStore.isLoggedIn()) {
+      this._initializeDashboards();
+    }
   }
 
   get dashboards(): Immutable.List<Dashboard> {


### PR DESCRIPTION
Listen to `SessionStore` events to ensure we reset the dashboards after a
logout, so users are not able to see data from previous sessions.

Fixes #3693