### PR TITLE
Add and use ExternalLink and ExternalLinkButton components

### DIFF
--- a/graylog2-web-interface/src/components/alertnotifications/CreateAlertNotificationInput.jsx
+++ b/graylog2-web-interface/src/components/alertnotifications/CreateAlertNotificationInput.jsx
@@ -4,7 +4,7 @@ import naturalSort from 'javascript-natural-sort';
 import { Button, Col, Row } from 'react-bootstrap';
 
 import { Input } from 'components/bootstrap';
-import { Select, Spinner } from 'components/common';
+import { ExternalLinkButton, Select, Spinner } from 'components/common';
 import { ConfigurationForm } from 'components/configurationforms';
 import Routes from 'routing/Routes';
 import UserNotification from 'util/UserNotification';
@@ -107,9 +107,11 @@ const CreateAlertNotificationInput = React.createClass({
 
     return (
       <div>
-        <Button bsStyle="info" href="https://marketplace.graylog.org/" target="_blank" className="pull-right">
-          <i className="fa fa-external-link" />&nbsp; Find more notifications
-        </Button>
+        <ExternalLinkButton href="https://marketplace.graylog.org/"
+                            bsStyle="info"
+                            className="pull-right">
+          Find more notifications
+        </ExternalLinkButton>
 
         <h2>Notification</h2>
         <p className="description">

--- a/graylog2-web-interface/src/components/common/ExternalLink.jsx
+++ b/graylog2-web-interface/src/components/common/ExternalLink.jsx
@@ -1,0 +1,53 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import _ from 'lodash';
+
+/**
+ * Component that renders a link to an external resource.
+ */
+const ExternalLink = React.createClass({
+  propTypes: {
+    /** Link to the external location. If this is not defined, the component does not render a `<a />` element but only the text and the icon. */
+    href: PropTypes.string,
+    /** Text for the link. (should be one line) */
+    children: PropTypes.node.isRequired,
+    /** Browser window target attribute for the link. */
+    target: PropTypes.string,
+    /** FontAwesome icon class name to use for the indicator icon. */
+    iconClass: PropTypes.string,
+    /** Class name for the link. Can be used to change the styling of the link. */
+    className: PropTypes.string,
+  },
+
+  getDefaultProps() {
+    return {
+      href: '',
+      target: '_blank',
+      iconClass: 'fa-external-link',
+      className: '',
+    };
+  },
+
+  render() {
+    const content = (
+      <span>
+        {this.props.children}
+        &nbsp;
+        <i className={`fa ${this.props.iconClass}`} />
+      </span>
+    );
+
+    // This makes the component usable as child element of a component that already renders a link (e.g. MenuItem)
+    if (_.trim(this.props.href) === '') {
+      return content;
+    }
+
+    return (
+      <a href={this.props.href} target={this.props.target} className={this.props.className}>
+        {content}
+      </a>
+    );
+  },
+});
+
+export default ExternalLink;

--- a/graylog2-web-interface/src/components/common/ExternalLink.md
+++ b/graylog2-web-interface/src/components/common/ExternalLink.md
@@ -1,0 +1,17 @@
+`ExternalLink` in a text:
+```js
+<p>Please read the <ExternalLink href="http://docs.graylog.org/">Graylog documentation</ExternalLink> to learn about the product.</p>
+```
+
+`ExternalLink` with a different icon:
+```js
+<ExternalLink href="http://docs.graylog.org/"
+              iconClass="fa-external-link-square">
+  Graylog documentation
+</ExternalLink>
+```
+
+`ExternalLink` without a `href` prop:
+```js
+<ExternalLink>Graylog documentation</ExternalLink>
+```

--- a/graylog2-web-interface/src/components/common/ExternalLinkButton.jsx
+++ b/graylog2-web-interface/src/components/common/ExternalLinkButton.jsx
@@ -1,0 +1,54 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { Button } from 'react-bootstrap';
+
+import { ExternalLink } from 'components/common';
+
+/**
+ * Component that renders a link to an external resource as a button.
+ *
+ * All props besides `iconClass` and `children` are passed down to the react-bootstrap `<Button />` component.
+ */
+const ExternalLinkButton = React.createClass({
+  propTypes: {
+    /** Link to the external location. */
+    href: PropTypes.string.isRequired,
+    /** Text for the button. (should be one line) */
+    children: PropTypes.node.isRequired,
+    /** Button style. (bootstrap style name) */
+    bsStyle: PropTypes.string,
+    /** Button size. (bootstrap size name) */
+    bsSize: PropTypes.string,
+    /** Browser window target attribute for the external link. */
+    target: PropTypes.string,
+    /** FontAwesome icon class name to use for the indicator icon. */
+    iconClass: PropTypes.string,
+    /** Additional class name to adjust styling of the button. */
+    className: PropTypes.string,
+    /** Render a disabled button if this is <code>true</code>. */
+    disabled: PropTypes.bool,
+  },
+
+  getDefaultProps() {
+    return {
+      bsStyle: 'default',
+      bsSize: '',
+      target: '_blank',
+      iconClass: 'fa-external-link',
+      className: '',
+      disabled: false,
+    };
+  },
+
+  render() {
+    const { iconClass, children, ...props } = this.props;
+
+    return (
+      <Button {...props}>
+        <ExternalLink iconClass={iconClass}>{children}</ExternalLink>
+      </Button>
+    );
+  },
+});
+
+export default ExternalLinkButton;

--- a/graylog2-web-interface/src/components/common/ExternalLinkButton.md
+++ b/graylog2-web-interface/src/components/common/ExternalLinkButton.md
@@ -1,0 +1,19 @@
+`ExternalLinkButton`:
+```js
+<ExternalLinkButton href="http://docs.graylog.org/">Graylog documentation</ExternalLinkButton>
+```
+
+`ExternalLinkButton` with different size, style and icon:
+```js
+<ExternalLinkButton href="http://docs.graylog.org/"
+                    bsStyle="success"
+                    bsSize="lg"
+                    iconClass="fa-external-link-square">
+  Graylog documentation
+</ExternalLinkButton>
+```
+
+`ExternalLinkButton` that is disabled:
+```js
+<ExternalLinkButton href="http://docs.graylog.org/" disabled>Graylog documentation</ExternalLinkButton>
+```

--- a/graylog2-web-interface/src/components/common/index.jsx
+++ b/graylog2-web-interface/src/components/common/index.jsx
@@ -5,6 +5,8 @@ export { default as DatePicker } from './DatePicker';
 export { default as DocumentTitle } from './DocumentTitle';
 export { default as EntityList } from './EntityList';
 export { default as EntityListItem } from './EntityListItem';
+export { default as ExternalLink } from './ExternalLink';
+export { default as ExternalLinkButton } from './ExternalLinkButton';
 export { default as IfPermitted } from './IfPermitted';
 export { default as ISODurationInput } from './ISODurationInput';
 export { default as LinkToNode } from './LinkToNode';

--- a/graylog2-web-interface/src/components/inputs/CreateInputControl.jsx
+++ b/graylog2-web-interface/src/components/inputs/CreateInputControl.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import Reflux from 'reflux';
 import { Button, Row, Col } from 'react-bootstrap';
 
-import { Select } from 'components/common';
+import { ExternalLinkButton, Select } from 'components/common';
 
 import ActionsProvider from 'injection/ActionsProvider';
 const InputTypesActions = ActionsProvider.getActions('InputTypes');
@@ -77,9 +77,11 @@ const CreateInputControl = React.createClass({
             </div>
             &nbsp;
             <Button bsStyle="success" type="submit" disabled={!this.state.selectedInput}>Launch new input</Button>
-            <Button href="https://marketplace.graylog.org/" target="_blank" bsStyle="info" style={{ marginLeft: 10 }}>
-              <i className="fa fa-external-link" />&nbsp;Find more inputs
-            </Button>
+            <ExternalLinkButton href="https://marketplace.graylog.org/"
+                                bsStyle="info"
+                                style={{ marginLeft: 10 }}>
+              Find more inputs
+            </ExternalLinkButton>
           </form>
           {inputModal}
         </Col>

--- a/graylog2-web-interface/src/components/navigation/HelpMenu.jsx
+++ b/graylog2-web-interface/src/components/navigation/HelpMenu.jsx
@@ -2,6 +2,7 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import { NavDropdown, MenuItem } from 'react-bootstrap';
 import { LinkContainer } from 'react-router-bootstrap';
+import { ExternalLink } from 'components/common';
 
 import DocsHelper from 'util/DocsHelper';
 import Routes from 'routing/Routes';
@@ -16,8 +17,8 @@ const HelpMenu = React.createClass({
         <LinkContainer to={Routes.getting_started(true)}>
           <MenuItem>Getting Started</MenuItem>
         </LinkContainer>
-        <MenuItem href={DocsHelper.versionedDocsHomePage()} target="blank">
-          <i className="fa fa-external-link" /> Documentation
+        <MenuItem href={DocsHelper.versionedDocsHomePage()} target="_blank">
+          <ExternalLink>Documentation</ExternalLink>
         </MenuItem>
       </NavDropdown>
     );

--- a/graylog2-web-interface/src/components/nodes/InputTypesDataTable.jsx
+++ b/graylog2-web-interface/src/components/nodes/InputTypesDataTable.jsx
@@ -2,7 +2,7 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import { Alert } from 'react-bootstrap';
 
-import { DataTable, Spinner } from 'components/common';
+import { DataTable, ExternalLink, Spinner } from 'components/common';
 
 const InputTypesDataTable = React.createClass({
   propTypes: {
@@ -18,7 +18,7 @@ const InputTypesDataTable = React.createClass({
         <td className="limited">{inputType.type}</td>
         <td className="limited" style={{ width: 150 }}>
           {inputType.link_to_docs &&
-          <a href={inputType.link_to_docs} target="_blank"><i className="fa fa-external-link" /> Documentation</a>
+          <ExternalLink href={inputType.link_to_docs}>Documentation</ExternalLink>
           }
         </td>
       </tr>

--- a/graylog2-web-interface/src/components/nodes/NodeMaintenanceDropdown.jsx
+++ b/graylog2-web-interface/src/components/nodes/NodeMaintenanceDropdown.jsx
@@ -4,7 +4,7 @@ import { LinkContainer } from 'react-router-bootstrap';
 import { ButtonGroup, DropdownButton, MenuItem } from 'react-bootstrap';
 import URI from 'urijs';
 
-import { IfPermitted } from 'components/common';
+import { ExternalLink, IfPermitted } from 'components/common';
 
 import Routes from 'routing/Routes';
 
@@ -34,7 +34,7 @@ const NodeMaintenanceDropdown = React.createClass({
           </IfPermitted>
 
           <MenuItem href={apiBrowserURI} target="_blank">
-            API Browser <i className="fa fa-external-link" />
+            <ExternalLink>API Browser</ExternalLink>
           </MenuItem>
         </DropdownButton>
       </ButtonGroup>

--- a/graylog2-web-interface/src/components/nodes/NodesActions.jsx
+++ b/graylog2-web-interface/src/components/nodes/NodesActions.jsx
@@ -4,7 +4,7 @@ import { LinkContainer } from 'react-router-bootstrap';
 import { Button, DropdownButton, MenuItem } from 'react-bootstrap';
 import URI from 'urijs';
 
-import { IfPermitted } from 'components/common';
+import { ExternalLinkButton, IfPermitted } from 'components/common';
 
 import StoreProvider from 'injection/StoreProvider';
 const SystemProcessingStore = StoreProvider.getStore('SystemProcessing');
@@ -51,9 +51,9 @@ const NodesActions = React.createClass({
           <Button bsStyle="info">Metrics</Button>
         </LinkContainer>
 
-        <Button bsStyle="info" href={apiBrowserURI} target="_blank">
-          <i className="fa fa-external-link" />&nbsp; API browser
-        </Button>
+        <ExternalLinkButton bsStyle="info" href={apiBrowserURI}>
+          API browser
+        </ExternalLinkButton>
 
         <DropdownButton title="More actions" id={`more-actions-dropdown-${this.props.node.node_id}`} pullRight>
           <IfPermitted permissions="processing:changestate">

--- a/graylog2-web-interface/src/components/nodes/PluginsDataTable.jsx
+++ b/graylog2-web-interface/src/components/nodes/PluginsDataTable.jsx
@@ -2,7 +2,7 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import { Alert } from 'react-bootstrap';
 
-import { DataTable, Spinner } from 'components/common';
+import { DataTable, ExternalLink, Spinner } from 'components/common';
 
 const PluginsDataTable = React.createClass({
   propTypes: {
@@ -19,8 +19,8 @@ const PluginsDataTable = React.createClass({
         <td className="limited">{plugin.author}</td>
         <td className="limited" style={{ width: '50%' }}>
           {plugin.description}
-          &nbsp;
-          <a href={plugin.url} target="_blank" style={{ marginLeft: 10 }}><i className="fa fa-external-link" /> Website</a>
+          &nbsp;&nbsp;
+          <ExternalLink href={plugin.url} style={{ marginLeft: 10 }}>Website</ExternalLink>
         </td>
       </tr>
     );


### PR DESCRIPTION
They can be used to render links to external websites which should be decorated with an icon to make it visible that the user leaves the Graylog UI.

Also switch all external links in our codebase over to the new components.

Note: This needs to be **cherry-picked into 2.4** once it's merged

## ExternalLink

![image](https://user-images.githubusercontent.com/461/33897482-e3518d46-df65-11e7-972c-6b1908acfc29.png)

## ExternalLinkButton

![image](https://user-images.githubusercontent.com/461/33897516-f66e4360-df65-11e7-9b43-a7913848e9f7.png)
