### PR TITLE
Adding ids to Stream UI form elements for tests.

### DIFF
--- a/graylog2-web-interface/src/components/bootstrap/Input.jsx
+++ b/graylog2-web-interface/src/components/bootstrap/Input.jsx
@@ -141,6 +141,7 @@ const Input = React.createClass({
   render() {
     const { id, type, bsStyle, wrapperClassName, label, labelClassName, help, children, addonAfter, ...controlProps } = this.props;
     controlProps.type = type;
+    controlProps.label = label;
 
     if (!type) {
       return this._renderFormGroup(id, bsStyle, wrapperClassName, label, labelClassName, help, children);

--- a/graylog2-web-interface/src/components/common/TypeAheadFieldInput.jsx
+++ b/graylog2-web-interface/src/components/common/TypeAheadFieldInput.jsx
@@ -76,7 +76,7 @@ const TypeAheadFieldInput = React.createClass({
 
   render() {
     return (
-      <Input ref="fieldInput"
+      <Input ref="fieldInput" label={this.props.label}
              wrapperClassName="typeahead-wrapper"
              defaultValue={this.props.valueLink ? this.props.valueLink.value : null}
         {...this._getFilteredProps()} />

--- a/graylog2-web-interface/src/components/streamrules/StreamRuleForm.jsx
+++ b/graylog2-web-interface/src/components/streamrules/StreamRuleForm.jsx
@@ -60,22 +60,23 @@ const StreamRuleForm = React.createClass({
     const fieldBox = (String(this.state.type) !== String(this.ALWAYS_MATCH_RULE_TYPE) ?
       <TypeAheadFieldInput ref="fieldInput" type="text" required label="Field" valueLink={this.linkState('field')} autoFocus /> : '');
     const valueBox = (String(this.state.type) !== String(this.FIELD_PRESENCE_RULE_TYPE) && String(this.state.type) !== String(this.ALWAYS_MATCH_RULE_TYPE) ?
-      <Input type="text" required label="Value" name="Value" valueLink={this.linkState('value')} /> : '');
+      <Input id="Value" type="text" required label="Value" name="Value" valueLink={this.linkState('value')} /> : '');
     return (
       <BootstrapModalForm ref="modal"
                           title={this.props.title}
                           onSubmitForm={this._onSubmit}
-                          submitButtonText="Save">
+                          submitButtonText="Save"
+                          formProps={{id: 'StreamRuleForm'}}>
         <div>
           <Col md={8}>
             {fieldBox}
-            <Input type="select" required label="Type" name="Type" valueLink={this.linkState('type')}>
+            <Input id="Type" type="select" required label="Type" name="Type" valueLink={this.linkState('type')}>
               {streamRuleTypes}
             </Input>
             {valueBox}
-            <Input type="checkbox" label="Inverted" name="Inverted" checkedLink={this.linkState('inverted')} />
+            <Input id="Inverted" type="checkbox" label="Inverted" name="Inverted" checkedLink={this.linkState('inverted')} />
 
-            <Input type="textarea" label="Description (optional)" name="Description" valueLink={this.linkState('description')} />
+            <Input id="Description" type="textarea" label="Description (optional)" name="Description" valueLink={this.linkState('description')} />
 
             <p>
               <strong>Result:</strong>

--- a/graylog2-web-interface/src/components/streams/StreamForm.jsx
+++ b/graylog2-web-interface/src/components/streams/StreamForm.jsx
@@ -103,14 +103,14 @@ const StreamForm = React.createClass({
                           title={this.props.title}
                           onSubmitForm={this._onSubmit}
                           submitButtonText="Save">
-        <Input type="text" required label="Title" name="Title"
+        <Input id="Title" type="text" required label="Title" name="Title"
                placeholder="A descriptive name of the new stream"
                valueLink={this.linkState('title')} autoFocus />
-        <Input type="text" required label="Description" name="Description"
+        <Input id="Description" type="text" required label="Description" name="Description"
                placeholder="What kind of messages are routed into this stream?"
                valueLink={this.linkState('description')} />
         {indexSetSelect}
-        <Input type="checkbox" label="Remove matches from 'All messages' stream" name="Remove from All messages"
+        <Input id="RemoveFromDefaultStream" type="checkbox" label="Remove matches from 'All messages' stream" name="Remove from All messages"
                help={<span>Remove messages that match this stream from the 'All messages' stream which is assigned to every message by default.</span>}
                checkedLink={this.linkState('remove_matches_from_default_stream')} />
       </BootstrapModalForm>


### PR DESCRIPTION
This change is:

  * adding ids to elements in `Stream(Rule)Forms`
  * adding a configurable label element for the `TypeAheadFieldInput` component, being added to the actual `Input` component used

Both changes assist in finding the required fields in browser tests.