### PR TITLE
Return helpful error message when CSRF protection fails.

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/shared/initializers/JerseyService.java
+++ b/graylog2-server/src/main/java/org/graylog2/shared/initializers/JerseyService.java
@@ -34,7 +34,6 @@ import org.glassfish.grizzly.ssl.SSLEngineConfigurator;
 import org.glassfish.jersey.grizzly2.httpserver.GrizzlyHttpServerFactory;
 import org.glassfish.jersey.server.ResourceConfig;
 import org.glassfish.jersey.server.ServerProperties;
-import org.glassfish.jersey.server.filter.CsrfProtectionFilter;
 import org.glassfish.jersey.server.model.Resource;
 import org.graylog2.audit.PluginAuditEventTypes;
 import org.graylog2.audit.jersey.AuditEventModelProcessor;
@@ -48,6 +47,7 @@ import org.graylog2.shared.rest.NodeIdResponseFilter;
 import org.graylog2.shared.rest.NotAuthorizedResponseFilter;
 import org.graylog2.shared.rest.PrintModelProcessor;
 import org.graylog2.shared.rest.RestAccessLogFilter;
+import org.graylog2.shared.rest.VerboseCsrfProtectionFilter;
 import org.graylog2.shared.rest.XHRFilter;
 import org.graylog2.shared.rest.exceptionmappers.AnyExceptionClassMapper;
 import org.graylog2.shared.rest.exceptionmappers.BadRequestExceptionMapper;
@@ -240,7 +240,7 @@ public class JerseyService extends AbstractIdleService {
                 .register(new PrefixAddingModelProcessor(packagePrefixes))
                 .register(new AuditEventModelProcessor(pluginAuditEventTypes))
                 .registerClasses(
-                        CsrfProtectionFilter.class,
+                        VerboseCsrfProtectionFilter.class,
                         JacksonJaxbJsonProvider.class,
                         JsonProcessingExceptionMapper.class,
                         JacksonPropertyExceptionMapper.class,

--- a/graylog2-server/src/main/java/org/graylog2/shared/rest/VerboseCsrfProtectionFilter.java
+++ b/graylog2-server/src/main/java/org/graylog2/shared/rest/VerboseCsrfProtectionFilter.java
@@ -28,7 +28,10 @@ public class VerboseCsrfProtectionFilter extends CsrfProtectionFilter {
         try {
             super.filter(rc);
         } catch (BadRequestException badRequestException) {
-            throw new BadRequestException("CSRF protection header is missing.", badRequestException);
+            throw new BadRequestException(
+                    "CSRF protection header is missing. Please add a \"" + HEADER_NAME + "\" header to your request.",
+                    badRequestException
+            );
         }
     }
 }

--- a/graylog2-server/src/main/java/org/graylog2/shared/rest/VerboseCsrfProtectionFilter.java
+++ b/graylog2-server/src/main/java/org/graylog2/shared/rest/VerboseCsrfProtectionFilter.java
@@ -1,0 +1,34 @@
+/**
+ * This file is part of Graylog.
+ *
+ * Graylog is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.graylog2.shared.rest;
+
+import org.glassfish.jersey.server.filter.CsrfProtectionFilter;
+
+import javax.ws.rs.BadRequestException;
+import javax.ws.rs.container.ContainerRequestContext;
+import java.io.IOException;
+
+public class VerboseCsrfProtectionFilter extends CsrfProtectionFilter {
+    @Override
+    public void filter(ContainerRequestContext rc) throws IOException {
+        try {
+            super.filter(rc);
+        } catch (BadRequestException badRequestException) {
+            throw new BadRequestException("CSRF protection header is missing.", badRequestException);
+        }
+    }
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Before this change, the server returned a generic "Bad Request" error
message when a client queried the API without the required CSRF
protection header. This leaves the consumer confused, especially for
previous users of the API which now do not know what to change in their
request to make it work again.

This change now leaves the error code intact but adds a helpful message
telling the consumer what went wrong.

Fixes #5012.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
