### PR TITLE
Get ES version from cluster, return IndexMapping according to that.

### DIFF
--- a/UPGRADING.rst
+++ b/UPGRADING.rst
@@ -50,8 +50,6 @@ The following configuration options are now being used to configure connectivity
 +----------------------------------------------------+-----------+--------------------------------------------------------------+-----------------------------+
 | ``elasticsearch_socket_timeout``                   | Duration  | Timeout when sending/receiving from Elasticsearch connection | ``60s`` (60 Seconds)        |
 +----------------------------------------------------+-----------+--------------------------------------------------------------+-----------------------------+
-| ``elasticsearch_version``                          | (2 or 5)  | Major version of Elasticsearch being used in the cluster     | ``5``                       |
-+----------------------------------------------------+-----------+--------------------------------------------------------------+-----------------------------+
 | ``elasticsearch_discovery_enabled``                | boolean   | Enable automatic Elasticsearch node discovery                | ``false``                   |
 +----------------------------------------------------+-----------+--------------------------------------------------------------+-----------------------------+
 | ``elasticsearch_discovery_filter``                 | String    | Filter by node attributes for the discovered nodes           | empty (use all nodes)       |
@@ -59,7 +57,7 @@ The following configuration options are now being used to configure connectivity
 | ``elasticsearch_discovery_frequency``              | Duration  | Frequency of the Elasticsearch node discovery                | ``30s`` (30 Seconds)        |
 +----------------------------------------------------+-----------+--------------------------------------------------------------+-----------------------------+
 
-In most cases, the only configuration setting that needs to be set explicitly is ``elasticsearch_hosts``, unless you use Elasticsearch 2.x (or earlier). In the latter case you would need to set ``elasticsearch_version`` to ``2``. All other configuration settings should be tweaked only in case of errors.
+In most cases, the only configuration setting that needs to be set explicitly is ``elasticsearch_hosts``. All other configuration settings should be tweaked only in case of errors.
 
 .. warn:: The automatic node discovery does not work if Elasticsearch requires authentication, e. g. when using Shield (X-Pack).
 

--- a/graylog2-server/src/main/java/org/graylog2/bindings/ElasticsearchModule.java
+++ b/graylog2-server/src/main/java/org/graylog2/bindings/ElasticsearchModule.java
@@ -21,6 +21,7 @@ import com.google.gson.GsonBuilder;
 import com.google.inject.AbstractModule;
 import io.searchbox.client.JestClient;
 import org.graylog2.bindings.providers.JestClientProvider;
+import org.graylog2.bindings.providers.VersionSpecificIndexMappingProvider;
 import org.graylog2.configuration.ElasticsearchClientConfiguration;
 import org.graylog2.indexer.IndexMapping;
 import org.graylog2.indexer.IndexMapping2;
@@ -37,16 +38,6 @@ public class ElasticsearchModule extends AbstractModule {
     protected void configure() {
         bind(Gson.class).toInstance(new GsonBuilder().create());
         bind(JestClient.class).toProvider(JestClientProvider.class).asEagerSingleton();
-
-        switch (elasticsearchClientConfiguration.getVersion()) {
-            case 2:
-                bind(IndexMapping.class).to(IndexMapping2.class).asEagerSingleton();
-                break;
-            case 5:
-                bind(IndexMapping.class).to(IndexMapping5.class).asEagerSingleton();
-                break;
-            default:
-                throw new IllegalArgumentException("Invalid Elasticsearch version: " + elasticsearchClientConfiguration.getVersion());
-        }
+        bind(IndexMapping.class).toProvider(VersionSpecificIndexMappingProvider.class);
     }
 }

--- a/graylog2-server/src/main/java/org/graylog2/bindings/providers/VersionSpecificIndexMappingProvider.java
+++ b/graylog2-server/src/main/java/org/graylog2/bindings/providers/VersionSpecificIndexMappingProvider.java
@@ -1,3 +1,19 @@
+/**
+ * This file is part of Graylog.
+ *
+ * Graylog is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package org.graylog2.bindings.providers;
 
 import com.github.zafarkhaja.semver.Version;

--- a/graylog2-server/src/main/java/org/graylog2/bindings/providers/VersionSpecificIndexMappingProvider.java
+++ b/graylog2-server/src/main/java/org/graylog2/bindings/providers/VersionSpecificIndexMappingProvider.java
@@ -1,0 +1,57 @@
+package org.graylog2.bindings.providers;
+
+import com.github.zafarkhaja.semver.Version;
+import io.searchbox.action.GenericResultAbstractAction;
+import io.searchbox.client.JestClient;
+import io.searchbox.client.JestResult;
+import io.searchbox.core.Ping;
+import org.graylog2.indexer.ElasticsearchException;
+import org.graylog2.indexer.IndexMapping;
+import org.graylog2.indexer.IndexMapping2;
+import org.graylog2.indexer.IndexMapping5;
+import org.graylog2.indexer.cluster.jest.JestUtils;
+import org.graylog2.indexer.gson.GsonUtils;
+
+import javax.inject.Inject;
+import javax.inject.Provider;
+import javax.inject.Singleton;
+import java.util.Optional;
+
+@Singleton
+public class VersionSpecificIndexMappingProvider implements Provider<IndexMapping> {
+    private final static Version V2 = Version.valueOf("2.0.0");
+    private final static Version V5 = Version.valueOf("5.0.0");
+
+    private final IndexMapping indexMapping;
+
+    @Inject
+    public VersionSpecificIndexMappingProvider(JestClientProvider jestClientProvider) {
+        final JestClient jestClient = jestClientProvider.get();
+        final Ping.Builder request = new Ping.Builder();
+
+        final JestResult result = JestUtils.execute(jestClient, request.build(), () -> "Unable to retrieve node info.");
+
+        final Optional<String> versionString = Optional.of(result.getJsonObject())
+            .map(json -> GsonUtils.asJsonObject(json.get("version")))
+            .map(versionObject -> GsonUtils.asString(versionObject.get("number")));
+
+        final Version version = Version.valueOf(versionString.orElseThrow(() -> new ElasticsearchException("Unable to determine version from Elasticsearch cluster")));
+        this.indexMapping = getIndexMappingForVersion(version);
+    }
+
+    @Override
+    public IndexMapping get() {
+        return this.indexMapping;
+    }
+
+    private IndexMapping getIndexMappingForVersion(Version version) {
+        if (version.greaterThanOrEqualTo(V5)) {
+            return new IndexMapping5();
+        }
+        if (version.greaterThanOrEqualTo(V2)) {
+            return new IndexMapping2();
+        }
+
+        throw new ElasticsearchException("Elasticsearch cluster is using unsupported version: " + version.toString());
+    }
+}

--- a/graylog2-server/src/main/java/org/graylog2/configuration/ElasticsearchClientConfiguration.java
+++ b/graylog2-server/src/main/java/org/graylog2/configuration/ElasticsearchClientConfiguration.java
@@ -48,9 +48,6 @@ public class ElasticsearchClientConfiguration {
     @Parameter(value = "elasticsearch_max_total_connections_per_route", validators = { PositiveIntegerValidator.class })
     private int elasticsearchMaxTotalConnectionsPerRoute = 2;
 
-    @Parameter(value = "elasticsearch_version")
-    private int elasticsearchVersion = 5;
-
     @Parameter(value = "elasticsearch_discovery_enabled")
     private boolean discoveryEnabled = false;
 
@@ -59,20 +56,4 @@ public class ElasticsearchClientConfiguration {
 
     @Parameter(value = "elasticsearch_discovery_frequency")
     private Duration discoveryFrequency = Duration.ofSeconds(30L);
-
-    public int getVersion() {
-        return elasticsearchVersion;
-    }
-
-    @SuppressWarnings("unused")
-    @ValidatorMethod
-    public void validateElasticsearchVersion() throws ValidationException {
-        switch (elasticsearchVersion) {
-            case 2:
-            case 5:
-                return;
-            default:
-                throw new ValidationException("Valid values for \"elasticsearch_version\" are 2 and 5, value was " + elasticsearchVersion);
-        }
-    }
 }

--- a/misc/graylog.conf
+++ b/misc/graylog.conf
@@ -177,12 +177,6 @@ rest_listen_uri = http://127.0.0.1:9000/api/
 # Default: "http://127.0.0.1:9200"
 #elasticsearch_hosts = http://node1:9200,http://user:password@node2:19200
 
-# The (major) version of Elasticsearch being used in the cluster. This setting controls which
-# index mapping/index template is being used by Graylog. Valid values are 2 and 5.
-#
-# Default: 5
-#elasticsearch_version = 5
-
 # Maximum amount of time to wait for successfull connection to Elasticsearch HTTP port.
 #
 # Default: 10 Seconds


### PR DESCRIPTION
Before this change, users need to explicitly configure the Elasticsearch
major version in their config file. After this change, it is retrieved
upon bindings initialization time by querying the root resource of the
Elasticsearch cluster, extracting the retrieved version string and
configuring the index mapping according to that.

Obviously it queries only a single server in the cluster, assuming that
at least the major version of all nodes in the cluster match. But this
is the same for the explicit configuration setting.
