### PR TITLE
Minor lookup table fixes

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/lookup/adapters/dsvhttp/DSVParser.java
+++ b/graylog2-server/src/main/java/org/graylog2/lookup/adapters/dsvhttp/DSVParser.java
@@ -1,16 +1,16 @@
 /**
  * This file is part of Graylog.
- * <p>
+ *
  * Graylog is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
- * <p>
+ *
  * Graylog is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
- * <p>
+ *
  * You should have received a copy of the GNU General Public License
  * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
  */

--- a/graylog2-server/src/main/java/org/graylog2/lookup/adapters/dsvhttp/DSVParser.java
+++ b/graylog2-server/src/main/java/org/graylog2/lookup/adapters/dsvhttp/DSVParser.java
@@ -1,16 +1,16 @@
 /**
  * This file is part of Graylog.
- *
+ * <p>
  * Graylog is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
- *
+ * <p>
  * Graylog is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
- *
+ * <p>
  * You should have received a copy of the GNU General Public License
  * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
  */
@@ -23,35 +23,42 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.Optional;
 
+/**
+ * The main difference to using a CSVReader is that this explicitly handles comment lines and does not support
+ * a column name line.
+ */
 public class DSVParser {
     private final String ignorechar;
     private final String lineSeparator;
-    private final String separator;
     private final String quoteChar;
-    private final Boolean keyOnly;
-    private final Boolean caseInsensitive;
-    private final Integer keyColumn;
-    private final Optional<Integer> valueColumn;
-    
+    private final boolean keyOnly;
+    private final boolean caseInsensitive;
+    private final int keyColumn;
+    private final int valueColumn;
+
     private final String splitPattern;
 
     public DSVParser(String ignorechar,
                      String lineSeparator,
                      String separator,
                      String quoteChar,
-                     Boolean keyOnly,
-                     Boolean caseInsensitive,
-                     Integer keyColumn,
-                     Optional<Integer> valueColumn) {
+                     boolean keyOnly,
+                     boolean caseInsensitive,
+                     int keyColumn,
+                     @SuppressWarnings("OptionalUsedAsFieldOrParameterType") Optional<Integer> valueColumn) {
 
         this.ignorechar = ignorechar;
         this.lineSeparator = lineSeparator;
-        this.separator = separator;
         this.quoteChar = quoteChar;
         this.keyOnly = keyOnly;
         this.caseInsensitive = caseInsensitive;
         this.keyColumn = keyColumn;
-        this.valueColumn = valueColumn;
+        this.valueColumn = valueColumn.orElse(0);
+
+        if (!keyOnly) {
+            //noinspection ResultOfMethodCallIgnored
+            valueColumn.orElseThrow(() -> new IllegalStateException("No value column and not key only parsing specified!"));
+        }
 
         if (Strings.isNullOrEmpty(quoteChar)) {
             this.splitPattern = separator;
@@ -70,11 +77,11 @@ public class DSVParser {
                 continue;
             }
             final String[] values = line.split(this.splitPattern);
-            if (values.length <= Math.max(keyColumn, keyOnly ? 0 : valueColumn.orElse(0))) {
+            if (values.length <= Math.max(keyColumn, keyOnly ? 0 : valueColumn)) {
                 continue;
             }
             final String key = this.caseInsensitive ? values[keyColumn].toLowerCase(Locale.ENGLISH) : values[keyColumn];
-            final String value = this.keyOnly ? "" : values[valueColumn.orElseThrow(() -> new IllegalStateException("No value column and not key only parsing specified!"))].trim();
+            final String value = this.keyOnly ? "" : values[valueColumn].trim();
             final String finalKey = Strings.isNullOrEmpty(quoteChar) ? key.trim() : key.trim().replaceAll("^" + quoteChar + "|" + quoteChar + "$", "");
             final String finalValue = Strings.isNullOrEmpty(quoteChar) ? value.trim() : value.trim().replaceAll("^" + quoteChar + "|" + quoteChar + "$", "");
             newLookupBuilder.put(finalKey, finalValue);

--- a/graylog2-server/src/main/java/org/graylog2/plugin/lookup/LookupCache.java
+++ b/graylog2-server/src/main/java/org/graylog2/plugin/lookup/LookupCache.java
@@ -23,6 +23,7 @@ import com.codahale.metrics.Timer;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.util.concurrent.AbstractIdleService;
 import com.google.inject.assistedinject.Assisted;
+import org.graylog2.shared.metrics.MetricUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -44,7 +45,6 @@ public abstract class LookupCache extends AbstractIdleService {
     private final Meter hitCount;
     private final Meter missCount;
     private final Timer lookupTimer;
-    private final Gauge entryCount;
 
     private AtomicReference<Throwable> error = new AtomicReference<>();
 
@@ -60,7 +60,7 @@ public abstract class LookupCache extends AbstractIdleService {
         this.hitCount = metricRegistry.meter(MetricRegistry.name("org.graylog2.lookup.caches", id, "hits"));
         this.missCount = metricRegistry.meter(MetricRegistry.name("org.graylog2.lookup.caches", id, "misses"));
         this.lookupTimer = metricRegistry.timer(MetricRegistry.name("org.graylog2.lookup.caches", id, "lookupTime"));
-        this.entryCount = metricRegistry.register(MetricRegistry.name("org.graylog2.lookup.caches", id, "entries"), () -> entryCount());
+        MetricUtils.safelyRegister(metricRegistry, MetricRegistry.name("org.graylog2.lookup.caches", id, "entries"), entryCount());
     }
 
     public void incrTotalCount() {

--- a/graylog2-web-interface/src/components/lookup-tables/adapters/index.js
+++ b/graylog2-web-interface/src/components/lookup-tables/adapters/index.js
@@ -3,7 +3,7 @@ import { PluginManifest, PluginStore } from 'graylog-web-plugin/plugin';
 import CSVFileAdapterFieldSet from './CSVFileAdapterFieldSet';
 import CSVFileAdapterSummary from './CSVFileAdapterSummary';
 import CSVFileAdapterDocumentation from './CSVFileAdapterDocumentation';
-import DSVHTTPAdapterFieldSet from './CSVFileAdapterFieldSet';
+import DSVHTTPAdapterFieldSet from './DSVHTTPAdapterFieldSet';
 import DSVHTTPAdapterSummary from './DSVHTTPAdapterSummary';
 import DSVHTTPAdapterDocumentation from './DSVHTTPAdapterDocumentation';
 import HTTPJSONPathAdapterFieldSet from './HTTPJSONPathAdapterFieldSet';


### PR DESCRIPTION
The DSV HTTP adapter used the wrong component in the frontend and its internal fields were a bit complicated.

Fix a gauge metric reregistration issue in LookupCaches.