### PR TITLE
Correcting required permissions for (Stream) Output Management.

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/rest/resources/streams/outputs/StreamOutputResource.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/resources/streams/outputs/StreamOutputResource.java
@@ -23,7 +23,6 @@ import io.swagger.annotations.ApiParam;
 import io.swagger.annotations.ApiResponse;
 import io.swagger.annotations.ApiResponses;
 import org.apache.shiro.authz.annotation.RequiresAuthentication;
-import org.apache.shiro.authz.annotation.RequiresPermissions;
 import org.graylog2.audit.AuditEventTypes;
 import org.graylog2.audit.jersey.AuditEvent;
 import org.graylog2.database.NotFoundException;
@@ -81,7 +80,6 @@ public class StreamOutputResource extends RestResource {
     @GET
     @Timed
     @ApiOperation(value = "Get a list of all outputs for a stream")
-    @RequiresPermissions(RestPermissions.STREAM_OUTPUTS_CREATE)
     @Produces(MediaType.APPLICATION_JSON)
     @ApiResponses(value = {
             @ApiResponse(code = 404, message = "No such stream on this node.")
@@ -112,7 +110,6 @@ public class StreamOutputResource extends RestResource {
     @Path("/{outputId}")
     @Timed
     @ApiOperation(value = "Get specific output of a stream")
-    @RequiresPermissions(RestPermissions.STREAM_OUTPUTS_READ)
     @Produces(MediaType.APPLICATION_JSON)
     @ApiResponses(value = {
             @ApiResponse(code = 404, message = "No such stream/output on this node.")
@@ -134,7 +131,6 @@ public class StreamOutputResource extends RestResource {
     @ApiOperation(value = "Associate outputs with a stream")
     @Consumes(MediaType.APPLICATION_JSON)
     @Produces(MediaType.APPLICATION_JSON)
-    @RequiresPermissions(RestPermissions.STREAM_OUTPUTS_CREATE)
     @ApiResponses(value = {
             @ApiResponse(code = 400, message = "Invalid output specification in input.")
     })
@@ -143,6 +139,9 @@ public class StreamOutputResource extends RestResource {
                         @PathParam("streamid") String streamid,
                         @ApiParam(name = "JSON body", required = true)
                         @Valid @NotNull AddOutputRequest aor) throws ValidationException, NotFoundException {
+        checkPermission(RestPermissions.STREAMS_EDIT, streamid);
+        checkPermission(RestPermissions.STREAM_OUTPUTS_CREATE);
+
         final Stream stream = streamService.load(streamid);
         for (String outputId : aor.outputs()) {
             final Output output = outputService.load(outputId);
@@ -156,7 +155,6 @@ public class StreamOutputResource extends RestResource {
     @DELETE
     @Path("/{outputId}")
     @Timed
-    @RequiresPermissions(RestPermissions.STREAM_OUTPUTS_DELETE)
     @Produces(MediaType.APPLICATION_JSON)
     @ApiOperation(value = "Delete output of a stream")
     @ApiResponses(value = {
@@ -167,6 +165,9 @@ public class StreamOutputResource extends RestResource {
                        @PathParam("streamid") String streamid,
                        @ApiParam(name = "outputId", value = "The id of the output that should be deleted", required = true)
                        @PathParam("outputId") String outputId) throws NotFoundException {
+        checkPermission(RestPermissions.STREAMS_EDIT, streamid);
+        checkPermission(RestPermissions.STREAM_OUTPUTS_DELETE, outputId);
+
         final Stream stream = streamService.load(streamid);
         final Output output = outputService.load(outputId);
 

--- a/graylog2-server/src/main/java/org/graylog2/rest/resources/system/outputs/OutputResource.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/resources/system/outputs/OutputResource.java
@@ -24,7 +24,6 @@ import io.swagger.annotations.ApiParam;
 import io.swagger.annotations.ApiResponse;
 import io.swagger.annotations.ApiResponses;
 import org.apache.shiro.authz.annotation.RequiresAuthentication;
-import org.apache.shiro.authz.annotation.RequiresPermissions;
 import org.graylog2.audit.AuditEventTypes;
 import org.graylog2.audit.jersey.AuditEvent;
 import org.graylog2.database.NotFoundException;
@@ -79,7 +78,6 @@ public class OutputResource extends RestResource {
     @GET
     @Timed
     @ApiOperation(value = "Get a list of all outputs")
-    @RequiresPermissions(RestPermissions.STREAM_OUTPUTS_CREATE)
     @Produces(MediaType.APPLICATION_JSON)
     public OutputListResponse get() {
         checkPermission(RestPermissions.OUTPUTS_READ);
@@ -103,7 +101,6 @@ public class OutputResource extends RestResource {
     @Path("/{outputId}")
     @Timed
     @ApiOperation(value = "Get specific output")
-    @RequiresPermissions(RestPermissions.OUTPUTS_CREATE)
     @Produces(MediaType.APPLICATION_JSON)
     @ApiResponses(value = {
             @ApiResponse(code = 404, message = "No such output on this node.")
@@ -161,7 +158,6 @@ public class OutputResource extends RestResource {
     @Path("/{outputId}")
     @Timed
     @ApiOperation(value = "Delete output")
-    @RequiresPermissions(RestPermissions.OUTPUTS_TERMINATE)
     @Produces(MediaType.APPLICATION_JSON)
     @ApiResponses(value = {
             @ApiResponse(code = 404, message = "No such stream/output on this node.")
@@ -178,9 +174,9 @@ public class OutputResource extends RestResource {
     @Path("/available")
     @Timed
     @ApiOperation(value = "Get all available output modules")
-    @RequiresPermissions(RestPermissions.STREAMS_READ)
     @Produces(MediaType.APPLICATION_JSON)
     public Map<String, Map<String, AvailableOutputSummary>> available() {
+        checkPermission(RestPermissions.OUTPUTS_READ);
         return ImmutableMap.of("types", messageOutputFactory.getAvailableOutputs());
     }
 
@@ -188,7 +184,6 @@ public class OutputResource extends RestResource {
     @Path("/{outputId}")
     @Timed
     @ApiOperation(value = "Update output")
-    @RequiresPermissions(RestPermissions.OUTPUTS_EDIT)
     @Produces(MediaType.APPLICATION_JSON)
     @ApiResponses(value = {
             @ApiResponse(code = 404, message = "No such output on this node.")


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

**StreamOutputResource**:

  * consistenly using `checkPermission()` instead of mixed usage of
    `checkPermission()` and @RequiresPermission
  * removing check for `stream_outputs:create` permission in `get()`,
    this permission should not be required for retrieving stream output
    list
  * adding checks for stream editing permissions in `add` & `remove`

**OutputResource**:

  * consistenly using `checkPermission()` instead of mixed usage of
    `checkPermission()` and @RequiresPermission
  * removing check for `stream_outputs:create` permission in `get()`,
    this permission should not be required for retrieving system output
    list
  * changing permission of `available` from `streams:read` (sic!) to
    `outputs:read`
  * removing `@RequirePermission` in `delete` & `update`, as they were
    redundant due to usages of `checkPermission()`

  Fixes #4142.

## Motivation and Context

Before this change, the required permissions for managing (stream) outputs as a non-admin user were inconsistent and misleading. Users were [stumbling](https://community.graylog.org/t/permission-role-for-outputs-not-working/2399) across this when trying to work with the system as non-priviledged users.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.