### PR TITLE
Remove navigation warnings

### DIFF
--- a/graylog2-web-interface/src/components/bootstrap/Badge.css
+++ b/graylog2-web-interface/src/components/bootstrap/Badge.css
@@ -1,0 +1,25 @@
+:local(.badgeSuccess) {
+    background-color: #8DC63F !important;
+}
+
+:local(.badgeInfo) {
+    background-color: #16ACE3 !important;
+
+}
+
+:local(.badgeWarning) {
+    background-color: #F7941E !important;
+}
+
+:local(.badgeDanger) {
+    background-color: #FF3B00 !important;
+
+}
+
+:local(.badgePrimary) {
+    background-color: #9E1F63 !important;
+}
+
+:local(.badgeDefault) {
+    background-color: #AAAAAA !important;
+}

--- a/graylog2-web-interface/src/components/navigation/InactiveNavItem.jsx
+++ b/graylog2-web-interface/src/components/navigation/InactiveNavItem.jsx
@@ -1,0 +1,24 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { NavItem } from 'react-bootstrap';
+
+// Don't pass active prop, since NavItem should always be inactive
+// eslint-disable-next-line no-unused-vars
+function InactiveNavItem({ active, children, ...props }) {
+  return <NavItem {...props}>{children}</NavItem>;
+}
+
+InactiveNavItem.propTypes = {
+  active: PropTypes.any,
+  children: PropTypes.oneOfType([
+    PropTypes.array,
+    PropTypes.element,
+    PropTypes.string,
+  ]).isRequired,
+};
+
+InactiveNavItem.defaultProps = {
+  active: undefined,
+};
+
+export default InactiveNavItem;

--- a/graylog2-web-interface/src/components/navigation/Navigation.jsx
+++ b/graylog2-web-interface/src/components/navigation/Navigation.jsx
@@ -21,6 +21,7 @@ import UserMenu from 'components/navigation/UserMenu';
 import HelpMenu from 'components/navigation/HelpMenu';
 import { IfPermitted } from 'components/common';
 import NavigationBrand from './NavigationBrand';
+import InactiveNavItem from './InactiveNavItem';
 
 const Navigation = React.createClass({
   propTypes: {
@@ -238,15 +239,9 @@ const Navigation = React.createClass({
           {notificationBadge}
 
           <Nav navbar pullRight>
-            {/* Needed to replace NavItem with `li` and `a` elements to avoid LinkContainer setting NavItem as active */}
-            {/* More information here: https://github.com/react-bootstrap/react-router-bootstrap/issues/134 */}
-            <li role="presentation" className="">
-              <LinkContainer to={Routes.SYSTEM.NODES.LIST}>
-                <a>
-                  <GlobalThroughput />
-                </a>
-              </LinkContainer>
-            </li>
+            <LinkContainer to={Routes.SYSTEM.NODES.LIST}>
+              <InactiveNavItem><GlobalThroughput /></InactiveNavItem>
+            </LinkContainer>
             <HelpMenu active={this._isActive(Routes.GETTING_STARTED)} />
             <UserMenu fullName={this.props.fullName} loginName={this.props.loginName} />
             {AppConfig.gl2DevMode() ?

--- a/graylog2-web-interface/src/components/navigation/Navigation.jsx
+++ b/graylog2-web-interface/src/components/navigation/Navigation.jsx
@@ -146,7 +146,7 @@ const Navigation = React.createClass({
           </Navbar.Brand>
           <Navbar.Toggle />
         </Navbar.Header>
-        <Navbar.Collapse eventKey={0}>
+        <Navbar.Collapse>
           <Nav navbar>
             <IfPermitted permissions={['searches:absolute', 'searches:relative', 'searches:keyword']}>
               <LinkContainer to={Routes.SEARCH}>

--- a/graylog2-web-interface/src/components/navigation/Navigation.jsx
+++ b/graylog2-web-interface/src/components/navigation/Navigation.jsx
@@ -2,7 +2,7 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import Reflux from 'reflux';
 
-import { Navbar, Nav, NavItem, NavDropdown, MenuItem } from 'react-bootstrap';
+import { Badge, Navbar, Nav, NavItem, NavDropdown, MenuItem } from 'react-bootstrap';
 import { LinkContainer } from 'react-router-bootstrap';
 import naturalSort from 'javascript-natural-sort';
 
@@ -22,6 +22,8 @@ import HelpMenu from 'components/navigation/HelpMenu';
 import { IfPermitted } from 'components/common';
 import NavigationBrand from './NavigationBrand';
 import InactiveNavItem from './InactiveNavItem';
+
+import badgeStyles from 'components/bootstrap/Badge.css';
 
 const Navigation = React.createClass({
   propTypes: {
@@ -101,12 +103,11 @@ const Navigation = React.createClass({
     if (this.state.total > 0) {
       notificationBadge = (
         <Nav navbar>
-          <NavItem className="notification-badge-link">
-            <LinkContainer to={Routes.SYSTEM.OVERVIEW}>
-              <span className="badge" style={{ backgroundColor: '#ff3b00' }}
-                    id="notification-badge">{this.state.total}</span>
-            </LinkContainer>
-          </NavItem>
+          <LinkContainer to={Routes.SYSTEM.OVERVIEW}>
+            <InactiveNavItem className="notification-badge-link">
+              <Badge className={badgeStyles.badgeDanger} id="notification-badge">{this.state.total}</Badge>
+            </InactiveNavItem>
+          </LinkContainer>
         </Nav>
       );
     }
@@ -246,7 +247,7 @@ const Navigation = React.createClass({
             <UserMenu fullName={this.props.fullName} loginName={this.props.loginName} />
             {AppConfig.gl2DevMode() ?
               <NavItem className="notification-badge-link">
-                <span className="badge" style={{ backgroundColor: '#ff3b00' }}>DEV</span>
+                <Badge className={badgeStyles.badgeDanger}>DEV</Badge>
               </NavItem>
               : null}
           </Nav>

--- a/graylog2-web-interface/src/components/navigation/Navigation.jsx
+++ b/graylog2-web-interface/src/components/navigation/Navigation.jsx
@@ -20,6 +20,7 @@ import GlobalThroughput from 'components/throughput/GlobalThroughput';
 import UserMenu from 'components/navigation/UserMenu';
 import HelpMenu from 'components/navigation/HelpMenu';
 import { IfPermitted } from 'components/common';
+import NavigationBrand from './NavigationBrand';
 
 const Navigation = React.createClass({
   propTypes: {
@@ -94,12 +95,6 @@ const Navigation = React.createClass({
   },
 
   render() {
-    const logoUrl = require('images/toplogo.png');
-    const brand = (
-      <LinkContainer to={Routes.STARTPAGE}>
-        <a><img src={logoUrl} /></a>
-      </LinkContainer>);
-
     let notificationBadge;
 
     if (this.state.total > 0) {
@@ -144,7 +139,11 @@ const Navigation = React.createClass({
     return (
       <Navbar inverse fluid fixedTop>
         <Navbar.Header>
-          <Navbar.Brand>{brand}</Navbar.Brand>
+          <Navbar.Brand>
+            <LinkContainer to={Routes.STARTPAGE}>
+              <NavigationBrand />
+            </LinkContainer>
+          </Navbar.Brand>
           <Navbar.Toggle />
         </Navbar.Header>
         <Navbar.Collapse eventKey={0}>

--- a/graylog2-web-interface/src/components/navigation/Navigation.jsx
+++ b/graylog2-web-interface/src/components/navigation/Navigation.jsx
@@ -192,24 +192,24 @@ const Navigation = React.createClass({
                 <MenuItem>Nodes</MenuItem>
               </LinkContainer>
               {this.isPermitted(this.props.permissions, ['inputs:read']) &&
-                <LinkContainer to={Routes.SYSTEM.INPUTS}>
-                  <MenuItem>Inputs</MenuItem>
-                </LinkContainer>
+              <LinkContainer to={Routes.SYSTEM.INPUTS}>
+                <MenuItem>Inputs</MenuItem>
+              </LinkContainer>
               }
               {this.isPermitted(this.props.permissions, ['outputs:read']) &&
-                <LinkContainer to={Routes.SYSTEM.OUTPUTS}>
-                  <MenuItem>Outputs</MenuItem>
-                </LinkContainer>
+              <LinkContainer to={Routes.SYSTEM.OUTPUTS}>
+                <MenuItem>Outputs</MenuItem>
+              </LinkContainer>
               }
               {this.isPermitted(this.props.permissions, ['indices:read']) &&
-                <LinkContainer to={Routes.SYSTEM.INDICES.LIST}>
-                  <MenuItem>Indices</MenuItem>
-                </LinkContainer>
+              <LinkContainer to={Routes.SYSTEM.INDICES.LIST}>
+                <MenuItem>Indices</MenuItem>
+              </LinkContainer>
               }
               {this.isPermitted(this.props.permissions, ['loggers:read']) &&
-                <LinkContainer to={Routes.SYSTEM.LOGGING}>
-                  <MenuItem>Logging</MenuItem>
-                </LinkContainer>
+              <LinkContainer to={Routes.SYSTEM.LOGGING}>
+                <MenuItem>Logging</MenuItem>
+              </LinkContainer>
               }
               {this.isAnyPermitted(this.props.permissions, ['users:list, roles:read']) &&
               <LinkContainer to={Routes.SYSTEM.AUTHENTICATION.OVERVIEW}>
@@ -222,14 +222,14 @@ const Navigation = React.createClass({
               </LinkContainer>
               }
               {this.isPermitted(this.props.permissions, ['inputs:edit']) &&
-               <LinkContainer to={Routes.SYSTEM.GROKPATTERNS}>
-                 <MenuItem>Grok Patterns</MenuItem>
-               </LinkContainer>
+              <LinkContainer to={Routes.SYSTEM.GROKPATTERNS}>
+                <MenuItem>Grok Patterns</MenuItem>
+              </LinkContainer>
               }
               {this.isPermitted(this.props.permissions, ['inputs:edit']) &&
-                <LinkContainer to={Routes.SYSTEM.LOOKUPTABLES.OVERVIEW}>
+              <LinkContainer to={Routes.SYSTEM.LOOKUPTABLES.OVERVIEW}>
                 <MenuItem>Lookup Tables</MenuItem>
-                </LinkContainer>
+              </LinkContainer>
               }
               {pluginSystemNavigations}
             </NavDropdown>

--- a/graylog2-web-interface/src/components/navigation/NavigationBrand.jsx
+++ b/graylog2-web-interface/src/components/navigation/NavigationBrand.jsx
@@ -1,0 +1,20 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+const logoUrl = require('images/toplogo.png');
+
+// Don't pass active prop, since `a` tag doesn't support it.
+// eslint-disable-next-line no-unused-vars
+function BrandComponent({ active, ...props }) {
+  return <a {...props}><img src={logoUrl} alt="Graylog logo" /></a>;
+}
+
+BrandComponent.propTypes = {
+  active: PropTypes.bool,
+};
+
+BrandComponent.defaultProps = {
+  active: false,
+};
+
+export default BrandComponent;


### PR DESCRIPTION
Since the update to React 15, our navigation was triggering a few `react-unknown-prop` warnings, polluting the web console during development with some stacktraces.

This PR tackles the underlying problems, making the development experience slightly less annoying. There are still some warnings, mostly from react-router, but those will be fixed with a future update.

This PR should be applied both to master and 2.4.