### PR TITLE
Escape Typeahead templates content

### DIFF
--- a/graylog2-web-interface/src/components/common/TypeAheadInput.jsx
+++ b/graylog2-web-interface/src/components/common/TypeAheadInput.jsx
@@ -2,8 +2,10 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import ReactDOM from 'react-dom';
 import { Input } from 'components/bootstrap';
-import UniversalSearch from 'logic/search/UniversalSearch';
+import lodash from 'lodash';
 import $ from 'jquery';
+
+import UniversalSearch from 'logic/search/UniversalSearch';
 // eslint-disable-next-line no-unused-vars
 import Typeahead from 'typeahead.js';
 
@@ -100,10 +102,11 @@ class TypeAheadInput extends React.Component {
       source: UniversalSearch.substringMatcher(props.suggestions, props.displayKey, 6),
       templates: {
         suggestion: (value) => {
+          // Escape all text here that may be user-generated, since this is not automatically escaped by React.
           if (props.suggestionText) {
-            return `<div><strong>${props.suggestionText}</strong> ${value[props.displayKey]}</div>`;
+            return `<div><strong>${lodash.escape(props.suggestionText)}</strong> ${lodash.escape(value[props.displayKey])}</div>`;
           }
-          return `<div>${value[props.displayKey]}</div>`;
+          return `<div>${lodash.escape(value[props.displayKey])}</div>`;
         },
       },
     });

--- a/graylog2-web-interface/src/components/search/QueryInput.ts
+++ b/graylog2-web-interface/src/components/search/QueryInput.ts
@@ -5,6 +5,7 @@ const FieldsStore = StoreProvider.getStore('Fields');
 import queryParser = require('../../logic/search/queryParser');
 import SerializeVisitor = require('../../logic/search/visitors/SerializeVisitor');
 import DumpVisitor = require('../../logic/search/visitors/DumpVisitor');
+import lodash = require('lodash');
 const $ = require('jquery');
 const Typeahead = require('typeahead.js');
 
@@ -42,14 +43,14 @@ class QueryInput {
             displayKey: this.displayKey,
             source: this.codeCompletionProvider.bind(this),
             templates: {
-                // TODO: highlight errors on suggestions once query parser is completed
-                suggestion: (match: Match) => {
-                    var previousTerms = match.prefix;
-                    var matchPrefix = match.match.substring(0, match.match.indexOf(match.currentSegment));
-                    var currentMatch = match.currentSegment;
-                    var matchSuffix = match.match.substring(match.match.indexOf(match.currentSegment) + match.currentSegment.length);
-                    return '<p><strong>' + previousTerms + '</strong>' + matchPrefix + '<strong>' + currentMatch + '</strong>' + matchSuffix + '</p>';
-                }
+              // Escape all text here that may be user-generated, since this is not automatically escaped by React.
+              suggestion: (match: Match) => {
+                const previousTerms = match.prefix;
+                const matchPrefix = match.match.substring(0, match.match.indexOf(match.currentSegment));
+                const currentMatch = match.currentSegment;
+                const matchSuffix = match.match.substring(match.match.indexOf(match.currentSegment) + match.currentSegment.length);
+                return `<p><strong>${lodash.escape(previousTerms)}</strong>${lodash.escape(matchPrefix)}<strong>${lodash.escape(currentMatch)}</strong>${lodash.escape(matchSuffix)}</p>`;
+              }
             }
         };
     }


### PR DESCRIPTION
Escape content of templates used to draw Typeahead suggestions.

This change needs to be backported to the 2.4 branch.