### PR TITLE
Unbreak elasticsearch duration config settings

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/bindings/providers/JestClientProvider.java
+++ b/graylog2-server/src/main/java/org/graylog2/bindings/providers/JestClientProvider.java
@@ -16,6 +16,7 @@
  */
 package org.graylog2.bindings.providers;
 
+import com.github.joschi.jadconfig.util.Duration;
 import com.google.common.base.Splitter;
 import com.google.common.base.Strings;
 import com.google.gson.Gson;
@@ -34,7 +35,6 @@ import javax.inject.Named;
 import javax.inject.Provider;
 import javax.inject.Singleton;
 import java.net.URI;
-import java.time.Duration;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
@@ -87,15 +87,15 @@ public class JestClientProvider implements Provider<JestClient> {
         final HttpClientConfig.Builder httpClientConfigBuilder = new HttpClientConfig
                 .Builder(hosts)
                 .credentialsProvider(credentialsProvider)
-                .connTimeout(Math.toIntExact(elasticsearchConnectTimeout.toMillis()))
-                .readTimeout(Math.toIntExact(elasticsearchSocketTimeout.toMillis()))
-                .maxConnectionIdleTime(elasticsearchIdleTimeout.getSeconds(), TimeUnit.SECONDS)
+                .connTimeout(Math.toIntExact(elasticsearchConnectTimeout.toMilliseconds()))
+                .readTimeout(Math.toIntExact(elasticsearchSocketTimeout.toMilliseconds()))
+                .maxConnectionIdleTime(elasticsearchIdleTimeout.toSeconds(), TimeUnit.SECONDS)
                 .maxTotalConnection(elasticsearchMaxTotalConnections)
                 .defaultMaxTotalConnectionPerRoute(elasticsearchMaxTotalConnectionsPerRoute)
                 .multiThreaded(true)
                 .discoveryEnabled(discoveryEnabled)
                 .discoveryFilter(discoveryFilter)
-                .discoveryFrequency(discoveryFrequency.getSeconds(), TimeUnit.SECONDS)
+                .discoveryFrequency(discoveryFrequency.toSeconds(), TimeUnit.SECONDS)
                 .preemptiveAuthTargetHosts(preemptiveAuthHosts)
                 .gson(gson);
 

--- a/graylog2-server/src/main/java/org/graylog2/configuration/ElasticsearchClientConfiguration.java
+++ b/graylog2-server/src/main/java/org/graylog2/configuration/ElasticsearchClientConfiguration.java
@@ -17,13 +17,13 @@
 package org.graylog2.configuration;
 
 import com.github.joschi.jadconfig.Parameter;
+import com.github.joschi.jadconfig.util.Duration;
 import com.github.joschi.jadconfig.validators.PositiveIntegerValidator;
 import org.graylog2.configuration.converters.URIListConverter;
 import org.graylog2.configuration.validators.ListOfURIsWithHostAndSchemeValidator;
 import org.graylog2.configuration.validators.NonEmptyListValidator;
 
 import java.net.URI;
-import java.time.Duration;
 import java.util.Collections;
 import java.util.List;
 
@@ -32,13 +32,13 @@ public class ElasticsearchClientConfiguration {
     private List<URI> elasticsearchHosts = Collections.singletonList(URI.create("http://127.0.0.1:9200"));
 
     @Parameter(value = "elasticsearch_connect_timeout")
-    private Duration elasticsearchConnectTimeout = Duration.ofSeconds(10);
+    private Duration elasticsearchConnectTimeout = Duration.seconds(10);
 
     @Parameter(value = "elasticsearch_socket_timeout", validators = { PositiveIntegerValidator.class })
-    private Duration elasticsearchSocketTimeout = Duration.ofSeconds(60);
+    private Duration elasticsearchSocketTimeout = Duration.seconds(60);
 
     @Parameter(value = "elasticsearch_idle_timeout")
-    private Duration elasticsearchIdleTimeout = Duration.ofSeconds(-1L);
+    private Duration elasticsearchIdleTimeout = Duration.seconds(-1L);
 
     @Parameter(value = "elasticsearch_max_total_connections", validators = { PositiveIntegerValidator.class })
     private int elasticsearchMaxTotalConnections = 20;
@@ -53,5 +53,5 @@ public class ElasticsearchClientConfiguration {
     private String discoveryFilter = null;
 
     @Parameter(value = "elasticsearch_discovery_frequency")
-    private Duration discoveryFrequency = Duration.ofSeconds(30L);
+    private Duration discoveryFrequency = Duration.seconds(30L);
 }

--- a/graylog2-server/src/test/java/org/graylog2/indexer/counts/JestClientRule.java
+++ b/graylog2-server/src/test/java/org/graylog2/indexer/counts/JestClientRule.java
@@ -16,6 +16,7 @@
  */
 package org.graylog2.indexer.counts;
 
+import com.github.joschi.jadconfig.util.Duration;
 import com.google.common.collect.ImmutableList;
 import com.google.gson.Gson;
 import io.searchbox.client.JestClient;
@@ -24,8 +25,6 @@ import org.graylog2.bindings.providers.JestClientProvider;
 import org.junit.rules.ExternalResource;
 
 import java.net.URI;
-import java.time.Duration;
-import java.time.temporal.ChronoUnit;
 
 public class JestClientRule extends ExternalResource {
     private final JestClientProvider jestClientProvider;
@@ -35,14 +34,14 @@ public class JestClientRule extends ExternalResource {
         final URI esUri = URI.create("http://localhost:" + esHttpPort);
         this.jestClientProvider = new JestClientProvider(
             ImmutableList.of(esUri),
-            Duration.ofSeconds(10),
-            Duration.ofSeconds(60),
-            Duration.of(60, ChronoUnit.SECONDS),
+            Duration.seconds(10),
+            Duration.seconds(60),
+            Duration.seconds(60),
             20,
             2,
             false,
             null,
-            Duration.ofSeconds(30),
+            Duration.seconds(30),
             new Gson()
         );
     }


### PR DESCRIPTION
Use jadconfig.util.Duration instead of java.time.Duration like we do for the other configuration durations as well.

Fixes the following config file settings:

- `elasticsearch_connect_timeout`
- `elasticsearch_socket_timeout`
- `elasticsearch_idle_timeout`
- `elasticsearch_discovery_frequency`