### PR TITLE
Waiting for data adapter/cache creation in bundle importer

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/bindings/providers/BundleImporterProvider.java
+++ b/graylog2-server/src/main/java/org/graylog2/bindings/providers/BundleImporterProvider.java
@@ -26,6 +26,7 @@ import org.graylog2.indexer.IndexSetRegistry;
 import org.graylog2.inputs.InputService;
 import org.graylog2.inputs.converters.ConverterFactory;
 import org.graylog2.inputs.extractors.ExtractorFactory;
+import org.graylog2.lookup.LookupTableService;
 import org.graylog2.lookup.db.DBCacheService;
 import org.graylog2.lookup.db.DBDataAdapterService;
 import org.graylog2.lookup.db.DBLookupTableService;
@@ -39,7 +40,9 @@ import org.graylog2.streams.StreamService;
 import org.graylog2.timeranges.TimeRangeFactory;
 
 import javax.inject.Inject;
+import javax.inject.Named;
 import javax.inject.Provider;
+import java.util.concurrent.ScheduledExecutorService;
 
 public class BundleImporterProvider implements Provider<BundleImporter> {
 
@@ -60,9 +63,11 @@ public class BundleImporterProvider implements Provider<BundleImporter> {
     private final DBLookupTableService dbLookupTableService;
     private final DBCacheService dbCacheService;
     private final DBDataAdapterService dbDataAdapterService;
+    private final LookupTableService lookupTableService;
     private final TimeRangeFactory timeRangeFactory;
     private final ClusterEventBus clusterBus;
     private final ObjectMapper objectMapper;
+    private final ScheduledExecutorService scheduler;
 
     @Inject
     public BundleImporterProvider(final InputService inputService,
@@ -82,9 +87,11 @@ public class BundleImporterProvider implements Provider<BundleImporter> {
                                   final DBLookupTableService dbLookupTableService,
                                   final DBCacheService dbCacheService,
                                   final DBDataAdapterService dbDataAdapterService,
+                                  final LookupTableService lookupTableService,
                                   final TimeRangeFactory timeRangeFactory,
                                   final ClusterEventBus clusterBus,
-                                  final ObjectMapper objectMapper) {
+                                  final ObjectMapper objectMapper,
+                                  @Named("daemonScheduler") ScheduledExecutorService scheduler) {
         this.inputService = inputService;
         this.inputRegistry = inputRegistry;
         this.extractorFactory = extractorFactory;
@@ -102,9 +109,11 @@ public class BundleImporterProvider implements Provider<BundleImporter> {
         this.dbLookupTableService = dbLookupTableService;
         this.dbCacheService = dbCacheService;
         this.dbDataAdapterService = dbDataAdapterService;
+        this.lookupTableService = lookupTableService;
         this.timeRangeFactory = timeRangeFactory;
         this.clusterBus = clusterBus;
         this.objectMapper = objectMapper;
+        this.scheduler = scheduler;
     }
 
     @Override
@@ -113,7 +122,7 @@ public class BundleImporterProvider implements Provider<BundleImporter> {
                 streamService, streamRuleService, indexSetRegistry, outputService, dashboardService,
                 dashboardWidgetCreator, serverStatus, messageInputFactory,
                 inputLauncher, grokPatternService,
-                dbLookupTableService, dbCacheService, dbDataAdapterService,
-                timeRangeFactory, clusterBus, objectMapper);
+                dbLookupTableService, dbCacheService, dbDataAdapterService, lookupTableService,
+                timeRangeFactory, clusterBus, objectMapper, scheduler);
     }
 }

--- a/graylog2-server/src/main/java/org/graylog2/bundles/BundleImporter.java
+++ b/graylog2-server/src/main/java/org/graylog2/bundles/BundleImporter.java
@@ -17,7 +17,6 @@
 package org.graylog2.bundles;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.google.common.base.Throwables;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
@@ -35,12 +34,15 @@ import org.graylog2.indexer.IndexSetRegistry;
 import org.graylog2.inputs.InputService;
 import org.graylog2.inputs.converters.ConverterFactory;
 import org.graylog2.inputs.extractors.ExtractorFactory;
+import org.graylog2.lookup.LookupTableService;
 import org.graylog2.lookup.db.DBCacheService;
 import org.graylog2.lookup.db.DBDataAdapterService;
 import org.graylog2.lookup.db.DBLookupTableService;
 import org.graylog2.lookup.dto.CacheDto;
 import org.graylog2.lookup.dto.DataAdapterDto;
 import org.graylog2.lookup.dto.LookupTableDto;
+import org.graylog2.lookup.events.CachesUpdated;
+import org.graylog2.lookup.events.DataAdaptersUpdated;
 import org.graylog2.lookup.events.LookupTablesDeleted;
 import org.graylog2.lookup.events.LookupTablesUpdated;
 import org.graylog2.plugin.Message;
@@ -52,7 +54,9 @@ import org.graylog2.plugin.database.ValidationException;
 import org.graylog2.plugin.indexer.searches.timeranges.InvalidRangeParametersException;
 import org.graylog2.plugin.indexer.searches.timeranges.TimeRange;
 import org.graylog2.plugin.inputs.MessageInput;
+import org.graylog2.plugin.lookup.LookupCache;
 import org.graylog2.plugin.lookup.LookupCacheConfiguration;
+import org.graylog2.plugin.lookup.LookupDataAdapter;
 import org.graylog2.plugin.lookup.LookupDataAdapterConfiguration;
 import org.graylog2.rest.models.dashboards.requests.WidgetPositionsRequest;
 import org.graylog2.shared.inputs.InputLauncher;
@@ -67,11 +71,14 @@ import org.graylog2.streams.StreamRuleService;
 import org.graylog2.streams.StreamService;
 import org.graylog2.streams.events.StreamsChangedEvent;
 import org.graylog2.timeranges.TimeRangeFactory;
+import org.graylog2.utilities.LatchUpdaterListener;
 import org.joda.time.DateTime;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import javax.inject.Inject;
+import javax.inject.Named;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
@@ -79,6 +86,9 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
 
 import static com.google.common.base.Strings.isNullOrEmpty;
 import static org.graylog2.plugin.inputs.Extractor.Type.GROK;
@@ -104,9 +114,11 @@ public class BundleImporter {
     private final DBLookupTableService dbLookupTableService;
     private final DBCacheService dbCacheService;
     private final DBDataAdapterService dbDataAdapterService;
+    private final LookupTableService lookupTableService;
     private final TimeRangeFactory timeRangeFactory;
     private final ClusterEventBus clusterBus;
     private final ObjectMapper objectMapper;
+    private final ScheduledExecutorService scheduler;
 
     private final Map<String, org.graylog2.grok.GrokPattern> createdGrokPatterns = new HashMap<>();
     private final Map<String, MessageInput> createdInputs = new HashMap<>();
@@ -119,6 +131,7 @@ public class BundleImporter {
     private final Map<String, org.graylog2.plugin.streams.Output> outputsByReferenceId = new HashMap<>();
     private final Map<String, org.graylog2.plugin.streams.Stream> streamsByReferenceId = new HashMap<>();
 
+    // TODO: This class has become HUGE, it should be split into smaller classes.
     @Inject
     public BundleImporter(final InputService inputService,
                           final InputRegistry inputRegistry,
@@ -137,9 +150,11 @@ public class BundleImporter {
                           final DBLookupTableService dbLookupTableService,
                           final DBCacheService dbCacheService,
                           final DBDataAdapterService dbDataAdapterService,
+                          final LookupTableService lookupTableService,
                           final TimeRangeFactory timeRangeFactory,
                           final ClusterEventBus clusterBus,
-                          final ObjectMapper objectMapper) {
+                          final ObjectMapper objectMapper,
+                          @Named("daemonScheduler") ScheduledExecutorService scheduler) {
         this.inputService = inputService;
         this.inputRegistry = inputRegistry;
         this.extractorFactory = extractorFactory;
@@ -157,9 +172,11 @@ public class BundleImporter {
         this.dbLookupTableService = dbLookupTableService;
         this.dbCacheService = dbCacheService;
         this.dbDataAdapterService = dbDataAdapterService;
+        this.lookupTableService = lookupTableService;
         this.timeRangeFactory = timeRangeFactory;
         this.clusterBus = clusterBus;
         this.objectMapper = objectMapper;
+        this.scheduler = scheduler;
     }
 
     public void runImport(final ConfigurationBundle bundle, final String userName) {
@@ -180,7 +197,7 @@ public class BundleImporter {
             if (!rollback()) {
                 LOG.error("Rollback unsuccessful.");
             }
-            Throwables.propagate(e);
+            throw new RuntimeException(e);
         }
     }
 
@@ -695,7 +712,9 @@ public class BundleImporter {
             createdLookupTables.put(dto.id(), dto);
         }
 
-        clusterBus.post(LookupTablesUpdated.create(createdLookupTables.values()));
+        if (!createdLookupDataAdapters.isEmpty()) {
+            clusterBus.post(LookupTablesUpdated.create(createdLookupTables.values()));
+        }
     }
 
     private void createLookupCaches(String bundleId, Set<LookupCacheBundle> lookupCaches) {
@@ -709,6 +728,22 @@ public class BundleImporter {
                     .build());
             createdLookupCaches.put(dto.id(), dto);
         }
+
+        if (!createdLookupCaches.isEmpty()) {
+            clusterBus.post(CachesUpdated.create(createdLookupCaches.keySet()));
+        }
+
+        final Collection<LookupCache> caches = lookupTableService.getCaches(createdLookupCaches.keySet());
+        final CountDownLatch latch = new CountDownLatch(caches.size());
+        caches.forEach(c -> c.addListener(new LatchUpdaterListener(latch), scheduler));
+
+        try {
+            if (!latch.await(30, TimeUnit.SECONDS)) {
+                LOG.warn("Starting imported Lookup Table Caches did not finish within 30 seconds. A server restart might be required for imported Lookup Tables to function.");
+            }
+        } catch (InterruptedException e) {
+            LOG.warn("Starting imported Lookup Table Caches did not finish properly. A server restart might be required for imported Lookup Tables to function: ", e);
+        }
     }
 
     private void createLookupDataAdapters(String bundleId, Set<LookupDataAdapterBundle> lookupDataAdapters) {
@@ -721,6 +756,22 @@ public class BundleImporter {
                     .config(objectMapper.convertValue(bundle.getConfig(), LookupDataAdapterConfiguration.class))
                     .build());
             createdLookupDataAdapters.put(dto.id(), dto);
+        }
+
+        if (!createdLookupDataAdapters.isEmpty()) {
+            clusterBus.post(DataAdaptersUpdated.create(createdLookupDataAdapters.keySet()));
+        }
+
+        final Collection<LookupDataAdapter> dataAdapters = lookupTableService.getDataAdapters(createdLookupDataAdapters.keySet());
+        final CountDownLatch latch = new CountDownLatch(dataAdapters.size());
+        dataAdapters.forEach(da -> da.addListener(new LatchUpdaterListener(latch), scheduler));
+
+        try {
+            if (!latch.await(30, TimeUnit.SECONDS)) {
+                LOG.warn("Starting imported Lookup Table Data Adapters did not finish within 30 seconds. A server restart might be required for imported Lookup Tables to function.");
+            }
+        } catch (InterruptedException e) {
+            LOG.warn("Starting imported Lookup Table Data Adapters did not finish properly. A server restart might be required for imported Lookup Tables to function: ", e);
         }
     }
 }


### PR DESCRIPTION
Before this change, lookup data adapters, caches and tables were created
sequentially during content pack import, leading to errors when lookup
tables were created before caches or data adapters were successfully
created and started. Imported lookup tables were usable only after the
server was restarted at least once after a content pack import.

After this change, the bundle importer waits for the successful creation
of data adapters/caches before creating lookup tables.

Fixes Graylog2/graylog-plugin-threatintel#57
Refs #4197
(cherry picked from commit 3493509ffb69ef46604e8d72a3480e21758f7b68)