### PR TITLE
Add noop rotation strategy

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/indexer/rotation/RotationStrategyBindings.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/rotation/RotationStrategyBindings.java
@@ -14,10 +14,10 @@
  * You should have received a copy of the GNU General Public License
  * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
  */
-
 package org.graylog2.indexer.rotation;
 
 import org.graylog2.indexer.rotation.strategies.MessageCountRotationStrategy;
+import org.graylog2.indexer.rotation.strategies.NoopRotationStrategy;
 import org.graylog2.indexer.rotation.strategies.SizeBasedRotationStrategy;
 import org.graylog2.indexer.rotation.strategies.TimeBasedRotationStrategy;
 import org.graylog2.plugin.PluginModule;
@@ -28,6 +28,6 @@ public class RotationStrategyBindings extends PluginModule {
         addRotationStrategy(MessageCountRotationStrategy.class);
         addRotationStrategy(SizeBasedRotationStrategy.class);
         addRotationStrategy(TimeBasedRotationStrategy.class);
+        addRotationStrategy(NoopRotationStrategy.class);
     }
-
 }

--- a/graylog2-server/src/main/java/org/graylog2/indexer/rotation/strategies/NoopRotationStrategy.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/rotation/strategies/NoopRotationStrategy.java
@@ -1,0 +1,38 @@
+/**
+ * This file is part of Graylog.
+ *
+ * Graylog is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.graylog2.indexer.rotation.strategies;
+
+import org.graylog2.indexer.IndexSet;
+import org.graylog2.plugin.indexer.rotation.RotationStrategy;
+import org.graylog2.plugin.indexer.rotation.RotationStrategyConfig;
+
+public class NoopRotationStrategy implements RotationStrategy {
+    @Override
+    public void rotate(IndexSet indexSet) {
+        // noop
+    }
+
+    @Override
+    public Class<? extends RotationStrategyConfig> configurationClass() {
+        return NoopRotationStrategyConfig.class;
+    }
+
+    @Override
+    public RotationStrategyConfig defaultConfiguration() {
+        return NoopRotationStrategyConfig.createDefault();
+    }
+}

--- a/graylog2-server/src/main/java/org/graylog2/indexer/rotation/strategies/NoopRotationStrategyConfig.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/rotation/strategies/NoopRotationStrategyConfig.java
@@ -1,0 +1,36 @@
+/**
+ * This file is part of Graylog.
+ *
+ * Graylog is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.graylog2.indexer.rotation.strategies;
+
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.auto.value.AutoValue;
+import org.graylog2.plugin.indexer.rotation.RotationStrategyConfig;
+
+@JsonAutoDetect
+@AutoValue
+public abstract class NoopRotationStrategyConfig implements RotationStrategyConfig {
+    @JsonCreator
+    public static NoopRotationStrategyConfig create(@JsonProperty(TYPE_FIELD) String type) {
+        return new AutoValue_NoopRotationStrategyConfig(type);
+    }
+
+    public static NoopRotationStrategyConfig createDefault() {
+        return create(NoopRotationStrategyConfig.class.getCanonicalName());
+    }
+}

--- a/graylog2-server/src/test/java/org/graylog2/indexer/rotation/strategies/NoopRotationStrategyConfigTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/indexer/rotation/strategies/NoopRotationStrategyConfigTest.java
@@ -1,0 +1,57 @@
+/**
+ * This file is part of Graylog.
+ *
+ * Graylog is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.graylog2.indexer.rotation.strategies;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.jayway.jsonpath.Configuration;
+import com.jayway.jsonpath.JsonPath;
+import org.graylog2.plugin.indexer.rotation.RotationStrategyConfig;
+import org.graylog2.shared.bindings.providers.ObjectMapperProvider;
+import org.junit.Test;
+
+import java.io.IOException;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class NoopRotationStrategyConfigTest {
+    @Test
+    public void testCreate() throws Exception {
+        final NoopRotationStrategyConfig config = NoopRotationStrategyConfig.createDefault();
+        assertThat(config.type()).isEqualTo(NoopRotationStrategyConfig.class.getCanonicalName());
+    }
+
+    @Test
+    public void testSerialization() throws JsonProcessingException {
+        final RotationStrategyConfig config = NoopRotationStrategyConfig.createDefault();
+        final ObjectMapper objectMapper = new ObjectMapperProvider().get();
+        final String json = objectMapper.writeValueAsString(config);
+
+        final Object document = Configuration.defaultConfiguration().jsonProvider().parse(json);
+        assertThat((String) JsonPath.read(document, "$.type")).isEqualTo("org.graylog2.indexer.rotation.strategies.NoopRotationStrategyConfig");
+    }
+
+    @Test
+    public void testDeserialization() throws IOException {
+        final ObjectMapper objectMapper = new ObjectMapperProvider().get();
+        final String json = "{ \"type\": \"org.graylog2.indexer.rotation.strategies.NoopRotationStrategyConfig\" }";
+        final RotationStrategyConfig config = objectMapper.readValue(json, RotationStrategyConfig.class);
+
+        assertThat(config).isInstanceOf(NoopRotationStrategyConfig.class);
+        assertThat(config.type()).isEqualTo(NoopRotationStrategyConfig.class.getCanonicalName());
+    }
+}

--- a/graylog2-server/src/test/java/org/graylog2/indexer/rotation/strategies/NoopRotationStrategyTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/indexer/rotation/strategies/NoopRotationStrategyTest.java
@@ -1,0 +1,35 @@
+/**
+ * This file is part of Graylog.
+ *
+ * Graylog is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.graylog2.indexer.rotation.strategies;
+
+import org.graylog2.indexer.IndexSet;
+import org.junit.Test;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+public class NoopRotationStrategyTest {
+    @Test
+    public void testRotate() throws Exception {
+        final NoopRotationStrategy strategy = new NoopRotationStrategy();
+        final IndexSet indexSet = mock(IndexSet.class);
+
+        strategy.rotate(indexSet);
+        verify(indexSet, never()).cycle();
+    }
+}

--- a/graylog2-web-interface/src/components/indices/rotation/NoopRotationStrategyConfiguration.jsx
+++ b/graylog2-web-interface/src/components/indices/rotation/NoopRotationStrategyConfiguration.jsx
@@ -1,0 +1,21 @@
+import PropTypes from 'prop-types';
+import React from 'react';
+import { Input } from 'components/bootstrap';
+
+const NoopRotationStrategyConfiguration = React.createClass({
+  propTypes: {
+    config: PropTypes.object.isRequired,
+    jsonSchema: PropTypes.object.isRequired,
+    updateConfig: PropTypes.func.isRequired,
+  },
+
+  getInitialState() {
+    return {
+    };
+  },
+
+  render() {
+  },
+});
+
+export default NoopRotationStrategyConfiguration;

--- a/graylog2-web-interface/src/components/indices/rotation/NoopRotationStrategySummary.jsx
+++ b/graylog2-web-interface/src/components/indices/rotation/NoopRotationStrategySummary.jsx
@@ -1,0 +1,13 @@
+import PropTypes from 'prop-types';
+import React from 'react';
+
+const NoopRotationStrategySummary = React.createClass({
+  propTypes: {
+    config: PropTypes.object.isRequired,
+  },
+
+  render() {
+  },
+});
+
+export default NoopRotationStrategySummary;

--- a/graylog2-web-interface/src/components/indices/rotation/index.js
+++ b/graylog2-web-interface/src/components/indices/rotation/index.js
@@ -2,6 +2,8 @@ import { PluginManifest, PluginStore } from 'graylog-web-plugin/plugin';
 
 import MessageCountRotationStrategyConfiguration from './MessageCountRotationStrategyConfiguration';
 import MessageCountRotationStrategySummary from './MessageCountRotationStrategySummary';
+import NoopRotationStrategyConfiguration from './NoopRotationStrategyConfiguration';
+import NoopRotationStrategySummary from './NoopRotationStrategySummary';
 import SizeBasedRotationStrategyConfiguration from './SizeBasedRotationStrategyConfiguration';
 import SizeBasedRotationStrategySummary from './SizeBasedRotationStrategySummary';
 import TimeBasedRotationStrategyConfiguration from './TimeBasedRotationStrategyConfiguration';
@@ -26,6 +28,12 @@ PluginStore.register(new PluginManifest({}, {
       displayName: 'Index Time',
       configComponent: TimeBasedRotationStrategyConfiguration,
       summaryComponent: TimeBasedRotationStrategySummary,
+    },
+    {
+      type: 'org.graylog2.indexer.rotation.strategies.NoopRotationStrategy',
+      displayName: 'Do nothing',
+      configComponent: NoopRotationStrategyConfiguration,
+      summaryComponent: NoopRotationStrategySummary,
     },
   ],
 }));


### PR DESCRIPTION
Users might want to control the rotation of indices externally (i. e. with programs such as [Curator](https://www.elastic.co/guide/en/elasticsearch/client/curator/5.1/index.html)) instead of relying on Graylog's built-in rotation strategies.

This change set adds a noop rotation strategy which simply does nothing.