### PR TITLE
Allow specifying locale for Date converter

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/rest/models/system/responses/LocalesResponse.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/models/system/responses/LocalesResponse.java
@@ -1,0 +1,61 @@
+/**
+ * This file is part of Graylog.
+ *
+ * Graylog is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.graylog2.rest.models.system.responses;
+
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.auto.value.AutoValue;
+import com.google.common.collect.ImmutableMap;
+
+import java.util.Arrays;
+import java.util.Locale;
+import java.util.function.Function;
+
+@JsonAutoDetect
+@AutoValue
+public abstract class LocalesResponse {
+    @JsonProperty("locales")
+    public abstract ImmutableMap<String, LocaleDescription> locales();
+
+    public static LocalesResponse create(Locale[] locales) {
+        final ImmutableMap<String, LocaleDescription> localeMap = Arrays.stream(locales)
+                .map(LocaleDescription::create)
+                .collect(ImmutableMap.toImmutableMap(
+                        LocaleDescription::languageTag,
+                        Function.identity()
+                ));
+        return new AutoValue_LocalesResponse(localeMap);
+    }
+
+    @JsonAutoDetect
+    @AutoValue
+    public static abstract class LocaleDescription {
+        @JsonProperty("language_tag")
+        public abstract String languageTag();
+
+        @JsonProperty("display_name")
+        public abstract String displayName();
+
+        public static LocaleDescription create(Locale locale) {
+            return create(locale.toLanguageTag(), locale.getDisplayName(Locale.ENGLISH));
+        }
+
+        private static LocaleDescription create(String languageTag, String displayName) {
+            return new AutoValue_LocalesResponse_LocaleDescription(languageTag, displayName);
+        }
+    }
+}

--- a/graylog2-server/src/main/java/org/graylog2/shared/rest/resources/system/SystemResource.java
+++ b/graylog2-server/src/main/java/org/graylog2/shared/rest/resources/system/SystemResource.java
@@ -28,6 +28,7 @@ import org.graylog2.plugin.ServerStatus;
 import org.graylog2.plugin.Tools;
 import org.graylog2.plugin.cluster.ClusterConfigService;
 import org.graylog2.plugin.cluster.ClusterId;
+import org.graylog2.rest.models.system.responses.LocalesResponse;
 import org.graylog2.rest.models.system.responses.SystemJVMResponse;
 import org.graylog2.rest.models.system.responses.SystemOverviewResponse;
 import org.graylog2.rest.models.system.responses.SystemThreadDumpResponse;
@@ -123,6 +124,14 @@ public class SystemResource extends RestResource {
     public StreamingOutput threadDumpAsText() {
         checkPermission(RestPermissions.THREADS_DUMP, serverStatus.getNodeId().toString());
         return output -> new ThreadDump(ManagementFactory.getThreadMXBean()).dump(output);
+    }
+
+    @GET
+    @ApiOperation(value = "Get supported locales")
+    @Path("/locales")
+    @Timed
+    public LocalesResponse locales() {
+        return LocalesResponse.create(Locale.getAvailableLocales());
     }
 
     private Map<String, Long> bytesToValueMap(long bytes) {

--- a/graylog2-server/src/test/java/org/graylog2/inputs/converters/DateConverterTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/inputs/converters/DateConverterTest.java
@@ -26,6 +26,7 @@ import org.joda.time.YearMonth;
 import org.junit.Test;
 
 import java.util.HashMap;
+import java.util.Locale;
 import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -34,7 +35,7 @@ public class DateConverterTest {
     @Test
     public void testBasicConvert() throws Exception {
         // .startsWith() because of possibly different timezones per test environment.
-        final DateConverter converter = new DateConverter(config("YYYY MMM dd HH:mm:ss", null));
+        final DateConverter converter = new DateConverter(config("YYYY MMM dd HH:mm:ss", null, null));
         final Object result = converter.convert("2013 Aug 15 23:15:16");
         assertThat(result).isNotNull();
         assertThat(String.valueOf(result)).startsWith("2013-08-15T23:15:16.000");
@@ -42,7 +43,7 @@ public class DateConverterTest {
 
     @Test
     public void testAnotherBasicConvert() throws Exception {
-        final DateConverter converter = new DateConverter(config("yyyy-MM-dd'T'HH:mm:ss.SSSSSSZZ", "Etc/UTC"));
+        final DateConverter converter = new DateConverter(config("yyyy-MM-dd'T'HH:mm:ss.SSSSSSZZ", "Etc/UTC", null));
         final DateTime date = (DateTime) converter.convert("2014-05-19T00:30:43.116+00:00");
         assertThat(date).isNotNull();
         Assertions.assertThat(date).isEqualTo(new DateTime(2014, 5, 19, 0, 30, 43, 116, DateTimeZone.UTC));
@@ -52,7 +53,7 @@ public class DateConverterTest {
     @Test
     public void testConvertWithoutYear() throws Exception {
         final int year = YearMonth.now(DateTimeZone.UTC).getYear();
-        final DateConverter converter = new DateConverter(config("dd-MM HH:mm:ss", "Etc/UTC"));
+        final DateConverter converter = new DateConverter(config("dd-MM HH:mm:ss", "Etc/UTC", null));
         final DateTime date = (DateTime) converter.convert("19-05 10:20:30");
         assertThat(date).isNotNull();
         Assertions.assertThat(date).isEqualTo(new DateTime(year, 5, 19, 10, 20, 30, DateTimeZone.UTC));
@@ -60,18 +61,18 @@ public class DateConverterTest {
 
     @Test(expected = ConfigurationException.class)
     public void testWithEmptyDateFormat() throws Exception {
-        assertThat(new DateConverter(config("", null)).convert("foo")).isNull();
+        assertThat(new DateConverter(config("", null, null)).convert("foo")).isNull();
     }
 
     @Test(expected = ConfigurationException.class)
     public void testWithNullDateFormat() throws Exception {
-        assertThat(new DateConverter(config(null, null)).convert("foo")).isNull();
+        assertThat(new DateConverter(config(null, null, null)).convert("foo")).isNull();
     }
 
     @Test
     public void convertObeysTimeZone() throws Exception {
         final DateTimeZone timeZone = DateTimeZone.forOffsetHours(12);
-        final Converter c = new DateConverter(config("YYYY-MM-dd HH:mm:ss", timeZone.toString()));
+        final Converter c = new DateConverter(config("YYYY-MM-dd HH:mm:ss", timeZone.toString(), null));
 
         final DateTime dateOnly = (DateTime) c.convert("2014-03-12 10:00:00");
         assertThat(dateOnly.getZone()).isEqualTo(timeZone);
@@ -88,23 +89,44 @@ public class DateConverterTest {
 
     @Test
     public void convertUsesEtcUTCIfTimeZoneSettingIsEmpty() throws Exception {
-        final Converter c = new DateConverter(config("YYYY-MM-dd HH:mm:ss", ""));
+        final Converter c = new DateConverter(config("YYYY-MM-dd HH:mm:ss", "", null));
         final DateTime dateOnly = (DateTime) c.convert("2014-03-12 10:00:00");
         assertThat(dateOnly.getZone()).isEqualTo(DateTimeZone.forID("Etc/UTC"));
     }
 
     @Test
     public void convertUsesEtcUTCIfTimeZoneSettingIsBlank() throws Exception {
-        final Converter c = new DateConverter(config("YYYY-MM-dd HH:mm:ss", " "));
+        final Converter c = new DateConverter(config("YYYY-MM-dd HH:mm:ss", " ", null));
         final DateTime dateOnly = (DateTime) c.convert("2014-03-12 10:00:00");
         assertThat(dateOnly.getZone()).isEqualTo(DateTimeZone.forID("Etc/UTC"));
     }
 
     @Test
     public void convertUsesEtcUTCIfTimeZoneSettingIsInvalid() throws Exception {
-        final Converter c = new DateConverter(config("YYYY-MM-dd HH:mm:ss", "TEST"));
+        final Converter c = new DateConverter(config("YYYY-MM-dd HH:mm:ss", "TEST", null));
         final DateTime dateOnly = (DateTime) c.convert("2014-03-12 10:00:00");
         assertThat(dateOnly.getZone()).isEqualTo(DateTimeZone.forID("Etc/UTC"));
+    }
+
+    @Test
+    public void convertUsesEnglishIfLocaleIsNull() throws Exception {
+        final Converter c = new DateConverter(config("dd/MMM/YYYY HH:mm:ss Z", null, null));
+        final DateTime dateOnly = (DateTime) c.convert("11/May/2017 15:10:48 +0200");
+        Assertions.assertThat(dateOnly).isEqualTo(new DateTime(2017, 5, 11, 13, 10, 48, DateTimeZone.UTC));
+    }
+
+    @Test
+    public void convertUsesEnglishIfLocaleIsInvalid() throws Exception {
+        final Converter c = new DateConverter(config("dd/MMM/YYYY HH:mm:ss Z", null, "Wurstweck"));
+        final DateTime dateOnly = (DateTime) c.convert("11/May/2017 15:10:48 +0200");
+        Assertions.assertThat(dateOnly).isEqualTo(new DateTime(2017, 5, 11, 13, 10, 48, DateTimeZone.UTC));
+    }
+
+    @Test
+    public void convertUsesCustomLocale() throws Exception {
+        final Converter c = new DateConverter(config("dd/MMM/YYYY HH:mm:ss Z", null, "de-DE"));
+        final DateTime dateOnly = (DateTime) c.convert("11/März/2017 15:10:48 +0200");
+        Assertions.assertThat(dateOnly).isEqualTo(new DateTime(2017, 3, 11, 13, 10, 48, DateTimeZone.UTC));
     }
 
     /**
@@ -112,26 +134,27 @@ public class DateConverterTest {
      */
     @Test
     public void issue2648() throws Exception {
-        final Converter utc = new DateConverter(config("YYYY-MM-dd HH:mm:ss", "UTC"));
+        final Converter utc = new DateConverter(config("YYYY-MM-dd HH:mm:ss", "UTC", null));
         final DateTime utcDate = (DateTime) utc.convert("2016-08-10 12:00:00");
         assertThat(utcDate.getZone()).isEqualTo(DateTimeZone.UTC);
         assertThat(utcDate.getZone().getOffsetFromLocal(0L)).isEqualTo(0);
 
-        final Converter cet = new DateConverter(config("YYYY-MM-dd HH:mm:ss", "CET"));
+        final Converter cet = new DateConverter(config("YYYY-MM-dd HH:mm:ss", "CET", null));
         final DateTime cetDate = (DateTime) cet.convert("2016-08-10 12:00:00");
         assertThat(cetDate.getZone()).isEqualTo(DateTimeZone.forID("CET"));
         assertThat(cetDate.getZone().getOffsetFromLocal(0L)).isEqualTo((int) Duration.standardHours(1L).getMillis());
 
-        final Converter berlin = new DateConverter(config("YYYY-MM-dd HH:mm:ss", "Europe/Berlin"));
+        final Converter berlin = new DateConverter(config("YYYY-MM-dd HH:mm:ss", "Europe/Berlin", null));
         final DateTime berlinDate = (DateTime) berlin.convert("2016-08-10 12:00:00");
         assertThat(berlinDate.getZone()).isEqualTo(DateTimeZone.forID("Europe/Berlin"));
         assertThat(berlinDate.getZone().getOffsetFromLocal(0L)).isEqualTo((int) Duration.standardHours(1L).getMillis());
     }
 
-    private Map<String, Object> config(final String dateFormat, final String timeZone) {
+    private Map<String, Object> config(final String dateFormat, final String timeZone, final String locale) {
         final Map<String, Object> config = new HashMap<>();
         config.put("date_format", dateFormat);
         config.put("time_zone", timeZone);
+        config.put("locale", locale);
         return config;
     }
 }

--- a/graylog2-web-interface/src/components/common/LocaleSelect.jsx
+++ b/graylog2-web-interface/src/components/common/LocaleSelect.jsx
@@ -1,0 +1,51 @@
+import React from "react";
+import Reflux from 'reflux';
+
+import Select from "components/common/Select";
+
+import StoreProvider from "injection/StoreProvider";
+const SystemStore = StoreProvider.getStore('System');
+
+const LocaleSelect = React.createClass({
+  mixins: [Reflux.connect(SystemStore)],
+  propTypes: {
+    onChange: React.PropTypes.func,
+  },
+  getValue() {
+    return this.refs.locale.getValue();
+  },
+  _formatLocales(locales) {
+    return Object.values(locales).map(locale => {
+      return {value: locale['language_tag'], label: locale['display_name']}
+    }).sort(function(a, b) {
+        const nameA = a.label.toUpperCase();
+        const nameB = b.label.toUpperCase();
+        if (nameA < nameB) {
+            return -1;
+        }
+        if (nameA > nameB) {
+            return 1;
+        }
+
+        return 0;
+    });
+  },
+  _renderOption(option) {
+      return <span key={option.value} title="{option.value} [{option.value}]">{option.label} [{option.value}]</span>;
+  },
+  render() {
+    if (!this.state.locales) {
+      return <Spinner />;
+    }
+
+    const locales = this._formatLocales(this.state.locales);
+    return (
+      <Select ref="locale" {...this.props}
+              placeholder="Pick a locale"
+              options={locales}
+              optionRenderer={this._renderOption} />
+    );
+  },
+});
+
+export default LocaleSelect;

--- a/graylog2-web-interface/src/components/common/LocaleSelect.jsx
+++ b/graylog2-web-interface/src/components/common/LocaleSelect.jsx
@@ -1,5 +1,5 @@
 import React from "react";
-import Reflux from 'reflux';
+import Reflux from "reflux";
 
 import Select from "components/common/Select";
 
@@ -15,9 +15,12 @@ const LocaleSelect = React.createClass({
     return this.refs.locale.getValue();
   },
   _formatLocales(locales) {
-    return Object.values(locales).map(locale => {
-      return {value: locale['language_tag'], label: locale['display_name']}
-    }).sort(function(a, b) {
+    const sortedLocales = Object.values(locales)
+        .filter(locale => locale['language_tag'] !== 'und')
+        .map(locale => {
+          return {value: locale['language_tag'], label: locale['display_name']}
+        })
+        .sort(function(a, b) {
         const nameA = a.label.toUpperCase();
         const nameB = b.label.toUpperCase();
         if (nameA < nameB) {
@@ -29,6 +32,8 @@ const LocaleSelect = React.createClass({
 
         return 0;
     });
+
+    return [{value: 'und', label:'Default locale'}].concat(sortedLocales);
   },
   _renderOption(option) {
       return <span key={option.value} title="{option.value} [{option.value}]">{option.label} [{option.value}]</span>;

--- a/graylog2-web-interface/src/components/common/index.jsx
+++ b/graylog2-web-interface/src/components/common/index.jsx
@@ -9,6 +9,7 @@ export { default as IfPermitted } from './IfPermitted';
 export { default as ISODurationInput } from './ISODurationInput';
 export { default as LinkToNode } from './LinkToNode';
 export { default as LoadingIndicator } from './LoadingIndicator';
+export { default as LocaleSelect } from './LocaleSelect';
 export { default as KeyValueTable } from './KeyValueTable';
 export { default as MultiSelect } from './MultiSelect';
 export { default as OverlayElement } from './OverlayElement';

--- a/graylog2-web-interface/src/components/extractors/converters_configuration/DateConverterConfiguration.jsx
+++ b/graylog2-web-interface/src/components/extractors/converters_configuration/DateConverterConfiguration.jsx
@@ -2,7 +2,7 @@ import React, { PropTypes } from 'react';
 import { Row, Col } from 'react-bootstrap';
 
 import { Input } from 'components/bootstrap';
-import { TimezoneSelect } from 'components/common';
+import { LocaleSelect, TimezoneSelect } from 'components/common';
 import DocumentationLink from 'components/support/DocumentationLink';
 
 import DocsHelper from 'util/DocsHelper';
@@ -51,6 +51,13 @@ const DateConverterConfiguration = React.createClass({
       </span>
     );
 
+    const localeHelpMessage = (
+      <span>
+        Locale to use when parsing the date. Read more in the <DocumentationLink
+        page={DocsHelper.PAGES.PAGE_STANDARD_DATE_CONVERTER} text="documentation" />.
+      </span>
+    );
+
     return (
       <div className="xtrc-converter">
         <Input type="checkbox"
@@ -84,6 +91,17 @@ const DateConverterConfiguration = React.createClass({
                                 className="timezone-select"
                                 value={this.props.configuration.time_zone}
                                 onChange={this._onChange('time_zone')} />
+              </Input>
+              <Input label="Locale"
+                     id={`${this.props.type}_converter_locale`}
+                     labelClassName="col-sm-3"
+                     wrapperClassName="col-sm-9"
+                     help={localeHelpMessage}>
+                <LocaleSelect ref="locale"
+                              id={`${this.props.type}_converter_locale`}
+                              className="locale-select"
+                              value={this.props.configuration.locale}
+                              onChange={this._onChange('locale')} />
               </Input>
             </div>
           </Col>

--- a/graylog2-web-interface/src/routing/ApiRoutes.js
+++ b/graylog2-web-interface/src/routing/ApiRoutes.js
@@ -189,6 +189,7 @@ const ApiRoutes = {
     info: () => { return { url: '/system' }; },
     jvm: () => { return { url: '/system/jvm' }; },
     fields: () => { return { url: '/system/fields' }; },
+    locales: () => { return { url: '/system/locales' }; },
   },
   SystemJobsApiController: {
     list: () => { return { url: '/cluster/jobs' }; },

--- a/graylog2-web-interface/src/stores/system/SystemStore.js
+++ b/graylog2-web-interface/src/stores/system/SystemStore.js
@@ -6,14 +6,19 @@ import fetch from 'logic/rest/FetchProvider';
 
 const SystemStore = Reflux.createStore({
   system: undefined,
+  locales: undefined,
   init() {
     this.info().then((response) => {
       this.trigger({ system: response });
       this.system = response;
     });
+    this.systemLocales().then((response) => {
+      this.trigger({ locales: response });
+      this.locales = response.locales;
+    });
   },
   getInitialState() {
-    return { system: this.system };
+    return { system: this.system, locales: this.locales };
   },
   info() {
     const url = URLUtils.qualifyUrl(ApiRoutes.SystemApiController.info().url);
@@ -22,6 +27,11 @@ const SystemStore = Reflux.createStore({
   },
   jvm() {
     const url = URLUtils.qualifyUrl(ApiRoutes.SystemApiController.jvm().url);
+
+    return fetch('GET', url);
+  },
+  systemLocales() {
+    const url = URLUtils.qualifyUrl(ApiRoutes.SystemApiController.locales().url);
 
     return fetch('GET', url);
   },


### PR DESCRIPTION
## Description

The Date converter was using the system locale for parsing date strings, which can lead to unwanted results in environments with multiple languages (e. g. month names) or "unclean" runtime environments.

This PR adds an attribute to the Date converter which specifies the locale being used for parsing strings.

Closes #3811

## Types of changes
- [x] New feature (non-breaking change which adds functionality)

## Checklist:
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
