### PR TITLE
Check auth realm access on instance level

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/rest/resources/system/authentication/AuthenticationResource.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/resources/system/authentication/AuthenticationResource.java
@@ -35,6 +35,7 @@ import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
 import javax.ws.rs.core.MediaType;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 import static org.graylog2.shared.security.RestPermissions.AUTHENTICATION_EDIT;
 import static org.graylog2.shared.security.RestPermissions.AUTHENTICATION_READ;
@@ -60,11 +61,13 @@ public class AuthenticationResource extends RestResource {
     @GET
     @Path("config")
     @ApiOperation("Retrieve authentication providers configuration")
-    @RequiresPermissions({CLUSTER_CONFIG_ENTRY_READ, AUTHENTICATION_READ})
+    @RequiresPermissions({CLUSTER_CONFIG_ENTRY_READ})
     public AuthenticationConfig getAuthenticators() {
         final AuthenticationConfig config = clusterConfigService.getOrDefault(AuthenticationConfig.class,
                                                                               AuthenticationConfig.defaultInstance());
-        return config.withRealms(availableRealms.keySet());
+        return config.withRealms(availableRealms.keySet().stream()
+                .filter(realmName -> isPermitted(AUTHENTICATION_READ, realmName))
+                .collect(Collectors.toSet()));
     }
 
     @PUT

--- a/graylog2-server/src/main/java/org/graylog2/shared/security/RestPermissions.java
+++ b/graylog2-server/src/main/java/org/graylog2/shared/security/RestPermissions.java
@@ -138,6 +138,8 @@ public class RestPermissions implements PluginPermissions {
     public static final String USERS_TOKENREMOVE = "users:tokenremove";
 
     protected static final ImmutableSet<Permission> PERMISSIONS = ImmutableSet.<Permission>builder()
+        .add(create(AUTHENTICATION_EDIT, ""))
+        .add(create(AUTHENTICATION_READ, ""))
         .add(create(BLACKLISTENTRY_CREATE, ""))
         .add(create(BLACKLISTENTRY_DELETE, ""))
         .add(create(BLACKLISTENTRY_EDIT, ""))


### PR DESCRIPTION
These changes allow the UI to request information about the auth realms without requiring a global permission to do so.
Each realm is check individually, and a user without any access to them gets an empty set instead of a permission error.

This allows the UI to avoid special handling for users editing their own profile information.

Also include the new authentication permissions in the meta resource.

This requires backporting to 2.4 once reviewed.

fixes #4420 
fixes #4442 