### PR TITLE
Add missing index for "session_id" in "sessions" collection

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/security/MongoDBSessionServiceImpl.java
+++ b/graylog2-server/src/main/java/org/graylog2/security/MongoDBSessionServiceImpl.java
@@ -19,26 +19,36 @@ package org.graylog2.security;
 import com.google.common.collect.Lists;
 import com.mongodb.BasicDBObject;
 import com.mongodb.DBObject;
+import com.mongodb.client.MongoCollection;
+import com.mongodb.client.MongoDatabase;
+import com.mongodb.client.model.Indexes;
+import org.bson.Document;
 import org.bson.types.ObjectId;
 import org.graylog2.database.MongoConnection;
 import org.graylog2.database.PersistedServiceImpl;
 
 import javax.annotation.Nullable;
 import javax.inject.Inject;
+import javax.inject.Singleton;
 import java.util.Collection;
 import java.util.List;
 
+@Singleton
 public class MongoDBSessionServiceImpl extends PersistedServiceImpl implements MongoDBSessionService {
     @Inject
     public MongoDBSessionServiceImpl(MongoConnection mongoConnection) {
         super(mongoConnection);
+
+        final MongoDatabase database = mongoConnection.getMongoDatabase();
+        final MongoCollection<Document> sessions = database.getCollection(MongoDbSession.COLLECTION_NAME);
+        sessions.createIndex(Indexes.ascending(MongoDbSession.FIELD_SESSION_ID));
     }
 
     @Override
     @Nullable
     public MongoDbSession load(String sessionId) {
         DBObject query = new BasicDBObject();
-        query.put("session_id", sessionId);
+        query.put(MongoDbSession.FIELD_SESSION_ID, sessionId);
 
         DBObject result = findOne(MongoDbSession.class, query);
         if (result == null) {

--- a/graylog2-server/src/main/java/org/graylog2/security/MongoDbSession.java
+++ b/graylog2-server/src/main/java/org/graylog2/security/MongoDbSession.java
@@ -35,9 +35,11 @@ import java.util.Date;
 import java.util.Map;
 import java.util.Optional;
 
-@CollectionName("sessions")
+@CollectionName(MongoDbSession.COLLECTION_NAME)
 public class MongoDbSession extends PersistedImpl {
     private static final Logger LOG = LoggerFactory.getLogger(MongoDbSession.class);
+    static final String COLLECTION_NAME = "sessions";
+    static final String FIELD_SESSION_ID = "session_id";
 
     protected MongoDbSession(Map<String, Object> fields) {
         super(fields);
@@ -144,6 +146,6 @@ public class MongoDbSession extends PersistedImpl {
     }
 
     public String getSessionId() {
-        return String.valueOf(fields.get("session_id"));
+        return String.valueOf(fields.get(FIELD_SESSION_ID));
     }
 }


### PR DESCRIPTION
In environments with a large number of concurrent sessions, the session lookups cause a heavy load on MongoDB if there is no index on `sessions.session_id`.

Refs https://community.graylog.org/t/mongodb-affecting-the-graylog-infra/2001/3