### PR TITLE
Add NullAway static code analysis

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/cluster/NodeImpl.java
+++ b/graylog2-server/src/main/java/org/graylog2/cluster/NodeImpl.java
@@ -58,7 +58,7 @@ public class NodeImpl extends PersistedImpl implements Node {
 
     @Override
     public DateTime getLastSeen() {
-        return new DateTime(((Integer) fields.get("last_seen")) * 1000L, DateTimeZone.UTC);
+        return new DateTime(((Integer) fields.getOrDefault("last_seen", 0)) * 1000L, DateTimeZone.UTC);
     }
 
     @Override

--- a/graylog2-server/src/main/java/org/graylog2/inputs/extractors/SplitAndIndexExtractor.java
+++ b/graylog2-server/src/main/java/org/graylog2/inputs/extractors/SplitAndIndexExtractor.java
@@ -46,13 +46,19 @@ public class SplitAndIndexExtractor extends Extractor {
                                   String conditionValue) throws ReservedFieldException, ConfigurationException {
         super(metricRegistry, id, title, order, Type.SPLIT_AND_INDEX, cursorStrategy, sourceField, targetField, extractorConfig, creatorUserId, converters, conditionType, conditionValue);
 
-        if (extractorConfig == null || extractorConfig.get("index") == null || extractorConfig.get("split_by") == null) {
+        if (extractorConfig == null) {
+            throw new ConfigurationException("Missing configuration.");
+        }
+
+        final Object indexConfig = extractorConfig.get("index");
+        final Object splitCharConfig = extractorConfig.get("split_by");
+        if (indexConfig == null || splitCharConfig == null) {
             throw new ConfigurationException("Missing configuration fields. Required: index, split_by");
         }
 
         try {
-            index = ((Integer) extractorConfig.get("index")) - 1;
-            splitChar = (String) extractorConfig.get("split_by");
+            this.index = ((Integer) indexConfig) - 1;
+            splitChar = (String) splitCharConfig;
         } catch (ClassCastException e) {
             throw new ConfigurationException("Parameters cannot be casted.");
         }

--- a/pom.xml
+++ b/pom.xml
@@ -129,6 +129,7 @@
         <natty.version>0.13</natty.version>
         <netty.version>4.1.22.Final</netty.version>
         <netty-tcnative-boringssl-static.version>2.0.7.Final</netty-tcnative-boringssl-static.version>
+        <nullaway.version>0.3.5</nullaway.version>
         <okhttp.version>3.9.1</okhttp.version>
         <opencsv.version>2.3</opencsv.version>
         <os-platform-finder.version>1.2.2</os-platform-finder.version>
@@ -324,10 +325,30 @@
                     <forceJavacCompilerUse>true</forceJavacCompilerUse>
                     <compilerArgs>
                         <arg>-XepDisableWarningsInGeneratedCode</arg>
+                        <arg>-Xep:NullAway:ERROR</arg>
+                        <arg>-XepOpt:NullAway:AnnotatedPackages=com.uber</arg>
+                        <arg>-XepOpt:NullAway:ExcludedFieldAnnotations=javax.inject.Inject,javax.ws.rs.core.Context</arg>
                     </compilerArgs>
                     <annotationProcessors>
                         <annotationProcessor>com.google.auto.value.processor.AutoValueProcessor</annotationProcessor>
                     </annotationProcessors>
+                    <annotationProcessorPaths>
+                        <path>
+                            <groupId>com.uber.nullaway</groupId>
+                            <artifactId>nullaway</artifactId>
+                            <version>${nullaway.version}</version>
+                        </path>
+                        <path>
+                            <groupId>com.google.auto.value</groupId>
+                            <artifactId>auto-value</artifactId>
+                            <version>${auto-value.version}</version>
+                        </path>
+                        <path>
+                            <groupId>org.graylog.autovalue</groupId>
+                            <artifactId>auto-value-javabean</artifactId>
+                            <version>${auto-value-javabean.version}</version>
+                        </path>
+                    </annotationProcessorPaths>
                 </configuration>
                 <dependencies>
                     <dependency>


### PR DESCRIPTION
This commit adds Uber's NullAway Error Prone plugin.

> NullAway is a tool to help eliminate NullPointerExceptions (NPEs) in your Java code.

See also:
* https://github.com/uber/NullAway
* https://eng.uber.com/nullaway/