### PR TITLE
Small spelling/documentation fixes.

### DIFF
--- a/UPGRADING.rst
+++ b/UPGRADING.rst
@@ -40,7 +40,7 @@ The following configuration options are now being used to configure connectivity
 +====================================================+===========+==============================================================+=============================+
 | ``elasticsearch_connect_timeout``                  | Duration  | Timeout when connection to individual Elasticsearch hosts    | ``10s`` (10 Seconds)        |
 +----------------------------------------------------+-----------+--------------------------------------------------------------+-----------------------------+
-| ``elasticsearch_hosts``                            | List<URI> | Comma-separated list of URIs of Elasticsearch hosts          | ``"http://127.0.0.1:9200"`` |
+| ``elasticsearch_hosts``                            | List<URI> | Comma-separated list of URIs of Elasticsearch hosts          | ``http://127.0.0.1:9200``   |
 +----------------------------------------------------+-----------+--------------------------------------------------------------+-----------------------------+
 | ``elasticsearch_idle_timeout``                     | Duration  | Timeout after which idle connections are terminated          | ``-1s`` (Never)             |
 +----------------------------------------------------+-----------+--------------------------------------------------------------+-----------------------------+

--- a/graylog2-server/src/main/java/org/graylog2/indexer/MongoIndexSet.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/MongoIndexSet.java
@@ -245,7 +245,7 @@ public class MongoIndexSet implements IndexSet {
         if (isUp()) {
             LOG.info("Found deflector alias <{}>. Using it.", getWriteIndexAlias());
         } else {
-            LOG.info("Did not find an deflector alias. Setting one up now.");
+            LOG.info("Did not find a deflector alias. Setting one up now.");
 
             // Do we have a target index to point to?
             try {

--- a/misc/graylog.conf
+++ b/misc/graylog.conf
@@ -174,7 +174,7 @@ rest_listen_uri = http://127.0.0.1:9000/api/
 # If one or more of your elasticsearch hosts require authentication, include the credentials in each node URI that
 # requires authentication.
 #
-# Default: "http://127.0.0.1:9200"
+# Default: http://127.0.0.1:9200
 #elasticsearch_hosts = http://node1:9200,http://user:password@node2:19200
 
 # The (major) version of Elasticsearch being used in the cluster. This setting controls which


### PR DESCRIPTION
 * Removing quotes from `elasticsearch_hosts` config directive samples
 * Correcting minor spelling error
