### PR TITLE
Fix test snapshot after updating react-bootstrap

### DIFF
--- a/graylog2-web-interface/src/components/users/__snapshots__/UserPreferencesButton.test.js.snap
+++ b/graylog2-web-interface/src/components/users/__snapshots__/UserPreferencesButton.test.js.snap
@@ -52,11 +52,14 @@ exports[`UserPreferencesButton should load user data when user clicks edit butto
             keyboard={true}
             manager={
               ModalManager {
+                "add": [Function],
                 "containers": Array [],
                 "data": Array [],
                 "handleContainerOverflow": true,
                 "hideSiblingNodes": true,
+                "isTopModal": [Function],
                 "modals": Array [],
+                "remove": [Function],
               }
             }
             onHide={[Function]}
@@ -75,11 +78,14 @@ exports[`UserPreferencesButton should load user data when user clicks edit butto
               keyboard={true}
               manager={
                 ModalManager {
+                  "add": [Function],
                   "containers": Array [],
                   "data": Array [],
                   "handleContainerOverflow": true,
                   "hideSiblingNodes": true,
+                  "isTopModal": [Function],
                   "modals": Array [],
+                  "remove": [Function],
                 }
               }
               onEntering={[Function]}


### PR DESCRIPTION
Apparently there are some new props inside react-bootstrap that affect the `UserPreferencesButton` snapshot.