### PR TITLE
Make "keyword" field type enumerable instead of full-text searchable

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/indexer/fieldtypes/FieldTypeMapper.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/fieldtypes/FieldTypeMapper.java
@@ -55,8 +55,6 @@ public class FieldTypeMapper {
     private static final ImmutableMap<String, FieldTypes.Type> TYPE_MAP = ImmutableMap.<String, FieldTypes.Type>builder()
             .put("keyword", STRING_TYPE) // since ES 5.x
             .put("text", STRING_FTS_TYPE) // since ES 5.x
-            // TODO: Depending on the value of the "index" field, a "string" can be similar to "keyword" or "text".
-            .put("string", STRING_FTS_TYPE) // until ES 2.x
             .put("long", LONG_TYPE)
             .put("integer", INT_TYPE)
             .put("short", SHORT_TYPE)

--- a/graylog2-server/src/main/java/org/graylog2/indexer/fieldtypes/FieldTypeMapper.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/fieldtypes/FieldTypeMapper.java
@@ -35,7 +35,8 @@ public class FieldTypeMapper {
     private static final String PROP_FULL_TEXT_SEARCH = "full-text-search";
     private static final String PROP_NUMERIC = "numeric";
 
-    private static final FieldTypes.Type STRING_TYPE = createType("string", of(PROP_FULL_TEXT_SEARCH));
+    private static final FieldTypes.Type STRING_TYPE = createType("string", of(PROP_ENUMERABLE));
+    private static final FieldTypes.Type STRING_FTS_TYPE = createType("string", of(PROP_FULL_TEXT_SEARCH));
     private static final FieldTypes.Type LONG_TYPE = createType("long", of(PROP_NUMERIC, PROP_ENUMERABLE));
     private static final FieldTypes.Type INT_TYPE = createType("int", of(PROP_NUMERIC, PROP_ENUMERABLE));
     private static final FieldTypes.Type SHORT_TYPE = createType("short", of(PROP_NUMERIC, PROP_ENUMERABLE));
@@ -53,8 +54,9 @@ public class FieldTypeMapper {
      */
     private static final ImmutableMap<String, FieldTypes.Type> TYPE_MAP = ImmutableMap.<String, FieldTypes.Type>builder()
             .put("keyword", STRING_TYPE) // since ES 5.x
-            .put("text", STRING_TYPE) // since ES 5.x
-            .put("string", STRING_TYPE) // until ES 2.x
+            .put("text", STRING_FTS_TYPE) // since ES 5.x
+            // TODO: Depending on the value of the "index" field, a "string" can be similar to "keyword" or "text".
+            .put("string", STRING_FTS_TYPE) // until ES 2.x
             .put("long", LONG_TYPE)
             .put("integer", INT_TYPE)
             .put("short", SHORT_TYPE)

--- a/graylog2-server/src/test/java/org/graylog2/indexer/fieldtypes/FieldTypeMapperTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/indexer/fieldtypes/FieldTypeMapperTest.java
@@ -41,7 +41,6 @@ public class FieldTypeMapperTest {
     public void mappings() {
         assertMapping("text", "string", "full-text-search");
         assertMapping("keyword", "string", "enumerable");
-        assertMapping("string", "string", "full-text-search");
 
         assertMapping("long", "long", "numeric", "enumerable");
         assertMapping("integer", "int", "numeric", "enumerable");

--- a/graylog2-server/src/test/java/org/graylog2/indexer/fieldtypes/FieldTypeMapperTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/indexer/fieldtypes/FieldTypeMapperTest.java
@@ -40,7 +40,7 @@ public class FieldTypeMapperTest {
     @Test
     public void mappings() {
         assertMapping("text", "string", "full-text-search");
-        assertMapping("keyword", "string", "full-text-search");
+        assertMapping("keyword", "string", "enumerable");
         assertMapping("string", "string", "full-text-search");
 
         assertMapping("long", "long", "numeric", "enumerable");


### PR DESCRIPTION
Also add a TODO comment to revisit the ES 2.x "string" data type.

Fixes #4841
