### PR TITLE
Add HOC generator connecting ES6 class components to stores.

### DIFF
--- a/graylog2-web-interface/src/stores/connect.jsx
+++ b/graylog2-web-interface/src/stores/connect.jsx
@@ -1,0 +1,75 @@
+import React from 'react';
+import { ListenerMethods } from 'reflux';
+import { isFunction } from 'lodash';
+
+/**
+ * Generating a higher order component wrapping an ES6 React component class, connecting it to the supplied stores.
+ * The generated wrapper class passes the state it receives from the stores to the component it wraps as props.
+ *
+ * The `stores` parameter should consist of an object mapping desired props keys to stores. i.e.:
+ * {
+ *  samples: SamplesStore
+ * }
+ *
+ * will connect to the provided `SamplesStore` and pass the state it receives from it to the supplied component as a
+ * `samples` prop.
+ *
+ * @param {Object} Component - The component which should be connected to the stores.
+ * @param {Object} stores - A mapping of desired props keys to stores.
+ * @returns {Object} - A React component wrapping the passed component.
+ *
+ * @example
+ *
+ * // Connecting the `SamplesComponent` class to the `SamplesStore`, hooking up its state to the `samples` prop and
+ * // waiting for the store to settle down.
+ *
+ * connect(SamplesComponent, { samples: SamplesStore }, [SamplesActions.list])
+ *
+ */
+export default (Component, stores) => {
+  return class ConnectStoresWrapper extends React.Component {
+    constructor(props) {
+      super(props);
+
+      if (!this.state) {
+        this.state = {};
+      }
+
+      Object.keys(ListenerMethods).forEach((listenerMethod) => {
+        this[listenerMethod] = ListenerMethods[listenerMethod].bind(this);
+      });
+      this.componentWillUnmount = ListenerMethods.stopListeningToAll.bind(this);
+
+      // Retrieving initial state from each configured store
+      Object.keys(stores).forEach((key) => {
+        const store = stores[key];
+        if (isFunction(store.getInitialState)) {
+          this.state[key] = store.getInitialState();
+        }
+      });
+    }
+
+    componentDidMount() {
+      // Listening to each store.
+      Object.keys(stores).forEach((key) => {
+        const store = stores[key];
+        const cb = (v) => {
+          const newState = {};
+          newState[key] = v;
+          this.setState(newState);
+        };
+
+        this.listenTo(store, cb);
+      });
+    }
+
+    render() {
+      const storeProps = {};
+      Object.keys(stores).forEach((key) => {
+        storeProps[key] = this.state[key];
+      });
+
+      return <Component {...storeProps} {...this.props} />;
+    }
+  };
+};

--- a/graylog2-web-interface/src/stores/connect.test.jsx
+++ b/graylog2-web-interface/src/stores/connect.test.jsx
@@ -48,6 +48,7 @@ describe('connect()', () => {
   });
 
   it('connects component to store without state', () => {
+    SimpleStore.reset();
     const Component = connect(SimpleComponentWithDummyStore, { simpleStore: SimpleStore });
     const wrapper = mount(<Component />);
     expect(wrapper).toHaveText('No value.');
@@ -63,6 +64,7 @@ describe('connect()', () => {
   it('reflects state changes in store', () => {
     const Component = connect(SimpleComponentWithDummyStore, { simpleStore: SimpleStore });
     const wrapper = mount(<Component />);
+    SimpleStore.reset();
     expect(wrapper).toHaveText('No value.');
     SimpleStore.setValue(42);
     expect(wrapper).toHaveText('Value is: 42');

--- a/graylog2-web-interface/src/stores/connect.test.jsx
+++ b/graylog2-web-interface/src/stores/connect.test.jsx
@@ -1,0 +1,74 @@
+/* eslint-disable react/no-multi-comp */
+import React from 'react';
+import { mount } from 'enzyme';
+import Reflux from 'reflux';
+import PropTypes from 'prop-types';
+
+import connect from './connect';
+
+const SimpleComponentWithoutStores = () => <span>Hello World!</span>;
+
+const SimpleStore = Reflux.createStore({
+  getInitialState() {
+    return this.state;
+  },
+  setValue(value) {
+    this.state = { value: value };
+    this.trigger(this.state);
+  },
+  noop() {},
+  reset() {
+    this.state = undefined;
+    this.trigger(this.state);
+  },
+});
+
+class SimpleComponentWithDummyStore extends React.Component {
+  static propTypes = {
+    simpleStore: PropTypes.shape({ foo: PropTypes.number }),
+  };
+  static defaultProps = {
+    simpleStore: undefined,
+  };
+
+  render() {
+    const { simpleStore } = this.props;
+    if (simpleStore && simpleStore.value) {
+      return <span>Value is: {simpleStore.value}</span>;
+    }
+    return <span>No value.</span>;
+  }
+}
+
+describe('connect()', () => {
+  it('does not do anything if no stores are provided', () => {
+    const Component = connect(SimpleComponentWithoutStores, {});
+    const wrapper = mount(<Component />);
+    expect(wrapper).toHaveHTML('<span>Hello World!</span>');
+  });
+
+  it('connects component to store without state', () => {
+    const Component = connect(SimpleComponentWithDummyStore, { simpleStore: SimpleStore });
+    const wrapper = mount(<Component />);
+    expect(wrapper).toHaveText('No value.');
+  });
+
+  it('connects component to store with state', () => {
+    SimpleStore.setValue(42);
+    const Component = connect(SimpleComponentWithDummyStore, { simpleStore: SimpleStore });
+    const wrapper = mount(<Component />);
+    expect(wrapper).toHaveText('Value is: 42');
+  });
+
+  it('reflects state changes in store', () => {
+    const Component = connect(SimpleComponentWithDummyStore, { simpleStore: SimpleStore });
+    const wrapper = mount(<Component />);
+    expect(wrapper).toHaveText('No value.');
+    SimpleStore.setValue(42);
+    expect(wrapper).toHaveText('Value is: 42');
+    SimpleStore.noop();
+    expect(wrapper).toHaveText('Value is: 42');
+    SimpleStore.reset();
+    expect(wrapper).toHaveText('No value.');
+  });
+});


### PR DESCRIPTION
## Description
## Motivation and Context

This generator allows ES6 class components to be connected to stores,
although the current version of Reflux allows this only using a mixin,
which is not usable for ES6 classes.

The change provides a `connect()` function which takes the supplied
component class and wraps it in a generated component which connects
itself to the stores defined in the provided mapping. The state supplied
by the stores is then passed to the component as props.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
