### PR TITLE
Dependency updates

### DIFF
--- a/graylog-plugin-parent/pom.xml
+++ b/graylog-plugin-parent/pom.xml
@@ -42,7 +42,7 @@
         <auto-service.version>1.0-rc4</auto-service.version>
 
         <!-- Plugin versions -->
-        <jdeb.version>1.5</jdeb.version>
+        <jdeb.version>1.6</jdeb.version>
         <rpm-maven.version>2.1.5</rpm-maven.version>
         <license-maven.version>2.11</license-maven.version>
     </properties>

--- a/graylog-plugin-parent/pom.xml
+++ b/graylog-plugin-parent/pom.xml
@@ -39,7 +39,7 @@
         <graylog.plugin-dir>/usr/share/graylog-server/plugin</graylog.plugin-dir>
 
         <!-- Dependencies -->
-        <auto-service.version>1.0-rc2</auto-service.version>
+        <auto-service.version>1.0-rc4</auto-service.version>
 
         <!-- Plugin versions -->
         <jdeb.version>1.5</jdeb.version>

--- a/graylog-project-parent/pom.xml
+++ b/graylog-project-parent/pom.xml
@@ -512,7 +512,7 @@
             </dependency>
             <dependency>
                 <groupId>org.jooq</groupId>
-                <artifactId>jool</artifactId>
+                <artifactId>jool-java-8</artifactId>
                 <version>${jool.version}</version>
             </dependency>
             <dependency>

--- a/graylog-project-parent/pom.xml
+++ b/graylog-project-parent/pom.xml
@@ -789,7 +789,7 @@
                                 <plugin>
                                     <groupId>com.mebigfatguy.fb-contrib</groupId>
                                     <artifactId>fb-contrib</artifactId>
-                                    <version>7.0.5.sb</version>
+                                    <version>7.2.0.sb</version>
                                 </plugin>
                             </plugins>
                         </configuration>

--- a/graylog-project-parent/pom.xml
+++ b/graylog-project-parent/pom.xml
@@ -595,7 +595,7 @@
                 <scope>test</scope>
             </dependency>
             <dependency>
-                <groupId>com.jayway.awaitility</groupId>
+                <groupId>org.awaitility</groupId>
                 <artifactId>awaitility</artifactId>
                 <version>${awaitility.version}</version>
                 <scope>test</scope>

--- a/graylog2-server/pom.xml
+++ b/graylog2-server/pom.xml
@@ -103,10 +103,6 @@
             <groupId>com.google.inject.extensions</groupId>
             <artifactId>guice-assistedinject</artifactId>
         </dependency>
-        <dependency>
-            <groupId>com.google.inject.extensions</groupId>
-            <artifactId>guice-multibindings</artifactId>
-        </dependency>
         <!-- fishy -->
         <dependency>
             <groupId>org.glassfish.hk2.external</groupId>

--- a/graylog2-server/pom.xml
+++ b/graylog2-server/pom.xml
@@ -557,7 +557,7 @@
             <artifactId>assertj-core</artifactId>
         </dependency>
         <dependency>
-            <groupId>com.jayway.awaitility</groupId>
+            <groupId>org.awaitility</groupId>
             <artifactId>awaitility</artifactId>
         </dependency>
         <dependency>

--- a/graylog2-server/pom.xml
+++ b/graylog2-server/pom.xml
@@ -503,7 +503,7 @@
         </dependency>
         <dependency>
             <groupId>org.jooq</groupId>
-            <artifactId>jool</artifactId>
+            <artifactId>jool-java-8</artifactId>
         </dependency>
         <dependency>
             <groupId>com.squareup</groupId>

--- a/graylog2-server/src/test/java/org/graylog/plugins/netflow/codecs/NetflowV9CodecAggregatorTest.java
+++ b/graylog2-server/src/test/java/org/graylog/plugins/netflow/codecs/NetflowV9CodecAggregatorTest.java
@@ -485,7 +485,7 @@ public class NetflowV9CodecAggregatorTest {
             pcap.loop(packet -> {
                         if (packet.hasProtocol(Protocol.UDP)) {
                             final UDPPacket udp = (UDPPacket) packet.getPacket(Protocol.UDP);
-                            final InetSocketAddress source = new InetSocketAddress(udp.getSourceIP(), udp.getSourcePort());
+                            final InetSocketAddress source = new InetSocketAddress(udp.getParentPacket().getSourceIP(), udp.getSourcePort());
                             final CodecAggregator.Result result = codecAggregator.addChunk(Unpooled.copiedBuffer(udp.getPayload().getArray()), source);
                             if (result.isValid() && result.getMessage() != null) {
                                 final ByteBuf buffer = result.getMessage();
@@ -509,7 +509,7 @@ public class NetflowV9CodecAggregatorTest {
             pcap.loop(packet -> {
                         if (packet.hasProtocol(Protocol.UDP)) {
                             final UDPPacket udp = (UDPPacket) packet.getPacket(Protocol.UDP);
-                            final InetSocketAddress source = new InetSocketAddress(udp.getSourceIP(), udp.getSourcePort());
+                            final InetSocketAddress source = new InetSocketAddress(udp.getParentPacket().getSourceIP(), udp.getSourcePort());
                             final CodecAggregator.Result result = codecAggregator.addChunk(Unpooled.copiedBuffer(udp.getPayload().getArray()), source);
                             if (result.isValid() && result.getMessage() != null) {
                                 final Collection<Message> c = codec.decodeMessages(convertToRawMessage(result, source));

--- a/graylog2-server/src/test/java/org/graylog2/inputs/transports/UdpTransportTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/inputs/transports/UdpTransportTest.java
@@ -57,8 +57,8 @@ import java.util.concurrent.Callable;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.TimeUnit;
 
-import static com.jayway.awaitility.Awaitility.await;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
 import static org.junit.Assume.assumeTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;

--- a/graylog2-server/src/test/java/org/graylog2/plugin/inputs/transports/AbstractTcpTransportTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/plugin/inputs/transports/AbstractTcpTransportTest.java
@@ -46,8 +46,8 @@ import java.io.IOException;
 import java.net.InetSocketAddress;
 import java.util.concurrent.TimeUnit;
 
-import static com.jayway.awaitility.Awaitility.await;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
 import static org.junit.Assume.assumeFalse;
 import static org.junit.Assume.assumeTrue;
 import static org.mockito.Mockito.mock;

--- a/integration-tests/pom.xml
+++ b/integration-tests/pom.xml
@@ -146,7 +146,7 @@
             <artifactId>assertj-core</artifactId>
         </dependency>
         <dependency>
-            <groupId>com.jayway.awaitility</groupId>
+            <groupId>org.awaitility</groupId>
             <artifactId>awaitility</artifactId>
         </dependency>
     </dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -132,7 +132,7 @@
         <okhttp.version>3.9.1</okhttp.version>
         <opencsv.version>2.3</opencsv.version>
         <os-platform-finder.version>1.2.2</os-platform-finder.version>
-        <pkts.version>2.0.7</pkts.version>
+        <pkts.version>3.0.2</pkts.version>
         <protobuf.version>3.5.1</protobuf.version>
         <reflections.version>0.9.11</reflections.version>
         <retrofit.version>2.3.0</retrofit.version>

--- a/pom.xml
+++ b/pom.xml
@@ -93,7 +93,7 @@
         <commons-codec.version>1.11</commons-codec.version>
         <commons-email.version>1.5</commons-email.version>
         <commons-io.version>2.6</commons-io.version>
-        <disruptor.version>3.3.7</disruptor.version>
+        <disruptor.version>3.4.0</disruptor.version>
         <drools.version>6.5.0.Final</drools.version>
         <elasticsearch.version>5.6.8</elasticsearch.version>
         <jest.version>2.4.11+jackson</jest.version>

--- a/pom.xml
+++ b/pom.xml
@@ -150,7 +150,7 @@
 
         <!-- Test dependencies -->
         <apacheds-server.version>2.0.0-M24</apacheds-server.version>
-        <assertj-core.version>3.9.0</assertj-core.version>
+        <assertj-core.version>3.9.1</assertj-core.version>
         <assertj-joda-time.version>2.0.0</assertj-joda-time.version>
         <awaitility.version>1.7.0</awaitility.version>
         <equalsverifier.version>2.4</equalsverifier.version>

--- a/pom.xml
+++ b/pom.xml
@@ -110,7 +110,7 @@
         <jadconfig.version>0.13.0</jadconfig.version>
         <java-semver.version>0.9.0</java-semver.version>
         <javapoet.version>1.7.0</javapoet.version>
-        <javax.annotation-api.version>1.3</javax.annotation-api.version>
+        <javax.annotation-api.version>1.3.2</javax.annotation-api.version>
         <javax.el-api.version>3.0.0</javax.el-api.version>
         <javax.inject.version>1</javax.inject.version>
         <javax.ws.rs-api.version>2.0.1</javax.ws.rs-api.version>

--- a/pom.xml
+++ b/pom.xml
@@ -106,7 +106,7 @@
         <HdrHistogram.version>2.1.10</HdrHistogram.version>
         <hibernate-validator.version>6.0.7.Final</hibernate-validator.version>
         <hk2.version>2.5.0-b32</hk2.version> <!-- The HK2 version should match the version being used by Jersey -->
-        <jackson.version>2.8.9</jackson.version>
+        <jackson.version>2.8.11</jackson.version>
         <jadconfig.version>0.13.0</jadconfig.version>
         <java-semver.version>0.9.0</java-semver.version>
         <javapoet.version>1.7.0</javapoet.version>

--- a/pom.xml
+++ b/pom.xml
@@ -102,7 +102,7 @@
         <grok.version>0.1.7-graylog</grok.version>
         <guava-retrying.version>2.0.0</guava-retrying.version>
         <guava.version>23.6-jre</guava.version>
-        <guice.version>4.1.0</guice.version>
+        <guice.version>4.2.0</guice.version>
         <HdrHistogram.version>2.1.10</HdrHistogram.version>
         <hibernate-validator.version>6.0.7.Final</hibernate-validator.version>
         <hk2.version>2.5.0-b32</hk2.version> <!-- The HK2 version should match the version being used by Jersey -->

--- a/pom.xml
+++ b/pom.xml
@@ -165,7 +165,7 @@
 
         <!-- Nodejs dependencies -->
         <nodejs.version>v8.9.4</nodejs.version>
-        <yarn.version>v1.3.2</yarn.version>
+        <yarn.version>v1.5.1</yarn.version>
     </properties>
 
     <repositories>

--- a/pom.xml
+++ b/pom.xml
@@ -161,7 +161,7 @@
         <nosqlunit.version>1.0.0-rc.5</nosqlunit.version>
         <nosqlunit-elasticsearch-http.version>1.0.0-4+jackson</nosqlunit-elasticsearch-http.version>
         <restassured.version>2.9.0</restassured.version>
-        <system-rules.version>1.17.0</system-rules.version>
+        <system-rules.version>1.17.1</system-rules.version>
 
         <!-- Nodejs dependencies -->
         <nodejs.version>v8.9.1</nodejs.version>

--- a/pom.xml
+++ b/pom.xml
@@ -153,7 +153,7 @@
         <assertj-core.version>3.9.1</assertj-core.version>
         <assertj-joda-time.version>2.0.0</assertj-joda-time.version>
         <awaitility.version>1.7.0</awaitility.version>
-        <equalsverifier.version>2.4</equalsverifier.version>
+        <equalsverifier.version>2.4.3</equalsverifier.version>
         <fongo.version>2.1.0</fongo.version>
         <jukito.version>1.5</jukito.version>
         <junit.version>4.12</junit.version>

--- a/pom.xml
+++ b/pom.xml
@@ -152,7 +152,7 @@
         <apacheds-server.version>2.0.0-M24</apacheds-server.version>
         <assertj-core.version>3.9.1</assertj-core.version>
         <assertj-joda-time.version>2.0.0</assertj-joda-time.version>
-        <awaitility.version>1.7.0</awaitility.version>
+        <awaitility.version>3.0.0</awaitility.version>
         <equalsverifier.version>2.4.3</equalsverifier.version>
         <fongo.version>2.1.0</fongo.version>
         <jukito.version>1.5</jukito.version>

--- a/pom.xml
+++ b/pom.xml
@@ -101,7 +101,7 @@
         <geoip2.version>2.11.0</geoip2.version>
         <grok.version>0.1.7-graylog</grok.version>
         <guava-retrying.version>2.0.0</guava-retrying.version>
-        <guava.version>23.6-jre</guava.version>
+        <guava.version>24.0-jre</guava.version>
         <guice.version>4.2.0</guice.version>
         <HdrHistogram.version>2.1.10</HdrHistogram.version>
         <hibernate-validator.version>6.0.7.Final</hibernate-validator.version>

--- a/pom.xml
+++ b/pom.xml
@@ -255,7 +255,7 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-pmd-plugin</artifactId>
-                    <version>3.8</version>
+                    <version>3.9.0</version>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -95,7 +95,7 @@
         <commons-io.version>2.6</commons-io.version>
         <disruptor.version>3.3.7</disruptor.version>
         <drools.version>6.5.0.Final</drools.version>
-        <elasticsearch.version>5.6.5</elasticsearch.version>
+        <elasticsearch.version>5.6.8</elasticsearch.version>
         <jest.version>2.4.11+jackson</jest.version>
         <gelfclient.version>1.4.1</gelfclient.version>
         <geoip2.version>2.8.1</geoip2.version>

--- a/pom.xml
+++ b/pom.xml
@@ -140,7 +140,7 @@
         <shiro.version>1.4.0</shiro.version>
         <sigar.version>1.6.4</sigar.version>
         <slf4j.version>1.7.25</slf4j.version>
-        <spotbugs-annotations.version>3.1.1</spotbugs-annotations.version>
+        <spotbugs-annotations.version>3.1.2</spotbugs-annotations.version>
         <swagger.version>1.5.13</swagger.version>
         <syslog4j.version>0.9.60</syslog4j.version>
         <uuid.version>3.2</uuid.version>
@@ -280,7 +280,7 @@
                 <plugin>
                     <groupId>com.github.spotbugs</groupId>
                     <artifactId>spotbugs-maven-plugin</artifactId>
-                    <version>3.1.1</version>
+                    <version>3.1.2</version>
                 </plugin>
                 <plugin>
                     <groupId>org.codehaus.mojo</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -119,7 +119,7 @@
         <jersey.version>2.25.1</jersey.version>
         <jmte.version>4.0.0</jmte.version>
         <joda-time.version>2.9.9</joda-time.version>
-        <jool.version>0.9.9</jool.version>
+        <jool.version>0.9.13</jool.version>
         <json-path.version>2.4.0</json-path.version>
         <kafka.version>0.9.0.1</kafka.version>
         <log4j.version>2.10.0</log4j.version>

--- a/pom.xml
+++ b/pom.xml
@@ -84,7 +84,7 @@
 
         <!-- Dependencies -->
         <airline.version>2.3.0</airline.version>
-        <amqp-client.version>5.1.1</amqp-client.version>
+        <amqp-client.version>5.1.2</amqp-client.version>
         <antlr.version>4.7.1</antlr.version>
         <apache-directory-version>1.0.0</apache-directory-version>
         <auto-value.version>1.5.3</auto-value.version>

--- a/pom.xml
+++ b/pom.xml
@@ -98,7 +98,7 @@
         <elasticsearch.version>5.6.8</elasticsearch.version>
         <jest.version>2.4.11+jackson</jest.version>
         <gelfclient.version>1.4.1</gelfclient.version>
-        <geoip2.version>2.8.1</geoip2.version>
+        <geoip2.version>2.11.0</geoip2.version>
         <grok.version>0.1.7-graylog</grok.version>
         <guava-retrying.version>2.0.0</guava-retrying.version>
         <guava.version>23.6-jre</guava.version>

--- a/pom.xml
+++ b/pom.xml
@@ -333,7 +333,7 @@
                     <dependency>
                         <groupId>org.codehaus.plexus</groupId>
                         <artifactId>plexus-compiler-javac-errorprone</artifactId>
-                        <version>2.8.2</version>
+                        <version>2.8.3</version>
                     </dependency>
                     <dependency>
                         <groupId>com.google.errorprone</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -85,7 +85,7 @@
         <!-- Dependencies -->
         <airline.version>2.3.0</airline.version>
         <amqp-client.version>5.1.1</amqp-client.version>
-        <antlr.version>4.5.1</antlr.version>
+        <antlr.version>4.7.1</antlr.version>
         <apache-directory-version>1.0.0</apache-directory-version>
         <auto-value.version>1.5.3</auto-value.version>
         <auto-value-javabean.version>1.0.0</auto-value-javabean.version>
@@ -308,7 +308,7 @@
                 <plugin>
                     <groupId>org.antlr</groupId>
                     <artifactId>antlr4-maven-plugin</artifactId>
-                    <version>4.5</version>
+                    <version>${antlr.version}</version>
                 </plugin>
             </plugins>
         </pluginManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -129,7 +129,7 @@
         <natty.version>0.13</natty.version>
         <netty.version>4.1.22.Final</netty.version>
         <netty-tcnative-boringssl-static.version>2.0.7.Final</netty-tcnative-boringssl-static.version>
-        <okhttp.version>3.9.1</okhttp.version>
+        <okhttp.version>3.10.0</okhttp.version>
         <opencsv.version>2.3</opencsv.version>
         <os-platform-finder.version>1.2.2</os-platform-finder.version>
         <pkts.version>3.0.2</pkts.version>

--- a/pom.xml
+++ b/pom.xml
@@ -157,7 +157,7 @@
         <fongo.version>2.1.0</fongo.version>
         <jukito.version>1.5</jukito.version>
         <junit.version>4.12</junit.version>
-        <mockito.version>2.13.0</mockito.version>
+        <mockito.version>2.15.0</mockito.version>
         <nosqlunit.version>1.0.0-rc.5</nosqlunit.version>
         <nosqlunit-elasticsearch-http.version>1.0.0-4+jackson</nosqlunit-elasticsearch-http.version>
         <restassured.version>2.9.0</restassured.version>

--- a/pom.xml
+++ b/pom.xml
@@ -300,7 +300,7 @@
                 <plugin>
                     <groupId>com.github.alexcojocaru</groupId>
                     <artifactId>elasticsearch-maven-plugin</artifactId>
-                    <version>6.0</version>
+                    <version>6.4</version>
                     <configuration>
                         <skip>true</skip>
                     </configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -164,7 +164,7 @@
         <system-rules.version>1.17.1</system-rules.version>
 
         <!-- Nodejs dependencies -->
-        <nodejs.version>v8.9.1</nodejs.version>
+        <nodejs.version>v8.9.4</nodejs.version>
         <yarn.version>v1.3.2</yarn.version>
     </properties>
 


### PR DESCRIPTION
* Upgrade to plexus-compiler-javac-errorprone 2.8.3
  * https://github.com/codehaus-plexus/plexus-compiler/milestone/3?closed=1
* Upgrade to Mockito 2.15.0
  * https://github.com/mockito/mockito/blob/release/2.x/doc/release-notes/official.md#2150-2018-02-10-published-to-jcentermaven-central
* Upgrade to jOOλ 0.9.13
* Upgrade to Elasticsearch 5.6.8
  * https://www.elastic.co/guide/en/elasticsearch/reference/5.6/release-notes-5.6.6.html
  * https://www.elastic.co/guide/en/elasticsearch/reference/5.6/release-notes-5.6.7.html
  * https://www.elastic.co/guide/en/elasticsearch/reference/5.6/release-notes-5.6.7.html
* Upgrade to AssertJ Core 3.9.1
  * https://joel-costigliola.github.io/assertj/assertj-core-news.html#assertj-core-3.9.1
* Upgrade to ANTLR 4.7.1
  * https://github.com/antlr/antlr4/releases/tag/4.5.2
  * https://github.com/antlr/antlr4/releases/tag/4.5.3
  * https://github.com/antlr/antlr4/releases/tag/4.6
  * https://github.com/antlr/antlr4/releases/tag/4.7
  * https://github.com/antlr/antlr4/releases/tag/4.7.1
* Upgrade to Equals Verifier 2.4.3
  * http://jqno.nl/equalsverifier/changelog/#version-241
  * http://jqno.nl/equalsverifier/changelog/#version-242
  * http://jqno.nl/equalsverifier/changelog/#version-243
* Upgrade to javax.annotation-api 1.3.2
* Upgrade to pkts.io 3.0.2
  * https://github.com/aboutsip/pkts/blob/release-pkts-3.0.2/CHANGELOG.md
* Upgrade to OkHttp 3.10.0
  * https://github.com/square/okhttp/blob/parent-3.10.0/CHANGELOG.md
* Upgrade to RabbitMQ AMQP client 5.1.2
  * https://github.com/rabbitmq/rabbitmq-java-client/releases/tag/v5.1.2
* Upgrade to MaxMind GeoIP2 2.11.0
  * https://github.com/maxmind/GeoIP2-java/blob/v2.11.0/CHANGELOG.md
* Upgrade to Disruptor 3.4.0
  * https://github.com/LMAX-Exchange/disruptor/releases/tag/3.3.8
  * https://github.com/LMAX-Exchange/disruptor/releases/tag/3.3.9
  * https://github.com/LMAX-Exchange/disruptor/releases/tag/3.4.0
* Upgrade to Guice 4.2.0
  * https://github.com/google/guice/wiki/Guice42
* Upgrade to Guava 24.0
  * https://github.com/google/guava/releases/tag/v24.0
* Upgrade to System Rules 1.17.1
* Upgrade to SpotBugs 3.1.2
  * https://github.com/spotbugs/spotbugs/blob/3.1.2/CHANGELOG.md
* Upgrade to Jackson 2.8.11
  * https://github.com/FasterXML/jackson/wiki/Jackson-Release-2.8.10
  * https://github.com/FasterXML/jackson/wiki/Jackson-Release-2.8.11
* Upgrade to Awaitility 3.0.0
  * https://github.com/awaitility/awaitility/blob/awaitility-3.0.0/changelog.txt
* Upgrade to Maven PMD Plugin 3.9.0
* Upgrade to elasticsearch-maven-plugin 6.4
* Upgrade to Node.js 8.9.4 LTS
  * https://github.com/nodejs/node/blob/v8.9.4/doc/changelogs/CHANGELOG_V8.md#8.9.2
  * https://github.com/nodejs/node/blob/v8.9.4/doc/changelogs/CHANGELOG_V8.md#8.9.3
  * https://github.com/nodejs/node/blob/v8.9.4/doc/changelogs/CHANGELOG_V8.md#8.9.4
* Upgrade to Yarn 1.5.1
  * https://github.com/yarnpkg/yarn/releases/tag/v1.4.0
  * https://github.com/yarnpkg/yarn/releases/tag/v1.4.1
  * https://github.com/yarnpkg/yarn/releases/tag/v1.5.1
* Upgrade to Google Auto Service 1.0-rc4
  * https://github.com/google/auto/releases/tag/auto-service-1.0-rc4
* Upgrade to jdeb 1.6
  * https://github.com/tcurdt/jdeb/blob/jdeb-1.6/HISTORY.md
* Upgrade to fb-contrib 7.2.0.sb