### PR TITLE
Improve Content Pack Constraints Overview

### DIFF
--- a/graylog2-web-interface/src/components/content-packs/ContentPackConstraints.jsx
+++ b/graylog2-web-interface/src/components/content-packs/ContentPackConstraints.jsx
@@ -20,7 +20,7 @@ class ContentPackConstraints extends React.Component {
     const constraint = item.constraint || item;
     const fulfilledIcon = item.fulfilled || this.props.isFulfilled ? <i className="fa fa-check" /> : <i className="fa fa-times" />;
     const fulfilledBg = item.fulfilled || this.props.isFulfilled ? 'success' : 'failure';
-    const name = constraint.type === "server-version" ? "Graylog" : constraint.plugin;
+    const name = constraint.type === 'server-version' ? 'Graylog' : constraint.plugin;
     return (
       <tr key={constraint.id}>
         <td>{name}</td>

--- a/graylog2-web-interface/src/components/content-packs/ContentPackConstraints.jsx
+++ b/graylog2-web-interface/src/components/content-packs/ContentPackConstraints.jsx
@@ -20,10 +20,11 @@ class ContentPackConstraints extends React.Component {
     const constraint = item.constraint || item;
     const fulfilledIcon = item.fulfilled || this.props.isFulfilled ? <i className="fa fa-check" /> : <i className="fa fa-times" />;
     const fulfilledBg = item.fulfilled || this.props.isFulfilled ? 'success' : 'failure';
+    const name = constraint.type === "server-version" ? "Graylog" : constraint.plugin;
     return (
       <tr key={constraint.id}>
+        <td>{name}</td>
         <td>{constraint.type}</td>
-        <td>{constraint.plugin}</td>
         <td>{constraint.version}</td>
         <td><Badge className={fulfilledBg}>{fulfilledIcon}</Badge></td>
       </tr>
@@ -31,7 +32,7 @@ class ContentPackConstraints extends React.Component {
   };
 
   render() {
-    const headers = ['Type', 'Plugin', 'Version', 'Fulfilled'];
+    const headers = ['Name', 'Type', 'Version', 'Fulfilled'];
     const constraints = this.props.constraints.map((constraint) => {
       const newConstraint = constraint.constraint || constraint;
       newConstraint.fulfilled = constraint.fulfilled;

--- a/graylog2-web-interface/src/components/content-packs/__snapshots__/ContentPackConstraints.test.jsx.snap
+++ b/graylog2-web-interface/src/components/content-packs/__snapshots__/ContentPackConstraints.test.jsx.snap
@@ -24,10 +24,10 @@ exports[`<ContentPackConstraints /> should render with created constraints 1`] =
             <thead>
               <tr>
                 <th>
-                  Type
+                  Name
                 </th>
                 <th>
-                  Plugin
+                  Type
                 </th>
                 <th>
                   Version
@@ -40,10 +40,10 @@ exports[`<ContentPackConstraints /> should render with created constraints 1`] =
             <tbody>
               <tr>
                 <td>
-                  plugin-version
+                  org.graylog.plugins.threatintel.ThreatIntelPlugin
                 </td>
                 <td>
-                  org.graylog.plugins.threatintel.ThreatIntelPlugin
+                  plugin-version
                 </td>
                 <td>
                   &gt;=3.0.0-alpha.2
@@ -60,9 +60,11 @@ exports[`<ContentPackConstraints /> should render with created constraints 1`] =
               </tr>
               <tr>
                 <td>
+                  Graylog
+                </td>
+                <td>
                   server-version
                 </td>
-                <td />
                 <td>
                   &gt;=3.0.0-alpha.2+af8d8e0
                 </td>
@@ -109,10 +111,10 @@ exports[`<ContentPackConstraints /> should render with new constraints with forc
             <thead>
               <tr>
                 <th>
-                  Type
+                  Name
                 </th>
                 <th>
-                  Plugin
+                  Type
                 </th>
                 <th>
                   Version
@@ -125,10 +127,10 @@ exports[`<ContentPackConstraints /> should render with new constraints with forc
             <tbody>
               <tr>
                 <td>
-                  plugin-version
+                  org.graylog.plugins.threatintel.ThreatIntelPlugin
                 </td>
                 <td>
-                  org.graylog.plugins.threatintel.ThreatIntelPlugin
+                  plugin-version
                 </td>
                 <td>
                   &gt;=3.0.0-alpha.2
@@ -145,9 +147,11 @@ exports[`<ContentPackConstraints /> should render with new constraints with forc
               </tr>
               <tr>
                 <td>
+                  Graylog
+                </td>
+                <td>
                   server-version
                 </td>
-                <td />
                 <td>
                   &gt;=3.0.0-alpha.2+af8d8e0
                 </td>
@@ -194,10 +198,10 @@ exports[`<ContentPackConstraints /> should render with new constraints without f
             <thead>
               <tr>
                 <th>
-                  Type
+                  Name
                 </th>
                 <th>
-                  Plugin
+                  Type
                 </th>
                 <th>
                   Version
@@ -210,10 +214,10 @@ exports[`<ContentPackConstraints /> should render with new constraints without f
             <tbody>
               <tr>
                 <td>
-                  plugin-version
+                  org.graylog.plugins.threatintel.ThreatIntelPlugin
                 </td>
                 <td>
-                  org.graylog.plugins.threatintel.ThreatIntelPlugin
+                  plugin-version
                 </td>
                 <td>
                   &gt;=3.0.0-alpha.2
@@ -230,9 +234,11 @@ exports[`<ContentPackConstraints /> should render with new constraints without f
               </tr>
               <tr>
                 <td>
+                  Graylog
+                </td>
+                <td>
                   server-version
                 </td>
-                <td />
                 <td>
                   &gt;=3.0.0-alpha.2+af8d8e0
                 </td>


### PR DESCRIPTION
## Description
Rename `plugin` column to `name` and default "Graylog" for the server-version.
 
## Motivation and Context
The Constraints overview did have some ascetic drawbacks. The plugin column was always empty for the server.

Fixes #5217 

## Screenshots (if appropriate):
![graylog - content packs 4](https://user-images.githubusercontent.com/448763/47088952-ffaac180-d21f-11e8-83fb-33a9a34d70a2.png)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
