### PR TITLE
Popover improvements

### DIFF
--- a/graylog2-web-interface/src/components/common/ColorPickerPopover.jsx
+++ b/graylog2-web-interface/src/components/common/ColorPickerPopover.jsx
@@ -27,6 +27,13 @@ const ColorPickerPopover = createReactClass({
     triggerNode: PropTypes.node.isRequired,
     /** Event that will show/hide the popover. */
     triggerAction: PropTypes.oneOf(['click', 'hover', 'focus']),
+    /**
+     * Function that will be called when the selected color changes.
+     * The function receives the color in hexadecimal format as first argument,
+     * the event as the second argument, and a callback function to hide the
+     * overlay as third argument.
+     */
+    onChange: PropTypes.func.isRequired,
   },
 
   getDefaultProps() {
@@ -37,16 +44,24 @@ const ColorPickerPopover = createReactClass({
     };
   },
 
+  handleChange(color, event) {
+    this.props.onChange(color, event, () => this.overlay.hide());
+  },
+
   render() {
     const { id, placement, title, triggerNode, triggerAction, ...colorPickerProps } = this.props;
     const popover = (
       <Popover id={id} title={title} className={style.customPopover}>
-        <ColorPicker {...colorPickerProps} />
+        <ColorPicker {...colorPickerProps} onChange={this.handleChange} />
       </Popover>
     );
 
     return (
-      <OverlayTrigger trigger={triggerAction} placement={placement} overlay={popover} rootClose>
+      <OverlayTrigger ref={(c) => { this.overlay = c; }}
+                      trigger={triggerAction}
+                      placement={placement}
+                      overlay={popover}
+                      rootClose>
         {triggerNode}
       </OverlayTrigger>
     );

--- a/graylog2-web-interface/src/components/common/ColorPickerPopover.md
+++ b/graylog2-web-interface/src/components/common/ColorPickerPopover.md
@@ -9,7 +9,8 @@ const ColorPickerOverlayExample = createReactClass({
     };
   },
 
-  handleColorChange(color) {
+  handleColorChange(color, _, hidePopover) {
+    hidePopover();
     this.setState({ color: color });
   },
 

--- a/graylog2-web-interface/src/components/common/SelectPopover.jsx
+++ b/graylog2-web-interface/src/components/common/SelectPopover.jsx
@@ -46,6 +46,8 @@ const SelectPopover = createReactClass({
     displayDataFilter: PropTypes.bool,
     /** Placeholder to display in the filter text input. */
     filterPlaceholder: PropTypes.string,
+    /** Text to display in the entry to clear the current selection. */
+    clearSelectionText: PropTypes.string,
   },
 
   getDefaultProps() {
@@ -58,6 +60,7 @@ const SelectPopover = createReactClass({
       onItemSelect: () => {},
       displayDataFilter: true,
       filterPlaceholder: 'Type to filter',
+      clearSelectionText: 'Clear selection',
     };
   },
 
@@ -112,7 +115,9 @@ const SelectPopover = createReactClass({
 
   renderClearSelectionItem() {
     return (
-      <ListGroupItem onClick={this.handleItemSelection()}><i className="fa fa-fw fa-times text-danger" /> Clear selection</ListGroupItem>
+      <ListGroupItem onClick={this.handleItemSelection()}>
+        <i className="fa fa-fw fa-times text-danger" /> {this.props.clearSelectionText}
+      </ListGroupItem>
     );
   },
 

--- a/graylog2-web-interface/src/components/common/SelectPopover.jsx
+++ b/graylog2-web-interface/src/components/common/SelectPopover.jsx
@@ -38,8 +38,8 @@ const SelectPopover = createReactClass({
     selectedItem: PropTypes.string,
     /**
      * Function that will be called when the item selection changes.
-     * The function will receive the selected item as argument or `undefined` if the selection
-     * is cleared.
+     * The function will receive the selected item as first argument or `undefined` if the selection
+     * is cleared, and a callback function to hide the popover as a second argument.
      */
     onItemSelect: PropTypes.func.isRequired,
     /** Indicates whether the component should display a text filter or not. */
@@ -81,7 +81,7 @@ const SelectPopover = createReactClass({
   handleItemSelection(item) {
     return () => {
       this.setState({ selectedItem: item });
-      this.props.onItemSelect(item);
+      this.props.onItemSelect(item, () => this.overlay.hide());
     };
   },
 
@@ -142,7 +142,11 @@ const SelectPopover = createReactClass({
     );
 
     return (
-      <OverlayTrigger trigger={triggerAction} placement={placement} overlay={popover} rootClose>
+      <OverlayTrigger ref={(c) => { this.overlay = c; }}
+                      trigger={triggerAction}
+                      placement={placement}
+                      overlay={popover}
+                      rootClose>
         {triggerNode}
       </OverlayTrigger>
     );

--- a/graylog2-web-interface/src/components/common/SelectPopover.md
+++ b/graylog2-web-interface/src/components/common/SelectPopover.md
@@ -34,7 +34,8 @@ const SelectPopoverExample = createReactClass({
                          items={items}
                          selectedItem={selectedItem}
                          onItemSelect={this.handleItemSelect}
-                         displayDataFilter={false} />
+                         displayDataFilter={false}
+                         clearSelectionText="Clear color selection"/>
         </div>
         
         {selectedItem ? `You have selected ${selectedItem}` : 'Please select a color!'}

--- a/graylog2-web-interface/src/components/common/SelectPopover.md
+++ b/graylog2-web-interface/src/components/common/SelectPopover.md
@@ -77,7 +77,8 @@ const SelectPopoverFormattedExample = createReactClass({
     };
   },
   
-  handleItemSelect(item) {
+  handleItemSelect(item, hidePopover) {
+    hidePopover();
     this.setState({ selectedItem: item });
   },
   

--- a/graylog2-web-interface/src/components/common/SelectPopover.md
+++ b/graylog2-web-interface/src/components/common/SelectPopover.md
@@ -14,16 +14,16 @@ const items = [
 const SelectPopoverExample = createReactClass({
   getInitialState() {
     return {
-      selectedItem: undefined,
+      selectedColor: undefined,
     };
   },
   
   handleItemSelect(item) {
-    this.setState({ selectedItem: item });
+    this.setState({ selectedColor: item[0] });
   },
   
   render() {
-    const selectedItem = this.state.selectedItem;
+    const selectedColor = this.state.selectedColor;
 
     return (
       <div>
@@ -32,13 +32,13 @@ const SelectPopoverExample = createReactClass({
                          title="Filter by color"
                          triggerNode={<Button bsStyle="info" bsSize="small">Select color</Button>}
                          items={items}
-                         selectedItem={selectedItem}
+                         selectedItems={selectedColor ? [selectedColor] : []}
                          onItemSelect={this.handleItemSelect}
                          displayDataFilter={false}
                          clearSelectionText="Clear color selection"/>
         </div>
         
-        {selectedItem ? `You have selected ${selectedItem}` : 'Please select a color!'}
+        {selectedColor ? `You have selected ${selectedColor}` : 'Please select a color!'}
       </div>
     );
   }
@@ -74,13 +74,12 @@ const items = [
 const SelectPopoverFormattedExample = createReactClass({
   getInitialState() {
     return {
-      selectedItem: undefined,
+      selectedColors: [],
     };
   },
   
-  handleItemSelect(item, hidePopover) {
-    hidePopover();
-    this.setState({ selectedItem: item });
+  handleItemSelect(item) {
+    this.setState({ selectedColors: item });
   },
   
   formatItem(item) {
@@ -92,7 +91,7 @@ const SelectPopoverFormattedExample = createReactClass({
   },
   
   render() {
-    const selectedItem = this.state.selectedItem;
+    const selectedColors = this.state.selectedColors;
 
     return (
       <div>
@@ -102,12 +101,13 @@ const SelectPopoverFormattedExample = createReactClass({
                          triggerNode={<Button bsStyle="info" bsSize="small">Select color</Button>}
                          items={items}
                          itemFormatter={this.formatItem}
-                         selectedItem={selectedItem}
                          onItemSelect={this.handleItemSelect}
-                         filterPlaceholder="Filter by color" />
+                         filterPlaceholder="Filter by color"
+                         multiple={true}
+                         selectedItems={selectedColors} />
         </div>
         
-        {selectedItem ? `You have selected ${selectedItem}` : 'Please select another color!'}
+        {selectedColors.length > 0 ? `You have selected ${selectedColors.join(', ')}` : 'Please select some colors!'}
       </div>
     );
   }


### PR DESCRIPTION
This PR adds a couple of improvements to popovers, namely:

- `SelectPopover`:
  - Let consumers control if the popover should disappear after an item has been selected
  - Let consumers customize clear selection text via a prop
  - Add support for multiple selected entries

- `ColorPickerPopover`:
  - Let consumers control if the popover should disappear after an item has been selected