### PR TITLE
Catch Netty exceptions and avoid logging stacktraces

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/inputs/transports/netty/ExceptionLoggingChannelHandler.java
+++ b/graylog2-server/src/main/java/org/graylog2/inputs/transports/netty/ExceptionLoggingChannelHandler.java
@@ -39,13 +39,13 @@ public class ExceptionLoggingChannelHandler extends ChannelInboundHandlerAdapter
                     input.getId(),
                     ctx.channel());
         } else {
-            logger.error("Error in Input [{}/{}] (channel {})",
+            logger.error("Error in Input [{}/{}] (channel {}) (cause {})",
                     input.getName(),
                     input.getId(),
                     ctx.channel(),
                     cause);
         }
 
-        super.exceptionCaught(ctx, cause);
+        ctx.close();
     }
 }

--- a/graylog2-server/src/main/java/org/graylog2/plugin/inputs/transports/AbstractTcpTransport.java
+++ b/graylog2-server/src/main/java/org/graylog2/plugin/inputs/transports/AbstractTcpTransport.java
@@ -236,6 +236,7 @@ public abstract class AbstractTcpTransport extends NettyTransport {
             handlers.put("tls", getSslHandlerCallable(input));
         }
         handlers.putAll(super.getChildChannelHandlers(input));
+        handlers.put("exception-logger", () -> new ExceptionLoggingChannelHandler(input, LOG));
 
         return handlers;
     }


### PR DESCRIPTION
To handle exceptions that happen in the server context,
we need to register our ExceptionLoggingChannelHandler as a childHandler.

In addition, make sure that the ExceptionLoggingChannelHandler is
always added to the top of the (bottom-up evaluated) pipeline.
Otherwise it might miss some exceptions.

Do not propagate the exception any further.
A full netty stacktrace does not help anyone.
One meaningful log message should be enough.
This last bit of the change fixes #5109
