### PR TITLE
Display Timestamp in User Timezone

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/rest/resources/users/UsersResource.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/resources/users/UsersResource.java
@@ -517,7 +517,7 @@ public class UsersResource extends RestResource {
                 user.getFullName(),
                 includePermissions ? userService.getPermissionsForUser(user) : Collections.emptyList(),
                 user.getPreferences(),
-                firstNonNull(user.getTimeZone(), DateTimeZone.UTC).getID(),
+                user.getTimeZone() == null ? null : user.getTimeZone().getID(),
                 user.getSessionTimeoutMs(),
                 user.isReadOnly(),
                 user.isExternalUser(),

--- a/graylog2-server/src/main/java/org/graylog2/users/UserImpl.java
+++ b/graylog2-server/src/main/java/org/graylog2/users/UserImpl.java
@@ -273,10 +273,9 @@ public class UserImpl extends PersistedImpl implements User {
         DateTimeZone dateTimeZone = null;
         if (timeZone != null) {
             try {
-                dateTimeZone = DateTimeZone.forID(firstNonNull(timeZone, DateTimeZone.UTC.getID()));
+                dateTimeZone = DateTimeZone.forID(timeZone);
             } catch (IllegalArgumentException e) {
-                LOG.info("Invalid timezone \"{}\", falling back to UTC.", timeZone);
-                dateTimeZone = DateTimeZone.UTC;
+                LOG.error("Invalid timezone \"{}\", falling back to UTC.", timeZone);
             }
         }
         setTimeZone(dateTimeZone);

--- a/graylog2-server/src/main/java/org/graylog2/users/UserImpl.java
+++ b/graylog2-server/src/main/java/org/graylog2/users/UserImpl.java
@@ -270,20 +270,21 @@ public class UserImpl extends PersistedImpl implements User {
 
     @Override
     public void setTimeZone(final String timeZone) {
-        DateTimeZone dateTimeZone;
-        try {
-            dateTimeZone = DateTimeZone.forID(firstNonNull(timeZone, DateTimeZone.UTC.getID()));
-        } catch (IllegalArgumentException e) {
-            LOG.info("Invalid timezone \"{}\", falling back to UTC.", timeZone);
-            dateTimeZone = DateTimeZone.UTC;
+        DateTimeZone dateTimeZone = null;
+        if (timeZone != null) {
+            try {
+                dateTimeZone = DateTimeZone.forID(firstNonNull(timeZone, DateTimeZone.UTC.getID()));
+            } catch (IllegalArgumentException e) {
+                LOG.info("Invalid timezone \"{}\", falling back to UTC.", timeZone);
+                dateTimeZone = DateTimeZone.UTC;
+            }
         }
-
         setTimeZone(dateTimeZone);
     }
 
     @Override
     public void setTimeZone(final DateTimeZone timeZone) {
-        fields.put(TIMEZONE, timeZone.getID());
+        fields.put(TIMEZONE, timeZone == null ? null : timeZone.getID());
     }
 
     @Override

--- a/graylog2-web-interface/src/components/search/MessageDetail.jsx
+++ b/graylog2-web-interface/src/components/search/MessageDetail.jsx
@@ -23,7 +23,7 @@ const MessageDetail = React.createClass({
     expandAllRenderAsync: PropTypes.bool,
     showTimestamp: PropTypes.bool,
     disableFieldActions: PropTypes.bool,
-    possiblyHighlight: PropTypes.func,
+    renderForDisplay: PropTypes.func,
     inputs: PropTypes.object,
     nodes: PropTypes.object,
     message: PropTypes.object,
@@ -263,7 +263,7 @@ const MessageDetail = React.createClass({
         <Col md={9}>
           <div ref="messageList">
             <MessageFields message={this.props.message}
-                           possiblyHighlight={this.props.possiblyHighlight}
+                           renderForDisplay={this.props.renderForDisplay}
                            disableFieldActions={this.props.disableFieldActions}
                            customFieldActions={this.props.customFieldActions}
                            showDecoration={this.state.showOriginal}

--- a/graylog2-web-interface/src/components/search/MessageField.jsx
+++ b/graylog2-web-interface/src/components/search/MessageField.jsx
@@ -9,7 +9,7 @@ const MessageField = React.createClass({
     disableFieldActions: PropTypes.bool,
     fieldName: PropTypes.string.isRequired,
     message: PropTypes.object.isRequired,
-    possiblyHighlight: PropTypes.func.isRequired,
+    renderForDisplay: PropTypes.func.isRequired,
     value: PropTypes.any.isRequired,
   },
   SPECIAL_FIELDS: ['full_message', 'level'],
@@ -38,7 +38,7 @@ const MessageField = React.createClass({
                                  message={this.props.message}
                                  fieldName={key}
                                  fieldValue={innerValue}
-                                 possiblyHighlight={this.props.possiblyHighlight}
+                                 renderForDisplay={this.props.renderForDisplay}
                                  disableFieldActions={this._isAdded(key) || this.props.disableFieldActions}
                                  customFieldActions={this.props.customFieldActions}
                                  isDecorated={this._isDecorated(key)} />

--- a/graylog2-web-interface/src/components/search/MessageFieldDescription.jsx
+++ b/graylog2-web-interface/src/components/search/MessageFieldDescription.jsx
@@ -20,7 +20,7 @@ const MessageFieldDescription = React.createClass({
     message: PropTypes.object.isRequired,
     fieldName: PropTypes.string.isRequired,
     fieldValue: PropTypes.any.isRequired,
-    possiblyHighlight: PropTypes.func.isRequired,
+    renderForDisplay: PropTypes.func.isRequired,
     disableFieldActions: PropTypes.bool,
     customFieldActions: PropTypes.node,
     isDecorated: PropTypes.bool,
@@ -79,7 +79,7 @@ const MessageFieldDescription = React.createClass({
     return (
       <dd className={className} key={`${this.props.fieldName}dd`}>
         {this._getFormattedFieldActions()}
-        <div className="field-value">{this.props.possiblyHighlight(this.props.fieldName)}</div>
+        <div className="field-value">{this.props.renderForDisplay(this.props.fieldName)}</div>
         {this._shouldShowTerms() &&
         <Alert bsStyle="info" onDismiss={() => this.setState({ messageTerms: Immutable.Map() })}>
           Field terms: &nbsp;{this._getFormattedTerms()}

--- a/graylog2-web-interface/src/components/search/MessageFields.jsx
+++ b/graylog2-web-interface/src/components/search/MessageFields.jsx
@@ -8,7 +8,7 @@ const MessageFields = React.createClass({
     customFieldActions: PropTypes.node,
     disableFieldActions: PropTypes.bool,
     message: PropTypes.object.isRequired,
-    possiblyHighlight: PropTypes.func.isRequired,
+    renderForDisplay: PropTypes.func.isRequired,
     showDecoration: PropTypes.bool,
   },
 

--- a/graylog2-web-interface/src/components/search/MessageShow.jsx
+++ b/graylog2-web-interface/src/components/search/MessageShow.jsx
@@ -28,7 +28,7 @@ const MessageShow = React.createClass({
     };
   },
 
-  possiblyHighlight(fieldName) {
+  renderForDisplay(fieldName) {
     // No highlighting for the message details view.
     return StringUtils.stringify(this.props.message.fields[fieldName]);
   },
@@ -40,7 +40,7 @@ const MessageShow = React.createClass({
                                          inputs={this.props.inputs}
                                          streams={this.state.streams}
                                          nodes={this.state.nodes}
-                                         possiblyHighlight={this.possiblyHighlight}
+                                         renderForDisplay={this.renderForDisplay}
                                          showTimestamp />
         </Col>
       </Row>

--- a/graylog2-web-interface/src/components/search/MessageTableEntry.css
+++ b/graylog2-web-interface/src/components/search/MessageTableEntry.css
@@ -1,0 +1,3 @@
+:local .timezoneInfo {
+    color: #cccccc;
+}

--- a/graylog2-web-interface/src/components/search/MessageTableEntry.css
+++ b/graylog2-web-interface/src/components/search/MessageTableEntry.css
@@ -1,3 +1,3 @@
 :local .timezoneInfo {
-    color: #cccccc;
+    color: #aaa;
 }

--- a/graylog2-web-interface/src/components/search/MessageTableEntry.jsx
+++ b/graylog2-web-interface/src/components/search/MessageTableEntry.jsx
@@ -7,8 +7,7 @@ import MessageDetail from './MessageDetail';
 import { Timestamp } from 'components/common';
 import StringUtils from 'util/StringUtils';
 import DateTime from 'logic/datetimes/DateTime';
-
-const style = require('!style!css!./MessageTableEntry.css');
+import style from './MessageTableEntry.css';
 
 const MessageTableEntry = React.createClass({
   propTypes: {

--- a/graylog2-web-interface/src/components/search/MessageTableEntry.jsx
+++ b/graylog2-web-interface/src/components/search/MessageTableEntry.jsx
@@ -116,7 +116,7 @@ const MessageTableEntry = React.createClass({
 
   _toUserTime(value) {
     const dateTime = new DateTime(value);
-    return dateTime.toString(DateTime.Formats.TIMESTAMP);
+    return dateTime.toString(DateTime.Formats.TIMESTAMP_TZ);
   },
 
   render() {

--- a/graylog2-web-interface/src/components/search/MessageTableEntry.test.jsx
+++ b/graylog2-web-interface/src/components/search/MessageTableEntry.test.jsx
@@ -12,6 +12,7 @@ import { mount } from 'enzyme';
 import MessageTableEntry from 'components/search/MessageTableEntry';
 
 describe('<MessageTableEntry />', () => {
+  DateTime.getBrowserTimezone = () => { return 'Europe/Berlin'; };
   const allStreams = Immutable.List([
     { id: '01', description: 'stream1' },
     { id: '02', description: 'stream2' },

--- a/graylog2-web-interface/src/components/search/MessageTableEntry.test.jsx
+++ b/graylog2-web-interface/src/components/search/MessageTableEntry.test.jsx
@@ -1,0 +1,85 @@
+import React from 'react';
+import renderer from 'react-test-renderer';
+import Immutable from 'immutable';
+import DateTime from 'logic/datetimes/DateTime';
+import {} from 'jquery-ui/ui/version';
+import {} from 'jquery-ui/ui/effect';
+import {} from 'jquery-ui/ui/plugin';
+import {} from 'jquery-ui/ui/widget';
+import {} from 'jquery-ui/ui/widgets/mouse';
+import { mount } from 'enzyme';
+
+import MessageTableEntry from 'components/search/MessageTableEntry';
+
+describe('<MessageTableEntry />', () => {
+  const allStreams = Immutable.List([
+    { id: '01', description: 'stream1' },
+    { id: '02', description: 'stream2' },
+  ]);
+  const streams = Immutable.Map({ '01': { id: '01', description: 'stream1' } });
+  const inputs = Immutable.Map({ '00001': { id: '00001', title: 'syslog', name: 'syslog' } });
+  const message = {
+    fields: { message: '2018-01-22T15:36:02.189Z foo', timestamp: '2018-01-22T15:36:02.189Z' },
+    formatted_fields: { message: '2018-01-22T15:36:02.189Z foo', timestamp: '2018-01-22T15:36:02.189Z' },
+    highlight_ranges: {},
+    id: '01',
+    index: '01',
+  };
+  const nodes = Immutable.Map({});
+
+  describe('rendering', () => {
+    it('should render a MessageTableEntry', () => {
+      const wrapper = renderer.create(<MessageTableEntry
+        allStreams={allStreams}
+        allStreamsLoaded
+        disableSurroundingSearch
+        expandAllRenderAsync={false}
+        expanded
+        inputs={inputs}
+        searchConfig={{}}
+        message={message}
+        nodes={nodes}
+        streams={streams}
+        toggleDetail={jest.fn}
+      />);
+      expect(wrapper.toJSON()).toMatchSnapshot();
+    });
+  });
+
+  describe('timezone handling', () => {
+    it('should render a in the UTC timezone', () => {
+      const wrapper = mount(<MessageTableEntry
+        allStreams={allStreams}
+        allStreamsLoaded
+        disableSurroundingSearch
+        expandAllRenderAsync={false}
+        expanded
+        inputs={inputs}
+        searchConfig={{}}
+        message={message}
+        nodes={nodes}
+        streams={streams}
+        toggleDetail={jest.fn}
+      />);
+      expect(wrapper.find('time').text()).toEqual('2018-01-22 16:36:02.189');
+    });
+
+    it('should render a in the USA/Honolulu timezone', () => {
+      DateTime.getBrowserTimezone = () => { return 'Pacific/Honolulu'; };
+      const wrapper = mount(<MessageTableEntry
+        allStreams={allStreams}
+        allStreamsLoaded
+        disableSurroundingSearch
+        expandAllRenderAsync={false}
+        expanded
+        inputs={inputs}
+        searchConfig={{}}
+        message={message}
+        nodes={nodes}
+        streams={streams}
+        toggleDetail={jest.fn}
+      />);
+      expect(wrapper.find('time').text()).toEqual('2018-01-22 05:36:02.189');
+    });
+  });
+});

--- a/graylog2-web-interface/src/components/search/MessageTableEntry.test.jsx
+++ b/graylog2-web-interface/src/components/search/MessageTableEntry.test.jsx
@@ -62,7 +62,7 @@ describe('<MessageTableEntry />', () => {
         streams={streams}
         toggleDetail={jest.fn}
       />);
-      expect(wrapper.find('time').text()).toEqual('2018-01-22 16:36:02.189');
+      expect(wrapper.find('time').at(1).text()).toEqual('2018-01-22 16:36:02.189 +01:00');
     });
 
     it('should render a in the USA/Honolulu timezone', () => {
@@ -80,7 +80,7 @@ describe('<MessageTableEntry />', () => {
         streams={streams}
         toggleDetail={jest.fn}
       />);
-      expect(wrapper.find('time').text()).toEqual('2018-01-22 05:36:02.189');
+      expect(wrapper.find('time').at(1).text()).toEqual('2018-01-22 05:36:02.189 -10:00');
     });
   });
 });

--- a/graylog2-web-interface/src/components/search/__snapshots__/MessageTableEntry.test.jsx.snap
+++ b/graylog2-web-interface/src/components/search/__snapshots__/MessageTableEntry.test.jsx.snap
@@ -580,7 +580,20 @@ exports[`<MessageTableEntry /> rendering should render a MessageTableEntry 1`] =
                     <div
                       className="field-value"
                     >
-                      2018-01-22 16:36:02.189 +01:00
+                      <span>
+                        <time
+                          dateTime="2018-01-22T15:36:02.189Z"
+                          title="2018-01-22T15:36:02.189Z"
+                        >
+                          2018-01-22 16:36:02.189 +01:00
+                        </time>
+                        <i
+                          className="fa fa-fw fa-info timezoneInfo"
+                          onClick={null}
+                          onMouseOut={[Function]}
+                          onMouseOver={[Function]}
+                        />
+                      </span>
                     </div>
                   </dd>
                 </span>

--- a/graylog2-web-interface/src/components/search/__snapshots__/MessageTableEntry.test.jsx.snap
+++ b/graylog2-web-interface/src/components/search/__snapshots__/MessageTableEntry.test.jsx.snap
@@ -1,0 +1,595 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`<MessageTableEntry /> rendering should render a MessageTableEntry 1`] = `
+<tbody
+  className="message-group message-group-toggled"
+>
+  <tr
+    className="fields-row"
+    onClick={[Function]}
+  >
+    <td>
+      <strong>
+        <time
+          dateTime="2018-01-22T15:36:02.189Z"
+          title="2018-01-22T15:36:02.189Z"
+        >
+          2018-01-22 16:36:02.189
+        </time>
+      </strong>
+    </td>
+  </tr>
+  <tr
+    className="message-detail-row"
+    style={
+      Object {
+        "display": "table-row",
+      }
+    }
+  >
+    <td
+      colSpan={1}
+    >
+      <div>
+        <div
+          className="row-sm row"
+        >
+          <div
+            className="col-md-12"
+          >
+            <div
+              className="pull-right btn-group btn-group-sm"
+            >
+              <a
+                className="btn btn-default"
+                href="/messages/01/01"
+                onClick={[Function]}
+                onKeyDown={[Function]}
+              >
+                Permalink
+              </a>
+              <button
+                className="btn btn-default"
+                data-clipboard-action="copy"
+                data-clipboard-button={true}
+                data-clipboard-text="01"
+                disabled={false}
+                onClick={[Function]}
+                style={undefined}
+                title={undefined}
+                type="button"
+              >
+                Copy ID
+              </button>
+              <div
+                className="dropdown btn-group btn-group-sm"
+              >
+                <button
+                  aria-expanded={false}
+                  aria-haspopup={true}
+                  className="dropdown-toggle btn btn-sm btn-default"
+                  disabled={false}
+                  id="select-stream-dropdown"
+                  onClick={[Function]}
+                  onKeyDown={[Function]}
+                  role="button"
+                  type="button"
+                >
+                  Test against stream
+                   
+                  <span
+                    className="caret"
+                  />
+                </button>
+                <ul
+                  aria-labelledby="select-stream-dropdown"
+                  className="dropdown-menu dropdown-menu-right"
+                  role="menu"
+                >
+                  <li
+                    className=""
+                    role="presentation"
+                    style={undefined}
+                  >
+                    <a
+                      action="push"
+                      href="#"
+                      onClick={[Function]}
+                      onKeyDown={[Function]}
+                      role="menuitem"
+                      tabIndex="-1"
+                    />
+                  </li>
+                  <li
+                    className=""
+                    role="presentation"
+                    style={undefined}
+                  >
+                    <a
+                      action="push"
+                      href="#"
+                      onClick={[Function]}
+                      onKeyDown={[Function]}
+                      role="menuitem"
+                      tabIndex="-1"
+                    />
+                  </li>
+                </ul>
+              </div>
+            </div>
+            <h3
+              className="message-details-title"
+            >
+              <i
+                className="fa fa-envelope"
+              />
+               
+              <a
+                action="push"
+                href="#"
+                onClick={[Function]}
+              >
+                01
+              </a>
+            </h3>
+          </div>
+        </div>
+        <div
+          className="row"
+        >
+          <div
+            className="col-md-3"
+          >
+            <dl
+              className="message-details"
+            >
+              <dt>
+                Stored in index
+              </dt>
+              <dd>
+                01
+              </dd>
+            </dl>
+          </div>
+          <div
+            className="col-md-9"
+          >
+            <div>
+              <dl
+                className="message-details message-details-fields"
+              >
+                <span>
+                  <dt>
+                    message
+                  </dt>
+                  <dd
+                    className="message-field"
+                  >
+                    <div
+                      className="message-field-actions pull-right"
+                    >
+                      <div
+                        className="dropdown btn-group btn-group-xs"
+                      >
+                        <button
+                          className="btn btn-xs btn-default"
+                          disabled={false}
+                          onClick={[Function]}
+                          type="button"
+                        >
+                          <i
+                            className="fa fa-search-plus"
+                          />
+                        </button>
+                        <button
+                          aria-expanded={false}
+                          aria-haspopup={true}
+                          aria-label={
+                            <i
+                              className="fa fa-search-plus"
+                            />
+                          }
+                          className="dropdown-toggle btn btn-xs btn-default"
+                          disabled={false}
+                          id="more-actions-dropdown-field-message"
+                          onClick={[Function]}
+                          onKeyDown={[Function]}
+                          role="button"
+                          type="button"
+                        >
+                           
+                          <span
+                            className="caret"
+                          />
+                        </button>
+                        <ul
+                          aria-labelledby="more-actions-dropdown-field-message"
+                          className="dropdown-menu dropdown-menu-right"
+                          role="menu"
+                        >
+                          <li
+                            className="dropdown-submenu left-submenu"
+                            onKeyDown={[Function]}
+                            onSelect={[Function]}
+                          >
+                            <a
+                              href="#"
+                            >
+                              Create extractor for field 
+                              message
+                            </a>
+                            <ul
+                              className="dropdown-menu"
+                            >
+                              <li
+                                className=""
+                                role="presentation"
+                                style={undefined}
+                              >
+                                <a
+                                  href="/system/inputs/undefined/undefined/extractors/new?extractor_type=copy_input&field=message&example_index=01&example_id=01"
+                                  onClick={[Function]}
+                                  onKeyDown={[Function]}
+                                  role="menuitem"
+                                  tabIndex="-1"
+                                >
+                                  Copy input
+                                </a>
+                              </li>
+                              <li
+                                className=""
+                                role="presentation"
+                                style={undefined}
+                              >
+                                <a
+                                  href="/system/inputs/undefined/undefined/extractors/new?extractor_type=grok&field=message&example_index=01&example_id=01"
+                                  onClick={[Function]}
+                                  onKeyDown={[Function]}
+                                  role="menuitem"
+                                  tabIndex="-1"
+                                >
+                                  Grok pattern
+                                </a>
+                              </li>
+                              <li
+                                className=""
+                                role="presentation"
+                                style={undefined}
+                              >
+                                <a
+                                  href="/system/inputs/undefined/undefined/extractors/new?extractor_type=json&field=message&example_index=01&example_id=01"
+                                  onClick={[Function]}
+                                  onKeyDown={[Function]}
+                                  role="menuitem"
+                                  tabIndex="-1"
+                                >
+                                  JSON
+                                </a>
+                              </li>
+                              <li
+                                className=""
+                                role="presentation"
+                                style={undefined}
+                              >
+                                <a
+                                  href="/system/inputs/undefined/undefined/extractors/new?extractor_type=regex&field=message&example_index=01&example_id=01"
+                                  onClick={[Function]}
+                                  onKeyDown={[Function]}
+                                  role="menuitem"
+                                  tabIndex="-1"
+                                >
+                                  Regular expression
+                                </a>
+                              </li>
+                              <li
+                                className=""
+                                role="presentation"
+                                style={undefined}
+                              >
+                                <a
+                                  href="/system/inputs/undefined/undefined/extractors/new?extractor_type=regex_replace&field=message&example_index=01&example_id=01"
+                                  onClick={[Function]}
+                                  onKeyDown={[Function]}
+                                  role="menuitem"
+                                  tabIndex="-1"
+                                >
+                                  Replace with regular expression
+                                </a>
+                              </li>
+                              <li
+                                className=""
+                                role="presentation"
+                                style={undefined}
+                              >
+                                <a
+                                  href="/system/inputs/undefined/undefined/extractors/new?extractor_type=split_and_index&field=message&example_index=01&example_id=01"
+                                  onClick={[Function]}
+                                  onKeyDown={[Function]}
+                                  role="menuitem"
+                                  tabIndex="-1"
+                                >
+                                  Split & Index
+                                </a>
+                              </li>
+                              <li
+                                className=""
+                                role="presentation"
+                                style={undefined}
+                              >
+                                <a
+                                  href="/system/inputs/undefined/undefined/extractors/new?extractor_type=substring&field=message&example_index=01&example_id=01"
+                                  onClick={[Function]}
+                                  onKeyDown={[Function]}
+                                  role="menuitem"
+                                  tabIndex="-1"
+                                >
+                                  Substring
+                                </a>
+                              </li>
+                              <li
+                                className=""
+                                role="presentation"
+                                style={undefined}
+                              >
+                                <a
+                                  href="/system/inputs/undefined/undefined/extractors/new?extractor_type=lookup_table&field=message&example_index=01&example_id=01"
+                                  onClick={[Function]}
+                                  onKeyDown={[Function]}
+                                  role="menuitem"
+                                  tabIndex="-1"
+                                >
+                                  Lookup Table
+                                </a>
+                              </li>
+                            </ul>
+                          </li>
+                          <li
+                            className=""
+                            role="presentation"
+                            style={undefined}
+                          >
+                            <a
+                              href="#"
+                              onClick={[Function]}
+                              onKeyDown={[Function]}
+                              role="menuitem"
+                              tabIndex="-1"
+                            >
+                              Show terms of 
+                              <em>
+                                message
+                              </em>
+                            </a>
+                          </li>
+                        </ul>
+                      </div>
+                    </div>
+                    <div
+                      className="field-value"
+                    >
+                      2018-01-22T15:36:02.189Z foo
+                    </div>
+                  </dd>
+                </span>
+                <span>
+                  <dt>
+                    timestamp
+                  </dt>
+                  <dd
+                    className=""
+                  >
+                    <div
+                      className="message-field-actions pull-right"
+                    >
+                      <div
+                        className="dropdown btn-group btn-group-xs"
+                      >
+                        <button
+                          className="btn btn-xs btn-default"
+                          disabled={false}
+                          onClick={[Function]}
+                          type="button"
+                        >
+                          <i
+                            className="fa fa-search-plus"
+                          />
+                        </button>
+                        <button
+                          aria-expanded={false}
+                          aria-haspopup={true}
+                          aria-label={
+                            <i
+                              className="fa fa-search-plus"
+                            />
+                          }
+                          className="dropdown-toggle btn btn-xs btn-default"
+                          disabled={false}
+                          id="more-actions-dropdown-field-timestamp"
+                          onClick={[Function]}
+                          onKeyDown={[Function]}
+                          role="button"
+                          type="button"
+                        >
+                           
+                          <span
+                            className="caret"
+                          />
+                        </button>
+                        <ul
+                          aria-labelledby="more-actions-dropdown-field-timestamp"
+                          className="dropdown-menu dropdown-menu-right"
+                          role="menu"
+                        >
+                          <li
+                            className="dropdown-submenu left-submenu"
+                            onKeyDown={[Function]}
+                            onSelect={[Function]}
+                          >
+                            <a
+                              href="#"
+                            >
+                              Create extractor for field 
+                              timestamp
+                            </a>
+                            <ul
+                              className="dropdown-menu"
+                            >
+                              <li
+                                className=""
+                                role="presentation"
+                                style={undefined}
+                              >
+                                <a
+                                  href="/system/inputs/undefined/undefined/extractors/new?extractor_type=copy_input&field=timestamp&example_index=01&example_id=01"
+                                  onClick={[Function]}
+                                  onKeyDown={[Function]}
+                                  role="menuitem"
+                                  tabIndex="-1"
+                                >
+                                  Copy input
+                                </a>
+                              </li>
+                              <li
+                                className=""
+                                role="presentation"
+                                style={undefined}
+                              >
+                                <a
+                                  href="/system/inputs/undefined/undefined/extractors/new?extractor_type=grok&field=timestamp&example_index=01&example_id=01"
+                                  onClick={[Function]}
+                                  onKeyDown={[Function]}
+                                  role="menuitem"
+                                  tabIndex="-1"
+                                >
+                                  Grok pattern
+                                </a>
+                              </li>
+                              <li
+                                className=""
+                                role="presentation"
+                                style={undefined}
+                              >
+                                <a
+                                  href="/system/inputs/undefined/undefined/extractors/new?extractor_type=json&field=timestamp&example_index=01&example_id=01"
+                                  onClick={[Function]}
+                                  onKeyDown={[Function]}
+                                  role="menuitem"
+                                  tabIndex="-1"
+                                >
+                                  JSON
+                                </a>
+                              </li>
+                              <li
+                                className=""
+                                role="presentation"
+                                style={undefined}
+                              >
+                                <a
+                                  href="/system/inputs/undefined/undefined/extractors/new?extractor_type=regex&field=timestamp&example_index=01&example_id=01"
+                                  onClick={[Function]}
+                                  onKeyDown={[Function]}
+                                  role="menuitem"
+                                  tabIndex="-1"
+                                >
+                                  Regular expression
+                                </a>
+                              </li>
+                              <li
+                                className=""
+                                role="presentation"
+                                style={undefined}
+                              >
+                                <a
+                                  href="/system/inputs/undefined/undefined/extractors/new?extractor_type=regex_replace&field=timestamp&example_index=01&example_id=01"
+                                  onClick={[Function]}
+                                  onKeyDown={[Function]}
+                                  role="menuitem"
+                                  tabIndex="-1"
+                                >
+                                  Replace with regular expression
+                                </a>
+                              </li>
+                              <li
+                                className=""
+                                role="presentation"
+                                style={undefined}
+                              >
+                                <a
+                                  href="/system/inputs/undefined/undefined/extractors/new?extractor_type=split_and_index&field=timestamp&example_index=01&example_id=01"
+                                  onClick={[Function]}
+                                  onKeyDown={[Function]}
+                                  role="menuitem"
+                                  tabIndex="-1"
+                                >
+                                  Split & Index
+                                </a>
+                              </li>
+                              <li
+                                className=""
+                                role="presentation"
+                                style={undefined}
+                              >
+                                <a
+                                  href="/system/inputs/undefined/undefined/extractors/new?extractor_type=substring&field=timestamp&example_index=01&example_id=01"
+                                  onClick={[Function]}
+                                  onKeyDown={[Function]}
+                                  role="menuitem"
+                                  tabIndex="-1"
+                                >
+                                  Substring
+                                </a>
+                              </li>
+                              <li
+                                className=""
+                                role="presentation"
+                                style={undefined}
+                              >
+                                <a
+                                  href="/system/inputs/undefined/undefined/extractors/new?extractor_type=lookup_table&field=timestamp&example_index=01&example_id=01"
+                                  onClick={[Function]}
+                                  onKeyDown={[Function]}
+                                  role="menuitem"
+                                  tabIndex="-1"
+                                >
+                                  Lookup Table
+                                </a>
+                              </li>
+                            </ul>
+                          </li>
+                          <li
+                            className=""
+                            role="presentation"
+                            style={undefined}
+                          >
+                            <a
+                              href="#"
+                              onClick={[Function]}
+                              onKeyDown={[Function]}
+                              role="menuitem"
+                              tabIndex="-1"
+                            >
+                              Show terms of 
+                              <em>
+                                timestamp
+                              </em>
+                            </a>
+                          </li>
+                        </ul>
+                      </div>
+                    </div>
+                    <div
+                      className="field-value"
+                    >
+                      2018-01-22 16:36:02.189
+                    </div>
+                  </dd>
+                </span>
+              </dl>
+            </div>
+          </div>
+        </div>
+      </div>
+    </td>
+  </tr>
+</tbody>
+`;

--- a/graylog2-web-interface/src/components/search/__snapshots__/MessageTableEntry.test.jsx.snap
+++ b/graylog2-web-interface/src/components/search/__snapshots__/MessageTableEntry.test.jsx.snap
@@ -580,7 +580,7 @@ exports[`<MessageTableEntry /> rendering should render a MessageTableEntry 1`] =
                     <div
                       className="field-value"
                     >
-                      2018-01-22 16:36:02.189
+                      2018-01-22 16:36:02.189 +01:00
                     </div>
                   </dd>
                 </span>

--- a/graylog2-web-interface/src/logic/datetimes/DateTime.js
+++ b/graylog2-web-interface/src/logic/datetimes/DateTime.js
@@ -60,7 +60,15 @@ class DateTime {
   }
 
   static getUserTimezone() {
-    return currentUser ? currentUser.timezone : AppConfig.rootTimeZone();
+    if (currentUser && currentUser.timezone) {
+      return currentUser.timezone;
+    } else {
+      return this.getBrowserTimezone() || AppConfig.rootTimeZone() || 'UTC';
+    }
+  }
+
+  static getBrowserTimezone() {
+    return moment.tz.guess();
   }
 
   constructor(dateTime) {


### PR DESCRIPTION
## Description
Display timestamps on the search page in the timezone of the user. The timezone of the user
is either the user setting or the timezone of the browser.

Additionally make it possible for a user to unset his timezone setting so the Graylog gui
can use the browser timezone.

## Motivation and Context
The user saw timestamps in UTC even though he set his browser and user setting to
his timezone.

## How Has This Been Tested?
Started browser in timezone US Pacific with:
 TZ="US/Pacific" google-chrome "--user-data-dir=$HOME/chrome-profile"
Set and unset the timezone of the user.

Partially Fixes #2689 
For the CSV Export I'll open an other issue.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
