### PR TITLE
Remove Cobertura Maven plugin

### DIFF
--- a/graylog-project-parent/pom.xml
+++ b/graylog-project-parent/pom.xml
@@ -820,10 +820,6 @@
                             </execution>
                         </executions>
                     </plugin>
-                    <plugin>
-                        <groupId>org.codehaus.mojo</groupId>
-                        <artifactId>cobertura-maven-plugin</artifactId>
-                    </plugin>
                 </plugins>
             </build>
         </profile>

--- a/pom.xml
+++ b/pom.xml
@@ -283,11 +283,6 @@
                     <version>3.1.2</version>
                 </plugin>
                 <plugin>
-                    <groupId>org.codehaus.mojo</groupId>
-                    <artifactId>cobertura-maven-plugin</artifactId>
-                    <version>2.7</version>
-                </plugin>
-                <plugin>
                     <groupId>de.thetaphi</groupId>
                     <artifactId>forbiddenapis</artifactId>
                     <version>2.4.1</version>


### PR DESCRIPTION
The Cobertura Maven plugin (and Cobertura itself) doesn't support Java 8.

Additionally, code coverage metrics are currently not used anywhere in the build, so we can as well remove it.

Refs mojohaus/cobertura-maven-plugin#21
Refs cobertura/cobertura#166