### PR TITLE
Do not include 'in_grace' flag in streams list.

### DIFF
--- a/UPGRADING.rst
+++ b/UPGRADING.rst
@@ -17,3 +17,10 @@ Rotation and Retention strategies
 The deprecated HTTP resources at ``/system/indices/rotation`` and ``/system/indices/retention``, which didn't work since Graylog 2.2.0, have been removed.
 
 These settings are part of the index set configuration and can be configured under ``/system/indices/index_sets``.
+
+Stream List Response structure does not include `in_grace` field anymore
+------------------------------------------------------------------------
+
+The response to ``GET /streams``, ``GET /streams/<id>`` & ``PUT /streams/<id>`` does not contain the ``in_grace`` field for configured alert conditions anymore.
+
+The value of this flag can be retrieved using the ``GET /alerts/conditions`` endpoint, or per stream using the ``GET /streams/<streamId>/alerts/conditions`` endpoint.

--- a/graylog2-server/src/main/java/org/graylog2/rest/models/streams/alerts/AlertConditionSummary.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/models/streams/alerts/AlertConditionSummary.java
@@ -18,6 +18,7 @@ package org.graylog2.rest.models.streams.alerts;
 
 import com.fasterxml.jackson.annotation.JsonAutoDetect;
 import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.auto.value.AutoValue;
 import org.graylog.autovalue.WithBeanGetter;
@@ -25,6 +26,8 @@ import org.graylog.autovalue.WithBeanGetter;
 import javax.annotation.Nullable;
 import java.util.Date;
 import java.util.Map;
+
+import static com.google.common.base.Preconditions.checkNotNull;
 
 @AutoValue
 @WithBeanGetter
@@ -46,6 +49,8 @@ public abstract class AlertConditionSummary {
     public abstract Map<String, Object> parameters();
 
     @JsonProperty("in_grace")
+    @Nullable
+    @JsonInclude(JsonInclude.Include.NON_NULL)
     public abstract Boolean inGrace();
 
     @JsonProperty("title")
@@ -60,6 +65,17 @@ public abstract class AlertConditionSummary {
                                                @JsonProperty("parameters") Map<String, Object> parameters,
                                                @JsonProperty("in_grace") Boolean inGrace,
                                                @JsonProperty("title") @Nullable String title) {
+        checkNotNull(inGrace);
         return new AutoValue_AlertConditionSummary(id, type, creatorUserId, createdAt, parameters, inGrace, title);
+    }
+
+    @JsonCreator
+    public static AlertConditionSummary createWithoutGrace(@JsonProperty("id") String id,
+                                               @JsonProperty("type") String type,
+                                               @JsonProperty("creator_user_id") String creatorUserId,
+                                               @JsonProperty("created_at") Date createdAt,
+                                               @JsonProperty("parameters") Map<String, Object> parameters,
+                                               @JsonProperty("title") @Nullable String title) {
+        return new AutoValue_AlertConditionSummary(id, type, creatorUserId, createdAt, parameters, null, title);
     }
 }

--- a/graylog2-server/src/main/java/org/graylog2/rest/models/streams/alerts/AlertConditionSummary.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/models/streams/alerts/AlertConditionSummary.java
@@ -69,7 +69,6 @@ public abstract class AlertConditionSummary {
         return new AutoValue_AlertConditionSummary(id, type, creatorUserId, createdAt, parameters, inGrace, title);
     }
 
-    @JsonCreator
     public static AlertConditionSummary createWithoutGrace(@JsonProperty("id") String id,
                                                @JsonProperty("type") String type,
                                                @JsonProperty("creator_user_id") String creatorUserId,

--- a/graylog2-server/src/main/java/org/graylog2/rest/models/streams/alerts/AlertConditionSummary.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/models/streams/alerts/AlertConditionSummary.java
@@ -69,12 +69,12 @@ public abstract class AlertConditionSummary {
         return new AutoValue_AlertConditionSummary(id, type, creatorUserId, createdAt, parameters, inGrace, title);
     }
 
-    public static AlertConditionSummary createWithoutGrace(@JsonProperty("id") String id,
-                                               @JsonProperty("type") String type,
-                                               @JsonProperty("creator_user_id") String creatorUserId,
-                                               @JsonProperty("created_at") Date createdAt,
-                                               @JsonProperty("parameters") Map<String, Object> parameters,
-                                               @JsonProperty("title") @Nullable String title) {
+    public static AlertConditionSummary createWithoutGrace(String id,
+                                                           String type,
+                                                           String creatorUserId,
+                                                           Date createdAt,
+                                                           Map<String, Object> parameters,
+                                                           @Nullable String title) {
         return new AutoValue_AlertConditionSummary(id, type, creatorUserId, createdAt, parameters, null, title);
     }
 }

--- a/graylog2-server/src/main/java/org/graylog2/rest/resources/streams/StreamResource.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/resources/streams/StreamResource.java
@@ -467,13 +467,12 @@ public class StreamResource extends RestResource {
         final List<String> usersAlertReceivers = stream.getAlertReceivers().get("users");
         final Collection<AlertConditionSummary> alertConditions = streamService.getAlertConditions(stream)
             .stream()
-            .map((alertCondition) -> AlertConditionSummary.create(
+            .map((alertCondition) -> AlertConditionSummary.createWithoutGrace(
                 alertCondition.getId(),
                 alertCondition.getType(),
                 alertCondition.getCreatorUserId(),
                 alertCondition.getCreatedAt().toDate(),
                 alertCondition.getParameters(),
-                alertService.inGracePeriod(alertCondition),
                 alertCondition.getTitle()))
             .collect(Collectors.toList());
         return StreamResponse.create(


### PR DESCRIPTION
## Description

This change is removing the `in_grace` field from the stream list retrieved via `StreamResource#get/getEnabled/get(id)/update`. The DTO is slightly modified, it is not including the field if it was initialized with `null`. Other parts of the code using it can still do so and it will continue to include the flag.

## Motivation and Context

The `in_grace` field is not shown in the web interface in stream lists, but it is right now costly to calculate, compared to just retrieving all/individual streams. If the flag will be used in future parts, it can be retrieved for streams individually using additional API calls.

The performance benefit of not calculating the field is massive for those parts, which are fetching the whole stream list. This is a single call to `/streams` with 39 configured streams before the change:

![screen shot 2017-04-26 at 12 40 22](https://cloud.githubusercontent.com/assets/41929/25430773/417913be-2a7e-11e7-81f5-66db2e6d0521.png)

And after:

![screen shot 2017-04-26 at 12 37 03](https://cloud.githubusercontent.com/assets/41929/25430779/45d0be58-2a7e-11e7-91b4-81fc589309ec.png)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
