### PR TITLE
Fix flaky ConnectionCounterTest by waiting for serverChannel to be set

### DIFF
--- a/graylog2-server/src/test/java/org/graylog2/plugin/inputs/util/ConnectionCounterTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/plugin/inputs/util/ConnectionCounterTest.java
@@ -85,9 +85,15 @@ public class ConnectionCounterTest {
                     }
                 });
 
+        final CountDownLatch serverChannelLatch = new CountDownLatch(1);
         serverBootstrap.bind(InetAddress.getLocalHost(), 0)
-                .addListener((ChannelFutureListener) future -> serverChannel = future.channel())
+                .addListener((ChannelFutureListener) future -> {
+                    serverChannel = future.channel();
+                    serverChannelLatch.countDown();
+                })
                 .syncUninterruptibly();
+        // Wait for serverChannel to be set to make sure we can use it in tests
+        serverChannelLatch.await(LATCH_TIMEOUT, TimeUnit.SECONDS);
     }
 
     @After


### PR DESCRIPTION
Should fix a NullPointerException seen on Jenkins:
```
java.lang.NullPointerException
  at org.graylog2.plugin.inputs.util.ConnectionCounterTest.testConnectAndDisconnect(ConnectionCounterTest.java:112)
```