### PR TITLE
Fix overlapping rows with long descriptions

### DIFF
--- a/graylog2-web-interface/src/components/content-packs/ContentPackEntitiesList.css
+++ b/graylog2-web-interface/src/components/content-packs/ContentPackEntitiesList.css
@@ -10,3 +10,7 @@
     width:100%;
     table-layout:fixed;
 }
+
+:local(.bigColumns) {
+    word-wrap: break-word;
+}

--- a/graylog2-web-interface/src/components/content-packs/ContentPackEntitiesList.jsx
+++ b/graylog2-web-interface/src/components/content-packs/ContentPackEntitiesList.jsx
@@ -126,9 +126,9 @@ class ContentPackEntitiesList extends React.Component {
     const appliedParameterCount = (this.props.appliedParameter[entity.id] || []).length;
     return (
       <tr key={entity.id}>
-        <td>{this._entityTitle(entity)}</td>
+        <td className={ContentPackEntitiesListStyle.bigColumns}>{this._entityTitle(entity)}</td>
         <td>{entity.type}</td>
-        <td>{this._entityDescription(entity)}</td>
+        <td className={ContentPackEntitiesListStyle.bigColumns}>{this._entityDescription(entity)}</td>
         {!this.props.readOnly && <td>{appliedParameterCount}</td>}
         <td>
           <ButtonToolbar>

--- a/graylog2-web-interface/src/components/content-packs/ContentPackParameterList.css
+++ b/graylog2-web-interface/src/components/content-packs/ContentPackParameterList.css
@@ -10,3 +10,7 @@
     width:100%;
     table-layout:fixed;
 }
+
+:local(.bigColumns) {
+    word-wrap: break-word;
+}

--- a/graylog2-web-interface/src/components/content-packs/ContentPackParameterList.jsx
+++ b/graylog2-web-interface/src/components/content-packs/ContentPackParameterList.jsx
@@ -41,9 +41,9 @@ class ContentPackParameterList extends React.Component {
   _parameterRowFormatter = (parameter) => {
     return (
       <tr key={parameter.title}>
-        <td>{parameter.title}</td>
+        <td className={ContentPackParameterListStyle.bigColumns}>{parameter.title}</td>
         <td>{parameter.name}</td>
-        <td>{parameter.description}</td>
+        <td className={ContentPackParameterListStyle.bigColumns}>{parameter.description}</td>
         <td>{parameter.type}</td>
         <td>{ContentPackUtils.convertToString(parameter)}</td>
         {!this.props.readOnly &&

--- a/graylog2-web-interface/src/components/content-packs/__snapshots__/ContentPackEntitiesList.test.jsx.snap
+++ b/graylog2-web-interface/src/components/content-packs/__snapshots__/ContentPackEntitiesList.test.jsx.snap
@@ -200,13 +200,17 @@ exports[`<ContentPackEntitiesList /> should render with entities and parameters 
             </thead>
             <tbody>
               <tr>
-                <td>
+                <td
+                  className="bigColumns"
+                >
                   A good input
                 </td>
                 <td>
                   Input
                 </td>
-                <td>
+                <td
+                  className="bigColumns"
+                >
                   Input
                 </td>
                 <td>
@@ -237,13 +241,17 @@ exports[`<ContentPackEntitiesList /> should render with entities and parameters 
                 </td>
               </tr>
               <tr>
-                <td>
+                <td
+                  className="bigColumns"
+                >
                   A bad input
                 </td>
                 <td>
                   Input
                 </td>
-                <td>
+                <td
+                  className="bigColumns"
+                >
                   BadInput
                 </td>
                 <td>

--- a/graylog2-web-interface/src/components/content-packs/__snapshots__/ContentPackInstall.test.jsx.snap
+++ b/graylog2-web-interface/src/components/content-packs/__snapshots__/ContentPackInstall.test.jsx.snap
@@ -190,11 +190,15 @@ exports[`<ContentPackInstall /> should render a install 1`] = `
                   </thead>
                   <tbody>
                     <tr>
-                      <td>
+                      <td
+                        className="bigColumns"
+                      >
                         franz
                       </td>
                       <td />
-                      <td>
+                      <td
+                        className="bigColumns"
+                      >
                         
                       </td>
                       <td>

--- a/graylog2-web-interface/src/components/content-packs/__snapshots__/ContentPackParameterList.test.jsx.snap
+++ b/graylog2-web-interface/src/components/content-packs/__snapshots__/ContentPackParameterList.test.jsx.snap
@@ -305,13 +305,17 @@ exports[`<ContentPackParameterList /> should render with parameters with readOnl
             </thead>
             <tbody>
               <tr>
-                <td>
+                <td
+                  className="bigColumns"
+                >
                   A parameter title
                 </td>
                 <td>
                   A parameter name
                 </td>
-                <td>
+                <td
+                  className="bigColumns"
+                >
                   A parameter descriptions
                 </td>
                 <td>
@@ -452,13 +456,17 @@ exports[`<ContentPackParameterList /> should render with parameters without read
             </thead>
             <tbody>
               <tr>
-                <td>
+                <td
+                  className="bigColumns"
+                >
                   A parameter title
                 </td>
                 <td>
                   A parameter name
                 </td>
-                <td>
+                <td
+                  className="bigColumns"
+                >
                   A parameter descriptions
                 </td>
                 <td>

--- a/graylog2-web-interface/src/components/content-packs/__snapshots__/ContentPackParameters.test.jsx.snap
+++ b/graylog2-web-interface/src/components/content-packs/__snapshots__/ContentPackParameters.test.jsx.snap
@@ -129,13 +129,17 @@ exports[`<ContentPackParameters /> should render a parameter 1`] = `
                   </thead>
                   <tbody>
                     <tr>
-                      <td>
+                      <td
+                        className="bigColumns"
+                      >
                         A parameter title
                       </td>
                       <td>
                         A parameter name
                       </td>
-                      <td>
+                      <td
+                        className="bigColumns"
+                      >
                         A parameter descriptions
                       </td>
                       <td>
@@ -289,11 +293,15 @@ exports[`<ContentPackParameters /> should render a parameter 1`] = `
                   </thead>
                   <tbody>
                     <tr>
-                      <td>
+                      <td
+                        className="bigColumns"
+                      >
                         A good input
                       </td>
                       <td />
-                      <td>
+                      <td
+                        className="bigColumns"
+                      >
                         Input
                       </td>
                       <td>


### PR DESCRIPTION
## Description
Let title and description column break the word if to long.

## Motivation and Context
Entities with a single-word long description (like a github url) overlap with table rows.

## How Has This Been Tested?
With a rather long description!

## Screenshots (if appropriate):
![screenshot_2018-07-24 graylog - content packs 2](https://user-images.githubusercontent.com/448763/43141123-74c23cea-8f55-11e8-8720-449bf678c7a8.png)

Fixes #4943 

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
