### PR TITLE
Overwrite 'gl2serverurl' with an environment variable 'GL2_SERVER_URL'

### DIFF
--- a/graylog2-web-interface/src/util/AppConfig.js
+++ b/graylog2-web-interface/src/util/AppConfig.js
@@ -1,5 +1,10 @@
 const AppConfig = {
   gl2ServerUrl() {
+    if (typeof (GL2_SERVER_URL) !== 'undefined') {
+      // The GL2_SERVER_URL variable will be set by webpack via the DefinePlugin.
+      // eslint-disable-next-line no-undef
+      return GL2_SERVER_URL;
+    }
     return this.appConfig().gl2ServerUrl;
   },
 

--- a/graylog2-web-interface/webpack.config.js
+++ b/graylog2-web-interface/webpack.config.js
@@ -123,6 +123,7 @@ if (TARGET === 'start') {
     plugins: [
       new webpack.DefinePlugin({
         DEVELOPMENT: true,
+        GL2_SERVER_URL: JSON.stringify(process.env.GL2_SERVER_URL),
       }),
       new CopyWebpackPlugin([{ from: 'config.js' }]),
       new webpack.HotModuleReplacementPlugin(),


### PR DESCRIPTION
This allows us to start a developement server on an SSL enabled API:

 `$ GL2_SERVER_URL=https://localhost:9000/api npm run start`
