### PR TITLE
Moved Widget Labels to Widget Footer

### DIFF
--- a/graylog2-web-interface/public/stylesheets/graylog2.less
+++ b/graylog2-web-interface/public/stylesheets/graylog2.less
@@ -1161,7 +1161,6 @@ td.limited {
 .dashboard .widget .widget-title {
   font-size: 18px;
   height: 25px;
-  margin-right: 130px;
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
@@ -1173,11 +1172,11 @@ td.limited {
 }
 
 .dashboard .widget .widget-update-info {
-  text-align: right;
-  float: right;
+  text-align: left;
+  float: left;
   font-size: 11px;
-  height: 25px;
-  line-height: 25px;
+  position: absolute;
+  bottom: 10px;
   width: 130px;
 }
 

--- a/graylog2-web-interface/src/components/widgets/Widget.jsx
+++ b/graylog2-web-interface/src/components/widgets/Widget.jsx
@@ -223,10 +223,7 @@ const Widget = React.createClass({
     return (
       <div ref="widget" className="widget" data-widget-id={this.props.widget.id}>
         <WidgetHeader ref="widgetHeader"
-                      title={this.props.widget.description}
-                      calculatedAt={this.state.calculatedAt}
-                      error={this.state.error}
-                      errorMessage={this.state.errorMessage} />
+                      title={this.props.widget.description} />
 
         {this._getVisualization()}
 
@@ -236,7 +233,10 @@ const Widget = React.createClass({
                       onEditConfig={this._showEditConfig}
                       onDelete={this.deleteWidget}
                       replayHref={this.replayUrl()}
-                      replayToolTip={disabledTooltip} />
+                      replayToolTip={disabledTooltip}
+                      calculatedAt={this.state.calculatedAt}
+                      error={this.state.error}
+                      errorMessage={this.state.errorMessage} />
         {this.props.locked ? showConfigModal : editConfigModal}
       </div>
     );

--- a/graylog2-web-interface/src/components/widgets/WidgetFooter.jsx
+++ b/graylog2-web-interface/src/components/widgets/WidgetFooter.jsx
@@ -1,6 +1,7 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 import { Button, OverlayTrigger, Tooltip } from 'react-bootstrap';
+import { Timestamp } from 'components/common';
 
 const WidgetFooter = React.createClass({
   propTypes: {
@@ -9,6 +10,9 @@ const WidgetFooter = React.createClass({
     onEditConfig: PropTypes.func.isRequired,
     onShowConfig: PropTypes.func.isRequired,
     replayHref: PropTypes.string.isRequired,
+    error: PropTypes.any,
+    errorMessage: PropTypes.string,
+    calculatedAt: PropTypes.string,
     replayToolTip: PropTypes.string,
   },
   _showConfig(e) {
@@ -24,6 +28,24 @@ const WidgetFooter = React.createClass({
     this.props.onDelete();
   },
   render() {
+    let loadErrorElement;
+
+    if (this.props.error) {
+      loadErrorElement = (
+        <span className="load-error" title={this.props.errorMessage}>
+          <i className="fa fa-exclamation-triangle" />
+        </span>
+      );
+    }
+
+    let calculatedAtTime;
+
+    if (this.props.calculatedAt) {
+      calculatedAtTime = <span title={this.props.calculatedAt}><Timestamp dateTime={this.props.calculatedAt} relative /></span>;
+    } else {
+      calculatedAtTime = 'Loading...';
+    }
+
     // if we have a tooltip, we disable the button link and instead show a tooltip on hover
     const title = this.props.replayToolTip ? null : 'Replay search';
     const href = this.props.replayToolTip ? null : this.props.replayHref;
@@ -69,7 +91,13 @@ const WidgetFooter = React.createClass({
 
     return (
       <div>
-        {this.props.locked ? lockedActions : unlockedActions}
+        <div className="widget-update-info">
+        {loadErrorElement}
+        {calculatedAtTime}
+        </div>
+        <div>
+          {this.props.locked ? lockedActions : unlockedActions}
+        </div>
       </div>
     );
   },

--- a/graylog2-web-interface/src/components/widgets/WidgetHeader.jsx
+++ b/graylog2-web-interface/src/components/widgets/WidgetHeader.jsx
@@ -1,39 +1,14 @@
 import PropTypes from 'prop-types';
 import React from 'react';
-import { Timestamp } from 'components/common';
 
 const WidgetHeader = React.createClass({
   propTypes: {
     title: PropTypes.string.isRequired,
-    error: PropTypes.any,
-    errorMessage: PropTypes.string,
-    calculatedAt: PropTypes.string,
   },
   render() {
-    let loadErrorElement;
-
-    if (this.props.error) {
-      loadErrorElement = (
-        <span className="load-error" title={this.props.errorMessage}>
-          <i className="fa fa-exclamation-triangle" />
-        </span>
-      );
-    }
-
-    let calculatedAtTime;
-
-    if (this.props.calculatedAt) {
-      calculatedAtTime = <span title={this.props.calculatedAt}><Timestamp dateTime={this.props.calculatedAt} relative /></span>;
-    } else {
-      calculatedAtTime = 'Loading...';
-    }
 
     return (
       <div>
-        <div className="widget-update-info">
-          {loadErrorElement}
-          {calculatedAtTime}
-        </div>
         <div className="widget-title">
           {this.props.title}
         </div>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Move Widget time calculation and error labels to the bottom-left of the widget panel to make more room for the Widget Title.

## Description
Modified the Widget, Widget Header, Widget Footer and related CSS to facilitate the movement of the time calculation and error label to the bottom-left of the widget. The label uses absolute positioning like the action buttons which are also located within the footer.

## Motivation and Context
The PR implements the change requested in Issue #4052 

## How Has This Been Tested?
Modified source code, started local web development environment (*npm start*) with hot-loading to test changes.

## Screenshots (if appropriate):
**Before**
![Before Image](http://i.imgur.com/EMeGA7v.png)

**After**
![After Image](http://i.imgur.com/6O6GUEN.png)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
