### PR TITLE
Fixing `Date.now` for WidgetFooter tests.

### DIFF
--- a/graylog2-web-interface/src/components/widgets/WidgetFooter.test.jsx
+++ b/graylog2-web-interface/src/components/widgets/WidgetFooter.test.jsx
@@ -5,6 +5,15 @@ import WidgetFooter from 'components/widgets/WidgetFooter';
 
 describe('<WidgetFooter />', () => {
   const date = new Date(Date.UTC(1995, 12, 17, 3, 24, 0));
+  let dateNowMock;
+
+  beforeAll(() => {
+    dateNowMock = jest.spyOn(Date, 'now').mockImplementation(() => new Date(Date.UTC(2018, 1, 22, 17, 35, 0)));
+  });
+
+  afterAll(() => {
+    dateNowMock.mockReset();
+  });
 
   it('should render a widget footer locked and enabled replay', () => {
     const wrapper = renderer.create(<WidgetFooter


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Before this change, `Date.now` returned the actual time of the test run
which cause the result to inevitably deviate from the snapshot over
time.

This change is mocking `Date.now` and returning a fixed date instead.

Fixes #4916.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
