### PR TITLE
Lookup ui cleanup

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/lookup/LookupTableService.java
+++ b/graylog2-server/src/main/java/org/graylog2/lookup/LookupTableService.java
@@ -61,6 +61,7 @@ public class LookupTableService {
     private final ConcurrentMap<String, LookupTable> lookupTables = new ConcurrentHashMap<>();
 
     private final ConcurrentMap<String, LookupDataAdapter> liveAdapters = new ConcurrentHashMap<>();
+    private final ConcurrentMap<String, LookupCache> liveCaches = new ConcurrentHashMap<>();
 
     @Inject
     public LookupTableService(MongoLutService mongoLutService,
@@ -252,6 +253,16 @@ public class LookupTableService {
         }
         return liveAdapters.entrySet().stream()
                 .filter(e -> adapterNames.contains(e.getKey()))
+                .map(Map.Entry::getValue)
+                .collect(Collectors.toSet());
+    }
+
+    public Collection<LookupCache> getCaches(Set<String> cacheNames) {
+        if (cacheNames == null) {
+            return Collections.emptySet();
+        }
+        return liveCaches.entrySet().stream()
+                .filter(e -> cacheNames.contains(e.getKey()))
                 .map(Map.Entry::getValue)
                 .collect(Collectors.toSet());
     }

--- a/graylog2-server/src/main/java/org/graylog2/lookup/caches/GuavaLookupCache.java
+++ b/graylog2-server/src/main/java/org/graylog2/lookup/caches/GuavaLookupCache.java
@@ -94,6 +94,15 @@ public class GuavaLookupCache extends LookupCache {
     }
 
     @Override
+    public LookupResult getIfPresent(Object key) {
+        final LookupResult cacheEntry = cache.getIfPresent(key);
+        if (cacheEntry == null) {
+            return LookupResult.empty();
+        }
+        return cacheEntry;
+    }
+
+    @Override
     public void set(Object key, Object retrievedValue) {
         final LookupDataAdapter dataAdapter = getLookupTable().dataAdapter();
         dataAdapter.set(key, retrievedValue);

--- a/graylog2-server/src/main/java/org/graylog2/lookup/caches/NullCache.java
+++ b/graylog2-server/src/main/java/org/graylog2/lookup/caches/NullCache.java
@@ -16,13 +16,15 @@
  */
 package org.graylog2.lookup.caches;
 
+import com.google.auto.value.AutoValue;
+import com.google.inject.Inject;
+import com.google.inject.assistedinject.Assisted;
+
 import com.fasterxml.jackson.annotation.JsonAutoDetect;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
-import com.google.auto.value.AutoValue;
-import com.google.inject.Inject;
-import com.google.inject.assistedinject.Assisted;
+
 import org.graylog.autovalue.WithBeanGetter;
 import org.graylog2.plugin.lookup.LookupCache;
 import org.graylog2.plugin.lookup.LookupCacheConfiguration;
@@ -43,6 +45,11 @@ public class NullCache extends LookupCache {
     @Override
     public LookupResult get(Object key) {
         return getLookupTable().dataAdapter().get(key);
+    }
+
+    @Override
+    public LookupResult getIfPresent(Object key) {
+        return LookupResult.empty();
     }
 
     @Override

--- a/graylog2-server/src/main/java/org/graylog2/plugin/lookup/LookupCache.java
+++ b/graylog2-server/src/main/java/org/graylog2/plugin/lookup/LookupCache.java
@@ -55,6 +55,8 @@ public abstract class LookupCache {
 
     public abstract LookupResult get(Object key);
 
+    public abstract LookupResult getIfPresent(Object key);
+
     public abstract void set(Object key, Object retrievedValue);
 
     public abstract void purge();

--- a/graylog2-server/src/main/java/org/graylog2/rest/resources/system/lookup/LookupTableResource.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/resources/system/lookup/LookupTableResource.java
@@ -17,6 +17,7 @@
 package org.graylog2.rest.resources.system.lookup;
 
 import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Iterables;
 import com.google.common.collect.Maps;
 
 import com.fasterxml.jackson.annotation.JsonAutoDetect;
@@ -40,6 +41,7 @@ import org.graylog2.lookup.events.LookupTablesDeleted;
 import org.graylog2.lookup.events.LookupTablesUpdated;
 import org.graylog2.plugin.lookup.LookupCache;
 import org.graylog2.plugin.lookup.LookupDataAdapter;
+import org.graylog2.plugin.lookup.LookupResult;
 import org.graylog2.rest.models.PaginatedList;
 import org.graylog2.rest.models.system.lookup.CacheApi;
 import org.graylog2.rest.models.system.lookup.DataAdapterApi;
@@ -118,10 +120,10 @@ public class LookupTableResource extends RestResource {
     }
 
     @GET
-    @Path("data/{name}")
+    @Path("tables/{name}/query")
     @ApiOperation(value = "Query a lookup table")
-    public Object performLookup(@ApiParam(name = "name") @PathParam("name") @NotEmpty String name,
-                                @ApiParam(name = "key") @QueryParam("key") @NotEmpty String key) {
+    public LookupResult performLookup(@ApiParam(name = "name") @PathParam("name") @NotEmpty String name,
+                                      @ApiParam(name = "key") @QueryParam("key") @NotEmpty String key) {
         return lookupTables.newBuilder().lookupTable(name).build().lookup(key);
     }
 
@@ -341,6 +343,40 @@ public class LookupTableResource extends RestResource {
             return DataAdapterApi.fromDto(dataAdapterDto.get());
         }
         throw new NotFoundException();
+    }
+
+    @GET
+    @Path("adapters/{name}/query")
+    @ApiOperation(value = "Query a lookup table")
+    public LookupResult performAdapterLookup(@ApiParam(name = "name") @PathParam("name") @NotEmpty String name,
+                                             @ApiParam(name = "key") @QueryParam("key") @NotEmpty String key) {
+        final Collection<LookupDataAdapter> dataAdapters = lookupTables.getDataAdapters(singleton(name));
+        if (!dataAdapters.isEmpty()) {
+            return Iterables.getOnlyElement(dataAdapters).get(key);
+        } else {
+            // not a currently running adapter, we'll have to manually start it to query it
+            final Optional<DataAdapterDto> dtoOptional = adapterService.get(name);
+            if (!dtoOptional.isPresent()) {
+                throw new NotFoundException();
+            }
+            final DataAdapterDto adapterDto = dtoOptional.get();
+            final LookupDataAdapter.Factory factory = dataAdapterTypes.get(adapterDto.config().type());
+            if (factory == null) {
+                LOG.error("Unable to find data adapter factory for type {}, is a plugin missing?", adapterDto.config().type());
+                throw new NotFoundException();
+            }
+            final LookupDataAdapter lookupDataAdapter = factory.create(adapterDto.id(), adapterDto.name(), adapterDto.config());
+            final LookupResult lookupResult;
+            try {
+                lookupDataAdapter.startAsync().awaitRunning();
+                lookupResult = lookupDataAdapter.get(key);
+                lookupDataAdapter.stopAsync();
+            } catch (Exception e) {
+                LOG.error("Unable to start data adapter {}", name, e);
+                return LookupResult.empty();
+            }
+            return lookupResult;
+        }
     }
 
     @POST

--- a/graylog2-web-interface/src/actions/lookup-tables/LookupTableDataAdaptersActions.js
+++ b/graylog2-web-interface/src/actions/lookup-tables/LookupTableDataAdaptersActions.js
@@ -8,6 +8,7 @@ const LookupTableDataAdaptersActions = Reflux.createActions({
   delete: { asyncResult: true },
   update: { asyncResult: true },
   getTypes: { asyncResult: true },
+  lookup: { asyncResult: true },
 });
 
 export default LookupTableDataAdaptersActions;

--- a/graylog2-web-interface/src/actions/lookup-tables/LookupTablesActions.js
+++ b/graylog2-web-interface/src/actions/lookup-tables/LookupTablesActions.js
@@ -8,6 +8,7 @@ const LookupTablesActions = Reflux.createActions({
   delete: { asyncResult: true },
   update: { asyncResult: true },
   getErrors: { asyncResult: true },
+  lookup: { asyncResult: true },
 });
 
 export default LookupTablesActions;

--- a/graylog2-web-interface/src/components/lookup-tables/Cache.jsx
+++ b/graylog2-web-interface/src/components/lookup-tables/Cache.jsx
@@ -39,7 +39,7 @@ const Cache = React.createClass({
           </div>
         </Col>
         <Col md={6}>
-          <h3>Cached data</h3>
+          <h3>TODO: Cached data</h3>
           <p>Use this to inspect the lookup table cache.</p>
         </Col>
       </Row>

--- a/graylog2-web-interface/src/components/lookup-tables/DataAdapter.jsx
+++ b/graylog2-web-interface/src/components/lookup-tables/DataAdapter.jsx
@@ -1,13 +1,39 @@
 import React from 'react';
-import { Row, Col } from 'react-bootstrap';
+import { Button, Row, Col } from 'react-bootstrap';
+import { Input } from 'components/bootstrap';
+import FormsUtils from 'util/FormsUtils';
 import { PluginStore } from 'graylog-web-plugin/plugin';
-
+import CombinedProvider from 'injection/CombinedProvider';
 import Styles from './ConfigSummary.css';
+
+const { LookupTableDataAdaptersActions } = CombinedProvider.get('LookupTableDataAdapters');
 
 const DataAdapter = React.createClass({
 
   propTypes: {
     dataAdapter: React.PropTypes.object.isRequired,
+    lookupResult: React.PropTypes.object,
+  },
+
+  getDefaultProps() {
+    return {
+      lookupResult: null,
+    };
+  },
+
+  getInitialState() {
+    return {
+      lookupKey: null,
+    };
+  },
+
+  _onChange(event) {
+    this.setState({ lookupKey: FormsUtils.getValueFromInput(event.target) });
+  },
+
+  _lookupKey(e) {
+    e.preventDefault();
+    LookupTableDataAdaptersActions.lookup(this.props.dataAdapter.name, this.state.lookupKey);
   },
 
   render() {
@@ -39,8 +65,31 @@ const DataAdapter = React.createClass({
           </div>
         </Col>
         <Col md={6}>
-          <h3>Retrieve data</h3>
-          <p>Use this to manually trigger the data adapter.</p>
+          <h3>Test lookup</h3>
+          <p>You can manually trigger the data adapter using this form. The data will be not cached.</p>
+          <form onSubmit={this._lookupKey}>
+            <fieldset>
+              <Input type="text"
+                     id="key"
+                     name="key"
+                     label="Key"
+                     required
+                     onChange={this._onChange}
+                     help="Key to look up a value for."
+                     value={this.state.lookupKey} />
+            </fieldset>
+            <fieldset>
+              <Input>
+                <Button type="submit" bsStyle="success">Look up</Button>
+              </Input>
+            </fieldset>
+          </form>
+          { this.props.lookupResult && (
+            <div>
+              <h4>Lookup result</h4>
+              <pre>{JSON.stringify(this.props.lookupResult, null, 2)}</pre>
+            </div>
+          )}
         </Col>
       </Row>
     );

--- a/graylog2-web-interface/src/components/lookup-tables/LookupTable.jsx
+++ b/graylog2-web-interface/src/components/lookup-tables/LookupTable.jsx
@@ -1,5 +1,14 @@
 import React from 'react';
-import { Row, Col } from 'react-bootstrap';
+import { Button, Row, Col } from 'react-bootstrap';
+import { Input } from 'components/bootstrap';
+import { LinkContainer } from 'react-router-bootstrap';
+import Routes from 'routing/Routes';
+
+import FormsUtils from 'util/FormsUtils';
+
+import CombinedProvider from 'injection/CombinedProvider';
+
+const { LookupTablesActions } = CombinedProvider.get('LookupTables');
 
 const LookupTable = React.createClass({
 
@@ -7,6 +16,28 @@ const LookupTable = React.createClass({
     table: React.PropTypes.object.isRequired,
     cache: React.PropTypes.object.isRequired,
     dataAdapter: React.PropTypes.object.isRequired,
+    lookupResult: React.PropTypes.object,
+  },
+
+  getDefaultProps() {
+    return {
+      lookupResult: null,
+    };
+  },
+
+  getInitialState() {
+    return {
+      lookupKey: null,
+    };
+  },
+
+  _onChange(event) {
+    this.setState({ lookupKey: FormsUtils.getValueFromInput(event.target) });
+  },
+
+  _lookupKey(e) {
+    e.preventDefault();
+    LookupTablesActions.lookup(this.props.table.name, this.state.lookupKey);
   },
 
   render() {
@@ -15,10 +46,41 @@ const LookupTable = React.createClass({
         <Col md={6}>
           <h3>{this.props.table.title}</h3>
           <span>{this.props.table.description}</span>
+          <dl>
+            <dt>Data adapter</dt>
+            <dd>
+              <LinkContainer to={Routes.SYSTEM.LOOKUPTABLES.DATA_ADAPTERS.show(this.props.dataAdapter.name)}><a>{this.props.dataAdapter.title}</a></LinkContainer>
+            </dd>
+            <dt>Cache</dt>
+            <dd><LinkContainer to={Routes.SYSTEM.LOOKUPTABLES.CACHES.show(this.props.cache.name)}><a>{this.props.cache.title}</a></LinkContainer></dd>
+          </dl>
         </Col>
         <Col md={6}>
-          <h3>Retrieve data</h3>
-          <p>Use this to query the lookup table.</p>
+          <h3>Test lookup</h3>
+          <p>You can manually query the lookup table using this form. The data will be cached as configured by Graylog.</p>
+          <form onSubmit={this._lookupKey}>
+            <fieldset>
+              <Input type="text"
+                     id="key"
+                     name="key"
+                     label="Key"
+                     required
+                     onChange={this._onChange}
+                     help="Key to look up a value for."
+                     value={this.state.lookupKey} />
+            </fieldset>
+            <fieldset>
+              <Input>
+                <Button type="submit" bsStyle="success">Look up</Button>
+              </Input>
+            </fieldset>
+          </form>
+          { this.props.lookupResult && (
+            <div>
+              <h4>Lookup result</h4>
+              <pre>{JSON.stringify(this.props.lookupResult, null, 2)}</pre>
+            </div>
+          )}
         </Col>
       </Row>
     );

--- a/graylog2-web-interface/src/pages/LUTDataAdaptersPage.jsx
+++ b/graylog2-web-interface/src/pages/LUTDataAdaptersPage.jsx
@@ -96,7 +96,7 @@ const LUTDataAdaptersPage = React.createClass({
           </Row>
         );
       } else {
-        content = <DataAdapter dataAdapter={this.state.dataAdapter} />;
+        content = <DataAdapter dataAdapter={this.state.dataAdapter} lookupResult={this.state.lookupResult} />;
       }
     } else if (this._isCreating(this.props)) {
       if (!this.state.types) {

--- a/graylog2-web-interface/src/pages/LUTTablesPage.jsx
+++ b/graylog2-web-interface/src/pages/LUTTablesPage.jsx
@@ -94,7 +94,8 @@ const LUTTablesPage = React.createClass({
       } else {
         content = (<LookupTable dataAdapter={this.state.dataAdapter}
                                 cache={this.state.cache}
-                                table={this.state.table} />);
+                                table={this.state.table}
+                                lookupResult={this.state.lookupResult} />);
       }
     } else if (this._isCreating(this.props)) {
       content = (<LookupTableCreate history={this.props.history} saved={this._saved} />);

--- a/graylog2-web-interface/src/stores/lookup-tables/LookupTableDataAdaptersStore.js
+++ b/graylog2-web-interface/src/stores/lookup-tables/LookupTableDataAdaptersStore.js
@@ -114,6 +114,19 @@ const LookupTableDataAdaptersStore = Reflux.createStore({
     return promise;
   },
 
+  lookup(tableName, key) {
+    const promise = fetch('GET', this._url(`adapters/${tableName}/query?key=${key}`));
+
+    promise.then((response) => {
+      this.trigger({
+        lookupResult: response,
+      });
+    });
+
+    LookupTableDataAdaptersActions.lookup.promise(promise);
+    return promise;
+  },
+
   _errorHandler(message, title, cb) {
     return (error) => {
       let errorMessage;

--- a/graylog2-web-interface/src/stores/lookup-tables/LookupTablesStore.js
+++ b/graylog2-web-interface/src/stores/lookup-tables/LookupTablesStore.js
@@ -75,10 +75,11 @@ const LookupTablesStore = Reflux.createStore({
 
     promise.then((response) => {
       // do not propagate pagination! it will destroy the subsequent overview page's state.
+      const lookupTable = response.lookup_tables[0];
       this.trigger({
-        table: response.lookup_tables[0],
-        cache: response.caches,
-        dataAdapter: response.data_adapters,
+        table: lookupTable,
+        cache: response.caches[lookupTable.cache_id],
+        dataAdapter: response.data_adapters[lookupTable.data_adapter_id],
       });
     }, this._errorHandler(`Fetching lookup table ${idOrName} failed`,
       'Could not retrieve lookup table'));
@@ -136,6 +137,19 @@ const LookupTablesStore = Reflux.createStore({
     }, this._errorHandler('Fetching lookup table error state failed.', 'Could not error states'));
 
     LookupTablesActions.getErrors.promise(promise);
+    return promise;
+  },
+
+  lookup(tableName, key) {
+    const promise = fetch('GET', this._url(`tables/${tableName}/query?key=${key}`));
+
+    promise.then((response) => {
+      this.trigger({
+        lookupResult: response,
+      });
+    });
+
+    LookupTablesActions.lookup.promise(promise);
     return promise;
   },
 


### PR DESCRIPTION
This PR probably needs a bit of work to make it mergable after #3795 has gone into master.

https://github.com/Graylog2/graylog2-server/commit/a1b8397404eb8c02ba85fc8176c2a3099b7e98f9 fixes the HTTP adapter constructor and `name()` method collision.
https://github.com/Graylog2/graylog2-server/commit/05017de7431010eaefd43229bf3ebc7ac66da124 is the actual new feature adding the lookup functions.
The other commits are actually from #3795 to be able to compile against the plugins.