### PR TITLE
Store collector commend arguments as string

### DIFF
--- a/graylog2-server/src/main/java/org/graylog/plugins/sidecar/migrations/V20180212165000_AddDefaultCollectors.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/sidecar/migrations/V20180212165000_AddDefaultCollectors.java
@@ -25,9 +25,6 @@ import org.slf4j.LoggerFactory;
 import javax.annotation.Nullable;
 import javax.inject.Inject;
 import java.time.ZonedDateTime;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.List;
 
 public class V20180212165000_AddDefaultCollectors extends Migration {
     private static final Logger LOG = LoggerFactory.getLogger(V20180212165000_AddDefaultCollectors.class);
@@ -52,8 +49,8 @@ public class V20180212165000_AddDefaultCollectors extends Migration {
                 "linux",
                 "/usr/bin/filebeat",
                 "/etc/graylog/collector-sidecar/generated/filebeat.yml",
-                new ArrayList<String>(Arrays.asList("-c",  "%s")),
-                new ArrayList<String>(Arrays.asList("test", "config", "-c", "%s")),
+                "-c  %s",
+                "test config -c %s",
                 ""
         );
         ensureCollector(
@@ -62,8 +59,8 @@ public class V20180212165000_AddDefaultCollectors extends Migration {
                 "windows",
                 "C:\\Program Files\\graylog\\collector-sidecar\\winlogbeat.exe",
                 "C:\\Program Files\\graylog\\collector-sidecar\\generated\\winlogbeat.yml",
-                new ArrayList<String>(Arrays.asList("-c", "%s")),
-                new ArrayList<String>(Arrays.asList("test", "config", "-c", "%s")),
+                "-c %s",
+                "test config -c %s",
                 ""
         );
         ensureCollector(
@@ -72,8 +69,8 @@ public class V20180212165000_AddDefaultCollectors extends Migration {
                 "linux",
                 "/usr/bin/nxlog",
                 "/etc/graylog/collector-sidecar/generated/nxlog.conf",
-                new ArrayList<String>(Arrays.asList("-f", "-c", "%s")),
-                new ArrayList<String>(Arrays.asList("-v", "-c", "%s")),
+                "-f -c %s",
+                "-v -c %s",
                 ""
         );
     }
@@ -84,8 +81,8 @@ public class V20180212165000_AddDefaultCollectors extends Migration {
                                    String nodeOperatingSystem,
                                    String executablePath,
                                    String configurationPath,
-                                   List<String> executeParameters,
-                                   List<String> validationCommand,
+                                   String executeParameters,
+                                   String validationCommand,
                                    String defaultTemplate) {
         Collector collector = null;
         try {

--- a/graylog2-server/src/main/java/org/graylog/plugins/sidecar/rest/models/Collector.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/sidecar/rest/models/Collector.java
@@ -68,7 +68,7 @@ public abstract class Collector {
     public abstract List<String> executeParameters();
 
     @JsonProperty(FIELD_VALIDATION_PARAMETERS)
-    public abstract List<String> validationCommand();
+    public abstract List<String> validationParameters();
 
     @JsonProperty(FIELD_DEFAULT_TEMPLATE)
     public abstract String defaultTemplate();
@@ -88,7 +88,7 @@ public abstract class Collector {
         public abstract Builder executablePath(String executablePath);
         public abstract Builder configurationPath(String configurationPath);
         public abstract Builder executeParameters(List<String> executeParameters);
-        public abstract Builder validationCommand(List<String> validationCommand);
+        public abstract Builder validationParameters(List<String> validationParameters);
         public abstract Builder defaultTemplate(String defaultTemplate);
         public abstract Collector build();
     }
@@ -101,7 +101,7 @@ public abstract class Collector {
                                    @JsonProperty(FIELD_EXECUTABLE_PATH) String executablePath,
                                    @JsonProperty(FIELD_CONFIGURATION_PATH) String configurationPath,
                                    @JsonProperty(FIELD_EXECUTE_PARAMETERS) @Nullable List<String> executeParameters,
-                                   @JsonProperty(FIELD_VALIDATION_PARAMETERS) @Nullable List<String> validationCommand,
+                                   @JsonProperty(FIELD_VALIDATION_PARAMETERS) @Nullable List<String> validationParameters,
                                    @JsonProperty(FIELD_DEFAULT_TEMPLATE) String defaultTemplate) {
         return builder()
                 .id(id)
@@ -111,7 +111,7 @@ public abstract class Collector {
                 .executablePath(executablePath)
                 .configurationPath(configurationPath)
                 .executeParameters(firstNonNull(executeParameters, new ArrayList<>()))
-                .validationCommand(firstNonNull(validationCommand, new ArrayList<>()))
+                .validationParameters(firstNonNull(validationParameters, new ArrayList<>()))
                 .defaultTemplate(defaultTemplate)
                 .build();
     }

--- a/graylog2-server/src/main/java/org/graylog/plugins/sidecar/rest/models/Collector.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/sidecar/rest/models/Collector.java
@@ -24,10 +24,6 @@ import org.mongojack.Id;
 import org.mongojack.ObjectId;
 
 import javax.annotation.Nullable;
-import java.util.ArrayList;
-import java.util.List;
-
-import static org.apache.commons.lang3.ObjectUtils.firstNonNull;
 
 @AutoValue
 @JsonAutoDetect
@@ -65,10 +61,10 @@ public abstract class Collector {
     public abstract String configurationPath();
 
     @JsonProperty(FIELD_EXECUTE_PARAMETERS)
-    public abstract List<String> executeParameters();
+    public abstract String executeParameters();
 
     @JsonProperty(FIELD_VALIDATION_PARAMETERS)
-    public abstract List<String> validationParameters();
+    public abstract String validationParameters();
 
     @JsonProperty(FIELD_DEFAULT_TEMPLATE)
     public abstract String defaultTemplate();
@@ -87,8 +83,8 @@ public abstract class Collector {
         public abstract Builder nodeOperatingSystem(String nodeOperatingSystem);
         public abstract Builder executablePath(String executablePath);
         public abstract Builder configurationPath(String configurationPath);
-        public abstract Builder executeParameters(List<String> executeParameters);
-        public abstract Builder validationParameters(List<String> validationParameters);
+        public abstract Builder executeParameters(String executeParameters);
+        public abstract Builder validationParameters(String validationParameters);
         public abstract Builder defaultTemplate(String defaultTemplate);
         public abstract Collector build();
     }
@@ -100,8 +96,8 @@ public abstract class Collector {
                                    @JsonProperty(FIELD_NODE_OPERATING_SYSTEM) String nodeOperatingSystem,
                                    @JsonProperty(FIELD_EXECUTABLE_PATH) String executablePath,
                                    @JsonProperty(FIELD_CONFIGURATION_PATH) String configurationPath,
-                                   @JsonProperty(FIELD_EXECUTE_PARAMETERS) @Nullable List<String> executeParameters,
-                                   @JsonProperty(FIELD_VALIDATION_PARAMETERS) @Nullable List<String> validationParameters,
+                                   @JsonProperty(FIELD_EXECUTE_PARAMETERS) @Nullable String executeParameters,
+                                   @JsonProperty(FIELD_VALIDATION_PARAMETERS) @Nullable String validationParameters,
                                    @JsonProperty(FIELD_DEFAULT_TEMPLATE) String defaultTemplate) {
         return builder()
                 .id(id)
@@ -110,8 +106,8 @@ public abstract class Collector {
                 .nodeOperatingSystem(nodeOperatingSystem)
                 .executablePath(executablePath)
                 .configurationPath(configurationPath)
-                .executeParameters(firstNonNull(executeParameters, new ArrayList<>()))
-                .validationParameters(firstNonNull(validationParameters, new ArrayList<>()))
+                .executeParameters(executeParameters)
+                .validationParameters(validationParameters)
                 .defaultTemplate(defaultTemplate)
                 .build();
     }

--- a/graylog2-server/src/main/java/org/graylog/plugins/sidecar/services/CollectorService.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/sidecar/services/CollectorService.java
@@ -83,7 +83,7 @@ public class CollectorService extends PaginatedDbService<Collector> {
                 request.executablePath(),
                 request.configurationPath(),
                 request.executeParameters(),
-                request.validationCommand(),
+                request.validationParameters(),
                 request.defaultTemplate());
     }
 

--- a/graylog2-server/src/main/java/org/graylog2/contentpacks/facades/CollectorFacade.java
+++ b/graylog2-server/src/main/java/org/graylog2/contentpacks/facades/CollectorFacade.java
@@ -36,7 +36,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import javax.inject.Inject;
-import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
@@ -60,21 +59,14 @@ public class CollectorFacade implements EntityFacade<Collector> {
 
     @Override
     public EntityWithConstraints exportNativeEntity(Collector collector) {
-        final List<ValueReference> executeParameters = collector.executeParameters().stream()
-                .map(ValueReference::of)
-                .collect(Collectors.toList());
-        final List<ValueReference> validationCommand = collector.validationParameters().stream()
-                .map(ValueReference::of)
-                .collect(Collectors.toList());
-
         final CollectorEntity collectorEntity = CollectorEntity.create(
                 ValueReference.of(collector.name()),
                 ValueReference.of(collector.serviceType()),
                 ValueReference.of(collector.nodeOperatingSystem()),
                 ValueReference.of(collector.executablePath()),
                 ValueReference.of(collector.configurationPath()),
-                executeParameters,
-                validationCommand,
+                ValueReference.of(collector.executeParameters()),
+                ValueReference.of(collector.validationParameters()),
                 ValueReference.of(collector.defaultTemplate())
         );
 
@@ -102,21 +94,14 @@ public class CollectorFacade implements EntityFacade<Collector> {
     private NativeEntity<Collector> decode(EntityV1 entity, Map<String, ValueReference> parameters) {
         final CollectorEntity collectorEntity = objectMapper.convertValue(entity.data(), CollectorEntity.class);
 
-        final List<String> executeParameters = collectorEntity.executeParameters().stream()
-                .map(parameter -> parameter.asString(parameters))
-                .collect(Collectors.toList());
-        final List<String> validationParameters = collectorEntity.validationParameters().stream()
-                .map(parameter -> parameter.asString(parameters))
-                .collect(Collectors.toList());
-
         final Collector collector = Collector.builder()
                 .name(collectorEntity.name().asString(parameters))
                 .serviceType(collectorEntity.serviceType().asString(parameters))
                 .nodeOperatingSystem(collectorEntity.nodeOperatingSystem().asString(parameters))
                 .executablePath(collectorEntity.executablePath().asString(parameters))
                 .configurationPath(collectorEntity.configurationPath().asString(parameters))
-                .executeParameters(executeParameters)
-                .validationParameters(validationParameters)
+                .executeParameters(collectorEntity.executeParameters().asString(parameters))
+                .validationParameters(collectorEntity.validationParameters().asString(parameters))
                 .defaultTemplate(collectorEntity.defaultTemplate().asString(parameters))
                 .build();
 

--- a/graylog2-server/src/main/java/org/graylog2/contentpacks/facades/CollectorFacade.java
+++ b/graylog2-server/src/main/java/org/graylog2/contentpacks/facades/CollectorFacade.java
@@ -63,7 +63,7 @@ public class CollectorFacade implements EntityFacade<Collector> {
         final List<ValueReference> executeParameters = collector.executeParameters().stream()
                 .map(ValueReference::of)
                 .collect(Collectors.toList());
-        final List<ValueReference> validationCommand = collector.validationCommand().stream()
+        final List<ValueReference> validationCommand = collector.validationParameters().stream()
                 .map(ValueReference::of)
                 .collect(Collectors.toList());
 
@@ -105,7 +105,7 @@ public class CollectorFacade implements EntityFacade<Collector> {
         final List<String> executeParameters = collectorEntity.executeParameters().stream()
                 .map(parameter -> parameter.asString(parameters))
                 .collect(Collectors.toList());
-        final List<String> validationCommand = collectorEntity.validationCommand().stream()
+        final List<String> validationParameters = collectorEntity.validationParameters().stream()
                 .map(parameter -> parameter.asString(parameters))
                 .collect(Collectors.toList());
 
@@ -116,7 +116,7 @@ public class CollectorFacade implements EntityFacade<Collector> {
                 .executablePath(collectorEntity.executablePath().asString(parameters))
                 .configurationPath(collectorEntity.configurationPath().asString(parameters))
                 .executeParameters(executeParameters)
-                .validationCommand(validationCommand)
+                .validationParameters(validationParameters)
                 .defaultTemplate(collectorEntity.defaultTemplate().asString(parameters))
                 .build();
 

--- a/graylog2-server/src/main/java/org/graylog2/contentpacks/model/entities/CollectorEntity.java
+++ b/graylog2-server/src/main/java/org/graylog2/contentpacks/model/entities/CollectorEntity.java
@@ -47,8 +47,8 @@ public abstract class CollectorEntity {
     @JsonProperty("execute_parameters")
     public abstract List<ValueReference> executeParameters();
 
-    @JsonProperty("validation_command")
-    public abstract List<ValueReference> validationCommand();
+    @JsonProperty("validation_parameters")
+    public abstract List<ValueReference> validationParameters();
 
     @JsonProperty("default_template")
     public abstract ValueReference defaultTemplate();
@@ -60,7 +60,7 @@ public abstract class CollectorEntity {
                                          @JsonProperty("executable_path") ValueReference executablePath,
                                          @JsonProperty("configuration_path") ValueReference configurationPath,
                                          @JsonProperty("execute_parameters") List<ValueReference> executeParameters,
-                                         @JsonProperty("validation_command") List<ValueReference> validationCommand,
+                                         @JsonProperty("validation_parameters") List<ValueReference> validationParameters,
                                          @JsonProperty("default_template") ValueReference defaultTemplate) {
         return new AutoValue_CollectorEntity(name,
                 serviceType,
@@ -68,7 +68,7 @@ public abstract class CollectorEntity {
                 executablePath,
                 configurationPath,
                 executeParameters,
-                validationCommand,
+                validationParameters,
                 defaultTemplate);
     }
 }

--- a/graylog2-server/src/main/java/org/graylog2/contentpacks/model/entities/CollectorEntity.java
+++ b/graylog2-server/src/main/java/org/graylog2/contentpacks/model/entities/CollectorEntity.java
@@ -45,10 +45,10 @@ public abstract class CollectorEntity {
     public abstract ValueReference configurationPath();
 
     @JsonProperty("execute_parameters")
-    public abstract List<ValueReference> executeParameters();
+    public abstract ValueReference executeParameters();
 
     @JsonProperty("validation_parameters")
-    public abstract List<ValueReference> validationParameters();
+    public abstract ValueReference validationParameters();
 
     @JsonProperty("default_template")
     public abstract ValueReference defaultTemplate();
@@ -59,8 +59,8 @@ public abstract class CollectorEntity {
                                          @JsonProperty("node_operating_system") ValueReference nodeOperatingSystem,
                                          @JsonProperty("executable_path") ValueReference executablePath,
                                          @JsonProperty("configuration_path") ValueReference configurationPath,
-                                         @JsonProperty("execute_parameters") List<ValueReference> executeParameters,
-                                         @JsonProperty("validation_parameters") List<ValueReference> validationParameters,
+                                         @JsonProperty("execute_parameters") ValueReference executeParameters,
+                                         @JsonProperty("validation_parameters") ValueReference validationParameters,
                                          @JsonProperty("default_template") ValueReference defaultTemplate) {
         return new AutoValue_CollectorEntity(name,
                 serviceType,

--- a/graylog2-server/src/test/java/org/graylog2/contentpacks/facades/CollectorFacadeTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/contentpacks/facades/CollectorFacadeTest.java
@@ -43,7 +43,6 @@ import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
 
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.Set;
 
@@ -84,12 +83,8 @@ public class CollectorFacadeTest {
                         ValueReference.of("linux"),
                         ValueReference.of("/usr/bin/filebeat"),
                         ValueReference.of("/etc/graylog/collector-sidecar/generated/filebeat.yml"),
-                        Arrays.asList(ValueReference.of("-c"), ValueReference.of("%s")),
-                        Arrays.asList(
-                                ValueReference.of("test"),
-                                ValueReference.of("config"),
-                                ValueReference.of("-c"),
-                                ValueReference.of("%s")),
+                        ValueReference.of("-c %s"),
+                        ValueReference.of("test config -c %s"),
                         ValueReference.of("")), JsonNode.class))
                 .build();
         assertThat(entityWithConstraints.entity()).isEqualTo(expectedEntity);
@@ -111,12 +106,8 @@ public class CollectorFacadeTest {
                         ValueReference.of("linux"),
                         ValueReference.of("/usr/bin/filebeat"),
                         ValueReference.of("/etc/graylog/collector-sidecar/generated/filebeat.yml"),
-                        Arrays.asList(ValueReference.of("-c"), ValueReference.of("%s")),
-                        Arrays.asList(
-                                ValueReference.of("test"),
-                                ValueReference.of("config"),
-                                ValueReference.of("-c"),
-                                ValueReference.of("%s")),
+                        ValueReference.of("-c %s"),
+                        ValueReference.of("test config -c %s"),
                         ValueReference.of("")), JsonNode.class))
                 .build();
         assertThat(entityWithConstraints.entity()).isEqualTo(expectedEntity);
@@ -134,12 +125,8 @@ public class CollectorFacadeTest {
                         ValueReference.of("linux"),
                         ValueReference.of("/usr/bin/filebeat"),
                         ValueReference.of("/etc/graylog/collector-sidecar/generated/filebeat.yml"),
-                        Arrays.asList(ValueReference.of("-c"), ValueReference.of("%s")),
-                        Arrays.asList(
-                                ValueReference.of("test"),
-                                ValueReference.of("config"),
-                                ValueReference.of("-c"),
-                                ValueReference.of("%s")),
+                        ValueReference.of("-c %s"),
+                        ValueReference.of("test config -c %s"),
                         ValueReference.of("")), JsonNode.class))
                 .build();
 
@@ -168,12 +155,8 @@ public class CollectorFacadeTest {
                         ValueReference.of("linux"),
                         ValueReference.of("/usr/bin/filebeat"),
                         ValueReference.of("/etc/graylog/collector-sidecar/generated/filebeat.yml"),
-                        Arrays.asList(ValueReference.of("-c"), ValueReference.of("%s")),
-                        Arrays.asList(
-                                ValueReference.of("test"),
-                                ValueReference.of("config"),
-                                ValueReference.of("-c"),
-                                ValueReference.of("%s")),
+                        ValueReference.of("-c %s"),
+                        ValueReference.of("test config -c %s"),
                         ValueReference.of("")), JsonNode.class))
                 .build();
 
@@ -252,12 +235,8 @@ public class CollectorFacadeTest {
                         ValueReference.of("linux"),
                         ValueReference.of("/usr/bin/filebeat"),
                         ValueReference.of("/etc/graylog/collector-sidecar/generated/filebeat.yml"),
-                        Arrays.asList(ValueReference.of("-c"), ValueReference.of("%s")),
-                        Arrays.asList(
-                                ValueReference.of("test"),
-                                ValueReference.of("config"),
-                                ValueReference.of("-c"),
-                                ValueReference.of("%s")),
+                        ValueReference.of("-c %s"),
+                        ValueReference.of("test config -c %s"),
                         ValueReference.of("")), JsonNode.class))
                 .build();
 

--- a/graylog2-server/src/test/resources/org/graylog2/contentpacks/sidecar_collectors.json
+++ b/graylog2-server/src/test/resources/org/graylog2/contentpacks/sidecar_collectors.json
@@ -9,16 +9,8 @@
       "node_operating_system": "linux",
       "executable_path": "/usr/bin/filebeat",
       "configuration_path": "/etc/graylog/collector-sidecar/generated/filebeat.yml",
-      "execute_parameters": [
-        "-c",
-        "%s"
-      ],
-      "validation_parameters": [
-        "test",
-        "config",
-        "-c",
-        "%s"
-      ],
+      "execute_parameters": "-c %s",
+      "validation_parameters": "test config -c %s",
       "default_template": ""
     },
     {
@@ -30,16 +22,8 @@
       "node_operating_system": "windows",
       "executable_path": "C:\\Program Files\\graylog\\collector-sidecar\\winlogbeat.exe",
       "configuration_path": "C:\\Program Files\\graylog\\collector-sidecar\\generated\\winlogbeat.yml",
-      "execute_parameters": [
-        "-c",
-        "%s"
-      ],
-      "validation_parameters": [
-        "test",
-        "config",
-        "-c",
-        "%s"
-      ],
+      "execute_parameters": "-c %s",
+      "validation_parameters": "test config -c %s",
       "default_template": ""
     },
     {
@@ -51,16 +35,8 @@
       "node_operating_system": "linux",
       "executable_path": "/usr/bin/nxlog",
       "configuration_path": "/etc/graylog/collector-sidecar/generated/nxlog.conf",
-      "execute_parameters": [
-        "-f",
-        "-c",
-        "%s"
-      ],
-      "validation_parameters": [
-        "-v",
-        "-c",
-        "%s"
-      ],
+      "execute_parameters": "-f -c %s",
+      "validation_parameters": "-v -c %s",
       "default_template": ""
     }
   ]

--- a/graylog2-web-interface/src/components/sidecars/configuration-forms/CollectorForm.jsx
+++ b/graylog2-web-interface/src/components/sidecars/configuration-forms/CollectorForm.jsx
@@ -94,12 +94,6 @@ const CollectorForm = createReactClass({
     };
   },
 
-  _onListInputChange(key) {
-    return (event) => {
-      this._formDataUpdate(key)(event.target.value.split(' '));
-    };
-  },
-
   _onSubmit(event) {
     event.preventDefault();
     this._save();
@@ -129,10 +123,10 @@ const CollectorForm = createReactClass({
     let validationParameters = '';
     let executeParameters = '';
     if (this.state.formData.validation_parameters) {
-      validationParameters = this.state.formData.validation_parameters.join(' ');
+      validationParameters = this.state.formData.validation_parameters;
     }
     if (this.state.formData.execute_parameters) {
-      executeParameters = this.state.formData.execute_parameters.join(' ');
+      executeParameters = this.state.formData.execute_parameters;
     }
     return (
       <div>
@@ -189,14 +183,14 @@ const CollectorForm = createReactClass({
             <Input type="text"
                    id="executeParameters"
                    label="Execute Parameters"
-                   onChange={this._onListInputChange('execute_parameters')}
+                   onChange={this._onInputChange('execute_parameters')}
                    help="Parameters the collector is started with. %s will be replaced by the path to the configuration file."
                    value={executeParameters} />
 
             <Input type="text"
                    id="validationParameters"
                    label="Parameters for Configuration Validation"
-                   onChange={this._onListInputChange('validation_parameters')}
+                   onChange={this._onInputChange('validation_parameters')}
                    help="Parameters that validate the configuration file. %s will be replaced by the path to the configuration file."
                    value={validationParameters} />
 

--- a/graylog2-web-interface/src/components/sidecars/configuration-forms/CollectorForm.jsx
+++ b/graylog2-web-interface/src/components/sidecars/configuration-forms/CollectorForm.jsx
@@ -18,12 +18,13 @@ const { CollectorConfigurationsActions } = CombinedProvider.get('CollectorConfig
 
 const CollectorForm = createReactClass({
   displayName: 'CollectorForm',
-  mixins: [Reflux.connect(CollectorsStore)],
 
   propTypes: {
     action: PropTypes.oneOf(['create', 'edit']),
     collector: PropTypes.object,
   },
+
+  mixins: [Reflux.connect(CollectorsStore)],
 
   getDefaultProps() {
     return {

--- a/graylog2-web-interface/src/components/sidecars/configuration-forms/ConfigurationForm.jsx
+++ b/graylog2-web-interface/src/components/sidecars/configuration-forms/ConfigurationForm.jsx
@@ -9,22 +9,23 @@ import { ColorPickerPopover, Select, SourceCodeEditor } from 'components/common'
 import { Input } from 'components/bootstrap';
 import history from 'util/History';
 import Routes from 'routing/Routes';
-
-import CombinedProvider from 'injection/CombinedProvider';
-import SourceViewModal from './SourceViewModal';
 import ColorLabel from 'components/sidecars/common/ColorLabel';
+import CombinedProvider from 'injection/CombinedProvider';
+
+import SourceViewModal from './SourceViewModal';
 
 const { CollectorsStore, CollectorsActions } = CombinedProvider.get('Collectors');
 const { CollectorConfigurationsActions } = CombinedProvider.get('CollectorConfigurations');
 
 const ConfigurationForm = createReactClass({
   displayName: 'ConfigurationForm',
-  mixins: [Reflux.connect(CollectorsStore)],
 
   propTypes: {
     action: PropTypes.oneOf(['create', 'edit']),
     configuration: PropTypes.object,
   },
+
+  mixins: [Reflux.connect(CollectorsStore)],
 
   getDefaultProps() {
     return {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Currently we store the command arguments of a collector as a list of strings. This can lead to problems like described in #4889. This PR is changing the model in a way that it stores the argument as a simple string. The arguments need to be split up on the Sidecar side afterwards so this work depends  on https://github.com/Graylog2/collector-sidecar/pull/273

Fixes #4889 