### PR TITLE
Replace webpack-dev-server with custom express server

### DIFF
--- a/graylog2-web-interface/devServer.js
+++ b/graylog2-web-interface/devServer.js
@@ -1,0 +1,37 @@
+const express = require('express');
+const webpack = require('webpack');
+const compress = require('compression');
+const history = require('connect-history-api-fallback');
+const webpackDevMiddleware = require('webpack-dev-middleware');
+const webpackHotMiddleware = require('webpack-hot-middleware');
+const webpackConfig = require('./webpack.bundled');
+
+const app = express();
+const vendorConfig = webpackConfig[0];
+const appConfig = webpackConfig[1];
+// Use two compilers to avoid re-compiling the vendor config on every change.
+// We assume dependencies won't change while the server is running.
+const vendorCompiler = webpack(vendorConfig);
+const appCompiler = webpack(appConfig);
+
+
+app.use(compress()); // Enables compression middleware
+app.use(history()); // Enables HTML5 History API middleware
+
+app.use(webpackDevMiddleware(vendorCompiler, {
+  publicPath: appConfig.output.publicPath,
+  lazy: false,
+  noInfo: true,
+}));
+
+app.use(webpackDevMiddleware(appCompiler, {
+  publicPath: appConfig.output.publicPath,
+  lazy: false,
+  noInfo: true,
+}));
+
+app.use(webpackHotMiddleware(appCompiler));
+
+app.listen(8080, () => {
+  console.log('Graylog web interface listening on port 8080!\n');
+});

--- a/graylog2-web-interface/package.json
+++ b/graylog2-web-interface/package.json
@@ -11,7 +11,7 @@
   "readme": "../README.md",
   "scripts": {
     "start": "webpack-dev-server --config webpack.bundled.js --history-api-fallback --hot --inline",
-    "start-nohmr": "webpack-dev-server --watch --history-api-fallback --config webpack.bundled.js",
+    "start-nohmr": "node devServer.js",
     "watch": "webpack --watch --config webpack.bundled.js",
     "devd": "devd --livewatch --port=8080 --address=127.0.0.1 --notfound=index.html build/",
     "build": "disable_plugins=true webpack --config webpack.bundled.js",
@@ -99,12 +99,15 @@
     "babel-preset-react": "^6.22.0",
     "babel-preset-stage-0": "^6.22.0",
     "clean-webpack-plugin": "^0.1.3",
+    "compression": "^1.7.1",
+    "connect-history-api-fallback": "^1.4.0",
     "copy-webpack-plugin": "^4.2.0",
     "css-loader": "^0.28.4",
     "enzyme": "^2.9.0",
     "eslint": "^4.3.0",
     "eslint-loader": "^1.6.3",
     "estraverse-fb": "^1.3.1",
+    "express": "^4.16.2",
     "extract-text-webpack-plugin": "^3.0.0",
     "file-loader": "^0.11.0",
     "glob": "^7.0.0",
@@ -126,7 +129,9 @@
     "typescript": "^2.4.2",
     "url-loader": "^0.5.6",
     "webpack": "^3.4.1",
+    "webpack-dev-middleware": "^1.12.0",
     "webpack-dev-server": "^2.6.1",
+    "webpack-hot-middleware": "^2.20.0",
     "webpack-merge": "^4.1.0"
   }
 }

--- a/graylog2-web-interface/src/index.jsx
+++ b/graylog2-web-interface/src/index.jsx
@@ -1,3 +1,5 @@
+/* global REPLACE_MODULES */
+
 // We need to set the app prefix before doing anything else, so it applies to styles too.
 // eslint-disable-next-line no-unused-vars
 import webpackEntry from 'webpack-entry';
@@ -15,9 +17,7 @@ function renderAppContainer(appContainer) {
   // eslint-disable-next-line global-require
   const AppFacade = require('routing/AppFacade');
   ReactDOM.render(
-    <AppContainer>
-      <AppFacade />
-    </AppContainer>,
+    REPLACE_MODULES ? <AppContainer><AppFacade /></AppContainer> : <AppFacade />,
     appContainer,
   );
 }
@@ -28,7 +28,8 @@ window.onload = () => {
 
   renderAppContainer(appContainer);
 
-  if (module.hot) {
+  if (module.hot && REPLACE_MODULES) {
+    console.log('HMR enabled');
     module.hot.accept('routing/AppFacade', () => {
       renderAppContainer(appContainer);
     });

--- a/graylog2-web-interface/webpack.combined.config.js
+++ b/graylog2-web-interface/webpack.combined.config.js
@@ -7,6 +7,7 @@ const merge = require('webpack-merge');
 const ROOT_PATH = path.resolve(__dirname);
 const MANIFESTS_PATH = path.resolve(ROOT_PATH, 'manifests');
 const VENDOR_MANIFEST_PATH = path.resolve(MANIFESTS_PATH, 'vendor-manifest.json');
+const TARGET = process.env.npm_lifecycle_event;
 
 const pluginPrefix = '../../graylog-plugin-*/**/';
 const pluginConfigPattern = pluginPrefix + 'webpack.config.js';
@@ -34,12 +35,31 @@ function isNotDependency(pluginConfig) {
   return !pluginConfig.includes('/target/') && !pluginConfig.includes('/node_modules/');
 }
 
-pluginConfigs.filter(isNotDependency).forEach(pluginConfig => {
+pluginConfigs.filter(isNotDependency).forEach((pluginConfig) => {
   const pluginName = getPluginName(pluginConfig);
   const pluginDir = path.resolve(pluginConfig, '../src/web');
   webpackConfig.entry[pluginName] = pluginDir;
   webpackConfig.resolve.modules.unshift(pluginDir);
   webpackConfig.plugins.unshift(new webpack.DllReferencePlugin({ manifest: VENDOR_MANIFEST_PATH, context: path.resolve(pluginDir, '../..') }));
 });
+
+// We need to inject webpack-hot-middleware to all entries, ensuring the app is able to reload on changes.
+if (TARGET === 'start-nohmr') {
+  const hmrEntries = {};
+  const webpackHotMiddlewareEntry = 'webpack-hot-middleware/client?reload=true';
+
+  Object.keys(webpackConfig.entry).forEach((entryKey) => {
+    const entryValue = webpackConfig.entry[entryKey];
+    const hmrValue = [webpackHotMiddlewareEntry];
+    if (Array.isArray(entryValue)) {
+      hmrValue.push(...entryValue);
+    } else {
+      hmrValue.push(entryValue);
+    }
+    hmrEntries[entryKey] = hmrValue;
+  });
+
+  webpackConfig.entry = hmrEntries;
+}
 
 module.exports = webpackConfig;

--- a/graylog2-web-interface/webpack.config.js
+++ b/graylog2-web-interface/webpack.config.js
@@ -3,6 +3,7 @@ const webpack = require('webpack');
 const path = require('path');
 const HtmlWebpackPlugin = require('html-webpack-plugin');
 const merge = require('webpack-merge');
+const CopyWebpackPlugin = require('copy-webpack-plugin');
 
 const ROOT_PATH = path.resolve(__dirname);
 const APP_PATH = path.resolve(ROOT_PATH, 'src');
@@ -125,28 +126,23 @@ if (TARGET === 'start-nohmr') {
   console.error('Running in development (no HMR) mode');
   module.exports = merge(webpackConfig, {
     devtool: 'eval',
-    devServer: {
-      historyApiFallback: true,
-      hot: false,
-      inline: true,
-      watchOptions: {
-        ignored: /node_modules/,
-      },
-    },
     output: {
       path: BUILD_PATH,
       filename: '[name].js',
       publicPath: '/',
     },
     plugins: [
-      new webpack.DefinePlugin({DEVELOPMENT: true}),
+      new webpack.DefinePlugin({
+        DEVELOPMENT: true,
+        REPLACE_MODULES: false, // We don't intend to use HMR but for reloading the browser window
+      }),
+      new CopyWebpackPlugin([{ from: 'config.js' }]),
+      new webpack.HotModuleReplacementPlugin(),
     ],
   });
 }
 
 if (TARGET === 'watch') {
-  const CopyWebpackPlugin = require('copy-webpack-plugin');
-
   console.error('Running in development (watch) mode');
   module.exports = merge(webpackConfig, {
     devtool: 'eval',

--- a/graylog2-web-interface/webpack.config.js
+++ b/graylog2-web-interface/webpack.config.js
@@ -117,7 +117,10 @@ if (TARGET === 'start') {
     },
     plugins: [
       new webpack.NamedModulesPlugin(),
-      new webpack.DefinePlugin({DEVELOPMENT: true}),
+      new webpack.DefinePlugin({
+        DEVELOPMENT: true,
+        REPLACE_MODULES: true,
+      }),
     ],
   });
 }
@@ -152,7 +155,10 @@ if (TARGET === 'watch') {
       publicPath: '/',
     },
     plugins: [
-      new webpack.DefinePlugin({DEVELOPMENT: true}),
+      new webpack.DefinePlugin({
+        DEVELOPMENT: true,
+        REPLACE_MODULES: false, // We don't intend to use HMR but for reloading the browser window
+      }),
       // We need config.js in the "build/" folder. No idea how webpack-dev-server
       // handles that, I found nothing in the config. (bernd)
       new CopyWebpackPlugin([{ from: 'config.js' }]),


### PR DESCRIPTION
Many of us (if not everyone) has problems running `webpack-dev-server` with many plugins, as the server keeps disconnecting from the web browser.

In order to solve that, but keeping the setup easy to install and start, this PR adds a custom express server, using `webpack-dev-middleware` and `webpack-hot-middleware` to achieve something similar to what we had before with the `start-nohmr` script. This works by enabling webpack hot module replacement, but not accepting any changes, forcing webpack to reload the page when a change is detected.

Apart from performing a full page reload on each change, the new setup also helps highlighting errors in files, producing a result like this:
<img width="649" alt="screen shot 2017-11-08 at 14 55 21" src="https://user-images.githubusercontent.com/716185/32553866-4b22abc8-c498-11e7-9080-677cc8c1f747.png">

Regarding build times, they seem to be roughly the same, but this needs more testing and also some external experiences to see if it's any good.
