### PR TITLE
Fix number parsing in Indices#getStoreSiztInBytes() (#4008)

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/indexer/indices/Indices.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/indices/Indices.java
@@ -571,7 +571,7 @@ public class Indices {
                 .path("primaries")
                 .path("store")
                 .path("size_in_bytes");
-        return Optional.of(sizeInBytes).filter(JsonNode::isLong).map(JsonNode::asLong);
+        return Optional.of(sizeInBytes).filter(JsonNode::isNumber).map(JsonNode::asLong);
     }
 
     public Set<IndexStatistics> getIndicesStats(final IndexSet indexSet) {


### PR DESCRIPTION
The size might be an integer instead of a long

Fixes #3997
(cherry picked from commit b29b1031e0b70c79278d36990443b57a5f9d64ab)
