### PR TITLE
Unbreak input throttling by publishing throttle state again

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/shared/events/DeadEventLoggingListener.java
+++ b/graylog2-server/src/main/java/org/graylog2/shared/events/DeadEventLoggingListener.java
@@ -26,7 +26,7 @@ public class DeadEventLoggingListener {
 
     @Subscribe
     public void handleDeadEvent(DeadEvent event) {
-        LOGGER.warn("Received unhandled event of type <{}> from event bus <{}>", event.getEvent().getClass().getCanonicalName(),
+        LOGGER.debug("Received unhandled event of type <{}> from event bus <{}>", event.getEvent().getClass().getCanonicalName(),
                 event.getSource().toString());
         LOGGER.debug("Dead event contents: {}", event.getEvent());
     }


### PR DESCRIPTION
This broke in PR #1948 where I refactored the cluster event handling and removed the throttle state publishing by accident.

Fixes #4321
Refs #1948

(cherry picked from commit 060bd1552445737e773b10111a847193bf2f526e)