### PR TITLE
Remove obsolete "disableExpensiveUpdates" user preference

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/users/UserImpl.java
+++ b/graylog2-server/src/main/java/org/graylog2/users/UserImpl.java
@@ -72,7 +72,6 @@ public class UserImpl extends PersistedImpl implements User {
 
     private static final Map<String, Object> DEFAULT_PREFERENCES = new ImmutableMap.Builder<String, Object>()
             .put("updateUnfocussed", false)
-            .put("disableExpensiveUpdates", false)
             .put("enableSmartSearch", true)
             .build();
 


### PR DESCRIPTION
The "disableExpensiveUpdates" preference hasn't been used since Graylog 1.3.x.