### PR TITLE
Add file system type and name to FsStats

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/shared/system/stats/fs/FsStats.java
+++ b/graylog2-server/src/main/java/org/graylog2/shared/system/stats/fs/FsStats.java
@@ -51,6 +51,14 @@ public abstract class FsStats {
         public abstract String dev();
 
         @JsonProperty
+        @Nullable
+        public  abstract String typeName();
+
+        @JsonProperty
+        @Nullable
+        public  abstract String sysTypeName();
+
+        @JsonProperty
         public abstract long total();
 
         @JsonProperty
@@ -98,6 +106,8 @@ public abstract class FsStats {
         public static Filesystem create(String path,
                                         String mount,
                                         String dev,
+                                        String typeName,
+                                        String sysTypeName,
                                         long total,
                                         long free,
                                         long available,
@@ -114,7 +124,7 @@ public abstract class FsStats {
                                         double diskQueue,
                                         double diskServiceTime) {
             return new AutoValue_FsStats_Filesystem(
-                    path, mount, dev, total, free, available, used, usedPercent,
+                    path, mount, dev, typeName, sysTypeName, total, free, available, used, usedPercent,
                     inodesTotal, inodesFree, inodesUsed, inodesUsedPercent,
                     diskReads, diskWrites, diskReadBytes, diskWriteBytes, diskQueue, diskServiceTime);
         }
@@ -125,7 +135,7 @@ public abstract class FsStats {
                                         long available,
                                         long used,
                                         short usedPercent) {
-            return create(path, null, null, total, free, available, used, usedPercent,
+            return create(path, null, null, null, null, total, free, available, used, usedPercent,
                     -1L, -1L, -1L, (short) -1, -1L, -1L, -1L, -1L, -1L, -1L);
         }
     }

--- a/graylog2-server/src/main/java/org/graylog2/shared/system/stats/fs/SigarFsProbe.java
+++ b/graylog2-server/src/main/java/org/graylog2/shared/system/stats/fs/SigarFsProbe.java
@@ -44,6 +44,7 @@ public class SigarFsProbe implements FsProbe {
         this.locations = ImmutableSet.of(
                 configuration.getBinDir(),
                 configuration.getDataDir(),
+                configuration.getPluginDir(),
                 kafkaJournalConfiguration.getMessageJournalDir()
         );
     }
@@ -69,6 +70,8 @@ public class SigarFsProbe implements FsProbe {
 
                 String mount = null;
                 String dev = null;
+                String typeName = null;
+                String sysTypeName = null;
                 long total = -1;
                 long free = -1;
                 long available = -1;
@@ -87,6 +90,8 @@ public class SigarFsProbe implements FsProbe {
                 if (fileSystem != null) {
                     mount = fileSystem.getDirName();
                     dev = fileSystem.getDevName();
+                    typeName = fileSystem.getTypeName();
+                    sysTypeName = fileSystem.getSysTypeName();
 
                     final FileSystemUsage fileSystemUsage = sigar.getFileSystemUsage(mount);
                     if (fileSystemUsage != null) {
@@ -111,7 +116,7 @@ public class SigarFsProbe implements FsProbe {
                 }
 
                 final FsStats.Filesystem filesystem = FsStats.Filesystem.create(
-                        path, mount, dev, total, free, available, used, usedPercent,
+                        path, mount, dev, typeName, sysTypeName, total, free, available, used, usedPercent,
                         inodesTotal, inodesFree, inodesUsed, inodesUsedPercent,
                         diskReads, diskWrites, diskReadBytes, diskWriteBytes, diskQueue, diskServiceTime
                 );


### PR DESCRIPTION
The type will show if the file system is a local or remote one and the
name will show the file system name. (e.g. ext4)

This will help debugging IO issues, especially for the journal
directory.