### PR TITLE
Fix highligh results checkbox size

### DIFF
--- a/graylog2-web-interface/public/stylesheets/graylog2.less
+++ b/graylog2-web-interface/public/stylesheets/graylog2.less
@@ -1591,12 +1591,9 @@ input.required-input-highlight {
 }
 
 .result-highlight-control label {
-  font-size: 12px;
   display: inline-block;
-}
-
-.result-highlight-control label > * {
-  vertical-align: middle;
+  font-size: 1em;
+  line-height: 20px;
 }
 
 .node-state {

--- a/graylog2-web-interface/src/components/search/FieldAnalyzersSidebar.jsx
+++ b/graylog2-web-interface/src/components/search/FieldAnalyzersSidebar.jsx
@@ -136,7 +136,7 @@ const FieldAnalyzersSidebar = React.createClass({
       shouldHighlightToggle = (
         <Input ref="highlightToggle" type="checkbox" bsSize="small" checked={this.props.shouldHighlight}
                onChange={this.props.toggleShouldHighlight} label="Highlight results"
-               groupClassName="result-highlight-control" />
+               wrapperClassName="result-highlight-control" />
       );
     }
 


### PR DESCRIPTION
I just realised the "Highlight results" was looking too big and I saw that we missed to migrate one of the prop names on #3598. Here is a small fix for it, including an improved CSS so the checkbox looks aligned with the text.

Before:
<img width="416" alt="before" src="https://user-images.githubusercontent.com/716185/31073649-217b0f60-a76d-11e7-8ce9-433bb900d7da.png">

After:
<img width="416" alt="after" src="https://user-images.githubusercontent.com/716185/31073651-2303b3f0-a76d-11e7-8bfa-2166a05b4ab1.png">