### PR TITLE
Adding DSV over HTTP data adapter.

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/lookup/LookupModule.java
+++ b/graylog2-server/src/main/java/org/graylog2/lookup/LookupModule.java
@@ -19,6 +19,7 @@ package org.graylog2.lookup;
 import com.google.inject.assistedinject.FactoryModuleBuilder;
 
 import org.graylog2.lookup.adapters.CSVFileDataAdapter;
+import org.graylog2.lookup.adapters.DSVHTTPDataAdapter;
 import org.graylog2.lookup.adapters.HTTPJSONPathDataAdapter;
 import org.graylog2.lookup.caches.GuavaLookupCache;
 import org.graylog2.lookup.caches.NullCache;
@@ -49,6 +50,11 @@ public class LookupModule extends Graylog2Module {
                 HTTPJSONPathDataAdapter.class,
                 HTTPJSONPathDataAdapter.Factory.class,
                 HTTPJSONPathDataAdapter.Config.class);
+
+        installLookupDataAdapter(DSVHTTPDataAdapter.NAME,
+                DSVHTTPDataAdapter.class,
+                DSVHTTPDataAdapter.Factory.class,
+                DSVHTTPDataAdapter.Config.class);
     }
 
 }

--- a/graylog2-server/src/main/java/org/graylog2/lookup/adapters/DSVHTTPDataAdapter.java
+++ b/graylog2-server/src/main/java/org/graylog2/lookup/adapters/DSVHTTPDataAdapter.java
@@ -1,0 +1,298 @@
+/**
+ * This file is part of Graylog.
+ *
+ * Graylog is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.graylog2.lookup.adapters;
+
+import com.codahale.metrics.MetricRegistry;
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonTypeName;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.google.auto.value.AutoValue;
+import com.google.common.collect.ArrayListMultimap;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.Multimap;
+import com.google.common.primitives.Ints;
+import com.google.inject.assistedinject.Assisted;
+import okhttp3.Call;
+import okhttp3.HttpUrl;
+import okhttp3.OkHttpClient;
+import okhttp3.Request;
+import okhttp3.Response;
+import org.graylog.autovalue.WithBeanGetter;
+import org.graylog2.lookup.adapters.dsvhttp.DSVParser;
+import org.graylog2.lookup.adapters.dsvhttp.HTTPFileRetriever;
+import org.graylog2.plugin.lookup.LookupCachePurge;
+import org.graylog2.plugin.lookup.LookupDataAdapter;
+import org.graylog2.plugin.lookup.LookupDataAdapterConfiguration;
+import org.graylog2.plugin.lookup.LookupResult;
+import org.hibernate.validator.constraints.NotEmpty;
+import org.joda.time.DateTime;
+import org.joda.time.DateTimeZone;
+import org.joda.time.Duration;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.inject.Inject;
+import javax.validation.constraints.Min;
+import javax.validation.constraints.Size;
+import java.io.IOException;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static com.google.common.base.Strings.isNullOrEmpty;
+
+public class DSVHTTPDataAdapter extends LookupDataAdapter {
+    private static final Logger LOG = LoggerFactory.getLogger(DSVHTTPDataAdapter.class);
+
+    public static final String NAME = "dsvhttp";
+
+    private final DSVHTTPDataAdapter.Config config;
+    private final HTTPFileRetriever httpFileRetriever;
+    private final AtomicReference<Map<String, String>> lookupRef = new AtomicReference<>(Collections.emptyMap());
+    private final DSVParser dsvParser;
+
+    @Inject
+    public DSVHTTPDataAdapter(@Assisted("id") String id,
+                              @Assisted("name") String name,
+                              @Assisted LookupDataAdapterConfiguration config,
+                              MetricRegistry metricRegistry,
+                              HTTPFileRetriever httpFileRetriever) {
+        super(id, name, config, metricRegistry);
+        this.config = (DSVHTTPDataAdapter.Config) config;
+        this.httpFileRetriever = httpFileRetriever;
+        this.dsvParser = new DSVParser(
+                this.config.ignorechar(),
+                this.config.separator(),
+                this.config.quotechar(),
+                this.config.isCheckPresenceOnly(),
+                this.config.isCaseInsensitiveLookup(),
+                this.config.keyColumn(),
+                this.config.valueColumn()
+        );
+    }
+
+    @Override
+    public void doStart() throws Exception {
+        LOG.debug("Starting HTTP DSV data adapter for URL: {}", config.url());
+        if (isNullOrEmpty(config.url())) {
+            throw new IllegalStateException("File path needs to be set");
+        }
+        if (config.refreshInterval() < 1) {
+            throw new IllegalStateException("Check interval setting cannot be smaller than 1");
+        }
+
+        final Optional<String> response = httpFileRetriever.fetchFileIfNotModified(config.url());
+
+        response.ifPresent(body -> lookupRef.set(dsvParser.parse(body)));
+    }
+
+    @Override
+    public Duration refreshInterval() {
+        return Duration.standardSeconds(Ints.saturatedCast(config.refreshInterval()));
+    }
+
+    @Override
+    protected void doRefresh(LookupCachePurge cachePurge) throws Exception {
+        try {
+            final Optional<String> response = this.httpFileRetriever.fetchFileIfNotModified(config.url());
+
+            response.ifPresent(body -> {
+                LOG.debug("DSV file {} has changed, updating data", config.url());
+                lookupRef.set(dsvParser.parse(body));
+                cachePurge.purgeAll();
+                clearError();
+            });
+        } catch (IOException e) {
+            LOG.error("Couldn't check data adapter <{}> DSV file {} for updates: {} {}", name(), config.url(), e.getClass().getCanonicalName(), e.getMessage());
+            setError(e);
+        }
+    }
+
+    @Override
+    public void doStop() throws Exception {
+        LOG.debug("Stopping HTTP DSV data adapter for url: {}", config.url());
+    }
+
+    @Override
+    public LookupResult doGet(Object key) {
+        final String stringKey = config.isCaseInsensitiveLookup() ? String.valueOf(key).toLowerCase(Locale.ENGLISH) : String.valueOf(key);
+
+        if (config.isCheckPresenceOnly()) {
+            return LookupResult.single(lookupRef.get().containsKey(stringKey));
+        }
+
+        final String value = lookupRef.get().get(stringKey);
+
+        if (value == null) {
+            return LookupResult.empty();
+        }
+
+        return LookupResult.single(value);
+    }
+
+    @Override
+    public void set(Object key, Object value) {
+        throw new UnsupportedOperationException();
+    }
+
+    public interface Factory extends LookupDataAdapter.Factory<DSVHTTPDataAdapter> {
+        @Override
+        DSVHTTPDataAdapter create(@Assisted("id") String id,
+                                  @Assisted("name") String name,
+                                  LookupDataAdapterConfiguration configuration);
+
+        @Override
+        DSVHTTPDataAdapter.Descriptor getDescriptor();
+    }
+
+    public static class Descriptor extends LookupDataAdapter.Descriptor<DSVHTTPDataAdapter.Config> {
+        public Descriptor() {
+            super(NAME, DSVHTTPDataAdapter.Config.class);
+        }
+
+        @Override
+        public DSVHTTPDataAdapter.Config defaultConfiguration() {
+            return DSVHTTPDataAdapter.Config.builder()
+                    .type(NAME)
+                    .url("https://example.org/table.csv")
+                    .separator(",")
+                    .quotechar("\"")
+                    .ignorechar("#")
+                    .keyColumn(1)
+                    .valueColumn(2)
+                    .refreshInterval(60)
+                    .caseInsensitiveLookup(false)
+                    .checkPresenceOnly(false)
+                    .build();
+        }
+    }
+
+    @AutoValue
+    @WithBeanGetter
+    @JsonAutoDetect
+    @JsonDeserialize(builder = AutoValue_DSVHTTPDataAdapter_Config.Builder.class)
+    @JsonTypeName(NAME)
+    public static abstract class Config implements LookupDataAdapterConfiguration {
+
+        @Override
+        @JsonProperty(TYPE_FIELD)
+        public abstract String type();
+
+        @JsonProperty("url")
+        @NotEmpty
+        public abstract String url();
+
+        // Using String here instead of char to allow deserialization of a longer (invalid) string to get proper
+        // validation error messages
+        @JsonProperty("separator")
+        @Size(min = 1, max = 1)
+        @NotEmpty
+        public abstract String separator();
+
+        // Using String here instead of char to allow deserialization of a longer (invalid) string to get proper
+        // validation error messages
+        @JsonProperty("quotechar")
+        @Size(min = 1, max = 1)
+        @NotEmpty
+        public abstract String quotechar();
+
+        @JsonProperty("ignorechar")
+        @Size(min = 1)
+        @NotEmpty
+        public abstract String ignorechar();
+
+        @JsonProperty("key_column")
+        @NotEmpty
+        public abstract Integer keyColumn();
+
+        @JsonProperty("check_presence_only")
+        public abstract Optional<Boolean> checkPresenceOnly();
+
+        @JsonProperty("value_column")
+        @NotEmpty
+        public abstract Optional<Integer> valueColumn();
+
+        @JsonProperty("refresh_interval")
+        @Min(1)
+        public abstract long refreshInterval();
+
+        @JsonProperty("case_insensitive_lookup")
+        public abstract Optional<Boolean> caseInsensitiveLookup();
+
+        public boolean isCaseInsensitiveLookup() {
+            return caseInsensitiveLookup().orElse(false);
+        }
+
+        public boolean isCheckPresenceOnly() {
+            return checkPresenceOnly().orElse(false);
+        }
+
+        public static DSVHTTPDataAdapter.Config.Builder builder() {
+            return new AutoValue_DSVHTTPDataAdapter_Config.Builder();
+        }
+
+        @Override
+        public Optional<Multimap<String, String>> validate() {
+            final ArrayListMultimap<String, String> errors = ArrayListMultimap.create();
+
+            if (HttpUrl.parse(url()) == null) {
+                errors.put("url", "Unable to parse url: " + url());
+            }
+
+            return errors.isEmpty() ? Optional.empty() : Optional.of(errors);
+        }
+
+        @AutoValue.Builder
+        public abstract static class Builder {
+            @JsonProperty(TYPE_FIELD)
+            public abstract DSVHTTPDataAdapter.Config.Builder type(String type);
+
+            @JsonProperty("url")
+            public abstract DSVHTTPDataAdapter.Config.Builder url(String url);
+
+            @JsonProperty("separator")
+            public abstract DSVHTTPDataAdapter.Config.Builder separator(String separator);
+
+            @JsonProperty("quotechar")
+            public abstract DSVHTTPDataAdapter.Config.Builder quotechar(String quotechar);
+
+            @JsonProperty("ignorechar")
+            public abstract DSVHTTPDataAdapter.Config.Builder ignorechar(String ignorechar);
+
+            @JsonProperty("key_column")
+            public abstract DSVHTTPDataAdapter.Config.Builder keyColumn(Integer keyColumn);
+
+            @JsonProperty("value_column")
+            public abstract DSVHTTPDataAdapter.Config.Builder valueColumn(Integer valueColumn);
+
+            @JsonProperty("refresh_interval")
+            public abstract DSVHTTPDataAdapter.Config.Builder refreshInterval(long refreshInterval);
+
+            @JsonProperty("case_insensitive_lookup")
+            public abstract DSVHTTPDataAdapter.Config.Builder caseInsensitiveLookup(Boolean caseInsensitiveLookup);
+
+            @JsonProperty("check_presence_only")
+            public abstract DSVHTTPDataAdapter.Config.Builder checkPresenceOnly(Boolean checkPresenceOnly);
+
+            public abstract DSVHTTPDataAdapter.Config build();
+        }
+    }
+}

--- a/graylog2-server/src/main/java/org/graylog2/lookup/adapters/DSVHTTPDataAdapter.java
+++ b/graylog2-server/src/main/java/org/graylog2/lookup/adapters/DSVHTTPDataAdapter.java
@@ -81,6 +81,7 @@ public class DSVHTTPDataAdapter extends LookupDataAdapter {
         this.dsvParser = new DSVParser(
                 this.config.ignorechar(),
                 this.config.separator(),
+                this.config.lineSeparator(),
                 this.config.quotechar(),
                 this.config.isCheckPresenceOnly(),
                 this.config.isCaseInsensitiveLookup(),
@@ -174,6 +175,7 @@ public class DSVHTTPDataAdapter extends LookupDataAdapter {
                     .type(NAME)
                     .url("https://example.org/table.csv")
                     .separator(",")
+                    .lineSeparator("\n")
                     .quotechar("\"")
                     .ignorechar("#")
                     .keyColumn(1)
@@ -206,6 +208,11 @@ public class DSVHTTPDataAdapter extends LookupDataAdapter {
         @Size(min = 1, max = 1)
         @NotEmpty
         public abstract String separator();
+
+        @JsonProperty("line_separator")
+        @Size(min = 1, max = 1)
+        @NotEmpty
+        public abstract String lineSeparator();
 
         // Using String here instead of char to allow deserialization of a longer (invalid) string to get proper
         // validation error messages
@@ -270,6 +277,9 @@ public class DSVHTTPDataAdapter extends LookupDataAdapter {
 
             @JsonProperty("separator")
             public abstract DSVHTTPDataAdapter.Config.Builder separator(String separator);
+
+            @JsonProperty("line_separator")
+            public abstract DSVHTTPDataAdapter.Config.Builder lineSeparator(String separator);
 
             @JsonProperty("quotechar")
             public abstract DSVHTTPDataAdapter.Config.Builder quotechar(String quotechar);

--- a/graylog2-server/src/main/java/org/graylog2/lookup/adapters/dsvhttp/DSVParser.java
+++ b/graylog2-server/src/main/java/org/graylog2/lookup/adapters/dsvhttp/DSVParser.java
@@ -1,3 +1,19 @@
+/**
+ * This file is part of Graylog.
+ *
+ * Graylog is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package org.graylog2.lookup.adapters.dsvhttp;
 
 import com.google.common.base.Strings;

--- a/graylog2-server/src/main/java/org/graylog2/lookup/adapters/dsvhttp/DSVParser.java
+++ b/graylog2-server/src/main/java/org/graylog2/lookup/adapters/dsvhttp/DSVParser.java
@@ -32,6 +32,8 @@ public class DSVParser {
     private final Boolean caseInsensitive;
     private final Integer keyColumn;
     private final Optional<Integer> valueColumn;
+    
+    private final String splitPattern;
 
     public DSVParser(String ignorechar,
                      String lineSeparator,
@@ -50,6 +52,12 @@ public class DSVParser {
         this.caseInsensitive = caseInsensitive;
         this.keyColumn = keyColumn;
         this.valueColumn = valueColumn;
+
+        if (Strings.isNullOrEmpty(quoteChar)) {
+            this.splitPattern = separator;
+        } else {
+            this.splitPattern = separator + "(?=(?:[^\\" + quoteChar + "]*\\" + quoteChar + "[^\\" + quoteChar + "]*\\" + quoteChar + ")*[^\\" + quoteChar + "]*$)";
+        }
     }
 
     public Map<String, String> parse(String body) {
@@ -61,7 +69,7 @@ public class DSVParser {
             if (line.startsWith(this.ignorechar)) {
                 continue;
             }
-            final String[] values = line.split(this.separator);
+            final String[] values = line.split(this.splitPattern);
             if (values.length <= Math.max(keyColumn, keyOnly ? 0 : valueColumn.orElse(0))) {
                 continue;
             }

--- a/graylog2-server/src/main/java/org/graylog2/lookup/adapters/dsvhttp/DSVParser.java
+++ b/graylog2-server/src/main/java/org/graylog2/lookup/adapters/dsvhttp/DSVParser.java
@@ -1,0 +1,58 @@
+package org.graylog2.lookup.adapters.dsvhttp;
+
+import com.google.common.base.Strings;
+import com.google.common.collect.ImmutableMap;
+
+import java.util.Locale;
+import java.util.Map;
+import java.util.Optional;
+
+public class DSVParser {
+    private final String ignorechar;
+    private final String separator;
+    private final String quoteChar;
+    private final Boolean keyOnly;
+    private final Boolean caseInsensitive;
+    private final Integer keyColumn;
+    private final Optional<Integer> valueColumn;
+
+    public DSVParser(String ignorechar,
+                     String separator,
+                     String quoteChar,
+                     Boolean keyOnly,
+                     Boolean caseInsensitive,
+                     Integer keyColumn,
+                     Optional<Integer> valueColumn) {
+
+        this.ignorechar = ignorechar;
+        this.separator = separator;
+        this.quoteChar = quoteChar;
+        this.keyOnly = keyOnly;
+        this.caseInsensitive = caseInsensitive;
+        this.keyColumn = keyColumn;
+        this.valueColumn = valueColumn;
+    }
+
+    public Map<String, String> parse(String body) {
+        final ImmutableMap.Builder<String, String> newLookupBuilder = ImmutableMap.builder();
+
+        final String[] lines = body.split("\n");
+
+        for (String line : lines) {
+            if (line.startsWith(this.ignorechar)) {
+                continue;
+            }
+            final String[] values = line.split(this.separator);
+            if (values.length <= Math.max(keyColumn, keyOnly ? 0 : valueColumn.orElse(0))) {
+                continue;
+            }
+            final String key = this.caseInsensitive ? values[keyColumn].toLowerCase(Locale.ENGLISH) : values[keyColumn];
+            final String value = this.keyOnly ? "" : values[valueColumn.orElseThrow(() -> new IllegalStateException("No value column and not key only parsing specified!"))].trim();
+            final String finalKey = Strings.isNullOrEmpty(quoteChar) ? key.trim() : key.trim().replaceAll("^" + quoteChar + "|" + quoteChar + "$", "");
+            final String finalValue = Strings.isNullOrEmpty(quoteChar) ? value.trim() : value.trim().replaceAll("^" + quoteChar + "|" + quoteChar + "$", "");
+            newLookupBuilder.put(finalKey, finalValue);
+        }
+
+        return newLookupBuilder.build();
+    }
+}

--- a/graylog2-server/src/main/java/org/graylog2/lookup/adapters/dsvhttp/DSVParser.java
+++ b/graylog2-server/src/main/java/org/graylog2/lookup/adapters/dsvhttp/DSVParser.java
@@ -25,6 +25,7 @@ import java.util.Optional;
 
 public class DSVParser {
     private final String ignorechar;
+    private final String lineSeparator;
     private final String separator;
     private final String quoteChar;
     private final Boolean keyOnly;
@@ -33,6 +34,7 @@ public class DSVParser {
     private final Optional<Integer> valueColumn;
 
     public DSVParser(String ignorechar,
+                     String lineSeparator,
                      String separator,
                      String quoteChar,
                      Boolean keyOnly,
@@ -41,6 +43,7 @@ public class DSVParser {
                      Optional<Integer> valueColumn) {
 
         this.ignorechar = ignorechar;
+        this.lineSeparator = lineSeparator;
         this.separator = separator;
         this.quoteChar = quoteChar;
         this.keyOnly = keyOnly;
@@ -52,7 +55,7 @@ public class DSVParser {
     public Map<String, String> parse(String body) {
         final ImmutableMap.Builder<String, String> newLookupBuilder = ImmutableMap.builder();
 
-        final String[] lines = body.split("\n");
+        final String[] lines = body.split(lineSeparator);
 
         for (String line : lines) {
             if (line.startsWith(this.ignorechar)) {

--- a/graylog2-server/src/main/java/org/graylog2/lookup/adapters/dsvhttp/HTTPFileRetriever.java
+++ b/graylog2-server/src/main/java/org/graylog2/lookup/adapters/dsvhttp/HTTPFileRetriever.java
@@ -1,0 +1,62 @@
+package org.graylog2.lookup.adapters.dsvhttp;
+
+import com.google.common.collect.ImmutableMap;
+import okhttp3.Call;
+import okhttp3.OkHttpClient;
+import okhttp3.Request;
+import okhttp3.Response;
+import org.joda.time.DateTime;
+import org.joda.time.DateTimeZone;
+
+import javax.inject.Inject;
+import java.io.IOException;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.atomic.AtomicReference;
+
+public class HTTPFileRetriever {
+    private final AtomicReference<Map<String, String>> lastLastModified = new AtomicReference<>(Collections.emptyMap());
+    private final OkHttpClient client;
+
+    @Inject
+    public HTTPFileRetriever(OkHttpClient httpClient) {
+        this.client = httpClient.newBuilder()
+                .followRedirects(true)
+                .followSslRedirects(true)
+                .build();
+    }
+
+    public Optional<String> fetchFileIfNotModified(String url) throws IOException {
+        final Request.Builder requestBuilder = new Request.Builder()
+                .get()
+                .url(url)
+                .header("User-Agent", "Graylog (server)");
+        final String lastModified = this.lastLastModified.get().get(url);
+        if (lastModified != null) {
+            requestBuilder.header("If-Modified-Since", lastModified);
+        }
+        final Call request = client.newCall(requestBuilder.build());
+
+        final Response response = request.execute();
+
+        if (response.isSuccessful()) {
+            final String lastModifiedHeader = response.header("Last-Modified", DateTime.now(DateTimeZone.UTC).toString());
+            final Map<String, String> newLastModified = new HashMap<>(this.lastLastModified.get());
+            newLastModified.put(url, lastModifiedHeader);
+            this.lastLastModified.set(ImmutableMap.copyOf(newLastModified));
+
+            if (response.body() != null) {
+                final String body = response.body().string();
+                return body == null ? Optional.empty() : Optional.of(body);
+            }
+        } else {
+            if (response.code() != 304) {
+                throw new IOException("Request failed: " + response.message());
+            }
+        }
+
+        return Optional.empty();
+    }
+}

--- a/graylog2-server/src/main/java/org/graylog2/lookup/adapters/dsvhttp/HTTPFileRetriever.java
+++ b/graylog2-server/src/main/java/org/graylog2/lookup/adapters/dsvhttp/HTTPFileRetriever.java
@@ -1,3 +1,19 @@
+/**
+ * This file is part of Graylog.
+ *
+ * Graylog is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package org.graylog2.lookup.adapters.dsvhttp;
 
 import com.google.common.collect.ImmutableMap;

--- a/graylog2-server/src/test/java/org/graylog2/lookup/adapters/dsvhttp/DSVParserTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/lookup/adapters/dsvhttp/DSVParserTest.java
@@ -90,7 +90,9 @@ public class DSVParserTest {
         final String input = "# Sample file for testing\n" +
                 "\"foo\":\"23\"\n" +
                 "\"bar\":\"42\"\n" +
-                "\"baz\":\"17\"";
+                "\"baz\":\"17\"\n" +
+                "\"qux\":\"42:23\"\n" +
+                "\"qu:ux\":\"42\"";
         final DSVParser dsvParser = new DSVParser("#", "\n", ":", "\"", false, false, 0, Optional.of(1));
 
         final Map<String, String> result = dsvParser.parse(input);
@@ -98,11 +100,13 @@ public class DSVParserTest {
         assertThat(result)
                 .isNotNull()
                 .isNotEmpty()
-                .hasSize(3)
+                .hasSize(5)
                 .containsExactly(
                         new AbstractMap.SimpleEntry<>("foo", "23"),
                         new AbstractMap.SimpleEntry<>("bar", "42"),
-                        new AbstractMap.SimpleEntry<>("baz", "17")
+                        new AbstractMap.SimpleEntry<>("baz", "17"),
+                        new AbstractMap.SimpleEntry<>("qux", "42:23"),
+                        new AbstractMap.SimpleEntry<>("qu:ux", "42")
                 );
     }
 

--- a/graylog2-server/src/test/java/org/graylog2/lookup/adapters/dsvhttp/DSVParserTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/lookup/adapters/dsvhttp/DSVParserTest.java
@@ -1,0 +1,131 @@
+package org.graylog2.lookup.adapters.dsvhttp;
+
+import org.junit.Test;
+
+import java.util.AbstractMap;
+import java.util.Map;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class DSVParserTest {
+    @Test
+    public void parseSimpleFile() throws Exception {
+        final String input = "# Sample file for testing\n" +
+                "foo:23\n" +
+                "bar:42\n" +
+                "baz:17";
+        final DSVParser dsvParser = new DSVParser("#", ":", "", false, false, 0, Optional.of(1));
+
+        final Map<String, String> result = dsvParser.parse(input);
+
+        assertThat(result)
+                .isNotNull()
+                .isNotEmpty()
+                .hasSize(3)
+                .containsExactly(
+                        new AbstractMap.SimpleEntry<>("foo", "23"),
+                        new AbstractMap.SimpleEntry<>("bar", "42"),
+                        new AbstractMap.SimpleEntry<>("baz", "17")
+                );
+    }
+
+    @Test
+    public void parseFileWithSwappedColumns() throws Exception {
+        final String input = "# Sample file for testing\n" +
+                "foo:23\n" +
+                "bar:42\n" +
+                "baz:17";
+        final DSVParser dsvParser = new DSVParser("#", ":", "", false, false, 1, Optional.of(0));
+
+        final Map<String, String> result = dsvParser.parse(input);
+
+        assertThat(result)
+                .isNotNull()
+                .isNotEmpty()
+                .hasSize(3)
+                .containsExactly(
+                        new AbstractMap.SimpleEntry<>("23", "foo"),
+                        new AbstractMap.SimpleEntry<>("42", "bar"),
+                        new AbstractMap.SimpleEntry<>("17", "baz")
+                );
+    }
+
+    @Test
+    public void parseQuotedStrings() throws Exception {
+        final String input = "# Sample file for testing\n" +
+                "\"foo\":\"23\"\n" +
+                "\"bar\":\"42\"\n" +
+                "\"baz\":\"17\"";
+        final DSVParser dsvParser = new DSVParser("#", ":", "\"", false, false, 0, Optional.of(1));
+
+        final Map<String, String> result = dsvParser.parse(input);
+
+        assertThat(result)
+                .isNotNull()
+                .isNotEmpty()
+                .hasSize(3)
+                .containsExactly(
+                        new AbstractMap.SimpleEntry<>("foo", "23"),
+                        new AbstractMap.SimpleEntry<>("bar", "42"),
+                        new AbstractMap.SimpleEntry<>("baz", "17")
+                );
+    }
+
+    @Test
+    public void parseKeyOnlyFile() throws Exception {
+        final String input = "# Sample file for testing\n" +
+                "foo\n" +
+                "bar\n" +
+                "baz";
+        final DSVParser dsvParser = new DSVParser("#", ":", "", true, false, 0, Optional.empty());
+
+        final Map<String, String> result = dsvParser.parse(input);
+
+        assertThat(result)
+                .isNotNull()
+                .isNotEmpty()
+                .hasSize(3)
+                .containsExactly(
+                        new AbstractMap.SimpleEntry<>("foo", ""),
+                        new AbstractMap.SimpleEntry<>("bar", ""),
+                        new AbstractMap.SimpleEntry<>("baz", "")
+                );
+    }
+
+    @Test
+    public void parseKeyOnlyFileWithDifferentKeyColumn() throws Exception {
+        final String input = "# Sample file for testing\n" +
+                "1;foo\n" +
+                "2;bar\n" +
+                "3;baz";
+        final DSVParser dsvParser = new DSVParser("#", ";", "", true, false, 1, Optional.empty());
+
+        final Map<String, String> result = dsvParser.parse(input);
+
+        assertThat(result)
+                .isNotNull()
+                .isNotEmpty()
+                .hasSize(3)
+                .containsExactly(
+                        new AbstractMap.SimpleEntry<>("foo", ""),
+                        new AbstractMap.SimpleEntry<>("bar", ""),
+                        new AbstractMap.SimpleEntry<>("baz", "")
+                );
+    }
+
+    @Test
+    public void parseKeyOnlyFileWithNonexistingKeyColumn() throws Exception {
+        final String input = "# Sample file for testing\n" +
+                "1;foo\n" +
+                "2;bar\n" +
+                "3;baz";
+        final DSVParser dsvParser = new DSVParser("#", ";", "", true, false, 2, Optional.empty());
+
+        final Map<String, String> result = dsvParser.parse(input);
+
+        assertThat(result)
+                .isNotNull()
+                .isEmpty();
+    }
+}

--- a/graylog2-server/src/test/java/org/graylog2/lookup/adapters/dsvhttp/DSVParserTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/lookup/adapters/dsvhttp/DSVParserTest.java
@@ -31,7 +31,25 @@ public class DSVParserTest {
                 "foo:23\n" +
                 "bar:42\n" +
                 "baz:17";
-        final DSVParser dsvParser = new DSVParser("#", ":", "", false, false, 0, Optional.of(1));
+        final DSVParser dsvParser = new DSVParser("#", "\n", ":", "", false, false, 0, Optional.of(1));
+
+        final Map<String, String> result = dsvParser.parse(input);
+
+        assertThat(result)
+                .isNotNull()
+                .isNotEmpty()
+                .hasSize(3)
+                .containsExactly(
+                        new AbstractMap.SimpleEntry<>("foo", "23"),
+                        new AbstractMap.SimpleEntry<>("bar", "42"),
+                        new AbstractMap.SimpleEntry<>("baz", "17")
+                );
+    }
+
+    @Test
+    public void parseSimpleFileWithDifferentLineSeparator() throws Exception {
+        final String input = "# Sample file for testing;foo:23;bar:42;baz:17";
+        final DSVParser dsvParser = new DSVParser("#", ";", ":", "", false, false, 0, Optional.of(1));
 
         final Map<String, String> result = dsvParser.parse(input);
 
@@ -52,7 +70,7 @@ public class DSVParserTest {
                 "foo:23\n" +
                 "bar:42\n" +
                 "baz:17";
-        final DSVParser dsvParser = new DSVParser("#", ":", "", false, false, 1, Optional.of(0));
+        final DSVParser dsvParser = new DSVParser("#", "\n", ":", "", false, false, 1, Optional.of(0));
 
         final Map<String, String> result = dsvParser.parse(input);
 
@@ -73,7 +91,7 @@ public class DSVParserTest {
                 "\"foo\":\"23\"\n" +
                 "\"bar\":\"42\"\n" +
                 "\"baz\":\"17\"";
-        final DSVParser dsvParser = new DSVParser("#", ":", "\"", false, false, 0, Optional.of(1));
+        final DSVParser dsvParser = new DSVParser("#", "\n", ":", "\"", false, false, 0, Optional.of(1));
 
         final Map<String, String> result = dsvParser.parse(input);
 
@@ -94,7 +112,7 @@ public class DSVParserTest {
                 "foo\n" +
                 "bar\n" +
                 "baz";
-        final DSVParser dsvParser = new DSVParser("#", ":", "", true, false, 0, Optional.empty());
+        final DSVParser dsvParser = new DSVParser("#", "\n", ":", "", true, false, 0, Optional.empty());
 
         final Map<String, String> result = dsvParser.parse(input);
 
@@ -115,7 +133,7 @@ public class DSVParserTest {
                 "1;foo\n" +
                 "2;bar\n" +
                 "3;baz";
-        final DSVParser dsvParser = new DSVParser("#", ";", "", true, false, 1, Optional.empty());
+        final DSVParser dsvParser = new DSVParser("#", "\n", ";", "", true, false, 1, Optional.empty());
 
         final Map<String, String> result = dsvParser.parse(input);
 
@@ -136,7 +154,7 @@ public class DSVParserTest {
                 "1;foo\n" +
                 "2;bar\n" +
                 "3;baz";
-        final DSVParser dsvParser = new DSVParser("#", ";", "", true, false, 2, Optional.empty());
+        final DSVParser dsvParser = new DSVParser("#", "\n", ";", "", true, false, 2, Optional.empty());
 
         final Map<String, String> result = dsvParser.parse(input);
 

--- a/graylog2-server/src/test/java/org/graylog2/lookup/adapters/dsvhttp/DSVParserTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/lookup/adapters/dsvhttp/DSVParserTest.java
@@ -1,3 +1,19 @@
+/**
+ * This file is part of Graylog.
+ *
+ * Graylog is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package org.graylog2.lookup.adapters.dsvhttp;
 
 import org.junit.Test;

--- a/graylog2-server/src/test/java/org/graylog2/lookup/adapters/dsvhttp/DSVParserTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/lookup/adapters/dsvhttp/DSVParserTest.java
@@ -107,6 +107,31 @@ public class DSVParserTest {
     }
 
     @Test
+    public void parseQuotedStringsWithSeparatorInKey() throws Exception {
+        final String input = "# Sample file for testing\n" +
+                "\"foo\":\"23\"\n" +
+                "\"bar\":\"42\"\n" +
+                "\"baz\":\"17\"\n" +
+                "\"qux\":\"42:23\"\n" +
+                "\"qu:ux\":\"42\"";
+        final DSVParser dsvParser = new DSVParser("#", "\n", ":", "\"", false, false, 0, Optional.of(1));
+
+        final Map<String, String> result = dsvParser.parse(input);
+
+        assertThat(result)
+                .isNotNull()
+                .isNotEmpty()
+                .hasSize(5)
+                .containsExactly(
+                        new AbstractMap.SimpleEntry<>("foo", "23"),
+                        new AbstractMap.SimpleEntry<>("bar", "42"),
+                        new AbstractMap.SimpleEntry<>("baz", "17"),
+                        new AbstractMap.SimpleEntry<>("qux", "42:23"),
+                        new AbstractMap.SimpleEntry<>("qu:ux", "42")
+                );
+    }
+
+    @Test
     public void parseKeyOnlyFile() throws Exception {
         final String input = "# Sample file for testing\n" +
                 "foo\n" +

--- a/graylog2-server/src/test/java/org/graylog2/lookup/adapters/dsvhttp/HTTPFileRetrieverTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/lookup/adapters/dsvhttp/HTTPFileRetrieverTest.java
@@ -1,3 +1,19 @@
+/**
+ * This file is part of Graylog.
+ *
+ * Graylog is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package org.graylog2.lookup.adapters.dsvhttp;
 
 import okhttp3.OkHttpClient;

--- a/graylog2-server/src/test/java/org/graylog2/lookup/adapters/dsvhttp/HTTPFileRetrieverTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/lookup/adapters/dsvhttp/HTTPFileRetrieverTest.java
@@ -1,0 +1,104 @@
+package org.graylog2.lookup.adapters.dsvhttp;
+
+import okhttp3.OkHttpClient;
+import okhttp3.mockwebserver.MockResponse;
+import okhttp3.mockwebserver.MockWebServer;
+import okhttp3.mockwebserver.RecordedRequest;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+import java.io.IOException;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class HTTPFileRetrieverTest {
+    private MockWebServer server;
+
+    @Rule
+    public final ExpectedException expectedException = ExpectedException.none();
+
+    @Before
+    public void setUp() throws Exception {
+        server = new MockWebServer();
+    }
+
+    @Test
+    public void successfulRetrieve() throws Exception {
+        this.server.enqueue(new MockResponse()
+                .setResponseCode(200)
+                .setBody("foobar"));
+        server.start();
+
+        final HTTPFileRetriever httpFileRetriever = new HTTPFileRetriever(new OkHttpClient());
+
+        final Optional<String> body = httpFileRetriever.fetchFileIfNotModified(server.url("/").toString());
+        final RecordedRequest request = server.takeRequest();
+
+        assertThat(request).isNotNull();
+        assertThat(request.getPath()).isEqualTo("/");
+
+        assertThat(body).isNotNull()
+                .isPresent()
+                .contains("foobar");
+    }
+
+    @Test
+    public void doNotRetrieveIfNotModified() throws Exception {
+        this.server.enqueue(new MockResponse()
+                .setResponseCode(200)
+                .setBody("foobar")
+                .setHeader("Last-Modified", "Fri, 18 Aug 2017 15:02:41 GMT"));
+        this.server.enqueue(new MockResponse()
+                .setResponseCode(304)
+                .setHeader("Last-Modified", "Fri, 18 Aug 2017 15:02:41 GMT"));
+        server.start();
+
+        final HTTPFileRetriever httpFileRetriever = new HTTPFileRetriever(new OkHttpClient());
+
+        final Optional<String> body = httpFileRetriever.fetchFileIfNotModified(server.url("/").toString());
+        final RecordedRequest request = server.takeRequest();
+
+        assertThat(request).isNotNull();
+        assertThat(request.getPath()).isEqualTo("/");
+
+        assertThat(body).isNotNull()
+                .isPresent()
+                .contains("foobar");
+
+        final Optional<String> secondBody = httpFileRetriever.fetchFileIfNotModified(server.url("/").toString());
+        final RecordedRequest secondRequest = server.takeRequest();
+
+        assertThat(secondRequest).isNotNull();
+        assertThat(secondRequest.getPath()).isEqualTo("/");
+        assertThat(secondRequest.getHeader("If-Modified-Since")).isEqualTo("Fri, 18 Aug 2017 15:02:41 GMT");
+
+        assertThat(secondBody).isNotNull()
+                .isEmpty();
+    }
+
+    @Test
+    public void unsuccessfulRetrieve() throws Exception {
+        this.server.enqueue(new MockResponse()
+                .setResponseCode(500)
+                .setBody("Error!"));
+        server.start();
+
+        final HTTPFileRetriever httpFileRetriever = new HTTPFileRetriever(new OkHttpClient());
+
+        expectedException.expect(IOException.class);
+        expectedException.expectMessage("Request failed: Server Error");
+
+        final Optional<String> ignored = httpFileRetriever.fetchFileIfNotModified(server.url("/").toString());
+    }
+
+    @After
+    public void shutDown() throws IOException {
+        if (server != null) {
+            server.shutdown();
+        }
+    }
+}

--- a/graylog2-web-interface/src/components/lookup-tables/adapters/DSVHTTPAdapterDocumentation.jsx
+++ b/graylog2-web-interface/src/components/lookup-tables/adapters/DSVHTTPAdapterDocumentation.jsx
@@ -1,0 +1,52 @@
+import React from 'react';
+
+import { Alert } from 'react-bootstrap';
+
+const DSVHTTPAdapterDocumentation = () => {
+  const csvFile1 = `"127.0.0.1","localhost"
+"10.0.0.1","server1"
+"10.0.0.2","server2"`;
+
+  const csvFile2 = `'127.0.0.1';'e4:b2:11:d1:38:14'
+'10.0.0.1';'e4:b2:12:d1:48:28'
+'10.0.0.2';'e4:b2:11:d1:58:34'`;
+
+  return (<div>
+    <p>The DSV data adapter can read key value pairs (or check for the presence of a key) from a DSV file.</p>
+    <p>Please make sure your DSV file is formatted according to your configuration settings.</p>
+
+    <Alert style={{ marginBottom: 10 }} bsStyle="info">
+      <h4 style={{ marginBottom: 10 }}>CSV file requirements:</h4>
+      <ul className="no-padding">
+        <li>The file uses <strong>utf-8</strong> encoding</li>
+        <li>The file is accessible using the same URL by <strong>every</strong> Graylog server node</li>
+      </ul>
+    </Alert>
+
+    <hr />
+
+    <h3 style={{ marginBottom: 10 }}>Example 1</h3>
+
+    <h5 style={{ marginBottom: 10 }}>Configuration</h5>
+    <p style={{ marginBottom: 10, padding: 0 }}>
+      Separator: <code>,</code><br />
+      Quote character: <code>"</code><br />
+    </p>
+
+    <h5 style={{ marginBottom: 10 }}>DSV File</h5>
+    <pre>{csvFile1}</pre>
+
+    <h3 style={{ marginBottom: 10 }}>Example 2</h3>
+
+    <h5 style={{ marginBottom: 10 }}>Configuration</h5>
+    <p style={{ marginBottom: 10, padding: 0 }}>
+      Separator: <code>;</code><br />
+      Quote character: <code>'</code><br />
+    </p>
+
+    <h5 style={{ marginBottom: 10 }}>DSV File</h5>
+    <pre>{csvFile2}</pre>
+  </div>);
+};
+
+export default DSVHTTPAdapterDocumentation;

--- a/graylog2-web-interface/src/components/lookup-tables/adapters/DSVHTTPAdapterFieldSet.jsx
+++ b/graylog2-web-interface/src/components/lookup-tables/adapters/DSVHTTPAdapterFieldSet.jsx
@@ -1,0 +1,98 @@
+import React from 'react';
+
+import { Input } from 'components/bootstrap';
+
+const DSVHTTPAdapterFieldSet = ({ handleFormEvent, validationState, validationMessage, config}) => {
+  return (<fieldset>
+    <Input type="text"
+           id="url"
+           name="url"
+           label="File URL"
+           autoFocus
+           required
+           onChange={handleFormEvent}
+           help={validationMessage('url', 'The URL of the DSV file.')}
+           bsStyle={validationState('url')}
+           value={config.url}
+           labelClassName="col-sm-3"
+           wrapperClassName="col-sm-9" />
+    <Input type="number"
+           id="refresh_interval"
+           name="refresh_interval"
+           label="Refresh interval"
+           required
+           onChange={handleFormEvent}
+           help="The interval to check if the DSV file needs a reload. (in seconds)"
+           value={config.refresh_interval}
+           labelClassName="col-sm-3"
+           wrapperClassName="col-sm-9" />
+    <Input type="text"
+           id="separator"
+           name="separator"
+           label="Separator"
+           required
+           onChange={handleFormEvent}
+           help="The delimiter to use for separating entries."
+           value={config.separator}
+           labelClassName="col-sm-3"
+           wrapperClassName="col-sm-9" />
+    <Input type="text"
+           id="quotechar"
+           name="quotechar"
+           label="Quote character"
+           required
+           onChange={handleFormEvent}
+           help="The character to use for quoted elements."
+           value={config.quotechar}
+           labelClassName="col-sm-3"
+           wrapperClassName="col-sm-9" />
+    <Input type="text"
+           id="ignorechar"
+           name="ignorechar"
+           label="Ignore characters"
+           required
+           onChange={handleFormEvent}
+           help="Ignore lines starting with these characters."
+           value={config.ignorechar}
+           labelClassName="col-sm-3"
+           wrapperClassName="col-sm-9" />
+    <Input type="text"
+           id="key_column"
+           name="key_column"
+           label="Key column"
+           required
+           onChange={handleFormEvent}
+           help="The column name that should be used for the key lookup."
+           value={config.key_column}
+           labelClassName="col-sm-3"
+           wrapperClassName="col-sm-9" />
+    <Input type="text"
+           id="value_column"
+           name="value_column"
+           label="Value column"
+           required
+           onChange={handleFormEvent}
+           help="The column name that should be used as the value for a key."
+           value={config.value_column}
+           labelClassName="col-sm-3"
+           wrapperClassName="col-sm-9" />
+    <Input type="checkbox"
+           id="case_insensitive_lookup"
+           name="case_insensitive_lookup"
+           label="Allow case-insensitive lookups"
+           checked={config.case_insensitive_lookup}
+           onChange={handleFormEvent}
+           help="Enable if the key lookup should be case-insensitive."
+           wrapperClassName="col-md-offset-3 col-md-9" />
+    <Input type="checkbox"
+           id="check_presence_only"
+           name="check_presence_only"
+           label="Check Presence Only"
+           checked={config.check_presence_only}
+           onChange={handleFormEvent}
+           help="Only check if key is present in table, returns boolean instead of value."
+           wrapperClassName="col-md-offset-3 col-md-9" />
+  </fieldset>);
+};
+
+export default DSVHTTPAdapterFieldSet;

--- a/graylog2-web-interface/src/components/lookup-tables/adapters/DSVHTTPAdapterFieldSet.jsx
+++ b/graylog2-web-interface/src/components/lookup-tables/adapters/DSVHTTPAdapterFieldSet.jsx
@@ -32,8 +32,18 @@ const DSVHTTPAdapterFieldSet = ({ handleFormEvent, validationState, validationMe
            label="Separator"
            required
            onChange={handleFormEvent}
-           help="The delimiter to use for separating entries."
+           help="The delimiter to use for separating columns of entries."
            value={config.separator}
+           labelClassName="col-sm-3"
+           wrapperClassName="col-sm-9" />
+    <Input type="text"
+           id="line_separator"
+           name="line_separator"
+           label="Line Separator"
+           required
+           onChange={handleFormEvent}
+           help="The delimiter to use for separating lines."
+           value={config.line_separator}
            labelClassName="col-sm-3"
            wrapperClassName="col-sm-9" />
     <Input type="text"

--- a/graylog2-web-interface/src/components/lookup-tables/adapters/DSVHTTPAdapterSummary.jsx
+++ b/graylog2-web-interface/src/components/lookup-tables/adapters/DSVHTTPAdapterSummary.jsx
@@ -1,0 +1,26 @@
+import React from 'react';
+
+const DSVHTTPAdapterSummary = ({ dataAdapter }) => {
+  const { config } = dataAdapter;
+
+  return (<dl>
+    <dt>File URL</dt>
+    <dd>{config.url}</dd>
+    <dt>Separator</dt>
+    <dd><code>{config.separator}</code></dd>
+    <dt>Quote character</dt>
+    <dd><code>{config.quotechar}</code></dd>
+    <dt>Ignore lines starting with</dt>
+    <dd><code>{config.ignorechar}</code></dd>
+    <dt>Key column</dt>
+    <dd>{config.key_column}</dd>
+    <dt>Value column</dt>
+    <dd>{config.value_column}</dd>
+    <dt>Check interval</dt>
+    <dd>{config.check_interval} seconds</dd>
+    <dt>Case-insensitive lookup</dt>
+    <dd>{config.case_insensitive_lookup ? 'yes' : 'no'}</dd>
+  </dl>);
+};
+
+export default DSVHTTPAdapterSummary;

--- a/graylog2-web-interface/src/components/lookup-tables/adapters/DSVHTTPAdapterSummary.jsx
+++ b/graylog2-web-interface/src/components/lookup-tables/adapters/DSVHTTPAdapterSummary.jsx
@@ -8,6 +8,8 @@ const DSVHTTPAdapterSummary = ({ dataAdapter }) => {
     <dd>{config.url}</dd>
     <dt>Separator</dt>
     <dd><code>{config.separator}</code></dd>
+    <dt>Line Separator</dt>
+    <dd><code>{config.line_separator}</code></dd>
     <dt>Quote character</dt>
     <dd><code>{config.quotechar}</code></dd>
     <dt>Ignore lines starting with</dt>

--- a/graylog2-web-interface/src/components/lookup-tables/adapters/index.js
+++ b/graylog2-web-interface/src/components/lookup-tables/adapters/index.js
@@ -3,6 +3,9 @@ import { PluginManifest, PluginStore } from 'graylog-web-plugin/plugin';
 import CSVFileAdapterFieldSet from './CSVFileAdapterFieldSet';
 import CSVFileAdapterSummary from './CSVFileAdapterSummary';
 import CSVFileAdapterDocumentation from './CSVFileAdapterDocumentation';
+import DSVHTTPAdapterFieldSet from './CSVFileAdapterFieldSet';
+import DSVHTTPAdapterSummary from './DSVHTTPAdapterSummary';
+import DSVHTTPAdapterDocumentation from './DSVHTTPAdapterDocumentation';
 import HTTPJSONPathAdapterFieldSet from './HTTPJSONPathAdapterFieldSet';
 import HTTPJSONPathAdapterSummary from './HTTPJSONPathAdapterSummary';
 import HTTPJSONPathAdapterDocumentation from './HTTPJSONPathAdapterDocumentation';
@@ -22,6 +25,13 @@ PluginStore.register(new PluginManifest({}, {
       formComponent: HTTPJSONPathAdapterFieldSet,
       summaryComponent: HTTPJSONPathAdapterSummary,
       documentationComponent: HTTPJSONPathAdapterDocumentation,
+    },
+    {
+      type: 'dsvhttp',
+      displayName: 'DSV File from HTTP',
+      formComponent: DSVHTTPAdapterFieldSet,
+      summaryComponent: DSVHTTPAdapterSummary,
+      documentationComponent: DSVHTTPAdapterDocumentation,
     },
   ],
 }));


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
This adapter allows us to fetch delimiter-separated value files over
HTTP to back a lookup table with their content. The user is able to
specify the delimiter, (a) character(s) indicating lines which are
supposed to be ignored (comments) and if the lookup table should only
check for the presence of a key (in which case only true/false is
returned instead of the value).

Unlike the CSV adapter, this adapter does not support a starting line
naming the columns and specifying the key/value column.

<!--- Provide a general summary of your changes in the Title above -->


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
