### PR TITLE
Fixes for content packs

### DIFF
--- a/graylog2-web-interface/src/components/common/ExpandableListItem.jsx
+++ b/graylog2-web-interface/src/components/common/ExpandableListItem.jsx
@@ -85,10 +85,16 @@ class ExpandableListItem extends React.Component {
     return inputProps;
   };
 
+  _clickOnHeader = () => {
+    if (this._checkbox) {
+      this._checkbox.click();
+    }
+  };
+
   render() {
     const { expanded } = this.state;
     const { checked, expandable, selectable, header, subheader, children, ...otherProps } = this.props;
-    const headerToRender = selectable ? (<span role="button" tabIndex={0} onClick={() => { this._checkbox.click(); }}>{header}</span>) : header;
+    const headerToRender = selectable ? (<span role="button" tabIndex={0} onClick={this._clickOnHeader}>{header}</span>) : header;
     const inputProps = this._filterInputProps(otherProps);
 
     return (

--- a/graylog2-web-interface/src/components/common/ExpandableListItem.jsx
+++ b/graylog2-web-interface/src/components/common/ExpandableListItem.jsx
@@ -88,6 +88,7 @@ class ExpandableListItem extends React.Component {
   render() {
     const { expanded } = this.state;
     const { checked, expandable, selectable, header, subheader, children, ...otherProps } = this.props;
+    const headerToRender = selectable ? (<span role="button" tabIndex={0} onClick={() => { this._checkbox.click(); }}>{header}</span>) : header;
     const inputProps = this._filterInputProps(otherProps);
 
     return (
@@ -102,7 +103,7 @@ class ExpandableListItem extends React.Component {
             </div>
           </div>
           }
-          <span className={style.header}>{header}{subheader && <span className={style.subheader}>{subheader}</span>}</span>
+          <span className={style.header}>{headerToRender}{subheader && <span className={style.subheader}>{subheader}</span>}</span>
         </div>
         <div className={style.expandableContent}>
           {expanded && children}

--- a/graylog2-web-interface/src/components/common/__snapshots__/ExpandableList.test.jsx.snap
+++ b/graylog2-web-interface/src/components/common/__snapshots__/ExpandableList.test.jsx.snap
@@ -40,7 +40,13 @@ exports[`<ExpandableList /> should render with a Item 1`] = `
       <span
         className="header"
       >
-        Wheel of time
+        <span
+          onClick={[Function]}
+          role="button"
+          tabIndex={0}
+        >
+          Wheel of time
+        </span>
       </span>
     </div>
     <div
@@ -90,7 +96,13 @@ exports[`<ExpandableList /> should render with a nested ExpandableList 1`] = `
       <span
         className="header"
       >
-        Wheel of time
+        <span
+          onClick={[Function]}
+          role="button"
+          tabIndex={0}
+        >
+          Wheel of time
+        </span>
       </span>
     </div>
     <div
@@ -135,7 +147,13 @@ exports[`<ExpandableList /> should render with a nested ExpandableList 1`] = `
             <span
               className="header"
             >
-              Edmonds Field
+              <span
+                onClick={[Function]}
+                role="button"
+                tabIndex={0}
+              >
+                Edmonds Field
+              </span>
             </span>
           </div>
           <div

--- a/graylog2-web-interface/src/components/content-packs/ContentPackInstall.jsx
+++ b/graylog2-web-interface/src/components/content-packs/ContentPackInstall.jsx
@@ -105,7 +105,7 @@ class ContentPackInstall extends React.Component {
     });
     return (<div>
       <Row>
-        <Col smOffset={1}>
+        <Col smOffset={1} sm={10}>
           <h2>Install comment</h2>
           <br />
           <br />
@@ -123,7 +123,7 @@ class ContentPackInstall extends React.Component {
       </Row>
       {parameterInput.length > 0 &&
       <Row>
-        <Col smOffset={1}>
+        <Col smOffset={1} sm={10}>
           <h2>Configure Parameter</h2>
           <br />
           <br />

--- a/graylog2-web-interface/src/components/content-packs/ContentPackParameterList.jsx
+++ b/graylog2-web-interface/src/components/content-packs/ContentPackParameterList.jsx
@@ -67,7 +67,7 @@ class ContentPackParameterList extends React.Component {
       modalRef.close();
     };
 
-    const open = () => {
+    const openModal = () => {
       modalRef.open();
     };
 
@@ -104,12 +104,14 @@ class ContentPackParameterList extends React.Component {
     );
 
     return (
-      <Button bsStyle="info"
-              bsSize={size}
-              onClick={() => { open(); }}>
-        {name}
+      <React.Fragment>
+        <Button bsStyle="info"
+                bsSize={size}
+                onClick={openModal}>
+          {name}
+        </Button>
         {modal}
-      </Button>
+      </React.Fragment>
     );
   }
 

--- a/graylog2-web-interface/src/components/content-packs/__snapshots__/ContentPackEdit.test.jsx.snap
+++ b/graylog2-web-interface/src/components/content-packs/__snapshots__/ContentPackEdit.test.jsx.snap
@@ -880,7 +880,13 @@ exports[`<ContentPackEdit /> should render with content pack for edit 1`] = `
                   <span
                     className="header"
                   >
-                    Dashboard
+                    <span
+                      onClick={[Function]}
+                      role="button"
+                      tabIndex={0}
+                    >
+                      Dashboard
+                    </span>
                   </span>
                 </div>
                 <div

--- a/graylog2-web-interface/src/components/content-packs/__snapshots__/ContentPackInstall.test.jsx.snap
+++ b/graylog2-web-interface/src/components/content-packs/__snapshots__/ContentPackInstall.test.jsx.snap
@@ -6,7 +6,7 @@ exports[`<ContentPackInstall /> should render a install 1`] = `
     className="row"
   >
     <div
-      className="col-sm-offset-1"
+      className="col-sm-10 col-sm-offset-1"
     >
       <h2>
         Install comment
@@ -45,7 +45,7 @@ exports[`<ContentPackInstall /> should render a install 1`] = `
     className="row"
   >
     <div
-      className="col-sm-offset-1"
+      className="col-sm-10 col-sm-offset-1"
     >
       <h2>
         Configure Parameter

--- a/graylog2-web-interface/src/components/content-packs/__snapshots__/ContentPackSelection.test.jsx.snap
+++ b/graylog2-web-interface/src/components/content-packs/__snapshots__/ContentPackSelection.test.jsx.snap
@@ -555,7 +555,13 @@ exports[`<ContentPackSelection /> should render with filled content pack 1`] = `
             <span
               className="header"
             >
-              Spaceship
+              <span
+                onClick={[Function]}
+                role="button"
+                tabIndex={0}
+              >
+                Spaceship
+              </span>
             </span>
           </div>
           <div


### PR DESCRIPTION
## Description
Small fixes regarding content packs.

## Motivation and Context
* Allign Install form fields

  The install form has a list of entities
  which were unallgined to the form fields.
  Fixes #5115

* Fix closing of ContentPackEditParameter modal
    
   the modal did not close since it was a child of
   the open button. A click on the close button bubbled up
   to the open button which would than reopen the closed
   modal. 
   I moved out the modal as a child from the open button.

* Make click on ExpandleListItem select checkbox
   
   We do not have label and checkboxes, since we do not have
   ids for the ExpandleListItem. There for I add an click
   handler to the header which will click on the
   associated checkbox.  
   Fixes #5114 

## Screenshots (if appropriate):
![graylog - content packs 2](https://user-images.githubusercontent.com/448763/46013137-9ece1480-c0cb-11e8-9a75-48a40bc4bba8.png)


## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
