### PR TITLE
Allow trailing comma in Gelf JSON parser

### DIFF
--- a/graylog2-server/src/main/java/org/graylog/plugins/beats/Beats2Codec.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/beats/Beats2Codec.java
@@ -74,6 +74,11 @@ public class Beats2Codec extends AbstractCodec {
             return null;
         }
 
+        // Adhere to the legacy behaviour
+        if (event == null) {
+            return null;
+        }
+
         return parseEvent(event);
     }
 

--- a/graylog2-server/src/main/java/org/graylog2/inputs/codecs/GelfCodec.java
+++ b/graylog2-server/src/main/java/org/graylog2/inputs/codecs/GelfCodec.java
@@ -62,7 +62,9 @@ public class GelfCodec extends AbstractCodec {
     public GelfCodec(@Assisted Configuration configuration, GelfChunkAggregator aggregator) {
         super(configuration);
         this.aggregator = aggregator;
-        this.objectMapper = new ObjectMapper().enable(JsonParser.Feature.ALLOW_UNQUOTED_CONTROL_CHARS);
+        this.objectMapper = new ObjectMapper().enable(
+            JsonParser.Feature.ALLOW_UNQUOTED_CONTROL_CHARS,
+            JsonParser.Feature.ALLOW_TRAILING_COMMA);
         this.decompressSizeLimit = configuration.getInt(CK_DECOMPRESS_SIZE_LIMIT, DEFAULT_DECOMPRESS_SIZE_LIMIT);
     }
 

--- a/graylog2-server/src/test/java/org/graylog2/contentpacks/jackson/ValueTypeDeserializerTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/contentpacks/jackson/ValueTypeDeserializerTest.java
@@ -40,10 +40,10 @@ public class ValueTypeDeserializerTest {
         assertThat(objectMapper.readValue("\"parameter\"", ValueType.class)).isEqualTo(ValueType.PARAMETER);
         assertThatThrownBy(() -> objectMapper.readValue("\"\"", ValueType.class))
                 .isInstanceOf(JsonMappingException.class)
-                .hasMessageStartingWith("Can not deserialize value of type org.graylog2.contentpacks.model.entities.references.ValueType from String \"\": No enum constant org.graylog2.contentpacks.model.entities.references.ValueType");
+                .hasMessageStartingWith("Cannot deserialize value of type `org.graylog2.contentpacks.model.entities.references.ValueType` from String \"\": No enum constant org.graylog2.contentpacks.model.entities.references.ValueType");
         assertThatThrownBy(() -> objectMapper.readValue("\"UNKNOWN\"", ValueType.class))
                 .isInstanceOf(JsonMappingException.class)
-                .hasMessageStartingWith("Can not deserialize value of type org.graylog2.contentpacks.model.entities.references.ValueType from String \"UNKNOWN\": No enum constant org.graylog2.contentpacks.model.entities.references.ValueType");
+                .hasMessageStartingWith("Cannot deserialize value of type `org.graylog2.contentpacks.model.entities.references.ValueType` from String \"UNKNOWN\": No enum constant org.graylog2.contentpacks.model.entities.references.ValueType");
         assertThatThrownBy(() -> objectMapper.readValue("0", ValueType.class))
                 .isInstanceOf(JsonMappingException.class)
                 .hasMessageStartingWith("Unexpected token (VALUE_NUMBER_INT), expected VALUE_STRING: expected String");

--- a/graylog2-server/src/test/java/org/graylog2/inputs/codecs/GelfCodecTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/inputs/codecs/GelfCodecTest.java
@@ -378,6 +378,12 @@ public class GelfCodecTest {
     }
 
     @Test
+    public void decodeSucceedsWithTrailingComma() throws Exception {
+        assertThat(codec.decode(new RawMessage("{\"short_message\":\"0\",}".getBytes(StandardCharsets.UTF_8)))).isNotNull();
+        assertThat(codec.decode(new RawMessage("{\"message\":\"0\",}".getBytes(StandardCharsets.UTF_8)))).isNotNull();
+    }
+
+    @Test
     public void decodeSucceedsWithValidTimestampIssue4027() throws Exception {
         // https://github.com/Graylog2/graylog2-server/issues/4027
         final String json = "{"

--- a/pom.xml
+++ b/pom.xml
@@ -106,7 +106,7 @@
         <HdrHistogram.version>2.1.10</HdrHistogram.version>
         <hibernate-validator.version>6.0.10.Final</hibernate-validator.version>
         <hk2.version>2.5.0-b32</hk2.version> <!-- The HK2 version should match the version being used by Jersey -->
-        <jackson.version>2.8.11.20180608</jackson.version>
+        <jackson.version>2.9.7</jackson.version>
         <jadconfig.version>0.13.0</jadconfig.version>
         <java-semver.version>0.9.0</java-semver.version>
         <javapoet.version>1.11.1</javapoet.version>


### PR DESCRIPTION
## Description
- Upgrade to Jackson 2.9.7 (with tests fixed)
- Enable `ALLOW_TRAILING_COMMA` JSON parser feature in `GelfCodec`

## Motivation and Context
Graylog 0.10.x (LOL) used to be less stringent on JSON produced by early `gelfj` library and accepted trailing commas. The behavior changed in more recent Graylog releases which makes it impossible to upgrade Graylog seamlessly within existing installations with misbehaving `gelfj` serializers emitting trailing commas into JSON.

## How Has This Been Tested?
Added `GelfCodecTest.decodeSucceedsWithTrailingComma()` unit test.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.