### PR TITLE
Improving stores/connect helper function.

### DIFF
--- a/graylog2-web-interface/src/stores/connect.jsx
+++ b/graylog2-web-interface/src/stores/connect.jsx
@@ -16,6 +16,7 @@ import { isFunction } from 'lodash';
  *
  * @param {Object} Component - The component which should be connected to the stores.
  * @param {Object} stores - A mapping of desired props keys to stores.
+ * @param {Function} mapProps - A function which is executed before props are passed to the component.
  * @returns {Object} - A React component wrapping the passed component.
  *
  * @example
@@ -23,11 +24,12 @@ import { isFunction } from 'lodash';
  * // Connecting the `SamplesComponent` class to the `SamplesStore`, hooking up its state to the `samples` prop and
  * // waiting for the store to settle down.
  *
- * connect(SamplesComponent, { samples: SamplesStore }, [SamplesActions.list])
+ * connect(SamplesComponent, { samples: SamplesStore }, ({ samples }) => ({ samples: samples.filter(sample => sample.id === 4) }))
  *
  */
-export default (Component, stores) => {
-  return class ConnectStoresWrapper extends React.Component {
+export default (Component, stores, mapProps = props => props) => {
+  const wrappedComponentName = Component.displayName || Component.name || 'Unknown/Anonymous';
+  class ConnectStoresWrapper extends React.Component {
     constructor(props) {
       super(props);
 
@@ -43,7 +45,11 @@ export default (Component, stores) => {
       // Retrieving initial state from each configured store
       Object.keys(stores).forEach((key) => {
         const store = stores[key];
-        if (isFunction(store.getInitialState)) {
+        if (store === undefined) {
+          // eslint-disable-next-line no-console
+          console.error(`Error: The store passed for the \`${key}\` property is not defined. Check the connect()-call wrapping your \`${wrappedComponentName}\` component.`);
+        }
+        else if (isFunction(store.getInitialState)) {
           this.state[key] = store.getInitialState();
         }
       });
@@ -69,7 +75,10 @@ export default (Component, stores) => {
         storeProps[key] = this.state[key];
       });
 
-      return <Component {...storeProps} {...this.props} />;
+      return <Component {...mapProps(storeProps)} {...this.props} />;
     }
-  };
+  }
+  ConnectStoresWrapper.displayName = `ConnectStoresWrapper[${wrappedComponentName}] stores=${Object.keys(stores)}`;
+
+  return ConnectStoresWrapper;
 };

--- a/graylog2-web-interface/src/stores/connect.jsx
+++ b/graylog2-web-interface/src/stores/connect.jsx
@@ -48,8 +48,7 @@ export default (Component, stores, mapProps = props => props) => {
         if (store === undefined) {
           // eslint-disable-next-line no-console
           console.error(`Error: The store passed for the \`${key}\` property is not defined. Check the connect()-call wrapping your \`${wrappedComponentName}\` component.`);
-        }
-        else if (isFunction(store.getInitialState)) {
+        } else if (isFunction(store.getInitialState)) {
           this.state[key] = store.getInitialState();
         }
       });


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context

This PR is adding small improvements to the `connect` helper function
used to connect React components to Reflux stores:

  * Adds a meaningful `displayName` to the generated wrapper component
which is visible in Chrome Devtools during debugging, including the name
of the wrapped component and the configured stores
  * Allows passing a props mapper function to mangle props before
passing them to the component, which is helping to prevent unneeded re-rendering
  * Corrects example in JSDoc
  * Adds helpful error message which is printed to the console when one
of the passed stores is `undefined`

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
