### PR TITLE
Add quotes to default winlogbeat collector parameter

### DIFF
--- a/graylog2-server/src/main/java/org/graylog/plugins/sidecar/migrations/V20180212165000_AddDefaultCollectors.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/sidecar/migrations/V20180212165000_AddDefaultCollectors.java
@@ -59,8 +59,8 @@ public class V20180212165000_AddDefaultCollectors extends Migration {
                 "windows",
                 "C:\\Program Files\\Graylog\\sidecar\\winlogbeat.exe",
                 "C:\\Program Files\\Graylog\\sidecar\\generated\\winlogbeat.yml",
-                "-c %s",
-                "test config -c %s",
+                "-c \"%s\"",
+                "test config -c \"%s\"",
                 ""
         );
         ensureCollector(

--- a/graylog2-server/src/test/resources/org/graylog2/contentpacks/sidecar_collectors.json
+++ b/graylog2-server/src/test/resources/org/graylog2/contentpacks/sidecar_collectors.json
@@ -22,8 +22,8 @@
       "node_operating_system": "windows",
       "executable_path": "C:\\Program Files\\Graylog\\sidecar\\winlogbeat.exe",
       "configuration_path": "C:\\Program Files\\Graylog\\sidecar\\generated\\winlogbeat.yml",
-      "execute_parameters": "-c %s",
-      "validation_parameters": "test config -c %s",
+      "execute_parameters": "-c \"%s\"",
+      "validation_parameters": "test config -c \"%s\"",
       "default_template": ""
     },
     {


### PR DESCRIPTION
The config path contains whitespaces and needs to be quoted.

Fixes https://github.com/Graylog2/collector-sidecar/issues/290