### PR TITLE
Enforce newlines at the end of rendered configurations

### DIFF
--- a/graylog2-server/src/main/java/org/graylog/plugins/sidecar/services/ConfigurationService.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/sidecar/services/ConfigurationService.java
@@ -194,9 +194,6 @@ public class ConfigurationService extends PaginatedDbService<Configuration> {
         }
 
         template = writer.toString();
-        if (!template.substring(template.length() -1).equals("\n")) {
-            return template + "\n";
-        }
-        return template;
+        return template.endsWith("\n") ? template : template + "\n";
     }
 }

--- a/graylog2-server/src/main/java/org/graylog/plugins/sidecar/services/ConfigurationService.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/sidecar/services/ConfigurationService.java
@@ -181,6 +181,7 @@ public class ConfigurationService extends PaginatedDbService<Configuration> {
 
     private String renderTemplate(String configurationId, Map<String, Object> context) throws RenderTemplateException {
         Writer writer = new StringWriter();
+        String template;
         try {
             Template compiledTemplate = templateConfiguration.getTemplate(configurationId);
             compiledTemplate.process(context, writer);
@@ -192,6 +193,10 @@ public class ConfigurationService extends PaginatedDbService<Configuration> {
             throw new RenderTemplateException(e.getMessage(), e);
         }
 
-        return writer.toString();
+        template = writer.toString();
+        if (!template.substring(template.length() -1).equals("\n")) {
+            return template + "\n";
+        }
+        return template;
     }
 }

--- a/graylog2-server/src/test/java/org/graylog/plugins/sidecar/collectors/ConfigurationServiceTest.java
+++ b/graylog2-server/src/test/java/org/graylog/plugins/sidecar/collectors/ConfigurationServiceTest.java
@@ -1,0 +1,121 @@
+/**
+ * This file is part of Graylog.
+ *
+ * Graylog is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.graylog.plugins.sidecar.collectors;
+
+import com.lordofthejars.nosqlunit.annotation.CustomComparisonStrategy;
+import com.lordofthejars.nosqlunit.annotation.IgnorePropertyValue;
+import com.lordofthejars.nosqlunit.annotation.ShouldMatchDataSet;
+import com.lordofthejars.nosqlunit.annotation.UsingDataSet;
+import com.lordofthejars.nosqlunit.core.LoadStrategyEnum;
+import com.lordofthejars.nosqlunit.mongodb.InMemoryMongoDb;
+import com.lordofthejars.nosqlunit.mongodb.MongoFlexibleComparisonStrategy;
+import org.graylog.plugins.sidecar.database.MongoConnectionRule;
+import org.graylog.plugins.sidecar.rest.models.Configuration;
+import org.graylog.plugins.sidecar.rest.models.NodeDetails;
+import org.graylog.plugins.sidecar.rest.models.Sidecar;
+import org.graylog.plugins.sidecar.services.CollectorService;
+import org.graylog.plugins.sidecar.services.ConfigurationService;
+import org.graylog.plugins.sidecar.services.SidecarService;
+import org.graylog2.bindings.providers.MongoJackObjectMapperProvider;
+import org.graylog2.shared.bindings.ObjectMapperModule;
+import org.graylog2.shared.bindings.ValidatorModule;
+import org.jukito.JukitoRunner;
+import org.jukito.UseModules;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnit;
+import org.mockito.junit.MockitoRule;
+
+import javax.validation.Validator;
+import java.util.List;
+
+import static com.lordofthejars.nosqlunit.mongodb.InMemoryMongoDb.InMemoryMongoRuleBuilder.newInMemoryMongoDbRule;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+@RunWith(JukitoRunner.class)
+@UseModules({ObjectMapperModule.class, ValidatorModule.class})
+@CustomComparisonStrategy(comparisonStrategy = MongoFlexibleComparisonStrategy.class)
+public class ConfigurationServiceTest {
+    private final String FILEBEAT_CONF_ID = "5b8fe5f97ad37b17a44e2a34";
+    @Mock
+    private CollectorService collectorService;
+
+    @Mock
+    private Sidecar sidecar;
+
+    @Mock
+    private NodeDetails nodeDetails;
+
+    @Rule public MockitoRule mockitoRule = MockitoJUnit.rule();
+
+    @ClassRule
+    public static final InMemoryMongoDb IN_MEMORY_MONGO_DB = newInMemoryMongoDbRule().build();
+
+    @Rule
+    public MongoConnectionRule mongoRule = MongoConnectionRule.build("test");
+
+    private ConfigurationService configurationService;
+    private Configuration configuration;
+
+
+    private Configuration buildTestConfig(String template) {
+        return Configuration.create(FILEBEAT_CONF_ID, "collId", "filebeat", "#ffffff", template);
+    }
+
+    @Before
+    public void setUp(MongoJackObjectMapperProvider mapperProvider,
+                      Validator validator) throws Exception {
+        when(nodeDetails.operatingSystem()).thenReturn("DummyOS");
+        when(nodeDetails.ip()).thenReturn("1.2.3.4");
+        when(sidecar.nodeId()).thenReturn("42");
+        when(sidecar.nodeName()).thenReturn("mockymock");
+        when(sidecar.nodeDetails()).thenReturn(nodeDetails);
+
+        this.configurationService = new ConfigurationService(mongoRule.getMongoConnection(), mapperProvider);
+    }
+
+    @Test
+    public void testTemplateRender() throws Exception {
+        final String TEMPLATE = "foo bar\n nodename: ${nodeName}\n";
+        final String TEMPLATE_RENDERED = "foo bar\n nodename: mockymock\n";
+        configuration = buildTestConfig(TEMPLATE);
+        this.configurationService.save(configuration);
+        Configuration result = this.configurationService.renderConfigurationForCollector(sidecar, configuration);
+
+        Configuration configWithNewline = buildTestConfig(TEMPLATE_RENDERED);
+        assertEquals(configWithNewline, result);
+    }
+
+    @Test
+    public void testAddMissingNewline() throws Exception {
+        configuration = buildTestConfig("template\n without\n newline");
+        this.configurationService.save(configuration);
+        Configuration result = this.configurationService.renderConfigurationForCollector(sidecar, configuration);
+
+        Configuration configWithNewline = buildTestConfig(configuration.template() + "\n");
+        assertEquals(configWithNewline, result);
+    }
+
+}

--- a/graylog2-server/src/test/java/org/graylog/plugins/sidecar/collectors/ConfigurationServiceTest.java
+++ b/graylog2-server/src/test/java/org/graylog/plugins/sidecar/collectors/ConfigurationServiceTest.java
@@ -16,51 +16,32 @@
  */
 package org.graylog.plugins.sidecar.collectors;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.lordofthejars.nosqlunit.annotation.CustomComparisonStrategy;
-import com.lordofthejars.nosqlunit.annotation.IgnorePropertyValue;
-import com.lordofthejars.nosqlunit.annotation.ShouldMatchDataSet;
-import com.lordofthejars.nosqlunit.annotation.UsingDataSet;
-import com.lordofthejars.nosqlunit.core.LoadStrategyEnum;
 import com.lordofthejars.nosqlunit.mongodb.InMemoryMongoDb;
 import com.lordofthejars.nosqlunit.mongodb.MongoFlexibleComparisonStrategy;
 import org.graylog.plugins.sidecar.database.MongoConnectionRule;
 import org.graylog.plugins.sidecar.rest.models.Configuration;
 import org.graylog.plugins.sidecar.rest.models.NodeDetails;
 import org.graylog.plugins.sidecar.rest.models.Sidecar;
-import org.graylog.plugins.sidecar.services.CollectorService;
 import org.graylog.plugins.sidecar.services.ConfigurationService;
-import org.graylog.plugins.sidecar.services.SidecarService;
 import org.graylog2.bindings.providers.MongoJackObjectMapperProvider;
-import org.graylog2.shared.bindings.ObjectMapperModule;
-import org.graylog2.shared.bindings.ValidatorModule;
-import org.jukito.JukitoRunner;
-import org.jukito.UseModules;
+import org.graylog2.shared.bindings.providers.ObjectMapperProvider;
 import org.junit.Before;
 import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
-import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnit;
 import org.mockito.junit.MockitoRule;
 
-import javax.validation.Validator;
-import java.util.List;
-
 import static com.lordofthejars.nosqlunit.mongodb.InMemoryMongoDb.InMemoryMongoRuleBuilder.newInMemoryMongoDbRule;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-@RunWith(JukitoRunner.class)
-@UseModules({ObjectMapperModule.class, ValidatorModule.class})
 @CustomComparisonStrategy(comparisonStrategy = MongoFlexibleComparisonStrategy.class)
 public class ConfigurationServiceTest {
     private final String FILEBEAT_CONF_ID = "5b8fe5f97ad37b17a44e2a34";
-    @Mock
-    private CollectorService collectorService;
 
     @Mock
     private Sidecar sidecar;
@@ -85,15 +66,16 @@ public class ConfigurationServiceTest {
     }
 
     @Before
-    public void setUp(MongoJackObjectMapperProvider mapperProvider,
-                      Validator validator) throws Exception {
+    public void setUp() throws Exception {
+        final ObjectMapper objectMapper = new ObjectMapperProvider().get();
+        final MongoJackObjectMapperProvider mongoJackObjectMapperProvider = new MongoJackObjectMapperProvider(objectMapper);
         when(nodeDetails.operatingSystem()).thenReturn("DummyOS");
         when(nodeDetails.ip()).thenReturn("1.2.3.4");
         when(sidecar.nodeId()).thenReturn("42");
         when(sidecar.nodeName()).thenReturn("mockymock");
         when(sidecar.nodeDetails()).thenReturn(nodeDetails);
 
-        this.configurationService = new ConfigurationService(mongoRule.getMongoConnection(), mapperProvider);
+        this.configurationService = new ConfigurationService(mongoRule.getMongoConnection(), mongoJackObjectMapperProvider);
     }
 
     @Test


### PR DESCRIPTION
If a user entered a Sidecar configuration without an empty last line,
we would render the last configuration line without a newline terminator.
This might confuse some config parsers, looks weird when using `cat` and
is against my personal taste ;-)

Also add a small unit test for the ConfigurationService.
