### PR TITLE
Adding hyperlinked fields in search result details

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/decorators/DecoratorBindings.java
+++ b/graylog2-server/src/main/java/org/graylog2/decorators/DecoratorBindings.java
@@ -35,5 +35,9 @@ public class DecoratorBindings extends Graylog2Module {
         installSearchResponseDecorator(searchResponseDecoratorBinder,
                                        LookupTableDecorator.class,
                                        LookupTableDecorator.Factory.class);
+
+        installSearchResponseDecorator(searchResponseDecoratorBinder,
+                                       LinkFieldConverter.class,
+                                       LinkFieldConverter.Factory.class);
     }
 }

--- a/graylog2-server/src/main/java/org/graylog2/decorators/DecoratorBindings.java
+++ b/graylog2-server/src/main/java/org/graylog2/decorators/DecoratorBindings.java
@@ -37,7 +37,7 @@ public class DecoratorBindings extends Graylog2Module {
                                        LookupTableDecorator.Factory.class);
 
         installSearchResponseDecorator(searchResponseDecoratorBinder,
-                                       LinkFieldConverter.class,
-                                       LinkFieldConverter.Factory.class);
+                                       LinkFieldDecorator.class,
+                                       LinkFieldDecorator.Factory.class);
     }
 }

--- a/graylog2-server/src/main/java/org/graylog2/decorators/LinkFieldConverter.java
+++ b/graylog2-server/src/main/java/org/graylog2/decorators/LinkFieldConverter.java
@@ -1,0 +1,104 @@
+/**
+ * This file is part of Graylog.
+ *
+ * Graylog is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.graylog2.decorators;
+
+import com.floreysoft.jmte.Engine;
+import com.floreysoft.jmte.template.Template;
+import com.floreysoft.jmte.template.VariableDescription;
+import com.google.common.collect.ImmutableMap;
+import com.google.inject.assistedinject.Assisted;
+import org.graylog2.plugin.Message;
+import org.graylog2.plugin.configuration.ConfigurationRequest;
+import org.graylog2.plugin.configuration.fields.BooleanField;
+import org.graylog2.plugin.configuration.fields.TextField;
+import org.graylog2.plugin.decorators.SearchResponseDecorator;
+import org.graylog2.rest.models.messages.responses.ResultMessageSummary;
+import org.graylog2.rest.resources.search.responses.SearchResponse;
+
+import javax.inject.Inject;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.stream.Collectors;
+
+import static java.util.Objects.requireNonNull;
+
+public class LinkFieldConverter implements SearchResponseDecorator {
+
+    private static final String CK_LINK_FIELD = "link_field";
+
+    private final String linkField;
+
+    public interface Factory extends SearchResponseDecorator.Factory {
+        @Override
+        LinkFieldConverter create(Decorator decorator);
+
+        @Override
+        LinkFieldConverter.Config getConfig();
+
+        @Override
+        LinkFieldConverter.Descriptor getDescriptor();
+    }
+
+    public static class Config implements SearchResponseDecorator.Config {
+
+        @Override
+        public ConfigurationRequest getRequestedConfiguration() {
+            return new ConfigurationRequest() {
+                {
+                    addField(new TextField(
+                            CK_LINK_FIELD,
+                            "Link field",
+                            "message",
+                            "The field that will be transformed into a hyperlink."
+                    ));
+                }
+            };
+        }
+    }
+
+    public static class Descriptor extends SearchResponseDecorator.Descriptor {
+        public Descriptor() {
+            super("Hyperlink String", "http://docs.graylog.org/", "Hyperlink string");
+        }
+    }
+
+    @Inject
+    public LinkFieldConverter(@Assisted Decorator decorator, Engine templateEngine) {
+        this.linkField = (String) requireNonNull(decorator.config().get(CK_LINK_FIELD),
+                                                   CK_LINK_FIELD + " cannot be null");
+    }
+
+    @Override
+    public SearchResponse apply(SearchResponse searchResponse) {
+        final List<ResultMessageSummary> summaries = searchResponse.messages().stream()
+                .map(summary -> {
+                    final Message message = new Message(ImmutableMap.copyOf(summary.message()));
+                    if (summary.message().containsKey(linkField)) {
+                        final String href = (String) summary.message().get(linkField);
+                        final LinkedHashMap object = new LinkedHashMap<String, String>();
+                        object.put("type", "a");
+                        object.put("href", href);
+                        message.addField(linkField, object);
+                    }
+                    return summary.toBuilder().message(message.getFields()).build();
+                })
+                .collect(Collectors.toList());
+
+        return searchResponse.toBuilder().messages(summaries).build();
+    }
+}

--- a/graylog2-server/src/main/java/org/graylog2/decorators/LinkFieldDecorator.java
+++ b/graylog2-server/src/main/java/org/graylog2/decorators/LinkFieldDecorator.java
@@ -31,6 +31,7 @@ import org.graylog2.rest.resources.search.responses.SearchResponse;
 
 import javax.inject.Inject;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 

--- a/graylog2-server/src/main/java/org/graylog2/decorators/LinkFieldDecorator.java
+++ b/graylog2-server/src/main/java/org/graylog2/decorators/LinkFieldDecorator.java
@@ -30,9 +30,8 @@ import org.graylog2.rest.models.messages.responses.ResultMessageSummary;
 import org.graylog2.rest.resources.search.responses.SearchResponse;
 
 import javax.inject.Inject;
-import java.util.LinkedHashMap;
-import java.util.List;
-import java.util.Locale;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.stream.Collectors;
 
 import static java.util.Objects.requireNonNull;
@@ -45,13 +44,13 @@ public class LinkFieldDecorator implements SearchResponseDecorator {
 
     public interface Factory extends SearchResponseDecorator.Factory {
         @Override
-        LinkFieldConverter create(Decorator decorator);
+        LinkFieldDecorator create(Decorator decorator);
 
         @Override
-        LinkFieldConverter.Config getConfig();
+        LinkFieldDecorator.Config getConfig();
 
         @Override
-        LinkFieldConverter.Descriptor getDescriptor();
+        LinkFieldDecorator.Descriptor getDescriptor();
     }
 
     public static class Config implements SearchResponseDecorator.Config {
@@ -78,7 +77,7 @@ public class LinkFieldDecorator implements SearchResponseDecorator {
     }
 
     @Inject
-    public LinkFieldConverter(@Assisted Decorator decorator) {
+    public LinkFieldDecorator(@Assisted Decorator decorator) {
         this.linkField = (String) requireNonNull(decorator.config().get(CK_LINK_FIELD),
                                                    CK_LINK_FIELD + " cannot be null");
     }

--- a/graylog2-web-interface/src/components/search/MessageFieldDescription.jsx
+++ b/graylog2-web-interface/src/components/search/MessageFieldDescription.jsx
@@ -50,13 +50,12 @@ class MessageFieldDescription extends React.Component {
     SearchStore.addSearchTerm(this.props.fieldName, this.props.fieldValue);
   };
 
-  _getFieldValue() {
+  _getFieldValue = () => {
     if (this.props.isDecorated && ('type' in this.props.fieldValue) && (this.props.fieldValue.type === 'a')) {
       const link = this.props.fieldValue.href;
-      return React.createElement('a', {href: link}, link);
-    } else {
-      return this.props.renderForDisplay(this.props.fieldName)
+      return React.createElement('a', { href: link }, link);
     }
+    return this.props.renderForDisplay(this.props.fieldName);
   };
 
   _getFormattedTerms = () => {

--- a/graylog2-web-interface/src/components/search/MessageFieldDescription.jsx
+++ b/graylog2-web-interface/src/components/search/MessageFieldDescription.jsx
@@ -50,6 +50,15 @@ class MessageFieldDescription extends React.Component {
     SearchStore.addSearchTerm(this.props.fieldName, this.props.fieldValue);
   };
 
+  _getFieldValue() {
+    if (this.props.isDecorated && ('type' in this.props.fieldValue) && (this.props.fieldValue.type === 'a')) {
+      const link = this.props.fieldValue.href;
+      return React.createElement('a', {href: link}, link);
+    } else {
+      return this.props.renderForDisplay(this.props.fieldName)
+    }
+  };
+
   _getFormattedTerms = () => {
     const termsMarkup = [];
     this.state.messageTerms.forEach((term, idx) => {
@@ -85,7 +94,7 @@ class MessageFieldDescription extends React.Component {
     return (
       <dd className={className} key={`${this.props.fieldName}dd`}>
         {this._getFormattedFieldActions()}
-        <div className="field-value">{this.props.renderForDisplay(this.props.fieldName)}</div>
+        <div className="field-value">{this._getFieldValue()}</div>
         {this._shouldShowTerms() &&
         <Alert bsStyle="info" onDismiss={() => this.setState({ messageTerms: Immutable.Map() })}>
           Field terms: &nbsp;{this._getFormattedTerms()}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This PR allows graylog to have hyperlinked search result fields. A user can create a decorator for a field that they want to allow to be a hyperlink.

Closes this issue/feature request: https://github.com/Graylog2/graylog2-server/issues/1914

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
I built graylog via `mvn compile`
I then ran the frontend and backend servers.
Tested saving config with several fields, not fields, etc.
Made sure that the search page details rendered accordingly.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
