### PR TITLE
Add "http_non_proxy_hosts" configuration option

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/plugin/BaseConfiguration.java
+++ b/graylog2-server/src/main/java/org/graylog2/plugin/BaseConfiguration.java
@@ -30,6 +30,8 @@ import com.lmax.disruptor.BusySpinWaitStrategy;
 import com.lmax.disruptor.SleepingWaitStrategy;
 import com.lmax.disruptor.WaitStrategy;
 import com.lmax.disruptor.YieldingWaitStrategy;
+import org.graylog2.utilities.ProxyHostsPattern;
+import org.graylog2.utilities.ProxyHostsPatternConverter;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -119,6 +121,9 @@ public abstract class BaseConfiguration {
 
     @Parameter(value = "http_proxy_uri")
     private URI httpProxyUri;
+
+    @Parameter(value = "http_non_proxy_hosts", converter = ProxyHostsPatternConverter.class)
+    private ProxyHostsPattern httpNonProxyHostsPattern;
 
     @Parameter(value = "http_connect_timeout", validator = PositiveDurationValidator.class)
     private Duration httpConnectTimeout = Duration.seconds(5L);
@@ -352,6 +357,10 @@ public abstract class BaseConfiguration {
 
     public URI getHttpProxyUri() {
         return httpProxyUri;
+    }
+
+    public ProxyHostsPattern getHttpNonProxyHostsPattern() {
+        return httpNonProxyHostsPattern;
     }
 
     public Duration getHttpConnectTimeout() {

--- a/graylog2-server/src/main/java/org/graylog2/utilities/ProxyHostsPattern.java
+++ b/graylog2-server/src/main/java/org/graylog2/utilities/ProxyHostsPattern.java
@@ -1,0 +1,102 @@
+/**
+ * This file is part of Graylog.
+ *
+ * Graylog is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.graylog2.utilities;
+
+import com.google.common.base.Splitter;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.annotation.Nullable;
+import java.util.Locale;
+import java.util.Set;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+
+import static com.google.common.base.Strings.isNullOrEmpty;
+
+/**
+ * Hostname and IP address matcher implementation similar to what the JDK is using in the proxy server selector
+ * to support the {@code http.nonProxyHosts} property.
+ * <p>
+ * The main difference to the implementation in the JDK is, that this one is using {@code ","} as delimiter.
+ * <p>
+ * See: <https://docs.oracle.com/javase/8/docs/technotes/guides/net/proxies.html>
+ */
+public class ProxyHostsPattern {
+    private static final Logger LOG = LoggerFactory.getLogger(ProxyHostsPattern.class);
+    private static final String DELIMITER = ",";
+
+    private final String noProxyHosts;
+    private final Pattern pattern;
+
+    private ProxyHostsPattern(String noProxyHosts, Pattern pattern) {
+        this.noProxyHosts = noProxyHosts;
+        this.pattern = pattern;
+    }
+
+    public String getNoProxyHosts() {
+        return noProxyHosts;
+    }
+
+    public boolean matches(@Nullable final String hostOrIp) {
+        if (pattern == null) {
+            LOG.debug("No proxy host pattern defined");
+            return false;
+        }
+        if (isNullOrEmpty(hostOrIp)) {
+            LOG.debug("Host or IP address <{}> doesn't match <{}>", hostOrIp, noProxyHosts);
+            return false;
+        }
+
+        if (pattern.matcher(hostOrIp.toLowerCase(Locale.ROOT)).matches()) {
+            LOG.debug("Host or IP address <{}> matches <{}>", hostOrIp, noProxyHosts);
+            return true;
+        } else {
+            LOG.debug("Host or IP address <{}> doesn't match <{}>", hostOrIp, noProxyHosts);
+            return false;
+        }
+    }
+
+    public static ProxyHostsPattern create(final String noProxyHosts) {
+        if (isNullOrEmpty(noProxyHosts)) {
+            return new ProxyHostsPattern("", null);
+        }
+
+        final Set<String> patterns = Splitter.on(DELIMITER)
+                .trimResults()
+                .omitEmptyStrings()
+                .splitToList(noProxyHosts)
+                .stream()
+                .map(ProxyHostsPattern::toPattern)
+                .collect(Collectors.toSet());
+
+        if (patterns.isEmpty()) {
+            return new ProxyHostsPattern(noProxyHosts, null);
+        }
+        return new ProxyHostsPattern(noProxyHosts, Pattern.compile(String.join("|", patterns)));
+    }
+
+    private static String toPattern(String hostPattern) {
+        if (hostPattern.startsWith("*")) {
+            return ".*" + Pattern.quote(hostPattern.substring(1).toLowerCase(Locale.ROOT));
+        } else if (hostPattern.endsWith("*")) {
+            return Pattern.quote(hostPattern.substring(0, hostPattern.length() - 1).toLowerCase(Locale.ROOT)) + ".*";
+        } else {
+            return Pattern.quote(hostPattern);
+        }
+    }
+}

--- a/graylog2-server/src/main/java/org/graylog2/utilities/ProxyHostsPatternConverter.java
+++ b/graylog2-server/src/main/java/org/graylog2/utilities/ProxyHostsPatternConverter.java
@@ -14,23 +14,23 @@
  * You should have received a copy of the GNU General Public License
  * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
  */
-package org.graylog2.shared.bindings.providers;
+package org.graylog2.utilities;
 
-import com.github.joschi.jadconfig.util.Duration;
+import com.github.joschi.jadconfig.Converter;
+import com.github.joschi.jadconfig.ParameterException;
 
-import javax.inject.Singleton;
+public class ProxyHostsPatternConverter implements Converter<ProxyHostsPattern> {
+    @Override
+    public ProxyHostsPattern convertFrom(String value) {
+        try {
+            return ProxyHostsPattern.create(value);
+        } catch (IllegalArgumentException e) {
+            throw new ParameterException("Invalid proxy hosts pattern: \"" + value + "\"", e);
+        }
+    }
 
-/**
- * Provider for a configured {@link com.squareup.okhttp.OkHttpClient} used for system-level tasks.
- */
-@Singleton
-public class SystemOkHttpClientProvider extends OkHttpClientProvider {
-    public SystemOkHttpClientProvider() {
-        super(
-                Duration.seconds(2L),
-                Duration.seconds(5L),
-                Duration.seconds(5L),
-                null,
-                null);
+    @Override
+    public String convertTo(ProxyHostsPattern value) {
+        return value.getNoProxyHosts();
     }
 }

--- a/graylog2-server/src/test/java/org/graylog2/shared/bindings/providers/OkHttpClientProviderTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/shared/bindings/providers/OkHttpClientProviderTest.java
@@ -301,7 +301,8 @@ public class OkHttpClientProviderTest {
                 Duration.milliseconds(100L),
                 Duration.milliseconds(100L),
                 Duration.milliseconds(100L),
-                proxyURI);
+                proxyURI,
+                null);
 
         return provider.get();
     }

--- a/graylog2-server/src/test/java/org/graylog2/utilities/ProxyHostsPatternConverterTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/utilities/ProxyHostsPatternConverterTest.java
@@ -14,23 +14,19 @@
  * You should have received a copy of the GNU General Public License
  * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
  */
-package org.graylog2.shared.bindings.providers;
+package org.graylog2.utilities;
 
-import com.github.joschi.jadconfig.util.Duration;
+import org.junit.Test;
 
-import javax.inject.Singleton;
+import static org.assertj.core.api.Assertions.assertThat;
 
-/**
- * Provider for a configured {@link com.squareup.okhttp.OkHttpClient} used for system-level tasks.
- */
-@Singleton
-public class SystemOkHttpClientProvider extends OkHttpClientProvider {
-    public SystemOkHttpClientProvider() {
-        super(
-                Duration.seconds(2L),
-                Duration.seconds(5L),
-                Duration.seconds(5L),
-                null,
-                null);
+public class ProxyHostsPatternConverterTest {
+    @Test
+    public void convertFromAndTo() {
+        final ProxyHostsPatternConverter converter = new ProxyHostsPatternConverter();
+        final ProxyHostsPattern pattern = converter.convertFrom("127.0.0.1,node0.graylog.example.com");
+
+        assertThat(pattern.matches("127.0.0.1")).isTrue();
+        assertThat(converter.convertTo(pattern)).isEqualTo("127.0.0.1,node0.graylog.example.com");
     }
 }

--- a/graylog2-server/src/test/java/org/graylog2/utilities/ProxyHostsPatternTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/utilities/ProxyHostsPatternTest.java
@@ -1,0 +1,54 @@
+/**
+ * This file is part of Graylog.
+ *
+ * Graylog is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.graylog2.utilities;
+
+import org.assertj.core.api.AbstractBooleanAssert;
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+
+public class ProxyHostsPatternTest {
+    private AbstractBooleanAssert assertPattern(String pattern, String hostOrIp) {
+        return assertThat(ProxyHostsPattern.create(pattern).matches(hostOrIp));
+    }
+
+    @Test
+    public void matches() {
+        assertPattern(null, "127.0.0.1").isFalse();
+        assertPattern("", "127.0.0.1").isFalse();
+        assertPattern(",,", "127.0.0.1").isFalse();
+
+        assertPattern("127.0.0.1", "127.0.0.1").isTrue();
+        assertPattern("127.0.0.1", "127.0.0.2").isFalse();
+        assertPattern("127.0.0.*", "127.0.0.1").isTrue();
+        assertPattern("127.0.*", "127.0.0.1").isTrue();
+        assertPattern("127.0.*,10.0.0.*", "127.0.0.1").isTrue();
+
+        assertPattern("node0.graylog.example.com", "node0.graylog.example.com").isTrue();
+        assertPattern("node0.graylog.example.com", "node1.graylog.example.com").isFalse();
+        assertPattern("*.graylog.example.com", "node0.graylog.example.com").isTrue();
+        assertPattern("*.graylog.example.com", "node1.graylog.example.com").isTrue();
+        assertPattern("node0.graylog.example.*", "node0.GRAYLOG.example.com").isTrue();
+        assertPattern("node0.graylog.example.*,127.0.0.1,*.graylog.example.com", "node1.graylog.example.com").isTrue();
+
+        // Wildcard is only supported at beginning or end of the pattern
+        assertPattern("127.0.*.1", "127.0.0.1").isFalse();
+        assertPattern("node0.*.example.com", "node0.graylog.example.com").isFalse();
+        assertPattern("*.0.0.*", "127.0.0.1").isFalse();
+    }
+}

--- a/misc/graylog.conf
+++ b/misc/graylog.conf
@@ -526,10 +526,20 @@ mongodb_threads_allowed_to_block_multiplier = 5
 #http_write_timeout = 10s
 
 # HTTP proxy for outgoing HTTP connections
+# ATTENTION: If you configure a proxy, make sure to also configure the "http_non_proxy_hosts" option so internal
+#            HTTP connections with other nodes does not go through the proxy.
 # Examples:
 #   - http://proxy.example.com:8123
 #   - http://username:password@proxy.example.com:8123
 #http_proxy_uri =
+
+# A list of hosts that should be reached directly, bypassing the configured proxy server.
+# This is a list of patterns separated by ",". The patterns may start or end with a "*" for wildcards.
+# Any host matching one of these patterns will be reached through a direct connection instead of through a proxy.
+# Examples:
+#   - localhost,127.0.0.1
+#   - 10.0.*,*.example.com
+#http_non_proxy_hosts =
 
 # Disable the optimization of Elasticsearch indices after index cycling. This may take some load from Elasticsearch
 # on heavily used systems with large indices, but it will decrease search performance. The default is to optimize


### PR DESCRIPTION
This can be used to bypass a configured proxy server for a list of
hostnames or IP addresses. It must be used if the inter-node
communication between graylog servers should not go through a configured
proxy server.

The matcher implementation for the "http_non_proxy_hosts" is similar to
the implementation that is used for the "http.nonProxyHosts" system
property. (only the delimiter is "," instead of "|" for consistency)
By using a similar implementation, it will be possible to also set the
system property in the future. (if needed - tbd)

Fixes #4905
Fixes #4392

(cherry picked from commit 979787eaed617e3f9e8988fed9c3f114f1afdc5e)
