### PR TITLE
Add support for int values in SearchQuery

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/search/SearchQueryField.java
+++ b/graylog2-server/src/main/java/org/graylog2/search/SearchQueryField.java
@@ -18,7 +18,7 @@ package org.graylog2.search;
 
 public class SearchQueryField {
     public enum Type {
-        STRING, DATE;
+        STRING, DATE, INT;
     }
 
     private final String dbField;

--- a/graylog2-server/src/main/java/org/graylog2/search/SearchQueryField.java
+++ b/graylog2-server/src/main/java/org/graylog2/search/SearchQueryField.java
@@ -18,7 +18,7 @@ package org.graylog2.search;
 
 public class SearchQueryField {
     public enum Type {
-        STRING, DATE, INT;
+        STRING, DATE, INT, LONG;
     }
 
     private final String dbField;

--- a/graylog2-server/src/main/java/org/graylog2/search/SearchQueryParser.java
+++ b/graylog2-server/src/main/java/org/graylog2/search/SearchQueryParser.java
@@ -238,6 +238,8 @@ public class SearchQueryParser {
                 return new FieldValue(parseDate(pair.getLeft()), pair.getRight(), negate);
             case STRING:
                 return new FieldValue(pair.getLeft(), pair.getRight(), negate);
+            case INT:
+                return new FieldValue(Integer.parseInt(pair.getLeft()), pair.getRight(), negate);
             default:
                 throw new IllegalArgumentException("Unhandled field type: " + field.getFieldType().toString());
         }

--- a/graylog2-server/src/main/java/org/graylog2/search/SearchQueryParser.java
+++ b/graylog2-server/src/main/java/org/graylog2/search/SearchQueryParser.java
@@ -243,6 +243,8 @@ public class SearchQueryParser {
                 return new FieldValue(pair.getLeft(), pair.getRight(), negate);
             case INT:
                 return new FieldValue(Integer.parseInt(pair.getLeft()), pair.getRight(), negate);
+            case LONG:
+                return new FieldValue(Long.parseLong(pair.getLeft()), pair.getRight(), negate);
             default:
                 throw new IllegalArgumentException("Unhandled field type: " + fieldType.toString());
         }

--- a/graylog2-server/src/main/java/org/graylog2/search/SearchQueryParser.java
+++ b/graylog2-server/src/main/java/org/graylog2/search/SearchQueryParser.java
@@ -42,6 +42,7 @@ import java.util.stream.Collectors;
 
 import static com.google.common.base.Preconditions.checkArgument;
 import static java.util.Objects.requireNonNull;
+import static org.graylog2.search.SearchQueryField.Type.STRING;
 
 /**
  * Parses a simple query language for use in list filtering of data sitting in MongoDB.
@@ -80,7 +81,8 @@ public class SearchQueryParser {
     private static final Pattern QUERY_SPLITTER_PATTERN = Pattern.compile("(\\S+:(=|=~|<|<=|>|>=)?'(?:[^'\\\\]|\\\\.)*')|(\\S+:(=|=~|<|<=|>|>=)?\"(?:[^\"\\\\]|\\\\.)*\")|\\S+|\\S+:(=|=~|<|<=|>|>=)?\\S+");
     private static final String INVALID_ENTRY_MESSAGE = "Chunk [%s] is not a valid entry";
     private static final String QUOTE_REPLACE_REGEX = "^[\"']|[\"']$";
-    public static final SearchQueryOperator DEFAULT_OPERATOR = SearchQueryOperators.REGEXP;
+    public static final SearchQueryOperator DEFAULT_STRING_OPERATOR = SearchQueryOperators.REGEXP;
+    public static final SearchQueryOperator DEFAULT_OPERATOR = SearchQueryOperators.EQUALS;
 
     // We parse all date strings in UTC because we store and show all dates in UTC as well.
     private static final List<DateTimeFormatter> DATE_TIME_FORMATTERS = ImmutableList.of(
@@ -116,7 +118,7 @@ public class SearchQueryParser {
     public SearchQueryParser(@Nonnull String defaultField,
                              @Nonnull Map<String, SearchQueryField> allowedFieldsWithMapping) {
         this.defaultField = requireNonNull(defaultField);
-        this.defaultFieldKey = SearchQueryField.create(defaultField, SearchQueryField.Type.STRING);
+        this.defaultFieldKey = SearchQueryField.create(defaultField, STRING);
         this.dbFieldMapping = allowedFieldsWithMapping;
     }
 
@@ -231,9 +233,10 @@ public class SearchQueryParser {
     FieldValue createFieldValue(SearchQueryField field, String quotedStringValue, boolean negate) {
         // Make sure there are no quotes in the value (e.g. `"foo"' --> `foo')
         final String value = quotedStringValue.replaceAll(QUOTE_REPLACE_REGEX, "");
-        final Pair<String, SearchQueryOperator> pair = extractOperator(value, DEFAULT_OPERATOR);
+        final SearchQueryField.Type fieldType = field.getFieldType();
+        final Pair<String, SearchQueryOperator> pair = extractOperator(value, fieldType == STRING ? DEFAULT_STRING_OPERATOR : DEFAULT_OPERATOR);
 
-        switch (field.getFieldType()) {
+        switch (fieldType) {
             case DATE:
                 return new FieldValue(parseDate(pair.getLeft()), pair.getRight(), negate);
             case STRING:
@@ -241,7 +244,7 @@ public class SearchQueryParser {
             case INT:
                 return new FieldValue(Integer.parseInt(pair.getLeft()), pair.getRight(), negate);
             default:
-                throw new IllegalArgumentException("Unhandled field type: " + field.getFieldType().toString());
+                throw new IllegalArgumentException("Unhandled field type: " + fieldType.toString());
         }
     }
 
@@ -251,7 +254,7 @@ public class SearchQueryParser {
         private final boolean negate;
 
         public FieldValue(final Object value, final boolean negate) {
-            this(value, DEFAULT_OPERATOR, negate);
+            this(value, DEFAULT_STRING_OPERATOR, negate);
         }
 
         public FieldValue(final Object value, final SearchQueryOperator operator, final boolean negate) {

--- a/graylog2-server/src/test/java/org/graylog2/search/SearchQueryParserTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/search/SearchQueryParserTest.java
@@ -158,6 +158,13 @@ public class SearchQueryParserTest {
         checkQuery(parser, "<1", SearchQueryField.Type.INT, "1", SearchQueryOperators.LESS);
         checkQuery(parser, "=1", SearchQueryField.Type.INT, "1", SearchQueryOperators.EQUALS);
         checkQuery(parser, "1", SearchQueryField.Type.INT, "1", SearchQueryOperators.EQUALS);
+
+        checkQuery(parser, ">=1", SearchQueryField.Type.LONG, "1", SearchQueryOperators.GREATER_EQUALS);
+        checkQuery(parser, "<=1", SearchQueryField.Type.LONG, "1", SearchQueryOperators.LESS_EQUALS);
+        checkQuery(parser, ">1", SearchQueryField.Type.LONG, "1", SearchQueryOperators.GREATER);
+        checkQuery(parser, "<1", SearchQueryField.Type.LONG, "1", SearchQueryOperators.LESS);
+        checkQuery(parser, "=1", SearchQueryField.Type.LONG, "1", SearchQueryOperators.EQUALS);
+        checkQuery(parser, "1", SearchQueryField.Type.LONG, "1", SearchQueryOperators.EQUALS);
     }
 
     private void checkQuery(SearchQueryParser parser, String query, SearchQueryField.Type type, String expectedQuery, SearchQueryOperator expectedOp) {

--- a/graylog2-server/src/test/java/org/graylog2/search/SearchQueryParserTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/search/SearchQueryParserTest.java
@@ -128,31 +128,41 @@ public class SearchQueryParserTest {
         final SearchQueryParser parser = new SearchQueryParser("defaultfield",
                 ImmutableMap.of(
                         "id", SearchQueryField.create("real_id"),
-                        "date", SearchQueryField.create("created_at", SearchQueryField.Type.DATE))
+                        "date", SearchQueryField.create("created_at", SearchQueryField.Type.DATE),
+                        "int", SearchQueryField.create("int", SearchQueryField.Type.INT))
         );
 
         final SearchQueryOperator defaultOp = SearchQueryOperators.REGEXP;
 
-        checkQuery(parser, "", "", defaultOp);
-        checkQuery(parser, "h", "h", defaultOp);
-        checkQuery(parser, "he", "he", defaultOp);
-        checkQuery(parser, "hel", "hel", defaultOp);
-        checkQuery(parser, "hello", "hello", defaultOp);
+        checkQuery(parser, "", SearchQueryField.Type.STRING, "", defaultOp);
+        checkQuery(parser, "h", SearchQueryField.Type.STRING, "h", defaultOp);
+        checkQuery(parser, "he", SearchQueryField.Type.STRING, "he", defaultOp);
+        checkQuery(parser, "hel", SearchQueryField.Type.STRING, "hel", defaultOp);
+        checkQuery(parser, "hello", SearchQueryField.Type.STRING, "hello", defaultOp);
+        checkQuery(parser, "=~ hello", SearchQueryField.Type.STRING, "hello", SearchQueryOperators.REGEXP);
+        checkQuery(parser, "=  hello", SearchQueryField.Type.STRING, "hello", SearchQueryOperators.EQUALS);
 
-        checkQuery(parser, ">=2017-03-23", "2017-03-23", SearchQueryOperators.GREATER_EQUALS);
-        checkQuery(parser, ">= 2017-03-23", "2017-03-23", SearchQueryOperators.GREATER_EQUALS);
-        checkQuery(parser, "<=2017-03-23", "2017-03-23", SearchQueryOperators.LESS_EQUALS);
-        checkQuery(parser, "<=  2017-03-23", "2017-03-23", SearchQueryOperators.LESS_EQUALS);
-        checkQuery(parser, ">2017-03-23", "2017-03-23", SearchQueryOperators.GREATER);
-        checkQuery(parser, ">    2017-03-23", "2017-03-23", SearchQueryOperators.GREATER);
-        checkQuery(parser, "<2017-03-23", "2017-03-23", SearchQueryOperators.LESS);
-        checkQuery(parser, "< 2017-03-23", "2017-03-23", SearchQueryOperators.LESS);
-        checkQuery(parser, "=~ hello", "hello", SearchQueryOperators.REGEXP);
-        checkQuery(parser, "=  hello", "hello", SearchQueryOperators.EQUALS);
+        checkQuery(parser, ">=2017-03-23", SearchQueryField.Type.DATE, "2017-03-23", SearchQueryOperators.GREATER_EQUALS);
+        checkQuery(parser, ">= 2017-03-23", SearchQueryField.Type.DATE, "2017-03-23", SearchQueryOperators.GREATER_EQUALS);
+        checkQuery(parser, "<=2017-03-23", SearchQueryField.Type.DATE, "2017-03-23", SearchQueryOperators.LESS_EQUALS);
+        checkQuery(parser, "<=  2017-03-23", SearchQueryField.Type.DATE, "2017-03-23", SearchQueryOperators.LESS_EQUALS);
+        checkQuery(parser, ">2017-03-23", SearchQueryField.Type.DATE, "2017-03-23", SearchQueryOperators.GREATER);
+        checkQuery(parser, ">    2017-03-23", SearchQueryField.Type.DATE, "2017-03-23", SearchQueryOperators.GREATER);
+        checkQuery(parser, "<2017-03-23", SearchQueryField.Type.DATE, "2017-03-23", SearchQueryOperators.LESS);
+        checkQuery(parser, "< 2017-03-23", SearchQueryField.Type.DATE, "2017-03-23", SearchQueryOperators.LESS);
+        checkQuery(parser, "2017-03-23", SearchQueryField.Type.DATE, "2017-03-23", SearchQueryOperators.EQUALS);
+
+        checkQuery(parser, ">=1", SearchQueryField.Type.INT, "1", SearchQueryOperators.GREATER_EQUALS);
+        checkQuery(parser, "<=1", SearchQueryField.Type.INT, "1", SearchQueryOperators.LESS_EQUALS);
+        checkQuery(parser, ">1", SearchQueryField.Type.INT, "1", SearchQueryOperators.GREATER);
+        checkQuery(parser, "<1", SearchQueryField.Type.INT, "1", SearchQueryOperators.LESS);
+        checkQuery(parser, "=1", SearchQueryField.Type.INT, "1", SearchQueryOperators.EQUALS);
+        checkQuery(parser, "1", SearchQueryField.Type.INT, "1", SearchQueryOperators.EQUALS);
     }
 
-    private void checkQuery(SearchQueryParser parser, String query, String expectedQuery, SearchQueryOperator expectedOp) {
-        final Pair<String, SearchQueryOperator> pair = parser.extractOperator(query, SearchQueryOperators.REGEXP);
+    private void checkQuery(SearchQueryParser parser, String query, SearchQueryField.Type type, String expectedQuery, SearchQueryOperator expectedOp) {
+        final SearchQueryOperator defaultOperator = type == SearchQueryField.Type.STRING ? SearchQueryParser.DEFAULT_STRING_OPERATOR : SearchQueryParser.DEFAULT_OPERATOR;
+        final Pair<String, SearchQueryOperator> pair = parser.extractOperator(query, defaultOperator);
         assertThat(pair.getLeft()).isEqualTo(expectedQuery);
         assertThat(pair.getRight()).isEqualTo(expectedOp);
     }
@@ -185,7 +195,7 @@ public class SearchQueryParserTest {
         final SearchQueryParser parser = new SearchQueryParser("defaultfield", fields);
 
         final SearchQueryParser.FieldValue v1 = parser.createFieldValue(fields.get("id"), "abc", false);
-        assertThat(v1.getOperator()).isEqualTo(SearchQueryParser.DEFAULT_OPERATOR);
+        assertThat(v1.getOperator()).isEqualTo(SearchQueryParser.DEFAULT_STRING_OPERATOR);
         assertThat(v1.getValue()).isEqualTo("abc");
         assertThat(v1.isNegate()).isFalse();
 


### PR DESCRIPTION
This PR adds support for querying `int` values in `SearchQuery`, and adapts the default search operator, so that users can still find `int` and `Date` values even if they don't specify an operator.

With the changes, these are the default operators:
- `foo` -> Behaves like before the changes
- `string_field:foo` -> Behaves like before the changes
- `int_field:0` -> Uses an `equals` operator to find `0` in `int_field`
- `date_field:2018-04-18T12:15:00Z` -> Uses an `equals` operator to find `2018-04-18T12:15:00Z` in `date_field`