### PR TITLE
Use lenient delimiter based frame decoder in TcpTransport

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/inputs/transports/TcpTransport.java
+++ b/graylog2-server/src/main/java/org/graylog2/inputs/transports/TcpTransport.java
@@ -22,6 +22,7 @@ import com.google.common.collect.Maps;
 import com.google.common.util.concurrent.ThreadFactoryBuilder;
 import com.google.inject.assistedinject.Assisted;
 import com.google.inject.assistedinject.AssistedInject;
+import org.graylog2.inputs.transports.netty.LenientDelimiterBasedFrameDecoder;
 import org.graylog2.plugin.LocalMetricRegistry;
 import org.graylog2.plugin.configuration.Configuration;
 import org.graylog2.plugin.configuration.ConfigurationRequest;
@@ -99,7 +100,7 @@ public class TcpTransport extends AbstractTcpTransport {
         finalChannelHandlers.put("framer", new Callable<ChannelHandler>() {
             @Override
             public ChannelHandler call() throws Exception {
-                return new DelimiterBasedFrameDecoder(maxFrameLength, delimiter);
+                return new LenientDelimiterBasedFrameDecoder(maxFrameLength, delimiter);
             }
         });
         finalChannelHandlers.putAll(super.getFinalChannelHandlers(input));

--- a/graylog2-server/src/main/java/org/graylog2/inputs/transports/netty/LenientDelimiterBasedFrameDecoder.java
+++ b/graylog2-server/src/main/java/org/graylog2/inputs/transports/netty/LenientDelimiterBasedFrameDecoder.java
@@ -14,6 +14,21 @@
  * You should have received a copy of the GNU General Public License
  * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
  */
+/*
+ * Copyright 2012 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
 package org.graylog2.inputs.transports.netty;
 
 import org.jboss.netty.buffer.ChannelBuffer;

--- a/graylog2-server/src/main/java/org/graylog2/inputs/transports/netty/LenientDelimiterBasedFrameDecoder.java
+++ b/graylog2-server/src/main/java/org/graylog2/inputs/transports/netty/LenientDelimiterBasedFrameDecoder.java
@@ -1,0 +1,385 @@
+/**
+ * This file is part of Graylog.
+ *
+ * Graylog is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.graylog2.inputs.transports.netty;
+
+import org.jboss.netty.buffer.ChannelBuffer;
+import org.jboss.netty.channel.Channel;
+import org.jboss.netty.channel.ChannelHandlerContext;
+import org.jboss.netty.channel.Channels;
+import org.jboss.netty.handler.codec.frame.Delimiters;
+import org.jboss.netty.handler.codec.frame.FrameDecoder;
+import org.jboss.netty.handler.codec.frame.LineBasedFrameDecoder;
+import org.jboss.netty.handler.codec.frame.TooLongFrameException;
+
+/**
+ * A decoder that splits the received {@link ChannelBuffer}s by one or more
+ * delimiters.  It is particularly useful for decoding the frames which ends
+ * with a delimiter such as {@link Delimiters#nulDelimiter() NUL} or
+ * {@linkplain Delimiters#lineDelimiter() newline characters}.
+ *
+ * <h3>Predefined delimiters</h3>
+ * <p>
+ * {@link Delimiters} defines frequently used delimiters for convenience' sake.
+ *
+ * <h3>Specifying more than one delimiter</h3>
+ * <p>
+ * {@link LenientDelimiterBasedFrameDecoder} allows you to specify more than one
+ * delimiter.  If more than one delimiter is found in the buffer, it chooses
+ * the delimiter which produces the shortest frame.  For example, if you have
+ * the following data in the buffer:
+ * <pre>
+ * +--------------+
+ * | ABC\nDEF\r\n |
+ * +--------------+
+ * </pre>
+ * a {@link LenientDelimiterBasedFrameDecoder}{@code (}{@link Delimiters#lineDelimiter() Delimiters.lineDelimiter()}{@code )}
+ * will choose {@code '\n'} as the first delimiter and produce two frames:
+ * <pre>
+ * +-----+-----+
+ * | ABC | DEF |
+ * +-----+-----+
+ * </pre>
+ * rather than incorrectly choosing {@code '\r\n'} as the first delimiter:
+ * <pre>
+ * +----------+
+ * | ABC\nDEF |
+ * +----------+
+ * </pre>
+ *
+ *
+ * @apiviz.uses org.jboss.netty.handler.codec.frame.Delimiters - - useful
+ */
+public class LenientDelimiterBasedFrameDecoder extends FrameDecoder {
+
+    private final ChannelBuffer[] delimiters;
+    private final int maxFrameLength;
+    private final boolean stripDelimiter;
+    private final boolean failFast;
+    private final boolean emitLastLineWithoutDelimiter;
+    private boolean discardingTooLongFrame;
+    private int tooLongFrameLength;
+    /** Set only when decoding with "\n" and "\r\n" as the delimiter.  */
+    private final LenientLineBasedFrameDecoder lineBasedDecoder;
+
+    /**
+     * Creates a new instance.
+     *
+     * @param maxFrameLength  the maximum length of the decoded frame.
+     *                        A {@link TooLongFrameException} is thrown if
+     *                        the length of the frame exceeds this value.
+     * @param delimiter  the delimiter
+     */
+    public LenientDelimiterBasedFrameDecoder(int maxFrameLength, ChannelBuffer delimiter) {
+        this(maxFrameLength, true, delimiter);
+    }
+
+    /**
+     * Creates a new instance.
+     *
+     * @param maxFrameLength  the maximum length of the decoded frame.
+     *                        A {@link TooLongFrameException} is thrown if
+     *                        the length of the frame exceeds this value.
+     * @param stripDelimiter  whether the decoded frame should strip out the
+     *                        delimiter or not
+     * @param delimiter  the delimiter
+     */
+    public LenientDelimiterBasedFrameDecoder(
+            int maxFrameLength, boolean stripDelimiter, ChannelBuffer delimiter) {
+        this(maxFrameLength, stripDelimiter, false, true, delimiter);
+    }
+
+    /**
+     * Creates a new instance.
+     *
+     * @param maxFrameLength  the maximum length of the decoded frame.
+     *                        A {@link TooLongFrameException} is thrown if
+     *                        the length of the frame exceeds this value.
+     * @param stripDelimiter  whether the decoded frame should strip out the
+     *                        delimiter or not
+     * @param failFast  If <tt>true</tt>, a {@link TooLongFrameException} is
+     *                  thrown as soon as the decoder notices the length of the
+     *                  frame will exceed <tt>maxFrameLength</tt> regardless of
+     *                  whether the entire frame has been read.
+     *                  If <tt>false</tt>, a {@link TooLongFrameException} is
+     *                  thrown after the entire frame that exceeds
+     *                  <tt>maxFrameLength</tt> has been read.
+     * @param delimiter  the delimiter
+     */
+    public LenientDelimiterBasedFrameDecoder(
+            int maxFrameLength, boolean stripDelimiter, boolean failFast,
+            ChannelBuffer delimiter) {
+        this(maxFrameLength, stripDelimiter, failFast, true, delimiter.slice(delimiter.readerIndex(), delimiter.readableBytes()));
+    }
+
+    /**
+     * Creates a new instance.
+     *
+     * @param maxFrameLength  the maximum length of the decoded frame.
+     *                        A {@link TooLongFrameException} is thrown if
+     *                        the length of the frame exceeds this value.
+     * @param delimiters  the delimiters
+     */
+    public LenientDelimiterBasedFrameDecoder(int maxFrameLength, ChannelBuffer... delimiters) {
+        this(maxFrameLength, true, delimiters);
+    }
+
+    /**
+     * Creates a new instance.
+     *
+     * @param maxFrameLength  the maximum length of the decoded frame.
+     *                        A {@link TooLongFrameException} is thrown if
+     *                        the length of the frame exceeds this value.
+     * @param stripDelimiter  whether the decoded frame should strip out the
+     *                        delimiter or not
+     * @param delimiters  the delimiters
+     */
+    public LenientDelimiterBasedFrameDecoder(
+            int maxFrameLength, boolean stripDelimiter, ChannelBuffer... delimiters) {
+        this(maxFrameLength, stripDelimiter, false, true, delimiters);
+    }
+
+    /**
+     * Creates a new instance.
+     *
+     * @param maxFrameLength  the maximum length of the decoded frame.
+     *                        A {@link TooLongFrameException} is thrown if
+     *                        the length of the frame exceeds this value.
+     * @param stripDelimiter  whether the decoded frame should strip out the
+     *                        delimiter or not
+     * @param failFast  If <tt>true</tt>, a {@link TooLongFrameException} is
+     *                  thrown as soon as the decoder notices the length of the
+     *                  frame will exceed <tt>maxFrameLength</tt> regardless of
+     *                  whether the entire frame has been read.
+     *                  If <tt>false</tt>, a {@link TooLongFrameException} is
+     *                  thrown after the entire frame that exceeds
+     *                  <tt>maxFrameLength</tt> has been read.
+     * @param emitLastLineWithoutDelimiter emit the last line even if it doesn't
+     *                                     end with the delimiter
+     * @param delimiters  the delimiters
+     */
+    public LenientDelimiterBasedFrameDecoder(
+            int maxFrameLength, boolean stripDelimiter, boolean failFast, boolean emitLastLineWithoutDelimiter, ChannelBuffer... delimiters) {
+        validateMaxFrameLength(maxFrameLength);
+        if (delimiters == null) {
+            throw new NullPointerException("delimiters");
+        }
+        if (delimiters.length == 0) {
+            throw new IllegalArgumentException("empty delimiters");
+        }
+
+        if (isLineBased(delimiters) && !isSubclass()) {
+            lineBasedDecoder = new LenientLineBasedFrameDecoder(maxFrameLength, stripDelimiter, failFast, emitLastLineWithoutDelimiter);
+            this.delimiters = null;
+        } else {
+            this.delimiters = new ChannelBuffer[delimiters.length];
+            for (int i = 0; i < delimiters.length; i ++) {
+                ChannelBuffer d = delimiters[i];
+                validateDelimiter(d);
+                this.delimiters[i] = d.slice(d.readerIndex(), d.readableBytes());
+            }
+            lineBasedDecoder = null;
+        }
+        this.maxFrameLength = maxFrameLength;
+        this.stripDelimiter = stripDelimiter;
+        this.failFast = failFast;
+        this.emitLastLineWithoutDelimiter = emitLastLineWithoutDelimiter;
+    }
+
+    /** Returns true if the delimiters are "\n" and "\r\n".  */
+    private static boolean isLineBased(final ChannelBuffer[] delimiters) {
+        if (delimiters.length != 2) {
+            return false;
+        }
+        ChannelBuffer a = delimiters[0];
+        ChannelBuffer b = delimiters[1];
+        if (a.capacity() < b.capacity()) {
+            a = delimiters[1];
+            b = delimiters[0];
+        }
+        return a.capacity() == 2 && b.capacity() == 1
+            && a.getByte(0) == '\r' && a.getByte(1) == '\n'
+            && b.getByte(0) == '\n';
+    }
+
+    /**
+     * Return {@code true} if the current instance is a subclass of DelimiterBasedFrameDecoder
+     */
+    private boolean isSubclass() {
+        return getClass() != LenientDelimiterBasedFrameDecoder.class;
+    }
+
+    @Override
+    protected Object decode(
+            ChannelHandlerContext ctx, Channel channel, ChannelBuffer buffer) throws Exception {
+        if (lineBasedDecoder != null) {
+            return lineBasedDecoder.decode(ctx, channel, buffer);
+        }
+        // Try all delimiters and choose the delimiter which yields the shortest frame.
+        int minFrameLength = Integer.MAX_VALUE;
+        ChannelBuffer minDelim = null;
+        for (ChannelBuffer delim: delimiters) {
+            int frameLength = indexOf(buffer, delim);
+            if (frameLength >= 0 && frameLength < minFrameLength) {
+                minFrameLength = frameLength;
+                minDelim = delim;
+            }
+        }
+
+        if (minDelim != null) {
+            int minDelimLength = minDelim.capacity();
+            ChannelBuffer frame;
+
+            if (discardingTooLongFrame) {
+                // We've just finished discarding a very large frame.
+                // Go back to the initial state.
+                discardingTooLongFrame = false;
+                buffer.skipBytes(minFrameLength + minDelimLength);
+
+                int tooLongFrameLength = this.tooLongFrameLength;
+                this.tooLongFrameLength = 0;
+                if (!failFast) {
+                    fail(ctx, tooLongFrameLength);
+                }
+                return null;
+            }
+
+            if (minFrameLength > maxFrameLength) {
+                // Discard read frame.
+                buffer.skipBytes(minFrameLength + minDelimLength);
+                fail(ctx, minFrameLength);
+                return null;
+            }
+
+            if (stripDelimiter) {
+                frame = extractFrame(buffer, buffer.readerIndex(), minFrameLength);
+            } else {
+                frame = extractFrame(buffer, buffer.readerIndex(), minFrameLength + minDelimLength);
+            }
+            buffer.skipBytes(minFrameLength + minDelimLength);
+
+            return frame;
+        } else if (emitLastLineWithoutDelimiter && !channel.isConnected()) {
+            minFrameLength = buffer.readableBytes();
+            ChannelBuffer frame;
+
+            if (discardingTooLongFrame) {
+                // We've just finished discarding a very large frame.
+                // Go back to the initial state.
+                discardingTooLongFrame = false;
+                buffer.skipBytes(minFrameLength);
+
+                int tooLongFrameLength = this.tooLongFrameLength;
+                this.tooLongFrameLength = 0;
+                if (!failFast) {
+                    fail(ctx, tooLongFrameLength);
+                }
+                return null;
+            }
+
+            if (minFrameLength > maxFrameLength) {
+                // Discard read frame.
+                buffer.skipBytes(minFrameLength);
+                fail(ctx, minFrameLength);
+                return null;
+            }
+
+            frame = extractFrame(buffer, buffer.readerIndex(), minFrameLength);
+            buffer.skipBytes(minFrameLength);
+
+            return frame;
+        } else {
+            if (!discardingTooLongFrame) {
+                if (buffer.readableBytes() > maxFrameLength) {
+                    // Discard the content of the buffer until a delimiter is found.
+                    tooLongFrameLength = buffer.readableBytes();
+                    buffer.skipBytes(buffer.readableBytes());
+                    discardingTooLongFrame = true;
+                    if (failFast) {
+                        fail(ctx, tooLongFrameLength);
+                    }
+                }
+            } else {
+                // Still discarding the buffer since a delimiter is not found.
+                tooLongFrameLength += buffer.readableBytes();
+                buffer.skipBytes(buffer.readableBytes());
+            }
+            return null;
+        }
+    }
+
+    private void fail(ChannelHandlerContext ctx, long frameLength) {
+        if (frameLength > 0) {
+            Channels.fireExceptionCaught(
+                    ctx.getChannel(),
+                    new TooLongFrameException(
+                            "frame length exceeds " + maxFrameLength +
+                            ": " + frameLength + " - discarded"));
+        } else {
+            Channels.fireExceptionCaught(
+                    ctx.getChannel(),
+                    new TooLongFrameException(
+                            "frame length exceeds " + maxFrameLength +
+                            " - discarding"));
+        }
+    }
+
+    /**
+     * Returns the number of bytes between the readerIndex of the haystack and
+     * the first needle found in the haystack.  -1 is returned if no needle is
+     * found in the haystack.
+     */
+    private static int indexOf(ChannelBuffer haystack, ChannelBuffer needle) {
+        for (int i = haystack.readerIndex(); i < haystack.writerIndex(); i ++) {
+            int haystackIndex = i;
+            int needleIndex;
+            for (needleIndex = 0; needleIndex < needle.capacity(); needleIndex ++) {
+                if (haystack.getByte(haystackIndex) != needle.getByte(needleIndex)) {
+                    break;
+                } else {
+                    haystackIndex ++;
+                    if (haystackIndex == haystack.writerIndex() &&
+                        needleIndex != needle.capacity() - 1) {
+                        return -1;
+                    }
+                }
+            }
+
+            if (needleIndex == needle.capacity()) {
+                // Found the needle from the haystack!
+                return i - haystack.readerIndex();
+            }
+        }
+        return -1;
+    }
+
+    private static void validateDelimiter(ChannelBuffer delimiter) {
+        if (delimiter == null) {
+            throw new NullPointerException("delimiter");
+        }
+        if (!delimiter.readable()) {
+            throw new IllegalArgumentException("empty delimiter");
+        }
+    }
+
+    private static void validateMaxFrameLength(int maxFrameLength) {
+        if (maxFrameLength <= 0) {
+            throw new IllegalArgumentException(
+                    "maxFrameLength must be a positive integer: " +
+                    maxFrameLength);
+        }
+    }
+}

--- a/graylog2-server/src/main/java/org/graylog2/inputs/transports/netty/LenientLineBasedFrameDecoder.java
+++ b/graylog2-server/src/main/java/org/graylog2/inputs/transports/netty/LenientLineBasedFrameDecoder.java
@@ -1,0 +1,180 @@
+/**
+ * This file is part of Graylog.
+ *
+ * Graylog is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.graylog2.inputs.transports.netty;
+
+import org.jboss.netty.buffer.ChannelBuffer;
+import org.jboss.netty.channel.Channel;
+import org.jboss.netty.channel.ChannelHandlerContext;
+import org.jboss.netty.channel.Channels;
+import org.jboss.netty.handler.codec.frame.DelimiterBasedFrameDecoder;
+import org.jboss.netty.handler.codec.frame.FrameDecoder;
+import org.jboss.netty.handler.codec.frame.TooLongFrameException;
+
+/**
+ * A decoder that splits the received {@link ChannelBuffer}s on line endings.
+ * <p>
+ * Both {@code "\n"} and {@code "\r\n"} are handled.
+ * For a more general delimiter-based decoder, see {@link DelimiterBasedFrameDecoder}.
+ */
+public class LenientLineBasedFrameDecoder extends FrameDecoder {
+
+    /** Maximum length of a frame we're willing to decode.  */
+    private final int maxLength;
+    /** Whether or not to throw an exception as soon as we exceed maxLength. */
+    private final boolean failFast;
+    private final boolean stripDelimiter;
+    private final boolean emitLastLineWithoutDelimiter;
+
+    /** True if we're discarding input because we're already over maxLength.  */
+    private boolean discarding;
+    private int discardedBytes;
+
+    /**
+     * Creates a new decoder.
+     * @param maxLength  the maximum length of the decoded frame.
+     *                   A {@link TooLongFrameException} is thrown if
+     *                   the length of the frame exceeds this value.
+     */
+    public LenientLineBasedFrameDecoder(final int maxLength) {
+        this(maxLength, true, false, true);
+    }
+
+    /**
+     * Creates a new decoder.
+     * @param maxLength  the maximum length of the decoded frame.
+     *                   A {@link TooLongFrameException} is thrown if
+     *                   the length of the frame exceeds this value.
+     * @param stripDelimiter  whether the decoded frame should strip out the
+     *                        delimiter or not
+     * @param failFast  If <tt>true</tt>, a {@link TooLongFrameException} is
+     *                  thrown as soon as the decoder notices the length of the
+     *                  frame will exceed <tt>maxFrameLength</tt> regardless of
+     *                  whether the entire frame has been read.
+     *                  If <tt>false</tt>, a {@link TooLongFrameException} is
+     *                  thrown after the entire frame that exceeds
+     *                  <tt>maxFrameLength</tt> has been read.
+     * @param emitLastLineWithoutDelimiter emit the last line even if it doesn't
+     *                                     end with the delimiter
+     */
+    public LenientLineBasedFrameDecoder(final int maxLength, final boolean stripDelimiter, final boolean failFast, boolean emitLastLineWithoutDelimiter) {
+        this.maxLength = maxLength;
+        this.failFast = failFast;
+        this.stripDelimiter = stripDelimiter;
+        this.emitLastLineWithoutDelimiter = emitLastLineWithoutDelimiter;
+    }
+
+    @Override
+    protected Object decode(final ChannelHandlerContext ctx,
+                            final Channel channel,
+                            final ChannelBuffer buffer) throws Exception {
+        final int eol = findEndOfLine(buffer);
+        if (!discarding) {
+            if (eol < 0 && emitLastLineWithoutDelimiter && !channel.isConnected()) {
+                final ChannelBuffer frame;
+                final int length = buffer.readableBytes();
+
+                if (length > maxLength) {
+                    buffer.readerIndex(length);
+                    fail(ctx, length);
+                    return null;
+                }
+
+                try {
+                    frame = extractFrame(buffer, buffer.readerIndex(), length);
+                } finally {
+                    buffer.skipBytes(length);
+                }
+                return frame;
+            } else if (eol >= 0) {
+                final ChannelBuffer frame;
+                final int length = eol - buffer.readerIndex();
+                final int delimLength = buffer.getByte(eol) == '\r'? 2 : 1;
+
+                if (length > maxLength) {
+                    buffer.readerIndex(eol + delimLength);
+                    fail(ctx, length);
+                    return null;
+                }
+
+                try {
+                    if (stripDelimiter) {
+                        frame = extractFrame(buffer, buffer.readerIndex(), length);
+                    } else {
+                        frame = extractFrame(buffer, buffer.readerIndex(), length + delimLength);
+                    }
+                } finally {
+                    buffer.skipBytes(length + delimLength);
+                }
+                return frame;
+            } else {
+                final int length = buffer.readableBytes();
+                if (length > maxLength) {
+                    discardedBytes = length;
+                    buffer.readerIndex(buffer.writerIndex());
+                    discarding = true;
+                    if (failFast) {
+                        fail(ctx, "over " + discardedBytes);
+                    }
+                }
+                return null;
+            }
+        } else {
+            if (eol >= 0) {
+                final int length = discardedBytes + eol - buffer.readerIndex();
+                final int delimLength = buffer.getByte(eol) == '\r'? 2 : 1;
+                buffer.readerIndex(eol + delimLength);
+                discardedBytes = 0;
+                discarding = false;
+                if (!failFast) {
+                    fail(ctx, length);
+                }
+            } else {
+                discardedBytes = buffer.readableBytes();
+                buffer.readerIndex(buffer.writerIndex());
+            }
+            return null;
+        }
+    }
+
+    private void fail(final ChannelHandlerContext ctx, int length) {
+        fail(ctx, String.valueOf(length));
+    }
+
+    private void fail(final ChannelHandlerContext ctx, String length) {
+        Channels.fireExceptionCaught(
+                ctx.getChannel(),
+                new TooLongFrameException(
+                        "frame length (" + length + ") exceeds the allowed maximum (" + maxLength + ')'));
+    }
+
+    /**
+     * Returns the index in the buffer of the end of line found.
+     * Returns -1 if no end of line was found in the buffer.
+     */
+    private static int findEndOfLine(final ChannelBuffer buffer) {
+        final int n = buffer.writerIndex();
+        for (int i = buffer.readerIndex(); i < n; i ++) {
+            final byte b = buffer.getByte(i);
+            if (b == '\n') {
+                return i;
+            } else if (b == '\r' && i < n - 1 && buffer.getByte(i + 1) == '\n') {
+                return i;  // \r\n
+            }
+        }
+        return -1;  // Not found.
+    }
+}

--- a/graylog2-server/src/main/java/org/graylog2/inputs/transports/netty/LenientLineBasedFrameDecoder.java
+++ b/graylog2-server/src/main/java/org/graylog2/inputs/transports/netty/LenientLineBasedFrameDecoder.java
@@ -14,6 +14,21 @@
  * You should have received a copy of the GNU General Public License
  * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
  */
+/*
+ * Copyright 2012 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
 package org.graylog2.inputs.transports.netty;
 
 import org.jboss.netty.buffer.ChannelBuffer;

--- a/graylog2-server/src/test/java/org/graylog2/inputs/transports/netty/LenientDelimiterBasedFrameDecoderTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/inputs/transports/netty/LenientDelimiterBasedFrameDecoderTest.java
@@ -1,0 +1,147 @@
+/**
+ * This file is part of Graylog.
+ *
+ * Graylog is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.graylog2.inputs.transports.netty;
+
+import org.jboss.netty.buffer.ChannelBuffer;
+import org.jboss.netty.buffer.ChannelBuffers;
+import org.jboss.netty.handler.codec.embedder.CodecEmbedderException;
+import org.jboss.netty.handler.codec.embedder.DecoderEmbedder;
+import org.jboss.netty.handler.codec.frame.Delimiters;
+import org.jboss.netty.handler.codec.frame.TooLongFrameException;
+import org.jboss.netty.util.CharsetUtil;
+import org.junit.Assert;
+import org.junit.Ignore;
+import org.junit.Test;
+
+public class LenientDelimiterBasedFrameDecoderTest {
+    @Test
+    public void testFailSlowTooLongFrameRecovery() throws Exception {
+        DecoderEmbedder<ChannelBuffer> embedder = new DecoderEmbedder<>(
+                new LenientDelimiterBasedFrameDecoder(1, Delimiters.nulDelimiter()));
+
+        for (int i = 0; i < 2; i ++) {
+            embedder.offer(ChannelBuffers.wrappedBuffer(new byte[] { 1, 2 }));
+            try {
+                embedder.offer(ChannelBuffers.wrappedBuffer(new byte[] { 0 }));
+                Assert.fail(CodecEmbedderException.class.getSimpleName() + " must be raised.");
+            } catch (CodecEmbedderException e) {
+                Assert.assertTrue(e.getCause() instanceof TooLongFrameException);
+                // Expected
+            }
+
+            embedder.offer(ChannelBuffers.wrappedBuffer(new byte[] { 'A', 0 }));
+            ChannelBuffer buf = embedder.poll();
+            Assert.assertEquals("A", buf.toString(CharsetUtil.ISO_8859_1));
+        }
+    }
+
+    @Test
+    public void testFailFastTooLongFrameRecovery() throws Exception {
+        DecoderEmbedder<ChannelBuffer> embedder = new DecoderEmbedder<>(
+                new LenientDelimiterBasedFrameDecoder(1, true, true, false, Delimiters.nulDelimiter()));
+
+        for (int i = 0; i < 2; i ++) {
+            try {
+                embedder.offer(ChannelBuffers.wrappedBuffer(new byte[] { 1, 2 }));
+                Assert.fail(CodecEmbedderException.class.getSimpleName() + " must be raised.");
+            } catch (CodecEmbedderException e) {
+                Assert.assertTrue(e.getCause() instanceof TooLongFrameException);
+                // Expected
+            }
+
+            embedder.offer(ChannelBuffers.wrappedBuffer(new byte[] { 0, 'A', 0 }));
+            ChannelBuffer buf = embedder.poll();
+            Assert.assertEquals("A", buf.toString(CharsetUtil.ISO_8859_1));
+        }
+    }
+
+    @Test
+    public void testLenientFailFastTooLongFrameRecovery() throws Exception {
+        DecoderEmbedder<ChannelBuffer> embedder = new DecoderEmbedder<>(
+                new LenientDelimiterBasedFrameDecoder(1, true, true, true, Delimiters.nulDelimiter()));
+
+        for (int i = 0; i < 2; i ++) {
+            try {
+                embedder.offer(ChannelBuffers.wrappedBuffer(new byte[] { 1, 2 }));
+                Assert.fail(CodecEmbedderException.class.getSimpleName() + " must be raised.");
+            } catch (CodecEmbedderException e) {
+                Assert.assertTrue(e.getCause() instanceof TooLongFrameException);
+                // Expected
+            }
+
+            embedder.offer(ChannelBuffers.wrappedBuffer(new byte[] { 0, 'A', 0 }));
+            ChannelBuffer buf = embedder.poll();
+            Assert.assertEquals("A", buf.toString(CharsetUtil.ISO_8859_1));
+        }
+    }
+
+    @Test
+    public void testDecodeNewlines() throws Exception {
+        DecoderEmbedder<ChannelBuffer> embedder = new DecoderEmbedder<>(
+                new LenientDelimiterBasedFrameDecoder(8192, true, Delimiters.lineDelimiter()));
+
+        Assert.assertTrue(embedder.offer(ChannelBuffers.copiedBuffer("first\r\nsecond\nthird", CharsetUtil.US_ASCII)));
+        Assert.assertTrue(embedder.finish());
+        Assert.assertEquals("first", embedder.poll().toString(CharsetUtil.US_ASCII));
+        Assert.assertEquals("second", embedder.poll().toString(CharsetUtil.US_ASCII));
+        Assert.assertNull(embedder.poll());
+
+    }
+
+    @Test
+    @Ignore("Doesn't work because EmbeddedChannel#isConnected() returns always true")
+    public void testDecodeLenientNewlines() throws Exception {
+        DecoderEmbedder<ChannelBuffer> embedder = new DecoderEmbedder<>(
+                new LenientDelimiterBasedFrameDecoder(8192, true, false, true, Delimiters.lineDelimiter()));
+
+        Assert.assertTrue(embedder.offer(ChannelBuffers.copiedBuffer("first\r\nsecond\nthird", CharsetUtil.US_ASCII)));
+        Assert.assertTrue(embedder.finish());
+        Assert.assertEquals("first", embedder.poll().toString(CharsetUtil.US_ASCII));
+        Assert.assertEquals("second", embedder.poll().toString(CharsetUtil.US_ASCII));
+        Assert.assertEquals("third", embedder.poll().toString(CharsetUtil.US_ASCII));
+        Assert.assertNull(embedder.poll());
+
+    }
+
+    @Test
+    public void testDecodeNul() throws Exception {
+        DecoderEmbedder<ChannelBuffer> embedder = new DecoderEmbedder<>(
+                new LenientDelimiterBasedFrameDecoder(8192, true, false, false, Delimiters.nulDelimiter()));
+
+        Assert.assertTrue(embedder.offer(ChannelBuffers.copiedBuffer("first\0second\0third", CharsetUtil.US_ASCII)));
+        Assert.assertTrue(embedder.finish());
+        Assert.assertEquals("first", embedder.poll().toString(CharsetUtil.US_ASCII));
+        Assert.assertEquals("second", embedder.poll().toString(CharsetUtil.US_ASCII));
+        Assert.assertNull(embedder.poll());
+
+    }
+
+    @Test
+    @Ignore("Doesn't work because EmbeddedChannel#isConnected() returns always true")
+    public void testDecodeLenientNul() throws Exception {
+        DecoderEmbedder<ChannelBuffer> embedder = new DecoderEmbedder<>(
+                new LenientDelimiterBasedFrameDecoder(8192, true, false, true, Delimiters.nulDelimiter()));
+
+        Assert.assertTrue(embedder.offer(ChannelBuffers.copiedBuffer("first\0second\0third", CharsetUtil.US_ASCII)));
+        Assert.assertTrue(embedder.finish());
+        Assert.assertEquals("first", embedder.poll().toString(CharsetUtil.US_ASCII));
+        Assert.assertEquals("second", embedder.poll().toString(CharsetUtil.US_ASCII));
+        Assert.assertEquals("third", embedder.poll().toString(CharsetUtil.US_ASCII));
+        Assert.assertNull(embedder.poll());
+
+    }
+}

--- a/graylog2-server/src/test/java/org/graylog2/inputs/transports/netty/LenientLineBasedFrameDecoderTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/inputs/transports/netty/LenientLineBasedFrameDecoderTest.java
@@ -1,0 +1,217 @@
+/**
+ * This file is part of Graylog.
+ *
+ * Graylog is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.graylog2.inputs.transports.netty;
+
+import org.jboss.netty.buffer.ChannelBuffer;
+import org.jboss.netty.handler.codec.embedder.CodecEmbedderException;
+import org.jboss.netty.handler.codec.embedder.DecoderEmbedder;
+import org.jboss.netty.handler.codec.frame.TooLongFrameException;
+import org.jboss.netty.util.CharsetUtil;
+import org.junit.Ignore;
+import org.junit.Test;
+
+import static org.hamcrest.CoreMatchers.*;
+import static org.jboss.netty.buffer.ChannelBuffers.*;
+import static org.junit.Assert.*;
+
+public class LenientLineBasedFrameDecoderTest {
+    @Test
+    public void testDecodeWithStrip() throws Exception {
+        DecoderEmbedder<ChannelBuffer> embedder = new DecoderEmbedder<>(
+                new LenientLineBasedFrameDecoder(8192, true, false, false));
+
+        assertTrue(embedder.offer(copiedBuffer("first\r\nsecond\nthird", CharsetUtil.US_ASCII)));
+        assertTrue(embedder.finish());
+        assertEquals("first", embedder.poll().toString(CharsetUtil.US_ASCII));
+        assertEquals("second", embedder.poll().toString(CharsetUtil.US_ASCII));
+        assertNull(embedder.poll());
+
+    }
+
+    @Test
+    @Ignore("Doesn't work because EmbeddedChannel#isConnected() returns always true")
+    public void testDecodeLenientWithStrip() throws Exception {
+        DecoderEmbedder<ChannelBuffer> embedder = new DecoderEmbedder<>(
+                new LenientLineBasedFrameDecoder(8192, true, false, true));
+
+        assertTrue(embedder.offer(copiedBuffer("first\r\nsecond\nthird", CharsetUtil.US_ASCII)));
+        assertTrue(embedder.finish());
+        assertEquals("first", embedder.poll().toString(CharsetUtil.US_ASCII));
+        assertEquals("second", embedder.poll().toString(CharsetUtil.US_ASCII));
+        assertEquals("third", embedder.poll().toString(CharsetUtil.US_ASCII));
+        assertNull(embedder.poll());
+
+    }
+
+    @Test
+    public void testDecodeWithoutStrip() throws Exception {
+        DecoderEmbedder<ChannelBuffer> embedder = new DecoderEmbedder<>(
+                new LenientLineBasedFrameDecoder(8192, false, false, false));
+
+        assertTrue(embedder.offer(copiedBuffer("first\r\nsecond\nthird", CharsetUtil.US_ASCII)));
+        assertTrue(embedder.finish());
+        assertEquals("first\r\n", embedder.poll().toString(CharsetUtil.US_ASCII));
+        assertEquals("second\n", embedder.poll().toString(CharsetUtil.US_ASCII));
+        assertNull(embedder.poll());
+
+    }
+
+    @Test
+    @Ignore("Doesn't work because EmbeddedChannel#isConnected() returns always true")
+    public void testDecodeLenientWithoutStrip() throws Exception {
+        DecoderEmbedder<ChannelBuffer> embedder = new DecoderEmbedder<>(
+                new LenientLineBasedFrameDecoder(8192, false, false, true));
+
+        assertTrue(embedder.offer(copiedBuffer("first\r\nsecond\nthird", CharsetUtil.US_ASCII)));
+        assertTrue(embedder.finish());
+        assertEquals("first\r\n", embedder.poll().toString(CharsetUtil.US_ASCII));
+        assertEquals("second\n", embedder.poll().toString(CharsetUtil.US_ASCII));
+        assertEquals("third", embedder.poll().toString(CharsetUtil.US_ASCII));
+        assertNull(embedder.poll());
+
+    }
+
+    @Test
+    public void testTooLongLine1() throws Exception {
+        DecoderEmbedder<ChannelBuffer> embedder = new DecoderEmbedder<>(
+                new LenientLineBasedFrameDecoder(16, false, false, false));
+
+        try {
+            embedder.offer(copiedBuffer("12345678901234567890\r\nfirst\nsecond", CharsetUtil.US_ASCII));
+            fail();
+        } catch (CodecEmbedderException e) {
+            assertThat(e.getCause(), is(instanceOf(TooLongFrameException.class)));
+        }
+
+        embedder.offer(wrappedBuffer(new byte[1])); // A workaround that triggers decode() once again.
+
+        assertThat(embedder.size(), is(1));
+        assertTrue(embedder.finish());
+
+        assertThat(embedder.size(), is(1));
+        assertThat(embedder.poll().toString(CharsetUtil.US_ASCII), is("first\n"));
+    }
+
+    @Test
+    @Ignore("Doesn't work because EmbeddedChannel#isConnected() returns always true")
+    public void testLenientTooLongLine1() throws Exception {
+        DecoderEmbedder<ChannelBuffer> embedder = new DecoderEmbedder<>(
+                new LenientLineBasedFrameDecoder(16, false, false, true));
+
+        try {
+            embedder.offer(copiedBuffer("12345678901234567890\r\nfirst\nsecond", CharsetUtil.US_ASCII));
+            fail();
+        } catch (CodecEmbedderException e) {
+            assertThat(e.getCause(), is(instanceOf(TooLongFrameException.class)));
+        }
+
+        embedder.offer(wrappedBuffer(new byte[1])); // A workaround that triggers decode() once again.
+
+        assertThat(embedder.size(), is(2));
+        assertTrue(embedder.finish());
+
+        assertThat(embedder.size(), is(2));
+        assertThat(embedder.poll().toString(CharsetUtil.US_ASCII), is("first\n"));
+        assertThat(embedder.poll().toString(CharsetUtil.US_ASCII), is("second"));
+    }
+
+    @Test
+    public void testTooLongLine2() throws Exception {
+        DecoderEmbedder<ChannelBuffer> embedder = new DecoderEmbedder<>(
+                new LenientLineBasedFrameDecoder(16, false, false, false));
+
+        assertFalse(embedder.offer(copiedBuffer("12345678901234567", CharsetUtil.US_ASCII)));
+        try {
+            embedder.offer(copiedBuffer("890\r\nfirst\r\n", CharsetUtil.US_ASCII));
+            fail();
+        } catch (CodecEmbedderException e) {
+            assertThat(e.getCause(), is(instanceOf(TooLongFrameException.class)));
+        }
+
+        embedder.offer(wrappedBuffer(new byte[1])); // A workaround that triggers decode() once again.
+
+        assertThat(embedder.size(), is(1));
+        assertTrue(embedder.finish());
+
+        assertThat(embedder.size(), is(1));
+        assertEquals("first\r\n", embedder.poll().toString(CharsetUtil.US_ASCII));
+    }
+
+    @Test
+    public void testLenientTooLongLine2() throws Exception {
+        DecoderEmbedder<ChannelBuffer> embedder = new DecoderEmbedder<>(
+                new LenientLineBasedFrameDecoder(16, false, false, true));
+
+        assertFalse(embedder.offer(copiedBuffer("12345678901234567", CharsetUtil.US_ASCII)));
+        try {
+            embedder.offer(copiedBuffer("890\r\nfirst\r\n", CharsetUtil.US_ASCII));
+            fail();
+        } catch (CodecEmbedderException e) {
+            assertThat(e.getCause(), is(instanceOf(TooLongFrameException.class)));
+        }
+
+        embedder.offer(wrappedBuffer(new byte[1])); // A workaround that triggers decode() once again.
+
+        assertThat(embedder.size(), is(1));
+        assertTrue(embedder.finish());
+
+        assertThat(embedder.size(), is(1));
+        assertEquals("first\r\n", embedder.poll().toString(CharsetUtil.US_ASCII));
+    }
+
+    @Test
+    public void testTooLongLineWithFailFast() throws Exception {
+        DecoderEmbedder<ChannelBuffer> embedder = new DecoderEmbedder<>(
+                new LenientLineBasedFrameDecoder(16, false, true, false));
+
+        try {
+            embedder.offer(copiedBuffer("12345678901234567", CharsetUtil.US_ASCII));
+            fail();
+        } catch (CodecEmbedderException e) {
+            assertThat(e.getCause(), is(instanceOf(TooLongFrameException.class)));
+        }
+
+        assertThat(embedder.offer(copiedBuffer("890", CharsetUtil.US_ASCII)), is(false));
+        assertThat(embedder.offer(copiedBuffer("123\r\nfirst\r\n", CharsetUtil.US_ASCII)), is(true));
+        assertThat(embedder.size(), is(1));
+        assertTrue(embedder.finish());
+
+        assertThat(embedder.size(), is(1));
+        assertEquals("first\r\n", embedder.poll().toString(CharsetUtil.US_ASCII));
+    }
+
+    @Test
+    public void testLenientTooLongLineWithFailFast() throws Exception {
+        DecoderEmbedder<ChannelBuffer> embedder = new DecoderEmbedder<>(
+                new LenientLineBasedFrameDecoder(16, false, true, true));
+
+        try {
+            embedder.offer(copiedBuffer("12345678901234567", CharsetUtil.US_ASCII));
+            fail();
+        } catch (CodecEmbedderException e) {
+            assertThat(e.getCause(), is(instanceOf(TooLongFrameException.class)));
+        }
+
+        assertThat(embedder.offer(copiedBuffer("890", CharsetUtil.US_ASCII)), is(false));
+        assertThat(embedder.offer(copiedBuffer("123\r\nfirst\r\n", CharsetUtil.US_ASCII)), is(true));
+        assertThat(embedder.size(), is(1));
+        assertTrue(embedder.finish());
+
+        assertThat(embedder.size(), is(1));
+        assertEquals("first\r\n", embedder.poll().toString(CharsetUtil.US_ASCII));
+    }
+}


### PR DESCRIPTION
In contrast to the standard `DelimiterBasedFrameDecoder` from Netty, the derivative `LenientDelimiterBasedFrameDecoder` emits the last bytes received on the channel
even if it doesn't end with the configured delimiter.

Fixes #4105