### PR TITLE
Switch RoleResponse to java.util.Optional to fix serialization

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/rest/models/roles/responses/RoleResponse.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/models/roles/responses/RoleResponse.java
@@ -20,11 +20,11 @@ import com.fasterxml.jackson.annotation.JsonAutoDetect;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.auto.value.AutoValue;
-import com.google.common.base.Optional;
 import org.graylog.autovalue.WithBeanGetter;
 import org.hibernate.validator.constraints.NotBlank;
 
 import javax.validation.constraints.NotNull;
+import java.util.Optional;
 import java.util.Set;
 
 @AutoValue

--- a/graylog2-server/src/main/java/org/graylog2/rest/resources/roles/RolesResource.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/resources/roles/RolesResource.java
@@ -16,7 +16,6 @@
  */
 package org.graylog2.rest.resources.roles;
 
-import com.google.common.base.Optional;
 import com.google.common.collect.Sets;
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
@@ -59,6 +58,7 @@ import java.net.URI;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashSet;
+import java.util.Optional;
 import java.util.Set;
 
 import static com.google.common.base.MoreObjects.firstNonNull;
@@ -86,7 +86,7 @@ public class RolesResource extends RestResource {
         final Set<Role> roles = roleService.loadAll();
         Set<RoleResponse> roleResponses = Sets.newHashSet();
         for (Role role : roles) {
-            roleResponses.add(RoleResponse.create(role.getName(), Optional.fromNullable(role.getDescription()), role.getPermissions(), role.isReadOnly()));
+            roleResponses.add(RoleResponse.create(role.getName(), Optional.ofNullable(role.getDescription()), role.getPermissions(), role.isReadOnly()));
         }
 
         return RolesResponse.create(roleResponses);
@@ -99,7 +99,7 @@ public class RolesResource extends RestResource {
         checkPermission(RestPermissions.ROLES_READ, name);
 
         final Role role = roleService.load(name);
-        return RoleResponse.create(role.getName(), Optional.fromNullable(role.getDescription()), role.getPermissions(), role.isReadOnly());
+        return RoleResponse.create(role.getName(), Optional.ofNullable(role.getDescription()), role.getPermissions(), role.isReadOnly());
     }
 
     @POST
@@ -114,7 +114,7 @@ public class RolesResource extends RestResource {
         Role role = new RoleImpl();
         role.setName(roleResponse.name());
         role.setPermissions(roleResponse.permissions());
-        role.setDescription(roleResponse.description().orNull());
+        role.setDescription(roleResponse.description().orElse(null));
 
         try {
             role = roleService.save(role);
@@ -128,7 +128,7 @@ public class RolesResource extends RestResource {
                 .build(role.getName());
 
         return Response.created(uri).entity(RoleResponse.create(role.getName(),
-                                                                Optional.fromNullable(role.getDescription()),
+                                                                Optional.ofNullable(role.getDescription()),
                                                                 role.getPermissions(),
                                                                 role.isReadOnly())).build();
     }
@@ -146,14 +146,14 @@ public class RolesResource extends RestResource {
             throw new BadRequestException("Cannot update read only role " + name);
         }
         roleToUpdate.setName(role.name());
-        roleToUpdate.setDescription(role.description().orNull());
+        roleToUpdate.setDescription(role.description().orElse(null));
         roleToUpdate.setPermissions(role.permissions());
         try {
             roleService.save(roleToUpdate);
         } catch (ValidationException e) {
             throw new BadRequestException(e);
         }
-        return RoleResponse.create(roleToUpdate.getName(), Optional.fromNullable(roleToUpdate.getDescription()), roleToUpdate.getPermissions(),
+        return RoleResponse.create(roleToUpdate.getName(), Optional.ofNullable(roleToUpdate.getDescription()), roleToUpdate.getPermissions(),
                                    role.readOnly());
     }
 


### PR DESCRIPTION
This fixes a StackOverflowError when accessing the /roles API endpoint. It looks like the guava Optional class cannot be serialized by jackson.

Fixes #3913
