### PR TITLE
Cleanup node_modules in plugins like we do in the main web interface

### DIFF
--- a/graylog-plugin-parent/pom.xml
+++ b/graylog-plugin-parent/pom.xml
@@ -102,6 +102,7 @@
                             <directory>${basedir}</directory>
                             <includes>
                                 <include>build/**/*</include>
+                                <include>node_modules/**/*</include>
                             </includes>
                             <followSymlinks>false</followSymlinks>
                         </fileset>


### PR DESCRIPTION
This ensures that a "mvn clean" removes the `node_modules` folder in all plugins.