### PR TITLE
Add adapter and cache config validation

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/lookup/adapters/CSVFileDataAdapter.java
+++ b/graylog2-server/src/main/java/org/graylog2/lookup/adapters/CSVFileDataAdapter.java
@@ -17,7 +17,9 @@
 package org.graylog2.lookup.adapters;
 
 import com.google.auto.value.AutoValue;
+import com.google.common.collect.ArrayListMultimap;
 import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.Multimap;
 import com.google.common.primitives.Ints;
 import com.google.inject.assistedinject.Assisted;
 
@@ -44,8 +46,10 @@ import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
+import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Map;
+import java.util.Optional;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.atomic.AtomicReference;
 
@@ -270,6 +274,20 @@ public class CSVFileDataAdapter extends LookupDataAdapter {
 
         public static Builder builder() {
             return new AutoValue_CSVFileDataAdapter_Config.Builder();
+        }
+
+        @Override
+        public Optional<Multimap<String, String>> validate() {
+            final ArrayListMultimap<String, String> errors = ArrayListMultimap.create();
+
+            final Path path = Paths.get(path());
+            if (!Files.exists(path)) {
+                errors.put("path", "The file does not exist");
+            } else if (!Files.isReadable(path)) {
+                errors.put("path", "The file cannot be read");
+            }
+
+            return errors.isEmpty() ? Optional.empty() : Optional.of(errors);
         }
 
         @AutoValue.Builder

--- a/graylog2-server/src/main/java/org/graylog2/lookup/adapters/CSVFileDataAdapter.java
+++ b/graylog2-server/src/main/java/org/graylog2/lookup/adapters/CSVFileDataAdapter.java
@@ -282,9 +282,9 @@ public class CSVFileDataAdapter extends LookupDataAdapter {
 
             final Path path = Paths.get(path());
             if (!Files.exists(path)) {
-                errors.put("path", "The file does not exist");
+                errors.put("path", "The file does not exist.");
             } else if (!Files.isReadable(path)) {
-                errors.put("path", "The file cannot be read");
+                errors.put("path", "The file cannot be read.");
             }
 
             return errors.isEmpty() ? Optional.empty() : Optional.of(errors);

--- a/graylog2-server/src/main/java/org/graylog2/plugin/database/ValidationException.java
+++ b/graylog2-server/src/main/java/org/graylog2/plugin/database/ValidationException.java
@@ -18,6 +18,7 @@ package org.graylog2.plugin.database;
 
 import com.google.common.base.MoreObjects;
 import com.google.common.collect.ImmutableMap;
+
 import org.graylog2.plugin.database.validators.ValidationResult;
 
 import java.util.Collections;

--- a/graylog2-server/src/main/java/org/graylog2/plugin/inject/Graylog2Module.java
+++ b/graylog2-server/src/main/java/org/graylog2/plugin/inject/Graylog2Module.java
@@ -385,10 +385,10 @@ public abstract class Graylog2Module extends AbstractModule {
     }
 
     protected void installLookupCache(String name,
-                                      Class<? extends LookupCache> adapterClass,
+                                      Class<? extends LookupCache> cacheClass,
                                       Class<? extends LookupCache.Factory> factoryClass,
                                       Class<? extends LookupCacheConfiguration> configClass) {
-        install(new FactoryModuleBuilder().implement(LookupCache.class, adapterClass).build(factoryClass));
+        install(new FactoryModuleBuilder().implement(LookupCache.class, cacheClass).build(factoryClass));
         lookupCacheBinder().addBinding(name).to(factoryClass);
         jacksonSubTypesBinder().addBinding(name).toInstance(configClass);
     }

--- a/graylog2-server/src/main/java/org/graylog2/plugin/lookup/LookupCacheConfiguration.java
+++ b/graylog2-server/src/main/java/org/graylog2/plugin/lookup/LookupCacheConfiguration.java
@@ -16,10 +16,16 @@
  */
 package org.graylog2.plugin.lookup;
 
+import com.google.common.collect.Multimap;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
 
-@JsonTypeInfo(use = JsonTypeInfo.Id.NAME,
+import java.util.Optional;
+
+@JsonTypeInfo(
+        use = JsonTypeInfo.Id.NAME,
         include = JsonTypeInfo.As.PROPERTY,
         property = LookupCacheConfiguration.TYPE_FIELD,
         visible = true,
@@ -30,4 +36,20 @@ public interface LookupCacheConfiguration {
     @JsonProperty(TYPE_FIELD)
     String type();
 
+    /**
+     * <p>Override this method to check for logical errors in the configuration, such as missing
+     * files, or invalid combinations of options. Prefer validation annotations for simple
+     * per-property validations rules, such as min/max values, non-empty strings etc. </p>
+     *
+     * <p> By default the configuration has no extra validation errors (i.e. the result of this
+     * method is {@link Optional#empty()}. </p>
+     *
+     * <p>Returning failing validations here <b>does not</b> prevent saving the configuration!</p>
+     *
+     * @return optionally map of property name to error messages
+     */
+    @JsonIgnore
+    default Optional<Multimap<String, String>> validate() {
+        return Optional.empty();
+    }
 }

--- a/graylog2-server/src/main/java/org/graylog2/plugin/lookup/LookupDataAdapterConfiguration.java
+++ b/graylog2-server/src/main/java/org/graylog2/plugin/lookup/LookupDataAdapterConfiguration.java
@@ -16,8 +16,13 @@
  */
 package org.graylog2.plugin.lookup;
 
+import com.google.common.collect.Multimap;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
+
+import java.util.Optional;
 
 @JsonTypeInfo(
         use = JsonTypeInfo.Id.NAME,
@@ -31,4 +36,19 @@ public interface LookupDataAdapterConfiguration {
     @JsonProperty(TYPE_FIELD)
     String type();
 
+    /**
+     * <p> Implement {@link #validate()} to check for logical errors in the configuration, such as
+     * missing files, or invalid combinations of options. Prefer validation annotations for simple
+     * per-property validations rules, such as min/max values, non-empty strings etc. </p>
+     *
+     * <p> By default the configuration has no extra validation errors (i.e. the result of this method is
+     * {@link Optional#empty()}. </p>
+     *
+     * <p>Returning failing validations here <b>does not</b> prevent saving the configuration!</p>
+     * @return optionally map of property name to error messages
+     */
+    @JsonIgnore
+    default Optional<Multimap<String, String>> validate() {
+        return Optional.empty();
+    }
 }

--- a/graylog2-server/src/main/java/org/graylog2/plugin/lookup/LookupDataAdapterConfiguration.java
+++ b/graylog2-server/src/main/java/org/graylog2/plugin/lookup/LookupDataAdapterConfiguration.java
@@ -37,14 +37,15 @@ public interface LookupDataAdapterConfiguration {
     String type();
 
     /**
-     * <p> Implement {@link #validate()} to check for logical errors in the configuration, such as
-     * missing files, or invalid combinations of options. Prefer validation annotations for simple
+     * <p> Override this method to check for logical errors in the configuration, such as missing
+     * files, or invalid combinations of options. Prefer validation annotations for simple
      * per-property validations rules, such as min/max values, non-empty strings etc. </p>
      *
-     * <p> By default the configuration has no extra validation errors (i.e. the result of this method is
-     * {@link Optional#empty()}. </p>
+     * <p> By default the configuration has no extra validation errors (i.e. the result of this
+     * method is {@link Optional#empty()}. </p>
      *
      * <p>Returning failing validations here <b>does not</b> prevent saving the configuration!</p>
+     *
      * @return optionally map of property name to error messages
      */
     @JsonIgnore

--- a/graylog2-server/src/main/java/org/graylog2/plugin/rest/ValidationResult.java
+++ b/graylog2-server/src/main/java/org/graylog2/plugin/rest/ValidationResult.java
@@ -1,0 +1,51 @@
+/**
+ * This file is part of Graylog.
+ *
+ * Graylog is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.graylog2.plugin.rest;
+
+import com.google.common.collect.ArrayListMultimap;
+import com.google.common.collect.Multimap;
+
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.Collection;
+import java.util.Map;
+
+@JsonAutoDetect
+public class ValidationResult {
+
+    private final Multimap<String, String> errors = ArrayListMultimap.create();
+
+
+    public void addError(String fieldName, String error) {
+        errors.put(fieldName, error);
+    }
+
+    public void addAll(Multimap<String, String> extraErrors) {
+        errors.putAll(extraErrors);
+    }
+
+    @JsonProperty("failed")
+    public boolean failed() {
+        return !errors.isEmpty();
+    }
+
+    @JsonProperty("errors")
+    public Map<String, Collection<String>> getErrors() {
+        return errors.asMap();
+    }
+}

--- a/graylog2-server/src/main/java/org/graylog2/rest/models/system/lookup/CacheApi.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/models/system/lookup/CacheApi.java
@@ -25,8 +25,11 @@ import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import org.graylog.autovalue.WithBeanGetter;
 import org.graylog2.lookup.dto.CacheDto;
 import org.graylog2.plugin.lookup.LookupCacheConfiguration;
+import org.hibernate.validator.constraints.NotEmpty;
 
 import javax.annotation.Nullable;
+import javax.validation.Valid;
+import javax.validation.constraints.NotNull;
 
 @AutoValue
 @JsonAutoDetect
@@ -39,15 +42,18 @@ public abstract class CacheApi {
     public abstract String id();
 
     @JsonProperty("title")
+    @NotEmpty
     public abstract String title();
 
     @JsonProperty("description")
     public abstract String description();
 
     @JsonProperty("name")
+    @NotEmpty
     public abstract String name();
 
     @JsonProperty
+    @NotNull
     public abstract LookupCacheConfiguration config();
 
     public static Builder builder() {
@@ -89,7 +95,7 @@ public abstract class CacheApi {
         public abstract Builder name(String name);
 
         @JsonProperty("config")
-        public abstract Builder config(LookupCacheConfiguration config);
+        public abstract Builder config(@Valid LookupCacheConfiguration config);
 
         public abstract CacheApi build();
     }

--- a/graylog2-server/src/main/java/org/graylog2/rest/resources/system/lookup/LookupTableResource.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/resources/system/lookup/LookupTableResource.java
@@ -437,7 +437,7 @@ public class LookupTableResource extends RestResource {
             //noinspection ConstantConditions
             if (!adapterDto.id().equals(toValidate.id())) {
                 // an adapter exists with a different id, so the name is already in use, fail validation
-                validation.addError("name", "The data adapter name must be unique.");
+                validation.addError("name", "The data adapter name is already in use.");
             }
         }
 

--- a/graylog2-web-interface/src/actions/lookup-tables/LookupTableCachesActions.js
+++ b/graylog2-web-interface/src/actions/lookup-tables/LookupTableCachesActions.js
@@ -8,6 +8,7 @@ const LookupTableCachesActions = Reflux.createActions({
   delete: { asyncResult: true },
   update: { asyncResult: true },
   getTypes: { asyncResult: true },
+  validate: { asyncResult: true },
 });
 
 export default LookupTableCachesActions;

--- a/graylog2-web-interface/src/actions/lookup-tables/LookupTableDataAdaptersActions.js
+++ b/graylog2-web-interface/src/actions/lookup-tables/LookupTableDataAdaptersActions.js
@@ -9,6 +9,7 @@ const LookupTableDataAdaptersActions = Reflux.createActions({
   update: { asyncResult: true },
   getTypes: { asyncResult: true },
   lookup: { asyncResult: true },
+  validate: { asyncResult: true },
 });
 
 export default LookupTableDataAdaptersActions;

--- a/graylog2-web-interface/src/components/lookup-tables/CacheCreate.jsx
+++ b/graylog2-web-interface/src/components/lookup-tables/CacheCreate.jsx
@@ -13,6 +13,15 @@ const CacheCreate = React.createClass({
   propTypes: {
     saved: PropTypes.func.isRequired,
     types: PropTypes.object.isRequired,
+    validate: PropTypes.func,
+    validationErrors: PropTypes.object,
+  },
+
+  getDefaultProps() {
+    return {
+      validate: null,
+      validationErrors: {},
+    };
   },
 
   getInitialState() {
@@ -70,7 +79,12 @@ const CacheCreate = React.createClass({
         <Row className="content">
           <Col lg={12}>
             <h3>Configure Cache</h3>
-            <CacheForm cache={this.state.cache} type={this.state.type} create saved={this.props.saved} />
+            <CacheForm cache={this.state.cache}
+                       type={this.state.type}
+                       create
+                       saved={this.props.saved}
+                       validationErrors={this.props.validationErrors}
+                       validate={this.props.validate} />
           </Col>
         </Row>
       )}

--- a/graylog2-web-interface/src/components/lookup-tables/CacheForm.jsx
+++ b/graylog2-web-interface/src/components/lookup-tables/CacheForm.jsx
@@ -1,5 +1,4 @@
 import React, { PropTypes } from 'react';
-import React, { PropTypes } from 'react';
 import _ from 'lodash';
 import { Button, Col, Row } from 'react-bootstrap';
 import { Input } from 'components/bootstrap';

--- a/graylog2-web-interface/src/components/lookup-tables/CacheForm.jsx
+++ b/graylog2-web-interface/src/components/lookup-tables/CacheForm.jsx
@@ -1,13 +1,13 @@
-import React, { PropTypes } from 'react';
-import _ from 'lodash';
-import { Button, Row, Col } from 'react-bootstrap';
-import { Input } from 'components/bootstrap';
-import ObjectUtils from 'util/ObjectUtils';
-import FormsUtils from 'util/FormsUtils';
+import React, {PropTypes} from "react";
+import _ from "lodash";
+import {Button, Col, Row} from "react-bootstrap";
+import {Input} from "components/bootstrap";
+import ObjectUtils from "util/ObjectUtils";
+import FormsUtils from "util/FormsUtils";
 
-import { PluginStore } from 'graylog-web-plugin/plugin';
+import {PluginStore} from "graylog-web-plugin/plugin";
 
-import CombinedProvider from 'injection/CombinedProvider';
+import CombinedProvider from "injection/CombinedProvider";
 
 const { LookupTableCachesActions } = CombinedProvider.get('LookupTableCaches');
 
@@ -41,7 +41,7 @@ const CacheForm = React.createClass({
   },
 
   componentWillReceiveProps(nextProps) {
-    if (_.isEqual(this.props, nextProps)) {
+    if (_.isEqual(this.props.cache, nextProps.cache)) {
       // props haven't change, don't update our state from them
       return;
     }

--- a/graylog2-web-interface/src/components/lookup-tables/CacheForm.jsx
+++ b/graylog2-web-interface/src/components/lookup-tables/CacheForm.jsx
@@ -1,13 +1,14 @@
-import React, {PropTypes} from "react";
-import _ from "lodash";
-import {Button, Col, Row} from "react-bootstrap";
-import {Input} from "components/bootstrap";
-import ObjectUtils from "util/ObjectUtils";
-import FormsUtils from "util/FormsUtils";
+import React, { PropTypes } from 'react';
+import React, { PropTypes } from 'react';
+import _ from 'lodash';
+import { Button, Col, Row } from 'react-bootstrap';
+import { Input } from 'components/bootstrap';
+import ObjectUtils from 'util/ObjectUtils';
+import FormsUtils from 'util/FormsUtils';
 
-import {PluginStore} from "graylog-web-plugin/plugin";
+import { PluginStore } from 'graylog-web-plugin/plugin';
 
-import CombinedProvider from "injection/CombinedProvider";
+import CombinedProvider from 'injection/CombinedProvider';
 
 const { LookupTableCachesActions } = CombinedProvider.get('LookupTableCaches');
 

--- a/graylog2-web-interface/src/components/lookup-tables/CacheForm.jsx
+++ b/graylog2-web-interface/src/components/lookup-tables/CacheForm.jsx
@@ -17,6 +17,8 @@ const CacheForm = React.createClass({
     saved: PropTypes.func.isRequired,
     create: PropTypes.bool,
     cache: PropTypes.object,
+    validate: PropTypes.func,
+    validationErrors: PropTypes.object,
   },
 
   getDefaultProps() {
@@ -29,6 +31,8 @@ const CacheForm = React.createClass({
         name: '',
         config: {},
       },
+      validate: null,
+      validationErrors: {},
     };
   },
 
@@ -48,6 +52,9 @@ const CacheForm = React.createClass({
     const cache = ObjectUtils.clone(c);
 
     return {
+      // when creating always initially auto-generate the adapter name,
+      // this will be false if the user changed the adapter name manually
+      generateName: this.props.create,
       cache: {
         id: cache.id,
         title: cache.title,
@@ -58,21 +65,54 @@ const CacheForm = React.createClass({
     };
   },
 
+  componentWillUnmount() {
+    this._clearTimer();
+  },
+
+  validationCheckTimer: undefined,
+
+  _clearTimer() {
+    if (this.validationCheckTimer !== undefined) {
+      clearTimeout(this.validationCheckTimer);
+      this.validationCheckTimer = undefined;
+    }
+  },
+
+  _validate(cache) {
+    // first cancel outstanding validation timer, we have new data
+    this._clearTimer();
+    if (this.props.validate) {
+      this.validationCheckTimer = setTimeout(() => this.props.validate(cache), 500);
+    }
+  },
+
   _onChange(event) {
     const cache = ObjectUtils.clone(this.state.cache);
     cache[event.target.name] = FormsUtils.getValueFromInput(event.target);
+    let generateName = this.state.generateName;
+    if (generateName && event.target.name === 'title') {
+      // generate the name
+      cache.name = this._sanitizeTitle(cache.title);
+    }
+    if (event.target.name === 'name') {
+      // the cache name has been changed manually, no longer automatically change it
+      generateName = false;
+    }
+    this._validate(cache);
     this.setState({ cache: cache });
   },
 
   _onConfigChange(event) {
     const cache = ObjectUtils.clone(this.state.cache);
     cache.config[event.target.name] = FormsUtils.getValueFromInput(event.target);
+    this._validate(cache);
     this.setState({ cache: cache });
   },
 
   _updateConfig(newConfig) {
     const cache = ObjectUtils.clone(this.state.cache);
     cache.config = newConfig;
+    this._validate(cache);
     this.setState({ cache: cache });
   },
 
@@ -91,6 +131,28 @@ const CacheForm = React.createClass({
     promise.then(() => { this.props.saved(); });
   },
 
+  _sanitizeTitle(title) {
+    return title.trim().replace(/\W+/g, '-').toLowerCase();
+  },
+
+  _validationState(fieldName) {
+    if (this.props.validationErrors[fieldName]) {
+      return 'error';
+    }
+    return null;
+  },
+
+  _validationMessage(fieldName, defaultText) {
+    if (this.props.validationErrors[fieldName]) {
+      return (<div>
+        <span>{defaultText}</span>
+        &nbsp;
+        <span><b>{this.props.validationErrors[fieldName][0]}</b></span>
+      </div>);
+    }
+    return <span>{defaultText}</span>;
+  },
+
   render() {
     const cache = this.state.cache;
 
@@ -105,6 +167,8 @@ const CacheForm = React.createClass({
         config: cache.config,
         handleFormEvent: this._onConfigChange,
         updateConfig: this._updateConfig,
+        validationMessage: this._validationMessage,
+        validationState: this._validationState,
       });
       if (p.documentationComponent) {
         documentationComponent = React.createElement(p.documentationComponent);
@@ -155,7 +219,8 @@ const CacheForm = React.createClass({
                      label="Name"
                      required
                      onChange={this._onChange}
-                     help="The name that is being used to refer to this cache. Must be unique."
+                     help={this._validationMessage('name', 'The name that is being used to refer to this cache. Must be unique.')}
+                     bsStyle={this._validationState('name')}
                      value={cache.name}
                      labelClassName="col-sm-3"
                      wrapperClassName="col-sm-9" />

--- a/graylog2-web-interface/src/components/lookup-tables/DataAdapterCreate.jsx
+++ b/graylog2-web-interface/src/components/lookup-tables/DataAdapterCreate.jsx
@@ -13,6 +13,15 @@ const DataAdapterCreate = React.createClass({
   propTypes: {
     saved: PropTypes.func.isRequired,
     types: PropTypes.object.isRequired,
+    validate: PropTypes.func,
+    validationErrors: PropTypes.array,
+  },
+
+  getDefaultProps() {
+    return {
+      validate: null,
+      validationErrors: [],
+    };
   },
 
   getInitialState() {
@@ -70,7 +79,12 @@ const DataAdapterCreate = React.createClass({
         <Row className="content">
           <Col lg={12}>
             <h3>Configure Adapter</h3>
-            <DataAdapterForm dataAdapter={this.state.dataAdapter} type={this.state.type} create saved={this.props.saved} />
+            <DataAdapterForm dataAdapter={this.state.dataAdapter}
+                             type={this.state.type}
+                             create
+                             validate={this.props.validate}
+                             validationErrors={this.props.validationErrors}
+                             saved={this.props.saved} />
           </Col>
         </Row>
       )}

--- a/graylog2-web-interface/src/components/lookup-tables/DataAdapterCreate.jsx
+++ b/graylog2-web-interface/src/components/lookup-tables/DataAdapterCreate.jsx
@@ -14,13 +14,13 @@ const DataAdapterCreate = React.createClass({
     saved: PropTypes.func.isRequired,
     types: PropTypes.object.isRequired,
     validate: PropTypes.func,
-    validationErrors: PropTypes.array,
+    validationErrors: PropTypes.object,
   },
 
   getDefaultProps() {
     return {
       validate: null,
-      validationErrors: [],
+      validationErrors: {},
     };
   },
 

--- a/graylog2-web-interface/src/components/lookup-tables/DataAdapterForm.jsx
+++ b/graylog2-web-interface/src/components/lookup-tables/DataAdapterForm.jsx
@@ -1,15 +1,15 @@
-import React, { PropTypes } from 'react';
+import React, {PropTypes} from "react";
 
-import _ from 'lodash';
+import _ from "lodash";
 
-import { Button, Row, Col } from 'react-bootstrap';
-import { Input } from 'components/bootstrap';
-import ObjectUtils from 'util/ObjectUtils';
-import FormsUtils from 'util/FormsUtils';
+import {Button, Col, Row} from "react-bootstrap";
+import {Input} from "components/bootstrap";
+import ObjectUtils from "util/ObjectUtils";
+import FormsUtils from "util/FormsUtils";
 
-import { PluginStore } from 'graylog-web-plugin/plugin';
+import {PluginStore} from "graylog-web-plugin/plugin";
 
-import CombinedProvider from 'injection/CombinedProvider';
+import CombinedProvider from "injection/CombinedProvider";
 
 const { LookupTableDataAdaptersActions } = CombinedProvider.get('LookupTableDataAdapters');
 
@@ -43,8 +43,8 @@ const DataAdapterForm = React.createClass({
   },
 
   componentWillReceiveProps(nextProps) {
-    if (_.isEqual(this.props, nextProps)) {
-      // props haven't change, don't update our state from them
+    if (_.isEqual(this.props.dataAdapter, nextProps.dataAdapter)) {
+      // props haven't changed, don't update our state from them
       return;
     }
     this.setState(this._initialState(nextProps.dataAdapter));

--- a/graylog2-web-interface/src/components/lookup-tables/DataAdapterForm.jsx
+++ b/graylog2-web-interface/src/components/lookup-tables/DataAdapterForm.jsx
@@ -1,15 +1,15 @@
-import React, {PropTypes} from "react";
+import React, { PropTypes } from 'react';
 
-import _ from "lodash";
+import _ from 'lodash';
 
-import {Button, Col, Row} from "react-bootstrap";
-import {Input} from "components/bootstrap";
-import ObjectUtils from "util/ObjectUtils";
-import FormsUtils from "util/FormsUtils";
+import { Button, Col, Row } from 'react-bootstrap';
+import { Input } from 'components/bootstrap';
+import ObjectUtils from 'util/ObjectUtils';
+import FormsUtils from 'util/FormsUtils';
 
-import {PluginStore} from "graylog-web-plugin/plugin";
+import { PluginStore } from 'graylog-web-plugin/plugin';
 
-import CombinedProvider from "injection/CombinedProvider";
+import CombinedProvider from 'injection/CombinedProvider';
 
 const { LookupTableDataAdaptersActions } = CombinedProvider.get('LookupTableDataAdapters');
 

--- a/graylog2-web-interface/src/components/lookup-tables/adapters/CSVFileAdapterFieldSet.jsx
+++ b/graylog2-web-interface/src/components/lookup-tables/adapters/CSVFileAdapterFieldSet.jsx
@@ -8,6 +8,8 @@ const CSVFileAdapterFieldSet = React.createClass({
 // eslint-disable-next-line react/no-unused-prop-types
     updateConfig: PropTypes.func.isRequired,
     handleFormEvent: PropTypes.func.isRequired,
+    validationState: PropTypes.func.isRequired,
+    validationMessage: PropTypes.func.isRequired,
   },
 
   render() {
@@ -21,10 +23,10 @@ const CSVFileAdapterFieldSet = React.createClass({
              autoFocus
              required
              onChange={this.props.handleFormEvent}
-             help="The path to the CSV file."
+             help={this.props.validationMessage('path', 'The path to the CSV file.')}
              value={config.path}
              labelClassName="col-sm-3"
-             wrapperClassName="col-sm-9" />
+             wrapperClassName="col-sm-9" bsStyle={this.props.validationState('path')} />
       <Input type="number"
              id="check_interval"
              name="check_interval"

--- a/graylog2-web-interface/src/components/lookup-tables/adapters/CSVFileAdapterFieldSet.jsx
+++ b/graylog2-web-interface/src/components/lookup-tables/adapters/CSVFileAdapterFieldSet.jsx
@@ -24,9 +24,10 @@ const CSVFileAdapterFieldSet = React.createClass({
              required
              onChange={this.props.handleFormEvent}
              help={this.props.validationMessage('path', 'The path to the CSV file.')}
+             bsStyle={this.props.validationState('path')}
              value={config.path}
              labelClassName="col-sm-3"
-             wrapperClassName="col-sm-9" bsStyle={this.props.validationState('path')} />
+             wrapperClassName="col-sm-9" />
       <Input type="number"
              id="check_interval"
              name="check_interval"

--- a/graylog2-web-interface/src/components/lookup-tables/adapters/HTTPJSONPathAdapterFieldSet.jsx
+++ b/graylog2-web-interface/src/components/lookup-tables/adapters/HTTPJSONPathAdapterFieldSet.jsx
@@ -8,6 +8,10 @@ const HTTPJSONPathAdapterFieldSet = React.createClass({
     // eslint-disable-next-line react/no-unused-prop-types
     updateConfig: PropTypes.func.isRequired,
     handleFormEvent: PropTypes.func.isRequired,
+    // eslint-disable-next-line react/no-unused-prop-types
+    validationState: PropTypes.func.isRequired,
+    // eslint-disable-next-line react/no-unused-prop-types
+    validationMessage: PropTypes.func.isRequired,
   },
 
   render() {

--- a/graylog2-web-interface/src/components/lookup-tables/caches/GuavaCacheFieldSet.jsx
+++ b/graylog2-web-interface/src/components/lookup-tables/caches/GuavaCacheFieldSet.jsx
@@ -9,6 +9,10 @@ const GuavaCacheFieldSet = React.createClass({
     config: PropTypes.object.isRequired,
     updateConfig: PropTypes.func.isRequired,
     handleFormEvent: PropTypes.func.isRequired,
+// eslint-disable-next-line react/no-unused-prop-types
+    validationState: PropTypes.func.isRequired,
+// eslint-disable-next-line react/no-unused-prop-types
+    validationMessage: PropTypes.func.isRequired,
   },
 
   _update(value, unit, enabled, name) {

--- a/graylog2-web-interface/src/components/lookup-tables/caches/NullCacheFieldSet.jsx
+++ b/graylog2-web-interface/src/components/lookup-tables/caches/NullCacheFieldSet.jsx
@@ -5,6 +5,10 @@ const NullCacheFieldSet = React.createClass({
     config: PropTypes.object.isRequired,
     updateConfig: PropTypes.func.isRequired,
     handleFormEvent: PropTypes.func.isRequired,
+    // eslint-disable-next-line react/no-unused-prop-types
+    validationState: PropTypes.func.isRequired,
+// eslint-disable-next-line react/no-unused-prop-types
+    validationMessage: PropTypes.func.isRequired,
   },
 
   render() {

--- a/graylog2-web-interface/src/pages/LUTCachesPage.jsx
+++ b/graylog2-web-interface/src/pages/LUTCachesPage.jsx
@@ -54,6 +54,10 @@ const LUTCachesPage = React.createClass({
     return props.route.action === 'create';
   },
 
+  _validateCache(adapter) {
+    LookupTableCachesActions.validate(adapter);
+  },
+
   render() {
     let content;
     const isShowing = this.props.route.action === 'show';
@@ -70,7 +74,9 @@ const LUTCachesPage = React.createClass({
               <CacheForm cache={this.state.cache}
                          type={this.state.cache.config.type}
                          create={false}
-                         saved={this._saved} />
+                         saved={this._saved}
+                         validate={this._validateCache}
+                         validationErrors={this.state.validationErrors} />
             </Col>
           </Row>
         );
@@ -82,7 +88,11 @@ const LUTCachesPage = React.createClass({
         content = <Spinner text="Loading data cache types" />;
       } else {
         content =
-          <CacheCreate history={this.props.history} types={this.state.types} saved={this._saved} />;
+          <CacheCreate history={this.props.history}
+                       types={this.state.types}
+                       saved={this._saved}
+                       validate={this._validateCache}
+                       validationErrors={this.state.validationErrors} />;
       }
     } else if (!this.state.caches) {
       content = <Spinner text="Loading caches" />;

--- a/graylog2-web-interface/src/pages/LUTCachesPage.jsx
+++ b/graylog2-web-interface/src/pages/LUTCachesPage.jsx
@@ -1,13 +1,13 @@
-import React, {PropTypes} from "react";
-import Reflux from "reflux";
-import {Button, Col, Row} from "react-bootstrap";
-import {LinkContainer} from "react-router-bootstrap";
-import Routes from "routing/Routes";
-import {DocumentTitle, PageHeader, Spinner} from "components/common";
+import React, { PropTypes } from 'react';
+import Reflux from 'reflux';
+import { Button, Col, Row } from 'react-bootstrap';
+import { LinkContainer } from 'react-router-bootstrap';
+import Routes from 'routing/Routes';
+import { DocumentTitle, PageHeader, Spinner } from 'components/common';
 
-import {Cache, CacheCreate, CacheForm, CachesOverview} from "components/lookup-tables";
+import { Cache, CacheCreate, CacheForm, CachesOverview } from 'components/lookup-tables';
 
-import CombinedProvider from "injection/CombinedProvider";
+import CombinedProvider from 'injection/CombinedProvider';
 
 const { LookupTableCachesStore, LookupTableCachesActions } = CombinedProvider.get(
   'LookupTableCaches');
@@ -87,11 +87,11 @@ const LUTCachesPage = React.createClass({
         content = <Spinner text="Loading data cache types" />;
       } else {
         content =
-          <CacheCreate history={this.props.history}
+          (<CacheCreate history={this.props.history}
                        types={this.state.types}
                        saved={this._saved}
                        validate={this._validateCache}
-                       validationErrors={this.state.validationErrors} />;
+                       validationErrors={this.state.validationErrors} />);
       }
     } else if (!this.state.caches) {
       content = <Spinner text="Loading caches" />;

--- a/graylog2-web-interface/src/pages/LUTCachesPage.jsx
+++ b/graylog2-web-interface/src/pages/LUTCachesPage.jsx
@@ -1,13 +1,13 @@
-import React, { PropTypes } from 'react';
-import Reflux from 'reflux';
-import { Button, Row, Col } from 'react-bootstrap';
-import { LinkContainer } from 'react-router-bootstrap';
-import Routes from 'routing/Routes';
-import { DocumentTitle, PageHeader, Spinner } from 'components/common';
+import React, {PropTypes} from "react";
+import Reflux from "reflux";
+import {Button, Col, Row} from "react-bootstrap";
+import {LinkContainer} from "react-router-bootstrap";
+import Routes from "routing/Routes";
+import {DocumentTitle, PageHeader, Spinner} from "components/common";
 
-import { CachesOverview, Cache, CacheForm, CacheCreate } from 'components/lookup-tables';
+import {Cache, CacheCreate, CacheForm, CachesOverview} from "components/lookup-tables";
 
-import CombinedProvider from 'injection/CombinedProvider';
+import CombinedProvider from "injection/CombinedProvider";
 
 const { LookupTableCachesStore, LookupTableCachesActions } = CombinedProvider.get(
   'LookupTableCaches');
@@ -35,12 +35,11 @@ const LUTCachesPage = React.createClass({
   _loadData(props) {
     if (props.params && props.params.cacheName) {
       LookupTableCachesActions.get(props.params.cacheName);
+    } else if (this._isCreating(props)) {
+      LookupTableCachesActions.getTypes();
     } else {
       const p = this.state.pagination;
       LookupTableCachesActions.searchPaginated(p.page, p.per_page, p.query);
-    }
-    if (this._isCreating(props)) {
-      LookupTableCachesActions.getTypes();
     }
   },
 

--- a/graylog2-web-interface/src/pages/LUTDataAdaptersPage.jsx
+++ b/graylog2-web-interface/src/pages/LUTDataAdaptersPage.jsx
@@ -87,6 +87,10 @@ const LUTDataAdaptersPage = React.createClass({
     return props.route.action === 'create';
   },
 
+  _validateAdapter(adapter) {
+    LookupTableDataAdaptersActions.validate(adapter);
+  },
+
   render() {
     let content;
     const isShowing = this.props.route.action === 'show';
@@ -103,7 +107,9 @@ const LUTDataAdaptersPage = React.createClass({
               <DataAdapterForm dataAdapter={this.state.dataAdapter}
                                type={this.state.dataAdapter.config.type}
                                create={false}
-                               saved={this._saved} />
+                               saved={this._saved}
+                               validate={this._validateAdapter}
+                               validationErrors={this.state.validationErrors} />
             </Col>
           </Row>
         );
@@ -114,7 +120,11 @@ const LUTDataAdaptersPage = React.createClass({
       if (!this.state.types) {
         content = <Spinner text="Loading data adapter types" />;
       } else {
-        content = <DataAdapterCreate history={this.props.history} types={this.state.types} saved={this._saved} />;
+        content = (<DataAdapterCreate history={this.props.history}
+                                      types={this.state.types}
+                                      saved={this._saved}
+                                      validate={this._validateAdapter}
+                                      validationErrors={this.state.validationErrors} />);
       }
     } else if (!this.state.dataAdapters) {
       content = <Spinner text="Loading data adapters" />;

--- a/graylog2-web-interface/src/pages/LUTDataAdaptersPage.jsx
+++ b/graylog2-web-interface/src/pages/LUTDataAdaptersPage.jsx
@@ -1,13 +1,13 @@
-import React, {PropTypes} from "react";
-import Reflux from "reflux";
-import {Button, Col, Row} from "react-bootstrap";
-import {LinkContainer} from "react-router-bootstrap";
-import Routes from "routing/Routes";
-import {DocumentTitle, PageHeader, Spinner} from "components/common";
+import React, { PropTypes } from 'react';
+import Reflux from 'reflux';
+import { Button, Col, Row } from 'react-bootstrap';
+import { LinkContainer } from 'react-router-bootstrap';
+import Routes from 'routing/Routes';
+import { DocumentTitle, PageHeader, Spinner } from 'components/common';
 
-import {DataAdapter, DataAdapterCreate, DataAdapterForm, DataAdaptersOverview} from "components/lookup-tables";
+import { DataAdapter, DataAdapterCreate, DataAdapterForm, DataAdaptersOverview } from 'components/lookup-tables';
 
-import CombinedProvider from "injection/CombinedProvider";
+import CombinedProvider from 'injection/CombinedProvider';
 
 const { LookupTableDataAdaptersStore, LookupTableDataAdaptersActions } = CombinedProvider.get(
   'LookupTableDataAdapters');
@@ -43,7 +43,6 @@ const LUTDataAdaptersPage = React.createClass({
 
   _startErrorStatesTimer() {
     this._stopErrorStatesTimer();
-    console.log("Starting errorstates retrieval");
 
     this.errorStatesTimer = setInterval(() => {
       let names = null;
@@ -58,7 +57,6 @@ const LUTDataAdaptersPage = React.createClass({
 
   _stopErrorStatesTimer() {
     if (this.errorStatesTimer) {
-      console.log("Stopping errorstates retrieval");
       clearInterval(this.errorStatesTimer);
       this.errorStatesTimer = undefined;
     }

--- a/graylog2-web-interface/src/pages/LUTDataAdaptersPage.jsx
+++ b/graylog2-web-interface/src/pages/LUTDataAdaptersPage.jsx
@@ -1,15 +1,13 @@
-import React, { PropTypes } from 'react';
-import Reflux from 'reflux';
-import { Button, Row, Col } from 'react-bootstrap';
-import { LinkContainer } from 'react-router-bootstrap';
-import Routes from 'routing/Routes';
-import { DocumentTitle, PageHeader, Spinner } from 'components/common';
+import React, {PropTypes} from "react";
+import Reflux from "reflux";
+import {Button, Col, Row} from "react-bootstrap";
+import {LinkContainer} from "react-router-bootstrap";
+import Routes from "routing/Routes";
+import {DocumentTitle, PageHeader, Spinner} from "components/common";
 
-import {
-  DataAdaptersOverview, DataAdapter, DataAdapterForm, DataAdapterCreate
-} from 'components/lookup-tables';
+import {DataAdapter, DataAdapterCreate, DataAdapterForm, DataAdaptersOverview} from "components/lookup-tables";
 
-import CombinedProvider from 'injection/CombinedProvider';
+import CombinedProvider from "injection/CombinedProvider";
 
 const { LookupTableDataAdaptersStore, LookupTableDataAdaptersActions } = CombinedProvider.get(
   'LookupTableDataAdapters');
@@ -45,6 +43,8 @@ const LUTDataAdaptersPage = React.createClass({
 
   _startErrorStatesTimer() {
     this._stopErrorStatesTimer();
+    console.log("Starting errorstates retrieval");
+
     this.errorStatesTimer = setInterval(() => {
       let names = null;
       if (this.state.dataAdapters) {
@@ -58,6 +58,7 @@ const LUTDataAdaptersPage = React.createClass({
 
   _stopErrorStatesTimer() {
     if (this.errorStatesTimer) {
+      console.log("Stopping errorstates retrieval");
       clearInterval(this.errorStatesTimer);
       this.errorStatesTimer = undefined;
     }
@@ -67,13 +68,12 @@ const LUTDataAdaptersPage = React.createClass({
     this._stopErrorStatesTimer();
     if (props.params && props.params.adapterName) {
       LookupTableDataAdaptersActions.get(props.params.adapterName);
+    } else if (this._isCreating(props)) {
+      LookupTableDataAdaptersActions.getTypes();
     } else {
       const p = this.state.pagination;
       LookupTableDataAdaptersActions.searchPaginated(p.page, p.per_page, p.query);
       this._startErrorStatesTimer();
-    }
-    if (this._isCreating(props)) {
-      LookupTableDataAdaptersActions.getTypes();
     }
   },
 

--- a/graylog2-web-interface/src/pages/LUTTablesPage.jsx
+++ b/graylog2-web-interface/src/pages/LUTTablesPage.jsx
@@ -1,14 +1,14 @@
-import React, { PropTypes } from 'react';
-import Reflux from 'reflux';
-import { Button, Row, Col } from 'react-bootstrap';
-import { LinkContainer } from 'react-router-bootstrap';
-import Routes from 'routing/Routes';
+import React, {PropTypes} from "react";
+import Reflux from "reflux";
+import {Button, Col, Row} from "react-bootstrap";
+import {LinkContainer} from "react-router-bootstrap";
+import Routes from "routing/Routes";
 
-import { DocumentTitle, PageHeader, Spinner } from 'components/common';
+import {DocumentTitle, PageHeader, Spinner} from "components/common";
 
-import { LookupTablesOverview, LookupTable, LookupTableCreate, LookupTableForm } from 'components/lookup-tables';
+import {LookupTable, LookupTableCreate, LookupTableForm, LookupTablesOverview} from "components/lookup-tables";
 
-import CombinedProvider from 'injection/CombinedProvider';
+import CombinedProvider from "injection/CombinedProvider";
 
 const { LookupTablesStore, LookupTablesActions } = CombinedProvider.get('LookupTables');
 
@@ -64,13 +64,12 @@ const LUTTablesPage = React.createClass({
     this._stopErrorStatesTimer();
     if (props.params && props.params.tableName) {
       LookupTablesActions.get(props.params.tableName);
+    } else if (this._isCreating(props)) {
+      // nothing to do, the intermediate data container will take care of loading the caches and adapters
     } else {
       const p = this.state.pagination;
       LookupTablesActions.searchPaginated(p.page, p.per_page, p.query);
       this._startErrorStatesTimer();
-    }
-    if (this._isCreating(props)) {
-      // nothing to do, the intermediate data container will take care of loading the caches and adapters
     }
   },
 

--- a/graylog2-web-interface/src/pages/LUTTablesPage.jsx
+++ b/graylog2-web-interface/src/pages/LUTTablesPage.jsx
@@ -1,14 +1,14 @@
-import React, {PropTypes} from "react";
-import Reflux from "reflux";
-import {Button, Col, Row} from "react-bootstrap";
-import {LinkContainer} from "react-router-bootstrap";
-import Routes from "routing/Routes";
+import React, { PropTypes } from 'react';
+import Reflux from 'reflux';
+import { Button, Col, Row } from 'react-bootstrap';
+import { LinkContainer } from 'react-router-bootstrap';
+import Routes from 'routing/Routes';
 
-import {DocumentTitle, PageHeader, Spinner} from "components/common";
+import { DocumentTitle, PageHeader, Spinner } from 'components/common';
 
-import {LookupTable, LookupTableCreate, LookupTableForm, LookupTablesOverview} from "components/lookup-tables";
+import { LookupTable, LookupTableCreate, LookupTableForm, LookupTablesOverview } from 'components/lookup-tables';
 
-import CombinedProvider from "injection/CombinedProvider";
+import CombinedProvider from 'injection/CombinedProvider';
 
 const { LookupTablesStore, LookupTablesActions } = CombinedProvider.get('LookupTables');
 

--- a/graylog2-web-interface/src/stores/lookup-tables/LookupTableCachesStore.js
+++ b/graylog2-web-interface/src/stores/lookup-tables/LookupTableCachesStore.js
@@ -25,6 +25,7 @@ const LookupTableCachesStore = Reflux.createStore({
     return {
       caches: undefined,
       pagination: this.pagination,
+      validationErrors: {},
     };
   },
 
@@ -111,6 +112,19 @@ const LookupTableCachesStore = Reflux.createStore({
     const promise = fetch('DELETE', url);
 
     LookupTableCachesActions.delete.promise(promise);
+    return promise;
+  },
+
+  validate(cache) {
+    const url = this._url('caches/validate');
+    const promise = fetch('POST', url, cache);
+
+    promise.then((response) => {
+      this.trigger({
+        validationErrors: response.errors,
+      });
+    });
+    LookupTableCachesActions.validate.promise(promise);
     return promise;
   },
 

--- a/graylog2-web-interface/src/stores/lookup-tables/LookupTableCachesStore.js
+++ b/graylog2-web-interface/src/stores/lookup-tables/LookupTableCachesStore.js
@@ -77,7 +77,7 @@ const LookupTableCachesStore = Reflux.createStore({
 
     promise.then((response) => {
       this.trigger({ cache: response });
-    });
+    }, this._errorHandler('Creating lookup table cache failed', `Could not create lookup table cache "${cache.name}"`));
 
     LookupTableCachesActions.create.promise(promise);
     return promise;
@@ -89,7 +89,7 @@ const LookupTableCachesStore = Reflux.createStore({
 
     promise.then((response) => {
       this.trigger({ cache: response });
-    });
+    }, this._errorHandler('Updating lookup table cache failed', `Could not update lookup table cache "${cache.name}"`));
 
     LookupTableCachesActions.update.promise(promise);
     return promise;
@@ -101,7 +101,7 @@ const LookupTableCachesStore = Reflux.createStore({
 
     promise.then((response) => {
       this.trigger({ types: response });
-    });
+    }, this._errorHandler('Fetching available types failed', 'Could not fetch the available lookup table cache types'));
 
     LookupTableCachesActions.getTypes.promise(promise);
     return promise;
@@ -110,6 +110,8 @@ const LookupTableCachesStore = Reflux.createStore({
   delete(idOrName) {
     const url = this._url(`caches/${idOrName}`);
     const promise = fetch('DELETE', url);
+
+    promise.catch(this._errorHandler('Deleting lookup table cache failed', `Could not delete lookup table cache "${idOrName}"`));
 
     LookupTableCachesActions.delete.promise(promise);
     return promise;
@@ -123,7 +125,7 @@ const LookupTableCachesStore = Reflux.createStore({
       this.trigger({
         validationErrors: response.errors,
       });
-    });
+    }, this._errorHandler('Lookup table cache validation failed', `Could not validate lookup table cache "${cache.name}"`));
     LookupTableCachesActions.validate.promise(promise);
     return promise;
   },

--- a/graylog2-web-interface/src/stores/lookup-tables/LookupTableDataAdaptersStore.js
+++ b/graylog2-web-interface/src/stores/lookup-tables/LookupTableDataAdaptersStore.js
@@ -77,7 +77,7 @@ const LookupTableDataAdaptersStore = Reflux.createStore({
 
     promise.then((response) => {
       this.trigger({ dataAdapter: response });
-    });
+    }, this._errorHandler('Creating lookup table data adapter failed', `Could not create lookup table data adapter "${dataAdapter.name}"`));
 
     LookupTableDataAdaptersActions.create.promise(promise);
     return promise;
@@ -89,7 +89,7 @@ const LookupTableDataAdaptersStore = Reflux.createStore({
 
     promise.then((response) => {
       this.trigger({ dataAdapter: response });
-    });
+    }, this._errorHandler('Updating lookup table data adapter failed', `Could not update lookup table data adapter "${dataAdapter.name}"`));
 
     LookupTableDataAdaptersActions.update.promise(promise);
     return promise;
@@ -101,7 +101,7 @@ const LookupTableDataAdaptersStore = Reflux.createStore({
 
     promise.then((response) => {
       this.trigger({ types: response });
-    });
+    }, this._errorHandler('Fetching available types failed', 'Could not fetch the available lookup table data adapter types'));
 
     LookupTableDataAdaptersActions.getTypes.promise(promise);
     return promise;
@@ -111,18 +111,20 @@ const LookupTableDataAdaptersStore = Reflux.createStore({
     const url = this._url(`adapters/${idOrName}`);
     const promise = fetch('DELETE', url);
 
+    promise.catch(this._errorHandler('Deleting lookup table data adapter failed', `Could not delete lookup table data adapter "${idOrName}"`));
+
     LookupTableDataAdaptersActions.delete.promise(promise);
     return promise;
   },
 
-  lookup(tableName, key) {
-    const promise = fetch('GET', this._url(`adapters/${tableName}/query?key=${key}`));
+  lookup(adapterName, key) {
+    const promise = fetch('GET', this._url(`adapters/${adapterName}/query?key=${key}`));
 
     promise.then((response) => {
       this.trigger({
         lookupResult: response,
       });
-    });
+    }, this._errorHandler('Lookup failed', `Could not lookup value for key "${key}" in lookup table data adapter "${adapterName}"`));
 
     LookupTableDataAdaptersActions.lookup.promise(promise);
 
@@ -137,7 +139,7 @@ const LookupTableDataAdaptersStore = Reflux.createStore({
       this.trigger({
         validationErrors: response.errors,
       });
-    });
+    }, this._errorHandler('Lookup table data adapter validation failed', `Could not validate lookup table data adapter "${adapter.name}"`));
     LookupTableDataAdaptersActions.validate.promise(promise);
     return promise;
   },

--- a/graylog2-web-interface/src/stores/lookup-tables/LookupTableDataAdaptersStore.js
+++ b/graylog2-web-interface/src/stores/lookup-tables/LookupTableDataAdaptersStore.js
@@ -25,6 +25,7 @@ const LookupTableDataAdaptersStore = Reflux.createStore({
     return {
       dataAdapters: undefined,
       pagination: this.pagination,
+      validationErrors: [],
     };
   },
 
@@ -124,6 +125,15 @@ const LookupTableDataAdaptersStore = Reflux.createStore({
     });
 
     LookupTableDataAdaptersActions.lookup.promise(promise);
+
+    return promise;
+  },
+
+  validate(adapter) {
+    const url = this._url('adapters/validate');
+    const promise = fetch('POST', url, adapter);
+
+    LookupTableDataAdaptersActions.validate.promise(promise);
     return promise;
   },
 

--- a/graylog2-web-interface/src/stores/lookup-tables/LookupTableDataAdaptersStore.js
+++ b/graylog2-web-interface/src/stores/lookup-tables/LookupTableDataAdaptersStore.js
@@ -25,7 +25,7 @@ const LookupTableDataAdaptersStore = Reflux.createStore({
     return {
       dataAdapters: undefined,
       pagination: this.pagination,
-      validationErrors: [],
+      validationErrors: {},
     };
   },
 
@@ -133,6 +133,11 @@ const LookupTableDataAdaptersStore = Reflux.createStore({
     const url = this._url('adapters/validate');
     const promise = fetch('POST', url, adapter);
 
+    promise.then((response) => {
+      this.trigger({
+        validationErrors: response.errors,
+      });
+    });
     LookupTableDataAdaptersActions.validate.promise(promise);
     return promise;
   },

--- a/graylog2-web-interface/src/stores/lookup-tables/LookupTablesStore.js
+++ b/graylog2-web-interface/src/stores/lookup-tables/LookupTablesStore.js
@@ -92,6 +92,8 @@ const LookupTablesStore = Reflux.createStore({
     const url = this._url('tables');
     const promise = fetch('POST', url, table);
 
+    promise.catch(this._errorHandler('Creating lookup table failed', `Could not create lookup table "${table.name}"`));
+
     LookupTablesActions.create.promise(promise);
     return promise;
   },
@@ -100,6 +102,8 @@ const LookupTablesStore = Reflux.createStore({
     const url = this._url('tables');
     const promise = fetch('PUT', url, table);
 
+    promise.catch(this._errorHandler('Updating lookup table failed', `Could not update lookup table "${table.name}"`));
+
     LookupTablesActions.update.promise(promise);
     return promise;
   },
@@ -107,6 +111,8 @@ const LookupTablesStore = Reflux.createStore({
   delete(idOrName) {
     const url = this._url(`tables/${idOrName}`);
     const promise = fetch('DELETE', url);
+
+    promise.catch(this._errorHandler('Deleting lookup table failed', `Could not delete lookup table "${idOrName}"`));
 
     LookupTablesActions.delete.promise(promise);
     return promise;
@@ -147,7 +153,7 @@ const LookupTablesStore = Reflux.createStore({
       this.trigger({
         lookupResult: response,
       });
-    });
+    }, this._errorHandler('Lookup failed', `Could not lookup value for key "${key}" in lookup table "${tableName}"`));
 
     LookupTablesActions.lookup.promise(promise);
     return promise;


### PR DESCRIPTION
config classes can now optionally validate their settings, e.g.
checking for missing files and non-sensical settings to raise mistakes
during creation of instances

this also allows uniform checking for unique names for entities as well
as helping plugin authors to provide a better user experience (e.g.
checking that a backend HTTP service is reachable etc)

how much or how little is done depends on the plugin author

failed validation currently does not prevent saving the configuration,
but the UI should warn the user

also auto-generates the name property from the title unless it has been modified manually

#3831
#3835
