### PR TITLE
fix node id file permission checks

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/Configuration.java
+++ b/graylog2-server/src/main/java/org/graylog2/Configuration.java
@@ -320,17 +320,20 @@ public class Configuration extends BaseConfiguration {
             if (!file.isFile()) {
                 b.append("a file");
             }
-            if (!file.canRead()) {
+            final boolean readable = file.canRead();
+            final boolean writable = file.canWrite();
+            if (!readable) {
                 if (b.length() > 0) {
                     b.append(", ");
                 }
                 b.append("readable");
             }
-            if (!file.canWrite()) {
+            final boolean empty = file.length() == 0;
+            if (!writable && readable && empty) {
                 if (b.length() > 0) {
                     b.append(", ");
                 }
-                b.append("writable");
+                b.append("writable, but it is empty");
             }
             if (b.length() == 0) {
                 // all good


### PR DESCRIPTION
server start would fail if the node id was non-empty, but not writable.
this is a valid scenario where the node id is frozen by making the file read-only

added tests for various scenarios

fixes #4427