### PR TITLE
Add Beats default templates

### DIFF
--- a/graylog2-server/src/main/java/org/graylog/plugins/sidecar/migrations/V20180212165000_AddDefaultCollectors.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/sidecar/migrations/V20180212165000_AddDefaultCollectors.java
@@ -47,7 +47,7 @@ public class V20180212165000_AddDefaultCollectors extends Migration {
                 "# Needed for Graylog\n" +
                 "fields_under_root: true\n" +
                 "fields.collector_node_id: ${nodeId}\n" +
-                "fields.gl2_source_collector: ${nodeName}\n";
+                "fields.gl2_source_collector: ${nodeName}\n\n";
 
         ensureCollector(
                 "filebeat",
@@ -57,7 +57,17 @@ public class V20180212165000_AddDefaultCollectors extends Migration {
                 "/var/lib/graylog-sidecar/generated/filebeat.yml",
                 "-c  %s",
                 "test config -c %s",
-                beatsPreambel
+                beatsPreambel +
+                        "filebeat.inputs:\n" +
+                        "- input_type: log\n" +
+                        "  paths:\n" +
+                        "    - /var/log/*.log\n" +
+                        "  type: log\n" +
+                        "output.logstash:\n" +
+                        "   hosts: [\"192.168.1.1:5044\"]\n" +
+                        "path:\n" +
+                        "  data: /var/cache/graylog-sidecar/filebeat/data\n" +
+                        "  logs: /var/log/graylog-sidecar"
         );
         ensureCollector(
                 "winlogbeat",
@@ -67,7 +77,19 @@ public class V20180212165000_AddDefaultCollectors extends Migration {
                 "C:\\Program Files\\Graylog\\sidecar\\generated\\winlogbeat.yml",
                 "-c \"%s\"",
                 "test config -c \"%s\"",
-                beatsPreambel
+                beatsPreambel +
+                        "output.logstash:\n" +
+                        "   hosts: [\"192.168.1.1:5044\"]\n" +
+                        "path:\n" +
+                        "  data: C:\\Program Files\\Graylog\\sidecar\\cache\\winlogbeat\\data\n" +
+                        "  logs: C:\\Program Files\\Graylog\\sidecar\\logs\n" +
+                        "tags:\n" +
+                        " - windows\n" +
+                        "winlogbeat:\n" +
+                        "  event_logs:\n" +
+                        "   - name: Application\n" +
+                        "   - name: System\n" +
+                        "   - name: Security"
         );
         ensureCollector(
                 "nxlog",

--- a/graylog2-server/src/main/java/org/graylog/plugins/sidecar/migrations/V20180212165000_AddDefaultCollectors.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/sidecar/migrations/V20180212165000_AddDefaultCollectors.java
@@ -43,6 +43,12 @@ public class V20180212165000_AddDefaultCollectors extends Migration {
 
     @Override
     public void upgrade() {
+        final String beatsPreambel =
+                "# Needed for Graylog\n" +
+                "fields_under_root: true\n" +
+                "fields.collector_node_id: ${nodeId}\n" +
+                "fields.gl2_source_collector: ${nodeName}\n";
+
         ensureCollector(
                 "filebeat",
                 "exec",
@@ -51,7 +57,7 @@ public class V20180212165000_AddDefaultCollectors extends Migration {
                 "/var/lib/graylog-sidecar/generated/filebeat.yml",
                 "-c  %s",
                 "test config -c %s",
-                ""
+                beatsPreambel
         );
         ensureCollector(
                 "winlogbeat",
@@ -61,7 +67,7 @@ public class V20180212165000_AddDefaultCollectors extends Migration {
                 "C:\\Program Files\\Graylog\\sidecar\\generated\\winlogbeat.yml",
                 "-c \"%s\"",
                 "test config -c \"%s\"",
-                ""
+                beatsPreambel
         );
         ensureCollector(
                 "nxlog",

--- a/graylog2-web-interface/src/components/sidecars/configuration-forms/FilebeatHelper.jsx
+++ b/graylog2-web-interface/src/components/sidecars/configuration-forms/FilebeatHelper.jsx
@@ -11,17 +11,17 @@ class FilebeatHelper extends React.Component {
   };
 
   static toc = {
-    prospectors: ['log'],
+    inputs: ['log'],
     outputs: ['logstash'],
     processors: ['fields', 'drop events'],
   };
 
-  prospectorsLog = () => {
+  inputsLog = () => {
     return (
       <div>
-        <h3>Log Prospector</h3>
+        <h3>Log Inputs</h3>
         Reads every line of the log file.
-        {this.example(`filebeat.prospectors:
+        {this.example(`filebeat.inputs:
   - type: log
     paths:
       - /var/log/apache/httpd-*.log`)}
@@ -72,7 +72,7 @@ class FilebeatHelper extends React.Component {
         {this.example(`ignore_older: 2h`)}
 
         <b>scan_frequency</b><br/>
-        How often the prospector checks for new files in the paths that are specified
+        How often the input checks for new files in the paths that are specified
         for harvesting.
         {this.example(`scan_frequency: 10s`)}
 

--- a/graylog2-web-interface/src/components/sidecars/configuration-forms/TemplatesHelper.jsx
+++ b/graylog2-web-interface/src/components/sidecars/configuration-forms/TemplatesHelper.jsx
@@ -28,7 +28,7 @@ class TemplatesHelper extends React.Component {
               <td>UUID of the sidecar.</td>
             </tr>
             <tr>
-              <td><code>{'${'}collectorVersion{'}'}</code></td>
+              <td><code>{'${'}sidecarVersion{'}'}</code></td>
               <td>Version string of the running sidecar.</td>
             </tr>
             <tr>


### PR DESCRIPTION
Provide our users with a sensible default template for filebeat and winlogbeat.

Include a config preamble that is needed for the Graylog GUI to function.

Fixes https://github.com/Graylog2/collector-sidecar/issues/297