### PR TITLE
Add CSRF backward compatibility for older Sidecars

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/shared/rest/VerboseCsrfProtectionFilter.java
+++ b/graylog2-server/src/main/java/org/graylog2/shared/rest/VerboseCsrfProtectionFilter.java
@@ -26,7 +26,10 @@ public class VerboseCsrfProtectionFilter extends CsrfProtectionFilter {
     @Override
     public void filter(ContainerRequestContext rc) throws IOException {
         try {
-            super.filter(rc);
+            // Backward compatibility for Sidecars < 0.1.7
+            if (!rc.getHeaders().containsKey("X-Graylog-Collector-Version")) {
+                super.filter(rc);
+            }
         } catch (BadRequestException badRequestException) {
             throw new BadRequestException(
                     "CSRF protection header is missing. Please add a \"" + HEADER_NAME + "\" header to your request.",


### PR DESCRIPTION
...who don't have the "X-Requested-By" header yet.
Simply accepting "X-Graylog-Collector-Version" serves the same purpose.

Relates to https://github.com/Graylog2/graylog2-server/pull/4987