### PR TITLE
Retrying bulk indexing in case of all IOExceptions and failed http response.

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/indexer/messages/Messages.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/messages/Messages.java
@@ -47,12 +47,10 @@ import org.slf4j.LoggerFactory;
 import javax.inject.Inject;
 import javax.inject.Singleton;
 import java.io.IOException;
-import java.net.SocketTimeoutException;
 import java.util.ArrayList;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
-import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.TimeUnit;
@@ -60,7 +58,6 @@ import java.util.function.Function;
 import java.util.stream.Collectors;
 
 import static com.codahale.metrics.MetricRegistry.name;
-import static com.google.common.base.Preconditions.checkNotNull;
 
 @Singleton
 public class Messages {
@@ -74,7 +71,7 @@ public class Messages {
                 @Override
                 public <V> void onRetry(Attempt<V> attempt) {
                     if (attempt.hasException()) {
-                        LOG.error("Caught exception during bulk indexing: {}, retrying (attempt #[]).", attempt.getExceptionCause(), attempt.getAttemptNumber());
+                        LOG.error("Caught exception during bulk indexing: {}, retrying (attempt #{}).", attempt.getExceptionCause(), attempt.getAttemptNumber());
                     }
                 }
             })

--- a/graylog2-server/src/main/java/org/graylog2/indexer/messages/Messages.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/messages/Messages.java
@@ -19,7 +19,9 @@ package org.graylog2.indexer.messages;
 import com.codahale.metrics.Meter;
 import com.codahale.metrics.MetricRegistry;
 import com.github.joschi.jadconfig.util.Duration;
+import com.github.rholder.retry.Attempt;
 import com.github.rholder.retry.RetryException;
+import com.github.rholder.retry.RetryListener;
 import com.github.rholder.retry.Retryer;
 import com.github.rholder.retry.RetryerBuilder;
 import com.github.rholder.retry.WaitStrategies;
@@ -65,8 +67,17 @@ public class Messages {
     private static final Logger LOG = LoggerFactory.getLogger(Messages.class);
     private static final Duration MAX_WAIT_TIME = Duration.seconds(30L);
     private static final Retryer<BulkResult> BULK_REQUEST_RETRYER = RetryerBuilder.<BulkResult>newBuilder()
-            .retryIfException(t -> t instanceof SocketTimeoutException)
+            .retryIfException(t -> t instanceof IOException)
+            .retryIfResult((result) -> result == null || !result.isSucceeded())
             .withWaitStrategy(WaitStrategies.exponentialWait(MAX_WAIT_TIME.getQuantity(), MAX_WAIT_TIME.getUnit()))
+            .withRetryListener(new RetryListener() {
+                @Override
+                public <V> void onRetry(Attempt<V> attempt) {
+                    if (attempt.hasException()) {
+                        LOG.error("Caught exception during bulk indexing: {}, retrying (attempt #[]).", attempt.getExceptionCause(), attempt.getAttemptNumber());
+                    }
+                }
+            })
             .build();
 
     private final Meter invalidTimestampMeter;
@@ -137,15 +148,14 @@ public class Messages {
 
     private BulkResult runBulkRequest(final Bulk request, int count) {
         try {
-            return client.execute(request);
-        } catch (IOException timeoutException) {
-            LOG.debug("Bulk indexing request timed out. Retrying.", timeoutException);
-            try {
-                return BULK_REQUEST_RETRYER.call(new BulkRequestCallable(client, request));
-            } catch (ExecutionException | RetryException e) {
+            return BULK_REQUEST_RETRYER.call(() -> client.execute(request));
+        } catch (ExecutionException | RetryException e) {
+            if (e instanceof RetryException) {
+                LOG.error("Could not bulk index {} messages. Giving up after {} attempts.", count, ((RetryException) e).getNumberOfFailedAttempts());
+            } else {
                 LOG.error("Couldn't bulk index " + count + " messages.", e);
-                throw new RuntimeException(e);
             }
+            throw new RuntimeException(e);
         }
     }
 
@@ -195,20 +205,5 @@ public class Messages {
 
     public LinkedBlockingQueue<List<IndexFailure>> getIndexFailureQueue() {
         return indexFailureQueue;
-    }
-
-    private static class BulkRequestCallable implements Callable<BulkResult> {
-        private final JestClient client;
-        private final Bulk request;
-
-        BulkRequestCallable(JestClient client, Bulk request) {
-            this.client = checkNotNull(client);
-            this.request = checkNotNull(request);
-        }
-
-        @Override
-        public BulkResult call() throws Exception {
-            return client.execute(request);
-        }
     }
 }


### PR DESCRIPTION
This change modifies the retrying semantics of bulk indexing to trigger retries also if the request failed on an http level (`result.isSucceeded()` is `false`) or in case of an `IOException` which is not a `SocketTimeoutException` in case of a repeated attempt.


Created in response to the discussions in #3927.