### PR TITLE
Add Sort Order Support to /terms API Request

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/indexer/searches/Sorting.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/searches/Sorting.java
@@ -48,6 +48,8 @@ public class Sorting {
         return SortOrder.valueOf(direction.toString().toUpperCase(Locale.ENGLISH));
     }
 
+    public Direction getDirection() { return this.direction; }
+
     public static Sorting fromApiParam(String param) {
         if (param == null || !param.contains(":")) {
             throw new IllegalArgumentException("Invalid sorting parameter: " + param);

--- a/graylog2-server/src/main/java/org/graylog2/rest/resources/search/RelativeSearchResource.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/resources/search/RelativeSearchResource.java
@@ -188,11 +188,14 @@ public class RelativeSearchResource extends SearchResource {
             @QueryParam("query") @NotEmpty String query,
             @ApiParam(name = "size", value = "Maximum number of terms to return", required = false) @QueryParam("size") int size,
             @ApiParam(name = "range", value = "Relative timeframe to search in. See search method description.", required = true) @QueryParam("range") int range,
-            @ApiParam(name = "filter", value = "Filter", required = false) @QueryParam("filter") String filter) {
+            @ApiParam(name = "filter", value = "Filter", required = false) @QueryParam("filter") String filter,
+            @ApiParam(name = "order", value = "Sorting (field:asc / field:desc)", required = false) @QueryParam("order") String order) {
         checkSearchPermission(filter, RestPermissions.SEARCHES_RELATIVE);
 
+        final Sorting.Direction sortOrder = (order.equals("asc")) ? Sorting.Direction.ASC : Sorting.Direction.DESC;
+
         try {
-            return buildTermsResult(searches.terms(field, size, query, filter, buildRelativeTimeRange(range)));
+            return buildTermsResult(searches.terms(field, size, query, filter, buildRelativeTimeRange(range), sortOrder));
         } catch (SearchPhaseExecutionException e) {
             throw createRequestExceptionForParseFailure(query, e);
         }

--- a/graylog2-server/src/main/java/org/graylog2/rest/resources/search/RelativeSearchResource.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/resources/search/RelativeSearchResource.java
@@ -45,6 +45,8 @@ import org.hibernate.validator.constraints.NotEmpty;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import static com.google.common.base.Strings.isNullOrEmpty;
+
 import javax.inject.Inject;
 import javax.ws.rs.BadRequestException;
 import javax.ws.rs.DefaultValue;
@@ -192,7 +194,13 @@ public class RelativeSearchResource extends SearchResource {
             @ApiParam(name = "order", value = "Sorting (field:asc / field:desc)", required = false) @QueryParam("order") String order) {
         checkSearchPermission(filter, RestPermissions.SEARCHES_RELATIVE);
 
-        final Sorting.Direction sortOrder = (order.equals("asc")) ? Sorting.Direction.ASC : Sorting.Direction.DESC;
+        final Sorting.Direction sortOrder;
+
+        if (isNullOrEmpty(order)) {
+            sortOrder = Sorting.Direction.DESC;
+        } else {
+            sortOrder = (order.equals("asc")) ? Sorting.Direction.ASC : Sorting.Direction.DESC;
+        }
 
         try {
             return buildTermsResult(searches.terms(field, size, query, filter, buildRelativeTimeRange(range), sortOrder));

--- a/graylog2-server/src/main/java/org/graylog2/rest/resources/search/RelativeSearchResource.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/resources/search/RelativeSearchResource.java
@@ -194,13 +194,7 @@ public class RelativeSearchResource extends SearchResource {
             @ApiParam(name = "order", value = "Sorting (field:asc / field:desc)", required = false) @QueryParam("order") String order) {
         checkSearchPermission(filter, RestPermissions.SEARCHES_RELATIVE);
 
-        final Sorting.Direction sortOrder;
-
-        if (isNullOrEmpty(order)) {
-            sortOrder = Sorting.Direction.DESC;
-        } else {
-            sortOrder = (order.equals("asc")) ? Sorting.Direction.ASC : Sorting.Direction.DESC;
-        }
+        final Sorting.Direction sortOrder = buildSorting(order).getDirection();
 
         try {
             return buildTermsResult(searches.terms(field, size, query, filter, buildRelativeTimeRange(range), sortOrder));


### PR DESCRIPTION
## Description
This changes adds *order* as an option when conducting an */search/universal/relative/terms* API query. This will allow the web interface to request ascending ordered term aggregations via the REST API. 

## Motivation and Context
* PR #3540 added sort order support to the Searches.terms method for sort order. This PR adds it to the Graylog API so that the web interface can take advantage of it via REST queries. 
* Right now, a term aggregation returned from a REST query can only be ordered Ascending in a generic manner since the underlying query is ordered in a descending manner.
* This PR fixes a bug I am experiencing in my QuickValuesPlus Widget Plugin [More Info](https://github.com/billmurrin/graylog-plugin-quickvaluesplus-widget/issues/7)

## How Has This Been Tested?
* I compiled the Graylog 2.3.0 SNAPSHOT with the incorporated changes and then replaced the graylog.jar file under /opt/graylog/server. Once the server loaded, I validated the latest SNAPSHOT version "2.3.0-SNAPSHOT+252f9fe" was loaded. I went into the API Browser on the node and validated under "GET /search/universal/relative/terms" that the *order* field was present. 
* I tested it with values for *asc*, *desc*, and blank and was able to see that the underlying JSON query contained the proper sort syntax. The results also indicated the query was providing the correct data.
* No unit testing on the code change was conducted.
* No errors were observed.

## Screenshots (if appropriate):
![alt text](http://i.imgur.com/D0zJGhr.png "API Screenshot")

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
