### PR TITLE
Replace Netty IpSubnet with custom class

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/Configuration.java
+++ b/graylog2-server/src/main/java/org/graylog2/Configuration.java
@@ -29,7 +29,7 @@ import com.github.joschi.jadconfig.validators.StringNotBlankValidator;
 import com.github.joschi.jadconfig.validators.URIAbsoluteValidator;
 import org.graylog2.plugin.BaseConfiguration;
 import org.graylog2.utilities.IPSubnetConverter;
-import org.jboss.netty.handler.ipfilter.IpSubnet;
+import org.graylog2.utilities.IpSubnet;
 import org.joda.time.DateTimeZone;
 
 import java.net.URI;

--- a/graylog2-server/src/main/java/org/graylog2/filters/blacklist/BlacklistIpMatcherCondition.java
+++ b/graylog2-server/src/main/java/org/graylog2/filters/blacklist/BlacklistIpMatcherCondition.java
@@ -17,7 +17,7 @@
 package org.graylog2.filters.blacklist;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-import org.jboss.netty.handler.ipfilter.IpSubnet;
+import org.graylog2.utilities.IpSubnet;
 
 import java.net.InetAddress;
 import java.net.UnknownHostException;

--- a/graylog2-server/src/main/java/org/graylog2/rest/RestTools.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/RestTools.java
@@ -21,7 +21,7 @@ import org.glassfish.grizzly.http.server.Request;
 import org.glassfish.jersey.server.model.Resource;
 import org.graylog2.shared.security.ShiroPrincipal;
 import org.graylog2.shared.security.ShiroSecurityContext;
-import org.jboss.netty.handler.ipfilter.IpSubnet;
+import org.graylog2.utilities.IpSubnet;
 
 import javax.annotation.Nullable;
 import javax.validation.constraints.NotNull;

--- a/graylog2-server/src/main/java/org/graylog2/rest/resources/system/SessionsResource.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/resources/system/SessionsResource.java
@@ -45,7 +45,7 @@ import org.graylog2.shared.rest.resources.RestResource;
 import org.graylog2.shared.security.ShiroAuthenticationFilter;
 import org.graylog2.shared.security.ShiroSecurityContext;
 import org.graylog2.shared.users.UserService;
-import org.jboss.netty.handler.ipfilter.IpSubnet;
+import org.graylog2.utilities.IpSubnet;
 import org.joda.time.DateTime;
 import org.joda.time.DateTimeZone;
 import org.slf4j.Logger;

--- a/graylog2-server/src/main/java/org/graylog2/shared/rest/RestAccessLogFilter.java
+++ b/graylog2-server/src/main/java/org/graylog2/shared/rest/RestAccessLogFilter.java
@@ -18,7 +18,7 @@ package org.graylog2.shared.rest;
 
 import org.glassfish.grizzly.http.server.Response;
 import org.graylog2.rest.RestTools;
-import org.jboss.netty.handler.ipfilter.IpSubnet;
+import org.graylog2.utilities.IpSubnet;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/graylog2-server/src/main/java/org/graylog2/shared/security/ShiroSecurityContextFilter.java
+++ b/graylog2-server/src/main/java/org/graylog2/shared/security/ShiroSecurityContextFilter.java
@@ -23,7 +23,7 @@ import org.apache.shiro.subject.Subject;
 import org.apache.shiro.util.ThreadContext;
 import org.glassfish.grizzly.http.server.Request;
 import org.graylog2.rest.RestTools;
-import org.jboss.netty.handler.ipfilter.IpSubnet;
+import org.graylog2.utilities.IpSubnet;
 
 import javax.annotation.Priority;
 import javax.inject.Inject;

--- a/graylog2-server/src/main/java/org/graylog2/utilities/IPSubnetConverter.java
+++ b/graylog2-server/src/main/java/org/graylog2/utilities/IPSubnetConverter.java
@@ -20,7 +20,6 @@ import com.github.joschi.jadconfig.Converter;
 import com.github.joschi.jadconfig.ParameterException;
 import com.google.common.base.Joiner;
 import com.google.common.base.Splitter;
-import org.jboss.netty.handler.ipfilter.IpSubnet;
 
 import java.net.UnknownHostException;
 import java.util.HashSet;

--- a/graylog2-server/src/main/java/org/graylog2/utilities/IpSubnet.java
+++ b/graylog2-server/src/main/java/org/graylog2/utilities/IpSubnet.java
@@ -1,0 +1,160 @@
+/**
+ * This file is part of Graylog.
+ *
+ * Graylog is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
+ */
+/*
+* The MIT License
+*
+* Copyright (c) 2013 Edin Dazdarevic (edin.dazdarevic@gmail.com)
+
+* Permission is hereby granted, free of charge, to any person obtaining a copy
+* of this software and associated documentation files (the "Software"), to deal
+* in the Software without restriction, including without limitation the rights
+* to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+* copies of the Software, and to permit persons to whom the Software is
+* furnished to do so, subject to the following conditions:
+
+* The above copyright notice and this permission notice shall be included in
+* all copies or substantial portions of the Software.
+
+* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+* IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+* OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+* THE SOFTWARE.
+*
+* */
+package org.graylog2.utilities;
+
+import java.math.BigInteger;
+import java.net.InetAddress;
+import java.net.UnknownHostException;
+import java.util.Objects;
+import java.util.StringJoiner;
+
+/**
+ * A class that enables to get an IP range from CIDR specification. It supports
+ * both IPv4 and IPv6.
+ */
+public class IpSubnet {
+    private static final byte[] MASK_IPV4 = {-1, -1, -1, -1};
+    private static final byte[] MASK_IPV6 = {-1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1};
+
+    private final InetAddress inetAddress;
+    private InetAddress startAddress;
+    private InetAddress endAddress;
+    private final int prefixLength;
+
+
+    public IpSubnet(String cidr) throws UnknownHostException {
+        Objects.requireNonNull(cidr, "CIDR must not be null");
+
+        /* split CIDR to address and prefix part */
+        if (cidr.contains("/")) {
+            int index = cidr.indexOf("/");
+            String addressPart = cidr.substring(0, index);
+            String networkPart = cidr.substring(index + 1);
+
+            inetAddress = InetAddress.getByName(addressPart);
+            prefixLength = Integer.parseInt(networkPart);
+
+            calculate();
+        } else {
+            throw new UnknownHostException("Invalid subnet: " + cidr);
+        }
+    }
+
+    private void calculate() throws UnknownHostException {
+        final int targetSize;
+        final BigInteger mask;
+        if (inetAddress.getAddress().length == 4) {
+            targetSize = 4;
+            mask = (new BigInteger(1, MASK_IPV4)).not().shiftRight(prefixLength);
+        } else {
+            targetSize = 16;
+            mask = (new BigInteger(1, MASK_IPV6)).not().shiftRight(prefixLength);
+        }
+
+        final BigInteger ipVal = new BigInteger(1, inetAddress.getAddress());
+
+        final BigInteger startIp = ipVal.and(mask);
+        final BigInteger endIp = startIp.add(mask.not());
+
+        final byte[] startIpArr = toBytes(startIp.toByteArray(), targetSize);
+        final byte[] endIpArr = toBytes(endIp.toByteArray(), targetSize);
+
+        this.startAddress = InetAddress.getByAddress(startIpArr);
+        this.endAddress = InetAddress.getByAddress(endIpArr);
+    }
+
+    private byte[] toBytes(byte[] array, int targetSize) {
+        final byte[] b = new byte[targetSize];
+        final int length = (targetSize > array.length) ? array.length : targetSize;
+        final int srcPos = (array.length > targetSize) ? array.length - targetSize : 0;
+        final int destPos = (targetSize > array.length) ? targetSize - array.length : 0;
+
+        System.arraycopy(array, srcPos, b, destPos, length);
+
+        return b;
+    }
+
+    public String getNetworkAddress() {
+        return this.startAddress.getHostAddress();
+    }
+
+    public String getBroadcastAddress() {
+        return this.endAddress.getHostAddress();
+    }
+
+    public boolean contains(String ipAddress) throws UnknownHostException {
+        return contains(InetAddress.getByName(ipAddress));
+    }
+
+    public boolean contains(InetAddress address) {
+        final BigInteger start = new BigInteger(1, this.startAddress.getAddress());
+        final BigInteger end = new BigInteger(1, this.endAddress.getAddress());
+        final BigInteger target = new BigInteger(1, address.getAddress());
+
+        final int st = start.compareTo(target);
+        final int te = target.compareTo(end);
+
+        return (st == -1 || st == 0) && (te == -1 || te == 0);
+    }
+
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+
+        IpSubnet that = (IpSubnet) o;
+
+        return Objects.equals(this.startAddress, that.startAddress) &&
+                Objects.equals(this.endAddress, that.endAddress) &&
+                Objects.equals(this.prefixLength, that.prefixLength);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(startAddress, endAddress, prefixLength);
+    }
+
+    @Override
+    public String toString() {
+        return inetAddress.getHostAddress() + "/" + prefixLength;
+    }
+}

--- a/graylog2-server/src/test/java/org/graylog2/rest/RestToolsTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/rest/RestToolsTest.java
@@ -18,7 +18,7 @@ package org.graylog2.rest;
 
 import com.google.common.collect.ImmutableList;
 import org.glassfish.grizzly.http.server.Request;
-import org.jboss.netty.handler.ipfilter.IpSubnet;
+import org.graylog2.utilities.IpSubnet;
 import org.junit.Test;
 
 import javax.ws.rs.core.HttpHeaders;
@@ -86,8 +86,26 @@ public class RestToolsTest {
     public void buildEndpointUriReturnsFirstHeaderValueIfMultipleHeadersArePresent() throws Exception {
         final HttpHeaders httpHeaders = mock(HttpHeaders.class);
         when(httpHeaders.getRequestHeader(anyString())).thenReturn(
-            ImmutableList.of("http://header1.example.com", "http://header2.example.com"));
+                ImmutableList.of("http://header1.example.com", "http://header2.example.com"));
         final URI endpointUri = URI.create("http://graylog.example.com");
         assertThat(RestTools.buildEndpointUri(httpHeaders, endpointUri)).isEqualTo("http://header1.example.com");
+    }
+
+    @Test
+    public void getRemoteAddrFromRequestWorksWithIPv6IfSubnetsContainsOnlyIPv4() throws Exception {
+        final Request request = mock(Request.class);
+        when(request.getRemoteAddr()).thenReturn("2001:DB8::42");
+        when(request.getHeader("X-Forwarded-For")).thenReturn("2001:DB8::1");
+        final String s = RestTools.getRemoteAddrFromRequest(request, Collections.singleton(new IpSubnet("127.0.0.1/32")));
+        assertThat(s).isEqualTo("2001:DB8::42");
+    }
+
+    @Test
+    public void getRemoteAddrFromRequestWorksWithIPv6IfSubnetsContainsOnlyIPv6() throws Exception {
+        final Request request = mock(Request.class);
+        when(request.getRemoteAddr()).thenReturn("2001:DB8::42");
+        when(request.getHeader("X-Forwarded-For")).thenReturn("2001:DB8::1:2:3:4:5:6");
+        final String s = RestTools.getRemoteAddrFromRequest(request, Collections.singleton(new IpSubnet("2001:DB8::/32")));
+        assertThat(s).isEqualTo("2001:DB8::1:2:3:4:5:6");
     }
 }

--- a/graylog2-server/src/test/java/org/graylog2/utilities/IPSubnetConverterTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/utilities/IPSubnetConverterTest.java
@@ -17,13 +17,10 @@
 package org.graylog2.utilities;
 
 import com.github.joschi.jadconfig.ParameterException;
-import org.jboss.netty.handler.ipfilter.IpSubnet;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 
-import java.net.Inet4Address;
-import java.net.Inet6Address;
 import java.util.Set;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -40,8 +37,8 @@ public class IPSubnetConverterTest {
         final Set<IpSubnet> results = converter.convertFrom(defaultList);
         assertThat(results)
             .hasSize(2)
-            .contains(new IpSubnet(Inet4Address.getByName("127.0.0.1"), 32))
-            .contains(new IpSubnet(Inet6Address.getByName("0:0:0:0:0:0:0:1"), 128));
+            .contains(new IpSubnet("127.0.0.1/32"))
+            .contains(new IpSubnet("0:0:0:0:0:0:0:1/128"));
         assertThat(converter.convertTo(results)).isEqualTo(defaultList);
     }
 

--- a/graylog2-server/src/test/java/org/graylog2/utilities/IpSubnetTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/utilities/IpSubnetTest.java
@@ -1,0 +1,73 @@
+/**
+ * This file is part of Graylog.
+ *
+ * Graylog is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.graylog2.utilities;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import java.net.UnknownHostException;
+import java.util.Arrays;
+import java.util.Collection;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@RunWith(Parameterized.class)
+public class IpSubnetTest {
+    @Parameterized.Parameters
+    public static Collection<Object[]> data() {
+        return Arrays.asList(new Object[][]{
+                {"127.0.0.1/32", "127.0.0.1", "127.0.0.1", "127.0.0.1", true},
+                {"127.0.0.1/32", "127.0.0.2", "127.0.0.1", "127.0.0.1", false},
+                {"::1/128", "::1", "0:0:0:0:0:0:0:1", "0:0:0:0:0:0:0:1", true},
+                {"::1/128", "::2", "0:0:0:0:0:0:0:1", "0:0:0:0:0:0:0:1", false},
+                {"::1/128", "127.0.0.1", "0:0:0:0:0:0:0:1", "0:0:0:0:0:0:0:1", false},
+                {"127.0.0.1/32", "::1", "127.0.0.1", "127.0.0.1", false},
+                {"10.0.0.0/8", "10.1.2.3", "10.0.0.0", "10.255.255.255", true},
+                {"2001:DB8::/128", "2001:DB8::1:2:3:4:5", "2001:db8:0:0:0:0:0:0", "2001:db8:0:0:0:0:0:0", false},
+        });
+    }
+
+    private final IpSubnet ipSubnet;
+    private final String ipAddress;
+    private final String networkAddress;
+    private final String broadcastAddress;
+    private final boolean isInSubnet;
+
+    public IpSubnetTest(String cidr, String ipAddress, String networkAddress, String broadcastAddress, boolean isInSubnet) throws UnknownHostException {
+        this.ipSubnet = new IpSubnet(cidr);
+        this.ipAddress = ipAddress;
+        this.networkAddress = networkAddress;
+        this.broadcastAddress = broadcastAddress;
+        this.isInSubnet = isInSubnet;
+    }
+
+    @Test
+    public void getNetworkAddress() {
+        assertThat(ipSubnet.getNetworkAddress()).isEqualTo(networkAddress);
+    }
+
+    @Test
+    public void getBroadcastAddress() {
+        assertThat(ipSubnet.getBroadcastAddress()).isEqualTo(broadcastAddress);
+    }
+
+    @Test
+    public void contains() throws UnknownHostException {
+        assertThat(ipSubnet.contains(ipAddress)).isEqualTo(isInSubnet);
+    }
+}


### PR DESCRIPTION
The Netty 3.6 `IpSubnet` class (http://netty.io/3.6/api/org/jboss/netty/handler/ipfilter/IpSubnet.html) doesn't allow checking if an IPv6 address is part of an IPv4 subnet and throws an exception instead.

In order to allow users to run a dualstack environment (IPv4 and IPv6 at the same time), this changeset introduces a custom `IpSubnet` implementation which can handle these cases properly.

The new `IpSubnet` implementation was initially copied from https://github.com/edazdarevic/CIDRUtils but modified for performance and compatibility with the Netty 3.6 `IpSubnet` class.

As the original source file is licensed under MIT, the IpSubnet source file contains a GPLv3 *and* an MIT license header (https://en.wikipedia.org/wiki/License_compatibility#GPL_compatibility).

Fixes #3870

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code follows the code style of this project.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.