### PR TITLE
Avoid noisy stack traces when Elasticsearch is not available

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/alerts/AlertScanner.java
+++ b/graylog2-server/src/main/java/org/graylog2/alerts/AlertScanner.java
@@ -90,7 +90,12 @@ public class AlertScanner {
                 }
             }
         } catch (Exception e) {
-            LOG.error("Skipping alert check that threw an exception.", e);
+            if (LOG.isDebugEnabled()) {
+                LOG.error("Skipping alert check <{}/{}>", alertCondition.getTitle(), alertCondition.getId(), e);
+            } else {
+                LOG.error("Skipping alert check <{}/{}>: {} ({})", alertCondition.getTitle(),
+                        alertCondition.getId(), e.getMessage(), e.getClass().getSimpleName());
+            }
         }
         return false;
     }


### PR DESCRIPTION
Only log stack traces if debug logging is enabled.

Closes #3861 

Especially `Cluster#isConnectec()` should not log anything if Elasticsearch is not reachable.

A starting/running Graylog server without Elasticsearch logs only this instead of pages of stack traces now.

```
2017-06-23 14:32:47,783 ERROR: org.graylog2.indexer.cluster.Cluster - Couldn't read cluster health for indices [graylog_*, emails_*, yolo_*] (Could not connect to http://127.0.0.1:9200)
2017-06-23 14:32:47,783 INFO : org.graylog2.periodical.IndexerClusterCheckerThread - Indexer not fully initialized yet. Skipping periodic cluster check.
2017-06-23 14:33:17,788 ERROR: org.graylog2.indexer.cluster.Cluster - Couldn't read cluster health for indices [graylog_*, emails_*, yolo_*] (Could not connect to http://127.0.0.1:9200)
2017-06-23 14:33:17,788 INFO : org.graylog2.periodical.IndexerClusterCheckerThread - Indexer not fully initialized yet. Skipping periodic cluster check.
2017-06-23 14:33:17,942 WARN : org.graylog2.migrations.V20161130141500_DefaultStreamRecalcIndexRanges - Interrupted or timed out waiting for Elasticsearch cluster, checking again.
2017-06-23 14:33:27,804 ERROR: org.graylog2.alerts.AlertScanner - Skipping alert check <yolo/2fa6a415-ce0c-4a36-accc-dd9519eb06d9>: Unable to perform count query. (ElasticsearchException)
2017-06-23 14:33:47,786 ERROR: org.graylog2.indexer.cluster.Cluster - Couldn't read cluster health for indices [graylog_*, emails_*, yolo_*] (Could not connect to http://127.0.0.1:9200)
2017-06-23 14:33:47,787 INFO : org.graylog2.periodical.IndexerClusterCheckerThread - Indexer not fully initialized yet. Skipping periodic cluster check.
2017-06-23 14:34:17,787 ERROR: org.graylog2.indexer.cluster.Cluster - Couldn't read cluster health for indices [graylog_*, emails_*, yolo_*] (Could not connect to http://127.0.0.1:9200)
2017-06-23 14:34:17,787 INFO : org.graylog2.periodical.IndexerClusterCheckerThread - Indexer not fully initialized yet. Skipping periodic cluster check.
```