### PR TITLE
Update gelfclient version to latest 1.4.4 (uses Netty 4.1.31)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -97,7 +97,7 @@
         <elasticsearch.version>5.6.12</elasticsearch.version>
         <freemarker.version>2.3.28</freemarker.version>
         <jest.version>2.4.13+jackson</jest.version>
-        <gelfclient.version>1.4.3</gelfclient.version>
+        <gelfclient.version>1.4.4</gelfclient.version>
         <geoip2.version>2.12.0</geoip2.version>
         <grok.version>0.1.9</grok.version>
         <guava-retrying.version>2.0.0</guava-retrying.version>


### PR DESCRIPTION
This updates the gelfclient version to latest 1.4.4 (includes Netty 4.1.31) in `master`.