### PR TITLE
Add "format" query parameter to Elasticsearch cat request

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/indexer/cluster/Cluster.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/cluster/Cluster.java
@@ -115,6 +115,7 @@ public class Cluster {
         final Cat request = new Cat.NodesBuilder()
                 .setParameter("h", fieldNames)
                 .setParameter("full_id", true)
+                .setParameter("format", "json")
                 .build();
         final CatResult response = JestUtils.execute(jestClient, request, () -> "Unable to read Elasticsearch node information");
         return response.getJsonObject().path("result");

--- a/graylog2-server/src/main/java/org/graylog2/indexer/cluster/Cluster.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/cluster/Cluster.java
@@ -122,15 +122,16 @@ public class Cluster {
     }
 
     public Set<NodeFileDescriptorStats> getFileDescriptorStats() {
-        final JsonNode nodes = catNodes("name", "host", "fileDescriptorMax");
+        final JsonNode nodes = catNodes("name", "host", "ip", "fileDescriptorMax");
         final ImmutableSet.Builder<NodeFileDescriptorStats> setBuilder = ImmutableSet.builder();
         for (JsonNode jsonElement : nodes) {
             if (jsonElement.isObject()) {
                 final String name = jsonElement.path("name").asText();
                 final String host = jsonElement.path("host").asText(null);
+                final String ip = jsonElement.path("ip").asText();
                 final JsonNode fileDescriptorMax = jsonElement.path("fileDescriptorMax");
                 final Long maxFileDescriptors = fileDescriptorMax.isLong() ? fileDescriptorMax.asLong() : null;
-                setBuilder.add(NodeFileDescriptorStats.create(name, host, maxFileDescriptors));
+                setBuilder.add(NodeFileDescriptorStats.create(name, ip, host, maxFileDescriptors));
             }
         }
 

--- a/graylog2-server/src/main/java/org/graylog2/indexer/cluster/Cluster.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/cluster/Cluster.java
@@ -69,6 +69,7 @@ public class Cluster {
     private Optional<JsonNode> clusterHealth(Collection<? extends String> indices) {
         final Health request = new Health.Builder()
                 .addIndex(indices)
+                .timeout(Ints.saturatedCast(requestTimeout.toSeconds()))
                 .build();
         try {
             final JestResult jestResult = JestUtils.execute(jestClient, request, () -> "Couldn't read cluster health for indices " + indices);

--- a/graylog2-server/src/main/java/org/graylog2/indexer/cluster/NodeFileDescriptorStats.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/cluster/NodeFileDescriptorStats.java
@@ -25,12 +25,14 @@ import java.util.Optional;
 public abstract class NodeFileDescriptorStats {
     public abstract String name();
 
+    public abstract String ip();
+
     @Nullable
     public abstract String host();
 
     public abstract Optional<Long> fileDescriptorMax();
 
-    public static NodeFileDescriptorStats create(String name, @Nullable String host, Long fileDescriptorMax) {
-        return new AutoValue_NodeFileDescriptorStats(name, host, Optional.ofNullable(fileDescriptorMax));
+    public static NodeFileDescriptorStats create(String name, String ip, @Nullable String host, Long fileDescriptorMax) {
+        return new AutoValue_NodeFileDescriptorStats(name, ip, host, Optional.ofNullable(fileDescriptorMax));
     }
 }

--- a/graylog2-server/src/test/java/org/graylog2/indexer/cluster/ClusterTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/indexer/cluster/ClusterTest.java
@@ -1,0 +1,236 @@
+/**
+ * This file is part of Graylog.
+ *
+ * Graylog is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.graylog2.indexer.cluster;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.github.joschi.jadconfig.util.Duration;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.util.concurrent.ThreadFactoryBuilder;
+import io.searchbox.client.JestResult;
+import io.searchbox.core.Cat;
+import io.searchbox.core.CatResult;
+import io.searchbox.indices.CreateIndex;
+import io.searchbox.indices.DeleteIndex;
+import io.searchbox.indices.aliases.AddAliasMapping;
+import io.searchbox.indices.aliases.ModifyAliases;
+import io.searchbox.indices.aliases.RemoveAliasMapping;
+import org.graylog2.AbstractESTest;
+import org.graylog2.indexer.IndexSetRegistry;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnit;
+import org.mockito.junit.MockitoRule;
+
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+
+public class ClusterTest extends AbstractESTest {
+    private static final String INDEX_NAME = "cluster_it_" + System.nanoTime();
+    private static final String ALIAS_NAME = "cluster_it_alias_" + System.nanoTime();
+
+    @Rule
+    public final MockitoRule mockitoRule = MockitoJUnit.rule();
+
+    @Mock
+    private IndexSetRegistry indexSetRegistry;
+
+    private Cluster cluster;
+
+    @Before
+    public void setUp() throws Exception {
+        super.setUp();
+
+        final Map<String, Map<String, Object>> settings = ImmutableMap.of("settings", ImmutableMap.of(
+                "number_of_shards", 1,
+                "number_of_replicas", 0));
+        final CreateIndex createIndex = new CreateIndex.Builder(INDEX_NAME).settings(settings).refresh(true).build();
+        final JestResult createIndexResponse = jestClient().execute(createIndex);
+        assertThat(createIndexResponse.isSucceeded()).isTrue();
+
+        final AddAliasMapping addAliasMapping = new AddAliasMapping.Builder(INDEX_NAME, ALIAS_NAME).build();
+        final ModifyAliases modifyAliases = new ModifyAliases.Builder(addAliasMapping).refresh(true).build();
+        final JestResult modifyAliasesResponse = jestClient().execute(modifyAliases);
+        assertThat(modifyAliasesResponse.isSucceeded()).isTrue();
+
+        final ScheduledExecutorService scheduler = Executors.newSingleThreadScheduledExecutor(
+                new ThreadFactoryBuilder().setNameFormat("cluster-it-%d").build()
+        );
+        cluster = new Cluster(jestClient(), indexSetRegistry, scheduler, Duration.seconds(1L));
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        final RemoveAliasMapping removeAliasMapping = new RemoveAliasMapping.Builder(INDEX_NAME, ALIAS_NAME).build();
+        final ModifyAliases modifyAliases = new ModifyAliases.Builder(removeAliasMapping).refresh(true).build();
+        final JestResult modifyAliasesResponse = jestClient().execute(modifyAliases);
+        assertThat(modifyAliasesResponse.isSucceeded()).isTrue();
+
+        final DeleteIndex deleteIndex = new DeleteIndex.Builder(INDEX_NAME).refresh(true).build();
+        final JestResult deleteIndexResponse = jestClient().execute(deleteIndex);
+        assertThat(deleteIndexResponse.isSucceeded()).isTrue();
+    }
+
+    @Test
+    public void getFileDescriptorStats() throws Exception {
+        final Set<NodeFileDescriptorStats> fileDescriptorStats = cluster.getFileDescriptorStats();
+        assertThat(fileDescriptorStats).isNotEmpty();
+    }
+
+    @Test
+    public void health() throws Exception {
+        when(indexSetRegistry.getIndexWildcards()).thenReturn(new String[]{INDEX_NAME});
+        final Optional<JsonNode> health = cluster.health();
+        assertThat(health)
+                .isPresent()
+                .hasValueSatisfying(json -> assertThat(json.path("status").asText()).isEqualTo("green"));
+    }
+
+    @Test
+    public void health_returns_empty_with_missing_index() throws Exception {
+        when(indexSetRegistry.getIndexWildcards()).thenReturn(new String[]{"does_not_exist"});
+        final Optional<JsonNode> health = cluster.health();
+        assertThat(health).isEmpty();
+    }
+
+    @Test
+    public void deflectorHealth() throws Exception {
+        when(indexSetRegistry.getWriteIndexAliases()).thenReturn(new String[]{ALIAS_NAME});
+        final Optional<JsonNode> deflectorHealth = cluster.deflectorHealth();
+        assertThat(deflectorHealth)
+                .isPresent()
+                .hasValueSatisfying(json -> assertThat(json.path("status").asText()).isEqualTo("green"));
+    }
+
+    @Test
+    public void deflectorHealth_returns_empty_with_missing_index() throws Exception {
+        when(indexSetRegistry.getWriteIndexAliases()).thenReturn(new String[]{"does_not_exist"});
+        final Optional<JsonNode> deflectorHealth = cluster.deflectorHealth();
+        assertThat(deflectorHealth).isEmpty();
+    }
+
+    @Test
+    public void nodeIdToName() throws Exception {
+        final Cat nodesInfo = new Cat.NodesBuilder()
+                .setParameter("h", "id,name")
+                .setParameter("format", "json")
+                .setParameter("full_id", "true")
+                .build();
+        final CatResult catResult = jestClient().execute(nodesInfo);
+        final JsonNode result = catResult.getJsonObject().path("result");
+        assertThat(result).isNotEmpty();
+
+        final JsonNode node = result.path(0);
+        final String nodeId = node.get("id").asText();
+        final String expectedName = node.get("name").asText();
+
+        final Optional<String> name = cluster.nodeIdToName(nodeId);
+        assertThat(name)
+                .isPresent()
+                .contains(expectedName);
+    }
+
+    @Test
+    public void nodeIdToName_returns_empty_with_invalid_node_id() throws Exception {
+        final Optional<String> name = cluster.nodeIdToName("invalid-node-id");
+        assertThat(name).isEmpty();
+    }
+
+    @Test
+    public void nodeIdToHostName() throws Exception {
+        final Cat nodesInfo = new Cat.NodesBuilder()
+                .setParameter("h", "id,host")
+                .setParameter("format", "json")
+                .setParameter("full_id", "true")
+                .build();
+        final CatResult catResult = jestClient().execute(nodesInfo);
+        final JsonNode result = catResult.getJsonObject().path("result");
+        assertThat(result).isNotEmpty();
+
+        final JsonNode node = result.path(0);
+        final String nodeId = node.get("id").asText();
+        final String expectedHostName = node.get("host").asText();
+
+        final Optional<String> hostName = cluster.nodeIdToHostName(nodeId);
+        assertThat(hostName)
+                .isPresent()
+                .contains(expectedHostName);
+    }
+
+    @Test
+    public void nodeIdToHostName_returns_empty_with_invalid_node_id() throws Exception {
+        final Optional<String> hostName = cluster.nodeIdToHostName("invalid-node-id");
+        assertThat(hostName).isEmpty();
+    }
+
+    @Test
+    public void isConnected() throws Exception {
+        assertThat(cluster.isConnected()).isTrue();
+    }
+
+    @Test
+    public void isHealthy() throws Exception {
+        when(indexSetRegistry.getIndexWildcards()).thenReturn(new String[]{INDEX_NAME});
+        when(indexSetRegistry.isUp()).thenReturn(true);
+        assertThat(cluster.isHealthy()).isTrue();
+    }
+
+    @Test
+    public void isHealthy_returns_false_with_missing_index() throws Exception {
+        when(indexSetRegistry.getIndexWildcards()).thenReturn(new String[]{"does-not-exist"});
+        when(indexSetRegistry.isUp()).thenReturn(true);
+        assertThat(cluster.isHealthy()).isFalse();
+    }
+
+    @Test
+    public void isHealthy_returns_false_with_missing_write_aliases() throws Exception {
+        when(indexSetRegistry.getIndexWildcards()).thenReturn(new String[]{INDEX_NAME});
+        when(indexSetRegistry.isUp()).thenReturn(false);
+        assertThat(cluster.isHealthy()).isFalse();
+    }
+
+    @Test
+    public void isDeflectorHealthy() throws Exception {
+        when(indexSetRegistry.getWriteIndexAliases()).thenReturn(new String[]{ALIAS_NAME});
+        when(indexSetRegistry.isUp()).thenReturn(true);
+        assertThat(cluster.isDeflectorHealthy()).isTrue();
+    }
+
+    @Test
+    public void isDeflectorHealthy_returns_false_with_missing_aliases() throws Exception {
+        when(indexSetRegistry.getWriteIndexAliases()).thenReturn(new String[]{"does-not-exist"});
+        when(indexSetRegistry.isUp()).thenReturn(true);
+        assertThat(cluster.isDeflectorHealthy()).isFalse();
+    }
+
+    @Test
+    public void waitForConnectedAndDeflectorHealthy() throws Exception {
+        when(indexSetRegistry.getIndexWildcards()).thenReturn(new String[]{INDEX_NAME});
+        when(indexSetRegistry.getWriteIndexAliases()).thenReturn(new String[]{ALIAS_NAME});
+        when(indexSetRegistry.isUp()).thenReturn(true);
+
+        cluster.waitForConnectedAndDeflectorHealthy();
+    }
+}


### PR DESCRIPTION
While using the "Accept" HTTP request header should be perfectly sufficient, some Elasticsearch "clones" (such as the AWS Elasticsearch Service) don't seem to support it.

This change set adds the alternative "format" query parameter to the cat request in order to satisfy these clones.

Also see: https://www.elastic.co/guide/en/elasticsearch/reference/5.4/cat.html#_response_as_text_json_smile_yaml_or_cbor

Additionally to adding an integration test for the `Cluster` class, this PR also addresses two other minor issues:

* Add missing timeout in the `Cluster#clusterHealth()` method
* Use IP address as fallback if the hostname of an Elasticsearch node can't be identified

Closes #4119