### PR TITLE
Show collector status messages with newlines

### DIFF
--- a/graylog2-web-interface/src/components/sidecars/common/CommonSidecarStyles.css
+++ b/graylog2-web-interface/src/components/sidecars/common/CommonSidecarStyles.css
@@ -24,3 +24,7 @@
     opacity: 0.5;
     z-index: 20;
 }
+
+:local(.collectorMessage) {
+    white-space: pre-line;
+}

--- a/graylog2-web-interface/src/components/sidecars/sidecars/SidecarStatus.jsx
+++ b/graylog2-web-interface/src/components/sidecars/sidecars/SidecarStatus.jsx
@@ -68,12 +68,12 @@ const SidecarStatus = createReactClass({
           break;
         case SidecarStatusEnum.FAILING:
           statusMessage = status.message;
-          statusClass = 'text-danger';
+          statusClass = `text-danger ${commonStyles.collectorMessage}`;
           statusBadge = <i className="fa fa-warning fa-fw" />;
           break;
         case SidecarStatusEnum.STOPPED:
           statusMessage = status.message;
-          statusClass = 'text-danger';
+          statusClass = `text-danger ${commonStyles.collectorMessage}`;
           statusBadge = <i className="fa fa-stop fa-fw" />;
           break;
         default:


### PR DESCRIPTION
Sidecar is reporting stdout and stderr of failed collectors
back to Graylog. Use css to render the newline formated text.

Fixes #5043

Example output:
![collstat](https://user-images.githubusercontent.com/3034831/46939759-72247180-d067-11e8-9864-55095f308eca.png)
