### PR TITLE
Fix and centralize lookup adapter/cache error handling

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/lookup/adapters/CSVFileDataAdapter.java
+++ b/graylog2-server/src/main/java/org/graylog2/lookup/adapters/CSVFileDataAdapter.java
@@ -79,18 +79,13 @@ public class CSVFileDataAdapter extends LookupDataAdapter {
         if (isNullOrEmpty(config.path())) {
             throw new IllegalStateException("File path needs to be set");
         }
-
-        try {
-            // Set file info before parsing the data for the first time
-            fileInfo = FileInfo.forPath(Paths.get(config.path()));
-            lookupRef.set(parseCSVFile());
-
-        } catch (Exception e) {
-            setError(e);
-        }
         if (config.checkInterval() < 1) {
             throw new IllegalStateException("Check interval setting cannot be smaller than 1");
         }
+
+        // Set file info before parsing the data for the first time
+        fileInfo = FileInfo.forPath(Paths.get(config.path()));
+        lookupRef.set(parseCSVFile());
     }
 
     @Override

--- a/graylog2-server/src/main/java/org/graylog2/lookup/adapters/CSVFileDataAdapter.java
+++ b/graylog2-server/src/main/java/org/graylog2/lookup/adapters/CSVFileDataAdapter.java
@@ -101,9 +101,8 @@ public class CSVFileDataAdapter extends LookupDataAdapter {
     @Override
     protected void doRefresh(LookupCachePurge cachePurge) throws Exception {
         try {
-            clearError();
             final FileInfo.Change fileChanged = fileInfo.checkForChange();
-            if (!fileChanged.isChanged()) {
+            if (!fileChanged.isChanged() && !getError().isPresent()) {
                 // Nothing to do, file did not change
                 return;
             }
@@ -112,8 +111,9 @@ public class CSVFileDataAdapter extends LookupDataAdapter {
             lookupRef.set(parseCSVFile());
             cachePurge.purgeAll();
             fileInfo = fileChanged.fileInfo();
+            clearError();
         } catch (IOException e) {
-            LOG.error("Couldn't check CSV file {} for updates", config.path(), e);
+            LOG.error("Couldn't check data adapter <{}> CSV file {} for updates: {} {}", name(), config.path(), e.getClass().getCanonicalName(), e.getMessage());
             setError(e);
         }
     }

--- a/graylog2-server/src/main/java/org/graylog2/plugin/lookup/LookupCache.java
+++ b/graylog2-server/src/main/java/org/graylog2/plugin/lookup/LookupCache.java
@@ -27,6 +27,8 @@ import java.util.Optional;
 import java.util.concurrent.Callable;
 import java.util.concurrent.atomic.AtomicReference;
 
+import static org.graylog2.utilities.ObjectUtils.objectId;
+
 public abstract class LookupCache extends AbstractIdleService {
     private static final Logger LOG = LoggerFactory.getLogger(LookupCache.class);
     private String id;
@@ -46,14 +48,25 @@ public abstract class LookupCache extends AbstractIdleService {
 
     @Override
     protected void startUp() throws Exception {
-        doStart();
+        // Make sure startUp() never throws an error - we handle errors internally
+        try {
+            doStart();
+        } catch (Exception e) {
+            LOG.error("Couldn't start cache <{}/{}/@{}>", name(), id(), objectId(this), e);
+            setError(e);
+        }
     }
 
     protected abstract void doStart() throws Exception;
 
     @Override
     protected void shutDown() throws Exception {
-        doStop();
+        // Make sure shutDown() never throws an error - we handle errors internally
+        try {
+            doStop();
+        } catch (Exception e) {
+            LOG.error("Couldn't stop cache <{}/{}/@{}>", name(), id(), objectId(this), e);
+        }
     }
 
     protected abstract void doStop() throws Exception;

--- a/graylog2-server/src/main/java/org/graylog2/plugin/lookup/LookupDataAdapter.java
+++ b/graylog2-server/src/main/java/org/graylog2/plugin/lookup/LookupDataAdapter.java
@@ -27,6 +27,7 @@ import java.util.Optional;
 import java.util.concurrent.atomic.AtomicReference;
 
 import static com.google.common.base.Preconditions.checkState;
+import static org.graylog2.utilities.ObjectUtils.objectId;
 
 public abstract class LookupDataAdapter extends AbstractIdleService {
     private static final Logger LOG = LoggerFactory.getLogger(LookupDataAdapter.class);
@@ -46,14 +47,25 @@ public abstract class LookupDataAdapter extends AbstractIdleService {
 
     @Override
     protected void startUp() throws Exception {
-        doStart();
+        // Make sure startUp() never throws an error - we handle errors internally
+        try {
+            doStart();
+        } catch (Exception e) {
+            LOG.error("Couldn't start data adapter <{}/{}/@{}>", name(), id(), objectId(this), e);
+            setError(e);
+        }
     }
 
     protected abstract void doStart() throws Exception;
 
     @Override
     protected void shutDown() throws Exception {
-        doStop();
+        // Make sure shutDown() never throws an error - we handle errors internally
+        try {
+            doStop();
+        } catch (Exception e) {
+            LOG.error("Couldn't stop data adapter <{}/{}/@{}>", name(), id(), objectId(this), e);
+        }
     }
 
     protected abstract void doStop() throws Exception;
@@ -65,10 +77,11 @@ public abstract class LookupDataAdapter extends AbstractIdleService {
     public abstract Duration refreshInterval();
 
     public void refresh(LookupCachePurge cachePurge) {
+        // Make sure refresh() never throws an error - we handle errors internally
         try {
             doRefresh(cachePurge);
         } catch (Exception e) {
-            LOG.error("Couldn't refresh data adapter", e);
+            LOG.error("Couldn't refresh data adapter <{}/{}/@{}>", name(), id(), objectId(this), e);
         }
     }
 

--- a/graylog2-web-interface/src/components/lookup-tables/CacheForm.jsx
+++ b/graylog2-web-interface/src/components/lookup-tables/CacheForm.jsx
@@ -49,8 +49,10 @@ const CacheForm = React.createClass({
   },
 
   componentDidMount() {
-    // Validate when mounted to immediately show errors for invalid objects
-    this._validate(this.props.cache);
+    if (!this.props.create) {
+      // Validate when mounted to immediately show errors for invalid objects
+      this._validate(this.props.cache);
+    }
   },
 
   _initialState(c) {

--- a/graylog2-web-interface/src/components/lookup-tables/CacheForm.jsx
+++ b/graylog2-web-interface/src/components/lookup-tables/CacheForm.jsx
@@ -48,6 +48,11 @@ const CacheForm = React.createClass({
     this.setState(this._initialState(nextProps.cache));
   },
 
+  componentDidMount() {
+    // Validate when mounted to immediately show errors for invalid objects
+    this._validate(this.props.cache);
+  },
+
   _initialState(c) {
     const cache = ObjectUtils.clone(c);
 

--- a/graylog2-web-interface/src/components/lookup-tables/DataAdapterForm.jsx
+++ b/graylog2-web-interface/src/components/lookup-tables/DataAdapterForm.jsx
@@ -51,8 +51,10 @@ const DataAdapterForm = React.createClass({
   },
 
   componentDidMount() {
-    // Validate when mounted to immediately show errors for invalid objects
-    this._validate(this.props.dataAdapter);
+    if (!this.props.create) {
+      // Validate when mounted to immediately show errors for invalid objects
+      this._validate(this.props.dataAdapter);
+    }
   },
 
   _initialState(dataAdapter) {

--- a/graylog2-web-interface/src/components/lookup-tables/DataAdapterForm.jsx
+++ b/graylog2-web-interface/src/components/lookup-tables/DataAdapterForm.jsx
@@ -50,6 +50,11 @@ const DataAdapterForm = React.createClass({
     this.setState(this._initialState(nextProps.dataAdapter));
   },
 
+  componentDidMount() {
+    // Validate when mounted to immediately show errors for invalid objects
+    this._validate(this.props.dataAdapter);
+  },
+
   _initialState(dataAdapter) {
     const adapter = ObjectUtils.clone(dataAdapter);
 

--- a/graylog2-web-interface/src/components/lookup-tables/adapters/HTTPJSONPathAdapterFieldSet.jsx
+++ b/graylog2-web-interface/src/components/lookup-tables/adapters/HTTPJSONPathAdapterFieldSet.jsx
@@ -8,9 +8,7 @@ const HTTPJSONPathAdapterFieldSet = React.createClass({
     // eslint-disable-next-line react/no-unused-prop-types
     updateConfig: PropTypes.func.isRequired,
     handleFormEvent: PropTypes.func.isRequired,
-    // eslint-disable-next-line react/no-unused-prop-types
     validationState: PropTypes.func.isRequired,
-    // eslint-disable-next-line react/no-unused-prop-types
     validationMessage: PropTypes.func.isRequired,
   },
 
@@ -25,7 +23,8 @@ const HTTPJSONPathAdapterFieldSet = React.createClass({
              autoFocus
              required
              onChange={this.props.handleFormEvent}
-             help="The URL for the lookup. (this is a template - see documentation)"
+             help={this.props.validationMessage('url', 'The URL for the lookup. (this is a template - see documentation)')}
+             bsStyle={this.props.validationState('url')}
              value={config.url}
              labelClassName="col-sm-3"
              wrapperClassName="col-sm-9" />
@@ -35,7 +34,8 @@ const HTTPJSONPathAdapterFieldSet = React.createClass({
              label="Single value JSONPath"
              required
              onChange={this.props.handleFormEvent}
-             help="The JSONPath string to get the single value from the response."
+             help={this.props.validationMessage('single_value_jsonpath', 'The JSONPath string to get the single value from the response.')}
+             bsStyle={this.props.validationState('single_value_jsonpath')}
              value={config.single_value_jsonpath}
              labelClassName="col-sm-3"
              wrapperClassName="col-sm-9" />
@@ -44,7 +44,8 @@ const HTTPJSONPathAdapterFieldSet = React.createClass({
              name="multi_value_jsonpath"
              label="Multi value JSONPath"
              onChange={this.props.handleFormEvent}
-             help={<span>The JSONPath string to get the multi value from the response. Needs to return a list or map. <strong>(optional)</strong></span>}
+             help={this.props.validationMessage('multi_value_jsonpath', 'The JSONPath string to get the multi value from the response. Needs to return a list or map. (optional)')}
+             bsStyle={this.props.validationState('multi_value_jsonpath')}
              value={config.multi_value_jsonpath}
              labelClassName="col-sm-3"
              wrapperClassName="col-sm-9" />


### PR DESCRIPTION
- During adapter refresh, only clear the error once the refresh is done
- Force refresh when an error is set, even when the file info didn't change
- Make sure that `#startUp()` and `#shutDown()` never throw an error
- Run validation when opening adapter/cache form to show problems immediately