### PR TITLE
Adding helpful exception when search tries to use nonexisting indices.

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/indexer/IndexNotFoundException.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/IndexNotFoundException.java
@@ -16,8 +16,14 @@
  */
 package org.graylog2.indexer;
 
+import java.util.List;
+
 public class IndexNotFoundException extends ElasticsearchException {
     public IndexNotFoundException(String message) {
         super(message);
+    }
+
+    public IndexNotFoundException(String message, List<String> errorDetails) {
+        super(message, errorDetails);
     }
 }

--- a/graylog2-server/src/main/java/org/graylog2/indexer/cluster/jest/JestUtils.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/cluster/jest/JestUtils.java
@@ -74,8 +74,12 @@ public class JestUtils {
 
         for (JsonObject rootCause : rootCauses) {
             final String type = asString(rootCause.get("type"));
-            if ("query_parsing_exception".equals(type)) {
-                return buildQueryParsingException(errorMessage, rootCause, reasons);
+            switch(type) {
+                case "query_parsing_exception":
+                    return buildQueryParsingException(errorMessage, rootCause, reasons);
+                case "index_not_found_exception":
+                    final String indexName = asString(rootCause.get("resource.id"));
+                    return new ElasticsearchException("Index not found for query: " + indexName + ". Try recalculating your index ranges.");
             }
         }
 

--- a/graylog2-server/src/main/java/org/graylog2/indexer/cluster/jest/JestUtils.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/cluster/jest/JestUtils.java
@@ -74,6 +74,9 @@ public class JestUtils {
 
         for (JsonObject rootCause : rootCauses) {
             final String type = asString(rootCause.get("type"));
+            if (type == null) {
+                continue;
+            }
             switch(type) {
                 case "query_parsing_exception":
                     return buildQueryParsingException(errorMessage, rootCause, reasons);

--- a/graylog2-server/src/main/java/org/graylog2/indexer/cluster/jest/JestUtils.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/cluster/jest/JestUtils.java
@@ -23,6 +23,7 @@ import io.searchbox.client.JestResult;
 import io.searchbox.client.http.JestHttpClient;
 import org.apache.http.client.config.RequestConfig;
 import org.graylog2.indexer.ElasticsearchException;
+import org.graylog2.indexer.IndexNotFoundException;
 import org.graylog2.indexer.QueryParsingException;
 import org.graylog2.indexer.gson.GsonUtils;
 
@@ -82,7 +83,7 @@ public class JestUtils {
                     return buildQueryParsingException(errorMessage, rootCause, reasons);
                 case "index_not_found_exception":
                     final String indexName = asString(rootCause.get("resource.id"));
-                    return new ElasticsearchException("Index not found for query: " + indexName + ". Try recalculating your index ranges.");
+                    return new IndexNotFoundException("Index not found for query: " + indexName + ". Try recalculating your index ranges.");
             }
         }
 

--- a/graylog2-server/src/main/java/org/graylog2/indexer/cluster/jest/JestUtils.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/cluster/jest/JestUtils.java
@@ -83,7 +83,7 @@ public class JestUtils {
                     return buildQueryParsingException(errorMessage, rootCause, reasons);
                 case "index_not_found_exception":
                     final String indexName = asString(rootCause.get("resource.id"));
-                    return new IndexNotFoundException("Index not found for query: " + indexName + ". Try recalculating your index ranges.");
+                    return buildIndexNotFoundException(errorMessage, indexName);
             }
         }
 
@@ -119,5 +119,9 @@ public class JestUtils {
         final String index = asString(rootCause.get("index"));
 
         return new QueryParsingException(errorMessage.get(), line, column, index, reasons);
+    }
+
+    private static IndexNotFoundException buildIndexNotFoundException(Supplier<String> errorMessage, String index) {
+        return new IndexNotFoundException(errorMessage.get(), Collections.singletonList("Index not found for query: " + index + ". Try recalculating your index ranges."));
     }
 }

--- a/graylog2-server/src/test/java/org/graylog2/indexer/counts/CountsTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/indexer/counts/CountsTest.java
@@ -192,10 +192,12 @@ public class CountsTest extends AbstractESTest {
         try {
             assertThat(counts.total(indexSet)).isEqualTo(-1L);
         } catch (IndexNotFoundException e) {
+            final String expectedErrorDetail = "Index not found for query: does_not_exist. Try recalculating your index ranges.";
             assertThat(e)
-                .hasMessage("Fetching message count failed for indices [does_not_exist]")
+                .hasMessageStartingWith("Fetching message count failed for indices [does_not_exist]")
+                .hasMessageEndingWith(expectedErrorDetail)
                 .hasNoSuppressedExceptions();
-            assertThat(e.getErrorDetails()).containsExactly("Index not found for query: does_not_exist. Try recalculating your index ranges.");
+            assertThat(e.getErrorDetails()).containsExactly(expectedErrorDetail);
         } catch (Exception e) {
             fail("Expected IndexNotFoundException to be thrown");
         }

--- a/graylog2-server/src/test/java/org/graylog2/indexer/counts/CountsTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/indexer/counts/CountsTest.java
@@ -20,6 +20,7 @@ import com.google.common.collect.ImmutableMap;
 import org.elasticsearch.action.index.IndexResponse;
 import org.graylog2.AbstractESTest;
 import org.graylog2.indexer.ElasticsearchException;
+import org.graylog2.indexer.IndexNotFoundException;
 import org.graylog2.indexer.IndexSet;
 import org.graylog2.indexer.IndexSetRegistry;
 import org.graylog2.indexer.indexset.IndexSetConfig;
@@ -186,8 +187,8 @@ public class CountsTest extends AbstractESTest {
     public void totalThrowsElasticsearchExceptionIfIndexDoesNotExist() throws Exception {
         final IndexSet indexSet = mock(IndexSet.class);
         when(indexSet.getManagedIndices()).thenReturn(new String[]{"does_not_exist"});
-        expectedException.expect(ElasticsearchException.class);
-        expectedException.expectMessage("Fetching message count failed for indices [does_not_exist]");
+        expectedException.expect(IndexNotFoundException.class);
+        expectedException.expectMessage("Index not found for query: does_not_exist. Try recalculating your index ranges.");
 
         assertThat(counts.total(indexSet)).isEqualTo(-1L);
     }


### PR DESCRIPTION
This could happen when indices were removed manually, the cluster was
switched and/or the index ranges are out of date.

In this case, the change now emits a useful exception instead of a
generic one.