### PR TITLE
Add total attribute of ContentPackList

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/rest/models/system/contenpacks/responses/ContentPackInstallationsResponse.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/models/system/contenpacks/responses/ContentPackInstallationsResponse.java
@@ -29,11 +29,14 @@ import java.util.Set;
 @AutoValue
 @WithBeanGetter
 public abstract class ContentPackInstallationsResponse {
+    @JsonProperty("total")
+    public abstract long total();
+
     @JsonProperty("installations")
     public abstract Set<ContentPackInstallation> contentPackInstallations();
 
     @JsonCreator
-    public static ContentPackInstallationsResponse create(@JsonProperty("installations") Set<ContentPackInstallation> contentPackInstallations) {
-        return new AutoValue_ContentPackInstallationsResponse(contentPackInstallations);
+    public static ContentPackInstallationsResponse create(@JsonProperty("total") long total, @JsonProperty("installations") Set<ContentPackInstallation> contentPackInstallations) {
+        return new AutoValue_ContentPackInstallationsResponse(total, contentPackInstallations);
     }
 }

--- a/graylog2-server/src/main/java/org/graylog2/rest/models/system/contenpacks/responses/ContentPackList.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/models/system/contenpacks/responses/ContentPackList.java
@@ -31,10 +31,13 @@ import java.util.Set;
 @WithBeanGetter
 public abstract class ContentPackList {
     @JsonProperty
+    public abstract long total();
+
+    @JsonProperty
     public abstract Set<ContentPack> contentPacks();
 
     @JsonCreator
-    public static ContentPackList create(@JsonProperty("content_packs") Set<ContentPack> contentPacks) {
-        return new AutoValue_ContentPackList(contentPacks);
+    public static ContentPackList create(@JsonProperty("total") long total, @JsonProperty("content_packs") Set<ContentPack> contentPacks) {
+        return new AutoValue_ContentPackList(total, contentPacks);
     }
 }

--- a/graylog2-server/src/main/java/org/graylog2/rest/resources/system/contentpacks/ContentPackResource.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/resources/system/contentpacks/ContentPackResource.java
@@ -278,7 +278,7 @@ public class ContentPackResource extends RestResource {
         checkPermission(RestPermissions.CONTENT_PACK_READ);
 
         final Set<ContentPackInstallation> installations = contentPackInstallationPersistenceService.loadAll();
-        return ContentPackInstallationsResponse.create(installations);
+        return ContentPackInstallationsResponse.create(installations.size(), installations);
     }
 
     @GET
@@ -295,7 +295,7 @@ public class ContentPackResource extends RestResource {
         checkPermission(RestPermissions.CONTENT_PACK_READ);
 
         final Set<ContentPackInstallation> installations = contentPackInstallationPersistenceService.findByContentPackId(id);
-        return ContentPackInstallationsResponse.create(installations);
+        return ContentPackInstallationsResponse.create(installations.size(), installations);
     }
 
     @GET
@@ -314,7 +314,7 @@ public class ContentPackResource extends RestResource {
         checkPermission(RestPermissions.CONTENT_PACK_READ);
 
         final Set<ContentPackInstallation> installations = contentPackInstallationPersistenceService.findByContentPackIdAndRevision(contentPackId, revision);
-        return ContentPackInstallationsResponse.create(installations);
+        return ContentPackInstallationsResponse.create(installations.size(), installations);
     }
 
     @DELETE

--- a/graylog2-server/src/main/java/org/graylog2/rest/resources/system/contentpacks/ContentPackResource.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/resources/system/contentpacks/ContentPackResource.java
@@ -97,7 +97,7 @@ public class ContentPackResource extends RestResource {
         checkPermission(RestPermissions.CONTENT_PACK_READ);
         Set<ContentPack> contentPacks = contentPackPersistenceService.loadAll();
 
-        return ContentPackList.create(contentPacks);
+        return ContentPackList.create(contentPacks.size(), contentPacks);
     }
 
     @GET
@@ -112,7 +112,7 @@ public class ContentPackResource extends RestResource {
         checkPermission(RestPermissions.CONTENT_PACK_READ);
 
         Set<ContentPack> contentPacks = contentPackPersistenceService.loadAllLatest();
-        return ContentPackList.create(contentPacks);
+        return ContentPackList.create(contentPacks.size(), contentPacks);
     }
 
     @GET

--- a/graylog2-server/src/test/java/org/graylog2/rest/resources/system/contentpacks/ContentPackResourceTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/rest/resources/system/contentpacks/ContentPackResourceTest.java
@@ -104,7 +104,7 @@ public class ContentPackResourceTest {
     public void listAndLatest() throws Exception {
         final ContentPack contentPack = objectMapper.readValue(CONTENT_PACK, ContentPack.class);
         final Set<ContentPack> contentPacks = Collections.singleton(contentPack);
-        final ContentPackList expectedList = ContentPackList.create(contentPacks);
+        final ContentPackList expectedList = ContentPackList.create(contentPacks.size(), contentPacks);
 
         when(contentPackPersistenceService.loadAll()).thenReturn(Collections.singleton(contentPack));
         final ContentPackList contentPackList = contentPackResource.listContentPacks();


### PR DESCRIPTION
## Description
To match other api endpoints which might support
pagination ContentPackResources now has the total flag

## Motivation and Context
All other endpoints which might support pagination in the future
have total attribute in the response.

Fixes #4947 

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
