### PR TITLE
Correctly initialize the "pageSize" prop in MessageTablePaginator

### DIFF
--- a/graylog2-web-interface/src/components/search/MessageTablePaginator.jsx
+++ b/graylog2-web-interface/src/components/search/MessageTablePaginator.jsx
@@ -19,16 +19,21 @@ const MessageTablePaginator = React.createClass({
     children: PropTypes.oneOfType([
       PropTypes.arrayOf(PropTypes.element),
       PropTypes.element,
-    ]).isRequired,
+    ]),
     onPageChange: PropTypes.func.isRequired,
     pageSize: PropTypes.number,
     position: PropTypes.string,
   },
 
+  getDefaultProps() {
+    return {
+      pageSize: UniversalSearchStore.DEFAULT_LIMIT,
+    };
+  },
+
   getInitialState() {
     return {
       paginationWidth: 0,
-      pageSize: UniversalSearchStore.DEFAULT_LIMIT,
     };
   },
 


### PR DESCRIPTION
Fixes an issue when no "pageSize" prop is provided. This broke in #4160.

Before this fix:

![image](https://user-images.githubusercontent.com/461/31241809-521458b2-aa05-11e7-849a-99650ce7346c.png)

This needs to be merged into the 2.4 branch as well!