### PR TITLE
Treat reindexed indices as managed indices in Graylog

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/indexer/MongoIndexSet.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/MongoIndexSet.java
@@ -65,6 +65,11 @@ public class MongoIndexSet implements IndexSet {
     // TODO 3.0: Remove this in 3.0, only used for pre 2.2 backwards compatibility.
     public static final String RESTORED_ARCHIVE_SUFFIX = "_restored_archive";
 
+    // This is needed to detect re-indexed indices as managed Graylog indices. The number at the end of the suffix
+    // is the Elasticsearch major version. That allows reindexing the same data with different ES major versions if
+    // necessary. (if users need to keep their data in indices for a long time)
+    public static final String REINDEX_SUFFIX = "_reindex_es\\d+";
+
     public interface Factory {
         MongoIndexSet create(IndexSetConfig config);
     }
@@ -103,11 +108,11 @@ public class MongoIndexSet implements IndexSet {
         // Part of the pattern can be configured in IndexSetConfig. If set we use the indexMatchPattern from the config.
         if (isNullOrEmpty(config.indexMatchPattern())) {
             // This pattern requires that we check that each index prefix is unique and unambiguous to avoid false matches.
-            this.indexPattern = Pattern.compile("^" + config.indexPrefix() + SEPARATOR + "\\d+(?:" + RESTORED_ARCHIVE_SUFFIX + ")?");
+            this.indexPattern = Pattern.compile("^" + config.indexPrefix() + SEPARATOR + "\\d+(?:" + RESTORED_ARCHIVE_SUFFIX + "|" + REINDEX_SUFFIX + ")?");
             this.deflectorIndexPattern = Pattern.compile("^" + config.indexPrefix() + SEPARATOR + "\\d+");
         } else {
             // This pattern requires that we check that each index prefix is unique and unambiguous to avoid false matches.
-            this.indexPattern = Pattern.compile("^" + config.indexMatchPattern() + SEPARATOR + "\\d+(?:" + RESTORED_ARCHIVE_SUFFIX + ")?");
+            this.indexPattern = Pattern.compile("^" + config.indexMatchPattern() + SEPARATOR + "\\d+(?:" + RESTORED_ARCHIVE_SUFFIX + "|" + REINDEX_SUFFIX + ")?");
             this.deflectorIndexPattern = Pattern.compile("^" + config.indexMatchPattern() + SEPARATOR + "\\d+");
         }
 

--- a/graylog2-server/src/test/java/org/graylog2/indexer/MongoIndexSetTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/indexer/MongoIndexSetTest.java
@@ -157,6 +157,18 @@ public class MongoIndexSetTest {
         assertFalse(mongoIndexSet.isGraylogDeflectorIndex("graylog_42_restored_archive"));
         assertTrue(mongoIndexSet.isManagedIndex("graylog_42_restored_archive"));
 
+        // The reindexed indices should NOT be taken into account when getting the new deflector number
+        assertFalse(mongoIndexSet.isGraylogDeflectorIndex("graylog_42_reindex_es5"));
+        assertFalse(mongoIndexSet.isGraylogDeflectorIndex("graylog_42_reindex_es6"));
+        // ... but they should be detected as managed index
+        assertTrue(mongoIndexSet.isManagedIndex("graylog_42_reindex_es5"));
+        assertTrue(mongoIndexSet.isManagedIndex("graylog_42_reindex_es6"));
+
+        assertFalse(mongoIndexSet.isGraylogDeflectorIndex("graylog_42_reindex_es6heyna"));
+        assertFalse(mongoIndexSet.isManagedIndex("graylog_42_reindex_es6heyna"));
+        assertFalse(mongoIndexSet.isGraylogDeflectorIndex("graylog_42_reindex_es6_12"));
+        assertFalse(mongoIndexSet.isManagedIndex("graylog_42_reindex_es6_12"));
+
         assertFalse(mongoIndexSet.isGraylogDeflectorIndex("graylog_42_restored_archive123"));
         assertFalse(mongoIndexSet.isManagedIndex("graylog_42_restored_archive123"));
 
@@ -188,7 +200,8 @@ public class MongoIndexSetTest {
                 "graylog_1", Collections.emptySet(),
                 "graylog_2", Collections.emptySet(),
                 "graylog_3", Collections.singleton("graylog_deflector"),
-                "graylog_4_restored_archive", Collections.emptySet());
+                "graylog_4_restored_archive", Collections.emptySet(),
+                "graylog_4_reindex_es5", Collections.emptySet());
 
         when(indices.getIndexNamesAndAliases(anyString())).thenReturn(indexNameAliases);
         final MongoIndexSet mongoIndexSet = new MongoIndexSet(config, indices, nodeId, indexRangeService, auditEventSender, systemJobManager, jobFactory, activityWriter);
@@ -200,7 +213,7 @@ public class MongoIndexSetTest {
     @Test
     public void getAllGraylogIndexNames() {
         final Map<String, Set<String>> indexNameAliases = ImmutableMap.of(
-                "graylog_1", Collections.emptySet(),
+                "graylog_1_reindex_es5", Collections.emptySet(),
                 "graylog_2", Collections.emptySet(),
                 "graylog_3", Collections.emptySet(),
                 "graylog_4_restored_archive", Collections.emptySet(),
@@ -217,7 +230,7 @@ public class MongoIndexSetTest {
     @Test
     public void getAllGraylogDeflectorIndices() {
         final Map<String, Set<String>> indexNameAliases = ImmutableMap.of(
-                "graylog_1", Collections.emptySet(),
+                "graylog_1_reindex_es5", Collections.emptySet(),
                 "graylog_2", Collections.emptySet(),
                 "graylog_3", Collections.emptySet(),
                 "graylog_4_restored_archive", Collections.emptySet(),
@@ -228,7 +241,7 @@ public class MongoIndexSetTest {
         final MongoIndexSet mongoIndexSet = new MongoIndexSet(config, indices, nodeId, indexRangeService, auditEventSender, systemJobManager, jobFactory, activityWriter);
         final Map<String, Set<String>> deflectorIndices = mongoIndexSet.getAllIndexAliases();
 
-        assertThat(deflectorIndices).containsOnlyKeys("graylog_1", "graylog_2", "graylog_3", "graylog_5");
+        assertThat(deflectorIndices).containsOnlyKeys("graylog_2", "graylog_3", "graylog_5");
     }
 
     @Test


### PR DESCRIPTION
When updating to ES 6, user might have to reindex old indices which have
been created with ES 2. Since ES doesn't allow index renames, the
reindexed indices will have a different name that doesn't match the
current index patterns in the index set.

This change introduces another index name suffix that allows users to
reindex an old index and have the new index be detected as managed index
in the index set.

Users have to use the "_reindex_es<es-major-ver>" suffix when reindexing
into a new index.

Example: "graylog_0" becomes "graylog_0_reindex_es5" when the new index
is reindexed in ES 5.x.

Using the ES major version in the suffix allows users to reindex that
index again with a new ES major version.