### PR TITLE
Initializing map holding element refs in `GeoIpResolverConfig`.

### DIFF
--- a/graylog2-web-interface/src/components/maps/configurations/GeoIpResolverConfig.jsx
+++ b/graylog2-web-interface/src/components/maps/configurations/GeoIpResolverConfig.jsx
@@ -15,6 +15,8 @@ const GeoIpResolverConfig = createReactClass({
     updateConfig: PropTypes.func.isRequired,
   },
 
+  inputs: {},
+
   getDefaultProps() {
     return {
       config: {

--- a/graylog2-web-interface/src/components/maps/configurations/GeoIpResolverConfig.jsx
+++ b/graylog2-web-interface/src/components/maps/configurations/GeoIpResolverConfig.jsx
@@ -15,8 +15,6 @@ const GeoIpResolverConfig = createReactClass({
     updateConfig: PropTypes.func.isRequired,
   },
 
-  inputs: {},
-
   getDefaultProps() {
     return {
       config: {
@@ -38,6 +36,8 @@ const GeoIpResolverConfig = createReactClass({
     this.setState({ config: ObjectUtils.clone(newProps.config) });
   },
 
+  inputs: {},
+
   _updateConfigField(field, value) {
     const update = ObjectUtils.clone(this.state.config);
     update[field] = value;
@@ -47,12 +47,6 @@ const GeoIpResolverConfig = createReactClass({
   _onCheckboxClick(field, ref) {
     return () => {
       this._updateConfigField(field, this.inputs[ref].getChecked());
-    };
-  },
-
-  _onSelect(field) {
-    return (selection) => {
-      this._updateConfigField(field, selection);
     };
   },
 
@@ -145,7 +139,7 @@ const GeoIpResolverConfig = createReactClass({
                    help={<span>You can download a free version of the database from <a href="https://dev.maxmind.com/geoip/geoip2/geolite2/" target="_blank" rel="noopener noreferrer">MaxMind</a>.</span>}
                    name="db_path"
                    value={this.state.config.db_path}
-                   onChange={this._onUpdate('db_path')}/>
+                   onChange={this._onUpdate('db_path')} />
           </fieldset>
         </BootstrapModalForm>
       </div>

--- a/graylog2-web-interface/src/components/maps/configurations/GeoIpResolverConfig.jsx
+++ b/graylog2-web-interface/src/components/maps/configurations/GeoIpResolverConfig.jsx
@@ -35,13 +35,13 @@ const GeoIpResolverConfig = createReactClass({
   },
 
   componentWillReceiveProps(newProps) {
-    this.setState({config: ObjectUtils.clone(newProps.config)});
+    this.setState({ config: ObjectUtils.clone(newProps.config) });
   },
 
   _updateConfigField(field, value) {
     const update = ObjectUtils.clone(this.state.config);
     update[field] = value;
-    this.setState({config: update});
+    this.setState({ config: update });
   },
 
   _onCheckboxClick(field, ref) {
@@ -84,12 +84,12 @@ const GeoIpResolverConfig = createReactClass({
   _availableDatabaseTypes() {
     // TODO: Support country database as well.
     return [
-      {value: 'MAXMIND_CITY', label: 'City database'},
+      { value: 'MAXMIND_CITY', label: 'City database' },
     ];
   },
 
   _activeDatabaseType(type) {
-    return this._availableDatabaseTypes().filter((t) => t.value === type)[0].label;
+    return this._availableDatabaseTypes().filter(t => t.value === type)[0].label;
   },
 
   render() {
@@ -142,7 +142,7 @@ const GeoIpResolverConfig = createReactClass({
             <Input id="maxmind-db-path"
                    type="text"
                    label="Path to the MaxMind database"
-                   help={<span>You can download a free version of the database from <a href="https://dev.maxmind.com/geoip/geoip2/geolite2/" target="_blank">MaxMind</a>.</span>}
+                   help={<span>You can download a free version of the database from <a href="https://dev.maxmind.com/geoip/geoip2/geolite2/" target="_blank" rel="noopener noreferrer">MaxMind</a>.</span>}
                    name="db_path"
                    value={this.state.config.db_path}
                    onChange={this._onUpdate('db_path')}/>


### PR DESCRIPTION
## Description
## Motivation and Context

In #4736, string refs have been replaced by callbacks. As a fallout of
this change, the map holding refs for inputs in `GeoIpResolverConfig`
was forgotten to initialize, breaking the Geo Ip Processor config modal.

This change is fixing this. Additionally, #4736 was checked again for
variables holding element refs in a nested way (like
`this.inputs[element]`) but no other occurrences where the holder was
not initialized were found.

*Update*: Also fixed linter hints in file.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
