### PR TITLE
Fix potential NullPointerException in csv and maxmind data adapters

### DIFF
--- a/graylog2-server/src/main/java/org/graylog/plugins/map/geoip/MaxmindDataAdapter.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/map/geoip/MaxmindDataAdapter.java
@@ -69,7 +69,7 @@ public class MaxmindDataAdapter extends LookupDataAdapter {
     public static final String NAME = "maxmind_geoip";
     private final Config config;
     private final AtomicReference<DatabaseReader> databaseReader = new AtomicReference<>();
-    private FileInfo fileInfo;
+    private FileInfo fileInfo = FileInfo.empty();
 
     @Inject
     protected MaxmindDataAdapter(@Assisted("id") String id,

--- a/graylog2-server/src/main/java/org/graylog2/lookup/adapters/CSVFileDataAdapter.java
+++ b/graylog2-server/src/main/java/org/graylog2/lookup/adapters/CSVFileDataAdapter.java
@@ -65,7 +65,7 @@ public class CSVFileDataAdapter extends LookupDataAdapter {
     private final Config config;
     private final AtomicReference<Map<String, String>> lookupRef = new AtomicReference<>(ImmutableMap.of());
 
-    private FileInfo fileInfo;
+    private FileInfo fileInfo = FileInfo.empty();
 
     @Inject
     public CSVFileDataAdapter(@Assisted("id") String id,

--- a/graylog2-server/src/test/java/org/graylog2/plugin/utilities/FileInfoTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/plugin/utilities/FileInfoTest.java
@@ -17,12 +17,12 @@
 package org.graylog2.plugin.utilities;
 
 import com.google.common.io.Files;
-
 import org.junit.Test;
 
 import java.io.File;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.concurrent.TimeUnit;
 
 import static com.google.common.util.concurrent.Uninterruptibles.sleepUninterruptibly;
@@ -93,5 +93,15 @@ public class FileInfoTest {
         Files.write("test".getBytes(StandardCharsets.US_ASCII), tempFile);
         change = fileInfo.checkForChange();
         assertThat(change.isChanged()).isTrue();
+    }
+
+    @Test
+    public void empty() {
+        assertThat(FileInfo.empty()).isEqualTo(FileInfo.builder()
+                .path(Paths.get(""))
+                .key(null)
+                .modificationTime(null)
+                .size(-1L)
+                .build());
     }
 }


### PR DESCRIPTION
Make sure the "fileInfo" field is initialized with an empty FileInfo
object. Also catch all exceptions in FileInfo#forPath instead of
IOExceptions only.

Refs #4748

**Note:** This needs to be cherry-picked into 2.4 once merged