### PR TITLE
Unify navigation

### DIFF
--- a/graylog2-web-interface/src/components/alertnotifications/CreateAlertNotificationInput.jsx
+++ b/graylog2-web-interface/src/components/alertnotifications/CreateAlertNotificationInput.jsx
@@ -97,8 +97,20 @@ const CreateAlertNotificationInput = React.createClass({
     const formattedStreams = this.state.streams
       .map(stream => this._formatOption(stream.title, stream.id))
       .sort((s1, s2) => naturalSort(s1.label.toLowerCase(), s2.label.toLowerCase()));
+
+    const notificationTypeHelp = (
+      <span>
+        Select the notification type that will be used. You can find more types in the{' '}
+        <a href="https://marketplace.graylog.org/" target="_blank" rel="noopener noreferrer">Graylog Marketplace</a>.
+      </span>
+    );
+
     return (
       <div>
+        <Button bsStyle="info" href="https://marketplace.graylog.org/" target="_blank" className="pull-right">
+          <i className="fa fa-external-link" />&nbsp; Find more notifications
+        </Button>
+
         <h2>Notification</h2>
         <p className="description">
           Define the notification that will be triggered from the alert conditions in a stream.
@@ -112,9 +124,12 @@ const CreateAlertNotificationInput = React.createClass({
                 <Select placeholder="Select a stream" options={formattedStreams} onChange={this._onStreamChange} />
               </Input>
 
-              <Input type="select" value={this.state.type} onChange={this._onChange}
+              <Input type="select"
+                     value={this.state.type}
+                     onChange={this._onChange}
                      disabled={!this.state.selectedStream}
-                     label="Notification type" help="Select the notification type that will be used.">
+                     label="Notification type"
+                     help={notificationTypeHelp}>
                 <option value={this.PLACEHOLDER} disabled>Select a notification type</option>
                 {availableTypes}
               </Input>

--- a/graylog2-web-interface/src/components/alerts/AlertsHeaderToolbar.jsx
+++ b/graylog2-web-interface/src/components/alerts/AlertsHeaderToolbar.jsx
@@ -1,0 +1,36 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { Button, ButtonToolbar } from 'react-bootstrap';
+import { LinkContainer } from 'react-router-bootstrap';
+
+import Routes from 'routing/Routes';
+
+const AlertsHeaderToolbar = React.createClass({
+  propTypes: {
+    active: PropTypes.string.isRequired,
+  },
+
+  _isActive(active, route) {
+    return active === route ? 'active' : '';
+  },
+
+  render() {
+    const { active } = this.props;
+
+    return (
+      <ButtonToolbar>
+        <LinkContainer to={Routes.ALERTS.LIST}>
+          <Button bsStyle="info" className={this._isActive(active, Routes.ALERTS.LIST)}>Alerts</Button>
+        </LinkContainer>
+        <LinkContainer to={Routes.ALERTS.CONDITIONS}>
+          <Button bsStyle="info" className={this._isActive(active, Routes.ALERTS.CONDITIONS)}>Conditions</Button>
+        </LinkContainer>
+        <LinkContainer to={Routes.ALERTS.NOTIFICATIONS}>
+          <Button bsStyle="info" className={this._isActive(active, Routes.ALERTS.NOTIFICATIONS)}>Notifications</Button>
+        </LinkContainer>
+      </ButtonToolbar>
+    );
+  },
+});
+
+export default AlertsHeaderToolbar;

--- a/graylog2-web-interface/src/components/alerts/index.jsx
+++ b/graylog2-web-interface/src/components/alerts/index.jsx
@@ -1,4 +1,5 @@
 export { default as Alert } from './Alert';
+export { default as AlertsHeaderToolbar } from './AlertsHeaderToolbar';
 export { default as AlertDetails } from './AlertDetails';
 export { default as AlertMessages } from './AlertMessages';
 export { default as AlertsComponent } from './AlertsComponent';

--- a/graylog2-web-interface/src/components/lookup-tables/Cache.jsx
+++ b/graylog2-web-interface/src/components/lookup-tables/Cache.jsx
@@ -1,6 +1,8 @@
 import PropTypes from 'prop-types';
 import React from 'react';
-import { Row, Col } from 'react-bootstrap';
+import { Button, Row, Col } from 'react-bootstrap';
+import { LinkContainer } from 'react-router-bootstrap';
+import Routes from 'routing/Routes';
 import { PluginStore } from 'graylog-web-plugin/plugin';
 import { ContentPackMarker } from 'components/common';
 
@@ -44,6 +46,9 @@ const Cache = React.createClass({
           <div className={Styles.config}>
             {React.createElement(summary, { cache: cache })}
           </div>
+          <LinkContainer to={Routes.SYSTEM.LOOKUPTABLES.CACHES.edit(cache.name)}>
+            <Button bsStyle="success">Edit</Button>
+          </LinkContainer>
         </Col>
         <Col md={6} />
       </Row>

--- a/graylog2-web-interface/src/components/lookup-tables/DataAdapter.jsx
+++ b/graylog2-web-interface/src/components/lookup-tables/DataAdapter.jsx
@@ -1,8 +1,10 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 import { Button, Row, Col } from 'react-bootstrap';
+import { LinkContainer } from 'react-router-bootstrap';
 import { Input } from 'components/bootstrap';
 import FormsUtils from 'util/FormsUtils';
+import Routes from 'routing/Routes';
 import { ContentPackMarker } from 'components/common';
 import { PluginStore } from 'graylog-web-plugin/plugin';
 import CombinedProvider from 'injection/CombinedProvider';
@@ -66,6 +68,9 @@ const DataAdapter = React.createClass({
           <div className={Styles.config}>
             {React.createElement(summary, { dataAdapter: dataAdapter })}
           </div>
+          <LinkContainer to={Routes.SYSTEM.LOOKUPTABLES.DATA_ADAPTERS.edit(dataAdapter.name)}>
+            <Button bsStyle="success">Edit</Button>
+          </LinkContainer>
         </Col>
         <Col md={6}>
           <h3>Test lookup</h3>

--- a/graylog2-web-interface/src/components/lookup-tables/LookupTable.jsx
+++ b/graylog2-web-interface/src/components/lookup-tables/LookupTable.jsx
@@ -59,11 +59,11 @@ const LookupTable = React.createClass({
     return (
       <Row className="content">
         <Col md={6}>
-          <h3>
+          <h2>
             {this.props.table.title}
             <ContentPackMarker contentPack={this.props.table.content_pack} marginLeft={5} />
-          </h3>
-          <span>{this.props.table.description}</span>
+          </h2>
+          <p>{this.props.table.description}</p>
           <dl>
             <dt>Data adapter</dt>
             <dd>
@@ -72,6 +72,9 @@ const LookupTable = React.createClass({
             <dt>Cache</dt>
             <dd><LinkContainer to={Routes.SYSTEM.LOOKUPTABLES.CACHES.show(this.props.cache.name)}><a>{this.props.cache.title}</a></LinkContainer></dd>
           </dl>
+          <LinkContainer to={Routes.SYSTEM.LOOKUPTABLES.edit(this.props.table.name)}>
+            <Button bsStyle="success">Edit</Button>
+          </LinkContainer>
           {
             (this.props.table.default_single_value || this.props.table.default_multi_value) &&
             <dl>
@@ -81,7 +84,8 @@ const LookupTable = React.createClass({
               <dd><code>{this.props.table.default_multi_value}</code>{' '}({this.props.table.default_multi_value_type.toLowerCase()})</dd>
             </dl>
           }
-          <h3>Purge Cache</h3>
+          <hr />
+          <h2>Purge Cache</h2>
           <p>You can purge the complete cache for this lookup table or only the cache entry for a single key.</p>
           <form onSubmit={this._onPurgeKey}>
             <fieldset>
@@ -103,7 +107,7 @@ const LookupTable = React.createClass({
           </form>
         </Col>
         <Col md={6}>
-          <h3>Test lookup</h3>
+          <h2>Test lookup</h2>
           <p>You can manually query the lookup table using this form. The data will be cached as configured by Graylog.</p>
           <form onSubmit={this._lookupKey}>
             <fieldset>

--- a/graylog2-web-interface/src/pages/AlertConditionsPage.jsx
+++ b/graylog2-web-interface/src/pages/AlertConditionsPage.jsx
@@ -1,10 +1,10 @@
 import React from 'react';
 import Reflux from 'reflux';
-import { Button, Col, Row } from 'react-bootstrap';
-import { LinkContainer } from 'react-router-bootstrap';
+import { Col, Row } from 'react-bootstrap';
 
 import DocumentationLink from 'components/support/DocumentationLink';
 import { DocumentTitle, PageHeader } from 'components/common';
+import { AlertsHeaderToolbar } from 'components/alerts';
 import { AlertConditionsComponent } from 'components/alertconditions';
 
 import Routes from 'routing/Routes';
@@ -30,9 +30,7 @@ const AlertConditionsPage = React.createClass({
             </span>
 
             <span>
-              <LinkContainer to={Routes.ALERTS.NOTIFICATIONS}>
-                <Button bsStyle="info">Manage notifications</Button>
-              </LinkContainer>
+              <AlertsHeaderToolbar active={Routes.ALERTS.CONDITIONS} />
             </span>
           </PageHeader>
 

--- a/graylog2-web-interface/src/pages/AlertNotificationsPage.jsx
+++ b/graylog2-web-interface/src/pages/AlertNotificationsPage.jsx
@@ -1,9 +1,9 @@
 import React from 'react';
 import Reflux from 'reflux';
-import { Button, Col, Row } from 'react-bootstrap';
-import { LinkContainer } from 'react-router-bootstrap';
+import { Col, Row } from 'react-bootstrap';
 
 import { DocumentTitle, PageHeader } from 'components/common';
+import { AlertsHeaderToolbar } from 'components/alerts';
 import { AlertNotificationsComponent } from 'components/alertnotifications';
 import Routes from 'routing/Routes';
 
@@ -27,13 +27,7 @@ const AlertNotificationsPage = React.createClass({
             </span>
 
             <span>
-              <LinkContainer to={Routes.ALERTS.CONDITIONS}>
-                <Button bsStyle="info">Manage conditions</Button>
-              </LinkContainer>
-              &nbsp;
-              <Button bsStyle="info" href="https://marketplace.graylog.org/" target="_blank">
-                <i className="fa fa-external-link" />&nbsp; Find more notifications
-              </Button>
+              <AlertsHeaderToolbar active={Routes.ALERTS.NOTIFICATIONS} />
             </span>
           </PageHeader>
 

--- a/graylog2-web-interface/src/pages/AlertsPage.jsx
+++ b/graylog2-web-interface/src/pages/AlertsPage.jsx
@@ -1,9 +1,8 @@
 import React from 'react';
 import Reflux from 'reflux';
-import { Button, Col, Row } from 'react-bootstrap';
-import { LinkContainer } from 'react-router-bootstrap';
+import { Col, Row } from 'react-bootstrap';
 
-import { AlertsComponent } from 'components/alerts';
+import { AlertsComponent, AlertsHeaderToolbar } from 'components/alerts';
 
 import DocumentationLink from 'components/support/DocumentationLink';
 import { DocumentTitle, PageHeader } from 'components/common';
@@ -31,13 +30,7 @@ const AlertsPage = React.createClass({
             </span>
 
             <span>
-              <LinkContainer to={Routes.ALERTS.CONDITIONS}>
-                <Button bsStyle="info">Manage conditions</Button>
-              </LinkContainer>
-              &nbsp;
-              <LinkContainer to={Routes.ALERTS.NOTIFICATIONS}>
-                <Button bsStyle="info">Manage notifications</Button>
-              </LinkContainer>
+              <AlertsHeaderToolbar active={Routes.ALERTS.LIST} />
             </span>
           </PageHeader>
 

--- a/graylog2-web-interface/src/pages/EditAlertConditionPage.jsx
+++ b/graylog2-web-interface/src/pages/EditAlertConditionPage.jsx
@@ -1,11 +1,11 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 import Reflux from 'reflux';
-import { Button, Col, Row } from 'react-bootstrap';
-import { LinkContainer } from 'react-router-bootstrap';
+import { Col, Row } from 'react-bootstrap';
 
 import DocumentationLink from 'components/support/DocumentationLink';
 import { DocumentTitle, PageHeader, Spinner } from 'components/common';
+import { AlertsHeaderToolbar } from 'components/alerts';
 import { ConditionAlertNotifications, EditAlertConditionForm } from 'components/alertconditions';
 
 import Routes from 'routing/Routes';
@@ -64,13 +64,7 @@ const EditAlertConditionPage = React.createClass({
             </span>
 
             <span>
-              <LinkContainer to={Routes.ALERTS.CONDITIONS}>
-                <Button bsStyle="info">Manage conditions</Button>
-              </LinkContainer>
-              &nbsp;
-              <LinkContainer to={Routes.ALERTS.NOTIFICATIONS}>
-                <Button bsStyle="info">Manage notifications</Button>
-              </LinkContainer>
+              <AlertsHeaderToolbar active={Routes.ALERTS.CONDITIONS} />
             </span>
           </PageHeader>
 

--- a/graylog2-web-interface/src/pages/LUTCachesPage.jsx
+++ b/graylog2-web-interface/src/pages/LUTCachesPage.jsx
@@ -1,7 +1,7 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 import Reflux from 'reflux';
-import { Button, Col, Row } from 'react-bootstrap';
+import { Button, ButtonToolbar, Col, Row } from 'react-bootstrap';
 import { LinkContainer } from 'react-router-bootstrap';
 import Routes from 'routing/Routes';
 import { DocumentTitle, PageHeader, Spinner } from 'components/common';
@@ -108,28 +108,17 @@ const LUTCachesPage = React.createClass({
             <span>Caches provide the actual values for lookup tables</span>
             {null}
             <span>
-              {(isShowing || isEditing) && (
-                <LinkContainer to={Routes.SYSTEM.LOOKUPTABLES.CACHES.edit(this.props.params.cacheName)}
-                               onlyActiveOnIndex>
-                  <Button bsStyle="success">Edit</Button>
+              <ButtonToolbar>
+                <LinkContainer to={Routes.SYSTEM.LOOKUPTABLES.OVERVIEW}>
+                  <Button bsStyle="info">Lookup Tables</Button>
                 </LinkContainer>
-              )}
-              &nbsp;
-              {(isShowing || isEditing) && (
-                <LinkContainer to={Routes.SYSTEM.LOOKUPTABLES.CACHES.OVERVIEW}
-                               onlyActiveOnIndex>
-                  <Button bsStyle="info">Caches</Button>
+                <LinkContainer to={Routes.SYSTEM.LOOKUPTABLES.CACHES.OVERVIEW}>
+                  <Button bsStyle="info" className="active">Caches</Button>
                 </LinkContainer>
-              )}
-              &nbsp;
-              <LinkContainer to={Routes.SYSTEM.LOOKUPTABLES.OVERVIEW} onlyActiveOnIndex>
-                <Button bsStyle="info">Lookup Tables</Button>
-              </LinkContainer>
-              &nbsp;
-              <LinkContainer to={Routes.SYSTEM.LOOKUPTABLES.DATA_ADAPTERS.OVERVIEW}
-                             onlyActiveOnIndex>
-                <Button bsStyle="info">Data Adapters</Button>
-              </LinkContainer>
+                <LinkContainer to={Routes.SYSTEM.LOOKUPTABLES.DATA_ADAPTERS.OVERVIEW}>
+                  <Button bsStyle="info">Data Adapters</Button>
+                </LinkContainer>
+              </ButtonToolbar>
             </span>
           </PageHeader>
 

--- a/graylog2-web-interface/src/pages/LUTDataAdaptersPage.jsx
+++ b/graylog2-web-interface/src/pages/LUTDataAdaptersPage.jsx
@@ -1,7 +1,7 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 import Reflux from 'reflux';
-import { Button, Col, Row } from 'react-bootstrap';
+import { Button, ButtonToolbar, Col, Row } from 'react-bootstrap';
 import { LinkContainer } from 'react-router-bootstrap';
 import Routes from 'routing/Routes';
 import { DocumentTitle, PageHeader, Spinner } from 'components/common';
@@ -139,27 +139,17 @@ const LUTDataAdaptersPage = React.createClass({
             <span>Data adapters provide the actual values for lookup tables</span>
             {null}
             <span>
-              {isShowing && (
-                <LinkContainer to={Routes.SYSTEM.LOOKUPTABLES.DATA_ADAPTERS.edit(this.props.params.adapterName)}
-                               onlyActiveOnIndex>
-                  <Button bsStyle="success">Edit</Button>
+              <ButtonToolbar>
+                <LinkContainer to={Routes.SYSTEM.LOOKUPTABLES.OVERVIEW}>
+                  <Button bsStyle="info">Lookup Tables</Button>
                 </LinkContainer>
-              )}
-              &nbsp;
-              {(isShowing || isEditing) && (
-                <LinkContainer to={Routes.SYSTEM.LOOKUPTABLES.DATA_ADAPTERS.OVERVIEW}
-                               onlyActiveOnIndex>
-                  <Button bsStyle="info">Data Adapters</Button>
+                <LinkContainer to={Routes.SYSTEM.LOOKUPTABLES.CACHES.OVERVIEW}>
+                  <Button bsStyle="info">Caches</Button>
                 </LinkContainer>
-              )}
-              &nbsp;
-              <LinkContainer to={Routes.SYSTEM.LOOKUPTABLES.OVERVIEW} onlyActiveOnIndex>
-                <Button bsStyle="info">Lookup Tables</Button>
-              </LinkContainer>
-              &nbsp;
-              <LinkContainer to={Routes.SYSTEM.LOOKUPTABLES.CACHES.OVERVIEW} onlyActiveOnIndex>
-                <Button bsStyle="info">Caches</Button>
-              </LinkContainer>
+                <LinkContainer to={Routes.SYSTEM.LOOKUPTABLES.DATA_ADAPTERS.OVERVIEW}>
+                  <Button bsStyle="info" className="active">Data Adapters</Button>
+                </LinkContainer>
+              </ButtonToolbar>
             </span>
           </PageHeader>
 

--- a/graylog2-web-interface/src/pages/LUTTablesPage.jsx
+++ b/graylog2-web-interface/src/pages/LUTTablesPage.jsx
@@ -1,7 +1,7 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 import Reflux from 'reflux';
-import { Button, Col, Row } from 'react-bootstrap';
+import { Button, ButtonToolbar, Col, Row } from 'react-bootstrap';
 import { LinkContainer } from 'react-router-bootstrap';
 import Routes from 'routing/Routes';
 
@@ -136,27 +136,17 @@ const LUTTablesPage = React.createClass({
             <span>Lookup tables can be used in extractors, converters and processing pipelines to translate message fields or to enrich messages.</span>
             {null}
             <span>
-              {isShowing && (
-                <LinkContainer to={Routes.SYSTEM.LOOKUPTABLES.edit(this.props.params.tableName)}
-                               onlyActiveOnIndex>
-                  <Button bsStyle="success">Edit</Button>
+              <ButtonToolbar>
+                <LinkContainer to={Routes.SYSTEM.LOOKUPTABLES.OVERVIEW}>
+                  <Button bsStyle="info" className="active">Lookup Tables</Button>
                 </LinkContainer>
-              )}
-              &nbsp;
-              {(isShowing || isEditing) && (
-                <LinkContainer to={Routes.SYSTEM.LOOKUPTABLES.OVERVIEW} onlyActiveOnIndex>
-                  <Button bsStyle="info">Lookup Tables</Button>
+                <LinkContainer to={Routes.SYSTEM.LOOKUPTABLES.CACHES.OVERVIEW}>
+                  <Button bsStyle="info">Caches</Button>
                 </LinkContainer>
-              )}
-              &nbsp;
-              <LinkContainer to={Routes.SYSTEM.LOOKUPTABLES.CACHES.OVERVIEW} onlyActiveOnIndex>
-                <Button bsStyle="info">Caches</Button>
-              </LinkContainer>
-              &nbsp;
-              <LinkContainer to={Routes.SYSTEM.LOOKUPTABLES.DATA_ADAPTERS.OVERVIEW}
-                             onlyActiveOnIndex>
-                <Button bsStyle="info">Data Adapters</Button>
-              </LinkContainer>
+                <LinkContainer to={Routes.SYSTEM.LOOKUPTABLES.DATA_ADAPTERS.OVERVIEW}>
+                  <Button bsStyle="info">Data Adapters</Button>
+                </LinkContainer>
+              </ButtonToolbar>
             </span>
           </PageHeader>
 

--- a/graylog2-web-interface/src/pages/NewAlertConditionPage.jsx
+++ b/graylog2-web-interface/src/pages/NewAlertConditionPage.jsx
@@ -1,10 +1,10 @@
 import React from 'react';
 import Reflux from 'reflux';
-import { Button, Col, Row } from 'react-bootstrap';
-import { LinkContainer } from 'react-router-bootstrap';
+import { Col, Row } from 'react-bootstrap';
 
 import DocumentationLink from 'components/support/DocumentationLink';
 import { DocumentTitle, PageHeader } from 'components/common';
+import { AlertsHeaderToolbar } from 'components/alerts';
 import { CreateAlertConditionInput } from 'components/alertconditions';
 
 import Routes from 'routing/Routes';
@@ -31,13 +31,7 @@ const NewAlertConditionPage = React.createClass({
             </span>
 
             <span>
-              <LinkContainer to={Routes.ALERTS.CONDITIONS}>
-                <Button bsStyle="info">Manage conditions</Button>
-              </LinkContainer>
-              &nbsp;
-              <LinkContainer to={Routes.ALERTS.NOTIFICATIONS}>
-                <Button bsStyle="info">Manage notifications</Button>
-              </LinkContainer>
+              <AlertsHeaderToolbar active={Routes.ALERTS.CONDITIONS} />
             </span>
           </PageHeader>
 

--- a/graylog2-web-interface/src/pages/NewAlertNotificationPage.jsx
+++ b/graylog2-web-interface/src/pages/NewAlertNotificationPage.jsx
@@ -1,9 +1,9 @@
 import React from 'react';
 import Reflux from 'reflux';
-import { Button, Col, Row } from 'react-bootstrap';
-import { LinkContainer } from 'react-router-bootstrap';
+import { Col, Row } from 'react-bootstrap';
 
 import { DocumentTitle, PageHeader } from 'components/common';
+import { AlertsHeaderToolbar } from 'components/alerts';
 import { CreateAlertNotificationInput } from 'components/alertnotifications';
 
 import Routes from 'routing/Routes';
@@ -27,13 +27,7 @@ const NewAlertNotificationPage = React.createClass({
             </span>
 
             <span>
-              <LinkContainer to={Routes.ALERTS.NOTIFICATIONS}>
-                <Button bsStyle="info">Manage notifications</Button>
-              </LinkContainer>
-              &nbsp;
-              <Button bsStyle="info" href="https://marketplace.graylog.org/" target="_blank">
-                <i className="fa fa-external-link" />&nbsp; Find more notifications
-              </Button>
+              <AlertsHeaderToolbar active={Routes.ALERTS.NOTIFICATIONS} />
             </span>
           </PageHeader>
 

--- a/graylog2-web-interface/src/pages/ShowAlertPage.jsx
+++ b/graylog2-web-interface/src/pages/ShowAlertPage.jsx
@@ -2,7 +2,7 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import Reflux from 'reflux';
 import { LinkContainer } from 'react-router-bootstrap';
-import { Button, Label, Tooltip } from 'react-bootstrap';
+import { Button, ButtonToolbar, Label, Tooltip } from 'react-bootstrap';
 
 import { DocumentTitle, OverlayElement, PageHeader, Spinner, Timestamp } from 'components/common';
 import { AlertDetails } from 'components/alerts';
@@ -127,16 +127,17 @@ const ShowAlertPage = React.createClass({
             </span>
 
             <span>
-              <OverlayElement overlay={conditionDetailsTooltip} placement="top" useOverlay={!condition.id}
-                              trigger={['hover', 'focus']}>
-                <LinkContainer to={Routes.show_alert_condition(stream.id, condition.id)} disabled={!condition.id}>
-                  <Button bsStyle="info">Condition details</Button>
+              <ButtonToolbar>
+                <LinkContainer to={Routes.ALERTS.LIST}>
+                  <Button bsStyle="info" className="active">Alerts</Button>
                 </LinkContainer>
-              </OverlayElement>
-              &nbsp;
-              <LinkContainer to={Routes.ALERTS.LIST}>
-                <Button bsStyle="info">Alerts overview</Button>
-              </LinkContainer>
+                <OverlayElement overlay={conditionDetailsTooltip} placement="top" useOverlay={!condition.id}
+                                trigger={['hover', 'focus']}>
+                  <LinkContainer to={Routes.show_alert_condition(stream.id, condition.id)} disabled={!condition.id}>
+                    <Button bsStyle="info">Condition details</Button>
+                  </LinkContainer>
+                </OverlayElement>
+              </ButtonToolbar>
             </span>
           </PageHeader>
 


### PR DESCRIPTION
@lennartkoopmann started unifying navigation buttons (e.g. https://github.com/Graylog2/graylog-plugin-pipeline-processor/pull/186), but alerts and lookup tables never got updated.

This PR takes care of those sections, by:
- Keeping same button layout when it makes sense
- Using `active` class to indicate the section currently opened
- Moving or changing some buttons, when there are many things to show in the navigation