### PR TITLE
Show stats of all index sets without pagination

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/rest/resources/system/indexer/IndexSetsResource.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/resources/system/indexer/IndexSetsResource.java
@@ -154,6 +154,29 @@ public class IndexSetsResource extends RestResource {
     }
 
     @GET
+    @Path("stats")
+    @Timed
+    @ApiOperation(value = "Get stats of all index sets")
+    @ApiResponses(value = {
+            @ApiResponse(code = 403, message = "Unauthorized"),
+    })
+    public IndexSetStats globalStats() {
+        checkPermission(RestPermissions.INDEXSETS_READ);
+
+        long indices = 0;
+        long documents = 0;
+        long size = 0;
+        for (IndexSetStats stats : indexSetRegistry.getAll().stream()
+                .collect(Collectors.toMap(indexSet -> indexSet.getConfig().id(), indexSetStatsCreator::getForIndexSet)).values()) {
+            indices += stats.indices();
+            documents += stats.documents();
+            size += stats.size();
+        }
+
+        return IndexSetStats.create(indices, documents, size);
+    }
+
+    @GET
     @Path("{id}")
     @Timed
     @ApiOperation(value = "Get index set")

--- a/graylog2-server/src/main/java/org/graylog2/rest/resources/system/indexer/IndexSetsResource.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/resources/system/indexer/IndexSetsResource.java
@@ -174,7 +174,8 @@ public class IndexSetsResource extends RestResource {
                 .map(IndexSet::getIndexWildcard)
                 .collect(Collectors.toSet());
         final Set<IndexStatistics> indicesStats = indices.getIndicesStats(indexWildcards);
-        return IndexSetStats.fromIndexStatistics(indicesStats);
+        final Set<String> closedIndices = indices.getClosedIndices(indexWildcards);
+        return IndexSetStats.fromIndexStatistics(indicesStats, closedIndices);
     }
 
     @GET

--- a/graylog2-server/src/main/java/org/graylog2/rest/resources/system/indexer/IndexSetsResource.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/resources/system/indexer/IndexSetsResource.java
@@ -67,13 +67,11 @@ import javax.ws.rs.Produces;
 import javax.ws.rs.QueryParam;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
-import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
-import java.util.StringJoiner;
 import java.util.stream.Collectors;
 
 import static java.util.Objects.requireNonNull;

--- a/graylog2-server/src/main/java/org/graylog2/rest/resources/system/indexer/responses/IndexSetStats.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/resources/system/indexer/responses/IndexSetStats.java
@@ -20,6 +20,10 @@ import com.fasterxml.jackson.annotation.JsonAutoDetect;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.auto.value.AutoValue;
+import org.graylog2.indexer.indices.stats.IndexStatistics;
+import org.graylog2.rest.models.system.indexer.responses.IndexStats;
+
+import java.util.Collection;
 
 @JsonAutoDetect
 @AutoValue
@@ -42,5 +46,19 @@ public abstract class IndexSetStats {
                                        @JsonProperty(FIELD_DOCUMENTS) long documents,
                                        @JsonProperty(FIELD_SIZE) long size) {
         return new AutoValue_IndexSetStats(indices, documents, size);
+    }
+
+    public static IndexSetStats fromIndexStatistics(Collection<IndexStatistics> indexStatistics) {
+        final long totalIndicesCount = indexStatistics.size();
+        final long totalDocumentsCount = indexStatistics.stream()
+                .map(IndexStatistics::allShards)
+                .map(IndexStats::documents)
+                .mapToLong(IndexStats.DocsStats::count)
+                .sum();
+        final long totalSizeInBytes = indexStatistics.stream()
+                .map(IndexStatistics::allShards)
+                .mapToLong(IndexStats::storeSizeBytes)
+                .sum();
+        return create(totalIndicesCount, totalDocumentsCount, totalSizeInBytes);
     }
 }

--- a/graylog2-server/src/main/java/org/graylog2/rest/resources/system/indexer/responses/IndexSetStats.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/resources/system/indexer/responses/IndexSetStats.java
@@ -48,8 +48,8 @@ public abstract class IndexSetStats {
         return new AutoValue_IndexSetStats(indices, documents, size);
     }
 
-    public static IndexSetStats fromIndexStatistics(Collection<IndexStatistics> indexStatistics) {
-        final long totalIndicesCount = indexStatistics.size();
+    public static IndexSetStats fromIndexStatistics(Collection<IndexStatistics> indexStatistics, Collection<String> closedIndices) {
+        final long totalIndicesCount = indexStatistics.size() + closedIndices.size();
         final long totalDocumentsCount = indexStatistics.stream()
                 .map(IndexStatistics::allShards)
                 .map(IndexStats::documents)

--- a/graylog2-server/src/test/java/org/graylog2/rest/resources/system/indexer/IndexSetsResourceTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/rest/resources/system/indexer/IndexSetsResourceTest.java
@@ -21,7 +21,6 @@ import org.graylog2.indexer.IndexSet;
 import org.graylog2.indexer.IndexSetRegistry;
 import org.graylog2.indexer.IndexSetStatsCreator;
 import org.graylog2.indexer.IndexSetValidator;
-import org.graylog2.indexer.TestIndexSet;
 import org.graylog2.indexer.indexset.DefaultIndexSetConfig;
 import org.graylog2.indexer.indexset.IndexSetConfig;
 import org.graylog2.indexer.indexset.IndexSetService;

--- a/graylog2-server/src/test/java/org/graylog2/rest/resources/system/indexer/IndexSetsResourceTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/rest/resources/system/indexer/IndexSetsResourceTest.java
@@ -21,15 +21,19 @@ import org.graylog2.indexer.IndexSet;
 import org.graylog2.indexer.IndexSetRegistry;
 import org.graylog2.indexer.IndexSetStatsCreator;
 import org.graylog2.indexer.IndexSetValidator;
+import org.graylog2.indexer.TestIndexSet;
 import org.graylog2.indexer.indexset.DefaultIndexSetConfig;
 import org.graylog2.indexer.indexset.IndexSetConfig;
 import org.graylog2.indexer.indexset.IndexSetService;
+import org.graylog2.indexer.indices.Indices;
 import org.graylog2.indexer.indices.jobs.IndexSetCleanupJob;
+import org.graylog2.indexer.indices.stats.IndexStatistics;
 import org.graylog2.indexer.retention.strategies.NoopRetentionStrategy;
 import org.graylog2.indexer.retention.strategies.NoopRetentionStrategyConfig;
 import org.graylog2.indexer.rotation.strategies.MessageCountRotationStrategy;
 import org.graylog2.indexer.rotation.strategies.MessageCountRotationStrategyConfig;
 import org.graylog2.plugin.cluster.ClusterConfigService;
+import org.graylog2.rest.models.system.indexer.responses.IndexStats;
 import org.graylog2.rest.resources.system.indexer.requests.IndexSetUpdateRequest;
 import org.graylog2.rest.resources.system.indexer.responses.IndexSetResponse;
 import org.graylog2.rest.resources.system.indexer.responses.IndexSetStats;
@@ -58,6 +62,7 @@ import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyCollection;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
@@ -73,6 +78,8 @@ public class IndexSetsResourceTest {
     @Rule
     public final ExpectedException expectedException = ExpectedException.none();
 
+    @Mock
+    private Indices indices;
     @Mock
     private IndexSetService indexSetService;
     @Mock
@@ -99,7 +106,7 @@ public class IndexSetsResourceTest {
     @Before
     public void setUp() throws Exception {
         this.permitted = true;
-        this.indexSetsResource = new TestResource(indexSetService, indexSetRegistry, indexSetValidator, indexSetCleanupJobFactory, indexSetStatsCreator, clusterConfigService, systemJobManager, () -> permitted);
+        this.indexSetsResource = new TestResource(indices, indexSetService, indexSetRegistry, indexSetValidator, indexSetCleanupJobFactory, indexSetStatsCreator, clusterConfigService, systemJobManager, () -> permitted);
     }
 
     private void notPermitted() {
@@ -540,6 +547,75 @@ public class IndexSetsResourceTest {
     }
 
     @Test
+    public void globalStats() throws Exception {
+        final IndexStatistics indexStatistics = IndexStatistics.create(
+                "prefix_0",
+                IndexStats.create(
+                        IndexStats.TimeAndTotalStats.create(0L, 0L),
+                        IndexStats.TimeAndTotalStats.create(0L, 0L),
+                        IndexStats.TimeAndTotalStats.create(0L, 0L),
+                        IndexStats.TimeAndTotalStats.create(0L, 0L),
+                        IndexStats.TimeAndTotalStats.create(0L, 0L),
+                        IndexStats.TimeAndTotalStats.create(0L, 0L),
+                        IndexStats.TimeAndTotalStats.create(0L, 0L),
+                        0L,
+                        23L,
+                        2L,
+                        IndexStats.DocsStats.create(42L, 0L)
+                ),
+                IndexStats.create(
+                        IndexStats.TimeAndTotalStats.create(0L, 0L),
+                        IndexStats.TimeAndTotalStats.create(0L, 0L),
+                        IndexStats.TimeAndTotalStats.create(0L, 0L),
+                        IndexStats.TimeAndTotalStats.create(0L, 0L),
+                        IndexStats.TimeAndTotalStats.create(0L, 0L),
+                        IndexStats.TimeAndTotalStats.create(0L, 0L),
+                        IndexStats.TimeAndTotalStats.create(0L, 0L),
+                        0L,
+                        23L,
+                        2L,
+                        IndexStats.DocsStats.create(42L, 0L)
+                ),
+                Collections.emptyList()
+        );
+        when(indices.getIndicesStats(anyCollection())).thenReturn(Collections.singleton(indexStatistics));
+
+        final IndexSetStats indexSetStats = indexSetsResource.globalStats();
+
+        assertThat(indexSetStats).isNotNull();
+        assertThat(indexSetStats.indices()).isEqualTo(1L);
+        assertThat(indexSetStats.documents()).isEqualTo(42L);
+        assertThat(indexSetStats.size()).isEqualTo(23L);
+    }
+
+    @Test
+    public void globalStats0() throws Exception {
+        when(indexSetRegistry.getAll()).thenReturn(Collections.emptySet());
+        when(indices.getIndicesStats(anyCollection())).thenReturn(Collections.emptySet());
+
+        final IndexSetStats indexSetStats = indexSetsResource.globalStats();
+
+        assertThat(indexSetStats).isNotNull();
+        assertThat(indexSetStats.indices()).isEqualTo(0L);
+        assertThat(indexSetStats.documents()).isEqualTo(0L);
+        assertThat(indexSetStats.size()).isEqualTo(0L);
+    }
+
+    @Test
+    public void globalStatsDenied() {
+        notPermitted();
+
+        expectedException.expect(ForbiddenException.class);
+        expectedException.expectMessage("Not authorized");
+
+        try {
+            indexSetsResource.globalStats();
+        } finally {
+            verifyZeroInteractions(indexSetService);
+        }
+    }
+
+    @Test
     public void setDefaultMakesIndexDefaultIfWritable() throws Exception {
         final String indexSetId = "newDefaultIndexSetId";
         final IndexSet indexSet = mock(IndexSet.class);
@@ -645,8 +721,8 @@ public class IndexSetsResourceTest {
     private static class TestResource extends IndexSetsResource {
         private final Provider<Boolean> permitted;
 
-        TestResource(IndexSetService indexSetService, IndexSetRegistry indexSetRegistry, IndexSetValidator indexSetValidator, IndexSetCleanupJob.Factory indexSetCleanupJobFactory, IndexSetStatsCreator indexSetStatsCreator, ClusterConfigService clusterConfigService, SystemJobManager systemJobManager, Provider<Boolean> permitted) {
-            super(indexSetService, indexSetRegistry, indexSetValidator, indexSetCleanupJobFactory, indexSetStatsCreator, clusterConfigService, systemJobManager);
+        TestResource(Indices indices, IndexSetService indexSetService, IndexSetRegistry indexSetRegistry, IndexSetValidator indexSetValidator, IndexSetCleanupJob.Factory indexSetCleanupJobFactory, IndexSetStatsCreator indexSetStatsCreator, ClusterConfigService clusterConfigService, SystemJobManager systemJobManager, Provider<Boolean> permitted) {
+            super(indices, indexSetService, indexSetRegistry, indexSetValidator, indexSetCleanupJobFactory, indexSetStatsCreator, clusterConfigService, systemJobManager);
             this.permitted = permitted;
         }
 

--- a/graylog2-server/src/test/java/org/graylog2/rest/resources/system/indexer/IndexSetsResourceTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/rest/resources/system/indexer/IndexSetsResourceTest.java
@@ -578,12 +578,13 @@ public class IndexSetsResourceTest {
                 ),
                 Collections.emptyList()
         );
+        when(indices.getClosedIndices(anyCollection())).thenReturn(Collections.singleton("closed_index_0"));
         when(indices.getIndicesStats(anyCollection())).thenReturn(Collections.singleton(indexStatistics));
 
         final IndexSetStats indexSetStats = indexSetsResource.globalStats();
 
         assertThat(indexSetStats).isNotNull();
-        assertThat(indexSetStats.indices()).isEqualTo(1L);
+        assertThat(indexSetStats.indices()).isEqualTo(2L);
         assertThat(indexSetStats.documents()).isEqualTo(42L);
         assertThat(indexSetStats.size()).isEqualTo(23L);
     }

--- a/graylog2-web-interface/src/actions/indices/IndexSetsActions.js
+++ b/graylog2-web-interface/src/actions/indices/IndexSetsActions.js
@@ -8,6 +8,7 @@ const IndexSetsActions = Reflux.createActions({
   create: { asyncResult: true },
   delete: { asyncResult: true },
   setDefault: { asyncResult: true },
+  stats: { asyncResult: true },
 });
 
 export default IndexSetsActions;

--- a/graylog2-web-interface/src/components/indices/IndexSetsComponent.jsx
+++ b/graylog2-web-interface/src/components/indices/IndexSetsComponent.jsx
@@ -25,6 +25,7 @@ const IndexSetsComponent = React.createClass({
     this.currentPageNo = pageNo;
     this.currentPageSize = limit;
     IndexSetsActions.listPaginated((pageNo - 1) * limit, limit, true);
+    IndexSetsActions.stats();
   },
 
   // Stores the current page and page size to be able to reload the current page
@@ -100,11 +101,7 @@ const IndexSetsComponent = React.createClass({
     let statsString;
     const stats = this.state.indexSetStats[indexSet.id];
     if (stats) {
-      const indices = `${NumberUtils.formatNumber(stats.indices)} ${StringUtils.pluralize(stats.indices, 'index', 'indices')}`;
-      const documents = `${NumberUtils.formatNumber(stats.documents)} ${StringUtils.pluralize(stats.documents, 'document', 'documents')}`;
-      const size = NumberUtils.formatBytes(stats.size);
-
-      statsString = `${indices}, ${documents}, ${size}`;
+      statsString = this._formatStatsString(stats)
     }
 
     return (
@@ -115,6 +112,14 @@ const IndexSetsComponent = React.createClass({
                       actions={actions}
                       contentRow={content} />
     );
+  },
+
+  _formatStatsString(stats) {
+    const indices = `${NumberUtils.formatNumber(stats.indices)} ${StringUtils.pluralize(stats.indices, 'index', 'indices')}`;
+    const documents = `${NumberUtils.formatNumber(stats.documents)} ${StringUtils.pluralize(stats.documents, 'document', 'documents')}`;
+    const size = NumberUtils.formatBytes(stats.size);
+
+    return `${indices}, ${documents}, ${size}`;
   },
 
   _isLoading() {
@@ -128,6 +133,10 @@ const IndexSetsComponent = React.createClass({
 
     return (
       <div>
+        <h4><strong>Total:</strong> {this._formatStatsString(this.state.globalIndexSetStats)}</h4>
+
+        <hr style={{ marginBottom: "0" }} />
+
         <PaginatedList pageSize={this.PAGE_SIZE} totalItems={this.state.indexSetsCount} onChange={this._onChangePaginatedList}
                        showPageSizeSelect={false}>
           <EntityList bsNoItemsStyle="info"

--- a/graylog2-web-interface/src/routing/ApiRoutes.js
+++ b/graylog2-web-interface/src/routing/ApiRoutes.js
@@ -89,6 +89,7 @@ const ApiRoutes = {
     create: () => { return { url: '/system/indices/index_sets' }; },
     delete: (indexSetId, deleteIndices) => { return { url: `/system/indices/index_sets/${indexSetId}?delete_indices=${deleteIndices}` }; },
     setDefault: (indexSetId) => { return { url: `/system/indices/index_sets/${indexSetId}/default` }; },
+    stats: () => { return { url: `/system/indices/index_sets/stats` }; },
   },
   IndicesApiController: {
     close: (indexName) => { return { url: `/system/indexer/indices/${indexName}/close` }; },

--- a/graylog2-web-interface/src/stores/indices/IndexSetsStore.jsx
+++ b/graylog2-web-interface/src/stores/indices/IndexSetsStore.jsx
@@ -128,6 +128,26 @@ const IndexSetsStore = Reflux.createStore({
     IndexSetsActions.setDefault.promise(promise);
   },
 
+  stats() {
+    const url = URLUtils.qualifyUrl(ApiRoutes.IndexSetsApiController.stats().url);
+    const promise = fetch('GET', url);
+    promise
+      .then(
+        response => this.trigger({
+          globalIndexSetStats: {
+            indices: response.indices,
+            documents: response.documents,
+            size: response.size,
+          }
+        }),
+        (error) => {
+          UserNotification.error(`Fetching global index stats failed: ${error.message}`,
+            'Could not retrieve global index stats.');
+        });
+
+    IndexSetsActions.stats.promise(promise);
+  },
+
   _errorMessage(error) {
     try {
       return error.additional.body.message;


### PR DESCRIPTION
Add information and stats about all indices on the "Index Sets" page without accounting for pagination. The reason for this is, that finding out the total size of all indices can be really annoying if you have a lot of index sets. See also #4204.

This change was initiated by customer request #1503. 

This introduces a new REST API endpoint at "/system/indices/index_sets/stats" to retrieve global, aggregated stats without pagination or other information about the index sets.

## How Has This Been Tested?
Tested on a local setup and also a v2.3.1 with about 500GB of data in over 400 indices and 3 index sets. The performance impact to calculate the stats with an initial concern but my benchmarks showed that it only adds about 300ms to the *Index Sets* page load time, which is acceptable IMO. Adding a caching layer or getting creative with the already computed `stats` of the paginated index sets is probably not worth the overhead.

## Screenshots:

![screen shot 2017-10-05 at 2 54 38 pm](https://user-images.githubusercontent.com/35022/31249672-d58e4f22-a9dd-11e7-9bfd-1b15a332ef57.png)

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
