### PR TITLE
Redirect to content pack overview if no content pack can be found

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/rest/resources/system/contentpacks/ContentPackResource.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/resources/system/contentpacks/ContentPackResource.java
@@ -143,6 +143,9 @@ public class ContentPackResource extends RestResource {
                 .collect(Collectors.toMap(Revisioned::revision, Function.identity()));
         Map<Integer, Set<ConstraintCheckResult>> constraintMap = contentPacks.stream()
                 .collect(Collectors.toMap(Revisioned::revision, contentPackService::checkConstraints));
+        if(contentPackMap.size() <= 0) {
+            throw new NotFoundException("Content pack " + id + " not found!");
+        }
 
         return ContentPackRevisions.create(contentPackMap, constraintMap);
     }

--- a/graylog2-web-interface/src/pages/ShowContentPackPage.jsx
+++ b/graylog2-web-interface/src/pages/ShowContentPackPage.jsx
@@ -35,7 +35,9 @@ const ShowContentPackPage = createReactClass({
 
 
   componentDidMount() {
-    ContentPacksActions.get(this.props.params.contentPackId);
+    ContentPacksActions.get(this.props.params.contentPackId).catch(() => {
+      window.location = '/system/contentpacks';
+    });
     ContentPacksActions.installList(this.props.params.contentPackId);
   },
 
@@ -47,16 +49,16 @@ const ShowContentPackPage = createReactClass({
     if (window.confirm('You are about to delete this content pack, are you sure?')) {
       ContentPacksActions.deleteRev(contentPackId, revision).then(() => {
         UserNotification.success('Content Pack deleted successfully.', 'Success');
-        ContentPacksActions.get(contentPackId);
+        ContentPacksActions.get(contentPackId).catch(() => {
+          window.location = '/system/contentpacks';
+        });
       }, (error) => {
-        /* eslint-disable camelcase */
-        let err_message = error.message;
-        const err_body = error.additional.body;
-        /* eslint-enable camlecase */
-        if (err_body && err_body.message) {
-          err_message = error.additional.body.message;
+        let errMessage = error.message;
+        const errBody = error.additional.body;
+        if (errBody && errBody.message) {
+          errMessage = error.additional.body.message;
         }
-        UserNotification.error(`Deleting bundle failed: ${err_message}`, 'Error');
+        UserNotification.error(`Deleting bundle failed: ${errMessage}`, 'Error');
       });
     }
   },

--- a/graylog2-web-interface/src/pages/ShowContentPackPage.jsx
+++ b/graylog2-web-interface/src/pages/ShowContentPackPage.jsx
@@ -36,7 +36,7 @@ const ShowContentPackPage = createReactClass({
 
 
   componentDidMount() {
-    ContentPacksActions.get(this.props.params.contentPackId).catch((error) => {
+    ContentPacksActions.get(this.props.params.contentPackId).catch(() => {
       UserNotification.error("Cannot find a matching Content Pack.");
       history.push(Routes.SYSTEM.CONTENTPACKS.LIST);
     });

--- a/graylog2-web-interface/src/pages/ShowContentPackPage.jsx
+++ b/graylog2-web-interface/src/pages/ShowContentPackPage.jsx
@@ -53,9 +53,9 @@ const ShowContentPackPage = createReactClass({
   },
 
   _deleteContentPackRev(contentPackId, revision) {
-    if (window.confirm('You are about to delete this content pack, are you sure?')) {
+    if (window.confirm('You are about to delete this content pack revision, are you sure?')) {
       ContentPacksActions.deleteRev(contentPackId, revision).then(() => {
-        UserNotification.success('Content Pack deleted successfully.', 'Success');
+        UserNotification.success('Content pack revision deleted successfully.', 'Success');
         ContentPacksActions.get(contentPackId).catch((error) => {
           if (error.status !== 404) {
             UserNotification.error('An internal server error occurred. Please check your logfiles for more information');
@@ -67,7 +67,7 @@ const ShowContentPackPage = createReactClass({
         if (error.responseMessage) {
           errMessage = error.responseMessage;
         }
-        UserNotification.error(`Deleting bundle failed: ${errMessage}`, 'Error');
+        UserNotification.error(`Deleting content pack failed: ${errMessage}`, 'Error');
       });
     }
   },

--- a/graylog2-web-interface/src/pages/ShowContentPackPage.jsx
+++ b/graylog2-web-interface/src/pages/ShowContentPackPage.jsx
@@ -37,7 +37,7 @@ const ShowContentPackPage = createReactClass({
 
   componentDidMount() {
     ContentPacksActions.get(this.props.params.contentPackId).catch(() => {
-      UserNotification.error("Cannot find a matching Content Pack.");
+      UserNotification.error('Cannot find a matching Content Pack.');
       history.push(Routes.SYSTEM.CONTENTPACKS.LIST);
     });
     ContentPacksActions.installList(this.props.params.contentPackId);

--- a/graylog2-web-interface/src/pages/ShowContentPackPage.jsx
+++ b/graylog2-web-interface/src/pages/ShowContentPackPage.jsx
@@ -6,6 +6,7 @@ import { Row, Col, Button, ButtonToolbar } from 'react-bootstrap';
 import { LinkContainer } from 'react-router-bootstrap';
 import Spinner from 'components/common/Spinner';
 
+import history from 'util/History';
 import Routes from 'routing/Routes';
 
 import UserNotification from 'util/UserNotification';
@@ -35,8 +36,9 @@ const ShowContentPackPage = createReactClass({
 
 
   componentDidMount() {
-    ContentPacksActions.get(this.props.params.contentPackId).catch(() => {
-      window.location = '/system/contentpacks';
+    ContentPacksActions.get(this.props.params.contentPackId).catch((error) => {
+      UserNotification.error("Cannot find a matching Content Pack.");
+      history.push(Routes.SYSTEM.CONTENTPACKS.LIST);
     });
     ContentPacksActions.installList(this.props.params.contentPackId);
   },
@@ -50,7 +52,7 @@ const ShowContentPackPage = createReactClass({
       ContentPacksActions.deleteRev(contentPackId, revision).then(() => {
         UserNotification.success('Content Pack deleted successfully.', 'Success');
         ContentPacksActions.get(contentPackId).catch(() => {
-          window.location = '/system/contentpacks';
+          history.push(Routes.SYSTEM.CONTENTPACKS.LIST);
         });
       }, (error) => {
         let errMessage = error.message;


### PR DESCRIPTION
## Description
If the user requests a content pack which is not there anymore we now redirect to the
content packs overview.

## Motivation and Context
If a user deleted the last content pack the show content pack site was throwing an error.

## How Has This Been Tested?
Removing the last revision of an content pack.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
