### PR TITLE
Show loading indicator when reloading field chart data

### DIFF
--- a/graylog2-web-interface/src/components/field-analyzers/LegacyFieldGraph.jsx
+++ b/graylog2-web-interface/src/components/field-analyzers/LegacyFieldGraph.jsx
@@ -27,8 +27,7 @@ const LegacyFieldGraph = React.createClass({
   },
   mixins: [PureRenderMixin],
   componentDidMount() {
-    const graphContainer = ReactDOM.findDOMNode(this.refs.fieldGraphContainer);
-    FieldGraphsStore.renderFieldGraph(this.props.graphOptions, graphContainer);
+    FieldGraphsStore.renderFieldGraph(this.props.graphOptions, this.fieldGraphContainer);
   },
   componentDidUpdate(prevProps) {
     if (this.props.from !== prevProps.from || this.props.to !== prevProps.to) {
@@ -112,7 +111,7 @@ const LegacyFieldGraph = React.createClass({
     );
 
     return (
-      <div ref="fieldGraphContainer"
+      <div ref={(c) => { this.fieldGraphContainer = c; }}
            style={{ display: this.props.hidden ? 'none' : 'block' }}
            className="content-col field-graph-container"
            data-chart-id={this.props.graphId}

--- a/graylog2-web-interface/src/components/field-analyzers/LegacyFieldGraph.jsx
+++ b/graylog2-web-interface/src/components/field-analyzers/LegacyFieldGraph.jsx
@@ -31,7 +31,7 @@ const LegacyFieldGraph = React.createClass({
   },
   componentDidUpdate(prevProps) {
     if (this.props.from !== prevProps.from || this.props.to !== prevProps.to) {
-      FieldGraphsStore.updateFieldGraphData(this.props.graphId);
+      FieldGraphsStore.updateFieldGraphData(this.props.graphId, this.fieldGraphContainer);
     }
   },
 

--- a/graylog2-web-interface/src/stores/field-analyzers/FieldGraphsStore.ts
+++ b/graylog2-web-interface/src/stores/field-analyzers/FieldGraphsStore.ts
@@ -193,7 +193,7 @@ class FieldGraphsStore {
       }
     }
 
-    updateFieldGraphData(graphId: string) {
+    updateFieldGraphData(graphId: string, graphContainer: Element) {
         const seriesName = graphId;
         const graphOptions = this.fieldGraphs.get(graphId);
         let effectiveGraphId;
@@ -211,7 +211,7 @@ class FieldGraphsStore {
             effectiveGraphId = graphId;
         }
 
-        FieldChart.updateFieldChartData(effectiveGraphId, graphOptions, seriesName);
+        FieldChart.updateFieldChartData(effectiveGraphId, graphOptions, seriesName, $(graphContainer));
     }
 
     stackGraphs(targetGraphId: string, sourceGraphId: string) {


### PR DESCRIPTION
This PR displays a loading spinner while we fetch data to update a field chart. This will be visible when the search is updated, a new statistical function is selected, and when the chart resolution changes.

Fixes #4295 and should be cherry-picked into 2.4.