### PR TITLE
Rule Helper Filter

### DIFF
--- a/graylog2-web-interface/src/components/common/FilterInput.jsx
+++ b/graylog2-web-interface/src/components/common/FilterInput.jsx
@@ -1,0 +1,63 @@
+import PropTypes from 'prop-types';
+import React from 'react';
+
+import { Input } from 'components/bootstrap';
+
+/**
+ * The FilterInput component will render a filter input and takes a
+ * list or object to be filtered and a filter function which will be
+ * executed while typing.
+ */
+class FilterInput extends React.Component {
+  static propTypes = {
+    /**
+     * This callback will be called when the user types in a filter string.
+     * It takes the new filter string as an argument.
+     */
+    onChange: PropTypes.func.isRequired,
+    /** The optional label for the filter. Default is 'Filter' */
+    filterLabel: PropTypes.string,
+    /** The wrapperClassName of the Input for styling */
+    wrapperClassName: PropTypes.string,
+    /** The labelClassName of the Input for styling */
+    labelClassName: PropTypes.string,
+  };
+
+  static defaultProps = {
+    filterLabel: 'Filter',
+    wrapperClassName: 'col-sm-4',
+    labelClassName: 'col-sm-1',
+  };
+
+  constructor(props) {
+    super(props);
+
+    this.state = {
+      filter: '',
+    };
+  }
+
+  _onChange = (e) => {
+    const filter = e.target.value;
+    this.setState({ filter: filter });
+    this.props.onChange(filter);
+  };
+
+  render() {
+    return (
+      <form className="form-horizontal" onSubmit={(e) => { e.preventDefault(); }}>
+        <Input
+          id="filter-descriptors"
+          type="text"
+          wrapperClassName={this.props.wrapperClassName}
+          labelClassName={this.props.labelClassName}
+          label={this.props.filterLabel}
+          value={this.state.filter}
+          onChange={this._onChange}
+        />
+      </form>
+    );
+  }
+}
+
+export default FilterInput;

--- a/graylog2-web-interface/src/components/common/FilterInput.md
+++ b/graylog2-web-interface/src/components/common/FilterInput.md
@@ -1,0 +1,48 @@
+```js
+const createReactClass = require('create-react-class');
+
+const FilterInputExample = createReactClass({
+
+  getInitialState() {
+    return {
+      filtered_rows: this.rows(),
+    };
+  },
+
+  rows() {
+    return [
+      "Rand",
+      "Mat",
+      "Perrin",
+      "Egwene",
+      "Nynaeve",
+    ]
+  },
+
+  onChange(filter) {
+    if (filter === '') {
+      this.setState({ filtered_rows: this.rows() });
+      return;
+    }
+    const newRows = this.state.filtered_rows.filter((row) => {
+      const regexp = RegExp(filter, 'i');
+      return regexp.test(row);
+    });
+    this.setState({ filtered_rows: newRows });
+  },
+
+  render() {
+    const rows = this.state.filtered_rows.map(e => <li key={e}>{e}</li>);
+    return (
+      <div>
+        <FilterInput onChange={this.onChange} />
+        <ul>
+          {rows}
+        </ul>
+      </div>
+    );
+  },
+});
+
+<FilterInputExample />
+```

--- a/graylog2-web-interface/src/components/common/FilterInput.test.jsx
+++ b/graylog2-web-interface/src/components/common/FilterInput.test.jsx
@@ -25,7 +25,7 @@ describe('<FilterInput />', () => {
     const changeFn = jest.fn((value) => {
       expect(value).toEqual('kaladin');
     });
-    const wrapper = mount(<FilterInput onChange={changeFn} />)
+    const wrapper = mount(<FilterInput onChange={changeFn} />);
 
     wrapper.find('input').simulate('change', { target: { value: 'kaladin' } });
     expect(changeFn.mock.calls.length).toBe(1);

--- a/graylog2-web-interface/src/components/common/FilterInput.test.jsx
+++ b/graylog2-web-interface/src/components/common/FilterInput.test.jsx
@@ -1,0 +1,33 @@
+import React from 'react';
+import renderer from 'react-test-renderer';
+import { mount } from 'enzyme';
+import 'helpers/mocking/react-dom_mock';
+
+import FilterInput from 'components/common/FilterInput';
+
+describe('<FilterInput />', () => {
+  it('should render a filter input', () => {
+    const wrapper = renderer.create(<FilterInput onChange={() => {}} />);
+    expect(wrapper.toJSON()).toMatchSnapshot();
+  });
+
+  it('should render a filter input with custom label', () => {
+    const wrapper = renderer.create(<FilterInput
+      onChange={() => {}}
+      filterLabel="Search"
+      labelClassName="col-sm-3"
+      wrapperClassName="col-xs-1"
+    />);
+    expect(wrapper.toJSON()).toMatchSnapshot();
+  });
+
+  it('should take filter input', () => {
+    const changeFn = jest.fn((value) => {
+      expect(value).toEqual('kaladin');
+    });
+    const wrapper = mount(<FilterInput onChange={changeFn} />)
+
+    wrapper.find('input').simulate('change', { target: { value: 'kaladin' } });
+    expect(changeFn.mock.calls.length).toBe(1);
+  });
+});

--- a/graylog2-web-interface/src/components/common/__snapshots__/FilterInput.test.jsx.snap
+++ b/graylog2-web-interface/src/components/common/__snapshots__/FilterInput.test.jsx.snap
@@ -1,0 +1,65 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`<FilterInput /> should render a filter input 1`] = `
+<form
+  className="form-horizontal"
+  onSubmit={[Function]}
+>
+  <div
+    className="form-group"
+  >
+    <label
+      className="col-sm-1 control-label"
+      htmlFor="filter-descriptors"
+    >
+      Filter
+    </label>
+    <div
+      className="col-sm-4"
+    >
+      <input
+        className="form-control"
+        id="filter-descriptors"
+        label="Filter"
+        onChange={[Function]}
+        placeholder=""
+        type="text"
+        value=""
+      />
+      
+    </div>
+  </div>
+</form>
+`;
+
+exports[`<FilterInput /> should render a filter input with custom label 1`] = `
+<form
+  className="form-horizontal"
+  onSubmit={[Function]}
+>
+  <div
+    className="form-group"
+  >
+    <label
+      className="col-sm-3 control-label"
+      htmlFor="filter-descriptors"
+    >
+      Search
+    </label>
+    <div
+      className="col-xs-1"
+    >
+      <input
+        className="form-control"
+        id="filter-descriptors"
+        label="Search"
+        onChange={[Function]}
+        placeholder=""
+        type="text"
+        value=""
+      />
+      
+    </div>
+  </div>
+</form>
+`;

--- a/graylog2-web-interface/src/components/common/index.jsx
+++ b/graylog2-web-interface/src/components/common/index.jsx
@@ -44,3 +44,4 @@ export { default as JSONValueInput } from './JSONValueInput';
 export { default as TimeUnitInput } from './TimeUnitInput';
 export { default as TimeUnit } from './TimeUnit';
 export { default as Wizard } from './Wizard';
+export { default as FilterInput } from './FilterInput';

--- a/graylog2-web-interface/src/components/rules/RuleHelper.jsx
+++ b/graylog2-web-interface/src/components/rules/RuleHelper.jsx
@@ -9,8 +9,7 @@ import RulesActions from 'actions/rules/RulesActions';
 import ObjectUtils from 'util/ObjectUtils';
 
 import DocumentationLink from 'components/support/DocumentationLink';
-import { PaginatedList, Spinner } from 'components/common';
-import { Input } from 'components/bootstrap';
+import { PaginatedList, Spinner, FilterInput } from 'components/common';
 
 import DocsHelper from 'util/DocsHelper';
 
@@ -113,8 +112,7 @@ end`,
     this.setState({ currentPage: newPage, pageSize: pageSize });
   },
 
-  _filterDescriptors(e) {
-    const filter = e.target.value;
+  _filterDescriptors(filter) {
     if (!this.state.functionDescriptors) {
       return;
     }
@@ -172,17 +170,7 @@ end`,
                 </Row>
                 <Row>
                   <Col sm={12}>
-                    <form className="form-horizontal" onSubmit={(e) => { e.preventDefault(); }}>
-                      <Input
-                        id="filter-descriptors"
-                        type="text"
-                        wrapperClassName="col-sm-4"
-                        labelClassName="col-sm-1"
-                        label="Filter"
-                        value={this.state.filter}
-                        onChange={this._filterDescriptors}
-                      />
-                    </form>
+                    <FilterInput onChange={this._filterDescriptors} />
                     <div className={`table-responsive ${RuleHelperStyle.marginTab}`}>
                       <PaginatedList totalItems={functionDescriptors.length} pageSize={this.state.pageSize} onChange={this._onPageChange} showPageSizeSelect={false}>
                         <Table condensed>


### PR DESCRIPTION
## Description
I add a filter to make it easier to search for a specific pipeline
rule function. The filter will search for the function signature and the description of the function.

## Motivation and Context
The Rule Helper displays a lot of documentation for pipeline rules.
Since it is tiresome to go through 10 pages of pipeline functions.

## How Has This Been Tested?
Searched for Pipeline Rules

## Screenshots (if appropriate):
![screenshot-2018-5-2 graylog - new pipeline rule](https://user-images.githubusercontent.com/448763/39517161-593460da-4dff-11e8-9c94-c2381cd84287.png)
![screenshot-2018-5-2 graylog - new pipeline rule 1](https://user-images.githubusercontent.com/448763/39517384-fb8803a0-4dff-11e8-833e-2911ea83a2c4.png)


## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
