### PR TITLE
Add "bin_path" and "data_dir" settings

### DIFF
--- a/UPGRADING.rst
+++ b/UPGRADING.rst
@@ -141,12 +141,12 @@ The following HTTP API paths changed due to the plugin merge:
 | ``/plugins/org.graylog.plugins.pipelineprocessor/system/pipelines/simulate``                | ``/system/pipelines/simulate``                |
 +---------------------------------------------------------------------------------------------+-----------------------------------------------+
 
-New "bin_path" and "data_dir" configuration parameters
-======================================================
+New "bin_dir" and "data_dir" configuration parameters
+=====================================================
 
 We introduced two new configuration parameters related to file system paths.
 
-- ``bin_path`` config option points to the directory that contains scripts like ``graylogctl``.
+- ``bin_dir`` config option points to the directory that contains scripts like ``graylogctl``.
 - ``data_dir`` option configures the base directory for Graylog server state.
 
 Please check the updated default ``graylog.conf`` configuration file for required changes to your existing file.

--- a/UPGRADING.rst
+++ b/UPGRADING.rst
@@ -140,3 +140,13 @@ The following HTTP API paths changed due to the plugin merge:
 +---------------------------------------------------------------------------------------------+-----------------------------------------------+
 | ``/plugins/org.graylog.plugins.pipelineprocessor/system/pipelines/simulate``                | ``/system/pipelines/simulate``                |
 +---------------------------------------------------------------------------------------------+-----------------------------------------------+
+
+New "bin_path" and "data_dir" configuration parameters
+======================================================
+
+We introduced two new configuration parameters related to file system paths.
+
+- ``bin_path`` config option points to the directory that contains scripts like ``graylogctl``.
+- ``data_dir`` option configures the base directory for Graylog server state.
+
+Please check the updated default ``graylog.conf`` configuration file for required changes to your existing file.

--- a/graylog2-server/src/main/java/org/graylog2/bootstrap/CmdLineTool.java
+++ b/graylog2-server/src/main/java/org/graylog2/bootstrap/CmdLineTool.java
@@ -69,6 +69,7 @@ import org.slf4j.LoggerFactory;
 import java.io.File;
 import java.lang.management.ManagementFactory;
 import java.nio.file.AccessDeniedException;
+import java.nio.file.Path;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
@@ -265,7 +266,7 @@ public abstract class CmdLineTool implements CliCommand {
         dumpCurrentConfigAndExit();
     }
 
-    private PluginBindings installPluginConfigAndBindings(String pluginPath, ChainingClassLoader classLoader) {
+    private PluginBindings installPluginConfigAndBindings(Path pluginPath, ChainingClassLoader classLoader) {
         final Set<Plugin> plugins = loadPlugins(pluginPath, classLoader);
         final PluginBindings pluginBindings = new PluginBindings(plugins);
         for (final Plugin plugin : plugins) {
@@ -279,18 +280,17 @@ public abstract class CmdLineTool implements CliCommand {
         return pluginBindings;
     }
 
-    private String getPluginPath(String configFile) {
+    private Path getPluginPath(String configFile) {
         final PluginLoaderConfig pluginLoaderConfig = new PluginLoaderConfig();
         processConfiguration(new JadConfig(getConfigRepositories(configFile), pluginLoaderConfig));
 
         return pluginLoaderConfig.getPluginDir();
     }
 
-    protected Set<Plugin> loadPlugins(String pluginPath, ChainingClassLoader chainingClassLoader) {
-        final File pluginDir = new File(pluginPath);
+    protected Set<Plugin> loadPlugins(Path pluginPath, ChainingClassLoader chainingClassLoader) {
         final Set<Plugin> plugins = new HashSet<>();
 
-        final PluginLoader pluginLoader = new PluginLoader(pluginDir, chainingClassLoader);
+        final PluginLoader pluginLoader = new PluginLoader(pluginPath.toFile(), chainingClassLoader);
         for (Plugin plugin : pluginLoader.loadPlugins()) {
             final PluginMetaData metadata = plugin.metadata();
             if (capabilities().containsAll(metadata.getRequiredCapabilities())) {

--- a/graylog2-server/src/main/java/org/graylog2/commands/journal/AbstractJournalCommand.java
+++ b/graylog2-server/src/main/java/org/graylog2/commands/journal/AbstractJournalCommand.java
@@ -30,6 +30,7 @@ import org.graylog2.shared.journal.KafkaJournal;
 import org.graylog2.shared.journal.KafkaJournalModule;
 import org.graylog2.shared.plugins.ChainingClassLoader;
 
+import java.nio.file.Path;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
@@ -73,7 +74,7 @@ public abstract class AbstractJournalCommand extends CmdLineTool {
     }
 
     @Override
-    protected Set<Plugin> loadPlugins(String pluginPath, ChainingClassLoader chainingClassLoader) {
+    protected Set<Plugin> loadPlugins(Path pluginPath, ChainingClassLoader chainingClassLoader) {
         // these commands do not need plugins, which could cause problems because of not loaded config beans
         return Collections.emptySet();
     }

--- a/graylog2-server/src/main/java/org/graylog2/commands/journal/JournalShow.java
+++ b/graylog2-server/src/main/java/org/graylog2/commands/journal/JournalShow.java
@@ -44,7 +44,7 @@ public class JournalShow extends AbstractJournalCommand {
         final long startOffset = journal.getLogStartOffset();
         final long lastOffset = journal.getLogEndOffset() - 1;
 
-        sb.append("Graylog message journal in directory: ").append(kafkaJournalConfiguration.getMessageJournalDir().getAbsolutePath()).append(
+        sb.append("Graylog message journal in directory: ").append(kafkaJournalConfiguration.getMessageJournalDir().toAbsolutePath()).append(
                 "\n");
         sb.append("\t").append("Total size in bytes: ").append(sizeInBytes).append("\n");
         sb.append("\t").append("Number of segments: ").append(numSegments).append("\n");

--- a/graylog2-server/src/main/java/org/graylog2/configuration/ExposedConfiguration.java
+++ b/graylog2-server/src/main/java/org/graylog2/configuration/ExposedConfiguration.java
@@ -23,6 +23,8 @@ import com.google.auto.value.AutoValue;
 import org.graylog.autovalue.WithBeanGetter;
 import org.graylog2.Configuration;
 
+import java.nio.file.Path;
+
 /**
  * List of configuration values that are safe to return, i.e. do not include any sensitive
  * information. Building a list manually because we need to guarantee never to return any
@@ -53,8 +55,14 @@ public abstract class ExposedConfiguration {
     @JsonProperty("ring_size")
     public abstract int ringSize();
 
+    @JsonProperty("bin_dir")
+    public abstract Path binDir();
+
+    @JsonProperty("data_dir")
+    public abstract Path dataDir();
+
     @JsonProperty("plugin_dir")
-    public abstract String pluginDir();
+    public abstract Path pluginDir();
 
     @JsonProperty("node_id_file")
     public abstract String nodeIdFile();
@@ -89,6 +97,8 @@ public abstract class ExposedConfiguration {
                 configuration.getInputBufferWaitStrategy().getClass().getName(),
                 configuration.getInputBufferRingSize(),
                 configuration.getRingSize(),
+                configuration.getBinDir(),
+                configuration.getDataDir(),
                 configuration.getPluginDir(),
                 configuration.getNodeIdFile(),
                 configuration.isAllowHighlighting(),
@@ -109,7 +119,9 @@ public abstract class ExposedConfiguration {
             @JsonProperty("inputbuffer_wait_strategy") String inputBufferWaitStrategy,
             @JsonProperty("inputbuffer_ring_size") int inputBufferRingSize,
             @JsonProperty("ring_size") int ringSize,
-            @JsonProperty("plugin_dir") String pluginDir,
+            @JsonProperty("bin_dir") Path binDir,
+            @JsonProperty("data_dir") Path dataDir,
+            @JsonProperty("plugin_dir") Path pluginDir,
             @JsonProperty("node_id_file") String nodeIdFile,
             @JsonProperty("allow_highlighting") boolean allowHighlighting,
             @JsonProperty("allow_leading_wildcard_searches") boolean allowLeadingWildcardSearches,
@@ -126,6 +138,8 @@ public abstract class ExposedConfiguration {
                 inputBufferWaitStrategy,
                 inputBufferRingSize,
                 ringSize,
+                binDir,
+                dataDir,
                 pluginDir,
                 nodeIdFile,
                 allowHighlighting,

--- a/graylog2-server/src/main/java/org/graylog2/configuration/PathConfiguration.java
+++ b/graylog2-server/src/main/java/org/graylog2/configuration/PathConfiguration.java
@@ -14,9 +14,33 @@
  * You should have received a copy of the GNU General Public License
  * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
  */
-package org.graylog2.plugin;
+package org.graylog2.configuration;
 
-import org.graylog2.configuration.PathConfiguration;
+import com.github.joschi.jadconfig.Parameter;
 
-public class PluginLoaderConfig extends PathConfiguration {
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+public abstract class PathConfiguration {
+    @Parameter(value = "bin_dir", required = true)
+    private Path binDir = Paths.get("bin");
+
+    @Parameter(value = "data_dir", required = true)
+    private Path dataDir = Paths.get("data");
+
+    @Parameter(value = "plugin_dir", required = true)
+    private Path pluginDir = Paths.get("plugin");
+
+    public Path getBinDir() {
+        return binDir;
+    }
+
+    public Path getDataDir() {
+        return dataDir;
+    }
+
+    public Path getPluginDir() {
+        return pluginDir;
+    }
+
 }

--- a/graylog2-server/src/main/java/org/graylog2/plugin/BaseConfiguration.java
+++ b/graylog2-server/src/main/java/org/graylog2/plugin/BaseConfiguration.java
@@ -30,6 +30,8 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.net.URI;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 
 @SuppressWarnings("FieldMayBeFinal")
 public abstract class BaseConfiguration {
@@ -52,6 +54,12 @@ public abstract class BaseConfiguration {
 
     @Parameter(value = "inputbuffer_wait_strategy", required = true)
     private String inputBufferWaitStrategy = "blocking";
+
+    @Parameter(value = "bin_path", required = true)
+    private Path binPath = Paths.get("bin");
+
+    @Parameter(value = "data_dir", required = true)
+    private Path dataDir = Paths.get("data");
 
     @Parameter(value = "plugin_dir")
     private String pluginDir = "plugin";
@@ -127,6 +135,14 @@ public abstract class BaseConfiguration {
 
     public WaitStrategy getInputBufferWaitStrategy() {
         return getWaitStrategy(inputBufferWaitStrategy, "inputbuffer_wait_strategy");
+    }
+
+    public Path getBinPath() {
+        return binPath;
+    }
+
+    public Path getDataDir() {
+        return dataDir;
     }
 
     public String getPluginDir() {

--- a/graylog2-server/src/main/java/org/graylog2/plugin/BaseConfiguration.java
+++ b/graylog2-server/src/main/java/org/graylog2/plugin/BaseConfiguration.java
@@ -26,6 +26,7 @@ import com.lmax.disruptor.BusySpinWaitStrategy;
 import com.lmax.disruptor.SleepingWaitStrategy;
 import com.lmax.disruptor.WaitStrategy;
 import com.lmax.disruptor.YieldingWaitStrategy;
+import org.graylog2.configuration.PathConfiguration;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -34,7 +35,7 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 
 @SuppressWarnings("FieldMayBeFinal")
-public abstract class BaseConfiguration {
+public abstract class BaseConfiguration extends PathConfiguration {
     private static final Logger LOG = LoggerFactory.getLogger(BaseConfiguration.class);
 
     @Parameter(value = "shutdown_timeout", validator = PositiveIntegerValidator.class)
@@ -54,15 +55,6 @@ public abstract class BaseConfiguration {
 
     @Parameter(value = "inputbuffer_wait_strategy", required = true)
     private String inputBufferWaitStrategy = "blocking";
-
-    @Parameter(value = "bin_path", required = true)
-    private Path binPath = Paths.get("bin");
-
-    @Parameter(value = "data_dir", required = true)
-    private Path dataDir = Paths.get("data");
-
-    @Parameter(value = "plugin_dir")
-    private String pluginDir = "plugin";
 
     @Parameter(value = "async_eventbus_processors")
     private int asyncEventbusProcessors = 2;
@@ -135,18 +127,6 @@ public abstract class BaseConfiguration {
 
     public WaitStrategy getInputBufferWaitStrategy() {
         return getWaitStrategy(inputBufferWaitStrategy, "inputbuffer_wait_strategy");
-    }
-
-    public Path getBinPath() {
-        return binPath;
-    }
-
-    public Path getDataDir() {
-        return dataDir;
-    }
-
-    public String getPluginDir() {
-        return pluginDir;
     }
 
     public int getAsyncEventbusProcessors() {

--- a/graylog2-server/src/main/java/org/graylog2/plugin/KafkaJournalConfiguration.java
+++ b/graylog2-server/src/main/java/org/graylog2/plugin/KafkaJournalConfiguration.java
@@ -21,18 +21,20 @@ import com.fasterxml.jackson.annotation.JsonFormat;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.github.joschi.jadconfig.Parameter;
 import com.github.joschi.jadconfig.util.Size;
+import org.graylog2.configuration.PathConfiguration;
 import org.joda.time.Duration;
 
 import javax.validation.constraints.NotNull;
 import java.io.File;
+import java.nio.file.Path;
 import java.util.Objects;
 
-public class KafkaJournalConfiguration {
+public class KafkaJournalConfiguration extends PathConfiguration {
 
     public KafkaJournalConfiguration() { }
 
     @JsonCreator
-    public KafkaJournalConfiguration(@NotNull @JsonProperty("directory") File messageJournalDir,
+    public KafkaJournalConfiguration(@NotNull @JsonProperty("directory") Path messageJournalDir,
                                      @JsonProperty("segment_size") long messageJournalSegmentSize,
                                      @JsonProperty("segment_age") Duration messageJournalSegmentAge,
                                      @JsonProperty("max_size") long messageJournalMaxSize,
@@ -50,7 +52,7 @@ public class KafkaJournalConfiguration {
 
     @Parameter(value = "message_journal_dir", required = true)
     @JsonProperty("directory")
-    private File messageJournalDir = new File("data/journal");
+    private Path messageJournalDir = getDataDir().resolve("journal");
 
     @Parameter("message_journal_segment_size")
     @JsonProperty("segment_size")
@@ -79,7 +81,7 @@ public class KafkaJournalConfiguration {
     @JsonProperty("flush_age")
     private Duration messageJournalFlushAge = Duration.standardMinutes(1L);
 
-    public File getMessageJournalDir() {
+    public Path getMessageJournalDir() {
         return messageJournalDir;
     }
 

--- a/graylog2-server/src/main/java/org/graylog2/shared/system/stats/fs/JmxFsProbe.java
+++ b/graylog2-server/src/main/java/org/graylog2/shared/system/stats/fs/JmxFsProbe.java
@@ -17,9 +17,10 @@
 package org.graylog2.shared.system.stats.fs;
 
 import com.google.common.collect.ImmutableSet;
+import org.graylog2.Configuration;
+import org.graylog2.plugin.KafkaJournalConfiguration;
 
 import javax.inject.Inject;
-import javax.inject.Named;
 import java.io.File;
 import java.util.HashMap;
 import java.util.Map;
@@ -29,8 +30,12 @@ public class JmxFsProbe implements FsProbe {
     private final Set<File> locations;
 
     @Inject
-    public JmxFsProbe(@Named("message_journal_dir") File journalDirectory) {
-        this.locations = ImmutableSet.of(journalDirectory);
+    public JmxFsProbe(Configuration configuration, KafkaJournalConfiguration kafkaJournalConfiguration) {
+        this.locations = ImmutableSet.of(
+                configuration.getBinDir().toFile(),
+                configuration.getDataDir().toFile(),
+                kafkaJournalConfiguration.getMessageJournalDir().toFile()
+        );
     }
 
     @Override

--- a/graylog2-server/src/main/java/org/graylog2/shared/system/stats/fs/SigarFsProbe.java
+++ b/graylog2-server/src/main/java/org/graylog2/shared/system/stats/fs/SigarFsProbe.java
@@ -17,6 +17,8 @@
 package org.graylog2.shared.system.stats.fs;
 
 import com.google.common.collect.ImmutableSet;
+import org.graylog2.Configuration;
+import org.graylog2.plugin.KafkaJournalConfiguration;
 import org.graylog2.shared.system.stats.SigarService;
 import org.hyperic.sigar.FileSystem;
 import org.hyperic.sigar.FileSystemMap;
@@ -25,21 +27,25 @@ import org.hyperic.sigar.Sigar;
 import org.hyperic.sigar.SigarException;
 
 import javax.inject.Inject;
-import javax.inject.Named;
-import java.io.File;
+import java.nio.file.Path;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
 
 public class SigarFsProbe implements FsProbe {
     private final SigarService sigarService;
-    private final Set<File> locations;
-    private final Map<File, FileSystem> sigarFileSystems = new HashMap<>();
+    private final Set<Path> locations;
+    private final Map<Path, FileSystem> sigarFileSystems = new HashMap<>();
 
     @Inject
-    public SigarFsProbe(SigarService sigarService, @Named("message_journal_dir") File journalDirectory) {
+    public SigarFsProbe(SigarService sigarService, Configuration configuration,
+                        KafkaJournalConfiguration kafkaJournalConfiguration) {
         this.sigarService = sigarService;
-        this.locations = ImmutableSet.of(journalDirectory);
+        this.locations = ImmutableSet.of(
+                configuration.getBinDir(),
+                configuration.getDataDir(),
+                kafkaJournalConfiguration.getMessageJournalDir()
+        );
     }
 
     @Override
@@ -47,8 +53,8 @@ public class SigarFsProbe implements FsProbe {
         final Sigar sigar = sigarService.sigar();
         final Map<String, FsStats.Filesystem> filesystems = new HashMap<>(locations.size());
 
-        for (File location : locations) {
-            final String path = location.getAbsolutePath();
+        for (Path location : locations) {
+            final String path = location.toAbsolutePath().toString();
 
             try {
                 FileSystem fileSystem = sigarFileSystems.get(location);
@@ -56,7 +62,7 @@ public class SigarFsProbe implements FsProbe {
                 if (fileSystem == null) {
                     FileSystemMap fileSystemMap = sigar.getFileSystemMap();
                     if (fileSystemMap != null) {
-                        fileSystem = fileSystemMap.getMountPoint(location.getPath());
+                        fileSystem = fileSystemMap.getMountPoint(path);
                         sigarFileSystems.put(location, fileSystem);
                     }
                 }

--- a/graylog2-server/src/test/java/org/graylog2/configuration/ExposedConfigurationTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/configuration/ExposedConfigurationTest.java
@@ -22,6 +22,9 @@ import org.graylog2.Configuration;
 import org.graylog2.shared.bindings.providers.ObjectMapperProvider;
 import org.junit.Test;
 
+import java.net.URI;
+import java.nio.file.Paths;
+
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class ExposedConfigurationTest {
@@ -39,6 +42,8 @@ public class ExposedConfigurationTest {
         assertThat(c.inputBufferWaitStrategy()).isEqualTo(configuration.getInputBufferWaitStrategy().getClass().getName());
         assertThat(c.inputBufferRingSize()).isEqualTo(configuration.getInputBufferRingSize());
         assertThat(c.ringSize()).isEqualTo(configuration.getRingSize());
+        assertThat(c.binDir()).isEqualTo(configuration.getBinDir());
+        assertThat(c.dataDir()).isEqualTo(configuration.getDataDir());
         assertThat(c.pluginDir()).isEqualTo(configuration.getPluginDir());
         assertThat(c.nodeIdFile()).isEqualTo(configuration.getNodeIdFile());
         assertThat(c.allowHighlighting()).isEqualTo(configuration.isAllowHighlighting());
@@ -63,7 +68,9 @@ public class ExposedConfigurationTest {
         assertThat((String) JsonPath.read(json, "$.inputbuffer_wait_strategy")).isEqualTo(c.inputBufferWaitStrategy());
         assertThat((int) JsonPath.read(json, "$.inputbuffer_ring_size")).isEqualTo(c.inputBufferRingSize());
         assertThat((int) JsonPath.read(json, "$.ring_size")).isEqualTo(c.ringSize());
-        assertThat((String) JsonPath.read(json, "$.plugin_dir")).isEqualTo(c.pluginDir());
+        assertThat(URI.create(JsonPath.read(json, "$.bin_dir"))).isEqualTo(c.binDir().toUri());
+        assertThat(URI.create(JsonPath.read(json, "$.data_dir"))).isEqualTo(c.dataDir().toUri());
+        assertThat(URI.create(JsonPath.read(json, "$.plugin_dir"))).isEqualTo(c.pluginDir().toUri());
         assertThat((String) JsonPath.read(json, "$.node_id_file")).isEqualTo(c.nodeIdFile());
         assertThat((boolean) JsonPath.read(json, "$.allow_highlighting")).isEqualTo(c.allowHighlighting());
         assertThat((boolean) JsonPath.read(json, "$.allow_leading_wildcard_searches")).isEqualTo(c.allowLeadingWildcardSearches());
@@ -84,6 +91,8 @@ public class ExposedConfigurationTest {
                 "  \"inputbuffer_wait_strategy\": \"com.lmax.disruptor.BlockingWaitStrategy\"," +
                 "  \"inputbuffer_ring_size\": 65536," +
                 "  \"ring_size\": 65536," +
+                "  \"bin_dir\": \"bin\"," +
+                "  \"data_dir\": \"data\"," +
                 "  \"plugin_dir\": \"plugin\"," +
                 "  \"node_id_file\": \"/etc/graylog/server/node-id\"," +
                 "  \"allow_highlighting\": false," +
@@ -104,7 +113,9 @@ public class ExposedConfigurationTest {
         assertThat(c.inputBufferWaitStrategy()).isEqualTo(JsonPath.read(json, "$.inputbuffer_wait_strategy"));
         assertThat(c.inputBufferRingSize()).isEqualTo(JsonPath.read(json, "$.inputbuffer_ring_size"));
         assertThat(c.ringSize()).isEqualTo(JsonPath.read(json, "$.ring_size"));
-        assertThat(c.pluginDir()).isEqualTo(JsonPath.read(json, "$.plugin_dir"));
+        assertThat(c.binDir()).isEqualTo(Paths.get((String) JsonPath.read(json, "$.bin_dir")));
+        assertThat(c.dataDir()).isEqualTo(Paths.get((String) JsonPath.read(json, "$.data_dir")));
+        assertThat(c.pluginDir()).isEqualTo(Paths.get((String) JsonPath.read(json, "$.plugin_dir")));
         assertThat(c.nodeIdFile()).isEqualTo(JsonPath.read(json, "$.node_id_file"));
         assertThat(c.allowHighlighting()).isEqualTo(JsonPath.read(json, "$.allow_highlighting"));
         assertThat(c.allowLeadingWildcardSearches()).isEqualTo(JsonPath.read(json, "$.allow_leading_wildcard_searches"));

--- a/graylog2-server/src/test/java/org/graylog2/shared/journal/KafkaJournalTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/shared/journal/KafkaJournalTest.java
@@ -104,7 +104,7 @@ public class KafkaJournalTest {
 
     @Test
     public void writeAndRead() throws IOException {
-        final Journal journal = new KafkaJournal(journalDirectory,
+        final Journal journal = new KafkaJournal(journalDirectory.toPath(),
                 scheduler,
                 Size.megabytes(100L),
                 Duration.standardHours(1),
@@ -129,7 +129,7 @@ public class KafkaJournalTest {
 
     @Test
     public void readAtLeastOne() throws Exception {
-        final Journal journal = new KafkaJournal(journalDirectory,
+        final Journal journal = new KafkaJournal(journalDirectory.toPath(),
                 scheduler,
                 Size.megabytes(100L),
                 Duration.standardHours(1),
@@ -185,7 +185,7 @@ public class KafkaJournalTest {
     @Test
     public void maxSegmentSize() throws Exception {
         final Size segmentSize = Size.kilobytes(1L);
-        final KafkaJournal journal = new KafkaJournal(journalDirectory,
+        final KafkaJournal journal = new KafkaJournal(journalDirectory.toPath(),
                 scheduler,
                 segmentSize,
                 Duration.standardHours(1),
@@ -217,7 +217,7 @@ public class KafkaJournalTest {
     @Test
     public void maxMessageSize() throws Exception {
         final Size segmentSize = Size.kilobytes(1L);
-        final KafkaJournal journal = new KafkaJournal(journalDirectory,
+        final KafkaJournal journal = new KafkaJournal(journalDirectory.toPath(),
                 scheduler,
                 segmentSize,
                 Duration.standardHours(1),
@@ -257,7 +257,7 @@ public class KafkaJournalTest {
     @Test
     public void segmentRotation() throws Exception {
         final Size segmentSize = Size.kilobytes(1L);
-        final KafkaJournal journal = new KafkaJournal(journalDirectory,
+        final KafkaJournal journal = new KafkaJournal(journalDirectory.toPath(),
                 scheduler,
                 segmentSize,
                 Duration.standardHours(1),
@@ -286,7 +286,7 @@ public class KafkaJournalTest {
     @Test
     public void segmentSizeCleanup() throws Exception {
         final Size segmentSize = Size.kilobytes(1L);
-        final KafkaJournal journal = new KafkaJournal(journalDirectory,
+        final KafkaJournal journal = new KafkaJournal(journalDirectory.toPath(),
                 scheduler,
                 segmentSize,
                 Duration.standardHours(1),
@@ -322,7 +322,7 @@ public class KafkaJournalTest {
         DateTimeUtils.setCurrentMillisProvider(clock);
         try {
             final Size segmentSize = Size.kilobytes(1L);
-            final KafkaJournal journal = new KafkaJournal(journalDirectory,
+            final KafkaJournal journal = new KafkaJournal(journalDirectory.toPath(),
                     scheduler,
                     segmentSize,
                     Duration.standardHours(1),
@@ -376,7 +376,7 @@ public class KafkaJournalTest {
     @Test
     public void segmentCommittedCleanup() throws Exception {
         final Size segmentSize = Size.kilobytes(1L);
-        final KafkaJournal journal = new KafkaJournal(journalDirectory,
+        final KafkaJournal journal = new KafkaJournal(journalDirectory.toPath(),
                 scheduler,
                 segmentSize,
                 Duration.standardHours(1),
@@ -427,7 +427,7 @@ public class KafkaJournalTest {
         assumeTrue(fileLock.tryLock());
 
         try {
-            new KafkaJournal(journalDirectory,
+            new KafkaJournal(journalDirectory.toPath(),
                 scheduler,
                 Size.megabytes(100L),
                 Duration.standardHours(1),
@@ -453,7 +453,7 @@ public class KafkaJournalTest {
         serverStatus.running();
 
         final Size segmentSize = Size.kilobytes(1L);
-        final KafkaJournal journal = new KafkaJournal(journalDirectory,
+        final KafkaJournal journal = new KafkaJournal(journalDirectory.toPath(),
             scheduler,
             segmentSize,
             Duration.standardSeconds(1L),
@@ -476,7 +476,7 @@ public class KafkaJournalTest {
         serverStatus.throttle();
 
         final Size segmentSize = Size.kilobytes(1L);
-        final KafkaJournal journal = new KafkaJournal(journalDirectory,
+        final KafkaJournal journal = new KafkaJournal(journalDirectory.toPath(),
             scheduler,
             segmentSize,
             Duration.standardSeconds(1L),

--- a/misc/graylog.conf
+++ b/misc/graylog.conf
@@ -73,6 +73,16 @@ root_password_sha2 =
 # Default is UTC
 #root_timezone = UTC
 
+# Set the bin directory here (relative or absolute)
+# This directory contains binaries that are used by the Graylog server.
+# Default: bin
+bin_path = bin
+
+# Set the data directory here (relative or absolute)
+# This directory is used to store Graylog server state.
+# Default: data
+data_dir = data
+
 # Set plugin directory here (relative or absolute)
 plugin_dir = plugin
 

--- a/misc/graylog.conf
+++ b/misc/graylog.conf
@@ -76,7 +76,7 @@ root_password_sha2 =
 # Set the bin directory here (relative or absolute)
 # This directory contains binaries that are used by the Graylog server.
 # Default: bin
-bin_path = bin
+bin_dir = bin
 
 # Set the data directory here (relative or absolute)
 # This directory is used to store Graylog server state.


### PR DESCRIPTION
The `data_dir` config setting can be usd by Graylog subsystems to store data instead of creating separate config settings for that.

Closes #2057