### PR TITLE
Not serializing `type` field twice for `TimeRange` instances.

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/plugin/indexer/searches/timeranges/TimeRange.java
+++ b/graylog2-server/src/main/java/org/graylog2/plugin/indexer/searches/timeranges/TimeRange.java
@@ -24,7 +24,7 @@ import org.joda.time.DateTime;
 
 import java.util.Map;
 
-@JsonTypeInfo(use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.PROPERTY, property = "type", visible = true)
+@JsonTypeInfo(use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.EXISTING_PROPERTY, property = "type", visible = true)
 @JsonSubTypes({
         @JsonSubTypes.Type(name = AbsoluteRange.ABSOLUTE, value = AbsoluteRange.class),
         @JsonSubTypes.Type(name = RelativeRange.RELATIVE, value = RelativeRange.class),


### PR DESCRIPTION
Before:

```
				"timerange": {
					"type": "relative",
					"type": "relative",
					"range": 300
				}
```

After:

```
				"timerange": {
					"type": "relative",
					"range": 300
				}
```

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
