### PR TITLE
Fix alignment of content pack selection

### DIFF
--- a/graylog2-web-interface/src/components/content-packs/ContentPackSelection.jsx
+++ b/graylog2-web-interface/src/components/content-packs/ContentPackSelection.jsx
@@ -248,12 +248,12 @@ class ContentPackSelection extends React.Component {
           </Col>
         </Row>
         <Row>
-          <Col smOffset={1}>
+          <Col smOffset={1} lg={8}>
             <h2>Content Pack selection</h2>
           </Col>
         </Row>
         <Row>
-          <Col smOffset={1}>
+          <Col smOffset={1} lg={8}>
             <SearchForm
               id="filter-input"
               onSearch={this._onSetFilter}
@@ -263,7 +263,7 @@ class ContentPackSelection extends React.Component {
           </Col>
         </Row>
         <Row>
-          <Col smOffset={1} sm={8}>
+          <Col smOffset={1} sm={8} lg={8}>
             {errors.selection && <Panel bsStyle="danger">{errors.selection}</Panel> }
             <ExpandableList>
               {entitiesComponent}

--- a/graylog2-web-interface/src/components/content-packs/__snapshots__/ContentPackEdit.test.jsx.snap
+++ b/graylog2-web-interface/src/components/content-packs/__snapshots__/ContentPackEdit.test.jsx.snap
@@ -265,7 +265,7 @@ exports[`<ContentPackEdit /> should render empty content pack for create 1`] = `
           className="row"
         >
           <div
-            className="col-sm-offset-1"
+            className="col-lg-8 col-sm-offset-1"
           >
             <h2>
               Content Pack selection
@@ -276,7 +276,7 @@ exports[`<ContentPackEdit /> should render empty content pack for create 1`] = `
           className="row"
         >
           <div
-            className="col-sm-offset-1"
+            className="col-lg-8 col-sm-offset-1"
           >
             <div
               className="search"
@@ -350,7 +350,7 @@ exports[`<ContentPackEdit /> should render empty content pack for create 1`] = `
           className="row"
         >
           <div
-            className="col-sm-8 col-sm-offset-1"
+            className="col-lg-8 col-sm-8 col-sm-offset-1"
           >
             <ul
               className="list"
@@ -739,7 +739,7 @@ exports[`<ContentPackEdit /> should render with content pack for edit 1`] = `
           className="row"
         >
           <div
-            className="col-sm-offset-1"
+            className="col-lg-8 col-sm-offset-1"
           >
             <h2>
               Content Pack selection
@@ -750,7 +750,7 @@ exports[`<ContentPackEdit /> should render with content pack for edit 1`] = `
           className="row"
         >
           <div
-            className="col-sm-offset-1"
+            className="col-lg-8 col-sm-offset-1"
           >
             <div
               className="search"
@@ -824,7 +824,7 @@ exports[`<ContentPackEdit /> should render with content pack for edit 1`] = `
           className="row"
         >
           <div
-            className="col-sm-8 col-sm-offset-1"
+            className="col-lg-8 col-sm-8 col-sm-offset-1"
           >
             <ul
               className="list"

--- a/graylog2-web-interface/src/components/content-packs/__snapshots__/ContentPackSelection.test.jsx.snap
+++ b/graylog2-web-interface/src/components/content-packs/__snapshots__/ContentPackSelection.test.jsx.snap
@@ -164,7 +164,7 @@ exports[`<ContentPackSelection /> should render with empty content pack 1`] = `
     className="row"
   >
     <div
-      className="col-sm-offset-1"
+      className="col-lg-8 col-sm-offset-1"
     >
       <h2>
         Content Pack selection
@@ -175,7 +175,7 @@ exports[`<ContentPackSelection /> should render with empty content pack 1`] = `
     className="row"
   >
     <div
-      className="col-sm-offset-1"
+      className="col-lg-8 col-sm-offset-1"
     >
       <div
         className="search"
@@ -249,7 +249,7 @@ exports[`<ContentPackSelection /> should render with empty content pack 1`] = `
     className="row"
   >
     <div
-      className="col-sm-8 col-sm-offset-1"
+      className="col-lg-8 col-sm-8 col-sm-offset-1"
     >
       <ul
         className="list"
@@ -428,7 +428,7 @@ exports[`<ContentPackSelection /> should render with filled content pack 1`] = `
     className="row"
   >
     <div
-      className="col-sm-offset-1"
+      className="col-lg-8 col-sm-offset-1"
     >
       <h2>
         Content Pack selection
@@ -439,7 +439,7 @@ exports[`<ContentPackSelection /> should render with filled content pack 1`] = `
     className="row"
   >
     <div
-      className="col-sm-offset-1"
+      className="col-lg-8 col-sm-offset-1"
     >
       <div
         className="search"
@@ -513,7 +513,7 @@ exports[`<ContentPackSelection /> should render with filled content pack 1`] = `
     className="row"
   >
     <div
-      className="col-sm-8 col-sm-offset-1"
+      className="col-lg-8 col-sm-8 col-sm-offset-1"
     >
       <ul
         className="list"


### PR DESCRIPTION
## Description
Fix alignment of content pack selection by adding `lg` prop to all `Row`s.

## Motivation and Context
The alignment of the input fields with the content pack selection was not proper.

## Screenshots (if appropriate):
![graylog - content packs 9](https://user-images.githubusercontent.com/448763/48764323-a6ff9600-ecaf-11e8-992c-8795bccb4035.png)

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
