### PR TITLE
Fix setting the maximum HTTP request headers size in JerseyService

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/plugin/BaseConfiguration.java
+++ b/graylog2-server/src/main/java/org/graylog2/plugin/BaseConfiguration.java
@@ -75,9 +75,6 @@ public abstract class BaseConfiguration {
     @Parameter(value = "rest_enable_gzip")
     private boolean restEnableGzip = true;
 
-    @Parameter(value = "rest_max_initial_line_length", required = true, validator = PositiveIntegerValidator.class)
-    private int restMaxInitialLineLength = 4096;
-
     @Parameter(value = "rest_max_header_size", required = true, validator = PositiveIntegerValidator.class)
     private int restMaxHeaderSize = 8192;
 
@@ -146,9 +143,6 @@ public abstract class BaseConfiguration {
 
     @Parameter(value = "web_enable_gzip")
     private boolean webEnableGzip = true;
-
-    @Parameter(value = "web_max_initial_line_length", required = true, validator = PositiveIntegerValidator.class)
-    private int webMaxInitialLineLength = 4096;
 
     @Parameter(value = "web_max_header_size", required = true, validator = PositiveIntegerValidator.class)
     private int webMaxHeaderSize = 8192;
@@ -286,10 +280,6 @@ public abstract class BaseConfiguration {
         return restEnableGzip;
     }
 
-    public int getRestMaxInitialLineLength() {
-        return restMaxInitialLineLength;
-    }
-
     public int getRestMaxHeaderSize() {
         return restMaxHeaderSize;
     }
@@ -402,10 +392,6 @@ public abstract class BaseConfiguration {
 
     public boolean isWebEnableGzip() {
         return webEnableGzip;
-    }
-
-    public int getWebMaxInitialLineLength() {
-        return webMaxInitialLineLength;
     }
 
     public int getWebMaxHeaderSize() {

--- a/graylog2-server/src/main/java/org/graylog2/shared/initializers/JerseyService.java
+++ b/graylog2-server/src/main/java/org/graylog2/shared/initializers/JerseyService.java
@@ -38,7 +38,6 @@ import org.graylog2.audit.PluginAuditEventTypes;
 import org.graylog2.audit.jersey.AuditEventModelProcessor;
 import org.graylog2.jersey.PrefixAddingModelProcessor;
 import org.graylog2.plugin.rest.PluginRestResource;
-import org.graylog2.rest.GraylogErrorPageGenerator;
 import org.graylog2.rest.filter.WebAppNotFoundResponseFilter;
 import org.graylog2.shared.rest.CORSFilter;
 import org.graylog2.shared.rest.NodeIdResponseFilter;
@@ -169,7 +168,6 @@ public class JerseyService extends AbstractIdleService {
                 sslEngineConfigurator,
                 configuration.getWebThreadPoolSize(),
                 configuration.getWebSelectorRunnersCount(),
-                configuration.getWebMaxInitialLineLength(),
                 configuration.getWebMaxHeaderSize(),
                 configuration.isWebEnableGzip(),
                 configuration.isWebEnableCors(),
@@ -226,7 +224,6 @@ public class JerseyService extends AbstractIdleService {
                 sslEngineConfigurator,
                 configuration.getRestThreadPoolSize(),
                 configuration.getRestSelectorRunnersCount(),
-                configuration.getRestMaxInitialLineLength(),
                 configuration.getRestMaxHeaderSize(),
                 configuration.isRestEnableGzip(),
                 configuration.isRestEnableCors(),
@@ -326,7 +323,6 @@ public class JerseyService extends AbstractIdleService {
                              SSLEngineConfigurator sslEngineConfigurator,
                              int threadPoolSize,
                              int selectorRunnersCount,
-                             int maxInitialLineLength,
                              int maxHeaderSize,
                              boolean enableGzip,
                              boolean enableCors,
@@ -347,8 +343,7 @@ public class JerseyService extends AbstractIdleService {
                 false);
 
         final NetworkListener listener = httpServer.getListener("grizzly");
-        listener.setMaxHttpHeaderSize(maxInitialLineLength);
-        listener.setMaxRequestHeaders(maxHeaderSize);
+        listener.setMaxHttpHeaderSize(maxHeaderSize);
 
         final ExecutorService workerThreadPoolExecutor = instrumentedExecutor(
                 namePrefix + "-worker-executor",

--- a/misc/graylog.conf
+++ b/misc/graylog.conf
@@ -115,9 +115,6 @@ rest_listen_uri = http://127.0.0.1:9000/api/
 # The maximum size of the HTTP request headers in bytes.
 #rest_max_header_size = 8192
 
-# The maximal length of the initial HTTP/1.1 line in bytes.
-#rest_max_initial_line_length = 4096
-
 # The size of the thread pool used exclusively for serving the REST API.
 #rest_thread_pool_size = 16
 
@@ -162,9 +159,6 @@ rest_listen_uri = http://127.0.0.1:9000/api/
 
 # The maximum size of the HTTP request headers in bytes.
 #web_max_header_size = 8192
-
-# The maximal length of the initial HTTP/1.1 line in bytes.
-#web_max_initial_line_length = 4096
 
 # The size of the thread pool used exclusively for serving the web interface.
 #web_thread_pool_size = 16


### PR DESCRIPTION
The configuration settings `rest_max_initial_line_length` and `web_max_initial_line_length` were incorrectly used in `JerseyService` to specify the maximum size of HTTP request headers.

The correct configuration settings to use are `rest_max_header_size` and `web_max_header_size`.

Since there are no equivalent settings in Grizzly (as opposed to Netty's HTTP handler, from which these settings have been carried over), the incorrectly used settings have been removed.

Fixes #4118
Refs #1613