### PR TITLE
Make search query in alert conditions configurable in the UI

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/alerts/AbstractAlertCondition.java
+++ b/graylog2-server/src/main/java/org/graylog2/alerts/AbstractAlertCondition.java
@@ -38,7 +38,6 @@ import java.util.Map;
 import java.util.UUID;
 
 import static com.google.common.base.Preconditions.checkArgument;
-import static com.google.common.base.Strings.isNullOrEmpty;
 
 public abstract class AbstractAlertCondition implements EmbeddedPersistable, AlertCondition {
     protected static final String CK_QUERY = "query";
@@ -169,12 +168,19 @@ public abstract class AbstractAlertCondition implements EmbeddedPersistable, Ale
      * @return the combined filter string
      */
     protected String buildQueryFilter(String streamId, String query) {
-        checkArgument(!isNullOrEmpty(streamId), "streamId parameter cannot be null or empty");
+        checkArgument(streamId != null, "streamId parameter cannot be null");
 
-        final StringBuilder builder = new StringBuilder().append("streams:").append(streamId);
+        final String trimmedStreamId = streamId.trim();
 
-        if (!isNullOrEmpty(query) && !"*".equals(query)) {
-            builder.append(" ").append(query);
+        checkArgument(!trimmedStreamId.isEmpty(), "streamId parameter cannot be empty");
+
+        final StringBuilder builder = new StringBuilder().append("streams:").append(trimmedStreamId);
+
+        if (query != null) {
+            final String trimmedQuery = query.trim();
+            if (!trimmedQuery.isEmpty() && !"*".equals(trimmedQuery)) {
+                builder.append(" ").append(trimmedQuery);
+            }
         }
 
         return builder.toString();

--- a/graylog2-server/src/main/java/org/graylog2/alerts/AbstractAlertCondition.java
+++ b/graylog2-server/src/main/java/org/graylog2/alerts/AbstractAlertCondition.java
@@ -179,7 +179,7 @@ public abstract class AbstractAlertCondition implements EmbeddedPersistable, Ale
         if (query != null) {
             final String trimmedQuery = query.trim();
             if (!trimmedQuery.isEmpty() && !"*".equals(trimmedQuery)) {
-                builder.append(" ").append(trimmedQuery);
+                builder.append(" AND (").append(trimmedQuery).append(")");
             }
         }
 

--- a/graylog2-server/src/main/java/org/graylog2/alerts/types/FieldContentValueAlertCondition.java
+++ b/graylog2-server/src/main/java/org/graylog2/alerts/types/FieldContentValueAlertCondition.java
@@ -52,6 +52,7 @@ public class FieldContentValueAlertCondition extends AbstractAlertCondition {
     private final Configuration configuration;
     private final String field;
     private final String value;
+    private final String query;
 
     public interface Factory extends AlertCondition.Factory {
         @Override
@@ -109,11 +110,12 @@ public class FieldContentValueAlertCondition extends AbstractAlertCondition {
         this.configuration = configuration;
         this.field = (String) parameters.get("field");
         this.value = (String) parameters.get("value");
+        this.query = (String) parameters.getOrDefault(CK_QUERY, CK_QUERY_DEFAULT_VALUE);
     }
 
     @Override
     public CheckResult runCheck() {
-        String filter = "streams:" + stream.getId();
+        String filter = buildQueryFilter(stream.getId(), query);
         String query = field + ":\"" + value + "\"";
         Integer backlogSize = getBacklog();
         boolean backlogEnabled = false;

--- a/graylog2-server/src/main/java/org/graylog2/alerts/types/FieldValueAlertCondition.java
+++ b/graylog2-server/src/main/java/org/graylog2/alerts/types/FieldValueAlertCondition.java
@@ -132,6 +132,7 @@ public class FieldValueAlertCondition extends AbstractAlertCondition {
     private final Number threshold;
     private final CheckType type;
     private final String field;
+    private final String query;
     private final DecimalFormat decimalFormat;
     private final Searches searches;
 
@@ -153,6 +154,7 @@ public class FieldValueAlertCondition extends AbstractAlertCondition {
         this.threshold = Tools.getNumber(parameters.get("threshold"), 0.0).doubleValue();
         this.type = CheckType.valueOf(((String) parameters.get("type")).toUpperCase(Locale.ENGLISH));
         this.field = (String) parameters.get("field");
+        this.query = (String) parameters.getOrDefault(CK_QUERY, CK_QUERY_DEFAULT_VALUE);
     }
 
     @Override
@@ -170,7 +172,7 @@ public class FieldValueAlertCondition extends AbstractAlertCondition {
     @Override
     public CheckResult runCheck() {
         try {
-            final String filter = "streams:" + stream.getId();
+            final String filter = buildQueryFilter(stream.getId(), query);
             // TODO we don't support cardinality yet
             final FieldStatsResult fieldStatsResult = searches.fieldStats(field, "*", filter,
                 RelativeRange.create(time * 60), false, true, false);

--- a/graylog2-server/src/main/java/org/graylog2/alerts/types/MessageCountAlertCondition.java
+++ b/graylog2-server/src/main/java/org/graylog2/alerts/types/MessageCountAlertCondition.java
@@ -120,6 +120,7 @@ public class MessageCountAlertCondition extends AbstractAlertCondition {
     private final int time;
     private final ThresholdType thresholdType;
     private final int threshold;
+    private final String query;
     private final Searches searches;
 
     @AssistedInject
@@ -152,6 +153,7 @@ public class MessageCountAlertCondition extends AbstractAlertCondition {
         }
         this.thresholdType = ThresholdType.valueOf(upperCaseThresholdType);
         this.threshold = Tools.getNumber(parameters.get("threshold"), 0).intValue();
+        this.query = (String) parameters.getOrDefault(CK_QUERY, CK_QUERY_DEFAULT_VALUE);
     }
 
     @Override
@@ -174,7 +176,7 @@ public class MessageCountAlertCondition extends AbstractAlertCondition {
             final RelativeRange relativeRange = RelativeRange.create(time * 60);
             final AbsoluteRange range = AbsoluteRange.create(relativeRange.getFrom(), relativeRange.getTo());
 
-            final String filter = "streams:" + stream.getId();
+            final String filter = buildQueryFilter(stream.getId(), query);
             final CountResult result = searches.count("*", range, filter);
             final long count = result.count();
 

--- a/graylog2-server/src/main/java/org/graylog2/rest/resources/streams/alerts/StreamAlertConditionResource.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/resources/streams/alerts/StreamAlertConditionResource.java
@@ -27,6 +27,7 @@ import org.apache.shiro.authz.annotation.RequiresAuthentication;
 import org.graylog2.alerts.AlertService;
 import org.graylog2.audit.AuditEventTypes;
 import org.graylog2.audit.jersey.AuditEvent;
+import org.graylog2.audit.jersey.NoAuditEvent;
 import org.graylog2.database.NotFoundException;
 import org.graylog2.plugin.alarms.AlertCondition;
 import org.graylog2.plugin.configuration.ConfigurationException;
@@ -218,6 +219,7 @@ public class StreamAlertConditionResource extends RestResource {
     @Path("test")
     @Timed
     @ApiOperation("Test new alert condition")
+    @NoAuditEvent("resource doesn't modify any data")
     public Response testNew(@ApiParam(name = "streamId", value = "The stream ID this alert condition belongs to.", required = true) @PathParam("streamId") String streamId,
                             @ApiParam(name = "Alert condition parameters", required = true) @Valid @NotNull CreateConditionRequest ccr) throws NotFoundException {
         checkPermission(RestPermissions.STREAMS_EDIT, streamId);
@@ -237,6 +239,7 @@ public class StreamAlertConditionResource extends RestResource {
     @Path("{conditionId}/test")
     @Timed
     @ApiOperation("Test existing alert condition")
+    @NoAuditEvent("resource doesn't modify any data")
     public Response testExisting(@ApiParam(name = "streamId", value = "The stream ID this alert condition belongs to.", required = true)
                                  @PathParam("streamId") String streamId,
                                  @ApiParam(name = "conditionId", value = "The alert condition ID to be fetched", required = true)

--- a/graylog2-server/src/main/java/org/graylog2/rest/resources/streams/responses/AlertConditionTestResponse.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/resources/streams/responses/AlertConditionTestResponse.java
@@ -1,0 +1,70 @@
+/**
+ * This file is part of Graylog.
+ *
+ * Graylog is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.graylog2.rest.resources.streams.responses;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.auto.value.AutoValue;
+import com.google.common.collect.ImmutableList;
+
+import javax.annotation.Nullable;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Optional;
+
+@AutoValue
+public abstract class AlertConditionTestResponse {
+
+    @JsonProperty("triggered")
+    public abstract boolean triggered();
+
+    @JsonProperty("description")
+    public abstract Optional<String> description();
+
+    @JsonProperty("error")
+    public boolean error() {
+        return !errorMessages().isEmpty();
+    }
+
+    @JsonProperty("error_messages")
+    public abstract ImmutableList<ErrorMessage> errorMessages();
+
+    public static AlertConditionTestResponse create(boolean triggered, @Nullable String description) {
+        return createResult(triggered, description, Collections.emptyList());
+    }
+
+    public static AlertConditionTestResponse createWithError(Throwable t) {
+        return createResult(false, null, ImmutableList.of(ErrorMessage.create(t)));
+    }
+
+    private static AlertConditionTestResponse createResult(boolean triggered, @Nullable String description, Collection<ErrorMessage> errorMessages) {
+        return new AutoValue_AlertConditionTestResponse(triggered, Optional.ofNullable(description), ImmutableList.copyOf(errorMessages));
+    }
+    @AutoValue
+    public static abstract class ErrorMessage {
+
+        @JsonProperty("type")
+        public abstract String type();
+
+        @JsonProperty("message")
+        @Nullable
+        public abstract String message();
+        public static ErrorMessage create(Throwable t) {
+            return new AutoValue_AlertConditionTestResponse_ErrorMessage(t.getClass().getCanonicalName(), t.getMessage());
+        }
+    }
+
+}

--- a/graylog2-server/src/test/java/org/graylog2/alerts/AbstractAlertConditionTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/alerts/AbstractAlertConditionTest.java
@@ -45,17 +45,21 @@ public class AbstractAlertConditionTest extends AlertConditionTest {
         final AbstractAlertCondition condition = (AbstractAlertCondition) getDummyAlertCondition(ImmutableMap.of());
 
         assertThatThrownBy(() -> condition.buildQueryFilter(null, null))
-                .hasMessageContaining("streamId");
+                .hasMessageContaining("streamId")
+                .hasMessageContaining("be null");
         assertThatThrownBy(() -> condition.buildQueryFilter("", null))
-                .hasMessageContaining("streamId");
+                .hasMessageContaining("streamId")
+                .hasMessageContaining("be empty");
 
-        assertThat(condition.buildQueryFilter("abc123", null))
+        assertThat(condition.buildQueryFilter("  abc123 ", null))
                 .isEqualTo("streams:abc123");
         assertThat(condition.buildQueryFilter("abc123", ""))
                 .isEqualTo("streams:abc123");
         assertThat(condition.buildQueryFilter("abc123", "*"))
                 .isEqualTo("streams:abc123");
-        assertThat(condition.buildQueryFilter("abc123", "hello:world foo:\"bar baz\""))
+        assertThat(condition.buildQueryFilter("abc123", " *  "))
+                .isEqualTo("streams:abc123");
+        assertThat(condition.buildQueryFilter("abc123", " hello:world foo:\"bar baz\"   "))
                 .isEqualTo("streams:abc123 hello:world foo:\"bar baz\"");
     }
 

--- a/graylog2-server/src/test/java/org/graylog2/alerts/AbstractAlertConditionTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/alerts/AbstractAlertConditionTest.java
@@ -23,6 +23,8 @@ import org.junit.Test;
 
 import java.util.Map;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.Assert.assertEquals;
 
 public class AbstractAlertConditionTest extends AlertConditionTest {
@@ -36,6 +38,25 @@ public class AbstractAlertConditionTest extends AlertConditionTest {
         assertEquals(3, alertConditionWithStringDouble.getGrace());
         final AlertCondition alertConditionWithStringInteger = getDummyAlertCondition(ImmutableMap.of("grace", "3"));
         assertEquals(3, alertConditionWithStringInteger.getGrace());
+    }
+
+    @Test
+    public void testQueryFilterBuilder() {
+        final AbstractAlertCondition condition = (AbstractAlertCondition) getDummyAlertCondition(ImmutableMap.of());
+
+        assertThatThrownBy(() -> condition.buildQueryFilter(null, null))
+                .hasMessageContaining("streamId");
+        assertThatThrownBy(() -> condition.buildQueryFilter("", null))
+                .hasMessageContaining("streamId");
+
+        assertThat(condition.buildQueryFilter("abc123", null))
+                .isEqualTo("streams:abc123");
+        assertThat(condition.buildQueryFilter("abc123", ""))
+                .isEqualTo("streams:abc123");
+        assertThat(condition.buildQueryFilter("abc123", "*"))
+                .isEqualTo("streams:abc123");
+        assertThat(condition.buildQueryFilter("abc123", "hello:world foo:\"bar baz\""))
+                .isEqualTo("streams:abc123 hello:world foo:\"bar baz\"");
     }
 
     private AlertCondition getDummyAlertCondition(Map<String, Object> parameters) {

--- a/graylog2-server/src/test/java/org/graylog2/alerts/AbstractAlertConditionTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/alerts/AbstractAlertConditionTest.java
@@ -60,7 +60,11 @@ public class AbstractAlertConditionTest extends AlertConditionTest {
         assertThat(condition.buildQueryFilter("abc123", " *  "))
                 .isEqualTo("streams:abc123");
         assertThat(condition.buildQueryFilter("abc123", " hello:world foo:\"bar baz\"   "))
-                .isEqualTo("streams:abc123 hello:world foo:\"bar baz\"");
+                .isEqualTo("streams:abc123 AND (hello:world foo:\"bar baz\")");
+        assertThat(condition.buildQueryFilter("abc123", "hello:world AND foo:\"bar baz\""))
+                .isEqualTo("streams:abc123 AND (hello:world AND foo:\"bar baz\")");
+        assertThat(condition.buildQueryFilter("abc123", "hello:world AND (foo:\"bar baz\" OR foo:yolo)"))
+                .isEqualTo("streams:abc123 AND (hello:world AND (foo:\"bar baz\" OR foo:yolo))");
     }
 
     private AlertCondition getDummyAlertCondition(Map<String, Object> parameters) {

--- a/graylog2-server/src/test/java/org/graylog2/alerts/types/FieldContentValueAlertConditionTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/alerts/types/FieldContentValueAlertConditionTest.java
@@ -127,6 +127,7 @@ public class FieldContentValueAlertConditionTest extends AlertConditionTest {
         final int alertCheckInterval = 42;
         final RelativeRange relativeRange = RelativeRange.create(alertCheckInterval);
 
+        when(stream.getId()).thenReturn("stream-id");
         when(configuration.getAlertCheckInterval()).thenReturn(alertCheckInterval);
 
         when(searches.search(anyString(),


### PR DESCRIPTION
This exposes a new query config field in the alert condition
configuration. The value defaults to "*".

The query is used to build a filter string for the alert condition
search. We add the query string to the query filter for performance
reasons.

This PR also adds two API endpoints to test new and existing alert conditions.

Fixes #3966

**Attention:** This needs to be cherry-picked into 2.5 once merged