### PR TITLE
Allow passing container prop to `ClipboardButton`.

### DIFF
--- a/graylog2-web-interface/package.json
+++ b/graylog2-web-interface/package.json
@@ -50,7 +50,7 @@
     "bootstrap": "^3.3.7",
     "c3": "^0.4.11-rc4",
     "classnames": "^2.2.0",
-    "clipboard": "^1.5.5",
+    "clipboard": "^2.0.0",
     "crossfilter": "1.3.x",
     "d3": "3.5.17",
     "dc": "2.0.5",

--- a/graylog2-web-interface/src/components/common/ClipboardButton.jsx
+++ b/graylog2-web-interface/src/components/common/ClipboardButton.jsx
@@ -39,6 +39,7 @@ class ClipboardButton extends React.Component {
     action: 'copy',
     disabled: false,
     buttonTitle: undefined,
+    container: undefined,
   };
 
   state = {

--- a/graylog2-web-interface/src/components/common/ClipboardButton.jsx
+++ b/graylog2-web-interface/src/components/common/ClipboardButton.jsx
@@ -1,7 +1,7 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 import { Button, Tooltip, OverlayTrigger } from 'react-bootstrap';
-import Clipboard from 'clipboard';
+import ClipboardJS from 'clipboard';
 
 /**
  * Component that renders a button to copy some text in the clipboard when pressed.
@@ -44,7 +44,7 @@ class ClipboardButton extends React.Component {
   };
 
   componentDidMount() {
-    this.clipboard = new Clipboard('[data-clipboard-button]');
+    this.clipboard = new ClipboardJS('[data-clipboard-button]');
     this.clipboard.on('success', this._onSuccess);
     this.clipboard.on('error', this._onError);
   }

--- a/graylog2-web-interface/src/components/common/ClipboardButton.jsx
+++ b/graylog2-web-interface/src/components/common/ClipboardButton.jsx
@@ -31,6 +31,8 @@ class ClipboardButton extends React.Component {
     disabled: PropTypes.bool,
     /** Text to display when hovering over the button. */
     buttonTitle: PropTypes.string,
+    /** Container element which is focussed */
+    container: PropTypes.any,
   };
 
   static defaultProps = {
@@ -44,7 +46,11 @@ class ClipboardButton extends React.Component {
   };
 
   componentDidMount() {
-    this.clipboard = new ClipboardJS('[data-clipboard-button]');
+    const options = {};
+    if (this.props.container) {
+      options.container = this.props.container;
+    }
+    this.clipboard = new ClipboardJS('[data-clipboard-button]', options);
     this.clipboard.on('success', this._onSuccess);
     this.clipboard.on('error', this._onError);
   }

--- a/graylog2-web-interface/src/components/common/ClipboardButton.test.jsx
+++ b/graylog2-web-interface/src/components/common/ClipboardButton.test.jsx
@@ -1,0 +1,17 @@
+import React from 'react';
+import { mount } from 'enzyme';
+import ClipboardJS from 'clipboard';
+import ClipboardButton from './ClipboardButton';
+
+jest.mock('clipboard');
+
+describe('ClipboardButton', () => {
+  it('does not pass container option to clipboard.js if not specified', () => {
+    mount(<ClipboardButton title="Copy" />);
+    expect(ClipboardJS).toHaveBeenCalledWith('[data-clipboard-button]', {});
+  });
+  it('uses `container` prop to pass as an option to clipboard.js', () => {
+    mount(<ClipboardButton title="Copy" container={42} />);
+    expect(ClipboardJS).toHaveBeenCalledWith('[data-clipboard-button]', { container: 42 });
+  });
+});

--- a/graylog2-web-interface/yarn.lock
+++ b/graylog2-web-interface/yarn.lock
@@ -2419,10 +2419,10 @@ clipboard-copy@^2.0.0:
   resolved "https://registry.yarnpkg.com/clipboard-copy/-/clipboard-copy-2.0.0.tgz#663abcd8be9c641de6e92a2eb9afef6e0afa727e"
   integrity sha512-7goBFzT1qI6TnzmaKUq9afyT3+hodAk3zNpktsK00a9vRwACUliCZzBBxBqRWVWNhBy+aQ1Uw6E/rlbuoqkBMg==
 
-clipboard@^1.5.5:
-  version "1.7.1"
-  resolved "https://registry.yarnpkg.com/clipboard/-/clipboard-1.7.1.tgz#360d6d6946e99a7a1fef395e42ba92b5e9b5a16b"
-  integrity sha1-Ng1taUbpmnof7zleQrqStem1oWs=
+clipboard@^2.0.0:
+  version "2.0.4"
+  resolved "https://registry.yarnpkg.com/clipboard/-/clipboard-2.0.4.tgz#836dafd66cf0fea5d71ce5d5b0bf6e958009112d"
+  integrity sha512-Vw26VSLRpJfBofiVaFb/I8PVfdI1OxKcYShe6fm0sP/DtmiWQNCjhM/okTvdCo0G+lMMm1rMYbk4IK4x1X+kgQ==
   dependencies:
     good-listener "^1.2.2"
     select "^1.1.2"
@@ -4723,12 +4723,12 @@ graceful-fs@^4.1.11, graceful-fs@^4.1.2, graceful-fs@^4.1.6, graceful-fs@^4.1.9:
   integrity sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg=
 
 "graylog-web-plugin@file:packages/graylog-web-plugin":
-  version "3.0.0-alpha.4-SNAPSHOT"
+  version "3.0.0-alpha.5-SNAPSHOT"
   dependencies:
     "@babel/preset-env" "^7.1.0"
     babel-eslint "^9.0.0"
     eslint "^4.3.0"
-    eslint-config-graylog "file:../../../../Library/Caches/Yarn/v3/npm-graylog-web-plugin-3.0.0-alpha.4-SNAPSHOT-e7eac202-4a6c-493f-984a-1dd18e6207d2-1542296283251/node_modules/eslint-config-graylog"
+    eslint-config-graylog "file:../../../../Library/Caches/Yarn/v3/npm-graylog-web-plugin-3.0.0-alpha.5-SNAPSHOT-3adca812-7c9d-4691-b50d-541b960f4a01-1542792528077/node_modules/eslint-config-graylog"
     html-webpack-plugin "^3.2.0"
     javascript-natural-sort "^0.7.1"
     jquery "^3.3.1"


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Under some circumstances (e.g. when embedding a `ClipboardButton` in the
body of a modal dialog), copying a value does not work because it
requires the currently focussed container.

This change allows passing the current container to `ClipboardButton`,
therefore enabling it to work properly in e.g. modal dialogs.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.