### PR TITLE
Log reason for message being incomplete on TRACE

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/plugin/Message.java
+++ b/graylog2-server/src/main/java/org/graylog2/plugin/Message.java
@@ -196,6 +196,9 @@ public class Message implements Messages {
         for (final String key : REQUIRED_FIELDS) {
             final Object field = getField(key);
             if (field == null || field instanceof String && ((String) field).isEmpty()) {
+                if (LOG.isTraceEnabled()) {
+                    LOG.trace("Message <{}> is incomplete because the field <{}> is <{}>", fields.get(FIELD_ID), key, field);
+                }
                 return false;
             }
         }


### PR DESCRIPTION
The `Message#isComplete()` function checks whether all mandatory message fields exist and aren't empty.

This change set adds useful debugging information on TRACE level about missing or empty mandatory fields.

Refs https://community.graylog.org/t/filebeat-logs-dropped-out/3929