### PR TITLE
Add another way to run the development setup

### DIFF
--- a/graylog2-web-interface/README.md
+++ b/graylog2-web-interface/README.md
@@ -26,6 +26,18 @@ In this case just set the correct (installed!) Python binary before running `npm
 npm config set python python2.7
 ```
 
+### Alternative Development Setup
+
+Due to problems with webpack-dev-server there is another way to run the development setup.
+
+* Install [devd](https://github.com/cortesi/devd)
+* Install [node.js](http://nodejs.org/) and npm.
+* Run `npm install`
+* Run `npm run watch` to start webpack in watch mode to rebuild on source changes
+* Run `npm run devd` after the initial build is done and the `build/` directory exists
+* Open http://localhost:8080
+
+
 #### Update Javascript dependencies
 
 a. Update a single dependency

--- a/graylog2-web-interface/README.md
+++ b/graylog2-web-interface/README.md
@@ -33,8 +33,8 @@ Due to problems with webpack-dev-server there is another way to run the developm
 * Install [devd](https://github.com/cortesi/devd)
 * Install [node.js](http://nodejs.org/) and npm.
 * Run `npm install`
-* Run `npm run watch` to start webpack in watch mode to rebuild on source changes
-* Run `npm run devd` after the initial build is done and the `build/` directory exists
+* Run `npm run watch` and **keep it running** to start webpack in watch mode so it rebuilds on source changes
+* Run `npm run devd` and **keep it running** once the `build/` directory exists
 * Open http://localhost:8080
 
 

--- a/graylog2-web-interface/package.json
+++ b/graylog2-web-interface/package.json
@@ -12,6 +12,8 @@
   "scripts": {
     "start": "webpack-dev-server --config webpack.bundled.js --history-api-fallback --hot --inline",
     "start-nohmr": "webpack-dev-server --watch --history-api-fallback --config webpack.bundled.js",
+    "watch": "webpack --watch --config webpack.bundled.js",
+    "devd": "devd --livewatch --port=8080 --address=127.0.0.1 --notfound=index.html build/",
     "build": "disable_plugins=true webpack --config webpack.bundled.js",
     "prepare-dev": "./tools/prepare-dev",
     "lint": "eslint --ext js,jsx src",
@@ -99,6 +101,7 @@
     "babel-preset-react": "^6.22.0",
     "babel-preset-stage-0": "^6.22.0",
     "clean-webpack-plugin": "^0.1.3",
+    "copy-webpack-plugin": "^4.2.0",
     "css-loader": "^0.28.4",
     "enzyme": "^2.9.0",
     "eslint": "^4.3.0",

--- a/graylog2-web-interface/webpack.config.js
+++ b/graylog2-web-interface/webpack.config.js
@@ -144,6 +144,26 @@ if (TARGET === 'start-nohmr') {
   });
 }
 
+if (TARGET === 'watch') {
+  const CopyWebpackPlugin = require('copy-webpack-plugin');
+
+  console.error('Running in development (watch) mode');
+  module.exports = merge(webpackConfig, {
+    devtool: 'eval',
+    output: {
+      path: BUILD_PATH,
+      filename: '[name].js',
+      publicPath: '/',
+    },
+    plugins: [
+      new webpack.DefinePlugin({DEVELOPMENT: true}),
+      // We need config.js in the "build/" folder. No idea how webpack-dev-server
+      // handles that, I found nothing in the config. (bernd)
+      new CopyWebpackPlugin([{ from: 'config.js' }]),
+    ],
+  });
+}
+
 if (TARGET === 'build') {
   console.error('Running in production mode');
   process.env.NODE_ENV = 'production';


### PR DESCRIPTION
Due to problems with the current webpack-dev-server setup and the number of plugins we use, this adds another option to run the development setup until we find a solution for the webpack-dev-server problem.