### PR TITLE
Remove audit log from resolve action of catalog recource

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/audit/AuditEventTypes.java
+++ b/graylog2-server/src/main/java/org/graylog2/audit/AuditEventTypes.java
@@ -34,7 +34,6 @@ public class AuditEventTypes implements PluginAuditEventTypes {
     public static final String ALERT_RECEIVER_DELETE = PREFIX + "alert_receiver:delete";
     public static final String ALERT_RECEIVER_UPDATE = PREFIX + "alert_receiver:update";
     public static final String AUTHENTICATION_PROVIDER_CONFIGURATION_UPDATE = PREFIX + "authentication_provider_configuration:update";
-    public static final String CATALOG_RESOLVE = PREFIX + "catalog:resolve";
     public static final String CLUSTER_CONFIGURATION_CREATE = PREFIX + "cluster_configuration:create";
     public static final String CLUSTER_CONFIGURATION_DELETE = PREFIX + "cluster_configuration:delete";
     public static final String CLUSTER_CONFIGURATION_UPDATE = PREFIX + "cluster_configuration:update";
@@ -159,7 +158,6 @@ public class AuditEventTypes implements PluginAuditEventTypes {
             .add(ALERT_RECEIVER_DELETE)
             .add(ALERT_RECEIVER_UPDATE)
             .add(AUTHENTICATION_PROVIDER_CONFIGURATION_UPDATE)
-            .add(CATALOG_RESOLVE)
             .add(CLUSTER_CONFIGURATION_CREATE)
             .add(CLUSTER_CONFIGURATION_DELETE)
             .add(CLUSTER_CONFIGURATION_UPDATE)

--- a/graylog2-server/src/main/java/org/graylog2/rest/resources/system/contentpacks/CatalogResource.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/resources/system/contentpacks/CatalogResource.java
@@ -22,8 +22,7 @@ import io.swagger.annotations.ApiOperation;
 import io.swagger.annotations.ApiParam;
 import org.apache.shiro.authz.annotation.RequiresAuthentication;
 import org.apache.shiro.authz.annotation.RequiresPermissions;
-import org.graylog2.audit.AuditEventTypes;
-import org.graylog2.audit.jersey.AuditEvent;
+import org.graylog2.audit.jersey.NoAuditEvent;
 import org.graylog2.contentpacks.ContentPackService;
 import org.graylog2.contentpacks.model.entities.EntitiesWithConstraints;
 import org.graylog2.contentpacks.model.entities.EntityDescriptor;
@@ -68,7 +67,7 @@ public class CatalogResource {
     @Timed
     @ApiOperation(value = "Resolve dependencies of entities and return their configuration")
     @RequiresPermissions(RestPermissions.CATALOG_RESOLVE)
-    @AuditEvent(type = AuditEventTypes.CATALOG_RESOLVE)
+    @NoAuditEvent("this is not changing any data")
     public CatalogResolveResponse resolveEntities(
             @ApiParam(name = "JSON body", required = true)
             @Valid @NotNull CatalogResolveRequest request) {


### PR DESCRIPTION
## Description
Remove audit log events from catalog resource

## Motivation and Context
The resolve action of catalog resource does not need a audit log event, since it is only computing
and not altering the database.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
