### PR TITLE
Field charts for non-numeric fields

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/indexer/results/FieldHistogramResult.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/results/FieldHistogramResult.java
@@ -21,6 +21,7 @@ import com.google.common.collect.Maps;
 import io.searchbox.core.search.aggregation.CardinalityAggregation;
 import io.searchbox.core.search.aggregation.HistogramAggregation;
 import io.searchbox.core.search.aggregation.StatsAggregation;
+import io.searchbox.core.search.aggregation.ValueCountAggregation;
 import org.graylog2.indexer.searches.Searches;
 import org.joda.time.DateTime;
 import org.joda.time.DateTimeZone;
@@ -70,13 +71,22 @@ public class FieldHistogramResult extends HistogramResult {
             resultMap.put("total_count", b.getCount());
 
             final StatsAggregation stats = b.getStatsAggregation(Searches.AGG_STATS);
-            resultMap.put("count", stats.getCount());
-            resultMap.put("min", stats.getMin() == null ? 0D : stats.getMin());
-            resultMap.put("max", stats.getMax() == null ? 0D : stats.getMax());
-            resultMap.put("total", stats.getSum() == null ? 0D : stats.getSum());
-            resultMap.put("mean", stats.getAvg() == null ? 0D : stats.getAvg());
+            if (stats != null) {
+                resultMap.put("count", stats.getCount() == null ? 0L : stats.getCount());
+                resultMap.put("min", stats.getMin() == null ? 0D : stats.getMin());
+                resultMap.put("max", stats.getMax() == null ? 0D : stats.getMax());
+                resultMap.put("total", stats.getSum() == null ? 0D : stats.getSum());
+                resultMap.put("mean", stats.getAvg() == null ? 0D : stats.getAvg());
+            } else {
+                // Get count from count aggregation if stats aggregation was not requested
+                final ValueCountAggregation count = b.getValueCountAggregation(Searches.AGG_VALUE_COUNT);
+                resultMap.put("count", count == null ? 0L : count.getValueCount());
+                resultMap.put("min", Double.NaN);
+                resultMap.put("max", Double.NaN);
+                resultMap.put("total", Double.NaN);
+                resultMap.put("mean", Double.NaN);
+            }
 
-            // cardinality is only calculated if it was explicitly requested, so this might be null
             final CardinalityAggregation cardinality = b.getCardinalityAggregation(Searches.AGG_CARDINALITY);
             resultMap.put("cardinality", cardinality == null ? 0 : cardinality.getCardinality());
 

--- a/graylog2-server/src/main/java/org/graylog2/indexer/searches/Searches.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/searches/Searches.java
@@ -534,11 +534,26 @@ public class Searches {
                                           String filter,
                                           TimeRange range,
                                           boolean includeCardinality) {
+        return fieldHistogram(query, field, interval, filter, range, true, includeCardinality);
+    }
+
+    public HistogramResult fieldHistogram(String query,
+                                          String field,
+                                          DateHistogramInterval interval,
+                                          String filter,
+                                          TimeRange range,
+                                          boolean includeStats,
+                                          boolean includeCardinality) {
         final DateHistogramBuilder dateHistogramBuilder = AggregationBuilders.dateHistogram(AGG_HISTOGRAM)
                 .field(Message.FIELD_TIMESTAMP)
-                .subAggregation(AggregationBuilders.stats(AGG_STATS).field(field))
                 .interval(interval.toESInterval());
 
+        if (includeStats) {
+            dateHistogramBuilder.subAggregation(AggregationBuilders.stats(AGG_STATS).field(field));
+        } else {
+            // Stats aggregation already include count. Only calculate it explicitly when stats are disabled
+            dateHistogramBuilder.subAggregation(AggregationBuilders.count(AGG_VALUE_COUNT).field(field));
+        }
         if (includeCardinality) {
             dateHistogramBuilder.subAggregation(AggregationBuilders.cardinality(AGG_CARDINALITY).field(field));
         }

--- a/graylog2-web-interface/src/legacy/analyzers/fieldcharts.js
+++ b/graylog2-web-interface/src/legacy/analyzers/fieldcharts.js
@@ -78,7 +78,7 @@ export const FieldChart = {
     }
 
     if (opts.valuetype === undefined) {
-      opts.valuetype = 'mean';
+      opts.valuetype = 'count';
     }
 
     if (opts.query === undefined) {


### PR DESCRIPTION
Up until now, trying to generate a field chart on a non-numeric value failed, as the server did only try to calculate statistical aggregations for the field and that is not possible. Anyway, we could still calculate the total and cardinality functions for those fields, as we do in the statistics analyzer.

This PR changes how we treat non-numeric field charts, enabling users to generate graphs for cardinality and total. It is as well possible to stack them to other field charts, and add them to dashboards, just as with any other field graphs.

Implements #4083.