### PR TITLE
Better timerange for Show Received Messages button

### DIFF
--- a/graylog2-web-interface/src/components/inputs/InputListItem.jsx
+++ b/graylog2-web-interface/src/components/inputs/InputListItem.jsx
@@ -60,7 +60,7 @@ const InputListItem = React.createClass({
     if (this.isPermitted(this.props.permissions, ['searches:relative'])) {
       actions.push(
         <LinkContainer key={`received-messages-${this.props.input.id}`}
-                       to={Routes.search(`gl2_source_input:${this.props.input.id}`, { relative: 28800 })}>
+                       to={Routes.search(`gl2_source_input:${this.props.input.id}`, { relative: 0 })}>
           <Button bsStyle="info">Show received messages</Button>
         </LinkContainer>,
       );


### PR DESCRIPTION
The old behaviour was to link to a search that only looked at the last 8 hours of data. I've come across a whole bunch of users who had messages with wrong timestamps and would only find them when searching in "All messages". This change makes the button link to a search over "All messages" instead, so users with timestamps in the past can find the messages and identify the issue.