### PR TITLE
Allow using colon character (":") in password

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/shared/security/ShiroSecurityContext.java
+++ b/graylog2-server/src/main/java/org/graylog2/shared/security/ShiroSecurityContext.java
@@ -19,11 +19,13 @@ package org.graylog2.shared.security;
 import com.google.common.annotations.VisibleForTesting;
 import org.apache.shiro.authc.AuthenticationException;
 import org.apache.shiro.authc.AuthenticationToken;
+import org.apache.shiro.authc.UsernamePasswordToken;
 import org.apache.shiro.subject.Subject;
 import org.apache.shiro.util.ThreadContext;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import javax.annotation.Nullable;
 import javax.ws.rs.core.MultivaluedHashMap;
 import javax.ws.rs.core.MultivaluedMap;
 import javax.ws.rs.core.SecurityContext;
@@ -49,6 +51,7 @@ public class ShiroSecurityContext implements SecurityContext {
         this.headers = new MultivaluedHashMap<String, String>(headers);
     }
 
+    @Nullable
     public String getUsername() {
         if (token == null || token.getPrincipal() == null) {
             return null;
@@ -56,11 +59,14 @@ public class ShiroSecurityContext implements SecurityContext {
         return token.getPrincipal().toString();
     }
 
+    @Nullable
     public String getPassword() {
-        if (token == null || token.getCredentials() == null) {
+        if (token instanceof UsernamePasswordToken) {
+            final char[] credentials = (char[]) token.getCredentials();
+            return String.valueOf(credentials);
+        } else {
             return null;
         }
-        return token.getCredentials().toString();
     }
 
     public Subject getSubject() {

--- a/graylog2-server/src/main/java/org/graylog2/shared/security/ShiroSecurityContextFilter.java
+++ b/graylog2-server/src/main/java/org/graylog2/shared/security/ShiroSecurityContextFilter.java
@@ -75,7 +75,7 @@ public class ShiroSecurityContextFilter implements ContainerRequestFilter {
         if (authHeader != null && authHeader.startsWith("Basic")) {
             final String base64UserPass = authHeader.substring(authHeader.indexOf(' ') + 1);
             final String userPass = decodeBase64(base64UserPass);
-            final String[] split = userPass.split(":");
+            final String[] split = userPass.split(":", 2);
 
             if (split.length != 2) {
                 throw new BadRequestException("Invalid credentials in Authorization header");

--- a/graylog2-server/src/test/java/org/graylog2/shared/security/ShiroSecurityContextFilterTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/shared/security/ShiroSecurityContextFilterTest.java
@@ -167,4 +167,24 @@ public class ShiroSecurityContextFilterTest {
         assertThat(securityContext.getAuthenticationScheme()).isEqualTo(SecurityContext.BASIC_AUTH);
         assertThat(securityContext.getToken()).isExactlyInstanceOf(AccessTokenAuthToken.class);
     }
+
+
+    @Test
+    public void filterWithBasicAuthAndPasswordWithColonShouldCreateShiroSecurityContextWithUsernamePasswordToken() throws Exception {
+        final MultivaluedHashMap<String, String> headers = new MultivaluedHashMap<>();
+        final String credentials = Base64.getEncoder().encodeToString("user:pass:word".getBytes(StandardCharsets.US_ASCII));
+        headers.putSingle(HttpHeaders.AUTHORIZATION, "Basic " + credentials);
+        when(requestContext.getHeaders()).thenReturn(headers);
+
+        filter.filter(requestContext);
+
+        final ArgumentCaptor<ShiroSecurityContext> argument = ArgumentCaptor.forClass(ShiroSecurityContext.class);
+        verify(requestContext).setSecurityContext(argument.capture());
+        final ShiroSecurityContext securityContext = argument.getValue();
+        assertThat(securityContext).isExactlyInstanceOf(ShiroSecurityContext.class);
+        assertThat(securityContext.getAuthenticationScheme()).isEqualTo(SecurityContext.BASIC_AUTH);
+        assertThat(securityContext.getUsername()).isEqualTo("user");
+        assertThat(securityContext.getPassword()).isEqualTo("pass:word");
+        assertThat(securityContext.getToken()).isExactlyInstanceOf(UsernamePasswordToken.class);
+    }
 }


### PR DESCRIPTION
`ShiroSecurityContextFilter` incorrectly parsed the HTTP Basic Auth header and
prevented users from using the colon character (":") in their passwords.

Refs #4547
(cherry picked from commit 6a49304d5fb60ff1cd5c4b77519527f42708ef8a)