### PR TITLE
Do not update positions after click in widget actions

### DIFF
--- a/graylog2-web-interface/src/components/common/ReactGridContainer.css
+++ b/graylog2-web-interface/src/components/common/ReactGridContainer.css
@@ -13,3 +13,7 @@
 :local(.reactGridLayout) .react-grid-placeholder {
     background: #16ACE3;
 }
+
+:local(.reactGridLayout) .actions {
+    cursor: default;
+}

--- a/graylog2-web-interface/src/components/common/ReactGridContainer.jsx
+++ b/graylog2-web-interface/src/components/common/ReactGridContainer.jsx
@@ -84,6 +84,9 @@ const ReactGridContainer = React.createClass({
                                     cols={COLUMNS}
                                     rowHeight={rowHeight}
                                     margin={[10, 10]}
+                                    // Do not allow dragging from elements inside a `.actions` css class. This is
+                                    // meant to avoid calling `onDragStop` callbacks when clicking on an action button.
+                                    draggableCancel=".actions"
                                     onDragStop={this._onLayoutChange}
                                     onResizeStop={this._onLayoutChange}
                                     draggableHandle={locked ? '.no-handle' : ''}>


### PR DESCRIPTION
Clicking anywhere on an unlocked widget generates a drag event, which in our case ends up sending a request to the server to update widgets positions. This also affects buttons that are meant to do other actions (like delete or edit widgets), making #4525 more likely to appear.

This PR is a partial backport of #4530, only including changes to avoid calling drag callbacks when a user clicks on the edit or delete buttons for a widget, which mitigates #4525.

Fixes #4525

PS: The issue seems to be way more likely to occur in Google Chrome than other browsers, so it's easier to reproduce the issue in that browser.
