### PR TITLE
Unify action components of all field analyzers

### DIFF
--- a/graylog2-web-interface/public/stylesheets/graylog2.less
+++ b/graylog2-web-interface/public/stylesheets/graylog2.less
@@ -1413,6 +1413,7 @@ table .dc-table-column {
 
 .field-graph-container .reposition-handle {
   cursor: move;
+  margin-left: 10px !important;
 }
 
 .field-graph-container .merge-hint {
@@ -2646,6 +2647,10 @@ ul.pill-list > li {
 .field-analyzer {
   margin-left: 0 !important;
   margin-top: 10px !important;
+}
+
+.field-analyzer-close {
+  margin-left: 10px !important;
 }
 
 .save-button-margin {

--- a/graylog2-web-interface/src/components/dashboard/AddToDashboardMenu.jsx
+++ b/graylog2-web-interface/src/components/dashboard/AddToDashboardMenu.jsx
@@ -39,7 +39,7 @@ const AddToDashboardMenu = React.createClass({
 
   getDefaultProps() {
     return {
-      bsStyle: 'info',
+      bsStyle: 'default',
       configuration: {},
       hidden: false,
       pullRight: false,
@@ -200,8 +200,11 @@ const AddToDashboardMenu = React.createClass({
     return (
       <div style={{ display: 'inline-block' }}>
         <ButtonGroup>
-          {this.props.children}
           {dropdownMenu}
+
+          <div style={{ display: 'inline' }}>
+            {this.props.children}
+          </div>
         </ButtonGroup>
         <WidgetCreationModal ref="widgetModal"
                              widgetType={this.props.widgetType}

--- a/graylog2-web-interface/src/components/field-analyzers/FieldQuickValues.jsx
+++ b/graylog2-web-interface/src/components/field-analyzers/FieldQuickValues.jsx
@@ -1,7 +1,7 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 import ReactDOM from 'react-dom';
-import { DropdownButton, MenuItem } from 'react-bootstrap';
+import { DropdownButton, MenuItem, Button } from 'react-bootstrap';
 import Reflux from 'reflux';
 
 import QuickValuesVisualization from 'components/visualizations/QuickValuesVisualization';
@@ -170,17 +170,11 @@ const FieldQuickValues = React.createClass({
             <AddToDashboardMenu title="Add to dashboard"
                                 widgetType={this.WIDGET_TYPE}
                                 configuration={this._buildDashboardConfig()}
-                                bsStyle="default"
                                 pullRight
                                 permissions={this.props.permissions}>
-              <DropdownButton bsSize="small"
-                              className="graph-settings"
-                              title="Customize"
-                              id="customize-field-graph-dropdown">
-                <MenuItem onSelect={this._showVizOptions}>Configuration</MenuItem>
-                <MenuItem divider />
-                <MenuItem onSelect={() => this._resetStatus()}>Dismiss</MenuItem>
-              </DropdownButton>
+
+                <Button bsSize="small" onClick={this._showVizOptions}>Customize</Button>
+                <Button bsSize="small" className="field-analyzer-close" onClick={() => this._resetStatus()}><i className="fa fa-close" /></Button>
             </AddToDashboardMenu>
           </div>
           <h1>Quick Values for <em>{this.state.field}</em> {this.state.loadPending && <i

--- a/graylog2-web-interface/src/components/field-analyzers/FieldStatistics.jsx
+++ b/graylog2-web-interface/src/components/field-analyzers/FieldStatistics.jsx
@@ -164,12 +164,11 @@ const FieldStatistics = React.createClass({
           <div className="pull-right">
             <AddToDashboardMenu title="Add to dashboard"
                                 widgetType={this.WIDGET_TYPE}
-                                bsStyle="default"
                                 fields={this.state.fieldStatistics.keySeq().toJS()}
                                 pullRight
                                 permissions={this.props.permissions}>
 
-              <Button bsSize="small" onClick={() => this._resetStatus()}>Dismiss</Button>
+              <Button bsSize="small" className="field-analyzer-close" onClick={() => this._resetStatus()}><i className="fa fa-close" /></Button>
             </AddToDashboardMenu>
           </div>
           <h1>Field Statistics</h1>

--- a/graylog2-web-interface/src/components/field-analyzers/LegacyFieldGraph.jsx
+++ b/graylog2-web-interface/src/components/field-analyzers/LegacyFieldGraph.jsx
@@ -118,18 +118,13 @@ const LegacyFieldGraph = React.createClass({
                               dashboards={this.props.dashboards}
                               widgetType={this._getWidgetType()}
                               configuration={this._getWidgetConfiguration()}
-                              bsStyle="default"
                               pullRight
                               permissions={this.props.permissions}>
             <DropdownButton bsSize="small" className="graph-settings" title="Customize"
                             id="customize-field-graph-dropdown">
               {submenus}
-              <MenuItem divider />
-              <MenuItem onSelect={this.props.onDelete}>Dismiss</MenuItem>
             </DropdownButton>
-          </AddToDashboardMenu>
 
-          <div style={{ display: 'inline', marginLeft: 20 }}>
             <Button href="#"
                     bsSize="small"
                     className="reposition-handle"
@@ -137,7 +132,9 @@ const LegacyFieldGraph = React.createClass({
                     title="Drag and drop to merge the graph into another">
               <i className="fa fa-reorder" />
             </Button>
-          </div>
+
+            <Button bsSize="small" className="field-analyzer-close" onClick={this.props.onDelete}><i className="fa fa-close" /></Button>
+          </AddToDashboardMenu>
         </div>
         <h1>{this._getGraphTitle()}</h1>
 


### PR DESCRIPTION
This change unifies the action components (buttons and dropdowns) of all field analyzer widgets we ship. Those components are found in the top right corner of each widget.

* The "Dismiss Widget" button is now always a close icon and on the far right of all actions. Before it was sometimes directly accessible and sometimes hidden behind a "Customize" drop-down. The change to a close _icon_ makes it stand out more and also saves real-estate. A margin to the left helps to identify it quickly and avoids accidental pressing of it.
* The "Add to dashboard" button has the same and less intrusive button across all widgets now.
* The new Quick Values configuration dialog is accessible directly without going through the "Customize" drop-down. In fact, the "Customize" drop-down only had "Customize" as a menu item after "Dismiss" was moved to the new close widget icon.

**Important**: There is a second PR in the map widget repository that should be merged after this one to keep UI consistency: Graylog2/graylog-plugin-map-widget#56

## Screenshots:

![screen shot 2017-10-06 at 9 19 48 pm](https://user-images.githubusercontent.com/35022/31303922-1f1dc830-aadc-11e7-82b7-60e4f8810942.png)

![screen shot 2017-10-06 at 9 20 16 pm](https://user-images.githubusercontent.com/35022/31303925-2f97ee98-aadc-11e7-9573-dd34b3ea26c6.png)

![screen shot 2017-10-06 at 9 21 15 pm](https://user-images.githubusercontent.com/35022/31303940-51fa4c88-aadc-11e7-83d4-c6534d91eeb2.png)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change