### PR TITLE
Make "license:check" and "license:format" work from the project root

### DIFF
--- a/graylog-plugin-parent/pom.xml
+++ b/graylog-plugin-parent/pom.xml
@@ -44,7 +44,6 @@
         <!-- Plugin versions -->
         <jdeb.version>1.6</jdeb.version>
         <rpm-maven.version>2.2.0</rpm-maven.version>
-        <license-maven.version>2.11</license-maven.version>
     </properties>
 
     <dependencyManagement>
@@ -72,12 +71,6 @@
     <build>
         <pluginManagement>
             <plugins>
-                <plugin>
-                    <groupId>com.mycila</groupId>
-                    <artifactId>license-maven-plugin</artifactId>
-                    <version>${license-maven.version}</version>
-                </plugin>
-
                 <plugin>
                     <artifactId>jdeb</artifactId>
                     <groupId>org.vafer</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -168,6 +168,9 @@
         <!-- Nodejs dependencies -->
         <nodejs.version>v8.11.2</nodejs.version>
         <yarn.version>v1.7.0</yarn.version>
+
+        <!-- Plugin versions -->
+        <license-maven.version>2.11</license-maven.version>
     </properties>
 
     <repositories>
@@ -308,6 +311,11 @@
                     <artifactId>antlr4-maven-plugin</artifactId>
                     <version>${antlr.version}</version>
                 </plugin>
+                <plugin>
+                    <groupId>com.mycila</groupId>
+                    <artifactId>license-maven-plugin</artifactId>
+                    <version>${license-maven.version}</version>
+                </plugin>
             </plugins>
         </pluginManagement>
 
@@ -361,6 +369,10 @@
                     <ignoreMissingDescriptor>true</ignoreMissingDescriptor>
                     <tarLongFileMode>posix</tarLongFileMode>
                 </configuration>
+            </plugin>
+            <plugin>
+                <groupId>com.mycila</groupId>
+                <artifactId>license-maven-plugin</artifactId>
             </plugin>
         </plugins>
     </build>


### PR DESCRIPTION
Fixes Graylog2/graylog-project-internal#19

**Notice:** This should be cherry-picked into 2.5 once merged