### PR TITLE
Log exception when handling generic exception in field types poller.

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/indexer/fieldtypes/IndexFieldTypePollerPeriodical.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/fieldtypes/IndexFieldTypePollerPeriodical.java
@@ -46,7 +46,6 @@ import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
-import java.util.stream.Collectors;
 
 /**
  * {@link Periodical} that creates and maintains index field type information in the database.
@@ -210,7 +209,7 @@ public class IndexFieldTypePollerPeriodical extends Periodical {
             } catch (TooManyAliasesException e) {
                 LOG.error("Couldn't get active write index", e);
             } catch (Exception e) {
-                LOG.error("Couldn't update field types for index set <{}/{}>", indexSetTitle, indexSetId);
+                LOG.error("Couldn't update field types for index set <{}/{}>", indexSetTitle, indexSetId, e);
             }
         }, 0, refreshInterval.getMillis(), TimeUnit.MILLISECONDS);
 


### PR DESCRIPTION
This change is logging the generic exception that is caught in the field types poller periodical, so a useful message is logged instead of a non-helpful one that signals an error, but does not explain what
happened.
