### PR TITLE
Ensure mandatory parameters in search resources are valid

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/plugin/indexer/searches/timeranges/AbsoluteRange.java
+++ b/graylog2-server/src/main/java/org/graylog2/plugin/indexer/searches/timeranges/AbsoluteRange.java
@@ -20,6 +20,7 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 import com.google.auto.value.AutoValue;
+import com.google.common.base.Strings;
 import com.google.common.collect.ImmutableMap;
 import org.graylog2.plugin.Tools;
 import org.joda.time.DateTime;
@@ -96,7 +97,7 @@ public abstract class AbsoluteRange extends TimeRange {
             try {
                 return to(parseDateTime(to));
             } catch (IllegalArgumentException e) {
-                throw new InvalidRangeParametersException("Invalid end of range: " + to, e);
+                throw new InvalidRangeParametersException("Invalid end of range: <" + to + ">", e);
             }
         }
 
@@ -105,19 +106,23 @@ public abstract class AbsoluteRange extends TimeRange {
             try {
                 return from(parseDateTime(from));
             } catch (IllegalArgumentException e) {
-                throw new InvalidRangeParametersException("Invalid start of range: " + from, e);
+                throw new InvalidRangeParametersException("Invalid start of range: <" + from + ">", e);
             }
         }
 
-        private DateTime parseDateTime(String to) {
+        private DateTime parseDateTime(String s) {
+            if (Strings.isNullOrEmpty(s)) {
+                throw new IllegalArgumentException("Null or empty string");
+            }
+
             final DateTimeFormatter formatter;
-            if (to.contains("T")) {
+            if (s.contains("T")) {
                 formatter = ISODateTimeFormat.dateTime();
             } else {
                 formatter = Tools.timeFormatterWithOptionalMilliseconds();
             }
             // Use withOffsetParsed() to keep the timezone!
-            return formatter.withOffsetParsed().parseDateTime(to);
+            return formatter.withOffsetParsed().parseDateTime(s);
         }
     }
 }

--- a/graylog2-server/src/main/java/org/graylog2/rest/resources/search/AbsoluteSearchResource.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/resources/search/AbsoluteSearchResource.java
@@ -87,8 +87,10 @@ public class AbsoluteSearchResource extends SearchResource {
     public SearchResponse searchAbsolute(
             @ApiParam(name = "query", value = "Query (Lucene syntax)", required = true)
             @QueryParam("query") @NotEmpty String query,
-            @ApiParam(name = "from", value = "Timerange start. See description for date format", required = true) @QueryParam("from") String from,
-            @ApiParam(name = "to", value = "Timerange end. See description for date format", required = true) @QueryParam("to") String to,
+            @ApiParam(name = "from", value = "Timerange start. See description for date format", required = true)
+            @QueryParam("from") @NotEmpty String from,
+            @ApiParam(name = "to", value = "Timerange end. See description for date format", required = true)
+            @QueryParam("to") @NotEmpty String to,
             @ApiParam(name = "limit", value = "Maximum number of messages to return.", required = false) @QueryParam("limit") int limit,
             @ApiParam(name = "offset", value = "Offset", required = false) @QueryParam("offset") int offset,
             @ApiParam(name = "filter", value = "Filter", required = false) @QueryParam("filter") String filter,
@@ -128,12 +130,15 @@ public class AbsoluteSearchResource extends SearchResource {
     public ChunkedOutput<ScrollResult.ScrollChunk> searchAbsoluteChunked(
             @ApiParam(name = "query", value = "Query (Lucene syntax)", required = true)
             @QueryParam("query") @NotEmpty String query,
-            @ApiParam(name = "from", value = "Timerange start. See description for date format", required = true) @QueryParam("from") String from,
-            @ApiParam(name = "to", value = "Timerange end. See description for date format", required = true) @QueryParam("to") String to,
+            @ApiParam(name = "from", value = "Timerange start. See description for date format", required = true)
+            @QueryParam("from") @NotEmpty String from,
+            @ApiParam(name = "to", value = "Timerange end. See description for date format", required = true)
+            @QueryParam("to") @NotEmpty String to,
             @ApiParam(name = "limit", value = "Maximum number of messages to return.", required = false) @QueryParam("limit") int limit,
             @ApiParam(name = "offset", value = "Offset", required = false) @QueryParam("offset") int offset,
             @ApiParam(name = "filter", value = "Filter", required = false) @QueryParam("filter") String filter,
-            @ApiParam(name = "fields", value = "Comma separated list of fields to return", required = true) @QueryParam("fields") String fields) {
+            @ApiParam(name = "fields", value = "Comma separated list of fields to return", required = true)
+            @QueryParam("fields") @NotEmpty String fields) {
         checkSearchPermission(filter, RestPermissions.SEARCHES_ABSOLUTE);
 
         final List<String> fieldList = parseFields(fields);
@@ -157,12 +162,15 @@ public class AbsoluteSearchResource extends SearchResource {
     public Response exportSearchAbsoluteChunked(
             @ApiParam(name = "query", value = "Query (Lucene syntax)", required = true)
             @QueryParam("query") @NotEmpty String query,
-            @ApiParam(name = "from", value = "Timerange start. See description for date format", required = true) @QueryParam("from") String from,
-            @ApiParam(name = "to", value = "Timerange end. See description for date format", required = true) @QueryParam("to") String to,
+            @ApiParam(name = "from", value = "Timerange start. See description for date format", required = true)
+            @QueryParam("from") @NotEmpty String from,
+            @ApiParam(name = "to", value = "Timerange end. See description for date format", required = true)
+            @QueryParam("to") @NotEmpty String to,
             @ApiParam(name = "limit", value = "Maximum number of messages to return.", required = false) @QueryParam("limit") int limit,
             @ApiParam(name = "offset", value = "Offset", required = false) @QueryParam("offset") int offset,
             @ApiParam(name = "filter", value = "Filter", required = false) @QueryParam("filter") String filter,
-            @ApiParam(name = "fields", value = "Comma separated list of fields to return", required = true) @QueryParam("fields") String fields) {
+            @ApiParam(name = "fields", value = "Comma separated list of fields to return", required = true)
+            @QueryParam("fields") @NotEmpty String fields) {
         checkSearchPermission(filter, RestPermissions.SEARCHES_ABSOLUTE);
         final String filename = "graylog-search-result-absolute-" + from + "-" + to + ".csv";
         return Response
@@ -186,8 +194,10 @@ public class AbsoluteSearchResource extends SearchResource {
             @QueryParam("query") @NotEmpty String query,
             @ApiParam(name = "stacked_fields", value = "Fields to stack", required = false) @QueryParam("stacked_fields") String stackedFieldsParam,
             @ApiParam(name = "size", value = "Maximum number of terms to return", required = false) @QueryParam("size") int size,
-            @ApiParam(name = "from", value = "Timerange start. See search method description for date format", required = true) @QueryParam("from") String from,
-            @ApiParam(name = "to", value = "Timerange end. See search method description for date format", required = true) @QueryParam("to") String to,
+            @ApiParam(name = "from", value = "Timerange start. See search method description for date format", required = true)
+            @QueryParam("from") @NotEmpty String from,
+            @ApiParam(name = "to", value = "Timerange end. See search method description for date format", required = true)
+            @QueryParam("to") @NotEmpty String to,
             @ApiParam(name = "filter", value = "Filter", required = false) @QueryParam("filter") String filter,
             @ApiParam(name = "order", value = "Sorting (field:asc / field:desc)", required = false) @QueryParam("order") String order) {
         checkSearchPermission(filter, RestPermissions.SEARCHES_ABSOLUTE);
@@ -212,8 +222,10 @@ public class AbsoluteSearchResource extends SearchResource {
             @QueryParam("query") @NotEmpty String query,
             @ApiParam(name = "stacked_fields", value = "Fields to stack", required = false) @QueryParam("stacked_fields") String stackedFieldsParam,
             @ApiParam(name = "size", value = "Maximum number of terms to return", required = true) @QueryParam("size") @Min(1) int size,
-            @ApiParam(name = "from", value = "Timerange start. See search method description for date format", required = true) @QueryParam("from") String from,
-            @ApiParam(name = "to", value = "Timerange end. See search method description for date format", required = true) @QueryParam("to") String to,
+            @ApiParam(name = "from", value = "Timerange start. See search method description for date format", required = true)
+            @QueryParam("from") @NotEmpty String from,
+            @ApiParam(name = "to", value = "Timerange end. See search method description for date format", required = true)
+            @QueryParam("to") @NotEmpty String to,
             @ApiParam(name = "interval", value = "Histogram interval / bucket size. (year, quarter, month, week, day, hour or minute)", required = true)
             @QueryParam("interval") String interval,
             @ApiParam(name = "filter", value = "Filter", required = false) @QueryParam("filter") String filter,
@@ -245,8 +257,10 @@ public class AbsoluteSearchResource extends SearchResource {
             @ApiParam(name = "query", value = "Query (Lucene syntax)", required = true)
             @QueryParam("query") @NotEmpty String query,
             @ApiParam(name = "size", value = "Maximum number of terms to return", required = false) @QueryParam("size") int size,
-            @ApiParam(name = "from", value = "Timerange start. See search method description for date format", required = true) @QueryParam("from") String from,
-            @ApiParam(name = "to", value = "Timerange end. See search method description for date format", required = true) @QueryParam("to") String to,
+            @ApiParam(name = "from", value = "Timerange start. See search method description for date format", required = true)
+            @QueryParam("from") @NotEmpty String from,
+            @ApiParam(name = "to", value = "Timerange end. See search method description for date format", required = true)
+            @QueryParam("to") @NotEmpty String to,
             @ApiParam(name = "filter", value = "Filter", required = false) @QueryParam("filter") String filter) {
         checkSearchPermission(filter, RestPermissions.SEARCHES_ABSOLUTE);
 
@@ -277,8 +291,10 @@ public class AbsoluteSearchResource extends SearchResource {
             @QueryParam("field") @NotEmpty String field,
             @ApiParam(name = "query", value = "Query (Lucene syntax)", required = true)
             @QueryParam("query") @NotEmpty String query,
-            @ApiParam(name = "from", value = "Timerange start. See search method description for date format", required = true) @QueryParam("from") String from,
-            @ApiParam(name = "to", value = "Timerange end. See search method description for date format", required = true) @QueryParam("to") String to,
+            @ApiParam(name = "from", value = "Timerange start. See search method description for date format", required = true)
+            @QueryParam("from") @NotEmpty String from,
+            @ApiParam(name = "to", value = "Timerange end. See search method description for date format", required = true)
+            @QueryParam("to") @NotEmpty String to,
             @ApiParam(name = "filter", value = "Filter", required = false) @QueryParam("filter") String filter) {
         checkSearchPermission(filter, RestPermissions.SEARCHES_ABSOLUTE);
 
@@ -299,8 +315,10 @@ public class AbsoluteSearchResource extends SearchResource {
             @QueryParam("query") @NotEmpty String query,
             @ApiParam(name = "interval", value = "Histogram interval / bucket size. (year, quarter, month, week, day, hour or minute)", required = true)
             @QueryParam("interval") @NotEmpty String interval,
-            @ApiParam(name = "from", value = "Timerange start. See search method description for date format", required = true) @QueryParam("from") String from,
-            @ApiParam(name = "to", value = "Timerange end. See search method description for date format", required = true) @QueryParam("to") String to,
+            @ApiParam(name = "from", value = "Timerange start. See search method description for date format", required = true)
+            @QueryParam("from") @NotEmpty String from,
+            @ApiParam(name = "to", value = "Timerange end. See search method description for date format", required = true)
+            @QueryParam("to") @NotEmpty String to,
             @ApiParam(name = "filter", value = "Filter", required = false) @QueryParam("filter") String filter) {
         checkSearchPermission(filter, RestPermissions.SEARCHES_ABSOLUTE);
 
@@ -334,8 +352,10 @@ public class AbsoluteSearchResource extends SearchResource {
             @QueryParam("field") @NotEmpty String field,
             @ApiParam(name = "interval", value = "Histogram interval / bucket size. (year, quarter, month, week, day, hour or minute)", required = true)
             @QueryParam("interval") @NotEmpty String interval,
-            @ApiParam(name = "from", value = "Timerange start. See search method description for date format", required = true) @QueryParam("from") String from,
-            @ApiParam(name = "to", value = "Timerange end. See search method description for date format", required = true) @QueryParam("to") String to,
+            @ApiParam(name = "from", value = "Timerange start. See search method description for date format", required = true)
+            @QueryParam("from") @NotEmpty String from,
+            @ApiParam(name = "to", value = "Timerange end. See search method description for date format", required = true)
+            @QueryParam("to") @NotEmpty String to,
             @ApiParam(name = "filter", value = "Filter", required = false) @QueryParam("filter") String filter,
             @ApiParam(name = "cardinality", value = "Calculate the cardinality of the field as well", required = false) @QueryParam("cardinality") boolean includeCardinality
     ) {
@@ -346,7 +366,6 @@ public class AbsoluteSearchResource extends SearchResource {
 
         return buildHistogramResult(fieldHistogram(field, query, interval, filter, buildAbsoluteTimeRange(from, to),
                                                    includeCardinality));
-
     }
 
     private TimeRange buildAbsoluteTimeRange(String from, String to) {

--- a/graylog2-server/src/main/java/org/graylog2/rest/resources/search/DecoratorResource.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/resources/search/DecoratorResource.java
@@ -33,6 +33,8 @@ import org.graylog2.shared.rest.resources.RestResource;
 import org.graylog2.shared.security.RestPermissions;
 
 import javax.inject.Inject;
+import javax.validation.Valid;
+import javax.validation.constraints.NotNull;
 import javax.ws.rs.Consumes;
 import javax.ws.rs.DELETE;
 import javax.ws.rs.GET;
@@ -64,8 +66,7 @@ public class DecoratorResource extends RestResource {
 
     @GET
     @Timed
-    @ApiOperation(value = "Returns all configured message decorations",
-        notes = "")
+    @ApiOperation(value = "Returns all configured message decorations")
     public List<Decorator> get() {
         checkPermission(RestPermissions.DECORATORS_READ);
         return this.decoratorService.findAll();
@@ -91,7 +92,7 @@ public class DecoratorResource extends RestResource {
     @Timed
     @ApiOperation(value = "Creates a message decoration configuration")
     @AuditEvent(type = AuditEventTypes.MESSAGE_DECORATOR_CREATE)
-    public Decorator create(@ApiParam(name = "JSON body", required = true) DecoratorImpl decorator) {
+    public Decorator create(@ApiParam(name = "JSON body", required = true) @Valid @NotNull DecoratorImpl decorator) {
         checkPermission(RestPermissions.DECORATORS_CREATE);
         if (decorator.stream().isPresent()) {
             checkPermission(RestPermissions.STREAMS_EDIT, decorator.stream().get());
@@ -119,8 +120,10 @@ public class DecoratorResource extends RestResource {
     @Timed
     @ApiOperation(value = "Update a decorator")
     @AuditEvent(type = AuditEventTypes.MESSAGE_DECORATOR_UPDATE)
-    public Decorator update(@ApiParam(name = "decorator id", required = true) @PathParam("decoratorId") final String decoratorId,
-                            @ApiParam(name = "JSON body", required = true) DecoratorImpl decorator) throws NotFoundException {
+    public Decorator update(@ApiParam(name = "decorator id", required = true)
+                            @PathParam("decoratorId") final String decoratorId,
+                            @ApiParam(name = "JSON body", required = true)
+                            @Valid @NotNull DecoratorImpl decorator) throws NotFoundException {
         final Decorator originalDecorator = decoratorService.findById(decoratorId);
         checkPermission(RestPermissions.DECORATORS_CREATE);
         if (originalDecorator.stream().isPresent()) {

--- a/graylog2-server/src/main/java/org/graylog2/rest/resources/search/KeywordSearchResource.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/resources/search/KeywordSearchResource.java
@@ -126,11 +126,13 @@ public class KeywordSearchResource extends SearchResource {
     public ChunkedOutput<ScrollResult.ScrollChunk> searchKeywordChunked(
             @ApiParam(name = "query", value = "Query (Lucene syntax)", required = true)
             @QueryParam("query") @NotEmpty String query,
-            @ApiParam(name = "keyword", value = "Range keyword", required = true) @QueryParam("keyword") String keyword,
+            @ApiParam(name = "keyword", value = "Range keyword", required = true)
+            @QueryParam("keyword") @NotEmpty String keyword,
             @ApiParam(name = "limit", value = "Maximum number of messages to return.", required = false) @QueryParam("limit") int limit,
             @ApiParam(name = "offset", value = "Offset", required = false) @QueryParam("offset") int offset,
             @ApiParam(name = "filter", value = "Filter", required = false) @QueryParam("filter") String filter,
-            @ApiParam(name = "fields", value = "Comma separated list of fields to return", required = true) @QueryParam("fields") String fields) {
+            @ApiParam(name = "fields", value = "Comma separated list of fields to return", required = true)
+            @QueryParam("fields") @NotEmpty String fields) {
         checkSearchPermission(filter, RestPermissions.SEARCHES_KEYWORD);
 
         final List<String> fieldList = parseFields(fields);
@@ -153,11 +155,13 @@ public class KeywordSearchResource extends SearchResource {
     public Response exportSearchKeywordChunked(
             @ApiParam(name = "query", value = "Query (Lucene syntax)", required = true)
             @QueryParam("query") @NotEmpty String query,
-            @ApiParam(name = "keyword", value = "Range keyword", required = true) @QueryParam("keyword") String keyword,
+            @ApiParam(name = "keyword", value = "Range keyword", required = true)
+            @QueryParam("keyword") @NotEmpty String keyword,
             @ApiParam(name = "limit", value = "Maximum number of messages to return.", required = false) @QueryParam("limit") int limit,
             @ApiParam(name = "offset", value = "Offset", required = false) @QueryParam("offset") int offset,
             @ApiParam(name = "filter", value = "Filter", required = false) @QueryParam("filter") String filter,
-            @ApiParam(name = "fields", value = "Comma separated list of fields to return", required = true) @QueryParam("fields") String fields) {
+            @ApiParam(name = "fields", value = "Comma separated list of fields to return", required = true)
+            @QueryParam("fields") @NotEmpty String fields) {
         checkSearchPermission(filter, RestPermissions.SEARCHES_KEYWORD);
         final String filename = "graylog-search-result-keyword-" + keyword + ".csv";
         return Response
@@ -180,7 +184,8 @@ public class KeywordSearchResource extends SearchResource {
             @QueryParam("query") @NotEmpty String query,
             @ApiParam(name = "interval", value = "Histogram interval / bucket size. (year, quarter, month, week, day, hour or minute)", required = true)
             @QueryParam("interval") @NotEmpty String interval,
-            @ApiParam(name = "keyword", value = "Range keyword", required = true) @QueryParam("keyword") String keyword,
+            @ApiParam(name = "keyword", value = "Range keyword", required = true)
+            @QueryParam("keyword") @NotEmpty String keyword,
             @ApiParam(name = "filter", value = "Filter", required = false) @QueryParam("filter") String filter) {
         checkSearchPermission(filter, RestPermissions.SEARCHES_KEYWORD);
 
@@ -212,7 +217,8 @@ public class KeywordSearchResource extends SearchResource {
             @QueryParam("query") @NotEmpty String query,
             @ApiParam(name = "stacked_fields", value = "Fields to stack", required = false) @QueryParam("stacked_fields") String stackedFieldsParam,
             @ApiParam(name = "size", value = "Maximum number of terms to return", required = false) @QueryParam("size") int size,
-            @ApiParam(name = "keyword", value = "Range keyword", required = true) @QueryParam("keyword") String keyword,
+            @ApiParam(name = "keyword", value = "Range keyword", required = true)
+            @QueryParam("keyword") @NotEmpty String keyword,
             @ApiParam(name = "filter", value = "Filter", required = false) @QueryParam("filter") String filter,
             @ApiParam(name = "order", value = "Sorting (field:asc / field:desc)", required = false) @QueryParam("order") String order) {
         checkSearchPermission(filter, RestPermissions.SEARCHES_KEYWORD);
@@ -236,8 +242,10 @@ public class KeywordSearchResource extends SearchResource {
             @ApiParam(name = "query", value = "Query (Lucene syntax)", required = true)
             @QueryParam("query") @NotEmpty String query,
             @ApiParam(name = "stacked_fields", value = "Fields to stack", required = false) @QueryParam("stacked_fields") String stackedFieldsParam,
-            @ApiParam(name = "size", value = "Maximum number of terms to return", required = true) @QueryParam("size") @Min(1) int size,
-            @ApiParam(name = "keyword", value = "Range keyword", required = true) @QueryParam("keyword") String keyword,
+            @ApiParam(name = "size", value = "Maximum number of terms to return", required = true)
+            @QueryParam("size") @Min(1) int size,
+            @ApiParam(name = "keyword", value = "Range keyword", required = true)
+            @QueryParam("keyword") @NotEmpty String keyword,
             @ApiParam(name = "interval", value = "Histogram interval / bucket size. (year, quarter, month, week, day, hour or minute)", required = true)
             @QueryParam("interval") String interval,
             @ApiParam(name = "filter", value = "Filter", required = false) @QueryParam("filter") String filter,
@@ -269,7 +277,8 @@ public class KeywordSearchResource extends SearchResource {
             @ApiParam(name = "query", value = "Query (Lucene syntax)", required = true)
             @QueryParam("query") @NotEmpty String query,
             @ApiParam(name = "size", value = "Maximum number of terms to return", required = false) @QueryParam("size") int size,
-            @ApiParam(name = "keyword", value = "Keyword timeframe", required = true) @QueryParam("keyword") String keyword,
+            @ApiParam(name = "keyword", value = "Keyword timeframe", required = true)
+            @QueryParam("keyword") @NotEmpty String keyword,
             @ApiParam(name = "filter", value = "Filter", required = false) @QueryParam("filter") String filter) {
         checkSearchPermission(filter, RestPermissions.SEARCHES_KEYWORD);
 
@@ -294,7 +303,8 @@ public class KeywordSearchResource extends SearchResource {
             @QueryParam("field") @NotEmpty String field,
             @ApiParam(name = "query", value = "Query (Lucene syntax)", required = true)
             @QueryParam("query") @NotEmpty String query,
-            @ApiParam(name = "keyword", value = "Range keyword", required = true) @QueryParam("keyword") String keyword,
+            @ApiParam(name = "keyword", value = "Range keyword", required = true)
+            @QueryParam("keyword") @NotEmpty String keyword,
             @ApiParam(name = "filter", value = "Filter", required = false) @QueryParam("filter") String filter) {
         checkSearchPermission(filter, RestPermissions.SEARCHES_KEYWORD);
 
@@ -318,7 +328,8 @@ public class KeywordSearchResource extends SearchResource {
             @QueryParam("field") @NotEmpty String field,
             @ApiParam(name = "interval", value = "Histogram interval / bucket size. (year, quarter, month, week, day, hour or minute)", required = true)
             @QueryParam("interval") @NotEmpty String interval,
-            @ApiParam(name = "keyword", value = "Range keyword", required = true) @QueryParam("keyword") String keyword,
+            @ApiParam(name = "keyword", value = "Range keyword", required = true)
+            @QueryParam("keyword") @NotEmpty String keyword,
             @ApiParam(name = "filter", value = "Filter", required = false) @QueryParam("filter") String filter,
             @ApiParam(name = "cardinality", value = "Calculate the cardinality of the field as well", required = false) @QueryParam("cardinality") boolean includeCardinality
     ) {

--- a/graylog2-server/src/main/java/org/graylog2/rest/resources/search/RelativeSearchResource.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/resources/search/RelativeSearchResource.java
@@ -48,6 +48,7 @@ import org.slf4j.LoggerFactory;
 import javax.inject.Inject;
 import javax.validation.constraints.Min;
 import javax.validation.constraints.NotEmpty;
+import javax.validation.constraints.PositiveOrZero;
 import javax.ws.rs.BadRequestException;
 import javax.ws.rs.DefaultValue;
 import javax.ws.rs.GET;
@@ -88,7 +89,8 @@ public class RelativeSearchResource extends SearchResource {
     public SearchResponse searchRelative(
             @ApiParam(name = "query", value = "Query (Lucene syntax)", required = true)
             @QueryParam("query") @NotEmpty String query,
-            @ApiParam(name = "range", value = "Relative timeframe to search in. See method description.", required = true) @QueryParam("range") int range,
+            @ApiParam(name = "range", value = "Relative timeframe to search in. See method description.", required = true)
+            @QueryParam("range") @PositiveOrZero int range,
             @ApiParam(name = "limit", value = "Maximum number of messages to return.", required = false) @QueryParam("limit") int limit,
             @ApiParam(name = "offset", value = "Offset", required = false) @QueryParam("offset") int offset,
             @ApiParam(name = "filter", value = "Filter", required = false) @QueryParam("filter") String filter,
@@ -128,11 +130,13 @@ public class RelativeSearchResource extends SearchResource {
     public ChunkedOutput<ScrollResult.ScrollChunk> searchRelativeChunked(
             @ApiParam(name = "query", value = "Query (Lucene syntax)", required = true)
             @QueryParam("query") @NotEmpty String query,
-            @ApiParam(name = "range", value = "Relative timeframe to search in. See method description.", required = true) @QueryParam("range") int range,
+            @ApiParam(name = "range", value = "Relative timeframe to search in. See method description.", required = true)
+            @QueryParam("range") @PositiveOrZero int range,
             @ApiParam(name = "limit", value = "Maximum number of messages to return.", required = false) @QueryParam("limit") int limit,
             @ApiParam(name = "offset", value = "Offset", required = false) @QueryParam("offset") int offset,
             @ApiParam(name = "filter", value = "Filter", required = false) @QueryParam("filter") String filter,
-            @ApiParam(name = "fields", value = "Comma separated list of fields to return", required = true) @QueryParam("fields") String fields) {
+            @ApiParam(name = "fields", value = "Comma separated list of fields to return", required = true)
+            @QueryParam("fields") @NotEmpty String fields) {
         checkSearchPermission(filter, RestPermissions.SEARCHES_RELATIVE);
 
         final List<String> fieldList = parseFields(fields);
@@ -156,11 +160,13 @@ public class RelativeSearchResource extends SearchResource {
     public Response exportSearchRelativeChunked(
             @ApiParam(name = "query", value = "Query (Lucene syntax)", required = true)
             @QueryParam("query") @NotEmpty String query,
-            @ApiParam(name = "range", value = "Relative timeframe to search in. See method description.", required = true) @QueryParam("range") int range,
+            @ApiParam(name = "range", value = "Relative timeframe to search in. See method description.", required = true)
+            @QueryParam("range") @PositiveOrZero int range,
             @ApiParam(name = "limit", value = "Maximum number of messages to return.", required = false) @QueryParam("limit") int limit,
             @ApiParam(name = "offset", value = "Offset", required = false) @QueryParam("offset") int offset,
             @ApiParam(name = "filter", value = "Filter", required = false) @QueryParam("filter") String filter,
-            @ApiParam(name = "fields", value = "Comma separated list of fields to return", required = true) @QueryParam("fields") String fields) {
+            @ApiParam(name = "fields", value = "Comma separated list of fields to return", required = true)
+            @QueryParam("fields") @NotEmpty String fields) {
         checkSearchPermission(filter, RestPermissions.SEARCHES_RELATIVE);
         final String filename = "graylog-search-result-relative-" + range + ".csv";
         return Response
@@ -184,7 +190,8 @@ public class RelativeSearchResource extends SearchResource {
             @QueryParam("query") @NotEmpty String query,
             @ApiParam(name = "stacked_fields", value = "Fields to stack", required = false) @QueryParam("stacked_fields") String stackedFieldsParam,
             @ApiParam(name = "size", value = "Maximum number of terms to return", required = false) @QueryParam("size") int size,
-            @ApiParam(name = "range", value = "Relative timeframe to search in. See search method description.", required = true) @QueryParam("range") int range,
+            @ApiParam(name = "range", value = "Relative timeframe to search in. See search method description.", required = true)
+            @QueryParam("range") @PositiveOrZero int range,
             @ApiParam(name = "filter", value = "Filter", required = false) @QueryParam("filter") String filter,
             @ApiParam(name = "order", value = "Sorting (field:asc / field:desc)", required = false) @QueryParam("order") String order) {
         checkSearchPermission(filter, RestPermissions.SEARCHES_RELATIVE);
@@ -208,8 +215,10 @@ public class RelativeSearchResource extends SearchResource {
             @ApiParam(name = "query", value = "Query (Lucene syntax)", required = true)
             @QueryParam("query") @NotEmpty String query,
             @ApiParam(name = "stacked_fields", value = "Fields to stack", required = false) @QueryParam("stacked_fields") String stackedFieldsParam,
-            @ApiParam(name = "size", value = "Maximum number of terms to return", required = true) @QueryParam("size") @Min(1) int size,
-            @ApiParam(name = "range", value = "Relative timeframe to search in. See search method description.", required = true) @QueryParam("range") int range,
+            @ApiParam(name = "size", value = "Maximum number of terms to return", required = true)
+            @QueryParam("size") @Min(1) int size,
+            @ApiParam(name = "range", value = "Relative timeframe to search in. See search method description.", required = true)
+            @QueryParam("range") @PositiveOrZero int range,
             @ApiParam(name = "interval", value = "Histogram interval / bucket size. (year, quarter, month, week, day, hour or minute)", required = false)
             @QueryParam("interval") String interval,
             @ApiParam(name = "filter", value = "Filter", required = false) @QueryParam("filter") String filter,
@@ -241,7 +250,8 @@ public class RelativeSearchResource extends SearchResource {
             @ApiParam(name = "query", value = "Query (Lucene syntax)", required = true)
             @QueryParam("query") @NotEmpty String query,
             @ApiParam(name = "size", value = "Maximum number of terms to return", required = false) @QueryParam("size") int size,
-            @ApiParam(name = "range", value = "Relative timeframe to search in. See search method description.", required = true) @QueryParam("range") int range,
+            @ApiParam(name = "range", value = "Relative timeframe to search in. See search method description.", required = true)
+            @QueryParam("range") @PositiveOrZero int range,
             @ApiParam(name = "filter", value = "Filter", required = false) @QueryParam("filter") String filter) {
         checkSearchPermission(filter, RestPermissions.SEARCHES_RELATIVE);
 
@@ -266,7 +276,8 @@ public class RelativeSearchResource extends SearchResource {
             @QueryParam("field") @NotEmpty String field,
             @ApiParam(name = "query", value = "Query (Lucene syntax)", required = true)
             @QueryParam("query") @NotEmpty String query,
-            @ApiParam(name = "range", value = "Relative timeframe to search in. See search method description.", required = true) @QueryParam("range") int range,
+            @ApiParam(name = "range", value = "Relative timeframe to search in. See search method description.", required = true)
+            @QueryParam("range") @PositiveOrZero int range,
             @ApiParam(name = "filter", value = "Filter", required = false) @QueryParam("filter") String filter) {
         checkSearchPermission(filter, RestPermissions.SEARCHES_RELATIVE);
 
@@ -287,7 +298,8 @@ public class RelativeSearchResource extends SearchResource {
             @QueryParam("query") @NotEmpty String query,
             @ApiParam(name = "interval", value = "Histogram interval / bucket size. (year, quarter, month, week, day, hour or minute)", required = true)
             @QueryParam("interval") @NotEmpty String interval,
-            @ApiParam(name = "range", value = "Relative timeframe to search in. See search method description.", required = true) @QueryParam("range") int range,
+            @ApiParam(name = "range", value = "Relative timeframe to search in. See search method description.", required = true)
+            @QueryParam("range") @PositiveOrZero int range,
             @ApiParam(name = "filter", value = "Filter", required = false) @QueryParam("filter") String filter) {
         checkSearchPermission(filter, RestPermissions.SEARCHES_RELATIVE);
 
@@ -321,7 +333,8 @@ public class RelativeSearchResource extends SearchResource {
             @QueryParam("field") @NotEmpty String field,
             @ApiParam(name = "interval", value = "Histogram interval / bucket size. (year, quarter, month, week, day, hour or minute)", required = true)
             @QueryParam("interval") @NotEmpty String interval,
-            @ApiParam(name = "range", value = "Relative timeframe to search in. See search method description.", required = true) @QueryParam("range") int range,
+            @ApiParam(name = "range", value = "Relative timeframe to search in. See search method description.", required = true)
+            @QueryParam("range") @PositiveOrZero int range,
             @ApiParam(name = "filter", value = "Filter", required = false) @QueryParam("filter") String filter,
             @ApiParam(name = "cardinality", value = "Calculate the cardinality of the field as well", required = false) @QueryParam("cardinality") boolean includeCardinality
     ) {

--- a/graylog2-server/src/main/java/org/graylog2/rest/resources/search/SavedSearchesResource.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/resources/search/SavedSearchesResource.java
@@ -41,6 +41,7 @@ import org.graylog2.shared.security.RestPermissions;
 
 import javax.inject.Inject;
 import javax.validation.Valid;
+import javax.validation.constraints.NotNull;
 import javax.ws.rs.BadRequestException;
 import javax.ws.rs.Consumes;
 import javax.ws.rs.DELETE;
@@ -80,7 +81,7 @@ public class SavedSearchesResource extends SearchResource {
     @ApiResponse(code = 400, message = "Validation error")
     @AuditEvent(type = AuditEventTypes.SAVED_SEARCH_CREATE)
     public Response create(@ApiParam(name = "JSON body", required = true)
-                           @Valid CreateSavedSearchRequest cr) throws ValidationException {
+                           @Valid @NotNull CreateSavedSearchRequest cr) throws ValidationException {
         if (!isTitleTaken("", cr.title())) {
             final String msg = "Cannot save search " + cr.title() + ". Title is already taken.";
             throw new BadRequestException(msg);
@@ -129,7 +130,7 @@ public class SavedSearchesResource extends SearchResource {
     public Map<String, Object> update(@ApiParam(name = "searchId", required = true)
                                       @PathParam("searchId") String searchId,
                                       @ApiParam(name = "JSON body", required = true)
-                                      @Valid CreateSavedSearchRequest cr) throws NotFoundException, ValidationException {
+                                      @Valid @NotNull CreateSavedSearchRequest cr) throws NotFoundException, ValidationException {
         final SavedSearch search = savedSearchService.load(searchId);
 
         if (!isTitleTaken(searchId, cr.title())) {

--- a/graylog2-server/src/test/java/org/graylog2/plugin/indexer/searches/timeranges/AbsoluteRangeTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/plugin/indexer/searches/timeranges/AbsoluteRangeTest.java
@@ -20,6 +20,7 @@ import org.joda.time.format.ISODateTimeFormat;
 import org.junit.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 public class AbsoluteRangeTest {
     @Test
@@ -38,5 +39,21 @@ public class AbsoluteRangeTest {
                 .isEqualTo("2016-03-24T00:00:00.000+09:00");
         assertThat(range2.to().toString(ISODateTimeFormat.dateTime()))
                 .isEqualTo("2016-03-24T23:59:59.000+09:00");
+    }
+
+    @Test
+    public void nullOrEmptyStringsThrowException() {
+        assertThatThrownBy(() -> AbsoluteRange.create(null, "2018-07-11T14:32:00.000Z"))
+                .isInstanceOf(InvalidRangeParametersException.class)
+                .hasMessage("Invalid start of range: <null>");
+        assertThatThrownBy(() -> AbsoluteRange.create("", "2018-07-11T14:32:00.000Z"))
+                .isInstanceOf(InvalidRangeParametersException.class)
+                .hasMessage("Invalid start of range: <>");
+        assertThatThrownBy(() -> AbsoluteRange.create("2018-07-11T14:32:00.000Z", null))
+                .isInstanceOf(InvalidRangeParametersException.class)
+                .hasMessage("Invalid end of range: <null>");
+        assertThatThrownBy(() -> AbsoluteRange.create("2018-07-11T14:32:00.000Z", ""))
+                .isInstanceOf(InvalidRangeParametersException.class)
+                .hasMessage("Invalid end of range: <>");
     }
 }


### PR DESCRIPTION
Mandatory query parameters in search resources, such as "from" and "to" in AbsoluteSearchResource, "range" in RelativeSearchResource, or "keyword" in KeywordSearchResource, weren't checked for basic validity (i. e. not null, empty, or negative) leading to unfriendly error messages for users sending invalid requests to one of these resources.

Refs https://community.graylog.org/t/api-search-universal-absolute-500-response-on-providing-query-in-params-field/5937