### PR TITLE
Pass response body in exception if unable to extract root causes.

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/indexer/cluster/jest/JestUtils.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/cluster/jest/JestUtils.java
@@ -27,6 +27,7 @@ import org.graylog2.indexer.QueryParsingException;
 import org.graylog2.indexer.gson.GsonUtils;
 
 import java.io.IOException;
+import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 import java.util.function.Supplier;
@@ -76,6 +77,10 @@ public class JestUtils {
             if ("query_parsing_exception".equals(type)) {
                 return buildQueryParsingException(errorMessage, rootCause, reasons);
             }
+        }
+
+        if (reasons.isEmpty()) {
+            return new ElasticsearchException(errorMessage.get(), Collections.singletonList(jsonObject.toString()));
         }
 
         return new ElasticsearchException(errorMessage.get(), reasons);

--- a/graylog2-server/src/test/java/org/graylog2/indexer/cluster/jest/JestUtilsTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/indexer/cluster/jest/JestUtilsTest.java
@@ -116,6 +116,32 @@ public class JestUtilsTest {
     }
 
     @Test
+    public void executeFailsWithCustomMessage() throws Exception {
+        final Ping request = new Ping.Builder().build();
+
+        final JestResult resultMock = mock(JestResult.class);
+        when(resultMock.isSucceeded()).thenReturn(false);
+
+        final JsonObject responseStub = new JsonObject();
+        responseStub.addProperty("Message", "Authorization header requires 'Credential' parameter.");
+
+        when(resultMock.getJsonObject()).thenReturn(responseStub);
+
+        when(clientMock.execute(request)).thenReturn(resultMock);
+
+        try {
+            JestUtils.execute(clientMock, request, () -> "BOOM");
+        } catch (ElasticsearchException e) {
+            assertThat(e)
+                .hasMessage("BOOM")
+                .hasNoSuppressedExceptions();
+            assertThat(e.getErrorDetails()).containsExactly("{\"Message\":\"Authorization header requires 'Credential' parameter.\"}");
+        } catch (Exception e) {
+            fail("Expected QueryParsingException to be thrown");
+        }
+    }
+
+    @Test
     public void executeWithQueryParsingException() throws Exception {
         final Ping request = new Ping.Builder().build();
 


### PR DESCRIPTION
This helps with 3rd party Elasticsearch services (like AWS's), which
return non-standard response bodys in some cases (for example failed
authentications/violated access policies).
