### PR TITLE
Add GrokPatternInput to GrokExtractorConfiguration

### DIFF
--- a/graylog2-web-interface/src/components/extractors/extractors_configuration/GrokExtractorConfiguration.css
+++ b/graylog2-web-interface/src/components/extractors/extractors_configuration/GrokExtractorConfiguration.css
@@ -1,3 +1,3 @@
-:local(.gorkInput) {
+:local(.grokInput) {
     margin-left: 1px;
 }

--- a/graylog2-web-interface/src/components/extractors/extractors_configuration/GrokExtractorConfiguration.css
+++ b/graylog2-web-interface/src/components/extractors/extractors_configuration/GrokExtractorConfiguration.css
@@ -1,0 +1,3 @@
+:local(.gorkInput) {
+    margin-left: 1px;
+}

--- a/graylog2-web-interface/src/components/extractors/extractors_configuration/GrokExtractorConfiguration.jsx
+++ b/graylog2-web-interface/src/components/extractors/extractors_configuration/GrokExtractorConfiguration.jsx
@@ -1,6 +1,6 @@
 import PropTypes from 'prop-types';
 import React from 'react';
-import { Row, Col, Button } from 'react-bootstrap';
+import { Row, Col, Button, FormGroup, ControlLabel } from 'react-bootstrap';
 
 import { Input } from 'components/bootstrap';
 import GrokPatternInput from 'components/grok-patterns/GrokPatternInput';
@@ -110,28 +110,26 @@ class GrokExtractorConfiguration extends React.Component {
                onChange={this._onChange('named_captures_only')}
                help="Only put the explicitly named captures into the message." />
 
-        <Input id="grok_pattern"
-               label="Grok pattern"
-               labelClassName="col-md-2"
-               wrapperClassName="col-md-10">
-          <Row className="row-sm">
-            <Col md={11}>
-              <GrokPatternInput
-                onPatternChange={this._onPatternChange}
-                pattern={this.props.configuration.grok_pattern || ''}
-                patterns={this.state.patterns}
-                className={Style.grokInput}
-              />
-            </Col>
-          </Row>
-          <Row>
-            <Col md={1}>
-              <Button bsStyle="info" onClick={this._onTryClick} disabled={this._isTryButtonDisabled()}>
-                {this.state.trying ? <i className="fa fa-spin fa-spinner" /> : 'Try against example'}
-              </Button>
-            </Col>
-          </Row>
-        </Input>
+        <Row>
+          <Col mdOffset={1} md={1}>
+            <ControlLabel className="col-md-offset-2">Grok pattern</ControlLabel>
+          </Col>
+          <Col md={10}>
+            <GrokPatternInput
+              onPatternChange={this._onPatternChange}
+              pattern={this.props.configuration.grok_pattern || ''}
+              patterns={this.state.patterns}
+              className={Style.grokInput}
+            />
+          </Col>
+        </Row>
+        <Row>
+          <Col mdOffset={2} md={1}>
+            <Button bsStyle="info" onClick={this._onTryClick} disabled={this._isTryButtonDisabled()}>
+              {this.state.trying ? <i className="fa fa-spin fa-spinner" /> : 'Try against example'}
+            </Button>
+          </Col>
+        </Row>
       </div>
     );
   }

--- a/graylog2-web-interface/src/components/extractors/extractors_configuration/GrokExtractorConfiguration.jsx
+++ b/graylog2-web-interface/src/components/extractors/extractors_configuration/GrokExtractorConfiguration.jsx
@@ -1,6 +1,6 @@
 import PropTypes from 'prop-types';
 import React from 'react';
-import { Row, Col, Button, FormGroup, ControlLabel } from 'react-bootstrap';
+import { Row, Col, Button, ControlLabel } from 'react-bootstrap';
 
 import { Input } from 'components/bootstrap';
 import GrokPatternInput from 'components/grok-patterns/GrokPatternInput';

--- a/graylog2-web-interface/src/components/grok-patterns/GrokPatternInput.jsx
+++ b/graylog2-web-interface/src/components/grok-patterns/GrokPatternInput.jsx
@@ -11,12 +11,14 @@ class GrokPatternInput extends React.Component {
     pattern: PropTypes.string,
     patterns: PropTypes.array,
     onPatternChange: PropTypes.func,
+    className: PropTypes.string,
   };
 
   static defaultProps = {
     pattern: '',
     patterns: [],
     onPatternChange: () => {},
+    className: '',
   };
 
   constructor(props) {
@@ -110,7 +112,7 @@ class GrokPatternInput extends React.Component {
           </ListGroupItem>);
       });
     return (
-      <Row>
+      <Row bsClass={this.props.className}>
         <Col sm={8}>
           <Input ref={(node) => { this.patternInput = node; }}
                  type="textarea"

--- a/graylog2-web-interface/src/components/grok-patterns/GrokPatternInput.jsx
+++ b/graylog2-web-interface/src/components/grok-patterns/GrokPatternInput.jsx
@@ -112,7 +112,7 @@ class GrokPatternInput extends React.Component {
           </ListGroupItem>);
       });
     return (
-      <Row bsClass={this.props.className}>
+      <Row className={this.props.className}>
         <Col sm={8}>
           <Input ref={(node) => { this.patternInput = node; }}
                  type="textarea"

--- a/graylog2-web-interface/src/components/grok-patterns/__snapshots__/GrokPatternInput.test.jsx.snap
+++ b/graylog2-web-interface/src/components/grok-patterns/__snapshots__/GrokPatternInput.test.jsx.snap
@@ -2,7 +2,7 @@
 
 exports[`<GrokPatternInput /> should render grok pattern input with patterns 1`] = `
 <div
-  className="row"
+  className=""
 >
   <div
     className="col-sm-8"
@@ -169,7 +169,7 @@ exports[`<GrokPatternInput /> should render grok pattern input with patterns 1`]
 
 exports[`<GrokPatternInput /> should render grok pattern input without patterns 1`] = `
 <div
-  className="row"
+  className=""
 >
   <div
     className="col-sm-8"

--- a/graylog2-web-interface/src/components/grok-patterns/__snapshots__/GrokPatternInput.test.jsx.snap
+++ b/graylog2-web-interface/src/components/grok-patterns/__snapshots__/GrokPatternInput.test.jsx.snap
@@ -2,7 +2,7 @@
 
 exports[`<GrokPatternInput /> should render grok pattern input with patterns 1`] = `
 <div
-  className=""
+  className="row"
 >
   <div
     className="col-sm-8"
@@ -169,7 +169,7 @@ exports[`<GrokPatternInput /> should render grok pattern input with patterns 1`]
 
 exports[`<GrokPatternInput /> should render grok pattern input without patterns 1`] = `
 <div
-  className=""
+  className="row"
 >
   <div
     className="col-sm-8"


### PR DESCRIPTION
## Description
Add the GrokPatternInput to the grok pattern extraction page.

Also fix some linter errors.

## Motivation and Context
A user needed to know all his grok patterns to create a extractor.
Now he can search in grok pattern list. 

## Screenshots (if appropriate):
![screenshot_2018-08-29 graylog - edit extractor post id](https://user-images.githubusercontent.com/448763/44794232-5db81280-aba8-11e8-9b41-dae857a424de.png)


## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
