### PR TITLE
3.0 changes

### DIFF
--- a/graylog2-web-interface/src/components/alarmcallbacks/AlarmCallbackHistoryOverview.jsx
+++ b/graylog2-web-interface/src/components/alarmcallbacks/AlarmCallbackHistoryOverview.jsx
@@ -1,15 +1,16 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 import Reflux from 'reflux';
-import moment from 'moment';
 import { Row, Col } from 'react-bootstrap';
 
 import CombinedProvider from 'injection/CombinedProvider';
-const { AlarmCallbackHistoryStore } = CombinedProvider.get('AlarmCallbackHistory');
-const { AlertNotificationsStore } = CombinedProvider.get('AlertNotifications');
+import { sortByDate } from 'util/SortUtils';
 
 import { EntityList, Spinner } from 'components/common';
 import { AlarmCallbackHistory } from 'components/alarmcallbacks';
+
+const { AlarmCallbackHistoryStore } = CombinedProvider.get('AlarmCallbackHistory');
+const { AlertNotificationsStore } = CombinedProvider.get('AlertNotifications');
 
 const AlarmCallbackHistoryOverview = React.createClass({
   propTypes: {
@@ -33,12 +34,7 @@ const AlarmCallbackHistoryOverview = React.createClass({
     }
 
     const histories = this.state.histories
-      .sort((h1, h2) => {
-        const h1Time = moment(h1.created_at);
-        const h2Time = moment(h2.created_at);
-
-        return (h1Time.isBefore(h2Time) ? -1 : h2Time.isBefore(h1Time) ? 1 : 0);
-      })
+      .sort((h1, h2) => sortByDate(h1.created_at, h2.created_at))
       .map(this._formatHistory);
     return (
       <Row>

--- a/graylog2-web-interface/src/components/alerts/AlertTimeline.jsx
+++ b/graylog2-web-interface/src/components/alerts/AlertTimeline.jsx
@@ -1,15 +1,15 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 import Reflux from 'reflux';
-import moment from 'moment';
 
 import { Spinner, Timestamp } from 'components/common';
 
 import CombinedProvider from 'injection/CombinedProvider';
-const { AlarmCallbackHistoryStore } = CombinedProvider.get('AlarmCallbackHistory');
-const { AlertNotificationsStore } = CombinedProvider.get('AlertNotifications');
+import { sortByDate } from 'util/SortUtils';
 
 import style from './AlertTimeline.css';
+const { AlarmCallbackHistoryStore } = CombinedProvider.get('AlarmCallbackHistory');
+const { AlertNotificationsStore } = CombinedProvider.get('AlertNotifications');
 
 const AlertTimeline = React.createClass({
   propTypes: {
@@ -36,12 +36,7 @@ const AlertTimeline = React.createClass({
     }
 
     this.state.histories
-      .sort((h1, h2) => {
-        const h1Time = moment(h1.created_at);
-        const h2Time = moment(h2.created_at);
-
-        return (h1Time.isBefore(h2Time) ? -1 : h2Time.isBefore(h1Time) ? 1 : 0);
-      })
+      .sort((h1, h2) => sortByDate(h1.created_at, h2.created_at))
       .forEach((history) => {
         const configuration = history.alarmcallbackconfiguration;
         const type = this.state.availableNotifications[configuration.type];

--- a/graylog2-web-interface/src/components/common/ReactGridContainer.jsx
+++ b/graylog2-web-interface/src/components/common/ReactGridContainer.jsx
@@ -38,6 +38,7 @@ const ReactGridContainer = React.createClass({
     isResizable: PropTypes.bool,
     rowHeight: PropTypes.number,
     columns: PropTypes.object,
+    animate: PropTypes.bool,
   },
 
   getDefaultProps() {
@@ -46,6 +47,7 @@ const ReactGridContainer = React.createClass({
       isResizable: true,
       rowHeight: ROW_HEIGHT,
       columns: COLUMNS,
+      animate: true,
     };
   },
 
@@ -65,7 +67,7 @@ const ReactGridContainer = React.createClass({
   },
 
   render() {
-    const { children, locked, isResizable, positions, rowHeight, columns } = this.props;
+    const { children, locked, isResizable, positions, rowHeight, columns, animate } = this.props;
     const layout = Object.keys(positions).map((id) => {
       const { col, row, height, width } = positions[id];
       return {
@@ -88,6 +90,7 @@ const ReactGridContainer = React.createClass({
                                     margin={[10, 10]}
                                     onDragStop={this._onLayoutChange}
                                     onResizeStop={this._onLayoutChange}
+                                    useCSSTransforms={animate}
                                     draggableHandle={locked ? '.no-handle' : ''}>
         {children}
       </WidthAdjustedReactGridLayout>

--- a/graylog2-web-interface/src/components/common/ReactGridContainer.jsx
+++ b/graylog2-web-interface/src/components/common/ReactGridContainer.jsx
@@ -37,6 +37,7 @@ const ReactGridContainer = React.createClass({
     locked: PropTypes.bool,
     isResizable: PropTypes.bool,
     rowHeight: PropTypes.number,
+    columns: PropTypes.object,
   },
 
   getDefaultProps() {
@@ -44,6 +45,7 @@ const ReactGridContainer = React.createClass({
       locked: false,
       isResizable: true,
       rowHeight: ROW_HEIGHT,
+      columns: COLUMNS,
     };
   },
 
@@ -63,7 +65,7 @@ const ReactGridContainer = React.createClass({
   },
 
   render() {
-    const { children, locked, isResizable, positions, rowHeight } = this.props;
+    const { children, locked, isResizable, positions, rowHeight, columns } = this.props;
     const layout = Object.keys(positions).map((id) => {
       const { col, row, height, width } = positions[id];
       return {
@@ -81,7 +83,7 @@ const ReactGridContainer = React.createClass({
       <WidthAdjustedReactGridLayout className={`${style.reactGridLayout} ${locked || !isResizable ? 'locked' : 'unlocked'}`}
                                     layouts={{ xxl: layout, xl: layout, lg: layout, md: layout, sm: layout, xs: layout }}
                                     breakpoints={BREAKPOINTS}
-                                    cols={COLUMNS}
+                                    cols={columns}
                                     rowHeight={rowHeight}
                                     margin={[10, 10]}
                                     onDragStop={this._onLayoutChange}

--- a/graylog2-web-interface/src/components/common/ReactGridContainer.jsx
+++ b/graylog2-web-interface/src/components/common/ReactGridContainer.jsx
@@ -35,8 +35,8 @@ const ReactGridContainer = React.createClass({
     children: PropTypes.node.isRequired,
     onPositionsChange: PropTypes.func.isRequired,
     locked: PropTypes.bool,
-    isResizable: React.PropTypes.bool,
-    rowHeight: React.PropTypes.number,
+    isResizable: PropTypes.bool,
+    rowHeight: PropTypes.number,
   },
 
   getDefaultProps() {
@@ -63,7 +63,7 @@ const ReactGridContainer = React.createClass({
   },
 
   render() {
-    const { children, locked, isResizable, positions, rowHeight } = this.props;
+    const { children, locked, positions, rowHeight } = this.props;
     const layout = Object.keys(positions).map((id) => {
       const { col, row, height, width } = positions[id];
       return {

--- a/graylog2-web-interface/src/components/common/ReactGridContainer.jsx
+++ b/graylog2-web-interface/src/components/common/ReactGridContainer.jsx
@@ -63,7 +63,7 @@ const ReactGridContainer = React.createClass({
   },
 
   render() {
-    const { children, locked, positions, rowHeight } = this.props;
+    const { children, locked, isResizable, positions, rowHeight } = this.props;
     const layout = Object.keys(positions).map((id) => {
       const { col, row, height, width } = positions[id];
       return {

--- a/graylog2-web-interface/src/components/visualizations/GraphVisualization.jsx
+++ b/graylog2-web-interface/src/components/visualizations/GraphVisualization.jsx
@@ -71,7 +71,9 @@ const GraphVisualization = React.createClass({
     }).isRequired,
     height: PropTypes.number,
     width: PropTypes.number,
+    onRenderComplete: React.PropTypes.func,
   },
+
   statics: {
     getReadableFieldChartStatisticalFunction(statisticalFunction) {
       switch (statisticalFunction) {
@@ -84,6 +86,13 @@ const GraphVisualization = React.createClass({
       }
     },
   },
+
+  getDefaultProps() {
+    return {
+      onRenderComplete: () => {},
+    };
+  },
+
   getInitialState() {
     this.triggerRender = true;
     this.graphData = crossfilter();
@@ -262,6 +271,8 @@ const GraphVisualization = React.createClass({
       .yAxisLabel(this.props.config.field)
       .renderTitle(false)
       .colors(D3Utils.glColourPalette());
+
+    this.graph.on('postRender', this.props.onRenderComplete);
 
     $(graphDomNode).tooltip({
       selector: '[rel="tooltip"]',

--- a/graylog2-web-interface/src/components/visualizations/GraphVisualization.jsx
+++ b/graylog2-web-interface/src/components/visualizations/GraphVisualization.jsx
@@ -267,7 +267,7 @@ const GraphVisualization = React.createClass({
     });
   },
   renderGraph() {
-    const graphDomNode = ReactDOM.findDOMNode(this);
+    const graphDomNode = this._graph;
     const interactive = this.props.interactive;
 
     this.graph = GraphFactory.create(this.props.config, graphDomNode, interactive, this._formatTooltipTitle);
@@ -311,7 +311,8 @@ const GraphVisualization = React.createClass({
   },
   render() {
     return (
-      <div id={`visualization-${this.props.id}`} className={`graph ${this.props.config.renderer}`} />
+      <div ref={(c) => { this._graph = c; }} id={`visualization-${this.props.id}`}
+           className={`graph ${this.props.config.renderer}`} />
     );
   },
 });

--- a/graylog2-web-interface/src/components/visualizations/GraphVisualization.jsx
+++ b/graylog2-web-interface/src/components/visualizations/GraphVisualization.jsx
@@ -21,30 +21,35 @@ global.jQuery = $;
 require('bootstrap/js/tooltip');
 
 const GraphFactory = {
-  create(config, domNode, tooltipTitleFormatter) {
+  create(config, domNode, renderTooltip, tooltipTitleFormatter) {
     let graph;
+    let tooltipSelector;
     switch (config.renderer) {
       case 'line':
         graph = dc.lineChart(domNode);
-        D3Utils.tooltipRenderlet(graph, '.chart-body circle.dot', tooltipTitleFormatter);
+        tooltipSelector = '.chart-body circle.dot';
         break;
       case 'area':
         graph = dc.lineChart(domNode);
         graph.renderArea(true);
-        D3Utils.tooltipRenderlet(graph, '.chart-body circle.dot', tooltipTitleFormatter);
+        tooltipSelector = '.chart-body circle.dot';
         break;
       case 'bar':
         graph = dc.barChart(domNode);
         graph.centerBar(true);
-        D3Utils.tooltipRenderlet(graph, '.chart-body rect.bar', tooltipTitleFormatter);
+        tooltipSelector = '.chart-body rect.bar';
         break;
       case 'scatterplot':
         graph = dc.lineChart(domNode);
         graph.renderDataPoints({ radius: 2, fillOpacity: 1, strokeOpacity: 1 });
-        D3Utils.tooltipRenderlet(graph, '.chart-body circle.dot', tooltipTitleFormatter);
+        tooltipSelector = '.chart-body circle.dot';
         break;
       default:
         throw new Error(`Unsupported renderer '${config.renderer}'`);
+    }
+
+    if (renderTooltip && tooltipSelector) {
+      D3Utils.tooltipRenderlet(graph, tooltipSelector, tooltipTitleFormatter);
     }
 
     if (config.renderer === 'line' || config.renderer === 'area') {
@@ -71,7 +76,8 @@ const GraphVisualization = React.createClass({
     }).isRequired,
     height: PropTypes.number,
     width: PropTypes.number,
-    onRenderComplete: React.PropTypes.func,
+    interactive: PropTypes.bool,
+    onRenderComplete: PropTypes.func,
   },
 
   statics: {
@@ -89,6 +95,7 @@ const GraphVisualization = React.createClass({
 
   getDefaultProps() {
     return {
+      interactive: true,
       onRenderComplete: () => {},
     };
   },
@@ -104,6 +111,8 @@ const GraphVisualization = React.createClass({
     };
   },
   componentDidMount() {
+    this.disableTransitions = dc.disableTransitions;
+    dc.disableTransitions = !this.props.interactive;
     this.renderGraph();
     this._updateData(this.props.data, this.props.config, this.props.computationTimeRange);
   },
@@ -120,6 +129,11 @@ const GraphVisualization = React.createClass({
     }
     this._updateData(nextProps.data, nextProps.config, nextProps.computationTimeRange);
   },
+
+  componentWillUnmount() {
+    dc.disableTransitions = this.disableTransitions;
+  },
+
   _updateData(data, config, computationTimeRange) {
     const isSearchAll = (config.timerange.type === 'relative' && config.timerange.range === 0);
     const dataPoints = HistogramFormatter.format(data, computationTimeRange,
@@ -254,8 +268,9 @@ const GraphVisualization = React.createClass({
   },
   renderGraph() {
     const graphDomNode = ReactDOM.findDOMNode(this);
+    const interactive = this.props.interactive;
 
-    this.graph = GraphFactory.create(this.props.config, graphDomNode, this._formatTooltipTitle);
+    this.graph = GraphFactory.create(this.props.config, graphDomNode, interactive, this._formatTooltipTitle);
     this.graph
       .width(this.props.width)
       .height(this.props.height)
@@ -274,13 +289,15 @@ const GraphVisualization = React.createClass({
 
     this.graph.on('postRender', this.props.onRenderComplete);
 
-    $(graphDomNode).tooltip({
-      selector: '[rel="tooltip"]',
-      container: 'body',
-      placement: 'auto',
-      delay: { show: 300, hide: 100 },
-      html: true,
-    });
+    if (interactive) {
+      $(graphDomNode).tooltip({
+        selector: '[rel="tooltip"]',
+        container: 'body',
+        placement: 'auto',
+        delay: { show: 300, hide: 100 },
+        html: true,
+      });
+    }
 
     this.graph.xAxis()
       .ticks(graphHelper.customTickInterval())

--- a/graylog2-web-interface/src/components/visualizations/HistogramVisualization.jsx
+++ b/graylog2-web-interface/src/components/visualizations/HistogramVisualization.jsx
@@ -121,7 +121,7 @@ const HistogramVisualization = React.createClass({
   },
 
   renderHistogram() {
-    const histogramDomNode = ReactDOM.findDOMNode(this);
+    const histogramDomNode = this._graph;
     const xAxisLabel = this.props.config.xAxis || 'Time';
     const yAxisLabel = this.props.config.yAxis || 'Messages';
 
@@ -161,7 +161,7 @@ const HistogramVisualization = React.createClass({
   },
   render() {
     return (
-      <div id={`visualization-${this.props.id}`} className="histogram" />
+      <div ref={(c) => { this._graph = c; }} id={`visualization-${this.props.id}`} className="histogram" />
     );
   },
 });

--- a/graylog2-web-interface/src/components/visualizations/HistogramVisualization.jsx
+++ b/graylog2-web-interface/src/components/visualizations/HistogramVisualization.jsx
@@ -26,7 +26,15 @@ const HistogramVisualization = React.createClass({
     computationTimeRange: PropTypes.object,
     height: PropTypes.number,
     width: PropTypes.number,
+    onRenderComplete: React.PropTypes.func,
   },
+
+  getDefaultProps() {
+    return {
+      onRenderComplete: () => {},
+    };
+  },
+
   getInitialState() {
     this.triggerRender = true;
     this.histogramData = crossfilter();
@@ -112,6 +120,8 @@ const HistogramVisualization = React.createClass({
           .attr('rel', 'tooltip')
           .attr('data-original-title', formatTitle);
       });
+
+    this.histogram.on('postRender', this.props.onRenderComplete);
 
     $(histogramDomNode).tooltip({
       selector: '[rel="tooltip"]',

--- a/graylog2-web-interface/src/components/visualizations/HistogramVisualization.jsx
+++ b/graylog2-web-interface/src/components/visualizations/HistogramVisualization.jsx
@@ -26,12 +26,15 @@ const HistogramVisualization = React.createClass({
     computationTimeRange: PropTypes.object,
     height: PropTypes.number,
     width: PropTypes.number,
-    onRenderComplete: React.PropTypes.func,
+    interactive: PropTypes.bool,
+    onRenderComplete: PropTypes.func,
   },
 
   getDefaultProps() {
     return {
-      onRenderComplete: () => {},
+      interactive: true,
+      onRenderComplete: () => {
+      },
     };
   },
 
@@ -46,6 +49,8 @@ const HistogramVisualization = React.createClass({
     };
   },
   componentDidMount() {
+    this.disableTransitions = dc.disableTransitions;
+    dc.disableTransitions = !this.props.interactive;
     this.renderHistogram();
     this._updateData(this.props.data);
   },
@@ -59,6 +64,11 @@ const HistogramVisualization = React.createClass({
     }
     this._updateData(nextProps.data);
   },
+
+  componentWillUnmount() {
+    dc.disableTransitions = this.disableTransitions;
+  },
+
   _updateData(data) {
     this.setState({ dataPoints: data }, this.drawData);
   },
@@ -86,6 +96,30 @@ const HistogramVisualization = React.createClass({
       this.histogram.redraw();
     }
   },
+
+  _renderTooltip(histogram, histogramDomNode) {
+    histogram.on('renderlet', () => {
+      const formatTitle = (d) => {
+        const valueText = `${numeral(d.y).format('0,0')} messages`;
+        const keyText = `<span class="date">${new DateTime(d.x).toString(DateTime.Formats.COMPLETE)}</span>`;
+
+        return `<div class="datapoint-info">${valueText}<br>${keyText}</div>`;
+      };
+
+      d3.select(histogramDomNode).selectAll('.chart-body rect.bar')
+        .attr('rel', 'tooltip')
+        .attr('data-original-title', formatTitle);
+    });
+
+    $(histogramDomNode).tooltip({
+      selector: '[rel="tooltip"]',
+      container: 'body',
+      placement: 'auto',
+      delay: { show: 300, hide: 100 },
+      html: true,
+    });
+  },
+
   renderHistogram() {
     const histogramDomNode = ReactDOM.findDOMNode(this);
     const xAxisLabel = this.props.config.xAxis || 'Time';
@@ -107,29 +141,13 @@ const HistogramVisualization = React.createClass({
       .xAxisLabel(xAxisLabel)
       .yAxisLabel(yAxisLabel)
       .renderTitle(false)
-      .colors(D3Utils.glColourPalette())
-      .on('renderlet', () => {
-        const formatTitle = (d) => {
-          const valueText = `${numeral(d.y).format('0,0')} messages`;
-          const keyText = `<span class="date">${new DateTime(d.x).toString(DateTime.Formats.COMPLETE)}</span>`;
+      .colors(D3Utils.glColourPalette());
 
-          return `<div class="datapoint-info">${valueText}<br>${keyText}</div>`;
-        };
-
-        d3.select(histogramDomNode).selectAll('.chart-body rect.bar')
-          .attr('rel', 'tooltip')
-          .attr('data-original-title', formatTitle);
-      });
+    if (this.props.interactive) {
+      this._renderTooltip(this.histogram, histogramDomNode);
+    }
 
     this.histogram.on('postRender', this.props.onRenderComplete);
-
-    $(histogramDomNode).tooltip({
-      selector: '[rel="tooltip"]',
-      container: 'body',
-      placement: 'auto',
-      delay: { show: 300, hide: 100 },
-      html: true,
-    });
 
     this.histogram.xAxis()
       .ticks(graphHelper.customTickInterval())

--- a/graylog2-web-interface/src/components/visualizations/NumericVisualization.css
+++ b/graylog2-web-interface/src/components/visualizations/NumericVisualization.css
@@ -1,40 +1,29 @@
+:local(.container) {
+    height: 100%;
+    text-align: center;
+    padding-bottom: 30px;
+}
+
 :local(.number) {
-    display: flex;
-    justify-content: center;
+    height: 100%;
     width: 100%;
 }
 
-:local(.aside) {
-    flex: 1;
-    align-self: flex-start;
-}
-
 :local(.value) {
-    flex: 2;
+    dominant-baseline: central;
     line-height: 100px; /* Ensure changing the value font-size doesn't change the element's height */
-    text-align: center;
-}
-
-:local(.trendIndicators) {
-    font-size: 24px;
-    margin-top: 12px; /* font-size / 2 */
-    margin-left: 10px;
-}
-
-:local(.trendIndicators) > *:first-child {
-    margin-bottom: 5px;
+    text-anchor: middle;
 }
 
 :local(.trendIcon) {
-    color: #E3E5E5;
-    height: 25px;
-    margin-bottom: -18px;
+    stroke: #E3E5E5;
+    fill: none;
 }
 
 :local(.trendGood) {
-    color: #8DC63F;
+    stroke: #8DC63F;
 }
 
 :local(.trendBad) {
-    color: #BE1E2D;
+    stroke: #BE1E2D;
 }

--- a/graylog2-web-interface/src/components/visualizations/NumericVisualization.css
+++ b/graylog2-web-interface/src/components/visualizations/NumericVisualization.css
@@ -8,22 +8,3 @@
     height: 100%;
     width: 100%;
 }
-
-:local(.value) {
-    dominant-baseline: central;
-    line-height: 100px; /* Ensure changing the value font-size doesn't change the element's height */
-    text-anchor: middle;
-}
-
-:local(.trendIcon) {
-    stroke: #E3E5E5;
-    fill: none;
-}
-
-:local(.trendGood) {
-    stroke: #8DC63F;
-}
-
-:local(.trendBad) {
-    stroke: #BE1E2D;
-}

--- a/graylog2-web-interface/src/components/visualizations/NumericVisualization.css
+++ b/graylog2-web-interface/src/components/visualizations/NumericVisualization.css
@@ -1,7 +1,7 @@
 :local(.container) {
     height: 100%;
     text-align: center;
-    padding-bottom: 30px;
+    padding-bottom: 10px;
 }
 
 :local(.number) {

--- a/graylog2-web-interface/src/components/visualizations/NumericVisualization.css
+++ b/graylog2-web-interface/src/components/visualizations/NumericVisualization.css
@@ -8,3 +8,8 @@
     height: 100%;
     width: 100%;
 }
+
+:local(.value) {
+    dominant-baseline: central;
+    text-anchor: middle;
+}

--- a/graylog2-web-interface/src/components/visualizations/NumericVisualization.jsx
+++ b/graylog2-web-interface/src/components/visualizations/NumericVisualization.jsx
@@ -18,7 +18,15 @@ const NumericVisualization = React.createClass({
       PropTypes.object,
       PropTypes.number,
     ]).isRequired,
+    onRenderComplete: React.PropTypes.func,
   },
+
+  getDefaultProps() {
+    return {
+      onRenderComplete: () => {},
+    };
+  },
+
   getInitialState() {
     return {
       currentNumber: undefined,
@@ -26,20 +34,24 @@ const NumericVisualization = React.createClass({
     };
   },
   componentDidMount() {
-    const state = this._normalizeStateFromProps(this.props.data);
-    this.setState(state);
+    this._updateData(this.props.data, this.props.onRenderComplete);
   },
   componentWillReceiveProps(nextProps) {
     if (deepEqual(this.props, nextProps)) {
       return;
     }
-
-    const state = this._normalizeStateFromProps(nextProps.data);
-    this.setState(state);
+    this._updateData(nextProps.data, this.props.onRenderComplete);
   },
+
   DEFAULT_VALUE_FONT_SIZE: '70px',
   NUMBER_OF_INDICATORS: 3,
   PERCENTAGE_PER_INDICATOR: 30,
+
+  _updateData(data, renderCallback) {
+    const state = this._normalizeStateFromProps(data);
+    this.setState(state, renderCallback);
+  },
+
   _normalizeStateFromProps(props) {
     let state = {};
     if (typeof props === 'object') {

--- a/graylog2-web-interface/src/components/visualizations/NumericVisualization.jsx
+++ b/graylog2-web-interface/src/components/visualizations/NumericVisualization.jsx
@@ -17,6 +17,7 @@ const TREND_ICON_BAD_COLOR = '#BE1E2D';
 
 const NumericVisualization = React.createClass({
   propTypes: {
+    id: PropTypes.string.isRequired,
     config: PropTypes.object.isRequired,
     data: PropTypes.oneOfType([
       PropTypes.object,
@@ -170,7 +171,7 @@ const NumericVisualization = React.createClass({
     };
   },
   render() {
-    const { config, width, height } = this.props;
+    const { id, config, width, height } = this.props;
 
     let trendIndicators;
 
@@ -192,7 +193,7 @@ const NumericVisualization = React.createClass({
     }
 
     return (
-      <div className={style.container}>
+      <div id={`visualization-${id}`} className={style.container}>
         <svg viewBox="0 0 300 100" className={style.number} width={width} height={height}>
           <defs>
             <path id="text-baseline" d="M0 45 H300" />

--- a/graylog2-web-interface/src/components/visualizations/NumericVisualization.jsx
+++ b/graylog2-web-interface/src/components/visualizations/NumericVisualization.jsx
@@ -194,7 +194,7 @@ const NumericVisualization = React.createClass({
 
     return (
       <div id={`visualization-${id}`} className={style.container}>
-        <svg viewBox="0 0 300 100" className={style.number} width={width} height={height}>
+        <svg viewBox="0 0 300 100" className={style.number} width="100%" height="100%" style={{ height: height, width: width }}>
           <defs>
             <path id="text-baseline" d="M0 45 H300" />
           </defs>

--- a/graylog2-web-interface/src/components/visualizations/NumericVisualization.jsx
+++ b/graylog2-web-interface/src/components/visualizations/NumericVisualization.jsx
@@ -23,7 +23,8 @@ const NumericVisualization = React.createClass({
 
   getDefaultProps() {
     return {
-      onRenderComplete: () => {},
+      onRenderComplete: () => {
+      },
     };
   },
 
@@ -43,7 +44,7 @@ const NumericVisualization = React.createClass({
     this._updateData(nextProps.data, this.props.onRenderComplete);
   },
 
-  DEFAULT_VALUE_FONT_SIZE: '70px',
+  DEFAULT_VALUE_FONT_SIZE: '60px',
   NUMBER_OF_INDICATORS: 3,
   PERCENTAGE_PER_INDICATOR: 30,
 
@@ -90,17 +91,17 @@ const NumericVisualization = React.createClass({
     }
 
     let fontSize;
-    const numberOfDigits = this._formatData().replace(/[,.]/g, '').length;
+    const formattedLength = this._formatData().length;
 
-    if (numberOfDigits < 7) {
+    if (formattedLength < 7) {
       fontSize = this.DEFAULT_VALUE_FONT_SIZE;
     } else {
-      switch (numberOfDigits) {
+      switch (formattedLength) {
         case 7:
-          fontSize = '60px';
+          fontSize = '50px';
           break;
         case 8:
-          fontSize = '50px';
+          fontSize = '45px';
           break;
         case 9:
         case 10:
@@ -160,42 +161,29 @@ const NumericVisualization = React.createClass({
 
     if (this.props.config.trend) {
       trendIndicators = (
-        <div className={style.trendIndicators}>
-          <div>
-            <div className={this._getHigherIndicatorClass(0)}>
-              <span><i className="fa fa-angle-up" /></span>
-            </div>
-            <div className={this._getHigherIndicatorClass(1)}>
-              <span><i className="fa fa-angle-up" /></span>
-            </div>
-            <div className={this._getHigherIndicatorClass(2)}>
-              <span><i className="fa fa-angle-up" /></span>
-            </div>
-          </div>
-          <div>
-            <div className={this._getLowerIndicatorClass(0)}>
-              <span><i className="fa fa-angle-down" /></span>
-            </div>
-            <div className={this._getLowerIndicatorClass(1)}>
-              <span><i className="fa fa-angle-down" /></span>
-            </div>
-            <div className={this._getLowerIndicatorClass(2)}>
-              <span><i className="fa fa-angle-down" /></span>
-            </div>
-          </div>
-        </div>
+        <g transform="translate(270,45)">
+          <g transform="translate(0,-17)">
+            <path d="M0 5 L5 0 L10 5" className={this._getHigherIndicatorClass(0)} />
+            <path d="M0 10 L5 5 L10 10" className={this._getHigherIndicatorClass(1)} />
+            <path d="M0 15 L5 10 L10 15" className={this._getHigherIndicatorClass(2)} />
+          </g>
+          <g transform="translate(0, 2) rotate(180,5,7.5)">
+            <path d="M0 5 L5 0 L10 5" className={this._getLowerIndicatorClass(2)} />
+            <path d="M0 10 L5 5 L10 10" className={this._getLowerIndicatorClass(1)} />
+            <path d="M0 15 L5 10 L10 15" className={this._getLowerIndicatorClass(0)} />
+          </g>
+        </g>
       );
     }
 
     return (
-      <div className={style.number}>
-        <div className={style.aside} />
-        <div className={style.value} style={{ fontSize: this._calculateFontSize() }}>
-          {this._formatData()}
-        </div>
-        <div className={style.aside}>
+      <div className={style.container}>
+        <svg viewBox="0 0 300 100" className={style.number}>
+          <text x="150" y="45" className={style.value} style={{ fontSize: this._calculateFontSize() }}>
+            {this._formatData()}
+          </text>
           {trendIndicators}
-        </div>
+        </svg>
       </div>
     );
   },

--- a/graylog2-web-interface/src/components/visualizations/NumericVisualization.jsx
+++ b/graylog2-web-interface/src/components/visualizations/NumericVisualization.jsx
@@ -11,6 +11,10 @@ const TrendIndicatorType = {
   LOWER: 'lower',
 };
 
+const TREND_ICON_COLOR = '#E3E5E5';
+const TREND_ICON_GOOD_COLOR = '#8DC63F';
+const TREND_ICON_BAD_COLOR = '#BE1E2D';
+
 const NumericVisualization = React.createClass({
   propTypes: {
     config: PropTypes.object.isRequired,
@@ -18,6 +22,8 @@ const NumericVisualization = React.createClass({
       PropTypes.object,
       PropTypes.number,
     ]).isRequired,
+    height: React.PropTypes.number,
+    width: React.PropTypes.number,
     onRenderComplete: React.PropTypes.func,
   },
 
@@ -135,42 +141,51 @@ const NumericVisualization = React.createClass({
     }
     return Math.abs(this.state.percentage) >= this.PERCENTAGE_PER_INDICATOR * index;
   },
-  _getIndicatorClass(index, trendIndicatorType) {
-    const className = style.trendIcon;
-
+  _getStrokeColor(index, trendIndicatorType) {
     const indicatorIsActive = this._isIndicatorActive(index, trendIndicatorType);
     if (!indicatorIsActive) {
-      return className;
+      return TREND_ICON_COLOR;
     }
 
-    const lowerClass = this.props.config.lower_is_better ? style.trendGood : style.trendBad;
-    const higherClass = this.props.config.lower_is_better ? style.trendBad : style.trendGood;
+    const lowerStroke = this.props.config.lower_is_better ? TREND_ICON_GOOD_COLOR : TREND_ICON_BAD_COLOR;
+    const higherStroke = this.props.config.lower_is_better ? TREND_ICON_BAD_COLOR : TREND_ICON_GOOD_COLOR;
 
-    const activeClass = trendIndicatorType === TrendIndicatorType.HIGHER ? higherClass : lowerClass;
+    const activeStroke = trendIndicatorType === TrendIndicatorType.HIGHER ? higherStroke : lowerStroke;
 
-    return `${className} ${activeClass}`;
+    return activeStroke;
   },
-  _getHigherIndicatorClass(index) {
-    return this._getIndicatorClass(index, TrendIndicatorType.HIGHER);
+  _getHigherStrokeColor(index) {
+    return this._getStrokeColor(index, TrendIndicatorType.HIGHER);
   },
-  _getLowerIndicatorClass(index) {
-    return this._getIndicatorClass(index, TrendIndicatorType.LOWER);
+  _getLowerStrokeColor(index) {
+    return this._getStrokeColor(index, TrendIndicatorType.LOWER);
+  },
+  // We need to set some attributes in the DOM elements that React v0.14 does not support.
+  // This is a hack to workaround it as suggested in https://github.com/facebook/react/pull/5210
+  _setAttribute(attribute, value) {
+    return (node) => {
+      if (node) {
+        node.setAttribute(attribute, value);
+      }
+    };
   },
   render() {
+    const { config, width, height } = this.props;
+
     let trendIndicators;
 
-    if (this.props.config.trend) {
+    if (config.trend) {
       trendIndicators = (
         <g transform="translate(270,45)">
           <g transform="translate(0,-17)">
-            <path d="M0 5 L5 0 L10 5" className={this._getHigherIndicatorClass(0)} />
-            <path d="M0 10 L5 5 L10 10" className={this._getHigherIndicatorClass(1)} />
-            <path d="M0 15 L5 10 L10 15" className={this._getHigherIndicatorClass(2)} />
+            <path d="M0 5 L5 0 L10 5" fill="none" stroke={this._getHigherStrokeColor(0)} />
+            <path d="M0 10 L5 5 L10 10" fill="none" stroke={this._getHigherStrokeColor(1)} />
+            <path d="M0 15 L5 10 L10 15" fill="none" stroke={this._getHigherStrokeColor(2)} />
           </g>
           <g transform="translate(0, 2) rotate(180,5,7.5)">
-            <path d="M0 5 L5 0 L10 5" className={this._getLowerIndicatorClass(2)} />
-            <path d="M0 10 L5 5 L10 10" className={this._getLowerIndicatorClass(1)} />
-            <path d="M0 15 L5 10 L10 15" className={this._getLowerIndicatorClass(0)} />
+            <path d="M0 5 L5 0 L10 5" fill="none" stroke={this._getLowerStrokeColor(2)} />
+            <path d="M0 10 L5 5 L10 10" fill="none" stroke={this._getLowerStrokeColor(1)} />
+            <path d="M0 15 L5 10 L10 15" fill="none" stroke={this._getLowerStrokeColor(0)} />
           </g>
         </g>
       );
@@ -178,9 +193,16 @@ const NumericVisualization = React.createClass({
 
     return (
       <div className={style.container}>
-        <svg viewBox="0 0 300 100" className={style.number}>
-          <text x="150" y="45" className={style.value} style={{ fontSize: this._calculateFontSize() }}>
-            {this._formatData()}
+        <svg viewBox="0 0 300 100" className={style.number} width={width} height={height}>
+          <defs>
+            <path id="text-baseline" d="M0 45 H300" />
+          </defs>
+          <text textAnchor="middle" style={{ fontSize: this._calculateFontSize(), lineHeight: '100px' }}>
+            <textPath xlinkHref="#text-baseline" ref={this._setAttribute('startOffset', '50%')}>
+              <tspan ref={this._setAttribute('baseline-shift', '-40%')}>
+                {this._formatData()}
+              </tspan>
+            </textPath>
           </text>
           {trendIndicators}
         </svg>

--- a/graylog2-web-interface/src/components/visualizations/NumericVisualization.jsx
+++ b/graylog2-web-interface/src/components/visualizations/NumericVisualization.jsx
@@ -195,15 +195,8 @@ const NumericVisualization = React.createClass({
     return (
       <div id={`visualization-${id}`} className={style.container}>
         <svg viewBox="0 0 300 100" className={style.number} width="100%" height="100%" style={{ height: height, width: width }}>
-          <defs>
-            <path id="text-baseline" d="M0 45 H300" />
-          </defs>
-          <text textAnchor="middle" style={{ fontSize: this._calculateFontSize(), lineHeight: '100px' }}>
-            <textPath xlinkHref="#text-baseline" ref={this._setAttribute('startOffset', '50%')}>
-              <tspan ref={this._setAttribute('baseline-shift', '-40%')}>
-                {this._formatData()}
-              </tspan>
-            </textPath>
+          <text x="150" y="45" className={style.value} style={{ fontSize: this._calculateFontSize() }}>
+            {this._formatData()}
           </text>
           {trendIndicators}
         </svg>

--- a/graylog2-web-interface/src/components/visualizations/QuickValuesVisualization.css
+++ b/graylog2-web-interface/src/components/visualizations/QuickValuesVisualization.css
@@ -1,0 +1,20 @@
+@media print {
+    :local(.pieChart) {
+        page-break-inside: avoid;
+    }
+
+    .datatable-badge {
+        background: inherit !important;
+        -webkit-print-color-adjust: exact;
+    }
+
+    .quickvalues-table .table thead th {
+        font-weight: bold;
+        border-bottom: 2px solid currentColor;
+        color: #333 !important;
+    }
+
+    .quickvalues-table .table .dc-table-group td {
+        border-bottom: 1px solid #333;
+    }
+}

--- a/graylog2-web-interface/src/components/visualizations/QuickValuesVisualization.jsx
+++ b/graylog2-web-interface/src/components/visualizations/QuickValuesVisualization.jsx
@@ -14,9 +14,11 @@ import NumberUtils from 'util/NumberUtils';
 
 import StoreProvider from 'injection/StoreProvider';
 
+import style from './QuickValuesVisualization.css';
+
 global.jQuery = $;
-// eslint-disable-next-line import/newline-after-import
 require('bootstrap/js/tooltip');
+
 const SearchStore = StoreProvider.getStore('Search');
 
 const QuickValuesVisualization = React.createClass({
@@ -418,7 +420,7 @@ const QuickValuesVisualization = React.createClass({
            style={limitHeight ? { height: height } : {}}>
         <div className="container-fluid">
           <div className="row" style={{ marginBottom: 0 }}>
-            <div className={pieChartClassName} style={pieChartStyle}>
+            <div className={`${pieChartClassName} ${style.pieChart}`} style={pieChartStyle}>
               {pieChart}
             </div>
             <div className={dataTableClassName}>

--- a/graylog2-web-interface/src/components/visualizations/QuickValuesVisualization.jsx
+++ b/graylog2-web-interface/src/components/visualizations/QuickValuesVisualization.jsx
@@ -182,7 +182,7 @@ const QuickValuesVisualization = React.createClass({
 
         if (typeof this.pieChart !== 'undefined' && this.dataTable.group()(d) !== 'Others') {
           const colour = this.pieChart.colors()(d.term);
-          colourBadge = `<span class="datatable-badge" style="background-color: ${colour}"></span>`;
+          colourBadge = `<span class="datatable-badge" style="background-color: ${colour} !important;"></span>`;
         }
 
         return `${colourBadge} ${d.term}`;

--- a/graylog2-web-interface/src/components/visualizations/QuickValuesVisualization.jsx
+++ b/graylog2-web-interface/src/components/visualizations/QuickValuesVisualization.jsx
@@ -44,6 +44,7 @@ const QuickValuesVisualization = React.createClass({
     displayAddToSearchButton: PropTypes.bool,
     interactive: PropTypes.bool,
     onRenderComplete: PropTypes.func,
+    limitHeight: PropTypes.bool,
   },
   getDefaultProps() {
     return {
@@ -54,6 +55,7 @@ const QuickValuesVisualization = React.createClass({
       displayAnalysisInformation: false,
       displayAddToSearchButton: false,
       interactive: true,
+      limitHeight: true,
       onRenderComplete: () => {},
     };
   },
@@ -365,6 +367,7 @@ const QuickValuesVisualization = React.createClass({
     return <span dangerouslySetInnerHTML={{ __html: `${analysisInformation.join(',')}.` }} />;
   },
   render() {
+    const { limitHeight } = this.props;
     let pieChartClassName;
     const pieChartStyle = {};
 
@@ -410,7 +413,8 @@ const QuickValuesVisualization = React.createClass({
     }
 
     return (
-      <div id={`visualization-${this.props.id}`} className="quickvalues-visualization" style={{ height: this.props.height }}>
+      <div id={`visualization-${this.props.id}`} className="quickvalues-visualization"
+           style={limitHeight ? { height: height } : {}}>
         <div className="container-fluid">
           <div className="row" style={{ marginBottom: 0 }}>
             <div className={pieChartClassName} style={pieChartStyle}>

--- a/graylog2-web-interface/src/components/visualizations/QuickValuesVisualization.jsx
+++ b/graylog2-web-interface/src/components/visualizations/QuickValuesVisualization.jsx
@@ -367,12 +367,12 @@ const QuickValuesVisualization = React.createClass({
     return <span dangerouslySetInnerHTML={{ __html: `${analysisInformation.join(',')}.` }} />;
   },
   render() {
-    const { limitHeight } = this.props;
+    const { horizontal, displayAnalysisInformation, height, id, displayAddToSearchButton, limitHeight } = this.props;
     let pieChartClassName;
     const pieChartStyle = {};
 
     if (this._getConfig('show_pie_chart')) {
-      if (this.props.horizontal) {
+      if (horizontal) {
         pieChartClassName = 'col-md-4';
         pieChartStyle.textAlign = 'center';
       } else {
@@ -389,13 +389,13 @@ const QuickValuesVisualization = React.createClass({
      * or when neither the data table or the pie chart are selected for rendering.
      */
     if (this._getConfig('show_data_table') || !this._getConfig('show_pie_chart')) {
-      dataTableClassName = this.props.horizontal ? 'col-md-8' : 'col-md-12';
+      dataTableClassName = horizontal ? 'col-md-8' : 'col-md-12';
     } else {
       dataTableClassName = 'hidden';
     }
 
     let pieChart;
-    if (this.props.displayAnalysisInformation) {
+    if (displayAnalysisInformation) {
       pieChart = (
         <Panel>
           <ListGroup fill>
@@ -413,7 +413,8 @@ const QuickValuesVisualization = React.createClass({
     }
 
     return (
-      <div id={`visualization-${this.props.id}`} className="quickvalues-visualization"
+      <div id={`visualization-${id}`}
+           className="quickvalues-visualization"
            style={limitHeight ? { height: height } : {}}>
         <div className="container-fluid">
           <div className="row" style={{ marginBottom: 0 }}>
@@ -428,7 +429,7 @@ const QuickValuesVisualization = React.createClass({
                       <th style={{ width: '60%' }}>Value</th>
                       <th>%</th>
                       <th>Count</th>
-                      {this.props.displayAddToSearchButton &&
+                      {displayAddToSearchButton &&
                       <th style={{ width: 30 }}>&nbsp;</th>
                       }
                     </tr>

--- a/graylog2-web-interface/src/components/visualizations/RenderCompletionObserver.jsx
+++ b/graylog2-web-interface/src/components/visualizations/RenderCompletionObserver.jsx
@@ -1,0 +1,33 @@
+import React from 'react';
+
+const RenderCompletionObserver = React.createClass({
+  propTypes: {
+    onRenderComplete: React.PropTypes.func.isRequired,
+    children: React.PropTypes.oneOfType([
+      React.PropTypes.element,
+      React.PropTypes.arrayOf(React.PropTypes.element),
+    ]).isRequired,
+  },
+
+  _renderComplete: false,
+
+  _handleRenderComplete() {
+    if (this._renderComplete) {
+      return;
+    }
+    this._renderComplete = true;
+    this.props.onRenderComplete();
+  },
+
+  render() {
+    return (
+      <span>
+        {React.Children.map(this.props.children, (child) => {
+          return React.cloneElement(child, { onRenderComplete: this._handleRenderComplete });
+        })}
+      </span>
+    );
+  },
+});
+
+export default RenderCompletionObserver;

--- a/graylog2-web-interface/src/components/visualizations/RenderCompletionObserver.jsx
+++ b/graylog2-web-interface/src/components/visualizations/RenderCompletionObserver.jsx
@@ -21,11 +21,11 @@ const RenderCompletionObserver = React.createClass({
 
   render() {
     return (
-      <span>
+      <div>
         {React.Children.map(this.props.children, (child) => {
           return React.cloneElement(child, { onRenderComplete: this._handleRenderComplete });
         })}
-      </span>
+      </div>
     );
   },
 });

--- a/graylog2-web-interface/src/components/visualizations/StackedGraphVisualization.jsx
+++ b/graylog2-web-interface/src/components/visualizations/StackedGraphVisualization.jsx
@@ -161,7 +161,7 @@ const StackedGraphVisualization = React.createClass({
     props.config.series.forEach((seriesConfig) => {
       i++;
       const seriesName = `series${i}`;
-      const seriesTitle = seriesConfig.title ? seriesConfig.title : `${seriesConfig.statistical_function} ${seriesConfig.field}, "${seriesConfig.query}"`;
+      const seriesTitle = seriesConfig.title ? seriesConfig.title : `${seriesConfig.statistical_function} ${seriesConfig.field}, "${seriesConfig.query || '*'}"`;
       newSeriesNames = newSeriesNames.set(seriesName, seriesTitle);
     }, this);
 
@@ -201,7 +201,7 @@ const StackedGraphVisualization = React.createClass({
     props.config.series.forEach((seriesConfig) => {
       i++;
       const seriesName = `series${i}`;
-      const seriesTitle = seriesConfig.title ? seriesConfig.title : `${seriesConfig.statistical_function} ${seriesConfig.field}, "${seriesConfig.query}"`;
+      const seriesTitle = seriesConfig.title ? seriesConfig.title : `${seriesConfig.statistical_function} ${seriesConfig.field}, "${seriesConfig.query || '*'}"`;
       this.series = this.series.push(seriesName);
       this.seriesNames = this.seriesNames.set(seriesName, seriesTitle);
       colours = colours.set(seriesName, colourPalette(seriesName));

--- a/graylog2-web-interface/src/components/visualizations/StackedGraphVisualization.jsx
+++ b/graylog2-web-interface/src/components/visualizations/StackedGraphVisualization.jsx
@@ -23,7 +23,15 @@ const StackedGraphVisualization = React.createClass({
     width: PropTypes.number,
     config: PropTypes.object.isRequired,
     computationTimeRange: PropTypes.object,
+    onRenderComplete: React.PropTypes.func,
   },
+
+  getDefaultProps() {
+    return {
+      onRenderComplete: () => {},
+    };
+  },
+
   getInitialState() {
     this.series = Immutable.List();
     this.seriesNames = Immutable.Map();
@@ -201,6 +209,7 @@ const StackedGraphVisualization = React.createClass({
 
     this.graph = c3.generate({
       bindto: graphDomNode,
+      onrendered: this.props.onRenderComplete,
       size: {
         height: props.height,
         width: props.width,

--- a/graylog2-web-interface/src/components/visualizations/StackedGraphVisualization.jsx
+++ b/graylog2-web-interface/src/components/visualizations/StackedGraphVisualization.jsx
@@ -23,11 +23,13 @@ const StackedGraphVisualization = React.createClass({
     width: PropTypes.number,
     config: PropTypes.object.isRequired,
     computationTimeRange: PropTypes.object,
-    onRenderComplete: React.PropTypes.func,
+    interactive: PropTypes.bool,
+    onRenderComplete: PropTypes.func,
   },
 
   getDefaultProps() {
     return {
+      interactive: true,
       onRenderComplete: () => {},
     };
   },
@@ -114,6 +116,7 @@ const StackedGraphVisualization = React.createClass({
     return graphType;
   },
   _applyGraphConfiguration(graphType) {
+    /* eslint-disable no-case-declarations */
     switch (graphType) {
       case 'bar':
         // Automatically resize bar width
@@ -131,6 +134,7 @@ const StackedGraphVisualization = React.createClass({
       default:
         console.warn(`Invalid graph type ${graphType}`);
     }
+    /* eslint-enable no-case-declarations */
   },
   _formatTooltipTitle(x) {
     return new DateTime(x).toString(DateTime.Formats.COMPLETE);
@@ -207,7 +211,7 @@ const StackedGraphVisualization = React.createClass({
       return Math.abs(value) > 1e+30 || value === 0 ? value.toPrecision(1) : d3.format('.2s')(value);
     };
 
-    this.graph = c3.generate({
+    const config = {
       bindto: graphDomNode,
       onrendered: this.props.onRenderComplete,
       size: {
@@ -262,7 +266,14 @@ const StackedGraphVisualization = React.createClass({
           value: this._formatTooltipValue,
         },
       },
-    });
+    };
+
+    if (!this.props.interactive) {
+      config.interaction = { enabled: false };
+      config.transition = { duration: null };
+    }
+
+    this.graph = c3.generate(config);
   },
   render() {
     const classNames = this.props.config.doNotShowCircles ? 'donotshowcircles' : '';

--- a/graylog2-web-interface/src/components/visualizations/StackedGraphVisualization.jsx
+++ b/graylog2-web-interface/src/components/visualizations/StackedGraphVisualization.jsx
@@ -192,7 +192,7 @@ const StackedGraphVisualization = React.createClass({
     });
   },
   renderGraph(props) {
-    const graphDomNode = ReactDOM.findDOMNode(this);
+    const graphDomNode = this._graph;
     const colourPalette = D3Utils.glColourPalette();
 
     let i = 0;
@@ -278,7 +278,7 @@ const StackedGraphVisualization = React.createClass({
   render() {
     const classNames = this.props.config.doNotShowCircles ? 'donotshowcircles' : '';
     return (
-      <div  id={`visualization-${this.props.id}`}
+      <div ref={(c) => { this._graph = c; }} id={`visualization-${this.props.id}`}
            className={`graph ${this.props.config.renderer}${classNames}`} />
     );
   },

--- a/graylog2-web-interface/src/components/visualizations/index.jsx
+++ b/graylog2-web-interface/src/components/visualizations/index.jsx
@@ -4,3 +4,4 @@ export { default as NumericVisualization } from './NumericVisualization';
 export { default as QuickValuesVisualization } from './QuickValuesVisualization';
 export { default as QuickValuesHistogramVisualization } from './QuickValuesHistogramVisualization';
 export { default as StackedGraphVisualization } from './StackedGraphVisualization';
+export { default as RenderCompletionObserver } from './RenderCompletionObserver';

--- a/graylog2-web-interface/src/components/widgets/Widget.jsx
+++ b/graylog2-web-interface/src/components/widgets/Widget.jsx
@@ -147,6 +147,7 @@ const Widget = React.createClass({
       height: this.state.height,
       width: this.state.width,
       computationTimeRange: this.state.computationTimeRange,
+      locked: !this.props.locked, // widget should be locked when dashboard is unlocked and widgets can be moved
     });
   },
   _getTimeRange() {

--- a/graylog2-web-interface/src/util/SortUtils.js
+++ b/graylog2-web-interface/src/util/SortUtils.js
@@ -1,0 +1,20 @@
+import moment from 'moment';
+import naturalSort from 'javascript-natural-sort';
+
+// sortOrder: "asc"|"desc"
+export function sortByDate(d1, d2, sortOrder) {
+  const effectiveSortOrder = sortOrder || 'asc';
+  const d1Time = moment(d1);
+  const d2Time = moment(d2);
+
+  if (effectiveSortOrder === 'asc') {
+    return (d1Time.isBefore(d2Time) ? -1 : d2Time.isBefore(d1Time) ? 1 : 0);
+  } else {
+    return (d2Time.isBefore(d1Time) ? -1 : d1Time.isBefore(d2Time) ? 1 : 0);
+  }
+}
+
+export function naturalSortIgnoreCase(s1, s2, sortOrder) {
+  const effectiveSortOrder = sortOrder || 'asc';
+  return (effectiveSortOrder === 'asc' ? naturalSort(s1.toLowerCase(), s2.toLowerCase()) : naturalSort(s2.toLowerCase(), s1.toLowerCase()));
+}


### PR DESCRIPTION
As we were working on some 3.0 features for some time, there are a number of commits that were made in parallel to the master branch, but we didn't merged back yet. Here are some of the changes done:

- Add control over resize widget, even if grid is locked
- Add render complete callbacks to widgets, making it easier for consumers to execute some code when widgets are actually rendered. This is specially useful for widgets not rendered by react
- Improvements in display of numeric visualization
- Make widgets more printer friendly, by adding print styles and props to disable animations
- Encapsulate common sorting methods into `SortUtils`