### PR TITLE
Return helpful error message when CSRF protection fails. (#5177)

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/shared/initializers/JerseyService.java
+++ b/graylog2-server/src/main/java/org/graylog2/shared/initializers/JerseyService.java
@@ -32,7 +32,6 @@ import org.glassfish.grizzly.ssl.SSLEngineConfigurator;
 import org.glassfish.jersey.grizzly2.httpserver.GrizzlyHttpServerFactory;
 import org.glassfish.jersey.server.ResourceConfig;
 import org.glassfish.jersey.server.ServerProperties;
-import org.glassfish.jersey.server.filter.CsrfProtectionFilter;
 import org.glassfish.jersey.server.model.Resource;
 import org.graylog2.Configuration;
 import org.graylog2.audit.PluginAuditEventTypes;
@@ -45,6 +44,7 @@ import org.graylog2.shared.rest.NodeIdResponseFilter;
 import org.graylog2.shared.rest.NotAuthorizedResponseFilter;
 import org.graylog2.shared.rest.PrintModelProcessor;
 import org.graylog2.shared.rest.RestAccessLogFilter;
+import org.graylog2.shared.rest.VerboseCsrfProtectionFilter;
 import org.graylog2.shared.rest.XHRFilter;
 import org.graylog2.shared.rest.exceptionmappers.AnyExceptionClassMapper;
 import org.graylog2.shared.rest.exceptionmappers.BadRequestExceptionMapper;
@@ -282,7 +282,7 @@ public class JerseyService extends AbstractIdleService {
                 .register(new PrefixAddingModelProcessor(packagePrefixes))
                 .register(new AuditEventModelProcessor(pluginAuditEventTypes))
                 .registerClasses(
-                        CsrfProtectionFilter.class,
+                        VerboseCsrfProtectionFilter.class,
                         JacksonJaxbJsonProvider.class,
                         JsonProcessingExceptionMapper.class,
                         JacksonPropertyExceptionMapper.class,

--- a/graylog2-server/src/main/java/org/graylog2/shared/rest/VerboseCsrfProtectionFilter.java
+++ b/graylog2-server/src/main/java/org/graylog2/shared/rest/VerboseCsrfProtectionFilter.java
@@ -1,0 +1,37 @@
+/**
+ * This file is part of Graylog.
+ *
+ * Graylog is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.graylog2.shared.rest;
+
+import org.glassfish.jersey.server.filter.CsrfProtectionFilter;
+
+import javax.ws.rs.BadRequestException;
+import javax.ws.rs.container.ContainerRequestContext;
+import java.io.IOException;
+
+public class VerboseCsrfProtectionFilter extends CsrfProtectionFilter {
+    @Override
+    public void filter(ContainerRequestContext rc) throws IOException {
+        try {
+            super.filter(rc);
+        } catch (BadRequestException badRequestException) {
+            throw new BadRequestException(
+                    "CSRF protection header is missing. Please add a \"" + HEADER_NAME + "\" header to your request.",
+                    badRequestException
+            );
+        }
+    }
+}


### PR DESCRIPTION
Port of https://github.com/Graylog2/graylog2-server/pull/5177 into 2.5.