### PR TITLE
Expose a syncLdapUser method which can be called by other authenticators or to sync signed-in and new users from Ldap

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/security/realm/LdapUserAuthenticator.java
+++ b/graylog2-server/src/main/java/org/graylog2/security/realm/LdapUserAuthenticator.java
@@ -87,11 +87,12 @@ public class LdapUserAuthenticator extends AuthenticatingRealm {
         // safe, we only handle this type
         final UsernamePasswordToken token = (UsernamePasswordToken) authtoken;
 
-        final LdapSettings ldapSettings = ldapSettingsService.load();
-        if (ldapSettings == null || !ldapSettings.isEnabled()) {
+        if (isEnabled() == false) {
             LOG.trace("LDAP is disabled, skipping");
             return null;
         }
+
+        final LdapSettings ldapSettings = ldapSettingsService.load();
 
         final String principal = (String) token.getPrincipal();
         final char[] tokenPassword = firstNonNull(token.getPassword(), new char[0]);
@@ -175,11 +176,12 @@ public class LdapUserAuthenticator extends AuthenticatingRealm {
     @Nullable
     public User syncLdapUser(String principal) {
 
-        final LdapSettings ldapSettings = ldapSettingsService.load();
-        if (ldapSettings == null || !ldapSettings.isEnabled()) {
+        if (isEnabled() == false) {
             LOG.trace("LDAP is disabled, skipping");
             return null;
         }
+
+        final LdapSettings ldapSettings = ldapSettingsService.load();
 
         // do not try to look a token up in LDAP if there is no principal or password
         if (isNullOrEmpty(principal)) {

--- a/graylog2-server/src/main/java/org/graylog2/security/realm/LdapUserAuthenticator.java
+++ b/graylog2-server/src/main/java/org/graylog2/security/realm/LdapUserAuthenticator.java
@@ -183,7 +183,7 @@ public class LdapUserAuthenticator extends AuthenticatingRealm {
 
         // do not try to look a token up in LDAP if there is no principal or password
         if (isNullOrEmpty(principal)) {
-            LOG.debug("Principal wsa empty. Not trying to sync user with LDAP.");
+            LOG.debug("Principal was empty. Not trying to sync user with LDAP.");
             return null;
         }
         try (final LdapNetworkConnection connection = openLdapConnection(ldapSettings)) {


### PR DESCRIPTION
## Description
This changelist exposes a syncLdapUser method which creates or sync a user from Ldap. 

## Motivation and Context
At the moment, SSO authentication creates a user based on HTTP headers and default values. Instead, it would be useful to be able to authenticate a user using SSO but then sync the user roles and information from Ldap if Ldap is available.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
