### PR TITLE
Prevent overwriting children's props in `IfPermitted`.

### DIFF
--- a/graylog2-web-interface/src/components/common/IfPermitted.jsx
+++ b/graylog2-web-interface/src/components/common/IfPermitted.jsx
@@ -22,7 +22,17 @@ const _checkPermissions = (permissions, anyPermissions, currentUser) => {
 
 const IfPermitted = ({ children, currentUser, permissions, anyPermissions, ...rest }) => {
   if ((!permissions || permissions.length === 0) || (currentUser && _checkPermissions(permissions, anyPermissions, currentUser))) {
-    return React.Children.map(children, child => (React.isValidElement(child) ? React.cloneElement(child, rest) : child));
+    return React.Children.map(children, (child) => {
+      if (React.isValidElement(child)) {
+        const presentProps = (child && child.props) ? Object.keys(child.props) : [];
+        // do not pass overwrite present props on child
+        const filteredRest = Object.entries(rest)
+          .filter(entry => !presentProps.includes(entry[0]))
+          .reduce((obj, [k, v]) => ({ ...obj, [k]: v }), {});
+        return React.cloneElement(child, filteredRest);
+      }
+      return child;
+    });
   }
 
   return null;

--- a/graylog2-web-interface/src/components/common/IfPermitted.jsx
+++ b/graylog2-web-interface/src/components/common/IfPermitted.jsx
@@ -25,7 +25,7 @@ const IfPermitted = ({ children, currentUser, permissions, anyPermissions, ...re
     return React.Children.map(children, (child) => {
       if (React.isValidElement(child)) {
         const presentProps = (child && child.props) ? Object.keys(child.props) : [];
-        // do not pass overwrite present props on child
+        // do not overwrite existing props
         const filteredRest = Object.entries(rest)
           .filter(entry => !presentProps.includes(entry[0]))
           .reduce((obj, [k, v]) => ({ ...obj, [k]: v }), {});

--- a/graylog2-web-interface/src/components/common/IfPermitted.test.jsx
+++ b/graylog2-web-interface/src/components/common/IfPermitted.test.jsx
@@ -165,4 +165,19 @@ describe('IfPermitted', () => {
     expect(wrapper.find(Bar)).toHaveProp('something', 42);
     expect(wrapper.find(Bar)).toHaveProp('otherProp', { foo: 'bar!' });
   });
+  it('does not pass property to children if already present', () => {
+    const Foo = mockComponent('Foo');
+    const Bar = mockComponent('Bar');
+    const wrapper = shallow((
+      <IfPermitted permissions={[]} something={42} otherProp={{ foo: 'bar!' }}>
+        <Foo something={23} />
+        <Bar otherProp={{ hello: 'world!' }} />
+      </IfPermitted>
+    ));
+
+    expect(wrapper.find(Foo)).toHaveProp('something', 23);
+    expect(wrapper.find(Foo)).toHaveProp('otherProp', { foo: 'bar!' });
+    expect(wrapper.find(Bar)).toHaveProp('something', 42);
+    expect(wrapper.find(Bar)).toHaveProp('otherProp', { hello: 'world!' });
+  });
 });


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Since #5193, `IfPermitted` passes given props to children to allow it being used in
scopes where the wrapped child(ren) is/are supposed to follow directly
after a parent component.

Unfortunately this mechanic previously did not check if the passed
property is already present on the child. This lead to a regression
where event handlers where overwritten.

This change is now checking if the given prop is present on the child
before passing it.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
