### PR TITLE
Migrate stream matching from MessageFilter to MessageProcessor

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/bindings/MessageFilterBindings.java
+++ b/graylog2-server/src/main/java/org/graylog2/bindings/MessageFilterBindings.java
@@ -22,7 +22,6 @@ import com.google.inject.multibindings.Multibinder;
 import org.graylog2.filters.ExtractorFilter;
 import org.graylog2.filters.RulesFilter;
 import org.graylog2.filters.StaticFieldFilter;
-import org.graylog2.filters.StreamMatcherFilter;
 import org.graylog2.plugin.filters.MessageFilter;
 
 import java.net.URI;
@@ -35,7 +34,6 @@ public class MessageFilterBindings extends AbstractModule {
         messageFilters.addBinding().to(StaticFieldFilter.class);
         messageFilters.addBinding().to(ExtractorFilter.class);
         messageFilters.addBinding().to(RulesFilter.class);
-        messageFilters.addBinding().to(StreamMatcherFilter.class);
 
         // built it drools rules
         final Multibinder<URI> rulesUrls = Multibinder.newSetBinder(binder(), URI.class);

--- a/graylog2-server/src/main/java/org/graylog2/messageprocessors/MessageProcessorModule.java
+++ b/graylog2-server/src/main/java/org/graylog2/messageprocessors/MessageProcessorModule.java
@@ -23,8 +23,8 @@ public class MessageProcessorModule extends PluginModule {
     @Override
     protected void configure() {
         addMessageProcessor(MessageFilterChainProcessor.class, MessageFilterChainProcessor.Descriptor.class);
+        addMessageProcessor(StreamMatcherProcessor.class, StreamMatcherProcessor.Descriptor.class);
         // must not be a singleton, because each thread should get an isolated copy of the processors
         bind(OrderedMessageProcessors.class).in(Scopes.NO_SCOPE);
     }
-
 }

--- a/graylog2-server/src/main/java/org/graylog2/migrations/MigrationsModule.java
+++ b/graylog2-server/src/main/java/org/graylog2/migrations/MigrationsModule.java
@@ -33,5 +33,6 @@ public class MigrationsModule extends PluginModule {
         addMigration(V20161216123500_DefaultIndexSetMigration.class);
         addMigration(V20170110150100_FixAlertConditionsMigration.class);
         addMigration(V20170607164210_MigrateReopenedIndicesToAliases.class);
+        addMigration(V20170927170100_StreamMatcherFilter.class);
     }
 }

--- a/graylog2-server/src/main/java/org/graylog2/migrations/V20170927170100_StreamMatcherFilter.java
+++ b/graylog2-server/src/main/java/org/graylog2/migrations/V20170927170100_StreamMatcherFilter.java
@@ -1,0 +1,92 @@
+/**
+ * This file is part of Graylog.
+ *
+ * Graylog is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.graylog2.migrations;
+
+import org.graylog2.messageprocessors.MessageProcessorsConfig;
+import org.graylog2.messageprocessors.StreamMatcherProcessor;
+import org.graylog2.plugin.cluster.ClusterConfigService;
+import org.graylog2.plugin.messageprocessors.MessageProcessor;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.inject.Inject;
+import java.time.ZonedDateTime;
+import java.util.LinkedList;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+public class V20170927170100_StreamMatcherFilter extends Migration {
+    private static final Logger LOG = LoggerFactory.getLogger(V20170927170100_StreamMatcherFilter.class);
+
+    private final Set<MessageProcessor.Descriptor> processorDescriptors;
+    private final ClusterConfigService clusterConfigService;
+
+    @Inject
+    public V20170927170100_StreamMatcherFilter(final Set<MessageProcessor.Descriptor> processorDescriptors,
+                                               final ClusterConfigService clusterConfigService) {
+        this.processorDescriptors = processorDescriptors;
+        this.clusterConfigService = clusterConfigService;
+    }
+
+    @Override
+    public ZonedDateTime createdAt() {
+        return ZonedDateTime.parse("2017-09-27T17:01:00Z");
+    }
+
+    @Override
+    public void upgrade() {
+        final StreamMatcherProcessor.Descriptor descriptor = new StreamMatcherProcessor.Descriptor();
+        final MessageProcessorsConfig processorsConfig = clusterConfigService.get(MessageProcessorsConfig.class);
+        if (processorsConfig == null) {
+            LOG.debug("No message processor configuration found. Creating new one.");
+
+            final Set<String> processorClassNames = processorDescriptors.stream()
+                    .map(MessageProcessor.Descriptor::className)
+                    .collect(Collectors.toSet());
+            final MessageProcessorsConfig defaultProcessorsConfig = MessageProcessorsConfig.defaultConfig()
+                    .withProcessors(processorClassNames);
+
+            final LinkedList<String> processorOrder = new LinkedList<>(defaultProcessorsConfig.processorOrder());
+
+            // Put stream matcher last
+            processorOrder.remove(descriptor.className());
+            processorOrder.addLast(descriptor.className());
+
+            final MessageProcessorsConfig newProcessorsConfig = defaultProcessorsConfig.toBuilder()
+                    .processorOrder(processorOrder)
+                    .build();
+
+            clusterConfigService.write(newProcessorsConfig);
+
+            return;
+        }
+
+        if (processorsConfig.processorOrder().contains(descriptor.className())) {
+            LOG.debug("Message processor configuration already contains stream matcher processor. Skipping migration.");
+            return;
+        }
+
+        final LinkedList<String> newProcessorOrder = new LinkedList<>(processorsConfig.processorOrder());
+        newProcessorOrder.addLast(descriptor.className());
+
+        final MessageProcessorsConfig newProcessorsConfig = processorsConfig.toBuilder()
+                .processorOrder(newProcessorOrder)
+                .build();
+
+        clusterConfigService.write(newProcessorsConfig);
+    }
+}

--- a/graylog2-server/src/test/java/org/graylog2/messageprocessors/StreamMatcherProcessorTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/messageprocessors/StreamMatcherProcessorTest.java
@@ -1,0 +1,99 @@
+/**
+ * This file is part of Graylog.
+ *
+ * Graylog is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.graylog2.messageprocessors;
+
+import com.google.common.collect.ImmutableMap;
+import org.graylog2.plugin.Message;
+import org.graylog2.plugin.Messages;
+import org.graylog2.plugin.streams.Stream;
+import org.graylog2.streams.StreamMock;
+import org.graylog2.streams.StreamRouter;
+import org.joda.time.DateTime;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnit;
+import org.mockito.junit.MockitoRule;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+public class StreamMatcherProcessorTest {
+    @Rule
+    public final MockitoRule mockitoRule = MockitoJUnit.rule();
+
+    @Mock
+    private StreamRouter streamRouter;
+    private StreamMatcherProcessor processor;
+
+    @Before
+    public void setUp() throws Exception {
+        processor = new StreamMatcherProcessor(streamRouter);
+    }
+
+    @Test
+    public void process_adds_streams_to_messages() throws Exception {
+        final Message message = new Message("message", "source", DateTime.parse("2017-09-27T16:00:00Z"));
+        final TestMessages messages = new TestMessages(Collections.singleton(message));
+        final Stream stream = new StreamMock(
+                ImmutableMap.of(
+                        "_id", "stream-id",
+                        "title", "title",
+                        "description", "description"
+                ));
+        when(streamRouter.route(message)).thenReturn(Collections.singletonList(stream));
+
+        assertThat(message.getStreams()).isEmpty();
+
+        final Messages processedMessages = processor.process(messages);
+
+        assertThat(processedMessages).hasSameSizeAs(messages);
+
+        final Message processedMessage = processedMessages.iterator().next();
+        assertThat(processedMessage.getFields()).isEqualTo(message.getFields());
+        assertThat(processedMessage.getStreams()).containsExactly(stream);
+    }
+
+    @Test
+    public void process_does_not_add_streams_to_messages_if_none_match() throws Exception {
+        final TestMessages messages = new TestMessages(Arrays.asList(
+                new Message("message1", "source1", DateTime.parse("2017-09-27T16:00:00Z")),
+                new Message("message2", "source2", DateTime.parse("2017-09-27T16:00:01Z"))
+        ));
+
+        when(streamRouter.route(any(Message.class))).thenReturn(Collections.emptyList());
+
+        final Messages processedMessages = processor.process(messages);
+
+        assertThat(processedMessages)
+                .hasSameSizeAs(messages)
+                .isEqualTo(messages);
+    }
+
+    private static class TestMessages extends ArrayList<Message> implements Messages {
+        private TestMessages(Collection<? extends Message> c) {
+            super(c);
+        }
+    }
+}

--- a/graylog2-server/src/test/java/org/graylog2/migrations/V20170927170100_StreamMatcherFilterTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/migrations/V20170927170100_StreamMatcherFilterTest.java
@@ -1,3 +1,19 @@
+/**
+ * This file is part of Graylog.
+ *
+ * Graylog is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package org.graylog2.migrations;
 
 import org.graylog2.messageprocessors.MessageProcessorsConfig;

--- a/graylog2-server/src/test/java/org/graylog2/migrations/V20170927170100_StreamMatcherFilterTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/migrations/V20170927170100_StreamMatcherFilterTest.java
@@ -1,0 +1,91 @@
+package org.graylog2.migrations;
+
+import org.graylog2.messageprocessors.MessageProcessorsConfig;
+import org.graylog2.messageprocessors.StreamMatcherProcessor;
+import org.graylog2.plugin.cluster.ClusterConfigService;
+import org.graylog2.plugin.messageprocessors.MessageProcessor;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnit;
+import org.mockito.junit.MockitoRule;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+public class V20170927170100_StreamMatcherFilterTest {
+    @Rule
+    public final MockitoRule mockitoRule = MockitoJUnit.rule();
+
+    @Mock
+    private ClusterConfigService clusterConfigService;
+
+    private V20170927170100_StreamMatcherFilter migration;
+
+    @Before
+    public void setUp() throws Exception {
+        final Set<MessageProcessor.Descriptor> descriptors = Collections.singleton(new MessageProcessor.Descriptor() {
+            @Override
+            public String name() {
+                return "Some Message Processor";
+            }
+
+            @Override
+            public String className() {
+                return "SomeMessageProcessor";
+            }
+        });
+        migration = new V20170927170100_StreamMatcherFilter(descriptors, clusterConfigService);
+    }
+
+    @Test
+    public void upgrade_creates_new_MessageProcessorsConfig_if_none_exists() throws Exception {
+        when(clusterConfigService.get(MessageProcessorsConfig.class)).thenReturn(null);
+
+        migration.upgrade();
+
+        final ArgumentCaptor<MessageProcessorsConfig> argument = ArgumentCaptor.forClass(MessageProcessorsConfig.class);
+        verify(clusterConfigService, times(1)).write(argument.capture());
+
+        final MessageProcessorsConfig processorsConfig = argument.getValue();
+        final StreamMatcherProcessor.Descriptor StreamMatcherProcessorDescriptor = new StreamMatcherProcessor.Descriptor();
+        assertThat(processorsConfig.processorOrder()).containsExactly("SomeMessageProcessor", StreamMatcherProcessorDescriptor.className());
+    }
+
+    @Test
+    public void upgrade_modifies_MessageProcessorsConfig_if_StreamMatcherProcessor_is_missing() throws Exception {
+        final MessageProcessorsConfig config = MessageProcessorsConfig.create(Collections.singletonList("Foobar"));
+        when(clusterConfigService.get(MessageProcessorsConfig.class)).thenReturn(config);
+
+        migration.upgrade();
+
+        final ArgumentCaptor<MessageProcessorsConfig> argument = ArgumentCaptor.forClass(MessageProcessorsConfig.class);
+        verify(clusterConfigService, times(1)).write(argument.capture());
+
+        final MessageProcessorsConfig processorsConfig = argument.getValue();
+        final StreamMatcherProcessor.Descriptor StreamMatcherProcessorDescriptor = new StreamMatcherProcessor.Descriptor();
+        assertThat(processorsConfig.processorOrder()).containsExactly("Foobar", StreamMatcherProcessorDescriptor.className());
+    }
+
+    @Test
+    public void upgrade_does_nothing_if_MessageProcessorsConfig_contains_StreamMatcherProcessor() throws Exception {
+        final StreamMatcherProcessor.Descriptor streamMatcherProcessorDescriptor = new StreamMatcherProcessor.Descriptor();
+        final MessageProcessorsConfig config = MessageProcessorsConfig.create(
+                Arrays.asList("Foobar", streamMatcherProcessorDescriptor.className(), "Quux"));
+        when(clusterConfigService.get(MessageProcessorsConfig.class)).thenReturn(config);
+
+        migration.upgrade();
+
+        verify(clusterConfigService, never()).write(any(MessageProcessorsConfig.class));
+    }
+}


### PR DESCRIPTION
Instead of matching stream rules as part of the legacy message filter chain, this change set moves it into a message processor which can be independently configured and moved inside the list of message processors as the users require.

For example it wasn't possible to use the GeoIP processor for retrieving the geo location of a client and sort the message into a country-specific stream (which requires the country code) without using a pipeline rule which means running the processing pipeline last which also affects other messages (which might require a different order).

Also see:
* https://community.graylog.org/t/is-it-possible-to-make-a-stream-with-geoip-filter/2605
* https://community.graylog.org/t/stream-pipeline-and-input-extractor-clarification/5655/8