### PR TITLE
Fixing `Indices#exists` and `Indices#aliasExists`.

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/indexer/indices/Indices.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/indices/Indices.java
@@ -298,7 +298,14 @@ public class Indices {
 
     public boolean exists(String indexName) {
         try {
-            return jestClient.execute(new IndicesExists.Builder(indexName).build()).isSucceeded();
+            final JestResult result = jestClient.execute(new GetSettings.Builder().addIndex(indexName).build());
+            if (!result.isSucceeded()) {
+                return false;
+            }
+            return Optional.of(result.getJsonObject())
+                .map(GsonUtils::entrySetAsMap)
+                .map(map -> map.containsKey(indexName))
+                .orElse(false);
         } catch (IOException e) {
             throw new ElasticsearchException("Couldn't check existence of index " + indexName, e);
         }
@@ -306,7 +313,14 @@ public class Indices {
 
     public boolean aliasExists(String alias) {
         try {
-            return jestClient.execute(new AliasExists.Builder().alias(alias).build()).isSucceeded();
+            final JestResult result = jestClient.execute(new GetSettings.Builder().addIndex(alias).build());
+            if (!result.isSucceeded()) {
+                return false;
+            }
+            return Optional.of(result.getJsonObject())
+                .map(GsonUtils::entrySetAsMap)
+                .map(map -> !map.containsKey(alias))
+                .orElse(false);
         } catch (IOException e) {
             throw new ElasticsearchException("Couldn't check existence of alias " + alias, e);
         }

--- a/graylog2-server/src/main/java/org/graylog2/indexer/indices/Indices.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/indices/Indices.java
@@ -296,6 +296,11 @@ public class Indices {
                 .map(indices -> asJsonObject(indices.get(indexName)));
     }
 
+    /**
+     * Check if a given name is an existing index.
+     * @param indexName Name of the index to check presence for.
+     * @return {@code true} if indexName is an existing index, {@code false} if it is non-existing or an alias.
+     */
     public boolean exists(String indexName) {
         try {
             final JestResult result = jestClient.execute(new GetSettings.Builder().addIndex(indexName).build());
@@ -311,6 +316,11 @@ public class Indices {
         }
     }
 
+    /**
+     * Check if a given name is an existing alias.
+     * @param alias Name of the alias to check presence for.
+     * @return {@code true} if alias is an existing alias, {@code false} if it is non-existing or an index.
+     */
     public boolean aliasExists(String alias) {
         try {
             final JestResult result = jestClient.execute(new GetSettings.Builder().addIndex(alias).build());

--- a/graylog2-server/src/test/java/org/graylog2/indexer/indices/IndicesTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/indexer/indices/IndicesTest.java
@@ -66,6 +66,7 @@ import org.graylog2.shared.bindings.providers.ObjectMapperProvider;
 import org.joda.time.DateTime;
 import org.joda.time.DateTimeZone;
 import org.junit.Before;
+import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.mockito.junit.MockitoJUnit;
@@ -179,6 +180,27 @@ public class IndicesTest extends AbstractESTest {
         assertThat(response.isAcknowledged()).isTrue();
         assertThat(indices.aliasExists(alias)).isTrue();
         assertThat(indices.exists(alias)).isFalse();
+    }
+
+    @Test
+    @UsingDataSet(locations = "IndicesTest-EmptyIndex.json", loadStrategy = LoadStrategyEnum.CLEAN_INSERT)
+    public void testAliasExistsForIndex() throws Exception {
+        final String indexNotAlias = "graylog_0";
+        assertThat(indices.aliasExists(indexNotAlias)).isFalse();
+    }
+
+    @Test
+    @UsingDataSet(locations = "IndicesTest-EmptyIndex.json", loadStrategy = LoadStrategyEnum.CLEAN_INSERT)
+    public void testIndexIfIndexExists() throws Exception {
+        final String indexNotAlias = "graylog_0";
+        assertThat(indices.exists(indexNotAlias)).isTrue();
+    }
+
+    @Test
+    @UsingDataSet(loadStrategy = LoadStrategyEnum.CLEAN_INSERT)
+    public void testExistsIfIndexDoesNotExist() throws Exception {
+        final String indexNotAlias = "graylog_index_does_not_exist";
+        assertThat(indices.exists(indexNotAlias)).isFalse();
     }
 
     @Test
@@ -345,7 +367,7 @@ public class IndicesTest extends AbstractESTest {
         final List<IndexTemplateMetaData> indexTemplates = getTemplatesResponse.getIndexTemplates();
         assertThat(indexTemplates)
                 .extracting(IndexTemplateMetaData::getName)
-                .containsExactly(customTemplateName);
+                .contains(customTemplateName);
 
         // Create index with custom template
         final String testIndexName = "graylog_override_template";

--- a/graylog2-server/src/test/java/org/graylog2/indexer/indices/IndicesTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/indexer/indices/IndicesTest.java
@@ -178,6 +178,7 @@ public class IndicesTest extends AbstractESTest {
         final IndicesAliasesResponse response = adminClient.aliases(request).actionGet(ES_TIMEOUT);
         assertThat(response.isAcknowledged()).isTrue();
         assertThat(indices.aliasExists(alias)).isTrue();
+        assertThat(indices.exists(alias)).isFalse();
     }
 
     @Test

--- a/graylog2-server/src/test/java/org/graylog2/indexer/indices/IndicesTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/indexer/indices/IndicesTest.java
@@ -66,7 +66,6 @@ import org.graylog2.shared.bindings.providers.ObjectMapperProvider;
 import org.joda.time.DateTime;
 import org.joda.time.DateTimeZone;
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.mockito.junit.MockitoJUnit;


### PR DESCRIPTION
Before this change, the checks in both methods were too simple:

  * `exists` checked if a HEAD on `/<indexname>` succeeds. This returns
`true` if the supplied name is an alias (which the method is clearly
supposed not to do according to
https://github.com/Graylog2/graylog2-server/blame/master/graylog2-server/src/main/java/org/graylog2/periodical/IndexRotationThread.java#L128.
Instead we are now getting the settings for the index and check if it
actually is an alias or not.

  * `aliasExists` checked if a HEAD on `/_all/_alias/<indexname>`
succeeds. Unfortunately, this also returns true if the name is an index
and not an alias. Instead we are now doing the same call as for `exists`
and reversing the alias condition.

