### PR TITLE
Add button after to input component again

### DIFF
--- a/graylog2-web-interface/src/components/bootstrap/Input.jsx
+++ b/graylog2-web-interface/src/components/bootstrap/Input.jsx
@@ -174,6 +174,7 @@ class Input extends React.Component {
       case 'radio':
         return this._renderRadioGroup(id, bsStyle, formGroupClassName, wrapperClassName, label, help, controlProps);
       default:
+        // eslint-disable-next-line no-console
         console.warn(`Unsupported input type ${type}`);
     }
 

--- a/graylog2-web-interface/src/components/bootstrap/Input.jsx
+++ b/graylog2-web-interface/src/components/bootstrap/Input.jsx
@@ -36,6 +36,10 @@ class Input extends React.Component {
       PropTypes.element,
       PropTypes.string,
     ]),
+    buttonAfter: PropTypes.oneOfType([
+      PropTypes.element,
+      PropTypes.string,
+    ]),
     children: PropTypes.oneOfType([
       PropTypes.array,
       PropTypes.element,
@@ -53,6 +57,7 @@ class Input extends React.Component {
     help: '',
     wrapperClassName: undefined,
     addonAfter: null,
+    buttonAfter: null,
     children: null,
   };
 
@@ -96,13 +101,15 @@ class Input extends React.Component {
     help,
     children,
     addon,
+    button,
   ) => {
     let input;
-    if (addon) {
+    if (addon || button) {
       input = (
         <InputGroup>
           {children}
-          <InputGroup.Addon>{addon}</InputGroup.Addon>
+          {button && <InputGroup.Button>{button}</InputGroup.Button>}
+          {addon && <InputGroup.Addon>{addon}</InputGroup.Addon>}
         </InputGroup>
       );
     } else {
@@ -143,7 +150,7 @@ class Input extends React.Component {
   };
 
   render() {
-    const { id, type, bsStyle, formGroupClassName, wrapperClassName, label, labelClassName, help, children, addonAfter, ...controlProps } = this.props;
+    const { id, type, bsStyle, formGroupClassName, wrapperClassName, label, labelClassName, help, children, addonAfter, buttonAfter, ...controlProps } = this.props;
     controlProps.type = type;
     controlProps.label = label;
 
@@ -157,7 +164,7 @@ class Input extends React.Component {
       case 'email':
       case 'number':
       case 'file':
-        return this._renderFormGroup(id, bsStyle, formGroupClassName, wrapperClassName, label, labelClassName, help, this._renderFormControl('input', controlProps), addonAfter);
+        return this._renderFormGroup(id, bsStyle, formGroupClassName, wrapperClassName, label, labelClassName, help, this._renderFormControl('input', controlProps), addonAfter, buttonAfter);
       case 'textarea':
         return this._renderFormGroup(id, bsStyle, formGroupClassName, wrapperClassName, label, labelClassName, help, this._renderFormControl('textarea', controlProps));
       case 'select':

--- a/graylog2-web-interface/src/components/bootstrap/Input.test.jsx
+++ b/graylog2-web-interface/src/components/bootstrap/Input.test.jsx
@@ -13,7 +13,7 @@ describe('Input', () => {
 
   it('renders a addon after the input if addonAfter is passed', () => {
     const wrapper = mount(<Input id="inputWithAddon" type="text" addonAfter={'.00'} />);
-    const addon = wrapper.find('span.input-group-addon')
+    const addon = wrapper.find('span.input-group-addon');
     expect(addon).toExist();
     expect(addon).toHaveText('.00');
     expect(wrapper).toMatchSnapshot();

--- a/graylog2-web-interface/src/components/bootstrap/Input.test.jsx
+++ b/graylog2-web-interface/src/components/bootstrap/Input.test.jsx
@@ -1,0 +1,27 @@
+import React from 'react';
+import { mount } from 'enzyme';
+import { Button } from 'react-bootstrap';
+
+import Input from './Input';
+
+describe('Input', () => {
+  it('renders a button after the input if buttonAfter is passed', () => {
+    const wrapper = mount(<Input id="inputWithButton" type="text" buttonAfter={<Button />} />);
+    expect(wrapper.find('button')).toExist();
+    expect(wrapper).toMatchSnapshot();
+  });
+
+  it('renders a addon after the input if addonAfter is passed', () => {
+    const wrapper = mount(<Input id="inputWithAddon" type="text" addonAfter={'.00'} />);
+    const addon = wrapper.find('span.input-group-addon')
+    expect(addon).toExist();
+    expect(addon).toHaveText('.00');
+    expect(wrapper).toMatchSnapshot();
+  });
+
+  it('renders a checkbox addon after the input if addonAfter is passed', () => {
+    const wrapper = mount(<Input id="inputWithCheckboxAddon" type="text" addonAfter={<input id="addonCheckbox" type="checkbox" aria-label="..." />} />);
+    expect(wrapper.find('input#addonCheckbox')).toExist();
+    expect(wrapper).toMatchSnapshot();
+  });
+});

--- a/graylog2-web-interface/src/components/bootstrap/__snapshots__/Input.test.jsx.snap
+++ b/graylog2-web-interface/src/components/bootstrap/__snapshots__/Input.test.jsx.snap
@@ -1,0 +1,214 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Input renders a addon after the input if addonAfter is passed 1`] = `
+<Input
+  addonAfter=".00"
+  bsStyle={null}
+  buttonAfter={null}
+  help=""
+  id="inputWithAddon"
+  label=""
+  placeholder=""
+  type="text"
+>
+  <FormGroup
+    bsClass="form-group"
+    controlId="inputWithAddon"
+    validationState={null}
+  >
+    <div
+      className="form-group"
+    >
+      <InputWrapper>
+        <span>
+          <InputGroup
+            bsClass="input-group"
+          >
+            <span
+              className="input-group"
+            >
+              <FormControl
+                bsClass="form-control"
+                componentClass="input"
+                inputRef={[Function]}
+                label=""
+                placeholder=""
+                type="text"
+              >
+                <input
+                  className="form-control"
+                  id="inputWithAddon"
+                  label=""
+                  placeholder=""
+                  type="text"
+                />
+              </FormControl>
+              <InputGroupAddon
+                bsClass="input-group-addon"
+              >
+                <span
+                  className="input-group-addon"
+                >
+                  .00
+                </span>
+              </InputGroupAddon>
+            </span>
+          </InputGroup>
+        </span>
+      </InputWrapper>
+    </div>
+  </FormGroup>
+</Input>
+`;
+
+exports[`Input renders a button after the input if buttonAfter is passed 1`] = `
+<Input
+  addonAfter={null}
+  bsStyle={null}
+  buttonAfter={
+    <Button
+      active={false}
+      block={false}
+      bsClass="btn"
+      bsStyle="default"
+      disabled={false}
+    />
+  }
+  help=""
+  id="inputWithButton"
+  label=""
+  placeholder=""
+  type="text"
+>
+  <FormGroup
+    bsClass="form-group"
+    controlId="inputWithButton"
+    validationState={null}
+  >
+    <div
+      className="form-group"
+    >
+      <InputWrapper>
+        <span>
+          <InputGroup
+            bsClass="input-group"
+          >
+            <span
+              className="input-group"
+            >
+              <FormControl
+                bsClass="form-control"
+                componentClass="input"
+                inputRef={[Function]}
+                label=""
+                placeholder=""
+                type="text"
+              >
+                <input
+                  className="form-control"
+                  id="inputWithButton"
+                  label=""
+                  placeholder=""
+                  type="text"
+                />
+              </FormControl>
+              <InputGroupButton
+                bsClass="input-group-btn"
+              >
+                <span
+                  className="input-group-btn"
+                >
+                  <Button
+                    active={false}
+                    block={false}
+                    bsClass="btn"
+                    bsStyle="default"
+                    disabled={false}
+                  >
+                    <button
+                      className="btn btn-default"
+                      disabled={false}
+                      type="button"
+                    />
+                  </Button>
+                </span>
+              </InputGroupButton>
+            </span>
+          </InputGroup>
+        </span>
+      </InputWrapper>
+    </div>
+  </FormGroup>
+</Input>
+`;
+
+exports[`Input renders a checkbox addon after the input if addonAfter is passed 1`] = `
+<Input
+  addonAfter={
+    <input
+      aria-label="..."
+      id="addonCheckbox"
+      type="checkbox"
+    />
+  }
+  bsStyle={null}
+  buttonAfter={null}
+  help=""
+  id="inputWithCheckboxAddon"
+  label=""
+  placeholder=""
+  type="text"
+>
+  <FormGroup
+    bsClass="form-group"
+    controlId="inputWithCheckboxAddon"
+    validationState={null}
+  >
+    <div
+      className="form-group"
+    >
+      <InputWrapper>
+        <span>
+          <InputGroup
+            bsClass="input-group"
+          >
+            <span
+              className="input-group"
+            >
+              <FormControl
+                bsClass="form-control"
+                componentClass="input"
+                inputRef={[Function]}
+                label=""
+                placeholder=""
+                type="text"
+              >
+                <input
+                  className="form-control"
+                  id="inputWithCheckboxAddon"
+                  label=""
+                  placeholder=""
+                  type="text"
+                />
+              </FormControl>
+              <InputGroupAddon
+                bsClass="input-group-addon"
+              >
+                <span
+                  className="input-group-addon"
+                >
+                  <input
+                    aria-label="..."
+                    id="addonCheckbox"
+                    type="checkbox"
+                  />
+                </span>
+              </InputGroupAddon>
+            </span>
+          </InputGroup>
+        </span>
+      </InputWrapper>
+    </div>
+  </FormGroup>
+</Input>
+`;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Since #3598 / bba0e6b components which are passed via the `buttonAfter` prop to the `Input` component are not rendered anymore, due to changes of the react-bootstrap API. This leads to inaccessible functionality as described in e.g. #4815.

This PR is reestablishing the used functionality.

Fixes #4815.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.