### PR TITLE
Do not run SetIndexReadOnlyAndCalculateRangeJob if index is closed

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/indexer/SetIndexReadOnlyJob.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/SetIndexReadOnlyJob.java
@@ -62,6 +62,11 @@ public class SetIndexReadOnlyJob extends SystemJob {
 
     @Override
     public void execute() {
+        if (indices.isClosed(index)) {
+            log.debug("Not running job for closed index <{}>", index);
+            return;
+        }
+
         final Optional<IndexSet> indexSet = indexSetRegistry.getForIndex(index);
 
         if (!indexSet.isPresent()) {

--- a/graylog2-server/src/main/java/org/graylog2/indexer/indices/Indices.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/indices/Indices.java
@@ -515,6 +515,10 @@ public class Indices {
         return getClosedIndices(Collections.singleton(indexSet.getIndexWildcard()));
     }
 
+    public boolean isClosed(final String indexName) {
+        return getClosedIndices(Collections.singleton(indexName)).contains(indexName);
+    }
+
     /**
      * Retrieve the response for the <a href="https://www.elastic.co/guide/en/elasticsearch/reference/current/cat-indices.html">cat indices</a> request from Elasticsearch.
      *

--- a/graylog2-server/src/main/java/org/graylog2/indexer/indices/jobs/OptimizeIndexJob.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/indices/jobs/OptimizeIndexJob.java
@@ -59,6 +59,11 @@ public class OptimizeIndexJob extends SystemJob {
 
     @Override
     public void execute() {
+        if (indices.isClosed(index)) {
+            LOG.debug("Not running job for closed index <{}>", index);
+            return;
+        }
+
         String msg = "Optimizing index <" + index + ">.";
         activityWriter.write(new Activity(msg, OptimizeIndexJob.class));
         LOG.info(msg);


### PR DESCRIPTION
Also add that check to other jobs that could fail if an index is already closed.

Fixes #3909