### PR TITLE
Check requirement fulfillment and show it on ShowContentPacksPage

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/contentpacks/constraints/ConstraintChecker.java
+++ b/graylog2-server/src/main/java/org/graylog2/contentpacks/constraints/ConstraintChecker.java
@@ -17,10 +17,12 @@
 package org.graylog2.contentpacks.constraints;
 
 import org.graylog2.contentpacks.model.constraints.Constraint;
+import org.graylog2.contentpacks.model.constraints.ConstraintCheckResult;
 
 import java.util.Collection;
 import java.util.Set;
 
 public interface ConstraintChecker {
-    Set<Constraint> checkConstraints(Collection<Constraint> requestedConstraints);
+    Set<Constraint> ensureConstraints(Collection<Constraint> requestedConstraints);
+    Set<ConstraintCheckResult> checkConstraints(Collection<Constraint> requestedConstraints);
 }

--- a/graylog2-server/src/main/java/org/graylog2/contentpacks/constraints/GraylogVersionConstraintChecker.java
+++ b/graylog2-server/src/main/java/org/graylog2/contentpacks/constraints/GraylogVersionConstraintChecker.java
@@ -21,6 +21,7 @@ import com.google.common.collect.ImmutableSet;
 import com.vdurmont.semver4j.Requirement;
 import com.vdurmont.semver4j.Semver;
 import org.graylog2.contentpacks.model.constraints.Constraint;
+import org.graylog2.contentpacks.model.constraints.ConstraintCheckResult;
 import org.graylog2.contentpacks.model.constraints.GraylogVersionConstraint;
 
 import java.util.Collection;
@@ -43,17 +44,32 @@ public class GraylogVersionConstraintChecker implements ConstraintChecker {
         this.graylogVersion = graylogVersion;
     }
 
+
     @Override
-    public Set<Constraint> checkConstraints(Collection<Constraint> requestedConstraints) {
+    public Set<Constraint> ensureConstraints(Collection<Constraint> requestedConstraints) {
         final ImmutableSet.Builder<Constraint> fulfilledConstraints = ImmutableSet.builder();
         for (Constraint constraint : requestedConstraints) {
             if (constraint instanceof GraylogVersionConstraint) {
                 final GraylogVersionConstraint versionConstraint = (GraylogVersionConstraint) constraint;
                 final Requirement requiredVersion = versionConstraint.version();
-
                 if (requiredVersion.isSatisfiedBy(graylogVersion.toString())) {
                     fulfilledConstraints.add(constraint);
                 }
+            }
+        }
+        return fulfilledConstraints.build();
+    }
+
+    @Override
+    public Set<ConstraintCheckResult> checkConstraints(Collection<Constraint> requestedConstraints) {
+        final ImmutableSet.Builder<ConstraintCheckResult> fulfilledConstraints = ImmutableSet.builder();
+        for (Constraint constraint : requestedConstraints) {
+            if (constraint instanceof GraylogVersionConstraint) {
+                final GraylogVersionConstraint versionConstraint = (GraylogVersionConstraint) constraint;
+                final Requirement requiredVersion = versionConstraint.version();
+                final ConstraintCheckResult constraintCheckResult = ConstraintCheckResult.create(versionConstraint,
+                        requiredVersion.isSatisfiedBy(graylogVersion.toString()));
+                fulfilledConstraints.add(constraintCheckResult);
             }
         }
         return fulfilledConstraints.build();

--- a/graylog2-server/src/main/java/org/graylog2/contentpacks/model/ContentPack.java
+++ b/graylog2-server/src/main/java/org/graylog2/contentpacks/model/ContentPack.java
@@ -18,6 +18,9 @@ package org.graylog2.contentpacks.model;
 
 import com.fasterxml.jackson.annotation.JsonSubTypes;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import org.graylog2.contentpacks.model.constraints.Constraint;
+
+import java.util.Set;
 
 @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.PROPERTY, property = Versioned.FIELD_META_VERSION, defaultImpl = LegacyContentPack.class)
 @JsonSubTypes({
@@ -27,4 +30,6 @@ import com.fasterxml.jackson.annotation.JsonTypeInfo;
 public interface ContentPack extends Identified, Revisioned, Versioned {
     interface ContentPackBuilder<SELF> extends IdBuilder<SELF>, RevisionBuilder<SELF>, VersionBuilder<SELF> {
     }
+
+    Set<Constraint> requires();
 }

--- a/graylog2-server/src/main/java/org/graylog2/contentpacks/model/constraints/Constraint.java
+++ b/graylog2-server/src/main/java/org/graylog2/contentpacks/model/constraints/Constraint.java
@@ -20,6 +20,8 @@ import com.fasterxml.jackson.annotation.JsonSubTypes;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import org.graylog2.contentpacks.model.Typed;
 
+import java.util.Optional;
+
 @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.PROPERTY, property = Constraint.FIELD_META_TYPE)
 @JsonSubTypes({
         @JsonSubTypes.Type(value = GraylogVersionConstraint.class, name = GraylogVersionConstraint.TYPE_NAME),
@@ -28,4 +30,6 @@ import org.graylog2.contentpacks.model.Typed;
 public interface Constraint extends Typed {
     interface ConstraintBuilder<SELF> extends Typed.TypeBuilder<SELF> {
     }
+
+    Optional<Boolean> fulfilled();
 }

--- a/graylog2-server/src/main/java/org/graylog2/contentpacks/model/constraints/Constraint.java
+++ b/graylog2-server/src/main/java/org/graylog2/contentpacks/model/constraints/Constraint.java
@@ -30,6 +30,4 @@ import java.util.Optional;
 public interface Constraint extends Typed {
     interface ConstraintBuilder<SELF> extends Typed.TypeBuilder<SELF> {
     }
-
-    Optional<Boolean> fulfilled();
 }

--- a/graylog2-server/src/main/java/org/graylog2/contentpacks/model/constraints/ConstraintCheckResult.java
+++ b/graylog2-server/src/main/java/org/graylog2/contentpacks/model/constraints/ConstraintCheckResult.java
@@ -14,33 +14,27 @@
  * You should have received a copy of the GNU General Public License
  * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
  */
-package org.graylog2.rest.models.system.contenpacks.responses;
+package org.graylog2.contentpacks.model.constraints;
 
 import com.fasterxml.jackson.annotation.JsonAutoDetect;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.auto.value.AutoValue;
 import org.graylog.autovalue.WithBeanGetter;
-import org.graylog2.contentpacks.model.ContentPack;
-import org.graylog2.contentpacks.model.constraints.ConstraintCheckResult;
-
-import java.util.Map;
-import java.util.Set;
 
 @JsonAutoDetect
 
 @AutoValue
 @WithBeanGetter
-public abstract class ContentPackRevisions {
-    @JsonProperty("content_pack_revisions")
-    public abstract Map<Integer, ContentPack> contentPackRevisions();
+public abstract class ConstraintCheckResult {
+    @JsonProperty
+    public abstract Constraint constraint();
 
-    @JsonProperty("constraints_result")
-    public abstract Map<Integer, Set<ConstraintCheckResult>> constraints();
+    @JsonProperty
+    public abstract boolean fulfilled();
 
     @JsonCreator
-    public static ContentPackRevisions create(@JsonProperty("content_pack_revisions") Map<Integer, ContentPack> contentPackRevisions,
-                                              @JsonProperty("constraints_result")Map<Integer, Set<ConstraintCheckResult>> constraints) {
-        return new AutoValue_ContentPackRevisions(contentPackRevisions, constraints);
+    public static ConstraintCheckResult create(@JsonProperty("constraint") Constraint constraint, @JsonProperty("fulfilled") boolean fulfilled) {
+       return new AutoValue_ConstraintCheckResult(constraint, fulfilled);
     }
 }

--- a/graylog2-server/src/main/java/org/graylog2/contentpacks/model/constraints/GraylogVersionConstraint.java
+++ b/graylog2-server/src/main/java/org/graylog2/contentpacks/model/constraints/GraylogVersionConstraint.java
@@ -17,6 +17,7 @@
 package org.graylog2.contentpacks.model.constraints;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.google.auto.value.AutoValue;
@@ -24,15 +25,25 @@ import com.vdurmont.semver4j.Requirement;
 import org.graylog2.contentpacks.model.ModelType;
 import org.graylog2.plugin.Version;
 
+import javax.annotation.Nullable;
+import java.util.Optional;
+
 @AutoValue
 @JsonDeserialize(builder = AutoValue_GraylogVersionConstraint.Builder.class)
 public abstract class GraylogVersionConstraint implements Constraint {
     // TODO: Rename to graylog-version
     static final String TYPE_NAME = "server-version";
     static final String FIELD_GRAYLOG_VERSION = "version";
+    static final String FULFILLED = "fulfilled";
 
     @JsonProperty(FIELD_GRAYLOG_VERSION)
     public abstract Requirement version();
+
+    @JsonInclude(JsonInclude.Include.NON_EMPTY)
+    @JsonProperty(FULFILLED)
+    public abstract Optional<Boolean> fulfilled();
+
+    public abstract Builder toBuilder();
 
     public static Builder builder() {
         return new AutoValue_GraylogVersionConstraint.Builder();
@@ -60,6 +71,9 @@ public abstract class GraylogVersionConstraint implements Constraint {
             final Requirement requirement = Requirement.buildNPM(versionExpression);
             return version(requirement);
         }
+
+        @JsonProperty(FULFILLED)
+        public abstract Builder fulfilled(Boolean fulfilled);
 
         abstract GraylogVersionConstraint autoBuild();
 

--- a/graylog2-server/src/main/java/org/graylog2/contentpacks/model/constraints/GraylogVersionConstraint.java
+++ b/graylog2-server/src/main/java/org/graylog2/contentpacks/model/constraints/GraylogVersionConstraint.java
@@ -34,14 +34,9 @@ public abstract class GraylogVersionConstraint implements Constraint {
     // TODO: Rename to graylog-version
     static final String TYPE_NAME = "server-version";
     static final String FIELD_GRAYLOG_VERSION = "version";
-    static final String FULFILLED = "fulfilled";
 
     @JsonProperty(FIELD_GRAYLOG_VERSION)
     public abstract Requirement version();
-
-    @JsonInclude(JsonInclude.Include.NON_EMPTY)
-    @JsonProperty(FULFILLED)
-    public abstract Optional<Boolean> fulfilled();
 
     public abstract Builder toBuilder();
 
@@ -71,9 +66,6 @@ public abstract class GraylogVersionConstraint implements Constraint {
             final Requirement requirement = Requirement.buildNPM(versionExpression);
             return version(requirement);
         }
-
-        @JsonProperty(FULFILLED)
-        public abstract Builder fulfilled(Boolean fulfilled);
 
         abstract GraylogVersionConstraint autoBuild();
 

--- a/graylog2-server/src/main/java/org/graylog2/contentpacks/model/constraints/PluginVersionConstraint.java
+++ b/graylog2-server/src/main/java/org/graylog2/contentpacks/model/constraints/PluginVersionConstraint.java
@@ -17,6 +17,7 @@
 package org.graylog2.contentpacks.model.constraints;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.google.auto.value.AutoValue;
@@ -25,18 +26,27 @@ import org.graylog2.contentpacks.model.ModelType;
 import org.graylog2.plugin.PluginMetaData;
 import org.graylog2.plugin.Version;
 
+import java.util.Optional;
+
 @AutoValue
 @JsonDeserialize(builder = AutoValue_PluginVersionConstraint.Builder.class)
 public abstract class PluginVersionConstraint implements Constraint {
     static final String TYPE_NAME = "plugin-version";
     static final String FIELD_PLUGIN_ID = "plugin";
     static final String FIELD_PLUGIN_VERSION = "version";
+    static final String FULFILLED = "fulfilled";
 
     @JsonProperty(FIELD_PLUGIN_ID)
     public abstract String pluginId();
 
     @JsonProperty(FIELD_PLUGIN_VERSION)
     public abstract Requirement version();
+
+    @JsonInclude(JsonInclude.Include.NON_EMPTY)
+    @JsonProperty(FULFILLED)
+    public abstract Optional<Boolean> fulfilled();
+
+    public abstract Builder toBuilder();
 
     public static PluginVersionConstraint of(PluginMetaData pluginMetaData) {
         final Version version = pluginMetaData.getVersion();
@@ -60,6 +70,9 @@ public abstract class PluginVersionConstraint implements Constraint {
 
         @JsonProperty(FIELD_PLUGIN_VERSION)
         public abstract Builder version(Requirement version);
+
+        @JsonProperty(FULFILLED)
+        public abstract Builder fulfilled(Boolean fulfilled);
 
         @JsonIgnore
         public Builder version(String versionExpression) {

--- a/graylog2-server/src/main/java/org/graylog2/contentpacks/model/constraints/PluginVersionConstraint.java
+++ b/graylog2-server/src/main/java/org/graylog2/contentpacks/model/constraints/PluginVersionConstraint.java
@@ -34,17 +34,12 @@ public abstract class PluginVersionConstraint implements Constraint {
     static final String TYPE_NAME = "plugin-version";
     static final String FIELD_PLUGIN_ID = "plugin";
     static final String FIELD_PLUGIN_VERSION = "version";
-    static final String FULFILLED = "fulfilled";
 
     @JsonProperty(FIELD_PLUGIN_ID)
     public abstract String pluginId();
 
     @JsonProperty(FIELD_PLUGIN_VERSION)
     public abstract Requirement version();
-
-    @JsonInclude(JsonInclude.Include.NON_EMPTY)
-    @JsonProperty(FULFILLED)
-    public abstract Optional<Boolean> fulfilled();
 
     public abstract Builder toBuilder();
 
@@ -70,9 +65,6 @@ public abstract class PluginVersionConstraint implements Constraint {
 
         @JsonProperty(FIELD_PLUGIN_VERSION)
         public abstract Builder version(Requirement version);
-
-        @JsonProperty(FULFILLED)
-        public abstract Builder fulfilled(Boolean fulfilled);
 
         @JsonIgnore
         public Builder version(String versionExpression) {

--- a/graylog2-server/src/main/java/org/graylog2/rest/models/system/contenpacks/responses/ContentPackResponse.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/models/system/contenpacks/responses/ContentPackResponse.java
@@ -20,27 +20,22 @@ import com.fasterxml.jackson.annotation.JsonAutoDetect;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.auto.value.AutoValue;
-import org.graylog.autovalue.WithBeanGetter;
 import org.graylog2.contentpacks.model.ContentPack;
 import org.graylog2.contentpacks.model.constraints.ConstraintCheckResult;
 
-import java.util.Map;
 import java.util.Set;
 
 @JsonAutoDetect
-
 @AutoValue
-@WithBeanGetter
-public abstract class ContentPackRevisions {
-    @JsonProperty("content_pack_revisions")
-    public abstract Map<Integer, ContentPack> contentPackRevisions();
+public abstract class ContentPackResponse {
+    @JsonProperty("content_pack")
+    public abstract ContentPack contentPack();
 
     @JsonProperty("constraints_result")
-    public abstract Map<Integer, Set<ConstraintCheckResult>> constraints();
+    public abstract Set<ConstraintCheckResult> constraints();
 
     @JsonCreator
-    public static ContentPackRevisions create(@JsonProperty("content_pack_revisions") Map<Integer, ContentPack> contentPackRevisions,
-                                              @JsonProperty("constraints_result")Map<Integer, Set<ConstraintCheckResult>> constraints) {
-        return new AutoValue_ContentPackRevisions(contentPackRevisions, constraints);
+    public static ContentPackResponse create(@JsonProperty("content_pack") ContentPack contentPack, @JsonProperty("constraints_result") Set<ConstraintCheckResult> constraints) {
+        return new AutoValue_ContentPackResponse(contentPack, constraints);
     }
 }

--- a/graylog2-server/src/test/java/org/graylog2/contentpacks/constraints/GraylogVersionConstraintCheckerTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/contentpacks/constraints/GraylogVersionConstraintCheckerTest.java
@@ -41,7 +41,7 @@ public class GraylogVersionConstraintCheckerTest {
                 .build();
         final ImmutableSet<Constraint> requiredConstraints = ImmutableSet.of(graylogVersionConstraint, pluginVersionConstraint);
         final Set<ConstraintCheckResult> result = constraintChecker.checkConstraints(requiredConstraints);
-        assertThat(result.stream().allMatch(c -> c.fulfilled()));
+        assertThat(result.stream().allMatch(c -> c.fulfilled())).isTrue();
     }
 
     @Test
@@ -57,6 +57,6 @@ public class GraylogVersionConstraintCheckerTest {
                 .build();
         final ImmutableSet<Constraint> requiredConstraints = ImmutableSet.of(graylogVersionConstraint, pluginVersionConstraint);
         final Set<ConstraintCheckResult> result = constraintChecker.checkConstraints(requiredConstraints);
-        assertThat(result.stream().allMatch(c -> !c.fulfilled()));
+        assertThat(result.stream().allMatch(c -> !c.fulfilled())).isTrue();
     }
 }

--- a/graylog2-server/src/test/java/org/graylog2/contentpacks/constraints/GraylogVersionConstraintCheckerTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/contentpacks/constraints/GraylogVersionConstraintCheckerTest.java
@@ -18,6 +18,7 @@ package org.graylog2.contentpacks.constraints;
 
 import com.google.common.collect.ImmutableSet;
 import org.graylog2.contentpacks.model.constraints.Constraint;
+import org.graylog2.contentpacks.model.constraints.ConstraintCheckResult;
 import org.graylog2.contentpacks.model.constraints.GraylogVersionConstraint;
 import org.graylog2.contentpacks.model.constraints.PluginVersionConstraint;
 import org.junit.Test;
@@ -39,7 +40,8 @@ public class GraylogVersionConstraintCheckerTest {
                 .version("^1.0.0")
                 .build();
         final ImmutableSet<Constraint> requiredConstraints = ImmutableSet.of(graylogVersionConstraint, pluginVersionConstraint);
-        assertThat(constraintChecker.checkConstraints(requiredConstraints).stream().allMatch(c -> c.fulfilled()));
+        final Set<ConstraintCheckResult> result = constraintChecker.checkConstraints(requiredConstraints);
+        assertThat(result.stream().allMatch(c -> c.fulfilled()));
     }
 
     @Test
@@ -54,6 +56,7 @@ public class GraylogVersionConstraintCheckerTest {
                 .version("^1.0.0")
                 .build();
         final ImmutableSet<Constraint> requiredConstraints = ImmutableSet.of(graylogVersionConstraint, pluginVersionConstraint);
-        assertThat(constraintChecker.checkConstraints(requiredConstraints).stream().allMatch(c -> !c.fulfilled()));
+        final Set<ConstraintCheckResult> result = constraintChecker.checkConstraints(requiredConstraints);
+        assertThat(result.stream().allMatch(c -> !c.fulfilled()));
     }
 }

--- a/graylog2-server/src/test/java/org/graylog2/contentpacks/constraints/GraylogVersionConstraintCheckerTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/contentpacks/constraints/GraylogVersionConstraintCheckerTest.java
@@ -22,6 +22,8 @@ import org.graylog2.contentpacks.model.constraints.GraylogVersionConstraint;
 import org.graylog2.contentpacks.model.constraints.PluginVersionConstraint;
 import org.junit.Test;
 
+import java.util.Set;
+
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class GraylogVersionConstraintCheckerTest {
@@ -37,7 +39,7 @@ public class GraylogVersionConstraintCheckerTest {
                 .version("^1.0.0")
                 .build();
         final ImmutableSet<Constraint> requiredConstraints = ImmutableSet.of(graylogVersionConstraint, pluginVersionConstraint);
-        assertThat(constraintChecker.checkConstraints(requiredConstraints)).containsOnly(graylogVersionConstraint);
+        assertThat(constraintChecker.checkConstraints(requiredConstraints).stream().allMatch(c -> c.fulfilled()));
     }
 
     @Test
@@ -52,6 +54,6 @@ public class GraylogVersionConstraintCheckerTest {
                 .version("^1.0.0")
                 .build();
         final ImmutableSet<Constraint> requiredConstraints = ImmutableSet.of(graylogVersionConstraint, pluginVersionConstraint);
-        assertThat(constraintChecker.checkConstraints(requiredConstraints)).isEmpty();
+        assertThat(constraintChecker.checkConstraints(requiredConstraints).stream().allMatch(c -> !c.fulfilled()));
     }
 }

--- a/graylog2-server/src/test/java/org/graylog2/contentpacks/constraints/PluginVersionConstraintCheckerTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/contentpacks/constraints/PluginVersionConstraintCheckerTest.java
@@ -45,7 +45,7 @@ public class PluginVersionConstraintCheckerTest {
                 .version("^1.0.0")
                 .build();
         final ImmutableSet<Constraint> requiredConstraints = ImmutableSet.of(graylogVersionConstraint, pluginVersionConstraint);
-        assertThat(constraintChecker.checkConstraints(requiredConstraints)).containsOnly(pluginVersionConstraint);
+        assertThat(constraintChecker.checkConstraints(requiredConstraints).stream().allMatch(c -> c.fulfilled()));
     }
 
     @Test
@@ -61,7 +61,7 @@ public class PluginVersionConstraintCheckerTest {
                 .version("^2.0.0")
                 .build();
         final ImmutableSet<Constraint> requiredConstraints = ImmutableSet.of(graylogVersionConstraint, pluginVersionConstraint);
-        assertThat(constraintChecker.checkConstraints(requiredConstraints)).isEmpty();
+        assertThat(constraintChecker.checkConstraints(requiredConstraints).stream().allMatch(c -> !c.fulfilled()));
     }
 
     private static final class TestPluginMetaData implements PluginMetaData {

--- a/graylog2-server/src/test/java/org/graylog2/contentpacks/constraints/PluginVersionConstraintCheckerTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/contentpacks/constraints/PluginVersionConstraintCheckerTest.java
@@ -45,7 +45,7 @@ public class PluginVersionConstraintCheckerTest {
                 .version("^1.0.0")
                 .build();
         final ImmutableSet<Constraint> requiredConstraints = ImmutableSet.of(graylogVersionConstraint, pluginVersionConstraint);
-        assertThat(constraintChecker.checkConstraints(requiredConstraints).stream().allMatch(c -> c.fulfilled()));
+        assertThat(constraintChecker.checkConstraints(requiredConstraints).stream().allMatch(c -> c.fulfilled())).isTrue();
     }
 
     @Test
@@ -61,7 +61,7 @@ public class PluginVersionConstraintCheckerTest {
                 .version("^2.0.0")
                 .build();
         final ImmutableSet<Constraint> requiredConstraints = ImmutableSet.of(graylogVersionConstraint, pluginVersionConstraint);
-        assertThat(constraintChecker.checkConstraints(requiredConstraints).stream().allMatch(c -> !c.fulfilled()));
+        assertThat(constraintChecker.checkConstraints(requiredConstraints).stream().allMatch(c -> !c.fulfilled())).isTrue();
     }
 
     private static final class TestPluginMetaData implements PluginMetaData {

--- a/graylog2-server/src/test/java/org/graylog2/rest/resources/system/contentpacks/ContentPackResourceTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/rest/resources/system/contentpacks/ContentPackResourceTest.java
@@ -22,8 +22,11 @@ import org.graylog2.contentpacks.ContentPackPersistenceService;
 import org.graylog2.contentpacks.ContentPackService;
 import org.graylog2.contentpacks.model.ContentPack;
 import org.graylog2.contentpacks.model.ModelId;
+import org.graylog2.contentpacks.model.constraints.Constraint;
+import org.graylog2.contentpacks.model.constraints.ConstraintCheckResult;
 import org.graylog2.jackson.AutoValueSubtypeResolver;
 import org.graylog2.rest.models.system.contenpacks.responses.ContentPackList;
+import org.graylog2.rest.models.system.contenpacks.responses.ContentPackResponse;
 import org.graylog2.rest.models.system.contenpacks.responses.ContentPackRevisions;
 import org.graylog2.shared.bindings.GuiceInjectorHolder;
 import org.graylog2.shared.bindings.providers.ObjectMapperProvider;
@@ -121,9 +124,11 @@ public class ContentPackResourceTest {
     public void getContentPack() throws Exception {
         final ContentPack contentPack = objectMapper.readValue(CONTENT_PACK, ContentPack.class);
         final Set<ContentPack> contentPackSet = Collections.singleton(contentPack);
+        final Set<ConstraintCheckResult> constraints = Collections.emptySet();
 
         final Map<Integer, ContentPack> contentPacks = Collections.singletonMap(1, contentPack);
-        final ContentPackRevisions expectedRevisions = ContentPackRevisions.create(contentPacks);
+        final Map<Integer, Set<ConstraintCheckResult>> constraintMap = Collections.singletonMap(1, constraints);
+        final ContentPackRevisions expectedRevisions = ContentPackRevisions.create(contentPacks, constraintMap);
         final ModelId id = ModelId.of("1");
 
         when(contentPackPersistenceService.findAllById(id)).thenReturn(contentPackSet);
@@ -132,9 +137,9 @@ public class ContentPackResourceTest {
         assertThat(contentPackRevisions).isEqualTo(expectedRevisions);
 
         when(contentPackPersistenceService.findByIdAndRevision(id, 1)).thenReturn(Optional.ofNullable(contentPack));
-        final ContentPack contentPackResult = contentPackResource.listContentPackRevisions(id, 1);
+        final ContentPackResponse contentPackResponse = contentPackResource.getContentPackRevisions(id, 1);
         verify(contentPackPersistenceService, times(1)).findByIdAndRevision(id, 1);
-        assertThat(contentPackResult).isEqualTo(contentPack);
+        assertThat(contentPackResponse.contentPack()).isEqualTo(contentPack);
     }
 
     @Test

--- a/graylog2-web-interface/src/components/content-packs/ContentPackConstraints.jsx
+++ b/graylog2-web-interface/src/components/content-packs/ContentPackConstraints.jsx
@@ -17,12 +17,13 @@ class ContentPackConstraints extends React.Component {
   };
 
   _rowFormatter = (item) => {
+    const constraint = item.constraint || item;
     const fulfilledIcon = item.fulfilled || this.props.isFulfilled ? <i className="fa fa-check" /> : <i className="fa fa-times" />;
     const fulfilledBg = item.fulfilled || this.props.isFulfilled ? 'success' : 'failure';
     return (
-      <tr key={item.id}>
-        <td>{item.type}</td>
-        <td>{item.version}</td>
+      <tr key={constraint.id}>
+        <td>{constraint.type}</td>
+        <td>{constraint.version}</td>
         <td><Badge className={fulfilledBg}>{fulfilledIcon}</Badge></td>
       </tr>
     );

--- a/graylog2-web-interface/src/components/content-packs/ContentPackDetails.jsx
+++ b/graylog2-web-interface/src/components/content-packs/ContentPackDetails.jsx
@@ -13,6 +13,7 @@ import 'components/content-packs/ContentPackDetails.css';
 const ContentPackDetails = (props) => {
   const markdownDescription = markdown.toHTML(props.contentPack.description || '');
   const contentPack = props.contentPack;
+  const constraints = props.constraints;
 
   return (
     <Row>
@@ -44,7 +45,7 @@ const ContentPackDetails = (props) => {
           <br />
           { contentPack.requires && props.showConstraints &&
           <div>
-            <ContentPackConstraints constraints={contentPack.requires} />
+            <ContentPackConstraints constraints={constraints} />
             <br />
           </div>
           }
@@ -62,6 +63,7 @@ const ContentPackDetails = (props) => {
 
 ContentPackDetails.propTypes = {
   contentPack: PropTypes.object.isRequired,
+  constraints: PropTypes.arrayOf(PropTypes.object),
   verbose: PropTypes.bool,
   offset: PropTypes.number,
   showConstraints: PropTypes.bool,
@@ -71,6 +73,7 @@ ContentPackDetails.defaultProps = {
   offset: 1,
   verbose: false,
   showConstraints: false,
+  constraints: [],
 };
 
 export default ContentPackDetails;

--- a/graylog2-web-interface/src/components/content-packs/ContentPackDownloadControl.jsx
+++ b/graylog2-web-interface/src/components/content-packs/ContentPackDownloadControl.jsx
@@ -24,7 +24,7 @@ class ContentPackDownloadControl extends React.Component {
 
   _getDownloadUrl() {
     const url = new URI(URLUtils.qualifyUrl(
-      ApiRoutes.ContentPacksController.getRev(this.props.contentPackId, this.props.revision).url,
+      ApiRoutes.ContentPacksController.downloadRev(this.props.contentPackId, this.props.revision).url,
     ));
 
     if (URLUtils.areCredentialsInURLSupported()) {

--- a/graylog2-web-interface/src/pages/ShowContentPackPage.jsx
+++ b/graylog2-web-interface/src/pages/ShowContentPackPage.jsx
@@ -75,7 +75,7 @@ const ShowContentPackPage = createReactClass({
       return (<Spinner />);
     }
 
-    const { contentPack, selectedVersion } = this.state;
+    const { contentPack, selectedVersion, constraints } = this.state;
     const lastVersion = this._getLastVersion();
     const lastPack = contentPack[lastVersion];
     return (
@@ -123,7 +123,7 @@ const ShowContentPackPage = createReactClass({
               </div>
             </Col>
             <Col md={8} className="content">
-              <ContentPackDetails contentPack={contentPack[selectedVersion]} showConstraints verbose />
+              <ContentPackDetails contentPack={contentPack[selectedVersion]} constraints={constraints[selectedVersion]} showConstraints verbose />
             </Col>
           </Row>
         </span>

--- a/graylog2-web-interface/src/routing/ApiRoutes.js
+++ b/graylog2-web-interface/src/routing/ApiRoutes.js
@@ -35,6 +35,7 @@ const ApiRoutes = {
     list: () => { return { url: '/system/content_packs/latest' }; },
     get: (contentPackId) => { return { url: `/system/content_packs/${contentPackId}` }; },
     getRev: (contentPackId, revision) => { return { url: `/system/content_packs/${contentPackId}/${revision}` }; },
+    downloadRev: (contentPackId, revision) => { return { url: `/system/content_packs/${contentPackId}/${revision}/download` }; },
     create: () => { return { url: '/system/content_packs' }; },
     delete: (contentPackId) => { return { url: `/system/content_packs/${contentPackId}` }; },
     deleteRev: (contentPackId, revision) => { return { url: `/system/content_packs/${contentPackId}/${revision}` }; },

--- a/graylog2-web-interface/src/stores/content-packs/ContentPacksStore.jsx
+++ b/graylog2-web-interface/src/stores/content-packs/ContentPacksStore.jsx
@@ -15,8 +15,9 @@ const ContentPacksStore = Reflux.createStore({
     const promise = fetch('GET', url)
       .then((result) => {
         const contentPack = result.content_pack_revisions;
+        const constraints = result.constraints_result;
         const versions = Object.keys(contentPack);
-        this.trigger({ contentPack: contentPack, selectedVersion: versions[0] });
+        this.trigger({ contentPack: contentPack, selectedVersion: versions[0], constraints: constraints });
 
         return result;
       });
@@ -28,7 +29,7 @@ const ContentPacksStore = Reflux.createStore({
     const url = URLUtils.qualifyUrl(ApiRoutes.ContentPacksController.getRev(contentPackId, contentPackRev).url);
     const promise = fetch('GET', url)
       .then((result) => {
-        this.trigger({ contentPack: result });
+        this.trigger({ contentPack: result.content_pack });
         return result;
       });
 


### PR DESCRIPTION
## Description
Add requirements check result to content pack response. 

## Motivation and Context
We want to display if a requirement of a content pack is met by the server,
for that the server checkes if every constraint is met and adds the
information to the json result.

The frontend can now use the so send fulfilled flag to check if
the requirement is met

## Screenshots (if appropriate):
it's now green!
![screenshot_2018-08-01 graylog - content packs](https://user-images.githubusercontent.com/448763/43524698-363da40e-95a0-11e8-9d95-52bb9c274fe5.png)


## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
