### PR TITLE
Better error log in case of failed index creation

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/indexer/indices/Indices.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/indices/Indices.java
@@ -434,7 +434,7 @@ public class Indices {
         if (succeeded) {
             auditEventSender.success(AuditActor.system(nodeId), ES_INDEX_CREATE, ImmutableMap.of("indexName", indexName));
         } else {
-            LOG.warn("Couldn't create index {}", indexName);
+            LOG.warn("Couldn't create index {}. Error: {}", indexName, jestResult.getErrorMessage());
             auditEventSender.failure(AuditActor.system(nodeId), ES_INDEX_CREATE, ImmutableMap.of("indexName", indexName));
         }
         return succeeded;


### PR DESCRIPTION
Issue Graylog2/graylog-plugin-archive#108 was hard to debug because of missing error logging in the `createIndex()` method. This pull request adds the error logging.