### PR TITLE
Move pipeline-processor and map-widget REST resources out of /plugins prefix

### DIFF
--- a/UPGRADING.rst
+++ b/UPGRADING.rst
@@ -112,3 +112,31 @@ Starting with Graylog 3.0.0, the following official plugins were merged into the
 That means these plugins are not available as separate plugins anymore. If you manually update your Graylog installation (without using operating system packages), make sure to remove all old plugin files from the `plugin_dir <http://docs.graylog.org/en/3.0/pages/configuration/server.conf.html>`_ folder.
 
 The old issues in these repositories are still available for reference but new issues should only be created in the `Graylog server issue tracker <https://github.com/Graylog2/graylog2-server/issues>`_.
+
+The following HTTP API paths changed due to the plugin merge:
+
++---------------------------------------------------------------------------------------------+-----------------------------------------------+
+| Old Path                                                                                    | New Path                                      |
++=============================================================================================+===============================================+
+| ``/plugins/org.graylog.plugins.map/mapdata``                                                | ``/search/mapdata``                           |
++---------------------------------------------------------------------------------------------+-----------------------------------------------+
+| ``/plugins/org.graylog.plugins.pipelineprocessor/system/pipelines/pipeline``                | ``/system/pipelines/pipeline``                |
++---------------------------------------------------------------------------------------------+-----------------------------------------------+
+| ``/plugins/org.graylog.plugins.pipelineprocessor/system/pipelines/pipeline/parse``          | ``/system/pipelines/pipeline/parse``          |
++---------------------------------------------------------------------------------------------+-----------------------------------------------+
+| ``/plugins/org.graylog.plugins.pipelineprocessor/system/pipelines/rule``                    | ``/system/pipelines/rule``                    |
++---------------------------------------------------------------------------------------------+-----------------------------------------------+
+| ``/plugins/org.graylog.plugins.pipelineprocessor/system/pipelines/rule/functions``          | ``/system/pipelines/rule/functions``          |
++---------------------------------------------------------------------------------------------+-----------------------------------------------+
+| ``/plugins/org.graylog.plugins.pipelineprocessor/system/pipelines/rule/multiple``           | ``/system/pipelines/rule/multiple``           |
++---------------------------------------------------------------------------------------------+-----------------------------------------------+
+| ``/plugins/org.graylog.plugins.pipelineprocessor/system/pipelines/rule/parse``              | ``/system/pipelines/rule/parse``              |
++---------------------------------------------------------------------------------------------+-----------------------------------------------+
+| ``/plugins/org.graylog.plugins.pipelineprocessor/system/pipelines/connections``             | ``/system/pipelines/connections``             |
++---------------------------------------------------------------------------------------------+-----------------------------------------------+
+| ``/plugins/org.graylog.plugins.pipelineprocessor/system/pipelines/connections/to_stream``   | ``/system/pipelines/connections/to_stream``   |
++---------------------------------------------------------------------------------------------+-----------------------------------------------+
+| ``/plugins/org.graylog.plugins.pipelineprocessor/system/pipelines/connections/to_pipeline`` | ``/system/pipelines/connections/to_pipeline`` |
++---------------------------------------------------------------------------------------------+-----------------------------------------------+
+| ``/plugins/org.graylog.plugins.pipelineprocessor/system/pipelines/simulate``                | ``/system/pipelines/simulate``                |
++---------------------------------------------------------------------------------------------+-----------------------------------------------+

--- a/graylog2-server/src/main/java/org/graylog/plugins/map/MapWidgetModule.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/map/MapWidgetModule.java
@@ -18,7 +18,6 @@ package org.graylog.plugins.map;
 
 import org.graylog.plugins.map.geoip.MaxmindDataAdapter;
 import org.graylog.plugins.map.geoip.processor.GeoIpProcessor;
-import org.graylog.plugins.map.rest.MapDataResource;
 import org.graylog.plugins.map.widget.strategy.MapWidgetStrategy;
 import org.graylog2.plugin.PluginModule;
 
@@ -27,7 +26,7 @@ public class MapWidgetModule extends PluginModule {
     protected void configure() {
         addMessageProcessor(GeoIpProcessor.class, GeoIpProcessor.Descriptor.class);
         addWidgetStrategy(MapWidgetStrategy.class, MapWidgetStrategy.Factory.class);
-        addRestResource(MapDataResource.class);
+        registerRestControllerPackage(getClass().getPackage().getName());
 
         installLookupDataAdapter(MaxmindDataAdapter.NAME,
                 MaxmindDataAdapter.class,

--- a/graylog2-server/src/main/java/org/graylog/plugins/map/rest/MapDataResource.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/map/rest/MapDataResource.java
@@ -47,7 +47,7 @@ import javax.ws.rs.core.MediaType;
 
 @RequiresAuthentication
 @Api(value = "MapWidget", description = "Get map data")
-@Path("/mapdata")
+@Path("/search/mapdata")
 public class MapDataResource extends SearchResource implements PluginRestResource {
     private static final Logger LOG = LoggerFactory.getLogger(MapDataResource.class);
 

--- a/graylog2-server/src/main/java/org/graylog/plugins/pipelineprocessor/PipelineProcessorModule.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/pipelineprocessor/PipelineProcessorModule.java
@@ -17,21 +17,12 @@
 package org.graylog.plugins.pipelineprocessor;
 
 import com.google.inject.assistedinject.FactoryModuleBuilder;
-
 import org.graylog.plugins.pipelineprocessor.audit.PipelineProcessorAuditEventTypes;
 import org.graylog.plugins.pipelineprocessor.functions.ProcessorFunctionsModule;
 import org.graylog.plugins.pipelineprocessor.periodical.LegacyDefaultStreamMigration;
 import org.graylog.plugins.pipelineprocessor.processors.PipelineInterpreter;
-import org.graylog.plugins.pipelineprocessor.rest.PipelineConnectionsResource;
-import org.graylog.plugins.pipelineprocessor.rest.PipelineResource;
 import org.graylog.plugins.pipelineprocessor.rest.PipelineRestPermissions;
-import org.graylog.plugins.pipelineprocessor.rest.RuleResource;
-import org.graylog.plugins.pipelineprocessor.rest.SimulatorResource;
-import org.graylog2.plugin.PluginConfigBean;
 import org.graylog2.plugin.PluginModule;
-
-import java.util.Collections;
-import java.util.Set;
 
 public class PipelineProcessorModule extends PluginModule {
     @Override
@@ -39,11 +30,9 @@ public class PipelineProcessorModule extends PluginModule {
         addPeriodical(LegacyDefaultStreamMigration.class);
 
         addMessageProcessor(PipelineInterpreter.class, PipelineInterpreter.Descriptor.class);
-        addRestResource(RuleResource.class);
-        addRestResource(PipelineResource.class);
-        addRestResource(PipelineConnectionsResource.class);
-        addRestResource(SimulatorResource.class);
         addPermissions(PipelineRestPermissions.class);
+
+        registerRestControllerPackage(getClass().getPackage().getName());
 
         install(new ProcessorFunctionsModule());
 

--- a/graylog2-server/src/main/java/org/graylog2/bindings/ServerBindings.java
+++ b/graylog2-server/src/main/java/org/graylog2/bindings/ServerBindings.java
@@ -37,7 +37,6 @@ import org.graylog2.bindings.providers.SystemJobFactoryProvider;
 import org.graylog2.bindings.providers.SystemJobManagerProvider;
 import org.graylog2.bundles.BundleService;
 import org.graylog2.cluster.ClusterConfigServiceImpl;
-import org.graylog2.users.UserPermissionsCleanupListener;
 import org.graylog2.dashboards.widgets.WidgetCacheTime;
 import org.graylog2.dashboards.widgets.WidgetEventsListener;
 import org.graylog2.database.MongoConnection;
@@ -94,11 +93,10 @@ import org.graylog2.users.RoleService;
 import org.graylog2.users.RoleServiceImpl;
 import org.graylog2.users.StartPageCleanupListener;
 import org.graylog2.users.UserImpl;
+import org.graylog2.users.UserPermissionsCleanupListener;
 
 import javax.ws.rs.container.DynamicFeature;
 import javax.ws.rs.ext.ExceptionMapper;
-
-import static com.google.inject.name.Names.named;
 
 public class ServerBindings extends Graylog2Module {
     private final Configuration configuration;
@@ -174,10 +172,8 @@ public class ServerBindings extends Graylog2Module {
         bind(Engine.class).toInstance(Engine.createEngine());
         bind(ErrorPageGenerator.class).to(GraylogErrorPageGenerator.class).asEagerSingleton();
 
-        bind(String[].class).annotatedWith(named("RestControllerPackages")).toInstance(new String[]{
-                "org.graylog2.rest.resources",
-                "org.graylog2.shared.rest.resources"
-        });
+        registerRestControllerPackage("org.graylog2.rest.resources");
+        registerRestControllerPackage("org.graylog2.shared.rest.resources");
     }
 
     private void bindInterfaces() {

--- a/graylog2-server/src/main/java/org/graylog2/plugin/inject/Graylog2Module.java
+++ b/graylog2-server/src/main/java/org/graylog2/plugin/inject/Graylog2Module.java
@@ -440,4 +440,9 @@ public abstract class Graylog2Module extends AbstractModule {
     private static class ContainerResponseFilterType extends TypeLiteral<Class<? extends ContainerResponseFilter>> {}
 
     private static class ExceptionMapperType extends TypeLiteral<Class<? extends ExceptionMapper>> {}
+
+    protected void registerRestControllerPackage(String packageName) {
+        final Multibinder<RestControllerPackage> restControllerPackages = Multibinder.newSetBinder(binder(), RestControllerPackage.class);
+        restControllerPackages.addBinding().toInstance(RestControllerPackage.create(packageName));
+    }
 }

--- a/graylog2-server/src/main/java/org/graylog2/plugin/inject/RestControllerPackage.java
+++ b/graylog2-server/src/main/java/org/graylog2/plugin/inject/RestControllerPackage.java
@@ -16,18 +16,13 @@
  */
 package org.graylog2.plugin.inject;
 
-public class RestControllerPackage {
-    public static RestControllerPackage create(String packageName) {
-        return new RestControllerPackage(packageName);
-    }
+import com.google.auto.value.AutoValue;
 
-    private final String packageName;
+@AutoValue
+public abstract class RestControllerPackage {
+    public abstract String name();
 
-    private RestControllerPackage(String packageName) {
-        this.packageName = packageName;
-    }
-
-    public String getPackageName() {
-        return packageName;
+    public static RestControllerPackage create(String name) {
+        return new AutoValue_RestControllerPackage(name);
     }
 }

--- a/graylog2-server/src/main/java/org/graylog2/plugin/inject/RestControllerPackage.java
+++ b/graylog2-server/src/main/java/org/graylog2/plugin/inject/RestControllerPackage.java
@@ -1,0 +1,33 @@
+/**
+ * This file is part of Graylog.
+ *
+ * Graylog is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.graylog2.plugin.inject;
+
+public class RestControllerPackage {
+    public static RestControllerPackage create(String packageName) {
+        return new RestControllerPackage(packageName);
+    }
+
+    private final String packageName;
+
+    private RestControllerPackage(String packageName) {
+        this.packageName = packageName;
+    }
+
+    public String getPackageName() {
+        return packageName;
+    }
+}

--- a/graylog2-server/src/main/java/org/graylog2/shared/initializers/JerseyService.java
+++ b/graylog2-server/src/main/java/org/graylog2/shared/initializers/JerseyService.java
@@ -39,6 +39,7 @@ import org.graylog2.audit.PluginAuditEventTypes;
 import org.graylog2.audit.jersey.AuditEventModelProcessor;
 import org.graylog2.configuration.HttpConfiguration;
 import org.graylog2.jersey.PrefixAddingModelProcessor;
+import org.graylog2.plugin.inject.RestControllerPackage;
 import org.graylog2.plugin.rest.PluginRestResource;
 import org.graylog2.rest.filter.WebAppNotFoundResponseFilter;
 import org.graylog2.shared.rest.CORSFilter;
@@ -94,7 +95,7 @@ public class JerseyService extends AbstractIdleService {
 
     private final HttpConfiguration configuration;
     private final Map<String, Set<Class<? extends PluginRestResource>>> pluginRestResources;
-    private final String[] restControllerPackages;
+    private final Set<RestControllerPackage> restControllerPackages;
 
     private final Set<Class<? extends DynamicFeature>> dynamicFeatures;
     private final Set<Class<? extends ContainerResponseFilter>> containerResponseFilters;
@@ -114,7 +115,7 @@ public class JerseyService extends AbstractIdleService {
                          Set<Class<? extends ExceptionMapper>> exceptionMappers,
                          @Named("additionalJerseyComponents") final Set<Class> additionalComponents,
                          final Map<String, Set<Class<? extends PluginRestResource>>> pluginRestResources,
-                         @Named("RestControllerPackages") final String[] restControllerPackages,
+                         final Set<RestControllerPackage> restControllerPackages,
                          Set<PluginAuditEventTypes> pluginAuditEventTypes,
                          ObjectMapper objectMapper,
                          MetricRegistry metricRegistry,
@@ -154,7 +155,9 @@ public class JerseyService extends AbstractIdleService {
 
     private void startUpApi() throws Exception {
         final List<String> resourcePackages = ImmutableList.<String>builder()
-                .add(restControllerPackages)
+                .addAll(restControllerPackages.stream()
+                        .map(RestControllerPackage::getPackageName)
+                        .collect(Collectors.toList()))
                 .add(RESOURCE_PACKAGE_WEB)
                 .build();
 

--- a/graylog2-server/src/main/java/org/graylog2/shared/initializers/JerseyService.java
+++ b/graylog2-server/src/main/java/org/graylog2/shared/initializers/JerseyService.java
@@ -156,7 +156,7 @@ public class JerseyService extends AbstractIdleService {
     private void startUpApi() throws Exception {
         final List<String> resourcePackages = ImmutableList.<String>builder()
                 .addAll(restControllerPackages.stream()
-                        .map(RestControllerPackage::getPackageName)
+                        .map(RestControllerPackage::name)
                         .collect(Collectors.toList()))
                 .add(RESOURCE_PACKAGE_WEB)
                 .build();

--- a/graylog2-server/src/main/java/org/graylog2/shared/rest/resources/documentation/DocumentationResource.java
+++ b/graylog2-server/src/main/java/org/graylog2/shared/rest/resources/documentation/DocumentationResource.java
@@ -23,6 +23,7 @@ import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
 import io.swagger.annotations.ApiParam;
 import org.graylog2.configuration.HttpConfiguration;
+import org.graylog2.plugin.inject.RestControllerPackage;
 import org.graylog2.plugin.rest.PluginRestResource;
 import org.graylog2.rest.RestTools;
 import org.graylog2.shared.plugins.PluginRestResourceClasses;
@@ -30,7 +31,6 @@ import org.graylog2.shared.rest.documentation.generator.Generator;
 import org.graylog2.shared.rest.resources.RestResource;
 
 import javax.inject.Inject;
-import javax.inject.Named;
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
@@ -43,6 +43,7 @@ import java.net.URI;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 import static java.util.Objects.requireNonNull;
 import static org.graylog2.shared.initializers.JerseyService.PLUGIN_PREFIX;
@@ -56,14 +57,16 @@ public class DocumentationResource extends RestResource {
 
     @Inject
     public DocumentationResource(HttpConfiguration httpConfiguration,
-                                 @Named("RestControllerPackages") String[] restControllerPackages,
+                                 Set<RestControllerPackage> restControllerPackages,
                                  ObjectMapper objectMapper,
                                  PluginRestResourceClasses pluginRestResourceClasses) {
 
         this.httpConfiguration = requireNonNull(httpConfiguration, "httpConfiguration");
 
         final ImmutableSet.Builder<String> packageNames = ImmutableSet.<String>builder()
-                .add(restControllerPackages);
+                .addAll(restControllerPackages.stream()
+                        .map(RestControllerPackage::getPackageName)
+                        .collect(Collectors.toList()));
 
         // All plugin resources get the plugin prefix + the plugin package.
         final Map<Class<?>, String> pluginRestControllerMapping = new HashMap<>();

--- a/graylog2-server/src/main/java/org/graylog2/shared/rest/resources/documentation/DocumentationResource.java
+++ b/graylog2-server/src/main/java/org/graylog2/shared/rest/resources/documentation/DocumentationResource.java
@@ -65,7 +65,7 @@ public class DocumentationResource extends RestResource {
 
         final ImmutableSet.Builder<String> packageNames = ImmutableSet.<String>builder()
                 .addAll(restControllerPackages.stream()
-                        .map(RestControllerPackage::getPackageName)
+                        .map(RestControllerPackage::name)
                         .collect(Collectors.toList()));
 
         // All plugin resources get the plugin prefix + the plugin package.

--- a/graylog2-web-interface/src/routing/ApiRoutes.js
+++ b/graylog2-web-interface/src/routing/ApiRoutes.js
@@ -337,6 +337,35 @@ const ApiRoutes = {
     parse: () => { return { url: '/messages/parse' }; },
     single: (index, messageId) => { return { url: `/messages/${index}/${messageId}` }; },
   },
+  MapDataController: {
+    search: () => { return { url: '/search/mapdata' }; },
+  },
+  PipelinesController: {
+    list: () => { return { url: '/system/pipelines/pipeline' }; },
+    create: () => { return { url: '/system/pipelines/pipeline' }; },
+    get: (pipelineId) => { return { url: `/system/pipelines/pipeline/${pipelineId}` }; },
+    update: (pipelineId) => { return { url: `/system/pipelines/pipeline/${pipelineId}` }; },
+    delete: (pipelineId) => { return { url: `/system/pipelines/pipeline/${pipelineId}` }; },
+    parse: () => { return { url: '/system/pipelines/pipeline/parse' }; },
+  },
+  RulesController: {
+    list: () => { return { url: '/system/pipelines/rule' }; },
+    create: () => { return { url: '/system/pipelines/rule' }; },
+    get: (ruleId) => { return { url: `/system/pipelines/rule/${ruleId}` }; },
+    update: (ruleId) => { return { url: `/system/pipelines/rule/${ruleId}` }; },
+    delete: (ruleId) => { return { url: `/system/pipelines/rule/${ruleId}` }; },
+    multiple: () => { return { url: '/system/pipelines/rule/multiple' }; },
+    functions: () => { return { url: '/system/pipelines/rule/functions' }; },
+    parse: () => { return { url: '/system/pipelines/rule/parse' }; },
+  },
+  ConnectionsController: {
+    list: () => { return { url: '/system/pipelines/connections' }; },
+    to_stream: () => { return { url: '/system/pipelines/connections/to_stream' }; },
+    to_pipeline: () => { return { url: '/system/pipelines/connections/to_pipeline' }; },
+  },
+  SimulatorController: {
+    simulate: () => { return { url: '/system/pipelines/simulate' }; },
+  },
   ping: () => { return { url: '/' }; },
 };
 

--- a/graylog2-web-interface/src/stores/maps/MapsStore.js
+++ b/graylog2-web-interface/src/stores/maps/MapsStore.js
@@ -1,6 +1,7 @@
 import Reflux from 'reflux';
 
 import URLUtils from 'util/URLUtils';
+import ApiRoutes from 'routing/ApiRoutes';
 import fetch from 'logic/rest/FetchProvider';
 import UserNotification from 'util/UserNotification';
 
@@ -26,7 +27,7 @@ export const MapsStore = Reflux.createStore({
     // The TimeRange object needs a type to correctly deserialize on the server.
     timerange.type = rangeType;
 
-    const promise = fetch('POST', URLUtils.qualifyUrl('/plugins/org.graylog.plugins.map/mapdata'), {
+    const promise = fetch('POST', URLUtils.qualifyUrl(ApiRoutes.MapDataController.search().url), {
       query: q,
       timerange: timerange,
       limit: 50,

--- a/graylog2-web-interface/src/stores/pipelines/PipelineConnectionsStore.js
+++ b/graylog2-web-interface/src/stores/pipelines/PipelineConnectionsStore.js
@@ -1,12 +1,11 @@
 import Reflux from 'reflux';
 
 import UserNotification from 'util/UserNotification';
+import ApiRoutes from 'routing/ApiRoutes';
 import URLUtils from 'util/URLUtils';
 import fetch from 'logic/rest/FetchProvider';
 
 import PipelineConnectionsActions from 'actions/pipelines/PipelineConnectionsActions';
-
-const urlPrefix = '/plugins/org.graylog.plugins.pipelineprocessor';
 
 const PipelineConnectionsStore = Reflux.createStore({
   listenables: [PipelineConnectionsActions],
@@ -22,7 +21,7 @@ const PipelineConnectionsStore = Reflux.createStore({
         'Could not retrieve pipeline connections');
     };
 
-    const url = URLUtils.qualifyUrl(urlPrefix + '/system/pipelines/connections');
+    const url = URLUtils.qualifyUrl(ApiRoutes.ConnectionsController.list().url);
     const promise = fetch('GET', url);
     promise.then((response) => {
       this.connections = response;
@@ -31,7 +30,7 @@ const PipelineConnectionsStore = Reflux.createStore({
   },
 
   connectToStream(connection) {
-    const url = URLUtils.qualifyUrl(urlPrefix + '/system/pipelines/connections/to_stream');
+    const url = URLUtils.qualifyUrl(ApiRoutes.ConnectionsController.to_stream().url);
     const updatedConnection = {
       stream_id: connection.stream,
       pipeline_ids: connection.pipelines,
@@ -52,7 +51,7 @@ const PipelineConnectionsStore = Reflux.createStore({
   },
 
   connectToPipeline(reverseConnection) {
-    const url = URLUtils.qualifyUrl(`${urlPrefix}/system/pipelines/connections/to_pipeline`);
+    const url = URLUtils.qualifyUrl(ApiRoutes.ConnectionsController.to_pipeline().url);
     const updatedConnection = {
       pipeline_id: reverseConnection.pipeline,
       stream_ids: reverseConnection.streams,

--- a/graylog2-web-interface/src/stores/pipelines/PipelinesStore.js
+++ b/graylog2-web-interface/src/stores/pipelines/PipelinesStore.js
@@ -4,9 +4,8 @@ import PipelinesActions from 'actions/pipelines/PipelinesActions';
 
 import UserNotification from 'util/UserNotification';
 import URLUtils from 'util/URLUtils';
+import ApiRoutes from 'routing/ApiRoutes';
 import fetch from 'logic/rest/FetchProvider';
-
-const urlPrefix = '/plugins/org.graylog.plugins.pipelineprocessor';
 
 const PipelinesStore = Reflux.createStore({
   listenables: [PipelinesActions],
@@ -36,7 +35,7 @@ const PipelinesStore = Reflux.createStore({
         'Could not retrieve processing pipelines');
     };
 
-    const url = URLUtils.qualifyUrl(urlPrefix + '/system/pipelines/pipeline');
+    const url = URLUtils.qualifyUrl(ApiRoutes.PipelinesController.list().url);
     return fetch('GET', url).then((response) => {
       this.pipelines = response;
       this.trigger({pipelines: response});
@@ -49,7 +48,7 @@ const PipelinesStore = Reflux.createStore({
         `Could not retrieve processing pipeline "${pipelineId}"`);
     };
 
-    const url = URLUtils.qualifyUrl(`${urlPrefix}/system/pipelines/pipeline/${pipelineId}`);
+    const url = URLUtils.qualifyUrl(ApiRoutes.PipelinesController.get(pipelineId).url);
     const promise = fetch('GET', url);
     promise.then(this._updatePipelinesState, failCallback);
   },
@@ -59,7 +58,7 @@ const PipelinesStore = Reflux.createStore({
       UserNotification.error('Saving pipeline failed with status: ' + error.message,
         'Could not save processing pipeline');
     };
-    const url = URLUtils.qualifyUrl(urlPrefix + '/system/pipelines/pipeline');
+    const url = URLUtils.qualifyUrl(ApiRoutes.PipelinesController.create().url);
     const pipeline = {
       title: pipelineSource.title,
       description: pipelineSource.description,
@@ -81,7 +80,7 @@ const PipelinesStore = Reflux.createStore({
       UserNotification.error('Updating pipeline failed with status: ' + error.message,
         'Could not update processing pipeline');
     };
-    const url = URLUtils.qualifyUrl(urlPrefix + '/system/pipelines/pipeline/' + pipelineSource.id);
+    const url = URLUtils.qualifyUrl(ApiRoutes.PipelinesController.get(pipelineSource.id).url);
     const pipeline = {
       id: pipelineSource.id,
       title: pipelineSource.title,
@@ -103,7 +102,7 @@ const PipelinesStore = Reflux.createStore({
       UserNotification.error('Deleting pipeline failed with status: ' + error.message,
         `Could not delete processing pipeline "${pipelineId}"`);
     };
-    const url = URLUtils.qualifyUrl(urlPrefix + '/system/pipelines/pipeline/' + pipelineId);
+    const url = URLUtils.qualifyUrl(ApiRoutes.PipelinesController.delete(pipelineId).url);
     return fetch('DELETE', url).then(() => {
       const updatedPipelines = this.pipelines || [];
       this.pipelines = updatedPipelines.filter((el) => el.id !== pipelineId);
@@ -112,7 +111,7 @@ const PipelinesStore = Reflux.createStore({
     }, failCallback);
   },
   parse(pipelineSource, callback) {
-    const url = URLUtils.qualifyUrl(urlPrefix + '/system/pipelines/pipeline/parse');
+    const url = URLUtils.qualifyUrl(ApiRoutes.PipelinesController.parse().url);
     const pipeline = {
       title: pipelineSource.title,
       description: pipelineSource.description,

--- a/graylog2-web-interface/src/stores/pipelines/PipelinesStore.js
+++ b/graylog2-web-interface/src/stores/pipelines/PipelinesStore.js
@@ -80,7 +80,7 @@ const PipelinesStore = Reflux.createStore({
       UserNotification.error('Updating pipeline failed with status: ' + error.message,
         'Could not update processing pipeline');
     };
-    const url = URLUtils.qualifyUrl(ApiRoutes.PipelinesController.get(pipelineSource.id).url);
+    const url = URLUtils.qualifyUrl(ApiRoutes.PipelinesController.update(pipelineSource.id).url);
     const pipeline = {
       id: pipelineSource.id,
       title: pipelineSource.title,

--- a/graylog2-web-interface/src/stores/rules/RulesStore.js
+++ b/graylog2-web-interface/src/stores/rules/RulesStore.js
@@ -4,10 +4,9 @@ import RulesActions from 'actions/rules/RulesActions';
 
 import UserNotification from 'util/UserNotification';
 import URLUtils from 'util/URLUtils';
+import ApiRoutes from 'routing/ApiRoutes';
 import fetch from 'logic/rest/FetchProvider';
 import naturalSort from 'javascript-natural-sort';
-
-const urlPrefix = '/plugins/org.graylog.plugins.pipelineprocessor';
 
 const RulesStore = Reflux.createStore({
   listenables: [RulesActions],
@@ -45,7 +44,7 @@ const RulesStore = Reflux.createStore({
         'Could not retrieve processing rules');
     };
 
-    const url = URLUtils.qualifyUrl(urlPrefix + '/system/pipelines/rule');
+    const url = URLUtils.qualifyUrl(ApiRoutes.RulesController.list().url);
     return fetch('GET', url).then((response) => {
       this.rules = response;
       this.trigger({ rules: response, functionDescriptors: this.functionDescriptors });
@@ -58,7 +57,7 @@ const RulesStore = Reflux.createStore({
         `Could not retrieve processing rule "${ruleId}"`);
     };
 
-    const url = URLUtils.qualifyUrl(`${urlPrefix}/system/pipelines/rule/${ruleId}`);
+    const url = URLUtils.qualifyUrl(ApiRoutes.RulesController.get(ruleId).url);
     const promise = fetch('GET', url);
     promise.then(this._updateRulesState, failCallback);
 
@@ -70,7 +69,7 @@ const RulesStore = Reflux.createStore({
       UserNotification.error(`Saving rule "${ruleSource.title}" failed with status: ${error.message}`,
         `Could not save processing rule "${ruleSource.title}"`);
     };
-    const url = URLUtils.qualifyUrl(`${urlPrefix}/system/pipelines/rule`);
+    const url = URLUtils.qualifyUrl(ApiRoutes.RulesController.create().url);
     const rule = {
       title: ruleSource.title,
       description: ruleSource.description,
@@ -91,7 +90,7 @@ const RulesStore = Reflux.createStore({
       UserNotification.error(`Updating rule "${ruleSource.title}" failed with status: ${error.message}`,
         `Could not update processing rule "${ruleSource.title}"`);
     };
-    const url = URLUtils.qualifyUrl(`${urlPrefix}/system/pipelines/rule/${ruleSource.id}`);
+    const url = URLUtils.qualifyUrl(ApiRoutes.RulesController.update(ruleSource.id).url);
     const rule = {
       id: ruleSource.id,
       title: ruleSource.title,
@@ -112,7 +111,7 @@ const RulesStore = Reflux.createStore({
       UserNotification.error(`Deleting rule "${rule.title}" failed with status: ${error.message}`,
         `Could not delete processing rule "${rule.title}"`);
     };
-    const url = URLUtils.qualifyUrl(`${urlPrefix}/system/pipelines/rule/${rule.id}`);
+    const url = URLUtils.qualifyUrl(ApiRoutes.RulesController.delete(rule.id).url);
     return fetch('DELETE', url).then(() => {
       this.rules = this.rules.filter((el) => el.id !== rule.id);
       this.trigger({ rules: this.rules, functionDescriptors: this.functionDescriptors });
@@ -120,7 +119,7 @@ const RulesStore = Reflux.createStore({
     }, failCallback);
   },
   parse(ruleSource, callback) {
-    const url = URLUtils.qualifyUrl(urlPrefix + '/system/pipelines/rule/parse');
+    const url = URLUtils.qualifyUrl(ApiRoutes.RulesController.parse().url);
     const rule = {
       title: ruleSource.title,
       description: ruleSource.description,
@@ -141,7 +140,7 @@ const RulesStore = Reflux.createStore({
     );
   },
   multiple(ruleNames, callback) {
-    const url = URLUtils.qualifyUrl(urlPrefix + '/system/pipelines/rule/multiple');
+    const url = URLUtils.qualifyUrl(ApiRoutes.RulesController.multiple().url);
     const promise = fetch('POST', url, { rules: ruleNames });
     promise.then(callback);
 
@@ -151,7 +150,7 @@ const RulesStore = Reflux.createStore({
     if (this.functionDescriptors) {
       return;
     }
-    const url = URLUtils.qualifyUrl(`${urlPrefix}/system/pipelines/rule/functions`);
+    const url = URLUtils.qualifyUrl(ApiRoutes.RulesController.functions().url);
     return fetch('GET', url)
       .then(this._updateFunctionDescriptors);
   },

--- a/graylog2-web-interface/src/stores/simulator/SimulatorStore.js
+++ b/graylog2-web-interface/src/stores/simulator/SimulatorStore.js
@@ -1,5 +1,6 @@
 import Reflux from 'reflux';
 import URLUtils from 'util/URLUtils';
+import ApiRoutes from 'routing/ApiRoutes';
 import fetch from 'logic/rest/FetchProvider';
 
 import MessageFormatter from 'logic/message/MessageFormatter';
@@ -7,13 +8,11 @@ import ObjectUtils from 'util/ObjectUtils';
 
 import SimulatorActions from 'actions/simulator/SimulatorActions';
 
-const urlPrefix = '/plugins/org.graylog.plugins.pipelineprocessor';
-
 const SimulatorStore = Reflux.createStore({
   listenables: [SimulatorActions],
 
   simulate(stream, messageFields, inputId) {
-    const url = URLUtils.qualifyUrl(`${urlPrefix}/system/pipelines/simulate`);
+    const url = URLUtils.qualifyUrl(ApiRoutes.SimulatorController.simulate().url);
     const simulation = {
       stream_id: stream.id,
       message: messageFields,


### PR DESCRIPTION
This moves the REST resources of the pipeline-processor and map-widget code out of the `/plugins/<package-name>` namespace into the regular server namespace.

The UI code has been adjusted and new entries in `ApiRoutes.js` created.