### PR TITLE
Exclude commons-logging artifacts from Jest and REST Assured

### DIFF
--- a/graylog-project-parent/pom.xml
+++ b/graylog-project-parent/pom.xml
@@ -115,6 +115,12 @@
                 <groupId>org.graylog.jest</groupId>
                 <artifactId>jest</artifactId>
                 <version>${jest.version}</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>commons-logging</groupId>
+                        <artifactId>commons-logging</artifactId>
+                    </exclusion>
+                </exclusions>
             </dependency>
 
             <dependency>
@@ -516,6 +522,12 @@
                 <artifactId>rest-assured</artifactId>
                 <version>${restassured.version}</version>
                 <scope>test</scope>
+                <exclusions>
+                    <exclusion>
+                        <groupId>commons-logging</groupId>
+                        <artifactId>commons-logging</artifactId>
+                    </exclusion>
+                </exclusions>
             </dependency>
             <dependency>
                 <groupId>com.jayway.restassured</groupId>


### PR DESCRIPTION
The transitive dependency on `commons-logging` shadows the SLF4J bridge being used by Graylog.

```
[WARNING] jcl-over-slf4j-1.7.25.jar, commons-logging-1.2.jar define 6 overlapping classes:
[WARNING]   - org.apache.commons.logging.impl.SimpleLog$1
[WARNING]   - org.apache.commons.logging.Log
[WARNING]   - org.apache.commons.logging.impl.SimpleLog
[WARNING]   - org.apache.commons.logging.LogConfigurationException
[WARNING]   - org.apache.commons.logging.impl.NoOpLog
[WARNING]   - org.apache.commons.logging.LogFactory
```