### PR TITLE
Improve robustness of QuickValues with stacked fields

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/system/stats/elasticsearch/ElasticsearchStats.java
+++ b/graylog2-server/src/main/java/org/graylog2/system/stats/elasticsearch/ElasticsearchStats.java
@@ -19,7 +19,6 @@ package org.graylog2.system.stats.elasticsearch;
 import com.fasterxml.jackson.annotation.JsonAutoDetect;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.auto.value.AutoValue;
-import org.elasticsearch.cluster.health.ClusterHealthStatus;
 import org.graylog.autovalue.WithBeanGetter;
 
 @JsonAutoDetect
@@ -34,6 +33,9 @@ public abstract class ElasticsearchStats {
     public abstract String clusterName();
 
     @JsonProperty
+    public abstract String clusterVersion();
+
+    @JsonProperty
     public abstract HealthStatus status();
 
     @JsonProperty
@@ -46,10 +48,11 @@ public abstract class ElasticsearchStats {
     public abstract IndicesStats indicesStats();
 
     public static ElasticsearchStats create(String clusterName,
+                                            String clusterVersion,
                                             HealthStatus status,
                                             ClusterHealth clusterHealth,
                                             NodesStats nodesStats,
                                             IndicesStats indicesStats) {
-        return new AutoValue_ElasticsearchStats(clusterName, status, clusterHealth, nodesStats, indicesStats);
+        return new AutoValue_ElasticsearchStats(clusterName, clusterVersion, status, clusterHealth, nodesStats, indicesStats);
     }
 }

--- a/graylog2-web-interface/src/components/field-analyzers/FieldQuickValues.jsx
+++ b/graylog2-web-interface/src/components/field-analyzers/FieldQuickValues.jsx
@@ -164,11 +164,11 @@ const FieldQuickValues = React.createClass({
     if (this.state.field !== undefined) {
       this.setState({ loadingData: true });
       if (this.state.showHistogram) {
-        FieldQuickValuesActions.getHistogram(this.state.field, this.state.fieldQueryObjects, this.state.options).then(() => {
+        FieldQuickValuesActions.getHistogram(this.state.field, this.state.fieldQueryObjects, this.state.options).finally(() => {
           this.setState({ loadingData: false });
         });
       } else {
-        FieldQuickValuesActions.get(this.state.field, this.state.options).then(() => {
+        FieldQuickValuesActions.get(this.state.field, this.state.options).finally(() => {
           this.setState({ loadingData: false });
         });
       }

--- a/graylog2-web-interface/src/components/field-analyzers/FieldQuickValues.jsx
+++ b/graylog2-web-interface/src/components/field-analyzers/FieldQuickValues.jsx
@@ -30,6 +30,14 @@ const FieldQuickValues = React.createClass({
   },
   mixins: [Reflux.listenTo(RefreshStore, '_setupTimer', '_setupTimer'), Reflux.connect(FieldQuickValuesStore)],
 
+  DEFAULT_OPTIONS: {
+    order: 'desc',
+    limit: 5,
+    tableSize: 50,
+    stackedFields: '',
+    interval: undefined,
+  },
+
   getDefaultProps() {
     return {
       fields: [],
@@ -42,13 +50,7 @@ const FieldQuickValues = React.createClass({
       data: [],
       showVizOptions: false,
       showHistogram: false,
-      options: {
-        order: 'desc',
-        limit: 5,
-        tableSize: 50,
-        stackedFields: '',
-        interval: undefined,
-      },
+      options: this.DEFAULT_OPTIONS,
       loadingData: false,
     };
   },
@@ -91,7 +93,12 @@ const FieldQuickValues = React.createClass({
     }
   },
   addField(field) {
-    this.setState({ field: field, showHistogram: false, showVizOptions: false }, () => this._loadQuickValuesData(false));
+    this.setState({
+      field: field,
+      showHistogram: false,
+      showVizOptions: false,
+      options: this.DEFAULT_OPTIONS,
+    }, () => this._loadQuickValuesData(false));
   },
   // Builds a field query object list: [{ field: "cluster_id", value: "a" }, { field: "source", value: "b" }, ...]
   _buildFieldQueryObjects() {

--- a/graylog2-web-interface/src/components/field-analyzers/FieldQuickValues.jsx
+++ b/graylog2-web-interface/src/components/field-analyzers/FieldQuickValues.jsx
@@ -17,6 +17,7 @@ import CombinedProvider from 'injection/CombinedProvider';
 
 const { FieldQuickValuesStore, FieldQuickValuesActions } = CombinedProvider.get('FieldQuickValues');
 const { RefreshStore } = CombinedProvider.get('Refresh');
+const { SystemStore } = CombinedProvider.get('System');
 
 const FieldQuickValues = React.createClass({
   propTypes: {
@@ -52,6 +53,7 @@ const FieldQuickValues = React.createClass({
       showHistogram: false,
       options: this.DEFAULT_OPTIONS,
       loadingData: false,
+      disableStackedFields: false,
     };
   },
 
@@ -187,6 +189,13 @@ const FieldQuickValues = React.createClass({
   },
 
   _showVizOptions() {
+    SystemStore.elasticsearchVersion().then((version) => {
+      // The stacking feature of the QuickValues widget needs at least ES 5 because earlier versions do not have
+      // the painless scripting engine.
+      if (version.major < 5) {
+        this.setState({ disableStackedFields: true });
+      }
+    });
     this.setState({ showVizOptions: true });
   },
 
@@ -232,6 +241,7 @@ const FieldQuickValues = React.createClass({
                                   order={this.state.options.order}
                                   stackedFields={this.state.options.stackedFields}
                                   stackedFieldsOptions={this.props.fields}
+                                  disableStackedFields={this.state.disableStackedFields}
                                   field={this.state.field}
                                   interval={this.state.options.interval}
                                   isHistogram={this.state.showHistogram}

--- a/graylog2-web-interface/src/components/field-analyzers/QuickValuesOptionsForm.jsx
+++ b/graylog2-web-interface/src/components/field-analyzers/QuickValuesOptionsForm.jsx
@@ -17,10 +17,17 @@ const QuickValuesOptionsForm = React.createClass({
     field: PropTypes.string.isRequired,
     stackedFields: PropTypes.string,
     stackedFieldsOptions: PropTypes.arrayOf(PropTypes.object).isRequired,
+    disableStackedFields: PropTypes.bool,
     interval: PropTypes.string,
     isHistogram: PropTypes.bool.isRequired,
     onSave: PropTypes.func.isRequired,
     onCancel: PropTypes.func.isRequired,
+  },
+
+  getDefaultProps() {
+    return {
+      disableStackedFields: false,
+    };
   },
 
   getInitialState() {
@@ -94,6 +101,11 @@ const QuickValuesOptionsForm = React.createClass({
       );
     }
 
+    let stackedFieldsPlaceholder = 'Select fields for stacking...';
+    if (this.props.disableStackedFields) {
+      stackedFieldsPlaceholder = 'Feature requires Elasticsearch version >= 5';
+    }
+
     return (
       <Row>
         <Col md={6}>
@@ -130,8 +142,9 @@ const QuickValuesOptionsForm = React.createClass({
                 <ControlLabel>Stacked fields</ControlLabel>
                 <MultiSelect options={fieldOptions}
                              value={this.state.stackedFields}
+                             disabled={this.props.disableStackedFields}
+                             placeholder={stackedFieldsPlaceholder}
                              onChange={this._onStackedFieldChange} />
-                <HelpBlock>The stacked fields option <strong>requires Elasticsearch version &gt;= 5</strong> to work correctly</HelpBlock>
               </FormGroup>
 
               {intervalForm}

--- a/graylog2-web-interface/src/routing/ApiRoutes.js
+++ b/graylog2-web-interface/src/routing/ApiRoutes.js
@@ -41,6 +41,7 @@ const ApiRoutes = {
   ClusterApiResource: {
     list: () => { return { url: '/system/cluster/nodes' }; },
     node: () => { return { url: '/system/cluster/node' }; },
+    elasticsearchStats: () => { return { url: '/system/cluster/stats/elasticsearch' }; },
   },
   DashboardsApiController: {
     create: () => { return { url: '/dashboards' }; },

--- a/graylog2-web-interface/src/stores/system/SystemStore.js
+++ b/graylog2-web-interface/src/stores/system/SystemStore.js
@@ -3,6 +3,7 @@ import Reflux from 'reflux';
 import URLUtils from 'util/URLUtils';
 import ApiRoutes from 'routing/ApiRoutes';
 import fetch from 'logic/rest/FetchProvider';
+import Promise from 'bluebird';
 
 const SystemStore = Reflux.createStore({
   system: undefined,
@@ -34,6 +35,19 @@ const SystemStore = Reflux.createStore({
     const url = URLUtils.qualifyUrl(ApiRoutes.SystemApiController.locales().url);
 
     return fetch('GET', url);
+  },
+  elasticsearchVersion() {
+    const url = URLUtils.qualifyUrl(ApiRoutes.ClusterApiResource.elasticsearchStats().url);
+
+    const promise = new Promise((resolve, reject) => {
+      fetch('GET', url).then((response) => {
+        const splitVersion = response.cluster_version.split('.');
+
+        resolve({ major: splitVersion[0], minor: splitVersion[1], patch: splitVersion[2] });
+      }).catch(reject);
+    });
+
+    return promise;
   },
 });
 


### PR DESCRIPTION
- Disable the stacked field form in QuickValues configuration when Elasticsearch version is < 5
- Reset loading state in case of an error so the user can change settings and try again
- Reset QuickValues visualization config to defaults when analyzing a new field

Closes #4289 

Note: This needs to go into the 2.4 branch as well