### PR TITLE
Mark inactive sidecars in administration page

### DIFF
--- a/graylog2-web-interface/src/components/sidecars/administration/CollectorsAdministration.jsx
+++ b/graylog2-web-interface/src/components/sidecars/administration/CollectorsAdministration.jsx
@@ -12,6 +12,8 @@ import OperatingSystemIcon from 'components/sidecars/common/OperatingSystemIcon'
 import SidecarSearchForm from 'components/sidecars/common/SidecarSearchForm';
 import StatusIndicator from 'components/sidecars/common/StatusIndicator';
 
+import commonStyle from 'components/sidecars/common/CommonSidecarStyles.css';
+
 import CollectorsAdministrationActions from './CollectorsAdministrationActions';
 import CollectorsAdministrationFilters from './CollectorsAdministrationFilters';
 import FiltersSummary from './FiltersSummary';
@@ -238,9 +240,9 @@ const CollectorsAdministration = createReactClass({
         <div className={style.collectorEntry}>
           <Row>
             <Col md={12}>
-              <h4 className={`list-group-item-heading ${style.alignedInformation}`}>
+              <h4 className={`list-group-item-heading ${style.alignedInformation} ${!sidecar.active && commonStyle.greyedOut}`}>
                 {sidecar.node_name} <OperatingSystemIcon operatingSystem={sidecar.node_details.operating_system} />
-                &emsp;<small>{sidecar.node_id}</small>
+                &emsp;<small>{sidecar.node_id} {!sidecar.active && <b>&mdash; inactive</b>}</small>
               </h4>
             </Col>
           </Row>

--- a/graylog2-web-interface/src/components/sidecars/common/CommonSidecarStyles.css
+++ b/graylog2-web-interface/src/components/sidecars/common/CommonSidecarStyles.css
@@ -19,3 +19,8 @@
 :local(.topMargin) {
     margin-top: 10px;
 }
+
+:local(.greyedOut) {
+    opacity: 0.5;
+    z-index: 20;
+}

--- a/graylog2-web-interface/src/components/sidecars/sidecars/SidecarRow.css
+++ b/graylog2-web-interface/src/components/sidecars/sidecars/SidecarRow.css
@@ -1,8 +1,3 @@
 :local(.sidecarName) {
     word-break: break-all;
 }
-
-:local(.greyedOut) {
-    opacity: 0.5;
-    z-index: 20;
-}

--- a/graylog2-web-interface/src/components/sidecars/sidecars/SidecarRow.jsx
+++ b/graylog2-web-interface/src/components/sidecars/sidecars/SidecarRow.jsx
@@ -10,6 +10,7 @@ import OperatingSystemIcon from 'components/sidecars/common/OperatingSystemIcon'
 import StatusIndicator from 'components/sidecars/common/StatusIndicator';
 import SidecarStatusEnum from 'logic/sidecar/SidecarStatusEnum';
 
+import commonStyle from 'components/sidecars/common/CommonSidecarStyles.css';
 import style from './SidecarRow.css';
 
 class SidecarRow extends React.Component {
@@ -23,7 +24,7 @@ class SidecarRow extends React.Component {
 
   render() {
     const sidecar = this.props.sidecar;
-    const sidecarClass = sidecar.active ? '' : style.greyedOut;
+    const sidecarClass = sidecar.active ? '' : commonStyle.greyedOut;
     const annotation = sidecar.active ? '' : ' (inactive)';
     let sidecarStatus = { status: null, message: null, id: null };
 


### PR DESCRIPTION
In a similar way of how we do it in the sidecar list page, display some indication that a sidecar is inactive in the administration page.

<img width="1792" alt="screen shot 2018-09-10 at 17 12 06" src="https://user-images.githubusercontent.com/716185/45307515-808ae500-b51f-11e8-8d78-e713c14eac7c.png">
