### PR TITLE
Revert "Add timing metrics to GelfOutput (#3810)"

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/outputs/BenchmarkOutput.java
+++ b/graylog2-server/src/main/java/org/graylog2/outputs/BenchmarkOutput.java
@@ -31,7 +31,6 @@ import org.graylog2.plugin.outputs.MessageOutput;
 import org.graylog2.plugin.streams.Stream;
 import org.graylog2.shared.journal.Journal;
 
-import javax.annotation.Nullable;
 import javax.inject.Inject;
 import java.io.File;
 import java.util.List;
@@ -48,6 +47,14 @@ public class BenchmarkOutput implements MessageOutput {
     private final Meter messagesWritten;
     private final CsvReporter csvReporter;
     private final Journal journal;
+
+    @AssistedInject
+    public BenchmarkOutput(final MetricRegistry metricRegistry,
+                           final Journal journal,
+                           @Assisted Stream stream,
+                           @Assisted Configuration configuration) {
+        this(metricRegistry, journal);
+    }
 
     @Inject
     public BenchmarkOutput(final MetricRegistry metricRegistry, final Journal journal) {
@@ -102,7 +109,7 @@ public class BenchmarkOutput implements MessageOutput {
 
     public interface Factory extends MessageOutput.Factory<GelfOutput> {
         @Override
-        GelfOutput create(Stream stream, Configuration configuration, @Nullable String id);
+        GelfOutput create(Stream stream, Configuration configuration);
 
         @Override
         Config getConfig();

--- a/graylog2-server/src/main/java/org/graylog2/outputs/DiscardMessageOutput.java
+++ b/graylog2-server/src/main/java/org/graylog2/outputs/DiscardMessageOutput.java
@@ -18,13 +18,15 @@ package org.graylog2.outputs;
 
 import com.codahale.metrics.Meter;
 import com.codahale.metrics.MetricRegistry;
+import com.google.inject.assistedinject.Assisted;
+import com.google.inject.assistedinject.AssistedInject;
 import org.graylog2.plugin.Message;
 import org.graylog2.plugin.configuration.Configuration;
+import org.graylog2.plugin.configuration.ConfigurationRequest;
 import org.graylog2.plugin.outputs.MessageOutput;
 import org.graylog2.plugin.streams.Stream;
 import org.graylog2.shared.journal.Journal;
 
-import javax.annotation.Nullable;
 import javax.inject.Inject;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -35,6 +37,14 @@ public class DiscardMessageOutput implements MessageOutput {
     private final AtomicBoolean isRunning = new AtomicBoolean(false);
     private final Journal journal;
     private final Meter messagesDiscarded;
+
+    @AssistedInject
+    public DiscardMessageOutput(final Journal journal,
+                                final MetricRegistry metricRegistry,
+                                @Assisted Stream stream,
+                                @Assisted Configuration configuration) {
+        this(journal, metricRegistry);
+    }
 
     @Inject
     public DiscardMessageOutput(final Journal journal, final MetricRegistry metricRegistry) {
@@ -72,14 +82,6 @@ public class DiscardMessageOutput implements MessageOutput {
     }
 
     public interface Factory extends MessageOutput.Factory<DiscardMessageOutput> {
-        @Override
-        DiscardMessageOutput create(Stream stream, Configuration configuration, @Nullable String id);
-
-        @Override
-        Config getConfig();
-
-        @Override
-        Descriptor getDescriptor();
     }
 
     public static class Config extends MessageOutput.Config {

--- a/graylog2-server/src/main/java/org/graylog2/outputs/ElasticSearchOutput.java
+++ b/graylog2-server/src/main/java/org/graylog2/outputs/ElasticSearchOutput.java
@@ -21,6 +21,8 @@ import com.codahale.metrics.MetricRegistry;
 import com.codahale.metrics.Timer;
 import com.google.common.base.Joiner;
 import com.google.common.collect.Ordering;
+import com.google.inject.assistedinject.Assisted;
+import com.google.inject.assistedinject.AssistedInject;
 import org.graylog2.indexer.IndexSet;
 import org.graylog2.indexer.messages.Messages;
 import org.graylog2.plugin.Message;
@@ -32,7 +34,6 @@ import org.graylog2.shared.journal.Journal;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import javax.annotation.Nullable;
 import javax.inject.Inject;
 import java.util.Collections;
 import java.util.List;
@@ -54,6 +55,15 @@ public class ElasticSearchOutput implements MessageOutput {
     private final Messages messages;
     private final Journal journal;
     private final AtomicBoolean isRunning = new AtomicBoolean(false);
+
+    @AssistedInject
+    public ElasticSearchOutput(MetricRegistry metricRegistry,
+                               Messages messages,
+                               Journal journal,
+                               @Assisted Stream stream,
+                               @Assisted Configuration configuration) {
+        this(metricRegistry, messages, journal);
+    }
 
     @Inject
     public ElasticSearchOutput(MetricRegistry metricRegistry,
@@ -112,7 +122,7 @@ public class ElasticSearchOutput implements MessageOutput {
 
     public interface Factory extends MessageOutput.Factory<ElasticSearchOutput> {
         @Override
-        ElasticSearchOutput create(Stream stream, Configuration configuration, @Nullable String id);
+        ElasticSearchOutput create(Stream stream, Configuration configuration);
 
         @Override
         Config getConfig();

--- a/graylog2-server/src/main/java/org/graylog2/outputs/LoggingOutput.java
+++ b/graylog2-server/src/main/java/org/graylog2/outputs/LoggingOutput.java
@@ -28,7 +28,6 @@ import org.graylog2.plugin.streams.Stream;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import javax.annotation.Nullable;
 import javax.inject.Inject;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -70,7 +69,7 @@ public class LoggingOutput implements MessageOutput {
 
     public interface Factory extends MessageOutput.Factory<LoggingOutput> {
         @Override
-        LoggingOutput create(Stream stream, Configuration configuration, @Nullable String id);
+        LoggingOutput create(Stream stream, Configuration configuration);
 
         @Override
         Config getConfig();

--- a/graylog2-server/src/main/java/org/graylog2/outputs/MessageOutputFactory.java
+++ b/graylog2-server/src/main/java/org/graylog2/outputs/MessageOutputFactory.java
@@ -48,7 +48,7 @@ public class MessageOutputFactory {
 
         Preconditions.checkArgument(factory != null, "Output type is not supported: %s!", outputType);
 
-        return factory.create(stream, configuration, output.getId());
+        return factory.create(stream, configuration);
     }
 
 

--- a/graylog2-server/src/main/java/org/graylog2/plugin/outputs/MessageOutput.java
+++ b/graylog2-server/src/main/java/org/graylog2/plugin/outputs/MessageOutput.java
@@ -23,12 +23,11 @@ import org.graylog2.plugin.configuration.Configuration;
 import org.graylog2.plugin.configuration.ConfigurationRequest;
 import org.graylog2.plugin.streams.Stream;
 
-import javax.annotation.Nullable;
 import java.util.List;
 
 public interface MessageOutput extends Stoppable {
     interface Factory<T> {
-        T create(Stream stream, Configuration configuration, @Nullable String id);
+        T create(Stream stream, Configuration configuration);
         Config getConfig();
         Descriptor getDescriptor();
     }

--- a/graylog2-server/src/test/java/org/graylog2/buffers/processors/fakestreams/FakeStream.java
+++ b/graylog2-server/src/test/java/org/graylog2/buffers/processors/fakestreams/FakeStream.java
@@ -16,12 +16,21 @@
  */
 package org.graylog2.buffers.processors.fakestreams;
 
+import com.google.common.collect.Lists;
+import com.google.common.collect.Maps;
+import org.graylog2.plugin.outputs.MessageOutput;
 import org.graylog2.streams.StreamImpl;
 
-import java.util.Collections;
+import java.util.List;
 
 public class FakeStream extends StreamImpl {
+    private List<MessageOutput> outputs = Lists.newArrayList();
+
     public FakeStream(String title) {
-        super(Collections.singletonMap(StreamImpl.FIELD_TITLE, title));
+        super(Maps.<String, Object>newHashMap());
+    }
+
+    public void addOutput(MessageOutput output) {
+        outputs.add(output);
     }
 }

--- a/graylog2-server/src/test/java/org/graylog2/outputs/GelfOutputTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/outputs/GelfOutputTest.java
@@ -16,7 +16,6 @@
  */
 package org.graylog2.outputs;
 
-import com.codahale.metrics.MetricRegistry;
 import org.graylog2.gelfclient.GelfMessage;
 import org.graylog2.gelfclient.GelfMessageLevel;
 import org.graylog2.gelfclient.transport.GelfTransport;
@@ -24,11 +23,9 @@ import org.graylog2.plugin.Message;
 import org.graylog2.plugin.configuration.ConfigurationRequest;
 import org.joda.time.DateTime;
 import org.joda.time.DateTimeZone;
-import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mockito;
 
-import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.mockito.ArgumentMatchers.eq;
@@ -37,102 +34,17 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 
 public class GelfOutputTest {
-    private MetricRegistry metricRegistry;
-
-    @Before
-    public void setUp() {
-        metricRegistry = new MetricRegistry();
-    }
-
     @Test
     public void testWrite() throws Exception {
         final GelfTransport transport = mock(GelfTransport.class);
         final Message message = mock(Message.class);
         final GelfMessage gelfMessage = new GelfMessage("Test");
-        final GelfOutput gelfOutput = Mockito.spy(new GelfOutput(transport, "0123456789abcdef", null, metricRegistry));
+        final GelfOutput gelfOutput = Mockito.spy(new GelfOutput(transport));
         doReturn(gelfMessage).when(gelfOutput).toGELFMessage(message);
 
         gelfOutput.write(message);
 
         verify(transport).send(eq(gelfMessage));
-    }
-
-    @Test
-    public void testWritesMetric() throws Exception {
-        final GelfTransport transport = mock(GelfTransport.class);
-        final Message message = mock(Message.class);
-        final GelfMessage gelfMessage = new GelfMessage("Test");
-        final GelfOutput gelfOutput = Mockito.spy(new GelfOutput(transport, "0123456789abcdef", null, metricRegistry));
-        doReturn(gelfMessage).when(gelfOutput).toGELFMessage(message);
-
-        for(int i = 0; i < 10; i++) {
-            gelfOutput.write(message);
-        }
-
-        assertThat(metricRegistry.getMeters()).isNotEmpty();
-        assertThat(metricRegistry.getMeters().get("org.graylog2.outputs.GelfOutput.stream.0123456789abcdef.writes").getCount()).isEqualTo(10L);
-    }
-
-    @Test
-    public void testWritesMetricWithId() throws Exception {
-        final GelfTransport transport = mock(GelfTransport.class);
-        final Message message = mock(Message.class);
-        final GelfMessage gelfMessage = new GelfMessage("Test");
-        final GelfOutput gelfOutput = Mockito.spy(new GelfOutput(transport, "0123456789abcdef", "00deadbeefcafebabe", metricRegistry));
-        doReturn(gelfMessage).when(gelfOutput).toGELFMessage(message);
-
-        for(int i = 0; i < 10; i++) {
-            gelfOutput.write(message);
-        }
-
-        assertThat(metricRegistry.getMeters()).isNotEmpty();
-        assertThat(metricRegistry.getMeters().get("org.graylog2.outputs.GelfOutput.00deadbeefcafebabe.stream.0123456789abcdef.writes").getCount()).isEqualTo(10L);
-    }
-
-    @Test
-    public void testProcessingTimeMetric() throws Exception {
-        final GelfTransport transport = mock(GelfTransport.class);
-        final Message message = mock(Message.class);
-        final GelfMessage gelfMessage = new GelfMessage("Test");
-        final GelfOutput gelfOutput = Mockito.spy(new GelfOutput(transport, "0123456789abcdef", null, metricRegistry));
-        doReturn(gelfMessage).when(gelfOutput).toGELFMessage(message);
-
-        for(int i = 0; i < 10; i++) {
-            gelfOutput.write(message);
-        }
-
-        assertThat(metricRegistry.getTimers()).isNotEmpty();
-        assertThat(metricRegistry.getTimers().get("org.graylog2.outputs.GelfOutput.stream.0123456789abcdef.processTime").getCount()).isEqualTo(10L);
-    }
-
-    @Test
-    public void testProcessingTimeMetricWithId() throws Exception {
-        final GelfTransport transport = mock(GelfTransport.class);
-        final Message message = mock(Message.class);
-        final GelfMessage gelfMessage = new GelfMessage("Test");
-        final GelfOutput gelfOutput = Mockito.spy(new GelfOutput(transport, "0123456789abcdef", "00deadbeefcafebabe", metricRegistry));
-        doReturn(gelfMessage).when(gelfOutput).toGELFMessage(message);
-
-        for(int i = 0; i < 10; i++) {
-            gelfOutput.write(message);
-        }
-
-        assertThat(metricRegistry.getTimers()).isNotEmpty();
-        assertThat(metricRegistry.getTimers().get("org.graylog2.outputs.GelfOutput.00deadbeefcafebabe.stream.0123456789abcdef.processTime").getCount()).isEqualTo(10L);
-    }
-
-    @Test
-    public void testStopRemovesMetrics() throws Exception {
-        final GelfTransport transport = mock(GelfTransport.class);
-        final GelfOutput gelfOutput = new GelfOutput(transport, "0123456789abcdef", null, metricRegistry);
-
-        assertThat(metricRegistry.getMetrics()).containsKeys(
-                "org.graylog2.outputs.GelfOutput.stream.0123456789abcdef.writes",
-                "org.graylog2.outputs.GelfOutput.stream.0123456789abcdef.processTime");
-
-        gelfOutput.stop();
-
-        assertThat(metricRegistry.getMetrics()).isEmpty();
     }
 
     @Test
@@ -148,7 +60,7 @@ public class GelfOutputTest {
     @Test
     public void testToGELFMessageTimestamp() throws Exception {
         final GelfTransport transport = mock(GelfTransport.class);
-        final GelfOutput gelfOutput = new GelfOutput(transport, "0123456789abcdef", null, metricRegistry);
+        final GelfOutput gelfOutput = new GelfOutput(transport);
         final DateTime now = DateTime.now(DateTimeZone.UTC);
         final Message message = new Message("Test", "Source", now);
 
@@ -160,7 +72,7 @@ public class GelfOutputTest {
     @Test
     public void testToGELFMessageFullMessage() throws Exception {
         final GelfTransport transport = mock(GelfTransport.class);
-        final GelfOutput gelfOutput = new GelfOutput(transport, "0123456789abcdef", null, metricRegistry);
+        final GelfOutput gelfOutput = new GelfOutput(transport);
         final DateTime now = DateTime.now(DateTimeZone.UTC);
         final Message message = new Message("Test", "Source", now);
         message.addField(Message.FIELD_FULL_MESSAGE, "Full Message");
@@ -173,7 +85,7 @@ public class GelfOutputTest {
     @Test
     public void testToGELFMessageWithValidNumericLevel() throws Exception {
         final GelfTransport transport = mock(GelfTransport.class);
-        final GelfOutput gelfOutput = new GelfOutput(transport, "0123456789abcdef", null, metricRegistry);
+        final GelfOutput gelfOutput = new GelfOutput(transport);
         final DateTime now = DateTime.now(DateTimeZone.UTC);
         final Message message = new Message("Test", "Source", now);
         message.addField("level", 6);
@@ -186,7 +98,7 @@ public class GelfOutputTest {
     @Test
     public void testToGELFMessageWithInvalidNumericLevel() throws Exception {
         final GelfTransport transport = mock(GelfTransport.class);
-        final GelfOutput gelfOutput = new GelfOutput(transport, "0123456789abcdef", null, metricRegistry);
+        final GelfOutput gelfOutput = new GelfOutput(transport);
         final DateTime now = DateTime.now(DateTimeZone.UTC);
         final Message message = new Message("Test", "Source", now);
         message.addField("level", -1L);
@@ -199,7 +111,7 @@ public class GelfOutputTest {
     @Test
     public void testToGELFMessageWithValidStringLevel() throws Exception {
         final GelfTransport transport = mock(GelfTransport.class);
-        final GelfOutput gelfOutput = new GelfOutput(transport, "0123456789abcdef", null, metricRegistry);
+        final GelfOutput gelfOutput = new GelfOutput(transport);
         final DateTime now = DateTime.now(DateTimeZone.UTC);
         final Message message = new Message("Test", "Source", now);
         message.addField("level", "6");
@@ -212,7 +124,7 @@ public class GelfOutputTest {
     @Test
     public void testToGELFMessageWithInvalidStringLevel() throws Exception {
         final GelfTransport transport = mock(GelfTransport.class);
-        final GelfOutput gelfOutput = new GelfOutput(transport, "0123456789abcdef", null, metricRegistry);
+        final GelfOutput gelfOutput = new GelfOutput(transport);
         final DateTime now = DateTime.now(DateTimeZone.UTC);
         final Message message = new Message("Test", "Source", now);
         message.addField("level", "BOOM");
@@ -225,7 +137,7 @@ public class GelfOutputTest {
     @Test
     public void testToGELFMessageWithInvalidNumericStringLevel() throws Exception {
         final GelfTransport transport = mock(GelfTransport.class);
-        final GelfOutput gelfOutput = new GelfOutput(transport, "0123456789abcdef", null, metricRegistry);
+        final GelfOutput gelfOutput = new GelfOutput(transport);
         final DateTime now = DateTime.now(DateTimeZone.UTC);
         final Message message = new Message("Test", "Source", now);
         message.addField("level", "-1");
@@ -238,7 +150,7 @@ public class GelfOutputTest {
     @Test
     public void testToGELFMessageWithInvalidTypeLevel() throws Exception {
         final GelfTransport transport = mock(GelfTransport.class);
-        final GelfOutput gelfOutput = new GelfOutput(transport, "0123456789abcdef", null, metricRegistry);
+        final GelfOutput gelfOutput = new GelfOutput(transport);
         final DateTime now = DateTime.now(DateTimeZone.UTC);
         final Message message = new Message("Test", "Source", now);
         message.addField("level", new Object());
@@ -251,7 +163,7 @@ public class GelfOutputTest {
     @Test
     public void testToGELFMessageWithNullLevel() throws Exception {
         final GelfTransport transport = mock(GelfTransport.class);
-        final GelfOutput gelfOutput = new GelfOutput(transport, "0123456789abcdef", null, metricRegistry);
+        final GelfOutput gelfOutput = new GelfOutput(transport);
         final DateTime now = DateTime.now(DateTimeZone.UTC);
         final Message message = new Message("Test", "Source", now);
         message.addField("level", null);


### PR DESCRIPTION
This reverts commit ff1a9f307a13f73cffaf2d37708417b6c114d51a.

It broke backwards compatibility with 3rd party output plugins.

Fixes #3851