### PR TITLE
Fixed CSS rules for main-nav dropdown

### DIFF
--- a/graylog2-web-interface/public/stylesheets/graylog2.less
+++ b/graylog2-web-interface/public/stylesheets/graylog2.less
@@ -2234,20 +2234,20 @@ dl.message-details dd div.message-field-actions {
   z-index: 20;
 }
 
-div#navigation-bar ul.dropdown-menu li a {
+nav.navbar-fixed-top ul.dropdown-menu li a {
   font-size: 12px;
 }
 
-div#navigation-bar ul.dropdown-menu {
+nav.navbar-fixed-top ul.dropdown-menu {
   padding-top: 10px;
   padding-bottom: 10px;
 }
 
-div#navigation-bar ul.dropdown-menu li {
+nav.navbar-fixed-top ul.dropdown-menu li {
   padding: 2px 2px 2px 0;
 }
 
-div#navigation-bar ul.dropdown-menu li.divider {
+nav.navbar-fixed-top ul.dropdown-menu li.divider {
   padding: 0;
 }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
After merging graylog-web interface into the server and React rewrite, the main navbar is not wrapped in `div#navigation-bar` anymore, so those CSS rules don't match. This triggers the default bootstrap rules with bigger font (14px vs 12px) and smaller paddings.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
I've been in a long-term relationship with Graylog, so the first thing I noticed when we were finally able to upgrade, was the different dropdown appearance... this will make it beautiful again.

## Screenshots (1.3.4 vs 2.4.1):

<img width="155" alt="screen shot 2018-01-24 at 00 29 38" src="https://user-images.githubusercontent.com/4599319/35306497-5e0fe420-009e-11e8-8b10-67422868c57e.png">
<img width="152" alt="screen shot 2018-01-24 at 00 29 54" src="https://user-images.githubusercontent.com/4599319/35306496-5df2f946-009e-11e8-804b-0b16dab024fa.png">


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)