### PR TITLE
Update netty-tcnative to 2.0.19

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -128,7 +128,7 @@
         <mongojack.version>2.8.2</mongojack.version>
         <natty.version>0.13</natty.version>
         <netty.version>4.1.31.Final</netty.version>
-        <netty-tcnative-boringssl-static.version>2.0.12.Final</netty-tcnative-boringssl-static.version>
+        <netty-tcnative-boringssl-static.version>2.0.19.Final</netty-tcnative-boringssl-static.version>
         <okhttp.version>3.11.0</okhttp.version>
         <opencsv.version>2.3</opencsv.version>
         <os-platform-finder.version>1.2.3</os-platform-finder.version>


### PR DESCRIPTION
The netty update to 4.1.31 prevented TLS enabled inputs to start.
The newest netty-tcnative version fixes that.

Fixes #5263
Refs #5250 