### PR TITLE
Fixing relative time range used by RecentMessageLoader.

### DIFF
--- a/graylog2-web-interface/src/stores/search/UniversalSearchStore.js
+++ b/graylog2-web-interface/src/stores/search/UniversalSearchStore.js
@@ -52,7 +52,7 @@ const UniversalSearchStore = Reflux.createStore({
 UniversalSearchStore.extractTimeRange = (type, timerange) => {
   // The server API uses the `range` parameter instead of `relative` for indicating a relative time range.
   if (type === 'relative') {
-    return { range: timerange.relative };
+    return { range: timerange.range || timerange.relative };
   }
 
   return timerange;


### PR DESCRIPTION
## Description
## Motivation and Context

The RecentMessageLoader component is trying to limit the range of the
search request it uses to get the last received message of an input to
the last hour. For this, it uses the range parameter. This is the
correct parameter name for the backend, but the web interface uses a
small conversion helper that expects the parameter to be named
relative for relative time ranges, according to the naming in the old
web interface.

This fix is changing the conversion helper to actually also take the
`range` parameter into account and use it if present, otherwise it uses
the `relative` parameter.

Fixes #4510.

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
