### PR TITLE
Collect and show metrics for lookup caches and adapters

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/lookup/adapters/CSVFileDataAdapter.java
+++ b/graylog2-server/src/main/java/org/graylog2/lookup/adapters/CSVFileDataAdapter.java
@@ -17,6 +17,7 @@
 package org.graylog2.lookup.adapters;
 
 import au.com.bytecode.opencsv.CSVReader;
+import com.codahale.metrics.MetricRegistry;
 import com.fasterxml.jackson.annotation.JsonAutoDetect;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -68,8 +69,9 @@ public class CSVFileDataAdapter extends LookupDataAdapter {
     @Inject
     public CSVFileDataAdapter(@Assisted("id") String id,
                               @Assisted("name") String name,
-                              @Assisted LookupDataAdapterConfiguration config) {
-        super(id, name, config);
+                              @Assisted LookupDataAdapterConfiguration config,
+                              MetricRegistry metricRegistry) {
+        super(id, name, config, metricRegistry);
         this.config = (Config) config;
     }
 

--- a/graylog2-server/src/main/java/org/graylog2/lookup/adapters/HTTPJSONPathDataAdapter.java
+++ b/graylog2-server/src/main/java/org/graylog2/lookup/adapters/HTTPJSONPathDataAdapter.java
@@ -86,7 +86,7 @@ public class HTTPJSONPathDataAdapter extends LookupDataAdapter {
                                       Engine templateEngine,
                                       OkHttpClient httpClient,
                                       MetricRegistry metricRegistry) {
-        super(id, name, config);
+        super(id, name, config, metricRegistry);
         this.config = (Config) config;
         this.templateEngine = templateEngine;
         // TODO Add config options: caching, timeouts, custom headers, basic auth (See: https://github.com/square/okhttp/wiki/Recipes)

--- a/graylog2-server/src/main/java/org/graylog2/lookup/caches/NullCache.java
+++ b/graylog2-server/src/main/java/org/graylog2/lookup/caches/NullCache.java
@@ -16,6 +16,7 @@
  */
 package org.graylog2.lookup.caches;
 
+import com.codahale.metrics.MetricRegistry;
 import com.fasterxml.jackson.annotation.JsonAutoDetect;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonTypeName;
@@ -44,8 +45,9 @@ public class NullCache extends LookupCache {
     @Inject
     public NullCache(@Assisted("id") String id,
                      @Assisted("name") String name,
-                     @Assisted LookupCacheConfiguration c) {
-        super(id, name, c);
+                     @Assisted LookupCacheConfiguration c,
+                     MetricRegistry metricRegistry) {
+        super(id, name, c, metricRegistry);
     }
 
     @Override

--- a/graylog2-web-interface/src/components/common/ContentPackMarker.jsx
+++ b/graylog2-web-interface/src/components/common/ContentPackMarker.jsx
@@ -2,13 +2,13 @@ import React from 'react';
 
 const ContentPackMarker = React.createClass({
   propTypes: {
-    contentPack: React.PropTypes.string.isRequired,
+    contentPack: React.PropTypes.string,
     marginLeft: React.PropTypes.number,
     marginRight: React.PropTypes.number,
   },
 
   getDefaultProps() {
-    return { marginLeft: 0, marginRight: 0 };
+    return { contentPack: undefined, marginLeft: 0, marginRight: 0 };
   },
 
   render() {

--- a/graylog2-web-interface/src/components/lookup-tables/CachesOverview.jsx
+++ b/graylog2-web-interface/src/components/lookup-tables/CachesOverview.jsx
@@ -113,6 +113,7 @@ const CachesOverview = React.createClass({
                   <th>Name</th>
                   <th>Entries</th>
                   <th>Hit rate</th>
+                  <th>Throughput</th>
                   <th className={Styles.actions}>Actions</th>
                 </tr>
               </thead>

--- a/graylog2-web-interface/src/components/lookup-tables/DataAdapterTableEntry.jsx
+++ b/graylog2-web-interface/src/components/lookup-tables/DataAdapterTableEntry.jsx
@@ -8,6 +8,7 @@ import CombinedProvider from 'injection/CombinedProvider';
 
 import { ErrorPopover } from 'components/lookup-tables';
 import { ContentPackMarker } from 'components/common';
+import { MetricContainer, CounterRate } from 'components/metrics';
 
 const { LookupTableDataAdaptersActions } = CombinedProvider.get('LookupTableDataAdapters');
 
@@ -42,7 +43,11 @@ const DataAdapterTableEntry = React.createClass({
           </td>
           <td>{this.props.adapter.description}</td>
           <td>{this.props.adapter.name}</td>
-          <td>TODO: <em>0</em></td>
+          <td>
+            <MetricContainer name={`org.graylog2.lookup.adapters.${this.props.adapter.id}.requests`}>
+              <CounterRate suffix="lookups/s" />
+            </MetricContainer>
+          </td>
           <td>
             <LinkContainer to={Routes.SYSTEM.LOOKUPTABLES.DATA_ADAPTERS.edit(this.props.adapter.name)}>
               <Button bsSize="xsmall" bsStyle="info">Edit</Button>

--- a/graylog2-web-interface/src/components/lookup-tables/DataAdaptersOverview.jsx
+++ b/graylog2-web-interface/src/components/lookup-tables/DataAdaptersOverview.jsx
@@ -114,7 +114,7 @@ const DataAdaptersOverview = React.createClass({
                   <th>Title</th>
                   <th>Description</th>
                   <th>Name</th>
-                  <th>Entries</th>
+                  <th>Throughput</th>
                   <th className={Styles.actions}>Actions</th>
                 </tr>
               </thead>

--- a/graylog2-web-interface/src/components/metrics/CounterRate.jsx
+++ b/graylog2-web-interface/src/components/metrics/CounterRate.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import numeral from 'numeral';
+import TimeHelper from 'util/TimeHelper';
 
 const CounterRate = React.createClass({
   propTypes: {
@@ -24,19 +25,15 @@ const CounterRate = React.createClass({
     return {
       prevMetric: null,
       prevTs: null,
-      nowTs: this._nowInSeconds(),
+      nowTs: TimeHelper.nowInSeconds(),
     };
   },
   componentWillReceiveProps() {
     this.setState({
       prevMetric: this.props.metric,
       prevTs: this.state.nowTs,
-      nowTs: this._nowInSeconds(),
+      nowTs: TimeHelper.nowInSeconds(),
     });
-  },
-
-  _nowInSeconds() {
-    return Math.floor(Date.now() / 1000);
   },
 
   _checkPrevMetric() {

--- a/graylog2-web-interface/src/components/metrics/MetricsMapper.jsx
+++ b/graylog2-web-interface/src/components/metrics/MetricsMapper.jsx
@@ -1,0 +1,70 @@
+import React from 'react';
+import Reflux from 'reflux';
+//import { Row, Col } from 'react-bootstrap';
+
+import CombinedProvider from 'injection/CombinedProvider';
+const { MetricsActions, MetricsStore } = CombinedProvider.get('Metrics');
+
+const MetricsMapper = React.createClass({
+  propTypes: {
+    map: React.PropTypes.object.isRequired,
+    computeValue: React.PropTypes.func.isRequired,
+  },
+  mixins: [Reflux.connect(MetricsStore)],
+
+  getDefaultProps() {
+    return {
+    };
+  },
+
+  getInitialState() {
+    return {};
+  },
+
+  componentWillMount() {
+    Object.keys(this.props.map).forEach(name => MetricsActions.addGlobal(this.props.map[name]));
+  },
+
+  shouldComponentUpdate(_, nextState) {
+    // Only re-render this component if the metric data has changed
+    if (this.state.metricsUpdatedAt && nextState.metricsUpdatedAt) {
+      return nextState.metricsUpdatedAt > this.state.metricsUpdatedAt;
+    }
+    return true;
+  },
+
+  componentWillUnmount() {
+    Object.keys(this.props.map).forEach(name => MetricsActions.removeGlobal(this.props.map[name]));
+  },
+
+  render() {
+    if (!this.state.metrics) {
+      return null;
+    }
+
+    const metricsMap = {};
+
+    Object.keys(this.state.metrics).forEach((nodeId) => {
+      Object.keys(this.props.map).forEach((key) => {
+        const metricName = this.props.map[key];
+
+        if (this.state.metrics[nodeId][metricName]) {
+          // Only create the node entry if we actually have data
+          if (!metricsMap[nodeId]) {
+            metricsMap[nodeId] = {};
+          }
+          metricsMap[nodeId][key] = this.state.metrics[nodeId][metricName];
+        }
+      });
+    });
+
+    const value = this.props.computeValue(metricsMap);
+    return (
+      <span>
+        {value}
+      </span>
+    );
+  },
+});
+
+export default MetricsMapper;

--- a/graylog2-web-interface/src/components/metrics/MetricsMapper.jsx
+++ b/graylog2-web-interface/src/components/metrics/MetricsMapper.jsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import Reflux from 'reflux';
-//import { Row, Col } from 'react-bootstrap';
 
 import CombinedProvider from 'injection/CombinedProvider';
 const { MetricsActions, MetricsStore } = CombinedProvider.get('Metrics');

--- a/graylog2-web-interface/src/components/metrics/index.jsx
+++ b/graylog2-web-interface/src/components/metrics/index.jsx
@@ -9,4 +9,5 @@ export { default as MetricDetails } from './MetricDetails';
 export { default as MetricsComponent } from './MetricsComponent';
 export { default as MetricsFilterInput } from './MetricsFilterInput';
 export { default as MetricsList } from './MetricsList';
+export { default as MetricsMapper } from './MetricsMapper';
 export { default as TimerDetails } from './TimerDetails';

--- a/graylog2-web-interface/src/logic/metrics/MetricsExtractor.js
+++ b/graylog2-web-interface/src/logic/metrics/MetricsExtractor.js
@@ -20,6 +20,8 @@ const MetricsExtractor = {
           metrics[metricShortName] = metricObject.metric.count;
         } else if (metricObject.type === 'meter') {
           metrics[metricShortName] = metricObject.metric.rate.total;
+        } else if (metricObject.type === 'timer') {
+          metrics[metricShortName] = metricObject.metric.rate.total;
         } else {
           metrics[metricShortName] = null;
         }

--- a/graylog2-web-interface/src/stores/metrics/MetricsStore.js
+++ b/graylog2-web-interface/src/stores/metrics/MetricsStore.js
@@ -3,6 +3,7 @@ import Reflux from 'reflux';
 import URLUtils from 'util/URLUtils';
 import ApiRoutes from 'routing/ApiRoutes';
 import fetch, { Builder, fetchPeriodically } from 'logic/rest/FetchProvider';
+import TimeHelper from 'util/TimeHelper';
 
 import StoreProvider from 'injection/StoreProvider';
 const SessionStore = StoreProvider.getStore('Session');
@@ -92,7 +93,8 @@ const MetricsStore = Reflux.createStore({
 
       promise.then((response) => {
         this.metrics = this._buildMetricsFromResponse(response);
-        this.trigger({ metrics: this.metrics });
+        // The metricsUpdatedAt value is used by components to decide if they should be re-rendered
+        this.trigger({ metrics: this.metrics, metricsUpdatedAt: TimeHelper.nowInSeconds() });
         return this.metrics;
       });
       this.promises.list = promise;

--- a/graylog2-web-interface/src/util/TimeHelper.js
+++ b/graylog2-web-interface/src/util/TimeHelper.js
@@ -1,0 +1,7 @@
+const TimeHelper = {
+  nowInSeconds() {
+    return Math.floor(Date.now() / 1000);
+  },
+};
+
+export default TimeHelper;


### PR DESCRIPTION
Extend lookup caches and data adapters to collect runtime metrics and expose some of them in the UI.

This also fixes an issue with the ContentPackMarker component (6eef181) and the MetricComponent (4640593).

https://github.com/Graylog2/graylog-plugin-map-widget/pull/50 needs to be merged once this is merged.