### PR TITLE
Upgrade to Jest 2.4.13+jackson

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -95,7 +95,7 @@
         <commons-io.version>2.6</commons-io.version>
         <disruptor.version>3.4.0</disruptor.version>
         <elasticsearch.version>5.6.8</elasticsearch.version>
-        <jest.version>2.4.12+jackson</jest.version>
+        <jest.version>2.4.13+jackson</jest.version>
         <gelfclient.version>1.4.1</gelfclient.version>
         <geoip2.version>2.11.0</geoip2.version>
         <grok.version>0.1.9-graylog</grok.version>


### PR DESCRIPTION
Prevent logging of Elasticsearch node credentials on startup.

Fixes #4804
Refs searchbox-io/Jest#592
Refs graylog-labs/Jest@55ad3d51b7a4a73e6fa7c46e1957565e63bc423e