### PR TITLE
Fix summary page for HTTPJSONPath adapter

### DIFF
--- a/graylog2-web-interface/src/components/lookup-tables/adapters/HTTPJSONPathAdapterSummary.jsx
+++ b/graylog2-web-interface/src/components/lookup-tables/adapters/HTTPJSONPathAdapterSummary.jsx
@@ -10,8 +10,10 @@ const HTTPJSONPathAdapterSummary = React.createClass({
     return (<dl>
       <dt>Lookup URL</dt>
       <dd>{config.url}</dd>
-      <dt>Value JSONPath</dt>
-      <dd><code>{config.value_jsonpath}</code></dd>
+      <dt>Single value JSONPath</dt>
+      <dd><code>{config.single_value_jsonpath}</code></dd>
+      <dt>Multi value JSONPath</dt>
+      <dd><code>{config.multi_value_jsonpath}</code></dd>
       <dt>HTTP User-Agent</dt>
       <dd>{config.user_agent}</dd>
     </dl>);


### PR DESCRIPTION
This was still using the old `value_jsonpath` setting.
