### PR TITLE
Implement content pack uninstallation

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/contentpacks/ContentPackService.java
+++ b/graylog2-server/src/main/java/org/graylog2/contentpacks/ContentPackService.java
@@ -113,7 +113,7 @@ public class ContentPackService {
         final Traverser<Entity> entityTraverser = Traverser.forGraph(dependencyGraph);
         final Iterable<Entity> entitiesInOrder = entityTraverser.depthFirstPostOrder(rootEntity);
 
-        // Insertion order is important for created entities!
+        // Insertion order is important for created entities so we can roll back in order!
         final Map<EntityDescriptor, Object> createdEntities = new LinkedHashMap<>();
         final Map<EntityDescriptor, Object> allEntities = new HashMap<>();
         final ImmutableSet.Builder<NativeEntityDescriptor> allEntityDescriptors = ImmutableSet.builder();

--- a/graylog2-server/src/main/java/org/graylog2/contentpacks/ContentPackService.java
+++ b/graylog2-server/src/main/java/org/graylog2/contentpacks/ContentPackService.java
@@ -16,7 +16,6 @@
  */
 package org.graylog2.contentpacks;
 
-import com.fasterxml.jackson.databind.node.NullNode;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
@@ -40,9 +39,7 @@ import org.graylog2.contentpacks.facades.UnsupportedEntityFacade;
 import org.graylog2.contentpacks.model.ContentPack;
 import org.graylog2.contentpacks.model.ContentPackInstallation;
 import org.graylog2.contentpacks.model.ContentPackV1;
-import org.graylog2.contentpacks.model.ModelId;
 import org.graylog2.contentpacks.model.ModelType;
-import org.graylog2.contentpacks.model.ModelTypes;
 import org.graylog2.contentpacks.model.constraints.Constraint;
 import org.graylog2.contentpacks.model.constraints.ConstraintCheckResult;
 import org.graylog2.contentpacks.model.constraints.GraylogVersionConstraint;
@@ -109,11 +106,7 @@ public class ContentPackService {
                                                       String user) {
         ensureConstraints(contentPack.requires());
 
-        final Entity rootEntity = EntityV1.builder()
-                .type(ModelTypes.ROOT)
-                .id(ModelId.of("virtual-root-" + contentPack.id() + "-" + contentPack.revision()))
-                .data(NullNode.getInstance())
-                .build();
+        final Entity rootEntity = EntityV1.createRoot(contentPack);
         final ImmutableMap<String, ValueReference> validatedParameters = validateParameters(parameters, contentPack.parameters());
         final ImmutableGraph<Entity> dependencyGraph = buildEntityGraph(rootEntity, contentPack.entities(), validatedParameters);
 

--- a/graylog2-server/src/main/java/org/graylog2/contentpacks/facades/DashboardFacade.java
+++ b/graylog2-server/src/main/java/org/graylog2/contentpacks/facades/DashboardFacade.java
@@ -35,6 +35,7 @@ import org.graylog2.contentpacks.model.entities.EntityExcerpt;
 import org.graylog2.contentpacks.model.entities.EntityV1;
 import org.graylog2.contentpacks.model.entities.EntityWithConstraints;
 import org.graylog2.contentpacks.model.entities.NativeEntity;
+import org.graylog2.contentpacks.model.entities.NativeEntityDescriptor;
 import org.graylog2.contentpacks.model.entities.TimeRangeEntity;
 import org.graylog2.contentpacks.model.entities.references.ValueReference;
 import org.graylog2.dashboards.Dashboard;
@@ -253,6 +254,16 @@ public class DashboardFacade implements EntityFacade<Dashboard> {
         return widgetCreator.buildDashboardWidget(type,
                 id, description, cacheTime,
                 widgetConfig, timeRange, username);
+    }
+
+    @Override
+    public Optional<NativeEntity<Dashboard>> loadNativeEntity(NativeEntityDescriptor nativeEntityDescriptor) {
+        try {
+            final Dashboard dashboard = dashboardService.load(nativeEntityDescriptor.id().id());
+            return Optional.of(NativeEntity.create(nativeEntityDescriptor, dashboard));
+        } catch (NotFoundException e) {
+            return Optional.empty();
+        }
     }
 
     @Override

--- a/graylog2-server/src/main/java/org/graylog2/contentpacks/facades/EntityFacade.java
+++ b/graylog2-server/src/main/java/org/graylog2/contentpacks/facades/EntityFacade.java
@@ -25,6 +25,7 @@ import org.graylog2.contentpacks.model.entities.EntityDescriptor;
 import org.graylog2.contentpacks.model.entities.EntityExcerpt;
 import org.graylog2.contentpacks.model.entities.EntityWithConstraints;
 import org.graylog2.contentpacks.model.entities.NativeEntity;
+import org.graylog2.contentpacks.model.entities.NativeEntityDescriptor;
 import org.graylog2.contentpacks.model.entities.references.ValueReference;
 
 import java.util.Map;
@@ -80,6 +81,15 @@ public interface EntityFacade<T> {
     default Optional<NativeEntity<T>> findExisting(Entity entity, Map<String, ValueReference> parameters) {
         return Optional.empty();
     }
+
+    /**
+     * Loads the native entity instance for the given native entity descriptor.
+     *
+     * @param nativeEntityDescriptor the native entity descriptor
+     * @return the existing native entity in the database wrapped in {@link NativeEntity<T>},
+     * or {@link Optional#empty()} if the native entity doesn't exist.
+     */
+    Optional<NativeEntity<T>> loadNativeEntity(NativeEntityDescriptor nativeEntityDescriptor);
 
     /**
      * Delete the given native entity.

--- a/graylog2-server/src/main/java/org/graylog2/contentpacks/facades/GrokPatternFacade.java
+++ b/graylog2-server/src/main/java/org/graylog2/contentpacks/facades/GrokPatternFacade.java
@@ -29,6 +29,7 @@ import org.graylog2.contentpacks.model.entities.EntityV1;
 import org.graylog2.contentpacks.model.entities.EntityWithConstraints;
 import org.graylog2.contentpacks.model.entities.GrokPatternEntity;
 import org.graylog2.contentpacks.model.entities.NativeEntity;
+import org.graylog2.contentpacks.model.entities.NativeEntityDescriptor;
 import org.graylog2.contentpacks.model.entities.references.ValueReference;
 import org.graylog2.database.NotFoundException;
 import org.graylog2.grok.GrokPattern;
@@ -94,6 +95,16 @@ public class GrokPatternFacade implements EntityFacade<GrokPattern> {
             return NativeEntity.create(entity.id(), savedGrokPattern.id(), TYPE_V1, savedGrokPattern);
         } catch (ValidationException e) {
             throw new RuntimeException("Couldn't create grok pattern " + grokPattern.name());
+        }
+    }
+
+    @Override
+    public Optional<NativeEntity<GrokPattern>> loadNativeEntity(NativeEntityDescriptor nativeEntityDescriptor) {
+        try {
+            final GrokPattern grokPattern = grokPatternService.load(nativeEntityDescriptor.id().id());
+            return Optional.of(NativeEntity.create(nativeEntityDescriptor, grokPattern));
+        } catch (NotFoundException e) {
+            return Optional.empty();
         }
     }
 

--- a/graylog2-server/src/main/java/org/graylog2/contentpacks/facades/InputFacade.java
+++ b/graylog2-server/src/main/java/org/graylog2/contentpacks/facades/InputFacade.java
@@ -36,6 +36,7 @@ import org.graylog2.contentpacks.model.entities.EntityWithConstraints;
 import org.graylog2.contentpacks.model.entities.ExtractorEntity;
 import org.graylog2.contentpacks.model.entities.InputEntity;
 import org.graylog2.contentpacks.model.entities.NativeEntity;
+import org.graylog2.contentpacks.model.entities.NativeEntityDescriptor;
 import org.graylog2.contentpacks.model.entities.references.ReferenceMap;
 import org.graylog2.contentpacks.model.entities.references.ValueReference;
 import org.graylog2.database.NotFoundException;
@@ -403,6 +404,16 @@ public class InputFacade implements EntityFacade<InputWithExtractors> {
         }
 
         return inputData.build();
+    }
+
+    @Override
+    public Optional<NativeEntity<InputWithExtractors>> loadNativeEntity(NativeEntityDescriptor nativeEntityDescriptor) {
+        try {
+            final InputWithExtractors input = InputWithExtractors.create(inputService.find(nativeEntityDescriptor.id().id()));
+            return Optional.of(NativeEntity.create(nativeEntityDescriptor, input));
+        } catch (NotFoundException e) {
+            return Optional.empty();
+        }
     }
 
     @Override

--- a/graylog2-server/src/main/java/org/graylog2/contentpacks/facades/LookupCacheFacade.java
+++ b/graylog2-server/src/main/java/org/graylog2/contentpacks/facades/LookupCacheFacade.java
@@ -30,6 +30,7 @@ import org.graylog2.contentpacks.model.entities.EntityV1;
 import org.graylog2.contentpacks.model.entities.EntityWithConstraints;
 import org.graylog2.contentpacks.model.entities.LookupCacheEntity;
 import org.graylog2.contentpacks.model.entities.NativeEntity;
+import org.graylog2.contentpacks.model.entities.NativeEntityDescriptor;
 import org.graylog2.contentpacks.model.entities.references.ValueReference;
 import org.graylog2.jackson.TypeReferences;
 import org.graylog2.lookup.db.DBCacheService;
@@ -133,6 +134,12 @@ public class LookupCacheFacade implements EntityFacade<CacheDto> {
         final Optional<CacheDto> existingCache = cacheService.get(name);
 
         return existingCache.map(cache -> NativeEntity.create(entity.id(), cache.id(), TYPE_V1, cache));
+    }
+
+    @Override
+    public Optional<NativeEntity<CacheDto>> loadNativeEntity(NativeEntityDescriptor nativeEntityDescriptor) {
+        return cacheService.get(nativeEntityDescriptor.id().id())
+                .map(entity -> NativeEntity.create(nativeEntityDescriptor, entity));
     }
 
     @Override

--- a/graylog2-server/src/main/java/org/graylog2/contentpacks/facades/LookupDataAdapterFacade.java
+++ b/graylog2-server/src/main/java/org/graylog2/contentpacks/facades/LookupDataAdapterFacade.java
@@ -30,6 +30,7 @@ import org.graylog2.contentpacks.model.entities.EntityV1;
 import org.graylog2.contentpacks.model.entities.EntityWithConstraints;
 import org.graylog2.contentpacks.model.entities.LookupDataAdapterEntity;
 import org.graylog2.contentpacks.model.entities.NativeEntity;
+import org.graylog2.contentpacks.model.entities.NativeEntityDescriptor;
 import org.graylog2.contentpacks.model.entities.references.ValueReference;
 import org.graylog2.jackson.TypeReferences;
 import org.graylog2.lookup.db.DBDataAdapterService;
@@ -134,6 +135,12 @@ public class LookupDataAdapterFacade implements EntityFacade<DataAdapterDto> {
         final Optional<DataAdapterDto> existingDataAdapter = dataAdapterService.get(name);
 
         return existingDataAdapter.map(dataAdapter -> NativeEntity.create(entity.id(), dataAdapter.id(), TYPE_V1, dataAdapter));
+    }
+
+    @Override
+    public Optional<NativeEntity<DataAdapterDto>> loadNativeEntity(NativeEntityDescriptor nativeEntityDescriptor) {
+        return dataAdapterService.get(nativeEntityDescriptor.id().id())
+                .map(entity -> NativeEntity.create(nativeEntityDescriptor, entity));
     }
 
     @Override

--- a/graylog2-server/src/main/java/org/graylog2/contentpacks/facades/LookupTableFacade.java
+++ b/graylog2-server/src/main/java/org/graylog2/contentpacks/facades/LookupTableFacade.java
@@ -35,6 +35,7 @@ import org.graylog2.contentpacks.model.entities.EntityV1;
 import org.graylog2.contentpacks.model.entities.EntityWithConstraints;
 import org.graylog2.contentpacks.model.entities.LookupTableEntity;
 import org.graylog2.contentpacks.model.entities.NativeEntity;
+import org.graylog2.contentpacks.model.entities.NativeEntityDescriptor;
 import org.graylog2.contentpacks.model.entities.references.ValueReference;
 import org.graylog2.lookup.LookupDefaultMultiValue;
 import org.graylog2.lookup.LookupDefaultSingleValue;
@@ -159,6 +160,12 @@ public class LookupTableFacade implements EntityFacade<LookupTableDto> {
         if (!name.equals(existingLookupTable.name()) || !title.equals(existingLookupTable.title())) {
             throw new DivergingEntityConfigurationException("Different lookup table configuration with name \"" + name + "\"");
         }
+    }
+
+    @Override
+    public Optional<NativeEntity<LookupTableDto>> loadNativeEntity(NativeEntityDescriptor nativeEntityDescriptor) {
+        return lookupTableService.get(nativeEntityDescriptor.id().id())
+                .map(entity -> NativeEntity.create(nativeEntityDescriptor, entity));
     }
 
     @Override

--- a/graylog2-server/src/main/java/org/graylog2/contentpacks/facades/OutputFacade.java
+++ b/graylog2-server/src/main/java/org/graylog2/contentpacks/facades/OutputFacade.java
@@ -30,6 +30,7 @@ import org.graylog2.contentpacks.model.entities.EntityExcerpt;
 import org.graylog2.contentpacks.model.entities.EntityV1;
 import org.graylog2.contentpacks.model.entities.EntityWithConstraints;
 import org.graylog2.contentpacks.model.entities.NativeEntity;
+import org.graylog2.contentpacks.model.entities.NativeEntityDescriptor;
 import org.graylog2.contentpacks.model.entities.OutputEntity;
 import org.graylog2.contentpacks.model.entities.references.ValueReference;
 import org.graylog2.database.NotFoundException;
@@ -130,6 +131,16 @@ public class OutputFacade implements EntityFacade<Output> {
             return NativeEntity.create(entity.id(), output.getId(), TYPE_V1, output);
         } catch (ValidationException e) {
             throw new IllegalArgumentException(e);
+        }
+    }
+
+    @Override
+    public Optional<NativeEntity<Output>> loadNativeEntity(NativeEntityDescriptor nativeEntityDescriptor) {
+        try {
+            final Output output = outputService.load(nativeEntityDescriptor.id().id());
+            return Optional.of(NativeEntity.create(nativeEntityDescriptor, output));
+        } catch (NotFoundException e) {
+            return Optional.empty();
         }
     }
 

--- a/graylog2-server/src/main/java/org/graylog2/contentpacks/facades/PipelineFacade.java
+++ b/graylog2-server/src/main/java/org/graylog2/contentpacks/facades/PipelineFacade.java
@@ -40,6 +40,7 @@ import org.graylog2.contentpacks.model.entities.EntityExcerpt;
 import org.graylog2.contentpacks.model.entities.EntityV1;
 import org.graylog2.contentpacks.model.entities.EntityWithConstraints;
 import org.graylog2.contentpacks.model.entities.NativeEntity;
+import org.graylog2.contentpacks.model.entities.NativeEntityDescriptor;
 import org.graylog2.contentpacks.model.entities.PipelineEntity;
 import org.graylog2.contentpacks.model.entities.references.ValueReference;
 import org.graylog2.database.NotFoundException;
@@ -178,6 +179,16 @@ public class PipelineFacade implements EntityFacade<PipelineDao> {
                 final PipelineConnections savedConnections = connectionsService.save(connections);
                 LOG.trace("Saved pipeline connections: {}", savedConnections);
             }
+        }
+    }
+
+    @Override
+    public Optional<NativeEntity<PipelineDao>> loadNativeEntity(NativeEntityDescriptor nativeEntityDescriptor) {
+        try {
+            final PipelineDao pipeline = pipelineService.load(nativeEntityDescriptor.id().id());
+            return Optional.of(NativeEntity.create(nativeEntityDescriptor, pipeline));
+        } catch (NotFoundException e) {
+            return Optional.empty();
         }
     }
 

--- a/graylog2-server/src/main/java/org/graylog2/contentpacks/facades/PipelineRuleFacade.java
+++ b/graylog2-server/src/main/java/org/graylog2/contentpacks/facades/PipelineRuleFacade.java
@@ -30,6 +30,7 @@ import org.graylog2.contentpacks.model.entities.EntityExcerpt;
 import org.graylog2.contentpacks.model.entities.EntityV1;
 import org.graylog2.contentpacks.model.entities.EntityWithConstraints;
 import org.graylog2.contentpacks.model.entities.NativeEntity;
+import org.graylog2.contentpacks.model.entities.NativeEntityDescriptor;
 import org.graylog2.contentpacks.model.entities.PipelineRuleEntity;
 import org.graylog2.contentpacks.model.entities.references.ValueReference;
 import org.graylog2.database.NotFoundException;
@@ -102,6 +103,16 @@ public class PipelineRuleFacade implements EntityFacade<RuleDao> {
 
         final RuleDao savedRuleDao = ruleService.save(ruleDao);
         return NativeEntity.create(entity.id(), savedRuleDao.id(), TYPE_V1, savedRuleDao);
+    }
+
+    @Override
+    public Optional<NativeEntity<RuleDao>> loadNativeEntity(NativeEntityDescriptor nativeEntityDescriptor) {
+        try {
+            final RuleDao ruleDao = ruleService.load(nativeEntityDescriptor.id().id());
+            return Optional.of(NativeEntity.create(nativeEntityDescriptor, ruleDao));
+        } catch (NotFoundException e) {
+            return Optional.empty();
+        }
     }
 
     @Override

--- a/graylog2-server/src/main/java/org/graylog2/contentpacks/facades/RootEntityFacade.java
+++ b/graylog2-server/src/main/java/org/graylog2/contentpacks/facades/RootEntityFacade.java
@@ -24,6 +24,7 @@ import org.graylog2.contentpacks.model.entities.EntityDescriptor;
 import org.graylog2.contentpacks.model.entities.EntityExcerpt;
 import org.graylog2.contentpacks.model.entities.EntityWithConstraints;
 import org.graylog2.contentpacks.model.entities.NativeEntity;
+import org.graylog2.contentpacks.model.entities.NativeEntityDescriptor;
 import org.graylog2.contentpacks.model.entities.references.ValueReference;
 import org.graylog2.utilities.Graphs;
 
@@ -46,6 +47,11 @@ public class RootEntityFacade implements EntityFacade<Void> {
                                                  Map<EntityDescriptor, Object> nativeEntities,
                                                  String username) {
         throw new UnsupportedOperationException("Unsupported operation for root entity");
+    }
+
+    @Override
+    public Optional<NativeEntity<Void>> loadNativeEntity(NativeEntityDescriptor nativeEntityDescriptor) {
+        return Optional.empty();
     }
 
     @Override

--- a/graylog2-server/src/main/java/org/graylog2/contentpacks/facades/SidecarCollectorConfigurationFacade.java
+++ b/graylog2-server/src/main/java/org/graylog2/contentpacks/facades/SidecarCollectorConfigurationFacade.java
@@ -34,6 +34,7 @@ import org.graylog2.contentpacks.model.entities.EntityExcerpt;
 import org.graylog2.contentpacks.model.entities.EntityV1;
 import org.graylog2.contentpacks.model.entities.EntityWithConstraints;
 import org.graylog2.contentpacks.model.entities.NativeEntity;
+import org.graylog2.contentpacks.model.entities.NativeEntityDescriptor;
 import org.graylog2.contentpacks.model.entities.references.ValueReference;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -104,6 +105,12 @@ public class SidecarCollectorConfigurationFacade implements EntityFacade<Configu
     public Optional<NativeEntity<Configuration>> findExisting(Entity entity, Map<String, ValueReference> parameters) {
         // TODO: Check if multiple configurations are allowed to exist (bernd)
         return Optional.empty();
+    }
+
+    @Override
+    public Optional<NativeEntity<Configuration>> loadNativeEntity(NativeEntityDescriptor nativeEntityDescriptor) {
+        return configurationService.get(nativeEntityDescriptor.id().id())
+                .map(entity -> NativeEntity.create(nativeEntityDescriptor, entity));
     }
 
     @Override

--- a/graylog2-server/src/main/java/org/graylog2/contentpacks/facades/SidecarCollectorFacade.java
+++ b/graylog2-server/src/main/java/org/graylog2/contentpacks/facades/SidecarCollectorFacade.java
@@ -31,6 +31,7 @@ import org.graylog2.contentpacks.model.entities.EntityExcerpt;
 import org.graylog2.contentpacks.model.entities.EntityV1;
 import org.graylog2.contentpacks.model.entities.EntityWithConstraints;
 import org.graylog2.contentpacks.model.entities.NativeEntity;
+import org.graylog2.contentpacks.model.entities.NativeEntityDescriptor;
 import org.graylog2.contentpacks.model.entities.references.ValueReference;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -133,6 +134,12 @@ public class SidecarCollectorFacade implements EntityFacade<Collector> {
         if (!name.equals(existingCollector.name()) || !serviceType.equals(existingCollector.serviceType())) {
             throw new DivergingEntityConfigurationException("Expected service type for Collector with name \"" + name + "\": <" + serviceType + ">; actual service type: <" + existingCollector.serviceType() + ">");
         }
+    }
+
+    @Override
+    public Optional<NativeEntity<Collector>> loadNativeEntity(NativeEntityDescriptor nativeEntityDescriptor) {
+        return collectorService.get(nativeEntityDescriptor.id().id())
+                .map(entity -> NativeEntity.create(nativeEntityDescriptor, entity));
     }
 
     @Override

--- a/graylog2-server/src/main/java/org/graylog2/contentpacks/facades/StreamFacade.java
+++ b/graylog2-server/src/main/java/org/graylog2/contentpacks/facades/StreamFacade.java
@@ -33,6 +33,7 @@ import org.graylog2.contentpacks.model.entities.EntityExcerpt;
 import org.graylog2.contentpacks.model.entities.EntityV1;
 import org.graylog2.contentpacks.model.entities.EntityWithConstraints;
 import org.graylog2.contentpacks.model.entities.NativeEntity;
+import org.graylog2.contentpacks.model.entities.NativeEntityDescriptor;
 import org.graylog2.contentpacks.model.entities.StreamEntity;
 import org.graylog2.contentpacks.model.entities.StreamRuleEntity;
 import org.graylog2.contentpacks.model.entities.references.ValueReference;
@@ -208,6 +209,16 @@ public class StreamFacade implements EntityFacade<Stream> {
                 throw new ContentPackException("Default stream <" + streamId + "> does not exist!", e);
             }
         } else {
+            return Optional.empty();
+        }
+    }
+
+    @Override
+    public Optional<NativeEntity<Stream>> loadNativeEntity(NativeEntityDescriptor nativeEntityDescriptor) {
+        try {
+            final Stream stream = streamService.load(nativeEntityDescriptor.id().id());
+            return Optional.of(NativeEntity.create(nativeEntityDescriptor, stream));
+        } catch (NotFoundException e) {
             return Optional.empty();
         }
     }

--- a/graylog2-server/src/main/java/org/graylog2/contentpacks/facades/StreamFacade.java
+++ b/graylog2-server/src/main/java/org/graylog2/contentpacks/facades/StreamFacade.java
@@ -225,6 +225,10 @@ public class StreamFacade implements EntityFacade<Stream> {
 
     @Override
     public void delete(Stream nativeEntity) {
+        if (nativeEntity.isDefaultStream()) {
+            LOG.debug("The default stream should not be deleted");
+            return;
+        }
         try {
             streamService.destroy(nativeEntity);
         } catch (NotFoundException ignore) {

--- a/graylog2-server/src/main/java/org/graylog2/contentpacks/facades/UnsupportedEntityFacade.java
+++ b/graylog2-server/src/main/java/org/graylog2/contentpacks/facades/UnsupportedEntityFacade.java
@@ -22,6 +22,7 @@ import org.graylog2.contentpacks.model.entities.EntityDescriptor;
 import org.graylog2.contentpacks.model.entities.EntityExcerpt;
 import org.graylog2.contentpacks.model.entities.EntityWithConstraints;
 import org.graylog2.contentpacks.model.entities.NativeEntity;
+import org.graylog2.contentpacks.model.entities.NativeEntityDescriptor;
 import org.graylog2.contentpacks.model.entities.references.ValueReference;
 import org.graylog2.utilities.Graphs;
 import org.slf4j.Logger;
@@ -48,6 +49,11 @@ public class UnsupportedEntityFacade implements EntityFacade<Void> {
                                                  Map<EntityDescriptor, Object> nativeEntities,
                                                  String username) {
         throw new UnsupportedOperationException("Unsupported entity " + entity.toEntityDescriptor());
+    }
+
+    @Override
+    public Optional<NativeEntity<Void>> loadNativeEntity(NativeEntityDescriptor nativeEntityDescriptor) {
+        return Optional.empty();
     }
 
     @Override

--- a/graylog2-server/src/main/java/org/graylog2/contentpacks/jackson/ReferenceConverter.java
+++ b/graylog2-server/src/main/java/org/graylog2/contentpacks/jackson/ReferenceConverter.java
@@ -53,7 +53,9 @@ public class ReferenceConverter extends StdConverter<JsonNode, Reference> {
                     return ValueReference.of(value.floatValue());
                 } else if (valueType == ValueType.INTEGER && value.isInt()) {
                     return ValueReference.of(value.intValue());
-                } else if (valueType == ValueType.LONG && value.isLong()) {
+                } else if (valueType == ValueType.LONG && (value.isLong() || value.isInt())) {
+                    //                                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+                    // Jackson actually creates an int value for a small number so we check for both (long and int value) here
                     return ValueReference.of(value.longValue());
                 } else if (valueType == ValueType.STRING && value.isTextual()) {
                     return ValueReference.of(value.textValue());

--- a/graylog2-server/src/main/java/org/graylog2/contentpacks/model/ContentPackUninstallation.java
+++ b/graylog2-server/src/main/java/org/graylog2/contentpacks/model/ContentPackUninstallation.java
@@ -1,0 +1,59 @@
+/**
+ * This file is part of Graylog.
+ *
+ * Graylog is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.graylog2.contentpacks.model;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.google.auto.value.AutoValue;
+import com.google.common.collect.ImmutableSet;
+import org.graylog2.contentpacks.model.entities.NativeEntityDescriptor;
+
+@AutoValue
+@JsonDeserialize(builder = ContentPackUninstallation.Builder.class)
+public abstract class ContentPackUninstallation {
+    private static final String FIELD_ENTITIES = "entities";
+    private static final String FIELD_FAILED_ENTITIES = "failed_entities";
+
+    @JsonProperty(FIELD_ENTITIES)
+    public abstract ImmutableSet<NativeEntityDescriptor> entities();
+
+    @JsonProperty(FIELD_FAILED_ENTITIES)
+    public abstract ImmutableSet<NativeEntityDescriptor> failedEntities();
+
+    public static Builder builder() {
+        return Builder.create();
+    }
+
+    public abstract Builder toBuilder();
+
+    @AutoValue.Builder
+    public static abstract class Builder {
+        @JsonCreator
+        public static Builder create() {
+            return new AutoValue_ContentPackUninstallation.Builder();
+        }
+
+        @JsonProperty(FIELD_ENTITIES)
+        public abstract Builder entities(ImmutableSet<NativeEntityDescriptor> entities);
+
+        @JsonProperty(FIELD_FAILED_ENTITIES)
+        public abstract Builder failedEntities(ImmutableSet<NativeEntityDescriptor> failedEntities);
+
+        public abstract ContentPackUninstallation build();
+    }
+}

--- a/graylog2-server/src/main/java/org/graylog2/contentpacks/model/entities/EntityV1.java
+++ b/graylog2-server/src/main/java/org/graylog2/contentpacks/model/entities/EntityV1.java
@@ -20,7 +20,11 @@ import com.fasterxml.jackson.annotation.JsonAutoDetect;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.node.NullNode;
 import com.google.auto.value.AutoValue;
+import org.graylog2.contentpacks.model.ContentPack;
+import org.graylog2.contentpacks.model.ModelId;
+import org.graylog2.contentpacks.model.ModelTypes;
 import org.graylog2.contentpacks.model.ModelVersion;
 
 @AutoValue
@@ -44,6 +48,14 @@ public abstract class EntityV1 implements Entity {
 
     public static Builder builder() {
         return new AutoValue_EntityV1.Builder();
+    }
+
+    public static Entity createRoot(ContentPack contentPack) {
+        return EntityV1.builder()
+                .type(ModelTypes.ROOT)
+                .id(ModelId.of("virtual-root-" + contentPack.id() + "-" + contentPack.revision()))
+                .data(NullNode.getInstance())
+                .build();
     }
 
     @AutoValue.Builder

--- a/graylog2-server/src/test/java/org/graylog2/contentpacks/jackson/ReferenceConverterTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/contentpacks/jackson/ReferenceConverterTest.java
@@ -1,0 +1,92 @@
+/**
+ * This file is part of Graylog.
+ *
+ * Graylog is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.graylog2.contentpacks.jackson;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.collect.ImmutableMap;
+import org.graylog2.contentpacks.model.entities.references.Reference;
+import org.graylog2.contentpacks.model.entities.references.ValueReference;
+import org.graylog2.shared.bindings.providers.ObjectMapperProvider;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class ReferenceConverterTest {
+    private ReferenceConverter converter;
+    private ObjectMapper om;
+
+    @Before
+    public void setUp() throws Exception {
+        converter = new ReferenceConverter();
+        om = new ObjectMapperProvider().get();
+    }
+
+    private Reference createReference(String type, Object value) {
+        return converter.convert(om.convertValue(ImmutableMap.of("type", type, "value", value), JsonNode.class));
+    }
+
+    @Test
+    public void convertBooleanValue() {
+        final Reference reference = createReference("boolean", false);
+
+        assertThat(reference).isEqualTo(ValueReference.of(false));
+    }
+
+    @Test
+    public void convertDoubleValue() {
+        final Reference reference = createReference("double", 10d);
+
+        assertThat(reference).isEqualTo(ValueReference.of(10d));
+    }
+
+    @Test
+    public void convertFloatValue() {
+        final Reference reference = createReference("float", 100f);
+
+        assertThat(reference).isEqualTo(ValueReference.of(100f));
+    }
+
+    @Test
+    public void convertIntegerValue() {
+        final Reference reference = createReference("integer", 0);
+
+        assertThat(reference).isEqualTo(ValueReference.of(0));
+    }
+
+    @Test
+    public void convertLongValue() {
+        final Reference reference = createReference("long", 1);
+
+        assertThat(reference).isEqualTo(ValueReference.of(1L));
+    }
+
+    @Test
+    public void convertStringValue() {
+        final Reference reference = createReference("string", "yolo");
+
+        assertThat(reference).isEqualTo(ValueReference.of("yolo"));
+    }
+
+    @Test
+    public void convertParameterValue() {
+        final Reference reference = createReference("parameter", "wat");
+
+        assertThat(reference).isEqualTo(ValueReference.createParameter("wat"));
+    }
+}

--- a/graylog2-web-interface/src/components/content-packs/ContentPackConstraints.jsx
+++ b/graylog2-web-interface/src/components/content-packs/ContentPackConstraints.jsx
@@ -40,7 +40,7 @@ class ContentPackConstraints extends React.Component {
           id="content-packs-constraints"
           headers={headers}
           headerCellFormatter={header => <th>{header}</th>}
-          sortByKey="type"
+          sortBy={row => row.constraint.type}
           dataRowFormatter={this._rowFormatter}
           rows={this.props.constraints}
           filterKeys={[]}


### PR DESCRIPTION
This PR implements content pack uninstallation.

## Known Issues

- Content packs that create inputs might fail to start the input on installation due to the problem in https://github.com/Graylog2/graylog2-server/issues/5106
- Content packs with an input that uses a lookup table extractor or converter cannot be installed because the dependency resolution in the InputFacade is incomplete. See: https://github.com/Graylog2/graylog2-server/issues/5105

## Open Tasks

- The user should see the list of entities that will be removed when a content pack gets uninstalled (https://github.com/Graylog2/graylog2-server/issues/5111)

Refs #4780