### PR TITLE
Throw FieldTypeException when aggregating on non-numeric fields.

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/alerts/types/FieldValueAlertCondition.java
+++ b/graylog2-server/src/main/java/org/graylog2/alerts/types/FieldValueAlertCondition.java
@@ -20,6 +20,7 @@ import com.google.common.collect.Lists;
 import com.google.inject.assistedinject.Assisted;
 import com.google.inject.assistedinject.AssistedInject;
 import org.graylog2.alerts.AbstractAlertCondition;
+import org.graylog2.indexer.FieldTypeException;
 import org.graylog2.indexer.results.FieldStatsResult;
 import org.graylog2.indexer.results.ResultMessage;
 import org.graylog2.indexer.searches.Searches;
@@ -247,7 +248,7 @@ public class FieldValueAlertCondition extends AbstractAlertCondition {
             // cannot happen lol
             LOG.error("Invalid timerange.", e);
             return null;
-        } catch (Searches.FieldTypeException e) {
+        } catch (FieldTypeException e) {
             LOG.debug("Field [{}] seems not to have a numerical type or doesn't even exist at all. Returning not triggered.", field, e);
             return new NegativeCheckResult();
         }

--- a/graylog2-server/src/main/java/org/graylog2/dashboards/widgets/strategies/FieldChartWidgetStrategy.java
+++ b/graylog2-server/src/main/java/org/graylog2/dashboards/widgets/strategies/FieldChartWidgetStrategy.java
@@ -19,6 +19,7 @@ package org.graylog2.dashboards.widgets.strategies;
 import com.google.inject.assistedinject.Assisted;
 import com.google.inject.assistedinject.AssistedInject;
 import org.graylog2.dashboards.widgets.InvalidWidgetConfigurationException;
+import org.graylog2.indexer.FieldTypeException;
 import org.graylog2.indexer.results.HistogramResult;
 import org.graylog2.indexer.searches.Searches;
 import org.graylog2.plugin.dashboards.widgets.ComputationResult;
@@ -87,7 +88,7 @@ public class FieldChartWidgetStrategy extends ChartWidgetStrategy {
                     "cardinality".equalsIgnoreCase(statisticalFunction));
 
             return new ComputationResult(histogramResult.getResults(), histogramResult.tookMs(), histogramResult.getHistogramBoundaries());
-        } catch (Searches.FieldTypeException e) {
+        } catch (FieldTypeException e) {
             String msg = "Could not calculate [" + this.getClass().getCanonicalName() + "] widget <" + this.widgetId + ">. Not a numeric field? The field was [" + field + "]";
             LOG.error(msg, e);
             throw new RuntimeException(msg, e);

--- a/graylog2-server/src/main/java/org/graylog2/dashboards/widgets/strategies/StackedChartWidgetStrategy.java
+++ b/graylog2-server/src/main/java/org/graylog2/dashboards/widgets/strategies/StackedChartWidgetStrategy.java
@@ -21,6 +21,7 @@ import com.google.common.collect.ImmutableMap;
 import com.google.inject.assistedinject.Assisted;
 import com.google.inject.assistedinject.AssistedInject;
 import org.graylog2.dashboards.widgets.InvalidWidgetConfigurationException;
+import org.graylog2.indexer.FieldTypeException;
 import org.graylog2.indexer.results.HistogramResult;
 import org.graylog2.indexer.searches.Searches;
 import org.graylog2.plugin.dashboards.widgets.ComputationResult;
@@ -106,7 +107,7 @@ public class StackedChartWidgetStrategy extends ChartWidgetStrategy {
 
                 results.add(histogramResult.getResults());
                 tookMs += histogramResult.tookMs();
-            } catch (Searches.FieldTypeException e) {
+            } catch (FieldTypeException e) {
                 String msg = "Could not calculate [" + this.getClass().getCanonicalName() + "] widget <" + widgetId + ">. Not a numeric field? The field was [" + series.field + "]";
                 LOG.error(msg, e);
                 throw new RuntimeException(msg, e);

--- a/graylog2-server/src/main/java/org/graylog2/dashboards/widgets/strategies/StatisticalCountWidgetStrategy.java
+++ b/graylog2-server/src/main/java/org/graylog2/dashboards/widgets/strategies/StatisticalCountWidgetStrategy.java
@@ -19,6 +19,7 @@ package org.graylog2.dashboards.widgets.strategies;
 import com.google.common.collect.Maps;
 import com.google.inject.assistedinject.Assisted;
 import com.google.inject.assistedinject.AssistedInject;
+import org.graylog2.indexer.FieldTypeException;
 import org.graylog2.indexer.results.FieldStatsResult;
 import org.graylog2.indexer.searches.Searches;
 import org.graylog2.plugin.dashboards.widgets.ComputationResult;
@@ -162,7 +163,7 @@ public class StatisticalCountWidgetStrategy extends SearchResultCountWidgetStrat
             } else {
                 return new ComputationResult(getStatisticalValue(fieldStatsResult), fieldStatsResult.tookMs());
             }
-        } catch (Searches.FieldTypeException e) {
+        } catch (FieldTypeException e) {
             log.warn("Invalid field provided, returning 'NaN'", e);
             return new ComputationResult(Double.NaN, 0);
         }

--- a/graylog2-server/src/main/java/org/graylog2/indexer/FieldTypeException.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/FieldTypeException.java
@@ -17,13 +17,14 @@
 package org.graylog2.indexer;
 
 import java.util.Collections;
+import java.util.List;
 
 public class FieldTypeException extends ElasticsearchException {
-    public FieldTypeException(String msg) {
-        super(msg);
+    public FieldTypeException(String message, String reason) {
+        this(message, Collections.singletonList(reason));
     }
 
-    public FieldTypeException(String message, String reason) {
-        super(message, Collections.singletonList(reason));
+    public FieldTypeException(String message, List<String> errorDetails) {
+        super(message, errorDetails);
     }
 }

--- a/graylog2-server/src/main/java/org/graylog2/indexer/FieldTypeException.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/FieldTypeException.java
@@ -1,0 +1,13 @@
+package org.graylog2.indexer;
+
+import java.util.Collections;
+
+public class FieldTypeException extends ElasticsearchException {
+    public FieldTypeException(String msg) {
+        super(msg);
+    }
+
+    public FieldTypeException(String message, String reason) {
+        super(message, Collections.singletonList(reason));
+    }
+}

--- a/graylog2-server/src/main/java/org/graylog2/indexer/FieldTypeException.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/FieldTypeException.java
@@ -1,3 +1,19 @@
+/**
+ * This file is part of Graylog.
+ *
+ * Graylog is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package org.graylog2.indexer;
 
 import java.util.Collections;

--- a/graylog2-server/src/main/java/org/graylog2/indexer/cluster/jest/JestUtils.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/cluster/jest/JestUtils.java
@@ -90,6 +90,7 @@ public class JestUtils {
                     if (reason != null && reason.startsWith("Expected numeric type on field")) {
                         return buildFieldTypeException(errorMessage, reason);
                     }
+                    break;
             }
         }
 

--- a/graylog2-server/src/main/java/org/graylog2/indexer/cluster/jest/JestUtils.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/cluster/jest/JestUtils.java
@@ -23,6 +23,7 @@ import io.searchbox.client.JestResult;
 import io.searchbox.client.http.JestHttpClient;
 import org.apache.http.client.config.RequestConfig;
 import org.graylog2.indexer.ElasticsearchException;
+import org.graylog2.indexer.FieldTypeException;
 import org.graylog2.indexer.IndexNotFoundException;
 import org.graylog2.indexer.QueryParsingException;
 import org.graylog2.indexer.gson.GsonUtils;
@@ -84,6 +85,11 @@ public class JestUtils {
                 case "index_not_found_exception":
                     final String indexName = asString(rootCause.get("resource.id"));
                     return buildIndexNotFoundException(errorMessage, indexName);
+                case "illegal_argument_exception":
+                    final String reason = asString(rootCause.get("reason"));
+                    if (reason != null && reason.startsWith("Expected numeric type on field")) {
+                        return buildFieldTypeException(errorMessage, reason);
+                    }
             }
         }
 
@@ -92,6 +98,10 @@ public class JestUtils {
         }
 
         return new ElasticsearchException(errorMessage.get(), reasons);
+    }
+
+    private static FieldTypeException buildFieldTypeException(Supplier<String> errorMessage, String reason) {
+        return new FieldTypeException(errorMessage.get(), reason);
     }
 
     private static List<String> extractReasons(List<JsonObject> rootCauses) {

--- a/graylog2-server/src/main/java/org/graylog2/indexer/searches/Searches.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/searches/Searches.java
@@ -34,7 +34,6 @@ import io.searchbox.core.search.aggregation.HistogramAggregation;
 import io.searchbox.core.search.aggregation.MissingAggregation;
 import io.searchbox.core.search.aggregation.TermsAggregation;
 import io.searchbox.core.search.aggregation.ValueCountAggregation;
-import io.searchbox.core.search.sort.Sort;
 import io.searchbox.params.Parameters;
 import org.elasticsearch.index.query.BoolQueryBuilder;
 import org.elasticsearch.index.query.QueryBuilder;
@@ -45,10 +44,10 @@ import org.elasticsearch.search.aggregations.bucket.filter.FilterAggregationBuil
 import org.elasticsearch.search.aggregations.bucket.histogram.DateHistogramBuilder;
 import org.elasticsearch.search.aggregations.bucket.terms.Terms;
 import org.elasticsearch.search.builder.SearchSourceBuilder;
-import org.elasticsearch.search.sort.SortParseElement;
 import org.graylog2.Configuration;
 import org.graylog2.database.NotFoundException;
 import org.graylog2.indexer.ElasticsearchException;
+import org.graylog2.indexer.FieldTypeException;
 import org.graylog2.indexer.IndexHelper;
 import org.graylog2.indexer.IndexMapping;
 import org.graylog2.indexer.IndexSet;
@@ -642,6 +641,11 @@ public class Searches {
                 .filter(Objects::nonNull)
                 .collect(Collectors.toList());
 
+            final Optional<String> nonNumericFieldError = errors.stream().filter(error -> error.startsWith("Expected numeric type on field")).findAny();
+            if (nonNumericFieldError.isPresent()) {
+                throw new FieldTypeException(nonNumericFieldError.get());
+            }
+
             throw new ElasticsearchException("Unable to perform search query.", errors);
         }
 
@@ -782,12 +786,6 @@ public class Searches {
         }
 
         return filterBuilder;
-    }
-
-    public static class FieldTypeException extends ElasticsearchException {
-        public FieldTypeException(Throwable e) {
-            super(e);
-        }
     }
 
 

--- a/graylog2-server/src/main/java/org/graylog2/indexer/searches/Searches.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/searches/Searches.java
@@ -641,9 +641,11 @@ public class Searches {
                 .filter(Objects::nonNull)
                 .collect(Collectors.toList());
 
-            final Optional<String> nonNumericFieldError = errors.stream().filter(error -> error.startsWith("Expected numeric type on field")).findAny();
-            if (nonNumericFieldError.isPresent()) {
-                throw new FieldTypeException(nonNumericFieldError.get());
+            final List<String> nonNumericFieldErrors = errors.stream()
+                .filter(error -> error.startsWith("Expected numeric type on field"))
+                .collect(Collectors.toList());
+            if (!nonNumericFieldErrors.isEmpty()) {
+                throw new FieldTypeException("Unable to perform search query.", nonNumericFieldErrors);
             }
 
             throw new ElasticsearchException("Unable to perform search query.", errors);

--- a/graylog2-server/src/main/java/org/graylog2/rest/resources/search/SearchResource.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/resources/search/SearchResource.java
@@ -21,6 +21,7 @@ import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
 import org.glassfish.jersey.server.ChunkedOutput;
 import org.graylog2.decorators.DecoratorProcessor;
+import org.graylog2.indexer.FieldTypeException;
 import org.graylog2.indexer.ranges.IndexRange;
 import org.graylog2.indexer.results.ResultMessage;
 import org.graylog2.indexer.results.ScrollResult;
@@ -114,11 +115,11 @@ public abstract class SearchResource extends RestResource {
                                                                        org.graylog2.plugin.indexer.searches.timeranges.TimeRange timeRange) {
         try {
             return searches.fieldStats(field, query, filter, timeRange);
-        } catch (Searches.FieldTypeException e) {
+        } catch (FieldTypeException e) {
             try {
                 LOG.debug("Stats query failed, make sure that field [{}] is a numeric type. Retrying without numeric statistics to calculate the field's cardinality.", field);
                 return searches.fieldStats(field, query, filter, timeRange, true, false, true);
-            } catch (Searches.FieldTypeException e1) {
+            } catch (FieldTypeException e1) {
                 LOG.error("Retrieving field statistics for field {} failed while calculating the cardinality. Cause: {}", field, ExceptionUtils.getRootCauseMessage(e1));
                 throw new BadRequestException("Field " + field + " is not of a numeric type and the cardinality could not be calculated either.", e1);
             }
@@ -139,7 +140,7 @@ public abstract class SearchResource extends RestResource {
                 filter,
                 timeRange,
                 includeCardinality);
-        } catch (Searches.FieldTypeException e) {
+        } catch (FieldTypeException e) {
             final String msg = "Field histogram query failed. Make sure that field [" + field + "] is a numeric type.";
             LOG.error(msg);
             throw new BadRequestException(msg, e);

--- a/graylog2-server/src/test/java/org/graylog2/alerts/types/FieldValueAlertConditionTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/alerts/types/FieldValueAlertConditionTest.java
@@ -17,8 +17,8 @@
 package org.graylog2.alerts.types;
 
 import org.graylog2.alerts.AlertConditionTest;
+import org.graylog2.indexer.FieldTypeException;
 import org.graylog2.indexer.results.FieldStatsResult;
-import org.graylog2.indexer.searches.Searches;
 import org.graylog2.plugin.Tools;
 import org.graylog2.plugin.alarms.AlertCondition;
 import org.graylog2.plugin.indexer.searches.timeranges.RelativeRange;
@@ -157,7 +157,7 @@ public class FieldValueAlertConditionTest extends AlertConditionTest {
                 anyBoolean(),
                 anyBoolean(),
                 anyBoolean())).thenReturn(fieldStatsResult);
-        } catch (Searches.FieldTypeException e) {
+        } catch (FieldTypeException e) {
             assertNotNull("This should not return an exception!", e);
         }
     }


### PR DESCRIPTION
This change is now throwing a `FieldTypeException` instead of a generic
`ElasticsearchException` again, when search requests try to aggregate on
a non-numeric field. This allows us to retry getting non-numeric
statistics or show a more accurate error message when trying to generate
charts.
