### PR TITLE
replace name, class map binder with NamedType set binder

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/plugin/inject/Graylog2Module.java
+++ b/graylog2-server/src/main/java/org/graylog2/plugin/inject/Graylog2Module.java
@@ -16,6 +16,7 @@
  */
 package org.graylog2.plugin.inject;
 
+import com.fasterxml.jackson.databind.jsontype.NamedType;
 import com.google.common.util.concurrent.Service;
 import com.google.inject.AbstractModule;
 import com.google.inject.Key;
@@ -25,7 +26,6 @@ import com.google.inject.multibindings.MapBinder;
 import com.google.inject.multibindings.Multibinder;
 import com.google.inject.multibindings.OptionalBinder;
 import com.google.inject.name.Names;
-
 import org.apache.shiro.realm.AuthenticatingRealm;
 import org.graylog2.audit.AuditEventSender;
 import org.graylog2.audit.AuditEventType;
@@ -52,13 +52,12 @@ import org.graylog2.plugin.security.PluginPermissions;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.lang.annotation.Annotation;
-
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import javax.ws.rs.container.ContainerResponseFilter;
 import javax.ws.rs.container.DynamicFeature;
 import javax.ws.rs.ext.ExceptionMapper;
+import java.lang.annotation.Annotation;
 
 public abstract class Graylog2Module extends AbstractModule {
     private static final Logger LOG = LoggerFactory.getLogger(Graylog2Module.class);
@@ -391,7 +390,7 @@ public abstract class Graylog2Module extends AbstractModule {
                                       Class<? extends LookupCacheConfiguration> configClass) {
         install(new FactoryModuleBuilder().implement(LookupCache.class, cacheClass).build(factoryClass));
         lookupCacheBinder().addBinding(name).to(factoryClass);
-        jacksonSubTypesBinder().addBinding(name).toInstance(configClass);
+        registerJacksonSubtype(configClass, name);
     }
 
 
@@ -405,11 +404,31 @@ public abstract class Graylog2Module extends AbstractModule {
                                             Class<? extends LookupDataAdapterConfiguration> configClass) {
         install(new FactoryModuleBuilder().implement(LookupDataAdapter.class, adapterClass).build(factoryClass));
         lookupDataAdapterBinder().addBinding(name).to(factoryClass);
-        jacksonSubTypesBinder().addBinding(name).toInstance(configClass);
+        registerJacksonSubtype(configClass, name);
     }
 
-    protected MapBinder<String, Object> jacksonSubTypesBinder() {
-        return MapBinder.newMapBinder(binder(), TypeLiteral.get(String.class), TypeLiteral.get(Object.class), JacksonSubTypes.class);
+    /**
+     * Prefer using {@link #registerJacksonSubtype(Class)} or {@link #registerJacksonSubtype(Class, String)}.
+     */
+    protected Multibinder<NamedType> jacksonSubTypesBinder() {
+        return Multibinder.newSetBinder(binder(), NamedType.class, JacksonSubTypes.class);
+    }
+
+    /**
+     * Use this if the class itself is annotated by {@link com.fasterxml.jackson.annotation.JsonTypeName} instead of explicitly given.
+     * @param klass
+     */
+    protected void registerJacksonSubtype(Class<?> klass) {
+        registerJacksonSubtype(klass, null);
+    }
+
+    /**
+     * Use this if the class does not have a {@link com.fasterxml.jackson.annotation.JsonTypeName} annotation.
+     * @param klass
+     * @param name
+     */
+    protected void registerJacksonSubtype(Class<?> klass, String name) {
+        jacksonSubTypesBinder().addBinding().toInstance(new NamedType(klass, name));
     }
 
     protected Multibinder<Migration> migrationsBinder() {

--- a/graylog2-server/src/main/java/org/graylog2/shared/bindings/ObjectMapperModule.java
+++ b/graylog2-server/src/main/java/org/graylog2/shared/bindings/ObjectMapperModule.java
@@ -18,13 +18,13 @@ package org.graylog2.shared.bindings;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.annotations.VisibleForTesting;
-import com.google.inject.AbstractModule;
+import org.graylog2.plugin.inject.Graylog2Module;
 import org.graylog2.shared.bindings.providers.ObjectMapperProvider;
 import org.graylog2.shared.plugins.GraylogClassLoader;
 
 import static java.util.Objects.requireNonNull;
 
-public class ObjectMapperModule extends AbstractModule {
+public class ObjectMapperModule extends Graylog2Module {
     private final ClassLoader classLoader;
 
     @VisibleForTesting
@@ -38,6 +38,7 @@ public class ObjectMapperModule extends AbstractModule {
 
     @Override
     protected void configure() {
+        jacksonSubTypesBinder();
         bind(ClassLoader.class).annotatedWith(GraylogClassLoader.class).toInstance(classLoader);
         bind(ObjectMapper.class).toProvider(ObjectMapperProvider.class).asEagerSingleton();
     }

--- a/graylog2-server/src/main/java/org/graylog2/shared/bindings/ObjectMapperModule.java
+++ b/graylog2-server/src/main/java/org/graylog2/shared/bindings/ObjectMapperModule.java
@@ -38,6 +38,8 @@ public class ObjectMapperModule extends Graylog2Module {
 
     @Override
     protected void configure() {
+        // the ObjectMapperProvider requires at least an empty JacksonSubtypes set.
+        // if the multibinder wasn't created that reference will be null, so we force its creation here
         jacksonSubTypesBinder();
         bind(ClassLoader.class).annotatedWith(GraylogClassLoader.class).toInstance(classLoader);
         bind(ObjectMapper.class).toProvider(ObjectMapperProvider.class).asEagerSingleton();

--- a/graylog2-server/src/main/java/org/graylog2/shared/bindings/providers/ObjectMapperProvider.java
+++ b/graylog2-server/src/main/java/org/graylog2/shared/bindings/providers/ObjectMapperProvider.java
@@ -28,7 +28,6 @@ import com.fasterxml.jackson.datatype.guava.GuavaModule;
 import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
 import com.fasterxml.jackson.datatype.joda.JodaModule;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
-
 import org.graylog2.database.ObjectIdSerializer;
 import org.graylog2.jackson.JodaTimePeriodKeyDeserializer;
 import org.graylog2.plugin.inject.JacksonSubTypes;
@@ -37,25 +36,24 @@ import org.graylog2.shared.plugins.GraylogClassLoader;
 import org.graylog2.shared.rest.RangeJsonSerializer;
 import org.joda.time.Period;
 
-import java.util.Collections;
-import java.util.Map;
-import java.util.concurrent.TimeUnit;
-
 import javax.inject.Inject;
 import javax.inject.Provider;
 import javax.inject.Singleton;
+import java.util.Collections;
+import java.util.Set;
+import java.util.concurrent.TimeUnit;
 
 @Singleton
 public class ObjectMapperProvider implements Provider<ObjectMapper> {
     protected final ObjectMapper objectMapper;
 
     public ObjectMapperProvider() {
-        this(ObjectMapperProvider.class.getClassLoader(), Collections.emptyMap());
+        this(ObjectMapperProvider.class.getClassLoader(), Collections.emptySet());
     }
 
     @Inject
     public ObjectMapperProvider(@GraylogClassLoader final ClassLoader classLoader,
-                                @JacksonSubTypes Map<String, Object> subtypes) {
+                                @JacksonSubTypes Set<NamedType> subtypes) {
         final ObjectMapper mapper = new ObjectMapper();
         final TypeFactory typeFactory = mapper.getTypeFactory().withClassLoader(classLoader);
 
@@ -75,7 +73,7 @@ public class ObjectMapperProvider implements Provider<ObjectMapper> {
                         .addSerializer(new SizeSerializer())
                         .addSerializer(new ObjectIdSerializer()));
 
-        subtypes.forEach((name, klass) -> objectMapper.registerSubtypes(new NamedType((Class)klass, name)));
+        objectMapper.registerSubtypes(subtypes.toArray(new NamedType[]{}));
     }
 
     @Override

--- a/graylog2-server/src/main/java/org/graylog2/shared/bindings/providers/ObjectMapperProvider.java
+++ b/graylog2-server/src/main/java/org/graylog2/shared/bindings/providers/ObjectMapperProvider.java
@@ -73,7 +73,9 @@ public class ObjectMapperProvider implements Provider<ObjectMapper> {
                         .addSerializer(new SizeSerializer())
                         .addSerializer(new ObjectIdSerializer()));
 
-        objectMapper.registerSubtypes(subtypes.toArray(new NamedType[]{}));
+        if (subtypes != null) {
+            objectMapper.registerSubtypes(subtypes.toArray(new NamedType[]{}));
+        }
     }
 
     @Override


### PR DESCRIPTION
this allows registering multiple jackson subtypes with overlapping names, which jackson already handles correctly

fixes #4457
