### PR TITLE
Retain legacy behavior of Beats input

### DIFF
--- a/graylog2-server/src/main/java/org/graylog/plugins/beats/Beats2Codec.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/beats/Beats2Codec.java
@@ -1,0 +1,178 @@
+/**
+ * This file is part of Graylog.
+ *
+ * Graylog is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.graylog.plugins.beats;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.inject.assistedinject.Assisted;
+import org.graylog2.plugin.Message;
+import org.graylog2.plugin.Tools;
+import org.graylog2.plugin.configuration.Configuration;
+import org.graylog2.plugin.configuration.ConfigurationRequest;
+import org.graylog2.plugin.configuration.fields.BooleanField;
+import org.graylog2.plugin.inputs.annotations.Codec;
+import org.graylog2.plugin.inputs.annotations.ConfigClass;
+import org.graylog2.plugin.inputs.annotations.FactoryClass;
+import org.graylog2.plugin.inputs.codecs.AbstractCodec;
+import org.graylog2.plugin.journal.RawMessage;
+import org.joda.time.DateTime;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import javax.inject.Inject;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+
+import static java.util.Objects.requireNonNull;
+
+@Codec(name = "beats", displayName = "Beats")
+public class Beats2Codec extends AbstractCodec {
+    private static final Logger LOG = LoggerFactory.getLogger(Beats2Codec.class);
+    private static final String MAP_KEY_SEPARATOR = "_";
+    private static final String BEATS_UNKNOWN = "unknown";
+    private static final String CK_BEATS_PREFIX = "beats_prefix";
+
+    private final ObjectMapper objectMapper;
+    private final boolean useBeatPrefix;
+
+    @Inject
+    public Beats2Codec(@Assisted Configuration configuration, ObjectMapper objectMapper) {
+        super(configuration);
+
+        this.useBeatPrefix = configuration.getBoolean(CK_BEATS_PREFIX, false);
+        this.objectMapper = requireNonNull(objectMapper);
+    }
+
+    @Nullable
+    @Override
+    public Message decode(@Nonnull RawMessage rawMessage) {
+        final byte[] payload = rawMessage.getPayload();
+        final JsonNode event;
+        try {
+            event = objectMapper.readTree(payload);
+        } catch (IOException e) {
+            LOG.error("Couldn't decode raw message {}", rawMessage);
+            return null;
+        }
+
+        return parseEvent(event);
+    }
+
+    private Message parseEvent(JsonNode event) {
+        final String beatsType = event.path("@metadata").path("beat").asText("beat");
+        final String rootPath = useBeatPrefix ? beatsType : "";
+        final String message = event.path("message").asText("-");
+        final String timestampField = event.path("@timestamp").asText();
+        final DateTime timestamp = Tools.dateTimeFromString(timestampField);
+
+        final JsonNode beat = event.path("beat");
+        final String hostname = beat.path("hostname").asText(BEATS_UNKNOWN);
+
+        final Message gelfMessage = new Message(message, hostname, timestamp);
+        gelfMessage.addField("beats_type", beatsType);
+        gelfMessage.addField("facility", "beats");
+
+        addFlattened(gelfMessage, rootPath, event);
+        return gelfMessage;
+    }
+
+    private void addFlattened(Message message, String currentPath, JsonNode jsonNode) {
+        if (jsonNode.isObject()) {
+            final Iterator<Map.Entry<String, JsonNode>> it = jsonNode.fields();
+            final String pathPrefix = currentPath.isEmpty() ? "" : currentPath + MAP_KEY_SEPARATOR;
+            while (it.hasNext()) {
+                final Map.Entry<String, JsonNode> entry = it.next();
+                addFlattened(message, pathPrefix + entry.getKey(), entry.getValue());
+            }
+        } else if (jsonNode.isArray()) {
+            final List<Object> values = new ArrayList<>(jsonNode.size());
+            for (int i = 0; i < jsonNode.size(); i++) {
+                final JsonNode currentNode = jsonNode.get(i);
+                if (currentNode.isObject()) {
+                    final String pathPrefix = currentPath.isEmpty() ? "" : currentPath + MAP_KEY_SEPARATOR + i;
+                    addFlattened(message, pathPrefix, currentNode);
+                } else if (currentNode.isValueNode()) {
+                    values.add(valueNode(currentNode));
+                }
+            }
+            message.addField(currentPath, values);
+        } else if (jsonNode.isValueNode()) {
+            message.addField(currentPath, valueNode(jsonNode));
+        }
+    }
+
+    @Nullable
+    private Object valueNode(JsonNode jsonNode) {
+        if (jsonNode.isInt()) {
+            return jsonNode.asInt();
+        } else if (jsonNode.isLong()) {
+            return jsonNode.asLong();
+        } else if (jsonNode.isIntegralNumber()) {
+            return jsonNode.asLong();
+        } else if (jsonNode.isFloatingPointNumber()) {
+            return jsonNode.asDouble();
+        } else if (jsonNode.isBoolean()) {
+            return jsonNode.asBoolean();
+        } else if (jsonNode.isNull()) {
+            return null;
+        } else {
+            return jsonNode.asText();
+        }
+    }
+
+
+    @FactoryClass
+    public interface Factory extends AbstractCodec.Factory<Beats2Codec> {
+        @Override
+        Beats2Codec create(Configuration configuration);
+
+        @Override
+        Config getConfig();
+
+        @Override
+        Descriptor getDescriptor();
+    }
+
+    @ConfigClass
+    public static class Config extends AbstractCodec.Config {
+        @Override
+        public ConfigurationRequest getRequestedConfiguration() {
+            final ConfigurationRequest configurationRequest = super.getRequestedConfiguration();
+
+            configurationRequest.addField(new BooleanField(
+                    CK_BEATS_PREFIX,
+                    "Add Beats type as prefix",
+                    false,
+                    "Use the Beats type as prefix for each field, e. g. \"filebeat_source\"."
+            ));
+
+            return configurationRequest;
+        }
+    }
+
+    public static class Descriptor extends AbstractCodec.Descriptor {
+        @Inject
+        public Descriptor() {
+            super(Beats2Codec.class.getAnnotation(Codec.class).displayName());
+        }
+    }
+}

--- a/graylog2-server/src/main/java/org/graylog/plugins/beats/Beats2Input.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/beats/Beats2Input.java
@@ -1,0 +1,71 @@
+/**
+ * This file is part of Graylog.
+ *
+ * Graylog is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.graylog.plugins.beats;
+
+import com.codahale.metrics.MetricRegistry;
+import com.google.inject.assistedinject.Assisted;
+import org.graylog2.plugin.LocalMetricRegistry;
+import org.graylog2.plugin.ServerStatus;
+import org.graylog2.plugin.configuration.Configuration;
+import org.graylog2.plugin.inputs.MessageInput;
+import org.graylog2.plugin.inputs.annotations.ConfigClass;
+import org.graylog2.plugin.inputs.annotations.FactoryClass;
+
+import javax.inject.Inject;
+
+public class Beats2Input extends MessageInput {
+    private static final String NAME = "Beats";
+
+    @Inject
+    public Beats2Input(@Assisted Configuration configuration,
+                       BeatsTransport.Factory transportFactory,
+                       Beats2Codec.Factory codecFactory,
+                       Config config,
+                       Descriptor descriptor,
+                       MetricRegistry metricRegistry,
+                       LocalMetricRegistry localRegistry,
+                       ServerStatus serverStatus) {
+        super(metricRegistry, configuration, transportFactory.create(configuration),
+                localRegistry, codecFactory.create(configuration), config, descriptor, serverStatus);
+    }
+
+    @FactoryClass
+    public interface Factory extends MessageInput.Factory<Beats2Input> {
+        @Override
+        Beats2Input create(Configuration configuration);
+
+        @Override
+        Config getConfig();
+
+        @Override
+        Descriptor getDescriptor();
+    }
+
+    public static class Descriptor extends MessageInput.Descriptor {
+        public Descriptor() {
+            super(NAME, false, "");
+        }
+    }
+
+    @ConfigClass
+    public static class Config extends MessageInput.Config {
+        @Inject
+        public Config(BeatsTransport.Factory transport, Beats2Codec.Factory codec) {
+            super(transport.getConfig(), codec.getConfig());
+        }
+    }
+}

--- a/graylog2-server/src/main/java/org/graylog/plugins/beats/BeatsCodec.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/beats/BeatsCodec.java
@@ -16,14 +16,12 @@
  */
 package org.graylog.plugins.beats;
 
-import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.inject.assistedinject.Assisted;
 import org.graylog2.plugin.Message;
 import org.graylog2.plugin.Tools;
 import org.graylog2.plugin.configuration.Configuration;
-import org.graylog2.plugin.configuration.ConfigurationRequest;
-import org.graylog2.plugin.configuration.fields.BooleanField;
 import org.graylog2.plugin.inputs.annotations.Codec;
 import org.graylog2.plugin.inputs.annotations.ConfigClass;
 import org.graylog2.plugin.inputs.annotations.FactoryClass;
@@ -37,9 +35,7 @@ import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import javax.inject.Inject;
 import java.io.IOException;
-import java.util.ArrayList;
-import java.util.Iterator;
-import java.util.List;
+import java.util.HashMap;
 import java.util.Map;
 
 import static java.util.Objects.requireNonNull;
@@ -48,17 +44,12 @@ import static java.util.Objects.requireNonNull;
 public class BeatsCodec extends AbstractCodec {
     private static final Logger LOG = LoggerFactory.getLogger(BeatsCodec.class);
     private static final String MAP_KEY_SEPARATOR = "_";
-    private static final String BEATS_UNKNOWN = "unknown";
-    private static final String CK_BEATS_PREFIX = "beats_prefix";
 
     private final ObjectMapper objectMapper;
-    private final boolean useBeatPrefix;
 
     @Inject
     public BeatsCodec(@Assisted Configuration configuration, ObjectMapper objectMapper) {
         super(configuration);
-
-        this.useBeatPrefix = configuration.getBoolean(CK_BEATS_PREFIX, false);
         this.objectMapper = requireNonNull(objectMapper);
     }
 
@@ -66,9 +57,10 @@ public class BeatsCodec extends AbstractCodec {
     @Override
     public Message decode(@Nonnull RawMessage rawMessage) {
         final byte[] payload = rawMessage.getPayload();
-        final JsonNode event;
+        final Map<String, Object> event;
         try {
-            event = objectMapper.readTree(payload);
+            event = objectMapper.readValue(payload, new TypeReference<Map<String, Object>>() {
+            });
         } catch (IOException e) {
             LOG.error("Couldn't decode raw message {}", rawMessage);
             return null;
@@ -77,66 +69,157 @@ public class BeatsCodec extends AbstractCodec {
         return parseEvent(event);
     }
 
-    private Message parseEvent(JsonNode event) {
-        final String beatsType = event.path("@metadata").path("beat").asText("beat");
-        final String rootPath = useBeatPrefix ? beatsType : "";
-        final String message = event.path("message").asText("-");
-        final String timestampField = event.path("@timestamp").asText();
-        final DateTime timestamp = Tools.dateTimeFromString(timestampField);
+    @Nullable
+    private Message parseEvent(Map<String, Object> event) {
+        @SuppressWarnings("unchecked")
+        final Map<String, String> metadata = (HashMap<String, String>) event.remove("@metadata");
+        final String type;
+        if (metadata == null) {
+            LOG.warn("Couldn't recognize Beats type");
+            type = "unknown";
+        } else {
+            type = metadata.get("beat");
+        }
+        final Message gelfMessage;
+        switch (type) {
+            case "filebeat":
+                gelfMessage = parseFilebeat(event);
+                break;
+            case "topbeat":
+                gelfMessage = parseTopbeat(event);
+                break;
+            case "metricbeat":
+                gelfMessage = parseMetricbeat(event);
+                break;
+            case "packetbeat":
+                gelfMessage = parsePacketbeat(event);
+                break;
+            case "winlogbeat":
+                gelfMessage = parseWinlogbeat(event);
+                break;
+            default:
+                LOG.debug("Unknown beats type {}. Using generic handler.", type);
+                gelfMessage = parseGenericBeat(event);
+                break;
+        }
 
-        final JsonNode beat = event.path("beat");
-        final String hostname = beat.path("hostname").asText(BEATS_UNKNOWN);
-
-        final Message gelfMessage = new Message(message, hostname, timestamp);
-        gelfMessage.addField("beats_type", beatsType);
-        gelfMessage.addField("facility", "beats");
-
-        addFlattened(gelfMessage, rootPath, event);
         return gelfMessage;
     }
 
-    private void addFlattened(Message message, String currentPath, JsonNode jsonNode) {
-        if (jsonNode.isObject()) {
-            final Iterator<Map.Entry<String, JsonNode>> it = jsonNode.fields();
-            final String pathPrefix = currentPath.isEmpty() ? "" : currentPath + MAP_KEY_SEPARATOR;
-            while (it.hasNext()) {
-                final Map.Entry<String, JsonNode> entry = it.next();
-                addFlattened(message, pathPrefix + entry.getKey(), entry.getValue());
-            }
-        } else if (jsonNode.isArray()) {
-            final List<Object> values = new ArrayList<>(jsonNode.size());
-            for (int i = 0; i < jsonNode.size(); i++) {
-                final JsonNode currentNode = jsonNode.get(i);
-                if (currentNode.isObject()) {
-                    final String pathPrefix = currentPath.isEmpty() ? "" : currentPath + MAP_KEY_SEPARATOR + i;
-                    addFlattened(message, pathPrefix, currentNode);
-                } else if (currentNode.isValueNode()) {
-                    values.add(valueNode(currentNode));
-                }
-            }
-            message.addField(currentPath, values);
-        } else if (jsonNode.isValueNode()) {
-            message.addField(currentPath, valueNode(jsonNode));
+    private Message createMessage(String message, Map<String, Object> event) {
+        @SuppressWarnings("unchecked")
+        final Map<String, Object> beat = (Map<String, Object>) event.remove("beat");
+        final String hostname;
+        final String name;
+        if (beat == null) {
+            hostname = "unknown";
+            name = "unknown";
+        } else {
+            hostname = String.valueOf(beat.get("hostname"));
+            name = String.valueOf(beat.get("name"));
         }
+        final String timestampField = String.valueOf(event.remove("@timestamp"));
+        final DateTime timestamp = Tools.dateTimeFromString(timestampField);
+        final String type = String.valueOf(event.get("type"));
+        final Object tags = event.get("tags");
+
+        final Message result = new Message(message, hostname, timestamp);
+        result.addField("name", name);
+        result.addField("type", type);
+        result.addField("tags", tags);
+
+        @SuppressWarnings("unchecked")
+        final Map<String, Object> fields = (Map<String, Object>) event.get("fields");
+        if (fields != null) {
+            result.addFields(fields);
+        }
+
+        return result;
     }
 
-    @Nullable
-    private Object valueNode(JsonNode jsonNode) {
-        if (jsonNode.isInt()) {
-            return jsonNode.asInt();
-        } else if (jsonNode.isLong()) {
-            return jsonNode.asLong();
-        } else if (jsonNode.isIntegralNumber()) {
-            return jsonNode.asLong();
-        } else if (jsonNode.isFloatingPointNumber()) {
-            return jsonNode.asDouble();
-        } else if (jsonNode.isBoolean()) {
-            return jsonNode.asBoolean();
-        } else if (jsonNode.isNull()) {
-            return null;
-        } else {
-            return jsonNode.asText();
-        }
+    /**
+     * @see <a href="https://www.elastic.co/guide/en/beats/filebeat/1.2/exported-fields.html">Filebeat Exported Fields</a>
+     */
+    private Message parseFilebeat(Map<String, Object> event) {
+        final String message = String.valueOf(event.get("message"));
+        final Message gelfMessage = createMessage(message, event);
+        gelfMessage.addField("facility", "filebeat");
+        gelfMessage.addField("file", event.get("source"));
+        gelfMessage.addField("input_type", event.get("input_type"));
+        gelfMessage.addField("count", event.get("count"));
+        gelfMessage.addField("offset", event.get("offset"));
+
+        return gelfMessage;
+    }
+
+    /**
+     * @see <a href="https://www.elastic.co/guide/en/beats/topbeat/1.2/exported-fields.html">Topbeat Exported Fields</a>
+     */
+    private Message parseTopbeat(Map<String, Object> event) {
+        final Message gelfMessage = createMessage("-", event);
+        gelfMessage.addField("facility", "topbeat");
+        final Map<String, Object> flattened = MapUtils.flatten(event, "topbeat", MAP_KEY_SEPARATOR);
+
+        // Fix field names containing dots, like "cpu.name"
+        final Map<String, Object> withoutDots = MapUtils.replaceKeyCharacter(flattened, '.', MAP_KEY_SEPARATOR.charAt(0));
+        gelfMessage.addFields(withoutDots);
+        return gelfMessage;
+    }
+
+    /**
+     * @see <a href="https://www.elastic.co/guide/en/beats/metricbeat/5.1/exported-fields.html">Metricbeat Exported Fields</a>
+     */
+    private Message parseMetricbeat(Map<String, Object> event) {
+        final Message gelfMessage = createMessage("-", event);
+        gelfMessage.addField("facility", "metricbeat");
+        final Map<String, Object> flattened = MapUtils.flatten(event, "metricbeat", MAP_KEY_SEPARATOR);
+
+        // Fix field names containing dots, like "cpu.name"
+        final Map<String, Object> withoutDots = MapUtils.replaceKeyCharacter(flattened, '.', MAP_KEY_SEPARATOR.charAt(0));
+        gelfMessage.addFields(withoutDots);
+        return gelfMessage;
+    }
+
+    /**
+     * @see <a href="https://www.elastic.co/guide/en/beats/packetbeat/1.2/exported-fields.html">Packetbeat Exported Fields</a>
+     */
+    private Message parsePacketbeat(Map<String, Object> event) {
+        final Message gelfMessage = createMessage("-", event);
+        gelfMessage.addField("facility", "packetbeat");
+        final Map<String, Object> flattened = MapUtils.flatten(event, "packetbeat", MAP_KEY_SEPARATOR);
+
+        // Fix field names containing dots, like "icmp.version"
+        final Map<String, Object> withoutDots = MapUtils.replaceKeyCharacter(flattened, '.', MAP_KEY_SEPARATOR.charAt(0));
+        gelfMessage.addFields(withoutDots);
+
+        return gelfMessage;
+    }
+
+    /**
+     * @see <a href="https://www.elastic.co/guide/en/beats/winlogbeat/1.2/exported-fields.html">Winlogbeat Exported Fields</a>
+     */
+    private Message parseWinlogbeat(Map<String, Object> event) {
+        final String message = String.valueOf(event.remove("message"));
+        final Message gelfMessage = createMessage(message, event);
+        gelfMessage.addField("facility", "winlogbeat");
+        final Map<String, Object> flattened = MapUtils.flatten(event, "winlogbeat", MAP_KEY_SEPARATOR);
+
+        // Fix field names containing dots, like "user.name"
+        final Map<String, Object> withoutDots = MapUtils.replaceKeyCharacter(flattened, '.', MAP_KEY_SEPARATOR.charAt(0));
+        gelfMessage.addFields(withoutDots);
+        return gelfMessage;
+    }
+
+    private Message parseGenericBeat(Map<String, Object> event) {
+        final String message = String.valueOf(event.remove("message"));
+        final Message gelfMessage = createMessage(message, event);
+        gelfMessage.addField("facility", "genericbeat");
+        final Map<String, Object> flattened = MapUtils.flatten(event, "beat", MAP_KEY_SEPARATOR);
+
+        // Fix field names containing dots
+        final Map<String, Object> withoutDots = MapUtils.replaceKeyCharacter(flattened, '.', MAP_KEY_SEPARATOR.charAt(0));
+        gelfMessage.addFields(withoutDots);
+        return gelfMessage;
     }
 
 
@@ -154,20 +237,8 @@ public class BeatsCodec extends AbstractCodec {
 
     @ConfigClass
     public static class Config extends AbstractCodec.Config {
-        @Override
-        public ConfigurationRequest getRequestedConfiguration() {
-            final ConfigurationRequest configurationRequest = super.getRequestedConfiguration();
-
-            configurationRequest.addField(new BooleanField(
-                    CK_BEATS_PREFIX,
-                    "Add Beats type as prefix",
-                    false,
-                    "Use the Beats type as prefix for each field, e. g. \"filebeat_source\"."
-            ));
-
-            return configurationRequest;
-        }
     }
+
 
     public static class Descriptor extends AbstractCodec.Descriptor {
         @Inject

--- a/graylog2-server/src/main/java/org/graylog/plugins/beats/BeatsCodec.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/beats/BeatsCodec.java
@@ -40,7 +40,7 @@ import java.util.Map;
 
 import static java.util.Objects.requireNonNull;
 
-@Codec(name = "beats", displayName = "Beats")
+@Codec(name = "beats-legacy", displayName = "Beats Legacy")
 public class BeatsCodec extends AbstractCodec {
     private static final Logger LOG = LoggerFactory.getLogger(BeatsCodec.class);
     private static final String MAP_KEY_SEPARATOR = "_";

--- a/graylog2-server/src/main/java/org/graylog/plugins/beats/BeatsInput.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/beats/BeatsInput.java
@@ -28,7 +28,7 @@ import org.graylog2.plugin.inputs.annotations.FactoryClass;
 import javax.inject.Inject;
 
 public class BeatsInput extends MessageInput {
-    private static final String NAME = "Beats";
+    private static final String NAME = "Beats Legacy";
 
     @Inject
     public BeatsInput(@Assisted Configuration configuration,

--- a/graylog2-server/src/main/java/org/graylog/plugins/beats/BeatsInputPluginModule.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/beats/BeatsInputPluginModule.java
@@ -22,9 +22,14 @@ public class BeatsInputPluginModule extends PluginModule {
     @Override
     protected void configure() {
         addTransport("beats", BeatsTransport.class);
-        addCodec("beats", BeatsCodec.class);
-        addCodec("beats", Beats2Codec.class);
+
+        // Beats legacy input
+        addCodec("beats-legacy", BeatsCodec.class);
         addMessageInput(BeatsInput.class);
+
+        // Beats input with improved field handling
+        // see https://github.com/Graylog2/graylog-plugin-beats/pull/29
+        addCodec("beats", Beats2Codec.class);
         addMessageInput(Beats2Input.class);
     }
 }

--- a/graylog2-server/src/main/java/org/graylog/plugins/beats/MapUtils.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/beats/MapUtils.java
@@ -1,0 +1,59 @@
+/**
+ * This file is part of Graylog Beats Plugin.
+ *
+ * Graylog Beats Plugin is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog Beats Plugin is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog Beats Plugin.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.graylog.plugins.beats;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public final class MapUtils {
+    public static Map<String, Object> flatten(Map<String, Object> originalMap, String parentKey, String separator) {
+        final Map<String, Object> result = new HashMap<>();
+        for (Map.Entry<String, Object> entry : originalMap.entrySet()) {
+            final String key = parentKey.isEmpty() ? entry.getKey() : parentKey + separator + entry.getKey();
+            final Object value = entry.getValue();
+            if (value instanceof Map) {
+                @SuppressWarnings("unchecked")
+                final Map<String, Object> valueMap = (Map<String, Object>) value;
+                result.putAll(flatten(valueMap, key, separator));
+            } else {
+                result.put(key, value);
+            }
+        }
+        return result;
+    }
+
+    public static void renameKey(Map<String, Object> map, String originalKey, String newKey) {
+        if (map.containsKey(originalKey)) {
+            final Object value = map.remove(originalKey);
+            map.put(newKey, value);
+        }
+    }
+
+    public static Map<String, Object> replaceKeyCharacter(Map<String, Object> map, char oldChar, char newChar) {
+        final Map<String, Object> result = new HashMap<>(map.size());
+        for (Map.Entry<String, Object> entry : map.entrySet()) {
+            final String key = entry.getKey().replace(oldChar, newChar);
+            final Object value = entry.getValue();
+            result.put(key, value);
+        }
+        return result;
+    }
+
+    private MapUtils() {
+        throw new AssertionError("No instances allowed");
+    }
+}

--- a/graylog2-server/src/main/java/org/graylog/plugins/beats/MapUtils.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/beats/MapUtils.java
@@ -1,18 +1,18 @@
 /**
- * This file is part of Graylog Beats Plugin.
+ * This file is part of Graylog.
  *
- * Graylog Beats Plugin is free software: you can redistribute it and/or modify
+ * Graylog is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * Graylog Beats Plugin is distributed in the hope that it will be useful,
+ * Graylog is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with Graylog Beats Plugin.  If not, see <http://www.gnu.org/licenses/>.
+ * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
  */
 package org.graylog.plugins.beats;
 

--- a/graylog2-server/src/test/java/org/graylog/plugins/beats/Beats2CodecTest.java
+++ b/graylog2-server/src/test/java/org/graylog/plugins/beats/Beats2CodecTest.java
@@ -1,0 +1,306 @@
+/**
+ * This file is part of Graylog.
+ *
+ * Graylog is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.graylog.plugins.beats;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.io.Resources;
+import org.graylog2.plugin.Message;
+import org.graylog2.plugin.configuration.Configuration;
+import org.graylog2.plugin.journal.RawMessage;
+import org.graylog2.shared.bindings.providers.ObjectMapperProvider;
+import org.joda.time.DateTime;
+import org.joda.time.DateTimeZone;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.mockito.junit.MockitoJUnit;
+import org.mockito.junit.MockitoRule;
+
+import java.io.IOException;
+import java.net.URL;
+import java.util.Collections;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class Beats2CodecTest {
+    @Rule
+    public final MockitoRule mockitoRule = MockitoJUnit.rule();
+
+    private final ObjectMapper objectMapper = new ObjectMapperProvider().get();
+    private Configuration configuration;
+    private Beats2Codec codec;
+
+    @Before
+    public void setUp() throws Exception {
+        configuration = new Configuration(Collections.singletonMap("beats_prefix", true));
+        codec = new Beats2Codec(configuration, objectMapper);
+    }
+
+    @Test
+    public void decodeReturnsNullIfPayloadCouldNotBeDecoded() throws Exception {
+        assertThat(codec.decode(new RawMessage(new byte[0]))).isNull();
+    }
+
+    @Test
+    public void decodeMessagesHandlesFilebeatMessagesWithoutPrefix() throws Exception {
+        configuration = new Configuration(Collections.singletonMap("beats_prefix", false));
+        codec = new Beats2Codec(configuration, objectMapper);
+
+        final Message message = codec.decode(messageFromJson("filebeat.json"));
+        assertThat(message).isNotNull();
+        assertThat(message.getMessage()).isEqualTo("TEST");
+        assertThat(message.getTimestamp()).isEqualTo(new DateTime(2016, 4, 1, 0, 0, DateTimeZone.UTC));
+        assertThat(message.getField("facility")).isEqualTo("beats");
+        assertThat(message.getField("beats_type")).isEqualTo("filebeat");
+        assertThat(message.getField("source")).isEqualTo("/tmp/test.log");
+        assertThat(message.getField("input_type")).isEqualTo("log");
+        assertThat(message.getField("count")).isEqualTo(1);
+        assertThat(message.getField("offset")).isEqualTo(0);
+        @SuppressWarnings("unchecked") final List<String> tags = (List<String>) message.getField("tags");
+        assertThat(tags).containsOnly("foobar", "test");
+    }
+
+    @Test
+    public void decodeMessagesHandlesFilebeatMessages() throws Exception {
+        final Message message = codec.decode(messageFromJson("filebeat.json"));
+        assertThat(message).isNotNull();
+        assertThat(message.getMessage()).isEqualTo("TEST");
+        assertThat(message.getSource()).isEqualTo("example.local");
+        assertThat(message.getTimestamp()).isEqualTo(new DateTime(2016, 4, 1, 0, 0, DateTimeZone.UTC));
+        assertThat(message.getField("facility")).isEqualTo("beats");
+        assertThat(message.getField("beats_type")).isEqualTo("filebeat");
+        assertThat(message.getField("filebeat_source")).isEqualTo("/tmp/test.log");
+        assertThat(message.getField("filebeat_input_type")).isEqualTo("log");
+        assertThat(message.getField("filebeat_count")).isEqualTo(1);
+        assertThat(message.getField("filebeat_offset")).isEqualTo(0);
+        @SuppressWarnings("unchecked") final List<String> tags = (List<String>) message.getField("filebeat_tags");
+        assertThat(tags).containsOnly("foobar", "test");
+    }
+
+    @Test
+    public void decodeMessagesHandlesPacketbeatMessages() throws Exception {
+        final Message message = codec.decode(messageFromJson("packetbeat-dns.json"));
+        assertThat(message).isNotNull();
+        assertThat(message.getSource()).isEqualTo("example.local");
+        assertThat(message.getTimestamp()).isEqualTo(new DateTime(2016, 4, 1, 0, 0, DateTimeZone.UTC));
+        assertThat(message.getField("facility")).isEqualTo("beats");
+        assertThat(message.getField("beats_type")).isEqualTo("packetbeat");
+        assertThat(message.getField("packetbeat_type")).isEqualTo("dns");
+        assertThat(message.getField("packetbeat_status")).isEqualTo("OK");
+        assertThat(message.getField("packetbeat_method")).isEqualTo("QUERY");
+        assertThat(message.getField("packetbeat_dns_answers_0_type")).isEqualTo("A");
+        assertThat(message.getField("packetbeat_dns_flags_recursion_allowed")).isEqualTo(true);
+    }
+
+    @Test
+    public void decodeMessagesHandlesTopbeatMessages() throws Exception {
+        final Message message = codec.decode(messageFromJson("topbeat-system.json"));
+        assertThat(message).isNotNull();
+        assertThat(message.getSource()).isEqualTo("example.local");
+        assertThat(message.getTimestamp()).isEqualTo(new DateTime(2016, 4, 1, 0, 0, DateTimeZone.UTC));
+        assertThat(message.getField("facility")).isEqualTo("beats");
+        assertThat(message.getField("beats_type")).isEqualTo("topbeat");
+        assertThat(message.getField("topbeat_type")).isEqualTo("system");
+    }
+
+    @Test
+    public void decodeMessagesHandlesWinlogbeatMessages() throws Exception {
+        final Message message = codec.decode(messageFromJson("winlogbeat.json"));
+        assertThat(message).isNotNull();
+        assertThat(message.getSource()).isEqualTo("example.local");
+        assertThat(message.getTimestamp()).isEqualTo(new DateTime(2016, 11, 24, 12, 13, DateTimeZone.UTC));
+        assertThat(message.getField("facility")).isEqualTo("beats");
+        assertThat(message.getField("beats_type")).isEqualTo("winlogbeat");
+        assertThat(message.getField("winlogbeat_type")).isEqualTo("wineventlog");
+        assertThat(message.getField("winlogbeat_level")).isEqualTo("Information");
+        assertThat(message.getField("winlogbeat_event_id")).isEqualTo(5024);
+        assertThat(message.getField("winlogbeat_process_id")).isEqualTo(500);
+        assertThat(message.getField("winlogbeat_log_name")).isEqualTo("Security");
+    }
+
+    @Test
+    public void decodeMessagesHandleGenericBeatMessages() throws Exception {
+        final Message message = codec.decode(messageFromJson("generic.json"));
+        assertThat(message).isNotNull();
+        assertThat(message.getSource()).isEqualTo("unknown");
+        assertThat(message.getTimestamp()).isEqualTo(new DateTime(2016, 4, 1, 0, 0, DateTimeZone.UTC));
+        assertThat(message.getField("facility")).isEqualTo("beats");
+        assertThat(message.getField("beats_type")).isEqualTo("beat");
+        assertThat(message.getField("beat_foo")).isEqualTo("bar");
+    }
+
+    @Test
+    public void decodeMessagesHandleGenericBeatMessagesWithFields() throws Exception {
+        final Message message = codec.decode(messageFromJson("generic-with-fields.json"));
+        assertThat(message).isNotNull();
+        assertThat(message.getSource()).isEqualTo("unknown");
+        assertThat(message.getTimestamp()).isEqualTo(new DateTime(2016, 4, 1, 0, 0, DateTimeZone.UTC));
+        assertThat(message.getField("facility")).isEqualTo("beats");
+        assertThat(message.getField("beats_type")).isEqualTo("beat");
+        assertThat(message.getField("beat_foo")).isEqualTo("bar");
+        assertThat(message.getField("beat_fields_foo_field")).isEqualTo("bar");
+    }
+
+    @Test
+    public void decodeMessagesHandlesMetricbeatMessages() throws Exception {
+        final String[] testFiles = {
+                "metricbeat-docker-container.json",
+                "metricbeat-docker-cpu.json",
+                "metricbeat-docker-diskio.json",
+                "metricbeat-docker-info.json",
+                "metricbeat-docker-memory.json",
+                "metricbeat-docker-network.json",
+                "metricbeat-mongodb-status.json",
+                "metricbeat-mysql-status.json",
+                "metricbeat-system-core.json",
+                "metricbeat-system-cpu.json",
+                "metricbeat-system-filesystem.json",
+                "metricbeat-system-fsstat.json",
+                "metricbeat-system-load.json",
+                "metricbeat-system-memory.json",
+                "metricbeat-system-network.json",
+                "metricbeat-system-process.json"
+        };
+
+        for (String testFile : testFiles) {
+            final Message message = codec.decode(messageFromJson(testFile));
+            assertThat(message).isNotNull();
+            assertThat(message.getSource()).isEqualTo("example.local");
+            assertThat(message.getTimestamp()).isEqualTo(new DateTime(2016, 12, 14, 12, 0, DateTimeZone.UTC));
+            assertThat(message.getField("facility")).isEqualTo("beats");
+            assertThat(message.getField("beats_type")).isEqualTo("metricbeat");
+        }
+    }
+
+    @Test
+    public void decodeMessagesHandlesGenericBeatWithDocker() throws Exception {
+        final Message message = codec.decode(messageFromJson("generic-with-docker.json"));
+        assertThat(message).isNotNull();
+        assertThat(message.getMessage()).isEqualTo("-");
+        assertThat(message.getSource()).isEqualTo("unknown");
+        assertThat(message.getTimestamp()).isEqualTo(new DateTime(2016, 4, 1, 0, 0, DateTimeZone.UTC));
+        assertThat(message.getField("facility")).isEqualTo("beats");
+        assertThat(message.getField("beats_type")).isEqualTo("beat");
+        assertThat(message.getField("beat_foo")).isEqualTo("bar");
+        assertThat(message.getField("beat_docker_id")).isEqualTo("123");
+        assertThat(message.getField("beat_docker_name")).isEqualTo("container-1");
+        assertThat(message.getField("beat_docker_labels_docker-kubernetes-pod")).isEqualTo("hello");
+    }
+
+    @Test
+    public void decodeMessagesHandlesGenericBeatWithKubernetes() throws Exception {
+        final Message message = codec.decode(messageFromJson("generic-with-kubernetes.json"));
+        assertThat(message).isNotNull();
+        assertThat(message.getMessage()).isEqualTo("-");
+        assertThat(message.getSource()).isEqualTo("unknown");
+        assertThat(message.getTimestamp()).isEqualTo(new DateTime(2016, 4, 1, 0, 0, DateTimeZone.UTC));
+        assertThat(message.getField("facility")).isEqualTo("beats");
+        assertThat(message.getField("beats_type")).isEqualTo("beat");
+        assertThat(message.getField("beat_foo")).isEqualTo("bar");
+        assertThat(message.getField("beat_kubernetes_pod_name")).isEqualTo("testpod");
+        assertThat(message.getField("beat_kubernetes_namespace")).isEqualTo("testns");
+        assertThat(message.getField("beat_kubernetes_labels_labelkey")).isEqualTo("labelvalue");
+    }
+
+    @Test
+    public void decodeMessagesHandlesGenericBeatWithCloudAlibaba() throws Exception {
+        final Message message = codec.decode(messageFromJson("generic-with-cloud-alibaba.json"));
+        assertThat(message).isNotNull();
+        assertThat(message.getMessage()).isEqualTo("-");
+        assertThat(message.getSource()).isEqualTo("unknown");
+        assertThat(message.getTimestamp()).isEqualTo(new DateTime(2016, 4, 1, 0, 0, DateTimeZone.UTC));
+        assertThat(message.getField("facility")).isEqualTo("beats");
+        assertThat(message.getField("beats_type")).isEqualTo("beat");
+        assertThat(message.getField("beat_foo")).isEqualTo("bar");
+        assertThat(message.getField("beat_meta_cloud_provider")).isEqualTo("ecs");
+        assertThat(message.getField("beat_meta_cloud_instance_id")).isEqualTo("i-wz9g2hqiikg0aliyun2b");
+        assertThat(message.getField("beat_meta_cloud_availability_zone")).isEqualTo("cn-shenzhen");
+        assertThat(message.getField("beat_meta_cloud_region")).isEqualTo("cn-shenzhen-a");
+    }
+
+    @Test
+    public void decodeMessagesHandlesGenericBeatWithCloudDigitalOcean() throws Exception {
+        final Message message = codec.decode(messageFromJson("generic-with-cloud-digital-ocean.json"));
+        assertThat(message).isNotNull();
+        assertThat(message.getMessage()).isEqualTo("-");
+        assertThat(message.getSource()).isEqualTo("unknown");
+        assertThat(message.getTimestamp()).isEqualTo(new DateTime(2016, 4, 1, 0, 0, DateTimeZone.UTC));
+        assertThat(message.getField("facility")).isEqualTo("beats");
+        assertThat(message.getField("beats_type")).isEqualTo("beat");
+        assertThat(message.getField("beat_foo")).isEqualTo("bar");
+        assertThat(message.getField("beat_meta_cloud_provider")).isEqualTo("digitalocean");
+        assertThat(message.getField("beat_meta_cloud_instance_id")).isEqualTo("1234567");
+        assertThat(message.getField("beat_meta_cloud_region")).isEqualTo("nyc2");
+    }
+
+    @Test
+    public void decodeMessagesHandlesGenericBeatWithCloudEC2() throws Exception {
+        final Message message = codec.decode(messageFromJson("generic-with-cloud-ec2.json"));
+        assertThat(message).isNotNull();
+        assertThat(message.getMessage()).isEqualTo("-");
+        assertThat(message.getSource()).isEqualTo("unknown");
+        assertThat(message.getTimestamp()).isEqualTo(new DateTime(2016, 4, 1, 0, 0, DateTimeZone.UTC));
+        assertThat(message.getField("facility")).isEqualTo("beats");
+        assertThat(message.getField("beats_type")).isEqualTo("beat");
+        assertThat(message.getField("beat_foo")).isEqualTo("bar");
+        assertThat(message.getField("beat_meta_cloud_provider")).isEqualTo("ec2");
+        assertThat(message.getField("beat_meta_cloud_machine_type")).isEqualTo("t2.medium");
+        assertThat(message.getField("beat_meta_cloud_instance_id")).isEqualTo("i-4e123456");
+        assertThat(message.getField("beat_meta_cloud_region")).isEqualTo("us-east-1");
+        assertThat(message.getField("beat_meta_cloud_availability_zone")).isEqualTo("us-east-1c");
+    }
+
+    @Test
+    public void decodeMessagesHandlesGenericBeatWithCloudGCE() throws Exception {
+        final Message message = codec.decode(messageFromJson("generic-with-cloud-gce.json"));
+        assertThat(message).isNotNull();
+        assertThat(message.getMessage()).isEqualTo("-");
+        assertThat(message.getSource()).isEqualTo("unknown");
+        assertThat(message.getTimestamp()).isEqualTo(new DateTime(2016, 4, 1, 0, 0, DateTimeZone.UTC));
+        assertThat(message.getField("facility")).isEqualTo("beats");
+        assertThat(message.getField("beats_type")).isEqualTo("beat");
+        assertThat(message.getField("beat_foo")).isEqualTo("bar");
+        assertThat(message.getField("beat_meta_cloud_provider")).isEqualTo("gce");
+        assertThat(message.getField("beat_meta_cloud_machine_type")).isEqualTo("projects/1234567890/machineTypes/f1-micro");
+        assertThat(message.getField("beat_meta_cloud_instance_id")).isEqualTo("1234556778987654321");
+        assertThat(message.getField("beat_meta_cloud_project_id")).isEqualTo("my-dev");
+        assertThat(message.getField("beat_meta_cloud_availability_zone")).isEqualTo("projects/1234567890/zones/us-east1-b");
+    }
+
+    @Test
+    public void decodeMessagesHandlesGenericBeatWithCloudTencent() throws Exception {
+        final Message message = codec.decode(messageFromJson("generic-with-cloud-tencent.json"));
+        assertThat(message).isNotNull();
+        assertThat(message.getMessage()).isEqualTo("-");
+        assertThat(message.getSource()).isEqualTo("unknown");
+        assertThat(message.getTimestamp()).isEqualTo(new DateTime(2016, 4, 1, 0, 0, DateTimeZone.UTC));
+        assertThat(message.getField("facility")).isEqualTo("beats");
+        assertThat(message.getField("beats_type")).isEqualTo("beat");
+        assertThat(message.getField("beat_foo")).isEqualTo("bar");
+        assertThat(message.getField("beat_meta_cloud_provider")).isEqualTo("qcloud");
+        assertThat(message.getField("beat_meta_cloud_instance_id")).isEqualTo("ins-qcloudv5");
+        assertThat(message.getField("beat_meta_cloud_region")).isEqualTo("china-south-gz");
+        assertThat(message.getField("beat_meta_cloud_availability_zone")).isEqualTo("gz-azone2");
+    }
+
+    private RawMessage messageFromJson(String resourceName) throws IOException {
+        final URL resource = Resources.getResource(this.getClass(), resourceName);
+        final byte[] json = Resources.toByteArray(resource);
+        return new RawMessage(json);
+    }
+}

--- a/graylog2-server/src/test/java/org/graylog/plugins/beats/Beats2InputDescriptorTest.java
+++ b/graylog2-server/src/test/java/org/graylog/plugins/beats/Beats2InputDescriptorTest.java
@@ -16,15 +16,13 @@
  */
 package org.graylog.plugins.beats;
 
-import org.graylog2.plugin.PluginModule;
+import org.junit.Test;
 
-public class BeatsInputPluginModule extends PluginModule {
-    @Override
-    protected void configure() {
-        addTransport("beats", BeatsTransport.class);
-        addCodec("beats", BeatsCodec.class);
-        addCodec("beats", Beats2Codec.class);
-        addMessageInput(BeatsInput.class);
-        addMessageInput(Beats2Input.class);
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class Beats2InputDescriptorTest {
+    @Test
+    public void descriptorNameIsCorrect() {
+        assertThat(new Beats2Input.Descriptor().getName()).isEqualTo("Beats");
     }
 }

--- a/graylog2-server/src/test/java/org/graylog/plugins/beats/BeatsInputDescriptorTest.java
+++ b/graylog2-server/src/test/java/org/graylog/plugins/beats/BeatsInputDescriptorTest.java
@@ -23,6 +23,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 public class BeatsInputDescriptorTest {
     @Test
     public void descriptorNameIsCorrect() {
-        assertThat(new BeatsInput.Descriptor().getName()).isEqualTo("Beats");
+        assertThat(new BeatsInput.Descriptor().getName()).isEqualTo("Beats Legacy");
     }
 }

--- a/graylog2-server/src/test/java/org/graylog/plugins/beats/LegacyConsolePrinter.java
+++ b/graylog2-server/src/test/java/org/graylog/plugins/beats/LegacyConsolePrinter.java
@@ -36,7 +36,7 @@ import org.graylog2.shared.bindings.providers.ObjectMapperProvider;
 
 import static com.google.common.base.MoreObjects.firstNonNull;
 
-public class ConsolePrinter {
+public class LegacyConsolePrinter {
     public static void main(String[] args) throws Exception {
         String hostname = "127.0.0.1";
         int port = 5044;
@@ -59,7 +59,7 @@ public class ConsolePrinter {
                         public void initChannel(SocketChannel ch) throws Exception {
                             ch.pipeline().addLast("logging", new LoggingHandler());
                             ch.pipeline().addLast("beats-frame-decoder", new BeatsFrameDecoder());
-                            ch.pipeline().addLast("beats-codec", new BeatsCodecHandler());
+                            ch.pipeline().addLast("beats-legacy-codec", new BeatsCodecHandler());
                         }
                     });
 
@@ -73,7 +73,7 @@ public class ConsolePrinter {
 
     public static class BeatsCodecHandler extends SimpleChannelInboundHandler<ByteBuf> {
         private final ObjectMapper objectMapper = new ObjectMapperProvider().get();
-        private final Beats2Codec beatsCodec = new Beats2Codec(Configuration.EMPTY_CONFIGURATION, objectMapper);
+        private final BeatsCodec beatsCodec = new BeatsCodec(Configuration.EMPTY_CONFIGURATION, objectMapper);
 
         @Override
         protected void channelRead0(ChannelHandlerContext ctx, ByteBuf message) throws Exception {

--- a/graylog2-server/src/test/java/org/graylog/plugins/beats/MapUtilsTest.java
+++ b/graylog2-server/src/test/java/org/graylog/plugins/beats/MapUtilsTest.java
@@ -1,18 +1,18 @@
 /**
- * This file is part of Graylog Beats Plugin.
+ * This file is part of Graylog.
  *
- * Graylog Beats Plugin is free software: you can redistribute it and/or modify
+ * Graylog is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * Graylog Beats Plugin is distributed in the hope that it will be useful,
+ * Graylog is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with Graylog Beats Plugin.  If not, see <http://www.gnu.org/licenses/>.
+ * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
  */
 package org.graylog.plugins.beats;
 

--- a/graylog2-server/src/test/java/org/graylog/plugins/beats/MapUtilsTest.java
+++ b/graylog2-server/src/test/java/org/graylog/plugins/beats/MapUtilsTest.java
@@ -1,0 +1,111 @@
+/**
+ * This file is part of Graylog Beats Plugin.
+ *
+ * Graylog Beats Plugin is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog Beats Plugin is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog Beats Plugin.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.graylog.plugins.beats;
+
+import com.google.common.collect.ImmutableMap;
+import org.junit.Test;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class MapUtilsTest {
+    @Test
+    public void flattenHandlesEmptyMap() throws Exception {
+        assertThat(MapUtils.flatten(Collections.emptyMap(), "", "_")).isEmpty();
+    }
+
+    @Test
+    public void flattenHandlesFlatMap() throws Exception {
+        final Map<String, Object> map = ImmutableMap.of(
+                "foo", "bar",
+                "baz", "qux");
+        assertThat(MapUtils.flatten(map, "", "_")).isEqualTo(map);
+    }
+
+    @Test
+    public void flattenAddsParentKey() throws Exception {
+        final Map<String, Object> map = ImmutableMap.of(
+                "map", ImmutableMap.of(
+                        "foo", "bar",
+                        "baz", "qux"));
+        final Map<String, Object> expected = ImmutableMap.of(
+                "map_foo", "bar",
+                "map_baz", "qux");
+        assertThat(MapUtils.flatten(map, "", "_")).isEqualTo(expected);
+    }
+
+    @Test
+    public void flattenAddsParentKeys() throws Exception {
+        final Map<String, Object> map = ImmutableMap.of(
+                "map", ImmutableMap.of(
+                        "foo", "bar",
+                        "baz", "qux"));
+        final Map<String, Object> expected = ImmutableMap.of(
+                "test_map_foo", "bar",
+                "test_map_baz", "qux");
+        assertThat(MapUtils.flatten(map, "test", "_")).isEqualTo(expected);
+    }
+
+    @Test
+    public void flattenSupportsMultipleLevels() throws Exception {
+        final Map<String, Object> map = ImmutableMap.of(
+                "map", ImmutableMap.of(
+                        "foo", "bar",
+                        "baz", ImmutableMap.of(
+                                "foo", "bar",
+                                "baz", "qux")));
+        final Map<String, Object> expected = ImmutableMap.of(
+                "map_foo", "bar",
+                "map_baz_foo", "bar",
+                "map_baz_baz", "qux");
+        assertThat(MapUtils.flatten(map, "", "_")).isEqualTo(expected);
+    }
+
+    @Test
+    public void renameKeyHandlesEmptyMap() {
+        final Map<String, Object> map = new HashMap<>();
+        MapUtils.renameKey(map, "foo", "bar");
+        assertThat(map).isEmpty();
+    }
+
+    @Test
+    public void renameKeyMutatesMap() {
+        final Map<String, Object> map = new HashMap<>();
+        map.put("foo", "test");
+        MapUtils.renameKey(map, "foo", "bar");
+        assertThat(map).containsEntry("bar", "test");
+    }
+
+    @Test
+    public void replaceKeyCharacterHandlesEmptyMap() {
+        assertThat(MapUtils.replaceKeyCharacter(Collections.emptyMap(), '.', '_')).isEmpty();
+    }
+
+    @Test
+    public void renameKeyReturnsMutatedMap() {
+        final Map<String, Object> map = ImmutableMap.of(
+                "foo.bar", "test",
+                "baz@quux", "test");
+        assertThat(MapUtils.replaceKeyCharacter(map, '.', '_'))
+                .hasSameSizeAs(map)
+                .containsEntry("foo_bar", "test")
+                .containsEntry("baz@quux", "test");
+    }
+}


### PR DESCRIPTION
Instead of changing the behavior of the old Beats input (`BeatsCodec`), this change set reverts the changes of Graylog2/graylog-plugin-beats#29 and creates a new input ( `Beats2Input`, `Beats2Codec`) instead.

This way, existing users don't need to change anything and new users can use the new Beats input with the improved field handling introduces in Graylog2/graylog-plugin-beats#29.

Closes Graylog2/graylog-plugin-beats#33