### PR TITLE
allow to pass custom renderers for key and value titles in histograms

### DIFF
--- a/graylog2-web-interface/src/components/cluster/TrafficGraph.jsx
+++ b/graylog2-web-interface/src/components/cluster/TrafficGraph.jsx
@@ -5,6 +5,8 @@ import HistogramVisualization from 'components/visualizations/HistogramVisualiza
 import _ from 'lodash';
 import moment from 'moment';
 import crossfilter from 'crossfilter';
+import numeral from 'numeral';
+import DateTime from 'logic/datetimes/DateTime';
 
 const TrafficGraph = React.createClass({
 
@@ -45,7 +47,9 @@ const TrafficGraph = React.createClass({
                               data={unixTraffic}
                               config={config}
                               width={this.props.width}
-                              interactive={false}
+                              interactive
+                              keyTitleRenderer={d => `<span class="date">${new DateTime(d.x).toString(DateTime.Formats.DATE)}</span>`}
+                              valueTitleRenderer={d => `${numeral(d.y).format('0.00b')}`}
                               computationTimeRange={{ from: this.props.from, to: this.props.to }} />
     );
   },

--- a/graylog2-web-interface/src/components/visualizations/HistogramVisualization.jsx
+++ b/graylog2-web-interface/src/components/visualizations/HistogramVisualization.jsx
@@ -28,6 +28,8 @@ const HistogramVisualization = React.createClass({
     width: PropTypes.number,
     interactive: PropTypes.bool,
     onRenderComplete: PropTypes.func,
+    keyTitleRenderer: PropTypes.func,
+    valueTitleRenderer: PropTypes.func,
   },
 
   getDefaultProps() {
@@ -35,6 +37,8 @@ const HistogramVisualization = React.createClass({
       interactive: true,
       onRenderComplete: () => {
       },
+      keyTitleRenderer: d => `<span class="date">${new DateTime(d.x).toString(DateTime.Formats.COMPLETE)}</span>`,
+      valueTitleRenderer: d => `${numeral(d.y).format('0,0')} messages`,
     };
   },
 
@@ -100,8 +104,8 @@ const HistogramVisualization = React.createClass({
   _renderTooltip(histogram, histogramDomNode) {
     histogram.on('renderlet', () => {
       const formatTitle = (d) => {
-        const valueText = `${numeral(d.y).format('0,0')} messages`;
-        const keyText = `<span class="date">${new DateTime(d.x).toString(DateTime.Formats.COMPLETE)}</span>`;
+        const valueText = this.props.valueTitleRenderer(d);
+        const keyText = this.props.keyTitleRenderer(d);
 
         return `<div class="datapoint-info">${valueText}<br>${keyText}</div>`;
       };


### PR DESCRIPTION
the default renderers can now be replaced individually by setting props

used in TrafficGraphs to display nicer values

fixes #4395
