### PR TITLE
Add custom request header to prevent CSRF

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/rest/RemoteInterfaceProvider.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/RemoteInterfaceProvider.java
@@ -21,6 +21,7 @@ import com.google.common.net.HttpHeaders;
 import com.google.common.net.MediaType;
 import okhttp3.OkHttpClient;
 import okhttp3.Request;
+import org.glassfish.jersey.client.filter.CsrfProtectionFilter;
 import org.graylog2.cluster.Node;
 import org.graylog2.security.realm.SessionAuthenticator;
 import retrofit2.Retrofit;
@@ -46,6 +47,7 @@ public class RemoteInterfaceProvider {
 
                     Request.Builder builder = original.newBuilder()
                             .header(HttpHeaders.ACCEPT, MediaType.JSON_UTF_8.toString())
+                            .header(CsrfProtectionFilter.HEADER_NAME, "Graylog Server")
                             .method(original.method(), original.body());
 
                     if (authorizationToken != null) {

--- a/graylog2-server/src/main/java/org/graylog2/shared/initializers/JerseyService.java
+++ b/graylog2-server/src/main/java/org/graylog2/shared/initializers/JerseyService.java
@@ -34,6 +34,7 @@ import org.glassfish.grizzly.ssl.SSLEngineConfigurator;
 import org.glassfish.jersey.grizzly2.httpserver.GrizzlyHttpServerFactory;
 import org.glassfish.jersey.server.ResourceConfig;
 import org.glassfish.jersey.server.ServerProperties;
+import org.glassfish.jersey.server.filter.CsrfProtectionFilter;
 import org.glassfish.jersey.server.model.Resource;
 import org.graylog2.audit.PluginAuditEventTypes;
 import org.graylog2.audit.jersey.AuditEventModelProcessor;
@@ -239,6 +240,7 @@ public class JerseyService extends AbstractIdleService {
                 .register(new PrefixAddingModelProcessor(packagePrefixes))
                 .register(new AuditEventModelProcessor(pluginAuditEventTypes))
                 .registerClasses(
+                        CsrfProtectionFilter.class,
                         JacksonJaxbJsonProvider.class,
                         JsonProcessingExceptionMapper.class,
                         JacksonPropertyExceptionMapper.class,

--- a/graylog2-server/src/main/java/org/graylog2/shared/rest/CORSFilter.java
+++ b/graylog2-server/src/main/java/org/graylog2/shared/rest/CORSFilter.java
@@ -40,7 +40,7 @@ public class CORSFilter implements ContainerRequestFilter, ContainerResponseFilt
         if (origin != null && !origin.isEmpty()) {
             responseContext.getHeaders().add("Access-Control-Allow-Origin", origin);
             responseContext.getHeaders().add("Access-Control-Allow-Credentials", true);
-            responseContext.getHeaders().add("Access-Control-Allow-Headers", "Authorization, Content-Type, X-Graylog-No-Session-Extension, X-Requested-With");
+            responseContext.getHeaders().add("Access-Control-Allow-Headers", "Authorization, Content-Type, X-Graylog-No-Session-Extension, X-Requested-With, X-Requested-By");
             responseContext.getHeaders().add("Access-Control-Allow-Methods", "GET, POST, PUT, DELETE, OPTIONS");
             // In order to avoid redoing the preflight thingy for every request, see http://stackoverflow.com/a/12021982/1088469
             responseContext.getHeaders().add("Access-Control-Max-Age", "600"); // 10 minutes seems to be the maximum allowable value
@@ -57,7 +57,7 @@ public class CORSFilter implements ContainerRequestFilter, ContainerResponseFilt
                 options.header("Access-Control-Allow-Origin", origin);
                 options.header("Access-Control-Allow-Credentials", true);
                 options.header("Access-Control-Allow-Headers",
-                               "Authorization, Content-Type, X-Graylog-No-Session-Extension, X-Requested-With");
+                               "Authorization, Content-Type, X-Graylog-No-Session-Extension, X-Requested-With, X-Requested-By");
                 options.header("Access-Control-Allow-Methods", "GET, POST, PUT, DELETE, OPTIONS");
                 // In order to avoid redoing the preflight thingy for every request, see http://stackoverflow.com/a/12021982/1088469
                 options.header("Access-Control-Max-Age", "600"); // 10 minutes seems to be the maximum allowable value

--- a/graylog2-server/src/main/resources/swagger/index.html.template
+++ b/graylog2-server/src/main/resources/swagger/index.html.template
@@ -56,6 +56,10 @@
     };
     $('#input_apiUser').change(updateApiAuth);
     $('#input_apiPassword').change(updateApiAuth);
+
+    // Add CSRF header
+    window.authorizations.add("csrf", new ApiKeyAuthorization("X-Requested-By", "Graylog API Browser", "header"));
+
     window.swaggerUi.load();
   });
 

--- a/graylog2-web-interface/src/logic/rest/FetchProvider.js
+++ b/graylog2-web-interface/src/logic/rest/FetchProvider.js
@@ -27,7 +27,9 @@ export class FetchError extends Error {
 
 export class Builder {
   constructor(method, url) {
-    this.request = request(method, url.replace(/([^:])\/\//, '$1/')).set('X-Requested-With', 'XMLHttpRequest');
+    this.request = request(method, url.replace(/([^:])\/\//, '$1/'))
+      .set('X-Requested-With', 'XMLHttpRequest')
+      .set('X-Requested-By', 'XMLHttpRequest');
   }
 
   authenticated() {


### PR DESCRIPTION
Improve our protection against CSRF by requiring a custom request header (`X-Requested-By`) in all non-GET requests sent to our API. This is mentioned as a way of CSRF prevention [1] and it is particularly suitable for REST APIs, since let requests to remain stateless.

1: https://www.owasp.org/index.php/Cross-Site_Request_Forgery_(CSRF)_Prevention_Cheat_Sheet#Protecting_REST_Services:_Use_of_Custom_Request_Headers
