### PR TITLE
Add content packs support for collectors and collector configurations

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/contentpacks/ContentPacksModule.java
+++ b/graylog2-server/src/main/java/org/graylog2/contentpacks/ContentPacksModule.java
@@ -18,6 +18,7 @@ package org.graylog2.contentpacks;
 
 import org.graylog2.contentpacks.catalogs.CatalogIndex;
 import org.graylog2.contentpacks.constraints.GraylogVersionConstraintChecker;
+import org.graylog2.contentpacks.facades.CollectorFacade;
 import org.graylog2.contentpacks.facades.DashboardFacade;
 import org.graylog2.contentpacks.facades.GrokPatternFacade;
 import org.graylog2.contentpacks.facades.InputFacade;
@@ -43,6 +44,7 @@ public class ContentPacksModule extends PluginModule {
         jerseyAdditionalComponentsBinder().addBinding().toInstance(ModelIdParamConverter.Provider.class);
 
         addEntityFacade(CollectorConfigurationFacade.TYPE, CollectorConfigurationFacade.class);
+        addEntityFacade(CollectorFacade.TYPE, CollectorFacade.class);
         addEntityFacade(DashboardFacade.TYPE, DashboardFacade.class);
         addEntityFacade(GrokPatternFacade.TYPE, GrokPatternFacade.class);
         addEntityFacade(InputFacade.TYPE, InputFacade.class);

--- a/graylog2-server/src/main/java/org/graylog2/contentpacks/ContentPacksModule.java
+++ b/graylog2-server/src/main/java/org/graylog2/contentpacks/ContentPacksModule.java
@@ -27,6 +27,7 @@ import org.graylog2.contentpacks.facades.LookupTableFacade;
 import org.graylog2.contentpacks.facades.OutputFacade;
 import org.graylog2.contentpacks.facades.PipelineFacade;
 import org.graylog2.contentpacks.facades.PipelineRuleFacade;
+import org.graylog2.contentpacks.facades.CollectorConfigurationFacade;
 import org.graylog2.contentpacks.facades.StreamFacade;
 import org.graylog2.contentpacks.jersey.ModelIdParamConverter;
 import org.graylog2.plugin.PluginModule;
@@ -41,6 +42,7 @@ public class ContentPacksModule extends PluginModule {
 
         jerseyAdditionalComponentsBinder().addBinding().toInstance(ModelIdParamConverter.Provider.class);
 
+        addEntityFacade(CollectorConfigurationFacade.TYPE, CollectorConfigurationFacade.class);
         addEntityFacade(DashboardFacade.TYPE, DashboardFacade.class);
         addEntityFacade(GrokPatternFacade.TYPE, GrokPatternFacade.class);
         addEntityFacade(InputFacade.TYPE, InputFacade.class);

--- a/graylog2-server/src/main/java/org/graylog2/contentpacks/facades/CollectorConfigurationFacade.java
+++ b/graylog2-server/src/main/java/org/graylog2/contentpacks/facades/CollectorConfigurationFacade.java
@@ -1,3 +1,19 @@
+/**
+ * This file is part of Graylog.
+ *
+ * Graylog is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package org.graylog2.contentpacks.facades;
 
 import com.fasterxml.jackson.databind.JsonNode;

--- a/graylog2-server/src/main/java/org/graylog2/contentpacks/facades/CollectorConfigurationFacade.java
+++ b/graylog2-server/src/main/java/org/graylog2/contentpacks/facades/CollectorConfigurationFacade.java
@@ -1,0 +1,107 @@
+package org.graylog2.contentpacks.facades;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.graylog.plugins.sidecar.rest.models.Configuration;
+import org.graylog.plugins.sidecar.services.ConfigurationService;
+import org.graylog2.contentpacks.model.ModelId;
+import org.graylog2.contentpacks.model.ModelType;
+import org.graylog2.contentpacks.model.ModelTypes;
+import org.graylog2.contentpacks.model.entities.CollectorConfigurationEntity;
+import org.graylog2.contentpacks.model.entities.Entity;
+import org.graylog2.contentpacks.model.entities.EntityDescriptor;
+import org.graylog2.contentpacks.model.entities.EntityExcerpt;
+import org.graylog2.contentpacks.model.entities.EntityV1;
+import org.graylog2.contentpacks.model.entities.EntityWithConstraints;
+import org.graylog2.contentpacks.model.entities.references.ValueReference;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.inject.Inject;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import static java.util.Objects.isNull;
+
+public class CollectorConfigurationFacade implements EntityFacade<Configuration> {
+    private static final Logger LOG = LoggerFactory.getLogger(CollectorConfigurationFacade.class);
+
+    public static final ModelType TYPE = ModelTypes.COLLECTOR_CONFIGURATION;
+
+    private final ObjectMapper objectMapper;
+    private final ConfigurationService configurationService;
+
+    @Inject
+    public CollectorConfigurationFacade(ObjectMapper objectMapper, ConfigurationService configurationService) {
+        this.objectMapper = objectMapper;
+        this.configurationService = configurationService;
+    }
+
+    @Override
+    public EntityWithConstraints encode(Configuration configuration) {
+        final CollectorConfigurationEntity configurationEntity = CollectorConfigurationEntity.create(
+                //TODO: Check how to collectorId can be used here
+                ValueReference.of(configuration.collectorId()),
+                ValueReference.of(configuration.name()),
+                ValueReference.of(configuration.color()),
+                ValueReference.of(configuration.template()));
+        final JsonNode data = objectMapper.convertValue(configurationEntity, JsonNode.class);
+        final EntityV1 entity = EntityV1.builder()
+                .id(ModelId.of(configuration.id()))
+                .type(TYPE)
+                .data(data)
+                .build();
+        return EntityWithConstraints.create(entity);
+    }
+
+    @Override
+    public Configuration decode(Entity entity, Map<String, ValueReference> parameters, String username) {
+        if (entity instanceof EntityV1) {
+            return decodeEntityV1((EntityV1) entity, parameters);
+        } else {
+            throw new IllegalArgumentException("Unsupported entity version: " + entity.getClass());
+        }
+    }
+
+    private Configuration decodeEntityV1(EntityV1 entity, Map<String, ValueReference> parameters) {
+        final CollectorConfigurationEntity configurationEntity = objectMapper.convertValue(entity.data(), CollectorConfigurationEntity.class);
+        final Configuration configuration = Configuration.create(
+                //TODO: Check how to use the collectorId here
+                configurationEntity.collectorId().asString(parameters),
+                configurationEntity.title().asString(parameters),
+                configurationEntity.color().asString(parameters),
+                configurationEntity.template().asString(parameters));
+
+        return configurationService.save(configuration);
+    }
+
+    @Override
+    public EntityExcerpt createExcerpt(Configuration configuration) {
+        return EntityExcerpt.builder()
+                .id(ModelId.of(configuration.id()))
+                .type(TYPE)
+                .title(configuration.name())
+                .build();
+    }
+
+    @Override
+    public Set<EntityExcerpt> listEntityExcerpts() {
+        return configurationService.all().stream()
+                .map(this::createExcerpt)
+                .collect(Collectors.toSet());
+    }
+
+    @Override
+    public Optional<EntityWithConstraints> collectEntity(EntityDescriptor entityDescriptor) {
+        final ModelId modelId = entityDescriptor.id();
+        final Configuration configuration = configurationService.find(modelId.id());
+        if (isNull(configuration)) {
+            LOG.debug("Couldn't find collector configuration {}", entityDescriptor);
+            return Optional.empty();
+        }
+
+        return Optional.of(encode(configuration));
+    }
+}

--- a/graylog2-server/src/main/java/org/graylog2/contentpacks/facades/CollectorConfigurationFacade.java
+++ b/graylog2-server/src/main/java/org/graylog2/contentpacks/facades/CollectorConfigurationFacade.java
@@ -62,7 +62,6 @@ public class CollectorConfigurationFacade implements EntityFacade<Configuration>
     @Override
     public EntityWithConstraints encode(Configuration configuration) {
         final CollectorConfigurationEntity configurationEntity = CollectorConfigurationEntity.create(
-                //TODO: Check how to collectorId can be used here
                 ValueReference.of(configuration.collectorId()),
                 ValueReference.of(configuration.name()),
                 ValueReference.of(configuration.color()),
@@ -88,7 +87,6 @@ public class CollectorConfigurationFacade implements EntityFacade<Configuration>
     private Configuration decodeEntityV1(EntityV1 entity, Map<String, ValueReference> parameters) {
         final CollectorConfigurationEntity configurationEntity = objectMapper.convertValue(entity.data(), CollectorConfigurationEntity.class);
         final Configuration configuration = Configuration.create(
-                //TODO: Check how to use the collectorId here
                 configurationEntity.collectorId().asString(parameters),
                 configurationEntity.title().asString(parameters),
                 configurationEntity.color().asString(parameters),

--- a/graylog2-server/src/main/java/org/graylog2/contentpacks/facades/CollectorFacade.java
+++ b/graylog2-server/src/main/java/org/graylog2/contentpacks/facades/CollectorFacade.java
@@ -1,3 +1,19 @@
+/**
+ * This file is part of Graylog.
+ *
+ * Graylog is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package org.graylog2.contentpacks.facades;
 
 import com.fasterxml.jackson.databind.JsonNode;

--- a/graylog2-server/src/main/java/org/graylog2/contentpacks/facades/CollectorFacade.java
+++ b/graylog2-server/src/main/java/org/graylog2/contentpacks/facades/CollectorFacade.java
@@ -1,0 +1,132 @@
+package org.graylog2.contentpacks.facades;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.graylog.plugins.sidecar.rest.models.Collector;
+import org.graylog.plugins.sidecar.services.CollectorService;
+import org.graylog2.contentpacks.model.ModelId;
+import org.graylog2.contentpacks.model.ModelType;
+import org.graylog2.contentpacks.model.ModelTypes;
+import org.graylog2.contentpacks.model.entities.CollectorEntity;
+import org.graylog2.contentpacks.model.entities.Entity;
+import org.graylog2.contentpacks.model.entities.EntityDescriptor;
+import org.graylog2.contentpacks.model.entities.EntityExcerpt;
+import org.graylog2.contentpacks.model.entities.EntityV1;
+import org.graylog2.contentpacks.model.entities.EntityWithConstraints;
+import org.graylog2.contentpacks.model.entities.references.ValueReference;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.inject.Inject;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import static java.util.Objects.isNull;
+
+public class CollectorFacade implements EntityFacade<Collector> {
+    private static final Logger LOG = LoggerFactory.getLogger(CollectorFacade.class);
+
+    public static final ModelType TYPE = ModelTypes.COLLECTOR;
+
+    private final ObjectMapper objectMapper;
+    private final CollectorService collectorService;
+
+    @Inject
+    public CollectorFacade(ObjectMapper objectMapper, CollectorService collectorService) {
+        this.objectMapper = objectMapper;
+        this.collectorService = collectorService;
+    }
+
+    @Override
+    public EntityWithConstraints encode(Collector collector) {
+        final List<ValueReference> executeParameters = collector.executeParameters().stream()
+                .map(ValueReference::of)
+                .collect(Collectors.toList());
+        final List<ValueReference> validationCommand = collector.validationCommand().stream()
+                .map(ValueReference::of)
+                .collect(Collectors.toList());
+
+        final CollectorEntity collectorEntity = CollectorEntity.create(
+                ValueReference.of(collector.name()),
+                ValueReference.of(collector.serviceType()),
+                ValueReference.of(collector.nodeOperatingSystem()),
+                ValueReference.of(collector.executablePath()),
+                ValueReference.of(collector.configurationPath()),
+                executeParameters,
+                validationCommand,
+                ValueReference.of(collector.defaultTemplate())
+        );
+
+        final JsonNode data = objectMapper.convertValue(collectorEntity, JsonNode.class);
+        final EntityV1 entity = EntityV1.builder()
+                .id(ModelId.of(collector.id()))
+                .type(TYPE)
+                .data(data)
+                .build();
+        return EntityWithConstraints.create(entity);
+    }
+
+    @Override
+    public Collector decode(Entity entity, Map<String, ValueReference> parameters, String username) {
+        if (entity instanceof EntityV1) {
+            return decodeEntityV1((EntityV1) entity, parameters);
+        } else {
+            throw new IllegalArgumentException("Unsupported entity version: " + entity.getClass());
+        }
+    }
+
+    private Collector decodeEntityV1(EntityV1 entity, Map<String, ValueReference> parameters) {
+        final CollectorEntity collectorEntity = objectMapper.convertValue(entity.data(), CollectorEntity.class);
+
+        final List<String> executeParameters = collectorEntity.executeParameters().stream()
+                .map(parameter -> parameter.asString(parameters))
+                .collect(Collectors.toList());
+        final List<String> validationCommand = collectorEntity.validationCommand().stream()
+                .map(parameter -> parameter.asString(parameters))
+                .collect(Collectors.toList());
+
+        final Collector collector = Collector.builder()
+                .name(collectorEntity.title().asString(parameters))
+                .serviceType(collectorEntity.serviceType().asString(parameters))
+                .nodeOperatingSystem(collectorEntity.nodeOperatingSystem().asString(parameters))
+                .executablePath(collectorEntity.executablePath().asString(parameters))
+                .configurationPath(collectorEntity.configurationPath().asString(parameters))
+                .executeParameters(executeParameters)
+                .validationCommand(validationCommand)
+                .defaultTemplate(collectorEntity.defaultTemplate().asString(parameters))
+                .build();
+
+        return collectorService.save(collector);
+    }
+
+    @Override
+    public EntityExcerpt createExcerpt(Collector collector) {
+        return EntityExcerpt.builder()
+                .id(ModelId.of(collector.id()))
+                .type(TYPE)
+                .title(collector.name())
+                .build();
+    }
+
+    @Override
+    public Set<EntityExcerpt> listEntityExcerpts() {
+        return collectorService.all().stream()
+                .map(this::createExcerpt)
+                .collect(Collectors.toSet());
+    }
+
+    @Override
+    public Optional<EntityWithConstraints> collectEntity(EntityDescriptor entityDescriptor) {
+        final ModelId modelId = entityDescriptor.id();
+        final Collector collector = collectorService.find(modelId.id());
+        if (isNull(collector)) {
+            LOG.debug("Couldn't find collector {}", entityDescriptor);
+            return Optional.empty();
+        }
+
+        return Optional.of(encode(collector));
+    }
+}

--- a/graylog2-server/src/main/java/org/graylog2/contentpacks/model/ModelTypes.java
+++ b/graylog2-server/src/main/java/org/graylog2/contentpacks/model/ModelTypes.java
@@ -18,6 +18,7 @@ package org.graylog2.contentpacks.model;
 
 public interface ModelTypes {
     ModelType COLLECTOR_CONFIGURATION = ModelType.of("collector_configuration");
+    ModelType COLLECTOR = ModelType.of("collector");
     ModelType DASHBOARD = ModelType.of("dashboard");
     ModelType GROK_PATTERN = ModelType.of("grok_pattern");
     ModelType LOOKUP_ADAPTER = ModelType.of("lookup_adapter");

--- a/graylog2-server/src/main/java/org/graylog2/contentpacks/model/ModelTypes.java
+++ b/graylog2-server/src/main/java/org/graylog2/contentpacks/model/ModelTypes.java
@@ -17,6 +17,7 @@
 package org.graylog2.contentpacks.model;
 
 public interface ModelTypes {
+    ModelType COLLECTOR_CONFIGURATION = ModelType.of("collector_configuration");
     ModelType DASHBOARD = ModelType.of("dashboard");
     ModelType GROK_PATTERN = ModelType.of("grok_pattern");
     ModelType LOOKUP_ADAPTER = ModelType.of("lookup_adapter");

--- a/graylog2-server/src/main/java/org/graylog2/contentpacks/model/entities/CollectorConfigurationEntity.java
+++ b/graylog2-server/src/main/java/org/graylog2/contentpacks/model/entities/CollectorConfigurationEntity.java
@@ -1,3 +1,19 @@
+/**
+ * This file is part of Graylog.
+ *
+ * Graylog is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package org.graylog2.contentpacks.model.entities;
 
 import com.fasterxml.jackson.annotation.JsonAutoDetect;

--- a/graylog2-server/src/main/java/org/graylog2/contentpacks/model/entities/CollectorConfigurationEntity.java
+++ b/graylog2-server/src/main/java/org/graylog2/contentpacks/model/entities/CollectorConfigurationEntity.java
@@ -1,0 +1,33 @@
+package org.graylog2.contentpacks.model.entities;
+
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.auto.value.AutoValue;
+import org.graylog.autovalue.WithBeanGetter;
+import org.graylog2.contentpacks.model.entities.references.ValueReference;
+
+@JsonAutoDetect
+@AutoValue
+@WithBeanGetter
+public abstract class CollectorConfigurationEntity {
+    @JsonProperty("collector_id")
+    public abstract ValueReference collectorId();
+
+    @JsonProperty("title")
+    public abstract ValueReference title();
+
+    @JsonProperty("color")
+    public abstract ValueReference color();
+
+    @JsonProperty("template")
+    public abstract ValueReference template();
+
+    @JsonCreator
+    public static CollectorConfigurationEntity create(@JsonProperty("collector_id") ValueReference collectorId,
+                                                      @JsonProperty("title") ValueReference title,
+                                                      @JsonProperty("color") ValueReference color,
+                                                      @JsonProperty("template") ValueReference template) {
+        return new AutoValue_CollectorConfigurationEntity(collectorId, title, color, template);
+    }
+}

--- a/graylog2-server/src/main/java/org/graylog2/contentpacks/model/entities/CollectorEntity.java
+++ b/graylog2-server/src/main/java/org/graylog2/contentpacks/model/entities/CollectorEntity.java
@@ -1,3 +1,19 @@
+/**
+ * This file is part of Graylog.
+ *
+ * Graylog is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package org.graylog2.contentpacks.model.entities;
 
 import com.fasterxml.jackson.annotation.JsonAutoDetect;

--- a/graylog2-server/src/main/java/org/graylog2/contentpacks/model/entities/CollectorEntity.java
+++ b/graylog2-server/src/main/java/org/graylog2/contentpacks/model/entities/CollectorEntity.java
@@ -1,0 +1,58 @@
+package org.graylog2.contentpacks.model.entities;
+
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.auto.value.AutoValue;
+import org.graylog.autovalue.WithBeanGetter;
+import org.graylog2.contentpacks.model.entities.references.ValueReference;
+
+import java.util.List;
+
+@JsonAutoDetect
+@AutoValue
+@WithBeanGetter
+public abstract class CollectorEntity {
+    @JsonProperty("title")
+    public abstract ValueReference title();
+
+    @JsonProperty("service_type")
+    public abstract ValueReference serviceType();
+
+    @JsonProperty("node_operating_system")
+    public abstract ValueReference nodeOperatingSystem();
+
+    @JsonProperty("executable_path")
+    public abstract ValueReference executablePath();
+
+    @JsonProperty("configuration_path")
+    public abstract ValueReference configurationPath();
+
+    @JsonProperty("execute_parameters")
+    public abstract List<ValueReference> executeParameters();
+
+    @JsonProperty("validation_command")
+    public abstract List<ValueReference> validationCommand();
+
+    @JsonProperty("default_template")
+    public abstract ValueReference defaultTemplate();
+
+    @JsonCreator
+    public static CollectorEntity create(@JsonProperty("title") ValueReference title,
+                                         @JsonProperty("service_type") ValueReference serviceType,
+                                         @JsonProperty("node_operating_system") ValueReference nodeOperatingSystem,
+                                         @JsonProperty("executable_path") ValueReference executablePath,
+                                         @JsonProperty("configuration_path") ValueReference configurationPath,
+                                         @JsonProperty("execute_parameters") List<ValueReference> executeParameters,
+                                         @JsonProperty("validation_command") List<ValueReference> validationCommand,
+                                         @JsonProperty("default_template") ValueReference defaultTemplate) {
+        return new AutoValue_CollectorEntity(title,
+                serviceType,
+                nodeOperatingSystem,
+                executablePath,
+                configurationPath,
+                executeParameters,
+                validationCommand,
+                defaultTemplate);
+    }
+}


### PR DESCRIPTION
This PR adds the code needed to support exporting/importing collectors and collector configurations through content packs.

I'm unsure if the current code will properly handle the ID reference that configurations have on a collector when installing the content pack, so please review that carefully and let me know if there are any other changes to make there.

These two entities are the only that I think make sense to export/import from content packs, so I think this would wrap up the content packs support for sidecars at this point.