### PR TITLE
Make optional collector fields nullable

### DIFF
--- a/graylog2-server/src/main/java/org/graylog/plugins/sidecar/rest/models/Collector.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/sidecar/rest/models/Collector.java
@@ -61,9 +61,11 @@ public abstract class Collector {
     public abstract String configurationPath();
 
     @JsonProperty(FIELD_EXECUTE_PARAMETERS)
+    @Nullable
     public abstract String executeParameters();
 
     @JsonProperty(FIELD_VALIDATION_PARAMETERS)
+    @Nullable
     public abstract String validationParameters();
 
     @JsonProperty(FIELD_DEFAULT_TEMPLATE)

--- a/graylog2-web-interface/src/stores/sidecars/CollectorConfigurationsStore.js
+++ b/graylog2-web-interface/src/stores/sidecars/CollectorConfigurationsStore.js
@@ -45,7 +45,8 @@ const CollectorConfigurationsStore = Reflux.createStore({
   },
 
   all() {
-    const promise = this._fetchConfigurations({ pageSize: 0 })
+    const promise = this._fetchConfigurations({ pageSize: 0 });
+    promise
       .then(
         (response) => {
           this.configurations = response.configurations;
@@ -62,7 +63,8 @@ const CollectorConfigurationsStore = Reflux.createStore({
   },
 
   list({ query = '', page = 1, pageSize = 10 }) {
-    const promise = this._fetchConfigurations({ query: query, page: page, pageSize: pageSize })
+    const promise = this._fetchConfigurations({ query: query, page: page, pageSize: pageSize });
+    promise
       .then(
         (response) => {
           this.query = response.query;

--- a/graylog2-web-interface/src/stores/sidecars/CollectorsStore.js
+++ b/graylog2-web-interface/src/stores/sidecars/CollectorsStore.js
@@ -62,6 +62,7 @@ const CollectorsStore = Reflux.createStore({
 
   all() {
     const promise = this._fetchCollectors({ pageSize: 0 })
+    promise
       .then(
         (response) => {
           this.collectors = response.collectors;
@@ -78,6 +79,7 @@ const CollectorsStore = Reflux.createStore({
 
   list({ query = '', page = 1, pageSize = 10 }) {
     const promise = this._fetchCollectors({ query: query, page: page, pageSize: pageSize })
+    promise
       .then(
         (response) => {
           this.query = response.query;
@@ -106,6 +108,7 @@ const CollectorsStore = Reflux.createStore({
 
   create(collector) {
     const promise = fetch('POST', URLUtils.qualifyUrl(`${this.sourceUrl}/collectors`), collector)
+    promise
       .then(
         (response) => {
           UserNotification.success('', 'Collector successfully created');
@@ -123,6 +126,7 @@ const CollectorsStore = Reflux.createStore({
 
   update(collector) {
     const promise = fetch('PUT', URLUtils.qualifyUrl(`${this.sourceUrl}/collectors/${collector.id}`), collector)
+    promise
       .then(
         (response) => {
           UserNotification.success('', 'Collector successfully updated');

--- a/graylog2-web-interface/src/stores/sidecars/CollectorsStore.js
+++ b/graylog2-web-interface/src/stores/sidecars/CollectorsStore.js
@@ -61,7 +61,7 @@ const CollectorsStore = Reflux.createStore({
   },
 
   all() {
-    const promise = this._fetchCollectors({ pageSize: 0 })
+    const promise = this._fetchCollectors({ pageSize: 0 });
     promise
       .then(
         (response) => {
@@ -78,7 +78,7 @@ const CollectorsStore = Reflux.createStore({
   },
 
   list({ query = '', page = 1, pageSize = 10 }) {
-    const promise = this._fetchCollectors({ query: query, page: page, pageSize: pageSize })
+    const promise = this._fetchCollectors({ query: query, page: page, pageSize: pageSize });
     promise
       .then(
         (response) => {
@@ -107,7 +107,7 @@ const CollectorsStore = Reflux.createStore({
   },
 
   create(collector) {
-    const promise = fetch('POST', URLUtils.qualifyUrl(`${this.sourceUrl}/collectors`), collector)
+    const promise = fetch('POST', URLUtils.qualifyUrl(`${this.sourceUrl}/collectors`), collector);
     promise
       .then(
         (response) => {
@@ -125,7 +125,7 @@ const CollectorsStore = Reflux.createStore({
   },
 
   update(collector) {
-    const promise = fetch('PUT', URLUtils.qualifyUrl(`${this.sourceUrl}/collectors/${collector.id}`), collector)
+    const promise = fetch('PUT', URLUtils.qualifyUrl(`${this.sourceUrl}/collectors/${collector.id}`), collector);
     promise
       .then(
         (response) => {

--- a/graylog2-web-interface/src/stores/sidecars/SidecarsStore.js
+++ b/graylog2-web-interface/src/stores/sidecars/SidecarsStore.js
@@ -136,7 +136,8 @@ const SidecarsStore = Reflux.createStore({
       return { node_id: sidecar.node_id, assignments: assignments };
     });
 
-    const promise = fetch('PUT', URLUtils.qualifyUrl(`${this.sourceUrl}/configurations`), { nodes: nodes })
+    const promise = fetch('PUT', URLUtils.qualifyUrl(`${this.sourceUrl}/configurations`), { nodes: nodes });
+    promise
       .then(
         (response) => {
           UserNotification.success('', `Configuration change for ${sidecars.length} collectors requested`);

--- a/graylog2-web-interface/src/stores/sidecars/SidecarsStore.js
+++ b/graylog2-web-interface/src/stores/sidecars/SidecarsStore.js
@@ -82,7 +82,7 @@ const SidecarsStore = Reflux.createStore({
     const promise = fetchPeriodically('GET', URLUtils.qualifyUrl(`${this.sourceUrl}/${sidecarId}`));
     promise
       .catch(
-        error => {
+        (error) => {
           UserNotification.error(`Fetching Sidecar failed with status: ${error}`,
             'Could not retrieve Sidecar');
         });
@@ -97,7 +97,7 @@ const SidecarsStore = Reflux.createStore({
     const promise = fetch('PUT', URLUtils.qualifyUrl(`${this.sourceUrl}/${sidecarId}/action`), [action]);
     promise
       .catch(
-        error => {
+        (error) => {
           UserNotification.error(`Restarting Sidecar failed with status: ${error}`,
             'Could not restart Sidecar');
         });
@@ -108,7 +108,7 @@ const SidecarsStore = Reflux.createStore({
     const promise = fetchPeriodically('GET', URLUtils.qualifyUrl(`${this.sourceUrl}/${sidecarId}/action`));
     promise
       .catch(
-        error => {
+        (error) => {
           UserNotification.error(`Fetching Sidecar actions failed with status: ${error}`,
             'Could not retrieve Sidecar actions');
         });


### PR DESCRIPTION
This PR fixes #5046 by marking the optional collector fields as nullable.

As #5046 also described, the web interface rendered another page, once the form was submitted, even if the end result was an error coming from the server. The PR also changes how we add handlers to the promises in the sidecar stores, to ensure that an error in the backend will not call `then` handlers added to the action promise. More info on chaining handlers vs multiple handlers in https://javascript.info/promise-chaining.