### PR TITLE
Add support for ES version-specific index mappings

### DIFF
--- a/UPGRADING.rst
+++ b/UPGRADING.rst
@@ -50,8 +50,10 @@ The following configuration options are now being used to configure connectivity
 +----------------------------------------------------+-----------+--------------------------------------------------------------+-----------------------------+
 | ``elasticsearch_socket_timeout``                   | Duration  | Timeout when sending/receiving from Elasticsearch connection | ``60s`` (60 Seconds)        |
 +----------------------------------------------------+-----------+--------------------------------------------------------------+-----------------------------+
+| ``elasticsearch_version``                          | (2 or 5)  | Major version of Elasticsearch being used in the cluster     | ``5``                       |
++----------------------------------------------------+-----------+--------------------------------------------------------------+-----------------------------+
 
-In most cases, the only configuration setting that needs to be set explicitly is ``elasticsearch_hosts``. All other configuration settings should be tweaked only in case of errors.
+In most cases, the only configuration setting that needs to be set explicitly is ``elasticsearch_hosts``, unless you use Elasticsearch 2.x (or earlier). In the latter case you would need to set ``elasticsearch_version`` to ``2``. All other configuration settings should be tweaked only in case of errors.
 
 .. caution:: Graylog does not react to externally triggered index changes (creating/closing/reopening/deleting an index) anymore. All of these actions need to be performed through the Graylog REST API in order to retain index consistency.
 

--- a/graylog2-server/src/main/java/org/graylog2/bindings/ElasticsearchModule.java
+++ b/graylog2-server/src/main/java/org/graylog2/bindings/ElasticsearchModule.java
@@ -1,0 +1,52 @@
+/**
+ * This file is part of Graylog.
+ *
+ * Graylog is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.graylog2.bindings;
+
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import com.google.inject.AbstractModule;
+import io.searchbox.client.JestClient;
+import org.graylog2.bindings.providers.JestClientProvider;
+import org.graylog2.configuration.ElasticsearchClientConfiguration;
+import org.graylog2.indexer.IndexMapping;
+import org.graylog2.indexer.IndexMapping2;
+import org.graylog2.indexer.IndexMapping5;
+
+public class ElasticsearchModule extends AbstractModule {
+    private final ElasticsearchClientConfiguration elasticsearchClientConfiguration;
+
+    public ElasticsearchModule(ElasticsearchClientConfiguration elasticsearchClientConfiguration) {
+        this.elasticsearchClientConfiguration = elasticsearchClientConfiguration;
+    }
+
+    @Override
+    protected void configure() {
+        bind(Gson.class).toInstance(new GsonBuilder().create());
+        bind(JestClient.class).toProvider(JestClientProvider.class).asEagerSingleton();
+
+        switch (elasticsearchClientConfiguration.getVersion()) {
+            case 2:
+                bind(IndexMapping.class).to(IndexMapping2.class).asEagerSingleton();
+                break;
+            case 5:
+                bind(IndexMapping.class).to(IndexMapping5.class).asEagerSingleton();
+                break;
+            default:
+                throw new IllegalArgumentException("Invalid Elasticsearch version: " + elasticsearchClientConfiguration.getVersion());
+        }
+    }
+}

--- a/graylog2-server/src/main/java/org/graylog2/bindings/ServerBindings.java
+++ b/graylog2-server/src/main/java/org/graylog2/bindings/ServerBindings.java
@@ -17,12 +17,9 @@
 package org.graylog2.bindings;
 
 import com.floreysoft.jmte.Engine;
-import com.google.gson.Gson;
-import com.google.gson.GsonBuilder;
 import com.google.inject.Scopes;
 import com.google.inject.assistedinject.FactoryModuleBuilder;
 import com.google.inject.multibindings.Multibinder;
-import io.searchbox.client.JestClient;
 import org.apache.shiro.mgt.DefaultSecurityManager;
 import org.glassfish.grizzly.http.server.ErrorPageGenerator;
 import org.graylog2.Configuration;
@@ -34,7 +31,6 @@ import org.graylog2.bindings.providers.BundleImporterProvider;
 import org.graylog2.bindings.providers.ClusterEventBusProvider;
 import org.graylog2.bindings.providers.DefaultSecurityManagerProvider;
 import org.graylog2.bindings.providers.DefaultStreamProvider;
-import org.graylog2.bindings.providers.JestClientProvider;
 import org.graylog2.bindings.providers.MongoConnectionProvider;
 import org.graylog2.bindings.providers.RulesEngineProvider;
 import org.graylog2.bindings.providers.SystemJobFactoryProvider;
@@ -161,8 +157,6 @@ public class ServerBindings extends Graylog2Module {
             install(new NoopJournalModule());
         }
 
-        bind(Gson.class).toInstance(new GsonBuilder().create());
-        bind(JestClient.class).toProvider(JestClientProvider.class).asEagerSingleton();
         bind(SystemJobManager.class).toProvider(SystemJobManagerProvider.class);
         bind(RulesEngine.class).toProvider(RulesEngineProvider.class);
         bind(LdapConnector.class).in(Scopes.SINGLETON);

--- a/graylog2-server/src/main/java/org/graylog2/commands/Server.java
+++ b/graylog2-server/src/main/java/org/graylog2/commands/Server.java
@@ -31,6 +31,7 @@ import org.graylog2.audit.AuditBindings;
 import org.graylog2.audit.AuditEventSender;
 import org.graylog2.bindings.AlarmCallbackBindings;
 import org.graylog2.bindings.ConfigurationModule;
+import org.graylog2.bindings.ElasticsearchModule;
 import org.graylog2.bindings.InitializerBindings;
 import org.graylog2.bindings.MessageFilterBindings;
 import org.graylog2.bindings.MessageOutputBindings;
@@ -108,6 +109,7 @@ public class Server extends ServerBootstrap {
         modules.add(
             new ConfigurationModule(configuration),
             new ServerBindings(configuration),
+            new ElasticsearchModule(elasticsearchClientConfiguration),
             new PersistenceServicesBindings(),
             new MessageFilterBindings(),
             new MessageProcessorModule(),

--- a/graylog2-server/src/main/java/org/graylog2/configuration/ElasticsearchClientConfiguration.java
+++ b/graylog2-server/src/main/java/org/graylog2/configuration/ElasticsearchClientConfiguration.java
@@ -17,6 +17,8 @@
 package org.graylog2.configuration;
 
 import com.github.joschi.jadconfig.Parameter;
+import com.github.joschi.jadconfig.ValidationException;
+import com.github.joschi.jadconfig.ValidatorMethod;
 import com.github.joschi.jadconfig.validators.PositiveIntegerValidator;
 import org.graylog2.configuration.converters.URIListConverter;
 import org.graylog2.configuration.validators.ListOfURIsWithHostAndSchemeValidator;
@@ -45,4 +47,46 @@ public class ElasticsearchClientConfiguration {
 
     @Parameter(value = "elasticsearch_max_total_connections_per_route", validators = { PositiveIntegerValidator.class })
     private int elasticsearchMaxTotalConnectionsPerRoute = 2;
+
+    @Parameter(value = "elasticsearch_version")
+    private int elasticsearchVersion = 5;
+
+    public List<URI> getHosts() {
+        return elasticsearchHosts;
+    }
+
+    public Duration getConnectTimeout() {
+        return elasticsearchConnectTimeout;
+    }
+
+    public Duration getSocketTimeout() {
+        return elasticsearchSocketTimeout;
+    }
+
+    public Duration getIdleTimeout() {
+        return elasticsearchIdleTimeout;
+    }
+
+    public int getMaxTotalConnections() {
+        return elasticsearchMaxTotalConnections;
+    }
+
+    public int getMaxTotalConnectionsPerRoute() {
+        return elasticsearchMaxTotalConnectionsPerRoute;
+    }
+
+    public int getVersion() {
+        return elasticsearchVersion;
+    }
+
+    @ValidatorMethod
+    public void validateElasticsearchVersion() throws ValidationException {
+        switch (elasticsearchVersion) {
+            case 2:
+            case 5:
+                return;
+            default:
+                throw new ValidationException("Valid values for \"elasticsearch_version\" are 2 and 5, value was " + elasticsearchVersion);
+        }
+    }
 }

--- a/graylog2-server/src/main/java/org/graylog2/configuration/ElasticsearchClientConfiguration.java
+++ b/graylog2-server/src/main/java/org/graylog2/configuration/ElasticsearchClientConfiguration.java
@@ -51,34 +51,11 @@ public class ElasticsearchClientConfiguration {
     @Parameter(value = "elasticsearch_version")
     private int elasticsearchVersion = 5;
 
-    public List<URI> getHosts() {
-        return elasticsearchHosts;
-    }
-
-    public Duration getConnectTimeout() {
-        return elasticsearchConnectTimeout;
-    }
-
-    public Duration getSocketTimeout() {
-        return elasticsearchSocketTimeout;
-    }
-
-    public Duration getIdleTimeout() {
-        return elasticsearchIdleTimeout;
-    }
-
-    public int getMaxTotalConnections() {
-        return elasticsearchMaxTotalConnections;
-    }
-
-    public int getMaxTotalConnectionsPerRoute() {
-        return elasticsearchMaxTotalConnectionsPerRoute;
-    }
-
     public int getVersion() {
         return elasticsearchVersion;
     }
 
+    @SuppressWarnings("unused")
     @ValidatorMethod
     public void validateElasticsearchVersion() throws ValidationException {
         switch (elasticsearchVersion) {

--- a/graylog2-server/src/main/java/org/graylog2/indexer/IndexMapping.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/IndexMapping.java
@@ -16,21 +16,18 @@
  */
 package org.graylog2.indexer;
 
-import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import org.graylog2.plugin.Tools;
 
 import javax.inject.Singleton;
-import java.io.Serializable;
 import java.util.List;
 import java.util.Map;
 
 /**
- * Representing the message type mapping in ElasticSearch. This is giving ES more
+ * Representing the message type mapping in Elasticsearch. This is giving ES more
  * information about what the fields look like and how it should analyze them.
  */
-@Singleton
-public class IndexMapping {
+public abstract class IndexMapping {
     public static final String TYPE_MESSAGE = "message";
 
     public Map<String, Object> messageTemplate(final String template, final String analyzer) {
@@ -39,8 +36,8 @@ public class IndexMapping {
 
     public Map<String, Object> messageTemplate(final String template, final String analyzer, final int order) {
         final Map<String, Object> analyzerKeyword = ImmutableMap.of("analyzer_keyword", ImmutableMap.of(
-            "tokenizer", "keyword",
-            "filter", "lowercase"));
+                "tokenizer", "keyword",
+                "filter", "lowercase"));
         final Map<String, Object> analysis = ImmutableMap.of("analyzer", analyzerKeyword);
         final Map<String, Object> settings = ImmutableMap.of("analysis", analysis);
         final Map<String, Object> mappings = ImmutableMap.of(TYPE_MESSAGE, messageMapping(analyzer));
@@ -53,67 +50,24 @@ public class IndexMapping {
         );
     }
 
-    public Map<String, Object> messageMapping(final String analyzer) {
+    protected Map<String, Object> messageMapping(final String analyzer) {
         return ImmutableMap.of(
-                "properties", partFieldProperties(analyzer),
-                "dynamic_templates", partDefaultAllInDynamicTemplate(),
+                "properties", fieldProperties(analyzer),
+                "dynamic_templates", dynamicTemplate(),
                 "_source", enabled());
     }
 
-    /*
-     * Disable analyzing for every field by default.
-     */
-    private List<Map<String, Map<String, Object>>> partDefaultAllInDynamicTemplate() {
-        final Map<String, Object> defaultInternal = ImmutableMap.of(
-                "match", "gl2_*",
-                "mapping", notAnalyzedString());
-        final Map<String, Map<String, Object>> templateInternal = ImmutableMap.of("internal_fields", defaultInternal);
+    protected abstract List<Map<String, Map<String, Object>>> dynamicTemplate();
 
-        final Map<String, Object> defaultAll = ImmutableMap.of(
-                // Match all
-                "match", "*",
-                // Analyze nothing by default
-                "mapping", ImmutableMap.of("index", "not_analyzed"));
-        final Map<String, Map<String, Object>> templateAll = ImmutableMap.of("store_generic", defaultAll);
+    protected abstract Map<String, Map<String, Object>> fieldProperties(String analyzer);
 
-        return ImmutableList.of(templateInternal, templateAll);
-    }
-
-    /*
-     * Enable analyzing for some fields again. Like for message and full_message.
-     */
-    private Map<String, Map<String, ? extends Serializable>> partFieldProperties(String analyzer) {
+    protected Map<String, Object> typeTimeWithMillis() {
         return ImmutableMap.of(
-                "message", analyzedString(analyzer),
-                "full_message", analyzedString(analyzer),
-                // http://joda-time.sourceforge.net/api-release/org/joda/time/format/DateTimeFormat.html
-                // http://www.elasticsearch.org/guide/reference/mapping/date-format.html
-                "timestamp", typeTimeWithMillis(),
-                // to support wildcard searches in source we need to lowercase the content (wildcard search lowercases search term)
-                "source", analyzedString("analyzer_keyword"),
-                "streams", notAnalyzedString());
-    }
-
-    private Map<String, String> notAnalyzedString() {
-        return ImmutableMap.of(
-                "index", "not_analyzed",
-                "type", "string");
-    }
-
-    private Map<String, String> analyzedString(String analyzer) {
-        return ImmutableMap.of(
-                "index", "analyzed",
-                "type", "string",
-                "analyzer", analyzer);
-    }
-
-    private Map<String, Serializable> typeTimeWithMillis() {
-        return ImmutableMap.<String, Serializable>of(
                 "type", "date",
                 "format", Tools.ES_DATE_FORMAT);
     }
 
-    private Map<String, Boolean> enabled() {
+    protected Map<String, Boolean> enabled() {
         return ImmutableMap.of("enabled", true);
     }
 }

--- a/graylog2-server/src/main/java/org/graylog2/indexer/IndexMapping.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/IndexMapping.java
@@ -16,6 +16,7 @@
  */
 package org.graylog2.indexer;
 
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import org.graylog2.plugin.Tools;
 
@@ -57,9 +58,25 @@ public abstract class IndexMapping {
                 "_source", enabled());
     }
 
-    protected abstract List<Map<String, Map<String, Object>>> dynamicTemplate();
+    protected List<Map<String, Map<String, Object>>> dynamicTemplate() {
+        final Map<String, Object> defaultInternal = ImmutableMap.of(
+                "match", "gl2_*",
+                "mapping", notAnalyzedString());
+        final Map<String, Map<String, Object>> templateInternal = ImmutableMap.of("internal_fields", defaultInternal);
+
+        final Map<String, Object> defaultAll = ImmutableMap.of(
+                // Match all
+                "match", "*",
+                // Analyze nothing by default
+                "mapping", ImmutableMap.of("index", "not_analyzed"));
+        final Map<String, Map<String, Object>> templateAll = ImmutableMap.of("store_generic", defaultAll);
+
+        return ImmutableList.of(templateInternal, templateAll);
+    }
 
     protected abstract Map<String, Map<String, Object>> fieldProperties(String analyzer);
+
+    protected abstract Map<String, Object> notAnalyzedString();
 
     protected Map<String, Object> typeTimeWithMillis() {
         return ImmutableMap.of(

--- a/graylog2-server/src/main/java/org/graylog2/indexer/IndexMapping2.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/IndexMapping2.java
@@ -1,0 +1,76 @@
+/**
+ * This file is part of Graylog.
+ *
+ * Graylog is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.graylog2.indexer;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+
+import javax.inject.Singleton;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Representing the message type mapping in Elasticsearch 2.x. This is giving ES more
+ * information about what the fields look like and how it should analyze them.
+ *
+ * @see <a href="https://www.elastic.co/guide/en/elasticsearch/reference/2.4/mapping.html">Elasticsearch Reference / Mapping</a>
+ */
+@Singleton
+public class IndexMapping2 extends IndexMapping {
+    @Override
+    protected List<Map<String, Map<String, Object>>> dynamicTemplate() {
+        final Map<String, Object> defaultInternal = ImmutableMap.of(
+                "match", "gl2_*",
+                "mapping", notAnalyzedString());
+        final Map<String, Map<String, Object>> templateInternal = ImmutableMap.of("internal_fields", defaultInternal);
+
+        final Map<String, Object> defaultAll = ImmutableMap.of(
+                // Match all
+                "match", "*",
+                // Analyze nothing by default
+                "mapping", ImmutableMap.of("index", "not_analyzed"));
+        final Map<String, Map<String, Object>> templateAll = ImmutableMap.of("store_generic", defaultAll);
+
+        return ImmutableList.of(templateInternal, templateAll);
+    }
+
+    @Override
+    protected Map<String, Map<String, Object>> fieldProperties(String analyzer) {
+        return ImmutableMap.of(
+                "message", analyzedString(analyzer),
+                "full_message", analyzedString(analyzer),
+                // http://joda-time.sourceforge.net/api-release/org/joda/time/format/DateTimeFormat.html
+                // http://www.elasticsearch.org/guide/reference/mapping/date-format.html
+                "timestamp", typeTimeWithMillis(),
+                // to support wildcard searches in source we need to lowercase the content (wildcard search lowercases search term)
+                "source", analyzedString("analyzer_keyword"),
+                "streams", notAnalyzedString());
+    }
+
+    private Map<String, Object> notAnalyzedString() {
+        return ImmutableMap.of(
+                "index", "not_analyzed",
+                "type", "string");
+    }
+
+    private Map<String, Object> analyzedString(String analyzer) {
+        return ImmutableMap.of(
+                "index", "analyzed",
+                "type", "string",
+                "analyzer", analyzer);
+    }
+}

--- a/graylog2-server/src/main/java/org/graylog2/indexer/IndexMapping2.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/IndexMapping2.java
@@ -32,23 +32,6 @@ import java.util.Map;
 @Singleton
 public class IndexMapping2 extends IndexMapping {
     @Override
-    protected List<Map<String, Map<String, Object>>> dynamicTemplate() {
-        final Map<String, Object> defaultInternal = ImmutableMap.of(
-                "match", "gl2_*",
-                "mapping", notAnalyzedString());
-        final Map<String, Map<String, Object>> templateInternal = ImmutableMap.of("internal_fields", defaultInternal);
-
-        final Map<String, Object> defaultAll = ImmutableMap.of(
-                // Match all
-                "match", "*",
-                // Analyze nothing by default
-                "mapping", ImmutableMap.of("index", "not_analyzed"));
-        final Map<String, Map<String, Object>> templateAll = ImmutableMap.of("store_generic", defaultAll);
-
-        return ImmutableList.of(templateInternal, templateAll);
-    }
-
-    @Override
     protected Map<String, Map<String, Object>> fieldProperties(String analyzer) {
         return ImmutableMap.of(
                 "message", analyzedString(analyzer),
@@ -61,7 +44,8 @@ public class IndexMapping2 extends IndexMapping {
                 "streams", notAnalyzedString());
     }
 
-    private Map<String, Object> notAnalyzedString() {
+    @Override
+    protected Map<String, Object> notAnalyzedString() {
         return ImmutableMap.of(
                 "index", "not_analyzed",
                 "type", "string");

--- a/graylog2-server/src/main/java/org/graylog2/indexer/IndexMapping5.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/IndexMapping5.java
@@ -16,11 +16,9 @@
  */
 package org.graylog2.indexer;
 
-import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 
 import javax.inject.Singleton;
-import java.util.List;
 import java.util.Map;
 
 /**
@@ -31,22 +29,7 @@ import java.util.Map;
  */
 @Singleton
 public class IndexMapping5 extends IndexMapping {
-    protected List<Map<String, Map<String, Object>>> dynamicTemplate() {
-        final Map<String, Object> defaultInternal = ImmutableMap.of(
-                "match", "gl2_*",
-                "mapping", notAnalyzedString());
-        final Map<String, Map<String, Object>> templateInternal = ImmutableMap.of("internal_fields", defaultInternal);
-
-        final Map<String, Object> defaultAll = ImmutableMap.of(
-                // Match all
-                "match", "*",
-                // Analyze nothing by default
-                "mapping", ImmutableMap.of("index", "not_analyzed"));
-        final Map<String, Map<String, Object>> templateAll = ImmutableMap.of("store_generic", defaultAll);
-
-        return ImmutableList.of(templateInternal, templateAll);
-    }
-
+    @Override
     protected Map<String, Map<String, Object>> fieldProperties(String analyzer) {
         return ImmutableMap.of(
                 "message", analyzedString(analyzer, false),
@@ -59,7 +42,8 @@ public class IndexMapping5 extends IndexMapping {
                 "streams", notAnalyzedString());
     }
 
-    private Map<String, Object> notAnalyzedString() {
+    @Override
+    protected Map<String, Object> notAnalyzedString() {
         return ImmutableMap.of("type", "keyword");
     }
 

--- a/graylog2-server/src/main/java/org/graylog2/indexer/IndexMapping5.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/IndexMapping5.java
@@ -1,0 +1,72 @@
+/**
+ * This file is part of Graylog.
+ *
+ * Graylog is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.graylog2.indexer;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+
+import javax.inject.Singleton;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Representing the message type mapping in Elasticsearch 5.x. This is giving ES more
+ * information about what the fields look like and how it should analyze them.
+ *
+ * @see <a href="https://www.elastic.co/guide/en/elasticsearch/reference/5.4/mapping.html">Elasticsearch Reference / Mapping</a>
+ */
+@Singleton
+public class IndexMapping5 extends IndexMapping {
+    protected List<Map<String, Map<String, Object>>> dynamicTemplate() {
+        final Map<String, Object> defaultInternal = ImmutableMap.of(
+                "match", "gl2_*",
+                "mapping", notAnalyzedString());
+        final Map<String, Map<String, Object>> templateInternal = ImmutableMap.of("internal_fields", defaultInternal);
+
+        final Map<String, Object> defaultAll = ImmutableMap.of(
+                // Match all
+                "match", "*",
+                // Analyze nothing by default
+                "mapping", ImmutableMap.of("index", "not_analyzed"));
+        final Map<String, Map<String, Object>> templateAll = ImmutableMap.of("store_generic", defaultAll);
+
+        return ImmutableList.of(templateInternal, templateAll);
+    }
+
+    protected Map<String, Map<String, Object>> fieldProperties(String analyzer) {
+        return ImmutableMap.of(
+                "message", analyzedString(analyzer, false),
+                "full_message", analyzedString(analyzer, false),
+                // http://joda-time.sourceforge.net/api-release/org/joda/time/format/DateTimeFormat.html
+                // http://www.elasticsearch.org/guide/reference/mapping/date-format.html
+                "timestamp", typeTimeWithMillis(),
+                // to support wildcard searches in source we need to lowercase the content (wildcard search lowercases search term)
+                "source", analyzedString("analyzer_keyword", true),
+                "streams", notAnalyzedString());
+    }
+
+    private Map<String, Object> notAnalyzedString() {
+        return ImmutableMap.of("type", "keyword");
+    }
+
+    private Map<String, Object> analyzedString(String analyzer, boolean fieldData) {
+        return ImmutableMap.of(
+                "type", "text",
+                "analyzer", analyzer,
+                "fielddata", fieldData);
+    }
+}

--- a/graylog2-server/src/test/java/org/graylog2/indexer/indices/IndicesGetAllMessageFieldsTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/indexer/indices/IndicesGetAllMessageFieldsTest.java
@@ -26,11 +26,11 @@ import org.elasticsearch.action.admin.indices.exists.indices.IndicesExistsReques
 import org.elasticsearch.action.admin.indices.exists.indices.IndicesExistsResponse;
 import org.elasticsearch.action.admin.indices.get.GetIndexRequest;
 import org.elasticsearch.action.admin.indices.get.GetIndexResponse;
+import org.graylog2.AbstractESTest;
 import org.graylog2.audit.NullAuditEventSender;
-import org.graylog2.indexer.IndexMapping;
+import org.graylog2.indexer.IndexMapping2;
 import org.graylog2.indexer.messages.Messages;
 import org.graylog2.plugin.system.NodeId;
-import org.graylog2.AbstractESTest;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
@@ -55,7 +55,7 @@ public class IndicesGetAllMessageFieldsTest extends AbstractESTest {
         super.setUp();
         indices = new Indices(jestClient(),
                 new Gson(),
-                new IndexMapping(),
+                new IndexMapping2(),
                 new Messages(new MetricRegistry(), jestClient()),
                 mock(NodeId.class),
                 new NullAuditEventSender(),

--- a/graylog2-server/src/test/java/org/graylog2/indexer/indices/IndicesTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/indexer/indices/IndicesTest.java
@@ -47,6 +47,7 @@ import org.elasticsearch.common.compress.CompressedXContent;
 import org.graylog2.AbstractESTest;
 import org.graylog2.audit.NullAuditEventSender;
 import org.graylog2.indexer.IndexMapping;
+import org.graylog2.indexer.IndexMapping2;
 import org.graylog2.indexer.IndexNotFoundException;
 import org.graylog2.indexer.IndexSet;
 import org.graylog2.indexer.TestIndexSet;
@@ -118,7 +119,7 @@ public class IndicesTest extends AbstractESTest {
         eventBus = new EventBus("indices-test");
         indices = new Indices(jestClient(),
                 new Gson(),
-                new IndexMapping(),
+                new IndexMapping2(),
                 new Messages(new MetricRegistry(), jestClient()),
                 mock(NodeId.class),
                 new NullAuditEventSender(),
@@ -311,7 +312,7 @@ public class IndicesTest extends AbstractESTest {
         assertThat(templateMetaData.getMappings().keysIt()).containsExactly(IndexMapping.TYPE_MESSAGE);
 
         final Map<String, Object> mapping = mapper.readValue(templateMetaData.getMappings().get(IndexMapping.TYPE_MESSAGE).uncompressed(), new TypeReference<Map<String, Object>>() {});
-        final Map<String, Object> expectedTemplate = new IndexMapping().messageTemplate(indexSet.getIndexWildcard(), indexSetConfig.indexAnalyzer());
+        final Map<String, Object> expectedTemplate = new IndexMapping2().messageTemplate(indexSet.getIndexWildcard(), indexSetConfig.indexAnalyzer());
         assertThat(mapping).isEqualTo(expectedTemplate.get("mappings"));
 
         final DeleteIndexTemplateRequest deleteRequest = client.prepareDeleteTemplate(templateName).request();

--- a/graylog2-server/src/test/java/org/graylog2/indexer/nosqlunit/IndexCreatingDatabaseOperation.java
+++ b/graylog2-server/src/test/java/org/graylog2/indexer/nosqlunit/IndexCreatingDatabaseOperation.java
@@ -26,6 +26,7 @@ import org.elasticsearch.client.IndicesAdminClient;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.unit.TimeValue;
 import org.graylog2.indexer.IndexMapping;
+import org.graylog2.indexer.IndexMapping2;
 import org.graylog2.indexer.IndexSet;
 
 import java.io.InputStream;
@@ -57,7 +58,7 @@ public class IndexCreatingDatabaseOperation implements DatabaseOperation<Client>
                 client.admin().indices().prepareDelete(index).execute().actionGet();
             }
 
-            final IndexMapping indexMapping = new IndexMapping();
+            final IndexMapping indexMapping = new IndexMapping2();
 
             final String templateName = "graylog-test-internal";
             final PutIndexTemplateResponse putIndexTemplateResponse = indicesAdminClient.preparePutTemplate(templateName)

--- a/misc/graylog.conf
+++ b/misc/graylog.conf
@@ -177,6 +177,12 @@ rest_listen_uri = http://127.0.0.1:9000/api/
 # Default: "http://127.0.0.1:9200"
 #elasticsearch_hosts = http://node1:9200,http://user:password@node2:19200
 
+# The (major) version of Elasticsearch being used in the cluster. This setting controls which
+# index mapping/index template is being used by Graylog. Valid values are 2 and 5.
+#
+# Default: 5
+#elasticsearch_version = 5
+
 # Maximum amount of time to wait for successfull connection to Elasticsearch HTTP port.
 #
 # Default: 10 Seconds


### PR DESCRIPTION
Index mappings changed quite a lot from Elasticsearch 2.x to Elasticsearch 5.x, so that we cannot simply use the same mapping for both (major) versions:

* https://www.elastic.co/guide/en/elasticsearch/reference/5.4/breaking_50_mapping_changes.html
* https://www.elastic.co/guide/en/elasticsearch/reference/5.4/mapping.html

This change set adds version-specific mappings for ES 2.x and 5.x which can be controlled by the `elasticsearch_version` configuration setting.