### PR TITLE
Allow kafka input consumer offset reset

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/inputs/transports/KafkaTransport.java
+++ b/graylog2-server/src/main/java/org/graylog2/inputs/transports/KafkaTransport.java
@@ -75,6 +75,7 @@ public class KafkaTransport extends ThrottleableTransport {
     public static final String CK_ZOOKEEPER = "zookeeper";
     public static final String CK_TOPIC_FILTER = "topic_filter";
     public static final String CK_THREADS = "threads";
+    public static final String CK_OFFSET_RESET = "offset_reset";
 
     private static final Logger LOG = LoggerFactory.getLogger(KafkaTransport.class);
 
@@ -179,6 +180,7 @@ public class KafkaTransport extends ThrottleableTransport {
         props.put("fetch.min.bytes", String.valueOf(configuration.getInt(CK_FETCH_MIN_BYTES)));
         props.put("fetch.wait.max.ms", String.valueOf(configuration.getInt(CK_FETCH_WAIT_MAX)));
         props.put("zookeeper.connect", configuration.getString(CK_ZOOKEEPER));
+        props.put("auto.offset.reset", configuration.getString(CK_OFFSET_RESET));
         // Default auto commit interval is 60 seconds. Reduce to 1 second to minimize message duplication
         // if something breaks.
         props.put("auto.commit.interval.ms", "1000");
@@ -360,6 +362,13 @@ public class KafkaTransport extends ThrottleableTransport {
                     2,
                     "Number of processor threads to spawn. Use one thread per Kafka topic partition.",
                     ConfigurationField.Optional.NOT_OPTIONAL));
+
+            cr.addField(new TextField(
+                    CK_OFFSET_RESET,
+                    "Auto offset reset",
+                    "largest",
+                    "What to do when there is no initial offset in ZooKeeper or if an offset is out of range",
+                    ConfigurationField.Optional.OPTIONAL));
 
             return cr;
         }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Allow kafka input to reset consumer reset to smallest

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
In case of mishaps with zookeeper offsets / downstream elasticsearch, should be able
to replay sitting data in kafka.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
