### PR TITLE
Add lookup table/cache/adapter permissions

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/rest/resources/system/lookup/LookupTableResource.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/resources/system/lookup/LookupTableResource.java
@@ -284,10 +284,11 @@ public class LookupTableResource extends RestResource {
     }
 
     @PUT
-    @Path("tables")
+    @Path("tables/{idOrName}")
     @AuditEvent(type = AuditEventTypes.LOOKUP_TABLE_UPDATE)
     @ApiOperation(value = "Update the given lookup table")
-    public LookupTableApi updateTable(@Valid @ApiParam LookupTableApi toUpdate) {
+    public LookupTableApi updateTable(@ApiParam(name = "idOrName") @PathParam("idOrName") @NotEmpty String idOrName,
+                                      @Valid @ApiParam LookupTableApi toUpdate) {
         LookupTableDto saved = dbTableService.save(toUpdate.toDto());
         clusterBus.post(LookupTablesUpdated.create(saved));
 
@@ -483,10 +484,11 @@ public class LookupTableResource extends RestResource {
     }
 
     @PUT
-    @Path("adapters")
+    @Path("adapters/{idOrName}")
     @AuditEvent(type = AuditEventTypes.LOOKUP_ADAPTER_UPDATE)
     @ApiOperation(value = "Update the given data adapter settings")
-    public DataAdapterApi updateAdapter(@Valid @ApiParam DataAdapterApi toUpdate) {
+    public DataAdapterApi updateAdapter(@ApiParam(name = "idOrName") @PathParam("idOrName") @NotEmpty String idOrName,
+                                        @Valid @ApiParam DataAdapterApi toUpdate) {
         DataAdapterDto saved = dbDataAdapterService.save(toUpdate.toDto());
         // the linked lookup tables will be updated by the service
         clusterBus.post(DataAdaptersUpdated.create(saved.id()));
@@ -630,10 +632,11 @@ public class LookupTableResource extends RestResource {
     }
 
     @PUT
-    @Path("caches")
+    @Path("caches/{idOrName}")
     @AuditEvent(type = AuditEventTypes.LOOKUP_CACHE_UPDATE)
     @ApiOperation(value = "Update the given cache settings")
-    public CacheApi updateCache(@ApiParam CacheApi toUpdate) {
+    public CacheApi updateCache(@ApiParam(name = "idOrName") @PathParam("idOrName") @NotEmpty String idOrName,
+                                @ApiParam CacheApi toUpdate) {
         CacheDto saved = dbCacheService.save(toUpdate.toDto());
         clusterBus.post(CachesUpdated.create(saved.id()));
         return CacheApi.fromDto(saved);

--- a/graylog2-server/src/main/java/org/graylog2/shared/security/RestPermissions.java
+++ b/graylog2-server/src/main/java/org/graylog2/shared/security/RestPermissions.java
@@ -77,6 +77,10 @@ public class RestPermissions implements PluginPermissions {
     public static final String LDAP_EDIT = "ldap:edit";
     public static final String LDAPGROUPS_EDIT = "ldapgroups:edit";
     public static final String LDAPGROUPS_READ = "ldapgroups:read";
+    public static final String LOOKUP_TABLES_CREATE = "lookuptables:create";
+    public static final String LOOKUP_TABLES_DELETE = "lookuptables:delete";
+    public static final String LOOKUP_TABLES_EDIT = "lookuptables:edit";
+    public static final String LOOKUP_TABLES_READ = "lookuptables:read";
     public static final String LOGGERS_EDIT = "loggers:edit";
     public static final String LOGGERS_EDITSUBSYSTEM = "loggers:editsubsystem";
     public static final String LOGGERS_READ = "loggers:read";
@@ -178,6 +182,10 @@ public class RestPermissions implements PluginPermissions {
         .add(create(LDAP_EDIT, ""))
         .add(create(LDAPGROUPS_EDIT, ""))
         .add(create(LDAPGROUPS_READ, ""))
+        .add(create(LOOKUP_TABLES_CREATE, ""))
+        .add(create(LOOKUP_TABLES_DELETE, ""))
+        .add(create(LOOKUP_TABLES_EDIT, ""))
+        .add(create(LOOKUP_TABLES_READ, ""))
         .add(create(LOGGERS_EDIT, ""))
         .add(create(LOGGERS_EDITSUBSYSTEM, ""))
         .add(create(LOGGERS_READ, ""))

--- a/graylog2-web-interface/src/stores/lookup-tables/LookupTableCachesStore.js
+++ b/graylog2-web-interface/src/stores/lookup-tables/LookupTableCachesStore.js
@@ -84,7 +84,7 @@ const LookupTableCachesStore = Reflux.createStore({
   },
 
   update(cache) {
-    const url = this._url('caches');
+    const url = this._url(`caches/${cache.id}`);
     const promise = fetch('PUT', url, cache);
 
     promise.then((response) => {

--- a/graylog2-web-interface/src/stores/lookup-tables/LookupTableDataAdaptersStore.js
+++ b/graylog2-web-interface/src/stores/lookup-tables/LookupTableDataAdaptersStore.js
@@ -84,7 +84,7 @@ const LookupTableDataAdaptersStore = Reflux.createStore({
   },
 
   update(dataAdapter) {
-    const url = this._url('adapters');
+    const url = this._url(`adapters/${dataAdapter.id}`);
     const promise = fetch('PUT', url, dataAdapter);
 
     promise.then((response) => {

--- a/graylog2-web-interface/src/stores/lookup-tables/LookupTablesStore.js
+++ b/graylog2-web-interface/src/stores/lookup-tables/LookupTablesStore.js
@@ -99,7 +99,7 @@ const LookupTablesStore = Reflux.createStore({
   },
 
   update(table) {
-    const url = this._url('tables');
+    const url = this._url(`tables/${table.id}`);
     const promise = fetch('PUT', url, table);
 
     promise.catch(this._errorHandler('Updating lookup table failed', `Could not update lookup table "${table.name}"`));


### PR DESCRIPTION
This adds custom permissions to lookup tables, caches and adapters. We decided to only use `lookuptables` for now, instead of separate permissions for tables, caches and adapters.