### PR TITLE
Change collector status data from a map to a set of objects

### DIFF
--- a/graylog2-server/src/main/java/org/graylog/plugins/sidecar/filter/StatusAdministrationFilter.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/sidecar/filter/StatusAdministrationFilter.java
@@ -38,7 +38,7 @@ public class StatusAdministrationFilter implements AdministrationFilter {
             // Sidecars with not known status are in an UNKNOWN status
             return Status.UNKNOWN.equals(status);
         }
-        return collectorStatusList.collectors().entrySet().stream()
-                .anyMatch(entry -> Status.fromStatusCode(entry.getValue().status()).equals(status));
+        return collectorStatusList.collectors().stream()
+                .anyMatch(status -> Status.fromStatusCode(status.status()).equals(this.status));
     }
 }

--- a/graylog2-server/src/main/java/org/graylog/plugins/sidecar/rest/models/CollectorStatus.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/sidecar/rest/models/CollectorStatus.java
@@ -24,6 +24,9 @@ import com.google.auto.value.AutoValue;
 @AutoValue
 @JsonAutoDetect
 public abstract class CollectorStatus {
+    @JsonProperty("name")
+    public abstract String name();
+
     @JsonProperty("status")
     public abstract int status();
 
@@ -31,8 +34,9 @@ public abstract class CollectorStatus {
     public abstract String message();
 
     @JsonCreator
-    public static CollectorStatus create(@JsonProperty("status") int status,
+    public static CollectorStatus create(@JsonProperty("name") String name,
+                                         @JsonProperty("status") int status,
                                          @JsonProperty("message") String message) {
-        return new AutoValue_CollectorStatus(status, message);
+        return new AutoValue_CollectorStatus(name, status, message);
     }
 }

--- a/graylog2-server/src/main/java/org/graylog/plugins/sidecar/rest/models/CollectorStatusList.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/sidecar/rest/models/CollectorStatusList.java
@@ -20,8 +20,9 @@ import com.fasterxml.jackson.annotation.JsonAutoDetect;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.auto.value.AutoValue;
+import com.google.common.collect.ImmutableSet;
 
-import java.util.HashMap;
+import java.util.Set;
 
 @AutoValue
 @JsonAutoDetect
@@ -33,11 +34,11 @@ public abstract class CollectorStatusList {
     public abstract String message();
 
     @JsonProperty("collectors")
-    public abstract HashMap<String, CollectorStatus> collectors();
+    public abstract ImmutableSet<CollectorStatus> collectors();
 
     @JsonCreator
     public static CollectorStatusList create(@JsonProperty("status") int status,
                                              @JsonProperty("message") String message,
-                                             @JsonProperty("collectors") HashMap<String, CollectorStatus> collectors) {
-        return new AutoValue_CollectorStatusList(status, message, collectors);
+                                             @JsonProperty("collectors") Set<CollectorStatus> collectors) {
+        return new AutoValue_CollectorStatusList(status, message, ImmutableSet.copyOf(collectors));
     }}

--- a/graylog2-web-interface/src/components/sidecars/administration/CollectorsAdministration.jsx
+++ b/graylog2-web-interface/src/components/sidecars/administration/CollectorsAdministration.jsx
@@ -182,7 +182,10 @@ const CollectorsAdministration = createReactClass({
     const configuration = configurations.find(config => config.id === configAssignment.configuration_id);
     let collectorStatus;
     try {
-      collectorStatus = sidecar.node_details.status.collectors[collector.name].status;
+      const result = sidecar.node_details.status.collectors.find(c => c.name === collector.name);
+      if (result) {
+        collectorStatus = result.status;
+      }
     } catch (e) {
       // Do nothing
     }

--- a/graylog2-web-interface/src/components/sidecars/sidecars/SidecarStatus.jsx
+++ b/graylog2-web-interface/src/components/sidecars/sidecars/SidecarStatus.jsx
@@ -54,14 +54,14 @@ const SidecarStatus = createReactClass({
       return <p>Did not receive collectors status, set the option <code>send_status: true</code> in the sidecar configuration to see this information.</p>;
     }
 
-    const collectors = Object.keys(details.status.collectors);
+    const collectors = details.status.collectors;
     if (collectors.length === 0) {
       return <p>There are no collectors configured in this sidecar.</p>;
     }
 
     const statuses = [];
-    collectors.forEach((collector) => {
-      const status = details.status.collectors[collector];
+    collectors.forEach((status) => {
+      const collector = status.name;
 
       let statusMessage;
       let statusBadge;


### PR DESCRIPTION
This fixes a problem when using a "." character in a collector backend
name. It also makes it easier to run MongoDB queries against collector
status objects.

Fixes #4885