### PR TITLE
Implement HTTP proxy server authentication in OkHttpClientProvider

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/shared/bindings/providers/OkHttpClientProvider.java
+++ b/graylog2-server/src/main/java/org/graylog2/shared/bindings/providers/OkHttpClientProvider.java
@@ -113,7 +113,6 @@ public class OkHttpClientProvider implements Provider<OkHttpClient> {
             if (!isNullOrEmpty(httpProxyUri.getUserInfo())) {
                 final List<String> list = Splitter.on(":")
                         .limit(2)
-                        .omitEmptyStrings()
                         .splitToList(httpProxyUri.getUserInfo());
                 if (list.size() == 2) {
                     clientBuilder.proxyAuthenticator(new ProxyAuthenticator(list.get(0), list.get(1)));

--- a/graylog2-server/src/main/java/org/graylog2/shared/bindings/providers/OkHttpClientProvider.java
+++ b/graylog2-server/src/main/java/org/graylog2/shared/bindings/providers/OkHttpClientProvider.java
@@ -45,6 +45,7 @@ import java.net.UnknownHostException;
 import java.util.List;
 
 import static com.google.common.base.Strings.isNullOrEmpty;
+import static com.google.common.net.HttpHeaders.PROXY_AUTHORIZATION;
 import static java.util.Objects.requireNonNull;
 
 /**
@@ -121,7 +122,6 @@ public class OkHttpClientProvider implements Provider<OkHttpClient> {
     }
 
     public static class ProxyAuthenticator implements Authenticator {
-        private static final String PROXY_AUTHORIZATION = "Proxy-Authorization";
         private final String credentials;
 
         ProxyAuthenticator(String user, String password) {

--- a/graylog2-server/src/main/java/org/graylog2/shared/bindings/providers/OkHttpClientProvider.java
+++ b/graylog2-server/src/main/java/org/graylog2/shared/bindings/providers/OkHttpClientProvider.java
@@ -131,7 +131,7 @@ public class OkHttpClientProvider implements Provider<OkHttpClient> {
         private final String credentials;
 
         ProxyAuthenticator(String user, String password) {
-            this.credentials = Credentials.basic(requireNonNull(user), requireNonNull(password));
+            this.credentials = Credentials.basic(requireNonNull(user, "user"), requireNonNull(password, "password"));
         }
 
         @Nullable

--- a/graylog2-server/src/test/java/org/graylog2/shared/bindings/providers/OkHttpClientProviderTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/shared/bindings/providers/OkHttpClientProviderTest.java
@@ -1,0 +1,192 @@
+/**
+ * This file is part of Graylog.
+ *
+ * Graylog is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.graylog2.shared.bindings.providers;
+
+import com.github.joschi.jadconfig.util.Duration;
+import com.google.common.net.HttpHeaders;
+import okhttp3.Credentials;
+import okhttp3.OkHttpClient;
+import okhttp3.Request;
+import okhttp3.Response;
+import okhttp3.ResponseBody;
+import okhttp3.mockwebserver.MockResponse;
+import okhttp3.mockwebserver.MockWebServer;
+import okhttp3.mockwebserver.RecordedRequest;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.net.Proxy;
+import java.net.URI;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class OkHttpClientProviderTest {
+    private final MockWebServer server = new MockWebServer();
+
+    @Before
+    public void setUp() throws IOException {
+        server.start();
+    }
+
+    @After
+    public void tearDown() throws IOException {
+        server.shutdown();
+    }
+
+    @Test
+    public void useProxyOnlyForExternalTargets() {
+        final OkHttpClient client = client(server.url("/").uri());
+        assertThat(client.proxySelector().select(URI.create("http://127.0.0.1/")))
+                .hasSize(1)
+                .first()
+                .matches(proxy -> proxy.type() == Proxy.Type.DIRECT);
+        assertThat(client.proxySelector().select(URI.create("http://www.example.com/")))
+                .hasSize(1)
+                .first()
+                .matches(proxy -> proxy.equals(server.toProxyAddress()));
+    }
+
+    @Test
+    public void testSuccessfulConnectionWithoutProxy() throws IOException, InterruptedException {
+        server.enqueue(successfulMockResponse());
+
+        final Request request = new Request.Builder().url(server.url("/")).get().build();
+        final Response response = client(null).newCall(request).execute();
+        assertThat(response.isSuccessful()).isTrue();
+        final ResponseBody body = response.body();
+        assertThat(body).isNotNull();
+        assertThat(body.string()).isEqualTo("Test");
+
+        assertThat(server.getRequestCount()).isEqualTo(1);
+        final RecordedRequest recordedRequest = server.takeRequest();
+        assertThat(recordedRequest.getMethod()).isEqualTo("GET");
+        assertThat(recordedRequest.getPath()).isEqualTo("/");
+    }
+
+    @Test
+    public void testSuccessfulProxyConnectionWithoutAuthentication() throws IOException, InterruptedException {
+        server.enqueue(successfulMockResponse());
+
+        final Response response = client(server.url("/").uri()).newCall(request()).execute();
+        assertThat(response.isSuccessful()).isTrue();
+        final ResponseBody body = response.body();
+        assertThat(body).isNotNull();
+        assertThat(body.string()).isEqualTo("Test");
+
+        assertThat(server.getRequestCount()).isEqualTo(1);
+        final RecordedRequest recordedRequest = server.takeRequest();
+        assertThat(recordedRequest.getMethod()).isEqualTo("GET");
+        assertThat(recordedRequest.getPath()).isEqualTo("http://www.example.com/");
+        assertThat(recordedRequest.getHeader(HttpHeaders.HOST)).isEqualTo("www.example.com");
+    }
+
+    @Test
+    public void testSuccessfulProxyConnectionWithAuthentication() throws IOException, InterruptedException {
+        server.enqueue(proxyAuthenticateMockResponse());
+        server.enqueue(successfulMockResponse());
+
+        final URI proxyURI = URI.create("http://user:password@" + server.getHostName() + ":" + server.getPort());
+        final Response response = client(proxyURI).newCall(request()).execute();
+        assertThat(response.isSuccessful()).isTrue();
+        final ResponseBody body = response.body();
+        assertThat(body).isNotNull();
+        assertThat(body.string()).isEqualTo("Test");
+
+        assertThat(server.getRequestCount()).isEqualTo(2);
+        final RecordedRequest unauthenticatedRequest = server.takeRequest();
+        assertThat(unauthenticatedRequest.getMethod()).isEqualTo("GET");
+        assertThat(unauthenticatedRequest.getPath()).isEqualTo("http://www.example.com/");
+        assertThat(unauthenticatedRequest.getHeader(HttpHeaders.HOST)).isEqualTo("www.example.com");
+        assertThat(unauthenticatedRequest.getHeader(HttpHeaders.PROXY_AUTHORIZATION)).isNull();
+        final RecordedRequest authenticatedRequest = server.takeRequest();
+        assertThat(authenticatedRequest.getMethod()).isEqualTo("GET");
+        assertThat(authenticatedRequest.getPath()).isEqualTo("http://www.example.com/");
+        assertThat(authenticatedRequest.getHeader(HttpHeaders.HOST)).isEqualTo("www.example.com");
+        assertThat(authenticatedRequest.getHeader(HttpHeaders.PROXY_AUTHORIZATION)).isEqualTo(Credentials.basic("user", "password"));
+    }
+
+    @Test
+    public void testFailingProxyConnectionWithoutAuthentication() throws IOException, InterruptedException {
+        server.enqueue(failedMockResponse());
+
+        final URI proxyURI = URI.create("http://" + server.getHostName() + ":" + server.getPort());
+        final Response response = client(proxyURI).newCall(request()).execute();
+        assertThat(response.isSuccessful()).isFalse();
+        final ResponseBody body = response.body();
+        assertThat(body).isNotNull();
+        assertThat(body.string()).isEqualTo("Failed");
+
+        assertThat(server.getRequestCount()).isEqualTo(1);
+        final RecordedRequest recordedRequest = server.takeRequest();
+        assertThat(recordedRequest.getMethod()).isEqualTo("GET");
+        assertThat(recordedRequest.getPath()).isEqualTo("http://www.example.com/");
+        assertThat(recordedRequest.getHeader(HttpHeaders.HOST)).isEqualTo("www.example.com");
+    }
+
+    @Test
+    public void testFailingProxyConnectionWithAuthentication() throws IOException, InterruptedException {
+        server.enqueue(proxyAuthenticateMockResponse());
+        server.enqueue(failedMockResponse());
+
+        final URI proxyURI = server.url("/").newBuilder().username("user").password("password").build().uri();
+        final Response response = client(proxyURI).newCall(request()).execute();
+        assertThat(response.isSuccessful()).isFalse();
+        final ResponseBody body = response.body();
+        assertThat(body).isNotNull();
+        assertThat(body.string()).isEqualTo("Failed");
+
+        assertThat(server.getRequestCount()).isEqualTo(2);
+        final RecordedRequest unauthenticatedRequest = server.takeRequest();
+        assertThat(unauthenticatedRequest.getMethod()).isEqualTo("GET");
+        assertThat(unauthenticatedRequest.getPath()).isEqualTo("http://www.example.com/");
+        assertThat(unauthenticatedRequest.getHeader(HttpHeaders.HOST)).isEqualTo("www.example.com");
+        assertThat(unauthenticatedRequest.getHeader(HttpHeaders.PROXY_AUTHORIZATION)).isNull();
+        final RecordedRequest authenticatedRequest = server.takeRequest();
+        assertThat(authenticatedRequest.getMethod()).isEqualTo("GET");
+        assertThat(authenticatedRequest.getPath()).isEqualTo("http://www.example.com/");
+        assertThat(authenticatedRequest.getHeader(HttpHeaders.HOST)).isEqualTo("www.example.com");
+        assertThat(authenticatedRequest.getHeader(HttpHeaders.PROXY_AUTHORIZATION)).isEqualTo(Credentials.basic("user", "password"));
+    }
+
+    private MockResponse successfulMockResponse() {
+        return new MockResponse().setResponseCode(200).setBody("Test");
+    }
+
+    private MockResponse failedMockResponse() {
+        return new MockResponse().setResponseCode(400).setBody("Failed");
+    }
+
+    private MockResponse proxyAuthenticateMockResponse() {
+        return new MockResponse().setResponseCode(407).addHeader(HttpHeaders.PROXY_AUTHENTICATE, "Basic");
+    }
+
+    private OkHttpClient client(URI proxyURI) {
+        final OkHttpClientProvider provider = new OkHttpClientProvider(
+                Duration.milliseconds(100L),
+                Duration.milliseconds(100L),
+                Duration.milliseconds(100L),
+                proxyURI);
+
+        return provider.get();
+    }
+
+    private Request request() {
+        return new Request.Builder().url("http://www.example.com/").get().build();
+    }
+}

--- a/misc/graylog.conf
+++ b/misc/graylog.conf
@@ -572,6 +572,9 @@ mongodb_threads_allowed_to_block_multiplier = 5
 #http_write_timeout = 10s
 
 # HTTP proxy for outgoing HTTP connections
+# Examples:
+#   - http://proxy.example.com:8123
+#   - http://username:password@proxy.example.com:8123
 #http_proxy_uri =
 
 # Disable the optimization of Elasticsearch indices after index cycling. This may take some load from Elasticsearch


### PR DESCRIPTION
This makes it possible to use a proxy server in `http_proxy_uri` that requires authentication.

Fixes #4594 

**Note:** This needs to be cherry picked into 2.4