### PR TITLE
Add Surrounding Filters Field Support to Individual Streams

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/plugin/streams/Stream.java
+++ b/graylog2-server/src/main/java/org/graylog2/plugin/streams/Stream.java
@@ -79,6 +79,10 @@ public interface Stream extends Persisted {
 
     void setRemoveMatchesFromDefaultStream(boolean removeMatchesFromDefaultStream);
 
+    String getSurroundingFilters();
+
+    String setSurroundingFilters(String fieldSurroundingFilters);
+
     IndexSet getIndexSet();
 
     String getIndexSetId();

--- a/graylog2-server/src/main/java/org/graylog2/rest/models/streams/requests/UpdateStreamRequest.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/models/streams/requests/UpdateStreamRequest.java
@@ -47,6 +47,10 @@ public abstract class UpdateStreamRequest {
     @Nullable
     public abstract Boolean removeMatchesFromDefaultStream();
 
+    @JsonProperty("surrounding_filters")
+    @Nullable
+    public abstract String surroundingFilters();
+
     @JsonProperty("index_set_id")
     @Nullable
     public abstract String indexSetId();
@@ -57,7 +61,8 @@ public abstract class UpdateStreamRequest {
                                              @JsonProperty("matching_type") @Nullable String matchingType,
                                              @JsonProperty("rules") @Nullable List rules,
                                              @JsonProperty("remove_matches_from_default_stream") @Nullable Boolean removeMatchesFromDefaultStream,
+                                             @JsonProperty("surrounding_filters") @Nullable String surroundingFilters,
                                              @JsonProperty("index_set_id") @Nullable String indexSetId) {
-        return new AutoValue_UpdateStreamRequest(title, description, matchingType, removeMatchesFromDefaultStream, indexSetId);
+        return new AutoValue_UpdateStreamRequest(title, description, matchingType, removeMatchesFromDefaultStream, surroundingFilters, indexSetId);
     }
 }

--- a/graylog2-server/src/main/java/org/graylog2/rest/resources/streams/StreamResource.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/resources/streams/StreamResource.java
@@ -148,6 +148,8 @@ public class StreamResource extends RestResource {
         final Stream stream = streamService.create(cr, getCurrentUser().getName());
         stream.setDisabled(true);
 
+        stream.setSurroundingFilters(stream.getSurroundingFilters());
+
         if (!stream.getIndexSet().getConfig().isWritable()) {
             throw new BadRequestException("Assigned index set must be writable!");
         }
@@ -246,6 +248,8 @@ public class StreamResource extends RestResource {
         if (!Strings.isNullOrEmpty(cr.description())) {
             stream.setDescription(cr.description());
         }
+
+        stream.setSurroundingFilters(cr.surroundingFilters());
 
         if (cr.matchingType() != null) {
             try {
@@ -407,6 +411,7 @@ public class StreamResource extends RestResource {
         streamData.put(StreamImpl.FIELD_CREATED_AT, Tools.nowUTC());
         streamData.put(StreamImpl.FIELD_MATCHING_TYPE, sourceStream.getMatchingType().toString());
         streamData.put(StreamImpl.FIELD_REMOVE_MATCHES_FROM_DEFAULT_STREAM, cr.removeMatchesFromDefaultStream());
+        streamData.put(StreamImpl.FIELD_SURROUNDING_FILTERS, cr.surroundingFilters());
         streamData.put(StreamImpl.FIELD_INDEX_SET_ID, cr.indexSetId());
 
         final Stream stream = streamService.create(streamData);
@@ -493,6 +498,7 @@ public class StreamResource extends RestResource {
             stream.getContentPack(),
             stream.isDefaultStream(),
             stream.getRemoveMatchesFromDefaultStream(),
+            stream.getSurroundingFilters(),
             stream.getIndexSetId()
         );
     }

--- a/graylog2-server/src/main/java/org/graylog2/rest/resources/streams/requests/CloneStreamRequest.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/resources/streams/requests/CloneStreamRequest.java
@@ -35,6 +35,9 @@ public abstract class CloneStreamRequest {
     @JsonProperty("remove_matches_from_default_stream")
     public abstract boolean removeMatchesFromDefaultStream();
 
+    @JsonProperty("surrounding_filters")
+    public abstract String surroundingFilters();
+
     @JsonProperty("index_set_id")
     public abstract String indexSetId();
 
@@ -42,7 +45,8 @@ public abstract class CloneStreamRequest {
     public static CloneStreamRequest create(@JsonProperty("title") String title,
                                             @JsonProperty("description") String description,
                                             @JsonProperty("remove_matches_from_default_stream") boolean removeMatchesFromDefaultStream,
+                                            @JsonProperty("surrounding_filters") String surroundingFilters,
                                             @JsonProperty("index_set_id") String indexSetId) {
-        return new AutoValue_CloneStreamRequest(title, description, removeMatchesFromDefaultStream, indexSetId);
+        return new AutoValue_CloneStreamRequest(title, description, removeMatchesFromDefaultStream, surroundingFilters, indexSetId);
     }
 }

--- a/graylog2-server/src/main/java/org/graylog2/rest/resources/streams/requests/CreateStreamRequest.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/resources/streams/requests/CreateStreamRequest.java
@@ -27,7 +27,6 @@ import org.hibernate.validator.constraints.NotEmpty;
 
 import javax.annotation.Nullable;
 import java.util.List;
-import java.util.Set;
 
 import static com.google.common.base.MoreObjects.firstNonNull;
 

--- a/graylog2-server/src/main/java/org/graylog2/rest/resources/streams/requests/CreateStreamRequest.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/resources/streams/requests/CreateStreamRequest.java
@@ -27,6 +27,7 @@ import org.hibernate.validator.constraints.NotEmpty;
 
 import javax.annotation.Nullable;
 import java.util.List;
+import java.util.Set;
 
 import static com.google.common.base.MoreObjects.firstNonNull;
 
@@ -34,6 +35,7 @@ import static com.google.common.base.MoreObjects.firstNonNull;
 @AutoValue
 @WithBeanGetter
 public abstract class CreateStreamRequest {
+
     @JsonProperty
     public abstract String title();
 
@@ -55,6 +57,9 @@ public abstract class CreateStreamRequest {
     @JsonProperty("remove_matches_from_default_stream")
     public abstract boolean removeMatchesFromDefaultStream();
 
+    @JsonProperty("surrounding_filters")
+    public abstract String surroundingFilters();
+
     @JsonProperty("index_set_id")
     public abstract String indexSetId();
 
@@ -65,6 +70,7 @@ public abstract class CreateStreamRequest {
                                              @JsonProperty("content_pack") @Nullable String contentPack,
                                              @JsonProperty("matching_type") @Nullable String matchingType,
                                              @JsonProperty("remove_matches_from_default_stream") @Nullable Boolean removeMatchesFromDefaultStream,
+                                             @JsonProperty("surrounding_filters") String surroundingFilters,
                                              @JsonProperty("index_set_id") String indexSetId) {
         return new AutoValue_CreateStreamRequest(
                 title,
@@ -73,6 +79,7 @@ public abstract class CreateStreamRequest {
                 contentPack,
                 Stream.MatchingType.valueOfOrDefault(matchingType),
                 firstNonNull(removeMatchesFromDefaultStream, false),
+                surroundingFilters,
                 indexSetId
         );
     }

--- a/graylog2-server/src/main/java/org/graylog2/rest/resources/streams/responses/StreamResponse.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/resources/streams/responses/StreamResponse.java
@@ -28,7 +28,6 @@ import org.graylog2.rest.models.system.outputs.responses.OutputSummary;
 
 import javax.annotation.Nullable;
 import java.util.Collection;
-import java.util.Set;
 
 import static com.google.common.base.MoreObjects.firstNonNull;
 

--- a/graylog2-server/src/main/java/org/graylog2/rest/resources/streams/responses/StreamResponse.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/resources/streams/responses/StreamResponse.java
@@ -28,6 +28,7 @@ import org.graylog2.rest.models.system.outputs.responses.OutputSummary;
 
 import javax.annotation.Nullable;
 import java.util.Collection;
+import java.util.Set;
 
 import static com.google.common.base.MoreObjects.firstNonNull;
 
@@ -80,6 +81,9 @@ public abstract class StreamResponse {
     @JsonProperty("remove_matches_from_default_stream")
     public abstract boolean removeMatchesFromDefaultStream();
 
+    @JsonProperty("surrounding_filters")
+    public abstract String surroundingFilters();
+
     @JsonProperty("index_set_id")
     public abstract String indexSetId();
 
@@ -98,6 +102,7 @@ public abstract class StreamResponse {
                                         @JsonProperty("content_pack") @Nullable String contentPack,
                                         @JsonProperty("is_default") @Nullable Boolean isDefault,
                                         @JsonProperty("remove_matches_from_default_stream") @Nullable Boolean removeMatchesFromDefaultStream,
+                                        @JsonProperty("surrounding_filters") String surroundingFilters,
                                         @JsonProperty("index_set_id") String indexSetId) {
         return new AutoValue_StreamResponse(
                 id,
@@ -114,6 +119,7 @@ public abstract class StreamResponse {
                 contentPack,
                 firstNonNull(isDefault, false),
                 firstNonNull(removeMatchesFromDefaultStream, false),
+                surroundingFilters,
                 indexSetId);
     }
 }

--- a/graylog2-server/src/main/java/org/graylog2/streams/StreamImpl.java
+++ b/graylog2-server/src/main/java/org/graylog2/streams/StreamImpl.java
@@ -60,11 +60,14 @@ public class StreamImpl extends PersistedImpl implements Stream {
     public static final String FIELD_DEFAULT_STREAM = "is_default_stream";
     public static final String FIELD_REMOVE_MATCHES_FROM_DEFAULT_STREAM = "remove_matches_from_default_stream";
     public static final String FIELD_INDEX_SET_ID = "index_set_id";
+    public static final String FIELD_SURROUNDING_FILTERS = "surrounding_filters";
     public static final String EMBEDDED_ALERT_CONDITIONS = "alert_conditions";
 
     private final List<StreamRule> streamRules;
     private final Set<Output> outputs;
     private final IndexSet indexSet;
+
+    public static final String DEFAULT_SURROUNDING_FILTERS = "source, gl2_source_input, file, source_file";
 
     public StreamImpl(Map<String, Object> fields) {
         super(fields);
@@ -185,6 +188,7 @@ public class StreamImpl extends PersistedImpl implements Stream {
         result.put(FIELD_MATCHING_TYPE, getMatchingType());
         result.put(FIELD_DEFAULT_STREAM, isDefaultStream());
         result.put(FIELD_REMOVE_MATCHES_FROM_DEFAULT_STREAM, getRemoveMatchesFromDefaultStream());
+        result.put(FIELD_SURROUNDING_FILTERS, getSurroundingFilters());
         result.put(FIELD_INDEX_SET_ID, getIndexSetId());
         return result;
     }
@@ -263,6 +267,18 @@ public class StreamImpl extends PersistedImpl implements Stream {
             throw new IllegalStateException("index set must not be null! (stream id=" + getId() + " title=\"" + getTitle() + "\")");
         }
         return indexSet;
+    }
+
+    @Override
+    public String getSurroundingFilters() { return (String) fields.getOrDefault(FIELD_SURROUNDING_FILTERS, DEFAULT_SURROUNDING_FILTERS); }
+
+    @Override
+    public String setSurroundingFilters(String fieldSurroundingFilters) {
+        if (fieldSurroundingFilters.isEmpty()) {
+            fieldSurroundingFilters = DEFAULT_SURROUNDING_FILTERS;
+        }
+
+        return (String) fields.put(FIELD_SURROUNDING_FILTERS, fieldSurroundingFilters);
     }
 
     @Override

--- a/graylog2-server/src/main/java/org/graylog2/streams/StreamServiceImpl.java
+++ b/graylog2-server/src/main/java/org/graylog2/streams/StreamServiceImpl.java
@@ -141,7 +141,6 @@ public class StreamServiceImpl extends PersistedServiceImpl implements StreamSer
         streamData.put(StreamImpl.FIELD_SURROUNDING_FILTERS, cr.surroundingFilters());
         streamData.put(StreamImpl.FIELD_INDEX_SET_ID, cr.indexSetId());
 
-
         return create(streamData);
     }
 

--- a/graylog2-server/src/main/java/org/graylog2/streams/StreamServiceImpl.java
+++ b/graylog2-server/src/main/java/org/graylog2/streams/StreamServiceImpl.java
@@ -138,7 +138,9 @@ public class StreamServiceImpl extends PersistedServiceImpl implements StreamSer
         streamData.put(StreamImpl.FIELD_CONTENT_PACK, cr.contentPack());
         streamData.put(StreamImpl.FIELD_MATCHING_TYPE, cr.matchingType().toString());
         streamData.put(StreamImpl.FIELD_REMOVE_MATCHES_FROM_DEFAULT_STREAM, cr.removeMatchesFromDefaultStream());
+        streamData.put(StreamImpl.FIELD_SURROUNDING_FILTERS, cr.surroundingFilters());
         streamData.put(StreamImpl.FIELD_INDEX_SET_ID, cr.indexSetId());
+
 
         return create(streamData);
     }

--- a/graylog2-server/src/test/java/org/graylog2/streams/StreamMock.java
+++ b/graylog2-server/src/test/java/org/graylog2/streams/StreamMock.java
@@ -52,7 +52,10 @@ public class StreamMock implements Stream {
     private MatchingType matchingType;
     private boolean defaultStream;
     private boolean removeMatchesFromDefaultStream;
+    private String surroundingFilters;
     private IndexSet indexSet;
+
+    public static final String DEFAULT_SURROUNDING_FILTERS = "source, gl2_source_input, file, source_file";
 
     public StreamMock(Map<String, Object> stream) {
         this(stream, Collections.emptyList());
@@ -70,6 +73,7 @@ public class StreamMock implements Stream {
         this.matchingType = (MatchingType) stream.getOrDefault(StreamImpl.FIELD_MATCHING_TYPE, MatchingType.AND);
         this.defaultStream = (boolean) stream.getOrDefault(StreamImpl.FIELD_DEFAULT_STREAM, false);
         this.removeMatchesFromDefaultStream = (boolean) stream.getOrDefault(StreamImpl.FIELD_REMOVE_MATCHES_FROM_DEFAULT_STREAM, false);
+        this.surroundingFilters = (String) stream.getOrDefault(StreamImpl.FIELD_SURROUNDING_FILTERS, "");
         this.indexSet = new TestIndexSet(IndexSetConfig.create(
                 "index-set-id",
                 "title",
@@ -212,6 +216,17 @@ public class StreamMock implements Stream {
     @Override
     public void setRemoveMatchesFromDefaultStream(boolean removeMatchesFromDefaultStream) {
         this.removeMatchesFromDefaultStream = removeMatchesFromDefaultStream;
+    }
+
+    @Override
+    public String getSurroundingFilters() {
+        return (this.surroundingFilters.isEmpty()) ? this.DEFAULT_SURROUNDING_FILTERS : this.surroundingFilters;
+    }
+
+    @Override
+    public String setSurroundingFilters(String surroundingFilters) {
+        this.surroundingFilters = surroundingFilters;
+        return this.surroundingFilters;
     }
 
     @Override

--- a/graylog2-server/src/test/java/org/graylog2/streams/StreamServiceImplTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/streams/StreamServiceImplTest.java
@@ -16,9 +16,11 @@
  */
 package org.graylog2.streams;
 
+import com.google.common.collect.ImmutableMap;
 import com.lordofthejars.nosqlunit.annotation.UsingDataSet;
 import com.lordofthejars.nosqlunit.core.LoadStrategyEnum;
 import com.lordofthejars.nosqlunit.mongodb.InMemoryMongoDb;
+import org.bson.types.ObjectId;
 import org.graylog2.alarmcallbacks.AlarmCallbackConfigurationService;
 import org.graylog2.alerts.AlertService;
 import org.graylog2.database.MongoConnectionRule;
@@ -38,6 +40,7 @@ import java.util.List;
 
 import static com.lordofthejars.nosqlunit.mongodb.InMemoryMongoDb.InMemoryMongoRuleBuilder.newInMemoryMongoDbRule;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.Assert.assertEquals;
 
 public class StreamServiceImplTest {
     @ClassRule
@@ -98,5 +101,30 @@ public class StreamServiceImplTest {
         assertThat(alertableStreams)
             .isNotEmpty()
             .hasSize(2);
+    }
+
+    @Test
+    public void getSurroundingFiltersOnStream() {
+        final StreamMock stream = getStreamMock("test");
+
+        assertEquals(stream.getSurroundingFilters(), stream.DEFAULT_SURROUNDING_FILTERS);
+    }
+
+    @Test
+    public void setSurroundingFiltersOnStream() {
+        final StreamMock stream = getStreamMock("test");
+        final String newSurroundingFilter = "test, source, name";
+
+        stream.setSurroundingFilters(newSurroundingFilter);
+
+        assertEquals(stream.getSurroundingFilters(), newSurroundingFilter);
+    }
+
+    private StreamMock getStreamMock(String title) {
+        return getStreamMock(title, Stream.MatchingType.AND);
+    }
+
+    private StreamMock getStreamMock(String title, Stream.MatchingType matchingType) {
+        return new StreamMock(ImmutableMap.of("_id", new ObjectId(), "title", title, "matching_type", matchingType));
     }
 }

--- a/graylog2-web-interface/src/components/search/MessageDetail.jsx
+++ b/graylog2-web-interface/src/components/search/MessageDetail.jsx
@@ -28,10 +28,13 @@ const MessageDetail = React.createClass({
     nodes: PropTypes.object,
     message: PropTypes.object,
     streams: PropTypes.object,
+    searchInStream: PropTypes.object,
     customFieldActions: PropTypes.node,
     searchConfig: PropTypes.object,
     disableMessageActions: PropTypes.bool,
   },
+
+  DEFAULT_SURROUNDING_FILTERS: 'source, gl2_source_input, file, source_file',
 
   getInitialState() {
     return {
@@ -131,11 +134,16 @@ const MessageDetail = React.createClass({
     const messageUrl = this.props.message.index ? Routes.message_show(this.props.message.index, this.props.message.id) : '#';
 
     let surroundingSearchButton;
+    console.log("Stream objecct");
+    console.log(this.props.streams);
+
+    let surrounding_filters = this.props.searchInStream ? this.STREAM_SEARCH_COUNT_WIDGET_TYPE : this.SEARCH_COUNT_WIDGET_TYPE
     if (!this.props.disableSurroundingSearch) {
       surroundingSearchButton = (
         <SurroundingSearchButton id={this.props.message.id}
                                  timestamp={this.props.message.timestamp}
                                  searchConfig={this.props.searchConfig}
+                                 surroundingFilters={this.props.searchInStream ? this.props.searchInStream.surrounding_filters : this.DEFAULT_SURROUNDING_FILTERS}
                                  messageFields={this.props.message.fields} />
       );
     }

--- a/graylog2-web-interface/src/components/search/MessageDetail.jsx
+++ b/graylog2-web-interface/src/components/search/MessageDetail.jsx
@@ -134,10 +134,7 @@ const MessageDetail = React.createClass({
     const messageUrl = this.props.message.index ? Routes.message_show(this.props.message.index, this.props.message.id) : '#';
 
     let surroundingSearchButton;
-    console.log("Stream objecct");
-    console.log(this.props.streams);
 
-    let surrounding_filters = this.props.searchInStream ? this.STREAM_SEARCH_COUNT_WIDGET_TYPE : this.SEARCH_COUNT_WIDGET_TYPE
     if (!this.props.disableSurroundingSearch) {
       surroundingSearchButton = (
         <SurroundingSearchButton id={this.props.message.id}

--- a/graylog2-web-interface/src/components/search/MessageTableEntry.jsx
+++ b/graylog2-web-interface/src/components/search/MessageTableEntry.jsx
@@ -96,7 +96,7 @@ const MessageTableEntry = React.createClass({
         <tr className="message-detail-row" style={{ display: 'table-row' }}>
           <td colSpan={colSpanFixup}>
             <MessageDetail message={this.props.message} inputs={this.props.inputs} streams={this.props.streams}
-                         allStreams={this.props.allStreams} allStreamsLoaded={this.props.allStreamsLoaded}
+                         allStreams={this.props.allStreams} searchInStream={this.props.searchInStream} allStreamsLoaded={this.props.allStreamsLoaded}
                          nodes={this.props.nodes} possiblyHighlight={this.possiblyHighlight}
                          expandAllRenderAsync={this.props.expandAllRenderAsync} searchConfig={this.props.searchConfig} />
           </td>

--- a/graylog2-web-interface/src/components/search/ResultTable.jsx
+++ b/graylog2-web-interface/src/components/search/ResultTable.jsx
@@ -24,6 +24,7 @@ const ResultTable = React.createClass({
     sortField: PropTypes.string.isRequired,
     sortOrder: PropTypes.string.isRequired,
     streams: PropTypes.object.isRequired,
+    searchInStream: PropTypes.object,
     searchConfig: PropTypes.object.isRequired,
   },
   getInitialState() {
@@ -171,6 +172,7 @@ const ResultTable = React.createClass({
                                        streams={this.props.streams}
                                        allStreams={this.state.allStreams}
                                        allStreamsLoaded={this.state.allStreamsLoaded}
+                                       searchInStream={this.props.searchInStream}
                                        nodes={this.props.nodes}
                                        highlight={this.props.highlight}
                                        highlightMessage={SearchStore.highlightMessage}

--- a/graylog2-web-interface/src/components/search/SearchResult.jsx
+++ b/graylog2-web-interface/src/components/search/SearchResult.jsx
@@ -219,6 +219,7 @@ const SearchResult = React.createClass({
                        resultCount={this.props.result.total_results}
                        inputs={this.props.inputs}
                        streams={this.props.streams}
+                       searchInStream={this.props.searchInStream}
                        nodes={this.props.nodes}
                        highlight={this.state.shouldHighlight}
                        searchConfig={this.props.searchConfig} />

--- a/graylog2-web-interface/src/components/search/SurroundingSearchButton.jsx
+++ b/graylog2-web-interface/src/components/search/SurroundingSearchButton.jsx
@@ -13,6 +13,7 @@ const SurroundingSearchButton = React.createClass({
     id: PropTypes.string.isRequired,
     timestamp: PropTypes.number.isRequired,
     searchConfig: PropTypes.object.isRequired,
+    surroundingFilters: PropTypes.string.isRequired,
     messageFields: PropTypes.object.isRequired,
   },
 
@@ -29,8 +30,12 @@ const SurroundingSearchButton = React.createClass({
   _buildFilterFields() {
     const fields = {};
 
-    if (this.props.searchConfig) {
-      this.props.searchConfig.surrounding_filter_fields.forEach((field) => {
+    if (this.props.surroundingFilters) {
+      let filters = this.props.surroundingFilters.split(",")
+        .map(f => f.trim())
+        .filter(f => f.length > 0);
+
+      filters.forEach((field) => {
         fields[field] = this.props.messageFields[field];
       });
     }

--- a/graylog2-web-interface/src/components/streams/StreamControls.jsx
+++ b/graylog2-web-interface/src/components/streams/StreamControls.jsx
@@ -75,8 +75,8 @@ const StreamControls = React.createClass({
             </MenuItem>
           </IfPermitted>
         </DropdownButton>
-        <StreamForm ref="streamForm" title="Editing Stream" onSubmit={this.props.onUpdate} stream={stream} indexSets={this.props.indexSets} />
-        <StreamForm ref="cloneForm" title="Cloning Stream" onSubmit={this._onCloneSubmit} indexSets={this.props.indexSets} />
+        <StreamForm ref="streamForm" title="Editing Stream" action="Edit" onSubmit={this.props.onUpdate} stream={stream} indexSets={this.props.indexSets} />
+        <StreamForm ref="cloneForm" title="Cloning Stream" action="Clone" onSubmit={this._onCloneSubmit} stream={stream} indexSets={this.props.indexSets} />
       </span>
     );
   },

--- a/graylog2-web-interface/src/components/streams/StreamForm.jsx
+++ b/graylog2-web-interface/src/components/streams/StreamForm.jsx
@@ -13,6 +13,7 @@ const StreamForm = React.createClass({
     onSubmit: PropTypes.func.isRequired,
     stream: PropTypes.object.isRequired,
     title: PropTypes.string.isRequired,
+    action: PropTypes.string,
     indexSets: PropTypes.array.isRequired,
   },
 
@@ -24,12 +25,17 @@ const StreamForm = React.createClass({
         title: '',
         description: '',
         remove_matches_from_default_stream: false,
+        surrounding_filters: 'file, source, gl2_source_input, source_file',
       },
     };
   },
 
   getInitialState() {
     return this._getValuesFromProps(this.props);
+  },
+
+  handleChange: function(field, value) {
+    this.setState({[field]: value});
   },
 
   _resetValues() {
@@ -49,6 +55,7 @@ const StreamForm = React.createClass({
       title: props.stream.title,
       description: props.stream.description,
       remove_matches_from_default_stream: props.stream.remove_matches_from_default_stream,
+      surrounding_filters: props.stream.surrounding_filters,
       index_set_id: defaultIndexSetId,
     };
   },
@@ -59,6 +66,7 @@ const StreamForm = React.createClass({
         title: this.state.title,
         description: this.state.description,
         remove_matches_from_default_stream: this.state.remove_matches_from_default_stream,
+        surrounding_filters: this.state.surrounding_filters,
         index_set_id: this.state.index_set_id,
       });
     this.refs.modal.close();
@@ -103,7 +111,7 @@ const StreamForm = React.createClass({
       <BootstrapModalForm ref="modal"
                           title={this.props.title}
                           onSubmitForm={this._onSubmit}
-                          submitButtonText="Save">
+                          submitButtonText={this.props.action ? this.props.action : "Save"}>
         <Input id="Title" type="text" required label="Title" name="Title"
                placeholder="A descriptive name of the new stream"
                valueLink={this.linkState('title')} autoFocus />
@@ -111,6 +119,9 @@ const StreamForm = React.createClass({
                placeholder="What kind of messages are routed into this stream?"
                valueLink={this.linkState('description')} />
         {indexSetSelect}
+        <Input id="SurroundingFilters" type="text" label="Surrounding Fields" name="Show Surrounding Fields"
+               placeholder="The fields to correlate with for Show Surrounding Messages." value={this.state.surrounding_filters} onChange={e=>this.handleChange('surrounding_filters', e.target.value)}
+               help={<span>If blank, defaults to 'file, source, gl2_source_input, source_file'</span>} />
         <Input id="RemoveFromDefaultStream" type="checkbox" label="Remove matches from 'All messages' stream" name="Remove from All messages"
                help={<span>Remove messages that match this stream from the 'All messages' stream which is assigned to every message by default.</span>}
                checkedLink={this.linkState('remove_matches_from_default_stream')} />


### PR DESCRIPTION
This PR adds the ability to maintain separate Surrounding Filters Fields for each individual Stream. By default, GL2 only provides a master configuration option in SearchesClusterConfig to modify this value. This is inadequate because different streams might contain many different types of correlated field names and these fields might only make sense for a particular stream.

## Description
- Implemented support for surrounding_filters in the Stream related JAVA classes. Supports creation, modification, and cloning.
- Implemented JSX support for surrounding filters in the StreamForm and subsequent CloneForm and Creation Form. 
- Created an "action" prop so that the Submit button can be assigned a related value such as "Edit", "Clone", or "Save". 
- If the surrounding_filter text input is saved as an empty string, the Java class will revert it back to the default value (Currently hard-coded in StreamImpl.DEFAULT_SURROUNDING_FILTERS.
- Fixed a bug in the cloneForm where values from the Stream being cloned were not being passed into cloneForm. The stream prop was not getting passed in.
- Implemented SurroundingSearchButton component to rely on the value of the Stream's surrounding_filters instead of the Global Configuration value. If the default stream is used, it will rely on the default value.

## Motivation and Context
Provides additional flexibility to filter on similar data more easily at the Stream level.
This feature was referred in Issue #4017

## How Has This Been Tested?
- Packaged Graylog Server with changes, moved to VM and tested server. Examined logs for related error messages. Tested web interface with Developer Tools/REACT dev tools.
- Added unit tests to StreamServiceImplTest to Get and Set the value of surroundingFilters.
- *The remaining challenge is to decide what happens to the value under the Search Configuration. I could see this becoming the Global default value and the Stream's would start with this value, or reset to it if the text input was empty. This PR doesn't go that far as I am unsure of the simplest manner to implement the lookup to SearchesClusterConfig from within the StreamImpl class to make the value of DEFAULT_SURROUNDING_FILTERS the value of global field.*

## Screenshots (if appropriate):
**Creating a Stream - Provides defaults, but can be modified**
![Creating Stream](http://i.imgur.com/GWgbroz.png)

**Editing a Stream - Modify Surrounding Filters, if blank will reset to default**
![Editing Stream](http://i.imgur.com/Y6lbdtT.png)

**Cloning a Stream - Will copy over existing value to new stream - Fixed error where title and description were not getting transferred over**
![Cloning Stream](http://i.imgur.com/ElivXta.png)

**Select Surrounding Filters from the GUI within a Stream will use that stream's surrounding filters.**
![Selecting SurroundingFilterOption](http://i.imgur.com/58Q7jdy.png)
![Filters were utilized](http://i.imgur.com/cniglh9.png)

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [X] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [X] My code follows the code style of this project.
- [X] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.

