### PR TITLE
Avoid DOM structure changes when there are no pages to show

### DIFF
--- a/graylog2-web-interface/src/components/common/PaginatedList.jsx
+++ b/graylog2-web-interface/src/components/common/PaginatedList.jsx
@@ -80,16 +80,14 @@ class PaginatedList extends React.Component {
 
   render() {
     const numberPages = Math.ceil(this.props.totalItems / this.state.pageSize);
-    const hasPages = numberPages > 0;
 
     return (
       <span>
-        {hasPages && this._pageSizeSelect()}
+        {this._pageSizeSelect()}
 
         {this.props.children}
 
-        {hasPages &&
-        <div className="text-center">
+        {<div className="text-center">
           <Pagination bsSize="small"
                       items={numberPages}
                       maxButtons={10}
@@ -99,8 +97,7 @@ class PaginatedList extends React.Component {
                       next
                       first
                       last />
-        </div>
-        }
+        </div>}
       </span>
     );
   }

--- a/graylog2-web-interface/src/components/common/PaginatedList.jsx
+++ b/graylog2-web-interface/src/components/common/PaginatedList.jsx
@@ -87,7 +87,7 @@ class PaginatedList extends React.Component {
 
         {this.props.children}
 
-        {<div className="text-center">
+        <div className="text-center">
           <Pagination bsSize="small"
                       items={numberPages}
                       maxButtons={10}
@@ -97,7 +97,7 @@ class PaginatedList extends React.Component {
                       next
                       first
                       last />
-        </div>}
+        </div>
       </span>
     );
   }

--- a/graylog2-web-interface/src/components/common/PaginatedList.jsx
+++ b/graylog2-web-interface/src/components/common/PaginatedList.jsx
@@ -80,16 +80,15 @@ class PaginatedList extends React.Component {
 
   render() {
     const numberPages = Math.ceil(this.props.totalItems / this.state.pageSize);
-    if (numberPages === 0) {
-      return <span>{this.props.children}</span>;
-    }
+    const hasPages = numberPages > 0;
 
     return (
       <span>
-        {this._pageSizeSelect()}
+        {hasPages && this._pageSizeSelect()}
 
         {this.props.children}
 
+        {hasPages &&
         <div className="text-center">
           <Pagination bsSize="small"
                       items={numberPages}
@@ -101,6 +100,7 @@ class PaginatedList extends React.Component {
                       first
                       last />
         </div>
+        }
       </span>
     );
   }


### PR DESCRIPTION
This fixes a long standing issue with the SearchForm component where the query string disappears when a search doesn't return any results.

The problem was that we had a shortcut in the render function that returned only the children and no page selectors when there are no items to show. This apparently changed the DOM structure in a way that the children of the PaginatedList component have been replaced with new instances.
In the case of a SearchForm component as a PaginatedList child, this reset the query string.