### PR TITLE
Reuse old widget IDs when installing a dashboard from content packs

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/contentpacks/facades/DashboardFacade.java
+++ b/graylog2-server/src/main/java/org/graylog2/contentpacks/facades/DashboardFacade.java
@@ -63,7 +63,6 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
-import java.util.UUID;
 import java.util.stream.Collectors;
 
 import static com.google.common.base.Strings.isNullOrEmpty;
@@ -114,6 +113,7 @@ public class DashboardFacade implements EntityFacade<Dashboard> {
 
     private DashboardWidgetEntity encodeWidget(DashboardWidget widget, @Nullable WidgetPosition position) {
         return DashboardWidgetEntity.create(
+                ValueReference.of(widget.getId()),
                 ValueReference.of(widget.getDescription()),
                 ValueReference.of(widget.getType()),
                 ValueReference.of(widget.getCacheTime()),
@@ -186,6 +186,7 @@ public class DashboardFacade implements EntityFacade<Dashboard> {
         final ImmutableList.Builder<WidgetPositionsRequest.WidgetPosition> widgetPositions = ImmutableList.builder();
         for (DashboardWidgetEntity widgetEntity : widgets) {
             final DashboardWidget widget = createDashboardWidget(
+                    widgetEntity.id().asString(parameters),
                     widgetEntity.type().asString(parameters),
                     widgetEntity.description().asString(parameters),
                     toValueMap(widgetEntity.configuration(), parameters),
@@ -217,6 +218,7 @@ public class DashboardFacade implements EntityFacade<Dashboard> {
 
     @SuppressWarnings("unchecked")
     private DashboardWidget createDashboardWidget(
+            final String id,
             final String type,
             final String description,
             final Map<String, Object> configuration,
@@ -248,9 +250,8 @@ public class DashboardFacade implements EntityFacade<Dashboard> {
         final Map<String, Object> timerangeConfig = (Map<String, Object>) widgetConfig.get("timerange");
         final TimeRange timeRange = timeRangeFactory.create(timerangeConfig);
 
-        final String widgetId = UUID.randomUUID().toString();
         return widgetCreator.buildDashboardWidget(type,
-                widgetId, description, cacheTime,
+                id, description, cacheTime,
                 widgetConfig, timeRange, username);
     }
 

--- a/graylog2-server/src/main/java/org/graylog2/contentpacks/model/entities/DashboardWidgetEntity.java
+++ b/graylog2-server/src/main/java/org/graylog2/contentpacks/model/entities/DashboardWidgetEntity.java
@@ -34,6 +34,10 @@ import java.util.Optional;
 @WithBeanGetter
 @JsonAutoDetect
 public abstract class DashboardWidgetEntity {
+    @JsonProperty("id")
+    @NotNull
+    public abstract ValueReference id();
+
     @JsonProperty("description")
     @NotNull
     public abstract ValueReference description();
@@ -59,13 +63,14 @@ public abstract class DashboardWidgetEntity {
 
     @JsonCreator
     public static DashboardWidgetEntity create(
+            @JsonProperty("id") @NotNull ValueReference id,
             @JsonProperty("description") @NotNull ValueReference description,
             @JsonProperty("type") @NotBlank ValueReference type,
             @JsonProperty("cache_time") @PositiveOrZero ValueReference cacheTime,
             @JsonProperty("time_range") @NotNull TimeRangeEntity timeRange,
             @JsonProperty("configuration") @NotNull ReferenceMap configuration,
             @JsonProperty("position") @Nullable Position position) {
-        return new AutoValue_DashboardWidgetEntity(description, type, cacheTime, timeRange, configuration, Optional.ofNullable(position));
+        return new AutoValue_DashboardWidgetEntity(id, description, type, cacheTime, timeRange, configuration, Optional.ofNullable(position));
     }
 
     @AutoValue

--- a/graylog2-server/src/test/java/org/graylog2/contentpacks/facades/DashboardFacadeTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/contentpacks/facades/DashboardFacadeTest.java
@@ -271,6 +271,7 @@ public class DashboardFacadeTest {
     @Test
     public void resolveEntity() throws InvalidRangeParametersException {
         final DashboardWidgetEntity dashboardWidgetEntity = DashboardWidgetEntity.create(
+                ValueReference.of("12345"),
                 ValueReference.of("Description"),
                 ValueReference.of("type"),
                 ValueReference.of(120),
@@ -320,6 +321,7 @@ public class DashboardFacadeTest {
     @UsingDataSet(loadStrategy = LoadStrategyEnum.DELETE_ALL)
     public void createNativeEntity() throws InvalidRangeParametersException {
         final DashboardWidgetEntity dashboardWidgetEntity = DashboardWidgetEntity.create(
+                ValueReference.of("12345"),
                 ValueReference.of("Description"),
                 ValueReference.of("type"),
                 ValueReference.of(120),
@@ -347,6 +349,9 @@ public class DashboardFacadeTest {
         final Dashboard savedDashboard = allDashboards.get(0);
         final Dashboard dashboard = nativeEntity.entity();
         assertThat(dashboard).isEqualTo(savedDashboard);
+
+        assertThat(dashboard.getWidgets().size()).isEqualTo(1);
+        assertThat(dashboard.getWidgets()).containsKeys("12345");
 
         final NativeEntityDescriptor expectedDescriptor = NativeEntityDescriptor.create(savedDashboard.getId(), ModelTypes.DASHBOARD);
         assertThat(nativeEntity.descriptor()).isEqualTo(expectedDescriptor);

--- a/graylog2-server/src/test/java/org/graylog2/contentpacks/jackson/ValueReferenceTypeIdResolverTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/contentpacks/jackson/ValueReferenceTypeIdResolverTest.java
@@ -41,6 +41,10 @@ public class ValueReferenceTypeIdResolverTest {
     @Test
     public void testEmbeddedDeserialization() throws IOException {
         String json = "{" +
+                "  \"id\" : {" +
+                "     \"value\" : \"12345\"," +
+                "     \"type\" : \"string\"" +
+                "  }," +
                 "  \"cache_time\" : {" +
                 "     \"value\" : 120," +
                 "     \"type\" : \"integer\"" +


### PR DESCRIPTION
Installing a dashboard through a content pack will reuse old widget IDs, ensuring references from other installed entities can still be used.

This is needed because dashboard widgets don't have their own `ModelType`, making it impossible to find the referenced widget during install. As widget IDs are embedded inside the dashboard document, potentially duplicating widget IDs should not be a problem.
