### PR TITLE
Remove warnings from test

### DIFF
--- a/graylog2-web-interface/src/components/common/ExpandableList.test.jsx
+++ b/graylog2-web-interface/src/components/common/ExpandableList.test.jsx
@@ -35,9 +35,9 @@ describe('<ExpandableList />', () => {
 
   it('should expand a expandable list item', () => {
     const wrapper = mount(<ExpandableList>
-      <ExpandableListItem expandable header="Wheel of time">
+      <ExpandableListItem expandable header="Wheel of time" readOnly>
         <ExpandableList>
-          <ExpandableListItem header="Edmonds Field" />
+          <ExpandableListItem header="Edmonds Field" readOnly />
         </ExpandableList>
       </ExpandableListItem>
     </ExpandableList>);
@@ -49,7 +49,7 @@ describe('<ExpandableList />', () => {
   it('should select a selectable list item', () => {
     const checkFn = jest.fn();
     const wrapper = mount(<ExpandableList>
-      <ExpandableListItem expanded header="Wheel of time">
+      <ExpandableListItem expanded header="Wheel of time" readOnly>
         <ExpandableList>
           <ExpandableListItem expanded selectable header="Edmonds Field" onChange={checkFn} />
         </ExpandableList>

--- a/graylog2-web-interface/src/components/content-packs/ContentPackSelection.test.jsx
+++ b/graylog2-web-interface/src/components/content-packs/ContentPackSelection.test.jsx
@@ -55,7 +55,13 @@ describe('<ContentPackSelection />', () => {
         expect(state.contentPack).toEqual(contentPack);
       }
     });
-    const contentPack = {};
+    const contentPack = {
+      name: '',
+      summary: '',
+      description: '',
+      vendor: '',
+      url: '',
+    };
     const wrapper = mount(<ContentPackSelection contentPack={contentPack} onStateChange={changeFn} />);
     wrapper.find('input#name').simulate('change', { target: { name: 'name', value: 'name' } });
     wrapper.find('input#summary').simulate('change', { target: { name: 'summary', value: 'summary' } });

--- a/graylog2-web-interface/src/components/content-packs/ContentPacksList.test.jsx
+++ b/graylog2-web-interface/src/components/content-packs/ContentPacksList.test.jsx
@@ -10,21 +10,21 @@ describe('<ContentPacksList />', () => {
   URLUtils.areCredentialsInURLSupported = jest.fn(() => { return false; });
 
   const contentPacks = [
-    { id: '1', title: 'UFW Grok Patterns', summary: 'Grok Patterns to extract informations from UFW logfiles', version: '1.0', states: ['installed', 'edited'] },
-    { id: '2', title: 'Rails Log Patterns', summary: 'Patterns to retreive rails production logs', version: '2.1', states: [] },
-    { id: '3', title: 'Backup Content Pack', summary: '', version: '3.0', states: ['installed'] },
-    { id: '4', title: 'SSH Archive', summary: 'A crypted backup over ssh.', version: '3.4', states: ['error'] },
-    { id: '5', title: 'FTP Backup', summary: 'Fast but insecure backup', version: '1.0', states: ['installed', 'updatable'] },
-    { id: '6', title: 'UFW Grok Patterns', summary: 'Grok Patterns to extract informations from UFW logfiles', version: '1.0', states: ['installed', 'edited'] },
-    { id: '7', title: 'Rails Log Patterns', summary: 'Patterns to retreive rails production logs', version: '2.1', states: [] },
-    { id: '8', title: 'Backup Content Pack', summary: '', version: '3.0', states: ['installed'] },
-    { id: '9', title: 'SSH Archive', summary: 'A crypted backup over ssh.', version: '3.4', states: ['error'] },
-    { id: '10', title: 'FTP Backup', summary: 'Fast but insecure backup', version: '1.0', states: ['installed', 'updatable'] },
-    { id: '11', title: 'UFW Grok Patterns', summary: 'Grok Patterns to extract informations from UFW logfiles', version: '1.0', states: ['installed', 'edited'] },
-    { id: '12', title: 'Rails Log Patterns', summary: 'Patterns to retreive rails production logs', version: '2.1', states: [] },
-    { id: '13', title: 'Backup Content Pack', summary: '', version: '3.0', states: ['installed'] },
-    { id: '14', title: 'SSH Archive', summary: 'A crypted backup over ssh.', version: '3.4', states: ['error'] },
-    { id: '15', title: 'FTP Backup', summary: 'Fast but insecure backup', version: '1.0', states: ['installed', 'updatable'] },
+    { id: '1', rev: 1, title: 'UFW Grok Patterns', summary: 'Grok Patterns to extract informations from UFW logfiles', version: '1.0', states: ['installed', 'edited'] },
+    { id: '2', rev: 1, title: 'Rails Log Patterns', summary: 'Patterns to retreive rails production logs', version: '2.1', states: [] },
+    { id: '3', rev: 1, title: 'Backup Content Pack', summary: '', version: '3.0', states: ['installed'] },
+    { id: '4', rev: 1, title: 'SSH Archive', summary: 'A crypted backup over ssh.', version: '3.4', states: ['error'] },
+    { id: '5', rev: 1, title: 'FTP Backup', summary: 'Fast but insecure backup', version: '1.0', states: ['installed', 'updatable'] },
+    { id: '6', rev: 1, title: 'UFW Grok Patterns', summary: 'Grok Patterns to extract informations from UFW logfiles', version: '1.0', states: ['installed', 'edited'] },
+    { id: '7', rev: 1, title: 'Rails Log Patterns', summary: 'Patterns to retreive rails production logs', version: '2.1', states: [] },
+    { id: '8', rev: 1, title: 'Backup Content Pack', summary: '', version: '3.0', states: ['installed'] },
+    { id: '9', rev: 1, title: 'SSH Archive', summary: 'A crypted backup over ssh.', version: '3.4', states: ['error'] },
+    { id: '10', rev: 1, title: 'FTP Backup', summary: 'Fast but insecure backup', version: '1.0', states: ['installed', 'updatable'] },
+    { id: '11', rev: 1, title: 'UFW Grok Patterns', summary: 'Grok Patterns to extract informations from UFW logfiles', version: '1.0', states: ['installed', 'edited'] },
+    { id: '12', rev: 1, title: 'Rails Log Patterns', summary: 'Patterns to retreive rails production logs', version: '2.1', states: [] },
+    { id: '13', rev: 1, title: 'Backup Content Pack', summary: '', version: '3.0', states: ['installed'] },
+    { id: '14', rev: 1, title: 'SSH Archive', summary: 'A crypted backup over ssh.', version: '3.4', states: ['error'] },
+    { id: '15', rev: 1, title: 'FTP Backup', summary: 'Fast but insecure backup', version: '1.0', states: ['installed', 'updatable'] },
   ];
 
   it('should render with empty content packs', () => {

--- a/graylog2-web-interface/src/components/content-packs/__snapshots__/ContentPacksList.test.jsx.snap
+++ b/graylog2-web-interface/src/components/content-packs/__snapshots__/ContentPacksList.test.jsx.snap
@@ -236,6 +236,7 @@ exports[`<ContentPacksList /> should render with content packs 1`] = `
                
               <small>
                 Version: 
+                1
               </small>
               <div>
                 <span
@@ -365,6 +366,7 @@ exports[`<ContentPacksList /> should render with content packs 1`] = `
                
               <small>
                 Version: 
+                1
               </small>
               <div />
             </h3>
@@ -483,6 +485,7 @@ exports[`<ContentPacksList /> should render with content packs 1`] = `
                
               <small>
                 Version: 
+                1
               </small>
               <div>
                 <span
@@ -607,6 +610,7 @@ exports[`<ContentPacksList /> should render with content packs 1`] = `
                
               <small>
                 Version: 
+                1
               </small>
               <div>
                 <span
@@ -731,6 +735,7 @@ exports[`<ContentPacksList /> should render with content packs 1`] = `
                
               <small>
                 Version: 
+                1
               </small>
               <div>
                 <span
@@ -866,6 +871,7 @@ exports[`<ContentPacksList /> should render with content packs 1`] = `
                
               <small>
                 Version: 
+                1
               </small>
               <div>
                 <span
@@ -995,6 +1001,7 @@ exports[`<ContentPacksList /> should render with content packs 1`] = `
                
               <small>
                 Version: 
+                1
               </small>
               <div />
             </h3>
@@ -1113,6 +1120,7 @@ exports[`<ContentPacksList /> should render with content packs 1`] = `
                
               <small>
                 Version: 
+                1
               </small>
               <div>
                 <span
@@ -1237,6 +1245,7 @@ exports[`<ContentPacksList /> should render with content packs 1`] = `
                
               <small>
                 Version: 
+                1
               </small>
               <div>
                 <span
@@ -1361,6 +1370,7 @@ exports[`<ContentPacksList /> should render with content packs 1`] = `
                
               <small>
                 Version: 
+                1
               </small>
               <div>
                 <span

--- a/graylog2-web-interface/src/components/grok-patterns/EditPatternModal.jsx
+++ b/graylog2-web-interface/src/components/grok-patterns/EditPatternModal.jsx
@@ -15,7 +15,7 @@ class EditPatternModal extends React.Component {
     create: PropTypes.bool,
     sampleData: PropTypes.string,
     savePattern: PropTypes.func.isRequired,
-    testPattern: PropTypes.func,
+    testPattern: PropTypes.func.isRequired,
     validPatternName: PropTypes.func.isRequired,
   };
 
@@ -26,7 +26,6 @@ class EditPatternModal extends React.Component {
     patterns: [],
     create: false,
     sampleData: '',
-    testPattern: () => {},
   };
 
   state = {

--- a/graylog2-web-interface/src/components/grok-patterns/EditPatternModal.test.jsx
+++ b/graylog2-web-interface/src/components/grok-patterns/EditPatternModal.test.jsx
@@ -6,12 +6,17 @@ import EditPatternModal from 'components/grok-patterns/EditPatternModal';
 
 describe('<EditPatternModal />', () => {
   it('should render a modal button with as edit', () => {
-    const wrapper = renderer.create(<EditPatternModal />);
+    const wrapper = renderer.create(<EditPatternModal savePattern={() => {}}
+                                                      testPattern={() => {}}
+                                                      validPatternName={() => {}} />);
     expect(wrapper.toJSON()).toMatchSnapshot();
   });
 
   it('should render a modal button with as create', () => {
-    const wrapper = renderer.create(<EditPatternModal create />);
+    const wrapper = renderer.create(<EditPatternModal create
+                                                      savePattern={() => {}}
+                                                      testPattern={() => {}}
+                                                      validPatternName={() => {}} />);
     expect(wrapper.toJSON()).toMatchSnapshot();
   });
 });

--- a/graylog2-web-interface/src/components/lookup-tables/DataAdapterCreate.test.jsx
+++ b/graylog2-web-interface/src/components/lookup-tables/DataAdapterCreate.test.jsx
@@ -47,14 +47,27 @@ describe('<DataAdapterCreate />', () => {
     expect(wrapper.toJSON()).toMatchSnapshot();
   });
 
-  it('should render for types without defined frontend components', () => {
-    const callback = () => {};
-    const types = {
-      unknownType: {
-        type: 'unknownType',
-      },
-    };
-    const wrapper = renderer.create(<DataAdapterCreate saved={callback} types={types} />);
-    expect(wrapper.toJSON()).toMatchSnapshot();
+  describe('with mocked console.error', () => {
+    const consoleError = console.error;
+
+    beforeAll(() => {
+      console.error = jest.fn();
+    });
+
+    afterAll(() => {
+      console.error = consoleError;
+    });
+
+    it('should render for types without defined frontend components', () => {
+      const callback = () => {};
+      const types = {
+        unknownType: {
+          type: 'unknownType',
+        },
+      };
+      const wrapper = renderer.create(<DataAdapterCreate saved={callback} types={types} />);
+      expect(wrapper.toJSON()).toMatchSnapshot();
+      expect(console.error.mock.calls.length).toBe(1);
+    });
   });
 });

--- a/graylog2-web-interface/src/components/lookup-tables/__snapshots__/DataAdapterCreate.test.jsx.snap
+++ b/graylog2-web-interface/src/components/lookup-tables/__snapshots__/DataAdapterCreate.test.jsx.snap
@@ -51,7 +51,51 @@ exports[`<DataAdapterCreate /> should render for types with defined frontend com
 </div>
 `;
 
-exports[`<DataAdapterCreate /> should render for types without defined frontend components 1`] = `
+exports[`<DataAdapterCreate /> should render with empty parameters 1`] = `
+<div>
+  <div
+    className="content row"
+  >
+    <div
+      className="col-lg-8"
+    >
+      <form
+        className="form form-horizontal"
+        onSubmit={[Function]}
+      >
+        <span
+          className="InputMock"
+        >
+          <span
+            autoFocus={true}
+            help="The type of data adapter to configure."
+            id="data-adapter-type-select"
+            label="Data Adapter Type"
+            labelClassName="col-sm-3"
+            required={true}
+            wrapperClassName="col-sm-9"
+          >
+            <span
+              className="SelectMock"
+            >
+              <span
+                clearable={false}
+                matchProp="value"
+                onChange={[Function]}
+                options={Array []}
+                placeholder="Select Data Adapter Type"
+                value={null}
+              />
+            </span>
+          </span>
+        </span>
+      </form>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`<DataAdapterCreate /> with mocked console.error should render for types without defined frontend components 1`] = `
 <div>
   <div
     className="content row"
@@ -91,50 +135,6 @@ exports[`<DataAdapterCreate /> should render for types without defined frontend 
                     },
                   ]
                 }
-                placeholder="Select Data Adapter Type"
-                value={null}
-              />
-            </span>
-          </span>
-        </span>
-      </form>
-    </div>
-  </div>
-</div>
-`;
-
-exports[`<DataAdapterCreate /> should render with empty parameters 1`] = `
-<div>
-  <div
-    className="content row"
-  >
-    <div
-      className="col-lg-8"
-    >
-      <form
-        className="form form-horizontal"
-        onSubmit={[Function]}
-      >
-        <span
-          className="InputMock"
-        >
-          <span
-            autoFocus={true}
-            help="The type of data adapter to configure."
-            id="data-adapter-type-select"
-            label="Data Adapter Type"
-            labelClassName="col-sm-3"
-            required={true}
-            wrapperClassName="col-sm-9"
-          >
-            <span
-              className="SelectMock"
-            >
-              <span
-                clearable={false}
-                matchProp="value"
-                onChange={[Function]}
-                options={Array []}
                 placeholder="Select Data Adapter Type"
                 value={null}
               />

--- a/graylog2-web-interface/src/components/search/MessageTableEntry.test.jsx
+++ b/graylog2-web-interface/src/components/search/MessageTableEntry.test.jsx
@@ -49,7 +49,7 @@ describe('<MessageTableEntry />', () => {
 
   describe('timezone handling', () => {
     it('should render a in the UTC timezone', () => {
-      const wrapper = mount(<MessageTableEntry
+      const wrapper = mount(<table><MessageTableEntry
         allStreams={allStreams}
         allStreamsLoaded
         disableSurroundingSearch
@@ -61,13 +61,13 @@ describe('<MessageTableEntry />', () => {
         nodes={nodes}
         streams={streams}
         toggleDetail={jest.fn}
-      />);
+      /></table>);
       expect(wrapper.find('time').at(1).text()).toEqual('2018-01-22 16:36:02.189 +01:00');
     });
 
     it('should render a in the USA/Honolulu timezone', () => {
       DateTime.getBrowserTimezone = () => { return 'Pacific/Honolulu'; };
-      const wrapper = mount(<MessageTableEntry
+      const wrapper = mount(<table><MessageTableEntry
         allStreams={allStreams}
         allStreamsLoaded
         disableSurroundingSearch
@@ -79,7 +79,7 @@ describe('<MessageTableEntry />', () => {
         nodes={nodes}
         streams={streams}
         toggleDetail={jest.fn}
-      />);
+      /></table>);
       expect(wrapper.find('time').at(1).text()).toEqual('2018-01-22 05:36:02.189 -10:00');
     });
   });

--- a/graylog2-web-interface/src/components/users/TokenList.test.jsx
+++ b/graylog2-web-interface/src/components/users/TokenList.test.jsx
@@ -5,8 +5,7 @@ import 'helpers/mocking/react-dom_mock';
 
 import TokenList from 'components/users/TokenList';
 
-jest.mock('components/common/ClipboardButton', () => 'ClipboardButton');
-
+jest.mock('components/common/ClipboardButton', () => 'clipboard-button');
 
 describe('<TokenList />', () => {
   const tokens = [

--- a/graylog2-web-interface/src/components/users/__snapshots__/TokenList.test.jsx.snap
+++ b/graylog2-web-interface/src/components/users/__snapshots__/TokenList.test.jsx.snap
@@ -307,7 +307,7 @@ exports[`<TokenList /> should render with tokens 1`] = `
               <div
                 className="btn-group"
               >
-                <ClipboardButton
+                <clipboard-button
                   bsSize="xsmall"
                   text="beef2001"
                   title="Copy to clipboard"
@@ -342,7 +342,7 @@ exports[`<TokenList /> should render with tokens 1`] = `
               <div
                 className="btn-group"
               >
-                <ClipboardButton
+                <clipboard-button
                   bsSize="xsmall"
                   text="beef2002"
                   title="Copy to clipboard"

--- a/graylog2-web-interface/src/components/widgets/WidgetFooter.test.jsx
+++ b/graylog2-web-interface/src/components/widgets/WidgetFooter.test.jsx
@@ -23,7 +23,7 @@ describe('<WidgetFooter />', () => {
       onDelete={() => {}}
       replayHref={'http://example.org'}
       replayDisabled={false}
-      calculatedAt={date.getTime()}
+      calculatedAt={date.toISOString()}
       error={{}}
       errorMessage={''} />);
     expect(wrapper.toJSON()).toMatchSnapshot();
@@ -37,7 +37,7 @@ describe('<WidgetFooter />', () => {
       onDelete={() => {}}
       replayHref={'http://example.org'}
       replayDisabled
-      calculatedAt={date.getTime()}
+      calculatedAt={date.toISOString()}
       error={{}}
       errorMessage={''} />);
     expect(wrapper.toJSON()).toMatchSnapshot();
@@ -51,7 +51,7 @@ describe('<WidgetFooter />', () => {
       onDelete={() => {}}
       replayHref={'http://example.org'}
       replayDisabled={false}
-      calculatedAt={date.getTime()}
+      calculatedAt={date.toISOString()}
       error={{}}
       errorMessage={''} />);
     expect(wrapper.toJSON()).toMatchSnapshot();

--- a/graylog2-web-interface/src/components/widgets/__snapshots__/WidgetFooter.test.jsx.snap
+++ b/graylog2-web-interface/src/components/widgets/__snapshots__/WidgetFooter.test.jsx.snap
@@ -14,11 +14,11 @@ exports[`<WidgetFooter /> should render a widget footer locked and disabled repl
       />
     </span>
     <span
-      title={821849040000}
+      title="1996-01-17T03:24:00.000Z"
     >
       <time
-        dateTime={821849040000}
-        title={821849040000}
+        dateTime="1996-01-17T03:24:00.000Z"
+        title="1996-01-17T03:24:00.000Z"
       >
         22 years ago
       </time>
@@ -62,11 +62,11 @@ exports[`<WidgetFooter /> should render a widget footer locked and enabled repla
       />
     </span>
     <span
-      title={821849040000}
+      title="1996-01-17T03:24:00.000Z"
     >
       <time
-        dateTime={821849040000}
-        title={821849040000}
+        dateTime="1996-01-17T03:24:00.000Z"
+        title="1996-01-17T03:24:00.000Z"
       >
         22 years ago
       </time>
@@ -125,11 +125,11 @@ exports[`<WidgetFooter /> should render a widget footer with unlocked 1`] = `
       />
     </span>
     <span
-      title={821849040000}
+      title="1996-01-17T03:24:00.000Z"
     >
       <time
-        dateTime={821849040000}
-        title={821849040000}
+        dateTime="1996-01-17T03:24:00.000Z"
+        title="1996-01-17T03:24:00.000Z"
       >
         22 years ago
       </time>

--- a/graylog2-web-interface/src/pages/DelegatedSearchPage.test.jsx
+++ b/graylog2-web-interface/src/pages/DelegatedSearchPage.test.jsx
@@ -1,19 +1,21 @@
 jest.mock('c3', () => ({ default: jest.fn() }))
   .mock('components/search/LegacyHistogram', () => ({ default: jest.fn() }))
   .mock('components/search/QueryInput', () => ({ default: jest.fn() }))
+  // eslint-disable-next-line global-require
   .mock('injection/CombinedProvider', () => new (require('helpers/mocking').CombinedProviderMock)());
 
+/* eslint-disable import/first */
 import React from 'react';
 import ShallowRenderer from 'react-test-renderer/shallow';
 import { PluginManifest, PluginStore } from 'graylog-web-plugin/plugin';
 
 import DelegatedSearchPage from 'pages/DelegatedSearchPage';
+/* eslint-enable import/first */
+
 
 test('Renders SearchPage by default', () => {
   const renderer = new ShallowRenderer();
-  const tree = renderer.render(
-    <DelegatedSearchPage />
-  );
+  const tree = renderer.render(<DelegatedSearchPage location={{}} searchConfig={{}} />);
   expect(tree).toMatchSnapshot();
 });
 
@@ -27,9 +29,7 @@ test('Renders other component if registered', () => {
     },
   }));
 
-  const tree = renderer.render(
-    <DelegatedSearchPage />
-  );
+  const tree = renderer.render(<DelegatedSearchPage />);
 
   expect(tree).toMatchSnapshot();
 });

--- a/graylog2-web-interface/src/pages/__snapshots__/DelegatedSearchPage.test.jsx.snap
+++ b/graylog2-web-interface/src/pages/__snapshots__/DelegatedSearchPage.test.jsx.snap
@@ -1,5 +1,10 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Renders SearchPage by default 1`] = `<SearchPage />`;
+exports[`Renders SearchPage by default 1`] = `
+<SearchPage
+  location={Object {}}
+  searchConfig={Object {}}
+/>
+`;
 
 exports[`Renders other component if registered 1`] = `<SimpleComponent />`;

--- a/graylog2-web-interface/test/setup-jest.jsx
+++ b/graylog2-web-interface/test/setup-jest.jsx
@@ -9,3 +9,7 @@ global.jQuery = jQuery;
 registerBuiltinStores();
 
 configure({ adapter: new Adapter() });
+
+console.error = jest.fn((error) => {
+  throw new Error(error);
+});


### PR DESCRIPTION
## Description
After upgrading to react 16 lots of deprecation warnings were gone from the tests.
To see rightful warnings (like missing required props) clearer I fixed all remaining warnings
from the tests.

## Screenshots (if appropriate):
![party-gorilla](https://user-images.githubusercontent.com/448763/45872241-d0737280-bd8f-11e8-9f35-f167df7a13d7.png)

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
