### PR TITLE
Improving MockComponent by rendering custom component.

### DIFF
--- a/graylog2-web-interface/src/components/lookup-tables/__snapshots__/DataAdapterCreate.test.jsx.snap
+++ b/graylog2-web-interface/src/components/lookup-tables/__snapshots__/DataAdapterCreate.test.jsx.snap
@@ -12,39 +12,31 @@ exports[`<DataAdapterCreate /> should render for types with defined frontend com
         className="form form-horizontal"
         onSubmit={[Function]}
       >
-        <span
-          className="InputMock"
+        <input-mock
+          autoFocus={true}
+          help="The type of data adapter to configure."
+          id="data-adapter-type-select"
+          label="Data Adapter Type"
+          labelClassName="col-sm-3"
+          required={true}
+          wrapperClassName="col-sm-9"
         >
-          <span
-            autoFocus={true}
-            help="The type of data adapter to configure."
-            id="data-adapter-type-select"
-            label="Data Adapter Type"
-            labelClassName="col-sm-3"
-            required={true}
-            wrapperClassName="col-sm-9"
-          >
-            <span
-              className="SelectMock"
-            >
-              <span
-                clearable={false}
-                matchProp="value"
-                onChange={[Function]}
-                options={
-                  Array [
-                    Object {
-                      "label": "Some Mocked Data Adapter Type",
-                      "value": "someType",
-                    },
-                  ]
-                }
-                placeholder="Select Data Adapter Type"
-                value={null}
-              />
-            </span>
-          </span>
-        </span>
+          <select-mock
+            clearable={false}
+            matchProp="value"
+            onChange={[Function]}
+            options={
+              Array [
+                Object {
+                  "label": "Some Mocked Data Adapter Type",
+                  "value": "someType",
+                },
+              ]
+            }
+            placeholder="Select Data Adapter Type"
+            value={null}
+          />
+        </input-mock>
       </form>
     </div>
   </div>
@@ -63,32 +55,24 @@ exports[`<DataAdapterCreate /> should render with empty parameters 1`] = `
         className="form form-horizontal"
         onSubmit={[Function]}
       >
-        <span
-          className="InputMock"
+        <input-mock
+          autoFocus={true}
+          help="The type of data adapter to configure."
+          id="data-adapter-type-select"
+          label="Data Adapter Type"
+          labelClassName="col-sm-3"
+          required={true}
+          wrapperClassName="col-sm-9"
         >
-          <span
-            autoFocus={true}
-            help="The type of data adapter to configure."
-            id="data-adapter-type-select"
-            label="Data Adapter Type"
-            labelClassName="col-sm-3"
-            required={true}
-            wrapperClassName="col-sm-9"
-          >
-            <span
-              className="SelectMock"
-            >
-              <span
-                clearable={false}
-                matchProp="value"
-                onChange={[Function]}
-                options={Array []}
-                placeholder="Select Data Adapter Type"
-                value={null}
-              />
-            </span>
-          </span>
-        </span>
+          <select-mock
+            clearable={false}
+            matchProp="value"
+            onChange={[Function]}
+            options={Array []}
+            placeholder="Select Data Adapter Type"
+            value={null}
+          />
+        </input-mock>
       </form>
     </div>
   </div>
@@ -107,40 +91,32 @@ exports[`<DataAdapterCreate /> with mocked console.error should render for types
         className="form form-horizontal"
         onSubmit={[Function]}
       >
-        <span
-          className="InputMock"
+        <input-mock
+          autoFocus={true}
+          help="The type of data adapter to configure."
+          id="data-adapter-type-select"
+          label="Data Adapter Type"
+          labelClassName="col-sm-3"
+          required={true}
+          wrapperClassName="col-sm-9"
         >
-          <span
-            autoFocus={true}
-            help="The type of data adapter to configure."
-            id="data-adapter-type-select"
-            label="Data Adapter Type"
-            labelClassName="col-sm-3"
-            required={true}
-            wrapperClassName="col-sm-9"
-          >
-            <span
-              className="SelectMock"
-            >
-              <span
-                clearable={false}
-                matchProp="value"
-                onChange={[Function]}
-                options={
-                  Array [
-                    Object {
-                      "disabled": true,
-                      "label": "unknownType - missing or invalid plugin",
-                      "value": "unknownType",
-                    },
-                  ]
-                }
-                placeholder="Select Data Adapter Type"
-                value={null}
-              />
-            </span>
-          </span>
-        </span>
+          <select-mock
+            clearable={false}
+            matchProp="value"
+            onChange={[Function]}
+            options={
+              Array [
+                Object {
+                  "disabled": true,
+                  "label": "unknownType - missing or invalid plugin",
+                  "value": "unknownType",
+                },
+              ]
+            }
+            placeholder="Select Data Adapter Type"
+            value={null}
+          />
+        </input-mock>
       </form>
     </div>
   </div>

--- a/graylog2-web-interface/test/helpers/mocking/MockComponent.jsx
+++ b/graylog2-web-interface/test/helpers/mocking/MockComponent.jsx
@@ -1,14 +1,12 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import { kebabCase } from 'lodash';
 
 export default (name) => {
-  const MockComponent = props => (
-    <span className={name}>
-      <span {...props}>{props.children}</span>
-    </span>
-  );
+  const MockComponent = ({ children, ...rest }) => React.createElement(kebabCase(name), rest, children);
+
   MockComponent.propTypes = {
-    children: PropTypes.element,
+    children: PropTypes.node,
   };
   MockComponent.defaultProps = {
     children: null,


### PR DESCRIPTION
This change is improving the `MockComponent` function which generates a
mock component usable in tests when rendering a subtree is not desired.

Before this change, `MockComponent` generated a component which renders
a series of `span` elements which were carrying the passed `props` to
it, so they show up in a snapshot. Unfortunately this fails when React
warnings fail tests, because those props were not accepted on `span`
elements.

After this change, `MockComponent` returns a component rendering a
custom element, which is named after the string parameter passed to it,
e.g. `MockComponent('FooMock')` returns a component rendering

```
<foo-mock {...props}>
  {children>
</foo-mock>
```

which serves the purpose of creating a minimal element which carries all
props and children passed to it, so they show up in a snapshot, in
contrast to a common pattern of using `() => 'foo-mock'` instead.
