### PR TITLE
Fix entry count metric for lookup caches

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/lookup/caches/GuavaLookupCache.java
+++ b/graylog2-server/src/main/java/org/graylog2/lookup/caches/GuavaLookupCache.java
@@ -16,7 +16,6 @@
  */
 package org.graylog2.lookup.caches;
 
-import com.codahale.metrics.Gauge;
 import com.codahale.metrics.MetricRegistry;
 import com.codahale.metrics.Timer;
 import com.fasterxml.jackson.annotation.JsonAutoDetect;
@@ -82,11 +81,11 @@ public class GuavaLookupCache extends LookupCache {
     }
 
     @Override
-    public Gauge<Long> entryCount() {
+    public long entryCount() {
         if (cache != null) {
-            return cache::size;
+            return cache.size();
         } else {
-            return () -> 0L;
+            return 0L;
         }
     }
 

--- a/graylog2-server/src/main/java/org/graylog2/plugin/lookup/LookupCache.java
+++ b/graylog2-server/src/main/java/org/graylog2/plugin/lookup/LookupCache.java
@@ -60,7 +60,13 @@ public abstract class LookupCache extends AbstractIdleService {
         this.hitCount = metricRegistry.meter(MetricRegistry.name("org.graylog2.lookup.caches", id, "hits"));
         this.missCount = metricRegistry.meter(MetricRegistry.name("org.graylog2.lookup.caches", id, "misses"));
         this.lookupTimer = metricRegistry.timer(MetricRegistry.name("org.graylog2.lookup.caches", id, "lookupTime"));
-        MetricUtils.safelyRegister(metricRegistry, MetricRegistry.name("org.graylog2.lookup.caches", id, "entries"), entryCount());
+        final Gauge<Long> entriesGauge = new Gauge<Long>() {
+            @Override
+            public Long getValue() {
+                return entryCount();
+            }
+        };
+        MetricUtils.safelyRegister(metricRegistry, MetricRegistry.name("org.graylog2.lookup.caches", id, "entries"), entriesGauge);
     }
 
     public void incrTotalCount() {
@@ -79,9 +85,13 @@ public abstract class LookupCache extends AbstractIdleService {
         return lookupTimer.time();
     }
 
-    public Gauge<Long> entryCount() {
-        // Returns -1 if the cache does not support counting entries
-        return () -> -1L;
+    /**
+     * Get the number of elements in this lookup cache.
+     *
+     * @return the number of elements in this lookup cache or {@code -1L} if the cache does not support counting entries
+     */
+    public long entryCount() {
+        return -1L;
     }
 
     @Override

--- a/graylog2-web-interface/src/components/lookup-tables/CacheTableEntry.jsx
+++ b/graylog2-web-interface/src/components/lookup-tables/CacheTableEntry.jsx
@@ -44,7 +44,7 @@ const LUTTableEntry = React.createClass({
   _onEntriesMetrics(metrics) {
     let total = 0;
 
-    Object.keys(metrics).map(nodeId => metrics[nodeId].count.metric.value.value).forEach((v) => { total += v; });
+    Object.keys(metrics).map(nodeId => metrics[nodeId].count.metric.value).forEach((v) => { total += v; });
 
     if (total < 0) {
       return 'n/a';


### PR DESCRIPTION
* Fix entry count metric for lookup caches

The way the `LookupCache#entryCount()` method was defined, caused implementers to write incorrect implementations.

For example `GuavaLookupCache#entryCount()` returned a constant `Gauge<Long>` on the first call (in the constructor
of `LookupCache`) which was never updated.

Additionally, the `CacheTableEntry` tried to access the entry count metric through an invalid object path which
resulted in the metric always being displayed as "NaN" in the web interface.

Fixes #4540

* Make entry count Gauge compatible with Graylog 2.4.x

Refs #4499

Refs #4541
(cherry picked from commit 0ddbeace09b177ba4ceb702962636dd26b5055a3)