### PR TITLE
Fix slow CSV export by using a bigger default batch size

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/rest/resources/search/AbsoluteSearchResource.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/resources/search/AbsoluteSearchResource.java
@@ -132,6 +132,7 @@ public class AbsoluteSearchResource extends SearchResource {
             @ApiParam(name = "to", value = "Timerange end. See description for date format", required = true) @QueryParam("to") String to,
             @ApiParam(name = "limit", value = "Maximum number of messages to return.", required = false) @QueryParam("limit") int limit,
             @ApiParam(name = "offset", value = "Offset", required = false) @QueryParam("offset") int offset,
+            @ApiParam(name = "batch_size", value = "Batch size for the backend storage export request.", required = false) @QueryParam("batch_size") @DefaultValue(DEFAULT_SCROLL_BATCH_SIZE) int batchSize,
             @ApiParam(name = "filter", value = "Filter", required = false) @QueryParam("filter") String filter,
             @ApiParam(name = "fields", value = "Comma separated list of fields to return", required = true) @QueryParam("fields") String fields) {
         checkSearchPermission(filter, RestPermissions.SEARCHES_ABSOLUTE);
@@ -140,7 +141,7 @@ public class AbsoluteSearchResource extends SearchResource {
         final TimeRange timeRange = buildAbsoluteTimeRange(from, to);
 
         final ScrollResult scroll = searches
-                .scroll(query, timeRange, limit, offset, fieldList, filter);
+                .scroll(query, timeRange, batchSize, offset, fieldList, filter);
         return buildChunkedOutput(scroll, limit);
     }
 
@@ -161,12 +162,13 @@ public class AbsoluteSearchResource extends SearchResource {
             @ApiParam(name = "to", value = "Timerange end. See description for date format", required = true) @QueryParam("to") String to,
             @ApiParam(name = "limit", value = "Maximum number of messages to return.", required = false) @QueryParam("limit") int limit,
             @ApiParam(name = "offset", value = "Offset", required = false) @QueryParam("offset") int offset,
+            @ApiParam(name = "batch_size", value = "Batch size for the backend storage export request.", required = false) @QueryParam("batch_size") @DefaultValue(DEFAULT_SCROLL_BATCH_SIZE) int batchSize,
             @ApiParam(name = "filter", value = "Filter", required = false) @QueryParam("filter") String filter,
             @ApiParam(name = "fields", value = "Comma separated list of fields to return", required = true) @QueryParam("fields") String fields) {
         checkSearchPermission(filter, RestPermissions.SEARCHES_ABSOLUTE);
         final String filename = "graylog-search-result-absolute-" + from + "-" + to + ".csv";
         return Response
-            .ok(searchAbsoluteChunked(query, from, to, limit, offset, filter, fields))
+            .ok(searchAbsoluteChunked(query, from, to, limit, offset, batchSize, filter, fields))
             .header("Content-Disposition", "attachment; filename=" + filename)
             .build();
     }

--- a/graylog2-server/src/main/java/org/graylog2/rest/resources/search/KeywordSearchResource.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/resources/search/KeywordSearchResource.java
@@ -129,6 +129,7 @@ public class KeywordSearchResource extends SearchResource {
             @ApiParam(name = "keyword", value = "Range keyword", required = true) @QueryParam("keyword") String keyword,
             @ApiParam(name = "limit", value = "Maximum number of messages to return.", required = false) @QueryParam("limit") int limit,
             @ApiParam(name = "offset", value = "Offset", required = false) @QueryParam("offset") int offset,
+            @ApiParam(name = "batch_size", value = "Batch size for the backend storage export request.", required = false) @QueryParam("batch_size") @DefaultValue(DEFAULT_SCROLL_BATCH_SIZE) int batchSize,
             @ApiParam(name = "filter", value = "Filter", required = false) @QueryParam("filter") String filter,
             @ApiParam(name = "fields", value = "Comma separated list of fields to return", required = true) @QueryParam("fields") String fields) {
         checkSearchPermission(filter, RestPermissions.SEARCHES_KEYWORD);
@@ -137,7 +138,7 @@ public class KeywordSearchResource extends SearchResource {
         final TimeRange timeRange = buildKeywordTimeRange(keyword);
 
         final ScrollResult scroll = searches
-                .scroll(query, timeRange, limit, offset, fieldList, filter);
+                .scroll(query, timeRange, batchSize, offset, fieldList, filter);
         return buildChunkedOutput(scroll, limit);
     }
 
@@ -156,12 +157,13 @@ public class KeywordSearchResource extends SearchResource {
             @ApiParam(name = "keyword", value = "Range keyword", required = true) @QueryParam("keyword") String keyword,
             @ApiParam(name = "limit", value = "Maximum number of messages to return.", required = false) @QueryParam("limit") int limit,
             @ApiParam(name = "offset", value = "Offset", required = false) @QueryParam("offset") int offset,
+            @ApiParam(name = "batch_size", value = "Batch size for the backend storage export request.", required = false) @QueryParam("batch_size") @DefaultValue(DEFAULT_SCROLL_BATCH_SIZE) int batchSize,
             @ApiParam(name = "filter", value = "Filter", required = false) @QueryParam("filter") String filter,
             @ApiParam(name = "fields", value = "Comma separated list of fields to return", required = true) @QueryParam("fields") String fields) {
         checkSearchPermission(filter, RestPermissions.SEARCHES_KEYWORD);
         final String filename = "graylog-search-result-keyword-" + keyword + ".csv";
         return Response
-            .ok(searchKeywordChunked(query, keyword, limit, offset, filter, fields))
+            .ok(searchKeywordChunked(query, keyword, limit, offset, batchSize, filter, fields))
             .header("Content-Disposition", "attachment; filename=" + filename)
             .build();
     }

--- a/graylog2-server/src/main/java/org/graylog2/rest/resources/search/RelativeSearchResource.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/resources/search/RelativeSearchResource.java
@@ -131,6 +131,7 @@ public class RelativeSearchResource extends SearchResource {
             @ApiParam(name = "range", value = "Relative timeframe to search in. See method description.", required = true) @QueryParam("range") int range,
             @ApiParam(name = "limit", value = "Maximum number of messages to return.", required = false) @QueryParam("limit") int limit,
             @ApiParam(name = "offset", value = "Offset", required = false) @QueryParam("offset") int offset,
+            @ApiParam(name = "batch_size", value = "Batch size for the backend storage export request.", required = false) @QueryParam("batch_size") @DefaultValue(DEFAULT_SCROLL_BATCH_SIZE) int batchSize,
             @ApiParam(name = "filter", value = "Filter", required = false) @QueryParam("filter") String filter,
             @ApiParam(name = "fields", value = "Comma separated list of fields to return", required = true) @QueryParam("fields") String fields) {
         checkSearchPermission(filter, RestPermissions.SEARCHES_RELATIVE);
@@ -139,7 +140,7 @@ public class RelativeSearchResource extends SearchResource {
         final TimeRange timeRange = buildRelativeTimeRange(range);
 
         final ScrollResult scroll = searches
-                .scroll(query, timeRange, limit, offset, fieldList, filter);
+                .scroll(query, timeRange, batchSize, offset, fieldList, filter);
         return buildChunkedOutput(scroll, limit);
     }
 
@@ -159,12 +160,13 @@ public class RelativeSearchResource extends SearchResource {
             @ApiParam(name = "range", value = "Relative timeframe to search in. See method description.", required = true) @QueryParam("range") int range,
             @ApiParam(name = "limit", value = "Maximum number of messages to return.", required = false) @QueryParam("limit") int limit,
             @ApiParam(name = "offset", value = "Offset", required = false) @QueryParam("offset") int offset,
+            @ApiParam(name = "batch_size", value = "Batch size for the backend storage export request.", required = false) @QueryParam("batch_size") @DefaultValue(DEFAULT_SCROLL_BATCH_SIZE) int batchSize,
             @ApiParam(name = "filter", value = "Filter", required = false) @QueryParam("filter") String filter,
             @ApiParam(name = "fields", value = "Comma separated list of fields to return", required = true) @QueryParam("fields") String fields) {
         checkSearchPermission(filter, RestPermissions.SEARCHES_RELATIVE);
         final String filename = "graylog-search-result-relative-" + range + ".csv";
         return Response
-            .ok(searchRelativeChunked(query, range, limit, offset, filter, fields))
+            .ok(searchRelativeChunked(query, range, limit, offset, batchSize, filter, fields))
             .header("Content-Disposition", "attachment; filename=" + filename)
             .build();
     }

--- a/graylog2-server/src/main/java/org/graylog2/rest/resources/search/SearchResource.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/resources/search/SearchResource.java
@@ -65,6 +65,8 @@ import static com.google.common.base.Strings.isNullOrEmpty;
 public abstract class SearchResource extends RestResource {
     private static final Logger LOG = LoggerFactory.getLogger(SearchResource.class);
 
+    protected static final String DEFAULT_SCROLL_BATCH_SIZE = "500";
+
     protected final Searches searches;
     private final ClusterConfigService clusterConfigService;
     private final DecoratorProcessor decoratorProcessor;


### PR DESCRIPTION
The default batch size in Elasticsearch is 10. We now use 500 as default
for the newly introduced "batch_size" parameter which we pass to the
search request as limit. (which is the batch size for scroll requests)

Previously we used the "limit" parameter for the batch size AND the
result limit. That was wrong and resulted in truncated results.

Fixes #5172

(cherry picked from commit a77756d54ce27bea15e921e0c75c0f34e19b1a40)