### PR TITLE
Provide details about missing permissions when unauthorized

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/shared/rest/resources/RestResource.java
+++ b/graylog2-server/src/main/java/org/graylog2/shared/rest/resources/RestResource.java
@@ -25,7 +25,6 @@ import org.apache.shiro.subject.Subject;
 import org.graylog2.configuration.HttpConfiguration;
 import org.graylog2.indexer.IndexSet;
 import org.graylog2.indexer.IndexSetRegistry;
-import org.graylog2.plugin.BaseConfiguration;
 import org.graylog2.plugin.database.users.User;
 import org.graylog2.shared.security.ShiroPrincipal;
 import org.graylog2.shared.users.UserService;
@@ -99,7 +98,7 @@ public abstract class RestResource {
 
     protected void checkPermission(String permission) {
         if (!isPermitted(permission)) {
-            throw new ForbiddenException("Not authorized");
+            throw new ForbiddenException("Not authorized. User is missing permission <" + permission + ">");
         }
     }
 
@@ -109,7 +108,7 @@ public abstract class RestResource {
 
     protected void checkPermission(String permission, String instanceId) {
         if (!isPermitted(permission, instanceId)) {
-            throw new ForbiddenException("Not authorized to access resource id <" + instanceId + ">");
+            throw new ForbiddenException("Not authorized to access resource id <" + instanceId + ">. User is missing permission <" + permission + ":" + instanceId + ">");
         }
     }
 
@@ -132,7 +131,7 @@ public abstract class RestResource {
 
     protected void checkAnyPermission(String permissions[], String instanceId) {
         if (!isAnyPermitted(permissions, instanceId)) {
-            throw new ForbiddenException("Not authorized to access resource id <" + instanceId + ">");
+            throw new ForbiddenException("Not authorized to access resource id <" + instanceId + ">. User is missing permissions " + Arrays.toString(permissions) + " on instance <" + instanceId + ">");
         }
     }
 

--- a/graylog2-server/src/main/java/org/graylog2/shared/rest/resources/RestResource.java
+++ b/graylog2-server/src/main/java/org/graylog2/shared/rest/resources/RestResource.java
@@ -98,8 +98,8 @@ public abstract class RestResource {
 
     protected void checkPermission(String permission) {
         if (!isPermitted(permission)) {
-            final String userName = getSubject().getPrincipal().toString();
-            throw new ForbiddenException("Not authorized. User <" + userName + "> is missing permission <" + permission + ">");
+            LOG.info("Not authorized. User <{}> is missing permission <{}>", getSubject().getPrincipal(), permission);
+            throw new ForbiddenException("Not authorized");
         }
     }
 
@@ -109,8 +109,9 @@ public abstract class RestResource {
 
     protected void checkPermission(String permission, String instanceId) {
         if (!isPermitted(permission, instanceId)) {
-            final String userName = getSubject().getPrincipal().toString();
-            throw new ForbiddenException("Not authorized to access resource id <" + instanceId + ">. User <" + userName + "> is missing permission <" + permission + ":" + instanceId + ">");
+            LOG.info("Not authorized to access resource id <{}>. User <{}> is missing permission <{}:{}>",
+                    instanceId, getSubject().getPrincipal(), permission, instanceId);
+            throw new ForbiddenException("Not authorized to access resource id <" + instanceId + ">");
         }
     }
 
@@ -133,8 +134,9 @@ public abstract class RestResource {
 
     protected void checkAnyPermission(String permissions[], String instanceId) {
         if (!isAnyPermitted(permissions, instanceId)) {
-            final String userName = getSubject().getPrincipal().toString();
-            throw new ForbiddenException("Not authorized to access resource id <" + instanceId + ">. User <" + userName + "> is missing permissions " + Arrays.toString(permissions) + " on instance <" + instanceId + ">");
+            LOG.info("Not authorized to access resource id <{}>. User <{}> is missing permissions {} on instance <{}>",
+                    instanceId, getSubject().getPrincipal(), Arrays.toString(permissions), instanceId);
+            throw new ForbiddenException("Not authorized to access resource id <" + instanceId + ">");
         }
     }
 

--- a/graylog2-server/src/main/java/org/graylog2/shared/rest/resources/RestResource.java
+++ b/graylog2-server/src/main/java/org/graylog2/shared/rest/resources/RestResource.java
@@ -98,7 +98,8 @@ public abstract class RestResource {
 
     protected void checkPermission(String permission) {
         if (!isPermitted(permission)) {
-            throw new ForbiddenException("Not authorized. User is missing permission <" + permission + ">");
+            final String userName = getSubject().getPrincipal().toString();
+            throw new ForbiddenException("Not authorized. User <" + userName + "> is missing permission <" + permission + ">");
         }
     }
 
@@ -108,7 +109,8 @@ public abstract class RestResource {
 
     protected void checkPermission(String permission, String instanceId) {
         if (!isPermitted(permission, instanceId)) {
-            throw new ForbiddenException("Not authorized to access resource id <" + instanceId + ">. User is missing permission <" + permission + ":" + instanceId + ">");
+            final String userName = getSubject().getPrincipal().toString();
+            throw new ForbiddenException("Not authorized to access resource id <" + instanceId + ">. User <" + userName + "> is missing permission <" + permission + ":" + instanceId + ">");
         }
     }
 
@@ -131,7 +133,8 @@ public abstract class RestResource {
 
     protected void checkAnyPermission(String permissions[], String instanceId) {
         if (!isAnyPermitted(permissions, instanceId)) {
-            throw new ForbiddenException("Not authorized to access resource id <" + instanceId + ">. User is missing permissions " + Arrays.toString(permissions) + " on instance <" + instanceId + ">");
+            final String userName = getSubject().getPrincipal().toString();
+            throw new ForbiddenException("Not authorized to access resource id <" + instanceId + ">. User <" + userName + "> is missing permissions " + Arrays.toString(permissions) + " on instance <" + instanceId + ">");
         }
     }
 

--- a/graylog2-server/src/main/java/org/graylog2/shared/security/ShiroAuthorizationFilter.java
+++ b/graylog2-server/src/main/java/org/graylog2/shared/security/ShiroAuthorizationFilter.java
@@ -30,7 +30,6 @@ import javax.ws.rs.container.ContainerRequestFilter;
 import javax.ws.rs.core.SecurityContext;
 import java.io.IOException;
 import java.util.Arrays;
-import java.util.Locale;
 
 @Priority(Priorities.AUTHORIZATION)
 public class ShiroAuthorizationFilter implements ContainerRequestFilter {
@@ -48,14 +47,14 @@ public class ShiroAuthorizationFilter implements ContainerRequestFilter {
             final ShiroSecurityContext context = (ShiroSecurityContext) securityContext;
             final String userName = RestTools.getUserNameFromRequest(requestContext);
             final ContextAwarePermissionAnnotationHandler annotationHandler = new ContextAwarePermissionAnnotationHandler(context);
+            final String[] requiredPermissions = annotation.value();
             try {
-                LOG.debug("Checking authorization for user [{}], needs permissions: {}", userName, annotation.value());
+                LOG.debug("Checking authorization for user [{}], needs permissions: {}", userName, requiredPermissions);
                 annotationHandler.assertAuthorized(annotation);
             } catch (AuthorizationException e) {
-                final String msg = String.format(Locale.US, "Not authorized. User <%s> is missing permissions %s to perform <%s %s>",
-                        userName, Arrays.toString(annotation.value()), requestContext.getMethod(), requestContext.getUriInfo().getPath());
-                LOG.info(msg);
-                throw new ForbiddenException(msg);
+                LOG.info("Not authorized. User <{}> is missing permissions {} to perform <{} {}>",
+                        userName, Arrays.toString(requiredPermissions), requestContext.getMethod(), requestContext.getUriInfo().getPath());
+                throw new ForbiddenException("Not authorized");
             }
         } else {
             throw new ForbiddenException();

--- a/graylog2-server/src/main/java/org/graylog2/shared/security/ShiroAuthorizationFilter.java
+++ b/graylog2-server/src/main/java/org/graylog2/shared/security/ShiroAuthorizationFilter.java
@@ -29,6 +29,7 @@ import javax.ws.rs.container.ContainerRequestContext;
 import javax.ws.rs.container.ContainerRequestFilter;
 import javax.ws.rs.core.SecurityContext;
 import java.io.IOException;
+import java.util.Arrays;
 import java.util.Locale;
 
 @Priority(Priorities.AUTHORIZATION)
@@ -51,8 +52,8 @@ public class ShiroAuthorizationFilter implements ContainerRequestFilter {
                 LOG.debug("Checking authorization for user [{}], needs permissions: {}", userName, annotation.value());
                 annotationHandler.assertAuthorized(annotation);
             } catch (AuthorizationException e) {
-                final String msg = String.format(Locale.US, "User [%s] not authorized. (%s %s)", userName,
-                        requestContext.getMethod(), requestContext.getUriInfo().getPath());
+                final String msg = String.format(Locale.US, "Not authorized. User <%s> is missing permissions %s to perform <%s %s>",
+                        userName, Arrays.toString(annotation.value()), requestContext.getMethod(), requestContext.getUriInfo().getPath());
                 LOG.info(msg);
                 throw new ForbiddenException(msg);
             }

--- a/graylog2-server/src/test/java/org/graylog2/rest/resources/system/indexer/IndexSetsResourceTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/rest/resources/system/indexer/IndexSetsResourceTest.java
@@ -730,6 +730,7 @@ public class IndexSetsResourceTest {
         protected Subject getSubject() {
             final Subject mockSubject = mock(Subject.class);
             when(mockSubject.isPermitted(anyString())).thenReturn(permitted.get());
+            when(mockSubject.getPrincipal()).thenReturn("test-user");
             return mockSubject;
         }
     }


### PR DESCRIPTION
Instead of just providing the information that some HTTP request of a user failed due to insufficient permissions, Graylog now provides helpful hints which permission was missing to successfully fulfill the request.

Example responses:
```
HTTP/1.1 403 Forbidden
X-Graylog-Node-ID: cd03ee44-b2a7-4824-be16-bb7456149dbd
Content-Type: application/json
Date: Wed, 11 Oct 2017 09:44:14 GMT
Content-Length: 123

{"type":"ApiError","message":"Not authorized. User <username> is missing permissions [users:list] to perform <GET api/users>"}
```
```
HTTP/1.1 403 Forbidden
X-Graylog-Node-ID: cd03ee44-b2a7-4824-be16-bb7456149dbd
X-Runtime-Microseconds: 81841
Content-Type: application/json
Date: Wed, 11 Oct 2017 09:39:12 GMT
Content-Length: 91

{"type":"ApiError","message":"Not authorized. User <username> is missing permission <indexsets:read>"}
```
Refs http://blog.koehntopp.info/index.php/2659-a-sad-security-user-story/ 😉 