### PR TITLE
Rename entity_id to content_pack_entity_id

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/contentpacks/model/entities/NativeEntityDescriptor.java
+++ b/graylog2-server/src/main/java/org/graylog2/contentpacks/model/entities/NativeEntityDescriptor.java
@@ -30,14 +30,14 @@ import org.graylog2.contentpacks.model.Typed;
 @AutoValue
 @JsonDeserialize(builder = AutoValue_NativeEntityDescriptor.Builder.class)
 public abstract class NativeEntityDescriptor implements Identified, Typed {
-    public static final String FIELD_ENTITY_ID = "entity_id";
+    public static final String FIELD_ENTITY_ID = "content_pack_entity_id";
 
     @JsonProperty(FIELD_ENTITY_ID)
-    public abstract ModelId entityId();
+    public abstract ModelId contentPackEntityId();
 
-    public static NativeEntityDescriptor create(ModelId entityId, ModelId id, ModelType type) {
+    public static NativeEntityDescriptor create(ModelId contentPackEntityId, ModelId id, ModelType type) {
         return builder()
-                .entityId(entityId)
+                .contentPackEntityId(contentPackEntityId)
                 .id(id)
                 .type(type)
                 .build();
@@ -46,12 +46,12 @@ public abstract class NativeEntityDescriptor implements Identified, Typed {
     /**
      * Shortcut for {@link #create(String, String, ModelType)}
      */
-    public static NativeEntityDescriptor create(String entityId, String nativeId, ModelType type) {
-        return create(ModelId.of(entityId), ModelId.of(nativeId), type);
+    public static NativeEntityDescriptor create(String contentPackEntityId, String nativeId, ModelType type) {
+        return create(ModelId.of(contentPackEntityId), ModelId.of(nativeId), type);
     }
 
-    public static NativeEntityDescriptor create(ModelId entityId, String nativeId, ModelType type) {
-        return create(entityId, ModelId.of(nativeId), type);
+    public static NativeEntityDescriptor create(ModelId contentPackEntityId, String nativeId, ModelType type) {
+        return create(contentPackEntityId, ModelId.of(nativeId), type);
     }
 
     public static Builder builder() {
@@ -62,7 +62,7 @@ public abstract class NativeEntityDescriptor implements Identified, Typed {
     public abstract static class Builder implements IdBuilder<Builder>, TypeBuilder<Builder> {
 
         @JsonProperty(FIELD_ENTITY_ID)
-        abstract Builder entityId(ModelId entityId);
+        abstract Builder contentPackEntityId(ModelId contentPackEntityId);
 
         public abstract NativeEntityDescriptor build();
     }

--- a/graylog2-server/src/test/resources/org/graylog2/contentpacks/ContentPackInstallationPersistenceServiceTest.json
+++ b/graylog2-server/src/test/resources/org/graylog2/contentpacks/ContentPackInstallationPersistenceServiceTest.json
@@ -23,7 +23,7 @@
             "name": "collector",
             "version": "1"
           },
-          "entity_id": "5b1a49eb3d274631fe07c86a"
+          "content_pack_entity_id": "5b1a49eb3d274631fe07c86a"
         },
         {
           "id": "5b4c920b4b900a0024af2b5c",
@@ -31,7 +31,7 @@
             "name": "collector",
             "version": "1"
           },
-          "entity_id": "5b1a49eb3d274631fe07beff"
+          "content_pack_entity_id": "5b1a49eb3d274631fe07beff"
         },
         {
           "id": "5b4c920b4b900a0024af2b5b",
@@ -39,7 +39,7 @@
             "name": "collector",
             "version": "1"
           },
-          "entity_id": "5b1a49eb3d274631fe07abfe"
+          "content_pack_entity_id": "5b1a49eb3d274631fe07abfe"
         }
       ],
       "comment": "comment1",
@@ -65,7 +65,7 @@
             "name": "dashboard",
             "version": "1"
           },
-          "entity_id": "beef49eb3d274631fe07abfe"
+          "content_pack_entity_id": "beef49eb3d274631fe07abfe"
         },
         {
           "id": "5b4c935b4b900a0062b7dc19",
@@ -73,7 +73,7 @@
             "name": "grok_pattern",
             "version": "1"
           },
-          "entity_id": "bee149eb3d274631fe07abfe"
+          "content_pack_entity_id": "bee149eb3d274631fe07abfe"
         },
         {
           "id": "5b4c935b4b900a0062b7dc1b",
@@ -81,7 +81,7 @@
             "name": "input",
             "version": "1"
           },
-          "entity_id": "bee249eb3d274631fe07abfe"
+          "content_pack_entity_id": "bee249eb3d274631fe07abfe"
         },
         {
           "id": "5b4c935b4b900a0062b7dc1f",
@@ -89,7 +89,7 @@
             "name": "output",
             "version": "1"
           },
-          "entity_id": "bee349eb3d274631fe07abfe"
+          "content_pack_entity_id": "bee349eb3d274631fe07abfe"
         },
         {
           "id": "5b4c935b4b900a0062b7dc20",
@@ -97,7 +97,7 @@
             "name": "stream",
             "version": "1"
           },
-          "entity_id": "bee449eb3d274631fe07abfe"
+          "content_pack_entity_id": "bee449eb3d274631fe07abfe"
         }
       ],
       "comment": "comment2",
@@ -123,7 +123,7 @@
             "name": "pipeline_rule",
             "version": "1"
           },
-          "entity_id": "bee549eb3d274631fe07abfe"
+          "content_pack_entity_id": "bee549eb3d274631fe07abfe"
         },
         {
           "id": "5b4c935b4b900a0062b7dc0b",
@@ -131,7 +131,7 @@
             "name": "pipeline",
             "version": "1"
           },
-          "entity_id": "bee649eb3d274631fe07abfe"
+          "content_pack_entity_id": "bee649eb3d274631fe07abfe"
         },
         {
           "id": "cp_lookup",
@@ -139,7 +139,7 @@
             "name": "lookup_adapter",
             "version": "1"
           },
-          "entity_id": "bee749eb3d274631fe07abfe"
+          "content_pack_entity_id": "bee749eb3d274631fe07abfe"
         },
         {
           "id": "cp_lookup",
@@ -147,7 +147,7 @@
             "name": "lookup_cache",
             "version": "1"
           },
-          "entity_id": "bee849eb3d274631fe07abfe"
+          "content_pack_entity_id": "bee849eb3d274631fe07abfe"
         },
         {
           "id": "5b4c935b4b900a0062b7dc14",
@@ -155,7 +155,7 @@
             "name": "lookup_table",
             "version": "1"
           },
-          "entity_id": "bee949eb3d274631fe07abfe"
+          "content_pack_entity_id": "bee949eb3d274631fe07abfe"
         }
       ],
       "comment": "comment3",


### PR DESCRIPTION

## Description
To clarify which id is which I rename entity_id to content_pack_entity_id
in NativeEntityDescriptor.

## Motivation and Context
 That way the entity_id from the content pack is
marked.


## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
