### PR TITLE
Prevent content packs to be deleted if installations exists

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/rest/resources/system/contentpacks/ContentPackResource.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/resources/system/contentpacks/ContentPackResource.java
@@ -221,7 +221,7 @@ public class ContentPackResource extends RestResource {
             @ApiParam(name = "contentPackId", value = "Content Pack ID", required = true)
             @PathParam("contentPackId") final ModelId contentPackId) {
         checkPermission(RestPermissions.CONTENT_PACK_DELETE, contentPackId.toString());
-        if (contentPackInstallationPersistenceService.findByContentPackId(contentPackId).size() > 0) {
+        if (!contentPackInstallationPersistenceService.findByContentPackId(contentPackId).isEmpty()) {
                throw new BadRequestException("Content pack " + contentPackId +
                        " with all his revisions can't be deleted: There are still installations of this content pack");
         }

--- a/graylog2-server/src/main/java/org/graylog2/rest/resources/system/contentpacks/ContentPackResource.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/resources/system/contentpacks/ContentPackResource.java
@@ -221,6 +221,10 @@ public class ContentPackResource extends RestResource {
             @ApiParam(name = "contentPackId", value = "Content Pack ID", required = true)
             @PathParam("contentPackId") final ModelId contentPackId) {
         checkPermission(RestPermissions.CONTENT_PACK_DELETE, contentPackId.toString());
+        if (contentPackInstallationPersistenceService.findByContentPackId(contentPackId).size() > 0) {
+               throw new BadRequestException("Content pack " + contentPackId +
+                       " with all his revisions can't be deleted: There are still installations of this content pack");
+        }
         final int deleted = contentPackPersistenceService.deleteById(contentPackId);
 
         LOG.debug("Deleted {} content packs with id {}", deleted, contentPackId);
@@ -242,6 +246,12 @@ public class ContentPackResource extends RestResource {
             @ApiParam(name = "revision", value = "Content Pack revision", required = true)
             @PathParam("revision") final int revision) {
         checkPermission(RestPermissions.CONTENT_PACK_DELETE, contentPackId.toString());
+
+        if (contentPackInstallationPersistenceService.findByContentPackIdAndRevision(contentPackId, revision).size() > 0) {
+            throw new BadRequestException("Content pack " + contentPackId + " and Revision " + revision +
+                    " can't be deleted: There are still installations of this content packs revision.");
+        }
+
         final int deleted = contentPackPersistenceService.deleteByIdAndRevision(contentPackId, revision);
 
         LOG.debug("Deleted {} content packs with id {} and revision", deleted, contentPackId, revision);

--- a/graylog2-server/src/main/java/org/graylog2/rest/resources/system/contentpacks/ContentPackResource.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/resources/system/contentpacks/ContentPackResource.java
@@ -248,7 +248,7 @@ public class ContentPackResource extends RestResource {
         checkPermission(RestPermissions.CONTENT_PACK_DELETE, contentPackId.toString());
 
         if (!contentPackInstallationPersistenceService.findByContentPackIdAndRevision(contentPackId, revision).isEmpty()) {
-            throw new BadRequestException("Content pack " + contentPackId + " and Revision " + revision +
+            throw new BadRequestException("Content pack " + contentPackId + " and revision " + revision +
                     " can't be deleted: There are still installations of this content packs revision.");
         }
 

--- a/graylog2-server/src/main/java/org/graylog2/rest/resources/system/contentpacks/ContentPackResource.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/resources/system/contentpacks/ContentPackResource.java
@@ -223,7 +223,7 @@ public class ContentPackResource extends RestResource {
         checkPermission(RestPermissions.CONTENT_PACK_DELETE, contentPackId.toString());
         if (!contentPackInstallationPersistenceService.findByContentPackId(contentPackId).isEmpty()) {
                throw new BadRequestException("Content pack " + contentPackId +
-                       " with all his revisions can't be deleted: There are still installations of this content pack");
+                       " with all its revisions can't be deleted: There are still installations of this content pack");
         }
         final int deleted = contentPackPersistenceService.deleteById(contentPackId);
 

--- a/graylog2-server/src/main/java/org/graylog2/rest/resources/system/contentpacks/ContentPackResource.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/resources/system/contentpacks/ContentPackResource.java
@@ -247,7 +247,7 @@ public class ContentPackResource extends RestResource {
             @PathParam("revision") final int revision) {
         checkPermission(RestPermissions.CONTENT_PACK_DELETE, contentPackId.toString());
 
-        if (contentPackInstallationPersistenceService.findByContentPackIdAndRevision(contentPackId, revision).size() > 0) {
+        if (!contentPackInstallationPersistenceService.findByContentPackIdAndRevision(contentPackId, revision).isEmpty()) {
             throw new BadRequestException("Content pack " + contentPackId + " and Revision " + revision +
                     " can't be deleted: There are still installations of this content packs revision.");
         }

--- a/graylog2-server/src/main/java/org/graylog2/rest/resources/system/contentpacks/ContentPackResource.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/resources/system/contentpacks/ContentPackResource.java
@@ -249,7 +249,7 @@ public class ContentPackResource extends RestResource {
 
         if (!contentPackInstallationPersistenceService.findByContentPackIdAndRevision(contentPackId, revision).isEmpty()) {
             throw new BadRequestException("Content pack " + contentPackId + " and revision " + revision +
-                    " can't be deleted: There are still installations of this content packs revision.");
+                    " can't be deleted: There are still installations of this content pack revision.");
         }
 
         final int deleted = contentPackPersistenceService.deleteByIdAndRevision(contentPackId, revision);

--- a/graylog2-web-interface/src/pages/ContentPacksPage.jsx
+++ b/graylog2-web-interface/src/pages/ContentPacksPage.jsx
@@ -27,8 +27,15 @@ const ContentPacksPage = createReactClass({
       ContentPacksActions.delete(contentPackId).then(() => {
         UserNotification.success('Content Pack deleted successfully.', 'Success');
         ContentPacksActions.list();
-      }, () => {
-        UserNotification.error('Deleting bundle failed, please check your logs for more information.', 'Error');
+      }, (error) => {
+        /* eslint-disable camelcase */
+        let err_message = error.message;
+        const err_body = error.additional.body;
+        /* eslint-enable camlecase */
+        if (err_body && err_body.message) {
+          err_message = error.additional.body.message;
+        }
+        UserNotification.error(`Deleting bundle failed: ${err_message}`, 'Error');
       });
     }
   },

--- a/graylog2-web-interface/src/pages/ShowContentPackPage.jsx
+++ b/graylog2-web-interface/src/pages/ShowContentPackPage.jsx
@@ -48,8 +48,15 @@ const ShowContentPackPage = createReactClass({
       ContentPacksActions.deleteRev(contentPackId, revision).then(() => {
         UserNotification.success('Content Pack deleted successfully.', 'Success');
         ContentPacksActions.get(contentPackId);
-      }, () => {
-        UserNotification.error('Deleting content pack failed, please check your logs for more information.', 'Error');
+      }, (error) => {
+        /* eslint-disable camelcase */
+        let err_message = error.message;
+        const err_body = error.additional.body;
+        /* eslint-enable camlecase */
+        if (err_body && err_body.message) {
+          err_message = error.additional.body.message;
+        }
+        UserNotification.error(`Deleting bundle failed: ${err_message}`, 'Error');
       });
     }
   },


### PR DESCRIPTION
## Description
Prevent deletion of content packs when installations of the content packs exists.

## Motivation and Context
If the user deletes a content pack with installed entities, he will no be able to uninstall
the content pack entities after he deleted the content pack.

## How Has This Been Tested?
Created, installed, deleted (which failed), uninstalled, deleted.

## Screenshots (if appropriate):
![graylog - content packs 5](https://user-images.githubusercontent.com/448763/47219993-bb026000-d3b0-11e8-8b59-069c8402e556.png)

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
