### PR TITLE
Add periodical to check free disk space in journal directory

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/bindings/PeriodicalBindings.java
+++ b/graylog2-server/src/main/java/org/graylog2/bindings/PeriodicalBindings.java
@@ -40,6 +40,7 @@ import org.graylog2.periodical.ThrottleStateUpdaterThread;
 import org.graylog2.periodical.UserPermissionMigrationPeriodical;
 import org.graylog2.periodical.VersionCheckThread;
 import org.graylog2.plugin.periodical.Periodical;
+import org.graylog2.shared.journal.KafkaJournalDiskCheckPeriodical;
 
 public class PeriodicalBindings extends AbstractModule {
     @Override
@@ -66,5 +67,6 @@ public class PeriodicalBindings extends AbstractModule {
         periodicalBinder.addBinding().to(ConfigurationManagementPeriodical.class);
         periodicalBinder.addBinding().to(LdapGroupMappingMigration.class);
         periodicalBinder.addBinding().to(IndexFailuresPeriodical.class);
+        periodicalBinder.addBinding().to(KafkaJournalDiskCheckPeriodical.class);
     }
 }

--- a/graylog2-server/src/main/java/org/graylog2/notifications/Notification.java
+++ b/graylog2-server/src/main/java/org/graylog2/notifications/Notification.java
@@ -60,6 +60,7 @@ public interface Notification extends Persisted {
         GC_TOO_LONG,
         JOURNAL_UTILIZATION_TOO_HIGH,
         JOURNAL_UNCOMMITTED_MESSAGES_DELETED,
+        JOURNAL_INSUFFICIENT_DISK_SPACE,
         OUTPUT_DISABLED,
         INDEX_RANGES_RECALCULATION,
         GENERIC

--- a/graylog2-server/src/main/java/org/graylog2/notifications/NotificationImpl.java
+++ b/graylog2-server/src/main/java/org/graylog2/notifications/NotificationImpl.java
@@ -32,7 +32,7 @@ import java.util.Locale;
 import java.util.Map;
 
 @CollectionName("notifications")
-public class NotificationImpl extends PersistedImpl implements Notification {
+public class    NotificationImpl extends PersistedImpl implements Notification {
     static final String FIELD_TYPE = "type";
     static final String FIELD_SEVERITY = "severity";
     static final String FIELD_TIMESTAMP = "timestamp";

--- a/graylog2-server/src/main/java/org/graylog2/notifications/NotificationImpl.java
+++ b/graylog2-server/src/main/java/org/graylog2/notifications/NotificationImpl.java
@@ -32,7 +32,7 @@ import java.util.Locale;
 import java.util.Map;
 
 @CollectionName("notifications")
-public class    NotificationImpl extends PersistedImpl implements Notification {
+public class NotificationImpl extends PersistedImpl implements Notification {
     static final String FIELD_TYPE = "type";
     static final String FIELD_SEVERITY = "severity";
     static final String FIELD_TIMESTAMP = "timestamp";

--- a/graylog2-server/src/main/java/org/graylog2/plugin/KafkaJournalConfiguration.java
+++ b/graylog2-server/src/main/java/org/graylog2/plugin/KafkaJournalConfiguration.java
@@ -21,6 +21,7 @@ import com.fasterxml.jackson.annotation.JsonFormat;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.github.joschi.jadconfig.Parameter;
 import com.github.joschi.jadconfig.util.Size;
+import com.github.joschi.jadconfig.validators.PositiveIntegerValidator;
 import org.joda.time.Duration;
 
 import javax.validation.constraints.NotNull;
@@ -28,6 +29,7 @@ import java.io.File;
 import java.util.Objects;
 
 public class KafkaJournalConfiguration {
+    private static final String PREFIX = "message_journal_";
 
     public KafkaJournalConfiguration() { }
 
@@ -38,7 +40,10 @@ public class KafkaJournalConfiguration {
                                      @JsonProperty("max_size") long messageJournalMaxSize,
                                      @JsonProperty("max_age") Duration messageJournalMaxAge,
                                      @JsonProperty("flush_interval") long messageJournalFlushInterval,
-                                     @JsonProperty("flush_age") Duration messageJournalFlushAge) {
+                                     @JsonProperty("flush_age") Duration messageJournalFlushAge,
+                                     @JsonProperty("check_enabled") boolean messageJournalCheckEnabled,
+                                     @JsonProperty("check_interval") Duration messageJournalCheckInterval,
+                                     @JsonProperty("check_disk_free_percent") int messageJournalCheckDiskFreePercent) {
         this.messageJournalDir = Objects.requireNonNull(messageJournalDir);
         this.messageJournalSegmentSize = Size.bytes(messageJournalSegmentSize);
         this.messageJournalSegmentAge = messageJournalSegmentAge;
@@ -46,38 +51,54 @@ public class KafkaJournalConfiguration {
         this.messageJournalMaxAge = messageJournalMaxAge;
         this.messageJournalFlushInterval = messageJournalFlushInterval;
         this.messageJournalFlushAge = messageJournalFlushAge;
+        this.messageJournalCheckEnabled = messageJournalCheckEnabled;
+        this.messageJournalCheckInterval = messageJournalCheckInterval;
+        this.messageJournalCheckDiskFreePercent = messageJournalCheckDiskFreePercent;
     }
 
-    @Parameter(value = "message_journal_dir", required = true)
+    @Parameter(value = PREFIX + "dir", required = true)
     @JsonProperty("directory")
     private File messageJournalDir = new File("data/journal");
 
-    @Parameter("message_journal_segment_size")
+    @Parameter(PREFIX + "segment_size")
     @JsonProperty("segment_size")
     private Size messageJournalSegmentSize = Size.megabytes(100L);
 
-    @Parameter("message_journal_segment_age")
+    @Parameter(PREFIX + "segment_age")
     @JsonFormat(shape = JsonFormat.Shape.NUMBER)
     @JsonProperty("segment_age")
     private Duration messageJournalSegmentAge = Duration.standardHours(1L);
 
-    @Parameter("message_journal_max_size")
+    @Parameter(PREFIX + "max_size")
     @JsonProperty("max_size")
     private Size messageJournalMaxSize = Size.gigabytes(5L);
 
-    @Parameter("message_journal_max_age")
+    @Parameter(PREFIX + "max_age")
     @JsonFormat(shape = JsonFormat.Shape.NUMBER)
     @JsonProperty("max_age")
     private Duration messageJournalMaxAge = Duration.standardHours(12L);
 
-    @Parameter("message_journal_flush_interval")
+    @Parameter(PREFIX + "flush_interval")
     @JsonProperty("flush_interval")
     private long messageJournalFlushInterval = 1_000_000L;
 
-    @Parameter("message_journal_flush_age")
+    @Parameter(PREFIX + "flush_age")
     @JsonFormat(shape = JsonFormat.Shape.NUMBER)
     @JsonProperty("flush_age")
     private Duration messageJournalFlushAge = Duration.standardMinutes(1L);
+
+    @Parameter(PREFIX + "check_enabled")
+    @JsonProperty("check_enabled")
+    private boolean messageJournalCheckEnabled = true;
+
+    @Parameter(PREFIX + "check_interval")
+    @JsonFormat(shape = JsonFormat.Shape.NUMBER)
+    @JsonProperty("check_interval")
+    private Duration messageJournalCheckInterval = Duration.standardMinutes(10L);
+
+    @Parameter(value = PREFIX + "check_disk_free_percent", validators = PositiveIntegerValidator.class)
+    @JsonProperty("check_disk_free_percent")
+    private int messageJournalCheckDiskFreePercent = 5;
 
     public File getMessageJournalDir() {
         return messageJournalDir;
@@ -105,5 +126,17 @@ public class KafkaJournalConfiguration {
 
     public Duration getMessageJournalFlushAge() {
         return messageJournalFlushAge;
+    }
+
+    public boolean isMessageJournalCheckEnabled() {
+        return messageJournalCheckEnabled;
+    }
+
+    public Duration getMessageJournalCheckInterval() {
+        return messageJournalCheckInterval;
+    }
+
+    public int getMessageJournalCheckDiskFreePercent() {
+        return messageJournalCheckDiskFreePercent;
     }
 }

--- a/graylog2-server/src/main/java/org/graylog2/plugin/KafkaJournalConfiguration.java
+++ b/graylog2-server/src/main/java/org/graylog2/plugin/KafkaJournalConfiguration.java
@@ -42,6 +42,7 @@ public class KafkaJournalConfiguration {
                                      @JsonProperty("flush_interval") long messageJournalFlushInterval,
                                      @JsonProperty("flush_age") Duration messageJournalFlushAge,
                                      @JsonProperty("check_enabled") boolean messageJournalCheckEnabled,
+                                     @JsonProperty("check_stop_inputs") boolean messageJournalCheckStopInputs,
                                      @JsonProperty("check_interval") Duration messageJournalCheckInterval,
                                      @JsonProperty("check_disk_free_percent") int messageJournalCheckDiskFreePercent) {
         this.messageJournalDir = Objects.requireNonNull(messageJournalDir);
@@ -52,6 +53,7 @@ public class KafkaJournalConfiguration {
         this.messageJournalFlushInterval = messageJournalFlushInterval;
         this.messageJournalFlushAge = messageJournalFlushAge;
         this.messageJournalCheckEnabled = messageJournalCheckEnabled;
+        this.messageJournalCheckStopInputs = messageJournalCheckStopInputs;
         this.messageJournalCheckInterval = messageJournalCheckInterval;
         this.messageJournalCheckDiskFreePercent = messageJournalCheckDiskFreePercent;
     }
@@ -90,6 +92,10 @@ public class KafkaJournalConfiguration {
     @Parameter(PREFIX + "check_enabled")
     @JsonProperty("check_enabled")
     private boolean messageJournalCheckEnabled = true;
+
+    @Parameter(PREFIX + "check_stop_inputs")
+    @JsonProperty("check_stop_inputs")
+    private boolean messageJournalCheckStopInputs = true;
 
     @Parameter(PREFIX + "check_interval")
     @JsonFormat(shape = JsonFormat.Shape.NUMBER)
@@ -130,6 +136,10 @@ public class KafkaJournalConfiguration {
 
     public boolean isMessageJournalCheckEnabled() {
         return messageJournalCheckEnabled;
+    }
+
+    public boolean isMessageJournalCheckStopInputs() {
+        return messageJournalCheckStopInputs;
     }
 
     public Duration getMessageJournalCheckInterval() {

--- a/graylog2-server/src/main/java/org/graylog2/shared/journal/KafkaJournalDiskCheckPeriodical.java
+++ b/graylog2-server/src/main/java/org/graylog2/shared/journal/KafkaJournalDiskCheckPeriodical.java
@@ -1,0 +1,126 @@
+/**
+ * This file is part of Graylog.
+ *
+ * Graylog is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.graylog2.shared.journal;
+
+import com.github.joschi.jadconfig.util.Size;
+import com.google.common.primitives.Ints;
+import org.graylog2.cluster.Node;
+import org.graylog2.notifications.Notification;
+import org.graylog2.notifications.NotificationService;
+import org.graylog2.plugin.BaseConfiguration;
+import org.graylog2.plugin.KafkaJournalConfiguration;
+import org.graylog2.plugin.ServerStatus;
+import org.graylog2.plugin.periodical.Periodical;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.inject.Inject;
+import java.io.File;
+
+public class KafkaJournalDiskCheckPeriodical extends Periodical {
+    private static final Logger LOG = LoggerFactory.getLogger(KafkaJournalDiskCheckPeriodical.class);
+
+    private final ServerStatus serverStatus;
+    private final Node node;
+    private final NotificationService notificationService;
+    private final int freeSpacePercentLimit;
+    private final File journalDir;
+    private final boolean checkEnabled;
+    private final boolean journalEnabled;
+    private final int periodSeconds;
+
+    @Inject
+    public KafkaJournalDiskCheckPeriodical(BaseConfiguration configuration,
+                                           KafkaJournalConfiguration kafkaJournalConfiguration,
+                                           ServerStatus serverStatus,
+                                           Node node,
+                                           NotificationService notificationService) {
+        this.serverStatus = serverStatus;
+        this.node = node;
+        this.notificationService = notificationService;
+
+        this.checkEnabled = kafkaJournalConfiguration.isMessageJournalCheckEnabled();
+        this.journalEnabled = configuration.isMessageJournalEnabled();
+        this.journalDir = kafkaJournalConfiguration.getMessageJournalDir();
+        this.freeSpacePercentLimit = kafkaJournalConfiguration.getMessageJournalCheckDiskFreePercent();
+        this.periodSeconds = Ints.saturatedCast(kafkaJournalConfiguration.getMessageJournalCheckInterval().getMillis() / 1000L);
+    }
+
+    @Override
+    public void doRun() {
+        final long totalSpace = journalDir.getTotalSpace();
+        final long freeSpace = journalDir.getFreeSpace();
+        final long freeSpacePercent = (long) (100L * ((double) freeSpace / (double) totalSpace));
+
+        if (freeSpacePercent < freeSpacePercentLimit) {
+            LOG.warn("Only {} ({}%) left on disk hosting \"{}\". Setting server status to DEAD.",
+                    Size.bytes(freeSpace), freeSpacePercent, journalDir.getAbsolutePath());
+
+            final Notification notification = notificationService.buildNow()
+                    .addType(Notification.Type.JOURNAL_INSUFFICIENT_DISK_SPACE)
+                    .addSeverity(Notification.Severity.URGENT)
+                    .addNode(node)
+                    .addDetail("journal_dir", journalDir.getAbsolutePath())
+                    .addDetail("disk_total_bytes", totalSpace)
+                    .addDetail("disk_free_bytes", freeSpace)
+                    .addDetail("disk_free_percent", freeSpacePercent);
+            notificationService.publishIfFirst(notification);
+
+            serverStatus.overrideLoadBalancerDead();
+        }
+    }
+
+    @Override
+    public boolean runsForever() {
+        return false;
+    }
+
+    @Override
+    public boolean stopOnGracefulShutdown() {
+        return true;
+    }
+
+    @Override
+    public boolean masterOnly() {
+        return false;
+    }
+
+    @Override
+    public boolean startOnThisNode() {
+        return journalEnabled && checkEnabled;
+    }
+
+    @Override
+    public boolean isDaemon() {
+        return true;
+    }
+
+    @Override
+    public int getInitialDelaySeconds() {
+        return 60;
+    }
+
+    @Override
+    public int getPeriodSeconds() {
+        return periodSeconds;
+    }
+
+    @Override
+    protected Logger getLogger() {
+        return LOG;
+    }
+}

--- a/graylog2-server/src/test/java/org/graylog2/shared/journal/KafkaJournalDiskCheckPeriodicalTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/shared/journal/KafkaJournalDiskCheckPeriodicalTest.java
@@ -1,0 +1,190 @@
+/**
+ * This file is part of Graylog.
+ *
+ * Graylog is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.graylog2.shared.journal;
+
+import org.graylog2.cluster.Node;
+import org.graylog2.notifications.Notification;
+import org.graylog2.notifications.NotificationImpl;
+import org.graylog2.notifications.NotificationService;
+import org.graylog2.plugin.BaseConfiguration;
+import org.graylog2.plugin.KafkaJournalConfiguration;
+import org.graylog2.plugin.ServerStatus;
+import org.joda.time.DateTime;
+import org.joda.time.DateTimeUtils;
+import org.joda.time.DateTimeZone;
+import org.joda.time.Duration;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.Spy;
+import org.mockito.junit.MockitoJUnit;
+import org.mockito.junit.MockitoRule;
+
+import java.io.File;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
+
+public class KafkaJournalDiskCheckPeriodicalTest {
+    private static final DateTime TIME = new DateTime(2017, 10, 11, 0, 0, DateTimeZone.UTC);
+
+    @Rule
+    public final MockitoRule mockitoRule = MockitoJUnit.rule();
+
+    @Spy
+    private BaseConfiguration baseConfiguration = new BaseConfiguration() {
+        @Override
+        public String getNodeIdFile() {
+            return "";
+        }
+    };
+    @Spy
+    private KafkaJournalConfiguration kafkaJournalConfiguration = new KafkaJournalConfiguration();
+    @Mock
+    private ServerStatus serverStatus;
+    @Mock
+    private Node node;
+    @Mock
+    private NotificationService notificationService;
+
+    @Before
+    public void setUp() throws Exception {
+        DateTimeUtils.setCurrentMillisFixed(TIME.getMillis());
+    }
+
+    @After
+    public void tearDown() {
+        DateTimeUtils.setCurrentMillisSystem();
+    }
+
+    @Test
+    public void doRun_sets_lifecycle_status_DEAD_if_disk_is_full() throws Exception {
+        final File mockJournalDir = mock(File.class);
+        when(mockJournalDir.getTotalSpace()).thenReturn(100L);
+        when(mockJournalDir.getFreeSpace()).thenReturn(1L);
+        when(mockJournalDir.getAbsolutePath()).thenReturn("/foo/bar");
+        when(kafkaJournalConfiguration.getMessageJournalDir()).thenReturn(mockJournalDir);
+        when(kafkaJournalConfiguration.getMessageJournalCheckDiskFreePercent()).thenReturn(5);
+        when(notificationService.buildNow()).thenReturn(new NotificationImpl().addTimestamp(TIME));
+
+        final KafkaJournalDiskCheckPeriodical periodical = new KafkaJournalDiskCheckPeriodical(baseConfiguration, kafkaJournalConfiguration, serverStatus, node, notificationService);
+        periodical.run();
+
+        ArgumentCaptor<Notification> notificationArgument = ArgumentCaptor.forClass(Notification.class);
+        verify(notificationService, times(1)).publishIfFirst(notificationArgument.capture());
+        verify(serverStatus, times(1)).overrideLoadBalancerDead();
+
+        final Notification notification = notificationArgument.getValue();
+        assertThat(notification).isNotNull();
+        assertThat(notification.getType()).isEqualTo(Notification.Type.JOURNAL_INSUFFICIENT_DISK_SPACE);
+        assertThat(notification.getSeverity()).isEqualTo(Notification.Severity.URGENT);
+        assertThat(notification.getTimestamp()).isEqualTo(TIME);
+        assertThat(notification.getDetail("journal_dir")).isEqualTo("/foo/bar");
+        assertThat(notification.getDetail("disk_total_bytes")).isEqualTo(100L);
+        assertThat(notification.getDetail("disk_free_bytes")).isEqualTo(1L);
+        assertThat(notification.getDetail("disk_free_percent")).isEqualTo(1L);
+    }
+
+    @Test
+    public void doRun_does_nothing_if_disk_is_free() throws Exception {
+        final File mockJournalDir = mock(File.class);
+        when(mockJournalDir.getTotalSpace()).thenReturn(100L);
+        when(mockJournalDir.getFreeSpace()).thenReturn(50L);
+        when(mockJournalDir.getAbsolutePath()).thenReturn("/foo/bar");
+        when(kafkaJournalConfiguration.getMessageJournalDir()).thenReturn(mockJournalDir);
+        when(kafkaJournalConfiguration.getMessageJournalCheckDiskFreePercent()).thenReturn(5);
+
+        final KafkaJournalDiskCheckPeriodical periodical = new KafkaJournalDiskCheckPeriodical(baseConfiguration, kafkaJournalConfiguration, serverStatus, node, notificationService);
+        periodical.run();
+
+        verifyNoMoreInteractions(serverStatus, notificationService);
+    }
+
+    @Test
+    public void runsForever() throws Exception {
+        final KafkaJournalDiskCheckPeriodical periodical = new KafkaJournalDiskCheckPeriodical(baseConfiguration, kafkaJournalConfiguration, serverStatus, node, notificationService);
+        assertThat(periodical.runsForever()).isFalse();
+    }
+
+    @Test
+    public void stopOnGracefulShutdown() throws Exception {
+        final KafkaJournalDiskCheckPeriodical periodical = new KafkaJournalDiskCheckPeriodical(baseConfiguration, kafkaJournalConfiguration, serverStatus, node, notificationService);
+        assertThat(periodical.stopOnGracefulShutdown()).isTrue();
+    }
+
+    @Test
+    public void masterOnly() throws Exception {
+        final KafkaJournalDiskCheckPeriodical periodical = new KafkaJournalDiskCheckPeriodical(baseConfiguration, kafkaJournalConfiguration, serverStatus, node, notificationService);
+        assertThat(periodical.masterOnly()).isFalse();
+    }
+
+    @Test
+    public void startOnThisNode() throws Exception {
+        when(baseConfiguration.isMessageJournalEnabled()).thenReturn(true);
+        when(kafkaJournalConfiguration.isMessageJournalCheckEnabled()).thenReturn(true);
+        final KafkaJournalDiskCheckPeriodical periodical = new KafkaJournalDiskCheckPeriodical(baseConfiguration, kafkaJournalConfiguration, serverStatus, node, notificationService);
+        assertThat(periodical.startOnThisNode()).isTrue();
+    }
+
+    @Test
+    public void startOnThisNode_returns_false_if_journal_is_disabled() throws Exception {
+        when(baseConfiguration.isMessageJournalEnabled()).thenReturn(false);
+        when(kafkaJournalConfiguration.isMessageJournalCheckEnabled()).thenReturn(true);
+        final KafkaJournalDiskCheckPeriodical periodical = new KafkaJournalDiskCheckPeriodical(baseConfiguration, kafkaJournalConfiguration, serverStatus, node, notificationService);
+        assertThat(periodical.startOnThisNode()).isFalse();
+    }
+
+    @Test
+    public void startOnThisNode_returns_false_if_check_is_disabled() throws Exception {
+        when(baseConfiguration.isMessageJournalEnabled()).thenReturn(true);
+        when(kafkaJournalConfiguration.isMessageJournalCheckEnabled()).thenReturn(false);
+        final KafkaJournalDiskCheckPeriodical periodical = new KafkaJournalDiskCheckPeriodical(baseConfiguration, kafkaJournalConfiguration, serverStatus, node, notificationService);
+        assertThat(periodical.startOnThisNode()).isFalse();
+    }
+
+    @Test
+    public void isDaemon() throws Exception {
+        final KafkaJournalDiskCheckPeriodical periodical = new KafkaJournalDiskCheckPeriodical(baseConfiguration, kafkaJournalConfiguration, serverStatus, node, notificationService);
+        assertThat(periodical.isDaemon()).isTrue();
+    }
+
+    @Test
+    public void getInitialDelaySeconds() throws Exception {
+        final KafkaJournalDiskCheckPeriodical periodical = new KafkaJournalDiskCheckPeriodical(baseConfiguration, kafkaJournalConfiguration, serverStatus, node, notificationService);
+        assertThat(periodical.getInitialDelaySeconds()).isEqualTo(60);
+    }
+
+    @Test
+    public void getPeriodSeconds() throws Exception {
+        when(kafkaJournalConfiguration.getMessageJournalCheckInterval()).thenReturn(Duration.standardMinutes(23L));
+        final KafkaJournalDiskCheckPeriodical periodical = new KafkaJournalDiskCheckPeriodical(baseConfiguration, kafkaJournalConfiguration, serverStatus, node, notificationService);
+        assertThat(periodical.getPeriodSeconds()).isEqualTo(23 * 60);
+    }
+
+    @Test
+    public void getLogger() throws Exception {
+        final KafkaJournalDiskCheckPeriodical periodical = new KafkaJournalDiskCheckPeriodical(baseConfiguration, kafkaJournalConfiguration, serverStatus, node, notificationService);
+        assertThat(periodical.getLogger()).isNotNull();
+    }
+}

--- a/misc/graylog.conf
+++ b/misc/graylog.conf
@@ -423,6 +423,27 @@ message_journal_dir = data/journal
 #message_journal_segment_age = 1h
 #message_journal_segment_size = 100mb
 
+# Enable the periodical disk space check for the journal directory.
+#
+# The disk space check for the journal directory periodically checks that the disk hosting the message journal
+# (also see $message_journal_dir) has enough free disk space.
+# If the free disk space drops below the configured limit (see $message_journal_check_disk_free_percent),
+# Graylog will create an urgend system notification for the administrator and set the load-balancer status of
+# this node to DEAD (see http://docs.graylog.org/en/2.3/pages/configuration/load_balancers.html).
+#
+# Default: true
+#message_journal_check_enabled = true
+
+# Time interval for Graylog to perform disk space checks for the journal directory.
+#
+# Default: 10 minutes
+#message_journal_check_interval = 10m
+
+# Minimum free disk space (in percent) for the journal directory.
+#
+# Default: 5
+#message_journal_check_disk_free_percent = 5
+
 # Number of threads used exclusively for dispatching internal events. Default is 2.
 #async_eventbus_processors = 2
 

--- a/misc/graylog.conf
+++ b/misc/graylog.conf
@@ -434,6 +434,11 @@ message_journal_dir = data/journal
 # Default: true
 #message_journal_check_enabled = true
 
+# Stop local inputs if there is not sufficient disk space left for the journal.
+#
+# Default: true
+#message_journal_check_stop_inputs = true
+
 # Time interval for Graylog to perform disk space checks for the journal directory.
 #
 # Default: 10 minutes


### PR DESCRIPTION
Users regularly run into problems with their Graylog setups due to the disk journal filling up the whole disk and thus corrupting the journal.

This change set adds a periodical which checks the available disk space in the journal directory and if it's insufficient, creates an urgent system notification and switches the load-balancer status of the Graylog node to DEAD.