### PR TITLE
Adding privileges to user for created stream if not admin.

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/rest/resources/streams/StreamResource.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/resources/streams/StreamResource.java
@@ -481,6 +481,8 @@ public class StreamResource extends RestResource {
             streamService.addOutput(stream, output);
         }
 
+        ensureUserHasPermissionsForStream(getCurrentUser(), id);
+
         clusterEventBus.post(StreamsChangedEvent.create(stream.getId()));
 
         final Map<String, String> result = ImmutableMap.of("stream_id", id);

--- a/graylog2-server/src/main/java/org/graylog2/rest/resources/streams/StreamResource.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/resources/streams/StreamResource.java
@@ -18,6 +18,7 @@ package org.graylog2.rest.resources.streams;
 
 import com.codahale.metrics.annotation.Timed;
 import com.google.common.base.Strings;
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
@@ -45,6 +46,7 @@ import org.graylog2.plugin.Tools;
 import org.graylog2.plugin.alarms.AlertCondition;
 import org.graylog2.plugin.configuration.ConfigurationException;
 import org.graylog2.plugin.database.ValidationException;
+import org.graylog2.plugin.database.users.User;
 import org.graylog2.plugin.streams.Output;
 import org.graylog2.plugin.streams.Stream;
 import org.graylog2.plugin.streams.StreamRule;
@@ -160,6 +162,8 @@ public class StreamResource extends RestResource {
             streamRuleService.save(streamRule);
         }
 
+        ensureUserHasPermissionsForStream(getCurrentUser(), id);
+
         clusterEventBus.post(StreamsChangedEvent.create(stream.getId()));
 
         final Map<String, String> result = ImmutableMap.of("stream_id", id);
@@ -168,6 +172,31 @@ public class StreamResource extends RestResource {
             .build(id);
 
         return Response.created(streamUri).entity(result).build();
+    }
+
+    private boolean ensureUserHasPermissionsForStream(User user, String id) throws ValidationException {
+        boolean permissionsChanged = false;
+        final ImmutableList.Builder<String> permissionsBuilder = ImmutableList.<String>builder()
+                .addAll(user.getPermissions());
+        if (!isPermitted(RestPermissions.STREAMS_READ, id)) {
+            permissionsChanged = true;
+            permissionsBuilder.add(RestPermissions.STREAMS_READ + ":" + id);
+        }
+        if (!isPermitted(RestPermissions.STREAMS_EDIT, id)) {
+            permissionsChanged = true;
+            permissionsBuilder.add(RestPermissions.STREAMS_EDIT + ":" + id);
+        }
+        if (!isPermitted(RestPermissions.STREAMS_CHANGESTATE, id)) {
+            permissionsChanged = true;
+            permissionsBuilder.add(RestPermissions.STREAMS_CHANGESTATE + ":" + id);
+        }
+
+        if (permissionsChanged) {
+            user.setPermissions(permissionsBuilder.build());
+            userService.save(user);
+        }
+
+        return permissionsChanged;
     }
 
     @GET

--- a/graylog2-server/src/main/java/org/graylog2/users/events/UserChangedEvent.java
+++ b/graylog2-server/src/main/java/org/graylog2/users/events/UserChangedEvent.java
@@ -1,3 +1,19 @@
+/**
+ * This file is part of Graylog.
+ *
+ * Graylog is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package org.graylog2.users.events;
 
 import com.fasterxml.jackson.annotation.JsonAutoDetect;

--- a/graylog2-server/src/main/java/org/graylog2/users/events/UserChangedEvent.java
+++ b/graylog2-server/src/main/java/org/graylog2/users/events/UserChangedEvent.java
@@ -1,0 +1,22 @@
+package org.graylog2.users.events;
+
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.auto.value.AutoValue;
+import org.graylog.autovalue.WithBeanGetter;
+
+@JsonAutoDetect
+@AutoValue
+@WithBeanGetter
+public abstract class UserChangedEvent {
+    private static final String FIELD_USER_ID = "user_id";
+
+    @JsonProperty(FIELD_USER_ID)
+    public abstract String userId();
+
+    @JsonCreator
+    public static UserChangedEvent create(@JsonProperty(FIELD_USER_ID) String userId) {
+        return new AutoValue_UserChangedEvent(userId);
+    }
+}

--- a/graylog2-server/src/test/java/org/graylog2/users/UserServiceImplTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/users/UserServiceImplTest.java
@@ -19,6 +19,7 @@ package org.graylog2.users;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Sets;
+import com.google.common.eventbus.EventBus;
 import com.lordofthejars.nosqlunit.annotation.UsingDataSet;
 import com.lordofthejars.nosqlunit.core.LoadStrategyEnum;
 import com.lordofthejars.nosqlunit.mongodb.InMemoryMongoDb;
@@ -72,6 +73,8 @@ public class UserServiceImplTest {
     private RoleService roleService;
     @Mock
     private InMemoryRolePermissionResolver permissionsResolver;
+    @Mock
+    private EventBus serverEventBus;
 
     @Before
     public void setUp() throws Exception {
@@ -80,7 +83,7 @@ public class UserServiceImplTest {
         this.userFactory = new UserImplFactory(configuration);
         this.permissions = new Permissions(ImmutableSet.of(new RestPermissions()));
         this.userService = new UserServiceImpl(mongoConnection, configuration, roleService, userFactory,
-                                               permissionsResolver);
+                                               permissionsResolver, serverEventBus);
 
         when(roleService.getAdminRoleObjectId()).thenReturn("deadbeef");
     }
@@ -207,7 +210,7 @@ public class UserServiceImplTest {
     public void testGetPermissionsForUser() throws Exception {
         final InMemoryRolePermissionResolver permissionResolver = mock(InMemoryRolePermissionResolver.class);
         final UserService userService = new UserServiceImpl(mongoConnection, configuration, roleService, userFactory,
-                                                            permissionResolver);
+                                                            permissionResolver, serverEventBus);
 
         final UserImplFactory factory = new UserImplFactory(new Configuration());
         final UserImpl user = factory.create(new HashMap<>());

--- a/graylog2-web-interface/src/routing/ApiRoutes.js
+++ b/graylog2-web-interface/src/routing/ApiRoutes.js
@@ -168,6 +168,7 @@ const ApiRoutes = {
     sendDummyAlert: (streamId) => { return { url: `/streams/${streamId}/alerts/sendDummyAlert` }; },
   },
   StreamsApiController: {
+    index: () => { return { url: '/streams' }; },
     get: (streamId) => { return { url: `/streams/${streamId}` }; },
     create: () => { return { url: '/streams' }; },
     update: (streamId) => { return { url: `/streams/${streamId}` }; },


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context

Before this change, a user with sufficient privileges to create a
stream could create one which is immediately inaccessible to the user
because the user is missing read/edit privileges to it. This change
checks for the required privileges and adds them to this specific
stream if necessary.

For non-admin users it is required to refresh user permissions both in
the frontend (using `CurrentUserStore.reload`) and the backend (by
invalidating the authorization cache, due to a race condition between
retrieving the list for the frontend and refreshing the authorization
cache) to be able to list the newly created stream.

Fixes #4450.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.