### PR TITLE
Sort content pack entities by name

### DIFF
--- a/graylog2-web-interface/src/components/content-packs/ContentPackSelection.jsx
+++ b/graylog2-web-interface/src/components/content-packs/ContentPackSelection.jsx
@@ -158,7 +158,11 @@ class ContentPackSelection extends React.Component {
   render() {
     const entitiesComponent = Object.keys(this.state.filteredEntities || {}).map((entityType) => {
       const group = this.state.filteredEntities[entityType];
-      const entities = group.map((entity) => {
+      const entities = group.sort((a, b) => {
+        if (a.title < b.title) return -1;
+        if (a.title > b.title) return 1;
+        return 0;
+      }).map((entity) => {
         const checked = this._isSelected(entity);
         return (<ExpandableListItem onChange={() => this._updateSelectionEntity(entity)}
                                     key={entity.id}

--- a/graylog2-web-interface/src/components/content-packs/ContentPackSelection.jsx
+++ b/graylog2-web-interface/src/components/content-packs/ContentPackSelection.jsx
@@ -1,5 +1,6 @@
 import PropTypes from 'prop-types';
 import React from 'react';
+import naturalSort from 'javascript-natural-sort';
 
 import { Row, Col, Panel } from 'react-bootstrap';
 import { Input } from 'components/bootstrap';
@@ -156,37 +157,35 @@ class ContentPackSelection extends React.Component {
   };
 
   render() {
-    const entitiesComponent = Object.keys(this.state.filteredEntities || {}).map((entityType) => {
-      const group = this.state.filteredEntities[entityType];
-      const entities = group.sort((a, b) => {
-        if (a.title < b.title) return -1;
-        if (a.title > b.title) return 1;
-        return 0;
-      }).map((entity) => {
-        const checked = this._isSelected(entity);
-        return (<ExpandableListItem onChange={() => this._updateSelectionEntity(entity)}
-                                    key={entity.id}
-                                    checked={checked}
-                                    expandable={false}
-                                    header={entity.title} />);
+    const entitiesComponent = Object.keys(this.state.filteredEntities || {})
+      .sort((a, b) => naturalSort(a, b))
+      .map((entityType) => {
+        const group = this.state.filteredEntities[entityType];
+        const entities = group.sort((a, b) => naturalSort(a.title, b.title)).map((entity) => {
+          const checked = this._isSelected(entity);
+          return (<ExpandableListItem onChange={() => this._updateSelectionEntity(entity)}
+                                      key={entity.id}
+                                      checked={checked}
+                                      expandable={false}
+                                      header={entity.title} />);
+        });
+        if (group.length <= 0) {
+          return null;
+        }
+        return (
+          <ExpandableListItem key={entityType}
+                              onChange={() => this._updateSelectionGroup(entityType)}
+                              indetermined={this._isUndetermined(entityType)}
+                              checked={this._isGroupSelected(entityType)}
+                              stayExpanded={this.state.isFiltered}
+                              expanded={this.state.isFiltered}
+                              header={ContentPackSelection._toDisplayTitle(entityType)}>
+            <ExpandableList>
+              {entities}
+            </ExpandableList>
+          </ExpandableListItem>
+        );
       });
-      if (group.length <= 0) {
-        return null;
-      }
-      return (
-        <ExpandableListItem key={entityType}
-                            onChange={() => this._updateSelectionGroup(entityType)}
-                            indetermined={this._isUndetermined(entityType)}
-                            checked={this._isGroupSelected(entityType)}
-                            stayExpanded={this.state.isFiltered}
-                            expanded={this.state.isFiltered}
-                            header={ContentPackSelection._toDisplayTitle(entityType)}>
-          <ExpandableList>
-            {entities}
-          </ExpandableList>
-        </ExpandableListItem>
-      );
-    });
 
     const { errors } = this.state;
 


### PR DESCRIPTION
## Description
Sort the content pack entities by name when displaying them for creation or editing.

## Motivation and Context
So user can easier find desired entities.

Fixes #4991 

## Screenshots (if appropriate):
![screenshot_2018-08-24 graylog - content packs](https://user-images.githubusercontent.com/448763/44583337-22cb6e80-a7a5-11e8-85c4-437a3a430f53.png)

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
