### PR TITLE
Disabling ESLint indent rule for JSX elements.

### DIFF
--- a/graylog2-web-interface/packages/eslint-config-graylog/index.js
+++ b/graylog2-web-interface/packages/eslint-config-graylog/index.js
@@ -14,7 +14,7 @@ module.exports = {
     'import/extensions': 0,
     'import/no-extraneous-dependencies': 0,
     'import/no-unresolved': 0,
-    indent: [2, 2, { SwitchCase: 1 }],
+    indent: [2, 2, { SwitchCase: 1, ignoredNodes: ['JSXElement *'] }],
     'max-len': 0,
     'new-cap': 0,
     'no-else-return': 1,
@@ -28,5 +28,5 @@ module.exports = {
     'react/jsx-space-before-closing': 0,
     'react/prefer-es6-class': 0,
     'react/prefer-stateless-function': 1,
-  }
+  },
 };

--- a/graylog2-web-interface/packages/eslint-config-graylog/index.js
+++ b/graylog2-web-interface/packages/eslint-config-graylog/index.js
@@ -14,7 +14,7 @@ module.exports = {
     'import/extensions': 0,
     'import/no-extraneous-dependencies': 0,
     'import/no-unresolved': 0,
-    indent: [2, 2, { SwitchCase: 1, ignoredNodes: ['JSXElement *'] }],
+    indent: [2, 2, { SwitchCase: 1, ignoredNodes: ['JSXAttribute *'] }],
     'max-len': 0,
     'new-cap': 0,
     'no-else-return': 1,


### PR DESCRIPTION
Due to conflicting views between ESLint and us on how JSX props should be indented, the `indent` rule is now disabled for JSX attributes.

It will be reenabled when there is the `first` option for JSX prop indentation. Otherwise a different, JSX-specific indentation rule supporting this will be put in place instead.
