### PR TITLE
Mark Message class as not thread-safe

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/plugin/Message.java
+++ b/graylog2-server/src/main/java/org/graylog2/plugin/Message.java
@@ -35,6 +35,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import javax.annotation.Nonnull;
+import javax.annotation.concurrent.NotThreadSafe;
 import java.net.InetAddress;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -54,6 +55,7 @@ import static org.graylog2.plugin.Tools.ES_DATE_FORMAT_FORMATTER;
 import static org.graylog2.plugin.Tools.buildElasticSearchTimeFormat;
 import static org.joda.time.DateTimeZone.UTC;
 
+@NotThreadSafe
 public class Message implements Messages {
     private static final Logger LOG = LoggerFactory.getLogger(Message.class);
 


### PR DESCRIPTION
The `Message` class is *not* thread-safe and shouldn't be concurrently modified (i. e. `Message#addField(…)`).

This PR doesn't solve that problem, but it at least marks the class as not thread-safe to begin with.

Refs #3876