### PR TITLE
Re-enable "_source" fetching in search requests with selected fields

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/indexer/searches/Searches.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/searches/Searches.java
@@ -34,6 +34,7 @@ import io.searchbox.core.search.aggregation.MissingAggregation;
 import io.searchbox.core.search.aggregation.TermsAggregation;
 import io.searchbox.core.search.aggregation.ValueCountAggregation;
 import io.searchbox.params.Parameters;
+import org.elasticsearch.common.Strings;
 import org.elasticsearch.index.query.BoolQueryBuilder;
 import org.elasticsearch.index.query.QueryBuilder;
 import org.elasticsearch.index.query.QueryBuilders;
@@ -653,18 +654,13 @@ public class Searches {
             request = filteredSearchRequest(config.query(), config.filter(), config.limit(), config.offset(), config.range(), config.sorting());
         }
 
-        if (config.fields() != null) {
-            // http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/search-request-fields.html#search-request-fields
-            // "For backwards compatibility, if the fields parameter specifies fields which are not stored , it will
-            // load the _source and extract it from it. This functionality has been replaced by the source filtering
-            // parameter."
-            // TODO: Look at the source filtering parameter once we switched to ES 1.x.
-            request.fields(config.fields());
-
-            // Re-enable source fetching, because
-            // "By default operations return the contents of the _source field unless you have used the fields parameter
-            // or if the _source field is disabled."
-            request.fetchSource(true);
+        final List<String> fields = config.fields();
+        if (fields != null) {
+            // Use source filtering instead of SearchSourceBuilder#fields() here because Jest cannot handle responses
+            // without a "_source" field yet. See:
+            // https://github.com/searchbox-io/Jest/issues/157
+            // https://github.com/searchbox-io/Jest/issues/339
+            request.fetchSource(fields.toArray(new String[fields.size()]), Strings.EMPTY_ARRAY);
         }
 
         return request;

--- a/graylog2-server/src/main/java/org/graylog2/indexer/searches/Searches.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/searches/Searches.java
@@ -660,6 +660,11 @@ public class Searches {
             // parameter."
             // TODO: Look at the source filtering parameter once we switched to ES 1.x.
             request.fields(config.fields());
+
+            // Re-enable source fetching, because
+            // "By default operations return the contents of the _source field unless you have used the fields parameter
+            // or if the _source field is disabled."
+            request.fetchSource(true);
         }
 
         return request;

--- a/graylog2-server/src/test/java/org/graylog2/indexer/searches/SearchesTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/indexer/searches/SearchesTest.java
@@ -739,4 +739,22 @@ public class SearchesTest extends AbstractESTest {
         assertThat(searchResult.getTotalResults()).isEqualTo(10L);
         assertThat(searchResult.getFields()).doesNotContain("es_metadata_id", "es_metadata_version");
     }
+
+    @Test
+    @UsingDataSet(loadStrategy = LoadStrategyEnum.CLEAN_INSERT)
+    public void searchReturnsResultWithSelectiveFields() throws Exception {
+        final AbsoluteRange range = AbsoluteRange.create(new DateTime(2015, 1, 1, 0, 0, DateTimeZone.UTC).withZone(UTC), new DateTime(2015, 1, 2, 0, 0, DateTimeZone.UTC).withZone(UTC));
+        final SearchesConfig searchesConfig = SearchesConfig.builder()
+                .query("*")
+                .range(range)
+                .limit(1)
+                .offset(0)
+                .fields(Collections.singletonList("source"))
+                .build();
+        final SearchResult searchResult = searches.search(searchesConfig);
+
+        assertThat(searchResult).isNotNull();
+        assertThat(searchResult.getResults()).hasSize(1);
+        assertThat(searchResult.getTotalResults()).isEqualTo(10L);
+    }
 }


### PR DESCRIPTION
The inclusion of the `_source` field has to be explicitly re-enabled if a search request specified the `fields` field to only return specific fields.

> By default operations return the contents of the `_source` field unless you have used the `fields` parameter or if the `_source` field is disabled.

https://www.elastic.co/guide/en/elasticsearch/reference/2.4/search-request-source-filtering.html

Fixes #4068