### PR TITLE
Disabling unreliable AbstractTcpTransportTest test case.

### DIFF
--- a/graylog2-server/src/test/java/org/graylog2/plugin/inputs/transports/AbstractTcpTransportTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/plugin/inputs/transports/AbstractTcpTransportTest.java
@@ -200,6 +200,7 @@ public class AbstractTcpTransportTest {
     }
 
     @Test
+    @Ignore("Disabled test due to being unreliable. For details see https://github.com/Graylog2/graylog2-server/issues/4791.")
     public void testConnectionCounter() throws Exception {
         final Configuration configuration = new Configuration(ImmutableMap.of(
                 "bind_address", "127.0.0.1",


### PR DESCRIPTION
A test of the `AbstractTcpTransportTest` suite keeps failing, which is
now disabled until it is fixed.