### PR TITLE
Avoid creating duplicate Grok patterns

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/grok/MongoDbGrokPatternService.java
+++ b/graylog2-server/src/main/java/org/graylog2/grok/MongoDbGrokPatternService.java
@@ -19,6 +19,8 @@ package org.graylog2.grok;
 import com.google.common.base.Strings;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
+import com.mongodb.client.model.IndexOptions;
+import com.mongodb.client.model.Indexes;
 import io.krakens.grok.api.Grok;
 import io.krakens.grok.api.GrokCompiler;
 import io.krakens.grok.api.exception.GrokException;
@@ -31,8 +33,6 @@ import org.mongojack.DBCursor;
 import org.mongojack.DBQuery;
 import org.mongojack.JacksonDBCollection;
 import org.mongojack.WriteResult;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import javax.inject.Inject;
 import java.util.Collection;
@@ -44,8 +44,9 @@ import java.util.regex.PatternSyntaxException;
 import static com.google.common.base.Preconditions.checkNotNull;
 
 public class MongoDbGrokPatternService implements GrokPatternService {
-    public static final String GROK_PATTERNS = "grok_patterns";
-    private static final Logger log = LoggerFactory.getLogger(MongoDbGrokPatternService.class);
+    public static final String COLLECTION_NAME = "grok_patterns";
+    public static final String INDEX_NAME = "idx_name_asc_unique";
+
     private final JacksonDBCollection<GrokPattern, ObjectId> dbCollection;
 
     @Inject
@@ -53,10 +54,24 @@ public class MongoDbGrokPatternService implements GrokPatternService {
                                         MongoJackObjectMapperProvider mapper) {
 
         dbCollection = JacksonDBCollection.wrap(
-                mongoConnection.getDatabase().getCollection(GROK_PATTERNS),
+                mongoConnection.getDatabase().getCollection(COLLECTION_NAME),
                 GrokPattern.class,
                 ObjectId.class,
                 mapper.get());
+
+
+        // TODO: Uncomment once there are no Graylog clusters with duplicate Grok patterns out there,
+        //       probably around Graylog 4.0.0.
+        // createIndex(mongoConnection);
+    }
+
+    private static void createIndex(MongoConnection mongoConnection) {
+        final IndexOptions indexOptions = new IndexOptions()
+                .name(INDEX_NAME)
+                .unique(true);
+        mongoConnection.getMongoDatabase()
+                .getCollection(COLLECTION_NAME)
+                .createIndex(Indexes.ascending("name"), indexOptions);
     }
 
     @Override

--- a/graylog2-server/src/main/java/org/graylog2/migrations/MigrationsModule.java
+++ b/graylog2-server/src/main/java/org/graylog2/migrations/MigrationsModule.java
@@ -34,5 +34,6 @@ public class MigrationsModule extends PluginModule {
         addMigration(V20170110150100_FixAlertConditionsMigration.class);
         addMigration(V20170607164210_MigrateReopenedIndicesToAliases.class);
         addMigration(V20180214093600_AdjustDashboardPositionToNewResolution.class);
+        addMigration(V2018070614390000_EnforceUniqueGrokPatterns.class);
     }
 }

--- a/graylog2-server/src/main/java/org/graylog2/migrations/V2018070614390000_EnforceUniqueGrokPatterns.java
+++ b/graylog2-server/src/main/java/org/graylog2/migrations/V2018070614390000_EnforceUniqueGrokPatterns.java
@@ -1,0 +1,119 @@
+/**
+ * This file is part of Graylog.
+ *
+ * Graylog is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.graylog2.migrations;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.collect.ImmutableSet;
+import com.mongodb.client.MongoCollection;
+import com.mongodb.client.model.IndexOptions;
+import com.mongodb.client.model.Indexes;
+import org.bson.Document;
+import org.bson.types.ObjectId;
+import org.graylog2.database.MongoConnection;
+import org.graylog2.events.ClusterEventBus;
+import org.graylog2.grok.GrokPatternsChangedEvent;
+import org.graylog2.grok.MongoDbGrokPatternService;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.inject.Inject;
+import java.time.ZonedDateTime;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+
+import static com.mongodb.client.model.Filters.eq;
+
+/**
+ * Migration removing duplicate Grok patterns and adding a unique index to the "grok_patterns" collection in
+ * MongoDB.
+ */
+public class V2018070614390000_EnforceUniqueGrokPatterns extends Migration {
+    private static final Logger LOG = LoggerFactory.getLogger(V2018070614390000_EnforceUniqueGrokPatterns.class);
+
+    private final MongoCollection<Document> collection;
+    private final ClusterEventBus clusterEventBus;
+    private boolean indexCreated = false;
+
+    @Inject
+    public V2018070614390000_EnforceUniqueGrokPatterns(MongoConnection mongoConnection, ClusterEventBus clusterEventBus) {
+        this(mongoConnection.getMongoDatabase().getCollection(MongoDbGrokPatternService.COLLECTION_NAME), clusterEventBus);
+    }
+
+    V2018070614390000_EnforceUniqueGrokPatterns(MongoCollection<Document> collection, ClusterEventBus clusterEventBus) {
+        this.collection = collection;
+        this.clusterEventBus = clusterEventBus;
+    }
+
+    public ZonedDateTime createdAt() {
+        return ZonedDateTime.parse("2018-07-06T14:39:00Z");
+    }
+
+    @Override
+    public void upgrade() {
+        boolean indexExists = false;
+        for (Document document : collection.listIndexes()) {
+            if (MongoDbGrokPatternService.INDEX_NAME.equals(document.getString("name")) && document.getBoolean("unique")) {
+                indexExists = true;
+                break;
+            }
+        }
+
+        if (indexExists) {
+            LOG.debug("Unique index for Grok patterns already exists, skipping migration.");
+            return;
+        }
+
+        final Collection<String> grokPatterns = new HashSet<>();
+        final Map<ObjectId, String> duplicatePatterns = new HashMap<>();
+        for (Document document : collection.find()) {
+            final ObjectId id = document.getObjectId("_id");
+            final String name = document.getString("name");
+            final String pattern = document.getString("pattern");
+            if (grokPatterns.contains(name)) {
+                LOG.info("Marking duplicate Grok pattern <{}> for removal: {}\t{}", id, name, pattern);
+                duplicatePatterns.put(id, name);
+            } else {
+                LOG.debug("Recording Grok pattern <{}>: {}\t{}", id, name, pattern);
+                grokPatterns.add(name);
+            }
+        }
+
+        for (ObjectId id : duplicatePatterns.keySet()) {
+            LOG.info("Deleting duplicate Grok pattern with ID <{}>", id);
+            collection.deleteOne(eq("_id", id));
+        }
+
+        final IndexOptions indexOptions = new IndexOptions()
+                .name(MongoDbGrokPatternService.INDEX_NAME)
+                .unique(true);
+        collection.createIndex(Indexes.ascending("name"), indexOptions);
+
+        if (!duplicatePatterns.isEmpty()) {
+            clusterEventBus.post(GrokPatternsChangedEvent.create(Collections.emptySet(), ImmutableSet.copyOf(duplicatePatterns.values())));
+        }
+
+        indexCreated = true;
+    }
+
+    @VisibleForTesting
+    boolean isIndexCreated() {
+        return indexCreated;
+    }
+}

--- a/graylog2-server/src/test/java/org/graylog2/grok/MongoDbGrokPatternServiceTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/grok/MongoDbGrokPatternServiceTest.java
@@ -1,3 +1,19 @@
+/**
+ * This file is part of Graylog.
+ *
+ * Graylog is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package org.graylog2.grok;
 
 import com.lordofthejars.nosqlunit.annotation.UsingDataSet;

--- a/graylog2-server/src/test/java/org/graylog2/grok/MongoDbGrokPatternServiceTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/grok/MongoDbGrokPatternServiceTest.java
@@ -1,0 +1,101 @@
+package org.graylog2.grok;
+
+import com.lordofthejars.nosqlunit.annotation.UsingDataSet;
+import com.lordofthejars.nosqlunit.core.LoadStrategyEnum;
+import com.lordofthejars.nosqlunit.mongodb.InMemoryMongoDb;
+import com.mongodb.client.MongoCollection;
+import org.bson.Document;
+import org.graylog2.bindings.providers.MongoJackObjectMapperProvider;
+import org.graylog2.database.MongoConnection;
+import org.graylog2.database.MongoConnectionRule;
+import org.graylog2.plugin.database.ValidationException;
+import org.graylog2.shared.bindings.providers.ObjectMapperProvider;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+
+import java.util.Arrays;
+import java.util.List;
+
+import static com.lordofthejars.nosqlunit.mongodb.InMemoryMongoDb.InMemoryMongoRuleBuilder.newInMemoryMongoDbRule;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+public class MongoDbGrokPatternServiceTest {
+    @ClassRule
+    public static final InMemoryMongoDb IN_MEMORY_MONGO_DB = newInMemoryMongoDbRule().build();
+
+    @Rule
+    public MongoConnectionRule mongoRule = MongoConnectionRule.build("test");
+
+    private MongoCollection<Document> collection;
+    private MongoDbGrokPatternService grokPatternService;
+
+    @Before
+    public void setUp() throws Exception {
+        final MongoConnection mongoConnection = mongoRule.getMongoConnection();
+        collection = mongoConnection.getMongoDatabase().getCollection(MongoDbGrokPatternService.COLLECTION_NAME);
+
+        final MongoJackObjectMapperProvider mapperProvider = new MongoJackObjectMapperProvider(new ObjectMapperProvider().get());
+        grokPatternService = new MongoDbGrokPatternService(mongoConnection, mapperProvider);
+    }
+
+    @Test
+    @UsingDataSet(loadStrategy = LoadStrategyEnum.DELETE_ALL)
+    public void saveSucceedsWithValidGrokPattern() throws ValidationException {
+        grokPatternService.save(GrokPattern.create("NUMBER", "[0-9]+"));
+
+        assertThat(collection.count()).isEqualTo(1L);
+    }
+
+    @Test
+    @UsingDataSet(loadStrategy = LoadStrategyEnum.DELETE_ALL)
+    public void saveFailsWithDuplicateGrokPattern() throws ValidationException {
+        grokPatternService.save(GrokPattern.create("NUMBER", "[0-9]+"));
+
+        assertThatThrownBy(() -> grokPatternService.save(GrokPattern.create("NUMBER", "[0-9]+")))
+                .isInstanceOf(ValidationException.class)
+                .hasMessageStartingWith("Grok pattern NUMBER already exists");
+        assertThat(collection.count()).isEqualTo(1L);
+    }
+
+
+    @Test
+    @UsingDataSet(loadStrategy = LoadStrategyEnum.DELETE_ALL)
+    public void saveAllSucceedsWithValidGrokPatterns() throws ValidationException {
+        final List<GrokPattern> grokPatterns = Arrays.asList(
+                GrokPattern.create("NUMBER", "[0-9]+"),
+                GrokPattern.create("INT", "[+-]?%{NUMBER}"));
+        grokPatternService.saveAll(grokPatterns, false);
+
+        assertThat(collection.count()).isEqualTo(2L);
+    }
+
+    @Test
+    @UsingDataSet(loadStrategy = LoadStrategyEnum.DELETE_ALL)
+    public void saveAllSucceedsWithDuplicateGrokPatternWithReplaceAll() throws ValidationException {
+        final List<GrokPattern> grokPatterns = Arrays.asList(
+                GrokPattern.create("NUMBER", "[0-9]+"),
+                GrokPattern.create("INT", "[+-]?%{NUMBER}"));
+        grokPatternService.save(GrokPattern.create("NUMBER", "[0-9]+"));
+
+        grokPatternService.saveAll(grokPatterns, true);
+
+        assertThat(collection.count()).isEqualTo(2L);
+    }
+
+    @Test
+    @UsingDataSet(loadStrategy = LoadStrategyEnum.DELETE_ALL)
+    public void saveAllFailsWithDuplicateGrokPatternWithoutReplaceAll() throws ValidationException {
+        final List<GrokPattern> grokPatterns = Arrays.asList(
+                GrokPattern.create("NUMBER", "[0-9]+"),
+                GrokPattern.create("INT", "[+-]?%{NUMBER}"));
+        grokPatternService.save(GrokPattern.create("NUMBER", "[0-9]+"));
+
+        assertThatThrownBy(() -> grokPatternService.saveAll(grokPatterns, false))
+                .isInstanceOf(ValidationException.class)
+                .hasMessageStartingWith("Grok pattern NUMBER already exists");
+        assertThat(collection.count()).isEqualTo(1L);
+    }
+}

--- a/graylog2-server/src/test/java/org/graylog2/migrations/V2018070614390000_EnforceUniqueGrokPatternsTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/migrations/V2018070614390000_EnforceUniqueGrokPatternsTest.java
@@ -1,0 +1,130 @@
+/**
+ * This file is part of Graylog.
+ *
+ * Graylog is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.graylog2.migrations;
+
+import com.github.fakemongo.Fongo;
+import com.google.common.eventbus.Subscribe;
+import com.google.common.util.concurrent.MoreExecutors;
+import com.mongodb.DuplicateKeyException;
+import com.mongodb.client.MongoCollection;
+import com.mongodb.client.model.IndexOptions;
+import com.mongodb.client.model.Indexes;
+import org.bson.Document;
+import org.bson.types.ObjectId;
+import org.graylog2.events.ClusterEventBus;
+import org.graylog2.grok.GrokPatternsChangedEvent;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+public class V2018070614390000_EnforceUniqueGrokPatternsTest {
+    private MongoCollection<Document> collection;
+    private V2018070614390000_EnforceUniqueGrokPatterns migration;
+    private ClusterEventBus clusterEventBus;
+    private TestSubscriber subscriber;
+
+    @Before
+    public void setUp() {
+        final Fongo fongo = new Fongo("migration-test");
+        collection = fongo.getDatabase("migration-test").getCollection("grok_patterns");
+        subscriber = new TestSubscriber();
+        clusterEventBus = new ClusterEventBus(MoreExecutors.newDirectExecutorService());
+        clusterEventBus.registerClusterEventSubscriber(subscriber);
+
+        migration = new V2018070614390000_EnforceUniqueGrokPatterns(collection, clusterEventBus);
+    }
+
+    @Test
+    public void upgradeAbortsIfIndexExists() {
+        final IndexOptions indexOptions = new IndexOptions()
+                .name("idx_name_asc_unique")
+                .unique(true);
+        collection.createIndex(Indexes.ascending("name"), indexOptions);
+
+        migration.upgrade();
+
+        assertThat(migration.isIndexCreated()).isFalse();
+        assertThat(subscriber.events).isEmpty();
+    }
+
+    @Test
+    public void upgradeRunsIfIndexDoesNotExist() {
+        migration.upgrade();
+
+        assertThat(migration.isIndexCreated()).isTrue();
+        assertThat(subscriber.events).isEmpty();
+    }
+
+    @Test
+    public void upgradeRemovesDuplicateGrokPatterns() {
+        collection.insertMany(
+                Arrays.asList(
+                        grokPattern("FOO", "[a-z]+"),
+                        grokPattern("BAR", "%{FOO}[0-9]+"),
+                        grokPattern("BAR", "[0-9]+")));
+        migration.upgrade();
+
+        assertThat(migration.isIndexCreated()).isTrue();
+        assertThat(collection.find())
+                .anySatisfy(document -> assertThat(document)
+                        .containsEntry("name", "FOO")
+                        .containsEntry("pattern", "[a-z]+"))
+                .anySatisfy(document -> assertThat(document)
+                        .containsEntry("name", "BAR")
+                        .containsEntry("pattern", "%{FOO}[0-9]+"))
+                .noneSatisfy(document -> assertThat(document)
+                        .containsEntry("name", "BAR")
+                        .containsEntry("pattern", "[0-9]+"));
+
+        assertThat(subscriber.events)
+                .containsOnly(GrokPatternsChangedEvent.create(Collections.emptySet(), Collections.singleton("BAR")));
+    }
+
+    @Test
+    public void insertingDuplicateGrokPatternsIsNotPossibleAfterUpgrade() {
+        collection.insertOne(grokPattern("FOO", "[a-z]+"));
+
+        migration.upgrade();
+
+        assertThatThrownBy(() -> collection.insertOne(grokPattern("FOO", "[a-z]+")))
+                .isInstanceOf(DuplicateKeyException.class)
+                .hasMessageContaining("E11000 duplicate key error index: migration-test.grok_patterns.idx_name_asc_unique");
+    }
+
+    private Document grokPattern(String name, String pattern) {
+        return new Document()
+                .append("_id", new ObjectId())
+                .append("name", name)
+                .append("pattern", pattern);
+    }
+
+    private static class TestSubscriber {
+        public final List<GrokPatternsChangedEvent> events = new CopyOnWriteArrayList<>();
+
+        @Subscribe
+        public void handleGrokPatternsChangedEvent(GrokPatternsChangedEvent event) {
+            events.add(event);
+        }
+    }
+}


### PR DESCRIPTION
Up until now, it's possible to create Grok patterns with the same name, but different patterns.

This change set ensures that there are no duplicate Grok patterns by removing them in a migration and adding a unique index on the "name" field of the "grok_patterns" MongoDB collection.

Refs https://community.graylog.org/t/feature-import-grok-pattern-with-duplicate-management/5865