### PR TITLE
Reduce development startup time by improving globbing.

### DIFF
--- a/graylog2-web-interface/webpack.combined.config.js
+++ b/graylog2-web-interface/webpack.combined.config.js
@@ -8,10 +8,15 @@ const MANIFESTS_PATH = path.resolve(ROOT_PATH, 'manifests');
 const VENDOR_MANIFEST_PATH = path.resolve(MANIFESTS_PATH, 'vendor-manifest.json');
 const TARGET = process.env.npm_lifecycle_event;
 
-const pluginPrefix = '../../graylog-plugin-*/**/';
-const pluginConfigPattern = `${pluginPrefix}webpack.config.js`;
+const pluginConfigPattern = 'graylog-plugin-*/**/webpack.config.js';
+const globCwd = '../..';
+const globOptions = {
+  ignore: '**/node_modules/**',
+  cwd: globCwd,
+  nodir: true,
+};
 
-const pluginConfigs = process.env.disable_plugins === 'true' ? [] : glob.sync(pluginConfigPattern);
+const pluginConfigs = process.env.disable_plugins === 'true' ? [] : glob.sync(pluginConfigPattern, globOptions);
 
 process.env.web_src_path = path.resolve(__dirname);
 

--- a/graylog2-web-interface/webpack.combined.config.js
+++ b/graylog2-web-interface/webpack.combined.config.js
@@ -16,7 +16,7 @@ const globOptions = {
   nodir: true,
 };
 
-const pluginConfigs = process.env.disable_plugins === 'true' ? [] : glob.sync(pluginConfigPattern, globOptions);
+const pluginConfigs = process.env.disable_plugins === 'true' ? [] : glob.sync(pluginConfigPattern, globOptions).map(config => `${globCwd}/${config}`);
 
 process.env.web_src_path = path.resolve(__dirname);
 


### PR DESCRIPTION
## Description
## Motivation and Context

With a higher number (>5) of plugins in development, running yarn start takes
significant time during the globbing step which finds all webpack configs of
the installed plugins.

By using better glob options (ignoring the `node_modules` directories of
installed plugins and setting the working directory of the glob
explicitly instead of implicitly by including it in the glob pattern),
we are able to reduce globbing times by the factor of 100.

I wrote a small script[1] to compare the times for both options, its
results are (on my machine):

```
glob: 53.336s
glob w/ ignoring + cwd: 0.581s
```

[1]: https://gist.github.com/dennisoelkers/682b8fd25233ec0d2df03107b929e860

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
