### PR TITLE
Remove VersionEye

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,8 +20,6 @@ before_script:
 script:
   - mvn -B verify -Dit.ElasticsearchVersion=${GRAYLOG_ELASTICSEARCH_VERSION}
 after_success:
-  - curl -X GET https://letsencrypt.org/certs/lets-encrypt-x3-cross-signed.der -o lets-encrypt-x3-cross-signed.der && sudo keytool -trustcacerts -keystore $JAVA_HOME/jre/lib/security/cacerts -storepass changeit -noprompt -importcert -alias lets-encrypt-x3-cross-signed -file lets-encrypt-x3-cross-signed.der
-  - mvn -B -Dmaven.test.skip=true -Dskip.web.build=true -pl graylog2-server versioneye:securityAndLicenseCheck
   - mvn -B -Dmaven.test.skip=true -Dskip.web.build=true assembly:single
   - mvn -B -Dmaven.test.skip=true -Dskip.web.build=true --settings config/settings.xml deploy
 deploy:

--- a/graylog2-server/pom.xml
+++ b/graylog2-server/pom.xml
@@ -556,11 +556,6 @@
                     <artifactId>buildnumber-maven-plugin</artifactId>
                     <version>1.4</version>
                 </plugin>
-                <plugin>
-                    <groupId>com.versioneye</groupId>
-                    <artifactId>versioneye-maven-plugin</artifactId>
-                    <version>3.11.1</version>
-                </plugin>
             </plugins>
         </pluginManagement>
         <plugins>
@@ -655,15 +650,6 @@
             <plugin>
                 <groupId>com.mycila</groupId>
                 <artifactId>license-maven-plugin</artifactId>
-            </plugin>
-            <plugin>
-                <groupId>com.versioneye</groupId>
-                <artifactId>versioneye-maven-plugin</artifactId>
-                <configuration>
-                    <organisation>Graylog</organisation>
-                    <team>Owners</team>
-                    <projectId>570f6fbbd1a090000fe62b58</projectId>
-                </configuration>
             </plugin>
         </plugins>
     </build>


### PR DESCRIPTION
The VersionEye SaaS is shutting down, so we should remove the integration with our build.

https://blog.versioneye.com/2017/10/19/versioneye-sunset-process/