### PR TITLE
Prevent ForkedBooter process from stealing window focus on Mac OS

### DIFF
--- a/graylog-project-parent/pom.xml
+++ b/graylog-project-parent/pom.xml
@@ -671,7 +671,7 @@
                     <!-- Use ALL the cores! -->
                     <forkCount>1C</forkCount>
                     <reuseForks>false</reuseForks>
-                    <argLine>-Djava.library.path=${project.basedir}/../lib/sigar-${sigar.version} -Dio.netty.leakDetectionLevel=paranoid</argLine>
+                    <argLine>-Djava.library.path=${project.basedir}/../lib/sigar-${sigar.version} -Dio.netty.leakDetectionLevel=paranoid -Djava.awt.headless=true</argLine>
                     <excludes>
                         <exclude>**/*IntegrationTest.java</exclude>
                         <exclude>**/*IT.java</exclude>

--- a/graylog2-server/pom.xml
+++ b/graylog2-server/pom.xml
@@ -868,6 +868,8 @@
                         <configuration>
                             <forkCount>1</forkCount>
                             <skip>${it.es.skip}</skip>
+                            <!-- prevent ForkedBooter from stealing window focus on Mac OS -->
+                            <argLine>-Djava.awt.headless=true</argLine>
                         </configuration>
                         <executions>
                             <execution>


### PR DESCRIPTION
When running (Java) tests via Surefire or Failsafe, the window focus on Mac OS X is regularly "stolen" by a process named "ForkedBooter".

This change set adds parameters to the Maven Surefire and Failsafe plugins which start the JVM in headless mode and which prevent the "ForkedBooter" process from stealing the window focus on Mac OS X.

See also:
* https://somethingididnotknow.wordpress.com/2014/07/23/forkedbooter-steals-window-focus-on-mac-os-while-maven-is-running/
* https://apple.stackexchange.com/questions/100069/when-terminal-forks-process-current-app-loses-focus