### PR TITLE
Add back search term highlighting

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/indexer/results/HighlightParser.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/results/HighlightParser.java
@@ -1,0 +1,62 @@
+/**
+ * This file is part of Graylog.
+ *
+ * Graylog is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.graylog2.indexer.results;
+
+import com.google.common.collect.ImmutableListMultimap;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Multimap;
+import com.google.common.collect.Range;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+final class HighlightParser {
+    private static final String startToken = "<em>";
+    private static final String endToken = "</em>";
+    private static final Pattern highlightPattern = Pattern.compile(startToken + "(.*?)" + endToken);
+    private static final Integer startTokenLength = startToken.length();
+    private static final Integer endTokenLength = endToken.length();
+
+    private HighlightParser() {}
+
+    static Multimap<String, Range<Integer>> extractHighlightRanges(Map<String, List<String>> highlight) {
+        if (highlight == null || highlight.isEmpty()) {
+            return ImmutableListMultimap.of();
+        }
+        final ImmutableListMultimap.Builder<String, Range<Integer>> builder = ImmutableListMultimap.builder();
+        highlight.forEach((key, value) -> extractRange(value).forEach(range -> builder.put(key, range)));
+        return builder.build();
+    }
+
+    private static Set<Range<Integer>> extractRange(List<String> highlights) {
+        final ImmutableSet.Builder<Range<Integer>> builder = ImmutableSet.builder();
+        highlights.forEach(highlight -> {
+            final Matcher matcher = highlightPattern.matcher(highlight);
+            Integer count = -1;
+            while (matcher.find()) {
+                count++;
+                final Integer start = matcher.start() - count * (startTokenLength + endTokenLength);
+                final Integer end = start + (matcher.end(1) - matcher.start(1));
+                builder.add(Range.closed(start, end));
+            }
+        });
+        return builder.build();
+    }
+}

--- a/graylog2-server/src/main/java/org/graylog2/indexer/results/ResultMessage.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/results/ResultMessage.java
@@ -24,6 +24,8 @@ import org.graylog2.plugin.Message;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.util.Collections;
+import java.util.List;
 import java.util.Map;
 
 import static org.graylog2.plugin.Tools.ES_DATE_FORMAT_FORMATTER;
@@ -39,12 +41,18 @@ public class ResultMessage {
 
     protected ResultMessage() { /* use factory method */}
 
-    public static ResultMessage parseFromSource(String id, String index, Map<String, Object> message) {
-        final ResultMessage m = new ResultMessage();
-        m.setMessage(id, message);
-        m.setIndex(index);
+    private ResultMessage(String id, String index, Map<String, Object> message, Multimap<String, Range<Integer>> highlightRanges) {
+        this.index = index;
+        this.highlightRanges = highlightRanges;
+        setMessage(id, message);
+    }
 
-        return m;
+    public static ResultMessage parseFromSource(String id, String index, Map<String, Object> message) {
+        return parseFromSource(id, index, message, Collections.emptyMap());
+    }
+
+    public static ResultMessage parseFromSource(String id, String index, Map<String, Object> message, Map<String, List<String>> highlight) {
+        return new ResultMessage(id, index, message, HighlightParser.extractHighlightRanges(highlight));
     }
 
     public static ResultMessage createFromMessage(Message message) {

--- a/graylog2-server/src/main/java/org/graylog2/indexer/searches/Searches.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/searches/Searches.java
@@ -39,6 +39,7 @@ import org.elasticsearch.common.Strings;
 import org.elasticsearch.index.query.BoolQueryBuilder;
 import org.elasticsearch.index.query.QueryBuilder;
 import org.elasticsearch.index.query.QueryBuilders;
+import org.elasticsearch.index.query.QueryStringQueryBuilder;
 import org.elasticsearch.search.aggregations.AggregationBuilders;
 import org.elasticsearch.search.aggregations.bucket.filter.FilterAggregationBuilder;
 import org.elasticsearch.search.aggregations.bucket.histogram.DateHistogramBuilder;

--- a/graylog2-server/src/main/java/org/graylog2/indexer/searches/Searches.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/searches/Searches.java
@@ -39,7 +39,6 @@ import org.elasticsearch.common.Strings;
 import org.elasticsearch.index.query.BoolQueryBuilder;
 import org.elasticsearch.index.query.QueryBuilder;
 import org.elasticsearch.index.query.QueryBuilders;
-import org.elasticsearch.index.query.QueryStringQueryBuilder;
 import org.elasticsearch.search.aggregations.AggregationBuilders;
 import org.elasticsearch.search.aggregations.bucket.filter.FilterAggregationBuilder;
 import org.elasticsearch.search.aggregations.bucket.histogram.DateHistogramBuilder;
@@ -278,7 +277,7 @@ public class Searches {
 
         final io.searchbox.core.SearchResult searchResult = checkForFailedShards(JestUtils.execute(jestClient, searchBuilder.build(), () -> "Unable to perform search query."));
         final List<ResultMessage> hits = searchResult.getHits(Map.class, false).stream()
-            .map(hit -> ResultMessage.parseFromSource(hit.id, hit.index, (Map<String, Object>) hit.source))
+            .map(hit -> ResultMessage.parseFromSource(hit.id, hit.index, (Map<String, Object>) hit.source, hit.highlight))
             .collect(Collectors.toList());
         final long tookMs = tookMsFromSearchResult(searchResult);
         recordEsMetrics(tookMs, config.range());

--- a/graylog2-server/src/test/java/org/graylog2/indexer/results/HighlightParserTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/indexer/results/HighlightParserTest.java
@@ -1,0 +1,103 @@
+/**
+ * This file is part of Graylog.
+ *
+ * Graylog is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.graylog2.indexer.results;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.Multimap;
+import com.google.common.collect.Range;
+import org.junit.Test;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class HighlightParserTest {
+    @Test
+    public void simpleHighlightAtStartOfString() throws Exception {
+        final Map<String, List<String>> highlights = ImmutableMap.of(
+                "message", ImmutableList.of("<em>last</em> message repeated 2 times")
+        );
+
+        final Multimap<String, Range<Integer>> result = HighlightParser.extractHighlightRanges(highlights);
+
+        assertThat(result).isNotNull();
+        assertThat(result.get("message")).isNotNull()
+                .isNotEmpty()
+                .containsExactly(Range.closed(0, 4));
+    }
+
+    @Test
+    public void multipleHighlights() throws Exception {
+        final Map<String, List<String>> highlights = ImmutableMap.of(
+                "message", ImmutableList.of("/<em>usr</em>/sbin/cron[22390]: (root) CMD (/<em>usr</em>/libexec/atrun)"),
+                "full_message", ImmutableList.of("<78>Aug 22 10:40:00 /<em>usr</em>/sbin/cron[22390]: (root) CMD (/<em>usr</em>/libexec/atrun)")
+        );
+
+        final Multimap<String, Range<Integer>> result = HighlightParser.extractHighlightRanges(highlights);
+
+        assertThat(result).isNotNull();
+        assertThat(result.get("message")).isNotNull()
+                .isNotEmpty()
+                .containsExactly(
+                        Range.closed(1, 4),
+                        Range.closed(36, 39)
+                );
+        assertThat(result.get("full_message")).isNotNull()
+                .isNotEmpty()
+                .containsExactly(
+                        Range.closed(21, 24),
+                        Range.closed(56, 59)
+                );
+    }
+
+    @Test
+    public void brokenHighlight() throws Exception {
+        final Map<String, List<String>> highlights = ImmutableMap.of(
+                "message", ImmutableList.of("/<em>usr</em>/sbin</em>/cron[22390]<em>: (root) CMD (/<em>usr</em>/libexec/atrun)")
+        );
+
+        final Multimap<String, Range<Integer>> result = HighlightParser.extractHighlightRanges(highlights);
+
+        assertThat(result).isNotNull();
+        assertThat(result.get("message")).isNotNull()
+                .isNotEmpty()
+                .containsExactly(
+                        Range.closed(1, 4),
+                        Range.closed(26, 48)
+                );
+    }
+
+    @Test
+    public void emptyHighlights() throws Exception {
+        final Map<String, List<String>> highlights = ImmutableMap.of();
+
+        final Multimap<String, Range<Integer>> result = HighlightParser.extractHighlightRanges(highlights);
+
+        assertThat(result).isNotNull();
+        assertThat(result.entries()).isEmpty();
+    }
+
+    @Test
+    public void nullHighlights() throws Exception {
+        final Multimap<String, Range<Integer>> result = HighlightParser.extractHighlightRanges(null);
+
+        assertThat(result).isNotNull();
+        assertThat(result.entries()).isEmpty();
+    }
+}


### PR DESCRIPTION
During the switch from an ES node client to an HTTP client, code relevant for parsing the highlighting information contained in the search response was removed.

Refs #4103
Fixes #4101

(cherry picked from commit 9c844a9ad460f10ab5de52eee3123d1ace3a8dfa)