### PR TITLE
Enable snapshot deployment in Travis CI for 2.x branches

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -39,6 +39,10 @@ deploy:
       - 1.2
       - 1.3
       - 2.0
+      - 2.1
+      - 2.2
+      - 2.3
+      - 2.4
 env:
   global:
   - secure: MYZwUwFkHwWfJ79JKyDK8VrYVcsax4t+7atMLLVNI4CDxTWZzR4qFGUfauf+7fDEmnGYbMHDRSnzzhVtSR0ZSuvWoSkZ+v62ASmSfglzI2GcMD/VBREq+9TlLasSIa+wR60VvgYwxJnawwJlV6sbjmetT6MWug7/icdi5KgfDlQ=


### PR DESCRIPTION
Travis CI stopped deploying snapshots from the `2.x` branches with `2.0` because they weren't listed in the `deploy.on.branch` section in `.travis.yml`.