### PR TITLE
New grok pattern input component

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/grok/InMemoryGrokPatternService.java
+++ b/graylog2-server/src/main/java/org/graylog2/grok/InMemoryGrokPatternService.java
@@ -115,10 +115,10 @@ public class InMemoryGrokPatternService implements GrokPatternService {
     public Map<String, Object> match(GrokPattern pattern, String sampleData) throws GrokException {
         final Set<GrokPattern> patterns = loadAll();
         final GrokCompiler grokCompiler = GrokCompiler.newInstance();
-        grokCompiler.register(pattern.name(), pattern.pattern());
         for(GrokPattern storedPattern : patterns) {
             grokCompiler.register(storedPattern.name(), storedPattern.pattern());
         }
+        grokCompiler.register(pattern.name(), pattern.pattern());
         Grok grok = grokCompiler.compile("%{" + pattern.name() + "}");
         return grok.capture(sampleData);
     }
@@ -128,10 +128,10 @@ public class InMemoryGrokPatternService implements GrokPatternService {
         final Set<GrokPattern> patterns = loadAll();
         final boolean fieldsMissing = Strings.isNullOrEmpty(pattern.name()) || Strings.isNullOrEmpty(pattern.pattern());
         final GrokCompiler grokCompiler = GrokCompiler.newInstance();
-        grokCompiler.register(pattern.name(), pattern.pattern());
         for(GrokPattern storedPattern : patterns) {
             grokCompiler.register(storedPattern.name(), storedPattern.pattern());
         }
+        grokCompiler.register(pattern.name(), pattern.pattern());
         grokCompiler.compile("%{" + pattern.name() + "}");
         return !fieldsMissing;
     }

--- a/graylog2-server/src/main/java/org/graylog2/grok/MongoDbGrokPatternService.java
+++ b/graylog2-server/src/main/java/org/graylog2/grok/MongoDbGrokPatternService.java
@@ -116,10 +116,10 @@ public class MongoDbGrokPatternService implements GrokPatternService {
     public Map<String, Object> match(GrokPattern pattern, String sampleData) throws GrokException {
         final Set<GrokPattern> patterns = loadAll();
         final GrokCompiler grokCompiler = GrokCompiler.newInstance();
-        grokCompiler.register(pattern.name(), pattern.pattern());
         for(GrokPattern storedPattern : patterns) {
             grokCompiler.register(storedPattern.name(), storedPattern.pattern());
         }
+        grokCompiler.register(pattern.name(), pattern.pattern());
         Grok grok = grokCompiler.compile("%{" + pattern.name() + "}");
         return grok.capture(sampleData);
     }
@@ -130,10 +130,10 @@ public class MongoDbGrokPatternService implements GrokPatternService {
         final Set<GrokPattern> patterns = loadAll();
         final boolean fieldsMissing = Strings.isNullOrEmpty(pattern.name()) || Strings.isNullOrEmpty(pattern.pattern());
         final GrokCompiler grokCompiler = GrokCompiler.newInstance();
-        grokCompiler.register(pattern.name(), pattern.pattern());
         for(GrokPattern storedPattern : patterns) {
             grokCompiler.register(storedPattern.name(), storedPattern.pattern());
         }
+        grokCompiler.register(pattern.name(), pattern.pattern());
         grokCompiler.compile("%{" + pattern.name() + "}");
         return !fieldsMissing;
     }

--- a/graylog2-web-interface/src/components/bootstrap/BootstrapModalForm.jsx
+++ b/graylog2-web-interface/src/components/bootstrap/BootstrapModalForm.jsx
@@ -21,6 +21,7 @@ class BootstrapModalForm extends React.Component {
     onModalClose: () => {},
     onSubmitForm: undefined,
     onCancel: () => {},
+    bsSize: 'large',
   }
 
   static propTypes = {
@@ -42,6 +43,9 @@ class BootstrapModalForm extends React.Component {
     /* Text to use in the submit button. "Submit" is the default */
     submitButtonText: PropTypes.string,
     submitButtonDisabled: PropTypes.bool,
+    bsSize: PropTypes.oneOf([
+      'large', 'lg', 'small', 'sm',
+    ]),
   }
 
   onModalCancel = () => {
@@ -91,6 +95,7 @@ class BootstrapModalForm extends React.Component {
       <BootstrapModalWrapper ref={(c) => { this.modal = c; }}
                              onOpen={this.props.onModalOpen}
                              onClose={this.props.onModalClose}
+                             bsSize={this.props.bsSize}
                              onHide={this.onModalCancel}>
         <Modal.Header closeButton>
           <Modal.Title>{this.props.title}</Modal.Title>

--- a/graylog2-web-interface/src/components/bootstrap/BootstrapModalForm.jsx
+++ b/graylog2-web-interface/src/components/bootstrap/BootstrapModalForm.jsx
@@ -21,8 +21,8 @@ class BootstrapModalForm extends React.Component {
     onModalClose: () => {},
     onSubmitForm: undefined,
     onCancel: () => {},
-    bsSize: 'large',
-  }
+    bsSize: undefined,
+  };
 
   static propTypes = {
     /* Modal title */
@@ -46,20 +46,20 @@ class BootstrapModalForm extends React.Component {
     bsSize: PropTypes.oneOf([
       'large', 'lg', 'small', 'sm',
     ]),
-  }
+  };
 
   onModalCancel = () => {
     this.props.onCancel();
     this.close();
-  }
+  };
 
   open = () => {
     this.modal.open();
-  }
+  };
 
   close = () => {
     this.modal.close();
-  }
+  };
 
   submit = (event) => {
     const formDOMNode = this.form;
@@ -82,7 +82,7 @@ class BootstrapModalForm extends React.Component {
       event.preventDefault();
       this.props.onSubmitForm(event);
     }
-  }
+  };
 
   render() {
     const body = (

--- a/graylog2-web-interface/src/components/bootstrap/BootstrapModalWrapper.jsx
+++ b/graylog2-web-interface/src/components/bootstrap/BootstrapModalWrapper.jsx
@@ -42,7 +42,7 @@ class BootstrapModalWrapper extends React.Component {
 
   render() {
     return (
-      <Modal show={this.state.showModal} onHide={this.hide}>
+      <Modal show={this.state.showModal} onHide={this.hide} bsSize="large">
         {this.props.children}
       </Modal>
     );

--- a/graylog2-web-interface/src/components/bootstrap/BootstrapModalWrapper.jsx
+++ b/graylog2-web-interface/src/components/bootstrap/BootstrapModalWrapper.jsx
@@ -11,7 +11,7 @@ class BootstrapModalWrapper extends React.Component {
     onOpen: () => {},
     onClose: () => {},
     onHide: () => {},
-    bsSize: 'large',
+    bsSize: undefined,
   };
 
   static propTypes = {

--- a/graylog2-web-interface/src/components/bootstrap/BootstrapModalWrapper.jsx
+++ b/graylog2-web-interface/src/components/bootstrap/BootstrapModalWrapper.jsx
@@ -11,7 +11,8 @@ class BootstrapModalWrapper extends React.Component {
     onOpen: () => {},
     onClose: () => {},
     onHide: () => {},
-  }
+    bsSize: 'large',
+  };
 
   static propTypes = {
     showModal: PropTypes.bool,
@@ -22,27 +23,30 @@ class BootstrapModalWrapper extends React.Component {
     onOpen: PropTypes.func,
     onClose: PropTypes.func,
     onHide: PropTypes.func,
-  }
+    bsSize: PropTypes.oneOf([
+      'large', 'lg', 'small', 'sm',
+    ]),
+  };
 
   state = {
     showModal: this.props.showModal || false,
-  }
+  };
 
   open = () => {
     this.setState({ showModal: true }, this.props.onOpen);
-  }
+  };
 
   close = () => {
     this.setState({ showModal: false }, this.props.onClose);
-  }
+  };
 
   hide = () => {
     this.setState({ showModal: false }, this.props.onHide);
-  }
+  };
 
   render() {
     return (
-      <Modal show={this.state.showModal} onHide={this.hide} bsSize="large">
+      <Modal show={this.state.showModal} onHide={this.hide} bsSize={this.props.bsSize}>
         {this.props.children}
       </Modal>
     );

--- a/graylog2-web-interface/src/components/grok-patterns/EditPatternModal.jsx
+++ b/graylog2-web-interface/src/components/grok-patterns/EditPatternModal.jsx
@@ -1,14 +1,17 @@
 import PropTypes from 'prop-types';
 import React from 'react';
-import { BootstrapModalForm, Input } from 'components/bootstrap';
 
+import { BootstrapModalForm, Input } from 'components/bootstrap';
 import { Button, Panel } from 'react-bootstrap';
+
+import GrokPatternInput from './GrokPatternInput';
 
 class EditPatternModal extends React.Component {
   static propTypes = {
     id: PropTypes.string,
     name: PropTypes.string,
     pattern: PropTypes.string,
+    patterns: PropTypes.array,
     create: PropTypes.bool,
     sampleData: PropTypes.string,
     savePattern: PropTypes.func.isRequired,
@@ -20,6 +23,7 @@ class EditPatternModal extends React.Component {
     id: '',
     name: '',
     pattern: '',
+    patterns: [],
     create: false,
     sampleData: '',
     testPattern: () => {},
@@ -40,8 +44,8 @@ class EditPatternModal extends React.Component {
     this.modal.open();
   };
 
-  _onPatternChange = (event) => {
-    this.setState({ pattern: event.target.value });
+  _onPatternChange = (newPattern) => {
+    this.setState({ pattern: newPattern });
   };
 
   _onNameChange = (event) => {
@@ -122,18 +126,13 @@ class EditPatternModal extends React.Component {
                    help={this.state.error ? this.state.error_message : "Under this name the pattern will be stored and can be used like: '%{THISNAME}' later on "}
                    autoFocus
                    required />
-            <Input type="textarea"
-                   id={this._getId('pattern')}
-                   label="Pattern"
-                   help="The pattern which will match the log line e.g: '%{IP:client}' or '.*?'"
-                   onChange={this._onPatternChange}
-                   value={this.state.pattern}
-                   required />
+            <GrokPatternInput onPatternChange={this._onPatternChange}
+                              pattern={this.state.pattern}
+                              patterns={this.props.patterns} />
             { this.state.test_error &&
             <Panel bsStyle="danger" header="Grok Error">
               <code style={{ display: 'block', whiteSpace: 'pre-wrap' }} >{this.state.test_error}</code>
-            </Panel>
-            }
+            </Panel> }
             <Input type="textarea"
                    id={this._getId('sampleData')}
                    label="Sample Data"

--- a/graylog2-web-interface/src/components/grok-patterns/EditPatternModal.jsx
+++ b/graylog2-web-interface/src/components/grok-patterns/EditPatternModal.jsx
@@ -114,6 +114,7 @@ class EditPatternModal extends React.Component {
         </button>
         <BootstrapModalForm ref={(modal) => { this.modal = modal; }}
                             title={`${this.props.create ? 'Create' : 'Edit'} Grok Pattern ${this.state.name}`}
+                            bsSize="large"
                             onSubmitForm={this._save}
                             submitButtonText="Save">
           <fieldset>

--- a/graylog2-web-interface/src/components/grok-patterns/GrokPatternInput.css
+++ b/graylog2-web-interface/src/components/grok-patterns/GrokPatternInput.css
@@ -1,0 +1,12 @@
+:local(.resultList) {
+    height: 160px;
+    max-height: 160px;
+    overflow: hidden;
+    overflow-y: scroll;
+    padding-left: 0;
+    border-bottom: 1px solid #ddd;
+}
+
+:local(.filterFormGroup) {
+    margin-bottom: 0px;
+}

--- a/graylog2-web-interface/src/components/grok-patterns/GrokPatternInput.css
+++ b/graylog2-web-interface/src/components/grok-patterns/GrokPatternInput.css
@@ -10,3 +10,16 @@
 :local(.filterFormGroup) {
     margin-bottom: 0px;
 }
+
+:local(.addButton) {
+    position: absolute;
+    top: 7px;
+    right: 7px;
+}
+
+:local(.patternDisplay) {
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    overflow: hidden;
+    display: block;
+}

--- a/graylog2-web-interface/src/components/grok-patterns/GrokPatternInput.jsx
+++ b/graylog2-web-interface/src/components/grok-patterns/GrokPatternInput.jsx
@@ -44,7 +44,9 @@ class GrokPatternInput extends React.Component {
     const listItem = this.shownListItems[this.state.activeListItem];
 
     let activeListItem = 0;
+    const firstElement = document.getElementById(`list-item-0`);
     let domElement;
+    let list;
     switch (e.keyCode) {
       case ARROW_DOWN:
         activeListItem = this.state.activeListItem + 1;
@@ -52,7 +54,8 @@ class GrokPatternInput extends React.Component {
           return;
         }
         domElement = document.getElementById(`list-item-${activeListItem}`);
-        domElement.scrollIntoView({ behavior: 'smooth' });
+        list = domElement.parentElement;
+        list.scrollTop = domElement.offsetTop - firstElement.offsetTop;
         this.setState({ activeListItem: activeListItem });
         e.preventDefault();
         break;
@@ -62,7 +65,8 @@ class GrokPatternInput extends React.Component {
           return;
         }
         domElement = document.getElementById(`list-item-${activeListItem}`);
-        domElement.scrollIntoView();
+        list = domElement.parentElement;
+        list.scrollTop = domElement.offsetTop - firstElement.offsetTop;
         this.setState({ activeListItem: activeListItem });
         e.preventDefault();
         break;

--- a/graylog2-web-interface/src/components/grok-patterns/GrokPatternInput.jsx
+++ b/graylog2-web-interface/src/components/grok-patterns/GrokPatternInput.jsx
@@ -1,0 +1,137 @@
+import PropTypes from 'prop-types';
+import React from 'react';
+
+import { Input } from 'components/bootstrap';
+import { Row, Col, Button, ListGroup, ListGroupItem } from 'react-bootstrap';
+
+import GrokPatternInputStyle from './GrokPatternInput.css';
+
+class GrokPatternInput extends React.Component {
+  static propTypes = {
+    pattern: PropTypes.string,
+    patterns: PropTypes.array,
+    onPatternChange: PropTypes.func,
+  };
+
+  static defaultProps = {
+    pattern: '',
+    patterns: [],
+    onPatternChange: () => {},
+  };
+
+  constructor(props) {
+    super(props);
+    this.state = {
+      patternFilter: '',
+      activeListItem: -1,
+    };
+  }
+
+  shownListItems = [];
+
+  _onPatternChange = (e) => {
+    this.props.onPatternChange(e.target.value);
+  };
+
+  _onPatternFilterChange = (e) => {
+    this.setState({ patternFilter: e.target.value, activeListItem: -1 });
+  };
+
+  _onPatternFilterKeyDown = (e) => {
+    const ARROW_DOWN = 40;
+    const ARROW_UP = 38;
+    const ENTER = 13;
+
+    let activeListItem = 0;
+    let domElement;
+    switch (e.keyCode) {
+      case ARROW_DOWN:
+        activeListItem = this.state.activeListItem + 1;
+        if (activeListItem >= this.shownListItems.length) {
+          return;
+        }
+        domElement = document.getElementById(`list-item-${activeListItem}`);
+        domElement.scrollIntoView({ behavior: 'smooth' });
+        this.setState({ activeListItem: activeListItem });
+        e.preventDefault();
+        break;
+      case ARROW_UP:
+        activeListItem = this.state.activeListItem - 1;
+        if (activeListItem < 0) {
+          return;
+        }
+        domElement = document.getElementById(`list-item-${activeListItem}`);
+        domElement.scrollIntoView();
+        this.setState({ activeListItem: activeListItem });
+        e.preventDefault();
+        break;
+      case ENTER:
+        this._addToPattern(this.shownListItems[this.state.activeListItem]);
+        e.preventDefault();
+        break;
+      default:
+        break;
+    }
+  };
+
+  _addToPattern = (name) => {
+    const pattern = this.props.pattern || '';
+    const index = this.patternInput.getInputDOMNode().selectionStart || pattern.length;
+    const newPattern = `${pattern.slice(0, index)}%{${name}}${pattern.slice(index)}`;
+    this.props.onPatternChange(newPattern);
+  };
+
+  render() {
+    const regExp = RegExp(this.state.patternFilter, 'i');
+    const maxLength = 20;
+    this.shownListItems = [];
+    const patternsToDisplay = this.props.patterns.filter(pattern => regExp.test(pattern.name))
+      .map((pattern, index) => {
+        const patternDisplay = pattern.pattern.length > maxLength ?
+          `${pattern.pattern.substring(0, maxLength)} ...` : pattern.pattern;
+        const active = index === this.state.activeListItem;
+        this.shownListItems.push(pattern.name);
+        return (
+          <ListGroupItem id={`list-item-${index}`}
+                         header={pattern.name}
+                         bsStyle={active ? 'info' : undefined}
+                         onKeyDown={this._onPatternFilterKeyDown}
+                         key={pattern.name}>
+            <span>{patternDisplay}</span>
+            <span className="pull-right">
+              <Button bsSize="xsmall" bsStyle="primary" onClick={() => { this._addToPattern(pattern.name); }}>
+                Add
+              </Button>
+            </span>
+          </ListGroupItem>);
+      });
+    return (
+      <Row>
+        <Col sm={8}>
+          <Input ref={(node) => { this.patternInput = node; }}
+                 type="textarea"
+                 id="pattern-input"
+                 label="Pattern"
+                 help="The pattern which will match the log line e.g: '%{IP:client}' or '.*?'"
+                 rows={9}
+                 onChange={this._onPatternChange}
+                 value={this.props.pattern}
+                 required />
+        </Col>
+        <Col sm={4}>
+          <Input type="text"
+                 id="pattern-selector"
+                 label="Filter pattern"
+                 onChange={this._onPatternFilterChange}
+                 autoComplete="off"
+                 formGroupClassName={GrokPatternInputStyle.filterFormGroup}
+                 onKeyDown={this._onPatternFilterKeyDown}
+                 value={this.state.patternFilter} />
+          <ListGroup bsClass={GrokPatternInputStyle.resultList}>{patternsToDisplay}</ListGroup>
+        </Col>
+      </Row>
+    );
+  }
+}
+
+export default GrokPatternInput;

--- a/graylog2-web-interface/src/components/grok-patterns/GrokPatternInput.jsx
+++ b/graylog2-web-interface/src/components/grok-patterns/GrokPatternInput.jsx
@@ -44,7 +44,7 @@ class GrokPatternInput extends React.Component {
     const listItem = this.shownListItems[this.state.activeListItem];
 
     let activeListItem = 0;
-    const firstElement = document.getElementById(`list-item-0`);
+    const firstElement = document.getElementById('list-item-0');
     let domElement;
     let list;
     switch (e.keyCode) {

--- a/graylog2-web-interface/src/components/grok-patterns/GrokPatternInput.jsx
+++ b/graylog2-web-interface/src/components/grok-patterns/GrokPatternInput.jsx
@@ -41,6 +41,7 @@ class GrokPatternInput extends React.Component {
     const ARROW_DOWN = 40;
     const ARROW_UP = 38;
     const ENTER = 13;
+    const listItem = this.shownListItems[this.state.activeListItem];
 
     let activeListItem = 0;
     let domElement;
@@ -66,7 +67,9 @@ class GrokPatternInput extends React.Component {
         e.preventDefault();
         break;
       case ENTER:
-        this._addToPattern(this.shownListItems[this.state.activeListItem]);
+        if (listItem) {
+          this._addToPattern(listItem);
+        }
         e.preventDefault();
         break;
       default:
@@ -83,12 +86,9 @@ class GrokPatternInput extends React.Component {
 
   render() {
     const regExp = RegExp(this.state.patternFilter, 'i');
-    const maxLength = 20;
     this.shownListItems = [];
     const patternsToDisplay = this.props.patterns.filter(pattern => regExp.test(pattern.name))
       .map((pattern, index) => {
-        const patternDisplay = pattern.pattern.length > maxLength ?
-          `${pattern.pattern.substring(0, maxLength)} ...` : pattern.pattern;
         const active = index === this.state.activeListItem;
         this.shownListItems.push(pattern.name);
         return (
@@ -97,8 +97,8 @@ class GrokPatternInput extends React.Component {
                          bsStyle={active ? 'info' : undefined}
                          onKeyDown={this._onPatternFilterKeyDown}
                          key={pattern.name}>
-            <span>{patternDisplay}</span>
-            <span className="pull-right">
+            <span className={GrokPatternInputStyle.patternDisplay}>{pattern.pattern}</span>
+            <span className={GrokPatternInputStyle.addButton}>
               <Button bsSize="xsmall" bsStyle="primary" onClick={() => { this._addToPattern(pattern.name); }}>
                 Add
               </Button>

--- a/graylog2-web-interface/src/components/grok-patterns/GrokPatternInput.test.jsx
+++ b/graylog2-web-interface/src/components/grok-patterns/GrokPatternInput.test.jsx
@@ -1,0 +1,40 @@
+import React from 'react';
+import renderer from 'react-test-renderer';
+import { mount } from 'enzyme';
+import 'helpers/mocking/react-dom_mock';
+
+import GrokPatternInput from 'components/grok-patterns/GrokPatternInput';
+
+describe('<GrokPatternInput />', () => {
+  const grokPatterns = [
+    { name: 'COMMONMAC', pattern: '(?:(?:[A-Fa-f0-9]{2}:){5}[A-Fa-f0-9]{2})' },
+    { name: 'DATA', pattern: '.*?' },
+    { name: 'DATE', pattern: '%{MONTHDAY}[./-]%{MONTHNUM}[./-]%{YEAR}' },
+  ];
+
+  it('should render grok pattern input without patterns', () => {
+    const wrapper = renderer.create(<GrokPatternInput patterns={[]} />);
+    expect(wrapper.toJSON()).toMatchSnapshot();
+  });
+
+  it('should render grok pattern input with patterns', () => {
+    const wrapper = renderer.create(<GrokPatternInput patterns={grokPatterns} />);
+    expect(wrapper.toJSON()).toMatchSnapshot();
+  });
+
+  it('should add a grok pattern when selected', () => {
+    const changeFn = jest.fn((pattern) => {
+      expect(pattern).toEqual('%{COMMONMAC}');
+    });
+    const wrapper = mount(<GrokPatternInput patterns={grokPatterns} onPatternChange={changeFn} />);
+    wrapper.find('button[children="Add"]').at(0).simulate('click');
+    expect(changeFn.mock.calls.length).toBe(1);
+  });
+
+  it('should filter the grok patterns', () => {
+    const wrapper = mount(<GrokPatternInput patterns={grokPatterns} />);
+    expect(wrapper.find('button[children="Add"]').length).toBe(3);
+    wrapper.find('input#pattern-selector').simulate('change', { target: { value: 'COMMON' } });
+    expect(wrapper.find('button[children="Add"]').length).toBe(1);
+  });
+});

--- a/graylog2-web-interface/src/components/grok-patterns/GrokPatterns.jsx
+++ b/graylog2-web-interface/src/components/grok-patterns/GrokPatterns.jsx
@@ -97,6 +97,7 @@ const GrokPatterns = createReactClass({
                               name={pattern.name}
                               pattern={pattern.pattern}
                               testPattern={this.testPattern}
+                              patterns={this.state.patterns}
                               create={false}
                               reload={this.loadData}
                               savePattern={this.savePattern}
@@ -125,6 +126,7 @@ const GrokPatterns = createReactClass({
               <EditPatternModal id={''}
                                 name={''}
                                 pattern={''}
+                                patterns={this.state.patterns}
                                 create
                                 testPattern={this.testPattern}
                                 reload={this.loadData}

--- a/graylog2-web-interface/src/components/grok-patterns/GrokPatterns.jsx
+++ b/graylog2-web-interface/src/components/grok-patterns/GrokPatterns.jsx
@@ -81,6 +81,7 @@ const GrokPatterns = createReactClass({
   },
 
   _patternFormatter(pattern) {
+    const patterns = this.state.patterns.filter(p => p.name !== pattern.name);
     return (
       <tr key={pattern.id}>
         <td>{pattern.name}</td>
@@ -97,7 +98,7 @@ const GrokPatterns = createReactClass({
                               name={pattern.name}
                               pattern={pattern.pattern}
                               testPattern={this.testPattern}
-                              patterns={this.state.patterns}
+                              patterns={patterns}
                               create={false}
                               reload={this.loadData}
                               savePattern={this.savePattern}

--- a/graylog2-web-interface/src/components/grok-patterns/__snapshots__/GrokPatternInput.test.jsx.snap
+++ b/graylog2-web-interface/src/components/grok-patterns/__snapshots__/GrokPatternInput.test.jsx.snap
@@ -79,11 +79,13 @@ exports[`<GrokPatternInput /> should render grok pattern input with patterns 1`]
         <p
           className="list-group-item-text"
         >
-          <span>
-            (?:(?:[A-Fa-f0-9]{2} ...
+          <span
+            className="patternDisplay"
+          >
+            (?:(?:[A-Fa-f0-9]{2}:){5}[A-Fa-f0-9]{2})
           </span>
           <span
-            className="pull-right"
+            className="addButton"
           >
             <button
               className="btn btn-xs btn-primary"
@@ -109,11 +111,13 @@ exports[`<GrokPatternInput /> should render grok pattern input with patterns 1`]
         <p
           className="list-group-item-text"
         >
-          <span>
+          <span
+            className="patternDisplay"
+          >
             .*?
           </span>
           <span
-            className="pull-right"
+            className="addButton"
           >
             <button
               className="btn btn-xs btn-primary"
@@ -139,11 +143,13 @@ exports[`<GrokPatternInput /> should render grok pattern input with patterns 1`]
         <p
           className="list-group-item-text"
         >
-          <span>
-            %{MONTHDAY}[./-]%{MO ...
+          <span
+            className="patternDisplay"
+          >
+            %{MONTHDAY}[./-]%{MONTHNUM}[./-]%{YEAR}
           </span>
           <span
-            className="pull-right"
+            className="addButton"
           >
             <button
               className="btn btn-xs btn-primary"

--- a/graylog2-web-interface/src/components/grok-patterns/__snapshots__/GrokPatternInput.test.jsx.snap
+++ b/graylog2-web-interface/src/components/grok-patterns/__snapshots__/GrokPatternInput.test.jsx.snap
@@ -1,0 +1,232 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`<GrokPatternInput /> should render grok pattern input with patterns 1`] = `
+<div
+  className="row"
+>
+  <div
+    className="col-sm-8"
+  >
+    <div
+      className="form-group"
+    >
+      <label
+        className="control-label"
+        htmlFor="pattern-input"
+      >
+        Pattern
+      </label>
+      <span>
+        <textarea
+          className="form-control"
+          id="pattern-input"
+          label="Pattern"
+          onChange={[Function]}
+          placeholder=""
+          required={true}
+          rows={9}
+          type="textarea"
+          value=""
+        />
+        <span
+          className="help-block"
+        >
+          The pattern which will match the log line e.g: '%{IP:client}' or '.*?'
+        </span>
+      </span>
+    </div>
+  </div>
+  <div
+    className="col-sm-4"
+  >
+    <div
+      className="filterFormGroup"
+    >
+      <label
+        className="control-label"
+        htmlFor="pattern-selector"
+      >
+        Filter pattern
+      </label>
+      <span>
+        <input
+          autoComplete="off"
+          className="form-control"
+          id="pattern-selector"
+          label="Filter pattern"
+          onChange={[Function]}
+          onKeyDown={[Function]}
+          placeholder=""
+          type="text"
+          value=""
+        />
+        
+      </span>
+    </div>
+    <ul
+      className="resultList"
+    >
+      <li
+        className="list-group-item"
+        id="list-item-0"
+        onKeyDown={[Function]}
+      >
+        <h4
+          className="list-group-item-heading"
+        >
+          COMMONMAC
+        </h4>
+        <p
+          className="list-group-item-text"
+        >
+          <span>
+            (?:(?:[A-Fa-f0-9]{2} ...
+          </span>
+          <span
+            className="pull-right"
+          >
+            <button
+              className="btn btn-xs btn-primary"
+              disabled={false}
+              onClick={[Function]}
+              type="button"
+            >
+              Add
+            </button>
+          </span>
+        </p>
+      </li>
+      <li
+        className="list-group-item"
+        id="list-item-1"
+        onKeyDown={[Function]}
+      >
+        <h4
+          className="list-group-item-heading"
+        >
+          DATA
+        </h4>
+        <p
+          className="list-group-item-text"
+        >
+          <span>
+            .*?
+          </span>
+          <span
+            className="pull-right"
+          >
+            <button
+              className="btn btn-xs btn-primary"
+              disabled={false}
+              onClick={[Function]}
+              type="button"
+            >
+              Add
+            </button>
+          </span>
+        </p>
+      </li>
+      <li
+        className="list-group-item"
+        id="list-item-2"
+        onKeyDown={[Function]}
+      >
+        <h4
+          className="list-group-item-heading"
+        >
+          DATE
+        </h4>
+        <p
+          className="list-group-item-text"
+        >
+          <span>
+            %{MONTHDAY}[./-]%{MO ...
+          </span>
+          <span
+            className="pull-right"
+          >
+            <button
+              className="btn btn-xs btn-primary"
+              disabled={false}
+              onClick={[Function]}
+              type="button"
+            >
+              Add
+            </button>
+          </span>
+        </p>
+      </li>
+    </ul>
+  </div>
+</div>
+`;
+
+exports[`<GrokPatternInput /> should render grok pattern input without patterns 1`] = `
+<div
+  className="row"
+>
+  <div
+    className="col-sm-8"
+  >
+    <div
+      className="form-group"
+    >
+      <label
+        className="control-label"
+        htmlFor="pattern-input"
+      >
+        Pattern
+      </label>
+      <span>
+        <textarea
+          className="form-control"
+          id="pattern-input"
+          label="Pattern"
+          onChange={[Function]}
+          placeholder=""
+          required={true}
+          rows={9}
+          type="textarea"
+          value=""
+        />
+        <span
+          className="help-block"
+        >
+          The pattern which will match the log line e.g: '%{IP:client}' or '.*?'
+        </span>
+      </span>
+    </div>
+  </div>
+  <div
+    className="col-sm-4"
+  >
+    <div
+      className="filterFormGroup"
+    >
+      <label
+        className="control-label"
+        htmlFor="pattern-selector"
+      >
+        Filter pattern
+      </label>
+      <span>
+        <input
+          autoComplete="off"
+          className="form-control"
+          id="pattern-selector"
+          label="Filter pattern"
+          onChange={[Function]}
+          onKeyDown={[Function]}
+          placeholder=""
+          type="text"
+          value=""
+        />
+        
+      </span>
+    </div>
+    <ul
+      className="resultList"
+    />
+  </div>
+</div>
+`;

--- a/graylog2-web-interface/src/components/users/__snapshots__/UserPreferencesButton.test.jsx.snap
+++ b/graylog2-web-interface/src/components/users/__snapshots__/UserPreferencesButton.test.jsx.snap
@@ -26,6 +26,7 @@ exports[`UserPreferencesButton should load user data when user clicks edit butto
       userName="Full"
     >
       <BootstrapModalForm
+        bsSize="large"
         cancelButtonText="Cancel"
         formProps={Object {}}
         onCancel={[Function]}
@@ -37,6 +38,7 @@ exports[`UserPreferencesButton should load user data when user clicks edit butto
         title="Preferences for user Full"
       >
         <BootstrapModalWrapper
+          bsSize="large"
           onClose={[Function]}
           onHide={[Function]}
           onOpen={[Function]}

--- a/graylog2-web-interface/src/components/users/__snapshots__/UserPreferencesButton.test.jsx.snap
+++ b/graylog2-web-interface/src/components/users/__snapshots__/UserPreferencesButton.test.jsx.snap
@@ -47,6 +47,7 @@ exports[`UserPreferencesButton should load user data when user clicks edit butto
             autoFocus={true}
             backdrop={true}
             bsClass="modal"
+            bsSize="large"
             dialogComponentClass={[Function]}
             enforceFocus={true}
             keyboard={true}

--- a/graylog2-web-interface/src/components/users/__snapshots__/UserPreferencesButton.test.jsx.snap
+++ b/graylog2-web-interface/src/components/users/__snapshots__/UserPreferencesButton.test.jsx.snap
@@ -26,7 +26,6 @@ exports[`UserPreferencesButton should load user data when user clicks edit butto
       userName="Full"
     >
       <BootstrapModalForm
-        bsSize="large"
         cancelButtonText="Cancel"
         formProps={Object {}}
         onCancel={[Function]}
@@ -38,7 +37,6 @@ exports[`UserPreferencesButton should load user data when user clicks edit butto
         title="Preferences for user Full"
       >
         <BootstrapModalWrapper
-          bsSize="large"
           onClose={[Function]}
           onHide={[Function]}
           onOpen={[Function]}
@@ -49,7 +47,6 @@ exports[`UserPreferencesButton should load user data when user clicks edit butto
             autoFocus={true}
             backdrop={true}
             bsClass="modal"
-            bsSize="large"
             dialogComponentClass={[Function]}
             enforceFocus={true}
             keyboard={true}


### PR DESCRIPTION
## Description
Create a new grok input component which will help a user creating a new
grok input from existing ones.

A user can search via filter for grok patterns and add them to the
text field beside him. A grok pattern will be placed under the current
cursor position of the text field.

## Motivation and Context
If you want to create a new grok pattern from existing ones you need to open a second
tap so you can search for the existing ones. To prevent such behavior we now have
the grok pattern filter which can also add the grok patterns to the text field.

## How Has This Been Tested?
Editing or creating a grok pattern and use the filter function to find a grok pattern and add it with 'Add' button.

## Screenshots (if appropriate):
![screenshot-2018-5-28 graylog - grok patterns](https://user-images.githubusercontent.com/448763/40615721-3e4d4186-6288-11e8-802b-cc81e3ca79c7.png)

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.