### PR TITLE
Upgrade to java-grok 0.1.9-graylog to allow commas in date patterns

### DIFF
--- a/graylog2-server/src/test/java/org/graylog2/inputs/extractors/GrokExtractorTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/inputs/extractors/GrokExtractorTest.java
@@ -184,6 +184,24 @@ public class GrokExtractorTest {
     }
 
     @Test
+    public void testDateWithComma() {
+        final GrokExtractor extractor = makeExtractor("%{GREEDY:timestamp;date;yyyy-MM-dd'T'HH:mm:ss,SSSX}");
+        final Extractor.Result[] results = extractor.run("2015-07-31T10:05:36,773Z");
+        assertEquals("ISO date is parsed", 1, results.length);
+        Object value = results[0].getValue();
+        assertTrue(value instanceof Instant);
+        DateTime date = new DateTime(((Instant) value).toEpochMilli(), DateTimeZone.UTC);
+
+        assertEquals(2015, date.getYear());
+        assertEquals(7, date.getMonthOfYear());
+        assertEquals(31, date.getDayOfMonth());
+        assertEquals(10, date.getHourOfDay());
+        assertEquals(5, date.getMinuteOfHour());
+        assertEquals(36, date.getSecondOfMinute());
+        assertEquals(773, date.getMillisOfSecond());
+    }
+
+    @Test
     public void testNamedCapturesOnly() throws Exception {
         final Map<String, Object> config = new HashMap<>();
 

--- a/pom.xml
+++ b/pom.xml
@@ -98,7 +98,7 @@
         <jest.version>2.4.11+jackson</jest.version>
         <gelfclient.version>1.4.1</gelfclient.version>
         <geoip2.version>2.11.0</geoip2.version>
-        <grok.version>0.1.8-graylog</grok.version>
+        <grok.version>0.1.9-graylog</grok.version>
         <guava-retrying.version>2.0.0</guava-retrying.version>
         <guava.version>24.0-jre</guava.version>
         <guice.version>4.2.0</guice.version>


### PR DESCRIPTION
Refs thekrakken/java-grok#97
Refs https://community.graylog.org/t/handling-comma-when-converting-extracted-data-to-date-type/5030