### PR TITLE
Fix KeyValue rule function to split entries once

### DIFF
--- a/graylog2-server/src/main/java/org/graylog/plugins/pipelineprocessor/functions/strings/KeyValue.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/pipelineprocessor/functions/strings/KeyValue.java
@@ -82,6 +82,7 @@ public class KeyValue extends AbstractFunction<Map<String, String>> {
 
         final Splitter entrySplitter = Splitter.on(kvDelimMatcher)
                 .omitEmptyStrings()
+                .limit(2)
                 .trimResults();
         return new MapSplitter(outerSplitter,
                                entrySplitter,

--- a/graylog2-server/src/test/java/org/graylog/plugins/pipelineprocessor/functions/FunctionsSnippetsTest.java
+++ b/graylog2-server/src/test/java/org/graylog/plugins/pipelineprocessor/functions/FunctionsSnippetsTest.java
@@ -849,7 +849,8 @@ public class FunctionsSnippetsTest extends BaseParserTest {
         assertThat(message.getField("e")).isEqualTo("4");
         assertThat(message.getField("f")).isEqualTo("1");
         assertThat(message.getField("g")).isEqualTo("3");
-        assertThat(message.hasField("h")).isFalse();
+        assertThat(message.getField("h")).isEqualTo("3=:3");
+        assertThat(message.hasField("i")).isFalse();
 
         assertThat(message.getField("dup_first")).isEqualTo("1");
         assertThat(message.getField("dup_last")).isEqualTo("2");

--- a/graylog2-server/src/test/resources/org/graylog/plugins/pipelineprocessor/functions/keyValue.txt
+++ b/graylog2-server/src/test/resources/org/graylog/plugins/pipelineprocessor/functions/keyValue.txt
@@ -2,7 +2,7 @@ rule "kv"
 when true
 then
     set_fields(key_value(
-            value: "a='1' <b>=2  \n 'c'=3 [d]=44 a=4 \"e\"=4 [f=1][[g]:3] h=",
+            value: "a='1' <b>=2  \n 'c'=3 [d]=44 a=4 \"e\"=4 [f=1][[g]:3] 'h'=3=:3 i=",
             delimiters: " \t\n\r[",
             kv_delimiters: "=:",
             ignore_empty_values: true,


### PR DESCRIPTION
Prevent splitting values if delimiter chars are found inside values

## Motivation and Context
Fixes #4920 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
