### PR TITLE
Sidecar collector rename

### DIFF
--- a/graylog2-server/src/main/java/org/graylog/plugins/sidecar/rest/models/CollectorStatus.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/sidecar/rest/models/CollectorStatus.java
@@ -24,8 +24,8 @@ import com.google.auto.value.AutoValue;
 @AutoValue
 @JsonAutoDetect
 public abstract class CollectorStatus {
-    @JsonProperty("name")
-    public abstract String name();
+    @JsonProperty("collector_id")
+    public abstract String collectorId();
 
     @JsonProperty("status")
     public abstract int status();
@@ -34,9 +34,9 @@ public abstract class CollectorStatus {
     public abstract String message();
 
     @JsonCreator
-    public static CollectorStatus create(@JsonProperty("name") String name,
+    public static CollectorStatus create(@JsonProperty("collector_id") String collectorId,
                                          @JsonProperty("status") int status,
                                          @JsonProperty("message") String message) {
-        return new AutoValue_CollectorStatus(name, status, message);
+        return new AutoValue_CollectorStatus(collectorId, status, message);
     }
 }

--- a/graylog2-server/src/main/java/org/graylog/plugins/sidecar/rest/models/CollectorSummary.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/sidecar/rest/models/CollectorSummary.java
@@ -36,16 +36,12 @@ public abstract class CollectorSummary {
     @JsonProperty("node_operating_system")
     public abstract String nodeOperatingSystem();
 
-    @JsonProperty("default_template")
-    public abstract String defaultTemplate();
-
     @JsonCreator
     public static CollectorSummary create(@JsonProperty("id") String id,
                                           @JsonProperty("name") String name,
                                           @JsonProperty("service_type") String serviceType,
-                                          @JsonProperty("node_operating_system") String nodeOperatingSystem,
-                                          @JsonProperty("default_template") String defaultTemplate) {
-        return new AutoValue_CollectorSummary(id, name, serviceType, nodeOperatingSystem, defaultTemplate);
+                                          @JsonProperty("node_operating_system") String nodeOperatingSystem) {
+        return new AutoValue_CollectorSummary(id, name, serviceType, nodeOperatingSystem);
     }
 
     public static CollectorSummary create(Collector collector) {
@@ -53,7 +49,6 @@ public abstract class CollectorSummary {
                 collector.id(),
                 collector.name(),
                 collector.serviceType(),
-                collector.nodeOperatingSystem(),
-                collector.defaultTemplate());
+                collector.nodeOperatingSystem());
     }
 }

--- a/graylog2-web-interface/src/components/sidecars/sidecars/SidecarStatus.jsx
+++ b/graylog2-web-interface/src/components/sidecars/sidecars/SidecarStatus.jsx
@@ -1,24 +1,18 @@
 import React from 'react';
 import createReactClass from 'create-react-class';
-import Reflux from 'reflux';
 import PropTypes from 'prop-types';
 import lodash from 'lodash';
 import { Col, Row } from 'react-bootstrap';
 
-import CombinedProvider from 'injection/CombinedProvider';
 import SidecarStatusFileList from './SidecarStatusFileList';
 
-const { CollectorsStore, CollectorsActions } = CombinedProvider.get('Collectors');
-
 const SidecarStatus = createReactClass({
-  mixins: [Reflux.connect(CollectorsStore)],
-
   propTypes: {
     sidecar: PropTypes.object.isRequired,
+    collectors: PropTypes.array.isRequired,
   },
 
   componentDidMount() {
-    this.loadCollectors();
     this.style.use();
   },
 
@@ -27,10 +21,6 @@ const SidecarStatus = createReactClass({
   },
 
   style: require('!style/useable!css!../styles/SidecarStyles.css'),
-
-  loadCollectors() {
-    CollectorsActions.all();
-  },
 
   formatNodeDetails(details) {
     if (!details) {
@@ -56,8 +46,7 @@ const SidecarStatus = createReactClass({
     );
   },
 
-  formatCollectorStatus(details) {
-    const { collectors } = this.state;
+  formatCollectorStatus(details, collectors) {
     if (!details || !collectors) {
       return <p>Collectors status are currently unavailable. Please wait a moment and ensure the sidecar is correctly connected to the server.</p>;
     }
@@ -127,7 +116,7 @@ const SidecarStatus = createReactClass({
           <Col md={12}>
             <h2>Collectors status</h2>
             <div className="top-margin">
-              {this.formatCollectorStatus(sidecar.node_details)}
+              {this.formatCollectorStatus(sidecar.node_details, this.props.collectors)}
             </div>
           </Col>
         </Row>

--- a/graylog2-web-interface/src/components/sidecars/sidecars/SidecarStatusFileList.jsx
+++ b/graylog2-web-interface/src/components/sidecars/sidecars/SidecarStatusFileList.jsx
@@ -44,7 +44,7 @@ class SidecarStatusFileList extends React.Component {
 
   render() {
     var filterKeys = [];
-    var headers = ["Mo2dified", "Size", "Path"];
+    var headers = ["Modified", "Size", "Path"];
 
     return (
       <div>

--- a/graylog2-web-interface/src/pages/SidecarStatusPage.jsx
+++ b/graylog2-web-interface/src/pages/SidecarStatusPage.jsx
@@ -13,6 +13,7 @@ import Routes from 'routing/Routes';
 import SidecarStatus from 'components/sidecars/sidecars/SidecarStatus';
 
 const { SidecarsActions } = CombinedProvider.get('Sidecars');
+const { CollectorsActions } = CombinedProvider.get('Collectors');
 
 class SidecarStatusPage extends React.Component {
   static propTypes = {
@@ -25,6 +26,7 @@ class SidecarStatusPage extends React.Component {
 
   componentDidMount() {
     this.reloadSidecar();
+    this.reloadCollectors();
     this.interval = setInterval(this.reloadSidecar, 5000);
   }
 
@@ -38,8 +40,13 @@ class SidecarStatusPage extends React.Component {
     SidecarsActions.getSidecar(this.props.params.sidecarId).then(sidecar => this.setState({ sidecar }));
   };
 
+  reloadCollectors() {
+    CollectorsActions.all().then(collectors => this.setState({ collectors }));
+  };
+
   render() {
     const sidecar = this.state.sidecar;
+    const collectors = this.state.collectors;
     const isLoading = !sidecar;
 
     if (isLoading) {
@@ -72,7 +79,7 @@ class SidecarStatusPage extends React.Component {
             </ButtonToolbar>
           </PageHeader>
 
-          <SidecarStatus sidecar={sidecar} />
+          <SidecarStatus sidecar={sidecar} collectors={collectors} />
         </span>
       </DocumentTitle>
     );


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Related to https://github.com/Graylog2/collector-sidecar/pull/262
Fixes https://github.com/Graylog2/collector-sidecar/issues/255

## Description
After merging https://github.com/Graylog2/collector-sidecar/pull/262 the Sidecar will only report the Collector-ID in the corresponding status response. So we have to change the response model as well as the frontend to resolve the ID to an actual collector name on the status page.
