### PR TITLE
Introducing config option that enables compression for indexer requests.

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/bindings/providers/JestClientProvider.java
+++ b/graylog2-server/src/main/java/org/graylog2/bindings/providers/JestClientProvider.java
@@ -57,6 +57,7 @@ public class JestClientProvider implements Provider<JestClient> {
                               @Named("elasticsearch_discovery_enabled") boolean discoveryEnabled,
                               @Named("elasticsearch_discovery_filter") @Nullable String discoveryFilter,
                               @Named("elasticsearch_discovery_frequency") Duration discoveryFrequency,
+                              @Named("elasticsearch_compression_enabled") boolean compressionEnabled,
                               Gson gson) {
         this.factory = new JestClientFactory();
         this.credentialsProvider = new BasicCredentialsProvider();
@@ -97,6 +98,7 @@ public class JestClientProvider implements Provider<JestClient> {
                 .discoveryFilter(discoveryFilter)
                 .discoveryFrequency(discoveryFrequency.toSeconds(), TimeUnit.SECONDS)
                 .preemptiveAuthTargetHosts(preemptiveAuthHosts)
+                .requestCompressionEnabled(compressionEnabled)
                 .gson(gson);
 
         factory.setHttpClientConfig(httpClientConfigBuilder.build());

--- a/graylog2-server/src/main/java/org/graylog2/configuration/ElasticsearchClientConfiguration.java
+++ b/graylog2-server/src/main/java/org/graylog2/configuration/ElasticsearchClientConfiguration.java
@@ -54,4 +54,7 @@ public class ElasticsearchClientConfiguration {
 
     @Parameter(value = "elasticsearch_discovery_frequency")
     private Duration discoveryFrequency = Duration.seconds(30L);
+
+    @Parameter(value = "elasticsearch_compression_enabled")
+    private boolean compressionEnabled = false;
 }

--- a/graylog2-server/src/test/java/org/graylog2/indexer/counts/JestClientRule.java
+++ b/graylog2-server/src/test/java/org/graylog2/indexer/counts/JestClientRule.java
@@ -42,6 +42,7 @@ public class JestClientRule extends ExternalResource {
             false,
             null,
             Duration.seconds(30),
+            false,
             new Gson()
         );
     }

--- a/misc/graylog.conf
+++ b/misc/graylog.conf
@@ -223,6 +223,11 @@ rest_listen_uri = http://127.0.0.1:9000/api/
 # Default: 30s
 # elasticsearch_discovery_frequency = 30s
 
+# Enable payload compression for Elasticsearch requests.
+#
+# Default: false
+#elasticsearch_compression_enabled = true
+
 # Graylog will use multiple indices to store documents in. You can configured the strategy it uses to determine
 # when to rotate the currently active write index.
 # It supports multiple rotation strategies:


### PR DESCRIPTION
## Description
## Motivation and Context

This change introduces the new boolean configuration option `elasticsearch_compression_enabled`, which allows the user to enable/disable the compression of requests going to the indexer (Elasticsearch) nodes. This helps to significantly reduce the traffic sent over the wire, especially for bulk indexing requests.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.