### PR TITLE
Display right collector status on null status code

### DIFF
--- a/graylog2-web-interface/src/logic/sidecar/SidecarStatusEnum.js
+++ b/graylog2-web-interface/src/logic/sidecar/SidecarStatusEnum.js
@@ -31,7 +31,7 @@ const SidecarStatusEnum = {
   },
 
   toString(statusCode) {
-    switch (Number(statusCode)) {
+    switch (statusCode) {
       case this.RUNNING:
         return 'running';
       case this.FAILING:


### PR DESCRIPTION
In some situations a collector's status code may be temporarily `null`, for example when a sidecar is starting. When we converted that status code into a string, we did an intermediate conversion into number, which converted `null` into `0`, the status code for the `running` state. This is not correct, as the status for that case should be `unknown`.

As I couldn't find any case where the status is a string, this commit drops the conversion into a number, fixing the issue described above.
