### PR TITLE
Dependency updates

### DIFF
--- a/auto-value-javabean/pom.xml
+++ b/auto-value-javabean/pom.xml
@@ -1,10 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
-    <prerequisites>
-        <maven>3.1.0</maven>
-    </prerequisites>
-
     <parent>
         <groupId>org.graylog</groupId>
         <artifactId>graylog-project-parent</artifactId>

--- a/graylog-plugin-archetype/pom.xml
+++ b/graylog-plugin-archetype/pom.xml
@@ -19,10 +19,6 @@
   -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
-    <prerequisites>
-        <maven>3.0.0</maven>
-    </prerequisites>
-
     <parent>
         <groupId>org.graylog</groupId>
         <artifactId>graylog-project-parent</artifactId>

--- a/graylog-plugin-archetype/src/main/resources/archetype-resources/pom.xml
+++ b/graylog-plugin-archetype/src/main/resources/archetype-resources/pom.xml
@@ -3,10 +3,6 @@
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
-    <prerequisites>
-        <maven>3.1</maven>
-    </prerequisites>
-
     <groupId>${groupId}</groupId>
     <artifactId>${artifactId}</artifactId>
     <version>${version}</version>

--- a/graylog-plugin-parent/graylog-plugin-web-parent/pom.xml
+++ b/graylog-plugin-parent/graylog-plugin-web-parent/pom.xml
@@ -19,10 +19,6 @@
   -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
-    <prerequisites>
-        <maven>3.1.0</maven>
-    </prerequisites>
-
     <parent>
         <groupId>org.graylog.plugins</groupId>
         <artifactId>graylog-plugin-parent</artifactId>

--- a/graylog-plugin-parent/pom.xml
+++ b/graylog-plugin-parent/pom.xml
@@ -19,10 +19,6 @@
   -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
-    <prerequisites>
-        <maven>3.1.0</maven>
-    </prerequisites>
-
     <modules>
         <module>graylog-plugin-web-parent</module>
     </modules>

--- a/graylog-project-parent/pom.xml
+++ b/graylog-project-parent/pom.xml
@@ -19,10 +19,6 @@
   -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
-    <prerequisites>
-        <maven>3.1.0</maven>
-    </prerequisites>
-
     <modules>
         <module>../auto-value-javabean</module>
         <module>../graylog2-server</module>

--- a/graylog2-server/pom.xml
+++ b/graylog2-server/pom.xml
@@ -19,10 +19,6 @@
   -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
-    <prerequisites>
-        <maven>3.1.0</maven>
-    </prerequisites>
-
     <parent>
         <groupId>org.graylog</groupId>
         <artifactId>graylog-project-parent</artifactId>

--- a/graylog2-server/src/main/java/org/graylog2/inputs/InputStateListener.java
+++ b/graylog2-server/src/main/java/org/graylog2/inputs/InputStateListener.java
@@ -64,6 +64,7 @@ public class InputStateListener {
                 break;
             case RUNNING:
                 notificationService.fixed(Notification.Type.NO_INPUT_RUNNING);
+                // fall through
             default:
                 final String msg = "Input [" + input.getName() + "/" + input.getId() + "] is now " + event.newState().toString();
                 activityWriter.write(new Activity(msg, InputStateListener.class));

--- a/graylog2-server/src/main/java/org/graylog2/inputs/converters/HashConverter.java
+++ b/graylog2-server/src/main/java/org/graylog2/inputs/converters/HashConverter.java
@@ -16,7 +16,6 @@
  */
 package org.graylog2.inputs.converters;
 
-import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import org.apache.commons.codec.digest.DigestUtils;
 import org.graylog2.plugin.inputs.Converter;
 
@@ -28,7 +27,7 @@ public class HashConverter extends Converter {
         super(Type.HASH, config);
     }
 
-    @SuppressFBWarnings("WEAK_MESSAGE_DIGEST_MD5")
+    @SuppressWarnings("WEAK_MESSAGE_DIGEST_MD5")
     @Override
     public Object convert(String value) {
         if (value == null || value.isEmpty()) {

--- a/graylog2-server/src/main/java/org/graylog2/rest/resources/system/logs/LoggersResource.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/resources/system/logs/LoggersResource.java
@@ -240,7 +240,7 @@ public class LoggersResource extends RestResource {
             if (thrownProxy == null) {
                 throwable = null;
             } else {
-                throwable = thrownProxy.getExtendedStackTraceAsString();
+                throwable = thrownProxy.getExtendedStackTraceAsString("");
             }
 
             final Marker marker = event.getMarker();

--- a/graylog2-server/src/main/java/org/graylog2/security/AESTools.java
+++ b/graylog2-server/src/main/java/org/graylog2/security/AESTools.java
@@ -16,7 +16,6 @@
  */
 package org.graylog2.security;
 
-import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import org.apache.shiro.codec.Hex;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -32,7 +31,7 @@ public class AESTools {
     @Nullable
     public static String encrypt(String plainText, String encryptionKey, String salt) {
         try {
-            @SuppressFBWarnings("CIPHER_INTEGRITY")
+            @SuppressWarnings("CIPHER_INTEGRITY")
             Cipher cipher = Cipher.getInstance("AES/CBC/ISO10126Padding", "SunJCE");
             SecretKeySpec key = new SecretKeySpec(encryptionKey.getBytes("UTF-8"), "AES");
             cipher.init(Cipher.ENCRYPT_MODE, key, new IvParameterSpec(salt.getBytes("UTF-8")));
@@ -46,7 +45,7 @@ public class AESTools {
     @Nullable
     public static String decrypt(String cipherText, String encryptionKey, String salt) {
         try {
-            @SuppressFBWarnings("CIPHER_INTEGRITY")
+            @SuppressWarnings("CIPHER_INTEGRITY")
             Cipher cipher = Cipher.getInstance("AES/CBC/ISO10126Padding", "SunJCE");
             SecretKeySpec key = new SecretKeySpec(encryptionKey.getBytes("UTF-8"), "AES");
             cipher.init(Cipher.DECRYPT_MODE, key, new IvParameterSpec(salt.getBytes("UTF-8")));

--- a/graylog2-server/src/test/java/org/graylog2/alerts/types/FieldValueAlertConditionTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/alerts/types/FieldValueAlertConditionTest.java
@@ -172,14 +172,19 @@ public class FieldValueAlertConditionTest extends AlertConditionTest {
         switch (type) {
             case MIN:
                 when(fieldStatsResult.getMin()).thenReturn(value);
+                break;
             case MAX:
                 when(fieldStatsResult.getMax()).thenReturn(value);
+                break;
             case MEAN:
                 when(fieldStatsResult.getMean()).thenReturn(value);
+                break;
             case STDDEV:
                 when(fieldStatsResult.getStdDeviation()).thenReturn(value);
+                break;
             case SUM:
                 when(fieldStatsResult.getSum()).thenReturn(value);
+                break;
         }
         return fieldStatsResult;
     }

--- a/integration-tests/pom.xml
+++ b/integration-tests/pom.xml
@@ -19,10 +19,6 @@
   -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
-    <prerequisites>
-        <maven>3.1.0</maven>
-    </prerequisites>
-
     <parent>
         <groupId>org.graylog</groupId>
         <artifactId>graylog-project-parent</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -90,7 +90,7 @@
         <airline.version>2.2.0</airline.version>
         <amqp-client.version>4.1.0</amqp-client.version>
         <apache-directory-version>1.0.0-RC2</apache-directory-version>
-        <auto-value.version>1.4</auto-value.version>
+        <auto-value.version>1.4.1</auto-value.version>
         <auto-value-extension-util.version>0.3.0</auto-value-extension-util.version>
         <commons-codec.version>1.10</commons-codec.version>
         <commons-email.version>1.4</commons-email.version>

--- a/pom.xml
+++ b/pom.xml
@@ -106,7 +106,7 @@
         <HdrHistogram.version>2.1.9</HdrHistogram.version>
         <hibernate-validator.version>5.4.1.Final</hibernate-validator.version>
         <hk2.version>2.5.0-b32</hk2.version> <!-- The HK2 version should match the version being used by Jersey -->
-        <jackson.version>2.8.7</jackson.version>
+        <jackson.version>2.8.8</jackson.version>
         <jadconfig.version>0.13.0</jadconfig.version>
         <java-semver.version>0.9.0</java-semver.version>
         <javapoet.version>1.8.0</javapoet.version>

--- a/pom.xml
+++ b/pom.xml
@@ -286,7 +286,7 @@
                 <plugin>
                     <groupId>com.github.eirslett</groupId>
                     <artifactId>frontend-maven-plugin</artifactId>
-                    <version>1.3</version>
+                    <version>1.4</version>
                 </plugin>
             </plugins>
         </pluginManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -154,7 +154,7 @@
         <fongo.version>2.0.12</fongo.version>
         <jukito.version>1.5</jukito.version>
         <junit.version>4.12</junit.version>
-        <mockito.version>2.7.20</mockito.version>
+        <mockito.version>2.7.22</mockito.version>
         <nosqlunit.version>0.10.0</nosqlunit.version>
         <restassured.version>2.9.0</restassured.version>
         <system-rules.version>1.16.1</system-rules.version>

--- a/pom.xml
+++ b/pom.xml
@@ -151,7 +151,7 @@
         <assertj-joda-time.version>2.0.0</assertj-joda-time.version>
         <awaitility.version>1.7.0</awaitility.version>
         <equalsverifier.version>2.2.2</equalsverifier.version>
-        <fongo.version>2.0.12</fongo.version>
+        <fongo.version>2.0.13</fongo.version>
         <jukito.version>1.5</jukito.version>
         <junit.version>4.12</junit.version>
         <mockito.version>2.7.22</mockito.version>

--- a/pom.xml
+++ b/pom.xml
@@ -125,7 +125,7 @@
         <log4j.version>2.8.2</log4j.version>
         <metrics.version>3.2.2</metrics.version>
         <mongodb-driver.version>3.4.2</mongodb-driver.version>
-        <mongojack.version>2.6.1</mongojack.version>
+        <mongojack.version>2.7.0</mongojack.version>
         <natty.version>0.13</natty.version>
         <netty.version>3.10.6.Final</netty.version>
         <okhttp.version>3.7.0</okhttp.version>

--- a/pom.xml
+++ b/pom.xml
@@ -150,7 +150,7 @@
         <assertj-core.version>3.6.2</assertj-core.version>
         <assertj-joda-time.version>2.0.0</assertj-joda-time.version>
         <awaitility.version>1.7.0</awaitility.version>
-        <equalsverifier.version>2.2.1</equalsverifier.version>
+        <equalsverifier.version>2.2.2</equalsverifier.version>
         <fongo.version>2.0.12</fongo.version>
         <jukito.version>1.5</jukito.version>
         <junit.version>4.12</junit.version>

--- a/pom.xml
+++ b/pom.xml
@@ -281,7 +281,7 @@
                 <plugin>
                     <groupId>de.thetaphi</groupId>
                     <artifactId>forbiddenapis</artifactId>
-                    <version>2.2</version>
+                    <version>2.3</version>
                 </plugin>
                 <plugin>
                     <groupId>com.github.eirslett</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -128,7 +128,7 @@
         <mongojack.version>2.6.1</mongojack.version>
         <natty.version>0.13</natty.version>
         <netty.version>3.10.6.Final</netty.version>
-        <okhttp.version>3.6.0</okhttp.version>
+        <okhttp.version>3.7.0</okhttp.version>
         <opencsv.version>2.3</opencsv.version>
         <os-platform-finder.version>1.2.2</os-platform-finder.version>
         <protobuf.version>3.2.0</protobuf.version>

--- a/pom.xml
+++ b/pom.xml
@@ -316,7 +316,7 @@
                     <dependency>
                         <groupId>com.google.errorprone</groupId>
                         <artifactId>error_prone_core</artifactId>
-                        <version>2.0.15</version>
+                        <version>2.0.19</version>
                     </dependency>
                 </dependencies>
             </plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -122,7 +122,7 @@
         <json-path.version>2.2.0</json-path.version>
         <jsr305.version>3.0.1</jsr305.version>
         <kafka.version>0.9.0.1</kafka.version>
-        <log4j.version>2.8.1</log4j.version>
+        <log4j.version>2.8.2</log4j.version>
         <metrics.version>3.2.2</metrics.version>
         <mongodb-driver.version>3.4.2</mongodb-driver.version>
         <mongojack.version>2.6.1</mongojack.version>

--- a/pom.xml
+++ b/pom.xml
@@ -19,10 +19,6 @@
   -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
-    <prerequisites>
-        <maven>3.1.0</maven>
-    </prerequisites>
-
     <modules>
         <module>graylog-project-parent</module>
         <module>graylog-plugin-parent</module>

--- a/pom.xml
+++ b/pom.xml
@@ -87,7 +87,7 @@
         <maven.compiler.useIncrementalCompilation>false</maven.compiler.useIncrementalCompilation>
 
         <!-- Dependencies -->
-        <airline.version>2.2.0</airline.version>
+        <airline.version>2.3.0</airline.version>
         <amqp-client.version>4.1.0</amqp-client.version>
         <apache-directory-version>1.0.0-RC2</apache-directory-version>
         <auto-value.version>1.4.1</auto-value.version>

--- a/pom.xml
+++ b/pom.xml
@@ -132,7 +132,7 @@
         <opencsv.version>2.3</opencsv.version>
         <os-platform-finder.version>1.2.2</os-platform-finder.version>
         <protobuf.version>3.2.0</protobuf.version>
-        <reflections.version>0.9.10</reflections.version>
+        <reflections.version>0.9.11</reflections.version>
         <retrofit.version>2.2.0</retrofit.version>
         <scala.version>2.11.8</scala.version>
         <shiro.version>1.3.2</shiro.version>

--- a/pom.xml
+++ b/pom.xml
@@ -120,7 +120,7 @@
         <jna.version>4.1.0</jna.version> <!-- for ES, make sure to use the version that ES uses -->
         <joda-time.version>2.9.9</joda-time.version>
         <json-path.version>2.2.0</json-path.version>
-        <jsr305.version>3.0.1</jsr305.version>
+        <jsr305.version>3.0.2</jsr305.version>
         <kafka.version>0.9.0.1</kafka.version>
         <log4j.version>2.8.2</log4j.version>
         <metrics.version>3.2.2</metrics.version>


### PR DESCRIPTION
* Upgrade to Jackson 2.8.8: https://github.com/FasterXML/jackson/wiki/Jackson-Release-2.8.8
* Upgrade to Log4j 2.8.2: https://logging.apache.org/log4j/2.x/changes-report.html#a2.8.2
* Upgrade to Reflections 0.9.11
* Upgrade to OkHttp 3.7.0: https://github.com/square/okhttp/blob/master/CHANGELOG.md#version-370
* Upgrade to AutoValue 1.4.1: https://github.com/google/auto/releases/tag/auto-value-1.4.1
* Upgrade to Airline 2.3.0: https://github.com/rvesse/airline/blob/master/CHANGELOG.md#230
* Upgrade to MongoJack 2.7.0: https://github.com/mongojack/mongojack/compare/mongojack-2.6.1...mongojack-2.7.0
* Upgrade to FindBugs JSR-305 annotations 3.0.2
* Upgrade to Mockito 2.7.22
* Upgrade to EqualsVerifier 2.2.2: http://jqno.nl/equalsverifier/changelog/#2.x
* Upgrade to Fongo 2.0.13
* Upgrade to Forbidden APIs 2.3
* Upgrade to Error Prone 2.0.19
* Upgrade to frontend-maven-plugin 1.4: https://github.com/eirslett/frontend-maven-plugin/blob/master/CHANGELOG.md#14
* Remove `<prerequisites>` section from POMs: https://maven.apache.org/docs/3.5.0/release-notes.html