### PR TITLE
Set `displayName` for mocked components.

### DIFF
--- a/graylog2-web-interface/test/helpers/mocking/MockComponent.jsx
+++ b/graylog2-web-interface/test/helpers/mocking/MockComponent.jsx
@@ -13,6 +13,7 @@ export default (name) => {
   MockComponent.defaultProps = {
     children: null,
   };
+  MockComponent.displayName = name;
 
   return MockComponent;
 };


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
This tiny change sets the `displayName` property for created mock
components used in react-based tests. This helps a lot to assert the
existence/quantity of mock components in the generated DOM tree.

This change affects only tests, not other code.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
