### PR TITLE
Make "license:check" and "license:format" work from the project root

### DIFF
--- a/graylog-plugin-parent/pom.xml
+++ b/graylog-plugin-parent/pom.xml
@@ -44,7 +44,6 @@
         <!-- Plugin versions -->
         <jdeb.version>1.5</jdeb.version>
         <rpm-maven.version>2.1.5</rpm-maven.version>
-        <license-maven.version>2.11</license-maven.version>
     </properties>
 
     <dependencyManagement>
@@ -72,12 +71,6 @@
     <build>
         <pluginManagement>
             <plugins>
-                <plugin>
-                    <groupId>com.mycila</groupId>
-                    <artifactId>license-maven-plugin</artifactId>
-                    <version>${license-maven.version}</version>
-                </plugin>
-
                 <plugin>
                     <artifactId>jdeb</artifactId>
                     <groupId>org.vafer</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -159,6 +159,9 @@
         <!-- Nodejs dependencies -->
         <nodejs.version>v6.9.2</nodejs.version>
         <npm.version>4.0.3</npm.version>
+
+        <!-- Plugin versions -->
+        <license-maven.version>2.11</license-maven.version>
     </properties>
 
     <repositories>
@@ -298,6 +301,11 @@
                         <skip>true</skip>
                     </configuration>
                 </plugin>
+                <plugin>
+                    <groupId>com.mycila</groupId>
+                    <artifactId>license-maven-plugin</artifactId>
+                    <version>${license-maven.version}</version>
+                </plugin>
             </plugins>
         </pluginManagement>
 
@@ -351,6 +359,10 @@
                     <ignoreMissingDescriptor>true</ignoreMissingDescriptor>
                     <tarLongFileMode>posix</tarLongFileMode>
                 </configuration>
+            </plugin>
+            <plugin>
+                <groupId>com.mycila</groupId>
+                <artifactId>license-maven-plugin</artifactId>
             </plugin>
         </plugins>
     </build>


### PR DESCRIPTION
Fixes Graylog2/graylog-project-internal#19

manual backport of https://github.com/Graylog2/graylog2-server/pull/5029