### PR TITLE
Restore ability to run behind reverse proxy

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/rest/RestTools.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/RestTools.java
@@ -27,7 +27,6 @@ import org.graylog2.utilities.IpSubnet;
 import javax.annotation.Nullable;
 import javax.validation.constraints.NotNull;
 import javax.ws.rs.container.ContainerRequestContext;
-import javax.ws.rs.core.HttpHeaders;
 import javax.ws.rs.core.MultivaluedMap;
 import javax.ws.rs.core.SecurityContext;
 import java.net.URI;
@@ -112,7 +111,13 @@ public class RestTools {
                     .findFirst();
         }
 
-        return externalUri.orElse(defaultUri);
+        final URI uri = externalUri.orElse(defaultUri);
+
+        // Make sure we return an URI object with a trailing slash
+        if (!uri.toString().endsWith("/")) {
+            return URI.create(uri.toString() + "/");
+        }
+        return uri;
     }
 
     public static String getPathFromResource(Resource resource) {

--- a/graylog2-server/src/main/java/org/graylog2/shared/initializers/JerseyService.java
+++ b/graylog2-server/src/main/java/org/graylog2/shared/initializers/JerseyService.java
@@ -84,6 +84,7 @@ import java.util.stream.Collectors;
 
 import static com.codahale.metrics.MetricRegistry.name;
 import static com.google.common.base.MoreObjects.firstNonNull;
+import static com.google.common.base.Strings.isNullOrEmpty;
 import static java.util.Objects.requireNonNull;
 
 public class JerseyService extends AbstractIdleService {
@@ -166,12 +167,13 @@ public class JerseyService extends AbstractIdleService {
                         configuration.getHttpTlsKeyPassword()) : null;
 
         final HostAndPort bindAddress = configuration.getHttpBindAddress();
+        final String contextPath = configuration.getHttpPublishUri().getPath();
         final URI listenUri = new URI(
                 configuration.getUriScheme(),
                 null,
                 bindAddress.getHost(),
                 bindAddress.getPort(),
-                "/",
+                isNullOrEmpty(contextPath) ? "/" : contextPath,
                 null,
                 null
         );

--- a/graylog2-server/src/main/java/org/graylog2/web/IndexHtmlGenerator.java
+++ b/graylog2-server/src/main/java/org/graylog2/web/IndexHtmlGenerator.java
@@ -69,7 +69,7 @@ public class IndexHtmlGenerator {
                 .put("title", "Graylog Web Interface")
                 .put("cssFiles", cssFiles)
                 .put("jsFiles", sortedJsFiles)
-                .put("baseUri", RestTools.buildExternalUri(headers, httpConfiguration.getHttpExternalUri()))
+                .put("appPrefix", RestTools.buildExternalUri(headers, httpConfiguration.getHttpExternalUri()))
                 .build();
         return templateEngine.transform(template, model);
     }

--- a/graylog2-server/src/main/resources/web-interface/index.html.template
+++ b/graylog2-server/src/main/resources/web-interface/index.html.template
@@ -5,16 +5,15 @@
     <meta name="robots" content="noindex, nofollow">
     <meta charset="UTF-8">
     <title>${title}</title>
-    <base href="${baseUri}">
-    <link rel="shortcut icon" href="assets/favicon.png">
+    <link rel="shortcut icon" href="${appPrefix}/assets/favicon.png">
     ${foreach cssFiles cssFile}
-    <link href="assets/${cssfile}" rel="stylesheet">
+    <link href="${appPrefix}/assets/${cssfile}" rel="stylesheet">
     ${end}
   </head>
   <body>
-    <script src="config.js"></script>
+    <script src="${appPrefix}/config.js"></script>
     ${foreach jsFiles jsFile}
-    <script src="assets/${jsFile}"></script>
+    <script src="${appPrefix}/assets/${jsFile}"></script>
     ${end}
   </body>
 </html>

--- a/graylog2-server/src/main/resources/web-interface/index.html.template
+++ b/graylog2-server/src/main/resources/web-interface/index.html.template
@@ -5,15 +5,15 @@
     <meta name="robots" content="noindex, nofollow">
     <meta charset="UTF-8">
     <title>${title}</title>
-    <link rel="shortcut icon" href="${appPrefix}/assets/favicon.png">
+    <link rel="shortcut icon" href="${appPrefix}assets/favicon.png">
     ${foreach cssFiles cssFile}
-    <link href="${appPrefix}/assets/${cssfile}" rel="stylesheet">
+    <link href="${appPrefix}assets/${cssfile}" rel="stylesheet">
     ${end}
   </head>
   <body>
-    <script src="${appPrefix}/config.js"></script>
+    <script src="${appPrefix}config.js"></script>
     ${foreach jsFiles jsFile}
-    <script src="${appPrefix}/assets/${jsFile}"></script>
+    <script src="${appPrefix}assets/${jsFile}"></script>
     ${end}
   </body>
 </html>

--- a/graylog2-server/src/test/java/org/graylog2/rest/RestToolsTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/rest/RestToolsTest.java
@@ -62,7 +62,7 @@ public class RestToolsTest {
     @Test
     public void buildExternalUriReturnsDefaultUriIfHeaderIsMissing() throws Exception {
         final MultivaluedMap<String, String> httpHeaders = new MultivaluedHashMap<>();
-        final URI externalUri = URI.create("http://graylog.example.com");
+        final URI externalUri = URI.create("http://graylog.example.com/");
         assertThat(RestTools.buildExternalUri(httpHeaders, externalUri)).isEqualTo(externalUri);
     }
 
@@ -70,7 +70,7 @@ public class RestToolsTest {
     public void buildExternalUriReturnsDefaultUriIfHeaderIsEmpty() throws Exception {
         final MultivaluedMap<String, String> httpHeaders = new MultivaluedHashMap<>();
         httpHeaders.putSingle(HttpConfiguration.OVERRIDE_HEADER, "");
-        final URI externalUri = URI.create("http://graylog.example.com");
+        final URI externalUri = URI.create("http://graylog.example.com/");
         assertThat(RestTools.buildExternalUri(httpHeaders, externalUri)).isEqualTo(externalUri);
     }
 
@@ -79,7 +79,7 @@ public class RestToolsTest {
         final MultivaluedMap<String, String> httpHeaders = new MultivaluedHashMap<>();
         httpHeaders.putSingle(HttpConfiguration.OVERRIDE_HEADER, "http://header.example.com");
         final URI externalUri = URI.create("http://graylog.example.com");
-        assertThat(RestTools.buildExternalUri(httpHeaders, externalUri)).isEqualTo(URI.create("http://header.example.com"));
+        assertThat(RestTools.buildExternalUri(httpHeaders, externalUri)).isEqualTo(URI.create("http://header.example.com/"));
     }
 
     @Test
@@ -87,7 +87,23 @@ public class RestToolsTest {
         final MultivaluedMap<String, String> httpHeaders = new MultivaluedHashMap<>();
         httpHeaders.put(HttpConfiguration.OVERRIDE_HEADER, ImmutableList.of("http://header1.example.com", "http://header2.example.com"));
         final URI endpointUri = URI.create("http://graylog.example.com");
-        assertThat(RestTools.buildExternalUri(httpHeaders, endpointUri)).isEqualTo(URI.create("http://header1.example.com"));
+        assertThat(RestTools.buildExternalUri(httpHeaders, endpointUri)).isEqualTo(URI.create("http://header1.example.com/"));
+    }
+
+    @Test
+    public void buildEndpointUriEnsuresTrailingSlash() {
+        final MultivaluedMap<String, String> httpHeaders = new MultivaluedHashMap<>();
+        final URI endpointUri = URI.create("http://graylog.example.com");
+        final URI endpointUri2 = URI.create("http://graylog.example.com/");
+
+        assertThat(RestTools.buildExternalUri(httpHeaders, endpointUri)).isEqualTo(URI.create("http://graylog.example.com/"));
+        assertThat(RestTools.buildExternalUri(httpHeaders, endpointUri2)).isEqualTo(URI.create("http://graylog.example.com/"));
+
+        httpHeaders.putSingle(HttpConfiguration.OVERRIDE_HEADER, "http://header.example.com");
+        assertThat(RestTools.buildExternalUri(httpHeaders, endpointUri)).isEqualTo(URI.create("http://header.example.com/"));
+
+        httpHeaders.putSingle(HttpConfiguration.OVERRIDE_HEADER, "http://header.example.com/");
+        assertThat(RestTools.buildExternalUri(httpHeaders, endpointUri)).isEqualTo(URI.create("http://header.example.com/"));
     }
 
     @Test

--- a/misc/graylog.conf
+++ b/misc/graylog.conf
@@ -139,7 +139,7 @@ plugin_dir = plugin
 # The maximum size of the HTTP request headers in bytes.
 #http_max_header_size = 8192
 
-# The size of the thread pool used exclusively for serving the HTTP interface and REST API.
+# The size of the thread pool used exclusively for serving the HTTP interface.
 #http_thread_pool_size = 16
 
 ################

--- a/misc/graylog.conf
+++ b/misc/graylog.conf
@@ -139,9 +139,10 @@ plugin_dir = plugin
 # The maximum size of the HTTP request headers in bytes.
 #http_max_header_size = 8192
 
-# The size of the thread pool used exclusively for serving the HTTP interface.
+# The size of the thread pool used exclusively for serving the HTTP interface and REST API.
 #http_thread_pool_size = 16
 
+################
 # HTTPS settings
 ################
 


### PR DESCRIPTION
Due to changes in the http config handling, the ability to run behind a proxy with a custom path prefix was lost.

This PR restores the application prefix handling.

fixes #4315