### PR TITLE
Don't reload errorstates on  pages that don't need them

### DIFF
--- a/graylog2-web-interface/src/pages/LUTDataAdaptersPage.jsx
+++ b/graylog2-web-interface/src/pages/LUTDataAdaptersPage.jsx
@@ -44,6 +44,7 @@ const LUTDataAdaptersPage = React.createClass({
   errorStatesInterval: 1000,
 
   _startErrorStatesTimer() {
+    this._stopErrorStatesTimer();
     this.errorStatesTimer = setInterval(() => {
       let names = null;
       if (this.state.dataAdapters) {

--- a/graylog2-web-interface/src/pages/LUTDataAdaptersPage.jsx
+++ b/graylog2-web-interface/src/pages/LUTDataAdaptersPage.jsx
@@ -30,16 +30,6 @@ const LUTDataAdaptersPage = React.createClass({
 
   componentDidMount() {
     this._loadData(this.props);
-
-    this.errorStatesTimer = setInterval(() => {
-      let names = null;
-      if (this.state.dataAdapters) {
-        names = this.state.dataAdapters.map(t => t.name);
-      }
-      if (names) {
-        LookupTablesActions.getErrors(null, null, names || null);
-      }
-    }, this.errorStatesInterval);
   },
 
   componentWillReceiveProps(nextProps) {
@@ -53,12 +43,33 @@ const LUTDataAdaptersPage = React.createClass({
   errorStatesTimer: undefined,
   errorStatesInterval: 1000,
 
+  _startErrorStatesTimer() {
+    this.errorStatesTimer = setInterval(() => {
+      let names = null;
+      if (this.state.dataAdapters) {
+        names = this.state.dataAdapters.map(t => t.name);
+      }
+      if (names) {
+        LookupTablesActions.getErrors(null, null, names || null);
+      }
+    }, this.errorStatesInterval);
+  },
+
+  _stopErrorStatesTimer() {
+    if (this.errorStatesTimer) {
+      clearInterval(this.errorStatesTimer);
+      this.errorStatesTimer = undefined;
+    }
+  },
+
   _loadData(props) {
+    this._stopErrorStatesTimer();
     if (props.params && props.params.adapterName) {
       LookupTableDataAdaptersActions.get(props.params.adapterName);
     } else {
       const p = this.state.pagination;
       LookupTableDataAdaptersActions.searchPaginated(p.page, p.per_page, p.query);
+      this._startErrorStatesTimer();
     }
     if (this._isCreating(props)) {
       LookupTableDataAdaptersActions.getTypes();

--- a/graylog2-web-interface/src/pages/LUTTablesPage.jsx
+++ b/graylog2-web-interface/src/pages/LUTTablesPage.jsx
@@ -26,17 +26,6 @@ const LUTTablesPage = React.createClass({
 
   componentDidMount() {
     this._loadData(this.props);
-
-    this.errorStatesTimer = setInterval(() => {
-      let tableNames = null;
-      if (this.state.tables) {
-        tableNames = this.state.tables.map(t => t.name);
-      }
-      if (tableNames) {
-        const adapterNames = Object.values(this.state.dataAdapters).map(a => a.name);
-        LookupTablesActions.getErrors(tableNames, null, adapterNames || null);
-      }
-    }, this.errorStatesInterval);
   },
 
   componentWillReceiveProps(nextProps) {
@@ -50,12 +39,34 @@ const LUTTablesPage = React.createClass({
   errorStatesTimer: undefined,
   errorStatesInterval: 1000,
 
+  _startErrorStatesTimer() {
+    this.errorStatesTimer = setInterval(() => {
+      let tableNames = null;
+      if (this.state.tables) {
+        tableNames = this.state.tables.map(t => t.name);
+      }
+      if (tableNames) {
+        const adapterNames = Object.values(this.state.dataAdapters).map(a => a.name);
+        LookupTablesActions.getErrors(tableNames, null, adapterNames || null);
+      }
+    }, this.errorStatesInterval);
+  },
+
+  _stopErrorStatesTimer() {
+    if (this.errorStatesTimer) {
+      clearInterval(this.errorStatesTimer);
+      this.errorStatesTimer = undefined;
+    }
+  },
+
   _loadData(props) {
+    this._stopErrorStatesTimer();
     if (props.params && props.params.tableName) {
       LookupTablesActions.get(props.params.tableName);
     } else {
       const p = this.state.pagination;
       LookupTablesActions.searchPaginated(p.page, p.per_page, p.query);
+      this._startErrorStatesTimer();
     }
     if (this._isCreating(props)) {
       // nothing to do, the intermediate data container will take care of loading the caches and adapters

--- a/graylog2-web-interface/src/pages/LUTTablesPage.jsx
+++ b/graylog2-web-interface/src/pages/LUTTablesPage.jsx
@@ -40,6 +40,7 @@ const LUTTablesPage = React.createClass({
   errorStatesInterval: 1000,
 
   _startErrorStatesTimer() {
+    this._stopErrorStatesTimer();
     this.errorStatesTimer = setInterval(() => {
       let tableNames = null;
       if (this.state.tables) {


### PR DESCRIPTION
Only schedule the error states reloading for overview pages.

fixes #3834 