### PR TITLE
Fix the way TypeScript loads type definitions.

### DIFF
--- a/graylog2-web-interface/src/stores/widgets/WidgetsStore.ts
+++ b/graylog2-web-interface/src/stores/widgets/WidgetsStore.ts
@@ -1,3 +1,5 @@
+///<reference path="../../../node_modules/@types/node/index.d.ts"/>
+
 const Reflux = require('reflux');
 
 const UserNotification = require('util/UserNotification');

--- a/graylog2-web-interface/tsconfig.json
+++ b/graylog2-web-interface/tsconfig.json
@@ -2,10 +2,10 @@
   "compilerOptions" : {
     "target": "es5",
     "sourceMap" : true,
-    "lib": ["es5", "es6", "dom"]
+    "lib": ["es5", "es6", "dom"],
+    "types": ["node"]
   },
   "include": [
     "src/**/*.ts",
-    "node_modules/@types/node/index.d.ts"
   ]
 }

--- a/graylog2-web-interface/tsconfig.json
+++ b/graylog2-web-interface/tsconfig.json
@@ -2,8 +2,7 @@
   "compilerOptions" : {
     "target": "es5",
     "sourceMap" : true,
-    "lib": ["es5", "es6", "dom"],
-    "types": ["node"]
+    "lib": ["es5", "es6", "dom"]
   },
   "include": [
     "src/**/*.ts",

--- a/graylog2-web-interface/tsconfig.json
+++ b/graylog2-web-interface/tsconfig.json
@@ -2,7 +2,8 @@
   "compilerOptions" : {
     "target": "es5",
     "sourceMap" : true,
-    "lib": ["es5", "es6", "dom"]
+    "lib": ["es5", "es6", "dom"],
+    "types": []
   },
   "include": [
     "src/**/*.ts",


### PR DESCRIPTION
Before this change, ts-loader/tsc just included the node types
explicitly. This lead to problems with duplicate inclusions for plugins
which transitively depend on typings.

This PR changes this behavior to the more standard one of defining which
types to include instead of including the types file explicitly.
