### PR TITLE
Add stream ID to stream rule metrics name

### DIFF
--- a/UPGRADING.rst
+++ b/UPGRADING.rst
@@ -272,3 +272,16 @@ See also:
 * `to_ip() <http://docs.graylog.org/en/3.0/pages/pipelines/functions.html#to-ip>`_
 * `cidr_match() <http://docs.graylog.org/en/3.0/pages/pipelines/functions.html#cidr-match>`_
 * `drop_message() <http://docs.graylog.org/en/3.0/pages/pipelines/functions.html#drop-message>`_
+
+Changed metrics name for stream rules
+=====================================
+
+The name of the metrics for stream rules have been changed to include the stream ID which helps identifying the actual stream they are related to.
+
+Old metric name::
+
+    org.graylog2.plugin.streams.StreamRule.${stream-rule-id}.executionTime
+
+New metric name::
+
+    org.graylog2.plugin.streams.Stream.${stream-id}.StreamRule.${stream-rule-id}.executionTime

--- a/graylog2-server/src/main/java/org/graylog2/streams/StreamMetrics.java
+++ b/graylog2-server/src/main/java/org/graylog2/streams/StreamMetrics.java
@@ -46,10 +46,10 @@ public class StreamMetrics {
         getIncomingMeter(streamId).mark();
     }
 
-    public Timer getExecutionTimer(String streamRuleId) {
+    public Timer getExecutionTimer(String streamId, String streamRuleId) {
         Timer timer = this.streamExecutionTimers.get(streamRuleId);
         if (timer == null) {
-            timer = metricRegistry.timer(MetricRegistry.name(StreamRule.class, streamRuleId, "executionTime"));
+            timer = metricRegistry.timer(MetricRegistry.name(Stream.class, streamId, "StreamRule", streamRuleId, "executionTime"));
             this.streamExecutionTimers.put(streamRuleId, timer);
         }
 

--- a/graylog2-server/src/test/java/org/graylog2/streams/StreamMetricsTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/streams/StreamMetricsTest.java
@@ -1,0 +1,44 @@
+/**
+ * This file is part of Graylog.
+ *
+ * Graylog is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.graylog2.streams;
+
+import com.codahale.metrics.MetricRegistry;
+import com.codahale.metrics.Timer;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class StreamMetricsTest {
+    private MetricRegistry metricRegistry;
+    private StreamMetrics streamMetrics;
+
+    @Before
+    public void setUp() {
+        metricRegistry = new MetricRegistry();
+        streamMetrics = new StreamMetrics(metricRegistry);
+    }
+
+    @Test
+    public void getExecutionTimer() {
+        final Timer timer = streamMetrics.getExecutionTimer("stream-id", "stream-rule-id");
+
+        assertThat(timer).isNotNull();
+        assertThat(metricRegistry.getTimers())
+                .containsKey("org.graylog2.plugin.streams.Stream.stream-id.StreamRule.stream-rule-id.executionTime");
+    }
+}


### PR DESCRIPTION
## Description

The original metrics name didn't contain any information about the stream which the stream rule was part of.

This made it very hard to identify the stream which included the stream rule and was only possible by either querying MongoDB directly or take a look into each stream (brute force).

This change set changes the metrics name from

    org.graylog2.plugin.streams.StreamRule.${stream-rule-id}.executionTime

to

    org.graylog2.plugin.streams.Stream.${stream-id}.StreamRule.${stream-rule-id}.executionTime

Refs https://community.graylog.org/t/identify-stream-rule-from-metrics/5266

## Types of changes

- Breaking change (fix or feature that would cause existing functionality to change)