### PR TITLE
Don't check ES cluster health when flushing messages

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/outputs/BlockingBatchedESOutput.java
+++ b/graylog2-server/src/main/java/org/graylog2/outputs/BlockingBatchedESOutput.java
@@ -20,12 +20,10 @@ import com.codahale.metrics.Histogram;
 import com.codahale.metrics.Meter;
 import com.codahale.metrics.MetricRegistry;
 import com.codahale.metrics.Timer;
-import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.google.inject.assistedinject.Assisted;
 import com.google.inject.assistedinject.AssistedInject;
 import org.graylog2.indexer.IndexSet;
-import org.graylog2.indexer.cluster.Cluster;
 import org.graylog2.indexer.messages.Messages;
 import org.graylog2.plugin.Message;
 import org.graylog2.plugin.configuration.Configuration;
@@ -35,9 +33,9 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import javax.inject.Inject;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
-import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
 
@@ -47,11 +45,11 @@ import static java.util.concurrent.TimeUnit.NANOSECONDS;
 // Singleton class
 public class BlockingBatchedESOutput extends ElasticSearchOutput {
     private static final Logger log = LoggerFactory.getLogger(BlockingBatchedESOutput.class);
-    private final Cluster cluster;
     private final int maxBufferSize;
     private final Timer processTime;
     private final Histogram batchSize;
     private final Meter bufferFlushes;
+    private final Meter bufferFlushFailures;
     private final Meter bufferFlushesRequested;
 
     private volatile List<Map.Entry<IndexSet, Message>> buffer;
@@ -63,30 +61,28 @@ public class BlockingBatchedESOutput extends ElasticSearchOutput {
     @AssistedInject
     public BlockingBatchedESOutput(MetricRegistry metricRegistry,
                                    Messages messages,
-                                   Cluster cluster,
                                    org.graylog2.Configuration serverConfiguration,
                                    Journal journal,
                                    @Assisted Stream stream,
                                    @Assisted Configuration configuration) {
-        this(metricRegistry, messages, cluster, serverConfiguration, journal);
+        this(metricRegistry, messages, serverConfiguration, journal);
     }
 
     @Inject
     public BlockingBatchedESOutput(MetricRegistry metricRegistry,
                                    Messages messages,
-                                   Cluster cluster,
                                    org.graylog2.Configuration serverConfiguration,
                                    Journal journal) {
         super(metricRegistry, messages, journal);
-        this.cluster = cluster;
         this.maxBufferSize = serverConfiguration.getOutputBatchSize();
         outputFlushInterval = serverConfiguration.getOutputFlushInterval();
         this.processTime = metricRegistry.timer(name(this.getClass(), "processTime"));
         this.batchSize = metricRegistry.histogram(name(this.getClass(), "batchSize"));
         this.bufferFlushes = metricRegistry.meter(name(this.getClass(), "bufferFlushes"));
+        this.bufferFlushFailures = metricRegistry.meter(name(this.getClass(), "bufferFlushFailures"));
         this.bufferFlushesRequested = metricRegistry.meter(name(this.getClass(), "bufferFlushesRequested"));
 
-        buffer = Lists.newArrayListWithCapacity(maxBufferSize);
+        buffer = new ArrayList<>(maxBufferSize);
 
     }
 
@@ -104,7 +100,7 @@ public class BlockingBatchedESOutput extends ElasticSearchOutput {
 
             if (buffer.size() >= maxBufferSize) {
                 flushBatch = buffer;
-                buffer = Lists.newArrayListWithCapacity(maxBufferSize);
+                buffer = new ArrayList<>(maxBufferSize);
             }
         }
         // if the current thread found it had to flush any messages, it does so but blocks.
@@ -116,21 +112,17 @@ public class BlockingBatchedESOutput extends ElasticSearchOutput {
     }
 
     private void flush(List<Map.Entry<IndexSet, Message>> messages) {
-        if (!cluster.isConnected() || !cluster.isDeflectorHealthy()) {
-            try {
-                cluster.waitForConnectedAndDeflectorHealthy();
-            } catch (TimeoutException | InterruptedException e) {
-                log.warn("Error while waiting for healthy Elasticsearch cluster. Not flushing.", e);
-                return;
-            }
-        }
         // never try to flush an empty buffer
-        if (messages.size() == 0) {
+        if (messages.isEmpty()) {
             return;
         }
-        log.debug("Starting flushing {} messages, flush threads active {}",
-                 messages.size(),
-                 activeFlushThreads.incrementAndGet());
+
+        activeFlushThreads.incrementAndGet();
+        if (log.isDebugEnabled()) {
+            log.debug("Starting flushing {} messages, flush threads active {}",
+                    messages.size(),
+                    activeFlushThreads.get());
+        }
 
         try (Timer.Context ignored = processTime.time()) {
             lastFlushTime.set(System.nanoTime());
@@ -139,18 +131,13 @@ public class BlockingBatchedESOutput extends ElasticSearchOutput {
             bufferFlushes.mark();
         } catch (Exception e) {
             log.error("Unable to flush message buffer", e);
+            bufferFlushFailures.mark();
         }
         activeFlushThreads.decrementAndGet();
         log.debug("Flushing {} messages completed", messages.size());
     }
 
     public void forceFlushIfTimedout() {
-        if (!cluster.isConnected() || !cluster.isDeflectorHealthy()) {
-            // do not actually try to flush, because that will block until the cluster comes back.
-            // simply check and return.
-            log.debug("Cluster unavailable, but not blocking for periodic flush attempt. This will try again.");
-            return;
-        }
         // if we shouldn't flush at all based on the last flush time, no need to synchronize on this.
         if (lastFlushTime.get() != 0 &&
                 outputFlushInterval > NANOSECONDS.toSeconds(System.nanoTime() - lastFlushTime.get())) {
@@ -160,7 +147,7 @@ public class BlockingBatchedESOutput extends ElasticSearchOutput {
         final List<Map.Entry<IndexSet, Message>> flushBatch;
         synchronized (this) {
             flushBatch = buffer;
-            buffer = Lists.newArrayListWithCapacity(maxBufferSize);
+            buffer = new ArrayList<>(maxBufferSize);
         }
         if (flushBatch != null) {
             bufferFlushesRequested.mark();

--- a/graylog2-server/src/main/java/org/graylog2/outputs/ElasticSearchOutput.java
+++ b/graylog2-server/src/main/java/org/graylog2/outputs/ElasticSearchOutput.java
@@ -19,8 +19,6 @@ package org.graylog2.outputs;
 import com.codahale.metrics.Meter;
 import com.codahale.metrics.MetricRegistry;
 import com.codahale.metrics.Timer;
-import com.google.common.base.Joiner;
-import com.google.common.collect.Ordering;
 import com.google.inject.assistedinject.Assisted;
 import com.google.inject.assistedinject.AssistedInject;
 import org.graylog2.indexer.IndexSet;
@@ -36,6 +34,7 @@ import org.slf4j.LoggerFactory;
 
 import javax.inject.Inject;
 import java.util.Collections;
+import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -45,12 +44,14 @@ import static com.codahale.metrics.MetricRegistry.name;
 
 public class ElasticSearchOutput implements MessageOutput {
     private static final String WRITES_METRICNAME = name(ElasticSearchOutput.class, "writes");
+    private static final String FAILURES_METRICNAME = name(ElasticSearchOutput.class, "failures");
     private static final String PROCESS_TIME_METRICNAME = name(ElasticSearchOutput.class, "processTime");
 
     private static final String NAME = "ElasticSearch Output";
     private static final Logger LOG = LoggerFactory.getLogger(ElasticSearchOutput.class);
 
     private final Meter writes;
+    private final Meter failures;
     private final Timer processTime;
     private final Messages messages;
     private final Journal journal;
@@ -73,6 +74,7 @@ public class ElasticSearchOutput implements MessageOutput {
         this.journal = journal;
         // Only constructing metrics here. write() get's another Core reference. (because this technically is a plugin)
         this.writes = metricRegistry.meter(WRITES_METRICNAME);
+        this.failures = metricRegistry.meter(FAILURES_METRICNAME);
         this.processTime = metricRegistry.timer(PROCESS_TIME_METRICNAME);
 
         // Should be set in initialize once this becomes a real plugin.
@@ -94,18 +96,26 @@ public class ElasticSearchOutput implements MessageOutput {
 
     public void writeMessageEntries(List<Map.Entry<IndexSet, Message>> messageList) throws Exception {
         if (LOG.isTraceEnabled()) {
-            final List<String> sortedIds = Ordering.natural().sortedCopy(messageList.stream()
-                    .map(entry -> entry.getValue().getId())
-                    .collect(Collectors.toList()));
-            LOG.trace("Writing message ids to [{}]: <{}>", NAME, Joiner.on(", ").join(sortedIds));
+            final String sortedIds = messageList.stream()
+                    .map(Map.Entry::getValue)
+                    .map(Message::getId)
+                    .sorted(Comparator.naturalOrder())
+                    .collect(Collectors.joining(", "));
+            LOG.trace("Writing message ids to [{}]: <{}>", NAME, sortedIds);
         }
 
         writes.mark(messageList.size());
+        final List<String> failedMessageIds;
         try (final Timer.Context ignored = processTime.time()) {
-            messages.bulkIndex(messageList);
+            failedMessageIds = messages.bulkIndex(messageList);
         }
+        failures.mark(failedMessageIds.size());
+
         for (final Map.Entry<IndexSet, Message> entry : messageList) {
-            journal.markJournalOffsetCommitted(entry.getValue().getJournalOffset());
+            final Message message = entry.getValue();
+            if (!failedMessageIds.contains(message.getId())) {
+                journal.markJournalOffsetCommitted(message.getJournalOffset());
+            }
         }
     }
 

--- a/graylog2-server/src/main/java/org/graylog2/outputs/ElasticSearchOutput.java
+++ b/graylog2-server/src/main/java/org/graylog2/outputs/ElasticSearchOutput.java
@@ -37,6 +37,7 @@ import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.stream.Collectors;
 
@@ -111,12 +112,12 @@ public class ElasticSearchOutput implements MessageOutput {
         }
         failures.mark(failedMessageIds.size());
 
-        for (final Map.Entry<IndexSet, Message> entry : messageList) {
-            final Message message = entry.getValue();
-            if (!failedMessageIds.contains(message.getId())) {
-                journal.markJournalOffsetCommitted(message.getJournalOffset());
-            }
-        }
+        final Optional<Long> offset = messageList.stream()
+            .map(Map.Entry::getValue)
+            .map(Message::getJournalOffset)
+            .max(Long::compare);
+
+        offset.ifPresent(journal::markJournalOffsetCommitted);
     }
 
     @Override


### PR DESCRIPTION
Checking the ES cluster health before flushing messages was important while using the embedded Elasticsearch client node because it would block processing until the cluster is available and healthy (YELLOW or GREEN).

After migrating to an HTTP-based Elasticsearch client, this isn't necessary anymore. The client will simply fail to index the messages without blocking.

Additionally, this changeset only marks those messages as committed, which could be successfully indexed. Before this change, all messages of a batch were marked as committed and removed from the journal, whether they've been indexed or not.