### PR TITLE
Upgrade to gelfclient 1.4.2.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -95,7 +95,7 @@
         <drools.version>6.5.0.Final</drools.version>
         <elasticsearch.version>2.4.4</elasticsearch.version>
         <jest.version>2.4.5+jackson</jest.version>
-        <gelfclient.version>1.4.1</gelfclient.version>
+        <gelfclient.version>1.4.2.1</gelfclient.version>
         <grok.version>0.1.7-graylog</grok.version>
         <guava-retrying.version>2.0.0</guava-retrying.version>
         <guava.version>21.0</guava.version>


### PR DESCRIPTION
Older versions of gelfclient didn't handle boolean values correctly and only generated the Java type string (such as "[B@1234abc") instead of `true` or `false`.

Refs Graylog2/gelfclient#29