### PR TITLE
Fix editing of content packs

### DIFF
--- a/graylog2-web-interface/src/components/content-packs/ContentPackSelection.test.jsx
+++ b/graylog2-web-interface/src/components/content-packs/ContentPackSelection.test.jsx
@@ -175,12 +175,18 @@ describe('<ContentPackSelection />', () => {
   it('should validate that all fields are filled out', () => {
     const breq = {
       title: 'breq',
-      type: 'spaceship',
+      type: {
+        name: 'spaceship',
+        version: '1',
+      },
       id: 'beef123',
     };
     const falcon = {
       title: 'falcon',
-      type: 'spaceship',
+      type: {
+        name: 'spaceship',
+        version: '1',
+      },
       id: 'beef124',
     };
     const entities = { spaceship: [breq, falcon] };

--- a/graylog2-web-interface/src/pages/EditContentPackPage.jsx
+++ b/graylog2-web-interface/src/pages/EditContentPackPage.jsx
@@ -35,11 +35,16 @@ const EditContentPackPage = createReactClass({
   },
 
   componentDidMount() {
-    ContentPacksActions.getRev(this.props.params.contentPackId, this.props.params.contentPackRev).then(() => {
+    ContentPacksActions.get(this.props.params.contentPackId).then(() => {
+      const originContentPackRev =  this.props.params.contentPackRev;
+      const newContentPack = this.state.contentPack[originContentPackRev];
+      const nextContentPackRev = Math.max(...Object.keys(this.state.contentPack).map(x => parseInt(x, 10))) + 1;
+      newContentPack.rev = nextContentPackRev;
+      this.setState({ contentPack: newContentPack });
+
       CatalogActions.showEntityIndex().then(() => {
         this._getSelectedEntities();
         this._getAppliedParameter();
-        this._bumpVersion();
       });
     });
   },
@@ -49,12 +54,12 @@ const EditContentPackPage = createReactClass({
       return;
     }
     const selectedEntities = this.state.contentPack.entities.reduce((result, entity) => {
-      if (this.state.entityIndex[entity.type] &&
-        this.state.entityIndex[entity.type].findIndex((fetchedEntity) => { return fetchedEntity.id === entity.id; }) >= 0) {
+      if (this.state.entityIndex[entity.type.name] &&
+        this.state.entityIndex[entity.type.name].findIndex((fetchedEntity) => { return fetchedEntity.id === entity.id; }) >= 0) {
         const newResult = result;
         const selectedEntity = { type: entity.type, id: entity.id };
-        newResult[entity.type] = result[entity.type] || [];
-        newResult[entity.type].push(selectedEntity);
+        newResult[entity.type.name] = result[entity.type.name] || [];
+        newResult[entity.type.name].push(selectedEntity);
         return newResult;
       }
       return result;
@@ -80,13 +85,6 @@ const EditContentPackPage = createReactClass({
       return newResult;
     }, {});
     this.setState({ appliedParameter: appliedParameter });
-  },
-
-  _bumpVersion() {
-    const newContentPack = ObjectUtils.clone(this.state.contentPack);
-    const rev = parseInt(newContentPack.rev, 10);
-    newContentPack.rev = rev + 1;
-    this.setState({ contentPack: newContentPack });
   },
 
   _onStateChanged(newState) {

--- a/graylog2-web-interface/src/pages/EditContentPackPage.jsx
+++ b/graylog2-web-interface/src/pages/EditContentPackPage.jsx
@@ -36,7 +36,7 @@ const EditContentPackPage = createReactClass({
 
   componentDidMount() {
     ContentPacksActions.get(this.props.params.contentPackId).then(() => {
-      const originContentPackRev =  this.props.params.contentPackRev;
+      const originContentPackRev = this.props.params.contentPackRev;
       const newContentPack = this.state.contentPack[originContentPackRev];
       const nextContentPackRev = Math.max(...Object.keys(this.state.contentPack).map(x => parseInt(x, 10))) + 1;
       newContentPack.rev = nextContentPackRev;


### PR DESCRIPTION
## Description
   * Fix revision bump when editing a new content pack revision
   * Fix selection of entities from former content pack revision

## Motivation and Context
   * When a content pack was created from revision `1` but there was already a revision `2`, the create would fail, since the new content pack would have a content pack `1`,
   * When editing a content pack the entities were not considering the new entity type format 

## How Has This Been Tested?
Edit a content pack

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
