### PR TITLE
Add config option to disable analysis features in the UI for certain fields

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/indexer/searches/SearchesClusterConfig.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/searches/SearchesClusterConfig.java
@@ -25,6 +25,7 @@ import com.google.common.collect.ImmutableSet;
 import org.graylog.autovalue.WithBeanGetter;
 import org.joda.time.Period;
 
+import javax.annotation.Nullable;
 import java.util.Map;
 import java.util.Set;
 
@@ -62,6 +63,10 @@ public abstract class SearchesClusterConfig {
             .add("file")
             .add("source_file")
             .build();
+    private static final Set<String> DEFAULT_ANALYSIS_DISABLED_FIELDS = ImmutableSet.<String>builder()
+            .add("message")
+            .add("full_message")
+            .build();
 
     @JsonProperty("query_time_range_limit")
     public abstract Period queryTimeRangeLimit();
@@ -75,16 +80,21 @@ public abstract class SearchesClusterConfig {
     @JsonProperty("surrounding_filter_fields")
     public abstract Set<String> surroundingFilterFields();
 
+    @JsonProperty("analysis_disabled_fields")
+    public abstract Set<String> analysisDisabledFields();
+
     @JsonCreator
     public static SearchesClusterConfig create(@JsonProperty("query_time_range_limit") Period queryTimeRangeLimit,
                                                @JsonProperty("relative_timerange_options") Map<Period, String> relativeTimerangeOptions,
                                                @JsonProperty("surrounding_timerange_options") Map<Period, String> surroundingTimerangeOptions,
-                                               @JsonProperty("surrounding_filter_fields") Set<String> surroundingFilterFields) {
+                                               @JsonProperty("surrounding_filter_fields") Set<String> surroundingFilterFields,
+                                               @JsonProperty("analysis_disabled_fields") @Nullable Set<String> analysisDisabledFields) {
         return builder()
                 .queryTimeRangeLimit(queryTimeRangeLimit)
                 .relativeTimerangeOptions(relativeTimerangeOptions)
                 .surroundingTimerangeOptions(surroundingTimerangeOptions)
                 .surroundingFilterFields(surroundingFilterFields)
+                .analysisDisabledFields(analysisDisabledFields == null ? DEFAULT_ANALYSIS_DISABLED_FIELDS : analysisDisabledFields)
                 .build();
     }
 
@@ -94,6 +104,7 @@ public abstract class SearchesClusterConfig {
                 .relativeTimerangeOptions(DEFAULT_RELATIVE_TIMERANGE_OPTIONS)
                 .surroundingTimerangeOptions(DEFAULT_SURROUNDING_TIMERANGE_OPTIONS)
                 .surroundingFilterFields(DEFAULT_SURROUNDING_FILTER_FIELDS)
+                .analysisDisabledFields(DEFAULT_ANALYSIS_DISABLED_FIELDS)
                 .build();
     }
 
@@ -109,6 +120,7 @@ public abstract class SearchesClusterConfig {
         public abstract Builder relativeTimerangeOptions(Map<Period, String> relativeTimerangeOptions);
         public abstract Builder surroundingTimerangeOptions(Map<Period, String> surroundingTimerangeOptions);
         public abstract Builder surroundingFilterFields(Set<String> surroundingFilterFields);
+        public abstract Builder analysisDisabledFields(Set<String> analysisDisabledFields);
 
         public abstract SearchesClusterConfig build();
     }

--- a/graylog2-web-interface/src/components/search/FieldAnalyzersSidebar.jsx
+++ b/graylog2-web-interface/src/components/search/FieldAnalyzersSidebar.jsx
@@ -14,6 +14,7 @@ const FieldAnalyzersSidebar = React.createClass({
     maximumHeight: PropTypes.number,
     predefinedFieldSelection: PropTypes.func,
     result: PropTypes.object,
+    searchConfig: PropTypes.object.isRequired,
     selectedFields: PropTypes.object,
     shouldHighlight: PropTypes.bool,
     showAllFields: PropTypes.bool,
@@ -123,6 +124,7 @@ const FieldAnalyzersSidebar = React.createClass({
                                  fieldAnalyzers={this.props.fieldAnalyzers}
                                  onToggled={this.props.onFieldToggled}
                                  onFieldAnalyzer={this.props.onFieldAnalyzer}
+                                 searchConfig={this.props.searchConfig}
                                  selected={this.props.selectedFields.contains(field.name)} />
           );
         }

--- a/graylog2-web-interface/src/components/search/SearchResult.jsx
+++ b/graylog2-web-interface/src/components/search/SearchResult.jsx
@@ -199,6 +199,7 @@ const SearchResult = React.createClass({
                          searchInStream={this.props.searchInStream}
                          permissions={this.props.permissions}
                          loadingSearch={this.props.loadingSearch}
+                         searchConfig={this.props.searchConfig}
           />
         </Col>
         <Col md={9} sm={12} id="main-content-sidebar">

--- a/graylog2-web-interface/src/components/search/SearchSidebar.jsx
+++ b/graylog2-web-interface/src/components/search/SearchSidebar.jsx
@@ -45,6 +45,7 @@ const SearchSidebar = React.createClass({
     togglePageFields: PropTypes.func,
     toggleShouldHighlight: PropTypes.func,
     loadingSearch: PropTypes.bool,
+    searchConfig: PropTypes.object.isRequired,
   },
 
   getInitialState() {
@@ -255,6 +256,7 @@ const SearchSidebar = React.createClass({
                                      maximumHeight={this.state.availableHeight}
                                      predefinedFieldSelection={this.props.predefinedFieldSelection}
                                      result={this.props.result}
+                                     searchConfig={this.props.searchConfig}
                                      selectedFields={this.props.selectedFields}
                                      shouldHighlight={this.props.shouldHighlight}
                                      showAllFields={this.props.showAllFields}

--- a/graylog2-web-interface/src/components/search/SidebarMessageField.jsx
+++ b/graylog2-web-interface/src/components/search/SidebarMessageField.jsx
@@ -12,6 +12,7 @@ const SidebarMessageField = React.createClass({
     onFieldAnalyzer: PropTypes.func,
     onToggled: PropTypes.func,
     selected: PropTypes.bool,
+    searchConfig: PropTypes.object.isRequired,
   },
   getInitialState() {
     return {
@@ -36,18 +37,33 @@ const SidebarMessageField = React.createClass({
     };
   },
 
+  _analyzerIsDisabled(field) {
+    const disabledFields = this.props.searchConfig.analysis_disabled_fields;
+    return disabledFields && disabledFields.indexOf(field) >= 0;
+  },
+
   _fieldAnalyzersList() {
-    const analyzersList = this.props.fieldAnalyzers
-      .sort((a, b) => naturalSort(a.displayName, b.displayName))
-      .map((analyzer, idx) => {
-        return (
-          <li key={`field-analyzer-button-${idx}`}>
-            <a href="#" onClick={this._onFieldAnalyzer(analyzer.refId, this.props.field.name)}>
-              {analyzer.displayName}
-            </a>
-          </li>
-        );
-      });
+    let analyzersList;
+
+    if (this._analyzerIsDisabled(this.props.field.name)) {
+      analyzersList = (
+        <li key="field-analyzers-disabled">
+          Analysis features for this field have been disabled by the administrator.
+        </li>
+      );
+    } else {
+      analyzersList = this.props.fieldAnalyzers
+        .sort((a, b) => naturalSort(a.displayName, b.displayName))
+        .map((analyzer, idx) => {
+          return (
+            <li key={`field-analyzer-button-${idx}`}>
+              <a href="#" onClick={this._onFieldAnalyzer(analyzer.refId, this.props.field.name)}>
+                {analyzer.displayName}
+              </a>
+            </li>
+          );
+        });
+    }
 
     return <Panel className="field-analyzer"><ul>{analyzersList}</ul></Panel>;
   },


### PR DESCRIPTION
By default the "message" and "full_message" fields are disabled because using analysis features like QuickValues on these can harm an Elasticsearch cluster.

For now the config options *only* disable the UI elements in the web interface to make sure regular users cannot run dangerous queries. When using the REST API, a user can still run e.g. terms queries on these fields.

Closes #3957