### PR TITLE
Return additional field->value mapping for terms queries

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/indexer/results/TermsHistogramResult.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/results/TermsHistogramResult.java
@@ -26,6 +26,8 @@ import org.graylog2.plugin.indexer.searches.timeranges.AbsoluteRange;
 import org.joda.time.DateTime;
 
 import javax.annotation.Nullable;
+import java.util.Collections;
+import java.util.List;
 import java.util.Map;
 
 public class TermsHistogramResult extends IndexQueryResult {
@@ -34,7 +36,7 @@ public class TermsHistogramResult extends IndexQueryResult {
     private final Map<Long, TermsResult> result;
     private AbsoluteRange boundaries;
 
-    public TermsHistogramResult(@Nullable DateHistogramAggregation result, String originalQuery, String builtQuery, long size, long tookMs, Searches.DateHistogramInterval interval) {
+    public TermsHistogramResult(@Nullable DateHistogramAggregation result, String originalQuery, String builtQuery, long size, long tookMs, Searches.DateHistogramInterval interval, List<String> fields) {
         super(originalQuery, builtQuery, tookMs);
         this.size = size;
         this.interval = interval;
@@ -45,7 +47,7 @@ public class TermsHistogramResult extends IndexQueryResult {
                 final DateTime keyAsDate = new DateTime(histogram.getKey());
                 final TermsAggregation termsAggregation = histogram.getFilterAggregation(Searches.AGG_FILTER).getTermsAggregation(Searches.AGG_TERMS);
                 final MissingAggregation missingAgregation = histogram.getMissingAggregation("missing");
-                final TermsResult termsResult = new TermsResult(termsAggregation, missingAgregation.getMissing(), histogram.getCount(), "", "", tookMs);
+                final TermsResult termsResult = new TermsResult(termsAggregation, missingAgregation.getMissing(), histogram.getCount(), "", "", tookMs, fields);
 
                 this.result.put(keyAsDate.getMillis() / 1000L, termsResult);
             }
@@ -78,6 +80,6 @@ public class TermsHistogramResult extends IndexQueryResult {
     }
 
     public static TermsHistogramResult empty(String originalQuery, String builtQuery, long size, Searches.DateHistogramInterval interval) {
-        return new TermsHistogramResult(null, originalQuery, builtQuery, size, 0L, interval);
+        return new TermsHistogramResult(null, originalQuery, builtQuery, size, 0L, interval, Collections.emptyList());
     }
 }

--- a/graylog2-server/src/main/java/org/graylog2/rest/models/search/responses/TermsResult.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/models/search/responses/TermsResult.java
@@ -21,6 +21,8 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.auto.value.AutoValue;
 import org.graylog.autovalue.WithBeanGetter;
 
+import java.util.Collections;
+import java.util.List;
 import java.util.Map;
 
 @JsonAutoDetect
@@ -32,6 +34,9 @@ public abstract class TermsResult {
 
     @JsonProperty
     public abstract Map<String, Long> terms();
+
+    @JsonProperty
+    public abstract Map<String, List<Map<String, String>>> termsMapping();
 
     @JsonProperty
     public abstract long missing();
@@ -51,6 +56,16 @@ public abstract class TermsResult {
                                      long other,
                                      long total,
                                      String builtQuery) {
-        return new AutoValue_TermsResult(time, terms, missing, other, total, builtQuery);
+        return create(time, terms, Collections.emptyMap(), missing, other, total, builtQuery);
+    }
+
+    public static TermsResult create(long time,
+                                     Map<String, Long> terms,
+                                     Map<String, List<Map<String, String>>> termsMapping,
+                                     long missing,
+                                     long other,
+                                     long total,
+                                     String builtQuery) {
+        return new AutoValue_TermsResult(time, terms, termsMapping, missing, other, total, builtQuery);
     }
 }

--- a/graylog2-server/src/main/java/org/graylog2/rest/resources/search/SearchResource.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/resources/search/SearchResource.java
@@ -161,7 +161,7 @@ public abstract class SearchResource extends RestResource {
     }
 
     protected TermsResult buildTermsResult(org.graylog2.indexer.results.TermsResult tr) {
-        return TermsResult.create(tr.tookMs(), tr.getTerms(), tr.getMissing(), tr.getOther(), tr.getTotal(), tr.getBuiltQuery());
+        return TermsResult.create(tr.tookMs(), tr.getTerms(), tr.termsMapping(), tr.getMissing(), tr.getOther(), tr.getTotal(), tr.getBuiltQuery());
     }
 
     protected TermsStatsResult buildTermsStatsResult(org.graylog2.indexer.results.TermsStatsResult tr) {

--- a/graylog2-server/src/main/java/org/graylog2/utilities/SearchUtils.java
+++ b/graylog2-server/src/main/java/org/graylog2/utilities/SearchUtils.java
@@ -76,7 +76,7 @@ public class SearchUtils {
         final Map<Long, TermsResult> result = termsHistogram.getResults().entrySet().stream()
                 .collect(Collectors.toMap(Map.Entry::getKey, entry -> {
                     final org.graylog2.indexer.results.TermsResult tr = entry.getValue();
-                    return TermsResult.create(tr.tookMs(), tr.getTerms(), tr.getMissing(), tr.getOther(), tr.getTotal(), tr.getBuiltQuery());
+                    return TermsResult.create(tr.tookMs(), tr.getTerms(), tr.termsMapping(), tr.getMissing(), tr.getOther(), tr.getTotal(), tr.getBuiltQuery());
                 }));
 
         return TermsHistogramResult.create(

--- a/graylog2-web-interface/src/components/visualizations/QuickValuesVisualization.jsx
+++ b/graylog2-web-interface/src/components/visualizations/QuickValuesVisualization.jsx
@@ -68,6 +68,7 @@ const QuickValuesVisualization = React.createClass({
       others: undefined,
       missing: undefined,
       terms: Immutable.List(),
+      termsMapping: {},
     };
   },
   componentDidMount() {
@@ -136,6 +137,7 @@ const QuickValuesVisualization = React.createClass({
         others: quickValues.other,
         missing: quickValues.missing,
         terms: formattedTerms,
+        termsMapping: quickValues.terms_mapping,
       }, this.drawData);
     }
   },
@@ -210,7 +212,7 @@ const QuickValuesVisualization = React.createClass({
         table.selectAll('td.dc-table-column button').on('click', () => {
           // noinspection Eslint
           const term = $(d3.event.target).closest('button').data('term');
-          SearchStore.addSearchTerm(props.id, term);
+          SearchStore.addSearchTermWithMapping(this.state.termsMapping, props.id, term);
         });
       });
 

--- a/graylog2-web-interface/src/stores/search/SearchStore.ts
+++ b/graylog2-web-interface/src/stores/search/SearchStore.ts
@@ -237,6 +237,16 @@ class SearchStore {
         this.addQueryTerm(term, effectiveOperator);
     }
 
+    addSearchTermWithMapping(mapping, field, value, operator) {
+        if (!mapping[value]) {
+          return this.addSearchTerm(field, value, operator);
+        }
+
+        mapping[value].forEach((m) => {
+          this.addSearchTerm(m.field, m.value, operator);
+        });
+    }
+
     changeTimeRange(newRangeType: string, newRangeParams: Object) {
         this.rangeType = newRangeType;
         this.rangeParams = Immutable.fromJS(newRangeParams);


### PR DESCRIPTION
This mapping can be used to construct correct ES queries when using the `QuickValues` widget with stacked fields.

Fixes #4216

Note: This needs to be merged into 2.4