### PR TITLE
Preventing index size/time input to hide rotation strategy dropdown.

### DIFF
--- a/graylog2-web-interface/src/components/common/Select.css
+++ b/graylog2-web-interface/src/components/common/Select.css
@@ -9,3 +9,8 @@
 .select-sm .Select-input > input {
     padding: 0;
 }
+
+:local(.increaseZIndex) .Select-menu-outer {
+    z-index: 3;
+}
+

--- a/graylog2-web-interface/src/components/common/Select.css
+++ b/graylog2-web-interface/src/components/common/Select.css
@@ -11,6 +11,6 @@
 }
 
 :local(.increaseZIndex) .Select-menu-outer {
-    z-index: 3;
+    z-index: 5;
 }
 

--- a/graylog2-web-interface/src/components/common/Select.jsx
+++ b/graylog2-web-interface/src/components/common/Select.jsx
@@ -165,7 +165,7 @@ const Select = createReactClass({
     }
 
     return (
-      <div className={size === 'small' ? 'select-sm' : ''}>
+      <div className={`${size === 'small' ? 'select-sm' : ''} ${this.reactSelectSmStyles.locals.increaseZIndex}`}>
         <SelectComponent ref={(c) => { this._select = c; }}
                          onChange={onReactSelectChange || this._onChange}
                          {...reactSelectProps}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Before this change, other elements (namely react-bootstrap input
components with addons) overlapped with `Select` inputs due to a higher
`z-index` of the first.

This change is increasing the `z-index` of the `Select`/`react-select`
menu to `3` (react-bootstrap input addons are on `2`) to prevent this.

Fixes #4769.

Should be backported to `2.4`.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

Before:
![screen shot 2018-06-08 at 10 22 14](https://user-images.githubusercontent.com/41929/41147173-fa3fa7f0-6b05-11e8-876a-607d95dc647f.png)
![screen shot 2018-06-08 at 10 22 25](https://user-images.githubusercontent.com/41929/41147174-fa5b7084-6b05-11e8-9daa-303c90b8983a.png)

After:
![screen shot 2018-06-08 at 10 22 57](https://user-images.githubusercontent.com/41929/41147184-027bb102-6b06-11e8-8229-0be70c39b8c1.png)
![screen shot 2018-06-08 at 10 23 05](https://user-images.githubusercontent.com/41929/41147185-02963414-6b06-11e8-90b1-d31f4d83777b.png)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
