### PR TITLE
Switching react into production mode for production builds.

### DIFF
--- a/graylog2-web-interface/webpack.config.js
+++ b/graylog2-web-interface/webpack.config.js
@@ -149,6 +149,9 @@ if (TARGET === 'build') {
   process.env.NODE_ENV = 'production';
   module.exports = merge(webpackConfig, {
     plugins: [
+      new webpack.DefinePlugin({
+        'process.env.NODE_ENV': JSON.stringify('production'),
+      }),
       new webpack.optimize.UglifyJsPlugin({
         minimize: true,
         sourceMap: true,
@@ -160,7 +163,7 @@ if (TARGET === 'build') {
         },
       }),
       new webpack.LoaderOptionsPlugin({
-        minimize: true
+        minimize: true,
       }),
     ],
   });

--- a/graylog2-web-interface/webpack.vendor.js
+++ b/graylog2-web-interface/webpack.vendor.js
@@ -63,19 +63,13 @@ const webpackConfig = {
 if (TARGET === 'build') {
   module.exports = merge(webpackConfig, {
     plugins: [
-      new Clean([path.resolve(BUILD_PATH)]),
-      new webpack.optimize.UglifyJsPlugin({
-        minimize: true,
-        sourceMap: true,
-        compress: {
-          warnings: false,
-        },
-        mangle: {
-          except: ['$super', '$', 'exports', 'require'],
-        },
+      new webpack.DefinePlugin({
+        'process.env.NODE_ENV': JSON.stringify('production'),
       }),
+      new Clean([path.resolve(BUILD_PATH)]),
+      new webpack.optimize.UglifyJsPlugin(),
       new webpack.LoaderOptionsPlugin({
-        minimize: true
+        minimize: true,
       }),
     ],
     output: {

--- a/graylog2-web-interface/webpack.vendor.js
+++ b/graylog2-web-interface/webpack.vendor.js
@@ -67,7 +67,16 @@ if (TARGET === 'build') {
         'process.env.NODE_ENV': JSON.stringify('production'),
       }),
       new Clean([path.resolve(BUILD_PATH)]),
-      new webpack.optimize.UglifyJsPlugin(),
+      new webpack.optimize.UglifyJsPlugin({
+        minimize: true,
+        sourceMap: true,
+        compress: {
+          warnings: false,
+        },
+        mangle: {
+          except: ['$super', '$', 'exports', 'require'],
+        },
+      }),
       new webpack.LoaderOptionsPlugin({
         minimize: true,
       }),


### PR DESCRIPTION
## Description
## Motivation and Context

Before this change, react was running in development mode even for
production builds, because the vendor bundle was not built with the
proper environment variable set. This change is supposed to remediate
this.

<!--- Provide a general summary of your changes in the Title above -->

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?

The Chrome React Developer Tools show warnings if the development build is used, the build is not minified or the version is out of date. This has been used to make sure that for production there is the production build in use.

## Screenshots (if appropriate):

Before:
![screen shot 2017-08-02 at 13 19 03](https://user-images.githubusercontent.com/41929/28871526-33b54b72-7785-11e7-8b64-7f911b4fd82b.png)

After:
![screen shot 2017-08-02 at 13 19 10](https://user-images.githubusercontent.com/41929/28871530-38f59b3c-7785-11e7-9340-1c89ffbc2e62.png)


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
