### PR TITLE
Adapting plugin archetype to recent changes.

### DIFF
--- a/graylog-plugin-archetype/src/main/resources/archetype-resources/package.json
+++ b/graylog-plugin-archetype/src/main/resources/archetype-resources/package.json
@@ -7,9 +7,9 @@
     "url": "${githubRepo}"
   },
   "scripts": {
-    "start": "./node_modules/.bin/webpack-dev-server",
-    "build": "./node_modules/.bin/webpack",
-    "lint": "./node_modules/.bin/eslint -c .eslintrc src/**/*"
+    "build": "webpack",
+    "lint": "eslint -c .eslintrc src/**/*",
+    "test": "jest"
   },
   "keywords": [
     "graylog"
@@ -19,7 +19,6 @@
   "dependencies": {
   },
   "devDependencies": {
-    "webpack": "^1.12.2",
     "graylog-web-plugin": "file:${serverCheckoutPath}/graylog2-web-interface/packages/graylog-web-plugin"
   }
 }

--- a/graylog-plugin-archetype/src/main/resources/archetype-resources/pom.xml
+++ b/graylog-plugin-archetype/src/main/resources/archetype-resources/pom.xml
@@ -3,6 +3,14 @@
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.graylog.plugins</groupId>
+        <artifactId>graylog-plugin-web-parent</artifactId>
+        <version>3.0.0-alpha.3-SNAPSHOT</version>
+        <relativePath>${serverCheckoutPath}/graylog-plugin-parent/graylog-plugin-web-parent</relativePath>
+    </parent>
+
     <groupId>${groupId}</groupId>
     <artifactId>${artifactId}</artifactId>
     <version>${version}</version>
@@ -34,7 +42,7 @@
         <!-- Plugins will not be deployed by default - set to `false` if you actually want to deploy it -->
         <maven.deploy.skip>true</maven.deploy.skip>
 
-        <graylog.version>2.1.1</graylog.version>
+        <graylog.version>${project.parent.version}</graylog.version>
         <graylog.plugin-dir>/usr/share/graylog-server/plugin</graylog.plugin-dir>
     </properties>
 
@@ -219,7 +227,6 @@
                     <plugin>
                         <groupId>com.github.eirslett</groupId>
                         <artifactId>frontend-maven-plugin</artifactId>
-                        <version>1.3</version>
 
                         <executions>
                             <execution>
@@ -228,8 +235,8 @@
                                     <goal>install-node-and-yarn</goal>
                                 </goals>
                                 <configuration>
-                                    <nodeVersion>v8.9.1</nodeVersion>
-                                    <yarn.version>v1.3.2</yarn.version>
+                                    <nodeVersion>${nodejs.version}</nodeVersion>
+                                    <yarn.version>${yarn.version}</yarn.version>
                                 </configuration>
                             </execution>
 

--- a/graylog-plugin-parent/pom.xml
+++ b/graylog-plugin-parent/pom.xml
@@ -66,6 +66,12 @@
             <artifactId>graylog2-server</artifactId>
             <scope>provided</scope>
         </dependency>
+        <dependency>
+            <groupId>com.google.auto.value</groupId>
+            <artifactId>auto-value</artifactId>
+            <version>${auto-value.version}</version>
+            <scope>provided</scope>
+        </dependency>
     </dependencies>
 
     <build>


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

  * Removing unneeded prefixes from tasks in `package.json` of generated plugin
  * Using project parent in generated POM, so explicit versions can be removed
  * Removing explicit, ancient webpack dependency from generated `package.json`
  * Adding `AutoValue` dependency due  to configured annotation processor

With these changes it should be easier to keep a plugin POM in line with the changes we make in core, as the POM will take over versions and certain configurations from the `graylog-plugin-web-parent` module which is managed in core and used by our plugins as well.

To test the changes, please follow the [introductions](
https://github.com/Graylog2/graylog2-server/tree/master/graylog-plugin-archetype#development) on how to use a locally installed archetype.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
