### PR TITLE
Handle 404s in sidecar

### DIFF
--- a/graylog2-server/src/main/java/org/graylog/plugins/sidecar/rest/resources/CollectorResource.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/sidecar/rest/resources/CollectorResource.java
@@ -98,7 +98,13 @@ public class CollectorResource extends RestResource implements PluginRestResourc
     @ApiOperation(value = "Show collector details")
     public Collector getCollector(@ApiParam(name = "id", required = true)
                                   @PathParam("id") String id) {
-        return this.collectorService.find(id);
+
+        final Collector collector = this.collectorService.find(id);
+        if (collector == null) {
+            throw new NotFoundException("Cound not find collector <" + id + ">.");
+        }
+
+        return collector;
     }
 
     @GET

--- a/graylog2-server/src/main/java/org/graylog/plugins/sidecar/rest/resources/ConfigurationResource.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/sidecar/rest/resources/ConfigurationResource.java
@@ -131,7 +131,11 @@ public class ConfigurationResource extends RestResource implements PluginRestRes
     @ApiOperation(value = "Show configuration details")
     public Configuration getConfigurations(@ApiParam(name = "id", required = true)
                                            @PathParam("id") String id) {
-        return this.configurationService.find(id);
+        final Configuration configuration = this.configurationService.find(id);
+        if (configuration == null) {
+            throw new NotFoundException("Could not find Configuration <" + id + ">.");
+        }
+        return configuration;
     }
 
     @GET
@@ -141,7 +145,10 @@ public class ConfigurationResource extends RestResource implements PluginRestRes
     @ApiOperation(value = "Show sidecars using the given configuration")
     public ConfigurationSidecarsResponse getConfigurationSidecars(@ApiParam(name = "id", required = true)
                                                                       @PathParam("id") String id) {
-        final Configuration configuration = configurationService.find(id);
+        final Configuration configuration = this.configurationService.find(id);
+        if (configuration == null) {
+            throw new NotFoundException("Could not find Configuration <" + id + ">.");
+        }
         final List<String> sidecarsWithConfiguration = sidecarService.all().stream()
                 .filter(sidecar -> isConfigurationAssignedToSidecar(configuration.id(), sidecar))
                 .map(Sidecar::id)
@@ -268,6 +275,10 @@ public class ConfigurationResource extends RestResource implements PluginRestRes
                                              @ApiParam(name = "JSON body", required = true)
                                              @Valid @NotNull Configuration request) {
         final Configuration previousConfiguration = configurationService.find(id);
+        if (previousConfiguration == null) {
+            throw new NotFoundException("Could not find Configuration <" + id + ">.");
+        }
+
         // Only allow changing the associated collector ID if the configuration is not in use
         if (!previousConfiguration.collectorId().equals(request.collectorId())) {
             if (isConfigurationInUse(id)) {

--- a/graylog2-server/src/main/java/org/graylog/plugins/sidecar/rest/resources/SidecarResource.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/sidecar/rest/resources/SidecarResource.java
@@ -176,11 +176,10 @@ public class SidecarResource extends RestResource implements PluginRestResource 
     public SidecarSummary get(@ApiParam(name = "sidecarId", required = true)
                               @PathParam("sidecarId") @NotEmpty String sidecarId) {
         final Sidecar sidecar = sidecarService.findByNodeId(sidecarId);
-        if (sidecar != null) {
-            return sidecar.toSummary(activeSidecarFilter);
-        } else {
-            throw new NotFoundException("Sidecar <" + sidecarId + "> not found!");
+        if (sidecar == null) {
+            throw new NotFoundException("Could not find sidecar <" + sidecarId + ">");
         }
+        return sidecar.toSummary(activeSidecarFilter);
     }
 
     @PUT

--- a/graylog2-web-interface/src/components/sidecars/configuration-forms/SourceViewModal.jsx
+++ b/graylog2-web-interface/src/components/sidecars/configuration-forms/SourceViewModal.jsx
@@ -71,7 +71,7 @@ class SourceViewModal extends React.Component {
             this.setState({ source: configuration.template, name: configuration.name });
           },
           (error) => {
-            this.setState({ source: `Error fetching configuration: ${error}` });
+            this.setState({ source: `Error fetching configuration: ${error.responseMessage || error}` });
           },
         );
     }

--- a/graylog2-web-interface/src/pages/SidecarEditCollectorPage.jsx
+++ b/graylog2-web-interface/src/pages/SidecarEditCollectorPage.jsx
@@ -6,6 +6,7 @@ import { LinkContainer } from 'react-router-bootstrap';
 
 import { DocumentTitle, PageHeader, Spinner } from 'components/common';
 import Routes from 'routing/Routes';
+import history from 'util/History';
 import CombinedProvider from 'injection/CombinedProvider';
 
 import CollectorForm from 'components/sidecars/configuration-forms/CollectorForm';
@@ -30,11 +31,14 @@ const SidecarEditCollectorPage = createReactClass({
   },
 
   _reloadCollector() {
-    CollectorsActions.getCollector(this.props.params.collectorId).then(this._setCollector);
-  },
-
-  _setCollector(collector) {
-    this.setState({ collector });
+    CollectorsActions.getCollector(this.props.params.collectorId).then(
+      collector => this.setState({ collector }),
+      (error) => {
+        if (error.status === 404) {
+          history.push(Routes.SYSTEM.SIDECARS.CONFIGURATION);
+        }
+      },
+    );
   },
 
   _isLoading() {

--- a/graylog2-web-interface/src/pages/SidecarEditConfigurationPage.jsx
+++ b/graylog2-web-interface/src/pages/SidecarEditConfigurationPage.jsx
@@ -10,6 +10,7 @@ import CombinedProvider from 'injection/CombinedProvider';
 
 import ConfigurationForm from 'components/sidecars/configuration-forms/ConfigurationForm';
 import ConfigurationHelper from 'components/sidecars/configuration-forms/ConfigurationHelper';
+import history from 'util/History';
 
 const { CollectorConfigurationsActions } = CombinedProvider.get('CollectorConfigurations');
 
@@ -32,20 +33,23 @@ const SidecarEditConfigurationPage = createReactClass({
 
   _reloadConfiguration() {
     const configurationId = this.props.params.configurationId;
-    CollectorConfigurationsActions.getConfiguration(configurationId).then(this._setConfiguration);
-    CollectorConfigurationsActions.getConfigurationSidecars(configurationId).then(this._setConfigurationSidecars);
-  },
 
-  _setConfiguration(configuration) {
-    this.setState({ configuration });
-  },
-
-  _setConfigurationSidecars(configurationSidecars) {
-    this.setState({ configurationSidecars });
+    CollectorConfigurationsActions.getConfiguration(configurationId).then(
+      (configuration) => {
+        this.setState({ configuration: configuration });
+        CollectorConfigurationsActions.getConfigurationSidecars(configurationId)
+          .then(configurationSidecars => this.setState({ configurationSidecars: configurationSidecars }));
+      },
+      (error) => {
+        if (error.status === 404) {
+          history.push(Routes.SYSTEM.SIDECARS.CONFIGURATION);
+        }
+      },
+    );
   },
 
   _isLoading() {
-    return !(this.state.configuration);
+    return !this.state.configuration || !this.state.configurationSidecars;
   },
 
   render() {

--- a/graylog2-web-interface/src/pages/SidecarStatusPage.jsx
+++ b/graylog2-web-interface/src/pages/SidecarStatusPage.jsx
@@ -10,6 +10,7 @@ import DocumentationLink from 'components/support/DocumentationLink';
 
 import CombinedProvider from 'injection/CombinedProvider';
 import Routes from 'routing/Routes';
+import history from 'util/History';
 import SidecarStatus from 'components/sidecars/sidecars/SidecarStatus';
 
 const { SidecarsActions } = CombinedProvider.get('Sidecars');
@@ -37,7 +38,14 @@ class SidecarStatusPage extends React.Component {
   }
 
   reloadSidecar = () => {
-    SidecarsActions.getSidecar(this.props.params.sidecarId).then(sidecar => this.setState({ sidecar }));
+    SidecarsActions.getSidecar(this.props.params.sidecarId).then(
+      sidecar => this.setState({ sidecar }),
+      (error) => {
+        if (error.status === 404) {
+          history.push(Routes.SYSTEM.SIDECARS.OVERVIEW);
+        }
+      },
+    );
   };
 
   reloadCollectors = () => {

--- a/graylog2-web-interface/src/stores/sidecars/CollectorConfigurationsStore.js
+++ b/graylog2-web-interface/src/stores/sidecars/CollectorConfigurationsStore.js
@@ -93,23 +93,25 @@ const CollectorConfigurationsStore = Reflux.createStore({
 
   getConfiguration(configurationId) {
     const promise = fetch('GET', URLUtils.qualifyUrl(`${this.sourceUrl}/configurations/${configurationId}`));
-    promise
-      .catch(
-        (error) => {
-          UserNotification.error(`Fetching collector configuration failed with status: ${error}`,
-            'Could not retrieve configuration');
-        });
+    promise.catch((error) => {
+      let errorMessage = `Fetching Configuration failed with status: ${error}`;
+      if (error.status === 404) {
+        errorMessage = `Unable to find a Configuration with ID <${configurationId}>, please ensure it was not deleted.`;
+      }
+      UserNotification.error(errorMessage, 'Could not retrieve Configuration');
+    });
     CollectorConfigurationsActions.getConfiguration.promise(promise);
   },
 
   getConfigurationSidecars(configurationId) {
     const promise = fetch('GET', URLUtils.qualifyUrl(`${this.sourceUrl}/configurations/${configurationId}/sidecars`));
-    promise
-      .catch(
-        (error) => {
-          UserNotification.error(`Fetching Sidecars for Configuration failed with status: ${error}`,
-            'Could not retrieve Sidecars for Configuration');
-        });
+    promise.catch((error) => {
+      let errorMessage = `Fetching Configuration failed with status: ${error}`;
+      if (error.status === 404) {
+        errorMessage = `Unable to find a Configuration with ID <${configurationId}>, please ensure it was not deleted.`;
+      }
+      UserNotification.error(errorMessage, 'Could not retrieve Configuration');
+    });
     CollectorConfigurationsActions.getConfigurationSidecars.promise(promise);
   },
 

--- a/graylog2-web-interface/src/stores/sidecars/CollectorsStore.js
+++ b/graylog2-web-interface/src/stores/sidecars/CollectorsStore.js
@@ -5,8 +5,6 @@ import URLUtils from 'util/URLUtils';
 import fetch from 'logic/rest/FetchProvider';
 import UserNotification from 'util/UserNotification';
 import CombinedProvider from 'injection/CombinedProvider';
-import history from '../../util/History';
-import Routes from '../../routing/Routes';
 
 const { CollectorsActions } = CombinedProvider.get('Collectors');
 

--- a/graylog2-web-interface/src/stores/sidecars/CollectorsStore.js
+++ b/graylog2-web-interface/src/stores/sidecars/CollectorsStore.js
@@ -5,6 +5,8 @@ import URLUtils from 'util/URLUtils';
 import fetch from 'logic/rest/FetchProvider';
 import UserNotification from 'util/UserNotification';
 import CombinedProvider from 'injection/CombinedProvider';
+import history from '../../util/History';
+import Routes from '../../routing/Routes';
 
 const { CollectorsActions } = CombinedProvider.get('Collectors');
 
@@ -39,12 +41,13 @@ const CollectorsStore = Reflux.createStore({
 
   getCollector(collectorId) {
     const promise = fetch('GET', URLUtils.qualifyUrl(`${this.sourceUrl}/collectors/${collectorId}`));
-    promise
-      .catch(
-        (error) => {
-          UserNotification.error(`Fetching collector failed with status: ${error}`,
-            'Could not retrieve collector');
-        });
+    promise.catch((error) => {
+      let errorMessage = `Fetching Collector failed with status: ${error}`;
+      if (error.status === 404) {
+        errorMessage = `Unable to find a collector with ID <${collectorId}>, please ensure it was not deleted.`;
+      }
+      UserNotification.error(errorMessage, 'Could not retrieve Collector');
+    });
     CollectorsActions.getCollector.promise(promise);
   },
 

--- a/graylog2-web-interface/src/stores/sidecars/SidecarsStore.js
+++ b/graylog2-web-interface/src/stores/sidecars/SidecarsStore.js
@@ -80,12 +80,13 @@ const SidecarsStore = Reflux.createStore({
 
   getSidecar(sidecarId) {
     const promise = fetchPeriodically('GET', URLUtils.qualifyUrl(`${this.sourceUrl}/${sidecarId}`));
-    promise
-      .catch(
-        (error) => {
-          UserNotification.error(`Fetching Sidecar failed with status: ${error}`,
-            'Could not retrieve Sidecar');
-        });
+    promise.catch((error) => {
+      let errorMessage = `Fetching Sidecar failed with status: ${error}`;
+      if (error.status === 404) {
+        errorMessage = `Unable to find a sidecar with ID <${sidecarId}>, maybe it was inactive for too long.`;
+      }
+      UserNotification.error(errorMessage, 'Could not retrieve Sidecar');
+    });
     SidecarsActions.getSidecar.promise(promise);
   },
 


### PR DESCRIPTION
These changes ensure we handle 404s when getting a sidecar, collector or configuration in a consistent way. Users will see an error informing that the entity is not there, and they will be also redirected when accessing an edit page for one of those entities.