### PR TITLE
Change edit auth providers config button

### DIFF
--- a/graylog2-web-interface/src/components/authentication/AuthProvidersConfig.jsx
+++ b/graylog2-web-interface/src/components/authentication/AuthProvidersConfig.jsx
@@ -166,7 +166,7 @@ const AuthProvidersConfig = React.createClass({
               </Table>
 
               <IfPermitted permissions="clusterconfigentry:edit">
-                <Button bsStyle="primary" onClick={this._openModal} className="save-button-margin">Update</Button>
+                <Button bsStyle="primary" onClick={this._openModal} className="save-button-margin">Edit</Button>
                 <Button onClick={this._onCancel}>Cancel</Button>
               </IfPermitted>
 


### PR DESCRIPTION
Update in this screen feels like there will be some configuration change happening once the button is pressed, but we use that button to open a modal where the user can actually change the configuration. I found it a bit confusing myself, and thought that "edit" would be more appropriate in this case.

Before:
<img width="1037" alt="before" src="https://user-images.githubusercontent.com/716185/32776449-e09b3d20-c932-11e7-8b45-a4c756ccd109.png">

After:
<img width="1036" alt="after" src="https://user-images.githubusercontent.com/716185/32776451-e240593a-c932-11e7-8d06-38cae6cbf9ec.png">
