### PR TITLE
Improve log messages for alert conditions and configuration requests

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/alerts/AlertConditionFactory.java
+++ b/graylog2-server/src/main/java/org/graylog2/alerts/AlertConditionFactory.java
@@ -48,8 +48,10 @@ public class AlertConditionFactory {
                                                Map<String, Object> parameters,
                                                String title) throws ConfigurationException {
 
+        final String conditionTitle = isNullOrEmpty(title) ? "" : "'" + title + "' ";
         final AlertCondition.Factory factory = this.alertConditionMap.get(type);
-        checkArgument(factory != null, "Unknown alert condition type: " + type);
+        checkArgument(factory != null, "Unknown alert condition type <%s> for alert condition %s<%s> on stream <%s>",
+                type, conditionTitle, id, stream.getId());
 
         /*
          * Ensure the given parameters fulfill the requested configuration preconditions.
@@ -62,8 +64,7 @@ public class AlertConditionFactory {
             final Configuration configuration = new Configuration(parameters);
             requestedConfiguration.check(configuration);
         } catch (ConfigurationException e) {
-            final String conditionTitle = isNullOrEmpty(title) ? "" : "'" + title + "' ";
-            LOG.error("Could not load alert condition " + conditionTitle + "<" + id + ">, invalid configuration detected.");
+            LOG.error("Could not load alert condition {}<{}> on stream <{}>, invalid configuration detected.", conditionTitle, id, stream.getId());
             throw e;
         }
 

--- a/graylog2-server/src/main/java/org/graylog2/alerts/AlertConditionFactory.java
+++ b/graylog2-server/src/main/java/org/graylog2/alerts/AlertConditionFactory.java
@@ -50,8 +50,8 @@ public class AlertConditionFactory {
 
         final String conditionTitle = isNullOrEmpty(title) ? "" : "'" + title + "' ";
         final AlertCondition.Factory factory = this.alertConditionMap.get(type);
-        checkArgument(factory != null, "Unknown alert condition type <%s> for alert condition %s<%s> on stream <%s>",
-                type, conditionTitle, id, stream.getId());
+        checkArgument(factory != null, "Unknown alert condition type <%s> for alert condition %s<%s> on stream \"%s\" <%s>",
+                type, conditionTitle, id, stream.getTitle(), stream.getId());
 
         /*
          * Ensure the given parameters fulfill the requested configuration preconditions.
@@ -64,7 +64,7 @@ public class AlertConditionFactory {
             final Configuration configuration = new Configuration(parameters);
             requestedConfiguration.check(configuration);
         } catch (ConfigurationException e) {
-            LOG.error("Could not load alert condition {}<{}> on stream <{}>, invalid configuration detected.", conditionTitle, id, stream.getId());
+            LOG.error("Could not load alert condition {}<{}> on stream \"{}\" <{}>, invalid configuration detected.", conditionTitle, id, stream.getTitle(), stream.getId());
             throw e;
         }
 

--- a/graylog2-server/src/main/java/org/graylog2/plugin/configuration/ConfigurationRequest.java
+++ b/graylog2-server/src/main/java/org/graylog2/plugin/configuration/ConfigurationRequest.java
@@ -99,26 +99,27 @@ public class ConfigurationRequest {
         for (ConfigurationField field : fields.values()) {
             if (field.isOptional().equals(ConfigurationField.Optional.NOT_OPTIONAL)) {
                 final String type = field.getFieldType();
-                log.debug("Checking for non-optional field {} of type {} in configuration", field.getName(), type);
+                final String fieldName = field.getName();
+                log.debug("Checking for mandatory field \"{}\" of type {} in configuration", fieldName, type);
                 switch (type) {
                     case BooleanField.FIELD_TYPE:
-                        if (!configuration.booleanIsSet(field.getName())) {
-                            throw new ConfigurationException("Mandatory configuration field " + field.getName() + " is missing or has the wrong data type");
+                        if (!configuration.booleanIsSet(fieldName)) {
+                            throw new ConfigurationException("Mandatory configuration field \"" + fieldName + "\" is missing or has the wrong data type");
                         }
                         break;
                     case NumberField.FIELD_TYPE:
-                        if (!configuration.intIsSet(field.getName())) {
-                            throw new ConfigurationException("Mandatory configuration field " + field.getName() + " is missing or has the wrong data type");
+                        if (!configuration.intIsSet(fieldName)) {
+                            throw new ConfigurationException("Mandatory configuration field \"" + fieldName + "\" is missing or has the wrong data type");
                         }
                         break;
                     case TextField.FIELD_TYPE:
                     case DropdownField.FIELD_TYPE:
-                        if (!configuration.stringIsSet(field.getName())) {
-                                throw new ConfigurationException("Mandatory configuration field " + field.getName() + " is missing or has the wrong data type");
+                        if (!configuration.stringIsSet(fieldName)) {
+                            throw new ConfigurationException("Mandatory configuration field \"" + fieldName + "\" is missing or has the wrong data type");
                         }
                         break;
                     default:
-                        throw new IllegalStateException("Unknown field type " + type + ". This is a bug.");
+                        throw new IllegalStateException("Unknown field type " + type + " for configuration field \"" + fieldName + "\". This is a bug.");
                 }
             }
         }
@@ -155,7 +156,7 @@ public class ConfigurationRequest {
                     }
                     break;
                 default:
-                    throw new IllegalStateException("Unknown field type " + type + ". This is a bug.");
+                    throw new IllegalStateException("Unknown field type " + type + " for configuration field \"" + name + "\". This is a bug.");
             }
         }
         return new Configuration(values);


### PR DESCRIPTION
Improve error and warning messages for alert conditions by always including the alert condition ID and the stream ID it's connected to.

Refs #4883