### PR TITLE
Requires user to be authenticated to retrieve plugin list.

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/shared/rest/resources/system/SystemPluginResource.java
+++ b/graylog2-server/src/main/java/org/graylog2/shared/rest/resources/system/SystemPluginResource.java
@@ -20,6 +20,7 @@ import com.codahale.metrics.annotation.Timed;
 import com.google.common.collect.Lists;
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
+import org.apache.shiro.authz.annotation.RequiresAuthentication;
 import org.graylog2.plugin.Capabilities;
 import org.graylog2.plugin.PluginMetaData;
 import org.graylog2.rest.models.system.plugins.responses.PluginList;
@@ -37,6 +38,7 @@ import java.util.Set;
 @Api(value = "System/Plugins", description = "Plugin information")
 @Path("/system/plugins")
 @Produces(MediaType.APPLICATION_JSON)
+@RequiresAuthentication
 public class SystemPluginResource extends RestResource {
     private final Set<PluginMetaData> pluginMetaDataSet;
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Before this change, the `SystemPluginResource` which returns the list of
installed plugins for this node, did not require any authentication at
all. This might lead to unnecessary disclosure of harmful information
and should be avoided.

Therefore this change adds the annotation which requires the caller of
the `SystemPluginResource` to be authenticated. If this is not
sufficient, a further check for a permission can be introduced.

Fixes #4863.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
