### PR TITLE
Do not reset SelectPopover filter on hide

### DIFF
--- a/graylog2-web-interface/src/components/common/SelectPopover.jsx
+++ b/graylog2-web-interface/src/components/common/SelectPopover.jsx
@@ -130,7 +130,7 @@ const SelectPopover = createReactClass({
   renderDataFilter(items) {
     return (
       <FormGroup controlId="dataFilterInput" className={style.dataFilterInput}>
-        <FormControl type="text" placeholder={this.props.filterPlaceholder} onChange={this.handleFilterChange(items)} />
+        <FormControl type="text" placeholder={this.props.filterPlaceholder} value={this.state.filterText} onChange={this.handleFilterChange(items)} />
       </FormGroup>
     );
   },


### PR DESCRIPTION
These changes allow us to maintain the `SelectPopover` filter after the component is hidden, so the filter state is consistent with the list of elements displayed.

Before:
![before](https://user-images.githubusercontent.com/716185/40064764-823f977c-5860-11e8-8a22-64845167cb9a.gif)

After:
![after](https://user-images.githubusercontent.com/716185/40064776-86539bc4-5860-11e8-8c9c-511c8b2f46fe.gif)
