### PR TITLE
feat(MessageList): terminal view

### DIFF
--- a/NOTES
+++ b/NOTES
@@ -1,0 +1,8 @@
+1. Start docker-compose to back web interface
+2. `yarn start` in graylog2-web-interface
+3. Emit some messages:
+```
+for i in (seq 0 400);
+  echo "test message $i" | nc localhost 514
+end
+```

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,41 @@
+version: '2'
+services:
+  # MongoDB: https://hub.docker.com/_/mongo/
+  mongo:
+    image: mongo:3
+  # Elasticsearch: https://www.elastic.co/guide/en/elasticsearch/reference/5.5/docker.html
+  elasticsearch:
+    image: docker.elastic.co/elasticsearch/elasticsearch:5.6.9
+    environment:
+      - http.host=0.0.0.0
+      # Disable X-Pack security: https://www.elastic.co/guide/en/elasticsearch/reference/5.5/security-settings.html#general-security-settings
+      - xpack.security.enabled=false
+      - "ES_JAVA_OPTS=-Xms512m -Xmx512m"
+    ulimits:
+      memlock:
+        soft: -1
+        hard: -1
+    mem_limit: 1g
+  # Graylog: https://hub.docker.com/r/graylog/graylog/
+  graylog:
+    image: graylog/graylog:2.4
+    environment:
+      # CHANGE ME!
+      - GRAYLOG_PASSWORD_SECRET=somepasswordpepper
+      # Password: admin
+      - GRAYLOG_ROOT_PASSWORD_SHA2=8c6976e5b5410415bde908bd4dee15dfb167a9c873fc4bb8a81f6f2ab448a918
+      - GRAYLOG_WEB_ENDPOINT_URI=http://127.0.0.1:9000/api
+    links:
+      - mongo
+      - elasticsearch
+    ports:
+      # Graylog web interface and REST API
+      - 9000:9000
+      # Syslog TCP
+      - 514:514
+      # Syslog UDP
+      - 514:514/udp
+      # GELF TCP
+      - 12201:12201
+      # GELF UDP
+      - 12201:12201/udp

--- a/graylog2-web-interface/src/components/search/MessageTableEntry.css
+++ b/graylog2-web-interface/src/components/search/MessageTableEntry.css
@@ -6,8 +6,18 @@
 }
 
 :local .terminalView :global(tr.message-row td) {
+    left: 5px;
     padding-bottom: 0 !important;
-    color: white;
+    color: white !important;
+    font-size: 105%;
+    word-break: break-word;
+    border-bottom: 1px solid #444;
+    overflow: visible;
+    padding-left: 10px;
+}
+
+:local .terminalView :global(tr.message-row time) {
+    margin-left: -10px;
 }
 
 :local .terminalView :global(.message-detail-row td) {

--- a/graylog2-web-interface/src/components/search/MessageTableEntry.css
+++ b/graylog2-web-interface/src/components/search/MessageTableEntry.css
@@ -1,3 +1,24 @@
 :local .timezoneInfo {
     color: #aaa;
 }
+
+:local .terminalView {
+}
+
+:local .terminalView :global(tr.message-row td) {
+    padding-bottom: 0 !important;
+    color: white;
+}
+
+:local .terminalView :global(.message-detail-row td) {
+    background: white;
+    left: 0;
+}
+
+:local .terminalView :global(.message-wrapper:after) {
+    display: none;
+}
+
+:local .terminalSource {
+    color: #AF892D;
+}

--- a/graylog2-web-interface/src/components/search/MessageTableEntry.jsx
+++ b/graylog2-web-interface/src/components/search/MessageTableEntry.jsx
@@ -32,6 +32,7 @@ class MessageTableEntry extends React.Component {
     selectedFields: ImmutablePropTypes.orderedSet,
     showMessageRow: PropTypes.bool,
     streams: ImmutablePropTypes.map.isRequired,
+    terminalView: PropTypes.bool,
     toggleDetail: PropTypes.func.isRequired,
   };
 
@@ -42,6 +43,7 @@ class MessageTableEntry extends React.Component {
     searchConfig: undefined,
     selectedFields: Immutable.OrderedSet(),
     showMessageRow: false,
+    terminalView: false,
   };
 
   shouldComponentUpdate(newProps) {
@@ -61,6 +63,9 @@ class MessageTableEntry extends React.Component {
       return true;
     }
     if (this.props.showMessageRow !== newProps.showMessageRow) {
+      return true;
+    }
+    if (this.props.terminalView !== newProps.terminalView) {
       return true;
     }
     return false;
@@ -145,34 +150,48 @@ class MessageTableEntry extends React.Component {
   };
 
   render() {
-    const colSpanFixup = this.props.selectedFields.size + 1;
+    const { expanded, highlightMessage, message, selectedFields, showMessageRow, terminalView } = this.props;
+    const colSpanFixup = selectedFields.size + 1;
 
     let classes = 'message-group';
-    if (this.props.expanded) {
+    if (expanded) {
       classes += ' message-group-toggled';
     }
-    if (this.props.message.id === this.props.highlightMessage) {
+    if (message.id === highlightMessage) {
       classes += ' message-highlight';
+    }
+    if (terminalView) {
+      classes += ` ${style.terminalView}`;
     }
 
     return (
       <tbody className={classes}>
+        {!terminalView &&
         <tr className="fields-row" onClick={this._toggleDetail}>
           <td><strong>
-            <Timestamp dateTime={this.props.message.fields.timestamp} />
+            <Timestamp dateTime={message.fields.timestamp} />
           </strong></td>
-          { this.props.selectedFields.toSeq().map(selectedFieldName => (<td
+          {selectedFields.toSeq().map(selectedFieldName => (<td
             key={selectedFieldName}>{this.renderForDisplay(selectedFieldName, true)} </td>)) }
         </tr>
+        }
 
-        {this.props.showMessageRow &&
+        {showMessageRow &&
         <tr className="message-row" onClick={this._toggleDetail}>
-          <td colSpan={colSpanFixup}><div className="message-wrapper">{this.renderForDisplay('message', true)}</div></td>
+          <td colSpan={colSpanFixup}>
+            <div className="message-wrapper">
+              {terminalView && <Timestamp datetime={message.fields.timestamp} />}
+              {terminalView && <span className={style.terminalSource}> {this.renderForDisplay('source')} </span>}
+              {this.renderForDisplay('message', true)}
+            </div>
+          </td>
         </tr>
         }
-        {this.props.expanded &&
+
+        {expanded &&
         <tr className="message-detail-row" style={{ display: 'table-row' }}>
           <td colSpan={colSpanFixup}>
+
             <MessageDetail message={this.props.message}
                            inputs={this.props.inputs}
                            streams={this.props.streams}

--- a/graylog2-web-interface/src/components/search/ResultTable.css
+++ b/graylog2-web-interface/src/components/search/ResultTable.css
@@ -1,0 +1,7 @@
+:local .terminalView {
+    background: black;
+}
+
+:local .terminalView :global(thead) {
+    display: none;
+}

--- a/graylog2-web-interface/src/components/search/ResultTable.jsx
+++ b/graylog2-web-interface/src/components/search/ResultTable.jsx
@@ -156,7 +156,7 @@ class ResultTable extends React.Component {
   render() {
     const selectedColumns = this._fieldColumns();
     let { messages } = this.props;
-    if (this.state.reverseMessages) messages = messages.reverse();
+    if (this.state.reverseMessages) messages = messages.concat().reverse();
 
     return (
       <div className="content-col">

--- a/graylog2-web-interface/src/components/search/ResultTable.jsx
+++ b/graylog2-web-interface/src/components/search/ResultTable.jsx
@@ -11,6 +11,7 @@ import ActionsProvider from 'injection/ActionsProvider';
 const RefreshActions = ActionsProvider.getActions('Refresh');
 
 import { MessageTableEntry, MessageTablePaginator } from 'components/search';
+import style from './ResultTable.css';
 
 class ResultTable extends React.Component {
   static propTypes = {
@@ -40,6 +41,8 @@ class ResultTable extends React.Component {
     allStreamsLoaded: false,
     allStreams: Immutable.List(),
     expandAllRenderAsync: false,
+    reverse: false,
+    terminalView: false,
   };
 
   componentDidMount() {
@@ -100,6 +103,14 @@ class ResultTable extends React.Component {
     this.setState({ expandedMessages: Immutable.Set() });
   };
 
+  reverseMessages = () => {
+    this.setState({ reverseMessages: !this.state.reverseMessages });
+  };
+
+  terminalView = () => {
+    this.setState({ terminalView: !this.state.terminalView });
+  };
+
   _handleSort = (e, field, order) => {
     e.preventDefault();
     SearchStore.sort(field, order);
@@ -144,6 +155,9 @@ class ResultTable extends React.Component {
 
   render() {
     const selectedColumns = this._fieldColumns();
+    let { messages } = this.props;
+    if (this.state.reverseMessages) messages = messages.reverse();
+
     return (
       <div className="content-col">
         <h1 className="pull-left">Messages</h1>
@@ -152,7 +166,16 @@ class ResultTable extends React.Component {
           <Button title="Expand all messages" onClick={this.expandAll}><i className="fa fa-expand" /></Button>
           <Button title="Collapse all messages"
                   onClick={this.collapseAll}
-                  disabled={this.state.expandedMessages.size === 0}><i className="fa fa-compress" /></Button>
+                  disabled={this.state.expandedMessages.size === 0}>
+            <i className="fa fa-compress" />
+          </Button>
+          {this.state.terminalView ?
+            <Button title="List View" onClick={this.terminalView}><i className="fa fa-list-ul" /></Button>
+            : <Button title="Terminal View" onClick={this.terminalView}><i className="fa fa-terminal" /></Button>
+          }
+          <Button title="Reverse Messages" onClick={this.reverseMessages}>
+            <i className={`fa fa-${this.state.reverseMessages ? 'arrow-down' : 'arrow-up'}`} />
+          </Button>
         </ButtonGroup>
 
         <MessageTablePaginator currentPage={Number(this.props.page)}
@@ -161,7 +184,7 @@ class ResultTable extends React.Component {
                                position="top"
                                resultCount={this.props.resultCount} />
 
-        <div className="search-results-table">
+        <div className={`search-results-table ${this.state.terminalView ? style.terminalView : ''}`}>
           <div className="table-responsive">
             <div className="messages-container">
               <table className="table table-condensed messages">
@@ -178,7 +201,7 @@ class ResultTable extends React.Component {
                     })}
                   </tr>
                 </thead>
-                {this.props.messages.map((message) => {
+                {messages.map((message) => {
                   return (
                     <MessageTableEntry key={`${message.index}-${message.id}`}
                                        disableSurroundingSearch={this.props.disableSurroundingSearch}
@@ -195,6 +218,7 @@ class ResultTable extends React.Component {
                                        highlight={this.props.highlight}
                                        highlightMessage={SearchStore.highlightMessage}
                                        expandAllRenderAsync={this.state.expandAllRenderAsync}
+                                       terminalView={this.state.terminalView}
                                        searchConfig={this.props.searchConfig} />
                   );
                 })}


### PR DESCRIPTION
Addresses #2479.

Please treat this as a work in progress as I want to gather feedback on the style we're using here. I also would like to persist these state options to localStorage, but I don't see an established pattern. I use/recommend [react-localstorage](https://github.com/STRML/react-localstorage), of course.

## Description
Adds a few buttons to easily modify list style for readability.

There are two main features here:

1. Terminal View, which shows only `date`, `source`, and `message`, and
2. A "Reverse Messages" button. This is different than simply reversing timestamp, which puts the oldest messages in the entire search at the top. I might want the oldest messages *on the current page* at the top in terminal view, so it reads like `tail -f` output.

## Motivation and Context
Modeling this view similarly to a terminal or Papertrail's output.

## How Has This Been Tested?
Has not been tested. New to development on graylog2-web-server core but happy to add tests if you have pointers.

## Screenshots (if appropriate):
<img width="748" alt="screen shot 2018-08-01 at 13 31 18" src="https://user-images.githubusercontent.com/1197375/43541129-3c8fb628-958f-11e8-8ee7-4fc77ec859d0.png">
<img width="754" alt="screen shot 2018-08-01 at 13 31 32" src="https://user-images.githubusercontent.com/1197375/43541131-3dfb7a42-958f-11e8-8252-82dbc2e23cc1.png">
<img width="758" alt="screen shot 2018-08-01 at 13 26 28" src="https://user-images.githubusercontent.com/1197375/43541010-eb386ac2-958e-11e8-8980-77f98f62b333.png">
<img width="774" alt="screen shot 2018-08-01 at 13 26 33" src="https://user-images.githubusercontent.com/1197375/43541011-ebc1df8c-958e-11e8-8c54-b3e9bad220aa.png">
<img width="752" alt="screen shot 2018-08-01 at 13 26 40" src="https://user-images.githubusercontent.com/1197375/43541012-ec4acaea-958e-11e8-9c7a-0fe032905326.png">
<img width="753" alt="screen shot 2018-08-01 at 13 26 43" src="https://user-images.githubusercontent.com/1197375/43541013-ecd16564-958e-11e8-9dbc-3cd9c9a69804.png">


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
