### PR TITLE
More detailed error message for missing Grok patterns

### DIFF
--- a/graylog2-server/src/main/java/org/graylog/plugins/pipelineprocessor/functions/strings/GrokMatch.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/pipelineprocessor/functions/strings/GrokMatch.java
@@ -17,8 +17,8 @@
 package org.graylog.plugins.pipelineprocessor.functions.strings;
 
 import com.google.common.collect.ForwardingMap;
-import oi.thekraken.grok.api.Grok;
-import oi.thekraken.grok.api.Match;
+import io.thekraken.grok.api.Grok;
+import io.thekraken.grok.api.Match;
 import org.graylog.plugins.pipelineprocessor.EvaluationContext;
 import org.graylog.plugins.pipelineprocessor.ast.functions.AbstractFunction;
 import org.graylog.plugins.pipelineprocessor.ast.functions.FunctionArgs;
@@ -62,9 +62,8 @@ public class GrokMatch extends AbstractFunction<GrokMatch.GrokResult> {
 
         final Grok grok = grokPatternRegistry.cachedGrokForPattern(pattern, onlyNamedCaptures);
 
-        final Match match = grok.match(value);
-        match.captures();
-        return new GrokResult(match.toMap());
+        final Match match = grok.match(value);;
+        return new GrokResult(match.capture());
     }
 
     @Override

--- a/graylog2-server/src/main/java/org/graylog2/grok/InMemoryGrokPatternService.java
+++ b/graylog2-server/src/main/java/org/graylog2/grok/InMemoryGrokPatternService.java
@@ -19,8 +19,8 @@ package org.graylog2.grok;
 import com.google.common.base.Strings;
 import com.google.common.collect.MapMaker;
 import com.google.common.collect.Sets;
-import oi.thekraken.grok.api.Grok;
-import oi.thekraken.grok.api.exception.GrokException;
+import io.thekraken.grok.api.GrokCompiler;
+import io.thekraken.grok.api.exception.GrokException;
 import org.graylog2.database.NotFoundException;
 import org.graylog2.plugin.database.ValidationException;
 import org.slf4j.Logger;
@@ -106,8 +106,8 @@ public class InMemoryGrokPatternService implements GrokPatternService {
     public boolean validate(GrokPattern pattern) {
         final boolean fieldsMissing = !(Strings.isNullOrEmpty(pattern.name()) || Strings.isNullOrEmpty(pattern.pattern()));
         try {
-            final Grok grok = new Grok();
-            grok.addPattern(pattern.name(), pattern.pattern());
+            final GrokCompiler grok = GrokCompiler.newInstance();
+            grok.register(pattern.name(), pattern.pattern());
             grok.compile("%{" + pattern.name() + "}");
         } catch (GrokException ignored) {
             // this only checks for null or empty again.

--- a/graylog2-server/src/main/java/org/graylog2/grok/MongoDbGrokPatternService.java
+++ b/graylog2-server/src/main/java/org/graylog2/grok/MongoDbGrokPatternService.java
@@ -20,8 +20,8 @@ import com.google.common.base.Strings;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Sets;
-import oi.thekraken.grok.api.Grok;
-import oi.thekraken.grok.api.exception.GrokException;
+import io.thekraken.grok.api.GrokCompiler;
+import io.thekraken.grok.api.exception.GrokException;
 import org.bson.types.ObjectId;
 import org.graylog2.bindings.providers.MongoJackObjectMapperProvider;
 import org.graylog2.database.MongoConnection;
@@ -101,8 +101,8 @@ public class MongoDbGrokPatternService implements GrokPatternService {
     public boolean validate(GrokPattern pattern) {
         final boolean fieldsMissing = !(Strings.isNullOrEmpty(pattern.name()) || Strings.isNullOrEmpty(pattern.pattern()));
         try {
-            final Grok grok = new Grok();
-            grok.addPattern(pattern.name(), pattern.pattern());
+            final GrokCompiler grok = GrokCompiler.newInstance();
+            grok.register(pattern.name(), pattern.pattern());
             grok.compile("%{" + pattern.name() + "}");
         } catch (GrokException ignored) {
             // this only checks for null or empty again.

--- a/graylog2-server/src/main/java/org/graylog2/plugin/Message.java
+++ b/graylog2-server/src/main/java/org/graylog2/plugin/Message.java
@@ -41,6 +41,7 @@ import java.time.Instant;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.OffsetDateTime;
+import java.time.ZoneId;
 import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
 import java.time.temporal.Temporal;
@@ -382,12 +383,22 @@ public class Message implements Messages {
             } else if (value instanceof OffsetDateTime) {
                 date = Date.from(((OffsetDateTime) value).toInstant());
             } else if (value instanceof LocalDateTime) {
-                date = Date.from(((LocalDateTime) value).toInstant(ZoneOffset.UTC));
+                final LocalDateTime localDateTime = (LocalDateTime) value;
+                final ZoneId defaultZoneId = ZoneId.systemDefault();
+                final ZoneOffset offset = defaultZoneId.getRules().getOffset(localDateTime);
+                date = Date.from(localDateTime.toInstant(offset));
             } else if (value instanceof LocalDate) {
-                date = Date.from(((LocalDate) value).atStartOfDay(ZoneOffset.UTC).toInstant());
+                final LocalDate localDate = (LocalDate) value;
+                final LocalDateTime localDateTime = localDate.atStartOfDay();
+                final ZoneId defaultZoneId = ZoneId.systemDefault();
+                final ZoneOffset offset = defaultZoneId.getRules().getOffset(localDateTime);
+                date = Date.from(localDateTime.toInstant(offset));
             } else if (value instanceof Instant) {
                 date = Date.from((Instant) value);
             } else {
+                if (LOG.isDebugEnabled()) {
+                    LOG.debug("Unsupported temporal type {}. Using current date and time in message {}.", value.getClass(), getId());
+                }
                 date = new Date();
             }
 

--- a/graylog2-server/src/main/java/org/graylog2/rest/resources/tools/GrokTesterResource.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/resources/tools/GrokTesterResource.java
@@ -84,13 +84,19 @@ public class GrokTesterResource extends RestResource {
             grokCompiler.register(grokPattern.name(), grokPattern.pattern());
         }
 
-        final Grok grok = grokCompiler.compile(pattern, namedCapturesOnly);
+        final Grok grok;
+        try {
+            grok = grokCompiler.compile(pattern, namedCapturesOnly);
+        } catch (Exception e) {
+            return GrokTesterResponse.createError(pattern, string, e.getMessage());
+        }
+
         final Match match = grok.match(string);
         final Map<String, Object> matches = match.capture();
 
         final GrokTesterResponse response;
         if (matches.isEmpty()) {
-            response = GrokTesterResponse.create(false, Collections.<GrokTesterResponse.Match>emptyList(), pattern, string);
+            response = GrokTesterResponse.createSuccess(false, Collections.<GrokTesterResponse.Match>emptyList(), pattern, string);
         } else {
             final List<GrokTesterResponse.Match> responseMatches = Lists.newArrayList();
             for (final Map.Entry<String, Object> entry : matches.entrySet()) {
@@ -100,7 +106,7 @@ public class GrokTesterResource extends RestResource {
                 }
             }
 
-            response = GrokTesterResponse.create(true, responseMatches, pattern, string);
+            response = GrokTesterResponse.createSuccess(true, responseMatches, pattern, string);
         }
         return response;
     }

--- a/graylog2-server/src/main/java/org/graylog2/rest/resources/tools/responses/GrokTesterResponse.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/resources/tools/responses/GrokTesterResponse.java
@@ -24,6 +24,7 @@ import com.google.auto.value.AutoValue;
 import org.graylog.autovalue.WithBeanGetter;
 
 import javax.annotation.Nullable;
+import java.util.Collections;
 import java.util.List;
 
 @JsonAutoDetect
@@ -31,25 +32,43 @@ import java.util.List;
 @WithBeanGetter
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public abstract class GrokTesterResponse {
-    @JsonProperty
+    @JsonProperty("matched")
     public abstract boolean matched();
 
-    @JsonProperty
+    @JsonProperty("matches")
     @Nullable
     public abstract List<Match> matches();
 
-    @JsonProperty
+    @JsonProperty("pattern")
     public abstract String pattern();
 
-    @JsonProperty
+    @JsonProperty("string")
     public abstract String string();
+
+    @JsonProperty("error_message")
+    @Nullable
+    public abstract String errorMessage();
 
     @JsonCreator
     public static GrokTesterResponse create(@JsonProperty("matched") boolean matched,
                                             @JsonProperty("matches") @Nullable List<Match> matches,
                                             @JsonProperty("pattern") String pattern,
-                                            @JsonProperty("string") String string) {
-        return new AutoValue_GrokTesterResponse(matched, matches, pattern, string);
+                                            @JsonProperty("string") String string,
+                                            @JsonProperty("error_message") @Nullable String errorMessage) {
+        return new AutoValue_GrokTesterResponse(matched, matches, pattern, string, errorMessage);
+    }
+
+    public static GrokTesterResponse createError(String pattern,
+                                                 String string,
+                                                 @Nullable String errorMessage) {
+        return create(false, Collections.emptyList(), pattern, string, errorMessage);
+    }
+
+    public static GrokTesterResponse createSuccess(boolean matched,
+                                                   @Nullable List<Match> matches,
+                                                   String pattern,
+                                                   String string) {
+        return create(matched, matches, pattern, string, null);
     }
 
     @JsonAutoDetect

--- a/graylog2-server/src/test/java/org/graylog2/grok/GrokPatternRegistryTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/grok/GrokPatternRegistryTest.java
@@ -18,8 +18,8 @@ package org.graylog2.grok;
 
 import com.google.common.eventbus.EventBus;
 import com.google.common.util.concurrent.ThreadFactoryBuilder;
-import oi.thekraken.grok.api.Grok;
-import oi.thekraken.grok.api.exception.GrokException;
+import io.thekraken.grok.api.Grok;
+import io.thekraken.grok.api.exception.GrokException;
 import org.hamcrest.Matchers;
 import org.junit.Before;
 import org.junit.Rule;
@@ -49,20 +49,19 @@ public class GrokPatternRegistryTest {
 
     private GrokPatternRegistry grokPatternRegistry;
     private EventBus eventBus;
-    private ScheduledExecutorService executor;
     @Mock
     private GrokPatternService grokPatternService;
 
     @Before
     public void setUp() {
         eventBus = new EventBus("Test");
-        executor = Executors.newSingleThreadScheduledExecutor(new ThreadFactoryBuilder().setNameFormat("updater-%d").build());
+        final ScheduledExecutorService executor = Executors.newSingleThreadScheduledExecutor(new ThreadFactoryBuilder().setNameFormat("updater-%d").build());
         when(grokPatternService.loadAll()).thenReturn(GROK_PATTERNS);
         grokPatternRegistry = new GrokPatternRegistry(eventBus, grokPatternService, executor);
     }
 
     @Test
-    public void grokPatternsChanged() throws Exception {
+    public void grokPatternsChanged() {
         final Set<GrokPattern> newPatterns = Collections.singleton(GrokPattern.create("NEW_PATTERN", "\\w+"));
         when(grokPatternService.loadAll()).thenReturn(newPatterns);
         eventBus.post(GrokPatternsChangedEvent.create(Collections.emptySet(), Collections.singleton("NEW_PATTERN")));
@@ -71,16 +70,16 @@ public class GrokPatternRegistryTest {
     }
 
     @Test
-    public void cachedGrokForPattern() throws Exception {
+    public void cachedGrokForPattern() {
         final Grok grok = grokPatternRegistry.cachedGrokForPattern("%{TESTNUM}");
         assertThat(grok.getPatterns()).containsEntry(GROK_PATTERN.name(), GROK_PATTERN.pattern());
     }
 
     @Test
-    public void cachedGrokForPatternThrowsRuntimeException() throws Exception {
-        expectedException.expectMessage("Invalid Pattern");
+    public void cachedGrokForPatternThrowsRuntimeException() {
+        expectedException.expectMessage("No definition for key 'EMPTY' found, aborting");
         expectedException.expect(RuntimeException.class);
-        expectedException.expectCause(Matchers.any(GrokException.class));
+        expectedException.expectCause(Matchers.any(IllegalArgumentException.class));
 
         final Set<GrokPattern> newPatterns = Collections.singleton(GrokPattern.create("EMPTY", ""));
         when(grokPatternService.loadAll()).thenReturn(newPatterns);
@@ -90,16 +89,16 @@ public class GrokPatternRegistryTest {
     }
 
     @Test
-    public void cachedGrokForPatternWithNamedCaptureOnly() throws Exception {
+    public void cachedGrokForPatternWithNamedCaptureOnly() {
         final Grok grok = grokPatternRegistry.cachedGrokForPattern("%{TESTNUM}", true);
         assertThat(grok.getPatterns()).containsEntry(GROK_PATTERN.name(), GROK_PATTERN.pattern());
     }
 
     @Test
-    public void cachedGrokForPatternWithNamedCaptureOnlyThrowsRuntimeException() throws Exception {
-        expectedException.expectMessage("Invalid Pattern");
+    public void cachedGrokForPatternWithNamedCaptureOnlyThrowsRuntimeException() {
+        expectedException.expectMessage("No definition for key 'EMPTY' found, aborting");
         expectedException.expect(RuntimeException.class);
-        expectedException.expectCause(Matchers.any(GrokException.class));
+        expectedException.expectCause(Matchers.any(IllegalArgumentException.class));
 
         final Set<GrokPattern> newPatterns = Collections.singleton(GrokPattern.create("EMPTY", ""));
         when(grokPatternService.loadAll()).thenReturn(newPatterns);
@@ -109,7 +108,7 @@ public class GrokPatternRegistryTest {
     }
 
     @Test
-    public void patterns() throws Exception {
+    public void patterns() {
         assertThat(grokPatternRegistry.patterns()).isEqualTo(GROK_PATTERNS);
     }
 }

--- a/graylog2-server/src/test/java/org/graylog2/inputs/extractors/GrokExtractorTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/inputs/extractors/GrokExtractorTest.java
@@ -34,6 +34,7 @@ import java.util.Map;
 import java.util.Set;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
@@ -67,7 +68,8 @@ public class GrokExtractorTest {
 
 
     @Test
-    public void postfix() {
+    public void issue_3949() {
+        // Also see: https://github.com/Graylog2/graylog2-server/issues/3949
         patternSet.add(GrokPattern.create("POSTFIX_QMGR_REMOVED", "%{POSTFIX_QUEUEID:postfix_queueid}: removed"));
         patternSet.add(GrokPattern.create("POSTFIX_CLEANUP_MILTER", "%{POSTFIX_QUEUEID:postfix_queueid}: milter-%{POSTFIX_ACTION:postfix_milter_result}: %{GREEDYDATA:postfix_milter_message}; %{GREEDYDATA_NO_COLON:postfix_keyvalue_data}(: %{GREEDYDATA:postfix_milter_data})?"));
         patternSet.add(GrokPattern.create("POSTFIX_QMGR_ACTIVE", "%{POSTFIX_QUEUEID:postfix_queueid}: %{POSTFIX_KEYVALUE_DATA:postfix_keyvalue_data} \\(queue active\\)"));
@@ -158,10 +160,9 @@ public class GrokExtractorTest {
 
         final Map<String, Object> config = new HashMap<>();
         config.put("named_captures_only", true);
-        final GrokExtractor extractor = makeExtractor("%{POSTFIX_SMTPD}", config);
-
-        final Extractor.Result[] results = extractor.run("Test 12345 Foobar");
-        assertEquals(0, results.length);
+        assertThatThrownBy(() ->  makeExtractor("%{POSTFIX_SMTPD}", config))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("No definition for key 'HOSTNAME' found, aborting");
     }
 
     @Test

--- a/graylog2-server/src/test/java/org/graylog2/inputs/extractors/GrokExtractorTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/inputs/extractors/GrokExtractorTest.java
@@ -28,7 +28,7 @@ import org.joda.time.DateTimeZone;
 import org.junit.Before;
 import org.junit.Test;
 
-import java.util.Date;
+import java.time.Instant;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
@@ -170,8 +170,8 @@ public class GrokExtractorTest {
         final Extractor.Result[] results = extractor.run("2015-07-31T10:05:36.773Z");
         assertEquals("ISO date is parsed", 1, results.length);
         Object value = results[0].getValue();
-        assertTrue(value instanceof Date);
-        DateTime date = new DateTime(value, DateTimeZone.UTC);
+        assertTrue(value instanceof Instant);
+        DateTime date = new DateTime(((Instant) value).toEpochMilli(), DateTimeZone.UTC);
 
         assertEquals(2015, date.getYear());
         assertEquals(7, date.getMonthOfYear());

--- a/graylog2-server/src/test/java/org/graylog2/inputs/extractors/GrokExtractorTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/inputs/extractors/GrokExtractorTest.java
@@ -65,6 +65,105 @@ public class GrokExtractorTest {
         assertEquals(199999, results[0].getValue());
     }
 
+
+    @Test
+    public void postfix() {
+        patternSet.add(GrokPattern.create("POSTFIX_QMGR_REMOVED", "%{POSTFIX_QUEUEID:postfix_queueid}: removed"));
+        patternSet.add(GrokPattern.create("POSTFIX_CLEANUP_MILTER", "%{POSTFIX_QUEUEID:postfix_queueid}: milter-%{POSTFIX_ACTION:postfix_milter_result}: %{GREEDYDATA:postfix_milter_message}; %{GREEDYDATA_NO_COLON:postfix_keyvalue_data}(: %{GREEDYDATA:postfix_milter_data})?"));
+        patternSet.add(GrokPattern.create("POSTFIX_QMGR_ACTIVE", "%{POSTFIX_QUEUEID:postfix_queueid}: %{POSTFIX_KEYVALUE_DATA:postfix_keyvalue_data} \\(queue active\\)"));
+        patternSet.add(GrokPattern.create("POSTFIX_TRIVIAL_REWRITE", "%{POSTFIX_WARNING}"));
+        patternSet.add(GrokPattern.create("POSTFIX_WARNING", "%{POSTFIX_WARNING_WITH_KV}|%{POSTFIX_WARNING_WITHOUT_KV}"));
+        patternSet.add(GrokPattern.create("POSTFIX_SMTPD_DISCONNECT", "disconnect from %{POSTFIX_CLIENT_INFO}"));
+        patternSet.add(GrokPattern.create("POSTFIX_SMTPD_CONNECT", "connect from %{POSTFIX_CLIENT_INFO}"));
+        patternSet.add(GrokPattern.create("POSTFIX_SMTPD_NOQUEUE", "NOQUEUE: %{POSTFIX_ACTION:postfix_action}: %{POSTFIX_SMTP_STAGE:postfix_smtp_stage} from %{POSTFIX_CLIENT_INFO}:( %{POSTFIX_STATUS_CODE:postfix_status_code} %{POSTFIX_STATUS_CODE_ENHANCED:postfix_status_code_enhanced})?( <%{DATA:postfix_status_data}>:)? (%{POSTFIX_DNSBL_MESSAGE}|%{GREEDYDATA:postfix_status_message};) %{POSTFIX_KEYVALUE_DATA:postfix_keyvalue_data}"));
+        patternSet.add(GrokPattern.create("POSTFIX_SMTPD_LOSTCONN", "%{POSTFIX_LOSTCONN:postfix_smtpd_lostconn_data}( after %{POSTFIX_SMTP_STAGE:postfix_smtp_stage}( \\(%{INT} bytes\\))?)? from %{POSTFIX_CLIENT_INFO}(: %{GREEDYDATA:postfix_smtpd_lostconn_reason})?"));
+        patternSet.add(GrokPattern.create("POSTFIX_SMTPD_PROXY", "proxy-%{POSTFIX_ACTION:postfix_proxy_result}: (%{POSTFIX_SMTP_STAGE:postfix_proxy_smtp_stage}): %{POSTFIX_PROXY_MESSAGE:postfix_proxy_message}; %{POSTFIX_KEYVALUE_DATA:postfix_keyvalue_data}"));
+        patternSet.add(GrokPattern.create("POSTFIX_SMTPD_PIPELINING", "improper command pipelining after %{POSTFIX_SMTP_STAGE:postfix_smtp_stage} from %{POSTFIX_CLIENT_INFO}: %{GREEDYDATA:postfix_improper_pipelining_data}"));
+        patternSet.add(GrokPattern.create("POSTFIX_QMGR", "%{POSTFIX_QMGR_REMOVED}|%{POSTFIX_QMGR_ACTIVE}|%{POSTFIX_QMGR_EXPIRED}|%{POSTFIX_WARNING}"));
+        patternSet.add(GrokPattern.create("POSTFIX_CLEANUP", "%{POSTFIX_CLEANUP_MILTER}|%{POSTFIX_WARNING}|%{POSTFIX_KEYVALUE}"));
+        patternSet.add(GrokPattern.create("POSTFIX_POSTSCREEN", "%{POSTFIX_PS_CONNECT}|%{POSTFIX_PS_ACCESS}|%{POSTFIX_PS_NOQUEUE}|%{POSTFIX_PS_TOOBUSY}|%{POSTFIX_PS_CACHE}|%{POSTFIX_PS_DNSBL}|%{POSTFIX_PS_VIOLATIONS}|%{POSTFIX_WARNING}"));
+        patternSet.add(GrokPattern.create("POSTFIX_PIPE", "%{POSTFIX_PIPE_ANY}"));
+        patternSet.add(GrokPattern.create("POSTFIX_ANVIL", "%{POSTFIX_ANVIL_CONN_RATE}|%{POSTFIX_ANVIL_CONN_CACHE}|%{POSTFIX_ANVIL_CONN_COUNT}"));
+        patternSet.add(GrokPattern.create("POSTFIX_DNSBLOG", "%{POSTFIX_DNSBLOG_LISTING}|%{POSTFIX_WARNING}"));
+        patternSet.add(GrokPattern.create("POSTFIX_PICKUP", "%{POSTFIX_KEYVALUE}"));
+        patternSet.add(GrokPattern.create("POSTFIX_LMTP", "%{POSTFIX_SMTP}"));
+        patternSet.add(GrokPattern.create("POSTFIX_MASTER", "%{POSTFIX_MASTER_START}|%{POSTFIX_MASTER_EXIT}|%{POSTFIX_WARNING}"));
+        patternSet.add(GrokPattern.create("POSTFIX_TLSPROXY", "%{POSTFIX_TLSPROXY_CONN}|%{POSTFIX_WARNING}"));
+        patternSet.add(GrokPattern.create("POSTFIX_SENDMAIL", "%{POSTFIX_WARNING}"));
+        patternSet.add(GrokPattern.create("POSTFIX_BOUNCE", "%{POSTFIX_BOUNCE_NOTIFICATION}"));
+        patternSet.add(GrokPattern.create("POSTFIX_SCACHE", "%{POSTFIX_SCACHE_LOOKUPS}|%{POSTFIX_SCACHE_SIMULTANEOUS}|%{POSTFIX_SCACHE_TIMESTAMP}"));
+        patternSet.add(GrokPattern.create("POSTFIX_POSTDROP", "%{POSTFIX_WARNING}"));
+        patternSet.add(GrokPattern.create("POSTFIX_LOSTCONN_REASONS", "(receiving the initial server greeting|sending message body|sending end of data -- message may be sent more than once)"));
+        patternSet.add(GrokPattern.create("POSTFIX_PROXY_MESSAGE", "(%{POSTFIX_STATUS_CODE:postfix_proxy_status_code} )?(%{POSTFIX_STATUS_CODE_ENHANCED:postfix_proxy_status_code_enhanced})?.*"));
+        patternSet.add(GrokPattern.create("GREEDYDATA_NO_COLON", "[^:]*"));
+        patternSet.add(GrokPattern.create("GREEDYDATA_NO_SEMICOLON", "[^;]*"));
+        patternSet.add(GrokPattern.create("POSTFIX_DISCARD", "%{POSTFIX_DISCARD_ANY}|%{POSTFIX_WARNING}"));
+        patternSet.add(GrokPattern.create("POSTFIX_WARNING_WITH_KV", "(%{POSTFIX_QUEUEID:postfix_queueid}: )?%{POSTFIX_WARNING_LEVEL:postfix_message_level}: %{GREEDYDATA:postfix_message}; %{POSTFIX_KEYVALUE_DATA:postfix_keyvalue_data}"));
+        patternSet.add(GrokPattern.create("POSTFIX_SMTP", "%{POSTFIX_SMTP_DELIVERY}|%{POSTFIX_SMTP_CONNERR}|%{POSTFIX_SMTP_LOSTCONN}|%{POSTFIX_SMTP_TIMEOUT}|%{POSTFIX_SMTP_RELAYERR}|%{POSTFIX_TLSCONN}|%{POSTFIX_WARNING}"));
+        patternSet.add(GrokPattern.create("POSTFIX_WARNING_WITHOUT_KV", "(%{POSTFIX_QUEUEID:postfix_queueid}: )?%{POSTFIX_WARNING_LEVEL:postfix_message_level}: %{GREEDYDATA:postfix_message}"));
+        patternSet.add(GrokPattern.create("POSTFIX_TLSPROXY_CONN", "(DIS)?CONNECT( from)? %{POSTFIX_CLIENT_INFO}"));
+        patternSet.add(GrokPattern.create("POSTFIX_ANVIL_CONN_CACHE", "statistics: max cache size %{NUMBER:postfix_anvil_cache_size} at %{SYSLOGTIMESTAMP:postfix_anvil_timestamp}"));
+        patternSet.add(GrokPattern.create("POSTFIX_ANVIL_CONN_RATE", "statistics: max connection rate %{NUMBER:postfix_anvil_conn_rate}/%{POSTFIX_TIME_UNIT:postfix_anvil_conn_period} for \\(%{DATA:postfix_service}:%{IP:postfix_client_ip}\\) at %{SYSLOGTIMESTAMP:postfix_anvil_timestamp}"));
+        patternSet.add(GrokPattern.create("POSTFIX_SMTP_DELIVERY", "%{POSTFIX_KEYVALUE} status=%{WORD:postfix_status}( \\(%{GREEDYDATA:postfix_smtp_response}\\))?"));
+        patternSet.add(GrokPattern.create("POSTFIX_ANVIL_CONN_COUNT", "statistics: max connection count %{NUMBER:postfix_anvil_conn_count} for \\(%{DATA:postfix_service}:%{IP:postfix_client_ip}\\) at %{SYSLOGTIMESTAMP:postfix_anvil_timestamp}"));
+        patternSet.add(GrokPattern.create("POSTFIX_SMTP_CONNERR", "connect to %{POSTFIX_RELAY_INFO}: (Connection timed out|No route to host|Connection refused|Network is unreachable)"));
+        patternSet.add(GrokPattern.create("POSTFIX_SMTPD", "%{POSTFIX_SMTPD_CONNECT}|%{POSTFIX_SMTPD_DISCONNECT}|%{POSTFIX_SMTPD_LOSTCONN}|%{POSTFIX_SMTPD_NOQUEUE}|%{POSTFIX_SMTPD_PIPELINING}|%{POSTFIX_TLSCONN}|%{POSTFIX_WARNING}|%{POSTFIX_SMTPD_PROXY}|%{POSTFIX_KEYVALUE}"));
+        patternSet.add(GrokPattern.create("POSTFIX_SMTP_RELAYERR", "%{POSTFIX_QUEUEID:postfix_queueid}: host %{POSTFIX_RELAY_INFO} said: %{GREEDYDATA:postfix_smtp_response} \\(in reply to %{POSTFIX_SMTP_STAGE:postfix_smtp_stage} command\\)"));
+        patternSet.add(GrokPattern.create("POSTFIX_STATUS_CODE_ENHANCED", "\\d\\.\\d\\.\\d"));
+        patternSet.add(GrokPattern.create("POSTFIX_SMTP_TIMEOUT", "%{POSTFIX_QUEUEID:postfix_queueid}: conversation with %{POSTFIX_RELAY_INFO} timed out( while %{POSTFIX_LOSTCONN_REASONS:postfix_smtp_lostconn_reason})?"));
+        patternSet.add(GrokPattern.create("POSTFIX_MASTER_EXIT", "terminating on signal %{INT:postfix_termination_signal}"));
+        patternSet.add(GrokPattern.create("POSTFIX_MASTER_START", "(daemon started|reload) -- version %{DATA:postfix_version}, configuration %{PATH:postfix_config_path}"));
+        patternSet.add(GrokPattern.create("POSTFIX_SCACHE_LOOKUPS", "statistics: (address|domain) lookup hits=%{INT:postfix_scache_hits} miss=%{INT:postfix_scache_miss} success=%{INT:postfix_scache_success}%"));
+        patternSet.add(GrokPattern.create("POSTFIX_BOUNCE_NOTIFICATION", "%{POSTFIX_QUEUEID:postfix_queueid}: sender (non-delivery|delivery status|delay) notification: %{POSTFIX_QUEUEID:postfix_bounce_queueid}"));
+        patternSet.add(GrokPattern.create("POSTFIX_SCACHE_TIMESTAMP", "statistics: start interval %{SYSLOGTIMESTAMP:postfix_scache_timestamp}"));
+        patternSet.add(GrokPattern.create("POSTFIX_SCACHE_SIMULTANEOUS", "statistics: max simultaneous domains=%{INT:postfix_scache_domains} addresses=%{INT:postfix_scache_addresses} connection=%{INT:postfix_scache_connection}"));
+        patternSet.add(GrokPattern.create("POSTFIX_CLIENT_INFO", "%{HOSTNAME:postfix_client_hostname}?\\[%{IP:postfix_client_ip}\\](:%{INT:postfix_client_port})?"));
+        patternSet.add(GrokPattern.create("POSTFIX_RELAY_INFO", "%{HOSTNAME:postfix_relay_hostname}?\\[(%{IP:postfix_relay_ip}|%{DATA:postfix_relay_service})\\](:%{INT:postfix_relay_port})?|%{WORD:postfix_relay_service}"));
+        patternSet.add(GrokPattern.create("POSTFIX_SMTP_STAGE", "(CONNECT|HELO|EHLO|STARTTLS|AUTH|MAIL( FROM)?|RCPT( TO)?|(end of )?DATA|RSET|UNKNOWN|END-OF-MESSAGE|VRFY|\\.)"));
+        patternSet.add(GrokPattern.create("POSTFIX_ACTION", "(accept|defer|discard|filter|header-redirect|reject)"));
+        patternSet.add(GrokPattern.create("POSTFIX_SMTP_LOSTCONN", "%{POSTFIX_QUEUEID:postfix_queueid}: %{POSTFIX_LOSTCONN:postfix_smtp_lostconn_data} with %{POSTFIX_RELAY_INFO}( while %{POSTFIX_LOSTCONN_REASONS:postfix_smtp_lostconn_reason})?"));
+        patternSet.add(GrokPattern.create("POSTFIX_STATUS_CODE", "\\d{3}"));
+        patternSet.add(GrokPattern.create("POSTFIX_TLSCONN", "(Anonymous|Trusted|Untrusted|Verified) TLS connection established (to %{POSTFIX_RELAY_INFO}|from %{POSTFIX_CLIENT_INFO}): %{DATA:postfix_tls_version} with cipher %{DATA:postfix_tls_cipher} \\(%{DATA:postfix_tls_cipher_size} bits\\)"));
+        patternSet.add(GrokPattern.create("POSTFIX_DELAYS", "%{NUMBER:postfix_delay_before_qmgr}/%{NUMBER:postfix_delay_in_qmgr}/%{NUMBER:postfix_delay_conn_setup}/%{NUMBER:postfix_delay_transmission}"));
+        patternSet.add(GrokPattern.create("POSTFIX_LOSTCONN", "(lost connection|timeout|SSL_accept error)"));
+        patternSet.add(GrokPattern.create("POSTFIX_PIPE_ANY", "%{POSTFIX_QUEUEID:postfix_queueid}: %{POSTFIX_KEYVALUE_DATA:postfix_keyvalue_data}, status=%{WORD:postfix_status} \\(%{GREEDYDATA:postfix_pipe_response}\\)"));
+        patternSet.add(GrokPattern.create("POSTFIX_QMGR_EXPIRED", "%{POSTFIX_QUEUEID:postfix_queueid}: from=<%{DATA:postfix_from}>, status=%{WORD:postfix_status}, returned to sender"));
+        patternSet.add(GrokPattern.create("POSTFIX_DISCARD_ANY", "%{POSTFIX_QUEUEID:postfix_queueid}: %{POSTFIX_KEYVALUE_DATA:postfix_keyvalue_data} status=%{WORD:postfix_status} %{GREEDYDATA}"));
+        patternSet.add(GrokPattern.create("POSTFIX_ERROR_ANY", "%{POSTFIX_QUEUEID:postfix_queueid}: %{POSTFIX_KEYVALUE_DATA:postfix_keyvalue_data}, status=%{WORD:postfix_status} \\(%{GREEDYDATA:postfix_error_response}\\)"));
+        patternSet.add(GrokPattern.create("POSTFIX_POSTSUPER_ACTION", "%{POSTFIX_QUEUEID:postfix_queueid}: %{POSTFIX_POSTSUPER_ACTIONS:postfix_postsuper_action}"));
+        patternSet.add(GrokPattern.create("POSTFIX_POSTSUPER_ACTIONS", "(removed|requeued|placed on hold|released from hold)"));
+        patternSet.add(GrokPattern.create("POSTFIX_DNSBLOG_LISTING", "addr %{IP:postfix_client_ip} listed by domain %{HOSTNAME:postfix_dnsbl_domain} as %{IP:postfix_dnsbl_result}"));
+        patternSet.add(GrokPattern.create("POSTFIX_DNSBL_MESSAGE", "Service unavailable; .* \\[%{GREEDYDATA:postfix_status_data}\\] %{GREEDYDATA:postfix_status_message};"));
+        patternSet.add(GrokPattern.create("POSTFIX_PS_VIOLATIONS", "%{POSTFIX_PS_VIOLATION:postfix_postscreen_violation}( %{INT})?( after %{NUMBER:postfix_postscreen_violation_time})? from %{POSTFIX_CLIENT_INFO}(( after %{POSTFIX_SMTP_STAGE:postfix_smtp_stage})?(: %{GREEDYDATA:postfix_postscreen_data})?| in tests (after|before) SMTP handshake)"));
+        patternSet.add(GrokPattern.create("POSTFIX_PS_ACCESS_ACTION", "(DISCONNECT|BLACKLISTED|WHITELISTED|WHITELIST VETO|PASS NEW|PASS OLD)"));
+        patternSet.add(GrokPattern.create("POSTFIX_PS_VIOLATION", "(BARE NEWLINE|COMMAND (TIME|COUNT|LENGTH) LIMIT|COMMAND PIPELINING|DNSBL|HANGUP|NON-SMTP COMMAND|PREGREET)"));
+        patternSet.add(GrokPattern.create("POSTFIX_TIME_UNIT", "%{NUMBER}[smhd]"));
+        patternSet.add(GrokPattern.create("POSTFIX_KEYVALUE_DATA", "[\\w-]+=[^;]*"));
+        patternSet.add(GrokPattern.create("POSTFIX_KEYVALUE", "%{POSTFIX_QUEUEID:postfix_queueid}: %{POSTFIX_KEYVALUE_DATA:postfix_keyvalue_data}"));
+        patternSet.add(GrokPattern.create("POSTFIX_WARNING_LEVEL", "(warning|fatal|info)"));
+        patternSet.add(GrokPattern.create("POSTFIX_POSTSUPER_SUMMARY", "%{POSTFIX_POSTSUPER_SUMMARY_ACTIONS:postfix_postsuper_summary_action}: %{NUMBER:postfix_postsuper_summary_count} messages?"));
+        patternSet.add(GrokPattern.create("POSTFIX_POSTSUPER_SUMMARY_ACTIONS", "(Deleted|Requeued|Placed on hold|Released from hold)"));
+        patternSet.add(GrokPattern.create("POSTFIX_PS_ACCESS", "%{POSTFIX_PS_ACCESS_ACTION:postfix_postscreen_access} %{POSTFIX_CLIENT_INFO}"));
+        patternSet.add(GrokPattern.create("POSTFIX_PS_CONNECT", "CONNECT from %{POSTFIX_CLIENT_INFO} to \\[%{IP:postfix_server_ip}\\]:%{INT:postfix_server_port}"));
+        patternSet.add(GrokPattern.create("POSTFIX_PS_TOOBUSY", "NOQUEUE: reject: CONNECT from %{POSTFIX_CLIENT_INFO}: %{GREEDYDATA:postfix_postscreen_toobusy_data}"));
+        patternSet.add(GrokPattern.create("POSTFIX_PS_NOQUEUE", "%{POSTFIX_SMTPD_NOQUEUE}"));
+        patternSet.add(GrokPattern.create("POSTFIX_PS_CACHE", "cache %{DATA} full cleanup: retained=%{NUMBER:postfix_postscreen_cache_retained} dropped=%{NUMBER:postfix_postscreen_cache_dropped} entries"));
+        patternSet.add(GrokPattern.create("POSTFIX_PS_DNSBL", "%{POSTFIX_PS_VIOLATION:postfix_postscreen_violation} rank %{INT:postfix_postscreen_dnsbl_rank} for %{POSTFIX_CLIENT_INFO}"));
+        patternSet.add(GrokPattern.create("POSTFIX_LOCAL", "%{POSTFIX_KEYVALUE}"));
+        patternSet.add(GrokPattern.create("POSTFIX_TLSMGR", "%{POSTFIX_WARNING}"));
+        patternSet.add(GrokPattern.create("POSTFIX_ERROR", "%{POSTFIX_ERROR_ANY}"));
+        patternSet.add(GrokPattern.create("POSTFIX_QUEUEID", "([0-9A-F]{6,}|[0-9a-zA-Z]{15,})"));
+        patternSet.add(GrokPattern.create("POSTFIX_VIRTUAL", "%{POSTFIX_SMTP_DELIVERY}"));
+        patternSet.add(GrokPattern.create("POSTFIX_POSTSUPER", "%{POSTFIX_POSTSUPER_ACTION}|%{POSTFIX_POSTSUPER_SUMMARY}"));
+
+        final Map<String, Object> config = new HashMap<>();
+        config.put("named_captures_only", true);
+        final GrokExtractor extractor = makeExtractor("%{POSTFIX_SMTPD}", config);
+
+        final Extractor.Result[] results = extractor.run("Test 12345 Foobar");
+        assertEquals(0, results.length);
+    }
+
     @Test
     public void testDateExtraction() {
         final GrokExtractor extractor = makeExtractor("%{GREEDY:timestamp;date;yyyy-MM-dd'T'HH:mm:ss.SSSX}");

--- a/graylog2-server/src/test/java/org/graylog2/rest/resources/tools/GrokTesterResourceTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/rest/resources/tools/GrokTesterResourceTest.java
@@ -1,0 +1,99 @@
+/**
+ * This file is part of Graylog.
+ *
+ * Graylog is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.graylog2.rest.resources.tools;
+
+import org.graylog2.grok.GrokPattern;
+import org.graylog2.grok.InMemoryGrokPatternService;
+import org.graylog2.rest.resources.tools.responses.GrokTesterResponse;
+import org.graylog2.shared.bindings.GuiceInjectorHolder;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.Collections;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class GrokTesterResourceTest {
+    static {
+        GuiceInjectorHolder.createInjector(Collections.emptyList());
+    }
+
+    private GrokTesterResource resource;
+
+    @Before
+    public void setUp() throws Exception {
+        final InMemoryGrokPatternService grokPatternService = new InMemoryGrokPatternService();
+        grokPatternService.save(GrokPattern.create("NUMBER", "[0-9]+"));
+        resource = new GrokTesterResource(grokPatternService);
+    }
+
+    @Test
+    public void testGrokWithValidPatternAndMatch() {
+        final GrokTesterResponse response = resource.grokTest("%{NUMBER}", "abc 1234", false);
+        assertThat(response.matched()).isTrue();
+        assertThat(response.pattern()).isEqualTo("%{NUMBER}");
+        assertThat(response.string()).isEqualTo("abc 1234");
+        assertThat(response.matches()).containsOnly(GrokTesterResponse.Match.create("NUMBER", "1234"));
+        assertThat(response.errorMessage()).isNullOrEmpty();
+    }
+
+    @Test
+    public void testGrokWithValidPatternAndNoMatch() {
+        final GrokTesterResponse response = resource.grokTest("%{NUMBER}", "abc def", false);
+        assertThat(response.matched()).isFalse();
+        assertThat(response.pattern()).isEqualTo("%{NUMBER}");
+        assertThat(response.string()).isEqualTo("abc def");
+        assertThat(response.matches()).isEmpty();
+        assertThat(response.errorMessage()).isNullOrEmpty();
+    }
+
+    @Test
+    public void testGrokWithInvalidPattern() {
+        final GrokTesterResponse response = resource.grokTest("%{NUMBER", "abc 1234", false);
+        assertThat(response.matched()).isFalse();
+        assertThat(response.pattern()).isEqualTo("%{NUMBER");
+        assertThat(response.string()).isEqualTo("abc 1234");
+        assertThat(response.errorMessage()).startsWith("Illegal repetition near index 0");
+    }
+
+    @Test
+    public void testGrokWithMissingPattern() {
+        final GrokTesterResponse response = resource.grokTest("%{FOOBAR} %{NUMBER}", "abc 1234", false);
+        assertThat(response.matched()).isFalse();
+        assertThat(response.pattern()).isEqualTo("%{FOOBAR} %{NUMBER}");
+        assertThat(response.string()).isEqualTo("abc 1234");
+        assertThat(response.errorMessage()).isEqualTo("No definition for key 'FOOBAR' found, aborting");
+    }
+
+    @Test
+    public void testGrokWithEmptyPattern() {
+        final GrokTesterResponse response = resource.grokTest("", "abc 1234", false);
+        assertThat(response.matched()).isFalse();
+        assertThat(response.pattern()).isEqualTo("");
+        assertThat(response.string()).isEqualTo("abc 1234");
+        assertThat(response.errorMessage()).isEqualTo("{pattern} should not be empty or null");
+    }
+
+    @Test
+    public void testGrokWithEmptyTestString() {
+        final GrokTesterResponse response = resource.grokTest("%{NUMBER}", "", false);
+        assertThat(response.matched()).isFalse();
+        assertThat(response.pattern()).isEqualTo("%{NUMBER}");
+        assertThat(response.string()).isEqualTo("");
+        assertThat(response.errorMessage()).isNullOrEmpty();
+    }
+}

--- a/graylog2-web-interface/src/components/extractors/extractors_configuration/GrokExtractorConfiguration.jsx
+++ b/graylog2-web-interface/src/components/extractors/extractors_configuration/GrokExtractorConfiguration.jsx
@@ -37,6 +37,11 @@ class GrokExtractorConfiguration extends React.Component {
 
     const promise = ToolsStore.testGrok(this.props.configuration.grok_pattern, this.props.configuration.named_captures_only, this.props.exampleMessage);
     promise.then((result) => {
+      if (result.error_message != null) {
+        UserNotification.error('We were not able to run the grok extraction because of the following error: ' + result.error_message);
+        return;
+      }
+
       if (!result.matched) {
         UserNotification.warning('We were not able to run the grok extraction. Please check your parameters.');
         return;

--- a/pom.xml
+++ b/pom.xml
@@ -98,7 +98,7 @@
         <jest.version>2.4.11+jackson</jest.version>
         <gelfclient.version>1.4.1</gelfclient.version>
         <geoip2.version>2.11.0</geoip2.version>
-        <grok.version>0.1.7-graylog</grok.version>
+        <grok.version>0.1.8-graylog</grok.version>
         <guava-retrying.version>2.0.0</guava-retrying.version>
         <guava.version>24.0-jre</guava.version>
         <guice.version>4.2.0</guice.version>


### PR DESCRIPTION
If a Grok pattern couldn't be resolved, the java-grok library emitted an error message which didn't include the name of the missing pattern.

After upgrading to the latest version of (our repackaged) java-grok, the error message includes the name of the missing Grok pattern to help users to solve the problem.

Fixes #3949