### PR TITLE
Add new StoreProviderMock and add custom Function to StoreMock

### DIFF
--- a/graylog2-web-interface/test/helpers/mocking/StoreMock.js
+++ b/graylog2-web-interface/test/helpers/mocking/StoreMock.js
@@ -1,6 +1,12 @@
-export default function() {
+export default function (...args) {
   const store = {};
-  Array.from(arguments).forEach((method) => { store[method] = jest.fn(); });
+  Array.from(args).forEach((method) => {
+    if (Array.isArray(method)) {
+      store[method[0]] = method[1];
+    } else {
+      store[method] = jest.fn();
+    }
+  });
 
   return store;
 }

--- a/graylog2-web-interface/test/helpers/mocking/StoreProviderMock.js
+++ b/graylog2-web-interface/test/helpers/mocking/StoreProviderMock.js
@@ -1,0 +1,14 @@
+export default class StoreProviderMock {
+  constructor(stores = {}) {
+    this.stores = stores;
+  }
+
+  getStore(name) {
+    const result = this.stores[name] || {};
+    if (!result[`${name}Store`]) {
+      result[`${name}Store`] = {};
+    }
+
+    return result;
+  }
+}

--- a/graylog2-web-interface/test/helpers/mocking/StoreProviderMock.js
+++ b/graylog2-web-interface/test/helpers/mocking/StoreProviderMock.js
@@ -1,5 +1,10 @@
 export default class StoreProviderMock {
-  constructor(stores = {}) {
+  static defaultStore = {
+    get: () => jest.fn(() => ({})),
+    listen: jest.fn(),
+  };
+
+  constructor(stores = StoreProviderMock.defaultStore) {
     this.stores = stores;
   }
 

--- a/graylog2-web-interface/test/helpers/mocking/index.js
+++ b/graylog2-web-interface/test/helpers/mocking/index.js
@@ -1,2 +1,3 @@
 export { default as CombinedProviderMock } from './CombinedProviderMock';
 export { default as StoreMock } from './StoreMock';
+export { default as StoreProviderMock } from './StoreProviderMock';


### PR DESCRIPTION
## Description
Add a new StoreProviderMock which can be used as a mock
for StoreProvider. It's a factory which takes a map of stores
with the store names as keys.

Also enhance StoreMock so it can add a custom function
in stead of jest.fn(). This is useful when the function
should return something specific or you want to add a
`expect` to the function outcome.

## Motivation and Context
StoreProviderMock is needed to make a meaningful mock of StoreProvider
(just like CombinedProviderMock)

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
