### PR TITLE
Return index set wildcard instead of individual indices in Searches#termineAffectedIndices()

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/indexer/searches/Searches.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/searches/Searches.java
@@ -821,7 +821,7 @@ public class Searches {
                     .map(IndexRange::indexName)
                     .map(indexSetRegistry::getForIndex)
                     .flatMap(o -> o.map(java.util.stream.Stream::of).orElseGet(java.util.stream.Stream::empty))
-                    .map(IndexSet::getWriteIndexAlias)
+                    .map(IndexSet::getIndexWildcard)
                     .collect(Collectors.toSet());
 
         } else {

--- a/graylog2-server/src/test/java/org/graylog2/indexer/searches/SearchesTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/indexer/searches/SearchesTest.java
@@ -607,7 +607,7 @@ public class SearchesTest extends AbstractESTest {
 
         final TimeRange absoluteRange = AbsoluteRange.create(now, now.plusDays(numberOfIndices + 1));
 
-        assertThat(searches.determineAffectedIndices(absoluteRange, null)).containsExactly(indexSet.getWriteIndexAlias());
+        assertThat(searches.determineAffectedIndices(absoluteRange, null)).containsExactly(indexSet.getIndexWildcard());
     }
 
     @Test

--- a/graylog2-server/src/test/java/org/graylog2/indexer/searches/SearchesTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/indexer/searches/SearchesTest.java
@@ -30,6 +30,7 @@ import org.graylog2.Configuration;
 import org.graylog2.buffers.processors.fakestreams.FakeStream;
 import org.graylog2.indexer.IndexHelper;
 import org.graylog2.indexer.IndexSet;
+import org.graylog2.indexer.IndexSetRegistry;
 import org.graylog2.indexer.TestIndexSet;
 import org.graylog2.indexer.indexset.IndexSetConfig;
 import org.graylog2.indexer.indices.Indices;
@@ -71,11 +72,13 @@ import java.time.ZonedDateTime;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.SortedSet;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.joda.time.DateTimeZone.UTC;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.startsWith;
 import static org.mockito.Mockito.mock;
@@ -131,6 +134,9 @@ public class SearchesTest extends AbstractESTest {
     private IndexRangeService indexRangeService;
 
     @Mock
+    private IndexSetRegistry indexSetRegistry;
+
+    @Mock
     private StreamService streamService;
 
     @Mock
@@ -170,6 +176,7 @@ public class SearchesTest extends AbstractESTest {
         searches = new Searches(
             new Configuration(),
             indexRangeService,
+            indexSetRegistry,
             metricRegistry,
             streamService,
             indices,
@@ -582,6 +589,25 @@ public class SearchesTest extends AbstractESTest {
                 .containsExactly(indexRangeLatest, indexRange0, indexRange1);
         assertThat(searches.determineAffectedIndicesWithRanges(relativeRange, null))
                 .containsExactly(indexRangeLatest, indexRange0, indexRange1);
+    }
+
+    @Test
+    public void determineAffectedIndicesOnlyReturnsAliasesIfTooManyIndicesAreFound() throws Exception {
+        final int numberOfIndices = Searches.MAX_INDICES_PER_QUERY + 1;
+        final DateTime now = DateTime.now(DateTimeZone.UTC);
+        final ImmutableSortedSet.Builder<IndexRange> indices = ImmutableSortedSet.orderedBy(IndexRange.COMPARATOR);
+
+        for (int i = 0; i < numberOfIndices; i++) {
+            final MongoIndexRange indexRange = MongoIndexRange.create("graylog_" + i, now.plusDays(i), now.plusDays(i + 1), now, 0);
+            indices.add(indexRange);
+        }
+
+        when(indexRangeService.find(any(DateTime.class), any(DateTime.class))).thenReturn(indices.build());
+        when(indexSetRegistry.getForIndex(anyString())).thenReturn(Optional.of(indexSet));
+
+        final TimeRange absoluteRange = AbsoluteRange.create(now, now.plusDays(numberOfIndices + 1));
+
+        assertThat(searches.determineAffectedIndices(absoluteRange, null)).containsExactly(indexSet.getWriteIndexAlias());
     }
 
     @Test


### PR DESCRIPTION
This PR changes the behavior of the `Searches` class to use a [Terms Query](https://www.elastic.co/guide/en/elasticsearch/reference/5.5/query-dsl-terms-query.html) filtering for the `_index` field instead of listing all indices in the URI path if a defined number of indices (see `Searches.MAX_INDICES_PER_QUERY`) has been reached.

While this leads to more load required on the side of Elasticsearch (because all index shards have to be visited instead of just the ones of the specified indices), it circumvents the problem with the URI being larger than 4 KB.

Using partitioned parallel queries when the maximum URI size has been reached would unfortunately only be feasible for a subset of queries currently supported by the `Searches` class. 😞 

Fixes #4054