### PR TITLE
Improve entity consistency in sidecar

### DIFF
--- a/graylog2-server/src/main/java/org/graylog/plugins/sidecar/rest/resources/ConfigurationResource.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/sidecar/rest/resources/ConfigurationResource.java
@@ -79,7 +79,7 @@ public class ConfigurationResource extends RestResource implements PluginRestRes
     private final SearchQueryParser searchQueryParser;
     private static final ImmutableMap<String, SearchQueryField> SEARCH_FIELD_MAPPING = ImmutableMap.<String, SearchQueryField>builder()
             .put("id", SearchQueryField.create(Configuration.FIELD_ID))
-            .put("backend_id", SearchQueryField.create(Configuration.FIELD_COLLECTOR_ID))
+            .put("collector_id", SearchQueryField.create(Configuration.FIELD_COLLECTOR_ID))
             .put("name", SearchQueryField.create(Configuration.FIELD_NAME))
             .build();
 
@@ -103,7 +103,7 @@ public class ConfigurationResource extends RestResource implements PluginRestRes
                                                         @ApiParam(name = "sort",
                                                                          value = "The field to sort the result on",
                                                                          required = true,
-                                                                         allowableValues = "name,id,backend_id")
+                                                                         allowableValues = "name,id,collector_id")
                                                                      @DefaultValue(Configuration.FIELD_NAME) @QueryParam("sort") String sort,
                                                         @ApiParam(name = "order", value = "The sort direction", allowableValues = "asc, desc")
                                                                      @DefaultValue("asc") @QueryParam("order") String order) {

--- a/graylog2-server/src/main/java/org/graylog/plugins/sidecar/rest/responses/ConfigurationSidecarsResponse.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/sidecar/rest/responses/ConfigurationSidecarsResponse.java
@@ -1,3 +1,19 @@
+/**
+ * This file is part of Graylog.
+ *
+ * Graylog is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package org.graylog.plugins.sidecar.rest.responses;
 
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/graylog2-server/src/main/java/org/graylog/plugins/sidecar/rest/responses/ConfigurationSidecarsResponse.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/sidecar/rest/responses/ConfigurationSidecarsResponse.java
@@ -1,0 +1,23 @@
+package org.graylog.plugins.sidecar.rest.responses;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.auto.value.AutoValue;
+
+import java.util.Collection;
+
+@AutoValue
+public abstract class ConfigurationSidecarsResponse {
+    @JsonProperty("configuration_id")
+    public abstract String configurationId();
+
+    @JsonProperty("sidecar_ids")
+    public abstract Collection<String> sidecarIds();
+
+    @JsonCreator
+    public static ConfigurationSidecarsResponse create(@JsonProperty("configuration_id") String configurationId,
+                                                       @JsonProperty("sidecar_ids") Collection<String> sidecarIds) {
+        return new AutoValue_ConfigurationSidecarsResponse(configurationId, sidecarIds);
+    }
+
+}

--- a/graylog2-web-interface/src/actions/sidecars/CollectorConfigurationsActions.js
+++ b/graylog2-web-interface/src/actions/sidecars/CollectorConfigurationsActions.js
@@ -4,6 +4,7 @@ const CollectorConfigurationsActions = Reflux.createActions({
   all: { asyncResult: true },
   list: { asyncResult: true },
   getConfiguration: { asyncResult: true },
+  getConfigurationSidecars: { asyncResult: true },
   createConfiguration: { asyncResult: true },
   updateConfiguration: { asyncResult: true },
   renderPreview: { asyncResult: true },

--- a/graylog2-web-interface/src/components/sidecars/configuration-forms/ConfigurationForm.jsx
+++ b/graylog2-web-interface/src/components/sidecars/configuration-forms/ConfigurationForm.jsx
@@ -3,7 +3,7 @@ import React from 'react';
 import createReactClass from 'create-react-class';
 import Reflux from 'reflux';
 import lodash from 'lodash';
-import { Button, ButtonToolbar, Col, ControlLabel, FormGroup, HelpBlock, Row } from 'react-bootstrap';
+import { Button, ButtonToolbar, Col, ControlLabel, FormControl, FormGroup, HelpBlock, Row } from 'react-bootstrap';
 
 import { ColorPickerPopover, Select, SourceCodeEditor } from 'components/common';
 import { Input } from 'components/bootstrap';

--- a/graylog2-web-interface/src/components/sidecars/configuration-forms/ConfigurationForm.jsx
+++ b/graylog2-web-interface/src/components/sidecars/configuration-forms/ConfigurationForm.jsx
@@ -148,7 +148,7 @@ const ConfigurationForm = createReactClass({
           <FormControl.Static>{this._formatCollector(collector)}</FormControl.Static>
           <HelpBlock bsClass="warning">
             <b>Note:</b> Log Collector cannot change while the Configuration is in use. Clone the Configuration
-            for testing it with a new Collector.
+            to test it using another Collector.
           </HelpBlock>
         </span>
       );

--- a/graylog2-web-interface/src/logic/rest/FetchProvider.js
+++ b/graylog2-web-interface/src/logic/rest/FetchProvider.js
@@ -14,6 +14,8 @@ export class FetchError extends Error {
     this.message = message || (additional.message || 'Undefined error.');
     /* eslint-disable no-console */
     try {
+      this.responseMessage = additional.body ? additional.body.message : undefined;
+
       console.error(`There was an error fetching a resource: ${this.message}.`,
         `Additional information: ${additional.body && additional.body.message ? additional.body.message : 'Not available'}`);
     } catch (e) {
@@ -22,6 +24,7 @@ export class FetchError extends Error {
     /* eslint-enable no-console */
 
     this.additional = additional;
+    this.status = additional.status; // Shortcut, as this is often used
   }
 }
 

--- a/graylog2-web-interface/src/pages/SidecarEditConfigurationPage.jsx
+++ b/graylog2-web-interface/src/pages/SidecarEditConfigurationPage.jsx
@@ -38,11 +38,17 @@ const SidecarEditConfigurationPage = createReactClass({
   style: require('!style/useable!css!components/sidecars/styles/SidecarStyles.css'),
 
   _reloadConfiguration() {
-    CollectorConfigurationsActions.getConfiguration(this.props.params.configurationId).then(this._setConfiguration);
+    const configurationId = this.props.params.configurationId;
+    CollectorConfigurationsActions.getConfiguration(configurationId).then(this._setConfiguration);
+    CollectorConfigurationsActions.getConfigurationSidecars(configurationId).then(this._setConfigurationSidecars);
   },
 
   _setConfiguration(configuration) {
     this.setState({ configuration });
+  },
+
+  _setConfigurationSidecars(configurationSidecars) {
+    this.setState({ configurationSidecars });
   },
 
   _isLoading() {
@@ -81,7 +87,8 @@ const SidecarEditConfigurationPage = createReactClass({
 
           <Row className="content">
             <Col md={6}>
-              <ConfigurationForm configuration={this.state.configuration} />
+              <ConfigurationForm configuration={this.state.configuration}
+                                 configurationSidecars={this.state.configurationSidecars} />
             </Col>
             <Col md={6}>
               <ConfigurationHelper type="filebeat" />

--- a/graylog2-web-interface/src/pages/SidecarEditConfigurationPage.jsx
+++ b/graylog2-web-interface/src/pages/SidecarEditConfigurationPage.jsx
@@ -27,15 +27,8 @@ const SidecarEditConfigurationPage = createReactClass({
   },
 
   componentDidMount() {
-    this.style.use();
     this._reloadConfiguration();
   },
-
-  componentWillUnmount() {
-    this.style.unuse();
-  },
-
-  style: require('!style/useable!css!components/sidecars/styles/SidecarStyles.css'),
 
   _reloadConfiguration() {
     const configurationId = this.props.params.configurationId;

--- a/graylog2-web-interface/src/stores/sidecars/CollectorConfigurationsStore.js
+++ b/graylog2-web-interface/src/stores/sidecars/CollectorConfigurationsStore.js
@@ -100,6 +100,17 @@ const CollectorConfigurationsStore = Reflux.createStore({
     CollectorConfigurationsActions.getConfiguration.promise(promise);
   },
 
+  getConfigurationSidecars(configurationId) {
+    const promise = fetch('GET', URLUtils.qualifyUrl(`${this.sourceUrl}/configurations/${configurationId}/sidecars`));
+    promise
+      .catch(
+        (error) => {
+          UserNotification.error(`Fetching Sidecars for Configuration failed with status: ${error}`,
+            'Could not retrieve Sidecars for Configuration');
+        });
+    CollectorConfigurationsActions.getConfigurationSidecars.promise(promise);
+  },
+
   renderPreview(template) {
     const requestTemplate = {
       template: template,
@@ -145,8 +156,8 @@ const CollectorConfigurationsStore = Reflux.createStore({
         this.refreshList();
         return response;
       }, (error) => {
-        UserNotification.error(`Updating configuration failed with status: ${error.message}`,
-          'Could not update configuration');
+        UserNotification.error(`Updating Configuration failed: ${error.status === 400 ? error.responseMessage : error.message}`,
+          `Could not update Configuration ${configuration.name}`);
       });
 
     CollectorConfigurationsActions.updateConfiguration.promise(promise);

--- a/graylog2-web-interface/src/stores/sidecars/CollectorConfigurationsStore.js
+++ b/graylog2-web-interface/src/stores/sidecars/CollectorConfigurationsStore.js
@@ -179,8 +179,8 @@ const CollectorConfigurationsStore = Reflux.createStore({
         this.refreshList();
         return response;
       }, (error) => {
-        UserNotification.error(`Deleting Output "${configuration.name}" failed with status: ${error.message}`,
-          'Could not delete Configuration');
+        UserNotification.error(`Deleting Configuration failed: ${error.status === 400 ? error.responseMessage : error.message}`,
+          `Could not delete Configuration ${configuration.name}`);
       });
 
     CollectorConfigurationsActions.delete.promise(promise);

--- a/graylog2-web-interface/src/stores/sidecars/CollectorsStore.js
+++ b/graylog2-web-interface/src/stores/sidecars/CollectorsStore.js
@@ -147,8 +147,8 @@ const CollectorsStore = Reflux.createStore({
         this.refreshList();
         return response;
       }, (error) => {
-        UserNotification.error(`Deleting Collector "${collector.name}" failed with status: ${error.message}`,
-          'Could not delete Collector');
+        UserNotification.error(`Deleting Collector failed: ${error.status === 400 ? error.responseMessage : error.message}`,
+          `Could not delete Collector "${collector.name}"`);
       });
 
     CollectorsActions.delete.promise(promise);


### PR DESCRIPTION
In order to avoid leaving Sidecars running in an unexpected state, this PR adds some restrictions on when it is possible to do certain actions:

- Deleting a Collector is only possible if there is not any Configurations using it
- Deleting a Configuration is only possible if there is not any Sidecars using it
- Changing the Collector associated to a Configuration is only possible if there are no Sidecars using that configuration

Fixes #5007