### PR TITLE
Check Elasticsearch version when creating index template

### DIFF
--- a/UPGRADING.rst
+++ b/UPGRADING.rst
@@ -50,8 +50,6 @@ The following configuration options are now being used to configure connectivity
 +----------------------------------------------------+-----------+--------------------------------------------------------------+-----------------------------+
 | ``elasticsearch_socket_timeout``                   | Duration  | Timeout when sending/receiving from Elasticsearch connection | ``60s`` (60 Seconds)        |
 +----------------------------------------------------+-----------+--------------------------------------------------------------+-----------------------------+
-| ``elasticsearch_version``                          | (2 or 5)  | Major version of Elasticsearch being used in the cluster     | ``5``                       |
-+----------------------------------------------------+-----------+--------------------------------------------------------------+-----------------------------+
 | ``elasticsearch_discovery_enabled``                | boolean   | Enable automatic Elasticsearch node discovery                | ``false``                   |
 +----------------------------------------------------+-----------+--------------------------------------------------------------+-----------------------------+
 | ``elasticsearch_discovery_filter``                 | String    | Filter by node attributes for the discovered nodes           | empty (use all nodes)       |
@@ -59,7 +57,7 @@ The following configuration options are now being used to configure connectivity
 | ``elasticsearch_discovery_frequency``              | Duration  | Frequency of the Elasticsearch node discovery                | ``30s`` (30 Seconds)        |
 +----------------------------------------------------+-----------+--------------------------------------------------------------+-----------------------------+
 
-In most cases, the only configuration setting that needs to be set explicitly is ``elasticsearch_hosts``, unless you use Elasticsearch 2.x (or earlier). In the latter case you would need to set ``elasticsearch_version`` to ``2``. All other configuration settings should be tweaked only in case of errors.
+In most cases, the only configuration setting that needs to be set explicitly is ``elasticsearch_hosts``. All other configuration settings should be tweaked only in case of errors.
 
 .. warn:: The automatic node discovery does not work if Elasticsearch requires authentication, e. g. when using Shield (X-Pack).
 

--- a/graylog2-server/src/main/java/org/graylog2/bindings/ElasticsearchModule.java
+++ b/graylog2-server/src/main/java/org/graylog2/bindings/ElasticsearchModule.java
@@ -21,32 +21,13 @@ import com.google.gson.GsonBuilder;
 import com.google.inject.AbstractModule;
 import io.searchbox.client.JestClient;
 import org.graylog2.bindings.providers.JestClientProvider;
-import org.graylog2.configuration.ElasticsearchClientConfiguration;
-import org.graylog2.indexer.IndexMapping;
-import org.graylog2.indexer.IndexMapping2;
-import org.graylog2.indexer.IndexMapping5;
+import org.graylog2.indexer.IndexMappingFactory;
 
 public class ElasticsearchModule extends AbstractModule {
-    private final ElasticsearchClientConfiguration elasticsearchClientConfiguration;
-
-    public ElasticsearchModule(ElasticsearchClientConfiguration elasticsearchClientConfiguration) {
-        this.elasticsearchClientConfiguration = elasticsearchClientConfiguration;
-    }
-
     @Override
     protected void configure() {
         bind(Gson.class).toInstance(new GsonBuilder().create());
         bind(JestClient.class).toProvider(JestClientProvider.class).asEagerSingleton();
-
-        switch (elasticsearchClientConfiguration.getVersion()) {
-            case 2:
-                bind(IndexMapping.class).to(IndexMapping2.class).asEagerSingleton();
-                break;
-            case 5:
-                bind(IndexMapping.class).to(IndexMapping5.class).asEagerSingleton();
-                break;
-            default:
-                throw new IllegalArgumentException("Invalid Elasticsearch version: " + elasticsearchClientConfiguration.getVersion());
-        }
+        bind(IndexMappingFactory.class).asEagerSingleton();
     }
 }

--- a/graylog2-server/src/main/java/org/graylog2/commands/Server.java
+++ b/graylog2-server/src/main/java/org/graylog2/commands/Server.java
@@ -109,7 +109,7 @@ public class Server extends ServerBootstrap {
         modules.add(
             new ConfigurationModule(configuration),
             new ServerBindings(configuration),
-            new ElasticsearchModule(elasticsearchClientConfiguration),
+            new ElasticsearchModule(),
             new PersistenceServicesBindings(),
             new MessageFilterBindings(),
             new MessageProcessorModule(),

--- a/graylog2-server/src/main/java/org/graylog2/configuration/ElasticsearchClientConfiguration.java
+++ b/graylog2-server/src/main/java/org/graylog2/configuration/ElasticsearchClientConfiguration.java
@@ -17,8 +17,6 @@
 package org.graylog2.configuration;
 
 import com.github.joschi.jadconfig.Parameter;
-import com.github.joschi.jadconfig.ValidationException;
-import com.github.joschi.jadconfig.ValidatorMethod;
 import com.github.joschi.jadconfig.validators.PositiveIntegerValidator;
 import org.graylog2.configuration.converters.URIListConverter;
 import org.graylog2.configuration.validators.ListOfURIsWithHostAndSchemeValidator;
@@ -48,9 +46,6 @@ public class ElasticsearchClientConfiguration {
     @Parameter(value = "elasticsearch_max_total_connections_per_route", validators = { PositiveIntegerValidator.class })
     private int elasticsearchMaxTotalConnectionsPerRoute = 2;
 
-    @Parameter(value = "elasticsearch_version")
-    private int elasticsearchVersion = 5;
-
     @Parameter(value = "elasticsearch_discovery_enabled")
     private boolean discoveryEnabled = false;
 
@@ -59,20 +54,4 @@ public class ElasticsearchClientConfiguration {
 
     @Parameter(value = "elasticsearch_discovery_frequency")
     private Duration discoveryFrequency = Duration.ofSeconds(30L);
-
-    public int getVersion() {
-        return elasticsearchVersion;
-    }
-
-    @SuppressWarnings("unused")
-    @ValidatorMethod
-    public void validateElasticsearchVersion() throws ValidationException {
-        switch (elasticsearchVersion) {
-            case 2:
-            case 5:
-                return;
-            default:
-                throw new ValidationException("Valid values for \"elasticsearch_version\" are 2 and 5, value was " + elasticsearchVersion);
-        }
-    }
 }

--- a/graylog2-server/src/main/java/org/graylog2/indexer/IndexMapping.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/IndexMapping.java
@@ -20,7 +20,6 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import org.graylog2.plugin.Tools;
 
-import javax.inject.Singleton;
 import java.util.List;
 import java.util.Map;
 

--- a/graylog2-server/src/main/java/org/graylog2/indexer/IndexMapping2.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/IndexMapping2.java
@@ -16,11 +16,8 @@
  */
 package org.graylog2.indexer;
 
-import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 
-import javax.inject.Singleton;
-import java.util.List;
 import java.util.Map;
 
 /**
@@ -29,7 +26,6 @@ import java.util.Map;
  *
  * @see <a href="https://www.elastic.co/guide/en/elasticsearch/reference/2.4/mapping.html">Elasticsearch Reference / Mapping</a>
  */
-@Singleton
 public class IndexMapping2 extends IndexMapping {
     @Override
     protected Map<String, Map<String, Object>> fieldProperties(String analyzer) {

--- a/graylog2-server/src/main/java/org/graylog2/indexer/IndexMapping5.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/IndexMapping5.java
@@ -18,7 +18,6 @@ package org.graylog2.indexer;
 
 import com.google.common.collect.ImmutableMap;
 
-import javax.inject.Singleton;
 import java.util.Map;
 
 /**
@@ -27,7 +26,6 @@ import java.util.Map;
  *
  * @see <a href="https://www.elastic.co/guide/en/elasticsearch/reference/5.4/mapping.html">Elasticsearch Reference / Mapping</a>
  */
-@Singleton
 public class IndexMapping5 extends IndexMapping {
     @Override
     protected Map<String, Map<String, Object>> fieldProperties(String analyzer) {

--- a/graylog2-server/src/main/java/org/graylog2/indexer/IndexMappingFactory.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/IndexMappingFactory.java
@@ -1,0 +1,68 @@
+/**
+ * This file is part of Graylog.
+ *
+ * Graylog is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.graylog2.indexer;
+
+import com.github.zafarkhaja.semver.Version;
+import io.searchbox.client.JestClient;
+import io.searchbox.client.JestResult;
+import io.searchbox.core.Ping;
+import org.graylog2.indexer.cluster.jest.JestUtils;
+import org.graylog2.indexer.gson.GsonUtils;
+
+import javax.inject.Inject;
+import javax.inject.Singleton;
+import java.util.Optional;
+
+import static java.util.Objects.requireNonNull;
+
+@Singleton
+public class IndexMappingFactory {
+    private final JestClient jestClient;
+
+    @Inject
+    public IndexMappingFactory(JestClient jestClient) {
+        this.jestClient = requireNonNull(jestClient, "jestClient");
+    }
+
+    private Optional<Version> getElasticsearchVersion() {
+        final Ping request = new Ping.Builder().build();
+        final JestResult jestResult = JestUtils.execute(jestClient, request, () -> "Unable to retrieve Elasticsearch version");
+        return Optional.ofNullable(jestResult.getJsonObject())
+                .map(json -> GsonUtils.asJsonObject(json.get("version")))
+                .map(json -> GsonUtils.asString(json.get("number")))
+                .map(this::parseVersion);
+    }
+
+    private Version parseVersion(String version) {
+        try {
+            return Version.valueOf(version);
+        } catch (Exception e) {
+            throw new ElasticsearchException("Unable to parse Elasticsearch version: " + version, e);
+        }
+    }
+
+    public IndexMapping createIndexMapping() {
+        final Version elasticsearchVersion = getElasticsearchVersion().orElseThrow(() -> new ElasticsearchException("Unable to retrieve Elasticsearch version"));
+        if (elasticsearchVersion.satisfies(">=2.1.0 & <5.0.0")) {
+            return new IndexMapping2();
+        } else if (elasticsearchVersion.satisfies("^5.0.0")) {
+            return new IndexMapping5();
+        } else {
+            throw new ElasticsearchException("Unsupported Elasticsearch version: " + elasticsearchVersion);
+        }
+    }
+}

--- a/graylog2-server/src/main/java/org/graylog2/indexer/indices/Indices.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/indices/Indices.java
@@ -48,11 +48,9 @@ import io.searchbox.indices.CreateIndex;
 import io.searchbox.indices.DeleteIndex;
 import io.searchbox.indices.Flush;
 import io.searchbox.indices.ForceMerge;
-import io.searchbox.indices.IndicesExists;
 import io.searchbox.indices.OpenIndex;
 import io.searchbox.indices.Stats;
 import io.searchbox.indices.aliases.AddAliasMapping;
-import io.searchbox.indices.aliases.AliasExists;
 import io.searchbox.indices.aliases.AliasMapping;
 import io.searchbox.indices.aliases.GetAliases;
 import io.searchbox.indices.aliases.ModifyAliases;
@@ -74,6 +72,7 @@ import org.graylog2.audit.AuditActor;
 import org.graylog2.audit.AuditEventSender;
 import org.graylog2.indexer.ElasticsearchException;
 import org.graylog2.indexer.IndexMapping;
+import org.graylog2.indexer.IndexMappingFactory;
 import org.graylog2.indexer.IndexNotFoundException;
 import org.graylog2.indexer.IndexSet;
 import org.graylog2.indexer.cluster.jest.JestUtils;
@@ -128,19 +127,19 @@ public class Indices {
 
     private final JestClient jestClient;
     private final Gson gson;
-    private final IndexMapping indexMapping;
+    private final IndexMappingFactory indexMappingFactory;
     private final Messages messages;
     private final NodeId nodeId;
     private final AuditEventSender auditEventSender;
     private final EventBus eventBus;
 
     @Inject
-    public Indices(JestClient jestClient, Gson gson, IndexMapping indexMapping,
+    public Indices(JestClient jestClient, Gson gson, IndexMappingFactory indexMappingFactory,
                    Messages messages, NodeId nodeId, AuditEventSender auditEventSender,
                    EventBus eventBus) {
         this.jestClient = jestClient;
         this.gson = gson;
-        this.indexMapping = indexMapping;
+        this.indexMappingFactory = indexMappingFactory;
         this.messages = messages;
         this.nodeId = nodeId;
         this.auditEventSender = auditEventSender;
@@ -387,6 +386,7 @@ public class Indices {
     private void ensureIndexTemplate(IndexSet indexSet) {
         final IndexSetConfig indexSetConfig = indexSet.getConfig();
         final String templateName = indexSetConfig.indexTemplateName();
+        final IndexMapping indexMapping = indexMappingFactory.createIndexMapping();
         final Map<String, Object> template = indexMapping.messageTemplate(indexSet.getIndexWildcard(), indexSetConfig.indexAnalyzer(), -1);
 
         final PutTemplate request = new PutTemplate.Builder(templateName, template).build();

--- a/graylog2-server/src/test/java/org/graylog2/indexer/IndexMappingFactoryTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/indexer/IndexMappingFactoryTest.java
@@ -1,0 +1,187 @@
+/**
+ * This file is part of Graylog.
+ *
+ * Graylog is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.graylog2.indexer;
+
+import com.github.zafarkhaja.semver.ParseException;
+import com.google.gson.JsonObject;
+import io.searchbox.client.JestClient;
+import io.searchbox.client.JestResult;
+import io.searchbox.core.Ping;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnit;
+import org.mockito.junit.MockitoRule;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.Collection;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class IndexMappingFactoryTest {
+    @Rule
+    public final MockitoRule mockitoRule = MockitoJUnit.rule();
+
+    @Mock
+    private JestClient jestClient;
+    private IndexMappingFactory indexMappingFactory;
+
+    @Before
+    public void setUp() throws Exception {
+        indexMappingFactory = new IndexMappingFactory(jestClient);
+    }
+
+    @Test
+    public void createIndexMappingFailsIfElasticsearchIsUnavailable() throws Exception {
+        when(jestClient.execute(any(Ping.class))).thenThrow(IOException.class);
+
+        assertThatThrownBy(() -> indexMappingFactory.createIndexMapping())
+                .isInstanceOf(ElasticsearchException.class)
+                .hasCauseInstanceOf(IOException.class);
+    }
+
+    @Test
+    public void createIndexMappingFailsIfElasticsearchResponseFailed() throws Exception {
+        final JestResult failedResult = mock(JestResult.class);
+        when(failedResult.isSucceeded()).thenReturn(false);
+        when(failedResult.getJsonObject()).thenReturn(new JsonObject());
+        when(jestClient.execute(any(Ping.class))).thenReturn(failedResult);
+        assertThatThrownBy(() -> indexMappingFactory.createIndexMapping())
+                .isInstanceOf(ElasticsearchException.class)
+                .hasMessageStartingWith("Unable to retrieve Elasticsearch version")
+                .hasNoCause();
+    }
+
+    @Test
+    public void createIndexMappingFailsIfElasticsearchVersionIsTooLow() throws Exception {
+        final JestResult jestResult = mock(JestResult.class);
+        when(jestResult.isSucceeded()).thenReturn(true);
+        when(jestResult.getJsonObject()).thenReturn(buildVersionJsonObject("1.7.3"));
+        when(jestClient.execute(any(Ping.class))).thenReturn(jestResult);
+
+        assertThatThrownBy(() -> indexMappingFactory.createIndexMapping())
+                .isInstanceOf(ElasticsearchException.class)
+                .hasMessageStartingWith("Unsupported Elasticsearch version: 1.7.3")
+                .hasNoCause();
+    }
+
+    @Test
+    public void createIndexMappingFailsIfElasticsearch2VersionIsTooLow() throws Exception {
+        final JestResult jestResult = mock(JestResult.class);
+        when(jestResult.isSucceeded()).thenReturn(true);
+        when(jestResult.getJsonObject()).thenReturn(buildVersionJsonObject("2.0.0"));
+        when(jestClient.execute(any(Ping.class))).thenReturn(jestResult);
+
+        assertThatThrownBy(() -> indexMappingFactory.createIndexMapping())
+                .isInstanceOf(ElasticsearchException.class)
+                .hasMessageStartingWith("Unsupported Elasticsearch version: 2.0.0")
+                .hasNoCause();
+    }
+
+    @Test
+    public void createIndexMappingFailsIfElasticsearchVersionIsTooHigh() throws Exception {
+        final JestResult jestResult = mock(JestResult.class);
+        when(jestResult.isSucceeded()).thenReturn(true);
+        when(jestResult.getJsonObject()).thenReturn(buildVersionJsonObject("6.0.0"));
+        when(jestClient.execute(any(Ping.class))).thenReturn(jestResult);
+
+        assertThatThrownBy(() -> indexMappingFactory.createIndexMapping())
+                .isInstanceOf(ElasticsearchException.class)
+                .hasMessageStartingWith("Unsupported Elasticsearch version: 6.0.0")
+                .hasNoCause();
+    }
+
+    @Test
+    public void createIndexMappingFailsIfElasticsearchVersionIsInvalid() throws Exception {
+        final JestResult jestResult = mock(JestResult.class);
+        when(jestResult.isSucceeded()).thenReturn(true);
+        when(jestResult.getJsonObject()).thenReturn(buildVersionJsonObject("Foobar"));
+        when(jestClient.execute(any(Ping.class))).thenReturn(jestResult);
+
+        assertThatThrownBy(() -> indexMappingFactory.createIndexMapping())
+                .isInstanceOf(ElasticsearchException.class)
+                .hasMessageStartingWith("Unable to parse Elasticsearch version: Foobar")
+                .hasCauseInstanceOf(ParseException.class);
+    }
+
+    private static JsonObject buildVersionJsonObject(String foobar) {
+        final JsonObject versionObject = new JsonObject();
+        versionObject.addProperty("number", foobar);
+        final JsonObject jsonObject = new JsonObject();
+        jsonObject.add("version", versionObject);
+        return jsonObject;
+    }
+
+    @RunWith(Parameterized.class)
+    public static class ParameterizedTest {
+        @Parameterized.Parameters
+        public static Collection<Object[]> data() {
+            return Arrays.asList(new Object[][]{
+                    {"2.1.0", IndexMapping2.class},
+                    {"2.2.0", IndexMapping2.class},
+                    {"2.3.0", IndexMapping2.class},
+                    {"2.4.0", IndexMapping2.class},
+                    {"2.4.5", IndexMapping2.class},
+                    {"5.0.0", IndexMapping5.class},
+                    {"5.1.0", IndexMapping5.class},
+                    {"5.2.0", IndexMapping5.class},
+                    {"5.3.0", IndexMapping5.class},
+                    {"5.4.0", IndexMapping5.class},
+            });
+        }
+
+        @Rule
+        public final MockitoRule mockitoRule = MockitoJUnit.rule();
+
+        private final String version;
+        private final Class<? extends IndexMapping> expectedMapping;
+
+        @Mock
+        private JestClient jestClient;
+        private IndexMappingFactory indexMappingFactory;
+
+
+        public ParameterizedTest(String version, Class<? extends IndexMapping> expectedMapping) {
+            this.version = version;
+            this.expectedMapping = expectedMapping;
+        }
+
+        @Before
+        public void setUp() throws Exception {
+            indexMappingFactory = new IndexMappingFactory(jestClient);
+        }
+
+        @Test
+        public void test() throws Exception {
+            final JestResult jestResult = mock(JestResult.class);
+            when(jestResult.isSucceeded()).thenReturn(true);
+            final JsonObject jsonObject = buildVersionJsonObject(version);
+            when(jestResult.getJsonObject()).thenReturn(jsonObject);
+            when(jestClient.execute(any(Ping.class))).thenReturn(jestResult);
+
+            assertThat(indexMappingFactory.createIndexMapping()).isInstanceOf(expectedMapping);
+        }
+    }
+}

--- a/graylog2-server/src/test/java/org/graylog2/indexer/indices/IndicesGetAllMessageFieldsTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/indexer/indices/IndicesGetAllMessageFieldsTest.java
@@ -28,7 +28,7 @@ import org.elasticsearch.action.admin.indices.get.GetIndexRequest;
 import org.elasticsearch.action.admin.indices.get.GetIndexResponse;
 import org.graylog2.AbstractESTest;
 import org.graylog2.audit.NullAuditEventSender;
-import org.graylog2.indexer.IndexMapping2;
+import org.graylog2.indexer.IndexMappingFactory;
 import org.graylog2.indexer.messages.Messages;
 import org.graylog2.plugin.system.NodeId;
 import org.junit.After;
@@ -55,7 +55,7 @@ public class IndicesGetAllMessageFieldsTest extends AbstractESTest {
         super.setUp();
         indices = new Indices(jestClient(),
                 new Gson(),
-                new IndexMapping2(),
+                new IndexMappingFactory(jestClient()),
                 new Messages(new MetricRegistry(), jestClient()),
                 mock(NodeId.class),
                 new NullAuditEventSender(),

--- a/graylog2-server/src/test/java/org/graylog2/indexer/nosqlunit/IndexCreatingDatabaseOperation.java
+++ b/graylog2-server/src/test/java/org/graylog2/indexer/nosqlunit/IndexCreatingDatabaseOperation.java
@@ -58,6 +58,7 @@ public class IndexCreatingDatabaseOperation implements DatabaseOperation<Client>
                 client.admin().indices().prepareDelete(index).execute().actionGet();
             }
 
+            // TODO: Use IndexMappingFactory if another version than Elasticsearch 2.x is being used (depends on NoSQLUnit).
             final IndexMapping indexMapping = new IndexMapping2();
 
             final String templateName = "graylog-test-internal";

--- a/misc/graylog.conf
+++ b/misc/graylog.conf
@@ -177,12 +177,6 @@ rest_listen_uri = http://127.0.0.1:9000/api/
 # Default: http://127.0.0.1:9200
 #elasticsearch_hosts = http://node1:9200,http://user:password@node2:19200
 
-# The (major) version of Elasticsearch being used in the cluster. This setting controls which
-# index mapping/index template is being used by Graylog. Valid values are 2 and 5.
-#
-# Default: 5
-#elasticsearch_version = 5
-
 # Maximum amount of time to wait for successfull connection to Elasticsearch HTTP port.
 #
 # Default: 10 Seconds


### PR DESCRIPTION
Instead of using a static configuration setting or trying to discover the Elasticsearch version
on startup (which might fail if Elasticsearch is unavailable), Graylog now checks the Elasticsearch
version when trying to create an index template and select the correct index mapping.

The "ping" request of Elasticsearch should be simple enough to not negatively influence the
Elasticsearch cluster and small enough to tolerate the additional network roundtrip.

This will fail if Elasticsearch is unavailable, but so would creating the index template.