### PR TITLE
Waiting for data adapter/cache creation in bundle importer.

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/bindings/providers/BundleImporterProvider.java
+++ b/graylog2-server/src/main/java/org/graylog2/bindings/providers/BundleImporterProvider.java
@@ -26,6 +26,7 @@ import org.graylog2.indexer.IndexSetRegistry;
 import org.graylog2.inputs.InputService;
 import org.graylog2.inputs.converters.ConverterFactory;
 import org.graylog2.inputs.extractors.ExtractorFactory;
+import org.graylog2.lookup.LookupTableService;
 import org.graylog2.lookup.db.DBCacheService;
 import org.graylog2.lookup.db.DBDataAdapterService;
 import org.graylog2.lookup.db.DBLookupTableService;
@@ -39,7 +40,9 @@ import org.graylog2.streams.StreamService;
 import org.graylog2.timeranges.TimeRangeFactory;
 
 import javax.inject.Inject;
+import javax.inject.Named;
 import javax.inject.Provider;
+import java.util.concurrent.ScheduledExecutorService;
 
 public class BundleImporterProvider implements Provider<BundleImporter> {
 
@@ -60,9 +63,11 @@ public class BundleImporterProvider implements Provider<BundleImporter> {
     private final DBLookupTableService dbLookupTableService;
     private final DBCacheService dbCacheService;
     private final DBDataAdapterService dbDataAdapterService;
+    private final LookupTableService lookupTableService;
     private final TimeRangeFactory timeRangeFactory;
     private final ClusterEventBus clusterBus;
     private final ObjectMapper objectMapper;
+    private final ScheduledExecutorService scheduler;
 
     @Inject
     public BundleImporterProvider(final InputService inputService,
@@ -82,9 +87,11 @@ public class BundleImporterProvider implements Provider<BundleImporter> {
                                   final DBLookupTableService dbLookupTableService,
                                   final DBCacheService dbCacheService,
                                   final DBDataAdapterService dbDataAdapterService,
+                                  final LookupTableService lookupTableService,
                                   final TimeRangeFactory timeRangeFactory,
                                   final ClusterEventBus clusterBus,
-                                  final ObjectMapper objectMapper) {
+                                  final ObjectMapper objectMapper,
+                                  @Named("daemonScheduler") ScheduledExecutorService scheduler) {
         this.inputService = inputService;
         this.inputRegistry = inputRegistry;
         this.extractorFactory = extractorFactory;
@@ -102,9 +109,11 @@ public class BundleImporterProvider implements Provider<BundleImporter> {
         this.dbLookupTableService = dbLookupTableService;
         this.dbCacheService = dbCacheService;
         this.dbDataAdapterService = dbDataAdapterService;
+        this.lookupTableService = lookupTableService;
         this.timeRangeFactory = timeRangeFactory;
         this.clusterBus = clusterBus;
         this.objectMapper = objectMapper;
+        this.scheduler = scheduler;
     }
 
     @Override
@@ -113,7 +122,7 @@ public class BundleImporterProvider implements Provider<BundleImporter> {
                 streamService, streamRuleService, indexSetRegistry, outputService, dashboardService,
                 dashboardWidgetCreator, serverStatus, messageInputFactory,
                 inputLauncher, grokPatternService,
-                dbLookupTableService, dbCacheService, dbDataAdapterService,
-                timeRangeFactory, clusterBus, objectMapper);
+                dbLookupTableService, dbCacheService, dbDataAdapterService, lookupTableService,
+                timeRangeFactory, clusterBus, objectMapper, scheduler);
     }
 }

--- a/graylog2-server/src/main/java/org/graylog2/bundles/BundleImporter.java
+++ b/graylog2-server/src/main/java/org/graylog2/bundles/BundleImporter.java
@@ -738,9 +738,11 @@ public class BundleImporter {
         caches.forEach(c -> c.addListener(new LatchUpdaterListener(latch), scheduler));
 
         try {
-            latch.await(30, TimeUnit.SECONDS);
+            if (!latch.await(30, TimeUnit.SECONDS)) {
+                LOG.warn("Starting imported Lookup Table Caches did not finish within 30 seconds. A server restart might be required for imported Lookup Tables to function.");
+            }
         } catch (InterruptedException e) {
-            LOG.warn("Starting imported Lookup Table Caches did not finish within 30 seconds. A server restart might be required for imported Lookup Tables to function.");
+            LOG.warn("Starting imported Lookup Table Caches did not finish properly. A server restart might be required for imported Lookup Tables to function: ", e);
         }
     }
 
@@ -765,9 +767,11 @@ public class BundleImporter {
         dataAdapters.forEach(da -> da.addListener(new LatchUpdaterListener(latch), scheduler));
 
         try {
-            latch.await(30, TimeUnit.SECONDS);
+            if (!latch.await(30, TimeUnit.SECONDS)) {
+                LOG.warn("Starting imported Lookup Table Data Adapters did not finish within 30 seconds. A server restart might be required for imported Lookup Tables to function.");
+            }
         } catch (InterruptedException e) {
-            LOG.warn("Starting imported Lookup Table Data Adapters did not finish within 30 seconds. A server restart might be required for imported Lookup Tables to function.");
+            LOG.warn("Starting imported Lookup Table Data Adapters did not finish properly. A server restart might be required for imported Lookup Tables to function: ", e);
         }
     }
 }

--- a/graylog2-server/src/main/java/org/graylog2/bundles/BundleImporter.java
+++ b/graylog2-server/src/main/java/org/graylog2/bundles/BundleImporter.java
@@ -713,7 +713,9 @@ public class BundleImporter {
             createdLookupTables.put(dto.id(), dto);
         }
 
-        clusterBus.post(LookupTablesUpdated.create(createdLookupTables.values()));
+        if (!createdLookupDataAdapters.isEmpty()) {
+            clusterBus.post(LookupTablesUpdated.create(createdLookupTables.values()));
+        }
     }
 
     private void createLookupCaches(String bundleId, Set<LookupCacheBundle> lookupCaches) throws InterruptedException {
@@ -728,15 +730,15 @@ public class BundleImporter {
             createdLookupCaches.put(dto.id(), dto);
         }
 
+        if (!createdLookupCaches.isEmpty()) {
+            clusterBus.post(CachesUpdated.create(createdLookupCaches.keySet()));
+        }
+
         final Collection<LookupCache> caches = lookupTableService.getCaches(createdLookupCaches.keySet());
         final CountDownLatch latch = new CountDownLatch(caches.size());
         caches.forEach(c -> c.addListener(new LatchUpdaterListener(latch), scheduler));
 
         latch.await(30, TimeUnit.SECONDS);
-
-        if (!createdLookupCaches.isEmpty()) {
-            clusterBus.post(CachesUpdated.create(createdLookupCaches.keySet()));
-        }
     }
 
     private void createLookupDataAdapters(String bundleId, Set<LookupDataAdapterBundle> lookupDataAdapters) throws InterruptedException {
@@ -751,14 +753,14 @@ public class BundleImporter {
             createdLookupDataAdapters.put(dto.id(), dto);
         }
 
+        if (!createdLookupDataAdapters.isEmpty()) {
+            clusterBus.post(DataAdaptersUpdated.create(createdLookupDataAdapters.keySet()));
+        }
+
         final Collection<LookupDataAdapter> dataAdapters = lookupTableService.getDataAdapters(createdLookupDataAdapters.keySet());
         final CountDownLatch latch = new CountDownLatch(dataAdapters.size());
         dataAdapters.forEach(da -> da.addListener(new LatchUpdaterListener(latch), scheduler));
 
         latch.await(30, TimeUnit.SECONDS);
-
-        if (!createdLookupDataAdapters.isEmpty()) {
-            clusterBus.post(DataAdaptersUpdated.create(createdLookupDataAdapters.keySet()));
-        }
     }
 }


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Before this change, lookup data adapters, caches and tables were created
sequentially during content pack import, leading to errors when lookup
tables were created before caches or data adapters were successfully
created and started. Imported lookup tables were usable only after the
server was restarted at least once after a content pack import.

After this change, the bundle importer waits for the successful creation
of data adapters/caches before creating lookup tables.

Fixes Graylog2/graylog-plugin-threatintel#57.

<!--- Provide a general summary of your changes in the Title above -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
