### PR TITLE
Replace "_missing_" query with "NOT _exists_"

### DIFF
--- a/graylog2-web-interface/src/components/search/QueryInput.ts
+++ b/graylog2-web-interface/src/components/search/QueryInput.ts
@@ -145,7 +145,7 @@ class QueryInput {
         this.fields.forEach((field) => {
             possibleMatches.push(field + ":");
             possibleMatches.push("_exists_:" + field);
-            possibleMatches.push("_missing_:" + field);
+            possibleMatches.push("NOT _exists_:" + field);
         });
         return possibleMatches;
     }


### PR DESCRIPTION
The "_missing_" query has been removed in Elasticsearch 5.0:

https://www.elastic.co/guide/en/elasticsearch/reference/5.0/breaking_50_search_changes.html#_deprecated_queries_removed

Refs #4362