### PR TITLE
Add missing spacing in ExpandableListItem

### DIFF
--- a/graylog2-web-interface/src/components/common/ExpandableListItem.css
+++ b/graylog2-web-interface/src/components/common/ExpandableListItem.css
@@ -46,6 +46,7 @@
 
 :local(.subheader) {
     font-size: 0.95em;
+    margin-left: 0.5em;
     color: #aaaaaa;
 }
 


### PR DESCRIPTION
Add space between header and subheader.

Before:
<img width="330" alt="screen shot 2018-07-09 at 16 38 31" src="https://user-images.githubusercontent.com/716185/42456997-8a738348-8396-11e8-8574-e517834030c2.png">


After:
<img width="361" alt="screen shot 2018-07-09 at 16 36 46" src="https://user-images.githubusercontent.com/716185/42456938-63b1c3a0-8396-11e8-9aa8-49fee9bce336.png">
