### PR TITLE
Check auth realm access on instance level (#4488)

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/rest/resources/system/authentication/AuthenticationResource.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/resources/system/authentication/AuthenticationResource.java
@@ -35,6 +35,7 @@ import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
 import javax.ws.rs.core.MediaType;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 import static org.graylog2.shared.security.RestPermissions.AUTHENTICATION_EDIT;
 import static org.graylog2.shared.security.RestPermissions.AUTHENTICATION_READ;
@@ -60,11 +61,13 @@ public class AuthenticationResource extends RestResource {
     @GET
     @Path("config")
     @ApiOperation("Retrieve authentication providers configuration")
-    @RequiresPermissions({CLUSTER_CONFIG_ENTRY_READ, AUTHENTICATION_READ})
+    @RequiresPermissions({CLUSTER_CONFIG_ENTRY_READ})
     public AuthenticationConfig getAuthenticators() {
         final AuthenticationConfig config = clusterConfigService.getOrDefault(AuthenticationConfig.class,
                                                                               AuthenticationConfig.defaultInstance());
-        return config.withRealms(availableRealms.keySet());
+        return config.withRealms(availableRealms.keySet().stream()
+                .filter(realmName -> isPermitted(AUTHENTICATION_READ, realmName))
+                .collect(Collectors.toSet()));
     }
 
     @PUT

--- a/graylog2-server/src/main/java/org/graylog2/shared/security/RestPermissions.java
+++ b/graylog2-server/src/main/java/org/graylog2/shared/security/RestPermissions.java
@@ -138,6 +138,8 @@ public class RestPermissions implements PluginPermissions {
     public static final String USERS_TOKENREMOVE = "users:tokenremove";
 
     protected static final ImmutableSet<Permission> PERMISSIONS = ImmutableSet.<Permission>builder()
+        .add(create(AUTHENTICATION_EDIT, ""))
+        .add(create(AUTHENTICATION_READ, ""))
         .add(create(BLACKLISTENTRY_CREATE, ""))
         .add(create(BLACKLISTENTRY_DELETE, ""))
         .add(create(BLACKLISTENTRY_EDIT, ""))


### PR DESCRIPTION
* include authentication permissions in meta resource

fixes #4442

* filter authentication provider information by realm names

instead of requiring a global permission, apply the permission check to each
realm to be returned.
this makes it possible to assign more finely grained access, but more importantly
allows the call to succeed even if the user cannot see any realm configuration
in that case the set is merely empty, but it is not a permission violation

this allows users to edit their own profile again

fixes #4420

(cherry picked from commit 5a4376dcae4f84e6e61ce736ecb948825faa1493)
