### PR TITLE
Close response body in HTTPFileRetriever if request was unsuccessful. (2.4)

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/lookup/adapters/dsvhttp/HTTPFileRetriever.java
+++ b/graylog2-server/src/main/java/org/graylog2/lookup/adapters/dsvhttp/HTTPFileRetriever.java
@@ -69,6 +69,9 @@ public class HTTPFileRetriever {
             }
         } else {
             if (response.code() != 304) {
+                if (response.body() != null) {
+                    response.close();
+                }
                 throw new IOException("Request failed: " + response.message());
             }
         }

--- a/graylog2-server/src/main/java/org/graylog2/lookup/adapters/dsvhttp/HTTPFileRetriever.java
+++ b/graylog2-server/src/main/java/org/graylog2/lookup/adapters/dsvhttp/HTTPFileRetriever.java
@@ -55,24 +55,21 @@ public class HTTPFileRetriever {
         }
         final Call request = client.newCall(requestBuilder.build());
 
-        final Response response = request.execute();
+        try (final Response response = request.execute()) {
+            if (response.isSuccessful()) {
+                final String lastModifiedHeader = response.header("Last-Modified", DateTime.now(DateTimeZone.UTC).toString());
+                final Map<String, String> newLastModified = new HashMap<>(this.lastLastModified.get());
+                newLastModified.put(url, lastModifiedHeader);
+                this.lastLastModified.set(ImmutableMap.copyOf(newLastModified));
 
-        if (response.isSuccessful()) {
-            final String lastModifiedHeader = response.header("Last-Modified", DateTime.now(DateTimeZone.UTC).toString());
-            final Map<String, String> newLastModified = new HashMap<>(this.lastLastModified.get());
-            newLastModified.put(url, lastModifiedHeader);
-            this.lastLastModified.set(ImmutableMap.copyOf(newLastModified));
-
-            if (response.body() != null) {
-                final String body = response.body().string();
-                return body == null ? Optional.empty() : Optional.of(body);
-            }
-        } else {
-            if (response.code() != 304) {
                 if (response.body() != null) {
-                    response.close();
+                    final String body = response.body().string();
+                    return Optional.ofNullable(body);
                 }
-                throw new IOException("Request failed: " + response.message());
+            } else {
+                if (response.code() != 304) {
+                    throw new IOException("Request failed: " + response.message());
+                }
             }
         }
 


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
When a request was not successful but has a body, its response body was
not closed. This change checks if the response has a response body in
case it was unsuccessful and closes the response body before throwing an
exception.

Refs Graylog2/graylog-plugin-threatintel#59.

<!--- Provide a general summary of your changes in the Title above -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
