### PR TITLE
Fix router for routes with query parameters

### DIFF
--- a/graylog2-web-interface/src/routing/Routes.jsx
+++ b/graylog2-web-interface/src/routing/Routes.jsx
@@ -196,12 +196,12 @@ const qualifyUrls = (routes, appPrefix) => {
   Object.keys(routes).forEach((routeName) => {
     switch (typeof routes[routeName]) {
       case 'string':
-        qualifiedRoutes[routeName] = new URI(appPrefix + '/' + routes[routeName]).normalizePath().resource();
+        qualifiedRoutes[routeName] = new URI(`${appPrefix}/${routes[routeName]}`).normalizePath().resource();
         break;
       case 'function':
         qualifiedRoutes[routeName] = (...params) => {
           const result = routes[routeName](...params);
-          return new URI(appPrefix + '/' + result).normalizePath().resource();
+          return new URI(`${appPrefix}/${result}`).normalizePath().resource();
         };
         break;
       case 'object':

--- a/graylog2-web-interface/src/routing/Routes.jsx
+++ b/graylog2-web-interface/src/routing/Routes.jsx
@@ -196,12 +196,12 @@ const qualifyUrls = (routes, appPrefix) => {
   Object.keys(routes).forEach((routeName) => {
     switch (typeof routes[routeName]) {
       case 'string':
-        qualifiedRoutes[routeName] = new URI(appPrefix + '/' + routes[routeName]).normalizePath().path();
+        qualifiedRoutes[routeName] = new URI(appPrefix + '/' + routes[routeName]).normalizePath().resource();
         break;
       case 'function':
         qualifiedRoutes[routeName] = (...params) => {
           const result = routes[routeName](...params);
-          return new URI(appPrefix + '/' + result).normalizePath().path();
+          return new URI(appPrefix + '/' + result).normalizePath().resource();
         };
         break;
       case 'object':

--- a/graylog2-web-interface/src/routing/Routes.test.jsx
+++ b/graylog2-web-interface/src/routing/Routes.test.jsx
@@ -1,0 +1,58 @@
+import URI from 'urijs';
+
+let Routes;
+const prefix = '/test';
+
+describe('Routes', () => {
+  describe('without prefix', () => {
+    beforeAll(() => {
+      jest.resetModules();
+      window.appConfig = {}; // Ensure no prefix is set
+      Routes = require.requireActual('./Routes');
+    });
+
+    it('returns a route from constant', () => {
+      expect(Routes.SEARCH).toMatch('/search');
+    });
+
+    it('returns a route from function', () => {
+      expect(Routes.node('id')).toMatch('/system/nodes/id');
+    });
+
+    it('routes contain query parameters', () => {
+      const uri = URI(Routes.search('', { rangetype: 'relative', relative: 300 }, 'hour'));
+      expect(uri.path()).toMatch('/search');
+      expect(uri.hasQuery('q', '')).toBeTruthy();
+      expect(uri.hasQuery('rangetype', 'relative')).toBeTruthy();
+      expect(uri.hasQuery('relative', '300')).toBeTruthy();
+      expect(uri.hasQuery('interval', 'hour')).toBeTruthy();
+    });
+  });
+
+  describe('with prefix', () => {
+    beforeAll(() => {
+      jest.resetModules();
+      window.appConfig = {
+        gl2AppPathPrefix: prefix,
+      };
+      Routes = require.requireActual('./Routes');
+    });
+
+    it('returns a route from constant', () => {
+      expect(Routes.SEARCH).toMatch(`${prefix}/search`);
+    });
+
+    it('returns a route from function', () => {
+      expect(Routes.node('id')).toMatch(`${prefix}/system/nodes/id`);
+    });
+
+    it('routes contain query parameters', () => {
+      const uri = URI(Routes.search('', { rangetype: 'relative', relative: 300 }, 'hour'));
+      expect(uri.path()).toMatch(`${prefix}/search`);
+      expect(uri.hasQuery('q', '')).toBeTruthy();
+      expect(uri.hasQuery('rangetype', 'relative')).toBeTruthy();
+      expect(uri.hasQuery('relative', '300')).toBeTruthy();
+      expect(uri.hasQuery('interval', 'hour')).toBeTruthy();
+    });
+  });
+});


### PR DESCRIPTION
Use `resource()` urijs method instead of `path()` when generating routes with prefixes. It also adds some tests to ensure this works in the future.

Fixes #4290.