### PR TITLE
Check for permission before terminating input. (#4867)

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/rest/resources/system/inputs/InputsResource.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/resources/system/inputs/InputsResource.java
@@ -157,6 +157,7 @@ public class InputsResource extends RestResource {
     })
     @AuditEvent(type = AuditEventTypes.MESSAGE_INPUT_DELETE)
     public void terminate(@ApiParam(name = "inputId", required = true) @PathParam("inputId") String inputId) throws org.graylog2.database.NotFoundException {
+        checkPermission(RestPermissions.INPUTS_TERMINATE, inputId);
         final Input input = inputService.find(inputId);
         inputService.destroy(input);
     }


### PR DESCRIPTION
Before this change it was possible to terminate any input for every
authenticated user. This change introduces a check for the
`inputs:terminate:<input id>` permission before terminating an input.

Fixes #4858.

(cherry picked from commit 0582e31474fa56c1cc21f9cd2536ff58d43e27fa)