### PR TITLE
Return NaN for non-present fields of FieldStatsResult.

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/indexer/results/FieldStatsResult.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/results/FieldStatsResult.java
@@ -45,7 +45,7 @@ public class FieldStatsResult extends IndexQueryResult {
                             long tookMs) {
         super(query, source, tookMs);
         this.count = getValueCount(valueCountAggregation, extendedStatsAggregation);
-        this.cardinality = cardinalityAggregation == null ? Long.MIN_VALUE : cardinalityAggregation.getCardinality();
+        this.cardinality = cardinalityAggregation == null || cardinalityAggregation.getCardinality() == null ? Long.MIN_VALUE : cardinalityAggregation.getCardinality();
 
         if (extendedStatsAggregation != null) {
             sum = Optional.ofNullable(extendedStatsAggregation.getSum()).orElse(Double.NaN);
@@ -83,9 +83,9 @@ public class FieldStatsResult extends IndexQueryResult {
     }
 
     private long getValueCount(ValueCountAggregation valueCountAggregation, ExtendedStatsAggregation extendedStatsAggregation) {
-        if (valueCountAggregation != null) {
+        if (valueCountAggregation != null && valueCountAggregation.getValueCount() != null) {
             return valueCountAggregation.getValueCount();
-        } else if (extendedStatsAggregation != null) {
+        } else if (extendedStatsAggregation != null && extendedStatsAggregation.getCount() != null) {
             return extendedStatsAggregation.getCount();
         }
         return Long.MIN_VALUE;

--- a/graylog2-server/src/main/java/org/graylog2/indexer/results/FieldStatsResult.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/results/FieldStatsResult.java
@@ -21,6 +21,7 @@ import io.searchbox.core.search.aggregation.ExtendedStatsAggregation;
 import io.searchbox.core.search.aggregation.ValueCountAggregation;
 
 import java.util.List;
+import java.util.Optional;
 
 public class FieldStatsResult extends IndexQueryResult {
     private List<ResultMessage> searchHits;
@@ -47,13 +48,13 @@ public class FieldStatsResult extends IndexQueryResult {
         this.cardinality = cardinalityAggregation == null ? Long.MIN_VALUE : cardinalityAggregation.getCardinality();
 
         if (extendedStatsAggregation != null) {
-            sum = extendedStatsAggregation.getSum();
-            sumOfSquares = extendedStatsAggregation.getSumOfSquares();
-            mean = extendedStatsAggregation.getAvg();
-            min = extendedStatsAggregation.getMin();
-            max = extendedStatsAggregation.getMax();
-            variance = extendedStatsAggregation.getVariance();
-            stdDeviation = extendedStatsAggregation.getStdDeviation();
+            sum = Optional.ofNullable(extendedStatsAggregation.getSum()).orElse(Double.NaN);
+            sumOfSquares = Optional.ofNullable(extendedStatsAggregation.getSumOfSquares()).orElse(Double.NaN);
+            mean = Optional.ofNullable(extendedStatsAggregation.getAvg()).orElse(Double.NaN);
+            min = Optional.ofNullable(extendedStatsAggregation.getMin()).orElse(Double.NaN);
+            max = Optional.ofNullable(extendedStatsAggregation.getMax()).orElse(Double.NaN);
+            variance = Optional.ofNullable(extendedStatsAggregation.getVariance()).orElse(Double.NaN);
+            stdDeviation = Optional.ofNullable(extendedStatsAggregation.getStdDeviation()).orElse(Double.NaN);
         } else {
             sum = Double.NaN;
             sumOfSquares = Double.NaN;

--- a/graylog2-server/src/main/java/org/graylog2/indexer/results/FieldStatsResult.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/results/FieldStatsResult.java
@@ -21,7 +21,6 @@ import io.searchbox.core.search.aggregation.ExtendedStatsAggregation;
 import io.searchbox.core.search.aggregation.ValueCountAggregation;
 
 import java.util.List;
-import java.util.Optional;
 
 public class FieldStatsResult extends IndexQueryResult {
     private List<ResultMessage> searchHits;
@@ -48,13 +47,13 @@ public class FieldStatsResult extends IndexQueryResult {
         this.cardinality = cardinalityAggregation == null || cardinalityAggregation.getCardinality() == null ? Long.MIN_VALUE : cardinalityAggregation.getCardinality();
 
         if (extendedStatsAggregation != null) {
-            sum = Optional.ofNullable(extendedStatsAggregation.getSum()).orElse(Double.NaN);
-            sumOfSquares = Optional.ofNullable(extendedStatsAggregation.getSumOfSquares()).orElse(Double.NaN);
-            mean = Optional.ofNullable(extendedStatsAggregation.getAvg()).orElse(Double.NaN);
-            min = Optional.ofNullable(extendedStatsAggregation.getMin()).orElse(Double.NaN);
-            max = Optional.ofNullable(extendedStatsAggregation.getMax()).orElse(Double.NaN);
-            variance = Optional.ofNullable(extendedStatsAggregation.getVariance()).orElse(Double.NaN);
-            stdDeviation = Optional.ofNullable(extendedStatsAggregation.getStdDeviation()).orElse(Double.NaN);
+            sum = extendedStatsAggregation.getSum() != null ? extendedStatsAggregation.getSum() : Double.NaN;
+            sumOfSquares = extendedStatsAggregation.getSumOfSquares() != null ? extendedStatsAggregation.getSumOfSquares() : Double.NaN;
+            mean = extendedStatsAggregation.getAvg() != null ? extendedStatsAggregation.getAvg() : Double.NaN;
+            min = extendedStatsAggregation.getMin() != null ? extendedStatsAggregation.getMin() : Double.NaN;
+            max = extendedStatsAggregation.getMax() != null ? extendedStatsAggregation.getMax() : Double.NaN;
+            variance = extendedStatsAggregation.getVariance() != null ? extendedStatsAggregation.getVariance() : Double.NaN;
+            stdDeviation = extendedStatsAggregation.getStdDeviation() != null ? extendedStatsAggregation.getStdDeviation() : Double.NaN;
         } else {
             sum = Double.NaN;
             sumOfSquares = Double.NaN;

--- a/graylog2-server/src/test/java/org/graylog2/indexer/results/FieldStatsResultTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/indexer/results/FieldStatsResultTest.java
@@ -1,3 +1,19 @@
+/**
+ * This file is part of Graylog.
+ *
+ * Graylog is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package org.graylog2.indexer.results;
 
 import io.searchbox.core.search.aggregation.ExtendedStatsAggregation;

--- a/graylog2-server/src/test/java/org/graylog2/indexer/results/FieldStatsResultTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/indexer/results/FieldStatsResultTest.java
@@ -1,0 +1,47 @@
+package org.graylog2.indexer.results;
+
+import edu.emory.mathcs.backport.java.util.Collections;
+import io.searchbox.core.search.aggregation.CardinalityAggregation;
+import io.searchbox.core.search.aggregation.ExtendedStatsAggregation;
+import io.searchbox.core.search.aggregation.ValueCountAggregation;
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class FieldStatsResultTest {
+    @Test
+    public void worksForNullFieldsInAggregationResults() throws Exception {
+        final ExtendedStatsAggregation extendedStatsAggregation = mock(ExtendedStatsAggregation.class);
+
+        when(extendedStatsAggregation.getCount()).thenReturn(null);
+        when(extendedStatsAggregation.getSum()).thenReturn(null);
+        when(extendedStatsAggregation.getSumOfSquares()).thenReturn(null);
+        when(extendedStatsAggregation.getAvg()).thenReturn(null);
+        when(extendedStatsAggregation.getMin()).thenReturn(null);
+        when(extendedStatsAggregation.getMax()).thenReturn(null);
+        when(extendedStatsAggregation.getVariance()).thenReturn(null);
+        when(extendedStatsAggregation.getStdDeviation()).thenReturn(null);
+
+        final FieldStatsResult result = new FieldStatsResult(null,
+                extendedStatsAggregation,
+                null,
+                Collections.emptyList(),
+                null,
+                null,
+                0);
+
+        assertThat(result).isNotNull();
+        assertThat(result.getSum()).isEqualTo(Double.NaN);
+        assertThat(result.getSumOfSquares()).isEqualTo(Double.NaN);
+        assertThat(result.getMean()).isEqualTo(Double.NaN);
+        assertThat(result.getMin()).isEqualTo(Double.NaN);
+        assertThat(result.getMax()).isEqualTo(Double.NaN);
+        assertThat(result.getVariance()).isEqualTo(Double.NaN);
+        assertThat(result.getStdDeviation()).isEqualTo(Double.NaN);
+
+        assertThat(result.getCount()).isEqualTo(Long.MIN_VALUE);
+        assertThat(result.getCardinality()).isEqualTo(Long.MIN_VALUE);
+    }
+}

--- a/graylog2-server/src/test/java/org/graylog2/indexer/results/FieldStatsResultTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/indexer/results/FieldStatsResultTest.java
@@ -1,10 +1,9 @@
 package org.graylog2.indexer.results;
 
-import edu.emory.mathcs.backport.java.util.Collections;
-import io.searchbox.core.search.aggregation.CardinalityAggregation;
 import io.searchbox.core.search.aggregation.ExtendedStatsAggregation;
-import io.searchbox.core.search.aggregation.ValueCountAggregation;
 import org.junit.Test;
+
+import java.util.Collections;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;


### PR DESCRIPTION
Before this change, an ExtendedStatsAggregation could include an
arbitrary number of fields that are null. Assigning them a non-boxed
field type leads to an NPE and a 500 is being returned to the caller
when the result of a extended field stats widget is requested.

This change properly assigns a valid value for those fields, so a result
(albeit possibly containing NaN for one or more fields) is being
returned to the caller.

Fixes #4026.

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
