### PR TITLE
Add id to edit user button

### DIFF
--- a/graylog2-web-interface/src/components/users/UserList.jsx
+++ b/graylog2-web-interface/src/components/users/UserList.jsx
@@ -127,7 +127,7 @@ const UserList = React.createClass({
 
       const editAction = (
         <LinkContainer to={Routes.SYSTEM.AUTHENTICATION.USERS.edit(encodeURIComponent(user.username))}>
-          <Button bsStyle="info" bsSize="xs" title={`Edit user ${user.username}`}>
+          <Button id={`edit-user-${user.username}`} bsStyle="info" bsSize="xs" title={`Edit user ${user.username}`}>
             Edit
           </Button>
         </LinkContainer>


### PR DESCRIPTION
Add an ID to edit user button, to make it work in the same way as the delete button. That would help to make the browser tests more consistent and simple.