### PR TITLE
Remove special handling of "facility" field in GELF Output

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/outputs/GelfOutput.java
+++ b/graylog2-server/src/main/java/org/graylog2/outputs/GelfOutput.java
@@ -242,7 +242,6 @@ public class GelfOutput implements MessageOutput {
 
         final GelfMessageLevel messageLevel = extractLevel(message.getField(Message.FIELD_LEVEL));
         final String fullMessage = (String) message.getField(Message.FIELD_FULL_MESSAGE);
-        final String facility = (String) message.getField("facility");
         final String forwarder = GelfOutput.class.getCanonicalName();
 
         final GelfMessageBuilder builder = new GelfMessageBuilder(message.getMessage(), message.getSource())
@@ -256,10 +255,6 @@ public class GelfOutput implements MessageOutput {
 
         if (fullMessage != null) {
             builder.fullMessage(fullMessage);
-        }
-
-        if (facility != null) {
-            builder.additionalField("_facility", facility);
         }
 
         return builder.build();

--- a/graylog2-server/src/test/java/org/graylog2/outputs/GelfOutputTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/outputs/GelfOutputTest.java
@@ -172,4 +172,17 @@ public class GelfOutputTest {
 
         assertEquals(GelfMessageLevel.ALERT, gelfMessage.getLevel());
     }
+
+    @Test
+    public void testToGELFMessageWithNonStringFacility() throws Exception {
+        final GelfTransport transport = mock(GelfTransport.class);
+        final GelfOutput gelfOutput = new GelfOutput(transport);
+        final DateTime now = DateTime.now(DateTimeZone.UTC);
+        final Message message = new Message("Test", "Source", now);
+        message.addField("facility", 42L);
+
+        final GelfMessage gelfMessage = gelfOutput.toGELFMessage(message);
+
+        assertEquals(42L, gelfMessage.getAdditionalFields().get("facility"));
+    }
 }


### PR DESCRIPTION
Since "facility" is not a reserved field (as of GELF 1.1), it shouldn't be handled in a special way.

This change set removes casting the "facility" field to a string and uses it as-is in the generated GELF message.

Fixes #4140