### PR TITLE
Explicitly close MongoDB cursors after use

### DIFF
--- a/graylog2-server/src/main/java/org/graylog/plugins/pipelineprocessor/db/mongodb/MongoDbPipelineService.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/pipelineprocessor/db/mongodb/MongoDbPipelineService.java
@@ -16,7 +16,7 @@
  */
 package org.graylog.plugins.pipelineprocessor.db.mongodb;
 
-import com.google.common.collect.Sets;
+import com.google.common.collect.ImmutableSet;
 import com.mongodb.BasicDBObject;
 import com.mongodb.MongoException;
 import org.graylog.plugins.pipelineprocessor.db.PipelineDao;
@@ -69,9 +69,8 @@ public class MongoDbPipelineService implements PipelineService {
 
     @Override
     public Collection<PipelineDao> loadAll() {
-        try {
-            final DBCursor<PipelineDao> daos = dbCollection.find();
-            return Sets.newHashSet(daos.iterator());
+        try (DBCursor<PipelineDao> daos = dbCollection.find()) {
+            return ImmutableSet.copyOf((Iterable<PipelineDao>) daos);
         } catch (MongoException e) {
             log.error("Unable to load pipelines", e);
             return Collections.emptySet();

--- a/graylog2-server/src/main/java/org/graylog/plugins/pipelineprocessor/db/mongodb/MongoDbPipelineStreamConnectionsService.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/pipelineprocessor/db/mongodb/MongoDbPipelineStreamConnectionsService.java
@@ -16,7 +16,7 @@
  */
 package org.graylog.plugins.pipelineprocessor.db.mongodb;
 
-import com.google.common.collect.Sets;
+import com.google.common.collect.ImmutableSet;
 import com.mongodb.BasicDBObject;
 import com.mongodb.MongoException;
 import org.graylog.plugins.pipelineprocessor.db.PipelineStreamConnectionsService;
@@ -78,9 +78,8 @@ public class MongoDbPipelineStreamConnectionsService implements PipelineStreamCo
 
     @Override
     public Set<PipelineConnections> loadAll() {
-        try {
-            final DBCursor<PipelineConnections> connections = dbCollection.find();
-            return Sets.newHashSet(connections.iterator());
+        try (DBCursor<PipelineConnections> connections = dbCollection.find()) {
+            return ImmutableSet.copyOf((Iterable<PipelineConnections>) connections);
         } catch (MongoException e) {
             log.error("Unable to load pipeline connections", e);
             return Collections.emptySet();

--- a/graylog2-server/src/main/java/org/graylog/plugins/pipelineprocessor/db/mongodb/MongoDbRuleService.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/pipelineprocessor/db/mongodb/MongoDbRuleService.java
@@ -16,8 +16,7 @@
  */
 package org.graylog.plugins.pipelineprocessor.db.mongodb;
 
-import com.google.common.collect.ImmutableList;
-import com.google.common.collect.Sets;
+import com.google.common.collect.ImmutableSet;
 import com.mongodb.BasicDBObject;
 import com.mongodb.MongoException;
 import org.graylog.plugins.pipelineprocessor.db.RuleDao;
@@ -74,9 +73,8 @@ public class MongoDbRuleService implements RuleService {
 
     @Override
     public Collection<RuleDao> loadAll() {
-        try {
-            final DBCursor<RuleDao> ruleDaos = dbCollection.find().sort(DBSort.asc("title"));
-            return ruleDaos.toArray();
+        try(DBCursor<RuleDao> ruleDaos = dbCollection.find().sort(DBSort.asc("title"))) {
+            return ImmutableSet.copyOf((Iterable<RuleDao>) ruleDaos);
         } catch (MongoException e) {
             log.error("Unable to load processing rules", e);
             return Collections.emptySet();
@@ -93,9 +91,8 @@ public class MongoDbRuleService implements RuleService {
 
     @Override
     public Collection<RuleDao> loadNamed(Collection<String> ruleNames) {
-        try {
-            final DBCursor<RuleDao> ruleDaos = dbCollection.find(DBQuery.in("title", ruleNames));
-            return Sets.newHashSet(ruleDaos.iterator());
+        try (DBCursor<RuleDao> ruleDaos = dbCollection.find(DBQuery.in("title", ruleNames))) {
+            return ImmutableSet.copyOf((Iterable<RuleDao>) ruleDaos);
         } catch (MongoException e) {
             log.error("Unable to bulk load rules", e);
             return Collections.emptySet();

--- a/graylog2-server/src/main/java/org/graylog2/bundles/BundleService.java
+++ b/graylog2-server/src/main/java/org/graylog2/bundles/BundleService.java
@@ -16,7 +16,7 @@
  */
 package org.graylog2.bundles;
 
-import com.google.common.collect.Iterators;
+import com.google.common.collect.ImmutableSet;
 import org.bson.types.ObjectId;
 import org.graylog2.bindings.providers.BundleExporterProvider;
 import org.graylog2.bindings.providers.BundleImporterProvider;
@@ -31,7 +31,6 @@ import org.mongojack.WriteResult;
 
 import javax.inject.Inject;
 import javax.inject.Singleton;
-import java.util.HashSet;
 import java.util.Set;
 
 @Singleton
@@ -77,14 +76,9 @@ public class BundleService {
     }
 
     public Set<ConfigurationBundle> loadAll() {
-        final DBCursor<ConfigurationBundle> ConfigurationBundles = dbCollection.find();
-        final Set<ConfigurationBundle> bundles = new HashSet<>();
-
-        if (ConfigurationBundles.hasNext()) {
-            Iterators.addAll(bundles, ConfigurationBundles);
+        try (DBCursor<ConfigurationBundle> configurationBundles = dbCollection.find()) {
+            return ImmutableSet.copyOf((Iterable<ConfigurationBundle>) configurationBundles);
         }
-
-        return bundles;
     }
 
     public boolean update(final String bundleId, final ConfigurationBundle bundle) {

--- a/graylog2-server/src/main/java/org/graylog2/cluster/ClusterConfigServiceImpl.java
+++ b/graylog2-server/src/main/java/org/graylog2/cluster/ClusterConfigServiceImpl.java
@@ -150,16 +150,17 @@ public class ClusterConfigServiceImpl implements ClusterConfigService {
 
     @Override
     public Set<Class<?>> list() {
-        final DBCursor<ClusterConfig> clusterConfigs = dbCollection.find();
         final ImmutableSet.Builder<Class<?>> classes = ImmutableSet.builder();
 
-        for (ClusterConfig clusterConfig : clusterConfigs) {
-            final String type = clusterConfig.type();
-            try {
-                final Class<?> cls = chainingClassLoader.loadClass(type);
-                classes.add(cls);
-            } catch (ClassNotFoundException e) {
-                LOG.debug("Couldn't find configuration class \"{}\"", type, e);
+        try (DBCursor<ClusterConfig> clusterConfigs = dbCollection.find()) {
+            for (ClusterConfig clusterConfig : clusterConfigs) {
+                final String type = clusterConfig.type();
+                try {
+                    final Class<?> cls = chainingClassLoader.loadClass(type);
+                    classes.add(cls);
+                } catch (ClassNotFoundException e) {
+                    LOG.debug("Couldn't find configuration class \"{}\"", type, e);
+                }
             }
         }
 

--- a/graylog2-server/src/main/java/org/graylog2/events/ClusterEventPeriodical.java
+++ b/graylog2-server/src/main/java/org/graylog2/events/ClusterEventPeriodical.java
@@ -141,10 +141,8 @@ public class ClusterEventPeriodical extends Periodical {
 
     @Override
     public void doRun() {
-        try {
-            LOG.debug("Opening MongoDB cursor on \"{}\"", COLLECTION_NAME);
-
-            final DBCursor<ClusterEvent> cursor = eventCursor(nodeId);
+        LOG.debug("Opening MongoDB cursor on \"{}\"", COLLECTION_NAME);
+        try (DBCursor<ClusterEvent> cursor = eventCursor(nodeId)) {
             if (LOG.isTraceEnabled()) {
                 LOG.trace("MongoDB query plan: {}", cursor.explain());
             }

--- a/graylog2-server/src/main/java/org/graylog2/grok/MongoDbGrokPatternService.java
+++ b/graylog2-server/src/main/java/org/graylog2/grok/MongoDbGrokPatternService.java
@@ -18,8 +18,7 @@ package org.graylog2.grok;
 
 import com.google.common.base.Strings;
 import com.google.common.collect.ImmutableList;
-import com.google.common.collect.Iterables;
-import com.google.common.collect.Sets;
+import com.google.common.collect.ImmutableSet;
 import io.thekraken.grok.api.GrokCompiler;
 import io.thekraken.grok.api.exception.GrokException;
 import org.bson.types.ObjectId;
@@ -67,10 +66,9 @@ public class MongoDbGrokPatternService implements GrokPatternService {
 
     @Override
     public Set<GrokPattern> loadAll() {
-        final DBCursor<GrokPattern> grokPatterns = dbCollection.find();
-        final Set<GrokPattern> patterns = Sets.newHashSet();
-        Iterables.addAll(patterns, grokPatterns);
-        return patterns;
+        try (DBCursor<GrokPattern> grokPatterns = dbCollection.find()) {
+            return ImmutableSet.copyOf((Iterable<GrokPattern>) grokPatterns);
+        }
     }
 
     @Override

--- a/graylog2-server/src/main/java/org/graylog2/indexer/fieldtypes/IndexFieldTypePollerPeriodical.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/fieldtypes/IndexFieldTypePollerPeriodical.java
@@ -16,6 +16,7 @@
  */
 package org.graylog2.indexer.fieldtypes;
 
+import com.google.common.collect.ImmutableSet;
 import com.google.common.eventbus.EventBus;
 import com.google.common.eventbus.Subscribe;
 import com.google.common.primitives.Ints;
@@ -111,8 +112,7 @@ public class IndexFieldTypePollerPeriodical extends Periodical {
         indexSetService.findAll().forEach(indexSetConfig -> {
             final String indexSetId = indexSetConfig.id();
             final String indexSetTitle = indexSetConfig.title();
-            final Set<IndexFieldTypesDTO> existingIndexTypes = dbService.streamForIndexSet(indexSetId)
-                    .collect(Collectors.toSet());
+            final Set<IndexFieldTypesDTO> existingIndexTypes = ImmutableSet.copyOf(dbService.findForIndexSet(indexSetId));
 
             final IndexSet indexSet = mongoIndexSetFactory.create(indexSetConfig);
 
@@ -126,7 +126,7 @@ public class IndexFieldTypePollerPeriodical extends Periodical {
             }
 
             // Cleanup orphaned field type entries that haven't been removed by the event handler
-            dbService.streamForIndexSet(indexSetId)
+            dbService.findForIndexSet(indexSetId).stream()
                     .filter(types -> !indices.exists(types.indexName()))
                     .forEach(types -> dbService.delete(types.id()));
         });

--- a/graylog2-server/src/main/java/org/graylog2/indexer/fieldtypes/IndexFieldTypesService.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/fieldtypes/IndexFieldTypesService.java
@@ -16,8 +16,8 @@
  */
 package org.graylog2.indexer.fieldtypes;
 
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
-import com.google.common.collect.Streams;
 import com.mongodb.BasicDBObject;
 import org.bson.types.ObjectId;
 import org.graylog2.bindings.providers.MongoJackObjectMapperProvider;
@@ -30,10 +30,9 @@ import javax.inject.Inject;
 import java.util.Collection;
 import java.util.Locale;
 import java.util.Optional;
-import java.util.stream.Stream;
 
 /**
- * Manages the "index_field_Types" MongoDB collection.
+ * Manages the "index_field_types" MongoDB collection.
  */
 public class IndexFieldTypesService {
     private static final String FIELDS_FIELD_NAMES = String.format(Locale.US, "%s.%s", IndexFieldTypesDTO.FIELD_FIELDS, FieldTypeDTO.FIELD_NAME);
@@ -99,28 +98,28 @@ public class IndexFieldTypesService {
         }
     }
 
-    public Stream<IndexFieldTypesDTO> streamForIndexSet(String indexSetId) {
-        return streamQuery(DBQuery.is(IndexFieldTypesDTO.FIELD_INDEX_SET_ID, indexSetId));
+    public Collection<IndexFieldTypesDTO> findForIndexSet(String indexSetId) {
+        return findByQuery(DBQuery.is(IndexFieldTypesDTO.FIELD_INDEX_SET_ID, indexSetId));
     }
 
-    public Stream<IndexFieldTypesDTO> streamForFieldNames(Collection<String> fieldNames) {
-        return streamQuery(DBQuery.in(FIELDS_FIELD_NAMES, fieldNames));
+    public Collection<IndexFieldTypesDTO> findForFieldNames(Collection<String> fieldNames) {
+        return findByQuery(DBQuery.in(FIELDS_FIELD_NAMES, fieldNames));
     }
 
-    public Stream<IndexFieldTypesDTO> streamForFieldNamesAndIndices(Collection<String> fieldNames, Collection<String> indexNames) {
+    public Collection<IndexFieldTypesDTO> findForFieldNamesAndIndices(Collection<String> fieldNames, Collection<String> indexNames) {
         final DBQuery.Query query = DBQuery.and(
                 DBQuery.in(IndexFieldTypesDTO.FIELD_INDEX_NAME, indexNames),
                 DBQuery.in(FIELDS_FIELD_NAMES, fieldNames)
         );
 
-        return streamQuery(query);
+        return findByQuery(query);
     }
 
-    public Stream<IndexFieldTypesDTO> streamAll() {
-        return streamQuery(DBQuery.empty());
+    public Collection<IndexFieldTypesDTO> findAll() {
+        return findByQuery(DBQuery.empty());
     }
 
-    private Stream<IndexFieldTypesDTO> streamQuery(DBQuery.Query query) {
-        return Streams.stream((Iterable<IndexFieldTypesDTO>) db.find(query));
+    private Collection<IndexFieldTypesDTO> findByQuery(DBQuery.Query query) {
+        return ImmutableList.copyOf((Iterable<IndexFieldTypesDTO>) db.find(query));
     }
 }

--- a/graylog2-server/src/main/java/org/graylog2/indexer/fieldtypes/MongoFieldTypeLookup.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/fieldtypes/MongoFieldTypeLookup.java
@@ -168,11 +168,11 @@ public class MongoFieldTypeLookup implements FieldTypeLookup {
         return result.build();
     }
 
-    private Stream<IndexFieldTypesDTO> getTypesStream(Collection<String> fieldNames, Collection<String> indexNames) {
+    private Collection<IndexFieldTypesDTO> getTypesStream(Collection<String> fieldNames, Collection<String> indexNames) {
         if (indexNames.isEmpty()) {
-            return dbService.streamForFieldNames(fieldNames);
+            return dbService.findForFieldNames(fieldNames);
         }
 
-        return dbService.streamForFieldNamesAndIndices(fieldNames, indexNames);
+        return dbService.findForFieldNamesAndIndices(fieldNames, indexNames);
     }
 }

--- a/graylog2-server/src/main/java/org/graylog2/lookup/LookupTableService.java
+++ b/graylog2-server/src/main/java/org/graylog2/lookup/LookupTableService.java
@@ -268,7 +268,7 @@ public class LookupTableService extends AbstractIdleService {
     }
 
     private CountDownLatch createAndStartAdapters() {
-        final Set<LookupDataAdapter> adapters = dbAdapters.streamAll()
+        final Set<LookupDataAdapter> adapters = dbAdapters.findAll().stream()
                 .map(dto -> createAdapter(dto, null))
                 .filter(Objects::nonNull)
                 .collect(Collectors.toSet());
@@ -320,7 +320,7 @@ public class LookupTableService extends AbstractIdleService {
     }
 
     private CountDownLatch createAndStartCaches() {
-        final Set<LookupCache> caches = dbCaches.streamAll()
+        final Set<LookupCache> caches = dbCaches.findAll().stream()
                 .map(dto -> createCache(dto, null))
                 .filter(Objects::nonNull)
                 .collect(Collectors.toSet());

--- a/graylog2-server/src/main/java/org/graylog2/rest/resources/system/MetricsHistoryResource.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/resources/system/MetricsHistoryResource.java
@@ -20,6 +20,7 @@ import com.codahale.metrics.annotation.Timed;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.mongodb.BasicDBObject;
+import com.mongodb.DBCollection;
 import com.mongodb.DBCursor;
 import com.mongodb.DBObject;
 import io.swagger.annotations.Api;
@@ -84,75 +85,75 @@ public class MetricsHistoryResource extends RestResource {
         }
         andQuery.put("$and", obj);
 
-        final DBCursor cursor = mongoConnection.getDatabase().getCollection("graylog2_metrics")
-                .find(andQuery).sort(new BasicDBObject("timestamp", 1));
+        final DBCollection dbCollection = mongoConnection.getDatabase().getCollection("graylog2_metrics");
+        try(DBCursor cursor = dbCollection.find(andQuery).sort(new BasicDBObject("timestamp", 1))) {
+            final Map<String, Object> metricsData = Maps.newHashMap();
+            metricsData.put("name", metricName);
+            final List<Object> values = Lists.newArrayList();
+            metricsData.put("values", values);
 
-        final Map<String, Object> metricsData = Maps.newHashMap();
-        metricsData.put("name", metricName);
-        final List<Object> values = Lists.newArrayList();
-        metricsData.put("values", values);
+            while (cursor.hasNext()) {
+                final DBObject value = cursor.next();
+                metricsData.put("node", value.get("node"));
 
-        while (cursor.hasNext()) {
-            final DBObject value = cursor.next();
-            metricsData.put("node", value.get("node"));
+                final MetricType metricType = MetricType.valueOf(((String) value.get("type")).toUpperCase(Locale.ENGLISH));
+                Map<String, Object> dataPoint = Maps.newHashMap();
+                values.add(dataPoint);
 
-            final MetricType metricType = MetricType.valueOf(((String) value.get("type")).toUpperCase(Locale.ENGLISH));
-            Map<String, Object> dataPoint = Maps.newHashMap();
-            values.add(dataPoint);
+                dataPoint.put("timestamp", value.get("timestamp"));
+                metricsData.put("type", metricType.toString().toLowerCase(Locale.ENGLISH));
 
-            dataPoint.put("timestamp", value.get("timestamp"));
-            metricsData.put("type", metricType.toString().toLowerCase(Locale.ENGLISH));
+                switch (metricType) {
+                    case GAUGE:
+                        final Object gaugeValue = value.get("value");
+                        dataPoint.put("value", gaugeValue);
+                        break;
+                    case COUNTER:
+                        dataPoint.put("count", value.get("count"));
+                        break;
+                    case HISTOGRAM:
+                        dataPoint.put("75-percentile", value.get("75-percentile"));
+                        dataPoint.put("95-percentile", value.get("95-percentile"));
+                        dataPoint.put("98-percentile", value.get("98-percentile"));
+                        dataPoint.put("99-percentile", value.get("99-percentile"));
+                        dataPoint.put("999-percentile", value.get("999-percentile"));
+                        dataPoint.put("max", value.get("max"));
+                        dataPoint.put("min", value.get("min"));
+                        dataPoint.put("mean", value.get("mean"));
+                        dataPoint.put("median", value.get("median"));
+                        dataPoint.put("std_dev", value.get("std_dev"));
+                        break;
+                    case METER:
+                        dataPoint.put("count", value.get("count"));
+                        dataPoint.put("1-minute-rate", value.get("1-minute-rate"));
+                        dataPoint.put("5-minute-rate", value.get("5-minute-rate"));
+                        dataPoint.put("15-minute-rate", value.get("15-minute-rate"));
+                        dataPoint.put("mean-rate", value.get("mean-rate"));
+                        break;
+                    case TIMER:
+                        dataPoint.put("count", value.get("count"));
+                        dataPoint.put("rate-unit", value.get("rate-unit"));
+                        dataPoint.put("1-minute-rate", value.get("1-minute-rate"));
+                        dataPoint.put("5-minute-rate", value.get("5-minute-rate"));
+                        dataPoint.put("15-minute-rate", value.get("15-minute-rate"));
+                        dataPoint.put("mean-rate", value.get("mean-rate"));
+                        dataPoint.put("duration-unit", value.get("duration-unit"));
+                        dataPoint.put("75-percentile", value.get("75-percentile"));
+                        dataPoint.put("95-percentile", value.get("95-percentile"));
+                        dataPoint.put("98-percentile", value.get("98-percentile"));
+                        dataPoint.put("99-percentile", value.get("99-percentile"));
+                        dataPoint.put("999-percentile", value.get("999-percentile"));
+                        dataPoint.put("max", value.get("max"));
+                        dataPoint.put("min", value.get("min"));
+                        dataPoint.put("mean", value.get("mean"));
+                        dataPoint.put("median", value.get("median"));
+                        dataPoint.put("stddev", value.get("stddev"));
+                        break;
+                }
 
-            switch (metricType) {
-                case GAUGE:
-                    final Object gaugeValue = value.get("value");
-                    dataPoint.put("value", gaugeValue);
-                    break;
-                case COUNTER:
-                    dataPoint.put("count", value.get("count"));
-                    break;
-                case HISTOGRAM:
-                    dataPoint.put("75-percentile", value.get("75-percentile"));
-                    dataPoint.put("95-percentile", value.get("95-percentile"));
-                    dataPoint.put("98-percentile", value.get("98-percentile"));
-                    dataPoint.put("99-percentile", value.get("99-percentile"));
-                    dataPoint.put("999-percentile", value.get("999-percentile"));
-                    dataPoint.put("max", value.get("max"));
-                    dataPoint.put("min", value.get("min"));
-                    dataPoint.put("mean", value.get("mean"));
-                    dataPoint.put("median", value.get("median"));
-                    dataPoint.put("std_dev", value.get("std_dev"));
-                    break;
-                case METER:
-                    dataPoint.put("count", value.get("count"));
-                    dataPoint.put("1-minute-rate", value.get("1-minute-rate"));
-                    dataPoint.put("5-minute-rate", value.get("5-minute-rate"));
-                    dataPoint.put("15-minute-rate", value.get("15-minute-rate"));
-                    dataPoint.put("mean-rate", value.get("mean-rate"));
-                    break;
-                case TIMER:
-                    dataPoint.put("count", value.get("count"));
-                    dataPoint.put("rate-unit", value.get("rate-unit"));
-                    dataPoint.put("1-minute-rate", value.get("1-minute-rate"));
-                    dataPoint.put("5-minute-rate", value.get("5-minute-rate"));
-                    dataPoint.put("15-minute-rate", value.get("15-minute-rate"));
-                    dataPoint.put("mean-rate", value.get("mean-rate"));
-                    dataPoint.put("duration-unit", value.get("duration-unit"));
-                    dataPoint.put("75-percentile", value.get("75-percentile"));
-                    dataPoint.put("95-percentile", value.get("95-percentile"));
-                    dataPoint.put("98-percentile", value.get("98-percentile"));
-                    dataPoint.put("99-percentile", value.get("99-percentile"));
-                    dataPoint.put("999-percentile", value.get("999-percentile"));
-                    dataPoint.put("max", value.get("max"));
-                    dataPoint.put("min", value.get("min"));
-                    dataPoint.put("mean", value.get("mean"));
-                    dataPoint.put("median", value.get("median"));
-                    dataPoint.put("stddev", value.get("stddev"));
-                    break;
             }
 
+            return metricsData;
         }
-
-        return metricsData;
     }
 }

--- a/graylog2-server/src/main/java/org/graylog2/streams/OutputServiceImpl.java
+++ b/graylog2-server/src/main/java/org/graylog2/streams/OutputServiceImpl.java
@@ -16,7 +16,7 @@
  */
 package org.graylog2.streams;
 
-import com.google.common.collect.Sets;
+import com.google.common.collect.ImmutableSet;
 import com.mongodb.BasicDBObject;
 import com.mongodb.DBCollection;
 import com.mongodb.DBCursor;
@@ -38,7 +38,6 @@ import org.mongojack.WriteResult;
 
 import javax.inject.Inject;
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
@@ -72,14 +71,9 @@ public class OutputServiceImpl implements OutputService {
 
     @Override
     public Set<Output> loadAll() {
-        return toAbstractSetType(coll.find().toArray());
-    }
-
-    private Set<Output> toAbstractSetType(List<OutputImpl> outputs) {
-        final Set<Output> result = Sets.newHashSet();
-        result.addAll(outputs);
-
-        return result;
+        try (org.mongojack.DBCursor<OutputImpl> outputs = coll.find()) {
+            return ImmutableSet.copyOf((Iterable<OutputImpl>) outputs);
+        }
     }
 
     @Override
@@ -109,7 +103,7 @@ public class OutputServiceImpl implements OutputService {
         for (Map.Entry<String, Object> fields : deltas.entrySet())
             update = update.set(fields.getKey(), fields.getValue());
 
-        return coll.findAndModify(DBQuery.is("_id", id), update);
+        return coll.findAndModify(DBQuery.is(OutputImpl.FIELD_CREATOR_USER_ID, id), update);
     }
 
     @Override
@@ -119,15 +113,16 @@ public class OutputServiceImpl implements OutputService {
 
     @Override
     public Map<String, Long> countByType() {
-        final DBCursor outputTypes = dbCollection.find(null, new BasicDBObject(OutputImpl.FIELD_TYPE, 1));
+        final Map<String, Long> outputsCountByType = new HashMap<>();
+        try (DBCursor outputTypes = dbCollection.find(null, new BasicDBObject(OutputImpl.FIELD_TYPE, 1))) {
 
-        final Map<String, Long> outputsCountByType = new HashMap<>(outputTypes.count());
-        for (DBObject outputType : outputTypes) {
-            final String type = (String) outputType.get(OutputImpl.FIELD_TYPE);
-            if (type != null) {
-                final Long oldValue = outputsCountByType.get(type);
-                final Long newValue = (oldValue == null) ? 1 : oldValue + 1;
-                outputsCountByType.put(type, newValue);
+            for (DBObject outputType : outputTypes) {
+                final String type = (String) outputType.get(OutputImpl.FIELD_TYPE);
+                if (type != null) {
+                    final Long oldValue = outputsCountByType.get(type);
+                    final Long newValue = (oldValue == null) ? 1 : oldValue + 1;
+                    outputsCountByType.put(type, newValue);
+                }
             }
         }
 

--- a/graylog2-server/src/main/java/org/graylog2/users/RoleServiceImpl.java
+++ b/graylog2-server/src/main/java/org/graylog2/users/RoleServiceImpl.java
@@ -17,6 +17,7 @@
 package org.graylog2.users;
 
 import com.google.common.base.Function;
+import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
 import com.mongodb.BasicDBObject;
@@ -153,8 +154,9 @@ public class RoleServiceImpl implements RoleService {
 
     @Override
     public Set<Role> loadAll() throws NotFoundException {
-        final DBCursor<RoleImpl> rolesCursor = dbCollection.find();
-        return Sets.newHashSet((Iterable<? extends Role>) rolesCursor);
+        try (DBCursor<RoleImpl> rolesCursor = dbCollection.find()) {
+            return ImmutableSet.copyOf((Iterable<? extends Role>) rolesCursor);
+        }
     }
 
     @Override

--- a/graylog2-server/src/test/java/org/graylog2/indexer/fieldtypes/IndexFieldTypesServiceTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/indexer/fieldtypes/IndexFieldTypesServiceTest.java
@@ -99,7 +99,7 @@ public class IndexFieldTypesServiceTest {
                 .extracting("indexName")
                 .containsOnly("graylog_1");
 
-        assertThat(dbService.streamAll().count())
+        assertThat(dbService.findAll().size())
                 .as("check that all entries are returned as a stream")
                 .isEqualTo(2);
 
@@ -112,7 +112,7 @@ public class IndexFieldTypesServiceTest {
         final IndexFieldTypesDTO newDto1 = createDto("graylog_0", Collections.emptySet());
         final IndexFieldTypesDTO newDto2 = createDto("graylog_1", Collections.emptySet());
 
-        assertThat(dbService.streamAll().count()).isEqualTo(0);
+        assertThat(dbService.findAll().size()).isEqualTo(0);
 
         final IndexFieldTypesDTO upsertedDto1 = dbService.upsert(newDto1).orElse(null);
         final IndexFieldTypesDTO upsertedDto2 = dbService.upsert(newDto2).orElse(null);
@@ -123,12 +123,12 @@ public class IndexFieldTypesServiceTest {
         assertThat(upsertedDto1.indexName()).isEqualTo("graylog_0");
         assertThat(upsertedDto2.indexName()).isEqualTo("graylog_1");
 
-        assertThat(dbService.streamAll().count()).isEqualTo(2);
+        assertThat(dbService.findAll().size()).isEqualTo(2);
 
         assertThat(dbService.upsert(newDto1)).isNotPresent();
         assertThat(dbService.upsert(newDto2)).isNotPresent();
 
-        assertThat(dbService.streamAll().count()).isEqualTo(2);
+        assertThat(dbService.findAll().size()).isEqualTo(2);
     }
 
     @Test
@@ -141,11 +141,11 @@ public class IndexFieldTypesServiceTest {
         final IndexFieldTypesDTO savedDto2 = dbService.save(newDto2);
         final IndexFieldTypesDTO savedDto3 = dbService.save(newDto3);
 
-        assertThat(dbService.streamForIndexSet("abc").count()).isEqualTo(1);
-        assertThat(dbService.streamForIndexSet("xyz").count()).isEqualTo(2);
+        assertThat(dbService.findForIndexSet("abc").size()).isEqualTo(1);
+        assertThat(dbService.findForIndexSet("xyz").size()).isEqualTo(2);
 
-        assertThat(dbService.streamForIndexSet("abc").findFirst().orElse(null)).isEqualTo(savedDto1);
-        assertThat(dbService.streamForIndexSet("xyz").toArray()).containsExactly(savedDto2, savedDto3);
+        assertThat(dbService.findForIndexSet("abc")).first().isEqualTo(savedDto1);
+        assertThat(dbService.findForIndexSet("xyz").toArray()).containsExactly(savedDto2, savedDto3);
     }
 
     @Test
@@ -157,14 +157,14 @@ public class IndexFieldTypesServiceTest {
                 FieldTypeDTO.create("yolo1", "text")
         )));
 
-        assertThat(dbService.streamForFieldNames(of()).count()).isEqualTo(0);
-        assertThat(dbService.streamForFieldNames(of("message")).count()).isEqualTo(4);
-        assertThat(dbService.streamForFieldNames(of("message", "yolo_1")).count()).isEqualTo(4);
-        assertThat(dbService.streamForFieldNames(of("yolo1")).count()).isEqualTo(1);
-        assertThat(dbService.streamForFieldNames(of("source")).count()).isEqualTo(4);
-        assertThat(dbService.streamForFieldNames(of("source", "non-existent")).count()).isEqualTo(4);
-        assertThat(dbService.streamForFieldNames(of("non-existent")).count()).isEqualTo(0);
-        assertThat(dbService.streamForFieldNames(of("non-existent", "yolo1")).count()).isEqualTo(1);
+        assertThat(dbService.findForFieldNames(of()).size()).isEqualTo(0);
+        assertThat(dbService.findForFieldNames(of("message")).size()).isEqualTo(4);
+        assertThat(dbService.findForFieldNames(of("message", "yolo_1")).size()).isEqualTo(4);
+        assertThat(dbService.findForFieldNames(of("yolo1")).size()).isEqualTo(1);
+        assertThat(dbService.findForFieldNames(of("source")).size()).isEqualTo(4);
+        assertThat(dbService.findForFieldNames(of("source", "non-existent")).size()).isEqualTo(4);
+        assertThat(dbService.findForFieldNames(of("non-existent")).size()).isEqualTo(0);
+        assertThat(dbService.findForFieldNames(of("non-existent", "yolo1")).size()).isEqualTo(1);
     }
 
     @Test
@@ -176,24 +176,24 @@ public class IndexFieldTypesServiceTest {
                 FieldTypeDTO.create("yolo1", "text")
         )));
 
-        assertThat(dbService.streamForFieldNamesAndIndices(
+        assertThat(dbService.findForFieldNamesAndIndices(
                 of(),
                 of()
-        ).count()).isEqualTo(0);
+        ).size()).isEqualTo(0);
 
-        assertThat(dbService.streamForFieldNamesAndIndices(
+        assertThat(dbService.findForFieldNamesAndIndices(
                 of("message"),
                 of("graylog_1")
-        ).count()).isEqualTo(1);
+        ).size()).isEqualTo(1);
 
-        assertThat(dbService.streamForFieldNamesAndIndices(
+        assertThat(dbService.findForFieldNamesAndIndices(
                 of("message", "yolo1"),
                 of("graylog_1", "graylog_3")
-        ).count()).isEqualTo(2);
+        ).size()).isEqualTo(2);
 
-        assertThat(dbService.streamForFieldNamesAndIndices(
+        assertThat(dbService.findForFieldNamesAndIndices(
                 of("message", "yolo1"),
                 of("graylog_1", "graylog_3", "graylog_0")
-        ).count()).isEqualTo(3);
+        ).size()).isEqualTo(3);
     }
 }


### PR DESCRIPTION
While MongoDB cursors are usually being closed if they've been exhausted or after a certain timeout, explicitly closing these server-side resources helps MongoDB to manage resources and not occupy memory for open cursors longer than necessary.

https://docs.mongodb.com/manual/tutorial/iterate-a-cursor/#cursor-behaviors
https://stackoverflow.com/a/24261314