### PR TITLE
Implement Error Boundary for Navigation Bar children.

### DIFF
--- a/graylog2-web-interface/src/components/support/ContactUs.jsx
+++ b/graylog2-web-interface/src/components/support/ContactUs.jsx
@@ -1,36 +1,14 @@
 import React from 'react';
 import { Col, Row } from 'react-bootstrap';
 
-import DocumentationLink from 'components/support/DocumentationLink';
-import DocsHelper from 'util/DocsHelper';
+import SupportSources from './SupportSources';
 
 class ContactUs extends React.Component {
   render() {
     return (
       <Row className="content">
         <Col md={12}>
-          <div className="support-sources">
-            <h2>Need help?</h2>
-            <p>
-              Do not hesitate to consult the Graylog community if your questions are not answered in the{' '}
-              <DocumentationLink page={DocsHelper.PAGES.WELCOME} text="documentation" />.
-            </p>
-
-            <ul>
-              <li>
-                <i className="fa fa-group" />&nbsp;
-                <a href="https://www.graylog.org/community-support/" target="_blank">Community support</a>
-              </li>
-              <li>
-                <i className="fa fa-github-alt" />&nbsp;
-                <a href="https://github.com/Graylog2/graylog2-server/issues" target="_blank">Issue tracker</a>
-              </li>
-              <li>
-                <i className="fa fa-heart" />&nbsp;
-                <a href="https://www.graylog.org/professional-support" target="_blank">Professional support</a>
-              </li>
-            </ul>
-          </div>
+          <SupportSources />
         </Col>
       </Row>
     );

--- a/graylog2-web-interface/src/components/support/ContactUs.jsx
+++ b/graylog2-web-interface/src/components/support/ContactUs.jsx
@@ -3,16 +3,12 @@ import { Col, Row } from 'react-bootstrap';
 
 import SupportSources from './SupportSources';
 
-class ContactUs extends React.Component {
-  render() {
-    return (
-      <Row className="content">
-        <Col md={12}>
-          <SupportSources />
-        </Col>
-      </Row>
-    );
-  }
-}
+const ContactUs = () => (
+  <Row className="content">
+    <Col md={12}>
+      <SupportSources />
+    </Col>
+  </Row>
+);
 
 export default ContactUs;

--- a/graylog2-web-interface/src/components/support/SupportSources.jsx
+++ b/graylog2-web-interface/src/components/support/SupportSources.jsx
@@ -1,0 +1,34 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+import DocumentationLink from './DocumentationLink';
+import DocsHelper from '../../util/DocsHelper';
+
+const SupportSources = () => (
+  <div className="support-sources">
+    <h2>Need help?</h2>
+    <p>
+      Do not hesitate to consult the Graylog community if your questions are not answered in the{' '}
+      <DocumentationLink page={DocsHelper.PAGES.WELCOME} text="documentation" />.
+    </p>
+
+    <ul>
+      <li>
+        <i className="fa fa-group" />&nbsp;
+        <a href="https://www.graylog.org/community-support/" target="_blank">Community support</a>
+      </li>
+      <li>
+        <i className="fa fa-github-alt" />&nbsp;
+        <a href="https://github.com/Graylog2/graylog2-server/issues" target="_blank">Issue tracker</a>
+      </li>
+      <li>
+        <i className="fa fa-heart" />&nbsp;
+        <a href="https://www.graylog.org/professional-support" target="_blank">Professional support</a>
+      </li>
+    </ul>
+  </div>
+);
+
+SupportSources.propTypes = {};
+
+export default SupportSources;

--- a/graylog2-web-interface/src/components/support/SupportSources.jsx
+++ b/graylog2-web-interface/src/components/support/SupportSources.jsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 
 import DocumentationLink from './DocumentationLink';
 import DocsHelper from '../../util/DocsHelper';
@@ -15,15 +14,15 @@ const SupportSources = () => (
     <ul>
       <li>
         <i className="fa fa-group" />&nbsp;
-        <a href="https://www.graylog.org/community-support/" target="_blank">Community support</a>
+        <a href="https://www.graylog.org/community-support/" target="_blank" rel="noopener noreferrer">Community support</a>
       </li>
       <li>
         <i className="fa fa-github-alt" />&nbsp;
-        <a href="https://github.com/Graylog2/graylog2-server/issues" target="_blank">Issue tracker</a>
+        <a href="https://github.com/Graylog2/graylog2-server/issues" target="_blank" rel="noopener noreferrer">Issue tracker</a>
       </li>
       <li>
         <i className="fa fa-heart" />&nbsp;
-        <a href="https://www.graylog.org/professional-support" target="_blank">Professional support</a>
+        <a href="https://www.graylog.org/professional-support" target="_blank" rel="noopener noreferrer">Professional support</a>
       </li>
     </ul>
   </div>

--- a/graylog2-web-interface/src/pages/ErrorPage.css
+++ b/graylog2-web-interface/src/pages/ErrorPage.css
@@ -1,0 +1,6 @@
+:local(.errorMessage) {
+    width: 80%;
+    margin-left: auto;
+    margin-right: auto;
+    text-align: left;
+}

--- a/graylog2-web-interface/src/pages/ErrorPage.css
+++ b/graylog2-web-interface/src/pages/ErrorPage.css
@@ -1,6 +1,13 @@
 :local(.errorMessage) {
-    width: 80%;
     margin-left: auto;
     margin-right: auto;
     text-align: left;
+}
+
+:local(.errorMessage dt) {
+    font-size: 1.2em;
+}
+
+:local(.greyBackground) {
+    background-color: #f5f5f5;
 }

--- a/graylog2-web-interface/src/pages/ErrorPage.css
+++ b/graylog2-web-interface/src/pages/ErrorPage.css
@@ -11,3 +11,7 @@
 :local(.greyBackground) {
     background-color: #f5f5f5;
 }
+
+:local(.toggleDetails) {
+    font-weight: normal;
+}

--- a/graylog2-web-interface/src/pages/ErrorPage.jsx
+++ b/graylog2-web-interface/src/pages/ErrorPage.jsx
@@ -29,34 +29,36 @@ class ErrorPage extends React.Component {
     const { error, info } = this.props;
 
     return (
-      <DocumentTitle title="Something went wrong.">
-        <Row className="jumbotron-container">
-          <Col mdOffset={2} md={8}>
-            <Jumbotron>
-              <h1>Something went wrong.</h1>
-              <p>It seems like the page you navigated to contained an error.</p>
-              <p>You can use the navigation to reach other parts of the product, refresh the page or submit an error report.</p>
-              <p>The details of the error are below:</p>
-              <dl className={errorPageStyles.errorMessage}>
-                <dt>Error:</dt>
-                <dd>
-                  <pre>{error.message}</pre>
-                </dd>
+      <div className="container-fluid">
+        <DocumentTitle title="Something went wrong.">
+          <Row className="jumbotron-container">
+            <Col mdOffset={2} md={8}>
+              <Jumbotron>
+                <h1>Something went wrong.</h1>
+                <p>It seems like the page you navigated to contained an error.</p>
+                <p>You can use the navigation to reach other parts of the product, refresh the page or submit an error report.</p>
+                <p>The details of the error are below:</p>
+                <dl className={errorPageStyles.errorMessage}>
+                  <dt>Error:</dt>
+                  <dd>
+                    <pre>{error.message}</pre>
+                  </dd>
 
-                <dt>Stack:</dt>
-                <dd>
-                  <pre>{error.stack}</pre>
-                </dd>
+                  <dt>Stack:</dt>
+                  <dd>
+                    <pre>{error.stack}</pre>
+                  </dd>
 
-                <dt>Component Tree:</dt>
-                <dd>
-                  <pre>{info.componentStack}</pre>
-                </dd>
-              </dl>
-            </Jumbotron>
-          </Col>
-        </Row>
-      </DocumentTitle>
+                  <dt>Component Tree:</dt>
+                  <dd>
+                    <pre>{info.componentStack}</pre>
+                  </dd>
+                </dl>
+              </Jumbotron>
+            </Col>
+          </Row>
+        </DocumentTitle>
+      </div>
     );
   }
 }

--- a/graylog2-web-interface/src/pages/ErrorPage.jsx
+++ b/graylog2-web-interface/src/pages/ErrorPage.jsx
@@ -60,7 +60,7 @@ class ErrorPage extends React.Component {
                     <dt>
                       Error:
                       <div className={`pull-right ${errorPageStyles.toggleDetails}`}>
-                        <a role="link" tabIndex={0} onClick={this._toggleDetails}>{showDetails ? 'Show less' : 'Show more'}</a>
+                        <a role="link" href="#" tabIndex={0} onClick={this._toggleDetails}>{showDetails ? 'Show less' : 'Show more'}</a>
                       </div>
                     </dt>
                     <dd className={errorPageStyles.greyBackground}>

--- a/graylog2-web-interface/src/pages/ErrorPage.jsx
+++ b/graylog2-web-interface/src/pages/ErrorPage.jsx
@@ -35,7 +35,10 @@ class ErrorPage extends React.Component {
     style.unuse();
   }
 
-  _toggleDetails = () => this.setState(({ showDetails }) => ({ showDetails: !showDetails }));
+  _toggleDetails = (e) => {
+    e.preventDefault();
+    this.setState(({ showDetails }) => ({ showDetails: !showDetails }));
+  };
 
   render() {
     const { error, info } = this.props;

--- a/graylog2-web-interface/src/pages/ErrorPage.jsx
+++ b/graylog2-web-interface/src/pages/ErrorPage.jsx
@@ -1,0 +1,64 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { Col, Jumbotron, Row } from 'react-bootstrap';
+import { DocumentTitle } from 'components/common';
+
+// eslint-disable-next-line import/no-webpack-loader-syntax
+import style from '!style/useable!css!./NotFoundPage.css';
+import errorPageStyles from './ErrorPage.css';
+
+class ErrorPage extends React.Component {
+  static propTypes = {
+    error: PropTypes.shape({
+      message: PropTypes.string.isRequired,
+    }).isRequired,
+    info: PropTypes.shape({
+      componentStack: PropTypes.string.isRequired,
+    }).isRequired,
+  };
+
+  componentDidMount() {
+    style.use();
+  }
+
+  componentWillUnmount() {
+    style.unuse();
+  }
+
+  render() {
+    const { error, info } = this.props;
+
+    return (
+      <DocumentTitle title="Not Found">
+        <Row className="jumbotron-container">
+          <Col mdOffset={2} md={8}>
+            <Jumbotron>
+              <h1>Something went wrong.</h1>
+              <p>It seems like the page you navigated to contained an error.</p>
+              <p>You can use the navigation to reach other parts of the product, refresh the page or submit an error report.</p>
+              <p>The details of the error are below:</p>
+              <dl className={errorPageStyles.errorMessage}>
+                <dt>Error:</dt>
+                <dd>
+                  <pre>{error.message}</pre>
+                </dd>
+
+                <dt>Stack:</dt>
+                <dd>
+                  <pre>{error.stack}</pre>
+                </dd>
+
+                <dt>Component Tree:</dt>
+                <dd>
+                  <pre>{info.componentStack}</pre>
+                </dd>
+              </dl>
+            </Jumbotron>
+          </Col>
+        </Row>
+      </DocumentTitle>
+    );
+  }
+}
+
+export default ErrorPage;

--- a/graylog2-web-interface/src/pages/ErrorPage.jsx
+++ b/graylog2-web-interface/src/pages/ErrorPage.jsx
@@ -29,7 +29,7 @@ class ErrorPage extends React.Component {
     const { error, info } = this.props;
 
     return (
-      <DocumentTitle title="Not Found">
+      <DocumentTitle title="Something went wrong.">
         <Row className="jumbotron-container">
           <Col mdOffset={2} md={8}>
             <Jumbotron>

--- a/graylog2-web-interface/src/pages/ErrorPage.jsx
+++ b/graylog2-web-interface/src/pages/ErrorPage.jsx
@@ -7,6 +7,8 @@ import { DocumentTitle } from 'components/common';
 import style from '!style/useable!css!./NotFoundPage.css';
 import errorPageStyles from './ErrorPage.css';
 import SupportSources from '../components/support/SupportSources';
+import ClipboardButton from '../components/common/ClipboardButton';
+import AppConfig from '../util/AppConfig';
 
 class ErrorPage extends React.Component {
   static propTypes = {
@@ -18,6 +20,13 @@ class ErrorPage extends React.Component {
     }).isRequired,
   };
 
+  constructor(props) {
+    super(props);
+    this.state = {
+      showDetails: AppConfig.gl2DevMode(),
+    };
+  }
+
   componentDidMount() {
     style.use();
   }
@@ -26,8 +35,13 @@ class ErrorPage extends React.Component {
     style.unuse();
   }
 
+  _toggleDetails = () => this.setState(({ showDetails }) => ({ showDetails: !showDetails }));
+
   render() {
     const { error, info } = this.props;
+    const { showDetails } = this.state;
+
+    const errorDetails = `\n\nStack Trace:\n\n${error.stack}\n\nComponent Stack:\n${info.componentStack}`;
 
     return (
       <div className="container-fluid">
@@ -45,17 +59,17 @@ class ErrorPage extends React.Component {
                   <dl>
                     <dt>Error:</dt>
                     <dd className={errorPageStyles.greyBackground}>
-                      <pre className="content">{error.message}</pre>
-                    </dd>
-
-                    <dt>Stack:</dt>
-                    <dd className={errorPageStyles.greyBackground}>
-                      <pre className="content">{error.stack}</pre>
-                    </dd>
-
-                    <dt>Component Tree:</dt>
-                    <dd className={errorPageStyles.greyBackground}>
-                      <pre className="content">{info.componentStack}</pre>
+                      <pre className="content">
+                        <div className="pull-right">
+                          <ClipboardButton title={<i className="fa fa-copy fa-fw" />}
+                                           bsSize="sm"
+                                           text={`${error.message}\n${errorDetails}`}
+                                           buttonTitle="Copy error details to clipboard" />
+                        </div>
+                        <a role="link" tabIndex={0} onClick={this._toggleDetails}><i className={`fa ${showDetails ? 'fa-caret-down' : 'fa-caret-right'}`} /></a>
+                        {error.message}
+                        {showDetails && errorDetails}
+                      </pre>
                     </dd>
                   </dl>
                 </div>

--- a/graylog2-web-interface/src/pages/ErrorPage.jsx
+++ b/graylog2-web-interface/src/pages/ErrorPage.jsx
@@ -6,6 +6,7 @@ import { DocumentTitle } from 'components/common';
 // eslint-disable-next-line import/no-webpack-loader-syntax
 import style from '!style/useable!css!./NotFoundPage.css';
 import errorPageStyles from './ErrorPage.css';
+import SupportSources from '../components/support/SupportSources';
 
 class ErrorPage extends React.Component {
   static propTypes = {
@@ -37,23 +38,27 @@ class ErrorPage extends React.Component {
                 <h1>Something went wrong.</h1>
                 <p>It seems like the page you navigated to contained an error.</p>
                 <p>You can use the navigation to reach other parts of the product, refresh the page or submit an error report.</p>
-                <p>The details of the error are below:</p>
-                <dl className={errorPageStyles.errorMessage}>
-                  <dt>Error:</dt>
-                  <dd>
-                    <pre>{error.message}</pre>
-                  </dd>
+                <div className={errorPageStyles.errorMessage}>
+                  <div className="content" style={{ padding: '2em' }}>
+                    <SupportSources />
+                  </div>
+                  <dl>
+                    <dt>Error:</dt>
+                    <dd className={errorPageStyles.greyBackground}>
+                      <pre className="content">{error.message}</pre>
+                    </dd>
 
-                  <dt>Stack:</dt>
-                  <dd>
-                    <pre>{error.stack}</pre>
-                  </dd>
+                    <dt>Stack:</dt>
+                    <dd className={errorPageStyles.greyBackground}>
+                      <pre className="content">{error.stack}</pre>
+                    </dd>
 
-                  <dt>Component Tree:</dt>
-                  <dd>
-                    <pre>{info.componentStack}</pre>
-                  </dd>
-                </dl>
+                    <dt>Component Tree:</dt>
+                    <dd className={errorPageStyles.greyBackground}>
+                      <pre className="content">{info.componentStack}</pre>
+                    </dd>
+                  </dl>
+                </div>
               </Jumbotron>
             </Col>
           </Row>

--- a/graylog2-web-interface/src/pages/ErrorPage.jsx
+++ b/graylog2-web-interface/src/pages/ErrorPage.jsx
@@ -46,6 +46,7 @@ class ErrorPage extends React.Component {
 
     const errorDetails = `\n\nStack Trace:\n\n${error.stack}\n\nComponent Stack:\n${info.componentStack}`;
 
+    /* eslint-disable jsx-a11y/href-no-hash */
     return (
       <div className="container-fluid">
         <DocumentTitle title="Something went wrong.">
@@ -63,7 +64,7 @@ class ErrorPage extends React.Component {
                     <dt>
                       Error:
                       <div className={`pull-right ${errorPageStyles.toggleDetails}`}>
-                        <a role="link" href="#" tabIndex={0} onClick={this._toggleDetails}>{showDetails ? 'Show less' : 'Show more'}</a>
+                        <a href="#" tabIndex={0} onClick={this._toggleDetails}>{showDetails ? 'Show less' : 'Show more'}</a>
                       </div>
                     </dt>
                     <dd className={errorPageStyles.greyBackground}>
@@ -86,6 +87,7 @@ class ErrorPage extends React.Component {
         </DocumentTitle>
       </div>
     );
+    /* eslint-enable jsx-a11y/href-no-hash */
   }
 }
 

--- a/graylog2-web-interface/src/pages/ErrorPage.jsx
+++ b/graylog2-web-interface/src/pages/ErrorPage.jsx
@@ -57,7 +57,12 @@ class ErrorPage extends React.Component {
                     <SupportSources />
                   </div>
                   <dl>
-                    <dt>Error:</dt>
+                    <dt>
+                      Error:
+                      <div className={`pull-right ${errorPageStyles.toggleDetails}`}>
+                        <a role="link" tabIndex={0} onClick={this._toggleDetails}>{showDetails ? 'Show less' : 'Show more'}</a>
+                      </div>
+                    </dt>
                     <dd className={errorPageStyles.greyBackground}>
                       <pre className="content">
                         <div className="pull-right">
@@ -66,7 +71,6 @@ class ErrorPage extends React.Component {
                                            text={`${error.message}\n${errorDetails}`}
                                            buttonTitle="Copy error details to clipboard" />
                         </div>
-                        <a role="link" tabIndex={0} onClick={this._toggleDetails}><i className={`fa ${showDetails ? 'fa-caret-down' : 'fa-caret-right'}`} /></a>
                         {error.message}
                         {showDetails && errorDetails}
                       </pre>

--- a/graylog2-web-interface/src/routing/App.jsx
+++ b/graylog2-web-interface/src/routing/App.jsx
@@ -12,6 +12,7 @@ import 'c3/c3.css';
 import 'dc/dc.css';
 
 import StoreProvider from 'injection/StoreProvider';
+import AppErrorBoundary from './AppErrorBoundary';
 
 const CurrentUserStore = StoreProvider.getStore('CurrentUser');
 
@@ -41,7 +42,9 @@ const App = createReactClass({
         <div id="scroll-to-hint" style={{ display: 'none' }} className="alpha80">
           <i className="fa fa-arrow-up" />
         </div>
-        {this.props.children}
+        <AppErrorBoundary>
+          {this.props.children}
+        </AppErrorBoundary>
         <Footer />
       </div>
     );

--- a/graylog2-web-interface/src/routing/AppErrorBoundary.jsx
+++ b/graylog2-web-interface/src/routing/AppErrorBoundary.jsx
@@ -1,0 +1,43 @@
+import React from 'react';
+import { withRouter } from 'react-router';
+import PropTypes from 'prop-types';
+import ErrorPage from '../pages/ErrorPage';
+
+class AppErrorBoundary extends React.Component {
+  static propTypes = {
+    children: PropTypes.oneOfType([
+      PropTypes.element,
+      PropTypes.arrayOf(PropTypes.element),
+    ]).isRequired,
+    router: PropTypes.object.isRequired,
+  };
+
+  constructor(props) {
+    super(props);
+    this.state = {};
+    this.unlisten = () => {};
+  }
+
+  componentDidMount() {
+    const { router } = this.props;
+    this.unlisten = router.listen(() => this.setState(() => ({ error: undefined, info: undefined })));
+  }
+
+  componentWillUnmount() {
+    this.unlisten();
+  }
+
+  componentDidCatch(error, info) {
+    this.setState({ error, info });
+  }
+
+  render() {
+    const { error, info } = this.state;
+    if (error) {
+      return <ErrorPage error={error} info={info} />;
+    }
+    return this.props.children;
+  }
+}
+
+export default withRouter(AppErrorBoundary);

--- a/graylog2-web-interface/src/routing/AppErrorBoundary.test.jsx
+++ b/graylog2-web-interface/src/routing/AppErrorBoundary.test.jsx
@@ -19,6 +19,7 @@ const suppressConsole = (fn) => {
 };
 
 const ErroneusComponent = () => {
+  // eslint-disable-next-line no-throw-literal
   throw {
     message: 'Oh no, a banana peel fell on the party gorilla\'s head!',
     stack: 'This the stack trace.',

--- a/graylog2-web-interface/src/routing/AppErrorBoundary.test.jsx
+++ b/graylog2-web-interface/src/routing/AppErrorBoundary.test.jsx
@@ -1,0 +1,115 @@
+import React from 'react';
+import { mount } from 'enzyme';
+
+import AppErrorBoundary from './AppErrorBoundary';
+
+jest.mock('react-router', () => ({ withRouter: x => x }));
+jest.mock('!style/useable!css!./NotFoundPage.css', () => ({ use: jest.fn(), unuse: jest.fn() }));
+
+const suppressConsole = (fn) => {
+  /* eslint-disable no-console */
+  const originalConsoleError = console.error;
+  console.error = () => {
+  };
+
+  fn();
+
+  console.error = originalConsoleError;
+  /* eslint-enable no-console */
+};
+
+const ErroneusComponent = () => {
+  throw {
+    message: 'Oh no, a banana peel fell on the party gorilla\'s head!',
+    stack: 'This the stack trace.',
+  };
+};
+
+const WorkingComponent = () => <div>Hello World!</div>;
+
+describe('AppErrorBoundary', () => {
+  it('registers to router upon mount', () => {
+    const router = {
+      listen: jest.fn(),
+    };
+
+    mount((
+      <AppErrorBoundary router={router}>
+        <WorkingComponent />
+      </AppErrorBoundary>
+    ));
+
+    expect(router.listen).toHaveBeenCalled();
+  });
+
+  it('unregisters from router upon unmount', () => {
+    const unlisten = jest.fn();
+    const router = {
+      listen: () => unlisten,
+    };
+
+    const wrapper = mount((
+      <AppErrorBoundary router={router}>
+        <WorkingComponent />
+      </AppErrorBoundary>
+    ));
+    wrapper.unmount();
+
+    expect(unlisten).toHaveBeenCalled();
+  });
+
+  it('displays child component if there is no error', () => {
+    const router = {
+      listen: jest.fn(),
+    };
+    const wrapper = mount((
+      <AppErrorBoundary router={router}>
+        <WorkingComponent />
+      </AppErrorBoundary>
+    ));
+
+    expect(wrapper).toMatchSnapshot();
+    expect(wrapper.find(WorkingComponent)).toHaveLength(1);
+  });
+
+  it('displays error after catching', () => {
+    const router = {
+      listen: jest.fn(),
+    };
+
+    suppressConsole(() => {
+      const wrapper = mount((
+        <AppErrorBoundary router={router}>
+          <ErroneusComponent />
+        </AppErrorBoundary>
+      ));
+
+      expect(wrapper).toMatchSnapshot();
+    });
+  });
+
+  it('resets error when navigation changes', () => {
+    const router = {
+      listen: jest.fn(),
+    };
+
+    suppressConsole(() => {
+      const wrapper = mount((
+        <AppErrorBoundary router={router}>
+          <ErroneusComponent />
+        </AppErrorBoundary>
+      ));
+
+      expect(wrapper).toIncludeText('banana peel');
+
+      wrapper.setProps({ children: <WorkingComponent /> });
+      const listenCallback = router.listen.mock.calls[0][0];
+      listenCallback();
+      // force update of component to reflect state changes
+      wrapper.update();
+
+      expect(wrapper.find(WorkingComponent)).toHaveLength(1);
+      expect(wrapper).toIncludeText('Hello World');
+    });
+  });
+});

--- a/graylog2-web-interface/src/routing/__snapshots__/AppErrorBoundary.test.jsx.snap
+++ b/graylog2-web-interface/src/routing/__snapshots__/AppErrorBoundary.test.jsx.snap
@@ -178,7 +178,6 @@ exports[`AppErrorBoundary displays error after catching 1`] = `
                             <a
                               href="#"
                               onClick={[Function]}
-                              role="link"
                               tabIndex={0}
                             >
                               Show more

--- a/graylog2-web-interface/src/routing/__snapshots__/AppErrorBoundary.test.jsx.snap
+++ b/graylog2-web-interface/src/routing/__snapshots__/AppErrorBoundary.test.jsx.snap
@@ -54,81 +54,248 @@ exports[`AppErrorBoundary displays error after catching 1`] = `
       }
     }
   >
-    <DocumentTitle
-      title="Something went wrong."
+    <div
+      className="container-fluid"
     >
-      <Row
-        bsClass="row"
-        className="jumbotron-container"
-        componentClass="div"
+      <DocumentTitle
+        title="Something went wrong."
       >
-        <div
-          className="jumbotron-container row"
+        <Row
+          bsClass="row"
+          className="jumbotron-container"
+          componentClass="div"
         >
-          <Col
-            bsClass="col"
-            componentClass="div"
-            md={8}
-            mdOffset={2}
+          <div
+            className="jumbotron-container row"
           >
-            <div
-              className="col-md-8 col-md-offset-2"
+            <Col
+              bsClass="col"
+              componentClass="div"
+              md={8}
+              mdOffset={2}
             >
-              <Jumbotron
-                bsClass="jumbotron"
-                componentClass="div"
+              <div
+                className="col-md-8 col-md-offset-2"
               >
-                <div
-                  className="jumbotron"
+                <Jumbotron
+                  bsClass="jumbotron"
+                  componentClass="div"
                 >
-                  <h1>
-                    Something went wrong.
-                  </h1>
-                  <p>
-                    It seems like the page you navigated to contained an error.
-                  </p>
-                  <p>
-                    You can use the navigation to reach other parts of the product, refresh the page or submit an error report.
-                  </p>
-                  <p>
-                    The details of the error are below:
-                  </p>
-                  <dl>
-                    <dt>
-                      Error:
-                    </dt>
-                    <dd>
-                      <pre>
-                        Oh no, a banana peel fell on the party gorilla's head!
-                      </pre>
-                    </dd>
-                    <dt>
-                      Stack:
-                    </dt>
-                    <dd>
-                      <pre>
-                        This the stack trace.
-                      </pre>
-                    </dd>
-                    <dt>
-                      Component Tree:
-                    </dt>
-                    <dd>
-                      <pre>
-                        
+                  <div
+                    className="jumbotron"
+                  >
+                    <h1>
+                      Something went wrong.
+                    </h1>
+                    <p>
+                      It seems like the page you navigated to contained an error.
+                    </p>
+                    <p>
+                      You can use the navigation to reach other parts of the product, refresh the page or submit an error report.
+                    </p>
+                    <div>
+                      <div
+                        className="content"
+                        style={
+                          Object {
+                            "padding": "2em",
+                          }
+                        }
+                      >
+                        <SupportSources>
+                          <div
+                            className="support-sources"
+                          >
+                            <h2>
+                              Need help?
+                            </h2>
+                            <p>
+                              Do not hesitate to consult the Graylog community if your questions are not answered in the
+                               
+                              <DocumentationLink
+                                page=""
+                                text="documentation"
+                              >
+                                <a
+                                  href="http://docs.graylog.org/en/3.0"
+                                  target="_blank"
+                                >
+                                  documentation
+                                </a>
+                              </DocumentationLink>
+                              .
+                            </p>
+                            <ul>
+                              <li>
+                                <i
+                                  className="fa fa-group"
+                                />
+                                 
+                                <a
+                                  href="https://www.graylog.org/community-support/"
+                                  rel="noopener noreferrer"
+                                  target="_blank"
+                                >
+                                  Community support
+                                </a>
+                              </li>
+                              <li>
+                                <i
+                                  className="fa fa-github-alt"
+                                />
+                                 
+                                <a
+                                  href="https://github.com/Graylog2/graylog2-server/issues"
+                                  rel="noopener noreferrer"
+                                  target="_blank"
+                                >
+                                  Issue tracker
+                                </a>
+                              </li>
+                              <li>
+                                <i
+                                  className="fa fa-heart"
+                                />
+                                 
+                                <a
+                                  href="https://www.graylog.org/professional-support"
+                                  rel="noopener noreferrer"
+                                  target="_blank"
+                                >
+                                  Professional support
+                                </a>
+                              </li>
+                            </ul>
+                          </div>
+                        </SupportSources>
+                      </div>
+                      <dl>
+                        <dt>
+                          Error:
+                          <div
+                            className="pull-right undefined"
+                          >
+                            <a
+                              href="#"
+                              onClick={[Function]}
+                              role="link"
+                              tabIndex={0}
+                            >
+                              Show more
+                            </a>
+                          </div>
+                        </dt>
+                        <dd>
+                          <pre
+                            className="content"
+                          >
+                            <div
+                              className="pull-right"
+                            >
+                              <ClipboardButton
+                                action="copy"
+                                bsSize="sm"
+                                buttonTitle="Copy error details to clipboard"
+                                disabled={false}
+                                text="Oh no, a banana peel fell on the party gorilla's head!
+
+
+Stack Trace:
+
+This the stack trace.
+
+Component Stack:
+
     in ErroneusComponent
     in AppErrorBoundary (created by WrapperComponent)
-    in WrapperComponent
-                      </pre>
-                    </dd>
-                  </dl>
-                </div>
-              </Jumbotron>
-            </div>
-          </Col>
-        </div>
-      </Row>
-    </DocumentTitle>
+    in WrapperComponent"
+                                title={
+                                  <i
+                                    className="fa fa-copy fa-fw"
+                                  />
+                                }
+                              >
+                                <OverlayTrigger
+                                  defaultOverlayShown={false}
+                                  overlay={
+                                    <Tooltip
+                                      bsClass="tooltip"
+                                      id="copy-button-tooltip"
+                                      placement="right"
+                                    >
+                                      
+                                    </Tooltip>
+                                  }
+                                  placement="top"
+                                  rootClose={true}
+                                  trigger="click"
+                                >
+                                  <Button
+                                    active={false}
+                                    block={false}
+                                    bsClass="btn"
+                                    bsSize="sm"
+                                    bsStyle="default"
+                                    data-clipboard-action="copy"
+                                    data-clipboard-button={true}
+                                    data-clipboard-text="Oh no, a banana peel fell on the party gorilla's head!
+
+
+Stack Trace:
+
+This the stack trace.
+
+Component Stack:
+
+    in ErroneusComponent
+    in AppErrorBoundary (created by WrapperComponent)
+    in WrapperComponent"
+                                    disabled={false}
+                                    onClick={[Function]}
+                                    title="Copy error details to clipboard"
+                                  >
+                                    <button
+                                      className="btn btn-sm btn-default"
+                                      data-clipboard-action="copy"
+                                      data-clipboard-button={true}
+                                      data-clipboard-text="Oh no, a banana peel fell on the party gorilla's head!
+
+
+Stack Trace:
+
+This the stack trace.
+
+Component Stack:
+
+    in ErroneusComponent
+    in AppErrorBoundary (created by WrapperComponent)
+    in WrapperComponent"
+                                      disabled={false}
+                                      onClick={[Function]}
+                                      title="Copy error details to clipboard"
+                                      type="button"
+                                    >
+                                      <i
+                                        className="fa fa-copy fa-fw"
+                                      />
+                                    </button>
+                                  </Button>
+                                </OverlayTrigger>
+                              </ClipboardButton>
+                            </div>
+                            Oh no, a banana peel fell on the party gorilla's head!
+                          </pre>
+                        </dd>
+                      </dl>
+                    </div>
+                  </div>
+                </Jumbotron>
+              </div>
+            </Col>
+          </div>
+        </Row>
+      </DocumentTitle>
+    </div>
   </ErrorPage>
 </AppErrorBoundary>
 `;

--- a/graylog2-web-interface/src/routing/__snapshots__/AppErrorBoundary.test.jsx.snap
+++ b/graylog2-web-interface/src/routing/__snapshots__/AppErrorBoundary.test.jsx.snap
@@ -1,0 +1,134 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`AppErrorBoundary displays child component if there is no error 1`] = `
+<AppErrorBoundary
+  router={
+    Object {
+      "listen": [MockFunction] {
+        "calls": Array [
+          Array [
+            [Function],
+          ],
+        ],
+        "results": undefined,
+      },
+    }
+  }
+>
+  <WorkingComponent>
+    <div>
+      Hello World!
+    </div>
+  </WorkingComponent>
+</AppErrorBoundary>
+`;
+
+exports[`AppErrorBoundary displays error after catching 1`] = `
+<AppErrorBoundary
+  router={
+    Object {
+      "listen": [MockFunction] {
+        "calls": Array [
+          Array [
+            [Function],
+          ],
+        ],
+        "results": undefined,
+      },
+    }
+  }
+>
+  <ErrorPage
+    error={
+      Object {
+        "message": "Oh no, a banana peel fell on the party gorilla's head!",
+        "stack": "This the stack trace.",
+      }
+    }
+    info={
+      Object {
+        "componentStack": "
+    in ErroneusComponent
+    in AppErrorBoundary (created by WrapperComponent)
+    in WrapperComponent",
+      }
+    }
+  >
+    <DocumentTitle
+      title="Not Found"
+    >
+      <Row
+        bsClass="row"
+        className="jumbotron-container"
+        componentClass="div"
+      >
+        <div
+          className="jumbotron-container row"
+        >
+          <Col
+            bsClass="col"
+            componentClass="div"
+            md={8}
+            mdOffset={2}
+          >
+            <div
+              className="col-md-8 col-md-offset-2"
+            >
+              <Jumbotron
+                bsClass="jumbotron"
+                componentClass="div"
+              >
+                <div
+                  className="jumbotron"
+                >
+                  <h1>
+                    Something went wrong.
+                  </h1>
+                  <p>
+                    It seems like the page you navigated to contained an error.
+                  </p>
+                  <p>
+                    You can use the navigation to reach other parts of the product, refresh the page or submit an error report.
+                  </p>
+                  <p>
+                    The details of the error are below:
+                  </p>
+                  <dl>
+                    <dt>
+                      Error:
+                    </dt>
+                    <dd>
+                      <pre>
+                        Oh no, a banana peel fell on the party gorilla's head!
+                      </pre>
+                    </dd>
+                    <dt>
+                      Stack:
+                    </dt>
+                    <dd>
+                      <pre>
+                        This the stack trace.
+                      </pre>
+                    </dd>
+                    <dt>
+                      Component Tree:
+                    </dt>
+                    <dd>
+                      <pre>
+                        
+    in ErroneusComponent
+    in AppErrorBoundary (created by WrapperComponent)
+    in WrapperComponent
+                      </pre>
+                    </dd>
+                  </dl>
+                </div>
+              </Jumbotron>
+            </div>
+          </Col>
+        </div>
+      </Row>
+    </DocumentTitle>
+  </ErrorPage>
+</AppErrorBoundary>
+`;

--- a/graylog2-web-interface/src/routing/__snapshots__/AppErrorBoundary.test.jsx.snap
+++ b/graylog2-web-interface/src/routing/__snapshots__/AppErrorBoundary.test.jsx.snap
@@ -55,7 +55,7 @@ exports[`AppErrorBoundary displays error after catching 1`] = `
     }
   >
     <DocumentTitle
-      title="Not Found"
+      title="Something went wrong."
     >
       <Row
         bsClass="row"

--- a/graylog2-web-interface/webpack.config.js
+++ b/graylog2-web-interface/webpack.config.js
@@ -114,7 +114,7 @@ if (TARGET === 'start') {
   console.error('Running in development (no HMR) mode');
   module.exports = merge(webpackConfig, {
     mode: 'development',
-    devtool: 'eval',
+    devtool: 'cheap-module-source-map',
     output: {
       path: BUILD_PATH,
       filename: '[name].js',


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
    This change implements a error boundary component wrapping children of
    the navigation bar in the `App` component.

    Before this change, any errors in children components of the navigation
    bar caused the application to malfunction, errors being shown on the
    js console only and (for React 16) the DOM to be unmounted, requiring
    the user to do a full page refresh to be able to work with the
    application again.

    After this change, errors occuring in components which are children of
    the navigation bar leave the application in a functional state, while
    showing the error message, stack trace and component tree in the
    browser. Users are still able to navigate the application afterwards.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.