### PR TITLE
Add JSON factory method for `LookupResult`

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/plugin/lookup/LookupCacheKey.java
+++ b/graylog2-server/src/main/java/org/graylog2/plugin/lookup/LookupCacheKey.java
@@ -39,6 +39,12 @@ import javax.annotation.Nullable;
  * // Key with prefix only
  * LookupCacheKey.prefix(dataAdapter.id());
  * }</pre>
+ * <p>
+ * For convenience, this class can be serialized and deserialized with Jackson (see
+ * {@link com.fasterxml.jackson.databind.ObjectMapper}, but we strongly recommend implementing your own
+ * serialization and deserialization logic if you're implementing a lookup cache.
+ * <p>
+ * There are <em>no guarantees</em> about binary compatibility of this class across Graylog releases!
  */
 @AutoValue
 public abstract class LookupCacheKey {

--- a/graylog2-server/src/main/java/org/graylog2/plugin/lookup/LookupResult.java
+++ b/graylog2-server/src/main/java/org/graylog2/plugin/lookup/LookupResult.java
@@ -16,6 +16,8 @@
  */
 package org.graylog2.plugin.lookup;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.auto.value.AutoValue;
 import org.graylog2.lookup.LookupDefaultMultiValue;
@@ -25,6 +27,19 @@ import javax.annotation.Nullable;
 import java.util.Collections;
 import java.util.Map;
 
+/**
+ * The result of looking up a key in a lookup table (i. e. lookup data adapter or lookup cache).
+ * <p>
+ * For convenience, this class can be serialized and deserialized with Jackson (see
+ * {@link com.fasterxml.jackson.databind.ObjectMapper}, but we strongly recommend implementing your own
+ * serialization and deserialization logic if you're implementing a lookup cache.
+ * <p>
+ * There are <em>no guarantees</em> about binary compatibility of this class across Graylog releases!
+ *
+ * @see LookupDataAdapter#get(Object)
+ * @see LookupCache#get(LookupCacheKey, java.util.concurrent.Callable)
+ * @see LookupCacheKey
+ */
 @AutoValue
 public abstract class LookupResult {
     private static final LookupResult EMPTY_LOOKUP_RESULT = builder()
@@ -44,7 +59,7 @@ public abstract class LookupResult {
     @JsonProperty("ttl")
     public abstract long cacheTTL();
 
-    @JsonProperty("empty")
+    @JsonIgnore
     public boolean isEmpty() {
         return singleValue() == null && multiValue() == null;
     }
@@ -104,6 +119,18 @@ public abstract class LookupResult {
 
             return builder.build();
     }
+
+    @JsonCreator
+    public static LookupResult createFromJSON(@JsonProperty("single_value") final Object singleValue,
+                                              @JsonProperty("multi_value") final Map<Object, Object> multiValue,
+                                              @JsonProperty("ttl") final long cacheTTL) {
+        return builder()
+                .singleValue(singleValue)
+                .multiValue(multiValue)
+                .cacheTTL(cacheTTL)
+                .build();
+    }
+
 
     public static Builder withoutTTL() {
         return builder().cacheTTL(Long.MAX_VALUE);

--- a/graylog2-server/src/test/java/org/graylog2/plugin/lookup/LookupResultTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/plugin/lookup/LookupResultTest.java
@@ -1,0 +1,177 @@
+/**
+ * This file is part of Graylog.
+ *
+ * Graylog is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.graylog2.plugin.lookup;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.collect.ImmutableMap;
+import org.graylog2.shared.bindings.providers.ObjectMapperProvider;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class LookupResultTest {
+    private static final Map<Object, Object> MULTI_VALUE = ImmutableMap.of(
+            "int", 42,
+            "bool", true,
+            "string", "Foobar"
+    );
+
+    private final ObjectMapper objectMapper = new ObjectMapperProvider().get();
+
+    @Test
+    public void serializeEmpty() {
+        final LookupResult lookupResult = LookupResult.empty();
+        final JsonNode node = objectMapper.convertValue(lookupResult, JsonNode.class);
+
+        assertThat(node.isNull()).isFalse();
+        assertThat(node.path("single_value").isNull()).isTrue();
+        assertThat(node.path("multi_value").isNull()).isTrue();
+        assertThat(node.path("ttl").asLong()).isEqualTo(Long.MAX_VALUE);
+    }
+
+    @Test
+    public void deserializeEmpty() throws IOException {
+        final String json = "{\"single_value\":null,\"multi_value\":null,\"ttl\":23}";
+        final LookupResult lookupResult = objectMapper.readValue(json, LookupResult.class);
+
+        assertThat(lookupResult.isEmpty()).isTrue();
+        assertThat(lookupResult.singleValue()).isNull();
+        assertThat(lookupResult.multiValue()).isNull();
+        assertThat(lookupResult.cacheTTL()).isEqualTo(23L);
+    }
+
+
+    @Test
+    public void serializeSingleNumber() {
+        final LookupResult lookupResult = LookupResult.single(42);
+        final JsonNode node = objectMapper.convertValue(lookupResult, JsonNode.class);
+
+        assertThat(node.isNull()).isFalse();
+        assertThat(node.path("single_value").asInt()).isEqualTo(42);
+        assertThat(node.path("multi_value").path("value").asInt()).isEqualTo(42);
+        assertThat(node.path("ttl").asLong()).isEqualTo(Long.MAX_VALUE);
+    }
+
+    @Test
+    public void deserializeSingleNumber() throws IOException {
+        final String json = "{\"single_value\":42,\"multi_value\":{\"value\":42},\"ttl\":23}";
+        final LookupResult lookupResult = objectMapper.readValue(json, LookupResult.class);
+
+        assertThat(lookupResult.isEmpty()).isFalse();
+        assertThat(lookupResult.singleValue()).isEqualTo(42);
+        assertThat(lookupResult.multiValue()).hasEntrySatisfying("value", v -> assertThat(v).isEqualTo(42));
+        assertThat(lookupResult.cacheTTL()).isEqualTo(23L);
+    }
+
+    @Test
+    public void serializeSingleBoolean() {
+        final LookupResult lookupResult = LookupResult.single(true);
+        final JsonNode node = objectMapper.convertValue(lookupResult, JsonNode.class);
+
+        assertThat(node.isNull()).isFalse();
+        assertThat(node.path("single_value").asBoolean()).isTrue();
+        assertThat(node.path("multi_value").path("value").asBoolean()).isTrue();
+        assertThat(node.path("ttl").asLong()).isEqualTo(Long.MAX_VALUE);
+    }
+
+    @Test
+    public void deserializeSingleBoolean() throws IOException {
+        final String json = "{\"single_value\":true,\"multi_value\":{\"value\":true},\"ttl\":23}";
+        final LookupResult lookupResult = objectMapper.readValue(json, LookupResult.class);
+
+        assertThat(lookupResult.isEmpty()).isFalse();
+        assertThat(lookupResult.singleValue()).isEqualTo(true);
+        assertThat(lookupResult.multiValue()).hasEntrySatisfying("value", v -> assertThat(v).isEqualTo(true));
+        assertThat(lookupResult.cacheTTL()).isEqualTo(23L);
+    }
+
+    @Test
+    public void serializeMultiString() {
+        final LookupResult lookupResult = LookupResult.multi("Foobar", MULTI_VALUE);
+        final JsonNode node = objectMapper.convertValue(lookupResult, JsonNode.class);
+
+        assertThat(node.isNull()).isFalse();
+        assertThat(node.path("single_value").asText()).isEqualTo("Foobar");
+        assertThat(node.path("multi_value").path("int").asInt()).isEqualTo(42);
+        assertThat(node.path("multi_value").path("bool").asBoolean()).isEqualTo(true);
+        assertThat(node.path("multi_value").path("string").asText()).isEqualTo("Foobar");
+        assertThat(node.path("ttl").asLong()).isEqualTo(Long.MAX_VALUE);
+    }
+
+    @Test
+    public void deserializeMultiString() throws IOException {
+        final String json = "{\"single_value\":\"Foobar\",\"multi_value\":{\"int\":42,\"bool\":true,\"string\":\"Foobar\"},\"ttl\":23}";
+        final LookupResult lookupResult = objectMapper.readValue(json, LookupResult.class);
+
+        assertThat(lookupResult.isEmpty()).isFalse();
+        assertThat(lookupResult.singleValue()).isEqualTo("Foobar");
+        assertThat(lookupResult.multiValue()).isEqualTo(MULTI_VALUE);
+        assertThat(lookupResult.cacheTTL()).isEqualTo(23L);
+    }
+
+    @Test
+    public void serializeMultiNumber() {
+        final LookupResult lookupResult = LookupResult.multi(42, MULTI_VALUE);
+        final JsonNode node = objectMapper.convertValue(lookupResult, JsonNode.class);
+
+        assertThat(node.isNull()).isFalse();
+        assertThat(node.path("single_value").asInt()).isEqualTo(42);
+        assertThat(node.path("multi_value").path("int").asInt()).isEqualTo(42);
+        assertThat(node.path("multi_value").path("bool").asBoolean()).isEqualTo(true);
+        assertThat(node.path("multi_value").path("string").asText()).isEqualTo("Foobar");
+        assertThat(node.path("ttl").asLong()).isEqualTo(Long.MAX_VALUE);
+    }
+
+    @Test
+    public void deserializeMultiNumber() throws IOException {
+        final String json = "{\"single_value\":42,\"multi_value\":{\"int\":42,\"bool\":true,\"string\":\"Foobar\"},\"ttl\":23}";
+        final LookupResult lookupResult = objectMapper.readValue(json, LookupResult.class);
+
+        assertThat(lookupResult.isEmpty()).isFalse();
+        assertThat(lookupResult.singleValue()).isEqualTo(42);
+        assertThat(lookupResult.multiValue()).isEqualTo(MULTI_VALUE);
+        assertThat(lookupResult.cacheTTL()).isEqualTo(23L);
+    }
+
+    @Test
+    public void serializeMultiBoolean() {
+        final LookupResult lookupResult = LookupResult.multi(true, MULTI_VALUE);
+        final JsonNode node = objectMapper.convertValue(lookupResult, JsonNode.class);
+
+        assertThat(node.isNull()).isFalse();
+        assertThat(node.path("single_value").asBoolean()).isTrue();
+        assertThat(node.path("multi_value").path("int").asInt()).isEqualTo(42);
+        assertThat(node.path("multi_value").path("bool").asBoolean()).isEqualTo(true);
+        assertThat(node.path("multi_value").path("string").asText()).isEqualTo("Foobar");
+        assertThat(node.path("ttl").asLong()).isEqualTo(Long.MAX_VALUE);
+    }
+
+    @Test
+    public void deserializeMultiBoolean() throws IOException {
+        final String json = "{\"single_value\":true,\"multi_value\":{\"int\":42,\"bool\":true,\"string\":\"Foobar\"},\"ttl\":23}";
+        final LookupResult lookupResult = objectMapper.readValue(json, LookupResult.class);
+
+        assertThat(lookupResult.isEmpty()).isFalse();
+        assertThat(lookupResult.singleValue()).isEqualTo(true);
+        assertThat(lookupResult.multiValue()).isEqualTo(MULTI_VALUE);
+        assertThat(lookupResult.cacheTTL()).isEqualTo(23L);
+    }
+}


### PR DESCRIPTION
This commit adds a factory method to `LookupResult` which can be used by Jackson to
deserialize an instance of `LookupResult` from JSON.

Additionally, the derived field "empty" (via `LookupResult#isEmpty()`) is being ignored
and thus not part of the serialized or deserialized representation of `LookupResult`.

Refs #4534
Refs #4542
(cherry picked from commit d9f081ab4e9be9129ce7fd843ad5421ba75ccc31)