### PR TITLE
Improve filtering for standard aggregation queries.

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/indexer/searches/Searches.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/searches/Searches.java
@@ -289,22 +289,13 @@ public class Searches {
     public TermsResult terms(String field, int size, String query, String filter, TimeRange range, Sorting.Direction sorting) {
         final Terms.Order termsOrder = sorting == Sorting.Direction.DESC ? Terms.Order.count(false) : Terms.Order.count(true);
 
-        final SearchSourceBuilder searchSourceBuilder = filter == null ? standardSearchRequest(query, range) : filteredSearchRequest(query, filter, range);
-
-        final FilterAggregationBuilder filterBuilder = AggregationBuilders.filter(AGG_FILTER)
-            .subAggregation(
-                AggregationBuilders.terms(AGG_TERMS)
-                    .field(field)
-                    .size(size > 0 ? size : 50)
-                    .order(termsOrder)
-            )
-            .subAggregation(
-                AggregationBuilders.missing("missing")
-                    .field(field)
-            )
-            .filter(standardAggregationFilters(range, filter));
-
-        searchSourceBuilder.aggregation(filterBuilder);
+        final SearchSourceBuilder searchSourceBuilder = filteredSearchRequest(query, filter, range)
+                .aggregation(AggregationBuilders.terms(AGG_TERMS)
+                        .field(field)
+                        .size(size > 0 ? size : 50)
+                        .order(termsOrder))
+                .aggregation(AggregationBuilders.missing("missing")
+                        .field(field));
 
         final Set<String> affectedIndices = determineAffectedIndices(range, filter);
         if (affectedIndices.isEmpty()) {
@@ -321,14 +312,13 @@ public class Searches {
 
         recordEsMetrics(tookMs, range);
 
-        final FilterAggregation filterAggregation = searchResult.getAggregations().getFilterAggregation(AGG_FILTER);
-        final TermsAggregation termsAggregation = filterAggregation.getTermsAggregation(AGG_TERMS);
-        final MissingAggregation missing = filterAggregation.getMissingAggregation("missing");
+        final TermsAggregation termsAggregation = searchResult.getAggregations().getTermsAggregation(AGG_TERMS);
+        final MissingAggregation missing = searchResult.getAggregations().getMissingAggregation("missing");
 
         return new TermsResult(
                 termsAggregation,
                 missing.getMissing(),
-                filterAggregation.getCount(),
+                searchResult.getTotal(),
                 query,
                 searchSourceBuilder.toString(),
                 tookMs
@@ -452,31 +442,20 @@ public class Searches {
                                        TimeRange range,
                                        boolean includeCardinality,
                                        boolean includeStats,
-                                       boolean includeCount)
-        {
-        SearchSourceBuilder searchSourceBuilder;
+                                       boolean includeCount) {
+        final SearchSourceBuilder searchSourceBuilder = filteredSearchRequest(query, filter, range);
 
         final Set<String> affectedIndices = indicesContainingField(determineAffectedIndices(range, filter), field);
 
-        if (filter == null) {
-            searchSourceBuilder = standardSearchRequest(query, range);
-        } else {
-            searchSourceBuilder = filteredSearchRequest(query, filter, range);
-        }
-
-        final FilterAggregationBuilder filterBuilder = AggregationBuilders.filter(AGG_FILTER)
-                .filter(standardAggregationFilters(range, filter));
         if (includeCount) {
-            filterBuilder.subAggregation(AggregationBuilders.count(AGG_VALUE_COUNT).field(field));
+            searchSourceBuilder.aggregation(AggregationBuilders.count(AGG_VALUE_COUNT).field(field));
         }
         if (includeStats) {
-            filterBuilder.subAggregation(AggregationBuilders.extendedStats(AGG_EXTENDED_STATS).field(field));
+            searchSourceBuilder.aggregation(AggregationBuilders.extendedStats(AGG_EXTENDED_STATS).field(field));
         }
         if (includeCardinality) {
-            filterBuilder.subAggregation(AggregationBuilders.cardinality(AGG_CARDINALITY).field(field));
+            searchSourceBuilder.aggregation(AggregationBuilders.cardinality(AGG_CARDINALITY).field(field));
         }
-
-        searchSourceBuilder.aggregation(filterBuilder);
 
         final Search.Builder searchBuilder = new Search.Builder(searchSourceBuilder.toString())
             .addType(IndexMapping.TYPE_MESSAGE)
@@ -524,20 +503,12 @@ public class Searches {
     }
 
     public HistogramResult histogram(String query, DateHistogramInterval interval, String filter, TimeRange range) {
-        final FilterAggregationBuilder builder = AggregationBuilders.filter(AGG_FILTER)
-            .subAggregation(
-                AggregationBuilders.dateHistogram(AGG_HISTOGRAM)
-                    .field(Message.FIELD_TIMESTAMP)
-                    .interval(interval.toESInterval())
-            )
-            .filter(standardAggregationFilters(range, filter));
+        final DateHistogramBuilder histogramBuilder = AggregationBuilders.dateHistogram(AGG_HISTOGRAM)
+                .field(Message.FIELD_TIMESTAMP)
+                .interval(interval.toESInterval());
 
-        final QueryStringQueryBuilder qs = queryStringQuery(query)
-            .allowLeadingWildcard(configuration.isAllowLeadingWildcardSearches());
-
-        final SearchSourceBuilder searchSourceBuilder = new SearchSourceBuilder()
-            .query(qs)
-            .aggregation(builder);
+        final SearchSourceBuilder searchSourceBuilder = filteredSearchRequest(query, filter, range)
+            .aggregation(histogramBuilder);
 
         final Set<String> affectedIndices = determineAffectedIndices(range, filter);
         if (affectedIndices.isEmpty()) {
@@ -555,8 +526,7 @@ public class Searches {
         final long tookMs = tookMsFromSearchResult(searchResult);
         recordEsMetrics(tookMs, range);
 
-        final FilterAggregation filterAggregation = searchResult.getAggregations().getFilterAggregation(AGG_FILTER);
-        final HistogramAggregation histogramAggregation = filterAggregation.getHistogramAggregation(AGG_HISTOGRAM);
+        final HistogramAggregation histogramAggregation = searchResult.getAggregations().getHistogramAggregation(AGG_HISTOGRAM);
 
         return new DateHistogramResult(
             histogramAggregation,
@@ -582,16 +552,11 @@ public class Searches {
             dateHistogramBuilder.subAggregation(AggregationBuilders.cardinality(AGG_CARDINALITY).field(field));
         }
 
-        final FilterAggregationBuilder filterBuilder = AggregationBuilders.filter(AGG_FILTER)
-                .subAggregation(dateHistogramBuilder)
-                .filter(standardAggregationFilters(range, filter));
-
         final QueryStringQueryBuilder qs = queryStringQuery(query)
             .allowLeadingWildcard(configuration.isAllowLeadingWildcardSearches());
 
-        final SearchSourceBuilder searchSourceBuilder = new SearchSourceBuilder()
-            .query(qs)
-            .aggregation(filterBuilder);
+        final SearchSourceBuilder searchSourceBuilder = filteredSearchRequest(query, filter, range)
+            .aggregation(dateHistogramBuilder);
 
         final Set<String> affectedIndices = determineAffectedIndices(range, filter);
         if (affectedIndices.isEmpty()) {
@@ -606,8 +571,7 @@ public class Searches {
         final long tookMs = tookMsFromSearchResult(searchResult);
         recordEsMetrics(tookMs, range);
 
-        final FilterAggregation filterAggregation = searchResult.getAggregations().getFilterAggregation(AGG_FILTER);
-        final HistogramAggregation histogramAggregation = filterAggregation.getHistogramAggregation(AGG_HISTOGRAM);
+        final HistogramAggregation histogramAggregation = searchResult.getAggregations().getHistogramAggregation(AGG_HISTOGRAM);
 
         return new FieldHistogramResult(
                 histogramAggregation,

--- a/graylog2-server/src/main/java/org/graylog2/indexer/searches/Searches.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/searches/Searches.java
@@ -473,10 +473,9 @@ public class Searches {
         final long tookMs = tookMsFromSearchResult(searchResponse);
         recordEsMetrics(tookMs, range);
 
-        final FilterAggregation filterAggregation = searchResponse.getAggregations().getFilterAggregation(AGG_FILTER);
-        final ExtendedStatsAggregation extendedStatsAggregation = filterAggregation.getExtendedStatsAggregation(AGG_EXTENDED_STATS);
-        final ValueCountAggregation valueCountAggregation = filterAggregation.getValueCountAggregation(AGG_VALUE_COUNT);
-        final CardinalityAggregation cardinalityAggregation = filterAggregation.getCardinalityAggregation(AGG_CARDINALITY);
+        final ExtendedStatsAggregation extendedStatsAggregation = searchResponse.getAggregations().getExtendedStatsAggregation(AGG_EXTENDED_STATS);
+        final ValueCountAggregation valueCountAggregation = searchResponse.getAggregations().getValueCountAggregation(AGG_VALUE_COUNT);
+        final CardinalityAggregation cardinalityAggregation = searchResponse.getAggregations().getCardinalityAggregation(AGG_CARDINALITY);
 
         return new FieldStatsResult(
                 valueCountAggregation,
@@ -551,9 +550,6 @@ public class Searches {
         if (includeCardinality) {
             dateHistogramBuilder.subAggregation(AggregationBuilders.cardinality(AGG_CARDINALITY).field(field));
         }
-
-        final QueryStringQueryBuilder qs = queryStringQuery(query)
-            .allowLeadingWildcard(configuration.isAllowLeadingWildcardSearches());
 
         final SearchSourceBuilder searchSourceBuilder = filteredSearchRequest(query, filter, range)
             .aggregation(dateHistogramBuilder);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

This change improves the queries generated by the Searches#terms/fieldStats/histogram/fieldHistogram methods. By filtering the search result based on the specified time range in the query instead of the aggregation, overall ES runtime is improved.

Fortunately, filteredSearchRequest is already returning a matching query + time range search builder which can be used for those cases. Before this change, the source builder was generated by the specific method and contained only the query instead of query + time range.

Thanks to @hc4 for the input.

Fixes #4051.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

Sample runtimes for the histogram before the change:

![screen shot 2017-08-03 at 10 52 02](https://user-images.githubusercontent.com/41929/28923394-3c9a68b0-785e-11e7-903c-3a57ed424ff4.png)

Sample runtimes for the histogram after the change:

![screen shot 2017-08-03 at 10 51 32](https://user-images.githubusercontent.com/41929/28923409-4603d7f6-785e-11e7-8cd3-ca24f1155e00.png)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.