### PR TITLE
Prevent ldap server password leak

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/rest/models/system/ldap/requests/LdapSettingsRequest.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/models/system/ldap/requests/LdapSettingsRequest.java
@@ -39,6 +39,7 @@ public abstract class LdapSettingsRequest {
     public abstract String systemUsername();
 
     @JsonProperty
+    @Nullable
     public abstract String systemPassword();
 
     @JsonProperty
@@ -91,7 +92,7 @@ public abstract class LdapSettingsRequest {
     @JsonCreator
     public static LdapSettingsRequest create(@JsonProperty("enabled") boolean enabled,
                                              @JsonProperty("system_username") @NotEmpty String systemUsername,
-                                             @JsonProperty("system_password") @NotEmpty String systemPassword,
+                                             @JsonProperty("system_password") @Nullable String systemPassword,
                                              @JsonProperty("system_password_set") boolean isSystemPasswordSet,
                                              @JsonProperty("ldap_uri") URI ldapUri,
                                              @JsonProperty("use_start_tls") boolean useStartTls,

--- a/graylog2-server/src/main/java/org/graylog2/rest/models/system/ldap/requests/LdapSettingsRequest.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/models/system/ldap/requests/LdapSettingsRequest.java
@@ -42,6 +42,9 @@ public abstract class LdapSettingsRequest {
     public abstract String systemPassword();
 
     @JsonProperty
+    public abstract boolean isSystemPasswordSet();
+
+    @JsonProperty
     public abstract URI ldapUri();
 
     @JsonProperty
@@ -89,6 +92,7 @@ public abstract class LdapSettingsRequest {
     public static LdapSettingsRequest create(@JsonProperty("enabled") boolean enabled,
                                              @JsonProperty("system_username") @NotEmpty String systemUsername,
                                              @JsonProperty("system_password") @NotEmpty String systemPassword,
+                                             @JsonProperty("system_password_set") boolean isSystemPasswordSet,
                                              @JsonProperty("ldap_uri") URI ldapUri,
                                              @JsonProperty("use_start_tls") boolean useStartTls,
                                              @JsonProperty("trust_all_certificates") boolean trustAllCertificates,
@@ -105,6 +109,7 @@ public abstract class LdapSettingsRequest {
         return new AutoValue_LdapSettingsRequest(enabled,
                                                  systemUsername,
                                                  systemPassword,
+                                                 isSystemPasswordSet,
                                                  ldapUri,
                                                  useStartTls,
                                                  trustAllCertificates,

--- a/graylog2-server/src/main/java/org/graylog2/rest/models/system/ldap/responses/LdapSettingsResponse.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/models/system/ldap/responses/LdapSettingsResponse.java
@@ -38,7 +38,7 @@ public abstract class LdapSettingsResponse {
     public abstract String systemUsername();
 
     @JsonProperty
-    public abstract String systemPassword();
+    public abstract boolean isSystemPasswordSet();
 
     @JsonProperty
     public abstract URI ldapUri();
@@ -88,7 +88,7 @@ public abstract class LdapSettingsResponse {
     @JsonCreator
     public static LdapSettingsResponse create(@JsonProperty("enabled") boolean enabled,
                                               @JsonProperty("system_username") String systemUsername,
-                                              @JsonProperty("system_password") String systemPassword,
+                                              @JsonProperty("system_password_set") boolean isSystemPasswordSet ,
                                               @JsonProperty("ldap_uri") URI ldapUri,
                                               @JsonProperty("use_start_tls") boolean useStartTls,
                                               @JsonProperty("trust_all_certificates") boolean trustAllCertificates,
@@ -104,7 +104,7 @@ public abstract class LdapSettingsResponse {
                                               @JsonProperty("group_search_pattern") @Nullable String groupSearchPattern) {
         return new AutoValue_LdapSettingsResponse(enabled,
                                                   systemUsername,
-                                                  systemPassword,
+                                                  isSystemPasswordSet,
                                                   ldapUri,
                                                   useStartTls,
                                                   trustAllCertificates,
@@ -123,7 +123,7 @@ public abstract class LdapSettingsResponse {
     public static LdapSettingsResponse emptyDisabled() {
         return new AutoValue_LdapSettingsResponse(false,
                                                   "",
-                                                  "",
+                                                  false,
                                                   URI.create("ldap://localhost:389"),
                                                   false,
                                                   false,

--- a/graylog2-server/src/main/java/org/graylog2/rest/resources/system/ldap/LdapResource.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/resources/system/ldap/LdapResource.java
@@ -100,7 +100,7 @@ public class LdapResource extends RestResource {
         return LdapSettingsResponse.create(
                 ldapSettings.isEnabled(),
                 ldapSettings.getSystemUserName(),
-                ldapSettings.getSystemPassword(),
+                ldapSettings.getSystemPasswordPlaceholder(),
                 ldapSettings.getUri(),
                 ldapSettings.isUseStartTls(),
                 ldapSettings.isTrustAllCertificates(),

--- a/graylog2-server/src/main/java/org/graylog2/rest/resources/system/ldap/LdapResource.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/resources/system/ldap/LdapResource.java
@@ -100,7 +100,7 @@ public class LdapResource extends RestResource {
         return LdapSettingsResponse.create(
                 ldapSettings.isEnabled(),
                 ldapSettings.getSystemUserName(),
-                ldapSettings.getSystemPasswordPlaceholder(),
+                ldapSettings.isSystemPasswordSet(),
                 ldapSettings.getUri(),
                 ldapSettings.isUseStartTls(),
                 ldapSettings.isTrustAllCertificates(),

--- a/graylog2-server/src/main/java/org/graylog2/security/ldap/LdapSettingsImpl.java
+++ b/graylog2-server/src/main/java/org/graylog2/security/ldap/LdapSettingsImpl.java
@@ -84,8 +84,6 @@ public class LdapSettingsImpl extends PersistedImpl implements LdapSettings {
     public static final String LDAP_GROUP_MAPPING_NAMEKEY = "group";
     public static final String LDAP_GROUP_MAPPING_ROLEKEY = "role_id";
 
-    public static final String SYSTEM_PASSWORD_PLACEHOLDER = "*************";
-
     protected Configuration configuration;
     private final RoleService roleService;
 
@@ -143,17 +141,13 @@ public class LdapSettingsImpl extends PersistedImpl implements LdapSettings {
     }
 
     @Override
-    public String getSystemPasswordPlaceholder() {
+    public boolean isSystemPasswordSet() {
         final Object o = fields.get(SYSTEM_PASSWORD);
-        if (o == null) return "";
-        return SYSTEM_PASSWORD_PLACEHOLDER;
+        return o != null;
     }
 
     @Override
     public void setSystemPassword(String systemPassword) {
-        if (systemPassword == SYSTEM_PASSWORD_PLACEHOLDER) {
-            return;
-        }
         // set new salt value, if we didn't have any.
         if (getSystemPasswordSalt().isEmpty()) {
             LOG.debug("Generating new salt for LDAP system password.");

--- a/graylog2-server/src/main/java/org/graylog2/security/ldap/LdapSettingsImpl.java
+++ b/graylog2-server/src/main/java/org/graylog2/security/ldap/LdapSettingsImpl.java
@@ -144,6 +144,8 @@ public class LdapSettingsImpl extends PersistedImpl implements LdapSettings {
 
     @Override
     public String getSystemPasswordPlaceholder() {
+        final Object o = fields.get(SYSTEM_PASSWORD);
+        if (o == null) return "";
         return SYSTEM_PASSWORD_PLACEHOLDER;
     }
 

--- a/graylog2-server/src/main/java/org/graylog2/security/ldap/LdapSettingsImpl.java
+++ b/graylog2-server/src/main/java/org/graylog2/security/ldap/LdapSettingsImpl.java
@@ -148,6 +148,9 @@ public class LdapSettingsImpl extends PersistedImpl implements LdapSettings {
 
     @Override
     public void setSystemPassword(String systemPassword) {
+        if (systemPassword == null || systemPassword.isEmpty()) {
+            return;
+        }
         // set new salt value, if we didn't have any.
         if (getSystemPasswordSalt().isEmpty()) {
             LOG.debug("Generating new salt for LDAP system password.");

--- a/graylog2-server/src/main/java/org/graylog2/security/ldap/LdapSettingsImpl.java
+++ b/graylog2-server/src/main/java/org/graylog2/security/ldap/LdapSettingsImpl.java
@@ -84,6 +84,8 @@ public class LdapSettingsImpl extends PersistedImpl implements LdapSettings {
     public static final String LDAP_GROUP_MAPPING_NAMEKEY = "group";
     public static final String LDAP_GROUP_MAPPING_ROLEKEY = "role_id";
 
+    public static final String SYSTEM_PASSWORD_PLACEHOLDER = "*************";
+
     protected Configuration configuration;
     private final RoleService roleService;
 
@@ -141,7 +143,15 @@ public class LdapSettingsImpl extends PersistedImpl implements LdapSettings {
     }
 
     @Override
+    public String getSystemPasswordPlaceholder() {
+        return SYSTEM_PASSWORD_PLACEHOLDER;
+    }
+
+    @Override
     public void setSystemPassword(String systemPassword) {
+        if (systemPassword == SYSTEM_PASSWORD_PLACEHOLDER) {
+            return;
+        }
         // set new salt value, if we didn't have any.
         if (getSystemPasswordSalt().isEmpty()) {
             LOG.debug("Generating new salt for LDAP system password.");

--- a/graylog2-server/src/main/java/org/graylog2/shared/security/ldap/LdapSettings.java
+++ b/graylog2-server/src/main/java/org/graylog2/shared/security/ldap/LdapSettings.java
@@ -33,6 +33,8 @@ public interface LdapSettings extends Persisted {
 
     String getSystemPassword();
 
+    String getSystemPasswordPlaceholder();
+
     void setSystemPassword(String systemPassword);
 
     String getSystemPasswordSalt();

--- a/graylog2-server/src/main/java/org/graylog2/shared/security/ldap/LdapSettings.java
+++ b/graylog2-server/src/main/java/org/graylog2/shared/security/ldap/LdapSettings.java
@@ -33,7 +33,7 @@ public interface LdapSettings extends Persisted {
 
     String getSystemPassword();
 
-    String getSystemPasswordPlaceholder();
+    boolean isSystemPasswordSet();
 
     void setSystemPassword(String systemPassword);
 

--- a/graylog2-web-interface/src/components/ldap/LdapComponent.css
+++ b/graylog2-web-interface/src/components/ldap/LdapComponent.css
@@ -1,0 +1,4 @@
+:local(.passwordSet) {
+    font-size: 14px;
+    margin-right: 12px;
+}

--- a/graylog2-web-interface/src/components/ldap/LdapComponent.jsx
+++ b/graylog2-web-interface/src/components/ldap/LdapComponent.jsx
@@ -261,6 +261,9 @@ const LdapComponent = React.createClass({
 
     const rolesOptions = this.state.roles;
 
+    const ldapPasswordPlaceHolder = this.state.ldapSettings.system_password_set ?
+      '*** PASSWORD SET ***' : 'System Password';
+
     return (
       <Row>
         <Col lg={8}>
@@ -332,7 +335,7 @@ const LdapComponent = React.createClass({
                      onChange={this._bindValue} disabled={disabled} />
 
               <Input type="password" id="system_password" name="system_password" labelClassName="col-sm-3"
-                     wrapperClassName="col-sm-9" placeholder="System Password" label="System Password"
+                     wrapperClassName="col-sm-9" placeholder={ldapPasswordPlaceHolder} label="System Password"
                      value={this.state.ldapSettings.system_password} help={help.SYSTEM_PASSWORD}
                      onChange={this._bindValue} disabled={disabled} />
             </fieldset>

--- a/graylog2-web-interface/src/components/ldap/LdapComponent.jsx
+++ b/graylog2-web-interface/src/components/ldap/LdapComponent.jsx
@@ -5,12 +5,14 @@ import { Row, Col, Button, Panel } from 'react-bootstrap';
 import URI from 'urijs';
 import naturalSort from 'javascript-natural-sort';
 
-import { Input } from 'components/bootstrap';
+import { Input, InputWrapper } from 'components/bootstrap';
+import { FormGroup, ControlLabel } from 'react-bootstrap';
 import { MultiSelect, Spinner } from 'components/common';
 import ObjectUtils from 'util/ObjectUtils';
 
 import TestLdapConnection from './TestLdapConnection';
 import TestLdapLogin from './TestLdapLogin';
+import LdapComponentStyle from './LdapComponent.css';
 
 import StoreProvider from 'injection/StoreProvider';
 const RolesStore = StoreProvider.getStore('Roles');
@@ -141,6 +143,7 @@ const LdapComponent = React.createClass({
       ldapSettings: undefined,
       ldapUri: undefined,
       roles: undefined,
+      showPasswordInput: true,
     };
   },
 
@@ -167,7 +170,7 @@ const LdapComponent = React.createClass({
     // Clone settings object, so we don't the store reference
     const settings = ObjectUtils.clone(state.ldapSettings);
     const ldapUri = new URI(settings.ldap_uri);
-    this.setState({ ldapSettings: settings, ldapUri: ldapUri });
+    this.setState({ ldapSettings: settings, ldapUri: ldapUri, hidePasswordInput: settings.system_password_set });
   },
 
   _isLoading() {
@@ -250,6 +253,10 @@ const LdapComponent = React.createClass({
     this.props.onShowGroups();
   },
 
+  _showPasswordInput() {
+    this.setState({hidePasswordInput: false});
+  },
+
   render() {
     if (this._isLoading()) {
       return <Spinner />;
@@ -261,8 +268,25 @@ const LdapComponent = React.createClass({
 
     const rolesOptions = this.state.roles;
 
-    const ldapPasswordPlaceHolder = this.state.ldapSettings.system_password_set ?
-      '*** PASSWORD SET ***' : 'System Password';
+    const ldapPasswordInput = this.state.hidePasswordInput ?
+      (<FormGroup controlId="system_password">
+        <ControlLabel className="col-sm-3">System Password</ControlLabel>
+        <InputWrapper className="col-sm-9">
+          <span className={LdapComponentStyle.passwordSet}>Password is set</span>
+          <Button onClick={this._showPasswordInput} >Reset Password</Button>
+        </InputWrapper>
+      </FormGroup>) :
+      (<Input type="password"
+             id="system_password"
+             name="system_password"
+             labelClassName="col-sm-3"
+             wrapperClassName="col-sm-9"
+             placeholder="System Password"
+             label="System Password"
+             value={this.state.ldapSettings.system_password}
+             help={help.SYSTEM_PASSWORD}
+             onChange={this._bindValue}
+             disabled={disabled} />);
 
     return (
       <Row>
@@ -334,10 +358,7 @@ const LdapComponent = React.createClass({
                      value={this.state.ldapSettings.system_username} help={help.SYSTEM_USERNAME}
                      onChange={this._bindValue} disabled={disabled} />
 
-              <Input type="password" id="system_password" name="system_password" labelClassName="col-sm-3"
-                     wrapperClassName="col-sm-9" placeholder={ldapPasswordPlaceHolder} label="System Password"
-                     value={this.state.ldapSettings.system_password} help={help.SYSTEM_PASSWORD}
-                     onChange={this._bindValue} disabled={disabled} />
+              {ldapPasswordInput}
             </fieldset>
 
             <fieldset>


### PR DESCRIPTION
## Description
The ldap configuration page was setting the input value of the
password field to the actuall password.

This change prevents reading the password via "inspect" in browser,
by hiding the password input field and instead show a string "Password is set".

If the user wants to set a new password he now needs to click the "Reset Password" button.

There is now no way anymore to clear the password anymore, since we drop empty
passwords now. That is needed since the GUI does not receive and therefore cannot send
the password any longer.

![graylog - ldap settings](https://user-images.githubusercontent.com/448763/35922277-74883d08-0c1d-11e8-9288-e7cb2d911a62.png)

## Motivation and Context
 A attacker could read the ldap password, if he gained admin access to graylog.

## How Has This Been Tested?
Password set and updated and checked via inspect.

Fixes #3763 

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
