### PR TITLE
Fixing relative time range used by RecentMessageLoader.

### DIFF
--- a/graylog2-web-interface/src/components/messageloaders/RecentMessageLoader.jsx
+++ b/graylog2-web-interface/src/components/messageloaders/RecentMessageLoader.jsx
@@ -26,7 +26,7 @@ const RecentMessageLoader = React.createClass({
     }
     this.setState({ loading: true });
     const promise = UniversalSearchStore.search('relative', `gl2_source_input:${inputId} OR gl2_source_radio_input:${inputId}`,
-      { range: 3600 }, undefined, 1, undefined, undefined, undefined, false);
+      { relative: 3600 }, undefined, 1, undefined, undefined, undefined, false);
     promise.then((response) => {
       if (response.total_results > 0) {
         this.props.onMessageLoaded(response.messages[0]);


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

The RecentMessageLoader component is trying to limit the range of the
search request it used to get the last received message of an input to
the last hour. For this, it uses the `range` parameter. This is the
correct parameter name for the backend, but the web interface uses a
small conversion helper that expects the parameter to be named
`relative` for relative time ranges, according to the naming in the old
web interface.

To make the fix as small as possible for a point release, this change
just uses the `relative` parameter. For `master` and subsequent releases
we should either switch over to the `range` parameter or use it in case
the `relative` parameter is not present. This way we do not discourage
consumers of the `UniversalSearchStore` to use the actually correct
parameter naming.

Fixes #4510.

<!--- Provide a general summary of your changes in the Title above -->
## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
