### PR TITLE
Allow showing/hiding BootstrapModalForm declaratively.

### DIFF
--- a/graylog2-web-interface/src/components/bootstrap/BootstrapModalForm.jsx
+++ b/graylog2-web-interface/src/components/bootstrap/BootstrapModalForm.jsx
@@ -19,7 +19,6 @@ class BootstrapModalForm extends React.Component {
     submitButtonDisabled: false,
     onModalOpen: () => {},
     onModalClose: () => {},
-    bsSize: 'lg',
     onSubmitForm: undefined,
     onCancel: () => {},
     bsSize: undefined,

--- a/graylog2-web-interface/src/components/bootstrap/BootstrapModalForm.jsx
+++ b/graylog2-web-interface/src/components/bootstrap/BootstrapModalForm.jsx
@@ -23,6 +23,7 @@ class BootstrapModalForm extends React.Component {
     onSubmitForm: undefined,
     onCancel: () => {},
     bsSize: undefined,
+    show: false,
   };
 
   static propTypes = {
@@ -45,9 +46,7 @@ class BootstrapModalForm extends React.Component {
     /* Text to use in the submit button. "Submit" is the default */
     submitButtonText: PropTypes.string,
     submitButtonDisabled: PropTypes.bool,
-    bsSize: PropTypes.oneOf([
-      'large', 'lg', 'small', 'sm',
-    ]),
+    show: PropTypes.bool,
   };
 
   onModalCancel = () => {
@@ -98,6 +97,7 @@ class BootstrapModalForm extends React.Component {
                              onOpen={this.props.onModalOpen}
                              onClose={this.props.onModalClose}
                              bsSize={this.props.bsSize}
+                             showModal={this.props.show}
                              onHide={this.onModalCancel}>
         <Modal.Header closeButton>
           <Modal.Title>{this.props.title}</Modal.Title>

--- a/graylog2-web-interface/src/components/bootstrap/BootstrapModalForm.test.jsx
+++ b/graylog2-web-interface/src/components/bootstrap/BootstrapModalForm.test.jsx
@@ -1,0 +1,73 @@
+import React from 'react';
+import { mount } from 'enzyme';
+import BootstrapModalForm from './BootstrapModalForm';
+
+describe('BootstrapModalForm', () => {
+  const children = <span>42</span>;
+  it('shows modal form when triggering open', () => {
+    const wrapper = mount(<BootstrapModalForm title="Sample Form">
+      {children}
+    </BootstrapModalForm>);
+    expect(wrapper).not.toContainReact(children);
+    wrapper.instance().open();
+    wrapper.update();
+    expect(wrapper).toContainReact(children);
+  });
+  it('hides modal form when triggering close', () => {
+    const wrapper = mount(<BootstrapModalForm title="Sample Form">
+      {children}
+    </BootstrapModalForm>);
+    expect(wrapper).not.toContainReact(children);
+
+    wrapper.instance().open();
+    wrapper.update();
+    expect(wrapper).toContainReact(children);
+    expect(wrapper.find('Modal').at(0)).toHaveProp('show', true);
+
+    wrapper.instance().close();
+    wrapper.update();
+    expect(wrapper.find('Modal').at(0)).toHaveProp('show', false);
+  });
+  it('calls onOpen when triggering open', (done) => {
+    const wrapper = mount(<BootstrapModalForm show={false} title="Sample Form" onModalOpen={done}>
+      {children}
+    </BootstrapModalForm>);
+    wrapper.instance().open();
+  });
+  it('calls onClose when triggering close', (done) => {
+    const wrapper = mount(<BootstrapModalForm show title="Sample Form" onModalClose={done}>
+      {children}
+    </BootstrapModalForm>);
+    wrapper.instance().close();
+  });
+  it('does not show modal form when show property is false', () => {
+    const wrapper = mount(<BootstrapModalForm show={false} title="Sample Form">
+      {children}
+    </BootstrapModalForm>);
+    expect(wrapper).not.toContainReact(children);
+  });
+  it('shows modal form when show property is true', () => {
+    const wrapper = mount(<BootstrapModalForm show title="Sample Form">
+      {children}
+    </BootstrapModalForm>);
+    expect(wrapper).toContainReact(children);
+  });
+  it('calls onSubmit when form is submitted', (done) => {
+    const onHide = jest.fn();
+    const wrapper = mount(<BootstrapModalForm show title="Sample Form" onSubmitForm={() => done()} onHide={onHide}>
+      {children}
+    </BootstrapModalForm>);
+    const form = wrapper.find('form');
+    form.simulate('submit');
+    expect(onHide).not.toHaveBeenCalled();
+  });
+  it('calls onCancel when form is cancelled', (done) => {
+    const onSubmitForm = jest.fn();
+    const wrapper = mount(<BootstrapModalForm show title="Sample Form" onSubmitForm={onSubmitForm} onCancel={done}>
+      {children}
+    </BootstrapModalForm>);
+    const cancel = wrapper.find('button[children="Cancel"]');
+    cancel.simulate('click');
+    expect(onSubmitForm).not.toHaveBeenCalled();
+  });
+});

--- a/graylog2-web-interface/src/components/users/__snapshots__/UserPreferencesButton.test.jsx.snap
+++ b/graylog2-web-interface/src/components/users/__snapshots__/UserPreferencesButton.test.jsx.snap
@@ -32,6 +32,7 @@ exports[`UserPreferencesButton should load user data when user clicks edit butto
         onModalClose={[Function]}
         onModalOpen={[Function]}
         onSubmitForm={[Function]}
+        show={false}
         submitButtonDisabled={false}
         submitButtonText="Save"
         title="Preferences for user Full"


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Before this change, the `BootstrapModalForm` component relied on the
consumer calling the `open`/`close` functions, which does not align well
with the way react is used declaratively.

This change leaves this functionality in place but also adds a `show`
property (being `false` by default) which allows to show a modal when
the property is `true`.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
