### PR TITLE
Fix QuickValues term separator rendering

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/dashboards/widgets/strategies/QuickvaluesWidgetStrategy.java
+++ b/graylog2-server/src/main/java/org/graylog2/dashboards/widgets/strategies/QuickvaluesWidgetStrategy.java
@@ -60,6 +60,7 @@ public class QuickvaluesWidgetStrategy extends QuickvaluesBaseWidgetStrategy {
 
         Map<String, Object> result = Maps.newHashMap();
         result.put("terms", terms.getTerms());
+        result.put("terms_mapping", terms.termsMapping());
         result.put("total", terms.getTotal());
         result.put("other", terms.getOther());
         result.put("missing", terms.getMissing());

--- a/graylog2-web-interface/src/components/visualizations/QuickValuesVisualization.jsx
+++ b/graylog2-web-interface/src/components/visualizations/QuickValuesVisualization.jsx
@@ -190,7 +190,7 @@ const QuickValuesVisualization = React.createClass({
         if (this.props.data.terms_mapping && this.props.data.terms_mapping[d.term]) {
           // Separate the terms with a character that is unusual in terms and use a different text color to make the
           // different terms in the stacked value more visible.
-          formattedTerm = this.props.data.terms_mapping[d.term].map(t => t.value).join(' <strong style="color: #e3e3e3;">&mdash;</strong> ');
+          formattedTerm = this.props.data.terms_mapping[d.term].map(t => t.value).join(' <strong style="color: #999999;">&mdash;</strong> ');
         }
 
         if (typeof this.pieChart !== 'undefined' && this.dataTable.group()(d) !== 'Others') {


### PR DESCRIPTION
- Return "terms_mapping" in QuickValuesWidgetStrategy. This ensures that we also use a more visible separator when using stacked fields.
-  Use a darker color for the QuickValues field separator. The previous one was too bright.

Fixes #4336 

Note: This needs to be cherry-picked into 2.4 as well