### PR TITLE
Fix JSON serialization of PaginatedResponse

### DIFF
--- a/graylog-project-parent/pom.xml
+++ b/graylog-project-parent/pom.xml
@@ -541,6 +541,12 @@
                 <scope>test</scope>
             </dependency>
             <dependency>
+                <groupId>com.revinate</groupId>
+                <artifactId>assertj-json</artifactId>
+                <version>${assertj-json.version}</version>
+                <scope>test</scope>
+            </dependency>
+            <dependency>
                 <groupId>org.mockito</groupId>
                 <artifactId>mockito-core</artifactId>
                 <version>${mockito.version}</version>

--- a/graylog2-server/pom.xml
+++ b/graylog2-server/pom.xml
@@ -356,6 +356,10 @@
             <artifactId>assertj-joda-time</artifactId>
         </dependency>
         <dependency>
+            <groupId>com.revinate</groupId>
+            <artifactId>assertj-json</artifactId>
+        </dependency>
+        <dependency>
             <groupId>com.lordofthejars</groupId>
             <artifactId>nosqlunit-mongodb</artifactId>
         </dependency>

--- a/graylog2-server/src/main/java/org/graylog2/rest/models/PaginatedResponse.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/models/PaginatedResponse.java
@@ -17,7 +17,7 @@
 package org.graylog2.rest.models;
 
 import com.fasterxml.jackson.annotation.JsonAutoDetect;
-import com.fasterxml.jackson.annotation.JsonUnwrapped;
+import com.fasterxml.jackson.annotation.JsonValue;
 import com.google.common.collect.ImmutableMap;
 import org.graylog2.database.PaginatedList;
 
@@ -27,11 +27,18 @@ import java.util.Map;
 
 @JsonAutoDetect
 public class PaginatedResponse<T> {
-    @SuppressWarnings("unused")
-    @JsonUnwrapped
-    private final Map<String, Object> data;
+    private final String listKey;
+    private final PaginatedList<T> paginatedList;
+    private final String query;
 
     private PaginatedResponse(String listKey, PaginatedList<T> paginatedList, @Nullable String query) {
+        this.listKey = listKey;
+        this.paginatedList = paginatedList;
+        this.query = query;
+    }
+
+    @JsonValue
+    public Map<String, Object> jsonValue() {
         final ImmutableMap.Builder<String, Object> builder = ImmutableMap.<String, Object>builder()
                 .putAll(paginatedList.pagination().asMap())
                 .put(listKey, new ArrayList<>(paginatedList));
@@ -40,7 +47,7 @@ public class PaginatedResponse<T> {
             builder.put("query", query);
         }
 
-        this.data = builder.build();
+        return builder.build();
     }
 
     public static <T> PaginatedResponse<T> create(String listKey, PaginatedList<T> paginatedList) {

--- a/graylog2-server/src/test/java/org/graylog2/rest/models/PaginatedResponseTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/rest/models/PaginatedResponseTest.java
@@ -1,0 +1,57 @@
+package org.graylog2.rest.models;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.collect.ImmutableList;
+import com.jayway.jsonpath.DocumentContext;
+import com.jayway.jsonpath.JsonPath;
+import com.revinate.assertj.json.JsonPathAssert;
+import org.graylog2.database.PaginatedList;
+import org.graylog2.shared.bindings.providers.ObjectMapperProvider;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.Collections;
+
+public class PaginatedResponseTest {
+    private ObjectMapper objectMapper;
+
+    @Before
+    public void setUp() throws Exception {
+        this.objectMapper = new ObjectMapperProvider(getClass().getClassLoader(), Collections.emptySet()).get();
+    }
+
+    @Test
+    public void serialize() throws Exception {
+        final ImmutableList<String> values = ImmutableList.of("hello", "world");
+        final PaginatedList<String> paginatedList = new PaginatedList<>(values, values.size(), 1, 10);
+        final PaginatedResponse<String> response = PaginatedResponse.create("foo", paginatedList);
+
+        final DocumentContext ctx = JsonPath.parse(objectMapper.writeValueAsString(response));
+        final JsonPathAssert jsonPathAssert = JsonPathAssert.assertThat(ctx);
+
+        jsonPathAssert.jsonPathAsInteger("$.total").isEqualTo(2);
+        jsonPathAssert.jsonPathAsInteger("$.count").isEqualTo(2);
+        jsonPathAssert.jsonPathAsInteger("$.page").isEqualTo(1);
+        jsonPathAssert.jsonPathAsInteger("$.per_page").isEqualTo(10);
+        jsonPathAssert.jsonPathAsString("$.foo[0]").isEqualTo("hello");
+        jsonPathAssert.jsonPathAsString("$.foo[1]").isEqualTo("world");
+    }
+
+    @Test
+    public void serializeWithQuery() throws Exception {
+        final ImmutableList<String> values = ImmutableList.of("hello", "world");
+        final PaginatedList<String> paginatedList = new PaginatedList<>(values, values.size(), 1, 10);
+        final PaginatedResponse<String> response = PaginatedResponse.create("foo", paginatedList, "query1");
+
+        final DocumentContext ctx = JsonPath.parse(objectMapper.writeValueAsString(response));
+        final JsonPathAssert jsonPathAssert = JsonPathAssert.assertThat(ctx);
+
+        jsonPathAssert.jsonPathAsString("$.query").isEqualTo("query1");
+        jsonPathAssert.jsonPathAsInteger("$.total").isEqualTo(2);
+        jsonPathAssert.jsonPathAsInteger("$.count").isEqualTo(2);
+        jsonPathAssert.jsonPathAsInteger("$.page").isEqualTo(1);
+        jsonPathAssert.jsonPathAsInteger("$.per_page").isEqualTo(10);
+        jsonPathAssert.jsonPathAsString("$.foo[0]").isEqualTo("hello");
+        jsonPathAssert.jsonPathAsString("$.foo[1]").isEqualTo("world");
+    }
+}

--- a/graylog2-server/src/test/java/org/graylog2/rest/models/PaginatedResponseTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/rest/models/PaginatedResponseTest.java
@@ -1,3 +1,19 @@
+/**
+ * This file is part of Graylog.
+ *
+ * Graylog is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package org.graylog2.rest.models;
 
 import com.fasterxml.jackson.databind.ObjectMapper;

--- a/pom.xml
+++ b/pom.xml
@@ -152,6 +152,7 @@
         <apacheds-server.version>2.0.0-M24</apacheds-server.version>
         <assertj-core.version>3.9.1</assertj-core.version>
         <assertj-joda-time.version>2.0.0</assertj-joda-time.version>
+        <assertj-json.version>1.1.0</assertj-json.version>
         <awaitility.version>3.0.0</awaitility.version>
         <equalsverifier.version>2.4.3</equalsverifier.version>
         <fongo.version>2.1.0</fongo.version>


### PR DESCRIPTION
Don't put the pagination info inside a "data" object in the response.
For some reason JsonUnwrapped didn't work as expected.