### PR TITLE
Allow user created roles as default role for LDAP users

### DIFF
--- a/graylog2-web-interface/src/components/ldap/LdapComponent.jsx
+++ b/graylog2-web-interface/src/components/ldap/LdapComponent.jsx
@@ -157,7 +157,6 @@ const LdapComponent = createReactClass({
 
   _formatAdditionalRoles(roles) {
     return roles
-      .filter(r => !(r.name.toLowerCase() === 'reader' || r.name.toLowerCase() === 'admin'))
       .sort((r1, r2) => naturalSort(r1.name.toLowerCase(), r2.name.toLowerCase()))
       .map((r) => {
         return { label: r.name, value: r.name };
@@ -418,17 +417,14 @@ const LdapComponent = createReactClass({
               <Input id="default_group" labelClassName="col-sm-3"
                      wrapperClassName="col-sm-9" label="Default User Role"
                      help={help.defaultGroup(this._onShowGroups)}>
-                <Row>
-                  <Col sm={4}>
-                    <select id="default_group" name="default_group" className="form-control" required
-                            value={this.state.ldapSettings.default_group.toLowerCase()} disabled={disabled}
-                            onChange={ev => this._setSetting('default_group', ev.target.value)}>
-
-                      <option value="reader">Reader - basic access</option>
-                      <option value="admin">Administrator - complete access</option>
-                    </select>
-                  </Col>
-                </Row>
+                <MultiSelect
+                  options={rolesOptions}
+                  disabled={disabled}
+                  multi={false}
+                  value={this.state.ldapSettings.default_group}
+                  onChange={role => this._setSetting('default_group', role)}
+                  placeholder="Choose a default role"
+                />
               </Input>
 
               <Row>


### PR DESCRIPTION
## Description
Allows selecting custom roles as default roles for LDAP users. 
Only default (reader and administrator) roles were eligible from the list.

## Motivation and Context
Implements #5000 

## How Has This Been Tested?
1. Create a custom role
2. Configure Graylog for LDAP authentication
3. In the LDAP settings, the new custom role appears in the list of Default Roles

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
