### PR TITLE
Update to netty-4.1.22

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -127,7 +127,7 @@
         <mongodb-driver.version>3.5.0</mongodb-driver.version>
         <mongojack.version>2.8.0</mongojack.version>
         <natty.version>0.13</natty.version>
-        <netty.version>4.1.19.Final</netty.version>
+        <netty.version>4.1.22.Final</netty.version>
         <netty-tcnative-boringssl-static.version>2.0.7.Final</netty-tcnative-boringssl-static.version>
         <okhttp.version>3.9.1</okhttp.version>
         <opencsv.version>2.3</opencsv.version>


### PR DESCRIPTION
This updates netty to the latest 4.1.x release.

I ran this in my test setup with NetFlow, Beats and GELF inputs for about 18 hours and didn't run into any issues.

- http://netty.io/news/2018/01/22/4-0-55-Final-4-1-20-Final.html
- http://netty.io/news/2018/02/05/4-0-56-Final-4-1-21-Final.html
- http://netty.io/news/2018/02/21/4-1-22-Final.html