### PR TITLE
 Make sure to reload the default stream if it has been changed

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/bindings/ServerBindings.java
+++ b/graylog2-server/src/main/java/org/graylog2/bindings/ServerBindings.java
@@ -77,6 +77,7 @@ import org.graylog2.shared.journal.NoopJournalModule;
 import org.graylog2.shared.metrics.jersey2.MetricsDynamicBinding;
 import org.graylog2.shared.security.RestrictToMasterFeature;
 import org.graylog2.shared.system.activities.ActivityWriter;
+import org.graylog2.streams.DefaultStreamChangeHandler;
 import org.graylog2.streams.StreamRouter;
 import org.graylog2.streams.StreamRouterEngine;
 import org.graylog2.system.activities.SystemMessageActivityWriter;
@@ -142,6 +143,7 @@ public class ServerBindings extends Graylog2Module {
 
         install(new FactoryModuleBuilder().build(ProcessBufferProcessor.Factory.class));
         bind(Stream.class).annotatedWith(DefaultStream.class).toProvider(DefaultStreamProvider.class);
+        bind(DefaultStreamChangeHandler.class).asEagerSingleton();
     }
 
     private void bindSingletons() {

--- a/graylog2-server/src/main/java/org/graylog2/bindings/providers/DefaultStreamProvider.java
+++ b/graylog2-server/src/main/java/org/graylog2/bindings/providers/DefaultStreamProvider.java
@@ -42,6 +42,11 @@ public class DefaultStreamProvider implements Provider<Stream> {
         this.service = service;
     }
 
+    public void setDefaultStream(Stream defaultStream) {
+        LOG.debug("Setting new default stream: {}", defaultStream);
+        this.sharedInstance.set(defaultStream);
+    }
+
     @Override
     public Stream get() {
         Stream defaultStream = sharedInstance.get();

--- a/graylog2-server/src/main/java/org/graylog2/streams/DefaultStreamChangeHandler.java
+++ b/graylog2-server/src/main/java/org/graylog2/streams/DefaultStreamChangeHandler.java
@@ -1,0 +1,69 @@
+/**
+ * This file is part of Graylog.
+ *
+ * Graylog is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.graylog2.streams;
+
+import com.google.common.eventbus.EventBus;
+import com.google.common.eventbus.Subscribe;
+import org.graylog2.bindings.providers.DefaultStreamProvider;
+import org.graylog2.plugin.streams.Stream;
+import org.graylog2.streams.events.StreamsChangedEvent;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.inject.Inject;
+import javax.inject.Singleton;
+
+/**
+ * This class subscribes to all {@link StreamsChangedEvent} events and reloads the default stream if it has changed.
+ *
+ * We need this because the default Stream instance is only loaded once when it is first accessed. (see {@link DefaultStreamProvider#get()})
+ * Without this, changes to the default stream would only be applied after a server restart.
+ */
+@Singleton
+public class DefaultStreamChangeHandler {
+    private static final Logger LOG = LoggerFactory.getLogger(DefaultStreamChangeHandler.class);
+
+    private final StreamService streamService;
+    private final DefaultStreamProvider defaultStreamProvider;
+
+    @Inject
+    public DefaultStreamChangeHandler(StreamService streamService,
+                                      DefaultStreamProvider defaultStreamProvider,
+                                      EventBus eventBus) {
+        this.streamService = streamService;
+        this.defaultStreamProvider = defaultStreamProvider;
+
+        // TODO: This class needs lifecycle management to avoid leaking objects in the EventBus
+        eventBus.register(this);
+    }
+
+    @Subscribe
+    public void handleStreamsChange(StreamsChangedEvent event) {
+        event.streamIds().stream()
+                .filter(Stream.DEFAULT_STREAM_ID::equals)
+                .findFirst().ifPresent(streamId -> reloadDefaultStream());
+    }
+
+    private void reloadDefaultStream() {
+        try {
+            LOG.debug("Attempting to reload and set default stream");
+            defaultStreamProvider.setDefaultStream(streamService.load(Stream.DEFAULT_STREAM_ID));
+        } catch (Exception e) {
+            LOG.error("Couldn't reload default stream", e);
+        }
+    }
+}

--- a/graylog2-server/src/test/java/org/graylog2/streams/StreamServiceImplTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/streams/StreamServiceImplTest.java
@@ -22,6 +22,7 @@ import com.lordofthejars.nosqlunit.mongodb.InMemoryMongoDb;
 import org.graylog2.alarmcallbacks.AlarmCallbackConfigurationService;
 import org.graylog2.alerts.AlertService;
 import org.graylog2.database.MongoConnectionRule;
+import org.graylog2.events.ClusterEventBus;
 import org.graylog2.indexer.MongoIndexSet;
 import org.graylog2.indexer.indexset.IndexSetService;
 import org.graylog2.notifications.NotificationService;
@@ -68,7 +69,7 @@ public class StreamServiceImplTest {
     @Before
     public void setUp() throws Exception {
         this.streamService = new StreamServiceImpl(mongoRule.getMongoConnection(), streamRuleService, alertService,
-            outputService, indexSetService, factory, notificationService, alarmCallbackConfigurationService);
+            outputService, indexSetService, factory, notificationService, new ClusterEventBus(), alarmCallbackConfigurationService);
     }
 
     @Test


### PR DESCRIPTION
Without this, changes to the default stream would not become active until a server restart because the default stream is only loaded once when it's first accessed. (see DefaultStreamProvider)

Fixes #4747

**Note:** This needs to be cherry picked into 2.4 once merged