### PR TITLE
Web dev improvements

### DIFF
--- a/graylog-plugin-archetype/src/main/resources/archetype-resources/src/web/index.jsx
+++ b/graylog-plugin-archetype/src/main/resources/archetype-resources/src/web/index.jsx
@@ -25,8 +25,3 @@ const manifest = new PluginManifest(packageJson, {
 });
 
 PluginStore.register(manifest);
-
-if (module.hot) {
-  module.hot.accept();
-  module.hot.dispose(() => PluginStore.unregister(manifest));
-}

--- a/graylog-plugin-archetype/src/main/resources/archetype-resources/src/web/index.jsx
+++ b/graylog-plugin-archetype/src/main/resources/archetype-resources/src/web/index.jsx
@@ -1,5 +1,4 @@
-// eslint-disable-next-line no-unused-vars
-import webpackEntry from 'webpack-entry';
+import 'webpack-entry';
 
 import { PluginManifest, PluginStore } from 'graylog-web-plugin/plugin';
 

--- a/graylog2-web-interface/.babelrc
+++ b/graylog2-web-interface/.babelrc
@@ -1,4 +1,4 @@
 {
   "presets": ["es2015", "react", "stage-0"],
-  "plugins": ["add-module-exports", "react-hot-loader/babel"]
+  "plugins": ["add-module-exports"]
 }

--- a/graylog2-web-interface/README.md
+++ b/graylog2-web-interface/README.md
@@ -15,6 +15,8 @@
 
 The `yarn start` (or `disable_plugins=true yarn start`) command will run an [Express](http://expressjs.com) web server which is configured to do a full page reload in your browser every time that you save a file. This ensures that you will always use the latest version of your code.
 
+You can start the development server in any other port that you like. To do so, use the `--port=<port>` option, e.g. `yarn start --port=8000` will start the development server in port 8000 instead of the default 8080. The server will also pick a random port if the port is already taken, so you don't need to worry if another process is already using that port.
+
 We mainly develop using IntelliJ or WebStorm. If you also decide to use them to work in Graylog, enable `React JSX` as Javascript language version to support the JSX language extension. This setting was called `JSX harmony` before, and it is available in one or the other form since IntelliJ 14 and WebStorm 9.
 
 ## Update Javascript dependencies

--- a/graylog2-web-interface/README.md
+++ b/graylog2-web-interface/README.md
@@ -1,44 +1,35 @@
 # Graylog Web Interface
 
+## Requirements
+- [Node.js](https://nodejs.org/), at this time we use v8.9.1
+- [Yarn](https://yarnpkg.com/)
+
+**Note:** NPM v5 changed completely the way it builds local modules, breaking the Graylog web interface build. Please use Yarn instead of NPM v5.
+
 ## Development Setup
 
-* Install [node.js](http://nodejs.org/) and npm.
-* Run `npm install`
-* Run `npm start` (if you don't want to include plugins in the build while developing, simply run `disable_plugins=true npm start`) 
-* Open http://localhost:8080
+* Install the requirements listed above
+* Run `yarn install`
+* Run `yarn start` to do a development build. You can exclude any Graylog frontend plugins from the build by running `disable_plugins=true npm start` instead
+* Open http://localhost:8080 in your browser to access the Graylog web interface
 
-The `npm start` (or `disable_plugins=true npm start`) command will run the `webpack-dev-server`, which allows in-browser hot reloading.
-In order to make switching between different branches faster, we use a script to store all `node_modules` folders
-into `.node_cache` and then symlink the folder for the current branch to `node_modules`.
+The `yarn start` (or `disable_plugins=true yarn start`) command will run an [Express](http://expressjs.com) web server which is configured to do a full page reload in your browser every time that you save a file. This ensures that you will always use the latest version of your code.
 
-When using IntelliJ or WebStorm, be sure to enable `JSX harmony` (available in IntelliJ 14 and WebStorm 9)
-as JavaScript language version to properly support react templates.
+We mainly develop using IntelliJ or WebStorm. If you also decide to use them to work in Graylog, be sure to enable `React JSX` as Javascript language version (called `JSX harmony` in previous versions) in order to support the JSX language extension. This setting is available since IntelliJ 14 and WebStorm 9.
 
-You might get an error message during `npm install` from `gyp` because the installed (default) Python version is too recent (sic!):
+## Update Javascript dependencies
 
-```
-gyp ERR! stack Error: Python executable "python" is v3.4.2, which is not supported by gyp.                                                                                                                 
-```
+1. Update a single dependency
 
-In this case just set the correct (installed!) Python binary before running `npm install`:
+    * Run `yarn upgrade <package>@<version>`
+    * Commit any changes in both `package.json` and `yarn.lock` files
+    * Do any changes required by the upgrade and test those changes
 
-```
-npm config set python python2.7
-```
+1. Update many dependencies
 
+    * It may be dangerous updating many dependencies at the same time, so be sure you checked the upgrade notes of all modules before getting started. Yarn provides some options for doing this:
+        * You can pass all packages you want to upgrade to Yarn: `yarn upgrade <package1> <package2>...`
+        * Yarn also supports upgrading packages matching a pattern, so you can execute `yarn upgrade --pattern <pattern>`
+        * You can execute `yarn upgrade` if you really want to upgrade all packages
+    * After doing the upgrade, remember to commit both the `package.json` and `yarn.lock` files
 
-#### Update Javascript dependencies
-
-a. Update a single dependency
-
-* Update `package.json` file with the new dependency
-* `npm update <npm-package>`
-* `npm shrinkwrap --dev` to save the whole dependency tree into the `npm-shrinkwrap.json` file
-
-b. Update devDependencies
-
-* `npm shinkwrap` to keep the dependency tree (without devDependencies) into `npm-shrinkwrap.json`
-* Update `package.json` file with the new devDependencies
-* `npm install`
-* Do more work with the new devDependencies
-* `npm shrinkwrap --dev` to export the whole dependency tree with the new devDependencies into `npm-shrinkwrap.json`

--- a/graylog2-web-interface/README.md
+++ b/graylog2-web-interface/README.md
@@ -10,12 +10,12 @@
 
 * Install the requirements listed above
 * Run `yarn install`
-* Run `yarn start` to do a development build. You can exclude any Graylog frontend plugins from the build by running `disable_plugins=true npm start` instead
+* Run `yarn start` to build the project for development and start the development server. You can exclude any Graylog frontend plugins from the build by running `disable_plugins=true npm start` instead
 * Open http://localhost:8080 in your browser to access the Graylog web interface
 
 The `yarn start` (or `disable_plugins=true yarn start`) command will run an [Express](http://expressjs.com) web server which is configured to do a full page reload in your browser every time that you save a file. This ensures that you will always use the latest version of your code.
 
-We mainly develop using IntelliJ or WebStorm. If you also decide to use them to work in Graylog, be sure to enable `React JSX` as Javascript language version (called `JSX harmony` in previous versions) in order to support the JSX language extension. This setting is available since IntelliJ 14 and WebStorm 9.
+We mainly develop using IntelliJ or WebStorm. If you also decide to use them to work in Graylog, enable `React JSX` as Javascript language version to support the JSX language extension. This setting was called `JSX harmony` before, and it is available in one or the other form since IntelliJ 14 and WebStorm 9.
 
 ## Update Javascript dependencies
 
@@ -23,13 +23,13 @@ We mainly develop using IntelliJ or WebStorm. If you also decide to use them to 
 
     * Run `yarn upgrade <package>@<version>`
     * Commit any changes in both `package.json` and `yarn.lock` files
-    * Do any changes required by the upgrade and test those changes
+    * Do any changes required to adapt the code to the upgraded modules
 
 1. Update many dependencies
 
-    * It may be dangerous updating many dependencies at the same time, so be sure you checked the upgrade notes of all modules before getting started. Yarn provides some options for doing this:
+    * It may be dangerous updating many dependencies at the same time, so be sure you checked the upgrade notes of all modules before getting started. Once you are ready to upgrade the modules, Yarn provides a few options to do it:
         * You can pass all packages you want to upgrade to Yarn: `yarn upgrade <package1> <package2>...`
         * Yarn also supports upgrading packages matching a pattern, so you can execute `yarn upgrade --pattern <pattern>`
-        * You can execute `yarn upgrade` if you really want to upgrade all packages
+        * You could execute `yarn upgrade` if you really want to upgrade all packages
     * After doing the upgrade, remember to commit both the `package.json` and `yarn.lock` files
 

--- a/graylog2-web-interface/README.md
+++ b/graylog2-web-interface/README.md
@@ -26,17 +26,6 @@ In this case just set the correct (installed!) Python binary before running `npm
 npm config set python python2.7
 ```
 
-### Alternative Development Setup
-
-Due to problems with webpack-dev-server there is another way to run the development setup.
-
-* Install [devd](https://github.com/cortesi/devd)
-* Install [node.js](http://nodejs.org/) and npm.
-* Run `npm install`
-* Run `npm run watch` and **keep it running** to start webpack in watch mode so it rebuilds on source changes
-* Run `npm run devd` and **keep it running** once the `build/` directory exists
-* Open http://localhost:8080
-
 
 #### Update Javascript dependencies
 

--- a/graylog2-web-interface/devServer.js
+++ b/graylog2-web-interface/devServer.js
@@ -8,7 +8,7 @@ const webpackDevMiddleware = require('webpack-dev-middleware');
 const webpackHotMiddleware = require('webpack-hot-middleware');
 const webpackConfig = require('./webpack.bundled');
 
-const DEFAULT_PORT = 8081;
+const DEFAULT_PORT = 8080;
 
 const app = express();
 const vendorConfig = webpackConfig[0];

--- a/graylog2-web-interface/package.json
+++ b/graylog2-web-interface/package.json
@@ -12,8 +12,7 @@
   "scripts": {
     "docs:build": "styleguidist build",
     "docs:server": "styleguidist server",
-    "start": "webpack-dev-server --config webpack.bundled.js --history-api-fallback --hot --inline",
-    "start-nohmr": "node devServer.js",
+    "start": "node devServer.js",
     "build": "disable_plugins=true webpack --config webpack.bundled.js",
     "lint": "eslint --ext js,jsx src",
     "test": "jest"
@@ -118,7 +117,6 @@
     "less": "^2.5.3",
     "less-loader": "^4.0.5",
     "phantomjs-prebuilt": ">=1.9",
-    "react-hot-loader": "^3.0.0-beta.6",
     "react-proxy-loader": "^0.3.4",
     "react-styleguidist": "^6.0.33",
     "react-test-renderer": "^15.6.1",

--- a/graylog2-web-interface/package.json
+++ b/graylog2-web-interface/package.json
@@ -14,8 +14,6 @@
     "docs:server": "styleguidist server",
     "start": "webpack-dev-server --config webpack.bundled.js --history-api-fallback --hot --inline",
     "start-nohmr": "node devServer.js",
-    "watch": "webpack --watch --config webpack.bundled.js",
-    "devd": "devd --livewatch --port=8080 --address=127.0.0.1 --notfound=index.html build/",
     "build": "disable_plugins=true webpack --config webpack.bundled.js",
     "lint": "eslint --ext js,jsx src",
     "test": "jest"

--- a/graylog2-web-interface/package.json
+++ b/graylog2-web-interface/package.json
@@ -134,7 +134,8 @@
     "webpack-dev-middleware": "^1.12.0",
     "webpack-dev-server": "^2.6.1",
     "webpack-hot-middleware": "^2.20.0",
-    "webpack-merge": "^4.1.0"
+    "webpack-merge": "^4.1.0",
+    "yargs": "^10.0.3"
   },
   "resolutions": {
     "@types/jquery": "2.0.48",

--- a/graylog2-web-interface/src/index.jsx
+++ b/graylog2-web-interface/src/index.jsx
@@ -1,6 +1,5 @@
 // We need to set the app prefix before doing anything else, so it applies to styles too.
-// eslint-disable-next-line no-unused-vars
-import webpackEntry from 'webpack-entry';
+import 'webpack-entry';
 
 import React from 'react';
 import ReactDOM from 'react-dom';

--- a/graylog2-web-interface/src/index.jsx
+++ b/graylog2-web-interface/src/index.jsx
@@ -1,5 +1,3 @@
-/* global REPLACE_MODULES */
-
 // We need to set the app prefix before doing anything else, so it applies to styles too.
 // eslint-disable-next-line no-unused-vars
 import webpackEntry from 'webpack-entry';
@@ -8,16 +6,14 @@ import React from 'react';
 import ReactDOM from 'react-dom';
 import Promise from 'bluebird';
 import Reflux from 'reflux';
-import { AppContainer } from 'react-hot-loader';
+import AppFacade from 'routing/AppFacade';
 
 Promise.config({ cancellation: true });
 Reflux.setPromiseFactory(handlers => new Promise(handlers));
 
 function renderAppContainer(appContainer) {
-  // eslint-disable-next-line global-require
-  const AppFacade = require('routing/AppFacade');
   ReactDOM.render(
-    REPLACE_MODULES ? <AppContainer><AppFacade /></AppContainer> : <AppFacade />,
+    <AppFacade />,
     appContainer,
   );
 }
@@ -27,11 +23,4 @@ window.onload = () => {
   document.body.appendChild(appContainer);
 
   renderAppContainer(appContainer);
-
-  if (module.hot && REPLACE_MODULES) {
-    console.log('HMR enabled');
-    module.hot.accept('routing/AppFacade', () => {
-      renderAppContainer(appContainer);
-    });
-  }
 };

--- a/graylog2-web-interface/webpack.combined.config.js
+++ b/graylog2-web-interface/webpack.combined.config.js
@@ -44,7 +44,7 @@ pluginConfigs.filter(isNotDependency).forEach((pluginConfig) => {
 });
 
 // We need to inject webpack-hot-middleware to all entries, ensuring the app is able to reload on changes.
-if (TARGET === 'start-nohmr') {
+if (TARGET === 'start') {
   const hmrEntries = {};
   const webpackHotMiddlewareEntry = 'webpack-hot-middleware/client?reload=true';
 

--- a/graylog2-web-interface/webpack.combined.config.js
+++ b/graylog2-web-interface/webpack.combined.config.js
@@ -2,7 +2,6 @@ const webpack = require('webpack');
 const glob = require('glob');
 const path = require('path');
 const fs = require('fs');
-const merge = require('webpack-merge');
 
 const ROOT_PATH = path.resolve(__dirname);
 const MANIFESTS_PATH = path.resolve(ROOT_PATH, 'manifests');
@@ -10,12 +9,13 @@ const VENDOR_MANIFEST_PATH = path.resolve(MANIFESTS_PATH, 'vendor-manifest.json'
 const TARGET = process.env.npm_lifecycle_event;
 
 const pluginPrefix = '../../graylog-plugin-*/**/';
-const pluginConfigPattern = pluginPrefix + 'webpack.config.js';
+const pluginConfigPattern = `${pluginPrefix}webpack.config.js`;
 
 const pluginConfigs = process.env.disable_plugins === 'true' ? [] : glob.sync(pluginConfigPattern);
 
 process.env.web_src_path = path.resolve(__dirname);
 
+// eslint-disable-next-line import/no-dynamic-require
 const webpackConfig = require(path.resolve(__dirname, './webpack.config.js'));
 
 function getPluginName(pluginConfig) {

--- a/graylog2-web-interface/webpack.config.js
+++ b/graylog2-web-interface/webpack.config.js
@@ -145,27 +145,6 @@ if (TARGET === 'start-nohmr') {
   });
 }
 
-if (TARGET === 'watch') {
-  console.error('Running in development (watch) mode');
-  module.exports = merge(webpackConfig, {
-    devtool: 'eval',
-    output: {
-      path: BUILD_PATH,
-      filename: '[name].js',
-      publicPath: '/',
-    },
-    plugins: [
-      new webpack.DefinePlugin({
-        DEVELOPMENT: true,
-        REPLACE_MODULES: false, // We don't intend to use HMR but for reloading the browser window
-      }),
-      // We need config.js in the "build/" folder. No idea how webpack-dev-server
-      // handles that, I found nothing in the config. (bernd)
-      new CopyWebpackPlugin([{ from: 'config.js' }]),
-    ],
-  });
-}
-
 if (TARGET === 'build') {
   console.error('Running in production mode');
   process.env.NODE_ENV = 'production';

--- a/graylog2-web-interface/webpack.config.js
+++ b/graylog2-web-interface/webpack.config.js
@@ -93,39 +93,6 @@ const webpackConfig = {
 };
 
 if (TARGET === 'start') {
-  console.error('Running in development mode');
-  module.exports = merge(webpackConfig, {
-    entry: {
-      reacthot: 'react-hot-loader/patch',
-    },
-    devtool: 'eval',
-    devServer: {
-      historyApiFallback: true,
-      hot: true,
-      inline: true,
-      lazy: false,
-      watchOptions: {
-        ignored: /node_modules/,
-      },
-    },
-    output: {
-      path: BUILD_PATH,
-      filename: '[name].js',
-      publicPath: '/',
-      hotUpdateChunkFilename: '[id].hot-update.js',
-      hotUpdateMainFilename: 'hot-update.json',
-    },
-    plugins: [
-      new webpack.NamedModulesPlugin(),
-      new webpack.DefinePlugin({
-        DEVELOPMENT: true,
-        REPLACE_MODULES: true,
-      }),
-    ],
-  });
-}
-
-if (TARGET === 'start-nohmr') {
   console.error('Running in development (no HMR) mode');
   module.exports = merge(webpackConfig, {
     devtool: 'eval',
@@ -137,7 +104,6 @@ if (TARGET === 'start-nohmr') {
     plugins: [
       new webpack.DefinePlugin({
         DEVELOPMENT: true,
-        REPLACE_MODULES: false, // We don't intend to use HMR but for reloading the browser window
       }),
       new CopyWebpackPlugin([{ from: 'config.js' }]),
       new webpack.HotModuleReplacementPlugin(),
@@ -152,7 +118,6 @@ if (TARGET === 'build') {
     plugins: [
       new webpack.DefinePlugin({
         'process.env.NODE_ENV': JSON.stringify('production'),
-        REPLACE_MODULES: false, // Do not use HMR in production
       }),
       new webpack.optimize.UglifyJsPlugin({
         minimize: true,

--- a/graylog2-web-interface/webpack.config.js
+++ b/graylog2-web-interface/webpack.config.js
@@ -16,11 +16,12 @@ process.env.BABEL_ENV = TARGET;
 const BABELRC = path.resolve(ROOT_PATH, '.babelrc');
 const BABELOPTIONS = {
   cacheDirectory: 'cache',
-  'extends': BABELRC,
+  extends: BABELRC,
 };
 
 const BABELLOADER = { loader: 'babel-loader', options: BABELOPTIONS };
 
+// eslint-disable-next-line import/no-dynamic-require
 const BOOTSTRAPVARS = require(path.resolve(ROOT_PATH, 'public', 'stylesheets', 'bootstrap-config.json')).vars;
 
 const webpackConfig = {
@@ -41,16 +42,19 @@ const webpackConfig = {
       { test: /\.ts$/, use: [BABELLOADER, { loader: 'ts-loader' }], exclude: /node_modules|\.node_cache/ },
       { test: /\.(woff(2)?|svg|eot|ttf|gif|jpg)(\?.+)?$/, use: 'file-loader' },
       { test: /\.png$/, use: 'url-loader' },
-      { test: /bootstrap\.less$/, use: [
-        'style-loader',
-        'css-loader',
-        {
-          loader: 'less-loader',
-          options: {
-            modifyVars: BOOTSTRAPVARS,
+      {
+        test: /bootstrap\.less$/,
+        use: [
+          'style-loader',
+          'css-loader',
+          {
+            loader: 'less-loader',
+            options: {
+              modifyVars: BOOTSTRAPVARS,
+            },
           },
-        },
-      ] },
+        ],
+      },
       { test: /\.less$/, use: ['style-loader', 'css-loader', 'less-loader'], exclude: /bootstrap\.less$/ },
       { test: /\.css$/, use: ['style-loader', 'css-loader'] },
     ],
@@ -141,7 +145,7 @@ if (TARGET === 'test') {
   module.exports = merge(webpackConfig, {
     module: {
       rules: [
-        { test: /\.js(x)?$/, enforce: 'pre', loader: 'eslint-loader', exclude: /node_modules|public\/javascripts/ }
+        { test: /\.js(x)?$/, enforce: 'pre', loader: 'eslint-loader', exclude: /node_modules|public\/javascripts/ },
       ],
     },
   });

--- a/graylog2-web-interface/yarn.lock
+++ b/graylog2-web-interface/yarn.lock
@@ -2278,10 +2278,6 @@ dom-serializer@0, dom-serializer@~0.1.0:
     domelementtype "~1.1.1"
     entities "~1.1.1"
 
-dom-walk@^0.1.0:
-  version "0.1.1"
-  resolved "https://registry.yarnpkg.com/dom-walk/-/dom-walk-0.1.1.tgz#672226dc74c8f799ad35307df936aba11acd6018"
-
 domain-browser@^1.1.1:
   version "1.1.7"
   resolved "https://registry.yarnpkg.com/domain-browser/-/domain-browser-1.1.7.tgz#867aa4b093faa05f1de08c06f4d7b21fdf8698bc"
@@ -2458,12 +2454,6 @@ error-ex@^1.2.0:
   resolved "https://registry.yarnpkg.com/error-ex/-/error-ex-1.3.1.tgz#f855a86ce61adc4e8621c3cda21e7a7612c3a8dc"
   dependencies:
     is-arrayish "^0.2.1"
-
-error-stack-parser@^1.3.6:
-  version "1.3.6"
-  resolved "https://registry.yarnpkg.com/error-stack-parser/-/error-stack-parser-1.3.6.tgz#e0e73b93e417138d1cd7c0b746b1a4a14854c292"
-  dependencies:
-    stackframe "^0.3.1"
 
 es-abstract@^1.6.1, es-abstract@^1.7.0:
   version "1.9.0"
@@ -3310,13 +3300,6 @@ global-prefix@^1.0.1:
     ini "^1.3.4"
     is-windows "^1.0.1"
     which "^1.2.14"
-
-global@^4.3.0:
-  version "4.3.2"
-  resolved "https://registry.yarnpkg.com/global/-/global-4.3.2.tgz#e76989268a6c74c38908b1305b10fc0e394e9d0f"
-  dependencies:
-    min-document "^2.19.0"
-    process "~0.5.1"
 
 globals@^9.17.0, globals@^9.18.0:
   version "9.18.0"
@@ -4989,7 +4972,7 @@ lodash.uniq@^4.5.0:
   version "4.5.0"
   resolved "https://registry.yarnpkg.com/lodash.uniq/-/lodash.uniq-4.5.0.tgz#d0225373aeb652adc1bc82e4945339a842754773"
 
-lodash@^4.14.0, lodash@^4.17.2, lodash@^4.17.3, lodash@^4.17.4, lodash@^4.2.0, lodash@^4.2.1, lodash@^4.3.0, lodash@^4.6.1:
+lodash@^4.14.0, lodash@^4.17.2, lodash@^4.17.3, lodash@^4.17.4, lodash@^4.2.0, lodash@^4.2.1, lodash@^4.3.0:
   version "4.17.4"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.4.tgz#78203a4d1c328ae1d86dca6460e369b57f4055ae"
 
@@ -5206,12 +5189,6 @@ mime@1.4.1, mime@^1.2.11, mime@^1.3.4, mime@^1.4.1:
 mimic-fn@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/mimic-fn/-/mimic-fn-1.1.0.tgz#e667783d92e89dbd342818b5230b9d62a672ad18"
-
-min-document@^2.19.0:
-  version "2.19.0"
-  resolved "https://registry.yarnpkg.com/min-document/-/min-document-2.19.0.tgz#7bd282e3f5842ed295bb748cdd9f1ffa2c824685"
-  dependencies:
-    dom-walk "^0.1.0"
 
 minimalistic-assert@^1.0.0:
   version "1.0.0"
@@ -6180,10 +6157,6 @@ process@^0.11.0, process@^0.11.10, process@~0.11.0:
   version "0.11.10"
   resolved "https://registry.yarnpkg.com/process/-/process-0.11.10.tgz#7332300e840161bda3e69a1d1d91a7d4bc16f182"
 
-process@~0.5.1:
-  version "0.5.2"
-  resolved "https://registry.yarnpkg.com/process/-/process-0.5.2.tgz#1638d8a8e34c2f440a91db95ab9aeb677fc185cf"
-
 progress@^1.1.8:
   version "1.1.8"
   resolved "https://registry.yarnpkg.com/progress/-/progress-1.1.8.tgz#e260c78f6161cdd9b0e56cc3e0a85de17c7a57be"
@@ -6208,7 +6181,7 @@ prop-types-extra@^1.0.1:
   dependencies:
     warning "^3.0.0"
 
-prop-types@15.x, prop-types@^15.5.10, prop-types@^15.5.4, prop-types@^15.5.8:
+prop-types@15.x, prop-types@^15.5.10, prop-types@^15.5.8:
   version "15.6.0"
   resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.6.0.tgz#ceaf083022fc46b4a35f69e13ef75aed0d639856"
   dependencies:
@@ -6403,10 +6376,6 @@ react-day-picker@^5.0.0:
   dependencies:
     prop-types "^15.5.10"
 
-react-deep-force-update@^2.1.1:
-  version "2.1.1"
-  resolved "https://registry.yarnpkg.com/react-deep-force-update/-/react-deep-force-update-2.1.1.tgz#8ea4263cd6455a050b37445b3f08fd839d86e909"
-
 react-dev-utils@^3.0.2:
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/react-dev-utils/-/react-dev-utils-3.1.1.tgz#09ae7209a81384248db56547e718e65bd3b20eb5"
@@ -6504,16 +6473,6 @@ react-group@^1.0.5:
   dependencies:
     prop-types "^15.5.10"
 
-react-hot-loader@^3.0.0-beta.6:
-  version "3.1.3"
-  resolved "https://registry.yarnpkg.com/react-hot-loader/-/react-hot-loader-3.1.3.tgz#6f92877326958c7cb0134b512474517869126082"
-  dependencies:
-    global "^4.3.0"
-    react-deep-force-update "^2.1.1"
-    react-proxy "^3.0.0-alpha.0"
-    redbox-react "^1.3.6"
-    source-map "^0.6.1"
-
 react-icon-base@2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/react-icon-base/-/react-icon-base-2.1.0.tgz#a196e33fdf1e7aaa1fda3aefbb68bdad9e82a79d"
@@ -6561,12 +6520,6 @@ react-proxy-loader@^0.3.4:
   resolved "https://registry.yarnpkg.com/react-proxy-loader/-/react-proxy-loader-0.3.5.tgz#eaeebc3950f9efad36b8bfc47cf58a9a8ca3432d"
   dependencies:
     loader-utils "^1.0.2"
-
-react-proxy@^3.0.0-alpha.0:
-  version "3.0.0-alpha.1"
-  resolved "https://registry.yarnpkg.com/react-proxy/-/react-proxy-3.0.0-alpha.1.tgz#4400426bcfa80caa6724c7755695315209fa4b07"
-  dependencies:
-    lodash "^4.6.1"
 
 react-resizable@^1.4.0:
   version "1.7.5"
@@ -6764,15 +6717,6 @@ recursive-readdir@2.2.1:
   resolved "https://registry.yarnpkg.com/recursive-readdir/-/recursive-readdir-2.2.1.tgz#90ef231d0778c5ce093c9a48d74e5c5422d13a99"
   dependencies:
     minimatch "3.0.3"
-
-redbox-react@^1.3.6:
-  version "1.5.0"
-  resolved "https://registry.yarnpkg.com/redbox-react/-/redbox-react-1.5.0.tgz#04dab11557d26651bf3562a67c22ace56c5d3967"
-  dependencies:
-    error-stack-parser "^1.3.6"
-    object-assign "^4.0.1"
-    prop-types "^15.5.4"
-    sourcemapped-stacktrace "^1.1.6"
 
 redent@^1.0.0:
   version "1.0.0"
@@ -7327,10 +7271,6 @@ source-map-support@^0.5.0:
   dependencies:
     source-map "^0.6.0"
 
-source-map@0.5.6:
-  version "0.5.6"
-  resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.5.6.tgz#75ce38f52bf0733c5a7f0c118d81334a2bb5f412"
-
 source-map@0.5.x, source-map@^0.5.3, source-map@^0.5.6, source-map@~0.5.0, source-map@~0.5.1, source-map@~0.5.6:
   version "0.5.7"
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.5.7.tgz#8a039d2d1021d22d1ea14c80d8ea468ba2ef3fcc"
@@ -7344,12 +7284,6 @@ source-map@^0.4.4:
 source-map@^0.6.0, source-map@^0.6.1, source-map@~0.6.1:
   version "0.6.1"
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.6.1.tgz#74722af32e9614e9c287a8d0bbde48b5e2f1a263"
-
-sourcemapped-stacktrace@^1.1.6:
-  version "1.1.7"
-  resolved "https://registry.yarnpkg.com/sourcemapped-stacktrace/-/sourcemapped-stacktrace-1.1.7.tgz#17e05374ff78b71a9d89ad3975a49f22725ba935"
-  dependencies:
-    source-map "0.5.6"
 
 sparkles@^1.0.0:
   version "1.0.0"
@@ -7415,10 +7349,6 @@ ssri@^4.1.6:
   resolved "https://registry.yarnpkg.com/ssri/-/ssri-4.1.6.tgz#0cb49b6ac84457e7bdd466cb730c3cb623e9a25b"
   dependencies:
     safe-buffer "^5.1.0"
-
-stackframe@^0.3.1:
-  version "0.3.1"
-  resolved "https://registry.yarnpkg.com/stackframe/-/stackframe-0.3.1.tgz#33aa84f1177a5548c8935533cbfeb3420975f5a4"
 
 state-toggle@^1.0.0:
   version "1.0.0"


### PR DESCRIPTION
In the last few weeks we did quite a few changes in the development toolchain we use in the web interface, resulting in unfinished configurations, confusing scripts running different tools, and outdated documentation (or, let's say, even useless documentation).

This PR fixes at least some of those problems by:

- Letting users customise the port of the development server
- Use a random port when the first we try to use is taken (cc @lilliCao)
- Remove alternative dev setup introduced in #4294, since we already fixed the issues with the dev-server that lead to its creation
- Remove dev setup using react-hot-loader, as I could not find a way to fix it, and nobody seems to use it anyway. I wrote a bit more about the reasoning for this in the [commit message](https://github.com/Graylog2/graylog2-server/commit/a6d07f265c838d2c91743d6e014933a7d4e859d1). This change require some changes in some plugins as well. I will create PRs for them as well shortly
- Due to the previous change, the dev setup not using react-hot-loader (`start-nohmr`) is now used in `yarn start`, as that is the most conventional script name to run an application
- Update README file to include all these changes, the use of Yarn by default, and remove some old comments from there

I hope all this changes help making the setup easier to understand and clearer.