### PR TITLE
Fixing typo in proptypes.

### DIFF
--- a/graylog2-web-interface/src/pages/EditTokensPage.jsx
+++ b/graylog2-web-interface/src/pages/EditTokensPage.jsx
@@ -16,7 +16,7 @@ const EditTokensPage = createReactClass({
   mixins: [Reflux.connect(CurrentUserStore), PermissionsMixin],
 
   propTypes: {
-    params: PropTypes.object.isRequiered,
+    params: PropTypes.object.isRequired,
   },
 
   getInitialState() {


### PR DESCRIPTION
This PR is fixing a small typo in the prop types of the `EditTokensPage` component.