### PR TITLE
Removing usages of deprecated React.createClass().

### DIFF
--- a/graylog2-web-interface/src/components/alarmcallbacks/AlarmCallbackHistory.jsx
+++ b/graylog2-web-interface/src/components/alarmcallbacks/AlarmCallbackHistory.jsx
@@ -6,11 +6,11 @@ import { EntityListItem, Timestamp } from 'components/common';
 import { ConfigurationWell } from 'components/configurationforms';
 import DateTime from 'logic/datetimes/DateTime';
 
-const AlarmCallbackHistory = React.createClass({
-  propTypes: {
+class AlarmCallbackHistory extends React.Component {
+  static propTypes = {
     types: PropTypes.object.isRequired,
     alarmCallbackHistory: PropTypes.object.isRequired,
-  },
+  };
 
   render() {
     const history = this.props.alarmCallbackHistory;
@@ -55,7 +55,7 @@ const AlarmCallbackHistory = React.createClass({
     return (
       <EntityListItem title={title} titleSuffix={result} description={description} contentRow={content} />
     );
-  },
-});
+  }
+}
 
 export default AlarmCallbackHistory;

--- a/graylog2-web-interface/src/components/alarmcallbacks/AlarmCallbackHistoryOverview.jsx
+++ b/graylog2-web-interface/src/components/alarmcallbacks/AlarmCallbackHistoryOverview.jsx
@@ -1,5 +1,6 @@
 import PropTypes from 'prop-types';
 import React from 'react';
+import createReactClass from 'create-react-class';
 import Reflux from 'reflux';
 import { Row, Col } from 'react-bootstrap';
 
@@ -12,7 +13,9 @@ import { AlarmCallbackHistory } from 'components/alarmcallbacks';
 const { AlarmCallbackHistoryStore } = CombinedProvider.get('AlarmCallbackHistory');
 const { AlertNotificationsStore } = CombinedProvider.get('AlertNotifications');
 
-const AlarmCallbackHistoryOverview = React.createClass({
+const AlarmCallbackHistoryOverview = createReactClass({
+  displayName: 'AlarmCallbackHistoryOverview',
+
   propTypes: {
     alertId: PropTypes.string.isRequired,
     streamId: PropTypes.string.isRequired,
@@ -25,9 +28,11 @@ const AlarmCallbackHistoryOverview = React.createClass({
       <AlarmCallbackHistory key={history.id} alarmCallbackHistory={history} types={this.state.availableNotifications} />
     );
   },
+
   _isLoading() {
     return !(this.state.histories && this.state.availableNotifications);
   },
+
   render() {
     if (this._isLoading()) {
       return <Spinner />;

--- a/graylog2-web-interface/src/components/alertconditions/AlertCondition.jsx
+++ b/graylog2-web-interface/src/components/alertconditions/AlertCondition.jsx
@@ -1,5 +1,6 @@
 import PropTypes from 'prop-types';
 import React from 'react';
+import createReactClass from 'create-react-class';
 import Reflux from 'reflux';
 import { DropdownButton, MenuItem } from 'react-bootstrap';
 
@@ -10,11 +11,14 @@ const { CurrentUserStore } = CombinedProvider.get('CurrentUser');
 import { AlertConditionSummary, UnknownAlertCondition } from 'components/alertconditions';
 import PermissionsMixin from 'util/PermissionsMixin';
 
-const AlertCondition = React.createClass({
+const AlertCondition = createReactClass({
+  displayName: 'AlertCondition',
+
   propTypes: {
     alertCondition: PropTypes.object.isRequired,
     stream: PropTypes.object,
   },
+
   mixins: [Reflux.connect(AlertConditionsStore), Reflux.connect(CurrentUserStore), PermissionsMixin],
 
   _onDelete() {

--- a/graylog2-web-interface/src/components/alertconditions/AlertConditionForm.jsx
+++ b/graylog2-web-interface/src/components/alertconditions/AlertConditionForm.jsx
@@ -1,5 +1,6 @@
 import PropTypes from 'prop-types';
 import React from 'react';
+import createReactClass from 'create-react-class';
 import Reflux from 'reflux';
 import { ControlLabel, FormControl, FormGroup } from 'react-bootstrap';
 
@@ -8,13 +9,16 @@ import { ConfigurationForm } from 'components/configurationforms';
 import CombinedProvider from 'injection/CombinedProvider';
 const { AlertConditionsStore } = CombinedProvider.get('AlertConditions');
 
-const AlertConditionForm = React.createClass({
+const AlertConditionForm = createReactClass({
+  displayName: 'AlertConditionForm',
+
   propTypes: {
     alertCondition: PropTypes.object,
     onCancel: PropTypes.func,
     onSubmit: PropTypes.func.isRequired,
     type: PropTypes.string.isRequired,
   },
+
   mixins: [Reflux.connect(AlertConditionsStore)],
 
   getDefaultProps() {
@@ -34,16 +38,20 @@ const AlertConditionForm = React.createClass({
       parameters: values.configuration,
     };
   },
+
   open() {
     this.refs.configurationForm.open();
   },
+
   _onCancel() {
     this.props.onCancel();
   },
+
   _onSubmit() {
     const request = this.getValue();
     this.props.onSubmit(request);
   },
+
   _formatTitle(alertCondition, name) {
     const action = alertCondition ? 'Update' : 'Create new';
     const conditionName = alertCondition ? <em>{alertCondition.title || 'Untitled'}</em> : name;

--- a/graylog2-web-interface/src/components/alertconditions/AlertConditionSummary.jsx
+++ b/graylog2-web-interface/src/components/alertconditions/AlertConditionSummary.jsx
@@ -10,14 +10,14 @@ import { EntityListItem } from 'components/common';
 import { GenericAlertConditionSummary } from 'components/alertconditions';
 import { PluginStore } from 'graylog-web-plugin/plugin';
 
-const AlertConditionSummary = React.createClass({
-  propTypes: {
+class AlertConditionSummary extends React.Component {
+  static propTypes = {
     alertCondition: PropTypes.object.isRequired,
     typeDefinition: PropTypes.object.isRequired,
     stream: PropTypes.object,
     actions: PropTypes.array.isRequired,
     linkToDetails: PropTypes.bool,
-  },
+  };
 
   render() {
     const stream = this.props.stream;
@@ -54,7 +54,7 @@ const AlertConditionSummary = React.createClass({
                       actions={this.props.actions}
                       contentRow={content} />
     );
-  },
-});
+  }
+}
 
 export default AlertConditionSummary;

--- a/graylog2-web-interface/src/components/alertconditions/AlertConditionsComponent.jsx
+++ b/graylog2-web-interface/src/components/alertconditions/AlertConditionsComponent.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import createReactClass from 'create-react-class';
 import Reflux from 'reflux';
 import { Button } from 'react-bootstrap';
 import { LinkContainer } from 'react-router-bootstrap';
@@ -13,7 +14,8 @@ import CombinedProvider from 'injection/CombinedProvider';
 const { StreamsStore } = CombinedProvider.get('Streams');
 const { AlertConditionsStore, AlertConditionsActions } = CombinedProvider.get('AlertConditions');
 
-const AlertConditionsComponent = React.createClass({
+const AlertConditionsComponent = createReactClass({
+  displayName: 'AlertConditionsComponent',
   mixins: [Reflux.connect(AlertConditionsStore)],
 
   getInitialState() {

--- a/graylog2-web-interface/src/components/alertconditions/AlertConditionsList.jsx
+++ b/graylog2-web-interface/src/components/alertconditions/AlertConditionsList.jsx
@@ -4,32 +4,30 @@ import React from 'react';
 import { AlertCondition } from 'components/alertconditions';
 import { EntityList, PaginatedList } from 'components/common';
 
-const AlertConditionsList = React.createClass({
-  propTypes: {
+class AlertConditionsList extends React.Component {
+  static propTypes = {
     alertConditions: PropTypes.array.isRequired,
     streams: PropTypes.array.isRequired,
-  },
+  };
 
-  getInitialState() {
-    return {
-      currentPage: 0,
-    };
-  },
+  state = {
+    currentPage: 0,
+  };
 
-  PAGE_SIZE: 10,
+  PAGE_SIZE = 10;
 
-  _onChangePaginatedList(currentPage) {
+  _onChangePaginatedList = (currentPage) => {
     this.setState({ currentPage: currentPage - 1 });
-  },
+  };
 
-  _paginatedConditions() {
+  _paginatedConditions = () => {
     return this.props.alertConditions.slice(this.state.currentPage * this.PAGE_SIZE, (this.state.currentPage + 1) * this.PAGE_SIZE);
-  },
+  };
 
-  _formatCondition(condition) {
+  _formatCondition = (condition) => {
     const stream = this.props.streams.find(s => s.alert_conditions.find(c => c.id === condition.id));
     return <AlertCondition key={condition.id} alertCondition={condition} stream={stream} />;
-  },
+  };
 
   render() {
     const alertConditions = this.props.alertConditions;
@@ -42,7 +40,7 @@ const AlertConditionsList = React.createClass({
                     items={this._paginatedConditions().map(condition => this._formatCondition(condition))} />
       </PaginatedList>
     );
-  },
-});
+  }
+}
 
 export default AlertConditionsList;

--- a/graylog2-web-interface/src/components/alertconditions/BacklogSummary.jsx
+++ b/graylog2-web-interface/src/components/alertconditions/BacklogSummary.jsx
@@ -1,11 +1,12 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 
-const BacklogSummary = React.createClass({
-  propTypes: {
+class BacklogSummary extends React.Component {
+  static propTypes = {
     alertCondition: PropTypes.object.isRequired,
-  },
-  _formatMessageCount(count) {
+  };
+
+  _formatMessageCount = (count) => {
     if (count === 0) {
       return 'Not including any messages';
     }
@@ -15,13 +16,14 @@ const BacklogSummary = React.createClass({
     }
 
     return `Including last ${count} messages`;
-  },
+  };
+
   render() {
     const backlog = this.props.alertCondition.parameters.backlog;
     return (
       <span>{this._formatMessageCount(backlog)} in alert notification.</span>
     );
-  },
-});
+  }
+}
 
 export default BacklogSummary;

--- a/graylog2-web-interface/src/components/alertconditions/ConditionAlertNotifications.jsx
+++ b/graylog2-web-interface/src/components/alertconditions/ConditionAlertNotifications.jsx
@@ -9,31 +9,29 @@ import CombinedProvider from 'injection/CombinedProvider';
 const { AlarmCallbacksActions } = CombinedProvider.get('AlarmCallbacks');
 const { AlertNotificationsActions } = CombinedProvider.get('AlertNotifications');
 
-const ConditionAlertNotifications = React.createClass({
-  propTypes: {
+class ConditionAlertNotifications extends React.Component {
+  static propTypes = {
     alertCondition: PropTypes.object.isRequired,
     stream: PropTypes.object.isRequired,
-  },
+  };
 
-  getInitialState() {
-    return {
-      conditionNotifications: undefined,
-    };
-  },
+  state = {
+    conditionNotifications: undefined,
+  };
 
   componentDidMount() {
     this._loadData();
-  },
+  }
 
-  _loadData() {
+  _loadData = () => {
     AlertNotificationsActions.available();
     AlarmCallbacksActions.list(this.props.stream.id)
       .then(callbacks => this.setState({ conditionNotifications: callbacks }));
-  },
+  };
 
-  _isLoading() {
+  _isLoading = () => {
     return !this.state.conditionNotifications;
-  },
+  };
 
   render() {
     if (this._isLoading()) {
@@ -60,7 +58,7 @@ const ConditionAlertNotifications = React.createClass({
                                 onNotificationUpdate={this._loadData} onNotificationDelete={this._loadData} />
       </div>
     );
-  },
-});
+  }
+}
 
 export default ConditionAlertNotifications;

--- a/graylog2-web-interface/src/components/alertconditions/CreateAlertConditionInput.jsx
+++ b/graylog2-web-interface/src/components/alertconditions/CreateAlertConditionInput.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import createReactClass from 'create-react-class';
 import Reflux from 'reflux';
 import naturalSort from 'javascript-natural-sort';
 import { Button, Col, Row } from 'react-bootstrap';
@@ -14,8 +15,10 @@ import CombinedProvider from 'injection/CombinedProvider';
 const { AlertConditionsStore, AlertConditionsActions } = CombinedProvider.get('AlertConditions');
 const { StreamsStore } = CombinedProvider.get('Streams');
 
-const CreateAlertConditionInput = React.createClass({
+const CreateAlertConditionInput = createReactClass({
+  displayName: 'CreateAlertConditionInput',
   mixins: [Reflux.connect(AlertConditionsStore)],
+
   getInitialState() {
     return {
       streams: undefined,
@@ -49,12 +52,15 @@ const CreateAlertConditionInput = React.createClass({
       history.push(Routes.show_alert_condition(this.state.selectedStream.id, conditionId));
     });
   },
+
   _openForm() {
     this.refs.configurationForm.open();
   },
+
   _resetForm() {
     this.setState({ type: this.PLACEHOLDER });
   },
+
   _formatConditionForm(type) {
     return (
       <AlertConditionForm ref="configurationForm" onCancel={this._resetForm} onSubmit={this._onSubmit} type={type} />

--- a/graylog2-web-interface/src/components/alertconditions/EditAlertConditionForm.jsx
+++ b/graylog2-web-interface/src/components/alertconditions/EditAlertConditionForm.jsx
@@ -1,5 +1,6 @@
 import PropTypes from 'prop-types';
 import React from 'react';
+import createReactClass from 'create-react-class';
 import Reflux from 'reflux';
 import { Button } from 'react-bootstrap';
 
@@ -11,7 +12,9 @@ import CombinedProvider from 'injection/CombinedProvider';
 const { AlertConditionsActions, AlertConditionsStore } = CombinedProvider.get('AlertConditions');
 const { CurrentUserStore } = CombinedProvider.get('CurrentUser');
 
-const EditAlertConditionForm = React.createClass({
+const EditAlertConditionForm = createReactClass({
+  displayName: 'EditAlertConditionForm',
+
   propTypes: {
     alertCondition: PropTypes.object.isRequired,
     stream: PropTypes.object.isRequired,

--- a/graylog2-web-interface/src/components/alertconditions/GenericAlertConditionSummary.jsx
+++ b/graylog2-web-interface/src/components/alertconditions/GenericAlertConditionSummary.jsx
@@ -5,10 +5,10 @@ import { ConfigurationWell } from 'components/configurationforms';
 import GracePeriodSummary from 'components/alertconditions/GracePeriodSummary';
 import BacklogSummary from 'components/alertconditions/BacklogSummary';
 
-const GenericAlertConditionSummary = React.createClass({
-  propTypes: {
+class GenericAlertConditionSummary extends React.Component {
+  static propTypes = {
     alertCondition: PropTypes.object.isRequired,
-  },
+  };
 
   render() {
     const alertCondition = this.props.alertCondition;
@@ -22,7 +22,7 @@ const GenericAlertConditionSummary = React.createClass({
         <ConfigurationWell configuration={alertCondition.parameters} />
       </span>
     );
-  },
-});
+  }
+}
 
 export default GenericAlertConditionSummary;

--- a/graylog2-web-interface/src/components/alertconditions/GracePeriodInput.jsx
+++ b/graylog2-web-interface/src/components/alertconditions/GracePeriodInput.jsx
@@ -3,24 +3,26 @@ import React from 'react';
 
 import { Pluralize } from 'components/common';
 
-const GracePeriodInput = React.createClass({
-  propTypes: {
+class GracePeriodInput extends React.Component {
+  static propTypes = {
     parameters: PropTypes.object.isRequired,
-  },
-  getInitialState() {
-    return {
-      grace: this.props.parameters.grace,
-      backlog: this.props.parameters.backlog,
-    };
-  },
-  getValue() {
+  };
+
+  state = {
+    grace: this.props.parameters.grace,
+    backlog: this.props.parameters.backlog,
+  };
+
+  getValue = () => {
     return this.state;
-  },
-  _onChange(event) {
+  };
+
+  _onChange = (event) => {
     const state = {};
     state[event.target.name] = event.target.value;
     this.setState(state);
-  },
+  };
+
   render() {
     return (
       <span>
@@ -38,7 +40,7 @@ const GracePeriodInput = React.createClass({
         <Pluralize singular="message" plural="messages" value={this.state.backlog} /> of the stream evaluated for this alert condition.
       </span>
     );
-  },
-});
+  }
+}
 
 export default GracePeriodInput;

--- a/graylog2-web-interface/src/components/alertconditions/GracePeriodSummary.jsx
+++ b/graylog2-web-interface/src/components/alertconditions/GracePeriodSummary.jsx
@@ -1,21 +1,23 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 
-const GracePeriodSummary = React.createClass({
-  propTypes: {
+class GracePeriodSummary extends React.Component {
+  static propTypes = {
     alertCondition: PropTypes.object.isRequired,
-  },
-  _formatTime(time) {
+  };
+
+  _formatTime = (time) => {
     if (time === 1) {
       return '1 minute';
     }
 
     return `${time} minutes`;
-  },
+  };
+
   render() {
     const time = this.props.alertCondition.parameters.grace;
     return <span>Grace period: {this._formatTime(time)}.</span>;
-  },
-});
+  }
+}
 
 export default GracePeriodSummary;

--- a/graylog2-web-interface/src/components/alertconditions/RepeatNotificationsSummary.jsx
+++ b/graylog2-web-interface/src/components/alertconditions/RepeatNotificationsSummary.jsx
@@ -1,16 +1,17 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 
-const RepeatNotificationsSummary = React.createClass({
-  propTypes: {
+class RepeatNotificationsSummary extends React.Component {
+  static propTypes = {
     alertCondition: PropTypes.object.isRequired,
-  },
+  };
+
   render() {
     const repeatNotifications = this.props.alertCondition.parameters.repeat_notifications || false;
     return (
       <span>Configured to {!repeatNotifications && <b>not</b>} repeat notifications.</span>
     );
-  },
-});
+  }
+}
 
 export default RepeatNotificationsSummary;

--- a/graylog2-web-interface/src/components/alertconditions/UnknownAlertCondition.jsx
+++ b/graylog2-web-interface/src/components/alertconditions/UnknownAlertCondition.jsx
@@ -4,12 +4,12 @@ import { Alert, Col, DropdownButton, MenuItem } from 'react-bootstrap';
 
 import { EntityListItem } from 'components/common';
 
-const UnknownAlertCondition = React.createClass({
-  propTypes: {
+class UnknownAlertCondition extends React.Component {
+  static propTypes = {
     alertCondition: PropTypes.object.isRequired,
     stream: PropTypes.object,
     onDelete: PropTypes.func.isRequired,
-  },
+  };
 
   render() {
     const condition = this.props.alertCondition;
@@ -36,7 +36,7 @@ const UnknownAlertCondition = React.createClass({
                       actions={actions}
                       contentRow={content} />
     );
-  },
-});
+  }
+}
 
 export default UnknownAlertCondition;

--- a/graylog2-web-interface/src/components/alertconditions/fieldcontentcondition/FieldContentConditionSummary.jsx
+++ b/graylog2-web-interface/src/components/alertconditions/fieldcontentcondition/FieldContentConditionSummary.jsx
@@ -5,13 +5,15 @@ import GracePeriodSummary from 'components/alertconditions/GracePeriodSummary';
 import BacklogSummary from 'components/alertconditions/BacklogSummary';
 import RepeatNotificationsSummary from 'components/alertconditions/RepeatNotificationsSummary';
 
-const FieldContentConditionSummary = React.createClass({
-  propTypes: {
+class FieldContentConditionSummary extends React.Component {
+  static propTypes = {
     alertCondition: PropTypes.object.isRequired,
-  },
-  _formatMatcher(field, value) {
+  };
+
+  _formatMatcher = (field, value) => {
     return <span>{`\<${field}: "${value}"\>`}</span>;
-  },
+  };
+
   render() {
     const alertCondition = this.props.alertCondition;
     const field = alertCondition.parameters.field;
@@ -28,7 +30,7 @@ const FieldContentConditionSummary = React.createClass({
         <RepeatNotificationsSummary alertCondition={alertCondition} />
       </span>
     );
-  },
-});
+  }
+}
 
 export default FieldContentConditionSummary;

--- a/graylog2-web-interface/src/components/alertconditions/fieldvaluecondition/FieldValueConditionSummary.jsx
+++ b/graylog2-web-interface/src/components/alertconditions/fieldvaluecondition/FieldValueConditionSummary.jsx
@@ -6,10 +6,11 @@ import BacklogSummary from 'components/alertconditions/BacklogSummary';
 import RepeatNotificationsSummary from 'components/alertconditions/RepeatNotificationsSummary';
 import { Pluralize } from 'components/common';
 
-const FieldValueConditionSummary = React.createClass({
-  propTypes: {
+class FieldValueConditionSummary extends React.Component {
+  static propTypes = {
     alertCondition: PropTypes.object.isRequired,
-  },
+  };
+
   render() {
     const alertCondition = this.props.alertCondition;
     const field = alertCondition.parameters.field;
@@ -32,7 +33,7 @@ const FieldValueConditionSummary = React.createClass({
         <RepeatNotificationsSummary alertCondition={alertCondition} />
       </span>
     );
-  },
-});
+  }
+}
 
 export default FieldValueConditionSummary;

--- a/graylog2-web-interface/src/components/alertconditions/messagecountcondition/MessageCountConditionSummary.jsx
+++ b/graylog2-web-interface/src/components/alertconditions/messagecountcondition/MessageCountConditionSummary.jsx
@@ -6,10 +6,11 @@ import BacklogSummary from 'components/alertconditions/BacklogSummary';
 import RepeatNotificationsSummary from 'components/alertconditions/RepeatNotificationsSummary';
 import { Pluralize } from 'components/common';
 
-const MessageCountConditionSummary = React.createClass({
-  propTypes: {
+class MessageCountConditionSummary extends React.Component {
+  static propTypes = {
     alertCondition: PropTypes.object.isRequired,
-  },
+  };
+
   render() {
     const alertCondition = this.props.alertCondition;
     const threshold = alertCondition.parameters.threshold;
@@ -32,7 +33,7 @@ const MessageCountConditionSummary = React.createClass({
         <RepeatNotificationsSummary alertCondition={alertCondition} />
       </span>
     );
-  },
-});
+  }
+}
 
 export default MessageCountConditionSummary;

--- a/graylog2-web-interface/src/components/alertnotifications/AlertNotification.jsx
+++ b/graylog2-web-interface/src/components/alertnotifications/AlertNotification.jsx
@@ -1,5 +1,6 @@
 import PropTypes from 'prop-types';
 import React from 'react';
+import createReactClass from 'create-react-class';
 import Reflux from 'reflux';
 import { Button, Col, DropdownButton, MenuItem } from 'react-bootstrap';
 
@@ -14,13 +15,16 @@ import { EntityListItem, Spinner } from 'components/common';
 import { UnknownAlertNotification } from 'components/alertnotifications';
 import { ConfigurationForm, ConfigurationWell } from 'components/configurationforms';
 
-const AlertNotification = React.createClass({
+const AlertNotification = createReactClass({
+  displayName: 'AlertNotification',
+
   propTypes: {
     alertNotification: PropTypes.object.isRequired,
     stream: PropTypes.object,
     onNotificationUpdate: PropTypes.func,
     onNotificationDelete: PropTypes.func,
   },
+
   mixins: [Reflux.connect(AlertNotificationsStore), Reflux.connect(CurrentUserStore), PermissionsMixin],
 
   getInitialState() {

--- a/graylog2-web-interface/src/components/alertnotifications/AlertNotificationsComponent.jsx
+++ b/graylog2-web-interface/src/components/alertnotifications/AlertNotificationsComponent.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import createReactClass from 'create-react-class';
 import Reflux from 'reflux';
 import { Button } from 'react-bootstrap';
 import { LinkContainer } from 'react-router-bootstrap';
@@ -13,7 +14,8 @@ import CombinedProvider from 'injection/CombinedProvider';
 const { AlertNotificationsStore, AlertNotificationsActions } = CombinedProvider.get('AlertNotifications');
 const { StreamsStore } = CombinedProvider.get('Streams');
 
-const AlertNotificationsComponent = React.createClass({
+const AlertNotificationsComponent = createReactClass({
+  displayName: 'AlertNotificationsComponent',
   mixins: [Reflux.connect(AlertNotificationsStore)],
 
   getInitialState() {

--- a/graylog2-web-interface/src/components/alertnotifications/AlertNotificationsList.jsx
+++ b/graylog2-web-interface/src/components/alertnotifications/AlertNotificationsList.jsx
@@ -4,38 +4,36 @@ import React from 'react';
 import { AlertNotification } from 'components/alertnotifications';
 import { EntityList, PaginatedList } from 'components/common';
 
-const AlertNotificationsList = React.createClass({
-  propTypes: {
+class AlertNotificationsList extends React.Component {
+  static propTypes = {
     alertNotifications: PropTypes.array.isRequired,
     streams: PropTypes.array.isRequired,
     onNotificationUpdate: PropTypes.func,
     onNotificationDelete: PropTypes.func,
-  },
+  };
 
-  getInitialState() {
-    return {
-      currentPage: 0,
-    };
-  },
+  state = {
+    currentPage: 0,
+  };
 
-  PAGE_SIZE: 10,
+  PAGE_SIZE = 10;
 
-  _onChangePaginatedList(currentPage) {
+  _onChangePaginatedList = (currentPage) => {
     this.setState({ currentPage: currentPage - 1 });
-  },
+  };
 
-  _paginatedNotifications() {
+  _paginatedNotifications = () => {
     return this.props.alertNotifications.slice(this.state.currentPage * this.PAGE_SIZE, (this.state.currentPage + 1) * this.PAGE_SIZE);
-  },
+  };
 
-  _formatNotification(notification) {
+  _formatNotification = (notification) => {
     const stream = this.props.streams.find(s => s.id === notification.stream_id);
     return (
       <AlertNotification key={notification.id} alertNotification={notification} stream={stream}
                          onNotificationUpdate={this.props.onNotificationUpdate}
                          onNotificationDelete={this.props.onNotificationDelete} />
     );
-  },
+  };
 
   render() {
     const notifications = this.props.alertNotifications;
@@ -48,7 +46,7 @@ const AlertNotificationsList = React.createClass({
                     items={this._paginatedNotifications().map(notification => this._formatNotification(notification))} />
       </PaginatedList>
     );
-  },
-});
+  }
+}
 
 export default AlertNotificationsList;

--- a/graylog2-web-interface/src/components/alertnotifications/CreateAlertNotificationInput.jsx
+++ b/graylog2-web-interface/src/components/alertnotifications/CreateAlertNotificationInput.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import createReactClass from 'create-react-class';
 import Reflux from 'reflux';
 import naturalSort from 'javascript-natural-sort';
 import { Button, Col, Row } from 'react-bootstrap';
@@ -15,8 +16,10 @@ const { AlertNotificationsStore, AlertNotificationsActions } = CombinedProvider.
 const { AlarmCallbacksActions } = CombinedProvider.get('AlarmCallbacks');
 const { StreamsStore } = CombinedProvider.get('Streams');
 
-const CreateAlertNotificationInput = React.createClass({
+const CreateAlertNotificationInput = createReactClass({
+  displayName: 'CreateAlertNotificationInput',
   mixins: [Reflux.connect(AlertNotificationsStore)],
+
   getInitialState() {
     return {
       streams: undefined,
@@ -54,12 +57,15 @@ const CreateAlertNotificationInput = React.createClass({
       () => this.refs.configurationForm.open(),
     );
   },
+
   _openForm() {
     this.refs.configurationForm.open();
   },
+
   _resetForm() {
     this.setState({ type: this.PLACEHOLDER });
   },
+
   _formatNotificationForm(type) {
     const typeDefinition = this.state.availableNotifications[type];
     return (

--- a/graylog2-web-interface/src/components/alertnotifications/UnknownAlertNotification.jsx
+++ b/graylog2-web-interface/src/components/alertnotifications/UnknownAlertNotification.jsx
@@ -4,11 +4,11 @@ import { Alert, Col, DropdownButton, MenuItem } from 'react-bootstrap';
 
 import { EntityListItem } from 'components/common';
 
-const UnknownAlertNotification = React.createClass({
-  propTypes: {
+class UnknownAlertNotification extends React.Component {
+  static propTypes = {
     alertNotification: PropTypes.object.isRequired,
     onDelete: PropTypes.func.isRequired,
-  },
+  };
 
   render() {
     const notification = this.props.alertNotification;
@@ -34,7 +34,7 @@ const UnknownAlertNotification = React.createClass({
                       actions={actions}
                       contentRow={content} />
     );
-  },
-});
+  }
+}
 
 export default UnknownAlertNotification;

--- a/graylog2-web-interface/src/components/alerts/Alert.jsx
+++ b/graylog2-web-interface/src/components/alerts/Alert.jsx
@@ -10,19 +10,17 @@ import DateTime from 'logic/datetimes/DateTime';
 
 import styles from './Alert.css';
 
-const Alert = React.createClass({
-  propTypes: {
+class Alert extends React.Component {
+  static propTypes = {
     alert: PropTypes.object.isRequired,
     alertConditions: PropTypes.array.isRequired,
     streams: PropTypes.array.isRequired,
     conditionTypes: PropTypes.object.isRequired,
-  },
+  };
 
-  getInitialState() {
-    return {
-      showAlarmCallbackHistory: false,
-    };
-  },
+  state = {
+    showAlarmCallbackHistory: false,
+  };
 
   render() {
     const alert = this.props.alert;
@@ -92,7 +90,7 @@ const Alert = React.createClass({
                       description={alertTime}
                       contentRow={content} />
     );
-  },
-});
+  }
+}
 
 export default Alert;

--- a/graylog2-web-interface/src/components/alerts/AlertDetails.jsx
+++ b/graylog2-web-interface/src/components/alerts/AlertDetails.jsx
@@ -9,22 +9,22 @@ import CombinedProvider from 'injection/CombinedProvider';
 const { AlarmCallbackHistoryActions } = CombinedProvider.get('AlarmCallbackHistory');
 const { AlertNotificationsActions } = CombinedProvider.get('AlertNotifications');
 
-const AlertDetails = React.createClass({
-  propTypes: {
+class AlertDetails extends React.Component {
+  static propTypes = {
     alert: PropTypes.object.isRequired,
     condition: PropTypes.object,
     conditionType: PropTypes.object,
     stream: PropTypes.object.isRequired,
-  },
+  };
 
   componentDidMount() {
     this._loadData();
-  },
+  }
 
-  _loadData() {
+  _loadData = () => {
     AlertNotificationsActions.available();
     AlarmCallbackHistoryActions.list(this.props.alert.stream_id, this.props.alert.id);
-  },
+  };
 
   render() {
     const alert = this.props.alert;
@@ -61,7 +61,7 @@ const AlertDetails = React.createClass({
         </Row>
       </div>
     );
-  },
-});
+  }
+}
 
 export default AlertDetails;

--- a/graylog2-web-interface/src/components/alerts/AlertMessages.jsx
+++ b/graylog2-web-interface/src/components/alerts/AlertMessages.jsx
@@ -12,31 +12,29 @@ import Routes from 'routing/Routes';
 import DateTime from 'logic/datetimes/DateTime';
 import UserNotification from 'util/UserNotification';
 
-const AlertMessages = React.createClass({
-  propTypes: {
+class AlertMessages extends React.Component {
+  static propTypes = {
     alert: PropTypes.object.isRequired,
     stream: PropTypes.object.isRequired,
-  },
+  };
 
-  getInitialState() {
-    return {
-      messages: undefined,
-      totalMessages: 0,
-    };
-  },
+  state = {
+    messages: undefined,
+    totalMessages: 0,
+  };
 
   componentDidMount() {
     this._loadData();
-  },
+  }
 
-  PAGE_SIZE: 20,
+  PAGE_SIZE = 20;
 
-  _getFrom() {
+  _getFrom = () => {
     const momentFrom = DateTime.parseFromString(this.props.alert.triggered_at).toMoment();
     return momentFrom.subtract(1, 'minute').toISOString();
-  },
+  };
 
-  _getTo() {
+  _getTo = () => {
     const alert = this.props.alert;
     let momentTo;
     if (alert.is_interval) {
@@ -45,9 +43,9 @@ const AlertMessages = React.createClass({
       momentTo = DateTime.parseFromString(alert.triggered_at).toMoment().add(1, 'minute');
     }
     return momentTo.toISOString();
-  },
+  };
 
-  _loadData(page) {
+  _loadData = (page) => {
     const searchParams = {
       from: this._getFrom(),
       to: this._getTo(),
@@ -67,17 +65,17 @@ const AlertMessages = React.createClass({
           'Could not get messages during alert');
       },
     );
-  },
+  };
 
-  _isLoading() {
+  _isLoading = () => {
     return !this.state.messages;
-  },
+  };
 
-  _onPageChange(page) {
+  _onPageChange = (page) => {
     this._loadData(page);
-  },
+  };
 
-  _formatMessages(messages) {
+  _formatMessages = (messages) => {
     return messages
       .map((message) => {
         return (
@@ -87,9 +85,9 @@ const AlertMessages = React.createClass({
           </tr>
         );
       });
-  },
+  };
 
-  _formatAlertTimeRange() {
+  _formatAlertTimeRange = () => {
     return (
       <span>
         (
@@ -98,7 +96,7 @@ const AlertMessages = React.createClass({
         )
       </span>
     );
-  },
+  };
 
   render() {
     const timeRange = {
@@ -163,7 +161,7 @@ const AlertMessages = React.createClass({
         </PaginatedList>
       </div>
     );
-  },
-});
+  }
+}
 
 export default AlertMessages;

--- a/graylog2-web-interface/src/components/alerts/AlertTimeline.jsx
+++ b/graylog2-web-interface/src/components/alerts/AlertTimeline.jsx
@@ -1,5 +1,6 @@
 import PropTypes from 'prop-types';
 import React from 'react';
+import createReactClass from 'create-react-class';
 import Reflux from 'reflux';
 
 import { Spinner, Timestamp } from 'components/common';
@@ -11,7 +12,9 @@ import style from './AlertTimeline.css';
 const { AlarmCallbackHistoryStore } = CombinedProvider.get('AlarmCallbackHistory');
 const { AlertNotificationsStore } = CombinedProvider.get('AlertNotifications');
 
-const AlertTimeline = React.createClass({
+const AlertTimeline = createReactClass({
+  displayName: 'AlertTimeline',
+
   propTypes: {
     alert: PropTypes.object.isRequired,
     stream: PropTypes.object.isRequired,

--- a/graylog2-web-interface/src/components/alerts/AlertsComponent.jsx
+++ b/graylog2-web-interface/src/components/alerts/AlertsComponent.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import createReactClass from 'create-react-class';
 import Reflux from 'reflux';
 import { Button } from 'react-bootstrap';
 import Promise from 'bluebird';
@@ -11,7 +12,8 @@ const { StreamsStore } = CombinedProvider.get('Streams');
 import { Alert } from 'components/alerts';
 import { EntityList, PaginatedList, Spinner } from 'components/common';
 
-const AlertsComponent = React.createClass({
+const AlertsComponent = createReactClass({
+  displayName: 'AlertsComponent',
   mixins: [Reflux.connect(AlertsStore), Reflux.connect(AlertConditionsStore)],
 
   getInitialState() {

--- a/graylog2-web-interface/src/components/alerts/AlertsHeaderToolbar.jsx
+++ b/graylog2-web-interface/src/components/alerts/AlertsHeaderToolbar.jsx
@@ -5,14 +5,14 @@ import { LinkContainer } from 'react-router-bootstrap';
 
 import Routes from 'routing/Routes';
 
-const AlertsHeaderToolbar = React.createClass({
-  propTypes: {
+class AlertsHeaderToolbar extends React.Component {
+  static propTypes = {
     active: PropTypes.string.isRequired,
-  },
+  };
 
-  _isActive(active, route) {
+  _isActive = (active, route) => {
     return active === route ? 'active' : '';
-  },
+  };
 
   render() {
     const { active } = this.props;
@@ -30,7 +30,7 @@ const AlertsHeaderToolbar = React.createClass({
         </LinkContainer>
       </ButtonToolbar>
     );
-  },
-});
+  }
+}
 
 export default AlertsHeaderToolbar;

--- a/graylog2-web-interface/src/components/authentication/AuthProvidersConfig.jsx
+++ b/graylog2-web-interface/src/components/authentication/AuthProvidersConfig.jsx
@@ -1,5 +1,6 @@
 import PropTypes from 'prop-types';
 import React from 'react';
+import createReactClass from 'create-react-class';
 import { Alert, Button, Col, Row, Table } from 'react-bootstrap';
 import BootstrapModalForm from 'components/bootstrap/BootstrapModalForm';
 import { DocumentTitle, IfPermitted, PageHeader, SortableList } from 'components/common';
@@ -8,7 +9,9 @@ import ObjectUtils from 'util/ObjectUtils';
 import history from 'util/History';
 import naturalSort from 'javascript-natural-sort';
 
-const AuthProvidersConfig = React.createClass({
+const AuthProvidersConfig = createReactClass({
+  displayName: 'AuthProvidersConfig',
+
   propTypes: {
     config: PropTypes.object.isRequired,
     descriptors: PropTypes.object.isRequired,

--- a/graylog2-web-interface/src/components/authentication/AuthenticationComponent.jsx
+++ b/graylog2-web-interface/src/components/authentication/AuthenticationComponent.jsx
@@ -1,5 +1,6 @@
 import PropTypes from 'prop-types';
 import React from 'react';
+import createReactClass from 'create-react-class';
 import Reflux from 'reflux';
 import { Alert, Nav, NavItem, Row, Col } from 'react-bootstrap';
 import { LinkContainer } from 'react-router-bootstrap';
@@ -19,7 +20,8 @@ const CurrentUserStore = StoreProvider.getStore('CurrentUser');
 
 import AuthenticationComponentStyle from '!style!css!./AuthenticationComponent.css';
 
-const AuthenticationComponent = React.createClass({
+const AuthenticationComponent = createReactClass({
+  displayName: 'AuthenticationComponent',
 
   propTypes: {
     location: PropTypes.object.isRequired,

--- a/graylog2-web-interface/src/components/authentication/LegacyLdapConfig.jsx
+++ b/graylog2-web-interface/src/components/authentication/LegacyLdapConfig.jsx
@@ -11,28 +11,26 @@ const { LdapActions } = CombinedProvider.get('Ldap');
 
 import Routes from 'routing/Routes';
 
-const LegacyLdapConfig = React.createClass({
-  getInitialState() {
-    return {
-      showSettings: true,
-    };
-  },
+class LegacyLdapConfig extends React.Component {
+  state = {
+    showSettings: true,
+  };
 
   componentDidMount() {
     LdapActions.loadSettings();
-  },
+  }
 
-  _toggleButton() {
+  _toggleButton = () => {
     this.setState({ showSettings: !this.state.showSettings });
-  },
+  };
 
-  _onSettingsCancel() {
+  _onSettingsCancel = () => {
     this._toggleButton();
-  },
+  };
 
-  _onCancel() {
+  _onCancel = () => {
     history.push(Routes.SYSTEM.AUTHENTICATION.OVERVIEW);
-  },
+  };
 
   render() {
     const toggleButtonText = this.state.showSettings ? 'LDAP Group Mapping' : 'LDAP Settings';
@@ -57,7 +55,7 @@ const LegacyLdapConfig = React.createClass({
         </span>
       </DocumentTitle>
     );
-  },
-});
+  }
+}
 
 export default LegacyLdapConfig;

--- a/graylog2-web-interface/src/components/authentication/MongoDbPasswordConfig.jsx
+++ b/graylog2-web-interface/src/components/authentication/MongoDbPasswordConfig.jsx
@@ -2,10 +2,11 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import { DocumentTitle, PageHeader } from 'components/common';
 
-const MongoDbPasswordConfig = React.createClass({
-  propTypes: {
+class MongoDbPasswordConfig extends React.Component {
+  static propTypes = {
     config: PropTypes.object,
-  },
+  };
+
   render() {
     return (
       <DocumentTitle title="Password Authenticator">
@@ -17,7 +18,7 @@ const MongoDbPasswordConfig = React.createClass({
         </span>
       </DocumentTitle>
     );
-  },
-});
+  }
+}
 
 export default MongoDbPasswordConfig;

--- a/graylog2-web-interface/src/components/bootstrap/BootstrapAccordion.jsx
+++ b/graylog2-web-interface/src/components/bootstrap/BootstrapAccordion.jsx
@@ -1,20 +1,21 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 
-const BootstrapAccordion = React.createClass({
-  propTypes: {
+class BootstrapAccordion extends React.Component {
+  static propTypes = {
     children: PropTypes.oneOfType([
       PropTypes.arrayOf(PropTypes.element),
       PropTypes.element,
     ]).isRequired,
-  },
+  };
+
   render() {
     return (
       <div id="bundles" className="panel-group">
         {this.props.children}
       </div>
     );
-  },
-});
+  }
+}
 
 export default BootstrapAccordion;

--- a/graylog2-web-interface/src/components/bootstrap/BootstrapAccordionGroup.jsx
+++ b/graylog2-web-interface/src/components/bootstrap/BootstrapAccordionGroup.jsx
@@ -1,14 +1,15 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 
-const BootstrapAccordionGroup = React.createClass({
-  propTypes: {
+class BootstrapAccordionGroup extends React.Component {
+  static propTypes = {
     name: PropTypes.string,
     children: PropTypes.oneOfType([
       PropTypes.arrayOf(PropTypes.element),
       PropTypes.element,
     ]).isRequired,
-  },
+  };
+
   render() {
     let name;
     let id;
@@ -32,7 +33,7 @@ const BootstrapAccordionGroup = React.createClass({
         </div>
       </div>
     );
-  },
-});
+  }
+}
 
 export default BootstrapAccordionGroup;

--- a/graylog2-web-interface/src/components/bootstrap/Input.jsx
+++ b/graylog2-web-interface/src/components/bootstrap/Input.jsx
@@ -11,8 +11,8 @@ import InputWrapper from './InputWrapper';
  * code is adapted to the new API.
  *
  */
-const Input = React.createClass({
-  propTypes: {
+class Input extends React.Component {
+  static propTypes = {
     id: PropTypes.string.isRequired,
     type: PropTypes.string,
     label: PropTypes.oneOfType([
@@ -39,28 +39,26 @@ const Input = React.createClass({
       PropTypes.array,
       PropTypes.element,
     ]),
-  },
+  };
 
-  getDefaultProps() {
-    return {
-      type: undefined,
-      label: '',
-      labelClassName: undefined,
-      bsStyle: null,
-      value: undefined,
-      placeholder: '',
-      help: '',
-      wrapperClassName: undefined,
-      addonAfter: null,
-      children: null,
-    };
-  },
+  static defaultProps = {
+    type: undefined,
+    label: '',
+    labelClassName: undefined,
+    bsStyle: null,
+    value: undefined,
+    placeholder: '',
+    help: '',
+    wrapperClassName: undefined,
+    addonAfter: null,
+    children: null,
+  };
 
-  getInputDOMNode() {
+  getInputDOMNode = () => {
     return this.input;
-  },
+  };
 
-  getValue() {
+  getValue = () => {
     if (!this.props.type) {
       throw new Error('Cannot use getValue without specifying input type.');
     }
@@ -72,21 +70,30 @@ const Input = React.createClass({
       default:
         return this.getInputDOMNode().value;
     }
-  },
+  };
 
-  getChecked() {
+  getChecked = () => {
     return this.getInputDOMNode().checked;
-  },
+  };
 
-  _renderFormControl(componentClass, props, children) {
+  _renderFormControl = (componentClass, props, children) => {
     return (
       <FormControl inputRef={(ref) => { this.input = ref; }} componentClass={componentClass} {...props}>
         {children}
       </FormControl>
     );
-  },
+  };
 
-  _renderFormGroup(id, validationState, wrapperClassName, label, labelClassName, help, children, addon) {
+  _renderFormGroup = (
+    id,
+    validationState,
+    wrapperClassName,
+    label,
+    labelClassName,
+    help,
+    children,
+    addon,
+  ) => {
     let input;
     if (addon) {
       input = (
@@ -108,9 +115,9 @@ const Input = React.createClass({
         </InputWrapper>
       </FormGroup>
     );
-  },
+  };
 
-  _renderCheckboxGroup(id, validationState, wrapperClassName, label, help, props) {
+  _renderCheckboxGroup = (id, validationState, wrapperClassName, label, help, props) => {
     return (
       <FormGroup controlId={id} validationState={validationState}>
         <InputWrapper className={wrapperClassName}>
@@ -119,9 +126,9 @@ const Input = React.createClass({
         </InputWrapper>
       </FormGroup>
     );
-  },
+  };
 
-  _renderRadioGroup(id, validationState, wrapperClassName, label, help, props) {
+  _renderRadioGroup = (id, validationState, wrapperClassName, label, help, props) => {
     return (
       <FormGroup controlId={id} validationState={validationState}>
         <InputWrapper className={wrapperClassName}>
@@ -130,7 +137,7 @@ const Input = React.createClass({
         </InputWrapper>
       </FormGroup>
     );
-  },
+  };
 
   render() {
     const { id, type, bsStyle, wrapperClassName, label, labelClassName, help, children, addonAfter, ...controlProps } = this.props;
@@ -161,7 +168,7 @@ const Input = React.createClass({
     }
 
     return null;
-  },
-});
+  }
+}
 
 export default Input;

--- a/graylog2-web-interface/src/components/bootstrap/InputWrapper.jsx
+++ b/graylog2-web-interface/src/components/bootstrap/InputWrapper.jsx
@@ -1,28 +1,26 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 
-const InputWrapper = React.createClass({
-  propTypes: {
+class InputWrapper extends React.Component {
+  static propTypes = {
     className: PropTypes.string,
     children: PropTypes.oneOfType([
       PropTypes.arrayOf(PropTypes.oneOfType([PropTypes.element, PropTypes.string])),
       PropTypes.element,
       PropTypes.string,
     ]).isRequired,
-  },
+  };
 
-  getDefaultProps() {
-    return {
-      className: undefined,
-    };
-  },
+  static defaultProps = {
+    className: undefined,
+  };
 
   render() {
     if (this.props.className) {
       return <div className={this.props.className}>{this.props.children}</div>;
     }
     return <span>{this.props.children}</span>;
-  },
-});
+  }
+}
 
 export default InputWrapper;

--- a/graylog2-web-interface/src/components/cluster/GraylogClusterOverview.jsx
+++ b/graylog2-web-interface/src/components/cluster/GraylogClusterOverview.jsx
@@ -1,6 +1,7 @@
 /* eslint-disable react/no-find-dom-node */
 /* global window */
 import React from 'react';
+import createReactClass from 'create-react-class';
 import ReactDOM from 'react-dom';
 import Reflux from 'reflux';
 import { Col, Row } from 'react-bootstrap';
@@ -18,7 +19,8 @@ const ClusterTrafficStore = StoreProvider.getStore('ClusterTraffic');
 const ClusterTrafficActions = ActionsProvider.getActions('ClusterTraffic');
 const NodesStore = StoreProvider.getStore('Nodes');
 
-const GraylogClusterOverview = React.createClass({
+const GraylogClusterOverview = createReactClass({
+  displayName: 'GraylogClusterOverview',
   mixins: [Reflux.connect(NodesStore, 'nodes'), Reflux.connect(ClusterTrafficStore, 'traffic')],
 
   getInitialState() {

--- a/graylog2-web-interface/src/components/cluster/TrafficGraph.jsx
+++ b/graylog2-web-interface/src/components/cluster/TrafficGraph.jsx
@@ -8,14 +8,13 @@ import crossfilter from 'crossfilter';
 import numeral from 'numeral';
 import DateTime from 'logic/datetimes/DateTime';
 
-const TrafficGraph = React.createClass({
-
-  propTypes: {
+class TrafficGraph extends React.Component {
+  static propTypes = {
     from: PropTypes.string.isRequired,
     to: PropTypes.string.isRequired,
     traffic: PropTypes.object.isRequired, // traffic is: {"2017-11-15T15:00:00.000Z": 68287229, ...}
     width: PropTypes.number.isRequired,
-  },
+  };
 
   render() {
     if (!this.props.traffic) {
@@ -52,7 +51,7 @@ const TrafficGraph = React.createClass({
                               valueTitleRenderer={d => `${numeral(d.y).format('0.00b')}`}
                               computationTimeRange={{ from: this.props.from, to: this.props.to }} />
     );
-  },
-});
+  }
+}
 
 export default TrafficGraph;

--- a/graylog2-web-interface/src/components/common/ClipboardButton.jsx
+++ b/graylog2-web-interface/src/components/common/ClipboardButton.jsx
@@ -7,8 +7,8 @@ import Clipboard from 'clipboard';
  * Component that renders a button to copy some text in the clipboard when pressed.
  * The text to be copied can be given in the `text` prop, or in an external element through a CSS selector in the `target` prop.
  */
-const ClipboardButton = React.createClass({
-  propTypes: {
+class ClipboardButton extends React.Component {
+  static propTypes = {
     /** Text or element used in the button. */
     title: PropTypes.oneOfType([PropTypes.node, PropTypes.string]).isRequired,
     /** Action to perform. */
@@ -31,30 +31,31 @@ const ClipboardButton = React.createClass({
     disabled: PropTypes.bool,
     /** Text to display when hovering over the button. */
     buttonTitle: PropTypes.string,
-  },
-  getDefaultProps() {
-    return {
-      action: 'copy',
-      disabled: false,
-      buttonTitle: undefined,
-    };
-  },
-  getInitialState() {
-    return {
-      tooltipMessage: '',
-    };
-  },
+  };
+
+  static defaultProps = {
+    action: 'copy',
+    disabled: false,
+    buttonTitle: undefined,
+  };
+
+  state = {
+    tooltipMessage: '',
+  };
+
   componentDidMount() {
     this.clipboard = new Clipboard('[data-clipboard-button]');
     this.clipboard.on('success', this._onSuccess);
     this.clipboard.on('error', this._onError);
-  },
+  }
+
   componentWillUnmount() {
     if (this.clipboard) {
       this.clipboard.destroy();
     }
-  },
-  _onSuccess(event) {
+  }
+
+  _onSuccess = (event) => {
     this.setState({ tooltipMessage: 'Copied!' });
 
     if (this.props.onSuccess) {
@@ -62,12 +63,14 @@ const ClipboardButton = React.createClass({
     }
 
     event.clearSelection();
-  },
-  _onError(event) {
+  };
+
+  _onError = (event) => {
     const key = event.action === 'cut' ? 'K' : 'C';
     this.setState({ tooltipMessage: <span>Press Ctrl+{key}&thinsp;/&thinsp;&#8984;{key} to {event.action}</span> });
-  },
-  _getFilteredProps() {
+  };
+
+  _getFilteredProps = () => {
     const { className, style, bsStyle, bsSize, disabled, buttonTitle } = this.props;
     return {
       className: className,
@@ -77,7 +80,8 @@ const ClipboardButton = React.createClass({
       disabled: disabled,
       title: buttonTitle,
     };
-  },
+  };
+
   render() {
     const filteredProps = this._getFilteredProps();
     const tooltip = <Tooltip id={'copy-button-tooltip'}>{this.state.tooltipMessage}</Tooltip>;
@@ -95,7 +99,7 @@ const ClipboardButton = React.createClass({
         </Button>
       </OverlayTrigger>
     );
-  },
-});
+  }
+}
 
 export default ClipboardButton;

--- a/graylog2-web-interface/src/components/common/ContentPackMarker.jsx
+++ b/graylog2-web-interface/src/components/common/ContentPackMarker.jsx
@@ -4,19 +4,17 @@ import React from 'react';
 /**
  * Adds an icon to an entity that was created by a content pack.
  */
-const ContentPackMarker = React.createClass({
-  propTypes: {
+class ContentPackMarker extends React.Component {
+  static propTypes = {
     /** Content pack key of the entity's object. When set, the component will render the content pack marker. */
     contentPack: PropTypes.string,
     /** Margin-left the marker should use. */
     marginLeft: PropTypes.number,
     /** Margin-right the marker should use. */
     marginRight: PropTypes.number,
-  },
+  };
 
-  getDefaultProps() {
-    return { contentPack: undefined, marginLeft: 0, marginRight: 0 };
-  },
+  static defaultProps = { contentPack: undefined, marginLeft: 0, marginRight: 0 };
 
   render() {
     const style = { marginLeft: this.props.marginLeft, marginRight: this.props.marginRight };
@@ -26,7 +24,7 @@ const ContentPackMarker = React.createClass({
     }
 
     return null;
-  },
-});
+  }
+}
 
 export default ContentPackMarker;

--- a/graylog2-web-interface/src/components/common/DataTable.jsx
+++ b/graylog2-web-interface/src/components/common/DataTable.jsx
@@ -8,8 +8,8 @@ import DataTableElement from './DataTableElement';
  * decide exactly how the data should be rendered. It optionally adds a filter
  * input to the data table by using the the `TypeAheadDataFilter` component.
  */
-const DataTable = React.createClass({
-  propTypes: {
+class DataTable extends React.Component {
+  static propTypes = {
     /** Adds a custom children element next to the data filter input. */
     children: PropTypes.node,
     /** Adds a custom class to the table element. */
@@ -53,31 +53,31 @@ const DataTable = React.createClass({
      * The main reason to disable this is if the table is clipping a dropdown menu or another component in a table edge.
      */
     useResponsiveTable: PropTypes.bool,
-  },
-  getDefaultProps() {
-    return {
-      filterSuggestions: [],
-      displayKey: 'value',
-      noDataText: 'No data available.',
-      rowClassName: '',
-      useResponsiveTable: true,
-    };
-  },
-  getInitialState() {
-    return {
-      headers: this.props.headers,
-      rows: this.props.rows,
-      filteredRows: this.props.rows,
-    };
-  },
+  };
+
+  static defaultProps = {
+    filterSuggestions: [],
+    displayKey: 'value',
+    noDataText: 'No data available.',
+    rowClassName: '',
+    useResponsiveTable: true,
+  };
+
+  state = {
+    headers: this.props.headers,
+    rows: this.props.rows,
+    filteredRows: this.props.rows,
+  };
+
   componentWillReceiveProps(newProps) {
     this.setState({
       headers: newProps.headers,
       rows: newProps.rows,
       filteredRows: newProps.rows,
     });
-  },
-  getFormattedHeaders() {
+  }
+
+  getFormattedHeaders = () => {
     let i = 0;
     const formattedHeaders = this.state.headers.map((header) => {
       const el = <DataTableElement key={`header-${i}`} element={header} index={i} formatter={this.props.headerCellFormatter} />;
@@ -86,8 +86,9 @@ const DataTable = React.createClass({
     });
 
     return <tr>{formattedHeaders}</tr>;
-  },
-  getFormattedDataRows() {
+  };
+
+  getFormattedDataRows = () => {
     let i = 0;
     let sortedDataRows = this.state.filteredRows;
     if (this.props.sortByKey) {
@@ -102,10 +103,12 @@ const DataTable = React.createClass({
     });
 
     return formattedDataRows;
-  },
-  filterDataRows(filteredRows) {
+  };
+
+  filterDataRows = (filteredRows) => {
     this.setState({ filteredRows });
-  },
+  };
+
   render() {
     let filter;
     if (this.props.filterKeys.length !== 0) {
@@ -158,7 +161,7 @@ const DataTable = React.createClass({
         </div>
       </div>
     );
-  },
-});
+  }
+}
 
 export default DataTable;

--- a/graylog2-web-interface/src/components/common/DataTableElement.jsx
+++ b/graylog2-web-interface/src/components/common/DataTableElement.jsx
@@ -6,8 +6,8 @@ import React from 'react';
  * should not use this component directly, but through `DataTable`. Look at the `DataTable`
  * section for a usage example.
  */
-const DataTableElement = React.createClass({
-  propTypes: {
+class DataTableElement extends React.Component {
+  static propTypes = {
     /** Element to be formatted. */
     element: PropTypes.any,
     /**
@@ -17,10 +17,11 @@ const DataTableElement = React.createClass({
     formatter: PropTypes.func.isRequired,
     /** Element index. */
     index: PropTypes.number,
-  },
+  };
+
   render() {
     return this.props.formatter(this.props.element, this.props.index);
-  },
-});
+  }
+}
 
 export default DataTableElement;

--- a/graylog2-web-interface/src/components/common/DatePicker.jsx
+++ b/graylog2-web-interface/src/components/common/DatePicker.jsx
@@ -10,8 +10,8 @@ import 'react-day-picker/lib/style.css';
  * Component that renders a given children and wraps a date picker around it. The date picker will show when
  * the children is clicked, and hidden when clicking somewhere else.
  */
-const DatePicker = React.createClass({
-  propTypes: {
+class DatePicker extends React.Component {
+  static propTypes = {
     /** Element id to use in the date picker Popover. */
     id: PropTypes.string.isRequired,
     /** Title to use in the date picker Popover.  */
@@ -25,7 +25,8 @@ const DatePicker = React.createClass({
     onChange: PropTypes.func.isRequired,
     /** Element that will trigger the date picker Popover. */
     children: PropTypes.node.isRequired,
-  },
+  };
+
   render() {
     let selectedDate;
     if (this.props.date) {
@@ -60,7 +61,7 @@ const DatePicker = React.createClass({
         {this.props.children}
       </OverlayTrigger>
     );
-  },
-});
+  }
+}
 
 export default DatePicker;

--- a/graylog2-web-interface/src/components/common/DocumentTitle.jsx
+++ b/graylog2-web-interface/src/components/common/DocumentTitle.jsx
@@ -13,8 +13,8 @@ import React from 'react';
  * </DocumentTitle>
  * ```
  */
-const DocumentTitle = React.createClass({
-  propTypes: {
+class DocumentTitle extends React.Component {
+  static propTypes = {
     /** Title to prepend to the page `document.title`. */
     title: PropTypes.string.isRequired,
     /** Children to be rendered. */
@@ -22,20 +22,21 @@ const DocumentTitle = React.createClass({
       PropTypes.arrayOf(PropTypes.element),
       PropTypes.element,
     ]).isRequired,
-  },
+  };
 
   componentDidMount() {
     document.title = `${document.title} - ${this.props.title}`;
-  },
+  }
 
   componentWillUnmount() {
     document.title = this.defaultTitle;
-  },
+  }
 
-  defaultTitle: 'Graylog',
+  defaultTitle = 'Graylog';
+
   render() {
     return this.props.children;
-  },
-});
+  }
+}
 
 export default DocumentTitle;

--- a/graylog2-web-interface/src/components/common/EntityList.jsx
+++ b/graylog2-web-interface/src/components/common/EntityList.jsx
@@ -7,8 +7,8 @@ import { Alert } from 'react-bootstrap';
  * action buttons, etc. You need to use this component alongside `EntityListItem` in order to get a similar
  * look and feel among different entities.
  */
-const EntityList = React.createClass({
-  propTypes: {
+class EntityList extends React.Component {
+  static propTypes = {
     /** bsStyle to use when there are no items in the list. */
     bsNoItemsStyle: PropTypes.oneOf(['info', 'success', 'warning']),
     /** Text to show when there are no items in the list. */
@@ -18,13 +18,13 @@ const EntityList = React.createClass({
     ]),
     /** Array of `EntityListItem` that will be shown.  */
     items: PropTypes.array.isRequired,
-  },
-  getDefaultProps() {
-    return {
-      bsNoItemsStyle: 'info',
-      noItemsText: 'No items available',
-    };
-  },
+  };
+
+  static defaultProps = {
+    bsNoItemsStyle: 'info',
+    noItemsText: 'No items available',
+  };
+
   render() {
     if (this.props.items.length === 0) {
       return (
@@ -40,7 +40,7 @@ const EntityList = React.createClass({
         {this.props.items}
       </ul>
     );
-  },
-});
+  }
+}
 
 export default EntityList;

--- a/graylog2-web-interface/src/components/common/EntityListItem.jsx
+++ b/graylog2-web-interface/src/components/common/EntityListItem.jsx
@@ -6,8 +6,8 @@ import { Row, Col } from 'react-bootstrap';
  * Component that let you render an entity item using a similar look and feel as other entities in Graylog.
  * This component is meant to use alongside `EntityList`. Look there for an example of how to use this component.
  */
-const EntityListItem = React.createClass({
-  propTypes: {
+class EntityListItem extends React.Component {
+  static propTypes = {
     /** Entity's title. */
     title: PropTypes.oneOfType([PropTypes.string, PropTypes.node]),
     /** Text to append to the title. Usually the type or a short description. */
@@ -23,12 +23,12 @@ const EntityListItem = React.createClass({
      * to show configuration options.
      */
     contentRow: PropTypes.node,
-  },
-  getDefaultProps() {
-    return {
-      createdFromContentPack: false,
-    };
-  },
+  };
+
+  static defaultProps = {
+    createdFromContentPack: false,
+  };
+
   render() {
     let titleSuffix;
     if (this.props.titleSuffix) {
@@ -69,7 +69,7 @@ const EntityListItem = React.createClass({
         </Row>
       </li>
     );
-  },
-});
+  }
+}
 
 export default EntityListItem;

--- a/graylog2-web-interface/src/components/common/ExternalLink.jsx
+++ b/graylog2-web-interface/src/components/common/ExternalLink.jsx
@@ -5,8 +5,8 @@ import _ from 'lodash';
 /**
  * Component that renders a link to an external resource.
  */
-const ExternalLink = React.createClass({
-  propTypes: {
+class ExternalLink extends React.Component {
+  static propTypes = {
     /** Link to the external location. If this is not defined, the component does not render a `<a />` element but only the text and the icon. */
     href: PropTypes.string,
     /** Text for the link. (should be one line) */
@@ -17,16 +17,14 @@ const ExternalLink = React.createClass({
     iconClass: PropTypes.string,
     /** Class name for the link. Can be used to change the styling of the link. */
     className: PropTypes.string,
-  },
+  };
 
-  getDefaultProps() {
-    return {
-      href: '',
-      target: '_blank',
-      iconClass: 'fa-external-link',
-      className: '',
-    };
-  },
+  static defaultProps = {
+    href: '',
+    target: '_blank',
+    iconClass: 'fa-external-link',
+    className: '',
+  };
 
   render() {
     const content = (
@@ -47,7 +45,7 @@ const ExternalLink = React.createClass({
         {content}
       </a>
     );
-  },
-});
+  }
+}
 
 export default ExternalLink;

--- a/graylog2-web-interface/src/components/common/ExternalLinkButton.jsx
+++ b/graylog2-web-interface/src/components/common/ExternalLinkButton.jsx
@@ -9,8 +9,8 @@ import { ExternalLink } from 'components/common';
  *
  * All props besides `iconClass` and `children` are passed down to the react-bootstrap `<Button />` component.
  */
-const ExternalLinkButton = React.createClass({
-  propTypes: {
+class ExternalLinkButton extends React.Component {
+  static propTypes = {
     /** Link to the external location. */
     href: PropTypes.string.isRequired,
     /** Text for the button. (should be one line) */
@@ -27,18 +27,16 @@ const ExternalLinkButton = React.createClass({
     className: PropTypes.string,
     /** Render a disabled button if this is <code>true</code>. */
     disabled: PropTypes.bool,
-  },
+  };
 
-  getDefaultProps() {
-    return {
-      bsStyle: 'default',
-      bsSize: '',
-      target: '_blank',
-      iconClass: 'fa-external-link',
-      className: '',
-      disabled: false,
-    };
-  },
+  static defaultProps = {
+    bsStyle: 'default',
+    bsSize: '',
+    target: '_blank',
+    iconClass: 'fa-external-link',
+    className: '',
+    disabled: false,
+  };
 
   render() {
     const { iconClass, children, ...props } = this.props;
@@ -48,7 +46,7 @@ const ExternalLinkButton = React.createClass({
         <ExternalLink iconClass={iconClass}>{children}</ExternalLink>
       </Button>
     );
-  },
-});
+  }
+}
 
 export default ExternalLinkButton;

--- a/graylog2-web-interface/src/components/common/ISODurationInput.jsx
+++ b/graylog2-web-interface/src/components/common/ISODurationInput.jsx
@@ -6,8 +6,8 @@ import ISODurationUtils from 'util/ISODurationUtils';
 /**
  * Displays an `Input` component for ISO8601 durations.
  */
-const ISODurationInput = React.createClass({
-  propTypes: {
+class ISODurationInput extends React.Component {
+  static propTypes = {
     /** Input id */
     id: PropTypes.string.isRequired,
     /** Value to show in the Input. */
@@ -30,26 +30,22 @@ const ISODurationInput = React.createClass({
     autoFocus: PropTypes.bool,
     /** Specify that the Input is required to submit the form. */
     required: PropTypes.bool,
-  },
+  };
 
-  getDefaultProps() {
-    return {
-      label: 'Duration',
-      help: 'as ISO8601 Duration',
-      validator: () => true,
-      errorText: 'invalid',
-      autoFocus: false,
-      required: false,
-    };
-  },
+  static defaultProps = {
+    label: 'Duration',
+    help: 'as ISO8601 Duration',
+    validator: () => true,
+    errorText: 'invalid',
+    autoFocus: false,
+    required: false,
+  };
 
-  getInitialState() {
-    return {
-      duration: this.props.duration,
-    };
-  },
+  state = {
+    duration: this.props.duration,
+  };
 
-  _onUpdate() {
+  _onUpdate = () => {
     let duration = this.refs.isoDuration.getValue().toUpperCase();
 
     if (!duration.startsWith('P')) {
@@ -62,7 +58,7 @@ const ISODurationInput = React.createClass({
       // Only propagate state if the config is valid.
       this.props.update(duration);
     }
-  },
+  };
 
   render() {
     return (
@@ -78,7 +74,7 @@ const ISODurationInput = React.createClass({
              autoFocus={this.props.autoFocus}
              required={this.props.required} />
     );
-  },
-});
+  }
+}
 
 export default ISODurationInput;

--- a/graylog2-web-interface/src/components/common/IfPermitted.jsx
+++ b/graylog2-web-interface/src/components/common/IfPermitted.jsx
@@ -1,5 +1,6 @@
 import PropTypes from 'prop-types';
 import React from 'react';
+import createReactClass from 'create-react-class';
 import Reflux from 'reflux';
 
 import StoreProvider from 'injection/StoreProvider';
@@ -11,7 +12,9 @@ import PermissionsMixin from 'util/PermissionsMixin';
  * Wrapper component that renders its children only if the current user fulfills certain permissions.
  * Current user's permissions are fetched from the server.
  */
-const IfPermitted = React.createClass({
+const IfPermitted = createReactClass({
+  displayName: 'IfPermitted',
+
   propTypes: {
     /** Children to render if user has permissions. */
     children: PropTypes.node.isRequired,
@@ -23,12 +26,15 @@ const IfPermitted = React.createClass({
     /** This flag controls which permissions the user must fulfill: (all, at least one). */
     anyPermissions: PropTypes.bool,
   },
+
   mixins: [Reflux.connect(CurrentUserStore), PermissionsMixin],
+
   getDefaultProps() {
     return {
       anyPermissions: false,
     };
   },
+
   _checkPermissions() {
     if (this.props.anyPermissions) {
       return this.isAnyPermitted(this.state.currentUser.permissions, this.props.permissions);
@@ -36,6 +42,7 @@ const IfPermitted = React.createClass({
 
     return this.isPermitted(this.state.currentUser.permissions, this.props.permissions);
   },
+
   render() {
     if (this.state.currentUser && this._checkPermissions()) {
       return React.Children.count(this.props.children) > 1 ? <span>{this.props.children}</span> : this.props.children;

--- a/graylog2-web-interface/src/components/common/JSONValueInput.jsx
+++ b/graylog2-web-interface/src/components/common/JSONValueInput.jsx
@@ -14,8 +14,8 @@ const OPTIONS = [
   { value: 'NULL', label: 'null' },
 ];
 
-const JSONValueInput = React.createClass({
-  propTypes: {
+class JSONValueInput extends React.Component {
+  static propTypes = {
     update: PropTypes.func.isRequired,
     label: PropTypes.string,
     help: PropTypes.oneOfType([PropTypes.string, PropTypes.object]),
@@ -42,49 +42,45 @@ const JSONValueInput = React.createClass({
     },
     labelClassName: PropTypes.string,
     wrapperClassName: PropTypes.string,
-  },
+  };
 
-  getDefaultProps() {
-    return {
-      value: '',
-      valueType: 'STRING',
-      allowedTypes: OPTIONS.map(option => option.value),
-      label: '',
-      help: '',
-      required: false,
-      validationState: null,
-      labelClassName: undefined,
-      wrapperClassName: undefined,
-    };
-  },
-
-  getInitialState() {
-    return this._computeInitialState(this.props);
-  },
+  static defaultProps = {
+    value: '',
+    valueType: 'STRING',
+    allowedTypes: OPTIONS.map(option => option.value),
+    label: '',
+    help: '',
+    required: false,
+    validationState: null,
+    labelClassName: undefined,
+    wrapperClassName: undefined,
+  };
 
   componentWillReceiveProps(nextProps) {
     this.setState(this._computeInitialState(nextProps));
-  },
+  }
 
-  _computeInitialState(props) {
+  _computeInitialState = (props) => {
     return {
       value: props.value,
       valueType: props.valueType,
     };
-  },
+  };
 
-  _propagateState() {
+  _propagateState = () => {
     this.props.update(this.state.value, this.state.valueType);
-  },
+  };
 
-  _onUpdate(e) {
+  _onUpdate = (e) => {
     const value = e.target.value;
     this.setState({ value: value }, this._propagateState);
-  },
+  };
 
-  _onValueTypeSelect(valueType) {
+  _onValueTypeSelect = (valueType) => {
     this.setState({ valueType: valueType }, this._propagateState);
-  },
+  };
+
+  state = this._computeInitialState(this.props);
 
   render() {
     const options = OPTIONS.filter(o => this.props.allowedTypes.indexOf(o.value) > -1).map((o) => {
@@ -108,7 +104,7 @@ const JSONValueInput = React.createClass({
         </InputWrapper>
       </FormGroup>
     );
-  },
-});
+  }
+}
 
 export default JSONValueInput;

--- a/graylog2-web-interface/src/components/common/KeyValueTable.jsx
+++ b/graylog2-web-interface/src/components/common/KeyValueTable.jsx
@@ -12,8 +12,8 @@ import style from './KeyValueTable.css';
  * KeyValueTable displays a table for all key-value pairs in a JS object. If the editable prop is set to true, it also
  * provides inputs to create, edit and delete key-value pairs.
  */
-const KeyValueTable = React.createClass({
-  propTypes: {
+class KeyValueTable extends React.Component {
+  static propTypes = {
     /** Object containing key-values to represent in the table. */
     pairs: PropTypes.object.isRequired,
     /** Table headers. Must be an array with three elements [ key header, value header, actions header]. */
@@ -28,46 +28,42 @@ const KeyValueTable = React.createClass({
     containerClassName: PropTypes.string,
     /** Size of action buttons. */
     actionsSize: PropTypes.oneOf(['large', 'medium', 'small', 'xsmall']),
-  },
+  };
 
-  getInitialState() {
-    return {
-      newKey: '',
-      newValue: '',
-    };
-  },
+  static defaultProps = {
+    headers: ['Name', 'Value', 'Actions'],
+    editable: false,
+    actionsSize: 'xsmall',
+    className: '',
+    containerClassName: '',
+  };
 
-  getDefaultProps() {
-    return {
-      headers: ['Name', 'Value', 'Actions'],
-      editable: false,
-      actionsSize: 'xsmall',
-      className: '',
-      containerClassName: '',
-    };
-  },
+  state = {
+    newKey: '',
+    newValue: '',
+  };
 
-  _onPairsChange(newPairs) {
+  _onPairsChange = (newPairs) => {
     if (this.props.onChange) {
       this.props.onChange(newPairs);
     }
-  },
+  };
 
-  _bindValue(event) {
+  _bindValue = (event) => {
     const newState = {};
     newState[event.target.name] = event.target.value;
     this.setState(newState);
-  },
+  };
 
-  _addRow() {
+  _addRow = () => {
     const newPairs = ObjectUtils.clone(this.props.pairs);
     newPairs[this.state.newKey] = this.state.newValue;
     this._onPairsChange(newPairs);
 
     this.setState({ newKey: '', newValue: '' });
-  },
+  };
 
-  _deleteRow(key) {
+  _deleteRow = (key) => {
     return () => {
       if (window.confirm(`Are you sure you want to delete property '${key}'?`)) {
         const newPairs = ObjectUtils.clone(this.props.pairs);
@@ -75,9 +71,9 @@ const KeyValueTable = React.createClass({
         this._onPairsChange(newPairs);
       }
     };
-  },
+  };
 
-  _formattedHeaders(headers) {
+  _formattedHeaders = (headers) => {
     return (
       <tr>
         {headers.map((header, idx) => {
@@ -96,9 +92,9 @@ const KeyValueTable = React.createClass({
         })}
       </tr>
     );
-  },
+  };
 
-  _formattedRows(pairs) {
+  _formattedRows = (pairs) => {
     return Object.keys(pairs).sort().map((key) => {
       let actionsColumn;
       if (this.props.editable) {
@@ -120,9 +116,9 @@ const KeyValueTable = React.createClass({
         </tr>
       );
     });
-  },
+  };
 
-  _newRow() {
+  _newRow = () => {
     if (!this.props.editable) {
       return null;
     }
@@ -143,7 +139,7 @@ const KeyValueTable = React.createClass({
         </td>
       </tr>
     );
-  },
+  };
 
   render() {
     return (
@@ -159,7 +155,7 @@ const KeyValueTable = React.createClass({
         </div>
       </div>
     );
-  },
-});
+  }
+}
 
 export default KeyValueTable;

--- a/graylog2-web-interface/src/components/common/LinkToNode.jsx
+++ b/graylog2-web-interface/src/components/common/LinkToNode.jsx
@@ -1,5 +1,6 @@
 import PropTypes from 'prop-types';
 import React from 'react';
+import createReactClass from 'create-react-class';
 import Reflux from 'reflux';
 import { Link } from 'react-router';
 
@@ -17,12 +18,16 @@ import { Spinner } from 'components/common';
  *
  * All this information will be obtained from the `NodesStore`.
  */
-const LinkToNode = React.createClass({
+const LinkToNode = createReactClass({
+  displayName: 'LinkToNode',
+
   propTypes: {
     /** Node ID that will be used to generate the link. */
     nodeId: PropTypes.string.isRequired,
   },
+
   mixins: [Reflux.connect(NodesStore)],
+
   render() {
     if (!this.state.nodes) {
       return <Spinner />;

--- a/graylog2-web-interface/src/components/common/LoadingIndicator.jsx
+++ b/graylog2-web-interface/src/components/common/LoadingIndicator.jsx
@@ -13,21 +13,19 @@ import loadingIndicatorStyle from './LoadingIndicator.css';
  * Use this component when you want to load something in the background, but still provide some feedback that
  * an action is happening.
  */
-const LoadingIndicator = React.createClass({
-  propTypes: {
+class LoadingIndicator extends React.Component {
+  static propTypes = {
     /** Text to display while the indicator is shown. */
     text: PropTypes.string,
-  },
+  };
 
-  getDefaultProps() {
-    return {
-      text: 'Loading...',
-    };
-  },
+  static defaultProps = {
+    text: 'Loading...',
+  };
 
   render() {
     return <Alert bsStyle="info" className={loadingIndicatorStyle.loadingIndicator}><Spinner text={this.props.text} /></Alert>;
-  },
-});
+  }
+}
 
 export default LoadingIndicator;

--- a/graylog2-web-interface/src/components/common/LocaleSelect.jsx
+++ b/graylog2-web-interface/src/components/common/LocaleSelect.jsx
@@ -1,5 +1,6 @@
 import PropTypes from 'prop-types';
 import React from "react";
+import createReactClass from 'create-react-class';
 import Reflux from "reflux";
 
 import Select from "components/common/Select";
@@ -11,15 +12,19 @@ const SystemStore = StoreProvider.getStore('System');
  * Component that renders a form input with all available locale settings. It also makes easy to filter
  * values to quickly find the locale needed.
  */
-const LocaleSelect = React.createClass({
+const LocaleSelect = createReactClass({
+  displayName: 'LocaleSelect',
   mixins: [Reflux.connect(SystemStore)],
+
   propTypes: {
     /** Function to call when the input changes. It will receive the new locale value as argument. */
     onChange: PropTypes.func,
   },
+
   getValue() {
     return this.refs.locale.getValue();
   },
+
   _formatLocales(locales) {
     const sortedLocales = Object.values(locales)
         .filter(locale => locale['language_tag'] !== 'und')
@@ -41,9 +46,11 @@ const LocaleSelect = React.createClass({
 
     return [{value: 'und', label:'Default locale'}].concat(sortedLocales);
   },
+
   _renderOption(option) {
       return <span key={option.value} title="{option.value} [{option.value}]">{option.label} [{option.value}]</span>;
   },
+
   render() {
     if (!this.state.locales) {
       return <Spinner />;

--- a/graylog2-web-interface/src/components/common/MultiSelect.jsx
+++ b/graylog2-web-interface/src/components/common/MultiSelect.jsx
@@ -6,15 +6,17 @@ import Select from 'components/common/Select';
  * Component that wraps and render a `Select` where multiple options can be selected. It passes all
  * props to the underlying `Select` component, so please look there to find more information about them.
  */
-const MultiSelect = React.createClass({
-  propTypes: Select.propTypes,
-  _select: undefined,
-  getValue() {
+class MultiSelect extends React.Component {
+  static propTypes = Select.propTypes;
+  _select = undefined;
+
+  getValue = () => {
     return this._select.getValue();
-  },
+  };
+
   render() {
     return <Select ref={(c) => { this._select = c; }} multi {...this.props} />;
-  },
-});
+  }
+}
 
 export default MultiSelect;

--- a/graylog2-web-interface/src/components/common/OverlayElement.jsx
+++ b/graylog2-web-interface/src/components/common/OverlayElement.jsx
@@ -8,8 +8,8 @@ import { OverlayTrigger } from 'react-bootstrap';
  *
  * See: https://github.com/react-bootstrap/react-bootstrap/issues/364
  */
-const OverlayElement = React.createClass({
-  propTypes: {
+class OverlayElement extends React.Component {
+  static propTypes = {
     /** Element that will be displayed in the overlay. */
     overlay: PropTypes.element,
     /** Placement for the overlay. */
@@ -26,7 +26,7 @@ const OverlayElement = React.createClass({
       PropTypes.arrayOf(PropTypes.element),
       PropTypes.element,
     ]).isRequired,
-  },
+  };
 
   render() {
     if (this.props.overlay && this.props.useOverlay) {
@@ -42,7 +42,7 @@ const OverlayElement = React.createClass({
     }
 
     return this.props.children;
-  },
-});
+  }
+}
 
 export default OverlayElement;

--- a/graylog2-web-interface/src/components/common/Page.jsx
+++ b/graylog2-web-interface/src/components/common/Page.jsx
@@ -7,8 +7,8 @@ import { Pager } from 'react-bootstrap';
  *
  * @deprecated Please use `Pager.Item` directly, as this abstraction doesn't provide much value at the moment.
  */
-const Page = React.createClass({
-  propTypes: {
+class Page extends React.Component {
+  static propTypes = {
     /** href the page should link to. */
     href: PropTypes.string,
     /** Page name or number. */
@@ -22,7 +22,8 @@ const Page = React.createClass({
     isDisabled: PropTypes.bool,
     /** Specifies if the current page is selected or not. */
     isActive: PropTypes.bool,
-  },
+  };
+
   render() {
     let className = '';
     if (this.props.isActive) {
@@ -37,7 +38,7 @@ const Page = React.createClass({
         {this.props.page}
       </Pager.Item>
     );
-  },
-});
+  }
+}
 
 export default Page;

--- a/graylog2-web-interface/src/components/common/PageErrorOverview.jsx
+++ b/graylog2-web-interface/src/components/common/PageErrorOverview.jsx
@@ -9,20 +9,21 @@ import style from '!style/useable!css!pages/NotFoundPage.css';
  * only when the page would make no sense if the information is not available (i.e. a node page where we
  * can't reach the node).
  */
-const PageErrorOverview = React.createClass({
-  propTypes: {
+class PageErrorOverview extends React.Component {
+  static propTypes = {
     /** Array of errors that prevented the original page to load. */
     errors: PropTypes.array.isRequired,
-  },
+  };
+
   componentDidMount() {
     style.use();
-  },
+  }
 
   componentWillUnmount() {
     style.unuse();
-  },
+  }
 
-  _formatErrors(errors) {
+  _formatErrors = (errors) => {
     const formattedErrors = errors ? errors.map(error => <li key={`key-${error.toString()}`}>{error.toString()}</li>) : [];
     return (
       <ul>
@@ -30,7 +31,8 @@ const PageErrorOverview = React.createClass({
         <li>Check your Graylog logs for more information.</li>
       </ul>
     );
-  },
+  };
+
   render() {
     return (
       <Row className="jumbotron-container">
@@ -43,7 +45,7 @@ const PageErrorOverview = React.createClass({
         </Col>
       </Row>
     );
-  },
-});
+  }
+}
 
 export default PageErrorOverview;

--- a/graylog2-web-interface/src/components/common/PageHeader.jsx
+++ b/graylog2-web-interface/src/components/common/PageHeader.jsx
@@ -9,8 +9,8 @@ import SupportLink from 'components/support/SupportLink';
  * This ensures all pages look and feel the same way across the product, so
  * please use it in your pages.
  */
-const PageHeader = React.createClass({
-  propTypes: {
+class PageHeader extends React.Component {
+  static propTypes = {
     /** Page header heading. */
     title: PropTypes.oneOfType([PropTypes.node, PropTypes.string]).isRequired,
     /**
@@ -26,13 +26,13 @@ const PageHeader = React.createClass({
     experimental: PropTypes.bool,
     /** Specifies if the page header is children of a content `Row` or not. */
     subpage: PropTypes.bool,
-  },
-  getDefaultProps() {
-    return {
-      experimental: false,
-      subpage: false,
-    };
-  },
+  };
+
+  static defaultProps = {
+    experimental: false,
+    subpage: false,
+  };
+
   render() {
     const children = (this.props.children !== undefined && this.props.children.length !== undefined ? this.props.children : [this.props.children]);
 
@@ -84,7 +84,7 @@ const PageHeader = React.createClass({
         </Row>
       </div>
     );
-  },
-});
+  }
+}
 
 export default PageHeader;

--- a/graylog2-web-interface/src/components/common/PaginatedList.jsx
+++ b/graylog2-web-interface/src/components/common/PaginatedList.jsx
@@ -9,8 +9,8 @@ import { Input } from 'components/bootstrap';
  * You still need to fetch or filter the data yourself to ensure that
  * the selected page is displayed on screen.
  */
-const PaginatedList = React.createClass({
-  propTypes: {
+class PaginatedList extends React.Component {
+  static propTypes = {
     /** React element containing items of the current selected page. */
     children: PropTypes.node.isRequired,
     /**
@@ -26,31 +26,34 @@ const PaginatedList = React.createClass({
     totalItems: PropTypes.number.isRequired,
     /** */
     showPageSizeSelect: PropTypes.bool,
-  },
-  getDefaultProps() {
+  };
+
+  static defaultProps = function() {
     const defaultPageSizes = [10, 50, 100];
     return {
       pageSizes: defaultPageSizes,
       pageSize: defaultPageSizes[0],
       showPageSizeSelect: true,
     };
-  },
-  getInitialState() {
-    return { currentPage: 1, pageSize: this.props.pageSize };
-  },
-  _onChangePageSize(event) {
+  }();
+
+  state = { currentPage: 1, pageSize: this.props.pageSize };
+
+  _onChangePageSize = (event) => {
     event.preventDefault();
     const pageSize = Number(event.target.value);
     this.setState({ pageSize: pageSize });
     this.props.onChange(this.state.currentPage, pageSize);
-  },
-  _onChangePage(eventKey, event) {
+  };
+
+  _onChangePage = (eventKey, event) => {
     event.preventDefault();
     const pageNo = Number(eventKey);
     this.setState({ currentPage: pageNo });
     this.props.onChange(pageNo, this.state.pageSize);
-  },
-  _pageSizeSelect() {
+  };
+
+  _pageSizeSelect = () => {
     if (!this.props.showPageSizeSelect) {
       return null;
     }
@@ -61,7 +64,8 @@ const PaginatedList = React.createClass({
         </Input>
       </div>
     );
-  },
+  };
+
   render() {
     const numberPages = Math.ceil(this.props.totalItems / this.state.pageSize);
     if (numberPages === 0) {
@@ -82,7 +86,7 @@ const PaginatedList = React.createClass({
         </div>
       </span>
     );
-  },
-});
+  }
+}
 
 export default PaginatedList;

--- a/graylog2-web-interface/src/components/common/Pluralize.jsx
+++ b/graylog2-web-interface/src/components/common/Pluralize.jsx
@@ -6,8 +6,8 @@ import StringUtils from 'util/StringUtils';
 /**
  * Component that will render a singular or plural text depending on a given value.
  */
-const Pluralize = React.createClass({
-  propTypes: {
+class Pluralize extends React.Component {
+  static propTypes = {
     /** Singular form of the word. */
     singular: PropTypes.string.isRequired,
     /** Plural form of the word. */
@@ -17,10 +17,11 @@ const Pluralize = React.createClass({
       PropTypes.number,
       PropTypes.string,
     ]).isRequired,
-  },
+  };
+
   render() {
     return <span>{StringUtils.pluralize(this.props.value, this.props.singular, this.props.plural)}</span>;
-  },
-});
+  }
+}
 
 export default Pluralize;

--- a/graylog2-web-interface/src/components/common/ReactGridContainer.jsx
+++ b/graylog2-web-interface/src/components/common/ReactGridContainer.jsx
@@ -36,8 +36,8 @@ const BREAKPOINTS = {
  * or draggable. Use this for dashboards or pages where the user should
  * be able to decide how to arrange the content.
  */
-const ReactGridContainer = React.createClass({
-  propTypes: {
+class ReactGridContainer extends React.Component {
+  static propTypes = {
     /**
      * Object of positions in this format:
      * ```
@@ -103,31 +103,23 @@ const ReactGridContainer = React.createClass({
     columns: PropTypes.object,
     /** Specifies whether the grid should use CSS animations or not. */
     animate: PropTypes.bool,
-  },
+  };
 
-  getDefaultProps() {
-    return {
-      locked: false,
-      isResizable: true,
-      rowHeight: ROW_HEIGHT,
-      columns: COLUMNS,
-      animate: true,
-    };
-  },
-
-  getInitialState() {
-    return {
-      layout: this.computeLayout(this.props.positions),
-    };
-  },
+  static defaultProps = {
+    locked: false,
+    isResizable: true,
+    rowHeight: ROW_HEIGHT,
+    columns: COLUMNS,
+    animate: true,
+  };
 
   componentWillReceiveProps(nextProps) {
     if (!lodash.isEqual(nextProps.positions, this.props.positions)) {
       this.setState({ layout: this.computeLayout(nextProps.positions) });
     }
-  },
+  }
 
-  computeLayout(positions) {
+  computeLayout = (positions) => {
     return Object.keys(positions).map((id) => {
       const { col, row, height, width } = positions[id];
       return {
@@ -138,9 +130,9 @@ const ReactGridContainer = React.createClass({
         w: width || 1,
       };
     });
-  },
+  };
 
-  _onLayoutChange(newLayout) {
+  _onLayoutChange = (newLayout) => {
     // `onLayoutChange` may be triggered when clicking somewhere in a widget, check before propagating the change.
     // Filter out additional Object properties in nextLayout, as it comes directly from react-grid-layout
     const filteredNewLayout = newLayout.map(item => ({ i: item.i, x: item.x, y: item.y, h: item.h, w: item.w }));
@@ -160,7 +152,11 @@ const ReactGridContainer = React.createClass({
     });
 
     this.props.onPositionsChange(newPositions);
-  },
+  };
+
+  state = {
+    layout: this.computeLayout(this.props.positions),
+  };
 
   render() {
     const { children, locked, isResizable, rowHeight, columns, animate } = this.props;
@@ -185,7 +181,7 @@ const ReactGridContainer = React.createClass({
         {children}
       </WidthAdjustedReactGridLayout>
     );
-  },
-});
+  }
+}
 
 export default ReactGridContainer;

--- a/graylog2-web-interface/src/components/common/SearchForm.jsx
+++ b/graylog2-web-interface/src/components/common/SearchForm.jsx
@@ -8,8 +8,8 @@ import { Spinner } from 'components/common';
  * supports a loading state, adding children next to the form, and
  * styles customization.
  */
-const SearchForm = React.createClass({
-  propTypes: {
+class SearchForm extends React.Component {
+  static propTypes = {
     /**
      * Callback when a search was submitted. The function receives the query
      * and a callback to reset the loading state of the form as arguments.
@@ -51,56 +51,52 @@ const SearchForm = React.createClass({
       PropTypes.arrayOf(PropTypes.element),
       PropTypes.element,
     ]),
-  },
+  };
 
-  getDefaultProps() {
-    return {
-      placeholder: 'Enter search query...',
-      wrapperClass: 'search',
-      queryWidth: 'auto',
-      topMargin: 15,
-      buttonLeftMargin: 5,
-      searchBsStyle: 'default',
-      searchButtonLabel: 'Search',
-      resetButtonLabel: 'Reset',
-      loadingLabel: 'Loading...',
-    };
-  },
+  static defaultProps = {
+    placeholder: 'Enter search query...',
+    wrapperClass: 'search',
+    queryWidth: 'auto',
+    topMargin: 15,
+    buttonLeftMargin: 5,
+    searchBsStyle: 'default',
+    searchButtonLabel: 'Search',
+    resetButtonLabel: 'Reset',
+    loadingLabel: 'Loading...',
+  };
 
-  getInitialState() {
-    return {
-      isLoading: false,
-    };
-  },
+  state = {
+    isLoading: false,
+  };
 
   componentWillReceiveProps() {
     this._resetLoadingState();
-  },
+  }
 
-  _setLoadingState() {
+  _setLoadingState = () => {
     if (this.props.useLoadingState) {
       this.setState({ isLoading: true });
     }
-  },
+  };
 
-  _resetLoadingState() {
+  _resetLoadingState = () => {
     if (this.props.useLoadingState) {
       this.setState({ isLoading: false });
     }
-  },
+  };
 
-  _onSearch(e) {
+  _onSearch = (e) => {
     e.preventDefault();
 
     this._setLoadingState();
     this.props.onSearch(this.refs.query.value, this._resetLoadingState);
-  },
+  };
 
-  _onReset() {
+  _onReset = () => {
     this._resetLoadingState();
     this.refs.query.value = '';
     this.props.onReset();
-  },
+  };
 
   render() {
     return (
@@ -136,7 +132,7 @@ const SearchForm = React.createClass({
         </form>
       </div>
     );
-  },
-});
+  }
+}
 
 export default SearchForm;

--- a/graylog2-web-interface/src/components/common/Select.jsx
+++ b/graylog2-web-interface/src/components/common/Select.jsx
@@ -1,5 +1,6 @@
 import PropTypes from 'prop-types';
 import React from 'react';
+import createReactClass from 'create-react-class';
 import ReactSelect from 'react-select';
 import lodash from 'lodash';
 
@@ -19,7 +20,9 @@ const acceptedReactSelectProps = lodash.without(lodash.keys(ReactSelect.propType
  * https://github.com/JedWatson/react-select/tree/v1.0.0#usage
  * for more information about the accepted props.
  */
-const Select = React.createClass({
+const Select = createReactClass({
+  displayName: 'Select',
+
   propTypes: {
     /**
      * Callback when selected option changes. It receives the value of the
@@ -72,32 +75,39 @@ const Select = React.createClass({
       allowCreate: false,
     };
   },
+
   getInitialState() {
     return {
       value: this.props.value,
     };
   },
+
   componentDidMount() {
     this.reactSelectStyles.use();
     this.reactSelectSmStyles.use();
   },
+
   componentWillReceiveProps(nextProps) {
     if (this.props.value !== nextProps.value) {
       this.setState({ value: nextProps.value });
     }
   },
+
   componentWillUnmount() {
     this.reactSelectStyles.unuse();
     this.reactSelectSmStyles.unuse();
   },
+
   getValue() {
     return this.state.value;
   },
+
   clearValue() {
     // Clear value needs an event, so we just give it one :grumpy:
     // As someone said: "This can't do any more harm that we already do"
     this._select.clearValue(new CustomEvent('fake'));
   },
+
   // This helps us emulate the behaviour of react-select < 1.0:
   //  - On simple selects it returns the value
   //  - On multi selects it returns all selected values split by a delimiter (',' by default)
@@ -109,6 +119,7 @@ const Select = React.createClass({
     }
     return '';
   },
+
   _onChange(selectedOption) {
     const value = this._extractOptionValue(selectedOption);
     this.setState({ value: value });
@@ -122,6 +133,7 @@ const Select = React.createClass({
       this.props.onValueChange(value);
     }
   },
+
   _select: undefined,
   reactSelectStyles: require('!style/useable!css!react-select/dist/react-select.css'),
   reactSelectSmStyles: require('!style/useable!css!./Select.css'),
@@ -140,6 +152,7 @@ const Select = React.createClass({
       return option || predicate;
     });
   },
+
   render() {
     const { allowCreate, displayKey, size, onReactSelectChange, multi } = this.props;
     const value = this.state.value;

--- a/graylog2-web-interface/src/components/common/SelectableList.jsx
+++ b/graylog2-web-interface/src/components/common/SelectableList.jsx
@@ -16,8 +16,8 @@ import { Select } from 'components/common';
  * This component also allows to select the same option many times, and
  * it accepts both arrays of strings and objects as selected options.
  */
-const SelectableList = React.createClass({
-  propTypes: {
+class SelectableList extends React.Component {
+  static propTypes = {
     /** Options to display in the input. See `Select`'s `options` prop for more information. */
     options: PropTypes.array,
     /** Specifies whether `selectedOptions` contains strings or objects. */
@@ -41,31 +41,29 @@ const SelectableList = React.createClass({
     onChange: PropTypes.func,
     /** Specifies if the input should receive the input focus or not. */
     autoFocus: PropTypes.bool,
-  },
+  };
 
-  getDefaultProps() {
-    return {
-      selectedOptionsType: 'string',
-      displayKey: 'label',
-      idKey: 'value',
-    };
-  },
+  static defaultProps = {
+    selectedOptionsType: 'string',
+    displayKey: 'label',
+    idKey: 'value',
+  };
 
   componentWillReceiveProps(nextProps) {
     if (this.props.selectedOptions !== nextProps.selectedOptions) {
       this.refs.select.clearValue();
     }
-  },
+  }
 
-  _getOptionId(option) {
+  _getOptionId = (option) => {
     return (typeof option === 'string' ? option : option[this.props.idKey]);
-  },
+  };
 
-  _getOptionDisplayValue(option) {
+  _getOptionDisplayValue = (option) => {
     return (typeof option === 'string' ? option : option[this.props.displayKey]);
-  },
+  };
 
-  _onAddOption(option) {
+  _onAddOption = (option) => {
     if (option === '') {
       return;
     }
@@ -80,16 +78,16 @@ const SelectableList = React.createClass({
     if (typeof this.props.onChange === 'function') {
       this.props.onChange(newSelectedOptions);
     }
-  },
+  };
 
-  _onRemoveOption(optionIndex) {
+  _onRemoveOption = (optionIndex) => {
     return () => {
       const newSelectedOptions = this.props.selectedOptions.filter((_, idx) => idx !== optionIndex);
       if (typeof this.props.onChange === 'function') {
         this.props.onChange(newSelectedOptions);
       }
     };
-  },
+  };
 
   render() {
     const formattedOptions = this.props.selectedOptions.map((option, idx) => {
@@ -110,7 +108,7 @@ const SelectableList = React.createClass({
         }
       </div>
     );
-  },
-});
+  }
+}
 
 export default SelectableList;

--- a/graylog2-web-interface/src/components/common/SortableList.jsx
+++ b/graylog2-web-interface/src/components/common/SortableList.jsx
@@ -14,8 +14,8 @@ import SortableListItem from './SortableListItem';
  * using a different array or object to keep the sorting state can still
  * use it.
  */
-const SortableList = React.createClass({
-  propTypes: {
+class SortableList extends React.Component {
+  static propTypes = {
     /** Specifies if dragging and dropping is disabled or not. */
     disableDragging: PropTypes.bool,
     /**
@@ -30,22 +30,21 @@ const SortableList = React.createClass({
      * The function will receive the newly sorted list as an argument.
      */
     onMoveItem: PropTypes.func,
-  },
-  getDefaultProps() {
-    return {
-      disableDragging: false,
-    };
-  },
+  };
 
-  getInitialState() {
-    return {
-      items: this.props.items,
-    };
-  },
+  static defaultProps = {
+    disableDragging: false,
+  };
+
+  state = {
+    items: this.props.items,
+  };
+
   componentWillReceiveProps(nextProps) {
     this.setState({ items: nextProps.items });
-  },
-  _moveItem(dragIndex, hoverIndex) {
+  }
+
+  _moveItem = (dragIndex, hoverIndex) => {
     const sortedItems = this.state.items;
     const tempItem = sortedItems[dragIndex];
     sortedItems[dragIndex] = sortedItems[hoverIndex];
@@ -54,7 +53,8 @@ const SortableList = React.createClass({
     if (typeof this.props.onMoveItem === 'function') {
       this.props.onMoveItem(sortedItems);
     }
-  },
+  };
+
   render() {
     const formattedItems = this.state.items.map((item, idx) => {
       return (
@@ -72,8 +72,8 @@ const SortableList = React.createClass({
         {formattedItems}
       </ListGroup>
     );
-  },
-});
+  }
+}
 
 
 export default DragDropContext(HTML5Backend)(SortableList);

--- a/graylog2-web-interface/src/components/common/SortableListItem.jsx
+++ b/graylog2-web-interface/src/components/common/SortableListItem.jsx
@@ -85,8 +85,8 @@ function collectTarget(connect, monitor) {
  * You most likely don't want to use this component directly, so please
  * check the `SortableList` documentation instead.
  */
-const SortableListItem = React.createClass({
-  propTypes: {
+class SortableListItem extends React.Component {
+  static propTypes = {
     connectDragSource: PropTypes.func.isRequired,
     connectDropTarget: PropTypes.func.isRequired,
     content: PropTypes.any.isRequired,
@@ -96,12 +96,11 @@ const SortableListItem = React.createClass({
     isOver: PropTypes.bool.isRequired,
     id: PropTypes.any.isRequired,
     moveItem: PropTypes.func.isRequired,
-  },
-  getDefaultProps() {
-    return {
-      disableDragging: false,
-    };
-  },
+  };
+
+  static defaultProps = {
+    disableDragging: false,
+  };
 
   render() {
     const { content, isDragging, isOver, connectDragSource, connectDropTarget } = this.props;
@@ -127,7 +126,7 @@ const SortableListItem = React.createClass({
     );
 
     return this.props.disableDragging ? component : connectDragSource(connectDropTarget(component));
-  },
-});
+  }
+}
 
 export default DropTarget(ItemTypes.ITEM, itemTarget, collectTarget)(DragSource(ItemTypes.ITEM, itemSource, collectSource)(SortableListItem));

--- a/graylog2-web-interface/src/components/common/TableList.jsx
+++ b/graylog2-web-interface/src/components/common/TableList.jsx
@@ -24,8 +24,8 @@ import style from './TableList.css';
  * customize how the list of components should look like, or how filtering works,
  * please use that component instead of this one.
  */
-const TableList = React.createClass({
-  propTypes: {
+class TableList extends React.Component {
+  static propTypes = {
     /** Specifies key to use as item ID. */
     idKey: PropTypes.string,
     /** Specifies a key to use as item title. */
@@ -65,25 +65,23 @@ const TableList = React.createClass({
      * The function will receive the whole item object as an argument.
      */
     itemActionsFactory: PropTypes.func,
-  },
-  getDefaultProps() {
-    return {
-      idKey: 'id',
-      titleKey: 'title',
-      descriptionKey: 'description',
-      enableFilter: true,
-      filterLabel: 'Filter',
-      enableBulkActions: true,
-      bulkActionsFactory: () => {},
-      itemActionsFactory: () => {},
-    };
-  },
-  getInitialState() {
-    return {
-      filteredItems: this.props.items,
-      selected: Immutable.Set(),
-    };
-  },
+  };
+
+  static defaultProps = {
+    idKey: 'id',
+    titleKey: 'title',
+    descriptionKey: 'description',
+    enableFilter: true,
+    filterLabel: 'Filter',
+    enableBulkActions: true,
+    bulkActionsFactory: () => {},
+    itemActionsFactory: () => {},
+  };
+
+  state = {
+    filteredItems: this.props.items,
+    selected: Immutable.Set(),
+  };
 
   componentDidUpdate(prevProps) {
     const { filteredItems, selected } = this.state;
@@ -97,36 +95,36 @@ const TableList = React.createClass({
         this._updateFilteredItems(this.props.items);
       }
     }
-  },
+  }
 
-  _recalculateSelection(selected, nextFilteredItems) {
+  _recalculateSelection = (selected, nextFilteredItems) => {
     const nextFilteredIds = Immutable.Set(nextFilteredItems.map(item => item[this.props.idKey]));
     return selected.intersect(nextFilteredIds);
-  },
+  };
 
-  _updateFilteredItems(nextFilteredItems) {
+  _updateFilteredItems = (nextFilteredItems) => {
     const filteredSelected = this._recalculateSelection(this.state.selected, nextFilteredItems);
     this.setState({ filteredItems: nextFilteredItems, selected: filteredSelected });
-  },
+  };
 
-  _setSelectAllCheckboxState(selectAllInput, filteredItems, selected) {
+  _setSelectAllCheckboxState = (selectAllInput, filteredItems, selected) => {
     const selectAllCheckbox = selectAllInput ? selectAllInput.getInputDOMNode() : undefined;
     if (!selectAllCheckbox) {
       return;
     }
     // Set the select all checkbox as indeterminate if some but not items are selected.
     selectAllCheckbox.indeterminate = selected.count() > 0 && !this._isAllSelected(filteredItems, selected);
-  },
+  };
 
-  _filterItems(filteredItems) {
+  _filterItems = (filteredItems) => {
     this._updateFilteredItems(Immutable.List(filteredItems));
-  },
+  };
 
-  _isAllSelected(filteredItems, selected) {
+  _isAllSelected = (filteredItems, selected) => {
     return filteredItems.count() > 0 && filteredItems.count() === selected.count();
-  },
+  };
 
-  _headerItem() {
+  _headerItem = () => {
     if (!this.props.enableBulkActions) {
       return <ControlledTableList.Header />;
     }
@@ -151,12 +149,14 @@ const TableList = React.createClass({
                wrapperClassName="form-group-inline" />
       </ControlledTableList.Header>
     );
-  },
-  _toggleSelectAll(event) {
+  };
+
+  _toggleSelectAll = (event) => {
     const newSelected = event.target.checked ? Immutable.Set(this.state.filteredItems.map(item => item[this.props.idKey])) : Immutable.Set();
     this.setState({ selected: newSelected });
-  },
-  _formatItem(item) {
+  };
+
+  _formatItem = (item) => {
     let formattedItem;
 
     if (this.props.enableBulkActions) {
@@ -184,13 +184,15 @@ const TableList = React.createClass({
         </div>
       </ControlledTableList.Item>
     );
-  },
-  _onItemSelect(id) {
+  };
+
+  _onItemSelect = (id) => {
     return (event) => {
       const newSelected = event.target.checked ? this.state.selected.add(id) : this.state.selected.delete(id);
       this.setState({ selected: newSelected });
     };
-  },
+  };
+
   render() {
     let filter;
     if (this.props.enableFilter) {
@@ -233,7 +235,7 @@ const TableList = React.createClass({
         </ControlledTableList>
       </div>
     );
-  },
-});
+  }
+}
 
 export default TableList;

--- a/graylog2-web-interface/src/components/common/TimeUnit.jsx
+++ b/graylog2-web-interface/src/components/common/TimeUnit.jsx
@@ -1,11 +1,15 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 
+import createReactClass from 'create-react-class';
+
 /**
  * Component that renders a time value given in a certain unit.
  * It can also use 0 as never if `zeroIsNever` is set.
  */
-const TimeUnit = React.createClass({
+const TimeUnit = createReactClass({
+  displayName: 'TimeUnit',
+
   propTypes: {
     /** Value to display. */
     value: PropTypes.number.isRequired,

--- a/graylog2-web-interface/src/components/common/TimeUnitInput.jsx
+++ b/graylog2-web-interface/src/components/common/TimeUnitInput.jsx
@@ -1,5 +1,6 @@
 import PropTypes from 'prop-types';
 import React from 'react';
+import createReactClass from 'create-react-class';
 import {
   InputGroup, FormGroup, ControlLabel, FormControl, HelpBlock, DropdownButton, MenuItem
 } from 'react-bootstrap';
@@ -11,7 +12,9 @@ import { InputWrapper } from 'components/bootstrap';
  * and a select that let the user choose the unit used for the given time
  * value.
  */
-const TimeUnitInput = React.createClass({
+const TimeUnitInput = createReactClass({
+  displayName: 'TimeUnitInput',
+
   propTypes: {
     /**
      * Function that will be called when the input changes, that is,

--- a/graylog2-web-interface/src/components/common/Timestamp.jsx
+++ b/graylog2-web-interface/src/components/common/Timestamp.jsx
@@ -16,8 +16,8 @@ import DateTime from 'logic/datetimes/DateTime';
  * was used in the server.
  *
  */
-const Timestamp = React.createClass({
-  propTypes: {
+class Timestamp extends React.Component {
+  static propTypes = {
     /**
      * Date time to be displayed in the component. You can provide an ISO
      * 8601 string, a JS native `Date` object, or a moment `Date` object.
@@ -45,13 +45,13 @@ const Timestamp = React.createClass({
      * time zones supported by moment timezone.
      */
     tz: PropTypes.string,
-  },
-  getDefaultProps() {
-    return {
-      format: DateTime.Formats.TIMESTAMP,
-    };
-  },
-  _formatDateTime() {
+  };
+
+  static defaultProps = {
+    format: DateTime.Formats.TIMESTAMP,
+  };
+
+  _formatDateTime = () => {
     const dateTime = new DateTime(this.props.dateTime);
     if (this.props.relative) {
       return dateTime.toRelativeString();
@@ -66,14 +66,15 @@ const Timestamp = React.createClass({
         return dateTime.toTimeZone(this.props.tz).toString(this.props.format);
 
     }
-  },
+  };
+
   render() {
     return (
       <time key={`time-${this.props.dateTime}`} dateTime={this.props.dateTime} title={this.props.dateTime}>
         {this._formatDateTime()}
       </time>
     );
-  },
-});
+  }
+}
 
 export default Timestamp;

--- a/graylog2-web-interface/src/components/common/TimezoneSelect.jsx
+++ b/graylog2-web-interface/src/components/common/TimezoneSelect.jsx
@@ -14,8 +14,8 @@ import Select from 'components/common/Select';
  * the `Select` input behaves. Check the `Select` documentation for more
  * information.
  */
-const TimezoneSelect = React.createClass({
-  propTypes: {
+class TimezoneSelect extends React.Component {
+  static propTypes = {
     /**
      * Function that will be called when the selected timezone changes. The
      * function will receive the new time zone identifier as argument. See
@@ -23,17 +23,17 @@ const TimezoneSelect = React.createClass({
      * a list of time zone identifiers.
      */
     onChange: PropTypes.func,
-  },
+  };
 
-  getValue() {
+  getValue = () => {
     return this.refs.timezone.getValue();
-  },
+  };
 
   // Some time zones are not stored into any areas, this is the group we use to put them apart in the dropdown
   // https://en.wikipedia.org/wiki/List_of_tz_database_time_zones
-  _UNCLASSIFIED_AREA: 'Unclassified',
+  _UNCLASSIFIED_AREA = 'Unclassified';
 
-  _formatTimezones() {
+  _formatTimezones = () => {
     const timezones = {};
     // Group time zones by area
     moment.tz.names().forEach((timezone) => {
@@ -66,13 +66,15 @@ const TimezoneSelect = React.createClass({
       });
 
     return labels;
-  },
-  _renderOption(option) {
+  };
+
+  _renderOption = (option) => {
     if (!option.disabled) {
       return <span key={option.value} title={option.value}>&nbsp; {option.label}</span>;
     }
     return <span key={option.value} title={option.value}>{option.label}</span>;
-  },
+  };
+
   render() {
     const timezones = this._formatTimezones();
     const { onChange, ...otherProps } = this.props;
@@ -84,7 +86,7 @@ const TimezoneSelect = React.createClass({
               options={timezones}
               optionRenderer={this._renderOption} />
     );
-  },
-});
+  }
+}
 
 export default TimezoneSelect;

--- a/graylog2-web-interface/src/components/common/TypeAheadDataFilter.jsx
+++ b/graylog2-web-interface/src/components/common/TypeAheadDataFilter.jsx
@@ -13,8 +13,8 @@ import { TypeAheadInput } from 'components/common';
  * **Note** There are a few quirks around this component and it will be
  * refactored soon.
  */
-const TypeAheadDataFilter = React.createClass({
-  propTypes: {
+class TypeAheadDataFilter extends React.Component {
+  static propTypes = {
     /** ID to use in the filter input field. */
     id: PropTypes.string,
     /**
@@ -63,30 +63,33 @@ const TypeAheadDataFilter = React.createClass({
      * input field.
      */
     searchInKeys: PropTypes.array,
-  },
-  getInitialState() {
-    return {
-      filterText: '',
-      filters: Immutable.OrderedSet(),
-      filterByKey: `${this.props.filterBy}s`,
-    };
-  },
-  _onSearchTextChanged(event) {
+  };
+
+  state = {
+    filterText: '',
+    filters: Immutable.OrderedSet(),
+    filterByKey: `${this.props.filterBy}s`,
+  };
+
+  _onSearchTextChanged = (event) => {
     event.preventDefault();
     this.setState({ filterText: this.refs.typeAheadInput.getValue() }, this.filterData);
-  },
-  _onFilterAdded(event, suggestion) {
+  };
+
+  _onFilterAdded = (event, suggestion) => {
     this.setState({
       filters: this.state.filters.add(suggestion[this.props.displayKey]),
       filterText: '',
     }, this.filterData);
     this.refs.typeAheadInput.clear();
-  },
-  _onFilterRemoved(event) {
+  };
+
+  _onFilterRemoved = (event) => {
     event.preventDefault();
     this.setState({ filters: this.state.filters.delete(event.target.getAttribute('data-target')) }, this.filterData);
-  },
-  _matchFilters(datum) {
+  };
+
+  _matchFilters = (datum) => {
     return this.state.filters.every((filter) => {
       let dataToFilter = datum[this.state.filterByKey];
 
@@ -98,8 +101,9 @@ const TypeAheadDataFilter = React.createClass({
 
       return dataToFilter.indexOf(filter.toLocaleLowerCase()) !== -1;
     }, this);
-  },
-  _matchStringSearch(datum) {
+  };
+
+  _matchStringSearch = (datum) => {
     return this.props.searchInKeys.some((searchInKey) => {
       const key = datum[searchInKey];
       const value = this.state.filterText;
@@ -119,12 +123,14 @@ const TypeAheadDataFilter = React.createClass({
       }
       return containsFilter(key, value);
     }, this);
-  },
-  _resetFilters() {
+  };
+
+  _resetFilters = () => {
     this.refs.typeAheadInput.clear();
     this.setState({ filterText: '', filters: Immutable.OrderedSet() }, this.filterData);
-  },
-  filterData() {
+  };
+
+  filterData = () => {
     if (typeof this.props.filterData === 'function') {
       return this.props.filterData(this.props.data);
     }
@@ -134,7 +140,8 @@ const TypeAheadDataFilter = React.createClass({
     }, this);
 
     this.props.onDataFiltered(filteredData);
-  },
+  };
+
   render() {
     const filters = this.state.filters.map((filter) => {
       return (
@@ -178,7 +185,7 @@ const TypeAheadDataFilter = React.createClass({
         </ul>
       </div>
     );
-  },
-});
+  }
+}
 
 export default TypeAheadDataFilter;

--- a/graylog2-web-interface/src/components/common/TypeAheadFieldInput.jsx
+++ b/graylog2-web-interface/src/components/common/TypeAheadFieldInput.jsx
@@ -17,8 +17,8 @@ import fetch from 'logic/rest/FetchProvider';
  * Component that renders an input offering auto-completion for message fields.
  * Fields are loaded from the Graylog server in the background.
  */
-const TypeAheadFieldInput = React.createClass({
-  propTypes: {
+class TypeAheadFieldInput extends React.Component {
+  static propTypes = {
     /** ID of the input. */
     id: PropTypes.string.isRequired,
     /**
@@ -35,7 +35,8 @@ const TypeAheadFieldInput = React.createClass({
      * https://github.com/twitter/typeahead.js/blob/master/doc/jquery_typeahead.md#custom-events
      */
     onChange: PropTypes.func,
-  },
+  };
+
   componentDidMount() {
     if (this.refs.fieldInput) {
       const fieldInput = $(this.refs.fieldInput.getInputDOMNode());
@@ -70,7 +71,8 @@ const TypeAheadFieldInput = React.createClass({
         }
       });
     }
-  },
+  }
+
   componentWillUnmount() {
     if (this.refs.fieldInput) {
       const fieldInput = $(this.refs.fieldInput.getInputDOMNode());
@@ -78,9 +80,9 @@ const TypeAheadFieldInput = React.createClass({
       const fieldFormGroup = ReactDOM.findDOMNode(this.refs.fieldInput);
       $(fieldFormGroup).off('typeahead:change typeahead:selected');
     }
-  },
+  }
 
-  _getFilteredProps() {
+  _getFilteredProps = () => {
     let props = Immutable.fromJS(this.props);
 
     ['valueLink', 'onChange'].forEach((key) => {
@@ -90,7 +92,7 @@ const TypeAheadFieldInput = React.createClass({
     });
 
     return props.toJS();
-  },
+  };
 
   render() {
     return (
@@ -101,7 +103,7 @@ const TypeAheadFieldInput = React.createClass({
              defaultValue={this.props.valueLink ? this.props.valueLink.value : null}
              {...this._getFilteredProps()} />
     );
-  },
-});
+  }
+}
 
 export default TypeAheadFieldInput;

--- a/graylog2-web-interface/src/components/common/TypeAheadInput.jsx
+++ b/graylog2-web-interface/src/components/common/TypeAheadInput.jsx
@@ -13,8 +13,8 @@ import Typeahead from 'typeahead.js';
  * **Note** There are a few quirks around this component and it will be
  * refactored soon.
  */
-const TypeAheadInput = React.createClass({
-  propTypes: {
+class TypeAheadInput extends React.Component {
+  static propTypes = {
     /** ID to use in the input field. */
     id: PropTypes.string.isRequired,
     /** Label to use for the input field. */
@@ -51,36 +51,39 @@ const TypeAheadInput = React.createClass({
      *
      */
     onSuggestionSelected: PropTypes.func,
-  },
+  };
 
-  getDefaultProps() {
-    return {
-      displayKey: 'suggestion',
-    };
-  },
+  static defaultProps = {
+    displayKey: 'suggestion',
+  };
 
   componentDidMount() {
     this._updateTypeahead(this.props);
-  },
+  }
+
   componentWillReceiveProps(newProps) {
     this._destroyTypeahead();
     this._updateTypeahead(newProps);
-  },
+  }
+
   componentWillUnmount() {
     this._destroyTypeahead();
-  },
+  }
 
-  getValue() {
+  getValue = () => {
     return $(this.fieldInput).typeahead('val');
-  },
-  clear() {
+  };
+
+  clear = () => {
     $(this.fieldInput).typeahead('val', '');
-  },
-  _destroyTypeahead() {
+  };
+
+  _destroyTypeahead = () => {
     $(this.fieldInput).typeahead('destroy');
     $(this.fieldFormGroup).off('typeahead:select typeahead:autocomplete');
-  },
-  _updateTypeahead(props) {
+  };
+
+  _updateTypeahead = (props) => {
     this.fieldInput = this.refs.fieldInput.getInputDOMNode();
     this.fieldFormGroup = ReactDOM.findDOMNode(this.refs.fieldInput);
 
@@ -115,7 +118,8 @@ const TypeAheadInput = React.createClass({
         props.onSuggestionSelected(event, suggestion);
       }
     });
-  },
+  };
+
   render() {
     return (<Input id={this.props.id}
                    type="text"
@@ -123,7 +127,7 @@ const TypeAheadInput = React.createClass({
                    wrapperClassName="typeahead-wrapper"
                    label={this.props.label}
                    onKeyPress={this.props.onKeyPress} />);
-  },
-});
+  }
+}
 
 export default TypeAheadInput;

--- a/graylog2-web-interface/src/components/configurationforms/BooleanField.jsx
+++ b/graylog2-web-interface/src/components/configurationforms/BooleanField.jsx
@@ -4,15 +4,16 @@ import FieldHelpers from './FieldHelpers';
 
 import FormsUtils from 'util/FormsUtils';
 
-const BooleanField = React.createClass({
-  propTypes: {
+class BooleanField extends React.Component {
+  static propTypes = {
     autoFocus: PropTypes.bool,
     field: PropTypes.object.isRequired,
     onChange: PropTypes.func.isRequired,
     title: PropTypes.string.isRequired,
     typeName: PropTypes.string.isRequired,
     value: PropTypes.any,
-  },
+  };
+
   render() {
     const field = this.props.field;
     const typeName = this.props.typeName;
@@ -35,11 +36,12 @@ const BooleanField = React.createClass({
         <p className="help-block">{field.description}</p>
       </div>
     );
-  },
-  handleChange(event) {
+  }
+
+  handleChange = (event) => {
     const newValue = FormsUtils.getValueFromInput(event.target);
     this.props.onChange(this.props.title, newValue);
-  },
-});
+  };
+}
 
 export default BooleanField;

--- a/graylog2-web-interface/src/components/configurationforms/ConfigurationForm.jsx
+++ b/graylog2-web-interface/src/components/configurationforms/ConfigurationForm.jsx
@@ -2,6 +2,8 @@ import $ from 'jquery';
 import PropTypes from 'prop-types';
 import React from 'react';
 
+import createReactClass from 'create-react-class';
+
 import BootstrapModalForm from 'components/bootstrap/BootstrapModalForm';
 import {
   BooleanField,
@@ -12,7 +14,9 @@ import {
   TitleField,
 } from 'components/configurationforms';
 
-const ConfigurationForm = React.createClass({
+const ConfigurationForm = createReactClass({
+  displayName: 'ConfigurationForm',
+
   propTypes: {
     cancelAction: PropTypes.func,
     children: PropTypes.node,
@@ -32,15 +36,18 @@ const ConfigurationForm = React.createClass({
       values: {},
     };
   },
+
   getInitialState() {
     return this._copyStateFromProps(this.props);
   },
+
   componentWillReceiveProps(props) {
     const newState = this._copyStateFromProps(props);
     const values = this.state ? this.state.values : {};
     newState.values = $.extend(newState.values, values);
     this.setState(newState);
   },
+
   getValue() {
     const data = {};
     const values = this.state.values;
@@ -57,6 +64,7 @@ const ConfigurationForm = React.createClass({
 
     return data;
   },
+
   _copyStateFromProps(props) {
     const effectiveTitleValue = (this.state && this.state.titleValue !== undefined ? this.state.titleValue : props.titleValue);
     const defaultValues = {};
@@ -73,32 +81,39 @@ const ConfigurationForm = React.createClass({
       titleValue: effectiveTitleValue,
     };
   },
+
   _sortByOptionality(x1, x2) {
     return (this.state.configFields[x1].is_optional - this.state.configFields[x2].is_optional);
   },
+
   _save() {
     const data = this.getValue();
 
     this.props.submitAction(data);
     this.refs.modal.close();
   },
+
   open() {
     this.refs.modal.open();
   },
+
   _closeModal() {
     this.setState($.extend(this.getInitialState(), { titleValue: this.props.titleValue }));
     if (this.props.cancelAction) {
       this.props.cancelAction();
     }
   },
+
   _handleTitleChange(field, value) {
     this.setState({ titleValue: value });
   },
+
   _handleChange(field, value) {
     const values = this.state.values;
     values[field] = value;
     this.setState({ values: values });
   },
+
   _renderConfigField(configField, key, autoFocus) {
     const value = this.state.values[key];
     const typeName = this.props.typeName;
@@ -124,6 +139,7 @@ const ConfigurationForm = React.createClass({
         return null;
     }
   },
+
   render() {
     const typeName = this.props.typeName;
     const title = this.props.title;

--- a/graylog2-web-interface/src/components/configurationforms/ConfigurationWell.jsx
+++ b/graylog2-web-interface/src/components/configurationforms/ConfigurationWell.jsx
@@ -1,14 +1,16 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 
-const ConfigurationWell = React.createClass({
-  propTypes: {
+class ConfigurationWell extends React.Component {
+  static propTypes = {
     id: PropTypes.string,
     configuration: PropTypes.any,
     typeDefinition: PropTypes.object,
-  },
-  PASSWORD_PLACEHOLDER: '********',
-  _formatRegularField(value, key) {
+  };
+
+  PASSWORD_PLACEHOLDER = '********';
+
+  _formatRegularField = (value, key) => {
     let finalValue;
     if (value === null || value === undefined || value === '' || (Array.isArray(value) && value.length === 0)) {
       finalValue = <i>{'<empty>'}</i>;
@@ -17,11 +19,13 @@ const ConfigurationWell = React.createClass({
     }
 
     return (<li key={`${this.props.id}-${key}`}><div className="key">{key}:</div> <div className="value">{finalValue}</div></li>);
-  },
-  _formatPasswordField(value, key) {
+  };
+
+  _formatPasswordField = (value, key) => {
     return (<li key={`${this.props.id}-${key}`}><div className="key">{key}:</div> <div className="value">{this.PASSWORD_PLACEHOLDER}</div></li>);
-  },
-  _formatConfiguration(id, config, typeDefinition) {
+  };
+
+  _formatConfiguration = (id, config, typeDefinition) => {
     if (!config) {
       return ('');
     }
@@ -43,14 +47,15 @@ const ConfigurationWell = React.createClass({
         {formattedItems}
       </ul>
     );
-  },
+  };
+
   render() {
     return (
       <div className="well well-small configuration-well react-configuration-well">
         {this._formatConfiguration(this.props.id, this.props.configuration, this.props.typeDefinition)}
       </div>
     );
-  },
-});
+  }
+}
 
 export default ConfigurationWell;

--- a/graylog2-web-interface/src/components/configurationforms/DropdownField.jsx
+++ b/graylog2-web-interface/src/components/configurationforms/DropdownField.jsx
@@ -5,8 +5,8 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import FieldHelpers from 'components/configurationforms/FieldHelpers';
 
-const DropdownField = React.createClass({
-  propTypes: {
+class DropdownField extends React.Component {
+  static propTypes = {
     autoFocus: PropTypes.bool.isRequired,
     field: PropTypes.object.isRequired,
     onChange: PropTypes.func.isRequired,
@@ -15,32 +15,34 @@ const DropdownField = React.createClass({
     value: PropTypes.any,
     addPlaceholder: PropTypes.bool,
     disabled: PropTypes.bool,
-  },
-  getDefaultProps() {
-    return {
-      addPlaceholder: false,
-    };
-  },
-  getInitialState() {
-    return {
-      typeName: this.props.typeName,
-      field: this.props.field,
-      title: this.props.title,
-      value: this.props.value,
-    };
-  },
+  };
+
+  static defaultProps = {
+    addPlaceholder: false,
+  };
+
+  state = {
+    typeName: this.props.typeName,
+    field: this.props.field,
+    title: this.props.title,
+    value: this.props.value,
+  };
+
   componentWillReceiveProps(props) {
     this.setState(props);
-  },
-  _formatOption(value, key, disabled) {
+  }
+
+  _formatOption = (value, key, disabled) => {
     return (
       <option key={`${this.state.typeName}-${this.state.title}-${key}`} value={key} id={key} disabled={disabled}>{value}</option>
     );
-  },
-  handleChange(evt) {
+  };
+
+  handleChange = (evt) => {
     this.props.onChange(this.state.title, evt.target.value);
     this.setState({ value: evt.target.value });
-  },
+  };
+
   render() {
     const field = this.state.field;
     const options = $.map(field.additional_info.values, this._formatOption);
@@ -64,7 +66,7 @@ const DropdownField = React.createClass({
         <p className="help-block">{field.description}</p>
       </div>
     );
-  },
-});
+  }
+}
 
 export default DropdownField;

--- a/graylog2-web-interface/src/components/configurationforms/ListField.jsx
+++ b/graylog2-web-interface/src/components/configurationforms/ListField.jsx
@@ -4,8 +4,8 @@ import React from 'react';
 import { MultiSelect } from 'components/common';
 import { FieldHelpers } from 'components/configurationforms';
 
-const ListField = React.createClass({
-  propTypes: {
+class ListField extends React.Component {
+  static propTypes = {
     autoFocus: PropTypes.bool.isRequired,
     field: PropTypes.object.isRequired,
     onChange: PropTypes.func.isRequired,
@@ -14,36 +14,32 @@ const ListField = React.createClass({
     value: PropTypes.oneOfType([PropTypes.array, PropTypes.string]),
     addPlaceholder: PropTypes.bool,
     disabled: PropTypes.bool,
-  },
+  };
 
-  getDefaultProps() {
-    return {
-      addPlaceholder: false,
-    };
-  },
+  static defaultProps = {
+    addPlaceholder: false,
+  };
 
-  getInitialState() {
-    return {
-      typeName: this.props.typeName,
-      field: this.props.field,
-      title: this.props.title,
-      value: this.props.value,
-    };
-  },
+  state = {
+    typeName: this.props.typeName,
+    field: this.props.field,
+    title: this.props.title,
+    value: this.props.value,
+  };
 
   componentWillReceiveProps(props) {
     this.setState(props);
-  },
+  }
 
-  _formatOption(key, value) {
+  _formatOption = (key, value) => {
     return { value: value, label: key };
-  },
+  };
 
-  _handleChange(nextValue) {
+  _handleChange = (nextValue) => {
     const values = (nextValue === '' ? [] : nextValue.split(','));
     this.props.onChange(this.state.title, values);
     this.setState({ value: values });
-  },
+  };
 
   render() {
     const field = this.state.field;
@@ -75,7 +71,7 @@ const ListField = React.createClass({
         <p className="help-block">{field.description}</p>
       </div>
     );
-  },
-});
+  }
+}
 
 export default ListField;

--- a/graylog2-web-interface/src/components/configurationforms/NumberField.jsx
+++ b/graylog2-web-interface/src/components/configurationforms/NumberField.jsx
@@ -1,10 +1,13 @@
 import PropTypes from 'prop-types';
 import React from 'react';
+import createReactClass from 'create-react-class';
 import FieldHelpers from './FieldHelpers';
 
 import FormsUtils from 'util/FormsUtils';
 
-const NumberField = React.createClass({
+const NumberField = createReactClass({
+  displayName: 'NumberField',
+
   propTypes: {
     autoFocus: PropTypes.bool,
     field: PropTypes.object.isRequired,
@@ -13,11 +16,14 @@ const NumberField = React.createClass({
     typeName: PropTypes.string.isRequired,
     value: PropTypes.any,
   },
+
   MAX_SAFE_INTEGER: (Number.MAX_SAFE_INTEGER !== undefined ? Number.MAX_SAFE_INTEGER : Math.pow(2, 53) - 1),
   MIN_SAFE_INTEGER: (Number.MIN_SAFE_INTEGER !== undefined ? Number.MIN_SAFE_INTEGER : -1 * (Math.pow(2, 53) - 1)),
+
   _getDefaultValidationSpecs() {
     return { min: this.MIN_SAFE_INTEGER, max: this.MAX_SAFE_INTEGER };
   },
+
   mapValidationAttribute(attribute) {
     switch (attribute.toLocaleUpperCase()) {
       case 'ONLY_NEGATIVE': return { min: this.MIN_SAFE_INTEGER, max: -1 };
@@ -26,6 +32,7 @@ const NumberField = React.createClass({
       default: return this._getDefaultValidationSpecs();
     }
   },
+
   validationSpec(field) {
     const validationAttributes = field.attributes.map(this.mapValidationAttribute);
     if (validationAttributes.length > 0) {
@@ -36,10 +43,12 @@ const NumberField = React.createClass({
 
     return this._getDefaultValidationSpecs();
   },
+
   handleChange(evt) {
     const numericValue = FormsUtils.getValueFromInput(evt.target);
     this.props.onChange(this.props.title, numericValue);
   },
+
   render() {
     const typeName = this.props.typeName;
     const field = this.props.field;

--- a/graylog2-web-interface/src/components/configurationforms/TextField.jsx
+++ b/graylog2-web-interface/src/components/configurationforms/TextField.jsx
@@ -2,30 +2,32 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import FieldHelpers from 'components/configurationforms/FieldHelpers';
 
-const TextField = React.createClass({
-  propTypes: {
+class TextField extends React.Component {
+  static propTypes = {
     autoFocus: PropTypes.bool,
     field: PropTypes.object.isRequired,
     onChange: PropTypes.func.isRequired,
     title: PropTypes.string.isRequired,
     typeName: PropTypes.string.isRequired,
     value: PropTypes.any,
-  },
-  getInitialState() {
-    return {
-      typeName: this.props.typeName,
-      field: this.props.field,
-      title: this.props.title,
-      value: this.props.value,
-    };
-  },
+  };
+
+  state = {
+    typeName: this.props.typeName,
+    field: this.props.field,
+    title: this.props.title,
+    value: this.props.value,
+  };
+
   componentWillReceiveProps(props) {
     this.setState(props);
-  },
-  handleChange(evt) {
+  }
+
+  handleChange = (evt) => {
     this.props.onChange(this.state.title, evt.target.value);
     this.setState({ value: evt.target.value });
-  },
+  };
+
   render() {
     const field = this.state.field;
     const title = this.state.title;
@@ -59,7 +61,7 @@ const TextField = React.createClass({
         <p className="help-block">{field.description}</p>
       </div>
     );
-  },
-});
+  }
+}
 
 export default TextField;

--- a/graylog2-web-interface/src/components/configurationforms/TitleField.jsx
+++ b/graylog2-web-interface/src/components/configurationforms/TitleField.jsx
@@ -3,19 +3,18 @@ import React from 'react';
 
 import { TextField } from 'components/configurationforms';
 
-const TitleField = React.createClass({
-  propTypes: {
+class TitleField extends React.Component {
+  static propTypes = {
     helpBlock: PropTypes.node,
     onChange: PropTypes.func,
     typeName: PropTypes.string.isRequired,
     value: PropTypes.any,
-  },
-  getDefaultProps() {
-    return {
-      helpBlock: <span />,
-      onChange: () => {},
-    };
-  },
+  };
+
+  static defaultProps = {
+    helpBlock: <span />,
+    onChange: () => {},
+  };
 
   render() {
     const typeName = this.props.typeName;
@@ -24,7 +23,7 @@ const TitleField = React.createClass({
       <TextField key={`${typeName}-title`} typeName={typeName} title="title" field={titleField}
                                  value={this.props.value} onChange={this.props.onChange} autoFocus />
     );
-  },
-});
+  }
+}
 
 export default TitleField;

--- a/graylog2-web-interface/src/components/configurations/MessageProcessorsConfig.jsx
+++ b/graylog2-web-interface/src/components/configurations/MessageProcessorsConfig.jsx
@@ -1,12 +1,15 @@
 import PropTypes from 'prop-types';
 import React from 'react';
+import createReactClass from 'create-react-class';
 import { Button, Alert, Table } from 'react-bootstrap';
 import BootstrapModalForm from 'components/bootstrap/BootstrapModalForm';
 import { IfPermitted, SortableList } from 'components/common';
 import ObjectUtils from 'util/ObjectUtils';
 import naturalSort from 'javascript-natural-sort';
 
-const MessageProcessorsConfig = React.createClass({
+const MessageProcessorsConfig = createReactClass({
+  displayName: 'MessageProcessorsConfig',
+
   propTypes: {
     config: PropTypes.object.isRequired,
     updateConfig: PropTypes.func.isRequired,

--- a/graylog2-web-interface/src/components/configurations/SearchesConfig.jsx
+++ b/graylog2-web-interface/src/components/configurations/SearchesConfig.jsx
@@ -1,5 +1,6 @@
 import PropTypes from 'prop-types';
 import React from 'react';
+import createReactClass from 'create-react-class';
 import { Button, Row, Col } from 'react-bootstrap';
 import { BootstrapModalForm, Input } from 'components/bootstrap';
 import { IfPermitted, ISODurationInput } from 'components/common';
@@ -11,7 +12,9 @@ import {} from 'moment-duration-format';
 import TimeRangeOptionsForm from './TimeRangeOptionsForm';
 import TimeRangeOptionsSummary from './TimeRangeOptionsSummary';
 
-const SearchesConfig = React.createClass({
+const SearchesConfig = createReactClass({
+  displayName: 'SearchesConfig',
+
   propTypes: {
     config: PropTypes.object.isRequired,
     updateConfig: PropTypes.func.isRequired,

--- a/graylog2-web-interface/src/components/configurations/TimeRangeOptionsForm.jsx
+++ b/graylog2-web-interface/src/components/configurations/TimeRangeOptionsForm.jsx
@@ -8,38 +8,36 @@ import ObjectUtils from 'util/ObjectUtils';
 /**
  * Expects `this.props.options` to be an array of period/description objects. `[{period: 'PT1S', description: 'yo'}]`
  */
-const TimeRangeOptionsForm = React.createClass({
-  propTypes: {
+class TimeRangeOptionsForm extends React.Component {
+  static propTypes = {
     options: PropTypes.array,
     title: PropTypes.string.isRequired,
     help: PropTypes.any.isRequired,
     addButtonTitle: PropTypes.string,
     update: PropTypes.func.isRequired,
     validator: PropTypes.func,
-  },
+  };
 
-  getDefaultProps() {
-    return {
-      options: [],
-      addButtonTitle: 'Add option',
-      validator: () => true,
-    };
-  },
+  static defaultProps = {
+    options: [],
+    addButtonTitle: 'Add option',
+    validator: () => true,
+  };
 
-  _update(options) {
+  _update = (options) => {
     this.props.update(options);
-  },
+  };
 
-  _onAdd() {
+  _onAdd = () => {
     const options = ObjectUtils.clone(this.props.options);
 
     if (options) {
       options.push({ period: '', description: '' });
       this._update(options);
     }
-  },
+  };
 
-  _onRemove(removedIdx) {
+  _onRemove = (removedIdx) => {
     return () => {
       const options = ObjectUtils.clone(this.props.options);
 
@@ -48,9 +46,9 @@ const TimeRangeOptionsForm = React.createClass({
 
       this._update(options);
     };
-  },
+  };
 
-  _onChange(changedIdx, field) {
+  _onChange = (changedIdx, field) => {
     return (e) => {
       const options = ObjectUtils.clone(this.props.options);
 
@@ -71,10 +69,9 @@ const TimeRangeOptionsForm = React.createClass({
 
       this._update(options);
     };
-  },
+  };
 
-
-  _buildTimeRangeOptions() {
+  _buildTimeRangeOptions = () => {
     return this.props.options.map((option, idx) => {
       const period = option.period;
       const description = option.description;
@@ -107,7 +104,7 @@ const TimeRangeOptionsForm = React.createClass({
         </div>
       );
     });
-  },
+  };
 
   render() {
     return (
@@ -120,7 +117,7 @@ const TimeRangeOptionsForm = React.createClass({
         <Button bsSize="xs" onClick={this._onAdd}>{this.props.addButtonTitle}</Button>
       </div>
     );
-  },
-});
+  }
+}
 
 export default TimeRangeOptionsForm;

--- a/graylog2-web-interface/src/components/configurations/TimeRangeOptionsSummary.jsx
+++ b/graylog2-web-interface/src/components/configurations/TimeRangeOptionsSummary.jsx
@@ -1,10 +1,10 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 
-const TimeRangeOptionsSummary = React.createClass({
-  propTypes: {
+class TimeRangeOptionsSummary extends React.Component {
+  static propTypes = {
     options: PropTypes.object.isRequired,
-  },
+  };
 
   render() {
     let timerangeOptionsSummary = null;
@@ -24,7 +24,7 @@ const TimeRangeOptionsSummary = React.createClass({
         {timerangeOptionsSummary}
       </dl>
     );
-  },
-});
+  }
+}
 
 export default TimeRangeOptionsSummary;

--- a/graylog2-web-interface/src/components/dashboard/AddToDashboardMenu.jsx
+++ b/graylog2-web-interface/src/components/dashboard/AddToDashboardMenu.jsx
@@ -1,5 +1,6 @@
 import PropTypes from 'prop-types';
 import React from 'react';
+import createReactClass from 'create-react-class';
 import Reflux from 'reflux';
 import { ButtonGroup, ButtonToolbar, DropdownButton, MenuItem } from 'react-bootstrap';
 import Immutable from 'immutable';
@@ -17,7 +18,9 @@ import { EditDashboardModal } from 'components/dashboard';
 
 import style from './AddToDashboardMenu.css';
 
-const AddToDashboardMenu = React.createClass({
+const AddToDashboardMenu = createReactClass({
+  displayName: 'AddToDashboardMenu',
+
   propTypes: {
     widgetType: PropTypes.string.isRequired,
     title: PropTypes.string.isRequired,
@@ -59,6 +62,7 @@ const AddToDashboardMenu = React.createClass({
     this.setState({ selectedDashboard: dashboardId });
     this.refs.widgetModal.open();
   },
+
   _saveWidget(title, configuration) {
     let widgetConfig = Immutable.Map(this.props.configuration);
     let searchParams = Immutable.Map(SearchStore.getOriginalSearchParams());
@@ -118,9 +122,11 @@ const AddToDashboardMenu = React.createClass({
       .then(() => this.refs.widgetModal.saved())
       .finally(() => this.setState({ loading: false }));
   },
+
   _createNewDashboard() {
     this.refs.createDashboardModal.open();
   },
+
   _renderLoadingDashboardsMenu() {
     return (
       <DropdownButton bsStyle={this.props.bsStyle}
@@ -132,6 +138,7 @@ const AddToDashboardMenu = React.createClass({
       </DropdownButton>
     );
   },
+
   _renderDashboardMenu() {
     let dashboards = Immutable.List();
 
@@ -156,6 +163,7 @@ const AddToDashboardMenu = React.createClass({
       </DropdownButton>
     );
   },
+
   _renderNoDashboardsMenu() {
     const canCreateDashboard = this.isPermitted(this.props.permissions, ['dashboards:create']);
     let option;
@@ -179,6 +187,7 @@ const AddToDashboardMenu = React.createClass({
       </div>
     );
   },
+
   render() {
     let addToDashboardMenu;
     if (this.state.writableDashboards === undefined) {

--- a/graylog2-web-interface/src/components/dashboard/Dashboard.jsx
+++ b/graylog2-web-interface/src/components/dashboard/Dashboard.jsx
@@ -1,5 +1,6 @@
 import PropTypes from 'prop-types';
 import React from 'react';
+import createReactClass from 'create-react-class';
 import Reflux from 'reflux';
 import { DropdownButton, MenuItem } from 'react-bootstrap';
 import { Link } from 'react-router';
@@ -16,20 +17,26 @@ const StartpageStore = StoreProvider.getStore('Startpage');
 
 import Routes from 'routing/Routes';
 
-const Dashboard = React.createClass({
+const Dashboard = createReactClass({
+  displayName: 'Dashboard',
+
   propTypes: {
     dashboard: PropTypes.object,
     permissions: PropTypes.arrayOf(PropTypes.string),
   },
+
   mixins: [PermissionsMixin, Reflux.connect(CurrentUserStore)],
+
   _setStartpage() {
     StartpageStore.set(this.state.currentUser.username, 'dashboard', this.props.dashboard.id);
   },
+
   _onDashboardDelete() {
     if (window.confirm(`Do you really want to delete the dashboard ${this.props.dashboard.title}?`)) {
       DashboardsActions.delete(this.props.dashboard);
     }
   },
+
   _getDashboardActions() {
     let dashboardActions;
     const setAsStartpageMenuItem = (
@@ -61,6 +68,7 @@ const Dashboard = React.createClass({
 
     return dashboardActions;
   },
+
   render() {
     const createdFromContentPack = (this.props.dashboard.content_pack ?
       <i className="fa fa-cube" title="Created from content pack" /> : null);

--- a/graylog2-web-interface/src/components/dashboard/DashboardList.jsx
+++ b/graylog2-web-interface/src/components/dashboard/DashboardList.jsx
@@ -1,5 +1,6 @@
 import PropTypes from 'prop-types';
 import React from 'react';
+import createReactClass from 'create-react-class';
 import ImmutablePropTypes from 'react-immutable-proptypes';
 import { Alert } from 'react-bootstrap';
 
@@ -7,18 +8,23 @@ import Dashboard from './Dashboard';
 import EditDashboardModalTrigger from './EditDashboardModalTrigger';
 import PermissionsMixin from '../../util/PermissionsMixin';
 
-const DashboardList = React.createClass({
+const DashboardList = createReactClass({
+  displayName: 'DashboardList',
+
   propTypes: {
     dashboards: ImmutablePropTypes.list,
     onDashboardAdd: PropTypes.func,
     permissions: PropTypes.arrayOf(PropTypes.string),
   },
+
   mixins: [PermissionsMixin],
+
   _formatDashboard(dashboard) {
     return (
       <Dashboard key={`dashboard-${dashboard.id}`} dashboard={dashboard} permissions={this.props.permissions} />
     );
   },
+
   render() {
     if (this.props.dashboards.isEmpty()) {
       let createDashboardButton;

--- a/graylog2-web-interface/src/components/dashboard/DashboardListPage.jsx
+++ b/graylog2-web-interface/src/components/dashboard/DashboardListPage.jsx
@@ -1,5 +1,6 @@
 import PropTypes from 'prop-types';
 import React from 'react';
+import createReactClass from 'create-react-class';
 import Reflux from 'reflux';
 import Immutable from 'immutable';
 import { Row, Col } from 'react-bootstrap';
@@ -17,19 +18,25 @@ import PageHeader from 'components/common/PageHeader';
 import DashboardList from './DashboardList';
 import EditDashboardModalTrigger from './EditDashboardModalTrigger';
 
-const DashboardListPage = React.createClass({
+const DashboardListPage = createReactClass({
+  displayName: 'DashboardListPage',
+
   propTypes: {
     permissions: PropTypes.arrayOf(PropTypes.string),
   },
+
   mixins: [Reflux.connect(DashboardsStore, 'dashboards'), PermissionsMixin],
+
   getInitialState() {
     return {
       dashboardsLoaded: false,
     };
   },
+
   componentDidMount() {
     DashboardsActions.list();
   },
+
   render() {
     const { dashboards } = this.state.dashboards;
     const filteredDashboards = dashboards;

--- a/graylog2-web-interface/src/components/dashboard/EditDashboardModal.jsx
+++ b/graylog2-web-interface/src/components/dashboard/EditDashboardModal.jsx
@@ -3,6 +3,7 @@ import $ from 'jquery';
 import PropTypes from 'prop-types';
 
 import React from 'react';
+import createReactClass from 'create-react-class';
 import { Input } from 'components/bootstrap';
 
 import BootstrapModalForm from '../bootstrap/BootstrapModalForm';
@@ -10,7 +11,9 @@ import BootstrapModalForm from '../bootstrap/BootstrapModalForm';
 import CombinedProvider from 'injection/CombinedProvider';
 const { DashboardsActions } = CombinedProvider.get('Dashboards');
 
-const EditDashboardModal = React.createClass({
+const EditDashboardModal = createReactClass({
+  displayName: 'EditDashboardModal',
+
   propTypes: {
     action: PropTypes.oneOf(['create', 'edit']),
     description: PropTypes.string,
@@ -18,6 +21,7 @@ const EditDashboardModal = React.createClass({
     onSaved: PropTypes.func,
     title: PropTypes.string,
   },
+
   getInitialState() {
     return {
       id: this.props.id,
@@ -25,11 +29,13 @@ const EditDashboardModal = React.createClass({
       title: this.props.title,
     };
   },
+
   getDefaultProps() {
     return {
       action: 'create',
     };
   },
+
   render() {
     return (
       <BootstrapModalForm ref="modal"
@@ -43,12 +49,15 @@ const EditDashboardModal = React.createClass({
       </BootstrapModalForm>
     );
   },
+
   close() {
     this.refs.modal.close();
   },
+
   open() {
     this.refs.modal.open();
   },
+
   _save() {
     let promise;
 
@@ -85,12 +94,15 @@ const EditDashboardModal = React.createClass({
       });
     }
   },
+
   _onDescriptionChange(event) {
     this.setState({ description: event.target.value });
   },
+
   _onTitleChange(event) {
     this.setState({ title: event.target.value });
   },
+
   _isCreateModal() {
     return this.props.action === 'create';
   },

--- a/graylog2-web-interface/src/components/dashboard/EditDashboardModalTrigger.jsx
+++ b/graylog2-web-interface/src/components/dashboard/EditDashboardModalTrigger.jsx
@@ -3,21 +3,23 @@ import React from 'react';
 
 import { EditDashboardModal } from 'components/dashboard';
 
-const EditDashboardModalTrigger = React.createClass({
-  propTypes: {
+class EditDashboardModalTrigger extends React.Component {
+  static propTypes = {
     action: PropTypes.string.isRequired,
-  },
-  getDefaultProps() {
-    return {
-      action: 'create',
-    };
-  },
-  _isCreateModal() {
+  };
+
+  static defaultProps = {
+    action: 'create',
+  };
+
+  _isCreateModal = () => {
     return this.props.action === 'create';
-  },
-  openModal() {
+  };
+
+  openModal = () => {
     this.refs.modal.open();
-  },
+  };
+
   render() {
     let triggerButtonContent;
 
@@ -36,7 +38,7 @@ const EditDashboardModalTrigger = React.createClass({
         <EditDashboardModal ref="modal" {...this.props} />
       </span>
     );
-  },
-});
+  }
+}
 
 export default EditDashboardModalTrigger;

--- a/graylog2-web-interface/src/components/enterprise/PluginList.jsx
+++ b/graylog2-web-interface/src/components/enterprise/PluginList.jsx
@@ -1,9 +1,12 @@
 import React from 'react';
+import createReactClass from 'create-react-class';
 import { Row, Col } from 'react-bootstrap';
 
 import { PluginStore } from 'graylog-web-plugin/plugin';
 
-const PluginList = React.createClass({
+const PluginList = createReactClass({
+  displayName: 'PluginList',
+
   componentDidMount() {
     this.style.use();
   },

--- a/graylog2-web-interface/src/components/extractors/AddExtractorWizard.jsx
+++ b/graylog2-web-interface/src/components/extractors/AddExtractorWizard.jsx
@@ -5,18 +5,19 @@ import { Row, Col, Button } from 'react-bootstrap';
 import LoaderTabs from 'components/messageloaders/LoaderTabs';
 import MessageFieldExtractorActions from 'components/search/MessageFieldExtractorActions';
 
-const AddExtractorWizard = React.createClass({
-  propTypes: {
+class AddExtractorWizard extends React.Component {
+  static propTypes = {
     inputId: PropTypes.string,
-  },
-  getInitialState() {
-    return {
-      showExtractorForm: false,
-    };
-  },
-  _showAddExtractorForm() {
+  };
+
+  state = {
+    showExtractorForm: false,
+  };
+
+  _showAddExtractorForm = () => {
     this.setState({ showExtractorForm: !this.state.showExtractorForm });
-  },
+  };
+
   render() {
     let extractorForm;
 
@@ -49,7 +50,7 @@ const AddExtractorWizard = React.createClass({
         </Col>
       </Row>
     );
-  },
-});
+  }
+}
 
 export default AddExtractorWizard;

--- a/graylog2-web-interface/src/components/extractors/EditExtractor.jsx
+++ b/graylog2-web-interface/src/components/extractors/EditExtractor.jsx
@@ -16,34 +16,33 @@ import FormUtils from 'util/FormsUtils';
 import StoreProvider from 'injection/StoreProvider';
 const ToolsStore = StoreProvider.getStore('Tools');
 
-const EditExtractor = React.createClass({
-  propTypes: {
+class EditExtractor extends React.Component {
+  static propTypes = {
     action: PropTypes.oneOf(['create', 'edit']).isRequired,
     extractor: PropTypes.object.isRequired,
     inputId: PropTypes.string.isRequired,
     exampleMessage: PropTypes.string,
     onSave: PropTypes.func.isRequired,
-  },
-  getInitialState() {
-    return {
-      updatedExtractor: this.props.extractor,
-      conditionTestResult: undefined,
-      exampleMessage: this.props.exampleMessage,
-    };
-  },
+  };
+
+  state = {
+    updatedExtractor: this.props.extractor,
+    conditionTestResult: undefined,
+    exampleMessage: this.props.exampleMessage,
+  };
 
   componentWillReceiveProps(nextProps) {
     if (this.props.exampleMessage !== nextProps.exampleMessage) {
       this._updateExampleMessage(nextProps.exampleMessage);
     }
-  },
+  }
 
-  _updateExampleMessage(nextExample) {
+  _updateExampleMessage = (nextExample) => {
     this.setState({ exampleMessage: nextExample });
-  },
+  };
 
   // Ensures the target field only contains alphanumeric characters and underscores
-  _onTargetFieldChange(event) {
+  _onTargetFieldChange = (event) => {
     const value = event.target.value;
     const newValue = value.replace(/[^\w\d_]/g, '');
 
@@ -52,8 +51,9 @@ const EditExtractor = React.createClass({
     }
 
     this._onFieldChange('target_field')(event);
-  },
-  _onFieldChange(key) {
+  };
+
+  _onFieldChange = (key) => {
     return (event) => {
       const nextState = {};
       const updatedExtractor = this.state.updatedExtractor;
@@ -67,13 +67,15 @@ const EditExtractor = React.createClass({
 
       this.setState(nextState);
     };
-  },
-  _onConfigurationChange(newConfiguration) {
+  };
+
+  _onConfigurationChange = (newConfiguration) => {
     const updatedExtractor = this.state.updatedExtractor;
     updatedExtractor.extractor_config = newConfiguration;
     this.setState({ updatedExtractor: updatedExtractor });
-  },
-  _onConverterChange(converterType, newConverter) {
+  };
+
+  _onConverterChange = (converterType, newConverter) => {
     const updatedExtractor = this.state.updatedExtractor;
     const previousConverter = updatedExtractor.converters.filter(converter => converter.type === converterType)[0];
 
@@ -88,17 +90,20 @@ const EditExtractor = React.createClass({
     }
 
     this.setState({ updatedExtractor: updatedExtractor });
-  },
-  _testCondition() {
+  };
+
+  _testCondition = () => {
     const updatedExtractor = this.state.updatedExtractor;
     const tester = (updatedExtractor.condition_type === 'string' ? ToolsStore.testContainsString : ToolsStore.testRegex);
     const promise = tester(updatedExtractor.condition_value, this.state.exampleMessage);
     promise.then(result => this.setState({ conditionTestResult: result.matched }));
-  },
-  _tryButtonDisabled() {
+  };
+
+  _tryButtonDisabled = () => {
     return this.state.updatedExtractor.condition_value === '' || this.state.updatedExtractor.condition_value === undefined || !this.state.exampleMessage;
-  },
-  _getExtractorConditionControls() {
+  };
+
+  _getExtractorConditionControls = () => {
     if (!this.state.updatedExtractor.condition_type || this.state.updatedExtractor.condition_type === 'none') {
       return <div />;
     }
@@ -146,14 +151,15 @@ const EditExtractor = React.createClass({
         </Input>
       </div>
     );
-  },
-  _saveExtractor(event) {
+  };
+
+  _saveExtractor = (event) => {
     event.preventDefault();
     ExtractorsActions.save.triggerPromise(this.props.inputId, this.state.updatedExtractor)
       .then(() => this.props.onSave());
-  },
+  };
 
-  _staticField(label, text) {
+  _staticField = (label, text) => {
     return (
       <FormGroup>
         <Col componentClass={ControlLabel} md={2}>
@@ -164,7 +170,7 @@ const EditExtractor = React.createClass({
         </Col>
       </FormGroup>
     );
-  },
+  };
 
   render() {
     const conditionTypeHelpMessage = 'Extracting only from messages that match a certain condition helps you ' +
@@ -308,7 +314,7 @@ const EditExtractor = React.createClass({
         </Row>
       </div>
     );
-  },
-});
+  }
+}
 
 export default EditExtractor;

--- a/graylog2-web-interface/src/components/extractors/EditExtractorConfiguration.jsx
+++ b/graylog2-web-interface/src/components/extractors/EditExtractorConfiguration.jsx
@@ -15,21 +15,22 @@ import {
 
 import ExtractorUtils from 'util/ExtractorUtils';
 
-const EditExtractorConfiguration = React.createClass({
-  propTypes: {
+class EditExtractorConfiguration extends React.Component {
+  static propTypes = {
     extractorType: PropTypes.oneOf(ExtractorUtils.EXTRACTOR_TYPES).isRequired,
     configuration: PropTypes.object.isRequired,
     onChange: PropTypes.func.isRequired,
     exampleMessage: PropTypes.string,
-  },
-  getInitialState() {
-    return {
-      extractorPreview: undefined,
-    };
-  },
-  _onExtractorPreviewLoad(extractorPreviewNode) {
+  };
+
+  state = {
+    extractorPreview: undefined,
+  };
+
+  _onExtractorPreviewLoad = (extractorPreviewNode) => {
     this.setState({ extractorPreview: extractorPreviewNode });
-  },
+  };
+
   render() {
     let extractorConfiguration;
 
@@ -117,7 +118,7 @@ const EditExtractorConfiguration = React.createClass({
         {extractorPreview}
       </div>
     );
-  },
-});
+  }
+}
 
 export default EditExtractorConfiguration;

--- a/graylog2-web-interface/src/components/extractors/EditExtractorConverters.jsx
+++ b/graylog2-web-interface/src/components/extractors/EditExtractorConverters.jsx
@@ -22,28 +22,30 @@ import {
 
 import ExtractorUtils from 'util/ExtractorUtils';
 
-const EditExtractorConverters = React.createClass({
-  propTypes: {
+class EditExtractorConverters extends React.Component {
+  static propTypes = {
     extractorType: PropTypes.string.isRequired,
     converters: PropTypes.array.isRequired,
     onChange: PropTypes.func.isRequired,
-  },
-  getInitialState() {
-    return {
-      displayedConverters: this.props.converters.map(converter => converter.type),
-      disabledConverters: {}, // Keep disabled converters configuration, so the user doesn't need to type it again
-      selectedConverter: undefined,
-    };
-  },
-  _onConverterSelect(newValue) {
+  };
+
+  state = {
+    displayedConverters: this.props.converters.map(converter => converter.type),
+    disabledConverters: {}, // Keep disabled converters configuration, so the user doesn't need to type it again
+    selectedConverter: undefined,
+  };
+
+  _onConverterSelect = (newValue) => {
     this.setState({ selectedConverter: newValue });
-  },
-  _onConverterAdd() {
+  };
+
+  _onConverterAdd = () => {
     const newDisplayedConverters = this.state.displayedConverters;
     newDisplayedConverters.push(this.state.selectedConverter);
     this.setState({ selectedConverter: undefined, converters: newDisplayedConverters });
-  },
-  _onConverterChange(converterType, converter) {
+  };
+
+  _onConverterChange = (converterType, converter) => {
     if (converter) {
       const newDisabledConverters = this.state.disabledConverters;
       if (newDisabledConverters.hasOwnProperty(converterType)) {
@@ -57,8 +59,9 @@ const EditExtractorConverters = React.createClass({
     }
 
     this.props.onChange(converterType, converter);
-  },
-  _getConverterOptions() {
+  };
+
+  _getConverterOptions = () => {
     const converterOptions = [];
     Object.keys(ExtractorUtils.ConverterTypes).forEach((converterType) => {
       const type = ExtractorUtils.ConverterTypes[converterType];
@@ -71,12 +74,14 @@ const EditExtractorConverters = React.createClass({
     });
 
     return converterOptions;
-  },
-  _getConverterByType(converterType) {
+  };
+
+  _getConverterByType = (converterType) => {
     const currentConverter = this.props.converters.filter(converter => converter.type === converterType)[0];
     return (currentConverter ? currentConverter.config : {});
-  },
-  _getConvertersConfiguration() {
+  };
+
+  _getConvertersConfiguration = () => {
     const controls = this.state.displayedConverters.map((converterType) => {
       // Get converter configuration from disabledConverters if it was disabled
       let converterConfig = this._getConverterByType(converterType);
@@ -182,7 +187,8 @@ const EditExtractorConverters = React.createClass({
     });
 
     return controls;
-  },
+  };
+
   render() {
     if (this.props.extractorType === ExtractorUtils.ExtractorTypes.GROK || this.props.extractorType === ExtractorUtils.ExtractorTypes.JSON) {
       return (
@@ -224,7 +230,7 @@ const EditExtractorConverters = React.createClass({
         {this._getConvertersConfiguration()}
       </div>
     );
-  },
-});
+  }
+}
 
 export default EditExtractorConverters;

--- a/graylog2-web-interface/src/components/extractors/ExportExtractors.jsx
+++ b/graylog2-web-interface/src/components/extractors/ExportExtractors.jsx
@@ -1,5 +1,6 @@
 import PropTypes from 'prop-types';
 import React from 'react';
+import createReactClass from 'create-react-class';
 import Reflux from 'reflux';
 import { Row, Col } from 'react-bootstrap';
 
@@ -13,17 +14,23 @@ const ExtractorsActions = ActionsProvider.getActions('Extractors');
 import StoreProvider from 'injection/StoreProvider';
 const ExtractorsStore = StoreProvider.getStore('Extractors');
 
-const ExportExtractors = React.createClass({
+const ExportExtractors = createReactClass({
+  displayName: 'ExportExtractors',
+
   propTypes: {
     input: PropTypes.object.isRequired,
   },
+
   mixins: [Reflux.connect(ExtractorsStore), Reflux.ListenerMethods],
+
   componentDidMount() {
     ExtractorsActions.list.triggerPromise(this.props.input.id);
   },
+
   _isLoading() {
     return !this.state.extractors;
   },
+
   render() {
     if (this._isLoading()) {
       return <Spinner />;

--- a/graylog2-web-interface/src/components/extractors/ExtractorExampleMessage.jsx
+++ b/graylog2-web-interface/src/components/extractors/ExtractorExampleMessage.jsx
@@ -2,16 +2,18 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import MessageLoader from './MessageLoader';
 
-const ExtractorExampleMessage = React.createClass({
-  propTypes: {
+class ExtractorExampleMessage extends React.Component {
+  static propTypes = {
     field: PropTypes.string.isRequired,
     example: PropTypes.string,
     onExampleLoad: PropTypes.func,
-  },
-  _onExampleLoad(message) {
+  };
+
+  _onExampleLoad = (message) => {
     const newExample = message.fields[this.props.field];
     this.props.onExampleLoad(newExample);
-  },
+  };
+
   render() {
     const originalMessage = <span id="xtrc-original-example" style={{ display: 'none' }}>{this.props.example}</span>;
     let messagePreview;
@@ -38,7 +40,7 @@ const ExtractorExampleMessage = React.createClass({
         <MessageLoader onMessageLoaded={this._onExampleLoad} />
       </div>
     );
-  },
-});
+  }
+}
 
 export default ExtractorExampleMessage;

--- a/graylog2-web-interface/src/components/extractors/ExtractorSortModal.jsx
+++ b/graylog2-web-interface/src/components/extractors/ExtractorSortModal.jsx
@@ -8,27 +8,32 @@ import SortableList from 'components/common/SortableList';
 import ActionsProvider from 'injection/ActionsProvider';
 const ExtractorsActions = ActionsProvider.getActions('Extractors');
 
-const ExtractorSortModal = React.createClass({
-  propTypes: {
+class ExtractorSortModal extends React.Component {
+  static propTypes = {
     input: PropTypes.object.isRequired,
     extractors: PropTypes.array.isRequired,
-  },
-  open() {
+  };
+
+  open = () => {
     this.refs.modal.open();
-  },
-  close() {
+  };
+
+  close = () => {
     this.refs.modal.close();
-  },
-  _updateSorting(newSorting) {
+  };
+
+  _updateSorting = (newSorting) => {
     this.sortedExtractors = newSorting;
-  },
-  _saveSorting() {
+  };
+
+  _saveSorting = () => {
     if (!this.sortedExtractors) {
       this.close();
     }
     const promise = ExtractorsActions.order.triggerPromise(this.props.input.id, this.sortedExtractors);
     promise.then(() => this.close());
-  },
+  };
+
   render() {
     return (
       <BootstrapModalWrapper ref="modal">
@@ -51,7 +56,7 @@ const ExtractorSortModal = React.createClass({
         </Modal.Footer>
       </BootstrapModalWrapper>
     );
-  },
-});
+  }
+}
 
 export default ExtractorSortModal;

--- a/graylog2-web-interface/src/components/extractors/ExtractorsList.jsx
+++ b/graylog2-web-interface/src/components/extractors/ExtractorsList.jsx
@@ -1,5 +1,6 @@
 import PropTypes from 'prop-types';
 import React from 'react';
+import createReactClass from 'create-react-class';
 import Reflux from 'reflux';
 import { Row, Col, Button } from 'react-bootstrap';
 import naturalSort from 'javascript-natural-sort';
@@ -16,27 +17,35 @@ const ExtractorsActions = ActionsProvider.getActions('Extractors');
 import StoreProvider from 'injection/StoreProvider';
 const ExtractorsStore = StoreProvider.getStore('Extractors');
 
-const ExtractorsList = React.createClass({
+const ExtractorsList = createReactClass({
+  displayName: 'ExtractorsList',
+
   propTypes: {
     input: PropTypes.object.isRequired,
     node: PropTypes.object.isRequired,
   },
+
   mixins: [Reflux.connect(ExtractorsStore), Reflux.ListenerMethods],
+
   componentDidMount() {
     ExtractorsActions.list.triggerPromise(this.props.input.id);
   },
+
   _formatExtractor(extractor) {
     return (
       <ExtractorsListItem key={extractor.id} extractor={extractor} inputId={this.props.input.id}
                           nodeId={this.props.node.node_id} />
     );
   },
+
   _isLoading() {
     return !this.state.extractors;
   },
+
   _openSortModal() {
     this.refs.sortModal.open();
   },
+
   render() {
     if (this._isLoading()) {
       return <Spinner />;

--- a/graylog2-web-interface/src/components/extractors/ExtractorsListItem.jsx
+++ b/graylog2-web-interface/src/components/extractors/ExtractorsListItem.jsx
@@ -9,26 +9,28 @@ import ActionsProvider from 'injection/ActionsProvider';
 import Routes from 'routing/Routes';
 const ExtractorsActions = ActionsProvider.getActions('Extractors');
 
-const ExtractorsListItem = React.createClass({
-  propTypes: {
+class ExtractorsListItem extends React.Component {
+  static propTypes = {
     extractor: PropTypes.object.isRequired,
     inputId: PropTypes.string.isRequired,
     nodeId: PropTypes.string.isRequired,
-  },
-  getInitialState() {
-    return {
-      showDetails: false,
-    };
-  },
-  _toggleDetails() {
+  };
+
+  state = {
+    showDetails: false,
+  };
+
+  _toggleDetails = () => {
     this.setState({ showDetails: !this.state.showDetails });
-  },
-  _deleteExtractor() {
+  };
+
+  _deleteExtractor = () => {
     if (window.confirm(`Really remove extractor "${this.props.extractor.title}?"`)) {
       ExtractorsActions.delete.triggerPromise(this.props.inputId, this.props.extractor);
     }
-  },
-  _formatExtractorSubtitle() {
+  };
+
+  _formatExtractorSubtitle = () => {
     return (
       <span>
         Trying to extract data from <em>{this.props.extractor.source_field}</em> into{' '}
@@ -37,8 +39,9 @@ const ExtractorsListItem = React.createClass({
         leaving the original intact.
       </span>
     );
-  },
-  _formatCondition() {
+  };
+
+  _formatCondition = () => {
     if (this.props.extractor.condition_type === 'none') {
       return <div />;
     }
@@ -55,8 +58,9 @@ const ExtractorsListItem = React.createClass({
         </ul>
       </div>
     );
-  },
-  _formatActions() {
+  };
+
+  _formatActions = () => {
     const actions = [];
 
     actions.push(
@@ -73,14 +77,16 @@ const ExtractorsListItem = React.createClass({
     actions.push(<Button key={'delete-extractor-'} bsStyle="danger" onClick={this._deleteExtractor}>Delete</Button>);
 
     return actions;
-  },
-  _formatOptions(options) {
+  };
+
+  _formatOptions = (options) => {
     const attributes = Object.keys(options);
     return attributes.map((attribute) => {
       return <li key={`${attribute}-${this.props.extractor.id}`}>{attribute}: {options[attribute]}</li>;
     });
-  },
-  _formatConfiguration(extractorConfig) {
+  };
+
+  _formatConfiguration = (extractorConfig) => {
     let formattedOptions = this._formatOptions(extractorConfig);
     if (formattedOptions.length === 0) {
       formattedOptions = <li>No configuration options</li>;
@@ -94,16 +100,18 @@ const ExtractorsListItem = React.createClass({
         </ul>
       </div>
     );
-  },
-  _formatConverter(key, converter) {
+  };
+
+  _formatConverter = (key, converter) => {
     return (
       <li key={`converter-${key}`}>
         {converter.type}
         {converter.config && <ul>{this._formatOptions(converter.config)}</ul>}
       </li>
     );
-  },
-  _formatConverters(converters) {
+  };
+
+  _formatConverters = (converters) => {
     const converterKeys = Object.keys(converters);
     const formattedConverters = converterKeys.map(converterKey => this._formatConverter(converterKey, converters[converterKey]));
     if (formattedConverters.length === 0) {
@@ -118,8 +126,9 @@ const ExtractorsListItem = React.createClass({
         </ul>
       </div>
     );
-  },
-  _formatTimingMetrics(timing) {
+  };
+
+  _formatTimingMetrics = (timing) => {
     return (
       <dl className="metric-def metric-timer">
         <dt>95th percentile:</dt>
@@ -144,8 +153,9 @@ const ExtractorsListItem = React.createClass({
         <dd>{numeral(timing.max).format('0,0.[00]')}&#956;s</dd>
       </dl>
     );
-  },
-  _formatMetrics(metrics) {
+  };
+
+  _formatMetrics = (metrics) => {
     let totalRate;
     if (metrics.total.rate) {
       totalRate = (
@@ -218,8 +228,9 @@ const ExtractorsListItem = React.createClass({
         </Row>
       </div>
     );
-  },
-  _formatDetails() {
+  };
+
+  _formatDetails = () => {
     return (
       <div>
         <Col md={8}>
@@ -237,7 +248,8 @@ const ExtractorsListItem = React.createClass({
         </Col>
       </div>
     );
-  },
+  };
+
   render() {
     return (
       <EntityListItem key={`entry-list-${this.props.extractor.id}`}
@@ -247,7 +259,7 @@ const ExtractorsListItem = React.createClass({
                       actions={this._formatActions()}
                       contentRow={this.state.showDetails ? this._formatDetails() : null} />
     );
-  },
-});
+  }
+}
 
 export default ExtractorsListItem;

--- a/graylog2-web-interface/src/components/extractors/ImportExtractors.jsx
+++ b/graylog2-web-interface/src/components/extractors/ImportExtractors.jsx
@@ -8,11 +8,12 @@ const ExtractorsActions = ActionsProvider.getActions('Extractors');
 
 import UserNotification from 'util/UserNotification';
 
-const ImportExtractors = React.createClass({
-  propTypes: {
+class ImportExtractors extends React.Component {
+  static propTypes = {
     input: PropTypes.object.isRequired,
-  },
-  _onSubmit(event) {
+  };
+
+  _onSubmit = (event) => {
     event.preventDefault();
     try {
       const parsedExtractors = JSON.parse(this.refs.extractorsInput.getValue());
@@ -22,7 +23,8 @@ const ImportExtractors = React.createClass({
       UserNotification.error(`There was an error while parsing extractors. Are they in JSON format? ${error}`,
         'Could not import extractors');
     }
-  },
+  };
+
   render() {
     return (
       <Row className="content">
@@ -43,7 +45,7 @@ const ImportExtractors = React.createClass({
         </Col>
       </Row>
     );
-  },
-});
+  }
+}
 
 export default ImportExtractors;

--- a/graylog2-web-interface/src/components/extractors/MessageLoader.jsx
+++ b/graylog2-web-interface/src/components/extractors/MessageLoader.jsx
@@ -8,33 +8,33 @@ import StoreProvider from 'injection/StoreProvider';
 // eslint-disable-next-line no-unused-vars
 const MessagesStore = StoreProvider.getStore('Messages');
 
-const MessageLoader = React.createClass({
-  propTypes: {
+class MessageLoader extends React.Component {
+  static propTypes = {
     hidden: PropTypes.bool,
     hideText: PropTypes.bool,
     onMessageLoaded: PropTypes.func,
-  },
-  getDefaultProps() {
-    return {
-      hidden: true,
-    };
-  },
-  getInitialState() {
-    return ({
-      hidden: this.props.hidden,
-      loading: false,
-    });
-  },
+  };
 
-  toggleMessageForm() {
+  static defaultProps = {
+    hidden: true,
+  };
+
+  state = {
+    hidden: this.props.hidden,
+    loading: false,
+  };
+
+  toggleMessageForm = () => {
     this.setState({ hidden: !this.state.hidden }, this._focusMessageLoaderForm);
-  },
-  _focusMessageLoaderForm() {
+  };
+
+  _focusMessageLoaderForm = () => {
     if (!this.state.hidden) {
       this.refs.messageId.focus();
     }
-  },
-  loadMessage(event) {
+  };
+
+  loadMessage = (event) => {
     const messageId = this.refs.messageId.value;
     const index = this.refs.index.value;
     if (messageId === '' || index === '') {
@@ -46,12 +46,14 @@ const MessageLoader = React.createClass({
     promise.finally(() => this.setState({ loading: false }));
 
     event.preventDefault();
-  },
-  submit(messageId, index) {
+  };
+
+  submit = (messageId, index) => {
     this.refs.messageId.value = messageId;
     this.refs.index.value = index;
     this.refs.submitButton.click();
-  },
+  };
+
   render() {
     let explanatoryText;
     if (!this.props.hideText) {
@@ -79,7 +81,7 @@ const MessageLoader = React.createClass({
         {this.state.hidden ? null : loadMessageForm}
       </div>
     );
-  },
-});
+  }
+}
 
 export default MessageLoader;

--- a/graylog2-web-interface/src/components/extractors/converters_configuration/CSVConverterConfiguration.jsx
+++ b/graylog2-web-interface/src/components/extractors/converters_configuration/CSVConverterConfiguration.jsx
@@ -5,33 +5,38 @@ import { Row, Col } from 'react-bootstrap';
 import { Input } from 'components/bootstrap';
 import FormUtils from 'util/FormsUtils';
 
-const CSVConverterConfiguration = React.createClass({
-  propTypes: {
+class CSVConverterConfiguration extends React.Component {
+  static propTypes = {
     type: PropTypes.string.isRequired,
     configuration: PropTypes.object.isRequired,
     onChange: PropTypes.func.isRequired,
-  },
+  };
+
   componentDidMount() {
     this.props.onChange(this.props.type, this._getConverterObject());
-  },
-  _getConverterObject(configuration) {
+  }
+
+  _getConverterObject = (configuration) => {
     return { type: this.props.type, config: configuration || this.props.configuration };
-  },
-  _toggleConverter(event) {
+  };
+
+  _toggleConverter = (event) => {
     let converter;
     if (FormUtils.getValueFromInput(event.target) === true) {
       converter = this._getConverterObject();
     }
 
     this.props.onChange(this.props.type, converter);
-  },
-  _onChange(key) {
+  };
+
+  _onChange = (key) => {
     return (event) => {
       const newConfig = this.props.configuration;
       newConfig[key] = FormUtils.getValueFromInput(event.target);
       this.props.onChange(this.props.type, this._getConverterObject(newConfig));
     };
-  },
+  };
+
   render() {
     const separatorHelpMessage = (
       <span>
@@ -110,7 +115,7 @@ const CSVConverterConfiguration = React.createClass({
         </Row>
       </div>
     );
-  },
-});
+  }
+}
 
 export default CSVConverterConfiguration;

--- a/graylog2-web-interface/src/components/extractors/converters_configuration/DateConverterConfiguration.jsx
+++ b/graylog2-web-interface/src/components/extractors/converters_configuration/DateConverterConfiguration.jsx
@@ -9,34 +9,39 @@ import DocumentationLink from 'components/support/DocumentationLink';
 import DocsHelper from 'util/DocsHelper';
 import FormUtils from 'util/FormsUtils';
 
-const DateConverterConfiguration = React.createClass({
-  propTypes: {
+class DateConverterConfiguration extends React.Component {
+  static propTypes = {
     type: PropTypes.string.isRequired,
     configuration: PropTypes.object.isRequired,
     onChange: PropTypes.func.isRequired,
-  },
+  };
+
   componentDidMount() {
     this.props.onChange(this.props.type, this._getConverterObject());
-  },
-  _getConverterObject(configuration) {
+  }
+
+  _getConverterObject = (configuration) => {
     return { type: this.props.type, config: configuration || this.props.configuration };
-  },
-  _toggleConverter(event) {
+  };
+
+  _toggleConverter = (event) => {
     let converter;
     if (FormUtils.getValueFromInput(event.target) === true) {
       converter = this._getConverterObject();
     }
 
     this.props.onChange(this.props.type, converter);
-  },
-  _onChange(key) {
+  };
+
+  _onChange = (key) => {
     return (data) => {
       const newConfig = this.props.configuration;
       // data can be an event or a value, we need to check its type :sick:
       newConfig[key] = typeof data === 'object' ? FormUtils.getValueFromInput(data.target) : data;
       this.props.onChange(this.props.type, this._getConverterObject(newConfig));
     };
-  },
+  };
+
   render() {
     const dateFormatHelpMessage = (
       <span>
@@ -109,7 +114,7 @@ const DateConverterConfiguration = React.createClass({
         </Row>
       </div>
     );
-  },
-});
+  }
+}
 
 export default DateConverterConfiguration;

--- a/graylog2-web-interface/src/components/extractors/converters_configuration/FlexdateConverterConfiguration.jsx
+++ b/graylog2-web-interface/src/components/extractors/converters_configuration/FlexdateConverterConfiguration.jsx
@@ -9,34 +9,39 @@ import DocumentationLink from 'components/support/DocumentationLink';
 import DocsHelper from 'util/DocsHelper';
 import FormUtils from 'util/FormsUtils';
 
-const FlexdateConverterConfiguration = React.createClass({
-  propTypes: {
+class FlexdateConverterConfiguration extends React.Component {
+  static propTypes = {
     type: PropTypes.string.isRequired,
     configuration: PropTypes.object.isRequired,
     onChange: PropTypes.func.isRequired,
-  },
+  };
+
   componentDidMount() {
     this.props.onChange(this.props.type, this._getConverterObject());
-  },
-  _getConverterObject(configuration) {
+  }
+
+  _getConverterObject = (configuration) => {
     return { type: this.props.type, config: configuration || this.props.configuration };
-  },
-  _toggleConverter(event) {
+  };
+
+  _toggleConverter = (event) => {
     let converter;
     if (FormUtils.getValueFromInput(event.target) === true) {
       converter = this._getConverterObject();
     }
 
     this.props.onChange(this.props.type, converter);
-  },
-  _onChange(key) {
+  };
+
+  _onChange = (key) => {
     return (data) => {
       const newConfig = this.props.configuration;
       // data can be an event or a value, we need to check its type :sick:
       newConfig[key] = typeof data === 'object' ? FormUtils.getValueFromInput(data.target) : data;
       this.props.onChange(this.props.type, this._getConverterObject(newConfig));
     };
-  },
+  };
+
   render() {
     const timezoneHelpMessage = (
       <span>
@@ -72,7 +77,7 @@ const FlexdateConverterConfiguration = React.createClass({
         </Row>
       </div>
     );
-  },
-});
+  }
+}
 
 export default FlexdateConverterConfiguration;

--- a/graylog2-web-interface/src/components/extractors/converters_configuration/HashConverterConfiguration.jsx
+++ b/graylog2-web-interface/src/components/extractors/converters_configuration/HashConverterConfiguration.jsx
@@ -4,26 +4,30 @@ import { Input } from 'components/bootstrap';
 
 import FormUtils from 'util/FormsUtils';
 
-const HashConverterConfiguration = React.createClass({
-  propTypes: {
+class HashConverterConfiguration extends React.Component {
+  static propTypes = {
     type: PropTypes.string.isRequired,
     configuration: PropTypes.object.isRequired,
     onChange: PropTypes.func.isRequired,
-  },
+  };
+
   componentDidMount() {
     this.props.onChange(this.props.type, this._getConverterObject());
-  },
-  _getConverterObject() {
+  }
+
+  _getConverterObject = () => {
     return { type: this.props.type, config: this.props.configuration };
-  },
-  _toggleConverter(event) {
+  };
+
+  _toggleConverter = (event) => {
     let converter;
     if (FormUtils.getValueFromInput(event.target) === true) {
       converter = this._getConverterObject();
     }
 
     this.props.onChange(this.props.type, converter);
-  },
+  };
+
   render() {
     return (
       <div className="xtrc-converter">
@@ -35,7 +39,7 @@ const HashConverterConfiguration = React.createClass({
                onChange={this._toggleConverter} />
       </div>
     );
-  },
-});
+  }
+}
 
 export default HashConverterConfiguration;

--- a/graylog2-web-interface/src/components/extractors/converters_configuration/IpAnonymizerConverterConfiguration.jsx
+++ b/graylog2-web-interface/src/components/extractors/converters_configuration/IpAnonymizerConverterConfiguration.jsx
@@ -4,26 +4,30 @@ import { Input } from 'components/bootstrap';
 
 import FormUtils from 'util/FormsUtils';
 
-const IpAnonymizerConverterConfiguration = React.createClass({
-  propTypes: {
+class IpAnonymizerConverterConfiguration extends React.Component {
+  static propTypes = {
     type: PropTypes.string.isRequired,
     configuration: PropTypes.object.isRequired,
     onChange: PropTypes.func.isRequired,
-  },
+  };
+
   componentDidMount() {
     this.props.onChange(this.props.type, this._getConverterObject());
-  },
-  _getConverterObject() {
+  }
+
+  _getConverterObject = () => {
     return { type: this.props.type, config: this.props.configuration };
-  },
-  _toggleConverter(event) {
+  };
+
+  _toggleConverter = (event) => {
     let converter;
     if (FormUtils.getValueFromInput(event.target) === true) {
       converter = this._getConverterObject();
     }
 
     this.props.onChange(this.props.type, converter);
-  },
+  };
+
   render() {
     return (
       <div className="xtrc-converter">
@@ -35,7 +39,7 @@ const IpAnonymizerConverterConfiguration = React.createClass({
                onChange={this._toggleConverter} />
       </div>
     );
-  },
-});
+  }
+}
 
 export default IpAnonymizerConverterConfiguration;

--- a/graylog2-web-interface/src/components/extractors/converters_configuration/LookupTableConverterConfiguration.jsx
+++ b/graylog2-web-interface/src/components/extractors/converters_configuration/LookupTableConverterConfiguration.jsx
@@ -12,18 +12,16 @@ import CombinedProvider from 'injection/CombinedProvider';
 
 const { LookupTablesActions } = CombinedProvider.get('LookupTables');
 
-const LookupTableConverterConfiguration = React.createClass({
-  propTypes: {
+class LookupTableConverterConfiguration extends React.Component {
+  static propTypes = {
     type: PropTypes.string.isRequired,
     configuration: PropTypes.object.isRequired,
     onChange: PropTypes.func.isRequired,
-  },
+  };
 
-  getInitialState() {
-    return {
-      lookupTables: undefined,
-    };
-  },
+  state = {
+    lookupTables: undefined,
+  };
 
   componentDidMount() {
     this.props.onChange(this.props.type, this._getConverterObject());
@@ -32,34 +30,34 @@ const LookupTableConverterConfiguration = React.createClass({
     LookupTablesActions.searchPaginated(1, 10000, null).then((result) => {
       this.setState({ lookupTables: result.lookup_tables });
     });
-  },
+  }
 
-  _getConverterObject(configuration) {
+  _getConverterObject = (configuration) => {
     return { type: this.props.type, config: configuration || this.props.configuration };
-  },
+  };
 
-  _toggleConverter(event) {
+  _toggleConverter = (event) => {
     let converter;
     if (FormUtils.getValueFromInput(event.target) === true) {
       converter = this._getConverterObject();
     }
 
     this.props.onChange(this.props.type, converter);
-  },
+  };
 
-  _updateConfigValue(key, value) {
+  _updateConfigValue = (key, value) => {
     const newConfig = this.props.configuration;
     newConfig[key] = value;
     this.props.onChange(this.props.type, this._getConverterObject(newConfig));
-  },
+  };
 
-  _onChange(key) {
+  _onChange = (key) => {
     return event => this._updateConfigValue(key, FormUtils.getValueFromInput(event.target));
-  },
+  };
 
-  _onSelect(key) {
+  _onSelect = (key) => {
     return value => this._updateConfigValue(key, value);
-  },
+  };
 
   render() {
     if (!this.state.lookupTables) {
@@ -107,7 +105,7 @@ const LookupTableConverterConfiguration = React.createClass({
         </Row>
       </div>
     );
-  },
-});
+  }
+}
 
 export default LookupTableConverterConfiguration;

--- a/graylog2-web-interface/src/components/extractors/converters_configuration/LowercaseConverterConfiguration.jsx
+++ b/graylog2-web-interface/src/components/extractors/converters_configuration/LowercaseConverterConfiguration.jsx
@@ -4,26 +4,30 @@ import { Input } from 'components/bootstrap';
 
 import FormUtils from 'util/FormsUtils';
 
-const LowercaseConverterConfiguration = React.createClass({
-  propTypes: {
+class LowercaseConverterConfiguration extends React.Component {
+  static propTypes = {
     type: PropTypes.string.isRequired,
     configuration: PropTypes.object.isRequired,
     onChange: PropTypes.func.isRequired,
-  },
+  };
+
   componentDidMount() {
     this.props.onChange(this.props.type, this._getConverterObject());
-  },
-  _getConverterObject() {
+  }
+
+  _getConverterObject = () => {
     return { type: this.props.type, config: this.props.configuration };
-  },
-  _toggleConverter(event) {
+  };
+
+  _toggleConverter = (event) => {
     let converter;
     if (FormUtils.getValueFromInput(event.target) === true) {
       converter = this._getConverterObject();
     }
 
     this.props.onChange(this.props.type, converter);
-  },
+  };
+
   render() {
     return (
       <div className="xtrc-converter">
@@ -35,7 +39,7 @@ const LowercaseConverterConfiguration = React.createClass({
                onChange={this._toggleConverter} />
       </div>
     );
-  },
-});
+  }
+}
 
 export default LowercaseConverterConfiguration;

--- a/graylog2-web-interface/src/components/extractors/converters_configuration/NumericConverterConfiguration.jsx
+++ b/graylog2-web-interface/src/components/extractors/converters_configuration/NumericConverterConfiguration.jsx
@@ -4,26 +4,30 @@ import { Input } from 'components/bootstrap';
 
 import FormUtils from 'util/FormsUtils';
 
-const NumericConverterConfiguration = React.createClass({
-  propTypes: {
+class NumericConverterConfiguration extends React.Component {
+  static propTypes = {
     type: PropTypes.string.isRequired,
     configuration: PropTypes.object.isRequired,
     onChange: PropTypes.func.isRequired,
-  },
+  };
+
   componentDidMount() {
     this.props.onChange(this.props.type, this._getConverterObject());
-  },
-  _getConverterObject() {
+  }
+
+  _getConverterObject = () => {
     return { type: this.props.type, config: this.props.configuration };
-  },
-  _toggleConverter(event) {
+  };
+
+  _toggleConverter = (event) => {
     let converter;
     if (FormUtils.getValueFromInput(event.target) === true) {
       converter = this._getConverterObject();
     }
 
     this.props.onChange(this.props.type, converter);
-  },
+  };
+
   render() {
     return (
       <div className="xtrc-converter">
@@ -35,7 +39,7 @@ const NumericConverterConfiguration = React.createClass({
                onChange={this._toggleConverter} />
       </div>
     );
-  },
-});
+  }
+}
 
 export default NumericConverterConfiguration;

--- a/graylog2-web-interface/src/components/extractors/converters_configuration/SplitAndCountConverterConfiguration.jsx
+++ b/graylog2-web-interface/src/components/extractors/converters_configuration/SplitAndCountConverterConfiguration.jsx
@@ -5,33 +5,38 @@ import { Row, Col } from 'react-bootstrap';
 import { Input } from 'components/bootstrap';
 import FormUtils from 'util/FormsUtils';
 
-const SplitAndCountConverterConfiguration = React.createClass({
-  propTypes: {
+class SplitAndCountConverterConfiguration extends React.Component {
+  static propTypes = {
     type: PropTypes.string.isRequired,
     configuration: PropTypes.object.isRequired,
     onChange: PropTypes.func.isRequired,
-  },
+  };
+
   componentDidMount() {
     this.props.onChange(this.props.type, this._getConverterObject());
-  },
-  _getConverterObject(configuration) {
+  }
+
+  _getConverterObject = (configuration) => {
     return { type: this.props.type, config: configuration || this.props.configuration };
-  },
-  _toggleConverter(event) {
+  };
+
+  _toggleConverter = (event) => {
     let converter;
     if (FormUtils.getValueFromInput(event.target) === true) {
       converter = this._getConverterObject();
     }
 
     this.props.onChange(this.props.type, converter);
-  },
-  _onChange(key) {
+  };
+
+  _onChange = (key) => {
     return (event) => {
       const newConfig = this.props.configuration;
       newConfig[key] = FormUtils.getValueFromInput(event.target);
       this.props.onChange(this.props.type, this._getConverterObject(newConfig));
     };
-  },
+  };
+
   render() {
     const splitByHelpMessage = (
       <span>
@@ -67,7 +72,7 @@ const SplitAndCountConverterConfiguration = React.createClass({
         </Row>
       </div>
     );
-  },
-});
+  }
+}
 
 export default SplitAndCountConverterConfiguration;

--- a/graylog2-web-interface/src/components/extractors/converters_configuration/SyslogPriFacilityConverterConfiguration.jsx
+++ b/graylog2-web-interface/src/components/extractors/converters_configuration/SyslogPriFacilityConverterConfiguration.jsx
@@ -4,26 +4,30 @@ import { Input } from 'components/bootstrap';
 
 import FormUtils from 'util/FormsUtils';
 
-const SyslogPriFacilityConverterConfiguration = React.createClass({
-  propTypes: {
+class SyslogPriFacilityConverterConfiguration extends React.Component {
+  static propTypes = {
     type: PropTypes.string.isRequired,
     configuration: PropTypes.object.isRequired,
     onChange: PropTypes.func.isRequired,
-  },
+  };
+
   componentDidMount() {
     this.props.onChange(this.props.type, this._getConverterObject());
-  },
-  _getConverterObject() {
+  }
+
+  _getConverterObject = () => {
     return { type: this.props.type, config: this.props.configuration };
-  },
-  _toggleConverter(event) {
+  };
+
+  _toggleConverter = (event) => {
     let converter;
     if (FormUtils.getValueFromInput(event.target) === true) {
       converter = this._getConverterObject();
     }
 
     this.props.onChange(this.props.type, converter);
-  },
+  };
+
   render() {
     return (
       <div className="xtrc-converter">
@@ -35,7 +39,7 @@ const SyslogPriFacilityConverterConfiguration = React.createClass({
                onChange={this._toggleConverter} />
       </div>
     );
-  },
-});
+  }
+}
 
 export default SyslogPriFacilityConverterConfiguration;

--- a/graylog2-web-interface/src/components/extractors/converters_configuration/SyslogPriLevelConverterConfiguration.jsx
+++ b/graylog2-web-interface/src/components/extractors/converters_configuration/SyslogPriLevelConverterConfiguration.jsx
@@ -4,26 +4,30 @@ import { Input } from 'components/bootstrap';
 
 import FormUtils from 'util/FormsUtils';
 
-const SyslogPriLevelConverterConfiguration = React.createClass({
-  propTypes: {
+class SyslogPriLevelConverterConfiguration extends React.Component {
+  static propTypes = {
     type: PropTypes.string.isRequired,
     configuration: PropTypes.object.isRequired,
     onChange: PropTypes.func.isRequired,
-  },
+  };
+
   componentDidMount() {
     this.props.onChange(this.props.type, this._getConverterObject());
-  },
-  _getConverterObject() {
+  }
+
+  _getConverterObject = () => {
     return { type: this.props.type, config: this.props.configuration };
-  },
-  _toggleConverter(event) {
+  };
+
+  _toggleConverter = (event) => {
     let converter;
     if (FormUtils.getValueFromInput(event.target) === true) {
       converter = this._getConverterObject();
     }
 
     this.props.onChange(this.props.type, converter);
-  },
+  };
+
   render() {
     return (
       <div className="xtrc-converter">
@@ -35,7 +39,7 @@ const SyslogPriLevelConverterConfiguration = React.createClass({
                onChange={this._toggleConverter} />
       </div>
     );
-  },
-});
+  }
+}
 
 export default SyslogPriLevelConverterConfiguration;

--- a/graylog2-web-interface/src/components/extractors/converters_configuration/TokenizerConverterConfiguration.jsx
+++ b/graylog2-web-interface/src/components/extractors/converters_configuration/TokenizerConverterConfiguration.jsx
@@ -4,26 +4,30 @@ import { Input } from 'components/bootstrap';
 
 import FormUtils from 'util/FormsUtils';
 
-const TokenizerConverterConfiguration = React.createClass({
-  propTypes: {
+class TokenizerConverterConfiguration extends React.Component {
+  static propTypes = {
     type: PropTypes.string.isRequired,
     configuration: PropTypes.object.isRequired,
     onChange: PropTypes.func.isRequired,
-  },
+  };
+
   componentDidMount() {
     this.props.onChange(this.props.type, this._getConverterObject());
-  },
-  _getConverterObject() {
+  }
+
+  _getConverterObject = () => {
     return { type: this.props.type, config: this.props.configuration };
-  },
-  _toggleConverter(event) {
+  };
+
+  _toggleConverter = (event) => {
     let converter;
     if (FormUtils.getValueFromInput(event.target) === true) {
       converter = this._getConverterObject();
     }
 
     this.props.onChange(this.props.type, converter);
-  },
+  };
+
   render() {
     return (
       <div className="xtrc-converter">
@@ -35,7 +39,7 @@ const TokenizerConverterConfiguration = React.createClass({
                onChange={this._toggleConverter} />
       </div>
     );
-  },
-});
+  }
+}
 
 export default TokenizerConverterConfiguration;

--- a/graylog2-web-interface/src/components/extractors/converters_configuration/UppercaseConverterConfiguration.jsx
+++ b/graylog2-web-interface/src/components/extractors/converters_configuration/UppercaseConverterConfiguration.jsx
@@ -4,26 +4,30 @@ import { Input } from 'components/bootstrap';
 
 import FormUtils from 'util/FormsUtils';
 
-const UppercaseConverterConfiguration = React.createClass({
-  propTypes: {
+class UppercaseConverterConfiguration extends React.Component {
+  static propTypes = {
     type: PropTypes.string.isRequired,
     configuration: PropTypes.object.isRequired,
     onChange: PropTypes.func.isRequired,
-  },
+  };
+
   componentDidMount() {
     this.props.onChange(this.props.type, this._getConverterObject());
-  },
-  _getConverterObject() {
+  }
+
+  _getConverterObject = () => {
     return { type: this.props.type, config: this.props.configuration };
-  },
-  _toggleConverter(event) {
+  };
+
+  _toggleConverter = (event) => {
     let converter;
     if (FormUtils.getValueFromInput(event.target) === true) {
       converter = this._getConverterObject();
     }
 
     this.props.onChange(this.props.type, converter);
-  },
+  };
+
   render() {
     return (
       <div className="xtrc-converter">
@@ -35,7 +39,7 @@ const UppercaseConverterConfiguration = React.createClass({
                onChange={this._toggleConverter} />
       </div>
     );
-  },
-});
+  }
+}
 
 export default UppercaseConverterConfiguration;

--- a/graylog2-web-interface/src/components/extractors/extractors_configuration/CopyInputExtractorConfiguration.jsx
+++ b/graylog2-web-interface/src/components/extractors/extractors_configuration/CopyInputExtractorConfiguration.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { Panel } from 'react-bootstrap';
 
-const CopyInputExtractorConfiguration = React.createClass({
+class CopyInputExtractorConfiguration extends React.Component {
   render() {
     return (
       <div className="form-group">
@@ -12,6 +12,7 @@ const CopyInputExtractorConfiguration = React.createClass({
         </div>
       </div>
     );
-  },
-});
+  }
+}
+
 export default CopyInputExtractorConfiguration;

--- a/graylog2-web-interface/src/components/extractors/extractors_configuration/GrokExtractorConfiguration.jsx
+++ b/graylog2-web-interface/src/components/extractors/extractors_configuration/GrokExtractorConfiguration.jsx
@@ -11,27 +11,28 @@ import FormUtils from 'util/FormsUtils';
 import StoreProvider from 'injection/StoreProvider';
 const ToolsStore = StoreProvider.getStore('Tools');
 
-const GrokExtractorConfiguration = React.createClass({
-  propTypes: {
+class GrokExtractorConfiguration extends React.Component {
+  static propTypes = {
     configuration: PropTypes.object.isRequired,
     exampleMessage: PropTypes.string,
     onChange: PropTypes.func.isRequired,
     onExtractorPreviewLoad: PropTypes.func.isRequired,
-  },
-  getInitialState() {
-    return {
-      trying: false,
-    };
-  },
-  _onChange(key) {
+  };
+
+  state = {
+    trying: false,
+  };
+
+  _onChange = (key) => {
     return (event) => {
       this.props.onExtractorPreviewLoad(undefined);
       const newConfig = this.props.configuration;
       newConfig[key] = FormUtils.getValueFromInput(event.target);
       this.props.onChange(newConfig);
     };
-  },
-  _onTryClick() {
+  };
+
+  _onTryClick = () => {
     this.setState({ trying: true });
 
     const promise = ToolsStore.testGrok(this.props.configuration.grok_pattern, this.props.configuration.named_captures_only, this.props.exampleMessage);
@@ -52,10 +53,12 @@ const GrokExtractorConfiguration = React.createClass({
     });
 
     promise.finally(() => this.setState({ trying: false }));
-  },
-  _isTryButtonDisabled() {
+  };
+
+  _isTryButtonDisabled = () => {
     return this.state.trying || !this.props.configuration.grok_pattern || !this.props.exampleMessage;
-  },
+  };
+
   render() {
     const helpMessage = (
       <span>
@@ -95,7 +98,7 @@ const GrokExtractorConfiguration = React.createClass({
         </Input>
       </div>
     );
-  },
-});
+  }
+}
 
 export default GrokExtractorConfiguration;

--- a/graylog2-web-interface/src/components/extractors/extractors_configuration/JSONExtractorConfiguration.jsx
+++ b/graylog2-web-interface/src/components/extractors/extractors_configuration/JSONExtractorConfiguration.jsx
@@ -1,5 +1,6 @@
 import PropTypes from 'prop-types';
 import React from 'react';
+import createReactClass from 'create-react-class';
 import { Button, Col, Row } from 'react-bootstrap';
 
 import { Input } from 'components/bootstrap';
@@ -9,25 +10,31 @@ const ToolsStore = StoreProvider.getStore('Tools');
 import ExtractorUtils from 'util/ExtractorUtils';
 import FormUtils from 'util/FormsUtils';
 
-const JSONExtractorConfiguration = React.createClass({
+const JSONExtractorConfiguration = createReactClass({
+  displayName: 'JSONExtractorConfiguration',
+
   propTypes: {
     configuration: PropTypes.object.isRequired,
     exampleMessage: PropTypes.string,
     onChange: PropTypes.func.isRequired,
     onExtractorPreviewLoad: PropTypes.func.isRequired,
   },
+
   getInitialState() {
     return {
       trying: false,
       configuration: this._getEffectiveConfiguration(this.props.configuration),
     };
   },
+
   componentDidMount() {
     this.props.onChange(this.state.configuration);
   },
+
   componentWillReceiveProps(nextProps) {
     this.setState({ configuration: this._getEffectiveConfiguration(nextProps.configuration) });
   },
+
   DEFAULT_CONFIGURATION: {
     list_separator: ', ',
     key_separator: '_',
@@ -36,9 +43,11 @@ const JSONExtractorConfiguration = React.createClass({
     replace_key_whitespace: false,
     key_whitespace_replacement: '_',
   },
+
   _getEffectiveConfiguration(configuration) {
     return ExtractorUtils.getEffectiveConfiguration(this.DEFAULT_CONFIGURATION, configuration);
   },
+
   _onChange(key) {
     return (event) => {
       this.props.onExtractorPreviewLoad(undefined);
@@ -47,6 +56,7 @@ const JSONExtractorConfiguration = React.createClass({
       this.props.onChange(newConfig);
     };
   },
+
   _onTryClick() {
     this.setState({ trying: true });
 
@@ -70,9 +80,11 @@ const JSONExtractorConfiguration = React.createClass({
 
     promise.finally(() => this.setState({ trying: false }));
   },
+
   _isTryButtonDisabled() {
     return this.state.trying || !this.props.exampleMessage;
   },
+
   render() {
     return (
       <div>

--- a/graylog2-web-interface/src/components/extractors/extractors_configuration/LookupTableExtractorConfiguration.jsx
+++ b/graylog2-web-interface/src/components/extractors/extractors_configuration/LookupTableExtractorConfiguration.jsx
@@ -14,50 +14,46 @@ import CombinedProvider from 'injection/CombinedProvider';
 const ToolsStore = StoreProvider.getStore('Tools');
 const { LookupTablesActions } = CombinedProvider.get('LookupTables');
 
-const LookupTableExtractorConfiguration = React.createClass({
-  propTypes: {
+class LookupTableExtractorConfiguration extends React.Component {
+  static propTypes = {
     configuration: PropTypes.object.isRequired,
     exampleMessage: PropTypes.string,
     onChange: PropTypes.func.isRequired,
     onExtractorPreviewLoad: PropTypes.func.isRequired,
-  },
+  };
 
-  getDefaultProps() {
-    return {
-      exampleMessage: '',
-    };
-  },
+  static defaultProps = {
+    exampleMessage: '',
+  };
 
-  getInitialState() {
-    return {
-      trying: false,
-      lookupTables: undefined,
-    };
-  },
+  state = {
+    trying: false,
+    lookupTables: undefined,
+  };
 
   componentDidMount() {
     // TODO the 10k items is bad. we need a searchable/scrollable long list select box
     LookupTablesActions.searchPaginated(1, 10000, null).then((result) => {
       this.setState({ lookupTables: result.lookup_tables });
     });
-  },
+  }
 
-  _updateConfigValue(key, value) {
+  _updateConfigValue = (key, value) => {
     this.props.onExtractorPreviewLoad(undefined);
     const newConfig = this.props.configuration;
     newConfig[key] = value;
     this.props.onChange(newConfig);
-  },
+  };
 
-  _onChange(key) {
+  _onChange = (key) => {
     return event => this._updateConfigValue(key, FormUtils.getValueFromInput(event.target));
-  },
+  };
 
-  _onSelect(key) {
+  _onSelect = (key) => {
     return value => this._updateConfigValue(key, value);
-  },
+  };
 
-  _onTryClick() {
+  _onTryClick = () => {
     this.setState({ trying: true });
 
     const promise = ToolsStore.testLookupTable(this.props.configuration.lookup_table_name, this.props.exampleMessage);
@@ -75,11 +71,11 @@ const LookupTableExtractorConfiguration = React.createClass({
     });
 
     promise.finally(() => this.setState({ trying: false }));
-  },
+  };
 
-  _isTryButtonDisabled() {
+  _isTryButtonDisabled = () => {
     return this.state.trying || !this.props.configuration.lookup_table_name || !this.props.exampleMessage;
-  },
+  };
 
   render() {
     if (!this.state.lookupTables) {
@@ -121,7 +117,7 @@ const LookupTableExtractorConfiguration = React.createClass({
         </Input>
       </div>
     );
-  },
-});
+  }
+}
 
 export default LookupTableExtractorConfiguration;

--- a/graylog2-web-interface/src/components/extractors/extractors_configuration/RegexExtractorConfiguration.jsx
+++ b/graylog2-web-interface/src/components/extractors/extractors_configuration/RegexExtractorConfiguration.jsx
@@ -12,27 +12,28 @@ import FormUtils from 'util/FormsUtils';
 import StoreProvider from 'injection/StoreProvider';
 const ToolsStore = StoreProvider.getStore('Tools');
 
-const RegexExtractorConfiguration = React.createClass({
-  propTypes: {
+class RegexExtractorConfiguration extends React.Component {
+  static propTypes = {
     configuration: PropTypes.object.isRequired,
     exampleMessage: PropTypes.string,
     onChange: PropTypes.func.isRequired,
     onExtractorPreviewLoad: PropTypes.func.isRequired,
-  },
-  getInitialState() {
-    return {
-      trying: false,
-    };
-  },
-  _onChange(key) {
+  };
+
+  state = {
+    trying: false,
+  };
+
+  _onChange = (key) => {
     return (event) => {
       this.props.onExtractorPreviewLoad(undefined);
       const newConfig = this.props.configuration;
       newConfig[key] = FormUtils.getValueFromInput(event.target);
       this.props.onChange(newConfig);
     };
-  },
-  _onTryClick() {
+  };
+
+  _onTryClick = () => {
     this.setState({ trying: true });
 
     const promise = ToolsStore.testRegex(this.props.configuration.regex_value, this.props.exampleMessage);
@@ -52,10 +53,12 @@ const RegexExtractorConfiguration = React.createClass({
     });
 
     promise.finally(() => this.setState({ trying: false }));
-  },
-  _isTryButtonDisabled() {
+  };
+
+  _isTryButtonDisabled = () => {
     return this.state.trying || !this.props.configuration.regex_value || !this.props.exampleMessage;
-  },
+  };
+
   render() {
     const helpMessage = (
       <span>
@@ -88,7 +91,7 @@ const RegexExtractorConfiguration = React.createClass({
         </Input>
       </div>
     );
-  },
-});
+  }
+}
 
 export default RegexExtractorConfiguration;

--- a/graylog2-web-interface/src/components/extractors/extractors_configuration/RegexReplaceExtractorConfiguration.jsx
+++ b/graylog2-web-interface/src/components/extractors/extractors_configuration/RegexReplaceExtractorConfiguration.jsx
@@ -12,27 +12,28 @@ import FormUtils from 'util/FormsUtils';
 import StoreProvider from 'injection/StoreProvider';
 const ToolsStore = StoreProvider.getStore('Tools');
 
-const RegexReplaceExtractorConfiguration = React.createClass({
-  propTypes: {
+class RegexReplaceExtractorConfiguration extends React.Component {
+  static propTypes = {
     configuration: PropTypes.object.isRequired,
     exampleMessage: PropTypes.string,
     onChange: PropTypes.func.isRequired,
     onExtractorPreviewLoad: PropTypes.func.isRequired,
-  },
-  getInitialState() {
-    return {
-      trying: false,
-    };
-  },
-  _onChange(key) {
+  };
+
+  state = {
+    trying: false,
+  };
+
+  _onChange = (key) => {
     return (event) => {
       this.props.onExtractorPreviewLoad(undefined);
       const newConfig = this.props.configuration;
       newConfig[key] = FormUtils.getValueFromInput(event.target);
       this.props.onChange(newConfig);
     };
-  },
-  _onTryClick() {
+  };
+
+  _onTryClick = () => {
     this.setState({ trying: true });
 
     const configuration = this.props.configuration;
@@ -54,10 +55,12 @@ const RegexReplaceExtractorConfiguration = React.createClass({
     });
 
     promise.finally(() => this.setState({ trying: false }));
-  },
-  _isTryButtonDisabled() {
+  };
+
+  _isTryButtonDisabled = () => {
     return this.state.trying || !this.props.configuration.regex || !this.props.configuration.replacement || !this.props.exampleMessage;
-  },
+  };
+
   render() {
     const regexHelpMessage = (
       <span>
@@ -115,7 +118,7 @@ const RegexReplaceExtractorConfiguration = React.createClass({
         </Row>
       </div>
     );
-  },
-});
+  }
+}
 
 export default RegexReplaceExtractorConfiguration;

--- a/graylog2-web-interface/src/components/extractors/extractors_configuration/SplitAndIndexExtractorConfiguration.jsx
+++ b/graylog2-web-interface/src/components/extractors/extractors_configuration/SplitAndIndexExtractorConfiguration.jsx
@@ -1,5 +1,6 @@
 import PropTypes from 'prop-types';
 import React from 'react';
+import createReactClass from 'create-react-class';
 import { Button, Col, Row } from 'react-bootstrap';
 
 import { Input } from 'components/bootstrap';
@@ -10,29 +11,37 @@ import UserNotification from 'util/UserNotification';
 import ExtractorUtils from 'util/ExtractorUtils';
 import FormUtils from 'util/FormsUtils';
 
-const SplitAndIndexExtractorConfiguration = React.createClass({
+const SplitAndIndexExtractorConfiguration = createReactClass({
+  displayName: 'SplitAndIndexExtractorConfiguration',
+
   propTypes: {
     configuration: PropTypes.object.isRequired,
     exampleMessage: PropTypes.string,
     onChange: PropTypes.func.isRequired,
     onExtractorPreviewLoad: PropTypes.func.isRequired,
   },
+
   getInitialState() {
     return {
       trying: false,
       configuration: this._getEffectiveConfiguration(this.props.configuration),
     };
   },
+
   componentDidMount() {
     this.props.onChange(this.state.configuration);
   },
+
   componentWillReceiveProps(nextProps) {
     this.setState({ configuration: this._getEffectiveConfiguration(nextProps.configuration) });
   },
+
   DEFAULT_CONFIGURATION: { index: 1 },
+
   _getEffectiveConfiguration(configuration) {
     return ExtractorUtils.getEffectiveConfiguration(this.DEFAULT_CONFIGURATION, configuration);
   },
+
   _onChange(key) {
     return (event) => {
       this.props.onExtractorPreviewLoad(undefined);
@@ -41,6 +50,7 @@ const SplitAndIndexExtractorConfiguration = React.createClass({
       this.props.onChange(newConfig);
     };
   },
+
   _onTryClick() {
     this.setState({ trying: true });
 
@@ -59,10 +69,12 @@ const SplitAndIndexExtractorConfiguration = React.createClass({
 
     promise.finally(() => this.setState({ trying: false }));
   },
+
   _isTryButtonDisabled() {
     const configuration = this.state.configuration;
     return this.state.trying || configuration.split_by === '' || configuration.index === undefined || configuration.index < 1 || !this.props.exampleMessage;
   },
+
   render() {
     const splitByHelpMessage = (
       <span>

--- a/graylog2-web-interface/src/components/extractors/extractors_configuration/SubstringExtractorConfiguration.jsx
+++ b/graylog2-web-interface/src/components/extractors/extractors_configuration/SubstringExtractorConfiguration.jsx
@@ -1,5 +1,6 @@
 import PropTypes from 'prop-types';
 import React from 'react';
+import createReactClass from 'create-react-class';
 import { Button, Col, Row } from 'react-bootstrap';
 
 import { Input } from 'components/bootstrap';
@@ -10,29 +11,37 @@ import UserNotification from 'util/UserNotification';
 import ExtractorUtils from 'util/ExtractorUtils';
 import FormUtils from 'util/FormsUtils';
 
-const SubstringExtractorConfiguration = React.createClass({
+const SubstringExtractorConfiguration = createReactClass({
+  displayName: 'SubstringExtractorConfiguration',
+
   propTypes: {
     configuration: PropTypes.object.isRequired,
     exampleMessage: PropTypes.string,
     onChange: PropTypes.func.isRequired,
     onExtractorPreviewLoad: PropTypes.func.isRequired,
   },
+
   getInitialState() {
     return {
       trying: false,
       configuration: this._getEffectiveConfiguration(this.props.configuration),
     };
   },
+
   componentDidMount() {
     this.props.onChange(this.state.configuration);
   },
+
   componentWillReceiveProps(nextProps) {
     this.setState({ configuration: this._getEffectiveConfiguration(nextProps.configuration) });
   },
+
   DEFAULT_CONFIGURATION: { begin_index: 0, end_index: 1 },
+
   _getEffectiveConfiguration(configuration) {
     return ExtractorUtils.getEffectiveConfiguration(this.DEFAULT_CONFIGURATION, configuration);
   },
+
   _onChange(key) {
     return (event) => {
       this.props.onExtractorPreviewLoad(undefined);
@@ -41,6 +50,7 @@ const SubstringExtractorConfiguration = React.createClass({
       this.props.onChange(newConfig);
     };
   },
+
   _verifySubstringInputs() {
     const beginIndex = this.refs.beginIndex.getInputDOMNode();
     const endIndex = this.refs.endIndex.getInputDOMNode();
@@ -60,6 +70,7 @@ const SubstringExtractorConfiguration = React.createClass({
       this._onChange('begin_index')({ target: beginIndex });
     }
   },
+
   _onTryClick() {
     this.setState({ trying: true });
 
@@ -83,10 +94,12 @@ const SubstringExtractorConfiguration = React.createClass({
       promise.finally(() => this.setState({ trying: false }));
     }
   },
+
   _isTryButtonDisabled() {
     const configuration = this.state.configuration;
     return this.state.trying || configuration.begin_index === undefined || configuration.begin_index < 0 || configuration.end_index === undefined || configuration.end_index < 0 || !this.props.exampleMessage;
   },
+
   render() {
     const endIndexHelpMessage = (
       <span>

--- a/graylog2-web-interface/src/components/field-analyzers/FieldGraphs.jsx
+++ b/graylog2-web-interface/src/components/field-analyzers/FieldGraphs.jsx
@@ -1,5 +1,6 @@
 import PropTypes from 'prop-types';
 import React from 'react';
+import createReactClass from 'create-react-class';
 import ReactDOM from 'react-dom';
 import Immutable from 'immutable';
 import PureRenderMixin from 'react-addons-pure-render-mixin';
@@ -11,7 +12,9 @@ const FieldGraphsStore = StoreProvider.getStore('FieldGraphs');
 
 import UIUtils from 'util/UIUtils';
 
-const FieldGraphs = React.createClass({
+const FieldGraphs = createReactClass({
+  displayName: 'FieldGraphs',
+
   propTypes: {
     from: PropTypes.any.isRequired,
     to: PropTypes.any.isRequired,
@@ -19,7 +22,9 @@ const FieldGraphs = React.createClass({
     stream: PropTypes.object,
     permissions: PropTypes.arrayOf(PropTypes.string).isRequired,
   },
+
   mixins: [PureRenderMixin],
+
   getInitialState() {
     this.notifyOnNewGraphs = false;
 
@@ -28,6 +33,7 @@ const FieldGraphs = React.createClass({
       stackedGraphs: Immutable.fromJS(FieldGraphsStore.stackedGraphs.toJS()),
     };
   },
+
   componentDidMount() {
     this.initialFieldGraphs = this.state.fieldGraphs;
     this.notifyOnNewGraphs = true;
@@ -41,16 +47,20 @@ const FieldGraphs = React.createClass({
       }
     };
   },
+
   componentWillUnmount() {
     FieldGraphsStore.resetStore();
   },
+
   addField(field) {
     const streamId = this.props.stream ? this.props.stream.id : undefined;
     FieldGraphsStore.newFieldGraph(field, { interval: this.props.resolution, streamid: streamId });
   },
+
   deleteFieldGraph(graphId) {
     FieldGraphsStore.deleteGraph(graphId);
   },
+
   render() {
     const fieldGraphs = this.state.fieldGraphs
       .sortBy(graph => graph.createdAt)

--- a/graylog2-web-interface/src/components/field-analyzers/FieldQuickValues.jsx
+++ b/graylog2-web-interface/src/components/field-analyzers/FieldQuickValues.jsx
@@ -1,5 +1,6 @@
 import PropTypes from 'prop-types';
 import React from 'react';
+import createReactClass from 'create-react-class';
 import ReactDOM from 'react-dom';
 import { DropdownButton, MenuItem, Button } from 'react-bootstrap';
 import Reflux from 'reflux';
@@ -19,7 +20,9 @@ const { FieldQuickValuesStore, FieldQuickValuesActions } = CombinedProvider.get(
 const { RefreshStore } = CombinedProvider.get('Refresh');
 const { SystemStore } = CombinedProvider.get('System');
 
-const FieldQuickValues = React.createClass({
+const FieldQuickValues = createReactClass({
+  displayName: 'FieldQuickValues',
+
   propTypes: {
     permissions: PropTypes.arrayOf(PropTypes.string).isRequired,
     query: PropTypes.string.isRequired,
@@ -29,6 +32,7 @@ const FieldQuickValues = React.createClass({
     forceFetch: PropTypes.bool,
     fields: PropTypes.arrayOf(PropTypes.object),
   },
+
   mixins: [Reflux.listenTo(RefreshStore, '_setupTimer', '_setupTimer'), Reflux.connect(FieldQuickValuesStore)],
 
   DEFAULT_OPTIONS: {
@@ -60,6 +64,7 @@ const FieldQuickValues = React.createClass({
   componentDidMount() {
     this._loadQuickValuesData();
   },
+
   componentWillReceiveProps(nextProps) {
     // Reload values when executed search changes
     if (this.props.query !== nextProps.query ||
@@ -70,12 +75,14 @@ const FieldQuickValues = React.createClass({
       this._loadQuickValuesData();
     }
   },
+
   componentDidUpdate(oldProps, oldState) {
     if (this.state.field !== oldState.field) {
       const element = ReactDOM.findDOMNode(this);
       UIUtils.scrollToHint(element);
     }
   },
+
   componentWillUnmount() {
     this._stopTimer();
   },
@@ -89,11 +96,13 @@ const FieldQuickValues = React.createClass({
       this.timer = setInterval(this._loadQuickValuesData, refresh.interval);
     }
   },
+
   _stopTimer() {
     if (this.timer) {
       clearInterval(this.timer);
     }
   },
+
   addField(field) {
     this.setState({
       field: field,
@@ -102,6 +111,7 @@ const FieldQuickValues = React.createClass({
       options: this.DEFAULT_OPTIONS,
     }, () => this._loadQuickValuesData(false));
   },
+
   // Builds a field query object list: [{ field: "cluster_id", value: "a" }, { field: "source", value: "b" }, ...]
   _buildFieldQueryObjects() {
     // We build a list of field query objects from the terms and terms_mapping data.
@@ -162,6 +172,7 @@ const FieldQuickValues = React.createClass({
       return list;
     }, []);
   },
+
   _loadQuickValuesData() {
     if (this.state.field !== undefined) {
       this.setState({ loadingData: true });
@@ -176,6 +187,7 @@ const FieldQuickValues = React.createClass({
       }
     }
   },
+
   _resetStatus() {
     this.setState(this.getInitialState());
   },

--- a/graylog2-web-interface/src/components/field-analyzers/FieldStatistics.jsx
+++ b/graylog2-web-interface/src/components/field-analyzers/FieldStatistics.jsx
@@ -1,5 +1,6 @@
 import PropTypes from 'prop-types';
 import React from 'react';
+import createReactClass from 'create-react-class';
 import Reflux from 'reflux';
 import Immutable from 'immutable';
 import { Button } from 'react-bootstrap';
@@ -13,7 +14,9 @@ const RefreshStore = StoreProvider.getStore('Refresh');
 import NumberUtils from 'util/NumberUtils';
 import UserNotification from 'util/UserNotification';
 
-const FieldStatistics = React.createClass({
+const FieldStatistics = createReactClass({
+  displayName: 'FieldStatistics',
+
   propTypes: {
     permissions: PropTypes.arrayOf(PropTypes.string).isRequired,
     query: PropTypes.string.isRequired,
@@ -22,6 +25,7 @@ const FieldStatistics = React.createClass({
     stream: PropTypes.object,
     forceFetch: PropTypes.bool,
   },
+
   mixins: [Reflux.listenTo(RefreshStore, '_setupTimer', '_setupTimer')],
 
   getInitialState() {
@@ -90,6 +94,7 @@ const FieldStatistics = React.createClass({
       });
     }
   },
+
   _changeSortOrder(column) {
     if (this.state.sortBy === column) {
       this.setState({ sortDescending: !this.state.sortDescending });
@@ -101,6 +106,7 @@ const FieldStatistics = React.createClass({
   _resetStatus() {
     this.setState(this.getInitialState());
   },
+
   _renderStatistics() {
     const statistics = [];
 
@@ -140,6 +146,7 @@ const FieldStatistics = React.createClass({
 
     return statistics;
   },
+
   _renderStatisticalFunctionsHeaders() {
     return FieldStatisticsStore.FUNCTIONS.keySeq().map((statFunction) => {
       return (
@@ -149,12 +156,14 @@ const FieldStatistics = React.createClass({
       );
     });
   },
+
   _getHeaderCaret(column) {
     if (this.state.sortBy !== column) {
       return null;
     }
     return this.state.sortDescending ? <i className="fa fa-caret-down" /> : <i className="fa fa-caret-up" />;
   },
+
   render() {
     let content;
 

--- a/graylog2-web-interface/src/components/field-analyzers/LegacyFieldGraph.jsx
+++ b/graylog2-web-interface/src/components/field-analyzers/LegacyFieldGraph.jsx
@@ -1,5 +1,6 @@
 import PropTypes from 'prop-types';
 import React from 'react';
+import createReactClass from 'create-react-class';
 import ReactDOM from 'react-dom';
 import { Button, ButtonGroup, DropdownButton } from 'react-bootstrap';
 import PureRenderMixin from 'react-addons-pure-render-mixin';
@@ -13,7 +14,9 @@ const FieldGraphsStore = StoreProvider.getStore('FieldGraphs');
 
 import StringUtils from 'util/StringUtils';
 
-const LegacyFieldGraph = React.createClass({
+const LegacyFieldGraph = createReactClass({
+  displayName: 'LegacyFieldGraph',
+
   propTypes: {
     graphId: PropTypes.string.isRequired,
     from: PropTypes.any.isRequired,
@@ -25,10 +28,13 @@ const LegacyFieldGraph = React.createClass({
     permissions: PropTypes.arrayOf(PropTypes.string).isRequired,
     onDelete: PropTypes.func.isRequired,
   },
+
   mixins: [PureRenderMixin],
+
   componentDidMount() {
     FieldGraphsStore.renderFieldGraph(this.props.graphOptions, this.fieldGraphContainer);
   },
+
   componentDidUpdate(prevProps) {
     if (this.props.from !== prevProps.from || this.props.to !== prevProps.to) {
       FieldGraphsStore.updateFieldGraphData(this.props.graphId, this.fieldGraphContainer);
@@ -37,7 +43,6 @@ const LegacyFieldGraph = React.createClass({
 
   STACKED_WIDGET_TYPE: 'STACKED_CHART',
   REGULAR_WIDGET_TYPE: 'FIELD_CHART',
-
   statisticalFunctions: ['mean', 'max', 'min', 'total', 'count', 'cardinality'],
   interpolations: ['linear', 'step-after', 'basis', 'bundle', 'cardinal', 'monotone'],
   resolutions: ['minute', 'hour', 'day', 'week', 'month', 'quarter', 'year'],
@@ -49,19 +54,24 @@ const LegacyFieldGraph = React.createClass({
 
     return this.props.from;
   },
+
   _getGraphTitle() {
     return this.props.stacked ? 'Combined graph' : `${this.props.graphOptions.field} graph`;
   },
+
   _getWidgetType() {
     return this.props.stacked ? this.STACKED_WIDGET_TYPE : this.REGULAR_WIDGET_TYPE;
   },
+
   _getWidgetConfiguration() {
     return this.props.stacked ? FieldGraphsStore.getStackedGraphAsCreateWidgetRequestParams(this.props.graphId) :
       FieldGraphsStore.getFieldGraphAsCreateWidgetRequestParams(this.props.graphId);
   },
+
   _submenuItemClassName(configKey, value) {
     return this.props.graphOptions[configKey] === value ? 'selected' : '';
   },
+
   _getSubmenu(configKey, values) {
     const submenuItems = values.map((value) => {
       const readableName = (configKey === 'valuetype') ? GraphVisualization.getReadableFieldChartStatisticalFunction(value) : value;
@@ -76,7 +86,9 @@ const LegacyFieldGraph = React.createClass({
 
     return <ul className={`dropdown-menu ${configKey}-selector`}>{submenuItems}</ul>;
   },
+
   renderers: ['area', 'bar', 'line', 'scatterplot'],
+
   render() {
     const submenus = [
       <li key="renderer-submenu" className="dropdown-submenu left-submenu">

--- a/graylog2-web-interface/src/components/field-analyzers/QuickValuesOptionsForm.jsx
+++ b/graylog2-web-interface/src/components/field-analyzers/QuickValuesOptionsForm.jsx
@@ -9,8 +9,8 @@ import SearchUtils from 'util/SearchUtils';
 
 import style from './QuickValuesOptionsForm.css';
 
-const QuickValuesOptionsForm = React.createClass({
-  propTypes: {
+class QuickValuesOptionsForm extends React.Component {
+  static propTypes = {
     limit: PropTypes.number.isRequired,
     tableSize: PropTypes.number.isRequired,
     order: PropTypes.string.isRequired,
@@ -22,50 +22,46 @@ const QuickValuesOptionsForm = React.createClass({
     isHistogram: PropTypes.bool.isRequired,
     onSave: PropTypes.func.isRequired,
     onCancel: PropTypes.func.isRequired,
-  },
+  };
 
-  getDefaultProps() {
-    return {
-      disableStackedFields: false,
-    };
-  },
+  static defaultProps = {
+    disableStackedFields: false,
+  };
 
-  getInitialState() {
-    return {
-      limit: this.props.limit,
-      tableSize: this.props.tableSize,
-      order: this.props.order,
-      stackedFields: this.props.stackedFields,
-      interval: this.props.interval,
-    };
-  },
+  state = {
+    limit: this.props.limit,
+    tableSize: this.props.tableSize,
+    order: this.props.order,
+    stackedFields: this.props.stackedFields,
+    interval: this.props.interval,
+  };
 
-  _changeConfig(key, value) {
+  _changeConfig = (key, value) => {
     const state = _.cloneDeep(this.state);
     state[key] = value;
     this.setState(state);
-  },
+  };
 
-  _onChange(event) {
+  _onChange = (event) => {
     this._changeConfig(event.target.name, FormsUtils.getValueFromInput(event.target));
-  },
+  };
 
-  _onStackedFieldChange(values) {
+  _onStackedFieldChange = (values) => {
     this._changeConfig('stackedFields', values);
-  },
+  };
 
-  _onIntervalChange(value) {
+  _onIntervalChange = (value) => {
     this._changeConfig('interval', value);
-  },
+  };
 
-  _onCancel() {
+  _onCancel = () => {
     this.props.onCancel();
-  },
+  };
 
-  _onSave(e) {
+  _onSave = (e) => {
     e.preventDefault();
     this.props.onSave(this.state);
-  },
+  };
 
   render() {
     const fieldOptions = this.props.stackedFieldsOptions
@@ -160,7 +156,7 @@ const QuickValuesOptionsForm = React.createClass({
         </Col>
       </Row>
     );
-  },
-});
+  }
+}
 
 export default QuickValuesOptionsForm;

--- a/graylog2-web-interface/src/components/gettingstarted/GettingStarted.jsx
+++ b/graylog2-web-interface/src/components/gettingstarted/GettingStarted.jsx
@@ -8,8 +8,8 @@ import { Spinner } from 'components/common';
 import ActionsProvider from 'injection/ActionsProvider';
 const GettingStartedActions = ActionsProvider.getActions('GettingStarted');
 
-const GettingStarted = React.createClass({
-  propTypes() {
+class GettingStarted extends React.Component {
+  static propTypes() {
     return {
       clusterId: PropTypes.string.isRequired,
       masterOs: PropTypes.string.isRequired,
@@ -18,21 +18,22 @@ const GettingStarted = React.createClass({
       noDismissButton: PropTypes.bool,
       onDismiss: PropTypes.func,
     };
-  },
-  getInitialState() {
-    return {
-      guideLoaded: false,
-      guideUrl: '',
-      showStaticContent: false,
-      frameHeight: '500px',
-    };
-  },
+  }
+
+  state = {
+    guideLoaded: false,
+    guideUrl: '',
+    showStaticContent: false,
+    frameHeight: '500px',
+  };
+
   componentDidMount() {
     if (window.addEventListener) {
       window.addEventListener('message', this._onMessage);
     }
     this.timeoutId = window.setTimeout(this._displayFallbackContent, 3000);
-  },
+  }
+
   componentWillUnmount() {
     if (window.removeEventListener) {
       window.removeEventListener('message', this._onMessage);
@@ -41,10 +42,11 @@ const GettingStarted = React.createClass({
       window.clearTimeout(Number(this.timeoutId));
       this.timeoutId = null;
     }
-  },
+  }
 
-  timeoutId: null,
-  _onMessage(messageEvent) {
+  timeoutId = null;
+
+  _onMessage = (messageEvent) => {
     // make sure we only process messages from the getting started url, otherwise this can interfere with other messages being posted
     if (this.props.gettingStartedUrl.indexOf(messageEvent.origin) === 0) {
       if (this.timeoutId !== null) {
@@ -57,17 +59,20 @@ const GettingStarted = React.createClass({
         minHeight: messageEvent.data.height === 0 ? this.state.minHeight : messageEvent.data.height,
       });
     }
-  },
-  _displayFallbackContent() {
+  };
+
+  _displayFallbackContent = () => {
     this.setState({ showStaticContent: true });
-  },
-  _dismissGuide() {
+  };
+
+  _dismissGuide = () => {
     GettingStartedActions.dismiss.triggerPromise().then(() => {
       if (this.props.onDismiss) {
         this.props.onDismiss();
       }
     });
-  },
+  };
+
   render() {
     let dismissButton = null;
     if (!this.props.noDismissButton) {
@@ -141,7 +146,7 @@ const GettingStarted = React.createClass({
         {gettingStartedContent}
       </div>
     );
-  },
-});
+  }
+}
 
 export default GettingStarted;

--- a/graylog2-web-interface/src/components/grok-patterns/BulkLoadPatternModal.jsx
+++ b/graylog2-web-interface/src/components/grok-patterns/BulkLoadPatternModal.jsx
@@ -10,17 +10,16 @@ const GrokPatternsStore = StoreProvider.getStore('GrokPatterns');
 
 import BootstrapModalForm from 'components/bootstrap/BootstrapModalForm';
 
-const BulkLoadPatternModal = React.createClass({
-  propTypes: {
+class BulkLoadPatternModal extends React.Component {
+  static propTypes = {
     onSuccess: PropTypes.func.isRequired,
-  },
-  getInitialState() {
-    return {
-      replacePatterns: false,
-    };
-  },
+  };
 
-  _onSubmit(evt) {
+  state = {
+    replacePatterns: false,
+  };
+
+  _onSubmit = (evt) => {
     evt.preventDefault();
 
     const reader = new FileReader();
@@ -35,7 +34,8 @@ const BulkLoadPatternModal = React.createClass({
     };
 
     reader.readAsText(this.refs['pattern-file'].getInputDOMNode().files[0]);
-  },
+  };
+
   render() {
     return (
       <span>
@@ -61,7 +61,7 @@ const BulkLoadPatternModal = React.createClass({
         </BootstrapModalForm>
       </span>
     );
-  },
-});
+  }
+}
 
 export default BulkLoadPatternModal;

--- a/graylog2-web-interface/src/components/grok-patterns/EditPatternModal.jsx
+++ b/graylog2-web-interface/src/components/grok-patterns/EditPatternModal.jsx
@@ -2,31 +2,33 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import { BootstrapModalForm, Input } from 'components/bootstrap';
 
-const EditPatternModal = React.createClass({
-  propTypes: {
+class EditPatternModal extends React.Component {
+  static propTypes = {
     id: PropTypes.string,
     name: PropTypes.string,
     pattern: PropTypes.string,
     create: PropTypes.bool,
     savePattern: PropTypes.func.isRequired,
     validPatternName: PropTypes.func.isRequired,
-  },
-  getInitialState() {
-    return {
-      id: this.props.id,
-      name: this.props.name,
-      pattern: this.props.pattern,
-      error: false,
-      error_message: '',
-    };
-  },
-  openModal() {
+  };
+
+  state = {
+    id: this.props.id,
+    name: this.props.name,
+    pattern: this.props.pattern,
+    error: false,
+    error_message: '',
+  };
+
+  openModal = () => {
     this.refs.modal.open();
-  },
-  _onPatternChange(event) {
+  };
+
+  _onPatternChange = (event) => {
     this.setState({ pattern: event.target.value });
-  },
-  _onNameChange(event) {
+  };
+
+  _onNameChange = (event) => {
     const name = event.target.value;
 
     if (!this.props.validPatternName(name)) {
@@ -34,26 +36,31 @@ const EditPatternModal = React.createClass({
     } else {
       this.setState({ name: name, error: false, error_message: '' });
     }
-  },
-  _getId(prefixIdName) {
+  };
+
+  _getId = (prefixIdName) => {
     return this.state.name !== undefined ? prefixIdName + this.state.name : prefixIdName;
-  },
-  _closeModal() {
+  };
+
+  _closeModal = () => {
     this.refs.modal.close();
-  },
-  _saved() {
+  };
+
+  _saved = () => {
     this._closeModal();
     if (this.props.create) {
       this.setState({ name: '', pattern: '' });
     }
-  },
-  _save() {
+  };
+
+  _save = () => {
     const pattern = this.state;
 
     if (!pattern.error) {
       this.props.savePattern(pattern, this._saved);
     }
-  },
+  };
+
   render() {
     let triggerButtonContent;
     if (this.props.create) {
@@ -90,7 +97,7 @@ const EditPatternModal = React.createClass({
         </BootstrapModalForm>
       </span>
     );
-  },
-});
+  }
+}
 
 export default EditPatternModal;

--- a/graylog2-web-interface/src/components/grok-patterns/GrokPatterns.jsx
+++ b/graylog2-web-interface/src/components/grok-patterns/GrokPatterns.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import createReactClass from 'create-react-class';
 import { Row, Col, Button } from 'react-bootstrap';
 
 import StoreProvider from 'injection/StoreProvider';
@@ -11,15 +12,19 @@ import BulkLoadPatternModal from 'components/grok-patterns/BulkLoadPatternModal'
 import DataTable from 'components/common/DataTable';
 import IfPermitted from 'components/common/IfPermitted';
 
-const GrokPatterns = React.createClass({
+const GrokPatterns = createReactClass({
+  displayName: 'GrokPatterns',
+
   getInitialState() {
     return {
       patterns: [],
     };
   },
+
   componentDidMount() {
     this.loadData();
   },
+
   loadData() {
     GrokPatternsStore.loadPatterns((patterns) => {
       if (this.isMounted()) {
@@ -29,21 +34,25 @@ const GrokPatterns = React.createClass({
       }
     });
   },
+
   validPatternName(name) {
     // Check if patterns already contain a pattern with the given name.
     return !this.state.patterns.some(pattern => pattern.name === name);
   },
+
   savePattern(pattern, callback) {
     GrokPatternsStore.savePattern(pattern, () => {
       callback();
       this.loadData();
     });
   },
+
   confirmedRemove(pattern) {
     if (window.confirm(`Really delete the grok pattern ${pattern.name}?\nIt will be removed from the system and unavailable for any extractor. If it is still in use by extractors those will fail to work.`)) {
       GrokPatternsStore.deletePattern(pattern, this.loadData);
     }
   },
+
   _headerCellFormatter(header) {
     let formattedHeaderCell;
 
@@ -60,6 +69,7 @@ const GrokPatterns = React.createClass({
 
     return formattedHeaderCell;
   },
+
   _patternFormatter(pattern) {
     return (
       <tr key={pattern.id}>
@@ -85,6 +95,7 @@ const GrokPatterns = React.createClass({
       </tr>
     );
   },
+
   render() {
     const headers = ['Name', 'Pattern', 'Actions'];
     const filterKeys = ['name'];

--- a/graylog2-web-interface/src/components/indexers/IndexerClusterHealth.jsx
+++ b/graylog2-web-interface/src/components/indexers/IndexerClusterHealth.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import createReactClass from 'create-react-class';
 import Reflux from 'reflux';
 import { Row, Col } from 'react-bootstrap';
 
@@ -10,7 +11,8 @@ import { DocumentationLink, SmallSupportLink } from 'components/support';
 import DocsHelper from 'util/DocsHelper';
 import { IndexerClusterHealthSummary } from 'components/indexers';
 
-const IndexerClusterHealth = React.createClass({
+const IndexerClusterHealth = createReactClass({
+  displayName: 'IndexerClusterHealth',
   mixins: [Reflux.connect(IndexerClusterStore)],
 
   componentDidMount() {

--- a/graylog2-web-interface/src/components/indexers/IndexerClusterHealthSummary.jsx
+++ b/graylog2-web-interface/src/components/indexers/IndexerClusterHealthSummary.jsx
@@ -5,19 +5,21 @@ import { Alert } from 'react-bootstrap';
 import { DocumentationLink } from 'components/support';
 import DocsHelper from 'util/DocsHelper';
 
-const IndexerClusterHealthSummary = React.createClass({
-  propTypes: {
+class IndexerClusterHealthSummary extends React.Component {
+  static propTypes = {
     health: PropTypes.object.isRequired,
-  },
-  _alertClassForHealth(health) {
+  };
+
+  _alertClassForHealth = (health) => {
     switch (health.status) {
       case 'green': return 'success';
       case 'yellow': return 'warning';
       case 'red': return 'danger';
       default: return 'success';
     }
-  },
-  _formatTextForHealth(health) {
+  };
+
+  _formatTextForHealth = (health) => {
     const text = `Elasticsearch cluster is ${health.status}.`;
     switch (health.status) {
       case 'green': return text;
@@ -25,15 +27,17 @@ const IndexerClusterHealthSummary = React.createClass({
       case 'red': return <strong>{text}</strong>;
       default: return text;
     }
-  },
-  _iconNameForHealth(health) {
+  };
+
+  _iconNameForHealth = (health) => {
     switch (health.status) {
       case 'green': return 'check-circle';
       case 'yellow': return 'warning';
       case 'red': return 'ambulance';
       default: return 'check-circle';
     }
-  },
+  };
+
   render() {
     const { health } = this.props;
     return (
@@ -47,7 +51,7 @@ const IndexerClusterHealthSummary = React.createClass({
         <DocumentationLink page={DocsHelper.PAGES.CLUSTER_STATUS_EXPLAINED} text="What does this mean?" />
       </Alert>
     );
-  },
-});
+  }
+}
 
 export default IndexerClusterHealthSummary;

--- a/graylog2-web-interface/src/components/indexers/IndexerFailure.jsx
+++ b/graylog2-web-interface/src/components/indexers/IndexerFailure.jsx
@@ -2,10 +2,11 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import { Timestamp } from 'components/common';
 
-const IndexerFailure = React.createClass({
-  propTypes: {
+class IndexerFailure extends React.Component {
+  static propTypes = {
     failure: PropTypes.object.isRequired,
-  },
+  };
+
   render() {
     const failure = this.props.failure;
     return (
@@ -16,7 +17,7 @@ const IndexerFailure = React.createClass({
         <td>{failure.message}</td>
       </tr>
     );
-  },
-});
+  }
+}
 
 export default IndexerFailure;

--- a/graylog2-web-interface/src/components/indexers/IndexerFailuresComponent.jsx
+++ b/graylog2-web-interface/src/components/indexers/IndexerFailuresComponent.jsx
@@ -13,18 +13,18 @@ import Routes from 'routing/Routes';
 import { Spinner } from 'components/common';
 import { SmallSupportLink, DocumentationLink } from 'components/support';
 
-const IndexerFailuresComponent = React.createClass({
-  getInitialState() {
-    return {};
-  },
+class IndexerFailuresComponent extends React.Component {
+  state = {};
+
   componentDidMount() {
     const since = moment().subtract(24, 'hours');
 
     IndexerFailuresStore.count(since).then((response) => {
       this.setState({ total: response.count });
     });
-  },
-  _formatFailuresSummary() {
+  }
+
+  _formatFailuresSummary = () => {
     return (
       <Alert bsStyle={this.state.total === 0 ? 'success' : 'danger'}>
         <i className={`fa fa-${this._iconForFailureCount(this.state.total)}`} /> {this._formatTextForFailureCount(this.state.total)}
@@ -36,19 +36,22 @@ const IndexerFailuresComponent = React.createClass({
         </LinkContainer>
       </Alert>
     );
-  },
-  _formatTextForFailureCount(count) {
+  };
+
+  _formatTextForFailureCount = (count) => {
     if (count === 0) {
       return 'No failed indexing attempts in the last 24 hours.';
     }
     return <strong>There were {numeral(count).format('0,0')} failed indexing attempts in the last 24 hours.</strong>;
-  },
-  _iconForFailureCount(count) {
+  };
+
+  _iconForFailureCount = (count) => {
     if (count === 0) {
       return 'check-circle';
     }
     return 'ambulance';
-  },
+  };
+
   render() {
     let content;
     if (this.state.total === undefined) {
@@ -71,7 +74,7 @@ const IndexerFailuresComponent = React.createClass({
         </Col>
       </Row>
     );
-  },
-});
+  }
+}
 
 export default IndexerFailuresComponent;

--- a/graylog2-web-interface/src/components/indexers/IndexerFailuresList.jsx
+++ b/graylog2-web-interface/src/components/indexers/IndexerFailuresList.jsx
@@ -4,10 +4,11 @@ import { Alert, Table } from 'react-bootstrap';
 
 import { IndexerFailure } from 'components/indexers';
 
-const IndexerFailuresList = React.createClass({
-  propTypes: {
+class IndexerFailuresList extends React.Component {
+  static propTypes = {
     failures: PropTypes.arrayOf(PropTypes.object).isRequired,
-  },
+  };
+
   render() {
     if (this.props.failures.length === 0) {
       return (
@@ -32,7 +33,7 @@ const IndexerFailuresList = React.createClass({
         </Table>
       </div>
     );
-  },
-});
+  }
+}
 
 export default IndexerFailuresList;

--- a/graylog2-web-interface/src/components/indices/ClosedIndexDetails.jsx
+++ b/graylog2-web-interface/src/components/indices/ClosedIndexDetails.jsx
@@ -7,19 +7,22 @@ const IndicesActions = ActionsProvider.getActions('Indices');
 
 import { IndexRangeSummary } from 'components/indices';
 
-const ClosedIndexDetails = React.createClass({
-  propTypes: {
+class ClosedIndexDetails extends React.Component {
+  static propTypes = {
     indexName: PropTypes.string.isRequired,
     indexRange: PropTypes.object,
-  },
-  _onReopen() {
+  };
+
+  _onReopen = () => {
     IndicesActions.reopen(this.props.indexName);
-  },
-  _onDeleteIndex() {
+  };
+
+  _onDeleteIndex = () => {
     if (window.confirm(`Really delete index ${this.props.indexName}?`)) {
       IndicesActions.delete(this.props.indexName);
     }
-  },
+  };
+
   render() {
     const { indexRange } = this.props;
     return (
@@ -34,7 +37,7 @@ const ClosedIndexDetails = React.createClass({
         <Button bsStyle="danger" bsSize="xs" onClick={this._onDeleteIndex}>Delete index</Button>
       </div>
     );
-  },
-});
+  }
+}
 
 export default ClosedIndexDetails;

--- a/graylog2-web-interface/src/components/indices/IndexDetails.jsx
+++ b/graylog2-web-interface/src/components/indices/IndexDetails.jsx
@@ -12,22 +12,24 @@ StoreProvider.getStore('IndexRanges'); // To make IndexRangesActions work.
 
 import { IndexRangeSummary, ShardMeter, ShardRoutingOverview } from 'components/indices';
 
-const IndexDetails = React.createClass({
-  propTypes: {
+class IndexDetails extends React.Component {
+  static propTypes = {
     index: PropTypes.object.isRequired,
     indexName: PropTypes.string.isRequired,
     indexRange: PropTypes.object.isRequired,
     indexSetId: PropTypes.string.isRequired,
     isDeflector: PropTypes.bool.isRequired,
-  },
+  };
+
   componentDidMount() {
     IndicesActions.subscribe(this.props.indexName);
-  },
+  }
+
   componentWillUnmount() {
     IndicesActions.unsubscribe(this.props.indexName);
-  },
+  }
 
-  _formatActionButtons() {
+  _formatActionButtons = () => {
     if (this.props.isDeflector) {
       return (
         <span>
@@ -44,28 +46,32 @@ const IndexDetails = React.createClass({
         <Button bsStyle="danger" bsSize="xs" onClick={this._onDeleteIndex}>Delete index</Button>
       </span>
     );
-  },
-  _onRecalculateIndex() {
+  };
+
+  _onRecalculateIndex = () => {
     if (window.confirm(`Really recalculate the index ranges for index ${this.props.indexName}?`)) {
       IndexRangesActions.recalculateIndex(this.props.indexName).then(() => {
         IndicesActions.list(this.props.indexSetId);
       });
     }
-  },
-  _onCloseIndex() {
+  };
+
+  _onCloseIndex = () => {
     if (window.confirm(`Really close index ${this.props.indexName}?`)) {
       IndicesActions.close(this.props.indexName).then(() => {
         IndicesActions.list(this.props.indexSetId);
       });
     }
-  },
-  _onDeleteIndex() {
+  };
+
+  _onDeleteIndex = () => {
     if (window.confirm(`Really delete index ${this.props.indexName}?`)) {
       IndicesActions.delete(this.props.indexName).then(() => {
         IndicesActions.list(this.props.indexSetId);
       });
     }
-  },
+  };
+
   render() {
     if (!this.props.index || !this.props.index.all_shards) {
       return <Spinner />;
@@ -95,7 +101,7 @@ const IndexDetails = React.createClass({
         {this._formatActionButtons()}
       </div>
     );
-  },
-});
+  }
+}
 
 export default IndexDetails;

--- a/graylog2-web-interface/src/components/indices/IndexMaintenanceStrategiesConfiguration.jsx
+++ b/graylog2-web-interface/src/components/indices/IndexMaintenanceStrategiesConfiguration.jsx
@@ -4,8 +4,8 @@ import { Input } from 'components/bootstrap';
 
 import { Select } from 'components/common';
 
-const IndexMaintenanceStrategiesConfiguration = React.createClass({
-  propTypes: {
+class IndexMaintenanceStrategiesConfiguration extends React.Component {
+  static propTypes = {
     title: PropTypes.string.isRequired,
     description: PropTypes.string.isRequired,
     selectPlaceholder: PropTypes.string.isRequired,
@@ -13,37 +13,35 @@ const IndexMaintenanceStrategiesConfiguration = React.createClass({
     strategies: PropTypes.array.isRequired,
     activeConfig: PropTypes.object.isRequired,
     updateState: PropTypes.func.isRequired,
-  },
+  };
 
-  getInitialState() {
-    return {
-      activeStrategy: this.props.activeConfig.strategy,
-      activeConfig: this.props.activeConfig.config,
-      newStrategy: this.props.activeConfig.strategy,
-      newConfig: this.props.activeConfig.config,
-    };
-  },
+  state = {
+    activeStrategy: this.props.activeConfig.strategy,
+    activeConfig: this.props.activeConfig.config,
+    newStrategy: this.props.activeConfig.strategy,
+    newConfig: this.props.activeConfig.config,
+  };
 
-  _getDefaultStrategyConfig(selectedStrategy) {
+  _getDefaultStrategyConfig = (selectedStrategy) => {
     const result = this.props.strategies.filter(strategy => strategy.type === selectedStrategy)[0];
     return result ? result.default_config : undefined;
-  },
+  };
 
-  _getStrategyJsonSchema(selectedStrategy) {
+  _getStrategyJsonSchema = (selectedStrategy) => {
     const result = this.props.strategies.filter(strategy => strategy.type === selectedStrategy)[0];
     return result ? result.json_schema : undefined;
-  },
+  };
 
-  _getStrategyConfig(selectedStrategy) {
+  _getStrategyConfig = (selectedStrategy) => {
     if (this.state.activeStrategy === selectedStrategy) {
       // If the newly selected strategy is the current active strategy, we use the active configuration.
       return this.state.activeConfig;
     }
       // If the newly selected strategy is not the current active strategy, we use the selected strategy's default config.
     return this._getDefaultStrategyConfig(selectedStrategy);
-  },
+  };
 
-  _onSelect(newStrategy) {
+  _onSelect = (newStrategy) => {
     if (!newStrategy || newStrategy.length < 1) {
       this.setState({ newStrategy: undefined });
       return;
@@ -53,9 +51,9 @@ const IndexMaintenanceStrategiesConfiguration = React.createClass({
 
     this.setState({ newStrategy: newStrategy, newConfig: newConfig });
     this.props.updateState(newStrategy, newConfig);
-  },
+  };
 
-  _addConfigType(strategy, data) {
+  _addConfigType = (strategy, data) => {
     // The config object needs to have the "type" field set to the "default_config.type" to make the REST call work.
     const result = this.props.strategies.filter(s => s.type === strategy)[0];
     const copy = data;
@@ -65,22 +63,22 @@ const IndexMaintenanceStrategiesConfiguration = React.createClass({
     }
 
     return copy;
-  },
+  };
 
-  _onConfigUpdate(newConfig) {
+  _onConfigUpdate = (newConfig) => {
     const config = this._addConfigType(this.state.newStrategy, newConfig);
 
     this.setState({ newConfig: config });
     this.props.updateState(this.state.newStrategy, config);
-  },
+  };
 
-  _availableSelectOptions() {
+  _availableSelectOptions = () => {
     return this.props.pluginExports.map((config) => {
       return { value: config.type, label: config.displayName };
     });
-  },
+  };
 
-  _getConfigurationComponent(selectedStrategy) {
+  _getConfigurationComponent = (selectedStrategy) => {
     if (!selectedStrategy || selectedStrategy.length < 1) {
       return null;
     }
@@ -99,11 +97,11 @@ const IndexMaintenanceStrategiesConfiguration = React.createClass({
     });
 
     return (<span key={strategy.type}>{element}</span>);
-  },
+  };
 
-  _activeSelection() {
+  _activeSelection = () => {
     return this.state.newStrategy;
-  },
+  };
 
   render() {
     return (
@@ -120,7 +118,7 @@ const IndexMaintenanceStrategiesConfiguration = React.createClass({
         {this._getConfigurationComponent(this._activeSelection())}
       </span>
     );
-  },
-});
+  }
+}
 
 export default IndexMaintenanceStrategiesConfiguration;

--- a/graylog2-web-interface/src/components/indices/IndexMaintenanceStrategiesSummary.jsx
+++ b/graylog2-web-interface/src/components/indices/IndexMaintenanceStrategiesSummary.jsx
@@ -3,11 +3,11 @@ import React from 'react';
 import { Alert } from 'react-bootstrap';
 import Spinner from 'components/common/Spinner';
 
-const IndexMaintenanceStrategiesSummary = React.createClass({
-  propTypes: {
+class IndexMaintenanceStrategiesSummary extends React.Component {
+  static propTypes = {
     config: PropTypes.object.isRequired,
     pluginExports: PropTypes.array.isRequired,
-  },
+  };
 
   render() {
     if (!this.props.config) {
@@ -24,7 +24,7 @@ const IndexMaintenanceStrategiesSummary = React.createClass({
     const element = React.createElement(strategy.summaryComponent, { config: this.props.config.config });
 
     return (<span key={strategy.type}>{element}</span>);
-  },
-});
+  }
+}
 
 export default IndexMaintenanceStrategiesSummary;

--- a/graylog2-web-interface/src/components/indices/IndexRangeSummary.jsx
+++ b/graylog2-web-interface/src/components/indices/IndexRangeSummary.jsx
@@ -2,10 +2,11 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import { Timestamp } from 'components/common';
 
-const IndexRangeSummary = React.createClass({
-  propTypes: {
+class IndexRangeSummary extends React.Component {
+  static propTypes = {
     indexRange: PropTypes.object,
-  },
+  };
+
   render() {
     const { indexRange } = this.props;
     if (!indexRange) {
@@ -17,7 +18,7 @@ const IndexRangeSummary = React.createClass({
         in {indexRange.took_ms}ms.
       </span>
     );
-  },
-});
+  }
+}
 
 export default IndexRangeSummary;

--- a/graylog2-web-interface/src/components/indices/IndexSetConfigurationForm.jsx
+++ b/graylog2-web-interface/src/components/indices/IndexSetConfigurationForm.jsx
@@ -11,30 +11,28 @@ import IndexMaintenanceStrategiesConfiguration from 'components/indices/IndexMai
 import {} from 'components/indices/rotation'; // Load rotation plugin UI plugins from core.
 import {} from 'components/indices/retention'; // Load rotation plugin UI plugins from core.
 
-const IndexSetConfigurationForm = React.createClass({
-  propTypes: {
+class IndexSetConfigurationForm extends React.Component {
+  static propTypes = {
     indexSet: PropTypes.object.isRequired,
     rotationStrategies: PropTypes.array.isRequired,
     retentionStrategies: PropTypes.array.isRequired,
     create: PropTypes.bool,
     onUpdate: PropTypes.func.isRequired,
     cancelLink: PropTypes.string.isRequired,
-  },
+  };
 
-  getInitialState() {
-    return {
-      indexSet: this.props.indexSet,
-      validationErrors: {},
-    };
-  },
+  state = {
+    indexSet: this.props.indexSet,
+    validationErrors: {},
+  };
 
-  _updateConfig(fieldName, value) {
+  _updateConfig = (fieldName, value) => {
     const config = this.state.indexSet;
     config[fieldName] = value;
     this.setState({ indexSet: config });
-  },
+  };
 
-  _validateIndexPrefix(event) {
+  _validateIndexPrefix = (event) => {
     const value = event.target.value;
 
     if (value.match(/^[a-z0-9][a-z0-9_\-+]*$/)) {
@@ -58,17 +56,17 @@ const IndexSetConfigurationForm = React.createClass({
     }
 
     this._onInputChange(event);
-  },
+  };
 
-  _onInputChange(event) {
+  _onInputChange = (event) => {
     this._updateConfig(event.target.name, event.target.value);
-  },
+  };
 
-  _onDisableOptimizationClick(event) {
+  _onDisableOptimizationClick = (event) => {
     this._updateConfig(event.target.name, event.target.checked);
-  },
+  };
 
-  _saveConfiguration(event) {
+  _saveConfiguration = (event) => {
     event.preventDefault();
 
     const invalidFields = Object.keys(this.state.validationErrors);
@@ -78,18 +76,19 @@ const IndexSetConfigurationForm = React.createClass({
     }
 
     this.props.onUpdate(this.state.indexSet);
-  },
+  };
 
-  _updateRotationConfigState(strategy, data) {
+  _updateRotationConfigState = (strategy, data) => {
     this._updateConfig('rotation_strategy_class', strategy);
     this._updateConfig('rotation_strategy', data);
-  },
+  };
 
-  _updateRetentionConfigState(strategy, data) {
+  _updateRetentionConfigState = (strategy, data) => {
     this._updateConfig('retention_strategy_class', strategy);
     this._updateConfig('retention_strategy', data);
-  },
-  _onFieldTypeRefreshIntervalChange(value, unit) {
+  };
+
+  _onFieldTypeRefreshIntervalChange = (value, unit) => {
     let interval;
     switch (unit) {
       case 'NANOSECONDS':
@@ -118,7 +117,8 @@ const IndexSetConfigurationForm = React.createClass({
     }
 
     this._updateConfig('field_type_refresh_interval', interval);
-  },
+  };
+
   render() {
     const indexSet = this.props.indexSet;
     const validationErrors = this.state.validationErrors;
@@ -278,7 +278,7 @@ const IndexSetConfigurationForm = React.createClass({
         </Col>
       </Row>
     );
-  },
-});
+  }
+}
 
 export default IndexSetConfigurationForm;

--- a/graylog2-web-interface/src/components/indices/IndexSetDeletionForm.jsx
+++ b/graylog2-web-interface/src/components/indices/IndexSetDeletionForm.jsx
@@ -9,20 +9,18 @@ import naturalSort from 'javascript-natural-sort';
 import CombinedProvider from 'injection/CombinedProvider';
 const { StreamsStore } = CombinedProvider.get('Streams');
 
-const IndexSetDeletionForm = React.createClass({
-  propTypes: {
+class IndexSetDeletionForm extends React.Component {
+  static propTypes = {
     indexSet: PropTypes.object.isRequired,
     onDelete: PropTypes.func.isRequired,
-  },
+  };
 
-  getInitialState() {
-    return {
-      assignedStreams: undefined,
-      deleteIndices: true,
-    };
-  },
+  state = {
+    assignedStreams: undefined,
+    deleteIndices: true,
+  };
 
-  _onModalOpen() {
+  _onModalOpen = () => {
     StreamsStore.load((streams) => {
       const assignedStreams = [];
 
@@ -34,29 +32,29 @@ const IndexSetDeletionForm = React.createClass({
 
       this.setState({ assignedStreams: assignedStreams });
     });
-  },
+  };
 
-  _onRemoveClick(e) {
+  _onRemoveClick = (e) => {
     this.setState({ deleteIndices: e.target.checked });
-  },
+  };
 
-  open() {
+  open = () => {
     this.refs[`index-set-deletion-modal-${this.props.indexSet.id}`].open();
-  },
+  };
 
-  close() {
+  close = () => {
     this.refs[`index-set-deletion-modal-${this.props.indexSet.id}`].close();
-  },
+  };
 
-  _isLoading() {
+  _isLoading = () => {
     return !this.state.assignedStreams;
-  },
+  };
 
-  _isDeletable() {
+  _isDeletable = () => {
     return !this._isLoading() && this.state.assignedStreams.length < 1 && !this.props.indexSet.default;
-  },
+  };
 
-  _modalContent() {
+  _modalContent = () => {
     if (this._isLoading()) {
       return <Spinner text="Loading assigned streams..." />;
     }
@@ -111,15 +109,15 @@ const IndexSetDeletionForm = React.createClass({
         </Col>
       </Row>
     );
-  },
+  };
 
-  _onDelete(e) {
+  _onDelete = (e) => {
     e.preventDefault();
 
     if (this._isDeletable()) {
       this.props.onDelete(this.props.indexSet, this.state.deleteIndices);
     }
-  },
+  };
 
   render() {
     return (
@@ -132,7 +130,7 @@ const IndexSetDeletionForm = React.createClass({
         {this._modalContent()}
       </BootstrapModalForm>
     );
-  },
-});
+  }
+}
 
 export default IndexSetDeletionForm;

--- a/graylog2-web-interface/src/components/indices/IndexSetDetails.jsx
+++ b/graylog2-web-interface/src/components/indices/IndexSetDetails.jsx
@@ -6,18 +6,18 @@ import { IndicesConfiguration } from 'components/indices';
 
 const style = require('!style/useable!css!./IndexSetDetails.css');
 
-const IndexSetDetails = React.createClass({
-  propTypes: {
+class IndexSetDetails extends React.Component {
+  static propTypes = {
     indexSet: PropTypes.object.isRequired,
-  },
+  };
 
   componentDidMount() {
     style.use();
-  },
+  }
 
   componentWillUnmount() {
     style.unuse();
-  },
+  }
 
   render() {
     const indexSet = this.props.indexSet;
@@ -45,7 +45,7 @@ const IndexSetDetails = React.createClass({
         </Col>
       </Row>
     );
-  },
-});
+  }
+}
 
 export default IndexSetDetails;

--- a/graylog2-web-interface/src/components/indices/IndexSetsComponent.jsx
+++ b/graylog2-web-interface/src/components/indices/IndexSetsComponent.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import createReactClass from 'create-react-class';
 import Reflux from 'reflux';
 import { LinkContainer } from 'react-router-bootstrap';
 import { Link } from 'react-router';
@@ -15,7 +16,8 @@ import CombinedProvider from 'injection/CombinedProvider';
 
 const { IndexSetsStore, IndexSetsActions } = CombinedProvider.get('IndexSets');
 
-const IndexSetsComponent = React.createClass({
+const IndexSetsComponent = createReactClass({
+  displayName: 'IndexSetsComponent',
   mixins: [Reflux.connect(IndexSetsStore)],
 
   componentDidMount() {
@@ -31,8 +33,8 @@ const IndexSetsComponent = React.createClass({
 
   // Stores the current page and page size to be able to reload the current page
   currentPageNo: 1,
-  currentPageSize: 10,
 
+  currentPageSize: 10,
   PAGE_SIZE: 10,
 
   _onChangePaginatedList(page, size) {

--- a/graylog2-web-interface/src/components/indices/IndexSizeSummary.jsx
+++ b/graylog2-web-interface/src/components/indices/IndexSizeSummary.jsx
@@ -3,10 +3,11 @@ import React from 'react';
 import numeral from 'numeral';
 import NumberUtils from 'util/NumberUtils';
 
-const IndexSizeSummary = React.createClass({
-  propTypes: {
+class IndexSizeSummary extends React.Component {
+  static propTypes = {
     index: PropTypes.object.isRequired,
-  },
+  };
+
   render() {
     const { index } = this.props;
     if (index.size) {
@@ -17,7 +18,7 @@ const IndexSizeSummary = React.createClass({
     }
 
     return <span />;
-  },
-});
+  }
+}
 
 export default IndexSizeSummary;

--- a/graylog2-web-interface/src/components/indices/IndexSummary.jsx
+++ b/graylog2-web-interface/src/components/indices/IndexSummary.jsx
@@ -7,18 +7,18 @@ import DateTime from 'logic/datetimes/DateTime';
 
 import { IndexSizeSummary } from 'components/indices';
 
-const IndexSummary = React.createClass({
-  propTypes: {
+class IndexSummary extends React.Component {
+  static propTypes = {
     children: PropTypes.node.isRequired,
     index: PropTypes.object.isRequired,
     indexRange: PropTypes.object,
     isDeflector: PropTypes.bool.isRequired,
     name: PropTypes.string.isRequired,
-  },
-  getInitialState() {
-    return { showDetails: this.props.isDeflector };
-  },
-  _formatLabels(index) {
+  };
+
+  state = { showDetails: this.props.isDeflector };
+
+  _formatLabels = (index) => {
     const labels = [];
     if (index.is_deflector) {
       labels.push(<Label key={`${this.props.name}-deflector-label`} bsStyle="primary">active write index</Label>);
@@ -33,9 +33,9 @@ const IndexSummary = React.createClass({
     }
 
     return <span className="index-label">{labels}</span>;
-  },
+  };
 
-  _formatIndexRange() {
+  _formatIndexRange = () => {
     if (this.props.isDeflector) {
       return <span>Contains messages up to <Timestamp dateTime={new DateTime().toISOString()} relative /></span>;
     }
@@ -63,17 +63,20 @@ const IndexSummary = React.createClass({
         <Timestamp dateTime={this.props.indexRange.end} relative />
       </span>
     );
-  },
-  _formatShowDetailsLink() {
+  };
+
+  _formatShowDetailsLink = () => {
     if (this.state.showDetails) {
       return <span className="index-more-actions"><i className="fa fa-caret-down" /> Hide Details / Actions</span>;
     }
     return <span className="index-more-actions"><i className="fa fa-caret-right" /> Show Details / Actions</span>;
-  },
-  _toggleShowDetails(event) {
+  };
+
+  _toggleShowDetails = (event) => {
     event.preventDefault();
     this.setState({ showDetails: !this.state.showDetails });
-  },
+  };
+
   render() {
     const index = this.props.index;
     return (
@@ -96,7 +99,7 @@ const IndexSummary = React.createClass({
         </div>
       </span>
     );
-  },
-});
+  }
+}
 
 export default IndexSummary;

--- a/graylog2-web-interface/src/components/indices/IndicesConfiguration.jsx
+++ b/graylog2-web-interface/src/components/indices/IndicesConfiguration.jsx
@@ -10,18 +10,18 @@ import {} from 'components/indices/retention'; // Load rotation plugin UI plugin
 
 const style = require('!style/useable!css!components/configurations/ConfigurationStyles.css');
 
-const IndicesConfiguration = React.createClass({
-  propTypes: {
+class IndicesConfiguration extends React.Component {
+  static propTypes = {
     indexSet: PropTypes.object.isRequired,
-  },
+  };
 
   componentDidMount() {
     style.use();
-  },
+  }
 
   componentWillUnmount() {
     style.unuse();
-  },
+  }
 
   render() {
     if (!this.props.indexSet.writable) {
@@ -56,7 +56,7 @@ const IndicesConfiguration = React.createClass({
         </Col>
       </Row>
     );
-  },
-});
+  }
+}
 
 export default IndicesConfiguration;

--- a/graylog2-web-interface/src/components/indices/IndicesMaintenanceDropdown.jsx
+++ b/graylog2-web-interface/src/components/indices/IndicesMaintenanceDropdown.jsx
@@ -9,24 +9,26 @@ const IndexRangesActions = ActionsProvider.getActions('IndexRanges');
 import StoreProvider from 'injection/StoreProvider';
 const DeflectorStore = StoreProvider.getStore('Deflector'); // eslint-disable-line no-unused-vars
 
-const IndicesMaintenanceDropdown = React.createClass({
-  propTypes: {
+class IndicesMaintenanceDropdown extends React.Component {
+  static propTypes = {
     indexSetId: PropTypes.string.isRequired,
     indexSet: PropTypes.object,
-  },
+  };
 
-  _onRecalculateIndexRange() {
+  _onRecalculateIndexRange = () => {
     if (window.confirm('This will recalculate index ranges for this index set using a background system job. Do you want to proceed?')) {
       IndexRangesActions.recalculate(this.props.indexSetId);
     }
-  },
-  _onCycleDeflector() {
+  };
+
+  _onCycleDeflector = () => {
     if (window.confirm('This will manually cycle the current active write index on this index set. Do you want to proceed?')) {
       DeflectorActions.cycle(this.props.indexSetId).then(() => {
         DeflectorActions.list(this.props.indexSetId);
       });
     }
-  },
+  };
+
   render() {
     let cycleButton;
     if (this.props.indexSet && this.props.indexSet.writable) {
@@ -40,7 +42,7 @@ const IndicesMaintenanceDropdown = React.createClass({
         </DropdownButton>
       </ButtonGroup>
     );
-  },
-});
+  }
+}
 
 export default IndicesMaintenanceDropdown;

--- a/graylog2-web-interface/src/components/indices/IndicesOverview.jsx
+++ b/graylog2-web-interface/src/components/indices/IndicesOverview.jsx
@@ -5,15 +5,16 @@ import naturalSort from 'javascript-natural-sort';
 
 import { ClosedIndexDetails, IndexDetails, IndexSummary } from 'components/indices';
 
-const IndicesOverview = React.createClass({
-  propTypes: {
+class IndicesOverview extends React.Component {
+  static propTypes = {
     closedIndices: PropTypes.array.isRequired,
     deflector: PropTypes.object.isRequired,
     indexDetails: PropTypes.object.isRequired,
     indices: PropTypes.object.isRequired,
     indexSetId: PropTypes.string.isRequired,
-  },
-  _formatIndex(indexName, index) {
+  };
+
+  _formatIndex = (indexName, index) => {
     const indexSummary = this.props.indices[indexName];
     const indexRange = indexSummary && indexSummary.range ? indexSummary.range : null;
     return (
@@ -32,8 +33,9 @@ const IndicesOverview = React.createClass({
         </Col>
       </Row>
     );
-  },
-  _formatClosedIndex(indexName, index) {
+  };
+
+  _formatClosedIndex = (indexName, index) => {
     const indexRange = index.range;
     return (
       <Row key={`index-summary-${indexName}`} className="content index-description">
@@ -46,7 +48,8 @@ const IndicesOverview = React.createClass({
         </Col>
       </Row>
     );
-  },
+  };
+
   render() {
     const indices = Object.keys(this.props.indices).map((indexName) => {
       return !this.props.indices[indexName].is_closed ?
@@ -57,7 +60,7 @@ const IndicesOverview = React.createClass({
         {indices.sort((index1, index2) => naturalSort(index2.key, index1.key))}
       </span>
     );
-  },
-});
+  }
+}
 
 export default IndicesOverview;

--- a/graylog2-web-interface/src/components/indices/ShardMeter.jsx
+++ b/graylog2-web-interface/src/components/indices/ShardMeter.jsx
@@ -3,12 +3,13 @@ import React from 'react';
 import numeral from 'numeral';
 import moment from 'moment';
 
-const ShardMeter = React.createClass({
-  propTypes: {
+class ShardMeter extends React.Component {
+  static propTypes = {
     title: PropTypes.string.isRequired,
     shardMeter: PropTypes.object.isRequired,
-  },
-  _formatMeter(meter) {
+  };
+
+  _formatMeter = (meter) => {
     const value = <span>{numeral(meter.total).format('0,0')} ops</span>;
 
     if (meter.total > 0) {
@@ -16,7 +17,8 @@ const ShardMeter = React.createClass({
     }
 
     return value;
-  },
+  };
+
   render() {
     const sm = this.props.shardMeter;
     return (
@@ -46,7 +48,7 @@ const ShardMeter = React.createClass({
         </dl>
       </span>
     );
-  },
-});
+  }
+}
 
 export default ShardMeter;

--- a/graylog2-web-interface/src/components/indices/ShardRouting.jsx
+++ b/graylog2-web-interface/src/components/indices/ShardRouting.jsx
@@ -3,10 +3,11 @@ import React from 'react';
 import classNames from 'classnames';
 import { OverlayTrigger, Tooltip } from 'react-bootstrap';
 
-const ShardRouting = React.createClass({
-  propTypes: {
+class ShardRouting extends React.Component {
+  static propTypes = {
     route: PropTypes.object.isRequired,
-  },
+  };
+
   render() {
     const route = this.props.route;
     const tooltip = <Tooltip id="shard-route-state-tooltip">State: <i>{route.state}</i> on {route.node_hostname} ({route.node_name})</Tooltip>;
@@ -17,7 +18,7 @@ const ShardRouting = React.createClass({
         </OverlayTrigger>
       </li>
     );
-  },
-});
+  }
+}
 
 export default ShardRouting;

--- a/graylog2-web-interface/src/components/indices/ShardRoutingOverview.jsx
+++ b/graylog2-web-interface/src/components/indices/ShardRoutingOverview.jsx
@@ -4,11 +4,12 @@ import React from 'react';
 import { ShardRouting } from 'components/indices';
 import naturalSort from 'javascript-natural-sort';
 
-const ShardRoutingOverview = React.createClass({
-  propTypes: {
+class ShardRoutingOverview extends React.Component {
+  static propTypes = {
     routing: PropTypes.array.isRequired,
     indexName: PropTypes.string.isRequired,
-  },
+  };
+
   render() {
     const { indexName, routing } = this.props;
     return (
@@ -30,7 +31,7 @@ const ShardRoutingOverview = React.createClass({
         </div>
       </div>
     );
-  },
-});
+  }
+}
 
 export default ShardRoutingOverview;

--- a/graylog2-web-interface/src/components/indices/retention/ClosingRetentionStrategyConfiguration.jsx
+++ b/graylog2-web-interface/src/components/indices/retention/ClosingRetentionStrategyConfiguration.jsx
@@ -2,20 +2,18 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import { Input } from 'components/bootstrap';
 
-const ClosingRetentionStrategyConfiguration = React.createClass({
-  propTypes: {
+class ClosingRetentionStrategyConfiguration extends React.Component {
+  static propTypes = {
     config: PropTypes.object.isRequired,
     jsonSchema: PropTypes.object.isRequired,
     updateConfig: PropTypes.func.isRequired,
-  },
+  };
 
-  getInitialState() {
-    return {
-      max_number_of_indices: this.props.config.max_number_of_indices,
-    };
-  },
+  state = {
+    max_number_of_indices: this.props.config.max_number_of_indices,
+  };
 
-  _onInputUpdate(field) {
+  _onInputUpdate = (field) => {
     return (e) => {
       const update = {};
       update[field] = e.target.value;
@@ -23,7 +21,7 @@ const ClosingRetentionStrategyConfiguration = React.createClass({
       this.setState(update);
       this.props.updateConfig(update);
     };
-  },
+  };
 
   render() {
     return (
@@ -39,7 +37,7 @@ const ClosingRetentionStrategyConfiguration = React.createClass({
         </fieldset>
       </div>
     );
-  },
-});
+  }
+}
 
 export default ClosingRetentionStrategyConfiguration;

--- a/graylog2-web-interface/src/components/indices/retention/ClosingRetentionStrategySummary.jsx
+++ b/graylog2-web-interface/src/components/indices/retention/ClosingRetentionStrategySummary.jsx
@@ -1,10 +1,10 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 
-const ClosingRetentionStrategySummary = React.createClass({
-  propTypes: {
+class ClosingRetentionStrategySummary extends React.Component {
+  static propTypes = {
     config: PropTypes.object.isRequired,
-  },
+  };
 
   render() {
     return (
@@ -17,7 +17,7 @@ const ClosingRetentionStrategySummary = React.createClass({
         </dl>
       </div>
     );
-  },
-});
+  }
+}
 
 export default ClosingRetentionStrategySummary;

--- a/graylog2-web-interface/src/components/indices/retention/DeletionRetentionStrategyConfiguration.jsx
+++ b/graylog2-web-interface/src/components/indices/retention/DeletionRetentionStrategyConfiguration.jsx
@@ -2,20 +2,18 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import { Input } from 'components/bootstrap';
 
-const DeletionRetentionStrategyConfiguration = React.createClass({
-  propTypes: {
+class DeletionRetentionStrategyConfiguration extends React.Component {
+  static propTypes = {
     config: PropTypes.object.isRequired,
     jsonSchema: PropTypes.object.isRequired,
     updateConfig: PropTypes.func.isRequired,
-  },
+  };
 
-  getInitialState() {
-    return {
-      max_number_of_indices: this.props.config.max_number_of_indices,
-    };
-  },
+  state = {
+    max_number_of_indices: this.props.config.max_number_of_indices,
+  };
 
-  _onInputUpdate(field) {
+  _onInputUpdate = (field) => {
     return (e) => {
       const update = {};
       update[field] = e.target.value;
@@ -23,7 +21,7 @@ const DeletionRetentionStrategyConfiguration = React.createClass({
       this.setState(update);
       this.props.updateConfig(update);
     };
-  },
+  };
 
   render() {
     return (
@@ -39,7 +37,7 @@ const DeletionRetentionStrategyConfiguration = React.createClass({
         </fieldset>
       </div>
     );
-  },
-});
+  }
+}
 
 export default DeletionRetentionStrategyConfiguration;

--- a/graylog2-web-interface/src/components/indices/retention/DeletionRetentionStrategySummary.jsx
+++ b/graylog2-web-interface/src/components/indices/retention/DeletionRetentionStrategySummary.jsx
@@ -1,10 +1,10 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 
-const DeletionRetentionStrategySummary = React.createClass({
-  propTypes: {
+class DeletionRetentionStrategySummary extends React.Component {
+  static propTypes = {
     config: PropTypes.object.isRequired,
-  },
+  };
 
   render() {
     return (
@@ -17,7 +17,7 @@ const DeletionRetentionStrategySummary = React.createClass({
         </dl>
       </div>
     );
-  },
-});
+  }
+}
 
 export default DeletionRetentionStrategySummary;

--- a/graylog2-web-interface/src/components/indices/retention/NoopRetentionStrategyConfiguration.jsx
+++ b/graylog2-web-interface/src/components/indices/retention/NoopRetentionStrategyConfiguration.jsx
@@ -1,14 +1,14 @@
 import React from 'react';
 import { Alert } from 'react-bootstrap';
 
-const NoopRetentionStrategyConfiguration = React.createClass({
+class NoopRetentionStrategyConfiguration extends React.Component {
   render() {
     return (
       <Alert>
         This retention strategy is not configurable because it does not do anything.
       </Alert>
     );
-  },
-});
+  }
+}
 
 export default NoopRetentionStrategyConfiguration;

--- a/graylog2-web-interface/src/components/indices/retention/NoopRetentionStrategySummary.jsx
+++ b/graylog2-web-interface/src/components/indices/retention/NoopRetentionStrategySummary.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-const NoopRetentionStrategySummary = React.createClass({
+class NoopRetentionStrategySummary extends React.Component {
   render() {
     return (
       <div>
@@ -10,7 +10,7 @@ const NoopRetentionStrategySummary = React.createClass({
         </dl>
       </div>
     );
-  },
-});
+  }
+}
 
 export default NoopRetentionStrategySummary;

--- a/graylog2-web-interface/src/components/indices/rotation/MessageCountRotationStrategyConfiguration.jsx
+++ b/graylog2-web-interface/src/components/indices/rotation/MessageCountRotationStrategyConfiguration.jsx
@@ -2,20 +2,18 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import { Input } from 'components/bootstrap';
 
-const MessageCountRotationStrategyConfiguration = React.createClass({
-  propTypes: {
+class MessageCountRotationStrategyConfiguration extends React.Component {
+  static propTypes = {
     config: PropTypes.object.isRequired,
     jsonSchema: PropTypes.object.isRequired,
     updateConfig: PropTypes.func.isRequired,
-  },
+  };
 
-  getInitialState() {
-    return {
-      max_docs_per_index: this.props.config.max_docs_per_index,
-    };
-  },
+  state = {
+    max_docs_per_index: this.props.config.max_docs_per_index,
+  };
 
-  _onInputUpdate(field) {
+  _onInputUpdate = (field) => {
     return (e) => {
       const update = {};
       update[field] = e.target.value;
@@ -23,7 +21,7 @@ const MessageCountRotationStrategyConfiguration = React.createClass({
       this.setState(update);
       this.props.updateConfig(update);
     };
-  },
+  };
 
   render() {
     return (
@@ -40,7 +38,7 @@ const MessageCountRotationStrategyConfiguration = React.createClass({
         </fieldset>
       </div>
     );
-  },
-});
+  }
+}
 
 export default MessageCountRotationStrategyConfiguration;

--- a/graylog2-web-interface/src/components/indices/rotation/MessageCountRotationStrategySummary.jsx
+++ b/graylog2-web-interface/src/components/indices/rotation/MessageCountRotationStrategySummary.jsx
@@ -1,10 +1,10 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 
-const MessageCountRotationStrategySummary = React.createClass({
-  propTypes: {
+class MessageCountRotationStrategySummary extends React.Component {
+  static propTypes = {
     config: PropTypes.object.isRequired,
-  },
+  };
 
   render() {
     return (
@@ -17,7 +17,7 @@ const MessageCountRotationStrategySummary = React.createClass({
         </dl>
       </div>
     );
-  },
-});
+  }
+}
 
 export default MessageCountRotationStrategySummary;

--- a/graylog2-web-interface/src/components/indices/rotation/SizeBasedRotationStrategyConfiguration.jsx
+++ b/graylog2-web-interface/src/components/indices/rotation/SizeBasedRotationStrategyConfiguration.jsx
@@ -4,20 +4,18 @@ import { Input } from 'components/bootstrap';
 
 import NumberUtils from 'util/NumberUtils';
 
-const SizeBasedRotationStrategyConfiguration = React.createClass({
-  propTypes: {
+class SizeBasedRotationStrategyConfiguration extends React.Component {
+  static propTypes = {
     config: PropTypes.object.isRequired,
     jsonSchema: PropTypes.object.isRequired,
     updateConfig: PropTypes.func.isRequired,
-  },
+  };
 
-  getInitialState() {
-    return {
-      max_size: this.props.config.max_size,
-    };
-  },
+  state = {
+    max_size: this.props.config.max_size,
+  };
 
-  _onInputUpdate(field) {
+  _onInputUpdate = (field) => {
     return (e) => {
       const update = {};
       update[field] = e.target.value;
@@ -25,11 +23,11 @@ const SizeBasedRotationStrategyConfiguration = React.createClass({
       this.setState(update);
       this.props.updateConfig(update);
     };
-  },
+  };
 
-  _formatSize() {
+  _formatSize = () => {
     return NumberUtils.formatBytes(this.state.max_size);
-  },
+  };
 
   render() {
     return (
@@ -46,7 +44,7 @@ const SizeBasedRotationStrategyConfiguration = React.createClass({
         </fieldset>
       </div>
     );
-  },
-});
+  }
+}
 
 export default SizeBasedRotationStrategyConfiguration;

--- a/graylog2-web-interface/src/components/indices/rotation/SizeBasedRotationStrategySummary.jsx
+++ b/graylog2-web-interface/src/components/indices/rotation/SizeBasedRotationStrategySummary.jsx
@@ -2,10 +2,10 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import NumberUtils from 'util/NumberUtils';
 
-const SizeBasedRotationStrategySummary = React.createClass({
-  propTypes: {
+class SizeBasedRotationStrategySummary extends React.Component {
+  static propTypes = {
     config: PropTypes.object.isRequired,
-  },
+  };
 
   render() {
     return (
@@ -18,7 +18,7 @@ const SizeBasedRotationStrategySummary = React.createClass({
         </dl>
       </div>
     );
-  },
-});
+  }
+}
 
 export default SizeBasedRotationStrategySummary;

--- a/graylog2-web-interface/src/components/indices/rotation/TimeBasedRotationStrategyConfiguration.jsx
+++ b/graylog2-web-interface/src/components/indices/rotation/TimeBasedRotationStrategyConfiguration.jsx
@@ -3,20 +3,18 @@ import React from 'react';
 import { Input } from 'components/bootstrap';
 import moment from 'moment';
 
-const TimeBasedRotationStrategyConfiguration = React.createClass({
-  propTypes: {
+class TimeBasedRotationStrategyConfiguration extends React.Component {
+  static propTypes = {
     config: PropTypes.object.isRequired,
     jsonSchema: PropTypes.object.isRequired,
     updateConfig: PropTypes.func.isRequired,
-  },
+  };
 
-  getInitialState() {
-    return {
-      rotation_period: this.props.config.rotation_period,
-    };
-  },
+  state = {
+    rotation_period: this.props.config.rotation_period,
+  };
 
-  _onPeriodUpdate(field) {
+  _onPeriodUpdate = (field) => {
     return () => {
       const update = {};
       let period = this.refs[field].getValue().toUpperCase();
@@ -34,23 +32,23 @@ const TimeBasedRotationStrategyConfiguration = React.createClass({
         this.props.updateConfig(update);
       }
     };
-  },
+  };
 
-  _isValidPeriod(duration) {
+  _isValidPeriod = (duration) => {
     const check = duration || this.state.rotation_period;
     return moment.duration(check).asMilliseconds() >= 3600000;
-  },
+  };
 
-  _validationState() {
+  _validationState = () => {
     if (this._isValidPeriod()) {
       return undefined;
     }
     return 'error';
-  },
+  };
 
-  _formatDuration() {
+  _formatDuration = () => {
     return this._isValidPeriod() ? moment.duration(this.state.rotation_period).humanize() : 'invalid (min 1 hour)';
-  },
+  };
 
   render() {
     return (
@@ -67,7 +65,7 @@ const TimeBasedRotationStrategyConfiguration = React.createClass({
                required />
       </div>
     );
-  },
-});
+  }
+}
 
 export default TimeBasedRotationStrategyConfiguration;

--- a/graylog2-web-interface/src/components/indices/rotation/TimeBasedRotationStrategySummary.jsx
+++ b/graylog2-web-interface/src/components/indices/rotation/TimeBasedRotationStrategySummary.jsx
@@ -4,16 +4,16 @@ import React from 'react';
 import moment from 'moment';
 import {} from 'moment-duration-format';
 
-const TimeBasedRotationStrategySummary = React.createClass({
-  propTypes: {
+class TimeBasedRotationStrategySummary extends React.Component {
+  static propTypes = {
     config: PropTypes.object.isRequired,
-  },
+  };
 
-  _humanizedPeriod() {
+  _humanizedPeriod = () => {
     const duration = moment.duration(this.props.config.rotation_period);
 
     return `${duration.format()}, ${duration.humanize()}`;
-  },
+  };
 
   render() {
     return (
@@ -26,7 +26,7 @@ const TimeBasedRotationStrategySummary = React.createClass({
         </dl>
       </div>
     );
-  },
-});
+  }
+}
 
 export default TimeBasedRotationStrategySummary;

--- a/graylog2-web-interface/src/components/inputs/CreateInputControl.jsx
+++ b/graylog2-web-interface/src/components/inputs/CreateInputControl.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import createReactClass from 'create-react-class';
 import Reflux from 'reflux';
 import { Button, Row, Col } from 'react-bootstrap';
 
@@ -13,14 +14,17 @@ const InputTypesStore = StoreProvider.getStore('InputTypes');
 
 import { InputForm } from 'components/inputs';
 
-const CreateInputControl = React.createClass({
+const CreateInputControl = createReactClass({
+  displayName: 'CreateInputControl',
   mixins: [Reflux.connect(InputTypesStore)],
+
   getInitialState() {
     return {
       selectedInput: undefined,
       selectedInputDefinition: undefined,
     };
   },
+
   _formatSelectOptions() {
     let options = [];
 
@@ -36,6 +40,7 @@ const CreateInputControl = React.createClass({
 
     return options;
   },
+
   _onInputSelect(selectedInput) {
     if (selectedInput === '') {
       this.setState(this.getInitialState());
@@ -44,15 +49,18 @@ const CreateInputControl = React.createClass({
     this.setState({ selectedInput: selectedInput });
     InputTypesActions.get.triggerPromise(selectedInput).then(inputDefinition => this.setState({ selectedInputDefinition: inputDefinition }));
   },
+
   _openModal(event) {
     event.preventDefault();
     this.refs.configurationForm.open();
   },
+
   _createInput(data) {
     InputsActions.create(data).then(() => {
       this.setState(this.getInitialState());
     });
   },
+
   render() {
     let inputModal;
     if (this.state.selectedInputDefinition) {

--- a/graylog2-web-interface/src/components/inputs/InputDropdown.jsx
+++ b/graylog2-web-interface/src/components/inputs/InputDropdown.jsx
@@ -5,39 +5,45 @@ import { Button } from 'react-bootstrap';
 import { Input } from 'components/bootstrap';
 import Spinner from 'components/common/Spinner';
 
-const InputDropdown = React.createClass({
-  propTypes: {
+class InputDropdown extends React.Component {
+  static propTypes = {
     inputs: PropTypes.object,
     title: PropTypes.string,
     preselectedInputId: PropTypes.string,
     onLoadMessage: PropTypes.func,
     disabled: PropTypes.bool,
-  },
-  getInitialState() {
-    return {
-      selectedInput: this.props.preselectedInputId || this.PLACEHOLDER,
-    };
-  },
-  PLACEHOLDER: 'placeholder',
-  _formatInput(input) {
+  };
+
+  PLACEHOLDER = 'placeholder';
+
+  _formatInput = (input) => {
     return <option key={input.id} value={input.id}>{input.title} ({input.type})</option>;
-  },
-  _sortByTitle(input1, input2) {
+  };
+
+  _sortByTitle = (input1, input2) => {
     return input1.title.localeCompare(input2.title);
-  },
-  _onLoadMessage() {
+  };
+
+  _onLoadMessage = () => {
     this.props.onLoadMessage(this.state.selectedInput);
-  },
-  _formatStaticInput(input) {
+  };
+
+  _formatStaticInput = (input) => {
     return (
       <Input id={`${input.type}-select`} type="select" style={{ float: 'left', width: 400, marginRight: 10 }} disabled>
         <option>{`${input.title} (${input.type})`}</option>
       </Input>
     );
-  },
-  onSelectedInputChange(event) {
+  };
+
+  onSelectedInputChange = (event) => {
     this.setState({ selectedInput: event.target.value });
-  },
+  };
+
+  state = {
+    selectedInput: this.props.preselectedInputId || this.PLACEHOLDER,
+  };
+
   render() {
     const { selectedInput } = this.state;
     // When an input is pre-selected, show a static dropdown
@@ -79,7 +85,7 @@ const InputDropdown = React.createClass({
     }
 
     return <Spinner />;
-  },
-});
+  }
+}
 
 export default InputDropdown;

--- a/graylog2-web-interface/src/components/inputs/InputForm.jsx
+++ b/graylog2-web-interface/src/components/inputs/InputForm.jsx
@@ -5,32 +5,35 @@ import jQuery from 'jquery';
 import { NodeOrGlobalSelect } from 'components/inputs';
 import { ConfigurationForm } from 'components/configurationforms';
 
-const InputForm = React.createClass({
-  propTypes: {
+class InputForm extends React.Component {
+  static propTypes = {
     globalValue: PropTypes.bool,
     nodeValue: PropTypes.string,
     titleValue: PropTypes.string,
     submitAction: PropTypes.func.isRequired,
     values: PropTypes.object,
-  },
-  getInitialState() {
-    return {
-      global: this.props.globalValue !== undefined ? this.props.globalValue : false,
-      node: this.props.nodeValue !== undefined ? this.props.nodeValue : undefined,
-    };
-  },
-  _handleChange(field, value) {
+  };
+
+  state = {
+    global: this.props.globalValue !== undefined ? this.props.globalValue : false,
+    node: this.props.nodeValue !== undefined ? this.props.nodeValue : undefined,
+  };
+
+  _handleChange = (field, value) => {
     const state = {};
     state[field] = value;
     this.setState(state);
-  },
-  _onSubmit(data) {
+  };
+
+  _onSubmit = (data) => {
     const newData = jQuery.extend(data, { global: this.state.global, node: this.state.node });
     this.props.submitAction(newData);
-  },
-  open() {
+  };
+
+  open = () => {
     this.refs.configurationForm.open();
-  },
+  };
+
   render() {
     const values = this.props.values ? this.props.values :
       (this.refs.configurationForm ? this.refs.configurationForm.getValue().configuration : {});
@@ -42,7 +45,7 @@ const InputForm = React.createClass({
         <NodeOrGlobalSelect onChange={this._handleChange} global={this.state.global} node={this.state.node} />
       </ConfigurationForm>
     );
-  },
-});
+  }
+}
 
 export default InputForm;

--- a/graylog2-web-interface/src/components/inputs/InputListItem.jsx
+++ b/graylog2-web-interface/src/components/inputs/InputListItem.jsx
@@ -1,5 +1,6 @@
 import PropTypes from 'prop-types';
 import React from 'react';
+import createReactClass from 'create-react-class';
 import Reflux from 'reflux';
 import { Button, DropdownButton, MenuItem, Col } from 'react-bootstrap';
 import { LinkContainer } from 'react-router-bootstrap';
@@ -18,13 +19,17 @@ const InputsActions = ActionsProvider.getActions('Inputs');
 
 import { InputForm, InputStateBadge, InputStateControl, InputStaticFields, InputThroughput, StaticFieldForm } from 'components/inputs';
 
-const InputListItem = React.createClass({
+const InputListItem = createReactClass({
+  displayName: 'InputListItem',
+
   propTypes: {
     input: PropTypes.object.isRequired,
     currentNode: PropTypes.object.isRequired,
     permissions: PropTypes.array.isRequired,
   },
+
   mixins: [PermissionsMixin, Reflux.connect(InputTypesStore)],
+
   _deleteInput() {
     if (window.confirm(`Do you really want to delete input '${this.props.input.title}'?`)) {
       InputsActions.delete(this.props.input);
@@ -34,12 +39,15 @@ const InputListItem = React.createClass({
   _openStaticFieldForm() {
     this.refs.staticFieldForm.open();
   },
+
   _editInput() {
     this.refs.configurationForm.open();
   },
+
   _updateInput(data) {
     InputsActions.update(this.props.input.id, data);
   },
+
   render() {
     if (!this.state.inputTypes) {
       return <Spinner />;

--- a/graylog2-web-interface/src/components/inputs/InputStateBadge.jsx
+++ b/graylog2-web-interface/src/components/inputs/InputStateBadge.jsx
@@ -1,5 +1,6 @@
 import PropTypes from 'prop-types';
 import React from 'react';
+import createReactClass from 'create-react-class';
 import Reflux from 'reflux';
 import { Label, OverlayTrigger, Popover } from 'react-bootstrap';
 
@@ -11,12 +12,16 @@ import { LinkToNode, Spinner } from 'components/common';
 
 import InputStateComparator from 'logic/inputs/InputStateComparator';
 
-const InputStateBadge = React.createClass({
+const InputStateBadge = createReactClass({
+  displayName: 'InputStateBadge',
+
   propTypes: {
     input: PropTypes.object.isRequired,
   },
+
   mixins: [Reflux.connect(InputStatesStore), Reflux.connect(NodesStore)],
   comparator: new InputStateComparator(),
+
   _labelClassForState(sortedStates) {
     const nodesWithKnownState = sortedStates.reduce((numberOfNodes, state) => {
       return numberOfNodes + state.count;
@@ -38,15 +43,18 @@ const InputStateBadge = React.createClass({
         return 'warning';
     }
   },
+
   _textForState(sortedStates) {
     if (this.props.input.global) {
       return sortedStates.map(state => `${state.count} ${state.state}`).join(', ');
     }
     return sortedStates[0].state;
   },
+
   _isLoading() {
     return !(this.state.inputStates && this.state.nodes);
   },
+
   render() {
     if (this._isLoading()) {
       return <Spinner />;

--- a/graylog2-web-interface/src/components/inputs/InputStateControl.jsx
+++ b/graylog2-web-interface/src/components/inputs/InputStateControl.jsx
@@ -1,5 +1,6 @@
 import PropTypes from 'prop-types';
 import React from 'react';
+import createReactClass from 'create-react-class';
 import Reflux from 'reflux';
 import { Button } from 'react-bootstrap';
 
@@ -10,10 +11,13 @@ function inputStateFilter(state) {
   return state.inputStates ? state.inputStates[this.props.input.id] : undefined;
 }
 
-const InputStateControl = React.createClass({
+const InputStateControl = createReactClass({
+  displayName: 'InputStateControl',
+
   propTypes: {
     input: PropTypes.object.isRequired,
   },
+
   mixins: [Reflux.connectFilter(InputStatesStore, 'inputState', inputStateFilter)],
 
   getInitialState() {

--- a/graylog2-web-interface/src/components/inputs/InputStaticFields.jsx
+++ b/graylog2-web-interface/src/components/inputs/InputStaticFields.jsx
@@ -5,25 +5,28 @@ import { Button } from 'react-bootstrap';
 import StoreProvider from 'injection/StoreProvider';
 const InputStaticFieldsStore = StoreProvider.getStore('InputStaticFields');
 
-const InputStaticFields = React.createClass({
-  propTypes: {
+class InputStaticFields extends React.Component {
+  static propTypes = {
     input: PropTypes.object.isRequired,
-  },
-  _deleteStaticField(fieldName) {
+  };
+
+  _deleteStaticField = (fieldName) => {
     return () => {
       if (window.confirm(`Are you sure you want to remove static field '${fieldName}' from '${this.props.input.title}'?`)) {
         InputStaticFieldsStore.destroy(this.props.input, fieldName);
       }
     };
-  },
-  _deleteButton(fieldName) {
+  };
+
+  _deleteButton = (fieldName) => {
     return (
       <Button bsStyle="link" bsSize="xsmall" style={{ verticalAlign: 'baseline' }} onClick={this._deleteStaticField(fieldName)}>
         <i className="fa fa-remove" />
       </Button>
     );
-  },
-  _formatStaticFields(staticFields) {
+  };
+
+  _formatStaticFields = (staticFields) => {
     const formattedFields = [];
     const staticFieldNames = Object.keys(staticFields);
 
@@ -36,7 +39,8 @@ const InputStaticFields = React.createClass({
     });
 
     return formattedFields;
-  },
+  };
+
   render() {
     const staticFieldNames = Object.keys(this.props.input.static_fields);
     if (staticFieldNames.length === 0) {
@@ -51,7 +55,7 @@ const InputStaticFields = React.createClass({
         </ul>
       </div>
     );
-  },
-});
+  }
+}
 
 export default InputStaticFields;

--- a/graylog2-web-interface/src/components/inputs/InputThroughput.jsx
+++ b/graylog2-web-interface/src/components/inputs/InputThroughput.jsx
@@ -1,5 +1,6 @@
 import PropTypes from 'prop-types';
 import React from 'react';
+import createReactClass from 'create-react-class';
 import Reflux from 'reflux';
 import numeral from 'numeral';
 
@@ -12,22 +13,29 @@ const MetricsActions = ActionsProvider.getActions('Metrics');
 import NumberUtils from 'util/NumberUtils';
 import { LinkToNode, Spinner } from 'components/common';
 
-const InputThroughput = React.createClass({
+const InputThroughput = createReactClass({
+  displayName: 'InputThroughput',
+
   propTypes: {
     input: PropTypes.object.isRequired,
   },
+
   mixins: [Reflux.connect(MetricsStore)],
+
   getInitialState() {
     return {
       showDetails: false,
     };
   },
+
   componentWillMount() {
     this._metricNames().forEach(metricName => MetricsActions.addGlobal(metricName));
   },
+
   componentWillUnmount() {
     this._metricNames().forEach(metricName => MetricsActions.removeGlobal(metricName));
   },
+
   _metricNames() {
     return [
       this._prefix('incomingMessages'),
@@ -40,10 +48,12 @@ const InputThroughput = React.createClass({
       this._prefix('read_bytes_total'),
     ];
   },
+
   _prefix(metric) {
     const input = this.props.input;
     return `${input.type}.${input.id}.${metric}`;
   },
+
   _getValueFromMetric(metric) {
     if (metric === null || metric === undefined) {
       return undefined;
@@ -60,6 +70,7 @@ const InputThroughput = React.createClass({
         return undefined;
     }
   },
+
   _calculateMetrics(metrics) {
     const result = {};
     this._metricNames().forEach((metricName) => {
@@ -77,9 +88,11 @@ const InputThroughput = React.createClass({
 
     return result;
   },
+
   _formatCount(count) {
     return numeral(count).format('0,0');
   },
+
   _formatNetworkStats(writtenBytes1Sec, writtenBytesTotal, readBytes1Sec, readBytesTotal) {
     const network = (
       <span className="input-io">
@@ -107,6 +120,7 @@ const InputThroughput = React.createClass({
 
     return network;
   },
+
   _formatConnections(openConnections, totalConnections) {
     return (
       <span>
@@ -116,6 +130,7 @@ const InputThroughput = React.createClass({
       </span>
     );
   },
+
   _formatAllNodeDetails(metrics) {
     return (
       <span>
@@ -124,6 +139,7 @@ const InputThroughput = React.createClass({
       </span>
     );
   },
+
   _formatNodeDetails(nodeId, metrics) {
     const openConnections = this._getValueFromMetric(metrics[this._prefix('open_connections')]);
     const totalConnections = this._getValueFromMetric(metrics[this._prefix('total_connections')]);
@@ -146,10 +162,12 @@ const InputThroughput = React.createClass({
       </span>
     );
   },
+
   _toggleShowDetails(evt) {
     evt.preventDefault();
     this.setState({ showDetails: !this.state.showDetails });
   },
+
   render() {
     if (!this.state.metrics) {
       return <Spinner />;

--- a/graylog2-web-interface/src/components/inputs/InputsList.jsx
+++ b/graylog2-web-interface/src/components/inputs/InputsList.jsx
@@ -1,5 +1,6 @@
 import PropTypes from 'prop-types';
 import React from 'react';
+import createReactClass from 'create-react-class';
 import Reflux from 'reflux';
 import { Row, Col } from 'react-bootstrap';
 import naturalSort from 'javascript-natural-sort';
@@ -18,23 +19,29 @@ import StoreProvider from 'injection/StoreProvider';
 const InputsStore = StoreProvider.getStore('Inputs');
 const SingleNodeStore = StoreProvider.getStore('SingleNode');
 
-const InputsList = React.createClass({
+const InputsList = createReactClass({
+  displayName: 'InputsList',
+
   propTypes: {
     permissions: PropTypes.array.isRequired,
     node: PropTypes.object,
   },
+
   mixins: [Reflux.connect(SingleNodeStore), Reflux.listenTo(InputsStore, '_splitInputs')],
+
   getInitialState() {
     return {
       globalInputs: undefined,
       localInputs: undefined,
     };
   },
+
   componentDidMount() {
     InputTypesActions.list();
     InputsActions.list();
     SingleNodeActions.get();
   },
+
   _splitInputs(state) {
     const inputs = state.inputs;
     const globalInputs = inputs
@@ -50,15 +57,19 @@ const InputsList = React.createClass({
 
     this.setState({ globalInputs: globalInputs, localInputs: localInputs });
   },
+
   _isLoading() {
     return !(this.state.localInputs && this.state.globalInputs && this.state.node);
   },
+
   _formatInput(input) {
     return <InputListItem key={input.id} input={input} currentNode={this.state.node} permissions={this.props.permissions} />;
   },
+
   _nodeAffix() {
     return (this.props.node ? ' on this node' : '');
   },
+
   render() {
     if (this._isLoading()) {
       return <Spinner />;

--- a/graylog2-web-interface/src/components/inputs/NodeOrGlobalSelect.jsx
+++ b/graylog2-web-interface/src/components/inputs/NodeOrGlobalSelect.jsx
@@ -1,5 +1,6 @@
 import PropTypes from 'prop-types';
 import React from 'react';
+import createReactClass from 'create-react-class';
 import Reflux from 'reflux';
 import { Input } from 'components/bootstrap';
 
@@ -8,19 +9,24 @@ const NodesStore = StoreProvider.getStore('Nodes');
 
 import { Spinner } from 'components/common';
 
-const NodeOrGlobalSelect = React.createClass({
+const NodeOrGlobalSelect = createReactClass({
+  displayName: 'NodeOrGlobalSelect',
+
   propTypes: {
     global: PropTypes.bool,
     onChange: PropTypes.func.isRequired,
     node: PropTypes.string,
   },
+
   mixins: [Reflux.connect(NodesStore)],
+
   getInitialState() {
     return {
       global: this.props.global !== undefined ? this.props.global : false,
       node: this.props.node,
     };
   },
+
   _onChangeGlobal(evt) {
     const global = evt.target.checked;
     this.setState({ global: global });
@@ -32,10 +38,12 @@ const NodeOrGlobalSelect = React.createClass({
     }
     this.props.onChange('global', global);
   },
+
   _onChangeNode(evt) {
     this.setState({ node: evt.target.value });
     this.props.onChange('node', evt.target.value);
   },
+
   render() {
     if (!this.state.nodes) {
       return <Spinner />;

--- a/graylog2-web-interface/src/components/inputs/StaticFieldForm.jsx
+++ b/graylog2-web-interface/src/components/inputs/StaticFieldForm.jsx
@@ -6,19 +6,22 @@ import { BootstrapModalForm, Input } from 'components/bootstrap';
 import StoreProvider from 'injection/StoreProvider';
 const InputStaticFieldsStore = StoreProvider.getStore('InputStaticFields');
 
-const StaticFieldForm = React.createClass({
-  propTypes: {
+class StaticFieldForm extends React.Component {
+  static propTypes = {
     input: PropTypes.object.isRequired,
-  },
-  open() {
+  };
+
+  open = () => {
     this.refs.modal.open();
-  },
-  _addStaticField() {
+  };
+
+  _addStaticField = () => {
     const fieldName = this.refs.fieldName.getValue();
     const fieldValue = this.refs.fieldValue.getValue();
 
     InputStaticFieldsStore.create(this.props.input, fieldName, fieldValue).then(() => this.refs.modal.close());
-  },
+  };
+
   render() {
     return (
       <BootstrapModalForm ref="modal" title="Add static field" submitButtonText="Add field"
@@ -31,7 +34,7 @@ const StaticFieldForm = React.createClass({
         <Input ref="fieldValue" type="text" id="field-value" label="Field value" required />
       </BootstrapModalForm>
     );
-  },
-});
+  }
+}
 
 export default StaticFieldForm;

--- a/graylog2-web-interface/src/components/layout/Footer.jsx
+++ b/graylog2-web-interface/src/components/layout/Footer.jsx
@@ -1,18 +1,23 @@
 import React from 'react';
+import createReactClass from 'create-react-class';
 import Reflux from 'reflux';
 import Version from 'util/Version';
 
 import StoreProvider from 'injection/StoreProvider';
 const SystemStore = StoreProvider.getStore('System');
 
-const Footer = React.createClass({
+const Footer = createReactClass({
+  displayName: 'Footer',
   mixins: [Reflux.connect(SystemStore)],
+
   componentDidMount() {
     SystemStore.jvm().then(jvmInfo => this.setState({ jvm: jvmInfo }));
   },
+
   _isLoading() {
     return !(this.state.system && this.state.jvm);
   },
+
   render() {
     if (this._isLoading()) {
       return (

--- a/graylog2-web-interface/src/components/ldap/LdapComponent.jsx
+++ b/graylog2-web-interface/src/components/ldap/LdapComponent.jsx
@@ -1,5 +1,6 @@
 import PropTypes from 'prop-types';
 import React from 'react';
+import createReactClass from 'create-react-class';
 import Reflux from 'reflux';
 import { Row, Col, Button, Panel } from 'react-bootstrap';
 import URI from 'urijs';
@@ -130,7 +131,8 @@ const HelperText = {
   },
 };
 
-const LdapComponent = React.createClass({
+const LdapComponent = createReactClass({
+  displayName: 'LdapComponent',
   mixins: [Reflux.listenTo(LdapStore, '_onLdapSettingsChange', '_onLdapSettingsChange')],
 
   propTypes: {

--- a/graylog2-web-interface/src/components/ldap/LdapGroupsComponent.jsx
+++ b/graylog2-web-interface/src/components/ldap/LdapGroupsComponent.jsx
@@ -14,20 +14,18 @@ import StoreProvider from 'injection/StoreProvider';
 const RolesStore = StoreProvider.getStore('Roles');
 const LdapGroupsStore = StoreProvider.getStore('LdapGroups');
 
-const LdapGroupsComponent = React.createClass({
-  propTypes: {
+class LdapGroupsComponent extends React.Component {
+  static propTypes = {
     onCancel: PropTypes.func.isRequired,
     onShowConfig: PropTypes.func.isRequired,
-  },
+  };
 
-  getInitialState() {
-    return {
-      groups: Immutable.Set.of(),
-      roles: Immutable.Set.of(),
-      mapping: Immutable.Map(),
-      groupsErrorMessage: null,
-    };
-  },
+  state = {
+    groups: Immutable.Set.of(),
+    roles: Immutable.Set.of(),
+    mapping: Immutable.Map(),
+    groupsErrorMessage: null,
+  };
 
   componentDidMount() {
     LdapGroupsActions.loadMapping.triggerPromise().then(mapping => this.setState({ mapping: Immutable.Map(mapping) }));
@@ -41,9 +39,9 @@ const LdapGroupsComponent = React.createClass({
         },
       );
     RolesStore.loadRoles().then(roles => this.setState({ roles: Immutable.Set(roles) }));
-  },
+  }
 
-  _updateMapping(event) {
+  _updateMapping = (event) => {
     const role = event.target.value;
     const group = event.target.getAttribute('data-group');
     if (role === '') {
@@ -51,21 +49,21 @@ const LdapGroupsComponent = React.createClass({
     } else {
       this.setState({ mapping: this.state.mapping.set(group, role) });
     }
-  },
+  };
 
-  _saveMapping(event) {
+  _saveMapping = (event) => {
     event.preventDefault();
     LdapGroupsActions.saveMapping(this.state.mapping.toJS());
-  },
+  };
 
-  _onShowConfig(event) {
+  _onShowConfig = (event) => {
     event.preventDefault();
     this.props.onShowConfig();
-  },
+  };
 
-  _isLoading() {
+  _isLoading = () => {
     return !(this.state.mapping && this.state.groups && this.state.roles);
-  },
+  };
 
   render() {
     if (this._isLoading()) {
@@ -128,7 +126,7 @@ const LdapGroupsComponent = React.createClass({
         </Row>
       </form>
     );
-  },
-});
+  }
+}
 
 export default LdapGroupsComponent;

--- a/graylog2-web-interface/src/components/ldap/TestLdapConnection.jsx
+++ b/graylog2-web-interface/src/components/ldap/TestLdapConnection.jsx
@@ -5,27 +5,25 @@ import { Row, Col, Button, Alert } from 'react-bootstrap';
 import ActionsProvider from 'injection/ActionsProvider';
 const LdapActions = ActionsProvider.getActions('Ldap');
 
-const TestLdapConnection = React.createClass({
-  propTypes: {
+class TestLdapConnection extends React.Component {
+  static propTypes = {
     ldapSettings: PropTypes.object.isRequired,
     ldapUri: PropTypes.object.isRequired,
     disabled: PropTypes.bool,
-  },
+  };
 
-  getInitialState() {
-    return {
-      serverConnectionStatus: {},
-    };
-  },
+  state = {
+    serverConnectionStatus: {},
+  };
 
   componentWillReceiveProps(nextProps) {
     // Reset connection status if ldapSettings changed
     if (JSON.stringify(this.props.ldapSettings) !== JSON.stringify(nextProps.ldapSettings)) {
       this.setState({ serverConnectionStatus: {} });
     }
-  },
+  }
 
-  _testServerConnection() {
+  _testServerConnection = () => {
     LdapActions.testServerConnection.triggerPromise(this.props.ldapSettings)
       .then(
         (result) => {
@@ -46,9 +44,9 @@ const TestLdapConnection = React.createClass({
       );
 
     this.setState({ serverConnectionStatus: { loading: true } });
-  },
+  };
 
-  _getServerConnectionStyle() {
+  _getServerConnectionStyle = () => {
     if (this.state.serverConnectionStatus.success) {
       return 'success';
     }
@@ -57,7 +55,7 @@ const TestLdapConnection = React.createClass({
     }
 
     return 'info';
-  },
+  };
 
   render() {
     const serverConnectionStatus = this.state.serverConnectionStatus;
@@ -87,7 +85,7 @@ const TestLdapConnection = React.createClass({
         </Row>
       </div>
     );
-  },
-});
+  }
+}
 
 export default TestLdapConnection;

--- a/graylog2-web-interface/src/components/ldap/TestLdapLogin.jsx
+++ b/graylog2-web-interface/src/components/ldap/TestLdapLogin.jsx
@@ -1,5 +1,6 @@
 import PropTypes from 'prop-types';
 import React from 'react';
+import createReactClass from 'create-react-class';
 import { Row, Col, Button, Panel } from 'react-bootstrap';
 
 import { Input } from 'components/bootstrap';
@@ -8,7 +9,9 @@ import ObjectUtils from 'util/ObjectUtils';
 import ActionsProvider from 'injection/ActionsProvider';
 const LdapActions = ActionsProvider.getActions('Ldap');
 
-const TestLdapLogin = React.createClass({
+const TestLdapLogin = createReactClass({
+  displayName: 'TestLdapLogin',
+
   propTypes: {
     ldapSettings: PropTypes.object.isRequired,
     disabled: PropTypes.bool,

--- a/graylog2-web-interface/src/components/loggers/LogLevelDropdown.jsx
+++ b/graylog2-web-interface/src/components/loggers/LogLevelDropdown.jsx
@@ -1,5 +1,6 @@
 import PropTypes from 'prop-types';
 import React from 'react';
+import createReactClass from 'create-react-class';
 import Reflux from 'reflux';
 import { DropdownButton, MenuItem } from 'react-bootstrap';
 import lodash from 'lodash';
@@ -8,22 +9,28 @@ import CombinedProvider from 'injection/CombinedProvider';
 
 const { LoggersStore, LoggersActions } = CombinedProvider.get('Loggers');
 
-const LogLevelDropdown = React.createClass({
+const LogLevelDropdown = createReactClass({
+  displayName: 'LogLevelDropdown',
+
   propTypes: {
     name: PropTypes.string.isRequired,
     nodeId: PropTypes.string.isRequired,
     subsystem: PropTypes.object.isRequired,
   },
+
   mixins: [Reflux.connect(LoggersStore)],
+
   _changeLoglevel(loglevel) {
     LoggersActions.setSubsystemLoggerLevel(this.props.nodeId, this.props.name, loglevel);
   },
+
   _menuLevelClick(loglevel) {
     return (event) => {
       event.preventDefault();
       this._changeLoglevel(loglevel);
     };
   },
+
   render() {
     const { subsystem, nodeId } = this.props;
     const loglevels = this.state.availableLoglevels

--- a/graylog2-web-interface/src/components/loggers/LogLevelMetrics.jsx
+++ b/graylog2-web-interface/src/components/loggers/LogLevelMetrics.jsx
@@ -1,5 +1,6 @@
 import PropTypes from 'prop-types';
 import React from 'react';
+import createReactClass from 'create-react-class';
 import Reflux from 'reflux';
 import { Col } from 'react-bootstrap';
 import lodash from 'lodash';
@@ -10,21 +11,28 @@ import CombinedProvider from 'injection/CombinedProvider';
 
 const { MetricsStore, MetricsActions } = CombinedProvider.get('Metrics');
 
-const LogLevelMetrics = React.createClass({
+const LogLevelMetrics = createReactClass({
+  displayName: 'LogLevelMetrics',
+
   propTypes: {
     nodeId: PropTypes.string.isRequired,
     loglevel: PropTypes.string.isRequired,
   },
+
   mixins: [Reflux.connect(MetricsStore)],
+
   componentDidMount() {
     MetricsActions.add(this.props.nodeId, this._metricName());
   },
+
   componentWillUnmount() {
     MetricsActions.remove(this.props.nodeId, this._metricName());
   },
+
   _metricName() {
     return `org.apache.logging.log4j.core.Appender.${this.props.loglevel}`;
   },
+
   render() {
     const { loglevel, nodeId } = this.props;
     const { metrics } = this.state;

--- a/graylog2-web-interface/src/components/loggers/LogLevelMetricsOverview.jsx
+++ b/graylog2-web-interface/src/components/loggers/LogLevelMetricsOverview.jsx
@@ -1,5 +1,6 @@
 import PropTypes from 'prop-types';
 import React from 'react';
+import createReactClass from 'create-react-class';
 import Reflux from 'reflux';
 
 import StoreProvider from 'injection/StoreProvider';
@@ -7,11 +8,15 @@ const LoggersStore = StoreProvider.getStore('Loggers');
 
 import { LogLevelMetrics } from 'components/loggers';
 
-const LogLevelMetricsOverview = React.createClass({
+const LogLevelMetricsOverview = createReactClass({
+  displayName: 'LogLevelMetricsOverview',
+
   propTypes: {
     nodeId: PropTypes.string.isRequired,
   },
+
   mixins: [Reflux.connect(LoggersStore)],
+
   render() {
     const { nodeId } = this.props;
     const logLevelMetrics = this.state.availableLoglevels

--- a/graylog2-web-interface/src/components/loggers/LoggerOverview.jsx
+++ b/graylog2-web-interface/src/components/loggers/LoggerOverview.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import createReactClass from 'create-react-class';
 import Reflux from 'reflux';
 
 import { Spinner } from 'components/common';
@@ -7,8 +8,10 @@ import { NodeLoggers } from 'components/loggers';
 import StoreProvider from 'injection/StoreProvider';
 const LoggersStore = StoreProvider.getStore('Loggers');
 
-const LoggerOverview = React.createClass({
+const LoggerOverview = createReactClass({
+  displayName: 'LoggerOverview',
   mixins: [Reflux.connect(LoggersStore)],
+
   render() {
     if (!this.state.loggers || !this.state.subsystems) {
       return <Spinner />;

--- a/graylog2-web-interface/src/components/loggers/LoggingSubsystem.jsx
+++ b/graylog2-web-interface/src/components/loggers/LoggingSubsystem.jsx
@@ -5,12 +5,12 @@ import lodash from 'lodash';
 
 import { LogLevelDropdown } from 'components/loggers';
 
-const LoggingSubsystem = React.createClass({
-  propTypes: {
+class LoggingSubsystem extends React.Component {
+  static propTypes = {
     name: PropTypes.string.isRequired,
     nodeId: PropTypes.string.isRequired,
     subsystem: PropTypes.object.isRequired,
-  },
+  };
 
   render() {
     return (
@@ -27,7 +27,7 @@ const LoggingSubsystem = React.createClass({
         </Col>
       </div>
     );
-  },
-});
+  }
+}
 
 export default LoggingSubsystem;

--- a/graylog2-web-interface/src/components/loggers/NodeLoggers.jsx
+++ b/graylog2-web-interface/src/components/loggers/NodeLoggers.jsx
@@ -1,5 +1,6 @@
 import PropTypes from 'prop-types';
 import React from 'react';
+import createReactClass from 'create-react-class';
 import Reflux from 'reflux';
 import { Button, Col, Row } from 'react-bootstrap';
 
@@ -12,22 +13,30 @@ const MetricsActions = ActionsProvider.getActions('Metrics');
 import StoreProvider from 'injection/StoreProvider';
 const MetricsStore = StoreProvider.getStore('Metrics');
 
-const NodeLoggers = React.createClass({
+const NodeLoggers = createReactClass({
+  displayName: 'NodeLoggers',
+
   propTypes: {
     nodeId: PropTypes.string.isRequired,
     subsystems: PropTypes.object.isRequired,
   },
+
   mixins: [Reflux.connect(MetricsStore)],
+
   getInitialState() {
     return { showDetails: false };
   },
+
   componentDidMount() {
     MetricsActions.add(this.props.nodeId, this.metric_name);
   },
+
   componentWillUnmount() {
     MetricsActions.remove(this.props.nodeId, this.metric_name);
   },
+
   metric_name: 'org.apache.logging.log4j.core.Appender.all',
+
   _formatThroughput() {
     const { metrics } = this.state;
     const { nodeId } = this.props;

--- a/graylog2-web-interface/src/components/lookup-tables/Cache.jsx
+++ b/graylog2-web-interface/src/components/lookup-tables/Cache.jsx
@@ -8,11 +8,10 @@ import { ContentPackMarker } from 'components/common';
 
 import Styles from './ConfigSummary.css';
 
-const Cache = React.createClass({
-
-  propTypes: {
+class Cache extends React.Component {
+  static propTypes = {
     cache: PropTypes.object.isRequired,
-  },
+  };
 
   render() {
     const plugins = {};
@@ -53,8 +52,7 @@ const Cache = React.createClass({
         <Col md={6} />
       </Row>
     );
-  },
-
-});
+  }
+}
 
 export default Cache;

--- a/graylog2-web-interface/src/components/lookup-tables/CacheCreate.jsx
+++ b/graylog2-web-interface/src/components/lookup-tables/CacheCreate.jsx
@@ -9,30 +9,25 @@ import { CacheForm } from 'components/lookup-tables';
 import { PluginStore } from 'graylog-web-plugin/plugin';
 import ObjectUtils from 'util/ObjectUtils';
 
-const CacheCreate = React.createClass({
-
-  propTypes: {
+class CacheCreate extends React.Component {
+  static propTypes = {
     saved: PropTypes.func.isRequired,
     types: PropTypes.object.isRequired,
     validate: PropTypes.func,
     validationErrors: PropTypes.object,
-  },
+  };
 
-  getDefaultProps() {
-    return {
-      validate: null,
-      validationErrors: {},
-    };
-  },
+  static defaultProps = {
+    validate: null,
+    validationErrors: {},
+  };
 
-  getInitialState() {
-    return {
-      cache: undefined,
-      type: undefined,
-    };
-  },
+  state = {
+    cache: undefined,
+    type: undefined,
+  };
 
-  _onTypeSelect(cacheType) {
+  _onTypeSelect = (cacheType) => {
     this.setState({
       type: cacheType,
       cache: {
@@ -43,7 +38,7 @@ const CacheCreate = React.createClass({
         config: ObjectUtils.clone(this.props.types[cacheType].default_config),
       },
     });
-  },
+  };
 
   render() {
     const cachePlugins = {};
@@ -91,8 +86,8 @@ const CacheCreate = React.createClass({
         </Row>
       )}
     </div>);
-  },
-});
+  }
+}
 
 
 export default CacheCreate;

--- a/graylog2-web-interface/src/components/lookup-tables/CacheForm.jsx
+++ b/graylog2-web-interface/src/components/lookup-tables/CacheForm.jsx
@@ -12,34 +12,28 @@ import CombinedProvider from 'injection/CombinedProvider';
 
 const { LookupTableCachesActions } = CombinedProvider.get('LookupTableCaches');
 
-const CacheForm = React.createClass({
-  propTypes: {
+class CacheForm extends React.Component {
+  static propTypes = {
     type: PropTypes.string.isRequired,
     saved: PropTypes.func.isRequired,
     create: PropTypes.bool,
     cache: PropTypes.object,
     validate: PropTypes.func,
     validationErrors: PropTypes.object,
-  },
+  };
 
-  getDefaultProps() {
-    return {
-      create: true,
-      cache: {
-        id: undefined,
-        title: '',
-        description: '',
-        name: '',
-        config: {},
-      },
-      validate: null,
-      validationErrors: {},
-    };
-  },
-
-  getInitialState() {
-    return this._initialState(this.props.cache);
-  },
+  static defaultProps = {
+    create: true,
+    cache: {
+      id: undefined,
+      title: '',
+      description: '',
+      name: '',
+      config: {},
+    },
+    validate: null,
+    validationErrors: {},
+  };
 
   componentWillReceiveProps(nextProps) {
     if (_.isEqual(this.props.cache, nextProps.cache)) {
@@ -47,16 +41,16 @@ const CacheForm = React.createClass({
       return;
     }
     this.setState(this._initialState(nextProps.cache));
-  },
+  }
 
   componentDidMount() {
     if (!this.props.create) {
       // Validate when mounted to immediately show errors for invalid objects
       this._validate(this.props.cache);
     }
-  },
+  }
 
-  _initialState(c) {
+  _initialState = (c) => {
     const cache = ObjectUtils.clone(c);
 
     return {
@@ -71,30 +65,30 @@ const CacheForm = React.createClass({
         config: cache.config,
       },
     };
-  },
+  };
 
   componentWillUnmount() {
     this._clearTimer();
-  },
+  }
 
-  validationCheckTimer: undefined,
+  validationCheckTimer = undefined;
 
-  _clearTimer() {
+  _clearTimer = () => {
     if (this.validationCheckTimer !== undefined) {
       clearTimeout(this.validationCheckTimer);
       this.validationCheckTimer = undefined;
     }
-  },
+  };
 
-  _validate(cache) {
+  _validate = (cache) => {
     // first cancel outstanding validation timer, we have new data
     this._clearTimer();
     if (this.props.validate) {
       this.validationCheckTimer = setTimeout(() => this.props.validate(cache), 500);
     }
-  },
+  };
 
-  _onChange(event) {
+  _onChange = (event) => {
     const cache = ObjectUtils.clone(this.state.cache);
     cache[event.target.name] = FormsUtils.getValueFromInput(event.target);
     let generateName = this.state.generateName;
@@ -108,23 +102,23 @@ const CacheForm = React.createClass({
     }
     this._validate(cache);
     this.setState({ cache: cache });
-  },
+  };
 
-  _onConfigChange(event) {
+  _onConfigChange = (event) => {
     const cache = ObjectUtils.clone(this.state.cache);
     cache.config[event.target.name] = FormsUtils.getValueFromInput(event.target);
     this._validate(cache);
     this.setState({ cache: cache });
-  },
+  };
 
-  _updateConfig(newConfig) {
+  _updateConfig = (newConfig) => {
     const cache = ObjectUtils.clone(this.state.cache);
     cache.config = newConfig;
     this._validate(cache);
     this.setState({ cache: cache });
-  },
+  };
 
-  _save(event) {
+  _save = (event) => {
     if (event) {
       event.preventDefault();
     }
@@ -137,20 +131,20 @@ const CacheForm = React.createClass({
     }
 
     promise.then(() => { this.props.saved(); });
-  },
+  };
 
-  _sanitizeTitle(title) {
+  _sanitizeTitle = (title) => {
     return title.trim().replace(/\W+/g, '-').toLowerCase();
-  },
+  };
 
-  _validationState(fieldName) {
+  _validationState = (fieldName) => {
     if (this.props.validationErrors[fieldName]) {
       return 'error';
     }
     return null;
-  },
+  };
 
-  _validationMessage(fieldName, defaultText) {
+  _validationMessage = (fieldName, defaultText) => {
     if (this.props.validationErrors[fieldName]) {
       return (<div>
         <span>{defaultText}</span>
@@ -159,7 +153,9 @@ const CacheForm = React.createClass({
       </div>);
     }
     return <span>{defaultText}</span>;
-  },
+  };
+
+  state = this._initialState(this.props.cache);
 
   render() {
     const cache = this.state.cache;
@@ -246,7 +242,7 @@ const CacheForm = React.createClass({
         {documentationColumn}
       </Row>
     );
-  },
-});
+  }
+}
 
 export default CacheForm;

--- a/graylog2-web-interface/src/components/lookup-tables/CachePicker.jsx
+++ b/graylog2-web-interface/src/components/lookup-tables/CachePicker.jsx
@@ -6,22 +6,19 @@ import { PluginStore } from 'graylog-web-plugin/plugin';
 import { Input } from 'components/bootstrap';
 import { Select } from 'components/common';
 
-const CachePicker = React.createClass({
-
-  propTypes: {
+class CachePicker extends React.Component {
+  static propTypes = {
     onSelect: PropTypes.func.isRequired,
     selectedId: PropTypes.string,
     caches: PropTypes.array,
     pagination: PropTypes.object,
-  },
+  };
 
-  getDefaultProps() {
-    return {
-      selectedId: null,
-      caches: [],
-      pagination: {},
-    };
-  },
+  static defaultProps = {
+    selectedId: null,
+    caches: [],
+    pagination: {},
+  };
 
   render() {
     const cachePlugins = {};
@@ -51,7 +48,7 @@ const CachePicker = React.createClass({
         </Input>
       </fieldset>
     );
-  },
-});
+  }
+}
 
 export default CachePicker;

--- a/graylog2-web-interface/src/components/lookup-tables/CacheTableEntry.jsx
+++ b/graylog2-web-interface/src/components/lookup-tables/CacheTableEntry.jsx
@@ -13,20 +13,19 @@ import NumberUtils from 'util/NumberUtils';
 
 const { LookupTableCachesActions } = CombinedProvider.get('LookupTableCaches');
 
-const LUTTableEntry = React.createClass({
-
-  propTypes: {
+class LUTTableEntry extends React.Component {
+  static propTypes = {
     cache: PropTypes.object.isRequired,
-  },
+  };
 
-  _onDelete() {
+  _onDelete = () => {
 // eslint-disable-next-line no-alert
     if (window.confirm(`Are you sure you want to delete cache "${this.props.cache.title}"?`)) {
       LookupTableCachesActions.delete(this.props.cache.id).then(() => LookupTableCachesActions.reloadPage());
     }
-  },
+  };
 
-  _onCountMetrics(metrics) {
+  _onCountMetrics = (metrics) => {
     let totalHits = 0;
     let totalMisses = 0;
 
@@ -40,9 +39,9 @@ const LUTTableEntry = React.createClass({
     }
     const hitRate = (totalHits * 100.0) / total;
     return `${NumberUtils.formatNumber(hitRate)}%`;
-  },
+  };
 
-  _onEntriesMetrics(metrics) {
+  _onEntriesMetrics = (metrics) => {
     let total = 0;
 
     Object.keys(metrics).map(nodeId => metrics[nodeId].count.metric.value).forEach((v) => { total += v; });
@@ -52,7 +51,7 @@ const LUTTableEntry = React.createClass({
     }
 
     return NumberUtils.formatNumber(total);
-  },
+  };
 
   render() {
     const countMap = {
@@ -93,9 +92,8 @@ const LUTTableEntry = React.createClass({
         </tr>
       </tbody>
     );
-  },
-
-});
+  }
+}
 
 export default LUTTableEntry;
 

--- a/graylog2-web-interface/src/components/lookup-tables/CachesContainer.jsx
+++ b/graylog2-web-interface/src/components/lookup-tables/CachesContainer.jsx
@@ -1,5 +1,6 @@
 import PropTypes from 'prop-types';
 import React from 'react';
+import createReactClass from 'create-react-class';
 import Reflux from 'reflux';
 
 import { Spinner } from 'components/common';
@@ -9,7 +10,8 @@ import CombinedProvider from 'injection/CombinedProvider';
 const { LookupTableCachesActions, LookupTableCachesStore } = CombinedProvider.get(
   'LookupTableCaches');
 
-const CachesContainer = React.createClass({
+const CachesContainer = createReactClass({
+  displayName: 'CachesContainer',
 
   propTypes: {
     children: PropTypes.oneOfType([

--- a/graylog2-web-interface/src/components/lookup-tables/CachesOverview.jsx
+++ b/graylog2-web-interface/src/components/lookup-tables/CachesOverview.jsx
@@ -14,28 +14,27 @@ import Styles from './Overview.css';
 
 const { LookupTableCachesActions } = CombinedProvider.get('LookupTableCaches');
 
-const CachesOverview = React.createClass({
-
-  propTypes: {
+class CachesOverview extends React.Component {
+  static propTypes = {
     caches: PropTypes.array.isRequired,
     pagination: PropTypes.object.isRequired,
-  },
+  };
 
-  _onPageChange(newPage, newPerPage) {
+  _onPageChange = (newPage, newPerPage) => {
     LookupTableCachesActions.searchPaginated(newPage, newPerPage, this.props.pagination.query);
-  },
+  };
 
-  _onSearch(query, resetLoadingStateCb) {
+  _onSearch = (query, resetLoadingStateCb) => {
     LookupTableCachesActions
       .searchPaginated(this.props.pagination.page, this.props.pagination.per_page, query)
       .then(resetLoadingStateCb);
-  },
+  };
 
-  _onReset() {
+  _onReset = () => {
     LookupTableCachesActions.searchPaginated(this.props.pagination.page, this.props.pagination.per_page);
-  },
+  };
 
-  _helpPopover() {
+  _helpPopover = () => {
     return (
       <Popover id="search-query-help" className={Styles.popoverWide} title="Search Syntax Help">
         <p><strong>Available search fields</strong></p>
@@ -78,7 +77,7 @@ const CachesOverview = React.createClass({
         </p>
       </Popover>
     );
-  },
+  };
 
   render() {
     if (!this.props.caches) {
@@ -124,7 +123,7 @@ const CachesOverview = React.createClass({
         </Col>
       </Row>
     </div>);
-  },
-});
+  }
+}
 
 export default CachesOverview;

--- a/graylog2-web-interface/src/components/lookup-tables/DataAdapter.jsx
+++ b/graylog2-web-interface/src/components/lookup-tables/DataAdapter.jsx
@@ -12,29 +12,26 @@ import Styles from './ConfigSummary.css';
 
 const { LookupTableDataAdaptersActions } = CombinedProvider.get('LookupTableDataAdapters');
 
-const DataAdapter = React.createClass({
-
-  propTypes: {
+class DataAdapter extends React.Component {
+  static propTypes = {
     dataAdapter: PropTypes.object.isRequired,
-  },
+  };
 
-  getInitialState() {
-    return {
-      lookupKey: null,
-      lookupResult: null,
-    };
-  },
+  state = {
+    lookupKey: null,
+    lookupResult: null,
+  };
 
-  _onChange(event) {
+  _onChange = (event) => {
     this.setState({ lookupKey: FormsUtils.getValueFromInput(event.target) });
-  },
+  };
 
-  _lookupKey(e) {
+  _lookupKey = (e) => {
     e.preventDefault();
     LookupTableDataAdaptersActions.lookup(this.props.dataAdapter.name, this.state.lookupKey).then((result) => {
       this.setState({ lookupResult: result });
     });
-  },
+  };
 
   render() {
     const plugins = {};
@@ -97,8 +94,7 @@ const DataAdapter = React.createClass({
         </Col>
       </Row>
     );
-  },
-
-});
+  }
+}
 
 export default DataAdapter;

--- a/graylog2-web-interface/src/components/lookup-tables/DataAdapterCreate.jsx
+++ b/graylog2-web-interface/src/components/lookup-tables/DataAdapterCreate.jsx
@@ -9,30 +9,25 @@ import { DataAdapterForm } from 'components/lookup-tables';
 import { PluginStore } from 'graylog-web-plugin/plugin';
 import ObjectUtils from 'util/ObjectUtils';
 
-const DataAdapterCreate = React.createClass({
-
-  propTypes: {
+class DataAdapterCreate extends React.Component {
+  static propTypes = {
     saved: PropTypes.func.isRequired,
     types: PropTypes.object.isRequired,
     validate: PropTypes.func,
     validationErrors: PropTypes.object,
-  },
+  };
 
-  getDefaultProps() {
-    return {
-      validate: null,
-      validationErrors: {},
-    };
-  },
+  static defaultProps = {
+    validate: null,
+    validationErrors: {},
+  };
 
-  getInitialState() {
-    return {
-      dataAdapter: undefined,
-      type: undefined,
-    };
-  },
+  state = {
+    dataAdapter: undefined,
+    type: undefined,
+  };
 
-  _onTypeSelect(adapterType) {
+  _onTypeSelect = (adapterType) => {
     this.setState({
       type: adapterType,
       dataAdapter: {
@@ -43,7 +38,7 @@ const DataAdapterCreate = React.createClass({
         config: ObjectUtils.clone(this.props.types[adapterType].default_config),
       },
     });
-  },
+  };
 
   render() {
     const adapterPlugins = {};
@@ -95,8 +90,8 @@ const DataAdapterCreate = React.createClass({
         </Row>
       )}
     </div>);
-  },
-});
+  }
+}
 
 
 export default DataAdapterCreate;

--- a/graylog2-web-interface/src/components/lookup-tables/DataAdapterForm.jsx
+++ b/graylog2-web-interface/src/components/lookup-tables/DataAdapterForm.jsx
@@ -14,34 +14,28 @@ import CombinedProvider from 'injection/CombinedProvider';
 
 const { LookupTableDataAdaptersActions } = CombinedProvider.get('LookupTableDataAdapters');
 
-const DataAdapterForm = React.createClass({
-  propTypes: {
+class DataAdapterForm extends React.Component {
+  static propTypes = {
     type: PropTypes.string.isRequired,
     saved: PropTypes.func.isRequired,
     create: PropTypes.bool,
     dataAdapter: PropTypes.object,
     validate: PropTypes.func,
     validationErrors: PropTypes.object,
-  },
+  };
 
-  getDefaultProps() {
-    return {
-      create: true,
-      dataAdapter: {
-        id: undefined,
-        title: '',
-        description: '',
-        name: '',
-        config: {},
-      },
-      validate: null,
-      validationErrors: {},
-    };
-  },
-
-  getInitialState() {
-    return this._initialState(this.props.dataAdapter);
-  },
+  static defaultProps = {
+    create: true,
+    dataAdapter: {
+      id: undefined,
+      title: '',
+      description: '',
+      name: '',
+      config: {},
+    },
+    validate: null,
+    validationErrors: {},
+  };
 
   componentWillReceiveProps(nextProps) {
     if (_.isEqual(this.props.dataAdapter, nextProps.dataAdapter)) {
@@ -49,16 +43,16 @@ const DataAdapterForm = React.createClass({
       return;
     }
     this.setState(this._initialState(nextProps.dataAdapter));
-  },
+  }
 
   componentDidMount() {
     if (!this.props.create) {
       // Validate when mounted to immediately show errors for invalid objects
       this._validate(this.props.dataAdapter);
     }
-  },
+  }
 
-  _initialState(dataAdapter) {
+  _initialState = (dataAdapter) => {
     const adapter = ObjectUtils.clone(dataAdapter);
 
     return {
@@ -73,30 +67,30 @@ const DataAdapterForm = React.createClass({
         config: adapter.config,
       },
     };
-  },
+  };
 
   componentWillUnmount() {
     this._clearTimer();
-  },
+  }
 
-  validationCheckTimer: undefined,
+  validationCheckTimer = undefined;
 
-  _clearTimer() {
+  _clearTimer = () => {
     if (this.validationCheckTimer !== undefined) {
       clearTimeout(this.validationCheckTimer);
       this.validationCheckTimer = undefined;
     }
-  },
+  };
 
-  _validate(adapter) {
+  _validate = (adapter) => {
     // first cancel outstanding validation timer, we have new data
     this._clearTimer();
     if (this.props.validate) {
       this.validationCheckTimer = setTimeout(() => this.props.validate(adapter), 500);
     }
-  },
+  };
 
-  _onChange(event) {
+  _onChange = (event) => {
     const dataAdapter = ObjectUtils.clone(this.state.dataAdapter);
     dataAdapter[event.target.name] = FormsUtils.getValueFromInput(event.target);
     let generateAdapterName = this.state.generateAdapterName;
@@ -110,23 +104,23 @@ const DataAdapterForm = React.createClass({
     }
     this._validate(dataAdapter);
     this.setState({ dataAdapter: dataAdapter, generateAdapterName: generateAdapterName });
-  },
+  };
 
-  _onConfigChange(event) {
+  _onConfigChange = (event) => {
     const dataAdapter = ObjectUtils.clone(this.state.dataAdapter);
     dataAdapter.config[event.target.name] = FormsUtils.getValueFromInput(event.target);
     this._validate(dataAdapter);
     this.setState({ dataAdapter: dataAdapter });
-  },
+  };
 
-  _updateConfig(newConfig) {
+  _updateConfig = (newConfig) => {
     const dataAdapter = ObjectUtils.clone(this.state.dataAdapter);
     dataAdapter.config = newConfig;
     this._validate(dataAdapter);
     this.setState({ dataAdapter: dataAdapter });
-  },
+  };
 
-  _save(event) {
+  _save = (event) => {
     if (event) {
       event.preventDefault();
     }
@@ -141,20 +135,20 @@ const DataAdapterForm = React.createClass({
     promise.then(() => {
       this.props.saved();
     });
-  },
+  };
 
-  _sanitizeTitle(title) {
+  _sanitizeTitle = (title) => {
     return title.trim().replace(/\W+/g, '-').toLowerCase();
-  },
+  };
 
-  _validationState(fieldName) {
+  _validationState = (fieldName) => {
     if (this.props.validationErrors[fieldName]) {
       return 'error';
     }
     return null;
-  },
+  };
 
-  _validationMessage(fieldName, defaultText) {
+  _validationMessage = (fieldName, defaultText) => {
     if (this.props.validationErrors[fieldName]) {
       return (<div>
         <span>{defaultText}</span>
@@ -163,7 +157,9 @@ const DataAdapterForm = React.createClass({
       </div>);
     }
     return <span>{defaultText}</span>;
-  },
+  };
+
+  state = this._initialState(this.props.dataAdapter);
 
   render() {
     const adapter = this.state.dataAdapter;
@@ -253,7 +249,7 @@ const DataAdapterForm = React.createClass({
         {documentationColumn}
       </Row>
     );
-  },
-});
+  }
+}
 
 export default DataAdapterForm;

--- a/graylog2-web-interface/src/components/lookup-tables/DataAdapterPicker.jsx
+++ b/graylog2-web-interface/src/components/lookup-tables/DataAdapterPicker.jsx
@@ -6,22 +6,19 @@ import { PluginStore } from 'graylog-web-plugin/plugin';
 import { Input } from 'components/bootstrap';
 import { Select } from 'components/common';
 
-const DataAdapterPicker = React.createClass({
-
-  propTypes: {
+class DataAdapterPicker extends React.Component {
+  static propTypes = {
     onSelect: PropTypes.func.isRequired,
     selectedId: PropTypes.string,
     dataAdapters: PropTypes.array,
     pagination: PropTypes.object,
-  },
+  };
 
-  getDefaultProps() {
-    return {
-      selectedId: null,
-      dataAdapters: [],
-      pagination: {},
-    };
-  },
+  static defaultProps = {
+    selectedId: null,
+    dataAdapters: [],
+    pagination: {},
+  };
 
   render() {
     const adapterPlugins = {};
@@ -51,7 +48,7 @@ const DataAdapterPicker = React.createClass({
         </Input>
       </fieldset>
     );
-  },
-});
+  }
+}
 
 export default DataAdapterPicker;

--- a/graylog2-web-interface/src/components/lookup-tables/DataAdapterTableEntry.jsx
+++ b/graylog2-web-interface/src/components/lookup-tables/DataAdapterTableEntry.jsx
@@ -14,25 +14,22 @@ import { MetricContainer, CounterRate } from 'components/metrics';
 
 const { LookupTableDataAdaptersActions } = CombinedProvider.get('LookupTableDataAdapters');
 
-const DataAdapterTableEntry = React.createClass({
-
-  propTypes: {
+class DataAdapterTableEntry extends React.Component {
+  static propTypes = {
     adapter: PropTypes.object.isRequired,
     error: PropTypes.string,
-  },
+  };
 
-  getDefaultProps() {
-    return {
-      error: null,
-    };
-  },
+  static defaultProps = {
+    error: null,
+  };
 
-  _onDelete() {
+  _onDelete = () => {
 // eslint-disable-next-line no-alert
     if (window.confirm(`Are you sure you want to delete data adapter "${this.props.adapter.title}"?`)) {
       LookupTableDataAdaptersActions.delete(this.props.adapter.id).then(() => LookupTableDataAdaptersActions.reloadPage());
     }
-  },
+  };
 
   render() {
     return (
@@ -60,9 +57,8 @@ const DataAdapterTableEntry = React.createClass({
         </tr>
       </tbody>
     );
-  },
-
-});
+  }
+}
 
 export default DataAdapterTableEntry;
 

--- a/graylog2-web-interface/src/components/lookup-tables/DataAdaptersContainer.jsx
+++ b/graylog2-web-interface/src/components/lookup-tables/DataAdaptersContainer.jsx
@@ -1,5 +1,6 @@
 import PropTypes from 'prop-types';
 import React from 'react';
+import createReactClass from 'create-react-class';
 import Reflux from 'reflux';
 
 import { Spinner } from 'components/common';
@@ -9,7 +10,8 @@ import CombinedProvider from 'injection/CombinedProvider';
 const { LookupTableDataAdaptersActions, LookupTableDataAdaptersStore } = CombinedProvider.get(
   'LookupTableDataAdapters');
 
-const DataAdaptersContainer = React.createClass({
+const DataAdaptersContainer = createReactClass({
+  displayName: 'DataAdaptersContainer',
 
   propTypes: {
     children: PropTypes.oneOfType([

--- a/graylog2-web-interface/src/components/lookup-tables/DataAdaptersOverview.jsx
+++ b/graylog2-web-interface/src/components/lookup-tables/DataAdaptersOverview.jsx
@@ -14,30 +14,29 @@ import Styles from './Overview.css';
 
 const { LookupTableDataAdaptersActions } = CombinedProvider.get('LookupTableDataAdapters');
 
-const DataAdaptersOverview = React.createClass({
-
-  propTypes: {
+class DataAdaptersOverview extends React.Component {
+  static propTypes = {
     dataAdapters: PropTypes.array.isRequired,
     pagination: PropTypes.object.isRequired,
     errorStates: PropTypes.object.isRequired,
-  },
+  };
 
-  _onPageChange(newPage, newPerPage) {
+  _onPageChange = (newPage, newPerPage) => {
     LookupTableDataAdaptersActions.searchPaginated(newPage, newPerPage,
       this.props.pagination.query);
-  },
+  };
 
-  _onSearch(query, resetLoadingStateCb) {
+  _onSearch = (query, resetLoadingStateCb) => {
     LookupTableDataAdaptersActions
       .searchPaginated(this.props.pagination.page, this.props.pagination.per_page, query)
       .then(resetLoadingStateCb);
-  },
+  };
 
-  _onReset() {
+  _onReset = () => {
     LookupTableDataAdaptersActions.searchPaginated(this.props.pagination.page, this.props.pagination.per_page);
-  },
+  };
 
-  _helpPopover() {
+  _helpPopover = () => {
     return (
       <Popover id="search-query-help" className={Styles.popoverWide} title="Search Syntax Help">
         <p><strong>Available search fields</strong></p>
@@ -80,7 +79,7 @@ const DataAdaptersOverview = React.createClass({
         </p>
       </Popover>
     );
-  },
+  };
 
   render() {
     if (!this.props.dataAdapters) {
@@ -125,7 +124,7 @@ const DataAdaptersOverview = React.createClass({
         </Col>
       </Row>
     </div>);
-  },
-});
+  }
+}
 
 export default DataAdaptersOverview;

--- a/graylog2-web-interface/src/components/lookup-tables/ErrorPopover.jsx
+++ b/graylog2-web-interface/src/components/lookup-tables/ErrorPopover.jsx
@@ -5,20 +5,17 @@ import { OverlayTrigger, Popover } from 'react-bootstrap';
 
 import Styles from './ErrorPopover.css';
 
-const ErrorPopover = React.createClass({
-
-  propTypes: {
+class ErrorPopover extends React.Component {
+  static propTypes = {
     errorText: PropTypes.string.isRequired,
     title: PropTypes.string,
     placement: PropTypes.string,
-  },
+  };
 
-  getDefaultProps() {
-    return {
-      title: 'Error',
-      placement: 'bottom',
-    };
-  },
+  static defaultProps = {
+    title: 'Error',
+    placement: 'bottom',
+  };
 
   render() {
     const overlay = (<Popover id="error-popover" title={this.props.title} className={Styles.overlay}>
@@ -32,7 +29,7 @@ const ErrorPopover = React.createClass({
         </span>
       </OverlayTrigger>
     );
-  },
-});
+  }
+}
 
 export default ErrorPopover;

--- a/graylog2-web-interface/src/components/lookup-tables/LUTTableEntry.jsx
+++ b/graylog2-web-interface/src/components/lookup-tables/LUTTableEntry.jsx
@@ -13,31 +13,28 @@ import { ContentPackMarker } from 'components/common';
 
 const { LookupTablesActions } = CombinedProvider.get('LookupTables');
 
-const LUTTableEntry = React.createClass({
-
-  propTypes: {
+class LUTTableEntry extends React.Component {
+  static propTypes = {
     table: PropTypes.object.isRequired,
     cache: PropTypes.object.isRequired,
     dataAdapter: PropTypes.object.isRequired,
     errors: PropTypes.object,
-  },
+  };
 
-  getDefaultProps() {
-    return {
-      errors: {
-        table: null,
-        cache: null,
-        dataAdapter: null,
-      },
-    };
-  },
+  static defaultProps = {
+    errors: {
+      table: null,
+      cache: null,
+      dataAdapter: null,
+    },
+  };
 
-  _onDelete() {
+  _onDelete = () => {
 // eslint-disable-next-line no-alert
     if (window.confirm(`Are you sure you want to delete lookup table "${this.props.table.title}"?`)) {
       LookupTablesActions.delete(this.props.table.id).then(() => LookupTablesActions.reloadPage());
     }
-  },
+  };
 
   render() {
     return (<tbody>
@@ -66,9 +63,8 @@ const LUTTableEntry = React.createClass({
         </td>
       </tr>
     </tbody>);
-  },
-
-});
+  }
+}
 
 export default LUTTableEntry;
 

--- a/graylog2-web-interface/src/components/lookup-tables/LookupTable.jsx
+++ b/graylog2-web-interface/src/components/lookup-tables/LookupTable.jsx
@@ -13,48 +13,45 @@ import CombinedProvider from 'injection/CombinedProvider';
 
 const { LookupTablesActions } = CombinedProvider.get('LookupTables');
 
-const LookupTable = React.createClass({
-
-  propTypes: {
+class LookupTable extends React.Component {
+  static propTypes = {
     table: PropTypes.object.isRequired,
     cache: PropTypes.object.isRequired,
     dataAdapter: PropTypes.object.isRequired,
-  },
+  };
 
-  getInitialState() {
-    return {
-      lookupKey: null,
-      lookupResult: null,
-      purgeKey: null,
-    };
-  },
+  state = {
+    lookupKey: null,
+    lookupResult: null,
+    purgeKey: null,
+  };
 
-  _onChange(event) {
+  _onChange = (event) => {
     this.setState({ lookupKey: FormsUtils.getValueFromInput(event.target) });
-  },
+  };
 
-  _onChangePurgeKey(event) {
+  _onChangePurgeKey = (event) => {
     this.setState({ purgeKey: FormsUtils.getValueFromInput(event.target) });
-  },
+  };
 
-  _onPurgeKey(e) {
+  _onPurgeKey = (e) => {
     e.preventDefault();
     if (this.state.purgeKey && this.state.purgeKey.length > 0) {
       LookupTablesActions.purgeKey(this.props.table, this.state.purgeKey);
     }
-  },
+  };
 
-  _onPurgeAll(e) {
+  _onPurgeAll = (e) => {
     e.preventDefault();
     LookupTablesActions.purgeAll(this.props.table);
-  },
+  };
 
-  _lookupKey(e) {
+  _lookupKey = (e) => {
     e.preventDefault();
     LookupTablesActions.lookup(this.props.table.name, this.state.lookupKey).then((result) => {
       this.setState({ lookupResult: result });
     });
-  },
+  };
 
   render() {
     return (
@@ -130,8 +127,7 @@ const LookupTable = React.createClass({
         </Col>
       </Row>
     );
-  },
-
-});
+  }
+}
 
 export default LookupTable;

--- a/graylog2-web-interface/src/components/lookup-tables/LookupTableCreate.jsx
+++ b/graylog2-web-interface/src/components/lookup-tables/LookupTableCreate.jsx
@@ -3,26 +3,21 @@ import React from 'react';
 import { Row, Col } from 'react-bootstrap';
 import { LookupTableForm } from 'components/lookup-tables';
 
-const LookupTableCreate = React.createClass({
-
-  propTypes: {
+class LookupTableCreate extends React.Component {
+  static propTypes = {
     saved: PropTypes.func.isRequired,
     validate: PropTypes.func,
     validationErrors: PropTypes.object,
-  },
+  };
 
-  getDefaultProps() {
-    return {
-      validate: null,
-      validationErrors: {},
-    };
-  },
+  static defaultProps = {
+    validate: null,
+    validationErrors: {},
+  };
 
-  getInitialState() {
-    return {
-      table: undefined,
-    };
-  },
+  state = {
+    table: undefined,
+  };
 
   render() {
     return (
@@ -37,8 +32,7 @@ const LookupTableCreate = React.createClass({
         </Row>
       </div>
     );
-  },
-
-});
+  }
+}
 
 export default LookupTableCreate;

--- a/graylog2-web-interface/src/components/lookup-tables/LookupTableForm.jsx
+++ b/graylog2-web-interface/src/components/lookup-tables/LookupTableForm.jsx
@@ -13,45 +13,39 @@ import CombinedProvider from 'injection/CombinedProvider';
 
 const { LookupTablesActions } = CombinedProvider.get('LookupTables');
 
-const LookupTableForm = React.createClass({
-  propTypes: {
+class LookupTableForm extends React.Component {
+  static propTypes = {
     saved: PropTypes.func.isRequired,
     create: PropTypes.bool,
     table: PropTypes.object,
     validate: PropTypes.func,
     validationErrors: PropTypes.object,
-  },
+  };
 
-  getDefaultProps() {
-    return {
-      create: true,
-      table: {
-        id: undefined,
-        title: '',
-        description: '',
-        name: '',
-        cache_id: undefined,
-        data_adapter_id: undefined,
-        default_single_value: '',
-        default_single_value_type: 'NULL',
-        default_multi_value: '',
-        default_multi_value_type: 'NULL',
-      },
-      validate: null,
-      validationErrors: {},
-    };
-  },
-
-  getInitialState() {
-    return this._initialState(this.props.table);
-  },
+  static defaultProps = {
+    create: true,
+    table: {
+      id: undefined,
+      title: '',
+      description: '',
+      name: '',
+      cache_id: undefined,
+      data_adapter_id: undefined,
+      default_single_value: '',
+      default_single_value_type: 'NULL',
+      default_multi_value: '',
+      default_multi_value_type: 'NULL',
+    },
+    validate: null,
+    validationErrors: {},
+  };
 
   componentDidMount() {
     if (!this.props.create) {
       // Validate when mounted to immediately show errors for invalid objects
       this._validate(this.props.table);
     }
-  },
+  }
 
   componentWillReceiveProps(nextProps) {
     if (_.isEqual(this.props.table, nextProps.table)) {
@@ -59,22 +53,22 @@ const LookupTableForm = React.createClass({
       return;
     }
     this.setState(this._initialState(nextProps.table));
-  },
+  }
 
   componentWillUnmount() {
     this._clearTimer();
-  },
+  }
 
-  validationCheckTimer: undefined,
+  validationCheckTimer = undefined;
 
-  _clearTimer() {
+  _clearTimer = () => {
     if (this.validationCheckTimer !== undefined) {
       clearTimeout(this.validationCheckTimer);
       this.validationCheckTimer = undefined;
     }
-  },
+  };
 
-  _validate(table) {
+  _validate = (table) => {
     if (!table.cache_id || !table.data_adapter_id) {
       return;
     }
@@ -83,9 +77,9 @@ const LookupTableForm = React.createClass({
     if (this.props.validate) {
       this.validationCheckTimer = setTimeout(() => this.props.validate(table), 500);
     }
-  },
+  };
 
-  _initialState(t) {
+  _initialState = (t) => {
     const table = ObjectUtils.clone(t);
 
     return {
@@ -104,23 +98,23 @@ const LookupTableForm = React.createClass({
       enable_default_single: table.default_single_value_type && table.default_single_value_type !== 'NULL',
       enable_default_multi: table.default_multi_value_type && table.default_multi_value_type !== 'NULL',
     };
-  },
+  };
 
-  _onChange(event) {
+  _onChange = (event) => {
     const table = ObjectUtils.clone(this.state.table);
     table[event.target.name] = FormsUtils.getValueFromInput(event.target);
     this._validate(table);
     this.setState({ table: table });
-  },
+  };
 
-  _onConfigChange(event) {
+  _onConfigChange = (event) => {
     const table = ObjectUtils.clone(this.state.table);
     table.config[event.target.name] = FormsUtils.getValueFromInput(event.target);
     this._validate(table);
     this.setState({ table: table });
-  },
+  };
 
-  _save(event) {
+  _save = (event) => {
     if (event) {
       event.preventDefault();
     }
@@ -135,23 +129,23 @@ const LookupTableForm = React.createClass({
     promise.then(() => {
       this.props.saved();
     });
-  },
+  };
 
-  _onAdapterSelect(id) {
+  _onAdapterSelect = (id) => {
     const table = ObjectUtils.clone(this.state.table);
     table.data_adapter_id = id;
     this._validate(table);
     this.setState({ table: table });
-  },
+  };
 
-  _onCacheSelect(id) {
+  _onCacheSelect = (id) => {
     const table = ObjectUtils.clone(this.state.table);
     table.cache_id = id;
     this._validate(table);
     this.setState({ table: table });
-  },
+  };
 
-  _onDefaultValueUpdate(name, value, valueType) {
+  _onDefaultValueUpdate = (name, value, valueType) => {
     const table = ObjectUtils.clone(this.state.table);
 
     table[`default_${name}_value`] = value;
@@ -159,42 +153,42 @@ const LookupTableForm = React.createClass({
 
     this._validate(table);
     this.setState({ table: table });
-  },
+  };
 
-  _onCheckEnableSingleDefault(e) {
+  _onCheckEnableSingleDefault = (e) => {
     const value = FormsUtils.getValueFromInput(e.target);
     this.setState({ enable_default_single: value });
 
     if (value === false) {
       this._onDefaultValueUpdate('single', '', 'NULL');
     }
-  },
+  };
 
-  _onCheckEnableMultiDefault(e) {
+  _onCheckEnableMultiDefault = (e) => {
     const value = FormsUtils.getValueFromInput(e.target);
     this.setState({ enable_default_multi: value });
 
     if (value === false) {
       this._onDefaultValueUpdate('multi', '', 'NULL');
     }
-  },
+  };
 
-  _onDefaultSingleValueUpdate(value, valueType) {
+  _onDefaultSingleValueUpdate = (value, valueType) => {
     this._onDefaultValueUpdate('single', value, valueType);
-  },
+  };
 
-  _onDefaultMultiValueUpdate(value, valueType) {
+  _onDefaultMultiValueUpdate = (value, valueType) => {
     this._onDefaultValueUpdate('multi', value, valueType);
-  },
+  };
 
-  _validationState(fieldName) {
+  _validationState = (fieldName) => {
     if (this.props.validationErrors[fieldName]) {
       return 'error';
     }
     return null;
-  },
+  };
 
-  _validationMessage(fieldName, defaultText) {
+  _validationMessage = (fieldName, defaultText) => {
     if (this.props.validationErrors[fieldName]) {
       return (<div>
         <span>{defaultText}</span>
@@ -203,7 +197,9 @@ const LookupTableForm = React.createClass({
       </div>);
     }
     return <span>{defaultText}</span>;
-  },
+  };
+
+  state = this._initialState(this.props.table);
 
   render() {
     const table = this.state.table;
@@ -303,7 +299,7 @@ const LookupTableForm = React.createClass({
         </fieldset>
       </form>
     );
-  },
-});
+  }
+}
 
 export default LookupTableForm;

--- a/graylog2-web-interface/src/components/lookup-tables/LookupTablesOverview.jsx
+++ b/graylog2-web-interface/src/components/lookup-tables/LookupTablesOverview.jsx
@@ -13,39 +13,38 @@ import Styles from './Overview.css';
 
 const { LookupTablesActions } = CombinedProvider.get('LookupTables');
 
-const LookupTablesOverview = React.createClass({
-
-  propTypes: {
+class LookupTablesOverview extends React.Component {
+  static propTypes = {
     tables: PropTypes.arrayOf(PropTypes.object).isRequired,
     caches: PropTypes.objectOf(PropTypes.object).isRequired,
     dataAdapters: PropTypes.objectOf(PropTypes.object).isRequired,
     pagination: PropTypes.object.isRequired,
     errorStates: PropTypes.object.isRequired,
-  },
+  };
 
-  _onPageChange(newPage, newPerPage) {
+  _onPageChange = (newPage, newPerPage) => {
     LookupTablesActions.searchPaginated(newPage, newPerPage, this.props.pagination.query);
-  },
+  };
 
-  _onSearch(query, resetLoadingStateCb) {
+  _onSearch = (query, resetLoadingStateCb) => {
     LookupTablesActions
       .searchPaginated(this.props.pagination.page, this.props.pagination.per_page, query)
       .then(resetLoadingStateCb);
-  },
+  };
 
-  _onReset() {
+  _onReset = () => {
     LookupTablesActions.searchPaginated(this.props.pagination.page, this.props.pagination.per_page);
-  },
+  };
 
-  _lookupName(id, map) {
+  _lookupName = (id, map) => {
     const empty = { title: 'None' };
     if (!map) {
       return empty;
     }
     return map[id] || empty;
-  },
+  };
 
-  _lookupAdapterError(table) {
+  _lookupAdapterError = (table) => {
     if (this.props.errorStates.dataAdapters && this.props.dataAdapters) {
       const adapter = this.props.dataAdapters[table.data_adapter_id];
       if (!adapter) {
@@ -54,9 +53,9 @@ const LookupTablesOverview = React.createClass({
       return this.props.errorStates.dataAdapters[adapter.name];
     }
     return null;
-  },
+  };
 
-  _helpPopover() {
+  _helpPopover = () => {
     return (
       <Popover id="search-query-help" className={Styles.popoverWide} title="Search Syntax Help">
         <p><strong>Available search fields</strong></p>
@@ -99,7 +98,7 @@ const LookupTablesOverview = React.createClass({
         </p>
       </Popover>
     );
-  },
+  };
 
   render() {
     const lookupTables = this.props.tables.map((table) => {
@@ -151,7 +150,7 @@ const LookupTablesOverview = React.createClass({
         </Col>
       </Row>
     </div>);
-  },
-});
+  }
+}
 
 export default LookupTablesOverview;

--- a/graylog2-web-interface/src/components/lookup-tables/adapters/CSVFileAdapterDocumentation.jsx
+++ b/graylog2-web-interface/src/components/lookup-tables/adapters/CSVFileAdapterDocumentation.jsx
@@ -2,7 +2,7 @@
 import React from 'react';
 import { Alert } from 'react-bootstrap';
 
-const CSVFileAdapterDocumentation = React.createClass({
+class CSVFileAdapterDocumentation extends React.Component {
   render() {
     const csvFile1 = `"ipaddr","hostname"
 "127.0.0.1","localhost"
@@ -55,7 +55,7 @@ const CSVFileAdapterDocumentation = React.createClass({
       <h5 style={{ marginBottom: 10 }}>CSV File</h5>
       <pre>{csvFile2}</pre>
     </div>);
-  },
-});
+  }
+}
 
 export default CSVFileAdapterDocumentation;

--- a/graylog2-web-interface/src/components/lookup-tables/adapters/CSVFileAdapterFieldSet.jsx
+++ b/graylog2-web-interface/src/components/lookup-tables/adapters/CSVFileAdapterFieldSet.jsx
@@ -3,92 +3,92 @@ import React from 'react';
 
 import { Input } from 'components/bootstrap';
 
-const CSVFileAdapterFieldSet = React.createClass({
-  propTypes: {
-    config: PropTypes.object.isRequired,
-// eslint-disable-next-line react/no-unused-prop-types
-    updateConfig: PropTypes.func.isRequired,
-    handleFormEvent: PropTypes.func.isRequired,
-    validationState: PropTypes.func.isRequired,
-    validationMessage: PropTypes.func.isRequired,
-  },
+class CSVFileAdapterFieldSet extends React.Component {
+       static propTypes = {
+         config: PropTypes.object.isRequired,
+     // eslint-disable-next-line react/no-unused-prop-types
+         updateConfig: PropTypes.func.isRequired,
+         handleFormEvent: PropTypes.func.isRequired,
+         validationState: PropTypes.func.isRequired,
+         validationMessage: PropTypes.func.isRequired,
+       };
 
-  render() {
-    const config = this.props.config;
+       render() {
+         const config = this.props.config;
 
-    return (<fieldset>
-      <Input type="text"
-             id="path"
-             name="path"
-             label="File path"
-             autoFocus
-             required
-             onChange={this.props.handleFormEvent}
-             help={this.props.validationMessage('path', 'The path to the CSV file.')}
-             bsStyle={this.props.validationState('path')}
-             value={config.path}
-             labelClassName="col-sm-3"
-             wrapperClassName="col-sm-9" />
-      <Input type="number"
-             id="check_interval"
-             name="check_interval"
-             label="Check interval"
-             required
-             onChange={this.props.handleFormEvent}
-             help="The interval to check if the CSV file needs a reload. (in seconds)"
-             value={config.check_interval}
-             labelClassName="col-sm-3"
-             wrapperClassName="col-sm-9" />
-      <Input type="text"
-             id="separator"
-             name="separator"
-             label="Separator"
-             required
-             onChange={this.props.handleFormEvent}
-             help="The delimiter to use for separating entries."
-             value={config.separator}
-             labelClassName="col-sm-3"
-             wrapperClassName="col-sm-9" />
-      <Input type="text"
-             id="quotechar"
-             name="quotechar"
-             label="Quote character"
-             required
-             onChange={this.props.handleFormEvent}
-             help="The character to use for quoted elements."
-             value={config.quotechar}
-             labelClassName="col-sm-3"
-             wrapperClassName="col-sm-9" />
-      <Input type="text"
-             id="key_column"
-             name="key_column"
-             label="Key column"
-             required
-             onChange={this.props.handleFormEvent}
-             help="The column name that should be used for the key lookup."
-             value={config.key_column}
-             labelClassName="col-sm-3"
-             wrapperClassName="col-sm-9" />
-      <Input type="text"
-             id="value_column"
-             name="value_column"
-             label="Value column"
-             required
-             onChange={this.props.handleFormEvent}
-             help="The column name that should be used as the value for a key."
-             value={config.value_column}
-             labelClassName="col-sm-3"
-             wrapperClassName="col-sm-9" />
-      <Input type="checkbox"
-             id="case_insensitive_lookup"
-             name="case_insensitive_lookup"
-             label="Allow case-insensitive lookups"
-             checked={config.case_insensitive_lookup}
-             onChange={this.props.handleFormEvent}
-             help="Enable if the key lookup should be case-insensitive."
-             wrapperClassName="col-md-offset-3 col-md-9" />
-    </fieldset>);
-  },
-});
+         return (<fieldset>
+           <Input type="text"
+                  id="path"
+                  name="path"
+                  label="File path"
+                  autoFocus
+                  required
+                  onChange={this.props.handleFormEvent}
+                  help={this.props.validationMessage('path', 'The path to the CSV file.')}
+                  bsStyle={this.props.validationState('path')}
+                  value={config.path}
+                  labelClassName="col-sm-3"
+                  wrapperClassName="col-sm-9" />
+           <Input type="number"
+                  id="check_interval"
+                  name="check_interval"
+                  label="Check interval"
+                  required
+                  onChange={this.props.handleFormEvent}
+                  help="The interval to check if the CSV file needs a reload. (in seconds)"
+                  value={config.check_interval}
+                  labelClassName="col-sm-3"
+                  wrapperClassName="col-sm-9" />
+           <Input type="text"
+                  id="separator"
+                  name="separator"
+                  label="Separator"
+                  required
+                  onChange={this.props.handleFormEvent}
+                  help="The delimiter to use for separating entries."
+                  value={config.separator}
+                  labelClassName="col-sm-3"
+                  wrapperClassName="col-sm-9" />
+           <Input type="text"
+                  id="quotechar"
+                  name="quotechar"
+                  label="Quote character"
+                  required
+                  onChange={this.props.handleFormEvent}
+                  help="The character to use for quoted elements."
+                  value={config.quotechar}
+                  labelClassName="col-sm-3"
+                  wrapperClassName="col-sm-9" />
+           <Input type="text"
+                  id="key_column"
+                  name="key_column"
+                  label="Key column"
+                  required
+                  onChange={this.props.handleFormEvent}
+                  help="The column name that should be used for the key lookup."
+                  value={config.key_column}
+                  labelClassName="col-sm-3"
+                  wrapperClassName="col-sm-9" />
+           <Input type="text"
+                  id="value_column"
+                  name="value_column"
+                  label="Value column"
+                  required
+                  onChange={this.props.handleFormEvent}
+                  help="The column name that should be used as the value for a key."
+                  value={config.value_column}
+                  labelClassName="col-sm-3"
+                  wrapperClassName="col-sm-9" />
+           <Input type="checkbox"
+                  id="case_insensitive_lookup"
+                  name="case_insensitive_lookup"
+                  label="Allow case-insensitive lookups"
+                  checked={config.case_insensitive_lookup}
+                  onChange={this.props.handleFormEvent}
+                  help="Enable if the key lookup should be case-insensitive."
+                  wrapperClassName="col-md-offset-3 col-md-9" />
+         </fieldset>);
+       }
+}
 
 export default CSVFileAdapterFieldSet;

--- a/graylog2-web-interface/src/components/lookup-tables/adapters/CSVFileAdapterSummary.jsx
+++ b/graylog2-web-interface/src/components/lookup-tables/adapters/CSVFileAdapterSummary.jsx
@@ -1,10 +1,10 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 
-const CSVFileAdapterSummary = React.createClass({
-  propTypes: {
+class CSVFileAdapterSummary extends React.Component {
+  static propTypes = {
     dataAdapter: PropTypes.object.isRequired,
-  },
+  };
 
   render() {
     const config = this.props.dataAdapter.config;
@@ -24,8 +24,8 @@ const CSVFileAdapterSummary = React.createClass({
       <dt>Case-insensitive lookup</dt>
       <dd>{config.case_insensitive_lookup ? 'yes' : 'no'}</dd>
     </dl>);
-  },
-});
+  }
+}
 
 
 export default CSVFileAdapterSummary;

--- a/graylog2-web-interface/src/components/lookup-tables/adapters/HTTPJSONPathAdapterFieldSet.jsx
+++ b/graylog2-web-interface/src/components/lookup-tables/adapters/HTTPJSONPathAdapterFieldSet.jsx
@@ -4,23 +4,24 @@ import { Input } from 'components/bootstrap';
 import { KeyValueTable } from 'components/common';
 import ObjectUtils from 'util/ObjectUtils';
 
-const HTTPJSONPathAdapterFieldSet = React.createClass({
-  propTypes: {
+class HTTPJSONPathAdapterFieldSet extends React.Component {
+  static propTypes = {
     config: PropTypes.object.isRequired,
     // eslint-disable-next-line react/no-unused-prop-types
     updateConfig: PropTypes.func.isRequired,
     handleFormEvent: PropTypes.func.isRequired,
     validationState: PropTypes.func.isRequired,
     validationMessage: PropTypes.func.isRequired,
-  },
-  getInitialState() {
-    return {};
-  },
-  onHTTPHeaderUpdate(headers) {
+  };
+
+  state = {};
+
+  onHTTPHeaderUpdate = (headers) => {
     const config = ObjectUtils.clone(this.props.config);
     config.headers = headers;
     this.props.updateConfig(config);
-  },
+  };
+
   render() {
     const config = this.props.config;
 
@@ -77,7 +78,7 @@ const HTTPJSONPathAdapterFieldSet = React.createClass({
       </Input>
 
     </fieldset>);
-  },
-});
+  }
+}
 
 export default HTTPJSONPathAdapterFieldSet;

--- a/graylog2-web-interface/src/components/lookup-tables/caches/GuavaCacheDocumentation.jsx
+++ b/graylog2-web-interface/src/components/lookup-tables/caches/GuavaCacheDocumentation.jsx
@@ -2,7 +2,7 @@
 import React from 'react';
 import { Alert } from 'react-bootstrap';
 
-const GuavaCacheDocumentation = React.createClass({
+class GuavaCacheDocumentation extends React.Component {
   render() {
     return (<div>
       <p>The in-memory cache maintains recently used values from data adapters.</p>
@@ -35,7 +35,7 @@ const GuavaCacheDocumentation = React.createClass({
       </p>
 
     </div>);
-  },
-});
+  }
+}
 
 export default GuavaCacheDocumentation;

--- a/graylog2-web-interface/src/components/lookup-tables/caches/GuavaCacheFieldSet.jsx
+++ b/graylog2-web-interface/src/components/lookup-tables/caches/GuavaCacheFieldSet.jsx
@@ -5,8 +5,8 @@ import ObjectUtils from 'util/ObjectUtils';
 import { Input } from 'components/bootstrap';
 import { TimeUnitInput } from 'components/common';
 
-const GuavaCacheFieldSet = React.createClass({
-  propTypes: {
+class GuavaCacheFieldSet extends React.Component {
+  static propTypes = {
     config: PropTypes.object.isRequired,
     updateConfig: PropTypes.func.isRequired,
     handleFormEvent: PropTypes.func.isRequired,
@@ -14,26 +14,26 @@ const GuavaCacheFieldSet = React.createClass({
     validationState: PropTypes.func.isRequired,
 // eslint-disable-next-line react/no-unused-prop-types
     validationMessage: PropTypes.func.isRequired,
-  },
+  };
 
-  _update(value, unit, enabled, name) {
+  _update = (value, unit, enabled, name) => {
     const config = ObjectUtils.clone(this.props.config);
     config[name] = enabled ? value : 0;
     config[`${name}_unit`] = unit;
     this.props.updateConfig(config);
-  },
+  };
 
-  updateAfterAccess(value, unit, enabled) {
+  updateAfterAccess = (value, unit, enabled) => {
     this._update(value, unit, enabled, 'expire_after_access');
-  },
+  };
 
-  updateAfterWrite(value, unit, enabled) {
+  updateAfterWrite = (value, unit, enabled) => {
     this._update(value, unit, enabled, 'expire_after_write');
-  },
+  };
 
-  updateRefresh(value, unit, enabled) {
+  updateRefresh = (value, unit, enabled) => {
     this._update(value, unit, enabled, 'refresh_after_write');
-  },
+  };
 
   render() {
     const config = this.props.config;
@@ -67,7 +67,7 @@ const GuavaCacheFieldSet = React.createClass({
                      labelClassName="col-sm-3"
                      wrapperClassName="col-sm-9" />
     </fieldset>);
-  },
-});
+  }
+}
 
 export default GuavaCacheFieldSet;

--- a/graylog2-web-interface/src/components/lookup-tables/caches/GuavaCacheSummary.jsx
+++ b/graylog2-web-interface/src/components/lookup-tables/caches/GuavaCacheSummary.jsx
@@ -2,10 +2,10 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import { TimeUnit } from 'components/common';
 
-const GuavaCacheSummary = React.createClass({
-  propTypes: {
+class GuavaCacheSummary extends React.Component {
+  static propTypes = {
     cache: PropTypes.object.isRequired,
-  },
+  };
 
   render() {
     const config = this.props.cache.config;
@@ -17,7 +17,7 @@ const GuavaCacheSummary = React.createClass({
       <dt>Expire after write</dt>
       <dd><TimeUnit value={config.expire_after_write} unit={config.expire_after_write_unit} /></dd>
     </dl>);
-  },
-});
+  }
+}
 
 export default GuavaCacheSummary;

--- a/graylog2-web-interface/src/components/lookup-tables/caches/NullCacheFieldSet.jsx
+++ b/graylog2-web-interface/src/components/lookup-tables/caches/NullCacheFieldSet.jsx
@@ -1,8 +1,8 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 
-const NullCacheFieldSet = React.createClass({
-  propTypes: {
+class NullCacheFieldSet extends React.Component {
+  static propTypes = {
     config: PropTypes.object.isRequired,
     updateConfig: PropTypes.func.isRequired,
     handleFormEvent: PropTypes.func.isRequired,
@@ -10,11 +10,11 @@ const NullCacheFieldSet = React.createClass({
     validationState: PropTypes.func.isRequired,
 // eslint-disable-next-line react/no-unused-prop-types
     validationMessage: PropTypes.func.isRequired,
-  },
+  };
 
   render() {
     return null;
-  },
-});
+  }
+}
 
 export default NullCacheFieldSet;

--- a/graylog2-web-interface/src/components/lookup-tables/caches/NullCacheSummary.jsx
+++ b/graylog2-web-interface/src/components/lookup-tables/caches/NullCacheSummary.jsx
@@ -1,14 +1,14 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 
-const NullCacheSummary = React.createClass({
-  propTypes: {
+class NullCacheSummary extends React.Component {
+  static propTypes = {
     cache: PropTypes.object.isRequired,
-  },
+  };
 
   render() {
     return (<p>This cache has no configuration.</p>);
-  },
-});
+  }
+}
 
 export default NullCacheSummary;

--- a/graylog2-web-interface/src/components/maps/adapter/MaxmindAdapterDocumentation.jsx
+++ b/graylog2-web-interface/src/components/maps/adapter/MaxmindAdapterDocumentation.jsx
@@ -2,7 +2,7 @@
 import React from 'react';
 import { Alert } from 'react-bootstrap';
 
-const MaxmindAdapterDocumentation = React.createClass({
+class MaxmindAdapterDocumentation extends React.Component {
   render() {
     const cityFields = `{
     "city": { "geoname_id": 5375480, "names": { "en": "Mountain View" } },
@@ -57,7 +57,7 @@ const MaxmindAdapterDocumentation = React.createClass({
 
       <p>For a complete documentation of the fields, please see MaxMind's <a href="http://maxmind.github.io/GeoIP2-java/" target="_blank" rel="noopener noreferrer">developer documentation</a></p>
     </div>);
-  },
-});
+  }
+}
 
 export default MaxmindAdapterDocumentation;

--- a/graylog2-web-interface/src/components/maps/adapter/MaxmindAdapterFieldSet.jsx
+++ b/graylog2-web-interface/src/components/maps/adapter/MaxmindAdapterFieldSet.jsx
@@ -5,32 +5,32 @@ import ObjectUtils from 'util/ObjectUtils';
 import { Input } from 'components/bootstrap';
 import { Select, TimeUnitInput } from 'components/common';
 
-const MaxmindAdapterFieldSet = React.createClass({
-  propTypes: {
+class MaxmindAdapterFieldSet extends React.Component {
+  static propTypes = {
     config: PropTypes.object.isRequired,
 // eslint-disable-next-line react/no-unused-prop-types
     updateConfig: PropTypes.func.isRequired,
     handleFormEvent: PropTypes.func.isRequired,
     validationState: PropTypes.func.isRequired,
     validationMessage: PropTypes.func.isRequired,
-  },
+  };
 
-  _update(value, unit, enabled, name) {
+  _update = (value, unit, enabled, name) => {
     const config = ObjectUtils.clone(this.props.config);
     config[name] = enabled ? value : 0;
     config[`${name}_unit`] = unit;
     this.props.updateConfig(config);
-  },
+  };
 
-  updateCheckInterval(value, unit, enabled) {
+  updateCheckInterval = (value, unit, enabled) => {
     this._update(value, unit, enabled, 'check_interval');
-  },
+  };
 
-  _onDbTypeSelect(id) {
+  _onDbTypeSelect = (id) => {
     const config = ObjectUtils.clone(this.props.config);
     config.database_type = id;
     this.props.updateConfig(config);
-  },
+  };
 
   render() {
     const config = this.props.config;
@@ -74,7 +74,7 @@ const MaxmindAdapterFieldSet = React.createClass({
                      labelClassName="col-sm-3"
                      wrapperClassName="col-sm-9" />
     </fieldset>);
-  },
-});
+  }
+}
 
 export default MaxmindAdapterFieldSet;

--- a/graylog2-web-interface/src/components/maps/adapter/MaxmindAdapterSummary.jsx
+++ b/graylog2-web-interface/src/components/maps/adapter/MaxmindAdapterSummary.jsx
@@ -2,10 +2,10 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import { TimeUnit } from 'components/common';
 
-const MaxmindAdapterSummary = React.createClass({
-  propTypes: {
+class MaxmindAdapterSummary extends React.Component {
+  static propTypes = {
     dataAdapter: PropTypes.object.isRequired,
-  },
+  };
 
   render() {
     const config = this.props.dataAdapter.config;
@@ -21,7 +21,7 @@ const MaxmindAdapterSummary = React.createClass({
       <dt>Check interval</dt>
       <dd><TimeUnit value={config.check_interval} unit={config.check_interval_unit} /></dd>
     </dl>);
-  },
-});
+  }
+}
 
 export default MaxmindAdapterSummary;

--- a/graylog2-web-interface/src/components/maps/configurations/GeoIpResolverConfig.jsx
+++ b/graylog2-web-interface/src/components/maps/configurations/GeoIpResolverConfig.jsx
@@ -1,12 +1,15 @@
 import PropTypes from 'prop-types';
 import React from 'react';
+import createReactClass from 'create-react-class';
 import { Button } from 'react-bootstrap';
 import { BootstrapModalForm, Input } from 'components/bootstrap';
 import { IfPermitted, Select } from 'components/common';
 import { DocumentationLink } from 'components/support';
 import ObjectUtils from 'util/ObjectUtils';
 
-const GeoIpResolverConfig = React.createClass({
+const GeoIpResolverConfig = createReactClass({
+  displayName: 'GeoIpResolverConfig',
+
   propTypes: {
     config: PropTypes.object,
     updateConfig: PropTypes.func.isRequired,

--- a/graylog2-web-interface/src/components/maps/field-analyzers/FieldAnalyzerMapComponent.jsx
+++ b/graylog2-web-interface/src/components/maps/field-analyzers/FieldAnalyzerMapComponent.jsx
@@ -1,5 +1,6 @@
 import PropTypes from 'prop-types';
 import React from 'react';
+import createReactClass from 'create-react-class';
 import Reflux from 'reflux';
 import { Spinner } from 'components/common';
 import AddToDashboardMenu from 'components/dashboard/AddToDashboardMenu';
@@ -11,7 +12,9 @@ import EventHandlersThrottler from 'util/EventHandlersThrottler';
 import StoreProvider from 'injection/StoreProvider';
 const RefreshStore = StoreProvider.getStore('Refresh');
 
-const FieldAnalyzerMapComponent = React.createClass({
+const FieldAnalyzerMapComponent = createReactClass({
+  displayName: 'FieldAnalyzerMapComponent',
+
   propTypes: {
     from: PropTypes.any.isRequired,
     to: PropTypes.any.isRequired,
@@ -41,6 +44,7 @@ const FieldAnalyzerMapComponent = React.createClass({
   componentWillUnmount() {
     window.removeEventListener('resize', this._onResize);
   },
+
   componentWillReceiveProps(nextProps) {
     // Reload values when executed search changes
     if (this.props.query !== nextProps.query ||
@@ -58,11 +62,13 @@ const FieldAnalyzerMapComponent = React.createClass({
       this.timer = setInterval(() => this._loadData(this.props), refresh.interval);
     }
   },
+
   _stopTimer() {
     if (this.timer) {
       clearInterval(this.timer);
     }
   },
+
   DEFAULT_WIDTH: 800,
   WIDGET_TYPE: 'org.graylog.plugins.map.widget.strategy.MapWidgetStrategy',
   eventThrottler: new EventHandlersThrottler(),

--- a/graylog2-web-interface/src/components/maps/widgets/MapVisualization.jsx
+++ b/graylog2-web-interface/src/components/maps/widgets/MapVisualization.jsx
@@ -1,12 +1,15 @@
 /* eslint-env browser */
 import PropTypes from 'prop-types';
 import React from 'react';
+import createReactClass from 'create-react-class';
 import { Map, TileLayer, CircleMarker, Popup } from 'react-leaflet';
 
 import {} from 'leaflet/dist/leaflet.css';
 import style from './MapVisualization.css';
 
-const MapVisualization = React.createClass({
+const MapVisualization = createReactClass({
+  displayName: 'MapVisualization',
+
   propTypes: {
     id: PropTypes.string.isRequired,
     data: PropTypes.object,
@@ -18,6 +21,7 @@ const MapVisualization = React.createClass({
     onRenderComplete: PropTypes.func,
     locked: PropTypes.bool, // Disables zoom and dragging
   },
+
   getDefaultProps() {
     return {
       data: {},
@@ -79,9 +83,11 @@ const MapVisualization = React.createClass({
       </CircleMarker>
     );
   },
+
   _onZoomChange(event) {
     this.setState({ zoomLevel: event.target.getZoom() });
   },
+
   _getBucket(value, bucketCount, minValue, maxValue, increment) {
     // Calculate bucket size based on min/max value and the number of buckets.
     const bucketSize = (maxValue - minValue) / bucketCount;

--- a/graylog2-web-interface/src/components/messageloaders/LoaderTabs.jsx
+++ b/graylog2-web-interface/src/components/messageloaders/LoaderTabs.jsx
@@ -1,5 +1,6 @@
 import PropTypes from 'prop-types';
 import React from 'react';
+import createReactClass from 'create-react-class';
 import Reflux from 'reflux';
 import { Tab, Tabs, Col } from 'react-bootstrap';
 import Immutable from 'immutable';
@@ -16,7 +17,9 @@ import MessageLoader from 'components/extractors/MessageLoader';
 import RawMessageLoader from './RawMessageLoader';
 import RecentMessageLoader from './RecentMessageLoader';
 
-const LoaderTabs = React.createClass({
+const LoaderTabs = createReactClass({
+  displayName: 'LoaderTabs',
+
   propTypes: {
     tabs: PropTypes.oneOfType([
       PropTypes.oneOf(['recent', 'messageId', 'raw']),
@@ -45,6 +48,7 @@ const LoaderTabs = React.createClass({
       inputs: undefined,
     };
   },
+
   componentDidMount() {
     this.loadData();
     if (this.props.messageId && this.props.index) {

--- a/graylog2-web-interface/src/components/messageloaders/RawMessageLoader.jsx
+++ b/graylog2-web-interface/src/components/messageloaders/RawMessageLoader.jsx
@@ -1,5 +1,6 @@
 import PropTypes from 'prop-types';
 import React from 'react';
+import createReactClass from 'create-react-class';
 import Reflux from 'reflux';
 import { Button, Col, Row } from 'react-bootstrap';
 
@@ -18,7 +19,9 @@ const MessagesStore = StoreProvider.getStore('Messages');
 const CodecTypesStore = StoreProvider.getStore('CodecTypes');
 const InputsStore = StoreProvider.getStore('Inputs');
 
-const RawMessageLoader = React.createClass({
+const RawMessageLoader = createReactClass({
+  displayName: 'RawMessageLoader',
+
   propTypes: {
     onMessageLoaded: PropTypes.func.isRequired,
     inputIdSelector: PropTypes.bool,

--- a/graylog2-web-interface/src/components/messageloaders/RecentMessageLoader.jsx
+++ b/graylog2-web-interface/src/components/messageloaders/RecentMessageLoader.jsx
@@ -6,19 +6,18 @@ import UserNotification from 'util/UserNotification';
 import StoreProvider from 'injection/StoreProvider';
 const UniversalSearchStore = StoreProvider.getStore('UniversalSearch');
 
-const RecentMessageLoader = React.createClass({
-  propTypes: {
+class RecentMessageLoader extends React.Component {
+  static propTypes = {
     inputs: PropTypes.object,
     onMessageLoaded: PropTypes.func.isRequired,
     selectedInputId: PropTypes.string,
-  },
-  getInitialState() {
-    return {
-      loading: false,
-    };
-  },
+  };
 
-  onClick(inputId) {
+  state = {
+    loading: false,
+  };
+
+  onClick = (inputId) => {
     const input = this.props.inputs.get(inputId);
     if (!input) {
       UserNotification.error(`Invalid input selected: ${inputId}`,
@@ -36,7 +35,8 @@ const RecentMessageLoader = React.createClass({
       }
     });
     promise.finally(() => this.setState({ loading: false }));
-  },
+  };
+
   render() {
     let helpMessage;
     if (this.props.selectedInputId) {
@@ -52,7 +52,7 @@ const RecentMessageLoader = React.createClass({
                        disabled={this.state.loading} />
       </div>
     );
-  },
-});
+  }
+}
 
 export default RecentMessageLoader;

--- a/graylog2-web-interface/src/components/metrics/CounterDetails.jsx
+++ b/graylog2-web-interface/src/components/metrics/CounterDetails.jsx
@@ -2,10 +2,11 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import numeral from 'numeral';
 
-const CounterDetails = React.createClass({
-  propTypes: {
+class CounterDetails extends React.Component {
+  static propTypes = {
     metric: PropTypes.object.isRequired,
-  },
+  };
+
   render() {
     const metric = this.props.metric.metric;
     return (
@@ -14,7 +15,7 @@ const CounterDetails = React.createClass({
         <dd><span className="number-format">{numeral(metric.count).format('0,0')}</span></dd>
       </dl>
     );
-  },
-});
+  }
+}
 
 export default CounterDetails;

--- a/graylog2-web-interface/src/components/metrics/CounterRate.jsx
+++ b/graylog2-web-interface/src/components/metrics/CounterRate.jsx
@@ -3,64 +3,62 @@ import React from 'react';
 import numeral from 'numeral';
 import TimeHelper from 'util/TimeHelper';
 
-const CounterRate = React.createClass({
-  propTypes: {
+class CounterRate extends React.Component {
+  static propTypes = {
     metric: PropTypes.object,
     showTotal: PropTypes.bool,
     prefix: PropTypes.string,
     suffix: PropTypes.string,
     hideOnZero: PropTypes.bool,
     hideOnMissing: PropTypes.bool,
-  },
-  getDefaultProps() {
-    return {
-      showTotal: false,
-      prefix: null,
-      suffix: 'per second',
-      hideOnZero: false,
-      hideOnMissing: false,
-    };
-  },
+  };
 
-  getInitialState() {
-    return {
-      prevMetric: null,
-      prevTs: null,
-      nowTs: TimeHelper.nowInSeconds(),
-    };
-  },
+  static defaultProps = {
+    showTotal: false,
+    prefix: null,
+    suffix: 'per second',
+    hideOnZero: false,
+    hideOnMissing: false,
+  };
+
+  state = {
+    prevMetric: null,
+    prevTs: null,
+    nowTs: TimeHelper.nowInSeconds(),
+  };
+
   componentWillReceiveProps() {
     this.setState({
       prevMetric: this.props.metric,
       prevTs: this.state.nowTs,
       nowTs: TimeHelper.nowInSeconds(),
     });
-  },
+  }
 
-  _checkPrevMetric() {
+  _checkPrevMetric = () => {
     return this.state.prevMetric && this.state.prevMetric.count !== undefined && this.state.prevTs;
-  },
+  };
 
-  _placeholder() {
+  _placeholder = () => {
     if (this.props.hideOnZero) {
       return null;
     }
     return (<span>{this._prefix()}Calculating...</span>);
-  },
+  };
 
-  _prefix() {
+  _prefix = () => {
     if (this.props.prefix) {
       return `${this.props.prefix} `;
     }
     return null;
-  },
+  };
 
-  _suffix() {
+  _suffix = () => {
     if (this.props.suffix) {
       return ` ${this.props.suffix}`;
     }
     return null;
-  },
+  };
 
   render() {
     if (!(this.props.metric && this.props.metric.count !== undefined)) {
@@ -89,7 +87,7 @@ const CounterRate = React.createClass({
       {rate}
       {this.props.showTotal && <span key="absolute" className="number-format"> ({numeral(count).format('0')} total)</span>}
     </span>);
-  },
-});
+  }
+}
 
 export default CounterRate;

--- a/graylog2-web-interface/src/components/metrics/GaugeDetails.jsx
+++ b/graylog2-web-interface/src/components/metrics/GaugeDetails.jsx
@@ -2,10 +2,11 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import numeral from 'numeral';
 
-const GaugeDetails = React.createClass({
-  propTypes: {
+class GaugeDetails extends React.Component {
+  static propTypes = {
     metric: PropTypes.object.isRequired,
-  },
+  };
+
   render() {
     const gauge = this.props.metric.metric;
     return (
@@ -14,7 +15,7 @@ const GaugeDetails = React.createClass({
         <dd><span className="number-format">{numeral(gauge.value).format('0,0')}</span></dd>
       </dl>
     );
-  },
-});
+  }
+}
 
 export default GaugeDetails;

--- a/graylog2-web-interface/src/components/metrics/HistogramDetails.jsx
+++ b/graylog2-web-interface/src/components/metrics/HistogramDetails.jsx
@@ -2,10 +2,11 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import numeral from 'numeral';
 
-const HistogramDetails = React.createClass({
-  propTypes: {
+class HistogramDetails extends React.Component {
+  static propTypes = {
     metric: PropTypes.object.isRequired,
-  },
+  };
+
   render() {
     const histogram = this.props.metric.metric;
     return (
@@ -28,7 +29,7 @@ const HistogramDetails = React.createClass({
         <dd><span className="number-format">{numeral(histogram.count).format('0,0')}</span></dd>
       </dl>
     );
-  },
-});
+  }
+}
 
 export default HistogramDetails;

--- a/graylog2-web-interface/src/components/metrics/MeterDetails.jsx
+++ b/graylog2-web-interface/src/components/metrics/MeterDetails.jsx
@@ -2,10 +2,11 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import numeral from 'numeral';
 
-const MeterDetails = React.createClass({
-  propTypes: {
+class MeterDetails extends React.Component {
+  static propTypes = {
     metric: PropTypes.object.isRequired,
-  },
+  };
+
   render() {
     const meter = this.props.metric.metric;
     return (
@@ -22,7 +23,7 @@ const MeterDetails = React.createClass({
         <dd><span className="number-format">{numeral(meter.rate.fifteen_minute).format('0,0.[00]')}</span> {meter.rate_unit}</dd>
       </dl>
     );
-  },
-});
+  }
+}
 
 export default MeterDetails;

--- a/graylog2-web-interface/src/components/metrics/Metric.jsx
+++ b/graylog2-web-interface/src/components/metrics/Metric.jsx
@@ -1,19 +1,25 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 
+import createReactClass from 'create-react-class';
+
 import { MetricDetails } from 'components/metrics';
 
-const Metric = React.createClass({
+const Metric = createReactClass({
+  displayName: 'Metric',
+
   propTypes: {
     metric: PropTypes.object.isRequired,
     namespace: PropTypes.string,
     nodeId: PropTypes.string.isRequired,
   },
+
   getInitialState() {
     return {
       expanded: false,
     };
   },
+
   iconMapping: {
     timer: 'clock-o',
     histogram: 'signal',
@@ -22,6 +28,7 @@ const Metric = React.createClass({
     counter: 'circle',
     unknown: 'question-circle',
   },
+
   _formatIcon(type) {
     const icon = this.iconMapping[type];
     if (icon) {
@@ -30,6 +37,7 @@ const Metric = React.createClass({
 
     return this.iconMapping.unknown;
   },
+
   _formatName(metricName) {
     const namespace = this.props.namespace;
     const split = metricName.split(namespace);
@@ -41,10 +49,12 @@ const Metric = React.createClass({
       </span>
     );
   },
+
   _showDetails(event) {
     event.preventDefault();
     this.setState({ expanded: !this.state.expanded });
   },
+
   render() {
     const metric = this.props.metric;
     const details = this.state.expanded ? <MetricDetails nodeId={this.props.nodeId} metric={this.props.metric} /> : null;

--- a/graylog2-web-interface/src/components/metrics/MetricContainer.jsx
+++ b/graylog2-web-interface/src/components/metrics/MetricContainer.jsx
@@ -1,5 +1,6 @@
 import PropTypes from 'prop-types';
 import React from 'react';
+import createReactClass from 'create-react-class';
 import Reflux from 'reflux';
 
 import TimeHelper from 'util/TimeHelper';
@@ -12,12 +13,15 @@ const MetricsActions = ActionsProvider.getActions('Metrics');
 
 import MetricsExtractor from 'logic/metrics/MetricsExtractor';
 
-const MetricContainer = React.createClass({
+const MetricContainer = createReactClass({
+  displayName: 'MetricContainer',
+
   propTypes: {
     name: PropTypes.string.isRequired,
     zeroOnMissing: PropTypes.bool,
     children: PropTypes.node.isRequired,
   },
+
   mixins: [Reflux.connect(MetricsStore)],
 
   getDefaultProps() {

--- a/graylog2-web-interface/src/components/metrics/MetricDetails.jsx
+++ b/graylog2-web-interface/src/components/metrics/MetricDetails.jsx
@@ -1,5 +1,6 @@
 import PropTypes from 'prop-types';
 import React from 'react';
+import createReactClass from 'create-react-class';
 import Reflux from 'reflux';
 import lodash from 'lodash';
 
@@ -8,17 +9,23 @@ import CombinedProvider from 'injection/CombinedProvider';
 
 const { MetricsStore, MetricsActions } = CombinedProvider.get('Metrics');
 
-const MetricDetails = React.createClass({
+const MetricDetails = createReactClass({
+  displayName: 'MetricDetails',
+
   propTypes: {
     metric: PropTypes.object.isRequired,
   },
+
   mixins: [Reflux.connect(MetricsStore)],
+
   componentDidMount() {
     MetricsActions.add(this.props.nodeId, this.props.metric.full_name);
   },
+
   componentWillUnmount() {
     MetricsActions.remove(this.props.nodeId, this.props.metric.full_name);
   },
+
   _formatDetailsForType(type, metric) {
     switch (type) {
       case 'Counter':
@@ -35,6 +42,7 @@ const MetricDetails = React.createClass({
         return <i>Invalid metric type: {type}</i>;
     }
   },
+
   render() {
     const metricName = this.props.metric.full_name;
     const nodeId = this.props.nodeId;

--- a/graylog2-web-interface/src/components/metrics/MetricsComponent.jsx
+++ b/graylog2-web-interface/src/components/metrics/MetricsComponent.jsx
@@ -4,31 +4,26 @@ import { Col, Row } from 'react-bootstrap';
 
 import { MetricsFilterInput, MetricsList } from 'components/metrics';
 
-const MetricsComponent = React.createClass({
-  propTypes: {
+class MetricsComponent extends React.Component {
+  static propTypes = {
     names: PropTypes.arrayOf(PropTypes.object).isRequired,
     namespace: PropTypes.string.isRequired,
     nodeId: PropTypes.string.isRequired,
     filter: PropTypes.string,
-  },
+  };
 
-  getInitialState() {
-    return { filter: this.props.filter };
-  },
+  static defaultProps = { filter: '' };
+  state = { filter: this.props.filter };
 
   componentWillReceiveProps(nextProps) {
     if (nextProps.filter !== this.props.filter) {
       this.setState({ filter: nextProps.filter });
     }
-  },
+  }
 
-  getDefaultProps() {
-    return { filter: '' };
-  },
-
-  onFilterChange(nextFilter) {
+  onFilterChange = (nextFilter) => {
     this.setState({ filter: nextFilter });
-  },
+  };
 
   render() {
     const { filter } = this.state;
@@ -48,7 +43,7 @@ const MetricsComponent = React.createClass({
         </Col>
       </Row>
     );
-  },
-});
+  }
+}
 
 export default MetricsComponent;

--- a/graylog2-web-interface/src/components/metrics/MetricsFilterInput.jsx
+++ b/graylog2-web-interface/src/components/metrics/MetricsFilterInput.jsx
@@ -2,15 +2,15 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { FormControl } from 'react-bootstrap';
 
-const MetricsFilterInput = React.createClass({
-  propTypes: {
+class MetricsFilterInput extends React.Component {
+  static propTypes = {
     filter: PropTypes.string.isRequired,
     onChange: PropTypes.func.isRequired,
-  },
+  };
 
-  handleChange(event) {
+  handleChange = (event) => {
     this.props.onChange(event.target.value);
-  },
+  };
 
   render() {
     const { filter } = this.props;
@@ -22,7 +22,7 @@ const MetricsFilterInput = React.createClass({
                    value={filter}
                    onChange={this.handleChange} />
     );
-  },
-});
+  }
+}
 
 export default MetricsFilterInput;

--- a/graylog2-web-interface/src/components/metrics/MetricsList.jsx
+++ b/graylog2-web-interface/src/components/metrics/MetricsList.jsx
@@ -3,19 +3,21 @@ import React from 'react';
 
 import { Metric } from 'components/metrics';
 
-const MetricsList = React.createClass({
-  propTypes: {
+class MetricsList extends React.Component {
+  static propTypes = {
     names: PropTypes.arrayOf(PropTypes.object).isRequired,
     namespace: PropTypes.string.isRequired,
     nodeId: PropTypes.string.isRequired,
-  },
-  _formatMetric(metric) {
+  };
+
+  _formatMetric = (metric) => {
     return (
       <li key={`li-${metric.full_name}`}>
         <Metric key={metric.full_name} metric={metric} namespace={this.props.namespace} nodeId={this.props.nodeId} />
       </li>
     );
-  },
+  };
+
   render() {
     const metrics = this.props.names
       .sort((m1, m2) => m1.full_name.localeCompare(m2.full_name))
@@ -26,7 +28,7 @@ const MetricsList = React.createClass({
         {metrics.length > 0 ? metrics : <li>No metrics match the given filter. Please ensure you use a valid regular expression</li>}
       </ul>
     );
-  },
-});
+  }
+}
 
 export default MetricsList;

--- a/graylog2-web-interface/src/components/metrics/MetricsMapper.jsx
+++ b/graylog2-web-interface/src/components/metrics/MetricsMapper.jsx
@@ -1,15 +1,19 @@
 import PropTypes from 'prop-types';
 import React from 'react';
+import createReactClass from 'create-react-class';
 import Reflux from 'reflux';
 
 import CombinedProvider from 'injection/CombinedProvider';
 const { MetricsActions, MetricsStore } = CombinedProvider.get('Metrics');
 
-const MetricsMapper = React.createClass({
+const MetricsMapper = createReactClass({
+  displayName: 'MetricsMapper',
+
   propTypes: {
     map: PropTypes.object.isRequired,
     computeValue: PropTypes.func.isRequired,
   },
+
   mixins: [Reflux.connect(MetricsStore)],
 
   getDefaultProps() {

--- a/graylog2-web-interface/src/components/metrics/TimerDetails.jsx
+++ b/graylog2-web-interface/src/components/metrics/TimerDetails.jsx
@@ -2,10 +2,11 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import numeral from 'numeral';
 
-const TimerDetails = React.createClass({
-  propTypes: {
+class TimerDetails extends React.Component {
+  static propTypes = {
     metric: PropTypes.object.isRequired,
-  },
+  };
+
   render() {
     const timing = this.props.metric.metric.time;
     return (
@@ -32,7 +33,7 @@ const TimerDetails = React.createClass({
         <dd><span>{numeral(timing.max).format('0,0.[00]')}</span>&#956;s</dd>
       </dl>
     );
-  },
-});
+  }
+}
 
 export default TimerDetails;

--- a/graylog2-web-interface/src/components/navigation/HelpMenu.jsx
+++ b/graylog2-web-interface/src/components/navigation/HelpMenu.jsx
@@ -7,10 +7,11 @@ import { ExternalLink } from 'components/common';
 import DocsHelper from 'util/DocsHelper';
 import Routes from 'routing/Routes';
 
-const HelpMenu = React.createClass({
-  propTypes: {
+class HelpMenu extends React.Component {
+  static propTypes = {
     active: PropTypes.bool.isRequired,
-  },
+  };
+
   render() {
     return (
       <NavDropdown title="Help" id="help-menu-dropdown" active={this.props.active}>
@@ -22,7 +23,7 @@ const HelpMenu = React.createClass({
         </MenuItem>
       </NavDropdown>
     );
-  },
-});
+  }
+}
 
 export default HelpMenu;

--- a/graylog2-web-interface/src/components/navigation/Navigation.jsx
+++ b/graylog2-web-interface/src/components/navigation/Navigation.jsx
@@ -1,5 +1,6 @@
 import PropTypes from 'prop-types';
 import React from 'react';
+import createReactClass from 'create-react-class';
 import Reflux from 'reflux';
 
 import { Badge, Navbar, Nav, NavItem, NavDropdown, MenuItem } from 'react-bootstrap';
@@ -25,7 +26,9 @@ import InactiveNavItem from './InactiveNavItem';
 
 import badgeStyles from 'components/bootstrap/Badge.css';
 
-const Navigation = React.createClass({
+const Navigation = createReactClass({
+  displayName: 'Navigation',
+
   propTypes: {
     requestPath: PropTypes.string.isRequired,
     loginName: PropTypes.string.isRequired,
@@ -38,6 +41,7 @@ const Navigation = React.createClass({
   componentDidMount() {
     this.interval = setInterval(NotificationsStore.list, this.POLL_INTERVAL);
   },
+
   componentWillUnmount() {
     clearInterval(this.interval);
   },

--- a/graylog2-web-interface/src/components/navigation/UserMenu.jsx
+++ b/graylog2-web-interface/src/components/navigation/UserMenu.jsx
@@ -12,16 +12,18 @@ const SessionActions = ActionsProvider.getActions('Session');
 import Routes from 'routing/Routes';
 import history from 'util/History';
 
-const UserMenu = React.createClass({
-  propTypes: {
+class UserMenu extends React.Component {
+  static propTypes = {
     loginName: PropTypes.string.isRequired,
     fullName: PropTypes.string.isRequired,
-  },
-  onLogoutClicked() {
+  };
+
+  onLogoutClicked = () => {
     SessionActions.logout.triggerPromise(SessionStore.getSessionId()).then(() => {
       history.push(Routes.STARTPAGE);
     });
-  },
+  };
+
   render() {
     return (
       <NavDropdown title={this.props.fullName} id="user-menu-dropdown">
@@ -32,8 +34,8 @@ const UserMenu = React.createClass({
         <MenuItem onSelect={this.onLogoutClicked}><i className="fa fa-sign-out" /> Log out</MenuItem>
       </NavDropdown>
     );
-  },
-});
+  }
+}
 
 export default UserMenu;
 

--- a/graylog2-web-interface/src/components/nodes/BufferUsage.jsx
+++ b/graylog2-web-interface/src/components/nodes/BufferUsage.jsx
@@ -1,5 +1,6 @@
 import PropTypes from 'prop-types';
 import React from 'react';
+import createReactClass from 'create-react-class';
 import Reflux from 'reflux';
 import numeral from 'numeral';
 import { Button, ProgressBar } from 'react-bootstrap';
@@ -15,13 +16,17 @@ import Routes from 'routing/Routes';
 import NumberUtils from 'util/NumberUtils';
 import { Spinner } from 'components/common';
 
-const BufferUsage = React.createClass({
+const BufferUsage = createReactClass({
+  displayName: 'BufferUsage',
+
   propTypes: {
     bufferType: PropTypes.string.isRequired,
     nodeId: PropTypes.string.isRequired,
     title: PropTypes.node.isRequired,
   },
+
   mixins: [Reflux.connect(MetricsStore)],
+
   componentWillMount() {
     const prefix = this._metricPrefix();
     const metricNames = [
@@ -30,12 +35,15 @@ const BufferUsage = React.createClass({
     ];
     metricNames.forEach(metricName => MetricsActions.add(this.props.nodeId, metricName));
   },
+
   _metricPrefix() {
     return `org.graylog2.buffers.${this.props.bufferType}`;
   },
+
   _metricFilter() {
     return `org\\.graylog2\\.buffers\\.${this.props.bufferType}\\.|${this.props.bufferType}buffer`;
   },
+
   render() {
     if (!this.state.metrics) {
       return <Spinner />;

--- a/graylog2-web-interface/src/components/nodes/InputTypesDataTable.jsx
+++ b/graylog2-web-interface/src/components/nodes/InputTypesDataTable.jsx
@@ -4,14 +4,16 @@ import { Alert } from 'react-bootstrap';
 
 import { DataTable, ExternalLink, Spinner } from 'components/common';
 
-const InputTypesDataTable = React.createClass({
-  propTypes: {
+class InputTypesDataTable extends React.Component {
+  static propTypes = {
     inputDescriptions: PropTypes.object,
-  },
-  _headerCellFormatter(header) {
+  };
+
+  _headerCellFormatter = (header) => {
     return <th>{header}</th>;
-  },
-  _inputTypeFormatter(inputType) {
+  };
+
+  _inputTypeFormatter = (inputType) => {
     return (
       <tr key={inputType.type}>
         <td className="limited">{inputType.name}</td>
@@ -23,7 +25,8 @@ const InputTypesDataTable = React.createClass({
         </td>
       </tr>
     );
-  },
+  };
+
   render() {
     if (!this.props.inputDescriptions) {
       return <Spinner text="Loading input types..." />;
@@ -53,7 +56,7 @@ const InputTypesDataTable = React.createClass({
                  filterLabel="Filter"
                  filterKeys={[]} />
     );
-  },
-});
+  }
+}
 
 export default InputTypesDataTable;

--- a/graylog2-web-interface/src/components/nodes/JournalDetails.jsx
+++ b/graylog2-web-interface/src/components/nodes/JournalDetails.jsx
@@ -1,5 +1,6 @@
 import PropTypes from 'prop-types';
 import React from 'react';
+import createReactClass from 'create-react-class';
 import Reflux from 'reflux';
 import { Link } from 'react-router';
 import { ProgressBar, Row, Col, Alert } from 'react-bootstrap';
@@ -21,10 +22,13 @@ import { Spinner, Timestamp } from 'components/common';
 import NumberUtils from 'util/NumberUtils';
 import Routes from 'routing/Routes';
 
-const JournalDetails = React.createClass({
+const JournalDetails = createReactClass({
+  displayName: 'JournalDetails',
+
   propTypes: {
     nodeId: PropTypes.string.isRequired,
   },
+
   mixins: [Reflux.connect(MetricsStore)],
 
   getInitialState() {

--- a/graylog2-web-interface/src/components/nodes/JournalState.jsx
+++ b/graylog2-web-interface/src/components/nodes/JournalState.jsx
@@ -1,5 +1,6 @@
 import PropTypes from 'prop-types';
 import React from 'react';
+import createReactClass from 'create-react-class';
 import Reflux from 'reflux';
 import numeral from 'numeral';
 
@@ -13,11 +14,15 @@ const MetricsStore = StoreProvider.getStore('Metrics');
 import ActionsProvider from 'injection/ActionsProvider';
 const MetricsActions = ActionsProvider.getActions('Metrics');
 
-const JournalState = React.createClass({
+const JournalState = createReactClass({
+  displayName: 'JournalState',
+
   propTypes: {
     nodeId: PropTypes.string.isRequired,
   },
+
   mixins: [Reflux.connect(MetricsStore)],
+
   componentWillMount() {
     this.metricNames = {
       append: 'org.graylog2.journal.append.1-sec-rate',
@@ -27,12 +32,15 @@ const JournalState = React.createClass({
     };
     Object.keys(this.metricNames).forEach(metricShortName => MetricsActions.add(this.props.nodeId, this.metricNames[metricShortName]));
   },
+
   componentWillUnmount() {
     Object.keys(this.metricNames).forEach(metricShortName => MetricsActions.remove(this.props.nodeId, this.metricNames[metricShortName]));
   },
+
   _isLoading() {
     return !this.state.metrics;
   },
+
   render() {
     if (this._isLoading()) {
       return <Spinner text="Loading journal metrics..." />;

--- a/graylog2-web-interface/src/components/nodes/JvmHeapUsage.jsx
+++ b/graylog2-web-interface/src/components/nodes/JvmHeapUsage.jsx
@@ -1,5 +1,6 @@
 import PropTypes from 'prop-types';
 import React from 'react';
+import createReactClass from 'create-react-class';
 import Reflux from 'reflux';
 import { ProgressBar } from 'react-bootstrap';
 
@@ -14,11 +15,15 @@ const MetricsStore = StoreProvider.getStore('Metrics');
 import ActionsProvider from 'injection/ActionsProvider';
 const MetricsActions = ActionsProvider.getActions('Metrics');
 
-const JvmHeapUsage = React.createClass({
+const JvmHeapUsage = createReactClass({
+  displayName: 'JvmHeapUsage',
+
   propTypes: {
     nodeId: PropTypes.string.isRequired,
   },
+
   mixins: [Reflux.connect(MetricsStore)],
+
   componentWillMount() {
     this.metricNames = {
       usedMemory: 'jvm.memory.heap.used',
@@ -28,9 +33,11 @@ const JvmHeapUsage = React.createClass({
 
     Object.keys(this.metricNames).forEach(metricShortName => MetricsActions.add(this.props.nodeId, this.metricNames[metricShortName]));
   },
+
   componentWillUnmount() {
     Object.keys(this.metricNames).forEach(metricShortName => MetricsActions.remove(this.props.nodeId, this.metricNames[metricShortName]));
   },
+
   _extractMetricValues() {
     const nodeId = this.props.nodeId;
     const nodeMetrics = this.state.metrics[nodeId];
@@ -41,6 +48,7 @@ const JvmHeapUsage = React.createClass({
 
     return metrics;
   },
+
   render() {
     let progressBar;
     let detail;

--- a/graylog2-web-interface/src/components/nodes/NodeListItem.jsx
+++ b/graylog2-web-interface/src/components/nodes/NodeListItem.jsx
@@ -9,11 +9,12 @@ import JvmHeapUsage from './JvmHeapUsage';
 import JournalState from './JournalState';
 import NodeThroughput from 'components/throughput/NodeThroughput';
 
-const NodeListItem = React.createClass({
-  propTypes: {
+class NodeListItem extends React.Component {
+  static propTypes = {
     node: PropTypes.object.isRequired,
     systemOverview: PropTypes.object,
-  },
+  };
+
   render() {
     const node = this.props.node;
     const title = <LinkToNode nodeId={node.node_id} />;
@@ -49,7 +50,7 @@ const NodeListItem = React.createClass({
                       actions={actions}
                       contentRow={additionalContent} />
     );
-  },
-});
+  }
+}
 
 export default NodeListItem;

--- a/graylog2-web-interface/src/components/nodes/NodeMaintenanceDropdown.jsx
+++ b/graylog2-web-interface/src/components/nodes/NodeMaintenanceDropdown.jsx
@@ -8,10 +8,11 @@ import { ExternalLink, IfPermitted } from 'components/common';
 
 import Routes from 'routing/Routes';
 
-const NodeMaintenanceDropdown = React.createClass({
-  propTypes: {
+class NodeMaintenanceDropdown extends React.Component {
+  static propTypes = {
     node: PropTypes.object.isRequired,
-  },
+  };
+
   render() {
     const apiBrowserURI = new URI(`${this.props.node.transport_address}/api-browser`).normalizePathname().toString();
     return (
@@ -39,7 +40,7 @@ const NodeMaintenanceDropdown = React.createClass({
         </DropdownButton>
       </ButtonGroup>
     );
-  },
-});
+  }
+}
 
 export default NodeMaintenanceDropdown;

--- a/graylog2-web-interface/src/components/nodes/NodeOverview.jsx
+++ b/graylog2-web-interface/src/components/nodes/NodeOverview.jsx
@@ -14,15 +14,16 @@ import InputTypesDataTable from './InputTypesDataTable';
 
 import Routes from 'routing/Routes';
 
-const NodeOverview = React.createClass({
-  propTypes: {
+class NodeOverview extends React.Component {
+  static propTypes = {
     node: PropTypes.object.isRequired,
     systemOverview: PropTypes.object.isRequired,
     jvmInformation: PropTypes.object,
     plugins: PropTypes.array,
     inputDescriptions: PropTypes.object,
     inputStates: PropTypes.array,
-  },
+  };
+
   render() {
     const node = this.props.node;
     const systemOverview = this.props.systemOverview;
@@ -119,7 +120,7 @@ const NodeOverview = React.createClass({
         </Row>
       </div>
     );
-  },
-});
+  }
+}
 
 export default NodeOverview;

--- a/graylog2-web-interface/src/components/nodes/NodesActions.jsx
+++ b/graylog2-web-interface/src/components/nodes/NodesActions.jsx
@@ -13,12 +13,13 @@ const SystemShutdownStore = StoreProvider.getStore('SystemShutdown');
 
 import Routes from 'routing/Routes';
 
-const NodesActions = React.createClass({
-  propTypes: {
+class NodesActions extends React.Component {
+  static propTypes = {
     node: PropTypes.object.isRequired,
     systemOverview: PropTypes.object.isRequired,
-  },
-  _toggleMessageProcessing() {
+  };
+
+  _toggleMessageProcessing = () => {
     if (confirm(`You are about to ${this.props.systemOverview.is_processing ? 'pause' : 'resume'} message processing in this node. Are you sure?`)) {
       if (this.props.systemOverview.is_processing) {
         SystemProcessingStore.pause(this.props.node.node_id);
@@ -26,19 +27,22 @@ const NodesActions = React.createClass({
         SystemProcessingStore.resume(this.props.node.node_id);
       }
     }
-  },
-  _changeLBStatus(status) {
+  };
+
+  _changeLBStatus = (status) => {
     return () => {
       if (confirm(`You are about to change the load balancer status for this node to ${status}. Are you sure?`)) {
         SystemLoadBalancerStore.override(this.props.node.node_id, status);
       }
     };
-  },
-  _shutdown() {
+  };
+
+  _shutdown = () => {
     if (prompt('Do you really want to shutdown this node? Confirm by typing "SHUTDOWN".') === 'SHUTDOWN') {
       SystemShutdownStore.shutdown(this.props.node.node_id);
     }
-  },
+  };
+
   render() {
     const apiBrowserURI = new URI(`${this.props.node.transport_address}/api-browser`).normalizePathname().toString();
     return (
@@ -95,7 +99,7 @@ const NodesActions = React.createClass({
         </DropdownButton>
       </div>
     );
-  },
-});
+  }
+}
 
 export default NodesActions;

--- a/graylog2-web-interface/src/components/nodes/NodesList.jsx
+++ b/graylog2-web-interface/src/components/nodes/NodesList.jsx
@@ -1,5 +1,6 @@
 import PropTypes from 'prop-types';
 import React from 'react';
+import createReactClass from 'create-react-class';
 import Reflux from 'reflux';
 import { Row, Col } from 'react-bootstrap';
 
@@ -10,14 +11,19 @@ import StoreProvider from 'injection/StoreProvider';
 const NodesStore = StoreProvider.getStore('Nodes');
 const ClusterOverviewStore = StoreProvider.getStore('ClusterOverview');
 
-const NodesList = React.createClass({
+const NodesList = createReactClass({
+  displayName: 'NodesList',
+
   propTypes: {
     permissions: PropTypes.array.isRequired,
   },
+
   mixins: [Reflux.connect(NodesStore), Reflux.connect(ClusterOverviewStore)],
+
   _isLoading() {
     return !(this.state.nodes && this.state.clusterOverview);
   },
+
   _formatNodes(nodes, clusterOverview) {
     const nodeIDs = Object.keys(nodes);
 
@@ -25,6 +31,7 @@ const NodesList = React.createClass({
       return <NodeListItem key={nodeID} node={nodes[nodeID]} systemOverview={clusterOverview[nodeID]} />;
     });
   },
+
   render() {
     if (this._isLoading()) {
       return <Spinner />;

--- a/graylog2-web-interface/src/components/nodes/PluginsDataTable.jsx
+++ b/graylog2-web-interface/src/components/nodes/PluginsDataTable.jsx
@@ -4,14 +4,16 @@ import { Alert } from 'react-bootstrap';
 
 import { DataTable, ExternalLink, Spinner } from 'components/common';
 
-const PluginsDataTable = React.createClass({
-  propTypes: {
+class PluginsDataTable extends React.Component {
+  static propTypes = {
     plugins: PropTypes.array,
-  },
-  _headerCellFormatter(header) {
+  };
+
+  _headerCellFormatter = (header) => {
     return <th>{header}</th>;
-  },
-  _pluginInfoFormatter(plugin) {
+  };
+
+  _pluginInfoFormatter = (plugin) => {
     return (
       <tr key={plugin.name}>
         <td className="limited">{plugin.name}</td>
@@ -24,7 +26,8 @@ const PluginsDataTable = React.createClass({
         </td>
       </tr>
     );
-  },
+  };
+
   render() {
     if (!this.props.plugins) {
       return <Spinner text="Loading plugins on this node..." />;
@@ -48,7 +51,7 @@ const PluginsDataTable = React.createClass({
                  filterLabel="Filter"
                  filterKeys={[]} />
     );
-  },
-});
+  }
+}
 
 export default PluginsDataTable;

--- a/graylog2-web-interface/src/components/nodes/RestApiOverview.jsx
+++ b/graylog2-web-interface/src/components/nodes/RestApiOverview.jsx
@@ -2,10 +2,11 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import { Timestamp } from 'components/common';
 
-const RestApiOverview = React.createClass({
-  propTypes: {
+class RestApiOverview extends React.Component {
+  static propTypes = {
     node: PropTypes.object.isRequired,
-  },
+  };
+
   render() {
     return (
       <dl className="system-rest">
@@ -15,7 +16,7 @@ const RestApiOverview = React.createClass({
         <dd><Timestamp dateTime={this.props.node.last_seen} relative /></dd>
       </dl>
     );
-  },
-});
+  }
+}
 
 export default RestApiOverview;

--- a/graylog2-web-interface/src/components/nodes/SystemInformation.jsx
+++ b/graylog2-web-interface/src/components/nodes/SystemInformation.jsx
@@ -1,26 +1,33 @@
 import PropTypes from 'prop-types';
 import React from 'react';
+import createReactClass from 'create-react-class';
 import moment from 'moment';
 
 import { Timestamp } from 'components/common';
 
 import DateTime from 'logic/datetimes/DateTime';
 
-const SystemInformation = React.createClass({
+const SystemInformation = createReactClass({
+  displayName: 'SystemInformation',
+
   propTypes: {
     node: PropTypes.object.isRequired,
     systemInformation: PropTypes.object.isRequired,
     jvmInformation: PropTypes.object,
   },
+
   getInitialState() {
     return { time: moment() };
   },
+
   componentDidMount() {
     this.interval = setInterval(() => this.setState(this.getInitialState()), 1000);
   },
+
   componentWillUnmount() {
     clearTimeout(this.interval);
   },
+
   render() {
     const systemInformation = this.props.systemInformation;
     let jvmInformation;

--- a/graylog2-web-interface/src/components/nodes/SystemOverviewDetails.jsx
+++ b/graylog2-web-interface/src/components/nodes/SystemOverviewDetails.jsx
@@ -12,12 +12,13 @@ import StringUtils from 'util/StringUtils';
 import StoreProvider from 'injection/StoreProvider';
 const SystemProcessingStore = StoreProvider.getStore('SystemProcessing');
 
-const SystemOverviewDetails = React.createClass({
-  propTypes: {
+class SystemOverviewDetails extends React.Component {
+  static propTypes = {
     node: PropTypes.object.isRequired,
     information: PropTypes.object.isRequired,
-  },
-  _toggleMessageProcessing() {
+  };
+
+  _toggleMessageProcessing = () => {
     if (confirm(`You are about to ${this.props.information.is_processing ? 'pause' : 'resume'} message processing in this node. Are you sure?`)) {
       if (this.props.information.is_processing) {
         SystemProcessingStore.pause(this.props.node.node_id);
@@ -25,7 +26,8 @@ const SystemOverviewDetails = React.createClass({
         SystemProcessingStore.resume(this.props.node.node_id);
       }
     }
-  },
+  };
+
   render() {
     const information = this.props.information;
     const lbStatus = information.lb_status.toUpperCase();
@@ -75,7 +77,7 @@ const SystemOverviewDetails = React.createClass({
         </Col>
       </Row>
     );
-  },
-});
+  }
+}
 
 export default SystemOverviewDetails;

--- a/graylog2-web-interface/src/components/nodes/SystemOverviewSummary.jsx
+++ b/graylog2-web-interface/src/components/nodes/SystemOverviewSummary.jsx
@@ -2,10 +2,11 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import StringUtils from 'util/StringUtils';
 
-const SystemOverviewSummary = React.createClass({
-  propTypes: {
+class SystemOverviewSummary extends React.Component {
+  static propTypes = {
     information: PropTypes.object.isRequired,
-  },
+  };
+
   render() {
     const lbStatus = this.props.information.lb_status.toUpperCase();
     return (
@@ -18,7 +19,7 @@ const SystemOverviewSummary = React.createClass({
         <dd className={lbStatus === 'DEAD' ? 'text-danger' : ''}>{lbStatus}</dd>
       </dl>
     );
-  },
-});
+  }
+}
 
 export default SystemOverviewSummary;

--- a/graylog2-web-interface/src/components/notifications/Notification.jsx
+++ b/graylog2-web-interface/src/components/notifications/Notification.jsx
@@ -8,15 +8,17 @@ import NotificationsFactory from 'logic/notifications/NotificationsFactory';
 import ActionsProvider from 'injection/ActionsProvider';
 const NotificationsActions = ActionsProvider.getActions('Notifications');
 
-const Notification = React.createClass({
-  propTypes: {
+class Notification extends React.Component {
+  static propTypes = {
     notification: PropTypes.object.isRequired,
-  },
-  _onClose() {
+  };
+
+  _onClose = () => {
     if (window.confirm('Really delete this notification?')) {
       NotificationsActions.delete(this.props.notification.type);
     }
-  },
+  };
+
   render() {
     const notification = this.props.notification;
     const notificationView = NotificationsFactory.getForNotification(notification);
@@ -37,7 +39,7 @@ const Notification = React.createClass({
         </div>
       </Alert>
     );
-  },
-});
+  }
+}
 
 export default Notification;

--- a/graylog2-web-interface/src/components/notifications/NotificationsList.jsx
+++ b/graylog2-web-interface/src/components/notifications/NotificationsList.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import createReactClass from 'create-react-class';
 import Reflux from 'reflux';
 import { Alert, Row, Col } from 'react-bootstrap';
 
@@ -8,8 +9,10 @@ const NotificationsStore = StoreProvider.getStore('Notifications');
 import { Spinner } from 'components/common';
 import Notification from 'components/notifications/Notification';
 
-const NotificationsList = React.createClass({
+const NotificationsList = createReactClass({
+  displayName: 'NotificationsList',
   mixins: [Reflux.connect(NotificationsStore)],
+
   _formatNotificationCount(count) {
     if (count === 0) {
       return 'is no notification';
@@ -20,6 +23,7 @@ const NotificationsList = React.createClass({
 
     return `are ${count} notifications`;
   },
+
   render() {
     if (!this.state.notifications) {
       return <Spinner />;

--- a/graylog2-web-interface/src/components/outputs/AssignOutputDropdown.jsx
+++ b/graylog2-web-interface/src/components/outputs/AssignOutputDropdown.jsx
@@ -2,27 +2,31 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import { Button } from 'react-bootstrap';
 
-const AssignOutputDropdown = React.createClass({
-  propTypes: {
+class AssignOutputDropdown extends React.Component {
+  static propTypes = {
     outputs: PropTypes.array.isRequired,
     onSubmit: PropTypes.func.isRequired,
-  },
-  getInitialState() {
-    return {
-      selectedOutput: this.PLACEHOLDER,
-    };
-  },
-  PLACEHOLDER: 'placeholder',
-  _formatOutput(output) {
+  };
+
+  PLACEHOLDER = 'placeholder';
+
+  _formatOutput = (output) => {
     return <option key={output.id} value={output.id}>{output.title}</option>;
-  },
-  _handleUpdate(evt) {
+  };
+
+  _handleUpdate = (evt) => {
     this.setState({ selectedOutput: evt.target.value });
-  },
-  _handleClick() {
+  };
+
+  _handleClick = () => {
     this.props.onSubmit(this.state.selectedOutput);
     this.setState({ selectedOutput: this.PLACEHOLDER });
-  },
+  };
+
+  state = {
+    selectedOutput: this.PLACEHOLDER,
+  };
+
   render() {
     const outputs = this.props.outputs;
     const outputList = (outputs.length > 0 ? outputs.map(this._formatOutput) :
@@ -43,7 +47,7 @@ const AssignOutputDropdown = React.createClass({
         </div>
       </div>
     );
-  },
-});
+  }
+}
 
 export default AssignOutputDropdown;

--- a/graylog2-web-interface/src/components/outputs/CreateOutputDropdown.jsx
+++ b/graylog2-web-interface/src/components/outputs/CreateOutputDropdown.jsx
@@ -3,19 +3,16 @@ import $ from 'jquery';
 
 import { ConfigurationForm } from 'components/configurationforms';
 
-const CreateOutputDropdown = React.createClass({
-  PLACEHOLDER: 'placeholder',
-  getInitialState() {
-    return {
-      typeDefinition: [],
-      typeName: this.PLACEHOLDER,
-    };
-  },
+class CreateOutputDropdown extends React.Component {
+  PLACEHOLDER = 'placeholder';
+
   componentDidMount() {
     this.loadData();
-  },
-  loadData() {
-  },
+  }
+
+  loadData = () => {
+  };
+
   render() {
     const outputTypes = $.map(this.props.types, this._formatOutputType);
     return (
@@ -35,22 +32,30 @@ const CreateOutputDropdown = React.createClass({
                                    submitAction={this.props.onSubmit} />
       </div>
     );
-  },
-  _openModal(evt) {
+  }
+
+  _openModal = (evt) => {
     if (this.state.typeName !== this.PLACEHOLDER && this.state.typeName !== '') {
       this.refs.configurationForm.open();
     }
-  },
-  _formatOutputType(type, typeName) {
+  };
+
+  _formatOutputType = (type, typeName) => {
     return (<option key={typeName} value={typeName}>{type.name}</option>);
-  },
-  _onTypeChange(evt) {
+  };
+
+  _onTypeChange = (evt) => {
     const outputType = evt.target.value;
     this.setState({ typeName: evt.target.value });
     this.props.getTypeDefinition(outputType, (definition) => {
       this.setState({ typeDefinition: definition.requested_configuration });
     });
-  },
-});
+  };
+
+  state = {
+    typeDefinition: [],
+    typeName: this.PLACEHOLDER,
+  };
+}
 
 export default CreateOutputDropdown;

--- a/graylog2-web-interface/src/components/outputs/EditOutputButton.jsx
+++ b/graylog2-web-interface/src/components/outputs/EditOutputButton.jsx
@@ -3,31 +3,30 @@ import React from 'react';
 import { Button } from 'react-bootstrap';
 import { ConfigurationForm } from 'components/configurationforms';
 
-const EditOutputButton = React.createClass({
-  propTypes: {
+class EditOutputButton extends React.Component {
+  static propTypes = {
     output: PropTypes.object,
     disabled: PropTypes.bool,
     getTypeDefinition: PropTypes.func.isRequired,
     onUpdate: PropTypes.func,
-  },
-  getInitialState() {
-    return {
-      typeDefinition: undefined,
-      typeName: undefined,
-      configurationForm: '',
-    };
-  },
+  };
 
-  handleClick() {
+  state = {
+    typeDefinition: undefined,
+    typeName: undefined,
+    configurationForm: '',
+  };
+
+  handleClick = () => {
     this.props.getTypeDefinition(this.props.output.type, (definition) => {
       this.setState({ typeDefinition: definition.requested_configuration });
       this.refs.configurationForm.open();
     });
-  },
+  };
 
-  _handleSubmit(data) {
+  _handleSubmit = (data) => {
     this.props.onUpdate(this.props.output, data);
-  },
+  };
 
   render() {
     const typeDefinition = this.state.typeDefinition;
@@ -53,7 +52,7 @@ const EditOutputButton = React.createClass({
         {configurationForm}
       </span>
     );
-  },
-});
+  }
+}
 
 export default EditOutputButton;

--- a/graylog2-web-interface/src/components/outputs/Output.jsx
+++ b/graylog2-web-interface/src/components/outputs/Output.jsx
@@ -6,34 +6,38 @@ import EditOutputButton from 'components/outputs/EditOutputButton';
 import { ConfigurationWell } from 'components/configurationforms';
 import { IfPermitted, Spinner } from 'components/common';
 
-const Output = React.createClass({
-  propTypes: {
+class Output extends React.Component {
+  static propTypes = {
     streamId: PropTypes.string,
     output: PropTypes.object.isRequired,
     types: PropTypes.object.isRequired,
     getTypeDefinition: PropTypes.func.isRequired,
     removeOutputFromStream: PropTypes.func.isRequired,
     removeOutputGlobally: PropTypes.func.isRequired,
-  },
-  getInitialState() {
-    return {};
-  },
+  };
+
+  state = {};
+
   componentDidMount() {
     if (!this._typeNotAvailable()) {
       this.props.getTypeDefinition(this.props.output.type, (typeDefinition) => {
         this.setState({ typeDefinition: typeDefinition });
       });
     }
-  },
-  _onDeleteFromStream() {
+  }
+
+  _onDeleteFromStream = () => {
     this.props.removeOutputFromStream(this.props.output.id, this.props.streamId);
-  },
-  _onDeleteGlobally() {
+  };
+
+  _onDeleteGlobally = () => {
     this.props.removeOutputGlobally(this.props.output.id);
-  },
-  _typeNotAvailable() {
+  };
+
+  _typeNotAvailable = () => {
     return (this.props.types[this.props.output.type] === undefined);
-  },
+  };
+
   render() {
     if (!this._typeNotAvailable() && !this.state.typeDefinition) {
       return <Spinner />;
@@ -111,7 +115,7 @@ const Output = React.createClass({
         </Col>
       </div>
     );
-  },
-});
+  }
+}
 
 export default Output;

--- a/graylog2-web-interface/src/components/outputs/OutputList.jsx
+++ b/graylog2-web-interface/src/components/outputs/OutputList.jsx
@@ -6,8 +6,8 @@ import naturalSort from 'javascript-natural-sort';
 import { Spinner } from 'components/common/Spinner';
 import Output from 'components/outputs/Output';
 
-const OutputList = React.createClass({
-  propTypes: {
+class OutputList extends React.Component {
+  static propTypes = {
     streamId: PropTypes.string,
     outputs: PropTypes.array,
     onRemove: PropTypes.func.isRequired,
@@ -15,18 +15,21 @@ const OutputList = React.createClass({
     onUpdate: PropTypes.func.isRequired,
     getTypeDefinition: PropTypes.func.isRequired,
     types: PropTypes.object.isRequired,
-  },
-  _sortByTitle(output1, output2) {
+  };
+
+  _sortByTitle = (output1, output2) => {
     return naturalSort(output1.title.toLowerCase(), output2.title.toLowerCase());
-  },
-  _formatOutput(output) {
+  };
+
+  _formatOutput = (output) => {
     return (
       <Output key={output.id} output={output} streamId={this.props.streamId}
               removeOutputFromStream={this.props.onRemove} removeOutputGlobally={this.props.onTerminate}
               onUpdate={this.props.onUpdate} getTypeDefinition={this.props.getTypeDefinition}
               types={this.props.types} />
     );
-  },
+  };
+
   render() {
     if (!this.props.outputs) {
       return <Spinner />;
@@ -44,7 +47,7 @@ const OutputList = React.createClass({
 
     const outputs = this.props.outputs.sort(this._sortByTitle).map(this._formatOutput);
     return <div>{outputs}</div>;
-  },
-});
+  }
+}
 
 export default OutputList;

--- a/graylog2-web-interface/src/components/outputs/OutputsComponent.jsx
+++ b/graylog2-web-interface/src/components/outputs/OutputsComponent.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import createReactClass from 'create-react-class';
 import { Row, Col } from 'react-bootstrap';
 
 import StoreProvider from 'injection/StoreProvider';
@@ -12,11 +13,14 @@ import OutputList from './OutputList';
 import CreateOutputDropdown from './CreateOutputDropdown';
 import AssignOutputDropdown from './AssignOutputDropdown';
 
-const OutputsComponent = React.createClass({
+const OutputsComponent = createReactClass({
+  displayName: 'OutputsComponent',
   mixins: [PermissionsMixin],
+
   componentDidMount() {
     this.loadData();
   },
+
   loadData() {
     const callback = (resp) => {
       this.setState({
@@ -36,13 +40,16 @@ const OutputsComponent = React.createClass({
       this.setState({ types: resp.types });
     });
   },
+
   getInitialState() {
     return {
     };
   },
+
   _handleUpdate() {
     this.loadData();
   },
+
   _handleCreateOutput(data) {
     OutputsStore.save(data, (result) => {
       this.setState({ typeName: 'placeholder' });
@@ -57,6 +64,7 @@ const OutputsComponent = React.createClass({
       return result;
     });
   },
+
   _fetchAssignableOutputs(outputs) {
     OutputsStore.load((resp) => {
       const streamOutputIds = outputs.map((output) => { return output.id; });
@@ -66,12 +74,14 @@ const OutputsComponent = React.createClass({
       this.setState({ assignableOutputs: assignableOutputs });
     });
   },
+
   _handleAssignOutput(outputId) {
     StreamsStore.addOutput(this.props.streamId, outputId, (response) => {
       this._handleUpdate();
       return response;
     });
   },
+
   _removeOutputGlobally(outputId) {
     if (window.confirm('Do you really want to terminate this output?')) {
       OutputsStore.remove(outputId, (response) => {
@@ -81,6 +91,7 @@ const OutputsComponent = React.createClass({
       });
     }
   },
+
   _removeOutputFromStream(outputId, streamId) {
     if (window.confirm('Do you really want to remove this output from the stream?')) {
       StreamsStore.removeOutput(streamId, outputId, (response) => {
@@ -90,11 +101,13 @@ const OutputsComponent = React.createClass({
       });
     }
   },
+
   _handleOutputUpdate(output, deltas) {
     OutputsStore.update(output, deltas, () => {
       this._handleUpdate();
     });
   },
+
   render() {
     if (this.state.outputs && this.state.types && (!this.props.streamId || this.state.assignableOutputs)) {
       const permissions = this.props.permissions;

--- a/graylog2-web-interface/src/components/pipelines/NewPipeline.jsx
+++ b/graylog2-web-interface/src/components/pipelines/NewPipeline.jsx
@@ -7,22 +7,22 @@ import PipelineDetails from './PipelineDetails';
 
 import Routes from 'routing/Routes';
 
-const NewPipeline = React.createClass({
-  propTypes: {
+class NewPipeline extends React.Component {
+  static propTypes = {
     onChange: PropTypes.func.isRequired,
-  },
+  };
 
-  _onChange(newPipeline) {
+  _onChange = (newPipeline) => {
     this.props.onChange(newPipeline, this._goToPipeline);
-  },
+  };
 
-  _goToPipeline(pipeline) {
+  _goToPipeline = (pipeline) => {
     history.push(Routes.SYSTEM.PIPELINES.PIPELINE(pipeline.id));
-  },
+  };
 
-  _goBack() {
+  _goBack = () => {
     history.goBack();
-  },
+  };
 
   render() {
     return (
@@ -35,7 +35,7 @@ const NewPipeline = React.createClass({
         </Col>
       </Row>
     );
-  },
-});
+  }
+}
 
 export default NewPipeline;

--- a/graylog2-web-interface/src/components/pipelines/Pipeline.jsx
+++ b/graylog2-web-interface/src/components/pipelines/Pipeline.jsx
@@ -1,5 +1,6 @@
 import PropTypes from 'prop-types';
 import React from 'react';
+import createReactClass from 'create-react-class';
 import { Button, Row, Col, Alert } from 'react-bootstrap';
 import { LinkContainer } from 'react-router-bootstrap';
 
@@ -12,7 +13,9 @@ import PipelineConnectionsList from './PipelineConnectionsList';
 
 import Routes from 'routing/Routes';
 
-const Pipeline = React.createClass({
+const Pipeline = createReactClass({
+  displayName: 'Pipeline',
+
   propTypes: {
     pipeline: PropTypes.object.isRequired,
     connections: PropTypes.array.isRequired,

--- a/graylog2-web-interface/src/components/pipelines/PipelineConnectionsForm.jsx
+++ b/graylog2-web-interface/src/components/pipelines/PipelineConnectionsForm.jsx
@@ -1,5 +1,6 @@
 import PropTypes from 'prop-types';
 import React from 'react';
+import createReactClass from 'create-react-class';
 import { Button, ControlLabel, FormGroup, HelpBlock } from 'react-bootstrap';
 import { Link } from 'react-router';
 import naturalSort from 'javascript-natural-sort';
@@ -9,7 +10,9 @@ import BootstrapModalForm from 'components/bootstrap/BootstrapModalForm';
 
 import Routes from 'routing/Routes';
 
-const PipelineConnectionsForm = React.createClass({
+const PipelineConnectionsForm = createReactClass({
+  displayName: 'PipelineConnectionsForm',
+
   propTypes: {
     pipeline: PropTypes.object.isRequired,
     connections: PropTypes.array.isRequired,

--- a/graylog2-web-interface/src/components/pipelines/PipelineConnectionsList.jsx
+++ b/graylog2-web-interface/src/components/pipelines/PipelineConnectionsList.jsx
@@ -2,20 +2,18 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import naturalSort from 'javascript-natural-sort';
 
-const PipelineConnectionsList = React.createClass({
-  propTypes: {
+class PipelineConnectionsList extends React.Component {
+  static propTypes = {
     pipeline: PropTypes.object.isRequired,
     connections: PropTypes.array.isRequired,
     streams: PropTypes.array.isRequired,
     streamsFormatter: PropTypes.func.isRequired,
     noConnectionsMessage: PropTypes.any,
-  },
+  };
 
-  getDefaultProps() {
-    return {
-      noConnectionsMessage: 'Pipeline not connected to any streams',
-    };
-  },
+  static defaultProps = {
+    noConnectionsMessage: 'Pipeline not connected to any streams',
+  };
 
   render() {
     const streamsUsingPipeline = this.props.connections
@@ -29,7 +27,7 @@ const PipelineConnectionsList = React.createClass({
         {streamsUsingPipeline.length === 0 ? this.props.noConnectionsMessage : this.props.streamsFormatter(streamsUsingPipeline)}
       </span>
     );
-  },
-});
+  }
+}
 
 export default PipelineConnectionsList;

--- a/graylog2-web-interface/src/components/pipelines/PipelineDetails.jsx
+++ b/graylog2-web-interface/src/components/pipelines/PipelineDetails.jsx
@@ -7,13 +7,13 @@ import PipelineForm from './PipelineForm';
 
 import { MetricContainer, CounterRate } from 'components/metrics';
 
-const PipelineDetails = React.createClass({
-  propTypes: {
+class PipelineDetails extends React.Component {
+  static propTypes = {
     pipeline: PropTypes.object,
     create: PropTypes.bool,
     onChange: PropTypes.func.isRequired,
     onCancel: PropTypes.func,
-  },
+  };
 
   render() {
     if (this.props.create) {
@@ -50,7 +50,7 @@ const PipelineDetails = React.createClass({
         <hr />
       </div>
     );
-  },
-});
+  }
+}
 
 export default PipelineDetails;

--- a/graylog2-web-interface/src/components/pipelines/PipelineForm.jsx
+++ b/graylog2-web-interface/src/components/pipelines/PipelineForm.jsx
@@ -1,12 +1,15 @@
 import PropTypes from 'prop-types';
 import React from 'react';
+import createReactClass from 'create-react-class';
 import { Row, Col, Button } from 'react-bootstrap';
 
 import { BootstrapModalForm, Input } from 'components/bootstrap';
 import ObjectUtils from 'util/ObjectUtils';
 import FormsUtils from 'util/FormsUtils';
 
-const PipelineForm = React.createClass({
+const PipelineForm = createReactClass({
+  displayName: 'PipelineForm',
+
   propTypes: {
     pipeline: PropTypes.object,
     create: PropTypes.bool,

--- a/graylog2-web-interface/src/components/pipelines/ProcessingTimelineComponent.jsx
+++ b/graylog2-web-interface/src/components/pipelines/ProcessingTimelineComponent.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import createReactClass from 'create-react-class';
 import Reflux from 'reflux';
 import { Alert, Button } from 'react-bootstrap';
 import { LinkContainer } from 'react-router-bootstrap';
@@ -19,7 +20,8 @@ const StreamsStore = StoreProvider.getStore('Streams');
 
 import Routes from 'routing/Routes';
 
-const ProcessingTimelineComponent = React.createClass({
+const ProcessingTimelineComponent = createReactClass({
+  displayName: 'ProcessingTimelineComponent',
   mixins: [Reflux.connect(PipelinesStore), Reflux.connect(PipelineConnectionsStore)],
 
   componentDidMount() {

--- a/graylog2-web-interface/src/components/pipelines/Stage.jsx
+++ b/graylog2-web-interface/src/components/pipelines/Stage.jsx
@@ -1,5 +1,6 @@
 import PropTypes from 'prop-types';
 import React from 'react';
+import createReactClass from 'create-react-class';
 import Reflux from 'reflux';
 import { Col, Button } from 'react-bootstrap';
 import { Link } from 'react-router';
@@ -11,7 +12,9 @@ import { MetricContainer, CounterRate } from 'components/metrics';
 
 import Routes from 'routing/Routes';
 
-const Stage = React.createClass({
+const Stage = createReactClass({
+  displayName: 'Stage',
+
   propTypes: {
     stage: PropTypes.object.isRequired,
     pipeline: PropTypes.object.isRequired,
@@ -19,6 +22,7 @@ const Stage = React.createClass({
     onUpdate: PropTypes.func.isRequired,
     onDelete: PropTypes.func.isRequired,
   },
+
   mixins: [Reflux.connect(RulesStore)],
 
   _ruleHeaderFormatter(header) {

--- a/graylog2-web-interface/src/components/pipelines/StageForm.jsx
+++ b/graylog2-web-interface/src/components/pipelines/StageForm.jsx
@@ -1,5 +1,6 @@
 import PropTypes from 'prop-types';
 import React from 'react';
+import createReactClass from 'create-react-class';
 import Reflux from 'reflux';
 import { Button } from 'react-bootstrap';
 import { Link } from 'react-router';
@@ -13,13 +14,16 @@ import RulesStore from 'stores/rules/RulesStore';
 
 import Routes from 'routing/Routes';
 
-const StageForm = React.createClass({
+const StageForm = createReactClass({
+  displayName: 'StageForm',
+
   propTypes: {
     stage: PropTypes.object,
     create: PropTypes.bool,
     save: PropTypes.func.isRequired,
     validateStage: PropTypes.func.isRequired,
   },
+
   mixins: [Reflux.connect(RulesStore)],
 
   getDefaultProps() {

--- a/graylog2-web-interface/src/components/rules/Rule.jsx
+++ b/graylog2-web-interface/src/components/rules/Rule.jsx
@@ -13,14 +13,14 @@ import RuleHelper from './RuleHelper';
 
 import Routes from 'routing/Routes';
 
-const Rule = React.createClass({
-  propTypes: {
+class Rule extends React.Component {
+  static propTypes = {
     rule: PropTypes.object,
     usedInPipelines: PropTypes.array,
     create: PropTypes.bool,
     onSave: PropTypes.func.isRequired,
     validateRule: PropTypes.func.isRequired,
-  },
+  };
 
   render() {
     let title;
@@ -70,7 +70,7 @@ const Rule = React.createClass({
         </Row>
       </div>
     );
-  },
-});
+  }
+}
 
 export default Rule;

--- a/graylog2-web-interface/src/components/rules/RuleForm.jsx
+++ b/graylog2-web-interface/src/components/rules/RuleForm.jsx
@@ -11,29 +11,29 @@ import history from 'util/History';
 
 import RuleFormStyle from './RuleForm.css';
 
-const RuleForm = React.createClass({
-  propTypes: {
+class RuleForm extends React.Component {
+  static propTypes = {
     rule: PropTypes.object,
     usedInPipelines: PropTypes.array,
     create: PropTypes.bool,
     onSave: PropTypes.func.isRequired,
     validateRule: PropTypes.func.isRequired,
-  },
+  };
 
-  getDefaultProps() {
-    return {
-      rule: {
-        id: '',
-        title: '',
-        description: '',
-        source: '',
-      },
-    };
-  },
+  static defaultProps = {
+    rule: {
+      id: '',
+      title: '',
+      description: '',
+      source: '',
+    },
+  };
 
-  getInitialState() {
-    const rule = this.props.rule;
-    return {
+  constructor(props) {
+    super(props);
+    const rule = props.rule;
+
+    this.state = {
       // when editing, take the rule that's been passed in
       rule: {
         id: rule.id,
@@ -43,22 +43,22 @@ const RuleForm = React.createClass({
       },
       parseErrors: [],
     };
-  },
+  }
 
   componentWillUnmount() {
     if (this.parseTimer !== undefined) {
       clearTimeout(this.parseTimer);
       this.parseTimer = undefined;
     }
-  },
+  }
 
-  parseTimer: undefined,
+  parseTimer = undefined;
 
-  _setParseErrors(errors) {
+  _setParseErrors = (errors) => {
     this.setState({ parseErrors: errors });
-  },
+  };
 
-  _onSourceChange(value) {
+  _onSourceChange = (value) => {
     // don't try to parse the previous value, gets reset below
     if (this.parseTimer !== undefined) {
       clearTimeout(this.parseTimer);
@@ -71,44 +71,44 @@ const RuleForm = React.createClass({
       // have the caller validate the rule after typing stopped for a while. usually this will mean send to server to parse
       this.parseTimer = setTimeout(() => this.props.validateRule(rule, this._setParseErrors), 500);
     }
-  },
+  };
 
-  _onDescriptionChange(event) {
+  _onDescriptionChange = (event) => {
     const rule = this.state.rule;
     rule.description = event.target.value;
     this.setState({ rule });
-  },
+  };
 
-  _onTitleChange(event) {
+  _onTitleChange = (event) => {
     const rule = this.state.rule;
     rule.title = event.target.value;
     this.setState({ rule });
-  },
+  };
 
-  _getId(prefixIdName) {
+  _getId = (prefixIdName) => {
     return this.state.name !== undefined ? prefixIdName + this.state.name : prefixIdName;
-  },
+  };
 
-  _goBack() {
+  _goBack = () => {
     history.goBack();
-  },
+  };
 
-  _saved() {
+  _saved = () => {
     history.push(Routes.SYSTEM.PIPELINES.RULES);
-  },
+  };
 
-  _save() {
+  _save = () => {
     if (this.state.parseErrors.length === 0) {
       this.props.onSave(this.state.rule, this._saved);
     }
-  },
+  };
 
-  _submit(event) {
+  _submit = (event) => {
     event.preventDefault();
     this._save();
-  },
+  };
 
-  _formatPipelinesUsingRule() {
+  _formatPipelinesUsingRule = () => {
     if (this.props.usedInPipelines.length === 0) {
       return 'This rule is not being used in any pipelines.';
     }
@@ -124,7 +124,7 @@ const RuleForm = React.createClass({
     });
 
     return <ul className={RuleFormStyle.usedInPipelines}>{formattedPipelines}</ul>;
-  },
+  };
 
   render() {
     let pipelinesUsingRule;
@@ -179,7 +179,7 @@ const RuleForm = React.createClass({
         </Row>
       </form>
     );
-  },
-});
+  }
+}
 
 export default RuleForm;

--- a/graylog2-web-interface/src/components/rules/RuleHelper.jsx
+++ b/graylog2-web-interface/src/components/rules/RuleHelper.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import createReactClass from 'create-react-class';
 import { Row, Col, Panel, Table, Tabs, Tab } from 'react-bootstrap';
 
 import Reflux from 'reflux';
@@ -14,7 +15,9 @@ import DocsHelper from 'util/DocsHelper';
 
 import RuleHelperStyle from './RuleHelper.css';
 
-const RuleHelper = React.createClass({
+const RuleHelper = createReactClass({
+  displayName: 'RuleHelper',
+
   mixins: [
     Reflux.connect(RulesStore),
   ],

--- a/graylog2-web-interface/src/components/rules/RuleList.jsx
+++ b/graylog2-web-interface/src/components/rules/RuleList.jsx
@@ -12,24 +12,24 @@ import { MetricContainer, CounterRate } from 'components/metrics';
 
 import Routes from 'routing/Routes';
 
-const RuleList = React.createClass({
-  propTypes: {
+class RuleList extends React.Component {
+  static propTypes = {
     rules: PropTypes.array.isRequired,
-  },
+  };
 
-  _delete(rule) {
+  _delete = (rule) => {
     return () => {
       if (window.confirm(`Do you really want to delete rule "${rule.title}"?`)) {
         RulesActions.delete(rule);
       }
     };
-  },
+  };
 
-  _headerCellFormatter(header) {
+  _headerCellFormatter = (header) => {
     return <th>{header}</th>;
-  },
+  };
 
-  _ruleInfoFormatter(rule) {
+  _ruleInfoFormatter = (rule) => {
     const actions = [
       <Button key="delete" bsStyle="primary" bsSize="xsmall" onClick={this._delete(rule)} title="Delete rule">
         Delete
@@ -63,7 +63,8 @@ const RuleList = React.createClass({
         <td className="actions">{actions}</td>
       </tr>
     );
-  },
+  };
+
   render() {
     const filterKeys = ['title', 'description'];
     const headers = ['Title', 'Description', 'Created', 'Last modified', 'Throughput', 'Errors', 'Actions'];
@@ -88,7 +89,7 @@ const RuleList = React.createClass({
         </DataTable>
       </div>
     );
-  },
-});
+  }
+}
 
 export default RuleList;

--- a/graylog2-web-interface/src/components/rules/RulesComponent.jsx
+++ b/graylog2-web-interface/src/components/rules/RulesComponent.jsx
@@ -4,10 +4,10 @@ import React from 'react';
 import { Spinner } from 'components/common';
 import RuleList from './RuleList';
 
-const RulesComponent = React.createClass({
-  propTypes: {
+class RulesComponent extends React.Component {
+  static propTypes = {
     rules: PropTypes.array,
-  },
+  };
 
   render() {
     if (!this.props.rules) {
@@ -19,7 +19,7 @@ const RulesComponent = React.createClass({
         <RuleList rules={this.props.rules} />
       </div>
     );
-  },
-});
+  }
+}
 
 export default RulesComponent;

--- a/graylog2-web-interface/src/components/search/AddDecoratorButton.jsx
+++ b/graylog2-web-interface/src/components/search/AddDecoratorButton.jsx
@@ -1,5 +1,6 @@
 import PropTypes from 'prop-types';
 import React from 'react';
+import createReactClass from 'create-react-class';
 import Reflux from 'reflux';
 import jQuery from 'jquery';
 import PureRenderMixin from 'react-addons-pure-render-mixin';
@@ -16,18 +17,23 @@ const DecoratorsActions = ActionsProvider.getActions('Decorators');
 
 import DecoratorStyles from '!style!css!components/search/decoratorStyles.css';
 
-const AddDecoratorButton = React.createClass({
+const AddDecoratorButton = createReactClass({
+  displayName: 'AddDecoratorButton',
+
   propTypes: {
     nextOrder: PropTypes.number.isRequired,
     stream: PropTypes.string,
     disabled: PropTypes.bool,
   },
+
   mixins: [Reflux.connect(DecoratorsStore), PureRenderMixin],
+
   getDefaultProps() {
     return {
       disabled: false,
     };
   },
+
   getInitialState() {
     return {
       typeDefinition: {},
@@ -37,10 +43,12 @@ const AddDecoratorButton = React.createClass({
   _formatDecoratorType(typeDefinition, typeName) {
     return { value: typeName, label: typeDefinition.name };
   },
+
   _handleCancel() {
     this.refs.select.clearValue();
     this.setState(this.getInitialState());
   },
+
   _handleSubmit(data) {
     const request = {
       stream: this.props.stream,
@@ -51,9 +59,11 @@ const AddDecoratorButton = React.createClass({
     DecoratorsActions.create(request);
     this.setState({ typeName: this.PLACEHOLDER });
   },
+
   _openModal() {
     this.refs.configurationForm.open();
   },
+
   _onTypeChange(decoratorType) {
     this.setState({ typeName: decoratorType });
     if (this.state.types[decoratorType]) {
@@ -62,6 +72,7 @@ const AddDecoratorButton = React.createClass({
       this.setState({ typeDefinition: {} });
     }
   },
+
   render() {
     if (!this.state.types) {
       return <Spinner />;

--- a/graylog2-web-interface/src/components/search/AddSearchCountToDashboard.jsx
+++ b/graylog2-web-interface/src/components/search/AddSearchCountToDashboard.jsx
@@ -2,15 +2,15 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import AddToDashboardMenu from 'components/dashboard/AddToDashboardMenu';
 
-const AddSearchCountToDashboard = React.createClass({
-  propTypes: {
+class AddSearchCountToDashboard extends React.Component {
+  static propTypes = {
     searchInStream: PropTypes.object,
     permissions: PropTypes.array.isRequired,
     pullRight: PropTypes.bool,
-  },
+  };
 
-  SEARCH_COUNT_WIDGET_TYPE: 'SEARCH_RESULT_COUNT',
-  STREAM_SEARCH_COUNT_WIDGET_TYPE: 'STREAM_SEARCH_RESULT_COUNT',
+  SEARCH_COUNT_WIDGET_TYPE = 'SEARCH_RESULT_COUNT';
+  STREAM_SEARCH_COUNT_WIDGET_TYPE = 'STREAM_SEARCH_RESULT_COUNT';
 
   render() {
     return (
@@ -19,7 +19,7 @@ const AddSearchCountToDashboard = React.createClass({
                           widgetType={this.props.searchInStream ? this.STREAM_SEARCH_COUNT_WIDGET_TYPE : this.SEARCH_COUNT_WIDGET_TYPE}
                           permissions={this.props.permissions} />
     );
-  },
-});
+  }
+}
 
 export default AddSearchCountToDashboard;

--- a/graylog2-web-interface/src/components/search/ChangedMessageField.jsx
+++ b/graylog2-web-interface/src/components/search/ChangedMessageField.jsx
@@ -3,18 +3,17 @@ import React from 'react';
 
 const style = require('!style!css!./ChangedMessageField.css');
 
-const ChangedMessageField = React.createClass({
-  propTypes: {
+class ChangedMessageField extends React.Component {
+  static propTypes = {
     fieldName: PropTypes.string.isRequired,
     originalValue: PropTypes.string,
     newValue: PropTypes.string,
-  },
-  getDefaultProps() {
-    return {
-      originalField: undefined,
-      newField: undefined,
-    };
-  },
+  };
+
+  static defaultProps = {
+    originalField: undefined,
+    newField: undefined,
+  };
 
   render() {
     return (
@@ -26,7 +25,7 @@ const ChangedMessageField = React.createClass({
         </dd>
       </span>
     );
-  },
-});
+  }
+}
 
 export default ChangedMessageField;

--- a/graylog2-web-interface/src/components/search/DecoratedMessageFieldMarker.jsx
+++ b/graylog2-web-interface/src/components/search/DecoratedMessageFieldMarker.jsx
@@ -3,10 +3,11 @@ import React from 'react';
 
 import DecoratorStyles from '!style!css!components/search/decoratorStyles.css';
 
-const DecoratedMessageFieldMarker = React.createClass({
-  propTypes: {
+class DecoratedMessageFieldMarker extends React.Component {
+  static propTypes = {
     className: PropTypes.string,
-  },
+  };
+
   render() {
     const classNames = [DecoratorStyles.decoratorMarker];
     if (this.props.className) {
@@ -14,7 +15,7 @@ const DecoratedMessageFieldMarker = React.createClass({
     }
 
     return <small className={classNames.join(' ')}>(decorated)</small>;
-  },
-});
+  }
+}
 
 export default DecoratedMessageFieldMarker;

--- a/graylog2-web-interface/src/components/search/DecoratedSidebarMessageField.jsx
+++ b/graylog2-web-interface/src/components/search/DecoratedSidebarMessageField.jsx
@@ -6,12 +6,13 @@ import { DecoratedMessageFieldMarker } from 'components/search';
 
 import DecoratorStyles from '!style!css!components/search/decoratorStyles.css';
 
-const DecoratedSidebarMessageField = React.createClass({
-  propTypes: {
+class DecoratedSidebarMessageField extends React.Component {
+  static propTypes = {
     field: PropTypes.object,
     onToggled: PropTypes.func,
     selected: PropTypes.bool,
-  },
+  };
+
   render() {
     const label = (<span>
       {this.props.field.name}
@@ -30,7 +31,7 @@ const DecoratedSidebarMessageField = React.createClass({
         </div>
       </li>
     );
-  },
-});
+  }
+}
 
 export default DecoratedSidebarMessageField;

--- a/graylog2-web-interface/src/components/search/Decorator.jsx
+++ b/graylog2-web-interface/src/components/search/Decorator.jsx
@@ -1,5 +1,6 @@
 import PropTypes from 'prop-types';
 import React from 'react';
+import createReactClass from 'create-react-class';
 import Reflux from 'reflux';
 
 import { DropdownButton, MenuItem } from 'react-bootstrap';
@@ -18,12 +19,16 @@ import PermissionsMixin from 'util/PermissionsMixin';
 
 import DecoratorStyles from '!style!css!components/search/decoratorStyles.css';
 
-const Decorator = React.createClass({
+const Decorator = createReactClass({
+  displayName: 'Decorator',
+
   propTypes: {
     decorator: PropTypes.object.isRequired,
     typeDefinition: PropTypes.object.isRequired,
   },
+
   mixins: [Reflux.connect(DecoratorsStore), Reflux.connect(CurrentUserStore), PermissionsMixin],
+
   componentDidMount() {
     DecoratorsActions.available();
   },
@@ -33,9 +38,11 @@ const Decorator = React.createClass({
       DecoratorsActions.remove(this.props.decorator.id);
     }
   },
+
   _handleEditClick() {
     this.refs.editForm.open();
   },
+
   _handleSubmit(data) {
     DecoratorsActions.update(this.props.decorator.id, {
       type: data.type,
@@ -44,11 +51,13 @@ const Decorator = React.createClass({
       stream: this.props.decorator.stream,
     });
   },
+
   _decoratorTypeNotPresent() {
     return {
       name: 'Unknown decorator type',
     };
   },
+
   // Attempts to resolve ID values in the decorator configuration against the type definition.
   // This allows users to see actual names for entities in drop-downs, instead of their IDs.
   _resolveConfigurationIds(config) {
@@ -68,6 +77,7 @@ const Decorator = React.createClass({
 
     return Object.assign({}, config, resolvedConfig);
   },
+
   _formatActionsMenu() {
     const permissions = this.state.currentUser.permissions;
     const decorator = this.props.decorator;
@@ -80,6 +90,7 @@ const Decorator = React.createClass({
       </DropdownButton>
     );
   },
+
   render() {
     if (!this.state.types || !this.state.currentUser) {
       return <Spinner />;

--- a/graylog2-web-interface/src/components/search/DecoratorList.jsx
+++ b/graylog2-web-interface/src/components/search/DecoratorList.jsx
@@ -6,18 +6,19 @@ import { SortableList } from 'components/common';
 
 import DecoratorStyles from '!style!css!components/search/decoratorStyles.css';
 
-const DecoratorList = React.createClass({
-  propTypes: {
+class DecoratorList extends React.Component {
+  static propTypes = {
     decorators: PropTypes.arrayOf(PropTypes.object).isRequired,
     disableDragging: PropTypes.bool,
     onReorder: PropTypes.func,
-  },
+  };
 
-  _onReorderWrapper(...args) {
+  _onReorderWrapper = (...args) => {
     if (this.props.onReorder) {
       this.props.onReorder(...args);
     }
-  },
+  };
+
   render() {
     if (!this.props.decorators || this.props.decorators.length === 0) {
       return (
@@ -29,7 +30,7 @@ const DecoratorList = React.createClass({
     return (
       <SortableList items={this.props.decorators} onMoveItem={this._onReorderWrapper} disableDragging={this.props.disableDragging} />
     );
-  },
-});
+  }
+}
 
 export default DecoratorList;

--- a/graylog2-web-interface/src/components/search/DecoratorSidebar.jsx
+++ b/graylog2-web-interface/src/components/search/DecoratorSidebar.jsx
@@ -1,5 +1,6 @@
 import PropTypes from 'prop-types';
 import React from 'react';
+import createReactClass from 'create-react-class';
 import ReactDOM from 'react-dom';
 import Reflux from 'reflux';
 import { Button, OverlayTrigger, Popover } from 'react-bootstrap';
@@ -19,12 +20,16 @@ const DecoratorsActions = ActionsProvider.getActions('Decorators');
 
 import DecoratorStyles from '!style!css!components/search/decoratorStyles.css';
 
-const DecoratorSidebar = React.createClass({
+const DecoratorSidebar = createReactClass({
+  displayName: 'DecoratorSidebar',
+
   propTypes: {
     stream: PropTypes.string,
     maximumHeight: PropTypes.number,
   },
+
   mixins: [Reflux.connect(DecoratorsStore), Reflux.connect(CurrentUserStore), PermissionsMixin],
+
   getInitialState() {
     return {
       maxDecoratorsHeight: 1000,
@@ -62,6 +67,7 @@ const DecoratorSidebar = React.createClass({
                                                    decorator={decorator}
                                                    typeDefinition={typeDefinition} /> });
   },
+
   _updateOrder(decorators) {
     decorators.forEach((item, idx) => {
       const decorator = this.state.decorators.find(i => i.id === item.id);
@@ -69,6 +75,7 @@ const DecoratorSidebar = React.createClass({
       DecoratorsActions.update(decorator.id, decorator);
     });
   },
+
   render() {
     if (!this.state.decorators) {
       return <Spinner />;

--- a/graylog2-web-interface/src/components/search/FieldAnalyzersSidebar.jsx
+++ b/graylog2-web-interface/src/components/search/FieldAnalyzersSidebar.jsx
@@ -5,8 +5,8 @@ import { Input } from 'components/bootstrap';
 
 import { DecoratedSidebarMessageField, SidebarMessageField } from 'components/search';
 
-const FieldAnalyzersSidebar = React.createClass({
-  propTypes: {
+class FieldAnalyzersSidebar extends React.Component {
+  static propTypes = {
     fields: PropTypes.array,
     fieldAnalyzers: PropTypes.array,
     onFieldAnalyzer: PropTypes.func,
@@ -21,33 +21,31 @@ const FieldAnalyzersSidebar = React.createClass({
     showHighlightToggle: PropTypes.bool,
     togglePageFields: PropTypes.func,
     toggleShouldHighlight: PropTypes.func,
-  },
+  };
 
-  getInitialState() {
-    return {
-      fieldFilter: '',
-      maxFieldsHeight: 1000,
-    };
-  },
+  state = {
+    fieldFilter: '',
+    maxFieldsHeight: 1000,
+  };
 
   componentDidMount() {
     this._updateHeight();
     window.addEventListener('scroll', this._updateHeight);
-  },
+  }
 
   componentDidUpdate(prevProps) {
     if (this.props.showAllFields !== prevProps.showAllFields || this.props.maximumHeight !== prevProps.maximumHeight) {
       this._updateHeight();
     }
-  },
+  }
 
   componentWillUnmount() {
     window.removeEventListener('scroll', this._updateHeight);
-  },
+  }
 
-  MINIMUM_FIELDS_HEIGHT: 50,
+  MINIMUM_FIELDS_HEIGHT = 50;
 
-  _updateHeight() {
+  _updateHeight = () => {
     const fieldsContainer = ReactDOM.findDOMNode(this.refs.fields);
 
     const footer = ReactDOM.findDOMNode(this.refs.footer);
@@ -70,37 +68,41 @@ const FieldAnalyzersSidebar = React.createClass({
       highlightToggleMargins;
 
     this.setState({ maxFieldsHeight: Math.max(maxHeight, this.MINIMUM_FIELDS_HEIGHT) });
-  },
+  };
 
-  _filterFields(event) {
+  _filterFields = (event) => {
     this.setState({ fieldFilter: event.target.value });
-  },
+  };
 
-  _showAllFields(event) {
+  _showAllFields = (event) => {
     event.preventDefault();
     if (!this.props.showAllFields) {
       this.props.togglePageFields();
     }
-  },
-  _showPageFields(event) {
+  };
+
+  _showPageFields = (event) => {
     event.preventDefault();
     if (this.props.showAllFields) {
       this.props.togglePageFields();
     }
-  },
+  };
 
-  _updateFieldSelection(setName) {
+  _updateFieldSelection = (setName) => {
     this.props.predefinedFieldSelection(setName);
-  },
-  _updateFieldSelectionToDefault() {
+  };
+
+  _updateFieldSelectionToDefault = () => {
     this._updateFieldSelection('default');
-  },
-  _updateFieldSelectionToAll() {
+  };
+
+  _updateFieldSelectionToAll = () => {
     this._updateFieldSelection('all');
-  },
-  _updateFieldSelectionToNone() {
+  };
+
+  _updateFieldSelectionToNone = () => {
     this._updateFieldSelection('none');
-  },
+  };
 
   render() {
     const decorationStats = this.props.result.decoration_stats;
@@ -181,7 +183,7 @@ const FieldAnalyzersSidebar = React.createClass({
         </div>
       </div>
     );
-  },
-});
+  }
+}
 
 export default FieldAnalyzersSidebar;

--- a/graylog2-web-interface/src/components/search/LegacyHistogram.jsx
+++ b/graylog2-web-interface/src/components/search/LegacyHistogram.jsx
@@ -1,5 +1,6 @@
 import PropTypes from 'prop-types';
 import React from 'react';
+import createReactClass from 'create-react-class';
 import ReactDOM from 'react-dom';
 
 import AddToDashboardMenu from 'components/dashboard/AddToDashboardMenu';
@@ -12,25 +13,31 @@ import EventHandlersThrottler from 'util/EventHandlersThrottler';
 import resultHistogram from 'legacy/result-histogram';
 
 // Hue-manatee. We tried to be sorry, but aren't.
-const LegacyHistogram = React.createClass({
+const LegacyHistogram = createReactClass({
+  displayName: 'LegacyHistogram',
+
   propTypes: {
     formattedHistogram: PropTypes.array.isRequired,
     histogram: PropTypes.object.isRequired,
     stream: PropTypes.object,
     permissions: PropTypes.arrayOf(PropTypes.string).isRequired,
   },
+
   getInitialState() {
     return {};
   },
+
   componentDidMount() {
     this._renderHistogram(this.props.formattedHistogram);
     window.addEventListener('resize', this._onResize);
   },
+
   componentDidUpdate(prevProps) {
     if (JSON.stringify(this.props.formattedHistogram) !== JSON.stringify(prevProps.formattedHistogram)) {
       this._updateHistogram(this.props.formattedHistogram, prevProps.formattedHistogram);
     }
   },
+
   componentWillUnmount() {
     window.removeEventListener('resize', this._onResize);
   },
@@ -48,15 +55,18 @@ const LegacyHistogram = React.createClass({
     resultHistogram.setData(histogram, this.props.stream);
     resultHistogram.drawResultGraph();
   },
+
   _updateHistogram(histogram) {
     resultHistogram.updateData(histogram);
   },
+
   _resolutionChanged(newResolution) {
     return (event) => {
       event.preventDefault();
       SearchStore.resolution = newResolution;
     };
   },
+
   _getFirstHistogramValue() {
     if (SearchStore.rangeType === 'relative' && SearchStore.rangeParams.get('relative') === 0) {
       return null;
@@ -64,6 +74,7 @@ const LegacyHistogram = React.createClass({
 
     return this.props.histogram.histogram_boundaries.from;
   },
+
   render() {
     if (SearchStore.resolution === undefined) {
       SearchStore.resolution = this.props.histogram.interval;

--- a/graylog2-web-interface/src/components/search/MalformedSearchQuery.jsx
+++ b/graylog2-web-interface/src/components/search/MalformedSearchQuery.jsx
@@ -5,22 +5,22 @@ import { Col, Panel, Row } from 'react-bootstrap';
 import { ContactUs, DocumentationLink } from 'components/support';
 import DocsHelper from 'util/DocsHelper';
 
-const MalformedSearchQuery = React.createClass({
-  propTypes: {
+class MalformedSearchQuery extends React.Component {
+  static propTypes = {
     error: PropTypes.object.isRequired,
-  },
+  };
 
-  _isGenericError(error) {
+  _isGenericError = (error) => {
     return error.column === null || error.line === null;
-  },
+  };
 
-  _getFormattedErrorDetails(details) {
+  _getFormattedErrorDetails = (details) => {
     return details.map(function(detail) {
         return <li><code>{detail}</code></li>
     });
-  },
+  };
 
-  _getFormattedErrorDescription(error) {
+  _getFormattedErrorDescription = (error) => {
     return (
       <Panel bsStyle="danger">
         <dl style={{ marginBottom: 0 }}>
@@ -31,7 +31,7 @@ const MalformedSearchQuery = React.createClass({
         </dl>
       </Panel>
     );
-  },
+  };
 
   render() {
     const error = this.props.error.body;
@@ -81,7 +81,7 @@ const MalformedSearchQuery = React.createClass({
         <ContactUs />
       </div>
     );
-  },
-});
+  }
+}
 
 export default MalformedSearchQuery;

--- a/graylog2-web-interface/src/components/search/MessageDetail.jsx
+++ b/graylog2-web-interface/src/components/search/MessageDetail.jsx
@@ -15,8 +15,8 @@ import SurroundingSearchButton from 'components/search/SurroundingSearchButton';
 
 import Routes from 'routing/Routes';
 
-const MessageDetail = React.createClass({
-  propTypes: {
+class MessageDetail extends React.Component {
+  static propTypes = {
     allStreams: PropTypes.object,
     allStreamsLoaded: PropTypes.bool,
     disableTestAgainstStream: PropTypes.bool,
@@ -32,15 +32,14 @@ const MessageDetail = React.createClass({
     customFieldActions: PropTypes.node,
     searchConfig: PropTypes.object,
     disableMessageActions: PropTypes.bool,
-  },
+  };
 
-  getInitialState() {
-    return {
-      allStreamsLoaded: false,
-      allStreams: Immutable.List(),
-      showOriginal: false,
-    };
-  },
+  state = {
+    allStreamsLoaded: false,
+    allStreams: Immutable.List(),
+    showOriginal: false,
+  };
+
   componentDidMount() {
     if (this.props.allStreams === undefined) {
       // our parent does not provide allStreams for the test against stream menu, we have to load it ourselves
@@ -52,16 +51,18 @@ const MessageDetail = React.createClass({
       const promise = StreamsStore.listStreams();
       promise.done(streams => this._onStreamsLoaded(streams));
     }
-  },
-  _onStreamsLoaded(streams) {
-    this.setState({ allStreamsLoaded: true, allStreams: Immutable.List(streams).sortBy(stream => stream.title) });
-  },
+  }
 
-  _inputName(inputId) {
+  _onStreamsLoaded = (streams) => {
+    this.setState({ allStreamsLoaded: true, allStreams: Immutable.List(streams).sortBy(stream => stream.title) });
+  };
+
+  _inputName = (inputId) => {
     const input = this.props.inputs.get(inputId);
     return input ? <span style={{ wordBreak: 'break-word' }}>{input.title}</span> : 'deleted input';
-  },
-  _nodeName(nodeId) {
+  };
+
+  _nodeName = (nodeId) => {
     const node = this.props.nodes.get(nodeId);
     let nodeInformation;
 
@@ -79,16 +80,16 @@ const MessageDetail = React.createClass({
       nodeInformation = <span style={{ wordBreak: 'break-word' }}>stopped node</span>;
     }
     return nodeInformation;
-  },
+  };
 
-  _getAllStreams() {
+  _getAllStreams = () => {
     if (this.props.allStreams) {
       return this.props.allStreams;
     }
     return this.state.allStreams;
-  },
+  };
 
-  _getTestAgainstStreamButton() {
+  _getTestAgainstStreamButton = () => {
     if (this.props.disableTestAgainstStream) {
       return null;
     }
@@ -122,9 +123,9 @@ const MessageDetail = React.createClass({
         { (!streamList && this.props.allStreamsLoaded) && <MenuItem header>No streams available</MenuItem> }
       </DropdownButton>
     );
-  },
+  };
 
-  _formatMessageActions() {
+  _formatMessageActions = () => {
     if (this.props.disableMessageActions) {
       return <ButtonGroup className="pull-right" bsSize="small" />;
     }
@@ -156,11 +157,11 @@ const MessageDetail = React.createClass({
         {this._getTestAgainstStreamButton()}
       </ButtonGroup>
     );
-  },
+  };
 
-  _toggleShowOriginal() {
+  _toggleShowOriginal = () => {
     this.setState({ showOriginal: !this.state.showOriginal });
-  },
+  };
 
   render() {
     // Short circuit when all messages are being expanded at the same time
@@ -273,7 +274,7 @@ const MessageDetail = React.createClass({
         </Col>
       </Row>
     </div>);
-  },
-});
+  }
+}
 
 export default MessageDetail;

--- a/graylog2-web-interface/src/components/search/MessageField.jsx
+++ b/graylog2-web-interface/src/components/search/MessageField.jsx
@@ -1,9 +1,13 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 
+import createReactClass from 'create-react-class';
+
 import { MessageFieldDescription } from 'components/search';
 
-const MessageField = React.createClass({
+const MessageField = createReactClass({
+  displayName: 'MessageField',
+
   propTypes: {
     customFieldActions: PropTypes.node,
     disableFieldActions: PropTypes.bool,
@@ -12,18 +16,23 @@ const MessageField = React.createClass({
     renderForDisplay: PropTypes.func.isRequired,
     value: PropTypes.any.isRequired,
   },
+
   SPECIAL_FIELDS: ['full_message', 'level'],
+
   _isAdded(key) {
     const decorationStats = this.props.message.decoration_stats;
     return decorationStats && decorationStats.added_fields && decorationStats.added_fields[key] !== undefined;
   },
+
   _isChanged(key) {
     const decorationStats = this.props.message.decoration_stats;
     return decorationStats && decorationStats.changed_fields && decorationStats.changed_fields[key] !== undefined;
   },
+
   _isDecorated(key) {
     return this._isAdded(key) || this._isChanged(key);
   },
+
   render() {
     let innerValue = this.props.value;
     const key = this.props.fieldName;

--- a/graylog2-web-interface/src/components/search/MessageFieldDescription.jsx
+++ b/graylog2-web-interface/src/components/search/MessageFieldDescription.jsx
@@ -15,8 +15,8 @@ import MessageFieldSearchActions from './MessageFieldSearchActions';
 
 import { DecoratedMessageFieldMarker } from 'components/search';
 
-const MessageFieldDescription = React.createClass({
-  propTypes: {
+class MessageFieldDescription extends React.Component {
+  static propTypes = {
     message: PropTypes.object.isRequired,
     fieldName: PropTypes.string.isRequired,
     fieldValue: PropTypes.any.isRequired,
@@ -24,37 +24,42 @@ const MessageFieldDescription = React.createClass({
     disableFieldActions: PropTypes.bool,
     customFieldActions: PropTypes.node,
     isDecorated: PropTypes.bool,
-  },
-  getInitialState() {
-    return {
-      messageTerms: Immutable.List(),
-    };
-  },
-  loadTerms(field) {
+  };
+
+  state = {
+    messageTerms: Immutable.List(),
+  };
+
+  loadTerms = (field) => {
     return () => {
       const promise = MessagesActions.fieldTerms.triggerPromise(this.props.message.index, this.props.message.fields[field]);
       promise.then(terms => this._onTermsLoaded(terms));
     };
-  },
-  _onTermsLoaded(terms) {
+  };
+
+  _onTermsLoaded = (terms) => {
     this.setState({ messageTerms: Immutable.fromJS(terms) });
-  },
-  _shouldShowTerms() {
+  };
+
+  _shouldShowTerms = () => {
     return this.state.messageTerms.size !== 0;
-  },
-  addFieldToSearchBar(event) {
+  };
+
+  addFieldToSearchBar = (event) => {
     event.preventDefault();
     SearchStore.addSearchTerm(this.props.fieldName, this.props.fieldValue);
-  },
-  _getFormattedTerms() {
+  };
+
+  _getFormattedTerms = () => {
     const termsMarkup = [];
     this.state.messageTerms.forEach((term, idx) => {
       termsMarkup.push(<span key={idx} className="message-terms">{term}</span>);
     });
 
     return termsMarkup;
-  },
-  _getFormattedFieldActions() {
+  };
+
+  _getFormattedFieldActions = () => {
     if (this.props.disableFieldActions) {
       return null;
     }
@@ -72,7 +77,8 @@ const MessageFieldDescription = React.createClass({
     }
 
     return fieldActions;
-  },
+  };
+
   render() {
     const className = this.props.fieldName === 'message' || this.props.fieldName === 'full_message' ? 'message-field' : '';
 
@@ -88,7 +94,7 @@ const MessageFieldDescription = React.createClass({
         {this.props.isDecorated && <DecoratedMessageFieldMarker />}
       </dd>
     );
-  },
-});
+  }
+}
 
 export default MessageFieldDescription;

--- a/graylog2-web-interface/src/components/search/MessageFieldExtractorActions.jsx
+++ b/graylog2-web-interface/src/components/search/MessageFieldExtractorActions.jsx
@@ -4,22 +4,26 @@ import { DropdownButton, MenuItem } from 'react-bootstrap';
 import { LinkContainer } from 'react-router-bootstrap';
 import ExtractorUtils from 'util/ExtractorUtils';
 
-const MessageFieldExtractorActions = React.createClass({
-  propTypes: {
+class MessageFieldExtractorActions extends React.Component {
+  static propTypes = {
     fieldName: PropTypes.string.isRequired,
     message: PropTypes.object.isRequired,
-  },
+  };
+
   componentWillMount() {
     this._refreshExtractorRoutes(this.props);
-  },
+  }
+
   componentWillReceiveProps(nextProps) {
     this._refreshExtractorRoutes(nextProps);
-  },
-  _refreshExtractorRoutes(props) {
+  }
+
+  _refreshExtractorRoutes = (props) => {
     this.newExtractorRoutes = ExtractorUtils.getNewExtractorRoutes(props.message.source_node_id,
       props.message.source_input_id, props.fieldName, props.message.index, props.message.id);
-  },
-  _formatExtractorMenuItem(extractorType) {
+  };
+
+  _formatExtractorMenuItem = (extractorType) => {
     return (
       <LinkContainer to={this.newExtractorRoutes[extractorType]}>
         <MenuItem key={`menu-item-${extractorType}`}>
@@ -27,7 +31,8 @@ const MessageFieldExtractorActions = React.createClass({
         </MenuItem>
       </LinkContainer>
     );
-  },
+  };
+
   render() {
     const messageField = this.props.message.fields[this.props.fieldName];
     if (typeof messageField === 'string') {
@@ -56,7 +61,7 @@ const MessageFieldExtractorActions = React.createClass({
         </DropdownButton>
       </div>
     );
-  },
-});
+  }
+}
 
 export default MessageFieldExtractorActions;

--- a/graylog2-web-interface/src/components/search/MessageFieldSearchActions.jsx
+++ b/graylog2-web-interface/src/components/search/MessageFieldSearchActions.jsx
@@ -3,26 +3,30 @@ import React from 'react';
 import { SplitButton, MenuItem } from 'react-bootstrap';
 import ExtractorUtils from 'util/ExtractorUtils';
 
-const MessageFieldSearchActions = React.createClass({
-  propTypes: {
+class MessageFieldSearchActions extends React.Component {
+  static propTypes = {
     fieldName: PropTypes.string.isRequired,
     message: PropTypes.object.isRequired,
     onLoadTerms: PropTypes.func.isRequired,
     onAddFieldToSearchBar: PropTypes.func.isRequired,
-  },
-  getInitialState() {
-    this.newExtractorRoutes = ExtractorUtils.getNewExtractorRoutes(this.props.message.source_node_id,
-      this.props.message.source_input_id, this.props.fieldName, this.props.message.index, this.props.message.id);
+  };
 
-    return null;
-  },
-  _formatExtractorMenuItem(extractorType) {
+  constructor(props) {
+    super(props);
+    this.newExtractorRoutes = ExtractorUtils.getNewExtractorRoutes(props.message.source_node_id,
+      props.message.source_input_id, props.fieldName, props.message.index, props.message.id);
+
+    this.state = null;
+  }
+
+  _formatExtractorMenuItem = (extractorType) => {
     return (
       <MenuItem key={`menu-item-${extractorType}`} href={this.newExtractorRoutes[extractorType]}>
         {ExtractorUtils.getReadableExtractorTypeName(extractorType)}
       </MenuItem>
     );
-  },
+  };
+
   render() {
     const messageField = this.props.message.fields[this.props.fieldName];
     let extractors;
@@ -50,7 +54,7 @@ const MessageFieldSearchActions = React.createClass({
         </SplitButton>
       </div>
     );
-  },
-});
+  }
+}
 
 export default MessageFieldSearchActions;

--- a/graylog2-web-interface/src/components/search/MessageFields.jsx
+++ b/graylog2-web-interface/src/components/search/MessageFields.jsx
@@ -3,22 +3,20 @@ import React from 'react';
 
 import { ChangedMessageField, MessageField } from 'components/search';
 
-const MessageFields = React.createClass({
-  propTypes: {
+class MessageFields extends React.Component {
+  static propTypes = {
     customFieldActions: PropTypes.node,
     disableFieldActions: PropTypes.bool,
     message: PropTypes.object.isRequired,
     renderForDisplay: PropTypes.func.isRequired,
     showDecoration: PropTypes.bool,
-  },
+  };
 
-  getDefaultProps() {
-    return {
-      showDecoration: false,
-    };
-  },
+  static defaultProps = {
+    showDecoration: false,
+  };
 
-  _formatFields(fields, showDecoration) {
+  _formatFields = (fields, showDecoration) => {
     const decorationStats = this.props.message.decoration_stats;
 
     if (!showDecoration || !decorationStats) {
@@ -54,7 +52,8 @@ const MessageFields = React.createClass({
 
       return <MessageField key={key} {...this.props} fieldName={key} value={fields[key]} disableFieldActions />;
     });
-  },
+  };
+
   render() {
     const formattedFields = this.props.message.formatted_fields;
     const fields = this._formatFields(formattedFields, this.props.showDecoration);
@@ -64,7 +63,7 @@ const MessageFields = React.createClass({
         {fields}
       </dl>
     );
-  },
-});
+  }
+}
 
 export default MessageFields;

--- a/graylog2-web-interface/src/components/search/MessageShow.jsx
+++ b/graylog2-web-interface/src/components/search/MessageShow.jsx
@@ -5,33 +5,32 @@ import Immutable from 'immutable';
 import MessageDetail from './MessageDetail';
 import StringUtils from 'util/StringUtils';
 
-const MessageShow = React.createClass({
-  propTypes: {
+class MessageShow extends React.Component {
+  static propTypes = {
     message: PropTypes.object,
     inputs: PropTypes.object,
     streams: PropTypes.object,
     nodes: PropTypes.object,
-  },
-
-  getInitialState() {
-    return this._getImmutableProps(this.props);
-  },
+  };
 
   componentWillReceiveProps(nextProps) {
     this.setState(this._getImmutableProps(nextProps));
-  },
+  }
 
-  _getImmutableProps(props) {
+  _getImmutableProps = (props) => {
     return {
       streams: props.streams ? Immutable.Map(props.streams) : props.streams,
       nodes: props.nodes ? Immutable.Map(props.nodes) : props.nodes,
     };
-  },
+  };
 
-  renderForDisplay(fieldName) {
+  renderForDisplay = (fieldName) => {
     // No highlighting for the message details view.
     return StringUtils.stringify(this.props.message.fields[fieldName]);
-  },
+  };
+
+  state = this._getImmutableProps(this.props);
+
   render() {
     return (
       <Row className="content">
@@ -45,7 +44,7 @@ const MessageShow = React.createClass({
         </Col>
       </Row>
     );
-  },
-});
+  }
+}
 
 export default MessageShow;

--- a/graylog2-web-interface/src/components/search/MessageTableEntry.jsx
+++ b/graylog2-web-interface/src/components/search/MessageTableEntry.jsx
@@ -10,8 +10,8 @@ import StringUtils from 'util/StringUtils';
 import DateTime from 'logic/datetimes/DateTime';
 import style from './MessageTableEntry.css';
 
-const MessageTableEntry = React.createClass({
-  propTypes: {
+class MessageTableEntry extends React.Component {
+  static propTypes = {
     allStreams: ImmutablePropTypes.list.isRequired,
     allStreamsLoaded: PropTypes.bool.isRequired,
     disableSurroundingSearch: PropTypes.bool,
@@ -32,17 +32,16 @@ const MessageTableEntry = React.createClass({
     showMessageRow: PropTypes.bool,
     streams: ImmutablePropTypes.map.isRequired,
     toggleDetail: PropTypes.func.isRequired,
-  },
-  getDefaultProps() {
-    return {
-      disableSurroundingSearch: false,
-      highlight: false,
-      highlightMessage: undefined,
-      searchConfig: undefined,
-      selectedFields: Immutable.OrderedSet(),
-      showMessageRow: false,
-    };
-  },
+  };
+
+  static defaultProps = {
+    disableSurroundingSearch: false,
+    highlight: false,
+    highlightMessage: undefined,
+    searchConfig: undefined,
+    selectedFields: Immutable.OrderedSet(),
+    showMessageRow: false,
+  };
 
   shouldComponentUpdate(newProps) {
     if (this.props.highlight !== newProps.highlight) {
@@ -64,9 +63,9 @@ const MessageTableEntry = React.createClass({
       return true;
     }
     return false;
-  },
+  }
 
-  renderForDisplay(fieldName, truncate) {
+  renderForDisplay = (fieldName, truncate) => {
     const fullOrigValue = this.props.message.fields[fieldName];
 
     if (fullOrigValue === undefined) {
@@ -80,9 +79,9 @@ const MessageTableEntry = React.createClass({
     } else {
       return this.possiblyHighlight(fieldName, fullOrigValue, truncate);
     }
-  },
+  };
 
-  possiblyHighlight(fieldName, fullOrigValue, truncate) {
+  possiblyHighlight = (fieldName, fullOrigValue, truncate) => {
     // Ensure the field is a string for later processing
     const fullStringOrigValue = StringUtils.stringify(fullOrigValue);
 
@@ -115,12 +114,13 @@ const MessageTableEntry = React.createClass({
       return String(origValue);
     }
     return String(origValue);
-  },
-  _toggleDetail() {
-    this.props.toggleDetail(`${this.props.message.index}-${this.props.message.id}`);
-  },
+  };
 
-  _toTimestamp(value) {
+  _toggleDetail = () => {
+    this.props.toggleDetail(`${this.props.message.index}-${this.props.message.id}`);
+  };
+
+  _toTimestamp = (value) => {
     const popoverHoverFocus = (
       <Popover id="popover-trigger-hover-focus">
         This timestamp is rendered in your timezone.
@@ -135,7 +135,7 @@ const MessageTableEntry = React.createClass({
         </OverlayTrigger>
       </span>
     );
-  },
+  };
 
   render() {
     const colSpanFixup = this.props.selectedFields.size + 1;
@@ -181,7 +181,7 @@ const MessageTableEntry = React.createClass({
         }
       </tbody>
     );
-  },
-});
+  }
+}
 
 export default MessageTableEntry;

--- a/graylog2-web-interface/src/components/search/MessageTablePaginator.jsx
+++ b/graylog2-web-interface/src/components/search/MessageTablePaginator.jsx
@@ -1,5 +1,6 @@
 import PropTypes from 'prop-types';
 import React from 'react';
+import createReactClass from 'create-react-class';
 import ReactDOM from 'react-dom';
 import { Page } from 'components/common';
 
@@ -12,7 +13,9 @@ import $ from 'jquery';
 global.jQuery = $;
 require('bootstrap/js/affix');
 
-const MessageTablePaginator = React.createClass({
+const MessageTablePaginator = createReactClass({
+  displayName: 'MessageTablePaginator',
+
   propTypes: {
     resultCount: PropTypes.number.isRequired,
     currentPage: PropTypes.number.isRequired,
@@ -59,6 +62,7 @@ const MessageTablePaginator = React.createClass({
       });
     }
   },
+
   _setPaginationWidth() {
     if (this.props.position === 'bottom') {
       this.eventsThrottler.throttle(() => {
@@ -66,13 +70,16 @@ const MessageTablePaginator = React.createClass({
       });
     }
   },
+
   _numberOfPages() {
     return Math.ceil(this.props.resultCount / this.props.pageSize);
   },
+
   _minPage() {
     const currentTenMin = Math.floor(this.props.currentPage / 10) * 10;
     return Math.max(1, currentTenMin);
   },
+
   _maxPage() {
     if (this.props.currentPage > this._numberOfPages()) {
       return this.props.currentPage;
@@ -80,6 +87,7 @@ const MessageTablePaginator = React.createClass({
     const currentTenMax = Math.ceil((this.props.currentPage + 1) / 10) * 10;
     return Math.min(this._numberOfPages(), currentTenMax);
   },
+
   _onPageChanged(page) {
     let newPage;
 
@@ -93,6 +101,7 @@ const MessageTablePaginator = React.createClass({
 
     this.props.onPageChange(newPage);
   },
+
   render() {
     const pages = [];
 

--- a/graylog2-web-interface/src/components/search/NoSearchResults.jsx
+++ b/graylog2-web-interface/src/components/search/NoSearchResults.jsx
@@ -1,5 +1,6 @@
 import PropTypes from 'prop-types';
 import React from 'react';
+import createReactClass from 'create-react-class';
 import { Col, Row } from 'react-bootstrap';
 
 import { AddSearchCountToDashboard, SavedSearchControls, ShowQueryModal } from 'components/search';
@@ -11,7 +12,9 @@ import DocsHelper from 'util/DocsHelper';
 import StoreProvider from 'injection/StoreProvider';
 const SearchStore = StoreProvider.getStore('Search');
 
-const NoSearchResults = React.createClass({
+const NoSearchResults = createReactClass({
+  displayName: 'NoSearchResults',
+
   propTypes: {
     builtQuery: PropTypes.string,
     histogram: PropTypes.object.isRequired,

--- a/graylog2-web-interface/src/components/search/RefreshControls.jsx
+++ b/graylog2-web-interface/src/components/search/RefreshControls.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import createReactClass from 'create-react-class';
 import Reflux from 'reflux';
 import moment from 'moment';
 import { Button, ButtonGroup, DropdownButton, MenuItem } from 'react-bootstrap';
@@ -11,8 +12,10 @@ const RefreshStore = StoreProvider.getStore('Refresh');
 import ActionsProvider from 'injection/ActionsProvider';
 const RefreshActions = ActionsProvider.getActions('Refresh');
 
-const RefreshControls = React.createClass({
+const RefreshControls = createReactClass({
+  displayName: 'RefreshControls',
   mixins: [Reflux.connect(RefreshStore, 'refresh')],
+
   INTERVAL_OPTIONS: {
     '1 Second': 1,
     '2 Seconds': 2,
@@ -22,10 +25,12 @@ const RefreshControls = React.createClass({
     '1 Minute': 60,
     '5 Minutes': 300,
   },
+
   _changeInterval(interval) {
     RefreshActions.changeInterval(interval);
     RefreshActions.enable();
   },
+
   render() {
     const intervalOptions = Object.keys(this.INTERVAL_OPTIONS).map((key) => {
       const interval = this.INTERVAL_OPTIONS[key] * 1000;

--- a/graylog2-web-interface/src/components/search/ResultTable.jsx
+++ b/graylog2-web-interface/src/components/search/ResultTable.jsx
@@ -12,8 +12,8 @@ const RefreshActions = ActionsProvider.getActions('Refresh');
 
 import { MessageTableEntry, MessageTablePaginator } from 'components/search';
 
-const ResultTable = React.createClass({
-  propTypes: {
+class ResultTable extends React.Component {
+  static propTypes = {
     disableSurroundingSearch: PropTypes.bool,
     highlight: PropTypes.bool.isRequired,
     inputs: PropTypes.object.isRequired,
@@ -28,21 +28,20 @@ const ResultTable = React.createClass({
     sortOrder: PropTypes.string.isRequired,
     streams: PropTypes.object.isRequired,
     searchConfig: PropTypes.object.isRequired,
-  },
-  getDefaultProps() {
-    return {
-      disableSurroundingSearch: false,
-      onPageChange: (page) => { SearchStore.page = page; },
-    };
-  },
-  getInitialState() {
-    return {
-      expandedMessages: Immutable.Set(),
-      allStreamsLoaded: false,
-      allStreams: Immutable.List(),
-      expandAllRenderAsync: false,
-    };
-  },
+  };
+
+  static defaultProps = {
+    disableSurroundingSearch: false,
+    onPageChange: (page) => { SearchStore.page = page; },
+  };
+
+  state = {
+    expandedMessages: Immutable.Set(),
+    allStreamsLoaded: false,
+    allStreams: Immutable.List(),
+    expandAllRenderAsync: false,
+  };
+
   componentDidMount() {
     // only load the streams per page
     if (this.state.allStreamsLoaded) {
@@ -50,20 +49,23 @@ const ResultTable = React.createClass({
     }
     const promise = StreamsStore.listStreams();
     promise.done(streams => this._onStreamsLoaded(streams));
-  },
+  }
+
   componentDidUpdate() {
     if (this.state.expandAllRenderAsync) {
       // This may take some time, so we ensure we display a loading indicator in the page
       // while all messages are being expanded
       setTimeout(() => this.setState({ expandAllRenderAsync: false }), this.EXPAND_ALL_RENDER_ASYNC_DELAY);
     }
-  },
-  EXPAND_ALL_RENDER_ASYNC_DELAY: 10,
-  _onStreamsLoaded(streams) {
-    this.setState({ allStreamsLoaded: true, allStreams: Immutable.List(streams).sortBy(stream => stream.title) });
-  },
+  }
 
-  _toggleMessageDetail(id) {
+  EXPAND_ALL_RENDER_ASYNC_DELAY = 10;
+
+  _onStreamsLoaded = (streams) => {
+    this.setState({ allStreamsLoaded: true, allStreams: Immutable.List(streams).sortBy(stream => stream.title) });
+  };
+
+  _toggleMessageDetail = (id) => {
     let newSet;
     if (this.state.expandedMessages.contains(id)) {
       newSet = this.state.expandedMessages.delete(id);
@@ -72,33 +74,38 @@ const ResultTable = React.createClass({
       RefreshActions.disable();
     }
     this.setState({ expandedMessages: newSet });
-  },
+  };
 
-  _fieldColumns() {
+  _fieldColumns = () => {
     return this.props.selectedFields.delete('message');
-  },
-  _columnStyle(fieldName) {
+  };
+
+  _columnStyle = (fieldName) => {
     if (fieldName.toLowerCase() === 'source' && this._fieldColumns().size > 1) {
       return { width: 180 };
     }
     return {};
-  },
-  expandAll() {
+  };
+
+  expandAll = () => {
     // If more than 30% of the messages are being expanded, show a loading indicator
     const expandedChangeRatio = (this.props.messages.length - this.state.expandedMessages.size) / 100;
     const renderLoadingIndicator = expandedChangeRatio > 0.3;
 
     const newSet = Immutable.Set(this.props.messages.map(message => `${message.index}-${message.id}`));
     this.setState({ expandedMessages: newSet, expandAllRenderAsync: renderLoadingIndicator });
-  },
-  collapseAll() {
+  };
+
+  collapseAll = () => {
     this.setState({ expandedMessages: Immutable.Set() });
-  },
-  _handleSort(e, field, order) {
+  };
+
+  _handleSort = (e, field, order) => {
     e.preventDefault();
     SearchStore.sort(field, order);
-  },
-  _sortIcons(fieldName) {
+  };
+
+  _sortIcons = (fieldName) => {
     let sortLinks = null;
     // the classes look funny, but using the default asc/desc icons looks odd.
     // .sort-order-item does the margins
@@ -133,7 +140,7 @@ const ResultTable = React.createClass({
       );
     }
     return <span>{sortLinks}</span>;
-  },
+  };
 
   render() {
     const selectedColumns = this._fieldColumns();
@@ -210,7 +217,7 @@ const ResultTable = React.createClass({
         </MessageTablePaginator>
       </div>
     );
-  },
-});
+  }
+}
 
 export default ResultTable;

--- a/graylog2-web-interface/src/components/search/SavedSearchControls.jsx
+++ b/graylog2-web-interface/src/components/search/SavedSearchControls.jsx
@@ -1,5 +1,6 @@
 import PropTypes from 'prop-types';
 import React from 'react';
+import createReactClass from 'create-react-class';
 import Reflux from 'reflux';
 import { Button, DropdownButton, MenuItem } from 'react-bootstrap';
 
@@ -11,29 +12,37 @@ const SavedSearchesStore = StoreProvider.getStore('SavedSearches');
 import ActionsProvider from 'injection/ActionsProvider';
 const SavedSearchesActions = ActionsProvider.getActions('SavedSearches');
 
-const SavedSearchControls = React.createClass({
+const SavedSearchControls = createReactClass({
+  displayName: 'SavedSearchControls',
+
   propTypes: {
     currentSavedSearch: PropTypes.string, // saved search ID
     pullRight: PropTypes.bool,
   },
+
   mixins: [Reflux.listenTo(SavedSearchesStore, '_updateTitle')],
+
   getInitialState() {
     return {
       title: '',
       error: false,
     };
   },
+
   componentDidMount() {
     this._updateTitle();
   },
+
   componentDidUpdate(prevProps) {
     if (prevProps.currentSavedSearch !== this.props.currentSavedSearch) {
       this._updateTitle();
     }
   },
+
   _isSearchSaved() {
     return this.props.currentSavedSearch !== undefined;
   },
+
   _updateTitle() {
     if (!this._isSearchSaved()) {
       if (this.state.title !== '') {
@@ -47,12 +56,15 @@ const SavedSearchControls = React.createClass({
       this.setState({ title: currentSavedSearch.title, error: false });
     }
   },
+
   _openModal() {
     this.refs.saveSearchModal.open();
   },
+
   _hide() {
     this.refs.saveSearchModal.close();
   },
+
   _save() {
     if (this.state.error) {
       return;
@@ -66,18 +78,22 @@ const SavedSearchControls = React.createClass({
     }
     promise.then(() => this._hide());
   },
+
   _deleteSavedSearch(_, event) {
     event.preventDefault();
     if (window.confirm('Do you really want to delete this saved search?')) {
       SavedSearchesActions.delete(this.props.currentSavedSearch);
     }
   },
+
   _titleChanged() {
     this.setState({ error: !SavedSearchesStore.isValidTitle(this.props.currentSavedSearch, this.refs.title.getValue()) });
   },
+
   _getNewSavedSearchButtons() {
     return <Button bsStyle="success" bsSize="small" onClick={this._openModal}>Save search criteria</Button>;
   },
+
   _getEditSavedSearchControls() {
     return (
       <DropdownButton bsSize="small" title="Saved search" id="saved-search-actions-dropdown" pullRight={this.props.pullRight}>
@@ -87,6 +103,7 @@ const SavedSearchControls = React.createClass({
       </DropdownButton>
     );
   },
+
   render() {
     return (
       <div style={{ display: 'inline-block' }}>

--- a/graylog2-web-interface/src/components/search/SearchBar.jsx
+++ b/graylog2-web-interface/src/components/search/SearchBar.jsx
@@ -1,6 +1,7 @@
 import $ from 'jquery';
 import PropTypes from 'prop-types';
 import React from 'react';
+import createReactClass from 'create-react-class';
 import ReactDOM from 'react-dom';
 import Immutable from 'immutable';
 import { Button, ButtonToolbar, DropdownButton, MenuItem, Alert } from 'react-bootstrap';
@@ -24,7 +25,9 @@ import UIUtils from 'util/UIUtils';
 import DateTime from 'logic/datetimes/DateTime';
 import moment from 'moment';
 
-const SearchBar = React.createClass({
+const SearchBar = createReactClass({
+  displayName: 'SearchBar',
+
   propTypes: {
     userPreferences: PropTypes.object,
     savedSearches: PropTypes.arrayOf(PropTypes.object).isRequired,
@@ -49,6 +52,7 @@ const SearchBar = React.createClass({
       keywordPreview: Immutable.Map(),
     };
   },
+
   componentDidMount() {
     SearchStore.onParamsChanged = newParams => this.setState(newParams);
     SearchStore.onSubmitSearch = () => {
@@ -57,17 +61,21 @@ const SearchBar = React.createClass({
     SearchStore.onAddQueryTerm = this._animateQueryChange;
     this._initializeSearchQueryInput();
   },
+
   componentDidUpdate(prevProps, prevState) {
     if (this.state.query !== prevState.query) {
       this._updateSearchQueryInput(this.state.query);
     }
   },
+
   componentWillUnmount() {
     this._removeSearchQueryInput();
   },
+
   reload() {
     this.setState(this.getInitialState());
   },
+
   _initializeSearchQueryInput() {
     if (this.props.userPreferences.enableSmartSearch) {
       this.queryInput = new QueryInput(this.refs.query.getInputDOMNode());
@@ -79,34 +87,41 @@ const SearchBar = React.createClass({
       });
     }
   },
+
   _updateSearchQueryInput(value) {
     if (this.props.userPreferences.enableSmartSearch) {
       this.queryInput.update(value);
     }
   },
+
   _removeSearchQueryInput() {
     if (this.props.userPreferences.enableSmartSearch) {
       const queryDOMElement = ReactDOM.findDOMNode(this.refs.query);
       $(queryDOMElement).off('typeahead:change');
     }
   },
+
   _closeSearchQueryAutoCompletion() {
     if (this.props.userPreferences.enableSmartSearch) {
       const queryDOMElement = ReactDOM.findDOMNode(this.refs.query.getInputDOMNode());
       $(queryDOMElement).typeahead('close');
     }
   },
+
   _animateQueryChange() {
     UIUtils.scrollToHint(ReactDOM.findDOMNode(this.refs.universalSearch));
     $(ReactDOM.findDOMNode(this.refs.query)).effect('bounce');
   },
+
   _queryChanged() {
     SearchStore.query = this.refs.query.getValue();
   },
+
   _rangeTypeChanged(newRangeType, event) {
     SearchStore.rangeType = newRangeType;
     this._resetKeywordPreview();
   },
+
   _rangeParamsChanged(key) {
     return () => {
       let refInput;
@@ -130,6 +145,7 @@ const SearchBar = React.createClass({
       SearchStore.rangeParams = this.state.rangeParams.set(key, refInput.getValue());
     };
   },
+
   _keywordSearchChanged() {
     this._rangeParamsChanged('keyword')();
     const value = this.refs.keyword.getValue();
@@ -142,14 +158,17 @@ const SearchBar = React.createClass({
         .catch(() => this._resetKeywordPreview());
     }
   },
+
   _resetKeywordPreview() {
     this.setState({ keywordPreview: Immutable.Map() });
   },
+
   _onKeywordPreviewLoaded(data) {
     const from = DateTime.fromUTCDateTime(data.from).toString();
     const to = DateTime.fromUTCDateTime(data.to).toString();
     this.setState({ keywordPreview: Immutable.Map({ from: from, to: to }) });
   },
+
   _formattedDateStringInUserTZ(field) {
     const dateString = this.state.rangeParams.get(field);
 
@@ -165,6 +184,7 @@ const SearchBar = React.createClass({
 
     return dateString;
   },
+
   _setDateTimeToNow(field) {
     return () => {
       const inputNode = this.refs[`${field}Formatted`].getInputDOMNode();
@@ -172,9 +192,11 @@ const SearchBar = React.createClass({
       this._rangeParamsChanged(field)();
     };
   },
+
   _isValidDateField(field) {
     return this._isValidDateString(this._formattedDateStringInUserTZ(field));
   },
+
   _isValidDateString(dateString) {
     try {
       if (dateString !== undefined) {
@@ -185,6 +207,7 @@ const SearchBar = React.createClass({
       return false;
     }
   },
+
   _performSearch(event) {
     if (event) {
       event.preventDefault();
@@ -215,6 +238,7 @@ const SearchBar = React.createClass({
       this.props.onExecuteSearch(resource);
     }
   },
+
   _onSavedSearchSelect(searchId) {
     if (searchId === '') {
       this._performSearch();

--- a/graylog2-web-interface/src/components/search/SearchExecutionError.jsx
+++ b/graylog2-web-interface/src/components/search/SearchExecutionError.jsx
@@ -4,16 +4,16 @@ import {Col, Panel, Row} from "react-bootstrap";
 
 import {ContactUs} from "components/support";
 
-const SearchExecutionError = React.createClass({
-  propTypes: {
+class SearchExecutionError extends React.Component {
+  static propTypes = {
     error: PropTypes.object.isRequired,
-  },
+  };
 
-  _getFormattedErrorDetails(details) {
+  _getFormattedErrorDetails = (details) => {
       return details.map(function(detail) {
           return <li><code>{detail}</code></li>
       });
-  },
+  };
 
   render() {
     const error = this.props.error;
@@ -47,7 +47,7 @@ const SearchExecutionError = React.createClass({
         <ContactUs />
       </div>
     );
-  },
-});
+  }
+}
 
 export default SearchExecutionError;

--- a/graylog2-web-interface/src/components/search/SearchResult.jsx
+++ b/graylog2-web-interface/src/components/search/SearchResult.jsx
@@ -13,8 +13,8 @@ const SearchStore = StoreProvider.getStore('Search');
 import { PluginStore } from 'graylog-web-plugin/plugin';
 import {} from 'components/field-analyzers'; // Make sure to load all field analyzer plugins!
 
-const SearchResult = React.createClass({
-  propTypes: {
+class SearchResult extends React.Component {
+  static propTypes = {
     query: PropTypes.string,
     builtQuery: PropTypes.string,
     result: PropTypes.object.isRequired,
@@ -28,34 +28,23 @@ const SearchResult = React.createClass({
     searchConfig: PropTypes.object.isRequired,
     loadingSearch: PropTypes.bool,
     forceFetch: PropTypes.bool,
-  },
+  };
 
-  getDefaultProps() {
-    return {
-      query: '*',
-      builtQuery: '',
-      formattedHistogram: [],
-      searchInStream: null,
-      streams: Immutable.Map({}),
-      inputs: Immutable.Map({}),
-      nodes: Immutable.Map({}),
-    };
-  },
-
-  getInitialState() {
-    return {
-      selectedFields: this.sortFields(SearchStore.fields),
-      showAllFields: false,
-      shouldHighlight: true,
-      savedSearch: SearchStore.savedSearch,
-    };
-  },
+  static defaultProps = {
+    query: '*',
+    builtQuery: '',
+    formattedHistogram: [],
+    searchInStream: null,
+    streams: Immutable.Map({}),
+    inputs: Immutable.Map({}),
+    nodes: Immutable.Map({}),
+  };
 
   componentDidUpdate() {
     this._resetSelectedFields();
-  },
+  }
 
-  onFieldToggled(fieldName) {
+  onFieldToggled = (fieldName) => {
     const currentFields = this.state.selectedFields;
     let newFieldSet;
     if (currentFields.contains(fieldName)) {
@@ -64,23 +53,23 @@ const SearchResult = React.createClass({
       newFieldSet = currentFields.add(fieldName);
     }
     this.updateSelectedFields(newFieldSet);
-  },
+  };
 
   // Reset selected fields if saved search changed
-  _resetSelectedFields() {
+  _resetSelectedFields = () => {
     if (this.state.savedSearch !== SearchStore.savedSearch) {
       this.setState({
         savedSearch: SearchStore.savedSearch,
         selectedFields: this.sortFields(SearchStore.fields),
       });
     }
-  },
+  };
 
-  togglePageFields() {
+  togglePageFields = () => {
     this.setState({ showAllFields: !this.state.showAllFields });
-  },
+  };
 
-  predefinedFieldSelection(setName) {
+  predefinedFieldSelection = (setName) => {
     if (setName === 'none') {
       this.updateSelectedFields(Immutable.Set());
     } else if (setName === 'all') {
@@ -88,18 +77,19 @@ const SearchResult = React.createClass({
     } else if (setName === 'default') {
       this.updateSelectedFields(Immutable.Set(['message', 'source']));
     }
-  },
+  };
 
-  updateSelectedFields(fieldSelection) {
+  updateSelectedFields = (fieldSelection) => {
     const selectedFields = this.sortFields(fieldSelection);
     SearchStore.fields = selectedFields;
     this.setState({ selectedFields: selectedFields });
-  },
-  _fields() {
-    return this.props.result[this.state.showAllFields ? 'all_fields' : 'fields'];
-  },
+  };
 
-  sortFields(fieldSet) {
+  _fields = () => {
+    return this.props.result[this.state.showAllFields ? 'all_fields' : 'fields'];
+  };
+
+  sortFields = (fieldSet) => {
     let newFieldSet = fieldSet;
     let sortedFields = Immutable.OrderedSet();
 
@@ -109,18 +99,18 @@ const SearchResult = React.createClass({
     newFieldSet = newFieldSet.delete('source');
     const remainingFieldsSorted = newFieldSet.sort((field1, field2) => field1.toLowerCase().localeCompare(field2.toLowerCase()));
     return sortedFields.concat(remainingFieldsSorted);
-  },
+  };
 
-  addFieldAnalyzer(ref, field) {
+  addFieldAnalyzer = (ref, field) => {
     this.refs[ref].addField(field);
-  },
+  };
 
-  _fieldAnalyzers(filter) {
+  _fieldAnalyzers = (filter) => {
     return PluginStore.exports('fieldAnalyzers')
       .filter(analyzer => filter !== undefined ? filter(analyzer) : true);
-  },
+  };
 
-  _fieldAnalyzerComponents(filter) {
+  _fieldAnalyzerComponents = (filter) => {
     // Get params used in the last executed search.
     const searchParams = SearchStore.getOriginalSearchURLParams().toJS();
     const rangeParams = {};
@@ -148,19 +138,26 @@ const SearchResult = React.createClass({
           fields: this.props.result.all_fields,
         });
       });
-  },
+  };
 
-  _shouldRenderAboveHistogram(analyzer) {
+  _shouldRenderAboveHistogram = (analyzer) => {
     return analyzer.displayPriority > 0;
-  },
+  };
 
-  _shouldRenderBelowHistogram(analyzer) {
+  _shouldRenderBelowHistogram = (analyzer) => {
     return analyzer.displayPriority <= 0;
-  },
+  };
 
-  _toggleShouldHighlight() {
+  _toggleShouldHighlight = () => {
     this.setState({ shouldHighlight: !this.state.shouldHighlight });
-  },
+  };
+
+  state = {
+    selectedFields: this.sortFields(SearchStore.fields),
+    showAllFields: false,
+    shouldHighlight: true,
+    savedSearch: SearchStore.savedSearch,
+  };
 
   render() {
     const anyHighlightRanges = Immutable.fromJS(this.props.result.messages).some(message => message.get('highlight_ranges') !== null);
@@ -230,7 +227,7 @@ const SearchResult = React.createClass({
         </Col>
       </Row>
     );
-  },
-});
+  }
+}
 
 export default SearchResult;

--- a/graylog2-web-interface/src/components/search/SearchSidebar.jsx
+++ b/graylog2-web-interface/src/components/search/SearchSidebar.jsx
@@ -1,5 +1,6 @@
 import PropTypes from 'prop-types';
 import React from 'react';
+import createReactClass from 'create-react-class';
 import ReactDOM from 'react-dom';
 import { Button, DropdownButton, MenuItem, Modal, Tab, Tabs } from 'react-bootstrap';
 import { AutoAffix } from 'react-overlays';
@@ -26,7 +27,9 @@ import ApiRoutes from 'routing/ApiRoutes';
 
 import EventHandlersThrottler from 'util/EventHandlersThrottler';
 
-const SearchSidebar = React.createClass({
+const SearchSidebar = createReactClass({
+  displayName: 'SearchSidebar',
+
   propTypes: {
     builtQuery: PropTypes.any,
     currentSavedSearch: PropTypes.string,

--- a/graylog2-web-interface/src/components/search/ShowQueryModal.jsx
+++ b/graylog2-web-interface/src/components/search/ShowQueryModal.jsx
@@ -1,12 +1,15 @@
 import PropTypes from 'prop-types';
 import React from 'react';
+import createReactClass from 'create-react-class';
 import PureRenderMixin from 'react-addons-pure-render-mixin';
 import { Modal } from 'react-bootstrap';
 
 import BootstrapModalWrapper from 'components/bootstrap/BootstrapModalWrapper';
 import { ClipboardButton } from 'components/common';
 
-const ShowQueryModal = React.createClass({
+const ShowQueryModal = createReactClass({
+  displayName: 'ShowQueryModal',
+
   propTypes: {
     builtQuery: PropTypes.string,
   },

--- a/graylog2-web-interface/src/components/search/SidebarMessageField.jsx
+++ b/graylog2-web-interface/src/components/search/SidebarMessageField.jsx
@@ -1,11 +1,15 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 
+import createReactClass from 'create-react-class';
+
 import { Panel } from 'react-bootstrap';
 import naturalSort from 'javascript-natural-sort';
 import { Input } from 'components/bootstrap';
 
-const SidebarMessageField = React.createClass({
+const SidebarMessageField = createReactClass({
+  displayName: 'SidebarMessageField',
+
   propTypes: {
     field: PropTypes.object,
     fieldAnalyzers: PropTypes.array,
@@ -14,6 +18,7 @@ const SidebarMessageField = React.createClass({
     selected: PropTypes.bool,
     searchConfig: PropTypes.object.isRequired,
   },
+
   getInitialState() {
     return {
       showActions: false,

--- a/graylog2-web-interface/src/components/search/SurroundingSearchButton.jsx
+++ b/graylog2-web-interface/src/components/search/SurroundingSearchButton.jsx
@@ -8,15 +8,15 @@ const SearchStore = StoreProvider.getStore('Search');
 
 import moment from 'moment';
 
-const SurroundingSearchButton = React.createClass({
-  propTypes: {
+class SurroundingSearchButton extends React.Component {
+  static propTypes = {
     id: PropTypes.string.isRequired,
     timestamp: PropTypes.number.isRequired,
     searchConfig: PropTypes.object.isRequired,
     messageFields: PropTypes.object.isRequired,
-  },
+  };
 
-  _buildTimeRangeOptions(searchConfig) {
+  _buildTimeRangeOptions = (searchConfig) => {
     const options = {};
 
     Object.keys(searchConfig.surrounding_timerange_options).forEach((key) => {
@@ -24,9 +24,9 @@ const SurroundingSearchButton = React.createClass({
     });
 
     return options;
-  },
+  };
 
-  _buildFilterFields() {
+  _buildFilterFields = () => {
     const fields = {};
 
     if (this.props.searchConfig) {
@@ -36,14 +36,14 @@ const SurroundingSearchButton = React.createClass({
     }
 
     return fields;
-  },
+  };
 
-  _searchLink(range) {
+  _searchLink = (range) => {
     const fromTime = moment.unix(this.props.timestamp - Number(range)).toISOString();
     const toTime = moment.unix(this.props.timestamp + Number(range)).toISOString();
 
     return SearchStore.searchSurroundingMessages(this.props.id, fromTime, toTime, this._buildFilterFields());
-  },
+  };
 
   render() {
     const timeRangeOptions = this._buildTimeRangeOptions(this.props.searchConfig);
@@ -60,7 +60,7 @@ const SurroundingSearchButton = React.createClass({
         {menuItems}
       </DropdownButton>
     );
-  },
-});
+  }
+}
 
 export default SurroundingSearchButton;

--- a/graylog2-web-interface/src/components/simulator/ProcessorSimulator.jsx
+++ b/graylog2-web-interface/src/components/simulator/ProcessorSimulator.jsx
@@ -16,25 +16,26 @@ import SimulatorStore from 'stores/simulator/SimulatorStore';
 
 const DEFAULT_STREAM_ID = '000000000000000000000001';
 
-const ProcessorSimulator = React.createClass({
-  propTypes: {
+class ProcessorSimulator extends React.Component {
+  static propTypes = {
     streams: PropTypes.array.isRequired,
-  },
+  };
 
-  getInitialState() {
+  constructor(props) {
+    super(props);
     // The default stream could not be present in a system. In that case we fallback to the first available stream.
-    this.defaultStream = this.props.streams.find(s => s.id === DEFAULT_STREAM_ID) || this.props.streams[0];
+    this.defaultStream = props.streams.find(s => s.id === DEFAULT_STREAM_ID) || props.streams[0];
 
-    return {
+    this.state = {
       message: undefined,
       stream: this.defaultStream,
       simulation: undefined,
       loading: false,
       error: undefined,
     };
-  },
+  }
 
-  _onMessageLoad(message, options) {
+  _onMessageLoad = (message, options) => {
     this.setState({ message: message, simulation: undefined, loading: true, error: undefined });
 
     SimulatorActions.simulate
@@ -47,9 +48,9 @@ const ProcessorSimulator = React.createClass({
           this.setState({ loading: false, error: error });
         }
       );
-  },
+  };
 
-  _getFormattedStreams(streams) {
+  _getFormattedStreams = (streams) => {
     if (!streams) {
       return [];
     }
@@ -59,12 +60,12 @@ const ProcessorSimulator = React.createClass({
         return { value: s.id, label: s.title };
       })
       .sort((s1, s2) => naturalSort(s1.label, s2.label));
-  },
+  };
 
-  _onStreamSelect(selectedStream) {
+  _onStreamSelect = (selectedStream) => {
     const stream = this.props.streams.find(s => s.id.toLowerCase() === selectedStream.toLowerCase());
     this.setState({ stream: stream });
-  },
+  };
 
   render() {
     if (this.props.streams.length === 0) {
@@ -122,7 +123,7 @@ const ProcessorSimulator = React.createClass({
                            error={this.state.error} />
       </div>
     );
-  },
-});
+  }
+}
 
 export default ProcessorSimulator;

--- a/graylog2-web-interface/src/components/simulator/SimulationChanges.jsx
+++ b/graylog2-web-interface/src/components/simulator/SimulationChanges.jsx
@@ -1,10 +1,13 @@
 import PropTypes from 'prop-types';
 import React from 'react';
+import createReactClass from 'create-react-class';
 import { Col, Row } from 'react-bootstrap';
 
 import { Pluralize } from 'components/common';
 
-const SimulationChanges = React.createClass({
+const SimulationChanges = createReactClass({
+  displayName: 'SimulationChanges',
+
   propTypes: {
     originalMessage: PropTypes.object.isRequired,
     simulationResults: PropTypes.object.isRequired,

--- a/graylog2-web-interface/src/components/simulator/SimulationPreview.jsx
+++ b/graylog2-web-interface/src/components/simulator/SimulationPreview.jsx
@@ -4,11 +4,11 @@ import { Alert } from 'react-bootstrap';
 
 import MessageShow from 'components/search/MessageShow';
 
-const SimulationPreview = React.createClass({
-  propTypes: {
+class SimulationPreview extends React.Component {
+  static propTypes = {
     simulationResults: PropTypes.object.isRequired,
     streams: PropTypes.object.isRequired,
-  },
+  };
 
   render() {
     const messages = this.props.simulationResults.messages;
@@ -38,7 +38,7 @@ const SimulationPreview = React.createClass({
     });
 
     return <div className="message-preview-wrapper">{formattedMessages}</div>;
-  },
-});
+  }
+}
 
 export default SimulationPreview;

--- a/graylog2-web-interface/src/components/simulator/SimulationResults.jsx
+++ b/graylog2-web-interface/src/components/simulator/SimulationResults.jsx
@@ -1,5 +1,6 @@
 import PropTypes from 'prop-types';
 import React from 'react';
+import createReactClass from 'create-react-class';
 import { Alert, Col, DropdownButton, MenuItem, Row } from 'react-bootstrap';
 
 import { Spinner } from 'components/common';
@@ -11,7 +12,9 @@ import SimulationTrace from './SimulationTrace';
 
 import NumberUtils from 'util/NumberUtils';
 
-const SimulationResults = React.createClass({
+const SimulationResults = createReactClass({
+  displayName: 'SimulationResults',
+
   propTypes: {
     stream: PropTypes.object.isRequired,
     originalMessage: PropTypes.object,

--- a/graylog2-web-interface/src/components/simulator/SimulationTrace.jsx
+++ b/graylog2-web-interface/src/components/simulator/SimulationTrace.jsx
@@ -1,9 +1,13 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 
+import createReactClass from 'create-react-class';
+
 import NumberUtils from 'util/NumberUtils';
 
-const SimulationTrace = React.createClass({
+const SimulationTrace = createReactClass({
+  displayName: 'SimulationTrace',
+
   propTypes: {
     simulationResults: PropTypes.object.isRequired,
   },

--- a/graylog2-web-interface/src/components/source-tagging/ConfigurationBundlePreview.jsx
+++ b/graylog2-web-interface/src/components/source-tagging/ConfigurationBundlePreview.jsx
@@ -8,14 +8,14 @@ import UserNotification from 'util/UserNotification';
 import ActionsProvider from 'injection/ActionsProvider';
 const ConfigurationBundlesActions = ActionsProvider.getActions('ConfigurationBundles');
 
-const ConfigurationBundlePreview = React.createClass({
-  propTypes: {
+class ConfigurationBundlePreview extends React.Component {
+  static propTypes = {
     sourceTypeId: PropTypes.string,
     sourceTypeDescription: PropTypes.string,
     onDelete: PropTypes.func.isRequired,
-  },
+  };
 
-  _confirmDeletion() {
+  _confirmDeletion = () => {
     if (window.confirm('You are about to delete this content pack, are you sure?')) {
       ConfigurationBundlesActions.delete(this.props.sourceTypeId).then(() => {
         UserNotification.success('Bundle deleted successfully.', 'Success');
@@ -24,14 +24,16 @@ const ConfigurationBundlePreview = React.createClass({
         UserNotification.error('Deleting bundle failed, please check your logs for more information.', 'Error');
       });
     }
-  },
-  _onApply() {
+  };
+
+  _onApply = () => {
     ConfigurationBundlesActions.apply(this.props.sourceTypeId).then(() => {
       UserNotification.success('Bundle applied successfully.', 'Success');
     }, () => {
       UserNotification.error('Applying bundle failed, please check your logs for more information.', 'Error');
     });
-  },
+  };
+
   render() {
     let preview = 'Select a content pack from the list to see its preview.';
     let applyAction = '';
@@ -57,7 +59,7 @@ const ConfigurationBundlePreview = React.createClass({
         </div>
       </div>
     );
-  },
-});
+  }
+}
 
 export default ConfigurationBundlePreview;

--- a/graylog2-web-interface/src/components/source-tagging/ConfigurationBundles.jsx
+++ b/graylog2-web-interface/src/components/source-tagging/ConfigurationBundles.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import createReactClass from 'create-react-class';
 import Reflux from 'reflux';
 import { Accordion, Panel, Row, Col } from 'react-bootstrap';
 import $ from 'jquery';
@@ -15,7 +16,8 @@ import SourceType from './SourceType';
 import ConfigurationBundlePreview from './ConfigurationBundlePreview';
 import Spinner from 'components/common/Spinner';
 
-const ConfigurationBundles = React.createClass({
+const ConfigurationBundles = createReactClass({
+  displayName: 'ConfigurationBundles',
   mixins: [Reflux.connect(ConfigurationBundlesStore)],
 
   getInitialState() {
@@ -24,14 +26,17 @@ const ConfigurationBundles = React.createClass({
       sourceTypeDescription: '',
     };
   },
+
   componentDidMount() {
     ConfigurationBundlesActions.list();
   },
+
   _getCategoriesHtml() {
     const categories = $.map(this.state.configurationBundles, (bundles, category) => category);
     categories.sort();
     return categories.map((category, idx) => this._getSourceTypeHtml(category, idx), this);
   },
+
   _getSourceTypeHtml(category, idx) {
     const bundles = this._getSortedBundles(category);
     const bundlesJsx = bundles.map((bundle) => {
@@ -53,6 +58,7 @@ const ConfigurationBundles = React.createClass({
       </Panel>
     );
   },
+
   _getSortedBundles(category) {
     const bundles = this.state.configurationBundles[category];
     bundles.sort((bundle1, bundle2) => {
@@ -66,6 +72,7 @@ const ConfigurationBundles = React.createClass({
     });
     return bundles;
   },
+
   onSubmit(submitEvent) {
     submitEvent.preventDefault();
     if (!this.refs.uploadedFile.files || !this.refs.uploadedFile.files[0]) {
@@ -90,12 +97,15 @@ const ConfigurationBundles = React.createClass({
 
     reader.readAsText(this.refs.uploadedFile.files[0]);
   },
+
   handleSourceTypeChange(sourceTypeId, sourceTypeDescription) {
     this.setState({ sourceTypeId: sourceTypeId, sourceTypeDescription: sourceTypeDescription });
   },
+
   _resetSelection() {
     this.setState(this.getInitialState());
   },
+
   render() {
     return (
       <Row className="configuration-bundles">

--- a/graylog2-web-interface/src/components/source-tagging/SourceType.jsx
+++ b/graylog2-web-interface/src/components/source-tagging/SourceType.jsx
@@ -1,15 +1,17 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 
-const SourceType = React.createClass({
-  propTypes: {
+class SourceType extends React.Component {
+  static propTypes = {
     name: PropTypes.string.isRequired,
     description: PropTypes.string.isRequired,
     onSelect: PropTypes.func.isRequired,
-  },
-  _onChange(event) {
+  };
+
+  _onChange = (event) => {
     this.props.onSelect(event.target.id, event.target.value);
-  },
+  };
+
   render() {
     return (
       <label className="radio">
@@ -18,7 +20,7 @@ const SourceType = React.createClass({
         {this.props.name}
       </label>
     );
-  },
-});
+  }
+}
 
 export default SourceType;

--- a/graylog2-web-interface/src/components/sources/SourceDataTable.jsx
+++ b/graylog2-web-interface/src/components/sources/SourceDataTable.jsx
@@ -12,20 +12,18 @@ import StringUtils from 'util/StringUtils';
 import StoreProvider from 'injection/StoreProvider';
 const SearchStore = StoreProvider.getStore('Search');
 
-const SourceDataTable = React.createClass({
-  propTypes: {
+class SourceDataTable extends React.Component {
+  static propTypes = {
     numberOfTopValues: PropTypes.number.isRequired,
     resetFilters: PropTypes.func.isRequired,
     setSearchFilter: PropTypes.func.isRequired,
-  },
+  };
 
-  getInitialState() {
-    return {
-      numberOfSources: 100,
-    };
-  },
+  state = {
+    numberOfSources: 100,
+  };
 
-  _getAddToSearchButton(source) {
+  _getAddToSearchButton = (source) => {
     const addToSearchButton = document.createElement('button');
     addToSearchButton.className = 'btn btn-xs btn-default dc-search-button';
     addToSearchButton.title = 'Add to search query';
@@ -33,9 +31,9 @@ const SourceDataTable = React.createClass({
     addToSearchButton.innerHTML = "<i class='fa fa-search-plus'></i>";
 
     return addToSearchButton.outerHTML;
-  },
+  };
 
-  renderDataTable(dimension, group, onDataFiltered) {
+  renderDataTable = (dimension, group, onDataFiltered) => {
     const dataTableDomNode = $('#dc-sources-result')[0];
     this._dataTable = dc.dataTable(dataTableDomNode);
     this._dataTable
@@ -59,55 +57,55 @@ const SourceDataTable = React.createClass({
         this._addSourceToSearchBarListener(table);
         this._filterSourceListener(table, onDataFiltered);
       });
-  },
+  };
 
-  _addSourceToSearchBarListener(table) {
+  _addSourceToSearchBarListener = (table) => {
     table.selectAll('td.dc-table-column .dc-search-button').on('click', () => {
       const source = $(d3.event.target).closest('button').data('source');
       SearchStore.addSearchTerm('source', source, UniversalSearch.orOperator());
     });
-  },
+  };
 
-  _filterSourceListener(table, onDataFiltered) {
+  _filterSourceListener = (table, onDataFiltered) => {
     table.selectAll('td.dc-table-column a.dc-filter-link').on('click', () => {
       const parentTdElement = $(d3.event.target).parents('td.dc-table-column._0');
       const datum = d3.selectAll(parentTdElement).datum();
 
       onDataFiltered(datum.name);
     });
-  },
+  };
 
-  redraw() {
+  redraw = () => {
     this._dataTable.redraw();
-  },
+  };
 
-  clearFilters() {
+  clearFilters = () => {
     this._dataTable.filterAll();
-  },
+  };
 
-  getFilters() {
+  getFilters = () => {
     return (this._dataTable ? this._dataTable.filters() : []);
-  },
+  };
 
-  setFilter(filter) {
+  setFilter = (filter) => {
     this._dataTable.filter(filter);
-  },
+  };
 
-  changeNumberOfSources(numberOfSources) {
+  changeNumberOfSources = (numberOfSources) => {
     this._dataTable
       .size(numberOfSources)
       .redraw();
-  },
+  };
 
-  _onNumberOfSourcesChanged(event) {
+  _onNumberOfSourcesChanged = (event) => {
     this.setState({ numberOfSources: event.target.value }, () => {
       this.changeNumberOfSources(this.state.numberOfSources);
     });
-  },
+  };
 
-  _onFilterChanged(event) {
+  _onFilterChanged = (event) => {
     this.props.setSearchFilter(event.target.value);
-  },
+  };
 
   render() {
     const resultTable = (
@@ -155,7 +153,7 @@ const SourceDataTable = React.createClass({
         {resultTable}
       </div>
     );
-  },
-});
+  }
+}
 
 export default SourceDataTable;

--- a/graylog2-web-interface/src/components/sources/SourceLineChart.jsx
+++ b/graylog2-web-interface/src/components/sources/SourceLineChart.jsx
@@ -11,44 +11,42 @@ import D3Utils from 'util/D3Utils';
 
 import graphHelper from 'legacy/graphHelper';
 
-const SourceLineChart = React.createClass({
-  propTypes: {
+class SourceLineChart extends React.Component {
+  static propTypes = {
     histogramDataAvailable: PropTypes.bool.isRequired,
     reloadingHistogram: PropTypes.bool.isRequired,
     resetFilters: PropTypes.func.isRequired,
     resolution: PropTypes.string.isRequired,
-  },
+  };
 
-  getInitialState() {
-    return {
-      lineChartWidth: '100%',
-    };
-  },
+  state = {
+    lineChartWidth: '100%',
+  };
 
-  getFilters() {
+  getFilters = () => {
     return this._lineChart ? this._lineChart.filters() : [];
-  },
+  };
 
-  setFilter(filter) {
+  setFilter = (filter) => {
     this._lineChart.filter(filter);
-  },
+  };
 
-  clearFilters() {
+  clearFilters = () => {
     this._lineChart.filterAll();
-  },
+  };
 
-  _configureWidth(lineChartWidth) {
+  _configureWidth = (lineChartWidth) => {
     this._lineChart.width(lineChartWidth);
     this.setState({ lineChartWidth: `${String(lineChartWidth)}px` });
-  },
+  };
 
-  updateWidth() {
+  updateWidth = () => {
     const $lineChartDomNode = $('#dc-sources-line-chart');
     const lineChartWidth = $lineChartDomNode.width();
     this._configureWidth(lineChartWidth);
-  },
+  };
 
-  renderLineChart(dimension, group, onDataFiltered) {
+  renderLineChart = (dimension, group, onDataFiltered) => {
     const lineChartDomNode = $('#dc-sources-line-chart')[0];
     const width = $(lineChartDomNode).width();
     $(document).on('mouseup', '#dc-sources-line-chart svg', (event) => {
@@ -87,7 +85,7 @@ const SourceLineChart = React.createClass({
     this._lineChart.yAxis()
       .ticks(6)
       .tickFormat(d3.format('s'));
-  },
+  };
 
   render() {
     const loadingSpinnerStyle = {
@@ -116,7 +114,7 @@ const SourceLineChart = React.createClass({
         {noDataOverlay}
       </div>
     );
-  },
-});
+  }
+}
 
 export default SourceLineChart;

--- a/graylog2-web-interface/src/components/sources/SourceOverview.jsx
+++ b/graylog2-web-interface/src/components/sources/SourceOverview.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import createReactClass from 'create-react-class';
 import $ from 'jquery';
 import crossfilter from 'crossfilter';
 import dc from 'dc';
@@ -31,7 +32,9 @@ const SUPPORTED_RANGES_IN_SECS = [hoursToSeconds(1), daysToSeconds(1), daysToSec
 
 let SCREEN_RESOLUTION = $(window).width();
 
-const SourceOverview = React.createClass({
+const SourceOverview = createReactClass({
+  displayName: 'SourceOverview',
+
   getInitialState() {
     this.sourcesData = crossfilter();
     this.filterDimension = this.sourcesData.dimension(d => d.name);

--- a/graylog2-web-interface/src/components/sources/SourcePieChart.jsx
+++ b/graylog2-web-interface/src/components/sources/SourcePieChart.jsx
@@ -7,42 +7,42 @@ import React from 'react';
 import SourceTitle from './SourceTitle';
 import D3Utils from 'util/D3Utils';
 
-const SourcePieChart = React.createClass({
-  propTypes: {
+class SourcePieChart extends React.Component {
+  static propTypes = {
     resetFilters: PropTypes.func.isRequired,
     numberOfTopValues: PropTypes.number.isRequired,
-  },
+  };
 
-  getFilters() {
+  getFilters = () => {
     return this._pieChart ? this._pieChart.filters() : [];
-  },
+  };
 
-  setFilter(filter) {
+  setFilter = (filter) => {
     this._pieChart.filter(filter);
-  },
+  };
 
-  clearFilters() {
+  clearFilters = () => {
     this._pieChart.filterAll();
-  },
+  };
 
-  redraw() {
+  redraw = () => {
     this._pieChart.redraw();
-  },
+  };
 
-  _configureWidth(pieChartWidth) {
+  _configureWidth = (pieChartWidth) => {
     this._pieChart.width(pieChartWidth)
       .height(pieChartWidth)
       .radius(pieChartWidth / 2 - 10)
       .innerRadius(pieChartWidth / 5);
-  },
+  };
 
-  updateWidth() {
+  updateWidth = () => {
     const $pieChartDomNode = $('#dc-sources-pie-chart').parent();
     const pieChartWidth = $pieChartDomNode.width();
     this._configureWidth(pieChartWidth);
-  },
+  };
 
-  renderPieChart(dimension, group, onDataFiltered) {
+  renderPieChart = (dimension, group, onDataFiltered) => {
     const pieChartDomNode = $('#dc-sources-pie-chart')[0];
     const pieChartWidth = $(pieChartDomNode).width();
     this._pieChart = dc.pieChart(pieChartDomNode);
@@ -61,7 +61,7 @@ const SourcePieChart = React.createClass({
         });
       });
     this._configureWidth(pieChartWidth);
-  },
+  };
 
   render() {
     return (
@@ -69,7 +69,7 @@ const SourcePieChart = React.createClass({
         <SourceTitle className="reset" resetFilters={this.props.resetFilters}>Messages per source</SourceTitle>
       </div>
     );
-  },
-});
+  }
+}
 
 export default SourcePieChart;

--- a/graylog2-web-interface/src/components/sources/SourceTitle.jsx
+++ b/graylog2-web-interface/src/components/sources/SourceTitle.jsx
@@ -1,8 +1,8 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 
-const SourceTitle = React.createClass({
-  propTypes: {
+class SourceTitle extends React.Component {
+  static propTypes = {
     className: PropTypes.string,
     resetFilters: PropTypes.func.isRequired,
     resetFilterId: PropTypes.string,
@@ -11,7 +11,8 @@ const SourceTitle = React.createClass({
       PropTypes.element,
       PropTypes.string,
     ]).isRequired,
-  },
+  };
+
   render() {
     return (
       <h3 className="sources-title">
@@ -24,7 +25,7 @@ const SourceTitle = React.createClass({
         </span>
       </h3>
     );
-  },
-});
+  }
+}
 
 export default SourceTitle;

--- a/graylog2-web-interface/src/components/streamrules/CollapsibleStreamRuleList.jsx
+++ b/graylog2-web-interface/src/components/streamrules/CollapsibleStreamRuleList.jsx
@@ -4,21 +4,22 @@ import { Alert, Collapse } from 'react-bootstrap';
 
 import StreamRuleList from 'components/streamrules//StreamRuleList';
 
-const CollapsibleStreamRuleList = React.createClass({
-  propTypes: {
+class CollapsibleStreamRuleList extends React.Component {
+  static propTypes = {
     permissions: PropTypes.array.isRequired,
     stream: PropTypes.object.isRequired,
     streamRuleTypes: PropTypes.array.isRequired,
-  },
-  getInitialState() {
-    return {
-      expanded: false,
-    };
-  },
-  _onHandleToggle(e) {
+  };
+
+  state = {
+    expanded: false,
+  };
+
+  _onHandleToggle = (e) => {
     e.preventDefault();
     this.setState({ expanded: !this.state.expanded });
-  },
+  };
+
   render() {
     const text = this.state.expanded ? 'Hide' : 'Show';
 
@@ -34,7 +35,7 @@ const CollapsibleStreamRuleList = React.createClass({
         </Collapse>
       </span>
     );
-  },
-});
+  }
+}
 
 export default CollapsibleStreamRuleList;

--- a/graylog2-web-interface/src/components/streamrules/HumanReadableStreamRule.jsx
+++ b/graylog2-web-interface/src/components/streamrules/HumanReadableStreamRule.jsx
@@ -1,23 +1,26 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 
-const HumanReadableStreamRule = React.createClass({
-  propTypes: {
+class HumanReadableStreamRule extends React.Component {
+  static propTypes = {
     streamRule: PropTypes.object.isRequired,
     streamRuleTypes: PropTypes.array.isRequired,
-  },
-  EMPTY_TAG: '<empty>',
-  FIELD_PRESENCE_RULE_TYPE: 5,
-  ALWAYS_MATCH_RULE_TYPE: 7,
-  _getTypeForInteger(type, streamRuleTypes) {
+  };
+
+  EMPTY_TAG = '<empty>';
+  FIELD_PRESENCE_RULE_TYPE = 5;
+  ALWAYS_MATCH_RULE_TYPE = 7;
+
+  _getTypeForInteger = (type, streamRuleTypes) => {
     if (streamRuleTypes) {
       return streamRuleTypes.filter((streamRuleType) => {
         return String(streamRuleType.id) === String(type);
       })[0];
     }
     return undefined;
-  },
-  _formatRuleValue(streamRule) {
+  };
+
+  _formatRuleValue = (streamRule) => {
     if (String(streamRule.type) !== String(this.FIELD_PRESENCE_RULE_TYPE)) {
       if (streamRule.value) {
         return streamRule.value;
@@ -26,13 +29,15 @@ const HumanReadableStreamRule = React.createClass({
     }
 
     return null;
-  },
-  _formatRuleField(streamRule) {
+  };
+
+  _formatRuleField = (streamRule) => {
     if (streamRule.field) {
       return streamRule.field;
     }
     return this.EMPTY_TAG;
-  },
+  };
+
   render() {
     const streamRule = this.props.streamRule;
     const streamRuleType = this._getTypeForInteger(streamRule.type, this.props.streamRuleTypes);
@@ -46,7 +51,7 @@ const HumanReadableStreamRule = React.createClass({
     return (
       <span>Field <em>{this._formatRuleField(streamRule)}</em> must {negation}{longDesc} <em>{this._formatRuleValue(streamRule)}</em></span>
     );
-  },
-});
+  }
+}
 
 export default HumanReadableStreamRule;

--- a/graylog2-web-interface/src/components/streamrules/StreamRule.jsx
+++ b/graylog2-web-interface/src/components/streamrules/StreamRule.jsx
@@ -1,6 +1,8 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 
+import createReactClass from 'create-react-class';
+
 import PermissionsMixin from 'util/PermissionsMixin';
 import StreamRuleForm from 'components/streamrules/StreamRuleForm';
 import HumanReadableStreamRule from 'components/streamrules//HumanReadableStreamRule';
@@ -10,7 +12,9 @@ const StreamRulesStore = StoreProvider.getStore('StreamRules');
 
 import UserNotification from 'util/UserNotification';
 
-const StreamRule = React.createClass({
+const StreamRule = createReactClass({
+  displayName: 'StreamRule',
+
   propTypes: {
     matchData: PropTypes.array,
     onDelete: PropTypes.func,
@@ -20,11 +24,14 @@ const StreamRule = React.createClass({
     streamRule: PropTypes.object.isRequired,
     streamRuleTypes: PropTypes.array.isRequired,
   },
+
   mixins: [PermissionsMixin],
+
   _onEdit(event) {
     event.preventDefault();
     this.refs.streamRuleForm.open();
   },
+
   _onDelete(event) {
     event.preventDefault();
     if (window.confirm('Do you really want to delete this stream rule?')) {
@@ -36,6 +43,7 @@ const StreamRule = React.createClass({
       });
     }
   },
+
   _onSubmit(streamRuleId, data) {
     StreamRulesStore.update(this.props.stream.id, streamRuleId, data, () => {
       if (this.props.onSubmit) {
@@ -44,6 +52,7 @@ const StreamRule = React.createClass({
       UserNotification.success('Stream rule has been successfully updated.', 'Success');
     });
   },
+
   _formatActionItems() {
     return (
       <span>
@@ -56,9 +65,11 @@ const StreamRule = React.createClass({
       </span>
     );
   },
+
   _getMatchDataClassNames() {
     return (this.props.matchData.rules[this.props.streamRule.id] ? 'alert-success' : 'alert-danger');
   },
+
   render() {
     const streamRule = this.props.streamRule;
     const streamRuleTypes = this.props.streamRuleTypes;

--- a/graylog2-web-interface/src/components/streamrules/StreamRuleForm.jsx
+++ b/graylog2-web-interface/src/components/streamrules/StreamRuleForm.jsx
@@ -12,28 +12,28 @@ import FormsUtils from 'util/FormsUtils';
 
 import HumanReadableStreamRule from 'components/streamrules//HumanReadableStreamRule';
 
-const StreamRuleForm = React.createClass({
-  propTypes: {
+class StreamRuleForm extends React.Component {
+  static propTypes = {
     onSubmit: PropTypes.func.isRequired,
     streamRule: PropTypes.object,
     streamRuleTypes: PropTypes.array.isRequired,
     title: PropTypes.string.isRequired,
-  },
-  getDefaultProps() {
-    return {
-      streamRule: { field: '', type: 1, value: '', inverted: false, description: '' },
-    };
-  },
-  getInitialState() {
-    return this.props.streamRule;
-  },
-  FIELD_PRESENCE_RULE_TYPE: 5,
-  ALWAYS_MATCH_RULE_TYPE: 7,
-  modal: undefined,
-  _resetValues() {
+  };
+
+  static defaultProps = {
+    streamRule: { field: '', type: 1, value: '', inverted: false, description: '' },
+  };
+
+  state = this.props.streamRule;
+  FIELD_PRESENCE_RULE_TYPE = 5;
+  ALWAYS_MATCH_RULE_TYPE = 7;
+  modal = undefined;
+
+  _resetValues = () => {
     this.setState(this.props.streamRule);
-  },
-  _onSubmit() {
+  };
+
+  _onSubmit = () => {
     if (this.state.type === this.ALWAYS_MATCH_RULE_TYPE) {
       this.state.field = '';
     }
@@ -42,25 +42,30 @@ const StreamRuleForm = React.createClass({
     }
     this.props.onSubmit(this.props.streamRule.id, this.state);
     this.modal.close();
-  },
-  _formatStreamRuleType(streamRuleType) {
+  };
+
+  _formatStreamRuleType = (streamRuleType) => {
     return (
       <option key={`streamRuleType${streamRuleType.id}`}
               value={streamRuleType.id}>{streamRuleType.short_desc}</option>
     );
-  },
-  open() {
+  };
+
+  open = () => {
     this._resetValues();
     this.modal.open();
-  },
-  close() {
+  };
+
+  close = () => {
     this.modal.close();
-  },
-  handleChange(event) {
+  };
+
+  handleChange = (event) => {
     const change = {};
     change[event.target.name] = FormsUtils.getValueFromInput(event.target);
     this.setState(change);
-  },
+  };
+
   render() {
     const { field, type, value, inverted, description } = this.state;
 
@@ -111,7 +116,7 @@ const StreamRuleForm = React.createClass({
         </div>
       </BootstrapModalForm>
     );
-  },
-});
+  }
+}
 
 export default StreamRuleForm;

--- a/graylog2-web-interface/src/components/streamrules/StreamRuleList.jsx
+++ b/graylog2-web-interface/src/components/streamrules/StreamRuleList.jsx
@@ -4,17 +4,17 @@ import React from 'react';
 import StreamRule from 'components/streamrules/StreamRule';
 import { Spinner } from 'components/common';
 
-const StreamRuleList = React.createClass({
-  propTypes: {
+class StreamRuleList extends React.Component {
+  static propTypes = {
     matchData: PropTypes.object,
     onSubmit: PropTypes.func,
     onDelete: PropTypes.func,
     permissions: PropTypes.array.isRequired,
     stream: PropTypes.object.isRequired,
     streamRuleTypes: PropTypes.array.isRequired,
-  },
+  };
 
-  _formatStreamRules(streamRules) {
+  _formatStreamRules = (streamRules) => {
     if (streamRules && streamRules.length > 0) {
       return streamRules.map((streamRule) => {
         return (
@@ -25,7 +25,8 @@ const StreamRuleList = React.createClass({
       });
     }
     return <li>No rules defined.</li>;
-  },
+  };
+
   render() {
     if (this.props.stream) {
       const streamRules = this._formatStreamRules(this.props.stream.rules);
@@ -38,7 +39,7 @@ const StreamRuleList = React.createClass({
     return (
       <Spinner />
     );
-  },
-});
+  }
+}
 
 export default StreamRuleList;

--- a/graylog2-web-interface/src/components/streamrules/StreamRulesEditor.jsx
+++ b/graylog2-web-interface/src/components/streamrules/StreamRulesEditor.jsx
@@ -15,28 +15,30 @@ import StoreProvider from 'injection/StoreProvider';
 const StreamsStore = StoreProvider.getStore('Streams');
 const StreamRulesStore = StoreProvider.getStore('StreamRules');
 
-const StreamRulesEditor = React.createClass({
-  propTypes() {
+class StreamRulesEditor extends React.Component {
+  static propTypes() {
     return {
       currentUser: PropTypes.object.isRequired,
       streamId: PropTypes.string.isRequired,
       messageId: PropTypes.string,
       index: PropTypes.string,
     };
-  },
-  getInitialState() {
-    return {};
-  },
+  }
+
+  state = {};
+
   componentDidMount() {
     this.loadData();
     StreamsStore.onChange(this.loadData);
     StreamRulesStore.onChange(this.loadData);
-  },
+  }
+
   componentWillUnmount() {
     StreamsStore.unregister(this.loadData);
     StreamRulesStore.unregister(this.loadData);
-  },
-  onMessageLoaded(message) {
+  }
+
+  onMessageLoaded = (message) => {
     this.setState({ message: message });
     if (message !== undefined) {
       StreamsStore.testMatch(this.props.streamId, { message: message.fields }, (resultData) => {
@@ -45,8 +47,9 @@ const StreamRulesEditor = React.createClass({
     } else {
       this.setState({ matchData: undefined });
     }
-  },
-  loadData() {
+  };
+
+  loadData = () => {
     StreamRulesStore.types().then((types) => {
       this.setState({ streamRuleTypes: types });
     });
@@ -58,18 +61,22 @@ const StreamRulesEditor = React.createClass({
     if (this.state.message) {
       this.onMessageLoaded(this.state.message);
     }
-  },
-  _onStreamRuleFormSubmit(streamRuleId, data) {
+  };
+
+  _onStreamRuleFormSubmit = (streamRuleId, data) => {
     StreamRulesStore.create(this.props.streamId, data, () => {});
-  },
-  _onAddStreamRule(event) {
+  };
+
+  _onAddStreamRule = (event) => {
     event.preventDefault();
     this.refs.newStreamRuleForm.open();
-  },
-  _getListClassName(matchData) {
+  };
+
+  _getListClassName = (matchData) => {
     return (matchData.matches ? 'success' : 'danger');
-  },
-  _explainMatchResult() {
+  };
+
+  _explainMatchResult = () => {
     if (this.state.matchData) {
       if (this.state.matchData.matches) {
         return (
@@ -83,7 +90,8 @@ const StreamRulesEditor = React.createClass({
           </span>);
     }
     return ('Please load a message to check if it would match against these rules and therefore be routed into this stream.');
-  },
+  };
+
   render() {
     const styles = (this.state.matchData ? this._getListClassName(this.state.matchData) : 'info');
     if (this.state.stream && this.state.streamRuleTypes) {
@@ -139,7 +147,7 @@ const StreamRulesEditor = React.createClass({
       );
     }
     return (<div className="row content"><div style={{ marginLeft: 10 }}><Spinner /></div></div>);
-  },
-});
+  }
+}
 
 export default StreamRulesEditor;

--- a/graylog2-web-interface/src/components/streams/CreateStreamButton.jsx
+++ b/graylog2-web-interface/src/components/streams/CreateStreamButton.jsx
@@ -3,23 +3,24 @@ import React from 'react';
 import { Button } from 'react-bootstrap';
 import StreamForm from 'components/streams/StreamForm';
 
-const CreateStreamButton = React.createClass({
-  propTypes: {
+class CreateStreamButton extends React.Component {
+  static propTypes = {
     buttonText: PropTypes.string,
     bsStyle: PropTypes.string,
     bsSize: PropTypes.string,
     className: PropTypes.string,
     onSave: PropTypes.func.isRequired,
     indexSets: PropTypes.array.isRequired,
-  },
-  getDefaultProps() {
-    return {
-      buttonText: 'Create Stream',
-    };
-  },
-  onClick() {
+  };
+
+  static defaultProps = {
+    buttonText: 'Create Stream',
+  };
+
+  onClick = () => {
     this.refs.streamForm.open();
-  },
+  };
+
   render() {
     return (
       <span>
@@ -31,7 +32,7 @@ const CreateStreamButton = React.createClass({
                     onSubmit={this.props.onSave} />
       </span>
     );
-  },
-});
+  }
+}
 
 export default CreateStreamButton;

--- a/graylog2-web-interface/src/components/streams/Stream.jsx
+++ b/graylog2-web-interface/src/components/streams/Stream.jsx
@@ -1,5 +1,6 @@
 import PropTypes from 'prop-types';
 import React from 'react';
+import createReactClass from 'create-react-class';
 import StreamThroughput from './StreamThroughput';
 import StreamControls from './StreamControls';
 import StreamStateBadge from './StreamStateBadge';
@@ -20,7 +21,9 @@ import Routes from 'routing/Routes';
 
 import style from './Stream.css';
 
-const Stream = React.createClass({
+const Stream = createReactClass({
+  displayName: 'Stream',
+
   propTypes() {
     return {
       stream: PropTypes.object.isRequired,
@@ -30,6 +33,7 @@ const Stream = React.createClass({
       indexSets: PropTypes.array.isRequired,
     };
   },
+
   mixins: [PermissionsMixin],
 
   getInitialState() {
@@ -60,6 +64,7 @@ const Stream = React.createClass({
       </span>
     );
   },
+
   _onDelete(stream) {
     if (window.confirm('Do you really want to remove this stream?')) {
       StreamsStore.remove(stream.id, (response) => {
@@ -68,23 +73,27 @@ const Stream = React.createClass({
       });
     }
   },
+
   _onResume() {
     this.setState({ loading: true });
     StreamsStore.resume(this.props.stream.id, response => response)
       .finally(() => this.setState({ loading: false }));
   },
+
   _onUpdate(streamId, stream) {
     StreamsStore.update(streamId, stream, (response) => {
       UserNotification.success(`Stream '${stream.title}' was updated successfully.`, 'Success');
       return response;
     });
   },
+
   _onClone(streamId, stream) {
     StreamsStore.cloneStream(streamId, stream, (response) => {
       UserNotification.success(`Stream was successfully cloned as '${stream.title}'.`, 'Success');
       return response;
     });
   },
+
   _onPause() {
     if (window.confirm(`Do you really want to pause stream '${this.props.stream.title}'?`)) {
       this.setState({ loading: true });
@@ -92,12 +101,15 @@ const Stream = React.createClass({
         .finally(() => this.setState({ loading: false }));
     }
   },
+
   _onQuickAdd() {
     this.refs.quickAddStreamRuleForm.open();
   },
+
   _onSaveStreamRule(streamRuleId, streamRule) {
     StreamRulesStore.create(this.props.stream.id, streamRule, () => UserNotification.success('Stream rule was created successfully.', 'Success'));
   },
+
   render() {
     const stream = this.props.stream;
     const permissions = this.props.permissions;

--- a/graylog2-web-interface/src/components/streams/StreamComponent.jsx
+++ b/graylog2-web-interface/src/components/streams/StreamComponent.jsx
@@ -13,15 +13,14 @@ import Spinner from 'components/common/Spinner';
 
 import CreateStreamButton from './CreateStreamButton';
 
-const StreamComponent = React.createClass({
-  propTypes: {
+class StreamComponent extends React.Component {
+  static propTypes = {
     currentUser: PropTypes.object.isRequired,
     onStreamSave: PropTypes.func.isRequired,
     indexSets: PropTypes.array.isRequired,
-  },
-  getInitialState() {
-    return {};
-  },
+  };
+
+  state = {};
 
   componentDidMount() {
     this.loadData();
@@ -30,41 +29,41 @@ const StreamComponent = React.createClass({
     });
     StreamsStore.onChange(this.loadData);
     StreamRulesStore.onChange(this.loadData);
-  },
+  }
 
   componentDidUpdate() {
     if (this.state.filteredStreams === null) {
       this._filterStreams();
     }
-  },
+  }
 
   componentWillUnmount() {
     StreamsStore.unregister(this.loadData);
     StreamRulesStore.unregister(this.loadData);
-  },
+  }
 
-  loadData() {
+  loadData = () => {
     StreamsStore.load((streams) => {
       this.setState({
         streams: streams,
         filteredStreams: null,
       });
     });
-  },
+  };
 
-  _filterStreams() {
+  _filterStreams = () => {
     if (this.refs.streamFilter) {
       this.refs.streamFilter.filterData();
     }
-  },
+  };
 
-  _updateFilteredStreams(filteredStreams) {
+  _updateFilteredStreams = (filteredStreams) => {
     this.setState({ filteredStreams: filteredStreams });
-  },
+  };
 
-  _isLoading() {
+  _isLoading = () => {
     return !(this.state.streams && this.state.streamRuleTypes);
-  },
+  };
 
   render() {
     if (this._isLoading()) {
@@ -117,7 +116,7 @@ const StreamComponent = React.createClass({
         </Row>
       </div>
     );
-  },
-});
+  }
+}
 
 export default StreamComponent;

--- a/graylog2-web-interface/src/components/streams/StreamControls.jsx
+++ b/graylog2-web-interface/src/components/streams/StreamControls.jsx
@@ -1,5 +1,6 @@
 import PropTypes from 'prop-types';
 import React from 'react';
+import createReactClass from 'create-react-class';
 import { DropdownButton, MenuItem } from 'react-bootstrap';
 
 import { IfPermitted } from 'components/common';
@@ -9,7 +10,9 @@ import PermissionsMixin from 'util/PermissionsMixin';
 import StoreProvider from 'injection/StoreProvider';
 const StartpageStore = StoreProvider.getStore('Startpage');
 
-const StreamControls = React.createClass({
+const StreamControls = createReactClass({
+  displayName: 'StreamControls',
+
   propTypes: {
     stream: PropTypes.object.isRequired,
     user: PropTypes.object.isRequired,
@@ -20,33 +23,42 @@ const StreamControls = React.createClass({
     onUpdate: PropTypes.func.isRequired,
     isDefaultStream: PropTypes.bool,
   },
+
   mixins: [PermissionsMixin],
+
   getInitialState() {
     return {};
   },
+
   _onDelete(_, event) {
     event.preventDefault();
     this.props.onDelete(this.props.stream);
   },
+
   _onEdit(_, event) {
     event.preventDefault();
     this.refs.streamForm.open();
   },
+
   _onClone(_, event) {
     event.preventDefault();
     this.refs.cloneForm.open();
   },
+
   _onCloneSubmit(_, stream) {
     this.props.onClone(this.props.stream.id, stream);
   },
+
   _onQuickAdd(_, event) {
     event.preventDefault();
     this.props.onQuickAdd(this.props.stream.id);
   },
+
   _setStartpage(_, event) {
     event.preventDefault();
     StartpageStore.set(this.props.user.username, 'stream', this.props.stream.id);
   },
+
   render() {
     const stream = this.props.stream;
 

--- a/graylog2-web-interface/src/components/streams/StreamForm.jsx
+++ b/graylog2-web-interface/src/components/streams/StreamForm.jsx
@@ -8,35 +8,29 @@ import FormsUtils from 'util/FormsUtils';
 
 const { IndexSetsActions } = CombinedProvider.get('IndexSets');
 
-const StreamForm = React.createClass({
-  propTypes: {
+class StreamForm extends React.Component {
+  static propTypes = {
     onSubmit: PropTypes.func.isRequired,
     stream: PropTypes.object.isRequired,
     title: PropTypes.string.isRequired,
     indexSets: PropTypes.array.isRequired,
-  },
+  };
 
-  getDefaultProps() {
-    return {
-      stream: {
-        title: '',
-        description: '',
-        remove_matches_from_default_stream: false,
-      },
-    };
-  },
+  static defaultProps = {
+    stream: {
+      title: '',
+      description: '',
+      remove_matches_from_default_stream: false,
+    },
+  };
 
-  getInitialState() {
-    return this._getValuesFromProps(this.props);
-  },
+  modal = undefined;
 
-  modal: undefined,
-
-  _resetValues() {
+  _resetValues = () => {
     this.setState(this._getValuesFromProps(this.props));
-  },
+  };
 
-  _getValuesFromProps(props) {
+  _getValuesFromProps = (props) => {
     let defaultIndexSetId = props.stream.index_set_id;
     if (!defaultIndexSetId && props.indexSets && props.indexSets.length > 0) {
       const defaultIndexSet = props.indexSets.find(indexSet => indexSet.default);
@@ -51,9 +45,9 @@ const StreamForm = React.createClass({
       removeMatchesFromDefaultStream: props.stream.remove_matches_from_default_stream,
       indexSetId: defaultIndexSetId,
     };
-  },
+  };
 
-  _onSubmit() {
+  _onSubmit = () => {
     this.props.onSubmit(this.props.stream.id,
       {
         title: this.state.title,
@@ -62,33 +56,35 @@ const StreamForm = React.createClass({
         index_set_id: this.state.indexSetId,
       });
     this.modal.close();
-  },
+  };
 
-  open() {
+  open = () => {
     this._resetValues();
     IndexSetsActions.list(false);
     this.modal.open();
-  },
+  };
 
-  close() {
+  close = () => {
     this.modal.close();
-  },
+  };
 
-  _formatSelectOptions() {
+  _formatSelectOptions = () => {
     return this.props.indexSets.filter(indexSet => indexSet.writable).map((indexSet) => {
       return { value: indexSet.id, label: indexSet.title };
     });
-  },
+  };
 
-  _onIndexSetSelect(selection) {
+  _onIndexSetSelect = (selection) => {
     this.setState({ indexSetId: selection });
-  },
+  };
 
-  handleChange(event) {
+  handleChange = (event) => {
     const change = {};
     change[event.target.name] = FormsUtils.getValueFromInput(event.target);
     this.setState(change);
-  },
+  };
+
+  state = this._getValuesFromProps(this.props);
 
   render() {
     const { title, description, removeMatchesFromDefaultStream, indexSetId } = this.state;
@@ -143,7 +139,7 @@ const StreamForm = React.createClass({
                help={<span>Remove messages that match this stream from the &lsquo;All messages&rsquo; stream which is assigned to every message by default.</span>} />
       </BootstrapModalForm>
     );
-  },
-});
+  }
+}
 
 export default StreamForm;

--- a/graylog2-web-interface/src/components/streams/StreamLink.jsx
+++ b/graylog2-web-interface/src/components/streams/StreamLink.jsx
@@ -3,12 +3,12 @@ import { Link } from 'react-router';
 
 import Routes from 'routing/Routes';
 
-const StreamLink = React.createClass({
+class StreamLink extends React.Component {
   render() {
     const stream = this.props.stream;
     const route = Routes.stream_search(stream.id);
     return <Link to={route}>{stream.title}</Link>;
-  },
-});
+  }
+}
 
 export default StreamLink;

--- a/graylog2-web-interface/src/components/streams/StreamList.jsx
+++ b/graylog2-web-interface/src/components/streams/StreamList.jsx
@@ -1,11 +1,14 @@
 import PropTypes from 'prop-types';
 import React from 'react';
+import createReactClass from 'create-react-class';
 import { Alert } from 'react-bootstrap';
 
 import Stream from './Stream';
 import PermissionsMixin from 'util/PermissionsMixin';
 
-const StreamList = React.createClass({
+const StreamList = createReactClass({
+  displayName: 'StreamList',
+
   propTypes: {
     streams: PropTypes.array.isRequired,
     streamRuleTypes: PropTypes.array.isRequired,
@@ -14,6 +17,7 @@ const StreamList = React.createClass({
     permissions: PropTypes.array.isRequired,
     onStreamSave: PropTypes.func.isRequired,
   },
+
   mixins: [PermissionsMixin],
 
   getInitialState() {

--- a/graylog2-web-interface/src/components/streams/StreamStateBadge.jsx
+++ b/graylog2-web-interface/src/components/streams/StreamStateBadge.jsx
@@ -2,10 +2,11 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import { Label } from 'react-bootstrap';
 
-const StreamStateBadge = React.createClass({
-  propTypes: {
+class StreamStateBadge extends React.Component {
+  static propTypes = {
     stream: PropTypes.object.isRequired,
-  },
+  };
+
   render() {
     if (this.props.stream.is_default) {
       return <Label bsStyle="primary">Default</Label>;
@@ -16,7 +17,7 @@ const StreamStateBadge = React.createClass({
     }
 
     return <Label bsStyle="warning">Stopped</Label>;
-  },
-});
+  }
+}
 
 export default StreamStateBadge;

--- a/graylog2-web-interface/src/components/streams/StreamThroughput.jsx
+++ b/graylog2-web-interface/src/components/streams/StreamThroughput.jsx
@@ -1,5 +1,6 @@
 import PropTypes from 'prop-types';
 import React from 'react';
+import createReactClass from 'create-react-class';
 import Reflux from 'reflux';
 
 import StoreProvider from 'injection/StoreProvider';
@@ -10,20 +11,27 @@ const MetricsActions = ActionsProvider.getActions('Metrics');
 
 import { Spinner } from 'components/common';
 
-const StreamThroughput = React.createClass({
+const StreamThroughput = createReactClass({
+  displayName: 'StreamThroughput',
+
   propTypes: {
     streamId: PropTypes.string.isRequired,
   },
+
   mixins: [Reflux.connect(MetricsStore)],
+
   componentWillMount() {
     MetricsActions.addGlobal(this._metricName());
   },
+
   componentWillUnmount() {
     MetricsActions.removeGlobal(this._metricName());
   },
+
   _metricName() {
     return `org.graylog2.plugin.streams.Stream.${this.props.streamId}.incomingMessages.1-sec-rate`;
   },
+
   _calculateThroughput() {
     return Object.keys(this.state.metrics)
       .map((nodeId) => {
@@ -32,6 +40,7 @@ const StreamThroughput = React.createClass({
       })
       .reduce((throughput1, throughput2) => throughput1 + throughput2, 0);
   },
+
   render() {
     if (!this.state.metrics) {
       return <Spinner />;

--- a/graylog2-web-interface/src/components/support/ContactUs.jsx
+++ b/graylog2-web-interface/src/components/support/ContactUs.jsx
@@ -4,7 +4,7 @@ import { Col, Row } from 'react-bootstrap';
 import DocumentationLink from 'components/support/DocumentationLink';
 import DocsHelper from 'util/DocsHelper';
 
-const ContactUs = React.createClass({
+class ContactUs extends React.Component {
   render() {
     return (
       <Row className="content">
@@ -34,7 +34,7 @@ const ContactUs = React.createClass({
         </Col>
       </Row>
     );
-  },
-});
+  }
+}
 
 export default ContactUs;

--- a/graylog2-web-interface/src/components/support/DocumentationLink.jsx
+++ b/graylog2-web-interface/src/components/support/DocumentationLink.jsx
@@ -2,19 +2,20 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import DocsHelper from 'util/DocsHelper';
 
-const DocumentationLink = React.createClass({
-  propTypes: {
+class DocumentationLink extends React.Component {
+  static propTypes = {
     page: PropTypes.string.isRequired,
     text: PropTypes.node.isRequired,
     title: PropTypes.string,
-  },
+  };
+
   render() {
     return (
       <a href={DocsHelper.toString(this.props.page)} title={this.props.title} target="_blank">
         {this.props.text}
       </a>
     );
-  },
-});
+  }
+}
 
 export default DocumentationLink;

--- a/graylog2-web-interface/src/components/support/SmallSupportLink.jsx
+++ b/graylog2-web-interface/src/components/support/SmallSupportLink.jsx
@@ -1,10 +1,11 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 
-const SmallSupportLink = React.createClass({
-  propTypes: {
+class SmallSupportLink extends React.Component {
+  static propTypes = {
     children: PropTypes.node.isRequired,
-  },
+  };
+
   render() {
     return (
       <p className="description-tooltips description-tooltips-small">
@@ -17,7 +18,7 @@ const SmallSupportLink = React.createClass({
         </strong>
       </p>
     );
-  },
-});
+  }
+}
 
 export default SmallSupportLink;

--- a/graylog2-web-interface/src/components/support/SupportLink.jsx
+++ b/graylog2-web-interface/src/components/support/SupportLink.jsx
@@ -1,11 +1,12 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 
-const SupportLink = React.createClass({
-  propTypes: {
+class SupportLink extends React.Component {
+  static propTypes = {
     small: PropTypes.bool,
     children: PropTypes.node.isRequired,
-  },
+  };
+
   render() {
     const classNames = (this.props.small ? 'fa-stack' : 'fa-stack fa-lg');
     return (
@@ -27,7 +28,7 @@ const SupportLink = React.createClass({
         </tbody>
       </table>
     );
-  },
-});
+  }
+}
 
 export default SupportLink;

--- a/graylog2-web-interface/src/components/systemjobs/SystemJob.jsx
+++ b/graylog2-web-interface/src/components/systemjobs/SystemJob.jsx
@@ -6,15 +6,16 @@ import { LinkToNode, Timestamp } from 'components/common';
 import ActionsProvider from 'injection/ActionsProvider';
 const SystemJobsActions = ActionsProvider.getActions('SystemJobs');
 
-const SystemJob = React.createClass({
-  _onCancel(job) {
+class SystemJob extends React.Component {
+  _onCancel = (job) => {
     return (e) => {
       e.preventDefault();
       if (window.confirm(`Are you sure you want to cancel system job "${job.info}"?`)) {
         SystemJobsActions.cancelJob(job.id);
       }
     };
-  },
+  };
+
   render() {
     const job = this.props.job;
     const progress = job.percent_complete < 100 ?
@@ -35,7 +36,7 @@ const SystemJob = React.createClass({
         {progress}
       </div>
     );
-  },
-});
+  }
+}
 
 export default SystemJob;

--- a/graylog2-web-interface/src/components/systemjobs/SystemJobsComponent.jsx
+++ b/graylog2-web-interface/src/components/systemjobs/SystemJobsComponent.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import createReactClass from 'create-react-class';
 import Reflux from 'reflux';
 import { Col, Row } from 'react-bootstrap';
 
@@ -11,16 +12,20 @@ const SystemJobsActions = ActionsProvider.getActions('SystemJobs');
 import { Spinner } from 'components/common';
 import { SystemJobsList } from 'components/systemjobs';
 
-const SystemJobsComponent = React.createClass({
+const SystemJobsComponent = createReactClass({
+  displayName: 'SystemJobsComponent',
   mixins: [Reflux.connect(SystemJobsStore)],
+
   componentDidMount() {
     SystemJobsActions.list();
 
     this.interval = setInterval(SystemJobsActions.list, 2000);
   },
+
   componentWillUnmount() {
     clearInterval(this.interval);
   },
+
   render() {
     if (!this.state.jobs) {
       return <Spinner />;

--- a/graylog2-web-interface/src/components/systemjobs/SystemJobsList.jsx
+++ b/graylog2-web-interface/src/components/systemjobs/SystemJobsList.jsx
@@ -4,17 +4,19 @@ import { Alert } from 'react-bootstrap';
 
 import { SystemJob } from 'components/systemjobs';
 
-const SystemJobsList = React.createClass({
-  propTypes: {
+class SystemJobsList extends React.Component {
+  static propTypes = {
     jobs: PropTypes.arrayOf(PropTypes.object).isRequired,
-  },
-  _formatSystemJob(job) {
+  };
+
+  _formatSystemJob = (job) => {
     return (
       <div className="systemjob systemjob-progress systemjob-active" key={`job-${job.id}`}>
         <SystemJob job={job} />
       </div>
     );
-  },
+  };
+
   render() {
     const jobs = this.props.jobs.map(this._formatSystemJob);
     if (jobs.length === 0) {
@@ -30,7 +32,7 @@ const SystemJobsList = React.createClass({
         {jobs}
       </span>
     );
-  },
-});
+  }
+}
 
 export default SystemJobsList;

--- a/graylog2-web-interface/src/components/systemmessages/SystemMessage.jsx
+++ b/graylog2-web-interface/src/components/systemmessages/SystemMessage.jsx
@@ -4,10 +4,11 @@ import moment from 'moment';
 
 import { LinkToNode } from 'components/common';
 
-const SystemMessage = React.createClass({
-  propTypes: {
+class SystemMessage extends React.Component {
+  static propTypes = {
     message: PropTypes.object.isRequired,
-  },
+  };
+
   render() {
     const message = this.props.message;
     return (
@@ -19,7 +20,7 @@ const SystemMessage = React.createClass({
         <td>{message.content}</td>
       </tr>
     );
-  },
-});
+  }
+}
 
 export default SystemMessage;

--- a/graylog2-web-interface/src/components/systemmessages/SystemMessagesComponent.jsx
+++ b/graylog2-web-interface/src/components/systemmessages/SystemMessagesComponent.jsx
@@ -7,27 +7,31 @@ const SystemMessagesStore = StoreProvider.getStore('SystemMessages');
 import { Spinner } from 'components/common';
 import { SystemMessagesList } from 'components/systemmessages';
 
-const SystemMessagesComponent = React.createClass({
-  getInitialState() {
-    return { currentPage: 1 };
-  },
+class SystemMessagesComponent extends React.Component {
+  state = { currentPage: 1 };
+
   componentDidMount() {
     this.loadMessages(this.state.currentPage);
     this.interval = setInterval(() => { this.loadMessages(this.state.currentPage); }, 1000);
-  },
+  }
+
   componentWillUnmount() {
     clearInterval(this.interval);
-  },
-  PER_PAGE: 30,
-  loadMessages(page) {
+  }
+
+  PER_PAGE = 30;
+
+  loadMessages = (page) => {
     SystemMessagesStore.all(page).then((response) => {
       this.setState(response);
     });
-  },
-  _onSelected(selectedPage) {
+  };
+
+  _onSelected = (selectedPage) => {
     this.setState({ currentPage: selectedPage });
     this.loadMessages(selectedPage);
-  },
+  };
+
   render() {
     let content;
     if (this.state.total && this.state.messages) {
@@ -66,7 +70,7 @@ const SystemMessagesComponent = React.createClass({
         </Col>
       </Row>
     );
-  },
-});
+  }
+}
 
 export default SystemMessagesComponent;

--- a/graylog2-web-interface/src/components/systemmessages/SystemMessagesList.jsx
+++ b/graylog2-web-interface/src/components/systemmessages/SystemMessagesList.jsx
@@ -4,10 +4,11 @@ import { Table } from 'react-bootstrap';
 
 import { SystemMessage } from 'components/systemmessages';
 
-const SystemMessagesList = React.createClass({
-  propTypes: {
+class SystemMessagesList extends React.Component {
+  static propTypes = {
     messages: PropTypes.arrayOf(PropTypes.object).isRequired,
-  },
+  };
+
   render() {
     return (
       <Table className="system-messages" striped hover condensed>
@@ -24,7 +25,7 @@ const SystemMessagesList = React.createClass({
         </tbody>
       </Table>
     );
-  },
-});
+  }
+}
 
 export default SystemMessagesList;

--- a/graylog2-web-interface/src/components/throughput/GlobalThroughput.jsx
+++ b/graylog2-web-interface/src/components/throughput/GlobalThroughput.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import createReactClass from 'create-react-class';
 import Reflux from 'reflux';
 import numeral from 'numeral';
 
@@ -7,8 +8,10 @@ const GlobalThroughputStore = StoreProvider.getStore('GlobalThroughput');
 
 import { Spinner } from 'components/common';
 
-const GlobalThroughput = React.createClass({
+const GlobalThroughput = createReactClass({
+  displayName: 'GlobalThroughput',
   mixins: [Reflux.connect(GlobalThroughputStore)],
+
   render() {
     if (!this.state.throughput) {
       return <Spinner />;

--- a/graylog2-web-interface/src/components/throughput/NodeThroughput.jsx
+++ b/graylog2-web-interface/src/components/throughput/NodeThroughput.jsx
@@ -1,5 +1,6 @@
 import PropTypes from 'prop-types';
 import React from 'react';
+import createReactClass from 'create-react-class';
 import Reflux from 'reflux';
 import numeral from 'numeral';
 
@@ -14,17 +15,22 @@ import ActionsProvider from 'injection/ActionsProvider';
 const MetricsActions = ActionsProvider.getActions('Metrics');
 
 // TODO this is a copy of GlobalTroughput, it just renders differently and only targets a single node.
-const NodeThroughput = React.createClass({
+const NodeThroughput = createReactClass({
+  displayName: 'NodeThroughput',
+
   propTypes: {
     nodeId: PropTypes.string.isRequired,
     longFormat: PropTypes.bool,
   },
+
   mixins: [Reflux.connect(MetricsStore)],
+
   getDefaultProps() {
     return {
       longFormat: false,
     };
   },
+
   componentWillMount() {
     this.metricNames = {
       totalIn: 'org.graylog2.throughput.input.1-sec-rate',
@@ -33,12 +39,15 @@ const NodeThroughput = React.createClass({
 
     Object.keys(this.metricNames).forEach(metricShortName => MetricsActions.add(this.props.nodeId, this.metricNames[metricShortName]));
   },
+
   componentWillUnmount() {
     Object.keys(this.metricNames).forEach(metricShortName => MetricsActions.remove(this.props.nodeId, this.metricNames[metricShortName]));
   },
+
   _isLoading() {
     return !this.state.metrics;
   },
+
   _formatThroughput(metrics) {
     if (this.props.longFormat) {
       return (
@@ -54,6 +63,7 @@ const NodeThroughput = React.createClass({
         </span>
     );
   },
+
   render() {
     if (this._isLoading()) {
       return <Spinner text="Loading throughput..." />;

--- a/graylog2-web-interface/src/components/times/TimesList.jsx
+++ b/graylog2-web-interface/src/components/times/TimesList.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import createReactClass from 'create-react-class';
 import Reflux from 'reflux';
 import { Col, Row } from 'react-bootstrap';
 import moment from 'moment';
@@ -10,17 +11,22 @@ const SystemStore = StoreProvider.getStore('System');
 
 import { Spinner, Timestamp } from 'components/common';
 
-const TimesList = React.createClass({
+const TimesList = createReactClass({
+  displayName: 'TimesList',
   mixins: [Reflux.connect(CurrentUserStore), Reflux.connect(SystemStore)],
+
   getInitialState() {
     return { time: moment() };
   },
+
   componentDidMount() {
     this.interval = setInterval(() => this.setState(this.getInitialState()), 1000);
   },
+
   componentWillUnmount() {
     clearInterval(this.interval);
   },
+
   render() {
     if (!this.state.system) {
       return <Spinner />;

--- a/graylog2-web-interface/src/components/users/EditRole.jsx
+++ b/graylog2-web-interface/src/components/users/EditRole.jsx
@@ -1,5 +1,6 @@
 import PropTypes from 'prop-types';
 import React from 'react';
+import createReactClass from 'create-react-class';
 import Immutable from 'immutable';
 import { Alert, Button, Col, ControlLabel, FormGroup, HelpBlock, Row } from 'react-bootstrap';
 
@@ -7,7 +8,9 @@ import { Input } from 'components/bootstrap';
 import PermissionSelector from 'components/users/PermissionSelector';
 import PermissionsMixin from 'util/PermissionsMixin';
 
-const EditRole = React.createClass({
+const EditRole = createReactClass({
+  displayName: 'EditRole',
+
   propTypes: {
     initialRole: PropTypes.object,
     onSave: PropTypes.func.isRequired,
@@ -43,6 +46,7 @@ const EditRole = React.createClass({
     role.name = ev.target.value;
     this.setState({ role: this.state.role });
   },
+
   _setDescription(ev) {
     const role = this.state.role;
     role.description = ev.target.value;

--- a/graylog2-web-interface/src/components/users/EditRolesForm.jsx
+++ b/graylog2-web-interface/src/components/users/EditRolesForm.jsx
@@ -17,21 +17,22 @@ import { Spinner } from 'components/common';
 
 import EditRolesFormStyle from '!style!css!./EditRolesForm.css';
 
-const EditRolesForm = React.createClass({
-  propTypes: {
+class EditRolesForm extends React.Component {
+  static propTypes = {
     user: PropTypes.object.isRequired,
-  },
-  getInitialState() {
-    return {
-      newRoles: null,
-    };
-  },
+  };
+
+  state = {
+    newRoles: null,
+  };
+
   componentDidMount() {
     RolesStore.loadRoles().then((roles) => {
       this.setState({ roles: roles.sort((r1, r2) => r1.name.localeCompare(r2.name)) });
     });
-  },
-  _updateRoles(evt) {
+  }
+
+  _updateRoles = (evt) => {
     evt.preventDefault();
     if (confirm(`Really update roles for "${this.props.user.username}"?`)) {
       const roles = this.refs.roles.getValue().filter(value => value !== '');
@@ -44,14 +45,17 @@ const EditRolesForm = React.createClass({
         UserNotification.error('Updating roles failed.', 'Error!');
       });
     }
-  },
-  _onCancel() {
+  };
+
+  _onCancel = () => {
     history.push(Routes.SYSTEM.AUTHENTICATION.USERS.LIST);
-  },
-  _onValueChange(newRoles) {
+  };
+
+  _onValueChange = (newRoles) => {
     const roles = newRoles.split(',');
     this.setState({ newRoles: roles });
-  },
+  };
+
   render() {
     const user = this.props.user;
     if (!this.state.roles) {
@@ -110,7 +114,7 @@ const EditRolesForm = React.createClass({
         </Col>
       </Row>
     );
-  },
-});
+  }
+}
 
 export default EditRolesForm;

--- a/graylog2-web-interface/src/components/users/NewUserForm.jsx
+++ b/graylog2-web-interface/src/components/users/NewUserForm.jsx
@@ -12,43 +12,41 @@ const UsersStore = StoreProvider.getStore('Users');
 
 import ValidationsUtils from 'util/ValidationsUtils';
 
-const NewUserForm = React.createClass({
-  propTypes: {
+class NewUserForm extends React.Component {
+  static propTypes = {
     roles: PropTypes.array.isRequired,
     onSubmit: PropTypes.func.isRequired,
     onCancel: PropTypes.func.isRequired,
-  },
+  };
 
-  getInitialState() {
-    return {
-      users: [],
-      newRoles: null,
-    };
-  },
+  state = {
+    users: [],
+    newRoles: null,
+  };
 
   componentDidMount() {
     UsersStore.loadUsers().then((users) => {
       this.setState({ users });
     });
-  },
+  }
 
-  _onUsernameChange(event) {
+  _onUsernameChange = (event) => {
     const usernameField = this.refs.username.getInputDOMNode();
     const usernameExists = this.state.users.some(user => user.username === event.target.value);
 
     ValidationsUtils.setFieldValidity(usernameField, usernameExists, 'Username is already taken');
-  },
+  };
 
-  _onPasswordChange() {
+  _onPasswordChange = () => {
     const passwordField = this.refs.password;
     const passwordConfirmField = this.refs.password_repeat;
 
     if (passwordField.value !== '' && passwordConfirmField.value !== '') {
       ValidationsUtils.setFieldValidity(passwordConfirmField, passwordField.value !== passwordConfirmField.value, 'Passwords do not match');
     }
-  },
+  };
 
-  _onSubmit(evt) {
+  _onSubmit = (evt) => {
     evt.preventDefault();
     const result = {};
     Object.keys(this.refs).forEach((ref) => {
@@ -58,12 +56,12 @@ const NewUserForm = React.createClass({
     });
 
     this.props.onSubmit(result);
-  },
+  };
 
-  _onValueChange(newRoles) {
+  _onValueChange = (newRoles) => {
     const roles = newRoles.split(',');
     this.setState({ newRoles: roles });
-  },
+  };
 
   render() {
     const rolesHelp = (
@@ -144,7 +142,7 @@ const NewUserForm = React.createClass({
         </div>
       </form>
     );
-  },
-});
+  }
+}
 
 export default NewUserForm;

--- a/graylog2-web-interface/src/components/users/PermissionSelector.jsx
+++ b/graylog2-web-interface/src/components/users/PermissionSelector.jsx
@@ -6,13 +6,13 @@ import { Button, ButtonGroup, ButtonToolbar, Tab, Tabs } from 'react-bootstrap';
 
 import { TableList } from 'components/common';
 
-const PermissionSelector = React.createClass({
-  propTypes: {
+class PermissionSelector extends React.Component {
+  static propTypes = {
     onChange: PropTypes.func,
     streams: PropTypes.object,
     dashboards: PropTypes.object,
     permissions: PropTypes.object,
-  },
+  };
 
   render() {
     const streamItemButtons = (stream) => {
@@ -99,48 +99,48 @@ const PermissionSelector = React.createClass({
         </Tabs>
       </div>
     );
-  },
+  }
 
   /*
    * onClick actions for single edits
    */
-  _toggleStreamReadPermissions(stream) {
+  _toggleStreamReadPermissions = (stream) => {
     this._toggleReadPermissions('streams', Immutable.Set.of(stream.id));
-  },
+  };
 
-  _toggleStreamEditPermissions(stream) {
+  _toggleStreamEditPermissions = (stream) => {
     this._toggleEditPermissions('streams', Immutable.Set.of(stream.id));
-  },
+  };
 
-  _toggleDashboardReadPermissions(dashboard) {
+  _toggleDashboardReadPermissions = (dashboard) => {
     this._toggleReadPermissions('dashboards', Immutable.Set.of(dashboard.id));
-  },
+  };
 
-  _toggleDashboardEditPermissions(dashboard) {
+  _toggleDashboardEditPermissions = (dashboard) => {
     this._toggleEditPermissions('dashboards', Immutable.Set.of(dashboard.id));
-  },
+  };
 
   /*
    * onClick actions for bulk edits
    */
 
-  _toggleAllStreamsRead(streamIds, clearPermissions) {
+  _toggleAllStreamsRead = (streamIds, clearPermissions) => {
     this._toggleReadPermissions('streams', streamIds, clearPermissions);
-  },
+  };
 
-  _toggleAllStreamsEdit(streamIds, clearPermissions) {
+  _toggleAllStreamsEdit = (streamIds, clearPermissions) => {
     this._toggleEditPermissions('streams', streamIds, clearPermissions);
-  },
+  };
 
-  _toggleAllDashboardsRead(dashboardIds, clearPermissions) {
+  _toggleAllDashboardsRead = (dashboardIds, clearPermissions) => {
     this._toggleReadPermissions('dashboards', dashboardIds, clearPermissions);
-  },
+  };
 
-  _toggleAllDashboardsEdit(dashboardIds, clearPermissions) {
+  _toggleAllDashboardsEdit = (dashboardIds, clearPermissions) => {
     this._toggleEditPermissions('dashboards', dashboardIds, clearPermissions);
-  },
+  };
 
-  _toggleReadPermissions(target, idList, clearPermissions = true) {
+  _toggleReadPermissions = (target, idList, clearPermissions = true) => {
     let added = Immutable.Set.of();
     let deleted = Immutable.Set.of();
 
@@ -155,8 +155,9 @@ const PermissionSelector = React.createClass({
       }
     }, this);
     this.props.onChange(added, deleted);
-  },
-  _toggleEditPermissions(target, idList, clearPermissions = true) {
+  };
+
+  _toggleEditPermissions = (target, idList, clearPermissions = true) => {
     let added = Immutable.Set.of();
     let deleted = Immutable.Set.of();
 
@@ -171,7 +172,7 @@ const PermissionSelector = React.createClass({
       }
     }, this);
     this.props.onChange(added, deleted);
-  },
-});
+  };
+}
 
 export default PermissionSelector;

--- a/graylog2-web-interface/src/components/users/RoleList.jsx
+++ b/graylog2-web-interface/src/components/users/RoleList.jsx
@@ -1,5 +1,6 @@
 import PropTypes from 'prop-types';
 import React from 'react';
+import createReactClass from 'create-react-class';
 import Reflux from 'reflux';
 import ImmutablePropTypes from 'react-immutable-proptypes';
 import { Button } from 'react-bootstrap';
@@ -11,8 +12,10 @@ const CurrentUserStore = StoreProvider.getStore('CurrentUser');
 
 import { DataTable } from 'components/common';
 
-const RoleList = React.createClass({
+const RoleList = createReactClass({
+  displayName: 'RoleList',
   mixins: [Reflux.connect(CurrentUserStore), PermissionsMixin],
+
   propTypes: {
     roles: ImmutablePropTypes.set.isRequired,
     showEditRole: PropTypes.func.isRequired,
@@ -23,18 +26,21 @@ const RoleList = React.createClass({
     const className = (header === 'Actions' ? 'actions' : '');
     return <th className={className}>{header}</th>;
   },
+
   _editButton(role) {
     if (this.isPermitted(this.state.currentUser.permissions, ['roles:edit:' + role.name]) === false || role.read_only) {
         return null;
     }
     return (<Button key="edit" bsSize="xsmall" bsStyle="info" onClick={() => this.props.showEditRole(role)} title="Edit role">Edit</Button>);
   },
+
   _deleteButton(role) {
     if (this.isPermitted(this.state.currentUser.permissions, ['roles:delete:' + role.name]) === false || role.read_only) {
         return null;
     }
     return (<Button key="delete" bsSize="xsmall" bsStyle="primary" onClick={() => this.props.deleteRole(role)} title="Delete role">Delete</Button>);
   },
+
   _roleInfoFormatter(role) {
     return (
       <tr key={role.name}>
@@ -48,6 +54,7 @@ const RoleList = React.createClass({
       </tr>
     );
   },
+
   render() {
     const filterKeys = ['name', 'description'];
     const headers = ['Name', 'Description', 'Actions'];

--- a/graylog2-web-interface/src/components/users/RolesComponent.jsx
+++ b/graylog2-web-interface/src/components/users/RolesComponent.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import createReactClass from 'create-react-class';
 import Reflux from 'reflux';
 import Immutable from 'immutable';
 import { Button, Col, Row } from 'react-bootstrap';
@@ -15,8 +16,10 @@ const { DashboardsActions, DashboardsStore } = CombinedProvider.get('Dashboards'
 const { RolesStore } = CombinedProvider.get('Roles');
 
 
-export default React.createClass({
+export default createReactClass({
+  displayName: 'RolesComponent',
   mixins: [Reflux.connect(DashboardsStore, 'dashboards')],
+
   getInitialState() {
     return {
       roles: Immutable.Set(),
@@ -25,6 +28,7 @@ export default React.createClass({
       streams: Immutable.List(),
     };
   },
+
   componentDidMount() {
     this.loadRoles();
     StreamsStore.load(streams => this.setState({ streams: Immutable.List(streams) }));
@@ -41,9 +45,11 @@ export default React.createClass({
   _showCreateRole() {
     this.setState({ showEditRole: true });
   },
+
   _showEditRole(role) {
     this.setState({ showEditRole: true, editRole: role });
   },
+
   _deleteRole(role) {
     // eslint-disable-next-line no-alert
     if (window.confirm(`Do you really want to delete role ${role.name}?`)) {
@@ -56,6 +62,7 @@ export default React.createClass({
       });
     }
   },
+
   _saveRole(initialName, role) {
     if (initialName === null) {
       RolesStore.createRole(role).then(this._clearEditRole).then(this.loadRoles);
@@ -63,6 +70,7 @@ export default React.createClass({
       RolesStore.updateRole(initialName, role).then(this._clearEditRole).then(this.loadRoles);
     }
   },
+
   _clearEditRole() {
     this.setState({ showEditRole: false, editRole: null });
   },

--- a/graylog2-web-interface/src/components/users/RolesSelect.jsx
+++ b/graylog2-web-interface/src/components/users/RolesSelect.jsx
@@ -3,20 +3,21 @@ import React from 'react';
 
 import MultiSelect from 'components/common/MultiSelect';
 
-const RolesSelect = React.createClass({
-  propTypes: {
+class RolesSelect extends React.Component {
+  static propTypes = {
     userRoles: PropTypes.arrayOf(PropTypes.string),
     availableRoles: PropTypes.array.isRequired,
     onValueChange: PropTypes.func,
-  },
-  getDefaultProps() {
-    return {
-      userRoles: [],
-    };
-  },
-  getValue() {
+  };
+
+  static defaultProps = {
+    userRoles: [],
+  };
+
+  getValue = () => {
     return this.refs.select.getValue().split(',');
-  },
+  };
+
   render() {
     const rolesValue = this.props.userRoles.join(',');
     const rolesOptions = this.props.availableRoles.map((role) => {
@@ -31,7 +32,7 @@ const RolesSelect = React.createClass({
         placeholder="Choose roles..."
       />
     );
-  },
-});
+  }
+}
 
 export default RolesSelect;

--- a/graylog2-web-interface/src/components/users/TimeoutInput.jsx
+++ b/graylog2-web-interface/src/components/users/TimeoutInput.jsx
@@ -1,11 +1,14 @@
 import PropTypes from 'prop-types';
 import React from 'react';
+import createReactClass from 'create-react-class';
 import { Row, Col } from 'react-bootstrap';
 
 import { Input } from 'components/bootstrap';
 import TimeoutUnitSelect from 'components/users/TimeoutUnitSelect';
 
-const TimeoutInput = React.createClass({
+const TimeoutInput = createReactClass({
+  displayName: 'TimeoutInput',
+
   propTypes: {
     controlSize: PropTypes.number,
     labelSize: PropTypes.number,
@@ -20,6 +23,7 @@ const TimeoutInput = React.createClass({
       controlSize: 10,
     };
   },
+
   getInitialState() {
     const unit = this._estimateUnit(this.props.value);
     return {
@@ -28,16 +32,19 @@ const TimeoutInput = React.createClass({
       unit: unit,
     };
   },
+
   getValue() {
     if (this.state.sessionTimeoutNever) {
       return -1;
     }
     return (this.refs.timeout.value * this.refs.session_timeout_unit.getValue());
   },
+
   MS_DAY: 24 * 60 * 60 * 1000,
   MS_HOUR: 60 * 60 * 1000,
   MS_MINUTE: 60 * 1000,
   MS_SECOND: 1000,
+
   _estimateUnit(value) {
     if (value === 0) {
       return this.MS_SECOND;
@@ -57,20 +64,25 @@ const TimeoutInput = React.createClass({
 
     return this.MS_SECOND;
   },
+
   _onClick(evt) {
     this.setState({ sessionTimeoutNever: evt.target.checked }, this._notifyChange);
   },
+
   _onChangeValue(evt) {
     this.setState({ value: evt.target.value }, this._notifyChange);
   },
+
   _onChangeUnit(evt) {
     this.setState({ unit: evt.target.value }, this._notifyChange);
   },
+
   _notifyChange() {
     if (typeof this.props.onChange === 'function') {
       this.props.onChange(this.getValue());
     }
   },
+
   render() {
     return (
       <span>

--- a/graylog2-web-interface/src/components/users/TimeoutUnitSelect.jsx
+++ b/graylog2-web-interface/src/components/users/TimeoutUnitSelect.jsx
@@ -1,10 +1,11 @@
 
 import React from 'react';
 
-const TimeoutUnitSelect = React.createClass({
-  getValue() {
+class TimeoutUnitSelect extends React.Component {
+  getValue = () => {
     return this.refs.session_timeout_unit.value;
-  },
+  };
+
   render() {
     return (
       <select className="form-control" ref="session_timeout_unit" {...this.props}>
@@ -14,7 +15,7 @@ const TimeoutUnitSelect = React.createClass({
         <option value={24 * 60 * 60 * 1000}>Days</option>
       </select>
     );
-  },
-});
+  }
+}
 
 export default TimeoutUnitSelect;

--- a/graylog2-web-interface/src/components/users/UserForm.jsx
+++ b/graylog2-web-interface/src/components/users/UserForm.jsx
@@ -1,5 +1,6 @@
 import PropTypes from 'prop-types';
 import React from 'react';
+import createReactClass from 'create-react-class';
 import Reflux from 'reflux';
 import { Button, Row, Col, Alert, Panel } from 'react-bootstrap';
 import Routes from 'routing/Routes';
@@ -24,17 +25,22 @@ import TimeoutInput from 'components/users/TimeoutInput';
 import EditRolesForm from 'components/users/EditRolesForm';
 import { IfPermitted, MultiSelect, TimezoneSelect, Spinner } from 'components/common';
 
-const UserForm = React.createClass({
+const UserForm = createReactClass({
+  displayName: 'UserForm',
+
   propTypes: {
     user: PropTypes.object.isRequired,
   },
+
   mixins: [PermissionsMixin, Reflux.connect(CurrentUserStore), Reflux.connect(DashboardsStore)],
+
   getInitialState() {
     return {
       streams: undefined,
       user: this._getUserStateFromProps(this.props),
     };
   },
+
   componentDidMount() {
     StreamsStore.listStreams().then((streams) => {
       this.setState({
@@ -69,12 +75,14 @@ const UserForm = React.createClass({
       return { value: item.id, label: item.title };
     });
   },
+
   formatSelectedOptions(permissions, permission, collection) {
     return collection
       .filter(item => this.isPermitted(permissions, [`${permission}:${item.id}`]))
       .map(item => item.id)
       .join(',');
   },
+
   _onPasswordChange() {
     const passwordField = this.refs.password.getInputDOMNode();
     const passwordConfirmField = this.refs.password_repeat.getInputDOMNode();

--- a/graylog2-web-interface/src/components/users/UserList.jsx
+++ b/graylog2-web-interface/src/components/users/UserList.jsx
@@ -1,5 +1,6 @@
 import PropTypes from 'prop-types';
 import React from 'react';
+import createReactClass from 'create-react-class';
 import { LinkContainer } from 'react-router-bootstrap';
 import { Button, OverlayTrigger, Popover, Tooltip, DropdownButton, MenuItem } from 'react-bootstrap';
 
@@ -14,7 +15,9 @@ import { DataTable, Spinner, Timestamp } from 'components/common';
 
 import UserListStyle from '!style!css!./UserList.css';
 
-const UserList = React.createClass({
+const UserList = createReactClass({
+  displayName: 'UserList',
+
   propTypes: {
     currentUsername: PropTypes.string.isRequired,
     currentUser: PropTypes.object.isRequired,
@@ -28,6 +31,7 @@ const UserList = React.createClass({
       roles: undefined,
     };
   },
+
   componentDidMount() {
     this.loadUsers();
     RolesStore.loadRoles().done((roles) => {
@@ -43,9 +47,11 @@ const UserList = React.createClass({
       });
     });
   },
+
   _hasAdminRole(user) {
     return this.isPermitted(user.permissions, ['*']);
   },
+
   deleteUser(username) {
     const promise = UsersStore.deleteUser(username);
 
@@ -53,6 +59,7 @@ const UserList = React.createClass({
       this.loadUsers();
     });
   },
+
   _deleteUserFunction(username) {
     return () => {
       if (window.confirm(`Do you really want to delete user ${username}?`)) {
@@ -60,6 +67,7 @@ const UserList = React.createClass({
       }
     };
   },
+
   _headerCellFormatter(header) {
     let formattedHeaderCell;
 
@@ -91,6 +99,7 @@ const UserList = React.createClass({
 
     return formattedHeaderCell;
   },
+
   _userInfoFormatter(user) {
     const rowClass = user.username === this.props.currentUsername ? 'active' : null;
     let userBadge = null;
@@ -182,6 +191,7 @@ const UserList = React.createClass({
       </tr>
     );
   },
+
   render() {
     const filterKeys = ['username', 'full_name', 'email', 'client_address'];
     const headers = ['', 'Name', 'Username', 'Email Address', 'Client Address', 'Role', 'Actions'];

--- a/graylog2-web-interface/src/components/users/UserPreferencesButton.jsx
+++ b/graylog2-web-interface/src/components/users/UserPreferencesButton.jsx
@@ -4,13 +4,15 @@ import { Button } from 'react-bootstrap';
 
 import UserPreferencesModal from 'components/users/UserPreferencesModal';
 
-const UserPreferencesButton = React.createClass({
-  propTypes: {
+class UserPreferencesButton extends React.Component {
+  static propTypes = {
     userName: PropTypes.string.isRequired,
-  },
-  onClick() {
+  };
+
+  onClick = () => {
     this.refs.userPreferencesModal.openModal();
-  },
+  };
+
   render() {
     return (
       <span>
@@ -18,7 +20,7 @@ const UserPreferencesButton = React.createClass({
         <UserPreferencesModal ref="userPreferencesModal" userName={this.props.userName} />
       </span>
     );
-  },
-});
+  }
+}
 
 export default UserPreferencesButton;

--- a/graylog2-web-interface/src/components/users/UserPreferencesModal.jsx
+++ b/graylog2-web-interface/src/components/users/UserPreferencesModal.jsx
@@ -7,14 +7,14 @@ const PreferencesStore = StoreProvider.getStore('Preferences');
 
 import BootstrapModalForm from 'components/bootstrap/BootstrapModalForm';
 
-const UserPreferencesModal = React.createClass({
-  propTypes: {
+class UserPreferencesModal extends React.Component {
+  static propTypes = {
     userName: PropTypes.string.isRequired,
-  },
-  getInitialState() {
-    return { preferences: [] };
-  },
-  _onPreferenceChanged(event) {
+  };
+
+  state = { preferences: [] };
+
+  _onPreferenceChanged = (event) => {
     const name = event.target.name;
     const preferenceToChange = this.state.preferences.filter(preference => preference.name === name)[0];
     // TODO: we need the type of the preference to set it properly
@@ -22,16 +22,19 @@ const UserPreferencesModal = React.createClass({
       preferenceToChange.value = event.target.value;
       this.setState({ preferences: this.state.preferences });
     }
-  },
-  _save() {
+  };
+
+  _save = () => {
     PreferencesStore.saveUserPreferences(this.state.preferences, this.refs.modal.close);
-  },
-  openModal() {
+  };
+
+  openModal = () => {
     PreferencesStore.loadUserPreferences(this.props.userName, (preferences) => {
       this.setState({ preferences: preferences });
       this.refs.modal.open();
     });
-  },
+  };
+
   render() {
     let shouldAutoFocus = true;
 
@@ -63,7 +66,7 @@ const UserPreferencesModal = React.createClass({
         <div>{formattedPreferences}</div>
       </BootstrapModalForm>
     );
-  },
-});
+  }
+}
 
 export default UserPreferencesModal;

--- a/graylog2-web-interface/src/components/visualizations/GraphVisualization.jsx
+++ b/graylog2-web-interface/src/components/visualizations/GraphVisualization.jsx
@@ -65,8 +65,8 @@ const GraphFactory = {
   },
 };
 
-const GraphVisualization = React.createClass({
-  propTypes: {
+class GraphVisualization extends React.Component {
+  static propTypes = {
     id: PropTypes.string.isRequired,
     data: PropTypes.object.isRequired,
     config: PropTypes.object.isRequired,
@@ -78,47 +78,47 @@ const GraphVisualization = React.createClass({
     width: PropTypes.number,
     interactive: PropTypes.bool,
     onRenderComplete: PropTypes.func,
-  },
+  };
 
-  statics: {
-    getReadableFieldChartStatisticalFunction(statisticalFunction) {
-      switch (statisticalFunction) {
-        case 'count':
-          return 'total';
-        case 'total':
-          return 'sum';
-        default:
-          return statisticalFunction;
-      }
-    },
-  },
+  static getReadableFieldChartStatisticalFunction(statisticalFunction) {
+    switch (statisticalFunction) {
+      case 'count':
+        return 'total';
+      case 'total':
+        return 'sum';
+      default:
+        return statisticalFunction;
+    }
+  }
 
-  getDefaultProps() {
-    return {
-      interactive: true,
-      onRenderComplete: () => {},
-    };
-  },
+  static defaultProps = {
+    interactive: true,
+    onRenderComplete: () => {},
+  };
 
-  getInitialState() {
+  constructor(props) {
+    super(props);
     this.triggerRender = true;
     this.graphData = crossfilter();
     this.dimension = this.graphData.dimension(d => d.x);
     this.group = this.dimension.group().reduceSum(d => d.y);
 
-    return {
+    this.state = {
       dataPoints: [],
     };
-  },
+  }
+
   componentDidMount() {
     this.disableTransitions = dc.disableTransitions;
     dc.disableTransitions = !this.props.interactive;
     this.renderGraph();
     this._updateData(this.props.data, this.props.config, this.props.computationTimeRange);
-  },
+  }
+
   componentDidUpdate() {
     this.drawData();
-  },
+  }
+
   componentWillReceiveProps(nextProps) {
     if (deepEqual(this.props, nextProps)) {
       return;
@@ -128,20 +128,21 @@ const GraphVisualization = React.createClass({
       this._resizeVisualization(nextProps.width, nextProps.height);
     }
     this._updateData(nextProps.data, nextProps.config, nextProps.computationTimeRange);
-  },
+  }
 
   componentWillUnmount() {
     dc.disableTransitions = this.disableTransitions;
-  },
+  }
 
-  _updateData(data, config, computationTimeRange) {
+  _updateData = (data, config, computationTimeRange) => {
     const isSearchAll = (config.timerange.type === 'relative' && config.timerange.range === 0);
     const dataPoints = HistogramFormatter.format(data, computationTimeRange,
       config.interval, this.props.width, isSearchAll, config.valuetype);
 
     this.setState({ dataPoints: this._normalizeData(dataPoints) });
-  },
-  _normalizeData(data) {
+  };
+
+  _normalizeData = (data) => {
     if (data === null || data === undefined || !Array.isArray(data)) {
       return [];
     }
@@ -149,8 +150,9 @@ const GraphVisualization = React.createClass({
       dataPoint.y = NumberUtils.normalizeGraphNumber(dataPoint.y);
       return dataPoint;
     });
-  },
-  _formatTooltipTitle(d) {
+  };
+
+  _formatTooltipTitle = (d) => {
     const formattedKey = d.x === undefined ? d.x : new DateTime(d.x).toString(DateTime.Formats.COMPLETE);
 
     let formattedValue;
@@ -164,14 +166,16 @@ const GraphVisualization = React.createClass({
     const keyText = `<span class="date">${formattedKey}</span>`;
 
     return `<div class="datapoint-info">${valueText}<br>${keyText}</div>`;
-  },
-  _resizeVisualization(width, height) {
+  };
+
+  _resizeVisualization = (width, height) => {
     this.graph
       .width(width)
       .height(height);
     this.triggerRender = true;
-  },
-  drawData() {
+  };
+
+  drawData = () => {
     this.graph.xUnits(() => Math.max(this.state.dataPoints.length - 1, 1));
     this.graphData.remove();
     this.graphData.add(this.state.dataPoints);
@@ -187,9 +191,10 @@ const GraphVisualization = React.createClass({
     if (this.props.config.threshold) {
       this.renderThreshold();
     }
-  },
+  };
+
   // Draws a horizontal threshold line in the graph
-  renderThreshold() {
+  renderThreshold = () => {
     const threshold = this.props.config.threshold;
     const thresholdColor = this.props.config.threshold_color || '#f00';
     const thresholdTooltip = this.props.config.threshold_tooltip || `threshold: ${threshold}`;
@@ -265,8 +270,9 @@ const GraphVisualization = React.createClass({
         .attr('fill', thresholdColor);
       dots.exit().remove();
     });
-  },
-  renderGraph() {
+  };
+
+  renderGraph = () => {
     const graphDomNode = this._graph;
     const interactive = this.props.interactive;
 
@@ -308,13 +314,14 @@ const GraphVisualization = React.createClass({
         return Math.abs(value) > 1e+30 ? value.toPrecision(1) : d3.format('.2s')(value);
       });
     this.graph.render();
-  },
+  };
+
   render() {
     return (
       <div ref={(c) => { this._graph = c; }} id={`visualization-${this.props.id}`}
            className={`graph ${this.props.config.renderer}`} />
     );
-  },
-});
+  }
+}
 
 export default GraphVisualization;

--- a/graylog2-web-interface/src/components/visualizations/HistogramVisualization.jsx
+++ b/graylog2-web-interface/src/components/visualizations/HistogramVisualization.jsx
@@ -18,8 +18,8 @@ import $ from 'jquery';
 global.jQuery = $;
 require('bootstrap/js/tooltip');
 
-const HistogramVisualization = React.createClass({
-  propTypes: {
+class HistogramVisualization extends React.Component {
+  static propTypes = {
     id: PropTypes.string.isRequired,
     data: PropTypes.object.isRequired,
     config: PropTypes.object.isRequired,
@@ -30,34 +30,35 @@ const HistogramVisualization = React.createClass({
     onRenderComplete: PropTypes.func,
     keyTitleRenderer: PropTypes.func,
     valueTitleRenderer: PropTypes.func,
-  },
+  };
 
-  getDefaultProps() {
-    return {
-      interactive: true,
-      onRenderComplete: () => {
-      },
-      keyTitleRenderer: d => `<span class="date">${new DateTime(d.x).toString(DateTime.Formats.COMPLETE)}</span>`,
-      valueTitleRenderer: d => `${numeral(d.y).format('0,0')} messages`,
-    };
-  },
+  static defaultProps = {
+    interactive: true,
+    onRenderComplete: () => {
+    },
+    keyTitleRenderer: d => `<span class="date">${new DateTime(d.x).toString(DateTime.Formats.COMPLETE)}</span>`,
+    valueTitleRenderer: d => `${numeral(d.y).format('0,0')} messages`,
+  };
 
-  getInitialState() {
+  constructor(props) {
+    super(props);
     this.triggerRender = true;
     this.histogramData = crossfilter();
     this.dimension = this.histogramData.dimension(d => d.x);
     this.group = this.dimension.group().reduceSum(d => d.y);
 
-    return {
+    this.state = {
       dataPoints: [],
     };
-  },
+  }
+
   componentDidMount() {
     this.disableTransitions = dc.disableTransitions;
     dc.disableTransitions = !this.props.interactive;
     this.renderHistogram();
     this._updateData(this.props.data);
-  },
+  }
+
   componentWillReceiveProps(nextProps) {
     if (deepEqual(this.props, nextProps)) {
       return;
@@ -67,22 +68,24 @@ const HistogramVisualization = React.createClass({
       this._resizeVisualization(nextProps.width, nextProps.height);
     }
     this._updateData(nextProps.data);
-  },
+  }
 
   componentWillUnmount() {
     dc.disableTransitions = this.disableTransitions;
-  },
+  }
 
-  _updateData(data) {
+  _updateData = (data) => {
     this.setState({ dataPoints: data }, this.drawData);
-  },
-  _resizeVisualization(width, height) {
+  };
+
+  _resizeVisualization = (width, height) => {
     this.histogram
       .width(width)
       .height(height);
     this.triggerRender = true;
-  },
-  drawData() {
+  };
+
+  drawData = () => {
     const isSearchAll = (this.props.config.timerange.type === 'relative' && this.props.config.timerange.range === 0);
     const dataPoints = HistogramFormatter.format(this.state.dataPoints, this.props.computationTimeRange,
       this.props.config.interval, this.props.width, isSearchAll, null);
@@ -99,9 +102,9 @@ const HistogramVisualization = React.createClass({
     } else {
       this.histogram.redraw();
     }
-  },
+  };
 
-  _renderTooltip(histogram, histogramDomNode) {
+  _renderTooltip = (histogram, histogramDomNode) => {
     histogram.on('renderlet', () => {
       const formatTitle = (d) => {
         const valueText = this.props.valueTitleRenderer(d);
@@ -122,9 +125,9 @@ const HistogramVisualization = React.createClass({
       delay: { show: 300, hide: 100 },
       html: true,
     });
-  },
+  };
 
-  renderHistogram() {
+  renderHistogram = () => {
     const histogramDomNode = this._graph;
     const xAxisLabel = this.props.config.xAxis || 'Time';
     const yAxisLabel = this.props.config.yAxis || 'Messages';
@@ -162,12 +165,13 @@ const HistogramVisualization = React.createClass({
         return value % 1 === 0 ? d3.format('s')(value) : null;
       });
     this.histogram.render();
-  },
+  };
+
   render() {
     return (
       <div ref={(c) => { this._graph = c; }} id={`visualization-${this.props.id}`} className="histogram" />
     );
-  },
-});
+  }
+}
 
 export default HistogramVisualization;

--- a/graylog2-web-interface/src/components/visualizations/NumericVisualization.jsx
+++ b/graylog2-web-interface/src/components/visualizations/NumericVisualization.jsx
@@ -15,8 +15,8 @@ const TREND_ICON_COLOR = '#E3E5E5';
 const TREND_ICON_GOOD_COLOR = '#8DC63F';
 const TREND_ICON_BAD_COLOR = '#BE1E2D';
 
-const NumericVisualization = React.createClass({
-  propTypes: {
+class NumericVisualization extends React.Component {
+  static propTypes = {
     id: PropTypes.string.isRequired,
     config: PropTypes.object.isRequired,
     data: PropTypes.oneOfType([
@@ -26,41 +26,39 @@ const NumericVisualization = React.createClass({
     height: PropTypes.number,
     width: PropTypes.number,
     onRenderComplete: PropTypes.func,
-  },
+  };
 
-  getDefaultProps() {
-    return {
-      onRenderComplete: () => {
-      },
-    };
-  },
+  static defaultProps = {
+    onRenderComplete: () => {
+    },
+  };
 
-  getInitialState() {
-    return {
-      currentNumber: undefined,
-      previousNumber: undefined,
-    };
-  },
+  state = {
+    currentNumber: undefined,
+    previousNumber: undefined,
+  };
+
   componentDidMount() {
     this._updateData(this.props.data, this.props.onRenderComplete);
-  },
+  }
+
   componentWillReceiveProps(nextProps) {
     if (deepEqual(this.props, nextProps)) {
       return;
     }
     this._updateData(nextProps.data, this.props.onRenderComplete);
-  },
+  }
 
-  DEFAULT_VALUE_FONT_SIZE: '60px',
-  NUMBER_OF_INDICATORS: 3,
-  PERCENTAGE_PER_INDICATOR: 30,
+  DEFAULT_VALUE_FONT_SIZE = '60px';
+  NUMBER_OF_INDICATORS = 3;
+  PERCENTAGE_PER_INDICATOR = 30;
 
-  _updateData(data, renderCallback) {
+  _updateData = (data, renderCallback) => {
     const state = this._normalizeStateFromProps(data);
     this.setState(state, renderCallback);
-  },
+  };
 
-  _normalizeStateFromProps(props) {
+  _normalizeStateFromProps = (props) => {
     let state = {};
     if (typeof props === 'object') {
       const normalizedNowNumber = NumberUtils.normalizeNumber(props.now);
@@ -74,8 +72,9 @@ const NumericVisualization = React.createClass({
       state = { currentNumber: props };
     }
     return state;
-  },
-  _calculatePercentage(nowNumber, previousNumber) {
+  };
+
+  _calculatePercentage = (nowNumber, previousNumber) => {
     let percentage;
     if (previousNumber === 0 || isNaN(previousNumber)) {
       let factor = 0;
@@ -91,8 +90,9 @@ const NumericVisualization = React.createClass({
     }
 
     return percentage;
-  },
-  _calculateFontSize() {
+  };
+
+  _calculateFontSize = () => {
     if (typeof this.props.data === 'undefined') {
       return this.DEFAULT_VALUE_FONT_SIZE;
     }
@@ -124,11 +124,13 @@ const NumericVisualization = React.createClass({
     }
 
     return fontSize;
-  },
-  _formatData() {
+  };
+
+  _formatData = () => {
     return String(NumberUtils.formatNumber(this.state.currentNumber));
-  },
-  _isIndicatorActive(index, trendIndicatorType) {
+  };
+
+  _isIndicatorActive = (index, trendIndicatorType) => {
     if ((this.state.percentage === 0) ||
       (this.state.currentNumber >= this.state.previousNumber && trendIndicatorType !== TrendIndicatorType.HIGHER) ||
       (this.state.currentNumber <= this.state.previousNumber && trendIndicatorType !== TrendIndicatorType.LOWER)) {
@@ -141,8 +143,9 @@ const NumericVisualization = React.createClass({
       index = Math.abs(index - (this.NUMBER_OF_INDICATORS - 1));
     }
     return Math.abs(this.state.percentage) >= this.PERCENTAGE_PER_INDICATOR * index;
-  },
-  _getStrokeColor(index, trendIndicatorType) {
+  };
+
+  _getStrokeColor = (index, trendIndicatorType) => {
     const indicatorIsActive = this._isIndicatorActive(index, trendIndicatorType);
     if (!indicatorIsActive) {
       return TREND_ICON_COLOR;
@@ -154,22 +157,26 @@ const NumericVisualization = React.createClass({
     const activeStroke = trendIndicatorType === TrendIndicatorType.HIGHER ? higherStroke : lowerStroke;
 
     return activeStroke;
-  },
-  _getHigherStrokeColor(index) {
+  };
+
+  _getHigherStrokeColor = (index) => {
     return this._getStrokeColor(index, TrendIndicatorType.HIGHER);
-  },
-  _getLowerStrokeColor(index) {
+  };
+
+  _getLowerStrokeColor = (index) => {
     return this._getStrokeColor(index, TrendIndicatorType.LOWER);
-  },
+  };
+
   // We need to set some attributes in the DOM elements that React v0.14 does not support.
   // This is a hack to workaround it as suggested in https://github.com/facebook/react/pull/5210
-  _setAttribute(attribute, value) {
+  _setAttribute = (attribute, value) => {
     return (node) => {
       if (node) {
         node.setAttribute(attribute, value);
       }
     };
-  },
+  };
+
   render() {
     const { id, config, width, height } = this.props;
 
@@ -202,7 +209,7 @@ const NumericVisualization = React.createClass({
         </svg>
       </div>
     );
-  },
-});
+  }
+}
 
 export default NumericVisualization;

--- a/graylog2-web-interface/src/components/visualizations/QuickValuesHistogramVisualization.jsx
+++ b/graylog2-web-interface/src/components/visualizations/QuickValuesHistogramVisualization.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import createReactClass from 'create-react-class';
 import PropTypes from 'prop-types';
 
 import crossfilter from 'crossfilter';
@@ -15,11 +16,14 @@ import D3Utils from 'util/D3Utils';
 /*
  * A stacked bar chart visualization to draw QuickValues over time based on dc.js.
  */
-const QuickValuesHistogramVisualization = React.createClass({
+const QuickValuesHistogramVisualization = createReactClass({
+  displayName: 'QuickValuesHistogramVisualization',
+
   DEFAULT_CONFIG: {
     limit: 5,
     sort_order: 'desc',
   },
+
   DEFAULT_HEIGHT: 220,
 
   // dc.js is modifying the margins passed into the graph so make sure this is immutable

--- a/graylog2-web-interface/src/components/visualizations/QuickValuesVisualization.jsx
+++ b/graylog2-web-interface/src/components/visualizations/QuickValuesVisualization.jsx
@@ -1,5 +1,6 @@
 import PropTypes from 'prop-types';
 import React from 'react';
+import createReactClass from 'create-react-class';
 import Immutable from 'immutable';
 import { ListGroup, ListGroupItem, Panel } from 'react-bootstrap';
 import crossfilter from 'crossfilter';
@@ -22,7 +23,9 @@ require('bootstrap/js/tooltip');
 
 const SearchStore = StoreProvider.getStore('Search');
 
-const QuickValuesVisualization = React.createClass({
+const QuickValuesVisualization = createReactClass({
+  displayName: 'QuickValuesVisualization',
+
   DEFAULT_CONFIG: {
     show_pie_chart: true,
     show_data_table: true,
@@ -30,6 +33,7 @@ const QuickValuesVisualization = React.createClass({
     limit: 5,
     sort_order: 'desc',
   },
+
   propTypes: {
     id: PropTypes.string.isRequired,
     field: PropTypes.string.isRequired,
@@ -50,6 +54,7 @@ const QuickValuesVisualization = React.createClass({
     onRenderComplete: PropTypes.func,
     limitHeight: PropTypes.bool,
   },
+
   getDefaultProps() {
     return {
       config: this.DEFAULT_CONFIG,
@@ -83,6 +88,7 @@ const QuickValuesVisualization = React.createClass({
       termsMapping: {},
     };
   },
+
   componentDidMount() {
     this.disableTransitions = dc.disableTransitions;
     dc.disableTransitions = !this.props.interactive;
@@ -91,6 +97,7 @@ const QuickValuesVisualization = React.createClass({
     this._renderDataTable(this.props);
     this._renderPieChart(this.props);
   },
+
   componentWillReceiveProps(nextProps) {
     if (deepEqual(this.props, nextProps)) {
       return;
@@ -175,6 +182,7 @@ const QuickValuesVisualization = React.createClass({
       }, this.drawData);
     }
   },
+
   _getAddToSearchButton(term) {
     const addToSearchButton = document.createElement('button');
     addToSearchButton.className = 'btn btn-xs btn-default';
@@ -184,6 +192,7 @@ const QuickValuesVisualization = React.createClass({
 
     return addToSearchButton.outerHTML;
   },
+
   _getFieldName(i) {
     if (this.props.fields.length === 0) {
       // calculate the fields from the data props
@@ -194,6 +203,7 @@ const QuickValuesVisualization = React.createClass({
       return this.props.fields[i];
     }
   },
+
   _getDataTableColumns() {
     function formatTimestamp(timestamp) {
       return new DateTime(Number(timestamp)).toString(DateTime.Formats.TIMESTAMP);
@@ -235,6 +245,7 @@ const QuickValuesVisualization = React.createClass({
 
     return columns;
   },
+
   _getSortOrder(sortOrder) {
     switch (sortOrder) {
       case 'desc': return d3.descending;
@@ -242,6 +253,7 @@ const QuickValuesVisualization = React.createClass({
       default: return d3.descending;
     }
   },
+
   _groupOrderFunc(sortOrder) {
     return (d) => {
       if (sortOrder === 'asc') {
@@ -251,6 +263,7 @@ const QuickValuesVisualization = React.createClass({
       }
     };
   },
+
   _renderDataTable(props) {
     const tableDomNode = this._table;
     const limit = this._getConfig('limit', props.config);
@@ -285,6 +298,7 @@ const QuickValuesVisualization = React.createClass({
 
     this.dataTable.render();
   },
+
   _renderPieChart(props) {
     const graphDomNode = this._graph;
 
@@ -326,11 +340,13 @@ const QuickValuesVisualization = React.createClass({
 
     this.pieChart.render();
   },
+
   _formatGraphTooltip(d) {
     const valueText = `${d.data.key}: ${NumberUtils.formatNumber(d.value)}`;
 
     return `<div class="datapoint-info">${valueText}</div>`;
   },
+
   _setPieChartSize(newSize) {
     this.pieChart
       .width(newSize)
@@ -339,6 +355,7 @@ const QuickValuesVisualization = React.createClass({
 
     this.triggerRender = true;
   },
+
   _resizeVisualization(width, height, showDataTable) {
     let computedSize;
 
@@ -355,18 +372,21 @@ const QuickValuesVisualization = React.createClass({
       }
     }
   },
+
   _clearDataFilters() {
     if (this.pieChart !== undefined) {
       this.filters = this.pieChart.filters();
       this.pieChart.filterAll();
     }
   },
+
   _restoreDataFilters() {
     if (this.pieChart !== undefined) {
       this.filters.forEach(filter => this.pieChart.filter(filter));
       this.filters = [];
     }
   },
+
   drawData() {
     if (this.shouldUpdateData) {
       this._clearDataFilters();
@@ -385,9 +405,11 @@ const QuickValuesVisualization = React.createClass({
       }
     }
   },
+
   _getTotalMessagesWithField() {
     return this.state.total - this.state.missing;
   },
+
   _getAnalysisInformation() {
     const analysisInformation = [`Found <em>${NumberUtils.formatNumber(this._getTotalMessagesWithField())}</em> messages with field <em>${this.props.field}</em>`];
 
@@ -402,6 +424,7 @@ const QuickValuesVisualization = React.createClass({
 
     return <span dangerouslySetInnerHTML={{ __html: `${analysisInformation.join(',')}.` }} />;
   },
+
   render() {
     const { horizontal, displayAnalysisInformation, height, id, displayAddToSearchButton, limitHeight } = this.props;
     let pieChartClassName;

--- a/graylog2-web-interface/src/components/visualizations/RenderCompletionObserver.jsx
+++ b/graylog2-web-interface/src/components/visualizations/RenderCompletionObserver.jsx
@@ -1,24 +1,24 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 
-const RenderCompletionObserver = React.createClass({
-  propTypes: {
+class RenderCompletionObserver extends React.Component {
+  static propTypes = {
     onRenderComplete: PropTypes.func.isRequired,
     children: PropTypes.oneOfType([
       PropTypes.element,
       PropTypes.arrayOf(PropTypes.element),
     ]).isRequired,
-  },
+  };
 
-  _renderComplete: false,
+  _renderComplete = false;
 
-  _handleRenderComplete() {
+  _handleRenderComplete = () => {
     if (this._renderComplete) {
       return;
     }
     this._renderComplete = true;
     this.props.onRenderComplete();
-  },
+  };
 
   render() {
     return (
@@ -28,7 +28,7 @@ const RenderCompletionObserver = React.createClass({
         })}
       </div>
     );
-  },
-});
+  }
+}
 
 export default RenderCompletionObserver;

--- a/graylog2-web-interface/src/components/visualizations/StackedGraphVisualization.jsx
+++ b/graylog2-web-interface/src/components/visualizations/StackedGraphVisualization.jsx
@@ -15,8 +15,8 @@ import graphHelper from 'legacy/graphHelper';
 
 import style from './StackedGraphVisualization.css';
 
-const StackedGraphVisualization = React.createClass({
-  propTypes: {
+class StackedGraphVisualization extends React.Component {
+  static propTypes = {
     id: PropTypes.string.isRequired,
     data: PropTypes.array.isRequired,
     height: PropTypes.number,
@@ -25,28 +25,29 @@ const StackedGraphVisualization = React.createClass({
     computationTimeRange: PropTypes.object,
     interactive: PropTypes.bool,
     onRenderComplete: PropTypes.func,
-  },
+  };
 
-  getDefaultProps() {
-    return {
-      interactive: true,
-      onRenderComplete: () => {},
-    };
-  },
+  static defaultProps = {
+    interactive: true,
+    onRenderComplete: () => {},
+  };
 
-  getInitialState() {
+  constructor(props) {
+    super(props);
     this.series = Immutable.List();
     this.seriesNames = Immutable.Map();
     this.barWidthScale = d3.scale.linear().domain(d3.range(0, 10000)).range(d3.range(0.6, 0, -0.01));
     this.dataPoints = Immutable.Set();
 
-    return {};
-  },
+    this.state = {};
+  }
+
   componentDidMount() {
     this.renderGraph(this.props);
     this.dataPoints = this._formatData(this.props);
     this.drawData();
-  },
+  }
+
   componentWillReceiveProps(nextProps) {
     if (deepEqual(this.props, nextProps)) {
       return;
@@ -59,14 +60,16 @@ const StackedGraphVisualization = React.createClass({
       this.renderGraph(nextProps);
     }
     this.drawData();
-  },
-  _normalizeData(data) {
+  }
+
+  _normalizeData = (data) => {
     if (data === null || data === undefined || !Array.isArray(data)) {
       return [];
     }
     return data;
-  },
-  _formatData(props) {
+  };
+
+  _formatData = (props) => {
     const data = props.data;
     const normalizedData = this._normalizeData(data);
     const isSearchAll = (props.config.timerange.type === 'relative' && props.config.timerange.range === 0);
@@ -78,8 +81,9 @@ const StackedGraphVisualization = React.createClass({
     }, this);
 
     return this._mergeSeries(formattedSeries);
-  },
-  _mergeSeries(series) {
+  };
+
+  _mergeSeries = (series) => {
     let mergedSeries = Immutable.Map();
 
     series.forEach((aSeries, idx) => {
@@ -95,8 +99,9 @@ const StackedGraphVisualization = React.createClass({
     }, this);
 
     return mergedSeries.toOrderedSet().sortBy(dataPoint => dataPoint.get('timestamp'));
-  },
-  _getGraphType() {
+  };
+
+  _getGraphType = () => {
     let graphType;
 
     switch (this.props.config.renderer) {
@@ -114,8 +119,9 @@ const StackedGraphVisualization = React.createClass({
     }
 
     return graphType;
-  },
-  _applyGraphConfiguration(graphType) {
+  };
+
+  _applyGraphConfiguration = (graphType) => {
     /* eslint-disable no-case-declarations */
     switch (graphType) {
       case 'bar':
@@ -135,11 +141,13 @@ const StackedGraphVisualization = React.createClass({
         console.warn(`Invalid graph type ${graphType}`);
     }
     /* eslint-enable no-case-declarations */
-  },
-  _formatTooltipTitle(x) {
+  };
+
+  _formatTooltipTitle = (x) => {
     return new DateTime(x).toString(DateTime.Formats.COMPLETE);
-  },
-  _formatTooltipValue(value) {
+  };
+
+  _formatTooltipValue = (value) => {
     let formattedValue;
     try {
       formattedValue = numeral(value).format('0,0.[00]');
@@ -148,14 +156,16 @@ const StackedGraphVisualization = React.createClass({
     }
 
     return formattedValue;
-  },
-  _resizeVisualization(width, height) {
+  };
+
+  _resizeVisualization = (width, height) => {
     this.graph.resize({
       width: width,
       height: height,
     });
-  },
-  _updateSeriesNames(props) {
+  };
+
+  _updateSeriesNames = (props) => {
     let i = 0;
     let newSeriesNames = Immutable.Map();
     props.config.series.forEach((seriesConfig) => {
@@ -169,8 +179,9 @@ const StackedGraphVisualization = React.createClass({
       this.seriesNames = newSeriesNames;
       this.graph.data.names(this.seriesNames.toJS());
     }
-  },
-  drawData() {
+  };
+
+  drawData = () => {
     const graphType = this._getGraphType();
     this._applyGraphConfiguration(graphType);
 
@@ -190,8 +201,9 @@ const StackedGraphVisualization = React.createClass({
       },
       type: graphType,
     });
-  },
-  renderGraph(props) {
+  };
+
+  renderGraph = (props) => {
     const graphDomNode = this._graph;
     const colourPalette = D3Utils.glColourPalette();
 
@@ -274,14 +286,15 @@ const StackedGraphVisualization = React.createClass({
     }
 
     this.graph = c3.generate(config);
-  },
+  };
+
   render() {
     const classNames = this.props.config.doNotShowCircles ? 'donotshowcircles' : '';
     return (
       <div ref={(c) => { this._graph = c; }} id={`visualization-${this.props.id}`}
            className={`graph ${this.props.config.renderer}${classNames}`} />
     );
-  },
-});
+  }
+}
 
 export default StackedGraphVisualization;

--- a/graylog2-web-interface/src/components/widgets/Widget.jsx
+++ b/graylog2-web-interface/src/components/widgets/Widget.jsx
@@ -1,5 +1,6 @@
 import PropTypes from 'prop-types';
 import React from 'react';
+import createReactClass from 'create-react-class';
 import $ from 'jquery';
 import Reflux from 'reflux';
 
@@ -14,7 +15,8 @@ import CombinedProvider from '../../injection/CombinedProvider';
 const { WidgetsStore, WidgetsActions } = CombinedProvider.get('Widgets');
 const CurrentUserStore = StoreProvider.getStore('CurrentUser');
 
-const Widget = React.createClass({
+const Widget = createReactClass({
+  displayName: 'Widget',
   mixins: [Reflux.connect(CurrentUserStore), PermissionsMixin],
 
   propTypes: {
@@ -24,6 +26,7 @@ const Widget = React.createClass({
     locked: PropTypes.bool.isRequired,
     streamIds: PropTypes.object,
   },
+
   getInitialState() {
     this.widgetPlugin = this._getWidgetPlugin(this.props.widget.type);
     return {
@@ -35,6 +38,7 @@ const Widget = React.createClass({
       width: undefined,
     };
   },
+
   componentDidMount() {
     this._loadValue();
     this.loadValueInterval = setInterval(this._loadValue, Math.min(this.props.widget.cache_time * 1000, this.DEFAULT_WIDGET_VALUE_REFRESH));
@@ -47,12 +51,15 @@ const Widget = React.createClass({
     // is going to be called n times on the same widget, resulting in a single widget being updated n times.
     $(window).on('resize', this._onResize);
   },
+
   componentWillReceiveProps(nextProps) {
     this.widgetPlugin = this._getWidgetPlugin(nextProps.widget.type);
   },
+
   componentDidUpdate() {
     this._calculateWidgetSize();
   },
+
   componentWillUnmount() {
     clearInterval(this.loadValueInterval);
     $(window).off('resize', this._onResize);
@@ -69,9 +76,11 @@ const Widget = React.createClass({
   _isBoundToStream() {
     return ('stream_id' in this.props.widget.config) && (this.props.widget.config.stream_id !== null);
   },
+
   _getWidgetNode() {
     return this.node;
   },
+
   _loadValue() {
     if (this.state.deleted || (this.state.result !== undefined && !this.props.shouldUpdate)) {
       return;
@@ -107,9 +116,11 @@ const Widget = React.createClass({
       });
     });
   },
+
   _onResize() {
     this.eventsThrottler.throttle(this._calculateWidgetSize, undefined, this.props.widget.id);
   },
+
   _calculateWidgetSize() {
     const $widgetNode = $(this._getWidgetNode());
     if (!$widgetNode) { return; }
@@ -121,6 +132,7 @@ const Widget = React.createClass({
       this.setState({ height: availableHeight, width: availableWidth });
     }
   },
+
   _getVisualization() {
     if (this.props.widget.type === '') {
       return null;
@@ -152,6 +164,7 @@ const Widget = React.createClass({
       locked: !this.props.locked, // widget should be locked when dashboard is unlocked and widgets can be moved
     });
   },
+
   _getTimeRange() {
     const config = this.props.widget.config;
     const rangeType = config.timerange.type;
@@ -176,6 +189,7 @@ const Widget = React.createClass({
 
     return timeRange;
   },
+
   replayUrl() {
     const config = this.props.widget.config;
     if (this._isBoundToStream()) {
@@ -184,24 +198,29 @@ const Widget = React.createClass({
 
     return Routes.search(config.query, this._getTimeRange(), config.interval);
   },
+
   _showConfig() {
     this.configModal.open();
   },
+
   _showEditConfig() {
     this.editModal.open();
   },
+
   updateWidget(newWidgetData) {
     const realNewWidgetData = newWidgetData;
     realNewWidgetData.id = this.props.widget.id;
 
     WidgetsStore.updateWidget(this.props.dashboardId, realNewWidgetData);
   },
+
   deleteWidget() {
     if (window.confirm(`Do you really want to delete "${this.props.widget.description}"?`)) {
       this.setState({ deleted: true });
       WidgetsActions.removeWidget(this.props.dashboardId, this.props.widget.id);
     }
   },
+
   render() {
     if (this.state.deleted) {
       return <span />;

--- a/graylog2-web-interface/src/components/widgets/WidgetConfigModal.jsx
+++ b/graylog2-web-interface/src/components/widgets/WidgetConfigModal.jsx
@@ -9,20 +9,22 @@ import StringUtils from 'util/StringUtils';
 
 import BootstrapModalWrapper from 'components/bootstrap/BootstrapModalWrapper';
 
-const WidgetConfigModal = React.createClass({
-  propTypes: {
+class WidgetConfigModal extends React.Component {
+  static propTypes = {
     boundToStream: PropTypes.bool.isRequired,
     widget: PropTypes.object.isRequired,
     dashboardId: PropTypes.string.isRequired,
-  },
+  };
 
-  open() {
+  open = () => {
     this.refs.configModal.open();
-  },
-  hide() {
+  };
+
+  hide = () => {
     this.refs.configModal.close();
-  },
-  _getBasicConfiguration() {
+  };
+
+  _getBasicConfiguration = () => {
     let basicConfigurationMessage;
     const widgetPlugin = PluginStore.exports('widgets').filter(widget => widget.type.toUpperCase() === this.props.widget.type.toUpperCase())[0];
     const widgetType = (widgetPlugin ? widgetPlugin.displayName : 'Not available');
@@ -43,11 +45,13 @@ const WidgetConfigModal = React.createClass({
     }
 
     return basicConfigurationMessage;
-  },
-  _formatConfigurationKey(key) {
+  };
+
+  _formatConfigurationKey = (key) => {
     return StringUtils.capitalizeFirstLetter(key.replace(/_/g, ' '));
-  },
-  _formatConfigurationValue(key, value) {
+  };
+
+  _formatConfigurationValue = (key, value) => {
     if (key === 'query' && value === '') {
       return '*';
     }
@@ -61,8 +65,9 @@ const WidgetConfigModal = React.createClass({
     }
 
     return value;
-  },
-  _getConfigAsDescriptionList() {
+  };
+
+  _getConfigAsDescriptionList = () => {
     const configKeys = Object.keys(this.props.widget.config);
     if (configKeys.length === 0) {
       return [];
@@ -79,7 +84,8 @@ const WidgetConfigModal = React.createClass({
     });
 
     return configListElements;
-  },
+  };
+
   render() {
     return (
       <BootstrapModalWrapper ref="configModal">
@@ -108,7 +114,7 @@ const WidgetConfigModal = React.createClass({
         </Modal.Footer>
       </BootstrapModalWrapper>
     );
-  },
-});
+  }
+}
 
 export default WidgetConfigModal;

--- a/graylog2-web-interface/src/components/widgets/WidgetCreationModal.jsx
+++ b/graylog2-web-interface/src/components/widgets/WidgetCreationModal.jsx
@@ -1,5 +1,6 @@
 import PropTypes from 'prop-types';
 import React from 'react';
+import createReactClass from 'create-react-class';
 import { Input } from 'components/bootstrap';
 import { PluginStore } from 'graylog-web-plugin/plugin';
 
@@ -9,7 +10,9 @@ import FormsUtils from 'util/FormsUtils';
 import ObjectUtils from 'util/ObjectUtils';
 import StringUtils from 'util/StringUtils';
 
-const WidgetCreationModal = React.createClass({
+const WidgetCreationModal = createReactClass({
+  displayName: 'WidgetCreationModal',
+
   propTypes: {
     fields: PropTypes.array,
     onConfigurationSaved: PropTypes.func.isRequired,

--- a/graylog2-web-interface/src/components/widgets/WidgetEditConfigModal.jsx
+++ b/graylog2-web-interface/src/components/widgets/WidgetEditConfigModal.jsx
@@ -1,5 +1,6 @@
 import PropTypes from 'prop-types';
 import React from 'react';
+import createReactClass from 'create-react-class';
 import { Input } from 'components/bootstrap';
 import { PluginStore } from 'graylog-web-plugin/plugin';
 
@@ -11,7 +12,9 @@ import FormsUtils from 'util/FormsUtils';
 
 import BootstrapModalForm from 'components/bootstrap/BootstrapModalForm';
 
-const WidgetEditConfigModal = React.createClass({
+const WidgetEditConfigModal = createReactClass({
+  displayName: 'WidgetEditConfigModal',
+
   propTypes: {
     onModalHidden: PropTypes.func,
     onUpdate: PropTypes.func.isRequired,
@@ -222,6 +225,7 @@ const WidgetEditConfigModal = React.createClass({
 
     return null;
   },
+
   render() {
     return (
       <BootstrapModalForm ref="editModal"

--- a/graylog2-web-interface/src/components/widgets/WidgetFooter.jsx
+++ b/graylog2-web-interface/src/components/widgets/WidgetFooter.jsx
@@ -3,8 +3,8 @@ import React from 'react';
 import { Button } from 'react-bootstrap';
 import { Timestamp } from 'components/common';
 
-const WidgetFooter = React.createClass({
-  propTypes: {
+class WidgetFooter extends React.Component {
+  static propTypes = {
     locked: PropTypes.bool.isRequired,
     onDelete: PropTypes.func.isRequired,
     onEditConfig: PropTypes.func.isRequired,
@@ -14,19 +14,23 @@ const WidgetFooter = React.createClass({
     errorMessage: PropTypes.string,
     calculatedAt: PropTypes.string,
     replayDisabled: PropTypes.bool,
-  },
-  _showConfig(e) {
+  };
+
+  _showConfig = (e) => {
     e.preventDefault();
     this.props.onShowConfig();
-  },
-  _editConfig(e) {
+  };
+
+  _editConfig = (e) => {
     e.preventDefault();
     this.props.onEditConfig();
-  },
-  _delete(e) {
+  };
+
+  _delete = (e) => {
     e.preventDefault();
     this.props.onDelete();
-  },
+  };
+
   render() {
     let loadErrorElement;
 
@@ -90,7 +94,7 @@ const WidgetFooter = React.createClass({
         </div>
       </div>
     );
-  },
-});
+  }
+}
 
 export default WidgetFooter;

--- a/graylog2-web-interface/src/components/widgets/WidgetHeader.jsx
+++ b/graylog2-web-interface/src/components/widgets/WidgetHeader.jsx
@@ -1,10 +1,11 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 
-const WidgetHeader = React.createClass({
-  propTypes: {
+class WidgetHeader extends React.Component {
+  static propTypes = {
     title: PropTypes.string.isRequired,
-  },
+  };
+
   render() {
 
     return (
@@ -15,7 +16,7 @@ const WidgetHeader = React.createClass({
         <div className="clearfix" />
       </div>
     );
-  },
-});
+  }
+}
 
 export default WidgetHeader;

--- a/graylog2-web-interface/src/components/widgets/WidgetVisualizationNotFound.jsx
+++ b/graylog2-web-interface/src/components/widgets/WidgetVisualizationNotFound.jsx
@@ -2,21 +2,19 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import { Alert } from 'react-bootstrap';
 
-const WidgetVisualizationNotFound = React.createClass({
-  propTypes: {
+class WidgetVisualizationNotFound extends React.Component {
+  static propTypes = {
     widgetClassName: PropTypes.string.isRequired,
     onRenderComplete: PropTypes.func,
-  },
+  };
 
-  getDefaultProps() {
-    return {
-      onRenderComplete: () => {},
-    };
-  },
+  static defaultProps = {
+    onRenderComplete: () => {},
+  };
 
   componentDidMount() {
     this.props.onRenderComplete();
-  },
+  }
 
   render() {
     return (
@@ -25,7 +23,7 @@ const WidgetVisualizationNotFound = React.createClass({
         It looks like the plugin supplying this widget is not loaded.
       </Alert>
     );
-  },
-});
+  }
+}
 
 export default WidgetVisualizationNotFound;

--- a/graylog2-web-interface/src/components/widgets/configurations/CountWidgetCreateConfiguration.jsx
+++ b/graylog2-web-interface/src/components/widgets/configurations/CountWidgetCreateConfiguration.jsx
@@ -2,18 +2,18 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import { Input } from 'components/bootstrap';
 
-const CountWidgetCreateConfiguration = React.createClass({
-  propTypes: {
+class CountWidgetCreateConfiguration extends React.Component {
+  static propTypes = {
     config: PropTypes.object.isRequired,
     onChange: PropTypes.func.isRequired,
-  },
+  };
 
-  getInitialConfiguration() {
+  getInitialConfiguration = () => {
     return {
       trend: false,
       lower_is_better: false,
     };
-  },
+  };
 
   render() {
     return (
@@ -38,7 +38,7 @@ const CountWidgetCreateConfiguration = React.createClass({
                help="Use green colour when trend goes down." />
       </fieldset>
     );
-  },
-});
+  }
+}
 
 export default CountWidgetCreateConfiguration;

--- a/graylog2-web-interface/src/components/widgets/configurations/CountWidgetEditConfiguration.jsx
+++ b/graylog2-web-interface/src/components/widgets/configurations/CountWidgetEditConfiguration.jsx
@@ -4,17 +4,17 @@ import { Input } from 'components/bootstrap';
 
 import { QueryConfiguration } from 'components/widgets/configurations';
 
-const CountWidgetEditConfiguration = React.createClass({
-  propTypes: {
+class CountWidgetEditConfiguration extends React.Component {
+  static propTypes = {
     config: PropTypes.object.isRequired,
     onChange: PropTypes.func.isRequired,
     showQueryConfig: PropTypes.bool,
-  },
-  getDefaultProps() {
-    return {
-      showQueryConfig: true,
-    };
-  },
+  };
+
+  static defaultProps = {
+    showQueryConfig: true,
+  };
+
   render() {
     return (
       <fieldset>
@@ -39,7 +39,7 @@ const CountWidgetEditConfiguration = React.createClass({
                help="Use green colour when trend goes down." />
       </fieldset>
     );
-  },
-});
+  }
+}
 
 export default CountWidgetEditConfiguration;

--- a/graylog2-web-interface/src/components/widgets/configurations/FieldChartWidgetConfiguration.jsx
+++ b/graylog2-web-interface/src/components/widgets/configurations/FieldChartWidgetConfiguration.jsx
@@ -6,11 +6,12 @@ import { QueryConfiguration } from 'components/widgets/configurations';
 import StoreProvider from 'injection/StoreProvider';
 const FieldGraphsStore = StoreProvider.getStore('FieldGraphs');
 
-const FieldChartWidgetConfiguration = React.createClass({
-  propTypes: {
+class FieldChartWidgetConfiguration extends React.Component {
+  static propTypes = {
     config: PropTypes.object.isRequired,
     onChange: PropTypes.func.isRequired,
-  },
+  };
+
   render() {
     return (
       <fieldset>
@@ -33,7 +34,7 @@ const FieldChartWidgetConfiguration = React.createClass({
         </Input>
       </fieldset>
     );
-  },
-});
+  }
+}
 
 export default FieldChartWidgetConfiguration;

--- a/graylog2-web-interface/src/components/widgets/configurations/QueryConfiguration.jsx
+++ b/graylog2-web-interface/src/components/widgets/configurations/QueryConfiguration.jsx
@@ -2,11 +2,12 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import { Input } from 'components/bootstrap';
 
-const QueryConfiguration = React.createClass({
-  propTypes: {
+class QueryConfiguration extends React.Component {
+  static propTypes = {
     config: PropTypes.object.isRequired,
     onChange: PropTypes.func.isRequired,
-  },
+  };
+
   render() {
     return (
       <Input type="text"
@@ -18,7 +19,7 @@ const QueryConfiguration = React.createClass({
              onChange={this.props.onChange}
              help="Search query that will be executed to get the widget value." />
     );
-  },
-});
+  }
+}
 
 export default QueryConfiguration;

--- a/graylog2-web-interface/src/components/widgets/configurations/QuickValuesConfiguration.jsx
+++ b/graylog2-web-interface/src/components/widgets/configurations/QuickValuesConfiguration.jsx
@@ -4,18 +4,19 @@ import { ControlLabel, FormGroup } from 'react-bootstrap';
 import { Input } from 'components/bootstrap';
 import { MultiSelect } from 'components/common';
 
-const QuickValuesConfiguration = React.createClass({
-  propTypes: {
+class QuickValuesConfiguration extends React.Component {
+  static propTypes = {
     config: PropTypes.object.isRequired,
     onChange: PropTypes.func.isRequired,
     isHistogram: PropTypes.bool,
-  },
-  getDefaultProps() {
-    return { isHistogram: false };
-  },
-  _onStackedFieldChange(values) {
+  };
+
+  static defaultProps = { isHistogram: false };
+
+  _onStackedFieldChange = (values) => {
     this.props.onChange('stacked_fields', values);
-  },
+  };
+
   render() {
     let dataTableLimitForm;
     if (!this.props.isHistogram) {
@@ -64,7 +65,7 @@ const QuickValuesConfiguration = React.createClass({
         </FormGroup>
       </div>
     );
-  },
-});
+  }
+}
 
 export default QuickValuesConfiguration;

--- a/graylog2-web-interface/src/components/widgets/configurations/QuickValuesHistogramWidgetCreateConfiguration.jsx
+++ b/graylog2-web-interface/src/components/widgets/configurations/QuickValuesHistogramWidgetCreateConfiguration.jsx
@@ -1,19 +1,19 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 
-const QuickValuesHistogramWidgetCreateConfiguration = React.createClass({
-  propTypes: {
+class QuickValuesHistogramWidgetCreateConfiguration extends React.Component {
+  static propTypes = {
     config: PropTypes.object.isRequired,
     onChange: PropTypes.func.isRequired,
-  },
+  };
 
-  getInitialConfiguration() {
+  getInitialConfiguration = () => {
     return {};
-  },
+  };
 
   render() {
     return null;
-  },
-});
+  }
+}
 
 export default QuickValuesHistogramWidgetCreateConfiguration;

--- a/graylog2-web-interface/src/components/widgets/configurations/QuickValuesHistogramWidgetEditConfiguration.jsx
+++ b/graylog2-web-interface/src/components/widgets/configurations/QuickValuesHistogramWidgetEditConfiguration.jsx
@@ -6,15 +6,15 @@ import SearchUtils from 'util/SearchUtils';
 
 import { QueryConfiguration, QuickValuesConfiguration } from 'components/widgets/configurations';
 
-const QuickValuesHistogramWidgetEditConfiguration = React.createClass({
-  propTypes: {
+class QuickValuesHistogramWidgetEditConfiguration extends React.Component {
+  static propTypes = {
     config: PropTypes.object.isRequired,
     onChange: PropTypes.func.isRequired,
-  },
+  };
 
-  _onIntervalChange(value) {
+  _onIntervalChange = (value) => {
     this.props.onChange('interval', value);
-  },
+  };
 
   render() {
     const intervalOptions = SearchUtils.histogramIntervals().map((i) => {
@@ -33,7 +33,7 @@ const QuickValuesHistogramWidgetEditConfiguration = React.createClass({
         </FormGroup>
       </fieldset>
     );
-  },
-});
+  }
+}
 
 export default QuickValuesHistogramWidgetEditConfiguration;

--- a/graylog2-web-interface/src/components/widgets/configurations/QuickValuesWidgetCreateConfiguration.jsx
+++ b/graylog2-web-interface/src/components/widgets/configurations/QuickValuesWidgetCreateConfiguration.jsx
@@ -2,18 +2,18 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import { Input } from 'components/bootstrap';
 
-const QuickValuesWidgetCreateConfiguration = React.createClass({
-  propTypes: {
+class QuickValuesWidgetCreateConfiguration extends React.Component {
+  static propTypes = {
     config: PropTypes.object.isRequired,
     onChange: PropTypes.func.isRequired,
-  },
+  };
 
-  getInitialConfiguration() {
+  getInitialConfiguration = () => {
     return {
       show_pie_chart: true,
       show_data_table: true,
     };
-  },
+  };
 
   render() {
     return (
@@ -37,7 +37,7 @@ const QuickValuesWidgetCreateConfiguration = React.createClass({
                help="Include a table with quantitative information." />
       </fieldset>
     );
-  },
-});
+  }
+}
 
 export default QuickValuesWidgetCreateConfiguration;

--- a/graylog2-web-interface/src/components/widgets/configurations/QuickValuesWidgetEditConfiguration.jsx
+++ b/graylog2-web-interface/src/components/widgets/configurations/QuickValuesWidgetEditConfiguration.jsx
@@ -4,11 +4,12 @@ import { Input } from 'components/bootstrap';
 
 import { QueryConfiguration, QuickValuesConfiguration } from 'components/widgets/configurations';
 
-const QuickValuesWidgetEditConfiguration = React.createClass({
-  propTypes: {
+class QuickValuesWidgetEditConfiguration extends React.Component {
+  static propTypes = {
     config: PropTypes.object.isRequired,
     onChange: PropTypes.func.isRequired,
-  },
+  };
+
   render() {
     return (
       <fieldset>
@@ -33,7 +34,7 @@ const QuickValuesWidgetEditConfiguration = React.createClass({
                help="Include a table with quantitative information." />
       </fieldset>
     );
-  },
-});
+  }
+}
 
 export default QuickValuesWidgetEditConfiguration;

--- a/graylog2-web-interface/src/components/widgets/configurations/StackedChartWidgetConfiguration.jsx
+++ b/graylog2-web-interface/src/components/widgets/configurations/StackedChartWidgetConfiguration.jsx
@@ -10,21 +10,21 @@ import FormsUtils from 'util/FormsUtils';
 import StoreProvider from 'injection/StoreProvider';
 const FieldGraphsStore = StoreProvider.getStore('FieldGraphs');
 
-const StackedChartWidgetConfiguration = React.createClass({
-  propTypes: {
+class StackedChartWidgetConfiguration extends React.Component {
+  static propTypes = {
     config: PropTypes.object.isRequired,
     onChange: PropTypes.func.isRequired,
-  },
+  };
 
-  _setSeriesSetting(seriesNo, key, value) {
+  _setSeriesSetting = (seriesNo, key, value) => {
     const newSeries = ObjectUtils.clone(this.props.config.series);
     newSeries[seriesNo][key] = value;
     this.props.onChange('series', newSeries);
-  },
+  };
 
-  _bindSeriesValue(event) {
+  _bindSeriesValue = (event) => {
     this._setSeriesSetting(event.target.getAttribute('data-series'), event.target.name, FormsUtils.getValueFromInput(event.target));
-  },
+  };
 
   render() {
     const controls = [];
@@ -76,7 +76,7 @@ const StackedChartWidgetConfiguration = React.createClass({
         {controls}
       </fieldset>
     );
-  },
-});
+  }
+}
 
 export default StackedChartWidgetConfiguration;

--- a/graylog2-web-interface/src/components/widgets/configurations/StatisticalCountWidgetCreateConfiguration.jsx
+++ b/graylog2-web-interface/src/components/widgets/configurations/StatisticalCountWidgetCreateConfiguration.jsx
@@ -8,35 +8,28 @@ import { CountWidgetCreateConfiguration } from 'components/widgets/configuration
 import StoreProvider from 'injection/StoreProvider';
 const FieldStatisticsStore = StoreProvider.getStore('FieldStatistics');
 
-const StatisticalCountWidgetCreateConfiguration = React.createClass({
-  propTypes: {
+class StatisticalCountWidgetCreateConfiguration extends React.Component {
+  static propTypes = {
     config: PropTypes.object.isRequired,
     fields: PropTypes.array.isRequired,
     onChange: PropTypes.func.isRequired,
-  },
-
-  getInitialState() {
-    return {
-      sortedFields: this._sortFields(this.props.fields),
-      sortedStatisticalFunctions: this._sortStatisticalFunctions(FieldStatisticsStore.FUNCTIONS.keySeq().toJS()),
-    };
-  },
+  };
 
   componentWillReceiveProps(nextProps) {
     if (this.props.fields !== nextProps.fields) {
       this.setState({ sortedFields: this._sortFields(nextProps.fields) });
     }
-  },
+  }
 
-  _sortFields(fields) {
+  _sortFields = (fields) => {
     return fields.sort((a, b) => naturalSort(a.toLowerCase(), b.toLowerCase()));
-  },
+  };
 
-  _sortStatisticalFunctions(statisticalFunctions) {
+  _sortStatisticalFunctions = (statisticalFunctions) => {
     return statisticalFunctions.sort();
-  },
+  };
 
-  getInitialConfiguration() {
+  getInitialConfiguration = () => {
     const countConfiguration = this.refs.countConfiguration.getInitialConfiguration();
     const initialConfiguration = {};
 
@@ -45,7 +38,12 @@ const StatisticalCountWidgetCreateConfiguration = React.createClass({
     initialConfiguration.stats_function = this.state.sortedStatisticalFunctions[0];
 
     return initialConfiguration;
-  },
+  };
+
+  state = {
+    sortedFields: this._sortFields(this.props.fields),
+    sortedStatisticalFunctions: this._sortStatisticalFunctions(FieldStatisticsStore.FUNCTIONS.keySeq().toJS()),
+  };
 
   render() {
     return (
@@ -84,7 +82,7 @@ const StatisticalCountWidgetCreateConfiguration = React.createClass({
         <CountWidgetCreateConfiguration ref="countConfiguration" {...this.props} />
       </fieldset>
     );
-  },
-});
+  }
+}
 
 export default StatisticalCountWidgetCreateConfiguration;

--- a/graylog2-web-interface/src/components/widgets/configurations/StatisticalCountWidgetEditConfiguration.jsx
+++ b/graylog2-web-interface/src/components/widgets/configurations/StatisticalCountWidgetEditConfiguration.jsx
@@ -7,11 +7,12 @@ import { QueryConfiguration, CountWidgetEditConfiguration } from 'components/wid
 import StoreProvider from 'injection/StoreProvider';
 const FieldStatisticsStore = StoreProvider.getStore('FieldStatistics');
 
-const StatisticalCountWidgetConfiguration = React.createClass({
-  propTypes: {
+class StatisticalCountWidgetConfiguration extends React.Component {
+  static propTypes = {
     config: PropTypes.object.isRequired,
     onChange: PropTypes.func.isRequired,
-  },
+  };
+
   render() {
     const defaultStatisticalFunction = this.props.config.stats_function === 'stddev' ? 'std_deviation' : this.props.config.stats_function;
 
@@ -37,7 +38,7 @@ const StatisticalCountWidgetConfiguration = React.createClass({
         <CountWidgetEditConfiguration {...this.props} showQueryConfig={false} />
       </fieldset>
     );
-  },
-});
+  }
+}
 
 export default StatisticalCountWidgetConfiguration;

--- a/graylog2-web-interface/src/pages/AlertConditionsPage.jsx
+++ b/graylog2-web-interface/src/pages/AlertConditionsPage.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import createReactClass from 'create-react-class';
 import Reflux from 'reflux';
 import { Col, Row } from 'react-bootstrap';
 
@@ -13,8 +14,10 @@ import DocsHelper from 'util/DocsHelper';
 import StoreProvider from 'injection/StoreProvider';
 const CurrentUserStore = StoreProvider.getStore('CurrentUser');
 
-const AlertConditionsPage = React.createClass({
+const AlertConditionsPage = createReactClass({
+  displayName: 'AlertConditionsPage',
   mixins: [Reflux.connect(CurrentUserStore)],
+
   render() {
     return (
       <DocumentTitle title="Alert conditions">

--- a/graylog2-web-interface/src/pages/AlertNotificationsPage.jsx
+++ b/graylog2-web-interface/src/pages/AlertNotificationsPage.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import createReactClass from 'create-react-class';
 import Reflux from 'reflux';
 import { Col, Row } from 'react-bootstrap';
 
@@ -10,8 +11,10 @@ import Routes from 'routing/Routes';
 import StoreProvider from 'injection/StoreProvider';
 const CurrentUserStore = StoreProvider.getStore('CurrentUser');
 
-const AlertNotificationsPage = React.createClass({
+const AlertNotificationsPage = createReactClass({
+  displayName: 'AlertNotificationsPage',
   mixins: [Reflux.connect(CurrentUserStore)],
+
   render() {
     return (
       <DocumentTitle title="Alert notifications">

--- a/graylog2-web-interface/src/pages/AlertsPage.jsx
+++ b/graylog2-web-interface/src/pages/AlertsPage.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import createReactClass from 'create-react-class';
 import Reflux from 'reflux';
 import { Col, Row } from 'react-bootstrap';
 
@@ -13,8 +14,10 @@ import DocsHelper from 'util/DocsHelper';
 import StoreProvider from 'injection/StoreProvider';
 const CurrentUserStore = StoreProvider.getStore('CurrentUser');
 
-const AlertsPage = React.createClass({
+const AlertsPage = createReactClass({
+  displayName: 'AlertsPage',
   mixins: [Reflux.connect(CurrentUserStore)],
+
   render() {
     return (
       <DocumentTitle title="Alerts">

--- a/graylog2-web-interface/src/pages/AuthenticationPage.jsx
+++ b/graylog2-web-interface/src/pages/AuthenticationPage.jsx
@@ -1,5 +1,6 @@
 import PropTypes from 'prop-types';
 import React from 'react';
+import createReactClass from 'create-react-class';
 import { Row, Col } from 'react-bootstrap';
 
 import DocsHelper from 'util/DocsHelper';
@@ -12,7 +13,8 @@ import DocumentationLink from 'components/support/DocumentationLink';
 
 import AuthenticationComponent from 'components/authentication/AuthenticationComponent';
 
-const AuthenticationPage = React.createClass({
+const AuthenticationPage = createReactClass({
+  displayName: 'AuthenticationPage',
 
   propTypes: {
     children: PropTypes.object,

--- a/graylog2-web-interface/src/pages/ConfigurationsPage.jsx
+++ b/graylog2-web-interface/src/pages/ConfigurationsPage.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import createReactClass from 'create-react-class';
 import Reflux from 'reflux';
 import { Row, Col } from 'react-bootstrap';
 import { DocumentTitle, PageHeader, Spinner } from 'components/common';
@@ -14,7 +15,8 @@ import SearchesConfig from 'components/configurations/SearchesConfig';
 import MessageProcessorsConfig from 'components/configurations/MessageProcessorsConfig';
 import {} from 'components/maps/configurations'
 
-const ConfigurationsPage = React.createClass({
+const ConfigurationsPage = createReactClass({
+  displayName: 'ConfigurationsPage',
   mixins: [Reflux.connect(ConfigurationsStore)],
 
   getInitialState() {

--- a/graylog2-web-interface/src/pages/ContentPacksPage.jsx
+++ b/graylog2-web-interface/src/pages/ContentPacksPage.jsx
@@ -7,7 +7,7 @@ import Routes from 'routing/Routes';
 import { DocumentTitle, PageHeader } from 'components/common';
 import ConfigurationBundles from 'components/source-tagging/ConfigurationBundles';
 
-const ContentPacksPage = React.createClass({
+class ContentPacksPage extends React.Component {
   render() {
     return (
       <DocumentTitle title="Content packs">
@@ -39,7 +39,7 @@ const ContentPacksPage = React.createClass({
         </span>
       </DocumentTitle>
     );
-  },
-});
+  }
+}
 
 export default ContentPacksPage;

--- a/graylog2-web-interface/src/pages/CreateExtractorsPage.jsx
+++ b/graylog2-web-interface/src/pages/CreateExtractorsPage.jsx
@@ -1,5 +1,6 @@
 import PropTypes from 'prop-types';
 import React from 'react';
+import createReactClass from 'create-react-class';
 import Reflux from 'reflux';
 
 import { DocumentTitle, PageHeader, Spinner } from 'components/common';
@@ -21,12 +22,16 @@ import ActionsProvider from 'injection/ActionsProvider';
 const InputsActions = ActionsProvider.getActions('Inputs');
 const MessagesActions = ActionsProvider.getActions('Messages');
 
-const CreateExtractorsPage = React.createClass({
+const CreateExtractorsPage = createReactClass({
+  displayName: 'CreateExtractorsPage',
+
   propTypes: {
     params: PropTypes.object.isRequired,
     location: PropTypes.object.isRequired,
   },
+
   mixins: [Reflux.connect(InputsStore)],
+
   getInitialState() {
     const { query } = this.props.location;
 
@@ -40,14 +45,17 @@ const CreateExtractorsPage = React.createClass({
       exampleId: query.example_id,
     };
   },
+
   componentDidMount() {
     InputsActions.get.triggerPromise(this.props.params.inputId);
     MessagesActions.loadMessage.triggerPromise(this.state.exampleIndex, this.state.exampleId)
       .then(message => this.setState({ exampleMessage: message }));
   },
+
   _isLoading() {
     return !(this.state.input && this.state.exampleMessage);
   },
+
   _extractorSaved() {
     let url;
     if (this.state.input.global) {
@@ -58,6 +66,7 @@ const CreateExtractorsPage = React.createClass({
 
     history.push(url);
   },
+
   render() {
     if (this._isLoading()) {
       return <Spinner />;

--- a/graylog2-web-interface/src/pages/CreateUsersPage.jsx
+++ b/graylog2-web-interface/src/pages/CreateUsersPage.jsx
@@ -12,20 +12,18 @@ const UsersStore = StoreProvider.getStore('Users');
 import { DocumentTitle, PageHeader, Spinner } from 'components/common';
 import NewUserForm from 'components/users/NewUserForm';
 
-const CreateUsersPage = React.createClass({
-  getInitialState() {
-    return {
-      roles: undefined,
-    };
-  },
+class CreateUsersPage extends React.Component {
+  state = {
+    roles: undefined,
+  };
 
   componentDidMount() {
     RolesStore.loadRoles().then((roles) => {
       this.setState({ roles: roles });
     });
-  },
+  }
 
-  _onSubmit(r) {
+  _onSubmit = (r) => {
     const request = r;
     request.permissions = [];
     delete request['session-timeout-never'];
@@ -35,11 +33,11 @@ const CreateUsersPage = React.createClass({
     }, () => {
       UserNotification.error('Failed to create user!', 'Error!');
     });
-  },
+  };
 
-  _onCancel() {
+  _onCancel = () => {
     history.push(Routes.SYSTEM.AUTHENTICATION.USERS.LIST);
-  },
+  };
 
   render() {
     if (!this.state.roles) {
@@ -62,7 +60,7 @@ const CreateUsersPage = React.createClass({
         </span>
       </DocumentTitle>
     );
-  },
-});
+  }
+}
 
 export default CreateUsersPage;

--- a/graylog2-web-interface/src/pages/DashboardsPage.jsx
+++ b/graylog2-web-interface/src/pages/DashboardsPage.jsx
@@ -1,12 +1,15 @@
 import React from 'react';
+import createReactClass from 'create-react-class';
 import Reflux from 'reflux';
 import { DocumentTitle } from 'components/common';
 import DashboardListPage from 'components/dashboard/DashboardListPage';
 import StoreProvider from 'injection/StoreProvider';
 const CurrentUserStore = StoreProvider.getStore('CurrentUser');
 
-const DashboardsPage = React.createClass({
+const DashboardsPage = createReactClass({
+  displayName: 'DashboardsPage',
   mixins: [Reflux.connect(CurrentUserStore)],
+
   render() {
     return (
       <DocumentTitle title="Dashboards">

--- a/graylog2-web-interface/src/pages/EditAlertConditionPage.jsx
+++ b/graylog2-web-interface/src/pages/EditAlertConditionPage.jsx
@@ -1,5 +1,6 @@
 import PropTypes from 'prop-types';
 import React from 'react';
+import createReactClass from 'create-react-class';
 import Reflux from 'reflux';
 import { Col, Row } from 'react-bootstrap';
 
@@ -16,7 +17,9 @@ const { CurrentUserStore } = CombinedProvider.get('CurrentUser');
 const { StreamsStore } = CombinedProvider.get('Streams');
 const { AlertConditionsStore, AlertConditionsActions } = CombinedProvider.get('AlertConditions');
 
-const EditAlertConditionPage = React.createClass({
+const EditAlertConditionPage = createReactClass({
+  displayName: 'EditAlertConditionPage',
+
   propTypes: {
     params: PropTypes.object.isRequired,
   },

--- a/graylog2-web-interface/src/pages/EditExtractorsPage.jsx
+++ b/graylog2-web-interface/src/pages/EditExtractorsPage.jsx
@@ -1,5 +1,6 @@
 import PropTypes from 'prop-types';
 import React from 'react';
+import createReactClass from 'create-react-class';
 import Reflux from 'reflux';
 
 import { DocumentTitle, PageHeader, Spinner } from 'components/common';
@@ -19,11 +20,15 @@ const ExtractorsStore = StoreProvider.getStore('Extractors');
 const InputsStore = StoreProvider.getStore('Inputs');
 const UniversalSearchstore = StoreProvider.getStore('UniversalSearch');
 
-const EditExtractorsPage = React.createClass({
+const EditExtractorsPage = createReactClass({
+  displayName: 'EditExtractorsPage',
+
   propTypes: {
     params: PropTypes.object.isRequired,
   },
+
   mixins: [Reflux.connect(ExtractorsStore), Reflux.connect(InputsStore)],
+
   getInitialState() {
     return {
       extractor: undefined,
@@ -31,6 +36,7 @@ const EditExtractorsPage = React.createClass({
       exampleMessage: undefined,
     };
   },
+
   componentDidMount() {
     InputsActions.get.triggerPromise(this.props.params.inputId);
     ExtractorsActions.get.triggerPromise(this.props.params.inputId, this.props.params.extractorId);
@@ -43,9 +49,11 @@ const EditExtractorsPage = React.createClass({
         }
       });
   },
+
   _isLoading() {
     return !(this.state.input && this.state.extractor && this.state.exampleMessage);
   },
+
   _extractorSaved() {
     let url;
     if (this.state.input.global) {
@@ -56,6 +64,7 @@ const EditExtractorsPage = React.createClass({
 
     history.push(url);
   },
+
   render() {
     // TODO:
     // - Redirect when extractor or input were deleted

--- a/graylog2-web-interface/src/pages/EditTokensPage.jsx
+++ b/graylog2-web-interface/src/pages/EditTokensPage.jsx
@@ -1,5 +1,6 @@
 import PropTypes from 'prop-types';
 import React from 'react';
+import createReactClass from 'create-react-class';
 import Reflux from 'reflux';
 
 import TokenList from 'components/users/TokenList';
@@ -10,7 +11,8 @@ import PermissionsMixin from 'util/PermissionsMixin';
 const UsersStore = StoreProvider.getStore('Users');
 const CurrentUserStore = StoreProvider.getStore('CurrentUser');
 
-const EditTokensPage = React.createClass({
+const EditTokensPage = createReactClass({
+  displayName: 'EditTokensPage',
   mixins: [Reflux.connect(CurrentUserStore), PermissionsMixin],
 
   propTypes: {

--- a/graylog2-web-interface/src/pages/EditUsersPage.jsx
+++ b/graylog2-web-interface/src/pages/EditUsersPage.jsx
@@ -11,36 +11,38 @@ import UserForm from 'components/users/UserForm';
 
 import UserPreferencesButton from 'components/users/UserPreferencesButton';
 
-const EditUsersPage = React.createClass({
-  propTypes: {
+class EditUsersPage extends React.Component {
+  static propTypes = {
     params: PropTypes.object.isRequired,
-  },
-  getInitialState() {
-    return {
-      user: undefined,
-    };
-  },
+  };
+
+  state = {
+    user: undefined,
+  };
+
   componentDidMount() {
     this._loadUser(this.props.params.username);
-  },
+  }
 
   componentWillReceiveProps(nextProps) {
     if (this.props.params.username !== nextProps.params.username) {
       this._loadUser(nextProps.params.username);
     }
-  },
+  }
 
-  _loadUser(username) {
+  _loadUser = (username) => {
     UsersStore.load(username).then((user) => {
       this.setState({ user: user });
     });
-  },
-  _resetStartpage() {
+  };
+
+  _resetStartpage = () => {
     if (window.confirm('Are you sure you want to reset the start page?')) {
       const username = this.props.params.username;
       StartpageStore.set(username).then(() => this._loadUser(username));
     }
-  },
+  };
+
   render() {
     if (!this.state.user) {
       return <Spinner />;
@@ -74,7 +76,7 @@ const EditUsersPage = React.createClass({
         </span>
       </DocumentTitle>
     );
-  },
-});
+  }
+}
 
 export default EditUsersPage;

--- a/graylog2-web-interface/src/pages/EnterprisePage.jsx
+++ b/graylog2-web-interface/src/pages/EnterprisePage.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import createReactClass from 'create-react-class';
 import Reflux from 'reflux';
 
 import { DocumentTitle, PageHeader } from 'components/common';
@@ -8,7 +9,8 @@ import PluginList from 'components/enterprise/PluginList';
 import StoreProvider from 'injection/StoreProvider';
 const NodesStore = StoreProvider.getStore('Nodes');
 
-const EnterprisePage = React.createClass({
+const EnterprisePage = createReactClass({
+  displayName: 'EnterprisePage',
   mixins: [Reflux.connect(NodesStore)],
 
   _isLoading() {

--- a/graylog2-web-interface/src/pages/ExportContentPackPage.jsx
+++ b/graylog2-web-interface/src/pages/ExportContentPackPage.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import createReactClass from 'create-react-class';
 import Reflux from 'reflux';
 import { Row, Col, Button } from 'react-bootstrap';
 
@@ -23,11 +24,14 @@ const ConfigurationBundlesStore = StoreProvider.getStore('ConfigurationBundles')
 const InputsActions = ActionsProvider.getActions('Inputs');
 const ConfigurationBundlesActions = ActionsProvider.getActions('ConfigurationBundles');
 
-const ExportContentPackPage = React.createClass({
+const ExportContentPackPage = createReactClass({
+  displayName: 'ExportContentPackPage',
   mixins: [Reflux.connect(InputsStore), Reflux.connect(DashboardsStore)],
+
   getInitialState() {
     return {};
   },
+
   componentDidMount() {
     GrokPatternsStore.loadPatterns((grokPatterns) => {
       this.setState({ grok_patterns: grokPatterns });
@@ -52,6 +56,7 @@ const ExportContentPackPage = React.createClass({
       this.setState({ lookup_data_adapters: result.data_adapters });
     });
   },
+
   onSubmit(evt) {
     evt.preventDefault();
     const request = {
@@ -80,9 +85,11 @@ const ExportContentPackPage = React.createClass({
         FileSaver.save(response, 'content_pack.json', 'application/json', 'utf-8');
       });
   },
+
   isEmpty(obj) {
     return ((obj === undefined) || (typeof obj.count === 'function' ? obj.count() === 0 : obj.length === 0));
   },
+
   inputDetails(input) {
     let details = input.name;
     if (input.attributes.bind_address) {
@@ -94,6 +101,7 @@ const ExportContentPackPage = React.createClass({
 
     return details;
   },
+
   formatDashboard(dashboard) {
     return (
       <div className="checkbox" key={`dashboard_checkbox-${dashboard.id}`}>
@@ -101,6 +109,7 @@ const ExportContentPackPage = React.createClass({
       </div>
     );
   },
+
   formatGrokPattern(grokPattern) {
     return (
       <div className="checkbox" key={`grok_pattern_checkbox-${grokPattern.id}`}>
@@ -109,6 +118,7 @@ const ExportContentPackPage = React.createClass({
       </div>
     );
   },
+
   formatInput(input) {
     return (
       <div className="checkbox" key={`input_checkbox-${input.id}`}>
@@ -117,6 +127,7 @@ const ExportContentPackPage = React.createClass({
       </div>
     );
   },
+
   formatOutput(output) {
     return (
       <div className="checkbox" key={`output_checkbox-${output.id}`}>
@@ -124,6 +135,7 @@ const ExportContentPackPage = React.createClass({
       </div>
     );
   },
+
   formatStream(stream) {
     return (
       <div className="checkbox" key={`stream_checkbox-${stream.id}`}>
@@ -131,6 +143,7 @@ const ExportContentPackPage = React.createClass({
       </div>
     );
   },
+
   formatLookupTable(lookupTable) {
     return (
       <div className="checkbox" key={`lookup_table_checkbox-${lookupTable.id}`}>
@@ -138,6 +151,7 @@ const ExportContentPackPage = React.createClass({
       </div>
     );
   },
+
   formatLookupCache(lookupCache) {
     return (
       <div className="checkbox" key={`lookup_cache_checkbox-${lookupCache.id}`}>
@@ -145,6 +159,7 @@ const ExportContentPackPage = React.createClass({
       </div>
     );
   },
+
   formatLookupDataAdapter(lookupDataAdapter) {
     return (
       <div className="checkbox" key={`lookup_data_adapter_checkbox-${lookupDataAdapter.id}`}>
@@ -152,6 +167,7 @@ const ExportContentPackPage = React.createClass({
       </div>
     );
   },
+
   selectAll(group) {
     Object.keys(this.refs).forEach((key) => {
       if (key.indexOf(group) === 0) {
@@ -159,30 +175,39 @@ const ExportContentPackPage = React.createClass({
       }
     });
   },
+
   selectAllInputs() {
     this.selectAll('input');
   },
+
   selectAllGrokPatterns() {
     this.selectAll('grok_pattern');
   },
+
   selectAllOutputs() {
     this.selectAll('output');
   },
+
   selectAllStreams() {
     this.selectAll('stream');
   },
+
   selectAllDashboards() {
     this.selectAll('dashboard');
   },
+
   selectAllLookupTables() {
     this.selectAll('lookup_table');
   },
+
   selectAllLookupCaches() {
     this.selectAll('lookup_cache');
   },
+
   selectAllLookupDataAdapters() {
     this.selectAll('lookup_data_adapter');
   },
+
   render() {
     return (
       <DocumentTitle title="Create a content pack">

--- a/graylog2-web-interface/src/pages/ExportExtractorsPage.jsx
+++ b/graylog2-web-interface/src/pages/ExportExtractorsPage.jsx
@@ -1,5 +1,6 @@
 import PropTypes from 'prop-types';
 import React from 'react';
+import createReactClass from 'create-react-class';
 import Reflux from 'reflux';
 
 import { DocumentTitle, PageHeader, Spinner } from 'components/common';
@@ -11,22 +12,29 @@ const InputsActions = ActionsProvider.getActions('Inputs');
 import StoreProvider from 'injection/StoreProvider';
 const InputsStore = StoreProvider.getStore('Inputs');
 
-const ExportExtractorsPage = React.createClass({
+const ExportExtractorsPage = createReactClass({
+  displayName: 'ExportExtractorsPage',
+
   propTypes: {
     params: PropTypes.object.isRequired,
   },
+
   mixins: [Reflux.connect(InputsStore)],
+
   getInitialState() {
     return {
       input: undefined,
     };
   },
+
   componentDidMount() {
     InputsActions.get.triggerPromise(this.props.params.inputId);
   },
+
   _isLoading() {
     return !this.state.input;
   },
+
   render() {
     if (this._isLoading()) {
       return <Spinner />;

--- a/graylog2-web-interface/src/pages/ExtractorsPage.jsx
+++ b/graylog2-web-interface/src/pages/ExtractorsPage.jsx
@@ -1,5 +1,6 @@
 import PropTypes from 'prop-types';
 import React from 'react';
+import createReactClass from 'create-react-class';
 import Reflux from 'reflux';
 import { DropdownButton, MenuItem } from 'react-bootstrap';
 import { LinkContainer } from 'react-router-bootstrap';
@@ -20,21 +21,27 @@ import StoreProvider from 'injection/StoreProvider';
 const NodesStore = StoreProvider.getStore('Nodes');
 const InputsStore = StoreProvider.getStore('Inputs');
 
-const ExtractorsPage = React.createClass({
+const ExtractorsPage = createReactClass({
+  displayName: 'ExtractorsPage',
+
   propTypes: {
     params: PropTypes.object.isRequired,
   },
+
   mixins: [Reflux.connect(InputsStore), Reflux.listenTo(NodesStore, 'onNodesChange')],
+
   getInitialState() {
     return {
       input: undefined,
       node: undefined,
     };
   },
+
   componentDidMount() {
     InputsActions.get.triggerPromise(this.props.params.inputId);
     NodesActions.list.triggerPromise();
   },
+
   onNodesChange(nodes) {
     let inputNode;
     if (this.props.params.nodeId) {
@@ -53,9 +60,11 @@ const ExtractorsPage = React.createClass({
       this.setState({ node: inputNode });
     }
   },
+
   _isLoading() {
     return !(this.state.input && this.state.node);
   },
+
   render() {
     if (this._isLoading()) {
       return <Spinner />;

--- a/graylog2-web-interface/src/pages/GettingStartedPage.jsx
+++ b/graylog2-web-interface/src/pages/GettingStartedPage.jsx
@@ -1,5 +1,6 @@
 import PropTypes from 'prop-types';
 import React from 'react';
+import createReactClass from 'create-react-class';
 import Reflux from 'reflux';
 
 import { DocumentTitle, Spinner } from 'components/common';
@@ -13,17 +14,23 @@ import StoreProvider from 'injection/StoreProvider';
 const SystemStore = StoreProvider.getStore('System');
 
 const GETTING_STARTED_URL = 'https://gettingstarted.graylog.org/';
-const GettingStartedPage = React.createClass({
+const GettingStartedPage = createReactClass({
+  displayName: 'GettingStartedPage',
+
   propTypes: {
     location: PropTypes.object.isRequired,
   },
+
   mixins: [Reflux.connect(SystemStore)],
+
   _isLoading() {
     return !this.state.system;
   },
+
   _onDismiss() {
     history.push(Routes.STARTPAGE);
   },
+
   render() {
     if (this._isLoading()) {
       return <Spinner />;

--- a/graylog2-web-interface/src/pages/GrokPatternsPage.jsx
+++ b/graylog2-web-interface/src/pages/GrokPatternsPage.jsx
@@ -3,14 +3,14 @@ import React from 'react';
 import GrokPatterns from 'components/grok-patterns/GrokPatterns';
 import { DocumentTitle } from 'components/common';
 
-const GrokPatternsPage = React.createClass({
+class GrokPatternsPage extends React.Component {
   render() {
     return (
       <DocumentTitle title="Grok patterns">
         <GrokPatterns />
       </DocumentTitle>
     );
-  },
-});
+  }
+}
 
 export default GrokPatternsPage;

--- a/graylog2-web-interface/src/pages/ImportExtractorsPage.jsx
+++ b/graylog2-web-interface/src/pages/ImportExtractorsPage.jsx
@@ -1,5 +1,6 @@
 import PropTypes from 'prop-types';
 import React from 'react';
+import createReactClass from 'create-react-class';
 import Reflux from 'reflux';
 
 import { DocumentTitle, PageHeader, Spinner } from 'components/common';
@@ -11,22 +12,29 @@ const InputsActions = ActionsProvider.getActions('Inputs');
 import StoreProvider from 'injection/StoreProvider';
 const InputsStore = StoreProvider.getStore('Inputs');
 
-const ImportExtractorsPage = React.createClass({
+const ImportExtractorsPage = createReactClass({
+  displayName: 'ImportExtractorsPage',
+
   propTypes: {
     params: PropTypes.object.isRequired,
   },
+
   mixins: [Reflux.connect(InputsStore)],
+
   getInitialState() {
     return {
       input: undefined,
     };
   },
+
   componentDidMount() {
     InputsActions.get.triggerPromise(this.props.params.inputId).then(input => this.setState({ input: input }));
   },
+
   _isLoading() {
     return !this.state.input;
   },
+
   render() {
     if (this._isLoading()) {
       return <Spinner />;

--- a/graylog2-web-interface/src/pages/IndexSetConfigurationPage.jsx
+++ b/graylog2-web-interface/src/pages/IndexSetConfigurationPage.jsx
@@ -1,5 +1,6 @@
 import PropTypes from 'prop-types';
 import React from 'react';
+import createReactClass from 'create-react-class';
 import Reflux from 'reflux';
 import { LinkContainer } from 'react-router-bootstrap';
 import { Button, Row, Col } from 'react-bootstrap';
@@ -17,7 +18,9 @@ import DocsHelper from 'util/DocsHelper';
 import history from 'util/History';
 import Routes from 'routing/Routes';
 
-const IndexSetConfigurationPage = React.createClass({
+const IndexSetConfigurationPage = createReactClass({
+  displayName: 'IndexSetConfigurationPage',
+
   propTypes: {
     params: PropTypes.object.isRequired,
     location: PropTypes.object.isRequired,

--- a/graylog2-web-interface/src/pages/IndexSetCreationPage.jsx
+++ b/graylog2-web-interface/src/pages/IndexSetCreationPage.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import createReactClass from 'create-react-class';
 import Reflux from 'reflux';
 import { LinkContainer } from 'react-router-bootstrap';
 import { Button, Row, Col } from 'react-bootstrap';
@@ -17,7 +18,8 @@ import history from 'util/History';
 import DocsHelper from 'util/DocsHelper';
 import Routes from 'routing/Routes';
 
-const IndexSetCreationPage = React.createClass({
+const IndexSetCreationPage = createReactClass({
+  displayName: 'IndexSetCreationPage',
   mixins: [Reflux.connect(IndexSetsStore), Reflux.connect(IndicesConfigurationStore)],
 
   getInitialState() {

--- a/graylog2-web-interface/src/pages/IndexSetPage.jsx
+++ b/graylog2-web-interface/src/pages/IndexSetPage.jsx
@@ -1,5 +1,6 @@
 import PropTypes from 'prop-types';
 import React from 'react';
+import createReactClass from 'create-react-class';
 import Reflux from 'reflux';
 import { LinkContainer } from 'react-router-bootstrap';
 import { Alert, Button, Row, Col, Panel } from 'react-bootstrap';
@@ -20,7 +21,9 @@ const { IndexerOverviewStore, IndexerOverviewActions } = CombinedProvider.get('I
 
 import Routes from 'routing/Routes';
 
-const IndexSetPage = React.createClass({
+const IndexSetPage = createReactClass({
+  displayName: 'IndexSetPage',
+
   propTypes: {
     params: PropTypes.object.isRequired,
   },

--- a/graylog2-web-interface/src/pages/IndexerFailuresPage.jsx
+++ b/graylog2-web-interface/src/pages/IndexerFailuresPage.jsx
@@ -12,25 +12,28 @@ import { DocumentTitle, Spinner, PageHeader, PaginatedList } from 'components/co
 import { DocumentationLink } from 'components/support';
 import { IndexerFailuresList } from 'components/indexers';
 
-const IndexerFailuresPage = React.createClass({
-  getInitialState() {
-    return {};
-  },
+class IndexerFailuresPage extends React.Component {
+  state = {};
+
   componentDidMount() {
     IndexerFailuresStore.count(moment().subtract(10, 'years')).then((response) => {
       this.setState({ total: response.count });
     });
     this.loadData(1, this.defaultPageSize);
-  },
-  defaultPageSize: 50,
-  loadData(page, size) {
+  }
+
+  defaultPageSize = 50;
+
+  loadData = (page, size) => {
     IndexerFailuresStore.list(size, (page - 1) * size).then((response) => {
       this.setState({ failures: response.failures });
     });
-  },
-  _onChangePaginatedList(page, size) {
+  };
+
+  _onChangePaginatedList = (page, size) => {
     this.loadData(page, size);
-  },
+  };
+
   render() {
     if (this.state.total === undefined || !this.state.failures) {
       return <Spinner />;
@@ -60,7 +63,7 @@ const IndexerFailuresPage = React.createClass({
         </span>
       </DocumentTitle>
     );
-  },
-});
+  }
+}
 
 export default IndexerFailuresPage;

--- a/graylog2-web-interface/src/pages/IndicesPage.jsx
+++ b/graylog2-web-interface/src/pages/IndicesPage.jsx
@@ -9,7 +9,7 @@ import { DocumentTitle, PageHeader } from 'components/common';
 import { DocumentationLink } from 'components/support';
 import { IndexSetsComponent } from 'components/indices';
 
-const IndicesPage = React.createClass({
+class IndicesPage extends React.Component {
   render() {
     const pageHeader = (
       <PageHeader title="Indices & Index Sets">
@@ -45,7 +45,7 @@ const IndicesPage = React.createClass({
         </span>
       </DocumentTitle>
     );
-  },
-});
+  }
+}
 
 export default IndicesPage;

--- a/graylog2-web-interface/src/pages/InputsPage.jsx
+++ b/graylog2-web-interface/src/pages/InputsPage.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import createReactClass from 'create-react-class';
 import Reflux from 'reflux';
 
 import StoreProvider from 'injection/StoreProvider';
@@ -8,14 +9,18 @@ const InputStatesStore = StoreProvider.getStore('InputStates');
 import { DocumentTitle, PageHeader } from 'components/common';
 import { InputsList } from 'components/inputs';
 
-const InputsPage = React.createClass({
+const InputsPage = createReactClass({
+  displayName: 'InputsPage',
   mixins: [Reflux.connect(CurrentUserStore)],
+
   componentDidMount() {
     this.interval = setInterval(InputStatesStore.list, 2000);
   },
+
   componentWillUnmount() {
     clearInterval(this.interval);
   },
+
   render() {
     return (
       <DocumentTitle title="Inputs">

--- a/graylog2-web-interface/src/pages/LUTCachesPage.jsx
+++ b/graylog2-web-interface/src/pages/LUTCachesPage.jsx
@@ -1,5 +1,6 @@
 import PropTypes from 'prop-types';
 import React from 'react';
+import createReactClass from 'create-react-class';
 import Reflux from 'reflux';
 import { Button, ButtonToolbar, Col, Row } from 'react-bootstrap';
 import { LinkContainer } from 'react-router-bootstrap';
@@ -14,7 +15,9 @@ import CombinedProvider from 'injection/CombinedProvider';
 const { LookupTableCachesStore, LookupTableCachesActions } = CombinedProvider.get(
   'LookupTableCaches');
 
-const LUTCachesPage = React.createClass({
+const LUTCachesPage = createReactClass({
+  displayName: 'LUTCachesPage',
+
   propTypes: {
     // eslint-disable-next-line react/no-unused-prop-types
     params: PropTypes.object.isRequired,

--- a/graylog2-web-interface/src/pages/LUTDataAdaptersPage.jsx
+++ b/graylog2-web-interface/src/pages/LUTDataAdaptersPage.jsx
@@ -1,5 +1,6 @@
 import PropTypes from 'prop-types';
 import React from 'react';
+import createReactClass from 'create-react-class';
 import Reflux from 'reflux';
 import { Button, ButtonToolbar, Col, Row } from 'react-bootstrap';
 import { LinkContainer } from 'react-router-bootstrap';
@@ -15,7 +16,9 @@ const { LookupTableDataAdaptersStore, LookupTableDataAdaptersActions } = Combine
   'LookupTableDataAdapters');
 const { LookupTablesStore, LookupTablesActions } = CombinedProvider.get('LookupTables');
 
-const LUTDataAdaptersPage = React.createClass({
+const LUTDataAdaptersPage = createReactClass({
+  displayName: 'LUTDataAdaptersPage',
+
   propTypes: {
     // eslint-disable-next-line react/no-unused-prop-types
     params: PropTypes.object.isRequired,

--- a/graylog2-web-interface/src/pages/LUTTablesPage.jsx
+++ b/graylog2-web-interface/src/pages/LUTTablesPage.jsx
@@ -1,5 +1,6 @@
 import PropTypes from 'prop-types';
 import React from 'react';
+import createReactClass from 'create-react-class';
 import Reflux from 'reflux';
 import { Button, ButtonToolbar, Col, Row } from 'react-bootstrap';
 import { LinkContainer } from 'react-router-bootstrap';
@@ -14,7 +15,9 @@ import CombinedProvider from 'injection/CombinedProvider';
 
 const { LookupTablesStore, LookupTablesActions } = CombinedProvider.get('LookupTables');
 
-const LUTTablesPage = React.createClass({
+const LUTTablesPage = createReactClass({
+  displayName: 'LUTTablesPage',
+
   propTypes: {
     // eslint-disable-next-line react/no-unused-prop-types
     params: PropTypes.object.isRequired,

--- a/graylog2-web-interface/src/pages/LoadingPage.jsx
+++ b/graylog2-web-interface/src/pages/LoadingPage.jsx
@@ -7,26 +7,24 @@ import { DocumentTitle, Spinner } from 'components/common';
 import disconnectedStyle from '!style/useable!css!less!stylesheets/disconnected.less';
 import authStyle from '!style/useable!css!less!stylesheets/auth.less';
 
-const LoadingPage = React.createClass({
-  propTypes: {
+class LoadingPage extends React.Component {
+  static propTypes = {
     text: PropTypes.string,
-  },
+  };
 
-  getDefaultProps() {
-    return {
-      text: 'Loading, please wait...',
-    };
-  },
+  static defaultProps = {
+    text: 'Loading, please wait...',
+  };
 
   componentDidMount() {
     disconnectedStyle.use();
     authStyle.use();
-  },
+  }
 
   componentWillUnmount() {
     disconnectedStyle.unuse();
     authStyle.unuse();
-  },
+  }
 
   render() {
     return (
@@ -43,7 +41,7 @@ const LoadingPage = React.createClass({
         </div>
       </DocumentTitle>
     );
-  },
-});
+  }
+}
 
 export default LoadingPage;

--- a/graylog2-web-interface/src/pages/LoggedInPage.jsx
+++ b/graylog2-web-interface/src/pages/LoggedInPage.jsx
@@ -1,10 +1,10 @@
 import React from 'react';
 import AppRouter from 'routing/AppRouter';
 
-const LoggedInPage = React.createClass({
+class LoggedInPage extends React.Component {
   render() {
     return <AppRouter />;
-  },
-});
+  }
+}
 
 export default LoggedInPage;

--- a/graylog2-web-interface/src/pages/LoggersPage.jsx
+++ b/graylog2-web-interface/src/pages/LoggersPage.jsx
@@ -3,7 +3,7 @@ import React from 'react';
 import { DocumentTitle, PageHeader } from 'components/common';
 import { LoggerOverview } from 'components/loggers';
 
-const LoggersPage = React.createClass({
+class LoggersPage extends React.Component {
   render() {
     return (
       <DocumentTitle title="Logging">
@@ -19,7 +19,7 @@ const LoggersPage = React.createClass({
         </span>
       </DocumentTitle>
     );
-  },
-});
+  }
+}
 
 export default LoggersPage;

--- a/graylog2-web-interface/src/pages/LoginPage.jsx
+++ b/graylog2-web-interface/src/pages/LoginPage.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import createReactClass from 'create-react-class';
 import Reflux from 'reflux';
 import { Row, Button, FormGroup, Alert } from 'react-bootstrap';
 import { DocumentTitle } from 'components/common';
@@ -14,7 +15,8 @@ const SessionActions = ActionsProvider.getActions('Session');
 import disconnectedStyle from '!style/useable!css!less!stylesheets/disconnected.less';
 import authStyle from '!style/useable!css!less!stylesheets/auth.less';
 
-const LoginPage = React.createClass({
+const LoginPage = createReactClass({
+  displayName: 'LoginPage',
   mixins: [Reflux.connect(SessionStore), Reflux.ListenerMethods],
 
   getInitialState() {
@@ -28,6 +30,7 @@ const LoginPage = React.createClass({
     authStyle.use();
     SessionActions.validate();
   },
+
   componentWillUnmount() {
     disconnectedStyle.unuse();
     authStyle.unuse();
@@ -57,6 +60,7 @@ const LoginPage = React.createClass({
       }
     });
   },
+
   formatLastError(error) {
     if (error) {
       return (
@@ -69,9 +73,11 @@ const LoginPage = React.createClass({
     }
     return null;
   },
+
   resetLastError() {
     this.setState({ lastError: undefined });
   },
+
   render() {
     if (this.state.validatingSession) {
       return (

--- a/graylog2-web-interface/src/pages/NewAlertConditionPage.jsx
+++ b/graylog2-web-interface/src/pages/NewAlertConditionPage.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import createReactClass from 'create-react-class';
 import Reflux from 'reflux';
 import { Col, Row } from 'react-bootstrap';
 
@@ -13,8 +14,10 @@ import DocsHelper from 'util/DocsHelper';
 import StoreProvider from 'injection/StoreProvider';
 const CurrentUserStore = StoreProvider.getStore('CurrentUser');
 
-const NewAlertConditionPage = React.createClass({
+const NewAlertConditionPage = createReactClass({
+  displayName: 'NewAlertConditionPage',
   mixins: [Reflux.connect(CurrentUserStore)],
+
   render() {
     return (
       <DocumentTitle title="New alert condition">

--- a/graylog2-web-interface/src/pages/NewAlertNotificationPage.jsx
+++ b/graylog2-web-interface/src/pages/NewAlertNotificationPage.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import createReactClass from 'create-react-class';
 import Reflux from 'reflux';
 import { Col, Row } from 'react-bootstrap';
 
@@ -11,8 +12,10 @@ import Routes from 'routing/Routes';
 import StoreProvider from 'injection/StoreProvider';
 const CurrentUserStore = StoreProvider.getStore('CurrentUser');
 
-const NewAlertNotificationPage = React.createClass({
+const NewAlertNotificationPage = createReactClass({
+  displayName: 'NewAlertNotificationPage',
   mixins: [Reflux.connect(CurrentUserStore)],
+
   render() {
     return (
       <DocumentTitle title="New alert notification">

--- a/graylog2-web-interface/src/pages/NodeInputsPage.jsx
+++ b/graylog2-web-interface/src/pages/NodeInputsPage.jsx
@@ -1,5 +1,6 @@
 import PropTypes from 'prop-types';
 import React from 'react';
+import createReactClass from 'create-react-class';
 import Reflux from 'reflux';
 import { Link } from 'react-router';
 
@@ -17,20 +18,27 @@ function nodeFilter(state) {
   return state.nodes ? state.nodes[this.props.params.nodeId] : state.nodes;
 }
 
-const NodeInputsPage = React.createClass({
+const NodeInputsPage = createReactClass({
+  displayName: 'NodeInputsPage',
+
   propTypes: {
     params: PropTypes.object.isRequired,
   },
+
   mixins: [Reflux.connect(CurrentUserStore), Reflux.connectFilter(NodesStore, 'node', nodeFilter)],
+
   componentDidMount() {
     this.interval = setInterval(InputStatesStore.list, 2000);
   },
+
   componentWillUnmount() {
     clearInterval(this.interval);
   },
+
   _isLoading() {
     return !this.state.node;
   },
+
   render() {
     if (this._isLoading()) {
       return <Spinner />;

--- a/graylog2-web-interface/src/pages/NodesPage.jsx
+++ b/graylog2-web-interface/src/pages/NodesPage.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import createReactClass from 'create-react-class';
 import Reflux from 'reflux';
 
 import StoreProvider from 'injection/StoreProvider';
@@ -7,8 +8,10 @@ const CurrentUserStore = StoreProvider.getStore('CurrentUser');
 import { DocumentTitle, PageHeader } from 'components/common';
 import { NodesList } from 'components/nodes';
 
-const NodesPage = React.createClass({
+const NodesPage = createReactClass({
+  displayName: 'NodesPage',
   mixins: [Reflux.connect(CurrentUserStore)],
+
   render() {
     return (
       <DocumentTitle title="Nodes">

--- a/graylog2-web-interface/src/pages/NotFoundPage.jsx
+++ b/graylog2-web-interface/src/pages/NotFoundPage.jsx
@@ -4,14 +4,14 @@ import { DocumentTitle } from 'components/common';
 
 import style from '!style/useable!css!./NotFoundPage.css';
 
-const NotFoundPage = React.createClass({
+class NotFoundPage extends React.Component {
   componentDidMount() {
     style.use();
-  },
+  }
 
   componentWillUnmount() {
     style.unuse();
-  },
+  }
 
   render() {
     return (
@@ -27,7 +27,7 @@ const NotFoundPage = React.createClass({
         </Row>
       </DocumentTitle>
     );
-  },
-});
+  }
+}
 
 export default NotFoundPage;

--- a/graylog2-web-interface/src/pages/PipelineDetailsPage.jsx
+++ b/graylog2-web-interface/src/pages/PipelineDetailsPage.jsx
@@ -1,5 +1,6 @@
 import PropTypes from 'prop-types';
 import React from 'react';
+import createReactClass from 'create-react-class';
 import Reflux from 'reflux';
 import { Row, Col, Button } from 'react-bootstrap';
 import { LinkContainer } from 'react-router-bootstrap';
@@ -32,7 +33,9 @@ function filterConnections(state) {
   return state.connections.filter(c => c.pipeline_ids && c.pipeline_ids.includes(this.props.params.pipelineId));
 }
 
-const PipelineDetailsPage = React.createClass({
+const PipelineDetailsPage = createReactClass({
+  displayName: 'PipelineDetailsPage',
+
   propTypes: {
     params: PropTypes.object.isRequired,
   },

--- a/graylog2-web-interface/src/pages/PipelinesOverviewPage.jsx
+++ b/graylog2-web-interface/src/pages/PipelinesOverviewPage.jsx
@@ -9,7 +9,7 @@ import ProcessingTimelineComponent from 'components/pipelines/ProcessingTimeline
 import Routes from 'routing/Routes';
 import DocsHelper from 'util/DocsHelper';
 
-const PipelinesOverviewPage = React.createClass({
+class PipelinesOverviewPage extends React.Component {
   render() {
     return (
       <DocumentTitle title="Pipelines">
@@ -46,7 +46,7 @@ const PipelinesOverviewPage = React.createClass({
         </div>
       </DocumentTitle>
     );
-  },
-});
+  }
+}
 
 export default PipelinesOverviewPage;

--- a/graylog2-web-interface/src/pages/RolesPage.jsx
+++ b/graylog2-web-interface/src/pages/RolesPage.jsx
@@ -4,7 +4,7 @@ import { Row, Col } from 'react-bootstrap';
 import RolesComponent from 'components/users/RolesComponent';
 import { DocumentTitle } from 'components/common';
 
-const RolesPage = React.createClass({
+class RolesPage extends React.Component {
   render() {
     return (
       <DocumentTitle title="Roles">
@@ -15,7 +15,7 @@ const RolesPage = React.createClass({
         </Row>
       </DocumentTitle>
     );
-  },
-});
+  }
+}
 
 export default RolesPage;

--- a/graylog2-web-interface/src/pages/RuleDetailsPage.jsx
+++ b/graylog2-web-interface/src/pages/RuleDetailsPage.jsx
@@ -1,5 +1,6 @@
 import PropTypes from 'prop-types';
 import React from 'react';
+import createReactClass from 'create-react-class';
 import Reflux from 'reflux';
 
 import { DocumentTitle, Spinner } from 'components/common';
@@ -15,7 +16,9 @@ function filterRules(state) {
   return state.rules ? state.rules.filter(r => r.id === this.props.params.ruleId)[0] : undefined;
 }
 
-const RuleDetailsPage = React.createClass({
+const RuleDetailsPage = createReactClass({
+  displayName: 'RuleDetailsPage',
+
   propTypes: {
     params: PropTypes.object.isRequired,
   },

--- a/graylog2-web-interface/src/pages/RulesPage.jsx
+++ b/graylog2-web-interface/src/pages/RulesPage.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import createReactClass from 'create-react-class';
 import { Row, Col, Button } from 'react-bootstrap';
 import { LinkContainer } from 'react-router-bootstrap';
 
@@ -15,10 +16,13 @@ import RulesActions from 'actions/rules/RulesActions';
 
 import Routes from 'routing/Routes';
 
-const RulesPage = React.createClass({
+const RulesPage = createReactClass({
+  displayName: 'RulesPage',
+
   mixins: [
     Reflux.connect(RulesStore),
   ],
+
   componentDidMount() {
     RulesActions.list();
   },

--- a/graylog2-web-interface/src/pages/SearchPage.jsx
+++ b/graylog2-web-interface/src/pages/SearchPage.jsx
@@ -1,5 +1,6 @@
 import PropTypes from 'prop-types';
 import React from 'react';
+import createReactClass from 'create-react-class';
 import Reflux from 'reflux';
 import Immutable from 'immutable';
 import moment from 'moment';
@@ -18,13 +19,16 @@ const { DecoratorsStore } = CombinedProvider.get('Decorators');
 import { DocumentTitle, Spinner } from 'components/common';
 import { MalformedSearchQuery, SearchExecutionError, SearchResult } from 'components/search';
 
-const SearchPage = React.createClass({
+const SearchPage = createReactClass({
+  displayName: 'SearchPage',
+
   propTypes: {
     location: PropTypes.object.isRequired,
     searchConfig: PropTypes.object.isRequired,
     searchInStream: PropTypes.object,
     forceFetch: PropTypes.bool,
   },
+
   mixins: [
     Reflux.connect(NodesStore),
     Reflux.connect(MessageFieldsStore),
@@ -33,6 +37,7 @@ const SearchPage = React.createClass({
     Reflux.listenTo(RefreshStore, '_setupTimer', '_setupTimer'),
     Reflux.listenTo(DecoratorsStore, '_refreshDataFromDecoratorStore', '_refreshDataFromDecoratorStore'),
   ],
+
   getInitialState() {
     return {
       error: undefined,
@@ -40,6 +45,7 @@ const SearchPage = React.createClass({
       updatingHistogram: false,
     };
   },
+
   componentDidMount() {
     InputsActions.list.triggerPromise();
 
@@ -51,6 +57,7 @@ const SearchPage = React.createClass({
 
     NodesActions.list();
   },
+
   componentWillReceiveProps(nextProps) {
     const currentLocation = this.props.location || {};
     const nextLocation = nextProps.location || {};
@@ -62,27 +69,32 @@ const SearchPage = React.createClass({
       this._refreshData(nextProps.searchInStream);
     }
   },
+
   componentWillUnmount() {
     if (this.promise) {
       this.promise.cancel();
     }
     this._stopTimer();
   },
+
   _setupTimer(refresh) {
     this._stopTimer();
     if (refresh.enabled) {
       this.timer = setInterval(this._refreshData, refresh.interval);
     }
   },
+
   _stopTimer() {
     if (this.timer) {
       clearInterval(this.timer);
     }
   },
+
   _refreshDataFromDecoratorStore() {
     const searchInStream = this.props.searchInStream;
     this._refreshData(searchInStream);
   },
+
   _refreshData(searchInStream) {
     const query = SearchStore.originalQuery;
     const stream = searchInStream || this.props.searchInStream || {};
@@ -126,10 +138,12 @@ const SearchPage = React.createClass({
         this.promise = undefined;
       });
   },
+
   _formatInputs(state) {
     const inputs = InputsStore.inputsAsMap(state.inputs);
     this.setState({ inputs: Immutable.Map(inputs) });
   },
+
   _determineSearchDuration(response) {
     const searchTo = response.to;
     let searchFrom;
@@ -153,6 +167,7 @@ const SearchPage = React.createClass({
 
     return moment.duration(queryRangeInMinutes, 'minutes');
   },
+
   _determineHistogramResolution(response) {
     const duration = this._determineSearchDuration(response);
 

--- a/graylog2-web-interface/src/pages/ServerUnavailablePage.jsx
+++ b/graylog2-web-interface/src/pages/ServerUnavailablePage.jsx
@@ -7,30 +7,28 @@ import URLUtils from 'util/URLUtils';
 
 import disconnectedStyle from '!style/useable!css!less!stylesheets/disconnected.less';
 
-const ServerUnavailablePage = React.createClass({
-  propTypes: {
+class ServerUnavailablePage extends React.Component {
+  static propTypes = {
     server: PropTypes.object,
-  },
+  };
 
-  getInitialState() {
-    return {
-      showDetails: false,
-    };
-  },
+  state = {
+    showDetails: false,
+  };
 
   componentDidMount() {
     disconnectedStyle.use();
-  },
+  }
 
   componentWillUnmount() {
     disconnectedStyle.unuse();
-  },
+  }
 
-  _toggleDetails() {
+  _toggleDetails = () => {
     this.setState({ showDetails: !this.state.showDetails });
-  },
+  };
 
-  _formatErrorMessage() {
+  _formatErrorMessage = () => {
     if (!this.state.showDetails) {
       return null;
     }
@@ -86,7 +84,7 @@ const ServerUnavailablePage = React.createClass({
         </Well>
       </div>
     );
-  },
+  };
 
   render() {
     return (
@@ -117,7 +115,7 @@ const ServerUnavailablePage = React.createClass({
         </Modal>
       </DocumentTitle>
     );
-  },
-});
+  }
+}
 
 export default ServerUnavailablePage;

--- a/graylog2-web-interface/src/pages/ShowAlertPage.jsx
+++ b/graylog2-web-interface/src/pages/ShowAlertPage.jsx
@@ -1,5 +1,6 @@
 import PropTypes from 'prop-types';
 import React from 'react';
+import createReactClass from 'create-react-class';
 import Reflux from 'reflux';
 import { LinkContainer } from 'react-router-bootstrap';
 import { Button, ButtonToolbar, Label, Tooltip } from 'react-bootstrap';
@@ -18,7 +19,9 @@ const { StreamsStore } = CombinedProvider.get('Streams');
 
 import style from './ShowAlertPage.css';
 
-const ShowAlertPage = React.createClass({
+const ShowAlertPage = createReactClass({
+  displayName: 'ShowAlertPage',
+
   propTypes: {
     params: PropTypes.object.isRequired,
   },

--- a/graylog2-web-interface/src/pages/ShowDashboardPage.jsx
+++ b/graylog2-web-interface/src/pages/ShowDashboardPage.jsx
@@ -1,5 +1,6 @@
 import PropTypes from 'prop-types';
 import React from 'react';
+import createReactClass from 'create-react-class';
 import Reflux from 'reflux';
 import { Row, Col, Button, Alert } from 'react-bootstrap';
 import { PluginStore } from 'graylog-web-plugin/plugin';
@@ -27,10 +28,13 @@ import Widget from 'components/widgets/Widget';
 
 import style from './ShowDashboardPage.css';
 
-const ShowDashboardPage = React.createClass({
+const ShowDashboardPage = createReactClass({
+  displayName: 'ShowDashboardPage',
+
   propTypes: {
     params: PropTypes.object.isRequired,
   },
+
   mixins: [Reflux.connect(CurrentUserStore), Reflux.connect(FocusStore), PermissionsMixin],
 
   getInitialState() {
@@ -40,6 +44,7 @@ const ShowDashboardPage = React.createClass({
       streamIds: null,
     };
   },
+
   componentDidMount() {
     this.loadData();
     this.listenTo(WidgetsStore, this.removeWidget);
@@ -56,6 +61,7 @@ const ShowDashboardPage = React.createClass({
     // eslint-disable-next-line react/no-did-mount-set-state
     this.setState({ forceUpdateInBackground: this.state.currentUser.preferences.updateUnfocussed });
   },
+
   componentWillUnmount() {
     if (this.loadInterval) {
       clearInterval(this.loadInterval);
@@ -64,9 +70,11 @@ const ShowDashboardPage = React.createClass({
       this.promise.cancel();
     }
   },
+
   DASHBOARDS_EDIT: 'dashboards:edit',
   DEFAULT_HEIGHT: 2,
   DEFAULT_WIDTH: 4,
+
   loadData() {
     const dashboardId = this.props.params.dashboardId;
     this.promise = DashboardsStore.get(dashboardId)
@@ -88,14 +96,17 @@ const ShowDashboardPage = React.createClass({
         }
       });
   },
+
   shouldUpdate() {
     return Boolean(this.state.forceUpdateInBackground || this.state.focus);
   },
+
   removeWidget(props) {
     if (props.delete) {
       this.loadData();
     }
   },
+
   emptyDashboard() {
     return (
       <Row className="content">
@@ -108,6 +119,7 @@ const ShowDashboardPage = React.createClass({
       </Row>
     );
   },
+
   _defaultWidgetDimensions(widget) {
     const dimensions = { col: 0, row: 0 };
 
@@ -122,12 +134,15 @@ const ShowDashboardPage = React.createClass({
 
     return dimensions;
   },
+
   _dashboardIsEmpty(dashboard) {
     return dashboard.widgets.length === 0;
   },
+
   _validDimension(dimension) {
     return Number.isInteger(dimension) && dimension > 0;
   },
+
   formatDashboard(dashboard) {
     if (this._dashboardIsEmpty(dashboard)) {
       return this.emptyDashboard();
@@ -172,18 +187,22 @@ const ShowDashboardPage = React.createClass({
       </Row>
     );
   },
+
   _unlockDashboard(event) {
     event.preventDefault();
     if (this.state.locked) {
       this._toggleUnlock();
     }
   },
+
   _toggleUnlock() {
     this.setState({ locked: !this.state.locked });
   },
+
   _onPositionsChange(newPositions) {
     DashboardsActions.updatePositions(this.state.dashboard, newPositions);
   },
+
   _toggleFullscreen() {
     const element = document.documentElement;
     if (element.requestFullscreen) {
@@ -196,11 +215,13 @@ const ShowDashboardPage = React.createClass({
       element.msRequestFullscreen();
     }
   },
+
   _toggleUpdateInBackground() {
     const forceUpdate = !this.state.forceUpdateInBackground;
     this.setState({ forceUpdateInBackground: forceUpdate });
     UserNotification.success(`Graphs will be updated ${forceUpdate ? 'even' : 'only'} when the browser is in the ${forceUpdate ? 'background' : 'foreground'}`, '');
   },
+
   render() {
     if (!this.state.dashboard) {
       return <Spinner />;

--- a/graylog2-web-interface/src/pages/ShowMessagePage.jsx
+++ b/graylog2-web-interface/src/pages/ShowMessagePage.jsx
@@ -1,5 +1,6 @@
 import PropTypes from 'prop-types';
 import React from 'react';
+import createReactClass from 'create-react-class';
 import Reflux from 'reflux';
 import Immutable from 'immutable';
 import MessageShow from 'components/search/MessageShow';
@@ -17,12 +18,16 @@ const InputsStore = StoreProvider.getStore('Inputs');
 // eslint-disable-next-line no-unused-vars
 const MessagesStore = StoreProvider.getStore('Messages');
 
-const ShowMessagePage = React.createClass({
+const ShowMessagePage = createReactClass({
+  displayName: 'ShowMessagePage',
+
   propTypes: {
     params: PropTypes.object,
     searchConfig: PropTypes.object.isRequired,
   },
+
   mixins: [Reflux.connect(NodesStore), Reflux.listenTo(InputsStore, '_formatInput')],
+
   getInitialState() {
     return {
       streams: undefined,
@@ -30,6 +35,7 @@ const ShowMessagePage = React.createClass({
       message: undefined,
     };
   },
+
   componentDidMount() {
     MessagesActions.loadMessage.triggerPromise(this.props.params.index, this.props.params.messageId).then((message) => {
       this.setState({ message: message });
@@ -44,14 +50,17 @@ const ShowMessagePage = React.createClass({
     });
     NodesActions.list.triggerPromise();
   },
+
   _formatInput(state) {
     const input = {};
     input[state.input.id] = state.input;
     this.setState({ inputs: Immutable.Map(input) });
   },
+
   _isLoaded() {
     return this.state.message && this.state.streams && this.state.nodes && this.state.inputs;
   },
+
   render() {
     if (this._isLoaded()) {
       return (

--- a/graylog2-web-interface/src/pages/ShowMetricsPage.jsx
+++ b/graylog2-web-interface/src/pages/ShowMetricsPage.jsx
@@ -1,5 +1,6 @@
 import PropTypes from 'prop-types';
 import React from 'react';
+import createReactClass from 'create-react-class';
 import Reflux from 'reflux';
 
 import StoreProvider from 'injection/StoreProvider';
@@ -12,11 +13,14 @@ const MetricsActions = ActionsProvider.getActions('Metrics');
 import { DocumentTitle, PageHeader, Spinner } from 'components/common';
 import { MetricsComponent } from 'components/metrics';
 
-const ShowMetricsPage = React.createClass({
+const ShowMetricsPage = createReactClass({
+  displayName: 'ShowMetricsPage',
+
   propTypes: {
     location: PropTypes.object.isRequired,
     params: PropTypes.object.isRequired,
   },
+
   mixins: [Reflux.connect(NodesStore), Reflux.connect(MetricsStore), Reflux.listenTo(NodesStore, '_getMetrics')],
 
   _getMetrics() {

--- a/graylog2-web-interface/src/pages/ShowNodePage.jsx
+++ b/graylog2-web-interface/src/pages/ShowNodePage.jsx
@@ -1,5 +1,6 @@
 import PropTypes from 'prop-types';
 import React from 'react';
+import createReactClass from 'create-react-class';
 import Reflux from 'reflux';
 
 import StoreProvider from 'injection/StoreProvider';
@@ -20,21 +21,26 @@ function clusterOverviewFilter(state) {
   return state.clusterOverview ? state.clusterOverview[this.props.params.nodeId] : undefined;
 }
 
-const ShowNodePage = React.createClass({
+const ShowNodePage = createReactClass({
+  displayName: 'ShowNodePage',
+
   propTypes: {
     params: PropTypes.object.isRequired,
   },
+
   mixins: [
     Reflux.connectFilter(NodesStore, 'node', nodeFilter),
     Reflux.connectFilter(ClusterOverviewStore, 'systemOverview', clusterOverviewFilter),
     Reflux.connect(InputTypesStore),
   ],
+
   getInitialState() {
     return {
       jvmInformation: undefined,
       plugins: undefined,
     };
   },
+
   componentWillMount() {
     Promise.all([
       ClusterOverviewStore.jvm(this.props.params.nodeId)
@@ -55,9 +61,11 @@ const ShowNodePage = React.createClass({
       }),
     ]).then(() => {}, errors => this.setState({ errors: errors }));
   },
+
   _isLoading() {
     return !(this.state.node && this.state.systemOverview);
   },
+
   render() {
     if (this.state.errors) {
       return <PageErrorOverview errors={[this.state.errors]} />;

--- a/graylog2-web-interface/src/pages/SimulatorPage.jsx
+++ b/graylog2-web-interface/src/pages/SimulatorPage.jsx
@@ -12,22 +12,20 @@ const StreamsStore = StoreProvider.getStore('Streams');
 import DocsHelper from 'util/DocsHelper';
 import Routes from 'routing/Routes';
 
-const SimulatorPage = React.createClass({
-  getInitialState() {
-    return {
-      streams: undefined,
-    };
-  },
+class SimulatorPage extends React.Component {
+  state = {
+    streams: undefined,
+  };
 
   componentDidMount() {
     StreamsStore.listStreams().then((streams) => {
       this.setState({ streams: streams });
     });
-  },
+  }
 
-  _isLoading() {
+  _isLoading = () => {
     return !this.state.streams;
-  },
+  };
 
   render() {
     let content;
@@ -72,7 +70,7 @@ const SimulatorPage = React.createClass({
         </div>
       </DocumentTitle>
     );
-  },
-});
+  }
+}
 
 export default SimulatorPage;

--- a/graylog2-web-interface/src/pages/SourcesPage.jsx
+++ b/graylog2-web-interface/src/pages/SourcesPage.jsx
@@ -3,14 +3,14 @@ import React from 'react';
 import SourceOverview from 'components/sources/SourceOverview';
 import { DocumentTitle } from 'components/common';
 
-const SourcesPage = React.createClass({
+class SourcesPage extends React.Component {
   render() {
     return (
       <DocumentTitle title="Sources">
         <SourceOverview />
       </DocumentTitle>
     );
-  },
-});
+  }
+}
 
 export default SourcesPage;

--- a/graylog2-web-interface/src/pages/StartPage.jsx
+++ b/graylog2-web-interface/src/pages/StartPage.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import createReactClass from 'create-react-class';
 import Reflux from 'reflux';
 
 import { Spinner } from 'components/common';
@@ -14,28 +15,35 @@ const GettingStartedStore = StoreProvider.getStore('GettingStarted');
 import ActionsProvider from 'injection/ActionsProvider';
 const GettingStartedActions = ActionsProvider.getActions('GettingStarted');
 
-const StartPage = React.createClass({
+const StartPage = createReactClass({
+  displayName: 'StartPage',
   mixins: [Reflux.connect(CurrentUserStore), Reflux.listenTo(GettingStartedStore, 'onGettingStartedUpdate')],
+
   getInitialState() {
     return {
       gettingStarted: undefined,
     };
   },
+
   componentDidMount() {
     GettingStartedActions.getStatus();
     CurrentUserStore.reload();
   },
+
   componentDidUpdate() {
     if (!this._isLoading()) {
       this._redirectToStartpage();
     }
   },
+
   onGettingStartedUpdate(state) {
     this.setState({ gettingStarted: state.status });
   },
+
   _redirect(page) {
     history.push(page);
   },
+
   _redirectToStartpage() {
     // Show getting started page if user is an admin and getting started wasn't dismissed
     if (PermissionsMixin.isPermitted(this.state.currentUser.permissions, ['inputs:create'])) {
@@ -63,9 +71,11 @@ const StartPage = React.createClass({
       this._redirect(Routes.STREAMS);
     }
   },
+
   _isLoading() {
     return !this.state.currentUser || !this.state.gettingStarted;
   },
+
   render() {
     return <Spinner />;
   },

--- a/graylog2-web-interface/src/pages/StreamEditPage.jsx
+++ b/graylog2-web-interface/src/pages/StreamEditPage.jsx
@@ -1,5 +1,6 @@
 import PropTypes from 'prop-types';
 import React from 'react';
+import createReactClass from 'create-react-class';
 import Reflux from 'reflux';
 import { Alert, Row, Col } from 'react-bootstrap';
 
@@ -10,11 +11,14 @@ import StoreProvider from 'injection/StoreProvider';
 const CurrentUserStore = StoreProvider.getStore('CurrentUser');
 const StreamsStore = StoreProvider.getStore('Streams');
 
-const StreamEditPage = React.createClass({
+const StreamEditPage = createReactClass({
+  displayName: 'StreamEditPage',
+
   propTypes: {
     params: PropTypes.object.isRequired,
     location: PropTypes.object.isRequired,
   },
+
   mixins: [Reflux.connect(CurrentUserStore)],
 
   componentDidMount() {

--- a/graylog2-web-interface/src/pages/StreamOutputsPage.jsx
+++ b/graylog2-web-interface/src/pages/StreamOutputsPage.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import createReactClass from 'create-react-class';
 import Reflux from 'reflux';
 import { Row, Col } from 'react-bootstrap';
 import { Link } from 'react-router';
@@ -12,16 +13,20 @@ import SupportLink from 'components/support/SupportLink';
 import { DocumentTitle, Spinner } from 'components/common';
 import Routes from 'routing/Routes';
 
-const StreamOutputsPage = React.createClass({
+const StreamOutputsPage = createReactClass({
+  displayName: 'StreamOutputsPage',
   mixins: [Reflux.connect(CurrentUserStore)],
+
   getInitialState() {
     return { stream: undefined };
   },
+
   componentDidMount() {
     StreamsStore.get(this.props.params.streamId, (stream) => {
       this.setState({ stream: stream });
     });
   },
+
   render() {
     if (!this.state.stream) {
       return <Spinner />;

--- a/graylog2-web-interface/src/pages/StreamSearchPage.jsx
+++ b/graylog2-web-interface/src/pages/StreamSearchPage.jsx
@@ -6,26 +6,29 @@ import { DocumentTitle, Spinner } from 'components/common';
 import StoreProvider from 'injection/StoreProvider';
 const StreamsStore = StoreProvider.getStore('Streams');
 
-const StreamSearchPage = React.createClass({
-  propTypes: {
+class StreamSearchPage extends React.Component {
+  static propTypes = {
     params: PropTypes.object.isRequired,
-  },
-  getInitialState() {
-    return {
-      stream: undefined,
-    };
-  },
+  };
+
+  state = {
+    stream: undefined,
+  };
+
   componentDidMount() {
     this._fetchStream(this.props.params.streamId);
-  },
+  }
+
   componentWillReceiveProps(nextProps) {
     if (this.props.params.streamId !== nextProps.params.streamId) {
       this._fetchStream(nextProps.params.streamId);
     }
-  },
-  _fetchStream(streamId) {
+  }
+
+  _fetchStream = (streamId) => {
     StreamsStore.get(streamId, stream => this.setState({ stream: stream }));
-  },
+  };
+
   render() {
     if (!this.state.stream) {
       return <Spinner />;
@@ -36,7 +39,7 @@ const StreamSearchPage = React.createClass({
         <SearchPage searchInStream={this.state.stream} {...this.props} />
       </DocumentTitle>
     );
-  },
-});
+  }
+}
 
 export default StreamSearchPage;

--- a/graylog2-web-interface/src/pages/StreamsPage.jsx
+++ b/graylog2-web-interface/src/pages/StreamsPage.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import createReactClass from 'create-react-class';
 import Reflux from 'reflux';
 import { Row, Col } from 'react-bootstrap';
 
@@ -19,24 +20,30 @@ const IndexSetsStore = StoreProvider.getStore('IndexSets');
 import ActionsProvider from 'injection/ActionsProvider';
 const IndexSetsActions = ActionsProvider.getActions('IndexSets');
 
-const StreamsPage = React.createClass({
+const StreamsPage = createReactClass({
+  displayName: 'StreamsPage',
   mixins: [Reflux.connect(CurrentUserStore), Reflux.connect(IndexSetsStore)],
+
   getInitialState() {
     return {
       indexSets: undefined,
     };
   },
+
   componentDidMount() {
     IndexSetsActions.list(false);
   },
+
   _isLoading() {
     return !this.state.currentUser || !this.state.indexSets;
   },
+
   _onSave(_, stream) {
     StreamsStore.save(stream, () => {
       UserNotification.success('Stream has been successfully created.', 'Success');
     });
   },
+
   render() {
     if (this._isLoading()) {
       return <Spinner />;

--- a/graylog2-web-interface/src/pages/SystemOutputsPage.jsx
+++ b/graylog2-web-interface/src/pages/SystemOutputsPage.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import createReactClass from 'create-react-class';
 import Reflux from 'reflux';
 
 import StoreProvider from 'injection/StoreProvider';
@@ -7,8 +8,10 @@ const CurrentUserStore = StoreProvider.getStore('CurrentUser');
 import { DocumentTitle, PageHeader } from 'components/common';
 import OutputsComponent from 'components/outputs/OutputsComponent';
 
-const SystemOutputsPage = React.createClass({
+const SystemOutputsPage = createReactClass({
+  displayName: 'SystemOutputsPage',
   mixins: [Reflux.connect(CurrentUserStore)],
+
   render() {
     return (
       <DocumentTitle title="Outputs">

--- a/graylog2-web-interface/src/pages/SystemOverviewPage.jsx
+++ b/graylog2-web-interface/src/pages/SystemOverviewPage.jsx
@@ -8,7 +8,7 @@ import { SystemMessagesComponent } from 'components/systemmessages';
 import { TimesList } from 'components/times';
 import { GraylogClusterOverview } from 'components/cluster';
 
-const SystemOverviewPage = React.createClass({
+class SystemOverviewPage extends React.Component {
   render() {
     return (
       <DocumentTitle title="System overview">
@@ -39,7 +39,7 @@ const SystemOverviewPage = React.createClass({
         </span>
       </DocumentTitle>
     );
-  },
-});
+  }
+}
 
 export default SystemOverviewPage;

--- a/graylog2-web-interface/src/pages/ThreadDumpPage.jsx
+++ b/graylog2-web-interface/src/pages/ThreadDumpPage.jsx
@@ -1,5 +1,6 @@
 import PropTypes from 'prop-types';
 import React from 'react';
+import createReactClass from 'create-react-class';
 import Reflux from 'reflux';
 import { Row, Col } from 'react-bootstrap';
 
@@ -16,17 +17,23 @@ function nodeFilter(state) {
   return state.nodes ? state.nodes[this.props.params.nodeId] : state.nodes;
 }
 
-const ThreadDumpPage = React.createClass({
+const ThreadDumpPage = createReactClass({
+  displayName: 'ThreadDumpPage',
+
   propTypes: {
     params: PropTypes.object.isRequired,
   },
+
   mixins: [Reflux.connect(CurrentUserStore), Reflux.connectFilter(NodesStore, 'node', nodeFilter)],
+
   componentDidMount() {
     ClusterOverviewStore.threadDump(this.props.params.nodeId).then(threadDump => this.setState({ threadDump: threadDump }));
   },
+
   _isLoading() {
     return !this.state.node;
   },
+
   render() {
     if (this._isLoading()) {
       return <Spinner />;

--- a/graylog2-web-interface/src/pages/UsersPage.jsx
+++ b/graylog2-web-interface/src/pages/UsersPage.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import createReactClass from 'create-react-class';
 import Reflux from 'reflux';
 import { Row, Col, Button } from 'react-bootstrap';
 import { LinkContainer } from 'react-router-bootstrap';
@@ -12,8 +13,10 @@ const CurrentUserStore = StoreProvider.getStore('CurrentUser');
 import { DocumentTitle, IfPermitted, PageHeader } from 'components/common';
 import UserList from 'components/users/UserList';
 
-const UsersPage = React.createClass({
+const UsersPage = createReactClass({
+  displayName: 'UsersPage',
   mixins: [Reflux.connect(CurrentUserStore), PermissionsMixin],
+
   render() {
     return (
       <DocumentTitle title="Users">

--- a/graylog2-web-interface/src/routing/App.jsx
+++ b/graylog2-web-interface/src/routing/App.jsx
@@ -1,5 +1,6 @@
 import PropTypes from 'prop-types';
 import React from 'react';
+import createReactClass from 'create-react-class';
 import Reflux from 'reflux';
 import Navigation from 'components/navigation/Navigation';
 import Spinner from 'components/common/Spinner';
@@ -14,7 +15,9 @@ import StoreProvider from 'injection/StoreProvider';
 
 const CurrentUserStore = StoreProvider.getStore('CurrentUser');
 
-const App = React.createClass({
+const App = createReactClass({
+  displayName: 'App',
+
   propTypes: {
     children: PropTypes.oneOfType([
       PropTypes.arrayOf(PropTypes.element),
@@ -24,6 +27,7 @@ const App = React.createClass({
   },
 
   mixins: [Reflux.connect(CurrentUserStore)],
+
   render() {
     if (!this.state.currentUser) {
       return <Spinner />;

--- a/graylog2-web-interface/src/routing/AppFacade.jsx
+++ b/graylog2-web-interface/src/routing/AppFacade.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import createReactClass from 'create-react-class';
 import Reflux from 'reflux';
 import LoginPage from 'react-proxy?name=LoginPage!pages/LoginPage';
 import LoadingPage from 'react-proxy?name=LoadingPage!pages/LoadingPage';
@@ -18,7 +19,8 @@ import 'toastr/toastr.less';
 import 'rickshaw/rickshaw.css';
 import 'stylesheets/graylog2.less';
 
-const AppFacade = React.createClass({
+const AppFacade = createReactClass({
+  displayName: 'AppFacade',
   mixins: [Reflux.connect(SessionStore), Reflux.connect(ServerAvailabilityStore), Reflux.connect(CurrentUserStore)],
 
   componentDidMount() {

--- a/graylog2-web-interface/src/routing/AppGlobalNotifications.jsx
+++ b/graylog2-web-interface/src/routing/AppGlobalNotifications.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { PluginStore } from 'graylog-web-plugin/plugin';
 
-const AppGlobalNotifications = React.createClass({
+class AppGlobalNotifications extends React.Component {
   render() {
     const globalNotifications = PluginStore.exports('globalNotifications')
       .map((notification) => {
@@ -24,7 +24,7 @@ const AppGlobalNotifications = React.createClass({
         {globalNotifications}
       </div>
     );
-  },
-});
+  }
+}
 
 export default AppGlobalNotifications;

--- a/graylog2-web-interface/src/routing/AppRouter.jsx
+++ b/graylog2-web-interface/src/routing/AppRouter.jsx
@@ -69,7 +69,7 @@ import RulesPage from 'pages/RulesPage';
 import RuleDetailsPage from 'pages/RuleDetailsPage';
 import EnterprisePage from 'pages/EnterprisePage';
 
-const AppRouter = React.createClass({
+class AppRouter extends React.Component {
   render() {
     const pluginRoutes = PluginStore.exports('routes').map((pluginRoute) => {
       return <Route key={pluginRoute.component.displayName} path={URLUtils.appPrefixed(pluginRoute.path)} component={pluginRoute.component} />;
@@ -167,7 +167,7 @@ const AppRouter = React.createClass({
         </Route>
       </Router>
     );
-  },
-});
+  }
+}
 
 export default AppRouter;

--- a/graylog2-web-interface/src/routing/AppWithGlobalNotifications.jsx
+++ b/graylog2-web-interface/src/routing/AppWithGlobalNotifications.jsx
@@ -3,13 +3,14 @@ import PropTypes from 'prop-types';
 
 import AppGlobalNotifications from './AppGlobalNotifications';
 
-const AppWithGlobalNotifications = React.createClass({
-  propTypes: {
+class AppWithGlobalNotifications extends React.Component {
+  static propTypes = {
     children: PropTypes.oneOfType([
       PropTypes.arrayOf(PropTypes.element),
       PropTypes.element,
     ]).isRequired,
-  },
+  };
+
   render() {
     return (
       <div>
@@ -17,7 +18,7 @@ const AppWithGlobalNotifications = React.createClass({
         {this.props.children}
       </div>
     );
-  },
-});
+  }
+}
 
 export default AppWithGlobalNotifications;

--- a/graylog2-web-interface/src/routing/AppWithSearchBar.jsx
+++ b/graylog2-web-interface/src/routing/AppWithSearchBar.jsx
@@ -1,5 +1,6 @@
 import PropTypes from 'prop-types';
 import React from 'react';
+import createReactClass from 'create-react-class';
 import Reflux from 'reflux';
 import { Row, Col } from 'react-bootstrap';
 
@@ -19,17 +20,21 @@ import ActionsProvider from 'injection/ActionsProvider';
 const SavedSearchesActions = ActionsProvider.getActions('SavedSearches');
 const ConfigurationActions = ActionsProvider.getActions('Configuration');
 
-const AppWithSearchBar = React.createClass({
+const AppWithSearchBar = createReactClass({
+  displayName: 'AppWithSearchBar',
+
   propTypes: {
     children: PropTypes.element.isRequired,
     location: PropTypes.object,
     params: PropTypes.object,
   },
+
   mixins: [
     Reflux.connect(CurrentUserStore),
     Reflux.connect(SavedSearchesStore),
     Reflux.connect(ConfigurationsStore),
   ],
+
   getInitialState() {
     return {
       forceFetch: false,
@@ -38,20 +43,25 @@ const AppWithSearchBar = React.createClass({
       searchesClusterConfig: undefined,
     };
   },
+
   componentDidMount() {
     SavedSearchesActions.list.triggerPromise();
     ConfigurationActions.listSearchesClusterConfig();
     this._loadStream(this.props.params.streamId);
   },
+
   componentWillReceiveProps(nextProps) {
     this._loadStream(nextProps.params.streamId);
   },
+
   componentWillUnmount() {
     SearchStore.unload();
   },
+
   _resetForceFetch() {
     this.setState({ forceFetch: false });
   },
+
   _loadStream(streamId) {
     if (streamId) {
       StreamsStore.get(streamId, stream => this.setState({ stream: stream }, this._updateSearchParams));
@@ -59,6 +69,7 @@ const AppWithSearchBar = React.createClass({
       this.setState({ stream: undefined }, this._updateSearchParams);
     }
   },
+
   _updateSearchParams() {
     SearchStore.searchInStream = this.state.stream;
     SearchStore.load();
@@ -66,21 +77,26 @@ const AppWithSearchBar = React.createClass({
       this.refs.searchBar.reload();
     }
   },
+
   _isLoading() {
     return !this.state.savedSearches || !this.state.searchesClusterConfig || (this.props.params.streamId && !this.state.stream);
   },
+
   _decorateChildren(children) {
     return React.Children.map(children, (child) => {
       return React.cloneElement(child, { searchConfig: this.state.searchesClusterConfig, forceFetch: this.state.forceFetch });
     });
   },
+
   _searchBarShouldDisplayRefreshControls() {
     // Hide refresh controls on sources page
     return this.props.location.pathname !== Routes.SOURCES;
   },
+
   _onExecuteSearch() {
     this.setState({ forceFetch: true }, this._resetForceFetch);
   },
+
   render() {
     if (this._isLoading()) {
       return <Spinner />;

--- a/graylog2-web-interface/src/routing/AppWithoutSearchBar.jsx
+++ b/graylog2-web-interface/src/routing/AppWithoutSearchBar.jsx
@@ -2,13 +2,14 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import { Row, Col } from 'react-bootstrap';
 
-const AppWithoutSearchBar = React.createClass({
-  propTypes: {
+class AppWithoutSearchBar extends React.Component {
+  static propTypes = {
     children: PropTypes.oneOfType([
       PropTypes.arrayOf(PropTypes.element),
       PropTypes.element,
     ]).isRequired,
-  },
+  };
+
   render() {
     return (
       <div className="container-fluid">
@@ -19,7 +20,7 @@ const AppWithoutSearchBar = React.createClass({
         </Row>
       </div>
     );
-  },
-});
+  }
+}
 
 export default AppWithoutSearchBar;

--- a/graylog2-web-interface/src/routing/DebugHandler.jsx
+++ b/graylog2-web-interface/src/routing/DebugHandler.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-const DebugHandler = React.createClass({
+class DebugHandler extends React.Component {
   render() {
     return (
       <div>
@@ -8,7 +8,7 @@ const DebugHandler = React.createClass({
         {this.props.location.pathname}
       </div>
     );
-  },
-});
+  }
+}
 
 export default DebugHandler;


### PR DESCRIPTION
This PR was generated using the class.js react codemod[1]. It converts all
suitable react components to ES6 classes. If an ES5 component which uses
`React.createClass()` is not suitable for conversion, it uses the
`createReactClass()` helper supplied by the `create-react-class` module.

This change is necessary in preparation for React 16, which removes
`React.createClass()` completely[2]. The codemod used claims to be very
reliable even in corner cases and supposedly `has converted thousands of
components internally at Facebook.`.

[1]: https://github.com/reactjs/react-codemod#explanation-of-the-new-es2015-class-transform-with-property-initializers
[2]: https://reactjs.org/blog/2017/04/07/react-v15.5.0.html#migrating-from-reactcreateclass

It was run like this:

```
$ node_modules/.bin/jscodeshift --extensions js,jsx -t ~/graylog2/react-codemod/transforms/class.js src
Processing 702 files...
Spawning 7 workers...
Sending 50 files to free worker...
Sending 50 files to free worker...
Sending 50 files to free worker...
Sending 50 files to free worker...
Sending 50 files to free worker...
Sending 50 files to free worker...
Sending 50 files to free worker...
src/pages/StreamsPage.jsx: `StreamsPage` was skipped because of inconvertible mixins.
src/pages/EditAlertConditionPage.jsx: `EditAlertConditionPage` was skipped because of inconvertible mixins.
src/pages/SystemOutputsPage.jsx: `SystemOutputsPage` was skipped because of inconvertible mixins.
src/pages/ThreadDumpPage.jsx: `ThreadDumpPage` was skipped because of inconvertible mixins.
src/pages/UsersPage.jsx: `UsersPage` was skipped because of inconvertible mixins.
src/pages/EditExtractorsPage.jsx: `EditExtractorsPage` was skipped because of inconvertible mixins.
src/pages/DashboardsPage.jsx: `DashboardsPage` was skipped because of inconvertible mixins.
src/components/cluster/GraylogClusterOverview.jsx: `GraylogClusterOverview` was skipped because of inconvertible mixins.
src/components/ldap/TestLdapLogin.jsx: `TestLdapLogin` was skipped because of invalid field(s) `style` on the React component. Remove any right-hand-side expressions that are not simple, like: `componentWillUpdate: createWillUpdate()` or `render: foo ? renderA : renderB`.
src/components/field-analyzers/FieldQuickValues.jsx: `FieldQuickValues` was skipped because of inconvertible mixins.
src/pages/ExportContentPackPage.jsx: `ExportContentPackPage` was skipped because of inconvertible mixins.
src/components/authentication/AuthProvidersConfig.jsx: `AuthProvidersConfig` was skipped because of API calls that will be removed. Remove calls to `getDefaultProps` and/or `getInitialState` in your React component and re-run this script.
Sending 50 files to free worker...
src/pages/EditTokensPage.jsx: `EditTokensPage` was skipped because of inconvertible mixins.
src/components/loggers/LogLevelDropdown.jsx: `LogLevelDropdown` was skipped because of inconvertible mixins.
src/components/authentication/AuthenticationComponent.jsx: `AuthenticationComponent` was skipped because of inconvertible mixins.
src/pages/EnterprisePage.jsx: `EnterprisePage` was skipped because of inconvertible mixins.
src/pages/ExportExtractorsPage.jsx: `ExportExtractorsPage` was skipped because of inconvertible mixins.
src/components/field-analyzers/FieldGraphs.jsx: `FieldGraphs` was skipped because of inconvertible mixins.
src/pages/ImportExtractorsPage.jsx: `ImportExtractorsPage` was skipped because of inconvertible mixins.
src/components/messageloaders/RawMessageLoader.jsx: `RawMessageLoader` was skipped because of inconvertible mixins.
src/pages/ExtractorsPage.jsx: `ExtractorsPage` was skipped because of inconvertible mixins.
src/routing/App.jsx: `App` was skipped because of inconvertible mixins.
src/pages/GettingStartedPage.jsx: `GettingStartedPage` was skipped because of inconvertible mixins.
src/routing/AppFacade.jsx: `AppFacade` was skipped because of inconvertible mixins.
src/components/field-analyzers/FieldStatistics.jsx: `FieldStatistics` was skipped because of inconvertible mixins.
src/components/messageloaders/LoaderTabs.jsx: `LoaderTabs` was skipped because of inconvertible mixins.
src/pages/IndexSetConfigurationPage.jsx: `IndexSetConfigurationPage` was skipped because of inconvertible mixins.
src/components/loggers/LoggerOverview.jsx: `LoggerOverview` was skipped because of inconvertible mixins.
src/pages/IndexSetCreationPage.jsx: `IndexSetCreationPage` was skipped because of inconvertible mixins.
src/components/loggers/LogLevelMetrics.jsx: `LogLevelMetrics` was skipped because of inconvertible mixins.
src/components/common/IfPermitted.jsx: `IfPermitted` was skipped because of inconvertible mixins.
src/components/configurations/MessageProcessorsConfig.jsx: `MessageProcessorsConfig` was skipped because of API calls that will be removed. Remove calls to `getDefaultProps` and/or `getInitialState` in your React component and re-run this script.
src/components/field-analyzers/LegacyFieldGraph.jsx: `LegacyFieldGraph` was skipped because of inconvertible mixins.
src/pages/IndexSetPage.jsx: `IndexSetPage` was skipped because of inconvertible mixins.
src/components/loggers/LogLevelMetricsOverview.jsx: `LogLevelMetricsOverview` was skipped because of inconvertible mixins.
src/components/common/LinkToNode.jsx: `LinkToNode` was skipped because of inconvertible mixins.
src/components/loggers/NodeLoggers.jsx: `NodeLoggers` was skipped because of inconvertible mixins.
src/pages/InputsPage.jsx: `InputsPage` was skipped because of inconvertible mixins.
src/components/alarmcallbacks/AlarmCallbackHistoryOverview.jsx: `AlarmCallbackHistoryOverview` was skipped because of inconvertible mixins.
src/pages/LUTCachesPage.jsx: `LUTCachesPage` was skipped because of inconvertible mixins.
src/routing/AppWithSearchBar.jsx: `AppWithSearchBar` was skipped because of inconvertible mixins.
src/components/configurations/SearchesConfig.jsx: `SearchesConfig` was skipped because of API calls that will be removed. Remove calls to `getDefaultProps` and/or `getInitialState` in your React component and re-run this script.
src/pages/LUTDataAdaptersPage.jsx: `LUTDataAdaptersPage` was skipped because of inconvertible mixins.
src/components/alertconditions/AlertConditionForm.jsx: `AlertConditionForm` was skipped because of inconvertible mixins.
src/components/indexers/IndexerClusterHealth.jsx: `IndexerClusterHealth` was skipped because of inconvertible mixins.
src/components/navigation/Navigation.jsx: `Navigation` was skipped because of inconvertible mixins.
src/pages/LoginPage.jsx: `LoginPage` was skipped because of inconvertible mixins.
src/components/alertconditions/AlertCondition.jsx: `AlertCondition` was skipped because of inconvertible mixins.
src/pages/LUTTablesPage.jsx: `LUTTablesPage` was skipped because of inconvertible mixins.
src/components/configurationforms/ConfigurationForm.jsx: `ConfigurationForm` was skipped because of API calls that will be removed. Remove calls to `getDefaultProps` and/or `getInitialState` in your React component and re-run this script.
src/pages/NewAlertConditionPage.jsx: `NewAlertConditionPage` was skipped because of inconvertible mixins.
src/components/alertconditions/AlertConditionsComponent.jsx: `AlertConditionsComponent` was skipped because of inconvertible mixins.
src/components/common/LocaleSelect.jsx: `LocaleSelect` was skipped because of inconvertible mixins.
src/components/configurationforms/NumberField.jsx: `NumberField` was skipped because of invalid field(s) `MAX_SAFE_INTEGER, MIN_SAFE_INTEGER` on the React component. Remove any right-hand-side expressions that are not simple, like: `componentWillUpdate: createWillUpdate()` or `render: foo ? renderA : renderB`.
src/pages/NodeInputsPage.jsx: `NodeInputsPage` was skipped because of inconvertible mixins.
src/components/alertconditions/EditAlertConditionForm.jsx: `EditAlertConditionForm` was skipped because of inconvertible mixins.
src/components/grok-patterns/GrokPatterns.jsx: `GrokPatterns` was skipped because of deprecated API calls. Remove calls to getDOMNode, isMounted, replaceProps, replaceState, setProps in your React component and re-run this script.
src/components/metrics/Metric.jsx: `Metric` was skipped because of invalid field(s) `iconMapping` on the React component. Remove any right-hand-side expressions that are not simple, like: `componentWillUpdate: createWillUpdate()` or `render: foo ? renderA : renderB`.
src/pages/NewAlertNotificationPage.jsx: `NewAlertNotificationPage` was skipped because of inconvertible mixins.
src/components/alertconditions/CreateAlertConditionInput.jsx: `CreateAlertConditionInput` was skipped because of inconvertible mixins.
src/components/dashboard/AddToDashboardMenu.jsx: `AddToDashboardMenu` was skipped because of inconvertible mixins.
src/pages/NodesPage.jsx: `NodesPage` was skipped because of inconvertible mixins.
src/components/metrics/MetricDetails.jsx: `MetricDetails` was skipped because of inconvertible mixins.
src/components/dashboard/Dashboard.jsx: `Dashboard` was skipped because of inconvertible mixins.
src/pages/PipelineDetailsPage.jsx: `PipelineDetailsPage` was skipped because of inconvertible mixins.
src/components/common/Select.jsx: `Select` was skipped because of invalid field(s) `reactSelectStyles, reactSelectSmStyles` on the React component. Remove any right-hand-side expressions that are not simple, like: `componentWillUpdate: createWillUpdate()` or `render: foo ? renderA : renderB`.
src/pages/AlertConditionsPage.jsx: `AlertConditionsPage` was skipped because of inconvertible mixins.
src/components/alertnotifications/AlertNotification.jsx: `AlertNotification` was skipped because of inconvertible mixins.
src/pages/AlertNotificationsPage.jsx: `AlertNotificationsPage` was skipped because of inconvertible mixins.
src/pages/RulesPage.jsx: `RulesPage` was skipped because of inconvertible mixins.
src/components/dashboard/DashboardList.jsx: `DashboardList` was skipped because of inconvertible mixins.
src/pages/AuthenticationPage.jsx: `AuthenticationPage` was skipped because of inconvertible mixins.
src/pages/RuleDetailsPage.jsx: `RuleDetailsPage` was skipped because of inconvertible mixins.
src/components/dashboard/DashboardListPage.jsx: `DashboardListPage` was skipped because of inconvertible mixins.
src/pages/AlertsPage.jsx: `AlertsPage` was skipped because of inconvertible mixins.
src/components/metrics/MetricContainer.jsx: `MetricContainer` was skipped because of inconvertible mixins.
src/pages/ShowAlertPage.jsx: `ShowAlertPage` was skipped because of inconvertible mixins.
src/components/dashboard/EditDashboardModal.jsx: `EditDashboardModal` was skipped because of API calls that will be removed. Remove calls to `getDefaultProps` and/or `getInitialState` in your React component and re-run this script.
src/components/alertnotifications/AlertNotificationsComponent.jsx: `AlertNotificationsComponent` was skipped because of inconvertible mixins.
src/pages/ConfigurationsPage.jsx: `ConfigurationsPage` was skipped because of inconvertible mixins.
src/pages/CreateExtractorsPage.jsx: `CreateExtractorsPage` was skipped because of inconvertible mixins.
src/pages/SearchPage.jsx: `SearchPage` was skipped because of inconvertible mixins.
src/components/metrics/MetricsMapper.jsx: `MetricsMapper` was skipped because of inconvertible mixins.
Sending 50 files to free worker...
src/pages/ShowMessagePage.jsx: `ShowMessagePage` was skipped because of inconvertible mixins.
src/components/alertnotifications/CreateAlertNotificationInput.jsx: `CreateAlertNotificationInput` was skipped because of inconvertible mixins.
src/components/layout/Footer.jsx: `Footer` was skipped because of inconvertible mixins.
src/components/alerts/AlertsComponent.jsx: `AlertsComponent` was skipped because of inconvertible mixins.
src/components/nodes/BufferUsage.jsx: `BufferUsage` was skipped because of inconvertible mixins.
src/components/notifications/NotificationsList.jsx: `NotificationsList` was skipped because of inconvertible mixins.
src/components/alerts/AlertTimeline.jsx: `AlertTimeline` was skipped because of inconvertible mixins.
src/pages/ShowDashboardPage.jsx: `ShowDashboardPage` was skipped because of inconvertible mixins.
src/components/inputs/CreateInputControl.jsx: `CreateInputControl` was skipped because of inconvertible mixins.
src/pages/ShowMetricsPage.jsx: `ShowMetricsPage` was skipped because of inconvertible mixins.
src/components/common/TimeUnitInput.jsx: `TimeUnitInput` was skipped because of invalid field(s) `OPTIONS` on the React component. Remove any right-hand-side expressions that are not simple, like: `componentWillUpdate: createWillUpdate()` or `render: foo ? renderA : renderB`.
Sending 50 files to free worker...
src/components/common/TimeUnit.jsx: `TimeUnit` was skipped because of invalid field(s) `UNITS` on the React component. Remove any right-hand-side expressions that are not simple, like: `componentWillUpdate: createWillUpdate()` or `render: foo ? renderA : renderB`.
src/pages/ShowNodePage.jsx: `ShowNodePage` was skipped because of inconvertible mixins.
src/components/indices/IndexSetsComponent.jsx: `IndexSetsComponent` was skipped because of inconvertible mixins.
src/pages/StreamEditPage.jsx: `StreamEditPage` was skipped because of inconvertible mixins.
src/pages/StartPage.jsx: `StartPage` was skipped because of inconvertible mixins.
Sending 50 files to free worker...
src/components/inputs/InputListItem.jsx: `InputListItem` was skipped because of inconvertible mixins.
src/pages/StreamOutputsPage.jsx: `StreamOutputsPage` was skipped because of inconvertible mixins.
src/components/search/RefreshControls.jsx: `RefreshControls` was skipped because of inconvertible mixins.
src/components/enterprise/PluginList.jsx: `PluginList` was skipped because of invalid field(s) `style, ENTERPRISE_PLUGINS` on the React component. Remove any right-hand-side expressions that are not simple, like: `componentWillUpdate: createWillUpdate()` or `render: foo ? renderA : renderB`.
src/components/sources/SourceOverview.jsx: `SourceOverview` was skipped because of invalid field(s) `eventThrottler` on the React component. Remove any right-hand-side expressions that are not simple, like: `componentWillUpdate: createWillUpdate()` or `render: foo ? renderA : renderB`.
src/components/search/NoSearchResults.jsx: `NoSearchResults` was skipped because of invalid field(s) `style` on the React component. Remove any right-hand-side expressions that are not simple, like: `componentWillUpdate: createWillUpdate()` or `render: foo ? renderA : renderB`.
src/components/nodes/JournalDetails.jsx: `JournalDetails` was skipped because of inconvertible mixins.
src/components/extractors/ExportExtractors.jsx: `ExportExtractors` was skipped because of inconvertible mixins.
src/components/extractors/ExtractorsList.jsx: `ExtractorsList` was skipped because of inconvertible mixins.
src/components/inputs/InputStateBadge.jsx: `InputStateBadge` was skipped because of inconvertible mixins.
src/components/lookup-tables/CachesContainer.jsx: `CachesContainer` was skipped because of inconvertible mixins.
src/components/nodes/JournalState.jsx: `JournalState` was skipped because of inconvertible mixins.
src/components/inputs/InputsList.jsx: `InputsList` was skipped because of inconvertible mixins.
src/components/nodes/NodesList.jsx: `NodesList` was skipped because of inconvertible mixins.
src/components/search/SavedSearchControls.jsx: `SavedSearchControls` was skipped because of inconvertible mixins.
src/components/inputs/InputStateControl.jsx: `InputStateControl` was skipped because of inconvertible mixins.
src/components/streamrules/StreamRule.jsx: `StreamRule` was skipped because of inconvertible mixins.
Sending 50 files to free worker...
Sending 50 files to free worker...
src/components/nodes/JvmHeapUsage.jsx: `JvmHeapUsage` was skipped because of inconvertible mixins.
src/components/users/UserList.jsx: `UserList` was skipped because of inconvertible mixins.
src/components/inputs/InputThroughput.jsx: `InputThroughput` was skipped because of inconvertible mixins.
src/components/lookup-tables/DataAdaptersContainer.jsx: `DataAdaptersContainer` was skipped because of inconvertible mixins.
src/components/inputs/NodeOrGlobalSelect.jsx: `NodeOrGlobalSelect` was skipped because of inconvertible mixins.
src/components/search/SearchBar.jsx: `SearchBar` was skipped because of API calls that will be removed. Remove calls to `getDefaultProps` and/or `getInitialState` in your React component and re-run this script.
src/components/users/UserForm.jsx: `UserForm` was skipped because of inconvertible mixins.
src/components/nodes/SystemInformation.jsx: `SystemInformation` was skipped because of API calls that will be removed. Remove calls to `getDefaultProps` and/or `getInitialState` in your React component and re-run this script.
Sending 50 files to free worker...
src/components/outputs/OutputsComponent.jsx: `OutputsComponent` was skipped because of inconvertible mixins.
src/components/ldap/LdapComponent.jsx: `LdapComponent` was skipped because of inconvertible mixins.
src/components/search/SearchSidebar.jsx: `SearchSidebar` was skipped because of invalid field(s) `eventsThrottler` on the React component. Remove any right-hand-side expressions that are not simple, like: `componentWillUpdate: createWillUpdate()` or `render: foo ? renderA : renderB`.
src/components/pipelines/Pipeline.jsx: `Pipeline` was skipped because of invalid field(s) `style` on the React component. Remove any right-hand-side expressions that are not simple, like: `componentWillUpdate: createWillUpdate()` or `render: foo ? renderA : renderB`.
src/components/streams/Stream.jsx: `Stream` was skipped because of inconvertible mixins.
Sending 2 files to free worker...
src/components/pipelines/PipelineConnectionsForm.jsx: `PipelineConnectionsForm` was skipped because of API calls that will be removed. Remove calls to `getDefaultProps` and/or `getInitialState` in your React component and re-run this script.
src/components/streams/StreamControls.jsx: `StreamControls` was skipped because of inconvertible mixins.
src/components/maps/field-analyzers/FieldAnalyzerMapComponent.jsx: `FieldAnalyzerMapComponent` was skipped because of inconvertible mixins.
src/components/search/ShowQueryModal.jsx: `ShowQueryModal` was skipped because of inconvertible mixins.
src/components/pipelines/PipelineForm.jsx: `PipelineForm` was skipped because of API calls that will be removed. Remove calls to `getDefaultProps` and/or `getInitialState` in your React component and re-run this script.
src/components/search/SidebarMessageField.jsx: `SidebarMessageField` was skipped because of invalid field(s) `style` on the React component. Remove any right-hand-side expressions that are not simple, like: `componentWillUpdate: createWillUpdate()` or `render: foo ? renderA : renderB`.
src/components/streams/StreamList.jsx: `StreamList` was skipped because of inconvertible mixins.
src/components/maps/configurations/GeoIpResolverConfig.jsx: `GeoIpResolverConfig` was skipped because of API calls that will be removed. Remove calls to `getDefaultProps` and/or `getInitialState` in your React component and re-run this script.
src/components/streams/StreamThroughput.jsx: `StreamThroughput` was skipped because of inconvertible mixins.
src/components/times/TimesList.jsx: `TimesList` was skipped because of inconvertible mixins.
src/components/systemjobs/SystemJobsComponent.jsx: `SystemJobsComponent` was skipped because of inconvertible mixins.
src/components/throughput/GlobalThroughput.jsx: `GlobalThroughput` was skipped because of inconvertible mixins.
src/components/pipelines/ProcessingTimelineComponent.jsx: `ProcessingTimelineComponent` was skipped because of inconvertible mixins.
src/components/search/AddDecoratorButton.jsx: `AddDecoratorButton` was skipped because of inconvertible mixins.
src/components/throughput/NodeThroughput.jsx: `NodeThroughput` was skipped because of inconvertible mixins.
src/components/maps/widgets/MapVisualization.jsx: `MapVisualization` was skipped because of invalid field(s) `position` on the React component. Remove any right-hand-side expressions that are not simple, like: `componentWillUpdate: createWillUpdate()` or `render: foo ? renderA : renderB`.
src/components/search/Decorator.jsx: `Decorator` was skipped because of inconvertible mixins.
src/components/pipelines/StageForm.jsx: `StageForm` was skipped because of inconvertible mixins.
src/components/search/DecoratorSidebar.jsx: `DecoratorSidebar` was skipped because of inconvertible mixins.
src/components/pipelines/Stage.jsx: `Stage` was skipped because of inconvertible mixins.
src/components/search/LegacyHistogram.jsx: `LegacyHistogram` was skipped because of invalid field(s) `RESOLUTIONS, eventThrottler` on the React component. Remove any right-hand-side expressions that are not simple, like: `componentWillUpdate: createWillUpdate()` or `render: foo ? renderA : renderB`.
src/components/visualizations/QuickValuesHistogramVisualization.jsx: `QuickValuesHistogramVisualization` was skipped because of invalid field(s) `DEFAULT_CONFIG, CHART_MARGINS` on the React component. Remove any right-hand-side expressions that are not simple, like: `componentWillUpdate: createWillUpdate()` or `render: foo ? renderA : renderB`.
src/components/rules/RuleHelper.jsx: `RuleHelper` was skipped because of inconvertible mixins.
src/components/simulator/SimulationResults.jsx: `SimulationResults` was skipped because of invalid field(s) `VIEW_OPTIONS, style` on the React component. Remove any right-hand-side expressions that are not simple, like: `componentWillUpdate: createWillUpdate()` or `render: foo ? renderA : renderB`.
src/components/extractors/extractors_configuration/JSONExtractorConfiguration.jsx: `JSONExtractorConfiguration` was skipped because of invalid field(s) `DEFAULT_CONFIGURATION` on the React component. Remove any right-hand-side expressions that are not simple, like: `componentWillUpdate: createWillUpdate()` or `render: foo ? renderA : renderB`.
src/components/source-tagging/ConfigurationBundles.jsx: `ConfigurationBundles` was skipped because of inconvertible mixins.
src/components/extractors/extractors_configuration/SubstringExtractorConfiguration.jsx: `SubstringExtractorConfiguration` was skipped because of invalid field(s) `DEFAULT_CONFIGURATION` on the React component. Remove any right-hand-side expressions that are not simple, like: `componentWillUpdate: createWillUpdate()` or `render: foo ? renderA : renderB`.
src/components/simulator/SimulationTrace.jsx: `SimulationTrace` was skipped because of invalid field(s) `style` on the React component. Remove any right-hand-side expressions that are not simple, like: `componentWillUpdate: createWillUpdate()` or `render: foo ? renderA : renderB`.
src/components/extractors/extractors_configuration/SplitAndIndexExtractorConfiguration.jsx: `SplitAndIndexExtractorConfiguration` was skipped because of invalid field(s) `DEFAULT_CONFIGURATION` on the React component. Remove any right-hand-side expressions that are not simple, like: `componentWillUpdate: createWillUpdate()` or `render: foo ? renderA : renderB`.
src/components/visualizations/QuickValuesVisualization.jsx: `QuickValuesVisualization` was skipped because of invalid field(s) `DEFAULT_CONFIG` on the React component. Remove any right-hand-side expressions that are not simple, like: `componentWillUpdate: createWillUpdate()` or `render: foo ? renderA : renderB`.
src/components/simulator/SimulationChanges.jsx: `SimulationChanges` was skipped because of invalid field(s) `style` on the React component. Remove any right-hand-side expressions that are not simple, like: `componentWillUpdate: createWillUpdate()` or `render: foo ? renderA : renderB`.
src/components/search/MessageField.jsx: `MessageField` was skipped because of invalid field(s) `SPECIAL_FIELDS` on the React component. Remove any right-hand-side expressions that are not simple, like: `componentWillUpdate: createWillUpdate()` or `render: foo ? renderA : renderB`.
src/components/search/MessageTablePaginator.jsx: `MessageTablePaginator` was skipped because of invalid field(s) `eventsThrottler` on the React component. Remove any right-hand-side expressions that are not simple, like: `componentWillUpdate: createWillUpdate()` or `render: foo ? renderA : renderB`.
src/components/widgets/Widget.jsx: `Widget` was skipped because of inconvertible mixins.
src/components/widgets/WidgetCreationModal.jsx: `WidgetCreationModal` was skipped because of API calls that will be removed. Remove calls to `getDefaultProps` and/or `getInitialState` in your React component and re-run this script.
src/components/widgets/WidgetEditConfigModal.jsx: `WidgetEditConfigModal` was skipped because `arguments` was found in your functions. Arrow functions do not expose an `arguments` object; consider changing to use ES6 spread operator and re-run this script.
src/components/users/EditRole.jsx: `EditRole` was skipped because of inconvertible mixins.
src/components/users/RoleList.jsx: `RoleList` was skipped because of inconvertible mixins.
src/components/users/RolesComponent.jsx: `` was skipped because of inconvertible mixins.
src/components/users/TimeoutInput.jsx: `TimeoutInput` was skipped because of invalid field(s) `MS_DAY, MS_HOUR, MS_MINUTE` on the React component. Remove any right-hand-side expressions that are not simple, like: `componentWillUpdate: createWillUpdate()` or `render: foo ? renderA : renderB`.
All done.
Results:
0 errors
237 unmodified
0 skipped
465 ok
Time elapsed: 10.613seconds
```
