### PR TITLE
Hide replay button if user has no permission

### DIFF
--- a/graylog2-web-interface/package.json
+++ b/graylog2-web-interface/package.json
@@ -22,7 +22,8 @@
       "src/**/*.{js,jsx,ts,tsx}"
     ],
     "setupFiles": [
-      "jest-localstorage-mock"
+      "jest-localstorage-mock",
+      "./test/setup-jest.jsx"
     ],
     "setupTestFrameworkScriptFile": "./node_modules/jest-enzyme/lib/index.js",
     "moduleDirectories": [
@@ -36,7 +37,8 @@
       "ts"
     ],
     "moduleNameMapper": {
-      "\\.(css|less)$": "identity-obj-proxy"
+      "\\.(css|less)$": "identity-obj-proxy",
+      "c3": "<rootDir>/test/helpers/mocking/c3_mock.jsx"
     },
     "transform": {
       "^.+\\.jsx?$": "<rootDir>/node_modules/babel-jest",

--- a/graylog2-web-interface/src/components/widgets/Widget.jsx
+++ b/graylog2-web-interface/src/components/widgets/Widget.jsx
@@ -1,17 +1,17 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 import $ from 'jquery';
-import { PluginStore } from 'graylog-web-plugin/plugin';
+import Reflux from 'reflux';
+
 import { WidgetConfigModal, WidgetEditConfigModal, WidgetFooter, WidgetHeader, WidgetVisualizationNotFound } from 'components/widgets';
+import { PluginStore } from 'graylog-web-plugin/plugin';
 import StoreProvider from 'injection/StoreProvider';
-import ActionsProvider from 'injection/ActionsProvider';
 import Routes from 'routing/Routes';
 import EventHandlersThrottler from 'util/EventHandlersThrottler';
-import Reflux from 'reflux';
 import PermissionsMixin from 'util/PermissionsMixin';
+import CombinedProvider from '../../injection/CombinedProvider';
 
-const WidgetsStore = StoreProvider.getStore('Widgets');
-const WidgetsActions = ActionsProvider.getActions('Widgets');
+const { WidgetsStore, WidgetsActions } = CombinedProvider.get('Widgets');
 const CurrentUserStore = StoreProvider.getStore('CurrentUser');
 
 const Widget = React.createClass({

--- a/graylog2-web-interface/src/components/widgets/Widget.jsx
+++ b/graylog2-web-interface/src/components/widgets/Widget.jsx
@@ -216,11 +216,8 @@ const Widget = React.createClass({
                              onUpdate={this.updateWidget} />
     );
 
-    let disabledReplay = false;
-    if (this.props.streamIds != null && this.props.widget.config.stream_id &&
-        !this.props.streamIds[this.props.widget.config.stream_id]) {
-      disabledReplay = true;
-    }
+    const disabledReplay = this.props.streamIds != null && this.props.widget.config.stream_id &&
+      !this.props.streamIds[this.props.widget.config.stream_id];
     return (
       <div ref="widget" className="widget" data-widget-id={this.props.widget.id}>
         <WidgetHeader ref="widgetHeader"

--- a/graylog2-web-interface/src/components/widgets/Widget.jsx
+++ b/graylog2-web-interface/src/components/widgets/Widget.jsx
@@ -1,21 +1,22 @@
 import PropTypes from 'prop-types';
 import React from 'react';
-import ReactDOM from 'react-dom';
 import $ from 'jquery';
 import { PluginStore } from 'graylog-web-plugin/plugin';
-
 import { WidgetConfigModal, WidgetEditConfigModal, WidgetFooter, WidgetHeader, WidgetVisualizationNotFound } from 'components/widgets';
-
 import StoreProvider from 'injection/StoreProvider';
-const WidgetsStore = StoreProvider.getStore('Widgets');
-
 import ActionsProvider from 'injection/ActionsProvider';
-const WidgetsActions = ActionsProvider.getActions('Widgets');
-
 import Routes from 'routing/Routes';
 import EventHandlersThrottler from 'util/EventHandlersThrottler';
+import Reflux from 'reflux';
+import PermissionsMixin from 'util/PermissionsMixin';
+
+const WidgetsStore = StoreProvider.getStore('Widgets');
+const WidgetsActions = ActionsProvider.getActions('Widgets');
+const CurrentUserStore = StoreProvider.getStore('CurrentUser');
 
 const Widget = React.createClass({
+  mixins: [Reflux.connect(CurrentUserStore), PermissionsMixin],
+
   propTypes: {
     widget: PropTypes.object.isRequired,
     dashboardId: PropTypes.string.isRequired,
@@ -69,14 +70,14 @@ const Widget = React.createClass({
     return ('stream_id' in this.props.widget.config) && (this.props.widget.config.stream_id !== null);
   },
   _getWidgetNode() {
-    return ReactDOM.findDOMNode(this.refs.widget);
+    return this.node;
   },
   _loadValue() {
     if (this.state.deleted || (this.state.result !== undefined && !this.props.shouldUpdate)) {
       return;
     }
 
-    const width = this.refs.widget.clientWidth;
+    const width = this.node.clientWidth;
 
     WidgetsStore.loadValue(this.props.dashboardId, this.props.widget.id, width).then((value) => {
       // Avoid updating state if the result didn't change
@@ -111,6 +112,7 @@ const Widget = React.createClass({
   },
   _calculateWidgetSize() {
     const $widgetNode = $(this._getWidgetNode());
+    if (!$widgetNode) { return; }
     // .height() give us the height of the whole widget without counting paddings, we need to remove the size
     // of the header and footer from that.
     const availableHeight = $widgetNode.height() - (this.WIDGET_HEADER_HEIGHT + this.WIDGET_FOOTER_HEIGHT);
@@ -189,9 +191,10 @@ const Widget = React.createClass({
     this.refs.editModal.open();
   },
   updateWidget(newWidgetData) {
-    newWidgetData.id = this.props.widget.id;
+    const realNewWidgetData = newWidgetData;
+    realNewWidgetData.id = this.props.widget.id;
 
-    WidgetsStore.updateWidget(this.props.dashboardId, newWidgetData);
+    WidgetsStore.updateWidget(this.props.dashboardId, realNewWidgetData);
   },
   deleteWidget() {
     if (window.confirm(`Do you really want to delete "${this.props.widget.description}"?`)) {
@@ -204,29 +207,29 @@ const Widget = React.createClass({
       return <span />;
     }
     const showConfigModal = (
-      <WidgetConfigModal ref="configModal"
-                         dashboardId={this.props.dashboardId}
+      <WidgetConfigModal dashboardId={this.props.dashboardId}
                          widget={this.props.widget}
                          boundToStream={this._isBoundToStream()} />
     );
 
     const editConfigModal = (
-      <WidgetEditConfigModal ref="editModal"
-                             widget={this.props.widget}
+      <WidgetEditConfigModal widget={this.props.widget}
                              onUpdate={this.updateWidget} />
     );
 
-    const disabledReplay = this.props.streamIds != null && this.props.widget.config.stream_id &&
-      !this.props.streamIds[this.props.widget.config.stream_id];
+    const disabledReplay = !((!this.props.widget.config.stream_id &&
+      this.isPermitted(this.state.currentUser.permissions,
+        ['searches:absolute', 'searches:keyword', 'searches:relative'])) ||
+      (this.props.widget.config.stream_id && this.props.streamIds != null &&
+      this.props.streamIds[this.props.widget.config.stream_id]));
+
     return (
-      <div ref="widget" className="widget" data-widget-id={this.props.widget.id}>
-        <WidgetHeader ref="widgetHeader"
-                      title={this.props.widget.description} />
+      <div ref={(node) => { this.node = node; }} className="widget" data-widget-id={this.props.widget.id}>
+        <WidgetHeader title={this.props.widget.description} />
 
         {this._getVisualization()}
 
-        <WidgetFooter ref="widgetFooter"
-                      locked={this.props.locked}
+        <WidgetFooter locked={this.props.locked}
                       onShowConfig={this._showConfig}
                       onEditConfig={this._showEditConfig}
                       onDelete={this.deleteWidget}

--- a/graylog2-web-interface/src/components/widgets/Widget.jsx
+++ b/graylog2-web-interface/src/components/widgets/Widget.jsx
@@ -216,10 +216,10 @@ const Widget = React.createClass({
                              onUpdate={this.updateWidget} />
     );
 
-    let disabledTooltip = null;
+    let disabledReplay = false;
     if (this.props.streamIds != null && this.props.widget.config.stream_id &&
         !this.props.streamIds[this.props.widget.config.stream_id]) {
-      disabledTooltip = 'The stream is not available, cannot replay search.';
+      disabledReplay = true;
     }
     return (
       <div ref="widget" className="widget" data-widget-id={this.props.widget.id}>
@@ -234,7 +234,7 @@ const Widget = React.createClass({
                       onEditConfig={this._showEditConfig}
                       onDelete={this.deleteWidget}
                       replayHref={this.replayUrl()}
-                      replayToolTip={disabledTooltip}
+                      replayDisabled={disabledReplay}
                       calculatedAt={this.state.calculatedAt}
                       error={this.state.error}
                       errorMessage={this.state.errorMessage} />

--- a/graylog2-web-interface/src/components/widgets/Widget.jsx
+++ b/graylog2-web-interface/src/components/widgets/Widget.jsx
@@ -185,10 +185,10 @@ const Widget = React.createClass({
     return Routes.search(config.query, this._getTimeRange(), config.interval);
   },
   _showConfig() {
-    this.refs.configModal.open();
+    this.configModal.open();
   },
   _showEditConfig() {
-    this.refs.editModal.open();
+    this.editModal.open();
   },
   updateWidget(newWidgetData) {
     const realNewWidgetData = newWidgetData;
@@ -207,21 +207,27 @@ const Widget = React.createClass({
       return <span />;
     }
     const showConfigModal = (
-      <WidgetConfigModal dashboardId={this.props.dashboardId}
+      <WidgetConfigModal ref={(node) => { this.configModal = node; }}
+                         dashboardId={this.props.dashboardId}
                          widget={this.props.widget}
                          boundToStream={this._isBoundToStream()} />
     );
 
     const editConfigModal = (
-      <WidgetEditConfigModal widget={this.props.widget}
+      <WidgetEditConfigModal ref={(node) => { this.editModal = node; }}
+                             widget={this.props.widget}
                              onUpdate={this.updateWidget} />
     );
 
-    const disabledReplay = !((!this.props.widget.config.stream_id &&
+    /* Note that we consider two cases here: a dashboard configured from
+       a stream and a dashboard configured from global search. */
+    const canReadConfiguredStream = this.props.widget.config.stream_id && this.props.streamIds != null &&
+      this.props.streamIds[this.props.widget.config.stream_id];
+    const canSearchGlobally = !this.props.widget.config.stream_id &&
       this.isPermitted(this.state.currentUser.permissions,
-        ['searches:absolute', 'searches:keyword', 'searches:relative'])) ||
-      (this.props.widget.config.stream_id && this.props.streamIds != null &&
-      this.props.streamIds[this.props.widget.config.stream_id]));
+        ['searches:absolute', 'searches:keyword', 'searches:relative']);
+
+    const disabledReplay = !canReadConfiguredStream && !canSearchGlobally;
 
     return (
       <div ref={(node) => { this.node = node; }} className="widget" data-widget-id={this.props.widget.id}>

--- a/graylog2-web-interface/src/components/widgets/Widget.test.jsx
+++ b/graylog2-web-interface/src/components/widgets/Widget.test.jsx
@@ -1,0 +1,63 @@
+import {} from 'jquery-ui/ui/version';
+import {} from 'jquery-ui/ui/effect';
+import {} from 'jquery-ui/ui/plugin';
+import {} from 'jquery-ui/ui/widget';
+import {} from 'jquery-ui/ui/widgets/mouse';
+import React from 'react';
+import { mount } from 'enzyme';
+import Widget from 'components/widgets/Widget';
+
+describe('<Widget />', () => {
+  const widget = {
+    id: 'widget-1',
+    type: 'foo',
+    description: 'A generic widget',
+    config: {
+      stream_id: 'stream-1',
+      timerange: {
+        type: 'UTC',
+      },
+    },
+  };
+  describe('locked and unlocked', () => {
+    it('should render a locked Widget', () => {
+      const wrapper = mount(<Widget
+        id={widget.id}
+        key={`widget-${widget.id}`}
+        widget={widget}
+        dashboardId={'dashboard-id'}
+        locked
+        shouldUpdate
+        streamIds={{ 'stream-1': 'stream-1' }} />);
+      expect(wrapper.find('.widget-replay').find('Button').prop('title')).toEqual('Replay search');
+      expect(wrapper.find('.widget-edit').exists()).toBeFalsy();
+    });
+
+    it('should render a unlocked Widget', () => {
+      const wrapper = mount(<Widget
+        id={widget.id}
+        key={`widget-${widget.id}`}
+        widget={widget}
+        dashboardId={'dashboard-id'}
+        locked={false}
+        shouldUpdate
+        streamIds={{ 'stream-1': 'stream-1' }} />);
+      expect(wrapper.find('.widget-edit').find('Button').prop('title')).toEqual('Edit widget');
+      expect(wrapper.find('.widget-replay').exists()).toBeFalsy();
+    });
+  });
+
+  describe('disable and enable replay', () => {
+    it('should not render a replay button if the user has no streams to read', () => {
+      const wrapper = mount(<Widget
+        id={widget.id}
+        key={`widget-${widget.id}`}
+        widget={widget}
+        dashboardId={'dashboard-id'}
+        locked
+        shouldUpdate
+        streamIds={{}} />);
+      expect(wrapper.find('.widget-replay').exists()).toBeFalsy();
+    });
+  });
+});

--- a/graylog2-web-interface/src/components/widgets/WidgetFooter.jsx
+++ b/graylog2-web-interface/src/components/widgets/WidgetFooter.jsx
@@ -47,7 +47,7 @@ const WidgetFooter = React.createClass({
     }
 
     // if we have a tooltip, we disable the button link and instead show a tooltip on hover
-    let replay = this.props.replayDisabled ? <div /> : (
+    const replay = this.props.replayDisabled ? <div /> : (
       <div className="widget-replay">
         <Button bsStyle="link" className="btn-text" title={'Replay search'} href={this.props.replayHref}>
           <i className="fa fa-play" />

--- a/graylog2-web-interface/src/components/widgets/WidgetFooter.jsx
+++ b/graylog2-web-interface/src/components/widgets/WidgetFooter.jsx
@@ -46,10 +46,9 @@ const WidgetFooter = React.createClass({
       calculatedAtTime = 'Loading...';
     }
 
-    // if we have a tooltip, we disable the button link and instead show a tooltip on hover
     const replay = this.props.replayDisabled ? null : (
       <div className="widget-replay">
-        <Button bsStyle="link" className="btn-text" title={'Replay search'} href={this.props.replayHref}>
+        <Button bsStyle="link" className="btn-text" title="Replay search" href={this.props.replayHref}>
           <i className="fa fa-play" />
         </Button>
       </div>

--- a/graylog2-web-interface/src/components/widgets/WidgetFooter.jsx
+++ b/graylog2-web-interface/src/components/widgets/WidgetFooter.jsx
@@ -13,7 +13,7 @@ const WidgetFooter = React.createClass({
     error: PropTypes.any,
     errorMessage: PropTypes.string,
     calculatedAt: PropTypes.string,
-    replayToolTip: PropTypes.string,
+    replayDisabled: PropTypes.bool,
   },
   _showConfig(e) {
     e.preventDefault();
@@ -47,25 +47,16 @@ const WidgetFooter = React.createClass({
     }
 
     // if we have a tooltip, we disable the button link and instead show a tooltip on hover
-    const title = this.props.replayToolTip ? null : 'Replay search';
-    const href = this.props.replayToolTip ? null : this.props.replayHref;
-    let replay = (
-      <Button bsStyle="link" className="btn-text" title={title} href={href}>
-        <i className="fa fa-play" />
-      </Button>
+    let replay = this.props.replayDisabled ? <div /> : (
+      <div className="widget-replay">
+        <Button bsStyle="link" className="btn-text" title={'Replay search'} href={this.props.replayHref}>
+          <i className="fa fa-play" />
+        </Button>
+      </div>
     );
-    if (this.props.replayToolTip) {
-      replay = (
-        <OverlayTrigger placement="bottom" overlay={<Tooltip id="tooltip">{this.props.replayToolTip}</Tooltip>}>
-          {replay}
-        </OverlayTrigger>
-      );
-    }
     const lockedActions = (
       <div className="actions">
-        <div className="widget-replay">
-          {replay}
-        </div>
+        {replay}
         <div className="widget-info">
           <Button bsStyle="link" className="btn-text" title="Show widget configuration" onClick={this._showConfig}>
             <i className="fa fa-info-circle" />

--- a/graylog2-web-interface/src/components/widgets/WidgetFooter.jsx
+++ b/graylog2-web-interface/src/components/widgets/WidgetFooter.jsx
@@ -1,6 +1,6 @@
 import PropTypes from 'prop-types';
 import React from 'react';
-import { Button, OverlayTrigger, Tooltip } from 'react-bootstrap';
+import { Button } from 'react-bootstrap';
 import { Timestamp } from 'components/common';
 
 const WidgetFooter = React.createClass({
@@ -47,7 +47,7 @@ const WidgetFooter = React.createClass({
     }
 
     // if we have a tooltip, we disable the button link and instead show a tooltip on hover
-    const replay = this.props.replayDisabled ? <div /> : (
+    const replay = this.props.replayDisabled ? null : (
       <div className="widget-replay">
         <Button bsStyle="link" className="btn-text" title={'Replay search'} href={this.props.replayHref}>
           <i className="fa fa-play" />
@@ -83,8 +83,8 @@ const WidgetFooter = React.createClass({
     return (
       <div>
         <div className="widget-update-info">
-        {loadErrorElement}
-        {calculatedAtTime}
+          {loadErrorElement}
+          {calculatedAtTime}
         </div>
         <div>
           {this.props.locked ? lockedActions : unlockedActions}

--- a/graylog2-web-interface/src/components/widgets/WidgetFooter.test.jsx
+++ b/graylog2-web-interface/src/components/widgets/WidgetFooter.test.jsx
@@ -5,12 +5,10 @@ import WidgetFooter from 'components/widgets/WidgetFooter';
 
 describe('<WidgetFooter />', () => {
   const date = new Date('December 17, 1995 03:24:00');
-  const lockWidget = true;
-  const disableReplay = true;
 
   it('should render a widget footer locked and enabled replay', () => {
     const wrapper = renderer.create(<WidgetFooter
-      locked={lockWidget}
+      locked
       onShowConfig={() => {}}
       onEditConfig={() => {}}
       onDelete={() => {}}
@@ -24,12 +22,12 @@ describe('<WidgetFooter />', () => {
 
   it('should render a widget footer locked and disabled replay', () => {
     const wrapper = renderer.create(<WidgetFooter
-      locked={lockWidget}
+      locked
       onShowConfig={() => {}}
       onEditConfig={() => {}}
       onDelete={() => {}}
       replayHref={'http://example.org'}
-      replayDisabled={disableReplay}
+      replayDisabled
       calculatedAt={date.getTime()}
       error={{}}
       errorMessage={''} />);

--- a/graylog2-web-interface/src/components/widgets/WidgetFooter.test.jsx
+++ b/graylog2-web-interface/src/components/widgets/WidgetFooter.test.jsx
@@ -4,7 +4,7 @@ import renderer from 'react-test-renderer';
 import WidgetFooter from 'components/widgets/WidgetFooter';
 
 describe('<WidgetFooter />', () => {
-  const date = new Date('December 17, 1995 03:24:00');
+  const date = new Date(Date.UTC(1995, 12, 17, 3, 24, 0));
 
   it('should render a widget footer locked and enabled replay', () => {
     const wrapper = renderer.create(<WidgetFooter

--- a/graylog2-web-interface/src/components/widgets/WidgetFooter.test.jsx
+++ b/graylog2-web-interface/src/components/widgets/WidgetFooter.test.jsx
@@ -1,0 +1,52 @@
+import React from 'react';
+import renderer from 'react-test-renderer';
+
+import WidgetFooter from 'components/widgets/WidgetFooter';
+
+describe('<WidgetFooter />', () => {
+  const date = new Date('December 17, 1995 03:24:00');
+  const lockWidget = true;
+  const disableReplay = true;
+
+  it('should render a widget footer locked and enabled replay', () => {
+    const wrapper = renderer.create(<WidgetFooter
+      locked={lockWidget}
+      onShowConfig={() => {}}
+      onEditConfig={() => {}}
+      onDelete={() => {}}
+      replayHref={'http://example.org'}
+      replayDisabled={false}
+      calculatedAt={date.getTime()}
+      error={{}}
+      errorMessage={''} />);
+    expect(wrapper.toJSON()).toMatchSnapshot();
+  });
+
+  it('should render a widget footer locked and disabled replay', () => {
+    const wrapper = renderer.create(<WidgetFooter
+      locked={lockWidget}
+      onShowConfig={() => {}}
+      onEditConfig={() => {}}
+      onDelete={() => {}}
+      replayHref={'http://example.org'}
+      replayDisabled={disableReplay}
+      calculatedAt={date.getTime()}
+      error={{}}
+      errorMessage={''} />);
+    expect(wrapper.toJSON()).toMatchSnapshot();
+  });
+
+  it('should render a widget footer with unlocked', () => {
+    const wrapper = renderer.create(<WidgetFooter
+      locked={false}
+      onShowConfig={() => {}}
+      onEditConfig={() => {}}
+      onDelete={() => {}}
+      replayHref={'http://example.org'}
+      replayDisabled={false}
+      calculatedAt={date.getTime()}
+      error={{}}
+      errorMessage={''} />);
+    expect(wrapper.toJSON()).toMatchSnapshot();
+  });
+});

--- a/graylog2-web-interface/src/components/widgets/__snapshots__/WidgetFooter.test.jsx.snap
+++ b/graylog2-web-interface/src/components/widgets/__snapshots__/WidgetFooter.test.jsx.snap
@@ -28,7 +28,6 @@ exports[`<WidgetFooter /> should render a widget footer locked and disabled repl
     <div
       className="actions"
     >
-      <div />
       <div
         className="widget-info"
       >

--- a/graylog2-web-interface/src/components/widgets/__snapshots__/WidgetFooter.test.jsx.snap
+++ b/graylog2-web-interface/src/components/widgets/__snapshots__/WidgetFooter.test.jsx.snap
@@ -14,11 +14,11 @@ exports[`<WidgetFooter /> should render a widget footer locked and disabled repl
       />
     </span>
     <span
-      title={819167040000}
+      title={821849040000}
     >
       <time
-        dateTime={819167040000}
-        title={819167040000}
+        dateTime={821849040000}
+        title={821849040000}
       >
         22 years ago
       </time>
@@ -62,11 +62,11 @@ exports[`<WidgetFooter /> should render a widget footer locked and enabled repla
       />
     </span>
     <span
-      title={819167040000}
+      title={821849040000}
     >
       <time
-        dateTime={819167040000}
-        title={819167040000}
+        dateTime={821849040000}
+        title={821849040000}
       >
         22 years ago
       </time>
@@ -125,11 +125,11 @@ exports[`<WidgetFooter /> should render a widget footer with unlocked 1`] = `
       />
     </span>
     <span
-      title={819167040000}
+      title={821849040000}
     >
       <time
-        dateTime={819167040000}
-        title={819167040000}
+        dateTime={821849040000}
+        title={821849040000}
       >
         22 years ago
       </time>

--- a/graylog2-web-interface/src/components/widgets/__snapshots__/WidgetFooter.test.jsx.snap
+++ b/graylog2-web-interface/src/components/widgets/__snapshots__/WidgetFooter.test.jsx.snap
@@ -1,0 +1,176 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`<WidgetFooter /> should render a widget footer locked and disabled replay 1`] = `
+<div>
+  <div
+    className="widget-update-info"
+  >
+    <span
+      className="load-error"
+      title=""
+    >
+      <i
+        className="fa fa-exclamation-triangle"
+      />
+    </span>
+    <span
+      title={819167040000}
+    >
+      <time
+        dateTime={819167040000}
+        title={819167040000}
+      >
+        22 years ago
+      </time>
+    </span>
+  </div>
+  <div>
+    <div
+      className="actions"
+    >
+      <div />
+      <div
+        className="widget-info"
+      >
+        <button
+          className="btn-text btn btn-link"
+          disabled={false}
+          onClick={[Function]}
+          title="Show widget configuration"
+          type="button"
+        >
+          <i
+            className="fa fa-info-circle"
+          />
+        </button>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`<WidgetFooter /> should render a widget footer locked and enabled replay 1`] = `
+<div>
+  <div
+    className="widget-update-info"
+  >
+    <span
+      className="load-error"
+      title=""
+    >
+      <i
+        className="fa fa-exclamation-triangle"
+      />
+    </span>
+    <span
+      title={819167040000}
+    >
+      <time
+        dateTime={819167040000}
+        title={819167040000}
+      >
+        22 years ago
+      </time>
+    </span>
+  </div>
+  <div>
+    <div
+      className="actions"
+    >
+      <div
+        className="widget-replay"
+      >
+        <a
+          className="btn-text btn btn-link"
+          href="http://example.org"
+          onClick={[Function]}
+          onKeyDown={[Function]}
+          title="Replay search"
+        >
+          <i
+            className="fa fa-play"
+          />
+        </a>
+      </div>
+      <div
+        className="widget-info"
+      >
+        <button
+          className="btn-text btn btn-link"
+          disabled={false}
+          onClick={[Function]}
+          title="Show widget configuration"
+          type="button"
+        >
+          <i
+            className="fa fa-info-circle"
+          />
+        </button>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`<WidgetFooter /> should render a widget footer with unlocked 1`] = `
+<div>
+  <div
+    className="widget-update-info"
+  >
+    <span
+      className="load-error"
+      title=""
+    >
+      <i
+        className="fa fa-exclamation-triangle"
+      />
+    </span>
+    <span
+      title={819167040000}
+    >
+      <time
+        dateTime={819167040000}
+        title={819167040000}
+      >
+        22 years ago
+      </time>
+    </span>
+  </div>
+  <div>
+    <div
+      className="actions"
+    >
+      <div
+        className="widget-delete"
+      >
+        <button
+          className="btn-text btn btn-link"
+          disabled={false}
+          onClick={[Function]}
+          title="Delete widget"
+          type="button"
+        >
+          <i
+            className="fa fa-trash"
+          />
+        </button>
+      </div>
+      <div
+        className="widget-edit"
+      >
+        <button
+          className="btn-text btn btn-link"
+          disabled={false}
+          onClick={[Function]}
+          title="Edit widget"
+          type="button"
+        >
+          <i
+            className="fa fa-pencil"
+          />
+        </button>
+      </div>
+    </div>
+  </div>
+</div>
+`;

--- a/graylog2-web-interface/test/helpers/mocking/c3_mock.jsx
+++ b/graylog2-web-interface/test/helpers/mocking/c3_mock.jsx
@@ -1,0 +1,2 @@
+const c3 = {};
+export default c3;

--- a/graylog2-web-interface/test/setup-jest.jsx
+++ b/graylog2-web-interface/test/setup-jest.jsx
@@ -1,0 +1,4 @@
+import jQuery from 'jquery';
+
+global.$ = jQuery;
+global.jQuery = jQuery;


### PR DESCRIPTION
## Description
A widget on a dashboard has a play button which directs the
user to the search on which the widget is based on.
If the user had no permission to look on the streams (no read
permission on the stream) he got the message:

'The stream is not available, cannot replay search.'

Some user thought that the button was broken, since they assumed
to trigger a update with this button.

To fix the problem we remove the button for users without
the necessary permissions.

Fixes #4120 
Fixes #1874

## How Has This Been Tested?
The tests generate snapshots which i diffed manually to ensure that
the expected result was rendered.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)