### PR TITLE
Remove legacy config options from config example

### DIFF
--- a/misc/graylog.conf
+++ b/misc/graylog.conf
@@ -632,17 +632,6 @@ mongodb_threads_allowed_to_block_multiplier = 5
 # The default cache time for dashboard widgets. (Default: 10 seconds, minimum: 1 second)
 #dashboard_widget_default_cache_time = 10s
 
-# Automatically load content packs in "content_packs_dir" on the first start of Graylog.
-#content_packs_loader_enabled = true
-
-# The directory which contains content packs which should be loaded on the first start of Graylog.
-#content_packs_dir = data/contentpacks
-
-# A comma-separated list of content packs (files in "content_packs_dir") which should be applied on
-# the first start of Graylog.
-# Default: empty
-content_packs_auto_load = grok-patterns.json
-
 # For some cluster-related REST requests, the node must query all other nodes in the cluster. This is the maximum number
 # of threads available for this. Increase it, if '/cluster/*' requests take long to complete.
 # Should be http_thread_pool_size * average_cluster_size if you have a high number of concurrent users.


### PR DESCRIPTION
## Description
In #5070 we removed the config options but forgot
the example config. This change removes the options
from the example config

Fixes #5119 

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
