### PR TITLE
remove "alt key submits" functionality from histogram

### DIFF
--- a/graylog2-web-interface/src/legacy/Rickshaw.Graph.Graylog2Selector.js
+++ b/graylog2-web-interface/src/legacy/Rickshaw.Graph.Graylog2Selector.js
@@ -110,14 +110,7 @@ const Graylog2Selector = Rickshaw.Class.create({
 
       SearchStore.changeTimeRange('absolute', { from: fromDate.toString(), to: toDate.toString() });
 
-      $('.timerange-selector-container').effect('bounce', {
-        complete() {
-                    // Submit search directly if alt key is pressed.
-          if (e.altKey) {
-            submitSearch();
-          }
-        },
-      });
+      $('.timerange-selector-container').effect('bounce');
 
       clearSelection();
     }, false);


### PR DESCRIPTION
the old jquery code could submit the search form directly when the alt key was pressed.
ever since moving to react this was broken because the code cannot submit the form anymore.
this removes the useless code to avoid a javascript error

fixes #4214
