### PR TITLE
Fix collector name validator when called on itself

### DIFF
--- a/graylog2-server/src/main/java/org/graylog/plugins/sidecar/rest/resources/CollectorResource.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/sidecar/rest/resources/CollectorResource.java
@@ -243,8 +243,15 @@ public class CollectorResource extends RestResource implements PluginRestResourc
     @RequiresPermissions(SidecarRestPermissions.CONFIGURATIONS_READ)
     @Produces(MediaType.APPLICATION_JSON)
     @ApiOperation(value = "Validates collector name")
-    public ValidationResponse validateCollector(@ApiParam(name = "name", required = true) @QueryParam("name") String name) {
-        final Collector collector = collectorService.findByName(name);
+    public ValidationResponse validateCollector(
+            @ApiParam(name = "name", required = true) @QueryParam("name") String name,
+            @ApiParam(name = "id", required = false) @QueryParam("id") String id) {
+        final Collector collector;
+        if (id == null) {
+            collector = collectorService.findByName(name);
+        } else {
+            collector = collectorService.findByNameExcludeId(name, id);
+        }
         if (collector == null) {
             return ValidationResponse.create(false, null);
         }

--- a/graylog2-server/src/main/java/org/graylog/plugins/sidecar/services/CollectorService.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/sidecar/services/CollectorService.java
@@ -53,6 +53,15 @@ public class CollectorService extends PaginatedDbService<Collector> {
         return db.findOne(DBQuery.is("name", name));
     }
 
+    @Nullable
+    public Collector findByNameExcludeId(String name, String id) {
+        return db.findOne(
+                DBQuery.and(
+                    DBQuery.is("name", name),
+                    DBQuery.notEquals("_id", id))
+        );
+    }
+
     public long count() {
         return db.count();
     }

--- a/graylog2-web-interface/src/components/sidecars/configuration-forms/CollectorForm.jsx
+++ b/graylog2-web-interface/src/components/sidecars/configuration-forms/CollectorForm.jsx
@@ -83,7 +83,7 @@ const CollectorForm = createReactClass({
   _onNameChange(event) {
     const nextName = event.target.value;
     this._formDataUpdate('name')(nextName);
-    CollectorsActions.validate(nextName).then(validation => (
+    CollectorsActions.validate(nextName, this.props.collector.id).then(validation => (
       this.setState({ error: validation.error, error_message: validation.error_message })
     ));
   },

--- a/graylog2-web-interface/src/stores/sidecars/CollectorsStore.js
+++ b/graylog2-web-interface/src/stores/sidecars/CollectorsStore.js
@@ -178,11 +178,15 @@ const CollectorsStore = Reflux.createStore({
   },
 
   validate(name, collectorId) {
-    let url = `${this.sourceUrl}/collectors/validate/?name=${name}`;
+    const search = {
+      name: name,
+    };
     if (collectorId) {
-      url += `&id=${collectorId}`;
+      search.id = collectorId;
     }
+    const url = URI(`${this.sourceUrl}/collectors/validate`).search(search).toString();
     const promise = fetch('GET', URLUtils.qualifyUrl(url));
+
     promise
       .then(
         response => response,

--- a/graylog2-web-interface/src/stores/sidecars/CollectorsStore.js
+++ b/graylog2-web-interface/src/stores/sidecars/CollectorsStore.js
@@ -177,8 +177,12 @@ const CollectorsStore = Reflux.createStore({
     CollectorsActions.copy.promise(promise);
   },
 
-  validate(name) {
-    const promise = fetch('GET', URLUtils.qualifyUrl(`${this.sourceUrl}/collectors/validate/?name=${name}`));
+  validate(name, collectorId) {
+    let url = `${this.sourceUrl}/collectors/validate/?name=${name}`;
+    if (collectorId) {
+      url += `&id=${collectorId}`;
+    }
+    const promise = fetch('GET', URLUtils.qualifyUrl(url));
     promise
       .then(
         response => response,


### PR DESCRIPTION
If a sidecar collector name is edited on an existing
collector and then changed back to its original name,
the validation would falsely claim that this collector
already exists.
We need to exclude ourself from the query.
