### PR TITLE
Use dashboard ID to add widget on new dashboard

### DIFF
--- a/graylog2-web-interface/src/components/dashboard/AddToDashboardMenu.jsx
+++ b/graylog2-web-interface/src/components/dashboard/AddToDashboardMenu.jsx
@@ -178,7 +178,7 @@ const AddToDashboardMenu = React.createClass({
                         id="no-dashboards-available-dropdown">
           {option}
         </DropdownButton>
-        <EditDashboardModal ref="createDashboardModal" onSaved={id => this._selectDashboard(undefined, id)} />
+        <EditDashboardModal ref="createDashboardModal" onSaved={this._selectDashboard} />
       </div>
     );
   },


### PR DESCRIPTION
Since #3598, the method signature for `this._selectDashboard()` changed,but this usage was not updated.

Fixes #3785