### PR TITLE
Fix loading of collector on edit collector page

### DIFF
--- a/graylog2-web-interface/src/pages/SidecarEditCollectorPage.jsx
+++ b/graylog2-web-interface/src/pages/SidecarEditCollectorPage.jsx
@@ -25,6 +25,10 @@ const SidecarEditCollectorPage = createReactClass({
     };
   },
 
+  componentDidMount() {
+    this._reloadCollector();
+  },
+
   _reloadCollector() {
     CollectorsActions.getCollector(this.props.params.collectorId).then(this._setCollector);
   },


### PR DESCRIPTION
Cleaning up linter errors on #5074, I accidentally deleted the call to load the collector on that page, resulting into a page that was stuck in the loading state. This PR corrects that mistake.