### PR TITLE
Add generic data and script dir settings

### DIFF
--- a/UPGRADING.rst
+++ b/UPGRADING.rst
@@ -140,3 +140,13 @@ The following HTTP API paths changed due to the plugin merge:
 +---------------------------------------------------------------------------------------------+-----------------------------------------------+
 | ``/plugins/org.graylog.plugins.pipelineprocessor/system/pipelines/simulate``                | ``/system/pipelines/simulate``                |
 +---------------------------------------------------------------------------------------------+-----------------------------------------------+
+
+New "bin_path" and "data_dir" configuration parameters
+======================================================
+
+We introduced two new configuration parameters related to file system paths.
+
+- ``bin_path`` config option points to the directory that contains scripts like ``graylogctl``.
+- ``data_dir`` option configures the base directory for other data directories like ``message_journal_dir``.
+
+Please check the updated default ``graylog.conf`` configuration file for required changes to your existing file.

--- a/graylog2-server/src/main/java/org/graylog2/Configuration.java
+++ b/graylog2-server/src/main/java/org/graylog2/Configuration.java
@@ -27,6 +27,7 @@ import com.github.joschi.jadconfig.validators.PositiveDurationValidator;
 import com.github.joschi.jadconfig.validators.PositiveIntegerValidator;
 import com.github.joschi.jadconfig.validators.PositiveLongValidator;
 import com.github.joschi.jadconfig.validators.StringNotBlankValidator;
+import org.graylog2.configuration.GraylogDataDir;
 import org.graylog2.plugin.BaseConfiguration;
 import org.graylog2.utilities.IPSubnetConverter;
 import org.graylog2.utilities.IpSubnet;
@@ -140,7 +141,8 @@ public class Configuration extends BaseConfiguration {
     private boolean contentPacksLoaderEnabled = true;
 
     @Parameter(value = "content_packs_dir", validators = DirectoryPathReadableValidator.class)
-    private Path contentPacksDir = Paths.get("data", "contentpacks");
+    @GraylogDataDir
+    private Path contentPacksDir = Paths.get("contentpacks");
 
     @Parameter(value = "content_packs_auto_load", converter = TrimmedStringSetConverter.class)
     private Set<String> contentPacksAutoLoad = Collections.emptySet();
@@ -278,10 +280,6 @@ public class Configuration extends BaseConfiguration {
 
     public boolean isContentPacksLoaderEnabled() {
         return contentPacksLoaderEnabled;
-    }
-
-    public Path getContentPacksDir() {
-        return contentPacksDir;
     }
 
     public Set<String> getContentPacksAutoLoad() {

--- a/graylog2-server/src/main/java/org/graylog2/commands/journal/JournalShow.java
+++ b/graylog2-server/src/main/java/org/graylog2/commands/journal/JournalShow.java
@@ -44,7 +44,7 @@ public class JournalShow extends AbstractJournalCommand {
         final long startOffset = journal.getLogStartOffset();
         final long lastOffset = journal.getLogEndOffset() - 1;
 
-        sb.append("Graylog message journal in directory: ").append(kafkaJournalConfiguration.getMessageJournalDir().getAbsolutePath()).append(
+        sb.append("Graylog message journal in directory: ").append(journal.getJournalDirectory().getAbsolutePath()).append(
                 "\n");
         sb.append("\t").append("Total size in bytes: ").append(sizeInBytes).append("\n");
         sb.append("\t").append("Number of segments: ").append(numSegments).append("\n");

--- a/graylog2-server/src/main/java/org/graylog2/configuration/ConfigurationPathParametersModule.java
+++ b/graylog2-server/src/main/java/org/graylog2/configuration/ConfigurationPathParametersModule.java
@@ -1,0 +1,195 @@
+/**
+ * This file is part of Graylog.
+ *
+ * Graylog is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.graylog2.configuration;
+
+import com.github.joschi.jadconfig.Parameter;
+import com.google.inject.AbstractModule;
+import com.google.inject.TypeLiteral;
+import org.graylog2.plugin.BaseConfiguration;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.lang.reflect.Field;
+import java.nio.file.Path;
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.Set;
+
+import static com.github.joschi.jadconfig.ReflectionUtils.getAllFields;
+import static com.github.joschi.jadconfig.ReflectionUtils.getFieldValue;
+import static java.util.Locale.ENGLISH;
+import static org.graylog2.configuration.GraylogDataDirImpl.dataDir;
+
+/**
+ * This module creates bindings for {@link Path} parameters annotated with {@link GraylogBinPath} and
+ * {@link GraylogDataDir}.
+ *
+ * <p>Example {@link GraylogBinPath} usage:
+ *
+ * <pre>
+ *   public class ScriptExec {
+ *     &#064;Inject
+ *     ScriptExec(<b>@GraylogBinPath</b> Path binPath, String scriptName) {
+ *         this.scriptName = binPath.resolve(scriptName);
+ *     }
+ *   }</pre>
+ *
+ * <p>Example {@link GraylogDataDir} usage:
+ *
+ * <pre>
+ *   public class Config {
+ *     &#064;Parameter("message_journal_dir")
+ *     <b>&#064;GraylogDataDir</b>
+ *     private Path messageJournalDir = Paths.get("journal");
+ *   }
+ *
+ *   public class Journal {
+ *     &#064;Inject
+ *     Journal(<b>@GraylogDataDir("message_journal_dir")</b> Path journalDir) {
+ *         // ...
+ *     }
+ *   }</pre>
+ */
+public class ConfigurationPathParametersModule extends AbstractModule {
+    private static final Logger LOG = LoggerFactory.getLogger(ConfigurationPathParametersModule.class);
+
+    private final Set<Object> configurationBeans;
+
+    /**
+     * Create a new {@link ConfigurationPathParametersModule} instance and add bindings for the instances in {@code beans}.
+     *
+     * @param configurationBeans A {@link Collection} containing all instances of the configuration beans which
+     *              should be registered.
+     */
+    public ConfigurationPathParametersModule(final Collection configurationBeans) {
+        this.configurationBeans = new HashSet<Object>(configurationBeans);
+    }
+
+    @Override
+    protected void configure() {
+        // The BIN_PATH parameter MUST have a value
+        final Path binPath = getConfigValue(BaseConfiguration.BIN_PATH)
+                .orElseThrow(() -> new IllegalStateException(BaseConfiguration.BIN_PATH + " configuration value is not defined"));
+
+        // The DATA_DIR parameter MUST have a value
+        final Path dataDir = getConfigValue(BaseConfiguration.DATA_DIR)
+                .orElseThrow(() -> new IllegalStateException(BaseConfiguration.DATA_DIR + " configuration value is not defined"));
+
+        LOG.debug("Binding {} parameter annotated with @GraylogBinPath to {}", Path.class.getCanonicalName(), binPath.toAbsolutePath());
+        bind(Path.class).annotatedWith(GraylogBinPath.class).toInstance(binPath.toAbsolutePath());
+
+        for (final Object bean : configurationBeans) {
+            createDataDirBindings(bean, dataDir);
+        }
+    }
+
+    /**
+     * Find the value for the given parameter name in all configuration beans.
+     *
+     * @param parameterName the config parameter name
+     * @return a non-empty optional if the parameter value has been found
+     */
+    private Optional<Path> getConfigValue(final String parameterName) {
+        final String name = Objects.requireNonNull(parameterName);
+
+        for (Object bean : configurationBeans) {
+            final Field[] fields = getAllFields(bean.getClass());
+
+            for (Field field : fields) {
+                final Parameter parameter = field.getAnnotation(Parameter.class);
+
+                if (parameter != null) {
+                    // We are only interested in this one parameter field
+                    if (!parameter.value().equals(name)) {
+                        continue;
+                    }
+
+                    // We are only interested in Path fields
+                    if (!TypeLiteral.get(field.getGenericType()).equals(TypeLiteral.get(Path.class))) {
+                        continue;
+                    }
+
+                    try {
+                        final Object value = getFieldValue(bean, field);
+
+                        if (value == null) {
+                            return Optional.empty();
+                        } else {
+                            if (value instanceof Path) {
+                                return Optional.of((Path) value);
+                            } else {
+                                // This shouldn't happen because we filter for paths above
+                                throw new IllegalStateException("Parameter value is not a Path");
+                            }
+                        }
+                    } catch (IllegalAccessException e) {
+                        LOG.warn("Couldn't bind \"{}\"", field.getName(), e);
+                    }
+                }
+            }
+        }
+
+        return Optional.empty();
+    }
+
+    /**
+     * Creates bindings for all {@link Path} configuration parameters that are annotated with {@link GraylogDataDir}.
+     *
+     * @param bean
+     * @param dataDir
+     */
+    private void createDataDirBindings(Object bean, Path dataDir) {
+        final Field[] fields = getAllFields(bean.getClass());
+
+        for (Field field : fields) {
+            final Parameter parameter = field.getAnnotation(Parameter.class);
+            final GraylogDataDir dataDirAnnotation = field.getAnnotation(GraylogDataDir.class);
+
+            // Only bind to config parameters which are annotated with GraylogDataDir
+            if (parameter != null && dataDirAnnotation != null) {
+                try {
+                    // We are only interested in Path fields
+                    if (!TypeLiteral.get(field.getGenericType()).equals(TypeLiteral.get(Path.class))) {
+                        continue;
+                    }
+
+                    final Object value = getFieldValue(bean, field);
+                    final GraylogDataDirImpl graylogDataDir = dataDir(parameter.value());
+
+                    if (value instanceof Path) {
+                        Path pathValue = (Path) value;
+                        if (!pathValue.isAbsolute()) {
+                            pathValue = dataDir.resolve(pathValue);
+                        }
+                        LOG.debug("Binding {} parameter annotated with {} to {}", Path.class.getCanonicalName(), graylogDataDir, pathValue.toAbsolutePath());
+                        bind(Path.class).annotatedWith(graylogDataDir).toInstance(pathValue.toAbsolutePath());
+                    } else {
+                        final String valueString = value == null ? "null" : String.format(ENGLISH, "%s (%s)", value.toString(), value.getClass().getCanonicalName());
+                        final String msg = String.format(ENGLISH, "Invalid value for %s: %s", graylogDataDir, valueString);
+                        throw new IllegalStateException(msg);
+                    }
+                } catch (IllegalAccessException e) {
+                    LOG.warn("Couldn't bind \"{}\"", field.getName(), e);
+                }
+            } else {
+                LOG.debug("Skipping field \"{}\"", field.getName());
+            }
+        }
+    }
+}

--- a/graylog2-server/src/main/java/org/graylog2/configuration/GraylogBinPath.java
+++ b/graylog2-server/src/main/java/org/graylog2/configuration/GraylogBinPath.java
@@ -1,0 +1,42 @@
+/**
+ * This file is part of Graylog.
+ *
+ * Graylog is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.graylog2.configuration;
+
+import javax.inject.Qualifier;
+import java.lang.annotation.Documented;
+import java.lang.annotation.Retention;
+
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+/**
+ * Marks a {@link java.nio.file.Path} parameter that should be set to the Graylog "bin_path" configuration setting.
+ *
+ * <p>Example usage:
+ *
+ * <pre>
+ *   public class ScriptExec {
+ *     &#064;Inject
+ *     ScriptExec(<b>@GraylogBinPath</b> Path binPath, String scriptName) {
+ *         this.scriptName = binPath.resolve(scriptName);
+ *     }
+ *   }</pre>
+ */
+@Qualifier
+@Documented
+@Retention(RUNTIME)
+public @interface GraylogBinPath {
+}

--- a/graylog2-server/src/main/java/org/graylog2/configuration/GraylogDataDir.java
+++ b/graylog2-server/src/main/java/org/graylog2/configuration/GraylogDataDir.java
@@ -1,0 +1,49 @@
+/**
+ * This file is part of Graylog.
+ *
+ * Graylog is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.graylog2.configuration;
+
+import javax.inject.Qualifier;
+import java.lang.annotation.Documented;
+import java.lang.annotation.Retention;
+
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+/**
+ * Marks a {@link java.nio.file.Path} parameter
+ * <p>Example usage:
+ *
+ * <pre>
+ *   public class Config {
+ *     &#064;Parameter("message_journal_dir")
+ *     <b>&#064;GraylogDataDir</b>
+ *     private Path messageJournalDir = Paths.get("journal");
+ *   }
+ *
+ *   public class Journal {
+ *     &#064;Inject
+ *     Journal(<b>@GraylogDataDir("message_journal_dir")</b> Path journalDir) {
+ *         // ...
+ *     }
+ *   }</pre>
+ */
+@Qualifier
+@Documented
+@Retention(RUNTIME)
+public @interface GraylogDataDir {
+    /** The path configuration name */
+    String value() default "";
+}

--- a/graylog2-server/src/main/java/org/graylog2/configuration/GraylogDataDirImpl.java
+++ b/graylog2-server/src/main/java/org/graylog2/configuration/GraylogDataDirImpl.java
@@ -1,0 +1,66 @@
+/**
+ * This file is part of Graylog.
+ *
+ * Graylog is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.graylog2.configuration;
+
+import com.google.inject.internal.Annotations;
+
+import java.lang.annotation.Annotation;
+import java.util.Objects;
+
+import static com.google.common.base.Strings.emptyToNull;
+import static java.util.Objects.requireNonNull;
+
+public class GraylogDataDirImpl implements GraylogDataDir {
+    private final String value;
+
+    public GraylogDataDirImpl(String value) {
+        this.value = requireNonNull(emptyToNull(value), "@GraylogDataDir value cannot be null");
+    }
+
+    public static GraylogDataDirImpl dataDir(String value) {
+        return new GraylogDataDirImpl(value);
+    }
+
+    @Override
+    public String value() {
+        return value;
+    }
+
+    @Override
+    public Class<? extends Annotation> annotationType() {
+        return GraylogDataDir.class;
+    }
+
+    @Override
+    public String toString() {
+        return "@" + GraylogDataDir.class.getSimpleName() + "(value=" + Annotations.memberValueString(value) + ")";
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        GraylogDataDirImpl that = (GraylogDataDirImpl) o;
+        return Objects.equals(value, that.value);
+    }
+
+    @Override
+    public int hashCode() {
+        // This is specified in java.lang.Annotation.
+        return (127 * "value".hashCode()) ^ value.hashCode();
+    }
+}

--- a/graylog2-server/src/main/java/org/graylog2/periodical/ContentPackLoaderPeriodical.java
+++ b/graylog2-server/src/main/java/org/graylog2/periodical/ContentPackLoaderPeriodical.java
@@ -25,6 +25,7 @@ import com.mongodb.MongoException;
 import org.graylog2.bundles.BundleService;
 import org.graylog2.bundles.ConfigurationBundle;
 import org.graylog2.bundles.ContentPackLoaderConfig;
+import org.graylog2.configuration.GraylogDataDir;
 import org.graylog2.plugin.cluster.ClusterConfigService;
 import org.graylog2.plugin.periodical.Periodical;
 import org.graylog2.shared.users.UserService;
@@ -62,7 +63,7 @@ public class ContentPackLoaderPeriodical extends Periodical {
                                        ClusterConfigService clusterConfigService,
                                        UserService userService,
                                        @Named("content_packs_loader_enabled") boolean contentPacksLoaderEnabled,
-                                       @Named("content_packs_dir") Path contentPacksDir,
+                                       @GraylogDataDir("content_packs_dir") Path contentPacksDir,
                                        @Named("content_packs_auto_load") Set<String> contentPacksAutoLoad) {
         this.objectMapper = objectMapper;
         this.bundleService = bundleService;

--- a/graylog2-server/src/main/java/org/graylog2/plugin/BaseConfiguration.java
+++ b/graylog2-server/src/main/java/org/graylog2/plugin/BaseConfiguration.java
@@ -30,10 +30,15 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.net.URI;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 
 @SuppressWarnings("FieldMayBeFinal")
 public abstract class BaseConfiguration {
     private static final Logger LOG = LoggerFactory.getLogger(BaseConfiguration.class);
+
+    public static final String BIN_PATH = "bin_path";
+    public static final String DATA_DIR = "data_dir";
 
     @Parameter(value = "shutdown_timeout", validator = PositiveIntegerValidator.class)
     protected int shutdownTimeout = 30000;
@@ -52,6 +57,12 @@ public abstract class BaseConfiguration {
 
     @Parameter(value = "inputbuffer_wait_strategy", required = true)
     private String inputBufferWaitStrategy = "blocking";
+
+    @Parameter(value = BIN_PATH, required = true)
+    private Path binPath = Paths.get("bin");
+
+    @Parameter(value = DATA_DIR, required = true)
+    private Path dataDir = Paths.get("data");
 
     @Parameter(value = "plugin_dir")
     private String pluginDir = "plugin";
@@ -127,6 +138,14 @@ public abstract class BaseConfiguration {
 
     public WaitStrategy getInputBufferWaitStrategy() {
         return getWaitStrategy(inputBufferWaitStrategy, "inputbuffer_wait_strategy");
+    }
+
+    public Path getBinPath() {
+        return binPath;
+    }
+
+    public Path getDataDir() {
+        return dataDir;
     }
 
     public String getPluginDir() {

--- a/graylog2-server/src/main/java/org/graylog2/plugin/KafkaJournalConfiguration.java
+++ b/graylog2-server/src/main/java/org/graylog2/plugin/KafkaJournalConfiguration.java
@@ -21,10 +21,12 @@ import com.fasterxml.jackson.annotation.JsonFormat;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.github.joschi.jadconfig.Parameter;
 import com.github.joschi.jadconfig.util.Size;
+import org.graylog2.configuration.GraylogDataDir;
 import org.joda.time.Duration;
 
 import javax.validation.constraints.NotNull;
-import java.io.File;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.Objects;
 
 public class KafkaJournalConfiguration {
@@ -32,7 +34,7 @@ public class KafkaJournalConfiguration {
     public KafkaJournalConfiguration() { }
 
     @JsonCreator
-    public KafkaJournalConfiguration(@NotNull @JsonProperty("directory") File messageJournalDir,
+    public KafkaJournalConfiguration(@NotNull @JsonProperty("directory") Path messageJournalDir,
                                      @JsonProperty("segment_size") long messageJournalSegmentSize,
                                      @JsonProperty("segment_age") Duration messageJournalSegmentAge,
                                      @JsonProperty("max_size") long messageJournalMaxSize,
@@ -49,8 +51,9 @@ public class KafkaJournalConfiguration {
     }
 
     @Parameter(value = "message_journal_dir", required = true)
+    @GraylogDataDir
     @JsonProperty("directory")
-    private File messageJournalDir = new File("data/journal");
+    private Path messageJournalDir = Paths.get("journal");
 
     @Parameter("message_journal_segment_size")
     @JsonProperty("segment_size")
@@ -78,10 +81,6 @@ public class KafkaJournalConfiguration {
     @JsonFormat(shape = JsonFormat.Shape.NUMBER)
     @JsonProperty("flush_age")
     private Duration messageJournalFlushAge = Duration.standardMinutes(1L);
-
-    public File getMessageJournalDir() {
-        return messageJournalDir;
-    }
 
     public Size getMessageJournalSegmentSize() {
         return messageJournalSegmentSize;

--- a/graylog2-server/src/main/java/org/graylog2/shared/system/stats/fs/JmxFsProbe.java
+++ b/graylog2-server/src/main/java/org/graylog2/shared/system/stats/fs/JmxFsProbe.java
@@ -17,10 +17,11 @@
 package org.graylog2.shared.system.stats.fs;
 
 import com.google.common.collect.ImmutableSet;
+import org.graylog2.configuration.GraylogDataDir;
 
 import javax.inject.Inject;
-import javax.inject.Named;
 import java.io.File;
+import java.nio.file.Path;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
@@ -29,8 +30,8 @@ public class JmxFsProbe implements FsProbe {
     private final Set<File> locations;
 
     @Inject
-    public JmxFsProbe(@Named("message_journal_dir") File journalDirectory) {
-        this.locations = ImmutableSet.of(journalDirectory);
+    public JmxFsProbe(@GraylogDataDir("message_journal_dir") Path journalDirectory) {
+        this.locations = ImmutableSet.of(journalDirectory.toFile());
     }
 
     @Override

--- a/graylog2-server/src/main/java/org/graylog2/shared/system/stats/fs/SigarFsProbe.java
+++ b/graylog2-server/src/main/java/org/graylog2/shared/system/stats/fs/SigarFsProbe.java
@@ -17,6 +17,7 @@
 package org.graylog2.shared.system.stats.fs;
 
 import com.google.common.collect.ImmutableSet;
+import org.graylog2.configuration.GraylogDataDir;
 import org.graylog2.shared.system.stats.SigarService;
 import org.hyperic.sigar.FileSystem;
 import org.hyperic.sigar.FileSystemMap;
@@ -25,8 +26,8 @@ import org.hyperic.sigar.Sigar;
 import org.hyperic.sigar.SigarException;
 
 import javax.inject.Inject;
-import javax.inject.Named;
 import java.io.File;
+import java.nio.file.Path;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
@@ -37,9 +38,9 @@ public class SigarFsProbe implements FsProbe {
     private final Map<File, FileSystem> sigarFileSystems = new HashMap<>();
 
     @Inject
-    public SigarFsProbe(SigarService sigarService, @Named("message_journal_dir") File journalDirectory) {
+    public SigarFsProbe(SigarService sigarService, @GraylogDataDir("message_journal_dir") Path journalDirectory) {
         this.sigarService = sigarService;
-        this.locations = ImmutableSet.of(journalDirectory);
+        this.locations = ImmutableSet.of(journalDirectory.toFile());
     }
 
     @Override

--- a/graylog2-server/src/test/java/org/graylog2/configuration/ConfigurationPathParametersModuleTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/configuration/ConfigurationPathParametersModuleTest.java
@@ -1,0 +1,139 @@
+/**
+ * This file is part of Graylog.
+ *
+ * Graylog is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.graylog2.configuration;
+
+import com.github.joschi.jadconfig.JadConfig;
+import com.github.joschi.jadconfig.Parameter;
+import com.github.joschi.jadconfig.repositories.InMemoryRepository;
+import com.google.common.collect.ImmutableMap;
+import com.google.inject.CreationException;
+import com.google.inject.Guice;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+import javax.inject.Inject;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.hamcrest.Matchers.isA;
+
+public class ConfigurationPathParametersModuleTest {
+    private static final Path ABSOLUTE_PATH = Paths.get("").toAbsolutePath();
+
+    private static class Config {
+        @Parameter("bin_path")
+        public Path binPath = null;
+
+        @Parameter("data_dir")
+        public Path dataDir = null;
+
+        @Parameter("message_journal_dir1")
+        @GraylogDataDir
+        public Path messageJournalDir1 = null;
+
+        @Parameter("message_journal_dir2")
+        @GraylogDataDir
+        public Path messageJournalDir2 = null;
+    }
+
+    private static class MyClass {
+        final Path binPath;
+        final Path journalDir1;
+        final Path journalDir2;
+
+        @Inject
+        public MyClass(@GraylogBinPath Path binPath,
+                       @GraylogDataDir("message_journal_dir1") Path journalDir1,
+                       @GraylogDataDir("message_journal_dir2") Path journalDir2) {
+            this.binPath = binPath;
+            this.journalDir1 = journalDir1;
+            this.journalDir2 = journalDir2;
+        }
+    }
+
+    private MyClass getInstanceWithConfig(Map<String, String> configMap) throws Exception {
+        final InMemoryRepository repository = new InMemoryRepository(configMap);
+        JadConfig jadConfig = new JadConfig(repository, new Config());
+        jadConfig.process();
+
+        return Guice.createInjector(new ConfigurationPathParametersModule(jadConfig.getConfigurationBeans())).getInstance(MyClass.class);
+    }
+
+    @Rule
+    public ExpectedException expectedException = ExpectedException.none();
+
+    @Test
+    public void testBinPath() throws Exception {
+        final MyClass instance = getInstanceWithConfig(ImmutableMap.of(
+                "bin_path", "bin",
+                "data_dir", "data",
+                "message_journal_dir1", "journal",
+                "message_journal_dir2", "journal"
+        ));
+
+        assertThat(instance.binPath)
+                .isAbsolute()
+                .isEqualTo(ABSOLUTE_PATH.resolve("bin"));
+    }
+
+    @Test
+    public void testBinPathWithoutValue() throws Exception {
+        expectedException.expect(CreationException.class);
+        expectedException.expectCause(isA(IllegalStateException.class));
+
+        getInstanceWithConfig(ImmutableMap.of(
+                "data_dir", "data",
+                "message_journal_dir1", "journal",
+                "message_journal_dir2", "journal"
+        ));
+    }
+
+    @Test
+    public void testDataDir() throws Exception {
+        final MyClass instance = getInstanceWithConfig(ImmutableMap.of(
+                "bin_path", "bin",
+                "data_dir", "data",
+                "message_journal_dir1", "jj",
+                "message_journal_dir2", "/tmp/journal"
+        ));
+
+        // If config value is a relative path, data_dir is used as base
+        assertThat(instance.journalDir1)
+                .isAbsolute()
+                .isEqualTo(ABSOLUTE_PATH.resolve("data/jj"));
+
+        // If config value is an absolute path, that one is used
+        assertThat(instance.journalDir2)
+                .isAbsolute()
+                .isEqualTo(Paths.get("/tmp/journal"));
+    }
+
+    @Test
+    public void testDataDirWithoutValue() throws Exception {
+        expectedException.expect(CreationException.class);
+        expectedException.expectCause(isA(IllegalStateException.class));
+
+        getInstanceWithConfig(ImmutableMap.of(
+                "bin_path", "bin",
+                "message_journal_dir1", "journal",
+                "message_journal_dir2", "journal"
+        ));
+    }
+}

--- a/graylog2-server/src/test/java/org/graylog2/shared/journal/KafkaJournalTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/shared/journal/KafkaJournalTest.java
@@ -50,6 +50,7 @@ import java.io.File;
 import java.io.FileFilter;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.Path;
 import java.util.EnumSet;
 import java.util.List;
 import java.util.UUID;
@@ -78,12 +79,14 @@ public class KafkaJournalTest {
     private ServerStatus serverStatus;
     private ScheduledThreadPoolExecutor scheduler;
     private File journalDirectory;
+    private Path journalDirectoryPath;
 
     @Before
     public void setUp() throws IOException {
         scheduler = new ScheduledThreadPoolExecutor(1);
         scheduler.prestartCoreThread();
         journalDirectory = temporaryFolder.newFolder();
+        journalDirectoryPath = journalDirectory.toPath();
 
         final File nodeId = temporaryFolder.newFile("node-id");
         Files.write(UUID.randomUUID().toString(), nodeId, StandardCharsets.UTF_8);
@@ -104,7 +107,7 @@ public class KafkaJournalTest {
 
     @Test
     public void writeAndRead() throws IOException {
-        final Journal journal = new KafkaJournal(journalDirectory,
+        final Journal journal = new KafkaJournal(journalDirectoryPath,
                 scheduler,
                 Size.megabytes(100L),
                 Duration.standardHours(1),
@@ -129,7 +132,7 @@ public class KafkaJournalTest {
 
     @Test
     public void readAtLeastOne() throws Exception {
-        final Journal journal = new KafkaJournal(journalDirectory,
+        final Journal journal = new KafkaJournal(journalDirectoryPath,
                 scheduler,
                 Size.megabytes(100L),
                 Duration.standardHours(1),
@@ -185,7 +188,7 @@ public class KafkaJournalTest {
     @Test
     public void maxSegmentSize() throws Exception {
         final Size segmentSize = Size.kilobytes(1L);
-        final KafkaJournal journal = new KafkaJournal(journalDirectory,
+        final KafkaJournal journal = new KafkaJournal(journalDirectoryPath,
                 scheduler,
                 segmentSize,
                 Duration.standardHours(1),
@@ -217,7 +220,7 @@ public class KafkaJournalTest {
     @Test
     public void maxMessageSize() throws Exception {
         final Size segmentSize = Size.kilobytes(1L);
-        final KafkaJournal journal = new KafkaJournal(journalDirectory,
+        final KafkaJournal journal = new KafkaJournal(journalDirectoryPath,
                 scheduler,
                 segmentSize,
                 Duration.standardHours(1),
@@ -257,7 +260,7 @@ public class KafkaJournalTest {
     @Test
     public void segmentRotation() throws Exception {
         final Size segmentSize = Size.kilobytes(1L);
-        final KafkaJournal journal = new KafkaJournal(journalDirectory,
+        final KafkaJournal journal = new KafkaJournal(journalDirectoryPath,
                 scheduler,
                 segmentSize,
                 Duration.standardHours(1),
@@ -286,7 +289,7 @@ public class KafkaJournalTest {
     @Test
     public void segmentSizeCleanup() throws Exception {
         final Size segmentSize = Size.kilobytes(1L);
-        final KafkaJournal journal = new KafkaJournal(journalDirectory,
+        final KafkaJournal journal = new KafkaJournal(journalDirectoryPath,
                 scheduler,
                 segmentSize,
                 Duration.standardHours(1),
@@ -322,7 +325,7 @@ public class KafkaJournalTest {
         DateTimeUtils.setCurrentMillisProvider(clock);
         try {
             final Size segmentSize = Size.kilobytes(1L);
-            final KafkaJournal journal = new KafkaJournal(journalDirectory,
+            final KafkaJournal journal = new KafkaJournal(journalDirectoryPath,
                     scheduler,
                     segmentSize,
                     Duration.standardHours(1),
@@ -376,7 +379,7 @@ public class KafkaJournalTest {
     @Test
     public void segmentCommittedCleanup() throws Exception {
         final Size segmentSize = Size.kilobytes(1L);
-        final KafkaJournal journal = new KafkaJournal(journalDirectory,
+        final KafkaJournal journal = new KafkaJournal(journalDirectoryPath,
                 scheduler,
                 segmentSize,
                 Duration.standardHours(1),
@@ -427,7 +430,7 @@ public class KafkaJournalTest {
         assumeTrue(fileLock.tryLock());
 
         try {
-            new KafkaJournal(journalDirectory,
+            new KafkaJournal(journalDirectoryPath,
                 scheduler,
                 Size.megabytes(100L),
                 Duration.standardHours(1),
@@ -453,7 +456,7 @@ public class KafkaJournalTest {
         serverStatus.running();
 
         final Size segmentSize = Size.kilobytes(1L);
-        final KafkaJournal journal = new KafkaJournal(journalDirectory,
+        final KafkaJournal journal = new KafkaJournal(journalDirectoryPath,
             scheduler,
             segmentSize,
             Duration.standardSeconds(1L),
@@ -476,7 +479,7 @@ public class KafkaJournalTest {
         serverStatus.throttle();
 
         final Size segmentSize = Size.kilobytes(1L);
-        final KafkaJournal journal = new KafkaJournal(journalDirectory,
+        final KafkaJournal journal = new KafkaJournal(journalDirectoryPath,
             scheduler,
             segmentSize,
             Duration.standardSeconds(1L),

--- a/misc/graylog.conf
+++ b/misc/graylog.conf
@@ -73,6 +73,14 @@ root_password_sha2 =
 # Default is UTC
 #root_timezone = UTC
 
+# Set the bin directory here (relative or absolute)
+# This directory contains binaries that are used by the Graylog server.
+bin_path = bin
+
+# Set the data directory here (relative or absolute)
+# This directory is used as base path for other directories like the "message_journal_dir" by default.
+data_dir = data
+
 # Set plugin directory here (relative or absolute)
 plugin_dir = plugin
 

--- a/misc/graylog.conf
+++ b/misc/graylog.conf
@@ -462,11 +462,16 @@ message_journal_enabled = true
 # The directory which will be used to store the message journal. The directory must me exclusively used by Graylog and
 # must not contain any other files than the ones created by Graylog itself.
 #
+# If this is a relative path, it will use the "data_dir" path as base dir.
+# Examples:
+# - "message_journal_dir = journal"          => "data/journal" (with the default "data_dir = data" setting)
+# - "message_journal_dir = /path/to/journal" => "/path/to/journal"
+#
 # ATTENTION:
 #   If you create a seperate partition for the journal files and use a file system creating directories like 'lost+found'
 #   in the root directory, you need to create a sub directory for your journal.
 #   Otherwise Graylog will log an error message that the journal is corrupt and Graylog will not start.
-message_journal_dir = data/journal
+message_journal_dir = journal
 
 # Journal hold messages before they could be written to Elasticsearch.
 # For a maximum of 12 hours or 5 GB whichever happens first.

--- a/misc/graylog.conf
+++ b/misc/graylog.conf
@@ -613,7 +613,11 @@ mongodb_threads_allowed_to_block_multiplier = 5
 #content_packs_loader_enabled = true
 
 # The directory which contains content packs which should be loaded on the first start of Graylog.
-#content_packs_dir = data/contentpacks
+# If this is a relative path, it will use the "data_dir" path as base dir.
+# Examples:
+# - "content_packs_dir = contentpacks"           => "data/contentpacks" (with the default "data_dir = data" setting)
+# - "content_packs_dir = /path/to/contentpacks" => "/path/to/contentpacks"
+#content_packs_dir = contentpacks
 
 # A comma-separated list of content packs (files in "content_packs_dir") which should be applied on
 # the first start of Graylog.


### PR DESCRIPTION
The data dir will be used as base dir for settings like `message_journal_dir` and `content_packs_dir`.

The `bin_path` setting will point to the relative `bin` path by default. The `data_dir` setting will point to the `data` directory by default and acts as the base directory for the `message_journal_dir` and `content_pack_dir` settings.

Config values can be injected into objects by using the `@GraylogDataDir` and `@GraylogBinPath` annotations.

#### `@GraylogBinPath`

```java
     public class ScriptExec {
       @Inject
       ScriptExec(@GraylogBinPath Path binPath, String scriptName) {
           this.scriptName = binPath.resolve(scriptName);
       }
     }
```

#### `@GraylogDataDir` -- with `data_dir` as base directory

```java
     public class Config {
       @Parameter("data_dir")
       private Path dataDir = Paths.get("data");

       @Parameter("message_journal_dir")
       @GraylogDataDir
       private Path messageJournalDir = Paths.get("journal");
     }
  
     public class Journal {
       @Inject
       Journal(@GraylogDataDir("message_journal_dir") Path journalDir) {
           // journalDir == "data/journal"
       }
     }
```

#### `@GraylogDataDir` -- without `data_dir` as base directory

```java
     public class Config {
       @Parameter("data_dir")
       private Path dataDir = Paths.get("data");

       @Parameter("message_journal_dir")
       @GraylogDataDir
       private Path messageJournalDir = Paths.get("/mnt/graylog-journal");
     }
  
     public class Journal {
       @Inject
       Journal(@GraylogDataDir("message_journal_dir") Path journalDir) {
           // journalDir == "/mnt/graylog-journal"
       }
     }
```