### PR TITLE
Add Jest as ESlint env

### DIFF
--- a/graylog2-web-interface/.eslintrc.json
+++ b/graylog2-web-interface/.eslintrc.json
@@ -14,7 +14,8 @@
     "import/no-extraneous-dependencies": 0
   },
   "env": {
-    "browser": true
+    "browser": true,
+    "jest": true
   }
 }
 


### PR DESCRIPTION
This removes ESlint errors when handling Jest globals, like describe.