### PR TITLE
Use title or name for the entity when renderning entities in the UI

### DIFF
--- a/graylog2-web-interface/src/components/content-packs/ContentPackEntitiesList.jsx
+++ b/graylog2-web-interface/src/components/content-packs/ContentPackEntitiesList.jsx
@@ -54,11 +54,11 @@ class ContentPackEntitiesList extends React.Component {
   };
 
   _entityTitle = (entity) => {
-    return (entity.data.title || {}).value || '';
+    return (entity.data.title || entity.data.name || {}).value || '';
   };
 
   _entityDescription = (entity) => {
-    return (entity.data.description || entity.data.name || {}).value || '';
+    return (entity.data.description || {}).value || '';
   };
 
   _entityRowFormatter = (entity) => {

--- a/graylog2-web-interface/src/components/content-packs/__snapshots__/ContentPackEntitiesList.test.jsx.snap
+++ b/graylog2-web-interface/src/components/content-packs/__snapshots__/ContentPackEntitiesList.test.jsx.snap
@@ -211,7 +211,7 @@ exports[`<ContentPackEntitiesList /> should render with entities and parameters 
                 <td
                   className="bigColumns"
                 >
-                  Input
+                  
                 </td>
                 <td>
                   1
@@ -252,7 +252,7 @@ exports[`<ContentPackEntitiesList /> should render with entities and parameters 
                 <td
                   className="bigColumns"
                 >
-                  BadInput
+                  
                 </td>
                 <td>
                   0

--- a/graylog2-web-interface/src/components/content-packs/__snapshots__/ContentPackParameters.test.jsx.snap
+++ b/graylog2-web-interface/src/components/content-packs/__snapshots__/ContentPackParameters.test.jsx.snap
@@ -302,7 +302,7 @@ exports[`<ContentPackParameters /> should render a parameter 1`] = `
                       <td
                         className="bigColumns"
                       >
-                        Input
+                        
                       </td>
                       <td>
                         0


### PR DESCRIPTION
Previously some entities had no title but a description, that looked
strange.

Refs #4946

## Before

![image](https://user-images.githubusercontent.com/461/43524891-ad94233e-95a0-11e8-9314-b075fa12b367.png)

## After

![image](https://user-images.githubusercontent.com/461/43524856-98146078-95a0-11e8-8d80-0503c3838766.png)
