### PR TITLE
Support drag handles in ReactGridContainer.

### DIFF
--- a/graylog2-web-interface/src/components/common/ReactGridContainer.jsx
+++ b/graylog2-web-interface/src/components/common/ReactGridContainer.jsx
@@ -30,6 +30,16 @@ const BREAKPOINTS = {
   xs: COLUMN_WIDTH * COLUMNS.xs,
 };
 
+const _gridClass = (locked, isResizable, useDragHandle) => {
+  if (locked || !isResizable) {
+    return 'locked';
+  }
+  if (useDragHandle) {
+    return '';
+  }
+  return 'unlocked';
+};
+
 /**
  * Component that renders a draggable and resizable grid. You can control
  * the grid elements' positioning, as well as if they should be resizable
@@ -103,6 +113,15 @@ class ReactGridContainer extends React.Component {
     columns: PropTypes.object,
     /** Specifies whether the grid should use CSS animations or not. */
     animate: PropTypes.bool,
+    /**
+     * Specifieds whether (and which css class) a drag handle should be used.
+     *
+     * If this prop is not specified, the whole widget can be used for dragging when the grid is unlockd.
+     *
+     * If this prop is specified, the css class specified will define which item can be used for dragging if unlocked.
+     *
+     */
+    useDragHandle: PropTypes.string,
   };
 
   static defaultProps = {
@@ -111,6 +130,7 @@ class ReactGridContainer extends React.Component {
     rowHeight: ROW_HEIGHT,
     columns: COLUMNS,
     animate: true,
+    useDragHandle: undefined,
   };
 
   componentWillReceiveProps(nextProps) {
@@ -159,13 +179,13 @@ class ReactGridContainer extends React.Component {
   };
 
   render() {
-    const { children, locked, isResizable, rowHeight, columns, animate } = this.props;
+    const { children, locked, isResizable, rowHeight, columns, animate, useDragHandle } = this.props;
     const { layout } = this.state;
 
     // We need to use a className and draggableHandle to avoid re-rendering all graphs on lock/unlock. See:
     // https://github.com/STRML/react-grid-layout/issues/371
     return (
-      <WidthAdjustedReactGridLayout className={`${style.reactGridLayout} ${locked || !isResizable ? 'locked' : 'unlocked'}`}
+      <WidthAdjustedReactGridLayout className={`${style.reactGridLayout} ${_gridClass(locked, isResizable, useDragHandle)}`}
                                     layouts={{ xxl: layout, xl: layout, lg: layout, md: layout, sm: layout, xs: layout }}
                                     breakpoints={BREAKPOINTS}
                                     cols={columns}
@@ -177,7 +197,7 @@ class ReactGridContainer extends React.Component {
                                     onDragStop={this._onLayoutChange}
                                     onResizeStop={this._onLayoutChange}
                                     useCSSTransforms={animate}
-                                    draggableHandle={locked ? '.no-handle' : ''}>
+                                    draggableHandle={locked ? '.no-handle' : useDragHandle}>
         {children}
       </WidthAdjustedReactGridLayout>
     );

--- a/graylog2-web-interface/src/components/common/ReactGridContainer.jsx
+++ b/graylog2-web-interface/src/components/common/ReactGridContainer.jsx
@@ -114,11 +114,11 @@ class ReactGridContainer extends React.Component {
     /** Specifies whether the grid should use CSS animations or not. */
     animate: PropTypes.bool,
     /**
-     * Specifieds whether (and which css class) a drag handle should be used.
+     * Specifies whether (and which css class) a drag handle should be used.
      *
-     * If this prop is not specified, the whole widget can be used for dragging when the grid is unlockd.
+     * If this prop is not specified, the whole widget can be used for dragging when the grid is unlocked.
      *
-     * If this prop is specified, the css class specified will define which item can be used for dragging if unlocked.
+     * If this prop is defined, the css class specified will define which item can be used for dragging if unlocked.
      *
      */
     useDragHandle: PropTypes.string,


### PR DESCRIPTION
## Description
## Motivation and Context
Before this change, it was only possible to move a widget by clicking
somewhere in the widget and drag it. For some use cases it is desirable
to have a fixed handle which allows dragging the widget. This PR allows
passing a CSS class which acts as drag handle.

<!--- Provide a general summary of your changes in the Title above -->
## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
