### PR TITLE
Add lifecycle and error messages to lookup table domain objects

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/lookup/LookupTable.java
+++ b/graylog2-server/src/main/java/org/graylog2/lookup/LookupTable.java
@@ -47,6 +47,11 @@ public abstract class LookupTable {
     }
 
     @Nullable
+    public String error() {
+        return dataAdapter().getError().map(Throwable::getMessage).orElse(null);
+    }
+
+    @Nullable
     public LookupResult lookup(@Nonnull Object key) {
         return cache().get(key);
     }

--- a/graylog2-server/src/main/java/org/graylog2/lookup/LookupTableCreator.java
+++ b/graylog2-server/src/main/java/org/graylog2/lookup/LookupTableCreator.java
@@ -17,6 +17,7 @@
 package org.graylog2.lookup;
 
 import com.google.inject.assistedinject.Assisted;
+
 import org.graylog2.lookup.dto.CacheDto;
 import org.graylog2.lookup.dto.DataAdapterDto;
 import org.graylog2.lookup.dto.LookupTableDto;
@@ -25,10 +26,11 @@ import org.graylog2.plugin.lookup.LookupDataAdapter;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import javax.inject.Inject;
 import java.util.Collection;
 import java.util.Map;
 import java.util.Optional;
+
+import javax.inject.Inject;
 
 /**
  * Responsible for creating correct {@link LookupTable} objects including data adapters and caches.
@@ -100,7 +102,11 @@ class LookupTableCreator {
         }
         final DataAdapterDto adapterDto = adapterDtoOptional.get();
         return getDataAdapterFactory(dto.name(), adapterDto)
-                .map(factory -> factory.create(adapterDto.config()));
+                .map(factory -> {
+                    final LookupDataAdapter adapter = factory.create(adapterDto.config());
+                    adapter.setId(adapterDto.id());
+                    return adapter;
+                });
     }
 
     private Optional<LookupCache.Factory> getCacheFactory(String lutName, CacheDto cacheDto) {

--- a/graylog2-server/src/main/java/org/graylog2/lookup/LookupTableCreator.java
+++ b/graylog2-server/src/main/java/org/graylog2/lookup/LookupTableCreator.java
@@ -102,11 +102,7 @@ class LookupTableCreator {
         }
         final DataAdapterDto adapterDto = adapterDtoOptional.get();
         return getDataAdapterFactory(dto.name(), adapterDto)
-                .map(factory -> {
-                    final LookupDataAdapter adapter = factory.create(adapterDto.config());
-                    adapter.setId(adapterDto.id());
-                    return adapter;
-                });
+                .map(factory -> factory.create(adapterDto.id(), adapterDto.name(), adapterDto.config()));
     }
 
     private Optional<LookupCache.Factory> getCacheFactory(String lutName, CacheDto cacheDto) {

--- a/graylog2-server/src/main/java/org/graylog2/lookup/LookupTableService.java
+++ b/graylog2-server/src/main/java/org/graylog2/lookup/LookupTableService.java
@@ -18,6 +18,8 @@ package org.graylog2.lookup;
 
 import com.google.common.eventbus.EventBus;
 import com.google.common.eventbus.Subscribe;
+import com.google.common.util.concurrent.Service;
+
 import org.graylog2.lookup.dto.CacheDto;
 import org.graylog2.lookup.dto.DataAdapterDto;
 import org.graylog2.lookup.dto.LookupTableDto;
@@ -29,16 +31,19 @@ import org.graylog2.plugin.lookup.LookupResult;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
-import javax.inject.Inject;
-import javax.inject.Singleton;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.ScheduledExecutorService;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import javax.inject.Inject;
+import javax.inject.Named;
+import javax.inject.Singleton;
 
 @Singleton
 public class LookupTableService {
@@ -48,6 +53,7 @@ public class LookupTableService {
     private final MongoLutCacheService cacheService;
     private final MongoLutDataAdapterService dataAdapterService;
     private final LookupTableCreator.Factory tableCreatorFactory;
+    private final ScheduledExecutorService scheduler;
 
     private final ConcurrentMap<String, LookupTable> lookupTables = new ConcurrentHashMap<>();
 
@@ -56,11 +62,13 @@ public class LookupTableService {
                               MongoLutCacheService cacheService,
                               MongoLutDataAdapterService dataAdapterService,
                               LookupTableCreator.Factory tableCreatorFactory,
-                              EventBus serverEventBus) {
+                              EventBus serverEventBus,
+                              @Named("daemonScheduler") ScheduledExecutorService scheduler) {
         this.mongoLutService = mongoLutService;
         this.cacheService = cacheService;
         this.dataAdapterService = dataAdapterService;
         this.tableCreatorFactory = tableCreatorFactory;
+        this.scheduler = scheduler;
 
         // Initialize all lookup tables before subscribing to events
         initialize();
@@ -70,17 +78,47 @@ public class LookupTableService {
     }
 
     private void activateTable(String name, @Nullable LookupTable existingTable, LookupTable newTable) {
-        // Always start the new data adapter before taking it live, it's a no-op if the adapter is already started
-        newTable.dataAdapter().start();
+        // Always start the new data adapter before taking it live, if it is new
+        final LookupDataAdapter newAdapter = newTable.dataAdapter();
+        if (newAdapter.state() == Service.State.NEW) {
+            newAdapter.addListener(new Service.Listener() {
+                @Override
+                public void starting() {
+                    LOG.info("Adapter {} STARTING", newAdapter.id());
+                }
 
-        lookupTables.put(name, newTable);
+                @Override
+                public void running() {
+                    LOG.info("Adapter {} RUNNING", newAdapter.id());
+                    lookupTables.put(name, newTable);
 
-        if (existingTable != null) {
-            // If the new table has a new data adapter, stop the old one to free up resources
-            // This needs to happen after the new table is live
-            if (!Objects.equals(existingTable.dataAdapter(), newTable.dataAdapter())) {
-                existingTable.dataAdapter().stop();
-            }
+                    if (existingTable != null) {
+                        // If the new table has a new data adapter, stop the old one to free up resources
+                        // This needs to happen after the new table is live
+                        final LookupDataAdapter existingAdapter = existingTable.dataAdapter();
+                        if (!Objects.equals(existingAdapter, newAdapter) && existingAdapter.isRunning()) {
+                            existingAdapter.stopAsync().awaitTerminated();
+                        }
+                    }
+                }
+
+                @Override
+                public void stopping(Service.State from) {
+                    LOG.info("Adapter {} FAILED, was {}", newAdapter.id(), from);
+                }
+
+                @Override
+                public void terminated(Service.State from) {
+                    LOG.info("Adapter {} TERMINATED, was {}", newAdapter.id(), from);
+                }
+
+                @Override
+                public void failed(Service.State from, Throwable failure) {
+                    LOG.info("Adapter {} FAILED, was {}", newAdapter.id(), from);
+                }
+            }, scheduler);
+
+            newAdapter.startAsync();
         }
     }
 

--- a/graylog2-server/src/main/java/org/graylog2/lookup/LookupTableService.java
+++ b/graylog2-server/src/main/java/org/graylog2/lookup/LookupTableService.java
@@ -33,6 +33,7 @@ import org.slf4j.LoggerFactory;
 
 import java.util.Collection;
 import java.util.Collections;
+import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
@@ -246,9 +247,12 @@ public class LookupTableService {
     }
 
     public Collection<LookupDataAdapter> getDataAdapters(Set<String> adapterNames) {
+        if (adapterNames == null) {
+            return Collections.emptySet();
+        }
         return liveAdapters.entrySet().stream()
                 .filter(e -> adapterNames.contains(e.getKey()))
-                .map(e -> e.getValue())
+                .map(Map.Entry::getValue)
                 .collect(Collectors.toSet());
     }
 

--- a/graylog2-server/src/main/java/org/graylog2/lookup/adapters/HTTPJSONPathDataAdapter.java
+++ b/graylog2-server/src/main/java/org/graylog2/lookup/adapters/HTTPJSONPathDataAdapter.java
@@ -63,7 +63,6 @@ import okhttp3.OkHttpClient;
 import okhttp3.Request;
 import okhttp3.Response;
 
-import static com.codahale.metrics.MetricRegistry.name;
 import static com.google.common.base.Strings.isNullOrEmpty;
 
 public class HTTPJSONPathDataAdapter extends LookupDataAdapter {
@@ -85,18 +84,20 @@ public class HTTPJSONPathDataAdapter extends LookupDataAdapter {
     @Inject
     protected HTTPJSONPathDataAdapter(@Assisted LookupDataAdapterConfiguration config,
                                       @Named("daemonScheduler") ScheduledExecutorService scheduler,
+                                      @Assisted("id") String id,
+                                      @Assisted("name") String name,
                                       Engine templateEngine,
                                       OkHttpClient httpClient,
                                       MetricRegistry metricRegistry) {
-        super(config, scheduler);
+        super(id, name, config, scheduler);
         this.config = (Config) config;
         this.templateEngine = templateEngine;
         // TODO Add config options: caching, timeouts, custom headers, basic auth (See: https://github.com/square/okhttp/wiki/Recipes)
         this.httpClient = httpClient.newBuilder().build(); // Copy HTTP client to be able to modify it
 
-        this.httpRequestTimer = metricRegistry.timer(name(getClass(), "httpRequestTime"));
-        this.httpRequestErrors = metricRegistry.meter(name(getClass(), "httpRequestErrors"));
-        this.httpURLErrors = metricRegistry.meter(name(getClass(), "httpURLErrors"));
+        this.httpRequestTimer = metricRegistry.timer(MetricRegistry.name(getClass(), "httpRequestTime"));
+        this.httpRequestErrors = metricRegistry.meter(MetricRegistry.name(getClass(), "httpRequestErrors"));
+        this.httpURLErrors = metricRegistry.meter(MetricRegistry.name(getClass(), "httpURLErrors"));
     }
 
     @Override
@@ -236,7 +237,9 @@ public class HTTPJSONPathDataAdapter extends LookupDataAdapter {
 
     public interface Factory extends LookupDataAdapter.Factory<HTTPJSONPathDataAdapter> {
         @Override
-        HTTPJSONPathDataAdapter create(LookupDataAdapterConfiguration configuration);
+        HTTPJSONPathDataAdapter create(@Assisted("id") String id,
+                                       @Assisted("name") String name,
+                                       LookupDataAdapterConfiguration configuration);
 
         @Override
         Descriptor getDescriptor();

--- a/graylog2-server/src/main/java/org/graylog2/plugin/lookup/LookupDataAdapter.java
+++ b/graylog2-server/src/main/java/org/graylog2/plugin/lookup/LookupDataAdapter.java
@@ -17,6 +17,7 @@
 package org.graylog2.plugin.lookup;
 
 import com.google.common.util.concurrent.AbstractIdleService;
+import com.google.inject.assistedinject.Assisted;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 
@@ -25,11 +26,12 @@ import org.joda.time.Duration;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.util.Optional;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
 
-import javax.annotation.Nullable;
 import javax.inject.Named;
 
 import static com.google.common.base.Preconditions.checkState;
@@ -37,27 +39,33 @@ import static com.google.common.base.Preconditions.checkState;
 public abstract class LookupDataAdapter extends AbstractIdleService {
     private static final Logger LOG = LoggerFactory.getLogger(LookupDataAdapter.class);
 
-    private String id;
+    private final String id;
     private LookupTable lookupTable;
+    private final String name;
 
     private final LookupDataAdapterConfiguration config;
     private final ScheduledExecutorService scheduler;
     private ScheduledFuture<?> refreshFuture = null;
 
-    protected LookupDataAdapter(LookupDataAdapterConfiguration config,
+    private AtomicReference<Throwable> dataSourceError = new AtomicReference<>();
+
+    protected LookupDataAdapter(String id, String name, LookupDataAdapterConfiguration config,
                                 @Named("daemonScheduler") ScheduledExecutorService scheduler) {
+        this.id = id;
+        this.name = name;
         this.config = config;
         this.scheduler = scheduler;
     }
 
     @Override
     protected void startUp() throws Exception {
+        doStart();
+
         final Duration interval = refreshInterval();
         if (!interval.equals(Duration.ZERO)) {
             LOG.debug("Schedule data adapter refresh method every {}ms", interval.getMillis());
             this.refreshFuture = scheduler.scheduleAtFixedRate(this::refresh, interval.getMillis(), interval.getMillis(), TimeUnit.MILLISECONDS);
         }
-        doStart();
     }
 
     protected abstract void doStart() throws Exception;
@@ -85,17 +93,28 @@ public abstract class LookupDataAdapter extends AbstractIdleService {
             LOG.error("Couldn't refresh data adapter", e);
         }
     }
+
     protected abstract void doRefresh() throws Exception;
 
-    @Nullable
+    protected void clearError() {
+        dataSourceError.set(null);
+    }
+
+    public Optional<Throwable> getError() {
+        return Optional.ofNullable(dataSourceError.get());
+    }
+
+    protected void setError(Throwable throwable) {
+        dataSourceError.set(throwable);
+    }
+
     public String id() {
         return id;
     }
 
-    public void setId(String id) {
-        this.id = id;
+    public String name() {
+        return name;
     }
-
     public LookupTable getLookupTable() {
         checkState(lookupTable != null, "lookup table cannot be null");
         return lookupTable;
@@ -120,8 +139,9 @@ public abstract class LookupDataAdapter extends AbstractIdleService {
         return config;
     }
 
+
     public interface Factory<T extends LookupDataAdapter> {
-        T create(LookupDataAdapterConfiguration configuration);
+        T create(@Assisted("id") String id, @Assisted("name") String name, LookupDataAdapterConfiguration configuration);
 
         Descriptor getDescriptor();
     }

--- a/graylog2-server/src/main/java/org/graylog2/rest/models/system/lookup/ErrorStates.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/models/system/lookup/ErrorStates.java
@@ -1,0 +1,68 @@
+/**
+ * This file is part of Graylog.
+ *
+ * Graylog is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.graylog2.rest.models.system.lookup;
+
+import com.google.auto.value.AutoValue;
+import com.google.common.collect.Maps;
+
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+
+import org.graylog.autovalue.WithBeanGetter;
+
+import java.util.Map;
+
+@AutoValue
+@WithBeanGetter
+@JsonAutoDetect
+@JsonDeserialize(builder = AutoValue_ErrorStates.Builder.class)
+public abstract class ErrorStates {
+
+
+    @JsonProperty("tables")
+    public abstract Map<String, String> tables();
+
+    @JsonProperty("data_adapters")
+    public abstract Map<String, String> dataAdapters();
+
+    @JsonProperty("caches")
+    public abstract Map<String, String> caches();
+
+    public static Builder builder() {
+        return new AutoValue_ErrorStates.Builder()
+                .caches(Maps.newHashMap())
+                .tables(Maps.newHashMap())
+                .dataAdapters(Maps.newHashMap());
+    }
+
+
+    @AutoValue.Builder
+    public abstract static class Builder {
+
+        public abstract Map<String, String> dataAdapters();
+        public abstract Builder dataAdapters(Map<String, String> dataAdapters);
+
+        public abstract Map<String, String> caches();
+        public abstract Builder caches(Map<String, String> caches);
+
+        public abstract Map<String, String> tables();
+        public abstract Builder tables(Map<String, String> tables);
+
+        public abstract ErrorStates build();
+    }
+}

--- a/graylog2-server/src/main/java/org/graylog2/rest/models/system/lookup/ErrorStatesRequest.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/models/system/lookup/ErrorStatesRequest.java
@@ -1,0 +1,68 @@
+/**
+ * This file is part of Graylog.
+ *
+ * Graylog is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.graylog2.rest.models.system.lookup;
+
+import com.google.auto.value.AutoValue;
+
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+
+import org.graylog.autovalue.WithBeanGetter;
+
+import java.util.Set;
+
+import javax.annotation.Nullable;
+
+@AutoValue
+@WithBeanGetter
+@JsonAutoDetect
+@JsonDeserialize(builder = AutoValue_ErrorStatesRequest.Builder.class)
+@JsonIgnoreProperties(ignoreUnknown = true)
+public abstract class ErrorStatesRequest {
+
+    @Nullable
+    @JsonProperty("tables")
+    public abstract Set<String > tables();
+
+    @Nullable
+    @JsonProperty("data_adapters")
+    public abstract Set<String > dataAdapters();
+
+    @Nullable
+    @JsonProperty("caches")
+    public abstract Set<String > caches();
+
+    public static Builder builder() {
+        return new AutoValue_ErrorStatesRequest.Builder();
+    }
+
+    @AutoValue.Builder
+    public abstract static class Builder {
+        @JsonProperty("tables")
+        public abstract Builder tables(@Nullable Set<String> tables);
+
+        @JsonProperty("data_adapters")
+        public abstract Builder dataAdapters(@Nullable Set<String> dataAdapters);
+
+        @JsonProperty("caches")
+        public abstract Builder caches(@Nullable Set<String> caches);
+
+        public abstract ErrorStatesRequest build();
+    }
+}

--- a/graylog2-server/src/main/java/org/graylog2/rest/resources/system/lookup/LookupTableResource.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/resources/system/lookup/LookupTableResource.java
@@ -310,9 +310,9 @@ public class LookupTableResource extends RestResource {
 
     @POST
     @NoAuditEvent("Bulk read call")
-    @Path("states")
-    @ApiOperation(value = "Retrieve the runtime error states of the given lookup tables")
-    public ErrorStates adapterErrorStates(@ApiParam(name = "tables") @Valid ErrorStatesRequest request) {
+    @Path("errorstates")
+    @ApiOperation(value = "Retrieve the runtime error states of the given lookup tables, caches and adapters")
+    public ErrorStates errorStates(@ApiParam(name = "request") @Valid ErrorStatesRequest request) {
         final ErrorStates.Builder errorStates = ErrorStates.builder();
         if (request.tables() != null) {
             //noinspection ConstantConditions
@@ -324,9 +324,11 @@ public class LookupTableResource extends RestResource {
                 }
             }
         }
-        lookupTables.getDataAdapters(request.dataAdapters()).forEach(adapter -> {
-            errorStates.dataAdapters().put(adapter.name(), adapter.getError().map(Throwable::getMessage).orElse(null));
-        });
+        if (request.dataAdapters() != null) {
+            lookupTables.getDataAdapters(request.dataAdapters()).forEach(adapter -> {
+                errorStates.dataAdapters().put(adapter.name(), adapter.getError().map(Throwable::getMessage).orElse(null));
+            });
+        }
         return errorStates.build();
     }
 

--- a/graylog2-web-interface/src/actions/lookup-tables/LookupTablesActions.js
+++ b/graylog2-web-interface/src/actions/lookup-tables/LookupTablesActions.js
@@ -7,6 +7,7 @@ const LookupTablesActions = Reflux.createActions({
   create: { asyncResult: true },
   delete: { asyncResult: true },
   update: { asyncResult: true },
+  getErrors: { asyncResult: true },
 });
 
 export default LookupTablesActions;

--- a/graylog2-web-interface/src/components/lookup-tables/DataAdapterTableEntry.jsx
+++ b/graylog2-web-interface/src/components/lookup-tables/DataAdapterTableEntry.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { LinkContainer } from 'react-router-bootstrap';
 
-import { Button } from 'react-bootstrap';
+import { Button, OverlayTrigger, Popover } from 'react-bootstrap';
 
 import Routes from 'routing/Routes';
 import CombinedProvider from 'injection/CombinedProvider';
@@ -12,6 +12,13 @@ const DataAdapterTableEntry = React.createClass({
 
   propTypes: {
     adapter: React.PropTypes.object.isRequired,
+    error: React.PropTypes.string,
+  },
+
+  getDefaultProps() {
+    return {
+      error: null,
+    };
   },
 
   _onDelete() {
@@ -22,10 +29,18 @@ const DataAdapterTableEntry = React.createClass({
   },
 
   render() {
+    const errorOverlay = !this.props.error ? null : (
+      <Popover id="popover-table-error" title="Lookup Table problem" style={{ maxWidth: 400 }}>
+        {this.props.error}
+      </Popover>);
     return (
       <tbody>
         <tr>
           <td>
+            {this.props.error && (
+              <OverlayTrigger trigger={['hover', 'focus']} placement="right" overlay={errorOverlay}>
+                <i className="fa fa-warning text-danger" style={{ marginRight: 5 }} />
+              </OverlayTrigger>)}
             <LinkContainer to={Routes.SYSTEM.LOOKUPTABLES.DATA_ADAPTERS.show(this.props.adapter.name)}><a>{this.props.adapter.title}</a></LinkContainer>
           </td>
           <td>{this.props.adapter.description}</td>

--- a/graylog2-web-interface/src/components/lookup-tables/DataAdapterTableEntry.jsx
+++ b/graylog2-web-interface/src/components/lookup-tables/DataAdapterTableEntry.jsx
@@ -1,10 +1,12 @@
 import React from 'react';
 import { LinkContainer } from 'react-router-bootstrap';
 
-import { Button, OverlayTrigger, Popover } from 'react-bootstrap';
+import { Button } from 'react-bootstrap';
 
 import Routes from 'routing/Routes';
 import CombinedProvider from 'injection/CombinedProvider';
+
+import { ErrorPopover } from 'components/lookup-tables';
 
 const { LookupTableDataAdaptersActions } = CombinedProvider.get('LookupTableDataAdapters');
 
@@ -29,18 +31,11 @@ const DataAdapterTableEntry = React.createClass({
   },
 
   render() {
-    const errorOverlay = !this.props.error ? null : (
-      <Popover id="popover-table-error" title="Lookup Table problem" style={{ maxWidth: 400 }}>
-        {this.props.error}
-      </Popover>);
     return (
       <tbody>
         <tr>
           <td>
-            {this.props.error && (
-              <OverlayTrigger trigger={['hover', 'focus']} placement="right" overlay={errorOverlay}>
-                <i className="fa fa-warning text-danger" style={{ marginRight: 5 }} />
-              </OverlayTrigger>)}
+            {this.props.error && <ErrorPopover errorText={this.props.error} title="Lookup table problem" placement="right" />}
             <LinkContainer to={Routes.SYSTEM.LOOKUPTABLES.DATA_ADAPTERS.show(this.props.adapter.name)}><a>{this.props.adapter.title}</a></LinkContainer>
           </td>
           <td>{this.props.adapter.description}</td>

--- a/graylog2-web-interface/src/components/lookup-tables/DataAdaptersOverview.jsx
+++ b/graylog2-web-interface/src/components/lookup-tables/DataAdaptersOverview.jsx
@@ -18,6 +18,7 @@ const DataAdaptersOverview = React.createClass({
   propTypes: {
     dataAdapters: PropTypes.array.isRequired,
     pagination: PropTypes.object.isRequired,
+    errorStates: PropTypes.object.isRequired,
   },
 
   _onPageChange(newPage, newPerPage) {
@@ -37,7 +38,8 @@ const DataAdaptersOverview = React.createClass({
     }
     const dataAdapters = this.props.dataAdapters.map((dataAdapter) => {
       return (<DataAdapterTableEntry key={dataAdapter.id}
-                                     adapter={dataAdapter} />);
+                                     adapter={dataAdapter}
+                                     error={this.props.errorStates.dataAdapters[dataAdapter.name]} />);
     });
 
     return (<div>

--- a/graylog2-web-interface/src/components/lookup-tables/ErrorPopover.css
+++ b/graylog2-web-interface/src/components/lookup-tables/ErrorPopover.css
@@ -1,0 +1,7 @@
+:local(.overlay) {
+    max-width: 400px;
+}
+
+:local(.trigger) {
+    margin-right: 5px;
+}

--- a/graylog2-web-interface/src/components/lookup-tables/ErrorPopover.jsx
+++ b/graylog2-web-interface/src/components/lookup-tables/ErrorPopover.jsx
@@ -1,0 +1,37 @@
+import React, { PropTypes } from 'react';
+
+import { OverlayTrigger, Popover } from 'react-bootstrap';
+
+import Styles from './ErrorPopover.css';
+
+const ErrorPopover = React.createClass({
+
+  propTypes: {
+    errorText: PropTypes.string.isRequired,
+    title: PropTypes.string,
+    placement: PropTypes.string,
+  },
+
+  getDefaultProps() {
+    return {
+      title: 'Error',
+      placement: 'bottom',
+    };
+  },
+
+  render() {
+    const overlay = (<Popover id="error-popover" title={this.props.title} className={Styles.overlay}>
+      {this.props.errorText}
+    </Popover>);
+
+    return (
+      <OverlayTrigger trigger={['hover', 'focus']} placement={this.props.placement} overlay={overlay}>
+        <span className={Styles.trigger}>
+          <i className="fa fa-warning text-danger" />
+        </span>
+      </OverlayTrigger>
+    );
+  },
+});
+
+export default ErrorPopover;

--- a/graylog2-web-interface/src/components/lookup-tables/LUTTableEntry.jsx
+++ b/graylog2-web-interface/src/components/lookup-tables/LUTTableEntry.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { LinkContainer } from 'react-router-bootstrap';
-import { Button } from 'react-bootstrap';
+import { Button, OverlayTrigger, Popover } from 'react-bootstrap';
 
 import CombinedProvider from 'injection/CombinedProvider';
 
@@ -14,6 +14,17 @@ const LUTTableEntry = React.createClass({
     table: React.PropTypes.object.isRequired,
     cache: React.PropTypes.object.isRequired,
     dataAdapter: React.PropTypes.object.isRequired,
+    errors: React.PropTypes.object,
+  },
+
+  getDefaultProps() {
+    return {
+      errors: {
+        table: null,
+        cache: null,
+        dataAdapter: null,
+      },
+    };
   },
 
   _onDelete() {
@@ -23,17 +34,49 @@ const LUTTableEntry = React.createClass({
     }
   },
   render() {
+    let tableErrorOverlay = null;
+    if (this.props.errors.table) {
+      tableErrorOverlay = (<Popover id="popover-table-error" title="Lookup Table problem" style={{ maxWidth: 400 }}>
+        {this.props.errors.table}
+      </Popover>);
+    }
+
+    let dataAdapterErrorOverlay = null;
+    if (this.props.errors.dataAdapter) {
+      dataAdapterErrorOverlay = (<Popover id="popover-adapter-error" title="Data adapter problem" style={{ maxWidth: 400 }}>
+        {this.props.errors.dataAdapter}
+      </Popover>);
+    }
+    let cacheErrorOverlay = null;
+    if (this.props.errors.cache) {
+      cacheErrorOverlay = (<Popover id="popover-adapter-error" title="Cache problem" style={{ maxWidth: 400 }}>
+        {this.props.errors.cache}
+      </Popover>);
+    }
+
     return (<tbody>
       <tr>
         <td>
+          {this.props.errors.table && (
+            <OverlayTrigger trigger={['hover', 'focus']} placement="right" overlay={tableErrorOverlay}>
+              <i className="fa fa-warning text-danger" style={{ marginRight: 5 }} />
+            </OverlayTrigger>)}
           <LinkContainer to={Routes.SYSTEM.LOOKUPTABLES.show(this.props.table.name)}><a>{this.props.table.title}</a></LinkContainer>
         </td>
         <td>{this.props.table.description}</td>
         <td>{this.props.table.name}</td>
         <td>
+          {this.props.errors.cache && (
+            <OverlayTrigger trigger={['hover', 'focus']} placement="bottom" overlay={cacheErrorOverlay}>
+              <i className="fa fa-warning text-danger" style={{ marginRight: 5 }} />
+            </OverlayTrigger>)}
           <LinkContainer to={Routes.SYSTEM.LOOKUPTABLES.CACHES.show(this.props.cache.name)}><a>{this.props.cache.title}</a></LinkContainer>
         </td>
         <td>
+          {this.props.errors.dataAdapter && (
+            <OverlayTrigger trigger={['hover', 'focus']} placement="bottom" overlay={dataAdapterErrorOverlay}>
+              <i className="fa fa-warning text-danger" style={{ marginRight: 5 }} />
+            </OverlayTrigger>)}
           <LinkContainer to={Routes.SYSTEM.LOOKUPTABLES.DATA_ADAPTERS.show(this.props.dataAdapter.name)}><a>{this.props.dataAdapter.title}</a></LinkContainer>
         </td>
         <td>

--- a/graylog2-web-interface/src/components/lookup-tables/LUTTableEntry.jsx
+++ b/graylog2-web-interface/src/components/lookup-tables/LUTTableEntry.jsx
@@ -1,10 +1,12 @@
 import React from 'react';
 import { LinkContainer } from 'react-router-bootstrap';
-import { Button, OverlayTrigger, Popover } from 'react-bootstrap';
+import { Button } from 'react-bootstrap';
 
 import CombinedProvider from 'injection/CombinedProvider';
 
 import Routes from 'routing/Routes';
+
+import { ErrorPopover } from 'components/lookup-tables';
 
 const { LookupTablesActions } = CombinedProvider.get('LookupTables');
 
@@ -33,50 +35,22 @@ const LUTTableEntry = React.createClass({
       LookupTablesActions.delete(this.props.table.id).then(() => LookupTablesActions.reloadPage());
     }
   },
+
   render() {
-    let tableErrorOverlay = null;
-    if (this.props.errors.table) {
-      tableErrorOverlay = (<Popover id="popover-table-error" title="Lookup Table problem" style={{ maxWidth: 400 }}>
-        {this.props.errors.table}
-      </Popover>);
-    }
-
-    let dataAdapterErrorOverlay = null;
-    if (this.props.errors.dataAdapter) {
-      dataAdapterErrorOverlay = (<Popover id="popover-adapter-error" title="Data adapter problem" style={{ maxWidth: 400 }}>
-        {this.props.errors.dataAdapter}
-      </Popover>);
-    }
-    let cacheErrorOverlay = null;
-    if (this.props.errors.cache) {
-      cacheErrorOverlay = (<Popover id="popover-adapter-error" title="Cache problem" style={{ maxWidth: 400 }}>
-        {this.props.errors.cache}
-      </Popover>);
-    }
-
     return (<tbody>
       <tr>
         <td>
-          {this.props.errors.table && (
-            <OverlayTrigger trigger={['hover', 'focus']} placement="right" overlay={tableErrorOverlay}>
-              <i className="fa fa-warning text-danger" style={{ marginRight: 5 }} />
-            </OverlayTrigger>)}
+          {this.props.errors.table && (<ErrorPopover placement="right" errorText={this.props.errors.table} title="Lookup Table problem" />) }
           <LinkContainer to={Routes.SYSTEM.LOOKUPTABLES.show(this.props.table.name)}><a>{this.props.table.title}</a></LinkContainer>
         </td>
         <td>{this.props.table.description}</td>
         <td>{this.props.table.name}</td>
         <td>
-          {this.props.errors.cache && (
-            <OverlayTrigger trigger={['hover', 'focus']} placement="bottom" overlay={cacheErrorOverlay}>
-              <i className="fa fa-warning text-danger" style={{ marginRight: 5 }} />
-            </OverlayTrigger>)}
+          {this.props.errors.cache && (<ErrorPopover placement="bottom" errorText={this.props.errors.cache} title="Cache problem" />) }
           <LinkContainer to={Routes.SYSTEM.LOOKUPTABLES.CACHES.show(this.props.cache.name)}><a>{this.props.cache.title}</a></LinkContainer>
         </td>
         <td>
-          {this.props.errors.dataAdapter && (
-            <OverlayTrigger trigger={['hover', 'focus']} placement="bottom" overlay={dataAdapterErrorOverlay}>
-              <i className="fa fa-warning text-danger" style={{ marginRight: 5 }} />
-            </OverlayTrigger>)}
+          {this.props.errors.dataAdapter && (<ErrorPopover placement="bottom" errorText={this.props.errors.dataAdapter} title="Data adapter problem" />) }
           <LinkContainer to={Routes.SYSTEM.LOOKUPTABLES.DATA_ADAPTERS.show(this.props.dataAdapter.name)}><a>{this.props.dataAdapter.title}</a></LinkContainer>
         </td>
         <td>

--- a/graylog2-web-interface/src/components/lookup-tables/LookupTablesOverview.jsx
+++ b/graylog2-web-interface/src/components/lookup-tables/LookupTablesOverview.jsx
@@ -19,6 +19,7 @@ const LookupTablesOverview = React.createClass({
     caches: PropTypes.objectOf(PropTypes.object).isRequired,
     dataAdapters: PropTypes.objectOf(PropTypes.object).isRequired,
     pagination: PropTypes.object.isRequired,
+    errorStates: PropTypes.object.isRequired,
   },
 
   _onPageChange(newPage, newPerPage) {
@@ -39,12 +40,32 @@ const LookupTablesOverview = React.createClass({
     return map[id] || empty;
   },
 
+  _lookupAdapterError(table) {
+    if (this.props.errorStates.dataAdapters && this.props.dataAdapters) {
+      const adapter = this.props.dataAdapters[table.data_adapter_id];
+      if (!adapter) {
+        return null;
+      }
+      return this.props.errorStates.dataAdapters[adapter.name];
+    }
+    return null;
+  },
+
   render() {
     const lookupTables = this.props.tables.map((table) => {
       const cache = this._lookupName(table.cache_id, this.props.caches);
       const dataAdapter = this._lookupName(table.data_adapter_id, this.props.dataAdapters);
+      const errors = {
+        table: this.props.errorStates.tables[table.name],
+        cache: null,
+        dataAdapter: this._lookupAdapterError(table),
+      };
 
-      return (<LUTTableEntry key={table.id} table={table} cache={cache} dataAdapter={dataAdapter} />);
+      return (<LUTTableEntry key={table.id}
+                             table={table}
+                             cache={cache}
+                             dataAdapter={dataAdapter}
+                             errors={errors} />);
     });
 
     return (<div>

--- a/graylog2-web-interface/src/components/lookup-tables/index.js
+++ b/graylog2-web-interface/src/components/lookup-tables/index.js
@@ -22,3 +22,5 @@ export { default as DataAdapterForm } from './DataAdapterForm';
 export { default as DataAdapterCreate } from './DataAdapterCreate';
 export { default as DataAdapterPicker } from './DataAdapterPicker';
 export { default as DataAdaptersContainer } from './DataAdaptersContainer';
+
+export { default as ErrorPopover } from './ErrorPopover';

--- a/graylog2-web-interface/src/pages/LUTCachesPage.jsx
+++ b/graylog2-web-interface/src/pages/LUTCachesPage.jsx
@@ -11,6 +11,7 @@ import CombinedProvider from 'injection/CombinedProvider';
 
 const { LookupTableCachesStore, LookupTableCachesActions } = CombinedProvider.get(
   'LookupTableCaches');
+const { LookupTablesStore, LookupTablesActions } = CombinedProvider.get('LookupTables');
 
 const LUTCachesPage = React.createClass({
   propTypes: {
@@ -22,15 +23,33 @@ const LUTCachesPage = React.createClass({
 
   mixins: [
     Reflux.connect(LookupTableCachesStore),
+    Reflux.connect(LookupTablesStore, 'tableStore'),
   ],
 
   componentDidMount() {
     this._loadData(this.props);
+
+    this.errorStatesTimer = setInterval(() => {
+      let names = null;
+      if (this.state.caches) {
+        names = this.state.caches.map(t => t.name);
+      }
+      if (names) {
+        LookupTablesActions.getErrors(null, names || null, null);
+      }
+    }, this.errorStatesInterval);
   },
 
   componentWillReceiveProps(nextProps) {
     this._loadData(nextProps);
   },
+
+  componentWillUnmount() {
+    clearInterval(this.errorStatesTimer);
+  },
+
+  errorStatesTimer: undefined,
+  errorStatesInterval: 1000,
 
   _loadData(props) {
     if (props.params && props.params.cacheName) {
@@ -98,6 +117,13 @@ const LUTCachesPage = React.createClass({
             <span>Caches provide the actual values for lookup tables</span>
             {null}
             <span>
+              {(isShowing || isEditing) && (
+                <LinkContainer to={Routes.SYSTEM.LOOKUPTABLES.CACHES.edit(this.props.params.cacheName)}
+                               onlyActiveOnIndex>
+                  <Button bsStyle="success">Edit</Button>
+                </LinkContainer>
+              )}
+              &nbsp;
               {(isShowing || isEditing) && (
                 <LinkContainer to={Routes.SYSTEM.LOOKUPTABLES.CACHES.OVERVIEW}
                                onlyActiveOnIndex>

--- a/graylog2-web-interface/src/pages/LUTCachesPage.jsx
+++ b/graylog2-web-interface/src/pages/LUTCachesPage.jsx
@@ -11,7 +11,6 @@ import CombinedProvider from 'injection/CombinedProvider';
 
 const { LookupTableCachesStore, LookupTableCachesActions } = CombinedProvider.get(
   'LookupTableCaches');
-const { LookupTablesStore, LookupTablesActions } = CombinedProvider.get('LookupTables');
 
 const LUTCachesPage = React.createClass({
   propTypes: {
@@ -23,33 +22,15 @@ const LUTCachesPage = React.createClass({
 
   mixins: [
     Reflux.connect(LookupTableCachesStore),
-    Reflux.connect(LookupTablesStore, 'tableStore'),
   ],
 
   componentDidMount() {
     this._loadData(this.props);
-
-    this.errorStatesTimer = setInterval(() => {
-      let names = null;
-      if (this.state.caches) {
-        names = this.state.caches.map(t => t.name);
-      }
-      if (names) {
-        LookupTablesActions.getErrors(null, names || null, null);
-      }
-    }, this.errorStatesInterval);
   },
 
   componentWillReceiveProps(nextProps) {
     this._loadData(nextProps);
   },
-
-  componentWillUnmount() {
-    clearInterval(this.errorStatesTimer);
-  },
-
-  errorStatesTimer: undefined,
-  errorStatesInterval: 1000,
 
   _loadData(props) {
     if (props.params && props.params.cacheName) {

--- a/graylog2-web-interface/src/pages/LUTTablesPage.jsx
+++ b/graylog2-web-interface/src/pages/LUTTablesPage.jsx
@@ -112,7 +112,7 @@ const LUTTablesPage = React.createClass({
       <DocumentTitle title="Lookup Tables">
         <span>
           <PageHeader title="Lookup Tables">
-            <span>Looking things up</span>
+            <span>Lookup tables can be used in extractors, converters and processing pipelines to translate message fields or to enrich messages.</span>
             {null}
             <span>
               {isShowing && (

--- a/graylog2-web-interface/src/stores/lookup-tables/LookupTablesStore.js
+++ b/graylog2-web-interface/src/stores/lookup-tables/LookupTablesStore.js
@@ -19,17 +19,16 @@ const LookupTablesStore = Reflux.createStore({
       count: 0,
       query: null,
     };
-    this.errorStates = {
-      tables: {},
-      caches: {},
-      dataAdapters: {},
-    };
   },
 
   getInitialState() {
     return {
       pagination: this.pagination,
-      errorStates: this.errorStates,
+      errorStates: {
+        tables: {},
+        caches: {},
+        dataAdapters: {},
+      },
     };
   },
 
@@ -129,9 +128,9 @@ const LookupTablesStore = Reflux.createStore({
     promise.then((response) => {
       this.trigger({
         errorStates: {
-          tables: response.tables || [],
-          caches: response.caches || [],
-          dataAdapters: response.data_adapters || [],
+          tables: response.tables || {},
+          caches: response.caches || {},
+          dataAdapters: response.data_adapters || {},
         },
       });
     }, this._errorHandler('Fetching lookup table error state failed.', 'Could not error states'));


### PR DESCRIPTION
This change adds error handling and exposing error messages to lookup tables and data adapters.
Caches don't have lifecycle at the moment, but once they do they will share the same logic as data adapters.
Lookup tables are supposed to expose aggregate information, currently they duplicate the error message from the data adapter.

New UI shows the errors of the currently displayed page.