### PR TITLE
Implement content pack entity versioning

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/contentpacks/ContentPacksModule.java
+++ b/graylog2-server/src/main/java/org/graylog2/contentpacks/ContentPacksModule.java
@@ -43,19 +43,19 @@ public class ContentPacksModule extends PluginModule {
 
         jerseyAdditionalComponentsBinder().addBinding().toInstance(ModelIdParamConverter.Provider.class);
 
-        addEntityFacade(CollectorConfigurationFacade.TYPE, CollectorConfigurationFacade.class);
-        addEntityFacade(CollectorFacade.TYPE, CollectorFacade.class);
-        addEntityFacade(DashboardFacade.TYPE, DashboardFacade.class);
-        addEntityFacade(GrokPatternFacade.TYPE, GrokPatternFacade.class);
-        addEntityFacade(InputFacade.TYPE, InputFacade.class);
-        addEntityFacade(LookupCacheFacade.TYPE, LookupCacheFacade.class);
-        addEntityFacade(LookupDataAdapterFacade.TYPE, LookupDataAdapterFacade.class);
-        addEntityFacade(LookupTableFacade.TYPE, LookupTableFacade.class);
-        addEntityFacade(OutputFacade.TYPE, OutputFacade.class);
-        addEntityFacade(PipelineFacade.TYPE, PipelineFacade.class);
-        addEntityFacade(PipelineRuleFacade.TYPE, PipelineRuleFacade.class);
+        addEntityFacade(CollectorConfigurationFacade.TYPE_V1, CollectorConfigurationFacade.class);
+        addEntityFacade(CollectorFacade.TYPE_V1, CollectorFacade.class);
+        addEntityFacade(DashboardFacade.TYPE_V1, DashboardFacade.class);
+        addEntityFacade(GrokPatternFacade.TYPE_V1, GrokPatternFacade.class);
+        addEntityFacade(InputFacade.TYPE_V1, InputFacade.class);
+        addEntityFacade(LookupCacheFacade.TYPE_V1, LookupCacheFacade.class);
+        addEntityFacade(LookupDataAdapterFacade.TYPE_V1, LookupDataAdapterFacade.class);
+        addEntityFacade(LookupTableFacade.TYPE_V1, LookupTableFacade.class);
+        addEntityFacade(OutputFacade.TYPE_V1, OutputFacade.class);
+        addEntityFacade(PipelineFacade.TYPE_V1, PipelineFacade.class);
+        addEntityFacade(PipelineRuleFacade.TYPE_V1, PipelineRuleFacade.class);
         addEntityFacade(RootEntityFacade.TYPE, RootEntityFacade.class);
-        addEntityFacade(StreamFacade.TYPE, StreamFacade.class);
+        addEntityFacade(StreamFacade.TYPE_V1, StreamFacade.class);
 
         addConstraintChecker(GraylogVersionConstraintChecker.class);
         addConstraintChecker(PluginVersionConstraintChecker.class);

--- a/graylog2-server/src/main/java/org/graylog2/contentpacks/facades/CollectorConfigurationFacade.java
+++ b/graylog2-server/src/main/java/org/graylog2/contentpacks/facades/CollectorConfigurationFacade.java
@@ -49,7 +49,7 @@ import static java.util.Objects.isNull;
 public class CollectorConfigurationFacade implements EntityFacade<Configuration> {
     private static final Logger LOG = LoggerFactory.getLogger(CollectorConfigurationFacade.class);
 
-    public static final ModelType TYPE = ModelTypes.COLLECTOR_CONFIGURATION;
+    public static final ModelType TYPE = ModelTypes.COLLECTOR_CONFIGURATION_V1;
 
     private final ObjectMapper objectMapper;
     private final ConfigurationService configurationService;
@@ -150,7 +150,7 @@ public class CollectorConfigurationFacade implements EntityFacade<Configuration>
             LOG.debug("Could not find configuration {}", entityDescriptor);
         } else {
             final EntityDescriptor collectorEntityDescriptor = EntityDescriptor.create(
-                    configuration.collectorId(), ModelTypes.COLLECTOR);
+                    configuration.collectorId(), ModelTypes.COLLECTOR_V1);
             mutableGraph.putEdge(entityDescriptor, collectorEntityDescriptor);
         }
 
@@ -175,7 +175,7 @@ public class CollectorConfigurationFacade implements EntityFacade<Configuration>
         mutableGraph.addNode(entity);
 
         final CollectorConfigurationEntity configurationEntity = objectMapper.convertValue(entity.data(), CollectorConfigurationEntity.class);
-        final EntityDescriptor collectorDescriptor = EntityDescriptor.create(configurationEntity.collectorId().asString(parameters), ModelTypes.COLLECTOR);
+        final EntityDescriptor collectorDescriptor = EntityDescriptor.create(configurationEntity.collectorId().asString(parameters), ModelTypes.COLLECTOR_V1);
         final Entity collectorEntity = entities.get(collectorDescriptor);
 
         if (collectorEntity != null) {

--- a/graylog2-server/src/main/java/org/graylog2/contentpacks/facades/CollectorConfigurationFacade.java
+++ b/graylog2-server/src/main/java/org/graylog2/contentpacks/facades/CollectorConfigurationFacade.java
@@ -49,7 +49,7 @@ import static java.util.Objects.isNull;
 public class CollectorConfigurationFacade implements EntityFacade<Configuration> {
     private static final Logger LOG = LoggerFactory.getLogger(CollectorConfigurationFacade.class);
 
-    public static final ModelType TYPE = ModelTypes.COLLECTOR_CONFIGURATION_V1;
+    public static final ModelType TYPE_V1 = ModelTypes.COLLECTOR_CONFIGURATION_V1;
 
     private final ObjectMapper objectMapper;
     private final ConfigurationService configurationService;
@@ -70,7 +70,7 @@ public class CollectorConfigurationFacade implements EntityFacade<Configuration>
         final JsonNode data = objectMapper.convertValue(configurationEntity, JsonNode.class);
         final EntityV1 entity = EntityV1.builder()
                 .id(ModelId.of(configuration.id()))
-                .type(TYPE)
+                .type(TYPE_V1)
                 .data(data)
                 .build();
         return EntityWithConstraints.create(entity);
@@ -97,7 +97,7 @@ public class CollectorConfigurationFacade implements EntityFacade<Configuration>
                 configurationEntity.template().asString(parameters));
 
         final Configuration savedConfiguration = configurationService.save(configuration);
-        return NativeEntity.create(entity.id(), savedConfiguration.id(), TYPE, savedConfiguration);
+        return NativeEntity.create(entity.id(), savedConfiguration.id(), TYPE_V1, savedConfiguration);
     }
 
     @Override
@@ -115,7 +115,7 @@ public class CollectorConfigurationFacade implements EntityFacade<Configuration>
     public EntityExcerpt createExcerpt(Configuration configuration) {
         return EntityExcerpt.builder()
                 .id(ModelId.of(configuration.id()))
-                .type(TYPE)
+                .type(TYPE_V1)
                 .title(configuration.name())
                 .build();
     }

--- a/graylog2-server/src/main/java/org/graylog2/contentpacks/facades/CollectorFacade.java
+++ b/graylog2-server/src/main/java/org/graylog2/contentpacks/facades/CollectorFacade.java
@@ -47,7 +47,7 @@ import static java.util.Objects.isNull;
 public class CollectorFacade implements EntityFacade<Collector> {
     private static final Logger LOG = LoggerFactory.getLogger(CollectorFacade.class);
 
-    public static final ModelType TYPE = ModelTypes.COLLECTOR;
+    public static final ModelType TYPE = ModelTypes.COLLECTOR_V1;
 
     private final ObjectMapper objectMapper;
     private final CollectorService collectorService;

--- a/graylog2-server/src/main/java/org/graylog2/contentpacks/facades/CollectorFacade.java
+++ b/graylog2-server/src/main/java/org/graylog2/contentpacks/facades/CollectorFacade.java
@@ -47,7 +47,7 @@ import static java.util.Objects.isNull;
 public class CollectorFacade implements EntityFacade<Collector> {
     private static final Logger LOG = LoggerFactory.getLogger(CollectorFacade.class);
 
-    public static final ModelType TYPE = ModelTypes.COLLECTOR_V1;
+    public static final ModelType TYPE_V1 = ModelTypes.COLLECTOR_V1;
 
     private final ObjectMapper objectMapper;
     private final CollectorService collectorService;
@@ -81,7 +81,7 @@ public class CollectorFacade implements EntityFacade<Collector> {
         final JsonNode data = objectMapper.convertValue(collectorEntity, JsonNode.class);
         final EntityV1 entity = EntityV1.builder()
                 .id(ModelId.of(collector.id()))
-                .type(TYPE)
+                .type(TYPE_V1)
                 .data(data)
                 .build();
         return EntityWithConstraints.create(entity);
@@ -121,7 +121,7 @@ public class CollectorFacade implements EntityFacade<Collector> {
                 .build();
 
         final Collector savedCollector = collectorService.save(collector);
-        return NativeEntity.create(entity.id(), savedCollector.id(), TYPE, savedCollector);
+        return NativeEntity.create(entity.id(), savedCollector.id(), TYPE_V1, savedCollector);
     }
 
     @Override
@@ -141,7 +141,7 @@ public class CollectorFacade implements EntityFacade<Collector> {
         final Optional<Collector> existingCollector = Optional.ofNullable(collectorService.findByName(name));
         existingCollector.ifPresent(collector -> compareCollectors(name, serviceType, collector));
 
-        return existingCollector.map(collector -> NativeEntity.create(entity.id(), collector.id(), TYPE, collector));
+        return existingCollector.map(collector -> NativeEntity.create(entity.id(), collector.id(), TYPE_V1, collector));
     }
 
     private void compareCollectors(String name, String serviceType, Collector existingCollector) {
@@ -159,7 +159,7 @@ public class CollectorFacade implements EntityFacade<Collector> {
     public EntityExcerpt createExcerpt(Collector collector) {
         return EntityExcerpt.builder()
                 .id(ModelId.of(collector.id()))
-                .type(TYPE)
+                .type(TYPE_V1)
                 .title(collector.name())
                 .build();
     }

--- a/graylog2-server/src/main/java/org/graylog2/contentpacks/facades/DashboardFacade.java
+++ b/graylog2-server/src/main/java/org/graylog2/contentpacks/facades/DashboardFacade.java
@@ -72,7 +72,7 @@ import static org.graylog2.contentpacks.model.entities.references.ReferenceMapUt
 public class DashboardFacade implements EntityFacade<Dashboard> {
     private static final Logger LOG = LoggerFactory.getLogger(DashboardFacade.class);
 
-    public static final ModelType TYPE = ModelTypes.DASHBOARD_V1;
+    public static final ModelType TYPE_V1 = ModelTypes.DASHBOARD_V1;
 
     private final ObjectMapper objectMapper;
     private final DashboardService dashboardService;
@@ -162,7 +162,7 @@ public class DashboardFacade implements EntityFacade<Dashboard> {
             throw new ContentPackException("Couldn't create dashboard", e);
         }
 
-        return NativeEntity.create(entity.id(), dashboard.getId(), TYPE, dashboard);
+        return NativeEntity.create(entity.id(), dashboard.getId(), TYPE_V1, dashboard);
     }
 
     private Dashboard createDashboard(

--- a/graylog2-server/src/main/java/org/graylog2/contentpacks/facades/DashboardFacade.java
+++ b/graylog2-server/src/main/java/org/graylog2/contentpacks/facades/DashboardFacade.java
@@ -72,7 +72,7 @@ import static org.graylog2.contentpacks.model.entities.references.ReferenceMapUt
 public class DashboardFacade implements EntityFacade<Dashboard> {
     private static final Logger LOG = LoggerFactory.getLogger(DashboardFacade.class);
 
-    public static final ModelType TYPE = ModelTypes.DASHBOARD;
+    public static final ModelType TYPE = ModelTypes.DASHBOARD_V1;
 
     private final ObjectMapper objectMapper;
     private final DashboardService dashboardService;
@@ -105,7 +105,7 @@ public class DashboardFacade implements EntityFacade<Dashboard> {
         final JsonNode data = objectMapper.convertValue(dashboardEntity, JsonNode.class);
         final EntityV1 entity = EntityV1.builder()
                 .id(ModelId.of(dashboard.getId()))
-                .type(ModelTypes.DASHBOARD)
+                .type(ModelTypes.DASHBOARD_V1)
                 .data(data)
                 .build();
         return EntityWithConstraints.create(entity);
@@ -232,7 +232,7 @@ public class DashboardFacade implements EntityFacade<Dashboard> {
         // Replace "stream_id" in configuration if it's set
         final String streamReference = (String) widgetConfig.get("stream_id");
         if (!isNullOrEmpty(streamReference)) {
-            final EntityDescriptor streamDescriptor = EntityDescriptor.create(streamReference, ModelTypes.STREAM);
+            final EntityDescriptor streamDescriptor = EntityDescriptor.create(streamReference, ModelTypes.STREAM_V1);
             final Object stream = nativeEntities.get(streamDescriptor);
 
             if (stream == null) {
@@ -264,7 +264,7 @@ public class DashboardFacade implements EntityFacade<Dashboard> {
     public EntityExcerpt createExcerpt(Dashboard dashboard) {
         return EntityExcerpt.builder()
                 .id(ModelId.of(dashboard.getId()))
-                .type(ModelTypes.DASHBOARD)
+                .type(ModelTypes.DASHBOARD_V1)
                 .title(dashboard.getTitle())
                 .build();
     }
@@ -301,7 +301,7 @@ public class DashboardFacade implements EntityFacade<Dashboard> {
                 if (!isNullOrEmpty(streamId)) {
                     LOG.debug("Adding stream <{}> as dependency of widget <{}> on dashboard <{}>",
                             streamId, widget.getId(), dashboard.getId());
-                    final EntityDescriptor stream = EntityDescriptor.create(streamId, ModelTypes.STREAM);
+                    final EntityDescriptor stream = EntityDescriptor.create(streamId, ModelTypes.STREAM_V1);
                     mutableGraph.putEdge(entityDescriptor, stream);
                 }
             }
@@ -336,7 +336,7 @@ public class DashboardFacade implements EntityFacade<Dashboard> {
                 .map(ref -> (ValueReference) ref)
                 .map(valueReference -> valueReference.asString(parameters))
                 .map(ModelId::of)
-                .map(modelId -> EntityDescriptor.create(modelId, ModelTypes.STREAM))
+                .map(modelId -> EntityDescriptor.create(modelId, ModelTypes.STREAM_V1))
                 .map(entities::get)
                 .filter(Objects::nonNull)
                 .forEach(stream -> mutableGraph.putEdge(entity, stream));

--- a/graylog2-server/src/main/java/org/graylog2/contentpacks/facades/GrokPatternFacade.java
+++ b/graylog2-server/src/main/java/org/graylog2/contentpacks/facades/GrokPatternFacade.java
@@ -46,7 +46,7 @@ import java.util.stream.Collectors;
 public class GrokPatternFacade implements EntityFacade<GrokPattern> {
     private static final Logger LOG = LoggerFactory.getLogger(GrokPatternFacade.class);
 
-    public static final ModelType TYPE = ModelTypes.GROK_PATTERN_V1;
+    public static final ModelType TYPE_V1 = ModelTypes.GROK_PATTERN_V1;
 
     private final ObjectMapper objectMapper;
     private final GrokPatternService grokPatternService;
@@ -91,7 +91,7 @@ public class GrokPatternFacade implements EntityFacade<GrokPattern> {
         final GrokPattern grokPattern = GrokPattern.create(name, pattern);
         try {
             final GrokPattern savedGrokPattern = grokPatternService.save(grokPattern);
-            return NativeEntity.create(entity.id(), savedGrokPattern.id(), TYPE, savedGrokPattern);
+            return NativeEntity.create(entity.id(), savedGrokPattern.id(), TYPE_V1, savedGrokPattern);
         } catch (ValidationException e) {
             throw new RuntimeException("Couldn't create grok pattern " + grokPattern.name());
         }
@@ -119,7 +119,7 @@ public class GrokPatternFacade implements EntityFacade<GrokPattern> {
         final Optional<GrokPattern> grokPattern = grokPatternService.loadByName(name);
         grokPattern.ifPresent(existingPattern -> compareGrokPatterns(name, pattern, existingPattern.pattern()));
 
-        return grokPattern.map(gp -> NativeEntity.create(entity.id(), gp.id(), TYPE, gp));
+        return grokPattern.map(gp -> NativeEntity.create(entity.id(), gp.id(), TYPE_V1, gp));
     }
 
     private void compareGrokPatterns(String name, String expectedPattern, String actualPattern) {

--- a/graylog2-server/src/main/java/org/graylog2/contentpacks/facades/GrokPatternFacade.java
+++ b/graylog2-server/src/main/java/org/graylog2/contentpacks/facades/GrokPatternFacade.java
@@ -46,7 +46,7 @@ import java.util.stream.Collectors;
 public class GrokPatternFacade implements EntityFacade<GrokPattern> {
     private static final Logger LOG = LoggerFactory.getLogger(GrokPatternFacade.class);
 
-    public static final ModelType TYPE = ModelTypes.GROK_PATTERN;
+    public static final ModelType TYPE = ModelTypes.GROK_PATTERN_V1;
 
     private final ObjectMapper objectMapper;
     private final GrokPatternService grokPatternService;
@@ -65,7 +65,7 @@ public class GrokPatternFacade implements EntityFacade<GrokPattern> {
         final JsonNode data = objectMapper.convertValue(grokPatternEntity, JsonNode.class);
         final EntityV1 entity = EntityV1.builder()
                 .id(ModelId.of(grokPattern.id()))
-                .type(ModelTypes.GROK_PATTERN)
+                .type(ModelTypes.GROK_PATTERN_V1)
                 .data(data)
                 .build();
         return EntityWithConstraints.create(entity);
@@ -132,7 +132,7 @@ public class GrokPatternFacade implements EntityFacade<GrokPattern> {
     public EntityExcerpt createExcerpt(GrokPattern grokPattern) {
         return EntityExcerpt.builder()
                 .id(ModelId.of(grokPattern.id()))
-                .type(ModelTypes.GROK_PATTERN)
+                .type(ModelTypes.GROK_PATTERN_V1)
                 .title(grokPattern.name())
                 .build();
     }

--- a/graylog2-server/src/main/java/org/graylog2/contentpacks/facades/InputFacade.java
+++ b/graylog2-server/src/main/java/org/graylog2/contentpacks/facades/InputFacade.java
@@ -75,7 +75,7 @@ import static org.graylog2.contentpacks.model.entities.references.ReferenceMapUt
 public class InputFacade implements EntityFacade<InputWithExtractors> {
     private static final Logger LOG = LoggerFactory.getLogger(InputFacade.class);
 
-    public static final ModelType TYPE = ModelTypes.INPUT;
+    public static final ModelType TYPE = ModelTypes.INPUT_V1;
 
     private final ObjectMapper objectMapper;
     private final InputService inputService;
@@ -129,7 +129,7 @@ public class InputFacade implements EntityFacade<InputWithExtractors> {
         final JsonNode data = objectMapper.convertValue(inputEntity, JsonNode.class);
         final EntityV1 entity = EntityV1.builder()
                 .id(ModelId.of(input.getId()))
-                .type(ModelTypes.INPUT)
+                .type(ModelTypes.INPUT_V1)
                 .data(data)
                 .build();
         final Set<Constraint> constraints = versionConstraints(input);
@@ -414,7 +414,7 @@ public class InputFacade implements EntityFacade<InputWithExtractors> {
     public EntityExcerpt createExcerpt(InputWithExtractors inputWithExtractors) {
         return EntityExcerpt.builder()
                 .id(ModelId.of(inputWithExtractors.input().getId()))
-                .type(ModelTypes.INPUT)
+                .type(ModelTypes.INPUT_V1)
                 .title(inputWithExtractors.input().getTitle())
                 .build();
     }

--- a/graylog2-server/src/main/java/org/graylog2/contentpacks/facades/InputFacade.java
+++ b/graylog2-server/src/main/java/org/graylog2/contentpacks/facades/InputFacade.java
@@ -75,7 +75,7 @@ import static org.graylog2.contentpacks.model.entities.references.ReferenceMapUt
 public class InputFacade implements EntityFacade<InputWithExtractors> {
     private static final Logger LOG = LoggerFactory.getLogger(InputFacade.class);
 
-    public static final ModelType TYPE = ModelTypes.INPUT_V1;
+    public static final ModelType TYPE_V1 = ModelTypes.INPUT_V1;
 
     private final ObjectMapper objectMapper;
     private final InputService inputService;
@@ -222,7 +222,7 @@ public class InputFacade implements EntityFacade<InputWithExtractors> {
             throw new RuntimeException("Couldn't create extractors", e);
         }
 
-        return NativeEntity.create(entity.id(), input.getId(), TYPE, InputWithExtractors.create(input, extractors));
+        return NativeEntity.create(entity.id(), input.getId(), TYPE_V1, InputWithExtractors.create(input, extractors));
     }
 
     private MessageInput createMessageInput(

--- a/graylog2-server/src/main/java/org/graylog2/contentpacks/facades/LookupCacheFacade.java
+++ b/graylog2-server/src/main/java/org/graylog2/contentpacks/facades/LookupCacheFacade.java
@@ -47,7 +47,7 @@ import static org.graylog2.contentpacks.model.entities.references.ReferenceMapUt
 import static org.graylog2.contentpacks.model.entities.references.ReferenceMapUtils.toValueMap;
 
 public class LookupCacheFacade implements EntityFacade<CacheDto> {
-    public static final ModelType TYPE = ModelTypes.LOOKUP_CACHE;
+    public static final ModelType TYPE = ModelTypes.LOOKUP_CACHE_V1;
 
     private final ObjectMapper objectMapper;
     private final DBCacheService cacheService;
@@ -74,7 +74,7 @@ public class LookupCacheFacade implements EntityFacade<CacheDto> {
         final JsonNode data = objectMapper.convertValue(lookupCacheEntity, JsonNode.class);
         final EntityV1 entity = EntityV1.builder()
                 .id(ModelId.of(cacheDto.id()))
-                .type(ModelTypes.LOOKUP_CACHE)
+                .type(ModelTypes.LOOKUP_CACHE_V1)
                 .data(data)
                 .build();
         final Set<Constraint> constraints = versionConstraints(cacheDto);
@@ -144,7 +144,7 @@ public class LookupCacheFacade implements EntityFacade<CacheDto> {
     public EntityExcerpt createExcerpt(CacheDto cacheDto) {
         return EntityExcerpt.builder()
                 .id(ModelId.of(cacheDto.name()))
-                .type(ModelTypes.LOOKUP_CACHE)
+                .type(ModelTypes.LOOKUP_CACHE_V1)
                 .title(cacheDto.title())
                 .build();
     }

--- a/graylog2-server/src/main/java/org/graylog2/contentpacks/facades/LookupCacheFacade.java
+++ b/graylog2-server/src/main/java/org/graylog2/contentpacks/facades/LookupCacheFacade.java
@@ -47,7 +47,7 @@ import static org.graylog2.contentpacks.model.entities.references.ReferenceMapUt
 import static org.graylog2.contentpacks.model.entities.references.ReferenceMapUtils.toValueMap;
 
 public class LookupCacheFacade implements EntityFacade<CacheDto> {
-    public static final ModelType TYPE = ModelTypes.LOOKUP_CACHE_V1;
+    public static final ModelType TYPE_V1 = ModelTypes.LOOKUP_CACHE_V1;
 
     private final ObjectMapper objectMapper;
     private final DBCacheService cacheService;
@@ -114,7 +114,7 @@ public class LookupCacheFacade implements EntityFacade<CacheDto> {
                 .build();
 
         final CacheDto savedCacheDto = cacheService.save(cacheDto);
-        return NativeEntity.create(entity.id(), savedCacheDto.name(), TYPE, savedCacheDto);
+        return NativeEntity.create(entity.id(), savedCacheDto.name(), TYPE_V1, savedCacheDto);
     }
 
     @Override
@@ -132,7 +132,7 @@ public class LookupCacheFacade implements EntityFacade<CacheDto> {
 
         final Optional<CacheDto> existingCache = cacheService.get(name);
 
-        return existingCache.map(cache -> NativeEntity.create(entity.id(), cache.id(), TYPE, cache));
+        return existingCache.map(cache -> NativeEntity.create(entity.id(), cache.id(), TYPE_V1, cache));
     }
 
     @Override

--- a/graylog2-server/src/main/java/org/graylog2/contentpacks/facades/LookupDataAdapterFacade.java
+++ b/graylog2-server/src/main/java/org/graylog2/contentpacks/facades/LookupDataAdapterFacade.java
@@ -47,7 +47,7 @@ import static org.graylog2.contentpacks.model.entities.references.ReferenceMapUt
 import static org.graylog2.contentpacks.model.entities.references.ReferenceMapUtils.toValueMap;
 
 public class LookupDataAdapterFacade implements EntityFacade<DataAdapterDto> {
-    public static final ModelType TYPE = ModelTypes.LOOKUP_ADAPTER_V1;
+    public static final ModelType TYPE_V1 = ModelTypes.LOOKUP_ADAPTER_V1;
 
     private final ObjectMapper objectMapper;
     private final DBDataAdapterService dataAdapterService;
@@ -115,7 +115,7 @@ public class LookupDataAdapterFacade implements EntityFacade<DataAdapterDto> {
                 .build();
 
         final DataAdapterDto savedDataAdapterDto = dataAdapterService.save(dataAdapterDto);
-        return NativeEntity.create(entity.id(), savedDataAdapterDto.name(), TYPE, savedDataAdapterDto);
+        return NativeEntity.create(entity.id(), savedDataAdapterDto.name(), TYPE_V1, savedDataAdapterDto);
     }
 
     @Override
@@ -133,7 +133,7 @@ public class LookupDataAdapterFacade implements EntityFacade<DataAdapterDto> {
 
         final Optional<DataAdapterDto> existingDataAdapter = dataAdapterService.get(name);
 
-        return existingDataAdapter.map(dataAdapter -> NativeEntity.create(entity.id(), dataAdapter.id(), TYPE, dataAdapter));
+        return existingDataAdapter.map(dataAdapter -> NativeEntity.create(entity.id(), dataAdapter.id(), TYPE_V1, dataAdapter));
     }
 
     @Override

--- a/graylog2-server/src/main/java/org/graylog2/contentpacks/facades/LookupDataAdapterFacade.java
+++ b/graylog2-server/src/main/java/org/graylog2/contentpacks/facades/LookupDataAdapterFacade.java
@@ -47,7 +47,7 @@ import static org.graylog2.contentpacks.model.entities.references.ReferenceMapUt
 import static org.graylog2.contentpacks.model.entities.references.ReferenceMapUtils.toValueMap;
 
 public class LookupDataAdapterFacade implements EntityFacade<DataAdapterDto> {
-    public static final ModelType TYPE = ModelTypes.LOOKUP_ADAPTER;
+    public static final ModelType TYPE = ModelTypes.LOOKUP_ADAPTER_V1;
 
     private final ObjectMapper objectMapper;
     private final DBDataAdapterService dataAdapterService;
@@ -74,7 +74,7 @@ public class LookupDataAdapterFacade implements EntityFacade<DataAdapterDto> {
         final JsonNode data = objectMapper.convertValue(lookupDataAdapterEntity, JsonNode.class);
         final EntityV1 entity = EntityV1.builder()
                 .id(ModelId.of(dataAdapterDto.id()))
-                .type(ModelTypes.LOOKUP_ADAPTER)
+                .type(ModelTypes.LOOKUP_ADAPTER_V1)
                 .data(data)
                 .build();
         final Set<Constraint> constraints = versionConstraints(dataAdapterDto);
@@ -145,7 +145,7 @@ public class LookupDataAdapterFacade implements EntityFacade<DataAdapterDto> {
     public EntityExcerpt createExcerpt(DataAdapterDto dataAdapterDto) {
         return EntityExcerpt.builder()
                 .id(ModelId.of(dataAdapterDto.name()))
-                .type(ModelTypes.LOOKUP_ADAPTER)
+                .type(ModelTypes.LOOKUP_ADAPTER_V1)
                 .title(dataAdapterDto.title())
                 .build();
     }

--- a/graylog2-server/src/main/java/org/graylog2/contentpacks/facades/LookupTableFacade.java
+++ b/graylog2-server/src/main/java/org/graylog2/contentpacks/facades/LookupTableFacade.java
@@ -50,7 +50,7 @@ import java.util.Set;
 import java.util.stream.Collectors;
 
 public class LookupTableFacade implements EntityFacade<LookupTableDto> {
-    public static final ModelType TYPE = ModelTypes.LOOKUP_TABLE_V1;
+    public static final ModelType TYPE_V1 = ModelTypes.LOOKUP_TABLE_V1;
 
     private final ObjectMapper objectMapper;
     private final DBLookupTableService lookupTableService;
@@ -132,7 +132,7 @@ public class LookupTableFacade implements EntityFacade<LookupTableDto> {
                 .defaultMultiValueType(lookupTableEntity.defaultMultiValueType().asEnum(parameters, LookupDefaultMultiValue.Type.class))
                 .build();
         final LookupTableDto savedLookupTableDto = lookupTableService.save(lookupTableDto);
-        return NativeEntity.create(entity.id(), savedLookupTableDto.id(), TYPE, savedLookupTableDto);
+        return NativeEntity.create(entity.id(), savedLookupTableDto.id(), TYPE_V1, savedLookupTableDto);
     }
 
     @Override
@@ -152,7 +152,7 @@ public class LookupTableFacade implements EntityFacade<LookupTableDto> {
         final Optional<LookupTableDto> lookupTable = lookupTableService.get(name);
         lookupTable.ifPresent(existingLookupTable -> compareLookupTable(name, title, existingLookupTable));
 
-        return lookupTable.map(lt -> NativeEntity.create(entity.id(), lt.id(), TYPE, lt));
+        return lookupTable.map(lt -> NativeEntity.create(entity.id(), lt.id(), TYPE_V1, lt));
     }
 
     private void compareLookupTable(String name, String title, LookupTableDto existingLookupTable) {

--- a/graylog2-server/src/main/java/org/graylog2/contentpacks/facades/LookupTableFacade.java
+++ b/graylog2-server/src/main/java/org/graylog2/contentpacks/facades/LookupTableFacade.java
@@ -50,7 +50,7 @@ import java.util.Set;
 import java.util.stream.Collectors;
 
 public class LookupTableFacade implements EntityFacade<LookupTableDto> {
-    public static final ModelType TYPE = ModelTypes.LOOKUP_TABLE;
+    public static final ModelType TYPE = ModelTypes.LOOKUP_TABLE_V1;
 
     private final ObjectMapper objectMapper;
     private final DBLookupTableService lookupTableService;
@@ -77,7 +77,7 @@ public class LookupTableFacade implements EntityFacade<LookupTableDto> {
         final JsonNode data = objectMapper.convertValue(lookupTableEntity, JsonNode.class);
         final EntityV1 entity = EntityV1.builder()
                 .id(ModelId.of(lookupTableDto.id()))
-                .type(ModelTypes.LOOKUP_TABLE)
+                .type(ModelTypes.LOOKUP_TABLE_V1)
                 .data(data)
                 .build();
         return EntityWithConstraints.create(entity);
@@ -102,7 +102,7 @@ public class LookupTableFacade implements EntityFacade<LookupTableDto> {
 
 
         final String referencedDataAdapterName = lookupTableEntity.dataAdapterName().asString(parameters);
-        final EntityDescriptor dataAdapterDescriptor = EntityDescriptor.create(referencedDataAdapterName, ModelTypes.LOOKUP_ADAPTER);
+        final EntityDescriptor dataAdapterDescriptor = EntityDescriptor.create(referencedDataAdapterName, ModelTypes.LOOKUP_ADAPTER_V1);
         final Object dataAdapter = nativeEntities.get(dataAdapterDescriptor);
         final String dataAdapterId;
         if (dataAdapter instanceof DataAdapterDto) {
@@ -112,7 +112,7 @@ public class LookupTableFacade implements EntityFacade<LookupTableDto> {
         }
 
         final String referencedCacheName = lookupTableEntity.cacheName().asString(parameters);
-        final EntityDescriptor cacheDescriptor = EntityDescriptor.create(referencedCacheName, ModelTypes.LOOKUP_CACHE);
+        final EntityDescriptor cacheDescriptor = EntityDescriptor.create(referencedCacheName, ModelTypes.LOOKUP_CACHE_V1);
         final Object cache = nativeEntities.get(cacheDescriptor);
         final String cacheId;
         if (cache instanceof CacheDto) {
@@ -170,7 +170,7 @@ public class LookupTableFacade implements EntityFacade<LookupTableDto> {
     public EntityExcerpt createExcerpt(LookupTableDto lookupTableDto) {
         return EntityExcerpt.builder()
                 .id(ModelId.of(lookupTableDto.name()))
-                .type(ModelTypes.LOOKUP_TABLE)
+                .type(ModelTypes.LOOKUP_TABLE_V1)
                 .title(lookupTableDto.title())
                 .build();
     }
@@ -197,10 +197,10 @@ public class LookupTableFacade implements EntityFacade<LookupTableDto> {
         final Optional<LookupTableDto> lookupTableDto = lookupTableService.get(modelId.id());
 
         lookupTableDto.map(LookupTableDto::dataAdapterId)
-                .map(dataAdapterId -> EntityDescriptor.create(dataAdapterId, ModelTypes.LOOKUP_ADAPTER))
+                .map(dataAdapterId -> EntityDescriptor.create(dataAdapterId, ModelTypes.LOOKUP_ADAPTER_V1))
                 .ifPresent(dataAdapter -> mutableGraph.putEdge(entityDescriptor, dataAdapter));
         lookupTableDto.map(LookupTableDto::cacheId)
-                .map(cacheId -> EntityDescriptor.create(cacheId, ModelTypes.LOOKUP_CACHE))
+                .map(cacheId -> EntityDescriptor.create(cacheId, ModelTypes.LOOKUP_CACHE_V1))
                 .ifPresent(cache -> mutableGraph.putEdge(entityDescriptor, cache));
 
         return ImmutableGraph.copyOf(mutableGraph);
@@ -226,7 +226,7 @@ public class LookupTableFacade implements EntityFacade<LookupTableDto> {
         final LookupTableEntity lookupTableEntity = objectMapper.convertValue(entity.data(), LookupTableEntity.class);
 
         final String dataAdapterName = lookupTableEntity.dataAdapterName().asString(parameters);
-        final EntityDescriptor dataAdapterDescriptor = EntityDescriptor.create(dataAdapterName, ModelTypes.LOOKUP_ADAPTER);
+        final EntityDescriptor dataAdapterDescriptor = EntityDescriptor.create(dataAdapterName, ModelTypes.LOOKUP_ADAPTER_V1);
         final Entity dataAdapterEntity = entities.get(dataAdapterDescriptor);
         if (dataAdapterEntity == null) {
             throw new ContentPackException("Missing data adapter \"" + dataAdapterName + "\" for lookup table " + entity.toEntityDescriptor());
@@ -235,7 +235,7 @@ public class LookupTableFacade implements EntityFacade<LookupTableDto> {
         }
 
         final String cacheName = lookupTableEntity.cacheName().asString(parameters);
-        final EntityDescriptor cacheDescriptor = EntityDescriptor.create(cacheName, ModelTypes.LOOKUP_CACHE);
+        final EntityDescriptor cacheDescriptor = EntityDescriptor.create(cacheName, ModelTypes.LOOKUP_CACHE_V1);
         final Entity cacheEntity = entities.get(cacheDescriptor);
         if (cacheEntity == null) {
             throw new ContentPackException("Missing cache \"" + cacheName + "\" for lookup table " + entity.toEntityDescriptor());

--- a/graylog2-server/src/main/java/org/graylog2/contentpacks/facades/OutputFacade.java
+++ b/graylog2-server/src/main/java/org/graylog2/contentpacks/facades/OutputFacade.java
@@ -54,7 +54,7 @@ import static org.graylog2.contentpacks.model.entities.references.ReferenceMapUt
 public class OutputFacade implements EntityFacade<Output> {
     private static final Logger LOG = LoggerFactory.getLogger(OutputFacade.class);
 
-    public static final ModelType TYPE = ModelTypes.OUTPUT_V1;
+    public static final ModelType TYPE_V1 = ModelTypes.OUTPUT_V1;
 
     private final ObjectMapper objectMapper;
     private final OutputService outputService;
@@ -127,7 +127,7 @@ public class OutputFacade implements EntityFacade<Output> {
         );
         try {
             final Output output = outputService.create(createOutputRequest, username);
-            return NativeEntity.create(entity.id(), output.getId(), TYPE, output);
+            return NativeEntity.create(entity.id(), output.getId(), TYPE_V1, output);
         } catch (ValidationException e) {
             throw new IllegalArgumentException(e);
         }

--- a/graylog2-server/src/main/java/org/graylog2/contentpacks/facades/OutputFacade.java
+++ b/graylog2-server/src/main/java/org/graylog2/contentpacks/facades/OutputFacade.java
@@ -54,7 +54,7 @@ import static org.graylog2.contentpacks.model.entities.references.ReferenceMapUt
 public class OutputFacade implements EntityFacade<Output> {
     private static final Logger LOG = LoggerFactory.getLogger(OutputFacade.class);
 
-    public static final ModelType TYPE = ModelTypes.OUTPUT;
+    public static final ModelType TYPE = ModelTypes.OUTPUT_V1;
 
     private final ObjectMapper objectMapper;
     private final OutputService outputService;
@@ -82,7 +82,7 @@ public class OutputFacade implements EntityFacade<Output> {
         final JsonNode data = objectMapper.convertValue(outputEntity, JsonNode.class);
         final EntityV1 entity = EntityV1.builder()
                 .id(ModelId.of(output.getId()))
-                .type(ModelTypes.OUTPUT)
+                .type(ModelTypes.OUTPUT_V1)
                 .data(data)
                 .build();
         final Set<Constraint> constraints = versionConstraints(output);
@@ -145,7 +145,7 @@ public class OutputFacade implements EntityFacade<Output> {
     public EntityExcerpt createExcerpt(Output output) {
         return EntityExcerpt.builder()
                 .id(ModelId.of(output.getId()))
-                .type(ModelTypes.OUTPUT)
+                .type(ModelTypes.OUTPUT_V1)
                 .title(output.getTitle())
                 .build();
     }

--- a/graylog2-server/src/main/java/org/graylog2/contentpacks/facades/PipelineFacade.java
+++ b/graylog2-server/src/main/java/org/graylog2/contentpacks/facades/PipelineFacade.java
@@ -63,7 +63,7 @@ import static java.util.Objects.requireNonNull;
 public class PipelineFacade implements EntityFacade<PipelineDao> {
     private static final Logger LOG = LoggerFactory.getLogger(PipelineFacade.class);
 
-    public static final ModelType TYPE = ModelTypes.PIPELINE_V1;
+    public static final ModelType TYPE_V1 = ModelTypes.PIPELINE_V1;
 
     private final ObjectMapper objectMapper;
     private final PipelineService pipelineService;
@@ -140,7 +140,7 @@ public class PipelineFacade implements EntityFacade<PipelineDao> {
         final Set<Stream> connectedStreams = connectedStreams(connectedStreamEntities, nativeEntities);
         createPipelineConnections(pipelineId, connectedStreams);
 
-        return NativeEntity.create(entity.id(), pipelineId, TYPE, savedPipelineDao);
+        return NativeEntity.create(entity.id(), pipelineId, TYPE_V1, savedPipelineDao);
     }
 
     private Set<Stream> connectedStreams(Set<EntityDescriptor> connectedStreamEntities, Map<EntityDescriptor, Object> nativeEntities) {

--- a/graylog2-server/src/main/java/org/graylog2/contentpacks/facades/PipelineFacade.java
+++ b/graylog2-server/src/main/java/org/graylog2/contentpacks/facades/PipelineFacade.java
@@ -63,7 +63,7 @@ import static java.util.Objects.requireNonNull;
 public class PipelineFacade implements EntityFacade<PipelineDao> {
     private static final Logger LOG = LoggerFactory.getLogger(PipelineFacade.class);
 
-    public static final ModelType TYPE = ModelTypes.PIPELINE;
+    public static final ModelType TYPE = ModelTypes.PIPELINE_V1;
 
     private final ObjectMapper objectMapper;
     private final PipelineService pipelineService;
@@ -92,7 +92,7 @@ public class PipelineFacade implements EntityFacade<PipelineDao> {
         final JsonNode data = objectMapper.convertValue(pipelineEntity, JsonNode.class);
         final EntityV1 entity = EntityV1.builder()
                 .id(ModelId.of(pipelineDao.title()))
-                .type(ModelTypes.PIPELINE)
+                .type(ModelTypes.PIPELINE_V1)
                 .data(data)
                 .build();
         return EntityWithConstraints.create(entity);
@@ -135,7 +135,7 @@ public class PipelineFacade implements EntityFacade<PipelineDao> {
         final String pipelineId = requireNonNull(savedPipelineDao.id(), "Saved pipeline ID must not be null");
         final Set<EntityDescriptor> connectedStreamEntities = pipelineEntity.connectedStreams().stream()
                 .map(valueReference -> valueReference.asString(parameters))
-                .map(streamId -> EntityDescriptor.create(streamId, ModelTypes.STREAM))
+                .map(streamId -> EntityDescriptor.create(streamId, ModelTypes.STREAM_V1))
                 .collect(Collectors.toSet());
         final Set<Stream> connectedStreams = connectedStreams(connectedStreamEntities, nativeEntities);
         createPipelineConnections(pipelineId, connectedStreams);
@@ -208,7 +208,7 @@ public class PipelineFacade implements EntityFacade<PipelineDao> {
     public EntityExcerpt createExcerpt(PipelineDao pipeline) {
         return EntityExcerpt.builder()
                 .id(ModelId.of(pipeline.title()))
-                .type(ModelTypes.PIPELINE)
+                .type(ModelTypes.PIPELINE_V1)
                 .title(pipeline.title())
                 .build();
     }
@@ -244,14 +244,14 @@ public class PipelineFacade implements EntityFacade<PipelineDao> {
             final Collection<String> referencedRules = referencedRules(pipelineSource);
             referencedRules.stream()
                     .map(ModelId::of)
-                    .map(id -> EntityDescriptor.create(id, ModelTypes.PIPELINE_RULE))
+                    .map(id -> EntityDescriptor.create(id, ModelTypes.PIPELINE_RULE_V1))
                     .forEach(rule -> mutableGraph.putEdge(entityDescriptor, rule));
 
             final Set<PipelineConnections> pipelineConnections = connectionsService.loadByPipelineId(pipelineDao.id());
             pipelineConnections.stream()
                     .map(PipelineConnections::streamId)
                     .map(ModelId::of)
-                    .map(id -> EntityDescriptor.create(id, ModelTypes.STREAM))
+                    .map(id -> EntityDescriptor.create(id, ModelTypes.STREAM_V1))
                     .forEach(stream -> mutableGraph.putEdge(entityDescriptor, stream));
         } catch (NotFoundException e) {
             LOG.debug("Couldn't find pipeline {}", entityDescriptor, e);
@@ -282,7 +282,7 @@ public class PipelineFacade implements EntityFacade<PipelineDao> {
         final Collection<String> referencedRules = referencedRules(source);
         referencedRules.stream()
                 .map(ModelId::of)
-                .map(modelId -> EntityDescriptor.create(modelId, ModelTypes.PIPELINE_RULE))
+                .map(modelId -> EntityDescriptor.create(modelId, ModelTypes.PIPELINE_RULE_V1))
                 .map(entities::get)
                 .filter(Objects::nonNull)
                 .forEach(ruleEntity -> mutableGraph.putEdge(entity, ruleEntity));
@@ -290,7 +290,7 @@ public class PipelineFacade implements EntityFacade<PipelineDao> {
         pipelineEntity.connectedStreams().stream()
                 .map(valueReference -> valueReference.asString(parameters))
                 .map(ModelId::of)
-                .map(modelId -> EntityDescriptor.create(modelId, ModelTypes.STREAM))
+                .map(modelId -> EntityDescriptor.create(modelId, ModelTypes.STREAM_V1))
                 .map(entities::get)
                 .filter(Objects::nonNull)
                 .forEach(streamEntity -> mutableGraph.putEdge(entity, streamEntity));

--- a/graylog2-server/src/main/java/org/graylog2/contentpacks/facades/PipelineRuleFacade.java
+++ b/graylog2-server/src/main/java/org/graylog2/contentpacks/facades/PipelineRuleFacade.java
@@ -47,7 +47,7 @@ import java.util.stream.Collectors;
 public class PipelineRuleFacade implements EntityFacade<RuleDao> {
     private static final Logger LOG = LoggerFactory.getLogger(PipelineRuleFacade.class);
 
-    public static final ModelType TYPE = ModelTypes.PIPELINE_RULE_V1;
+    public static final ModelType TYPE_V1 = ModelTypes.PIPELINE_RULE_V1;
 
     private final ObjectMapper objectMapper;
     private final RuleService ruleService;
@@ -101,7 +101,7 @@ public class PipelineRuleFacade implements EntityFacade<RuleDao> {
                 .build();
 
         final RuleDao savedRuleDao = ruleService.save(ruleDao);
-        return NativeEntity.create(entity.id(), savedRuleDao.id(), TYPE, savedRuleDao);
+        return NativeEntity.create(entity.id(), savedRuleDao.id(), TYPE_V1, savedRuleDao);
     }
 
     @Override
@@ -128,7 +128,7 @@ public class PipelineRuleFacade implements EntityFacade<RuleDao> {
             final RuleDao ruleDao = ruleService.loadByName(title);
             compareRuleSources(title, source, ruleDao.source());
 
-            return Optional.of(NativeEntity.create(entity.id(), ruleDao.id(), TYPE, ruleDao));
+            return Optional.of(NativeEntity.create(entity.id(), ruleDao.id(), TYPE_V1, ruleDao));
         } catch (NotFoundException e) {
             return Optional.empty();
         }

--- a/graylog2-server/src/main/java/org/graylog2/contentpacks/facades/PipelineRuleFacade.java
+++ b/graylog2-server/src/main/java/org/graylog2/contentpacks/facades/PipelineRuleFacade.java
@@ -47,7 +47,7 @@ import java.util.stream.Collectors;
 public class PipelineRuleFacade implements EntityFacade<RuleDao> {
     private static final Logger LOG = LoggerFactory.getLogger(PipelineRuleFacade.class);
 
-    public static final ModelType TYPE = ModelTypes.PIPELINE_RULE;
+    public static final ModelType TYPE = ModelTypes.PIPELINE_RULE_V1;
 
     private final ObjectMapper objectMapper;
     private final RuleService ruleService;
@@ -67,7 +67,7 @@ public class PipelineRuleFacade implements EntityFacade<RuleDao> {
         final JsonNode data = objectMapper.convertValue(ruleEntity, JsonNode.class);
         final EntityV1 entity = EntityV1.builder()
                 .id(ModelId.of(ruleDao.title()))
-                .type(ModelTypes.PIPELINE_RULE)
+                .type(ModelTypes.PIPELINE_RULE_V1)
                 .data(data)
                 .build();
         return EntityWithConstraints.create(entity);
@@ -145,7 +145,7 @@ public class PipelineRuleFacade implements EntityFacade<RuleDao> {
     public EntityExcerpt createExcerpt(RuleDao ruleDao) {
         return EntityExcerpt.builder()
                 .id(ModelId.of(ruleDao.title()))
-                .type(ModelTypes.PIPELINE_RULE)
+                .type(ModelTypes.PIPELINE_RULE_V1)
                 .title(ruleDao.title())
                 .build();
     }

--- a/graylog2-server/src/main/java/org/graylog2/contentpacks/facades/StreamFacade.java
+++ b/graylog2-server/src/main/java/org/graylog2/contentpacks/facades/StreamFacade.java
@@ -62,7 +62,7 @@ public class StreamFacade implements EntityFacade<Stream> {
     private static final Logger LOG = LoggerFactory.getLogger(StreamFacade.class);
     private static final String DUMMY_STREAM_ID = "ffffffffffffffffffffffff";
 
-    public static final ModelType TYPE = ModelTypes.STREAM;
+    public static final ModelType TYPE = ModelTypes.STREAM_V1;
 
     private final ObjectMapper objectMapper;
     private final StreamService streamService;
@@ -102,7 +102,7 @@ public class StreamFacade implements EntityFacade<Stream> {
         final JsonNode data = objectMapper.convertValue(streamEntity, JsonNode.class);
         final EntityV1 entity = EntityV1.builder()
                 .id(ModelId.of(stream.getId()))
-                .type(ModelTypes.STREAM)
+                .type(ModelTypes.STREAM_V1)
                 .data(data)
                 .build();
         return EntityWithConstraints.create(entity);
@@ -157,7 +157,7 @@ public class StreamFacade implements EntityFacade<Stream> {
         final Set<ObjectId> outputIds = streamEntity.outputs().stream()
                 .map(valueReference -> valueReference.asString(parameters))
                 .map(ModelId::of)
-                .map(modelId -> EntityDescriptor.create(modelId, ModelTypes.OUTPUT))
+                .map(modelId -> EntityDescriptor.create(modelId, ModelTypes.OUTPUT_V1))
                 .map(descriptor -> findOutput(descriptor, nativeEntities))
                 .map(Output::getId)
                 .map(ObjectId::new)
@@ -203,7 +203,7 @@ public class StreamFacade implements EntityFacade<Stream> {
         if (Stream.DEFAULT_STREAM_ID.equals(streamId)) {
             try {
                 final Stream stream = streamService.load(Stream.DEFAULT_STREAM_ID);
-                return Optional.of(NativeEntity.create(entity.id(), Stream.DEFAULT_STREAM_ID, ModelTypes.STREAM, stream));
+                return Optional.of(NativeEntity.create(entity.id(), Stream.DEFAULT_STREAM_ID, ModelTypes.STREAM_V1, stream));
             } catch (NotFoundException e) {
                 throw new ContentPackException("Default stream <" + streamId + "> does not exist!", e);
             }
@@ -224,7 +224,7 @@ public class StreamFacade implements EntityFacade<Stream> {
     public EntityExcerpt createExcerpt(Stream stream) {
         return EntityExcerpt.builder()
                 .id(ModelId.of(stream.getId()))
-                .type(ModelTypes.STREAM)
+                .type(ModelTypes.STREAM_V1)
                 .title(stream.getTitle())
                 .build();
     }
@@ -259,7 +259,7 @@ public class StreamFacade implements EntityFacade<Stream> {
             stream.getOutputs().stream()
                     .map(Output::getId)
                     .map(ModelId::of)
-                    .map(id -> EntityDescriptor.create(id, ModelTypes.OUTPUT))
+                    .map(id -> EntityDescriptor.create(id, ModelTypes.OUTPUT_V1))
                     .forEach(output -> mutableGraph.putEdge(entityDescriptor, output));
         } catch (NotFoundException e) {
             LOG.debug("Couldn't find stream {}", entityDescriptor, e);
@@ -290,7 +290,7 @@ public class StreamFacade implements EntityFacade<Stream> {
         streamEntity.outputs().stream()
                 .map(valueReference -> valueReference.asString(parameters))
                 .map(ModelId::of)
-                .map(modelId -> EntityDescriptor.create(modelId, ModelTypes.OUTPUT))
+                .map(modelId -> EntityDescriptor.create(modelId, ModelTypes.OUTPUT_V1))
                 .map(entities::get)
                 .filter(Objects::nonNull)
                 .forEach(outputEntity -> mutableGraph.putEdge(entity, outputEntity));

--- a/graylog2-server/src/main/java/org/graylog2/contentpacks/facades/StreamFacade.java
+++ b/graylog2-server/src/main/java/org/graylog2/contentpacks/facades/StreamFacade.java
@@ -62,7 +62,7 @@ public class StreamFacade implements EntityFacade<Stream> {
     private static final Logger LOG = LoggerFactory.getLogger(StreamFacade.class);
     private static final String DUMMY_STREAM_ID = "ffffffffffffffffffffffff";
 
-    public static final ModelType TYPE = ModelTypes.STREAM_V1;
+    public static final ModelType TYPE_V1 = ModelTypes.STREAM_V1;
 
     private final ObjectMapper objectMapper;
     private final StreamService streamService;
@@ -164,7 +164,7 @@ public class StreamFacade implements EntityFacade<Stream> {
                 .collect(Collectors.toSet());
         streamService.addOutputs(new ObjectId(savedStreamId), outputIds);
 
-        return NativeEntity.create(entity.id(), savedStreamId, TYPE, stream);
+        return NativeEntity.create(entity.id(), savedStreamId, TYPE_V1, stream);
     }
 
     private CreateStreamRuleRequest createStreamRuleRequest(StreamRuleEntity streamRuleEntity, Map<String, ValueReference> parameters) {

--- a/graylog2-server/src/main/java/org/graylog2/contentpacks/model/LegacyContentPack.java
+++ b/graylog2-server/src/main/java/org/graylog2/contentpacks/model/LegacyContentPack.java
@@ -249,7 +249,7 @@ public abstract class LegacyContentPack implements ContentPack {
         private Entity convertInput(JsonNode json) {
             return EntityV1.builder()
                     .id(ModelId.of(json.path("id").asText(UUID.randomUUID().toString())))
-                    .type(ModelTypes.INPUT)
+                    .type(ModelTypes.INPUT_V1)
                     .version(ModelVersion.of("1"))
                     .data(json)
                     .build();
@@ -268,7 +268,7 @@ public abstract class LegacyContentPack implements ContentPack {
         private Entity convertStream(JsonNode json) {
             return EntityV1.builder()
                     .id(ModelId.of(json.path("id").asText(UUID.randomUUID().toString())))
-                    .type(ModelTypes.STREAM)
+                    .type(ModelTypes.STREAM_V1)
                     .version(ModelVersion.of("1"))
                     .data(json)
                     .build();
@@ -287,7 +287,7 @@ public abstract class LegacyContentPack implements ContentPack {
         private Entity convertOutput(JsonNode json) {
             return EntityV1.builder()
                     .id(ModelId.of(json.path("id").asText(UUID.randomUUID().toString())))
-                    .type(ModelTypes.OUTPUT)
+                    .type(ModelTypes.OUTPUT_V1)
                     .version(ModelVersion.of("1"))
                     .data(json)
                     .build();
@@ -306,7 +306,7 @@ public abstract class LegacyContentPack implements ContentPack {
         private Entity convertDashboard(JsonNode json) {
             return EntityV1.builder()
                     .id(ModelId.of(UUID.randomUUID().toString()))
-                    .type(ModelTypes.DASHBOARD)
+                    .type(ModelTypes.DASHBOARD_V1)
                     .version(ModelVersion.of("1"))
                     .data(json)
                     .build();
@@ -325,7 +325,7 @@ public abstract class LegacyContentPack implements ContentPack {
         private Entity convertGrokPattern(JsonNode json) {
             return EntityV1.builder()
                     .id(ModelId.of(json.path("name").asText(UUID.randomUUID().toString())))
-                    .type(ModelTypes.GROK_PATTERN)
+                    .type(ModelTypes.GROK_PATTERN_V1)
                     .version(ModelVersion.of("1"))
                     .data(json)
                     .build();
@@ -344,7 +344,7 @@ public abstract class LegacyContentPack implements ContentPack {
         private Entity convertLookupTable(JsonNode json) {
             return EntityV1.builder()
                     .id(ModelId.of(json.path("name").asText(UUID.randomUUID().toString())))
-                    .type(ModelTypes.LOOKUP_TABLE)
+                    .type(ModelTypes.LOOKUP_TABLE_V1)
                     .version(ModelVersion.of("1"))
                     .data(json)
                     .build();
@@ -363,7 +363,7 @@ public abstract class LegacyContentPack implements ContentPack {
         private Entity convertLookupCache(JsonNode json) {
             return EntityV1.builder()
                     .id(ModelId.of(json.path("name").asText(UUID.randomUUID().toString())))
-                    .type(ModelTypes.LOOKUP_CACHE)
+                    .type(ModelTypes.LOOKUP_CACHE_V1)
                     .version(ModelVersion.of("1"))
                     .data(json)
                     .build();
@@ -382,7 +382,7 @@ public abstract class LegacyContentPack implements ContentPack {
         private Entity convertLookupDataAdapter(JsonNode json) {
             return EntityV1.builder()
                     .id(ModelId.of(json.path("name").asText(UUID.randomUUID().toString())))
-                    .type(ModelTypes.LOOKUP_ADAPTER)
+                    .type(ModelTypes.LOOKUP_ADAPTER_V1)
                     .version(ModelVersion.of("1"))
                     .data(json)
                     .build();

--- a/graylog2-server/src/main/java/org/graylog2/contentpacks/model/ModelType.java
+++ b/graylog2-server/src/main/java/org/graylog2/contentpacks/model/ModelType.java
@@ -17,25 +17,53 @@
 package org.graylog2.contentpacks.model;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
-import com.fasterxml.jackson.annotation.JsonValue;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.google.auto.value.AutoValue;
 import com.google.common.base.Preconditions;
 import org.apache.commons.lang.StringUtils;
 
 @AutoValue
+@JsonDeserialize(builder = ModelType.Builder.class)
 public abstract class ModelType {
-    @JsonValue
-    public abstract String type();
+    private static final String FIELD_NAME = "name";
+    private static final String FIELD_VERSION = "version";
 
-    @Override
-    public String toString() {
-        return type();
+    @JsonProperty(FIELD_NAME)
+    public abstract String name();
+
+    @JsonProperty(FIELD_VERSION)
+    public abstract String version();
+
+    public static ModelType of(String name, String version) {
+        validate(name, version);
+        return Builder.create().name(name).version(version).build();
     }
 
-    @JsonCreator
-    public static ModelType of(String type) {
-        Preconditions.checkArgument(StringUtils.isNotBlank(type), "Type must not be blank");
-        return new AutoValue_ModelType(type);
+    private static void validate(String name, String version) {
+        Preconditions.checkArgument(StringUtils.isNotBlank(name), "Type name must not be blank");
+        Preconditions.checkArgument(StringUtils.isNotBlank(version), "Type version must not be blank");
     }
 
+    @AutoValue.Builder
+    public abstract static class Builder {
+        @JsonCreator
+        public static Builder create() {
+            return new AutoValue_ModelType.Builder();
+        }
+
+        @JsonProperty(FIELD_NAME)
+        public abstract Builder name(String name);
+
+        @JsonProperty(FIELD_VERSION)
+        public abstract Builder version(String version);
+
+        public abstract ModelType autoBuild();
+
+        public ModelType build() {
+            final ModelType modelType = autoBuild();
+            validate(modelType.name(), modelType.version());
+            return modelType;
+        }
+    }
 }

--- a/graylog2-server/src/main/java/org/graylog2/contentpacks/model/ModelTypes.java
+++ b/graylog2-server/src/main/java/org/graylog2/contentpacks/model/ModelTypes.java
@@ -17,17 +17,17 @@
 package org.graylog2.contentpacks.model;
 
 public interface ModelTypes {
-    ModelType COLLECTOR_CONFIGURATION = ModelType.of("collector_configuration");
-    ModelType COLLECTOR = ModelType.of("collector");
-    ModelType DASHBOARD = ModelType.of("dashboard");
-    ModelType GROK_PATTERN = ModelType.of("grok_pattern");
-    ModelType LOOKUP_ADAPTER = ModelType.of("lookup_adapter");
-    ModelType LOOKUP_CACHE = ModelType.of("lookup_cache");
-    ModelType LOOKUP_TABLE = ModelType.of("lookup_table");
-    ModelType INPUT = ModelType.of("input");
-    ModelType OUTPUT = ModelType.of("output");
-    ModelType PIPELINE = ModelType.of("pipeline");
-    ModelType PIPELINE_RULE = ModelType.of("pipeline_rule");
-    ModelType ROOT = ModelType.of("virtual-root");
-    ModelType STREAM = ModelType.of("stream");
+    ModelType COLLECTOR_CONFIGURATION = ModelType.of("collector_configuration", "1");
+    ModelType COLLECTOR = ModelType.of("collector", "1");
+    ModelType DASHBOARD = ModelType.of("dashboard", "1");
+    ModelType GROK_PATTERN = ModelType.of("grok_pattern", "1");
+    ModelType LOOKUP_ADAPTER = ModelType.of("lookup_adapter", "1");
+    ModelType LOOKUP_CACHE = ModelType.of("lookup_cache", "1");
+    ModelType LOOKUP_TABLE = ModelType.of("lookup_table", "1");
+    ModelType INPUT = ModelType.of("input", "1");
+    ModelType OUTPUT = ModelType.of("output", "1");
+    ModelType PIPELINE = ModelType.of("pipeline", "1");
+    ModelType PIPELINE_RULE = ModelType.of("pipeline_rule", "1");
+    ModelType ROOT = ModelType.of("virtual-root", "1");
+    ModelType STREAM = ModelType.of("stream", "1");
 }

--- a/graylog2-server/src/main/java/org/graylog2/contentpacks/model/ModelTypes.java
+++ b/graylog2-server/src/main/java/org/graylog2/contentpacks/model/ModelTypes.java
@@ -17,17 +17,17 @@
 package org.graylog2.contentpacks.model;
 
 public interface ModelTypes {
-    ModelType COLLECTOR_CONFIGURATION = ModelType.of("collector_configuration", "1");
-    ModelType COLLECTOR = ModelType.of("collector", "1");
-    ModelType DASHBOARD = ModelType.of("dashboard", "1");
-    ModelType GROK_PATTERN = ModelType.of("grok_pattern", "1");
-    ModelType LOOKUP_ADAPTER = ModelType.of("lookup_adapter", "1");
-    ModelType LOOKUP_CACHE = ModelType.of("lookup_cache", "1");
-    ModelType LOOKUP_TABLE = ModelType.of("lookup_table", "1");
-    ModelType INPUT = ModelType.of("input", "1");
-    ModelType OUTPUT = ModelType.of("output", "1");
-    ModelType PIPELINE = ModelType.of("pipeline", "1");
-    ModelType PIPELINE_RULE = ModelType.of("pipeline_rule", "1");
+    ModelType COLLECTOR_CONFIGURATION_V1 = ModelType.of("collector_configuration", "1");
+    ModelType COLLECTOR_V1 = ModelType.of("collector", "1");
+    ModelType DASHBOARD_V1 = ModelType.of("dashboard", "1");
+    ModelType GROK_PATTERN_V1 = ModelType.of("grok_pattern", "1");
+    ModelType LOOKUP_ADAPTER_V1 = ModelType.of("lookup_adapter", "1");
+    ModelType LOOKUP_CACHE_V1 = ModelType.of("lookup_cache", "1");
+    ModelType LOOKUP_TABLE_V1 = ModelType.of("lookup_table", "1");
+    ModelType INPUT_V1 = ModelType.of("input", "1");
+    ModelType OUTPUT_V1 = ModelType.of("output", "1");
+    ModelType PIPELINE_V1 = ModelType.of("pipeline", "1");
+    ModelType PIPELINE_RULE_V1 = ModelType.of("pipeline_rule", "1");
     ModelType ROOT = ModelType.of("virtual-root", "1");
-    ModelType STREAM = ModelType.of("stream", "1");
+    ModelType STREAM_V1 = ModelType.of("stream", "1");
 }

--- a/graylog2-server/src/main/java/org/graylog2/contentpacks/model/constraints/Constraint.java
+++ b/graylog2-server/src/main/java/org/graylog2/contentpacks/model/constraints/Constraint.java
@@ -16,9 +16,9 @@
  */
 package org.graylog2.contentpacks.model.constraints;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonSubTypes;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
-import org.graylog2.contentpacks.model.Typed;
 
 import java.util.Optional;
 
@@ -27,7 +27,14 @@ import java.util.Optional;
         @JsonSubTypes.Type(value = GraylogVersionConstraint.class, name = GraylogVersionConstraint.TYPE_NAME),
         @JsonSubTypes.Type(value = PluginVersionConstraint.class, name = PluginVersionConstraint.TYPE_NAME)
 })
-public interface Constraint extends Typed {
-    interface ConstraintBuilder<SELF> extends Typed.TypeBuilder<SELF> {
+public interface Constraint {
+    String FIELD_META_TYPE = "type";
+
+    @JsonProperty(FIELD_META_TYPE)
+    String type();
+
+    interface ConstraintBuilder<SELF> {
+        @JsonProperty(FIELD_META_TYPE)
+        SELF type(String type);
     }
 }

--- a/graylog2-server/src/main/java/org/graylog2/contentpacks/model/constraints/GraylogVersionConstraint.java
+++ b/graylog2-server/src/main/java/org/graylog2/contentpacks/model/constraints/GraylogVersionConstraint.java
@@ -22,7 +22,6 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.google.auto.value.AutoValue;
 import com.vdurmont.semver4j.Requirement;
-import org.graylog2.contentpacks.model.ModelType;
 import org.graylog2.plugin.Version;
 
 import javax.annotation.Nullable;
@@ -70,7 +69,7 @@ public abstract class GraylogVersionConstraint implements Constraint {
         abstract GraylogVersionConstraint autoBuild();
 
         public GraylogVersionConstraint build() {
-            type(ModelType.of(TYPE_NAME));
+            type(TYPE_NAME);
             return autoBuild();
         }
     }

--- a/graylog2-server/src/main/java/org/graylog2/contentpacks/model/constraints/PluginVersionConstraint.java
+++ b/graylog2-server/src/main/java/org/graylog2/contentpacks/model/constraints/PluginVersionConstraint.java
@@ -22,7 +22,6 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.google.auto.value.AutoValue;
 import com.vdurmont.semver4j.Requirement;
-import org.graylog2.contentpacks.model.ModelType;
 import org.graylog2.plugin.PluginMetaData;
 import org.graylog2.plugin.Version;
 
@@ -75,7 +74,7 @@ public abstract class PluginVersionConstraint implements Constraint {
         abstract PluginVersionConstraint autoBuild();
 
         public PluginVersionConstraint build() {
-            type(ModelType.of(TYPE_NAME));
+            type(TYPE_NAME);
             return autoBuild();
         }
     }

--- a/graylog2-server/src/test/java/org/graylog2/contentpacks/ContentPackServiceTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/contentpacks/ContentPackServiceTest.java
@@ -23,7 +23,6 @@ import org.graylog2.contentpacks.constraints.ConstraintChecker;
 import org.graylog2.contentpacks.facades.EntityFacade;
 import org.graylog2.contentpacks.facades.OutputFacade;
 import org.graylog2.contentpacks.facades.StreamFacade;
-import org.graylog2.contentpacks.model.ModelId;
 import org.graylog2.contentpacks.model.ModelType;
 import org.graylog2.contentpacks.model.ModelTypes;
 import org.graylog2.contentpacks.model.entities.EntityDescriptor;
@@ -84,8 +83,8 @@ public class ContentPackServiceTest {
         pluginMetaData = new HashSet<>();
         outputFactories = new HashMap<>();
         final Map<ModelType, EntityFacade<?>> entityFacades = ImmutableMap.of(
-                ModelTypes.STREAM, new StreamFacade(objectMapper, streamService, streamRuleService, indexSetService),
-                ModelTypes.OUTPUT, new OutputFacade(objectMapper, outputService, pluginMetaData, outputFactories)
+                ModelTypes.STREAM_V1, new StreamFacade(objectMapper, streamService, streamRuleService, indexSetService),
+                ModelTypes.OUTPUT_V1, new OutputFacade(objectMapper, outputService, pluginMetaData, outputFactories)
         );
 
         contentPackService = new ContentPackService(contentPackInstallationPersistenceService, constraintCheckers, entityFacades);
@@ -107,11 +106,11 @@ public class ContentPackServiceTest {
         when(streamService.load("stream-1234")).thenReturn(streamMock);
 
         final ImmutableSet<EntityDescriptor> unresolvedEntities = ImmutableSet.of(
-                EntityDescriptor.create("stream-1234", ModelTypes.STREAM)
+                EntityDescriptor.create("stream-1234", ModelTypes.STREAM_V1)
         );
 
         final Set<EntityDescriptor> resolvedEntities = contentPackService.resolveEntities(unresolvedEntities);
-        assertThat(resolvedEntities).containsOnly(EntityDescriptor.create("stream-1234", ModelTypes.STREAM));
+        assertThat(resolvedEntities).containsOnly(EntityDescriptor.create("stream-1234", ModelTypes.STREAM_V1));
     }
 
     @Test
@@ -138,13 +137,13 @@ public class ContentPackServiceTest {
         when(streamService.load("stream-1234")).thenReturn(streamMock);
 
         final ImmutableSet<EntityDescriptor> unresolvedEntities = ImmutableSet.of(
-                EntityDescriptor.create("stream-1234", ModelTypes.STREAM)
+                EntityDescriptor.create("stream-1234", ModelTypes.STREAM_V1)
         );
 
         final Set<EntityDescriptor> resolvedEntities = contentPackService.resolveEntities(unresolvedEntities);
         assertThat(resolvedEntities).containsOnly(
-                EntityDescriptor.create("stream-1234", ModelTypes.STREAM),
-                EntityDescriptor.create("output-1234", ModelTypes.OUTPUT)
+                EntityDescriptor.create("stream-1234", ModelTypes.STREAM_V1),
+                EntityDescriptor.create("output-1234", ModelTypes.OUTPUT_V1)
         );
     }
 }

--- a/graylog2-server/src/test/java/org/graylog2/contentpacks/facades/CollectorFacadeTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/contentpacks/facades/CollectorFacadeTest.java
@@ -77,7 +77,7 @@ public class CollectorFacadeTest {
         assertThat(entityWithConstraints.constraints()).isEmpty();
         final Entity expectedEntity = EntityV1.builder()
                 .id(ModelId.of("5b4c920b4b900a0024af0001"))
-                .type(ModelTypes.COLLECTOR)
+                .type(ModelTypes.COLLECTOR_V1)
                 .data(objectMapper.convertValue(CollectorEntity.create(
                         ValueReference.of("filebeat"),
                         ValueReference.of("exec"),
@@ -98,13 +98,13 @@ public class CollectorFacadeTest {
     @Test
     @UsingDataSet(locations = "/org/graylog2/contentpacks/sidecar_collectors.json", loadStrategy = LoadStrategyEnum.CLEAN_INSERT)
     public void exportEntity() {
-        final EntityDescriptor descriptor = EntityDescriptor.create("5b4c920b4b900a0024af0001", ModelTypes.COLLECTOR);
+        final EntityDescriptor descriptor = EntityDescriptor.create("5b4c920b4b900a0024af0001", ModelTypes.COLLECTOR_V1);
 
         final EntityWithConstraints entityWithConstraints = facade.exportEntity(descriptor).orElseThrow(AssertionError::new);
         assertThat(entityWithConstraints.constraints()).isEmpty();
         final Entity expectedEntity = EntityV1.builder()
                 .id(ModelId.of("5b4c920b4b900a0024af0001"))
-                .type(ModelTypes.COLLECTOR)
+                .type(ModelTypes.COLLECTOR_V1)
                 .data(objectMapper.convertValue(CollectorEntity.create(
                         ValueReference.of("filebeat"),
                         ValueReference.of("exec"),
@@ -127,7 +127,7 @@ public class CollectorFacadeTest {
     public void createNativeEntity() {
         final Entity entity = EntityV1.builder()
                 .id(ModelId.of("0"))
-                .type(ModelTypes.COLLECTOR)
+                .type(ModelTypes.COLLECTOR_V1)
                 .data(objectMapper.convertValue(CollectorEntity.create(
                         ValueReference.of("filebeat"),
                         ValueReference.of("exec"),
@@ -151,7 +151,7 @@ public class CollectorFacadeTest {
         final Collector collector = collectorService.findByName("filebeat");
         assertThat(collector).isNotNull();
 
-        final NativeEntityDescriptor expectedDescriptor = NativeEntityDescriptor.create(entity.id(), collector.id(), ModelTypes.COLLECTOR);
+        final NativeEntityDescriptor expectedDescriptor = NativeEntityDescriptor.create(entity.id(), collector.id(), ModelTypes.COLLECTOR_V1);
         assertThat(nativeEntity.descriptor()).isEqualTo(expectedDescriptor);
         assertThat(nativeEntity.entity()).isEqualTo(collector);
     }
@@ -161,7 +161,7 @@ public class CollectorFacadeTest {
     public void findExisting() {
         final Entity entity = EntityV1.builder()
                 .id(ModelId.of("0"))
-                .type(ModelTypes.COLLECTOR)
+                .type(ModelTypes.COLLECTOR_V1)
                 .data(objectMapper.convertValue(CollectorEntity.create(
                         ValueReference.of("filebeat"),
                         ValueReference.of("exec"),
@@ -183,7 +183,7 @@ public class CollectorFacadeTest {
         final Collector collector = collectorService.findByName("filebeat");
         assertThat(collector).isNotNull();
 
-        final NativeEntityDescriptor expectedDescriptor = NativeEntityDescriptor.create(entity.id(), collector.id(), ModelTypes.COLLECTOR);
+        final NativeEntityDescriptor expectedDescriptor = NativeEntityDescriptor.create(entity.id(), collector.id(), ModelTypes.COLLECTOR_V1);
         assertThat(existingCollector.descriptor()).isEqualTo(expectedDescriptor);
         assertThat(existingCollector.entity()).isEqualTo(collector);
     }
@@ -205,7 +205,7 @@ public class CollectorFacadeTest {
         final EntityExcerpt excerpt = facade.createExcerpt(collector);
 
         assertThat(excerpt.id()).isEqualTo(ModelId.of("5b4c920b4b900a0024af0001"));
-        assertThat(excerpt.type()).isEqualTo(ModelTypes.COLLECTOR);
+        assertThat(excerpt.type()).isEqualTo(ModelTypes.COLLECTOR_V1);
         assertThat(excerpt.title()).isEqualTo("filebeat");
     }
 
@@ -216,17 +216,17 @@ public class CollectorFacadeTest {
         assertThat(entityExcerpts).containsOnly(
                 EntityExcerpt.builder()
                         .id(ModelId.of("5b4c920b4b900a0024af0001"))
-                        .type(ModelTypes.COLLECTOR)
+                        .type(ModelTypes.COLLECTOR_V1)
                         .title("filebeat")
                         .build(),
                 EntityExcerpt.builder()
                         .id(ModelId.of("5b4c920b4b900a0024af0002"))
-                        .type(ModelTypes.COLLECTOR)
+                        .type(ModelTypes.COLLECTOR_V1)
                         .title("winlogbeat")
                         .build(),
                 EntityExcerpt.builder()
                         .id(ModelId.of("5b4c920b4b900a0024af0003"))
-                        .type(ModelTypes.COLLECTOR)
+                        .type(ModelTypes.COLLECTOR_V1)
                         .title("nxlog")
                         .build()
         );
@@ -235,7 +235,7 @@ public class CollectorFacadeTest {
     @Test
     @UsingDataSet(locations = "/org/graylog2/contentpacks/sidecar_collectors.json", loadStrategy = LoadStrategyEnum.CLEAN_INSERT)
     public void resolveEntityDescriptor() {
-        final EntityDescriptor descriptor = EntityDescriptor.create("5b4c920b4b900a0024af0001", ModelTypes.COLLECTOR);
+        final EntityDescriptor descriptor = EntityDescriptor.create("5b4c920b4b900a0024af0001", ModelTypes.COLLECTOR_V1);
         final Graph<EntityDescriptor> graph = facade.resolveNativeEntity(descriptor);
         assertThat(graph.nodes()).containsOnly(descriptor);
     }
@@ -245,7 +245,7 @@ public class CollectorFacadeTest {
     public void resolveEntity() {
         final Entity entity = EntityV1.builder()
                 .id(ModelId.of("0"))
-                .type(ModelTypes.COLLECTOR)
+                .type(ModelTypes.COLLECTOR_V1)
                 .data(objectMapper.convertValue(CollectorEntity.create(
                         ValueReference.of("filebeat"),
                         ValueReference.of("exec"),

--- a/graylog2-server/src/test/java/org/graylog2/contentpacks/facades/DashboardFacadeTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/contentpacks/facades/DashboardFacadeTest.java
@@ -142,7 +142,7 @@ public class DashboardFacadeTest {
 
         assertThat(entity).isInstanceOf(EntityV1.class);
         assertThat(entity.id()).isEqualTo(ModelId.of(dashboard.getId()));
-        assertThat(entity.type()).isEqualTo(ModelTypes.DASHBOARD);
+        assertThat(entity.type()).isEqualTo(ModelTypes.DASHBOARD_V1);
 
         final EntityV1 entityV1 = (EntityV1) entity;
         final DashboardEntity dashboardEntity = objectMapper.convertValue(entityV1.data(), DashboardEntity.class);
@@ -172,13 +172,13 @@ public class DashboardFacadeTest {
     @Test
     @UsingDataSet(locations = "/org/graylog2/contentpacks/dashboards.json", loadStrategy = LoadStrategyEnum.CLEAN_INSERT)
     public void exportEntity() {
-        final EntityDescriptor descriptor = EntityDescriptor.create("5a82f5974b900a7a97caa1e5", ModelTypes.DASHBOARD);
+        final EntityDescriptor descriptor = EntityDescriptor.create("5a82f5974b900a7a97caa1e5", ModelTypes.DASHBOARD_V1);
         final Optional<EntityWithConstraints> entityWithConstraints = facade.exportEntity(descriptor);
         final Entity entity = entityWithConstraints.orElseThrow(AssertionError::new).entity();
 
         assertThat(entity).isInstanceOf(EntityV1.class);
         assertThat(entity.id()).isEqualTo(ModelId.of("5a82f5974b900a7a97caa1e5"));
-        assertThat(entity.type()).isEqualTo(ModelTypes.DASHBOARD);
+        assertThat(entity.type()).isEqualTo(ModelTypes.DASHBOARD_V1);
 
         final EntityV1 entityV1 = (EntityV1) entity;
         final DashboardEntity dashboardEntity = objectMapper.convertValue(entityV1.data(), DashboardEntity.class);
@@ -202,7 +202,7 @@ public class DashboardFacadeTest {
         final EntityExcerpt excerpt = facade.createExcerpt(dashboard);
 
         assertThat(excerpt.id()).isEqualTo(ModelId.of(dashboard.getId()));
-        assertThat(excerpt.type()).isEqualTo(ModelTypes.DASHBOARD);
+        assertThat(excerpt.type()).isEqualTo(ModelTypes.DASHBOARD_V1);
         assertThat(excerpt.title()).isEqualTo(dashboard.getTitle());
     }
 
@@ -211,7 +211,7 @@ public class DashboardFacadeTest {
     public void listEntityExcerpts() {
         final EntityExcerpt expectedEntityExcerpt = EntityExcerpt.builder()
                 .id(ModelId.of("5a82f5974b900a7a97caa1e5"))
-                .type(ModelTypes.DASHBOARD)
+                .type(ModelTypes.DASHBOARD_V1)
                 .title("Test")
                 .build();
 
@@ -222,7 +222,7 @@ public class DashboardFacadeTest {
     @Test
     @UsingDataSet(locations = "/org/graylog2/contentpacks/dashboards.json", loadStrategy = LoadStrategyEnum.CLEAN_INSERT)
     public void collectEntity() {
-        final Optional<EntityWithConstraints> collectedEntity = facade.exportEntity(EntityDescriptor.create("5a82f5974b900a7a97caa1e5", ModelTypes.DASHBOARD));
+        final Optional<EntityWithConstraints> collectedEntity = facade.exportEntity(EntityDescriptor.create("5a82f5974b900a7a97caa1e5", ModelTypes.DASHBOARD_V1));
         assertThat(collectedEntity)
                 .isPresent()
                 .map(EntityWithConstraints::entity)
@@ -230,7 +230,7 @@ public class DashboardFacadeTest {
 
         final EntityV1 entity = (EntityV1) collectedEntity.map(EntityWithConstraints::entity).orElseThrow(AssertionError::new);
         assertThat(entity.id()).isEqualTo(ModelId.of("5a82f5974b900a7a97caa1e5"));
-        assertThat(entity.type()).isEqualTo(ModelTypes.DASHBOARD);
+        assertThat(entity.type()).isEqualTo(ModelTypes.DASHBOARD_V1);
         final DashboardEntity dashboardEntity = objectMapper.convertValue(entity.data(), DashboardEntity.class);
         assertThat(dashboardEntity.title()).isEqualTo(ValueReference.of("Test"));
         assertThat(dashboardEntity.description()).isEqualTo(ValueReference.of("Description"));
@@ -240,8 +240,8 @@ public class DashboardFacadeTest {
     @Test
     @UsingDataSet(locations = "/org/graylog2/contentpacks/dashboards.json", loadStrategy = LoadStrategyEnum.CLEAN_INSERT)
     public void resolve() {
-        final EntityDescriptor dashboardEntity = EntityDescriptor.create("5a82f5974b900a7a97caa1e5", ModelTypes.DASHBOARD);
-        final EntityDescriptor streamEntity = EntityDescriptor.create("5adf23894b900a0fdb4e517d", ModelTypes.STREAM);
+        final EntityDescriptor dashboardEntity = EntityDescriptor.create("5a82f5974b900a7a97caa1e5", ModelTypes.DASHBOARD_V1);
+        final EntityDescriptor streamEntity = EntityDescriptor.create("5adf23894b900a0fdb4e517d", ModelTypes.STREAM_V1);
 
         final Graph<EntityDescriptor> graph = facade.resolveNativeEntity(dashboardEntity);
         assertThat(graph.nodes())
@@ -261,9 +261,9 @@ public class DashboardFacadeTest {
     @Test
     @UsingDataSet(locations = "/org/graylog2/contentpacks/dashboards.json", loadStrategy = LoadStrategyEnum.CLEAN_INSERT)
     public void resolveEntityDescriptor() {
-        final EntityDescriptor descriptor = EntityDescriptor.create("5a82f5974b900a7a97caa1e5", ModelTypes.DASHBOARD);
+        final EntityDescriptor descriptor = EntityDescriptor.create("5a82f5974b900a7a97caa1e5", ModelTypes.DASHBOARD_V1);
         final Graph<EntityDescriptor> graph = facade.resolveNativeEntity(descriptor);
-        final EntityDescriptor expectedStream = EntityDescriptor.create("5adf23894b900a0fdb4e517d", ModelTypes.STREAM);
+        final EntityDescriptor expectedStream = EntityDescriptor.create("5adf23894b900a0fdb4e517d", ModelTypes.STREAM_V1);
 
         assertThat(graph.nodes()).containsOnly(descriptor, expectedStream);
     }
@@ -280,16 +280,16 @@ public class DashboardFacadeTest {
                 null);
         final Entity dashboardEntity = EntityV1.builder()
                 .id(ModelId.of("id"))
-                .type(ModelTypes.DASHBOARD)
+                .type(ModelTypes.DASHBOARD_V1)
                 .data(objectMapper.convertValue(DashboardEntity.create(
                         ValueReference.of("Title"),
                         ValueReference.of("Description"),
                         Collections.singletonList(dashboardWidgetEntity)), JsonNode.class))
                 .build();
-        final EntityDescriptor streamDescriptor = EntityDescriptor.create("stream-id", ModelTypes.STREAM);
+        final EntityDescriptor streamDescriptor = EntityDescriptor.create("stream-id", ModelTypes.STREAM_V1);
         final Entity streamEntity = EntityV1.builder()
                 .id(ModelId.of("stream-id"))
-                .type(ModelTypes.STREAM)
+                .type(ModelTypes.STREAM_V1)
                 .data(objectMapper.convertValue(StreamEntity.create(
                         ValueReference.of("Title"),
                         ValueReference.of("Description"),
@@ -311,7 +311,7 @@ public class DashboardFacadeTest {
     public void findExisting() {
         final Entity entity = EntityV1.builder()
                 .id(ModelId.of("5a82f5974b900a7a97caa1e5"))
-                .type(ModelTypes.DASHBOARD)
+                .type(ModelTypes.DASHBOARD_V1)
                 .data(NullNode.getInstance())
                 .build();
         assertThat(facade.findExisting(entity, Collections.emptyMap())).isEmpty();
@@ -332,7 +332,7 @@ public class DashboardFacadeTest {
                 null);
         final Entity dashboardEntity = EntityV1.builder()
                 .id(ModelId.of("id"))
-                .type(ModelTypes.DASHBOARD)
+                .type(ModelTypes.DASHBOARD_V1)
                 .data(objectMapper.convertValue(DashboardEntity.create(
                         ValueReference.of("Title"),
                         ValueReference.of("Description"),
@@ -353,7 +353,7 @@ public class DashboardFacadeTest {
         assertThat(dashboard.getWidgets().size()).isEqualTo(1);
         assertThat(dashboard.getWidgets()).containsKeys("12345");
 
-        final NativeEntityDescriptor expectedDescriptor = NativeEntityDescriptor.create(dashboardEntity.id(), savedDashboard.getId(), ModelTypes.DASHBOARD);
+        final NativeEntityDescriptor expectedDescriptor = NativeEntityDescriptor.create(dashboardEntity.id(), savedDashboard.getId(), ModelTypes.DASHBOARD_V1);
         assertThat(nativeEntity.descriptor()).isEqualTo(expectedDescriptor);
     }
 }

--- a/graylog2-server/src/test/java/org/graylog2/contentpacks/facades/GrokPatternFacadeTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/contentpacks/facades/GrokPatternFacadeTest.java
@@ -74,7 +74,7 @@ public class GrokPatternFacadeTest {
 
         assertThat(entity).isInstanceOf(EntityV1.class);
         assertThat(entity.id()).isEqualTo(ModelId.of("01234567890"));
-        assertThat(entity.type()).isEqualTo(ModelTypes.GROK_PATTERN);
+        assertThat(entity.type()).isEqualTo(ModelTypes.GROK_PATTERN_V1);
 
         final EntityV1 entityV1 = (EntityV1) entity;
         final GrokPatternEntity grokPatternEntity = objectMapper.convertValue(entityV1.data(), GrokPatternEntity.class);
@@ -88,7 +88,7 @@ public class GrokPatternFacadeTest {
         final EntityExcerpt excerpt = facade.createExcerpt(grokPattern);
 
         assertThat(excerpt.id()).isEqualTo(ModelId.of("01234567890"));
-        assertThat(excerpt.type()).isEqualTo(ModelTypes.GROK_PATTERN);
+        assertThat(excerpt.type()).isEqualTo(ModelTypes.GROK_PATTERN_V1);
         assertThat(excerpt.title()).isEqualTo(grokPattern.name());
     }
 
@@ -99,12 +99,12 @@ public class GrokPatternFacadeTest {
 
         final EntityExcerpt expectedEntityExcerpt1 = EntityExcerpt.builder()
                 .id(ModelId.of("1"))
-                .type(ModelTypes.GROK_PATTERN)
+                .type(ModelTypes.GROK_PATTERN_V1)
                 .title("Test1")
                 .build();
         final EntityExcerpt expectedEntityExcerpt2 = EntityExcerpt.builder()
                 .id(ModelId.of("2"))
-                .type(ModelTypes.GROK_PATTERN)
+                .type(ModelTypes.GROK_PATTERN_V1)
                 .title("Test2")
                 .build();
 
@@ -124,12 +124,12 @@ public class GrokPatternFacadeTest {
                 "pattern", ValueReference.of("[a-z]+"));
         final JsonNode entityData = objectMapper.convertValue(entity, JsonNode.class);
         final Entity expectedEntity = EntityV1.builder()
-                .type(ModelTypes.GROK_PATTERN)
+                .type(ModelTypes.GROK_PATTERN_V1)
                 .id(ModelId.of("1"))
                 .data(entityData)
                 .build();
 
-        final Optional<EntityWithConstraints> collectedEntity = facade.exportEntity(EntityDescriptor.create("1", ModelTypes.GROK_PATTERN));
+        final Optional<EntityWithConstraints> collectedEntity = facade.exportEntity(EntityDescriptor.create("1", ModelTypes.GROK_PATTERN_V1));
         assertThat(collectedEntity)
                 .isPresent()
                 .map(EntityWithConstraints::entity)
@@ -149,7 +149,7 @@ public class GrokPatternFacadeTest {
     @Test
     public void resolveEntityDescriptor() throws ValidationException {
         final GrokPattern grokPattern = grokPatternService.save(GrokPattern.create("Test1", "[a-z]+"));
-        final EntityDescriptor descriptor = EntityDescriptor.create(grokPattern.id(), ModelTypes.GROK_PATTERN);
+        final EntityDescriptor descriptor = EntityDescriptor.create(grokPattern.id(), ModelTypes.GROK_PATTERN_V1);
         final Graph<EntityDescriptor> graph = facade.resolveNativeEntity(descriptor);
         assertThat(graph.nodes()).containsOnly(descriptor);
     }
@@ -158,7 +158,7 @@ public class GrokPatternFacadeTest {
     public void resolveEntity() {
         final Entity entity = EntityV1.builder()
                 .id(ModelId.of("grok-id"))
-                .type(ModelTypes.GROK_PATTERN)
+                .type(ModelTypes.GROK_PATTERN_V1)
                 .data(NullNode.getInstance())
                 .build();
         final Graph<Entity> graph = facade.resolveForInstallation(entity, Collections.emptyMap(), Collections.emptyMap());
@@ -170,13 +170,13 @@ public class GrokPatternFacadeTest {
         final GrokPattern grokPattern = grokPatternService.save(GrokPattern.create("Test", "[a-z]+"));
         final Entity grokPatternEntity = EntityV1.builder()
                 .id(ModelId.of("1"))
-                .type(ModelTypes.GROK_PATTERN)
+                .type(ModelTypes.GROK_PATTERN_V1)
                 .data(objectMapper.convertValue(GrokPatternEntity.create(
                         ValueReference.of("Test"),
                         ValueReference.of("[a-z]+")), JsonNode.class))
                 .build();
         final Optional<NativeEntity<GrokPattern>> existingGrokPattern = facade.findExisting(grokPatternEntity, Collections.emptyMap());
-        final NativeEntityDescriptor expectedDescriptor = NativeEntityDescriptor.create(grokPatternEntity.id(), "1", ModelTypes.GROK_PATTERN);
+        final NativeEntityDescriptor expectedDescriptor = NativeEntityDescriptor.create(grokPatternEntity.id(), "1", ModelTypes.GROK_PATTERN_V1);
         assertThat(existingGrokPattern)
                 .isPresent()
                 .get()
@@ -190,7 +190,7 @@ public class GrokPatternFacadeTest {
     public void createNativeEntity() throws NotFoundException {
         final Entity grokPatternEntity = EntityV1.builder()
                 .id(ModelId.of("1"))
-                .type(ModelTypes.GROK_PATTERN)
+                .type(ModelTypes.GROK_PATTERN_V1)
                 .data(objectMapper.convertValue(GrokPatternEntity.create(
                         ValueReference.of("Test"),
                         ValueReference.of("[a-z]+")), JsonNode.class))
@@ -198,7 +198,7 @@ public class GrokPatternFacadeTest {
         final NativeEntity<GrokPattern> nativeEntity = facade.createNativeEntity(grokPatternEntity, Collections.emptyMap(), Collections.emptyMap(), "admin");
 
         final GrokPattern expectedGrokPattern = GrokPattern.create("1", "Test", "[a-z]+", null);
-        final NativeEntityDescriptor expectedDescriptor = NativeEntityDescriptor.create("1", "1", ModelTypes.GROK_PATTERN);
+        final NativeEntityDescriptor expectedDescriptor = NativeEntityDescriptor.create("1", "1", ModelTypes.GROK_PATTERN_V1);
 
         assertThat(nativeEntity.descriptor()).isEqualTo(expectedDescriptor);
         assertThat(nativeEntity.entity()).isEqualTo(expectedGrokPattern);
@@ -210,7 +210,7 @@ public class GrokPatternFacadeTest {
         grokPatternService.save(GrokPattern.create("Test", "[a-z]+"));
         final Entity grokPatternEntity = EntityV1.builder()
                 .id(ModelId.of("1"))
-                .type(ModelTypes.GROK_PATTERN)
+                .type(ModelTypes.GROK_PATTERN_V1)
                 .data(objectMapper.convertValue(GrokPatternEntity.create(
                         ValueReference.of("Test"),
                         ValueReference.of("BOOM")), JsonNode.class))

--- a/graylog2-server/src/test/java/org/graylog2/contentpacks/facades/InputFacadeTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/contentpacks/facades/InputFacadeTest.java
@@ -156,7 +156,7 @@ public class InputFacadeTest {
 
         assertThat(entity).isInstanceOf(EntityV1.class);
         assertThat(entity.id()).isEqualTo(ModelId.of(input.getId()));
-        assertThat(entity.type()).isEqualTo(ModelTypes.INPUT);
+        assertThat(entity.type()).isEqualTo(ModelTypes.INPUT_V1);
 
         final EntityV1 entityV1 = (EntityV1) entity;
         final InputEntity inputEntity = objectMapper.convertValue(entityV1.data(), InputEntity.class);
@@ -169,13 +169,13 @@ public class InputFacadeTest {
     @UsingDataSet(locations = "/org/graylog2/contentpacks/inputs.json", loadStrategy = LoadStrategyEnum.CLEAN_INSERT)
     public void exportEntity() {
         final ModelId id = ModelId.of("5acc84f84b900a4ff290d9a7");
-        final EntityDescriptor descriptor = EntityDescriptor.create(id, ModelTypes.INPUT);
+        final EntityDescriptor descriptor = EntityDescriptor.create(id, ModelTypes.INPUT_V1);
         final EntityWithConstraints entityWithConstraints = facade.exportEntity(descriptor).orElseThrow(AssertionError::new);
         final Entity entity = entityWithConstraints.entity();
 
         assertThat(entity).isInstanceOf(EntityV1.class);
         assertThat(entity.id()).isEqualTo(id);
-        assertThat(entity.type()).isEqualTo(ModelTypes.INPUT);
+        assertThat(entity.type()).isEqualTo(ModelTypes.INPUT_V1);
 
         final EntityV1 entityV1 = (EntityV1) entity;
         final InputEntity inputEntity = objectMapper.convertValue(entityV1.data(), InputEntity.class);
@@ -200,7 +200,7 @@ public class InputFacadeTest {
         configuration.put("number_worker_threads", 8);
         final Entity entity = EntityV1.builder()
                 .id(ModelId.of("5acc84f84b900a4ff290d9a7"))
-                .type(ModelTypes.INPUT)
+                .type(ModelTypes.INPUT_V1)
                 .data(objectMapper.convertValue(InputEntity.create(
                         ValueReference.of("Local Raw UDP"),
                         ReferenceMapUtils.toReferenceMap(configuration),
@@ -215,7 +215,7 @@ public class InputFacadeTest {
         final InputWithExtractors inputWithExtractors = nativeEntity.entity();
         final Input savedInput = inputWithExtractors.input();
         final String savedId = savedInput.getId();
-        assertThat(nativeEntity.descriptor()).isEqualTo(EntityDescriptor.create(savedId, ModelTypes.INPUT));
+        assertThat(nativeEntity.descriptor()).isEqualTo(EntityDescriptor.create(savedId, ModelTypes.INPUT_V1));
         assertThat(savedInput.getTitle()).isEqualTo("Local Raw UDP");
         assertThat(savedInput.getType()).isEqualTo("org.graylog2.inputs.raw.udp.RawUDPInput");
         assertThat(savedInput.isGlobal()).isFalse();
@@ -232,7 +232,7 @@ public class InputFacadeTest {
         final EntityExcerpt excerpt = facade.createExcerpt(inputWithExtractors);
 
         assertThat(excerpt.id()).isEqualTo(ModelId.of(input.getId()));
-        assertThat(excerpt.type()).isEqualTo(ModelTypes.INPUT);
+        assertThat(excerpt.type()).isEqualTo(ModelTypes.INPUT_V1);
         assertThat(excerpt.title()).isEqualTo(input.getTitle());
     }
 
@@ -241,12 +241,12 @@ public class InputFacadeTest {
     public void listEntityExcerpts() {
         final EntityExcerpt expectedEntityExcerpt1 = EntityExcerpt.builder()
                 .id(ModelId.of("5adf25294b900a0fdb4e5365"))
-                .type(ModelTypes.INPUT)
+                .type(ModelTypes.INPUT_V1)
                 .title("Global Random HTTP")
                 .build();
         final EntityExcerpt expectedEntityExcerpt2 = EntityExcerpt.builder()
                 .id(ModelId.of("5acc84f84b900a4ff290d9a7"))
-                .type(ModelTypes.INPUT)
+                .type(ModelTypes.INPUT_V1)
                 .title("Local Raw UDP")
                 .build();
 
@@ -257,7 +257,7 @@ public class InputFacadeTest {
     @Test
     @UsingDataSet(locations = "/org/graylog2/contentpacks/inputs.json", loadStrategy = LoadStrategyEnum.CLEAN_INSERT)
     public void collectEntity() {
-        final Optional<EntityWithConstraints> collectedEntity = facade.exportEntity(EntityDescriptor.create("5adf25294b900a0fdb4e5365", ModelTypes.INPUT));
+        final Optional<EntityWithConstraints> collectedEntity = facade.exportEntity(EntityDescriptor.create("5adf25294b900a0fdb4e5365", ModelTypes.INPUT_V1));
         assertThat(collectedEntity)
                 .isPresent()
                 .map(EntityWithConstraints::entity)
@@ -265,7 +265,7 @@ public class InputFacadeTest {
 
         final EntityV1 entity = (EntityV1) collectedEntity.map(EntityWithConstraints::entity).orElseThrow(AssertionError::new);
         assertThat(entity.id()).isEqualTo(ModelId.of("5adf25294b900a0fdb4e5365"));
-        assertThat(entity.type()).isEqualTo(ModelTypes.INPUT);
+        assertThat(entity.type()).isEqualTo(ModelTypes.INPUT_V1);
         final InputEntity inputEntity = objectMapper.convertValue(entity.data(), InputEntity.class);
         assertThat(inputEntity.title()).isEqualTo(ValueReference.of("Global Random HTTP"));
         assertThat(inputEntity.type()).isEqualTo(ValueReference.of("org.graylog2.inputs.random.FakeHttpMessageInput"));
@@ -286,7 +286,7 @@ public class InputFacadeTest {
         configuration.put("number_worker_threads", 8);
         final Entity entity = EntityV1.builder()
                 .id(ModelId.of("5acc84f84b900a4ff290d9a7"))
-                .type(ModelTypes.INPUT)
+                .type(ModelTypes.INPUT_V1)
                 .data(objectMapper.convertValue(InputEntity.create(
                         ValueReference.of("Local Raw UDP"),
                         ReferenceMapUtils.toReferenceMap(configuration),
@@ -302,7 +302,7 @@ public class InputFacadeTest {
     @Test
     @UsingDataSet(locations = "/org/graylog2/contentpacks/inputs.json", loadStrategy = LoadStrategyEnum.CLEAN_INSERT)
     public void resolveEntityDescriptor() {
-        final EntityDescriptor descriptor = EntityDescriptor.create("5acc84f84b900a4ff290d9a7", ModelTypes.INPUT);
+        final EntityDescriptor descriptor = EntityDescriptor.create("5acc84f84b900a4ff290d9a7", ModelTypes.INPUT_V1);
         final Graph<EntityDescriptor> graph = facade.resolveNativeEntity(descriptor);
         assertThat(graph.nodes()).containsOnly(descriptor);
     }
@@ -318,7 +318,7 @@ public class InputFacadeTest {
         configuration.put("number_worker_threads", 8);
         final Entity entity = EntityV1.builder()
                 .id(ModelId.of("5acc84f84b900a4ff290d9a7"))
-                .type(ModelTypes.INPUT)
+                .type(ModelTypes.INPUT_V1)
                 .data(objectMapper.convertValue(InputEntity.create(
                         ValueReference.of("Local Raw UDP"),
                         ReferenceMapUtils.toReferenceMap(configuration),

--- a/graylog2-server/src/test/java/org/graylog2/contentpacks/facades/LookupCacheFacadeTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/contentpacks/facades/LookupCacheFacadeTest.java
@@ -98,7 +98,7 @@ public class LookupCacheFacadeTest {
 
         assertThat(entity).isInstanceOf(EntityV1.class);
         assertThat(entity.id()).isEqualTo(ModelId.of("1234567890"));
-        assertThat(entity.type()).isEqualTo(ModelTypes.LOOKUP_CACHE);
+        assertThat(entity.type()).isEqualTo(ModelTypes.LOOKUP_CACHE_V1);
 
         final EntityV1 entityV1 = (EntityV1) entity;
         final LookupCacheEntity lookupCacheEntity = objectMapper.convertValue(entityV1.data(), LookupCacheEntity.class);
@@ -111,13 +111,13 @@ public class LookupCacheFacadeTest {
     @Test
     @UsingDataSet(locations = "/org/graylog2/contentpacks/lut_caches.json", loadStrategy = LoadStrategyEnum.CLEAN_INSERT)
     public void exportEntity() {
-        final EntityDescriptor descriptor = EntityDescriptor.create("5adf24b24b900a0fdb4e52dd", ModelTypes.LOOKUP_CACHE);
+        final EntityDescriptor descriptor = EntityDescriptor.create("5adf24b24b900a0fdb4e52dd", ModelTypes.LOOKUP_CACHE_V1);
         final EntityWithConstraints entityWithConstraints = facade.exportEntity(descriptor).orElseThrow(AssertionError::new);
         final Entity entity = entityWithConstraints.entity();
 
         assertThat(entity).isInstanceOf(EntityV1.class);
         assertThat(entity.id()).isEqualTo(ModelId.of("5adf24b24b900a0fdb4e52dd"));
-        assertThat(entity.type()).isEqualTo(ModelTypes.LOOKUP_CACHE);
+        assertThat(entity.type()).isEqualTo(ModelTypes.LOOKUP_CACHE_V1);
 
         final EntityV1 entityV1 = (EntityV1) entity;
         final LookupCacheEntity lookupCacheEntity = objectMapper.convertValue(entityV1.data(), LookupCacheEntity.class);
@@ -132,7 +132,7 @@ public class LookupCacheFacadeTest {
     public void createNativeEntity() {
         final Entity entity = EntityV1.builder()
                 .id(ModelId.of("1"))
-                .type(ModelTypes.LOOKUP_CACHE)
+                .type(ModelTypes.LOOKUP_CACHE_V1)
                 .data(objectMapper.convertValue(LookupCacheEntity.create(
                         ValueReference.of("no-op-cache"),
                         ValueReference.of("No-op cache"),
@@ -147,7 +147,7 @@ public class LookupCacheFacadeTest {
         final CacheDto cacheDto = nativeEntity.entity();
 
         assertThat(descriptor.id()).isEqualTo(ModelId.of("no-op-cache"));
-        assertThat(descriptor.type()).isEqualTo(ModelTypes.LOOKUP_CACHE);
+        assertThat(descriptor.type()).isEqualTo(ModelTypes.LOOKUP_CACHE_V1);
         assertThat(cacheDto.name()).isEqualTo("no-op-cache");
         assertThat(cacheDto.title()).isEqualTo("No-op cache");
         assertThat(cacheDto.description()).isEqualTo("No-op cache");
@@ -161,7 +161,7 @@ public class LookupCacheFacadeTest {
     public void findExisting() {
         final Entity entity = EntityV1.builder()
                 .id(ModelId.of("1"))
-                .type(ModelTypes.LOOKUP_CACHE)
+                .type(ModelTypes.LOOKUP_CACHE_V1)
                 .data(objectMapper.convertValue(LookupCacheEntity.create(
                         ValueReference.of("no-op-cache"),
                         ValueReference.of("No-op cache"),
@@ -176,7 +176,7 @@ public class LookupCacheFacadeTest {
         final CacheDto cacheDto = existingCache.entity();
 
         assertThat(descriptor.id()).isEqualTo(ModelId.of("5adf24b24b900a0fdb4e52dd"));
-        assertThat(descriptor.type()).isEqualTo(ModelTypes.LOOKUP_CACHE);
+        assertThat(descriptor.type()).isEqualTo(ModelTypes.LOOKUP_CACHE_V1);
         assertThat(cacheDto.id()).isEqualTo("5adf24b24b900a0fdb4e52dd");
         assertThat(cacheDto.name()).isEqualTo("no-op-cache");
         assertThat(cacheDto.title()).isEqualTo("No-op cache");
@@ -189,7 +189,7 @@ public class LookupCacheFacadeTest {
     public void findExistingWithNoExistingEntity() {
         final Entity entity = EntityV1.builder()
                 .id(ModelId.of("1"))
-                .type(ModelTypes.LOOKUP_CACHE)
+                .type(ModelTypes.LOOKUP_CACHE_V1)
                 .data(objectMapper.convertValue(LookupCacheEntity.create(
                         ValueReference.of("some-cache"),
                         ValueReference.of("Some cache"),
@@ -208,7 +208,7 @@ public class LookupCacheFacadeTest {
     public void resolveEntity() {
         final Entity entity = EntityV1.builder()
                 .id(ModelId.of("1"))
-                .type(ModelTypes.LOOKUP_CACHE)
+                .type(ModelTypes.LOOKUP_CACHE_V1)
                 .data(objectMapper.convertValue(LookupCacheEntity.create(
                         ValueReference.of("no-op-cache"),
                         ValueReference.of("No-op cache"),
@@ -225,7 +225,7 @@ public class LookupCacheFacadeTest {
     @Test
     @UsingDataSet(locations = "/org/graylog2/contentpacks/lut_caches.json", loadStrategy = LoadStrategyEnum.CLEAN_INSERT)
     public void resolveEntityDescriptor() {
-        final EntityDescriptor descriptor = EntityDescriptor.create("5adf24b24b900a0fdb4e52dd", ModelTypes.LOOKUP_CACHE);
+        final EntityDescriptor descriptor = EntityDescriptor.create("5adf24b24b900a0fdb4e52dd", ModelTypes.LOOKUP_CACHE_V1);
         final Graph<EntityDescriptor> graph = facade.resolveNativeEntity(descriptor);
         assertThat(graph.nodes()).containsOnly(descriptor);
     }
@@ -254,7 +254,7 @@ public class LookupCacheFacadeTest {
         final EntityExcerpt excerpt = facade.createExcerpt(cacheDto);
 
         assertThat(excerpt.id()).isEqualTo(ModelId.of("cache-name"));
-        assertThat(excerpt.type()).isEqualTo(ModelTypes.LOOKUP_CACHE);
+        assertThat(excerpt.type()).isEqualTo(ModelTypes.LOOKUP_CACHE_V1);
         assertThat(excerpt.title()).isEqualTo("Cache Title");
     }
 
@@ -263,7 +263,7 @@ public class LookupCacheFacadeTest {
     public void listEntityExcerpts() {
         final EntityExcerpt expectedEntityExcerpt = EntityExcerpt.builder()
                 .id(ModelId.of("no-op-cache"))
-                .type(ModelTypes.LOOKUP_CACHE)
+                .type(ModelTypes.LOOKUP_CACHE_V1)
                 .title("No-op cache")
                 .build();
 
@@ -274,7 +274,7 @@ public class LookupCacheFacadeTest {
     @Test
     @UsingDataSet(locations = "/org/graylog2/contentpacks/lut_caches.json", loadStrategy = LoadStrategyEnum.CLEAN_INSERT)
     public void collectEntity() {
-        final Optional<EntityWithConstraints> collectedEntity = facade.exportEntity(EntityDescriptor.create("no-op-cache", ModelTypes.LOOKUP_CACHE));
+        final Optional<EntityWithConstraints> collectedEntity = facade.exportEntity(EntityDescriptor.create("no-op-cache", ModelTypes.LOOKUP_CACHE_V1));
         assertThat(collectedEntity)
                 .isPresent()
                 .map(EntityWithConstraints::entity)
@@ -282,7 +282,7 @@ public class LookupCacheFacadeTest {
 
         final EntityV1 entity = (EntityV1) collectedEntity.map(EntityWithConstraints::entity).orElseThrow(AssertionError::new);
         assertThat(entity.id()).isEqualTo(ModelId.of("5adf24b24b900a0fdb4e52dd"));
-        assertThat(entity.type()).isEqualTo(ModelTypes.LOOKUP_CACHE);
+        assertThat(entity.type()).isEqualTo(ModelTypes.LOOKUP_CACHE_V1);
         final LookupCacheEntity lookupCacheEntity = objectMapper.convertValue(entity.data(), LookupCacheEntity.class);
         assertThat(lookupCacheEntity.name()).isEqualTo(ValueReference.of("no-op-cache"));
         assertThat(lookupCacheEntity.title()).isEqualTo(ValueReference.of("No-op cache"));

--- a/graylog2-server/src/test/java/org/graylog2/contentpacks/facades/LookupDataAdapterFacadeTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/contentpacks/facades/LookupDataAdapterFacadeTest.java
@@ -96,7 +96,7 @@ public class LookupDataAdapterFacadeTest {
 
         assertThat(entity).isInstanceOf(EntityV1.class);
         assertThat(entity.id()).isEqualTo(ModelId.of("1234567890"));
-        assertThat(entity.type()).isEqualTo(ModelTypes.LOOKUP_ADAPTER);
+        assertThat(entity.type()).isEqualTo(ModelTypes.LOOKUP_ADAPTER_V1);
 
         final EntityV1 entityV1 = (EntityV1) entity;
         final LookupDataAdapterEntity lookupDataAdapterEntity = objectMapper.convertValue(entityV1.data(), LookupDataAdapterEntity.class);
@@ -109,13 +109,13 @@ public class LookupDataAdapterFacadeTest {
     @Test
     @UsingDataSet(locations = "/org/graylog2/contentpacks/lut_data_adapters.json", loadStrategy = LoadStrategyEnum.CLEAN_INSERT)
     public void exportEntityDescriptor() {
-        final EntityDescriptor descriptor = EntityDescriptor.create("5adf24a04b900a0fdb4e52c8", ModelTypes.LOOKUP_ADAPTER);
+        final EntityDescriptor descriptor = EntityDescriptor.create("5adf24a04b900a0fdb4e52c8", ModelTypes.LOOKUP_ADAPTER_V1);
         final EntityWithConstraints entityWithConstraints = facade.exportEntity(descriptor).orElseThrow(AssertionError::new);
         final Entity entity = entityWithConstraints.entity();
 
         assertThat(entity).isInstanceOf(EntityV1.class);
         assertThat(entity.id()).isEqualTo(ModelId.of("5adf24a04b900a0fdb4e52c8"));
-        assertThat(entity.type()).isEqualTo(ModelTypes.LOOKUP_ADAPTER);
+        assertThat(entity.type()).isEqualTo(ModelTypes.LOOKUP_ADAPTER_V1);
 
         final EntityV1 entityV1 = (EntityV1) entity;
         final LookupDataAdapterEntity lookupDataAdapterEntity = objectMapper.convertValue(entityV1.data(), LookupDataAdapterEntity.class);
@@ -129,7 +129,7 @@ public class LookupDataAdapterFacadeTest {
     public void createNativeEntity() {
         final Entity entity = EntityV1.builder()
                 .id(ModelId.of("1"))
-                .type(ModelTypes.LOOKUP_ADAPTER)
+                .type(ModelTypes.LOOKUP_ADAPTER_V1)
                 .data(objectMapper.convertValue(LookupDataAdapterEntity.create(
                         ValueReference.of("http-dsv"),
                         ValueReference.of("HTTP DSV"),
@@ -142,7 +142,7 @@ public class LookupDataAdapterFacadeTest {
         final NativeEntity<DataAdapterDto> nativeEntity = facade.createNativeEntity(entity, Collections.emptyMap(), Collections.emptyMap(), "username");
 
         assertThat(nativeEntity.descriptor().id()).isEqualTo(ModelId.of("http-dsv"));
-        assertThat(nativeEntity.descriptor().type()).isEqualTo(ModelTypes.LOOKUP_ADAPTER);
+        assertThat(nativeEntity.descriptor().type()).isEqualTo(ModelTypes.LOOKUP_ADAPTER_V1);
         assertThat(nativeEntity.entity().name()).isEqualTo("http-dsv");
         assertThat(nativeEntity.entity().title()).isEqualTo("HTTP DSV");
         assertThat(nativeEntity.entity().description()).isEqualTo("HTTP DSV");
@@ -155,7 +155,7 @@ public class LookupDataAdapterFacadeTest {
     public void findExisting() {
         final Entity entity = EntityV1.builder()
                 .id(ModelId.of("1"))
-                .type(ModelTypes.LOOKUP_ADAPTER)
+                .type(ModelTypes.LOOKUP_ADAPTER_V1)
                 .data(objectMapper.convertValue(LookupDataAdapterEntity.create(
                         ValueReference.of("http-dsv"),
                         ValueReference.of("HTTP DSV"),
@@ -166,7 +166,7 @@ public class LookupDataAdapterFacadeTest {
         final NativeEntity<DataAdapterDto> nativeEntity = facade.findExisting(entity, Collections.emptyMap()).orElseThrow(AssertionError::new);
 
         assertThat(nativeEntity.descriptor().id()).isEqualTo(ModelId.of("5adf24a04b900a0fdb4e52c8"));
-        assertThat(nativeEntity.descriptor().type()).isEqualTo(ModelTypes.LOOKUP_ADAPTER);
+        assertThat(nativeEntity.descriptor().type()).isEqualTo(ModelTypes.LOOKUP_ADAPTER_V1);
         assertThat(nativeEntity.entity().name()).isEqualTo("http-dsv");
         assertThat(nativeEntity.entity().title()).isEqualTo("HTTP DSV");
         assertThat(nativeEntity.entity().description()).isEqualTo("HTTP DSV");
@@ -177,7 +177,7 @@ public class LookupDataAdapterFacadeTest {
     public void findExistingWithNoExistingEntity() {
         final Entity entity = EntityV1.builder()
                 .id(ModelId.of("1"))
-                .type(ModelTypes.LOOKUP_ADAPTER)
+                .type(ModelTypes.LOOKUP_ADAPTER_V1)
                 .data(objectMapper.convertValue(LookupDataAdapterEntity.create(
                         ValueReference.of("some-name"),
                         ValueReference.of("Some title"),
@@ -204,7 +204,7 @@ public class LookupDataAdapterFacadeTest {
     @Test
     @UsingDataSet(locations = "/org/graylog2/contentpacks/lut_data_adapters.json", loadStrategy = LoadStrategyEnum.CLEAN_INSERT)
     public void resolveEntityDescriptor() {
-        final EntityDescriptor descriptor = EntityDescriptor.create("5adf24a04b900a0fdb4e52c8", ModelTypes.LOOKUP_ADAPTER);
+        final EntityDescriptor descriptor = EntityDescriptor.create("5adf24a04b900a0fdb4e52c8", ModelTypes.LOOKUP_ADAPTER_V1);
         final Graph<EntityDescriptor> graph = facade.resolveNativeEntity(descriptor);
         assertThat(graph.nodes()).containsOnly(descriptor);
     }
@@ -214,7 +214,7 @@ public class LookupDataAdapterFacadeTest {
     public void resolveEntity() {
         final Entity entity = EntityV1.builder()
                 .id(ModelId.of("5adf24a04b900a0fdb4e52c8"))
-                .type(ModelTypes.LOOKUP_ADAPTER)
+                .type(ModelTypes.LOOKUP_ADAPTER_V1)
                 .data(objectMapper.convertValue(LookupDataAdapterEntity.create(
                         ValueReference.of("http-dsv"),
                         ValueReference.of("HTTP DSV"),
@@ -239,7 +239,7 @@ public class LookupDataAdapterFacadeTest {
         final EntityExcerpt excerpt = facade.createExcerpt(dataAdapterDto);
 
         assertThat(excerpt.id()).isEqualTo(ModelId.of("data-adapter-name"));
-        assertThat(excerpt.type()).isEqualTo(ModelTypes.LOOKUP_ADAPTER);
+        assertThat(excerpt.type()).isEqualTo(ModelTypes.LOOKUP_ADAPTER_V1);
         assertThat(excerpt.title()).isEqualTo("Data Adapter Title");
     }
 
@@ -248,7 +248,7 @@ public class LookupDataAdapterFacadeTest {
     public void listEntityExcerpts() {
         final EntityExcerpt expectedEntityExcerpt = EntityExcerpt.builder()
                 .id(ModelId.of("http-dsv"))
-                .type(ModelTypes.LOOKUP_ADAPTER)
+                .type(ModelTypes.LOOKUP_ADAPTER_V1)
                 .title("HTTP DSV")
                 .build();
 
@@ -259,7 +259,7 @@ public class LookupDataAdapterFacadeTest {
     @Test
     @UsingDataSet(locations = "/org/graylog2/contentpacks/lut_data_adapters.json", loadStrategy = LoadStrategyEnum.CLEAN_INSERT)
     public void collectEntity() {
-        final Optional<EntityWithConstraints> collectedEntity = facade.exportEntity(EntityDescriptor.create("http-dsv", ModelTypes.LOOKUP_ADAPTER));
+        final Optional<EntityWithConstraints> collectedEntity = facade.exportEntity(EntityDescriptor.create("http-dsv", ModelTypes.LOOKUP_ADAPTER_V1));
         assertThat(collectedEntity)
                 .isPresent()
                 .map(EntityWithConstraints::entity)
@@ -267,7 +267,7 @@ public class LookupDataAdapterFacadeTest {
 
         final EntityV1 entity = (EntityV1) collectedEntity.map(EntityWithConstraints::entity).orElseThrow(AssertionError::new);
         assertThat(entity.id()).isEqualTo(ModelId.of("5adf24a04b900a0fdb4e52c8"));
-        assertThat(entity.type()).isEqualTo(ModelTypes.LOOKUP_ADAPTER);
+        assertThat(entity.type()).isEqualTo(ModelTypes.LOOKUP_ADAPTER_V1);
         final LookupDataAdapterEntity lookupDataAdapterEntity = objectMapper.convertValue(entity.data(), LookupDataAdapterEntity.class);
         assertThat(lookupDataAdapterEntity.name()).isEqualTo(ValueReference.of("http-dsv"));
         assertThat(lookupDataAdapterEntity.title()).isEqualTo(ValueReference.of("HTTP DSV"));

--- a/graylog2-server/src/test/java/org/graylog2/contentpacks/facades/LookupTableFacadeTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/contentpacks/facades/LookupTableFacadeTest.java
@@ -105,7 +105,7 @@ public class LookupTableFacadeTest {
 
         assertThat(entity).isInstanceOf(EntityV1.class);
         assertThat(entity.id()).isEqualTo(ModelId.of("1234567890"));
-        assertThat(entity.type()).isEqualTo(ModelTypes.LOOKUP_TABLE);
+        assertThat(entity.type()).isEqualTo(ModelTypes.LOOKUP_TABLE_V1);
 
         final EntityV1 entityV1 = (EntityV1) entity;
         final LookupTableEntity lookupTableEntity = objectMapper.convertValue(entityV1.data(), LookupTableEntity.class);
@@ -123,13 +123,13 @@ public class LookupTableFacadeTest {
     @Test
     @UsingDataSet(locations = "/org/graylog2/contentpacks/lut_tables.json", loadStrategy = LoadStrategyEnum.CLEAN_INSERT)
     public void exportNativeEntity() {
-        final EntityDescriptor descriptor = EntityDescriptor.create("5adf24dd4b900a0fdb4e530d", ModelTypes.LOOKUP_TABLE);
+        final EntityDescriptor descriptor = EntityDescriptor.create("5adf24dd4b900a0fdb4e530d", ModelTypes.LOOKUP_TABLE_V1);
         final EntityWithConstraints entityWithConstraints = facade.exportEntity(descriptor).orElseThrow(AssertionError::new);
         final Entity entity = entityWithConstraints.entity();
 
         assertThat(entity).isInstanceOf(EntityV1.class);
         assertThat(entity.id()).isEqualTo(ModelId.of("5adf24dd4b900a0fdb4e530d"));
-        assertThat(entity.type()).isEqualTo(ModelTypes.LOOKUP_TABLE);
+        assertThat(entity.type()).isEqualTo(ModelTypes.LOOKUP_TABLE_V1);
 
         final EntityV1 entityV1 = (EntityV1) entity;
         final LookupTableEntity lookupTableEntity = objectMapper.convertValue(entityV1.data(), LookupTableEntity.class);
@@ -149,7 +149,7 @@ public class LookupTableFacadeTest {
     public void createNativeEntity() {
         final Entity entity = EntityV1.builder()
                 .id(ModelId.of("1"))
-                .type(ModelTypes.LOOKUP_TABLE)
+                .type(ModelTypes.LOOKUP_TABLE_V1)
                 .data(objectMapper.convertValue(LookupTableEntity.create(
                         ValueReference.of("http-dsv-no-cache"),
                         ValueReference.of("HTTP DSV without Cache"),
@@ -161,7 +161,7 @@ public class LookupTableFacadeTest {
                         ValueReference.of("Default multi value"),
                         ValueReference.of(LookupDefaultValue.Type.OBJECT)), JsonNode.class))
                 .build();
-        final EntityDescriptor cacheDescriptor = EntityDescriptor.create("no-op-cache", ModelTypes.LOOKUP_CACHE);
+        final EntityDescriptor cacheDescriptor = EntityDescriptor.create("no-op-cache", ModelTypes.LOOKUP_CACHE_V1);
         final CacheDto cacheDto = CacheDto.builder()
                 .id("5adf24b24b900a0fdb4e0001")
                 .name("no-op-cache")
@@ -169,7 +169,7 @@ public class LookupTableFacadeTest {
                 .description("No-op cache")
                 .config(new FallbackCacheConfig())
                 .build();
-        final EntityDescriptor dataAdapterDescriptor = EntityDescriptor.create("http-dsv", ModelTypes.LOOKUP_ADAPTER);
+        final EntityDescriptor dataAdapterDescriptor = EntityDescriptor.create("http-dsv", ModelTypes.LOOKUP_ADAPTER_V1);
         final DataAdapterDto dataAdapterDto = DataAdapterDto.builder()
                 .id("5adf24a04b900a0fdb4e0002")
                 .name("http-dsv")
@@ -184,7 +184,7 @@ public class LookupTableFacadeTest {
 
         final NativeEntity<LookupTableDto> nativeEntity = facade.createNativeEntity(entity, Collections.emptyMap(), nativeEntities, "username");
 
-        assertThat(nativeEntity.descriptor().type()).isEqualTo(ModelTypes.LOOKUP_TABLE);
+        assertThat(nativeEntity.descriptor().type()).isEqualTo(ModelTypes.LOOKUP_TABLE_V1);
         assertThat(nativeEntity.entity().name()).isEqualTo("http-dsv-no-cache");
         assertThat(nativeEntity.entity().title()).isEqualTo("HTTP DSV without Cache");
         assertThat(nativeEntity.entity().description()).isEqualTo("HTTP DSV without Cache");
@@ -203,7 +203,7 @@ public class LookupTableFacadeTest {
     public void findExisting() {
         final Entity entity = EntityV1.builder()
                 .id(ModelId.of("1"))
-                .type(ModelTypes.LOOKUP_TABLE)
+                .type(ModelTypes.LOOKUP_TABLE_V1)
                 .data(objectMapper.convertValue(LookupTableEntity.create(
                         ValueReference.of("http-dsv-no-cache"),
                         ValueReference.of("HTTP DSV without Cache"),
@@ -218,7 +218,7 @@ public class LookupTableFacadeTest {
         final NativeEntity<LookupTableDto> existingEntity = facade.findExisting(entity, Collections.emptyMap()).orElseThrow(AssertionError::new);
 
         assertThat(existingEntity.descriptor().id()).isEqualTo(ModelId.of("5adf24dd4b900a0fdb4e530d"));
-        assertThat(existingEntity.descriptor().type()).isEqualTo(ModelTypes.LOOKUP_TABLE);
+        assertThat(existingEntity.descriptor().type()).isEqualTo(ModelTypes.LOOKUP_TABLE_V1);
         assertThat(existingEntity.entity().name()).isEqualTo("http-dsv-no-cache");
         assertThat(existingEntity.entity().title()).isEqualTo("HTTP DSV without Cache");
         assertThat(existingEntity.entity().description()).isEqualTo("HTTP DSV without Cache");
@@ -235,7 +235,7 @@ public class LookupTableFacadeTest {
     public void resolveEntity() {
         final Entity entity = EntityV1.builder()
                 .id(ModelId.of("5adf24dd4b900a0fdb4e530d"))
-                .type(ModelTypes.LOOKUP_TABLE)
+                .type(ModelTypes.LOOKUP_TABLE_V1)
                 .data(objectMapper.convertValue(LookupTableEntity.create(
                         ValueReference.of("http-dsv-no-cache"),
                         ValueReference.of("HTTP DSV without Cache"),
@@ -249,7 +249,7 @@ public class LookupTableFacadeTest {
                 .build();
         final Entity cacheEntity = EntityV1.builder()
                 .id(ModelId.of("5adf24b24b900a0fdb4e52dd"))
-                .type(ModelTypes.LOOKUP_CACHE)
+                .type(ModelTypes.LOOKUP_CACHE_V1)
                 .data(objectMapper.convertValue(LookupCacheEntity.create(
                         ValueReference.of("no-op-cache"),
                         ValueReference.of("No-op cache"),
@@ -259,7 +259,7 @@ public class LookupTableFacadeTest {
                 .build();
         final Entity dataAdapterEntity = EntityV1.builder()
                 .id(ModelId.of("5adf24a04b900a0fdb4e52c8"))
-                .type(ModelTypes.LOOKUP_ADAPTER)
+                .type(ModelTypes.LOOKUP_ADAPTER_V1)
                 .data(objectMapper.convertValue(LookupDataAdapterEntity.create(
                         ValueReference.of("http-dsv"),
                         ValueReference.of("HTTP DSV"),
@@ -280,15 +280,15 @@ public class LookupTableFacadeTest {
     @Test
     @UsingDataSet(locations = {"/org/graylog2/contentpacks/lut_caches.json", "/org/graylog2/contentpacks/lut_data_adapters.json", "/org/graylog2/contentpacks/lut_tables.json"}, loadStrategy = LoadStrategyEnum.CLEAN_INSERT)
     public void resolveEntityDescriptor() {
-        final EntityDescriptor descriptor = EntityDescriptor.create("5adf24dd4b900a0fdb4e530d", ModelTypes.LOOKUP_TABLE);
+        final EntityDescriptor descriptor = EntityDescriptor.create("5adf24dd4b900a0fdb4e530d", ModelTypes.LOOKUP_TABLE_V1);
 
         final Graph<EntityDescriptor> graph = facade.resolveNativeEntity(descriptor);
         assertThat(graph.nodes())
                 .hasSize(3)
                 .containsOnly(
                         descriptor,
-                        EntityDescriptor.create("5adf24a04b900a0fdb4e52c8", ModelTypes.LOOKUP_ADAPTER),
-                        EntityDescriptor.create("5adf24b24b900a0fdb4e52dd", ModelTypes.LOOKUP_CACHE));
+                        EntityDescriptor.create("5adf24a04b900a0fdb4e52c8", ModelTypes.LOOKUP_ADAPTER_V1),
+                        EntityDescriptor.create("5adf24b24b900a0fdb4e52dd", ModelTypes.LOOKUP_CACHE_V1));
     }
 
     @Test
@@ -296,7 +296,7 @@ public class LookupTableFacadeTest {
     public void findExistingWithNoExistingEntity() {
         final Entity entity = EntityV1.builder()
                 .id(ModelId.of("1"))
-                .type(ModelTypes.LOOKUP_TABLE)
+                .type(ModelTypes.LOOKUP_TABLE_V1)
                 .data(objectMapper.convertValue(LookupTableEntity.create(
                         ValueReference.of("some-name"),
                         ValueReference.of("Title"),
@@ -342,7 +342,7 @@ public class LookupTableFacadeTest {
         final EntityExcerpt excerpt = facade.createExcerpt(lookupTableDto);
 
         assertThat(excerpt.id()).isEqualTo(ModelId.of("lookup-table-name"));
-        assertThat(excerpt.type()).isEqualTo(ModelTypes.LOOKUP_TABLE);
+        assertThat(excerpt.type()).isEqualTo(ModelTypes.LOOKUP_TABLE_V1);
         assertThat(excerpt.title()).isEqualTo("Lookup Table Title");
     }
 
@@ -351,7 +351,7 @@ public class LookupTableFacadeTest {
     public void listEntityExcerpts() {
         final EntityExcerpt expectedEntityExcerpt = EntityExcerpt.builder()
                 .id(ModelId.of("http-dsv-no-cache"))
-                .type(ModelTypes.LOOKUP_TABLE)
+                .type(ModelTypes.LOOKUP_TABLE_V1)
                 .title("HTTP DSV without Cache")
                 .build();
 
@@ -362,7 +362,7 @@ public class LookupTableFacadeTest {
     @Test
     @UsingDataSet(locations = "/org/graylog2/contentpacks/lut_tables.json", loadStrategy = LoadStrategyEnum.CLEAN_INSERT)
     public void collectEntity() {
-        final Optional<EntityWithConstraints> collectedEntity = facade.exportEntity(EntityDescriptor.create("http-dsv-no-cache", ModelTypes.LOOKUP_TABLE));
+        final Optional<EntityWithConstraints> collectedEntity = facade.exportEntity(EntityDescriptor.create("http-dsv-no-cache", ModelTypes.LOOKUP_TABLE_V1));
         assertThat(collectedEntity)
                 .isPresent()
                 .map(EntityWithConstraints::entity)
@@ -370,7 +370,7 @@ public class LookupTableFacadeTest {
 
         final EntityV1 entity = (EntityV1) collectedEntity.map(EntityWithConstraints::entity).orElseThrow(AssertionError::new);
         assertThat(entity.id()).isEqualTo(ModelId.of("5adf24dd4b900a0fdb4e530d"));
-        assertThat(entity.type()).isEqualTo(ModelTypes.LOOKUP_TABLE);
+        assertThat(entity.type()).isEqualTo(ModelTypes.LOOKUP_TABLE_V1);
         final LookupTableEntity lookupTableEntity = objectMapper.convertValue(entity.data(), LookupTableEntity.class);
         assertThat(lookupTableEntity.name()).isEqualTo(ValueReference.of("http-dsv-no-cache"));
         assertThat(lookupTableEntity.title()).isEqualTo(ValueReference.of("HTTP DSV without Cache"));

--- a/graylog2-server/src/test/java/org/graylog2/contentpacks/facades/OutputFacadeTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/contentpacks/facades/OutputFacadeTest.java
@@ -122,7 +122,7 @@ public class OutputFacadeTest {
 
         assertThat(entity).isInstanceOf(EntityV1.class);
         assertThat(entity.id()).isEqualTo(ModelId.of("01234567890"));
-        assertThat(entity.type()).isEqualTo(ModelTypes.OUTPUT);
+        assertThat(entity.type()).isEqualTo(ModelTypes.OUTPUT_V1);
 
         final EntityV1 entityV1 = (EntityV1) entity;
         final OutputEntity outputEntity = objectMapper.convertValue(entityV1.data(), OutputEntity.class);
@@ -141,7 +141,7 @@ public class OutputFacadeTest {
 
         assertThat(entity).isInstanceOf(EntityV1.class);
         assertThat(entity.id()).isEqualTo(ModelId.of("5adf239e4b900a0fdb4e5197"));
-        assertThat(entity.type()).isEqualTo(ModelTypes.OUTPUT);
+        assertThat(entity.type()).isEqualTo(ModelTypes.OUTPUT_V1);
 
         final EntityV1 entityV1 = (EntityV1) entity;
         final OutputEntity outputEntity = objectMapper.convertValue(entityV1.data(), OutputEntity.class);
@@ -155,7 +155,7 @@ public class OutputFacadeTest {
     public void createNativeEntity() {
         final Entity entity = EntityV1.builder()
                 .id(ModelId.of("1"))
-                .type(ModelTypes.OUTPUT)
+                .type(ModelTypes.OUTPUT_V1)
                 .data(objectMapper.convertValue(OutputEntity.create(
                         ValueReference.of("STDOUT"),
                         ValueReference.of("org.graylog2.outputs.LoggingOutput"),
@@ -165,7 +165,7 @@ public class OutputFacadeTest {
 
         final NativeEntity<Output> nativeEntity = facade.createNativeEntity(entity, Collections.emptyMap(), Collections.emptyMap(), "username");
 
-        assertThat(nativeEntity.descriptor().type()).isEqualTo(ModelTypes.OUTPUT);
+        assertThat(nativeEntity.descriptor().type()).isEqualTo(ModelTypes.OUTPUT_V1);
         assertThat(nativeEntity.entity().getTitle()).isEqualTo("STDOUT");
         assertThat(nativeEntity.entity().getType()).isEqualTo("org.graylog2.outputs.LoggingOutput");
         assertThat(nativeEntity.entity().getCreatorUserId()).isEqualTo("username");
@@ -177,7 +177,7 @@ public class OutputFacadeTest {
     public void findExisting() {
         final Entity entity = EntityV1.builder()
                 .id(ModelId.of("1"))
-                .type(ModelTypes.OUTPUT)
+                .type(ModelTypes.OUTPUT_V1)
                 .data(objectMapper.convertValue(OutputEntity.create(
                         ValueReference.of("STDOUT"),
                         ValueReference.of("org.graylog2.outputs.LoggingOutput"),
@@ -193,7 +193,7 @@ public class OutputFacadeTest {
     public void resolveEntity() {
         final Entity entity = EntityV1.builder()
                 .id(ModelId.of("5adf239e4b900a0fdb4e5197"))
-                .type(ModelTypes.OUTPUT)
+                .type(ModelTypes.OUTPUT_V1)
                 .data(objectMapper.convertValue(OutputEntity.create(
                         ValueReference.of("STDOUT"),
                         ValueReference.of("org.graylog2.outputs.LoggingOutput"),
@@ -207,7 +207,7 @@ public class OutputFacadeTest {
     @Test
     @UsingDataSet(locations = "/org/graylog2/contentpacks/outputs.json", loadStrategy = LoadStrategyEnum.CLEAN_INSERT)
     public void resolveEntityDescriptor() {
-        final EntityDescriptor descriptor = EntityDescriptor.create("5adf239e4b900a0fdb4e5197", ModelTypes.OUTPUT);
+        final EntityDescriptor descriptor = EntityDescriptor.create("5adf239e4b900a0fdb4e5197", ModelTypes.OUTPUT_V1);
         final Graph<EntityDescriptor> graph = facade.resolveNativeEntity(descriptor);
         assertThat(graph.nodes()).containsOnly(descriptor);
     }
@@ -238,7 +238,7 @@ public class OutputFacadeTest {
         final EntityExcerpt excerpt = facade.createExcerpt(output);
 
         assertThat(excerpt.id()).isEqualTo(ModelId.of(output.getId()));
-        assertThat(excerpt.type()).isEqualTo(ModelTypes.OUTPUT);
+        assertThat(excerpt.type()).isEqualTo(ModelTypes.OUTPUT_V1);
         assertThat(excerpt.title()).isEqualTo(output.getTitle());
     }
 
@@ -247,7 +247,7 @@ public class OutputFacadeTest {
     public void listEntityExcerpts() {
         final EntityExcerpt expectedEntityExcerpt = EntityExcerpt.builder()
                 .id(ModelId.of("5adf239e4b900a0fdb4e5197"))
-                .type(ModelTypes.OUTPUT)
+                .type(ModelTypes.OUTPUT_V1)
                 .title("STDOUT")
                 .build();
 
@@ -258,7 +258,7 @@ public class OutputFacadeTest {
     @Test
     @UsingDataSet(locations = "/org/graylog2/contentpacks/outputs.json", loadStrategy = LoadStrategyEnum.CLEAN_INSERT)
     public void collectEntity() {
-        final Optional<EntityWithConstraints> collectedEntity = facade.exportEntity(EntityDescriptor.create("5adf239e4b900a0fdb4e5197", ModelTypes.OUTPUT));
+        final Optional<EntityWithConstraints> collectedEntity = facade.exportEntity(EntityDescriptor.create("5adf239e4b900a0fdb4e5197", ModelTypes.OUTPUT_V1));
         assertThat(collectedEntity)
                 .isPresent()
                 .map(EntityWithConstraints::entity)
@@ -266,7 +266,7 @@ public class OutputFacadeTest {
 
         final EntityV1 entity = (EntityV1) collectedEntity.map(EntityWithConstraints::entity).orElseThrow(AssertionError::new);
         assertThat(entity.id()).isEqualTo(ModelId.of("5adf239e4b900a0fdb4e5197"));
-        assertThat(entity.type()).isEqualTo(ModelTypes.OUTPUT);
+        assertThat(entity.type()).isEqualTo(ModelTypes.OUTPUT_V1);
         final OutputEntity outputEntity = objectMapper.convertValue(entity.data(), OutputEntity.class);
         assertThat(outputEntity.title()).isEqualTo(ValueReference.of("STDOUT"));
         assertThat(outputEntity.type()).isEqualTo(ValueReference.of("org.graylog2.outputs.LoggingOutput"));

--- a/graylog2-server/src/test/java/org/graylog2/contentpacks/facades/PipelineFacadeTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/contentpacks/facades/PipelineFacadeTest.java
@@ -122,7 +122,7 @@ public class PipelineFacadeTest {
 
         assertThat(entity).isInstanceOf(EntityV1.class);
         assertThat(entity.id()).isEqualTo(ModelId.of("title"));
-        assertThat(entity.type()).isEqualTo(ModelTypes.PIPELINE);
+        assertThat(entity.type()).isEqualTo(ModelTypes.PIPELINE_V1);
 
         final EntityV1 entityV1 = (EntityV1) entity;
         final PipelineEntity pipelineEntity = objectMapper.convertValue(entityV1.data(), PipelineEntity.class);
@@ -135,13 +135,13 @@ public class PipelineFacadeTest {
     @Test
     @UsingDataSet(locations = "/org/graylog2/contentpacks/pipeline_processor_pipelines.json", loadStrategy = LoadStrategyEnum.CLEAN_INSERT)
     public void exportNativeEntity() {
-        final EntityDescriptor descriptor = EntityDescriptor.create("Test", ModelTypes.PIPELINE);
+        final EntityDescriptor descriptor = EntityDescriptor.create("Test", ModelTypes.PIPELINE_V1);
         final EntityWithConstraints entityWithConstraints = facade.exportEntity(descriptor).orElseThrow(AssertionError::new);
         final Entity entity = entityWithConstraints.entity();
 
         assertThat(entity).isInstanceOf(EntityV1.class);
         assertThat(entity.id()).isEqualTo(ModelId.of("Test"));
-        assertThat(entity.type()).isEqualTo(ModelTypes.PIPELINE);
+        assertThat(entity.type()).isEqualTo(ModelTypes.PIPELINE_V1);
 
         final EntityV1 entityV1 = (EntityV1) entity;
         final PipelineEntity pipelineEntity = objectMapper.convertValue(entityV1.data(), PipelineEntity.class);
@@ -156,7 +156,7 @@ public class PipelineFacadeTest {
     public void createNativeEntity() throws NotFoundException {
         final Entity entity = EntityV1.builder()
                 .id(ModelId.of("1"))
-                .type(ModelTypes.PIPELINE)
+                .type(ModelTypes.PIPELINE_V1)
                 .data(objectMapper.convertValue(PipelineEntity.create(
                         ValueReference.of("Title"),
                         ValueReference.of("Description"),
@@ -164,13 +164,13 @@ public class PipelineFacadeTest {
                         Collections.singleton(ValueReference.of("5adf23894b900a0f00000001"))), JsonNode.class))
                 .build();
 
-        final EntityDescriptor streamDescriptor = EntityDescriptor.create("5adf23894b900a0f00000001", ModelTypes.STREAM);
+        final EntityDescriptor streamDescriptor = EntityDescriptor.create("5adf23894b900a0f00000001", ModelTypes.STREAM_V1);
         final Stream stream = mock(Stream.class);
         when(stream.getId()).thenReturn("5adf23894b900a0f00000001");
         final Map<EntityDescriptor, Object> nativeEntities = Collections.singletonMap(streamDescriptor, stream);
         final NativeEntity<PipelineDao> nativeEntity = facade.createNativeEntity(entity, Collections.emptyMap(), nativeEntities, "username");
 
-        assertThat(nativeEntity.descriptor().type()).isEqualTo(ModelTypes.PIPELINE);
+        assertThat(nativeEntity.descriptor().type()).isEqualTo(ModelTypes.PIPELINE_V1);
         assertThat(nativeEntity.entity().title()).isEqualTo("Title");
         assertThat(nativeEntity.entity().description()).isEqualTo("Description");
         assertThat(nativeEntity.entity().source()).startsWith("pipeline \"Title\"");
@@ -197,7 +197,7 @@ public class PipelineFacadeTest {
     public void findExisting() {
         final Entity entity = EntityV1.builder()
                 .id(ModelId.of("1"))
-                .type(ModelTypes.PIPELINE)
+                .type(ModelTypes.PIPELINE_V1)
                 .data(objectMapper.convertValue(PipelineEntity.create(
                         ValueReference.of("Title"),
                         ValueReference.of("Description"),
@@ -224,12 +224,12 @@ public class PipelineFacadeTest {
                 .build();
         when(pipelineRuleParser.parsePipeline("dummy", "pipeline \"Test\"\nstage 0 match either\nrule \"debug\"\nrule \"no-op\"\nend"))
                 .thenReturn(pipeline);
-        final EntityDescriptor descriptor = EntityDescriptor.create("Test", ModelTypes.PIPELINE);
+        final EntityDescriptor descriptor = EntityDescriptor.create("Test", ModelTypes.PIPELINE_V1);
         final Graph<EntityDescriptor> graph = facade.resolveNativeEntity(descriptor);
         assertThat(graph.nodes()).containsOnly(
                 descriptor,
-                EntityDescriptor.create("5adf23894b900a0fdb4e517d", ModelTypes.STREAM),
-                EntityDescriptor.create("no-op", ModelTypes.PIPELINE_RULE));
+                EntityDescriptor.create("5adf23894b900a0fdb4e517d", ModelTypes.STREAM_V1),
+                EntityDescriptor.create("no-op", ModelTypes.PIPELINE_RULE_V1));
     }
 
     @Test
@@ -243,7 +243,7 @@ public class PipelineFacadeTest {
         final EntityExcerpt excerpt = facade.createExcerpt(pipeline);
 
         assertThat(excerpt.id()).isEqualTo(ModelId.of("title"));
-        assertThat(excerpt.type()).isEqualTo(ModelTypes.PIPELINE);
+        assertThat(excerpt.type()).isEqualTo(ModelTypes.PIPELINE_V1);
         assertThat(excerpt.title()).isEqualTo("title");
     }
 
@@ -252,7 +252,7 @@ public class PipelineFacadeTest {
     public void listEntityExcerpts() {
         final EntityExcerpt expectedEntityExcerpt = EntityExcerpt.builder()
                 .id(ModelId.of("Test"))
-                .type(ModelTypes.PIPELINE)
+                .type(ModelTypes.PIPELINE_V1)
                 .title("Test")
                 .build();
 
@@ -263,7 +263,7 @@ public class PipelineFacadeTest {
     @Test
     @UsingDataSet(locations = "/org/graylog2/contentpacks/pipeline_processor_pipelines.json", loadStrategy = LoadStrategyEnum.CLEAN_INSERT)
     public void collectEntity() {
-        final Optional<EntityWithConstraints> collectedEntity = facade.exportEntity(EntityDescriptor.create("Test", ModelTypes.PIPELINE));
+        final Optional<EntityWithConstraints> collectedEntity = facade.exportEntity(EntityDescriptor.create("Test", ModelTypes.PIPELINE_V1));
         assertThat(collectedEntity)
                 .isPresent()
                 .map(EntityWithConstraints::entity)
@@ -271,7 +271,7 @@ public class PipelineFacadeTest {
 
         final EntityV1 entity = (EntityV1) collectedEntity.map(EntityWithConstraints::entity).orElseThrow(AssertionError::new);
         assertThat(entity.id()).isEqualTo(ModelId.of("Test"));
-        assertThat(entity.type()).isEqualTo(ModelTypes.PIPELINE);
+        assertThat(entity.type()).isEqualTo(ModelTypes.PIPELINE_V1);
         final PipelineEntity pipelineEntity = objectMapper.convertValue(entity.data(), PipelineEntity.class);
         assertThat(pipelineEntity.title()).isEqualTo(ValueReference.of("Test"));
         assertThat(pipelineEntity.description()).isEqualTo(ValueReference.of("Description"));
@@ -303,13 +303,13 @@ public class PipelineFacadeTest {
                 .stages(ImmutableSortedSet.of(stage))
                 .build();
         when(pipelineRuleParser.parsePipeline(eq("dummy"), anyString())).thenReturn(pipeline);
-        final EntityDescriptor pipelineEntity = EntityDescriptor.create("Test", ModelTypes.PIPELINE);
+        final EntityDescriptor pipelineEntity = EntityDescriptor.create("Test", ModelTypes.PIPELINE_V1);
 
         final Graph<EntityDescriptor> graph = facade.resolveNativeEntity(pipelineEntity);
 
-        final EntityDescriptor streamEntity = EntityDescriptor.create("5adf23894b900a0fdb4e517d", ModelTypes.STREAM);
-        final EntityDescriptor ruleEntity1 = EntityDescriptor.create("debug", ModelTypes.PIPELINE_RULE);
-        final EntityDescriptor ruleEntity2 = EntityDescriptor.create("no-op", ModelTypes.PIPELINE_RULE);
+        final EntityDescriptor streamEntity = EntityDescriptor.create("5adf23894b900a0fdb4e517d", ModelTypes.STREAM_V1);
+        final EntityDescriptor ruleEntity1 = EntityDescriptor.create("debug", ModelTypes.PIPELINE_RULE_V1);
+        final EntityDescriptor ruleEntity2 = EntityDescriptor.create("no-op", ModelTypes.PIPELINE_RULE_V1);
         assertThat(graph.nodes())
                 .containsOnly(pipelineEntity, streamEntity, ruleEntity1, ruleEntity2);
     }

--- a/graylog2-server/src/test/java/org/graylog2/contentpacks/facades/PipelineRuleFacadeTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/contentpacks/facades/PipelineRuleFacadeTest.java
@@ -94,7 +94,7 @@ public class PipelineRuleFacadeTest {
 
         assertThat(entity).isInstanceOf(EntityV1.class);
         assertThat(entity.id()).isEqualTo(ModelId.of("title"));
-        assertThat(entity.type()).isEqualTo(ModelTypes.PIPELINE_RULE);
+        assertThat(entity.type()).isEqualTo(ModelTypes.PIPELINE_RULE_V1);
 
         final EntityV1 entityV1 = (EntityV1) entity;
         final PipelineEntity pipelineEntity = objectMapper.convertValue(entityV1.data(), PipelineEntity.class);
@@ -106,12 +106,12 @@ public class PipelineRuleFacadeTest {
     @Test
     @UsingDataSet(locations = "/org/graylog2/contentpacks/pipeline_processor_rules.json", loadStrategy = LoadStrategyEnum.CLEAN_INSERT)
     public void exportNativeEntity() {
-        final EntityDescriptor descriptor = EntityDescriptor.create("debug", ModelTypes.PIPELINE_RULE);
+        final EntityDescriptor descriptor = EntityDescriptor.create("debug", ModelTypes.PIPELINE_RULE_V1);
         final EntityWithConstraints entityWithConstraints = facade.exportEntity(descriptor).orElseThrow(AssertionError::new);
         final Entity entity = entityWithConstraints.entity();
 
         assertThat(entity.id()).isEqualTo(ModelId.of("debug"));
-        assertThat(entity.type()).isEqualTo(ModelTypes.PIPELINE_RULE);
+        assertThat(entity.type()).isEqualTo(ModelTypes.PIPELINE_RULE_V1);
 
         final EntityV1 entityV1 = (EntityV1) entity;
         final PipelineEntity pipelineEntity = objectMapper.convertValue(entityV1.data(), PipelineEntity.class);
@@ -137,7 +137,7 @@ public class PipelineRuleFacadeTest {
     public void findExisting() {
         final Entity entity = EntityV1.builder()
                 .id(ModelId.of("debug"))
-                .type(ModelTypes.PIPELINE_RULE)
+                .type(ModelTypes.PIPELINE_RULE_V1)
                 .data(objectMapper.convertValue(PipelineRuleEntity.create(
                         ValueReference.of("debug"),
                         ValueReference.of("Debug"),
@@ -146,7 +146,7 @@ public class PipelineRuleFacadeTest {
         final NativeEntity<RuleDao> existingRule = facade.findExisting(entity, Collections.emptyMap()).orElseThrow(AssertionError::new);
 
         assertThat(existingRule.descriptor().id()).isEqualTo(ModelId.of("5adf25034b900a0fdb4e5338"));
-        assertThat(existingRule.descriptor().type()).isEqualTo(ModelTypes.PIPELINE_RULE);
+        assertThat(existingRule.descriptor().type()).isEqualTo(ModelTypes.PIPELINE_RULE_V1);
         assertThat(existingRule.entity().title()).isEqualTo("debug");
         assertThat(existingRule.entity().description()).isEqualTo("Debug");
         assertThat(existingRule.entity().source()).startsWith("rule \"debug\"\n");
@@ -157,7 +157,7 @@ public class PipelineRuleFacadeTest {
     public void findExistingWithDifferentSource() {
         final Entity entity = EntityV1.builder()
                 .id(ModelId.of("debug"))
-                .type(ModelTypes.PIPELINE_RULE)
+                .type(ModelTypes.PIPELINE_RULE_V1)
                 .data(objectMapper.convertValue(PipelineRuleEntity.create(
                         ValueReference.of("debug"),
                         ValueReference.of("Debug"),
@@ -173,7 +173,7 @@ public class PipelineRuleFacadeTest {
     public void resolveEntity() {
         final Entity entity = EntityV1.builder()
                 .id(ModelId.of("debug"))
-                .type(ModelTypes.PIPELINE_RULE)
+                .type(ModelTypes.PIPELINE_RULE_V1)
                 .data(objectMapper.convertValue(PipelineRuleEntity.create(
                         ValueReference.of("debug"),
                         ValueReference.of("Debug"),
@@ -186,7 +186,7 @@ public class PipelineRuleFacadeTest {
     @Test
     @UsingDataSet(locations = "/org/graylog2/contentpacks/pipeline_processor_rules.json", loadStrategy = LoadStrategyEnum.CLEAN_INSERT)
     public void resolveEntityDescriptor() {
-        final EntityDescriptor descriptor = EntityDescriptor.create("debug", ModelTypes.PIPELINE_RULE);
+        final EntityDescriptor descriptor = EntityDescriptor.create("debug", ModelTypes.PIPELINE_RULE_V1);
         final Graph<EntityDescriptor> graph = facade.resolveNativeEntity(descriptor);
         assertThat(graph.nodes()).containsOnly(descriptor);
     }
@@ -202,7 +202,7 @@ public class PipelineRuleFacadeTest {
         final EntityExcerpt excerpt = facade.createExcerpt(pipelineRule);
 
         assertThat(excerpt.id()).isEqualTo(ModelId.of("title"));
-        assertThat(excerpt.type()).isEqualTo(ModelTypes.PIPELINE_RULE);
+        assertThat(excerpt.type()).isEqualTo(ModelTypes.PIPELINE_RULE_V1);
         assertThat(excerpt.title()).isEqualTo("title");
     }
 
@@ -211,12 +211,12 @@ public class PipelineRuleFacadeTest {
     public void listEntityExcerpts() {
         final EntityExcerpt expectedEntityExcerpt1 = EntityExcerpt.builder()
                 .id(ModelId.of("debug"))
-                .type(ModelTypes.PIPELINE_RULE)
+                .type(ModelTypes.PIPELINE_RULE_V1)
                 .title("debug")
                 .build();
         final EntityExcerpt expectedEntityExcerpt2 = EntityExcerpt.builder()
                 .id(ModelId.of("no-op"))
-                .type(ModelTypes.PIPELINE_RULE)
+                .type(ModelTypes.PIPELINE_RULE_V1)
                 .title("no-op")
                 .build();
 
@@ -227,7 +227,7 @@ public class PipelineRuleFacadeTest {
     @Test
     @UsingDataSet(locations = "/org/graylog2/contentpacks/pipeline_processor_rules.json", loadStrategy = LoadStrategyEnum.CLEAN_INSERT)
     public void collectEntity() {
-        final Optional<EntityWithConstraints> collectedEntity = facade.exportEntity(EntityDescriptor.create("debug", ModelTypes.PIPELINE_RULE));
+        final Optional<EntityWithConstraints> collectedEntity = facade.exportEntity(EntityDescriptor.create("debug", ModelTypes.PIPELINE_RULE_V1));
         assertThat(collectedEntity)
                 .isPresent()
                 .map(EntityWithConstraints::entity)
@@ -235,7 +235,7 @@ public class PipelineRuleFacadeTest {
 
         final EntityV1 entity = (EntityV1) collectedEntity.map(EntityWithConstraints::entity).orElseThrow(AssertionError::new);
         assertThat(entity.id()).isEqualTo(ModelId.of("debug"));
-        assertThat(entity.type()).isEqualTo(ModelTypes.PIPELINE_RULE);
+        assertThat(entity.type()).isEqualTo(ModelTypes.PIPELINE_RULE_V1);
         final PipelineRuleEntity pipelineRuleEntity = objectMapper.convertValue(entity.data(), PipelineRuleEntity.class);
         assertThat(pipelineRuleEntity.title()).isEqualTo(ValueReference.of("debug"));
         assertThat(pipelineRuleEntity.description()).isEqualTo(ValueReference.of("Debug"));

--- a/graylog2-server/src/test/java/org/graylog2/contentpacks/facades/StreamCatalogTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/contentpacks/facades/StreamCatalogTest.java
@@ -152,7 +152,7 @@ public class StreamCatalogTest {
 
         assertThat(entity).isInstanceOf(EntityV1.class);
         assertThat(entity.id()).isEqualTo(ModelId.of(streamId.toHexString()));
-        assertThat(entity.type()).isEqualTo(ModelTypes.STREAM);
+        assertThat(entity.type()).isEqualTo(ModelTypes.STREAM_V1);
 
         final EntityV1 entityV1 = (EntityV1) entity;
         final StreamEntity streamEntity = objectMapper.convertValue(entityV1.data(), StreamEntity.class);
@@ -171,7 +171,7 @@ public class StreamCatalogTest {
         final EntityExcerpt excerpt = facade.createExcerpt(stream);
 
         assertThat(excerpt.id()).isEqualTo(ModelId.of(stream.getId()));
-        assertThat(excerpt.type()).isEqualTo(ModelTypes.STREAM);
+        assertThat(excerpt.type()).isEqualTo(ModelTypes.STREAM_V1);
         assertThat(excerpt.title()).isEqualTo(stream.getTitle());
     }
 
@@ -181,12 +181,12 @@ public class StreamCatalogTest {
     public void listEntityExcerpts() {
         final EntityExcerpt expectedEntityExcerpt1 = EntityExcerpt.builder()
                 .id(ModelId.of("000000000000000000000001"))
-                .type(ModelTypes.STREAM)
+                .type(ModelTypes.STREAM_V1)
                 .title("All messages")
                 .build();
         final EntityExcerpt expectedEntityExcerpt2 = EntityExcerpt.builder()
                 .id(ModelId.of("5adf23894b900a0fdb4e517d"))
-                .type(ModelTypes.STREAM)
+                .type(ModelTypes.STREAM_V1)
                 .title("Test")
                 .build();
 
@@ -197,7 +197,7 @@ public class StreamCatalogTest {
     @Test
     @UsingDataSet(locations = "/org/graylog2/contentpacks/streams.json", loadStrategy = LoadStrategyEnum.CLEAN_INSERT)
     public void collectEntity() {
-        final Optional<EntityWithConstraints> collectedEntity = facade.exportEntity(EntityDescriptor.create("5adf23894b900a0fdb4e517d", ModelTypes.STREAM));
+        final Optional<EntityWithConstraints> collectedEntity = facade.exportEntity(EntityDescriptor.create("5adf23894b900a0fdb4e517d", ModelTypes.STREAM_V1));
         assertThat(collectedEntity)
                 .isPresent()
                 .map(EntityWithConstraints::entity)
@@ -205,7 +205,7 @@ public class StreamCatalogTest {
 
         final EntityV1 entity = (EntityV1) collectedEntity.map(EntityWithConstraints::entity).orElseThrow(AssertionError::new);
         assertThat(entity.id()).isEqualTo(ModelId.of("5adf23894b900a0fdb4e517d"));
-        assertThat(entity.type()).isEqualTo(ModelTypes.STREAM);
+        assertThat(entity.type()).isEqualTo(ModelTypes.STREAM_V1);
         final StreamEntity streamEntity = objectMapper.convertValue(entity.data(), StreamEntity.class);
         assertThat(streamEntity.title()).isEqualTo(ValueReference.of("Test"));
         assertThat(streamEntity.description()).isEqualTo(ValueReference.of("Description"));

--- a/graylog2-server/src/test/java/org/graylog2/contentpacks/model/ContentPackTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/contentpacks/model/ContentPackTest.java
@@ -81,7 +81,7 @@ public class ContentPackTest {
                         LongParameter.builder().name("MY_LONG").title("My Long").description("Some description").defaultValue(Optional.of(42L)).build(),
                         StringParameter.builder().name("MY_STRING").title("My String").description("Some description").defaultValue(Optional.of("Default Value")).build()))
                 .entities(ImmutableSet.of(
-                        EntityV1.builder().id(ModelId.of("fafd32d1-7f71-41a8-89f5-53c9b307d4d5")).type(ModelTypes.INPUT).version(ModelVersion.of("1")).data(entityData).build()))
+                        EntityV1.builder().id(ModelId.of("fafd32d1-7f71-41a8-89f5-53c9b307d4d5")).type(ModelTypes.INPUT_V1).version(ModelVersion.of("1")).data(entityData).build()))
                 .build();
 
 
@@ -166,13 +166,13 @@ public class ContentPackTest {
                 EntityV1.builder()
                         .version(ModelVersion.of("1"))
                         .id(ModelId.of("311d9e16-e4d9-485d-a916-337fb4ca0e8b"))
-                        .type(ModelTypes.LOOKUP_TABLE)
+                        .type(ModelTypes.LOOKUP_TABLE_V1)
                         .data(objectMapper.convertValue(expectedLookupTable, JsonNode.class))
                         .build(),
                 EntityV1.builder()
                         .version(ModelVersion.of("1"))
                         .id(ModelId.of("2562ac46-65f1-454c-89e1-e9be96bfd5e7"))
-                        .type(ModelTypes.LOOKUP_ADAPTER)
+                        .type(ModelTypes.LOOKUP_ADAPTER_V1)
                         .data(objectMapper.convertValue(expectedLookupDataAdapter, JsonNode.class))
                         .build()
         );
@@ -245,7 +245,7 @@ public class ContentPackTest {
         assertThat(legacyContentPack.entities()).contains(
                 EntityV1.builder()
                         .id(ModelId.of("53794eebe4b03cdadeadbeef"))
-                        .type(ModelTypes.INPUT)
+                        .type(ModelTypes.INPUT_V1)
                         .version(ModelVersion.of("1"))
                         .data(objectMapper.createObjectNode()
                                 .put("id", "53794eebe4b03cdadeadbeef")
@@ -287,7 +287,7 @@ public class ContentPackTest {
                         .build(),
                 EntityV1.builder()
                         .id(ModelId.of("cafebabee4b0f504664790f8"))
-                        .type(ModelTypes.STREAM)
+                        .type(ModelTypes.STREAM_V1)
                         .version(ModelVersion.of("1"))
                         .data(objectMapper.createObjectNode()
                                 .put("id", "cafebabee4b0f504664790f8")
@@ -307,7 +307,7 @@ public class ContentPackTest {
                         .build(),
                 EntityV1.builder()
                         .id(ModelId.of("56ba78eae4b0bcb6deadbeef"))
-                        .type(ModelTypes.OUTPUT)
+                        .type(ModelTypes.OUTPUT_V1)
                         .version(ModelVersion.of("1"))
                         .data(objectMapper.createObjectNode()
                                 .put("id", "56ba78eae4b0bcb6deadbeef")
@@ -328,7 +328,7 @@ public class ContentPackTest {
                         .build(),
                 EntityV1.builder()
                         .id(ModelId.of("SOME_PATTERN"))
-                        .type(ModelTypes.GROK_PATTERN)
+                        .type(ModelTypes.GROK_PATTERN_V1)
                         .version(ModelVersion.of("1"))
                         .data(objectMapper.createObjectNode()
                                 .put("name", "SOME_PATTERN")
@@ -336,7 +336,7 @@ public class ContentPackTest {
                         .build(),
                 EntityV1.builder()
                         .id(ModelId.of("generic-lookup-table"))
-                        .type(ModelTypes.LOOKUP_TABLE)
+                        .type(ModelTypes.LOOKUP_TABLE_V1)
                         .version(ModelVersion.of("1"))
                         .data(objectMapper.createObjectNode()
                                 .put("title", "Lookup Table Title")
@@ -351,7 +351,7 @@ public class ContentPackTest {
                         .build(),
                 EntityV1.builder()
                         .id(ModelId.of("generic-lookup-cache"))
-                        .type(ModelTypes.LOOKUP_CACHE)
+                        .type(ModelTypes.LOOKUP_CACHE_V1)
                         .version(ModelVersion.of("1"))
                         .data(objectMapper.createObjectNode()
                                 .put("title", "Lookup Cache Title")
@@ -367,7 +367,7 @@ public class ContentPackTest {
                         .build(),
                 EntityV1.builder()
                         .id(ModelId.of("generic-data-adapter"))
-                        .type(ModelTypes.LOOKUP_ADAPTER)
+                        .type(ModelTypes.LOOKUP_ADAPTER_V1)
                         .version(ModelVersion.of("1"))
                         .data(objectMapper.createObjectNode()
                                 .put("title", "Data Adapter Title")
@@ -398,7 +398,7 @@ public class ContentPackTest {
         assertThat(contentPack.entities()).contains(
                 EntityV1.builder()
                         .id(ModelId.of("53794eebe4b03cdadeadbeef"))
-                        .type(ModelTypes.INPUT)
+                        .type(ModelTypes.INPUT_V1)
                         .version(ModelVersion.of("1"))
                         .data(objectMapper.createObjectNode()
                                 .put("id", "53794eebe4b03cdadeadbeef")
@@ -440,7 +440,7 @@ public class ContentPackTest {
                         .build(),
                 EntityV1.builder()
                         .id(ModelId.of("cafebabee4b0f504664790f8"))
-                        .type(ModelTypes.STREAM)
+                        .type(ModelTypes.STREAM_V1)
                         .version(ModelVersion.of("1"))
                         .data(objectMapper.createObjectNode()
                                 .put("id", "cafebabee4b0f504664790f8")
@@ -460,7 +460,7 @@ public class ContentPackTest {
                         .build(),
                 EntityV1.builder()
                         .id(ModelId.of("56ba78eae4b0bcb6deadbeef"))
-                        .type(ModelTypes.OUTPUT)
+                        .type(ModelTypes.OUTPUT_V1)
                         .version(ModelVersion.of("1"))
                         .data(objectMapper.createObjectNode()
                                 .put("id", "56ba78eae4b0bcb6deadbeef")
@@ -481,7 +481,7 @@ public class ContentPackTest {
                         .build(),
                 EntityV1.builder()
                         .id(ModelId.of("SOME_PATTERN"))
-                        .type(ModelTypes.GROK_PATTERN)
+                        .type(ModelTypes.GROK_PATTERN_V1)
                         .version(ModelVersion.of("1"))
                         .data(objectMapper.createObjectNode()
                                 .put("name", "SOME_PATTERN")
@@ -489,7 +489,7 @@ public class ContentPackTest {
                         .build(),
                 EntityV1.builder()
                         .id(ModelId.of("generic-lookup-table"))
-                        .type(ModelTypes.LOOKUP_TABLE)
+                        .type(ModelTypes.LOOKUP_TABLE_V1)
                         .version(ModelVersion.of("1"))
                         .data(objectMapper.createObjectNode()
                                 .put("title", "Lookup Table Title")
@@ -504,7 +504,7 @@ public class ContentPackTest {
                         .build(),
                 EntityV1.builder()
                         .id(ModelId.of("generic-lookup-cache"))
-                        .type(ModelTypes.LOOKUP_CACHE)
+                        .type(ModelTypes.LOOKUP_CACHE_V1)
                         .version(ModelVersion.of("1"))
                         .data(objectMapper.createObjectNode()
                                 .put("title", "Lookup Cache Title")
@@ -520,7 +520,7 @@ public class ContentPackTest {
                         .build(),
                 EntityV1.builder()
                         .id(ModelId.of("generic-data-adapter"))
-                        .type(ModelTypes.LOOKUP_ADAPTER)
+                        .type(ModelTypes.LOOKUP_ADAPTER_V1)
                         .version(ModelVersion.of("1"))
                         .data(objectMapper.createObjectNode()
                                 .put("title", "Data Adapter Title")

--- a/graylog2-server/src/test/java/org/graylog2/contentpacks/model/ContentPackTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/contentpacks/model/ContentPackTest.java
@@ -104,7 +104,8 @@ public class ContentPackTest {
         final JsonNode entityNode = entitiesNode.path(0);
         assertThat(entityNode.isObject()).isTrue();
         assertThat(entityNode.path("id").asText()).isEqualTo("fafd32d1-7f71-41a8-89f5-53c9b307d4d5");
-        assertThat(entityNode.path("type").asText()).isEqualTo("input");
+        assertThat(entityNode.path("type").path("name").asText()).isEqualTo("input");
+        assertThat(entityNode.path("type").path("version").asText()).isEqualTo("1");
         assertThat(entityNode.path("v").asText()).isEqualTo("1");
         final JsonNode entityDataNode = entityNode.path("data");
         assertThat(entityDataNode.isObject()).isTrue();
@@ -214,7 +215,8 @@ public class ContentPackTest {
         final JsonNode entityNode = entitiesNode.path(0);
         assertThat(entityNode.isObject()).isTrue();
         assertThat(entityNode.path("id").asText()).isEqualTo("SOME_PATTERN");
-        assertThat(entityNode.path("type").asText()).isEqualTo("grok_pattern");
+        assertThat(entityNode.path("type").path("name").asText()).isEqualTo("grok_pattern");
+        assertThat(entityNode.path("type").path("version").asText()).isEqualTo("1");
         assertThat(entityNode.path("v").asText()).isEqualTo("1");
         final JsonNode entityDataNode = entityNode.path("data");
         assertThat(entityDataNode.isObject()).isTrue();

--- a/graylog2-server/src/test/java/org/graylog2/contentpacks/model/ModelTypeTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/contentpacks/model/ModelTypeTest.java
@@ -30,29 +30,40 @@ public class ModelTypeTest {
 
     @Test
     public void deserialize() {
-        final ModelType modelType = ModelType.of("foobar");
+        final ModelType modelType = ModelType.of("foobar", "1");
         final JsonNode jsonNode = objectMapper.convertValue(modelType, JsonNode.class);
 
-        assertThat(jsonNode.isTextual()).isTrue();
-        assertThat(jsonNode.asText()).isEqualTo("foobar");
+        assertThat(jsonNode.isObject()).isTrue();
+        assertThat(jsonNode.path("name").asText()).isEqualTo("foobar");
+        assertThat(jsonNode.path("version").asText()).isEqualTo("1");
     }
 
     @Test
     public void serialize() throws IOException {
-        final ModelType modelType = objectMapper.readValue("\"foobar\"", ModelType.class);
-        assertThat(modelType).isEqualTo(ModelType.of("foobar"));
+        final ModelType modelType = objectMapper.readValue("{\"name\":\"foobar\",\"version\":\"1\"}", ModelType.class);
+        assertThat(modelType).isEqualTo(ModelType.of("foobar", "1"));
     }
 
     @Test
     public void ensureTypeIsNotBlank() {
-        assertThatThrownBy(() -> ModelType.of(null))
+        assertThatThrownBy(() -> ModelType.of(null, "1"))
                 .isInstanceOf(IllegalArgumentException.class)
-                .hasMessage("Type must not be blank");
-        assertThatThrownBy(() -> ModelType.of(""))
+                .hasMessage("Type name must not be blank");
+        assertThatThrownBy(() -> ModelType.of("", "1"))
                 .isInstanceOf(IllegalArgumentException.class)
-                .hasMessage("Type must not be blank");
-        assertThatThrownBy(() -> ModelType.of("    \n\r\t"))
+                .hasMessage("Type name must not be blank");
+        assertThatThrownBy(() -> ModelType.of("    \n\r\t", "1"))
                 .isInstanceOf(IllegalArgumentException.class)
-                .hasMessage("Type must not be blank");
+                .hasMessage("Type name must not be blank");
+
+        assertThatThrownBy(() -> ModelType.of("foo", null))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("Type version must not be blank");
+        assertThatThrownBy(() -> ModelType.of("foo", ""))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("Type version must not be blank");
+        assertThatThrownBy(() -> ModelType.of("foo", "    \n\r\t"))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("Type version must not be blank");
     }
 }

--- a/graylog2-server/src/test/java/org/graylog2/contentpacks/model/entities/EntityTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/contentpacks/model/entities/EntityTest.java
@@ -53,7 +53,7 @@ public class EntityTest {
 
         final EntityV1 entity = EntityV1.builder()
                 .id(ModelId.of("fafd32d1-7f71-41a8-89f5-53c9b307d4d5"))
-                .type(ModelTypes.INPUT)
+                .type(ModelTypes.INPUT_V1)
                 .version(ModelVersion.of("1"))
                 .data(entityData)
                 .build();
@@ -93,7 +93,7 @@ public class EntityTest {
         final EntityV1 entityV1 = (EntityV1) entity;
         assertThat(entityV1).isNotNull();
         assertThat(entityV1.version()).isEqualTo(ModelVersion.of("1"));
-        assertThat(entityV1.type()).isEqualTo(ModelTypes.INPUT);
+        assertThat(entityV1.type()).isEqualTo(ModelTypes.INPUT_V1);
         assertThat(entityV1.id()).isEqualTo(ModelId.of("78547c87-af21-4292-8e57-614da5baf6c3"));
         assertThat(entityV1.data()).isEqualTo(expectedData);
     }

--- a/graylog2-server/src/test/java/org/graylog2/contentpacks/model/entities/EntityTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/contentpacks/model/entities/EntityTest.java
@@ -62,7 +62,8 @@ public class EntityTest {
         final JsonNode jsonNode = objectMapper.convertValue(entity, JsonNode.class);
         assertThat(jsonNode).isNotNull();
         assertThat(jsonNode.path("id").asText()).isEqualTo("fafd32d1-7f71-41a8-89f5-53c9b307d4d5");
-        assertThat(jsonNode.path("type").asText()).isEqualTo("input");
+        assertThat(jsonNode.path("type").path("name").asText()).isEqualTo("input");
+        assertThat(jsonNode.path("type").path("version").asText()).isEqualTo("1");
         assertThat(jsonNode.path("v").asText()).isEqualTo("1");
         final JsonNode dataNode = jsonNode.path("data");
         assertThat(dataNode.isObject()).isTrue();

--- a/graylog2-server/src/test/java/org/graylog2/rest/resources/system/contentpacks/CatalogResourceTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/rest/resources/system/contentpacks/CatalogResourceTest.java
@@ -70,7 +70,7 @@ public class CatalogResourceTest {
         final ContentPackInstallationPersistenceService contentPackInstallationPersistenceService =
                 mock(ContentPackInstallationPersistenceService.class);
         final Set<ConstraintChecker> constraintCheckers = Collections.emptySet();
-        final Map<ModelType, EntityFacade<?>> entityFacades = Collections.singletonMap(ModelType.of("test"), mockEntityFacade);
+        final Map<ModelType, EntityFacade<?>> entityFacades = Collections.singletonMap(ModelType.of("test", "1"), mockEntityFacade);
         contentPackService = new ContentPackService(contentPackInstallationPersistenceService, constraintCheckers, entityFacades);
         catalogResource = new CatalogResource(contentPackService);
     }
@@ -80,7 +80,7 @@ public class CatalogResourceTest {
         final ImmutableSet<EntityExcerpt> entityExcerpts = ImmutableSet.of(
                 EntityExcerpt.builder()
                         .id(ModelId.of("1234567890"))
-                        .type(ModelType.of("test"))
+                        .type(ModelType.of("test", "1"))
                         .title("Test Entity")
                         .build()
         );
@@ -96,14 +96,14 @@ public class CatalogResourceTest {
     public void resolveEntities() {
         final EntityDescriptor entityDescriptor = EntityDescriptor.builder()
                 .id(ModelId.of("1234567890"))
-                .type(ModelType.of("test"))
+                .type(ModelType.of("test", "1"))
                 .build();
         final MutableGraph<EntityDescriptor> entityDescriptors = GraphBuilder.directed().build();
         entityDescriptors.addNode(entityDescriptor);
 
         final EntityV1 entity = EntityV1.builder()
                 .id(ModelId.of("1234567890"))
-                .type(ModelType.of("test"))
+                .type(ModelType.of("test", "1"))
                 .data(new ObjectNode(JsonNodeFactory.instance).put("test", "1234"))
                 .build();
         final EntityWithConstraints entityWithConstraints = EntityWithConstraints.create(entity);

--- a/graylog2-server/src/test/resources/org/graylog2/contentpacks/ContentPackInstallationPersistenceServiceTest.json
+++ b/graylog2-server/src/test/resources/org/graylog2/contentpacks/ContentPackInstallationPersistenceServiceTest.json
@@ -19,17 +19,26 @@
       "entities": [
         {
           "id": "5b4c920b4b900a0024af2b5d",
-          "type": "collector",
+          "type": {
+            "name": "collector",
+            "version": "1"
+          },
           "entity_id": "5b1a49eb3d274631fe07c86a"
         },
         {
           "id": "5b4c920b4b900a0024af2b5c",
-          "type": "collector",
+          "type": {
+            "name": "collector",
+            "version": "1"
+          },
           "entity_id": "5b1a49eb3d274631fe07beff"
         },
         {
           "id": "5b4c920b4b900a0024af2b5b",
-          "type": "collector",
+          "type": {
+            "name": "collector",
+            "version": "1"
+          },
           "entity_id": "5b1a49eb3d274631fe07abfe"
         }
       ],
@@ -52,27 +61,42 @@
       "entities": [
         {
           "id": "5b4c935b4b900a0062b7dc16",
-          "type": "dashboard",
+          "type": {
+            "name": "dashboard",
+            "version": "1"
+          },
           "entity_id": "beef49eb3d274631fe07abfe"
         },
         {
           "id": "5b4c935b4b900a0062b7dc19",
-          "type": "grok_pattern",
+          "type": {
+            "name": "grok_pattern",
+            "version": "1"
+          },
           "entity_id": "bee149eb3d274631fe07abfe"
         },
         {
           "id": "5b4c935b4b900a0062b7dc1b",
-          "type": "input",
+          "type": {
+            "name": "input",
+            "version": "1"
+          },
           "entity_id": "bee249eb3d274631fe07abfe"
         },
         {
           "id": "5b4c935b4b900a0062b7dc1f",
-          "type": "output",
+          "type": {
+            "name": "output",
+            "version": "1"
+          },
           "entity_id": "bee349eb3d274631fe07abfe"
         },
         {
           "id": "5b4c935b4b900a0062b7dc20",
-          "type": "stream",
+          "type": {
+            "name": "stream",
+            "version": "1"
+          },
           "entity_id": "bee449eb3d274631fe07abfe"
         }
       ],
@@ -95,27 +119,42 @@
       "entities": [
         {
           "id": "5b4c935b4b900a0062b7dc0a",
-          "type": "pipeline_rule",
+          "type": {
+            "name": "pipeline_rule",
+            "version": "1"
+          },
           "entity_id": "bee549eb3d274631fe07abfe"
         },
         {
           "id": "5b4c935b4b900a0062b7dc0b",
-          "type": "pipeline",
+          "type": {
+            "name": "pipeline",
+            "version": "1"
+          },
           "entity_id": "bee649eb3d274631fe07abfe"
         },
         {
           "id": "cp_lookup",
-          "type": "lookup_adapter",
+          "type": {
+            "name": "lookup_adapter",
+            "version": "1"
+          },
           "entity_id": "bee749eb3d274631fe07abfe"
         },
         {
           "id": "cp_lookup",
-          "type": "lookup_cache",
+          "type": {
+            "name": "lookup_cache",
+            "version": "1"
+          },
           "entity_id": "bee849eb3d274631fe07abfe"
         },
         {
           "id": "5b4c935b4b900a0062b7dc14",
-          "type": "lookup_table",
+          "type": {
+            "name": "lookup_table",
+            "version": "1"
+          },
           "entity_id": "bee949eb3d274631fe07abfe"
         }
       ],

--- a/graylog2-server/src/test/resources/org/graylog2/contentpacks/ContentPackPersistenceServiceTest.json
+++ b/graylog2-server/src/test/resources/org/graylog2/contentpacks/ContentPackPersistenceServiceTest.json
@@ -41,7 +41,10 @@
       "entities": [
         {
           "v": "1",
-          "type": "input",
+          "type": {
+            "name": "input",
+            "version": "1"
+          },
           "id": "78547c87-af21-4292-8e57-614da5baf6c3",
           "data": {
             "title": "GELF Input",
@@ -62,7 +65,10 @@
         },
         {
           "v": "1",
-          "type": "lookup_table",
+          "type": {
+            "name": "lookup_table",
+            "version": "1"
+          },
           "id": "311d9e16-e4d9-485d-a916-337fb4ca0e8b",
           "data": {
             "title": {
@@ -85,7 +91,10 @@
         },
         {
           "v": "1",
-          "type": "lookup_cache",
+          "type": {
+            "name": "lookup_cache",
+            "version": "1"
+          },
           "id": "911da25d-74e2-4364-b88e-7930368f6e56",
           "data": {
             "title": {
@@ -110,7 +119,10 @@
         },
         {
           "v": "1",
-          "type": "lookup_adapter",
+          "type": {
+            "name": "lookup_adapter",
+            "version": "1"
+          },
           "id": "2562ac46-65f1-454c-89e1-e9be96bfd5e7",
           "data": {
             "title": {
@@ -139,7 +151,10 @@
         },
         {
           "v": "1",
-          "type": "pipeline_connection",
+          "type": {
+            "name": "pipeline_connection",
+            "version": "1"
+          },
           "id": "726b6e09-4199-4ef4-8d69-275ebfe06d31",
           "data": {
             "pipeline_id": {
@@ -154,7 +169,10 @@
         },
         {
           "v": "1",
-          "type": "pipeline",
+          "type": {
+            "name": "pipeline",
+            "version": "1"
+          },
           "id": "37f26b0a-e4ab-41ff-985c-0dd4a01ff10c",
           "data": {
             "stream_id": {
@@ -165,7 +183,10 @@
         },
         {
           "v": "1",
-          "type": "stream",
+          "type": {
+            "name": "stream",
+            "version": "1"
+          },
           "id": "3fb82940-fd01-4c64-98f3-4ed2ce2577e3",
           "data": {
           }

--- a/graylog2-server/src/test/resources/org/graylog2/contentpacks/model/contentpack_reference.json
+++ b/graylog2-server/src/test/resources/org/graylog2/contentpacks/model/contentpack_reference.json
@@ -36,7 +36,10 @@
   "entities": [
     {
       "v": "1",
-      "type": "input",
+      "type": {
+        "name": "input",
+        "version": "1"
+      },
       "id": "78547c87-af21-4292-8e57-614da5baf6c3",
       "data": {
         "title": "GELF Input",
@@ -57,7 +60,10 @@
     },
     {
       "v": "1",
-      "type": "lookup_table",
+      "type": {
+        "name": "lookup_table",
+        "version": "1"
+      },
       "id": "311d9e16-e4d9-485d-a916-337fb4ca0e8b",
       "data": {
         "title": {
@@ -80,7 +86,10 @@
     },
     {
       "v": "1",
-      "type": "lookup_cache",
+      "type": {
+        "name": "lookup_cache",
+        "version": "1"
+      },
       "id": "911da25d-74e2-4364-b88e-7930368f6e56",
       "data": {
         "title": {
@@ -105,7 +114,10 @@
     },
     {
       "v": "1",
-      "type": "lookup_adapter",
+      "type": {
+        "name": "lookup_adapter",
+        "version": "1"
+      },
       "id": "2562ac46-65f1-454c-89e1-e9be96bfd5e7",
       "data": {
         "title": {
@@ -134,7 +146,10 @@
     },
     {
       "v": "1",
-      "type": "pipeline_connection",
+      "type": {
+        "name": "pipeline_connection",
+        "version": "1"
+      },
       "id": "726b6e09-4199-4ef4-8d69-275ebfe06d31",
       "data": {
         "pipeline_id": {
@@ -149,7 +164,10 @@
     },
     {
       "v": "1",
-      "type": "pipeline",
+      "type": {
+        "name": "pipeline",
+        "version": "1"
+      },
       "id": "37f26b0a-e4ab-41ff-985c-0dd4a01ff10c",
       "data": {
         "stream_id": {
@@ -160,7 +178,10 @@
     },
     {
       "v": "1",
-      "type": "stream",
+      "type": {
+        "name": "stream",
+        "version": "1"
+      },
       "id": "3fb82940-fd01-4c64-98f3-4ed2ce2577e3",
       "data": {
       }

--- a/graylog2-server/src/test/resources/org/graylog2/contentpacks/model/entities/entity_reference.json
+++ b/graylog2-server/src/test/resources/org/graylog2/contentpacks/model/entities/entity_reference.json
@@ -1,6 +1,9 @@
 {
   "v": "1",
-  "type": "input",
+  "type": {
+    "name": "input",
+    "version": "1"
+  },
   "id": "78547c87-af21-4292-8e57-614da5baf6c3",
   "data": {
     "title": "GELF Input",

--- a/graylog2-web-interface/src/components/content-packs/ContentPackEntitiesList.jsx
+++ b/graylog2-web-interface/src/components/content-packs/ContentPackEntitiesList.jsx
@@ -127,7 +127,7 @@ class ContentPackEntitiesList extends React.Component {
     return (
       <tr key={entity.id}>
         <td className={ContentPackEntitiesListStyle.bigColumns}>{this._entityTitle(entity)}</td>
-        <td>{entity.type}</td>
+        <td>{entity.type.name}</td>
         <td className={ContentPackEntitiesListStyle.bigColumns}>{this._entityDescription(entity)}</td>
         {!this.props.readOnly && <td>{appliedParameterCount}</td>}
         <td>
@@ -173,7 +173,7 @@ class ContentPackEntitiesList extends React.Component {
           id="entity-list"
           headers={headers}
           className={ContentPackEntitiesListStyle.scrollable}
-          sortByKey="type"
+          sortBy={entity => entity.type.name}
           filterKeys={[]}
           rows={this.state.filteredEntities}
           dataRowFormatter={this._entityRowFormatter}

--- a/graylog2-web-interface/src/components/content-packs/ContentPackEntitiesList.test.jsx
+++ b/graylog2-web-interface/src/components/content-packs/ContentPackEntitiesList.test.jsx
@@ -8,7 +8,10 @@ import ContentPackEntitiesList from 'components/content-packs/ContentPackEntitie
 describe('<ContentPackEntitiesList />', () => {
   const entity1 = {
     id: '111-beef',
-    type: 'Input',
+    type: {
+      name: 'Input',
+      version: '1',
+    },
     v: '1.0',
     data: {
       name: { type: 'string', value: 'Input' },
@@ -21,7 +24,10 @@ describe('<ContentPackEntitiesList />', () => {
   };
   const entity2 = {
     id: '121-beef',
-    type: 'Input',
+    type: {
+      name: 'Input',
+      version: '1',
+    },
     v: '1.0',
     data: {
       name: { type: 'string', value: 'BadInput' },

--- a/graylog2-web-interface/src/components/content-packs/ContentPackInstall.test.jsx
+++ b/graylog2-web-interface/src/components/content-packs/ContentPackInstall.test.jsx
@@ -14,6 +14,10 @@ describe('<ContentPackInstall />', () => {
   };
 
   const entity = {
+    type: {
+      name: 'grok_pattern',
+      version: '1',
+    },
     data: {
       title: { type: 'string', value: 'franz' },
       descr: { type: 'string', value: 'hans' },

--- a/graylog2-web-interface/src/components/content-packs/ContentPackParameters.test.jsx
+++ b/graylog2-web-interface/src/components/content-packs/ContentPackParameters.test.jsx
@@ -18,6 +18,10 @@ describe('<ContentPackParameters />', () => {
     const entity = {
       id: '111-beef',
       v: '1.0',
+      type: {
+        name: 'input',
+        version: '1',
+      },
       data: {
         name: { type: 'string', value: 'Input' },
         title: { type: 'string', value: 'A good input' },

--- a/graylog2-web-interface/src/components/content-packs/ContentPackSelection.jsx
+++ b/graylog2-web-interface/src/components/content-packs/ContentPackSelection.jsx
@@ -56,13 +56,14 @@ class ContentPackSelection extends React.Component {
   }
 
   _updateSelectionEntity = (entity) => {
+    const typeName = entity.type.name;
     const newSelection = ObjectUtils.clone(this.props.selectedEntities);
-    newSelection[entity.type] = (newSelection[entity.type] || []);
-    const index = newSelection[entity.type].findIndex((e) => { return e.id === entity.id; });
+    newSelection[typeName] = (newSelection[typeName] || []);
+    const index = newSelection[typeName].findIndex((e) => { return e.id === entity.id; });
     if (index < 0) {
-      newSelection[entity.type].push(entity);
+      newSelection[typeName].push(entity);
     } else {
-      newSelection[entity.type].splice(index, 1);
+      newSelection[typeName].splice(index, 1);
     }
     this.props.onStateChange({ selectedEntities: newSelection });
   };
@@ -88,11 +89,12 @@ class ContentPackSelection extends React.Component {
   }
 
   _isSelected(entity) {
-    if (!this.props.selectedEntities[entity.type]) {
+    const typeName = entity.type.name;
+    if (!this.props.selectedEntities[typeName]) {
       return false;
     }
 
-    return this.props.selectedEntities[entity.type].findIndex((e) => { return e.id === entity.id; }) >= 0;
+    return this.props.selectedEntities[typeName].findIndex((e) => { return e.id === entity.id; }) >= 0;
   }
 
   _isGroupSelected(type) {

--- a/graylog2-web-interface/src/components/content-packs/ContentPackSelection.test.jsx
+++ b/graylog2-web-interface/src/components/content-packs/ContentPackSelection.test.jsx
@@ -24,7 +24,10 @@ describe('<ContentPackSelection />', () => {
     const entities = {
       spaceship: [{
         title: 'breq',
-        type: 'spaceship',
+        type: {
+          name: 'spaceship',
+          version: '1',
+        },
         id: 'beef123',
       }],
     };
@@ -67,7 +70,10 @@ describe('<ContentPackSelection />', () => {
     const entities = {
       spaceship: [{
         title: 'breq',
-        type: 'spaceship',
+        type: {
+          name: 'spaceship',
+          version: '1',
+        },
         id: 'beef123',
       }],
     };
@@ -90,12 +96,18 @@ describe('<ContentPackSelection />', () => {
     const contentPack = {};
     const breq = {
       title: 'breq',
-      type: 'spaceship',
+      type: {
+        name: 'spaceship',
+        version: '1',
+      },
       id: 'beef123',
     };
     const falcon = {
       title: 'falcon',
-      type: 'spaceship',
+      type: {
+        name: 'spaceship',
+        version: '1',
+      },
       id: 'beef124',
     };
     const entities = { spaceship: [breq, falcon] };
@@ -121,12 +133,18 @@ describe('<ContentPackSelection />', () => {
     const contentPack = {};
     const breq = {
       title: 'breq',
-      type: 'spaceship',
+      type: {
+        name: 'spaceship',
+        version: '1',
+      },
       id: 'beef123',
     };
     const falcon = {
       title: 'falcon',
-      type: 'spaceship',
+      type: {
+        name: 'spaceship',
+        version: '1',
+      },
       id: 'beef124',
     };
     const entities = { spaceship: [breq, falcon] };

--- a/graylog2-web-interface/src/components/content-packs/__snapshots__/ContentPackInstall.test.jsx.snap
+++ b/graylog2-web-interface/src/components/content-packs/__snapshots__/ContentPackInstall.test.jsx.snap
@@ -195,7 +195,9 @@ exports[`<ContentPackInstall /> should render a install 1`] = `
                       >
                         franz
                       </td>
-                      <td />
+                      <td>
+                        grok_pattern
+                      </td>
                       <td
                         className="bigColumns"
                       >

--- a/graylog2-web-interface/src/components/content-packs/__snapshots__/ContentPackParameters.test.jsx.snap
+++ b/graylog2-web-interface/src/components/content-packs/__snapshots__/ContentPackParameters.test.jsx.snap
@@ -298,7 +298,9 @@ exports[`<ContentPackParameters /> should render a parameter 1`] = `
                       >
                         A good input
                       </td>
-                      <td />
+                      <td>
+                        input
+                      </td>
                       <td
                         className="bigColumns"
                       >

--- a/graylog2-web-interface/src/stores/content-packs/CatalogStore.jsx
+++ b/graylog2-web-interface/src/stores/content-packs/CatalogStore.jsx
@@ -16,7 +16,7 @@ const CatalogStore = Reflux.createStore({
     const url = URLUtils.qualifyUrl(ApiRoutes.CatalogsController.showEntityIndex().url);
     const promise = fetch('GET', url)
       .then((result) => {
-        const entityIndex = lodash.groupBy(result.entities, 'type');
+        const entityIndex = lodash.groupBy(result.entities, 'type.name');
         this.trigger({ entityIndex: entityIndex });
 
         return result;


### PR DESCRIPTION
Each entity has a `data` field of type `JsonNode`. A facade converts the contents `data` into an entity object. Previously an entity only had a `type` value of string. (e.g. `collector`) This PR changes the `type` field of an entiy from a string to an object with a `name` and `version` field. This allows us to handle different versions of entity data in the future.

Each facade will be registered for a specific entity version. One facade class can handle multiple versions of entity data or we can create a separate facade for each entity version. Most facades can probably built to handle multiple versions to avoid duplication.

```java
addEntityFacade(CollectorFacade.TYPE_V1, CollectorFacade.class);
```

## Old Entity

```json
{
  "id": "5b4c920b4b900a0024af2b5c",
  "type": "collector",
  "entity_id": "5b1a49eb3d274631fe07beff",
  "data": {
  }
}
```

## New Entity

```json
{
  "id": "5b4c920b4b900a0024af2b5c",
  "type": {
    "name": "collector",
    "version": "1"
  },
  "entity_id": "5b1a49eb3d274631fe07beff",
  "data": {
  }
}
```

Fixes #4977 