### PR TITLE
Preventing index size/time input to hide rotation strategy dropdown

### DIFF
--- a/graylog2-web-interface/src/components/common/Select.css
+++ b/graylog2-web-interface/src/components/common/Select.css
@@ -9,3 +9,8 @@
 .select-sm .Select-input > input {
     padding: 0;
 }
+
+:local(.increaseZIndex) .Select-menu-outer {
+    z-index: 5;
+}
+

--- a/graylog2-web-interface/src/components/common/Select.jsx
+++ b/graylog2-web-interface/src/components/common/Select.jsx
@@ -113,7 +113,7 @@ const Select = React.createClass({
     }
 
     return (
-      <div className={size === 'small' ? 'select-sm' : ''}>
+      <div className={`${size === 'small' ? 'select-sm' : ''} ${this.reactSelectSmStyles.locals.increaseZIndex}`}>
         <SelectComponent ref={(c) => { this._select = c; }}
                          onChange={onReactSelectChange || this._onChange}
                          {...reactSelectProps}


### PR DESCRIPTION
* Increasing z-index of `Select` component to overlay other elements.

Before this change, other elements (namely react-bootstrap input
components with addons) overlapped with `Select` inputs due to a higher
`z-index` of the first.

This change is increasing the `z-index` of the `Select`/`react-select`
menu to `3` (react-bootstrap input addons are on `2`) to prevent this.

Fixes #4769.

* Increase z index of `Select` component's menu to 5.

This change is increasing the z-index of the dropdown menu of a `Select`
component even more, so it is on top of the gutter of an Ace editor
component.

(cherry picked from commit 39816860f86aa1a60a1bd4a8c7676b9daa4befea)
