### PR TITLE
Fail fast and loud for invalid GELF messages

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/inputs/codecs/GelfCodec.java
+++ b/graylog2-server/src/main/java/org/graylog2/inputs/codecs/GelfCodec.java
@@ -228,13 +228,13 @@ public class GelfCodec extends AbstractCodec {
         final JsonNode hostNode = jsonNode.path("host");
         if (hostNode.isMissingNode()) {
             log.warn(prefix + "is missing mandatory \"host\" field.");
-            return;
-        }
-        if (!hostNode.isTextual()) {
-            throw new IllegalArgumentException(prefix + "has invalid \"host\": " + hostNode.asText());
-        }
-        if (StringUtils.isBlank(hostNode.asText())) {
-            throw new IllegalArgumentException(prefix + "has empty mandatory \"host\" field.");
+        } else {
+            if (!hostNode.isTextual()) {
+                throw new IllegalArgumentException(prefix + "has invalid \"host\": " + hostNode.asText());
+            }
+            if (StringUtils.isBlank(hostNode.asText())) {
+                throw new IllegalArgumentException(prefix + "has empty mandatory \"host\" field.");
+            }
         }
 
         final JsonNode shortMessageNode = jsonNode.path("short_message");

--- a/graylog2-server/src/main/java/org/graylog2/inputs/codecs/GelfCodec.java
+++ b/graylog2-server/src/main/java/org/graylog2/inputs/codecs/GelfCodec.java
@@ -221,14 +221,6 @@ public class GelfCodec extends AbstractCodec {
     }
 
     private void validateGELFMessage(JsonNode jsonNode) {
-        final JsonNode versionNode = jsonNode.path("version");
-        if (versionNode.isMissingNode()) {
-            throw new IllegalArgumentException("GELF message is missing mandatory \"version\" field.");
-        }
-        final String version = versionNode.asText();
-        if (!"1.1".equals(version)) {
-            throw new IllegalArgumentException("GELF message has invalid \"version\": " + version);
-        }
         final JsonNode hostNode = jsonNode.path("host");
         if (hostNode.isMissingNode()) {
             throw new IllegalArgumentException("GELF message is missing mandatory \"host\" field.");

--- a/graylog2-server/src/main/java/org/graylog2/inputs/codecs/GelfCodec.java
+++ b/graylog2-server/src/main/java/org/graylog2/inputs/codecs/GelfCodec.java
@@ -16,6 +16,7 @@
  */
 package org.graylog2.inputs.codecs;
 
+import com.eaio.uuid.UUID;
 import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -24,6 +25,7 @@ import org.apache.commons.lang3.StringUtils;
 import org.graylog2.inputs.codecs.gelf.GELFMessage;
 import org.graylog2.inputs.transports.TcpTransport;
 import org.graylog2.plugin.Message;
+import org.graylog2.plugin.ResolvableInetSocketAddress;
 import org.graylog2.plugin.Tools;
 import org.graylog2.plugin.configuration.Configuration;
 import org.graylog2.plugin.configuration.ConfigurationRequest;
@@ -124,7 +126,7 @@ public class GelfCodec extends AbstractCodec {
             throw new IllegalStateException("JSON is null/could not be parsed (invalid JSON)", e);
         }
 
-        validateGELFMessage(node);
+        validateGELFMessage(node, rawMessage.getId(), rawMessage.getRemoteAddress());
 
         // Timestamp.
         final double messageTimestamp = doubleValue(node, Message.FIELD_TIMESTAMP);
@@ -220,30 +222,44 @@ public class GelfCodec extends AbstractCodec {
         return message;
     }
 
-    private void validateGELFMessage(JsonNode jsonNode) {
+    private void validateGELFMessage(JsonNode jsonNode, UUID id, ResolvableInetSocketAddress remoteAddress) {
+        final String prefix = "GELF message <" + id + "> " + (remoteAddress == null ? "" : "(received from <" + remoteAddress + ">) ");
+
         final JsonNode hostNode = jsonNode.path("host");
         if (hostNode.isMissingNode()) {
-            throw new IllegalArgumentException("GELF message is missing mandatory \"host\" field.");
+            log.warn(prefix + "is missing mandatory \"host\" field.");
+            return;
         }
         if (!hostNode.isTextual()) {
-            throw new IllegalArgumentException("GELF message has invalid \"host\": " + hostNode.asText());
+            throw new IllegalArgumentException(prefix + "has invalid \"host\": " + hostNode.asText());
         }
         if (StringUtils.isBlank(hostNode.asText())) {
-            throw new IllegalArgumentException("GELF message has empty mandatory \"host\" field.");
+            throw new IllegalArgumentException(prefix + "has empty mandatory \"host\" field.");
         }
+
         final JsonNode shortMessageNode = jsonNode.path("short_message");
-        if (shortMessageNode.isMissingNode()) {
-            throw new IllegalArgumentException("GELF message is missing mandatory \"short_message\" field.");
+        final JsonNode messageNode = jsonNode.path("message");
+        if (!shortMessageNode.isMissingNode()) {
+            if (!shortMessageNode.isTextual()) {
+                throw new IllegalArgumentException(prefix + "has invalid \"short_message\": " + shortMessageNode.asText());
+            }
+            if (StringUtils.isBlank(shortMessageNode.asText())) {
+                throw new IllegalArgumentException(prefix + "has empty mandatory \"short_message\" field.");
+            }
+        } else if (!messageNode.isMissingNode()) {
+            if (!messageNode.isTextual()) {
+                throw new IllegalArgumentException(prefix + "has invalid \"message\": " + messageNode.asText());
+            }
+            if (StringUtils.isBlank(messageNode.asText())) {
+                throw new IllegalArgumentException(prefix + "has empty mandatory \"message\" field.");
+            }
+        } else {
+            throw new IllegalArgumentException(prefix + "is missing mandatory \"short_message\" or \"message\" field.");
         }
-        if (!shortMessageNode.isTextual()) {
-            throw new IllegalArgumentException("GELF message has invalid \"short_message\": " + shortMessageNode.asText());
-        }
-        if (StringUtils.isBlank(shortMessageNode.asText())) {
-            throw new IllegalArgumentException("GELF message has empty mandatory \"short_message\" field.");
-        }
+
         final JsonNode timestampNode = jsonNode.path("timestamp");
         if (timestampNode.isValueNode() && !timestampNode.isNumber()) {
-            throw new IllegalArgumentException("GELF message has invalid \"timestamp\": " + timestampNode.asText());
+            throw new IllegalArgumentException(prefix + "has invalid \"timestamp\": " + timestampNode.asText());
         }
     }
 

--- a/graylog2-server/src/test/java/org/graylog2/inputs/codecs/GelfCodecTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/inputs/codecs/GelfCodecTest.java
@@ -148,4 +148,167 @@ public class GelfCodecTest {
     public void getAggregatorReturnsGelfChunkAggregator() throws Exception {
         assertThat(codec.getAggregator()).isSameAs(aggregator);
     }
+
+    @Test
+    public void decodeFailsWithoutVersion() throws Exception {
+        final String json = "{"
+                + "\"host\": \"example.org\","
+                + "\"short_message\": \"A short message that helps you identify what is going on\""
+                + "}";
+
+        final RawMessage rawMessage = new RawMessage(json.getBytes(StandardCharsets.UTF_8));
+        expectedException.expect(IllegalArgumentException.class);
+        expectedException.expectMessage("GELF message is missing mandatory \"version\" field.");
+
+        codec.decode(rawMessage);
+    }
+
+    @Test
+    public void decodeFailsWithWrongVersion() throws Exception {
+        final String json = "{"
+                + "\"version\": \"Foobar\","
+                + "\"host\": \"example.org\","
+                + "\"short_message\": \"A short message that helps you identify what is going on\""
+                + "}";
+
+        final RawMessage rawMessage = new RawMessage(json.getBytes(StandardCharsets.UTF_8));
+        expectedException.expect(IllegalArgumentException.class);
+        expectedException.expectMessage("GELF message has invalid \"version\": Foobar");
+
+        codec.decode(rawMessage);
+    }
+
+    @Test
+    public void decodeFailsWithoutHost() throws Exception {
+        final String json = "{"
+                + "\"version\": \"1.1\","
+                + "\"short_message\": \"A short message that helps you identify what is going on\""
+                + "}";
+
+        final RawMessage rawMessage = new RawMessage(json.getBytes(StandardCharsets.UTF_8));
+        expectedException.expect(IllegalArgumentException.class);
+        expectedException.expectMessage("GELF message is missing mandatory \"host\" field.");
+
+        codec.decode(rawMessage);
+    }
+
+    @Test
+    public void decodeFailsWithWrongTypeForHost() throws Exception {
+        final String json = "{"
+                + "\"version\": \"1.1\","
+                + "\"host\": 42,"
+                + "\"short_message\": \"A short message that helps you identify what is going on\""
+                + "}";
+
+        final RawMessage rawMessage = new RawMessage(json.getBytes(StandardCharsets.UTF_8));
+        expectedException.expect(IllegalArgumentException.class);
+        expectedException.expectMessage("GELF message has invalid \"host\": 42");
+
+        codec.decode(rawMessage);
+    }
+
+    @Test
+    public void decodeFailsWithEmptyHost() throws Exception {
+        final String json = "{"
+                + "\"version\": \"1.1\","
+                + "\"host\": \"\","
+                + "\"short_message\": \"A short message that helps you identify what is going on\""
+                + "}";
+
+        final RawMessage rawMessage = new RawMessage(json.getBytes(StandardCharsets.UTF_8));
+        expectedException.expect(IllegalArgumentException.class);
+        expectedException.expectMessage("GELF message has empty mandatory \"host\" field.");
+
+        codec.decode(rawMessage);
+    }
+
+    @Test
+    public void decodeFailsWithBlankHost() throws Exception {
+        final String json = "{"
+                + "\"version\": \"1.1\","
+                + "\"host\": \"      \","
+                + "\"short_message\": \"A short message that helps you identify what is going on\""
+                + "}";
+
+        final RawMessage rawMessage = new RawMessage(json.getBytes(StandardCharsets.UTF_8));
+        expectedException.expect(IllegalArgumentException.class);
+        expectedException.expectMessage("GELF message has empty mandatory \"host\" field.");
+
+        codec.decode(rawMessage);
+    }
+
+    @Test
+    public void decodeFailsWithoutShortMessage() throws Exception {
+        final String json = "{"
+                + "\"version\": \"1.1\","
+                + "\"host\": \"example.org\""
+                + "}";
+
+        final RawMessage rawMessage = new RawMessage(json.getBytes(StandardCharsets.UTF_8));
+        expectedException.expect(IllegalArgumentException.class);
+        expectedException.expectMessage("GELF message is missing mandatory \"short_message\" field.");
+
+        codec.decode(rawMessage);
+    }
+
+    @Test
+    public void decodeFailsWithWrongTypeForShortMessage() throws Exception {
+        final String json = "{"
+                + "\"version\": \"1.1\","
+                + "\"host\": \"example.org\","
+                + "\"short_message\": 42"
+                + "}";
+
+        final RawMessage rawMessage = new RawMessage(json.getBytes(StandardCharsets.UTF_8));
+        expectedException.expect(IllegalArgumentException.class);
+        expectedException.expectMessage("GELF message has invalid \"short_message\": 42");
+
+        codec.decode(rawMessage);
+    }
+
+    @Test
+    public void decodeFailsWithEmptyShortMessage() throws Exception {
+        final String json = "{"
+                + "\"version\": \"1.1\","
+                + "\"host\": \"example.org\","
+                + "\"short_message\": \"\""
+                + "}";
+
+        final RawMessage rawMessage = new RawMessage(json.getBytes(StandardCharsets.UTF_8));
+        expectedException.expect(IllegalArgumentException.class);
+        expectedException.expectMessage("GELF message has empty mandatory \"short_message\" field.");
+
+        codec.decode(rawMessage);
+    }
+
+    @Test
+    public void decodeFailsWithBlankShortMessage() throws Exception {
+        final String json = "{"
+                + "\"version\": \"1.1\","
+                + "\"host\": \"example.org\","
+                + "\"short_message\": \"     \""
+                + "}";
+
+        final RawMessage rawMessage = new RawMessage(json.getBytes(StandardCharsets.UTF_8));
+        expectedException.expect(IllegalArgumentException.class);
+        expectedException.expectMessage("GELF message has empty mandatory \"short_message\" field.");
+
+        codec.decode(rawMessage);
+    }
+
+    @Test
+    public void decodeFailsWithWrongTypeForTimestamp() throws Exception {
+        final String json = "{"
+                + "\"version\": \"1.1\","
+                + "\"host\": \"example.org\","
+                + "\"short_message\": \"A short message that helps you identify what is going on\","
+                + "\"timestamp\": \"Foobar\""
+                + "}";
+
+        final RawMessage rawMessage = new RawMessage(json.getBytes(StandardCharsets.UTF_8));
+        expectedException.expect(IllegalArgumentException.class);
+        expectedException.expectMessage("GELF message has invalid \"timestamp\": Foobar");
+
+        codec.decode(rawMessage);
+    }
 }

--- a/graylog2-server/src/test/java/org/graylog2/inputs/codecs/GelfCodecTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/inputs/codecs/GelfCodecTest.java
@@ -355,4 +355,10 @@ public class GelfCodecTest {
                 .withNoCause()
                 .withMessageMatching("GELF message <[0-9a-f-]+> \\(received from <198\\.51\\.100\\.42:24783>\\) is missing mandatory \"short_message\" or \"message\" field.");
     }
+
+    @Test
+    public void decodeSucceedsWithMinimalMessages() throws Exception {
+        assertThat(codec.decode(new RawMessage("{\"short_message\":\"0\"}".getBytes(StandardCharsets.UTF_8)))).isNotNull();
+        assertThat(codec.decode(new RawMessage("{\"message\":\"0\"}".getBytes(StandardCharsets.UTF_8)))).isNotNull();
+    }
 }

--- a/graylog2-server/src/test/java/org/graylog2/inputs/codecs/GelfCodecTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/inputs/codecs/GelfCodecTest.java
@@ -150,35 +150,6 @@ public class GelfCodecTest {
     }
 
     @Test
-    public void decodeFailsWithoutVersion() throws Exception {
-        final String json = "{"
-                + "\"host\": \"example.org\","
-                + "\"short_message\": \"A short message that helps you identify what is going on\""
-                + "}";
-
-        final RawMessage rawMessage = new RawMessage(json.getBytes(StandardCharsets.UTF_8));
-        expectedException.expect(IllegalArgumentException.class);
-        expectedException.expectMessage("GELF message is missing mandatory \"version\" field.");
-
-        codec.decode(rawMessage);
-    }
-
-    @Test
-    public void decodeFailsWithWrongVersion() throws Exception {
-        final String json = "{"
-                + "\"version\": \"Foobar\","
-                + "\"host\": \"example.org\","
-                + "\"short_message\": \"A short message that helps you identify what is going on\""
-                + "}";
-
-        final RawMessage rawMessage = new RawMessage(json.getBytes(StandardCharsets.UTF_8));
-        expectedException.expect(IllegalArgumentException.class);
-        expectedException.expectMessage("GELF message has invalid \"version\": Foobar");
-
-        codec.decode(rawMessage);
-    }
-
-    @Test
     public void decodeFailsWithoutHost() throws Exception {
         final String json = "{"
                 + "\"version\": \"1.1\","


### PR DESCRIPTION
Instead of waiting for a later stage and "silently" dropping (logged on DEBUG)
invalid messages, `GelfCodec` now actively checks for the existence and validity
of mandatory GELF message fields (such as "version", "host", "short_message", and
"timestamp", according to the GELF spec).

Refs http://docs.graylog.org/en/2.2/pages/gelf.html
Fixes #3970