### PR TITLE
Add more lifecycle indicators to `PageHeader`

### DIFF
--- a/graylog2-web-interface/src/components/common/PageHeader.jsx
+++ b/graylog2-web-interface/src/components/common/PageHeader.jsx
@@ -1,8 +1,14 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 import { Row, Col, Label, OverlayTrigger, Tooltip } from 'react-bootstrap';
+import lodash from 'lodash';
 
 import SupportLink from 'components/support/SupportLink';
+
+const LIFECYCLE_DEFAULT_MESSAGES = {
+  experimental: 'This Graylog feature is new and should be considered experimental.',
+  legacy: 'This feature has been discontinued and will be removed in a future Graylog version.',
+};
 
 /**
  * Component that renders a page header, with a title and some optional content.
@@ -22,31 +28,41 @@ class PageHeader extends React.Component {
      * Please see the examples to see how to use this in practice.
      */
     children: PropTypes.node,
-    /** Flag that specifies if the page is experimental or not. */
-    experimental: PropTypes.bool,
+    /** Indicates the lifecycle of the current page, which will display an indicator right next to the page title. */
+    lifecycle: PropTypes.oneOf(['experimental', 'legacy']),
+    /** Text to customize the default message for the given lifecycle. */
+    lifecycleMessage: PropTypes.node,
     /** Specifies if the page header is children of a content `Row` or not. */
     subpage: PropTypes.bool,
   };
 
   static defaultProps = {
-    experimental: false,
+    lifecycle: undefined,
+    lifecycleMessage: undefined,
     subpage: false,
     children: [],
   };
 
+  renderLifecycleIndicator = () => {
+    if (this.props.lifecycle === undefined) {
+      return null;
+    }
+
+    const label = lodash.upperFirst(this.props.lifecycle);
+    const defaultMessage = this.props.lifecycle === 'experimental' ? LIFECYCLE_DEFAULT_MESSAGES.experimental : LIFECYCLE_DEFAULT_MESSAGES.legacy;
+    const tooltip = <Tooltip id={this.props.lifecycle}>{this.props.lifecycleMessage || defaultMessage}</Tooltip>;
+
+    return (
+      <span style={{ cursor: 'help', marginLeft: 5, fontSize: 14, lineHeight: '20px', verticalAlign: 'text-top' }}>
+        <OverlayTrigger placement="bottom" overlay={tooltip}>
+          <Label bsStyle="primary">{label}</Label>
+        </OverlayTrigger>
+      </span>
+    );
+  };
+
   render() {
     const children = (this.props.children !== undefined && this.props.children.length !== undefined ? this.props.children : [this.props.children]);
-
-    let experimentalLabel;
-    if (this.props.experimental) {
-      experimentalLabel = (
-        <span style={{ cursor: 'help', marginLeft: 5, fontSize: 14, lineHeight: '20px', verticalAlign: 'text-top' }}>
-          <OverlayTrigger placement="bottom" overlay={<Tooltip id="experimental">This feature of Graylog is new and should be considered experimental.</Tooltip>}>
-            <Label bsStyle="primary">Experimental</Label>
-          </OverlayTrigger>
-        </span>
-      );
-    }
 
     const topLevelClassNames = this.props.subpage ? 'content-head' : 'content content-head';
     return (
@@ -62,7 +78,7 @@ class PageHeader extends React.Component {
             }
 
             <h1>
-              {this.props.title} <small>{experimentalLabel}</small>
+              {this.props.title} <small>{this.renderLifecycleIndicator()}</small>
             </h1>
             {children[0] &&
             <p className="description">

--- a/graylog2-web-interface/src/components/common/PageHeader.jsx
+++ b/graylog2-web-interface/src/components/common/PageHeader.jsx
@@ -12,7 +12,7 @@ import SupportLink from 'components/support/SupportLink';
 class PageHeader extends React.Component {
   static propTypes = {
     /** Page header heading. */
-    title: PropTypes.oneOfType([PropTypes.node, PropTypes.string]).isRequired,
+    title: PropTypes.node.isRequired,
     /**
      * One or more children, they will be used in the header in this order:
      *  1. Page description
@@ -21,7 +21,7 @@ class PageHeader extends React.Component {
      *
      * Please see the examples to see how to use this in practice.
      */
-    children: PropTypes.oneOfType([PropTypes.array, PropTypes.node]),
+    children: PropTypes.node,
     /** Flag that specifies if the page is experimental or not. */
     experimental: PropTypes.bool,
     /** Specifies if the page header is children of a content `Row` or not. */
@@ -31,6 +31,7 @@ class PageHeader extends React.Component {
   static defaultProps = {
     experimental: false,
     subpage: false,
+    children: [],
   };
 
   render() {

--- a/graylog2-web-interface/src/components/common/PageHeader.md
+++ b/graylog2-web-interface/src/components/common/PageHeader.md
@@ -10,7 +10,7 @@ that there is no border around the header, as the `subpage` prop is set:
 ```js
 const Button = require('react-bootstrap').Button;
 
-<PageHeader title="Here goes the page title" experimental subpage>
+<PageHeader title="Here goes the page title" lifecycle="experimental" subpage>
   <span>This is a page description</span>
   <span>This is a support message</span>
   <span><Button bsStyle="info">Action</Button></span>


### PR DESCRIPTION
`PageHeader` so far allowed us to set an `experimental` flag, that would show an indicator if the rendered page was still considered experimental.

This PR adds a `legacy` lifecycle stage as well, and makes setting lifecycles more generic, so we could add more in the future if needed.

This PR also adds the possibility to set custom lifecycle messages that will be displayed in the tooltip, so consumers of `PageHeader` can customise the default messages for the given lifecycle.

Refs https://github.com/Graylog2/graylog-plugin-collector/issues/90
