### PR TITLE
Support case-insensitive auth-scheme token in proxy authentication

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/shared/bindings/providers/OkHttpClientProvider.java
+++ b/graylog2-server/src/main/java/org/graylog2/shared/bindings/providers/OkHttpClientProvider.java
@@ -44,6 +44,7 @@ import java.net.SocketAddress;
 import java.net.URI;
 import java.net.UnknownHostException;
 import java.util.List;
+import java.util.Locale;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -125,7 +126,7 @@ public class OkHttpClientProvider implements Provider<OkHttpClient> {
 
     public static class ProxyAuthenticator implements Authenticator {
         private static final Logger LOG = LoggerFactory.getLogger(ProxyAuthenticator.class);
-        private static final String AUTH_BASIC = "Basic";
+        private static final String AUTH_BASIC = "basic";
 
         private final String credentials;
 
@@ -138,6 +139,7 @@ public class OkHttpClientProvider implements Provider<OkHttpClient> {
         public Request authenticate(@Nonnull Route route, @Nonnull Response response) throws IOException {
             final Set<String> authenticationMethods = response.challenges().stream()
                     .map(Challenge::scheme)
+                    .map(s -> s.toLowerCase(Locale.ROOT))
                     .collect(Collectors.toSet());
 
             if (!authenticationMethods.contains(AUTH_BASIC)) {


### PR DESCRIPTION
The original implementation of the `ProxyAuthenticator` in `OkHttpClientProvider` matched the authentication scheme in a case-sensitive way, which doesn't work with all HTTP proxy servers in the wild.

Fixes #4788

References:

[RFC 7235, section 2.1](https://tools.ietf.org/html/rfc7235#section-2.1)
> Authentication parameters are name=value pairs, where the name token
> is matched case-insensitively, and each parameter name MUST only
> occur once per challenge.

[RFC 2617, section 1.2](https://tools.ietf.org/html/rfc2617#section-1.2)
> It [the authentication mechanism] uses an extensible,
> case-insensitive token to identify the authentication scheme,
> followed by a comma-separated list of attribute-value pairs which
> carry the parameters necessary for achieving authentication via that
> scheme.