### PR TITLE
Disable data adapters in creation dialog missing frontend components.

### DIFF
--- a/graylog2-web-interface/src/components/lookup-tables/DataAdapterCreate.jsx
+++ b/graylog2-web-interface/src/components/lookup-tables/DataAdapterCreate.jsx
@@ -53,6 +53,10 @@ const DataAdapterCreate = React.createClass({
 
     const sortedAdapters = Object.keys(this.props.types).map((key) => {
       const type = this.props.types[key];
+      if (adapterPlugins[type.type] === undefined) {
+        console.error(`Plugin component for data adapter type ${type.type} is missing - invalid or missing plugin?`);
+        return { value: type.type, disabled: true, label: `${type.type} - missing or invalid plugin` };
+      }
       return { value: type.type, label: adapterPlugins[type.type].displayName };
     }).sort((a, b) => naturalSort(a.label.toLowerCase(), b.label.toLowerCase()));
 

--- a/graylog2-web-interface/src/components/lookup-tables/DataAdapterCreate.test.jsx
+++ b/graylog2-web-interface/src/components/lookup-tables/DataAdapterCreate.test.jsx
@@ -1,0 +1,60 @@
+import React from 'react';
+import renderer from 'react-test-renderer';
+
+import mockComponent from 'helpers/mocking/MockComponent';
+
+import DataAdapterCreate from './DataAdapterCreate';
+
+jest.mock('components/common', () => ({
+  Select: mockComponent('SelectMock'),
+}));
+
+jest.mock('components/bootstrap', () => ({
+  Input: mockComponent('InputMock'),
+}));
+
+jest.mock('components/lookup-tables', () => ({
+  DataAdapterForm: mockComponent('DataAdapterFormMock'),
+}));
+
+jest.mock('graylog-web-plugin/plugin', () => ({
+  PluginStore: {
+    exports: () => ([
+      {
+        type: 'someType',
+        displayName: 'Some Mocked Data Adapter Type',
+      },
+    ]),
+  },
+}));
+
+describe('<DataAdapterCreate />', () => {
+  it('should render with empty parameters', () => {
+    const callback = () => {};
+    const types = {};
+    const wrapper = renderer.create(<DataAdapterCreate saved={callback} types={types} />);
+    expect(wrapper.toJSON()).toMatchSnapshot();
+  });
+
+  it('should render for types with defined frontend components', () => {
+    const callback = () => {};
+    const types = {
+      someType: {
+        type: 'someType',
+      },
+    };
+    const wrapper = renderer.create(<DataAdapterCreate saved={callback} types={types} />);
+    expect(wrapper.toJSON()).toMatchSnapshot();
+  });
+
+  it('should render for types without defined frontend components', () => {
+    const callback = () => {};
+    const types = {
+      unknownType: {
+        type: 'unknownType',
+      },
+    };
+    const wrapper = renderer.create(<DataAdapterCreate saved={callback} types={types} />);
+    expect(wrapper.toJSON()).toMatchSnapshot();
+  });
+});

--- a/graylog2-web-interface/src/components/lookup-tables/__snapshots__/DataAdapterCreate.test.jsx.snap
+++ b/graylog2-web-interface/src/components/lookup-tables/__snapshots__/DataAdapterCreate.test.jsx.snap
@@ -1,0 +1,148 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`<DataAdapterCreate /> should render for types with defined frontend components 1`] = `
+<div>
+  <div
+    className="content row"
+  >
+    <div
+      className="col-lg-8"
+    >
+      <form
+        className="form form-horizontal"
+        onSubmit={[Function]}
+      >
+        <span
+          className="InputMock"
+        >
+          <span
+            autoFocus={true}
+            help="The type of data adapter to configure."
+            id="data-adapter-type-select"
+            label="Data Adapter Type"
+            labelClassName="col-sm-3"
+            required={true}
+            wrapperClassName="col-sm-9"
+          >
+            <span
+              className="SelectMock"
+            >
+              <span
+                clearable={false}
+                matchProp="value"
+                onChange={[Function]}
+                options={
+                  Array [
+                    Object {
+                      "label": "Some Mocked Data Adapter Type",
+                      "value": "someType",
+                    },
+                  ]
+                }
+                placeholder="Select Data Adapter Type"
+                value={null}
+              />
+            </span>
+          </span>
+        </span>
+      </form>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`<DataAdapterCreate /> should render for types without defined frontend components 1`] = `
+<div>
+  <div
+    className="content row"
+  >
+    <div
+      className="col-lg-8"
+    >
+      <form
+        className="form form-horizontal"
+        onSubmit={[Function]}
+      >
+        <span
+          className="InputMock"
+        >
+          <span
+            autoFocus={true}
+            help="The type of data adapter to configure."
+            id="data-adapter-type-select"
+            label="Data Adapter Type"
+            labelClassName="col-sm-3"
+            required={true}
+            wrapperClassName="col-sm-9"
+          >
+            <span
+              className="SelectMock"
+            >
+              <span
+                clearable={false}
+                matchProp="value"
+                onChange={[Function]}
+                options={
+                  Array [
+                    Object {
+                      "disabled": true,
+                      "label": "unknownType - missing or invalid plugin",
+                      "value": "unknownType",
+                    },
+                  ]
+                }
+                placeholder="Select Data Adapter Type"
+                value={null}
+              />
+            </span>
+          </span>
+        </span>
+      </form>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`<DataAdapterCreate /> should render with empty parameters 1`] = `
+<div>
+  <div
+    className="content row"
+  >
+    <div
+      className="col-lg-8"
+    >
+      <form
+        className="form form-horizontal"
+        onSubmit={[Function]}
+      >
+        <span
+          className="InputMock"
+        >
+          <span
+            autoFocus={true}
+            help="The type of data adapter to configure."
+            id="data-adapter-type-select"
+            label="Data Adapter Type"
+            labelClassName="col-sm-3"
+            required={true}
+            wrapperClassName="col-sm-9"
+          >
+            <span
+              className="SelectMock"
+            >
+              <span
+                clearable={false}
+                matchProp="value"
+                onChange={[Function]}
+                options={Array []}
+                placeholder="Select Data Adapter Type"
+                value={null}
+              />
+            </span>
+          </span>
+        </span>
+      </form>
+    </div>
+  </div>
+</div>
+`;

--- a/graylog2-web-interface/test/helpers/mocking/MockComponent.jsx
+++ b/graylog2-web-interface/test/helpers/mocking/MockComponent.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
-export default name => {
+export default (name) => {
   const MockComponent = props => (
     <span className={name}>
       <span {...props}>{props.children}</span>

--- a/graylog2-web-interface/test/helpers/mocking/MockComponent.jsx
+++ b/graylog2-web-interface/test/helpers/mocking/MockComponent.jsx
@@ -1,0 +1,18 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+export default name => {
+  const MockComponent = props => (
+    <span className={name}>
+      <span {...props}>{props.children}</span>
+    </span>
+  );
+  MockComponent.propTypes = {
+    children: PropTypes.element,
+  };
+  MockComponent.defaultProps = {
+    children: null,
+  };
+
+  return MockComponent;
+};


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
If a data adapter is missing a frontend component definition, before
this change the data adapter creation page broke.

This change checks if the definition is there and if not the data
adapter type is disabled in the creation dialog and an error message is
logged.

Fixes #4528.

<!--- Provide a general summary of your changes in the Title above -->


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
