### PR TITLE
Adjust QuickValues pie chart subtitle

### DIFF
--- a/graylog2-web-interface/src/components/field-analyzers/FieldQuickValues.jsx
+++ b/graylog2-web-interface/src/components/field-analyzers/FieldQuickValues.jsx
@@ -196,6 +196,7 @@ const FieldQuickValues = React.createClass({
       inner = (
         <div className={style.visualizationWrapper}>
           <QuickValuesVisualization id={this.state.field}
+                                    field={this.state.field}
                                     config={config}
                                     data={this.state.data}
                                     horizontal

--- a/graylog2-web-interface/src/components/visualizations/QuickValuesVisualization.jsx
+++ b/graylog2-web-interface/src/components/visualizations/QuickValuesVisualization.jsx
@@ -29,6 +29,7 @@ const QuickValuesVisualization = React.createClass({
   },
   propTypes: {
     id: PropTypes.string.isRequired,
+    field: PropTypes.string.isRequired,
     config: PropTypes.shape({
       show_pie_chart: PropTypes.bool,
       show_data_table: PropTypes.bool,
@@ -316,11 +317,11 @@ const QuickValuesVisualization = React.createClass({
     return this.state.total - this.state.missing;
   },
   _getAnalysisInformation() {
-    const analysisInformation = [`Found <em>${NumberUtils.formatNumber(this._getTotalMessagesWithField())}</em> messages with this field`];
+    const analysisInformation = [`Found <em>${NumberUtils.formatNumber(this._getTotalMessagesWithField())}</em> messages with field <em>${this.props.field}</em>`];
 
     if (this.state.missing !== 0) {
       let missingMessage = this.state.others === 0 ? ' and' : '';
-      missingMessage += ` <em>${NumberUtils.formatNumber(this.state.missing)}</em> messages without it`;
+      missingMessage += ` <em>${NumberUtils.formatNumber(this.state.missing)}</em> messages without field <em>${this.props.field}</em>`;
       analysisInformation.push(missingMessage);
     }
     if (this.state.others !== 0) {


### PR DESCRIPTION
Explicitly name the root field in the subtitle because "this field" becomes unclear once stacking is in use.

Fixes #4217

Note: This needs to be cherry picked into 2.4