### PR TITLE
Revert "Upgrade to Drools 7.3.0.Final"

### DIFF
--- a/graylog2-server/src/main/resources/log4j2.xml
+++ b/graylog2-server/src/main/resources/log4j2.xml
@@ -20,7 +20,6 @@
         <Logger name="org.graylog2.periodical.VersionCheckThread" level="off"/>
         <!-- Suppress crazy byte array dump of Drools -->
         <Logger name="org.drools.compiler.kie.builder.impl.KieRepositoryImpl" level="warn"/>
-        <Logger name="org.kie.api.internal" level="warn"/>
         <!-- Silence chatty natty -->
         <Logger name="com.joestelmach.natty.Parser" level="warn"/>
         <!-- Silence Kafka log chatter -->

--- a/pom.xml
+++ b/pom.xml
@@ -92,7 +92,7 @@
         <commons-email.version>1.5</commons-email.version>
         <commons-io.version>2.5</commons-io.version>
         <disruptor.version>3.3.6</disruptor.version>
-        <drools.version>7.3.0.Final</drools.version>
+        <drools.version>6.5.0.Final</drools.version>
         <elasticsearch.version>2.4.4</elasticsearch.version>
         <jest.version>2.4.9+jackson</jest.version>
         <gelfclient.version>1.4.1</gelfclient.version>


### PR DESCRIPTION
The upgrade to the latest Drools release introduced Graylog server startup errors during the guice binding process.

This reverts commit 885049a1b2b4b264c455d4dc054f63f3eac9a2cb.

Errors:

<details>

```
2017-09-25 17:29:59,010 ERROR: org.graylog2.bootstrap.CmdLineTool - Guice error (more detail on log level debug): Error injecting constructor, java.lang.NullPointerException
Exception in thread "main" com.google.inject.CreationException: Unable to create injector, see the following errors:

1) Error injecting constructor, java.lang.NullPointerException
  at org.graylog2.rules.DroolsEngine.<init>(DroolsEngine.java:67)
  at org.graylog2.rules.DroolsEngine.class(DroolsEngine.java:55)
  while locating org.graylog2.rules.DroolsEngine
    for the 1st parameter of org.graylog2.bindings.providers.RulesEngineProvider.<init>(RulesEngineProvider.java:40)
  at org.graylog2.bindings.providers.RulesEngineProvider.class(RulesEngineProvider.java:33)
  while locating org.graylog2.bindings.providers.RulesEngineProvider
Caused by: java.lang.NullPointerException
	at org.kie.internal.io.ResourceFactory.newUrlResource(ResourceFactory.java:50)
	at org.graylog2.rules.DroolsEngine.createKJar(DroolsEngine.java:224)
	at org.graylog2.rules.DroolsEngine.createAndDeployJar(DroolsEngine.java:194)
	at org.graylog2.rules.DroolsEngine.deployRules(DroolsEngine.java:169)
	at org.graylog2.rules.DroolsEngine.commitRules(DroolsEngine.java:147)
	at org.graylog2.rules.DroolsEngine.<init>(DroolsEngine.java:71)
	at org.graylog2.rules.DroolsEngine$$FastClassByGuice$$33775601.newInstance(<generated>)
	at com.google.inject.internal.DefaultConstructionProxyFactory$FastClassProxy.newInstance(DefaultConstructionProxyFactory.java:89)
	at com.google.inject.internal.ConstructorInjector.provision(ConstructorInjector.java:111)
	at com.google.inject.internal.ConstructorInjector.construct(ConstructorInjector.java:90)
	at com.google.inject.internal.ConstructorBindingImpl$Factory.get(ConstructorBindingImpl.java:268)
	at com.google.inject.internal.ProviderToInternalFactoryAdapter$1.call(ProviderToInternalFactoryAdapter.java:46)
	at com.google.inject.internal.InjectorImpl.callInContext(InjectorImpl.java:1092)
	at com.google.inject.internal.ProviderToInternalFactoryAdapter.get(ProviderToInternalFactoryAdapter.java:40)
	at com.google.inject.internal.SingletonScope$1.get(SingletonScope.java:194)
	at com.google.inject.internal.InternalFactoryToProviderAdapter.get(InternalFactoryToProviderAdapter.java:41)
	at com.google.inject.internal.SingleParameterInjector.inject(SingleParameterInjector.java:38)
	at com.google.inject.internal.SingleParameterInjector.getAll(SingleParameterInjector.java:62)
	at com.google.inject.internal.ConstructorInjector.provision(ConstructorInjector.java:110)
	at com.google.inject.internal.ConstructorInjector.construct(ConstructorInjector.java:90)
	at com.google.inject.internal.ConstructorBindingImpl$Factory.get(ConstructorBindingImpl.java:268)
	at com.google.inject.internal.ProviderToInternalFactoryAdapter$1.call(ProviderToInternalFactoryAdapter.java:46)
	at com.google.inject.internal.InjectorImpl.callInContext(InjectorImpl.java:1092)
	at com.google.inject.internal.ProviderToInternalFactoryAdapter.get(ProviderToInternalFactoryAdapter.java:40)
	at com.google.inject.internal.SingletonScope$1.get(SingletonScope.java:194)
	at com.google.inject.internal.InternalFactoryToProviderAdapter.get(InternalFactoryToProviderAdapter.java:41)
	at com.google.inject.internal.InternalInjectorCreator$1.call(InternalInjectorCreator.java:205)
	at com.google.inject.internal.InternalInjectorCreator$1.call(InternalInjectorCreator.java:199)
	at com.google.inject.internal.InjectorImpl.callInContext(InjectorImpl.java:1085)
	at com.google.inject.internal.InternalInjectorCreator.loadEagerSingletons(InternalInjectorCreator.java:199)
	at com.google.inject.internal.InternalInjectorCreator.injectDynamically(InternalInjectorCreator.java:180)
	at com.google.inject.internal.InternalInjectorCreator.build(InternalInjectorCreator.java:110)
	at com.google.inject.Guice.createInjector(Guice.java:99)
	at org.graylog2.shared.bindings.GuiceInjectorHolder.createInjector(GuiceInjectorHolder.java:34)
	at org.graylog2.bootstrap.CmdLineTool.setupInjector(CmdLineTool.java:379)
	at org.graylog2.bootstrap.CmdLineTool.run(CmdLineTool.java:193)
	at org.graylog2.bootstrap.Main.main(Main.java:44)
```

</details>