### PR TITLE
Fix scroll queries using Searches#scroll()

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/indexer/IndexSetRegistry.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/IndexSetRegistry.java
@@ -48,6 +48,14 @@ public interface IndexSetRegistry extends Iterable<IndexSet> {
     Optional<IndexSet> getForIndex(String index);
 
     /**
+     * Returns the {@link IndexSet}s for the given indices.
+     *
+     * @param indices Collection with the name of the indicies
+     * @return Set of index sets which manages the given indices
+     */
+    Set<IndexSet> getForIndices(Collection<String> indices);
+
+    /**
      * Returns the {@link IndexSet} that is marked as default.
      *
      * Throws an {@link IllegalStateException} if the default index set does not exist.

--- a/graylog2-server/src/main/java/org/graylog2/indexer/MongoIndexSetRegistry.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/MongoIndexSetRegistry.java
@@ -126,6 +126,21 @@ public class MongoIndexSetRegistry implements IndexSetRegistry {
     }
 
     @Override
+    public Set<IndexSet> getForIndices(Collection<String> indices) {
+        final Set<? extends IndexSet> indexSets = findAllMongoIndexSets();
+        final ImmutableSet.Builder<IndexSet> resultBuilder = ImmutableSet.builder();
+        for (IndexSet indexSet : indexSets) {
+            for (String index : indices) {
+                if (indexSet.isManagedIndex(index)) {
+                    resultBuilder.add(indexSet);
+                }
+            }
+        }
+
+        return resultBuilder.build();
+    }
+
+    @Override
     public IndexSet getDefault() {
         return mongoIndexSetFactory.create(indexSetService.getDefault());
     }

--- a/graylog2-server/src/test/java/org/graylog2/indexer/searches/SearchesIT.java
+++ b/graylog2-server/src/test/java/org/graylog2/indexer/searches/SearchesIT.java
@@ -31,6 +31,7 @@ import org.graylog2.ElasticsearchBase;
 import org.graylog2.buffers.processors.fakestreams.FakeStream;
 import org.graylog2.indexer.IndexHelper;
 import org.graylog2.indexer.IndexSet;
+import org.graylog2.indexer.IndexSetRegistry;
 import org.graylog2.indexer.TestIndexSet;
 import org.graylog2.indexer.indexset.IndexSetConfig;
 import org.graylog2.indexer.indices.Indices;
@@ -152,6 +153,9 @@ public class SearchesIT extends ElasticsearchBase {
     @Mock
     private Indices indices;
 
+    @Mock
+    private IndexSetRegistry indexSetRegistry;
+
     private MetricRegistry metricRegistry;
     private Searches searches;
 
@@ -174,6 +178,7 @@ public class SearchesIT extends ElasticsearchBase {
             metricRegistry,
             streamService,
             indices,
+            indexSetRegistry,
             client(),
             new ScrollResult.Factory() {
                 @Override
@@ -766,5 +771,23 @@ public class SearchesIT extends ElasticsearchBase {
         assertThat(searchResult).isNotNull();
         assertThat(searchResult.getResults()).hasSize(1);
         assertThat(searchResult.getTotalResults()).isEqualTo(10L);
+    }
+
+    @Test
+    @UsingDataSet(loadStrategy = LoadStrategyEnum.CLEAN_INSERT)
+    public void scrollReturnsResultWithSelectiveFields() throws Exception {
+        when(indexSetRegistry.getForIndices(Collections.singleton("graylog_0"))).thenReturn(Collections.singleton(indexSet));
+        final AbsoluteRange range = AbsoluteRange.create(new DateTime(2015, 1, 1, 0, 0, DateTimeZone.UTC).withZone(UTC), new DateTime(2015, 1, 2, 0, 0, DateTimeZone.UTC).withZone(UTC));
+        final ScrollResult scrollResult = searches.scroll("*", range, 5, 0, Collections.singletonList("source"), null);
+
+        assertThat(scrollResult).isNotNull();
+        assertThat(scrollResult.getQueryHash()).isNotEmpty();
+        assertThat(scrollResult.totalHits()).isEqualTo(10L);
+
+        final ScrollResult.ScrollChunk firstChunk = scrollResult.nextChunk();
+        assertThat(firstChunk).isNotNull();
+        assertThat(firstChunk.getMessages()).hasSize(5);
+        assertThat(firstChunk.isFirstChunk()).isTrue();
+        assertThat(firstChunk.getFields()).containsExactly("source");
     }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -94,7 +94,7 @@
         <disruptor.version>3.3.6</disruptor.version>
         <drools.version>6.5.0.Final</drools.version>
         <elasticsearch.version>2.4.4</elasticsearch.version>
-        <jest.version>2.4.9+jackson</jest.version>
+        <jest.version>2.4.10+jackson</jest.version>
         <gelfclient.version>1.4.1</gelfclient.version>
         <grok.version>0.1.7-graylog</grok.version>
         <guava-retrying.version>2.0.0</guava-retrying.version>


### PR DESCRIPTION
Scroll queries were broken for a number of different reasons:

* The fork of Jest used by Graylog had a bug regarding scroll queries (searchbox-io/Jest#489, searchbox-io/Jest#491)
* The Elasticsearch Multi Search API doesn't support scroll queries (elastic/elasticsearch#18454)

Due to the default HTTP request length limit of Elasticsearch, `Search#scroll()` resolves the affected index sets and uses the index wildcards instead of separate index names.

Fixes #4190