### PR TITLE
Fix remove link placement on tag-remove elements

### DIFF
--- a/graylog2-web-interface/public/stylesheets/graylog2.less
+++ b/graylog2-web-interface/public/stylesheets/graylog2.less
@@ -2661,7 +2661,7 @@ ul.pill-list > li {
   color: #333;
   cursor: pointer;
   margin-left: 5px;
-  vertical-align: middle;
+  vertical-align: text-bottom;
 }
 
 .tag-remove:before,

--- a/graylog2-web-interface/public/stylesheets/graylog2.less
+++ b/graylog2-web-interface/public/stylesheets/graylog2.less
@@ -2652,8 +2652,6 @@ ul.pill-list > li {
   color: #333;
   background-color: #E3E5E5;
   padding: 6px 12px;
-  line-height: 1.42857143;
-  vertical-align: middle;
 }
 
 .tag-remove,
@@ -2661,7 +2659,6 @@ ul.pill-list > li {
   color: #333;
   cursor: pointer;
   margin-left: 5px;
-  vertical-align: text-bottom;
 }
 
 .tag-remove:before,


### PR DESCRIPTION
Just a small fix of something I saw in the new filter used in the collector plugin.