### PR TITLE
Add support for boolean values in GelfCodec

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/inputs/codecs/GelfCodec.java
+++ b/graylog2-server/src/main/java/org/graylog2/inputs/codecs/GelfCodec.java
@@ -207,6 +207,8 @@ public class GelfCodec extends AbstractCodec {
                 continue;
             } else if (value.isTextual()) {
                 fieldValue = value.asText();
+            } else if (value.isBoolean()) {
+                fieldValue = value.asBoolean();
             } else {
                 log.debug("Field [{}] has unknown value type. Skipping.", key);
                 continue;

--- a/graylog2-server/src/test/java/org/graylog2/inputs/codecs/GelfCodecTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/inputs/codecs/GelfCodecTest.java
@@ -94,6 +94,34 @@ public class GelfCodecTest {
     }
 
     @Test
+    public void decodeSupportsAllDataTypes() throws Exception {
+        final String json = "{"
+                + "\"version\": \"1.1\","
+                + "\"host\": \"example.org\","
+                + "\"short_message\": \"A short message that helps you identify what is going on\","
+                + "\"_boolean\": true,"
+                + "\"_long\": 42,"
+                + "\"_double\": 3.14,"
+                + "\"_string\": \"Foobar\","
+                + "\"_map\": {\"key\":\"value\"},"
+                + "\"_array\": [\"val1\",\"val2\"]"
+                + "}";
+
+        final RawMessage rawMessage = new RawMessage(json.getBytes(StandardCharsets.UTF_8));
+        final Message message = codec.decode(rawMessage);
+
+        assertThat(message).isNotNull();
+        assertThat(message.getField("boolean")).isEqualTo(true);
+        assertThat(message.getField("long")).isEqualTo(42L);
+        assertThat(message.getField("double")).isEqualTo(3.14D);
+        assertThat(message.getField("string")).isEqualTo("Foobar");
+
+        // Container nodes are converted into their JSON string equivalent
+        assertThat(message.getField("map")).isEqualTo("{\"key\":\"value\"}");
+        assertThat(message.getField("array")).isEqualTo("[\"val1\",\"val2\"]");
+    }
+
+    @Test
     public void decodeBuildsValidMessageObject() throws Exception {
         final String json = "{"
                 + "\"version\": \"1.1\","


### PR DESCRIPTION
This PR should serve as a base for discussion for extending the official GELF specification to support boolean values.

`GelfCodec` (and the GELF message format as specified by http://docs.graylog.org/en/2.2/pages/gelf.html) currently don't support boolean values.

Since the payload format of GELF messages is just JSON with some mandatory fields, there's no reason *not* to support booleans.

Graylog itself has no problems whatsoever in processing boolean values and other message inputs, as well as extractors and the processing pipelines, already do support boolean values.