### PR TITLE
Keep remote address in NettyTransport with message aggregation

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/plugin/inputs/transports/NettyTransport.java
+++ b/graylog2-server/src/main/java/org/graylog2/plugin/inputs/transports/NettyTransport.java
@@ -305,7 +305,7 @@ public abstract class NettyTransport implements Transport {
                 final ChannelBuffer completeMessage = result.getMessage();
                 if (completeMessage != null) {
                     log.debug("Message aggregation completion, forwarding {}", completeMessage);
-                    fireMessageReceived(ctx, completeMessage);
+                    fireMessageReceived(ctx, completeMessage, e.getRemoteAddress());
                 } else if (result.isValid()) {
                     log.debug("More chunks necessary to complete this message");
                 } else {
@@ -314,7 +314,7 @@ public abstract class NettyTransport implements Transport {
                 }
             } else {
                 log.debug("Could not handle netty message {}, sending further upstream.", e);
-                fireMessageReceived(ctx, message);
+                fireMessageReceived(ctx, message, e.getRemoteAddress());
             }
         }
     }


### PR DESCRIPTION
The `NettyTransport.MessageAggregationHandler#messageReceived()` method
failed to pass the original source address of the message to the following
handlers, so that any aggregating input (such as the GELF UDP input) lost
the information.

Fixes #3980, refs #3982

(cherry picked from commit 35cea152ff0eebc0dbcefb4873155962c8fb960a)