### PR TITLE
supply default implementations for adapter and cache configs

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/plugin/lookup/FallbackAdapterConfig.java
+++ b/graylog2-server/src/main/java/org/graylog2/plugin/lookup/FallbackAdapterConfig.java
@@ -1,0 +1,26 @@
+package org.graylog2.plugin.lookup;
+
+import com.fasterxml.jackson.annotation.JsonAnySetter;
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+/**
+ * This is the dummy config that accepts anything and has a marker method to detect a missing plugin.
+ * Otherwise loading the config from the database fails hard.
+ */
+@JsonAutoDetect
+public class FallbackAdapterConfig implements LookupDataAdapterConfiguration {
+
+    @JsonProperty
+    private String type;
+
+    @Override
+    public String type() {
+        return type;
+    }
+
+    @JsonAnySetter
+    public void setType(String key, Object value) {
+        // we ignore all the other values, we only want to be able to deserialize unknown configs
+    }
+}

--- a/graylog2-server/src/main/java/org/graylog2/plugin/lookup/FallbackAdapterConfig.java
+++ b/graylog2-server/src/main/java/org/graylog2/plugin/lookup/FallbackAdapterConfig.java
@@ -1,3 +1,19 @@
+/**
+ * This file is part of Graylog.
+ *
+ * Graylog is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package org.graylog2.plugin.lookup;
 
 import com.fasterxml.jackson.annotation.JsonAnySetter;

--- a/graylog2-server/src/main/java/org/graylog2/plugin/lookup/FallbackCacheConfig.java
+++ b/graylog2-server/src/main/java/org/graylog2/plugin/lookup/FallbackCacheConfig.java
@@ -1,0 +1,24 @@
+package org.graylog2.plugin.lookup;
+
+import com.fasterxml.jackson.annotation.JsonAnySetter;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+/**
+ * This is the dummy config that accepts anything and has a marker method to detect a missing plugin.
+ * Otherwise loading the config from the database fails hard.
+ */
+public class FallbackCacheConfig implements LookupCacheConfiguration {
+
+    @JsonProperty
+    private String type;
+
+    @Override
+    public String type() {
+        return type;
+    }
+
+    @JsonAnySetter
+    public void setType(String key, Object value) {
+        // we ignore all the other values, we only want to be able to deserialize unknown configs
+    }
+}

--- a/graylog2-server/src/main/java/org/graylog2/plugin/lookup/FallbackCacheConfig.java
+++ b/graylog2-server/src/main/java/org/graylog2/plugin/lookup/FallbackCacheConfig.java
@@ -1,3 +1,19 @@
+/**
+ * This file is part of Graylog.
+ *
+ * Graylog is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package org.graylog2.plugin.lookup;
 
 import com.fasterxml.jackson.annotation.JsonAnySetter;

--- a/graylog2-server/src/main/java/org/graylog2/plugin/lookup/LookupCacheConfiguration.java
+++ b/graylog2-server/src/main/java/org/graylog2/plugin/lookup/LookupCacheConfiguration.java
@@ -19,7 +19,11 @@ package org.graylog2.plugin.lookup;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
 
-@JsonTypeInfo(use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.PROPERTY, property = LookupCacheConfiguration.TYPE_FIELD, visible = true)
+@JsonTypeInfo(use = JsonTypeInfo.Id.NAME,
+        include = JsonTypeInfo.As.PROPERTY,
+        property = LookupCacheConfiguration.TYPE_FIELD,
+        visible = true,
+        defaultImpl = FallbackCacheConfig.class)
 public interface LookupCacheConfiguration {
     String TYPE_FIELD = "type";
 

--- a/graylog2-server/src/main/java/org/graylog2/plugin/lookup/LookupDataAdapterConfiguration.java
+++ b/graylog2-server/src/main/java/org/graylog2/plugin/lookup/LookupDataAdapterConfiguration.java
@@ -19,7 +19,12 @@ package org.graylog2.plugin.lookup;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
 
-@JsonTypeInfo(use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.PROPERTY, property = LookupDataAdapterConfiguration.TYPE_FIELD, visible = true)
+@JsonTypeInfo(
+        use = JsonTypeInfo.Id.NAME,
+        include = JsonTypeInfo.As.PROPERTY,
+        property = LookupDataAdapterConfiguration.TYPE_FIELD,
+        visible = true,
+        defaultImpl = FallbackAdapterConfig.class)
 public interface LookupDataAdapterConfiguration {
     String TYPE_FIELD = "type";
 


### PR DESCRIPTION
this allows loading entries from the database even though plugins are missing
the loading logic will fail to create the domain objects and they will be ignored