### PR TITLE
support for decimal IPv4 representation in to_ip

### DIFF
--- a/graylog2-server/src/main/java/org/graylog/plugins/pipelineprocessor/functions/ips/IpAddressConversion.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/pipelineprocessor/functions/ips/IpAddressConversion.java
@@ -46,6 +46,7 @@ public class IpAddressConversion extends AbstractFunction<IpAddress> {
         final Object ip = ipParam.required(args, context);
         try {
             if (ip instanceof Number) {
+                // this is only valid for IPv4 addresses, v6 requires 128 bits which we don't support
                 return new IpAddress(InetAddresses.fromInteger(((Number) ip).intValue()));
             } else {
                 return new IpAddress(InetAddresses.forString(String.valueOf(ip)));

--- a/graylog2-server/src/main/java/org/graylog/plugins/pipelineprocessor/functions/ips/IpAddressConversion.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/pipelineprocessor/functions/ips/IpAddressConversion.java
@@ -16,18 +16,17 @@
  */
 package org.graylog.plugins.pipelineprocessor.functions.ips;
 
+import static com.google.common.collect.ImmutableList.of;
+
 import com.google.common.net.InetAddresses;
+import java.net.InetAddress;
+import java.util.IllegalFormatException;
+import java.util.Optional;
 import org.graylog.plugins.pipelineprocessor.EvaluationContext;
 import org.graylog.plugins.pipelineprocessor.ast.functions.AbstractFunction;
 import org.graylog.plugins.pipelineprocessor.ast.functions.FunctionArgs;
 import org.graylog.plugins.pipelineprocessor.ast.functions.FunctionDescriptor;
 import org.graylog.plugins.pipelineprocessor.ast.functions.ParameterDescriptor;
-
-import java.net.InetAddress;
-import java.util.IllegalFormatException;
-import java.util.Optional;
-
-import static com.google.common.collect.ImmutableList.of;
 
 public class IpAddressConversion extends AbstractFunction<IpAddress> {
 
@@ -44,11 +43,13 @@ public class IpAddressConversion extends AbstractFunction<IpAddress> {
 
     @Override
     public IpAddress evaluate(FunctionArgs args, EvaluationContext context) {
-        final String ipString = String.valueOf(ipParam.required(args, context));
-
+        final Object ip = ipParam.required(args, context);
         try {
-            final InetAddress inetAddress = InetAddresses.forString(ipString);
-            return new IpAddress(inetAddress);
+            if (ip instanceof Number) {
+                return new IpAddress(InetAddresses.fromInteger(((Number) ip).intValue()));
+            } else {
+                return new IpAddress(InetAddresses.forString(String.valueOf(ip)));
+            }
         } catch (IllegalArgumentException e) {
             final Optional<String> defaultValue = defaultParam.optional(args, context);
             if (!defaultValue.isPresent()) {

--- a/graylog2-server/src/test/java/org/graylog/plugins/pipelineprocessor/functions/FunctionsSnippetsTest.java
+++ b/graylog2-server/src/test/java/org/graylog/plugins/pipelineprocessor/functions/FunctionsSnippetsTest.java
@@ -16,6 +16,14 @@
  */
 package org.graylog.plugins.pipelineprocessor.functions;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.fail;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Iterables;
@@ -23,6 +31,12 @@ import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
 import com.google.common.eventbus.EventBus;
 import com.google.common.net.InetAddresses;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.Executors;
+import javax.inject.Provider;
 import org.graylog.plugins.pipelineprocessor.BaseParserTest;
 import org.graylog.plugins.pipelineprocessor.EvaluationContext;
 import org.graylog.plugins.pipelineprocessor.ast.Rule;
@@ -139,21 +153,6 @@ import org.joda.time.Period;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import org.mockito.ArgumentMatchers;
-
-import javax.inject.Provider;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.Map;
-import java.util.Set;
-import java.util.concurrent.Executors;
-
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.fail;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
-import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
 
 public class FunctionsSnippetsTest extends BaseParserTest {
 
@@ -958,5 +957,13 @@ public class FunctionsSnippetsTest extends BaseParserTest {
 
         assertThat(message).isNotNull();
         assertThat(message.getStreams()).containsOnly(defaultStream);
+    }
+
+    @Test
+    public void int2ipv4() {
+        final Rule rule = parser.parseRule(ruleForTest(), true);
+        evaluateRule(rule);
+
+        assertThat(actionsTriggered.get()).isTrue();
     }
 }

--- a/graylog2-server/src/test/resources/org/graylog/plugins/pipelineprocessor/functions/int2ipv4.txt
+++ b/graylog2-server/src/test/resources/org/graylog/plugins/pipelineprocessor/functions/int2ipv4.txt
@@ -1,0 +1,5 @@
+rule "int2ipv4"
+when to_ip("8.8.8.8") == to_ip(134744072)
+then
+   trigger_test();
+end


### PR DESCRIPTION
if the argument is a number, try to convert its intValue into an IP address
otherwise the previous behavior of taking the string value and converting that applies

fixes #5268
