### PR TITLE
Use a unique LDAP server storage location in tests

### DIFF
--- a/graylog2-server/src/test/java/org/graylog2/ApacheDirectoryTestServiceFactory.java
+++ b/graylog2-server/src/test/java/org/graylog2/ApacheDirectoryTestServiceFactory.java
@@ -1,0 +1,28 @@
+package org.graylog2;
+
+import org.apache.directory.server.core.annotations.CreateDS;
+import org.apache.directory.server.core.factory.DefaultDirectoryServiceFactory;
+import org.apache.directory.server.core.factory.DirectoryServiceFactory;
+
+import java.util.Locale;
+import java.util.UUID;
+
+/**
+ * Custom ApacheDS {@link DirectoryServiceFactory} for running tests.
+ * <p>
+ * The {@link DefaultDirectoryServiceFactory} uses a storage directory based on the {@link CreateDS#name()}. Because
+ * that name is static, running tests in parallel and using the same TMPDIR leads to test failures.
+ */
+public class ApacheDirectoryTestServiceFactory extends DefaultDirectoryServiceFactory {
+    /**
+     * This init method ensures that the directory service is using a unique name so a unique storage location is
+     * used in TMPDIR.
+     *
+     * @see DefaultDirectoryServiceFactory#buildInstanceDirectory(String)
+     * @param name the server instance name
+     */
+    @Override
+    public void init(String name) throws Exception {
+        super.init(String.format(Locale.ENGLISH, "%s-%s", name, UUID.randomUUID().toString()));
+    }
+}

--- a/graylog2-server/src/test/java/org/graylog2/ApacheDirectoryTestServiceFactory.java
+++ b/graylog2-server/src/test/java/org/graylog2/ApacheDirectoryTestServiceFactory.java
@@ -1,3 +1,19 @@
+/**
+ * This file is part of Graylog.
+ *
+ * Graylog is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package org.graylog2;
 
 import org.apache.directory.server.core.annotations.CreateDS;

--- a/graylog2-server/src/test/java/org/graylog2/security/ldap/LdapConnectorTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/security/ldap/LdapConnectorTest.java
@@ -32,6 +32,7 @@ import org.apache.directory.server.core.integ.AbstractLdapTestUnit;
 import org.apache.directory.server.core.integ.FrameworkRunner;
 import org.apache.directory.server.core.partition.impl.avl.AvlPartition;
 import org.apache.directory.server.ldap.LdapServer;
+import org.graylog2.ApacheDirectoryTestServiceFactory;
 import org.graylog2.shared.security.ldap.LdapEntry;
 import org.junit.After;
 import org.junit.Before;
@@ -50,6 +51,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 })
 @CreateDS(
         name = "LdapConnectorTest",
+        factory = ApacheDirectoryTestServiceFactory.class, // Ensures a unique storage location
         partitions = {
                 @CreatePartition(
                         name = "example.com",

--- a/graylog2-server/src/test/java/org/graylog2/security/realm/LdapUserAuthenticatorTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/security/realm/LdapUserAuthenticatorTest.java
@@ -34,6 +34,7 @@ import org.apache.directory.server.core.partition.impl.avl.AvlPartition;
 import org.apache.directory.server.ldap.LdapServer;
 import org.apache.shiro.authc.AuthenticationToken;
 import org.apache.shiro.authc.UsernamePasswordToken;
+import org.graylog2.ApacheDirectoryTestServiceFactory;
 import org.graylog2.Configuration;
 import org.graylog2.plugin.database.users.User;
 import org.graylog2.security.ldap.LdapConnector;
@@ -68,6 +69,7 @@ import static org.mockito.Mockito.when;
 })
 @CreateDS(
         name = "LdapUserAuthenticatorTest",
+        factory = ApacheDirectoryTestServiceFactory.class, // Ensures a unique storage location
         partitions = {
                 @CreatePartition(
                         name = "example.com",


### PR DESCRIPTION
The default LDAP server factory creates a storage location based on the CreateDS annotation name. This led to sporadic test failures in our CI environment when running the same job in parallel.

Example failure:

```
2018-02-02 11:51:34,106 ERROR: org.apache.directory.server.core.integ.FrameworkRunner - ERR_181 Failed to run the class org.graylog2.security.realm.LdapUserAuthenticatorTest
2018-02-02 11:51:34,108 ERROR: org.apache.directory.server.core.integ.FrameworkRunner - java.io.FileNotFoundException: /tmp/server-work-LdapUserAuthenticatorTest/partitions/system/2.5.4.0.lg (No such file or directory)
Tests run: 1, Failures: 0, Errors: 1, Skipped: 0, Time elapsed: 24.402 sec <<< FAILURE! - in org.graylog2.security.realm.LdapUserAuthenticatorTest
org.graylog2.security.realm.LdapUserAuthenticatorTest  Time elapsed: 24.402 sec  <<< ERROR!
org.apache.directory.api.ldap.model.exception.LdapException: java.io.FileNotFoundException: /tmp/server-work-LdapUserAuthenticatorTest/partitions/system/2.5.4.0.lg (No such file or directory)
```
