### PR TITLE
Add pluggable global notification area to App component

### DIFF
--- a/graylog2-web-interface/src/routing/App.jsx
+++ b/graylog2-web-interface/src/routing/App.jsx
@@ -4,7 +4,6 @@ import Reflux from 'reflux';
 import Navigation from 'components/navigation/Navigation';
 import Spinner from 'components/common/Spinner';
 import Footer from 'components/layout/Footer';
-import AppGlobalNotifications from './AppGlobalNotifications';
 
 import 'stylesheets/jquery.dynatable.css';
 import 'stylesheets/typeahead.less';
@@ -12,6 +11,7 @@ import 'c3/c3.css';
 import 'dc/dc.css';
 
 import StoreProvider from 'injection/StoreProvider';
+import AppGlobalNotifications from './AppGlobalNotifications';
 const CurrentUserStore = StoreProvider.getStore('CurrentUser');
 
 const App = React.createClass({

--- a/graylog2-web-interface/src/routing/App.jsx
+++ b/graylog2-web-interface/src/routing/App.jsx
@@ -4,6 +4,7 @@ import Reflux from 'reflux';
 import Navigation from 'components/navigation/Navigation';
 import Spinner from 'components/common/Spinner';
 import Footer from 'components/layout/Footer';
+import AppGlobalNotifications from './AppGlobalNotifications';
 
 import 'stylesheets/jquery.dynatable.css';
 import 'stylesheets/typeahead.less';
@@ -31,6 +32,7 @@ const App = React.createClass({
       <div>
         <Navigation requestPath={this.props.location.pathname} fullName={this.state.currentUser.full_name}
                     loginName={this.state.currentUser.username} permissions={this.state.currentUser.permissions} />
+        <AppGlobalNotifications />
         <div id="scroll-to-hint" style={{ display: 'none' }} className="alpha80">
           <i className="fa fa-arrow-up" />
         </div>

--- a/graylog2-web-interface/src/routing/App.jsx
+++ b/graylog2-web-interface/src/routing/App.jsx
@@ -12,6 +12,7 @@ import 'dc/dc.css';
 
 import StoreProvider from 'injection/StoreProvider';
 import AppGlobalNotifications from './AppGlobalNotifications';
+
 const CurrentUserStore = StoreProvider.getStore('CurrentUser');
 
 const App = React.createClass({
@@ -30,8 +31,10 @@ const App = React.createClass({
     }
     return (
       <div>
-        <Navigation requestPath={this.props.location.pathname} fullName={this.state.currentUser.full_name}
-                    loginName={this.state.currentUser.username} permissions={this.state.currentUser.permissions} />
+        <Navigation requestPath={this.props.location.pathname}
+                    fullName={this.state.currentUser.full_name}
+                    loginName={this.state.currentUser.username}
+                    permissions={this.state.currentUser.permissions} />
         <AppGlobalNotifications />
         <div id="scroll-to-hint" style={{ display: 'none' }} className="alpha80">
           <i className="fa fa-arrow-up" />

--- a/graylog2-web-interface/src/routing/AppGlobalNotifications.css
+++ b/graylog2-web-interface/src/routing/AppGlobalNotifications.css
@@ -1,5 +1,0 @@
-:local(.globalNotifications):not(:empty) {
-    padding-top: 15px;
-    padding-left: 10px;
-    padding-right: 10px;
-}

--- a/graylog2-web-interface/src/routing/AppGlobalNotifications.css
+++ b/graylog2-web-interface/src/routing/AppGlobalNotifications.css
@@ -1,0 +1,5 @@
+:local(.globalNotifications):not(:empty) {
+    padding-top: 15px;
+    padding-left: 10px;
+    padding-right: 10px;
+}

--- a/graylog2-web-interface/src/routing/AppGlobalNotifications.jsx
+++ b/graylog2-web-interface/src/routing/AppGlobalNotifications.jsx
@@ -1,8 +1,6 @@
 import React from 'react';
 import { PluginStore } from 'graylog-web-plugin/plugin';
 
-import styles from './AppGlobalNotifications.css';
-
 const AppGlobalNotifications = React.createClass({
   render() {
     const globalNotifications = PluginStore.exports('globalNotifications')
@@ -22,7 +20,7 @@ const AppGlobalNotifications = React.createClass({
       .filter(component => !!component);
 
     return (
-      <div className={`container-fluid ${styles.globalNotifications}`} id="global-notifications">
+      <div id="global-notifications">
         {globalNotifications}
       </div>
     );

--- a/graylog2-web-interface/src/routing/AppGlobalNotifications.jsx
+++ b/graylog2-web-interface/src/routing/AppGlobalNotifications.jsx
@@ -8,11 +8,13 @@ const AppGlobalNotifications = React.createClass({
     const globalNotifications = PluginStore.exports('globalNotifications')
       .map((notification) => {
         if (!notification.component) {
+          // eslint-disable-next-line no-console
           console.error('Missing "component" for globalNotification plugin:', notification);
           return null;
         }
         const Component = notification.component;
         if (!notification.key) {
+          // eslint-disable-next-line no-console
           console.warn('Missing "key" for globalNotification plugin:', notification);
         }
         return <Component key={notification.key} />;

--- a/graylog2-web-interface/src/routing/AppGlobalNotifications.jsx
+++ b/graylog2-web-interface/src/routing/AppGlobalNotifications.jsx
@@ -1,0 +1,30 @@
+import React from 'react';
+import { PluginStore } from 'graylog-web-plugin/plugin';
+
+import styles from './AppGlobalNotifications.css';
+
+const AppGlobalNotifications = React.createClass({
+  render() {
+    const globalNotifications = PluginStore.exports('globalNotifications')
+      .map((notification) => {
+        if (!notification.component) {
+          console.error('Missing "component" for globalNotification plugin:', notification);
+          return null;
+        }
+        const Component = notification.component;
+        if (!notification.key) {
+          console.warn('Missing "key" for globalNotification plugin:', notification);
+        }
+        return <Component key={notification.key} />;
+      })
+      .filter(component => !!component);
+
+    return (
+      <div className={`container-fluid ${styles.globalNotifications}`} id="global-notifications">
+        {globalNotifications}
+      </div>
+    );
+  },
+});
+
+export default AppGlobalNotifications;


### PR DESCRIPTION
A plugin can register a "globalNotifications" UI extension that will be rendered into the global notification area on each page.

Note: This needs to be cherry-picked into 2.4

## Example notification

![image](https://user-images.githubusercontent.com/461/32842931-bb321076-ca1e-11e7-9c03-573d80ff9dae.png)

### Component

```jsx
import React from 'react';
import { Alert } from 'react-bootstrap';

const GlobalTestNotification = React.createClass({
  render() {
    return (
      <Alert bsStyle="danger">
        <h4><strong>Alert</strong></h4>
        <p>This is an example alert.</p>
      </Alert>
    );
  },
});

export default GlobalTestNotification;
```

### Register

```jsx
import packageJson from '../../package.json';
import { PluginManifest, PluginStore } from 'graylog-web-plugin/plugin';
import GlobalTestNotification from 'GlobalTestNotification';

PluginStore.register(new PluginManifest(packageJson, {
  globalNotifications: [
    {
      key: 'org.graylog.plugins.test.GlobalTestNotification',
      component: GlobalTestNotification,
    },
  ],
}));
```