### PR TITLE
Lookup now returns a LookupResult instead of Object

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/lookup/LookupTable.java
+++ b/graylog2-server/src/main/java/org/graylog2/lookup/LookupTable.java
@@ -17,10 +17,10 @@
 package org.graylog2.lookup;
 
 import com.google.auto.value.AutoValue;
-
 import org.graylog.autovalue.WithBeanGetter;
 import org.graylog2.plugin.lookup.LookupCache;
 import org.graylog2.plugin.lookup.LookupDataAdapter;
+import org.graylog2.plugin.lookup.LookupResult;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
@@ -47,7 +47,7 @@ public abstract class LookupTable {
     }
 
     @Nullable
-    public Object lookup(@Nonnull Object key) {
+    public LookupResult lookup(@Nonnull Object key) {
         return cache().get(key);
     }
 

--- a/graylog2-server/src/main/java/org/graylog2/lookup/LookupTableService.java
+++ b/graylog2-server/src/main/java/org/graylog2/lookup/LookupTableService.java
@@ -28,6 +28,7 @@ import org.graylog2.lookup.events.LookupTablesDeleted;
 import org.graylog2.lookup.events.LookupTablesUpdated;
 import org.graylog2.plugin.lookup.LookupCache;
 import org.graylog2.plugin.lookup.LookupDataAdapter;
+import org.graylog2.plugin.lookup.LookupResult;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -261,18 +262,21 @@ public class LookupTableService {
         }
 
         @Nullable
-        public Object lookup(@Nonnull Object key) {
+        public LookupResult lookup(@Nonnull Object key) {
             if (lookupTable == null) {
-                return defaultValue;
+                return LookupResult.single(key, defaultValue);
             }
 
-            final Object value = lookupTable.lookup(key);
+            final LookupResult result = lookupTable.lookup(key);
 
-            if (value == null) {
-                return defaultValue;
+            if (result == null || result.isEmpty()) {
+                if (defaultValue == null) {
+                    return LookupResult.empty();
+                }
+                return LookupResult.single(key, defaultValue);
             }
 
-            return value;
+            return result;
         }
     }
 }

--- a/graylog2-server/src/main/java/org/graylog2/lookup/adapters/RandomDataAdapter.java
+++ b/graylog2-server/src/main/java/org/graylog2/lookup/adapters/RandomDataAdapter.java
@@ -16,18 +16,17 @@
  */
 package org.graylog2.lookup.adapters;
 
-import com.google.auto.value.AutoValue;
-import com.google.inject.Inject;
-import com.google.inject.assistedinject.Assisted;
-
 import com.fasterxml.jackson.annotation.JsonAutoDetect;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
-
+import com.google.auto.value.AutoValue;
+import com.google.inject.Inject;
+import com.google.inject.assistedinject.Assisted;
 import org.graylog.autovalue.WithBeanGetter;
 import org.graylog2.plugin.lookup.LookupDataAdapter;
 import org.graylog2.plugin.lookup.LookupDataAdapterConfiguration;
+import org.graylog2.plugin.lookup.LookupResult;
 
 import java.security.SecureRandom;
 
@@ -45,8 +44,8 @@ public class RandomDataAdapter extends LookupDataAdapter {
     }
 
     @Override
-    public Object get(Object key) {
-        return secureRandom.ints(config.lowerBound(), config.upperBound()).findAny().getAsInt();
+    public LookupResult get(Object key) {
+        return LookupResult.single(key, secureRandom.ints(config.lowerBound(), config.upperBound()).findAny().orElse(0));
     }
 
     @Override

--- a/graylog2-server/src/main/java/org/graylog2/lookup/caches/NullCache.java
+++ b/graylog2-server/src/main/java/org/graylog2/lookup/caches/NullCache.java
@@ -16,20 +16,17 @@
  */
 package org.graylog2.lookup.caches;
 
-import com.google.auto.value.AutoValue;
-import com.google.inject.Inject;
-import com.google.inject.assistedinject.Assisted;
-
 import com.fasterxml.jackson.annotation.JsonAutoDetect;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
-
+import com.google.auto.value.AutoValue;
+import com.google.inject.Inject;
+import com.google.inject.assistedinject.Assisted;
 import org.graylog.autovalue.WithBeanGetter;
 import org.graylog2.plugin.lookup.LookupCache;
 import org.graylog2.plugin.lookup.LookupCacheConfiguration;
-
-import javax.annotation.Nullable;
+import org.graylog2.plugin.lookup.LookupResult;
 
 /**
  * The cache that doesn't. Used in place when no cache is wanted, having a null implementation saves us ugly null checks.
@@ -43,9 +40,8 @@ public class NullCache extends LookupCache {
         super(c);
     }
 
-    @Nullable
     @Override
-    public Object get(Object key) {
+    public LookupResult get(Object key) {
         return getDataAdapter().get(key);
     }
 

--- a/graylog2-server/src/main/java/org/graylog2/plugin/lookup/LookupCache.java
+++ b/graylog2-server/src/main/java/org/graylog2/plugin/lookup/LookupCache.java
@@ -63,8 +63,7 @@ public abstract class LookupCache {
         this.dataAdapter = dataAdapter;
     }
 
-    @Nullable
-    public abstract Object get(Object key);
+    public abstract LookupResult get(Object key);
 
     public abstract void set(Object key, Object retrievedValue);
 

--- a/graylog2-server/src/main/java/org/graylog2/plugin/lookup/LookupDataAdapter.java
+++ b/graylog2-server/src/main/java/org/graylog2/plugin/lookup/LookupDataAdapter.java
@@ -52,7 +52,7 @@ public abstract class LookupDataAdapter {
         this.lookupTable = lookupTable;
     }
 
-    public abstract Object get(Object key);
+    public abstract LookupResult get(Object key);
 
     public abstract void set(Object key, Object value);
 

--- a/graylog2-server/src/main/java/org/graylog2/plugin/lookup/LookupResult.java
+++ b/graylog2-server/src/main/java/org/graylog2/plugin/lookup/LookupResult.java
@@ -1,0 +1,66 @@
+/**
+ * This file is part of Graylog.
+ *
+ * Graylog is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.graylog2.plugin.lookup;
+
+import javax.annotation.Nullable;
+import java.util.Collections;
+import java.util.Map;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+public class LookupResult {
+    private static final LookupResult EMPTY_LOOKUP_RESULT = new LookupResult(Collections.emptyMap());
+
+    private final Map<Object, Object> values;
+    private final long cacheTTL;
+    private final boolean isEmpty;
+
+    public static LookupResult empty() {
+        return EMPTY_LOOKUP_RESULT;
+    }
+
+    public static LookupResult single(final Object key, final Object value) {
+        return new LookupResult(Collections.singletonMap(key, value));
+    }
+
+    public LookupResult(final Map<Object, Object> values) {
+        this(values, Long.MAX_VALUE);
+    }
+
+    public LookupResult(final Map<Object, Object> values, final long cacheTTL) {
+        this.values = checkNotNull(values);
+        this.isEmpty = values.size() == 0;
+        this.cacheTTL = cacheTTL;
+    }
+
+    public boolean isEmpty() {
+        return isEmpty;
+    }
+
+    public long cacheTTL() {
+        return cacheTTL;
+    }
+
+    @Nullable
+    public Object get(final Object key) {
+        return values.get(key);
+    }
+
+    public Map<Object, Object> asMap() {
+        return values;
+    }
+}


### PR DESCRIPTION
The LookupResult contains a map so it can hold multiple values for the key lookup. It also provides a cache-ttl value to allow custom expiration for individual results.

See https://github.com/Graylog2/graylog-plugin-pipeline-processor/pull/176 for the pipeline function changes.