### PR TITLE
Add source editor component

### DIFF
--- a/graylog2-web-interface/package.json
+++ b/graylog2-web-interface/package.json
@@ -71,6 +71,7 @@
     "react-dnd-html5-backend": "^2.0.0",
     "react-grid-layout": "^0.14.3",
     "react-overlays": "^0.6.5",
+    "react-resizable": "^1.7.5",
     "react-select": "^v1.0.0-rc.10",
     "rickshaw": "^1.5.1",
     "sockjs-client": "1.1.x",

--- a/graylog2-web-interface/package.json
+++ b/graylog2-web-interface/package.json
@@ -65,6 +65,7 @@
     "numeral": "^1.5.3",
     "opensans-npm-webfont": "^1.0.0",
     "qs": "^6.3.0",
+    "react-ace": "^5.8.0",
     "react-day-picker": "^5.0.0",
     "react-dnd": "^2.0.2",
     "react-dnd-html5-backend": "^2.0.0",

--- a/graylog2-web-interface/package.json
+++ b/graylog2-web-interface/package.json
@@ -65,7 +65,7 @@
     "numeral": "^1.5.3",
     "opensans-npm-webfont": "^1.0.0",
     "qs": "^6.3.0",
-    "react-ace": "^5.8.0",
+    "react-ace": "^5.9.0",
     "react-day-picker": "^5.0.0",
     "react-dnd": "^2.0.2",
     "react-dnd-html5-backend": "^2.0.0",

--- a/graylog2-web-interface/src/components/common/ClipboardButton.jsx
+++ b/graylog2-web-interface/src/components/common/ClipboardButton.jsx
@@ -29,11 +29,14 @@ const ClipboardButton = React.createClass({
     bsSize: PropTypes.string,
     /** Specifies if the button is disabled or not. */
     disabled: PropTypes.bool,
+    /** Text to display when hovering over the button. */
+    buttonTitle: PropTypes.string,
   },
   getDefaultProps() {
     return {
       action: 'copy',
       disabled: false,
+      buttonTitle: undefined,
     };
   },
   getInitialState() {
@@ -65,13 +68,14 @@ const ClipboardButton = React.createClass({
     this.setState({ tooltipMessage: `Press Ctrl+${key} to ${event.action}` });
   },
   _getFilteredProps() {
-    const { className, style, bsStyle, bsSize, disabled } = this.props;
+    const { className, style, bsStyle, bsSize, disabled, buttonTitle } = this.props;
     return {
       className: className,
       style: style,
       bsStyle: bsStyle,
       bsSize: bsSize,
       disabled: disabled,
+      title: buttonTitle,
     };
   },
   render() {

--- a/graylog2-web-interface/src/components/common/ClipboardButton.jsx
+++ b/graylog2-web-interface/src/components/common/ClipboardButton.jsx
@@ -65,7 +65,7 @@ const ClipboardButton = React.createClass({
   },
   _onError(event) {
     const key = event.action === 'cut' ? 'K' : 'C';
-    this.setState({ tooltipMessage: `Press Ctrl+${key} to ${event.action}` });
+    this.setState({ tooltipMessage: <span>Press Ctrl+{key}&thinsp;/&thinsp;&#8984;{key} to {event.action}</span> });
   },
   _getFilteredProps() {
     const { className, style, bsStyle, bsSize, disabled, buttonTitle } = this.props;

--- a/graylog2-web-interface/src/components/common/ClipboardButton.jsx
+++ b/graylog2-web-interface/src/components/common/ClipboardButton.jsx
@@ -27,10 +27,13 @@ const ClipboardButton = React.createClass({
     bsStyle: PropTypes.string,
     /** Button's bsSize. */
     bsSize: PropTypes.string,
+    /** Specifies if the button is disabled or not. */
+    disabled: PropTypes.bool,
   },
   getDefaultProps() {
     return {
       action: 'copy',
+      disabled: false,
     };
   },
   getInitialState() {
@@ -62,12 +65,13 @@ const ClipboardButton = React.createClass({
     this.setState({ tooltipMessage: `Press Ctrl+${key} to ${event.action}` });
   },
   _getFilteredProps() {
-    const { className, style, bsStyle, bsSize } = this.props;
+    const { className, style, bsStyle, bsSize, disabled } = this.props;
     return {
       className: className,
       style: style,
       bsStyle: bsStyle,
       bsSize: bsSize,
+      disabled: disabled,
     };
   },
   render() {

--- a/graylog2-web-interface/src/components/common/SourceCodeEditor.css
+++ b/graylog2-web-interface/src/components/common/SourceCodeEditor.css
@@ -1,0 +1,4 @@
+:local(.sourceCodeEditor) .ace_editor {
+    border: 1px solid #ccc;
+    border-radius: 5px;
+}

--- a/graylog2-web-interface/src/components/common/SourceCodeEditor.css
+++ b/graylog2-web-interface/src/components/common/SourceCodeEditor.css
@@ -2,3 +2,18 @@
     border: 1px solid #ccc;
     border-radius: 5px;
 }
+
+/* Ensure resize handle is over text editor */
+:local(.sourceCodeEditor) .react-resizable-handle {
+    z-index: 100;
+}
+
+/* Make resize handle visible on a dark background */
+:local(.darkMode) .react-resizable-handle {
+    filter: invert(100%) brightness(180%);
+}
+
+/* Hide resizable handle if editor is not resizable */
+:local(.static) .react-resizable-handle {
+    display: none;
+}

--- a/graylog2-web-interface/src/components/common/SourceCodeEditor.css
+++ b/graylog2-web-interface/src/components/common/SourceCodeEditor.css
@@ -1,3 +1,19 @@
+:local(.toolbar) {
+    background: #f8f8f8;
+    border: 1px solid #ccc;
+    border-bottom: 0;
+    border-radius: 5px 5px 0 0;
+}
+
+:local(.toolbar) .btn-link {
+    color: #333;
+}
+
+/* Do not add border radius if code editor comes after toolbar */
+:local(.toolbar) + :local(.sourceCodeEditor) .ace_editor {
+    border-radius: 0 0 5px 5px;
+}
+
 :local(.sourceCodeEditor) .ace_editor {
     border: 1px solid #ccc;
     border-radius: 5px;

--- a/graylog2-web-interface/src/components/common/SourceCodeEditor.jsx
+++ b/graylog2-web-interface/src/components/common/SourceCodeEditor.jsx
@@ -82,7 +82,6 @@ class SourceCodeEditor extends React.Component {
     return (
       <Resizable height={height}
                  width={width}
-                 axis="y"
                  minConstraints={[200, 200]}
                  onResize={this.handleResize}>
         <div className={containerStyle} style={{ height: height, width: Number.isNaN(width) ? '100%' : width }}>

--- a/graylog2-web-interface/src/components/common/SourceCodeEditor.jsx
+++ b/graylog2-web-interface/src/components/common/SourceCodeEditor.jsx
@@ -109,13 +109,13 @@ class SourceCodeEditor extends React.Component {
     }
   }
 
-  isRedoDisabled = () => {
-    return this.props.readOnly || !this.reactAce || !this.reactAce.editor.getSession().getUndoManager().hasRedo();
-  }
+  isCopyDisabled = () => this.props.readOnly || this.state.selectedText === '';
 
-  isUndoDisabled = () => {
-    return this.props.readOnly || !this.reactAce || !this.reactAce.editor.getSession().getUndoManager().hasUndo();
-  }
+  isPasteDisabled = () => this.props.readOnly;
+
+  isRedoDisabled = () => this.props.readOnly || !this.reactAce || !this.reactAce.editor.getSession().getUndoManager().hasRedo();
+
+  isUndoDisabled = () => this.props.readOnly || !this.reactAce || !this.reactAce.editor.getSession().getUndoManager().hasUndo();
 
   handleRedo = () => {
     this.reactAce.editor.redo();
@@ -154,9 +154,9 @@ class SourceCodeEditor extends React.Component {
                                  onSuccess={this.focusEditor}
                                  text={this.state.selectedText}
                                  buttonTitle="Copy (Ctrl+C / &#8984;C)"
-                                 disabled={this.state.selectedText === ''} />
+                                 disabled={this.isCopyDisabled} />
                 <OverlayTrigger placement="top" trigger="click" overlay={overlay} rootClose>
-                  <Button bsStyle="link" bsSize="sm" title="Paste (Ctrl+V / &#8984;V)">
+                  <Button bsStyle="link" bsSize="sm" title="Paste (Ctrl+V / &#8984;V)" disabled={this.isPasteDisabled}>
                     <i className="fa fa-paste fa-fw" />
                   </Button>
                 </OverlayTrigger>

--- a/graylog2-web-interface/src/components/common/SourceCodeEditor.jsx
+++ b/graylog2-web-interface/src/components/common/SourceCodeEditor.jsx
@@ -57,6 +57,7 @@ class SourceCodeEditor extends React.Component {
     this.state = {
       height: props.height,
       width: props.width,
+      selectedText: '',
     };
   }
 
@@ -73,6 +74,19 @@ class SourceCodeEditor extends React.Component {
 
   reloadEditor = () => {
     this.reactAce.editor.resize();
+  }
+
+  resetUndoHistory = () => {
+    // Hack to not clear editor form when executing undo action.
+    // See https://github.com/Graylog2/graylog-plugin-pipeline-processor/issues/224
+    if (!this.clearedUndoHistory) {
+      try {
+        this.reactAce.editor.getSession().getUndoManager().reset();
+        this.clearedUndoHistory = true;
+      } catch (e) {
+        // Do nothing
+      }
+    }
   }
 
   render() {
@@ -93,6 +107,7 @@ class SourceCodeEditor extends React.Component {
                      theme={this.props.theme === 'light' ? 'tomorrow' : 'monokai'}
                      name={this.props.id}
                      height="100%"
+                     onInput={this.resetUndoHistory}
                      onLoad={this.props.onLoad}
                      onChange={this.props.onChange}
                      readOnly={this.props.readOnly}

--- a/graylog2-web-interface/src/components/common/SourceCodeEditor.jsx
+++ b/graylog2-web-interface/src/components/common/SourceCodeEditor.jsx
@@ -18,6 +18,12 @@ import style from './SourceCodeEditor.css';
  */
 class SourceCodeEditor extends React.Component {
   static propTypes = {
+    /**
+     * Annotations to show in the editor's gutter. The format should be:
+     * `[{ row: 0, column: 2, type: 'error', text: 'Some error.'}]`
+     * The type value must be one of `error`, `warning`, or `info`.
+     */
+    annotations: PropTypes.array,
     /** Specifies if the source code editor should have the input focus or not. */
     focus: PropTypes.bool,
     /** Specifies the font size in pixels to use in the text editor. */
@@ -45,6 +51,7 @@ class SourceCodeEditor extends React.Component {
   }
 
   static defaultProps = {
+    annotations: [],
     focus: false,
     fontSize: 13,
     height: 200,
@@ -163,6 +170,7 @@ class SourceCodeEditor extends React.Component {
                    onResize={this.handleResize}>
           <div className={containerStyle} style={{ height: height, width: validCssWidth }}>
             <AceEditor ref={(c) => { this.reactAce = c; }}
+                       annotations={this.props.annotations}
                        editorProps={{ $blockScrolling: 'Infinity' }}
                        focus={this.props.focus}
                        fontSize={this.props.fontSize}

--- a/graylog2-web-interface/src/components/common/SourceCodeEditor.jsx
+++ b/graylog2-web-interface/src/components/common/SourceCodeEditor.jsx
@@ -1,0 +1,63 @@
+import React from 'react';
+import { PropTypes } from 'prop-types';
+import 'brace';
+import AceEditor from 'react-ace';
+
+import 'brace/mode/text';
+import 'brace/theme/tomorrow';
+import 'brace/theme/monokai';
+import style from './SourceCodeEditor.css';
+
+/**
+ * Component that renders a source code editor input. This is what powers the pipeline rules and collector
+ * editors.
+ */
+class SourceCodeEditor extends React.Component {
+  static propTypes = {
+    /** Specifies if the source code editor should have the input focus or not. */
+    focus: PropTypes.bool,
+    /** Specifies the font size in pixels to use in the text editor. */
+    fontSize: PropTypes.number,
+    /** Specifies a unique ID for the source code editor. */
+    id: PropTypes.string.isRequired,
+    /** Function called on editor load. The first argument is the instance of the editor. */
+    onLoad: PropTypes.func,
+    /**
+     * Function called when the value of the text changes. It receives the
+     * the new value and an event as arguments.
+     */
+    onChange: PropTypes.func.isRequired,
+    /** Specifies the theme to use for the editor. */
+    theme: PropTypes.oneOf(['light', 'dark']),
+    /** Text to use in the editor. */
+    value: PropTypes.string,
+  };
+
+  static defaultProps = {
+    focus: false,
+    fontSize: 13,
+    onLoad: () => {},
+    theme: 'light',
+    value: '',
+  };
+
+  render() {
+    return (
+      <div className={style.sourceCodeEditor}>
+        <AceEditor editorProps={{ $blockScrolling: 'Infinity' }}
+                   focus={this.props.focus}
+                   fontSize={this.props.fontSize}
+                   mode="text"
+                   theme={this.props.theme === 'light' ? 'tomorrow' : 'monokai'}
+                   name={this.props.id}
+                   height="18em"
+                   onLoad={this.props.onLoad}
+                   onChange={this.props.onChange}
+                   value={this.props.value}
+                   width="100%" />
+      </div>
+    );
+  }
+}
+
+export default SourceCodeEditor;

--- a/graylog2-web-interface/src/components/common/SourceCodeEditor.jsx
+++ b/graylog2-web-interface/src/components/common/SourceCodeEditor.jsx
@@ -7,7 +7,11 @@ import { Button, ButtonGroup, ButtonToolbar, OverlayTrigger, Tooltip } from 'rea
 
 import { ClipboardButton } from 'components/common';
 
+import 'brace/mode/json';
+import 'brace/mode/lua';
+import 'brace/mode/markdown';
 import 'brace/mode/text';
+import 'brace/mode/yaml';
 import 'brace/theme/tomorrow';
 import 'brace/theme/monokai';
 import style from './SourceCodeEditor.css';
@@ -32,6 +36,8 @@ class SourceCodeEditor extends React.Component {
     height: PropTypes.number,
     /** Specifies a unique ID for the source code editor. */
     id: PropTypes.string.isRequired,
+    /** Specifies the mode to use in the editor. This is used for highlighting and auto-completion. */
+    mode: PropTypes.oneOf(['json', 'lua', 'markdown', 'text', 'yaml']),
     /** Function called on editor load. The first argument is the instance of the editor. */
     onLoad: PropTypes.func,
     /** Function called when the value of the text changes. It receives the the new value and an event as arguments. */
@@ -55,6 +61,7 @@ class SourceCodeEditor extends React.Component {
     focus: false,
     fontSize: 13,
     height: 200,
+    mode: 'text',
     onChange: () => {},
     onLoad: () => {},
     readOnly: false,
@@ -183,7 +190,7 @@ class SourceCodeEditor extends React.Component {
                        editorProps={{ $blockScrolling: 'Infinity' }}
                        focus={this.props.focus}
                        fontSize={this.props.fontSize}
-                       mode="text"
+                       mode={this.props.mode}
                        theme={this.props.theme === 'light' ? 'tomorrow' : 'monokai'}
                        name={this.props.id}
                        height="100%"

--- a/graylog2-web-interface/src/components/common/SourceCodeEditor.jsx
+++ b/graylog2-web-interface/src/components/common/SourceCodeEditor.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { PropTypes } from 'prop-types';
+import { Resizable } from 'react-resizable';
 import 'brace';
 import AceEditor from 'react-ace';
 
@@ -18,48 +19,88 @@ class SourceCodeEditor extends React.Component {
     focus: PropTypes.bool,
     /** Specifies the font size in pixels to use in the text editor. */
     fontSize: PropTypes.number,
+    /** Editor height in pixels. */
+    height: PropTypes.number,
     /** Specifies a unique ID for the source code editor. */
     id: PropTypes.string.isRequired,
     /** Function called on editor load. The first argument is the instance of the editor. */
     onLoad: PropTypes.func,
-    /**
-     * Function called when the value of the text changes. It receives the
-     * the new value and an event as arguments.
-     */
+    /** Function called when the value of the text changes. It receives the the new value and an event as arguments. */
     onChange: PropTypes.func.isRequired,
     /** Specifies if the editor should be in read-only mode. */
     readOnly: PropTypes.bool,
+    /** Specifies if the editor should be resizable by the user. */
+    resizable: PropTypes.bool,
     /** Specifies the theme to use for the editor. */
     theme: PropTypes.oneOf(['light', 'dark']),
     /** Text to use in the editor. */
     value: PropTypes.string,
-  };
+    /** Editor width in pixels. Use `Infinity` to indicate the editor should use 100% of its container's width. */
+    width: PropTypes.number,
+  }
 
   static defaultProps = {
     focus: false,
     fontSize: 13,
+    height: 200,
     onLoad: () => {},
     readOnly: false,
+    resizable: true,
     theme: 'light',
     value: '',
-  };
+    width: Infinity,
+  }
+
+  constructor(props) {
+    super(props);
+    this.state = {
+      height: props.height,
+      width: props.width,
+    };
+  }
+
+  componentDidUpdate(prevProps) {
+    if (this.props.height !== prevProps.height || this.props.width !== prevProps.width) {
+      this.reloadEditor();
+    }
+  }
+
+  handleResize = (event, { size }) => {
+    const { height, width } = size;
+    this.setState({ height: height, width: width }, this.reloadEditor);
+  }
+
+  reloadEditor = () => {
+    this.reactAce.editor.resize();
+  }
 
   render() {
+    const { height, width } = this.state;
+    const { theme, resizable } = this.props;
+    const containerStyle = `${style.sourceCodeEditor} ${theme !== 'light' && style.darkMode} ${!resizable && style.static}`;
     return (
-      <div className={style.sourceCodeEditor}>
-        <AceEditor editorProps={{ $blockScrolling: 'Infinity' }}
-                   focus={this.props.focus}
-                   fontSize={this.props.fontSize}
-                   mode="text"
-                   theme={this.props.theme === 'light' ? 'tomorrow' : 'monokai'}
-                   name={this.props.id}
-                   height="18em"
-                   onLoad={this.props.onLoad}
-                   onChange={this.props.onChange}
-                   readOnly={this.props.readOnly}
-                   value={this.props.value}
-                   width="100%" />
-      </div>
+      <Resizable height={height}
+                 width={width}
+                 axis="y"
+                 minConstraints={[200, 200]}
+                 onResize={this.handleResize}>
+        <div className={containerStyle} style={{ height: height, width: Number.isNaN(width) ? '100%' : width }}>
+          <AceEditor ref={(c) => { this.reactAce = c; }}
+                     editorProps={{ $blockScrolling: 'Infinity' }}
+                     focus={this.props.focus}
+                     fontSize={this.props.fontSize}
+                     mode="text"
+                     theme={this.props.theme === 'light' ? 'tomorrow' : 'monokai'}
+                     name={this.props.id}
+                     height="100%"
+                     onLoad={this.props.onLoad}
+                     onChange={this.props.onChange}
+                     readOnly={this.props.readOnly}
+                     defaultValue={this.props.value}
+                     value={this.props.value}
+                     width="100%" />
+        </div>
+      </Resizable>
     );
   }
 }

--- a/graylog2-web-interface/src/components/common/SourceCodeEditor.jsx
+++ b/graylog2-web-interface/src/components/common/SourceCodeEditor.jsx
@@ -26,7 +26,7 @@ class SourceCodeEditor extends React.Component {
     /** Function called on editor load. The first argument is the instance of the editor. */
     onLoad: PropTypes.func,
     /** Function called when the value of the text changes. It receives the the new value and an event as arguments. */
-    onChange: PropTypes.func.isRequired,
+    onChange: PropTypes.func,
     /** Specifies if the editor should be in read-only mode. */
     readOnly: PropTypes.bool,
     /** Specifies if the editor should be resizable by the user. */
@@ -43,6 +43,7 @@ class SourceCodeEditor extends React.Component {
     focus: false,
     fontSize: 13,
     height: 200,
+    onChange: () => {},
     onLoad: () => {},
     readOnly: false,
     resizable: true,

--- a/graylog2-web-interface/src/components/common/SourceCodeEditor.jsx
+++ b/graylog2-web-interface/src/components/common/SourceCodeEditor.jsx
@@ -3,6 +3,7 @@ import { PropTypes } from 'prop-types';
 import { Resizable } from 'react-resizable';
 import 'brace';
 import AceEditor from 'react-ace';
+import { Button, ButtonGroup, ButtonToolbar } from 'react-bootstrap';
 
 import 'brace/mode/text';
 import 'brace/theme/tomorrow';
@@ -33,6 +34,8 @@ class SourceCodeEditor extends React.Component {
     resizable: PropTypes.bool,
     /** Specifies the theme to use for the editor. */
     theme: PropTypes.oneOf(['light', 'dark']),
+    /** Specifies if the editor should also include a toolbar. */
+    toolbar: PropTypes.bool,
     /** Text to use in the editor. */
     value: PropTypes.string,
     /** Editor width in pixels. Use `Infinity` to indicate the editor should use 100% of its container's width. */
@@ -48,6 +51,7 @@ class SourceCodeEditor extends React.Component {
     readOnly: false,
     resizable: true,
     theme: 'light',
+    toolbar: true,
     value: '',
     width: Infinity,
   }
@@ -89,33 +93,62 @@ class SourceCodeEditor extends React.Component {
     }
   }
 
+  handleRedo = () => {
+    const editor = this.reactAce.editor;
+    editor.redo();
+    editor.focus();
+  }
+
+  handleUndo = () => {
+    const editor = this.reactAce.editor;
+    editor.undo();
+    editor.focus();
+  }
+
   render() {
     const { height, width } = this.state;
+    const validCssWidth = Number.isNaN(width) ? '100%' : width;
     const { theme, resizable } = this.props;
     const containerStyle = `${style.sourceCodeEditor} ${theme !== 'light' && style.darkMode} ${!resizable && style.static}`;
     return (
-      <Resizable height={height}
-                 width={width}
-                 minConstraints={[200, 200]}
-                 onResize={this.handleResize}>
-        <div className={containerStyle} style={{ height: height, width: Number.isNaN(width) ? '100%' : width }}>
-          <AceEditor ref={(c) => { this.reactAce = c; }}
-                     editorProps={{ $blockScrolling: 'Infinity' }}
-                     focus={this.props.focus}
-                     fontSize={this.props.fontSize}
-                     mode="text"
-                     theme={this.props.theme === 'light' ? 'tomorrow' : 'monokai'}
-                     name={this.props.id}
-                     height="100%"
-                     onInput={this.resetUndoHistory}
-                     onLoad={this.props.onLoad}
-                     onChange={this.props.onChange}
-                     readOnly={this.props.readOnly}
-                     defaultValue={this.props.value}
-                     value={this.props.value}
-                     width="100%" />
-        </div>
-      </Resizable>
+      <div>
+        {this.props.toolbar &&
+          <div className={style.toolbar} style={{ width: validCssWidth }}>
+            <ButtonToolbar>
+              <ButtonGroup>
+                <Button bsStyle="link" bsSize="sm" onClick={this.handleUndo} disabled={this.props.readOnly}>
+                  <i className="fa fa-undo fa-fw" />
+                </Button>
+                <Button bsStyle="link" bsSize="sm" onClick={this.handleRedo} disabled={this.props.readOnly}>
+                  <i className="fa fa-repeat fa-fw" />
+                </Button>
+              </ButtonGroup>
+            </ButtonToolbar>
+          </div>
+        }
+        <Resizable height={height}
+                   width={width}
+                   minConstraints={[200, 200]}
+                   onResize={this.handleResize}>
+          <div className={containerStyle} style={{ height: height, width: validCssWidth }}>
+            <AceEditor ref={(c) => { this.reactAce = c; }}
+                       editorProps={{ $blockScrolling: 'Infinity' }}
+                       focus={this.props.focus}
+                       fontSize={this.props.fontSize}
+                       mode="text"
+                       theme={this.props.theme === 'light' ? 'tomorrow' : 'monokai'}
+                       name={this.props.id}
+                       height="100%"
+                       onInput={this.resetUndoHistory}
+                       onLoad={this.props.onLoad}
+                       onChange={this.props.onChange}
+                       readOnly={this.props.readOnly}
+                       defaultValue={this.props.value}
+                       value={this.props.value}
+                       width="100%" />
+          </div>
+        </Resizable>
+      </div>
     );
   }
 }

--- a/graylog2-web-interface/src/components/common/SourceCodeEditor.jsx
+++ b/graylog2-web-interface/src/components/common/SourceCodeEditor.jsx
@@ -93,6 +93,14 @@ class SourceCodeEditor extends React.Component {
     }
   }
 
+  isRedoDisabled = () => {
+    return this.props.readOnly || !this.reactAce || !this.reactAce.editor.getSession().getUndoManager().hasRedo();
+  }
+
+  isUndoDisabled = () => {
+    return this.props.readOnly || !this.reactAce || !this.reactAce.editor.getSession().getUndoManager().hasUndo();
+  }
+
   handleRedo = () => {
     const editor = this.reactAce.editor;
     editor.redo();
@@ -116,10 +124,10 @@ class SourceCodeEditor extends React.Component {
           <div className={style.toolbar} style={{ width: validCssWidth }}>
             <ButtonToolbar>
               <ButtonGroup>
-                <Button bsStyle="link" bsSize="sm" onClick={this.handleUndo} disabled={this.props.readOnly}>
+                <Button bsStyle="link" bsSize="sm" onClick={this.handleUndo} disabled={this.isUndoDisabled()}>
                   <i className="fa fa-undo fa-fw" />
                 </Button>
-                <Button bsStyle="link" bsSize="sm" onClick={this.handleRedo} disabled={this.props.readOnly}>
+                <Button bsStyle="link" bsSize="sm" onClick={this.handleRedo} disabled={this.isRedoDisabled()}>
                   <i className="fa fa-repeat fa-fw" />
                 </Button>
               </ButtonGroup>

--- a/graylog2-web-interface/src/components/common/SourceCodeEditor.jsx
+++ b/graylog2-web-interface/src/components/common/SourceCodeEditor.jsx
@@ -134,7 +134,7 @@ class SourceCodeEditor extends React.Component {
     const validCssWidth = Number.isNaN(width) ? '100%' : width;
     const { theme, resizable } = this.props;
     const containerStyle = `${style.sourceCodeEditor} ${theme !== 'light' && style.darkMode} ${!resizable && style.static}`;
-    const overlay = <Tooltip id={'copy-button-tooltip'}>Click Paste on the Edit menu to paste.</Tooltip>;
+    const overlay = <Tooltip id={'paste-button-tooltip'}>Click Paste on the Edit menu to paste.</Tooltip>;
     return (
       <div>
         {this.props.toolbar &&
@@ -146,18 +146,27 @@ class SourceCodeEditor extends React.Component {
                                  bsSize="sm"
                                  onSuccess={this.focusEditor}
                                  text={this.state.selectedText}
+                                 buttonTitle="Copy (Ctrl+C / &#8984;C)"
                                  disabled={this.state.selectedText === ''} />
                 <OverlayTrigger placement="top" trigger="click" overlay={overlay} rootClose>
-                  <Button bsStyle="link" bsSize="sm" onClick={this.handlePaste}>
+                  <Button bsStyle="link" bsSize="sm" title="Paste (Ctrl+V / &#8984;V)">
                     <i className="fa fa-paste fa-fw" />
                   </Button>
                 </OverlayTrigger>
               </ButtonGroup>
               <ButtonGroup>
-                <Button bsStyle="link" bsSize="sm" onClick={this.handleUndo} disabled={this.isUndoDisabled()}>
+                <Button bsStyle="link"
+                        bsSize="sm"
+                        onClick={this.handleUndo}
+                        title="Undo (Ctrl+Z / &#8984;Z)"
+                        disabled={this.isUndoDisabled()}>
                   <i className="fa fa-undo fa-fw" />
                 </Button>
-                <Button bsStyle="link" bsSize="sm" onClick={this.handleRedo} disabled={this.isRedoDisabled()}>
+                <Button bsStyle="link"
+                        bsSize="sm"
+                        onClick={this.handleRedo}
+                        title="Redo (Ctrl+Shift+Z / &#8984;&#8679;Z)"
+                        disabled={this.isRedoDisabled()}>
                   <i className="fa fa-repeat fa-fw" />
                 </Button>
               </ButtonGroup>

--- a/graylog2-web-interface/src/components/common/SourceCodeEditor.jsx
+++ b/graylog2-web-interface/src/components/common/SourceCodeEditor.jsx
@@ -93,7 +93,9 @@ class SourceCodeEditor extends React.Component {
   }
 
   reloadEditor = () => {
-    this.reactAce.editor.resize();
+    if (this.props.resizable) {
+      this.reactAce.editor.resize();
+    }
   }
 
   resetUndoHistory = () => {
@@ -128,6 +130,9 @@ class SourceCodeEditor extends React.Component {
   }
 
   handleSelectionChange = (selection) => {
+    if (!this.reactAce || !this.props.toolbar || this.props.readOnly) {
+      return;
+    }
     const selectedText = this.reactAce.editor.getSession().getTextRange(selection.getRange());
     this.setState({ selectedText: selectedText });
   }
@@ -138,8 +143,8 @@ class SourceCodeEditor extends React.Component {
 
   render() {
     const { height, width } = this.state;
-    const validCssWidth = Number.isNaN(width) ? '100%' : width;
     const { theme, resizable } = this.props;
+    const validCssWidth = Number.isNaN(width) ? '100%' : width;
     const containerStyle = `${style.sourceCodeEditor} ${theme !== 'light' && style.darkMode} ${!resizable && style.static}`;
     const overlay = <Tooltip id={'paste-button-tooltip'}>Press Ctrl+V (&#8984;V in macOS) or select Edit&thinsp;&rarr;&thinsp;Paste to paste from clipboard.</Tooltip>;
     return (
@@ -199,7 +204,6 @@ class SourceCodeEditor extends React.Component {
                        onChange={this.props.onChange}
                        onSelectionChange={this.handleSelectionChange}
                        readOnly={this.props.readOnly}
-                       defaultValue={this.props.value}
                        value={this.props.value}
                        width="100%" />
           </div>

--- a/graylog2-web-interface/src/components/common/SourceCodeEditor.jsx
+++ b/graylog2-web-interface/src/components/common/SourceCodeEditor.jsx
@@ -134,7 +134,7 @@ class SourceCodeEditor extends React.Component {
     const validCssWidth = Number.isNaN(width) ? '100%' : width;
     const { theme, resizable } = this.props;
     const containerStyle = `${style.sourceCodeEditor} ${theme !== 'light' && style.darkMode} ${!resizable && style.static}`;
-    const overlay = <Tooltip id={'paste-button-tooltip'}>Click Paste on the Edit menu to paste.</Tooltip>;
+    const overlay = <Tooltip id={'paste-button-tooltip'}>Press Ctrl+V (&#8984;V in macOS) or select Edit&thinsp;&rarr;&thinsp;Paste to paste from clipboard.</Tooltip>;
     return (
       <div>
         {this.props.toolbar &&

--- a/graylog2-web-interface/src/components/common/SourceCodeEditor.jsx
+++ b/graylog2-web-interface/src/components/common/SourceCodeEditor.jsx
@@ -27,6 +27,8 @@ class SourceCodeEditor extends React.Component {
      * the new value and an event as arguments.
      */
     onChange: PropTypes.func.isRequired,
+    /** Specifies if the editor should be in read-only mode. */
+    readOnly: PropTypes.bool,
     /** Specifies the theme to use for the editor. */
     theme: PropTypes.oneOf(['light', 'dark']),
     /** Text to use in the editor. */
@@ -37,6 +39,7 @@ class SourceCodeEditor extends React.Component {
     focus: false,
     fontSize: 13,
     onLoad: () => {},
+    readOnly: false,
     theme: 'light',
     value: '',
   };
@@ -53,6 +56,7 @@ class SourceCodeEditor extends React.Component {
                    height="18em"
                    onLoad={this.props.onLoad}
                    onChange={this.props.onChange}
+                   readOnly={this.props.readOnly}
                    value={this.props.value}
                    width="100%" />
       </div>

--- a/graylog2-web-interface/src/components/common/SourceCodeEditor.jsx
+++ b/graylog2-web-interface/src/components/common/SourceCodeEditor.jsx
@@ -19,6 +19,9 @@ import style from './SourceCodeEditor.css';
 /**
  * Component that renders a source code editor input. This is what powers the pipeline rules and collector
  * editors.
+ *
+ * **Note:** The component needs to be used in a [controlled way](https://reactjs.org/docs/forms.html#controlled-components).
+ * Letting the component handle its own internal state may lead to weird errors while typing.
  */
 class SourceCodeEditor extends React.Component {
   static propTypes = {

--- a/graylog2-web-interface/src/components/common/SourceCodeEditor.jsx
+++ b/graylog2-web-interface/src/components/common/SourceCodeEditor.jsx
@@ -149,9 +149,9 @@ class SourceCodeEditor extends React.Component {
                                  onSuccess={this.focusEditor}
                                  text={this.state.selectedText}
                                  buttonTitle="Copy (Ctrl+C / &#8984;C)"
-                                 disabled={this.isCopyDisabled} />
+                                 disabled={this.isCopyDisabled()} />
                 <OverlayTrigger placement="top" trigger="click" overlay={overlay} rootClose>
-                  <Button bsStyle="link" bsSize="sm" title="Paste (Ctrl+V / &#8984;V)" disabled={this.isPasteDisabled}>
+                  <Button bsStyle="link" bsSize="sm" title="Paste (Ctrl+V / &#8984;V)" disabled={this.isPasteDisabled()}>
                     <i className="fa fa-paste fa-fw" />
                   </Button>
                 </OverlayTrigger>

--- a/graylog2-web-interface/src/components/common/SourceCodeEditor.jsx
+++ b/graylog2-web-interface/src/components/common/SourceCodeEditor.jsx
@@ -101,19 +101,6 @@ class SourceCodeEditor extends React.Component {
     }
   }
 
-  resetUndoHistory = () => {
-    // Hack to not clear editor form when executing undo action.
-    // See https://github.com/Graylog2/graylog-plugin-pipeline-processor/issues/224
-    if (!this.clearedUndoHistory) {
-      try {
-        this.reactAce.editor.getSession().getUndoManager().reset();
-        this.clearedUndoHistory = true;
-      } catch (e) {
-        // Do nothing
-      }
-    }
-  }
-
   isCopyDisabled = () => this.props.readOnly || this.state.selectedText === '';
 
   isPasteDisabled = () => this.props.readOnly;
@@ -202,7 +189,6 @@ class SourceCodeEditor extends React.Component {
                        theme={this.props.theme === 'light' ? 'tomorrow' : 'monokai'}
                        name={this.props.id}
                        height="100%"
-                       onInput={this.resetUndoHistory}
                        onLoad={this.props.onLoad}
                        onChange={this.props.onChange}
                        onSelectionChange={this.handleSelectionChange}

--- a/graylog2-web-interface/src/components/common/SourceCodeEditor.md
+++ b/graylog2-web-interface/src/components/common/SourceCodeEditor.md
@@ -34,13 +34,14 @@ const LightSourceEditor = createReactClass({
 <LightSourceEditor />
 ```
 
-Dark-themed editor:
+Read-only dark-themed editor:
 ```js
 const code = `function foobar() {
   console.log('this is some source code!');
 }
 `;
 <SourceCodeEditor id="editor-2"
+                  readOnly
                   theme="dark"
                   value={code} />
 ```

--- a/graylog2-web-interface/src/components/common/SourceCodeEditor.md
+++ b/graylog2-web-interface/src/components/common/SourceCodeEditor.md
@@ -47,6 +47,7 @@ const annotations = [
 ];
 <SourceCodeEditor id="editor-2"
                   annotations={annotations}
+                  resizable={false}
                   readOnly
                   theme="dark"
                   value={code} />
@@ -59,7 +60,7 @@ const code = `function foobar() {
 }
 `;
 <SourceCodeEditor id="editor-2"
-                  resizable={true}
+                  resizable={false}
                   height={100}
                   toolbar={false}
                   width={400}

--- a/graylog2-web-interface/src/components/common/SourceCodeEditor.md
+++ b/graylog2-web-interface/src/components/common/SourceCodeEditor.md
@@ -46,15 +46,16 @@ const code = `function foobar() {
                   value={code} />
 ```
 
-Non-resizable editor with custom height and width:
+Non-resizable editor without toolbar and with custom height and width:
 ```js
 const code = `function foobar() {
   console.log('this is some source code!');
 }
 `;
 <SourceCodeEditor id="editor-2"
-                  resizable={false}
+                  resizable={true}
                   height={100}
+                  toolbar={false}
                   width={400}
                   value={code} />
 ```

--- a/graylog2-web-interface/src/components/common/SourceCodeEditor.md
+++ b/graylog2-web-interface/src/components/common/SourceCodeEditor.md
@@ -45,3 +45,16 @@ const code = `function foobar() {
                   theme="dark"
                   value={code} />
 ```
+
+Non-resizable editor with custom height and width:
+```js
+const code = `function foobar() {
+  console.log('this is some source code!');
+}
+`;
+<SourceCodeEditor id="editor-2"
+                  resizable={false}
+                  height={100}
+                  width={400}
+                  value={code} />
+```

--- a/graylog2-web-interface/src/components/common/SourceCodeEditor.md
+++ b/graylog2-web-interface/src/components/common/SourceCodeEditor.md
@@ -1,0 +1,46 @@
+Light-themed editor:
+```js
+const createReactClass = require('create-react-class');
+
+const LightSourceEditor = createReactClass({
+  getInitialState() {
+    return {
+      code: `function foobar() {
+  console.log('this is some source code!');
+}
+`,
+    };
+  },
+  
+  handleChange(nextValue) {
+    this.setState({ code: nextValue });
+  },
+  
+  render() {
+    const { code } = this.state;
+    return (
+      <div>
+        <SourceCodeEditor id="editor-1"
+                          theme="light"
+                          value={code}
+                          onChange={this.handleChange} />
+        <p>Preview:</p>
+        <pre>{code}</pre>
+      </div>
+    );
+  },
+});
+
+<LightSourceEditor />
+```
+
+Dark-themed editor:
+```js
+const code = `function foobar() {
+  console.log('this is some source code!');
+}
+`;
+<SourceCodeEditor id="editor-2"
+                  theme="dark"
+                  value={code} />
+```

--- a/graylog2-web-interface/src/components/common/SourceCodeEditor.md
+++ b/graylog2-web-interface/src/components/common/SourceCodeEditor.md
@@ -2,25 +2,27 @@ Light-themed editor:
 ```js
 const createReactClass = require('create-react-class');
 
-const LightSourceEditor = createReactClass({
+const MarkdownSourceEditor = createReactClass({
   getInitialState() {
     return {
-      code: `function foobar() {
-  console.log('this is some source code!');
-}
+      code: `## Markdown text
+
+- This is an example of a source text editor
+- The code we write is written in Markdown
 `,
     };
   },
-  
+
   handleChange(nextValue) {
     this.setState({ code: nextValue });
   },
-  
+
   render() {
     const { code } = this.state;
     return (
       <div>
         <SourceCodeEditor id="editor-1"
+                          mode="markdown"
                           theme="light"
                           value={code}
                           onChange={this.handleChange} />
@@ -31,38 +33,84 @@ const LightSourceEditor = createReactClass({
   },
 });
 
-<LightSourceEditor />
+<MarkdownSourceEditor />
 ```
 
 Read-only dark-themed editor:
 ```js
-const code = `function foobar() {
+const createReactClass = require('create-react-class');
+
+const TextSourceEditor = createReactClass({
+  getInitialState() {
+    return {
+      code: `function foobar() {
   console.log('this is some source code!');
 }
-`;
-const annotations = [
-  { row: 1, column: -1, text: 'oh noes!', type: 'error' },
-  { row: 2, column: -1, text: 'easy!', type: 'warning' },
-  { row: 3, column: -1, text: 'info!', type: 'info' },
-];
-<SourceCodeEditor id="editor-2"
-                  annotations={annotations}
-                  resizable={false}
-                  readOnly
-                  theme="dark"
-                  value={code} />
+`,
+    };
+  },
+
+  handleChange(nextValue) {
+    this.setState({ code: nextValue });
+  },
+
+  render() {
+    const { code } = this.state;
+    const annotations = [
+      { row: 1, column: -1, text: 'oh noes!', type: 'error' },
+      { row: 2, column: -1, text: 'easy!', type: 'warning' },
+      { row: 3, column: -1, text: 'info!', type: 'info' },
+    ];
+    return (
+        <SourceCodeEditor id="editor-2"
+                          annotations={annotations}
+                          resizable={false}
+                          readOnly
+                          theme="dark"
+                          value={code} />
+    );
+  },
+});
+
+<TextSourceEditor />
 ```
 
 Non-resizable editor without toolbar and with custom height and width:
 ```js
-const code = `function foobar() {
-  console.log('this is some source code!');
+const createReactClass = require('create-react-class');
+
+const JsonSourceEditor = createReactClass({
+  getInitialState() {
+    return {
+      code: `{
+  "key": "value",
+  "foo": [
+    "bar",
+    "baz"
+  ]
 }
-`;
-<SourceCodeEditor id="editor-2"
-                  resizable={false}
-                  height={100}
-                  toolbar={false}
-                  width={400}
-                  value={code} />
+`,
+    };
+  },
+
+  handleChange(nextValue) {
+    this.setState({ code: nextValue });
+  },
+
+  render() {
+    const { code } = this.state;
+    return (
+      <SourceCodeEditor id="editor-2"
+                      height={100}
+                      mode="json"
+                      onChange={this.handleChange}
+                      resizable={false}
+                      toolbar={false}
+                      width={400}
+                      value={code} />
+      );
+  },
+});
+
+<JsonSourceEditor />
 ```

--- a/graylog2-web-interface/src/components/common/SourceCodeEditor.md
+++ b/graylog2-web-interface/src/components/common/SourceCodeEditor.md
@@ -40,7 +40,13 @@ const code = `function foobar() {
   console.log('this is some source code!');
 }
 `;
+const annotations = [
+  { row: 1, column: -1, text: 'oh noes!', type: 'error' },
+  { row: 2, column: -1, text: 'easy!', type: 'warning' },
+  { row: 3, column: -1, text: 'info!', type: 'info' },
+];
 <SourceCodeEditor id="editor-2"
+                  annotations={annotations}
                   readOnly
                   theme="dark"
                   value={code} />

--- a/graylog2-web-interface/src/components/common/index.jsx
+++ b/graylog2-web-interface/src/components/common/index.jsx
@@ -26,6 +26,7 @@ export { default as Select } from './Select';
 export { default as SelectableList } from './SelectableList';
 export { default as SortableList } from './SortableList';
 export { default as SortableListItem } from './SortableListItem';
+export { default as SourceCodeEditor } from './SourceCodeEditor';
 export { default as Spinner } from './Spinner';
 export { default as TableList } from './TableList';
 export { default as Timestamp } from './Timestamp';

--- a/graylog2-web-interface/yarn.lock
+++ b/graylog2-web-interface/yarn.lock
@@ -1226,6 +1226,10 @@ brace-expansion@^1.0.0, brace-expansion@^1.1.7:
     balanced-match "^1.0.0"
     concat-map "0.0.1"
 
+brace@^0.11.0:
+  version "0.11.0"
+  resolved "https://registry.yarnpkg.com/brace/-/brace-0.11.0.tgz#155cd80607687dc8cb908f0df94e62a033c1d563"
+
 braces@^1.8.2:
   version "1.8.5"
   resolved "https://registry.yarnpkg.com/braces/-/braces-1.8.5.tgz#ba77962e12dff969d6b76711e914b737857bf6a7"
@@ -4861,7 +4865,7 @@ lodash.isequal@^3.0:
     lodash._baseisequal "^3.0.0"
     lodash._bindcallback "^3.0.0"
 
-lodash.isequal@^4.0.0:
+lodash.isequal@^4.0.0, lodash.isequal@^4.1.1:
   version "4.5.0"
   resolved "https://registry.yarnpkg.com/lodash.isequal/-/lodash.isequal-4.5.0.tgz#415c4478f2bcc30120c22ce10ed3226f7d3e18e0"
 
@@ -6331,6 +6335,15 @@ rc@^1.1.7:
     ini "~1.3.0"
     minimist "^1.2.0"
     strip-json-comments "~2.0.1"
+
+react-ace@^5.8.0:
+  version "5.8.0"
+  resolved "https://registry.yarnpkg.com/react-ace/-/react-ace-5.8.0.tgz#872d9ee8b664300ed5ab9edac6234bbe90836836"
+  dependencies:
+    brace "^0.11.0"
+    lodash.get "^4.4.2"
+    lodash.isequal "^4.1.1"
+    prop-types "^15.5.8"
 
 react-addons-pure-render-mixin@^15.6.0:
   version "15.6.2"

--- a/graylog2-web-interface/yarn.lock
+++ b/graylog2-web-interface/yarn.lock
@@ -6526,7 +6526,7 @@ react-proxy-loader@^0.3.4:
   dependencies:
     loader-utils "^1.0.2"
 
-react-resizable@^1.4.0:
+react-resizable@^1.4.0, react-resizable@^1.7.5:
   version "1.7.5"
   resolved "https://registry.yarnpkg.com/react-resizable/-/react-resizable-1.7.5.tgz#83eb75bb3684da6989bbbf4f826e1470f0af902e"
   dependencies:

--- a/graylog2-web-interface/yarn.lock
+++ b/graylog2-web-interface/yarn.lock
@@ -6337,8 +6337,8 @@ rc@^1.1.7:
     strip-json-comments "~2.0.1"
 
 react-ace@^5.8.0:
-  version "5.8.0"
-  resolved "https://registry.yarnpkg.com/react-ace/-/react-ace-5.8.0.tgz#872d9ee8b664300ed5ab9edac6234bbe90836836"
+  version "5.9.0"
+  resolved "https://registry.yarnpkg.com/react-ace/-/react-ace-5.9.0.tgz#427a1cc4869b960a6f9748aa7eb169a9269fc336"
   dependencies:
     brace "^0.11.0"
     lodash.get "^4.4.2"


### PR DESCRIPTION
This PR moves the source code editor we used in the pipelines to the web interface, so other plugins can reuse it if they need it.

I manage to make a few improvements in there, hopefully they will improve the experience of using it:
- Updated to latest version of ReactAce
- Fixed issue with undo command after load: https://github.com/Graylog2/graylog-plugin-pipeline-processor/issues/224. I'm not fully satisfied with the fix, so I'll try to do a better fix and get it upstream
- Allow editor to be user-resizable, fixing https://github.com/Graylog2/graylog-plugin-pipeline-processor/issues/229
- Add read-only flag, so we can also pre-visualize code with the component
- Add toolbar to make more visibles some actions that can be done in the editor. For now only copying, pasting*, undo, and redo are available.

Bonus: Add dark theme support! 
<img width="993" alt="screen shot 2017-12-13 at 17 36 42" src="https://user-images.githubusercontent.com/716185/33950293-5707a754-e02c-11e7-88b2-398410560938.png">

*Dispatching a pasting event from JS doesn't really work for privacy reasons, so the user must trigger an action in the OS. The button therefore only shows a small tooltip indicating it can be done in the Edit menu.