### PR TITLE
Fix open tasks from sidecars merge

### DIFF
--- a/graylog2-server/src/main/java/org/graylog/plugins/sidecar/SidecarModule.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/sidecar/SidecarModule.java
@@ -33,11 +33,6 @@ import org.graylog.plugins.sidecar.migrations.V20180323150000_AddSidecarUser;
 import org.graylog.plugins.sidecar.migrations.V20180601151500_AddDefaultConfiguration;
 import org.graylog.plugins.sidecar.periodical.PurgeExpiredSidecarsThread;
 import org.graylog.plugins.sidecar.permissions.SidecarRestPermissions;
-import org.graylog.plugins.sidecar.rest.resources.ActionResource;
-import org.graylog.plugins.sidecar.rest.resources.AdministrationResource;
-import org.graylog.plugins.sidecar.rest.resources.CollectorResource;
-import org.graylog.plugins.sidecar.rest.resources.ConfigurationResource;
-import org.graylog.plugins.sidecar.rest.resources.SidecarResource;
 import org.graylog.plugins.sidecar.services.CollectorService;
 import org.graylog.plugins.sidecar.services.ConfigurationService;
 import org.graylog.plugins.sidecar.services.EtagService;
@@ -69,11 +64,7 @@ public class SidecarModule extends PluginModule {
                 .implement(AdministrationFilter.class, Names.named("status"), StatusAdministrationFilter.class)
                 .build(AdministrationFilter.Factory.class));
 
-        addRestResource(ConfigurationResource.class);
-        addRestResource(CollectorResource.class);
-        addRestResource(ActionResource.class);
-        addRestResource(AdministrationResource.class);
-        addRestResource(SidecarResource.class);
+        registerRestControllerPackage(getClass().getPackage().getName());
         addPermissions(SidecarRestPermissions.class);
         addPeriodical(PurgeExpiredSidecarsThread.class);
 

--- a/graylog2-server/src/main/java/org/graylog/plugins/sidecar/audit/SidecarAuditEventTypes.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/sidecar/audit/SidecarAuditEventTypes.java
@@ -14,22 +14,6 @@
  * You should have received a copy of the GNU General Public License
  * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
  */
-/**
- * This file is part of Graylog Pipeline Processor.
- *
- * Graylog Pipeline Processor is free software: you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
- *
- * Graylog Pipeline Processor is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with Graylog Pipeline Processor.  If not, see <http://www.gnu.org/licenses/>.
- */
 package org.graylog.plugins.sidecar.audit;
 
 import com.google.common.collect.ImmutableSet;

--- a/graylog2-server/src/main/java/org/graylog/plugins/sidecar/filter/AdministrationFiltersFactory.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/sidecar/filter/AdministrationFiltersFactory.java
@@ -55,6 +55,7 @@ public class AdministrationFiltersFactory {
                     return null;
                 })
                 .filter(Objects::nonNull)
+                // We join all filters with an and condition, so results will need to match all filters
                 .reduce(Predicate::and);
     }
 }

--- a/graylog2-server/src/main/java/org/graylog/plugins/sidecar/filter/StatusAdministrationFilter.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/sidecar/filter/StatusAdministrationFilter.java
@@ -17,25 +17,28 @@
 package org.graylog.plugins.sidecar.filter;
 
 import com.google.inject.assistedinject.Assisted;
+import org.graylog.plugins.sidecar.mapper.SidecarStatusMapper.Status;
 import org.graylog.plugins.sidecar.rest.models.CollectorStatusList;
 import org.graylog.plugins.sidecar.rest.models.Sidecar;
 
 import javax.inject.Inject;
 
 public class StatusAdministrationFilter implements AdministrationFilter {
-    private final int status;
+    private final Status status;
 
     @Inject
     public StatusAdministrationFilter(@Assisted int status) {
-        this.status = status;
+        this.status = Status.fromStatusCode(status);
     }
 
     @Override
     public boolean test(Sidecar sidecar) {
         final CollectorStatusList collectorStatusList = sidecar.nodeDetails().statusList();
         if (collectorStatusList == null) {
-            return false;
+            // Sidecars with not known status are in an UNKNOWN status
+            return Status.UNKNOWN.equals(status);
         }
-        return collectorStatusList.collectors().entrySet().stream().anyMatch(entry -> entry.getValue().status() == status);
+        return collectorStatusList.collectors().entrySet().stream()
+                .anyMatch(entry -> Status.fromStatusCode(entry.getValue().status()).equals(status));
     }
 }

--- a/graylog2-server/src/main/java/org/graylog/plugins/sidecar/rest/models/CollectorAction.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/sidecar/rest/models/CollectorAction.java
@@ -28,14 +28,14 @@ import java.util.Map;
 @JsonAutoDetect
 public abstract class CollectorAction {
 
-    @JsonProperty("collectorId")
+    @JsonProperty("collector_id")
     public abstract String collectorId();
 
     @JsonProperty("properties")
     public abstract Map<String, Object> properties();
 
     @JsonCreator
-    public static CollectorAction create(@JsonProperty("collectorId") String collectorId,
+    public static CollectorAction create(@JsonProperty("collector_id") String collectorId,
                                          @JsonProperty("properties") Map<String, Object> properties) {
         return new AutoValue_CollectorAction(collectorId, properties);
     }

--- a/graylog2-server/src/main/java/org/graylog/plugins/sidecar/rest/resources/ActionResource.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/sidecar/rest/resources/ActionResource.java
@@ -48,7 +48,7 @@ import javax.ws.rs.core.Response;
 import java.util.ArrayList;
 import java.util.List;
 
-@Api(value = "Sidecar Collector Actions", description = "Manage Collector Actions")
+@Api(value = "Sidecar/Collector/Actions", description = "Manage Collector actions")
 @Path("/sidecar/action")
 @Consumes(MediaType.APPLICATION_JSON)
 @Produces(MediaType.APPLICATION_JSON)

--- a/graylog2-server/src/main/java/org/graylog/plugins/sidecar/rest/resources/ActionResource.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/sidecar/rest/resources/ActionResource.java
@@ -86,7 +86,7 @@ public class ActionResource extends RestResource implements PluginRestResource {
     @ApiOperation(value = "Set a collector action")
     @ApiResponses(value = {@ApiResponse(code = 400, message = "The supplied action is not valid.")})
     @AuditEvent(type = SidecarAuditEventTypes.ACTION_UPDATE)
-    public Response setAction(@ApiParam(name = "sidecarId", value = "The id this Sideacr is registering as.", required = true)
+    public Response setAction(@ApiParam(name = "sidecarId", value = "The id this Sidecar is registering as.", required = true)
                               @PathParam("sidecarId") @NotEmpty String sidecarId,
                               @ApiParam(name = "JSON body", required = true)
                               @Valid @NotNull List<CollectorAction> request) {

--- a/graylog2-server/src/main/java/org/graylog/plugins/sidecar/rest/resources/AdministrationResource.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/sidecar/rest/resources/AdministrationResource.java
@@ -122,6 +122,7 @@ public class AdministrationResource extends RestResource implements PluginRestRe
         final List<SidecarSummary> sidecarSummaries = sidecarService.toSummaryList(sidecars, activeSidecarFilter);
 
         final List<SidecarSummary> summariesWithCollectors = sidecarSummaries.stream()
+                // Enrich sidecars with a list of compatible collectors that may run on that OS
                 .map(collector -> {
                     final List<String> compatibleCollectors = collectors.stream()
                             .filter(c -> c.nodeOperatingSystem().equalsIgnoreCase(collector.nodeDetails().operatingSystem()))
@@ -165,9 +166,11 @@ public class AdministrationResource extends RestResource implements PluginRestRe
 
         final List<String> collectorIds = new ArrayList<>();
 
+        // Add ID of collector we want to filter for
         if (filters.containsKey(collectorKey)) {
             collectorIds.add(filters.get(collectorKey));
         }
+        // Load collectors using the configuration ID that we want to filter for
         if (filters.containsKey(configurationKey)) {
             final Configuration configuration = configurationService.find(filters.get(configurationKey));
             if (!collectorIds.contains(configuration.collectorId())) {

--- a/graylog2-server/src/main/java/org/graylog/plugins/sidecar/rest/resources/AdministrationResource.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/sidecar/rest/resources/AdministrationResource.java
@@ -114,6 +114,7 @@ public class AdministrationResource extends RestResource implements PluginRestRe
         final String sort = Sidecar.FIELD_NODE_NAME;
         final String order = "asc";
         final SearchQuery searchQuery = searchQueryParser.parse(request.query());
+        final long total = sidecarService.count();
 
         final Optional<Predicate<Sidecar>> filters = administrationFiltersFactory.getFilters(request.filters());
 
@@ -135,7 +136,7 @@ public class AdministrationResource extends RestResource implements PluginRestRe
                 .filter(collectorSummary -> !filters.isPresent() || collectorSummary.collectors().size() > 0)
                 .collect(Collectors.toList());
 
-        return SidecarListResponse.create(request.query(), sidecars.pagination(), false, sort, order, summariesWithCollectors, request.filters());
+        return SidecarListResponse.create(request.query(), sidecars.pagination(), total, false, sort, order, summariesWithCollectors, request.filters());
     }
 
     @PUT

--- a/graylog2-server/src/main/java/org/graylog/plugins/sidecar/rest/resources/AdministrationResource.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/sidecar/rest/resources/AdministrationResource.java
@@ -72,7 +72,7 @@ import java.util.Optional;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
 
-@Api(value = "Sidecar Administration", description = "Administrate sidecars")
+@Api(value = "Sidecar/Administration", description = "Administrate sidecars")
 @Path("/sidecar/administration")
 @Consumes(MediaType.APPLICATION_JSON)
 @Produces(MediaType.APPLICATION_JSON)

--- a/graylog2-server/src/main/java/org/graylog/plugins/sidecar/rest/resources/CollectorResource.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/sidecar/rest/resources/CollectorResource.java
@@ -157,11 +157,12 @@ public class CollectorResource extends RestResource implements PluginRestResourc
                                                            @DefaultValue("asc") @QueryParam("order") String order) {
         final SearchQuery searchQuery = searchQueryParser.parse(query);
         final PaginatedList<Collector> collectors = this.collectorService.findPaginated(searchQuery, page, perPage, sort, order);
+        final long total = this.collectorService.count();
         final List<CollectorSummary> summaries = collectors.stream()
                 .map(CollectorSummary::create)
                 .collect(Collectors.toList());
 
-        return CollectorSummaryResponse.create(query, collectors.pagination(), sort, order, summaries);
+        return CollectorSummaryResponse.create(query, collectors.pagination(), total, sort, order, summaries);
     }
 
     @POST

--- a/graylog2-server/src/main/java/org/graylog/plugins/sidecar/rest/resources/CollectorResource.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/sidecar/rest/resources/CollectorResource.java
@@ -63,7 +63,7 @@ import javax.ws.rs.core.Response;
 import java.util.List;
 import java.util.stream.Collectors;
 
-@Api(value = "Collectors", description = "Manage collectors")
+@Api(value = "Sidecar/Collectors", description = "Manage collectors")
 @Path("/sidecar/collectors")
 @Consumes(MediaType.APPLICATION_JSON)
 @Produces(MediaType.APPLICATION_JSON)
@@ -213,7 +213,7 @@ public class CollectorResource extends RestResource implements PluginRestResourc
     @RequiresAuthentication
     @RequiresPermissions(SidecarRestPermissions.COLLECTORS_DELETE)
     @Produces(MediaType.APPLICATION_JSON)
-    @ApiOperation(value = "Delets a collector")
+    @ApiOperation(value = "Delete a collector")
     @AuditEvent(type = SidecarAuditEventTypes.COLLECTOR_DELETE)
     public Response deleteCollector(@ApiParam(name = "id", required = true)
                                     @PathParam("id") String id) {

--- a/graylog2-server/src/main/java/org/graylog/plugins/sidecar/rest/resources/ConfigurationResource.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/sidecar/rest/resources/ConfigurationResource.java
@@ -67,7 +67,7 @@ import javax.ws.rs.core.Response;
 import java.util.List;
 import java.util.stream.Collectors;
 
-@Api(value = "Configurations", description = "Manage/Render collector configurations")
+@Api(value = "Sidecar/Configurations", description = "Manage/Render collector configurations")
 @Path("/sidecar/configurations")
 @Consumes(MediaType.APPLICATION_JSON)
 @Produces(MediaType.APPLICATION_JSON)

--- a/graylog2-server/src/main/java/org/graylog/plugins/sidecar/rest/resources/ConfigurationResource.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/sidecar/rest/resources/ConfigurationResource.java
@@ -109,11 +109,12 @@ public class ConfigurationResource extends RestResource implements PluginRestRes
                                                                      @DefaultValue("asc") @QueryParam("order") String order) {
         final SearchQuery searchQuery = searchQueryParser.parse(query);
         final PaginatedList<Configuration> configurations = this.configurationService.findPaginated(searchQuery, page, perPage, sort, order);
+        final long total = this.configurationService.count();
         final List<ConfigurationSummary> result = configurations.stream()
                 .map(ConfigurationSummary::create)
                 .collect(Collectors.toList());
 
-        return ConfigurationListResponse.create(query, configurations.pagination(), sort, order, result);
+        return ConfigurationListResponse.create(query, configurations.pagination(), total, sort, order, result);
     }
 
     @GET

--- a/graylog2-server/src/main/java/org/graylog/plugins/sidecar/rest/resources/SidecarResource.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/sidecar/rest/resources/SidecarResource.java
@@ -87,7 +87,7 @@ public class SidecarResource extends RestResource implements PluginRestResource 
             .put("id", SearchQueryField.create(Sidecar.FIELD_ID))
             .put("node_id", SearchQueryField.create(Sidecar.FIELD_NODE_ID))
             .put("name", SearchQueryField.create(Sidecar.FIELD_NODE_NAME))
-            .put("collector_version", SearchQueryField.create(Sidecar.FIELD_SIDECAR_VERSION))
+            .put("sidecar_version", SearchQueryField.create(Sidecar.FIELD_SIDECAR_VERSION))
             .put("last_seen", SearchQueryField.create(Sidecar.FIELD_LAST_SEEN, SearchQueryField.Type.DATE))
             .put("operating_system", SearchQueryField.create(Sidecar.FIELD_OPERATING_SYSTEM))
             .put("status", SearchQueryField.create(Sidecar.FIELD_STATUS, SearchQueryField.Type.INT))

--- a/graylog2-server/src/main/java/org/graylog/plugins/sidecar/rest/resources/SidecarResource.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/sidecar/rest/resources/SidecarResource.java
@@ -127,6 +127,7 @@ public class SidecarResource extends RestResource implements PluginRestResource 
                         sidecarSummaries.size(),
                         1,
                         sidecarSummaries.size()),
+                sidecarSummaries.size(),
                 false,
                 null,
                 null,
@@ -155,7 +156,8 @@ public class SidecarResource extends RestResource implements PluginRestResource 
                 sidecarService.findPaginated(searchQuery, activeSidecarFilter, page, perPage, sort, order) :
                 sidecarService.findPaginated(searchQuery, page, perPage, sort, order);
         final List<SidecarSummary> collectorSummaries = sidecarService.toSummaryList(sidecars, activeSidecarFilter);
-        return SidecarListResponse.create(query, sidecars.pagination(), onlyActive, sort, order, collectorSummaries);
+        final long total = sidecarService.count();
+        return SidecarListResponse.create(query, sidecars.pagination(), total, onlyActive, sort, order, collectorSummaries);
     }
 
     @GET

--- a/graylog2-server/src/main/java/org/graylog/plugins/sidecar/rest/responses/CollectorSummaryResponse.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/sidecar/rest/responses/CollectorSummaryResponse.java
@@ -18,7 +18,6 @@ package org.graylog.plugins.sidecar.rest.responses;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.annotation.JsonUnwrapped;
 import com.google.auto.value.AutoValue;
 import org.graylog.plugins.sidecar.rest.models.CollectorSummary;
 import org.graylog2.database.PaginatedList;
@@ -32,8 +31,11 @@ public abstract class CollectorSummaryResponse {
     @JsonProperty
     public abstract String query();
 
-    @JsonUnwrapped
+    @JsonProperty("pagination")
     public abstract PaginatedList.PaginationInfo paginationInfo();
+
+    @JsonProperty
+    public abstract long total();
 
     @Nullable
     @JsonProperty
@@ -48,10 +50,11 @@ public abstract class CollectorSummaryResponse {
 
     @JsonCreator
     public static CollectorSummaryResponse create(@JsonProperty("query") @Nullable String query,
-                                                  @JsonProperty("pagination_info") PaginatedList.PaginationInfo paginationInfo,
+                                                  @JsonProperty("pagination") PaginatedList.PaginationInfo paginationInfo,
+                                                  @JsonProperty("total") long total,
                                                   @JsonProperty("sort") String sort,
                                                   @JsonProperty("order") String order,
                                                   @JsonProperty("collectors") Collection<CollectorSummary> collectors) {
-        return new AutoValue_CollectorSummaryResponse(query, paginationInfo, sort, order, collectors);
+        return new AutoValue_CollectorSummaryResponse(query, paginationInfo, total, sort, order, collectors);
     }
 }

--- a/graylog2-server/src/main/java/org/graylog/plugins/sidecar/rest/responses/ConfigurationListResponse.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/sidecar/rest/responses/ConfigurationListResponse.java
@@ -18,7 +18,6 @@ package org.graylog.plugins.sidecar.rest.responses;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.annotation.JsonUnwrapped;
 import com.google.auto.value.AutoValue;
 import org.graylog.plugins.sidecar.rest.models.ConfigurationSummary;
 import org.graylog2.database.PaginatedList;
@@ -32,8 +31,11 @@ public abstract class ConfigurationListResponse {
     @JsonProperty
     public abstract String query();
 
-    @JsonUnwrapped
+    @JsonProperty("pagination")
     public abstract PaginatedList.PaginationInfo paginationInfo();
+
+    @JsonProperty
+    public abstract long total();
 
     @Nullable
     @JsonProperty
@@ -48,10 +50,11 @@ public abstract class ConfigurationListResponse {
 
     @JsonCreator
     public static ConfigurationListResponse create(@JsonProperty("query") String query,
-                                                   @JsonProperty("pagination_info") PaginatedList.PaginationInfo paginationInfo,
+                                                   @JsonProperty("pagination") PaginatedList.PaginationInfo paginationInfo,
+                                                   @JsonProperty("total") long total,
                                                    @JsonProperty("sort") String sort,
                                                    @JsonProperty("order") String order,
                                                    @JsonProperty("configurations") Collection<ConfigurationSummary> configurations) {
-        return new AutoValue_ConfigurationListResponse(query, paginationInfo, sort, order, configurations);
+        return new AutoValue_ConfigurationListResponse(query, paginationInfo, total, sort, order, configurations);
     }
 }

--- a/graylog2-server/src/main/java/org/graylog/plugins/sidecar/rest/responses/SidecarListResponse.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/sidecar/rest/responses/SidecarListResponse.java
@@ -18,7 +18,6 @@ package org.graylog.plugins.sidecar.rest.responses;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.annotation.JsonUnwrapped;
 import com.google.auto.value.AutoValue;
 import org.graylog.plugins.sidecar.rest.models.SidecarSummary;
 import org.graylog2.database.PaginatedList;
@@ -33,8 +32,11 @@ public abstract class SidecarListResponse {
     @JsonProperty
     public abstract String query();
 
-    @JsonUnwrapped
+    @JsonProperty("pagination")
     public abstract PaginatedList.PaginationInfo paginationInfo();
+
+    @JsonProperty
+    public abstract long total();
 
     @JsonProperty
     public abstract Boolean onlyActive();
@@ -56,21 +58,23 @@ public abstract class SidecarListResponse {
 
     @JsonCreator
     public static SidecarListResponse create(@JsonProperty("query") @Nullable String query,
-                                             @JsonProperty("pagination_info") PaginatedList.PaginationInfo paginationInfo,
+                                             @JsonProperty("pagination") PaginatedList.PaginationInfo paginationInfo,
+                                             @JsonProperty("total") long total,
                                              @JsonProperty("only_active") Boolean onlyActive,
                                              @JsonProperty("sort") @Nullable String sort,
                                              @JsonProperty("order") @Nullable String order,
                                              @JsonProperty("sidecars") Collection<SidecarSummary> sidecars,
                                              @JsonProperty("filters") @Nullable Map<String, String> filters) {
-        return new AutoValue_SidecarListResponse(query, paginationInfo, onlyActive, sort, order, sidecars, filters);
+        return new AutoValue_SidecarListResponse(query, paginationInfo, total, onlyActive, sort, order, sidecars, filters);
     }
 
     public static SidecarListResponse create(@JsonProperty("query") @Nullable String query,
-                                             @JsonProperty("pagination_info") PaginatedList.PaginationInfo paginationInfo,
+                                             @JsonProperty("pagination") PaginatedList.PaginationInfo paginationInfo,
+                                             @JsonProperty("total") long total,
                                              @JsonProperty("only_active") Boolean onlyActive,
                                              @JsonProperty("sort") @Nullable String sort,
                                              @JsonProperty("order") @Nullable String order,
                                              @JsonProperty("sidecars") Collection<SidecarSummary> sidecars) {
-        return create(query, paginationInfo, onlyActive, sort, order, sidecars, null);
+        return create(query, paginationInfo, total, onlyActive, sort, order, sidecars, null);
     }
 }

--- a/graylog2-server/src/main/java/org/graylog/plugins/sidecar/services/CollectorService.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/sidecar/services/CollectorService.java
@@ -50,6 +50,10 @@ public class CollectorService extends PaginatedDbService<Collector> {
         return db.findOne(DBQuery.is("name", name));
     }
 
+    public long count() {
+        return db.count();
+    }
+
     public List<Collector> allFilter(Predicate<Collector> filter) {
         try (final Stream<Collector> collectorsStream = streamAll()) {
             final Stream<Collector> filteredStream = filter == null ? collectorsStream : collectorsStream.filter(filter);

--- a/graylog2-server/src/main/java/org/graylog/plugins/sidecar/services/ConfigurationService.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/sidecar/services/ConfigurationService.java
@@ -23,6 +23,7 @@ import freemarker.cache.TemplateLoader;
 import freemarker.template.Template;
 import freemarker.template.TemplateException;
 import org.graylog.plugins.sidecar.rest.models.Configuration;
+import org.graylog.plugins.sidecar.rest.models.NodeMetrics;
 import org.graylog.plugins.sidecar.rest.models.Sidecar;
 import org.graylog.plugins.sidecar.template.directives.IndentTemplateDirective;
 import org.graylog.plugins.sidecar.template.loader.MongoDbTemplateLoader;
@@ -125,11 +126,14 @@ public class ConfigurationService extends PaginatedDbService<Configuration> {
         context.put("sidecarVersion", sidecar.sidecarVersion());
         context.put("operatingSystem", sidecar.nodeDetails().operatingSystem());
         context.put("ip", sidecar.nodeDetails().ip());
-        if (sidecar.nodeDetails().metrics().cpuIdle() != null) {
-            context.put("cpuIdle", sidecar.nodeDetails().metrics().cpuIdle());
-        }
-        if (sidecar.nodeDetails().metrics().load1() != null) {
-            context.put("load1", sidecar.nodeDetails().metrics().load1());
+        final NodeMetrics metrics = sidecar.nodeDetails().metrics();
+        if (metrics != null) {
+            if (metrics.cpuIdle() != null) {
+                context.put("cpuIdle", metrics.cpuIdle());
+            }
+            if (metrics.load1() != null) {
+                context.put("load1", metrics.load1());
+            }
         }
 
         return Configuration.create(

--- a/graylog2-server/src/main/java/org/graylog/plugins/sidecar/services/ConfigurationService.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/sidecar/services/ConfigurationService.java
@@ -78,6 +78,10 @@ public class ConfigurationService extends PaginatedDbService<Configuration> {
         return db.findOne(DBQuery.is(Configuration.FIELD_NAME, name));
     }
 
+    public long count() {
+        return db.count();
+    }
+
     public List<Configuration> all() {
         try (final Stream<Configuration> collectorConfigurationStream = streamAll()) {
             return collectorConfigurationStream.collect(Collectors.toList());

--- a/graylog2-server/src/main/java/org/graylog/plugins/sidecar/services/EtagService.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/sidecar/services/EtagService.java
@@ -39,7 +39,7 @@ import static com.codahale.metrics.MetricRegistry.name;
 public class EtagService extends AbstractIdleService {
     private static final Logger LOG = LoggerFactory.getLogger(EtagService.class);
 
-    private final Cache<String, String> cache;
+    private final Cache<String, Boolean> cache;
     private MetricRegistry metricRegistry;
     private EventBus eventBus;
     private ClusterEventBus clusterEventBus;
@@ -76,7 +76,7 @@ public class EtagService extends AbstractIdleService {
     }
 
     public void put(String etag) {
-        cache.put(etag, etag);
+        cache.put(etag, Boolean.TRUE);
     }
 
     public void invalidate(String etag) {

--- a/graylog2-web-interface/src/components/configurations/SidecarConfig.jsx
+++ b/graylog2-web-interface/src/components/configurations/SidecarConfig.jsx
@@ -1,5 +1,6 @@
 import PropTypes from 'prop-types';
 import React from 'react';
+import createReactClass from 'create-react-class';
 import { Button } from 'react-bootstrap';
 import { BootstrapModalForm, Input } from 'components/bootstrap';
 import { IfPermitted, ISODurationInput } from 'components/common';
@@ -8,7 +9,9 @@ import ISODurationUtils from 'util/ISODurationUtils';
 import FormUtils from 'util/FormsUtils';
 import StringUtils from 'util/StringUtils';
 
-const SidecarConfig = React.createClass({
+const SidecarConfig = createReactClass({
+  displayName: 'SidecarConfig',
+
   propTypes: {
     config: PropTypes.shape({
       sidecar_expiration_threshold: PropTypes.string,

--- a/graylog2-web-interface/src/components/navigation/Navigation.jsx
+++ b/graylog2-web-interface/src/components/navigation/Navigation.jsx
@@ -252,11 +252,13 @@ const Navigation = createReactClass({
               </LinkContainer>
               }
               <LinkContainer to={Routes.SYSTEM.ENTERPRISE}>
-                  <MenuItem>Enterprise</MenuItem>
+                <MenuItem>Enterprise</MenuItem>
               </LinkContainer>
+              {this.isPermitted(this.props.permissions, ['inputs:edit']) &&
               <LinkContainer to={Routes.SYSTEM.SIDECARS.OVERVIEW}>
                 <MenuItem>Sidecars</MenuItem>
               </LinkContainer>
+              }
               {pluginSystemNavigations}
             </NavDropdown>
           </Nav>

--- a/graylog2-web-interface/src/components/sidecars/administration/CollectorsAdministration.jsx
+++ b/graylog2-web-interface/src/components/sidecars/administration/CollectorsAdministration.jsx
@@ -176,7 +176,12 @@ const CollectorsAdministration = createReactClass({
     const sidecarCollectorId = this.sidecarCollectorId(sidecar, collector);
     const configAssignment = sidecar.assignments.find(assignment => assignment.collector_id === collector.id) || {};
     const configuration = configurations.find(config => config.id === configAssignment.configuration_id);
-    const collectorStatus = (sidecar.node_details.status.collectors[collector.name] || {}).status;
+    let collectorStatus;
+    try {
+      collectorStatus = sidecar.node_details.status.collectors[collector.name].status;
+    } catch (e) {
+      // Do nothing
+    }
 
     return (
       <Row key={sidecarCollectorId}>

--- a/graylog2-web-interface/src/components/sidecars/administration/CollectorsAdministration.jsx
+++ b/graylog2-web-interface/src/components/sidecars/administration/CollectorsAdministration.jsx
@@ -240,6 +240,10 @@ const CollectorsAdministration = createReactClass({
     this.props.onQueryChange();
   },
 
+  handleResetFilters() {
+    this.props.onFilter();
+  },
+
   render() {
     const { configurations, collectors, onPageChange, pagination, query, sidecarCollectorPairs, filters } = this.props;
 
@@ -271,7 +275,8 @@ const CollectorsAdministration = createReactClass({
           <SidecarSearchForm query={query} onSearch={this.handleSearch} onReset={this.handleReset} />
           <FiltersSummary collectors={collectors}
                           configurations={configurations}
-                          filters={filters} />
+                          filters={filters}
+                          onResetFilters={this.handleResetFilters} />
           <Row>
             <Col md={12}>
               <ControlledTableList>

--- a/graylog2-web-interface/src/components/sidecars/administration/CollectorsAdministration.jsx
+++ b/graylog2-web-interface/src/components/sidecars/administration/CollectorsAdministration.jsx
@@ -6,14 +6,17 @@ import { Col, Row } from 'react-bootstrap';
 
 import { ControlledTableList, PaginatedList } from 'components/common';
 import { Input } from 'components/bootstrap';
-import CollectorsAdministrationFilters from './CollectorsAdministrationFilters';
-import CollectorsAdministrationActions from './CollectorsAdministrationActions';
 
-import style from './CollectorsAdministration.css';
 import ColorLabel from 'components/sidecars/common/ColorLabel';
 import OperatingSystemIcon from 'components/sidecars/common/OperatingSystemIcon';
 import SidecarSearchForm from 'components/sidecars/common/SidecarSearchForm';
 import StatusIndicator from 'components/sidecars/common/StatusIndicator';
+
+import CollectorsAdministrationActions from './CollectorsAdministrationActions';
+import CollectorsAdministrationFilters from './CollectorsAdministrationFilters';
+import FiltersSummary from './FiltersSummary';
+
+import style from './CollectorsAdministration.css';
 
 const CollectorsAdministration = createReactClass({
   propTypes: {
@@ -238,7 +241,7 @@ const CollectorsAdministration = createReactClass({
   },
 
   render() {
-    const { configurations, onPageChange, pagination, query, sidecarCollectorPairs } = this.props;
+    const { configurations, collectors, onPageChange, pagination, query, sidecarCollectorPairs, filters } = this.props;
 
     let formattedCollectors;
     if (sidecarCollectorPairs.length === 0) {
@@ -250,11 +253,11 @@ const CollectorsAdministration = createReactClass({
     } else {
       const sidecars = lodash.uniq(sidecarCollectorPairs.map(({ sidecar }) => sidecar));
       formattedCollectors = sidecars.map((sidecarToMap) => {
-        const collectors = sidecarCollectorPairs
+        const sidecarCollectors = sidecarCollectorPairs
           .filter(({ sidecar }) => sidecar.node_id === sidecarToMap.node_id)
           .map(({ collector }) => collector)
           .filter(collector => !lodash.isEmpty(collector));
-        return this.formatSidecar(sidecarToMap, collectors, configurations);
+        return this.formatSidecar(sidecarToMap, sidecarCollectors, configurations);
       });
     }
 
@@ -266,6 +269,9 @@ const CollectorsAdministration = createReactClass({
                        totalItems={pagination.total}
                        onChange={onPageChange}>
           <SidecarSearchForm query={query} onSearch={this.handleSearch} onReset={this.handleReset} />
+          <FiltersSummary collectors={collectors}
+                          configurations={configurations}
+                          filters={filters} />
           <Row>
             <Col md={12}>
               <ControlledTableList>

--- a/graylog2-web-interface/src/components/sidecars/administration/CollectorsAdministration.jsx
+++ b/graylog2-web-interface/src/components/sidecars/administration/CollectorsAdministration.jsx
@@ -22,6 +22,7 @@ const CollectorsAdministration = createReactClass({
     configurations: PropTypes.array.isRequired,
     pagination: PropTypes.object.isRequired,
     query: PropTypes.string.isRequired,
+    filters: PropTypes.object.isRequired,
     onPageChange: PropTypes.func.isRequired,
     onFilter: PropTypes.func.isRequired,
     onQueryChange: PropTypes.func.isRequired,
@@ -100,7 +101,7 @@ const CollectorsAdministration = createReactClass({
     let headerMenu;
     if (selectedItems === 0) {
       headerMenu = (
-        <CollectorsAdministrationFilters collectors={collectors} configurations={configurations} filter={this.props.onFilter} />
+        <CollectorsAdministrationFilters collectors={collectors} configurations={configurations} filters={this.props.filters} filter={this.props.onFilter} />
       );
     } else {
       headerMenu = (

--- a/graylog2-web-interface/src/components/sidecars/administration/CollectorsAdministrationContainer.jsx
+++ b/graylog2-web-interface/src/components/sidecars/administration/CollectorsAdministrationContainer.jsx
@@ -54,8 +54,13 @@ const CollectorsAdministrationContainer = createReactClass({
 
   handleFilter(property, value) {
     const { filters, pagination, query } = this.state.sidecars;
-    const newFilters = lodash.cloneDeep(filters);
-    newFilters[property] = value;
+    let newFilters;
+    if (property) {
+      newFilters = lodash.cloneDeep(filters);
+      newFilters[property] = value;
+    } else {
+      newFilters = {};
+    }
     SidecarsAdministrationActions.list({ query: query, filters: newFilters, pageSize: pagination.pageSize });
   },
 

--- a/graylog2-web-interface/src/components/sidecars/administration/CollectorsAdministrationContainer.jsx
+++ b/graylog2-web-interface/src/components/sidecars/administration/CollectorsAdministrationContainer.jsx
@@ -109,6 +109,7 @@ const CollectorsAdministrationContainer = createReactClass({
                                 configurations={configurations.configurations}
                                 pagination={sidecars.pagination}
                                 query={sidecars.query}
+                                filters={sidecars.filters}
                                 onPageChange={this.handlePageChange}
                                 onFilter={this.handleFilter}
                                 onQueryChange={this.handleQueryChange}

--- a/graylog2-web-interface/src/components/sidecars/administration/CollectorsAdministrationFilters.jsx
+++ b/graylog2-web-interface/src/components/sidecars/administration/CollectorsAdministrationFilters.jsx
@@ -8,6 +8,7 @@ import { naturalSortIgnoreCase } from 'util/SortUtils';
 import { SelectPopover } from 'components/common';
 import CollectorIndicator from 'components/sidecars/common/CollectorIndicator';
 import ColorLabel from 'components/sidecars/common/ColorLabel';
+import StatusMapper from 'components/sidecars/common/StatusMapper';
 
 const CollectorsAdministrationFilters = createReactClass({
   propTypes: {
@@ -117,16 +118,7 @@ const CollectorsAdministrationFilters = createReactClass({
   getStatusFilter() {
     // 0: running, 1: unknown, 2: failing
     const status = ['0', '1', '2'];
-    const statusFormatter = (statusCode) => {
-      switch (Number(statusCode)) {
-        case 0:
-          return 'Running';
-        case 2:
-          return 'Failing';
-        default:
-          return 'Unknown';
-      }
-    };
+    const statusFormatter = StatusMapper.toString;
 
     const filter = ([statusCode], callback) => this.onFilterChange('status', statusCode, callback);
 

--- a/graylog2-web-interface/src/components/sidecars/administration/CollectorsAdministrationFilters.jsx
+++ b/graylog2-web-interface/src/components/sidecars/administration/CollectorsAdministrationFilters.jsx
@@ -13,6 +13,7 @@ const CollectorsAdministrationFilters = createReactClass({
   propTypes: {
     collectors: PropTypes.array.isRequired,
     configurations: PropTypes.array.isRequired,
+    filters: PropTypes.object.isRequired,
     filter: PropTypes.func.isRequired,
   },
 
@@ -22,10 +23,11 @@ const CollectorsAdministrationFilters = createReactClass({
   },
 
   getCollectorsFilter() {
+    const collectorMapper = collector => `${collector.id};${collector.name}`;
     const collectors = this.props.collectors
       .sort((c1, c2) => naturalSortIgnoreCase(c1.name, c2.name))
-      // Hack to be able to filter in SelectPopover. We should change that to avoid this hack.
-      .map(collector => `${collector.id};${collector.name}`);
+      // TODO: Hack to be able to filter in SelectPopover. We should change that to avoid this hack.
+      .map(collectorMapper);
 
     const collectorFormatter = (collectorId) => {
       const [id] = collectorId.split(';');
@@ -38,6 +40,12 @@ const CollectorsAdministrationFilters = createReactClass({
       this.onFilterChange('collector', id, callback);
     };
 
+    let collectorFilter;
+    if (this.props.filters.collector) {
+      const collector = this.props.collectors.find(c => c.id === this.props.filters.collector);
+      collectorFilter = collector ? collectorMapper(collector) : undefined;
+    }
+
     return (
       <SelectPopover id="collector-filter"
                      title="Filter by collector"
@@ -45,15 +53,17 @@ const CollectorsAdministrationFilters = createReactClass({
                      items={collectors}
                      itemFormatter={collectorFormatter}
                      onItemSelect={filter}
+                     selectedItems={collectorFilter ? [collectorFilter] : []}
                      filterPlaceholder="Filter by collector" />
     );
   },
 
   getConfigurationFilter() {
+    const configurationMapper = configuration => `${configuration.id};${configuration.name}`;
     const configurations = this.props.configurations
       .sort((c1, c2) => naturalSortIgnoreCase(c1.name, c2.name))
-      // Hack to be able to filter in SelectPopover. We should change that to avoid this hack.
-      .map(configuration => `${configuration.id};${configuration.name}`);
+      // TODO: Hack to be able to filter in SelectPopover. We should change that to avoid this hack.
+      .map(configurationMapper);
 
     const configurationFormatter = (configurationId) => {
       const [id] = configurationId.split(';');
@@ -66,6 +76,12 @@ const CollectorsAdministrationFilters = createReactClass({
       this.onFilterChange('configuration', id, callback);
     };
 
+    let configurationFilter;
+    if (this.props.filters.configuration) {
+      const configuration = this.props.configurations.find(c => c.id === this.props.filters.configuration);
+      configurationFilter = configuration ? configurationMapper(configuration) : undefined;
+    }
+
     return (
       <SelectPopover id="configuration-filter"
                      title="Filter by configuration"
@@ -73,6 +89,7 @@ const CollectorsAdministrationFilters = createReactClass({
                      items={configurations}
                      itemFormatter={configurationFormatter}
                      onItemSelect={filter}
+                     selectedItems={configurationFilter ? [configurationFilter] : []}
                      filterPlaceholder="Filter by configuration" />
     );
   },
@@ -84,12 +101,15 @@ const CollectorsAdministrationFilters = createReactClass({
 
     const filter = ([os], callback) => this.onFilterChange('os', os, callback);
 
+    const osFilter = this.props.filters.os;
+
     return (
       <SelectPopover id="os-filter"
                      title="Filter by OS"
                      triggerNode={<Button bsSize="small" bsStyle="link">OS <span className="caret" /></Button>}
                      items={operatingSystems}
                      onItemSelect={filter}
+                     selectedItems={osFilter ? [osFilter] : []}
                      filterPlaceholder="Filter by OS" />
     );
   },
@@ -110,6 +130,8 @@ const CollectorsAdministrationFilters = createReactClass({
 
     const filter = ([statusCode], callback) => this.onFilterChange('status', statusCode, callback);
 
+    const statusFilter = this.props.filters.status;
+
     return (
       <SelectPopover id="status-filter"
                      title="Filter by status"
@@ -117,6 +139,7 @@ const CollectorsAdministrationFilters = createReactClass({
                      items={status}
                      itemFormatter={statusFormatter}
                      onItemSelect={filter}
+                     selectedItems={statusFilter ? [statusFilter] : []}
                      filterPlaceholder="Filter by status" />
     );
   },

--- a/graylog2-web-interface/src/components/sidecars/administration/CollectorsAdministrationFilters.jsx
+++ b/graylog2-web-interface/src/components/sidecars/administration/CollectorsAdministrationFilters.jsx
@@ -118,8 +118,6 @@ const CollectorsAdministrationFilters = createReactClass({
   getStatusFilter() {
     // 0: running, 1: unknown, 2: failing
     const status = ['0', '1', '2'];
-    const statusFormatter = StatusMapper.toString;
-
     const filter = ([statusCode], callback) => this.onFilterChange('status', statusCode, callback);
 
     const statusFilter = this.props.filters.status;
@@ -129,7 +127,7 @@ const CollectorsAdministrationFilters = createReactClass({
                      title="Filter by status"
                      triggerNode={<Button bsSize="small" bsStyle="link">Status <span className="caret" /></Button>}
                      items={status}
-                     itemFormatter={statusFormatter}
+                     itemFormatter={StatusMapper.toString}
                      onItemSelect={filter}
                      selectedItems={statusFilter ? [statusFilter] : []}
                      filterPlaceholder="Filter by status" />

--- a/graylog2-web-interface/src/components/sidecars/administration/FiltersSummary.css
+++ b/graylog2-web-interface/src/components/sidecars/administration/FiltersSummary.css
@@ -1,0 +1,3 @@
+:local(.deleteButton) {
+    vertical-align: baseline;
+}

--- a/graylog2-web-interface/src/components/sidecars/administration/FiltersSummary.jsx
+++ b/graylog2-web-interface/src/components/sidecars/administration/FiltersSummary.jsx
@@ -1,15 +1,18 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { Col, Row } from 'react-bootstrap';
+import { Button, Col, Row } from 'react-bootstrap';
 import lodash from 'lodash';
 
 import StatusMapper from 'components/sidecars/common/StatusMapper';
+
+import style from './FiltersSummary.css';
 
 class FiltersSummary extends React.Component {
   static propTypes = {
     collectors: PropTypes.array.isRequired,
     configurations: PropTypes.array.isRequired,
     filters: PropTypes.object.isRequired,
+    onResetFilters: PropTypes.func.isRequired,
   };
 
   formatFilter = (type, value) => {
@@ -37,7 +40,7 @@ class FiltersSummary extends React.Component {
   };
 
   render() {
-    const { filters } = this.props;
+    const { filters, onResetFilters } = this.props;
 
     if (lodash.isEmpty(filters)) {
       return null;
@@ -49,6 +52,10 @@ class FiltersSummary extends React.Component {
           <ul className="list-inline">
             <li><b>Filters</b></li>
             {this.formatFilters(filters)}
+            <li>
+              <Button bsStyle="link" bsSize="xsmall" className={style.deleteButton} onClick={onResetFilters}>
+                <i className="fa fa-times" /> Clear all</Button>
+            </li>
           </ul>
         </Col>
       </Row>

--- a/graylog2-web-interface/src/components/sidecars/administration/FiltersSummary.jsx
+++ b/graylog2-web-interface/src/components/sidecars/administration/FiltersSummary.jsx
@@ -1,0 +1,59 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { Col, Row } from 'react-bootstrap';
+import lodash from 'lodash';
+
+import StatusMapper from 'components/sidecars/common/StatusMapper';
+
+class FiltersSummary extends React.Component {
+  static propTypes = {
+    collectors: PropTypes.array.isRequired,
+    configurations: PropTypes.array.isRequired,
+    filters: PropTypes.object.isRequired,
+  };
+
+  formatFilter = (type, value) => {
+    const { collectors, configurations } = this.props;
+
+    if (type === 'collector') {
+      // Get collector name
+      const collector = collectors.find(c => c.id === value);
+      return `${collector.name} on ${collector.node_operating_system}`;
+    } else if (type === 'configuration') {
+      // Get configuration name
+      return configurations.find(c => c.id === value).name;
+    } else if (type === 'status') {
+      // Convert status code to string
+      return StatusMapper.toString(value);
+    } else {
+      return value;
+    }
+  };
+
+  formatFilters = (filters) => {
+    return Object.keys(filters).map((filterKey) => {
+      return <li key={filterKey}>{filterKey}: {this.formatFilter(filterKey, filters[filterKey])}</li>;
+    });
+  };
+
+  render() {
+    const { filters } = this.props;
+
+    if (lodash.isEmpty(filters)) {
+      return null;
+    }
+
+    return (
+      <Row className="row-sm">
+        <Col md={10}>
+          <ul className="list-inline">
+            <li><b>Filters</b></li>
+            {this.formatFilters(filters)}
+          </ul>
+        </Col>
+      </Row>
+    );
+  }
+}
+
+export default FiltersSummary;

--- a/graylog2-web-interface/src/components/sidecars/common/SidecarSearchForm.jsx
+++ b/graylog2-web-interface/src/components/sidecars/common/SidecarSearchForm.jsx
@@ -52,7 +52,7 @@ class SidecarSearchForm extends React.Component {
               <td>Identifier of the sidecar</td>
             </tr>
             <tr>
-              <td>collector_version</td>
+              <td>sidecar_version</td>
               <td>Sidecar version</td>
             </tr>
           </tbody>

--- a/graylog2-web-interface/src/components/sidecars/common/StatusIndicator.jsx
+++ b/graylog2-web-interface/src/components/sidecars/common/StatusIndicator.jsx
@@ -3,7 +3,11 @@ import PropTypes from 'prop-types';
 
 class StatusIndicator extends React.Component {
   static propTypes = {
-    status: PropTypes.number.isRequired,
+    status: PropTypes.number,
+  };
+
+  static defaultProps = {
+    status: -1,
   };
 
   render() {

--- a/graylog2-web-interface/src/components/sidecars/common/StatusMapper.js
+++ b/graylog2-web-interface/src/components/sidecars/common/StatusMapper.js
@@ -1,0 +1,14 @@
+const StatusMapper = {
+  toString(statusCode) {
+    switch (Number(statusCode)) {
+      case 0:
+        return 'Running';
+      case 2:
+        return 'Failing';
+      default:
+        return 'Unknown';
+    }
+  },
+};
+
+export default StatusMapper;

--- a/graylog2-web-interface/src/components/sidecars/configuration-forms/CollectorForm.jsx
+++ b/graylog2-web-interface/src/components/sidecars/configuration-forms/CollectorForm.jsx
@@ -1,5 +1,6 @@
 import PropTypes from 'prop-types';
 import React from 'react';
+import createReactClass from 'create-react-class';
 import Reflux from 'reflux';
 import lodash from 'lodash';
 import { Button, ButtonToolbar, Col, ControlLabel, FormGroup, HelpBlock, Row } from 'react-bootstrap';
@@ -15,8 +16,10 @@ import SourceViewModal from './SourceViewModal';
 const { CollectorsStore, CollectorsActions } = CombinedProvider.get('Collectors');
 const { CollectorConfigurationsActions } = CombinedProvider.get('CollectorConfigurations');
 
-const CollectorForm = React.createClass({
+const CollectorForm = createReactClass({
+  displayName: 'CollectorForm',
   mixins: [Reflux.connect(CollectorsStore)],
+
   propTypes: {
     action: PropTypes.oneOf(['create', 'edit']),
     collector: PropTypes.object,

--- a/graylog2-web-interface/src/components/sidecars/configuration-forms/ConfigurationForm.jsx
+++ b/graylog2-web-interface/src/components/sidecars/configuration-forms/ConfigurationForm.jsx
@@ -72,10 +72,10 @@ const ConfigurationForm = createReactClass({
   },
 
   _formDataUpdate(key) {
-    return (nextValue) => {
+    return (nextValue, _, hideCallback) => {
       const nextFormData = lodash.cloneDeep(this.state.formData);
       nextFormData[key] = nextValue;
-      this.setState({ formData: nextFormData });
+      this.setState({ formData: nextFormData }, hideCallback);
     };
   },
 

--- a/graylog2-web-interface/src/components/sidecars/configuration-forms/ConfigurationForm.jsx
+++ b/graylog2-web-interface/src/components/sidecars/configuration-forms/ConfigurationForm.jsx
@@ -1,5 +1,6 @@
 import PropTypes from 'prop-types';
 import React from 'react';
+import createReactClass from 'create-react-class';
 import Reflux from 'reflux';
 import lodash from 'lodash';
 import { Button, ButtonToolbar, Col, ControlLabel, FormGroup, HelpBlock, Row } from 'react-bootstrap';
@@ -16,8 +17,10 @@ import ColorLabel from 'components/sidecars/common/ColorLabel';
 const { CollectorsStore, CollectorsActions } = CombinedProvider.get('Collectors');
 const { CollectorConfigurationsActions } = CombinedProvider.get('CollectorConfigurations');
 
-const ConfigurationForm = React.createClass({
+const ConfigurationForm = createReactClass({
+  displayName: 'ConfigurationForm',
   mixins: [Reflux.connect(CollectorsStore)],
+
   propTypes: {
     action: PropTypes.oneOf(['create', 'edit']),
     configuration: PropTypes.object,

--- a/graylog2-web-interface/src/components/sidecars/configuration-forms/ConfigurationHelper.jsx
+++ b/graylog2-web-interface/src/components/sidecars/configuration-forms/ConfigurationHelper.jsx
@@ -11,33 +11,31 @@ import TemplatesHelper from './TemplatesHelper';
 import IncludesHelper from './IncludesHelper';
 import ConfigurationHelperStyle from './ConfigurationHelper.css';
 
-const ConfigurationHelper = React.createClass({
-  propTypes: {
+class ConfigurationHelper extends React.Component {
+  static propTypes = {
     type: PropTypes.string.isRequired,
-  },
+  };
 
-  getInitialState() {
-    return {
-      section: undefined,
-      paragraph: undefined,
-    };
-  },
+  state = {
+    section: undefined,
+    paragraph: undefined,
+  };
 
-  _onSelect(event) {
+  _onSelect = (event) => {
     const newState = event.split('.');
     this.setState({ section: newState[0], paragraph: newState[1] });
-  },
+  };
 
-  _getId(idName, index) {
+  _getId = (idName, index) => {
     const idIndex = index !== undefined ? `. ${index}` : '';
     return idName + idIndex;
-  },
+  };
 
-  _getEventKey(a, b) {
+  _getEventKey = (a, b) => {
     return (`${a}.${b}`);
-  },
+  };
 
-  navDropDowns(content) {
+  navDropDowns = (content) => {
     const dropDowns = [];
     Object.keys(content).forEach((section) => {
       if (!Object.prototype.hasOwnProperty.call(content, section)) {
@@ -60,7 +58,7 @@ const ConfigurationHelper = React.createClass({
     });
 
     return dropDowns;
-  },
+  };
 
   render() {
     return (
@@ -104,7 +102,7 @@ const ConfigurationHelper = React.createClass({
         </Row>
       </Panel>
     );
-  },
-});
+  }
+}
 
 export default ConfigurationHelper;

--- a/graylog2-web-interface/src/components/sidecars/configuration-forms/FilebeatHelper.jsx
+++ b/graylog2-web-interface/src/components/sidecars/configuration-forms/FilebeatHelper.jsx
@@ -4,21 +4,19 @@ import React from 'react';
 
 import ConfigurationHelperStyle from './ConfigurationHelper.css';
 
-const FilebeatHelper = React.createClass({
-  propTypes: {
+class FilebeatHelper extends React.Component {
+  static propTypes = {
     section: PropTypes.string,
     paragraph: PropTypes.string,
-  },
+  };
 
-  statics: {
-    toc: {
-      prospectors: ['log'],
-      outputs: ['logstash'],
-      processors: ['fields', 'drop events'],
-    },
-  },
+  static toc = {
+    prospectors: ['log'],
+    outputs: ['logstash'],
+    processors: ['fields', 'drop events'],
+  };
 
-  prospectorsLog() {
+  prospectorsLog = () => {
     return (
       <div>
         <h3>Log Prospector</h3>
@@ -101,9 +99,9 @@ const FilebeatHelper = React.createClass({
         {this.example(`clean_inactive: 0`)}
       </div>
     );
-  },
+  };
 
-  outputsLogstash() {
+  outputsLogstash = () => {
     return (
       <div>
         <h3>Logstash Output</h3>
@@ -152,9 +150,9 @@ const FilebeatHelper = React.createClass({
         {this.example(`ssl.key_passphrase: 'secure'`)}
       </div>
     );
-  },
+  };
 
-  processorsFields() {
+  processorsFields = () => {
     return (
       <div>
         Processors are used to reduce the number of fields in the exported event or to
@@ -167,9 +165,9 @@ const FilebeatHelper = React.createClass({
     fields: ["cpu.user", "cpu.system"]`)}
       </div>
     );
-  },
+  };
 
-  processorsDropEvents() {
+  processorsDropEvents = () => {
     return (
       <div>
         The following example drops the events that have the HTTP response code 200:<br/>
@@ -181,17 +179,17 @@ const FilebeatHelper = React.createClass({
              http.code: 200`)}
       </div>
     );
-  },
+  };
 
-  example(data) {
+  example = (data) => {
     return (
       <pre className={`${ConfigurationHelperStyle.marginTab} ${ConfigurationHelperStyle.exampleFunction}`} >{data}</pre>
     );
-  },
+  };
 
-  lookupName() {
+  lookupName = () => {
     return lodash.camelCase(`${this.props.section} ${this.props.paragraph}`);
-  },
+  };
 
   render() {
     if (this.props.section && this.props.paragraph) {
@@ -203,6 +201,7 @@ const FilebeatHelper = React.createClass({
         <div>Choose a configuration topic from the drop down to get a quick help.</div>
       );
     }
-  },
-});
+  }
+}
+
 export default FilebeatHelper;

--- a/graylog2-web-interface/src/components/sidecars/configuration-forms/IncludesHelper.jsx
+++ b/graylog2-web-interface/src/components/sidecars/configuration-forms/IncludesHelper.jsx
@@ -7,34 +7,32 @@ import SourceViewModal from './SourceViewModal';
 
 const { CollectorConfigurationsActions } = CombinedProvider.get('CollectorConfigurations');
 
-const IncludesHelper = React.createClass({
-  getInitialState() {
-    return {
-      configurations: [],
-    };
-  },
+class IncludesHelper extends React.Component {
+  state = {
+    configurations: [],
+  };
 
   componentDidMount() {
     this._reloadConfiguration();
-  },
+  }
 
-  _reloadConfiguration() {
+  _reloadConfiguration = () => {
     CollectorConfigurationsActions.all()
       .then((configurations) => {
         this.setState({ configurations: configurations });
       });
-  },
+  };
 
-  _getId(idName, index) {
+  _getId = (idName, index) => {
     const idIndex = index !== undefined ? `. ${index}` : '';
     return idName + idIndex;
-  },
+  };
 
-  _onShowSource(id) {
+  _onShowSource = (id) => {
     this.refs[`modal_${id}`].open();
-  },
+  };
 
-  _configurationListFormatter() {
+  _configurationListFormatter = () => {
     const configurationRows = [];
     Object.values(this.state.configurations).forEach((configuration) => {
       const escapedName = `<#include "${configuration.id}">`;
@@ -55,11 +53,11 @@ const IncludesHelper = React.createClass({
       );
     });
     return configurationRows;
-  },
+  };
 
-  _isLoading() {
+  _isLoading = () => {
     return !(this.state.configurations);
-  },
+  };
 
   render() {
     if (this._isLoading()) {
@@ -83,6 +81,7 @@ const IncludesHelper = React.createClass({
         </Table>
       </div>
     );
-  },
-});
+  }
+}
+
 export default IncludesHelper;

--- a/graylog2-web-interface/src/components/sidecars/configuration-forms/SourceViewModal.jsx
+++ b/graylog2-web-interface/src/components/sidecars/configuration-forms/SourceViewModal.jsx
@@ -8,29 +8,27 @@ import CombinedProvider from 'injection/CombinedProvider';
 
 const { CollectorConfigurationsActions } = CombinedProvider.get('CollectorConfigurations');
 
-const SourceViewModal = React.createClass({
-  propTypes: {
+class SourceViewModal extends React.Component {
+  static propTypes = {
     configurationId: PropTypes.string,
     templateString: PropTypes.string,
-  },
+  };
 
-  getInitialState() {
-    return {
-      source: undefined,
-      name: undefined,
-    };
-  },
+  state = {
+    source: undefined,
+    name: undefined,
+  };
 
-  open() {
+  open = () => {
     this._loadConfiguration();
     this.sourceModal.open();
-  },
+  };
 
-  hide() {
+  hide = () => {
     this.sourceModal.close();
-  },
+  };
 
-  _loadConfiguration() {
+  _loadConfiguration = () => {
     if (this.props.templateString) {
       CollectorConfigurationsActions.renderPreview(this.props.templateString)
         .then((response) => {
@@ -42,7 +40,7 @@ const SourceViewModal = React.createClass({
           this.setState({ source: configuration.template, name: configuration.name });
         });
     }
-  },
+  };
 
   render() {
     return (
@@ -62,7 +60,7 @@ const SourceViewModal = React.createClass({
         </Modal.Footer>
       </BootstrapModalWrapper>
     );
-  },
-});
+  }
+}
 
 export default SourceViewModal;

--- a/graylog2-web-interface/src/components/sidecars/configuration-forms/TemplatesHelper.jsx
+++ b/graylog2-web-interface/src/components/sidecars/configuration-forms/TemplatesHelper.jsx
@@ -17,19 +17,19 @@ class TemplatesHelper extends React.Component {
           <tbody>
             <tr>
               <td><code>{'${'}operatingSystem{'}'}</code></td>
-              <td>Name of the agents operating system, e.g. <code>&quot;Linux&quot;, &quot;Windows&quot;</code></td>
+              <td>Name of the operating system the sidecar is running on, e.g. <code>&quot;Linux&quot;, &quot;Windows&quot;</code></td>
             </tr>
             <tr>
               <td><code>{'${'}nodeName{'}'}</code></td>
-              <td>The name of the agent, defaults to hostname if not set.</td>
+              <td>The name of the sidecar, defaults to hostname if not set.</td>
             </tr>
             <tr>
               <td><code>{'${'}nodeId{'}'}</code></td>
-              <td>UUID of the agent.</td>
+              <td>UUID of the sidecar.</td>
             </tr>
             <tr>
               <td><code>{'${'}collectorVersion{'}'}</code></td>
-              <td>Version string of the running Sidecar.</td>
+              <td>Version string of the running sidecar.</td>
             </tr>
             <tr>
               <td><code>{'${'}ip{'}'}</code></td>

--- a/graylog2-web-interface/src/components/sidecars/configuration-forms/TemplatesHelper.jsx
+++ b/graylog2-web-interface/src/components/sidecars/configuration-forms/TemplatesHelper.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { Table } from 'react-bootstrap';
 
-const TemplatesHelper = React.createClass({
+class TemplatesHelper extends React.Component {
   render() {
     return (
       <div>
@@ -47,6 +47,7 @@ const TemplatesHelper = React.createClass({
         </Table>
       </div>
     );
-  },
-});
+  }
+}
+
 export default TemplatesHelper;

--- a/graylog2-web-interface/src/components/sidecars/configuration-forms/TemplatesHelper.jsx
+++ b/graylog2-web-interface/src/components/sidecars/configuration-forms/TemplatesHelper.jsx
@@ -33,7 +33,7 @@ class TemplatesHelper extends React.Component {
             </tr>
             <tr>
               <td><code>{'${'}ip{'}'}</code></td>
-              <td>First public IP address.</td>
+              <td>First public IP address of the machine the sidecar is running on.</td>
             </tr>
             <tr>
               <td><code>{'${'}cpuIdle{'}'}</code></td>

--- a/graylog2-web-interface/src/components/sidecars/configurations/CollectorList.jsx
+++ b/graylog2-web-interface/src/components/sidecars/configurations/CollectorList.jsx
@@ -15,6 +15,7 @@ const CollectorList = createReactClass({
     collectors: PropTypes.array.isRequired,
     pagination: PropTypes.object.isRequired,
     query: PropTypes.string.isRequired,
+    total: PropTypes.number.isRequired,
     onClone: PropTypes.func.isRequired,
     onDelete: PropTypes.func.isRequired,
     onPageChange: PropTypes.func.isRequired,
@@ -36,7 +37,7 @@ const CollectorList = createReactClass({
   },
 
   render() {
-    const { collectors, pagination, query, onPageChange, onQueryChange } = this.props;
+    const { collectors, pagination, query, total, onPageChange, onQueryChange } = this.props;
 
     const headers = ['Name', 'Operating System', 'Actions'];
 
@@ -49,7 +50,7 @@ const CollectorList = createReactClass({
                 <Button bsStyle="success" bsSize="small">Create Log Collector</Button>
               </LinkContainer>
             </div>
-            <h2>Log Collectors <small>{collectors.length} total</small></h2>
+            <h2>Log Collectors <small>{total} total</small></h2>
           </Col>
           <Col md={12}>
             <p>Manage Log Collectors that you can configure and supervise through Graylog Sidecar and Graylog Web Interface.</p>

--- a/graylog2-web-interface/src/components/sidecars/configurations/CollectorListContainer.jsx
+++ b/graylog2-web-interface/src/components/sidecars/configurations/CollectorListContainer.jsx
@@ -54,6 +54,7 @@ const CollectorListContainer = createReactClass({
       <CollectorList collectors={collectors.paginatedCollectors}
                      pagination={collectors.pagination}
                      query={collectors.query}
+                     total={collectors.total}
                      onPageChange={this.handlePageChange}
                      onQueryChange={this.handleQueryChange}
                      onClone={this.handleClone}

--- a/graylog2-web-interface/src/components/sidecars/configurations/ConfigurationList.jsx
+++ b/graylog2-web-interface/src/components/sidecars/configurations/ConfigurationList.jsx
@@ -16,6 +16,7 @@ class ConfigurationList extends React.Component {
     configurations: PropTypes.array.isRequired,
     pagination: PropTypes.object.isRequired,
     query: PropTypes.string.isRequired,
+    total: PropTypes.number.isRequired,
     onPageChange: PropTypes.func.isRequired,
     onQueryChange: PropTypes.func.isRequired,
     onClone: PropTypes.func.isRequired,
@@ -42,7 +43,7 @@ class ConfigurationList extends React.Component {
   };
 
   render() {
-    const { configurations, pagination, query, onPageChange, onQueryChange } = this.props;
+    const { configurations, pagination, query, total, onPageChange, onQueryChange } = this.props;
     const headers = ['Configuration', 'Color', 'Collector', 'Actions'];
 
     return (
@@ -54,7 +55,7 @@ class ConfigurationList extends React.Component {
                 <Button onClick={this.openModal} bsStyle="success" bsSize="small">Create Configuration</Button>
               </LinkContainer>
             </div>
-            <h2>Configurations <small>{pagination.total} total</small></h2>
+            <h2>Configurations <small>{total} total</small></h2>
           </Col>
           <Col md={12}>
             <p>

--- a/graylog2-web-interface/src/components/sidecars/configurations/ConfigurationList.jsx
+++ b/graylog2-web-interface/src/components/sidecars/configurations/ConfigurationList.jsx
@@ -10,8 +10,8 @@ import ConfigurationRow from './ConfigurationRow';
 
 import style from './ConfigurationList.css';
 
-const ConfigurationList = React.createClass({
-  propTypes: {
+class ConfigurationList extends React.Component {
+  static propTypes = {
     collectors: PropTypes.array.isRequired,
     configurations: PropTypes.array.isRequired,
     pagination: PropTypes.object.isRequired,
@@ -21,14 +21,14 @@ const ConfigurationList = React.createClass({
     onClone: PropTypes.func.isRequired,
     onDelete: PropTypes.func.isRequired,
     validateConfiguration: PropTypes.func.isRequired,
-  },
+  };
 
-  _headerCellFormatter(header) {
+  _headerCellFormatter = (header) => {
     const className = (header === 'Actions' ? style.actionsColumn : '');
     return <th className={className}>{header}</th>;
-  },
+  };
 
-  _collectorConfigurationFormatter(configuration) {
+  _collectorConfigurationFormatter = (configuration) => {
     const { collectors, onClone, onDelete, validateConfiguration } = this.props;
     const configurationCollector = collectors.find(collector => collector.id === configuration.collector_id);
     return (
@@ -39,7 +39,7 @@ const ConfigurationList = React.createClass({
                         validateConfiguration={validateConfiguration}
                         onDelete={onDelete} />
     );
-  },
+  };
 
   render() {
     const { configurations, pagination, query, onPageChange, onQueryChange } = this.props;
@@ -99,7 +99,7 @@ const ConfigurationList = React.createClass({
         </Row>
       </div>
     );
-  },
-});
+  }
+}
 
 export default ConfigurationList;

--- a/graylog2-web-interface/src/components/sidecars/configurations/ConfigurationListContainer.jsx
+++ b/graylog2-web-interface/src/components/sidecars/configurations/ConfigurationListContainer.jsx
@@ -59,6 +59,7 @@ const ConfigurationListContainer = createReactClass({
       <ConfigurationList collectors={collectors.collectors}
                          query={configurations.query}
                          pagination={configurations.pagination}
+                         total={configurations.total}
                          configurations={configurations.paginatedConfigurations}
                          onPageChange={this.handlePageChange}
                          onQueryChange={this.handleQueryChange}

--- a/graylog2-web-interface/src/components/sidecars/configurations/ConfigurationRow.jsx
+++ b/graylog2-web-interface/src/components/sidecars/configurations/ConfigurationRow.jsx
@@ -11,27 +11,25 @@ import CopyConfigurationModal from './CopyConfigurationModal';
 
 import styles from './ConfigurationRow.css';
 
-const ConfigurationRow = React.createClass({
-  propTypes: {
+class ConfigurationRow extends React.Component {
+  static propTypes = {
     configuration: PropTypes.object.isRequired,
     collector: PropTypes.object,
     onCopy: PropTypes.func.isRequired,
     validateConfiguration: PropTypes.func.isRequired,
     onDelete: PropTypes.func.isRequired,
-  },
+  };
 
-  getDefaultProps() {
-    return {
-      collector: {},
-    };
-  },
+  static defaultProps = {
+    collector: {},
+  };
 
-  _handleDelete() {
+  _handleDelete = () => {
     const configuration = this.props.configuration;
     if (window.confirm(`You are about to delete configuration "${configuration.name}". Are you sure?`)) {
       this.props.onDelete(configuration);
     }
-  },
+  };
 
   render() {
     const { collector, configuration } = this.props;
@@ -63,7 +61,7 @@ const ConfigurationRow = React.createClass({
         </td>
       </tr>
     );
-  },
-});
+  }
+}
 
 export default ConfigurationRow;

--- a/graylog2-web-interface/src/components/sidecars/configurations/CopyCollectorModal.jsx
+++ b/graylog2-web-interface/src/components/sidecars/configurations/CopyCollectorModal.jsx
@@ -6,61 +6,57 @@ import { BootstrapModalForm, Input } from 'components/bootstrap';
 
 import style from './CopyModal.css';
 
-const CopyCollectorModal = React.createClass({
-  propTypes: {
+class CopyCollectorModal extends React.Component {
+  static propTypes = {
     id: PropTypes.string,
     copyCollector: PropTypes.func.isRequired,
     validateCollector: PropTypes.func.isRequired,
-  },
+  };
 
-  getDefaultProps() {
-    return {
-      id: '',
-      name: '',
-    };
-  },
+  static defaultProps = {
+    id: '',
+    name: '',
+  };
 
-  getInitialState() {
-    return {
-      id: this.props.id,
-      name: '',
-      error: false,
-      error_message: '',
-    };
-  },
+  state = {
+    id: this.props.id,
+    name: '',
+    error: false,
+    error_message: '',
+  };
 
-  openModal() {
+  openModal = () => {
     this.refs.modal.open();
-  },
+  };
 
-  _getId(prefixIdName) {
+  _getId = (prefixIdName) => {
     return `${prefixIdName}-${this.props.id}`;
-  },
+  };
 
-  _closeModal() {
+  _closeModal = () => {
     this.refs.modal.close();
-  },
+  };
 
-  _saved() {
+  _saved = () => {
     this._closeModal();
     this.setState({ name: '' });
-  },
+  };
 
-  _save() {
+  _save = () => {
     const collector = this.state;
 
     if (!collector.error) {
       this.props.copyCollector(this.props.id, this.state.name, this._saved);
     }
-  },
+  };
 
-  _changeName(event) {
+  _changeName = (event) => {
     const nextName = event.target.value;
     this.setState({ name: nextName });
     this.props.validateCollector(nextName).then(validation => (
       this.setState({ error: validation.error, error_message: validation.error_message })
     ));
-  },
+  };
 
   render() {
     return (
@@ -85,7 +81,7 @@ const CopyCollectorModal = React.createClass({
         </BootstrapModalForm>
       </span>
     );
-  },
-});
+  }
+}
 
 export default CopyCollectorModal;

--- a/graylog2-web-interface/src/components/sidecars/configurations/CopyConfigurationModal.jsx
+++ b/graylog2-web-interface/src/components/sidecars/configurations/CopyConfigurationModal.jsx
@@ -6,61 +6,57 @@ import { BootstrapModalForm, Input } from 'components/bootstrap';
 
 import style from './CopyModal.css';
 
-const CopyConfigurationModal = React.createClass({
-  propTypes: {
+class CopyConfigurationModal extends React.Component {
+  static propTypes = {
     id: PropTypes.string,
     copyConfiguration: PropTypes.func.isRequired,
     validateConfiguration: PropTypes.func.isRequired,
-  },
+  };
 
-  getDefaultProps() {
-    return {
-      id: '',
-      name: '',
-    };
-  },
+  static defaultProps = {
+    id: '',
+    name: '',
+  };
 
-  getInitialState() {
-    return {
-      id: this.props.id,
-      name: '',
-      error: false,
-      error_message: '',
-    };
-  },
+  state = {
+    id: this.props.id,
+    name: '',
+    error: false,
+    error_message: '',
+  };
 
-  openModal() {
+  openModal = () => {
     this.refs.modal.open();
-  },
+  };
 
-  _getId(prefixIdName) {
+  _getId = (prefixIdName) => {
     return `${prefixIdName}-${this.props.id}`;
-  },
+  };
 
-  _closeModal() {
+  _closeModal = () => {
     this.refs.modal.close();
-  },
+  };
 
-  _saved() {
+  _saved = () => {
     this._closeModal();
     this.setState({ name: '' });
-  },
+  };
 
-  _save() {
+  _save = () => {
     const configuration = this.state;
 
     if (!configuration.error) {
       this.props.copyConfiguration(this.props.id, this.state.name, this._saved);
     }
-  },
+  };
 
-  _changeName(event) {
+  _changeName = (event) => {
     const nextName = event.target.value;
     this.setState({ name: nextName });
     this.props.validateConfiguration(nextName).then(validation => (
       this.setState({ error: validation.error, error_message: validation.error_message })
     ));
-  },
+  };
 
   render() {
     return (
@@ -85,7 +81,7 @@ const CopyConfigurationModal = React.createClass({
         </BootstrapModalForm>
       </span>
     );
-  },
-});
+  }
+}
 
 export default CopyConfigurationModal;

--- a/graylog2-web-interface/src/components/sidecars/sidecars/SidecarList.jsx
+++ b/graylog2-web-interface/src/components/sidecars/sidecars/SidecarList.jsx
@@ -51,8 +51,8 @@ class SidecarList extends React.Component {
                 onClick={onSortChange('node_id')}>
               Node Id
             </th>
-            <th className={this.getTableHeaderClassName('collector_version')}
-                onClick={onSortChange('collector_version')}>
+            <th className={this.getTableHeaderClassName('sidecar_version')}
+                onClick={onSortChange('sidecar_version')}>
               Sidecar Version
             </th>
             <th className={style.actions}>&nbsp;</th>

--- a/graylog2-web-interface/src/components/sidecars/sidecars/SidecarList.jsx
+++ b/graylog2-web-interface/src/components/sidecars/sidecars/SidecarList.jsx
@@ -9,8 +9,8 @@ import SidecarSearchForm from 'components/sidecars/common/SidecarSearchForm';
 
 import style from './SidecarList.css';
 
-const SidecarList = React.createClass({
-  propTypes: {
+class SidecarList extends React.Component {
+  static propTypes = {
     sidecars: PropTypes.array.isRequired,
     onlyActive: PropTypes.bool.isRequired,
     pagination: PropTypes.object.isRequired,
@@ -20,13 +20,13 @@ const SidecarList = React.createClass({
     onQueryChange: PropTypes.func.isRequired,
     onSortChange: PropTypes.func.isRequired,
     toggleShowInactive: PropTypes.func.isRequired,
-  },
+  };
 
-  getTableHeaderClassName(field) {
+  getTableHeaderClassName = (field) => {
     return (this.props.sort.field === field ? `sort-${this.props.sort.order}` : 'sortable');
-  },
+  };
 
-  formatSidecarList(sidecars) {
+  formatSidecarList = (sidecars) => {
     const { onSortChange } = this.props;
 
     return (
@@ -63,12 +63,12 @@ const SidecarList = React.createClass({
         </tbody>
       </Table>
     );
-  },
+  };
 
-  formatEmptyListAlert() {
+  formatEmptyListAlert = () => {
     const showInactiveHint = (this.props.onlyActive ? ' and/or click on "Include inactive sidecars"' : null);
     return <Alert>There are no sidecars to show. Try adjusting your search filter{showInactiveHint}.</Alert>;
-  },
+  };
 
   render() {
     const { sidecars, onlyActive, pagination, query, onQueryChange, onPageChange, toggleShowInactive } = this.props;
@@ -103,7 +103,7 @@ const SidecarList = React.createClass({
         </PaginatedList>
       </div>
     );
-  },
-});
+  }
+}
 
 export default SidecarList;

--- a/graylog2-web-interface/src/components/sidecars/sidecars/SidecarListContainer.jsx
+++ b/graylog2-web-interface/src/components/sidecars/sidecars/SidecarListContainer.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import createReactClass from 'create-react-class';
 import Reflux from 'reflux';
 
 import { Spinner } from 'components/common';
@@ -7,13 +8,15 @@ import SidecarList from './SidecarList';
 
 const { SidecarsStore, SidecarsActions } = CombinedProvider.get('Sidecars');
 
-const SidecarListContainer = React.createClass({
+const SidecarListContainer = createReactClass({
+  displayName: 'SidecarListContainer',
   mixins: [Reflux.connect(SidecarsStore)],
 
   componentDidMount() {
     this._reloadSidecars({});
     this.interval = setInterval(() => this._reloadSidecars({}), this.SIDECAR_DATA_REFRESH);
   },
+
   componentWillUnmount() {
     if (this.interval) {
       clearInterval(this.interval);

--- a/graylog2-web-interface/src/components/sidecars/sidecars/SidecarRow.jsx
+++ b/graylog2-web-interface/src/components/sidecars/sidecars/SidecarRow.jsx
@@ -11,15 +11,14 @@ import StatusIndicator from 'components/sidecars/common/StatusIndicator';
 
 import style from './SidecarRow.css';
 
-const SidecarRow = React.createClass({
-  propTypes: {
+class SidecarRow extends React.Component {
+  static propTypes = {
     sidecar: PropTypes.object.isRequired,
-  },
-  getInitialState() {
-    return {
-      showRelativeTime: true,
-    };
-  },
+  };
+
+  state = {
+    showRelativeTime: true,
+  };
 
   render() {
     const sidecar = this.props.sidecar;
@@ -68,7 +67,7 @@ const SidecarRow = React.createClass({
         </td>
       </tr>
     );
-  },
-});
+  }
+}
 
 export default SidecarRow;

--- a/graylog2-web-interface/src/components/sidecars/sidecars/SidecarRow.jsx
+++ b/graylog2-web-interface/src/components/sidecars/sidecars/SidecarRow.jsx
@@ -53,7 +53,7 @@ class SidecarRow extends React.Component {
           {annotation}
         </td>
         <td>
-          {sidecar.collector_version}
+          {sidecar.sidecar_version}
         </td>
         <td>
           <ButtonToolbar>

--- a/graylog2-web-interface/src/components/sidecars/sidecars/SidecarStatus.jsx
+++ b/graylog2-web-interface/src/components/sidecars/sidecars/SidecarStatus.jsx
@@ -25,25 +25,33 @@ const SidecarStatus = createReactClass({
     if (!details) {
       return <p>Node details are currently unavailable. Please wait a moment and ensure the sidecar is correctly connected to the server.</p>;
     }
+    const metrics = details.metrics || {};
     return (
       <dl className="deflist top-margin">
         <dt>IP Address</dt>
-        <dd>{details.ip}</dd>
+        <dd>{lodash.defaultTo(details.ip, 'Not available')}</dd>
         <dt>Operating System</dt>
-        <dd>{details.operating_system}</dd>
+        <dd>{lodash.defaultTo(details.operating_system, 'Not available')}</dd>
         <dt>CPU Idle</dt>
-        <dd>{lodash.isNumber(details.metrics.cpu_idle) ? `${details.metrics.cpu_idle}%` : 'Not available' }</dd>
+        <dd>{lodash.isNumber(metrics.cpu_idle) ? `${metrics.cpu_idle}%` : 'Not available' }</dd>
         <dt>Load</dt>
-        <dd>{lodash.defaultTo(details.metrics.load_1, 'Not available')}</dd>
+        <dd>{lodash.defaultTo(metrics.load_1, 'Not available')}</dd>
         <dt>Volumes &gt; 75% full</dt>
-        <dd>{details.metrics.disks_75.length > 0 ? details.metrics.disks_75.join(', ') : 'None'}</dd>
+        {metrics.disks_75 === undefined ?
+          <dd>Not available</dd> :
+          <dd>{metrics.disks_75.length > 0 ? metrics.disks_75.join(', ') : 'None'}</dd>
+        }
       </dl>
     );
   },
 
   formatCollectorStatus(details) {
     if (!details) {
-      return <p>Collector statuses are currently unavailable. Please wait a moment and ensure the sidecar is correctly connected to the server.</p>;
+      return <p>Collectors status are currently unavailable. Please wait a moment and ensure the sidecar is correctly connected to the server.</p>;
+    }
+
+    if (!details.status) {
+      return <p>Did not receive collectors status, set the option <code>send_status: true</code> in the collector configuration to see this information.</p>;
     }
 
     const collectors = Object.keys(details.status.collectors);
@@ -103,7 +111,7 @@ const SidecarStatus = createReactClass({
         </Row>
         <Row className="content">
           <Col md={12}>
-            <h2>Collector statuses</h2>
+            <h2>Collectors status</h2>
             <div className="top-margin">
               {this.formatCollectorStatus(sidecar.node_details)}
             </div>

--- a/graylog2-web-interface/src/components/sidecars/sidecars/SidecarStatus.jsx
+++ b/graylog2-web-interface/src/components/sidecars/sidecars/SidecarStatus.jsx
@@ -51,7 +51,7 @@ const SidecarStatus = createReactClass({
     }
 
     if (!details.status) {
-      return <p>Did not receive collectors status, set the option <code>send_status: true</code> in the collector configuration to see this information.</p>;
+      return <p>Did not receive collectors status, set the option <code>send_status: true</code> in the sidecar configuration to see this information.</p>;
     }
 
     const collectors = Object.keys(details.status.collectors);

--- a/graylog2-web-interface/src/components/sidecars/sidecars/SidecarStatusFileList.jsx
+++ b/graylog2-web-interface/src/components/sidecars/sidecars/SidecarStatusFileList.jsx
@@ -3,16 +3,16 @@ import React from 'react';
 
 import { DataTable, Spinner, Timestamp } from 'components/common';
 
-const SidecarStatusFileList = React.createClass({
-  propTypes: {
+class SidecarStatusFileList extends React.Component {
+  static propTypes = {
     files: PropTypes.array.isRequired,
-  },
+  };
 
-  _headerCellFormatter(header) {
+  _headerCellFormatter = (header) => {
     return <th>{header}</th>;
-  },
+  };
 
-  _activityFormatter(time) {
+  _activityFormatter = (time) => {
     var now = new Date().getTime();
     var modDate = new Date(time).getTime();
     if (modDate > (now - 60000)) {
@@ -20,17 +20,17 @@ const SidecarStatusFileList = React.createClass({
     } else {
       return("");
     }
-  },
+  };
 
-  _dirFormatter(file) {
+  _dirFormatter = (file) => {
     if(file.is_dir) {
       return(<span><i className="fa fa-folder-open"/>&nbsp;&nbsp;{file.path}</span>);
     } else {
       return(<span><i className="fa fa-file-o"/>&nbsp;&nbsp;{file.path}</span>);
     }
-  },
+  };
 
-  _fileListFormatter(file) {
+  _fileListFormatter = (file) => {
     const format = "YYYY-MM-DD HH:mm:ss";
 
     return (
@@ -40,11 +40,11 @@ const SidecarStatusFileList = React.createClass({
         <td>{this._dirFormatter(file)}</td>
       </tr>
     );
-  },
+  };
 
   render() {
     var filterKeys = [];
-    var headers = ["Modified", "Size", "Path"];
+    var headers = ["Mo2dified", "Size", "Path"];
 
     return (
       <div>
@@ -60,6 +60,6 @@ const SidecarStatusFileList = React.createClass({
       </div>
     );
   }
-});
+}
 
 export default SidecarStatusFileList;

--- a/graylog2-web-interface/src/pages/SidecarConfigurationPage.jsx
+++ b/graylog2-web-interface/src/pages/SidecarConfigurationPage.jsx
@@ -10,7 +10,7 @@ import Routes from 'routing/Routes';
 import ConfigurationListContainer from 'components/sidecars/configurations/ConfigurationListContainer';
 import CollectorListContainer from 'components/sidecars/configurations/CollectorListContainer';
 
-const SidecarConfigurationPage = React.createClass({
+class SidecarConfigurationPage extends React.Component {
   render() {
     return (
       <DocumentTitle title="Collectors Configuration">
@@ -52,7 +52,7 @@ const SidecarConfigurationPage = React.createClass({
         </span>
       </DocumentTitle>
     );
-  },
-});
+  }
+}
 
 export default SidecarConfigurationPage;

--- a/graylog2-web-interface/src/pages/SidecarEditCollectorPage.jsx
+++ b/graylog2-web-interface/src/pages/SidecarEditCollectorPage.jsx
@@ -1,5 +1,6 @@
 import PropTypes from 'prop-types';
 import React from 'react';
+import createReactClass from 'create-react-class';
 import { Button, ButtonToolbar, Col, Row } from 'react-bootstrap';
 import { LinkContainer } from 'react-router-bootstrap';
 
@@ -11,7 +12,9 @@ import CollectorForm from 'components/sidecars/configuration-forms/CollectorForm
 
 const { CollectorsActions } = CombinedProvider.get('Collectors');
 
-const SidecarEditCollectorPage = React.createClass({
+const SidecarEditCollectorPage = createReactClass({
+  displayName: 'SidecarEditCollectorPage',
+
   propTypes: {
     params: PropTypes.object.isRequired,
   },

--- a/graylog2-web-interface/src/pages/SidecarEditConfigurationPage.jsx
+++ b/graylog2-web-interface/src/pages/SidecarEditConfigurationPage.jsx
@@ -1,5 +1,6 @@
 import PropTypes from 'prop-types';
 import React from 'react';
+import createReactClass from 'create-react-class';
 import { Button, ButtonToolbar, Col, Row } from 'react-bootstrap';
 import { LinkContainer } from 'react-router-bootstrap';
 
@@ -12,7 +13,9 @@ import ConfigurationHelper from 'components/sidecars/configuration-forms/Configu
 
 const { CollectorConfigurationsActions } = CombinedProvider.get('CollectorConfigurations');
 
-const SidecarEditConfigurationPage = React.createClass({
+const SidecarEditConfigurationPage = createReactClass({
+  displayName: 'SidecarEditConfigurationPage',
+
   propTypes: {
     params: PropTypes.object.isRequired,
   },

--- a/graylog2-web-interface/src/pages/SidecarNewCollectorPage.jsx
+++ b/graylog2-web-interface/src/pages/SidecarNewCollectorPage.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import createReactClass from 'create-react-class';
 import { Button, ButtonToolbar, Col, Row } from 'react-bootstrap';
 import { LinkContainer } from 'react-router-bootstrap';
 
@@ -7,7 +8,9 @@ import Routes from 'routing/Routes';
 
 import CollectorForm from 'components/sidecars/configuration-forms/CollectorForm';
 
-const SidecarNewCollectorPage = React.createClass({
+const SidecarNewCollectorPage = createReactClass({
+  displayName: 'SidecarNewCollectorPage',
+
   componentDidMount() {
     this.style.use();
   },

--- a/graylog2-web-interface/src/pages/SidecarNewConfigurationPage.jsx
+++ b/graylog2-web-interface/src/pages/SidecarNewConfigurationPage.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import createReactClass from 'create-react-class';
 import { Button, ButtonToolbar, Col, Row } from 'react-bootstrap';
 import { LinkContainer } from 'react-router-bootstrap';
 
@@ -8,7 +9,9 @@ import Routes from 'routing/Routes';
 import ConfigurationForm from 'components/sidecars/configuration-forms/ConfigurationForm';
 import ConfigurationHelper from 'components/sidecars/configuration-forms/ConfigurationHelper';
 
-const SidecarNewConfigurationPage = React.createClass({
+const SidecarNewConfigurationPage = createReactClass({
+  displayName: 'SidecarNewConfigurationPage',
+
   componentDidMount() {
     this.style.use();
   },

--- a/graylog2-web-interface/src/pages/SidecarStatusPage.jsx
+++ b/graylog2-web-interface/src/pages/SidecarStatusPage.jsx
@@ -14,31 +14,29 @@ import SidecarStatus from 'components/sidecars/sidecars/SidecarStatus';
 
 const { SidecarsActions } = CombinedProvider.get('Sidecars');
 
-const SidecarStatusPage = React.createClass({
-  propTypes: {
+class SidecarStatusPage extends React.Component {
+  static propTypes = {
     params: PropTypes.object.isRequired,
-  },
+  };
 
-  getInitialState() {
-    return {
-      sidecar: undefined,
-    };
-  },
+  state = {
+    sidecar: undefined,
+  };
 
   componentDidMount() {
     this.reloadSidecar();
     this.interval = setInterval(this.reloadSidecar, 5000);
-  },
+  }
 
   componentWillUnmount() {
     if (this.interval) {
       clearInterval(this.interval);
     }
-  },
+  }
 
-  reloadSidecar() {
+  reloadSidecar = () => {
     SidecarsActions.getSidecar(this.props.params.sidecarId).then(sidecar => this.setState({ sidecar }));
-  },
+  };
 
   render() {
     const sidecar = this.state.sidecar;
@@ -78,7 +76,7 @@ const SidecarStatusPage = React.createClass({
         </span>
       </DocumentTitle>
     );
-  },
-});
+  }
+}
 
 export default SidecarStatusPage;

--- a/graylog2-web-interface/src/pages/SidecarsPage.jsx
+++ b/graylog2-web-interface/src/pages/SidecarsPage.jsx
@@ -11,7 +11,7 @@ import SidecarListContainer from 'components/sidecars/sidecars/SidecarListContai
 
 import Routes from 'routing/Routes';
 
-const SidecarsPage = React.createClass({
+class SidecarsPage extends React.Component {
   render() {
     return (
       <DocumentTitle title="Sidecars">
@@ -47,7 +47,7 @@ const SidecarsPage = React.createClass({
         </span>
       </DocumentTitle>
     );
-  },
-});
+  }
+}
 
 export default SidecarsPage;

--- a/graylog2-web-interface/src/pages/SidecarsPage.jsx
+++ b/graylog2-web-interface/src/pages/SidecarsPage.jsx
@@ -24,7 +24,7 @@ class SidecarsPage extends React.Component {
             <span>
               Do you need an API token for a sidecar?&ensp;
               <Link to={Routes.SYSTEM.AUTHENTICATION.USERS.TOKENS.edit('graylog-sidecar')}>
-                <a>Create or reuse a token for the <em>graylog-sidecar</em> user</a>
+                Create or reuse a token for the <em>graylog-sidecar</em> user
               </Link>.
             </span>
 

--- a/graylog2-web-interface/src/pages/SidecarsPage.jsx
+++ b/graylog2-web-interface/src/pages/SidecarsPage.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
-
 import { Button, ButtonToolbar, Col, Row } from 'react-bootstrap';
 import { LinkContainer } from 'react-router-bootstrap';
+import { Link } from 'react-router';
 
 import DocsHelper from 'util/DocsHelper';
 
@@ -22,8 +22,10 @@ class SidecarsPage extends React.Component {
             </span>
 
             <span>
-              Read more about sidecars and how to set them up in the
-              {' '}<DocumentationLink page={DocsHelper.PAGES.COLLECTOR_SIDECAR} text="Graylog documentation" />.
+              Do you need an API token for a sidecar?&ensp;
+              <Link to={Routes.SYSTEM.AUTHENTICATION.USERS.TOKENS.edit('graylog-sidecar')}>
+                <a>Create or reuse a token for the <em>graylog-sidecar</em> user</a>
+              </Link>.
             </span>
 
             <ButtonToolbar>

--- a/graylog2-web-interface/src/pages/SidecarsPage.jsx
+++ b/graylog2-web-interface/src/pages/SidecarsPage.jsx
@@ -3,10 +3,7 @@ import { Button, ButtonToolbar, Col, Row } from 'react-bootstrap';
 import { LinkContainer } from 'react-router-bootstrap';
 import { Link } from 'react-router';
 
-import DocsHelper from 'util/DocsHelper';
-
 import { DocumentTitle, PageHeader } from 'components/common';
-import DocumentationLink from 'components/support/DocumentationLink';
 import SidecarListContainer from 'components/sidecars/sidecars/SidecarListContainer';
 
 import Routes from 'routing/Routes';

--- a/graylog2-web-interface/src/stores/sidecars/CollectorConfigurationsStore.js
+++ b/graylog2-web-interface/src/stores/sidecars/CollectorConfigurationsStore.js
@@ -10,7 +10,7 @@ const { CollectorConfigurationsActions } = CombinedProvider.get('CollectorConfig
 
 const CollectorConfigurationsStore = Reflux.createStore({
   listenables: [CollectorConfigurationsActions],
-  sourceUrl: '/plugins/org.graylog.plugins.sidecar/sidecar',
+  sourceUrl: '/sidecar',
   configurations: undefined,
   pagination: {
     page: undefined,

--- a/graylog2-web-interface/src/stores/sidecars/CollectorConfigurationsStore.js
+++ b/graylog2-web-interface/src/stores/sidecars/CollectorConfigurationsStore.js
@@ -17,6 +17,7 @@ const CollectorConfigurationsStore = Reflux.createStore({
     pageSize: undefined,
     total: undefined,
   },
+  total: undefined,
   paginatedConfigurations: undefined,
   query: undefined,
 
@@ -24,6 +25,7 @@ const CollectorConfigurationsStore = Reflux.createStore({
     this.trigger({
       configurations: this.configurations,
       query: this.query,
+      total: this.total,
       pagination: this.pagination,
       paginatedConfigurations: this.paginatedConfigurations,
     });
@@ -65,10 +67,11 @@ const CollectorConfigurationsStore = Reflux.createStore({
         (response) => {
           this.query = response.query;
           this.pagination = {
-            page: response.page,
-            pageSize: response.per_page,
-            total: response.total,
+            page: response.pagination.page,
+            pageSize: response.pagination.per_page,
+            total: response.pagination.total,
           };
+          this.total = response.total;
           this.paginatedConfigurations = response.configurations;
           this.propagateChanges();
 

--- a/graylog2-web-interface/src/stores/sidecars/CollectorsStore.js
+++ b/graylog2-web-interface/src/stores/sidecars/CollectorsStore.js
@@ -10,7 +10,7 @@ const { CollectorsActions } = CombinedProvider.get('Collectors');
 
 const CollectorsStore = Reflux.createStore({
   listenables: [CollectorsActions],
-  sourceUrl: '/plugins/org.graylog.plugins.sidecar/sidecar',
+  sourceUrl: '/sidecar',
   collectors: undefined,
   query: undefined,
   pagination: {

--- a/graylog2-web-interface/src/stores/sidecars/CollectorsStore.js
+++ b/graylog2-web-interface/src/stores/sidecars/CollectorsStore.js
@@ -18,6 +18,7 @@ const CollectorsStore = Reflux.createStore({
     pageSize: undefined,
     total: undefined,
   },
+  total: undefined,
   paginatedCollectors: undefined,
 
   getInitialState() {
@@ -31,6 +32,7 @@ const CollectorsStore = Reflux.createStore({
       collectors: this.collectors,
       paginatedCollectors: this.paginatedCollectors,
       query: this.query,
+      total: this.total,
       pagination: this.pagination,
     });
   },
@@ -80,10 +82,11 @@ const CollectorsStore = Reflux.createStore({
         (response) => {
           this.query = response.query;
           this.pagination = {
-            page: response.page,
-            pageSize: response.per_page,
-            total: response.total,
+            page: response.pagination.page,
+            pageSize: response.pagination.per_page,
+            total: response.pagination.total,
           };
+          this.total = response.total;
           this.paginatedCollectors = response.collectors;
 
           this.propagateChanges();

--- a/graylog2-web-interface/src/stores/sidecars/SidecarsAdministrationStore.js
+++ b/graylog2-web-interface/src/stores/sidecars/SidecarsAdministrationStore.js
@@ -45,10 +45,10 @@ const SidecarsAdministrationStore = Reflux.createStore({
         this.query = response.query;
         this.filters = response.filters;
         this.pagination = {
-          total: response.total,
-          count: response.count,
-          page: response.page,
-          pageSize: response.per_page,
+          total: response.pagination.total,
+          count: response.pagination.count,
+          page: response.pagination.page,
+          pageSize: response.pagination.per_page,
         };
         this.propagateChanges();
 

--- a/graylog2-web-interface/src/stores/sidecars/SidecarsAdministrationStore.js
+++ b/graylog2-web-interface/src/stores/sidecars/SidecarsAdministrationStore.js
@@ -9,7 +9,7 @@ const { SidecarsAdministrationActions } = CombinedProvider.get('SidecarsAdminist
 
 const SidecarsAdministrationStore = Reflux.createStore({
   listenables: [SidecarsAdministrationActions],
-  sourceUrl: '/plugins/org.graylog.plugins.sidecar/sidecar',
+  sourceUrl: '/sidecar',
   sidecars: undefined,
   filters: undefined,
   pagination: {

--- a/graylog2-web-interface/src/stores/sidecars/SidecarsStore.js
+++ b/graylog2-web-interface/src/stores/sidecars/SidecarsStore.js
@@ -57,10 +57,10 @@ const SidecarsStore = Reflux.createStore({
         this.query = response.query;
         this.onlyActive = response.only_active;
         this.pagination = {
-          total: response.total,
-          count: response.count,
-          page: response.page,
-          pageSize: response.per_page,
+          total: response.pagination.total,
+          count: response.pagination.count,
+          page: response.pagination.page,
+          pageSize: response.pagination.per_page,
         };
         this.sort = {
           field: response.sort,

--- a/graylog2-web-interface/src/stores/sidecars/SidecarsStore.js
+++ b/graylog2-web-interface/src/stores/sidecars/SidecarsStore.js
@@ -9,7 +9,7 @@ const { SidecarsActions } = CombinedProvider.get('Sidecars');
 
 const SidecarsStore = Reflux.createStore({
   listenables: [SidecarsActions],
-  sourceUrl: '/plugins/org.graylog.plugins.sidecar/sidecars',
+  sourceUrl: '/sidecars',
   sidecars: undefined,
   onlyActive: undefined,
   pagination: {


### PR DESCRIPTION
This PR takes care of fixing some issues and tasks found during the review of #4818. The list of changes includes:

- Remove plugin URL prefixes
- Remove usages of `React.createClass`
- Improve descriptions and documentation
- Preserve filters after selecting collectors in administration page
- Ensure UI works when sidecar is configured with the `send_status: false` option
- Display filter summary and allow to reset all filters in an easier way
- Add link to token management page for the _graylog\_sidecar_ user
- Display grand totals in configuration page

Fixes #4828