### PR TITLE
Fix preemptive authentication in JestClientProvider

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/bindings/providers/JestClientProvider.java
+++ b/graylog2-server/src/main/java/org/graylog2/bindings/providers/JestClientProvider.java
@@ -77,7 +77,7 @@ public class JestClientProvider implements Provider<JestClient> {
                         );
 
                         if (!Strings.isNullOrEmpty(username) || !Strings.isNullOrEmpty(password)) {
-                            preemptiveAuthHosts.add(HttpHost.create(hostUri.toString()));
+                            preemptiveAuthHosts.add(new HttpHost(hostUri.getHost(), hostUri.getPort(), hostUri.getScheme()));
                         }
                     }
                 }

--- a/graylog2-server/src/test/java/org/graylog2/bindings/providers/JestClientProviderTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/bindings/providers/JestClientProviderTest.java
@@ -1,0 +1,90 @@
+/**
+ * This file is part of Graylog.
+ *
+ * Graylog is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.graylog2.bindings.providers;
+
+import com.github.joschi.jadconfig.util.Duration;
+import com.google.gson.GsonBuilder;
+import io.searchbox.client.JestClient;
+import io.searchbox.client.http.JestHttpClient;
+import org.junit.Test;
+
+import java.net.URI;
+import java.util.Collections;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class JestClientProviderTest {
+    @Test
+    public void getReturnsJestHttpClient() {
+        final JestClientProvider provider = new JestClientProvider(
+                Collections.singletonList(URI.create("http://127.0.0.1:9200")),
+                Duration.seconds(5L),
+                Duration.seconds(5L),
+                Duration.seconds(5L),
+                8,
+                2,
+                false,
+                null,
+                Duration.seconds(5L),
+                false,
+                new GsonBuilder().create()
+        );
+
+        final JestClient jestClient = provider.get();
+        assertThat(jestClient).isInstanceOf(JestHttpClient.class);
+    }
+
+    @Test
+    public void preemptiveAuthWithoutTrailingSlash() {
+        final JestClientProvider provider = new JestClientProvider(
+                Collections.singletonList(URI.create("http://elastic:changeme@127.0.0.1:9200")),
+                Duration.seconds(5L),
+                Duration.seconds(5L),
+                Duration.seconds(5L),
+                8,
+                2,
+                false,
+                null,
+                Duration.seconds(5L),
+                false,
+                new GsonBuilder().create()
+        );
+
+        final JestClient jestClient = provider.get();
+        assertThat(jestClient).isInstanceOf(JestHttpClient.class);
+    }
+
+    @Test
+    public void preemptiveAuthWithTrailingSlash() {
+        final JestClientProvider provider = new JestClientProvider(
+                Collections.singletonList(URI.create("http://elastic:changeme@127.0.0.1:9200/")),
+                Duration.seconds(5L),
+                Duration.seconds(5L),
+                Duration.seconds(5L),
+                8,
+                2,
+                false,
+                null,
+                Duration.seconds(5L),
+                false,
+                new GsonBuilder().create()
+        );
+
+        final JestClient jestClient = provider.get();
+        assertThat(jestClient).isInstanceOf(JestHttpClient.class);
+    }
+}


### PR DESCRIPTION
`HttpHost.create(String)` can't handle trailing slashes in URIs and throws an `IllegalArgumentException` if it encounters anything after the port in a
URI, such as in "http://user:pass@localhost:9200/".