### PR TITLE
Add support for Java 8 lambda expressions to MetricUtils#map()

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/shared/metrics/MetricUtils.java
+++ b/graylog2-server/src/main/java/org/graylog2/shared/metrics/MetricUtils.java
@@ -93,9 +93,7 @@ public class MetricUtils {
             metricMap.put("metric", ((Gauge) metric).getValue());
             metricMap.put("type", "gauge");
         } else {
-            metricMap.put("metric", metric);
-            // best guess
-            metricMap.put("type", "gauge");
+            throw new IllegalArgumentException("Unknown metric type " + metric.getClass());
         }
         return metricMap;
     }

--- a/graylog2-server/src/main/java/org/graylog2/shared/metrics/MetricUtils.java
+++ b/graylog2-server/src/main/java/org/graylog2/shared/metrics/MetricUtils.java
@@ -87,10 +87,10 @@ public class MetricUtils {
             metricMap.put("metric", buildHistogramMap((Histogram) metric));
             metricMap.put("type", "histogram");
         } else if(metric instanceof Counter) {
-            metricMap.put("metric", ((Counter) metric).getCount());
+            metricMap.put("metric", metric);
             metricMap.put("type", "counter");
         } else if(metric instanceof Gauge) {
-            metricMap.put("metric", ((Gauge) metric).getValue());
+            metricMap.put("metric", metric);
             metricMap.put("type", "gauge");
         } else {
             throw new IllegalArgumentException("Unknown metric type " + metric.getClass());

--- a/graylog2-server/src/test/java/org/graylog2/shared/metrics/MetricUtilsTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/shared/metrics/MetricUtilsTest.java
@@ -16,11 +16,19 @@
  */
 package org.graylog2.shared.metrics;
 
+import com.codahale.metrics.Clock;
 import com.codahale.metrics.Counter;
 import com.codahale.metrics.Gauge;
+import com.codahale.metrics.Histogram;
+import com.codahale.metrics.Meter;
 import com.codahale.metrics.MetricRegistry;
+import com.codahale.metrics.Timer;
+import com.codahale.metrics.UniformReservoir;
 import org.junit.Test;
 
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
@@ -56,4 +64,109 @@ public class MetricUtilsTest {
         }
     }
 
+    @Test
+    public void mapSupportsCounter() {
+        final Counter counter = new Counter();
+        counter.inc(23L);
+
+        final Map<String, Object> map = MetricUtils.map("metric", counter);
+        assertThat(map)
+                .containsEntry("type", "counter")
+                .containsEntry("metric", 23L);
+    }
+
+    @Test
+    public void mapSupportsGauge() {
+        final Gauge<Integer> gauge = new Gauge<Integer>() {
+            @Override
+            public Integer getValue() {
+                return 23;
+            }
+        };
+
+        final Map<String, Object> map = MetricUtils.map("metric", gauge);
+        assertThat(map)
+                .containsEntry("type", "gauge")
+                .containsEntry("metric", 23);
+    }
+
+    @Test
+    public void mapSupportsGaugeLambda() {
+        final Gauge<Integer> gauge = () -> 23;
+
+        final Map<String, Object> map = MetricUtils.map("metric", gauge);
+        assertThat(map)
+                .containsEntry("type", "gauge")
+                .containsEntry("metric", 23);
+    }
+
+    @Test
+    public void mapSupportsHdrHistogram() {
+        final HdrHistogram histogram = new HdrHistogram(1000L, 0);
+        histogram.update(23);
+
+        final Map<String, Object> map = MetricUtils.map("metric", histogram);
+        assertThat(map)
+                .containsEntry("type", "histogram")
+                .extracting("metric")
+                .extracting("count")
+                .containsExactly(1L);
+    }
+
+    @Test
+    public void mapSupportsHistogram() {
+        final Histogram histogram = new Histogram(new UniformReservoir());
+        histogram.update(23);
+
+        final Map<String, Object> map = MetricUtils.map("metric", histogram);
+        assertThat(map)
+                .containsEntry("type", "histogram")
+                .extracting("metric")
+                .extracting("count")
+                .containsExactly(1L);
+    }
+
+    @Test
+    public void mapSupportsMeter() {
+        final Meter meter = new Meter();
+        meter.mark();
+
+        final Map<String, Object> map = MetricUtils.map("metric", meter);
+        assertThat(map)
+                .containsEntry("type", "meter")
+                .extracting("metric")
+                .extracting("rate")
+                .extracting("total")
+                .containsExactly(1L);
+    }
+
+    @Test
+    public void mapSupportsTimer() {
+        final TestClock clock = new TestClock();
+        final Timer timer = new Timer(new UniformReservoir(), clock);
+        try (Timer.Context time = timer.time()) {
+            clock.setTick(5000L);
+        }
+
+        final Map<String, Object> map = MetricUtils.map("metric", timer);
+        assertThat(map)
+                .containsEntry("type", "timer")
+                .extracting("metric")
+                .extracting("rate")
+                .extracting("total")
+                .containsExactly(1.0D);
+    }
+
+    private static class TestClock extends Clock {
+        private long tick = 0L;
+
+        @Override
+        public long getTick() {
+            return tick;
+        }
+
+        public void setTick(long tick) {
+            this.tick = tick;
+        }
+    }
 }

--- a/graylog2-server/src/test/java/org/graylog2/shared/metrics/MetricUtilsTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/shared/metrics/MetricUtilsTest.java
@@ -74,7 +74,9 @@ public class MetricUtilsTest {
         final Map<String, Object> map = MetricUtils.map("metric", counter);
         assertThat(map)
                 .containsEntry("type", "counter")
-                .containsEntry("metric", 23L);
+                .extracting("metric")
+                .extracting("count")
+                .containsExactly(23L);
     }
 
     @Test
@@ -89,7 +91,9 @@ public class MetricUtilsTest {
         final Map<String, Object> map = MetricUtils.map("metric", gauge);
         assertThat(map)
                 .containsEntry("type", "gauge")
-                .containsEntry("metric", 23);
+                .extracting("metric")
+                .extracting("value")
+                .containsExactly(23);
     }
 
     @Test
@@ -99,7 +103,9 @@ public class MetricUtilsTest {
         final Map<String, Object> map = MetricUtils.map("metric", gauge);
         assertThat(map)
                 .containsEntry("type", "gauge")
-                .containsEntry("metric", 23);
+                .extracting("metric")
+                .extracting("value")
+                .containsExactly(23);
     }
 
     @Test

--- a/graylog2-server/src/test/java/org/graylog2/shared/metrics/MetricUtilsTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/shared/metrics/MetricUtilsTest.java
@@ -21,6 +21,7 @@ import com.codahale.metrics.Counter;
 import com.codahale.metrics.Gauge;
 import com.codahale.metrics.Histogram;
 import com.codahale.metrics.Meter;
+import com.codahale.metrics.Metric;
 import com.codahale.metrics.MetricRegistry;
 import com.codahale.metrics.Timer;
 import com.codahale.metrics.UniformReservoir;
@@ -29,6 +30,7 @@ import org.junit.Test;
 import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
 import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
@@ -155,6 +157,15 @@ public class MetricUtilsTest {
                 .extracting("rate")
                 .extracting("total")
                 .containsExactly(1.0D);
+    }
+
+    @Test
+    public void mapThrowsIllegalArgumentExceptionForUnknownMetricType() {
+        final Metric metric = new Metric() {};
+
+        assertThatIllegalArgumentException()
+                .isThrownBy(() -> MetricUtils.map("metric", metric))
+                .withMessageStartingWith("Unknown metric type class org.graylog2.shared.metrics.MetricUtilsTest");
     }
 
     private static class TestClock extends Clock {


### PR DESCRIPTION
Lambda expressions in Java 8+ are synthetic classes and return that synthetic class when `#getClass()` is being used, so the "type discovery" in `MetricUtils#map()` didn't work as expected.

Also see https://stackoverflow.com/questions/16827262/how-will-java-lambda-functions-be-compiled and https://gist.github.com/dgageot/5840050 for an example.

Fixes #4493