### PR TITLE
 Change data that is shown by the QuickValues histogram

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/indexer/results/TermsHistogramResult.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/results/TermsHistogramResult.java
@@ -27,13 +27,16 @@ import org.joda.time.DateTime;
 
 import javax.annotation.Nullable;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 public class TermsHistogramResult extends IndexQueryResult {
     private final long size;
     private final Searches.DateHistogramInterval interval;
     private final Map<Long, TermsResult> result;
+    private final HashSet<String> terms;
     private AbsoluteRange boundaries;
 
     public TermsHistogramResult(@Nullable DateHistogramAggregation result, String originalQuery, String builtQuery, long size, long tookMs, Searches.DateHistogramInterval interval, List<String> fields) {
@@ -41,6 +44,7 @@ public class TermsHistogramResult extends IndexQueryResult {
         this.size = size;
         this.interval = interval;
         this.result = Maps.newTreeMap();
+        this.terms = new HashSet<>();
 
         if (result != null) {
             for (DateHistogramAggregation.DateHistogram histogram : result.getBuckets()) {
@@ -49,6 +53,7 @@ public class TermsHistogramResult extends IndexQueryResult {
                 final MissingAggregation missingAgregation = histogram.getMissingAggregation("missing");
                 final TermsResult termsResult = new TermsResult(termsAggregation, missingAgregation.getMissing(), histogram.getCount(), "", "", tookMs, fields);
 
+                this.terms.addAll(termsResult.getTerms().keySet());
                 this.result.put(keyAsDate.getMillis() / 1000L, termsResult);
             }
         }
@@ -64,6 +69,10 @@ public class TermsHistogramResult extends IndexQueryResult {
 
     public Map<Long, TermsResult> getResults() {
         return this.result;
+    }
+
+    public Set<String> getTerms() {
+        return this.terms;
     }
 
     /*

--- a/graylog2-server/src/main/java/org/graylog2/rest/models/search/responses/TermsHistogramResult.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/models/search/responses/TermsHistogramResult.java
@@ -22,6 +22,7 @@ import com.google.auto.value.AutoValue;
 import org.graylog.autovalue.WithBeanGetter;
 
 import java.util.Map;
+import java.util.Set;
 
 @JsonAutoDetect
 @AutoValue
@@ -39,13 +40,16 @@ public abstract class TermsHistogramResult {
     @JsonProperty("buckets")
     public abstract Map<Long, TermsResult> buckets();
 
+    @JsonProperty("terms")
+    public abstract Set<String> terms();
+
     @JsonProperty("built_query")
     public abstract String builtQuery();
 
     @JsonProperty("queried_timerange")
     public abstract TimeRange queriedTimerange();
 
-    public static TermsHistogramResult create(long time, String interval, long size, Map<Long, TermsResult> buckets, String builtQuery, TimeRange queriedTimerange) {
-        return new AutoValue_TermsHistogramResult(time, interval, size, buckets, builtQuery, queriedTimerange);
+    public static TermsHistogramResult create(long time, String interval, long size, Map<Long, TermsResult> buckets, Set<String> terms, String builtQuery, TimeRange queriedTimerange) {
+        return new AutoValue_TermsHistogramResult(time, interval, size, buckets, terms, builtQuery, queriedTimerange);
     }
 }

--- a/graylog2-server/src/main/java/org/graylog2/utilities/SearchUtils.java
+++ b/graylog2-server/src/main/java/org/graylog2/utilities/SearchUtils.java
@@ -84,6 +84,7 @@ public class SearchUtils {
                 termsHistogram.getInterval().toString().toLowerCase(Locale.ENGLISH),
                 termsHistogram.getSize(),
                 result,
+                termsHistogram.getTerms(),
                 termsHistogram.getBuiltQuery(),
                 org.graylog2.rest.models.search.responses.TimeRange.create(histogramBoundaries.getFrom(), histogramBoundaries.getTo()));
     }

--- a/graylog2-web-interface/src/components/field-analyzers/FieldQuickValues.jsx
+++ b/graylog2-web-interface/src/components/field-analyzers/FieldQuickValues.jsx
@@ -3,6 +3,7 @@ import React from 'react';
 import ReactDOM from 'react-dom';
 import { DropdownButton, MenuItem, Button } from 'react-bootstrap';
 import Reflux from 'reflux';
+import crossfilter from 'crossfilter';
 
 import { QuickValuesVisualization, QuickValuesHistogramVisualization } from 'components/visualizations';
 import AddToDashboardMenu from 'components/dashboard/AddToDashboardMenu';
@@ -92,11 +93,71 @@ const FieldQuickValues = React.createClass({
   addField(field) {
     this.setState({ field: field, showHistogram: false, showVizOptions: false }, () => this._loadQuickValuesData(false));
   },
+  // Builds a field query object list: [{ field: "cluster_id", value: "a" }, { field: "source", value: "b" }, ...]
+  _buildFieldQueryObjects() {
+    // We build a list of field query objects from the terms and terms_mapping data.
+    //
+    // {
+    //    field: "fieldName",
+    //    stacked_fields: ["fieldName2"],
+    //    terms: {
+    //      "foo - bar": 1,
+    //      "foo - baz": 2
+    //    },
+    //    terms_mapping: {
+    //      "foo - bar": [
+    //        { field: "fieldName", value: "foo" },
+    //        { field: "fieldName2", value: "bar" },
+    //      ],
+    //      "foo - baz": [
+    //        { field: "fieldName", value: "foo" },
+    //        { field: "fieldName2", value: "baz" },
+    //      ]
+    //    }
+    // }
+    //
+    // Will be transformed into:
+    //
+    //   [
+    //     [
+    //       { field: 'fieldName', value: 'foo' }
+    //       { field: 'fieldName2', value: 'bar' }
+    //     ],
+    //     [
+    //       { field: 'fieldName', value: 'foo' }
+    //       { field: 'fieldName2', value: 'baz' }
+    //     ],
+    //   ]
+    //
+    // We only transform the top/bottom N (limit) entries.
+
+    // Build a structure that is suitable for crossfilter
+    const data = Object.keys(this.state.data.terms)
+      .reduce((list, field) => {
+        list.push({ field: field, count: this.state.data.terms[field] });
+        return list;
+      }, []);
+
+    // Using crossfilter here to get the top or bottom N values
+    const cf = crossfilter(data).dimension(d => d.count);
+    let values;
+    if (this.state.options.order === 'desc') {
+      values = cf.top(this.state.options.limit);
+    } else {
+      values = cf.bottom(this.state.options.limit);
+    }
+
+    // Transform into field query objects as described above
+    return values.reduce((list, f) => {
+      list.push(this.state.data.terms_mapping[f.field]);
+      return list;
+    }, []);
+  },
   _loadQuickValuesData() {
     if (this.state.field !== undefined) {
       this.setState({ loadingData: true });
       if (this.state.showHistogram) {
-        FieldQuickValuesActions.getHistogram(this.state.field, this.state.options).then(() => {
+        FieldQuickValuesActions.getHistogram(this.state.field, this.state.fieldQueryObjects, this.state.options).then(() => {
           this.setState({ loadingData: false });
         });
       } else {
@@ -123,8 +184,8 @@ const FieldQuickValues = React.createClass({
   },
 
   _showHistogram() {
-    // Reset the data when toggling histogram
-    this.setState({ data: [], showHistogram: true }, this._loadQuickValuesData);
+    // Reset the data when toggling histogram and build field query objects from existing data
+    this.setState({ data: [], fieldQueryObjects: this._buildFieldQueryObjects(), showHistogram: true }, this._loadQuickValuesData);
   },
 
   _showOverview() {

--- a/graylog2-web-interface/src/components/field-analyzers/FieldQuickValues.jsx
+++ b/graylog2-web-interface/src/components/field-analyzers/FieldQuickValues.jsx
@@ -90,7 +90,7 @@ const FieldQuickValues = React.createClass({
     }
   },
   addField(field) {
-    this.setState({ field: field }, () => this._loadQuickValuesData(false));
+    this.setState({ field: field, showHistogram: false, showVizOptions: false }, () => this._loadQuickValuesData(false));
   },
   _loadQuickValuesData() {
     if (this.state.field !== undefined) {

--- a/graylog2-web-interface/src/components/visualizations/QuickValuesVisualization.jsx
+++ b/graylog2-web-interface/src/components/visualizations/QuickValuesVisualization.jsx
@@ -186,12 +186,19 @@ const QuickValuesVisualization = React.createClass({
       (d) => {
         let colourBadge = '';
 
+        let formattedTerm = d.term;
+        if (this.props.data.terms_mapping && this.props.data.terms_mapping[d.term]) {
+          // Separate the terms with a character that is unusual in terms and use a different text color to make the
+          // different terms in the stacked value more visible.
+          formattedTerm = this.props.data.terms_mapping[d.term].map(t => t.value).join(' <strong style="color: #e3e3e3;">&mdash;</strong> ');
+        }
+
         if (typeof this.pieChart !== 'undefined' && this.dataTable.group()(d) !== 'Others') {
           const colour = this.pieChart.colors()(d.term);
           colourBadge = `<span class="datatable-badge" style="background-color: ${colour} !important;"></span>`;
         }
 
-        return `${colourBadge} ${d.term}`;
+        return `${colourBadge} ${formattedTerm}`;
       },
       d => NumberUtils.formatPercentage(d.percentage),
       d => NumberUtils.formatNumber(d.count),

--- a/graylog2-web-interface/src/stores/field-analyzers/FieldQuickValuesStore.js
+++ b/graylog2-web-interface/src/stores/field-analyzers/FieldQuickValuesStore.js
@@ -62,7 +62,7 @@ const FieldQuickValuesStore = Reflux.createStore({
     FieldQuickValuesActions.get.promise(promise);
   },
 
-  getHistogram(field, options = {}) {
+  getHistogram(field, fieldQueryObjects, options = {}) {
     const { order, limit, stackedFields, interval } = options;
 
     this.trigger({ loading: true });
@@ -86,9 +86,12 @@ const FieldQuickValuesStore = Reflux.createStore({
       // Do nothing
     }
 
+    // Build a new query that scopes the result to the requested field terms
+    const query = SearchStore.appendFieldQueryObjectToQueryString(originalSearchURLParams.get('q') || '*', fieldQueryObjects, SearchStore.AND_OPERATOR);
+
     const url = ApiRoutes.UniversalSearchApiController.fieldTermsHistogram(
       rangeType,
-      originalSearchURLParams.get('q') || '*',
+      query,
       field,
       order,
       limit,


### PR DESCRIPTION
Previously we showed the top/bottom N terms for every bucket in the histogram. That was hard to visualize because every bucket could contain completely different terms.

Now we changed the visualization to show *only* the top/bottom N terms from the regular QuickValues widget projected over time.

Fixes #4291

Note: This needs to be merged into 2.4 as well