### PR TITLE
Add support for updating extractors in InputService

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/inputs/InputService.java
+++ b/graylog2-server/src/main/java/org/graylog2/inputs/InputService.java
@@ -93,6 +93,8 @@ public interface InputService extends PersistedService {
 
     Extractor getExtractor(Input input, String extractorId) throws NotFoundException;
 
+    void updateExtractor(Input input, Extractor extractor) throws ValidationException;
+
     void removeExtractor(Input input, String extractorId);
 
     void removeStaticField(Input input, String key);

--- a/graylog2-server/src/main/java/org/graylog2/inputs/InputServiceImpl.java
+++ b/graylog2-server/src/main/java/org/graylog2/inputs/InputServiceImpl.java
@@ -201,6 +201,13 @@ public class InputServiceImpl extends PersistedServiceImpl implements InputServi
     }
 
     @Override
+    public void updateExtractor(Input input, Extractor extractor) throws ValidationException {
+        removeEmbedded(input, InputImpl.EMBEDDED_EXTRACTORS, extractor.getId());
+        embed(input, InputImpl.EMBEDDED_EXTRACTORS, extractor);
+        publishChange(InputUpdated.create(input.getId()));
+    }
+
+    @Override
     public void addStaticField(Input input, final String key, final String value) throws ValidationException {
         final EmbeddedPersistable obj = new EmbeddedPersistable() {
             @Override

--- a/graylog2-server/src/main/java/org/graylog2/inputs/InputServiceImpl.java
+++ b/graylog2-server/src/main/java/org/graylog2/inputs/InputServiceImpl.java
@@ -34,6 +34,9 @@ import org.graylog2.database.PersistedServiceImpl;
 import org.graylog2.events.ClusterEventBus;
 import org.graylog2.inputs.converters.ConverterFactory;
 import org.graylog2.inputs.extractors.ExtractorFactory;
+import org.graylog2.inputs.extractors.events.ExtractorCreated;
+import org.graylog2.inputs.extractors.events.ExtractorDeleted;
+import org.graylog2.inputs.extractors.events.ExtractorUpdated;
 import org.graylog2.plugin.configuration.Configuration;
 import org.graylog2.plugin.database.EmbeddedPersistable;
 import org.graylog2.plugin.database.Persisted;
@@ -197,14 +200,14 @@ public class InputServiceImpl extends PersistedServiceImpl implements InputServi
     @Override
     public void addExtractor(Input input, Extractor extractor) throws ValidationException {
         embed(input, InputImpl.EMBEDDED_EXTRACTORS, extractor);
-        publishChange(InputUpdated.create(input.getId()));
+        publishChange(ExtractorCreated.create(input.getId(), extractor.getId()));
     }
 
     @Override
     public void updateExtractor(Input input, Extractor extractor) throws ValidationException {
         removeEmbedded(input, InputImpl.EMBEDDED_EXTRACTORS, extractor.getId());
         embed(input, InputImpl.EMBEDDED_EXTRACTORS, extractor);
-        publishChange(InputUpdated.create(input.getId()));
+        publishChange(ExtractorUpdated.create(input.getId(), extractor.getId()));
     }
 
     @Override
@@ -331,7 +334,7 @@ public class InputServiceImpl extends PersistedServiceImpl implements InputServi
     @Override
     public void removeExtractor(Input input, String extractorId) {
         removeEmbedded(input, InputImpl.EMBEDDED_EXTRACTORS, extractorId);
-        publishChange(InputUpdated.create(input.getId()));
+        publishChange(ExtractorDeleted.create(input.getId(), extractorId));
     }
 
     @Override

--- a/graylog2-server/src/main/java/org/graylog2/inputs/extractors/events/ExtractorCreated.java
+++ b/graylog2-server/src/main/java/org/graylog2/inputs/extractors/events/ExtractorCreated.java
@@ -1,0 +1,40 @@
+/**
+ * This file is part of Graylog.
+ *
+ * Graylog is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.graylog2.inputs.extractors.events;
+
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.auto.value.AutoValue;
+import org.graylog.autovalue.WithBeanGetter;
+
+@AutoValue
+@WithBeanGetter
+@JsonAutoDetect
+public abstract class ExtractorCreated {
+    @JsonProperty("input_id")
+    public abstract String inputId();
+
+    @JsonProperty("extractor_id")
+    public abstract String extractorId();
+
+    @JsonCreator
+    public static ExtractorCreated create(@JsonProperty("input_id") String inputId,
+                                          @JsonProperty("extractor_id") String extractorId) {
+        return new AutoValue_ExtractorCreated(inputId, extractorId);
+    }
+}

--- a/graylog2-server/src/main/java/org/graylog2/inputs/extractors/events/ExtractorDeleted.java
+++ b/graylog2-server/src/main/java/org/graylog2/inputs/extractors/events/ExtractorDeleted.java
@@ -1,0 +1,40 @@
+/**
+ * This file is part of Graylog.
+ *
+ * Graylog is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.graylog2.inputs.extractors.events;
+
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.auto.value.AutoValue;
+import org.graylog.autovalue.WithBeanGetter;
+
+@AutoValue
+@WithBeanGetter
+@JsonAutoDetect
+public abstract class ExtractorDeleted {
+    @JsonProperty("input_id")
+    public abstract String inputId();
+
+    @JsonProperty("extractor_id")
+    public abstract String extractorId();
+
+    @JsonCreator
+    public static ExtractorDeleted create(@JsonProperty("input_id") String inputId,
+                                          @JsonProperty("extractor_id") String extractorId) {
+        return new AutoValue_ExtractorDeleted(inputId, extractorId);
+    }
+}

--- a/graylog2-server/src/main/java/org/graylog2/inputs/extractors/events/ExtractorUpdated.java
+++ b/graylog2-server/src/main/java/org/graylog2/inputs/extractors/events/ExtractorUpdated.java
@@ -1,0 +1,40 @@
+/**
+ * This file is part of Graylog.
+ *
+ * Graylog is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.graylog2.inputs.extractors.events;
+
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.auto.value.AutoValue;
+import org.graylog.autovalue.WithBeanGetter;
+
+@AutoValue
+@WithBeanGetter
+@JsonAutoDetect
+public abstract class ExtractorUpdated {
+    @JsonProperty("input_id")
+    public abstract String inputId();
+
+    @JsonProperty("extractor_id")
+    public abstract String extractorId();
+
+    @JsonCreator
+    public static ExtractorUpdated create(@JsonProperty("input_id") String inputId,
+                                          @JsonProperty("extractor_id") String extractorId) {
+        return new AutoValue_ExtractorUpdated(inputId, extractorId);
+    }
+}

--- a/graylog2-server/src/main/java/org/graylog2/rest/resources/system/inputs/ExtractorsResource.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/resources/system/inputs/ExtractorsResource.java
@@ -169,9 +169,8 @@ public class ExtractorsResource extends RestResource {
         final Extractor originalExtractor = inputService.getExtractor(mongoInput, extractorId);
         final Extractor extractor = buildExtractorFromRequest(cer, originalExtractor.getId());
 
-        inputService.removeExtractor(mongoInput, originalExtractor.getId());
         try {
-            inputService.addExtractor(mongoInput, extractor);
+            inputService.updateExtractor(mongoInput, extractor);
         } catch (ValidationException e) {
             LOG.error("Extractor persist validation failed.", e);
             throw new BadRequestException(e);


### PR DESCRIPTION
Instead of calling `InputService#deleteExtractor()` followed by `InputService#addExtractor()`,
which also emits the `InputUpdated` event twice, the `InputService#updateExtractor()` method
replaces the extractor in the  embedded document in the "inputs" collection in MongoDB and
only emits the `InputUpdated` event once, which hopefully resolves the race condition described
in #3903.

Fixes #3903