### PR TITLE
Fix global variables when executing in nodejs

### DIFF
--- a/graylog2-web-interface/src/injection/ActionsProvider.jsx
+++ b/graylog2-web-interface/src/injection/ActionsProvider.jsx
@@ -1,7 +1,5 @@
 import CombinedProvider from 'injection/CombinedProvider';
 
-/* global actionsProvider */
-
 class ActionsProvider {
   getActions(actionsName) {
     const result = CombinedProvider.get(actionsName);
@@ -12,8 +10,8 @@ class ActionsProvider {
   }
 }
 
-if (typeof actionsProvider === 'undefined') {
+if (typeof window.actionsProvider === 'undefined') {
   window.actionsProvider = new ActionsProvider();
 }
 
-export default actionsProvider;
+export default window.actionsProvider;

--- a/graylog2-web-interface/src/injection/StoreProvider.jsx
+++ b/graylog2-web-interface/src/injection/StoreProvider.jsx
@@ -1,7 +1,5 @@
 import CombinedProvider from 'injection/CombinedProvider';
 
-/* global storeProvider */
-
 class StoreProvider {
   getStore(storeName) {
     const result = CombinedProvider.get(storeName);
@@ -12,8 +10,8 @@ class StoreProvider {
   }
 }
 
-if (typeof storeProvider === 'undefined') {
+if (typeof window.storeProvider === 'undefined') {
   window.storeProvider = new StoreProvider();
 }
 
-export default storeProvider;
+export default window.storeProvider;

--- a/graylog2-web-interface/src/logic/local-storage/Store.js
+++ b/graylog2-web-interface/src/logic/local-storage/Store.js
@@ -1,3 +1,5 @@
+const localStorage = window.localStorage;
+
 const Store = {
   set(key, value) {
     localStorage.setItem(key, JSON.stringify(value));


### PR DESCRIPTION
Use window to scope global variables, as they would be in a browser. This allow us to import these files in NodeJS and render components in jsdom.

The current best way of testing this, is to check the changes do not affect regular browsers.