### PR TITLE
Show "Not found" page if user lacks permission for entity.

### DIFF
--- a/graylog2-web-interface/src/logic/rest/FetchProvider.js
+++ b/graylog2-web-interface/src/logic/rest/FetchProvider.js
@@ -71,7 +71,7 @@ export class Builder {
 
         // Redirect to the start page if a user is logged in but not allowed to access a certain HTTP API.
         if (SessionStore.isLoggedIn() && error.status === 403) {
-          history.replaceState(null, Routes.STARTPAGE);
+          history.replaceState(null, Routes.NOTFOUND);
         }
 
         if (error.originalError && !error.originalError.status) {

--- a/graylog2-web-interface/src/pages/NotFoundPage.jsx
+++ b/graylog2-web-interface/src/pages/NotFoundPage.jsx
@@ -19,7 +19,7 @@ const NotFoundPage = React.createClass({
         <Row className="jumbotron-container">
           <Col mdOffset={2} md={8}>
             <Jumbotron>
-              <h1>404 - Page not found</h1>
+              <h1>Page not found</h1>
               <p>The party gorilla was just here, but had another party to rock.</p>
               <p>Oh, party gorilla! How we miss you! Will we ever see you again?</p>
             </Jumbotron>

--- a/graylog2-web-interface/src/routing/AppRouter.jsx
+++ b/graylog2-web-interface/src/routing/AppRouter.jsx
@@ -141,6 +141,7 @@ const AppRouter = React.createClass({
             <Route path={Routes.SYSTEM.OVERVIEW} component={SystemOverviewPage} />
             <Route path={Routes.SYSTEM.THREADDUMP(':nodeId')} component={ThreadDumpPage} />
             {pluginRoutes}
+            <Route path={Routes.NOTFOUND} component={NotFoundPage} />
             <Route path="*" component={NotFoundPage} />
           </Route>
         </Route>

--- a/graylog2-web-interface/src/routing/Routes.jsx
+++ b/graylog2-web-interface/src/routing/Routes.jsx
@@ -43,6 +43,7 @@ PluginStore.exports('routes').forEach((pluginRoute) => {
 
 const Routes = {
   STARTPAGE: '/',
+  NOTFOUND: '/notfound',
   SEARCH: '/search',
   STREAMS: '/streams',
   ALERTS: {


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Before this change, the user was redirected to the user's startpage,
when fetching an entity failed with an http error code of 403 (obviously
being the case for non-admin users only, admin users either get the
entity or a 404). This results in an infinite redirect loop if the
missing or non-permitted entity/resource is the same as the configured
start page.

With this change, the user is redirected to the already existing "Not
found" page previously used to handle nonexisting resources. This also
raises the user's attention that the configured start page is
inaccessible.

This change should also be merged into `master`.

Fixes #4117.

<!--- Provide a general summary of your changes in the Title above -->


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
