### PR TITLE
Fix parameters for count query in Searches#count()

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/indexer/searches/Searches.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/searches/Searches.java
@@ -201,7 +201,7 @@ public class Searches {
 
     public CountResult count(String query, TimeRange range, String filter) {
         // limit, offset, and highlight are *NOT* supported by count queries
-        final SearchSourceBuilder searchSourceBuilder = standardSearchRequest(query, -1, -1, range, null, null, false);
+        final SearchSourceBuilder searchSourceBuilder = standardSearchRequest(query, -1, -1, range, filter, null, false);
         final Set<String> affectedIndices = determineAffectedIndices(range, filter);
         if (affectedIndices.isEmpty()) {
             return CountResult.empty();

--- a/graylog2-server/src/main/java/org/graylog2/indexer/searches/Searches.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/searches/Searches.java
@@ -200,13 +200,8 @@ public class Searches {
     }
 
     public CountResult count(String query, TimeRange range, String filter) {
-        final SearchSourceBuilder searchSourceBuilder;
-        if (filter == null) {
-            searchSourceBuilder = standardSearchRequest(query, range);
-        } else {
-            searchSourceBuilder = filteredSearchRequest(query, filter, range);
-        }
-
+        // limit, offset, and highlight are *NOT* supported by count queries
+        final SearchSourceBuilder searchSourceBuilder = standardSearchRequest(query, -1, -1, range, null, null, false);
         final Set<String> affectedIndices = determineAffectedIndices(range, filter);
         if (affectedIndices.isEmpty()) {
             return CountResult.empty();


### PR DESCRIPTION
The [Elasticsearch Count API](https://www.elastic.co/guide/en/elasticsearch/reference/5.4/search-count.html) doesn't support "limit", "offset", and "highlight" parameters.

Older versions of Elasticsearch ignored unknown parameters but that changed in Elasticsearch 5.x: https://www.elastic.co/guide/en/elasticsearch/reference/5.4/breaking-changes-5.0.html

Fixes #3841