### PR TITLE
Remove warnings from browser console

### DIFF
--- a/graylog2-web-interface/src/components/alertconditions/AlertConditionSummary.jsx
+++ b/graylog2-web-interface/src/components/alertconditions/AlertConditionSummary.jsx
@@ -1,7 +1,7 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 import { Col } from 'react-bootstrap';
-import { LinkContainer } from 'react-router-bootstrap';
+import { Link } from 'react-router';
 
 import Routes from 'routing/Routes';
 
@@ -38,9 +38,9 @@ const AlertConditionSummary = React.createClass({
     let title;
     if (this.props.linkToDetails) {
       title = (
-        <LinkContainer to={Routes.show_alert_condition(stream.id, condition.id)}>
-          <a>{condition.title ? condition.title : 'Untitled'}</a>
-        </LinkContainer>
+        <Link to={Routes.show_alert_condition(stream.id, condition.id)}>
+          {condition.title ? condition.title : 'Untitled'}
+        </Link>
       );
     } else {
       title = (condition.title ? condition.title : 'Untitled');

--- a/graylog2-web-interface/src/components/alerts/Alert.jsx
+++ b/graylog2-web-interface/src/components/alerts/Alert.jsx
@@ -1,7 +1,7 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 import { Col, Label } from 'react-bootstrap';
-import { LinkContainer } from 'react-router-bootstrap';
+import { Link } from 'react-router';
 
 import { EntityListItem, Timestamp } from 'components/common';
 
@@ -34,9 +34,9 @@ const Alert = React.createClass({
     if (condition) {
       alertTitle = (
         <span>
-          <LinkContainer to={Routes.show_alert(alert.id)}>
-            <a>{condition.title || 'Untitled alert'}</a>
-          </LinkContainer>
+          <Link to={Routes.show_alert(alert.id)}>
+            {condition.title || 'Untitled alert'}
+          </Link>
           {' '}
           <small>on stream <em>{stream.title}</em></small>
         </span>
@@ -44,7 +44,7 @@ const Alert = React.createClass({
     } else {
       alertTitle = (
         <span>
-          <LinkContainer to={Routes.show_alert(alert.id)}><a>Unknown alert</a></LinkContainer>
+          <Link to={Routes.show_alert(alert.id)}>Unknown alert</Link>
         </span>
       );
     }

--- a/graylog2-web-interface/src/components/dashboard/Dashboard.jsx
+++ b/graylog2-web-interface/src/components/dashboard/Dashboard.jsx
@@ -2,7 +2,7 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import Reflux from 'reflux';
 import { DropdownButton, MenuItem } from 'react-bootstrap';
-import { LinkContainer } from 'react-router-bootstrap';
+import { Link } from 'react-router';
 
 import EditDashboardModalTrigger from './EditDashboardModalTrigger';
 import PermissionsMixin from 'util/PermissionsMixin';
@@ -68,9 +68,7 @@ const Dashboard = React.createClass({
     return (
       <li className="stream">
         <h2>
-          <LinkContainer to={Routes.dashboard_show(this.props.dashboard.id)}>
-            <a><span ref="dashboardTitle">{this.props.dashboard.title}</span></a>
-          </LinkContainer>
+          <Link to={Routes.dashboard_show(this.props.dashboard.id)}><span ref="dashboardTitle">{this.props.dashboard.title}</span></Link>
         </h2>
 
         <div className="stream-data">

--- a/graylog2-web-interface/src/components/dashboard/DashboardList.jsx
+++ b/graylog2-web-interface/src/components/dashboard/DashboardList.jsx
@@ -1,6 +1,7 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 import Immutable from 'immutable';
+import ImmutablePropTypes from 'react-immutable-proptypes';
 import { Alert } from 'react-bootstrap';
 
 import Dashboard from './Dashboard';
@@ -9,7 +10,7 @@ import PermissionsMixin from '../../util/PermissionsMixin';
 
 const DashboardList = React.createClass({
   propTypes: {
-    dashboards: PropTypes.instanceOf(Immutable.List),
+    dashboards: ImmutablePropTypes.list,
     onDashboardAdd: PropTypes.func,
     permissions: PropTypes.arrayOf(PropTypes.string),
   },

--- a/graylog2-web-interface/src/components/dashboard/DashboardList.jsx
+++ b/graylog2-web-interface/src/components/dashboard/DashboardList.jsx
@@ -1,6 +1,5 @@
 import PropTypes from 'prop-types';
 import React from 'react';
-import Immutable from 'immutable';
 import ImmutablePropTypes from 'react-immutable-proptypes';
 import { Alert } from 'react-bootstrap';
 

--- a/graylog2-web-interface/src/components/extractors/converters_configuration/LookupTableConverterConfiguration.jsx
+++ b/graylog2-web-interface/src/components/extractors/converters_configuration/LookupTableConverterConfiguration.jsx
@@ -1,7 +1,7 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 import { Row, Col } from 'react-bootstrap';
-import { LinkContainer } from 'react-router-bootstrap';
+import { Link } from 'react-router';
 
 import { Input } from 'components/bootstrap';
 import { Select, Spinner } from 'components/common';
@@ -72,7 +72,7 @@ const LookupTableConverterConfiguration = React.createClass({
 
     const helpMessage = (
       <span>
-        Lookup tables can be created <LinkContainer to={Routes.SYSTEM.LOOKUPTABLES.OVERVIEW}><a>here</a></LinkContainer>.
+        Lookup tables can be created <Link to={Routes.SYSTEM.LOOKUPTABLES.OVERVIEW}>here</Link>.
       </span>
     );
 

--- a/graylog2-web-interface/src/components/extractors/extractors_configuration/GrokExtractorConfiguration.jsx
+++ b/graylog2-web-interface/src/components/extractors/extractors_configuration/GrokExtractorConfiguration.jsx
@@ -1,7 +1,7 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 import { Row, Col, Button } from 'react-bootstrap';
-import { LinkContainer } from 'react-router-bootstrap';
+import { Link } from 'react-router';
 
 import { Input } from 'components/bootstrap';
 import Routes from 'routing/Routes';
@@ -60,8 +60,8 @@ const GrokExtractorConfiguration = React.createClass({
     const helpMessage = (
       <span>
           Matches the field against the current Grok pattern list, use <b>{'%{PATTERN-NAME}'}</b> to refer to a{' '}
-        <LinkContainer to={Routes.SYSTEM.GROKPATTERNS}><a>stored pattern</a></LinkContainer>.
-        </span>
+        <Link to={Routes.SYSTEM.GROKPATTERNS}>stored pattern</Link>.
+      </span>
     );
 
     return (

--- a/graylog2-web-interface/src/components/extractors/extractors_configuration/LookupTableExtractorConfiguration.jsx
+++ b/graylog2-web-interface/src/components/extractors/extractors_configuration/LookupTableExtractorConfiguration.jsx
@@ -1,7 +1,7 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 import { Row, Col, Button } from 'react-bootstrap';
-import { LinkContainer } from 'react-router-bootstrap';
+import { Link } from 'react-router';
 
 import { Input } from 'components/bootstrap';
 import { Select, Spinner } from 'components/common';
@@ -92,7 +92,7 @@ const LookupTableExtractorConfiguration = React.createClass({
 
     const helpMessage = (
       <span>
-        Lookup tables can be created <LinkContainer to={Routes.SYSTEM.LOOKUPTABLES.OVERVIEW}><a>here</a></LinkContainer>.
+        Lookup tables can be created <Link to={Routes.SYSTEM.LOOKUPTABLES.OVERVIEW}>here</Link>.
       </span>
     );
 

--- a/graylog2-web-interface/src/components/indices/IndexSetsComponent.jsx
+++ b/graylog2-web-interface/src/components/indices/IndexSetsComponent.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import Reflux from 'reflux';
 import { LinkContainer } from 'react-router-bootstrap';
+import { Link } from 'react-router';
 import { Col, Button, Label, DropdownButton, MenuItem } from 'react-bootstrap';
 
 import { EntityList, EntityListItem, PaginatedList, Spinner } from 'components/common';
@@ -82,9 +83,9 @@ const IndexSetsComponent = React.createClass({
     );
 
     const indexSetTitle = (
-      <LinkContainer to={Routes.SYSTEM.INDEX_SETS.SHOW(indexSet.id)}>
-        <a>{indexSet.title}</a>
-      </LinkContainer>
+      <Link to={Routes.SYSTEM.INDEX_SETS.SHOW(indexSet.id)}>
+        {indexSet.title}
+      </Link>
     );
 
     const isDefault = indexSet.default ? <Label key={`index-set-${indexSet.id}-default-label`} bsStyle="primary">default</Label> : '';

--- a/graylog2-web-interface/src/components/lookup-tables/CacheTableEntry.jsx
+++ b/graylog2-web-interface/src/components/lookup-tables/CacheTableEntry.jsx
@@ -1,6 +1,7 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 import { LinkContainer } from 'react-router-bootstrap';
+import { Link } from 'react-router';
 
 import { Button } from 'react-bootstrap';
 
@@ -66,7 +67,7 @@ const LUTTableEntry = React.createClass({
       <tbody>
         <tr>
           <td>
-            <LinkContainer to={Routes.SYSTEM.LOOKUPTABLES.CACHES.show(this.props.cache.name)}><a>{this.props.cache.title}</a></LinkContainer>
+            <Link to={Routes.SYSTEM.LOOKUPTABLES.CACHES.show(this.props.cache.name)}>{this.props.cache.title}</Link>
             <ContentPackMarker contentPack={this.props.cache.content_pack} marginLeft={5} />
           </td>
           <td>{this.props.cache.description}</td>

--- a/graylog2-web-interface/src/components/lookup-tables/DataAdapterTableEntry.jsx
+++ b/graylog2-web-interface/src/components/lookup-tables/DataAdapterTableEntry.jsx
@@ -1,6 +1,7 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 import { LinkContainer } from 'react-router-bootstrap';
+import { Link } from 'react-router';
 
 import { Button } from 'react-bootstrap';
 
@@ -39,7 +40,7 @@ const DataAdapterTableEntry = React.createClass({
         <tr>
           <td>
             {this.props.error && <ErrorPopover errorText={this.props.error} title="Lookup table problem" placement="right" />}
-            <LinkContainer to={Routes.SYSTEM.LOOKUPTABLES.DATA_ADAPTERS.show(this.props.adapter.name)}><a>{this.props.adapter.title}</a></LinkContainer>
+            <Link to={Routes.SYSTEM.LOOKUPTABLES.DATA_ADAPTERS.show(this.props.adapter.name)}>{this.props.adapter.title}</Link>
             <ContentPackMarker contentPack={this.props.adapter.content_pack} marginLeft={5} />
           </td>
           <td>{this.props.adapter.description}</td>

--- a/graylog2-web-interface/src/components/lookup-tables/LUTTableEntry.jsx
+++ b/graylog2-web-interface/src/components/lookup-tables/LUTTableEntry.jsx
@@ -1,6 +1,7 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 import { LinkContainer } from 'react-router-bootstrap';
+import { Link } from 'react-router';
 import { Button } from 'react-bootstrap';
 
 import CombinedProvider from 'injection/CombinedProvider';
@@ -43,18 +44,18 @@ const LUTTableEntry = React.createClass({
       <tr>
         <td>
           {this.props.errors.table && (<ErrorPopover placement="right" errorText={this.props.errors.table} title="Lookup Table problem" />) }
-          <LinkContainer to={Routes.SYSTEM.LOOKUPTABLES.show(this.props.table.name)}><a>{this.props.table.title}</a></LinkContainer>
+          <Link to={Routes.SYSTEM.LOOKUPTABLES.show(this.props.table.name)}>{this.props.table.title}</Link>
           <ContentPackMarker contentPack={this.props.table.content_pack} marginLeft={5} />
         </td>
         <td>{this.props.table.description}</td>
         <td>{this.props.table.name}</td>
         <td>
           {this.props.errors.cache && (<ErrorPopover placement="bottom" errorText={this.props.errors.cache} title="Cache problem" />) }
-          <LinkContainer to={Routes.SYSTEM.LOOKUPTABLES.CACHES.show(this.props.cache.name)}><a>{this.props.cache.title}</a></LinkContainer>
+          <Link to={Routes.SYSTEM.LOOKUPTABLES.CACHES.show(this.props.cache.name)}>{this.props.cache.title}</Link>
         </td>
         <td>
           {this.props.errors.dataAdapter && (<ErrorPopover placement="bottom" errorText={this.props.errors.dataAdapter} title="Data adapter problem" />) }
-          <LinkContainer to={Routes.SYSTEM.LOOKUPTABLES.DATA_ADAPTERS.show(this.props.dataAdapter.name)}><a>{this.props.dataAdapter.title}</a></LinkContainer>
+          <Link to={Routes.SYSTEM.LOOKUPTABLES.DATA_ADAPTERS.show(this.props.dataAdapter.name)}>{this.props.dataAdapter.title}</Link>
         </td>
         <td>
           <LinkContainer to={Routes.SYSTEM.LOOKUPTABLES.edit(this.props.table.name)}>

--- a/graylog2-web-interface/src/components/lookup-tables/LookupTable.jsx
+++ b/graylog2-web-interface/src/components/lookup-tables/LookupTable.jsx
@@ -3,6 +3,7 @@ import React from 'react';
 import { Button, ButtonToolbar, Row, Col } from 'react-bootstrap';
 import { Input } from 'components/bootstrap';
 import { LinkContainer } from 'react-router-bootstrap';
+import { Link } from 'react-router';
 import Routes from 'routing/Routes';
 
 import FormsUtils from 'util/FormsUtils';
@@ -67,10 +68,10 @@ const LookupTable = React.createClass({
           <dl>
             <dt>Data adapter</dt>
             <dd>
-              <LinkContainer to={Routes.SYSTEM.LOOKUPTABLES.DATA_ADAPTERS.show(this.props.dataAdapter.name)}><a>{this.props.dataAdapter.title}</a></LinkContainer>
+              <Link to={Routes.SYSTEM.LOOKUPTABLES.DATA_ADAPTERS.show(this.props.dataAdapter.name)}>{this.props.dataAdapter.title}</Link>
             </dd>
             <dt>Cache</dt>
-            <dd><LinkContainer to={Routes.SYSTEM.LOOKUPTABLES.CACHES.show(this.props.cache.name)}><a>{this.props.cache.title}</a></LinkContainer></dd>
+            <dd><Link to={Routes.SYSTEM.LOOKUPTABLES.CACHES.show(this.props.cache.name)}>{this.props.cache.title}</Link></dd>
           </dl>
           <LinkContainer to={Routes.SYSTEM.LOOKUPTABLES.edit(this.props.table.name)}>
             <Button bsStyle="success">Edit</Button>

--- a/graylog2-web-interface/src/components/nodes/JournalDetails.jsx
+++ b/graylog2-web-interface/src/components/nodes/JournalDetails.jsx
@@ -1,7 +1,7 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 import Reflux from 'reflux';
-import { LinkContainer } from 'react-router-bootstrap';
+import { Link } from 'react-router';
 import { ProgressBar, Row, Col, Alert } from 'react-bootstrap';
 import numeral from 'numeral';
 import moment from 'moment';
@@ -97,7 +97,7 @@ const JournalDetails = React.createClass({
       overcommittedWarning = (
         <span>
           <strong>Warning!</strong> The journal utilization is exceeding the maximum size defined.
-          {' '}<LinkContainer to={Routes.SYSTEM.OVERVIEW}><a>Click here</a></LinkContainer> for more information.<br />
+          {' '}<Link to={Routes.SYSTEM.OVERVIEW}>Click here</Link> for more information.<br />
         </span>
       );
     }

--- a/graylog2-web-interface/src/components/pipelines/PipelineConnectionsForm.jsx
+++ b/graylog2-web-interface/src/components/pipelines/PipelineConnectionsForm.jsx
@@ -1,7 +1,7 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 import { Button, ControlLabel, FormGroup, HelpBlock } from 'react-bootstrap';
-import { LinkContainer } from 'react-router-bootstrap';
+import { Link } from 'react-router';
 import naturalSort from 'javascript-natural-sort';
 
 import { SelectableList } from 'components/common';
@@ -76,7 +76,7 @@ const PipelineConnectionsForm = React.createClass({
     const streamsHelp = (
       <span>
         Select the streams you want to connect to this pipeline, or create one in the{' '}
-        <LinkContainer to={Routes.STREAMS}><a>Streams page</a></LinkContainer>.
+        <Link to={Routes.STREAMS}>Streams page</Link>.
       </span>
     );
 

--- a/graylog2-web-interface/src/components/pipelines/ProcessingTimelineComponent.jsx
+++ b/graylog2-web-interface/src/components/pipelines/ProcessingTimelineComponent.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import Reflux from 'reflux';
 import { Alert, Button } from 'react-bootstrap';
 import { LinkContainer } from 'react-router-bootstrap';
+import { Link } from 'react-router';
 import naturalSort from 'javascript-natural-sort';
 
 import { DataTable, Spinner } from 'components/common';
@@ -83,7 +84,7 @@ const ProcessingTimelineComponent = React.createClass({
     return (
       <tr key={pipeline.id}>
         <td className="pipeline-name">
-          <LinkContainer to={Routes.SYSTEM.PIPELINES.PIPELINE(pipeline.id)}><a>{pipeline.title}</a></LinkContainer><br />
+          <Link to={Routes.SYSTEM.PIPELINES.PIPELINE(pipeline.id)}>{pipeline.title}</Link><br />
           {pipeline.description}
           <br />
           <MetricContainer name={`org.graylog.plugins.pipelineprocessor.ast.Pipeline.${pipeline.id}.executed`}>

--- a/graylog2-web-interface/src/components/pipelines/Stage.jsx
+++ b/graylog2-web-interface/src/components/pipelines/Stage.jsx
@@ -2,7 +2,7 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import Reflux from 'reflux';
 import { Col, Button } from 'react-bootstrap';
-import { LinkContainer } from 'react-router-bootstrap';
+import { Link } from 'react-router';
 
 import { DataTable, EntityListItem, Spinner } from 'components/common';
 import RulesStore from 'stores/rules/RulesStore';
@@ -37,11 +37,11 @@ const Stage = React.createClass({
       };
       ruleTitle = <span><i className="fa fa-warning text-danger"/> {stage.rules[ruleIdx]}</span>;
     } else {
-      ruleTitle = (<LinkContainer to={Routes.SYSTEM.PIPELINES.RULE(rule.id)}>
-          <a>{rule.title}</a>
-        </LinkContainer>
+      ruleTitle = (
+        <Link to={Routes.SYSTEM.PIPELINES.RULE(rule.id)}>
+          {rule.title}
+        </Link>
       );
-
     }
     return (
       <tr key={rule.id}>

--- a/graylog2-web-interface/src/components/pipelines/StageForm.jsx
+++ b/graylog2-web-interface/src/components/pipelines/StageForm.jsx
@@ -2,7 +2,7 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import Reflux from 'reflux';
 import { Button } from 'react-bootstrap';
-import { LinkContainer } from 'react-router-bootstrap';
+import { Link } from 'react-router';
 
 import { SelectableList } from 'components/common';
 import { BootstrapModalForm, Input } from 'components/bootstrap';
@@ -92,7 +92,7 @@ const StageForm = React.createClass({
     const rulesHelp = (
       <span>
         Select the rules evaluated on this stage, or create one in the{' '}
-        <LinkContainer to={Routes.SYSTEM.PIPELINES.RULES}><a>Pipeline Rules page</a></LinkContainer>.
+        <Link to={Routes.SYSTEM.PIPELINES.RULES}>Pipeline Rules page</Link>.
       </span>
     );
 

--- a/graylog2-web-interface/src/components/rules/RuleForm.jsx
+++ b/graylog2-web-interface/src/components/rules/RuleForm.jsx
@@ -1,7 +1,7 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 import { Button, Col, ControlLabel, FormControl, FormGroup, Row } from 'react-bootstrap';
-import { LinkContainer } from 'react-router-bootstrap';
+import { Link } from 'react-router';
 
 import { SourceCodeEditor } from 'components/common';
 import { Input } from 'components/bootstrap';
@@ -116,9 +116,9 @@ const RuleForm = React.createClass({
     const formattedPipelines = this.props.usedInPipelines.map(pipeline => {
       return (
         <li key={pipeline.id}>
-          <LinkContainer to={Routes.SYSTEM.PIPELINES.PIPELINE(pipeline.id)}>
-            <a>{pipeline.title}</a>
-          </LinkContainer>
+          <Link to={Routes.SYSTEM.PIPELINES.PIPELINE(pipeline.id)}>
+            {pipeline.title}
+          </Link>
         </li>
       );
     });

--- a/graylog2-web-interface/src/components/rules/RuleList.jsx
+++ b/graylog2-web-interface/src/components/rules/RuleList.jsx
@@ -4,6 +4,7 @@ import { DataTable, Timestamp } from 'components/common';
 
 import { Button } from 'react-bootstrap';
 import { LinkContainer } from 'react-router-bootstrap';
+import { Link } from 'react-router';
 
 import RulesActions from 'actions/rules/RulesActions';
 
@@ -42,9 +43,9 @@ const RuleList = React.createClass({
     return (
       <tr key={rule.title}>
         <td>
-          <LinkContainer to={Routes.SYSTEM.PIPELINES.RULE(rule.id)}>
-            <a>{rule.title}</a>
-          </LinkContainer>
+          <Link to={Routes.SYSTEM.PIPELINES.RULE(rule.id)}>
+            {rule.title}
+          </Link>
         </td>
         <td className="limited">{rule.description}</td>
         <td className="limited"><Timestamp dateTime={rule.created_at} relative /></td>

--- a/graylog2-web-interface/src/components/search/MessageDetail.jsx
+++ b/graylog2-web-interface/src/components/search/MessageDetail.jsx
@@ -3,6 +3,7 @@ import React from 'react';
 import { ButtonGroup, Button, Row, Col, DropdownButton, MenuItem, Label } from 'react-bootstrap';
 import Immutable from 'immutable';
 import { LinkContainer } from 'react-router-bootstrap';
+import { Link } from 'react-router';
 
 import StoreProvider from 'injection/StoreProvider';
 const StreamsStore = StoreProvider.getStore('Streams');
@@ -222,9 +223,9 @@ const MessageDetail = React.createClass({
     let messageTitle;
     if (this.props.message.index) {
       messageTitle = (
-        <LinkContainer to={Routes.message_show(this.props.message.index, this.props.message.id)}>
-          <a href="#">{this.props.message.id}</a>
-        </LinkContainer>
+        <Link to={Routes.message_show(this.props.message.index, this.props.message.id)}>
+          {this.props.message.id}
+        </Link>
       );
     } else {
       messageTitle = <span>{this.props.message.id} <Label bsStyle="warning">Not stored</Label></span>;

--- a/graylog2-web-interface/src/components/search/MessageFieldExtractorActions.jsx
+++ b/graylog2-web-interface/src/components/search/MessageFieldExtractorActions.jsx
@@ -1,6 +1,7 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 import { DropdownButton, MenuItem } from 'react-bootstrap';
+import { LinkContainer } from 'react-router-bootstrap';
 import ExtractorUtils from 'util/ExtractorUtils';
 
 const MessageFieldExtractorActions = React.createClass({
@@ -20,9 +21,11 @@ const MessageFieldExtractorActions = React.createClass({
   },
   _formatExtractorMenuItem(extractorType) {
     return (
-      <MenuItem key={`menu-item-${extractorType}`} href={this.newExtractorRoutes[extractorType]}>
-        {ExtractorUtils.getReadableExtractorTypeName(extractorType)}
-      </MenuItem>
+      <LinkContainer to={this.newExtractorRoutes[extractorType]}>
+        <MenuItem key={`menu-item-${extractorType}`}>
+          {ExtractorUtils.getReadableExtractorTypeName(extractorType)}
+        </MenuItem>
+      </LinkContainer>
     );
   },
   render() {

--- a/graylog2-web-interface/src/components/search/MessageTableEntry.jsx
+++ b/graylog2-web-interface/src/components/search/MessageTableEntry.jsx
@@ -1,6 +1,7 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 import Immutable from 'immutable';
+import ImmutablePropTypes from 'react-immutable-proptypes';
 import { Popover, OverlayTrigger } from 'react-bootstrap';
 
 import MessageDetail from './MessageDetail';
@@ -11,25 +12,25 @@ import style from './MessageTableEntry.css';
 
 const MessageTableEntry = React.createClass({
   propTypes: {
-    allStreams: PropTypes.instanceOf(Immutable.List).isRequired,
+    allStreams: ImmutablePropTypes.list.isRequired,
     allStreamsLoaded: PropTypes.bool.isRequired,
     disableSurroundingSearch: PropTypes.bool,
     expandAllRenderAsync: PropTypes.bool.isRequired,
     expanded: PropTypes.bool.isRequired,
     highlight: PropTypes.bool,
     highlightMessage: PropTypes.string,
-    inputs: PropTypes.instanceOf(Immutable.Map).isRequired,
+    inputs: ImmutablePropTypes.map.isRequired,
     message: PropTypes.shape({
       fields: PropTypes.object.isRequired,
       highlight_ranges: PropTypes.object,
       id: PropTypes.string.isRequired,
       index: PropTypes.string.isRequired,
     }).isRequired,
-    nodes: PropTypes.instanceOf(Immutable.Map).isRequired,
+    nodes: ImmutablePropTypes.map.isRequired,
     searchConfig: PropTypes.object,
-    selectedFields: PropTypes.instanceOf(Immutable.OrderedSet),
+    selectedFields: ImmutablePropTypes.orderedSet,
     showMessageRow: PropTypes.bool,
-    streams: PropTypes.instanceOf(Immutable.Map).isRequired,
+    streams: ImmutablePropTypes.map.isRequired,
     toggleDetail: PropTypes.func.isRequired,
   },
   getDefaultProps() {

--- a/graylog2-web-interface/src/components/search/SearchResult.jsx
+++ b/graylog2-web-interface/src/components/search/SearchResult.jsx
@@ -1,6 +1,7 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 import Immutable from 'immutable';
+import ImmutablePropTypes from 'react-immutable-proptypes';
 import { Col, Row } from 'react-bootstrap';
 
 import { LoadingIndicator } from 'components/common';
@@ -20,9 +21,9 @@ const SearchResult = React.createClass({
     histogram: PropTypes.object.isRequired,
     formattedHistogram: PropTypes.array,
     searchInStream: PropTypes.object,
-    streams: PropTypes.instanceOf(Immutable.Map),
-    inputs: PropTypes.instanceOf(Immutable.Map),
-    nodes: PropTypes.instanceOf(Immutable.Map),
+    streams: ImmutablePropTypes.map,
+    inputs: ImmutablePropTypes.map,
+    nodes: ImmutablePropTypes.map,
     permissions: PropTypes.array.isRequired,
     searchConfig: PropTypes.object.isRequired,
     loadingSearch: PropTypes.bool,

--- a/graylog2-web-interface/src/components/search/__snapshots__/MessageTableEntry.test.jsx.snap
+++ b/graylog2-web-interface/src/components/search/__snapshots__/MessageTableEntry.test.jsx.snap
@@ -125,9 +125,8 @@ exports[`<MessageTableEntry /> rendering should render a MessageTableEntry 1`] =
               />
                
               <a
-                action="push"
-                href="#"
                 onClick={[Function]}
+                style={Object {}}
               >
                 01
               </a>

--- a/graylog2-web-interface/src/components/simulator/ProcessorSimulator.jsx
+++ b/graylog2-web-interface/src/components/simulator/ProcessorSimulator.jsx
@@ -2,7 +2,7 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import { Col, ControlLabel, FormGroup, HelpBlock, Panel, Row } from 'react-bootstrap';
 import naturalSort from 'javascript-natural-sort';
-import { LinkContainer } from 'react-router-bootstrap';
+import { Link } from 'react-router';
 
 import { Select } from 'components/common';
 import RawMessageLoader from 'components/messageloaders/RawMessageLoader';
@@ -74,7 +74,7 @@ const ProcessorSimulator = React.createClass({
             <Col md={8} mdOffset={2}>
               <Panel bsStyle="danger" header="No streams found">
                 Pipelines operate on streams, but your system currently has no streams. Please{' '}
-                <LinkContainer to={Routes.STREAMS}><a>create a stream</a></LinkContainer>{' '}
+                <Link to={Routes.STREAMS}>create a stream</Link>{' '}
                 and come back here later to test pipelines processing messages in your new stream.
               </Panel>
             </Col>

--- a/graylog2-web-interface/src/components/sources/SourceOverview.jsx
+++ b/graylog2-web-interface/src/components/sources/SourceOverview.jsx
@@ -45,7 +45,7 @@ const SourceOverview = React.createClass({
     this.valueGroup = this.valueDimension.group().reduceSum(d => d.y);
 
     return {
-      range: null,
+      range: '',
       resolution: 'minute',
       filter: '',
       loading: false,

--- a/graylog2-web-interface/src/components/streams/Stream.jsx
+++ b/graylog2-web-interface/src/components/streams/Stream.jsx
@@ -15,6 +15,7 @@ import { OverlayElement, Pluralize } from 'components/common';
 import UserNotification from 'util/UserNotification';
 import { Button, Tooltip } from 'react-bootstrap';
 import { LinkContainer } from 'react-router-bootstrap';
+import { Link } from 'react-router';
 import Routes from 'routing/Routes';
 
 import style from './Stream.css';
@@ -184,9 +185,7 @@ const Stream = React.createClass({
         </div>
 
         <h2 className={style.streamTitle}>
-          <LinkContainer to={Routes.stream_search(stream.id)}>
-            <a>{stream.title}</a>
-          </LinkContainer>
+          <Link to={Routes.stream_search(stream.id)}>{stream.title}</Link>
           {' '}
           <small>{indexSetDetails}<StreamStateBadge stream={stream} /></small>
         </h2>

--- a/graylog2-web-interface/src/components/users/RoleList.jsx
+++ b/graylog2-web-interface/src/components/users/RoleList.jsx
@@ -1,7 +1,7 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 import Reflux from 'reflux';
-import Immutable from 'immutable';
+import ImmutablePropTypes from 'react-immutable-proptypes';
 import { Button } from 'react-bootstrap';
 
 import StoreProvider from 'injection/StoreProvider';
@@ -14,7 +14,7 @@ import { DataTable } from 'components/common';
 const RoleList = React.createClass({
   mixins: [Reflux.connect(CurrentUserStore), PermissionsMixin],
   propTypes: {
-    roles: PropTypes.instanceOf(Immutable.Set).isRequired,
+    roles: ImmutablePropTypes.set.isRequired,
     showEditRole: PropTypes.func.isRequired,
     deleteRole: PropTypes.func.isRequired,
   },

--- a/graylog2-web-interface/src/pages/LoginPage.jsx
+++ b/graylog2-web-interface/src/pages/LoginPage.jsx
@@ -31,6 +31,9 @@ const LoginPage = React.createClass({
   componentWillUnmount() {
     disconnectedStyle.unuse();
     authStyle.unuse();
+    if (this.promise) {
+      this.promise.cancel();
+    }
   },
 
   onSignInClicked(event) {
@@ -40,16 +43,16 @@ const LoginPage = React.createClass({
     const username = this.refs.username.getValue();
     const password = this.refs.password.getValue();
     const location = document.location.host;
-    const promise = SessionActions.login.triggerPromise(username, password, location);
-    promise.catch((error) => {
+    this.promise = SessionActions.login.triggerPromise(username, password, location);
+    this.promise.catch((error) => {
       if (error.additional.status === 401) {
         this.setState({ lastError: 'Invalid credentials, please verify them and retry.' });
       } else {
         this.setState({ lastError: `Error - the server returned: ${error.additional.status} - ${error.message}` });
       }
     });
-    promise.finally(() => {
-      if (this.isMounted()) {
+    this.promise.finally(() => {
+      if (!this.promise.isCancelled()) {
         this.setState({ loading: false });
       }
     });

--- a/graylog2-web-interface/src/pages/NodeInputsPage.jsx
+++ b/graylog2-web-interface/src/pages/NodeInputsPage.jsx
@@ -1,7 +1,7 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 import Reflux from 'reflux';
-import { LinkContainer } from 'react-router-bootstrap';
+import { Link } from 'react-router';
 
 import StoreProvider from 'injection/StoreProvider';
 const NodesStore = StoreProvider.getStore('Nodes');
@@ -45,7 +45,7 @@ const NodeInputsPage = React.createClass({
             <span>Graylog nodes accept data via inputs. On this page you can see which inputs are running on this specific node.</span>
 
             <span>
-              You can launch and terminate inputs on your cluster <LinkContainer to={Routes.SYSTEM.INPUTS}><a>here</a></LinkContainer>.
+              You can launch and terminate inputs on your cluster <Link to={Routes.SYSTEM.INPUTS}>here</Link>.
             </span>
           </PageHeader>
           <InputsList permissions={this.state.currentUser.permissions} node={this.state.node} />

--- a/graylog2-web-interface/src/pages/SearchPage.jsx
+++ b/graylog2-web-interface/src/pages/SearchPage.jsx
@@ -63,6 +63,9 @@ const SearchPage = React.createClass({
     }
   },
   componentWillUnmount() {
+    if (this.promise) {
+      this.promise.cancel();
+    }
     this._stopTimer();
   },
   _setupTimer(refresh) {
@@ -93,9 +96,7 @@ const SearchPage = React.createClass({
     this.promise = UniversalSearchStore.search(SearchStore.originalRangeType, query, SearchStore.originalRangeParams.toJS(), streamId, null, SearchStore.page, SearchStore.sortField, SearchStore.sortOrder)
       .then(
         (response) => {
-          if (this.isMounted()) {
-            this.setState({ searchResult: response, error: undefined });
-          }
+          this.setState({ searchResult: response, error: undefined });
 
           const interval = this.props.location.query.interval ? this.props.location.query.interval : this._determineHistogramResolution(response);
 

--- a/graylog2-web-interface/src/pages/ShowDashboardPage.jsx
+++ b/graylog2-web-interface/src/pages/ShowDashboardPage.jsx
@@ -60,15 +60,18 @@ const ShowDashboardPage = React.createClass({
     if (this.loadInterval) {
       clearInterval(this.loadInterval);
     }
+    if (this.promise) {
+      this.promise.cancel();
+    }
   },
   DASHBOARDS_EDIT: 'dashboards:edit',
   DEFAULT_HEIGHT: 1,
   DEFAULT_WIDTH: 2,
   loadData() {
     const dashboardId = this.props.params.dashboardId;
-    DashboardsStore.get(dashboardId)
+    this.promise = DashboardsStore.get(dashboardId)
       .then((dashboard) => {
-        if (!this.isMounted()) {
+        if (this.promise.isCancelled()) {
           return;
         }
 

--- a/graylog2-web-interface/src/pages/StreamOutputsPage.jsx
+++ b/graylog2-web-interface/src/pages/StreamOutputsPage.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import Reflux from 'reflux';
 import { Row, Col } from 'react-bootstrap';
-import { LinkContainer } from 'react-router-bootstrap';
+import { Link } from 'react-router';
 
 import StoreProvider from 'injection/StoreProvider';
 const CurrentUserStore = StoreProvider.getStore('CurrentUser');
@@ -46,7 +46,7 @@ const StreamOutputsPage = React.createClass({
               <SupportLink>
                 <i>Removing</i> an output removes it from this stream but it will still be in the list of available outputs.
                 Deleting an output <i>globally</i> will remove it from this and all other streams and terminate it.
-                You can see all defined outputs in details at the {' '} <LinkContainer to={Routes.SYSTEM.OUTPUTS}><a>global output list</a></LinkContainer>.
+                You can see all defined outputs in details at the {' '} <Link to={Routes.SYSTEM.OUTPUTS}>global output list</Link>.
               </SupportLink>
             </Col>
           </Row>


### PR DESCRIPTION
## Description
With this change I try to reduce the amount of warnings created by some deprecation warnings
and misused components.

## Motivation and Context
- LinkContainer is meant for React-Bootstrap components to be used as navigation widgets with React-Router. But using it with Anchors (<a>) will cause an error since the prop active will be add to the component. Instead of using LinkContainer with Anchor the React-Router component Link should be used.
- A select component raises a warning when initilized with null. Instead a empty string should be used.
- instanceOf(Immutable.List) did raise a warning that it expected a List but got a List. Use already installed ImmutablePropTypes to silent this warning.
- isMounted is marked as deprecated and raises warnings therefore. The idea of the use of isMounted was to avoid setState() when the component is already unmounted. That happens when setState() is called in a promise.

## How Has This Been Tested?
- LinkContainer: I clicked on every Link I changed
- I retried that select did still correctly set the default value
- instanceOf I only looked that the warning was gone
- isMounted: I add a sleep to the corresponding server side code and so stimulated the cancel call. I also checked that the normal codeflow still worked

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
