### PR TITLE
Checking user privileges before performing Input State operations.

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/shared/security/RestPermissions.java
+++ b/graylog2-server/src/main/java/org/graylog2/shared/security/RestPermissions.java
@@ -67,6 +67,7 @@ public class RestPermissions implements PluginPermissions {
     public static final String INDICES_DELETE = "indices:delete";
     public static final String INDICES_FAILURES = "indices:failures";
     public static final String INDICES_READ = "indices:read";
+    public static final String INPUTS_CHANGESTATE = "inputs:changestate";
     public static final String INPUTS_CREATE = "inputs:create";
     public static final String INPUTS_EDIT = "inputs:edit";
     public static final String INPUTS_READ = "inputs:read";
@@ -172,6 +173,7 @@ public class RestPermissions implements PluginPermissions {
         .add(create(INDICES_DELETE, ""))
         .add(create(INDICES_FAILURES, ""))
         .add(create(INDICES_READ, ""))
+        .add(create(INPUTS_CHANGESTATE, ""))
         .add(create(INPUTS_CREATE, ""))
         .add(create(INPUTS_EDIT, ""))
         .add(create(INPUTS_READ, ""))


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
Before this change, any user was able to start/stop inputs without the
possession of the required privileges. The `InputStatesResource` class
did not perform any permission checks for operations.

After this change, a user who starts/stops an input requires the newly
introduced `inputs:changestate` permission (consistent with permission
handling of indices/processing/streams) in order to perform these
state changes.

Fixes #4439.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

  
  