### PR TITLE
Properly handle timestamp field in stacked quickvalues

### DIFF
--- a/graylog2-web-interface/src/components/field-analyzers/FieldQuickValues.jsx
+++ b/graylog2-web-interface/src/components/field-analyzers/FieldQuickValues.jsx
@@ -312,6 +312,13 @@ const FieldQuickValues = React.createClass({
         </DropdownButton>
       );
 
+      let fields;
+      if (!this.state.options.stackedFields) {
+        fields = this.state.field;
+      } else {
+        fields = `${this.state.field}, ${this.state.options.stackedFields}`;
+      }
+
       content = (
         <div className="content-col">
           <div className="pull-right">
@@ -324,7 +331,7 @@ const FieldQuickValues = React.createClass({
               <Button bsSize="small" onClick={() => this._resetStatus()}><i className="fa fa-close" /></Button>
             </AddToDashboardMenu>
           </div>
-          <h1>Quick Values for <em>{this.state.field}</em> {this.state.loadPending && <i
+          <h1>Quick Values for <em>{fields}</em> {this.state.loadPending && <i
             className="fa fa-spin fa-spinner" />}</h1>
 
           {inner}

--- a/graylog2-web-interface/src/components/field-analyzers/FieldQuickValues.jsx
+++ b/graylog2-web-interface/src/components/field-analyzers/FieldQuickValues.jsx
@@ -281,6 +281,7 @@ const FieldQuickValues = React.createClass({
         <div className={style.visualizationWrapper}>
           <QuickValuesVisualization id={this.state.field}
                                     field={this.state.field}
+                                    fields={[this.state.field].concat(this.state.options.stackedFields.split(','))}
                                     config={config}
                                     data={this.state.data}
                                     horizontal

--- a/graylog2-web-interface/src/components/visualizations/QuickValuesVisualization.jsx
+++ b/graylog2-web-interface/src/components/visualizations/QuickValuesVisualization.jsx
@@ -184,6 +184,16 @@ const QuickValuesVisualization = React.createClass({
 
     return addToSearchButton.outerHTML;
   },
+  _getFieldName(i) {
+    if (this.props.fields.length === 0) {
+      // calculate the fields from the data props
+      const anyKey = Object.keys(this.props.data.terms_mapping)[0];
+      const fields = this.props.data.terms_mapping[anyKey].map(a => a.field);
+      return fields[i];
+    } else {
+      return this.props.fields[i];
+    }
+  },
   _getDataTableColumns() {
     function formatTimestamp(timestamp) {
       return new DateTime(Number(timestamp)).toString(DateTime.Formats.TIMESTAMP);
@@ -199,7 +209,7 @@ const QuickValuesVisualization = React.createClass({
           // Separate the terms with a character that is unusual in terms and use a different text color to make the
           // different terms in the stacked value more visible.
           formattedTerm = this.props.data.terms_mapping[d.term]
-            .map((t, i) => (this.props.fields[i] === 'timestamp' ? formatTimestamp(t.value) : t.value))
+            .map((t, i) => (this._getFieldName(i) === 'timestamp' ? formatTimestamp(t.value) : t.value))
             .join(' <strong style="color: #999999;">&mdash;</strong> ');
         } else if (this.props.field === 'timestamp') { // only a single field, just check for the timestamp
           // convert unix timestamp to proper formatted value, so that add to search button works correctly

--- a/graylog2-web-interface/src/components/visualizations/QuickValuesVisualization.jsx
+++ b/graylog2-web-interface/src/components/visualizations/QuickValuesVisualization.jsx
@@ -185,8 +185,8 @@ const QuickValuesVisualization = React.createClass({
     return addToSearchButton.outerHTML;
   },
   _getDataTableColumns() {
-    function formatTimestamp(d) {
-      return new DateTime(Number(d.term)).toString(DateTime.Formats.TIMESTAMP);
+    function formatTimestamp(timestamp) {
+      return new DateTime(Number(timestamp)).toString(DateTime.Formats.TIMESTAMP);
     }
 
     const columns = [
@@ -203,7 +203,7 @@ const QuickValuesVisualization = React.createClass({
             .join(' <strong style="color: #999999;">&mdash;</strong> ');
         } else if (this.props.field === 'timestamp') { // only a single field, just check for the timestamp
           // convert unix timestamp to proper formatted value, so that add to search button works correctly
-          formattedTerm = formatTimestamp(d);
+          formattedTerm = formatTimestamp(d.term);
         }
         if (typeof this.pieChart !== 'undefined' && this.dataTable.group()(d) !== 'Others') {
           const colour = this.pieChart.colors()(d.term);

--- a/graylog2-web-interface/src/components/visualizations/QuickValuesVisualization.jsx
+++ b/graylog2-web-interface/src/components/visualizations/QuickValuesVisualization.jsx
@@ -53,7 +53,7 @@ const QuickValuesVisualization = React.createClass({
   getDefaultProps() {
     return {
       config: this.DEFAULT_CONFIG,
-      allFields: [],
+      fields: [],
       width: undefined,
       height: undefined,
       horizontal: false,

--- a/graylog2-web-interface/src/components/visualizations/QuickValuesVisualization.jsx
+++ b/graylog2-web-interface/src/components/visualizations/QuickValuesVisualization.jsx
@@ -1,7 +1,7 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 import Immutable from 'immutable';
-import { Panel, ListGroup, ListGroupItem } from 'react-bootstrap';
+import { ListGroup, ListGroupItem, Panel } from 'react-bootstrap';
 import crossfilter from 'crossfilter';
 import dc from 'dc';
 import d3 from 'd3';
@@ -33,6 +33,7 @@ const QuickValuesVisualization = React.createClass({
   propTypes: {
     id: PropTypes.string.isRequired,
     field: PropTypes.string.isRequired,
+    fields: PropTypes.arrayOf(PropTypes.string).isRequired,
     config: PropTypes.shape({
       show_pie_chart: PropTypes.bool,
       show_data_table: PropTypes.bool,
@@ -52,6 +53,7 @@ const QuickValuesVisualization = React.createClass({
   getDefaultProps() {
     return {
       config: this.DEFAULT_CONFIG,
+      allFields: [],
       width: undefined,
       height: undefined,
       horizontal: false,
@@ -192,12 +194,14 @@ const QuickValuesVisualization = React.createClass({
         let colourBadge = '';
 
         let formattedTerm = d.term;
+        // if we have terms_mapping, this is a stacked quick values, check every term for its field type
         if (this.props.data.terms_mapping && this.props.data.terms_mapping[d.term]) {
           // Separate the terms with a character that is unusual in terms and use a different text color to make the
           // different terms in the stacked value more visible.
-          formattedTerm = this.props.data.terms_mapping[d.term].map(t => t.value).join(' <strong style="color: #999999;">&mdash;</strong> ');
-        }
-        if (this.props.field === 'timestamp') {
+          formattedTerm = this.props.data.terms_mapping[d.term]
+            .map((t, i) => (this.props.fields[i] === 'timestamp' ? formatTimestamp(t.value) : t.value))
+            .join(' <strong style="color: #999999;">&mdash;</strong> ');
+        } else if (this.props.field === 'timestamp') { // only a single field, just check for the timestamp
           // convert unix timestamp to proper formatted value, so that add to search button works correctly
           formattedTerm = formatTimestamp(d);
         }
@@ -213,12 +217,10 @@ const QuickValuesVisualization = React.createClass({
     ];
 
     if (this.props.displayAddToSearchButton) {
-      if (this.props.field === 'timestamp') {
-        // convert unix timestamp to proper formatted value, so that add to search button works correctly
-        columns.push(d => this._getAddToSearchButton(formatTimestamp(d)));
-      } else {
-        columns.push(d => this._getAddToSearchButton(d.term));
-      }
+      // the timestamp formatting needs to be done in SearchStore.addSearchTerm based on the parameter `field`
+      // if we format it here, it won't match the raw data and not all fields will be added if the first stacked
+      // field is timestamp. See https://github.com/Graylog2/graylog2-server/issues/4509
+      columns.push(d => this._getAddToSearchButton(d.term));
     }
 
     return columns;

--- a/graylog2-web-interface/src/stores/search/SearchStore.ts
+++ b/graylog2-web-interface/src/stores/search/SearchStore.ts
@@ -229,8 +229,7 @@ class SearchStore {
     appendToQueryString(query: string, field: string, value: any, operator: any) {
       let effectiveValue = value;
       if (field === 'timestamp') {
-        const dateTime = new DateTime(Number(value)).toTimeZone('UTC');
-        effectiveValue = dateTime.toString(DateTime.Formats.TIMESTAMP);
+        effectiveValue = new DateTime(Number(value)).toString(DateTime.Formats.TIMESTAMP);
       }
       const term = `${field}:${SearchStore.escape(effectiveValue)}`;
       const effectiveOperator = operator || SearchStore.AND_OPERATOR;

--- a/graylog2-web-interface/src/stores/search/SearchStore.ts
+++ b/graylog2-web-interface/src/stores/search/SearchStore.ts
@@ -229,7 +229,7 @@ class SearchStore {
     appendToQueryString(query: string, field: string, value: any, operator: any) {
       let effectiveValue = value;
       if (field === 'timestamp') {
-        const dateTime = new DateTime(value).toTimeZone('UTC');
+        const dateTime = new DateTime(Number(value)).toTimeZone('UTC');
         effectiveValue = dateTime.toString(DateTime.Formats.TIMESTAMP);
       }
       const term = `${field}:${SearchStore.escape(effectiveValue)}`;


### PR DESCRIPTION
In certain scenarios the timestamp field was not properly formatted when being used in stacked quickvalues.

If the timestamp field wasn't the first field of the stack, it failed to be formatted.
Additionally, adding it to the query either dropped later fields or misconverted the timezone.

Widget rendering was also affected, although there it cannot be added to a search query so the "Add to query" issue did not happen.

fixes #4509 