### PR TITLE
Support navigation dropdowns contributed by plugins.

### DIFF
--- a/graylog2-web-interface/src/components/common/IfPermitted.test.jsx
+++ b/graylog2-web-interface/src/components/common/IfPermitted.test.jsx
@@ -107,6 +107,13 @@ describe('IfPermitted', () => {
         </IfPermitted>
       ));
     });
+    it('user has exact required permission for action with entity id', () => {
+      wrapper = mount((
+        <IfPermitted permissions={['entity:action:id']} currentUser={{ permissions: ['entity:action:id'] }}>
+          {element}
+        </IfPermitted>
+      ));
+    });
     it('user has wildcard permission', () => {
       wrapper = mount((
         <IfPermitted permissions={['something']} currentUser={{ permissions: ['*'] }}>

--- a/graylog2-web-interface/src/components/common/IfPermitted.test.jsx
+++ b/graylog2-web-interface/src/components/common/IfPermitted.test.jsx
@@ -1,5 +1,7 @@
 import React from 'react';
-import { mount } from 'enzyme';
+import { mount, shallow } from 'enzyme';
+import mockComponent from 'helpers/mocking/MockComponent';
+
 import IfPermitted from './IfPermitted';
 
 jest.mock('stores/connect', () => x => x);
@@ -140,5 +142,20 @@ describe('IfPermitted', () => {
         </IfPermitted>
       ));
     });
+  });
+  it('passes props to children', () => {
+    const Foo = mockComponent('Foo');
+    const Bar = mockComponent('Bar');
+    const wrapper = shallow((
+      <IfPermitted permissions={[]} something={42} otherProp={{ foo: 'bar!' }}>
+        <Foo />
+        <Bar />
+      </IfPermitted>
+    ));
+
+    expect(wrapper.find(Foo)).toHaveProp('something', 42);
+    expect(wrapper.find(Foo)).toHaveProp('otherProp', { foo: 'bar!' });
+    expect(wrapper.find(Bar)).toHaveProp('something', 42);
+    expect(wrapper.find(Bar)).toHaveProp('otherProp', { foo: 'bar!' });
   });
 });

--- a/graylog2-web-interface/src/components/common/IfPermitted.test.jsx
+++ b/graylog2-web-interface/src/components/common/IfPermitted.test.jsx
@@ -1,0 +1,144 @@
+import React from 'react';
+import { mount } from 'enzyme';
+import IfPermitted from './IfPermitted';
+
+jest.mock('stores/connect', () => x => x);
+jest.mock('injection/StoreProvider', () => ({ getStore: () => {} }));
+
+describe('IfPermitted', () => {
+  let element;
+  beforeEach(() => {
+    element = <p>Something!</p>;
+  });
+  describe('renders nothing if', () => {
+    let wrapper;
+    afterEach(() => {
+      expect(wrapper.find('IfPermitted')).toBeEmptyRender();
+    });
+    it('no user is present', () => {
+      wrapper = mount((
+        <IfPermitted permissions={['somepermission']}>
+          {element}
+        </IfPermitted>
+      ));
+    });
+    it('user does not have permissions', () => {
+      wrapper = mount((
+        <IfPermitted permissions={['somepermission']} currentUser={{}}>
+          {element}
+        </IfPermitted>
+      ));
+    });
+    it('user has empty permissions', () => {
+      wrapper = mount((
+        <IfPermitted permissions={['somepermission']} currentUser={{ permissions: [] }}>
+          {element}
+        </IfPermitted>
+      ));
+    });
+    it('user has different permissions', () => {
+      wrapper = mount((
+        <IfPermitted permissions={['somepermission']} currentUser={{ permissions: ['someotherpermission'] }}>
+          {element}
+        </IfPermitted>
+      ));
+    });
+    it('user is missing one permission', () => {
+      wrapper = mount((
+        <IfPermitted permissions={['somepermission', 'someotherpermission']} currentUser={{ permissions: ['someotherpermission'] }}>
+          {element}
+        </IfPermitted>
+      ));
+    });
+    it('user is missing permission for specific id', () => {
+      wrapper = mount((
+        <IfPermitted permissions={['entity:action:id']} currentUser={{ permissions: ['entity:action:otherid'] }}>
+          {element}
+        </IfPermitted>
+      ));
+    });
+    it('user has permission for different action', () => {
+      wrapper = mount((
+        <IfPermitted permissions={['entity:action']} currentUser={{ permissions: ['entity:otheraction'] }}>
+          {element}
+        </IfPermitted>
+      ));
+    });
+    it('user has permission for id only', () => {
+      wrapper = mount((
+        <IfPermitted permissions={['entity:action']} currentUser={{ permissions: ['entity:action:id'] }}>
+          {element}
+        </IfPermitted>
+      ));
+    });
+  });
+  describe('renders children if', () => {
+    let wrapper;
+    afterEach(() => {
+      expect(wrapper).toIncludeText('Something!');
+    });
+    it('empty permissions were passed', () => {
+      wrapper = mount((
+        <IfPermitted permissions={[]} currentUser={{ permissions: [] }}>
+          {element}
+        </IfPermitted>
+      ));
+    });
+    it('empty permissions were passed and no user is present', () => {
+      wrapper = mount((
+        <IfPermitted permissions={[]}>
+          {element}
+        </IfPermitted>
+      ));
+    });
+    it('user has exact required permissions', () => {
+      wrapper = mount((
+        <IfPermitted permissions={['something']} currentUser={{ permissions: ['something'] }}>
+          {element}
+        </IfPermitted>
+      ));
+    });
+    it('user has any exact required permission', () => {
+      wrapper = mount((
+        <IfPermitted permissions={['something', 'someother']} currentUser={{ permissions: ['something'] }} anyPermissions>
+          {element}
+        </IfPermitted>
+      ));
+    });
+    it('user has wildcard permission', () => {
+      wrapper = mount((
+        <IfPermitted permissions={['something']} currentUser={{ permissions: ['*'] }}>
+          {element}
+        </IfPermitted>
+      ));
+    });
+    it('user has wildcard permission for action', () => {
+      wrapper = mount((
+        <IfPermitted permissions={['entity:action:id']} currentUser={{ permissions: ['entity:action'] }}>
+          {element}
+        </IfPermitted>
+      ));
+    });
+    it('user has wildcard permission for id', () => {
+      wrapper = mount((
+        <IfPermitted permissions={['entity:action:id']} currentUser={{ permissions: ['entity:action:*'] }}>
+          {element}
+        </IfPermitted>
+      ));
+    });
+    it('user has wildcard permission for entity', () => {
+      wrapper = mount((
+        <IfPermitted permissions={['entity:action']} currentUser={{ permissions: ['entity:*'] }}>
+          {element}
+        </IfPermitted>
+      ));
+    });
+    it('user has wildcard permission for entity when permission for id is required', () => {
+      wrapper = mount((
+        <IfPermitted permissions={['entity:action:id']} currentUser={{ permissions: ['entity:*'] }}>
+          {element}
+        </IfPermitted>
+      ));
+    });
+  });
+});

--- a/graylog2-web-interface/src/components/navigation/Navigation.jsx
+++ b/graylog2-web-interface/src/components/navigation/Navigation.jsx
@@ -1,12 +1,15 @@
 import PropTypes from 'prop-types';
 import React from 'react';
-import createReactClass from 'create-react-class';
+import { withRouter } from 'react-router';
 
-import { Badge, Navbar, Nav, NavItem, NavDropdown, MenuItem } from 'react-bootstrap';
+import { Badge, Navbar, Nav, NavItem, NavDropdown } from 'react-bootstrap';
 import { LinkContainer } from 'react-router-bootstrap';
 import naturalSort from 'javascript-natural-sort';
 
+import connect from 'stores/connect';
+import StoreProvider from 'injection/StoreProvider';
 import PermissionsMixin from 'util/PermissionsMixin';
+
 import Routes from 'routing/Routes';
 import URLUtils from 'util/URLUtils';
 import AppConfig from 'util/AppConfig';
@@ -22,238 +25,121 @@ import badgeStyles from 'components/bootstrap/Badge.css';
 import NavigationBrand from './NavigationBrand';
 import InactiveNavItem from './InactiveNavItem';
 import NotificationBadge from './NotificationBadge';
+import NavigationLink from './NavigationLink';
+import SystemMenu from './SystemMenu';
 
-const Navigation = createReactClass({
-  displayName: 'Navigation',
+const CurrentUserStore = StoreProvider.getStore('CurrentUser');
+const { isPermitted } = PermissionsMixin;
 
-  propTypes: {
-    requestPath: PropTypes.string.isRequired,
-    loginName: PropTypes.string.isRequired,
-    fullName: PropTypes.string.isRequired,
-    permissions: PropTypes.arrayOf(PropTypes.string).isRequired,
-  },
+const _isActive = (requestPath, prefix) => {
+  return requestPath.indexOf(URLUtils.appPrefixed(prefix)) === 0;
+};
 
-  mixins: [PermissionsMixin],
+const formatSinglePluginRoute = ({ description, path, permissions }) => {
+  const link = <NavigationLink key={description} description={description} path={path} />;
+  if (permissions) {
+    return <IfPermitted key={description} permissions={permissions}>{link}</IfPermitted>;
+  }
+  return link;
+};
 
-  _isActive(prefix) {
-    return this.props.requestPath.indexOf(URLUtils.appPrefixed(prefix)) === 0;
-  },
-
-  _systemTitle() {
-    const prefix = 'System';
-
-    if (this._isActive('/system/overview')) {
-      return `${prefix} / Overview`;
+const formatPluginRoute = (pluginRoute, permissions, location) => {
+  if (pluginRoute.children) {
+    const activeChild = pluginRoute.children.filter(({ path }) => (path && _isActive(location.pathname, path)));
+    const title = activeChild.length > 0 ? `${pluginRoute.description} / ${activeChild[0].description}` : pluginRoute.description;
+    const isEmpty = !pluginRoute.children.some(child => isPermitted(permissions, child.permissions));
+    if (isEmpty) {
+      return null;
     }
-    if (this._isActive('/system/nodes')) {
-      return `${prefix} / Nodes`;
-    }
-    if (this._isActive('/system/inputs')) {
-      return `${prefix} / Inputs`;
-    }
-    if (this._isActive('/system/outputs')) {
-      return `${prefix} / Outputs`;
-    }
-    if (this._isActive('/system/indices')) {
-      return `${prefix} / Indices`;
-    }
-    if (this._isActive('/system/logging')) {
-      return `${prefix} / Logging`;
-    }
-    if (this._isActive('/system/authentication')) {
-      return `${prefix} / Authentication`;
-    }
-    if (this._isActive('/system/contentpacks')) {
-      return `${prefix} / Content Packs`;
-    }
-    if (this._isActive('/system/grokpatterns')) {
-      return `${prefix} / Grok Patterns`;
-    }
-    if (this._isActive('/system/lookuptables')) {
-      return `${prefix} / Lookup Tables`;
-    }
-    if (this._isActive('/system/configurations')) {
-      return `${prefix} / Configurations`;
-    }
-    if (this._isActive('/system/pipelines')) {
-      return `${prefix} / Pipelines`;
-    }
-    if (this._isActive('/system/enterprise')) {
-      return `${prefix} / Enterprise`;
-    }
-    if (this._isActive('/system/sidecars')) {
-      return `${prefix} / Sidecars`;
-    }
-
-    const pluginRoute = PluginStore.exports('systemnavigation').filter(route => this._isActive(route.path))[0];
-    if (pluginRoute) {
-      return `${prefix} / ${pluginRoute.description}`;
-    }
-
-    return prefix;
-  },
-
-  _shouldAddPluginRoute(pluginRoute) {
-    return !pluginRoute.permissions || (pluginRoute.permissions && this.isPermitted(this.props.permissions, pluginRoute.permissions));
-  },
-
-  render() {
-    const pluginNavigations = PluginStore.exports('navigation')
-      .sort((route1, route2) => naturalSort(route1.description.toLowerCase(), route2.description.toLowerCase()))
-      .map((pluginRoute) => {
-        if (this._shouldAddPluginRoute(pluginRoute)) {
-          return (
-            <LinkContainer key={pluginRoute.path} to={URLUtils.appPrefixed(pluginRoute.path)}>
-              <NavItem>{pluginRoute.description}</NavItem>
-            </LinkContainer>
-          );
-        }
-        return null;
-      });
-
-    const pluginSystemNavigations = PluginStore.exports('systemnavigation')
-      .sort((route1, route2) => naturalSort(route1.description.toLowerCase(), route2.description.toLowerCase()))
-      .map((pluginRoute) => {
-        if (this._shouldAddPluginRoute(pluginRoute)) {
-          return (
-            <LinkContainer key={pluginRoute.path} to={URLUtils.appPrefixed(pluginRoute.path)}>
-              <MenuItem>{pluginRoute.description}</MenuItem>
-            </LinkContainer>
-          );
-        }
-        return null;
-      });
-
     return (
-      <Navbar inverse fluid fixedTop>
-        <Navbar.Header>
-          <Navbar.Brand>
-            <LinkContainer to={Routes.STARTPAGE}>
-              <NavigationBrand />
-            </LinkContainer>
-          </Navbar.Brand>
-          <Navbar.Toggle />
-        </Navbar.Header>
-        <Navbar.Collapse>
-          <Nav navbar>
-            <IfPermitted permissions={['searches:absolute', 'searches:relative', 'searches:keyword']}>
-              <LinkContainer to={Routes.SEARCH}>
-                <NavItem to="search">Search</NavItem>
-              </LinkContainer>
-            </IfPermitted>
-
-            <LinkContainer to={Routes.STREAMS}>
-              <NavItem>Streams</NavItem>
-            </LinkContainer>
-
-            <LinkContainer to={Routes.ALERTS.LIST}>
-              <NavItem>Alerts</NavItem>
-            </LinkContainer>
-
-            <LinkContainer to={Routes.DASHBOARDS}>
-              <NavItem >Dashboards</NavItem>
-            </LinkContainer>
-
-            <IfPermitted permissions="sources:read">
-              <LinkContainer to={Routes.SOURCES}>
-                <NavItem>Sources</NavItem>
-              </LinkContainer>
-            </IfPermitted>
-
-            {pluginNavigations}
-
-            {/*
-             * We cannot use IfPermitted in the dropdown unless we modify it to clone children elements and pass
-             * props down to them. NavDropdown is passing some props needed in MenuItems that are being blocked
-             * by IfPermitted.
-             */}
-            <NavDropdown title={this._systemTitle()} id="system-menu-dropdown">
-              <LinkContainer to={Routes.SYSTEM.OVERVIEW}>
-                <MenuItem>Overview</MenuItem>
-              </LinkContainer>
-              {this.isPermitted(this.props.permissions, ['clusterconfigentry:read']) &&
-              <LinkContainer to={Routes.SYSTEM.CONFIGURATIONS}>
-                <MenuItem>Configurations</MenuItem>
-              </LinkContainer>
-              }
-              <LinkContainer to={Routes.SYSTEM.NODES.LIST}>
-                <MenuItem>Nodes</MenuItem>
-              </LinkContainer>
-              {this.isPermitted(this.props.permissions, ['inputs:read']) &&
-              <LinkContainer to={Routes.SYSTEM.INPUTS}>
-                <MenuItem>Inputs</MenuItem>
-              </LinkContainer>
-              }
-              {this.isPermitted(this.props.permissions, ['outputs:read']) &&
-              <LinkContainer to={Routes.SYSTEM.OUTPUTS}>
-                <MenuItem>Outputs</MenuItem>
-              </LinkContainer>
-              }
-              {this.isPermitted(this.props.permissions, ['indices:read']) &&
-              <LinkContainer to={Routes.SYSTEM.INDICES.LIST}>
-                <MenuItem>Indices</MenuItem>
-              </LinkContainer>
-              }
-              {this.isPermitted(this.props.permissions, ['loggers:read']) &&
-              <LinkContainer to={Routes.SYSTEM.LOGGING}>
-                <MenuItem>Logging</MenuItem>
-              </LinkContainer>
-              }
-              {this.isAnyPermitted(this.props.permissions, ['users:list', 'roles:read']) &&
-              <LinkContainer to={Routes.SYSTEM.AUTHENTICATION.OVERVIEW}>
-                <MenuItem>Authentication</MenuItem>
-              </LinkContainer>
-              }
-              {this.isPermitted(this.props.permissions, ['dashboards:create', 'inputs:create', 'streams:create']) &&
-              <LinkContainer to={Routes.SYSTEM.CONTENTPACKS.LIST}>
-                <MenuItem>Content Packs</MenuItem>
-              </LinkContainer>
-              }
-              {this.isPermitted(this.props.permissions, ['inputs:edit']) &&
-              <LinkContainer to={Routes.SYSTEM.GROKPATTERNS}>
-                <MenuItem>Grok Patterns</MenuItem>
-              </LinkContainer>
-              }
-              {this.isPermitted(this.props.permissions, ['inputs:edit']) &&
-              <LinkContainer to={Routes.SYSTEM.LOOKUPTABLES.OVERVIEW}>
-                <MenuItem>Lookup Tables</MenuItem>
-              </LinkContainer>
-              }
-              {this.isPermitted(this.props.permissions, ['inputs:create']) &&
-              <LinkContainer to={Routes.SYSTEM.PIPELINES.OVERVIEW}>
-                <MenuItem>Pipelines</MenuItem>
-              </LinkContainer>
-              }
-              <LinkContainer to={Routes.SYSTEM.ENTERPRISE}>
-                <MenuItem>Enterprise</MenuItem>
-              </LinkContainer>
-              {this.isPermitted(this.props.permissions, ['inputs:edit']) &&
-              <LinkContainer to={Routes.SYSTEM.SIDECARS.OVERVIEW}>
-                <MenuItem>Sidecars</MenuItem>
-              </LinkContainer>
-              }
-              {pluginSystemNavigations}
-            </NavDropdown>
-          </Nav>
-
-          <NotificationBadge />
-
-          <Nav navbar pullRight>
-            <LinkContainer to={Routes.SYSTEM.NODES.LIST}>
-              <InactiveNavItem><GlobalThroughput /></InactiveNavItem>
-            </LinkContainer>
-            <HelpMenu active={this._isActive(Routes.GETTING_STARTED)} />
-            <UserMenu fullName={this.props.fullName} loginName={this.props.loginName} />
-            {AppConfig.gl2DevMode() ?
-              <NavItem className="notification-badge-link">
-                <Badge className={badgeStyles.badgeDanger}>DEV</Badge>
-              </NavItem>
-              : null}
-          </Nav>
-        </Navbar.Collapse>
-      </Navbar>
+      <NavDropdown key={title} title={title} id="enterprise-dropdown">
+        {pluginRoute.children.map(formatSinglePluginRoute)}
+      </NavDropdown>
     );
-  },
-});
+  }
+  return formatSinglePluginRoute(pluginRoute);
+};
 
-export default Navigation;
+const Navigation = ({ permissions, fullName, location, loginName }) => {
+  const pluginNavigations = PluginStore.exports('navigation')
+    .sort((route1, route2) => naturalSort(route1.description.toLowerCase(), route2.description.toLowerCase()))
+    .map(pluginRoute => formatPluginRoute(pluginRoute, permissions, location));
+
+  return (
+    <Navbar inverse fluid fixedTop>
+      <Navbar.Header>
+        <Navbar.Brand>
+          <LinkContainer to={Routes.STARTPAGE}>
+            <NavigationBrand />
+          </LinkContainer>
+        </Navbar.Brand>
+        <Navbar.Toggle />
+      </Navbar.Header>
+      <Navbar.Collapse>
+        <Nav navbar>
+          <IfPermitted permissions={['searches:absolute', 'searches:relative', 'searches:keyword']}>
+            <LinkContainer to={Routes.SEARCH}>
+              <NavItem to="search">Search</NavItem>
+            </LinkContainer>
+          </IfPermitted>
+
+          <LinkContainer to={Routes.STREAMS}>
+            <NavItem>Streams</NavItem>
+          </LinkContainer>
+
+          <LinkContainer to={Routes.ALERTS.LIST}>
+            <NavItem>Alerts</NavItem>
+          </LinkContainer>
+
+          <LinkContainer to={Routes.DASHBOARDS}>
+            <NavItem>Dashboards</NavItem>
+          </LinkContainer>
+
+          <IfPermitted permissions="sources:read">
+            <LinkContainer to={Routes.SOURCES}>
+              <NavItem>Sources</NavItem>
+            </LinkContainer>
+          </IfPermitted>
+
+          {pluginNavigations}
+
+          <SystemMenu />
+        </Nav>
+
+        <NotificationBadge />
+
+        <Nav navbar pullRight>
+          <LinkContainer to={Routes.SYSTEM.NODES.LIST}>
+            <InactiveNavItem><GlobalThroughput /></InactiveNavItem>
+          </LinkContainer>
+          <HelpMenu active={_isActive(location.pathname, Routes.GETTING_STARTED)} />
+          <UserMenu fullName={fullName} loginName={loginName} />
+          {AppConfig.gl2DevMode() ?
+            <NavItem className="notification-badge-link">
+              <Badge className={badgeStyles.badgeDanger}>DEV</Badge>
+            </NavItem>
+            : null}
+        </Nav>
+      </Navbar.Collapse>
+    </Navbar>
+  );
+};
+
+Navigation.propTypes = {
+  location: PropTypes.shape({
+    pathname: PropTypes.string.isRequired,
+  }).isRequired,
+  loginName: PropTypes.string.isRequired,
+  fullName: PropTypes.string.isRequired,
+  permissions: PropTypes.arrayOf(PropTypes.string),
+};
+
+Navigation.defaultProps = {
+  permissions: undefined,
+};
+
+export default connect(
+  withRouter(Navigation),
+  { currentUser: CurrentUserStore },
+  ({ currentUser }) => ({ permissions: currentUser ? currentUser.currentUser.permissions : undefined }),
+);

--- a/graylog2-web-interface/src/components/navigation/Navigation.test.jsx
+++ b/graylog2-web-interface/src/components/navigation/Navigation.test.jsx
@@ -115,6 +115,13 @@ describe('Navigation', () => {
                                         loginName="slowry" />);
       expect(wrapper.find('NavDropdown[title="Neat Stuff"]')).toExist();
     });
+    it('sets dropdown title based on match', () => {
+      currentUser.permissions = ['somethingelse', 'completelydifferent'];
+      const wrapper = mount(<Navigation fullName="Sam Lowry"
+                                        location={{ pathname: '/somethingelse' }}
+                                        loginName="slowry" />);
+      expect(wrapper.find('NavDropdown[title="Neat Stuff / Something Else"]')).toExist();
+    });
   });
   describe('uses correct permissions:', () => {
     const verifyPermissions = ({ permissions, count, links }) => {

--- a/graylog2-web-interface/src/components/navigation/Navigation.test.jsx
+++ b/graylog2-web-interface/src/components/navigation/Navigation.test.jsx
@@ -1,0 +1,134 @@
+import React from 'react';
+import { mount } from 'enzyme';
+import { PluginStore } from 'graylog-web-plugin/plugin';
+
+import mockComponent from 'helpers/mocking/MockComponent';
+import Routes from 'routing/Routes';
+
+jest.mock('./SystemMenu', () => mockComponent('SystemMenu'));
+jest.mock('./NavigationBrand', () => mockComponent('NavigationBrand'));
+jest.mock('./NavigationLink', () => mockComponent('NavigationLink'));
+jest.mock('react-router', () => ({ withRouter: x => x }));
+jest.mock('components/navigation/NotificationBadge', () => mockComponent('NotificationBadge'));
+
+const findLink = (wrapper, title) => wrapper.find(`NavigationLink[description="${title}"]`);
+
+describe('Navigation', () => {
+  let currentUser;
+  let Navigation;
+  beforeEach(() => {
+    currentUser = { permissions: [] };
+    const CurrentUserStore = {
+      getInitialState: jest.fn(() => ({ currentUser })),
+      listen: jest.fn(),
+      get: jest.fn(),
+    };
+    jest.doMock('injection/StoreProvider', () => ({ getStore: () => CurrentUserStore }));
+    // eslint-disable-next-line global-require
+    Navigation = require('./Navigation');
+  });
+  describe('has common elements', () => {
+    let wrapper;
+    beforeEach(() => {
+      wrapper = mount(<Navigation permissions={[]}
+                                  fullName="Sam Lowry"
+                                  location={{ pathname: '/' }}
+                                  loginName="slowry" />);
+    });
+    it('contains brand icon', () => {
+      const brand = wrapper.find('NavbarBrand');
+      expect(brand).toExist();
+      expect(brand.find('LinkContainer')).toHaveProp('to', Routes.STARTPAGE);
+      expect(brand.find('NavigationBrand')).toExist();
+    });
+    it('contains user menu including correct username', () => {
+      const usermenu = wrapper.find('UserMenu');
+      expect(usermenu).toHaveProp('loginName', 'slowry');
+      expect(usermenu).toHaveProp('fullName', 'Sam Lowry');
+    });
+    it('contains help menu', () => {
+      expect(wrapper.find('HelpMenu')).toExist();
+    });
+    it('contains global throughput', () => {
+      expect(wrapper.find('GlobalThroughput')).toExist();
+    });
+    it('contains notification badge', () => {
+      expect(wrapper.find('NotificationBadge')).toExist();
+    });
+  });
+  describe('renders custom navigation elements supplied by plugins', () => {
+    const plugin = {
+      metadata: { name: 'DummyPlugin ' },
+      exports: {
+        navigation: [
+          { path: '/something', description: 'Perpetuum Mobile' },
+          { path: '/system/archives', description: 'Archives', permissions: 'archive:read' },
+          {
+            description: 'Neat Stuff',
+            children: [
+              { path: '/somethingelse', description: 'Something Else', permissions: 'somethingelse' },
+              { path: '/completelydiffrent', description: 'Completely Different', permissions: 'completelydifferent' },
+            ],
+          },
+        ],
+      },
+    };
+    beforeEach(() => {
+      PluginStore.register(plugin);
+    });
+    afterEach(() => {
+      PluginStore.unregister(plugin);
+    });
+    it('contains top-level navigation element', () => {
+      const wrapper = mount(<Navigation permissions={[]}
+                                  fullName="Sam Lowry"
+                                  location={{ pathname: '/' }}
+                                  loginName="slowry" />);
+      expect(findLink(wrapper, 'Perpetuum Mobile')).toExist();
+    });
+    it('does not contain navigation elements from plugins where permissions are missing', () => {
+      const wrapper = mount(<Navigation permissions={[]}
+                                  fullName="Sam Lowry"
+                                  location={{ pathname: '/' }}
+                                  loginName="slowry" />);
+      expect(findLink(wrapper, 'Archives')).not.toExist();
+    });
+    it('contains restricted navigation elements from plugins if permissions are present', () => {
+      currentUser.permissions = ['archive:read'];
+      const wrapper = mount(<Navigation permissions={[]}
+                                  fullName="Sam Lowry"
+                                  location={{ pathname: '/' }}
+                                  loginName="slowry" />);
+      expect(findLink(wrapper, 'Archives')).toExist();
+    });
+    it('does not render dropdown contributed by plugin if permissions for all elements are missing', () => {
+      const wrapper = mount(<Navigation permissions={[]}
+                                        fullName="Sam Lowry"
+                                        location={{ pathname: '/' }}
+                                        loginName="slowry" />);
+      expect(wrapper.find('NavDropdown[title="Neat Stuff"]')).not.toExist();
+    });
+    it('renders dropdown contributed by plugin if permissions are sufficient', () => {
+      currentUser.permissions = ['somethingelse', 'completelydifferent'];
+      const wrapper = mount(<Navigation fullName="Sam Lowry"
+                                        location={{ pathname: '/' }}
+                                        loginName="slowry" />);
+      expect(wrapper.find('NavDropdown[title="Neat Stuff"]')).toExist();
+    });
+  });
+  describe('uses correct permissions:', () => {
+    const verifyPermissions = ({ permissions, count, links }) => {
+      currentUser.permissions = permissions;
+      const wrapper = mount(<Navigation location={{ pathname: '/' }} fullName="Sam Lowry" loginName="slowry" />);
+      const navigationLinks = wrapper.find('NavItem');
+      expect(navigationLinks).toHaveLength(count);
+      links.forEach(title => expect(wrapper.find(`NavItem[children="${title}"]`)).toExist());
+    };
+    it.each`
+    permissions                    | count | links
+    ${[]}                          | ${4}  | ${['Streams', 'Alerts', 'Dashboards']}
+    ${['searches:absolute', 'searches:relative', 'searches:keyword']} | ${5}  | ${['Search']}
+    ${['sources:read']}            | ${5}  | ${['Sources']}
+  `('shows $links for user with $permissions permissions', verifyPermissions);
+  });
+});

--- a/graylog2-web-interface/src/components/navigation/NavigationLink.jsx
+++ b/graylog2-web-interface/src/components/navigation/NavigationLink.jsx
@@ -1,0 +1,19 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { MenuItem } from 'react-bootstrap';
+import { LinkContainer } from 'react-router-bootstrap';
+
+import URLUtils from 'util/URLUtils';
+
+const NavigationLink = ({ description, path, ...rest }) => (
+  <LinkContainer key={path} to={URLUtils.appPrefixed(path)} {...rest}>
+    <MenuItem>{description}</MenuItem>
+  </LinkContainer>
+);
+
+NavigationLink.propTypes = {
+  description: PropTypes.string.isRequired,
+  path: PropTypes.string.isRequired,
+};
+
+export default NavigationLink;

--- a/graylog2-web-interface/src/components/navigation/NavigationLink.test.jsx
+++ b/graylog2-web-interface/src/components/navigation/NavigationLink.test.jsx
@@ -1,0 +1,18 @@
+import React from 'react';
+import { mount } from 'enzyme';
+import NavigationLink from './NavigationLink';
+
+jest.mock('util/URLUtils', () => ({ appPrefixed: path => `/prefix${path}` }));
+
+describe('NavigationLink', () => {
+  it('renders with simple props', () => {
+    const wrapper = mount(<NavigationLink description="Hello there!" path="/hello" />);
+    expect(wrapper.find('LinkContainer')).toHaveProp('path', '/hello');
+    expect(wrapper.find('LinkContainer')).toHaveProp('to', '/prefix/hello');
+    expect(wrapper.find('MenuItem')).toHaveText('Hello there!');
+  });
+  it('passes props to LinkContainer', () => {
+    const wrapper = mount(<NavigationLink description="Hello there!" path="/hello" someProp={42} />);
+    expect(wrapper.find('LinkContainer')).toHaveProp('someProp', 42);
+  });
+});

--- a/graylog2-web-interface/src/components/navigation/NavigationLink.test.jsx
+++ b/graylog2-web-interface/src/components/navigation/NavigationLink.test.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { mount } from 'enzyme';
+import { mount, shallow } from 'enzyme';
 import NavigationLink from './NavigationLink';
 
 jest.mock('util/URLUtils', () => ({ appPrefixed: path => `/prefix${path}` }));
@@ -7,12 +7,11 @@ jest.mock('util/URLUtils', () => ({ appPrefixed: path => `/prefix${path}` }));
 describe('NavigationLink', () => {
   it('renders with simple props', () => {
     const wrapper = mount(<NavigationLink description="Hello there!" path="/hello" />);
-    expect(wrapper.find('LinkContainer')).toHaveProp('path', '/hello');
     expect(wrapper.find('LinkContainer')).toHaveProp('to', '/prefix/hello');
     expect(wrapper.find('MenuItem')).toHaveText('Hello there!');
   });
   it('passes props to LinkContainer', () => {
-    const wrapper = mount(<NavigationLink description="Hello there!" path="/hello" someProp={42} />);
+    const wrapper = shallow(<NavigationLink description="Hello there!" path="/hello" someProp={42} />);
     expect(wrapper.find('LinkContainer')).toHaveProp('someProp', 42);
   });
 });

--- a/graylog2-web-interface/src/components/navigation/SystemMenu.jsx
+++ b/graylog2-web-interface/src/components/navigation/SystemMenu.jsx
@@ -1,0 +1,131 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { withRouter } from 'react-router';
+import { NavDropdown } from 'react-bootstrap';
+import { PluginStore } from 'graylog-web-plugin/plugin';
+import naturalSort from 'javascript-natural-sort';
+
+import IfPermitted from 'components/common/IfPermitted';
+import Routes from 'routing/Routes';
+import URLUtils from 'util/URLUtils';
+import NavigationLink from './NavigationLink';
+
+const _isActive = (requestPath, prefix) => {
+  return requestPath.indexOf(URLUtils.appPrefixed(prefix)) === 0;
+};
+
+const _systemTitle = (pathname) => {
+  const prefix = 'System';
+
+  if (_isActive(pathname, '/system/overview')) {
+    return `${prefix} / Overview`;
+  }
+  if (_isActive(pathname, '/system/nodes')) {
+    return `${prefix} / Nodes`;
+  }
+  if (_isActive(pathname, '/system/inputs')) {
+    return `${prefix} / Inputs`;
+  }
+  if (_isActive(pathname, '/system/outputs')) {
+    return `${prefix} / Outputs`;
+  }
+  if (_isActive(pathname, '/system/indices')) {
+    return `${prefix} / Indices`;
+  }
+  if (_isActive(pathname, '/system/logging')) {
+    return `${prefix} / Logging`;
+  }
+  if (_isActive(pathname, '/system/authentication')) {
+    return `${prefix} / Authentication`;
+  }
+  if (_isActive(pathname, '/system/contentpacks')) {
+    return `${prefix} / Content Packs`;
+  }
+  if (_isActive(pathname, '/system/grokpatterns')) {
+    return `${prefix} / Grok Patterns`;
+  }
+  if (_isActive(pathname, '/system/lookuptables')) {
+    return `${prefix} / Lookup Tables`;
+  }
+  if (_isActive(pathname, '/system/configurations')) {
+    return `${prefix} / Configurations`;
+  }
+  if (_isActive(pathname, '/system/pipelines')) {
+    return `${prefix} / Pipelines`;
+  }
+  if (_isActive(pathname, '/system/enterprise')) {
+    return `${prefix} / Enterprise`;
+  }
+  if (_isActive(pathname, '/system/sidecars')) {
+    return `${prefix} / Sidecars`;
+  }
+
+  const pluginRoute = PluginStore.exports('systemnavigation').filter(route => _isActive(pathname, route.path))[0];
+  if (pluginRoute) {
+    return `${prefix} / ${pluginRoute.description}`;
+  }
+
+  return prefix;
+};
+
+const SystemMenu = ({ location }) => {
+  const pluginSystemNavigations = PluginStore.exports('systemnavigation')
+    .sort((route1, route2) => naturalSort(route1.description.toLowerCase(), route2.description.toLowerCase()))
+    .map(({ description, path, permissions }) => {
+      const link = <NavigationLink description={description} path={path} />;
+      if (permissions) {
+        return <IfPermitted key={description} permissions={permissions}>{link}</IfPermitted>;
+      }
+      return <NavigationLink key={description} path={path} description={description} />;
+    });
+
+  return (
+    <NavDropdown title={_systemTitle(location.pathname)} id="system-menu-dropdown">
+      <NavigationLink path={Routes.SYSTEM.OVERVIEW} description="Overview" />
+      <IfPermitted permissions={['clusterconfigentry:read']}>
+        <NavigationLink path={Routes.SYSTEM.CONFIGURATIONS} description="Configurations" />
+      </IfPermitted>
+      <NavigationLink path={Routes.SYSTEM.NODES.LIST} description="Nodes" />
+      <IfPermitted permissions={['inputs:read']}>
+        <NavigationLink path={Routes.SYSTEM.INPUTS} description="Inputs" />
+      </IfPermitted>
+      <IfPermitted permissions={['outputs:read']}>
+        <NavigationLink path={Routes.SYSTEM.OUTPUTS} description="Outputs" />
+      </IfPermitted>
+      <IfPermitted permissions={['indices:read']}>
+        <NavigationLink path={Routes.SYSTEM.INDICES.LIST} description="Indices" />
+      </IfPermitted>
+      <IfPermitted permissions={['loggers:read']}>
+        <NavigationLink path={Routes.SYSTEM.LOGGING} description="Logging" />
+      </IfPermitted>
+      <IfPermitted permissions={['users:list', 'roles:read']} anyPermissions>
+        <NavigationLink path={Routes.SYSTEM.AUTHENTICATION.OVERVIEW} description="Authentication" />
+      </IfPermitted>
+      <IfPermitted permissions={['dashboards:create', 'inputs:create', 'streams:create']}>
+        <NavigationLink path={Routes.SYSTEM.CONTENTPACKS.LIST} description="Content Packs" />
+      </IfPermitted>
+      <IfPermitted permissions={['inputs:edit']}>
+        <NavigationLink path={Routes.SYSTEM.GROKPATTERNS} description="Grok Patterns" />
+      </IfPermitted>
+      <IfPermitted permissions={['inputs:edit']}>
+        <NavigationLink path={Routes.SYSTEM.LOOKUPTABLES.OVERVIEW} description="Lookup Tables" />
+      </IfPermitted>
+      <IfPermitted permissions={['inputs:create']}>
+        <NavigationLink path={Routes.SYSTEM.PIPELINES.OVERVIEW} description="Pipelines" />
+      </IfPermitted>
+      <NavigationLink path={Routes.SYSTEM.ENTERPRISE} description="Enterprise" />
+      <IfPermitted permissions={['inputs:edit']}>
+        <NavigationLink path={Routes.SYSTEM.SIDECARS.OVERVIEW} description="Sidecars" />
+      </IfPermitted>
+      {pluginSystemNavigations}
+    </NavDropdown>
+  );
+};
+
+SystemMenu.propTypes = {
+  location: PropTypes.shape({
+    pathname: PropTypes.string.isRequired,
+  }).isRequired,
+};
+
+export default withRouter(SystemMenu);

--- a/graylog2-web-interface/src/components/navigation/SystemMenu.test.jsx
+++ b/graylog2-web-interface/src/components/navigation/SystemMenu.test.jsx
@@ -1,0 +1,103 @@
+import React from 'react';
+import { mount } from 'enzyme';
+
+const findLink = (wrapper, title) => wrapper.find(`NavigationLink[description="${title}"]`);
+const containsLink = (wrapper, title) => expect(findLink(wrapper, title)).toHaveLength(1);
+const containsAllLinks = (wrapper, titles) => titles.forEach(title => containsLink(wrapper, title));
+
+describe('SystemMenu', () => {
+  let currentUser;
+  let exports;
+  beforeEach(() => {
+    currentUser = { permissions: [] };
+    const CurrentUserStore = {
+      getInitialState: jest.fn(() => ({ currentUser })),
+      listen: jest.fn(),
+    };
+    jest.doMock('injection/StoreProvider', () => ({ getStore: () => CurrentUserStore }));
+    exports = {};
+    const PluginStore = { exports: jest.fn(key => exports[key] || []) };
+    jest.doMock('graylog-web-plugin/plugin', () => ({ PluginStore }));
+  });
+  describe('uses correct permissions:', () => {
+    let SystemMenu;
+    beforeEach(() => {
+      // eslint-disable-next-line global-require
+      SystemMenu = require('./SystemMenu');
+    });
+    const verifyPermissions = ({ permissions, count, links }) => {
+      currentUser.permissions = permissions;
+      const wrapper = mount(<SystemMenu location={{ pathname: '/' }} />);
+      const navigationLinks = wrapper.find('NavigationLink');
+      expect(navigationLinks).toHaveLength(count);
+      containsAllLinks(navigationLinks, links);
+    };
+    it.each`
+    permissions                    | count | links
+    ${[]}                          | ${3}  | ${['Overview', 'Nodes', 'Enterprise']}
+    ${['clusterconfigentry:read']} | ${4}  | ${['Configurations']}
+    ${['inputs:read']}             | ${4}  | ${['Inputs']}
+    ${['outputs:read']}            | ${4}  | ${['Outputs']}
+    ${['indices:read']}            | ${4}  | ${['Indices']}
+    ${['loggers:read']}            | ${4}  | ${['Logging']}
+    ${['users:list']}              | ${4}  | ${['Authentication']}
+    ${['roles:read']}              | ${4}  | ${['Authentication']}
+    ${['dashboards:create', 'inputs:create', 'streams:create']} | ${5}  | ${['Content Packs']}
+    ${['inputs:edit']}             | ${6}  | ${['Grok Patterns', 'Lookup Tables', 'Sidecars']}
+    ${['inputs:create']}           | ${4}  | ${['Pipelines']}
+  `('shows $links for user with $permissions permissions', verifyPermissions);
+  });
+  describe('uses items from plugins:', () => {
+    let SystemMenu;
+    beforeEach(() => {
+      exports.systemnavigation = [
+        { path: '/system/licenses', description: 'Licenses', permissions: 'inputs:create' },
+        { path: '/system/auditlog', description: 'Audit Log' },
+      ];
+      // eslint-disable-next-line global-require
+      SystemMenu = require('./SystemMenu');
+    });
+    afterEach(() => {
+      exports.systemnavigation = [];
+    });
+    it('includes plugin item in system navigation', () => {
+      const wrapper = mount(<SystemMenu location={{ pathname: '/' }} />);
+      containsLink(wrapper, 'Audit Log');
+      expect(findLink(wrapper, 'Audit Log')).toHaveProp('path', '/system/auditlog');
+      expect(wrapper.find('NavigationLink[description="Licenses"]')).not.toExist();
+    });
+    it('includes plugin item in system navigation if required permissions are present', () => {
+      currentUser.permissions = ['inputs:create'];
+      const wrapper = mount(<SystemMenu location={{ pathname: '/' }} />);
+      containsLink(wrapper, 'Audit Log');
+      containsLink(wrapper, 'Licenses');
+    });
+  });
+
+  describe('sets a location-specific title for the dropdown', () => {
+    let SystemMenu;
+    beforeEach(() => {
+      exports.systemnavigation = [
+        { path: '/system/licenses', description: 'Licenses', permissions: 'inputs:create' },
+        { path: '/system/auditlog', description: 'Audit Log' },
+      ];
+      // eslint-disable-next-line global-require
+      SystemMenu = require('./SystemMenu');
+    });
+    afterEach(() => {
+      exports.systemnavigation = [];
+    });
+    it('uses a default title if location is not matched', () => {
+      const wrapper = mount(<SystemMenu location={{ pathname: '/' }} />);
+      expect(wrapper.find('NavDropdown')).toHaveProp('title', 'System');
+    });
+    it('uses a custom title if location is matched', () => {
+      const wrapper = mount(<SystemMenu location={{ pathname: '/system/overview' }} />);
+      expect(wrapper.find('NavDropdown')).toHaveProp('title', 'System / Overview');
+    });
+    it('uses a custom title for a plugin route if location is matched', () => {
+      const wrapper = mount(<SystemMenu location={{ pathname: '/system/licenses' }} />);
+      expect(wrapper.find('NavDropdown')).toHaveProp('title', 'System / Licenses');
+    });
+  });
+});

--- a/graylog2-web-interface/src/util/PermissionsMixin.jsx
+++ b/graylog2-web-interface/src/util/PermissionsMixin.jsx
@@ -1,40 +1,43 @@
+const _isWildCard = permissionSet => (permissionSet.indexOf('*') > -1);
+const _permissionPredicate = (permissionSet, p) => {
+  if ((permissionSet.indexOf(p) > -1) || (permissionSet.indexOf('*') > -1)) {
+    return true;
+  }
+
+  const permissionParts = p.split(':');
+  if (permissionParts.length >= 2) {
+    const first = permissionParts[0];
+    const second = `${permissionParts[0]}:${permissionParts[1]}`;
+    return (permissionSet.indexOf(first) > -1)
+      || (permissionSet.indexOf(`${first}:*`) > -1)
+      || (permissionSet.indexOf(second) > -1)
+      || (permissionSet.indexOf(`${second}:*`) > -1);
+  }
+  return (permissionSet.indexOf(`${p}:*`) > -1);
+};
+
 const PermissionsMixin = {
-  _isWildCard(permissionSet) {
-    return (permissionSet.indexOf('*') > -1);
-  },
-
-  _permissionPredicate(permissionSet, p) {
-      if ((permissionSet.indexOf(p) > -1) || (permissionSet.indexOf('*') > -1)) {
+  isPermitted(possessedPermissions, requiredPermissions) {
+    if (!possessedPermissions) {
+      return false;
+    }
+    if (_isWildCard(possessedPermissions)) {
       return true;
     }
-
-    let permissionParts = p.split(':');
-    if (permissionParts.length >= 2) {
-      let first = permissionParts[0];
-      let second = permissionParts[0] + ':' + permissionParts[1];
-      return (permissionSet.indexOf(first) > -1)
-        || (permissionSet.indexOf(first + ':*') > -1)
-        || (permissionSet.indexOf(second) > -1)
-        || (permissionSet.indexOf(second + ':*') > -1);
+    if (requiredPermissions.every) {
+      return requiredPermissions.every(p => _permissionPredicate(possessedPermissions, p));
     }
-    return (permissionSet.indexOf(`${p}:*`) > -1);
+    return _permissionPredicate(possessedPermissions, requiredPermissions);
   },
 
-  isPermitted(permissionSet, permissions) {
-    if (this._isWildCard(permissionSet)) {
+  isAnyPermitted(possessedPermissions, requiredPermissions) {
+    if (!possessedPermissions) {
+      return false;
+    }
+    if (_isWildCard(possessedPermissions)) {
       return true;
     }
-    if (permissions.every) {
-      return permissions.every(p => this._permissionPredicate(permissionSet, p));
-    }
-    return this._permissionPredicate(permissionSet, permissions);
-  },
-
-  isAnyPermitted(permissionSet, permissions) {
-    if (this._isWildCard(permissionSet)) {
-      return true;
-    }
-    return permissions.some(p => this._permissionPredicate(permissionSet, p));
+    return requiredPermissions.some(p => _permissionPredicate(possessedPermissions, p));
   },
 };
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

This change allows plugins to contribute dropdowns for the navigation bar instead of individual navigation elements. This allows plugins which contribute more than one navigational entrypoint to group them together in a single navigation element and occupy less space.

For this, the `Navigation` component was broken down into additional `SystemMenu` and `NavigationLink` components and tests for these individual components were added.

Additionally, `IfPermitted` was used whenever possible. For this, props passthrough was implement to support wrapping e.g. `MenuItem` components which get some properties passed in externally.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
