### PR TITLE
Run template validation before saving collector configuration

### DIFF
--- a/graylog2-server/src/main/java/org/graylog/plugins/sidecar/services/ConfigurationService.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/sidecar/services/ConfigurationService.java
@@ -22,6 +22,7 @@ import freemarker.cache.StringTemplateLoader;
 import freemarker.cache.TemplateLoader;
 import freemarker.template.Template;
 import freemarker.template.TemplateException;
+import freemarker.template.TemplateExceptionHandler;
 import org.graylog.plugins.sidecar.rest.models.Configuration;
 import org.graylog.plugins.sidecar.rest.models.NodeMetrics;
 import org.graylog.plugins.sidecar.rest.models.Sidecar;
@@ -49,6 +50,8 @@ import java.util.UUID;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import static org.apache.commons.lang.CharEncoding.UTF_8;
+
 @Singleton
 public class ConfigurationService extends PaginatedDbService<Configuration> {
     private static final Logger LOG = LoggerFactory.getLogger(ConfigurationService.class);
@@ -68,6 +71,8 @@ public class ConfigurationService extends PaginatedDbService<Configuration> {
                 stringTemplateLoader });
         templateConfiguration.setTemplateLoader(multiTemplateLoader);
         templateConfiguration.setSharedVariable("indent", new IndentTemplateDirective());
+        templateConfiguration.setDefaultEncoding(UTF_8);
+        templateConfiguration.setTemplateExceptionHandler(TemplateExceptionHandler.RETHROW_HANDLER);
         templateConfiguration.setLogTemplateExceptions(false);
     }
 

--- a/graylog2-server/src/main/java/org/graylog/plugins/sidecar/services/ConfigurationService.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/sidecar/services/ConfigurationService.java
@@ -68,6 +68,7 @@ public class ConfigurationService extends PaginatedDbService<Configuration> {
                 stringTemplateLoader });
         templateConfiguration.setTemplateLoader(multiTemplateLoader);
         templateConfiguration.setSharedVariable("indent", new IndentTemplateDirective());
+        templateConfiguration.setLogTemplateExceptions(false);
     }
 
     public Configuration find(String id) {

--- a/graylog2-server/src/main/java/org/graylog/plugins/sidecar/template/RenderTemplateException.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/sidecar/template/RenderTemplateException.java
@@ -1,0 +1,13 @@
+package org.graylog.plugins.sidecar.template;
+
+public class RenderTemplateException extends Exception {
+    public RenderTemplateException() { }
+
+    public RenderTemplateException(String message) {
+        super(message);
+    }
+
+    public RenderTemplateException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/graylog2-server/src/main/java/org/graylog/plugins/sidecar/template/RenderTemplateException.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/sidecar/template/RenderTemplateException.java
@@ -1,3 +1,19 @@
+/**
+ * This file is part of Graylog.
+ *
+ * Graylog is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package org.graylog.plugins.sidecar.template;
 
 public class RenderTemplateException extends Exception {

--- a/graylog2-web-interface/src/stores/sidecars/CollectorConfigurationsStore.js
+++ b/graylog2-web-interface/src/stores/sidecars/CollectorConfigurationsStore.js
@@ -141,7 +141,7 @@ const CollectorConfigurationsStore = Reflux.createStore({
         UserNotification.success('', 'Configuration successfully created');
         return response;
       }, (error) => {
-        UserNotification.error(`Creating configuration failed with status: ${error.message}`,
+        UserNotification.error(error.status === 400 ? error.responseMessage : `Creating configuration failed with status: ${error.message}`,
           'Could not save configuration');
       });
 


### PR DESCRIPTION
This PR adds template validation before a collector configuration is added to the database. To do the validation we render a preview of the template and see if there was any error. This will probably not catch all errors that may happen, but it will at least prevent some undefined variables to be used, and check some lexical errors in the configuration template.

Fixes #5042 