### PR TITLE
Fix DateHistogram-related functionality in Searches class

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/indexer/searches/Searches.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/searches/Searches.java
@@ -144,8 +144,23 @@ public class Searches {
             return period;
         }
 
-        public long getMillis() {
-            return period.toStandardSeconds().getSeconds() * 1000L;
+        public org.elasticsearch.search.aggregations.bucket.histogram.DateHistogramInterval toESInterval() {
+            switch (this) {
+                case MINUTE:
+                    return org.elasticsearch.search.aggregations.bucket.histogram.DateHistogramInterval.MINUTE;
+                case HOUR:
+                    return org.elasticsearch.search.aggregations.bucket.histogram.DateHistogramInterval.HOUR;
+                case DAY:
+                    return org.elasticsearch.search.aggregations.bucket.histogram.DateHistogramInterval.DAY;
+                case WEEK:
+                    return org.elasticsearch.search.aggregations.bucket.histogram.DateHistogramInterval.WEEK;
+                case MONTH:
+                    return org.elasticsearch.search.aggregations.bucket.histogram.DateHistogramInterval.MONTH;
+                case QUARTER:
+                    return org.elasticsearch.search.aggregations.bucket.histogram.DateHistogramInterval.QUARTER;
+                default:
+                    return org.elasticsearch.search.aggregations.bucket.histogram.DateHistogramInterval.YEAR;
+            }
         }
     }
 
@@ -524,7 +539,7 @@ public class Searches {
             .subAggregation(
                 AggregationBuilders.dateHistogram(AGG_HISTOGRAM)
                     .field(Message.FIELD_TIMESTAMP)
-                    .interval(interval.getMillis())
+                    .interval(interval.toESInterval())
             )
             .filter(standardAggregationFilters(range, filter));
 
@@ -572,7 +587,7 @@ public class Searches {
         final DateHistogramBuilder dateHistogramBuilder = AggregationBuilders.dateHistogram(AGG_HISTOGRAM)
                 .field(Message.FIELD_TIMESTAMP)
                 .subAggregation(AggregationBuilders.stats(AGG_STATS).field(field))
-                .interval(interval.getMillis());
+                .interval(interval.toESInterval());
 
         if (includeCardinality) {
             dateHistogramBuilder.subAggregation(AggregationBuilders.cardinality(AGG_CARDINALITY).field(field));

--- a/graylog2-server/src/test/java/org/graylog2/indexer/searches/SearchesTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/indexer/searches/SearchesTest.java
@@ -444,6 +444,57 @@ public class SearchesTest extends AbstractESTest {
 
     @Test
     @UsingDataSet(loadStrategy = LoadStrategyEnum.CLEAN_INSERT)
+    @SuppressWarnings("unchecked")
+    public void testFieldHistogramWithMonth() throws Exception {
+        final AbsoluteRange range = AbsoluteRange.create(new DateTime(2015, 1, 1, 0, 0, DateTimeZone.UTC).withZone(UTC), new DateTime(2015, 1, 2, 0, 0, DateTimeZone.UTC).withZone(UTC));
+        HistogramResult h = searches.fieldHistogram("*", "n", Searches.DateHistogramInterval.MONTH, null, range, false);
+
+        assertThat(h.getInterval()).isEqualTo(Searches.DateHistogramInterval.MONTH);
+        assertThat(h.getHistogramBoundaries()).isEqualTo(range);
+        assertThat(h.getResults()).hasSize(1);
+        assertThat((Map<String, Number>) h.getResults().get(new DateTime(2015, 1, 1, 0, 0, UTC).getMillis() / 1000L))
+                .containsEntry("total_count", 10L)
+                .containsEntry("total", 19.0)
+                .containsEntry("min", 1.0)
+                .containsEntry("max", 4.0);
+    }
+
+    @Test
+    @UsingDataSet(loadStrategy = LoadStrategyEnum.CLEAN_INSERT)
+    @SuppressWarnings("unchecked")
+    public void testFieldHistogramWithQuarter() throws Exception {
+        final AbsoluteRange range = AbsoluteRange.create(new DateTime(2015, 1, 1, 0, 0, DateTimeZone.UTC).withZone(UTC), new DateTime(2015, 1, 2, 0, 0, DateTimeZone.UTC).withZone(UTC));
+        HistogramResult h = searches.fieldHistogram("*", "n", Searches.DateHistogramInterval.QUARTER, null, range, false);
+
+        assertThat(h.getInterval()).isEqualTo(Searches.DateHistogramInterval.QUARTER);
+        assertThat(h.getHistogramBoundaries()).isEqualTo(range);
+        assertThat(h.getResults()).hasSize(1);
+        assertThat((Map<String, Number>) h.getResults().get(new DateTime(2015, 1, 1, 0, 0, UTC).getMillis() / 1000L))
+                .containsEntry("total_count", 10L)
+                .containsEntry("total", 19.0)
+                .containsEntry("min", 1.0)
+                .containsEntry("max", 4.0);
+    }
+
+    @Test
+    @UsingDataSet(loadStrategy = LoadStrategyEnum.CLEAN_INSERT)
+    @SuppressWarnings("unchecked")
+    public void testFieldHistogramWithYear() throws Exception {
+        final AbsoluteRange range = AbsoluteRange.create(new DateTime(2015, 1, 1, 0, 0, DateTimeZone.UTC).withZone(UTC), new DateTime(2015, 1, 2, 0, 0, DateTimeZone.UTC).withZone(UTC));
+        HistogramResult h = searches.fieldHistogram("*", "n", Searches.DateHistogramInterval.YEAR, null, range, false);
+
+        assertThat(h.getInterval()).isEqualTo(Searches.DateHistogramInterval.YEAR);
+        assertThat(h.getHistogramBoundaries()).isEqualTo(range);
+        assertThat(h.getResults()).hasSize(1);
+        assertThat((Map<String, Number>) h.getResults().get(new DateTime(2015, 1, 1, 0, 0, UTC).getMillis() / 1000L))
+                .containsEntry("total_count", 10L)
+                .containsEntry("total", 19.0)
+                .containsEntry("min", 1.0)
+                .containsEntry("max", 4.0);
+    }
+
+    @Test
+    @UsingDataSet(loadStrategy = LoadStrategyEnum.CLEAN_INSERT)
     public void fieldHistogramRecordsMetrics() throws Exception {
         final AbsoluteRange range = AbsoluteRange.create(new DateTime(2015, 1, 1, 0, 0, DateTimeZone.UTC), new DateTime(2015, 1, 2, 0, 0, DateTimeZone.UTC));
         HistogramResult h = searches.fieldHistogram("*", "n", Searches.DateHistogramInterval.MINUTE, null, range, false);


### PR DESCRIPTION
`Searches.DateHistogramInterval` was using `java.time.Period` to define its intervals and tried to convert them to milliseconds in the `Searches.DateHistogramInterval#getMillis()` method which triggered an exception ("Cannot convert to Seconds as this period contains years and years vary in length") when using a period with variable length such as month, quarter, or year.

This change changes the DateHistogram-related methods in `Searches` to use the equivalent interval from the `org.elasticsearch.search.aggregations.bucket.histogram.DateHistogramInterval` class to perform aggregations.