### PR TITLE
Add Jest actions for use with ES Task API

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/indexer/cluster/jest/RequestResponseLogger.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/cluster/jest/RequestResponseLogger.java
@@ -17,8 +17,6 @@
 package org.graylog2.indexer.cluster.jest;
 
 import java.io.IOException;
-import java.net.URI;
-import java.net.URISyntaxException;
 import org.apache.http.HttpException;
 import org.apache.http.HttpHost;
 import org.apache.http.HttpRequest;
@@ -26,7 +24,6 @@ import org.apache.http.HttpResponse;
 import org.apache.http.HttpResponseInterceptor;
 import org.apache.http.RequestLine;
 import org.apache.http.StatusLine;
-import org.apache.http.client.utils.URIBuilder;
 import org.apache.http.protocol.HttpContext;
 import org.apache.http.protocol.HttpCoreContext;
 import org.slf4j.Logger;
@@ -54,17 +51,12 @@ public class RequestResponseLogger implements HttpResponseInterceptor {
     final HttpRequest httpRequest = (HttpRequest) context
         .getAttribute(HttpCoreContext.HTTP_REQUEST);
     final RequestLine request = httpRequest.getRequestLine();
-    URI uri = null;
-    try {
-      uri = new URIBuilder(targetHost.toURI()).setPath(request.getUri()).build();
-    } catch (URISyntaxException ignore) {
-      // we only update the path of a valid URI, that should never fail
-    }
-    logger.trace("[{} {}]: {} {}",
+    logger.trace("[{} {}]: {} {}{}",
         statusLine.getStatusCode(),
         statusLine.getReasonPhrase(),
         request.getMethod(),
-        uri
+        targetHost.toURI(),
+        request.getUri()
     );
   }
 }

--- a/graylog2-server/src/main/java/org/graylog2/indexer/cluster/jest/tasks/CancelTask.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/cluster/jest/tasks/CancelTask.java
@@ -14,28 +14,15 @@
  * You should have received a copy of the GNU General Public License
  * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
  */
-/**
- * This file is part of Graylog.
- *
- * Graylog is free software: you can redistribute it and/or modify it under the terms of the GNU
- * General Public License as published by the Free Software Foundation, either version 3 of the
- * License, or (at your option) any later version.
- *
- * Graylog is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even
- * the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General
- * Public License for more details.
- *
- * You should have received a copy of the GNU General Public License along with Graylog.  If not,
- * see <http://www.gnu.org/licenses/>.
- */
 package org.graylog2.indexer.cluster.jest.tasks;
 
 import io.searchbox.action.AbstractMultiINodeActionBuilder;
 import io.searchbox.action.GenericResultAbstractAction;
+
+import javax.annotation.Nonnull;
 import java.io.UnsupportedEncodingException;
 import java.net.URLEncoder;
 import java.util.Objects;
-import javax.annotation.Nonnull;
 
 public class CancelTask extends GenericResultAbstractAction {
 

--- a/graylog2-server/src/main/java/org/graylog2/indexer/cluster/jest/tasks/CancelTask.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/cluster/jest/tasks/CancelTask.java
@@ -1,0 +1,82 @@
+/**
+ * This file is part of Graylog.
+ *
+ * Graylog is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
+ */
+/**
+ * This file is part of Graylog.
+ *
+ * Graylog is free software: you can redistribute it and/or modify it under the terms of the GNU
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * Graylog is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even
+ * the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General
+ * Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with Graylog.  If not,
+ * see <http://www.gnu.org/licenses/>.
+ */
+package org.graylog2.indexer.cluster.jest.tasks;
+
+import io.searchbox.action.AbstractMultiINodeActionBuilder;
+import io.searchbox.action.GenericResultAbstractAction;
+import java.io.UnsupportedEncodingException;
+import java.net.URLEncoder;
+import java.util.Objects;
+import javax.annotation.Nonnull;
+
+public class CancelTask extends GenericResultAbstractAction {
+
+  private final String taskId;
+
+  public CancelTask(@Nonnull String taskId) {
+    this.taskId = Objects.requireNonNull(taskId);
+    setURI(buildURI());
+  }
+
+  @Override
+  public String getRestMethodName() {
+    return "POST";
+  }
+
+  @Override
+  protected String buildURI() {
+    try {
+      return super.buildURI() + "/_tasks/" + URLEncoder.encode(taskId, "utf-8") + "/_cancel";
+    } catch (UnsupportedEncodingException ignored) {
+      // cannot happen, utf-8 is a system encoding
+      return null;
+    }
+  }
+
+  public static class Builder extends AbstractMultiINodeActionBuilder<CancelTask, Builder> {
+
+    private String taskId;
+
+    public Builder(@Nonnull String taskId) {
+      Objects.requireNonNull(taskId);
+      this.taskId = taskId;
+    }
+
+    public Builder actions(String actionFilter) {
+      return setParameter("actions", actionFilter);
+    }
+
+    @Override
+    public CancelTask build() {
+      return new CancelTask(taskId);
+    }
+  }
+}

--- a/graylog2-server/src/main/java/org/graylog2/indexer/cluster/jest/tasks/GetTasks.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/cluster/jest/tasks/GetTasks.java
@@ -1,0 +1,114 @@
+/**
+ * This file is part of Graylog.
+ *
+ * Graylog is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
+ */
+/**
+ * This file is part of Graylog.
+ *
+ * Graylog is free software: you can redistribute it and/or modify it under the terms of the GNU
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * Graylog is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even
+ * the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General
+ * Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with Graylog.  If not,
+ * see <http://www.gnu.org/licenses/>.
+ */
+package org.graylog2.indexer.cluster.jest.tasks;
+
+import io.searchbox.action.AbstractMultiINodeActionBuilder;
+import io.searchbox.action.GenericResultAbstractAction;
+import java.io.UnsupportedEncodingException;
+import java.net.URLEncoder;
+import javax.annotation.Nullable;
+
+public class GetTasks extends GenericResultAbstractAction {
+
+  @Nullable
+  private final String taskId;
+
+  protected GetTasks(Builder builder, @Nullable String taskId) {
+    super(builder);
+    this.taskId = taskId;
+    setURI(buildURI());
+  }
+
+  @Override
+  protected String buildURI() {
+    final String baseUri = super.buildURI() + "/_tasks";
+    if (taskId != null) {
+      try {
+        return baseUri + "/" + URLEncoder.encode(taskId, "utf-8");
+      } catch (UnsupportedEncodingException ignored) {
+        // cannot happen, utf-8 is a system encoding
+        return null;
+      }
+    }
+    return baseUri;
+  }
+
+  @Override
+  public String getRestMethodName() {
+    return "GET";
+  }
+
+  public static class Builder extends AbstractMultiINodeActionBuilder<GetTasks, GetTasks.Builder> {
+
+    private String taskId;
+
+    public Builder() {
+      this(null);
+    }
+
+    public Builder(String taskId) {
+      this.taskId = taskId;
+    }
+
+    public Builder waitForCompletion(boolean waitForCompletion) {
+      return setParameter("wait_for_completion", waitForCompletion);
+    }
+
+    public Builder timeout(String timeout) {
+      return setParameter("timeout", timeout);
+    }
+
+    public Builder actions(String actionFilter) {
+      return setParameter("actions", actionFilter);
+    }
+
+    public Builder detailed(boolean detailed) {
+      return setParameter("detailed", detailed);
+    }
+
+    public Builder ofParentTaskId(String parentTaskId) {
+      return setParameter("parent_task_id", parentTaskId);
+    }
+
+    @Override
+    public GetTasks build() {
+      final String joinedNodes = getJoinedNodes();
+      // do not include `_all` if no nodes were given, some endpoints don't like this
+      if (!"_all".equals(joinedNodes)) {
+        // this api uses nodes as a parameter, not in the url
+        setParameter("nodes", joinedNodes);
+      }
+      return new GetTasks(this, taskId);
+    }
+
+  }
+
+}

--- a/graylog2-server/src/main/java/org/graylog2/indexer/cluster/jest/tasks/GetTasks.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/cluster/jest/tasks/GetTasks.java
@@ -14,27 +14,14 @@
  * You should have received a copy of the GNU General Public License
  * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
  */
-/**
- * This file is part of Graylog.
- *
- * Graylog is free software: you can redistribute it and/or modify it under the terms of the GNU
- * General Public License as published by the Free Software Foundation, either version 3 of the
- * License, or (at your option) any later version.
- *
- * Graylog is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even
- * the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General
- * Public License for more details.
- *
- * You should have received a copy of the GNU General Public License along with Graylog.  If not,
- * see <http://www.gnu.org/licenses/>.
- */
 package org.graylog2.indexer.cluster.jest.tasks;
 
 import io.searchbox.action.AbstractMultiINodeActionBuilder;
 import io.searchbox.action.GenericResultAbstractAction;
+
+import javax.annotation.Nullable;
 import java.io.UnsupportedEncodingException;
 import java.net.URLEncoder;
-import javax.annotation.Nullable;
 
 public class GetTasks extends GenericResultAbstractAction {
 

--- a/graylog2-server/src/test/java/org/graylog2/ElasticsearchBase.java
+++ b/graylog2-server/src/test/java/org/graylog2/ElasticsearchBase.java
@@ -16,10 +16,11 @@
  */
 package org.graylog2;
 
+import static com.google.common.base.Strings.nullToEmpty;
+import static org.assertj.core.api.Assertions.assertThat;
+
 import com.fasterxml.jackson.databind.JsonNode;
 import com.github.joschi.jadconfig.util.Duration;
-import com.github.joschi.nosqlunit.elasticsearch.http.ElasticsearchConfiguration;
-import com.github.joschi.nosqlunit.elasticsearch.http.ElasticsearchRule;
 import com.github.zafarkhaja.semver.Version;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.io.Resources;
@@ -38,12 +39,6 @@ import io.searchbox.indices.mapping.GetMapping;
 import io.searchbox.indices.template.DeleteTemplate;
 import io.searchbox.indices.template.GetTemplate;
 import io.searchbox.indices.template.PutTemplate;
-import org.graylog2.indexer.IndexMapping;
-import org.graylog2.indexer.IndexMapping2;
-import org.graylog2.indexer.IndexMapping5;
-import org.junit.Rule;
-
-import javax.inject.Inject;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.UncheckedIOException;
@@ -54,9 +49,11 @@ import java.util.HashMap;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Properties;
-
-import static com.google.common.base.Strings.nullToEmpty;
-import static org.assertj.core.api.Assertions.assertThat;
+import javax.inject.Inject;
+import org.graylog2.indexer.IndexMapping;
+import org.graylog2.indexer.IndexMapping2;
+import org.graylog2.indexer.IndexMapping5;
+import org.junit.Rule;
 
 public abstract class ElasticsearchBase {
     private static final String PROPERTIES_RESOURCE_NAME = "elasticsearch.properties";

--- a/graylog2-server/src/test/java/org/graylog2/ElasticsearchConfiguration.java
+++ b/graylog2-server/src/test/java/org/graylog2/ElasticsearchConfiguration.java
@@ -1,0 +1,200 @@
+/**
+ * This file is part of Graylog.
+ *
+ * Graylog is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.graylog2;
+
+import com.lordofthejars.nosqlunit.core.AbstractJsr330Configuration;
+import io.searchbox.client.JestClient;
+import io.searchbox.client.JestClientFactory;
+import io.searchbox.client.config.HttpClientConfig;
+
+import java.util.Collections;
+import java.util.Map;
+import java.util.Set;
+import org.apache.http.impl.client.HttpClientBuilder;
+import org.graylog2.indexer.cluster.jest.RequestResponseLogger;
+
+public class ElasticsearchConfiguration extends AbstractJsr330Configuration {
+  private final JestClient client;
+  private final boolean deleteAllIndices;
+  private final boolean createIndices;
+  private final Map<String, Object> indexSettings;
+  private final Map<String, Map<String, Object>> indexTemplates;
+
+  ElasticsearchConfiguration(JestClient client,
+      boolean deleteAllIndices,
+      boolean createIndices,
+      Map<String, Object> indexSettings,
+      Map<String, Map<String, Object>> indexTemplates) {
+    this.client = client;
+    this.deleteAllIndices = deleteAllIndices;
+    this.createIndices = createIndices;
+    this.indexSettings = indexSettings;
+    this.indexTemplates = indexTemplates;
+  }
+
+  public JestClient getClient() {
+    return client;
+  }
+
+  public boolean isCreateIndices() {
+    return createIndices;
+  }
+
+  public boolean isDeleteAllIndices() {
+    return deleteAllIndices;
+  }
+
+  public Map<String, Object> getIndexSettings() {
+    return indexSettings;
+  }
+
+  public Map<String, Map<String, Object>> getIndexTemplates() {
+    return indexTemplates;
+  }
+
+  /**
+   * Return a default builder for {@link ElasticsearchConfiguration}.
+   */
+  public static Builder remoteElasticsearch() {
+    return new Builder();
+  }
+
+  /**
+   * Return a builder for {@link ElasticsearchConfiguration} pre-configured with the given Elasticsearch node URL.
+   *
+   * @param server The URL of the Elasticsearch node to connect to
+   */
+  public static Builder remoteElasticsearch(String server) {
+    return remoteElasticsearch(Collections.singleton(server));
+  }
+
+  /**
+   * Return a builder for {@link ElasticsearchConfiguration} pre-configured with the given Elasticsearch node URLs.
+   *
+   * @param servers The URLs of the Elasticsearch nodes to connect to
+   */
+  public static Builder remoteElasticsearch(Set<String> servers) {
+    return new Builder().servers(servers);
+  }
+
+  public static class Builder {
+    private static final String DEFAULT_SERVER = "http://localhost:9200/";
+
+    private Set<String> servers = Collections.singleton(DEFAULT_SERVER);
+    private HttpClientConfig httpClientConfig = null;
+    private boolean createIndices = false;
+    private boolean deleteAllIndices = false;
+    private Map<String, Object> indexSettings = Collections.emptyMap();
+    private Map<String, Map<String, Object>> indexTemplates = Collections.emptyMap();
+
+    private Builder() {
+    }
+
+    /**
+     * The URL of the Elasticsearch node to connect to, for example {@code http://127.0.0.1:9200/}.
+     *
+     * @param server The URLs of the Elasticsearch nodes to connect to
+     */
+    public Builder server(String server) {
+      return servers(Collections.singleton(server));
+    }
+
+    /**
+     * The URLs of the Elasticsearch nodes to connect to, for example {@code http://127.0.0.1:9200/}.
+     *
+     * @param servers The URLs of the Elasticsearch nodes to connect to
+     */
+    public Builder servers(Set<String> servers) {
+      this.servers = servers;
+      return this;
+    }
+
+    /**
+     * Set the HTTP client configuration for {@link JestClient}.
+     */
+    public Builder httpClientConfig(HttpClientConfig httpClientConfig) {
+      this.httpClientConfig = httpClientConfig;
+      return this;
+    }
+
+    /**
+     * Whether to explicitly delete <em>all</em> indices from Elasticsearch when deleting data.
+     *
+     * @param deleteAllIndices Delete <em>all</em> indices from Elasticsearch if {@literal true}, delete individual documents if {@literal false}
+     */
+    public Builder deleteAllIndices(boolean deleteAllIndices) {
+      this.deleteAllIndices = deleteAllIndices;
+      return this;
+    }
+
+    /**
+     * Whether to explicitly create Elasticsearch indices when inserting data.
+     *
+     * @see #indexSettings(Map)
+     * @see #indexTemplates(Map)
+     */
+    public Builder createIndices(boolean createIndices) {
+      this.createIndices = createIndices;
+      return this;
+    }
+
+    /**
+     * Index settings to use if explicitly creating indices is enabled when inserting data.
+     *
+     * @see #createIndices(boolean)
+     * @see <a href="https://www.elastic.co/guide/en/elasticsearch/guide/2.x/_index_settings.html">Elasticsearch: The Definitive Guide » Getting Started » Index Management » Index Settings</a>
+     * @see <a href="https://www.elastic.co/guide/en/elasticsearch/reference/current/index-modules.html">Elasticsearch Reference » Index Modules</a>
+     */
+    public Builder indexSettings(Map<String, Object> indexSettings) {
+      this.indexSettings = indexSettings;
+      return this;
+    }
+
+    /**
+     * Collection of index templates to create before inserting data.
+     * The index templates will be deleted after data has been inserted.
+     *
+     * @param indexTemplates A map of index templates with the key being the name of the index template
+     *                       and the value being the template source.
+     * @see <a href="https://www.elastic.co/guide/en/elasticsearch/reference/current/indices-templates.html">Elasticsearch Reference » Indices APIs » Index Templates</a>
+     */
+    public Builder indexTemplates(Map<String, Map<String, Object>> indexTemplates) {
+      this.indexTemplates = indexTemplates;
+      return this;
+    }
+
+    public ElasticsearchConfiguration build() {
+      final JestClient client = getClient();
+      client.setServers(servers);
+
+      return new ElasticsearchConfiguration(client, deleteAllIndices, createIndices, indexSettings, indexTemplates);
+    }
+
+    private JestClient getClient() {
+      final JestClientFactory clientFactory = new JestClientFactory() {
+        @Override
+        protected HttpClientBuilder configureHttpClient(HttpClientBuilder builder) {
+          return super.configureHttpClient(builder.addInterceptorLast(new RequestResponseLogger()));
+        }
+      };
+      if (httpClientConfig != null) {
+        clientFactory.setHttpClientConfig(httpClientConfig);
+      }
+      return clientFactory.getObject();
+    }
+  }
+}

--- a/graylog2-server/src/test/java/org/graylog2/ElasticsearchRule.java
+++ b/graylog2-server/src/test/java/org/graylog2/ElasticsearchRule.java
@@ -1,0 +1,134 @@
+/**
+ * This file is part of Graylog.
+ *
+ * Graylog is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.graylog2;
+
+import com.github.joschi.nosqlunit.elasticsearch.http.ElasticsearchOperation;
+import com.lordofthejars.nosqlunit.core.AbstractNoSqlTestRule;
+import com.lordofthejars.nosqlunit.core.DatabaseOperation;
+import io.searchbox.client.JestClient;
+import java.util.Collections;
+import java.util.Set;
+
+public class ElasticsearchRule extends AbstractNoSqlTestRule {
+
+    private static final String EXTENSION = "json";
+
+    private DatabaseOperation<? extends JestClient> databaseOperation;
+
+    public static Builder newElasticsearchRule() {
+        return new Builder();
+    }
+
+    public static class Builder {
+
+        private ElasticsearchConfiguration elasticsearchConfiguration;
+        private Object target;
+
+        private Builder() {
+        }
+
+        /**
+         * Configure the {@link ElasticsearchRule} with the given configuration.
+         *
+         * @param elasticsearchConfiguration The configuration for the {@link ElasticsearchRule}
+         */
+        public Builder configure(ElasticsearchConfiguration elasticsearchConfiguration) {
+            this.elasticsearchConfiguration = elasticsearchConfiguration;
+            return this;
+        }
+
+        public Builder unitInstance(Object target) {
+            this.target = target;
+            return this;
+        }
+
+        /**
+         * Build an {@link ElasticsearchRule} with the default configuration (connecting to {@literal http://localhost:9200}).
+         *
+         * @return An {@link ElasticsearchRule} using the default configuration
+         */
+        public ElasticsearchRule remoteElasticsearch() {
+            return new ElasticsearchRule(ElasticsearchConfiguration.remoteElasticsearch().build());
+        }
+
+        /**
+         * Build an {@link ElasticsearchRule} with the default configuration (connecting to the given Elasticsearch node).
+         *
+         * @return An {@link ElasticsearchRule} using the default configuration
+         */
+        public ElasticsearchRule remoteElasticsearch(String server) {
+            return remoteElasticsearch(Collections.singleton(server));
+        }
+
+        /**
+         * Build an {@link ElasticsearchRule} with the default configuration (connecting to the given Elasticsearch nodes).
+         *
+         * @return An {@link ElasticsearchRule} using the default configuration
+         */
+        public ElasticsearchRule remoteElasticsearch(Set<String> servers) {
+            return new ElasticsearchRule(ElasticsearchConfiguration.remoteElasticsearch(servers).build());
+        }
+
+        /**
+         * Build an {@link ElasticsearchRule} with the given configuration.
+         *
+         * @return An {@link ElasticsearchRule} using the given configuration
+         * @see #configure(ElasticsearchConfiguration)
+         */
+        public ElasticsearchRule build() {
+
+            if (this.elasticsearchConfiguration == null) {
+                throw new IllegalArgumentException("Configuration object should be provided.");
+            }
+
+            return new ElasticsearchRule(elasticsearchConfiguration, target);
+        }
+
+    }
+
+    public ElasticsearchRule(ElasticsearchConfiguration elasticsearchConfiguration) {
+        super(elasticsearchConfiguration.getConnectionIdentifier());
+        this.databaseOperation = new ElasticsearchOperation(
+                elasticsearchConfiguration.getClient(),
+                elasticsearchConfiguration.isDeleteAllIndices(),
+                elasticsearchConfiguration.isCreateIndices(),
+                elasticsearchConfiguration.getIndexSettings(),
+                elasticsearchConfiguration.getIndexTemplates()
+        );
+    }
+
+    /*With JUnit 10 is impossible to get target from a Rule, it seems that future versions will support it. For now constructor is apporach is the only way.*/
+    public ElasticsearchRule(ElasticsearchConfiguration elasticsearchConfiguration, Object target) {
+        this(elasticsearchConfiguration);
+        setTarget(target);
+    }
+
+    @Override
+    public DatabaseOperation getDatabaseOperation() {
+        return this.databaseOperation;
+    }
+
+    @Override
+    public String getWorkingExtension() {
+        return EXTENSION;
+    }
+
+    @Override
+    public void close() {
+        this.databaseOperation.connectionManager().shutdownClient();
+    }
+}

--- a/graylog2-server/src/test/java/org/graylog2/indexer/cluster/jest/tasks/GetTasksTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/indexer/cluster/jest/tasks/GetTasksTest.java
@@ -1,0 +1,200 @@
+/**
+ * This file is part of Graylog.
+ *
+ * Graylog is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.graylog2.indexer.cluster.jest.tasks;
+
+
+import static com.google.common.collect.ImmutableMap.of;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.fail;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.MissingNode;
+import io.searchbox.client.JestResult;
+import io.searchbox.core.Bulk;
+import io.searchbox.core.BulkResult;
+import io.searchbox.core.Index;
+import io.searchbox.core.Index.Builder;
+import io.searchbox.indices.reindex.Reindex;
+import java.io.IOException;
+import java.net.SocketTimeoutException;
+import java.util.Collections;
+import org.assertj.core.api.ObjectAssert;
+import org.graylog2.ElasticsearchBase;
+import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class GetTasksTest extends ElasticsearchBase {
+
+  private static final Logger LOG = LoggerFactory.getLogger(GetTasksTest.class);
+  private static final MissingNode MISSING_NODE = MissingNode.getInstance();
+
+  private final static ObjectMapper om = new ObjectMapper();
+
+  private static void dump(JestResult result, String title) {
+    dump(result.getJsonObject(), title);
+  }
+
+  private static void dump(JsonNode node, String title) {
+    try {
+      LOG.info("{}:\n{}", title, om.writerWithDefaultPrettyPrinter().writeValueAsString(node));
+    } catch (JsonProcessingException e) {
+      LOG.error("Couldn't dump json!", e);
+    }
+  }
+
+  @Test
+  public void getTasks() throws IOException {
+    final GetTasks getTasks = new GetTasks.Builder().build();
+
+    final JestResult result = client().execute(getTasks);
+    assertThat(result.isSucceeded()).isTrue();
+
+    final JsonNode json = result.getJsonObject();
+    assertThat(json.path("nodes")).isNotEqualTo(MISSING_NODE);
+    for (JsonNode node : json.path("nodes")) {
+      assertThat(node.path("name")).isNotEqualTo(MISSING_NODE);
+      assertThat(node.path("tasks")).isNotEqualTo(MISSING_NODE);
+    }
+  }
+
+  @Test
+  public void findLongRunningTask() throws IOException {
+    final String indexName = createRandomIndex("gettasktest");
+    final String reindexName = createRandomIndex("reindex");
+    String reindexTaskId;
+    try {
+      prepareSourceIndex(indexName);
+
+      reindexTaskId = longRunningReindex(indexName, reindexName);
+      assertThat(reindexTaskId).isNotBlank();
+
+      final GetTasks getTasks = new GetTasks.Builder().detailed(true).build();
+      final JestResult tasksResult = client().execute(getTasks);
+      dump(tasksResult, "tasks");
+      assertThat(tasksResult.getJsonObject().findValuesAsText("action"))
+          .contains("indices:data/write/reindex");
+
+      final JsonNode reindexTaskNode = tasksResult.getJsonObject().findPath(reindexTaskId);
+      assertThat(reindexTaskNode.isObject()).isTrue();
+      assertThat(reindexTaskNode.path("cancellable").isBoolean()).isTrue();
+
+      final JestResult filteredTasksResult = client()
+          .execute(new GetTasks.Builder().detailed(true).actions("*reindex").build());
+      dump(filteredTasksResult, "filtered tasks");
+      assertThat(filteredTasksResult.isSucceeded()).isTrue();
+      final JsonNode filteredTasksJson = filteredTasksResult.getJsonObject();
+      // we should only have one task overall because we filtered on the only reindex task
+      assertThat(filteredTasksJson.findValues(reindexTaskId)).hasSize(1);
+      // repeat some generic checks as above when we manually peeled out the task result
+      final JsonNode ourReindexTask = filteredTasksJson.findValue(reindexTaskId);
+      assertThat(ourReindexTask.isObject()).isTrue();
+      assertThat(ourReindexTask.path("cancellable").isBoolean()).isTrue();
+
+//    this is unfortunate, because if there aren't any child tasks running _right_ now,
+//    then the response is empty. Not much to check for other than the success of the call itself
+
+      // get all child tasks of the reindexing task
+      final JestResult ofParentResult = client()
+          .execute(new GetTasks.Builder().ofParentTaskId(reindexTaskId).build());
+      assertThat(ofParentResult.isSucceeded()).isTrue();
+      final JsonNode parentJson = ofParentResult.getJsonObject();
+      dump(parentJson, "using parent_task_id (can be empty)");
+
+      // cancel the long running task
+      // we assume the task takes more than 1 second to complete
+      try {
+        final JestResult waitForCompleteTimeout = client().execute(
+            new GetTasks.Builder(reindexTaskId)
+                .waitForCompletion(true)
+                .timeout("250ms")
+                .build());
+        dump(waitForCompleteTimeout, "wait for completion with timeout");
+        assertThat(waitForCompleteTimeout.isSucceeded()).isFalse();
+      } catch (SocketTimeoutException e) {
+        // we expect a timeout here, all fine
+        System.out.println("Reindex still running, canceling it.");
+      } catch (Exception e) {
+        fail("Unexcepted exception", e);
+      }
+
+      final CancelTask cancelTask = new CancelTask.Builder(reindexTaskId).build();
+      final JestResult cancelResult = client().execute(cancelTask);
+      dump(cancelResult, "canceled task");
+      assertThat(cancelResult.isSucceeded()).isTrue();
+
+      // request the canceled task again and check that it is "done"
+      final GetTasks getCanceledTask = new GetTasks.Builder(reindexTaskId).build();
+      final JestResult canceledTaskResult = client().execute(getCanceledTask);
+      dump(canceledTaskResult, "after cancellation");
+      assertThat(canceledTaskResult.isSucceeded()).isTrue();
+      final JsonNode canceledJson = canceledTaskResult.getJsonObject();
+      assertThatJsonNode(canceledJson.path("completed"))
+          .matches(JsonNode::isBoolean)
+          .matches(completed -> !completed.asBoolean(), "task is not completed");
+      assertThatJsonNode(canceledJson.at("/task/status/canceled"))
+          .isNotEqualTo(MISSING_NODE)
+          .matches(JsonNode::isTextual)
+          .matches(status -> status.asText().equalsIgnoreCase("by user request"));
+    } finally {
+      deleteIndex(indexName);
+      deleteIndex(reindexName);
+    }
+  }
+
+  private void prepareSourceIndex(String indexName) throws IOException {
+    // we don't actually care about the document content, we just need some of them for scrolling
+    final Index doc = new Builder(of("message", "something")).build();
+
+    final Bulk.Builder bulkBuilder = new Bulk.Builder();
+    for (int i = 0; i < 10; i++) {
+      bulkBuilder.addAction(Collections.nCopies(10000, doc));
+      final BulkResult bulkResult = client().execute(
+          bulkBuilder
+              .defaultIndex(indexName)
+              .defaultType("test")
+              .build()
+      );
+      assertThat(bulkResult.isSucceeded()).isTrue();
+    }
+  }
+
+  private String longRunningReindex(String indexName, String reindexName)
+      throws IOException {
+    String reindexTaskId;
+    final Reindex reindex = new Reindex.Builder(
+        // use very small batch sizes
+        of("index", indexName, "size", 1),
+        of("index", reindexName))
+        // mas despacio, por favor
+        .requestsPerSecond(1)
+        .waitForCompletion(false)
+        .build();
+    final JestResult reindexResult = client().execute(reindex);
+    dump(reindexResult, "reindex response");
+    assertThat(reindexResult.isSucceeded()).isTrue();
+    reindexTaskId = reindexResult.getJsonObject().findPath("task").asText();
+    return reindexTaskId;
+  }
+
+  // A helper to avoid assertThat() creating IterableAssert objects: JsonNode is also Iterable<JsonNode>!
+  private static ObjectAssert<JsonNode> assertThatJsonNode(JsonNode node) {
+    return new ObjectAssert<>(node);
+  }
+}

--- a/graylog2-server/src/test/java/org/graylog2/indexer/cluster/jest/tasks/GetTasksTestIT.java
+++ b/graylog2-server/src/test/java/org/graylog2/indexer/cluster/jest/tasks/GetTasksTestIT.java
@@ -17,10 +17,6 @@
 package org.graylog2.indexer.cluster.jest.tasks;
 
 
-import static com.google.common.collect.ImmutableMap.of;
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.fail;
-
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -31,18 +27,23 @@ import io.searchbox.core.BulkResult;
 import io.searchbox.core.Index;
 import io.searchbox.core.Index.Builder;
 import io.searchbox.indices.reindex.Reindex;
-import java.io.IOException;
-import java.net.SocketTimeoutException;
-import java.util.Collections;
 import org.assertj.core.api.ObjectAssert;
 import org.graylog2.ElasticsearchBase;
 import org.junit.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-public class GetTasksTest extends ElasticsearchBase {
+import java.io.IOException;
+import java.net.SocketTimeoutException;
+import java.util.Collections;
 
-  private static final Logger LOG = LoggerFactory.getLogger(GetTasksTest.class);
+import static com.google.common.collect.ImmutableMap.of;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.fail;
+
+public class GetTasksTestIT extends ElasticsearchBase {
+
+  private static final Logger LOG = LoggerFactory.getLogger(GetTasksTestIT.class);
   private static final MissingNode MISSING_NODE = MissingNode.getInstance();
 
   private final static ObjectMapper om = new ObjectMapper();

--- a/graylog2-server/src/test/java/org/graylog2/indexer/indices/IndicesIT.java
+++ b/graylog2-server/src/test/java/org/graylog2/indexer/indices/IndicesIT.java
@@ -16,13 +16,16 @@
  */
 package org.graylog2.indexer.indices;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.Assume.assumeTrue;
+import static org.mockito.Mockito.mock;
+
 import com.codahale.metrics.MetricRegistry;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.BooleanNode;
 import com.fasterxml.jackson.databind.node.TextNode;
-import com.github.joschi.nosqlunit.elasticsearch.http.ElasticsearchConfiguration;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.eventbus.EventBus;
 import com.google.common.eventbus.Subscribe;
@@ -30,7 +33,14 @@ import com.lordofthejars.nosqlunit.annotation.UsingDataSet;
 import com.lordofthejars.nosqlunit.core.LoadStrategyEnum;
 import io.searchbox.client.JestResult;
 import io.searchbox.cluster.State;
+import java.io.IOException;
+import java.time.ZonedDateTime;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
 import org.graylog2.ElasticsearchBase;
+import org.graylog2.ElasticsearchConfiguration;
 import org.graylog2.audit.NullAuditEventSender;
 import org.graylog2.indexer.IndexMapping;
 import org.graylog2.indexer.IndexMappingFactory;
@@ -57,17 +67,6 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.mockito.junit.MockitoJUnit;
 import org.mockito.junit.MockitoRule;
-
-import java.io.IOException;
-import java.time.ZonedDateTime;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
-import java.util.Map;
-
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assume.assumeTrue;
-import static org.mockito.Mockito.mock;
 
 public class IndicesIT extends ElasticsearchBase {
     private static final String INDEX_NAME = "graylog_0";

--- a/graylog2-server/src/test/java/org/graylog2/indexer/results/ScrollResultIT.java
+++ b/graylog2-server/src/test/java/org/graylog2/indexer/results/ScrollResultIT.java
@@ -16,16 +16,23 @@
  */
 package org.graylog2.indexer.results;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.elasticsearch.index.query.QueryBuilders.matchAllQuery;
+
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.github.joschi.nosqlunit.elasticsearch.http.ElasticsearchConfiguration;
 import com.google.common.collect.ImmutableMap;
 import com.lordofthejars.nosqlunit.annotation.UsingDataSet;
 import com.lordofthejars.nosqlunit.core.LoadStrategyEnum;
 import io.searchbox.core.Search;
 import io.searchbox.core.SearchResult;
 import io.searchbox.params.Parameters;
+import java.io.IOException;
+import java.time.ZonedDateTime;
+import java.util.Collections;
+import java.util.Map;
 import org.elasticsearch.search.builder.SearchSourceBuilder;
 import org.graylog2.ElasticsearchBase;
+import org.graylog2.ElasticsearchConfiguration;
 import org.graylog2.indexer.IndexMapping;
 import org.graylog2.indexer.IndexSet;
 import org.graylog2.indexer.TestIndexSet;
@@ -40,14 +47,6 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.mockito.junit.MockitoJUnit;
 import org.mockito.junit.MockitoRule;
-
-import java.io.IOException;
-import java.time.ZonedDateTime;
-import java.util.Collections;
-import java.util.Map;
-
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.elasticsearch.index.query.QueryBuilders.matchAllQuery;
 
 public class ScrollResultIT extends ElasticsearchBase {
     @Rule

--- a/graylog2-server/src/test/java/org/graylog2/indexer/searches/SearchesIT.java
+++ b/graylog2-server/src/test/java/org/graylog2/indexer/searches/SearchesIT.java
@@ -16,18 +16,32 @@
  */
 package org.graylog2.indexer.searches;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.joda.time.DateTimeZone.UTC;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.startsWith;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
 import com.codahale.metrics.Histogram;
 import com.codahale.metrics.MetricRegistry;
 import com.codahale.metrics.Timer;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.github.joschi.nosqlunit.elasticsearch.http.ElasticsearchConfiguration;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSortedSet;
 import com.lordofthejars.nosqlunit.annotation.UsingDataSet;
 import com.lordofthejars.nosqlunit.core.LoadStrategyEnum;
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.SortedSet;
 import org.elasticsearch.index.query.RangeQueryBuilder;
 import org.graylog2.Configuration;
 import org.graylog2.ElasticsearchBase;
+import org.graylog2.ElasticsearchConfiguration;
 import org.graylog2.buffers.processors.fakestreams.FakeStream;
 import org.graylog2.indexer.IndexHelper;
 import org.graylog2.indexer.IndexSet;
@@ -66,21 +80,6 @@ import org.junit.Test;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnit;
 import org.mockito.junit.MockitoRule;
-
-import java.time.ZoneOffset;
-import java.time.ZonedDateTime;
-import java.util.Collections;
-import java.util.List;
-import java.util.Map;
-import java.util.SortedSet;
-
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.joda.time.DateTimeZone.UTC;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.ArgumentMatchers.startsWith;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
 
 public class SearchesIT extends ElasticsearchBase {
     private static final String REQUEST_TIMER_NAME = "org.graylog2.indexer.searches.Searches.elasticsearch.requests";


### PR DESCRIPTION
In preparation to expose reindex capabilities, we need to be able to access the status of the long running tasks (to show progress) and also be able to cancel them.

related to #4958 