### PR TITLE
Add missing permission checks

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/rest/resources/system/logs/LoggersResource.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/resources/system/logs/LoggersResource.java
@@ -35,6 +35,7 @@ import org.apache.logging.log4j.core.config.Configuration;
 import org.apache.logging.log4j.core.config.LoggerConfig;
 import org.apache.logging.log4j.core.impl.ThrowableProxy;
 import org.apache.shiro.authz.annotation.RequiresAuthentication;
+import org.apache.shiro.authz.annotation.RequiresPermissions;
 import org.graylog2.audit.AuditEventTypes;
 import org.graylog2.audit.jersey.AuditEvent;
 import org.graylog2.log4j.MemoryAppender;
@@ -213,6 +214,7 @@ public class LoggersResource extends RestResource {
     })
     @Path("/messages/recent")
     @Produces(MediaType.APPLICATION_JSON)
+    @RequiresPermissions(RestPermissions.LOGGERSMESSAGES_READ)
     public LogMessagesSummary messages(@ApiParam(name = "limit", value = "How many log messages should be returned", defaultValue = "500", allowableValues = "range[0, infinity]")
                                        @QueryParam("limit") @DefaultValue("500") @Min(0L) int limit,
                                        @ApiParam(name = "level", value = "Which log level (or higher) should the messages have", defaultValue = "ALL", allowableValues = "[OFF, FATAL, ERROR, WARN, INFO, DEBUG, TRACE, ALL]")

--- a/graylog2-server/src/main/java/org/graylog2/rest/resources/tools/LookupTableTesterResource.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/resources/tools/LookupTableTesterResource.java
@@ -18,12 +18,14 @@ package org.graylog2.rest.resources.tools;
 
 import com.codahale.metrics.annotation.Timed;
 import org.apache.shiro.authz.annotation.RequiresAuthentication;
+import org.apache.shiro.authz.annotation.RequiresPermissions;
 import org.graylog2.audit.jersey.NoAuditEvent;
 import org.graylog2.lookup.LookupTableService;
 import org.graylog2.plugin.lookup.LookupResult;
 import org.graylog2.rest.models.tools.requests.LookupTableTestRequest;
 import org.graylog2.rest.resources.tools.responses.LookupTableTesterResponse;
 import org.graylog2.shared.rest.resources.RestResource;
+import org.graylog2.shared.security.RestPermissions;
 
 import javax.inject.Inject;
 import javax.validation.Valid;
@@ -61,6 +63,7 @@ public class LookupTableTesterResource extends RestResource {
     @Consumes(MediaType.APPLICATION_JSON)
     @Produces(MediaType.APPLICATION_JSON)
     @NoAuditEvent("only used to test lookup tables")
+    @RequiresPermissions(RestPermissions.LOOKUP_TABLES_READ)
     public LookupTableTesterResponse testLookupTable(@Valid @NotNull LookupTableTestRequest lookupTableTestRequest) {
         return doTestLookupTable(lookupTableTestRequest.string(), lookupTableTestRequest.lookupTableName());
     }

--- a/graylog2-server/src/main/java/org/graylog2/shared/security/RestPermissions.java
+++ b/graylog2-server/src/main/java/org/graylog2/shared/security/RestPermissions.java
@@ -83,6 +83,7 @@ public class RestPermissions implements PluginPermissions {
     public static final String LOGGERS_EDITSUBSYSTEM = "loggers:editsubsystem";
     public static final String LOGGERS_READ = "loggers:read";
     public static final String LOGGERS_READSUBSYSTEM = "loggers:readsubsystem";
+    public static final String LOGGERSMESSAGES_READ = "loggersmessages:read";
     public static final String MESSAGECOUNT_READ = "messagecount:read";
     public static final String MESSAGES_ANALYZE = "messages:analyze";
     public static final String MESSAGES_READ = "messages:read";
@@ -187,6 +188,7 @@ public class RestPermissions implements PluginPermissions {
         .add(create(LOGGERS_EDITSUBSYSTEM, ""))
         .add(create(LOGGERS_READ, ""))
         .add(create(LOGGERS_READSUBSYSTEM, ""))
+        .add(create(LOGGERSMESSAGES_READ, ""))
         .add(create(MESSAGECOUNT_READ, ""))
         .add(create(MESSAGES_ANALYZE, ""))
         .add(create(MESSAGES_READ, ""))


### PR DESCRIPTION
This PR adds two missing permission checks to log messages and lookup table API endpoints.

Fixes #4861 
Fixes #4859 

**Note:** This should be cherry-picked into 2.4 once merged.