### PR TITLE
Disable unreliable tests.

### DIFF
--- a/graylog2-server/src/test/java/org/graylog2/configuration/HttpConfigurationTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/configuration/HttpConfigurationTest.java
@@ -62,7 +62,7 @@ public class HttpConfigurationTest {
     }
 
     @Test
-    @Ignore
+    @Ignore // Disabled test due to being unreliable (see https://github.com/Graylog2/graylog2-server/issues/4459)
     public void testHttpBindAddressIsIPv6AddressWithoutBrackets() throws RepositoryException, ValidationException {
         expectedException.expect(ValidationException.class);
         expectedException.expectMessage("Possible bracketless IPv6 literal: 2001:db8::1");
@@ -73,7 +73,7 @@ public class HttpConfigurationTest {
     }
 
     @Test
-    @Ignore
+    @Ignore // Disabled test due to being unreliable (see https://github.com/Graylog2/graylog2-server/issues/4459)
     public void testHttpBindAddressIsInvalidIPv6Address() throws RepositoryException, ValidationException {
         expectedException.expect(ValidationException.class);
         expectedException.expectMessage("Possible bracketless IPv6 literal: ff$$::1");
@@ -93,7 +93,7 @@ public class HttpConfigurationTest {
     }
 
     @Test
-    @Ignore
+    @Ignore // Disabled test due to being unreliable (see https://github.com/Graylog2/graylog2-server/issues/4459)
     public void testHttpBindAddressIsInvalidIPv4Address() throws RepositoryException, ValidationException {
         expectedException.expect(ValidationException.class);
         expectedException.expectMessage("1234.5.6.7: ");
@@ -104,7 +104,7 @@ public class HttpConfigurationTest {
     }
 
     @Test
-    @Ignore
+    @Ignore // Disabled test due to being unreliable (see https://github.com/Graylog2/graylog2-server/issues/4459)
     public void testHttpBindAddressIsInvalidHostName() throws RepositoryException, ValidationException {
         expectedException.expect(ValidationException.class);
         expectedException.expectMessage("this-does-not-exist-42: ");

--- a/graylog2-server/src/test/java/org/graylog2/configuration/HttpConfigurationTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/configuration/HttpConfigurationTest.java
@@ -62,7 +62,7 @@ public class HttpConfigurationTest {
     }
 
     @Test
-    @Ignore // Disabled test due to being unreliable (see https://github.com/Graylog2/graylog2-server/issues/4459)
+    @Ignore("Disabled test due to being unreliable (see https://github.com/Graylog2/graylog2-server/issues/4459)")
     public void testHttpBindAddressIsIPv6AddressWithoutBrackets() throws RepositoryException, ValidationException {
         expectedException.expect(ValidationException.class);
         expectedException.expectMessage("Possible bracketless IPv6 literal: 2001:db8::1");
@@ -73,7 +73,7 @@ public class HttpConfigurationTest {
     }
 
     @Test
-    @Ignore // Disabled test due to being unreliable (see https://github.com/Graylog2/graylog2-server/issues/4459)
+    @Ignore("Disabled test due to being unreliable (see https://github.com/Graylog2/graylog2-server/issues/4459)")
     public void testHttpBindAddressIsInvalidIPv6Address() throws RepositoryException, ValidationException {
         expectedException.expect(ValidationException.class);
         expectedException.expectMessage("Possible bracketless IPv6 literal: ff$$::1");
@@ -93,7 +93,7 @@ public class HttpConfigurationTest {
     }
 
     @Test
-    @Ignore // Disabled test due to being unreliable (see https://github.com/Graylog2/graylog2-server/issues/4459)
+    @Ignore("Disabled test due to being unreliable (see https://github.com/Graylog2/graylog2-server/issues/4459)")
     public void testHttpBindAddressIsInvalidIPv4Address() throws RepositoryException, ValidationException {
         expectedException.expect(ValidationException.class);
         expectedException.expectMessage("1234.5.6.7: ");
@@ -104,7 +104,7 @@ public class HttpConfigurationTest {
     }
 
     @Test
-    @Ignore // Disabled test due to being unreliable (see https://github.com/Graylog2/graylog2-server/issues/4459)
+    @Ignore("Disabled test due to being unreliable (see https://github.com/Graylog2/graylog2-server/issues/4459)")
     public void testHttpBindAddressIsInvalidHostName() throws RepositoryException, ValidationException {
         expectedException.expect(ValidationException.class);
         expectedException.expectMessage("this-does-not-exist-42: ");

--- a/graylog2-server/src/test/java/org/graylog2/configuration/HttpConfigurationTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/configuration/HttpConfigurationTest.java
@@ -24,6 +24,7 @@ import com.github.joschi.jadconfig.repositories.InMemoryRepository;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.net.HostAndPort;
 import org.junit.Before;
+import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
@@ -61,6 +62,7 @@ public class HttpConfigurationTest {
     }
 
     @Test
+    @Ignore
     public void testHttpBindAddressIsIPv6AddressWithoutBrackets() throws RepositoryException, ValidationException {
         expectedException.expect(ValidationException.class);
         expectedException.expectMessage("Possible bracketless IPv6 literal: 2001:db8::1");
@@ -71,6 +73,7 @@ public class HttpConfigurationTest {
     }
 
     @Test
+    @Ignore
     public void testHttpBindAddressIsInvalidIPv6Address() throws RepositoryException, ValidationException {
         expectedException.expect(ValidationException.class);
         expectedException.expectMessage("Possible bracketless IPv6 literal: ff$$::1");
@@ -90,6 +93,7 @@ public class HttpConfigurationTest {
     }
 
     @Test
+    @Ignore
     public void testHttpBindAddressIsInvalidIPv4Address() throws RepositoryException, ValidationException {
         expectedException.expect(ValidationException.class);
         expectedException.expectMessage("1234.5.6.7: ");
@@ -100,6 +104,7 @@ public class HttpConfigurationTest {
     }
 
     @Test
+    @Ignore
     public void testHttpBindAddressIsInvalidHostName() throws RepositoryException, ValidationException {
         expectedException.expect(ValidationException.class);
         expectedException.expectMessage("this-does-not-exist-42: ");


### PR DESCRIPTION
Some tests of the HttpConfigurationTest suite keep on failing
unpredictably and have proven to be unreliable, causing the need to
manually restart tests on Travis or Jenkins.
(See https://travis-ci.org/Graylog2/graylog2-server/builds/352299567 as
an example)

Therefore, this PR disables these tests until they are fixed.
