### PR TITLE
Add throttling to the AWS Flow Logs/Logs inputs

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/plugin/inputs/transports/ThrottleableTransport.java
+++ b/graylog2-server/src/main/java/org/graylog2/plugin/inputs/transports/ThrottleableTransport.java
@@ -136,11 +136,22 @@ public abstract class ThrottleableTransport implements Transport {
                 return;
             }
             currentlyThrottled.set(false);
+            handleChangedThrottledState(false);
             blockLatch.countDown();
         } else if (throttled) {
             currentlyThrottled.set(true);
+            handleChangedThrottledState(true);
             blockLatch = new CountDownLatch(1);
         }
+    }
+
+    /**
+     * Transports can override this to be notified when the throttled state changes. Only called when throttled state changes.
+     *
+     * @param isThrottled the current throttled state.
+     */
+    public void handleChangedThrottledState(boolean isThrottled) {
+
     }
 
     public boolean isThrottled() {

--- a/graylog2-server/src/main/java/org/graylog2/plugin/inputs/transports/ThrottleableTransport.java
+++ b/graylog2-server/src/main/java/org/graylog2/plugin/inputs/transports/ThrottleableTransport.java
@@ -229,10 +229,12 @@ public abstract class ThrottleableTransport implements Transport {
     }
 
     /**
-     * Blocks until the blockLatch is released or until timeout is exceeded.
+     * Blocks until the blockLatch is released or until the timeout is exceeded.
      *
      * @param timeout the maximum time to wait
-     * @param unit    the time unit of the {@code timeout} argument
+     * @param unit the time unit of the {@code timeout} argument
+     * @return {@code true} if the blockLatch was released before the {@code timeout} elapsed
+     *         and {@code false} if the {@code timeout} was exceeded before the blockLatch was released.
      */
     public boolean blockUntilUnthrottled(long timeout, TimeUnit unit) {
         // sanity: if there's no latch, don't try to access it

--- a/graylog2-server/src/main/java/org/graylog2/plugin/inputs/transports/ThrottleableTransport.java
+++ b/graylog2-server/src/main/java/org/graylog2/plugin/inputs/transports/ThrottleableTransport.java
@@ -232,9 +232,9 @@ public abstract class ThrottleableTransport implements Transport {
      * Blocks until the blockLatch is released or until the timeout is exceeded.
      *
      * @param timeout the maximum time to wait
-     * @param unit the time unit of the {@code timeout} argument
-     * @return {@code true} if the blockLatch was released before the {@code timeout} elapsed
-     *         and {@code false} if the {@code timeout} was exceeded before the blockLatch was released.
+     * @param unit    the time unit for the {@code timeout} argument.
+     * @return        {@code true} if the blockLatch was released before the {@code timeout} elapsed. and
+     *                {@code false} if the {@code timeout} was exceeded before the blockLatch was released.
      */
     public boolean blockUntilUnthrottled(long timeout, TimeUnit unit) {
         // sanity: if there's no latch, don't try to access it


### PR DESCRIPTION
This change adds a few methods to ThrottlableTransport needed to support throttling in the AWS Log/FlowLogs inputs.