### PR TITLE
Only removing session in localStorage upon failed validation when set.

### DIFF
--- a/graylog2-web-interface/src/stores/sessions/SessionStore.js
+++ b/graylog2-web-interface/src/stores/sessions/SessionStore.js
@@ -58,7 +58,11 @@ const SessionStore = Reflux.createStore({
             username: username || response.username,
           });
         }
-        this._removeSession();
+        if (sessionId && username) {
+          this._removeSession();
+        }
+
+        return response;
       })
       .finally(() => {
         this.validatingSession = false;


### PR DESCRIPTION

## Description
## Motivation and Context

Before this change, whenever a session validation attempt failed, the
session data in localStorage was removed. This was leading to a race
condition for automated browser testing, when validation took longer
than visiting the page for the first time to put session data in
localStorage, which was immediately removed by the validation promise
handler.

After this change, session data in localStorage is removed only if
present.

Refs #3634, #3948, #3973.

## How Has This Been Tested?

- Tested using automated browser testing (Graylog2/qa-frontend)
- Tested using SSO plugin & caddy

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
