### PR TITLE
Migrate usages of React.PropTypes to PropTypes

### DIFF
--- a/graylog2-web-interface/src/components/search/MessageTableEntry.jsx
+++ b/graylog2-web-interface/src/components/search/MessageTableEntry.jsx
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 import React from 'react';
 import Immutable from 'immutable';
 
@@ -7,26 +8,26 @@ import StringUtils from 'util/StringUtils';
 
 const MessageTableEntry = React.createClass({
   propTypes: {
-    allStreams: React.PropTypes.instanceOf(Immutable.List).isRequired,
-    allStreamsLoaded: React.PropTypes.bool.isRequired,
-    disableSurroundingSearch: React.PropTypes.bool,
-    expandAllRenderAsync: React.PropTypes.bool.isRequired,
-    expanded: React.PropTypes.bool.isRequired,
-    highlight: React.PropTypes.bool,
-    highlightMessage: React.PropTypes.string,
-    inputs: React.PropTypes.instanceOf(Immutable.Map).isRequired,
-    message: React.PropTypes.shape({
-      fields: React.PropTypes.object.isRequired,
-      highlight_ranges: React.PropTypes.object,
-      id: React.PropTypes.string.isRequired,
-      index: React.PropTypes.string.isRequired,
+    allStreams: PropTypes.instanceOf(Immutable.List).isRequired,
+    allStreamsLoaded: PropTypes.bool.isRequired,
+    disableSurroundingSearch: PropTypes.bool,
+    expandAllRenderAsync: PropTypes.bool.isRequired,
+    expanded: PropTypes.bool.isRequired,
+    highlight: PropTypes.bool,
+    highlightMessage: PropTypes.string,
+    inputs: PropTypes.instanceOf(Immutable.Map).isRequired,
+    message: PropTypes.shape({
+      fields: PropTypes.object.isRequired,
+      highlight_ranges: PropTypes.object,
+      id: PropTypes.string.isRequired,
+      index: PropTypes.string.isRequired,
     }).isRequired,
-    nodes: React.PropTypes.instanceOf(Immutable.Map).isRequired,
-    searchConfig: React.PropTypes.object,
-    selectedFields: React.PropTypes.instanceOf(Immutable.OrderedSet),
-    showMessageRow: React.PropTypes.bool,
-    streams: React.PropTypes.instanceOf(Immutable.Map).isRequired,
-    toggleDetail: React.PropTypes.func.isRequired,
+    nodes: PropTypes.instanceOf(Immutable.Map).isRequired,
+    searchConfig: PropTypes.object,
+    selectedFields: PropTypes.instanceOf(Immutable.OrderedSet),
+    showMessageRow: PropTypes.bool,
+    streams: PropTypes.instanceOf(Immutable.Map).isRequired,
+    toggleDetail: PropTypes.func.isRequired,
   },
   getDefaultProps() {
     return {

--- a/graylog2-web-interface/src/components/search/ResultTable.jsx
+++ b/graylog2-web-interface/src/components/search/ResultTable.jsx
@@ -14,14 +14,14 @@ import { MessageTableEntry, MessageTablePaginator } from 'components/search';
 
 const ResultTable = React.createClass({
   propTypes: {
-    disableSurroundingSearch: React.PropTypes.bool,
+    disableSurroundingSearch: PropTypes.bool,
     highlight: PropTypes.bool.isRequired,
     inputs: PropTypes.object.isRequired,
     messages: PropTypes.array.isRequired,
     nodes: PropTypes.object.isRequired,
-    onPageChange: React.PropTypes.func,
+    onPageChange: PropTypes.func,
     page: PropTypes.number.isRequired,
-    pageSize: React.PropTypes.number,
+    pageSize: PropTypes.number,
     resultCount: PropTypes.number.isRequired,
     selectedFields: PropTypes.object.isRequired,
     sortField: PropTypes.string.isRequired,

--- a/graylog2-web-interface/src/components/visualizations/NumericVisualization.jsx
+++ b/graylog2-web-interface/src/components/visualizations/NumericVisualization.jsx
@@ -23,9 +23,9 @@ const NumericVisualization = React.createClass({
       PropTypes.object,
       PropTypes.number,
     ]).isRequired,
-    height: React.PropTypes.number,
-    width: React.PropTypes.number,
-    onRenderComplete: React.PropTypes.func,
+    height: PropTypes.number,
+    width: PropTypes.number,
+    onRenderComplete: PropTypes.func,
   },
 
   getDefaultProps() {

--- a/graylog2-web-interface/src/components/visualizations/RenderCompletionObserver.jsx
+++ b/graylog2-web-interface/src/components/visualizations/RenderCompletionObserver.jsx
@@ -1,11 +1,12 @@
+import PropTypes from 'prop-types';
 import React from 'react';
 
 const RenderCompletionObserver = React.createClass({
   propTypes: {
-    onRenderComplete: React.PropTypes.func.isRequired,
-    children: React.PropTypes.oneOfType([
-      React.PropTypes.element,
-      React.PropTypes.arrayOf(React.PropTypes.element),
+    onRenderComplete: PropTypes.func.isRequired,
+    children: PropTypes.oneOfType([
+      PropTypes.element,
+      PropTypes.arrayOf(PropTypes.element),
     ]).isRequired,
   },
 


### PR DESCRIPTION
This PR takes care of a few missing usages of `React.PropTypes` that were in our code. The initial work was done in #4059.

This problem only triggers a warning in development mode, so no need to migrate it to 2.4.0.