### PR TITLE
Remove superfluous config from stacked charts

### DIFF
--- a/graylog2-web-interface/src/components/dashboard/AddToDashboardMenu.jsx
+++ b/graylog2-web-interface/src/components/dashboard/AddToDashboardMenu.jsx
@@ -117,6 +117,12 @@ const AddToDashboardMenu = React.createClass({
     if (searchParams.has('streamId')) {
       searchParams = searchParams.set('stream_id', searchParams.get('streamId')).delete('streamId');
     }
+
+    if (widgetConfig.has('series')) {
+      // If widget has several series, each of them will contain a query, delete it from global widget configuration.
+      searchParams = searchParams.delete('query');
+    }
+
     widgetConfig = searchParams.merge(widgetConfig).merge(configuration);
 
     const promise = WidgetsStore.addWidget(this.state.selectedDashboard, this.props.widgetType, title, widgetConfig.toJS());

--- a/graylog2-web-interface/src/stores/field-analyzers/FieldGraphsStore.ts
+++ b/graylog2-web-interface/src/stores/field-analyzers/FieldGraphsStore.ts
@@ -35,11 +35,6 @@ interface CreateStackedChartWidgetRequestParams {
     renderer: string;
     interpolation: string;
     interval: string;
-    rangeType: string;
-    relative?: number;
-    from?: string;
-    to?: string;
-    keyword?: string;
     series: Array<StackedChartSeries>;
 }
 
@@ -277,7 +272,6 @@ class FieldGraphsStore {
             renderer: graphOptions['renderer'],
             interpolation: graphOptions['interpolation'],
             interval: graphOptions['interval'],
-            rangeType: graphOptions['rangetype']
         };
 
         var series = [this.getSeriesInformation(graphOptions)];
@@ -290,19 +284,6 @@ class FieldGraphsStore {
         }, this);
 
         requestParams['series'] = series;
-
-        switch (graphOptions['rangetype']) {
-            case "relative":
-                requestParams['relative'] = graphOptions['range']['relative'];
-                break;
-            case "absolute":
-                requestParams['from'] = graphOptions['range']['from'];
-                requestParams['to'] = graphOptions['range']['to'];
-                break;
-            case "keyword":
-                requestParams['keyword'] = graphOptions['range']['keyword'];
-                break;
-        }
 
         return <CreateStackedChartWidgetRequestParams> requestParams;
     }


### PR DESCRIPTION
Stacked charts contained some configuration options that were redundant and/or incorrect. Namely the timerange information was twice in the configuration object, and the query appeared in the main configuration object, even if the query is independent for each one of the time series in the chart.

This change fixes the issue #4150 by filtering out those redundant fields.