### PR TITLE
Always send a complete user object when updating a user or role

### DIFF
--- a/graylog2-web-interface/src/components/users/EditRolesForm.jsx
+++ b/graylog2-web-interface/src/components/users/EditRolesForm.jsx
@@ -4,6 +4,7 @@ import Routes from 'routing/Routes';
 
 import { Input } from 'components/bootstrap';
 import UserNotification from 'util/UserNotification';
+import ObjectUtils from 'util/ObjectUtils';
 
 import StoreProvider from 'injection/StoreProvider';
 const RolesStore = StoreProvider.getStore('Roles');
@@ -33,7 +34,9 @@ const EditRolesForm = React.createClass({
     evt.preventDefault();
     if (confirm(`Really update roles for "${this.props.user.username}"?`)) {
       const roles = this.refs.roles.getValue().filter(value => value !== '');
-      UsersStore.updateRoles(this.props.user.username, roles).then(() => {
+      const user = ObjectUtils.clone(this.props.user);
+      user.roles = roles;
+      UsersStore.update(this.props.user.username, user).then(() => {
         UserNotification.success('Roles updated successfully.', 'Success!');
         this.props.history.replaceState(null, Routes.SYSTEM.AUTHENTICATION.USERS.LIST);
       }, () => {

--- a/graylog2-web-interface/src/components/users/UserForm.jsx
+++ b/graylog2-web-interface/src/components/users/UserForm.jsx
@@ -30,7 +30,6 @@ const UserForm = React.createClass({
     return {
       streams: undefined,
       dashboards: undefined,
-      roles: undefined,
       user: this._getUserStateFromProps(this.props),
     };
   },
@@ -62,6 +61,7 @@ const UserForm = React.createClass({
       permissions: props.user.permissions,
       read_only: props.user.read_only,
       external: props.user.external,
+      roles: props.user.roles,
     };
   },
 

--- a/graylog2-web-interface/src/stores/users/UsersStore.ts
+++ b/graylog2-web-interface/src/stores/users/UsersStore.ts
@@ -84,13 +84,6 @@ export const UsersStore = {
     return promise;
   },
 
-  updateRoles(username: string, roles: string[]): void {
-    const url = URLUtils.qualifyUrl(ApiRoutes.UsersApiController.update(encodeURIComponent(username)).url);
-    const promise = fetch('PUT', url, {roles: roles});
-
-    return promise;
-  },
-
   changePassword(username: string, request: ChangePasswordRequest): void {
     const url = URLUtils.qualifyUrl(ApiRoutes.UsersApiController.changePassword(encodeURIComponent(username)).url);
     const promise = fetch('PUT', url, request);


### PR DESCRIPTION
Previously, updating the user data sent a null roles field and updating a role sent only the list of roles.

Remove now unused `UsersStore#updateRoles()`.

Fixes #3918
