### PR TITLE
Enabling No Response bot for repository.

### DIFF
--- a/.github/no-response.yml
+++ b/.github/no-response.yml
@@ -1,0 +1,2 @@
+daysUntilClose: 30
+responseRequiredLabel: needs-input


### PR DESCRIPTION
Now that probot/no-response#12 is closed, we can try to reenable the bot.

This bot is automatically closing issues which are marked to be in need
for more information, but this information was not provided in a
reasonable time frame.

More information about the bot is provided here:
https://probot.github.io/apps/no-response/

