### PR TITLE
Show warning if configured journal size does not fit on disk

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/notifications/Notification.java
+++ b/graylog2-server/src/main/java/org/graylog2/notifications/Notification.java
@@ -62,7 +62,8 @@ public interface Notification extends Persisted {
         JOURNAL_UNCOMMITTED_MESSAGES_DELETED,
         OUTPUT_DISABLED,
         INDEX_RANGES_RECALCULATION,
-        GENERIC
+        GENERIC,
+        JOURNAL_WONT_FIT_IN_PARTITION
     }
 
     enum Severity {

--- a/graylog2-server/src/main/java/org/graylog2/periodical/ThrottleStateUpdaterThread.java
+++ b/graylog2-server/src/main/java/org/graylog2/periodical/ThrottleStateUpdaterThread.java
@@ -254,5 +254,13 @@ public class ThrottleStateUpdaterThread extends Periodical {
                     .addSeverity(Notification.Severity.URGENT);
             notificationService.publishIfFirst(notification);
         }
+
+        if (!journal.journalFileFitsInPartition()) {
+            Notification notification = notificationService.buildNow()
+                    .addNode(serverStatus.getNodeId().toString())
+                    .addType(Notification.Type.JOURNAL_WONT_FIT_IN_PARTITION)
+                    .addSeverity(Notification.Severity.URGENT);
+            notificationService.publishIfFirst(notification);
+        }
     }
 }

--- a/graylog2-server/src/main/java/org/graylog2/shared/journal/KafkaJournal.java
+++ b/graylog2-server/src/main/java/org/graylog2/shared/journal/KafkaJournal.java
@@ -369,6 +369,14 @@ public class KafkaJournal extends AbstractIdleService implements Journal {
             throw new RuntimeException(e);
         }
 
+        if (!journalFileFitsInPartition()) {
+            LOG.warn("Journal file won't fit in partition");
+        }
+    }
+
+    public boolean journalFileFitsInPartition()
+    {
+        return kafkaLog.dir().getUsableSpace() - (kafkaLog.config().retentionSize() - kafkaLog.size()) > 0;
     }
 
     /**

--- a/graylog2-web-interface/src/logic/notifications/NotificationsFactory.js
+++ b/graylog2-web-interface/src/logic/notifications/NotificationsFactory.js
@@ -150,6 +150,17 @@ class NotificationsFactory {
             </span>
           ),
         };
+      case 'journal_wont_fit_in_partition':
+        return {
+          title: 'Journal file won\'t fit in partition',
+          description: (
+            <span>
+              Journal file max size value is higher than free space in the partition. Root causes may be other files
+              in the same partition growing up (logs...) or the partition being too small.
+              (Node: <em>{notification.node_id}</em>)
+            </span>
+          ),
+        };
       case 'multi_master':
         return {
           title: 'Multiple Graylog server masters in the cluster',


### PR DESCRIPTION
## Description
Logs and shows a notification if the journal file can't fit in the partition (partition too small, or other files filling up the disk)

## Motivation and Context
Fixes #4933 

## How Has This Been Tested?
Configuring an small partition for the journal file and setting the journal file to almost the full size of the partition. Then moving some other files to the partition (making imposible to reach the journal max file without getting out of space) will trigger the notification.
If restarting graylog with these changes, it will also log a warning during start.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
