### PR TITLE
Fix scroll queries using Searches#scroll()

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/indexer/IndexSetRegistry.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/IndexSetRegistry.java
@@ -48,6 +48,14 @@ public interface IndexSetRegistry extends Iterable<IndexSet> {
     Optional<IndexSet> getForIndex(String index);
 
     /**
+     * Returns the {@link IndexSet}s for the given indices.
+     *
+     * @param indices Collection with the name of the indicies
+     * @return Set of index sets which manages the given indices
+     */
+    Set<IndexSet> getForIndices(Collection<String> indices);
+
+    /**
      * Returns the {@link IndexSet} that is marked as default.
      *
      * Throws an {@link IllegalStateException} if the default index set does not exist.

--- a/graylog2-server/src/main/java/org/graylog2/indexer/MongoIndexSetRegistry.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/MongoIndexSetRegistry.java
@@ -126,6 +126,21 @@ public class MongoIndexSetRegistry implements IndexSetRegistry {
     }
 
     @Override
+    public Set<IndexSet> getForIndices(Collection<String> indices) {
+        final Set<? extends IndexSet> indexSets = findAllMongoIndexSets();
+        final ImmutableSet.Builder<IndexSet> resultBuilder = ImmutableSet.builder();
+        for (IndexSet indexSet : indexSets) {
+            for (String index : indices) {
+                if (indexSet.isManagedIndex(index)) {
+                    resultBuilder.add(indexSet);
+                }
+            }
+        }
+
+        return resultBuilder.build();
+    }
+
+    @Override
     public IndexSet getDefault() {
         return mongoIndexSetFactory.create(indexSetService.getDefault());
     }

--- a/pom.xml
+++ b/pom.xml
@@ -94,7 +94,7 @@
         <disruptor.version>3.3.6</disruptor.version>
         <drools.version>6.5.0.Final</drools.version>
         <elasticsearch.version>2.4.4</elasticsearch.version>
-        <jest.version>2.4.7+jackson</jest.version>
+        <jest.version>2.4.10+jackson</jest.version>
         <gelfclient.version>1.4.1</gelfclient.version>
         <grok.version>0.1.7-graylog</grok.version>
         <guava-retrying.version>2.0.0</guava-retrying.version>


### PR DESCRIPTION
Scroll queries were broken for a number of different reasons:

* The fork of Jest used by Graylog had a bug regarding scroll queries (searchbox-io/Jest#489, searchbox-io/Jest#491)
* The Elasticsearch Multi Search API doesn't support scroll queries (elastic/elasticsearch#18454)

Due to the default HTTP request length limit of Elasticsearch, `Search#scroll()` resolves the affected index sets and uses the index wildcards instead of separate index names.

Fixes #4190
Refs #4262
(cherry picked from commit 7239f158fc2782b8a2c9f907e628e0b211db9d46)