### PR TITLE
Restrict search in edit extractor example (#4554)

### DIFF
--- a/graylog2-web-interface/src/pages/EditExtractorsPage.jsx
+++ b/graylog2-web-interface/src/pages/EditExtractorsPage.jsx
@@ -34,7 +34,7 @@ const EditExtractorsPage = React.createClass({
   componentDidMount() {
     InputsActions.get.triggerPromise(this.props.params.inputId);
     ExtractorsActions.get.triggerPromise(this.props.params.inputId, this.props.params.extractorId);
-    UniversalSearchstore.search('relative', `gl2_source_input:${this.props.params.inputId} OR gl2_source_radio_input:${this.props.params.inputId}`, { range: 0 }, undefined, 1)
+    UniversalSearchstore.search('relative', `gl2_source_input:${this.props.params.inputId} OR gl2_source_radio_input:${this.props.params.inputId}`, { relative: 3600 }, undefined, 1)
       .then((response) => {
         if (response.total_results > 0) {
           this.setState({ exampleMessage: response.messages[0] });


### PR DESCRIPTION
We recently fixed an issue in the RecentMessageLoader component to
ensure the search of an example is restricted to the last hour. This
change does the same for the edit extractor page.

Fixes #4553

(cherry picked from commit 4e89b70b256079868ff7c496d493ffc7c3fcffad)