### PR TITLE
Add validation to mandatory fields and better arrange overview

### DIFF
--- a/graylog2-web-interface/src/components/content-packs/ContentPackEdit.jsx
+++ b/graylog2-web-interface/src/components/content-packs/ContentPackEdit.jsx
@@ -44,8 +44,7 @@ class ContentPackEdit extends React.Component {
   _disableParameters() {
     const content = this.props.contentPack;
     const selection = Object.keys(this.props.selectedEntities).length !== 0;
-    return !(content.name && content.summary && content.description && content.vendor &&
-      selection);
+    return !(content.name && content.summary && content.vendor && selection);
   }
 
   _disablePreview() {

--- a/graylog2-web-interface/src/components/content-packs/ContentPackEdit.jsx
+++ b/graylog2-web-interface/src/components/content-packs/ContentPackEdit.jsx
@@ -43,7 +43,9 @@ class ContentPackEdit extends React.Component {
 
   _disableParameters() {
     const content = this.props.contentPack;
-    const selection = Object.keys(this.props.selectedEntities).length !== 0;
+    const { selectedEntities } = this.props;
+    const selection = Object.keys(selectedEntities)
+      .reduce((acc, key) => { return acc + selectedEntities[key].length; }, 0) > 0;
     return !(content.name && content.summary && content.vendor && selection);
   }
 

--- a/graylog2-web-interface/src/components/content-packs/ContentPackEntitiesList.jsx
+++ b/graylog2-web-interface/src/components/content-packs/ContentPackEntitiesList.jsx
@@ -30,7 +30,7 @@ class ContentPackEntitiesList extends React.Component {
   constructor(props) {
     super(props);
     this.state = {
-      filteredEntities: props.contentPack.entities,
+      filteredEntities: props.contentPack.entities || [],
       filter: undefined,
     };
   }

--- a/graylog2-web-interface/src/components/content-packs/ContentPackParameterList.jsx
+++ b/graylog2-web-interface/src/components/content-packs/ContentPackParameterList.jsx
@@ -29,7 +29,7 @@ class ContentPackParameterList extends React.Component {
     super(props);
 
     this.state = {
-      filteredParameters: props.contentPack.parameters,
+      filteredParameters: props.contentPack.parameters || [],
       filter: undefined,
     };
   }

--- a/graylog2-web-interface/src/components/content-packs/ContentPackPreview.jsx
+++ b/graylog2-web-interface/src/components/content-packs/ContentPackPreview.jsx
@@ -4,6 +4,8 @@ import React from 'react';
 import { Row, Col, Button } from 'react-bootstrap';
 import ContentPackDetails from 'components/content-packs/ContentPackDetails';
 import ContentPackConstraints from 'components/content-packs/ContentPackConstraints';
+import ContentPackEntitiesList from './ContentPackEntitiesList';
+import ContentPackParameterList from './ContentPackParameterList';
 
 class ContentPackPreview extends React.Component {
   static propTypes = {
@@ -27,10 +29,12 @@ class ContentPackPreview extends React.Component {
       <div>
         <Row>
           <Col sm={6}>
-            <ContentPackDetails contentPack={this.props.contentPack} verbose />
+            <ContentPackDetails contentPack={this.props.contentPack} />
           </Col>
           <Col sm={6}>
             <ContentPackConstraints constraints={this.props.contentPack.requires} isFulfilled />
+            <ContentPackEntitiesList contentPack={this.props.contentPack} readOnly />
+            <ContentPackParameterList contentPack={this.props.contentPack} readOnly />
           </Col>
         </Row>
         <Row>

--- a/graylog2-web-interface/src/components/content-packs/ContentPackSelection.jsx
+++ b/graylog2-web-interface/src/components/content-packs/ContentPackSelection.jsx
@@ -1,7 +1,7 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 
-import { Row, Col } from 'react-bootstrap';
+import { Row, Col, Panel } from 'react-bootstrap';
 import { Input } from 'components/bootstrap';
 import { ExpandableList, ExpandableListItem, SearchForm } from 'components/common';
 import FormsUtils from 'util/FormsUtils';
@@ -34,7 +34,12 @@ class ContentPackSelection extends React.Component {
       filteredEntities: ObjectUtils.clone(this.props.entities),
       filter: '',
       isFiltered: false,
+      errors: {},
     };
+  }
+
+  componentDidMount() {
+    this._validate();
   }
 
   componentWillReceiveProps(nextProps) {
@@ -48,9 +53,28 @@ class ContentPackSelection extends React.Component {
     const updatedPack = ObjectUtils.clone(this.state.contentPack);
     updatedPack[name] = value;
     this.props.onStateChange({ contentPack: updatedPack });
-    this.setState({ contentPack: updatedPack });
+    this.setState({ contentPack: updatedPack }, this._validate);
   }
 
+  _validate = () => {
+    const mandatoryFields = ['name', 'summary', 'vendor'];
+    const { contentPack } = this.state;
+    const { selectedEntities } = this.props;
+
+    const errors = mandatoryFields.reduce((acc, field) => {
+      const newErrors = acc;
+      if (!contentPack[field] || contentPack[field].length <= 0) {
+        newErrors[field] = 'Must be filled out.';
+      }
+      return newErrors;
+    }, {});
+
+    if (Object.keys(selectedEntities).length <= 0) {
+      errors.selection = 'Select at least one entity.';
+    }
+
+    this.setState({ errors });
+  };
   _bindValue(event) {
     this._updateField(event.target.name, FormsUtils.getValueFromInput(event.target));
   }
@@ -65,6 +89,7 @@ class ContentPackSelection extends React.Component {
       newSelection[entity.type].splice(index, 1);
     }
     this.props.onStateChange({ selectedEntities: newSelection });
+    this._validate();
   };
 
   _updateSelectionGroup = (type) => {
@@ -76,6 +101,7 @@ class ContentPackSelection extends React.Component {
     }
 
     this.props.onStateChange({ selectedEntities: newSelection });
+    this._validate();
   };
 
   _isUndetermined(type) {
@@ -156,6 +182,8 @@ class ContentPackSelection extends React.Component {
       );
     });
 
+    const { errors } = this.state;
+
     return (
       <div>
         <Row>
@@ -167,20 +195,22 @@ class ContentPackSelection extends React.Component {
                 <Input name="name"
                        id="name"
                        type="text"
+                       bsStyle={errors.name ? 'error' : null}
                        maxLength={250}
                        value={this.state.contentPack.name}
                        onChange={this._bindValue}
                        label="Name"
-                       help="Give a descriptive name for this content pack."
+                       help={errors.name ? errors.name : 'Give a descriptive name for this content pack.'}
                        required />
                 <Input name="summary"
                        id="summary"
                        type="text"
+                       bsStyle={errors.summary ? 'error' : null}
                        maxLength={250}
                        value={this.state.contentPack.summary}
                        onChange={this._bindValue}
                        label="Summary"
-                       help="Give a short summary of the content pack."
+                       help={errors.summary ? errors.summary : 'Give a short summary of the content pack.'}
                        required />
                 <Input name="description"
                        id="description"
@@ -189,16 +219,16 @@ class ContentPackSelection extends React.Component {
                        onChange={this._bindValue}
                        rows={6}
                        label="Description"
-                       help="Give a long description of the content pack in markdown."
-                       required />
+                       help="Give a long description of the content pack in markdown." />
                 <Input name="vendor"
                        id="vendor"
                        type="text"
+                       bsStyle={errors.vendor ? 'error' : null}
                        maxLength={250}
                        value={this.state.contentPack.vendor}
                        onChange={this._bindValue}
                        label="Vendor"
-                       help="Who did this content pack and how can he be reached. e.g Name and eMail"
+                       help={errors.vendor ? errors.vendor : 'Who did this content pack and how can he be reached. e.g Name and eMail'}
                        required />
                 <Input name="url"
                        id="url"
@@ -207,8 +237,7 @@ class ContentPackSelection extends React.Component {
                        value={this.state.contentPack.url}
                        onChange={this._bindValue}
                        label="URL"
-                       help="Where can I find the content pack. e.g. github url"
-                       required />
+                       help="Where can I find the content pack. e.g. github url" />
               </fieldset>
             </form>
           </Col>
@@ -228,6 +257,11 @@ class ContentPackSelection extends React.Component {
             />
           </Col>
         </Row>
+        {errors.selection &&
+          <Row>
+            <Col smOffset={1} sm={4}><Panel bsStyle="danger">{errors.selection}</Panel></Col>
+          </Row>
+        }
         <Row>
           <Col smOffset={1} sm={8}>
             <ExpandableList>

--- a/graylog2-web-interface/src/components/content-packs/ContentPackSelection.test.jsx
+++ b/graylog2-web-interface/src/components/content-packs/ContentPackSelection.test.jsx
@@ -155,16 +155,36 @@ describe('<ContentPackSelection />', () => {
   });
 
   it('should validate that all fields are filled out', () => {
-    const wrapper = mount(<ContentPackSelection contentPack={{ }} />);
+    const breq = {
+      title: 'breq',
+      type: 'spaceship',
+      id: 'beef123',
+    };
+    const falcon = {
+      title: 'falcon',
+      type: 'spaceship',
+      id: 'beef124',
+    };
+    const entities = { spaceship: [breq, falcon] };
+
+    const wrapper = mount(<ContentPackSelection contentPack={{ }} entities={entities} />);
+    wrapper.instance()._validate();
+    wrapper.update();
     expect(wrapper.find('span[children="Must be filled out."]').length).toEqual(3);
 
-    const wrapper2 = mount(<ContentPackSelection contentPack={{ name: 'name' }} />);
+    const wrapper2 = mount(<ContentPackSelection contentPack={{ name: 'name' }} entities={entities} />);
+    wrapper2.instance()._validate();
+    wrapper2.update();
     expect(wrapper2.find('span[children="Must be filled out."]').length).toEqual(2);
 
-    const wrapper1 = mount(<ContentPackSelection contentPack={{ name: 'name', summary: 'summary' }} />);
+    const wrapper1 = mount(<ContentPackSelection contentPack={{ name: 'name', summary: 'summary' }} entities={entities} />);
+    wrapper1.instance()._validate();
+    wrapper1.update();
     expect(wrapper1.find('span[children="Must be filled out."]').length).toEqual(1);
 
-    const wrapper0 = mount(<ContentPackSelection contentPack={{ name: 'name', summary: 'summary', vendor: 'vendor' }} />);
+    const wrapper0 = mount(<ContentPackSelection contentPack={{ name: 'name', summary: 'summary', vendor: 'vendor' }} entities={entities} />);
+    wrapper0.instance()._validate();
+    wrapper0.update();
     expect(wrapper0.find('span[children="Must be filled out."]').length).toEqual(0);
   });
 });

--- a/graylog2-web-interface/src/components/content-packs/ContentPackSelection.test.jsx
+++ b/graylog2-web-interface/src/components/content-packs/ContentPackSelection.test.jsx
@@ -153,4 +153,18 @@ describe('<ContentPackSelection />', () => {
     wrapper.find('div.fa-stack').simulate('click');
     expect(wrapper.find('input[type="checkbox"]').length).toEqual(3);
   });
+
+  it('should validate that all fields are filled out', () => {
+    const wrapper = mount(<ContentPackSelection contentPack={{ }} />);
+    expect(wrapper.find('span[children="Must be filled out."]').length).toEqual(3);
+
+    const wrapper2 = mount(<ContentPackSelection contentPack={{ name: 'name' }} />);
+    expect(wrapper2.find('span[children="Must be filled out."]').length).toEqual(2);
+
+    const wrapper1 = mount(<ContentPackSelection contentPack={{ name: 'name', summary: 'summary' }} />);
+    expect(wrapper1.find('span[children="Must be filled out."]').length).toEqual(1);
+
+    const wrapper0 = mount(<ContentPackSelection contentPack={{ name: 'name', summary: 'summary', vendor: 'vendor' }} />);
+    expect(wrapper0.find('span[children="Must be filled out."]').length).toEqual(0);
+  });
 });

--- a/graylog2-web-interface/src/components/content-packs/__snapshots__/ContentPackEdit.test.jsx.snap
+++ b/graylog2-web-interface/src/components/content-packs/__snapshots__/ContentPackEdit.test.jsx.snap
@@ -118,7 +118,7 @@ exports[`<ContentPackEdit /> should render empty content pack for create 1`] = `
             >
               <fieldset>
                 <div
-                  className="form-group"
+                  className="form-group has-error"
                 >
                   <label
                     className="control-label"
@@ -142,12 +142,12 @@ exports[`<ContentPackEdit /> should render empty content pack for create 1`] = `
                     <span
                       className="help-block"
                     >
-                      Give a descriptive name for this content pack.
+                      Must be filled out.
                     </span>
                   </span>
                 </div>
                 <div
-                  className="form-group"
+                  className="form-group has-error"
                 >
                   <label
                     className="control-label"
@@ -171,7 +171,7 @@ exports[`<ContentPackEdit /> should render empty content pack for create 1`] = `
                     <span
                       className="help-block"
                     >
-                      Give a short summary of the content pack.
+                      Must be filled out.
                     </span>
                   </span>
                 </div>
@@ -192,7 +192,6 @@ exports[`<ContentPackEdit /> should render empty content pack for create 1`] = `
                       name="description"
                       onChange={[Function]}
                       placeholder=""
-                      required={true}
                       rows={6}
                       type="textarea"
                       value=""
@@ -205,7 +204,7 @@ exports[`<ContentPackEdit /> should render empty content pack for create 1`] = `
                   </span>
                 </div>
                 <div
-                  className="form-group"
+                  className="form-group has-error"
                 >
                   <label
                     className="control-label"
@@ -229,7 +228,7 @@ exports[`<ContentPackEdit /> should render empty content pack for create 1`] = `
                     <span
                       className="help-block"
                     >
-                      Who did this content pack and how can he be reached. e.g Name and eMail
+                      Must be filled out.
                     </span>
                   </span>
                 </div>
@@ -251,7 +250,6 @@ exports[`<ContentPackEdit /> should render empty content pack for create 1`] = `
                       name="url"
                       onChange={[Function]}
                       placeholder=""
-                      required={true}
                       type="text"
                       value=""
                     />
@@ -348,6 +346,24 @@ exports[`<ContentPackEdit /> should render empty content pack for create 1`] = `
                   </button>
                 </div>
               </form>
+            </div>
+          </div>
+        </div>
+        <div
+          className="row"
+        >
+          <div
+            className="col-sm-4 col-sm-offset-1"
+          >
+            <div
+              className="panel panel-danger"
+              id={undefined}
+            >
+              <div
+                className="panel-body"
+              >
+                Select at least one entity.
+              </div>
             </div>
           </div>
         </div>
@@ -685,7 +701,6 @@ exports[`<ContentPackEdit /> should render with content pack for edit 1`] = `
                       name="description"
                       onChange={[Function]}
                       placeholder=""
-                      required={true}
                       rows={6}
                       type="textarea"
                       value="## No one dares"
@@ -744,7 +759,6 @@ exports[`<ContentPackEdit /> should render with content pack for edit 1`] = `
                       name="url"
                       onChange={[Function]}
                       placeholder=""
-                      required={true}
                       type="text"
                       value="http://beinstein.com"
                     />

--- a/graylog2-web-interface/src/components/content-packs/__snapshots__/ContentPackEdit.test.jsx.snap
+++ b/graylog2-web-interface/src/components/content-packs/__snapshots__/ContentPackEdit.test.jsx.snap
@@ -118,7 +118,7 @@ exports[`<ContentPackEdit /> should render empty content pack for create 1`] = `
             >
               <fieldset>
                 <div
-                  className="form-group has-error"
+                  className="form-group"
                 >
                   <label
                     className="control-label"
@@ -142,12 +142,12 @@ exports[`<ContentPackEdit /> should render empty content pack for create 1`] = `
                     <span
                       className="help-block"
                     >
-                      Must be filled out.
+                      Required. Give a descriptive name for this content pack.
                     </span>
                   </span>
                 </div>
                 <div
-                  className="form-group has-error"
+                  className="form-group"
                 >
                   <label
                     className="control-label"
@@ -171,7 +171,7 @@ exports[`<ContentPackEdit /> should render empty content pack for create 1`] = `
                     <span
                       className="help-block"
                     >
-                      Must be filled out.
+                      Required. Give a short summary of the content pack.
                     </span>
                   </span>
                 </div>
@@ -204,7 +204,7 @@ exports[`<ContentPackEdit /> should render empty content pack for create 1`] = `
                   </span>
                 </div>
                 <div
-                  className="form-group has-error"
+                  className="form-group"
                 >
                   <label
                     className="control-label"
@@ -228,7 +228,7 @@ exports[`<ContentPackEdit /> should render empty content pack for create 1`] = `
                     <span
                       className="help-block"
                     >
-                      Must be filled out.
+                      Required. Who did this content pack and how can he be reached. e.g Name and eMail
                     </span>
                   </span>
                 </div>
@@ -346,24 +346,6 @@ exports[`<ContentPackEdit /> should render empty content pack for create 1`] = `
                   </button>
                 </div>
               </form>
-            </div>
-          </div>
-        </div>
-        <div
-          className="row"
-        >
-          <div
-            className="col-sm-4 col-sm-offset-1"
-          >
-            <div
-              className="panel panel-danger"
-              id={undefined}
-            >
-              <div
-                className="panel-body"
-              >
-                Select at least one entity.
-              </div>
             </div>
           </div>
         </div>
@@ -651,7 +633,7 @@ exports[`<ContentPackEdit /> should render with content pack for edit 1`] = `
                     <span
                       className="help-block"
                     >
-                      Give a descriptive name for this content pack.
+                      Required. Give a descriptive name for this content pack.
                     </span>
                   </span>
                 </div>
@@ -680,7 +662,7 @@ exports[`<ContentPackEdit /> should render with content pack for edit 1`] = `
                     <span
                       className="help-block"
                     >
-                      Give a short summary of the content pack.
+                      Required. Give a short summary of the content pack.
                     </span>
                   </span>
                 </div>
@@ -737,7 +719,7 @@ exports[`<ContentPackEdit /> should render with content pack for edit 1`] = `
                     <span
                       className="help-block"
                     >
-                      Who did this content pack and how can he be reached. e.g Name and eMail
+                      Required. Who did this content pack and how can he be reached. e.g Name and eMail
                     </span>
                   </span>
                 </div>

--- a/graylog2-web-interface/src/components/content-packs/__snapshots__/ContentPackPreview.test.jsx.snap
+++ b/graylog2-web-interface/src/components/content-packs/__snapshots__/ContentPackPreview.test.jsx.snap
@@ -113,6 +113,186 @@ exports[`<ContentPackPreview /> should render with empty content pack 1`] = `
           </div>
         </div>
       </div>
+      <div>
+        <h2>
+          Entity list
+        </h2>
+        <br />
+        <div
+          className="search"
+          style={
+            Object {
+              "marginTop": 15,
+            }
+          }
+        >
+          <form
+            className="form-inline"
+            onSubmit={[Function]}
+          >
+            <div
+              className="form-group has-feedback"
+            >
+              <input
+                autoComplete="off"
+                className="query form-control"
+                id="common-search-form-query-input"
+                onChange={[Function]}
+                placeholder="Enter search query..."
+                spellCheck="false"
+                style={
+                  Object {
+                    "width": "auto",
+                  }
+                }
+                type="text"
+                value=""
+              />
+            </div>
+            <div
+              className="form-group"
+              style={
+                Object {
+                  "marginLeft": 5,
+                }
+              }
+            >
+              <button
+                className="submit-button btn btn-default"
+                disabled={false}
+                type="submit"
+              >
+                Filter
+              </button>
+            </div>
+            <div
+              className="form-group"
+              style={
+                Object {
+                  "marginLeft": 5,
+                }
+              }
+            >
+              <button
+                className="reset-button btn btn-default"
+                disabled={false}
+                onClick={[Function]}
+                type="reset"
+              >
+                Reset
+              </button>
+            </div>
+          </form>
+        </div>
+        <div>
+          <div
+            className="row "
+          >
+            <div
+              className="col-md-12"
+            >
+              <div
+                className="data-table table-responsive"
+                id="entity-list"
+              >
+                <p>
+                  No data available.
+                </p>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+      <div>
+        <h2>
+          Parameters list
+        </h2>
+        <br />
+        <div
+          className="search"
+          style={
+            Object {
+              "marginTop": 15,
+            }
+          }
+        >
+          <form
+            className="form-inline"
+            onSubmit={[Function]}
+          >
+            <div
+              className="form-group has-feedback"
+            >
+              <input
+                autoComplete="off"
+                className="query form-control"
+                id="common-search-form-query-input"
+                onChange={[Function]}
+                placeholder="Enter search query..."
+                spellCheck="false"
+                style={
+                  Object {
+                    "width": "auto",
+                  }
+                }
+                type="text"
+                value=""
+              />
+            </div>
+            <div
+              className="form-group"
+              style={
+                Object {
+                  "marginLeft": 5,
+                }
+              }
+            >
+              <button
+                className="submit-button btn btn-default"
+                disabled={false}
+                type="submit"
+              >
+                Filter
+              </button>
+            </div>
+            <div
+              className="form-group"
+              style={
+                Object {
+                  "marginLeft": 5,
+                }
+              }
+            >
+              <button
+                className="reset-button btn btn-default"
+                disabled={false}
+                onClick={[Function]}
+                type="reset"
+              >
+                Reset
+              </button>
+            </div>
+          </form>
+        </div>
+        <div>
+          <div
+            className="row "
+          >
+            <div
+              className="col-md-12"
+            >
+              <div
+                className="data-table table-responsive"
+                id="parameter-list"
+              >
+                <p>
+                  To use parameters for content packs, at first a parameter must be created and can then be applied to a entity.
+                </p>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
     </div>
   </div>
   <div
@@ -215,6 +395,15 @@ exports[`<ContentPackPreview /> should render with filled content pack 1`] = `
                   </a>
                    
                 </dd>
+                <span>
+                  <dt>
+                    Parameters:
+                  </dt>
+                   
+                  <dd>
+                    0
+                  </dd>
+                </span>
               </dl>
             </div>
             <h2>
@@ -261,6 +450,186 @@ exports[`<ContentPackPreview /> should render with filled content pack 1`] = `
               >
                 <p>
                   No data available.
+                </p>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+      <div>
+        <h2>
+          Entity list
+        </h2>
+        <br />
+        <div
+          className="search"
+          style={
+            Object {
+              "marginTop": 15,
+            }
+          }
+        >
+          <form
+            className="form-inline"
+            onSubmit={[Function]}
+          >
+            <div
+              className="form-group has-feedback"
+            >
+              <input
+                autoComplete="off"
+                className="query form-control"
+                id="common-search-form-query-input"
+                onChange={[Function]}
+                placeholder="Enter search query..."
+                spellCheck="false"
+                style={
+                  Object {
+                    "width": "auto",
+                  }
+                }
+                type="text"
+                value=""
+              />
+            </div>
+            <div
+              className="form-group"
+              style={
+                Object {
+                  "marginLeft": 5,
+                }
+              }
+            >
+              <button
+                className="submit-button btn btn-default"
+                disabled={false}
+                type="submit"
+              >
+                Filter
+              </button>
+            </div>
+            <div
+              className="form-group"
+              style={
+                Object {
+                  "marginLeft": 5,
+                }
+              }
+            >
+              <button
+                className="reset-button btn btn-default"
+                disabled={false}
+                onClick={[Function]}
+                type="reset"
+              >
+                Reset
+              </button>
+            </div>
+          </form>
+        </div>
+        <div>
+          <div
+            className="row "
+          >
+            <div
+              className="col-md-12"
+            >
+              <div
+                className="data-table table-responsive"
+                id="entity-list"
+              >
+                <p>
+                  No data available.
+                </p>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+      <div>
+        <h2>
+          Parameters list
+        </h2>
+        <br />
+        <div
+          className="search"
+          style={
+            Object {
+              "marginTop": 15,
+            }
+          }
+        >
+          <form
+            className="form-inline"
+            onSubmit={[Function]}
+          >
+            <div
+              className="form-group has-feedback"
+            >
+              <input
+                autoComplete="off"
+                className="query form-control"
+                id="common-search-form-query-input"
+                onChange={[Function]}
+                placeholder="Enter search query..."
+                spellCheck="false"
+                style={
+                  Object {
+                    "width": "auto",
+                  }
+                }
+                type="text"
+                value=""
+              />
+            </div>
+            <div
+              className="form-group"
+              style={
+                Object {
+                  "marginLeft": 5,
+                }
+              }
+            >
+              <button
+                className="submit-button btn btn-default"
+                disabled={false}
+                type="submit"
+              >
+                Filter
+              </button>
+            </div>
+            <div
+              className="form-group"
+              style={
+                Object {
+                  "marginLeft": 5,
+                }
+              }
+            >
+              <button
+                className="reset-button btn btn-default"
+                disabled={false}
+                onClick={[Function]}
+                type="reset"
+              >
+                Reset
+              </button>
+            </div>
+          </form>
+        </div>
+        <div>
+          <div
+            className="row "
+          >
+            <div
+              className="col-md-12"
+            >
+              <div
+                className="data-table table-responsive"
+                id="parameter-list"
+              >
+                <p>
+                  To use parameters for content packs, at first a parameter must be created and can then be applied to a entity.
                 </p>
               </div>
             </div>

--- a/graylog2-web-interface/src/components/content-packs/__snapshots__/ContentPackSelection.test.jsx.snap
+++ b/graylog2-web-interface/src/components/content-packs/__snapshots__/ContentPackSelection.test.jsx.snap
@@ -19,7 +19,7 @@ exports[`<ContentPackSelection /> should render with empty content pack 1`] = `
       >
         <fieldset>
           <div
-            className="form-group has-error"
+            className="form-group"
           >
             <label
               className="control-label"
@@ -43,12 +43,12 @@ exports[`<ContentPackSelection /> should render with empty content pack 1`] = `
               <span
                 className="help-block"
               >
-                Must be filled out.
+                Required. Give a descriptive name for this content pack.
               </span>
             </span>
           </div>
           <div
-            className="form-group has-error"
+            className="form-group"
           >
             <label
               className="control-label"
@@ -72,7 +72,7 @@ exports[`<ContentPackSelection /> should render with empty content pack 1`] = `
               <span
                 className="help-block"
               >
-                Must be filled out.
+                Required. Give a short summary of the content pack.
               </span>
             </span>
           </div>
@@ -105,7 +105,7 @@ exports[`<ContentPackSelection /> should render with empty content pack 1`] = `
             </span>
           </div>
           <div
-            className="form-group has-error"
+            className="form-group"
           >
             <label
               className="control-label"
@@ -129,7 +129,7 @@ exports[`<ContentPackSelection /> should render with empty content pack 1`] = `
               <span
                 className="help-block"
               >
-                Must be filled out.
+                Required. Who did this content pack and how can he be reached. e.g Name and eMail
               </span>
             </span>
           </div>
@@ -254,24 +254,6 @@ exports[`<ContentPackSelection /> should render with empty content pack 1`] = `
     className="row"
   >
     <div
-      className="col-sm-4 col-sm-offset-1"
-    >
-      <div
-        className="panel panel-danger"
-        id={undefined}
-      >
-        <div
-          className="panel-body"
-        >
-          Select at least one entity.
-        </div>
-      </div>
-    </div>
-  </div>
-  <div
-    className="row"
-  >
-    <div
       className="col-sm-8 col-sm-offset-1"
     >
       <ul
@@ -325,7 +307,7 @@ exports[`<ContentPackSelection /> should render with filled content pack 1`] = `
               <span
                 className="help-block"
               >
-                Give a descriptive name for this content pack.
+                Required. Give a descriptive name for this content pack.
               </span>
             </span>
           </div>
@@ -354,7 +336,7 @@ exports[`<ContentPackSelection /> should render with filled content pack 1`] = `
               <span
                 className="help-block"
               >
-                Give a short summary of the content pack.
+                Required. Give a short summary of the content pack.
               </span>
             </span>
           </div>
@@ -411,7 +393,7 @@ exports[`<ContentPackSelection /> should render with filled content pack 1`] = `
               <span
                 className="help-block"
               >
-                Who did this content pack and how can he be reached. e.g Name and eMail
+                Required. Who did this content pack and how can he be reached. e.g Name and eMail
               </span>
             </span>
           </div>
@@ -529,24 +511,6 @@ exports[`<ContentPackSelection /> should render with filled content pack 1`] = `
             </button>
           </div>
         </form>
-      </div>
-    </div>
-  </div>
-  <div
-    className="row"
-  >
-    <div
-      className="col-sm-4 col-sm-offset-1"
-    >
-      <div
-        className="panel panel-danger"
-        id={undefined}
-      >
-        <div
-          className="panel-body"
-        >
-          Select at least one entity.
-        </div>
       </div>
     </div>
   </div>

--- a/graylog2-web-interface/src/components/content-packs/__snapshots__/ContentPackSelection.test.jsx.snap
+++ b/graylog2-web-interface/src/components/content-packs/__snapshots__/ContentPackSelection.test.jsx.snap
@@ -19,7 +19,7 @@ exports[`<ContentPackSelection /> should render with empty content pack 1`] = `
       >
         <fieldset>
           <div
-            className="form-group"
+            className="form-group has-error"
           >
             <label
               className="control-label"
@@ -43,12 +43,12 @@ exports[`<ContentPackSelection /> should render with empty content pack 1`] = `
               <span
                 className="help-block"
               >
-                Give a descriptive name for this content pack.
+                Must be filled out.
               </span>
             </span>
           </div>
           <div
-            className="form-group"
+            className="form-group has-error"
           >
             <label
               className="control-label"
@@ -72,7 +72,7 @@ exports[`<ContentPackSelection /> should render with empty content pack 1`] = `
               <span
                 className="help-block"
               >
-                Give a short summary of the content pack.
+                Must be filled out.
               </span>
             </span>
           </div>
@@ -93,7 +93,6 @@ exports[`<ContentPackSelection /> should render with empty content pack 1`] = `
                 name="description"
                 onChange={[Function]}
                 placeholder=""
-                required={true}
                 rows={6}
                 type="textarea"
                 value={undefined}
@@ -106,7 +105,7 @@ exports[`<ContentPackSelection /> should render with empty content pack 1`] = `
             </span>
           </div>
           <div
-            className="form-group"
+            className="form-group has-error"
           >
             <label
               className="control-label"
@@ -130,7 +129,7 @@ exports[`<ContentPackSelection /> should render with empty content pack 1`] = `
               <span
                 className="help-block"
               >
-                Who did this content pack and how can he be reached. e.g Name and eMail
+                Must be filled out.
               </span>
             </span>
           </div>
@@ -152,7 +151,6 @@ exports[`<ContentPackSelection /> should render with empty content pack 1`] = `
                 name="url"
                 onChange={[Function]}
                 placeholder=""
-                required={true}
                 type="text"
                 value={undefined}
               />
@@ -249,6 +247,24 @@ exports[`<ContentPackSelection /> should render with empty content pack 1`] = `
             </button>
           </div>
         </form>
+      </div>
+    </div>
+  </div>
+  <div
+    className="row"
+  >
+    <div
+      className="col-sm-4 col-sm-offset-1"
+    >
+      <div
+        className="panel panel-danger"
+        id={undefined}
+      >
+        <div
+          className="panel-body"
+        >
+          Select at least one entity.
+        </div>
       </div>
     </div>
   </div>
@@ -359,7 +375,6 @@ exports[`<ContentPackSelection /> should render with filled content pack 1`] = `
                 name="description"
                 onChange={[Function]}
                 placeholder=""
-                required={true}
                 rows={6}
                 type="textarea"
                 value="descr"
@@ -418,7 +433,6 @@ exports[`<ContentPackSelection /> should render with filled content pack 1`] = `
                 name="url"
                 onChange={[Function]}
                 placeholder=""
-                required={true}
                 type="text"
                 value="http://example.com"
               />
@@ -515,6 +529,24 @@ exports[`<ContentPackSelection /> should render with filled content pack 1`] = `
             </button>
           </div>
         </form>
+      </div>
+    </div>
+  </div>
+  <div
+    className="row"
+  >
+    <div
+      className="col-sm-4 col-sm-offset-1"
+    >
+      <div
+        className="panel panel-danger"
+        id={undefined}
+      >
+        <div
+          className="panel-body"
+        >
+          Select at least one entity.
+        </div>
       </div>
     </div>
   </div>


### PR DESCRIPTION
## Description
A user new to the content packs might not understand what he
has to fill out to get to the next page. Now we show which fields
a necessay to complete the general information and content pack selection.

The preview of content pack edit/creation was wasting space.
Now all list are on the right side and all general information
are placed to the left.

## Motivation and Context
It was hard for user to see when the next wizard step could be taken.

## Screenshots (if appropriate):
![screenshot_2018-08-09 graylog - content packs 1](https://user-images.githubusercontent.com/448763/43897008-f8203434-9bda-11e8-9d27-f75fd4e1234d.png)
![screenshot_2018-08-09 graylog - content packs](https://user-images.githubusercontent.com/448763/43897009-f8390158-9bda-11e8-8aa2-bfc1ed9fc97c.png)


## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
