### PR TITLE
Requires user to be authenticated to retrieve plugin list

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/shared/rest/resources/system/SystemPluginResource.java
+++ b/graylog2-server/src/main/java/org/graylog2/shared/rest/resources/system/SystemPluginResource.java
@@ -20,6 +20,7 @@ import com.codahale.metrics.annotation.Timed;
 import com.google.common.collect.Lists;
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
+import org.apache.shiro.authz.annotation.RequiresAuthentication;
 import org.graylog2.plugin.Capabilities;
 import org.graylog2.plugin.PluginMetaData;
 import org.graylog2.rest.models.system.plugins.responses.PluginList;
@@ -37,6 +38,7 @@ import java.util.Set;
 @Api(value = "System/Plugins", description = "Plugin information")
 @Path("/system/plugins")
 @Produces(MediaType.APPLICATION_JSON)
+@RequiresAuthentication
 public class SystemPluginResource extends RestResource {
     private final Set<PluginMetaData> pluginMetaDataSet;
 


### PR DESCRIPTION
Before this change, the `SystemPluginResource` which returns the list of
installed plugins for this node, did not require any authentication at
all. This might lead to unnecessary disclosure of harmful information
and should be avoided.

Therefore this change adds the annotation which requires the caller of
the `SystemPluginResource` to be authenticated. If this is not
sufficient, a further check for a permission can be introduced.

Fixes #4863.

(cherry picked from commit 267be4ae23b3ef163427bbc816dd2c7378f755e4)
