### PR TITLE
Update netty to 4.1.31

### DIFF
--- a/graylog2-server/src/test/java/org/graylog2/plugin/inputs/util/ConnectionCounterTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/plugin/inputs/util/ConnectionCounterTest.java
@@ -22,6 +22,9 @@ import io.netty.buffer.Unpooled;
 import io.netty.channel.Channel;
 import io.netty.channel.ChannelFuture;
 import io.netty.channel.ChannelFutureListener;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.ChannelInboundHandlerAdapter;
+import io.netty.channel.ChannelInitializer;
 import io.netty.channel.EventLoopGroup;
 import io.netty.channel.nio.NioEventLoopGroup;
 import io.netty.channel.socket.nio.NioServerSocketChannel;
@@ -32,6 +35,7 @@ import org.junit.Before;
 import org.junit.Test;
 
 import java.net.InetAddress;
+import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
@@ -39,18 +43,46 @@ import java.util.concurrent.atomic.AtomicLong;
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class ConnectionCounterTest {
+    private static final int LATCH_TIMEOUT = 30;
+
     private ConnectionCounter connectionCounter;
     private NioEventLoopGroup eventLoopGroup;
     private Channel serverChannel;
+    private CountDownLatch readCompleteLatch;
+    private CountDownLatch disconnectedLatch;
 
     @Before
     public void setUp() throws Exception {
+        readCompleteLatch = new CountDownLatch(1);
+        disconnectedLatch = new CountDownLatch(1);
         connectionCounter = new ConnectionCounter(new AtomicInteger(), new AtomicLong());
         eventLoopGroup = new NioEventLoopGroup(1);
         final ServerBootstrap serverBootstrap = new ServerBootstrap()
                 .group(eventLoopGroup)
                 .channel(NioServerSocketChannel.class)
-                .childHandler(connectionCounter);
+                .childHandler(new ChannelInitializer<Channel>() {
+                    @Override
+                    protected void initChannel(Channel ch) {
+                        ch.pipeline().addFirst("connection-counter", connectionCounter);
+
+                        // This adds some latches to allow us to wait until the server processed our connection.
+                        // Without this, this test was failing from time to time because we checked the connection
+                        // counter values before the connection was actually processed.
+                        ch.pipeline().addLast("latches", new ChannelInboundHandlerAdapter() {
+                            @Override
+                            public void channelUnregistered(ChannelHandlerContext ctx) throws Exception {
+                                disconnectedLatch.countDown();
+                                super.channelUnregistered(ctx);
+                            }
+
+                            @Override
+                            public void channelReadComplete(ChannelHandlerContext ctx) throws Exception {
+                                readCompleteLatch.countDown();
+                                super.channelReadComplete(ctx);
+                            }
+                        });
+                    }
+                });
 
         serverBootstrap.bind(InetAddress.getLocalHost(), 0)
                 .addListener((ChannelFutureListener) future -> serverChannel = future.channel())
@@ -81,7 +113,11 @@ public class ConnectionCounterTest {
             final Channel clientChannel = connectFuture.channel();
 
             assertThat(clientChannel.isWritable()).isTrue();
-            clientChannel.writeAndFlush(Unpooled.EMPTY_BUFFER).syncUninterruptibly();
+            // We have to send a message here to make sure that channelReadComplete gets called in the handler
+            clientChannel.writeAndFlush(Unpooled.wrappedBuffer("canary".getBytes())).syncUninterruptibly();
+
+            // Wait until the server read the message
+            readCompleteLatch.await(LATCH_TIMEOUT, TimeUnit.SECONDS);
 
             // One client active
             assertThat(connectionCounter.getTotalConnections()).isEqualTo(1L);
@@ -92,6 +128,9 @@ public class ConnectionCounterTest {
             clientEventLoopGroup.shutdownGracefully();
             clientEventLoopGroup.awaitTermination(1, TimeUnit.SECONDS);
         }
+
+        // Wait until the client has disconnected
+        disconnectedLatch.await(LATCH_TIMEOUT, TimeUnit.SECONDS);
 
         // No client, but 1 connection so far
         assertThat(connectionCounter.getTotalConnections()).isEqualTo(1L);

--- a/graylog2-server/src/test/java/org/graylog2/plugin/inputs/util/ConnectionCounterTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/plugin/inputs/util/ConnectionCounterTest.java
@@ -35,6 +35,7 @@ import org.junit.Before;
 import org.junit.Test;
 
 import java.net.InetAddress;
+import java.nio.charset.StandardCharsets;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -114,7 +115,7 @@ public class ConnectionCounterTest {
 
             assertThat(clientChannel.isWritable()).isTrue();
             // We have to send a message here to make sure that channelReadComplete gets called in the handler
-            clientChannel.writeAndFlush(Unpooled.wrappedBuffer("canary".getBytes())).syncUninterruptibly();
+            clientChannel.writeAndFlush(Unpooled.wrappedBuffer("canary".getBytes(StandardCharsets.UTF_8))).syncUninterruptibly();
 
             // Wait until the server read the message
             readCompleteLatch.await(LATCH_TIMEOUT, TimeUnit.SECONDS);

--- a/pom.xml
+++ b/pom.xml
@@ -127,7 +127,7 @@
         <mongodb-driver.version>3.6.4</mongodb-driver.version>
         <mongojack.version>2.8.2</mongojack.version>
         <natty.version>0.13</natty.version>
-        <netty.version>4.1.30.Final</netty.version>
+        <netty.version>4.1.31.Final</netty.version>
         <netty-tcnative-boringssl-static.version>2.0.12.Final</netty-tcnative-boringssl-static.version>
         <okhttp.version>3.11.0</okhttp.version>
         <opencsv.version>2.3</opencsv.version>


### PR DESCRIPTION
This updates netty to version 4.1.31.

Changelog: https://netty.io/news/2018/10/30/4-1-31-Final.html

We are currently running into the following test failure from time to time since we updated from 4.1.27 to 4.1.30.

```
[ERROR] Tests run: 1, Failures: 1, Errors: 0, Skipped: 0, Time elapsed: 1.081 s <<< FAILURE! - in org.graylog2.plugin.inputs.util.ConnectionCounterTest
[ERROR] testConnectAndDisconnect(org.graylog2.plugin.inputs.util.ConnectionCounterTest)  Time elapsed: 1.077 s  <<< FAILURE!
org.junit.ComparisonFailure: expected:<[1]L> but was:<[0]L>
	at org.graylog2.plugin.inputs.util.ConnectionCounterTest.testConnectAndDisconnect(ConnectionCounterTest.java:87)
```

I hope this update with fix that. If not, we have to investigate.