### PR TITLE
Dependency updates

### DIFF
--- a/graylog-project-parent/pom.xml
+++ b/graylog-project-parent/pom.xml
@@ -209,7 +209,7 @@
                 <version>${javax.ws.rs-api.version}</version>
             </dependency>
             <dependency>
-                <groupId>org.hibernate.validator</groupId>
+                <groupId>org.hibernate</groupId>
                 <artifactId>hibernate-validator</artifactId>
                 <version>${hibernate-validator.version}</version>
             </dependency>

--- a/graylog-project-parent/pom.xml
+++ b/graylog-project-parent/pom.xml
@@ -161,6 +161,11 @@
             </dependency>
             <dependency>
                 <groupId>io.dropwizard.metrics</groupId>
+                <artifactId>metrics-jmx</artifactId>
+                <version>${metrics.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.dropwizard.metrics</groupId>
                 <artifactId>metrics-json</artifactId>
                 <version>${metrics.version}</version>
             </dependency>

--- a/graylog2-server/pom.xml
+++ b/graylog2-server/pom.xml
@@ -196,6 +196,10 @@
         </dependency>
         <dependency>
             <groupId>io.dropwizard.metrics</groupId>
+            <artifactId>metrics-jmx</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.dropwizard.metrics</groupId>
             <artifactId>metrics-json</artifactId>
         </dependency>
 

--- a/graylog2-server/pom.xml
+++ b/graylog2-server/pom.xml
@@ -321,7 +321,7 @@
             <artifactId>swagger-annotations</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.hibernate.validator</groupId>
+            <groupId>org.hibernate</groupId>
             <artifactId>hibernate-validator</artifactId>
         </dependency>
 

--- a/graylog2-server/src/main/java/org/graylog2/bootstrap/CmdLineTool.java
+++ b/graylog2-server/src/main/java/org/graylog2/bootstrap/CmdLineTool.java
@@ -16,8 +16,8 @@
  */
 package org.graylog2.bootstrap;
 
-import com.codahale.metrics.JmxReporter;
 import com.codahale.metrics.MetricRegistry;
+import com.codahale.metrics.jmx.JmxReporter;
 import com.codahale.metrics.log4j2.InstrumentedAppender;
 import com.github.joschi.jadconfig.JadConfig;
 import com.github.joschi.jadconfig.ParameterException;

--- a/pom.xml
+++ b/pom.xml
@@ -93,7 +93,7 @@
         <commons-io.version>2.6</commons-io.version>
         <disruptor.version>3.3.7</disruptor.version>
         <drools.version>6.5.0.Final</drools.version>
-        <elasticsearch.version>5.6.4</elasticsearch.version>
+        <elasticsearch.version>5.6.5</elasticsearch.version>
         <jest.version>2.4.11+jackson</jest.version>
         <gelfclient.version>1.4.1</gelfclient.version>
         <grok.version>0.1.7-graylog</grok.version>

--- a/pom.xml
+++ b/pom.xml
@@ -117,7 +117,7 @@
         <joda-time.version>2.9.9</joda-time.version>
         <json-path.version>2.4.0</json-path.version>
         <kafka.version>0.9.0.1</kafka.version>
-        <log4j.version>2.9.1</log4j.version>
+        <log4j.version>2.10.0</log4j.version>
         <metrics.version>3.2.5</metrics.version>
         <mongodb-driver.version>3.5.0</mongodb-driver.version>
         <mongojack.version>2.8.0</mongojack.version>

--- a/pom.xml
+++ b/pom.xml
@@ -98,7 +98,7 @@
         <gelfclient.version>1.4.1</gelfclient.version>
         <grok.version>0.1.7-graylog</grok.version>
         <guava-retrying.version>2.0.0</guava-retrying.version>
-        <guava.version>23.5-jre</guava.version>
+        <guava.version>23.6-jre</guava.version>
         <guice.version>4.1.0</guice.version>
         <HdrHistogram.version>2.1.10</HdrHistogram.version>
         <hibernate-validator.version>6.0.4.Final</hibernate-validator.version>

--- a/pom.xml
+++ b/pom.xml
@@ -273,7 +273,7 @@
                 <plugin>
                     <groupId>com.github.spotbugs</groupId>
                     <artifactId>spotbugs-maven-plugin</artifactId>
-                    <version>3.1.0-RC8</version>
+                    <version>3.1.1</version>
                 </plugin>
                 <plugin>
                     <groupId>org.codehaus.mojo</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -146,7 +146,7 @@
         <assertj-core.version>3.8.0</assertj-core.version>
         <assertj-joda-time.version>2.0.0</assertj-joda-time.version>
         <awaitility.version>1.7.0</awaitility.version>
-        <equalsverifier.version>2.3.3</equalsverifier.version>
+        <equalsverifier.version>2.4</equalsverifier.version>
         <fongo.version>2.1.0</fongo.version>
         <jukito.version>1.5</jukito.version>
         <junit.version>4.12</junit.version>

--- a/pom.xml
+++ b/pom.xml
@@ -126,7 +126,7 @@
         <okhttp.version>3.9.1</okhttp.version>
         <opencsv.version>2.3</opencsv.version>
         <os-platform-finder.version>1.2.2</os-platform-finder.version>
-        <protobuf.version>3.5.0</protobuf.version>
+        <protobuf.version>3.5.1</protobuf.version>
         <reflections.version>0.9.11</reflections.version>
         <retrofit.version>2.3.0</retrofit.version>
         <scala.version>2.11.8</scala.version>

--- a/pom.xml
+++ b/pom.xml
@@ -133,7 +133,7 @@
         <shiro.version>1.4.0</shiro.version>
         <sigar.version>1.6.4</sigar.version>
         <slf4j.version>1.7.25</slf4j.version>
-        <spotbugs-annotations.version>3.1.0</spotbugs-annotations.version>
+        <spotbugs-annotations.version>3.1.1</spotbugs-annotations.version>
         <swagger.version>1.5.13</swagger.version>
         <syslog4j.version>0.9.60</syslog4j.version>
         <uuid.version>3.2</uuid.version>

--- a/pom.xml
+++ b/pom.xml
@@ -118,7 +118,7 @@
         <json-path.version>2.4.0</json-path.version>
         <kafka.version>0.9.0.1</kafka.version>
         <log4j.version>2.10.0</log4j.version>
-        <metrics.version>3.2.5</metrics.version>
+        <metrics.version>4.0.2</metrics.version>
         <mongodb-driver.version>3.5.0</mongodb-driver.version>
         <mongojack.version>2.8.0</mongojack.version>
         <natty.version>0.13</natty.version>

--- a/pom.xml
+++ b/pom.xml
@@ -143,7 +143,7 @@
 
         <!-- Test dependencies -->
         <apacheds-server.version>2.0.0-M24</apacheds-server.version>
-        <assertj-core.version>3.8.0</assertj-core.version>
+        <assertj-core.version>3.9.0</assertj-core.version>
         <assertj-joda-time.version>2.0.0</assertj-joda-time.version>
         <awaitility.version>1.7.0</awaitility.version>
         <equalsverifier.version>2.4</equalsverifier.version>

--- a/pom.xml
+++ b/pom.xml
@@ -98,7 +98,7 @@
         <gelfclient.version>1.4.1</gelfclient.version>
         <grok.version>0.1.7-graylog</grok.version>
         <guava-retrying.version>2.0.0</guava-retrying.version>
-        <guava.version>23.4-jre</guava.version>
+        <guava.version>23.5-jre</guava.version>
         <guice.version>4.1.0</guice.version>
         <HdrHistogram.version>2.1.10</HdrHistogram.version>
         <hibernate-validator.version>6.0.4.Final</hibernate-validator.version>

--- a/pom.xml
+++ b/pom.xml
@@ -123,7 +123,7 @@
         <mongojack.version>2.8.0</mongojack.version>
         <natty.version>0.13</natty.version>
         <netty.version>3.10.6.Final</netty.version>
-        <okhttp.version>3.9.0</okhttp.version>
+        <okhttp.version>3.9.1</okhttp.version>
         <opencsv.version>2.3</opencsv.version>
         <os-platform-finder.version>1.2.2</os-platform-finder.version>
         <protobuf.version>3.4.0</protobuf.version>

--- a/pom.xml
+++ b/pom.xml
@@ -150,7 +150,7 @@
         <fongo.version>2.1.0</fongo.version>
         <jukito.version>1.5</jukito.version>
         <junit.version>4.12</junit.version>
-        <mockito.version>2.12.0</mockito.version>
+        <mockito.version>2.13.0</mockito.version>
         <nosqlunit.version>1.0.0-rc.5</nosqlunit.version>
         <nosqlunit-elasticsearch-http.version>1.0.0-4+jackson</nosqlunit-elasticsearch-http.version>
         <restassured.version>2.9.0</restassured.version>

--- a/pom.xml
+++ b/pom.xml
@@ -86,7 +86,7 @@
         <airline.version>2.3.0</airline.version>
         <amqp-client.version>5.0.0</amqp-client.version>
         <apache-directory-version>1.0.0</apache-directory-version>
-        <auto-value.version>1.5.2</auto-value.version>
+        <auto-value.version>1.5.3</auto-value.version>
         <auto-value-javabean.version>1.0.0</auto-value-javabean.version>
         <commons-codec.version>1.11</commons-codec.version>
         <commons-email.version>1.5</commons-email.version>

--- a/pom.xml
+++ b/pom.xml
@@ -101,7 +101,7 @@
         <guava.version>23.6-jre</guava.version>
         <guice.version>4.1.0</guice.version>
         <HdrHistogram.version>2.1.10</HdrHistogram.version>
-        <hibernate-validator.version>6.0.4.Final</hibernate-validator.version>
+        <hibernate-validator.version>6.0.7.Final</hibernate-validator.version>
         <hk2.version>2.5.0-b32</hk2.version> <!-- The HK2 version should match the version being used by Jersey -->
         <jackson.version>2.8.9</jackson.version>
         <jadconfig.version>0.13.0</jadconfig.version>

--- a/pom.xml
+++ b/pom.xml
@@ -126,7 +126,7 @@
         <okhttp.version>3.9.1</okhttp.version>
         <opencsv.version>2.3</opencsv.version>
         <os-platform-finder.version>1.2.2</os-platform-finder.version>
-        <protobuf.version>3.4.0</protobuf.version>
+        <protobuf.version>3.5.0</protobuf.version>
         <reflections.version>0.9.11</reflections.version>
         <retrofit.version>2.3.0</retrofit.version>
         <scala.version>2.11.8</scala.version>

--- a/pom.xml
+++ b/pom.xml
@@ -154,7 +154,7 @@
         <nosqlunit.version>1.0.0-rc.5</nosqlunit.version>
         <nosqlunit-elasticsearch-http.version>1.0.0-4+jackson</nosqlunit-elasticsearch-http.version>
         <restassured.version>2.9.0</restassured.version>
-        <system-rules.version>1.16.1</system-rules.version>
+        <system-rules.version>1.17.0</system-rules.version>
 
         <!-- Nodejs dependencies -->
         <nodejs.version>v8.9.1</nodejs.version>

--- a/pom.xml
+++ b/pom.xml
@@ -84,7 +84,7 @@
 
         <!-- Dependencies -->
         <airline.version>2.3.0</airline.version>
-        <amqp-client.version>5.0.0</amqp-client.version>
+        <amqp-client.version>5.1.1</amqp-client.version>
         <apache-directory-version>1.0.0</apache-directory-version>
         <auto-value.version>1.5.3</auto-value.version>
         <auto-value-javabean.version>1.0.0</auto-value-javabean.version>

--- a/pom.xml
+++ b/pom.xml
@@ -326,7 +326,7 @@
                     <dependency>
                         <groupId>com.google.errorprone</groupId>
                         <artifactId>error_prone_core</artifactId>
-                        <version>2.1.3</version>
+                        <version>2.2.0</version>
                     </dependency>
                 </dependencies>
             </plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -218,7 +218,7 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-javadoc-plugin</artifactId>
-                    <version>2.10.4</version>
+                    <version>3.0.0</version>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -326,7 +326,7 @@
                     <dependency>
                         <groupId>com.google.errorprone</groupId>
                         <artifactId>error_prone_core</artifactId>
-                        <version>2.1.2</version>
+                        <version>2.1.3</version>
                     </dependency>
                 </dependencies>
             </plugin>


### PR DESCRIPTION
* Upgrade to Hibernate Validator 6.0.7.Final
  * https://github.com/hibernate/hibernate-validator/blob/6.0.7.Final/changelog.txt#L4-L56
* Upgrade to Log4j 2.10.0
  * https://logging.apache.org/log4j/2.x/changes-report.html#a2.10.0
* Upgrade to OkHttp 3.9.1
  * https://github.com/square/okhttp/blob/17485bc41852ee9586ebe167555737825a0d1043/CHANGELOG.md#version-391
* Upgrade to Guava 23.6
  * https://github.com/google/guava/releases/tag/v23.5
  * https://github.com/google/guava/releases/tag/v23.6
* Upgrade to EqualsVerifier 2.4
* Upgrade to System Rules 1.17.0
* Upgrade to SpotBugs annotations 3.1.1
  * https://github.com/spotbugs/spotbugs/blob/3.1.1/CHANGELOG.md
* Upgrade to Google Protocol Buffers 3.5.1
  * https://github.com/google/protobuf/releases/tag/v3.5.0
  * https://github.com/google/protobuf/releases/tag/v3.5.1
* Upgrade to Error Prone 2.2.0
  * https://github.com/google/error-prone/releases/tag/v2.2.0
* Upgrade to Mockito 2.13.0
* Upgrade to Google Auto Value 1.5.3 
  * https://github.com/google/auto/releases/tag/auto-value-1.5.3
* Upgrade to AssertJ 3.9.0
  * https://joel-costigliola.github.io/assertj/assertj-core-news.html#assertj-core-3.9.0
* Upgrade to RabbitMQ AMQP Java client 5.1.1
  * https://github.com/rabbitmq/rabbitmq-java-client/releases/tag/v5.1.0
  * https://github.com/rabbitmq/rabbitmq-java-client/releases/tag/v5.1.1
* Upgrade to Dropwizard Metrics 4.0.2
  * https://github.com/dropwizard/metrics/releases/tag/v4.0.0
  * https://github.com/dropwizard/metrics/releases/tag/v4.0.1
  * https://github.com/dropwizard/metrics/releases/tag/v4.0.2
* Upgrade to Elasticsearch 5.6.5  …
  * https://www.elastic.co/guide/en/elasticsearch/reference/5.6/release-notes-5.6.5.html
* Upgrade to SpotBugs Maven Plugin 3.1.1
* Upgrade to Javadoc Maven Plugin 3.0.0


  