### PR TITLE
Make API Tokens configurable in web interface

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/rest/resources/users/UsersResource.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/resources/users/UsersResource.java
@@ -86,9 +86,7 @@ import java.util.Set;
 import static com.google.common.base.MoreObjects.firstNonNull;
 import static java.util.stream.Collectors.groupingBy;
 import static java.util.stream.Collectors.maxBy;
-import static org.graylog2.shared.security.RestPermissions.USERS_EDIT;
-import static org.graylog2.shared.security.RestPermissions.USERS_PERMISSIONSEDIT;
-import static org.graylog2.shared.security.RestPermissions.USERS_ROLESEDIT;
+import static org.graylog2.shared.security.RestPermissions.*;
 
 @RequiresAuthentication
 @Path("/users")
@@ -428,7 +426,7 @@ public class UsersResource extends RestResource {
                                 @PathParam("username") String username) {
         final User user = _tokensLoadUser(username);
 
-        if (!getSubject().isPermitted(RestPermissions.USERS_TOKENLIST + ":" + user.getName())) {
+        if (!isPermitted(USERS_TOKENLIST, username)) {
             throw new ForbiddenException("Not allowed to list tokens for user " + username);
         }
 
@@ -450,8 +448,8 @@ public class UsersResource extends RestResource {
             @ApiParam(name = "JSON Body", value = "Placeholder because POST requests should have a body. Set to '{}', the content will be ignored.", defaultValue = "{}") String body) {
         final User user = _tokensLoadUser(username);
 
-        if (!getSubject().isPermitted(RestPermissions.USERS_TOKENCREATE + ":" + user.getName())) {
-            throw new ForbiddenException("Not allowed to list tokens for user " + username);
+        if (!isPermitted(USERS_TOKENCREATE, username)) {
+            throw new ForbiddenException("Not allowed to create tokens for user " + username);
         }
 
         final AccessToken accessToken = accessTokenService.create(user.getName(), name);
@@ -468,8 +466,8 @@ public class UsersResource extends RestResource {
             @ApiParam(name = "token", required = true) @PathParam("token") String token) {
         final User user = _tokensLoadUser(username);
 
-        if (!getSubject().isPermitted(RestPermissions.USERS_TOKENREMOVE + ":" + user.getName())) {
-            throw new ForbiddenException("Not allowed to list tokens for user " + username);
+        if (!isPermitted(USERS_TOKENREMOVE, username)) {
+            throw new ForbiddenException("Not allowed to remove tokens for user " + username);
         }
 
         final AccessToken accessToken = accessTokenService.load(token);

--- a/graylog2-server/src/main/java/org/graylog2/shared/security/Permissions.java
+++ b/graylog2-server/src/main/java/org/graylog2/shared/security/Permissions.java
@@ -79,6 +79,9 @@ public class Permissions {
         ImmutableSet.Builder<String> perms = ImmutableSet.builder();
         perms.add(perInstance(RestPermissions.USERS_EDIT, username));
         perms.add(perInstance(RestPermissions.USERS_PASSWORDCHANGE, username));
+        perms.add(perInstance(RestPermissions.USERS_TOKENLIST, username));
+        perms.add(perInstance(RestPermissions.USERS_TOKENCREATE, username));
+        perms.add(perInstance(RestPermissions.USERS_TOKENREMOVE, username));
         return perms.build();
     }
 

--- a/graylog2-server/src/test/java/org/graylog2/shared/security/PermissionsTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/shared/security/PermissionsTest.java
@@ -88,7 +88,8 @@ public class PermissionsTest {
     @Test
     public void testUserSelfEditPermissions() throws Exception {
         assertThat(permissions.userSelfEditPermissions("john"))
-                .containsExactly("users:edit:john", "users:passwordchange:john");
+                .containsExactly("users:edit:john", "users:passwordchange:john", "users:tokenlist:john",
+                        "users:tokencreate:john", "users:tokenremove:john");
     }
 
     @Test
@@ -98,6 +99,9 @@ public class PermissionsTest {
         readerPermissions.addAll(permissions.readerBasePermissions());
         readerPermissions.add("users:edit:john");
         readerPermissions.add("users:passwordchange:john");
+        readerPermissions.add("users:tokenlist:john");
+        readerPermissions.add("users:tokencreate:john");
+        readerPermissions.add("users:tokenremove:john");
 
         assertThat(permissions.readerPermissions("john"))
                 .containsOnlyElementsOf(readerPermissions);

--- a/graylog2-server/src/test/java/org/graylog2/users/UserServiceImplTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/users/UserServiceImplTest.java
@@ -222,6 +222,7 @@ public class UserServiceImplTest {
 
         when(permissionResolver.resolveStringPermission(role.getId())).thenReturn(Collections.singleton("foo:bar"));
 
-        assertThat(userService.getPermissionsForUser(user)).containsOnly("users:passwordchange:user", "users:edit:user", "foo:bar", "hello:world");
+        assertThat(userService.getPermissionsForUser(user)).containsOnly("users:passwordchange:user", "users:edit:user",
+                "foo:bar", "hello:world", "users:tokenlist:user", "users:tokencreate:user", "users:tokenremove:user");
     }
 }

--- a/graylog2-web-interface/src/components/authentication/AuthenticationComponent.jsx
+++ b/graylog2-web-interface/src/components/authentication/AuthenticationComponent.jsx
@@ -115,9 +115,14 @@ const AuthenticationComponent = React.createClass({
 
     if (authenticators.length === 0) {
       // special case, this is a user editing their own profile
-      authenticators = [<LinkContainer key="profile-edit" to={Routes.SYSTEM.AUTHENTICATION.USERS.edit(encodeURIComponent(this.state.currentUser.username))}>
-        <NavItem title="Edit User">Edit User</NavItem>
-      </LinkContainer>];
+      authenticators = [
+        <LinkContainer key="profile-edit" to={Routes.SYSTEM.AUTHENTICATION.USERS.edit(encodeURIComponent(this.state.currentUser.username))}>
+          <NavItem title="Edit Profile">Edit Profile</NavItem>
+        </LinkContainer>,
+        <LinkContainer key="profile-edit-tokens" to={Routes.SYSTEM.AUTHENTICATION.USERS.edit_tokens(encodeURIComponent(this.state.currentUser.username))}>
+          <NavItem title="Edit Tokens">Edit Tokens</NavItem>
+        </LinkContainer>
+      ];
     }
     const subnavigation = (
       <Nav stacked bsStyle="pills">

--- a/graylog2-web-interface/src/components/authentication/AuthenticationComponent.jsx
+++ b/graylog2-web-interface/src/components/authentication/AuthenticationComponent.jsx
@@ -119,7 +119,7 @@ const AuthenticationComponent = React.createClass({
         <LinkContainer key="profile-edit" to={Routes.SYSTEM.AUTHENTICATION.USERS.edit(encodeURIComponent(this.state.currentUser.username))}>
           <NavItem title="Edit Profile">Edit Profile</NavItem>
         </LinkContainer>,
-        <LinkContainer key="profile-edit-tokens" to={Routes.SYSTEM.AUTHENTICATION.USERS.edit_tokens(encodeURIComponent(this.state.currentUser.username))}>
+        <LinkContainer key="profile-edit-tokens" to={Routes.SYSTEM.AUTHENTICATION.USERS.TOKENS.edit(encodeURIComponent(this.state.currentUser.username))}>
           <NavItem title="Edit Tokens">Edit Tokens</NavItem>
         </LinkContainer>,
       ];

--- a/graylog2-web-interface/src/components/authentication/AuthenticationComponent.jsx
+++ b/graylog2-web-interface/src/components/authentication/AuthenticationComponent.jsx
@@ -121,7 +121,7 @@ const AuthenticationComponent = React.createClass({
         </LinkContainer>,
         <LinkContainer key="profile-edit-tokens" to={Routes.SYSTEM.AUTHENTICATION.USERS.edit_tokens(encodeURIComponent(this.state.currentUser.username))}>
           <NavItem title="Edit Tokens">Edit Tokens</NavItem>
-        </LinkContainer>
+        </LinkContainer>,
       ];
     }
     const subnavigation = (

--- a/graylog2-web-interface/src/components/common/TableList.jsx
+++ b/graylog2-web-interface/src/components/common/TableList.jsx
@@ -29,6 +29,8 @@ const TableList = React.createClass({
     filterKeys: PropTypes.arrayOf(PropTypes.string).isRequired,
     /** Label to use next to the filter input. */
     filterLabel: PropTypes.string,
+    /** Hide description */
+    hideDescription: PropTypes.bool,
     /**
      * Immutable List of objects to display in the list. Objects are expected
      * to have an ID (`idKey` prop), a title (`title` prop), and an optional
@@ -68,6 +70,9 @@ const TableList = React.createClass({
       allSelected: false,
       selected: Immutable.Set(),
     };
+  },
+  componentWillReceiveProps(nextProps) {
+    this.setState({ filteredItems: Immutable.List(nextProps.items) });
   },
   _filterItems(filteredItems) {
     this.setState({ filteredItems: Immutable.List(filteredItems), allSelected: false });
@@ -113,7 +118,7 @@ const TableList = React.createClass({
     );
     return (
       <ListGroupItem key={`item-${item[this.props.idKey]}`} header={header}>
-        <span style={{ marginLeft: 20 }}>{item[this.props.descriptionKey]}</span>
+        {this.props.hideDescription ? null : <span style={{ marginLeft: 20 }}>{item[this.props.descriptionKey]}</span>}
       </ListGroupItem>
     );
   },

--- a/graylog2-web-interface/src/components/users/PermissionSelector.test.jsx
+++ b/graylog2-web-interface/src/components/users/PermissionSelector.test.jsx
@@ -2,18 +2,9 @@ import React from 'react';
 import renderer from 'react-test-renderer';
 import Immutable from 'immutable';
 import { mount } from 'enzyme';
+import 'helpers/mocking/react-dom_mock';
 
 import PermissionSelector from 'components/users/PermissionSelector';
-
-/* https://github.com/facebook/react/issues/7371
- *
- * findDomNode with refs is not supported by the react-test-renderer.
- * So we need to mock the findDOMNode function for TableList respectievly
- * for its child component TypeAheadDataFilter.
- */
-jest.mock('react-dom', () => ({
-  findDOMNode: () => ({}),
-}));
 
 describe('<PermissionSelector />', () => {
   const streams = Immutable.List([

--- a/graylog2-web-interface/src/components/users/TokenList.css
+++ b/graylog2-web-interface/src/components/users/TokenList.css
@@ -1,0 +1,3 @@
+:local(.tokenCreateForm) {
+    margin-top: 40px;
+}

--- a/graylog2-web-interface/src/components/users/TokenList.css
+++ b/graylog2-web-interface/src/components/users/TokenList.css
@@ -1,3 +1,3 @@
-:local(.tokenCreateForm) {
-    margin-top: 40px;
+:local(.tokenNewNameLabel) {
+    margin-top: 8px;
 }

--- a/graylog2-web-interface/src/components/users/TokenList.jsx
+++ b/graylog2-web-interface/src/components/users/TokenList.jsx
@@ -1,0 +1,101 @@
+import PropTypes from 'prop-types';
+import React from 'react';
+
+import { Row, Col, Form, FormControl, FormGroup, ControlLabel, InputWrapper, Button } from 'react-bootstrap';
+import { Input } from 'components/bootstrap';
+import ClipboardButton from 'components/common/ClipboardButton';
+import TokenListStyle from '!style!css!./TokenList.css';
+
+class TokenList extends React.Component {
+  static propTypes = {
+    tokens: PropTypes.arrayOf(PropTypes.object),
+    delete: PropTypes.func,
+    create: PropTypes.func,
+  };
+
+  static defaultProps = {
+    tokens: [],
+    delete: () => {},
+    create: () => {},
+  };
+
+  constructor(props) {
+    super(props);
+
+    this.state = {
+      token_name: '',
+    };
+
+    this._onNewTokeChanged = this._onNewTokeChanged.bind(this);
+    this._createToken = this._createToken.bind(this);
+  }
+
+  _onNewTokeChanged(e) {
+    this.setState({ token_name: e.target.value });
+  }
+
+  _deleteToken(token) {
+    return () => {
+      this.props.delete(token.token);
+    };
+  }
+
+  _createToken() {
+    this.props.create(this.state.token_name);
+    this.setState({ token_name: '' });
+  }
+
+  _tokenItem(token, idx) {
+    return (
+      <Form horizontal>
+        <Input label={token.name}
+               id={`token-${idx}-Id`}
+               type="text"
+               readonly
+               value={token.token}
+               labelClassName="col-sm-3"
+               wrapperClassName="col-sm-6" />
+        <div className="form-group">
+          <Col smOffset={3} sm={9}>
+            <ClipboardButton title="Copy" target={`#token-${idx}-Id`} />
+            {' '}
+            <Button id={`delete-user-${token.name}`}
+                    bsStyle="primary"
+                    title="Delete token"
+                    onClick={this._deleteToken(token)}>
+              Delete
+            </Button>
+          </Col>
+        </div>
+      </Form>
+    );
+  }
+
+  render() {
+    const tokenInputs = this.props.tokens.map((token, idx) => this._tokenItem(token, idx));
+    return (
+      <span>
+        <span>{tokenInputs}</span>
+        <div className={TokenListStyle.tokenCreateForm}>
+          <Form horizontal>
+            <Input label="Token Name"
+                   id="create-token-input"
+                   type="text"
+                   placeholder="e.g ServiceName"
+                   value={this.state.token_name}
+                   labelClassName="col-sm-3"
+                   wrapperClassName="col-sm-9"
+                   onChange={this._onNewTokeChanged} />
+            <div className="form-group">
+              <Col smOffset={3} sm={9}>
+                <Button id="create-token" onClick={this._createToken} bsStyle="primary" >Create Token</Button>
+              </Col>
+            </div>
+          </Form>
+        </div>
+      </span>
+    );
+  }
+}
+
+export default TokenList;

--- a/graylog2-web-interface/src/components/users/TokenList.jsx
+++ b/graylog2-web-interface/src/components/users/TokenList.jsx
@@ -126,7 +126,9 @@ class TokenList extends React.Component {
           descriptionKey="token"
           hideDescription={this.state.hide_tokens}
           itemActionsFactory={this.itemActionsFactory} />
-        <Checkbox onChange={this._onShowTokensChanged} checked={this.state.hide_tokens}>Hide Tokens</Checkbox>
+        <Checkbox id="hide-tokens" onChange={this._onShowTokensChanged} checked={this.state.hide_tokens}>
+          Hide Tokens
+        </Checkbox>
       </span>
     );
   }

--- a/graylog2-web-interface/src/components/users/TokenList.test.jsx
+++ b/graylog2-web-interface/src/components/users/TokenList.test.jsx
@@ -1,0 +1,61 @@
+import React from 'react';
+import renderer from 'react-test-renderer';
+import { mount } from 'enzyme';
+
+import TokenList from 'components/users/TokenList';
+
+/* https://github.com/facebook/react/issues/7371
+ *
+ * findDomNode with refs is not supported by the react-test-renderer.
+ * So we need to mock the findDOMNode function for TableList respectievly
+ * for its child component TypeAheadDataFilter.
+ */
+jest.mock('react-dom', () => ({
+  findDOMNode: () => ({}),
+}));
+
+describe('<TokenList />', () => {
+  const tokens = [
+    { name: 'Acme', token: 'beef2001' },
+    { name: 'Hamfred', token: 'beef2002' },
+  ];
+
+  it('should render with empty tokens', () => {
+    const wrapper = renderer.create(<TokenList tokens={[]} />);
+    expect(wrapper.toJSON()).toMatchSnapshot();
+  });
+
+  it('should render with tokens', () => {
+    const wrapper = renderer.create(<TokenList tokens={tokens} />);
+    expect(wrapper.toJSON()).toMatchSnapshot();
+  });
+
+  it('should add new token and delete existing ones', () => {
+    const createFn = jest.fn((tokenName) => {
+      expect(tokenName).toEqual('hans');
+    });
+    const deleteFn = jest.fn((token) => {
+      expect(token).toEqual('beef2001');
+    });
+    const wrapper = mount(<TokenList
+      tokens={tokens}
+      create={createFn}
+      delete={deleteFn}
+    />);
+    wrapper.find('#create-token-input').simulate('change', { target: { value: 'hans' } });
+    wrapper.find('button[type="submit"]').at(0).simulate('click');
+    expect(createFn.mock.calls.length).toBe(1);
+
+    wrapper.find('button[children="Delete"]').at(0).simulate('click');
+    expect(createFn.mock.calls.length).toBe(1);
+  });
+
+  it('should display tokens if "Hide tokens" was unchecked', () => {
+    const wrapper = mount(<TokenList
+      tokens={tokens}
+    />);
+    expect(wrapper.find('span[children="beef2001"]').length).toEqual(0);
+    wrapper.find('#hide-tokens').at(0).simulate('change', { target: { checked: false } });
+    expect(wrapper.find('span[children="beef2001"]').length).toEqual(1);
+  });
+});

--- a/graylog2-web-interface/src/components/users/TokenList.test.jsx
+++ b/graylog2-web-interface/src/components/users/TokenList.test.jsx
@@ -1,18 +1,12 @@
 import React from 'react';
 import renderer from 'react-test-renderer';
 import { mount } from 'enzyme';
+import 'helpers/mocking/react-dom_mock';
 
 import TokenList from 'components/users/TokenList';
 
-/* https://github.com/facebook/react/issues/7371
- *
- * findDomNode with refs is not supported by the react-test-renderer.
- * So we need to mock the findDOMNode function for TableList respectievly
- * for its child component TypeAheadDataFilter.
- */
-jest.mock('react-dom', () => ({
-  findDOMNode: () => ({}),
-}));
+jest.mock('components/common/ClipboardButton', () => 'ClipboardButton');
+
 
 describe('<TokenList />', () => {
   const tokens = [
@@ -39,11 +33,11 @@ describe('<TokenList />', () => {
     });
     const wrapper = mount(<TokenList
       tokens={tokens}
-      create={createFn}
-      delete={deleteFn}
+      onCreate={createFn}
+      onDelete={deleteFn}
     />);
     wrapper.find('#create-token-input').simulate('change', { target: { value: 'hans' } });
-    wrapper.find('button[type="submit"]').at(0).simulate('click');
+    wrapper.find('form').at(0).simulate('submit');
     expect(createFn.mock.calls.length).toBe(1);
 
     wrapper.find('button[children="Delete"]').at(0).simulate('click');

--- a/graylog2-web-interface/src/components/users/UserList.css
+++ b/graylog2-web-interface/src/components/users/UserList.css
@@ -36,6 +36,11 @@
     min-width: auto;
 }
 
+/* The context menu from the last drop down button in the list
+   was hidden behind the table since the overflow was set to auto
+   and the context menu could not overflow outside. For this
+   table we show the overflow event though it might make problems
+   with responsiveness (but no problems could be found). */
 #user-list {
    overflow-x: visible;
 }

--- a/graylog2-web-interface/src/components/users/UserList.css
+++ b/graylog2-web-interface/src/components/users/UserList.css
@@ -17,6 +17,11 @@
     max-width: 300px;
 }
 
+:local(.actions) {
+    width: 180px;
+    max-width: 180px;
+}
+
 :local(.help) {
     cursor: help;
 }
@@ -25,4 +30,12 @@
     cursor: help;
     padding: 0 0 0 2px;
     display: inline-flex;
+}
+
+:local(.moreActions) {
+    min-width: auto;
+}
+
+#user-list {
+   overflow-x: visible;
 }

--- a/graylog2-web-interface/src/components/users/UserList.jsx
+++ b/graylog2-web-interface/src/components/users/UserList.jsx
@@ -111,7 +111,7 @@ const UserList = React.createClass({
     let actions = null;
     if (user.read_only) {
       const editTokensAction = (
-        <LinkContainer to={Routes.SYSTEM.AUTHENTICATION.USERS.edit_tokens(encodeURIComponent(user.username))}>
+        <LinkContainer to={Routes.SYSTEM.AUTHENTICATION.USERS.TOKENS.edit(encodeURIComponent(user.username))}>
           <Button id={`edit-tokens-${user.username}`} bsStyle="info" bsSize="xs" title={`Edit tokens of user ${user.username}`}>
             Edit tokens
           </Button>
@@ -132,7 +132,7 @@ const UserList = React.createClass({
       );
     } else {
       const editTokensAction = (
-        <LinkContainer to={Routes.SYSTEM.AUTHENTICATION.USERS.edit_tokens(encodeURIComponent(user.username))}>
+        <LinkContainer to={Routes.SYSTEM.AUTHENTICATION.USERS.TOKENS.edit(encodeURIComponent(user.username))}>
           <MenuItem eventKey="1" id={`edit-tokens-${user.username}`} bsStyle="info" bsSize="xs" title={`Edit tokens of user ${user.username}`}>
             Edit tokens
           </MenuItem>

--- a/graylog2-web-interface/src/components/users/UserList.jsx
+++ b/graylog2-web-interface/src/components/users/UserList.jsx
@@ -1,7 +1,7 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 import { LinkContainer } from 'react-router-bootstrap';
-import { Button, OverlayTrigger, Popover, Tooltip } from 'react-bootstrap';
+import { Button, OverlayTrigger, Popover, Tooltip, DropdownButton, MenuItem } from 'react-bootstrap';
 
 import PermissionsMixin from 'util/PermissionsMixin';
 import Routes from 'routing/Routes';
@@ -110,20 +110,47 @@ const UserList = React.createClass({
 
     let actions = null;
     if (user.read_only) {
+      const editTokensAction = (
+        <LinkContainer to={Routes.SYSTEM.AUTHENTICATION.USERS.edit_tokens(encodeURIComponent(user.username))}>
+          <Button id={`edit-tokens-${user.username}`} bsStyle="info" bsSize="xs" title={`Edit tokens of user ${user.username}`}>
+            Edit tokens
+          </Button>
+        </LinkContainer>
+      );
+
       const tooltip = <Tooltip id="system-user">System users can only be modified in the Graylog configuration file.</Tooltip>;
       actions = (
-        <OverlayTrigger placement="left" overlay={tooltip}>
-          <span className={UserListStyle.help}>
-            <Button bsSize="xs" bsStyle="info" disabled>System user</Button>
-          </span>
-        </OverlayTrigger>
+        <span>
+          <OverlayTrigger placement="left" overlay={tooltip}>
+            <span className={UserListStyle.help}>
+              <Button bsSize="xs" bsStyle="info" disabled>System user</Button>
+            </span>
+          </OverlayTrigger>
+          &nbsp;
+          {editTokensAction}
+        </span>
       );
     } else {
+      const editTokensAction = (
+        <LinkContainer to={Routes.SYSTEM.AUTHENTICATION.USERS.edit_tokens(encodeURIComponent(user.username))}>
+          <MenuItem eventKey="1" id={`edit-tokens-${user.username}`} bsStyle="info" bsSize="xs" title={`Edit tokens of user ${user.username}`}>
+            Edit tokens
+          </MenuItem>
+        </LinkContainer>
+      );
+
       const deleteAction = (
-        <Button id={`delete-user-${user.username}`} bsStyle="primary" bsSize="xs" title="Delete user"
+        <MenuItem eventKey="2" id={`delete-user-${user.username}`} bsStyle="primary" bsSize="xs" title="Delete user"
                 onClick={this._deleteUserFunction(user.username)}>
           Delete
-        </Button>
+        </MenuItem>
+      );
+
+      const actionDropDown = (
+        <DropdownButton bsSize="xs" title="More actions" pullRight>
+          {editTokensAction}
+          {deleteAction}
+        </DropdownButton>
       );
 
       const editAction = (
@@ -136,9 +163,9 @@ const UserList = React.createClass({
 
       actions = (
         <div>
-          {this.isPermitted(this.props.currentUser.permissions, ['users:edit']) ? deleteAction : null}
-          &nbsp;
           {this.isPermitted(this.props.currentUser.permissions, [`users:edit:${user.username}`]) ? editAction : null}
+          &nbsp;
+          {actionDropDown}
         </div>
       );
     }
@@ -151,7 +178,7 @@ const UserList = React.createClass({
         <td className="limited">{user.email}</td>
         <td className="limited">{user.client_address}</td>
         <td className={UserListStyle.limitedWide}>{roleBadges}</td>
-        <td>{actions}</td>
+        <td className={UserListStyle.actions}>{actions}</td>
       </tr>
     );
   },

--- a/graylog2-web-interface/src/components/users/__snapshots__/TokenList.test.jsx.snap
+++ b/graylog2-web-interface/src/components/users/__snapshots__/TokenList.test.jsx.snap
@@ -2,7 +2,9 @@
 
 exports[`<TokenList /> should render with empty tokens 1`] = `
 <span>
-  <form>
+  <form
+    onSubmit={[Function]}
+  >
     <div
       className="form-group"
     >
@@ -38,7 +40,6 @@ exports[`<TokenList /> should render with empty tokens 1`] = `
             className="btn btn-primary"
             disabled={true}
             id="create-token"
-            onClick={[Function]}
             type="submit"
           >
             Create Token
@@ -81,7 +82,9 @@ exports[`<TokenList /> should render with empty tokens 1`] = `
 
 exports[`<TokenList /> should render with tokens 1`] = `
 <span>
-  <form>
+  <form
+    onSubmit={[Function]}
+  >
     <div
       className="form-group"
     >
@@ -117,7 +120,6 @@ exports[`<TokenList /> should render with tokens 1`] = `
             className="btn btn-primary"
             disabled={true}
             id="create-token"
-            onClick={[Function]}
             type="submit"
           >
             Create Token
@@ -259,16 +261,14 @@ exports[`<TokenList /> should render with tokens 1`] = `
               }
             }
           >
-            <span>
-              <button
-                className="btn btn-xs btn-default"
-                data-clipboard-button={true}
-                data-clipboard-text="beef2001"
-                disabled={false}
-                type="button"
-              >
-                Copy to clipboard
-              </button>
+            <div
+              className="btn-group"
+            >
+              <ClipboardButton
+                bsSize="xsmall"
+                text="beef2001"
+                title="Copy to clipboard"
+              />
               <button
                 className="btn btn-xs btn-primary"
                 disabled={false}
@@ -277,7 +277,7 @@ exports[`<TokenList /> should render with tokens 1`] = `
               >
                 Delete
               </button>
-            </span>
+            </div>
           </div>
           <div
             className="form-group"
@@ -326,16 +326,14 @@ exports[`<TokenList /> should render with tokens 1`] = `
               }
             }
           >
-            <span>
-              <button
-                className="btn btn-xs btn-default"
-                data-clipboard-button={true}
-                data-clipboard-text="beef2002"
-                disabled={false}
-                type="button"
-              >
-                Copy to clipboard
-              </button>
+            <div
+              className="btn-group"
+            >
+              <ClipboardButton
+                bsSize="xsmall"
+                text="beef2002"
+                title="Copy to clipboard"
+              />
               <button
                 className="btn btn-xs btn-primary"
                 disabled={false}
@@ -344,7 +342,7 @@ exports[`<TokenList /> should render with tokens 1`] = `
               >
                 Delete
               </button>
-            </span>
+            </div>
           </div>
           <div
             className="form-group"

--- a/graylog2-web-interface/src/components/users/__snapshots__/TokenList.test.jsx.snap
+++ b/graylog2-web-interface/src/components/users/__snapshots__/TokenList.test.jsx.snap
@@ -1,0 +1,401 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`<TokenList /> should render with empty tokens 1`] = `
+<span>
+  <form>
+    <div
+      className="form-group"
+    >
+      <div
+        className="row"
+      >
+        <div
+          className="col-sm-2"
+        >
+          <label
+            className="tokenNewNameLabel control-label"
+            htmlFor={undefined}
+          >
+            Token Name
+          </label>
+        </div>
+        <div
+          className="col-sm-4"
+        >
+          <input
+            className="form-control"
+            id="create-token-input"
+            onChange={[Function]}
+            placeholder="e.g ServiceName"
+            type="text"
+            value=""
+          />
+        </div>
+        <div
+          className="col-sm-2"
+        >
+          <button
+            className="btn btn-primary"
+            disabled={true}
+            id="create-token"
+            onClick={[Function]}
+            type="submit"
+          >
+            Create Token
+          </button>
+        </div>
+      </div>
+    </div>
+    <hr />
+  </form>
+  <div
+    className="row"
+  >
+    <div
+      className="col-md-12"
+    >
+      <div>
+        No items to display.
+      </div>
+    </div>
+  </div>
+  <div
+    className="checkbox"
+    style={undefined}
+  >
+    <label
+      title=""
+    >
+      <input
+        checked={true}
+        disabled={false}
+        id="hide-tokens"
+        onChange={[Function]}
+        type="checkbox"
+      />
+      Hide Tokens
+    </label>
+  </div>
+</span>
+`;
+
+exports[`<TokenList /> should render with tokens 1`] = `
+<span>
+  <form>
+    <div
+      className="form-group"
+    >
+      <div
+        className="row"
+      >
+        <div
+          className="col-sm-2"
+        >
+          <label
+            className="tokenNewNameLabel control-label"
+            htmlFor={undefined}
+          >
+            Token Name
+          </label>
+        </div>
+        <div
+          className="col-sm-4"
+        >
+          <input
+            className="form-control"
+            id="create-token-input"
+            onChange={[Function]}
+            placeholder="e.g ServiceName"
+            type="text"
+            value=""
+          />
+        </div>
+        <div
+          className="col-sm-2"
+        >
+          <button
+            className="btn btn-primary"
+            disabled={true}
+            id="create-token"
+            onClick={[Function]}
+            type="submit"
+          >
+            Create Token
+          </button>
+        </div>
+      </div>
+    </div>
+    <hr />
+  </form>
+  <div>
+    <div
+      className="row"
+    >
+      <div
+        className="col-md-5"
+      >
+        <div
+          className="filter"
+        >
+          <form
+            className="form-inline"
+            onSubmit={[Function]}
+            style={
+              Object {
+                "display": "inline",
+              }
+            }
+          >
+            <div
+              className="form-group"
+            >
+              <label
+                className="control-label"
+                htmlFor="filter-data-filter"
+              >
+                Filter
+              </label>
+              <div
+                className="typeahead-wrapper"
+              >
+                <input
+                  className="form-control"
+                  id="filter-data-filter"
+                  label="Filter"
+                  onKeyPress={undefined}
+                  placeholder=""
+                  type="text"
+                  value={undefined}
+                />
+                
+              </div>
+            </div>
+            <button
+              className="btn btn-default"
+              disabled={false}
+              style={
+                Object {
+                  "marginLeft": 5,
+                }
+              }
+              type="submit"
+            >
+              Filter
+            </button>
+            <button
+              className="btn btn-default"
+              disabled={true}
+              onClick={[Function]}
+              style={
+                Object {
+                  "marginLeft": 5,
+                }
+              }
+              type="button"
+            >
+              Reset
+            </button>
+          </form>
+          <ul
+            className="pill-list"
+          />
+        </div>
+      </div>
+    </div>
+    <ul
+      className="list-group"
+    >
+      <li
+        className="list-group-header list-group-item"
+      >
+        <div
+          className="list-group-item-heading"
+        >
+          <div
+            className="form-group"
+          >
+            <div
+              className="form-group-inline"
+            >
+              <div
+                className="checkbox"
+                style={undefined}
+              >
+                <label
+                  title=""
+                >
+                  <input
+                    checked={false}
+                    disabled={false}
+                    label="Select all"
+                    onChange={[Function]}
+                    placeholder=""
+                    type="checkbox"
+                    value={undefined}
+                  />
+                  Select all
+                </label>
+              </div>
+              
+            </div>
+          </div>
+        </div>
+        <p
+          className="list-group-item-text"
+        />
+      </li>
+      <li
+        className="list-group-item"
+      >
+        <div
+          className="list-group-item-heading"
+        >
+          <div
+            className="pull-right"
+            style={
+              Object {
+                "marginBottom": 10,
+                "marginTop": 10,
+              }
+            }
+          >
+            <span>
+              <button
+                className="btn btn-xs btn-default"
+                data-clipboard-button={true}
+                data-clipboard-text="beef2001"
+                disabled={false}
+                type="button"
+              >
+                Copy to clipboard
+              </button>
+              <button
+                className="btn btn-xs btn-primary"
+                disabled={false}
+                onClick={[Function]}
+                type="button"
+              >
+                Delete
+              </button>
+            </span>
+          </div>
+          <div
+            className="form-group"
+          >
+            <span>
+              <div
+                className="checkbox"
+                style={undefined}
+              >
+                <label
+                  title=""
+                >
+                  <input
+                    checked={false}
+                    disabled={false}
+                    groupClassName="form-group-inline"
+                    label="Acme"
+                    onChange={[Function]}
+                    placeholder=""
+                    type="checkbox"
+                    value={undefined}
+                  />
+                  Acme
+                </label>
+              </div>
+              
+            </span>
+          </div>
+        </div>
+        <p
+          className="list-group-item-text"
+        />
+      </li>
+      <li
+        className="list-group-item"
+      >
+        <div
+          className="list-group-item-heading"
+        >
+          <div
+            className="pull-right"
+            style={
+              Object {
+                "marginBottom": 10,
+                "marginTop": 10,
+              }
+            }
+          >
+            <span>
+              <button
+                className="btn btn-xs btn-default"
+                data-clipboard-button={true}
+                data-clipboard-text="beef2002"
+                disabled={false}
+                type="button"
+              >
+                Copy to clipboard
+              </button>
+              <button
+                className="btn btn-xs btn-primary"
+                disabled={false}
+                onClick={[Function]}
+                type="button"
+              >
+                Delete
+              </button>
+            </span>
+          </div>
+          <div
+            className="form-group"
+          >
+            <span>
+              <div
+                className="checkbox"
+                style={undefined}
+              >
+                <label
+                  title=""
+                >
+                  <input
+                    checked={false}
+                    disabled={false}
+                    groupClassName="form-group-inline"
+                    label="Hamfred"
+                    onChange={[Function]}
+                    placeholder=""
+                    type="checkbox"
+                    value={undefined}
+                  />
+                  Hamfred
+                </label>
+              </div>
+              
+            </span>
+          </div>
+        </div>
+        <p
+          className="list-group-item-text"
+        />
+      </li>
+    </ul>
+  </div>
+  <div
+    className="checkbox"
+    style={undefined}
+  >
+    <label
+      title=""
+    >
+      <input
+        checked={true}
+        disabled={false}
+        id="hide-tokens"
+        onChange={[Function]}
+        type="checkbox"
+      />
+      Hide Tokens
+    </label>
+  </div>
+</span>
+`;

--- a/graylog2-web-interface/src/pages/EditTokensPage.jsx
+++ b/graylog2-web-interface/src/pages/EditTokensPage.jsx
@@ -20,6 +20,8 @@ const EditTokensPage = React.createClass({
   getInitialState() {
     return {
       username: undefined,
+      creatingToken: false,
+      deletingToken: undefined,
       tokens: [],
     };
   },
@@ -49,14 +51,22 @@ const EditTokensPage = React.createClass({
       [`users:tokenlist:${username}`]);
   },
 
-  _deleteToken(token) {
-    const promise = UsersStore.deleteToken(this.props.params.username, token);
-    promise.then(() => this._loadTokens(this.props.params.username));
+  _deleteToken(token, tokenName) {
+    const promise = UsersStore.deleteToken(this.props.params.username, token, tokenName);
+    this.setState({ deletingToken: token });
+    promise.then(() => {
+      this._loadTokens(this.props.params.username);
+      this.setState({ deletingToken: undefined });
+    });
   },
 
   _createToken(tokenName) {
     const promise = UsersStore.createToken(this.props.params.username, tokenName);
-    promise.then(() => this._loadTokens(this.props.params.username));
+    this.setState({ creatingToken: true });
+    promise.then(() => {
+      this._loadTokens(this.props.params.username);
+      this.setState({ creatingToken: false });
+    });
   },
 
   render() {
@@ -68,8 +78,11 @@ const EditTokensPage = React.createClass({
             {null}
           </PageHeader>
           <TokenList tokens={this.state.tokens}
-                     delete={this._deleteToken}
-                     create={this._createToken} />
+                     onDelete={this._deleteToken}
+                     onCreate={this._createToken}
+                     creatingToken={this.state.creatingToken}
+                     deletingToken={this.state.deletingToken}
+          />
         </span>
       </DocumentTitle>
     );

--- a/graylog2-web-interface/src/pages/EditTokensPage.jsx
+++ b/graylog2-web-interface/src/pages/EditTokensPage.jsx
@@ -1,0 +1,79 @@
+import PropTypes from 'prop-types';
+import React from 'react';
+import Reflux from 'reflux';
+
+import TokenList from 'components/users/TokenList';
+import StoreProvider from 'injection/StoreProvider';
+import { DocumentTitle, PageHeader } from 'components/common';
+import PermissionsMixin from 'util/PermissionsMixin';
+
+const UsersStore = StoreProvider.getStore('Users');
+const CurrentUserStore = StoreProvider.getStore('CurrentUser');
+
+const EditTokensPage = React.createClass({
+  mixins: [Reflux.connect(CurrentUserStore), PermissionsMixin],
+
+  propTypes: {
+    params: PropTypes.object.isRequiered,
+  },
+
+  getInitialState() {
+    return {
+      username: undefined,
+      tokens: [],
+    };
+  },
+
+  componentDidMount() {
+    this._loadTokens(this.props.params.username);
+  },
+
+  componentWillReceiveProps(nextProps) {
+    if (this.props.params.username !== nextProps.params.username) {
+      this._loadTokens(nextProps.params.username);
+    }
+  },
+
+  _loadTokens(username) {
+    if (this._canListTokens(username)) {
+      UsersStore.loadTokens(username).then((tokens) => {
+        this.setState({ tokens: tokens });
+      });
+    } else {
+      this.setState({ tokens: [] });
+    }
+  },
+
+  _canListTokens(username) {
+    return this.isPermitted(this.state.currentUser.permissions,
+      [`users:tokenlist:${username}`]);
+  },
+
+  _deleteToken(token) {
+    const promise = UsersStore.deleteToken(this.props.params.username, token);
+    promise.then(() => this._loadTokens(this.props.params.username));
+  },
+
+  _createToken(tokenName) {
+    const promise = UsersStore.createToken(this.props.params.username, tokenName);
+    promise.then(() => this._loadTokens(this.props.params.username));
+  },
+
+  render() {
+    return (
+      <DocumentTitle title={`Edit tokens of user ${this.props.params.username}`}>
+        <span>
+          <PageHeader title={<span>Edit tokens of user <em>{this.props.params.username}</em></span>} subpage>
+            <span>You can create new tokens or delete old ones.</span>
+            {null}
+          </PageHeader>
+          <TokenList tokens={this.state.tokens}
+                     delete={this._deleteToken}
+                     create={this._createToken} />
+        </span>
+      </DocumentTitle>
+    );
+  },
+});
+
+export default EditTokensPage;

--- a/graylog2-web-interface/src/routing/ApiRoutes.js
+++ b/graylog2-web-interface/src/routing/ApiRoutes.js
@@ -319,9 +319,9 @@ const ApiRoutes = {
     load: (username) => { return { url: `/users/${username}` }; },
     delete: (username) => { return { url: `/users/${username}` }; },
     update: (username) => { return { url: `/users/${username}` }; },
-    create_token: (username, token_name) => {return { url: `/users/${username}/tokens/${token_name}`}},
-    delete_token: (username, token_name) => {return { url: `/users/${username}/tokens/${token_name}`}},
-    list_tokens: (username, token_name) => {return { url: `/users/${username}/tokens`}},
+    create_token: (username, tokenName) => { return { url: `/users/${username}/tokens/${tokenName}` }; },
+    delete_token: (username, tokenName) => { return { url: `/users/${username}/tokens/${tokenName}` }; },
+    list_tokens: (username) => { return { url: `/users/${username}/tokens` }; },
   },
   DashboardsController: {
     show: (id) => { return { url: `/dashboards/${id}` }; },

--- a/graylog2-web-interface/src/routing/ApiRoutes.js
+++ b/graylog2-web-interface/src/routing/ApiRoutes.js
@@ -319,6 +319,9 @@ const ApiRoutes = {
     load: (username) => { return { url: `/users/${username}` }; },
     delete: (username) => { return { url: `/users/${username}` }; },
     update: (username) => { return { url: `/users/${username}` }; },
+    create_token: (username, token_name) => {return { url: `/users/${username}/tokens/${token_name}`}},
+    delete_token: (username, token_name) => {return { url: `/users/${username}/tokens/${token_name}`}},
+    list_tokens: (username, token_name) => {return { url: `/users/${username}/tokens`}},
   },
   DashboardsController: {
     show: (id) => { return { url: `/dashboards/${id}` }; },

--- a/graylog2-web-interface/src/routing/AppRouter.jsx
+++ b/graylog2-web-interface/src/routing/AppRouter.jsx
@@ -137,7 +137,7 @@ const AppRouter = React.createClass({
                 <Route path={Routes.SYSTEM.AUTHENTICATION.USERS.LIST} component={UsersPage} />
                 <Route path={Routes.SYSTEM.AUTHENTICATION.USERS.CREATE} component={CreateUsersPage} />
                 <Route path={Routes.SYSTEM.AUTHENTICATION.USERS.edit(':username')} component={EditUsersPage} />
-                <Route path={Routes.SYSTEM.AUTHENTICATION.USERS.edit_tokens(':username')} component={EditTokensPage} />
+                <Route path={Routes.SYSTEM.AUTHENTICATION.USERS.TOKENS.edit(':username')} component={EditTokensPage} />
                 <Route path={Routes.SYSTEM.AUTHENTICATION.ROLES} component={RolesPage} />
                 <Route path={Routes.SYSTEM.AUTHENTICATION.PROVIDERS.CONFIG} />
                 <Route path={Routes.SYSTEM.AUTHENTICATION.PROVIDERS.provider(':name')} />

--- a/graylog2-web-interface/src/routing/AppRouter.jsx
+++ b/graylog2-web-interface/src/routing/AppRouter.jsx
@@ -42,6 +42,7 @@ import ExportContentPackPage from 'pages/ExportContentPackPage';
 import UsersPage from 'pages/UsersPage';
 import CreateUsersPage from 'pages/CreateUsersPage';
 import EditUsersPage from 'pages/EditUsersPage';
+import EditTokensPage from 'pages/EditTokensPage';
 import GrokPatternsPage from 'pages/GrokPatternsPage';
 import SystemOverviewPage from 'pages/SystemOverviewPage';
 import IndexerFailuresPage from 'pages/IndexerFailuresPage';
@@ -136,6 +137,7 @@ const AppRouter = React.createClass({
                 <Route path={Routes.SYSTEM.AUTHENTICATION.USERS.LIST} component={UsersPage} />
                 <Route path={Routes.SYSTEM.AUTHENTICATION.USERS.CREATE} component={CreateUsersPage} />
                 <Route path={Routes.SYSTEM.AUTHENTICATION.USERS.edit(':username')} component={EditUsersPage} />
+                <Route path={Routes.SYSTEM.AUTHENTICATION.USERS.edit_tokens(':username')} component={EditTokensPage} />
                 <Route path={Routes.SYSTEM.AUTHENTICATION.ROLES} component={RolesPage} />
                 <Route path={Routes.SYSTEM.AUTHENTICATION.PROVIDERS.CONFIG} />
                 <Route path={Routes.SYSTEM.AUTHENTICATION.PROVIDERS.provider(':name')} />

--- a/graylog2-web-interface/src/routing/Routes.jsx
+++ b/graylog2-web-interface/src/routing/Routes.jsx
@@ -93,6 +93,8 @@ const Routes = {
       USERS: {
         CREATE: '/system/authentication/users/new',
         edit: username => `/system/authentication/users/edit/${username}`,
+        edit_tokens: username => `/system/authentication/users/tokens/${username}`,
+        TOKENS: '/system/authentication/users/tokens/',
         LIST: '/system/authentication/users',
       },
       PROVIDERS: {

--- a/graylog2-web-interface/src/routing/Routes.jsx
+++ b/graylog2-web-interface/src/routing/Routes.jsx
@@ -93,8 +93,9 @@ const Routes = {
       USERS: {
         CREATE: '/system/authentication/users/new',
         edit: username => `/system/authentication/users/edit/${username}`,
-        edit_tokens: username => `/system/authentication/users/tokens/${username}`,
-        TOKENS: '/system/authentication/users/tokens/',
+        TOKENS: {
+          edit: username => `/system/authentication/users/tokens/${username}`,
+        },
         LIST: '/system/authentication/users',
       },
       PROVIDERS: {

--- a/graylog2-web-interface/src/stores/users/UsersStore.ts
+++ b/graylog2-web-interface/src/stores/users/UsersStore.ts
@@ -109,9 +109,9 @@ export const UsersStore = {
     return promise;
   },
 
-  deleteToken(username: string, token_name: string): Promise<string[]> {
+  deleteToken(username: string, token: string, token_name: string): Promise<string[]> {
     const  url = URLUtils.qualifyUrl(ApiRoutes.UsersApiController.delete_token(encodeURIComponent(username),
-      encodeURIComponent(token_name)).url, {});
+      encodeURIComponent(token)).url, {});
     const  promise = fetch('DELETE', url);
 
     promise.then(() => {

--- a/graylog2-web-interface/src/stores/users/UsersStore.ts
+++ b/graylog2-web-interface/src/stores/users/UsersStore.ts
@@ -25,6 +25,12 @@ export interface User {
   startpage?: StartPage;
 }
 
+export interface Token {
+  token_name: string;
+  token: string;
+  last_access: string;
+}
+
 export interface ChangePasswordRequest {
   old_password: string;
   password: string;
@@ -92,6 +98,43 @@ export const UsersStore = {
   update(username: string, request: any): void {
     const url = URLUtils.qualifyUrl(ApiRoutes.UsersApiController.update(encodeURIComponent(username)).url);
     const promise = fetch('PUT', url, request);
+
+    return promise;
+  },
+
+  createToken(username: string, token_name: string): Promise<Token> {
+    const url = URLUtils.qualifyUrl(ApiRoutes.UsersApiController.create_token(encodeURIComponent(username),
+      encodeURIComponent(token_name), ).url);
+    const promise = fetch('POST', url);
+    return promise;
+  },
+
+  deleteToken(username: string, token_name: string): Promise<string[]> {
+    const  url = URLUtils.qualifyUrl(ApiRoutes.UsersApiController.delete_token(encodeURIComponent(username),
+      encodeURIComponent(token_name)).url, {});
+    const  promise = fetch('DELETE', url);
+
+    promise.then(() => {
+      UserNotification.success("Token \"" + token_name + "\" of user \"" + username + "\" was deleted successfully");
+    }, (error) => {
+      if (error.additional.status !== 404) {
+        UserNotification.error("Delete token \"" + token_name + "\" of user failed with status: " + error,
+          "Could not delete token.");
+      }
+    });
+
+    return promise;
+  },
+
+  loadTokens(username: string): Promise<Token[]> {
+    const url = URLUtils.qualifyUrl(ApiRoutes.UsersApiController.list_tokens(encodeURIComponent(username)).url);
+    const promise = fetch('GET', url)
+      .then(
+        response => response.tokens,
+        (error) => {
+          UserNotification.error("Loading tokens of user failed with status: " + error,
+            "Could not load tokens of user " + username);
+        });
 
     return promise;
   },

--- a/graylog2-web-interface/test/helpers/mocking/react-dom_mock.js
+++ b/graylog2-web-interface/test/helpers/mocking/react-dom_mock.js
@@ -1,0 +1,10 @@
+/* https://github.com/facebook/react/issues/7371
+ *
+ * findDomNode with refs is not supported by the react-test-renderer.
+ * So we need to mock the findDOMNode function for TableList respectievly
+ * for its child component TypeAheadDataFilter.
+ */
+jest.mock('react-dom', () => ({
+  findDOMNode: () => ({}),
+}));
+


### PR DESCRIPTION
## Description
API Tokens are configurable via REST API but there is till now no way to
create, delete or list them in the web interface.

- I fixed the permissions handling for API Tokens which till now only worked, if the user requested his own tokens regardless of his role (like admin). That meant that even the admin could not alter the API Tokens. Now a normal user can only manage his own Tokens and a user with role *admin* can manage the tokens of other people additionally.
- Add a new TokenList Component which list, create and deletes tokens. I did not wire the UserStore into that component but rather gave handlers as arguments and implemented them by the caller. This is easier to test and easier to use IMHO.

## Motivation and Context
To use tokens a user needed to use the REST API manually to create delete or list
them.

## How Has This Been Tested?
I tested the REST API to ensure that the permissions worked as I described above.
I tested the TokenList manually.

## Screenshots (if appropriate):
![graylog - edit tokens of user admin](https://user-images.githubusercontent.com/448763/35853214-35db40e6-0b2d-11e8-8f3f-026c0d05a3ed.png)

Fixes #3318 
## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
