### PR TITLE
Add stream title to notification

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/streams/StreamFaultManager.java
+++ b/graylog2-server/src/main/java/org/graylog2/streams/StreamFaultManager.java
@@ -85,6 +85,7 @@ public class StreamFaultManager {
                 .addType(Notification.Type.STREAM_PROCESSING_DISABLED)
                 .addSeverity(Notification.Severity.URGENT)
                 .addDetail("stream_id", stream.getId())
+                .addDetail("stream_title", stream.getTitle())
                 .addDetail("fault_count", streamFaultCount);
 
         notificationService.publishIfFirst(notification);

--- a/graylog2-web-interface/src/logic/notifications/NotificationsFactory.js
+++ b/graylog2-web-interface/src/logic/notifications/NotificationsFactory.js
@@ -213,7 +213,7 @@ class NotificationsFactory {
           title: 'Processing of a stream has been disabled due to excessive processing time.',
           description: (
             <span>
-              The processing of stream <em>{notification.details.stream_id}</em> has taken too long for{' '}
+              The processing of stream <em>{notification.details.stream_title} ({notification.details.stream_id})</em> has taken too long for{' '}
               {notification.details.fault_count} times. To protect the stability of message processing,
               this stream has been disabled. Please correct the stream rules and reenable the stream.
               Check <DocumentationLink page={DocsHelper.PAGES.STREAM_PROCESSING_RUNTIME_LIMITS} text="the documentation" />{' '}


### PR DESCRIPTION

## Description 
I add the stream title to the message to clearify which stream
is meant.

## Motivation and Context
If a stream timesout to match a rule it will be shoutdown by
graylog leading to a notification for the user.
This notification only showed the stream id which was not
very helpful.


## How Has This Been Tested?
I let the notification be seen by hand.

## Screenshots (if appropriate):
![graylog - system overview](https://user-images.githubusercontent.com/448763/37042612-117f05dc-215f-11e8-8392-b143066f3acc.png)

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
