### PR TITLE
Add Bouncy Castle dependency

### DIFF
--- a/graylog2-server/pom.xml
+++ b/graylog2-server/pom.xml
@@ -320,6 +320,11 @@
             <groupId>org.hibernate</groupId>
             <artifactId>hibernate-validator</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.bouncycastle</groupId>
+            <artifactId>bcpkix-jdk15on</artifactId>
+            <version>${bouncycastle.version}</version>
+        </dependency>
 
         <!-- Logging dependencies -->
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -89,6 +89,7 @@
         <apache-directory-version>1.0.1</apache-directory-version>
         <auto-value.version>1.6.1</auto-value.version>
         <auto-value-javabean.version>1.0.0</auto-value-javabean.version>
+        <bouncycastle.version>1.60</bouncycastle.version>
         <cef-parser.version>0.0.1.10</cef-parser.version>
         <commons-codec.version>1.11</commons-codec.version>
         <commons-email.version>1.5</commons-email.version>


### PR DESCRIPTION
Having BC as a crypto provider offers several advantages over JCE.
Most importantly, it supports keys in PKCS#1 format, which is
still widely used, and the default output of `openssl genrsa`.
