### PR TITLE
Rename "Beats Legacy" input to "Beats (deprecated)"

### DIFF
--- a/graylog2-server/src/main/java/org/graylog/plugins/beats/BeatsCodec.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/beats/BeatsCodec.java
@@ -40,7 +40,7 @@ import java.util.Map;
 
 import static java.util.Objects.requireNonNull;
 
-@Codec(name = "beats-legacy", displayName = "Beats Legacy")
+@Codec(name = "beats-deprecated", displayName = "Beats (deprecated)")
 public class BeatsCodec extends AbstractCodec {
     private static final Logger LOG = LoggerFactory.getLogger(BeatsCodec.class);
     private static final String MAP_KEY_SEPARATOR = "_";

--- a/graylog2-server/src/main/java/org/graylog/plugins/beats/BeatsInput.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/beats/BeatsInput.java
@@ -28,7 +28,7 @@ import org.graylog2.plugin.inputs.annotations.FactoryClass;
 import javax.inject.Inject;
 
 public class BeatsInput extends MessageInput {
-    private static final String NAME = "Beats Legacy";
+    private static final String NAME = "Beats (deprecated)";
 
     @Inject
     public BeatsInput(@Assisted Configuration configuration,

--- a/graylog2-server/src/main/java/org/graylog/plugins/beats/BeatsInputPluginModule.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/beats/BeatsInputPluginModule.java
@@ -23,8 +23,8 @@ public class BeatsInputPluginModule extends PluginModule {
     protected void configure() {
         addTransport("beats", BeatsTransport.class);
 
-        // Beats legacy input
-        addCodec("beats-legacy", BeatsCodec.class);
+        // Beats deprecated input
+        addCodec("beats-deprecated", BeatsCodec.class);
         addMessageInput(BeatsInput.class);
 
         // Beats input with improved field handling

--- a/graylog2-server/src/test/java/org/graylog/plugins/beats/BeatsInputDescriptorTest.java
+++ b/graylog2-server/src/test/java/org/graylog/plugins/beats/BeatsInputDescriptorTest.java
@@ -23,6 +23,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 public class BeatsInputDescriptorTest {
     @Test
     public void descriptorNameIsCorrect() {
-        assertThat(new BeatsInput.Descriptor().getName()).isEqualTo("Beats Legacy");
+        assertThat(new BeatsInput.Descriptor().getName()).isEqualTo("Beats (deprecated)");
     }
 }

--- a/graylog2-server/src/test/java/org/graylog/plugins/beats/DeprecatedConsolePrinter.java
+++ b/graylog2-server/src/test/java/org/graylog/plugins/beats/DeprecatedConsolePrinter.java
@@ -36,7 +36,7 @@ import org.graylog2.shared.bindings.providers.ObjectMapperProvider;
 
 import static com.google.common.base.MoreObjects.firstNonNull;
 
-public class LegacyConsolePrinter {
+public class DeprecatedConsolePrinter {
     public static void main(String[] args) throws Exception {
         String hostname = "127.0.0.1";
         int port = 5044;
@@ -59,7 +59,7 @@ public class LegacyConsolePrinter {
                         public void initChannel(SocketChannel ch) throws Exception {
                             ch.pipeline().addLast("logging", new LoggingHandler());
                             ch.pipeline().addLast("beats-frame-decoder", new BeatsFrameDecoder());
-                            ch.pipeline().addLast("beats-legacy-codec", new BeatsCodecHandler());
+                            ch.pipeline().addLast("beats-deprecated-codec", new BeatsCodecHandler());
                         }
                     });
 


### PR DESCRIPTION
The former name suggested that it could be used to parse
an old version of the Beats protocol.
The new name is hopefully less confusing.