### PR TITLE
Upgrade to Jest 2.4.7+jackson

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/indexer/searches/Searches.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/searches/Searches.java
@@ -283,7 +283,7 @@ public class Searches {
         final long tookMs = tookMsFromSearchResult(searchResult);
         recordEsMetrics(tookMs, config.range());
 
-        return new SearchResult(hits, searchResult.getTotal().longValue(), indexRanges, config.query(), requestBuilder.toString(), tookMs);
+        return new SearchResult(hits, searchResult.getTotal(), indexRanges, config.query(), requestBuilder.toString(), tookMs);
     }
 
     private long tookMsFromSearchResult(io.searchbox.core.SearchResult searchResult) {

--- a/pom.xml
+++ b/pom.xml
@@ -94,7 +94,7 @@
         <disruptor.version>3.3.6</disruptor.version>
         <drools.version>6.5.0.Final</drools.version>
         <elasticsearch.version>2.4.4</elasticsearch.version>
-        <jest.version>2.4.6+jackson</jest.version>
+        <jest.version>2.4.7+jackson</jest.version>
         <gelfclient.version>1.4.1</gelfclient.version>
         <grok.version>0.1.7-graylog</grok.version>
         <guava-retrying.version>2.0.0</guava-retrying.version>


### PR DESCRIPTION
In large Elasticsearch clusters, the total number of results might easily be larger than the maximum value of `Integer` (2,147,483,647).

This change set upgrades to Jest 2.4.7+jackson which returns the total number of search results as `Long` instead of `Integer`.