### PR TITLE
Change select behaviour in SelectPopover

### DIFF
--- a/graylog2-web-interface/src/components/common/SelectPopover.jsx
+++ b/graylog2-web-interface/src/components/common/SelectPopover.jsx
@@ -100,10 +100,11 @@ const SelectPopover = createReactClass({
     return () => {
       const selectedItems = this.state.selectedItems;
       let nextSelectedItems;
-      if (selectedItems.includes(item)) {
-        nextSelectedItems = lodash.without(selectedItems, item);
+      if (this.props.multiple) {
+        // Clicking on a selected value on a multiselect input will toggle the item's select status
+        nextSelectedItems = selectedItems.includes(item) ? lodash.without(selectedItems, item) : lodash.concat(selectedItems, item);
       } else {
-        nextSelectedItems = this.props.multiple ? lodash.concat(selectedItems, item) : [item];
+        nextSelectedItems = [item];
       }
       this.handleSelectionChange(nextSelectedItems);
     };


### PR DESCRIPTION
When `SelectPopover` is used as a single-option select, clicking on a selected option will deselect it (aka toggle it's select status). That behaviour is not consistent with other selects we use, and also doesn't provide much value (since we already have an option to clear the selection).

This PR changes that behaviour by treating a click on a selected option in the same way as a click in a not-selected option.

On multiselects, it is still possible to deselect a single selected option by clicking on it.
