### PR TITLE
Replace "deprecated" Counts API with Multi Search with size=0

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/indexer/counts/Counts.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/counts/Counts.java
@@ -16,14 +16,19 @@
  */
 package org.graylog2.indexer.counts;
 
+import com.fasterxml.jackson.databind.JsonNode;
 import io.searchbox.client.JestClient;
-import io.searchbox.core.Count;
-import io.searchbox.core.CountResult;
+import io.searchbox.core.MultiSearch;
+import io.searchbox.core.MultiSearchResult;
+import io.searchbox.core.Search;
 import org.elasticsearch.index.query.QueryBuilders;
 import org.elasticsearch.search.builder.SearchSourceBuilder;
+import org.graylog2.indexer.ElasticsearchException;
 import org.graylog2.indexer.IndexSet;
 import org.graylog2.indexer.IndexSetRegistry;
 import org.graylog2.indexer.cluster.jest.JestUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import javax.inject.Inject;
 import javax.inject.Singleton;
@@ -32,6 +37,8 @@ import java.util.List;
 
 @Singleton
 public class Counts {
+    private static final Logger LOG = LoggerFactory.getLogger(Counts.class);
+
     private final JestClient jestClient;
     private final IndexSetRegistry indexSetRegistry;
 
@@ -59,12 +66,23 @@ public class Counts {
         final List<String> indices = Arrays.asList(indexNames);
         final String query = new SearchSourceBuilder()
                 .query(QueryBuilders.matchAllQuery())
+                .size(0)
                 .toString();
-        final Count request = new Count.Builder()
-                .query(query)
+        final Search request = new Search.Builder(query)
                 .addIndex(indices)
                 .build();
-        final CountResult result = JestUtils.execute(jestClient, request, () -> "Fetching message count failed for indices " + indices);
-        return result.getCount().longValue();
+        final MultiSearch multiSearch = new MultiSearch.Builder(request).build();
+        final MultiSearchResult searchResult = JestUtils.execute(jestClient, multiSearch, () -> "Fetching message count failed for indices " + indices);
+        final JsonNode responses = searchResult.getJsonObject().path("responses");
+        if (!responses.isArray()) {
+            LOG.debug("\"responses\" array not found: {}", responses.toString());
+            throw new ElasticsearchException("Expected list of results not found");
+        }
+
+        if (responses.size() != 1) {
+            throw new ElasticsearchException("Expected list of results to contain exactly 1 item, actual size: " + responses.size());
+        }
+
+        return responses.path(0).path("hits").path("total").asLong(-1L);
     }
 }

--- a/graylog2-server/src/test/java/org/graylog2/indexer/cluster/jest/JestUtilsTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/indexer/cluster/jest/JestUtilsTest.java
@@ -129,9 +129,11 @@ public class JestUtilsTest {
         when(resultMock.isSucceeded()).thenReturn(false);
 
         final ObjectNode responseStub = objectMapper.createObjectNode();
+        final ObjectNode errorStub = objectMapper.createObjectNode();
         responseStub.set("Message", new TextNode("Authorization header requires 'Credential' parameter."));
+        errorStub.set("error", responseStub);
 
-        when(resultMock.getJsonObject()).thenReturn(responseStub);
+        when(resultMock.getJsonObject()).thenReturn(errorStub);
 
         when(clientMock.execute(request)).thenReturn(resultMock);
 

--- a/graylog2-server/src/test/java/org/graylog2/indexer/counts/CountsIT.java
+++ b/graylog2-server/src/test/java/org/graylog2/indexer/counts/CountsIT.java
@@ -33,7 +33,6 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.ExpectedException;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnit;
 import org.mockito.junit.MockitoRule;
@@ -44,7 +43,6 @@ import java.util.Map;
 import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assert.fail;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -53,8 +51,6 @@ public class CountsIT extends ElasticsearchBase {
     private static final String INDEX_NAME_2 = "index_set_2_counts_test_0";
     @Rule
     public MockitoRule mockitoRule = MockitoJUnit.rule();
-    @Rule
-    public final ExpectedException expectedException = ExpectedException.none();
 
     @Mock
     private IndexSetRegistry indexSetRegistry;
@@ -200,7 +196,7 @@ public class CountsIT extends ElasticsearchBase {
         when(indexSet.getManagedIndices()).thenReturn(new String[]{"does_not_exist"});
 
         try {
-            assertThat(counts.total(indexSet)).isEqualTo(-1L);
+            counts.total(indexSet);
         } catch (IndexNotFoundException e) {
             final String expectedErrorDetail = "Index not found for query: does_not_exist. Try recalculating your index ranges.";
             assertThat(e)
@@ -208,8 +204,6 @@ public class CountsIT extends ElasticsearchBase {
                 .hasMessageEndingWith(expectedErrorDetail)
                 .hasNoSuppressedExceptions();
             assertThat(e.getErrorDetails()).containsExactly(expectedErrorDetail);
-        } catch (Exception e) {
-            fail("Expected IndexNotFoundException to be thrown");
         }
     }
 

--- a/graylog2-server/src/test/java/org/graylog2/indexer/counts/CountsIT.java
+++ b/graylog2-server/src/test/java/org/graylog2/indexer/counts/CountsIT.java
@@ -212,4 +212,29 @@ public class CountsIT extends ElasticsearchBase {
             fail("Expected IndexNotFoundException to be thrown");
         }
     }
+
+    @Test
+    public void totalSucceedsWithListOfIndicesLargerThan4Kilobytes() throws Exception {
+        final int numberOfIndices = 100;
+        final String[] indexNames = new String[numberOfIndices];
+        final String indexPrefix = "very_long_list_of_indices_0123456789_counts_it_";
+        final IndexSet indexSet = mock(IndexSet.class);
+
+        try {
+            for (int i = 0; i < numberOfIndices; i++) {
+                final String indexName = indexPrefix + i;
+                createIndex(indexName);
+                indexNames[i] = indexName;
+            }
+
+            when(indexSet.getManagedIndices()).thenReturn(indexNames);
+
+            final String indicesString = String.join(",", indexNames);
+            assertThat(indicesString.length()).isGreaterThanOrEqualTo(4096);
+
+            assertThat(counts.total(indexSet)).isEqualTo(0L);
+        } finally {
+            deleteIndex(indexNames);
+        }
+    }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -94,7 +94,7 @@
         <disruptor.version>3.3.6</disruptor.version>
         <drools.version>6.5.0.Final</drools.version>
         <elasticsearch.version>2.4.4</elasticsearch.version>
-        <jest.version>2.4.7+jackson</jest.version>
+        <jest.version>2.4.8+jackson</jest.version>
         <gelfclient.version>1.4.1</gelfclient.version>
         <grok.version>0.1.7-graylog</grok.version>
         <guava-retrying.version>2.0.0</guava-retrying.version>

--- a/pom.xml
+++ b/pom.xml
@@ -94,7 +94,7 @@
         <disruptor.version>3.3.6</disruptor.version>
         <drools.version>6.5.0.Final</drools.version>
         <elasticsearch.version>2.4.4</elasticsearch.version>
-        <jest.version>2.4.8+jackson</jest.version>
+        <jest.version>2.4.9+jackson</jest.version>
         <gelfclient.version>1.4.1</gelfclient.version>
         <grok.version>0.1.7-graylog</grok.version>
         <guava-retrying.version>2.0.0</guava-retrying.version>


### PR DESCRIPTION
The Elasticsearch Count API doesn't allow setting the indices in the HTTP request body
and suffers from the issue that users with a large number of indices run into the default
HTTP header size limit of Elasticsearch (4 KB).

This change set replaces the (kind of) deprecated Counts API with a regular search with
size=0 issued via the Elasticsearch Multi Search API which allows specifiying the list
of indices in the request body.

Fixes #4136
Refs elastic/elasticsearch#13928