### PR TITLE
Move expanded list from enterprise to server

### DIFF
--- a/graylog2-web-interface/src/components/common/ExpandableList.css
+++ b/graylog2-web-interface/src/components/common/ExpandableList.css
@@ -1,0 +1,8 @@
+:local(.list) {
+    padding-left: 0;
+    margin-bottom: 20px;
+}
+
+:local(.list) :local(.list) {
+    margin-bottom: 0;
+}

--- a/graylog2-web-interface/src/components/common/ExpandableList.jsx
+++ b/graylog2-web-interface/src/components/common/ExpandableList.jsx
@@ -1,0 +1,34 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+import style from './ExpandableList.css';
+
+/**
+ * The ExpandableList will take a array or one of ExpandeableListItem to render
+ * in list. This list can be expanded or flattened to give the user a overview
+ * of categories. Inside the categories the user has the possibility of doing a selection.
+ * The ExpandableList can be used nested.
+ */
+class ExpandableList extends React.Component {
+  static propTypes = {
+    /**
+     * One or more elements of ExpandableListItem
+     */
+    children: PropTypes.oneOfType([
+      PropTypes.element,
+      PropTypes.arrayOf(PropTypes.element),
+    ]),
+  };
+
+  render() {
+    const { children } = this.props;
+
+    return (
+      <ul className={style.list}>
+        {children}
+      </ul>
+    );
+  }
+}
+
+export default ExpandableList;

--- a/graylog2-web-interface/src/components/common/ExpandableList.jsx
+++ b/graylog2-web-interface/src/components/common/ExpandableList.jsx
@@ -2,7 +2,6 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 import style from './ExpandableList.css';
-
 /**
  * The ExpandableList will take a array or one of ExpandeableListItem to render
  * in list. This list can be expanded or flattened to give the user a overview
@@ -18,6 +17,10 @@ class ExpandableList extends React.Component {
       PropTypes.element,
       PropTypes.arrayOf(PropTypes.element),
     ]),
+  };
+
+  static defaultProps = {
+    children: [],
   };
 
   render() {

--- a/graylog2-web-interface/src/components/common/ExpandableList.md
+++ b/graylog2-web-interface/src/components/common/ExpandableList.md
@@ -1,0 +1,35 @@
+```js
+const createReactClass = require('create-react-class');
+
+const ExpandableListExample = createReactClass({
+
+  render() {
+    return (
+      <ExpandableList>
+        <ExpandableListItem selectable expanded header="Wheel of Time Character">
+          <ExpandableList>
+            <ExpandableListItem selectable header="Andor">
+              <ExpandableList>
+                <ExpandableListItem selectable expandable={false} header="Elayne" />
+                <ExpandableListItem selectable expandable={false} header="Morgase" />
+              </ExpandableList>
+            </ExpandableListItem>
+            <ExpandableListItem selectable header="Edmonds Field">
+              <ExpandableList>
+                <ExpandableListItem selectable expandable={false} header="Rand" />
+                <ExpandableListItem selectable expandable={false} header="Perrin" />
+                <ExpandableListItem selectable expandable={false} header="Egwene" />
+                <ExpandableListItem checked expandable={false} header="Mat" />
+                <ExpandableListItem expandable={false} selectable header="Nynaeve" />
+              </ExpandableList>
+            </ExpandableListItem>
+          </ExpandableList>
+        </ExpandableListItem>
+      </ExpandableList>
+    );
+  },
+});
+
+<ExpandableListExample />
+
+```

--- a/graylog2-web-interface/src/components/common/ExpandableList.test.jsx
+++ b/graylog2-web-interface/src/components/common/ExpandableList.test.jsx
@@ -1,0 +1,61 @@
+import React from 'react';
+import renderer from 'react-test-renderer';
+import { mount } from 'enzyme';
+import 'helpers/mocking/react-dom_mock';
+
+import ExpandableList from 'components/common/ExpandableList';
+import ExpandableListItem from 'components/common/ExpandableListItem';
+
+describe('<ExpandableList />', () => {
+  it('should render with no children', () => {
+    const wrapper = renderer.create(<ExpandableList />);
+    expect(wrapper.toJSON()).toMatchSnapshot();
+  });
+
+  it('should render with a Item', () => {
+    const wrapper = renderer.create(<ExpandableList>
+      <ExpandableListItem header="Wheel of time">
+        <span>Edmonds Field</span>
+      </ExpandableListItem>
+    </ExpandableList>);
+    expect(wrapper.toJSON()).toMatchSnapshot();
+  });
+
+  it('should render with a nested ExpandableList', () => {
+    const wrapper = renderer.create(<ExpandableList>
+      <ExpandableListItem expandable expanded header="Wheel of time">
+        <ExpandableList>
+          <ExpandableListItem expandable expanded={false} header="Edmonds Field" />
+        </ExpandableList>
+      </ExpandableListItem>
+    </ExpandableList>);
+    expect(wrapper.toJSON()).toMatchSnapshot();
+  });
+
+
+  it('should expand a expandable list item', () => {
+    const wrapper = mount(<ExpandableList>
+      <ExpandableListItem expandable header="Wheel of time">
+        <ExpandableList>
+          <ExpandableListItem header="Edmonds Field" />
+        </ExpandableList>
+      </ExpandableListItem>
+    </ExpandableList>);
+    expect(wrapper.find('span.header').length).toBe(1);
+    wrapper.find('div.fa-stack').simulate('click');
+    expect(wrapper.find('span.header').length).toBe(2);
+  });
+
+  it('should select a selectable list item', () => {
+    const checkFn = jest.fn();
+    const wrapper = mount(<ExpandableList>
+      <ExpandableListItem expanded header="Wheel of time">
+        <ExpandableList>
+          <ExpandableListItem expanded selectable header="Edmonds Field" onChange={checkFn} />
+        </ExpandableList>
+      </ExpandableListItem>
+    </ExpandableList>);
+    wrapper.find('input[type="checkbox"]').at(1).simulate('change', { target: { checked: true } });
+    expect(checkFn.mock.calls.length).toBe(1);
+  });
+});

--- a/graylog2-web-interface/src/components/common/ExpandableListItem.css
+++ b/graylog2-web-interface/src/components/common/ExpandableListItem.css
@@ -1,0 +1,57 @@
+:local(.listItem) {
+    padding: 10px 5px;
+}
+
+:local(.listItemContainer) {
+    font-size: 14px;
+    line-height: 20px;
+}
+
+:local(.listItemContainer) label {
+    min-height: 20px;
+    margin-bottom: 2px;
+    margin-right: 5px;
+}
+
+:local(.listItemContainer) label * {
+    cursor: pointer;
+}
+
+:local(.expandBoxContainer) {
+    display: inline-block;
+    width: 20px;
+    margin-right: 5px;
+}
+
+:local(.expandBox).fa-stack {
+    cursor: pointer;
+    font-size: 1.4em;
+    line-height: 20px;
+    width: 1em;
+    height: 1em;
+    vertical-align: text-top;
+}
+
+:local(.expandBox):hover * {
+    color: #731748;
+}
+
+:local(.iconBackground)  {
+    color: #FFF;
+}
+
+:local(.header) {
+    font-size: 14px;
+}
+
+:local(.subheader) {
+    font-size: 0.95em;
+    color: #aaaaaa;
+}
+
+:local(.expandableContent) {
+    border-left: 1px #eee solid;
+    margin-left: 35px;
+    margin-top: 10px;
+    padding-left: 5px;
+}

--- a/graylog2-web-interface/src/components/common/ExpandableListItem.jsx
+++ b/graylog2-web-interface/src/components/common/ExpandableListItem.jsx
@@ -11,8 +11,13 @@ class ExpandableListItem extends React.Component {
   static propTypes = {
     /** Is the Item checked */
     checked: PropTypes.bool,
-    /** TODO: i do not know what this means */
-    undetermined: PropTypes.bool,
+    /**
+     * Indicates whether the checkbox on this item should be in an indetermined state or not.
+     * This is mostly helpful to represent cases where the element is only partially checked,
+     * for instance when ExpandableListItem's child is an ExpandableList and some of its items
+     * are checked, but others are not.
+     */
+    indetermined: PropTypes.bool,
     /** Is the item selectable */
     selectable: PropTypes.bool,
     /** Is the Item expandable */
@@ -32,7 +37,7 @@ class ExpandableListItem extends React.Component {
 
   static defaultProps = {
     checked: false,
-    undetermined: false,
+    indetermined: false,
     expandable: true,
     expanded: false,
     selectable: true,
@@ -46,8 +51,8 @@ class ExpandableListItem extends React.Component {
   };
 
   componentDidMount() {
-    if (this.props.undetermined && this._checkbox) {
-      this._checkbox.indeterminate = this.props.undetermined;
+    if (this.props.indetermined && this._checkbox) {
+      this._checkbox.indeterminate = this.props.indetermined;
     }
   }
 
@@ -57,7 +62,7 @@ class ExpandableListItem extends React.Component {
     }
 
     if (this._checkbox) {
-      this._checkbox.indeterminate = this.props.undetermined;
+      this._checkbox.indeterminate = this.props.indetermined;
     }
   }
 
@@ -68,7 +73,7 @@ class ExpandableListItem extends React.Component {
   };
 
   _filterInputProps = (props) => {
-    const { expanded, undetermined, ...inputProps } = props;
+    const { expanded, indetermined, ...inputProps } = props;
     return inputProps;
   };
 

--- a/graylog2-web-interface/src/components/common/ExpandableListItem.jsx
+++ b/graylog2-web-interface/src/components/common/ExpandableListItem.jsx
@@ -1,0 +1,101 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { Checkbox } from 'react-bootstrap';
+
+import style from './ExpandableListItem.css';
+
+/**
+ * The ExpandableListItem is needed to render a ExpandableList.
+ */
+class ExpandableListItem extends React.Component {
+  static propTypes = {
+    /** Is the Item checked */
+    checked: PropTypes.bool,
+    /** TODO: i do not know what this means */
+    undetermined: PropTypes.bool,
+    /** Is the item selectable */
+    selectable: PropTypes.bool,
+    /** Is the Item expandable */
+    expandable: PropTypes.bool,
+    /** Is the Item expanded */
+    expanded: PropTypes.bool,
+    /** The header of the item */
+    header: PropTypes.oneOfType([PropTypes.string, PropTypes.element]).isRequired,
+    /** The possible subheader of the item */
+    subheader: PropTypes.oneOfType([PropTypes.string, PropTypes.element]),
+    /** Can be a html tag or again a ExpandableList */
+    children: PropTypes.oneOfType([
+      PropTypes.element,
+      PropTypes.arrayOf(PropTypes.element),
+    ]),
+  };
+
+  static defaultProps = {
+    checked: false,
+    undetermined: false,
+    expandable: true,
+    expanded: false,
+    selectable: true,
+  };
+
+  state = {
+    expanded: this.props.expanded,
+    selectable: false,
+    subheader: '',
+  };
+
+  componentDidMount() {
+    if (this.props.undetermined && this._checkbox) {
+      this._checkbox.indeterminate = this.props.undetermined;
+    }
+  }
+
+  componentDidUpdate(prevProps) {
+    if (prevProps.expanded !== this.props.expanded) {
+      this._toggleExpand();
+    }
+
+    if (this._checkbox) {
+      this._checkbox.indeterminate = this.props.undetermined;
+    }
+  }
+
+  _checkbox = undefined;
+
+  _toggleExpand = () => {
+    this.setState({ expanded: !this.state.expanded });
+  };
+
+  _filterInputProps = (props) => {
+    const { expanded, undetermined, ...inputProps } = props;
+    return inputProps;
+  };
+
+  render() {
+    const { expanded } = this.state;
+    const { checked, expandable, selectable, header, subheader, children, ...otherProps } = this.props;
+    const inputProps = this._filterInputProps(otherProps);
+
+    return (
+      <li className={style.listItem}>
+        <div className={style.listItemContainer}>
+          {selectable && <Checkbox inputRef={(c) => { this._checkbox = c; }} inline checked={checked} {...inputProps} />}
+          {expandable &&
+          <div className={style.expandBoxContainer}>
+            <div className={`fa-stack ${style.expandBox}`} role="button" tabIndex={0} onClick={this._toggleExpand}>
+              <i className={`fa fa-circle-thin fa-stack-1x ${style.iconBackground}`} />
+              <i className={`fa fa-stack-1x fa-angle-${expanded ? 'down' : 'up'}`} />
+            </div>
+          </div>
+          }
+          <span className={style.header}>{header} <span className={style.subheader}>{subheader}</span></span>
+        </div>
+        <div className={style.expandableContent}>
+          {expanded && children}
+        </div>
+      </li>
+    );
+  }
+}
+
+export default ExpandableListItem;

--- a/graylog2-web-interface/src/components/common/ExpandableListItem.jsx
+++ b/graylog2-web-interface/src/components/common/ExpandableListItem.jsx
@@ -42,6 +42,7 @@ class ExpandableListItem extends React.Component {
     expanded: false,
     selectable: true,
     children: [],
+    subheader: undefined,
   };
 
   state = {

--- a/graylog2-web-interface/src/components/common/ExpandableListItem.jsx
+++ b/graylog2-web-interface/src/components/common/ExpandableListItem.jsx
@@ -36,6 +36,7 @@ class ExpandableListItem extends React.Component {
     expandable: true,
     expanded: false,
     selectable: true,
+    children: [],
   };
 
   state = {
@@ -88,7 +89,7 @@ class ExpandableListItem extends React.Component {
             </div>
           </div>
           }
-          <span className={style.header}>{header} <span className={style.subheader}>{subheader}</span></span>
+          <span className={style.header}>{header}{subheader && <span className={style.subheader}>{subheader}</span>}</span>
         </div>
         <div className={style.expandableContent}>
           {expanded && children}

--- a/graylog2-web-interface/src/components/common/__snapshots__/ExpandableList.test.jsx.snap
+++ b/graylog2-web-interface/src/components/common/__snapshots__/ExpandableList.test.jsx.snap
@@ -1,0 +1,158 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`<ExpandableList /> should render with a Item 1`] = `
+<ul
+  className="list"
+>
+  <li
+    className="listItem"
+  >
+    <div
+      className="listItemContainer"
+    >
+      <label
+        className="checkbox-inline"
+        style={undefined}
+        title=""
+      >
+        <input
+          checked={false}
+          disabled={false}
+          type="checkbox"
+        />
+      </label>
+      <div
+        className="expandBoxContainer"
+      >
+        <div
+          className="fa-stack expandBox"
+          onClick={[Function]}
+          role="button"
+          tabIndex={0}
+        >
+          <i
+            className="fa fa-circle-thin fa-stack-1x iconBackground"
+          />
+          <i
+            className="fa fa-stack-1x fa-angle-up"
+          />
+        </div>
+      </div>
+      <span
+        className="header"
+      >
+        Wheel of time
+      </span>
+    </div>
+    <div
+      className="expandableContent"
+    />
+  </li>
+</ul>
+`;
+
+exports[`<ExpandableList /> should render with a nested ExpandableList 1`] = `
+<ul
+  className="list"
+>
+  <li
+    className="listItem"
+  >
+    <div
+      className="listItemContainer"
+    >
+      <label
+        className="checkbox-inline"
+        style={undefined}
+        title=""
+      >
+        <input
+          checked={false}
+          disabled={false}
+          type="checkbox"
+        />
+      </label>
+      <div
+        className="expandBoxContainer"
+      >
+        <div
+          className="fa-stack expandBox"
+          onClick={[Function]}
+          role="button"
+          tabIndex={0}
+        >
+          <i
+            className="fa fa-circle-thin fa-stack-1x iconBackground"
+          />
+          <i
+            className="fa fa-stack-1x fa-angle-down"
+          />
+        </div>
+      </div>
+      <span
+        className="header"
+      >
+        Wheel of time
+      </span>
+    </div>
+    <div
+      className="expandableContent"
+    >
+      <ul
+        className="list"
+      >
+        <li
+          className="listItem"
+        >
+          <div
+            className="listItemContainer"
+          >
+            <label
+              className="checkbox-inline"
+              style={undefined}
+              title=""
+            >
+              <input
+                checked={false}
+                disabled={false}
+                type="checkbox"
+              />
+            </label>
+            <div
+              className="expandBoxContainer"
+            >
+              <div
+                className="fa-stack expandBox"
+                onClick={[Function]}
+                role="button"
+                tabIndex={0}
+              >
+                <i
+                  className="fa fa-circle-thin fa-stack-1x iconBackground"
+                />
+                <i
+                  className="fa fa-stack-1x fa-angle-up"
+                />
+              </div>
+            </div>
+            <span
+              className="header"
+            >
+              Edmonds Field
+            </span>
+          </div>
+          <div
+            className="expandableContent"
+          />
+        </li>
+      </ul>
+    </div>
+  </li>
+</ul>
+`;
+
+exports[`<ExpandableList /> should render with no children 1`] = `
+<ul
+  className="list"
+/>
+`;

--- a/graylog2-web-interface/src/components/common/index.jsx
+++ b/graylog2-web-interface/src/components/common/index.jsx
@@ -8,6 +8,8 @@ export { default as DatePicker } from './DatePicker';
 export { default as DocumentTitle } from './DocumentTitle';
 export { default as EntityList } from './EntityList';
 export { default as EntityListItem } from './EntityListItem';
+export { default as ExpandableList } from './ExpandableList';
+export { default as ExpandableListItem } from './ExpandableListItem';
 export { default as ExternalLink } from './ExternalLink';
 export { default as ExternalLinkButton } from './ExternalLinkButton';
 export { default as IfPermitted } from './IfPermitted';


### PR DESCRIPTION
## Description
This change adds **ExpandableList** and **ExpandableListItem** from the enterprise plugin.
It also supplies documentation and tests for the components.

## Motivation and Context
These components are needed for content selection in Content Pack.

## How Has This Been Tested?
I add new tests, and ensured that the reports content selection still worked.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
