### PR TITLE
Randomize chunk id only once.

### DIFF
--- a/graylog2-web-interface/webpack/UniqueChunkIdPlugin.js
+++ b/graylog2-web-interface/webpack/UniqueChunkIdPlugin.js
@@ -6,10 +6,14 @@ class UniqueChunkIdPlugin {
   // eslint-disable-next-line class-methods-use-this
   apply(compiler) {
     const randomId = crypto.randomBytes(4).toString('hex');
+    const prefix = randomId + '-';
     compiler.hooks.compilation.tap(pluginName, (compilation) => {
       compilation.hooks.optimizeChunkIds.tap(pluginName, chunks => chunks.map((chunk) => {
         // eslint-disable-next-line prefer-template, no-param-reassign
-        chunk.id = randomId + '-' + chunk.id;
+        if (chunk.id && chunk.id.startsWith && chunk.id.startsWith(prefix)) {
+          return chunk;
+        }
+        chunk.id = prefix + chunk.id;
         // eslint-disable-next-line prefer-template, no-param-reassign
         chunk.ids = chunk.ids.map(id => randomId + '-' + id);
         return chunk;


### PR DESCRIPTION
## Description
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Before this change, the chunk id of a webpack compilation was being
prefixed with a random, build-specific identifier. This happened for
every compilation, even partial ones (when changing a file during
webpack/webpack-dev-server watch mode). Unfortunately there was no check
if the prefix had already been added, so for every partial compilation
it was added all over again.

This PR introduces a check if the given chunk contains an id which is
already prefixed and skips prefixing it in this case.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
