### PR TITLE
Dependency updates

### DIFF
--- a/graylog-plugin-archetype/pom.xml
+++ b/graylog-plugin-archetype/pom.xml
@@ -114,7 +114,7 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-resources-plugin</artifactId>
-                    <version>3.0.2</version>
+                    <version>3.1.0</version>
                 </plugin>
             </plugins>
         </pluginManagement>

--- a/graylog-plugin-parent/pom.xml
+++ b/graylog-plugin-parent/pom.xml
@@ -43,7 +43,7 @@
 
         <!-- Plugin versions -->
         <jdeb.version>1.6</jdeb.version>
-        <rpm-maven.version>2.1.5</rpm-maven.version>
+        <rpm-maven.version>2.2.0</rpm-maven.version>
         <license-maven.version>2.11</license-maven.version>
     </properties>
 

--- a/graylog-project-parent/pom.xml
+++ b/graylog-project-parent/pom.xml
@@ -421,6 +421,11 @@
             </dependency>
             <dependency>
                 <groupId>com.google.auto.value</groupId>
+                <artifactId>auto-value-annotations</artifactId>
+                <version>${auto-value.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.google.auto.value</groupId>
                 <artifactId>auto-value</artifactId>
                 <version>${auto-value.version}</version>
                 <scope>provided</scope>

--- a/graylog2-server/pom.xml
+++ b/graylog2-server/pom.xml
@@ -538,6 +538,10 @@
         </dependency>
         <dependency>
             <groupId>com.google.auto.value</groupId>
+            <artifactId>auto-value-annotations</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.google.auto.value</groupId>
             <artifactId>auto-value</artifactId>
         </dependency>
         <dependency>

--- a/graylog2-server/pom.xml
+++ b/graylog2-server/pom.xml
@@ -65,7 +65,7 @@
 
         <it.es.httpPort>19200</it.es.httpPort>
         <it.es.transportPort>19300</it.es.transportPort>
-        <it.es.version>5.6.4</it.es.version>
+        <it.es.version>5.6.9</it.es.version>
         <it.es.instanceCount>1</it.es.instanceCount>
         <it.es.clusterName>test</it.es.clusterName>
         <it.es.await>false</it.es.await>
@@ -863,7 +863,7 @@
                 </property>
             </activation>
             <properties>
-                <it.es.version>5.6.4</it.es.version>
+                <it.es.version>5.6.9</it.es.version>
             </properties>
             <build>
                 <plugins>

--- a/pom.xml
+++ b/pom.xml
@@ -84,7 +84,7 @@
 
         <!-- Dependencies -->
         <airline.version>2.3.0</airline.version>
-        <amqp-client.version>5.1.2</amqp-client.version>
+        <amqp-client.version>5.2.0</amqp-client.version>
         <antlr.version>4.7.1</antlr.version>
         <apache-directory-version>1.0.0</apache-directory-version>
         <auto-value.version>1.6.1</auto-value.version>

--- a/pom.xml
+++ b/pom.xml
@@ -124,7 +124,7 @@
         <kafka.version>0.9.0.1</kafka.version>
         <log4j.version>2.10.0</log4j.version>
         <metrics.version>4.0.2</metrics.version>
-        <mongodb-driver.version>3.5.0</mongodb-driver.version>
+        <mongodb-driver.version>3.6.4</mongodb-driver.version>
         <mongojack.version>2.8.0</mongojack.version>
         <natty.version>0.13</natty.version>
         <netty.version>4.1.22.Final</netty.version>

--- a/pom.xml
+++ b/pom.xml
@@ -165,7 +165,7 @@
         <system-rules.version>1.17.1</system-rules.version>
 
         <!-- Nodejs dependencies -->
-        <nodejs.version>v8.9.4</nodejs.version>
+        <nodejs.version>v8.11.2</nodejs.version>
         <yarn.version>v1.5.1</yarn.version>
     </properties>
 

--- a/pom.xml
+++ b/pom.xml
@@ -151,7 +151,7 @@
         <!-- Test dependencies -->
         <apacheds-server.version>2.0.0-M24</apacheds-server.version>
         <assertj-core.version>3.10.0</assertj-core.version>
-        <assertj-joda-time.version>2.0.0</assertj-joda-time.version>
+        <assertj-joda-time.version>2.1.0</assertj-joda-time.version>
         <assertj-json.version>1.2.0</assertj-json.version>
         <awaitility.version>3.1.0</awaitility.version>
         <equalsverifier.version>2.4.6</equalsverifier.version>

--- a/pom.xml
+++ b/pom.xml
@@ -128,7 +128,7 @@
         <mongojack.version>2.8.2</mongojack.version>
         <natty.version>0.13</natty.version>
         <netty.version>4.1.25.Final</netty.version>
-        <netty-tcnative-boringssl-static.version>2.0.7.Final</netty-tcnative-boringssl-static.version>
+        <netty-tcnative-boringssl-static.version>2.0.8.Final</netty-tcnative-boringssl-static.version>
         <okhttp.version>3.10.0</okhttp.version>
         <opencsv.version>2.3</opencsv.version>
         <os-platform-finder.version>1.2.3</os-platform-finder.version>

--- a/pom.xml
+++ b/pom.xml
@@ -135,7 +135,7 @@
         <pkts.version>3.0.2</pkts.version>
         <protobuf.version>3.5.1</protobuf.version>
         <reflections.version>0.9.11</reflections.version>
-        <retrofit.version>2.3.0</retrofit.version>
+        <retrofit.version>2.4.0</retrofit.version>
         <scala.version>2.11.8</scala.version>
         <shiro.version>1.4.0</shiro.version>
         <sigar.version>1.6.4</sigar.version>

--- a/pom.xml
+++ b/pom.xml
@@ -118,7 +118,7 @@
         <jcip-annotations.version>1.0</jcip-annotations.version>
         <jersey.version>2.25.1</jersey.version>
         <jmte.version>4.0.0</jmte.version>
-        <joda-time.version>2.9.9</joda-time.version>
+        <joda-time.version>2.10</joda-time.version>
         <jool.version>0.9.13</jool.version>
         <json-path.version>2.4.0</json-path.version>
         <kafka.version>0.9.0.1</kafka.version>

--- a/pom.xml
+++ b/pom.xml
@@ -131,7 +131,7 @@
         <netty-tcnative-boringssl-static.version>2.0.7.Final</netty-tcnative-boringssl-static.version>
         <okhttp.version>3.10.0</okhttp.version>
         <opencsv.version>2.3</opencsv.version>
-        <os-platform-finder.version>1.2.2</os-platform-finder.version>
+        <os-platform-finder.version>1.2.3</os-platform-finder.version>
         <pkts.version>3.0.2</pkts.version>
         <protobuf.version>3.5.1</protobuf.version>
         <reflections.version>0.9.11</reflections.version>

--- a/pom.xml
+++ b/pom.xml
@@ -98,7 +98,7 @@
         <freemarker.version>2.3.28</freemarker.version>
         <jest.version>2.4.13+jackson</jest.version>
         <gelfclient.version>1.4.1</gelfclient.version>
-        <geoip2.version>2.11.0</geoip2.version>
+        <geoip2.version>2.12.0</geoip2.version>
         <grok.version>0.1.9-graylog</grok.version>
         <guava-retrying.version>2.0.0</guava-retrying.version>
         <guava.version>25.1-jre</guava.version>

--- a/pom.xml
+++ b/pom.xml
@@ -83,7 +83,7 @@
         <maven.compiler.useIncrementalCompilation>false</maven.compiler.useIncrementalCompilation>
 
         <!-- Dependencies -->
-        <airline.version>2.3.0</airline.version>
+        <airline.version>2.4.0</airline.version>
         <amqp-client.version>5.2.0</amqp-client.version>
         <antlr.version>4.7.1</antlr.version>
         <apache-directory-version>1.0.0</apache-directory-version>

--- a/pom.xml
+++ b/pom.xml
@@ -154,7 +154,7 @@
         <assertj-joda-time.version>2.0.0</assertj-joda-time.version>
         <assertj-json.version>1.1.0</assertj-json.version>
         <awaitility.version>3.1.0</awaitility.version>
-        <equalsverifier.version>2.4.3</equalsverifier.version>
+        <equalsverifier.version>2.4.6</equalsverifier.version>
         <fongo.version>2.2.0-RC2</fongo.version>
         <jukito.version>1.5</jukito.version>
         <junit.version>4.12</junit.version>

--- a/pom.xml
+++ b/pom.xml
@@ -125,7 +125,7 @@
         <log4j.version>2.10.0</log4j.version>
         <metrics.version>4.0.2</metrics.version>
         <mongodb-driver.version>3.6.4</mongodb-driver.version>
-        <mongojack.version>2.8.0</mongojack.version>
+        <mongojack.version>2.8.2</mongojack.version>
         <natty.version>0.13</natty.version>
         <netty.version>4.1.22.Final</netty.version>
         <netty-tcnative-boringssl-static.version>2.0.7.Final</netty-tcnative-boringssl-static.version>

--- a/pom.xml
+++ b/pom.xml
@@ -86,7 +86,7 @@
         <airline.version>2.5.0</airline.version>
         <amqp-client.version>5.2.0</amqp-client.version>
         <antlr.version>4.7.1</antlr.version>
-        <apache-directory-version>1.0.0</apache-directory-version>
+        <apache-directory-version>1.0.1</apache-directory-version>
         <auto-value.version>1.6.1</auto-value.version>
         <auto-value-javabean.version>1.0.0</auto-value-javabean.version>
         <cef-parser.version>0.0.1.10</cef-parser.version>

--- a/pom.xml
+++ b/pom.xml
@@ -122,7 +122,7 @@
         <jool.version>0.9.13</jool.version>
         <json-path.version>2.4.0</json-path.version>
         <kafka.version>0.9.0.1</kafka.version>
-        <log4j.version>2.10.0</log4j.version>
+        <log4j.version>2.11.0</log4j.version>
         <metrics.version>4.0.2</metrics.version>
         <mongodb-driver.version>3.6.4</mongodb-driver.version>
         <mongojack.version>2.8.2</mongojack.version>

--- a/pom.xml
+++ b/pom.xml
@@ -94,7 +94,7 @@
         <commons-email.version>1.5</commons-email.version>
         <commons-io.version>2.6</commons-io.version>
         <disruptor.version>3.4.2</disruptor.version>
-        <elasticsearch.version>5.6.8</elasticsearch.version>
+        <elasticsearch.version>5.6.9</elasticsearch.version>
         <freemarker.version>2.3.28</freemarker.version>
         <jest.version>2.4.13+jackson</jest.version>
         <gelfclient.version>1.4.1</gelfclient.version>

--- a/pom.xml
+++ b/pom.xml
@@ -330,7 +330,7 @@
                     <dependency>
                         <groupId>org.codehaus.plexus</groupId>
                         <artifactId>plexus-compiler-javac-errorprone</artifactId>
-                        <version>2.8.3</version>
+                        <version>2.8.4</version>
                     </dependency>
                     <dependency>
                         <groupId>com.google.errorprone</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -127,7 +127,7 @@
         <mongodb-driver.version>3.6.4</mongodb-driver.version>
         <mongojack.version>2.8.2</mongojack.version>
         <natty.version>0.13</natty.version>
-        <netty.version>4.1.22.Final</netty.version>
+        <netty.version>4.1.25.Final</netty.version>
         <netty-tcnative-boringssl-static.version>2.0.7.Final</netty-tcnative-boringssl-static.version>
         <okhttp.version>3.10.0</okhttp.version>
         <opencsv.version>2.3</opencsv.version>

--- a/pom.xml
+++ b/pom.xml
@@ -109,7 +109,7 @@
         <jackson.version>2.8.11</jackson.version>
         <jadconfig.version>0.13.0</jadconfig.version>
         <java-semver.version>0.9.0</java-semver.version>
-        <javapoet.version>1.7.0</javapoet.version>
+        <javapoet.version>1.11.1</javapoet.version>
         <javax.annotation-api.version>1.3.2</javax.annotation-api.version>
         <javax.el-api.version>3.0.0</javax.el-api.version>
         <javax.inject.version>1</javax.inject.version>

--- a/pom.xml
+++ b/pom.xml
@@ -153,7 +153,7 @@
         <assertj-core.version>3.9.1</assertj-core.version>
         <assertj-joda-time.version>2.0.0</assertj-joda-time.version>
         <assertj-json.version>1.1.0</assertj-json.version>
-        <awaitility.version>3.0.0</awaitility.version>
+        <awaitility.version>3.1.0</awaitility.version>
         <equalsverifier.version>2.4.3</equalsverifier.version>
         <fongo.version>2.2.0-RC2</fongo.version>
         <jukito.version>1.5</jukito.version>

--- a/pom.xml
+++ b/pom.xml
@@ -132,7 +132,7 @@
         <okhttp.version>3.10.0</okhttp.version>
         <opencsv.version>2.3</opencsv.version>
         <os-platform-finder.version>1.2.3</os-platform-finder.version>
-        <pkts.version>3.0.2</pkts.version>
+        <pkts.version>3.0.3</pkts.version>
         <protobuf.version>3.5.1</protobuf.version>
         <reflections.version>0.9.11</reflections.version>
         <retrofit.version>2.4.0</retrofit.version>

--- a/pom.xml
+++ b/pom.xml
@@ -150,7 +150,7 @@
 
         <!-- Test dependencies -->
         <apacheds-server.version>2.0.0-M24</apacheds-server.version>
-        <assertj-core.version>3.9.1</assertj-core.version>
+        <assertj-core.version>3.10.0</assertj-core.version>
         <assertj-joda-time.version>2.0.0</assertj-joda-time.version>
         <assertj-json.version>1.2.0</assertj-json.version>
         <awaitility.version>3.1.0</awaitility.version>

--- a/pom.xml
+++ b/pom.xml
@@ -93,7 +93,7 @@
         <commons-codec.version>1.11</commons-codec.version>
         <commons-email.version>1.5</commons-email.version>
         <commons-io.version>2.6</commons-io.version>
-        <disruptor.version>3.4.0</disruptor.version>
+        <disruptor.version>3.4.2</disruptor.version>
         <elasticsearch.version>5.6.8</elasticsearch.version>
         <freemarker.version>2.3.28</freemarker.version>
         <jest.version>2.4.13+jackson</jest.version>

--- a/pom.xml
+++ b/pom.xml
@@ -83,7 +83,7 @@
         <maven.compiler.useIncrementalCompilation>false</maven.compiler.useIncrementalCompilation>
 
         <!-- Dependencies -->
-        <airline.version>2.4.0</airline.version>
+        <airline.version>2.5.0</airline.version>
         <amqp-client.version>5.2.0</amqp-client.version>
         <antlr.version>4.7.1</antlr.version>
         <apache-directory-version>1.0.0</apache-directory-version>

--- a/pom.xml
+++ b/pom.xml
@@ -87,7 +87,7 @@
         <amqp-client.version>5.1.2</amqp-client.version>
         <antlr.version>4.7.1</antlr.version>
         <apache-directory-version>1.0.0</apache-directory-version>
-        <auto-value.version>1.5.3</auto-value.version>
+        <auto-value.version>1.6.1</auto-value.version>
         <auto-value-javabean.version>1.0.0</auto-value-javabean.version>
         <cef-parser.version>0.0.1.10</cef-parser.version>
         <commons-codec.version>1.11</commons-codec.version>

--- a/pom.xml
+++ b/pom.xml
@@ -155,7 +155,7 @@
         <assertj-json.version>1.1.0</assertj-json.version>
         <awaitility.version>3.0.0</awaitility.version>
         <equalsverifier.version>2.4.3</equalsverifier.version>
-        <fongo.version>2.1.0</fongo.version>
+        <fongo.version>2.2.0-RC2</fongo.version>
         <jukito.version>1.5</jukito.version>
         <junit.version>4.12</junit.version>
         <mockito.version>2.15.0</mockito.version>

--- a/pom.xml
+++ b/pom.xml
@@ -166,7 +166,7 @@
 
         <!-- Nodejs dependencies -->
         <nodejs.version>v8.11.2</nodejs.version>
-        <yarn.version>v1.5.1</yarn.version>
+        <yarn.version>v1.7.0</yarn.version>
     </properties>
 
     <repositories>

--- a/pom.xml
+++ b/pom.xml
@@ -140,7 +140,7 @@
         <shiro.version>1.4.0</shiro.version>
         <sigar.version>1.6.4</sigar.version>
         <slf4j.version>1.7.25</slf4j.version>
-        <spotbugs-annotations.version>3.1.2</spotbugs-annotations.version>
+        <spotbugs-annotations.version>3.1.3</spotbugs-annotations.version>
         <swagger.version>1.5.13</swagger.version>
         <syslog4j.version>0.9.60</syslog4j.version>
         <uuid.version>3.2</uuid.version>

--- a/pom.xml
+++ b/pom.xml
@@ -101,7 +101,7 @@
         <geoip2.version>2.11.0</geoip2.version>
         <grok.version>0.1.9-graylog</grok.version>
         <guava-retrying.version>2.0.0</guava-retrying.version>
-        <guava.version>24.0-jre</guava.version>
+        <guava.version>25.1-jre</guava.version>
         <guice.version>4.2.0</guice.version>
         <HdrHistogram.version>2.1.10</HdrHistogram.version>
         <hibernate-validator.version>6.0.10.Final</hibernate-validator.version>

--- a/pom.xml
+++ b/pom.xml
@@ -104,7 +104,7 @@
         <guava.version>24.0-jre</guava.version>
         <guice.version>4.2.0</guice.version>
         <HdrHistogram.version>2.1.10</HdrHistogram.version>
-        <hibernate-validator.version>6.0.7.Final</hibernate-validator.version>
+        <hibernate-validator.version>6.0.10.Final</hibernate-validator.version>
         <hk2.version>2.5.0-b32</hk2.version> <!-- The HK2 version should match the version being used by Jersey -->
         <jackson.version>2.8.11</jackson.version>
         <jadconfig.version>0.13.0</jadconfig.version>

--- a/pom.xml
+++ b/pom.xml
@@ -106,7 +106,7 @@
         <HdrHistogram.version>2.1.10</HdrHistogram.version>
         <hibernate-validator.version>6.0.10.Final</hibernate-validator.version>
         <hk2.version>2.5.0-b32</hk2.version> <!-- The HK2 version should match the version being used by Jersey -->
-        <jackson.version>2.8.11</jackson.version>
+        <jackson.version>2.8.11.20180608</jackson.version>
         <jadconfig.version>0.13.0</jadconfig.version>
         <java-semver.version>0.9.0</java-semver.version>
         <javapoet.version>1.11.1</javapoet.version>

--- a/pom.xml
+++ b/pom.xml
@@ -144,7 +144,7 @@
         <swagger.version>1.5.13</swagger.version>
         <syslog4j.version>0.9.60</syslog4j.version>
         <uuid.version>3.2</uuid.version>
-        <validation-api.version>2.0.0.Final</validation-api.version>
+        <validation-api.version>2.0.1.Final</validation-api.version>
         <zkclient.version>0.7</zkclient.version>
         <zookeeper.version>3.4.9</zookeeper.version>
 

--- a/pom.xml
+++ b/pom.xml
@@ -282,7 +282,7 @@
                 <plugin>
                     <groupId>com.github.spotbugs</groupId>
                     <artifactId>spotbugs-maven-plugin</artifactId>
-                    <version>3.1.2</version>
+                    <version>3.1.3</version>
                 </plugin>
                 <plugin>
                     <groupId>de.thetaphi</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -152,7 +152,7 @@
         <apacheds-server.version>2.0.0-M24</apacheds-server.version>
         <assertj-core.version>3.9.1</assertj-core.version>
         <assertj-joda-time.version>2.0.0</assertj-joda-time.version>
-        <assertj-json.version>1.1.0</assertj-json.version>
+        <assertj-json.version>1.2.0</assertj-json.version>
         <awaitility.version>3.1.0</awaitility.version>
         <equalsverifier.version>2.4.6</equalsverifier.version>
         <fongo.version>2.2.0-RC2</fongo.version>

--- a/pom.xml
+++ b/pom.xml
@@ -162,7 +162,7 @@
         <nosqlunit.version>1.0.0-rc.5</nosqlunit.version>
         <nosqlunit-elasticsearch-http.version>1.0.0-4+jackson</nosqlunit-elasticsearch-http.version>
         <restassured.version>2.9.0</restassured.version>
-        <system-rules.version>1.17.1</system-rules.version>
+        <system-rules.version>1.18.0</system-rules.version>
 
         <!-- Nodejs dependencies -->
         <nodejs.version>v8.11.2</nodejs.version>

--- a/pom.xml
+++ b/pom.xml
@@ -201,7 +201,7 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-clean-plugin</artifactId>
-                    <version>3.0.0</version>
+                    <version>3.1.0</version>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
@@ -211,7 +211,7 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-resources-plugin</artifactId>
-                    <version>3.0.2</version>
+                    <version>3.1.0</version>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
@@ -232,7 +232,7 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-jar-plugin</artifactId>
-                    <version>3.0.2</version>
+                    <version>3.1.0</version>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
@@ -242,7 +242,7 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-shade-plugin</artifactId>
-                    <version>3.1.0</version>
+                    <version>3.1.1</version>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
@@ -287,7 +287,7 @@
                 <plugin>
                     <groupId>de.thetaphi</groupId>
                     <artifactId>forbiddenapis</artifactId>
-                    <version>2.4.1</version>
+                    <version>2.5</version>
                 </plugin>
                 <plugin>
                     <groupId>com.github.eirslett</groupId>
@@ -297,7 +297,7 @@
                 <plugin>
                     <groupId>com.github.alexcojocaru</groupId>
                     <artifactId>elasticsearch-maven-plugin</artifactId>
-                    <version>6.4</version>
+                    <version>6.5</version>
                     <configuration>
                         <skip>true</skip>
                     </configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -335,7 +335,7 @@
                     <dependency>
                         <groupId>com.google.errorprone</groupId>
                         <artifactId>error_prone_core</artifactId>
-                        <version>2.2.0</version>
+                        <version>2.3.1</version>
                     </dependency>
                 </dependencies>
             </plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -158,7 +158,7 @@
         <fongo.version>2.2.0-RC2</fongo.version>
         <jukito.version>1.5</jukito.version>
         <junit.version>4.12</junit.version>
-        <mockito.version>2.15.0</mockito.version>
+        <mockito.version>2.18.3</mockito.version>
         <nosqlunit.version>1.0.0-rc.5</nosqlunit.version>
         <nosqlunit-elasticsearch-http.version>1.0.0-4+jackson</nosqlunit-elasticsearch-http.version>
         <restassured.version>2.9.0</restassured.version>


### PR DESCRIPTION
Regular dependency updates on `master`.
----
* Upgrade to Joda-Time 2.10
  * http://www.joda.org/joda-time/changes-report.html#a2.10
* Upgrade to assertj-joda-time 2.1.0
  * http://joel-costigliola.github.io/assertj/assertj-joda-time.html#assertj-joda-time-2.1.0
* Upgrade to Elasticsearch 5.6.9
* Upgrade to AssertJ Core 3.10.0
  * https://joel-costigliola.github.io/assertj/assertj-core-news.html#assertj-core-3.10.0
* Upgrade to Apache Directory LDAP API 1.0.1
* Upgrade to Airline 2.5.0
  * https://github.com/rvesse/airline/blob/2.5.0/CHANGELOG.md
* Upgrade to Yarn 1.7.0
  * https://github.com/yarnpkg/yarn/releases/tag/v1.6.0
  * https://github.com/yarnpkg/yarn/releases/tag/v1.7.0
* Upgrade to System Rules 1.18.0
  * http://stefanbirkner.github.io/system-rules/releases.html
* Upgrade to AssertJ JSON 1.2.0
* Upgrade to SpotBugs 3.1.3
  * https://github.com/spotbugs/spotbugs/blob/3.1.3/CHANGELOG.md
* Upgrade to GeoIP2 2.12.0
  * https://github.com/maxmind/GeoIP2-java/blob/v2.12.0/CHANGELOG.md#2120-2018-04-11
* Upgrade to Error Prone 2.3.1
  * https://github.com/google/error-prone/releases/tag/v2.3.1
* Upgrade to Node.js v8.11.2 LTS
  * https://github.com/nodejs/node/blob/v8.11.2/doc/changelogs/CHANGELOG_V8.md
* Upgrade to plexus-compiler-javac-errorprone 2.8.4
* Upgrade to Airline 2.4.0
  * https://github.com/rvesse/airline/blob/2.4.0/CHANGELOG.md
* Upgrade to Netty TC native BoringSSL 2.0.8.Final
* Upgrade to Netty 4.1.25.Final
  * https://netty.io/news/2018/04/04/4-1-23-Final.html
  * https://netty.io/news/2018/04/19/4-1-24-Final.html
  * https://netty.io/news/2018/05/14/4-1-25-Final.html
* Upgrade to Pkts 3.0.3
* Upgrade to Log4j 2.11.0
  * https://logging.apache.org/log4j/2.x/changes-report.html#a2.11.0
* Upgrade to OS Platform Finder 1.2.3
* Upgrade to spotbugs-maven-plugin 3.1.3
* Upgrade to JavaPoet 1.11.1
  * https://github.com/square/javapoet/blob/javapoet-1.11.1/CHANGELOG.md
* Upgrade to RabbitMQ Java Client 5.2.0
  * https://github.com/rabbitmq/rabbitmq-java-client/releases/tag/v5.2.0
* Upgrade to Disruptor 3.4.2
  * https://github.com/LMAX-Exchange/disruptor/releases/tag/3.4.1
  * https://github.com/LMAX-Exchange/disruptor/releases/tag/3.4.2
* Upgrade to Retrofit 2.4.0
  * https://github.com/square/retrofit/blob/parent-2.4.0/CHANGELOG.md
* Upgrade to javax.validation:validation-api 2.0.1.Final
* Upgrade to Mockito 2.18.3
  * https://github.com/mockito/mockito/blob/v2.18.3/doc/release-notes/official.md
* Upgrade to EqualsVerifier 2.4.6
  * http://jqno.nl/equalsverifier/changelog/#version-246
* Upgrade to Google Auto Value 1.6.1
  * https://github.com/google/auto/releases/tag/auto-value-1.5.4
  * https://github.com/google/auto/releases/tag/auto-value-1.6
  * https://github.com/google/auto/releases/tag/auto-value-1.6.1
* Upgrade to Guava 25.1
  * https://github.com/google/guava/releases/tag/v24.1
  * https://github.com/google/guava/releases/tag/v25.0
  * https://github.com/google/guava/releases/tag/v25.1
* Upgrade to Awaitility 3.1.0
  * https://github.com/awaitility/awaitility/blob/awaitility-3.1.0/changelog.txt
* Upgrade to Hibernate Validator 6.0.10.Final
  * https://github.com/hibernate/hibernate-validator/blob/6.0.9.Final/changelog.txt
  * https://github.com/hibernate/hibernate-validator/blob/6.0.10.Final/changelog.txt
* Upgrade to Fongo 2.2.0-RC2, Refs #4560
* Upgrade to MongoJack 2.8.2, Refs #4560
* Upgrade to MongoDB Java Driver 3.6.4, Closes #4560
  * https://mongodb.github.io/mongo-java-driver/3.6/whats-new/
  * https://github.com/mongodb/mongo-java-driver/releases/tag/r3.6.0
  * https://github.com/mongodb/mongo-java-driver/releases/tag/r3.6.1
  * https://github.com/mongodb/mongo-java-driver/releases/tag/r3.6.2
  * https://github.com/mongodb/mongo-java-driver/releases/tag/r3.6.3
  * https://github.com/mongodb/mongo-java-driver/releases/tag/r3.6.4
* Upgrade to Jackson Databind 2.8.11.2
  https://github.com/FasterXML/jackson/wiki/Jackson-Release-2.8