### PR TITLE
Revert "Prevent useless session validation when no id or username is present. (#3634)"

### DIFF
--- a/graylog2-web-interface/src/stores/sessions/SessionStore.js
+++ b/graylog2-web-interface/src/stores/sessions/SessionStore.js
@@ -48,9 +48,6 @@ const SessionStore = Reflux.createStore({
   validate() {
     const sessionId = Store.get('sessionId');
     const username = Store.get('username');
-    if (sessionId === undefined || username === undefined) {
-      return;
-    }
     this.validatingSession = true;
     this._propagateState();
     this._validateSession(sessionId)


### PR DESCRIPTION
This reverts commit c3983db5dcffa6252421b697b6f6ddf91ee880bb.

The SSO plugin relies on validation of the session to be able to skip the login form and log in the user automatically.

Fixes #3948
