### PR TITLE
Revert node-id file validations

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/Configuration.java
+++ b/graylog2-server/src/main/java/org/graylog2/Configuration.java
@@ -353,20 +353,17 @@ public class Configuration extends BaseConfiguration {
             if (!file.isFile()) {
                 b.append("a file");
             }
-            final boolean readable = file.canRead();
-            final boolean writable = file.canWrite();
-            if (!readable) {
+            if (!file.canRead()) {
                 if (b.length() > 0) {
                     b.append(", ");
                 }
                 b.append("readable");
             }
-            final boolean empty = file.length() == 0;
-            if (!writable && readable && empty) {
+            if (!file.canWrite()) {
                 if (b.length() > 0) {
                     b.append(", ");
                 }
-                b.append("writable, but it is empty");
+                b.append("writable");
             }
             if (b.length() == 0) {
                 // all good

--- a/graylog2-server/src/main/java/org/graylog2/Configuration.java
+++ b/graylog2-server/src/main/java/org/graylog2/Configuration.java
@@ -18,7 +18,6 @@ package org.graylog2;
 
 import com.github.joschi.jadconfig.Parameter;
 import com.github.joschi.jadconfig.ValidationException;
-import com.github.joschi.jadconfig.Validator;
 import com.github.joschi.jadconfig.ValidatorMethod;
 import com.github.joschi.jadconfig.converters.TrimmedStringSetConverter;
 import com.github.joschi.jadconfig.util.Duration;
@@ -34,7 +33,6 @@ import org.graylog2.utilities.IpSubnet;
 import org.joda.time.DateTimeZone;
 
 import java.net.URI;
-import java.io.File;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Collections;
@@ -80,7 +78,7 @@ public class Configuration extends BaseConfiguration {
     @Parameter("rules_file")
     private String droolsRulesFile;
 
-    @Parameter(value = "node_id_file", validator = NodeIdFileValidator.class)
+    @Parameter(value = "node_id_file")
     private String nodeIdFile = "/etc/graylog/server/node-id";
 
     @Parameter(value = "root_username")
@@ -339,37 +337,6 @@ public class Configuration extends BaseConfiguration {
                 !restListenUri.getHost().equals(webListenUri.getHost()) &&
                 (WILDCARD_IP_ADDRESS.equals(restListenUri.getHost()) || WILDCARD_IP_ADDRESS.equals(webListenUri.getHost()))) {
             throw new ValidationException("Wildcard IP addresses cannot be used if the Graylog REST API and web interface listen on the same port.");
-        }
-    }
-
-    public static class NodeIdFileValidator implements Validator<String> {
-        @Override
-        public void validate(String name, String path) throws ValidationException {
-            if (path == null) {
-                return;
-            }
-            final File file = Paths.get(path).toFile();
-            final StringBuilder b = new StringBuilder();
-            if (!file.isFile()) {
-                b.append("a file");
-            }
-            if (!file.canRead()) {
-                if (b.length() > 0) {
-                    b.append(", ");
-                }
-                b.append("readable");
-            }
-            if (!file.canWrite()) {
-                if (b.length() > 0) {
-                    b.append(", ");
-                }
-                b.append("writable");
-            }
-            if (b.length() == 0) {
-                // all good
-                return;
-            }
-            throw new ValidationException("Node ID file at path " + path + " isn't " + b +". Please specify the correct path or change the permissions");
         }
     }
 }

--- a/graylog2-server/src/test/java/org/graylog2/ConfigurationTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/ConfigurationTest.java
@@ -26,19 +26,11 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 
-import java.io.IOException;
 import java.net.URI;
-import java.nio.charset.StandardCharsets;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.nio.file.attribute.PosixFilePermissions;
 import java.util.HashMap;
 import java.util.Map;
 
-import static java.nio.file.StandardOpenOption.TRUNCATE_EXISTING;
-import static java.nio.file.StandardOpenOption.WRITE;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.util.Files.newTemporaryFile;
 
 public class ConfigurationTest {
     @Rule
@@ -227,58 +219,5 @@ public class ConfigurationTest {
 
         Configuration configuration = new Configuration();
         new JadConfig(new InMemoryRepository(validProperties), configuration).process();
-    }
-
-    public void testNodeIdFilePermissions() throws IOException, ValidationException {
-        final Path nonEmptyNodeIdPath = newTemporaryFile().toPath();
-        final Path emptyNodeIdPath = newTemporaryFile().toPath();
-        try {
-            // create a node-id file and write some id
-            Files.write(nonEmptyNodeIdPath, "test-node-id".getBytes(StandardCharsets.UTF_8), WRITE, TRUNCATE_EXISTING);
-            assertThat(nonEmptyNodeIdPath.toFile().length()).isGreaterThan(0);
-
-            // make sure this file isn't accidentally present
-            final Path missingNodeIdPath = newTemporaryFile().toPath();
-            assertThat(missingNodeIdPath.toFile().delete()).isTrue();
-
-            // read/write permissions should make the validation pass
-            assertThat(validateWithPermissions(nonEmptyNodeIdPath, "rw-------")).isTrue();
-            assertThat(validateWithPermissions(emptyNodeIdPath, "rw-------")).isTrue();
-
-            // existing, but not writable is ok if the file is not empty
-            assertThat(validateWithPermissions(nonEmptyNodeIdPath, "r--------")).isTrue();
-
-            // existing, but not writable is not ok if the file is empty
-            assertThat(validateWithPermissions(emptyNodeIdPath, "r--------")).isFalse();
-
-            // existing, but not readable is not ok
-            assertThat(validateWithPermissions(nonEmptyNodeIdPath, "-w-------")).isFalse();
-
-            // missing, but not writable is not ok
-            assertThat(validateWithPermissions(missingNodeIdPath, "r--------")).isFalse();
-        } finally {
-            Files.delete(nonEmptyNodeIdPath);
-            Files.delete(emptyNodeIdPath);
-        }
-    }
-
-    /**
-     * Run the NodeIDFileValidator on a file with the given permissions.
-     * @param nodeFilePath the path to the node id file, can be missing
-     * @param permissions the posix permission to set the file to, if it exists, before running the validator
-     * @return true if the validation was successful, false otherwise
-     * @throws IOException if any file related problem occurred
-     */
-    private static boolean validateWithPermissions(Path nodeFilePath, String permissions) throws IOException {
-        try {
-            final Configuration.NodeIdFileValidator validator = new Configuration.NodeIdFileValidator();
-            if (nodeFilePath.toFile().exists()) {
-                Files.setPosixFilePermissions(nodeFilePath, PosixFilePermissions.fromString(permissions));
-            }
-            validator.validate("node-id", nodeFilePath.toString());
-        } catch (ValidationException ve) {
-            return false;
-        }
-        return true;
     }
 }


### PR DESCRIPTION
We revert this for 2.4 because we ran into issues and edge cases twice. So for the 2.4 release we don't want to risk any issues. We keep the changes in 3.0 and create another fix.