### PR TITLE
Link decorator fixes

### DIFF
--- a/graylog2-web-interface/src/components/search/MessageField.jsx
+++ b/graylog2-web-interface/src/components/search/MessageField.jsx
@@ -4,6 +4,7 @@ import React from 'react';
 import createReactClass from 'create-react-class';
 
 import { MessageFieldDescription } from 'components/search';
+import DecorationStats from 'logic/message/DecorationStats';
 
 const MessageField = createReactClass({
   displayName: 'MessageField',
@@ -18,20 +19,6 @@ const MessageField = createReactClass({
   },
 
   SPECIAL_FIELDS: ['full_message', 'level'],
-
-  _isAdded(key) {
-    const decorationStats = this.props.message.decoration_stats;
-    return decorationStats && decorationStats.added_fields && decorationStats.added_fields[key] !== undefined;
-  },
-
-  _isChanged(key) {
-    const decorationStats = this.props.message.decoration_stats;
-    return decorationStats && decorationStats.changed_fields && decorationStats.changed_fields[key] !== undefined;
-  },
-
-  _isDecorated(key) {
-    return this._isAdded(key) || this._isChanged(key);
-  },
 
   render() {
     const message = this.props.message;
@@ -49,9 +36,8 @@ const MessageField = createReactClass({
                                  fieldName={key}
                                  fieldValue={innerValue}
                                  renderForDisplay={this.props.renderForDisplay}
-                                 disableFieldActions={this._isAdded(key) || this.props.disableFieldActions}
-                                 customFieldActions={this.props.customFieldActions}
-                                 isDecorated={this._isDecorated(key)} />
+                                 disableFieldActions={DecorationStats.isFieldAddedByDecorator(message, key) || this.props.disableFieldActions}
+                                 customFieldActions={this.props.customFieldActions} />
       </span>
     );
   },

--- a/graylog2-web-interface/src/components/search/MessageField.jsx
+++ b/graylog2-web-interface/src/components/search/MessageField.jsx
@@ -34,17 +34,18 @@ const MessageField = createReactClass({
   },
 
   render() {
+    const message = this.props.message;
     let innerValue = this.props.value;
     const key = this.props.fieldName;
     if (this.SPECIAL_FIELDS.indexOf(key) !== -1) {
-      innerValue = this.props.message.fields[key];
+      innerValue = message.fields[key];
     }
 
     return (
       <span>
         <dt key={`${key}Title`}>{key}</dt>
         <MessageFieldDescription key={`${key}Description`}
-                                 message={this.props.message}
+                                 message={message}
                                  fieldName={key}
                                  fieldValue={innerValue}
                                  renderForDisplay={this.props.renderForDisplay}

--- a/graylog2-web-interface/src/components/search/MessageFieldDescription.jsx
+++ b/graylog2-web-interface/src/components/search/MessageFieldDescription.jsx
@@ -49,14 +49,6 @@ class MessageFieldDescription extends React.Component {
     SearchStore.addSearchTerm(this.props.fieldName, this.props.fieldValue);
   };
 
-  _getFieldValue = (isDecorated) => {
-    if (isDecorated && (typeof this.props.fieldValue === 'object') && (this.props.fieldValue.type === 'a')) {
-      const link = this.props.fieldValue.href;
-      return React.createElement('a', { href: link }, link);
-    }
-    return this.props.renderForDisplay(this.props.fieldName);
-  };
-
   _getFormattedTerms = () => {
     const termsMarkup = [];
     this.state.messageTerms.forEach((term, idx) => {
@@ -94,7 +86,7 @@ class MessageFieldDescription extends React.Component {
     return (
       <dd className={className} key={`${fieldName}dd`}>
         {this._getFormattedFieldActions()}
-        <div className="field-value">{this._getFieldValue(isDecorated)}</div>
+        <div className="field-value">{this.props.renderForDisplay(this.props.fieldName)}</div>
         {this._shouldShowTerms() &&
         <Alert bsStyle="info" onDismiss={() => this.setState({ messageTerms: Immutable.Map() })}>
           Field terms: &nbsp;{this._getFormattedTerms()}

--- a/graylog2-web-interface/src/components/search/MessageFieldDescription.jsx
+++ b/graylog2-web-interface/src/components/search/MessageFieldDescription.jsx
@@ -6,6 +6,7 @@ import Immutable from 'immutable';
 import StoreProvider from 'injection/StoreProvider';
 import ActionsProvider from 'injection/ActionsProvider';
 import { DecoratedMessageFieldMarker } from 'components/search';
+import DecorationStats from 'logic/message/DecorationStats';
 import MessageFieldSearchActions from './MessageFieldSearchActions';
 
 const SearchStore = StoreProvider.getStore('Search');
@@ -22,7 +23,6 @@ class MessageFieldDescription extends React.Component {
     renderForDisplay: PropTypes.func.isRequired,
     disableFieldActions: PropTypes.bool,
     customFieldActions: PropTypes.node,
-    isDecorated: PropTypes.bool,
   };
 
   state = {
@@ -49,8 +49,8 @@ class MessageFieldDescription extends React.Component {
     SearchStore.addSearchTerm(this.props.fieldName, this.props.fieldValue);
   };
 
-  _getFieldValue = () => {
-    if (this.props.isDecorated && (typeof this.props.fieldValue === 'object') && (this.props.fieldValue.type === 'a')) {
+  _getFieldValue = (isDecorated) => {
+    if (isDecorated && (typeof this.props.fieldValue === 'object') && (this.props.fieldValue.type === 'a')) {
       const link = this.props.fieldValue.href;
       return React.createElement('a', { href: link }, link);
     }
@@ -89,17 +89,18 @@ class MessageFieldDescription extends React.Component {
   render() {
     const fieldName = this.props.fieldName;
     const className = fieldName === 'message' || fieldName === 'full_message' ? 'message-field' : '';
+    const isDecorated = DecorationStats.isFieldDecorated(this.props.message, fieldName);
 
     return (
       <dd className={className} key={`${fieldName}dd`}>
         {this._getFormattedFieldActions()}
-        <div className="field-value">{this._getFieldValue()}</div>
+        <div className="field-value">{this._getFieldValue(isDecorated)}</div>
         {this._shouldShowTerms() &&
         <Alert bsStyle="info" onDismiss={() => this.setState({ messageTerms: Immutable.Map() })}>
           Field terms: &nbsp;{this._getFormattedTerms()}
         </Alert>
         }
-        {this.props.isDecorated && <DecoratedMessageFieldMarker />}
+        {isDecorated && <DecoratedMessageFieldMarker />}
       </dd>
     );
   }

--- a/graylog2-web-interface/src/components/search/MessageFieldDescription.jsx
+++ b/graylog2-web-interface/src/components/search/MessageFieldDescription.jsx
@@ -4,16 +4,15 @@ import { Alert } from 'react-bootstrap';
 import Immutable from 'immutable';
 
 import StoreProvider from 'injection/StoreProvider';
+import ActionsProvider from 'injection/ActionsProvider';
+import { DecoratedMessageFieldMarker } from 'components/search';
+import MessageFieldSearchActions from './MessageFieldSearchActions';
+
 const SearchStore = StoreProvider.getStore('Search');
 // eslint-disable-next-line no-unused-vars
 const MessagesStore = StoreProvider.getStore('Messages');
-
-import ActionsProvider from 'injection/ActionsProvider';
 const MessagesActions = ActionsProvider.getActions('Messages');
 
-import MessageFieldSearchActions from './MessageFieldSearchActions';
-
-import { DecoratedMessageFieldMarker } from 'components/search';
 
 class MessageFieldDescription extends React.Component {
   static propTypes = {
@@ -88,10 +87,11 @@ class MessageFieldDescription extends React.Component {
   };
 
   render() {
-    const className = this.props.fieldName === 'message' || this.props.fieldName === 'full_message' ? 'message-field' : '';
+    const fieldName = this.props.fieldName;
+    const className = fieldName === 'message' || fieldName === 'full_message' ? 'message-field' : '';
 
     return (
-      <dd className={className} key={`${this.props.fieldName}dd`}>
+      <dd className={className} key={`${fieldName}dd`}>
         {this._getFormattedFieldActions()}
         <div className="field-value">{this._getFieldValue()}</div>
         {this._shouldShowTerms() &&

--- a/graylog2-web-interface/src/components/search/MessageFieldDescription.jsx
+++ b/graylog2-web-interface/src/components/search/MessageFieldDescription.jsx
@@ -51,7 +51,7 @@ class MessageFieldDescription extends React.Component {
   };
 
   _getFieldValue = () => {
-    if (this.props.isDecorated && ('type' in this.props.fieldValue) && (this.props.fieldValue.type === 'a')) {
+    if (this.props.isDecorated && (typeof this.props.fieldValue === 'object') && (this.props.fieldValue.type === 'a')) {
       const link = this.props.fieldValue.href;
       return React.createElement('a', { href: link }, link);
     }

--- a/graylog2-web-interface/src/components/search/MessageTableEntry.jsx
+++ b/graylog2-web-interface/src/components/search/MessageTableEntry.jsx
@@ -4,10 +4,11 @@ import Immutable from 'immutable';
 import ImmutablePropTypes from 'react-immutable-proptypes';
 import { Popover, OverlayTrigger } from 'react-bootstrap';
 
-import MessageDetail from './MessageDetail';
 import { Timestamp } from 'components/common';
 import StringUtils from 'util/StringUtils';
 import DateTime from 'logic/datetimes/DateTime';
+import DecorationStats from 'logic/message/DecorationStats';
+import MessageDetail from './MessageDetail';
 import style from './MessageTableEntry.css';
 
 class MessageTableEntry extends React.Component {
@@ -123,6 +124,12 @@ class MessageTableEntry extends React.Component {
 
   renderForDisplay = (fieldName, truncate) => {
     const fullOrigValue = this.props.message.fields[fieldName];
+    const isDecorated = DecorationStats.isFieldDecorated(this.props.message, fieldName);
+
+    if (isDecorated && (typeof fullOrigValue === 'object') && (fullOrigValue.type === 'a')) {
+      const link = fullOrigValue.href;
+      return React.createElement('a', { href: link }, link);
+    }
 
     if (fullOrigValue === undefined) {
       return '';

--- a/graylog2-web-interface/src/components/search/MessageTableEntry.jsx
+++ b/graylog2-web-interface/src/components/search/MessageTableEntry.jsx
@@ -65,22 +65,6 @@ class MessageTableEntry extends React.Component {
     return false;
   }
 
-  renderForDisplay = (fieldName, truncate) => {
-    const fullOrigValue = this.props.message.fields[fieldName];
-
-    if (fullOrigValue === undefined) {
-      return '';
-    }
-
-    /* Timestamp can not be highlighted by elastic search. So we can safely
-     * skip them from highlighting. */
-    if (fieldName === 'timestamp') {
-      return this._toTimestamp(fullOrigValue);
-    } else {
-      return this.possiblyHighlight(fieldName, fullOrigValue, truncate);
-    }
-  };
-
   possiblyHighlight = (fieldName, fullOrigValue, truncate) => {
     // Ensure the field is a string for later processing
     const fullStringOrigValue = StringUtils.stringify(fullOrigValue);
@@ -135,6 +119,22 @@ class MessageTableEntry extends React.Component {
         </OverlayTrigger>
       </span>
     );
+  };
+
+  renderForDisplay = (fieldName, truncate) => {
+    const fullOrigValue = this.props.message.fields[fieldName];
+
+    if (fullOrigValue === undefined) {
+      return '';
+    }
+
+    /* Timestamp can not be highlighted by elastic search. So we can safely
+     * skip them from highlighting. */
+    if (fieldName === 'timestamp') {
+      return this._toTimestamp(fullOrigValue);
+    } else {
+      return this.possiblyHighlight(fieldName, fullOrigValue, truncate);
+    }
   };
 
   render() {

--- a/graylog2-web-interface/src/logic/message/DecorationStats.js
+++ b/graylog2-web-interface/src/logic/message/DecorationStats.js
@@ -1,0 +1,17 @@
+const DecorationStats = {
+  isFieldAddedByDecorator(message, fieldName) {
+    const decorationStats = message.decoration_stats;
+    return decorationStats && decorationStats.added_fields && decorationStats.added_fields[fieldName] !== undefined;
+  },
+
+  isFieldChangedByDecorator(message, fieldName) {
+    const decorationStats = message.decoration_stats;
+    return decorationStats && decorationStats.changed_fields && decorationStats.changed_fields[fieldName] !== undefined;
+  },
+
+  isFieldDecorated(message, fieldName) {
+    return this.isFieldAddedByDecorator(message, fieldName) || this.isFieldChangedByDecorator(message, fieldName);
+  },
+};
+
+export default DecorationStats;


### PR DESCRIPTION
After merging #4669, I realised that there were a couple of problems left:

- Fields decorated with decorators other than `LinkFieldDecorator` threw an error, as we used the `in` decorator to see if we needed to render a link for them, but that operator is only available in objects. I fixed that condition in here, to ensure it works in other decorated fields
- Fields using the `LinkFieldDecorator` were not decorated when being rendered in the message table, as the logic to decorate the field was in the message details. To fix this, I moved the logic up the component tree, and used the already existing `renderForDisplay` function to render the field

<img width="1260" alt="screen shot 2018-04-19 at 18 04 05" src="https://user-images.githubusercontent.com/716185/39003865-15dec7d8-43fc-11e8-830f-eaa47bc5cede.png">
