### PR TITLE
Fix dashboard layouts when width or height is 0

### DIFF
--- a/graylog2-web-interface/src/pages/ShowDashboardPage.jsx
+++ b/graylog2-web-interface/src/pages/ShowDashboardPage.jsx
@@ -119,6 +119,9 @@ const ShowDashboardPage = React.createClass({
   _dashboardIsEmpty(dashboard) {
     return dashboard.widgets.length === 0;
   },
+  _validDimension(dimension) {
+    return dimension !== null && dimension !== undefined && dimension !== 0;
+  },
   formatDashboard(dashboard) {
     if (this._dashboardIsEmpty(dashboard)) {
       return this.emptyDashboard();
@@ -131,8 +134,8 @@ const ShowDashboardPage = React.createClass({
       positions[widget.id] = {
         col: (persistedDimensions.col === undefined ? defaultDimensions.col : persistedDimensions.col),
         row: (persistedDimensions.row === undefined ? defaultDimensions.row : persistedDimensions.row),
-        height: (persistedDimensions.height === undefined ? defaultDimensions.height : persistedDimensions.height),
-        width: (persistedDimensions.width === undefined ? defaultDimensions.width : persistedDimensions.width),
+        height: (this._validDimension(persistedDimensions.height) ? persistedDimensions.height : defaultDimensions.height),
+        width: (this._validDimension(persistedDimensions.width) ? persistedDimensions.width : defaultDimensions.width),
       };
     });
 

--- a/graylog2-web-interface/src/pages/ShowDashboardPage.jsx
+++ b/graylog2-web-interface/src/pages/ShowDashboardPage.jsx
@@ -120,7 +120,7 @@ const ShowDashboardPage = React.createClass({
     return dashboard.widgets.length === 0;
   },
   _validDimension(dimension) {
-    return dimension !== null && dimension !== undefined && dimension !== 0;
+    return Number.isInteger(dimension) && dimension > 0;
   },
   formatDashboard(dashboard) {
     if (this._dashboardIsEmpty(dashboard)) {


### PR DESCRIPTION
Dashboards created from content packs always get a value for each widget dimensions, being 0 the default. This behaviour is different than what happens when a widget is created manually and is now taken into account.

Fixes #3765