### PR TITLE
Show entities in details of a content pack installation

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/contentpacks/facades/DashboardFacade.java
+++ b/graylog2-server/src/main/java/org/graylog2/contentpacks/facades/DashboardFacade.java
@@ -163,7 +163,7 @@ public class DashboardFacade implements EntityFacade<Dashboard> {
             throw new ContentPackException("Couldn't create dashboard", e);
         }
 
-        return NativeEntity.create(entity.id(), dashboard.getId(), TYPE_V1, dashboard);
+        return NativeEntity.create(entity.id(), dashboard.getId(), TYPE_V1, dashboard.getTitle(), dashboard);
     }
 
     private Dashboard createDashboard(

--- a/graylog2-server/src/main/java/org/graylog2/contentpacks/facades/GrokPatternFacade.java
+++ b/graylog2-server/src/main/java/org/graylog2/contentpacks/facades/GrokPatternFacade.java
@@ -92,7 +92,7 @@ public class GrokPatternFacade implements EntityFacade<GrokPattern> {
         final GrokPattern grokPattern = GrokPattern.create(name, pattern);
         try {
             final GrokPattern savedGrokPattern = grokPatternService.save(grokPattern);
-            return NativeEntity.create(entity.id(), savedGrokPattern.id(), TYPE_V1, savedGrokPattern);
+            return NativeEntity.create(entity.id(), savedGrokPattern.id(), TYPE_V1, savedGrokPattern.name(), savedGrokPattern);
         } catch (ValidationException e) {
             throw new RuntimeException("Couldn't create grok pattern " + grokPattern.name());
         }
@@ -130,7 +130,7 @@ public class GrokPatternFacade implements EntityFacade<GrokPattern> {
         final Optional<GrokPattern> grokPattern = grokPatternService.loadByName(name);
         grokPattern.ifPresent(existingPattern -> compareGrokPatterns(name, pattern, existingPattern.pattern()));
 
-        return grokPattern.map(gp -> NativeEntity.create(entity.id(), gp.id(), TYPE_V1, gp));
+        return grokPattern.map(gp -> NativeEntity.create(entity.id(), gp.id(), TYPE_V1,gp.name(), gp));
     }
 
     private void compareGrokPatterns(String name, String expectedPattern, String actualPattern) {

--- a/graylog2-server/src/main/java/org/graylog2/contentpacks/facades/InputFacade.java
+++ b/graylog2-server/src/main/java/org/graylog2/contentpacks/facades/InputFacade.java
@@ -223,7 +223,7 @@ public class InputFacade implements EntityFacade<InputWithExtractors> {
             throw new RuntimeException("Couldn't create extractors", e);
         }
 
-        return NativeEntity.create(entity.id(), input.getId(), TYPE_V1, InputWithExtractors.create(input, extractors));
+        return NativeEntity.create(entity.id(), input.getId(), TYPE_V1, input.getTitle(), InputWithExtractors.create(input, extractors));
     }
 
     private MessageInput createMessageInput(

--- a/graylog2-server/src/main/java/org/graylog2/contentpacks/facades/LookupCacheFacade.java
+++ b/graylog2-server/src/main/java/org/graylog2/contentpacks/facades/LookupCacheFacade.java
@@ -115,7 +115,7 @@ public class LookupCacheFacade implements EntityFacade<CacheDto> {
                 .build();
 
         final CacheDto savedCacheDto = cacheService.save(cacheDto);
-        return NativeEntity.create(entity.id(), savedCacheDto.name(), TYPE_V1, savedCacheDto);
+        return NativeEntity.create(entity.id(), savedCacheDto.name(), TYPE_V1, savedCacheDto.title(), savedCacheDto);
     }
 
     @Override
@@ -133,7 +133,7 @@ public class LookupCacheFacade implements EntityFacade<CacheDto> {
 
         final Optional<CacheDto> existingCache = cacheService.get(name);
 
-        return existingCache.map(cache -> NativeEntity.create(entity.id(), cache.id(), TYPE_V1, cache));
+        return existingCache.map(cache -> NativeEntity.create(entity.id(), cache.id(), TYPE_V1, cache.title(), cache));
     }
 
     @Override

--- a/graylog2-server/src/main/java/org/graylog2/contentpacks/facades/LookupDataAdapterFacade.java
+++ b/graylog2-server/src/main/java/org/graylog2/contentpacks/facades/LookupDataAdapterFacade.java
@@ -116,7 +116,7 @@ public class LookupDataAdapterFacade implements EntityFacade<DataAdapterDto> {
                 .build();
 
         final DataAdapterDto savedDataAdapterDto = dataAdapterService.save(dataAdapterDto);
-        return NativeEntity.create(entity.id(), savedDataAdapterDto.name(), TYPE_V1, savedDataAdapterDto);
+        return NativeEntity.create(entity.id(), savedDataAdapterDto.name(), TYPE_V1, savedDataAdapterDto.title(), savedDataAdapterDto);
     }
 
     @Override
@@ -134,7 +134,7 @@ public class LookupDataAdapterFacade implements EntityFacade<DataAdapterDto> {
 
         final Optional<DataAdapterDto> existingDataAdapter = dataAdapterService.get(name);
 
-        return existingDataAdapter.map(dataAdapter -> NativeEntity.create(entity.id(), dataAdapter.id(), TYPE_V1, dataAdapter));
+        return existingDataAdapter.map(dataAdapter -> NativeEntity.create(entity.id(), dataAdapter.id(), TYPE_V1, dataAdapter.title(), dataAdapter));
     }
 
     @Override

--- a/graylog2-server/src/main/java/org/graylog2/contentpacks/facades/LookupTableFacade.java
+++ b/graylog2-server/src/main/java/org/graylog2/contentpacks/facades/LookupTableFacade.java
@@ -133,7 +133,7 @@ public class LookupTableFacade implements EntityFacade<LookupTableDto> {
                 .defaultMultiValueType(lookupTableEntity.defaultMultiValueType().asEnum(parameters, LookupDefaultMultiValue.Type.class))
                 .build();
         final LookupTableDto savedLookupTableDto = lookupTableService.save(lookupTableDto);
-        return NativeEntity.create(entity.id(), savedLookupTableDto.id(), TYPE_V1, savedLookupTableDto);
+        return NativeEntity.create(entity.id(), savedLookupTableDto.id(), TYPE_V1, lookupTableDto.title(), savedLookupTableDto);
     }
 
     @Override
@@ -153,7 +153,7 @@ public class LookupTableFacade implements EntityFacade<LookupTableDto> {
         final Optional<LookupTableDto> lookupTable = lookupTableService.get(name);
         lookupTable.ifPresent(existingLookupTable -> compareLookupTable(name, title, existingLookupTable));
 
-        return lookupTable.map(lt -> NativeEntity.create(entity.id(), lt.id(), TYPE_V1, lt));
+        return lookupTable.map(lt -> NativeEntity.create(entity.id(), lt.id(), TYPE_V1, lt.title(), lt));
     }
 
     private void compareLookupTable(String name, String title, LookupTableDto existingLookupTable) {

--- a/graylog2-server/src/main/java/org/graylog2/contentpacks/facades/OutputFacade.java
+++ b/graylog2-server/src/main/java/org/graylog2/contentpacks/facades/OutputFacade.java
@@ -128,7 +128,7 @@ public class OutputFacade implements EntityFacade<Output> {
         );
         try {
             final Output output = outputService.create(createOutputRequest, username);
-            return NativeEntity.create(entity.id(), output.getId(), TYPE_V1, output);
+            return NativeEntity.create(entity.id(), output.getId(), TYPE_V1, output.getTitle(), output);
         } catch (ValidationException e) {
             throw new IllegalArgumentException(e);
         }

--- a/graylog2-server/src/main/java/org/graylog2/contentpacks/facades/PipelineFacade.java
+++ b/graylog2-server/src/main/java/org/graylog2/contentpacks/facades/PipelineFacade.java
@@ -141,7 +141,7 @@ public class PipelineFacade implements EntityFacade<PipelineDao> {
         final Set<Stream> connectedStreams = connectedStreams(connectedStreamEntities, nativeEntities);
         createPipelineConnections(pipelineId, connectedStreams);
 
-        return NativeEntity.create(entity.id(), pipelineId, TYPE_V1, savedPipelineDao);
+        return NativeEntity.create(entity.id(), pipelineId, TYPE_V1, savedPipelineDao.title(), savedPipelineDao);
     }
 
     private Set<Stream> connectedStreams(Set<EntityDescriptor> connectedStreamEntities, Map<EntityDescriptor, Object> nativeEntities) {

--- a/graylog2-server/src/main/java/org/graylog2/contentpacks/facades/PipelineRuleFacade.java
+++ b/graylog2-server/src/main/java/org/graylog2/contentpacks/facades/PipelineRuleFacade.java
@@ -102,7 +102,7 @@ public class PipelineRuleFacade implements EntityFacade<RuleDao> {
                 .build();
 
         final RuleDao savedRuleDao = ruleService.save(ruleDao);
-        return NativeEntity.create(entity.id(), savedRuleDao.id(), TYPE_V1, savedRuleDao);
+        return NativeEntity.create(entity.id(), savedRuleDao.id(), TYPE_V1, savedRuleDao.title(), savedRuleDao);
     }
 
     @Override
@@ -139,7 +139,7 @@ public class PipelineRuleFacade implements EntityFacade<RuleDao> {
             final RuleDao ruleDao = ruleService.loadByName(title);
             compareRuleSources(title, source, ruleDao.source());
 
-            return Optional.of(NativeEntity.create(entity.id(), ruleDao.id(), TYPE_V1, ruleDao));
+            return Optional.of(NativeEntity.create(entity.id(), ruleDao.id(), TYPE_V1, ruleDao.title(), ruleDao));
         } catch (NotFoundException e) {
             return Optional.empty();
         }

--- a/graylog2-server/src/main/java/org/graylog2/contentpacks/facades/SidecarCollectorConfigurationFacade.java
+++ b/graylog2-server/src/main/java/org/graylog2/contentpacks/facades/SidecarCollectorConfigurationFacade.java
@@ -98,7 +98,7 @@ public class SidecarCollectorConfigurationFacade implements EntityFacade<Configu
                 configurationEntity.template().asString(parameters));
 
         final Configuration savedConfiguration = configurationService.save(configuration);
-        return NativeEntity.create(entity.id(), savedConfiguration.id(), TYPE_V1, savedConfiguration);
+        return NativeEntity.create(entity.id(), savedConfiguration.id(), TYPE_V1, configuration.name(), savedConfiguration);
     }
 
     @Override

--- a/graylog2-server/src/main/java/org/graylog2/contentpacks/facades/SidecarCollectorFacade.java
+++ b/graylog2-server/src/main/java/org/graylog2/contentpacks/facades/SidecarCollectorFacade.java
@@ -107,7 +107,7 @@ public class SidecarCollectorFacade implements EntityFacade<Collector> {
                 .build();
 
         final Collector savedCollector = collectorService.save(collector);
-        return NativeEntity.create(entity.id(), savedCollector.id(), TYPE_V1, savedCollector);
+        return NativeEntity.create(entity.id(), savedCollector.id(), TYPE_V1, collector.name(), savedCollector);
     }
 
     @Override
@@ -127,7 +127,7 @@ public class SidecarCollectorFacade implements EntityFacade<Collector> {
         final Optional<Collector> existingCollector = Optional.ofNullable(collectorService.findByName(name));
         existingCollector.ifPresent(collector -> compareCollectors(name, serviceType, collector));
 
-        return existingCollector.map(collector -> NativeEntity.create(entity.id(), collector.id(), TYPE_V1, collector));
+        return existingCollector.map(collector -> NativeEntity.create(entity.id(), collector.id(), TYPE_V1, collector.name(), collector));
     }
 
     private void compareCollectors(String name, String serviceType, Collector existingCollector) {

--- a/graylog2-server/src/main/java/org/graylog2/contentpacks/facades/StreamFacade.java
+++ b/graylog2-server/src/main/java/org/graylog2/contentpacks/facades/StreamFacade.java
@@ -165,7 +165,7 @@ public class StreamFacade implements EntityFacade<Stream> {
                 .collect(Collectors.toSet());
         streamService.addOutputs(new ObjectId(savedStreamId), outputIds);
 
-        return NativeEntity.create(entity.id(), savedStreamId, TYPE_V1, stream);
+        return NativeEntity.create(entity.id(), savedStreamId, TYPE_V1, stream.getTitle(), stream);
     }
 
     private CreateStreamRuleRequest createStreamRuleRequest(StreamRuleEntity streamRuleEntity, Map<String, ValueReference> parameters) {
@@ -204,7 +204,7 @@ public class StreamFacade implements EntityFacade<Stream> {
         if (Stream.DEFAULT_STREAM_ID.equals(streamId)) {
             try {
                 final Stream stream = streamService.load(Stream.DEFAULT_STREAM_ID);
-                return Optional.of(NativeEntity.create(entity.id(), Stream.DEFAULT_STREAM_ID, ModelTypes.STREAM_V1, stream));
+                return Optional.of(NativeEntity.create(entity.id(), Stream.DEFAULT_STREAM_ID, ModelTypes.STREAM_V1, stream.getTitle(), stream));
             } catch (NotFoundException e) {
                 throw new ContentPackException("Default stream <" + streamId + "> does not exist!", e);
             }

--- a/graylog2-server/src/main/java/org/graylog2/contentpacks/model/entities/NativeEntity.java
+++ b/graylog2-server/src/main/java/org/graylog2/contentpacks/model/entities/NativeEntity.java
@@ -33,11 +33,11 @@ public abstract class NativeEntity<T> {
     /**
      * Shortcut for {@link #create(NativeEntityDescriptor, Object)}
      */
-    public static <T> NativeEntity<T> create(String entityId, String nativeId, ModelType type, T entity) {
-        return create(NativeEntityDescriptor.create(entityId, nativeId, type), entity);
+    public static <T> NativeEntity<T> create(String entityId, String nativeId, ModelType type, String title, T entity) {
+        return create(NativeEntityDescriptor.create(entityId, nativeId, type, title), entity);
     }
 
-    public static <T> NativeEntity<T> create(ModelId entityId, String nativeId, ModelType type, T entity) {
-        return create(NativeEntityDescriptor.create(entityId, nativeId, type), entity);
+    public static <T> NativeEntity<T> create(ModelId entityId, String nativeId, ModelType type, String title, T entity) {
+        return create(NativeEntityDescriptor.create(entityId, nativeId, type, title), entity);
     }
 }

--- a/graylog2-server/src/main/java/org/graylog2/contentpacks/model/entities/NativeEntityDescriptor.java
+++ b/graylog2-server/src/main/java/org/graylog2/contentpacks/model/entities/NativeEntityDescriptor.java
@@ -31,14 +31,19 @@ import org.graylog2.contentpacks.model.Typed;
 @JsonDeserialize(builder = AutoValue_NativeEntityDescriptor.Builder.class)
 public abstract class NativeEntityDescriptor implements Identified, Typed {
     public static final String FIELD_ENTITY_ID = "content_pack_entity_id";
+    public static final String FIELD_ENTITY_TITLE = "title";
 
     @JsonProperty(FIELD_ENTITY_ID)
     public abstract ModelId contentPackEntityId();
 
-    public static NativeEntityDescriptor create(ModelId contentPackEntityId, ModelId id, ModelType type) {
+    @JsonProperty(FIELD_ENTITY_TITLE)
+    public abstract String title();
+
+    public static NativeEntityDescriptor create(ModelId contentPackEntityId, ModelId id, ModelType type, String title) {
         return builder()
                 .contentPackEntityId(contentPackEntityId)
                 .id(id)
+                .title(title)
                 .type(type)
                 .build();
     }
@@ -46,12 +51,12 @@ public abstract class NativeEntityDescriptor implements Identified, Typed {
     /**
      * Shortcut for {@link #create(String, String, ModelType)}
      */
-    public static NativeEntityDescriptor create(String contentPackEntityId, String nativeId, ModelType type) {
-        return create(ModelId.of(contentPackEntityId), ModelId.of(nativeId), type);
+    public static NativeEntityDescriptor create(String contentPackEntityId, String nativeId, ModelType type, String title) {
+        return create(ModelId.of(contentPackEntityId), ModelId.of(nativeId), type, title);
     }
 
-    public static NativeEntityDescriptor create(ModelId contentPackEntityId, String nativeId, ModelType type) {
-        return create(contentPackEntityId, ModelId.of(nativeId), type);
+    public static NativeEntityDescriptor create(ModelId contentPackEntityId, String nativeId, ModelType type, String title) {
+        return create(contentPackEntityId, ModelId.of(nativeId), type, title);
     }
 
     public static Builder builder() {
@@ -63,6 +68,9 @@ public abstract class NativeEntityDescriptor implements Identified, Typed {
 
         @JsonProperty(FIELD_ENTITY_ID)
         abstract Builder contentPackEntityId(ModelId contentPackEntityId);
+
+        @JsonProperty(FIELD_ENTITY_TITLE)
+        abstract Builder title(String title);
 
         public abstract NativeEntityDescriptor build();
     }

--- a/graylog2-server/src/test/java/org/graylog2/contentpacks/facades/DashboardFacadeTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/contentpacks/facades/DashboardFacadeTest.java
@@ -353,7 +353,7 @@ public class DashboardFacadeTest {
         assertThat(dashboard.getWidgets().size()).isEqualTo(1);
         assertThat(dashboard.getWidgets()).containsKeys("12345");
 
-        final NativeEntityDescriptor expectedDescriptor = NativeEntityDescriptor.create(dashboardEntity.id(), savedDashboard.getId(), ModelTypes.DASHBOARD_V1);
+        final NativeEntityDescriptor expectedDescriptor = NativeEntityDescriptor.create(dashboardEntity.id(), savedDashboard.getId(), ModelTypes.DASHBOARD_V1, savedDashboard.getTitle());
         assertThat(nativeEntity.descriptor()).isEqualTo(expectedDescriptor);
     }
 }

--- a/graylog2-server/src/test/java/org/graylog2/contentpacks/facades/GrokPatternFacadeTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/contentpacks/facades/GrokPatternFacadeTest.java
@@ -176,7 +176,7 @@ public class GrokPatternFacadeTest {
                         ValueReference.of("[a-z]+")), JsonNode.class))
                 .build();
         final Optional<NativeEntity<GrokPattern>> existingGrokPattern = facade.findExisting(grokPatternEntity, Collections.emptyMap());
-        final NativeEntityDescriptor expectedDescriptor = NativeEntityDescriptor.create(grokPatternEntity.id(), "1", ModelTypes.GROK_PATTERN_V1);
+        final NativeEntityDescriptor expectedDescriptor = NativeEntityDescriptor.create(grokPatternEntity.id(), "1", ModelTypes.GROK_PATTERN_V1, grokPattern.name());
         assertThat(existingGrokPattern)
                 .isPresent()
                 .get()
@@ -198,7 +198,7 @@ public class GrokPatternFacadeTest {
         final NativeEntity<GrokPattern> nativeEntity = facade.createNativeEntity(grokPatternEntity, Collections.emptyMap(), Collections.emptyMap(), "admin");
 
         final GrokPattern expectedGrokPattern = GrokPattern.create("1", "Test", "[a-z]+", null);
-        final NativeEntityDescriptor expectedDescriptor = NativeEntityDescriptor.create("1", "1", ModelTypes.GROK_PATTERN_V1);
+        final NativeEntityDescriptor expectedDescriptor = NativeEntityDescriptor.create("1", "1", ModelTypes.GROK_PATTERN_V1, "Test");
 
         assertThat(nativeEntity.descriptor()).isEqualTo(expectedDescriptor);
         assertThat(nativeEntity.entity()).isEqualTo(expectedGrokPattern);

--- a/graylog2-server/src/test/java/org/graylog2/contentpacks/facades/SidecarCollectorFacadeTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/contentpacks/facades/SidecarCollectorFacadeTest.java
@@ -138,7 +138,7 @@ public class SidecarCollectorFacadeTest {
         final Collector collector = collectorService.findByName("filebeat");
         assertThat(collector).isNotNull();
 
-        final NativeEntityDescriptor expectedDescriptor = NativeEntityDescriptor.create(entity.id(), collector.id(), ModelTypes.SIDECAR_COLLECTOR_V1);
+        final NativeEntityDescriptor expectedDescriptor = NativeEntityDescriptor.create(entity.id(), collector.id(), ModelTypes.SIDECAR_COLLECTOR_V1, collector.name());
         assertThat(nativeEntity.descriptor()).isEqualTo(expectedDescriptor);
         assertThat(nativeEntity.entity()).isEqualTo(collector);
     }
@@ -166,7 +166,7 @@ public class SidecarCollectorFacadeTest {
         final Collector collector = collectorService.findByName("filebeat");
         assertThat(collector).isNotNull();
 
-        final NativeEntityDescriptor expectedDescriptor = NativeEntityDescriptor.create(entity.id(), collector.id(), ModelTypes.SIDECAR_COLLECTOR_V1);
+        final NativeEntityDescriptor expectedDescriptor = NativeEntityDescriptor.create(entity.id(), collector.id(), ModelTypes.SIDECAR_COLLECTOR_V1, collector.name());
         assertThat(existingCollector.descriptor()).isEqualTo(expectedDescriptor);
         assertThat(existingCollector.entity()).isEqualTo(collector);
     }

--- a/graylog2-web-interface/src/components/content-packs/ContentPackInstallView.jsx
+++ b/graylog2-web-interface/src/components/content-packs/ContentPackInstallView.jsx
@@ -2,28 +2,42 @@ import PropTypes from 'prop-types';
 import React from 'react';
 
 import { Row, Col } from 'react-bootstrap';
-import Timestamp from 'components/common/Timestamp';
+import { DataTable, Timestamp } from 'components/common';
 import DateTime from 'logic/datetimes/DateTime';
 
 import 'components/content-packs/ContentPackDetails.css';
 
 const ContentPackInstallView = (props) => {
+  const rowFormatter = entity => (<tr><td>{entity.title}</td><td>{entity.type.name}</td></tr>);
   const { comment } = props.install;
   const createdAt = props.install.created_at;
   const createdBy = props.install.created_by;
+  const headers = ['Title', 'Type'];
   return (<div>
     <Row>
-      <Col smOffset={1}>
-        <div>
-          <dl className="deflist">
-            <dt>Comment:</dt>
-            <dd>{comment}</dd>
-            <dt>Installed by:</dt>
-            <dd>{createdBy}&nbsp;</dd>
-            <dt>Installed at:</dt>
-            <dd><Timestamp dateTime={createdAt} format={DateTime.Formats.COMPLETE} tz="browser" /></dd>
-          </dl>
-        </div>
+      <Col smOffset={1} sm={10}>
+        <h3>General information</h3>
+        <dl className="deflist">
+          <dt>Comment:</dt>
+          <dd>{comment}</dd>
+          <dt>Installed by:</dt>
+          <dd>{createdBy}&nbsp;</dd>
+          <dt>Installed at:</dt>
+          <dd><Timestamp dateTime={createdAt} format={DateTime.Formats.COMPLETE} tz="browser" /></dd>
+        </dl>
+      </Col>
+    </Row>
+    <Row>
+      <Col smOffset={1} sm={10}>
+        <h3>Installed Entities</h3>
+        <DataTable
+          id="installed-entities"
+          headers={headers}
+          sortByKey="title"
+          dataRowFormatter={rowFormatter}
+          rows={props.install.entities}
+          filterKeys={[]}
+        />
       </Col>
     </Row>
   </div>);

--- a/graylog2-web-interface/src/components/content-packs/ContentPackInstallations.test.jsx
+++ b/graylog2-web-interface/src/components/content-packs/ContentPackInstallations.test.jsx
@@ -13,14 +13,19 @@ describe('<ContentPackInstallations />', () => {
       content_pack_revision: 1,
       parameters: {
         SOURCE: {
-          type: 'string',
+          name: 'string',
           value: 'hulud.com.uk',
         },
       },
       entities: [
         {
-          id: '5b55b8b73d274645e49f7eea',
-          type: 'input',
+          id: '5ba38df33d274660f0b94118',
+          type: {
+            name: 'input',
+            version: '1',
+          },
+          content_pack_entity_id: '5b6d973d3d274645572a4318',
+          title: 'hulud.net',
         },
       ],
       comment: 'The fake input',


### PR DESCRIPTION
## Description
Add title to `NativeEntityDescriptor` and show the title in the detail of the content pack installation.

## Motivation and Context
Before a user wants to uninstall a content pack he might want to look what entities are
installed via a content pack.

## How Has This Been Tested?
Installed a content pack and looked at the installation details.

## Screenshots (if appropriate):
![graylog - content packs](https://user-images.githubusercontent.com/448763/45822066-f561da00-bcea-11e8-9506-02cb46dc333c.png)

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
