### PR TITLE
Update ES6 classes formatting

### DIFF
--- a/graylog2-web-interface/src/components/bootstrap/BootstrapModalForm.jsx
+++ b/graylog2-web-interface/src/components/bootstrap/BootstrapModalForm.jsx
@@ -1,6 +1,5 @@
 import PropTypes from 'prop-types';
-import React, { Component } from 'react';
-import ReactDOM from 'react-dom';
+import React from 'react';
 import { Modal, Button } from 'react-bootstrap';
 import $ from 'jquery';
 
@@ -12,34 +11,54 @@ import { validate } from 'legacy/validations.js';
  * Encapsulates a form element inside a bootstrap modal, hiding some custom logic that this kind of component
  * has, and providing form validation using HTML5 and our custom validation.
  */
-class BootstrapModalForm extends Component {
-  constructor(props) {
-    super(props);
-
-    this.open = this.open.bind(this);
-    this.close = this.close.bind(this);
-    this._submit = this._submit.bind(this);
-    this._onModalCancel = this._onModalCancel.bind(this);
+class BootstrapModalForm extends React.Component {
+  static defaultProps = {
+    formProps: {},
+    cancelButtonText: 'Cancel',
+    submitButtonText: 'Submit',
+    submitButtonDisabled: false,
+    onModalOpen: () => {},
+    onModalClose: () => {},
+    onSubmitForm: undefined,
+    onCancel: () => {},
   }
 
-  _onModalCancel() {
-    if (typeof this.props.onCancel === 'function') {
-      this.props.onCancel();
-    }
+  static propTypes = {
+    /* Modal title */
+    title: PropTypes.oneOfType([PropTypes.string, PropTypes.node]).isRequired,
+    /* Form contents, included in the modal body */
+    children: PropTypes.oneOfType([
+      PropTypes.arrayOf(PropTypes.element),
+      PropTypes.element,
+    ]).isRequired,
+    onModalOpen: PropTypes.func,
+    onModalClose: PropTypes.func,
+    onSubmitForm: PropTypes.func,
+    onCancel: PropTypes.func,
+    /* Object with additional props to pass to the form */
+    formProps: PropTypes.object,
+    /* Text to use in the cancel button. "Cancel" is the default */
+    cancelButtonText: PropTypes.string,
+    /* Text to use in the submit button. "Submit" is the default */
+    submitButtonText: PropTypes.string,
+    submitButtonDisabled: PropTypes.bool,
+  }
 
+  onModalCancel = () => {
+    this.props.onCancel();
     this.close();
   }
 
-  open() {
-    this.refs.modal.open();
+  open = () => {
+    this.modal.open();
   }
 
-  close() {
-    this.refs.modal.close();
+  close = () => {
+    this.modal.close();
   }
 
-  _submit(event) {
-    const formDOMNode = ReactDOM.findDOMNode(this.refs.form);
+  submit = (event) => {
+    const formDOMNode = this.form;
     const $formDOMNode = $(formDOMNode);
 
     if ((typeof formDOMNode.checkValidity === 'function' && !formDOMNode.checkValidity()) ||
@@ -54,6 +73,7 @@ class BootstrapModalForm extends Component {
       return;
     }
 
+    // If function is not given, let the browser continue propagating the submit event
     if (typeof this.props.onSubmitForm === 'function') {
       event.preventDefault();
       this.props.onSubmitForm(event);
@@ -68,19 +88,19 @@ class BootstrapModalForm extends Component {
     );
 
     return (
-      <BootstrapModalWrapper ref="modal"
+      <BootstrapModalWrapper ref={(c) => { this.modal = c; }}
                              onOpen={this.props.onModalOpen}
                              onClose={this.props.onModalClose}
-                             onHide={this._onModalCancel}>
+                             onHide={this.onModalCancel}>
         <Modal.Header closeButton>
           <Modal.Title>{this.props.title}</Modal.Title>
         </Modal.Header>
-        <form ref="form" onSubmit={this._submit} {...this.props.formProps}>
+        <form ref={(c) => { this.form = c; }} onSubmit={this.submit} {...this.props.formProps}>
           <Modal.Body>
             {body}
           </Modal.Body>
           <Modal.Footer>
-            <Button type="button" onClick={this._onModalCancel}>{this.props.cancelButtonText}</Button>
+            <Button type="button" onClick={this.onModalCancel}>{this.props.cancelButtonText}</Button>
             <Button type="submit" disabled={this.props.submitButtonDisabled} bsStyle="primary">{this.props.submitButtonText}</Button>
           </Modal.Footer>
         </form>
@@ -88,33 +108,5 @@ class BootstrapModalForm extends Component {
     );
   }
 }
-
-BootstrapModalForm.propTypes = {
-  /* Modal title */
-  title: PropTypes.oneOfType([PropTypes.string, PropTypes.node]),
-  /* Form contents, included in the modal body */
-  children: PropTypes.oneOfType([
-    PropTypes.arrayOf(PropTypes.element),
-    PropTypes.element,
-  ]).isRequired,
-  onModalOpen: PropTypes.func,
-  onModalClose: PropTypes.func,
-  onSubmitForm: PropTypes.func,
-  onCancel: PropTypes.func,
-  /* Object with additional props to pass to the form */
-  formProps: PropTypes.object,
-  /* Text to use in the cancel button. "Cancel" is the default */
-  cancelButtonText: PropTypes.string,
-  /* Text to use in the submit button. "Submit" is the default */
-  submitButtonText: PropTypes.string,
-  submitButtonDisabled: PropTypes.bool,
-};
-
-BootstrapModalForm.defaultProps = {
-  formProps: {},
-  cancelButtonText: 'Cancel',
-  submitButtonText: 'Submit',
-  submitButtonDisabled: false,
-};
 
 export default BootstrapModalForm;

--- a/graylog2-web-interface/src/components/bootstrap/BootstrapModalWrapper.jsx
+++ b/graylog2-web-interface/src/components/bootstrap/BootstrapModalWrapper.jsx
@@ -1,71 +1,52 @@
 import PropTypes from 'prop-types';
-import React, { Component } from 'react';
+import React from 'react';
 import { Modal } from 'react-bootstrap';
 
 /**
  * Encapsulates a react-bootstrap modal, hiding the state handling for the modal
  */
-class BootstrapModalWrapper extends Component {
-  constructor(props) {
-    super(props);
-
-    this.open = this.open.bind(this);
-    this.close = this.close.bind(this);
-    this._hide = this._hide.bind(this);
-
-    this.state = {
-      showModal: props.showModal || false,
-    };
+class BootstrapModalWrapper extends React.Component {
+  static defaultProps = {
+    showModal: false,
+    onOpen: () => {},
+    onClose: () => {},
+    onHide: () => {},
   }
 
-  onOpen() {
-    if (typeof this.props.onOpen === 'function') {
-      this.props.onOpen();
-    }
+  static propTypes = {
+    showModal: PropTypes.bool,
+    children: PropTypes.oneOfType([
+      PropTypes.arrayOf(PropTypes.element),
+      PropTypes.element,
+    ]).isRequired,
+    onOpen: PropTypes.func,
+    onClose: PropTypes.func,
+    onHide: PropTypes.func,
   }
 
-  onClose() {
-    if (typeof this.props.onClose === 'function') {
-      this.props.onClose();
-    }
+  state = {
+    showModal: this.props.showModal || false,
   }
 
-  onHide() {
-    if (typeof this.props.onHide === 'function') {
-      this.props.onHide();
-    }
+  open = () => {
+    this.setState({ showModal: true }, this.props.onOpen);
   }
 
-  open() {
-    this.setState({ showModal: true }, this.onOpen);
+  close = () => {
+    this.setState({ showModal: false }, this.props.onClose);
   }
 
-  close() {
-    this.setState({ showModal: false }, this.onClose);
-  }
-
-  _hide() {
-    this.setState({ showModal: false }, this.onHide);
+  hide = () => {
+    this.setState({ showModal: false }, this.props.onHide);
   }
 
   render() {
     return (
-      <Modal show={this.state.showModal} onHide={this._hide}>
+      <Modal show={this.state.showModal} onHide={this.hide}>
         {this.props.children}
       </Modal>
     );
   }
 }
-
-BootstrapModalWrapper.propTypes = {
-  showModal: PropTypes.bool,
-  children: PropTypes.oneOfType([
-    PropTypes.arrayOf(PropTypes.element),
-    PropTypes.element,
-  ]).isRequired,
-  onOpen: PropTypes.func,
-  onClose: PropTypes.func,
-  onHide: PropTypes.func,
-};
 
 export default BootstrapModalWrapper;

--- a/graylog2-web-interface/src/components/streams/MatchingTypeSwitcher.jsx
+++ b/graylog2-web-interface/src/components/streams/MatchingTypeSwitcher.jsx
@@ -1,41 +1,27 @@
 import PropTypes from 'prop-types';
 import React from 'react';
-import { Component } from 'react';
 import { Input } from 'components/bootstrap';
 
 import StoreProvider from 'injection/StoreProvider';
-const StreamsStore = StoreProvider.getStore('Streams');
-
 import UserNotification from 'util/UserNotification';
 
-class MatchingTypeSwitcher extends Component {
+const StreamsStore = StoreProvider.getStore('Streams');
+
+class MatchingTypeSwitcher extends React.Component {
   static propTypes = {
     stream: PropTypes.object.isRequired,
     onChange: PropTypes.func.isRequired,
   };
 
-  render() {
-    return (
-      <div className="streamrule-connector-type-form">
-        <div>
-          <Input type="radio" label="A message must match all of the following rules"
-                 checked={this.props.stream.matching_type === 'AND'} onChange={this.handleTypeChangeToAnd.bind(this)} />
-          <Input type="radio" label="A message must match at least one of the following rules"
-                 checked={this.props.stream.matching_type === 'OR'} onChange={this.handleTypeChangeToOr.bind(this)} />
-        </div>
-      </div>
-    );
-  }
-
-  handleTypeChangeToAnd() {
+  handleTypeChangeToAnd = () => {
     this.handleTypeChange('AND');
   }
 
-  handleTypeChangeToOr() {
+  handleTypeChangeToOr = () => {
     this.handleTypeChange('OR');
   }
 
-  handleTypeChange(newValue) {
+  handleTypeChange = (newValue) => {
     if (window.confirm('You are about to change how rules are applied to this stream, do you want to continue? Changes will take effect immediately.')) {
       StreamsStore.update(this.props.stream.id, { matching_type: newValue }, (response) => {
         this.props.onChange();
@@ -44,6 +30,23 @@ class MatchingTypeSwitcher extends Component {
         return response;
       });
     }
+  }
+
+  render() {
+    return (
+      <div className="streamrule-connector-type-form">
+        <div>
+          <Input type="radio"
+                 label="A message must match all of the following rules"
+                 checked={this.props.stream.matching_type === 'AND'}
+                 onChange={this.handleTypeChangeToAnd} />
+          <Input type="radio"
+                 label="A message must match at least one of the following rules"
+                 checked={this.props.stream.matching_type === 'OR'}
+                 onChange={this.handleTypeChangeToOr} />
+        </div>
+      </div>
+    );
   }
 }
 


### PR DESCRIPTION
As ES6 React components are here to stay, update existing ES6 classes to ensure other people have a more or less good example to look at:

- Use arrow functions instead of manually binding functions in constructor
- Add `propTypes`, `defaultProps` and state directly inside the class, making components look more like those created with `createClass`. Unfortunately creating an ESLint rule for this requires more time that I'm willing to spend on it right now
- Use function `ref`s
- Remove superfluous functions
