### PR TITLE
Add `trigger_alert()` function

### DIFF
--- a/graylog2-server/src/main/java/org/graylog/plugins/pipelineprocessor/functions/ProcessorFunctionsModule.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/pipelineprocessor/functions/ProcessorFunctionsModule.java
@@ -21,6 +21,7 @@ import com.google.inject.Scopes;
 import com.google.inject.TypeLiteral;
 import com.google.inject.multibindings.MapBinder;
 import org.graylog.plugins.pipelineprocessor.ast.functions.Function;
+import org.graylog.plugins.pipelineprocessor.functions.alerts.TriggerAlert;
 import org.graylog.plugins.pipelineprocessor.functions.conversion.BooleanConversion;
 import org.graylog.plugins.pipelineprocessor.functions.conversion.DoubleConversion;
 import org.graylog.plugins.pipelineprocessor.functions.conversion.IsBoolean;
@@ -152,6 +153,9 @@ public class ProcessorFunctionsModule extends PluginModule {
         addMessageProcessorFunction(RouteToStream.NAME, RouteToStream.class);
         // helper service for route_to_stream
         serviceBinder().addBinding().to(StreamCacheService.class).in(Scopes.SINGLETON);
+
+        // alerting related functions
+        addMessageProcessorFunction(TriggerAlert.NAME, TriggerAlert.class);
 
         // input related functions
         addMessageProcessorFunction(FromInput.NAME, FromInput.class);

--- a/graylog2-server/src/main/java/org/graylog/plugins/pipelineprocessor/functions/alerts/TriggerAlert.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/pipelineprocessor/functions/alerts/TriggerAlert.java
@@ -1,0 +1,177 @@
+/**
+ * This file is part of Graylog.
+ *
+ * Graylog is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.graylog.plugins.pipelineprocessor.functions.alerts;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.reflect.TypeToken;
+import org.graylog.plugins.pipelineprocessor.EvaluationContext;
+import org.graylog.plugins.pipelineprocessor.ast.functions.AbstractFunction;
+import org.graylog.plugins.pipelineprocessor.ast.functions.FunctionArgs;
+import org.graylog.plugins.pipelineprocessor.ast.functions.FunctionDescriptor;
+import org.graylog.plugins.pipelineprocessor.ast.functions.ParameterDescriptor;
+import org.graylog.plugins.pipelineprocessor.functions.messages.StreamCacheService;
+import org.graylog2.alerts.Alert;
+import org.graylog2.alerts.AlertNotificationsSender;
+import org.graylog2.alerts.AlertService;
+import org.graylog2.alerts.types.DummyAlertCondition;
+import org.graylog2.plugin.Message;
+import org.graylog2.plugin.MessageSummary;
+import org.graylog2.plugin.Tools;
+import org.graylog2.plugin.alarms.AlertCondition;
+import org.graylog2.plugin.database.ValidationException;
+import org.graylog2.plugin.streams.DefaultStream;
+import org.graylog2.plugin.streams.Stream;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.inject.Inject;
+import javax.inject.Provider;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+
+import static org.graylog.plugins.pipelineprocessor.ast.functions.ParameterDescriptor.bool;
+import static org.graylog.plugins.pipelineprocessor.ast.functions.ParameterDescriptor.string;
+import static org.graylog.plugins.pipelineprocessor.ast.functions.ParameterDescriptor.type;
+
+public class TriggerAlert extends AbstractFunction<List<String>> {
+    private static final Logger LOG = LoggerFactory.getLogger(TriggerAlert.class);
+    @SuppressWarnings("unchecked")
+    private static final Class<List<String>> RETURN_TYPE = (Class<List<String>>) new TypeToken<List<String>>() {
+    }.getRawType();
+
+    public static final String NAME = "trigger_alert";
+
+    private final AlertService alertService;
+    private final AlertNotificationsSender alertNotificationsSender;
+    private final StreamCacheService streamCacheService;
+    private final Provider<Stream> defaultStreamProvider;
+
+    private final ParameterDescriptor<Message, Message> messageParam;
+    private final ParameterDescriptor<String, String> titleParam;
+    private final ParameterDescriptor<String, String> descriptionParam;
+    private final ParameterDescriptor<String, String> streamIdParam;
+    private final ParameterDescriptor<String, String> streamNameParam;
+    private final ParameterDescriptor<Boolean, Boolean> notifyParam;
+    private final ParameterDescriptor<Boolean, Boolean> resolveParam;
+
+    @Inject
+    public TriggerAlert(AlertService alertService,
+                        AlertNotificationsSender alertNotificationsSender,
+                        StreamCacheService streamCacheService,
+                        @DefaultStream Provider<Stream> defaultStreamProvider) {
+        this.alertService = alertService;
+        this.alertNotificationsSender = alertNotificationsSender;
+        this.streamCacheService = streamCacheService;
+        this.defaultStreamProvider = defaultStreamProvider;
+
+        messageParam = type("message", Message.class).optional().description("The message to drop, defaults to '$message'").build();
+        titleParam = string("title").optional().description("Title of the alert condition").build();
+        descriptionParam = string("description").optional().description("Description of the alert condition").build();
+        streamIdParam = string("stream_id").optional().description("The ID of the stream").build();
+        streamNameParam = string("stream_name").optional().description("The name of the stream, must match exactly").build();
+        notifyParam = bool("notify").description("Send alert notifications, defaults to 'true'").optional().build();
+        resolveParam = bool("resolve").description("Resolve alert immediately, defaults to 'true'").optional().build();
+    }
+
+    @Override
+    public List<String> evaluate(FunctionArgs args, EvaluationContext context) {
+        final Message message = messageParam.optional(args, context).orElse(context.currentMessage());
+        final String title = titleParam.optional(args, context).orElse("Manual alert for message " + message.getId());
+        final String description = descriptionParam.optional(args, context).orElse("Manual alert for message " + message.getId());
+        final boolean notify = notifyParam.optional(args, context).orElse(true);
+        final boolean resolve = resolveParam.optional(args, context).orElse(true);
+
+        final Optional<String> streamId = streamIdParam.optional(args, context);
+        final Collection<Stream> streams;
+        if (streamId.isPresent()) {
+            streams = streamId
+                    .map(streamCacheService::getById)
+                    .map(ImmutableList::of)
+                    .orElse(ImmutableList.of(defaultStreamProvider.get()));
+        } else {
+            streams = streamNameParam.optional(args, context)
+                    .map(streamCacheService::getByName)
+                    .orElse(ImmutableList.of(defaultStreamProvider.get()));
+        }
+
+        final MessageSummary messageSummary = createMessageSummary(message);
+        final ImmutableList.Builder<String> alertIds = ImmutableList.builder();
+        for (Stream stream : streams) {
+            if (stream.isPaused()) {
+                continue;
+            }
+
+            final AlertCondition alertCondition = createAlertCondition(stream, title, description, messageSummary);
+            final AlertCondition.CheckResult checkResult = alertCondition.runCheck();
+            final Alert alert = alertService.factory(checkResult);
+            try {
+                alertService.save(alert);
+            } catch (ValidationException e) {
+                LOG.error("Failed to save alert {}", alert, e);
+                return null;
+            }
+
+            alertIds.add(alert.getId());
+
+            if (resolve) {
+                final Alert resolvedAlert = alertService.resolveAlert(alert);
+                LOG.debug("Resolved alert {}", resolvedAlert);
+            }
+
+            if (notify) {
+                LOG.debug("Sending alert notifications for alert {} on stream {}", alert, stream);
+                alertNotificationsSender.send(checkResult, stream, alert, alertCondition);
+            }
+        }
+
+        return alertIds.build();
+    }
+
+    private AlertCondition createAlertCondition(Stream stream, String title, String description, MessageSummary messageSummary) {
+        return new DummyAlertCondition(
+                stream,
+                messageSummary.getId(),
+                description,
+                ImmutableList.of(messageSummary),
+                Tools.nowUTC(),
+                "$system", // TODO: Better default user name?
+                Collections.emptyMap(),
+                title);
+    }
+
+    private MessageSummary createMessageSummary(Message message) {
+        return new MessageSummary("", message);
+    }
+
+    @Override
+    public FunctionDescriptor<List<String>> descriptor() {
+        return FunctionDescriptor.<List<String>>builder()
+                .name(NAME)
+                .returnType(RETURN_TYPE)
+                .params(messageParam,
+                        titleParam,
+                        descriptionParam,
+                        streamIdParam,
+                        streamNameParam,
+                        notifyParam,
+                        resolveParam)
+                .description("Trigger an alert for the current message")
+                .build();
+    }
+}

--- a/graylog2-server/src/main/java/org/graylog2/alerts/types/DummyAlertCondition.java
+++ b/graylog2-server/src/main/java/org/graylog2/alerts/types/DummyAlertCondition.java
@@ -17,17 +17,27 @@
 package org.graylog2.alerts.types;
 
 import org.graylog2.alerts.AbstractAlertCondition;
+import org.graylog2.plugin.MessageSummary;
 import org.graylog2.plugin.Tools;
 import org.graylog2.plugin.streams.Stream;
 import org.joda.time.DateTime;
 
+import java.util.Collections;
+import java.util.List;
 import java.util.Map;
 
 public class DummyAlertCondition extends AbstractAlertCondition {
-    final String description = "Dummy alert to test notifications";
+    private final String description;
+    private final List<MessageSummary> messageSummaries;
+
+    public DummyAlertCondition(Stream stream, String id, String description, List<MessageSummary> messageSummaries, DateTime createdAt, String creatorUserId, Map<String, Object> parameters, String title) {
+        super(stream, id, Type.DUMMY.toString(), createdAt, creatorUserId, parameters, title);
+        this.description = description;
+        this.messageSummaries = messageSummaries;
+    }
 
     public DummyAlertCondition(Stream stream, String id, DateTime createdAt, String creatorUserId, Map<String, Object> parameters, String title) {
-        super(stream, id, Type.DUMMY.toString(), createdAt, creatorUserId, parameters, title);
+        this(stream, id, "Dummy alert to test notifications", Collections.emptyList(), createdAt, creatorUserId, parameters, title);
     }
 
     @Override
@@ -37,6 +47,6 @@ public class DummyAlertCondition extends AbstractAlertCondition {
 
     @Override
     public CheckResult runCheck() {
-        return new CheckResult(true, this, this.description, Tools.nowUTC(), null);
+        return new CheckResult(true, this, this.description, Tools.nowUTC(), messageSummaries);
     }
 }

--- a/graylog2-server/src/test/java/org/graylog/plugins/pipelineprocessor/functions/FunctionsSnippetsTest.java
+++ b/graylog2-server/src/test/java/org/graylog/plugins/pipelineprocessor/functions/FunctionsSnippetsTest.java
@@ -17,6 +17,7 @@
 package org.graylog.plugins.pipelineprocessor.functions;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Lists;
@@ -27,6 +28,7 @@ import org.graylog.plugins.pipelineprocessor.BaseParserTest;
 import org.graylog.plugins.pipelineprocessor.EvaluationContext;
 import org.graylog.plugins.pipelineprocessor.ast.Rule;
 import org.graylog.plugins.pipelineprocessor.ast.functions.Function;
+import org.graylog.plugins.pipelineprocessor.functions.alerts.TriggerAlert;
 import org.graylog.plugins.pipelineprocessor.functions.conversion.BooleanConversion;
 import org.graylog.plugins.pipelineprocessor.functions.conversion.DoubleConversion;
 import org.graylog.plugins.pipelineprocessor.functions.conversion.IsBoolean;
@@ -117,29 +119,40 @@ import org.graylog.plugins.pipelineprocessor.functions.urls.IsUrl;
 import org.graylog.plugins.pipelineprocessor.functions.urls.UrlConversion;
 import org.graylog.plugins.pipelineprocessor.parser.FunctionRegistry;
 import org.graylog.plugins.pipelineprocessor.parser.ParseException;
+import org.graylog2.alerts.Alert;
+import org.graylog2.alerts.AlertImpl;
+import org.graylog2.alerts.AlertNotificationsSender;
+import org.graylog2.alerts.AlertService;
 import org.graylog2.database.NotFoundException;
 import org.graylog2.grok.GrokPattern;
 import org.graylog2.grok.GrokPatternRegistry;
 import org.graylog2.grok.GrokPatternService;
-import org.graylog2.plugin.InstantMillisProvider;
 import org.graylog2.plugin.Message;
 import org.graylog2.plugin.Tools;
+import org.graylog2.plugin.database.ValidationException;
 import org.graylog2.plugin.streams.Stream;
 import org.graylog2.shared.SuppressForbidden;
 import org.graylog2.shared.bindings.providers.ObjectMapperProvider;
+import org.graylog2.streams.StreamImpl;
+import org.graylog2.streams.StreamMock;
 import org.graylog2.streams.StreamService;
 import org.joda.time.DateTime;
 import org.joda.time.DateTimeUtils;
 import org.joda.time.Duration;
 import org.joda.time.Period;
+import org.junit.After;
 import org.junit.Assert;
-import org.junit.BeforeClass;
+import org.junit.Before;
 import org.junit.Test;
 import org.mockito.ArgumentMatchers;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnit;
+import org.mockito.junit.MockitoRule;
 
 import javax.inject.Provider;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.Executors;
@@ -148,20 +161,40 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.fail;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyZeroInteractions;
 import static org.mockito.Mockito.when;
 
 public class FunctionsSnippetsTest extends BaseParserTest {
-
     public static final DateTime GRAYLOG_EPOCH = DateTime.parse("2010-07-30T16:03:25Z");
-    private static final EventBus eventBus = new EventBus();
-    private static StreamCacheService streamCacheService;
-    private static Stream otherStream;
+    private static Stream otherStream = new StreamMock(ImmutableMap.of(
+            "_id", "id2",
+            StreamImpl.FIELD_TITLE, "some name",
+            StreamImpl.FIELD_DISABLED, false)
+    );
 
-    @BeforeClass
+    @org.junit.Rule
+    public final MockitoRule mockitoRule = MockitoJUnit.rule();
+
+    private final EventBus eventBus = new EventBus();
+    private final Provider<Stream> defaultStreamProvider = () -> defaultStream;
+
+    private StreamCacheService streamCacheService;
+    @Mock
+    private StreamService streamService;
+    @Mock
+    private AlertService alertService;
+    @Mock
+    private AlertNotificationsSender alertNotificationsSender;
+
+    @Before
     @SuppressForbidden("Allow using default thread factory")
-    public static void registerFunctions() {
+    public void registerFunctions() throws ValidationException, NotFoundException {
         final Map<String, Function<?>> functions = commonFunctions();
 
         functions.put(BooleanConversion.NAME, new BooleanConversion());
@@ -182,30 +215,35 @@ public class FunctionsSnippetsTest extends BaseParserTest {
         functions.put(CloneMessage.NAME, new CloneMessage());
 
         // route to stream mocks
-        final StreamService streamService = mock(StreamService.class);
-
-        otherStream = mock(Stream.class, "some stream id2");
-        when(otherStream.isPaused()).thenReturn(false);
-        when(otherStream.getTitle()).thenReturn("some name");
-        when(otherStream.getId()).thenReturn("id2");
-
         when(streamService.loadAll()).thenReturn(Lists.newArrayList(defaultStream, otherStream));
         when(streamService.loadAllEnabled()).thenReturn(Lists.newArrayList(defaultStream, otherStream));
-        try {
-            when(streamService.load(anyString())).thenThrow(new NotFoundException());
-            when(streamService.load(ArgumentMatchers.eq(Stream.DEFAULT_STREAM_ID))).thenReturn(defaultStream);
-            when(streamService.load(ArgumentMatchers.eq("id2"))).thenReturn(otherStream);
-        } catch (NotFoundException ignored) {
-            // oh well, checked exceptions <3
-        }
+        when(streamService.load(anyString())).thenThrow(new NotFoundException());
+        when(streamService.load(ArgumentMatchers.eq(Stream.DEFAULT_STREAM_ID))).thenReturn(defaultStream);
+        when(streamService.load(ArgumentMatchers.eq("id2"))).thenReturn(otherStream);
+
         streamCacheService = new StreamCacheService(eventBus, streamService, null);
         streamCacheService.startAsync().awaitRunning();
-        final Provider<Stream> defaultStreamProvider = () -> defaultStream;
+
         functions.put(RouteToStream.NAME, new RouteToStream(streamCacheService, defaultStreamProvider));
         functions.put(RemoveFromStream.NAME, new RemoveFromStream(streamCacheService, defaultStreamProvider));
         // input related functions
         // TODO needs mock
         //functions.put(FromInput.NAME, new FromInput());
+
+        // alert functions
+        final Alert alert = AlertImpl.create(
+                "id",
+                defaultStream.getId(),
+                "condition-id",
+                GRAYLOG_EPOCH,
+                GRAYLOG_EPOCH,
+                "description",
+                Collections.emptyMap(),
+                true);
+        when(alertService.factory(any())).thenReturn(alert);
+        when(alertService.save(alert)).thenReturn(alert.getId());
+        when(alertService.resolveAlert(alert)).thenReturn(alert);
+        functions.put(TriggerAlert.NAME, new TriggerAlert(alertService, alertNotificationsSender, streamCacheService, defaultStreamProvider));
 
         // generic functions
         functions.put(RegexMatch.NAME, new RegexMatch());
@@ -309,6 +347,16 @@ public class FunctionsSnippetsTest extends BaseParserTest {
         functions.put(GrokMatch.NAME, new GrokMatch(grokPatternRegistry));
 
         functionRegistry = new FunctionRegistry(functions);
+
+        DateTimeUtils.setCurrentMillisFixed(GRAYLOG_EPOCH.getMillis());
+
+        super.setup();
+    }
+
+    @After
+    public void tearDown() {
+        streamCacheService.stopAsync().awaitTerminated();
+        DateTimeUtils.setCurrentMillisSystem();
     }
 
     @Test
@@ -407,43 +455,36 @@ public class FunctionsSnippetsTest extends BaseParserTest {
 
     @Test
     public void dates() {
-        final InstantMillisProvider clock = new InstantMillisProvider(GRAYLOG_EPOCH);
-        DateTimeUtils.setCurrentMillisProvider(clock);
-
+        final Rule rule;
         try {
-            final Rule rule;
-            try {
-                rule = parser.parseRule(ruleForTest(), false);
-            } catch (ParseException e) {
-                fail("Should not fail to parse", e);
-                return;
-            }
-            final Message message = evaluateRule(rule);
-
-            assertThat(actionsTriggered.get()).isTrue();
-            assertThat(message).isNotNull();
-            assertThat(message).isNotEmpty();
-            assertThat(message.hasField("year")).isTrue();
-            assertThat(message.getField("year")).isEqualTo(2010);
-            assertThat(message.getField("timezone")).isEqualTo("UTC");
-
-            // Date parsing locales
-            assertThat(message.getField("german_year")).isEqualTo(1983);
-            assertThat(message.getField("german_month")).isEqualTo(7);
-            assertThat(message.getField("german_day")).isEqualTo(24);
-            assertThat(message.getField("english_year")).isEqualTo(1983);
-            assertThat(message.getField("english_month")).isEqualTo(7);
-            assertThat(message.getField("english_day")).isEqualTo(24);
-            assertThat(message.getField("french_year")).isEqualTo(1983);
-            assertThat(message.getField("french_month")).isEqualTo(7);
-            assertThat(message.getField("french_day")).isEqualTo(24);
-
-            assertThat(message.getField("ts_hour")).isEqualTo(16);
-            assertThat(message.getField("ts_minute")).isEqualTo(3);
-            assertThat(message.getField("ts_second")).isEqualTo(25);
-        } finally {
-            DateTimeUtils.setCurrentMillisSystem();
+            rule = parser.parseRule(ruleForTest(), false);
+        } catch (ParseException e) {
+            fail("Should not fail to parse", e);
+            return;
         }
+        final Message message = evaluateRule(rule);
+
+        assertThat(actionsTriggered.get()).isTrue();
+        assertThat(message).isNotNull();
+        assertThat(message).isNotEmpty();
+        assertThat(message.hasField("year")).isTrue();
+        assertThat(message.getField("year")).isEqualTo(2010);
+        assertThat(message.getField("timezone")).isEqualTo("UTC");
+
+        // Date parsing locales
+        assertThat(message.getField("german_year")).isEqualTo(1983);
+        assertThat(message.getField("german_month")).isEqualTo(7);
+        assertThat(message.getField("german_day")).isEqualTo(24);
+        assertThat(message.getField("english_year")).isEqualTo(1983);
+        assertThat(message.getField("english_month")).isEqualTo(7);
+        assertThat(message.getField("english_day")).isEqualTo(24);
+        assertThat(message.getField("french_year")).isEqualTo(1983);
+        assertThat(message.getField("french_month")).isEqualTo(7);
+        assertThat(message.getField("french_day")).isEqualTo(24);
+
+        assertThat(message.getField("ts_hour")).isEqualTo(16);
+        assertThat(message.getField("ts_minute")).isEqualTo(3);
+        assertThat(message.getField("ts_second")).isEqualTo(25);
     }
 
     @Test
@@ -862,23 +903,14 @@ public class FunctionsSnippetsTest extends BaseParserTest {
 
     @Test
     public void timezones() {
-        final InstantMillisProvider clock = new InstantMillisProvider(GRAYLOG_EPOCH);
-        DateTimeUtils.setCurrentMillisProvider(clock);
-        try {
-            final Rule rule = parser.parseRule(ruleForTest(), true);
-            evaluateRule(rule);
+        final Rule rule = parser.parseRule(ruleForTest(), true);
+        evaluateRule(rule);
 
-            assertThat(actionsTriggered.get()).isTrue();
-        } finally {
-            DateTimeUtils.setCurrentMillisSystem();
-        }
+        assertThat(actionsTriggered.get()).isTrue();
     }
 
     @Test
     public void dateArithmetic() {
-        final InstantMillisProvider clock = new InstantMillisProvider(GRAYLOG_EPOCH);
-        DateTimeUtils.setCurrentMillisProvider(clock);
-        try {
             final Rule rule = parser.parseRule(ruleForTest(), true);
             final Message message = evaluateRule(rule);
 
@@ -897,13 +929,9 @@ public class FunctionsSnippetsTest extends BaseParserTest {
             assertThat(message.getField("millis")).isEqualTo(Period.millis(2));
             assertThat(message.getField("period")).isEqualTo(Period.parse("P1YT1M"));
 
-
             assertThat(message.getFieldAs(DateTime.class, "long_time_ago")).matches(date -> date.plus(Period.years(10000)).equals(GRAYLOG_EPOCH));
 
             assertThat(message.getTimestamp()).isEqualTo(GRAYLOG_EPOCH.plusHours(1));
-        } finally {
-            DateTimeUtils.setCurrentMillisSystem();
-        }
     }
 
     @Test
@@ -954,5 +982,73 @@ public class FunctionsSnippetsTest extends BaseParserTest {
 
         assertThat(message).isNotNull();
         assertThat(message.getStreams()).containsOnly(defaultStream);
+    }
+
+    @Test
+    public void triggerAlert() throws ValidationException {
+        final Rule rule = parser.parseRule(ruleForTest(), true);
+        final Message message = evaluateRule(rule);
+
+        assertThat(message).isNotNull();
+        assertThat(message.getField("alert_ids"))
+                .isInstanceOf(List.class)
+                .asList()
+                .contains("id");
+
+        verify(alertService).factory(any());
+        verify(alertService).save(any());
+        verify(alertService).resolveAlert(any());
+        verify(alertNotificationsSender).send(any(), eq(defaultStream), any(), any());
+    }
+
+    @Test
+    public void triggerAlertWithDifferentStream() throws ValidationException {
+        final Rule rule = parser.parseRule(ruleForTest(), true);
+        final Message message = evaluateRule(rule);
+
+        assertThat(message).isNotNull();
+        assertThat(message.getField("alert_ids"))
+                .isInstanceOf(List.class)
+                .asList()
+                .contains("id");
+
+        verify(alertService).factory(any());
+        verify(alertService).save(any());
+        verify(alertService).resolveAlert(any());
+        verify(alertNotificationsSender).send(any(), eq(otherStream), any(), any());
+    }
+
+    @Test
+    public void triggerAlertWithoutNotification() throws ValidationException {
+        final Rule rule = parser.parseRule(ruleForTest(), true);
+        final Message message = evaluateRule(rule);
+
+        assertThat(message).isNotNull();
+        assertThat(message.getField("alert_ids"))
+                .isInstanceOf(List.class)
+                .asList()
+                .contains("id");
+
+        verify(alertService).factory(any());
+        verify(alertService).save(any());
+        verify(alertService).resolveAlert(any());
+        verifyZeroInteractions(alertNotificationsSender);
+    }
+
+    @Test
+    public void triggerAlertWithoutResolving() throws ValidationException {
+        final Rule rule = parser.parseRule(ruleForTest(), true);
+        final Message message = evaluateRule(rule);
+
+        assertThat(message).isNotNull();
+        assertThat(message.getField("alert_ids"))
+                .isInstanceOf(List.class)
+                .asList()
+                .contains("id");
+
+        verify(alertService).factory(any());
+        verify(alertService).save(any());
+        verify(alertService, never()).resolveAlert(any());
+        verify(alertNotificationsSender).send(any(), eq(defaultStream), any(), any());
     }
 }

--- a/graylog2-server/src/test/resources/org/graylog/plugins/pipelineprocessor/functions/triggerAlert.txt
+++ b/graylog2-server/src/test/resources/org/graylog/plugins/pipelineprocessor/functions/triggerAlert.txt
@@ -1,0 +1,6 @@
+rule "trigger alert"
+when true
+then
+    let alert_ids = trigger_alert();
+    set_field("alert_ids", alert_ids);
+end

--- a/graylog2-server/src/test/resources/org/graylog/plugins/pipelineprocessor/functions/triggerAlertWithDifferentStream.txt
+++ b/graylog2-server/src/test/resources/org/graylog/plugins/pipelineprocessor/functions/triggerAlertWithDifferentStream.txt
@@ -1,0 +1,6 @@
+rule "trigger alert with different stream"
+when true
+then
+    let alert_ids = trigger_alert(stream_name: "some name");
+    set_field("alert_ids", alert_ids);
+end

--- a/graylog2-server/src/test/resources/org/graylog/plugins/pipelineprocessor/functions/triggerAlertWithoutNotification.txt
+++ b/graylog2-server/src/test/resources/org/graylog/plugins/pipelineprocessor/functions/triggerAlertWithoutNotification.txt
@@ -1,0 +1,6 @@
+rule "trigger alert without notification"
+when true
+then
+    let alert_ids = trigger_alert(notify: false);
+    set_field("alert_ids", alert_ids);
+end

--- a/graylog2-server/src/test/resources/org/graylog/plugins/pipelineprocessor/functions/triggerAlertWithoutResolving.txt
+++ b/graylog2-server/src/test/resources/org/graylog/plugins/pipelineprocessor/functions/triggerAlertWithoutResolving.txt
@@ -1,0 +1,6 @@
+rule "trigger alert without resolving"
+when true
+then
+    let alert_ids = trigger_alert(resolve: false);
+    set_field("alert_ids", alert_ids);
+end


### PR DESCRIPTION
Alert conditions in Graylog are evaluated in a fixed interval by `AlertScanner` and `AlertScannerThread`, which might be too inflexible for some users who want to trigger an immediate alert if a specific message is encountered.

In order to enable users to manually trigger alerts in a pipeline rule, this change set adds the `trigger_alert()` function.

The function also enables a primitive kind of "real-time alerting" utilizing pipeline rules.

Fixes #4772.