### PR TITLE
Move RequiresAuthentication annotation to the top of sidecar endpoints

### DIFF
--- a/graylog2-server/src/main/java/org/graylog/plugins/sidecar/rest/resources/ActionResource.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/sidecar/rest/resources/ActionResource.java
@@ -52,6 +52,7 @@ import java.util.List;
 @Path("/sidecar/action")
 @Consumes(MediaType.APPLICATION_JSON)
 @Produces(MediaType.APPLICATION_JSON)
+@RequiresAuthentication
 public class ActionResource extends RestResource implements PluginRestResource {
     private final ActionService actionService;
 
@@ -67,7 +68,6 @@ public class ActionResource extends RestResource implements PluginRestResource {
     @ApiResponses(value = {
             @ApiResponse(code = 404, message = "No actions found for specified id")
     })
-    @RequiresAuthentication
     @RequiresPermissions(SidecarRestPermissions.SIDECARS_READ)
     public List<CollectorAction> getAction(@ApiParam(name = "sidecarId", required = true)
                                            @PathParam("sidecarId") @NotEmpty String sidecarId) {
@@ -81,7 +81,6 @@ public class ActionResource extends RestResource implements PluginRestResource {
     @PUT
     @Timed
     @Path("/{sidecarId}")
-    @RequiresAuthentication
     @RequiresPermissions(SidecarRestPermissions.SIDECARS_UPDATE)
     @ApiOperation(value = "Set a collector action")
     @ApiResponses(value = {@ApiResponse(code = 400, message = "The supplied action is not valid.")})

--- a/graylog2-server/src/main/java/org/graylog/plugins/sidecar/rest/resources/AdministrationResource.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/sidecar/rest/resources/AdministrationResource.java
@@ -76,6 +76,7 @@ import java.util.stream.Collectors;
 @Path("/sidecar/administration")
 @Consumes(MediaType.APPLICATION_JSON)
 @Produces(MediaType.APPLICATION_JSON)
+@RequiresAuthentication
 public class AdministrationResource extends RestResource implements PluginRestResource {
     private final SidecarService sidecarService;
     private final ConfigurationService configurationService;
@@ -106,7 +107,6 @@ public class AdministrationResource extends RestResource implements PluginRestRe
     @POST
     @Timed
     @ApiOperation(value = "Lists existing Sidecar registrations including compatible sidecars using pagination")
-    @RequiresAuthentication
     @RequiresPermissions(SidecarRestPermissions.SIDECARS_READ)
     @NoAuditEvent("this is not changing any data")
     public SidecarListResponse administration(@ApiParam(name = "JSON body", required = true)
@@ -142,7 +142,6 @@ public class AdministrationResource extends RestResource implements PluginRestRe
     @PUT
     @Timed
     @Path("/action")
-    @RequiresAuthentication
     @RequiresPermissions(SidecarRestPermissions.COLLECTORS_UPDATE)
     @ApiOperation(value = "Set collector actions in bulk")
     @ApiResponses(value = {@ApiResponse(code = 400, message = "The supplied action is not valid.")})

--- a/graylog2-server/src/main/java/org/graylog/plugins/sidecar/rest/resources/CollectorResource.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/sidecar/rest/resources/CollectorResource.java
@@ -67,6 +67,7 @@ import java.util.stream.Collectors;
 @Path("/sidecar/collectors")
 @Consumes(MediaType.APPLICATION_JSON)
 @Produces(MediaType.APPLICATION_JSON)
+@RequiresAuthentication
 public class CollectorResource extends RestResource implements PluginRestResource {
     private final CollectorService collectorService;
     private final EtagService etagService;
@@ -87,7 +88,6 @@ public class CollectorResource extends RestResource implements PluginRestResourc
 
     @GET
     @Path("/{id}")
-    @RequiresAuthentication
     @RequiresPermissions(SidecarRestPermissions.COLLECTORS_READ)
     @Produces(MediaType.APPLICATION_JSON)
     @ApiOperation(value = "Show collector details")
@@ -97,7 +97,6 @@ public class CollectorResource extends RestResource implements PluginRestResourc
     }
 
     @GET
-    @RequiresAuthentication
     @RequiresPermissions(SidecarRestPermissions.COLLECTORS_READ)
     @Produces(MediaType.APPLICATION_JSON)
     @ApiOperation(value = "List all collectors")
@@ -141,7 +140,6 @@ public class CollectorResource extends RestResource implements PluginRestResourc
 
     @GET
     @Path("/summary")
-    @RequiresAuthentication
     @RequiresPermissions(SidecarRestPermissions.COLLECTORS_READ)
     @Produces(MediaType.APPLICATION_JSON)
     @ApiOperation(value = "List a summary of all collectors")
@@ -166,7 +164,6 @@ public class CollectorResource extends RestResource implements PluginRestResourc
     }
 
     @POST
-    @RequiresAuthentication
     @RequiresPermissions(SidecarRestPermissions.COLLECTORS_CREATE)
     @Produces(MediaType.APPLICATION_JSON)
     @ApiOperation(value = "Create a new collector")
@@ -180,7 +177,6 @@ public class CollectorResource extends RestResource implements PluginRestResourc
 
     @PUT
     @Path("/{id}")
-    @RequiresAuthentication
     @RequiresPermissions(SidecarRestPermissions.COLLECTORS_UPDATE)
     @Produces(MediaType.APPLICATION_JSON)
     @ApiOperation(value = "Update a collector")
@@ -196,7 +192,6 @@ public class CollectorResource extends RestResource implements PluginRestResourc
 
     @POST
     @Path("/{id}/{name}")
-    @RequiresAuthentication
     @RequiresPermissions(SidecarRestPermissions.COLLECTORS_CREATE)
     @ApiOperation(value = "Copy a collector")
     @AuditEvent(type = SidecarAuditEventTypes.COLLECTOR_CLONE)
@@ -211,7 +206,6 @@ public class CollectorResource extends RestResource implements PluginRestResourc
 
     @DELETE
     @Path("/{id}")
-    @RequiresAuthentication
     @RequiresPermissions(SidecarRestPermissions.COLLECTORS_DELETE)
     @Produces(MediaType.APPLICATION_JSON)
     @ApiOperation(value = "Delete a collector")
@@ -228,7 +222,6 @@ public class CollectorResource extends RestResource implements PluginRestResourc
 
     @GET
     @Path("/validate")
-    @RequiresAuthentication
     @RequiresPermissions(SidecarRestPermissions.CONFIGURATIONS_READ)
     @Produces(MediaType.APPLICATION_JSON)
     @ApiOperation(value = "Validates collector name")

--- a/graylog2-server/src/main/java/org/graylog/plugins/sidecar/rest/resources/ConfigurationResource.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/sidecar/rest/resources/ConfigurationResource.java
@@ -71,6 +71,7 @@ import java.util.stream.Collectors;
 @Path("/sidecar/configurations")
 @Consumes(MediaType.APPLICATION_JSON)
 @Produces(MediaType.APPLICATION_JSON)
+@RequiresAuthentication
 public class ConfigurationResource extends RestResource implements PluginRestResource {
     private final ConfigurationService configurationService;
     private final SidecarService sidecarService;
@@ -93,7 +94,6 @@ public class ConfigurationResource extends RestResource implements PluginRestRes
     }
 
     @GET
-    @RequiresAuthentication
     @RequiresPermissions(SidecarRestPermissions.CONFIGURATIONS_READ)
     @Produces(MediaType.APPLICATION_JSON)
     @ApiOperation(value = "List all configurations")
@@ -119,7 +119,6 @@ public class ConfigurationResource extends RestResource implements PluginRestRes
 
     @GET
     @Path("/{id}")
-    @RequiresAuthentication
     @RequiresPermissions(SidecarRestPermissions.CONFIGURATIONS_READ)
     @Produces(MediaType.APPLICATION_JSON)
     @ApiOperation(value = "Show configuration details")
@@ -130,7 +129,6 @@ public class ConfigurationResource extends RestResource implements PluginRestRes
 
     @GET
     @Path("/validate")
-    @RequiresAuthentication
     @RequiresPermissions(SidecarRestPermissions.CONFIGURATIONS_READ)
     @Produces(MediaType.APPLICATION_JSON)
     @ApiOperation(value = "Validates configuration name")
@@ -145,7 +143,6 @@ public class ConfigurationResource extends RestResource implements PluginRestRes
     @GET
     @Path("/render/{sidecarId}/{configurationId}")
     @Produces(MediaType.APPLICATION_JSON)
-    @RequiresAuthentication
     @RequiresPermissions(SidecarRestPermissions.CONFIGURATIONS_READ)
     @ApiOperation(value = "Render configuration template")
     public Response renderConfiguration(@Context HttpHeaders httpHeaders,
@@ -202,7 +199,6 @@ public class ConfigurationResource extends RestResource implements PluginRestRes
     @POST
     @Path("/render/preview")
     @Produces(MediaType.APPLICATION_JSON)
-    @RequiresAuthentication
     @RequiresPermissions(SidecarRestPermissions.CONFIGURATIONS_READ)
     @ApiOperation(value = "Render preview of a configuration template")
     @NoAuditEvent("this is not changing any data")
@@ -213,7 +209,6 @@ public class ConfigurationResource extends RestResource implements PluginRestRes
     }
 
     @POST
-    @RequiresAuthentication
     @RequiresPermissions(SidecarRestPermissions.CONFIGURATIONS_CREATE)
     @Produces(MediaType.APPLICATION_JSON)
     @ApiOperation(value = "Create new configuration")
@@ -226,7 +221,6 @@ public class ConfigurationResource extends RestResource implements PluginRestRes
 
     @POST
     @Path("/{id}/{name}")
-    @RequiresAuthentication
     @RequiresPermissions(SidecarRestPermissions.CONFIGURATIONS_CREATE)
     @ApiOperation(value = "Copy a configuration")
     @AuditEvent(type = SidecarAuditEventTypes.CONFIGURATION_CLONE)
@@ -240,7 +234,6 @@ public class ConfigurationResource extends RestResource implements PluginRestRes
 
     @PUT
     @Path("/{id}")
-    @RequiresAuthentication
     @RequiresPermissions(SidecarRestPermissions.CONFIGURATIONS_UPDATE)
     @Produces(MediaType.APPLICATION_JSON)
     @ApiOperation(value = "Update a configuration")
@@ -256,7 +249,6 @@ public class ConfigurationResource extends RestResource implements PluginRestRes
 
     @DELETE
     @Path("/{id}")
-    @RequiresAuthentication
     @RequiresPermissions(SidecarRestPermissions.CONFIGURATIONS_UPDATE)
     @Produces(MediaType.APPLICATION_JSON)
     @ApiOperation(value = "Delete a configuration")

--- a/graylog2-server/src/main/java/org/graylog/plugins/sidecar/rest/resources/SidecarResource.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/sidecar/rest/resources/SidecarResource.java
@@ -82,6 +82,7 @@ import java.util.stream.Collectors;
 @Path("/sidecars")
 @Consumes(MediaType.APPLICATION_JSON)
 @Produces(MediaType.APPLICATION_JSON)
+@RequiresAuthentication
 public class SidecarResource extends RestResource implements PluginRestResource {
     protected static final ImmutableMap<String, SearchQueryField> SEARCH_FIELD_MAPPING = ImmutableMap.<String, SearchQueryField>builder()
             .put("id", SearchQueryField.create(Sidecar.FIELD_ID))
@@ -117,7 +118,6 @@ public class SidecarResource extends RestResource implements PluginRestResource 
     @Timed
     @Path("/all")
     @ApiOperation(value = "Lists all existing Sidecar registrations")
-    @RequiresAuthentication
     @RequiresPermissions(SidecarRestPermissions.SIDECARS_READ)
     public SidecarListResponse all() {
         final List<Sidecar> sidecars = sidecarService.all();
@@ -137,7 +137,6 @@ public class SidecarResource extends RestResource implements PluginRestResource 
     @GET
     @Timed
     @ApiOperation(value = "Lists existing Sidecar registrations using pagination")
-    @RequiresAuthentication
     @RequiresPermissions(SidecarRestPermissions.SIDECARS_READ)
     public SidecarListResponse sidecars(@ApiParam(name = "page") @QueryParam("page") @DefaultValue("1") int page,
                                         @ApiParam(name = "per_page") @QueryParam("per_page") @DefaultValue("50") int perPage,
@@ -167,7 +166,6 @@ public class SidecarResource extends RestResource implements PluginRestResource 
     @ApiResponses(value = {
             @ApiResponse(code = 404, message = "No Sidecar with the specified id exists")
     })
-    @RequiresAuthentication
     @RequiresPermissions(SidecarRestPermissions.SIDECARS_READ)
     public SidecarSummary get(@ApiParam(name = "sidecarId", required = true)
                               @PathParam("sidecarId") @NotEmpty String sidecarId) {
@@ -187,7 +185,6 @@ public class SidecarResource extends RestResource implements PluginRestResource 
     @ApiResponses(value = {
             @ApiResponse(code = 400, message = "The supplied request is not valid.")
     })
-    @RequiresAuthentication
     @RequiresPermissions(SidecarRestPermissions.SIDECARS_UPDATE)
     @NoAuditEvent("this is only a ping from Sidecars, and would overflow the audit log")
     public Response register(@ApiParam(name = "sidecarId", value = "The id this Sidecar is registering as.", required = true)
@@ -230,7 +227,6 @@ public class SidecarResource extends RestResource implements PluginRestResource 
     @Timed
     @Path("/configurations")
     @ApiOperation(value = "Assign configurations to sidecars")
-    @RequiresAuthentication
     @RequiresPermissions(SidecarRestPermissions.SIDECARS_UPDATE)
     @AuditEvent(type = SidecarAuditEventTypes.SIDECAR_UPDATE)
     public Response assignConfiguration(@ApiParam(name = "JSON body", required = true)


### PR DESCRIPTION
While it's not an issue repeating the annotation for every resource
method, having it once at the class level prevents the accidental
introduction of unprotected endpoints in the future.

Fixes #4862
