### PR TITLE
Add more details about outputbuffer_* settings

### DIFF
--- a/misc/graylog.conf
+++ b/misc/graylog.conf
@@ -402,8 +402,20 @@ output_fault_penalty_seconds = 30
 processbuffer_processors = 5
 outputbuffer_processors = 3
 
+# The following settings (outputbuffer_processor_*) configure the thread pools backing each output buffer processor.
+# See https://docs.oracle.com/javase/8/docs/api/java/util/concurrent/ThreadPoolExecutor.html for technical details
+
+# When the number of threads is greater than the core (see outputbuffer_processor_threads_core_pool_size),
+# this is the maximum time in milliseconds that excess idle threads will wait for new tasks before terminating.
+# Default: 5000
 #outputbuffer_processor_keep_alive_time = 5000
+
+# The number of threads to keep in the pool, even if they are idle, unless allowCoreThreadTimeOut is set
+# Default: 3
 #outputbuffer_processor_threads_core_pool_size = 3
+
+# The maximum number of threads to allow in the pool
+# Default: 30
 #outputbuffer_processor_threads_max_pool_size = 30
 
 # UDP receive buffer size for all message inputs (e. g. SyslogUDPInput).


### PR DESCRIPTION
This PR adds more details about the `outputbuffer_processor_keep_alive_time`, `outputbuffer_processor_threads_core_pool_size`, and `outputbuffer_processor_threads_max_pool_size` settings based on the Javadoc for [`ThreadPoolExecutor`](https://docs.oracle.com/javase/8/docs/api/java/util/concurrent/ThreadPoolExecutor.html).