### PR TITLE
Don't render partial page content when missing permissions

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/rest/resources/system/authentication/AuthenticationResource.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/resources/system/authentication/AuthenticationResource.java
@@ -37,6 +37,7 @@ import javax.ws.rs.core.MediaType;
 import java.util.Map;
 
 import static org.graylog2.shared.security.RestPermissions.AUTHENTICATION_EDIT;
+import static org.graylog2.shared.security.RestPermissions.AUTHENTICATION_READ;
 import static org.graylog2.shared.security.RestPermissions.CLUSTER_CONFIG_ENTRY_READ;
 
 @RequiresAuthentication
@@ -59,7 +60,7 @@ public class AuthenticationResource extends RestResource {
     @GET
     @Path("config")
     @ApiOperation("Retrieve authentication providers configuration")
-    @RequiresPermissions(CLUSTER_CONFIG_ENTRY_READ)
+    @RequiresPermissions({CLUSTER_CONFIG_ENTRY_READ, AUTHENTICATION_READ})
     public AuthenticationConfig getAuthenticators() {
         final AuthenticationConfig config = clusterConfigService.getOrDefault(AuthenticationConfig.class,
                                                                               AuthenticationConfig.defaultInstance());

--- a/graylog2-server/src/main/java/org/graylog2/shared/security/RestPermissions.java
+++ b/graylog2-server/src/main/java/org/graylog2/shared/security/RestPermissions.java
@@ -30,6 +30,7 @@ public class RestPermissions implements PluginPermissions {
      * These should all be in the form of "group:action", because {@link Permissions#allPermissionsMap()} below depends on it.
      * Should this ever change, you need to adapt the code below, too.
      */
+    public static final String AUTHENTICATION_READ = "authentication:read";
     public static final String AUTHENTICATION_EDIT = "authentication:edit";
     public static final String BLACKLISTENTRY_CREATE = "blacklistentry:create";
     public static final String BLACKLISTENTRY_DELETE = "blacklistentry:delete";

--- a/graylog2-web-interface/src/components/authentication/AuthProvidersConfig.jsx
+++ b/graylog2-web-interface/src/components/authentication/AuthProvidersConfig.jsx
@@ -1,8 +1,8 @@
 import PropTypes from 'prop-types';
 import React from 'react';
-import { Row, Col, Button, Alert, Table } from 'react-bootstrap';
+import { Alert, Button, Col, Row, Table } from 'react-bootstrap';
 import BootstrapModalForm from 'components/bootstrap/BootstrapModalForm';
-import { DocumentTitle, PageHeader, IfPermitted, SortableList } from 'components/common';
+import { DocumentTitle, IfPermitted, PageHeader, SortableList } from 'components/common';
 import Routes from 'routing/Routes';
 import ObjectUtils from 'util/ObjectUtils';
 import history from 'util/History';
@@ -150,51 +150,53 @@ const AuthProvidersConfig = React.createClass({
             </span>
           </PageHeader>
           <Row>
-            <Col md={6}>
-              <Table striped bordered className="top-margin">
-                <thead>
-                  <tr>
-                    <th>#</th>
-                    <th>Provider</th>
-                    <th>Description</th>
-                    <th>Status</th>
-                  </tr>
-                </thead>
-                <tbody>
-                  {this._summary()}
-                </tbody>
-              </Table>
-
-              <IfPermitted permissions="clusterconfigentry:edit">
-                <Button bsStyle="primary" onClick={this._openModal} className="save-button-margin">Edit</Button>
-                <Button onClick={this._onCancel}>Cancel</Button>
-              </IfPermitted>
-
-              <BootstrapModalForm ref="configModal"
-                                  title="Update Authentication Provider Configuration"
-                                  onSubmitForm={this._saveConfig}
-                                  onModalClose={this._resetConfig}
-                                  submitButtonText="Save">
-                <h3>Order</h3>
-                <p>Use drag and drop to change the execution order of the authentication providers.</p>
-                <SortableList items={this._sortableItems()} onMoveItem={this._updateSorting} />
-
-                <h3>Status</h3>
-                <p>Change the checkboxes to change the status of an authentication provider.</p>
-                <Table striped bordered condensed className="top-margin">
+            <IfPermitted permissions={['clusterconfigentry:read', 'authentication:read']}>
+              <Col md={6}>
+                <Table striped bordered className="top-margin">
                   <thead>
                     <tr>
+                      <th>#</th>
                       <th>Provider</th>
-                      <th>Enabled</th>
+                      <th>Description</th>
+                      <th>Status</th>
                     </tr>
                   </thead>
                   <tbody>
-                    {this._statusForm()}
+                    {this._summary()}
                   </tbody>
                 </Table>
-                {this._noActiveRealmWarning()}
-              </BootstrapModalForm>
-            </Col>
+
+                <IfPermitted permissions={['clusterconfigentry:edit', 'authentication:edit']}>
+                  <Button bsStyle="primary" onClick={this._openModal} className="save-button-margin">Edit</Button>
+                  <Button onClick={this._onCancel}>Cancel</Button>
+                </IfPermitted>
+
+                <BootstrapModalForm ref="configModal"
+                                    title="Update Authentication Provider Configuration"
+                                    onSubmitForm={this._saveConfig}
+                                    onModalClose={this._resetConfig}
+                                    submitButtonText="Save">
+                  <h3>Order</h3>
+                  <p>Use drag and drop to change the execution order of the authentication providers.</p>
+                  <SortableList items={this._sortableItems()} onMoveItem={this._updateSorting} />
+
+                  <h3>Status</h3>
+                  <p>Change the checkboxes to change the status of an authentication provider.</p>
+                  <Table striped bordered condensed className="top-margin">
+                    <thead>
+                      <tr>
+                        <th>Provider</th>
+                        <th>Enabled</th>
+                      </tr>
+                    </thead>
+                    <tbody>
+                      {this._statusForm()}
+                    </tbody>
+                  </Table>
+                  {this._noActiveRealmWarning()}
+                </BootstrapModalForm>
+              </Col>
+            </IfPermitted>
           </Row>
         </span>
       </DocumentTitle>

--- a/graylog2-web-interface/src/components/grok-patterns/GrokPatterns.jsx
+++ b/graylog2-web-interface/src/components/grok-patterns/GrokPatterns.jsx
@@ -8,6 +8,7 @@ import PageHeader from 'components/common/PageHeader';
 import EditPatternModal from 'components/grok-patterns/EditPatternModal';
 import BulkLoadPatternModal from 'components/grok-patterns/BulkLoadPatternModal';
 import DataTable from 'components/common/DataTable';
+import IfPermitted from 'components/common/IfPermitted';
 
 const GrokPatterns = React.createClass({
   getInitialState() {
@@ -87,26 +88,30 @@ const GrokPatterns = React.createClass({
             your own manually or import a whole list of patterns from a so called pattern file.
           </span>
           {null}
-          <span>
-            <BulkLoadPatternModal onSuccess={this.loadData} />
-            <EditPatternModal id={''} name={''} pattern={''} create
-                              reload={this.loadData}
-                              savePattern={this.savePattern}
-                              validPatternName={this.validPatternName} />
-          </span>
+          <IfPermitted permissions="inputs:edit">
+            <span>
+              <BulkLoadPatternModal onSuccess={this.loadData} />
+              <EditPatternModal id={''} name={''} pattern={''} create
+                                reload={this.loadData}
+                                savePattern={this.savePattern}
+                                validPatternName={this.validPatternName} />
+            </span>
+          </IfPermitted>
         </PageHeader>
 
         <Row className="content">
           <Col md={12}>
-            <DataTable id="grok-pattern-list"
-                       className="table-striped table-hover"
-                       headers={headers}
-                       headerCellFormatter={this._headerCellFormatter}
-                       sortByKey={'name'}
-                       rows={this.state.patterns}
-                       dataRowFormatter={this._patternFormatter}
-                       filterLabel="Filter patterns"
-                       filterKeys={filterKeys} />
+            <IfPermitted permissions="inputs:read">
+              <DataTable id="grok-pattern-list"
+                         className="table-striped table-hover"
+                         headers={headers}
+                         headerCellFormatter={this._headerCellFormatter}
+                         sortByKey={'name'}
+                         rows={this.state.patterns}
+                         dataRowFormatter={this._patternFormatter}
+                         filterLabel="Filter patterns"
+                         filterKeys={filterKeys} />
+            </IfPermitted>
           </Col>
         </Row>
       </div>

--- a/graylog2-web-interface/src/components/grok-patterns/GrokPatterns.jsx
+++ b/graylog2-web-interface/src/components/grok-patterns/GrokPatterns.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { Row, Col, Button } from 'react-bootstrap';
 
 import StoreProvider from 'injection/StoreProvider';
+
 const GrokPatternsStore = StoreProvider.getStore('GrokPatterns');
 
 import PageHeader from 'components/common/PageHeader';
@@ -65,13 +66,21 @@ const GrokPatterns = React.createClass({
         <td>{pattern.name}</td>
         <td>{pattern.pattern}</td>
         <td>
-          <Button style={{ marginRight: 5 }} bsStyle="primary" bsSize="xs"
-                  onClick={this.confirmedRemove.bind(this, pattern)}>
-            Delete
-          </Button>
-          <EditPatternModal id={pattern.id} name={pattern.name} pattern={pattern.pattern} create={false}
-                            reload={this.loadData} savePattern={this.savePattern}
-                            validPatternName={this.validPatternName} />
+          <IfPermitted permissions="inputs:edit">
+            <Button style={{ marginRight: 5 }}
+                    bsStyle="primary"
+                    bsSize="xs"
+                    onClick={() => this.confirmedRemove(pattern)}>
+              Delete
+            </Button>
+            <EditPatternModal id={pattern.id}
+                              name={pattern.name}
+                              pattern={pattern.pattern}
+                              create={false}
+                              reload={this.loadData}
+                              savePattern={this.savePattern}
+                              validPatternName={this.validPatternName} />
+          </IfPermitted>
         </td>
       </tr>
     );
@@ -91,7 +100,10 @@ const GrokPatterns = React.createClass({
           <IfPermitted permissions="inputs:edit">
             <span>
               <BulkLoadPatternModal onSuccess={this.loadData} />
-              <EditPatternModal id={''} name={''} pattern={''} create
+              <EditPatternModal id={''}
+                                name={''}
+                                pattern={''}
+                                create
                                 reload={this.loadData}
                                 savePattern={this.savePattern}
                                 validPatternName={this.validPatternName} />

--- a/graylog2-web-interface/src/components/loggers/NodeLoggers.jsx
+++ b/graylog2-web-interface/src/components/loggers/NodeLoggers.jsx
@@ -3,7 +3,7 @@ import React from 'react';
 import Reflux from 'reflux';
 import { Button, Col, Row } from 'react-bootstrap';
 
-import { LinkToNode } from 'components/common';
+import { LinkToNode, IfPermitted } from 'components/common';
 import { LoggingSubsystem, LogLevelMetricsOverview } from 'components/loggers';
 
 import ActionsProvider from 'injection/ActionsProvider';
@@ -50,23 +50,25 @@ const NodeLoggers = React.createClass({
     return (
       <Row className="row-sm log-writing-node content">
         <Col md={12}>
-          <div style={{ marginBottom: '20' }}>
-            <div className="pull-right">
-              <Button bsSize="sm" bsStyle="primary" className="trigger-log-level-metrics"
-                      onClick={() => this.setState({ showDetails: !this.state.showDetails })}>
-                <i className="fa fa-dashboard" />{' '}
-                {this.state.showDetails ? 'Hide' : 'Show'} log level metrics
-              </Button>
+          <IfPermitted permissions="loggers:read">
+            <div style={{ marginBottom: '20' }}>
+              <div className="pull-right">
+                <Button bsSize="sm" bsStyle="primary" className="trigger-log-level-metrics"
+                        onClick={() => this.setState({ showDetails: !this.state.showDetails })}>
+                  <i className="fa fa-dashboard" />{' '}
+                  {this.state.showDetails ? 'Hide' : 'Show'} log level metrics
+                </Button>
+              </div>
+              <h2>
+                <LinkToNode nodeId={nodeId} />
+                <span style={{ fontSize: '12px' }}> Has written a total of <strong>{this._formatThroughput()} internal log messages.</strong></span>
+              </h2>
             </div>
-            <h2>
-              <LinkToNode nodeId={nodeId} />
-              <span style={{ fontSize: '12px' }}> Has written a total of <strong>{this._formatThroughput()} internal log messages.</strong></span>
-            </h2>
-          </div>
-          <div className="subsystems">
-            {subsystems}
-          </div>
-          {this.state.showDetails && logLevelMetrics}
+            <div className="subsystems">
+              {subsystems}
+            </div>
+            {this.state.showDetails && logLevelMetrics}
+          </IfPermitted>
         </Col>
       </Row>
     );

--- a/graylog2-web-interface/src/pages/GrokPatternsPage.jsx
+++ b/graylog2-web-interface/src/pages/GrokPatternsPage.jsx
@@ -1,15 +1,13 @@
 import React from 'react';
 
 import GrokPatterns from 'components/grok-patterns/GrokPatterns';
-import { DocumentTitle, IfPermitted } from 'components/common';
+import { DocumentTitle } from 'components/common';
 
 const GrokPatternsPage = React.createClass({
   render() {
     return (
       <DocumentTitle title="Grok patterns">
-        <IfPermitted permissions="inputs:read">
-          <GrokPatterns />
-        </IfPermitted>
+        <GrokPatterns />
       </DocumentTitle>
     );
   },

--- a/graylog2-web-interface/src/pages/GrokPatternsPage.jsx
+++ b/graylog2-web-interface/src/pages/GrokPatternsPage.jsx
@@ -1,13 +1,15 @@
 import React from 'react';
 
 import GrokPatterns from 'components/grok-patterns/GrokPatterns';
-import { DocumentTitle } from 'components/common';
+import { DocumentTitle, IfPermitted } from 'components/common';
 
 const GrokPatternsPage = React.createClass({
   render() {
     return (
       <DocumentTitle title="Grok patterns">
-        <GrokPatterns />
+        <IfPermitted permissions="inputs:read">
+          <GrokPatterns />
+        </IfPermitted>
       </DocumentTitle>
     );
   },


### PR DESCRIPTION
Hides various content when the user does not have the correct permission to avoid accidentally leaking information in the future.

Added a new `authentication:read` permission to disambiguate the `clusterconfigentry:read` check

fix #4407 