### PR TITLE
Dependency updates for Graylog 2.3.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -145,7 +145,7 @@
 
         <!-- Test dependencies -->
         <apacheds-server.version>2.0.0-M23</apacheds-server.version>
-        <assertj-core.version>3.6.2</assertj-core.version>
+        <assertj-core.version>3.8.0</assertj-core.version>
         <assertj-joda-time.version>2.0.0</assertj-joda-time.version>
         <awaitility.version>1.7.0</awaitility.version>
         <equalsverifier.version>2.2.2</equalsverifier.version>

--- a/pom.xml
+++ b/pom.xml
@@ -96,7 +96,7 @@
         <elasticsearch.version>2.4.4</elasticsearch.version>
         <jest.version>2.4.5</jest.version>
         <gelfclient.version>1.4.1</gelfclient.version>
-        <grok.version>0.1.6-graylog</grok.version>
+        <grok.version>0.1.7-graylog</grok.version>
         <guava-retrying.version>2.0.0</guava-retrying.version>
         <guava.version>21.0</guava.version>
         <guice.version>4.1.0</guice.version>

--- a/pom.xml
+++ b/pom.xml
@@ -126,7 +126,7 @@
         <mongojack.version>2.7.0</mongojack.version>
         <natty.version>0.13</natty.version>
         <netty.version>3.10.6.Final</netty.version>
-        <okhttp.version>3.7.0</okhttp.version>
+        <okhttp.version>3.8.0</okhttp.version>
         <opencsv.version>2.3</opencsv.version>
         <os-platform-finder.version>1.2.2</os-platform-finder.version>
         <protobuf.version>3.2.0</protobuf.version>

--- a/pom.xml
+++ b/pom.xml
@@ -137,7 +137,7 @@
         <sigar.version>1.6.4</sigar.version>
         <slf4j.version>1.7.25</slf4j.version>
         <swagger.version>1.5.13</swagger.version>
-        <syslog4j.version>0.9.59</syslog4j.version>
+        <syslog4j.version>0.9.60</syslog4j.version>
         <uuid.version>3.2</uuid.version>
         <validation-api.version>1.1.0.Final</validation-api.version>
         <zkclient.version>0.7</zkclient.version>

--- a/pom.xml
+++ b/pom.xml
@@ -131,7 +131,7 @@
         <os-platform-finder.version>1.2.2</os-platform-finder.version>
         <protobuf.version>3.2.0</protobuf.version>
         <reflections.version>0.9.11</reflections.version>
-        <retrofit.version>2.2.0</retrofit.version>
+        <retrofit.version>2.3.0</retrofit.version>
         <scala.version>2.11.8</scala.version>
         <shiro.version>1.3.2</shiro.version>
         <sigar.version>1.6.4</sigar.version>

--- a/pom.xml
+++ b/pom.xml
@@ -152,7 +152,7 @@
         <fongo.version>2.1.0</fongo.version>
         <jukito.version>1.5</jukito.version>
         <junit.version>4.12</junit.version>
-        <mockito.version>2.7.22</mockito.version>
+        <mockito.version>2.8.9</mockito.version>
         <nosqlunit.version>0.10.0</nosqlunit.version>
         <restassured.version>2.9.0</restassured.version>
         <system-rules.version>1.16.1</system-rules.version>

--- a/pom.xml
+++ b/pom.xml
@@ -133,7 +133,7 @@
         <reflections.version>0.9.11</reflections.version>
         <retrofit.version>2.3.0</retrofit.version>
         <scala.version>2.11.8</scala.version>
-        <shiro.version>1.3.2</shiro.version>
+        <shiro.version>1.4.0</shiro.version>
         <sigar.version>1.6.4</sigar.version>
         <slf4j.version>1.7.25</slf4j.version>
         <swagger.version>1.5.13</swagger.version>

--- a/pom.xml
+++ b/pom.xml
@@ -107,7 +107,7 @@
         <jackson.version>2.8.8</jackson.version>
         <jadconfig.version>0.13.0</jadconfig.version>
         <java-semver.version>0.9.0</java-semver.version>
-        <javapoet.version>1.8.0</javapoet.version>
+        <javapoet.version>1.9.0</javapoet.version>
         <javax.annotation-api.version>1.3</javax.annotation-api.version>
         <javax.el-api.version>3.0.0</javax.el-api.version>
         <javax.inject.version>1</javax.inject.version>

--- a/pom.xml
+++ b/pom.xml
@@ -149,7 +149,7 @@
         <assertj-joda-time.version>2.0.0</assertj-joda-time.version>
         <awaitility.version>1.7.0</awaitility.version>
         <equalsverifier.version>2.2.2</equalsverifier.version>
-        <fongo.version>2.0.13</fongo.version>
+        <fongo.version>2.1.0</fongo.version>
         <jukito.version>1.5</jukito.version>
         <junit.version>4.12</junit.version>
         <mockito.version>2.7.22</mockito.version>


### PR DESCRIPTION
* Upgrade to OkHttp 3.8.0: https://github.com/square/okhttp/blob/parent-3.8.0/CHANGELOG.md#version-380
* Upgrade to Retrofit 2.3.0: https://github.com/square/retrofit/blob/parent-2.3.0/CHANGELOG.md#version-230-2017-05-13
* Upgrade to JavaPoet 1.9.0: https://github.com/square/javapoet/blob/javapoet-1.9.0/CHANGELOG.md#javapoet-190-2017-05-13
* Upgrade to Apache Shiro 1.4.0
* Upgrade to Grok 0.1.7-graylog
* Upgrade to syslog4j 0.9.60
* Upgrade to Fongo 2.1.0
* Upgrade to AssertJ Core 3.8.0
  * https://joel-costigliola.github.io/assertj/assertj-core-news.html#assertj-core-3.7.0
  * https://joel-costigliola.github.io/assertj/assertj-core-news.html#assertj-core-3.8.0
* Upgrade to Mockito 2.8.9