### PR TITLE
Only update dashboard positions when necessary

### DIFF
--- a/graylog2-web-interface/src/components/common/ReactGridContainer.css
+++ b/graylog2-web-interface/src/components/common/ReactGridContainer.css
@@ -13,3 +13,7 @@
 :local(.reactGridLayout) .react-grid-placeholder {
     background: #16ACE3;
 }
+
+:local(.reactGridLayout) .actions {
+    cursor: default;
+}

--- a/graylog2-web-interface/src/components/common/ReactGridContainer.jsx
+++ b/graylog2-web-interface/src/components/common/ReactGridContainer.jsx
@@ -151,6 +151,9 @@ const ReactGridContainer = React.createClass({
                                     cols={columns}
                                     rowHeight={rowHeight}
                                     margin={[10, 10]}
+                                    // Do not allow dragging from elements inside a `.actions` css class. This is
+                                    // meant to avoid calling `onDragStop` callbacks when clicking on an action button.
+                                    draggableCancel=".actions"
                                     onDragStop={this._onLayoutChange}
                                     onResizeStop={this._onLayoutChange}
                                     useCSSTransforms={animate}

--- a/graylog2-web-interface/src/components/common/ReactGridContainer.jsx
+++ b/graylog2-web-interface/src/components/common/ReactGridContainer.jsx
@@ -60,8 +60,15 @@ const ReactGridContainer = React.createClass({
     children: PropTypes.node.isRequired,
     /**
      * Function that will be called when positions change. The function
-     * receives the new positions in the same format as specified in the
-     * `positions` prop.
+     * receives the new positions in the format:
+     *
+     * ```
+     * [
+     *   { id: widgetId, col: column, row: row, height: height, width: width },
+     *   // E.g.
+     *   { id: '2', col: 2, row: 0, height: 1, width: 4 },
+     * ]
+     * ```
      */
     onPositionsChange: PropTypes.func.isRequired,
     /**


### PR DESCRIPTION
This PR makes some modifications in the web interface to be smarter calculating and updating dashboard positions:

1. Avoid callbacks when clicking on an action button in a widget. This is what made #4525 too likely to happen
2. Only compute layout when positions change, instead of doing it on every render
3. Ensure there are layout changes before calling the `onLayoutChange` callback, avoiding doing unnecessary updates in the server

In order to fix the issue in 2.4, I think we should only backport change number 1, avoiding to introduce any other potential issues in the stable release. I can take care of that once this PR is reviewed.

Before a solution for #4527 lands, these changes fix #4525.