### PR TITLE
Use JestUtils.execute in Cluster#isConnected calls.

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/indexer/cluster/Cluster.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/cluster/Cluster.java
@@ -162,16 +162,11 @@ public class Cluster {
                 .timeout(Ints.saturatedCast(requestTimeout.toSeconds()))
                 .build();
 
-        try {
-            final JestResult result = jestClient.execute(request);
-            final int numberOfDataNodes = Optional.of(result.getJsonObject())
-                .map(json -> asInteger(json.get("number_of_data_nodes")))
-                .orElse(0);
-            return result.isSucceeded() && numberOfDataNodes > 0;
-        } catch (IOException e) {
-            LOG.warn("Couldn't check connection status of Elasticsearch", e);
-            return false;
-        }
+        final JestResult result = JestUtils.execute(jestClient, request, () -> "Couldn't check connection status of Elasticsearch");
+        final int numberOfDataNodes = Optional.of(result.getJsonObject())
+            .map(json -> asInteger(json.get("number_of_data_nodes")))
+            .orElse(0);
+        return result.isSucceeded() && numberOfDataNodes > 0;
     }
 
     /**

--- a/graylog2-server/src/main/java/org/graylog2/indexer/cluster/Cluster.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/cluster/Cluster.java
@@ -166,7 +166,7 @@ public class Cluster {
         final int numberOfDataNodes = Optional.of(result.getJsonObject())
             .map(json -> asInteger(json.get("number_of_data_nodes")))
             .orElse(0);
-        return result.isSucceeded() && numberOfDataNodes > 0;
+        return numberOfDataNodes > 0;
     }
 
     /**


### PR DESCRIPTION
This helps us to generate a more useful runtime exception in case the
Elasticsearch calls fail. Before this change, error messages of non-200
HTTP responses were not passed.
