### PR TITLE
Adding keys to plugin routes.

### DIFF
--- a/graylog2-web-interface/src/routing/AppRouter.jsx
+++ b/graylog2-web-interface/src/routing/AppRouter.jsx
@@ -72,7 +72,9 @@ import EnterprisePage from 'pages/EnterprisePage';
 class AppRouter extends React.Component {
   render() {
     const pluginRoutes = PluginStore.exports('routes').map((pluginRoute) => {
-      return <Route key={pluginRoute.component.displayName} path={URLUtils.appPrefixed(pluginRoute.path)} component={pluginRoute.component} />;
+      return (<Route key={`${pluginRoute.path}-${pluginRoute.component.displayName}`}
+                    path={URLUtils.appPrefixed(pluginRoute.path)}
+                    component={pluginRoute.component} />);
     });
     return (
       <Router history={history}>


### PR DESCRIPTION
## Description
## Motivation and Context
During initialization of the `AppRouter`, plugin routes are added by
iterating over a collection. During this step, `Route` components are
generated with a `key` based on the `displayName` property of a component,
which is `undefined` or non-unique in some cases.
This emits a warning generated by react and is prone to collisions preventing
individual routes to take effect.

This change is generating a key for each `Route` component consisting of
the plugin route component's `displayName` and its `path`. At least the
latter should be unique (otherwise one of the routes is shadowed
anyway).

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
