### PR TITLE
Change Permission Buttons from Toggle to Set and Clear

### DIFF
--- a/graylog2-web-interface/src/components/users/PermissionSelector.jsx
+++ b/graylog2-web-interface/src/components/users/PermissionSelector.jsx
@@ -19,19 +19,27 @@ const PermissionSelector = React.createClass({
       const isRead = this.props.permissions.contains(`streams:read:${stream.id}`);
       const isEdit = this.props.permissions.contains(`streams:edit:${stream.id}`);
       return (<ButtonGroup bsSize="small">
-        <Button bsStyle={isRead ? 'info' : 'default'} onClick={() => this._toggleStreamReadPermissions(stream)}
+        <Button bsStyle={isRead ? 'info' : 'default'}
+                onClick={() => this._toggleStreamReadPermissions(stream)}
                 active={isRead}>Allow reading</Button>
-        <Button bsStyle={isEdit ? 'info' : 'default'} onClick={() => this._toggleStreamEditPermissions(stream)}
+        <Button bsStyle={isEdit ? 'info' : 'default'}
+                onClick={() => this._toggleStreamEditPermissions(stream)}
                 active={isEdit}>Allow editing</Button>
       </ButtonGroup>);
     };
 
     const multiStreamButtons = (streamIds) => {
+      const selectedStreams = this.props.streams.filter(stream => streamIds.contains(stream.id));
+      const allRead = selectedStreams.every(stream => this.props.permissions.contains(`streams:read:${stream.id}`));
+      const allEdit = selectedStreams.every(stream => this.props.permissions.contains(`streams:edit:${stream.id}`));
+      const readActionLabel = allRead ? 'Clear' : 'Set';
+      const editActionLabel = allEdit ? 'Clear' : 'Set';
+
       return (
         <div className="pull-right" style={{ marginTop: 10, marginBottom: 10 }}>
-          <Button bsSize="xsmall" bsStyle="info" onClick={() => this._toggleAllStreamsRead(streamIds)}>Toggle read permissions</Button>
+          <Button bsSize="xsmall" bsStyle="info" onClick={() => this._toggleAllStreamsRead(streamIds, allRead)}>{readActionLabel} read permissions</Button>
           &nbsp;
-          <Button bsSize="xsmall" bsStyle="info" onClick={() => this._toggleAllStreamsEdit(streamIds)}>Toggle edit permissions</Button>
+          <Button bsSize="xsmall" bsStyle="info" onClick={() => this._toggleAllStreamsEdit(streamIds, allEdit)}>{editActionLabel} edit permissions</Button>
         </div>
       );
     };
@@ -40,19 +48,26 @@ const PermissionSelector = React.createClass({
       const isRead = this.props.permissions.contains(`dashboards:read:${dashboard.id}`);
       const isEdit = this.props.permissions.contains(`dashboards:edit:${dashboard.id}`);
       return (<ButtonGroup bsSize="small">
-        <Button bsStyle={isRead ? 'info' : 'default'} onClick={() => this._toggleDashboardReadPermissions(dashboard)}
+        <Button bsStyle={isRead ? 'info' : 'default'}
+                onClick={() => this._toggleDashboardReadPermissions(dashboard)}
                 active={isRead}>Allow reading</Button>
-        <Button bsStyle={isEdit ? 'info' : 'default'} onClick={() => this._toggleDashboardEditPermissions(dashboard)}
+        <Button bsStyle={isEdit ? 'info' : 'default'}
+                onClick={() => this._toggleDashboardEditPermissions(dashboard)}
                 active={isEdit}>Allow editing</Button>
       </ButtonGroup>);
     };
-
     const multiDashboardButtons = (dashboardIds) => {
+      const selectedDashboards = this.props.dashboards.filter(dashboard => dashboardIds.contains(dashboard.id));
+      const allRead = selectedDashboards.every(dashboard => this.props.permissions.contains(`dashboards:read:${dashboard.id}`));
+      const allEdit = selectedDashboards.every(dashboard => this.props.permissions.contains(`dashboards:edit:${dashboard.id}`));
+      const readActionLabel = allRead ? 'Clear' : 'Set';
+      const editActionLabel = allEdit ? 'Clear' : 'Set';
+
       return (
         <div className="pull-right" style={{ marginTop: 10, marginBottom: 10 }}>
-          <Button bsSize="xsmall" bsStyle="info" onClick={() => this._toggleAllDashboardsRead(dashboardIds)}>Toggle read permissions</Button>
+          <Button bsSize="xsmall" bsStyle="info" onClick={() => this._toggleAllDashboardsRead(dashboardIds, allRead)}>{readActionLabel} read permissions</Button>
           &nbsp;
-          <Button bsSize="xsmall" bsStyle="info" onClick={() => this._toggleAllDashboardsEdit(dashboardIds)}>Toggle edit permissions</Button>
+          <Button bsSize="xsmall" bsStyle="info" onClick={() => this._toggleAllDashboardsEdit(dashboardIds, allEdit)}>{editActionLabel} edit permissions</Button>
         </div>
       );
     };
@@ -110,23 +125,23 @@ const PermissionSelector = React.createClass({
    * onClick actions for bulk edits
    */
 
-  _toggleAllStreamsRead(streamIds) {
-    this._toggleReadPermissions('streams', streamIds);
+  _toggleAllStreamsRead(streamIds, clearPermissions) {
+    this._toggleReadPermissions('streams', streamIds, clearPermissions);
   },
 
-  _toggleAllStreamsEdit(streamIds) {
-    this._toggleEditPermissions('streams', streamIds);
+  _toggleAllStreamsEdit(streamIds, clearPermissions) {
+    this._toggleEditPermissions('streams', streamIds, clearPermissions);
   },
 
-  _toggleAllDashboardsRead(dashboardIds) {
-    this._toggleReadPermissions('dashboards', dashboardIds);
+  _toggleAllDashboardsRead(dashboardIds, clearPermissions) {
+    this._toggleReadPermissions('dashboards', dashboardIds, clearPermissions);
   },
 
-  _toggleAllDashboardsEdit(dashboardIds) {
-    this._toggleEditPermissions('dashboards', dashboardIds);
+  _toggleAllDashboardsEdit(dashboardIds, clearPermissions) {
+    this._toggleEditPermissions('dashboards', dashboardIds, clearPermissions);
   },
 
-  _toggleReadPermissions(target, idList) {
+  _toggleReadPermissions(target, idList, clearPermissions = true) {
     let added = Immutable.Set.of();
     let deleted = Immutable.Set.of();
 
@@ -134,7 +149,7 @@ const PermissionSelector = React.createClass({
       const readTarget = `${target}:read:${id}`;
       const editTarget = `${target}:edit:${id}`;
 
-      if (this.props.permissions.contains(readTarget)) {
+      if (this.props.permissions.contains(readTarget) && clearPermissions) {
         deleted = deleted.add(readTarget).add(editTarget);
       } else {
         added = added.add(readTarget);
@@ -142,7 +157,7 @@ const PermissionSelector = React.createClass({
     }, this);
     this.props.onChange(added, deleted);
   },
-  _toggleEditPermissions(target, idList) {
+  _toggleEditPermissions(target, idList, clearPermissions = true) {
     let added = Immutable.Set.of();
     let deleted = Immutable.Set.of();
 
@@ -150,7 +165,7 @@ const PermissionSelector = React.createClass({
       const readTarget = `${target}:read:${id}`;
       const editTarget = `${target}:edit:${id}`;
 
-      if (this.props.permissions.contains(editTarget)) {
+      if (this.props.permissions.contains(editTarget) && clearPermissions) {
         deleted = deleted.add(editTarget);
       } else {
         added = added.add(readTarget).add(editTarget);

--- a/graylog2-web-interface/src/components/users/PermissionSelector.test.jsx
+++ b/graylog2-web-interface/src/components/users/PermissionSelector.test.jsx
@@ -1,0 +1,163 @@
+import React from 'react';
+import renderer from 'react-test-renderer';
+import Immutable from 'immutable';
+import { mount } from 'enzyme';
+
+import PermissionSelector from 'components/users/PermissionSelector';
+
+/* https://github.com/facebook/react/issues/7371
+ *
+ * findDomNode with refs is not supported by the react-test-renderer.
+ * So we need to mock the findDOMNode function for TableList respectievly
+ * for its child component TypeAheadDataFilter.
+ */
+jest.mock('react-dom', () => ({
+  findDOMNode: () => ({}),
+}));
+
+describe('<PermissionSelector />', () => {
+  const streams = Immutable.List([
+    { id: '01', description: 'stream1' },
+    { id: '02', description: 'stream2' },
+  ]);
+  const dashboards = Immutable.List([
+    { id: '01', description: 'dashboard1' },
+    { id: '02', description: 'dashboard2' },
+  ]);
+
+  it('should render with empty permissions', () => {
+    const wrapper = renderer.create(<PermissionSelector
+      streams={streams}
+      permissions={Immutable.Set([])}
+      dashboards={dashboards}
+      onChange={() => {}}
+    />);
+    expect(wrapper.toJSON()).toMatchSnapshot();
+  });
+
+  it('should render with set permissions', () => {
+    const permissions = Immutable.Set([
+      'streams:read:01',
+      'streams:edit:02',
+      'dashboards:read:02',
+    ]);
+    const wrapper = renderer.create(<PermissionSelector
+      streams={streams}
+      permissions={permissions}
+      dashboards={dashboards}
+      onChange={() => {}}
+    />);
+    expect(wrapper.toJSON()).toMatchSnapshot();
+  });
+
+  it('should allow reading when clicked on "Allow reading"', () => {
+    const onButtonClick = jest.fn((added) => {
+      expect(added).toEqual(Immutable.Set(['streams:read:01']));
+    });
+    const wrapper = mount(<PermissionSelector
+      streams={streams}
+      permissions={Immutable.Set([])}
+      dashboards={dashboards}
+      onChange={onButtonClick}
+    />);
+    wrapper.find('button[children="Allow reading"]').at(0).simulate('click');
+    expect(onButtonClick.mock.calls.length).toBe(1);
+  });
+
+  it('should allow reading and editing when clicked on "Allow editing"', () => {
+    const onButtonClick = jest.fn((added) => {
+      expect(added).toEqual(Immutable.Set(['streams:read:01', 'streams:edit:01']));
+    });
+    const wrapper = mount(<PermissionSelector
+      streams={streams}
+      permissions={Immutable.Set([])}
+      dashboards={dashboards}
+      onChange={onButtonClick}
+    />);
+    wrapper.find('button[children="Allow editing"]').at(0).simulate('click');
+    expect(onButtonClick.mock.calls.length).toBe(1);
+  });
+
+  it('should not allow reading when "Allow reading" was unselected', () => {
+    const onButtonClick = jest.fn((_, deleted) => {
+      expect(deleted).toEqual(Immutable.Set(['streams:read:01', 'streams:edit:01']));
+    });
+    const wrapper = mount(<PermissionSelector
+      streams={streams}
+      permissions={Immutable.Set(['streams:read:01'])}
+      dashboards={dashboards}
+      onChange={onButtonClick}
+    />);
+    wrapper.find('button[children="Allow reading"]').at(0).simulate('click');
+    expect(onButtonClick.mock.calls.length).toBe(1);
+  });
+
+  it('should bulk set "Allow reading" for selected streams', () => {
+    const onButtonClick = jest.fn((added, deleted) => {
+      expect(added).toEqual(Immutable.Set(['streams:read:01', 'streams:read:02']));
+      expect(deleted).toEqual(Immutable.Set([]));
+    });
+    const wrapper = mount(<PermissionSelector
+      streams={streams}
+      permissions={Immutable.Set(['streams:read:01'])}
+      dashboards={dashboards}
+      onChange={onButtonClick}
+    />);
+    wrapper.find('input[label="Select all"]').at(0).simulate('change', { target: { checked: true } });
+    expect(wrapper.find('button').at(2).text()).toEqual('Set read permissions');
+    wrapper.find('button').at(2).simulate('click');
+    expect(onButtonClick.mock.calls.length).toBe(1);
+  });
+
+  it('should bulk set "Allow editing" and "Allow reading" for selected streams', () => {
+    const onButtonClick = jest.fn((added, deleted) => {
+      expect(added).toEqual(Immutable.Set(['streams:read:01', 'streams:edit:01', 'streams:read:02', 'streams:edit:02']));
+      expect(deleted).toEqual(Immutable.Set([]));
+    });
+    const wrapper = mount(<PermissionSelector
+      streams={streams}
+      permissions={Immutable.Set(['streams:read:01', 'stream:edit:01'])}
+      dashboards={dashboards}
+      onChange={onButtonClick}
+    />);
+    wrapper.find('input[label="Select all"]').at(0).simulate('change', { target: { checked: true } });
+    expect(wrapper.find('button').at(3).text()).toEqual('Set edit permissions');
+    wrapper.find('button').at(3).simulate('click');
+    expect(onButtonClick.mock.calls.length).toBe(1);
+  });
+
+  it('should bulk clear "Allow reading" for selected streams', () => {
+    const onButtonClick = jest.fn((added, deleted) => {
+      expect(added).toEqual(Immutable.Set([]));
+      expect(deleted).toEqual(Immutable.Set(['streams:read:01', 'streams:edit:01', 'streams:read:02', 'streams:edit:02']));
+    });
+    const wrapper = mount(<PermissionSelector
+      streams={streams}
+      permissions={Immutable.Set(['streams:read:01', 'streams:read:02'])}
+      dashboards={dashboards}
+      onChange={onButtonClick}
+    />);
+    wrapper.find('input[label="Select all"]').at(0).simulate('change', { target: { checked: true } });
+    expect(wrapper.find('button').at(2).text()).toEqual('Clear read permissions');
+    wrapper.find('button').at(2).simulate('click');
+    expect(onButtonClick.mock.calls.length).toBe(1);
+  });
+
+  it('should bulk set "Allow editing" for selected streams', () => {
+    const onButtonClick = jest.fn((added, deleted) => {
+      expect(added).toEqual(Immutable.Set(['streams:read:01', 'streams:edit:01',
+        'streams:read:02', 'streams:edit:02']));
+      expect(deleted).toEqual(Immutable.Set([]));
+    });
+    const wrapper = mount(<PermissionSelector
+      streams={streams}
+      permissions={Immutable.Set(['streams:read:01', 'streams:edit:01'])}
+      dashboards={dashboards}
+      onChange={onButtonClick}
+    />);
+    wrapper.find('input[label="Select all"]').at(0).simulate('change', { target: { checked: true } });
+    expect(wrapper.find('button').at(3).text()).toEqual('Set edit permissions');
+    wrapper.find('button').at(3).simulate('click');
+    expect(onButtonClick.mock.calls.length).toBe(1);
+  });
+});

--- a/graylog2-web-interface/src/components/users/__snapshots__/PermissionSelector.test.jsx.snap
+++ b/graylog2-web-interface/src/components/users/__snapshots__/PermissionSelector.test.jsx.snap
@@ -1,0 +1,1277 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`<PermissionSelector /> should render with empty permissions 1`] = `
+<div>
+  <div
+    className={undefined}
+    id="permissionSelectorTabs"
+    style={undefined}
+  >
+    <ul
+      className="nav nav-tabs"
+      role="tablist"
+    >
+      <li
+        className="active"
+        role="presentation"
+        style={undefined}
+      >
+        <a
+          aria-controls="permissionSelectorTabs-pane-1"
+          aria-selected={true}
+          href="#"
+          id="permissionSelectorTabs-tab-1"
+          onClick={[Function]}
+          onKeyDown={[Function]}
+          role="tab"
+          tabIndex={undefined}
+        >
+          Streams
+        </a>
+      </li>
+      <li
+        className=""
+        role="presentation"
+        style={undefined}
+      >
+        <a
+          aria-controls="permissionSelectorTabs-pane-2"
+          aria-selected={false}
+          href="#"
+          id="permissionSelectorTabs-tab-2"
+          onClick={[Function]}
+          onKeyDown={[Function]}
+          role="tab"
+          tabIndex={-1}
+        >
+          Dashboards
+        </a>
+      </li>
+    </ul>
+    <div
+      className="tab-content"
+    >
+      <div
+        aria-hidden={false}
+        aria-labelledby="permissionSelectorTabs-tab-1"
+        className="tab-pane active"
+        id="permissionSelectorTabs-pane-1"
+        role="tabpanel"
+      >
+        <div
+          style={
+            Object {
+              "marginTop": 10,
+            }
+          }
+        >
+          <div>
+            <div
+              className="row"
+            >
+              <div
+                className="col-md-5"
+              >
+                <div
+                  className="filter"
+                >
+                  <form
+                    className="form-inline"
+                    onSubmit={[Function]}
+                    style={
+                      Object {
+                        "display": "inline",
+                      }
+                    }
+                  >
+                    <div
+                      className="form-group"
+                    >
+                      <label
+                        className="control-label"
+                        htmlFor="filter-streams-data-filter"
+                      >
+                        Filter Streams
+                      </label>
+                      <div
+                        className="typeahead-wrapper"
+                      >
+                        <input
+                          className="form-control"
+                          id="filter-streams-data-filter"
+                          label="Filter Streams"
+                          onKeyPress={undefined}
+                          placeholder=""
+                          type="text"
+                          value={undefined}
+                        />
+                        
+                      </div>
+                    </div>
+                    <button
+                      className="btn btn-default"
+                      disabled={false}
+                      style={
+                        Object {
+                          "marginLeft": 5,
+                        }
+                      }
+                      type="submit"
+                    >
+                      Filter
+                    </button>
+                    <button
+                      className="btn btn-default"
+                      disabled={true}
+                      onClick={[Function]}
+                      style={
+                        Object {
+                          "marginLeft": 5,
+                        }
+                      }
+                      type="button"
+                    >
+                      Reset
+                    </button>
+                  </form>
+                  <ul
+                    className="pill-list"
+                  />
+                </div>
+              </div>
+            </div>
+            <ul
+              className="list-group"
+            >
+              <li
+                className="list-group-header list-group-item"
+              >
+                <div
+                  className="list-group-item-heading"
+                >
+                  <div
+                    className="form-group"
+                  >
+                    <div
+                      className="form-group-inline"
+                    >
+                      <div
+                        className="checkbox"
+                        style={undefined}
+                      >
+                        <label
+                          title=""
+                        >
+                          <input
+                            checked={false}
+                            disabled={false}
+                            label="Select all"
+                            onChange={[Function]}
+                            placeholder=""
+                            type="checkbox"
+                            value={undefined}
+                          />
+                          Select all
+                        </label>
+                      </div>
+                      
+                    </div>
+                  </div>
+                </div>
+                <p
+                  className="list-group-item-text"
+                />
+              </li>
+              <li
+                className="list-group-item"
+              >
+                <div
+                  className="list-group-item-heading"
+                >
+                  <div
+                    className="pull-right"
+                    style={
+                      Object {
+                        "marginBottom": 10,
+                        "marginTop": 10,
+                      }
+                    }
+                  >
+                    <div
+                      className="btn-group btn-group-sm"
+                    >
+                      <button
+                        className="btn btn-default"
+                        disabled={false}
+                        onClick={[Function]}
+                        type="button"
+                      >
+                        Allow reading
+                      </button>
+                      <button
+                        className="btn btn-default"
+                        disabled={false}
+                        onClick={[Function]}
+                        type="button"
+                      >
+                        Allow editing
+                      </button>
+                    </div>
+                  </div>
+                  <div
+                    className="form-group"
+                  >
+                    <span>
+                      <div
+                        className="checkbox"
+                        style={undefined}
+                      >
+                        <label
+                          title=""
+                        >
+                          <input
+                            checked={false}
+                            disabled={false}
+                            groupClassName="form-group-inline"
+                            label=""
+                            onChange={[Function]}
+                            placeholder=""
+                            type="checkbox"
+                            value={undefined}
+                          />
+                          
+                        </label>
+                      </div>
+                      
+                    </span>
+                  </div>
+                </div>
+                <p
+                  className="list-group-item-text"
+                >
+                  <span
+                    style={
+                      Object {
+                        "marginLeft": 20,
+                      }
+                    }
+                  >
+                    stream1
+                  </span>
+                </p>
+              </li>
+              <li
+                className="list-group-item"
+              >
+                <div
+                  className="list-group-item-heading"
+                >
+                  <div
+                    className="pull-right"
+                    style={
+                      Object {
+                        "marginBottom": 10,
+                        "marginTop": 10,
+                      }
+                    }
+                  >
+                    <div
+                      className="btn-group btn-group-sm"
+                    >
+                      <button
+                        className="btn btn-default"
+                        disabled={false}
+                        onClick={[Function]}
+                        type="button"
+                      >
+                        Allow reading
+                      </button>
+                      <button
+                        className="btn btn-default"
+                        disabled={false}
+                        onClick={[Function]}
+                        type="button"
+                      >
+                        Allow editing
+                      </button>
+                    </div>
+                  </div>
+                  <div
+                    className="form-group"
+                  >
+                    <span>
+                      <div
+                        className="checkbox"
+                        style={undefined}
+                      >
+                        <label
+                          title=""
+                        >
+                          <input
+                            checked={false}
+                            disabled={false}
+                            groupClassName="form-group-inline"
+                            label=""
+                            onChange={[Function]}
+                            placeholder=""
+                            type="checkbox"
+                            value={undefined}
+                          />
+                          
+                        </label>
+                      </div>
+                      
+                    </span>
+                  </div>
+                </div>
+                <p
+                  className="list-group-item-text"
+                >
+                  <span
+                    style={
+                      Object {
+                        "marginLeft": 20,
+                      }
+                    }
+                  >
+                    stream2
+                  </span>
+                </p>
+              </li>
+            </ul>
+          </div>
+        </div>
+      </div>
+      <div
+        aria-hidden={true}
+        aria-labelledby="permissionSelectorTabs-tab-2"
+        className="tab-pane"
+        id="permissionSelectorTabs-pane-2"
+        role="tabpanel"
+      >
+        <div
+          style={
+            Object {
+              "marginTop": 10,
+            }
+          }
+        >
+          <div>
+            <div
+              className="row"
+            >
+              <div
+                className="col-md-5"
+              >
+                <div
+                  className="filter"
+                >
+                  <form
+                    className="form-inline"
+                    onSubmit={[Function]}
+                    style={
+                      Object {
+                        "display": "inline",
+                      }
+                    }
+                  >
+                    <div
+                      className="form-group"
+                    >
+                      <label
+                        className="control-label"
+                        htmlFor="filter-dashboards-data-filter"
+                      >
+                        Filter Dashboards
+                      </label>
+                      <div
+                        className="typeahead-wrapper"
+                      >
+                        <input
+                          className="form-control"
+                          id="filter-dashboards-data-filter"
+                          label="Filter Dashboards"
+                          onKeyPress={undefined}
+                          placeholder=""
+                          type="text"
+                          value={undefined}
+                        />
+                        
+                      </div>
+                    </div>
+                    <button
+                      className="btn btn-default"
+                      disabled={false}
+                      style={
+                        Object {
+                          "marginLeft": 5,
+                        }
+                      }
+                      type="submit"
+                    >
+                      Filter
+                    </button>
+                    <button
+                      className="btn btn-default"
+                      disabled={true}
+                      onClick={[Function]}
+                      style={
+                        Object {
+                          "marginLeft": 5,
+                        }
+                      }
+                      type="button"
+                    >
+                      Reset
+                    </button>
+                  </form>
+                  <ul
+                    className="pill-list"
+                  />
+                </div>
+              </div>
+            </div>
+            <ul
+              className="list-group"
+            >
+              <li
+                className="list-group-header list-group-item"
+              >
+                <div
+                  className="list-group-item-heading"
+                >
+                  <div
+                    className="form-group"
+                  >
+                    <div
+                      className="form-group-inline"
+                    >
+                      <div
+                        className="checkbox"
+                        style={undefined}
+                      >
+                        <label
+                          title=""
+                        >
+                          <input
+                            checked={false}
+                            disabled={false}
+                            label="Select all"
+                            onChange={[Function]}
+                            placeholder=""
+                            type="checkbox"
+                            value={undefined}
+                          />
+                          Select all
+                        </label>
+                      </div>
+                      
+                    </div>
+                  </div>
+                </div>
+                <p
+                  className="list-group-item-text"
+                />
+              </li>
+              <li
+                className="list-group-item"
+              >
+                <div
+                  className="list-group-item-heading"
+                >
+                  <div
+                    className="pull-right"
+                    style={
+                      Object {
+                        "marginBottom": 10,
+                        "marginTop": 10,
+                      }
+                    }
+                  >
+                    <div
+                      className="btn-group btn-group-sm"
+                    >
+                      <button
+                        className="btn btn-default"
+                        disabled={false}
+                        onClick={[Function]}
+                        type="button"
+                      >
+                        Allow reading
+                      </button>
+                      <button
+                        className="btn btn-default"
+                        disabled={false}
+                        onClick={[Function]}
+                        type="button"
+                      >
+                        Allow editing
+                      </button>
+                    </div>
+                  </div>
+                  <div
+                    className="form-group"
+                  >
+                    <span>
+                      <div
+                        className="checkbox"
+                        style={undefined}
+                      >
+                        <label
+                          title=""
+                        >
+                          <input
+                            checked={false}
+                            disabled={false}
+                            groupClassName="form-group-inline"
+                            label=""
+                            onChange={[Function]}
+                            placeholder=""
+                            type="checkbox"
+                            value={undefined}
+                          />
+                          
+                        </label>
+                      </div>
+                      
+                    </span>
+                  </div>
+                </div>
+                <p
+                  className="list-group-item-text"
+                >
+                  <span
+                    style={
+                      Object {
+                        "marginLeft": 20,
+                      }
+                    }
+                  >
+                    dashboard1
+                  </span>
+                </p>
+              </li>
+              <li
+                className="list-group-item"
+              >
+                <div
+                  className="list-group-item-heading"
+                >
+                  <div
+                    className="pull-right"
+                    style={
+                      Object {
+                        "marginBottom": 10,
+                        "marginTop": 10,
+                      }
+                    }
+                  >
+                    <div
+                      className="btn-group btn-group-sm"
+                    >
+                      <button
+                        className="btn btn-default"
+                        disabled={false}
+                        onClick={[Function]}
+                        type="button"
+                      >
+                        Allow reading
+                      </button>
+                      <button
+                        className="btn btn-default"
+                        disabled={false}
+                        onClick={[Function]}
+                        type="button"
+                      >
+                        Allow editing
+                      </button>
+                    </div>
+                  </div>
+                  <div
+                    className="form-group"
+                  >
+                    <span>
+                      <div
+                        className="checkbox"
+                        style={undefined}
+                      >
+                        <label
+                          title=""
+                        >
+                          <input
+                            checked={false}
+                            disabled={false}
+                            groupClassName="form-group-inline"
+                            label=""
+                            onChange={[Function]}
+                            placeholder=""
+                            type="checkbox"
+                            value={undefined}
+                          />
+                          
+                        </label>
+                      </div>
+                      
+                    </span>
+                  </div>
+                </div>
+                <p
+                  className="list-group-item-text"
+                >
+                  <span
+                    style={
+                      Object {
+                        "marginLeft": 20,
+                      }
+                    }
+                  >
+                    dashboard2
+                  </span>
+                </p>
+              </li>
+            </ul>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`<PermissionSelector /> should render with set permissions 1`] = `
+<div>
+  <div
+    className={undefined}
+    id="permissionSelectorTabs"
+    style={undefined}
+  >
+    <ul
+      className="nav nav-tabs"
+      role="tablist"
+    >
+      <li
+        className="active"
+        role="presentation"
+        style={undefined}
+      >
+        <a
+          aria-controls="permissionSelectorTabs-pane-1"
+          aria-selected={true}
+          href="#"
+          id="permissionSelectorTabs-tab-1"
+          onClick={[Function]}
+          onKeyDown={[Function]}
+          role="tab"
+          tabIndex={undefined}
+        >
+          Streams
+        </a>
+      </li>
+      <li
+        className=""
+        role="presentation"
+        style={undefined}
+      >
+        <a
+          aria-controls="permissionSelectorTabs-pane-2"
+          aria-selected={false}
+          href="#"
+          id="permissionSelectorTabs-tab-2"
+          onClick={[Function]}
+          onKeyDown={[Function]}
+          role="tab"
+          tabIndex={-1}
+        >
+          Dashboards
+        </a>
+      </li>
+    </ul>
+    <div
+      className="tab-content"
+    >
+      <div
+        aria-hidden={false}
+        aria-labelledby="permissionSelectorTabs-tab-1"
+        className="tab-pane active"
+        id="permissionSelectorTabs-pane-1"
+        role="tabpanel"
+      >
+        <div
+          style={
+            Object {
+              "marginTop": 10,
+            }
+          }
+        >
+          <div>
+            <div
+              className="row"
+            >
+              <div
+                className="col-md-5"
+              >
+                <div
+                  className="filter"
+                >
+                  <form
+                    className="form-inline"
+                    onSubmit={[Function]}
+                    style={
+                      Object {
+                        "display": "inline",
+                      }
+                    }
+                  >
+                    <div
+                      className="form-group"
+                    >
+                      <label
+                        className="control-label"
+                        htmlFor="filter-streams-data-filter"
+                      >
+                        Filter Streams
+                      </label>
+                      <div
+                        className="typeahead-wrapper"
+                      >
+                        <input
+                          className="form-control"
+                          id="filter-streams-data-filter"
+                          label="Filter Streams"
+                          onKeyPress={undefined}
+                          placeholder=""
+                          type="text"
+                          value={undefined}
+                        />
+                        
+                      </div>
+                    </div>
+                    <button
+                      className="btn btn-default"
+                      disabled={false}
+                      style={
+                        Object {
+                          "marginLeft": 5,
+                        }
+                      }
+                      type="submit"
+                    >
+                      Filter
+                    </button>
+                    <button
+                      className="btn btn-default"
+                      disabled={true}
+                      onClick={[Function]}
+                      style={
+                        Object {
+                          "marginLeft": 5,
+                        }
+                      }
+                      type="button"
+                    >
+                      Reset
+                    </button>
+                  </form>
+                  <ul
+                    className="pill-list"
+                  />
+                </div>
+              </div>
+            </div>
+            <ul
+              className="list-group"
+            >
+              <li
+                className="list-group-header list-group-item"
+              >
+                <div
+                  className="list-group-item-heading"
+                >
+                  <div
+                    className="form-group"
+                  >
+                    <div
+                      className="form-group-inline"
+                    >
+                      <div
+                        className="checkbox"
+                        style={undefined}
+                      >
+                        <label
+                          title=""
+                        >
+                          <input
+                            checked={false}
+                            disabled={false}
+                            label="Select all"
+                            onChange={[Function]}
+                            placeholder=""
+                            type="checkbox"
+                            value={undefined}
+                          />
+                          Select all
+                        </label>
+                      </div>
+                      
+                    </div>
+                  </div>
+                </div>
+                <p
+                  className="list-group-item-text"
+                />
+              </li>
+              <li
+                className="list-group-item"
+              >
+                <div
+                  className="list-group-item-heading"
+                >
+                  <div
+                    className="pull-right"
+                    style={
+                      Object {
+                        "marginBottom": 10,
+                        "marginTop": 10,
+                      }
+                    }
+                  >
+                    <div
+                      className="btn-group btn-group-sm"
+                    >
+                      <button
+                        className="btn btn-info active"
+                        disabled={false}
+                        onClick={[Function]}
+                        type="button"
+                      >
+                        Allow reading
+                      </button>
+                      <button
+                        className="btn btn-default"
+                        disabled={false}
+                        onClick={[Function]}
+                        type="button"
+                      >
+                        Allow editing
+                      </button>
+                    </div>
+                  </div>
+                  <div
+                    className="form-group"
+                  >
+                    <span>
+                      <div
+                        className="checkbox"
+                        style={undefined}
+                      >
+                        <label
+                          title=""
+                        >
+                          <input
+                            checked={false}
+                            disabled={false}
+                            groupClassName="form-group-inline"
+                            label=""
+                            onChange={[Function]}
+                            placeholder=""
+                            type="checkbox"
+                            value={undefined}
+                          />
+                          
+                        </label>
+                      </div>
+                      
+                    </span>
+                  </div>
+                </div>
+                <p
+                  className="list-group-item-text"
+                >
+                  <span
+                    style={
+                      Object {
+                        "marginLeft": 20,
+                      }
+                    }
+                  >
+                    stream1
+                  </span>
+                </p>
+              </li>
+              <li
+                className="list-group-item"
+              >
+                <div
+                  className="list-group-item-heading"
+                >
+                  <div
+                    className="pull-right"
+                    style={
+                      Object {
+                        "marginBottom": 10,
+                        "marginTop": 10,
+                      }
+                    }
+                  >
+                    <div
+                      className="btn-group btn-group-sm"
+                    >
+                      <button
+                        className="btn btn-default"
+                        disabled={false}
+                        onClick={[Function]}
+                        type="button"
+                      >
+                        Allow reading
+                      </button>
+                      <button
+                        className="btn btn-info active"
+                        disabled={false}
+                        onClick={[Function]}
+                        type="button"
+                      >
+                        Allow editing
+                      </button>
+                    </div>
+                  </div>
+                  <div
+                    className="form-group"
+                  >
+                    <span>
+                      <div
+                        className="checkbox"
+                        style={undefined}
+                      >
+                        <label
+                          title=""
+                        >
+                          <input
+                            checked={false}
+                            disabled={false}
+                            groupClassName="form-group-inline"
+                            label=""
+                            onChange={[Function]}
+                            placeholder=""
+                            type="checkbox"
+                            value={undefined}
+                          />
+                          
+                        </label>
+                      </div>
+                      
+                    </span>
+                  </div>
+                </div>
+                <p
+                  className="list-group-item-text"
+                >
+                  <span
+                    style={
+                      Object {
+                        "marginLeft": 20,
+                      }
+                    }
+                  >
+                    stream2
+                  </span>
+                </p>
+              </li>
+            </ul>
+          </div>
+        </div>
+      </div>
+      <div
+        aria-hidden={true}
+        aria-labelledby="permissionSelectorTabs-tab-2"
+        className="tab-pane"
+        id="permissionSelectorTabs-pane-2"
+        role="tabpanel"
+      >
+        <div
+          style={
+            Object {
+              "marginTop": 10,
+            }
+          }
+        >
+          <div>
+            <div
+              className="row"
+            >
+              <div
+                className="col-md-5"
+              >
+                <div
+                  className="filter"
+                >
+                  <form
+                    className="form-inline"
+                    onSubmit={[Function]}
+                    style={
+                      Object {
+                        "display": "inline",
+                      }
+                    }
+                  >
+                    <div
+                      className="form-group"
+                    >
+                      <label
+                        className="control-label"
+                        htmlFor="filter-dashboards-data-filter"
+                      >
+                        Filter Dashboards
+                      </label>
+                      <div
+                        className="typeahead-wrapper"
+                      >
+                        <input
+                          className="form-control"
+                          id="filter-dashboards-data-filter"
+                          label="Filter Dashboards"
+                          onKeyPress={undefined}
+                          placeholder=""
+                          type="text"
+                          value={undefined}
+                        />
+                        
+                      </div>
+                    </div>
+                    <button
+                      className="btn btn-default"
+                      disabled={false}
+                      style={
+                        Object {
+                          "marginLeft": 5,
+                        }
+                      }
+                      type="submit"
+                    >
+                      Filter
+                    </button>
+                    <button
+                      className="btn btn-default"
+                      disabled={true}
+                      onClick={[Function]}
+                      style={
+                        Object {
+                          "marginLeft": 5,
+                        }
+                      }
+                      type="button"
+                    >
+                      Reset
+                    </button>
+                  </form>
+                  <ul
+                    className="pill-list"
+                  />
+                </div>
+              </div>
+            </div>
+            <ul
+              className="list-group"
+            >
+              <li
+                className="list-group-header list-group-item"
+              >
+                <div
+                  className="list-group-item-heading"
+                >
+                  <div
+                    className="form-group"
+                  >
+                    <div
+                      className="form-group-inline"
+                    >
+                      <div
+                        className="checkbox"
+                        style={undefined}
+                      >
+                        <label
+                          title=""
+                        >
+                          <input
+                            checked={false}
+                            disabled={false}
+                            label="Select all"
+                            onChange={[Function]}
+                            placeholder=""
+                            type="checkbox"
+                            value={undefined}
+                          />
+                          Select all
+                        </label>
+                      </div>
+                      
+                    </div>
+                  </div>
+                </div>
+                <p
+                  className="list-group-item-text"
+                />
+              </li>
+              <li
+                className="list-group-item"
+              >
+                <div
+                  className="list-group-item-heading"
+                >
+                  <div
+                    className="pull-right"
+                    style={
+                      Object {
+                        "marginBottom": 10,
+                        "marginTop": 10,
+                      }
+                    }
+                  >
+                    <div
+                      className="btn-group btn-group-sm"
+                    >
+                      <button
+                        className="btn btn-default"
+                        disabled={false}
+                        onClick={[Function]}
+                        type="button"
+                      >
+                        Allow reading
+                      </button>
+                      <button
+                        className="btn btn-default"
+                        disabled={false}
+                        onClick={[Function]}
+                        type="button"
+                      >
+                        Allow editing
+                      </button>
+                    </div>
+                  </div>
+                  <div
+                    className="form-group"
+                  >
+                    <span>
+                      <div
+                        className="checkbox"
+                        style={undefined}
+                      >
+                        <label
+                          title=""
+                        >
+                          <input
+                            checked={false}
+                            disabled={false}
+                            groupClassName="form-group-inline"
+                            label=""
+                            onChange={[Function]}
+                            placeholder=""
+                            type="checkbox"
+                            value={undefined}
+                          />
+                          
+                        </label>
+                      </div>
+                      
+                    </span>
+                  </div>
+                </div>
+                <p
+                  className="list-group-item-text"
+                >
+                  <span
+                    style={
+                      Object {
+                        "marginLeft": 20,
+                      }
+                    }
+                  >
+                    dashboard1
+                  </span>
+                </p>
+              </li>
+              <li
+                className="list-group-item"
+              >
+                <div
+                  className="list-group-item-heading"
+                >
+                  <div
+                    className="pull-right"
+                    style={
+                      Object {
+                        "marginBottom": 10,
+                        "marginTop": 10,
+                      }
+                    }
+                  >
+                    <div
+                      className="btn-group btn-group-sm"
+                    >
+                      <button
+                        className="btn btn-info active"
+                        disabled={false}
+                        onClick={[Function]}
+                        type="button"
+                      >
+                        Allow reading
+                      </button>
+                      <button
+                        className="btn btn-default"
+                        disabled={false}
+                        onClick={[Function]}
+                        type="button"
+                      >
+                        Allow editing
+                      </button>
+                    </div>
+                  </div>
+                  <div
+                    className="form-group"
+                  >
+                    <span>
+                      <div
+                        className="checkbox"
+                        style={undefined}
+                      >
+                        <label
+                          title=""
+                        >
+                          <input
+                            checked={false}
+                            disabled={false}
+                            groupClassName="form-group-inline"
+                            label=""
+                            onChange={[Function]}
+                            placeholder=""
+                            type="checkbox"
+                            value={undefined}
+                          />
+                          
+                        </label>
+                      </div>
+                      
+                    </span>
+                  </div>
+                </div>
+                <p
+                  className="list-group-item-text"
+                >
+                  <span
+                    style={
+                      Object {
+                        "marginLeft": 20,
+                      }
+                    }
+                  >
+                    dashboard2
+                  </span>
+                </p>
+              </li>
+            </ul>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;


### PR DESCRIPTION
## Description
So I changed the label of the buttons from "Toggle" to
"Set" and "Clear" depending on which state the streams
permissions are. If all permissions are "Allow" the button
will read "Clear" and remove the permissions. If one or
more will have no "Allow" permission, the button will read
"Set" and will set the permission to "Allow" for all selected
streams.

## Motivation and Context
After selecting two streams (or dashboards) in the Edit Role
view, two buttons appeared in the header of the table.
"Toggle read permissions" and "Toggle edit permissions"
which would invert the permissions of a selected streams.

The user would rather set or clear the permissions of the
selected streams.

Fixes #3210

## Screenshots (if appropriate):

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)