### PR TITLE
UI improvements for configuring and starting collectors

### DIFF
--- a/graylog2-web-interface/src/components/bootstrap/BootstrapModalConfirm.jsx
+++ b/graylog2-web-interface/src/components/bootstrap/BootstrapModalConfirm.jsx
@@ -18,6 +18,10 @@ class BootstrapModalConfirm extends React.Component {
     cancelButtonText: PropTypes.string,
     /** Text to use in the confirmation button. */
     confirmButtonText: PropTypes.string,
+    /** Indicates whether the cancel button should be disabled or not. */
+    cancelButtonDisabled: PropTypes.bool,
+    /** Indicates whether the confirm button should be disabled or not. */
+    confirmButtonDisabled: PropTypes.bool,
     /** Function to call when the modal is opened. The function does not receive any arguments. */
     onModalOpen: PropTypes.func,
     /** Function to call when the modal is closed. The function does not receive any arguments. */
@@ -43,6 +47,8 @@ class BootstrapModalConfirm extends React.Component {
     showModal: false,
     cancelButtonText: 'Cancel',
     confirmButtonText: 'Confirm',
+    cancelButtonDisabled: false,
+    confirmButtonDisabled: false,
     onModalOpen: () => {},
     onModalClose: () => {},
     onCancel: () => {},
@@ -80,8 +86,8 @@ class BootstrapModalConfirm extends React.Component {
           {this.props.children}
         </Modal.Body>
         <Modal.Footer>
-          <Button type="button" onClick={this.onCancel}>{this.props.cancelButtonText}</Button>
-          <Button type="button" onClick={this.onConfirm} bsStyle="primary">{this.props.confirmButtonText}</Button>
+          <Button type="button" onClick={this.onCancel} disabled={this.props.cancelButtonDisabled}>{this.props.cancelButtonText}</Button>
+          <Button type="button" onClick={this.onConfirm} bsStyle="primary" disabled={this.props.confirmButtonDisabled}>{this.props.confirmButtonText}</Button>
         </Modal.Footer>
       </BootstrapModalWrapper>
     );

--- a/graylog2-web-interface/src/components/sidecars/administration/CollectorProcessControl.jsx
+++ b/graylog2-web-interface/src/components/sidecars/administration/CollectorProcessControl.jsx
@@ -43,13 +43,13 @@ const CollectorProcessControl = createReactClass({
   },
 
   renderProcessActionSummary(selectedSidecarCollectorPairs, selectedAction) {
+    const selectedSidecars = lodash.uniq(selectedSidecarCollectorPairs.map(({ sidecar }) => sidecar.node_name));
     const actionSummary = (
       <span>
         You are going to <strong>{selectedAction}</strong> log collectors in&nbsp;
-        <Pluralize singular="this sidecar" plural="these sidecars" value={selectedSidecarCollectorPairs.length} />:
+        <Pluralize singular="this sidecar" plural="these sidecars" value={selectedSidecars.length} />:
       </span>
     );
-    const formattedSummary = lodash.uniq(selectedSidecarCollectorPairs.map(({ sidecar }) => sidecar.node_name)).join(', ');
 
     return (
       <BootstrapModalConfirm ref={(c) => { this.modal = c; }}
@@ -58,7 +58,7 @@ const CollectorProcessControl = createReactClass({
                              onCancel={this.cancelProcessAction}>
         <div>
           <p>{actionSummary}</p>
-          <p>{formattedSummary}</p>
+          <p>{selectedSidecars.join(', ')}</p>
           <p>Are you sure you want to proceed with this action?</p>
         </div>
       </BootstrapModalConfirm>

--- a/graylog2-web-interface/src/components/sidecars/administration/CollectorProcessControl.jsx
+++ b/graylog2-web-interface/src/components/sidecars/administration/CollectorProcessControl.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import createReactClass from 'create-react-class';
 import PropTypes from 'prop-types';
 import lodash from 'lodash';
-import { Button } from 'react-bootstrap';
+import { Button, Panel } from 'react-bootstrap';
 
 import { Pluralize, SelectPopover } from 'components/common';
 import { BootstrapModalConfirm } from 'components/bootstrap';
@@ -18,6 +18,7 @@ const CollectorProcessControl = createReactClass({
   getInitialState() {
     return {
       selectedAction: undefined,
+      isConfigurationWarningHidden: false,
     };
   },
 
@@ -42,24 +43,62 @@ const CollectorProcessControl = createReactClass({
     this.resetSelectedAction();
   },
 
-  renderProcessActionSummary(selectedSidecarCollectorPairs, selectedAction) {
-    const selectedSidecars = lodash.uniq(selectedSidecarCollectorPairs.map(({ sidecar }) => sidecar.node_name));
-    const actionSummary = (
-      <span>
-        You are going to <strong>{selectedAction}</strong> log collectors in&nbsp;
-        <Pluralize singular="this sidecar" plural="these sidecars" value={selectedSidecars.length} />:
-      </span>
+  hideConfigurationWarning() {
+    this.setState({ isConfigurationWarningHidden: true });
+  },
+
+
+  renderSummaryContent(selectedAction, selectedSidecars) {
+    return (
+      <React.Fragment>
+        <p>
+          You are going to <strong>{selectedAction}</strong> log collectors in&nbsp;
+          <Pluralize singular="this sidecar" plural="these sidecars" value={selectedSidecars.length} />:
+        </p>
+        <p>{selectedSidecars.join(', ')}</p>
+        <p>Are you sure you want to proceed with this action?</p>
+      </React.Fragment>
     );
+  },
+
+  renderConfigurationWarning(selectedAction) {
+    return (
+      <Panel bsStyle="info" header="Collectors without Configuration">
+        <p>
+          At least one selected Collector is not configured yet. To start a new Collector, assign a
+          Configuration to it and the Sidecar will start the process for you.
+        </p>
+        <p>
+          {lodash.capitalize(selectedAction)}ing a Collector without Configuration will have no effect.
+        </p>
+        <Button bsSize="xsmall" bsStyle="primary" onClick={this.hideConfigurationWarning}>Understood, continue
+          anyway</Button>
+      </Panel>
+    );
+  },
+
+  renderProcessActionSummary(selectedSidecarCollectorPairs, selectedAction) {
+    const { isConfigurationWarningHidden } = this.state;
+    const selectedSidecars = lodash.uniq(selectedSidecarCollectorPairs.map(({ sidecar }) => sidecar.node_name));
+
+    // Check if all selected collectors have assigned configurations
+    const allHaveConfigurationsAssigned = selectedSidecarCollectorPairs.every(({ collector, sidecar }) => {
+      // eslint-disable-next-line camelcase
+      return sidecar.assignments.some(({ collector_id }) => collector_id === collector.id);
+    });
+
+    const shouldShowConfigurationWarning = !isConfigurationWarningHidden && !allHaveConfigurationsAssigned;
 
     return (
       <BootstrapModalConfirm ref={(c) => { this.modal = c; }}
                              title="Process action summary"
+                             confirmButtonDisabled={shouldShowConfigurationWarning}
                              onConfirm={this.confirmProcessAction}
                              onCancel={this.cancelProcessAction}>
         <div>
-          <p>{actionSummary}</p>
-          <p>{selectedSidecars.join(', ')}</p>
-          <p>Are you sure you want to proceed with this action?</p>
+          {shouldShowConfigurationWarning ?
+            this.renderConfigurationWarning(selectedAction) :
+            this.renderSummaryContent(selectedAction, selectedSidecars)}
         </div>
       </BootstrapModalConfirm>
     );

--- a/graylog2-web-interface/src/components/sidecars/administration/CollectorsAdministrationActions.jsx
+++ b/graylog2-web-interface/src/components/sidecars/administration/CollectorsAdministrationActions.jsx
@@ -19,11 +19,11 @@ const CollectorsAdministrationActions = createReactClass({
     const { collectors, configurations, selectedSidecarCollectorPairs, onConfigurationSelectionChange, onProcessAction } = this.props;
     return (
       <ButtonToolbar>
-        <CollectorProcessControl selectedSidecarCollectorPairs={selectedSidecarCollectorPairs} onProcessAction={onProcessAction} />
         <CollectorConfigurationSelector collectors={collectors}
                                         configurations={configurations}
                                         selectedSidecarCollectorPairs={selectedSidecarCollectorPairs}
                                         onConfigurationSelectionChange={onConfigurationSelectionChange} />
+        <CollectorProcessControl selectedSidecarCollectorPairs={selectedSidecarCollectorPairs} onProcessAction={onProcessAction} />
       </ButtonToolbar>
     );
   },

--- a/graylog2-web-interface/src/components/sidecars/administration/CollectorsAdministrationFilters.jsx
+++ b/graylog2-web-interface/src/components/sidecars/administration/CollectorsAdministrationFilters.jsx
@@ -140,8 +140,8 @@ const CollectorsAdministrationFilters = createReactClass({
       <ButtonToolbar>
         {this.getCollectorsFilter()}
         {this.getConfigurationFilter()}
-        {this.getOSFilter()}
         {this.getStatusFilter()}
+        {this.getOSFilter()}
       </ButtonToolbar>
     );
   },

--- a/graylog2-web-interface/src/components/sidecars/common/StatusIndicator.css
+++ b/graylog2-web-interface/src/components/sidecars/common/StatusIndicator.css
@@ -1,0 +1,3 @@
+:local(.indicator) {
+    white-space: nowrap;
+}

--- a/graylog2-web-interface/src/components/sidecars/common/StatusIndicator.jsx
+++ b/graylog2-web-interface/src/components/sidecars/common/StatusIndicator.jsx
@@ -6,6 +6,8 @@ import lodash from 'lodash';
 import SidecarStatusEnum from 'logic/sidecar/SidecarStatusEnum';
 import DateTime from 'logic/datetimes/DateTime';
 
+import style from './StatusIndicator.css';
+
 class StatusIndicator extends React.Component {
   static propTypes = {
     id: PropTypes.string,
@@ -52,12 +54,12 @@ class StatusIndicator extends React.Component {
       const tooltip = <Tooltip id={`${this.props.id}-status-tooltip`}>{message}</Tooltip>;
       return (
         <OverlayTrigger placement="top" overlay={tooltip} rootClose>
-          <span className={`${className}`}><i className={`fa ${icon} fa-fw`} /> {text}</span>
+          <span className={`${className} ${style.indicator}`}><i className={`fa ${icon} fa-fw`} /> {text}</span>
         </OverlayTrigger>
       );
     }
     return (
-      <span className={`${className}`}><i className={`fa ${icon} fa-fw`} /> {text}</span>
+      <span className={`${className} ${style.indicator}`}><i className={`fa ${icon} fa-fw`} /> {text}</span>
     );
   }
 }


### PR DESCRIPTION
These changes try to improve the situation described in #5047 by:

- Swap actions, to show the configuration selector before the process control. This gives more visibility to the most used action (assign configurations)
- Add a warning when trying to manage collector processes, if some selected collectors are not configured yet

Besides that, the PR also contains a couple other minor UI fixes.