### PR TITLE
Upgrade jQuery to 3.3.1

### DIFF
--- a/graylog2-web-interface/package.json
+++ b/graylog2-web-interface/package.json
@@ -138,7 +138,7 @@
     "yargs": "^10.0.3"
   },
   "resolutions": {
-    "@types/jquery": "2.0.48",
-    "jquery": "2.1.4"
+    "@types/jquery": "3.3.0",
+    "jquery": "3.3.1"
   }
 }

--- a/graylog2-web-interface/packages/graylog-web-plugin/package.json
+++ b/graylog2-web-interface/packages/graylog-web-plugin/package.json
@@ -39,7 +39,7 @@
     "eslint-config-graylog": "file:../eslint-config-graylog",
     "html-webpack-plugin": "^2.22.0",
     "javascript-natural-sort": "^0.7.1",
-    "jquery": "2.1.x",
+    "jquery": "^3.3.1",
     "moment": "2.14.1",
     "moment-timezone": "0.5.7",
     "prop-types": "^15.5.10",

--- a/graylog2-web-interface/packages/graylog-web-plugin/yarn.lock
+++ b/graylog2-web-interface/packages/graylog-web-plugin/yarn.lock
@@ -2451,9 +2451,9 @@ javascript-natural-sort@^0.7.1:
   version "0.7.1"
   resolved "https://registry.yarnpkg.com/javascript-natural-sort/-/javascript-natural-sort-0.7.1.tgz#f9e2303d4507f6d74355a73664d1440fb5a0ef59"
 
-jquery@2.1.x:
-  version "2.1.4"
-  resolved "https://registry.yarnpkg.com/jquery/-/jquery-2.1.4.tgz#228bde698a0c61431dc2630a6a154f15890d2317"
+jquery@^3.3.1:
+  version "3.3.1"
+  resolved "https://registry.yarnpkg.com/jquery/-/jquery-3.3.1.tgz#958ce29e81c9790f31be7792df5d4d95fc57fbca"
 
 js-tokens@^3.0.0, js-tokens@^3.0.2:
   version "3.0.2"

--- a/graylog2-web-interface/src/components/common/TimezoneSelect.jsx
+++ b/graylog2-web-interface/src/components/common/TimezoneSelect.jsx
@@ -1,7 +1,7 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 import moment from 'moment-timezone';
-import jQuery from 'jquery';
+import lodash from 'lodash';
 
 import Select from 'components/common/Select';
 
@@ -35,6 +35,7 @@ const TimezoneSelect = React.createClass({
 
   _formatTimezones() {
     const timezones = {};
+    // Group time zones by area
     moment.tz.names().forEach((timezone) => {
       const splitted = timezone.split('/');
       const area = (splitted.length > 1 ? splitted[0] : this._UNCLASSIFIED_AREA);
@@ -47,16 +48,24 @@ const TimezoneSelect = React.createClass({
       timezones[area].push(location);
     });
 
-    return [].concat.apply([], Object.keys(timezones).sort().map((area) => {
-      return [{ label: area, disabled: true, value: area }]
-        .concat(jQuery.unique(timezones[area])
-          .sort()
-          .map((location) => {
-            const timezone = (area === this._UNCLASSIFIED_AREA ? location : `${area}/${location}`);
-            return { value: timezone, label: location.replace('_', ' ') };
-          }),
-        );
-    }));
+    const labels = [];
+
+    Object.keys(timezones)
+      .sort()
+      .forEach((area) => {
+        // Add disabled area option to use as TZ separator
+        labels.push({ label: area, disabled: true, value: area });
+
+        // Now add a label per timezone in the area
+        const effectiveTimezones = lodash.uniq(timezones[area]).sort();
+        const timezoneLabels = effectiveTimezones.map((location) => {
+          const timezone = (area === this._UNCLASSIFIED_AREA ? location : `${area}/${location}`);
+          return { value: timezone, label: location.replace('_', ' ') };
+        });
+        labels.push(...timezoneLabels);
+      });
+
+    return labels;
   },
   _renderOption(option) {
     if (!option.disabled) {

--- a/graylog2-web-interface/src/stores/tools/FocusStore.jsx
+++ b/graylog2-web-interface/src/stores/tools/FocusStore.jsx
@@ -4,8 +4,8 @@ import $ from 'jquery';
 const FocusStore = Reflux.createStore({
   focus: true,
   init() {
-    $(window).blur(() => { this.trigger({ focus: false }); this.focus = false; });
-    $(window).focus(() => { this.trigger({ focus: true }); this.focus = true; });
+    $(window).on('blur', () => { this.trigger({ focus: false }); this.focus = false; });
+    $(window).on('focus', () => { this.trigger({ focus: true }); this.focus = true; });
   },
   getInitialState() {
     return { focus: this.focus };

--- a/graylog2-web-interface/yarn.lock
+++ b/graylog2-web-interface/yarn.lock
@@ -6,7 +6,11 @@
   version "3.5.18"
   resolved "https://registry.yarnpkg.com/@types/bluebird/-/bluebird-3.5.18.tgz#6a60435d4663e290f3709898a4f75014f279c4d6"
 
-"@types/jquery@*", "@types/jquery@2.0.48", "@types/jquery@^2.0.0":
+"@types/jquery@*", "@types/jquery@3.3.0":
+  version "3.3.0"
+  resolved "https://registry.yarnpkg.com/@types/jquery/-/jquery-3.3.0.tgz#6316ac20a1a13c5d521a2dc661befc7184f73f5b"
+
+"@types/jquery@^2.0.0":
   version "2.0.48"
   resolved "https://registry.yarnpkg.com/@types/jquery/-/jquery-2.0.48.tgz#3e90d8cde2d29015e5583017f7830cb3975b2eef"
 
@@ -3354,7 +3358,7 @@ graceful-fs@^4.1.11, graceful-fs@^4.1.2, graceful-fs@^4.1.6, graceful-fs@^4.1.9:
     eslint-config-graylog "file:../../../../../.cache/yarn/v1/eslint-config-graylog"
     html-webpack-plugin "^2.22.0"
     javascript-natural-sort "^0.7.1"
-    jquery "2.1.x"
+    jquery "^3.3.1"
     moment "2.14.1"
     moment-timezone "0.5.7"
     prop-types "^15.5.10"
@@ -4434,9 +4438,9 @@ jquery-ui@1.12.x:
   version "1.12.1"
   resolved "https://registry.yarnpkg.com/jquery-ui/-/jquery-ui-1.12.1.tgz#bcb4045c8dd0539c134bc1488cdd3e768a7a9e51"
 
-jquery@2.1.4, jquery@2.1.x, jquery@>=1.7:
-  version "2.1.4"
-  resolved "https://registry.yarnpkg.com/jquery/-/jquery-2.1.4.tgz#228bde698a0c61431dc2630a6a154f15890d2317"
+jquery@3.3.1, jquery@>=1.12.0, jquery@>=1.7, jquery@^3.3.1:
+  version "3.3.1"
+  resolved "https://registry.yarnpkg.com/jquery/-/jquery-3.3.1.tgz#958ce29e81c9790f31be7792df5d4d95fc57fbca"
 
 js-base64@^2.1.9:
   version "2.3.2"
@@ -6336,7 +6340,7 @@ rc@^1.1.7:
     minimist "^1.2.0"
     strip-json-comments "~2.0.1"
 
-react-ace@^5.8.0:
+react-ace@^5.9.0:
   version "5.9.0"
   resolved "https://registry.yarnpkg.com/react-ace/-/react-ace-5.9.0.tgz#427a1cc4869b960a6f9748aa7eb169a9269fc336"
   dependencies:
@@ -7679,8 +7683,10 @@ to-fast-properties@^1.0.3:
   resolved "https://registry.yarnpkg.com/to-fast-properties/-/to-fast-properties-1.0.3.tgz#b83571fa4d8c25b82e231b06e3a3055de4ca1a47"
 
 toastr@^2.1.2:
-  version "2.1.2"
-  resolved "https://registry.yarnpkg.com/toastr/-/toastr-2.1.2.tgz#fd69066ae7578a5b3357725fc9c7c335e9b681df"
+  version "2.1.4"
+  resolved "https://registry.yarnpkg.com/toastr/-/toastr-2.1.4.tgz#8b43be64fb9d0c414871446f2db8e8ca4e95f181"
+  dependencies:
+    jquery ">=1.12.0"
 
 toposort@^1.0.0:
   version "1.0.6"


### PR DESCRIPTION
Also bump dependencies relying on jQuery (currently only toastr has a new bugfix version).

As this is a long version jump and there are many changes in jQuery as you can see in the release notes for [3.0](https://blog.jquery.com/2016/06/09/jquery-3-0-final-released/), [3.1](https://blog.jquery.com/2016/07/07/jquery-3-1-0-released-no-more-silent-errors/), [3.2](https://blog.jquery.com/2017/03/16/jquery-3-2-0-is-out/), and [3.3](https://blog.jquery.com/2018/01/19/jquery-3-3-0-a-fragrant-bouquet-of-deprecations-and-is-that-a-new-feature/).

Fortunately for us, 3.0 was developed with backwards compatibility in mind, so most of the changes that affect us are deprecations. On the other hand, most of the jQuery code we run is coming through 3rd party plugins, so we may have some problems to get fixes in them.

As recommended, I'm running the web interface with the [jQuery Migrate plugin](https://github.com/jquery/jquery-migrate/#README) to be able to see deprecations and changes we need to address.