### PR TITLE
Show feedback on create widget modal

### DIFF
--- a/graylog2-web-interface/src/components/dashboard/AddToDashboardMenu.jsx
+++ b/graylog2-web-interface/src/components/dashboard/AddToDashboardMenu.jsx
@@ -42,6 +42,7 @@ const AddToDashboardMenu = React.createClass({
   getInitialState() {
     return {
       selectedDashboard: '',
+      loading: false,
     };
   },
 
@@ -111,8 +112,11 @@ const AddToDashboardMenu = React.createClass({
 
     widgetConfig = searchParams.merge(widgetConfig).merge(configuration);
 
+    this.setState({ loading: true });
     const promise = WidgetsStore.addWidget(this.state.selectedDashboard, this.props.widgetType, title, widgetConfig.toJS());
-    promise.done(() => this.refs.widgetModal.saved());
+    promise
+      .then(() => this.refs.widgetModal.saved())
+      .finally(() => this.setState({ loading: false }));
   },
   _createNewDashboard() {
     this.refs.createDashboardModal.open();
@@ -184,6 +188,7 @@ const AddToDashboardMenu = React.createClass({
     }
 
     const { appendMenus, children } = this.props;
+    const loading = this.state.loading;
 
     return (
       <div style={{ display: 'inline-block' }}>
@@ -198,7 +203,8 @@ const AddToDashboardMenu = React.createClass({
         <WidgetCreationModal ref="widgetModal"
                              widgetType={this.props.widgetType}
                              onConfigurationSaved={this._saveWidget}
-                             fields={this.props.fields} />
+                             fields={this.props.fields}
+                             loading={loading} />
       </div>
     );
   },

--- a/graylog2-web-interface/src/components/widgets/WidgetCreationModal.jsx
+++ b/graylog2-web-interface/src/components/widgets/WidgetCreationModal.jsx
@@ -15,6 +15,13 @@ const WidgetCreationModal = React.createClass({
     onConfigurationSaved: PropTypes.func.isRequired,
     onModalHidden: PropTypes.func,
     widgetType: PropTypes.string.isRequired,
+    loading: PropTypes.bool,
+  },
+
+  getDefaultProps() {
+    return {
+      loading: false,
+    };
   },
 
   getInitialState() {
@@ -114,13 +121,15 @@ const WidgetCreationModal = React.createClass({
   },
 
   render() {
+    const loading = this.props.loading;
     return (
       <BootstrapModalForm ref="createModal"
                           title="Create Dashboard Widget"
                           onModalOpen={this._getInitialConfiguration}
                           onModalClose={this.props.onModalHidden}
                           onSubmitForm={this.save}
-                          submitButtonText="Create">
+                          submitButtonText={loading ? 'Creating...' : 'Create'}
+                          submitButtonDisabled={loading}>
         <fieldset>
           <Input type="text"
                  label="Title"


### PR DESCRIPTION
Disable button and change the submit button text while we create the new widget. Reset the state once the promise is fulfilled or rejected.

Fixes #4318 and should be cherry-picked into 2.4.