### PR TITLE
Remove Sidecar collector configuration path

### DIFF
--- a/graylog2-server/src/main/java/org/graylog/plugins/sidecar/migrations/V20180212165000_AddDefaultCollectors.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/sidecar/migrations/V20180212165000_AddDefaultCollectors.java
@@ -118,7 +118,6 @@ public class V20180212165000_AddDefaultCollectors extends Migration {
         final FindIterable<Document> documentsWithConfigPath = collection.find(exists("configuration_path"));
         for (Document document : documentsWithConfigPath) {
             final ObjectId objectId = document.getObjectId("_id");
-            System.out.print( document);
             document.remove("configuration_path");
             final UpdateResult updateResult = collection.replaceOne(eq("_id", objectId), document);
             if (updateResult.wasAcknowledged()) {

--- a/graylog2-server/src/main/java/org/graylog/plugins/sidecar/rest/models/Collector.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/sidecar/rest/models/Collector.java
@@ -16,9 +16,7 @@
  */
 package org.graylog.plugins.sidecar.rest.models;
 
-import com.fasterxml.jackson.annotation.JsonAutoDetect;
-import com.fasterxml.jackson.annotation.JsonCreator;
-import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.*;
 import com.google.auto.value.AutoValue;
 import org.mongojack.Id;
 import org.mongojack.ObjectId;
@@ -33,7 +31,6 @@ public abstract class Collector {
     public static final String FIELD_SERVICE_TYPE = "service_type";
     public static final String FIELD_NODE_OPERATING_SYSTEM = "node_operating_system";
     public static final String FIELD_EXECUTABLE_PATH = "executable_path";
-    public static final String FIELD_CONFIGURATION_PATH = "configuration_path";
     public static final String FIELD_EXECUTE_PARAMETERS = "execute_parameters";
     public static final String FIELD_VALIDATION_PARAMETERS = "validation_parameters";
     public static final String FIELD_DEFAULT_TEMPLATE = "default_template";
@@ -56,9 +53,6 @@ public abstract class Collector {
 
     @JsonProperty(FIELD_EXECUTABLE_PATH)
     public abstract String executablePath();
-
-    @JsonProperty(FIELD_CONFIGURATION_PATH)
-    public abstract String configurationPath();
 
     @JsonProperty(FIELD_EXECUTE_PARAMETERS)
     @Nullable
@@ -84,7 +78,6 @@ public abstract class Collector {
         public abstract Builder serviceType(String serviceType);
         public abstract Builder nodeOperatingSystem(String nodeOperatingSystem);
         public abstract Builder executablePath(String executablePath);
-        public abstract Builder configurationPath(String configurationPath);
         public abstract Builder executeParameters(String executeParameters);
         public abstract Builder validationParameters(String validationParameters);
         public abstract Builder defaultTemplate(String defaultTemplate);
@@ -97,7 +90,6 @@ public abstract class Collector {
                                    @JsonProperty(FIELD_SERVICE_TYPE) String serviceType,
                                    @JsonProperty(FIELD_NODE_OPERATING_SYSTEM) String nodeOperatingSystem,
                                    @JsonProperty(FIELD_EXECUTABLE_PATH) String executablePath,
-                                   @JsonProperty(FIELD_CONFIGURATION_PATH) String configurationPath,
                                    @JsonProperty(FIELD_EXECUTE_PARAMETERS) @Nullable String executeParameters,
                                    @JsonProperty(FIELD_VALIDATION_PARAMETERS) @Nullable String validationParameters,
                                    @JsonProperty(FIELD_DEFAULT_TEMPLATE) String defaultTemplate) {
@@ -107,7 +99,6 @@ public abstract class Collector {
                 .serviceType(serviceType)
                 .nodeOperatingSystem(nodeOperatingSystem)
                 .executablePath(executablePath)
-                .configurationPath(configurationPath)
                 .executeParameters(executeParameters)
                 .validationParameters(validationParameters)
                 .defaultTemplate(defaultTemplate)

--- a/graylog2-server/src/main/java/org/graylog/plugins/sidecar/rest/resources/CollectorResource.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/sidecar/rest/resources/CollectorResource.java
@@ -246,6 +246,9 @@ public class CollectorResource extends RestResource implements PluginRestResourc
     public ValidationResponse validateCollector(
             @ApiParam(name = "name", required = true) @QueryParam("name") String name,
             @ApiParam(name = "id", required = false) @QueryParam("id") String id) {
+        if (!name.matches("^[A-Za-z0-9_.-]+$")) {
+            return ValidationResponse.create(true, "Collector name can only contain the following characters: A-Z,a-z,0-9,_,-,.");
+        }
         final Collector collector;
         if (id == null) {
             collector = collectorService.findByName(name);

--- a/graylog2-server/src/main/java/org/graylog/plugins/sidecar/services/CollectorService.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/sidecar/services/CollectorService.java
@@ -35,7 +35,7 @@ import java.util.stream.Stream;
 
 @Singleton
 public class CollectorService extends PaginatedDbService<Collector> {
-    private static final String COLLECTION_NAME = "sidecar_collectors";
+    public static final String COLLECTION_NAME = "sidecar_collectors";
 
     @Inject
     public CollectorService(MongoConnection mongoConnection,
@@ -90,7 +90,6 @@ public class CollectorService extends PaginatedDbService<Collector> {
                 request.serviceType(),
                 request.nodeOperatingSystem(),
                 request.executablePath(),
-                request.configurationPath(),
                 request.executeParameters(),
                 request.validationParameters(),
                 request.defaultTemplate());

--- a/graylog2-server/src/main/java/org/graylog2/contentpacks/facades/SidecarCollectorFacade.java
+++ b/graylog2-server/src/main/java/org/graylog2/contentpacks/facades/SidecarCollectorFacade.java
@@ -65,7 +65,6 @@ public class SidecarCollectorFacade implements EntityFacade<Collector> {
                 ValueReference.of(collector.serviceType()),
                 ValueReference.of(collector.nodeOperatingSystem()),
                 ValueReference.of(collector.executablePath()),
-                ValueReference.of(collector.configurationPath()),
                 ValueReference.of(collector.executeParameters()),
                 ValueReference.of(collector.validationParameters()),
                 ValueReference.of(collector.defaultTemplate())
@@ -100,7 +99,6 @@ public class SidecarCollectorFacade implements EntityFacade<Collector> {
                 .serviceType(collectorEntity.serviceType().asString(parameters))
                 .nodeOperatingSystem(collectorEntity.nodeOperatingSystem().asString(parameters))
                 .executablePath(collectorEntity.executablePath().asString(parameters))
-                .configurationPath(collectorEntity.configurationPath().asString(parameters))
                 .executeParameters(collectorEntity.executeParameters().asString(parameters))
                 .validationParameters(collectorEntity.validationParameters().asString(parameters))
                 .defaultTemplate(collectorEntity.defaultTemplate().asString(parameters))

--- a/graylog2-server/src/main/java/org/graylog2/contentpacks/model/entities/SidecarCollectorEntity.java
+++ b/graylog2-server/src/main/java/org/graylog2/contentpacks/model/entities/SidecarCollectorEntity.java
@@ -39,9 +39,6 @@ public abstract class SidecarCollectorEntity {
     @JsonProperty("executable_path")
     public abstract ValueReference executablePath();
 
-    @JsonProperty("configuration_path")
-    public abstract ValueReference configurationPath();
-
     @JsonProperty("execute_parameters")
     public abstract ValueReference executeParameters();
 
@@ -56,7 +53,6 @@ public abstract class SidecarCollectorEntity {
                                          @JsonProperty("service_type") ValueReference serviceType,
                                          @JsonProperty("node_operating_system") ValueReference nodeOperatingSystem,
                                          @JsonProperty("executable_path") ValueReference executablePath,
-                                         @JsonProperty("configuration_path") ValueReference configurationPath,
                                          @JsonProperty("execute_parameters") ValueReference executeParameters,
                                          @JsonProperty("validation_parameters") ValueReference validationParameters,
                                          @JsonProperty("default_template") ValueReference defaultTemplate) {
@@ -64,7 +60,6 @@ public abstract class SidecarCollectorEntity {
                 serviceType,
                 nodeOperatingSystem,
                 executablePath,
-                configurationPath,
                 executeParameters,
                 validationParameters,
                 defaultTemplate);

--- a/graylog2-server/src/test/java/org/graylog2/contentpacks/facades/SidecarCollectorFacadeTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/contentpacks/facades/SidecarCollectorFacadeTest.java
@@ -82,7 +82,6 @@ public class SidecarCollectorFacadeTest {
                         ValueReference.of("exec"),
                         ValueReference.of("linux"),
                         ValueReference.of("/usr/lib/graylog-sidecar/filebeat"),
-                        ValueReference.of("/var/lib/graylog-sidecar/generated/filebeat.yml"),
                         ValueReference.of("-c %s"),
                         ValueReference.of("test config -c %s"),
                         ValueReference.of("")), JsonNode.class))
@@ -105,7 +104,6 @@ public class SidecarCollectorFacadeTest {
                         ValueReference.of("exec"),
                         ValueReference.of("linux"),
                         ValueReference.of("/usr/lib/graylog-sidecar/filebeat"),
-                        ValueReference.of("/var/lib/graylog-sidecar/generated/filebeat.yml"),
                         ValueReference.of("-c %s"),
                         ValueReference.of("test config -c %s"),
                         ValueReference.of("")), JsonNode.class))
@@ -124,7 +122,6 @@ public class SidecarCollectorFacadeTest {
                         ValueReference.of("exec"),
                         ValueReference.of("linux"),
                         ValueReference.of("/usr/lib/graylog-sidecar/filebeat"),
-                        ValueReference.of("/var/lib/graylog-sidecar/generated/filebeat.yml"),
                         ValueReference.of("-c %s"),
                         ValueReference.of("test config -c %s"),
                         ValueReference.of("")), JsonNode.class))
@@ -154,7 +151,6 @@ public class SidecarCollectorFacadeTest {
                         ValueReference.of("exec"),
                         ValueReference.of("linux"),
                         ValueReference.of("/usr/lib/graylog-sidecar/filebeat"),
-                        ValueReference.of("/var/lib/graylog-sidecar/generated/filebeat.yml"),
                         ValueReference.of("-c %s"),
                         ValueReference.of("test config -c %s"),
                         ValueReference.of("")), JsonNode.class))
@@ -234,7 +230,6 @@ public class SidecarCollectorFacadeTest {
                         ValueReference.of("exec"),
                         ValueReference.of("linux"),
                         ValueReference.of("/usr/lib/graylog-sidecar/filebeat"),
-                        ValueReference.of("/var/lib/graylog-sidecar/generated/filebeat.yml"),
                         ValueReference.of("-c %s"),
                         ValueReference.of("test config -c %s"),
                         ValueReference.of("")), JsonNode.class))

--- a/graylog2-server/src/test/resources/org/graylog2/contentpacks/sidecar_collectors.json
+++ b/graylog2-server/src/test/resources/org/graylog2/contentpacks/sidecar_collectors.json
@@ -8,7 +8,6 @@
       "service_type": "exec",
       "node_operating_system": "linux",
       "executable_path": "/usr/lib/graylog-sidecar/filebeat",
-      "configuration_path": "/var/lib/graylog-sidecar/generated/filebeat.yml",
       "execute_parameters": "-c %s",
       "validation_parameters": "test config -c %s",
       "default_template": ""
@@ -21,7 +20,6 @@
       "service_type": "svc",
       "node_operating_system": "windows",
       "executable_path": "C:\\Program Files\\Graylog\\sidecar\\winlogbeat.exe",
-      "configuration_path": "C:\\Program Files\\Graylog\\sidecar\\generated\\winlogbeat.yml",
       "execute_parameters": "-c \"%s\"",
       "validation_parameters": "test config -c \"%s\"",
       "default_template": ""
@@ -34,7 +32,6 @@
       "service_type": "exec",
       "node_operating_system": "linux",
       "executable_path": "/usr/lib/graylog-sidecar/nxlog",
-      "configuration_path": "/var/lib/graylog-sidecar/generated/nxlog.conf",
       "execute_parameters": "-f -c %s",
       "validation_parameters": "-v -c %s",
       "default_template": ""

--- a/graylog2-web-interface/src/components/sidecars/configuration-forms/CollectorForm.jsx
+++ b/graylog2-web-interface/src/components/sidecars/configuration-forms/CollectorForm.jsx
@@ -43,7 +43,6 @@ const CollectorForm = createReactClass({
         name: this.props.collector.name,
         service_type: this.props.collector.service_type,
         node_operating_system: this.props.collector.node_operating_system,
-        configuration_path: this.props.collector.configuration_path,
         executable_path: this.props.collector.executable_path,
         execute_parameters: this.props.collector.execute_parameters,
         validation_parameters: this.props.collector.validation_parameters,
@@ -165,14 +164,6 @@ const CollectorForm = createReactClass({
             </FormGroup>
 
             <Input type="text"
-                   id="configurationFilePath"
-                   label="Configuration Path"
-                   onChange={this._onInputChange('configuration_path')}
-                   help="Path to the collector configuration file"
-                   value={this.state.formData.configuration_path}
-                   required />
-
-            <Input type="text"
                    id="executablePath"
                    label="Executable Path"
                    onChange={this._onInputChange('executable_path')}
@@ -184,14 +175,14 @@ const CollectorForm = createReactClass({
                    id="executeParameters"
                    label="Execute Parameters"
                    onChange={this._onInputChange('execute_parameters')}
-                   help="Parameters the collector is started with. %s will be replaced by the path to the configuration file."
+                   help={<span>Parameters the collector is started with.<strong> %s will be replaced by the path to the configuration file.</strong></span>}
                    value={executeParameters} />
 
             <Input type="text"
                    id="validationParameters"
                    label="Parameters for Configuration Validation"
                    onChange={this._onInputChange('validation_parameters')}
-                   help="Parameters that validate the configuration file. %s will be replaced by the path to the configuration file."
+                   help={<span>Parameters that validate the configuration file. <strong> %s will be replaced by the path to the configuration file.</strong></span>}
                    value={validationParameters} />
 
             <FormGroup controlId="defaultTemplate">


### PR DESCRIPTION
Instead of a GUI option, we let the sidecar autogenerate the path
to ".../generated/<collector_name>.conf"

Add validations for the collector name, so it can be used as a filename.