### PR TITLE
Relax server and plugin version requirements

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/contentpacks/model/constraints/GraylogVersionConstraint.java
+++ b/graylog2-server/src/main/java/org/graylog2/contentpacks/model/constraints/GraylogVersionConstraint.java
@@ -17,15 +17,11 @@
 package org.graylog2.contentpacks.model.constraints;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
-import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.google.auto.value.AutoValue;
 import com.vdurmont.semver4j.Requirement;
 import org.graylog2.plugin.Version;
-
-import javax.annotation.Nullable;
-import java.util.Optional;
 
 @AutoValue
 @JsonDeserialize(builder = AutoValue_GraylogVersionConstraint.Builder.class)
@@ -45,7 +41,7 @@ public abstract class GraylogVersionConstraint implements Constraint {
 
     public static GraylogVersionConstraint of(Version version) {
         final String versionString = version.toString().replace("-SNAPSHOT", "");
-        final Requirement requirement = Requirement.buildNPM("^" + versionString);
+        final Requirement requirement = Requirement.buildNPM(">=" + versionString);
         return builder()
                 .version(requirement)
                 .build();

--- a/graylog2-server/src/main/java/org/graylog2/contentpacks/model/constraints/PluginVersionConstraint.java
+++ b/graylog2-server/src/main/java/org/graylog2/contentpacks/model/constraints/PluginVersionConstraint.java
@@ -45,7 +45,7 @@ public abstract class PluginVersionConstraint implements Constraint {
     public static PluginVersionConstraint of(PluginMetaData pluginMetaData) {
         final Version version = pluginMetaData.getVersion();
         final String versionString = version.toString().replace("-SNAPSHOT", "");
-        final Requirement requirement = Requirement.buildNPM("^" + versionString);
+        final Requirement requirement = Requirement.buildNPM(">=" + versionString);
 
         return builder()
                 .pluginId(pluginMetaData.getUniqueId())


### PR DESCRIPTION
## Description
Relax server and plugin version requirements

## Motivation and Context
Content packs created with a 3.0.0 server would not work with 4.0.0 any longer
and that for perhaps no reason at all.

## Screenshots (if appropriate):
![screenshot_2018-08-24 graylog - content packs 1](https://user-images.githubusercontent.com/448763/44586956-ba36be80-a7b1-11e8-9aff-4d2cfd439bd3.png)

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
