### PR TITLE
Backport DNS Lookup adapter to version 2.5

### DIFF
--- a/graylog.conf
+++ b/graylog.conf
@@ -1,0 +1,586 @@
+############################
+# GRAYLOG CONFIGURATION FILE
+############################
+#
+# This is the Graylog configuration file. The file has to use ISO 8859-1/Latin-1 character encoding.
+# Characters that cannot be directly represented in this encoding can be written using Unicode escapes
+# as defined in https://docs.oracle.com/javase/specs/jls/se8/html/jls-3.html#jls-3.3, using the \u prefix.
+# For example, \u002c.
+# 
+# * Entries are generally expected to be a single line of the form, one of the following:
+#
+# propertyName=propertyValue
+# propertyName:propertyValue
+#
+# * White space that appears between the property name and property value is ignored,
+#   so the following are equivalent:
+# 
+# name=Stephen
+# name = Stephen
+#
+# * White space at the beginning of the line is also ignored.
+#
+# * Lines that start with the comment characters ! or # are ignored. Blank lines are also ignored.
+#
+# * The property value is generally terminated by the end of the line. White space following the
+#   property value is not ignored, and is treated as part of the property value.
+#
+# * A property value can span several lines if each line is terminated by a backslash (‘\’) character.
+#   For example:
+#
+# targetCities=\
+#         Detroit,\
+#         Chicago,\
+#         Los Angeles
+#
+#   This is equivalent to targetCities=Detroit,Chicago,Los Angeles (white space at the beginning of lines is ignored).
+# 
+# * The characters newline, carriage return, and tab can be inserted with characters \n, \r, and \t, respectively.
+# 
+# * The backslash character must be escaped as a double backslash. For example:
+# 
+# path=c:\\docs\\doc1
+#
+
+# If you are running more than one instances of Graylog server you have to select one of these
+# instances as master. The master will perform some periodical tasks that non-masters won't perform.
+is_master = true
+
+# The auto-generated node ID will be stored in this file and read after restarts. It is a good idea
+# to use an absolute file path here if you are starting Graylog server from init scripts or similar.
+node_id_file = /etc/graylog/server/node-id
+
+# You MUST set a secret to secure/pepper the stored user passwords here. Use at least 64 characters.
+# Generate one by using for example: pwgen -N 1 -s 96
+password_secret =
+
+# The default root user is named 'admin'
+#root_username = admin
+
+# You MUST specify a hash password for the root user (which you only need to initially set up the
+# system and in case you lose connectivity to your authentication backend)
+# This password cannot be changed using the API or via the web interface. If you need to change it,
+# modify it in this file.
+# Create one by using for example: echo -n yourpassword | shasum -a 256
+# and put the resulting hash value into the following line
+root_password_sha2 =
+
+# The email address of the root user.
+# Default is empty
+#root_email = ""
+
+# The time zone setting of the root user. See http://www.joda.org/joda-time/timezones.html for a list of valid time zones.
+# Default is UTC
+#root_timezone = UTC
+
+# Set plugin directory here (relative or absolute)
+plugin_dir = plugin
+
+# REST API listen URI. Must be reachable by other Graylog server nodes if you run a cluster.
+# When using Graylog Collectors, this URI will be used to receive heartbeat messages and must be accessible for all collectors.
+rest_listen_uri = http://127.0.0.1:9000/api/
+
+# REST API transport address. Defaults to the value of rest_listen_uri. Exception: If rest_listen_uri
+# is set to a wildcard IP address (0.0.0.0) the first non-loopback IPv4 system address is used.
+# If set, this will be promoted in the cluster discovery APIs, so other nodes may try to connect on
+# this address and it is used to generate URLs addressing entities in the REST API. (see rest_listen_uri)
+# You will need to define this, if your Graylog server is running behind a HTTP proxy that is rewriting
+# the scheme, host name or URI.
+# This must not contain a wildcard address (0.0.0.0).
+#rest_transport_uri = http://192.168.1.1:9000/api/
+
+# Enable CORS headers for REST API. This is necessary for JS-clients accessing the server directly.
+# If these are disabled, modern browsers will not be able to retrieve resources from the server.
+# This is enabled by default. Uncomment the next line to disable it.
+#rest_enable_cors = false
+
+# Enable GZIP support for REST API. This compresses API responses and therefore helps to reduce
+# overall round trip times. This is enabled by default. Uncomment the next line to disable it.
+#rest_enable_gzip = false
+
+# Enable HTTPS support for the REST API. This secures the communication with the REST API with
+# TLS to prevent request forgery and eavesdropping. This is disabled by default. Uncomment the
+# next line to enable it.
+#rest_enable_tls = true
+
+# The X.509 certificate chain file in PEM format to use for securing the REST API.
+#rest_tls_cert_file = /path/to/graylog.crt
+
+# The PKCS#8 private key file in PEM format to use for securing the REST API.
+#rest_tls_key_file = /path/to/graylog.key
+
+# The password to unlock the private key used for securing the REST API.
+#rest_tls_key_password = secret
+
+# The maximum size of the HTTP request headers in bytes.
+#rest_max_header_size = 8192
+
+# The size of the thread pool used exclusively for serving the REST API.
+#rest_thread_pool_size = 16
+
+# Comma separated list of trusted proxies that are allowed to set the client address with X-Forwarded-For
+# header. May be subnets, or hosts.
+#trusted_proxies = 127.0.0.1/32, 0:0:0:0:0:0:0:1/128
+
+# Enable the embedded Graylog web interface.
+# Default: true
+#web_enable = false
+
+# Web interface listen URI.
+# Configuring a path for the URI here effectively prefixes all URIs in the web interface. This is a replacement
+# for the application.context configuration parameter in pre-2.0 versions of the Graylog web interface.
+#web_listen_uri = http://127.0.0.1:9000/
+
+# Web interface endpoint URI. This setting can be overriden on a per-request basis with the X-Graylog-Server-URL header.
+# Default: $rest_transport_uri
+#web_endpoint_uri =
+
+# Enable CORS headers for the web interface. This is necessary for JS-clients accessing the server directly.
+# If these are disabled, modern browsers will not be able to retrieve resources from the server.
+#web_enable_cors = false
+
+# Enable/disable GZIP support for the web interface. This compresses HTTP responses and therefore helps to reduce
+# overall round trip times. This is enabled by default. Uncomment the next line to disable it.
+#web_enable_gzip = false
+
+# Enable HTTPS support for the web interface. This secures the communication of the web browser with the web interface
+# using TLS to prevent request forgery and eavesdropping.
+# This is disabled by default. Uncomment the next line to enable it and see the other related configuration settings.
+#web_enable_tls = true
+
+# The X.509 certificate chain file in PEM format to use for securing the web interface.
+#web_tls_cert_file = /path/to/graylog-web.crt
+
+# The PKCS#8 private key file in PEM format to use for securing the web interface.
+#web_tls_key_file = /path/to/graylog-web.key
+
+# The password to unlock the private key used for securing the web interface.
+#web_tls_key_password = secret
+
+# The maximum size of the HTTP request headers in bytes.
+#web_max_header_size = 8192
+
+# The size of the thread pool used exclusively for serving the web interface.
+#web_thread_pool_size = 16
+
+# List of Elasticsearch hosts Graylog should connect to.
+# Need to be specified as a comma-separated list of valid URIs for the http ports of your elasticsearch nodes.
+# If one or more of your elasticsearch hosts require authentication, include the credentials in each node URI that
+# requires authentication.
+#
+# Default: http://127.0.0.1:9200
+#elasticsearch_hosts = http://node1:9200,http://user:password@node2:19200
+
+# Maximum amount of time to wait for successfull connection to Elasticsearch HTTP port.
+#
+# Default: 10 Seconds
+#elasticsearch_connect_timeout = 10s
+
+# Maximum amount of time to wait for reading back a response from an Elasticsearch server.
+#
+# Default: 60 seconds
+#elasticsearch_socket_timeout = 60s
+
+# Maximum idle time for an Elasticsearch connection. If this is exceeded, this connection will
+# be tore down.
+#
+# Default: inf
+#elasticsearch_idle_timeout = -1s
+
+# Maximum number of total connections to Elasticsearch.
+#
+# Default: 20
+#elasticsearch_max_total_connections = 20
+
+# Maximum number of total connections per Elasticsearch route (normally this means per
+# elasticsearch server).
+#
+# Default: 2
+#elasticsearch_max_total_connections_per_route = 2
+
+# Maximum number of times Graylog will retry failed requests to Elasticsearch.
+#
+# Default: 2
+#elasticsearch_max_retries = 2
+
+# Enable automatic Elasticsearch node discovery through Nodes Info,
+# see https://www.elastic.co/guide/en/elasticsearch/reference/5.4/cluster-nodes-info.html
+#
+# WARNING: Automatic node discovery does not work if Elasticsearch requires authentication, e. g. with Shield.
+#
+# Default: false
+#elasticsearch_discovery_enabled = true
+
+# Filter for including/excluding Elasticsearch nodes in discovery according to their custom attributes,
+# see https://www.elastic.co/guide/en/elasticsearch/reference/5.4/cluster.html#cluster-nodes
+#
+# Default: empty
+#elasticsearch_discovery_filter = rack:42
+
+# Frequency of the Elasticsearch node discovery.
+#
+# Default: 30s
+# elasticsearch_discovery_frequency = 30s
+
+# Enable payload compression for Elasticsearch requests.
+#
+# Default: false
+#elasticsearch_compression_enabled = true
+
+# Graylog will use multiple indices to store documents in. You can configured the strategy it uses to determine
+# when to rotate the currently active write index.
+# It supports multiple rotation strategies:
+#   - "count" of messages per index, use elasticsearch_max_docs_per_index below to configure
+#   - "size" per index, use elasticsearch_max_size_per_index below to configure
+# valid values are "count", "size" and "time", default is "count"
+#
+# ATTENTION: These settings have been moved to the database in 2.0. When you upgrade, make sure to set these
+#            to your previous 1.x settings so they will be migrated to the database!
+rotation_strategy = count
+
+# (Approximate) maximum number of documents in an Elasticsearch index before a new index
+# is being created, also see no_retention and elasticsearch_max_number_of_indices.
+# Configure this if you used 'rotation_strategy = count' above.
+#
+# ATTENTION: These settings have been moved to the database in 2.0. When you upgrade, make sure to set these
+#            to your previous 1.x settings so they will be migrated to the database!
+elasticsearch_max_docs_per_index = 20000000
+
+# (Approximate) maximum size in bytes per Elasticsearch index on disk before a new index is being created, also see
+# no_retention and elasticsearch_max_number_of_indices. Default is 1GB.
+# Configure this if you used 'rotation_strategy = size' above.
+#
+# ATTENTION: These settings have been moved to the database in 2.0. When you upgrade, make sure to set these
+#            to your previous 1.x settings so they will be migrated to the database!
+#elasticsearch_max_size_per_index = 1073741824
+
+# (Approximate) maximum time before a new Elasticsearch index is being created, also see
+# no_retention and elasticsearch_max_number_of_indices. Default is 1 day.
+# Configure this if you used 'rotation_strategy = time' above.
+# Please note that this rotation period does not look at the time specified in the received messages, but is
+# using the real clock value to decide when to rotate the index!
+# Specify the time using a duration and a suffix indicating which unit you want:
+#  1w  = 1 week
+#  1d  = 1 day
+#  12h = 12 hours
+# Permitted suffixes are: d for day, h for hour, m for minute, s for second.
+#
+# ATTENTION: These settings have been moved to the database in 2.0. When you upgrade, make sure to set these
+#            to your previous 1.x settings so they will be migrated to the database!
+#elasticsearch_max_time_per_index = 1d
+
+# Disable checking the version of Elasticsearch for being compatible with this Graylog release.
+# WARNING: Using Graylog with unsupported and untested versions of Elasticsearch may lead to data loss!
+#elasticsearch_disable_version_check = true
+
+# Disable message retention on this node, i. e. disable Elasticsearch index rotation.
+#no_retention = false
+
+# How many indices do you want to keep?
+#
+# ATTENTION: These settings have been moved to the database in 2.0. When you upgrade, make sure to set these
+#            to your previous 1.x settings so they will be migrated to the database!
+elasticsearch_max_number_of_indices = 20
+
+# Decide what happens with the oldest indices when the maximum number of indices is reached.
+# The following strategies are availble:
+#   - delete # Deletes the index completely (Default)
+#   - close # Closes the index and hides it from the system. Can be re-opened later.
+#
+# ATTENTION: These settings have been moved to the database in 2.0. When you upgrade, make sure to set these
+#            to your previous 1.x settings so they will be migrated to the database!
+retention_strategy = delete
+
+# How many Elasticsearch shards and replicas should be used per index? Note that this only applies to newly created indices.
+# ATTENTION: These settings have been moved to the database in Graylog 2.2.0. When you upgrade, make sure to set these
+#            to your previous settings so they will be migrated to the database!
+elasticsearch_shards = 4
+elasticsearch_replicas = 0
+
+# Prefix for all Elasticsearch indices and index aliases managed by Graylog.
+#
+# ATTENTION: These settings have been moved to the database in Graylog 2.2.0. When you upgrade, make sure to set these
+#            to your previous settings so they will be migrated to the database!
+elasticsearch_index_prefix = graylog
+
+# Name of the Elasticsearch index template used by Graylog to apply the mandatory index mapping.
+# Default: graylog-internal
+#
+# ATTENTION: These settings have been moved to the database in Graylog 2.2.0. When you upgrade, make sure to set these
+#            to your previous settings so they will be migrated to the database!
+#elasticsearch_template_name = graylog-internal
+
+# Do you want to allow searches with leading wildcards? This can be extremely resource hungry and should only
+# be enabled with care. See also: http://docs.graylog.org/en/2.1/pages/queries.html
+allow_leading_wildcard_searches = false
+
+# Do you want to allow searches to be highlighted? Depending on the size of your messages this can be memory hungry and
+# should only be enabled after making sure your Elasticsearch cluster has enough memory.
+allow_highlighting = false
+
+# Analyzer (tokenizer) to use for message and full_message field. The "standard" filter usually is a good idea.
+# All supported analyzers are: standard, simple, whitespace, stop, keyword, pattern, language, snowball, custom
+# Elasticsearch documentation: https://www.elastic.co/guide/en/elasticsearch/reference/2.3/analysis.html
+# Note that this setting only takes effect on newly created indices.
+#
+# ATTENTION: These settings have been moved to the database in Graylog 2.2.0. When you upgrade, make sure to set these
+#            to your previous settings so they will be migrated to the database!
+elasticsearch_analyzer = standard
+
+# Global request timeout for Elasticsearch requests (e. g. during search, index creation, or index time-range
+# calculations) based on a best-effort to restrict the runtime of Elasticsearch operations.
+# Default: 1m
+#elasticsearch_request_timeout = 1m
+
+# Global timeout for index optimization (force merge) requests.
+# Default: 1h
+#elasticsearch_index_optimization_timeout = 1h
+
+# Maximum number of concurrently running index optimization (force merge) jobs.
+# If you are using lots of different index sets, you might want to increase that number.
+# Default: 20
+#elasticsearch_index_optimization_jobs = 20
+
+# Time interval for index range information cleanups. This setting defines how often stale index range information
+# is being purged from the database.
+# Default: 1h
+#index_ranges_cleanup_interval = 1h
+
+# Batch size for the Elasticsearch output. This is the maximum (!) number of messages the Elasticsearch output
+# module will get at once and write to Elasticsearch in a batch call. If the configured batch size has not been
+# reached within output_flush_interval seconds, everything that is available will be flushed at once. Remember
+# that every outputbuffer processor manages its own batch and performs its own batch write calls.
+# ("outputbuffer_processors" variable)
+output_batch_size = 500
+
+# Flush interval (in seconds) for the Elasticsearch output. This is the maximum amount of time between two
+# batches of messages written to Elasticsearch. It is only effective at all if your minimum number of messages
+# for this time period is less than output_batch_size * outputbuffer_processors.
+output_flush_interval = 1
+
+# As stream outputs are loaded only on demand, an output which is failing to initialize will be tried over and
+# over again. To prevent this, the following configuration options define after how many faults an output will
+# not be tried again for an also configurable amount of seconds.
+output_fault_count_threshold = 5
+output_fault_penalty_seconds = 30
+
+# The number of parallel running processors.
+# Raise this number if your buffers are filling up.
+processbuffer_processors = 5
+outputbuffer_processors = 3
+
+# The following settings (outputbuffer_processor_*) configure the thread pools backing each output buffer processor.
+# See https://docs.oracle.com/javase/8/docs/api/java/util/concurrent/ThreadPoolExecutor.html for technical details
+
+# When the number of threads is greater than the core (see outputbuffer_processor_threads_core_pool_size),
+# this is the maximum time in milliseconds that excess idle threads will wait for new tasks before terminating.
+# Default: 5000
+#outputbuffer_processor_keep_alive_time = 5000
+
+# The number of threads to keep in the pool, even if they are idle, unless allowCoreThreadTimeOut is set
+# Default: 3
+#outputbuffer_processor_threads_core_pool_size = 3
+
+# The maximum number of threads to allow in the pool
+# Default: 30
+#outputbuffer_processor_threads_max_pool_size = 30
+
+# UDP receive buffer size for all message inputs (e. g. SyslogUDPInput).
+#udp_recvbuffer_sizes = 1048576
+
+# Wait strategy describing how buffer processors wait on a cursor sequence. (default: sleeping)
+# Possible types:
+#  - yielding
+#     Compromise between performance and CPU usage.
+#  - sleeping
+#     Compromise between performance and CPU usage. Latency spikes can occur after quiet periods.
+#  - blocking
+#     High throughput, low latency, higher CPU usage.
+#  - busy_spinning
+#     Avoids syscalls which could introduce latency jitter. Best when threads can be bound to specific CPU cores.
+processor_wait_strategy = blocking
+
+# Size of internal ring buffers. Raise this if raising outputbuffer_processors does not help anymore.
+# For optimum performance your LogMessage objects in the ring buffer should fit in your CPU L3 cache.
+# Must be a power of 2. (512, 1024, 2048, ...)
+ring_size = 65536
+
+inputbuffer_ring_size = 65536
+inputbuffer_processors = 2
+inputbuffer_wait_strategy = blocking
+
+# Enable the disk based message journal.
+message_journal_enabled = true
+
+# The directory which will be used to store the message journal. The directory must me exclusively used by Graylog and
+# must not contain any other files than the ones created by Graylog itself.
+#
+# ATTENTION:
+#   If you create a seperate partition for the journal files and use a file system creating directories like 'lost+found'
+#   in the root directory, you need to create a sub directory for your journal.
+#   Otherwise Graylog will log an error message that the journal is corrupt and Graylog will not start.
+message_journal_dir = data/journal
+
+# Journal hold messages before they could be written to Elasticsearch.
+# For a maximum of 12 hours or 5 GB whichever happens first.
+# During normal operation the journal will be smaller.
+#message_journal_max_age = 12h
+#message_journal_max_size = 5gb
+
+#message_journal_flush_age = 1m
+#message_journal_flush_interval = 1000000
+#message_journal_segment_age = 1h
+#message_journal_segment_size = 100mb
+
+# Number of threads used exclusively for dispatching internal events. Default is 2.
+#async_eventbus_processors = 2
+
+# How many seconds to wait between marking node as DEAD for possible load balancers and starting the actual
+# shutdown process. Set to 0 if you have no status checking load balancers in front.
+lb_recognition_period_seconds = 3
+
+# Journal usage percentage that triggers requesting throttling for this server node from load balancers. The feature is
+# disabled if not set.
+#lb_throttle_threshold_percentage = 95
+
+# Every message is matched against the configured streams and it can happen that a stream contains rules which
+# take an unusual amount of time to run, for example if its using regular expressions that perform excessive backtracking.
+# This will impact the processing of the entire server. To keep such misbehaving stream rules from impacting other
+# streams, Graylog limits the execution time for each stream.
+# The default values are noted below, the timeout is in milliseconds.
+# If the stream matching for one stream took longer than the timeout value, and this happened more than "max_faults" times
+# that stream is disabled and a notification is shown in the web interface.
+#stream_processing_timeout = 2000
+#stream_processing_max_faults = 3
+
+# Length of the interval in seconds in which the alert conditions for all streams should be checked
+# and alarms are being sent.
+#alert_check_interval = 60
+
+# Since 0.21 the Graylog server supports pluggable output modules. This means a single message can be written to multiple
+# outputs. The next setting defines the timeout for a single output module, including the default output module where all
+# messages end up.
+#
+# Time in milliseconds to wait for all message outputs to finish writing a single message.
+#output_module_timeout = 10000
+
+# Time in milliseconds after which a detected stale master node is being rechecked on startup.
+#stale_master_timeout = 2000
+
+# Time in milliseconds which Graylog is waiting for all threads to stop on shutdown.
+#shutdown_timeout = 30000
+
+# MongoDB connection string
+# See https://docs.mongodb.com/manual/reference/connection-string/ for details
+mongodb_uri = mongodb://localhost/graylog
+
+# Authenticate against the MongoDB server
+#mongodb_uri = mongodb://grayloguser:secret@localhost:27017/graylog
+
+# Use a replica set instead of a single host
+#mongodb_uri = mongodb://grayloguser:secret@localhost:27017,localhost:27018,localhost:27019/graylog
+
+# Increase this value according to the maximum connections your MongoDB server can handle from a single client
+# if you encounter MongoDB connection problems.
+mongodb_max_connections = 1000
+
+# Number of threads allowed to be blocked by MongoDB connections multiplier. Default: 5
+# If mongodb_max_connections is 100, and mongodb_threads_allowed_to_block_multiplier is 5,
+# then 500 threads can block. More than that and an exception will be thrown.
+# http://api.mongodb.com/java/current/com/mongodb/MongoOptions.html#threadsAllowedToBlockForConnectionMultiplier
+mongodb_threads_allowed_to_block_multiplier = 5
+
+# Drools Rule File (Use to rewrite incoming log messages)
+# See: http://docs.graylog.org/en/2.1/pages/drools.html
+#rules_file = /etc/graylog/server/rules.drl
+
+# Email transport
+#transport_email_enabled = false
+#transport_email_hostname = mail.example.com
+#transport_email_port = 587
+#transport_email_use_auth = true
+#transport_email_use_tls = true
+#transport_email_use_ssl = true
+#transport_email_auth_username = you@example.com
+#transport_email_auth_password = secret
+#transport_email_subject_prefix = [graylog]
+#transport_email_from_email = graylog@example.com
+
+# Specify and uncomment this if you want to include links to the stream in your stream alert mails.
+# This should define the fully qualified base url to your web interface exactly the same way as it is accessed by your users.
+#transport_email_web_interface_url = https://graylog.example.com
+
+# The default connect timeout for outgoing HTTP connections.
+# Values must be a positive duration (and between 1 and 2147483647 when converted to milliseconds).
+# Default: 5s
+#http_connect_timeout = 5s
+
+# The default read timeout for outgoing HTTP connections.
+# Values must be a positive duration (and between 1 and 2147483647 when converted to milliseconds).
+# Default: 10s
+#http_read_timeout = 10s
+
+# The default write timeout for outgoing HTTP connections.
+# Values must be a positive duration (and between 1 and 2147483647 when converted to milliseconds).
+# Default: 10s
+#http_write_timeout = 10s
+
+# HTTP proxy for outgoing HTTP connections
+# ATTENTION: If you configure a proxy, make sure to also configure the "http_non_proxy_hosts" option so internal
+#            HTTP connections with other nodes does not go through the proxy.
+# Examples:
+#   - http://proxy.example.com:8123
+#   - http://username:password@proxy.example.com:8123
+#http_proxy_uri =
+
+# A list of hosts that should be reached directly, bypassing the configured proxy server.
+# This is a list of patterns separated by ",". The patterns may start or end with a "*" for wildcards.
+# Any host matching one of these patterns will be reached through a direct connection instead of through a proxy.
+# Examples:
+#   - localhost,127.0.0.1
+#   - 10.0.*,*.example.com
+#http_non_proxy_hosts =
+
+# Disable the optimization of Elasticsearch indices after index cycling. This may take some load from Elasticsearch
+# on heavily used systems with large indices, but it will decrease search performance. The default is to optimize
+# cycled indices.
+#
+# ATTENTION: These settings have been moved to the database in Graylog 2.2.0. When you upgrade, make sure to set these
+#            to your previous settings so they will be migrated to the database!
+#disable_index_optimization = true
+
+# Optimize the index down to <= index_optimization_max_num_segments. A higher number may take some load from Elasticsearch
+# on heavily used systems with large indices, but it will decrease search performance. The default is 1.
+#
+# ATTENTION: These settings have been moved to the database in Graylog 2.2.0. When you upgrade, make sure to set these
+#            to your previous settings so they will be migrated to the database!
+#index_optimization_max_num_segments = 1
+
+# The threshold of the garbage collection runs. If GC runs take longer than this threshold, a system notification
+# will be generated to warn the administrator about possible problems with the system. Default is 1 second.
+#gc_warning_threshold = 1s
+
+# Connection timeout for a configured LDAP server (e. g. ActiveDirectory) in milliseconds.
+#ldap_connection_timeout = 2000
+
+# Disable the use of SIGAR for collecting system stats
+#disable_sigar = false
+
+# The default cache time for dashboard widgets. (Default: 10 seconds, minimum: 1 second)
+#dashboard_widget_default_cache_time = 10s
+
+# Automatically load content packs in "content_packs_dir" on the first start of Graylog.
+#content_packs_loader_enabled = true
+
+# The directory which contains content packs which should be loaded on the first start of Graylog.
+#content_packs_dir = data/contentpacks
+
+# A comma-separated list of content packs (files in "content_packs_dir") which should be applied on
+# the first start of Graylog.
+# Default: empty
+content_packs_auto_load = grok-patterns.json
+
+# For some cluster-related REST requests, the node must query all other nodes in the cluster. This is the maximum number
+# of threads available for this. Increase it, if '/cluster/*' requests take long to complete.
+# Should be rest_thread_pool_size * average_cluster_size if you have a high number of concurrent users.
+proxied_requests_thread_pool_size = 32

--- a/graylog2-server/pom.xml
+++ b/graylog2-server/pom.xml
@@ -413,6 +413,24 @@
         </dependency>
 
         <dependency>
+            <groupId>io.netty</groupId>
+            <artifactId>netty-common</artifactId>
+            <version>${netty4.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>io.netty</groupId>
+            <artifactId>netty-codec-dns</artifactId>
+            <version>${netty4.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>io.netty</groupId>
+            <artifactId>netty-resolver-dns</artifactId>
+            <version>${netty4.version}</version>
+        </dependency>
+
+        <dependency>
             <groupId>javax.annotation</groupId>
             <artifactId>javax.annotation-api</artifactId>
         </dependency>

--- a/graylog2-server/src/main/java/org/graylog2/lookup/LookupModule.java
+++ b/graylog2-server/src/main/java/org/graylog2/lookup/LookupModule.java
@@ -20,6 +20,7 @@ import com.google.inject.assistedinject.FactoryModuleBuilder;
 
 import org.graylog2.lookup.adapters.CSVFileDataAdapter;
 import org.graylog2.lookup.adapters.DSVHTTPDataAdapter;
+import org.graylog2.lookup.adapters.DnsLookupDataAdapter;
 import org.graylog2.lookup.adapters.HTTPJSONPathDataAdapter;
 import org.graylog2.lookup.caches.GuavaLookupCache;
 import org.graylog2.lookup.caches.NullCache;
@@ -45,6 +46,11 @@ public class LookupModule extends Graylog2Module {
                 CSVFileDataAdapter.class,
                 CSVFileDataAdapter.Factory.class,
                 CSVFileDataAdapter.Config.class);
+
+        installLookupDataAdapter(DnsLookupDataAdapter.NAME,
+                                 DnsLookupDataAdapter.class,
+                                 DnsLookupDataAdapter.Factory.class,
+                                 DnsLookupDataAdapter.Config.class);
 
         installLookupDataAdapter(HTTPJSONPathDataAdapter.NAME,
                 HTTPJSONPathDataAdapter.class,

--- a/graylog2-server/src/main/java/org/graylog2/lookup/adapters/DnsLookupDataAdapter.java
+++ b/graylog2-server/src/main/java/org/graylog2/lookup/adapters/DnsLookupDataAdapter.java
@@ -1,0 +1,538 @@
+/**
+ * This file is part of Graylog.
+ *
+ * Graylog is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.graylog2.lookup.adapters;
+
+
+import com.codahale.metrics.Counter;
+import com.codahale.metrics.MetricRegistry;
+import com.codahale.metrics.Timer;
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonTypeName;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.google.auto.value.AutoValue;
+import com.google.common.base.Strings;
+import com.google.common.collect.ArrayListMultimap;
+import com.google.common.collect.Multimap;
+import com.google.inject.assistedinject.Assisted;
+import org.apache.commons.collections4.CollectionUtils;
+import org.apache.commons.lang3.StringUtils;
+import org.graylog.autovalue.WithBeanGetter;
+import org.graylog2.lookup.adapters.dnslookup.ADnsAnswer;
+import org.graylog2.lookup.adapters.dnslookup.DnsAnswer;
+import org.graylog2.lookup.adapters.dnslookup.DnsClient;
+import org.graylog2.lookup.adapters.dnslookup.DnsLookupType;
+import org.graylog2.lookup.adapters.dnslookup.PtrDnsAnswer;
+import org.graylog2.lookup.adapters.dnslookup.TxtDnsAnswer;
+import org.graylog2.plugin.lookup.LookupCachePurge;
+import org.graylog2.plugin.lookup.LookupDataAdapter;
+import org.graylog2.plugin.lookup.LookupDataAdapterConfiguration;
+import org.graylog2.plugin.lookup.LookupResult;
+import org.graylog2.shared.utilities.ExceptionUtils;
+import org.joda.time.Duration;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.annotation.Nullable;
+import javax.inject.Inject;
+import java.net.UnknownHostException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.TimeUnit;
+
+public class DnsLookupDataAdapter extends LookupDataAdapter {
+
+    private static final Logger LOG = LoggerFactory.getLogger(DnsLookupDataAdapter.class);
+
+    public static final String NAME = "dnslookup";
+
+    private static final Duration REFRESH_INTERVAL_DURATION = Duration.ZERO;
+    private static final String A_RECORD_LABEL = "A";
+    private static final String AAAA_RECORD_LABEL = "AAAA";
+    private static final String ERROR_COUNTER = "errors";
+    private static final String RESULTS_FIELD = "results";
+    private static final String RAW_RESULTS_FIELD = "raw_results";
+    private static final String TIMER_RESOLVE_DOMAIN_NAME = "resolveDomainNameTime";
+    private static final String TIMER_REVERSE_LOOKUP = "reverseLookupTime";
+    private static final String TIMER_TEXT_LOOKUP = "textLookupTime";
+    private DnsClient dnsClient;
+    private final Config config;
+
+    private final Counter errorCounter;
+
+    // Timers exist for all request types, so that each can be troubleshot individually.
+    private final Timer resolveDomainNameTimer;
+    private final Timer reverseLookupTimer;
+    private final Timer textLookupTimer;
+
+    @Inject
+    public DnsLookupDataAdapter(@Assisted("id") String id,
+                                @Assisted("name") String name,
+                                @Assisted LookupDataAdapterConfiguration config,
+                                MetricRegistry metricRegistry) {
+        super(id, name, config, metricRegistry);
+        this.config = (Config) config;
+        this.errorCounter = metricRegistry.counter(MetricRegistry.name(getClass(), id, ERROR_COUNTER));
+        this.resolveDomainNameTimer = metricRegistry.timer(MetricRegistry.name(getClass(), id, TIMER_RESOLVE_DOMAIN_NAME));
+        this.reverseLookupTimer = metricRegistry.timer(MetricRegistry.name(getClass(), id, TIMER_REVERSE_LOOKUP));
+        this.textLookupTimer = metricRegistry.timer(MetricRegistry.name(getClass(), id, TIMER_TEXT_LOOKUP));
+    }
+
+    @Override
+    protected void doStart() {
+
+        dnsClient = new DnsClient();
+        dnsClient.start(config.serverIps(), config.requestTimeout());
+    }
+
+    @Override
+    protected void doStop() {
+
+        dnsClient.stop();
+    }
+
+    /**
+     * Not needed for the DNS Lookup adaptor.
+     */
+    @Override
+    public Duration refreshInterval() {
+        return REFRESH_INTERVAL_DURATION;
+    }
+
+    /**
+     * Not needed for the DNS Lookup adaptor.
+     */
+    @Override
+    protected void doRefresh(LookupCachePurge cachePurge) {
+
+    }
+
+    @Override
+    protected LookupResult doGet(Object key) {
+
+        final String trimmedKey = StringUtils.trimToNull(key.toString());
+        if (trimmedKey == null) {
+            LOG.debug("A blank key was supplied");
+            return LookupResult.empty();
+        }
+
+        LOG.debug("Beginning [{}] DNS resolution for key [{}]", config.lookupType(), trimmedKey);
+
+        LookupResult lookupResult;
+        switch (config.lookupType()) {
+            case A:
+                try (final Timer.Context ignored = resolveDomainNameTimer.time()) {
+                    lookupResult = resolveIPv4AddressForHostname(trimmedKey);
+                }
+                break;
+            case AAAA: {
+                try (final Timer.Context ignored = resolveDomainNameTimer.time()) {
+                    lookupResult = resolveIPv6AddressForHostname(trimmedKey);
+                }
+                break;
+            }
+            case A_AAAA: {
+                try (final Timer.Context ignored = resolveDomainNameTimer.time()) {
+                    lookupResult = resolveAllAddressesForHostname(trimmedKey);
+                }
+                break;
+            }
+            case PTR: {
+                try (final Timer.Context ignored = reverseLookupTimer.time()) {
+                    lookupResult = performReverseLookup(trimmedKey);
+                }
+                break;
+            }
+            case TXT: {
+                try (final Timer.Context ignored = textLookupTimer.time()) {
+                    lookupResult = performTextLookup(trimmedKey);
+                }
+                break;
+            }
+            default:
+                throw new IllegalArgumentException(String.format(Locale.ENGLISH, "DnsLookupType [%s] is not supported", config.lookupType()));
+        }
+
+        LOG.debug("[{}] DNS resolution complete for key [{}]. Response [{}]", config.lookupType(), trimmedKey, lookupResult);
+
+        return lookupResult;
+    }
+
+    /**
+     * Provides both single and multiple addresses in LookupResult. This is because the purpose of a hostname
+     * resolution request is to resolve to a single IP address (so that communication can be initiated with it).
+     * We also resolve all addresses in case they are needed.
+     */
+    private LookupResult resolveIPv4AddressForHostname(Object key) {
+
+        final List<ADnsAnswer> aDnsAnswers;
+        try {
+            aDnsAnswers = dnsClient.resolveIPv4AddressForHostname(key.toString(), false);
+        } catch (UnknownHostException e) {
+            return LookupResult.empty(); // UnknownHostException is a valid case when the DNS record does not exist. Do not log an error.
+        } catch (Exception e) {
+            LOG.error("Could not resolve [{}] records for hostname [{}]. Cause [{}]", A_RECORD_LABEL, key, ExceptionUtils.getRootCauseMessage(e));
+            errorCounter.inc();
+            return LookupResult.empty();
+        }
+
+        if (CollectionUtils.isNotEmpty(aDnsAnswers)) {
+            return buildLookupResult(aDnsAnswers);
+        }
+
+        LOG.debug("Could not resolve [{}] records for hostname [{}].", A_RECORD_LABEL, key);
+        return LookupResult.empty();
+    }
+
+    /**
+     * Provides both single and multiple addresses in LookupResult. This is because the purpose of a hostname
+     * resolution request is to resolve to a single IP address (so that communication can be initiated with it).
+     * We also resolve all addresses in case they are needed.
+     */
+    private LookupResult resolveIPv6AddressForHostname(Object key) {
+
+        final List<ADnsAnswer> aDnsAnswers;
+        try {
+            aDnsAnswers = dnsClient.resolveIPv6AddressForHostname(key.toString(), false);
+        } catch (UnknownHostException e) {
+            return LookupResult.empty(); // UnknownHostException is a valid case when the DNS record does not exist. Do not log an error.
+        } catch (Exception e) {
+            LOG.error("Could not resolve [{}] records for hostname [{}]. Cause [{}]", AAAA_RECORD_LABEL, key, ExceptionUtils.getRootCauseMessage(e));
+            errorCounter.inc();
+            return LookupResult.empty();
+        }
+
+        if (CollectionUtils.isNotEmpty(aDnsAnswers)) {
+            return buildLookupResult(aDnsAnswers);
+        }
+
+        LOG.debug("Could not resolve [{}] records for hostname [{}].", AAAA_RECORD_LABEL, key);
+        return LookupResult.empty();
+    }
+
+    private LookupResult buildLookupResult(List<ADnsAnswer> aDnsAnswers) {
+
+        /* Provide both a single and multiValue addresses.
+         * Always read the first entry and place in singleValue */
+        final String singleValue = aDnsAnswers.get(0).ipAddress();
+        LookupResult.Builder builder = LookupResult.builder()
+                                                   .single(singleValue)
+                                                   .multiValue(Collections.singletonMap(RESULTS_FIELD, aDnsAnswers));
+
+        assignMinimumTTL(aDnsAnswers, builder);
+
+        return builder.build();
+    }
+
+    /**
+     * Resolves all IPv4 and IPv6 addresses for the hostname. A single IP address will be returned in the singleValue
+     * field (IPv4 address will be returned if present). All IPv4 and IPv6 addresses will be included in the multiValue
+     * field.
+     *
+     * @param key a hostname
+     */
+    private LookupResult resolveAllAddressesForHostname(Object key) {
+
+        try {
+            List<ADnsAnswer> ip4Answers = new ArrayList<>();
+            List<ADnsAnswer> ip6Answers = new ArrayList<>();
+
+            // UnknownHostException is a valid case when the DNS record does not exist. Silently ignore and do not log an error.
+            try {
+                ip4Answers = dnsClient.resolveIPv4AddressForHostname(key.toString(), true); // Include IP version
+            } catch (UnknownHostException e) {
+            }
+
+            try {
+                ip6Answers = dnsClient.resolveIPv6AddressForHostname(key.toString(), true); // Include IP version
+            } catch (UnknownHostException e) {
+            }
+
+            // Select answer for single value. Prefer use of IPv4 address. Only return IPv6 address if no IPv6 address found.
+            final String singleValue;
+            if (CollectionUtils.isNotEmpty(ip4Answers)) {
+                singleValue = ip4Answers.get(0).ipAddress();
+            } else if (CollectionUtils.isNotEmpty(ip6Answers)) {
+                singleValue = ip6Answers.get(0).ipAddress();
+            } else {
+                LOG.debug("Could not resolve [A/AAAA] records hostname [{}].", key);
+                return LookupResult.empty();
+            }
+
+            final LookupResult.Builder builder = LookupResult.builder();
+            if (StringUtils.isNotBlank(singleValue)) {
+                builder.single(singleValue);
+            }
+
+            final List<ADnsAnswer> allAnswers = new ArrayList<>();
+            allAnswers.addAll(ip4Answers);
+            allAnswers.addAll(ip6Answers);
+
+            if (CollectionUtils.isNotEmpty(allAnswers)) {
+                builder.multiValue(Collections.singletonMap(RESULTS_FIELD, allAnswers));
+            }
+
+            assignMinimumTTL(allAnswers, builder);
+
+            return builder.build();
+        } catch (Exception e) {
+            LOG.error("Could not resolve [A/AAAA] records for hostname [{}]. Cause [{}]", key, ExceptionUtils.getRootCauseMessage(e));
+            errorCounter.inc();
+            return LookupResult.empty();
+        }
+    }
+
+    private LookupResult performReverseLookup(Object key) {
+
+        final PtrDnsAnswer dnsResponse;
+        try {
+            dnsResponse = dnsClient.reverseLookup(key.toString());
+        } catch (Exception e) {
+            LOG.error("Could not perform reverse DNS lookup for [{}]. Cause [{}]", key, ExceptionUtils.getRootCauseMessage(e));
+            errorCounter.inc();
+            return LookupResult.empty();
+        }
+
+        if (dnsResponse != null) {
+            if (!Strings.isNullOrEmpty(dnsResponse.fullDomain())) {
+
+                // Include answer in both single and multiValue fields.
+                final Map<Object, Object> multiValueResults = new LinkedHashMap<>();
+                multiValueResults.put(PtrDnsAnswer.FIELD_DOMAIN, dnsResponse.domain());
+                multiValueResults.put(PtrDnsAnswer.FIELD_FULL_DOMAIN, dnsResponse.fullDomain());
+                multiValueResults.put(PtrDnsAnswer.FIELD_DNS_TTL, dnsResponse.dnsTTL());
+
+                final LookupResult.Builder builder = LookupResult.builder()
+                                                                 .single(dnsResponse.fullDomain())
+                                                                 .multiValue(multiValueResults);
+
+                if (config.hasOverrideTTL()) {
+                    builder.cacheTTL(config.getCacheTTLOverrideMillis());
+                } else {
+                    builder.cacheTTL(dnsResponse.dnsTTL() * 1000);
+                }
+
+                return builder.build();
+            }
+        }
+
+        LOG.debug("Could not perform reverse lookup on IP address [{}]. No PTR record was found.", key);
+        return LookupResult.empty();
+    }
+
+    private LookupResult performTextLookup(Object key) {
+
+        /* Query all TXT records for hostname and provide them in the multiValue field as an array.
+         * Do not attempt to attempt to choose a single value for the user (all are valid). */
+        final List<TxtDnsAnswer> txtDnsAnswers;
+        try {
+            txtDnsAnswers = dnsClient.txtLookup(key.toString());
+        } catch (Exception e) {
+            LOG.error("Could not perform TXT DNS lookup for [{}]. Cause [{}]", key, ExceptionUtils.getRootCauseMessage(e));
+            errorCounter.inc();
+            return LookupResult.empty();
+        }
+
+        if (CollectionUtils.isNotEmpty(txtDnsAnswers)) {
+            final LookupResult.Builder builder = LookupResult.builder();
+            builder.multiValue(Collections.singletonMap(RAW_RESULTS_FIELD, txtDnsAnswers));
+            assignMinimumTTL(txtDnsAnswers, builder);
+
+            return builder.build();
+        }
+
+        LOG.debug("Could not perform Text lookup on IP address [{}]. No TXT records were found.", key);
+        return LookupResult.empty();
+    }
+
+    /**
+     * Assigns the minimum TTL found in the supplied DnsAnswers. The minimum makes sense, because this is the least
+     * amount of time that at least one of the records is valid for.
+     */
+    private void assignMinimumTTL(List<? extends DnsAnswer> dnsAnswers, LookupResult.Builder builder) {
+
+        if (config.hasOverrideTTL()) {
+            builder.cacheTTL(config.getCacheTTLOverrideMillis());
+        } else {
+            // Deduce minimum TTL on all TXT records. A TTL will always be returned by DNS server.
+            builder.cacheTTL(dnsAnswers.stream()
+                                       .map(DnsAnswer::dnsTTL)
+                                       .min(Comparator.comparing(Long::valueOf)).get() * 1000);
+        }
+    }
+
+    @Override
+    public void set(Object key, Object value) {
+        throw new UnsupportedOperationException();
+    }
+
+    public interface Factory extends LookupDataAdapter.Factory<DnsLookupDataAdapter> {
+        @Override
+        DnsLookupDataAdapter create(@Assisted("id") String id,
+                                    @Assisted("name") String name,
+                                    LookupDataAdapterConfiguration configuration);
+
+        @Override
+        DnsLookupDataAdapter.Descriptor getDescriptor();
+    }
+
+    public static class Descriptor extends LookupDataAdapter.Descriptor<Config> {
+        public Descriptor() {
+            super(NAME, DnsLookupDataAdapter.Config.class);
+        }
+
+        @Override
+        public DnsLookupDataAdapter.Config defaultConfiguration() {
+            return DnsLookupDataAdapter.Config.builder()
+                                              .type(NAME)
+                                              .lookupType(Config.DEFAULT_LOOKUP_TYPE)
+                                              .serverIps(Config.DEFAULT_SERVER_IP)
+                                              .cacheTTLOverrideEnabled(Config.DEFAULT_CACHE_TTL_OVERRIDE)
+                                              .requestTimeout(Config.DEFAULT_TIMEOUT_MILLIS)
+                                              .build();
+        }
+    }
+
+    @AutoValue
+    @WithBeanGetter
+    @JsonAutoDetect
+    @JsonDeserialize(builder = DnsLookupDataAdapter.Config.Builder.class)
+    @JsonTypeName(NAME)
+    public static abstract class Config implements LookupDataAdapterConfiguration {
+
+        // Fields
+        private static final String FIELD_CACHE_TTL_OVERRIDE = "cache_ttl_override";
+        private static final String FIELD_CACHE_TTL_OVERRIDE_ENABLED = "cache_ttl_override_enabled";
+        private static final String FIELD_CACHE_TTL_OVERRIDE_UNIT = "cache_ttl_override_unit";
+        private static final String FIELD_LOOKUP_TYPE = "lookup_type";
+        private static final String FIELD_REQUEST_TIMEOUT = "request_timeout";
+        private static final String FIELD_SERVER_IPS = "server_ips";
+
+        // Default values
+        private static final boolean DEFAULT_CACHE_TTL_OVERRIDE = false;
+        private static final DnsLookupType DEFAULT_LOOKUP_TYPE = DnsLookupType.A;
+        private static final int DEFAULT_TIMEOUT_MILLIS = 10000;
+        private static final String DEFAULT_SERVER_IP = ""; // Intentionally blank
+
+        @Override
+        @JsonProperty(TYPE_FIELD)
+        public abstract String type();
+
+        @JsonProperty(FIELD_LOOKUP_TYPE)
+        public abstract DnsLookupType lookupType();
+
+        @JsonProperty(FIELD_SERVER_IPS)
+        public abstract String serverIps();
+
+        @JsonProperty(FIELD_REQUEST_TIMEOUT)
+        public abstract int requestTimeout();
+
+        @JsonProperty(FIELD_CACHE_TTL_OVERRIDE_ENABLED)
+        public abstract boolean cacheTTLOverrideEnabled();
+
+        @Nullable
+        @JsonProperty(FIELD_CACHE_TTL_OVERRIDE)
+        public abstract Long cacheTTLOverride();
+
+        @Nullable
+        @JsonProperty(FIELD_CACHE_TTL_OVERRIDE_UNIT)
+        public abstract TimeUnit cacheTTLOverrideUnit();
+
+        public static Builder builder() {
+            return new AutoValue_DnsLookupDataAdapter_Config.Builder();
+        }
+
+        @Override
+        public Optional<Multimap<String, String>> validate() {
+
+            final ArrayListMultimap<String, String> errors = ArrayListMultimap.create();
+            if (StringUtils.isNotBlank(serverIps()) && !DnsClient.allIpAddressesValid(serverIps())) {
+                errors.put(FIELD_SERVER_IPS, "Invalid server IP address and/or port. " +
+                                             "Please enter one or more comma-separated IPv4 addresses with optional ports (eg. 192.168.1.1:5353, 192.168.1.244).");
+            }
+
+            if (requestTimeout() < 1) {
+                errors.put(FIELD_REQUEST_TIMEOUT, "Value cannot be smaller than 1");
+            }
+
+            return errors.isEmpty() ? Optional.empty() : Optional.of(errors);
+        }
+
+        private boolean hasOverrideTTL() {
+
+            return cacheTTLOverride() != null && cacheTTLOverrideUnit() != null;
+        }
+
+        private Long getCacheTTLOverrideMillis() {
+
+            // Valid default, because Cache DNS_TTL is always required.
+            if (!cacheTTLOverrideEnabled() || cacheTTLOverride() == null || cacheTTLOverrideUnit() == null) {
+                return Long.MAX_VALUE;
+            }
+
+            return cacheTTLOverrideUnit().toMillis(cacheTTLOverride());
+        }
+
+        @AutoValue.Builder
+        public abstract static class Builder {
+
+            @JsonCreator
+            public static Builder create() {
+                return Config.builder()
+                             .serverIps(DEFAULT_SERVER_IP)
+                             .lookupType(DnsLookupType.A)
+                             .cacheTTLOverrideEnabled(DEFAULT_CACHE_TTL_OVERRIDE)
+                             .requestTimeout(DEFAULT_TIMEOUT_MILLIS);
+            }
+
+            @JsonProperty(TYPE_FIELD)
+            public abstract Builder type(String type);
+
+            @JsonProperty(FIELD_LOOKUP_TYPE)
+            public abstract Builder lookupType(DnsLookupType lookupType);
+
+            @JsonProperty(FIELD_SERVER_IPS)
+            public abstract Builder serverIps(String serverIp);
+
+            @JsonProperty(FIELD_REQUEST_TIMEOUT)
+            public abstract Builder requestTimeout(int requestTimeout);
+
+            @JsonProperty(FIELD_CACHE_TTL_OVERRIDE_ENABLED)
+            public abstract Builder cacheTTLOverrideEnabled(boolean cacheTTLOverride);
+
+            @JsonProperty(FIELD_CACHE_TTL_OVERRIDE)
+            public abstract Builder cacheTTLOverride(Long cacheTTLOverride);
+
+            @JsonProperty(FIELD_CACHE_TTL_OVERRIDE_UNIT)
+            public abstract Builder cacheTTLOverrideUnit(@Nullable TimeUnit cacheTTLOverrideUnit);
+
+            abstract Config autoBuild();
+
+            public Config build() {
+
+                return autoBuild();
+            }
+        }
+    }
+}

--- a/graylog2-server/src/main/java/org/graylog2/lookup/adapters/dnslookup/ADnsAnswer.java
+++ b/graylog2-server/src/main/java/org/graylog2/lookup/adapters/dnslookup/ADnsAnswer.java
@@ -1,0 +1,89 @@
+/**
+ * This file is part of Graylog.
+ *
+ * Graylog is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.graylog2.lookup.adapters.dnslookup;
+
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.google.auto.value.AutoValue;
+import org.graylog.autovalue.WithBeanGetter;
+
+import javax.annotation.Nullable;
+
+/**
+ * Address (A/AAAA) DNS lookup response from {@link DnsClient}.
+ */
+@AutoValue
+@WithBeanGetter
+@JsonAutoDetect
+@JsonDeserialize(builder = ADnsAnswer.Builder.class)
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonPropertyOrder({ADnsAnswer.FIELD_IP_ADDRESS, ADnsAnswer.FIELD_IP_VERSION, ADnsAnswer.FIELD_DNS_TTL})
+public abstract class ADnsAnswer implements DnsAnswer {
+
+    static final String FIELD_IP_ADDRESS = "ip_address";
+    static final String FIELD_IP_VERSION = "ip_version";
+    static final String FIELD_DNS_TTL = "dns_ttl";
+
+    @JsonProperty(FIELD_IP_ADDRESS)
+    public abstract String ipAddress();
+
+    // Deliberately nullable, because only included when IPv4 and IPv6 results are supplied together
+    // (see usages of DnsLookupType.A_AAAA)
+    @Nullable
+    @JsonProperty(FIELD_IP_VERSION)
+    public abstract String ipVersion();
+
+    @Override
+    @JsonProperty(FIELD_DNS_TTL)
+    public abstract long dnsTTL();
+
+    public static Builder builder() {
+        return new AutoValue_ADnsAnswer.Builder();
+    }
+
+    @AutoValue.Builder
+    public abstract static class Builder {
+
+        @JsonCreator
+        public static Builder createDefault() {
+            return builder();
+        }
+
+        @JsonProperty(FIELD_IP_ADDRESS)
+        public abstract ADnsAnswer.Builder ipAddress(String ipAddress);
+
+        // Deliberately nullable, because only included when IPv4 and IPv6 results are supplied together
+        // (see usages of DnsLookupType.A_AAAA)
+        @Nullable
+        @JsonProperty(FIELD_IP_VERSION)
+        public abstract ADnsAnswer.Builder ipVersion(String ipVersion);
+
+        @JsonProperty(FIELD_DNS_TTL)
+        public abstract ADnsAnswer.Builder dnsTTL(long dnsTTL);
+
+        abstract ADnsAnswer autoBuild();
+
+        public ADnsAnswer build() {
+
+            return autoBuild();
+        }
+    }
+}

--- a/graylog2-server/src/main/java/org/graylog2/lookup/adapters/dnslookup/DnsAnswer.java
+++ b/graylog2-server/src/main/java/org/graylog2/lookup/adapters/dnslookup/DnsAnswer.java
@@ -1,0 +1,22 @@
+/**
+ * This file is part of Graylog.
+ *
+ * Graylog is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.graylog2.lookup.adapters.dnslookup;
+
+public interface DnsAnswer {
+
+    long dnsTTL();
+}

--- a/graylog2-server/src/main/java/org/graylog2/lookup/adapters/dnslookup/DnsClient.java
+++ b/graylog2-server/src/main/java/org/graylog2/lookup/adapters/dnslookup/DnsClient.java
@@ -1,0 +1,501 @@
+/**
+ * This file is part of Graylog.
+ *
+ * Graylog is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.graylog2.lookup.adapters.dnslookup;
+
+import com.google.common.base.Joiner;
+import com.google.common.base.Splitter;
+import com.google.common.base.Strings;
+import com.google.common.collect.Lists;
+import com.google.common.net.HostAndPort;
+import com.google.common.net.InetAddresses;
+import com.google.common.net.InternetDomainName;
+import io.netty.buffer.ByteBuf;
+import io.netty.channel.nio.NioEventLoopGroup;
+import io.netty.channel.socket.nio.NioDatagramChannel;
+import io.netty.handler.codec.dns.DefaultDnsPtrRecord;
+import io.netty.handler.codec.dns.DefaultDnsQuestion;
+import io.netty.handler.codec.dns.DefaultDnsRawRecord;
+import io.netty.handler.codec.dns.DefaultDnsRecordDecoder;
+import io.netty.handler.codec.dns.DnsRecord;
+import io.netty.handler.codec.dns.DnsRecordType;
+import io.netty.handler.codec.dns.DnsResponse;
+import io.netty.handler.codec.dns.DnsSection;
+import io.netty.resolver.dns.DnsNameResolver;
+import io.netty.resolver.dns.DnsNameResolverBuilder;
+import io.netty.resolver.dns.DnsServerAddressStreamProvider;
+import io.netty.resolver.dns.SequentialDnsServerAddressStreamProvider;
+import io.netty.util.concurrent.Future;
+import org.apache.commons.collections4.CollectionUtils;
+import org.apache.commons.lang3.StringUtils;
+import org.graylog2.shared.utilities.ExceptionUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.net.Inet4Address;
+import java.net.Inet6Address;
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
+import java.net.UnknownHostException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Locale;
+import java.util.Objects;
+import java.util.concurrent.ExecutionException;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+import java.util.stream.StreamSupport;
+
+public class DnsClient {
+
+    private static final Logger LOG = LoggerFactory.getLogger(DnsClient.class);
+
+    private static final int DEFAULT_DNS_PORT = 53;
+    private static final Pattern VALID_HOSTNAME_PATTERN = Pattern.compile("^(([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\\-]*[a-zA-Z0-9])\\.)*([A-Za-z0-9]|[A-Za-z0-9][A-Za-z0-9\\-]*[A-Za-z0-9])$");
+
+    // Use fully qualified reverse lookup domain names (with dot at end).
+    private static final String IP_4_REVERSE_SUFFIX = ".in-addr.arpa.";
+    private static final String IP_6_REVERSE_SUFFIX = ".ip6.arpa.";
+
+    private static final String IP_4_VERSION = "IPv4";
+    private static final String IP_6_VERSION = "IPv6";
+
+    // Used to convert binary IPv6 address to hex.
+    private static final char[] HEX_CHARS_ARRAY = "0123456789ABCDEF".toCharArray();
+
+    private NioEventLoopGroup nettyEventLoop;
+    private DnsNameResolver resolver;
+
+    public void start(String dnsServerIps, long requestTimeout) {
+
+        LOG.debug("Attempting to start DNS client");
+        final List<InetSocketAddress> iNetDnsServerIps = parseServerIpAddresses(dnsServerIps);
+
+        nettyEventLoop = new NioEventLoopGroup();
+
+        final DnsNameResolverBuilder dnsNameResolverBuilder = new DnsNameResolverBuilder(nettyEventLoop.next());
+        dnsNameResolverBuilder.channelType(NioDatagramChannel.class).queryTimeoutMillis(requestTimeout);
+
+        // Specify custom DNS servers if provided. If not, use those specified in local network adapter settings.
+        if (CollectionUtils.isNotEmpty(iNetDnsServerIps)) {
+
+            LOG.debug("Attempting to start DNS client with server IPs [{}] on port [{}] with timeout [{}]",
+                      dnsServerIps, DEFAULT_DNS_PORT, requestTimeout);
+
+            final DnsServerAddressStreamProvider dnsServer = new SequentialDnsServerAddressStreamProvider(iNetDnsServerIps);
+            dnsNameResolverBuilder.nameServerProvider(dnsServer);
+        } else {
+            LOG.debug("Attempting to start DNS client with the local network adapter DNS server address on port [{}] with timeout [{}]",
+                      DEFAULT_DNS_PORT, requestTimeout);
+        }
+
+        resolver = dnsNameResolverBuilder.build();
+
+        LOG.debug("DNS client startup successful");
+    }
+
+    private List<InetSocketAddress> parseServerIpAddresses(String dnsServerIps) {
+
+        // Parse and prepare DNS server IP addresses for Netty.
+        return StreamSupport
+                // Split comma-separated sever IP:port combos.
+                .stream(Splitter.on(",").trimResults().omitEmptyStrings().split(dnsServerIps).spliterator(), false)
+                // Parse as HostAndPort objects (allows convenient handling of port provided after colon).
+                .map(hostAndPort -> HostAndPort.fromString(hostAndPort).withDefaultPort(DnsClient.DEFAULT_DNS_PORT))
+                // Convert HostAndPort > InetSocketAddress as required by Netty.
+                .map(hostAndPort -> new InetSocketAddress(hostAndPort.getHost(), hostAndPort.getPort()))
+                .collect(Collectors.toList());
+    }
+
+    public void stop() {
+
+        LOG.debug("Attempting to stop DNS client");
+
+        if (nettyEventLoop == null) {
+            LOG.error("DNS resolution event loop not initialized");
+            return;
+        }
+
+        // Shutdown event loop (required by Netty).
+        final Future<?> shutdownFuture = nettyEventLoop.shutdownGracefully();
+        shutdownFuture.addListener(future -> LOG.debug("DNS client shutdown successful"));
+    }
+
+    public List<ADnsAnswer> resolveIPv4AddressForHostname(String hostName, boolean includeIpVersion)
+            throws InterruptedException, ExecutionException, UnknownHostException {
+
+        return resolveIpAddresses(hostName, DnsRecordType.A, includeIpVersion);
+    }
+
+    public List<ADnsAnswer> resolveIPv6AddressForHostname(String hostName, boolean includeIpVersion)
+            throws InterruptedException, ExecutionException, UnknownHostException {
+
+        return resolveIpAddresses(hostName, DnsRecordType.AAAA, includeIpVersion);
+    }
+
+    private List<ADnsAnswer> resolveIpAddresses(String hostName, DnsRecordType dnsRecordType, boolean includeIpVersion)
+            throws InterruptedException, ExecutionException {
+
+        LOG.debug("Attempting to resolve [{}] records for [{}]", dnsRecordType, hostName);
+
+        if (isShutdown()) {
+            throw new DnsClientNotRunningException();
+        }
+
+        validateHostName(hostName);
+
+        final DefaultDnsQuestion aRecordDnsQuestion = new DefaultDnsQuestion(hostName, dnsRecordType);
+
+        /* The DnsNameResolver.resolveAll(DnsQuestion) method handles all redirects through CNAME records to
+         * ultimately resolve a list of IP addresses with TTL values. */
+        return resolver.resolveAll(aRecordDnsQuestion).sync().get().stream()
+                       .map(dnsRecord -> decodeDnsRecord(dnsRecord, includeIpVersion))
+                       .filter(Objects::nonNull) // Removes any entries which the IP address could not be extracted for.
+                       .collect(Collectors.toList());
+    }
+
+    /**
+     * Picks out the IP address and TTL from the answer response for each record.
+     */
+    private static ADnsAnswer decodeDnsRecord(DnsRecord dnsRecord, boolean includeIpVersion) {
+
+        if (dnsRecord == null) {
+            return null;
+        }
+
+        LOG.trace("Attempting to decode DNS record [{}]", dnsRecord);
+
+        /* Read data from DNS record response. The data is a binary representation of the IP address
+         * IPv4 address: 32 bits, IPv6 address: 128 bits */
+        byte[] ipAddressBytes;
+        final DefaultDnsRawRecord dnsRawRecord = (DefaultDnsRawRecord) dnsRecord;
+        try {
+            final ByteBuf byteBuf = dnsRawRecord.content();
+            ipAddressBytes = new byte[byteBuf.readableBytes()];
+            int readerIndex = byteBuf.readerIndex();
+            byteBuf.getBytes(readerIndex, ipAddressBytes);
+        } finally {
+            /* Must manually release references on dnsRawRecord object since the DefaultDnsRawRecord class
+             * extends ReferenceCounted. This also releases the above ByteBuf, since DefaultDnsRawRecord is
+             * the holder for it. */
+            dnsRawRecord.release();
+        }
+
+        LOG.trace("The IP address has [{}] bytes", ipAddressBytes.length);
+
+        InetAddress ipAddress;
+        try {
+            ipAddress = InetAddress.getByAddress(ipAddressBytes); // Takes care of correctly creating an IPv4 or IPv6 address.
+        } catch (UnknownHostException e) {
+            // This should not happen.
+            LOG.error("Could not extract IP address from DNS entry [{}]. Cause [{}]", dnsRecord.toString(), ExceptionUtils.getRootCauseMessage(e));
+            return null;
+        }
+
+        LOG.trace("The resulting IP address is [{}]", ipAddress.getHostAddress());
+
+        final ADnsAnswer.Builder builder = ADnsAnswer.builder()
+                                                     .ipAddress(ipAddress.getHostAddress())
+                                                     .dnsTTL(dnsRecord.timeToLive());
+
+        if (includeIpVersion) {
+            builder.ipVersion(ipAddress instanceof Inet4Address ? IP_4_VERSION : IP_6_VERSION);
+        }
+
+        return builder.build();
+    }
+
+    public PtrDnsAnswer reverseLookup(String ipAddress) throws InterruptedException, ExecutionException {
+
+        LOG.debug("Attempting to perform reverse lookup for IP address [{}]", ipAddress);
+
+        if (isShutdown()) {
+            throw new DnsClientNotRunningException();
+        }
+
+        validateIpAddress(ipAddress);
+
+        final String inverseAddressFormat = getInverseAddressFormat(ipAddress);
+
+        DnsResponse content = null;
+        try {
+            content = resolver.query(new DefaultDnsQuestion(inverseAddressFormat, DnsRecordType.PTR)).sync().get().content();
+            for (int i = 0; i < content.count(DnsSection.ANSWER); i++) {
+
+                // Return the first PTR record, because there should be only one as per
+                // http://tools.ietf.org/html/rfc1035#section-3.5
+                final DnsRecord dnsRecord = content.recordAt(DnsSection.ANSWER, i);
+                if (dnsRecord instanceof DefaultDnsPtrRecord) {
+
+                    final DefaultDnsPtrRecord ptrRecord = (DefaultDnsPtrRecord) dnsRecord;
+                    final PtrDnsAnswer.Builder dnsAnswerBuilder = PtrDnsAnswer.builder();
+
+                    final String hostname = ptrRecord.hostname();
+                    LOG.trace("PTR record retrieved with hostname [{}]", hostname);
+
+                    try {
+                        parseReverseLookupDomain(dnsAnswerBuilder, hostname);
+                    } catch (IllegalArgumentException e) {
+                        LOG.debug("Reverse lookup of [{}] was partially successful. The DNS server returned [{}], " +
+                                  "which is an invalid host name. The \"domain\" field will be left blank.",
+                                  ipAddress, hostname);
+                        dnsAnswerBuilder.domain("");
+                    }
+
+                    return dnsAnswerBuilder.dnsTTL(ptrRecord.timeToLive())
+                                           .build();
+                }
+            }
+        } finally {
+            if (content != null) {
+                // Must manually release references on content object since the DnsResponse class extends ReferenceCounted
+                content.release();
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * Extract the domain name (without subdomain). The Guava {@link InternetDomainName} implementation
+     * provides a method to correctly handle this (and handles special cases for TLDs with multiple
+     * names. eg. for lb01.store.amazon.co.uk, only amazon.co.uk would be extracted).
+     * It uses https://publicsuffix.org behind the scenes.
+     * <p>
+     * Some domains (eg. completely randomly defined PTR domains) are not considered to have a public
+     * suffix according to Guava. For those, the only option is to manually extract the domain with
+     * string operations. This should be a rare case.
+     */
+    public static void parseReverseLookupDomain(PtrDnsAnswer.Builder dnsAnswerBuilder, String hostname) {
+
+        dnsAnswerBuilder.fullDomain(hostname);
+
+        final InternetDomainName internetDomainName = InternetDomainName.from(hostname);
+        if (internetDomainName.hasPublicSuffix()) {
+
+            // Use Guava to extract domain name.
+            final InternetDomainName topDomainName = internetDomainName.topDomainUnderRegistrySuffix();
+            dnsAnswerBuilder.domain(topDomainName.toString());
+        } else {
+
+            /* Manually extract domain name.
+             * Eg. for hostname test.some-domain.com, only some-domain.com will be extracted. */
+            String[] split = hostname.split("\\.");
+            if (split.length > 1) {
+                dnsAnswerBuilder.domain(split[split.length - 2] + "." + split[split.length - 1]);
+            } else if (split.length == 1) {
+                dnsAnswerBuilder.domain(hostname); // Domain is a single word with no dots.
+            } else {
+                dnsAnswerBuilder.domain(""); // Domain is blank.
+            }
+        }
+    }
+
+    public List<TxtDnsAnswer> txtLookup(String hostName) throws InterruptedException, ExecutionException {
+
+        if (isShutdown()) {
+            throw new DnsClientNotRunningException();
+        }
+
+        LOG.debug("Attempting to perform TXT lookup for hostname [{}]", hostName);
+
+        validateHostName(hostName);
+
+        DnsResponse content = null;
+        try {
+            content = resolver.query(new DefaultDnsQuestion(hostName, DnsRecordType.TXT)).sync().get().content();
+            int count = content.count(DnsSection.ANSWER);
+            final ArrayList<TxtDnsAnswer> txtRecords = new ArrayList<>(count);
+            for (int i = 0; i < count; i++) {
+
+                final DnsRecord dnsRecord = content.recordAt(DnsSection.ANSWER, i);
+                LOG.trace("TXT record [{}] retrieved with content [{}].", i, dnsRecord);
+
+                if (dnsRecord instanceof DefaultDnsRawRecord) {
+                    final DefaultDnsRawRecord txtRecord = (DefaultDnsRawRecord) dnsRecord;
+
+                    final TxtDnsAnswer.Builder dnsAnswerBuilder = TxtDnsAnswer.builder();
+                    final String decodeTxtRecord = decodeTxtRecord(txtRecord);
+                    LOG.trace("The decoded TXT record is [{}]", decodeTxtRecord);
+
+                    dnsAnswerBuilder.value(decodeTxtRecord)
+                                    .dnsTTL(txtRecord.timeToLive())
+                                    .build();
+
+                    txtRecords.add(dnsAnswerBuilder.build());
+                }
+            }
+
+            return txtRecords;
+        } finally {
+            if (content != null) {
+                // Must manually release references on content object since the DnsResponse class extends ReferenceCounted
+                content.release();
+            }
+        }
+    }
+
+    private boolean isShutdown() {
+        return nettyEventLoop == null || nettyEventLoop.isShutdown();
+    }
+
+    private static String decodeTxtRecord(DefaultDnsRawRecord record) {
+
+        LOG.debug("Attempting to read TXT value from DNS record [{}]", record);
+
+        return DefaultDnsRecordDecoder.decodeName(record.content());
+    }
+
+    public String getInverseAddressFormat(String ipAddress) {
+
+        ipAddress = StringUtils.trim(ipAddress);
+
+        validateIpAddress(ipAddress);
+
+        LOG.debug("Preparing inverse format for IP address [{}]", ipAddress);
+
+        // Detect what type of address is provided (IPv4 or IPv6)
+        if (isIp6Address(ipAddress)) {
+
+            LOG.debug("[{}] is an IPv6 address", ipAddress);
+
+            /* Build reverse IPv6 address string with correct ip6.arpa suffix.
+             * All hex nibbles from the full address should be reversed (with dots in between)
+             * and the ip6.arpa suffix added to the end.
+             *
+             * For example, the reverse format for the address 2604:a880:800:10::7a1:b001 is
+             * 1.0.0.b.1.a.7.0.0.0.0.0.0.0.0.0.0.1.0.0.0.0.8.0.0.8.8.a.4.0.6.2.ip6.arpa
+             * See https://www.dnscheck.co/ptr-record-monitor for more info. */
+
+            // Parse the full address as an InetAddress to allow the full address bytes (16 bytes/128 bits) to be obtained.
+            final byte[] addressBytes = InetAddresses.forString(ipAddress).getAddress();
+
+            if (addressBytes.length > 16) {
+                throw new IllegalArgumentException(String.format(Locale.ENGLISH, "[%s] is an invalid IPv6 address", ipAddress));
+            }
+
+            // Convert the raw address bytes to hex.
+            final char[] resolvedHex = new char[addressBytes.length * 2];
+            for (int i = 0; i < addressBytes.length; i++) {
+                final int v = addressBytes[i] & 0xFF;
+                resolvedHex[i * 2] = HEX_CHARS_ARRAY[v >>> 4];
+                resolvedHex[i * 2 + 1] = HEX_CHARS_ARRAY[v & 0x0F];
+            }
+
+            final String fullHexAddress = new String(resolvedHex).toLowerCase(Locale.ENGLISH);
+            final String[] reversedAndSplit = new StringBuilder(fullHexAddress).reverse().toString().split("");
+
+            final String invertedAddress = Joiner.on(".").join(reversedAndSplit);
+
+            LOG.debug("Inverted address [{}] built for [{}]", invertedAddress, ipAddress);
+
+            return invertedAddress + IP_6_REVERSE_SUFFIX;
+        } else {
+
+            LOG.debug("[{}] is an IPv4 address", ipAddress);
+
+            /* Build reverse IPv4 address string with correct in-addr.arpa suffix.
+             * All octets should be reversed and the ip6.arpa suffix added to the end.
+             *
+             * For example, the reverse format for the address 10.20.30.40 is
+             * 40.30.20.10.in-addr.arpa */
+            final String[] octets = ipAddress.split("\\.");
+            final String invertedAddress = octets[3] + "." + octets[2] + "." + octets[1] + "." + octets[0] + IP_4_REVERSE_SUFFIX;
+
+            LOG.debug("Inverted address [{}] built for [{}]", invertedAddress, ipAddress);
+
+            return invertedAddress;
+        }
+    }
+
+    private void validateHostName(String hostName) {
+
+        if (!isHostName(hostName)) {
+            throw new IllegalArgumentException(
+                    String.format(Locale.ENGLISH, "[%s] is an invalid hostname. Please supply a pure hostname (eg. api.graylog.com)",
+                                  hostName));
+        }
+    }
+
+    public static boolean isHostName(String hostName) {
+
+        return VALID_HOSTNAME_PATTERN.matcher(hostName).matches();
+    }
+
+    private static void validateIpAddress(final String ipAddress) {
+
+        if (!isValidIpAddress(ipAddress)) {
+            throw new IllegalArgumentException(
+                    String.format(Locale.ENGLISH, "[%s] is an invalid IP address.", ipAddress));
+        }
+    }
+
+    private static boolean isValidIpAddress(String ipAddress) {
+
+        return isIp4Address(ipAddress) || isIp6Address(ipAddress);
+    }
+
+    public static boolean isIp4Address(String ipAddress) {
+
+        try {
+            final InetAddress address = InetAddresses.forString(ipAddress);
+            if (address instanceof Inet4Address) {
+                return true;
+            }
+        } catch (IllegalArgumentException e) {
+            // Absorb exception.
+        }
+
+        return false;
+    }
+
+    public static boolean isIp6Address(String ipAddress) {
+
+        try {
+            final InetAddress address = InetAddresses.forString(ipAddress);
+            if (address instanceof Inet6Address) {
+                return true;
+            }
+        } catch (IllegalArgumentException e) {
+            // Absorb exception.
+        }
+
+        return false;
+    }
+
+    /**
+     * @param ipAddresses A comma-separated list of IP addresses
+     * @return true if all comma-separated IP addresses are valid
+     * "8.8.4.4, 8.8.8.8" returns true
+     * "8.8.4.4, " returns true
+     * "8.8.4.4" returns true
+     * "8.8.4.4 8.8.8.8" returns false
+     * "8.8.4.4, google.com" returns false
+     */
+    public static boolean allIpAddressesValid(String ipAddresses) {
+
+        if (!Strings.isNullOrEmpty(ipAddresses)) {
+            return Lists.newArrayList(Splitter.on(",")
+                                              .trimResults()
+                                              .omitEmptyStrings()
+                                              .split(ipAddresses)).stream()
+                        .map(hostAndPort -> HostAndPort.fromString(hostAndPort).withDefaultPort(DnsClient.DEFAULT_DNS_PORT))
+                        .allMatch(hostAndPort -> isValidIpAddress(hostAndPort.getHost()));
+        }
+
+        return false;
+    }
+}

--- a/graylog2-server/src/main/java/org/graylog2/lookup/adapters/dnslookup/DnsClientNotRunningException.java
+++ b/graylog2-server/src/main/java/org/graylog2/lookup/adapters/dnslookup/DnsClientNotRunningException.java
@@ -1,0 +1,26 @@
+/**
+ * This file is part of Graylog.
+ *
+ * Graylog is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.graylog2.lookup.adapters.dnslookup;
+
+public class DnsClientNotRunningException extends RuntimeException {
+
+    public DnsClientNotRunningException() {
+        super( "The DNS client is not running." );
+    }
+}
+
+

--- a/graylog2-server/src/main/java/org/graylog2/lookup/adapters/dnslookup/DnsLookupType.java
+++ b/graylog2-server/src/main/java/org/graylog2/lookup/adapters/dnslookup/DnsLookupType.java
@@ -1,0 +1,26 @@
+/**
+ * This file is part of Graylog.
+ *
+ * Graylog is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.graylog2.lookup.adapters.dnslookup;
+
+public enum DnsLookupType {
+
+    A,
+    AAAA,
+    A_AAAA, // Performs both A and AAAA lookup
+    PTR,
+    TXT
+}

--- a/graylog2-server/src/main/java/org/graylog2/lookup/adapters/dnslookup/PtrDnsAnswer.java
+++ b/graylog2-server/src/main/java/org/graylog2/lookup/adapters/dnslookup/PtrDnsAnswer.java
@@ -1,0 +1,77 @@
+/**
+ * This file is part of Graylog.
+ *
+ * Graylog is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.graylog2.lookup.adapters.dnslookup;
+
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.google.auto.value.AutoValue;
+import org.graylog.autovalue.WithBeanGetter;
+
+/**
+ * Reverse (PTR) DNS lookup response from {@link DnsClient}.
+ */
+@AutoValue
+@WithBeanGetter
+@JsonAutoDetect
+@JsonDeserialize(builder = PtrDnsAnswer.Builder.class)
+public abstract class PtrDnsAnswer implements DnsAnswer {
+
+    public static final String FIELD_DOMAIN = "domain";
+    public static final String FIELD_FULL_DOMAIN = "full_domain";
+    public static final String FIELD_DNS_TTL = "dns_ttl";
+
+    @JsonProperty(FIELD_DOMAIN)
+    public abstract String domain();
+
+    @JsonProperty(FIELD_FULL_DOMAIN)
+    public abstract String fullDomain();
+
+    @Override
+    @JsonProperty(FIELD_DNS_TTL)
+    public abstract long dnsTTL();
+
+    public static Builder builder() {
+        return new AutoValue_PtrDnsAnswer.Builder();
+    }
+
+    @AutoValue.Builder
+    public abstract static class Builder {
+
+        @JsonCreator
+        public static Builder createDefault() {
+            return builder();
+        }
+
+        @JsonProperty(FIELD_DOMAIN)
+        public abstract PtrDnsAnswer.Builder domain(String domain);
+
+        @JsonProperty(FIELD_FULL_DOMAIN)
+        public abstract PtrDnsAnswer.Builder fullDomain(String fullDomain);
+
+        @JsonProperty(FIELD_DNS_TTL)
+        public abstract PtrDnsAnswer.Builder dnsTTL(long dnsTTL);
+
+        abstract PtrDnsAnswer autoBuild();
+
+        public PtrDnsAnswer build() {
+
+            return autoBuild();
+        }
+    }
+}

--- a/graylog2-server/src/main/java/org/graylog2/lookup/adapters/dnslookup/TxtDnsAnswer.java
+++ b/graylog2-server/src/main/java/org/graylog2/lookup/adapters/dnslookup/TxtDnsAnswer.java
@@ -1,0 +1,72 @@
+/**
+ * This file is part of Graylog.
+ *
+ * Graylog is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.graylog2.lookup.adapters.dnslookup;
+
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.google.auto.value.AutoValue;
+import org.graylog.autovalue.WithBeanGetter;
+
+/**
+ * Text (TXT) DNS lookup response from {@link DnsClient}.
+ */
+@AutoValue
+@WithBeanGetter
+@JsonAutoDetect
+@JsonDeserialize(builder = TxtDnsAnswer.Builder.class)
+@JsonPropertyOrder({TxtDnsAnswer.FIELD_VALUE, TxtDnsAnswer.FIELD_DNS_TTL})
+public abstract class TxtDnsAnswer implements DnsAnswer {
+
+    static final String FIELD_VALUE = "value";
+    static final String FIELD_DNS_TTL = "dns_ttl";
+
+    @JsonProperty(FIELD_VALUE)
+    public abstract String value();
+
+    @Override
+    @JsonProperty(FIELD_DNS_TTL)
+    public abstract long dnsTTL();
+
+    public static Builder builder() {
+        return new AutoValue_TxtDnsAnswer.Builder();
+    }
+
+    @AutoValue.Builder
+    public abstract static class Builder {
+
+        @JsonCreator
+        public static Builder createDefault() {
+            return builder();
+        }
+
+        @JsonProperty(FIELD_VALUE)
+        public abstract TxtDnsAnswer.Builder value(String value);
+
+        @JsonProperty(FIELD_DNS_TTL)
+        public abstract TxtDnsAnswer.Builder dnsTTL(long dnsTTL);
+
+        abstract TxtDnsAnswer autoBuild();
+
+        public TxtDnsAnswer build() {
+
+            return autoBuild();
+        }
+    }
+}

--- a/graylog2-server/src/test/java/org/graylog2/lookup/adapters/dnslookup/DnsClientTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/lookup/adapters/dnslookup/DnsClientTest.java
@@ -1,0 +1,126 @@
+/**
+ * This file is part of Graylog.
+ *
+ * Graylog is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.graylog2.lookup.adapters.dnslookup;
+
+
+import com.google.common.net.InternetDomainName;
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+public class DnsClientTest {
+
+    @Test
+    public void testReverseIpFormat() {
+
+        DnsClient dnsClient = new DnsClient();
+
+        // Test IPv4 reverse format.
+        assertEquals("40.30.20.10.in-addr.arpa.", dnsClient.getInverseAddressFormat("10.20.30.40"));
+
+        // Test IPv6 reverse format.
+        assertEquals("1.0.0.b.1.a.7.0.0.0.0.0.0.0.0.0.0.1.0.0.0.0.8.0.0.8.8.a.4.0.6.2.ip6.arpa.",
+                     dnsClient.getInverseAddressFormat("2604:a880:800:10::7a1:b001"));
+    }
+
+    @Test
+    public void testValidIp4Address() {
+
+        assertTrue(DnsClient.isIp4Address("8.8.8.8"));
+        assertTrue(DnsClient.isIp4Address("127.0.0.1"));
+        assertFalse(DnsClient.isIp4Address("t127.0.0.1"));
+        assertFalse(DnsClient.isIp4Address("google.com"));
+    }
+
+    @Test
+    public void testValidIp6Address() {
+
+        assertTrue(DnsClient.isIp6Address("2607:f8b0:4000:812::200e"));
+        assertTrue(DnsClient.isIp6Address("2606:2800:220:1:248:1893:25c8:1946"));
+        assertFalse(DnsClient.isIp6Address("t2606:2800:220:1:248:1893:25c8:1946"));
+        assertFalse(DnsClient.isIp6Address("google.com"));
+    }
+
+    @Test
+    public void testValidCommaSeparatedIps() {
+
+        assertTrue(DnsClient.allIpAddressesValid("8.8.4.4:53, 8.8.8.8")); // Custom port.
+        assertTrue(DnsClient.allIpAddressesValid("8.8.4.4, ")); // Extra comma
+        assertTrue(DnsClient.allIpAddressesValid("8.8.4.4")); // Pure IP
+        assertFalse(DnsClient.allIpAddressesValid("8.8.4.4dfs:53, 8.8.4.4:59")); // Not an IP address
+        assertFalse(DnsClient.allIpAddressesValid("8.8.4.4 8.8.8.8")); // No comma separator
+        assertFalse(DnsClient.allIpAddressesValid("8.8.4.4, google.com")); // Hostname is not an IP address
+    }
+
+    @Test
+    public void testValidHostname() {
+
+        assertTrue(DnsClient.isHostName("google.com"));
+        assertTrue(DnsClient.isHostName("api.graylog.com"));
+        assertFalse(DnsClient.isHostName("http://api.graylog.com")); // Prefix not allowed
+        assertFalse(DnsClient.isHostName("api.graylog.com/10")); // URL params not allowed
+        assertFalse(DnsClient.isHostName("api.graylog.com?name=dano")); // Query strings not allowed.
+    }
+
+    /**
+     * This test ensures that Google Guava domain parsing is working as expected (helps add protection for if
+     * the Guava dependency is upgraded in the future.)
+     */
+    @Test
+    public void testExtractShortDomain() {
+
+        // Verify that Google Guava correctly returns just the top domain for multi-level TLDs.
+        // Eg. lb01.store.amazon.co.uk should resolve to just amazon.co.uk
+        InternetDomainName internetDomainName = InternetDomainName.from("lb01.store.amazon.co.uk");
+        assertEquals("amazon.co.uk", internetDomainName.topDomainUnderRegistrySuffix().toString());
+    }
+
+    /**
+     * The logic that parses reverse lookup domains is complex, so it needs to be tested.
+     */
+    @Test
+    public void testParseReverseLookupDomain() {
+
+        // Test all of the types of domains that parsing is performed for.
+        PtrDnsAnswer result = buildReverseLookupDomainTest("subdomain.test.co.uk");
+        assertEquals("subdomain.test.co.uk", result.fullDomain());
+        assertEquals("test.co.uk", result.domain());
+
+        result = buildReverseLookupDomainTest("subdomain.test.com");
+        assertEquals("subdomain.test.com", result.fullDomain());
+        assertEquals("test.com", result.domain());
+
+        // Test some completely bogus domain to verify that the manual domain parsing is exercised.
+        result = buildReverseLookupDomainTest("blah.blahblah.lala.blaaa");
+        assertEquals("blah.blahblah.lala.blaaa", result.fullDomain());
+        assertEquals("lala.blaaa", result.domain());
+
+        // Test a single word domain
+        result = buildReverseLookupDomainTest("HahaOneWordDomainTryingToBreakTheSoftware");
+        assertEquals("HahaOneWordDomainTryingToBreakTheSoftware", result.fullDomain());
+        assertEquals("HahaOneWordDomainTryingToBreakTheSoftware", result.domain());
+    }
+
+    private PtrDnsAnswer buildReverseLookupDomainTest(String hostname) {
+
+        PtrDnsAnswer.Builder builder = PtrDnsAnswer.builder();
+        builder.dnsTTL(1L);
+        DnsClient.parseReverseLookupDomain(builder, hostname);
+
+        return builder.build();
+    }
+}

--- a/graylog2-web-interface/src/components/lookup-tables/adapters/DnsAdapterDocumentation.jsx
+++ b/graylog2-web-interface/src/components/lookup-tables/adapters/DnsAdapterDocumentation.jsx
@@ -1,0 +1,158 @@
+import React from 'react';
+
+const DnsAdapterDocumentation = () => {
+  const styleMarginBottom = { marginBottom: 10 };
+  const codeStyle = { fontSize: 10 };
+
+  const aResponse = `{
+  "single_value": "34.239.63.98",
+  "multi_value": {
+    "results": [
+      {
+        "ip_address": "34.239.63.98",
+        "dns_ttl": 60
+      },
+      {
+        "ip_address": "34.238.48.57",
+        "dns_ttl": 60
+      }
+    ]
+  },
+  "ttl": 60000
+}`;
+
+  const aaaaResponse = `{
+  "single_value": "2307:f8b0:3000:800:0:0:0:200e",
+  "multi_value": {
+    "results": [
+      {
+        "ip_address": "2307:f8b0:3000:800:0:0:0:200e",
+        "dns_ttl": 77
+      }
+    ]
+  },
+  "ttl": 77000
+}`;
+
+  const aAndAaaaResponse = `{
+  "single_value": "144.222.6.132",
+  "multi_value": {
+    "results": [
+      {
+        "ip_address": "144.222.6.132",
+        "dns_ttl": 32,
+        "ip_version": "IPv4"
+      },
+      {
+        "ip_address": "1207:f8b1:6003:b01:0:0:0:8a",
+        "dns_ttl": 299,
+        "ip_version": "IPv6"
+      }
+    ]
+  },
+  "ttl": 32000
+}`;
+
+  const ptrResponse = `{
+  "single_value": "c-45-216-65-41.hd1.fl.someisp.co.uk",
+  "multi_value": {
+    "domain": "someisp.co.uk",
+    "full_domain": "c-45-216-65-41.hd1.fl.someisp.co.uk",
+    "dns_ttl": "300",
+  },
+  "ttl": 300000
+}`;
+
+  const txtResponse = `{
+  "single_value": null,
+  "multi_value": {
+    "results": [
+      {
+        "value": "Some text value that lives in a TXT DNS",
+        "dns_ttl": 300
+      },
+      {
+        "value": "v=spf1 include:some-email-domain.org ~all.",
+        "dns_ttl": 200
+      }
+    ]
+  },
+  "ttl": 200000
+}`;
+
+  return (
+
+
+    <div>
+
+      <h3 style={styleMarginBottom}>Configuration</h3>
+
+      <h5 style={styleMarginBottom}>DNS Lookup Type</h5>
+
+      <p style={styleMarginBottom}>
+        <strong>Resolve hostname to IPv4 address (A)</strong>: Returns both a <code>single_value</code> containing one
+        of the IPv4 addresses that the hostname resolves to,
+        and a <code>multi_value</code> containing all IPv4 addresses that the hostname resolves to.
+        Input for this type must be a pure domain name (eg. <code>api.graylog.com</code>).
+      </p>
+      <pre style={codeStyle}>{aResponse}</pre>
+
+      <p style={styleMarginBottom}>
+        <strong>Resolve hostname to IPv6 address (AAAA)</strong>: Returns both a <code>single_value</code> containing
+        one of the IPv6 addresses that the hostname resolves to,
+        and a <code>multi_value</code> containing all IPv6 addresses that the hostname resolves to.
+        Input for this type must be a pure domain name (eg. <code>api.graylog.com</code>).
+      </p>
+      <pre style={codeStyle}>{aaaaResponse}</pre>
+
+      <p style={styleMarginBottom}>
+        <strong>Resolve hostname to IPv4 and IPv6 address (A and AAAA)</strong>: Returns both
+        a <code>single_value</code> containing
+        one of the IPv4 or IPv6 addresses that the hostname resolves to (will return IPv4 if available),
+        and a <code>multi_value</code> containing all IPv4 and IPv6 addresses that the hostname resolves to.
+        Input for this type must be a pure domain name (eg. <code>api.graylog.com</code>).
+      </p>
+      <pre style={codeStyle}>{aAndAaaaResponse}</pre>
+
+      <p style={styleMarginBottom}>
+        <strong>Reverse lookup (PTR)</strong>: Returns a <code>single_value</code> containing the PTR value if defined
+        for the IP address. The <code>domain</code> field displays the domain name (with no subdomains).
+        The <code>full_domain</code> field displays the full un-trimmed host name/PTR value.
+        The input for this type must be a pure IPv4 or IPv6 address
+        (eg. <code>10.0.0.1</code> or <code>2622:f3b0:4000:812::200c</code>).
+      </p>
+      <pre style={codeStyle}>{ptrResponse}</pre>
+
+      <p style={styleMarginBottom}>
+        <strong>Text lookup (TXT)</strong>: Returns a <code>multi_value</code> with all TXT records defined for the
+        hostname.
+        Input for this type must be a pure domain name (eg. <code>api.graylog.com</code>).
+      </p>
+      <pre style={codeStyle}>{txtResponse}</pre>
+
+      <h5 style={styleMarginBottom}>DNS Server IP Addresses</h5>
+
+      <p style={styleMarginBottom}>
+        A comma-separated list of DNS server IP addresses and optional ports to use (eg. <code>192.168.1.1:5353,
+        192.168.1.244</code>).
+        Leave this blank to use the DNS server defined for your local system. All requests use port 53 unless
+        otherwise specified.
+      </p>
+
+      <h5 style={styleMarginBottom}>DNS Request Timeout</h5>
+
+      <p style={styleMarginBottom}>
+        The DNS request timeout in milliseconds.
+      </p>
+
+      <h5 style={styleMarginBottom}>Cache TTL Override</h5>
+
+      <p style={styleMarginBottom}>
+        If enabled, the TTL for this adapter&apos;s cache will be overridden with the specified value.
+      </p>
+
+    </div>
+  );
+};
+
+export default DnsAdapterDocumentation;

--- a/graylog2-web-interface/src/components/lookup-tables/adapters/DnsAdapterFieldSet.jsx
+++ b/graylog2-web-interface/src/components/lookup-tables/adapters/DnsAdapterFieldSet.jsx
@@ -1,0 +1,107 @@
+import PropTypes from 'prop-types';
+import React from 'react';
+import ObjectUtils from 'util/ObjectUtils';
+
+import { Input } from 'components/bootstrap';
+import { Select, TimeUnitInput } from 'components/common';
+
+
+class DnsAdapterFieldSet extends React.Component {
+  static propTypes = {
+    config: PropTypes.shape({
+      request_timeout: PropTypes.number.isRequired,
+      server_ips: PropTypes.string,
+    }).isRequired,
+    updateConfig: PropTypes.func.isRequired,
+    handleFormEvent: PropTypes.func.isRequired,
+    validationMessage: PropTypes.func.isRequired,
+    validationState: PropTypes.func.isRequired,
+  };
+
+  _onLookupTypeSelect = (id) => {
+    const config = ObjectUtils.clone(this.props.config);
+    config.lookup_type = id;
+    this.props.updateConfig(config);
+  };
+
+  updateCacheTTLOverride = (value, unit, enabled) => {
+    this._updateCacheTTLOverride(value, unit, enabled, 'cache_ttl_override');
+  };
+
+  _updateCacheTTLOverride = (value, unit, enabled, fieldPrefix) => {
+    const config = ObjectUtils.clone(this.props.config);
+
+    // If Cache TTL Override box is checked, then save the value. If not, then do not save it.
+    if (enabled && value) {
+      config[fieldPrefix] = enabled && value ? value : null;
+      config[`${fieldPrefix}_enabled`] = enabled;
+    } else {
+      config[fieldPrefix] = null;
+      config[`${fieldPrefix}_enabled`] = false;
+    }
+
+    config[`${fieldPrefix}_unit`] = enabled ? unit : null;
+    this.props.updateConfig(config);
+  };
+
+  render() {
+    const { config } = this.props;
+    const lookupTypes = [
+      { label: 'Resolve hostname to IPv4 address (A)', value: 'A' },
+      { label: 'Resolve hostname to IPv6 address (AAAA)', value: 'AAAA' },
+      { label: 'Resolve hostname to IPv4 and IPv6 addresses (A and AAAA)', value: 'A_AAAA' },
+      { label: 'Reverse lookup (PTR)', value: 'PTR' },
+      { label: 'Text lookup (TXT)', value: 'TXT' },
+    ];
+
+    return (
+      <fieldset>
+        <Input label="DNS Lookup Type"
+               id="lookup-type"
+               required
+               autoFocus
+               help="Select the type of DNS lookup to perform."
+               labelClassName="col-sm-3"
+               wrapperClassName="col-sm-9">
+          <Select placeholder="Select the type of DNS lookup"
+                  clearable={false}
+                  options={lookupTypes}
+                  matchProp="value"
+                  onChange={this._onLookupTypeSelect}
+                  value={config.lookup_type} />
+        </Input>
+        <Input type="text"
+               id="server_ips"
+               name="server_ips"
+               label="DNS Server IP Address"
+               onChange={this.props.handleFormEvent}
+               help={this.props.validationMessage('server_ips', 'An optional comma-separated list of DNS server IP addresses.')}
+               bsStyle={this.props.validationState('server_ips')}
+               value={config.server_ips}
+               labelClassName="col-sm-3"
+               wrapperClassName="col-sm-9" />
+        <Input type="number"
+               id="request_timeout"
+               name="request_timeout"
+               label="DNS Request Timeout"
+               required
+               onChange={this.props.handleFormEvent}
+               help={this.props.validationMessage('request_timeout', 'DNS request timeout in milliseconds.')}
+               bsStyle={this.props.validationState('request_timeout')}
+               value={config.request_timeout}
+               labelClassName="col-sm-3"
+               wrapperClassName="col-sm-9" />
+        <TimeUnitInput label="Cache TTL Override"
+                       help="If enabled, the TTL for this adapter&amp;s cache will be overridden with the specified value."
+                       update={this.updateCacheTTLOverride}
+                       value={config.cache_ttl_override}
+                       unit={config.cache_ttl_override_unit || 'MINUTES'}
+                       enabled={config.cache_ttl_override_enabled}
+                       labelClassName="col-sm-3"
+                       wrapperClassName="col-sm-9" />
+      </fieldset>
+    );
+  }
+}
+
+export default DnsAdapterFieldSet;

--- a/graylog2-web-interface/src/components/lookup-tables/adapters/DnsAdapterSummary.jsx
+++ b/graylog2-web-interface/src/components/lookup-tables/adapters/DnsAdapterSummary.jsx
@@ -1,0 +1,43 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { TimeUnit } from 'components/common';
+
+const DnsAdapterSummary = ({ dataAdapter }) => {
+  const { config } = dataAdapter;
+
+  // Allows enum > display label translation.
+  const lookupType = {
+    A: 'Resolve hostname to IPv4 address (A)',
+    AAAA: 'Resolve hostname to IPv6 address (AAAA)',
+    A_AAAA: 'Resolve hostname to IPv4 and IPv6 address (A and AAAA)',
+    PTR: 'Reverse lookup (PTR)',
+    TXT: 'Text lookup (TXT)',
+  };
+
+  return (<dl>
+    <dt>DNS Lookup Type</dt>
+    <dd>{ lookupType[config.lookup_type] }</dd>
+
+    <dt>DNS Server IP Address</dt>
+    <dd>{ config.server_ips || 'n/a' }</dd>
+
+    <dt>DNS Request Timeout</dt>
+    <dd>{ config.request_timeout } ms</dd>
+
+    <dt>Cache TTL Override</dt>
+    <dd>
+      { !config.cache_ttl_override_enabled ? 'n/a' : <TimeUnit value={config.cache_ttl_override} unit={config.cache_ttl_override_unit} /> }
+    </dd>
+  </dl>);
+};
+
+DnsAdapterSummary.propTypes = {
+  dataAdapter: PropTypes.shape({
+    config: PropTypes.shape({
+      lookup_type: PropTypes.string.isRequired,
+      request_timeout: PropTypes.number.isRequired,
+    }),
+  }).isRequired,
+};
+
+export default DnsAdapterSummary;

--- a/graylog2-web-interface/src/components/lookup-tables/adapters/index.js
+++ b/graylog2-web-interface/src/components/lookup-tables/adapters/index.js
@@ -1,8 +1,12 @@
 import { PluginManifest, PluginStore } from 'graylog-web-plugin/plugin';
 
+import {} from 'components/maps/adapter';
 import CSVFileAdapterFieldSet from './CSVFileAdapterFieldSet';
 import CSVFileAdapterSummary from './CSVFileAdapterSummary';
 import CSVFileAdapterDocumentation from './CSVFileAdapterDocumentation';
+import DnsAdapterFieldSet from './DnsAdapterFieldSet';
+import DnsAdapterSummary from './DnsAdapterSummary';
+import DnsAdapterDocumentation from './DnsAdapterDocumentation';
 import DSVHTTPAdapterFieldSet from './DSVHTTPAdapterFieldSet';
 import DSVHTTPAdapterSummary from './DSVHTTPAdapterSummary';
 import DSVHTTPAdapterDocumentation from './DSVHTTPAdapterDocumentation';
@@ -20,11 +24,11 @@ PluginStore.register(new PluginManifest({}, {
       documentationComponent: CSVFileAdapterDocumentation,
     },
     {
-      type: 'httpjsonpath',
-      displayName: 'HTTP JSONPath',
-      formComponent: HTTPJSONPathAdapterFieldSet,
-      summaryComponent: HTTPJSONPathAdapterSummary,
-      documentationComponent: HTTPJSONPathAdapterDocumentation,
+      type: 'dnslookup',
+      displayName: 'DNS Lookup',
+      formComponent: DnsAdapterFieldSet,
+      summaryComponent: DnsAdapterSummary,
+      documentationComponent: DnsAdapterDocumentation,
     },
     {
       type: 'dsvhttp',
@@ -32,6 +36,13 @@ PluginStore.register(new PluginManifest({}, {
       formComponent: DSVHTTPAdapterFieldSet,
       summaryComponent: DSVHTTPAdapterSummary,
       documentationComponent: DSVHTTPAdapterDocumentation,
+    },
+    {
+      type: 'httpjsonpath',
+      displayName: 'HTTP JSONPath',
+      formComponent: HTTPJSONPathAdapterFieldSet,
+      summaryComponent: HTTPJSONPathAdapterSummary,
+      documentationComponent: HTTPJSONPathAdapterDocumentation,
     },
   ],
 }));

--- a/pom.xml
+++ b/pom.xml
@@ -98,7 +98,7 @@
         <gelfclient.version>1.4.1</gelfclient.version>
         <grok.version>0.1.7-graylog</grok.version>
         <guava-retrying.version>2.0.0</guava-retrying.version>
-        <guava.version>23.0</guava.version>
+        <guava.version>23.6.1-jre</guava.version>
         <guice.version>4.1.0</guice.version>
         <HdrHistogram.version>2.1.10</HdrHistogram.version>
         <hibernate-validator.version>6.0.2.Final</hibernate-validator.version>
@@ -125,6 +125,7 @@
         <mongojack.version>2.7.0</mongojack.version>
         <natty.version>0.13</natty.version>
         <netty.version>3.10.6.Final</netty.version>
+        <netty4.version>4.1.31.Final</netty4.version>
         <okhttp.version>3.9.0</okhttp.version>
         <opencsv.version>2.3</opencsv.version>
         <os-platform-finder.version>1.2.2</os-platform-finder.version>


### PR DESCRIPTION
Backport DNS Lookup adapter to version 2.5. 
    
Add/update dependencies to allow backport:
- Add Netty 4.1.31.FINAL dependency
- Upgrade Google Guava from 23 to 23.6.1-jre

See https://github.com/Graylog2/graylog2-server/commit/5d755477c46150345ff111d54f45ae5cf1b87938 for original commit in master.