### PR TITLE
Disable automatic retries and replace Jest retries (#4738)

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/indexer/cluster/jest/GraylogJestRetryHandler.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/cluster/jest/GraylogJestRetryHandler.java
@@ -1,0 +1,64 @@
+/**
+ * This file is part of Graylog.
+ *
+ * Graylog is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.graylog2.indexer.cluster.jest;
+
+import com.google.common.base.Preconditions;
+import io.searchbox.client.JestRetryHandler;
+import java.net.SocketException;
+import java.net.UnknownHostException;
+import java.util.Arrays;
+import java.util.Collection;
+import javax.net.ssl.SSLException;
+import org.apache.http.ConnectionClosedException;
+import org.apache.http.client.methods.HttpUriRequest;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class GraylogJestRetryHandler implements JestRetryHandler<HttpUriRequest> {
+    private static final Logger log = LoggerFactory.getLogger(GraylogJestRetryHandler.class);
+
+    private final int retryCount;
+    private final Collection<Class<? extends Exception>> exceptionClasses = Arrays.asList(
+        UnknownHostException.class,
+        SocketException.class,
+        ConnectionClosedException.class,
+        SSLException.class);
+
+    public GraylogJestRetryHandler(int retryCount) {
+        Preconditions.checkArgument(retryCount >= 0, "retryCount must be positive");
+        this.retryCount = retryCount;
+    }
+
+    @Override
+    public boolean retryRequest(Exception exception, int executionCount, HttpUriRequest request) {
+        if (executionCount >= retryCount) {
+            log.debug("Maximum number of retries ({}) for request {} reached (executed {} times) (Reason: {})",
+                retryCount, request, executionCount, exception.getMessage());
+            return false;
+        } else {
+            for (Class<? extends Exception> exceptionClass : exceptionClasses) {
+                if (exceptionClass.isInstance(exception)) {
+                    log.debug("Retrying request {} (Reason: {})", request, exception.getMessage());
+                    return true;
+                }
+            }
+
+            log.debug("Not retrying request {} due to unsupported exception (Reason: {})", request, exception.getMessage());
+            return false;
+        }
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -95,7 +95,7 @@
         <commons-io.version>2.6</commons-io.version>
         <disruptor.version>3.4.0</disruptor.version>
         <elasticsearch.version>5.6.8</elasticsearch.version>
-        <jest.version>2.4.11+jackson</jest.version>
+        <jest.version>2.4.12+jackson</jest.version>
         <gelfclient.version>1.4.1</gelfclient.version>
         <geoip2.version>2.11.0</geoip2.version>
         <grok.version>0.1.8-graylog</grok.version>


### PR DESCRIPTION
* disable automatic retries and replace jest retries

we include all SocketExceptions in the list of retriable errors
this way we will always pick a new server from the list when
there's underlying issues

simply retrying the HTTP request against the same server makes little
sense in a cluster, so we disable that in favor of picking a new host

requires unreleased Jest client (2.4.12-jackson-SNAPSHOT)

* Update to jest-2.4.12+jackson

(cherry picked from commit a25c643e26be61dd4d3453177cc1f1d3352e3004)
