### PR TITLE
Stream alerting overview page

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/rest/resources/alerts/AlertResource.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/resources/alerts/AlertResource.java
@@ -93,7 +93,7 @@ public class AlertResource extends RestResource {
                                           @ApiParam(name = "limit", value = "The maximum number of elements to return.", required = true)
                                           @QueryParam("limit") @DefaultValue("300") int limit,
                                           @ApiParam(name = "state", value = "Alert state (resolved/unresolved)", required = false)
-                                          @QueryParam("state") String state) throws NotFoundException {
+                                          @QueryParam("state") String state) {
         final List<String> allowedStreamIds = getAllowedStreamIds();
 
         AlertState alertState;

--- a/graylog2-server/src/main/java/org/graylog2/rest/resources/streams/alerts/StreamAlertConditionResource.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/resources/streams/alerts/StreamAlertConditionResource.java
@@ -147,7 +147,7 @@ public class StreamAlertConditionResource extends RestResource {
             @ApiResponse(code = 404, message = "Stream not found."),
             @ApiResponse(code = 400, message = "Invalid ObjectId.")
     })
-    public AlertConditionListSummary list(@ApiParam(name = "streamId", value = "The stream id this new alert condition belongs to.", required = true)
+    public AlertConditionListSummary list(@ApiParam(name = "streamId", value = "The id of the stream whose alert conditions we want.", required = true)
                                           @PathParam("streamId") String streamid) throws NotFoundException {
         checkPermission(RestPermissions.STREAMS_READ, streamid);
 

--- a/graylog2-server/src/main/java/org/graylog2/rest/resources/streams/alerts/StreamAlertResource.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/resources/streams/alerts/StreamAlertResource.java
@@ -22,6 +22,7 @@ import com.google.common.base.Throwables;
 import com.google.common.cache.Cache;
 import com.google.common.cache.CacheBuilder;
 import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.Lists;
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
 import io.swagger.annotations.ApiParam;
@@ -149,13 +150,23 @@ public class StreamAlertResource extends RestResource {
                                           @ApiParam(name = "skip", value = "The number of elements to skip (offset).", required = true)
                                           @QueryParam("skip") @DefaultValue("0") int skip,
                                           @ApiParam(name = "limit", value = "The maximum number of elements to return.", required = true)
-                                          @QueryParam("limit") @DefaultValue("300") int limit) throws NotFoundException {
+                                          @QueryParam("limit") @DefaultValue("300") int limit,
+                                          @ApiParam(name = "state", value = "Alert state (resolved/unresolved)")
+                                          @QueryParam("state") String state) throws NotFoundException {
         checkPermission(RestPermissions.STREAMS_READ, streamId);
 
-        final Stream stream = streamService.load(streamId);
-        final List<AlertSummary> conditions = toSummaryList(alertService.listForStreamId(stream.getId(), skip, limit));
+        Alert.AlertState alertState;
+        try {
+            alertState = Alert.AlertState.fromString(state);
+        } catch (IllegalArgumentException e) {
+            alertState = Alert.AlertState.ANY;
+        }
 
-        return AlertListSummary.create(alertService.totalCountForStream(streamId), conditions);
+        final Stream stream = streamService.load(streamId);
+        final List<String> streamIdList = Lists.newArrayList(stream.getId());
+        final List<AlertSummary> conditions = toSummaryList(alertService.listForStreamIds(streamIdList, alertState, skip, limit));
+
+        return AlertListSummary.create(alertService.totalCountForStreams(streamIdList, alertState), conditions);
     }
 
     @GET

--- a/graylog2-web-interface/src/components/alertconditions/AlertCondition.jsx
+++ b/graylog2-web-interface/src/components/alertconditions/AlertCondition.jsx
@@ -18,12 +18,16 @@ const AlertCondition = createReactClass({
     alertCondition: PropTypes.object.isRequired,
     stream: PropTypes.object.isRequired,
     isDetailsView: PropTypes.bool,
+    onUpdate: PropTypes.func,
+    onDelete: PropTypes.func,
   },
   mixins: [Reflux.connect(AlertConditionsStore), Reflux.connect(CurrentUserStore), PermissionsMixin],
 
   getDefaultProps() {
     return {
       isDetailsView: false,
+      onUpdate: () => {},
+      onDelete: () => {},
     };
   },
 
@@ -32,14 +36,14 @@ const AlertCondition = createReactClass({
   },
 
   _onUpdate(request) {
-    AlertConditionsActions.update(this.props.stream.id, this.props.alertCondition.id, request).then(() => {
-      AlertConditionsActions.get(this.props.stream.id, this.props.alertCondition.id);
-    });
+    AlertConditionsActions.update(this.props.stream.id, this.props.alertCondition.id, request)
+      .then(() => this.props.onUpdate(this.props.stream.id, this.props.alertCondition.id));
   },
 
   _onDelete() {
     if (window.confirm('Really delete alert condition?')) {
-      AlertConditionsActions.delete(this.props.stream.id, this.props.alertCondition.id);
+      AlertConditionsActions.delete(this.props.stream.id, this.props.alertCondition.id)
+        .then(() => this.props.onDelete(this.props.stream.id, this.props.alertCondition.id));
     }
   },
 

--- a/graylog2-web-interface/src/components/alertconditions/AlertCondition.jsx
+++ b/graylog2-web-interface/src/components/alertconditions/AlertCondition.jsx
@@ -4,19 +4,19 @@ import createReactClass from 'create-react-class';
 import Reflux from 'reflux';
 import { DropdownButton, MenuItem } from 'react-bootstrap';
 
-import CombinedProvider from 'injection/CombinedProvider';
-const { AlertConditionsActions, AlertConditionsStore } = CombinedProvider.get('AlertConditions');
-const { CurrentUserStore } = CombinedProvider.get('CurrentUser');
-
 import { AlertConditionSummary, UnknownAlertCondition } from 'components/alertconditions';
 import PermissionsMixin from 'util/PermissionsMixin';
+import CombinedProvider from 'injection/CombinedProvider';
+
+const { AlertConditionsActions, AlertConditionsStore } = CombinedProvider.get('AlertConditions');
+const { CurrentUserStore } = CombinedProvider.get('CurrentUser');
 
 const AlertCondition = createReactClass({
   displayName: 'AlertCondition',
 
   propTypes: {
     alertCondition: PropTypes.object.isRequired,
-    stream: PropTypes.object,
+    stream: PropTypes.object.isRequired,
   },
 
   mixins: [Reflux.connect(AlertConditionsStore), Reflux.connect(CurrentUserStore), PermissionsMixin],
@@ -41,7 +41,9 @@ const AlertCondition = createReactClass({
     let actions = [];
     if (this.isPermitted(permissions, `streams:edit:${stream.id}`)) {
       actions = [
-        <DropdownButton key="more-actions-button" title="Actions" pullRight
+        <DropdownButton key="more-actions-button"
+                        title="Actions"
+                        pullRight
                         id={`more-actions-dropdown-${condition.id}`}>
           <MenuItem onSelect={this._onDelete}>Delete</MenuItem>
         </DropdownButton>,

--- a/graylog2-web-interface/src/components/alertconditions/AlertCondition.jsx
+++ b/graylog2-web-interface/src/components/alertconditions/AlertCondition.jsx
@@ -4,7 +4,7 @@ import createReactClass from 'create-react-class';
 import Reflux from 'reflux';
 import { DropdownButton, MenuItem } from 'react-bootstrap';
 
-import { AlertConditionSummary, UnknownAlertCondition } from 'components/alertconditions';
+import { AlertConditionForm, AlertConditionSummary, UnknownAlertCondition } from 'components/alertconditions';
 import PermissionsMixin from 'util/PermissionsMixin';
 import CombinedProvider from 'injection/CombinedProvider';
 
@@ -20,6 +20,16 @@ const AlertCondition = createReactClass({
   },
 
   mixins: [Reflux.connect(AlertConditionsStore), Reflux.connect(CurrentUserStore), PermissionsMixin],
+
+  _onEdit() {
+    this.updateForm.open();
+  },
+
+  _onUpdate(request) {
+    AlertConditionsActions.update(this.props.stream.id, this.props.alertCondition.id, request).then(() => {
+      AlertConditionsActions.get(this.props.stream.id, this.props.alertCondition.id);
+    });
+  },
 
   _onDelete() {
     if (window.confirm('Really delete alert condition?')) {
@@ -45,14 +55,25 @@ const AlertCondition = createReactClass({
                         title="Actions"
                         pullRight
                         id={`more-actions-dropdown-${condition.id}`}>
+          <MenuItem onSelect={this._onEdit}>Edit</MenuItem>
+          <MenuItem divider />
           <MenuItem onSelect={this._onDelete}>Delete</MenuItem>
         </DropdownButton>,
       ];
     }
 
     return (
-      <AlertConditionSummary alertCondition={condition} typeDefinition={typeDefinition} stream={stream}
-                             actions={actions} linkToDetails />
+      <React.Fragment>
+        <AlertConditionForm ref={(updateForm) => { this.updateForm = updateForm; }}
+                            type={condition.type}
+                            alertCondition={condition}
+                            onSubmit={this._onUpdate} />
+        <AlertConditionSummary alertCondition={condition}
+                               typeDefinition={typeDefinition}
+                               stream={stream}
+                               actions={actions}
+                               linkToDetails />
+      </React.Fragment>
     );
   },
 });

--- a/graylog2-web-interface/src/components/alertconditions/AlertCondition.jsx
+++ b/graylog2-web-interface/src/components/alertconditions/AlertCondition.jsx
@@ -10,7 +10,7 @@ import PermissionsMixin from 'util/PermissionsMixin';
 import CombinedProvider from 'injection/CombinedProvider';
 import Routes from 'routing/Routes';
 
-const { AlertConditionsActions, AlertConditionsStore } = CombinedProvider.get('AlertConditions');
+const { AlertConditionsActions } = CombinedProvider.get('AlertConditions');
 const { CurrentUserStore } = CombinedProvider.get('CurrentUser');
 
 const AlertCondition = createReactClass({
@@ -18,13 +18,14 @@ const AlertCondition = createReactClass({
 
   propTypes: {
     alertCondition: PropTypes.object.isRequired,
+    conditionType: PropTypes.object.isRequired,
     stream: PropTypes.object.isRequired,
     isDetailsView: PropTypes.bool,
     isStreamView: PropTypes.bool,
     onUpdate: PropTypes.func,
     onDelete: PropTypes.func,
   },
-  mixins: [Reflux.connect(AlertConditionsStore), Reflux.connect(CurrentUserStore), PermissionsMixin],
+  mixins: [Reflux.connect(CurrentUserStore), PermissionsMixin],
 
   getDefaultProps() {
     return {
@@ -52,12 +53,11 @@ const AlertCondition = createReactClass({
   },
 
   render() {
-    const type = this.props.alertCondition.type;
     const stream = this.props.stream;
     const condition = this.props.alertCondition;
-    const typeDefinition = this.state.types[type];
+    const conditionType = this.props.conditionType;
 
-    if (!typeDefinition) {
+    if (!conditionType) {
       return <UnknownAlertCondition alertCondition={condition} onDelete={this._onDelete} stream={stream} />;
     }
 
@@ -84,11 +84,11 @@ const AlertCondition = createReactClass({
     return (
       <React.Fragment>
         <AlertConditionForm ref={(updateForm) => { this.updateForm = updateForm; }}
-                            type={condition.type}
+                            conditionType={conditionType}
                             alertCondition={condition}
                             onSubmit={this._onUpdate} />
         <AlertConditionSummary alertCondition={condition}
-                               typeDefinition={typeDefinition}
+                               conditionType={conditionType}
                                stream={stream}
                                actions={actions}
                                isDetailsView={this.props.isDetailsView} />

--- a/graylog2-web-interface/src/components/alertconditions/AlertCondition.jsx
+++ b/graylog2-web-interface/src/components/alertconditions/AlertCondition.jsx
@@ -17,9 +17,15 @@ const AlertCondition = createReactClass({
   propTypes: {
     alertCondition: PropTypes.object.isRequired,
     stream: PropTypes.object.isRequired,
+    isDetailsView: PropTypes.bool,
   },
-
   mixins: [Reflux.connect(AlertConditionsStore), Reflux.connect(CurrentUserStore), PermissionsMixin],
+
+  getDefaultProps() {
+    return {
+      isDetailsView: false,
+    };
+  },
 
   _onEdit() {
     this.updateForm.open();
@@ -72,7 +78,7 @@ const AlertCondition = createReactClass({
                                typeDefinition={typeDefinition}
                                stream={stream}
                                actions={actions}
-                               linkToDetails />
+                               isDetailsView={this.props.isDetailsView} />
       </React.Fragment>
     );
   },

--- a/graylog2-web-interface/src/components/alertconditions/AlertCondition.jsx
+++ b/graylog2-web-interface/src/components/alertconditions/AlertCondition.jsx
@@ -3,10 +3,12 @@ import React from 'react';
 import createReactClass from 'create-react-class';
 import Reflux from 'reflux';
 import { DropdownButton, MenuItem } from 'react-bootstrap';
+import { LinkContainer } from 'react-router-bootstrap';
 
 import { AlertConditionForm, AlertConditionSummary, UnknownAlertCondition } from 'components/alertconditions';
 import PermissionsMixin from 'util/PermissionsMixin';
 import CombinedProvider from 'injection/CombinedProvider';
+import Routes from 'routing/Routes';
 
 const { AlertConditionsActions, AlertConditionsStore } = CombinedProvider.get('AlertConditions');
 const { CurrentUserStore } = CombinedProvider.get('CurrentUser');
@@ -18,6 +20,7 @@ const AlertCondition = createReactClass({
     alertCondition: PropTypes.object.isRequired,
     stream: PropTypes.object.isRequired,
     isDetailsView: PropTypes.bool,
+    isStreamView: PropTypes.bool,
     onUpdate: PropTypes.func,
     onDelete: PropTypes.func,
   },
@@ -26,6 +29,7 @@ const AlertCondition = createReactClass({
   getDefaultProps() {
     return {
       isDetailsView: false,
+      isStreamView: false,
       onUpdate: () => {},
       onDelete: () => {},
     };
@@ -65,6 +69,11 @@ const AlertCondition = createReactClass({
                         title="Actions"
                         pullRight
                         id={`more-actions-dropdown-${condition.id}`}>
+          {!this.props.isStreamView && (
+            <LinkContainer to={Routes.stream_alerts(stream.id)}>
+              <MenuItem>Alerts for this Stream</MenuItem>
+            </LinkContainer>
+          )}
           <MenuItem onSelect={this._onEdit}>Edit</MenuItem>
           <MenuItem divider />
           <MenuItem onSelect={this._onDelete}>Delete</MenuItem>

--- a/graylog2-web-interface/src/components/alertconditions/AlertCondition.jsx
+++ b/graylog2-web-interface/src/components/alertconditions/AlertCondition.jsx
@@ -71,7 +71,7 @@ const AlertCondition = createReactClass({
                         id={`more-actions-dropdown-${condition.id}`}>
           {!this.props.isStreamView && (
             <LinkContainer to={Routes.stream_alerts(stream.id)}>
-              <MenuItem>Alerts for this Stream</MenuItem>
+              <MenuItem>Alerting overview for Stream</MenuItem>
             </LinkContainer>
           )}
           <MenuItem onSelect={this._onEdit}>Edit</MenuItem>

--- a/graylog2-web-interface/src/components/alertconditions/AlertConditionForm.jsx
+++ b/graylog2-web-interface/src/components/alertconditions/AlertConditionForm.jsx
@@ -14,9 +14,9 @@ const AlertConditionForm = createReactClass({
 
   propTypes: {
     alertCondition: PropTypes.object,
+    conditionType: PropTypes.object.isRequired,
     onCancel: PropTypes.func,
     onSubmit: PropTypes.func.isRequired,
-    type: PropTypes.string.isRequired,
   },
 
   mixins: [Reflux.connect(AlertConditionsStore)],
@@ -34,7 +34,7 @@ const AlertConditionForm = createReactClass({
     const values = this.configurationForm.getValue();
     return {
       title: values.title,
-      type: this.props.type,
+      type: this.props.conditionType.type,
       parameters: values.configuration,
     };
   },
@@ -59,24 +59,23 @@ const AlertConditionForm = createReactClass({
   },
 
   render() {
-    const type = this.props.type;
     const alertCondition = this.props.alertCondition;
-    const typeDefinition = this.state.types[type];
+    const conditionType = this.props.conditionType;
 
     return (
       <ConfigurationForm ref={(configurationForm) => { this.configurationForm = configurationForm; }}
                          key="configuration-form-alert-condition"
-                         configFields={typeDefinition.requested_configuration}
-                         title={this._formatTitle(alertCondition, typeDefinition.name)}
-                         typeName={type}
+                         configFields={conditionType.requested_configuration}
+                         title={this._formatTitle(alertCondition, conditionType.name)}
+                         typeName={conditionType.name}
                          submitAction={this._onSubmit}
                          cancelAction={this._onCancel}
                          titleValue={alertCondition ? alertCondition.title : ''}
                          helpBlock="The alert condition title"
                          values={alertCondition ? alertCondition.parameters : {}}>
         <FormGroup>
-          <ControlLabel>{`${typeDefinition.name} description`}</ControlLabel>
-          <FormControl.Static>{typeDefinition.human_name}</FormControl.Static>
+          <ControlLabel>{`${conditionType.name} description`}</ControlLabel>
+          <FormControl.Static>{conditionType.human_name}</FormControl.Static>
         </FormGroup>
       </ConfigurationForm>
     );

--- a/graylog2-web-interface/src/components/alertconditions/AlertConditionForm.jsx
+++ b/graylog2-web-interface/src/components/alertconditions/AlertConditionForm.jsx
@@ -7,6 +7,7 @@ import { ControlLabel, FormControl, FormGroup } from 'react-bootstrap';
 import { ConfigurationForm } from 'components/configurationforms';
 
 import CombinedProvider from 'injection/CombinedProvider';
+
 const { AlertConditionsStore } = CombinedProvider.get('AlertConditions');
 
 const AlertConditionForm = createReactClass({
@@ -23,10 +24,9 @@ const AlertConditionForm = createReactClass({
 
   getDefaultProps() {
     return {
-      onCancel: () => {
-      },
-      onSubmit: () => {
-      },
+      alertCondition: undefined,
+      onCancel: () => {},
+      onSubmit: () => {},
     };
   },
 

--- a/graylog2-web-interface/src/components/alertconditions/AlertConditionSummary.jsx
+++ b/graylog2-web-interface/src/components/alertconditions/AlertConditionSummary.jsx
@@ -16,7 +16,12 @@ class AlertConditionSummary extends React.Component {
     typeDefinition: PropTypes.object.isRequired,
     stream: PropTypes.object,
     actions: PropTypes.array.isRequired,
-    linkToDetails: PropTypes.bool,
+    isDetailsView: PropTypes.bool,
+  };
+
+  static defaultProps = {
+    stream: undefined,
+    isDetailsView: false,
   };
 
   render() {
@@ -36,14 +41,14 @@ class AlertConditionSummary extends React.Component {
     );
 
     let title;
-    if (this.props.linkToDetails) {
+    if (this.props.isDetailsView) {
+      title = (condition.title ? condition.title : 'Untitled');
+    } else {
       title = (
         <Link to={Routes.show_alert_condition(stream.id, condition.id)}>
           {condition.title ? condition.title : 'Untitled'}
         </Link>
       );
-    } else {
-      title = (condition.title ? condition.title : 'Untitled');
     }
 
     return (

--- a/graylog2-web-interface/src/components/alertconditions/AlertConditionSummary.jsx
+++ b/graylog2-web-interface/src/components/alertconditions/AlertConditionSummary.jsx
@@ -13,7 +13,7 @@ import { PluginStore } from 'graylog-web-plugin/plugin';
 class AlertConditionSummary extends React.Component {
   static propTypes = {
     alertCondition: PropTypes.object.isRequired,
-    typeDefinition: PropTypes.object.isRequired,
+    conditionType: PropTypes.object.isRequired,
     stream: PropTypes.object,
     actions: PropTypes.array.isRequired,
     isDetailsView: PropTypes.bool,
@@ -27,9 +27,9 @@ class AlertConditionSummary extends React.Component {
   render() {
     const stream = this.props.stream;
     const condition = this.props.alertCondition;
-    const typeDefinition = this.props.typeDefinition;
-    const conditionType = PluginStore.exports('alertConditions').find(c => c.type === condition.type) || {};
-    const SummaryComponent = conditionType.summaryComponent || GenericAlertConditionSummary;
+    const conditionType = this.props.conditionType;
+    const conditionPlugin = PluginStore.exports('alertConditions').find(c => c.type === condition.type) || {};
+    const SummaryComponent = conditionPlugin.summaryComponent || GenericAlertConditionSummary;
 
     const description = (stream ?
       <span>Alerting on stream <em>{stream.title}</em></span> : 'Not alerting on any stream');
@@ -54,7 +54,7 @@ class AlertConditionSummary extends React.Component {
     return (
       <EntityListItem key={`entry-list-${condition.id}`}
                       title={title}
-                      titleSuffix={`(${typeDefinition.name})`}
+                      titleSuffix={`(${conditionType.name})`}
                       description={description}
                       actions={this.props.actions}
                       contentRow={content} />

--- a/graylog2-web-interface/src/components/alertconditions/AlertConditionsComponent.jsx
+++ b/graylog2-web-interface/src/components/alertconditions/AlertConditionsComponent.jsx
@@ -60,7 +60,10 @@ const AlertConditionsComponent = createReactClass({
         </div>
         <h2>Conditions</h2>
         <p>These are all configured alert conditions.</p>
-        <AlertConditionsList alertConditions={alertConditions} streams={this.state.streams} />
+        <AlertConditionsList alertConditions={alertConditions}
+                             streams={this.state.streams}
+                             onConditionUpdate={this._loadData}
+                             onConditionDelete={this._loadData} />
       </div>
     );
   },

--- a/graylog2-web-interface/src/components/alertconditions/AlertConditionsComponent.jsx
+++ b/graylog2-web-interface/src/components/alertconditions/AlertConditionsComponent.jsx
@@ -34,10 +34,11 @@ const AlertConditionsComponent = createReactClass({
     });
 
     AlertConditionsActions.listAll();
+    AlertConditionsActions.available();
   },
 
   _isLoading() {
-    return !this.state.streams || !this.state.allAlertConditions;
+    return !this.state.streams || !this.state.allAlertConditions || !this.state.availableConditions;
   },
 
   render() {
@@ -61,6 +62,7 @@ const AlertConditionsComponent = createReactClass({
         <h2>Conditions</h2>
         <p>These are all configured alert conditions.</p>
         <AlertConditionsList alertConditions={alertConditions}
+                             availableConditions={this.state.availableConditions}
                              streams={this.state.streams}
                              onConditionUpdate={this._loadData}
                              onConditionDelete={this._loadData} />

--- a/graylog2-web-interface/src/components/alertconditions/AlertConditionsComponent.jsx
+++ b/graylog2-web-interface/src/components/alertconditions/AlertConditionsComponent.jsx
@@ -11,6 +11,7 @@ import { AlertConditionsList } from 'components/alertconditions';
 import Routes from 'routing/Routes';
 
 import CombinedProvider from 'injection/CombinedProvider';
+
 const { StreamsStore } = CombinedProvider.get('Streams');
 const { AlertConditionsStore, AlertConditionsActions } = CombinedProvider.get('AlertConditions');
 

--- a/graylog2-web-interface/src/components/alertconditions/AlertConditionsList.jsx
+++ b/graylog2-web-interface/src/components/alertconditions/AlertConditionsList.jsx
@@ -8,6 +8,13 @@ class AlertConditionsList extends React.Component {
   static propTypes = {
     alertConditions: PropTypes.array.isRequired,
     streams: PropTypes.array.isRequired,
+    onConditionUpdate: PropTypes.func,
+    onConditionDelete: PropTypes.func,
+  };
+
+  static defaultProps = {
+    onConditionUpdate: () => {},
+    onConditionDelete: () => {},
   };
 
   state = {
@@ -26,7 +33,13 @@ class AlertConditionsList extends React.Component {
 
   _formatCondition = (condition) => {
     const stream = this.props.streams.find(s => s.alert_conditions.find(c => c.id === condition.id));
-    return <AlertCondition key={condition.id} alertCondition={condition} stream={stream} />;
+    return (
+      <AlertCondition key={condition.id}
+                      alertCondition={condition}
+                      stream={stream}
+                      onUpdate={this.props.onConditionUpdate}
+                      onDelete={this.props.onConditionDelete} />
+    );
   };
 
   render() {

--- a/graylog2-web-interface/src/components/alertconditions/AlertConditionsList.jsx
+++ b/graylog2-web-interface/src/components/alertconditions/AlertConditionsList.jsx
@@ -7,6 +7,7 @@ import { EntityList, PaginatedList } from 'components/common';
 class AlertConditionsList extends React.Component {
   static propTypes = {
     alertConditions: PropTypes.array.isRequired,
+    availableConditions: PropTypes.object.isRequired,
     streams: PropTypes.array.isRequired,
     onConditionUpdate: PropTypes.func,
     onConditionDelete: PropTypes.func,
@@ -39,10 +40,12 @@ class AlertConditionsList extends React.Component {
     if (!stream) {
       return null;
     }
+    const conditionType = this.props.availableConditions[condition.type];
 
     return (
       <AlertCondition key={condition.id}
                       alertCondition={condition}
+                      conditionType={conditionType}
                       stream={stream}
                       onUpdate={this.props.onConditionUpdate}
                       onDelete={this.props.onConditionDelete}

--- a/graylog2-web-interface/src/components/alertconditions/AlertConditionsList.jsx
+++ b/graylog2-web-interface/src/components/alertconditions/AlertConditionsList.jsx
@@ -10,11 +10,13 @@ class AlertConditionsList extends React.Component {
     streams: PropTypes.array.isRequired,
     onConditionUpdate: PropTypes.func,
     onConditionDelete: PropTypes.func,
+    isStreamView: PropTypes.bool,
   };
 
   static defaultProps = {
     onConditionUpdate: () => {},
     onConditionDelete: () => {},
+    isStreamView: false,
   };
 
   state = {
@@ -38,7 +40,8 @@ class AlertConditionsList extends React.Component {
                       alertCondition={condition}
                       stream={stream}
                       onUpdate={this.props.onConditionUpdate}
-                      onDelete={this.props.onConditionDelete} />
+                      onDelete={this.props.onConditionDelete}
+                      isStreamView={this.props.isStreamView} />
     );
   };
 

--- a/graylog2-web-interface/src/components/alertconditions/AlertConditionsList.jsx
+++ b/graylog2-web-interface/src/components/alertconditions/AlertConditionsList.jsx
@@ -33,8 +33,10 @@ class AlertConditionsList extends React.Component {
     const alertConditions = this.props.alertConditions;
 
     return (
-      <PaginatedList totalItems={alertConditions.length} onChange={this._onChangePaginatedList}
-                     showPageSizeSelect={false} pageSize={this.PAGE_SIZE}>
+      <PaginatedList totalItems={alertConditions.length}
+                     onChange={this._onChangePaginatedList}
+                     showPageSizeSelect={false}
+                     pageSize={this.PAGE_SIZE}>
         <EntityList bsNoItemsStyle="info"
                     noItemsText="There are no configured conditions."
                     items={this._paginatedConditions().map(condition => this._formatCondition(condition))} />

--- a/graylog2-web-interface/src/components/alertconditions/AlertConditionsList.jsx
+++ b/graylog2-web-interface/src/components/alertconditions/AlertConditionsList.jsx
@@ -35,6 +35,11 @@ class AlertConditionsList extends React.Component {
 
   _formatCondition = (condition) => {
     const stream = this.props.streams.find(s => s.alert_conditions.find(c => c.id === condition.id));
+    // Condition was deleted while rendering, don't render anything at this stage
+    if (!stream) {
+      return null;
+    }
+
     return (
       <AlertCondition key={condition.id}
                       alertCondition={condition}

--- a/graylog2-web-interface/src/components/alertconditions/CreateAlertConditionInput.jsx
+++ b/graylog2-web-interface/src/components/alertconditions/CreateAlertConditionInput.jsx
@@ -31,6 +31,7 @@ const CreateAlertConditionInput = createReactClass({
     StreamsStore.listStreams().then((streams) => {
       this.setState({ streams: streams });
     });
+    AlertConditionsActions.available();
   },
 
   PLACEHOLDER: 'placeholder',
@@ -63,7 +64,10 @@ const CreateAlertConditionInput = createReactClass({
 
   _formatConditionForm(type) {
     return (
-      <AlertConditionForm ref={(configurationForm) => { this.configurationForm = configurationForm; }} onCancel={this._resetForm} onSubmit={this._onSubmit} type={type} />
+      <AlertConditionForm ref={(configurationForm) => { this.configurationForm = configurationForm; }}
+                          onCancel={this._resetForm}
+                          onSubmit={this._onSubmit}
+                          conditionType={this.state.availableConditions[type]} />
     );
   },
 
@@ -72,7 +76,7 @@ const CreateAlertConditionInput = createReactClass({
   },
 
   _isLoading() {
-    return !this.state.types || !this.state.streams;
+    return !this.state.availableConditions || !this.state.streams;
   },
 
   render() {
@@ -81,8 +85,8 @@ const CreateAlertConditionInput = createReactClass({
     }
 
     const conditionForm = (this.state.type !== this.PLACEHOLDER ? this._formatConditionForm(this.state.type) : null);
-    const availableTypes = Object.keys(this.state.types).map((value) => {
-      return <option key={`type-option-${value}`} value={value}>{this.state.types[value].name}</option>;
+    const availableTypes = Object.keys(this.state.availableConditions).map((value) => {
+      return <option key={`type-option-${value}`} value={value}>{this.state.availableConditions[value].name}</option>;
     });
     const formattedStreams = this.state.streams
       .map(stream => this._formatOption(stream.title, stream.id))

--- a/graylog2-web-interface/src/components/alertconditions/CreateAlertConditionInput.jsx
+++ b/graylog2-web-interface/src/components/alertconditions/CreateAlertConditionInput.jsx
@@ -69,8 +69,8 @@ const CreateAlertConditionInput = createReactClass({
       UserNotification.error('Please select the stream that the condition should check.', 'Could not save condition');
     }
 
-    AlertConditionsActions.save(this.state.selectedStream.id, data).then((conditionId) => {
-      history.push(Routes.show_alert_condition(this.state.selectedStream.id, conditionId));
+    AlertConditionsActions.save(this.state.selectedStream.id, data).then(() => {
+      history.push(Routes.stream_alerts(this.state.selectedStream.id));
     });
   },
 

--- a/graylog2-web-interface/src/components/alertconditions/EditAlertConditionForm.jsx
+++ b/graylog2-web-interface/src/components/alertconditions/EditAlertConditionForm.jsx
@@ -18,9 +18,18 @@ const EditAlertConditionForm = createReactClass({
   propTypes: {
     alertCondition: PropTypes.object.isRequired,
     stream: PropTypes.object.isRequired,
+    onUpdate: PropTypes.func,
+    onDelete: PropTypes.func,
   },
 
   mixins: [Reflux.connect(AlertConditionsStore), Reflux.connect(CurrentUserStore), PermissionsMixin],
+
+  getDefaultProps() {
+    return {
+      onUpdate: () => {},
+      onDelete: () => {},
+    };
+  },
 
   _isLoading() {
     return !this.state.types;
@@ -37,7 +46,14 @@ const EditAlertConditionForm = createReactClass({
       <div>
         <h2>Condition details</h2>
         <p>Define the condition to evaluate when triggering a new alert.</p>
-        <EntityList items={[<AlertCondition key={alertCondition.id} stream={stream} alertCondition={alertCondition} isDetailsView />]} />
+        <EntityList items={[
+          <AlertCondition key={alertCondition.id}
+                          stream={stream}
+                          alertCondition={alertCondition}
+                          onUpdate={this.props.onUpdate}
+                          onDelete={this.props.onDelete}
+                          isDetailsView />,
+        ]} />
       </div>
     );
   },

--- a/graylog2-web-interface/src/components/alertconditions/EditAlertConditionForm.jsx
+++ b/graylog2-web-interface/src/components/alertconditions/EditAlertConditionForm.jsx
@@ -37,7 +37,7 @@ const EditAlertConditionForm = createReactClass({
       <div>
         <h2>Condition details</h2>
         <p>Define the condition to evaluate when triggering a new alert.</p>
-        <EntityList items={[<AlertCondition stream={stream} alertCondition={alertCondition} />]} />
+        <EntityList items={[<AlertCondition key={alertCondition.id} stream={stream} alertCondition={alertCondition} isDetailsView />]} />
       </div>
     );
   },

--- a/graylog2-web-interface/src/components/alertconditions/EditAlertConditionForm.jsx
+++ b/graylog2-web-interface/src/components/alertconditions/EditAlertConditionForm.jsx
@@ -3,13 +3,12 @@ import React from 'react';
 import createReactClass from 'create-react-class';
 import Reflux from 'reflux';
 
-import { EntityList, Spinner } from 'components/common';
+import { EntityList } from 'components/common';
 import { AlertCondition } from 'components/alertconditions';
 import PermissionsMixin from 'util/PermissionsMixin';
 
 import CombinedProvider from 'injection/CombinedProvider';
 
-const { AlertConditionsStore } = CombinedProvider.get('AlertConditions');
 const { CurrentUserStore } = CombinedProvider.get('CurrentUser');
 
 const EditAlertConditionForm = createReactClass({
@@ -17,12 +16,13 @@ const EditAlertConditionForm = createReactClass({
 
   propTypes: {
     alertCondition: PropTypes.object.isRequired,
+    conditionType: PropTypes.object.isRequired,
     stream: PropTypes.object.isRequired,
     onUpdate: PropTypes.func,
     onDelete: PropTypes.func,
   },
 
-  mixins: [Reflux.connect(AlertConditionsStore), Reflux.connect(CurrentUserStore), PermissionsMixin],
+  mixins: [Reflux.connect(CurrentUserStore), PermissionsMixin],
 
   getDefaultProps() {
     return {
@@ -31,16 +31,8 @@ const EditAlertConditionForm = createReactClass({
     };
   },
 
-  _isLoading() {
-    return !this.state.types;
-  },
-
   render() {
-    if (this._isLoading()) {
-      return <Spinner />;
-    }
-
-    const { alertCondition, stream } = this.props;
+    const { alertCondition, conditionType, stream } = this.props;
 
     return (
       <div>
@@ -50,6 +42,7 @@ const EditAlertConditionForm = createReactClass({
           <AlertCondition key={alertCondition.id}
                           stream={stream}
                           alertCondition={alertCondition}
+                          conditionType={conditionType}
                           onUpdate={this.props.onUpdate}
                           onDelete={this.props.onDelete}
                           isDetailsView />,

--- a/graylog2-web-interface/src/components/alertconditions/EditAlertConditionForm.jsx
+++ b/graylog2-web-interface/src/components/alertconditions/EditAlertConditionForm.jsx
@@ -2,15 +2,14 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import createReactClass from 'create-react-class';
 import Reflux from 'reflux';
-import { Button } from 'react-bootstrap';
 
 import { EntityList, Spinner } from 'components/common';
-import { AlertConditionForm, AlertConditionSummary } from 'components/alertconditions';
+import { AlertCondition } from 'components/alertconditions';
 import PermissionsMixin from 'util/PermissionsMixin';
 
 import CombinedProvider from 'injection/CombinedProvider';
 
-const { AlertConditionsActions, AlertConditionsStore } = CombinedProvider.get('AlertConditions');
+const { AlertConditionsStore } = CombinedProvider.get('AlertConditions');
 const { CurrentUserStore } = CombinedProvider.get('CurrentUser');
 
 const EditAlertConditionForm = createReactClass({
@@ -23,37 +22,6 @@ const EditAlertConditionForm = createReactClass({
 
   mixins: [Reflux.connect(AlertConditionsStore), Reflux.connect(CurrentUserStore), PermissionsMixin],
 
-  _onEdit() {
-    this.updateForm.open();
-  },
-
-  _onUpdate(request) {
-    AlertConditionsActions.update(this.props.stream.id, this.props.alertCondition.id, request).then(() => {
-      AlertConditionsActions.get(this.props.stream.id, this.props.alertCondition.id);
-    });
-  },
-
-  _formatCondition() {
-    const type = this.props.alertCondition.type;
-    const stream = this.props.stream;
-    const condition = this.props.alertCondition;
-    const typeDefinition = this.state.types[type];
-
-    const permissions = this.state.currentUser.permissions;
-    let actions = [];
-    if (this.isPermitted(permissions, `streams:edit:${stream.id}`)) {
-      actions = [
-        <Button key="edit-button" bsStyle="info" onClick={this._onEdit}>Edit</Button>,
-      ];
-    }
-
-    return [
-      <AlertConditionSummary key={`alert-condition-${condition.id}`} alertCondition={condition}
-                             typeDefinition={typeDefinition} stream={stream}
-                             actions={actions} />,
-    ];
-  },
-
   _isLoading() {
     return !this.state.types;
   },
@@ -63,17 +31,13 @@ const EditAlertConditionForm = createReactClass({
       return <Spinner />;
     }
 
-    const condition = this.props.alertCondition;
+    const { alertCondition, stream } = this.props;
 
     return (
       <div>
         <h2>Condition details</h2>
         <p>Define the condition to evaluate when triggering a new alert.</p>
-        <AlertConditionForm ref={(updateForm) => { this.updateForm = updateForm; }}
-                            type={condition.type}
-                            alertCondition={condition}
-                            onSubmit={this._onUpdate} />
-        <EntityList items={this._formatCondition()} />
+        <EntityList items={[<AlertCondition stream={stream} alertCondition={alertCondition} />]} />
       </div>
     );
   },

--- a/graylog2-web-interface/src/components/alertconditions/EditAlertConditionForm.jsx
+++ b/graylog2-web-interface/src/components/alertconditions/EditAlertConditionForm.jsx
@@ -9,6 +9,7 @@ import { AlertConditionForm, AlertConditionSummary } from 'components/alertcondi
 import PermissionsMixin from 'util/PermissionsMixin';
 
 import CombinedProvider from 'injection/CombinedProvider';
+
 const { AlertConditionsActions, AlertConditionsStore } = CombinedProvider.get('AlertConditions');
 const { CurrentUserStore } = CombinedProvider.get('CurrentUser');
 

--- a/graylog2-web-interface/src/components/alertconditions/StreamAlertConditions.jsx
+++ b/graylog2-web-interface/src/components/alertconditions/StreamAlertConditions.jsx
@@ -1,0 +1,60 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import createReactClass from 'create-react-class';
+import Reflux from 'reflux';
+import { Button } from 'react-bootstrap';
+import { LinkContainer } from 'react-router-bootstrap';
+import naturalSort from 'javascript-natural-sort';
+
+import { Spinner } from 'components/common';
+import { AlertConditionsList } from 'components/alertconditions';
+
+import Routes from 'routing/Routes';
+
+import CombinedProvider from 'injection/CombinedProvider';
+
+const { AlertConditionsStore, AlertConditionsActions } = CombinedProvider.get('AlertConditions');
+
+const StreamAlertConditions = createReactClass({
+  displayName: 'AlertConditionsComponent',
+  propTypes: {
+    stream: PropTypes.object.isRequired,
+  },
+  mixins: [Reflux.connect(AlertConditionsStore)],
+
+  componentDidMount() {
+    this.loadData();
+  },
+
+  loadData() {
+    AlertConditionsActions.list(this.props.stream.id);
+  },
+
+  render() {
+    const isLoading = !this.state.alertConditions;
+    if (isLoading) {
+      return <Spinner />;
+    }
+
+    const alertConditions = this.state.alertConditions.sort((a1, a2) => {
+      const t1 = a1.title || 'Untitled';
+      const t2 = a2.title || 'Untitled';
+      return naturalSort(t1.toLowerCase(), t2.toLowerCase());
+    });
+
+    return (
+      <div>
+        <div className="pull-right">
+          <LinkContainer to={Routes.ALERTS.NEW_CONDITION}>
+            <Button bsStyle="success">Add new condition</Button>
+          </LinkContainer>
+        </div>
+        <h2>Conditions</h2>
+        <p>These are all configured alert conditions for stream <em>{this.props.stream.title}</em>.</p>
+        <AlertConditionsList alertConditions={alertConditions} streams={[this.props.stream]} />
+      </div>
+    );
+  },
+});
+
+export default StreamAlertConditions;

--- a/graylog2-web-interface/src/components/alertconditions/StreamAlertConditions.jsx
+++ b/graylog2-web-interface/src/components/alertconditions/StreamAlertConditions.jsx
@@ -14,6 +14,7 @@ const StreamAlertConditions = createReactClass({
   propTypes: {
     stream: PropTypes.object.isRequired,
     alertConditions: PropTypes.array.isRequired,
+    availableConditions: PropTypes.object.isRequired,
   },
 
   render() {
@@ -33,6 +34,7 @@ const StreamAlertConditions = createReactClass({
         <h2>Conditions</h2>
         <p>These are all configured alert conditions for the stream <em>{this.props.stream.title}</em>.</p>
         <AlertConditionsList alertConditions={alertConditions}
+                             availableConditions={this.props.availableConditions}
                              streams={[this.props.stream]}
                              onConditionUpdate={this.loadData}
                              onConditionDelete={this.loadData}

--- a/graylog2-web-interface/src/components/alertconditions/StreamAlertConditions.jsx
+++ b/graylog2-web-interface/src/components/alertconditions/StreamAlertConditions.jsx
@@ -16,7 +16,7 @@ import CombinedProvider from 'injection/CombinedProvider';
 const { AlertConditionsStore, AlertConditionsActions } = CombinedProvider.get('AlertConditions');
 
 const StreamAlertConditions = createReactClass({
-  displayName: 'AlertConditionsComponent',
+  displayName: 'StreamAlertConditions',
   propTypes: {
     stream: PropTypes.object.isRequired,
   },

--- a/graylog2-web-interface/src/components/alertconditions/StreamAlertConditions.jsx
+++ b/graylog2-web-interface/src/components/alertconditions/StreamAlertConditions.jsx
@@ -51,7 +51,10 @@ const StreamAlertConditions = createReactClass({
         </div>
         <h2>Conditions</h2>
         <p>These are all configured alert conditions for the stream <em>{this.props.stream.title}</em>.</p>
-        <AlertConditionsList alertConditions={alertConditions} streams={[this.props.stream]} />
+        <AlertConditionsList alertConditions={alertConditions}
+                             streams={[this.props.stream]}
+                             onConditionUpdate={this.loadData}
+                             onConditionDelete={this.loadData} />
       </div>
     );
   },

--- a/graylog2-web-interface/src/components/alertconditions/StreamAlertConditions.jsx
+++ b/graylog2-web-interface/src/components/alertconditions/StreamAlertConditions.jsx
@@ -15,6 +15,15 @@ const StreamAlertConditions = createReactClass({
     stream: PropTypes.object.isRequired,
     alertConditions: PropTypes.array.isRequired,
     availableConditions: PropTypes.object.isRequired,
+    onConditionUpdate: PropTypes.func,
+    onConditionDelete: PropTypes.func,
+  },
+
+  getDefaultProps() {
+    return {
+      onConditionUpdate: () => {},
+      onConditionDelete: () => {},
+    };
   },
 
   render() {
@@ -36,8 +45,8 @@ const StreamAlertConditions = createReactClass({
         <AlertConditionsList alertConditions={alertConditions}
                              availableConditions={this.props.availableConditions}
                              streams={[this.props.stream]}
-                             onConditionUpdate={this.loadData}
-                             onConditionDelete={this.loadData}
+                             onConditionUpdate={this.props.onConditionUpdate}
+                             onConditionDelete={this.props.onConditionDelete}
                              isStreamView />
       </div>
     );

--- a/graylog2-web-interface/src/components/alertconditions/StreamAlertConditions.jsx
+++ b/graylog2-web-interface/src/components/alertconditions/StreamAlertConditions.jsx
@@ -27,7 +27,7 @@ const StreamAlertConditions = createReactClass({
     return (
       <div>
         <div className="pull-right">
-          <LinkContainer to={Routes.ALERTS.NEW_CONDITION}>
+          <LinkContainer to={Routes.new_alert_condition_for_stream(this.props.stream.id)}>
             <Button bsStyle="success">Add new condition</Button>
           </LinkContainer>
         </div>

--- a/graylog2-web-interface/src/components/alertconditions/StreamAlertConditions.jsx
+++ b/graylog2-web-interface/src/components/alertconditions/StreamAlertConditions.jsx
@@ -54,7 +54,8 @@ const StreamAlertConditions = createReactClass({
         <AlertConditionsList alertConditions={alertConditions}
                              streams={[this.props.stream]}
                              onConditionUpdate={this.loadData}
-                             onConditionDelete={this.loadData} />
+                             onConditionDelete={this.loadData}
+                             isStreamView />
       </div>
     );
   },

--- a/graylog2-web-interface/src/components/alertconditions/StreamAlertConditions.jsx
+++ b/graylog2-web-interface/src/components/alertconditions/StreamAlertConditions.jsx
@@ -1,42 +1,23 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import createReactClass from 'create-react-class';
-import Reflux from 'reflux';
 import { Button } from 'react-bootstrap';
 import { LinkContainer } from 'react-router-bootstrap';
 import naturalSort from 'javascript-natural-sort';
 
-import { Spinner } from 'components/common';
 import { AlertConditionsList } from 'components/alertconditions';
 
 import Routes from 'routing/Routes';
-
-import CombinedProvider from 'injection/CombinedProvider';
-
-const { AlertConditionsStore, AlertConditionsActions } = CombinedProvider.get('AlertConditions');
 
 const StreamAlertConditions = createReactClass({
   displayName: 'StreamAlertConditions',
   propTypes: {
     stream: PropTypes.object.isRequired,
-  },
-  mixins: [Reflux.connect(AlertConditionsStore)],
-
-  componentDidMount() {
-    this.loadData();
-  },
-
-  loadData() {
-    AlertConditionsActions.list(this.props.stream.id);
+    alertConditions: PropTypes.array.isRequired,
   },
 
   render() {
-    const isLoading = !this.state.alertConditions;
-    if (isLoading) {
-      return <Spinner />;
-    }
-
-    const alertConditions = this.state.alertConditions.sort((a1, a2) => {
+    const alertConditions = this.props.alertConditions.sort((a1, a2) => {
       const t1 = a1.title || 'Untitled';
       const t2 = a2.title || 'Untitled';
       return naturalSort(t1.toLowerCase(), t2.toLowerCase());

--- a/graylog2-web-interface/src/components/alertconditions/StreamAlertConditions.jsx
+++ b/graylog2-web-interface/src/components/alertconditions/StreamAlertConditions.jsx
@@ -50,7 +50,7 @@ const StreamAlertConditions = createReactClass({
           </LinkContainer>
         </div>
         <h2>Conditions</h2>
-        <p>These are all configured alert conditions for stream <em>{this.props.stream.title}</em>.</p>
+        <p>These are all configured alert conditions for the stream <em>{this.props.stream.title}</em>.</p>
         <AlertConditionsList alertConditions={alertConditions} streams={[this.props.stream]} />
       </div>
     );

--- a/graylog2-web-interface/src/components/alertconditions/StreamAlertConditions.jsx
+++ b/graylog2-web-interface/src/components/alertconditions/StreamAlertConditions.jsx
@@ -41,7 +41,7 @@ const StreamAlertConditions = createReactClass({
           </LinkContainer>
         </div>
         <h2>Conditions</h2>
-        <p>These are all configured alert conditions for the stream <em>{this.props.stream.title}</em>.</p>
+        <p className="description">Alert Conditions define when an Alert should be triggered for this Stream.</p>
         <AlertConditionsList alertConditions={alertConditions}
                              availableConditions={this.props.availableConditions}
                              streams={[this.props.stream]}

--- a/graylog2-web-interface/src/components/alertconditions/index.jsx
+++ b/graylog2-web-interface/src/components/alertconditions/index.jsx
@@ -3,7 +3,6 @@ export { default as AlertConditionForm } from './AlertConditionForm';
 export { default as AlertConditionSummary } from './AlertConditionSummary';
 export { default as AlertConditionsComponent } from './AlertConditionsComponent';
 export { default as AlertConditionsList } from './AlertConditionsList';
-export { default as ConditionAlertNotifications } from './ConditionAlertNotifications';
 export { default as CreateAlertConditionInput } from './CreateAlertConditionInput';
 export { default as EditAlertConditionForm } from './EditAlertConditionForm';
 export { default as GenericAlertConditionSummary } from './GenericAlertConditionSummary';

--- a/graylog2-web-interface/src/components/alertconditions/index.jsx
+++ b/graylog2-web-interface/src/components/alertconditions/index.jsx
@@ -1,3 +1,8 @@
+import { PluginManifest, PluginStore } from 'graylog-web-plugin/plugin';
+import { FieldContentConditionSummary } from 'components/alertconditions/fieldcontentcondition';
+import { FieldValueConditionSummary } from 'components/alertconditions/fieldvaluecondition';
+import { MessageCountConditionSummary } from 'components/alertconditions/messagecountcondition';
+
 export { default as AlertCondition } from './AlertCondition';
 export { default as AlertConditionForm } from './AlertConditionForm';
 export { default as AlertConditionSummary } from './AlertConditionSummary';
@@ -6,12 +11,8 @@ export { default as AlertConditionsList } from './AlertConditionsList';
 export { default as CreateAlertConditionInput } from './CreateAlertConditionInput';
 export { default as EditAlertConditionForm } from './EditAlertConditionForm';
 export { default as GenericAlertConditionSummary } from './GenericAlertConditionSummary';
+export { default as StreamAlertConditions } from './StreamAlertConditions';
 export { default as UnknownAlertCondition } from './UnknownAlertCondition';
-
-import { PluginManifest, PluginStore } from 'graylog-web-plugin/plugin';
-import { FieldContentConditionSummary } from 'components/alertconditions/fieldcontentcondition';
-import { FieldValueConditionSummary } from 'components/alertconditions/fieldvaluecondition';
-import { MessageCountConditionSummary } from 'components/alertconditions/messagecountcondition';
 
 PluginStore.register(new PluginManifest({}, {
   alertConditions: [

--- a/graylog2-web-interface/src/components/alertnotifications/AlertNotification.jsx
+++ b/graylog2-web-interface/src/components/alertnotifications/AlertNotification.jsx
@@ -36,6 +36,7 @@ const AlertNotification = createReactClass({
   getInitialState() {
     return {
       isTestingAlert: false,
+      isConfigurationShown: false,
     };
   },
 
@@ -61,6 +62,10 @@ const AlertNotification = createReactClass({
     }
   },
 
+  _toggleIsConfigurationShown() {
+    this.setState({ isConfigurationShown: !this.state.isConfigurationShown });
+  },
+
   render() {
     if (!this.state.availableNotifications) {
       return <Spinner />;
@@ -68,15 +73,22 @@ const AlertNotification = createReactClass({
 
     const notification = this.props.alertNotification;
     const stream = this.props.stream;
+    const { isConfigurationShown } = this.state;
     const typeDefinition = this.state.availableNotifications[notification.type];
 
     if (!typeDefinition) {
       return <UnknownAlertNotification alertNotification={notification} onDelete={this._onDelete} />;
     }
 
+    const toggleConfigurationLink = (
+      <a href="#toggleconfiguration" onClick={this._toggleIsConfigurationShown}>
+        {isConfigurationShown ? 'Hide' : 'Show'} configuration
+      </a>
+    );
+
     const description = (stream ?
-      <span>Executed once per triggered alert condition in stream <em>{stream.title}</em></span>
-      : 'Not executed, as it is not connected to a stream');
+      <span>Executed once per triggered alert condition in stream <em>{stream.title}</em>. {toggleConfigurationLink}</span> :
+      <span>Not executed, as it is not connected to a stream. {toggleConfigurationLink}</span>);
 
     const actions = stream && (
       <IfPermitted permissions={`streams:edit:${stream.id}`}>
@@ -110,7 +122,9 @@ const AlertNotification = createReactClass({
                              titleValue={notification.title}
                              submitAction={this._onSubmit}
                              values={notification.configuration} />
-          <ConfigurationWell configuration={notification.configuration} typeDefinition={typeDefinition} />
+          {isConfigurationShown &&
+            <ConfigurationWell configuration={notification.configuration} typeDefinition={typeDefinition} />
+          }
         </div>
       </Col>
     );

--- a/graylog2-web-interface/src/components/alertnotifications/AlertNotification.jsx
+++ b/graylog2-web-interface/src/components/alertnotifications/AlertNotification.jsx
@@ -3,6 +3,7 @@ import React from 'react';
 import createReactClass from 'create-react-class';
 import Reflux from 'reflux';
 import { Button, Col, DropdownButton, MenuItem } from 'react-bootstrap';
+import { LinkContainer } from 'react-router-bootstrap';
 
 import PermissionsMixin from 'util/PermissionsMixin';
 import CombinedProvider from 'injection/CombinedProvider';
@@ -10,6 +11,7 @@ import CombinedProvider from 'injection/CombinedProvider';
 import { EntityListItem, IfPermitted, Spinner } from 'components/common';
 import { UnknownAlertNotification } from 'components/alertnotifications';
 import { ConfigurationForm, ConfigurationWell } from 'components/configurationforms';
+import Routes from 'routing/Routes';
 
 const { AlertNotificationsStore } = CombinedProvider.get('AlertNotifications');
 const { AlarmCallbacksActions } = CombinedProvider.get('AlarmCallbacks');
@@ -23,6 +25,7 @@ const AlertNotification = createReactClass({
     stream: PropTypes.object,
     onNotificationUpdate: PropTypes.func.isRequired,
     onNotificationDelete: PropTypes.func.isRequired,
+    isStreamView: PropTypes.bool,
   },
 
   mixins: [Reflux.connect(AlertNotificationsStore), Reflux.connect(CurrentUserStore), PermissionsMixin],
@@ -30,6 +33,7 @@ const AlertNotification = createReactClass({
   getDefaultProps() {
     return {
       stream: undefined,
+      isStreamView: false,
     };
   },
 
@@ -103,6 +107,11 @@ const AlertNotification = createReactClass({
                           title="More actions"
                           pullRight
                           id={`more-actions-dropdown-${notification.id}`}>
+            {!this.props.isStreamView && (
+              <LinkContainer to={Routes.stream_alerts(stream.id)}>
+                <MenuItem>Alerts for this Stream</MenuItem>
+              </LinkContainer>
+            )}
             <MenuItem onSelect={this._onEdit}>Edit</MenuItem>
             <MenuItem divider />
             <MenuItem onSelect={this._onDelete}>Delete</MenuItem>

--- a/graylog2-web-interface/src/components/alertnotifications/AlertNotification.jsx
+++ b/graylog2-web-interface/src/components/alertnotifications/AlertNotification.jsx
@@ -109,7 +109,7 @@ const AlertNotification = createReactClass({
                           id={`more-actions-dropdown-${notification.id}`}>
             {!this.props.isStreamView && (
               <LinkContainer to={Routes.stream_alerts(stream.id)}>
-                <MenuItem>Alerts for this Stream</MenuItem>
+                <MenuItem>Alerting overview for Stream</MenuItem>
               </LinkContainer>
             )}
             <MenuItem onSelect={this._onEdit}>Edit</MenuItem>

--- a/graylog2-web-interface/src/components/alertnotifications/AlertNotificationsComponent.jsx
+++ b/graylog2-web-interface/src/components/alertnotifications/AlertNotificationsComponent.jsx
@@ -9,8 +9,8 @@ import { Spinner } from 'components/common';
 import { AlertNotificationsList } from 'components/alertnotifications';
 
 import Routes from 'routing/Routes';
-
 import CombinedProvider from 'injection/CombinedProvider';
+
 const { AlertNotificationsStore, AlertNotificationsActions } = CombinedProvider.get('AlertNotifications');
 const { StreamsStore } = CombinedProvider.get('Streams');
 
@@ -61,8 +61,10 @@ const AlertNotificationsComponent = createReactClass({
         </div>
         <h2>Notifications</h2>
         <p>These are all configured alert notifications.</p>
-        <AlertNotificationsList alertNotifications={notifications} streams={this.state.streams}
-                                onNotificationUpdate={this._loadData} onNotificationDelete={this._loadData} />
+        <AlertNotificationsList alertNotifications={notifications}
+                                streams={this.state.streams}
+                                onNotificationUpdate={this._loadData}
+                                onNotificationDelete={this._loadData} />
       </div>
     );
   },

--- a/graylog2-web-interface/src/components/alertnotifications/AlertNotificationsList.jsx
+++ b/graylog2-web-interface/src/components/alertnotifications/AlertNotificationsList.jsx
@@ -10,11 +10,13 @@ class AlertNotificationsList extends React.Component {
     streams: PropTypes.array.isRequired,
     onNotificationUpdate: PropTypes.func,
     onNotificationDelete: PropTypes.func,
+    isStreamView: PropTypes.bool,
   };
 
   static defaultProps = {
     onNotificationUpdate: () => {},
     onNotificationDelete: () => {},
+    isStreamView: false,
   };
 
   state = {
@@ -38,7 +40,8 @@ class AlertNotificationsList extends React.Component {
                          alertNotification={notification}
                          stream={stream}
                          onNotificationUpdate={this.props.onNotificationUpdate}
-                         onNotificationDelete={this.props.onNotificationDelete} />
+                         onNotificationDelete={this.props.onNotificationDelete}
+                         isStreamView={this.props.isStreamView} />
     );
   };
 

--- a/graylog2-web-interface/src/components/alertnotifications/AlertNotificationsList.jsx
+++ b/graylog2-web-interface/src/components/alertnotifications/AlertNotificationsList.jsx
@@ -12,6 +12,11 @@ class AlertNotificationsList extends React.Component {
     onNotificationDelete: PropTypes.func,
   };
 
+  static defaultProps = {
+    onNotificationUpdate: () => {},
+    onNotificationDelete: () => {},
+  };
+
   state = {
     currentPage: 0,
   };
@@ -29,7 +34,9 @@ class AlertNotificationsList extends React.Component {
   _formatNotification = (notification) => {
     const stream = this.props.streams.find(s => s.id === notification.stream_id);
     return (
-      <AlertNotification key={notification.id} alertNotification={notification} stream={stream}
+      <AlertNotification key={notification.id}
+                         alertNotification={notification}
+                         stream={stream}
                          onNotificationUpdate={this.props.onNotificationUpdate}
                          onNotificationDelete={this.props.onNotificationDelete} />
     );
@@ -39,8 +46,10 @@ class AlertNotificationsList extends React.Component {
     const notifications = this.props.alertNotifications;
 
     return (
-      <PaginatedList totalItems={notifications.length} onChange={this._onChangePaginatedList}
-                     showPageSizeSelect={false} pageSize={this.PAGE_SIZE}>
+      <PaginatedList totalItems={notifications.length}
+                     onChange={this._onChangePaginatedList}
+                     showPageSizeSelect={false}
+                     pageSize={this.PAGE_SIZE}>
         <EntityList bsNoItemsStyle="info"
                     noItemsText="There are no configured notifications."
                     items={this._paginatedNotifications().map(notification => this._formatNotification(notification))} />

--- a/graylog2-web-interface/src/components/alertnotifications/CreateAlertNotificationInput.jsx
+++ b/graylog2-web-interface/src/components/alertnotifications/CreateAlertNotificationInput.jsx
@@ -24,6 +24,12 @@ const CreateAlertNotificationInput = createReactClass({
   },
   mixins: [Reflux.connect(AlertNotificationsStore)],
 
+  getDefaultProps() {
+    return {
+      initialSelectedStream: undefined,
+    };
+  },
+
   getInitialState() {
     return {
       streams: undefined,
@@ -64,9 +70,7 @@ const CreateAlertNotificationInput = createReactClass({
     }
 
     AlarmCallbacksActions.save(this.state.selectedStream.id, data).then(
-      () => {
-        history.push(Routes.ALERTS.NOTIFICATIONS);
-      },
+      () => history.push(Routes.stream_alerts(this.state.selectedStream.id)),
       () => this.configurationForm.open(),
     );
   },

--- a/graylog2-web-interface/src/components/alertnotifications/StreamAlertNotifications.jsx
+++ b/graylog2-web-interface/src/components/alertnotifications/StreamAlertNotifications.jsx
@@ -6,12 +6,12 @@ import { Pluralize, Spinner } from 'components/common';
 import { AlertNotificationsList } from 'components/alertnotifications';
 
 import CombinedProvider from 'injection/CombinedProvider';
+
 const { AlarmCallbacksActions } = CombinedProvider.get('AlarmCallbacks');
 const { AlertNotificationsActions } = CombinedProvider.get('AlertNotifications');
 
-class ConditionAlertNotifications extends React.Component {
+class StreamAlertNotifications extends React.Component {
   static propTypes = {
-    alertCondition: PropTypes.object.isRequired,
     stream: PropTypes.object.isRequired,
   };
 
@@ -50,15 +50,18 @@ class ConditionAlertNotifications extends React.Component {
       <div>
         <h2>Notifications</h2>
         <p>
-          <Pluralize value={notifications.length} singular="This is" plural="These are" /> the notifications set
-          for the stream <em>{stream.title}</em>. They will be triggered when the alert condition is satisfied.
+          <Pluralize value={notifications.length} singular="This is the notification" plural="These are the notifications" />
+          {' '}set for the stream <em>{stream.title}</em>. <Pluralize value={notifications.length} singular="It" plural="They" />
+          {' '}will be triggered when the alert condition is satisfied.
         </p>
 
-        <AlertNotificationsList alertNotifications={notifications} streams={[this.props.stream]}
-                                onNotificationUpdate={this._loadData} onNotificationDelete={this._loadData} />
+        <AlertNotificationsList alertNotifications={notifications}
+                                streams={[this.props.stream]}
+                                onNotificationUpdate={this._loadData}
+                                onNotificationDelete={this._loadData} />
       </div>
     );
   }
 }
 
-export default ConditionAlertNotifications;
+export default StreamAlertNotifications;

--- a/graylog2-web-interface/src/components/alertnotifications/StreamAlertNotifications.jsx
+++ b/graylog2-web-interface/src/components/alertnotifications/StreamAlertNotifications.jsx
@@ -1,11 +1,14 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 import naturalSort from 'javascript-natural-sort';
+import { Button } from 'react-bootstrap';
+import { LinkContainer } from 'react-router-bootstrap';
 
 import { Pluralize, Spinner } from 'components/common';
 import { AlertNotificationsList } from 'components/alertnotifications';
 
 import CombinedProvider from 'injection/CombinedProvider';
+import Routes from 'routing/Routes';
 
 const { AlarmCallbacksActions } = CombinedProvider.get('AlarmCallbacks');
 const { AlertNotificationsActions } = CombinedProvider.get('AlertNotifications');
@@ -48,6 +51,11 @@ class StreamAlertNotifications extends React.Component {
 
     return (
       <div>
+        <div className="pull-right">
+          <LinkContainer to={Routes.ALERTS.NEW_NOTIFICATION}>
+            <Button bsStyle="success">Add new notification</Button>
+          </LinkContainer>
+        </div>
         <h2>Notifications</h2>
         <p>
           <Pluralize value={notifications.length} singular="This is the notification" plural="These are the notifications" />

--- a/graylog2-web-interface/src/components/alertnotifications/StreamAlertNotifications.jsx
+++ b/graylog2-web-interface/src/components/alertnotifications/StreamAlertNotifications.jsx
@@ -52,7 +52,7 @@ class StreamAlertNotifications extends React.Component {
     return (
       <div>
         <div className="pull-right">
-          <LinkContainer to={Routes.ALERTS.NEW_NOTIFICATION}>
+          <LinkContainer to={Routes.new_alert_notification_for_stream(stream.id)}>
             <Button bsStyle="success">Add new notification</Button>
           </LinkContainer>
         </div>

--- a/graylog2-web-interface/src/components/alertnotifications/StreamAlertNotifications.jsx
+++ b/graylog2-web-interface/src/components/alertnotifications/StreamAlertNotifications.jsx
@@ -60,13 +60,14 @@ class StreamAlertNotifications extends React.Component {
         <p>
           <Pluralize value={notifications.length} singular="This is the notification" plural="These are the notifications" />
           {' '}set for the stream <em>{stream.title}</em>. <Pluralize value={notifications.length} singular="It" plural="They" />
-          {' '}will be triggered when the alert condition is satisfied.
+          {' '}will be triggered when an alert condition is satisfied.
         </p>
 
         <AlertNotificationsList alertNotifications={notifications}
                                 streams={[this.props.stream]}
                                 onNotificationUpdate={this._loadData}
-                                onNotificationDelete={this._loadData} />
+                                onNotificationDelete={this._loadData}
+                                isStreamView />
       </div>
     );
   }

--- a/graylog2-web-interface/src/components/alertnotifications/StreamAlertNotifications.jsx
+++ b/graylog2-web-interface/src/components/alertnotifications/StreamAlertNotifications.jsx
@@ -4,7 +4,7 @@ import naturalSort from 'javascript-natural-sort';
 import { Button } from 'react-bootstrap';
 import { LinkContainer } from 'react-router-bootstrap';
 
-import { Pluralize, Spinner } from 'components/common';
+import { Spinner } from 'components/common';
 import { AlertNotificationsList } from 'components/alertnotifications';
 
 import CombinedProvider from 'injection/CombinedProvider';

--- a/graylog2-web-interface/src/components/alertnotifications/StreamAlertNotifications.jsx
+++ b/graylog2-web-interface/src/components/alertnotifications/StreamAlertNotifications.jsx
@@ -57,10 +57,8 @@ class StreamAlertNotifications extends React.Component {
           </LinkContainer>
         </div>
         <h2>Notifications</h2>
-        <p>
-          <Pluralize value={notifications.length} singular="This is the notification" plural="These are the notifications" />
-          {' '}set for the stream <em>{stream.title}</em>. <Pluralize value={notifications.length} singular="It" plural="They" />
-          {' '}will be triggered when an alert condition is satisfied.
+        <p className="description">
+          Alert Notifications will be executed when a Condition belonging to this Stream is satisfied.
         </p>
 
         <AlertNotificationsList alertNotifications={notifications}

--- a/graylog2-web-interface/src/components/alertnotifications/index.jsx
+++ b/graylog2-web-interface/src/components/alertnotifications/index.jsx
@@ -2,4 +2,5 @@ export { default as AlertNotification } from './AlertNotification';
 export { default as AlertNotificationsComponent } from './AlertNotificationsComponent';
 export { default as AlertNotificationsList } from './AlertNotificationsList';
 export { default as CreateAlertNotificationInput } from './CreateAlertNotificationInput';
+export { default as StreamAlertNotifications } from './StreamAlertNotifications';
 export { default as UnknownAlertNotification } from './UnknownAlertNotification';

--- a/graylog2-web-interface/src/components/alerts/Alert.jsx
+++ b/graylog2-web-interface/src/components/alerts/Alert.jsx
@@ -13,9 +13,13 @@ import styles from './Alert.css';
 class Alert extends React.Component {
   static propTypes = {
     alert: PropTypes.object.isRequired,
-    alertConditions: PropTypes.array.isRequired,
-    streams: PropTypes.array.isRequired,
-    conditionTypes: PropTypes.object.isRequired,
+    alertCondition: PropTypes.object,
+    stream: PropTypes.object.isRequired,
+    conditionType: PropTypes.object.isRequired,
+  };
+
+  static defaultProps = {
+    alertCondition: {},
   };
 
   state = {
@@ -23,17 +27,14 @@ class Alert extends React.Component {
   };
 
   render() {
-    const alert = this.props.alert;
-    const condition = this.props.alertConditions.find(alertCondition => alertCondition.id === alert.condition_id);
-    const stream = this.props.streams.find(s => s.id === alert.stream_id);
-    const conditionType = condition ? this.props.conditionTypes[condition.type] : {};
+    const { alert, alertCondition, stream, conditionType } = this.props;
 
     let alertTitle;
-    if (condition) {
+    if (alertCondition) {
       alertTitle = (
         <span>
           <Link to={Routes.show_alert(alert.id)}>
-            {condition.title || 'Untitled alert'}
+            {alertCondition.title || 'Untitled alert'}
           </Link>
           {' '}
           <small>on stream <em>{stream.title}</em></small>

--- a/graylog2-web-interface/src/components/alerts/AlertsComponent.jsx
+++ b/graylog2-web-interface/src/components/alerts/AlertsComponent.jsx
@@ -33,7 +33,7 @@ const AlertsComponent = createReactClass({
   loadData(pageNo, limit) {
     this.setState({ loading: true });
     const promises = [
-      AlertsActions.listAllPaginated((pageNo - 1) * limit, limit, this.state.displayAllAlerts ? 'all' : 'unresolved'),
+      AlertsActions.listAllPaginated((pageNo - 1) * limit, limit, this.state.displayAllAlerts ? 'any' : 'unresolved'),
       AlertConditionsActions.listAll(),
       AlertConditionsActions.available(),
       StreamsStore.listStreams().then((streams) => {

--- a/graylog2-web-interface/src/components/alerts/AlertsComponent.jsx
+++ b/graylog2-web-interface/src/components/alerts/AlertsComponent.jsx
@@ -63,7 +63,7 @@ const AlertsComponent = createReactClass({
   _formatAlert(alert) {
     const condition = this.state.allAlertConditions.find(alertCondition => alertCondition.id === alert.condition_id);
     const stream = this.state.streams.find(s => s.id === alert.stream_id);
-    const conditionType = condition ? this.state.types[condition.type] : {};
+    const conditionType = condition ? this.state.availableConditions[condition.type] : {};
 
     return (
       <Alert key={alert.id}
@@ -75,7 +75,7 @@ const AlertsComponent = createReactClass({
   },
 
   _isLoading() {
-    return !this.state.alerts || !this.state.allAlertConditions || !this.state.types || !this.state.streams;
+    return !this.state.alerts || !this.state.allAlertConditions || !this.state.availableConditions || !this.state.streams;
   },
 
   render() {

--- a/graylog2-web-interface/src/components/alerts/AlertsComponent.jsx
+++ b/graylog2-web-interface/src/components/alerts/AlertsComponent.jsx
@@ -4,13 +4,13 @@ import Reflux from 'reflux';
 import { Button } from 'react-bootstrap';
 import Promise from 'bluebird';
 
+import { Alert } from 'components/alerts';
+import { EntityList, PaginatedList, Spinner } from 'components/common';
 import CombinedProvider from 'injection/CombinedProvider';
+
 const { AlertsStore, AlertsActions } = CombinedProvider.get('Alerts');
 const { AlertConditionsStore, AlertConditionsActions } = CombinedProvider.get('AlertConditions');
 const { StreamsStore } = CombinedProvider.get('Streams');
-
-import { Alert } from 'components/alerts';
-import { EntityList, PaginatedList, Spinner } from 'components/common';
 
 const AlertsComponent = createReactClass({
   displayName: 'AlertsComponent',
@@ -61,9 +61,16 @@ const AlertsComponent = createReactClass({
   },
 
   _formatAlert(alert) {
+    const condition = this.state.allAlertConditions.find(alertCondition => alertCondition.id === alert.condition_id);
+    const stream = this.state.streams.find(s => s.id === alert.stream_id);
+    const conditionType = condition ? this.state.types[condition.type] : {};
+
     return (
-      <Alert key={alert.id} alert={alert} alertConditions={this.state.allAlertConditions} streams={this.state.streams}
-             conditionTypes={this.state.types} />
+      <Alert key={alert.id}
+             alert={alert}
+             alertCondition={condition}
+             stream={stream}
+             conditionType={conditionType} />
     );
   },
 
@@ -93,7 +100,9 @@ const AlertsComponent = createReactClass({
           {this.state.displayAllAlerts ? 'all' : 'unresolved'} alerts.
         </p>
 
-        <PaginatedList totalItems={this.state.alerts.total} pageSize={this.pageSize} onChange={this._onChangePaginatedList}
+        <PaginatedList totalItems={this.state.alerts.total}
+                       pageSize={this.pageSize}
+                       onChange={this._onChangePaginatedList}
                        showPageSizeSelect={false}>
           <EntityList bsNoItemsStyle={this.state.displayAllAlerts ? 'info' : 'success'}
                       noItemsText={this.state.displayAllAlerts ? 'There are no alerts to display' : 'Good news! Currently there are no unresolved alerts.'}

--- a/graylog2-web-interface/src/components/alerts/StreamAlerts.jsx
+++ b/graylog2-web-interface/src/components/alerts/StreamAlerts.jsx
@@ -16,7 +16,7 @@ const StreamAlerts = createReactClass({
   propTypes: {
     stream: PropTypes.object.isRequired,
     alertConditions: PropTypes.array.isRequired,
-    conditionTypes: PropTypes.object.isRequired,
+    availableConditions: PropTypes.object.isRequired,
   },
   mixins: [Reflux.connect(AlertsStore)],
 
@@ -51,7 +51,7 @@ const StreamAlerts = createReactClass({
 
   _formatAlert(alert) {
     const condition = this.props.alertConditions.find(alertCondition => alertCondition.id === alert.condition_id);
-    const conditionType = condition ? this.props.conditionTypes[condition.type] : {};
+    const conditionType = condition ? this.props.availableConditions[condition.type] : {};
 
     return (
       <Alert key={alert.id}

--- a/graylog2-web-interface/src/components/alerts/StreamAlerts.jsx
+++ b/graylog2-web-interface/src/components/alerts/StreamAlerts.jsx
@@ -31,11 +31,11 @@ const StreamAlerts = createReactClass({
   },
 
   currentPage: 1,
-  pageSize: 5,
+  pageSize: 3,
 
   loadData(pageNo, limit) {
     this.setState({ loading: true });
-    AlertsActions.listPaginated(this.props.stream.id, (pageNo - 1) * limit, limit)
+    AlertsActions.listPaginated(this.props.stream.id, (pageNo - 1) * limit, limit, 'unresolved')
       .finally(() => this.setState({ loading: false }));
   },
 
@@ -69,10 +69,10 @@ const StreamAlerts = createReactClass({
 
     return (
       <div>
-        <h2>Stream alerts</h2>
+        <h2>Unresolved stream alerts</h2>
         <p className="description">
-          Here you can see the currently unresolved alerts for this stream. To see resolved alerts on this stream
-          or alerts on other streams, visit the <Link to={Routes.ALERTS.LIST}>alerts</Link> page.
+          These are the currently unresolved alerts for this stream. To see all alerts or alerts on other streams,
+          visit the <Link to={Routes.ALERTS.LIST}>alerts</Link> page.
         </p>
 
         <PaginatedList totalItems={this.state.alerts.total}

--- a/graylog2-web-interface/src/components/alerts/StreamAlerts.jsx
+++ b/graylog2-web-interface/src/components/alerts/StreamAlerts.jsx
@@ -1,0 +1,100 @@
+import React from 'react';
+import createReactClass from 'create-react-class';
+import PropTypes from 'prop-types';
+import Reflux from 'reflux';
+import Promise from 'bluebird';
+import { Link } from 'react-router';
+
+import { Alert } from 'components/alerts';
+import { EntityList, PaginatedList, Spinner } from 'components/common';
+import Routes from 'routing/Routes';
+import CombinedProvider from 'injection/CombinedProvider';
+
+const { AlertsStore, AlertsActions } = CombinedProvider.get('Alerts');
+const { AlertConditionsStore, AlertConditionsActions } = CombinedProvider.get('AlertConditions');
+
+const StreamAlerts = createReactClass({
+  displayName: 'StreamAlerts',
+  propTypes: {
+    stream: PropTypes.object.isRequired,
+  },
+  mixins: [Reflux.connect(AlertsStore), Reflux.connect(AlertConditionsStore)],
+
+  getInitialState() {
+    return {
+      loading: false,
+    };
+  },
+
+  componentDidMount() {
+    this._refreshData();
+  },
+
+  currentPage: 1,
+  pageSize: 5,
+
+  loadData(pageNo, limit) {
+    this.setState({ loading: true });
+    const promises = [
+      AlertsActions.listPaginated(this.props.stream.id, (pageNo - 1) * limit, limit),
+      AlertConditionsActions.list(this.props.stream.id),
+      AlertConditionsActions.available(),
+    ];
+
+    Promise.all(promises).finally(() => this.setState({ loading: false }));
+  },
+
+  _refreshData() {
+    this.loadData(this.currentPage, this.pageSize);
+  },
+
+  _onChangePaginatedList(page, size) {
+    this.currentPage = page;
+    this.pageSize = size;
+    this.loadData(page, size);
+  },
+
+  _formatAlert(alert) {
+    const condition = this.state.alertConditions.find(alertCondition => alertCondition.id === alert.condition_id);
+    const conditionType = condition ? this.state.types[condition.type] : {};
+
+    return (
+      <Alert key={alert.id}
+             alert={alert}
+             alertCondition={condition}
+             stream={this.props.stream}
+             conditionType={conditionType} />
+    );
+  },
+
+  _isLoading() {
+    return !this.state.alerts || !this.state.alertConditions || !this.state.types;
+  },
+
+  render() {
+    if (this._isLoading()) {
+      return <Spinner />;
+    }
+
+    return (
+      <div>
+        <h2>Stream alerts</h2>
+        <p className="description">
+          Here you can see the currently unresolved alerts for this stream. To see resolved alerts on this stream
+          or alerts on other streams, visit the <Link to={Routes.ALERTS.LIST}>alerts</Link> page.
+        </p>
+
+        <PaginatedList totalItems={this.state.alerts.total}
+                       pageSize={this.pageSize}
+                       onChange={this._onChangePaginatedList}
+                       showPageSizeSelect={false}>
+          <EntityList bsNoItemsStyle="success"
+                      noItemsText="Good news! Currently there are no unresolved alerts on this stream."
+                      items={this.state.alerts.alerts.map(alert => this._formatAlert(alert))} />
+        </PaginatedList>
+      </div>
+    );
+  },
+});
+
+export default StreamAlerts;

--- a/graylog2-web-interface/src/components/alerts/StreamAlerts.jsx
+++ b/graylog2-web-interface/src/components/alerts/StreamAlerts.jsx
@@ -2,11 +2,9 @@ import React from 'react';
 import createReactClass from 'create-react-class';
 import PropTypes from 'prop-types';
 import Reflux from 'reflux';
-import { Link } from 'react-router';
 
 import { Alert } from 'components/alerts';
 import { EntityList, PaginatedList, Spinner } from 'components/common';
-import Routes from 'routing/Routes';
 import CombinedProvider from 'injection/CombinedProvider';
 
 const { AlertsStore, AlertsActions } = CombinedProvider.get('Alerts');
@@ -30,7 +28,7 @@ const StreamAlerts = createReactClass({
 
   componentDidMount() {
     this.loadData(this.currentPage, this.pageSize);
-    this.interval = setInterval(() => this.fetchData(this.currentPage, this.pageSize), ALERTS_REFRESH_INTERVAL)
+    this.interval = setInterval(() => this.fetchData(this.currentPage, this.pageSize), ALERTS_REFRESH_INTERVAL);
   },
 
   componentWillUnmount() {

--- a/graylog2-web-interface/src/components/alerts/StreamAlerts.jsx
+++ b/graylog2-web-interface/src/components/alerts/StreamAlerts.jsx
@@ -78,10 +78,10 @@ const StreamAlerts = createReactClass({
 
     return (
       <div>
-        <h2>Unresolved stream alerts</h2>
+        <h2>Unresolved Alerts</h2>
         <p className="description">
-          These are the currently unresolved alerts for this stream. To see all alerts or alerts on other streams,
-          visit the <Link to={Routes.ALERTS.LIST}>alerts</Link> page.
+          These are the Alerts for this Stream that require your attention. Alerts will be resolved automatically
+          when the Condition that triggered them is no longer satisfied.
         </p>
 
         <PaginatedList totalItems={this.state.alerts.total}

--- a/graylog2-web-interface/src/components/alerts/StreamAlertsOverviewContainer.jsx
+++ b/graylog2-web-interface/src/components/alerts/StreamAlertsOverviewContainer.jsx
@@ -45,19 +45,19 @@ const StreamAlertsOverviewContainer = createReactClass({
     }
 
     const stream = this.props.stream;
-    const { alertConditions, types } = this.state;
+    const { alertConditions, availableConditions } = this.state;
 
     return (
       <React.Fragment>
         <Row className="content">
           <Col md={12}>
-            <StreamAlerts stream={stream} alertConditions={alertConditions} conditionTypes={types} />
+            <StreamAlerts stream={stream} alertConditions={alertConditions} availableConditions={availableConditions} />
           </Col>
         </Row>
 
         <Row className="content">
           <Col md={12}>
-            <StreamAlertConditions stream={stream} alertConditions={alertConditions} />
+            <StreamAlertConditions stream={stream} alertConditions={alertConditions} availableConditions={availableConditions} />
           </Col>
         </Row>
 

--- a/graylog2-web-interface/src/components/alerts/StreamAlertsOverviewContainer.jsx
+++ b/graylog2-web-interface/src/components/alerts/StreamAlertsOverviewContainer.jsx
@@ -1,0 +1,74 @@
+import React from 'react';
+import createReactClass from 'create-react-class';
+import PropTypes from 'prop-types';
+import { Col, Row } from 'react-bootstrap';
+import Reflux from 'reflux';
+import Promise from 'bluebird';
+
+import { Spinner } from 'components/common';
+import { StreamAlerts } from 'components/alerts';
+import { StreamAlertConditions } from 'components/alertconditions';
+import { StreamAlertNotifications } from 'components/alertnotifications';
+import CombinedProvider from 'injection/CombinedProvider';
+
+const { AlertConditionsStore, AlertConditionsActions } = CombinedProvider.get('AlertConditions');
+
+const StreamAlertsOverviewContainer = createReactClass({
+  propTypes: {
+    stream: PropTypes.object.isRequired,
+  },
+  mixins: [Reflux.connect(AlertConditionsStore)],
+
+  getInitialState() {
+    return {
+      loading: true,
+    };
+  },
+
+  componentDidMount() {
+    this.loadData();
+  },
+
+  loadData() {
+    this.setState({ loading: true });
+    const promises = [
+      AlertConditionsActions.list(this.props.stream.id),
+      AlertConditionsActions.available(),
+    ];
+
+    Promise.all(promises).finally(() => this.setState({ loading: false }));
+  },
+
+  render() {
+    if (this.state.loading) {
+      return <Spinner />;
+    }
+
+    const stream = this.props.stream;
+    const { alertConditions, types } = this.state;
+
+    return (
+      <React.Fragment>
+        <Row className="content">
+          <Col md={12}>
+            <StreamAlerts stream={stream} alertConditions={alertConditions} conditionTypes={types} />
+          </Col>
+        </Row>
+
+        <Row className="content">
+          <Col md={12}>
+            <StreamAlertConditions stream={stream} alertConditions={alertConditions} />
+          </Col>
+        </Row>
+
+        <Row className="content">
+          <Col md={12}>
+            <StreamAlertNotifications stream={stream} />
+          </Col>
+        </Row>
+      </React.Fragment>
+    );
+  },
+});
+
+export default StreamAlertsOverviewContainer;

--- a/graylog2-web-interface/src/components/alerts/StreamAlertsOverviewContainer.jsx
+++ b/graylog2-web-interface/src/components/alerts/StreamAlertsOverviewContainer.jsx
@@ -57,7 +57,11 @@ const StreamAlertsOverviewContainer = createReactClass({
 
         <Row className="content">
           <Col md={12}>
-            <StreamAlertConditions stream={stream} alertConditions={alertConditions} availableConditions={availableConditions} />
+            <StreamAlertConditions stream={stream}
+                                   alertConditions={alertConditions}
+                                   availableConditions={availableConditions}
+                                   onConditionUpdate={this.loadData}
+                                   onConditionDelete={this.loadData} />
           </Col>
         </Row>
 

--- a/graylog2-web-interface/src/components/alerts/StreamAlertsOverviewContainer.jsx
+++ b/graylog2-web-interface/src/components/alerts/StreamAlertsOverviewContainer.jsx
@@ -31,12 +31,16 @@ const StreamAlertsOverviewContainer = createReactClass({
 
   loadData() {
     this.setState({ loading: true });
-    const promises = [
+    const promises = this.fetchData();
+
+    Promise.all(promises).finally(() => this.setState({ loading: false }));
+  },
+
+  fetchData() {
+    return [
       AlertConditionsActions.list(this.props.stream.id),
       AlertConditionsActions.available(),
     ];
-
-    Promise.all(promises).finally(() => this.setState({ loading: false }));
   },
 
   render() {
@@ -60,8 +64,8 @@ const StreamAlertsOverviewContainer = createReactClass({
             <StreamAlertConditions stream={stream}
                                    alertConditions={alertConditions}
                                    availableConditions={availableConditions}
-                                   onConditionUpdate={this.loadData}
-                                   onConditionDelete={this.loadData} />
+                                   onConditionUpdate={this.fetchData}
+                                   onConditionDelete={this.fetchData} />
           </Col>
         </Row>
 

--- a/graylog2-web-interface/src/components/alerts/index.jsx
+++ b/graylog2-web-interface/src/components/alerts/index.jsx
@@ -5,3 +5,4 @@ export { default as AlertMessages } from './AlertMessages';
 export { default as AlertsComponent } from './AlertsComponent';
 export { default as AlertTimeline } from './AlertTimeline';
 export { default as StreamAlerts } from './StreamAlerts';
+export { default as StreamAlertsOverviewContainer } from './StreamAlertsOverviewContainer';

--- a/graylog2-web-interface/src/components/alerts/index.jsx
+++ b/graylog2-web-interface/src/components/alerts/index.jsx
@@ -4,3 +4,4 @@ export { default as AlertDetails } from './AlertDetails';
 export { default as AlertMessages } from './AlertMessages';
 export { default as AlertsComponent } from './AlertsComponent';
 export { default as AlertTimeline } from './AlertTimeline';
+export { default as StreamAlerts } from './StreamAlerts';

--- a/graylog2-web-interface/src/components/streams/Stream.jsx
+++ b/graylog2-web-interface/src/components/streams/Stream.jsx
@@ -132,6 +132,12 @@ const Stream = createReactClass({
         </OverlayElement>
       );
 
+      manageAlertsLink = (
+        <LinkContainer to={Routes.stream_alerts(stream.id)}>
+          <Button bsStyle="info">Manage Alerts</Button>
+        </LinkContainer>
+      );
+
       if (this.isPermitted(permissions, ['stream_outputs:read'])) {
         manageOutputsLink = (
           <LinkContainer to={Routes.stream_outputs(stream.id)}>

--- a/graylog2-web-interface/src/components/streams/Stream.jsx
+++ b/graylog2-web-interface/src/components/streams/Stream.jsx
@@ -1,25 +1,27 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 import createReactClass from 'create-react-class';
+import { Button, Tooltip } from 'react-bootstrap';
+import { Link } from 'react-router';
+import { LinkContainer } from 'react-router-bootstrap';
+
+import { OverlayElement, Pluralize } from 'components/common';
+import CollapsibleStreamRuleList from 'components/streamrules/CollapsibleStreamRuleList';
+import StreamRuleForm from 'components/streamrules/StreamRuleForm';
+
+import PermissionsMixin from 'util/PermissionsMixin';
+import UserNotification from 'util/UserNotification';
+import StoreProvider from 'injection/StoreProvider';
+import Routes from 'routing/Routes';
+
 import StreamThroughput from './StreamThroughput';
 import StreamControls from './StreamControls';
 import StreamStateBadge from './StreamStateBadge';
-import CollapsibleStreamRuleList from 'components/streamrules/CollapsibleStreamRuleList';
-import PermissionsMixin from 'util/PermissionsMixin';
-
-import StoreProvider from 'injection/StoreProvider';
-const StreamsStore = StoreProvider.getStore('Streams');
-const StreamRulesStore = StoreProvider.getStore('StreamRules');
-
-import StreamRuleForm from 'components/streamrules/StreamRuleForm';
-import { OverlayElement, Pluralize } from 'components/common';
-import UserNotification from 'util/UserNotification';
-import { Button, Tooltip } from 'react-bootstrap';
-import { LinkContainer } from 'react-router-bootstrap';
-import { Link } from 'react-router';
-import Routes from 'routing/Routes';
 
 import style from './Stream.css';
+
+const StreamsStore = StoreProvider.getStore('Streams');
+const StreamRulesStore = StoreProvider.getStore('StreamRules');
 
 const Stream = createReactClass({
   displayName: 'Stream',
@@ -144,7 +146,9 @@ const Stream = createReactClass({
       if (stream.disabled) {
         toggleStreamLink = (
           <OverlayElement overlay={defaultStreamTooltip} placement="top" useOverlay={isDefaultStream}>
-            <Button bsStyle="success" className="toggle-stream-button" onClick={this._onResume}
+            <Button bsStyle="success"
+                    className="toggle-stream-button"
+                    onClick={this._onResume}
                     disabled={isDefaultStream || this.state.loading}>
               {this.state.loading ? 'Starting...' : 'Start Stream'}
             </Button>
@@ -153,7 +157,9 @@ const Stream = createReactClass({
       } else {
         toggleStreamLink = (
           <OverlayElement overlay={defaultStreamTooltip} placement="top" useOverlay={isDefaultStream}>
-            <Button bsStyle="primary" className="toggle-stream-button" onClick={this._onPause}
+            <Button bsStyle="primary"
+                    className="toggle-stream-button"
+                    onClick={this._onPause}
                     disabled={isDefaultStream || this.state.loading}>
               {this.state.loading ? 'Pausing...' : 'Pause Stream'}
             </Button>
@@ -166,15 +172,17 @@ const Stream = createReactClass({
       <i className="fa fa-cube" title="Created from content pack" /> : null);
 
     const streamRuleList = isDefaultStream ? null :
-                           (<CollapsibleStreamRuleList key={`streamRules-${stream.id}`}
-                                 stream={stream}
-                                 streamRuleTypes={this.props.streamRuleTypes}
-                                 permissions={this.props.permissions} />);
+      (<CollapsibleStreamRuleList key={`streamRules-${stream.id}`}
+                                  stream={stream}
+                                  streamRuleTypes={this.props.streamRuleTypes}
+                                  permissions={this.props.permissions} />);
     const streamControls = (
       <OverlayElement overlay={defaultStreamTooltip} placement="top" useOverlay={isDefaultStream}>
-        <StreamControls stream={stream} permissions={this.props.permissions}
+        <StreamControls stream={stream}
+                        permissions={this.props.permissions}
                         user={this.props.user}
-                        onDelete={this._onDelete} onUpdate={this._onUpdate}
+                        onDelete={this._onDelete}
+                        onUpdate={this._onUpdate}
                         onClone={this._onClone}
                         onQuickAdd={this._onQuickAdd}
                         indexSets={this.props.indexSets}
@@ -213,7 +221,8 @@ const Stream = createReactClass({
             {streamRuleList}
           </div>
         </div>
-        <StreamRuleForm ref={(quickAddStreamRuleForm) => { this.quickAddStreamRuleForm = quickAddStreamRuleForm; }} title="New Stream Rule"
+        <StreamRuleForm ref={(quickAddStreamRuleForm) => { this.quickAddStreamRuleForm = quickAddStreamRuleForm; }}
+                        title="New Stream Rule"
                         onSubmit={this._onSaveStreamRule}
                         streamRuleTypes={this.props.streamRuleTypes} />
       </li>

--- a/graylog2-web-interface/src/components/streams/StreamControls.jsx
+++ b/graylog2-web-interface/src/components/streams/StreamControls.jsx
@@ -4,10 +4,11 @@ import createReactClass from 'create-react-class';
 import { DropdownButton, MenuItem } from 'react-bootstrap';
 
 import { IfPermitted } from 'components/common';
-import StreamForm from './StreamForm';
 import PermissionsMixin from 'util/PermissionsMixin';
-
 import StoreProvider from 'injection/StoreProvider';
+
+import StreamForm from './StreamForm';
+
 const StartpageStore = StoreProvider.getStore('Startpage');
 
 const StreamControls = createReactClass({
@@ -26,22 +27,21 @@ const StreamControls = createReactClass({
 
   mixins: [PermissionsMixin],
 
-  getInitialState() {
-    return {};
+  getDefaultProps() {
+    return {
+      isDefaultStream: false,
+    };
   },
 
-  _onDelete(_, event) {
-    event.preventDefault();
+  _onDelete() {
     this.props.onDelete(this.props.stream);
   },
 
-  _onEdit(_, event) {
-    event.preventDefault();
+  _onEdit() {
     this.streamForm.open();
   },
 
-  _onClone(_, event) {
-    event.preventDefault();
+  _onClone() {
     this.cloneForm.open();
   },
 
@@ -49,13 +49,11 @@ const StreamControls = createReactClass({
     this.props.onClone(this.props.stream.id, stream);
   },
 
-  _onQuickAdd(_, event) {
-    event.preventDefault();
+  _onQuickAdd() {
     this.props.onQuickAdd(this.props.stream.id);
   },
 
-  _setStartpage(_, event) {
-    event.preventDefault();
+  _setStartpage() {
     StartpageStore.set(this.props.user.username, 'stream', this.props.stream.id);
   },
 
@@ -64,8 +62,10 @@ const StreamControls = createReactClass({
 
     return (
       <span>
-        <DropdownButton title="More Actions" pullRight
-                        id={`more-actions-dropdown-${stream.id}`} disabled={this.props.isDefaultStream}>
+        <DropdownButton title="More Actions"
+                        pullRight
+                        id={`more-actions-dropdown-${stream.id}`}
+                        disabled={this.props.isDefaultStream}>
           <IfPermitted permissions={`streams:edit:${stream.id}`}>
             <MenuItem key={`editStreams-${stream.id}`} onSelect={this._onEdit}>Edit stream</MenuItem>
           </IfPermitted>

--- a/graylog2-web-interface/src/components/streams/StreamList.jsx
+++ b/graylog2-web-interface/src/components/streams/StreamList.jsx
@@ -3,8 +3,8 @@ import React from 'react';
 import createReactClass from 'create-react-class';
 import { Alert } from 'react-bootstrap';
 
-import Stream from './Stream';
 import PermissionsMixin from 'util/PermissionsMixin';
+import Stream from './Stream';
 
 const StreamList = createReactClass({
   displayName: 'StreamList',
@@ -15,7 +15,6 @@ const StreamList = createReactClass({
     indexSets: PropTypes.array.isRequired,
     user: PropTypes.object.isRequired,
     permissions: PropTypes.array.isRequired,
-    onStreamSave: PropTypes.func.isRequired,
   },
 
   mixins: [PermissionsMixin],
@@ -26,8 +25,12 @@ const StreamList = createReactClass({
 
   _formatStream(stream) {
     return (
-      <Stream key={`stream-${stream.id}`} stream={stream} streamRuleTypes={this.props.streamRuleTypes}
-                   permissions={this.props.permissions} user={this.props.user} indexSets={this.props.indexSets} />
+      <Stream key={`stream-${stream.id}`}
+              stream={stream}
+              streamRuleTypes={this.props.streamRuleTypes}
+              permissions={this.props.permissions}
+              user={this.props.user}
+              indexSets={this.props.indexSets} />
     );
   },
 
@@ -48,7 +51,7 @@ const StreamList = createReactClass({
     return (
       <Alert bsStyle="info">
         <i className="fa fa-info-circle" />&nbsp;No streams match your search filter.
-        </Alert>
+      </Alert>
     );
   },
 });

--- a/graylog2-web-interface/src/pages/EditAlertConditionPage.jsx
+++ b/graylog2-web-interface/src/pages/EditAlertConditionPage.jsx
@@ -7,7 +7,8 @@ import { Col, Row } from 'react-bootstrap';
 import DocumentationLink from 'components/support/DocumentationLink';
 import { DocumentTitle, PageHeader, Spinner } from 'components/common';
 import { AlertsHeaderToolbar } from 'components/alerts';
-import { ConditionAlertNotifications, EditAlertConditionForm } from 'components/alertconditions';
+import { EditAlertConditionForm } from 'components/alertconditions';
+import { StreamAlertNotifications } from 'components/alertnotifications';
 
 import Routes from 'routing/Routes';
 import DocsHelper from 'util/DocsHelper';
@@ -79,7 +80,7 @@ const EditAlertConditionPage = createReactClass({
 
           <Row className="content">
             <Col md={12}>
-              <ConditionAlertNotifications alertCondition={condition} stream={stream} />
+              <StreamAlertNotifications stream={stream} />
             </Col>
           </Row>
         </div>

--- a/graylog2-web-interface/src/pages/EditAlertConditionPage.jsx
+++ b/graylog2-web-interface/src/pages/EditAlertConditionPage.jsx
@@ -40,6 +40,7 @@ const EditAlertConditionPage = createReactClass({
     });
 
     AlertConditionsActions.get(this.props.params.streamId, this.props.params.conditionId);
+    AlertConditionsActions.available();
   },
 
   _handleUpdate(streamId, conditionId) {
@@ -51,7 +52,7 @@ const EditAlertConditionPage = createReactClass({
   },
 
   _isLoading() {
-    return !this.state.stream || !this.state.alertCondition;
+    return !this.state.stream || !this.state.alertCondition || !this.state.availableConditions;
   },
 
   render() {
@@ -60,6 +61,7 @@ const EditAlertConditionPage = createReactClass({
     }
 
     const condition = this.state.alertCondition;
+    const conditionType = this.state.availableConditions[condition.type];
     const stream = this.state.stream;
 
     return (
@@ -84,6 +86,7 @@ const EditAlertConditionPage = createReactClass({
           <Row className="content">
             <Col md={12}>
               <EditAlertConditionForm alertCondition={condition}
+                                      conditionType={conditionType}
                                       stream={stream}
                                       onUpdate={this._handleUpdate}
                                       onDelete={this._handleDelete} />

--- a/graylog2-web-interface/src/pages/EditAlertConditionPage.jsx
+++ b/graylog2-web-interface/src/pages/EditAlertConditionPage.jsx
@@ -12,8 +12,9 @@ import { StreamAlertNotifications } from 'components/alertnotifications';
 
 import Routes from 'routing/Routes';
 import DocsHelper from 'util/DocsHelper';
-
+import history from 'util/History';
 import CombinedProvider from 'injection/CombinedProvider';
+
 const { CurrentUserStore } = CombinedProvider.get('CurrentUser');
 const { StreamsStore } = CombinedProvider.get('Streams');
 const { AlertConditionsStore, AlertConditionsActions } = CombinedProvider.get('AlertConditions');
@@ -39,6 +40,14 @@ const EditAlertConditionPage = createReactClass({
     });
 
     AlertConditionsActions.get(this.props.params.streamId, this.props.params.conditionId);
+  },
+
+  _handleUpdate(streamId, conditionId) {
+    AlertConditionsActions.get(streamId, conditionId);
+  },
+
+  _handleDelete() {
+    history.push(Routes.ALERTS.CONDITIONS);
   },
 
   _isLoading() {
@@ -74,7 +83,10 @@ const EditAlertConditionPage = createReactClass({
 
           <Row className="content">
             <Col md={12}>
-              <EditAlertConditionForm alertCondition={condition} stream={stream} />
+              <EditAlertConditionForm alertCondition={condition}
+                                      stream={stream}
+                                      onUpdate={this._handleUpdate}
+                                      onDelete={this._handleDelete} />
             </Col>
           </Row>
 

--- a/graylog2-web-interface/src/pages/NewAlertConditionPage.jsx
+++ b/graylog2-web-interface/src/pages/NewAlertConditionPage.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import createReactClass from 'create-react-class';
+import PropTypes from 'prop-types';
 import Reflux from 'reflux';
 import { Col, Row } from 'react-bootstrap';
 
@@ -10,15 +11,20 @@ import { CreateAlertConditionInput } from 'components/alertconditions';
 
 import Routes from 'routing/Routes';
 import DocsHelper from 'util/DocsHelper';
-
 import StoreProvider from 'injection/StoreProvider';
+
 const CurrentUserStore = StoreProvider.getStore('CurrentUser');
 
 const NewAlertConditionPage = createReactClass({
   displayName: 'NewAlertConditionPage',
+  propTypes: {
+    location: PropTypes.object.isRequired,
+  },
   mixins: [Reflux.connect(CurrentUserStore)],
 
   render() {
+    const streamId = this.props.location.query.stream_id;
+
     return (
       <DocumentTitle title="New alert condition">
         <div>
@@ -40,7 +46,7 @@ const NewAlertConditionPage = createReactClass({
 
           <Row className="content">
             <Col md={12}>
-              <CreateAlertConditionInput />
+              <CreateAlertConditionInput initialSelectedStream={streamId} />
             </Col>
           </Row>
         </div>

--- a/graylog2-web-interface/src/pages/NewAlertNotificationPage.jsx
+++ b/graylog2-web-interface/src/pages/NewAlertNotificationPage.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import createReactClass from 'create-react-class';
+import PropTypes from 'prop-types';
 import Reflux from 'reflux';
 import { Col, Row } from 'react-bootstrap';
 
@@ -8,15 +9,20 @@ import { AlertsHeaderToolbar } from 'components/alerts';
 import { CreateAlertNotificationInput } from 'components/alertnotifications';
 
 import Routes from 'routing/Routes';
-
 import StoreProvider from 'injection/StoreProvider';
+
 const CurrentUserStore = StoreProvider.getStore('CurrentUser');
 
 const NewAlertNotificationPage = createReactClass({
   displayName: 'NewAlertNotificationPage',
+  propTypes: {
+    location: PropTypes.object.isRequired,
+  },
   mixins: [Reflux.connect(CurrentUserStore)],
 
   render() {
+    const streamId = this.props.location.query.stream_id;
+
     return (
       <DocumentTitle title="New alert notification">
         <div>
@@ -36,7 +42,7 @@ const NewAlertNotificationPage = createReactClass({
 
           <Row className="content">
             <Col md={12}>
-              <CreateAlertNotificationInput />
+              <CreateAlertNotificationInput initialSelectedStream={streamId} />
             </Col>
           </Row>
         </div>

--- a/graylog2-web-interface/src/pages/ShowAlertPage.jsx
+++ b/graylog2-web-interface/src/pages/ShowAlertPage.jsx
@@ -64,7 +64,7 @@ const ShowAlertPage = createReactClass({
   },
 
   _isLoading() {
-    return !this.state.alert || !this.state.alertCondition || !this.state.types || !this.state.stream;
+    return !this.state.alert || !this.state.alertCondition || !this.state.availableConditions || !this.state.stream;
   },
 
   render() {
@@ -75,7 +75,7 @@ const ShowAlertPage = createReactClass({
     const alert = this.state.alert;
     const condition = this.state.alertCondition;
     const conditionExists = Object.keys(condition).length > 0;
-    const type = this.state.types[condition.type] || {};
+    const conditionType = this.state.availableConditions[condition.type] || {};
     const stream = this.state.stream;
 
     let statusLabel;
@@ -144,7 +144,7 @@ const ShowAlertPage = createReactClass({
             </span>
           </PageHeader>
 
-          <AlertDetails alert={alert} condition={conditionExists && condition} conditionType={type} stream={stream} />
+          <AlertDetails alert={alert} condition={conditionExists && condition} conditionType={conditionType} stream={stream} />
         </div>
       </DocumentTitle>
     );

--- a/graylog2-web-interface/src/pages/ShowAlertPage.jsx
+++ b/graylog2-web-interface/src/pages/ShowAlertPage.jsx
@@ -13,11 +13,11 @@ import UserNotification from 'util/UserNotification';
 import Routes from 'routing/Routes';
 
 import CombinedProvider from 'injection/CombinedProvider';
+import style from './ShowAlertPage.css';
+
 const { AlertsStore, AlertsActions } = CombinedProvider.get('Alerts');
 const { AlertConditionsStore, AlertConditionsActions } = CombinedProvider.get('AlertConditions');
 const { StreamsStore } = CombinedProvider.get('Streams');
-
-import style from './ShowAlertPage.css';
 
 const ShowAlertPage = createReactClass({
   displayName: 'ShowAlertPage',
@@ -134,7 +134,9 @@ const ShowAlertPage = createReactClass({
                 <LinkContainer to={Routes.ALERTS.LIST}>
                   <Button bsStyle="info" className="active">Alerts</Button>
                 </LinkContainer>
-                <OverlayElement overlay={conditionDetailsTooltip} placement="top" useOverlay={!condition.id}
+                <OverlayElement overlay={conditionDetailsTooltip}
+                                placement="top"
+                                useOverlay={!condition.id}
                                 trigger={['hover', 'focus']}>
                   <LinkContainer to={Routes.show_alert_condition(stream.id, condition.id)} disabled={!condition.id}>
                     <Button bsStyle="info">Condition details</Button>

--- a/graylog2-web-interface/src/pages/StreamAlertsOverviewPage.jsx
+++ b/graylog2-web-interface/src/pages/StreamAlertsOverviewPage.jsx
@@ -8,6 +8,7 @@ import { AlertsHeaderToolbar } from 'components/alerts';
 import Routes from 'routing/Routes';
 import CombinedProvider from 'injection/CombinedProvider';
 import { StreamAlertNotifications } from 'components/alertnotifications';
+import { StreamAlertConditions } from 'components/alertconditions';
 
 const { StreamsStore } = CombinedProvider.get('Streams');
 
@@ -51,6 +52,12 @@ class StreamAlertsOverviewPage extends React.Component {
               <AlertsHeaderToolbar active={Routes.ALERTS.NOTIFICATIONS} />
             </span>
           </PageHeader>
+
+          <Row className="content">
+            <Col md={12}>
+              <StreamAlertConditions stream={stream} />
+            </Col>
+          </Row>
 
           <Row className="content">
             <Col md={12}>

--- a/graylog2-web-interface/src/pages/StreamAlertsOverviewPage.jsx
+++ b/graylog2-web-interface/src/pages/StreamAlertsOverviewPage.jsx
@@ -1,0 +1,64 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { Col, Row } from 'react-bootstrap';
+
+import { DocumentTitle, PageHeader, Spinner } from 'components/common';
+import { AlertsHeaderToolbar } from 'components/alerts';
+
+import Routes from 'routing/Routes';
+import CombinedProvider from 'injection/CombinedProvider';
+
+const { StreamsStore } = CombinedProvider.get('Streams');
+
+class StreamAlertsOverviewPage extends React.Component {
+  static propTypes = {
+    params: PropTypes.object.isRequired,
+  };
+
+  state = {
+    stream: undefined,
+  };
+
+  componentDidMount() {
+    StreamsStore.get(this.props.params.streamId, (stream) => {
+      this.setState({ stream: stream });
+    });
+  }
+
+  render() {
+    const { stream } = this.state;
+    const isLoading = !stream;
+
+    if (isLoading) {
+      return <DocumentTitle title="Stream Alerts Overview"><Spinner /></DocumentTitle>;
+    }
+
+    return (
+      <DocumentTitle title={`Alerts for Stream ${stream.title}`}>
+        <div>
+          <PageHeader title={<span>Alerts for Stream &raquo;{stream.title}&laquo;</span>}>
+            <span>
+              Notifications let you be aware of changes in your alert conditions status any time. Graylog can send
+              notifications directly to you or to other systems you use for that purpose.
+            </span>
+
+            <span>
+              Remember to assign the notifications to use in the alert conditions page.
+            </span>
+
+            <span>
+              <AlertsHeaderToolbar active={Routes.ALERTS.NOTIFICATIONS} />
+            </span>
+          </PageHeader>
+
+          <Row className="content">
+            <Col md={12}>
+            </Col>
+          </Row>
+        </div>
+      </DocumentTitle>
+    );
+  }
+}
+
+export default StreamAlertsOverviewPage;

--- a/graylog2-web-interface/src/pages/StreamAlertsOverviewPage.jsx
+++ b/graylog2-web-interface/src/pages/StreamAlertsOverviewPage.jsx
@@ -7,6 +7,7 @@ import { AlertsHeaderToolbar } from 'components/alerts';
 
 import Routes from 'routing/Routes';
 import CombinedProvider from 'injection/CombinedProvider';
+import { StreamAlertNotifications } from 'components/alertnotifications';
 
 const { StreamsStore } = CombinedProvider.get('Streams');
 
@@ -53,6 +54,7 @@ class StreamAlertsOverviewPage extends React.Component {
 
           <Row className="content">
             <Col md={12}>
+              <StreamAlertNotifications stream={stream} />
             </Col>
           </Row>
         </div>

--- a/graylog2-web-interface/src/pages/StreamAlertsOverviewPage.jsx
+++ b/graylog2-web-interface/src/pages/StreamAlertsOverviewPage.jsx
@@ -1,9 +1,9 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { Col, Row } from 'react-bootstrap';
+import { Button, ButtonToolbar, Col, Row } from 'react-bootstrap';
+import { LinkContainer } from 'react-router-bootstrap';
 
 import { DocumentTitle, PageHeader, Spinner } from 'components/common';
-import { AlertsHeaderToolbar } from 'components/alerts';
 
 import Routes from 'routing/Routes';
 import CombinedProvider from 'injection/CombinedProvider';
@@ -48,9 +48,14 @@ class StreamAlertsOverviewPage extends React.Component {
               Remember to assign the notifications to use in the alert conditions page.
             </span>
 
-            <span>
-              <AlertsHeaderToolbar active={Routes.ALERTS.NOTIFICATIONS} />
-            </span>
+            <ButtonToolbar>
+              <LinkContainer to={Routes.STREAMS}>
+                <Button bsStyle="info">Streams</Button>
+              </LinkContainer>
+              <LinkContainer to={Routes.ALERTS.LIST}>
+                <Button bsStyle="info">Alerts</Button>
+              </LinkContainer>
+            </ButtonToolbar>
           </PageHeader>
 
           <Row className="content">

--- a/graylog2-web-interface/src/pages/StreamAlertsOverviewPage.jsx
+++ b/graylog2-web-interface/src/pages/StreamAlertsOverviewPage.jsx
@@ -9,6 +9,7 @@ import Routes from 'routing/Routes';
 import CombinedProvider from 'injection/CombinedProvider';
 import { StreamAlertNotifications } from 'components/alertnotifications';
 import { StreamAlertConditions } from 'components/alertconditions';
+import { StreamAlerts } from 'components/alerts';
 
 const { StreamsStore } = CombinedProvider.get('Streams');
 
@@ -57,6 +58,12 @@ class StreamAlertsOverviewPage extends React.Component {
               </LinkContainer>
             </ButtonToolbar>
           </PageHeader>
+
+          <Row className="content">
+            <Col md={12}>
+              <StreamAlerts stream={stream} />
+            </Col>
+          </Row>
 
           <Row className="content">
             <Col md={12}>

--- a/graylog2-web-interface/src/pages/StreamAlertsOverviewPage.jsx
+++ b/graylog2-web-interface/src/pages/StreamAlertsOverviewPage.jsx
@@ -7,9 +7,7 @@ import { DocumentTitle, PageHeader, Spinner } from 'components/common';
 
 import Routes from 'routing/Routes';
 import CombinedProvider from 'injection/CombinedProvider';
-import { StreamAlertNotifications } from 'components/alertnotifications';
-import { StreamAlertConditions } from 'components/alertconditions';
-import { StreamAlerts } from 'components/alerts';
+import { StreamAlertsOverviewContainer } from 'components/alerts';
 
 const { StreamsStore } = CombinedProvider.get('Streams');
 
@@ -59,23 +57,7 @@ class StreamAlertsOverviewPage extends React.Component {
             </ButtonToolbar>
           </PageHeader>
 
-          <Row className="content">
-            <Col md={12}>
-              <StreamAlerts stream={stream} />
-            </Col>
-          </Row>
-
-          <Row className="content">
-            <Col md={12}>
-              <StreamAlertConditions stream={stream} />
-            </Col>
-          </Row>
-
-          <Row className="content">
-            <Col md={12}>
-              <StreamAlertNotifications stream={stream} />
-            </Col>
-          </Row>
+          <StreamAlertsOverviewContainer stream={stream} />
         </div>
       </DocumentTitle>
     );

--- a/graylog2-web-interface/src/pages/StreamAlertsOverviewPage.jsx
+++ b/graylog2-web-interface/src/pages/StreamAlertsOverviewPage.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { Button, ButtonToolbar, Col, Row } from 'react-bootstrap';
+import { Button, ButtonToolbar } from 'react-bootstrap';
 import { LinkContainer } from 'react-router-bootstrap';
 
 import { DocumentTitle, PageHeader, Spinner } from 'components/common';
@@ -8,6 +8,8 @@ import { DocumentTitle, PageHeader, Spinner } from 'components/common';
 import Routes from 'routing/Routes';
 import CombinedProvider from 'injection/CombinedProvider';
 import { StreamAlertsOverviewContainer } from 'components/alerts';
+import DocumentationLink from 'components/support/DocumentationLink';
+import DocsHelper from 'util/DocsHelper';
 
 const { StreamsStore } = CombinedProvider.get('Streams');
 
@@ -35,16 +37,16 @@ class StreamAlertsOverviewPage extends React.Component {
     }
 
     return (
-      <DocumentTitle title={`Alerts for Stream ${stream.title}`}>
+      <DocumentTitle title={`Alerting overview for Stream ${stream.title}`}>
         <div>
-          <PageHeader title={<span>Alerts for Stream &raquo;{stream.title}&laquo;</span>}>
+          <PageHeader title={<span>Alerting overview for Stream &raquo;{stream.title}&laquo;</span>}>
             <span>
-              Notifications let you be aware of changes in your alert conditions status any time. Graylog can send
-              notifications directly to you or to other systems you use for that purpose.
+              This is an overview of alerts, conditions, and notifications belonging to the Stream{' '}
+              <em>{stream.title}</em>.
             </span>
 
             <span>
-              Remember to assign the notifications to use in the alert conditions page.
+              Read more about alerting in the <DocumentationLink page={DocsHelper.PAGES.ALERTS} text="documentation" />.
             </span>
 
             <ButtonToolbar>
@@ -52,7 +54,13 @@ class StreamAlertsOverviewPage extends React.Component {
                 <Button bsStyle="info">Streams</Button>
               </LinkContainer>
               <LinkContainer to={Routes.ALERTS.LIST}>
-                <Button bsStyle="info">Alerts</Button>
+                <Button bsStyle="info">All Alerts</Button>
+              </LinkContainer>
+              <LinkContainer to={Routes.ALERTS.CONDITIONS}>
+                <Button bsStyle="info">All Conditions</Button>
+              </LinkContainer>
+              <LinkContainer to={Routes.ALERTS.NOTIFICATIONS}>
+                <Button bsStyle="info">All Notifications</Button>
               </LinkContainer>
             </ButtonToolbar>
           </PageHeader>

--- a/graylog2-web-interface/src/pages/index.jsx
+++ b/graylog2-web-interface/src/pages/index.jsx
@@ -70,6 +70,7 @@ const SidecarNewCollectorPage = loadAsync(() => import('pages/SidecarNewCollecto
 const SidecarsPage = loadAsync(() => import('pages/SidecarsPage'));
 const SidecarConfigurationPage = loadAsync(() => import('pages/SidecarConfigurationPage'));
 const SidecarNewConfigurationPage = loadAsync(() => import('pages/SidecarNewConfigurationPage'));
+const StreamAlertsOverviewPage = loadAsync(() => import('pages/StreamAlertsOverviewPage'));
 
 export {
   AlertConditionsPage,
@@ -142,4 +143,5 @@ export {
   SidecarsPage,
   SidecarConfigurationPage,
   SidecarNewConfigurationPage,
+  StreamAlertsOverviewPage,
 };

--- a/graylog2-web-interface/src/routing/ApiRoutes.js
+++ b/graylog2-web-interface/src/routing/ApiRoutes.js
@@ -16,7 +16,7 @@ const ApiRoutes = {
   AlertsApiController: {
     get: (alertId) => { return { url: `/streams/alerts/${alertId}` }; },
     list: (streamId, since) => { return { url: `/streams/${streamId}/alerts?since=${since}` }; },
-    listPaginated: (streamId, skip, limit) => { return { url: `/streams/${streamId}/alerts/paginated?skip=${skip}&limit=${limit}` }; },
+    listPaginated: (streamId, skip, limit, state) => { return { url: `/streams/${streamId}/alerts/paginated?skip=${skip}&limit=${limit}&state=${state}` }; },
     listAllPaginated: (skip, limit, state) => { return { url: `/streams/alerts/paginated?skip=${skip}&limit=${limit}&state=${state}` }; },
     listAllStreams: (since) => { return { url: `/streams/alerts?since=${since}` }; },
   },

--- a/graylog2-web-interface/src/routing/AppRouter.jsx
+++ b/graylog2-web-interface/src/routing/AppRouter.jsx
@@ -79,6 +79,7 @@ import {
   SidecarsPage,
   SidecarConfigurationPage,
   SidecarNewConfigurationPage,
+  StreamAlertsOverviewPage,
 } from 'pages';
 
 const AppRouter = () => {
@@ -104,6 +105,7 @@ const AppRouter = () => {
             <Route path={Routes.STREAMS} component={StreamsPage} />
             <Route path={Routes.stream_edit(':streamId')} component={StreamEditPage} />
             <Route path={Routes.stream_outputs(':streamId')} component={StreamOutputsPage} />
+            <Route path={Routes.stream_alerts(':streamId')} component={StreamAlertsOverviewPage} />
             <Route path={Routes.ALERTS.LIST} component={AlertsPage} />
             <Route path={Routes.ALERTS.CONDITIONS} component={AlertConditionsPage} />
             <Route path={Routes.ALERTS.NEW_CONDITION} component={NewAlertConditionPage} />

--- a/graylog2-web-interface/src/routing/Routes.jsx
+++ b/graylog2-web-interface/src/routing/Routes.jsx
@@ -180,8 +180,9 @@ const Routes = {
   stream_search: (streamId, query, timeRange, resolution) => {
     return Routes._common_search_url(`${Routes.STREAMS}/${streamId}/search`, query, timeRange, resolution);
   },
-  legacy_stream_search: streamId => `/streams/${streamId}/messages`,
+  stream_alerts: streamId => `/streams/${streamId}/alerts`,
 
+  legacy_stream_search: streamId => `/streams/${streamId}/messages`,
   show_alert: alertId => `${Routes.ALERTS.LIST}/${alertId}`,
   show_alert_condition: (streamId, conditionId) => `${Routes.ALERTS.CONDITIONS}/${streamId}/${conditionId}`,
 

--- a/graylog2-web-interface/src/routing/Routes.jsx
+++ b/graylog2-web-interface/src/routing/Routes.jsx
@@ -186,6 +186,7 @@ const Routes = {
   show_alert: alertId => `${Routes.ALERTS.LIST}/${alertId}`,
   show_alert_condition: (streamId, conditionId) => `${Routes.ALERTS.CONDITIONS}/${streamId}/${conditionId}`,
   new_alert_condition_for_stream: streamId => `${Routes.ALERTS.NEW_CONDITION}?stream_id=${streamId}`,
+  new_alert_notification_for_stream: streamId => `${Routes.ALERTS.NEW_NOTIFICATION}?stream_id=${streamId}`,
 
   dashboard_show: dashboardId => `/dashboards/${dashboardId}`,
 

--- a/graylog2-web-interface/src/routing/Routes.jsx
+++ b/graylog2-web-interface/src/routing/Routes.jsx
@@ -185,6 +185,7 @@ const Routes = {
   legacy_stream_search: streamId => `/streams/${streamId}/messages`,
   show_alert: alertId => `${Routes.ALERTS.LIST}/${alertId}`,
   show_alert_condition: (streamId, conditionId) => `${Routes.ALERTS.CONDITIONS}/${streamId}/${conditionId}`,
+  new_alert_condition_for_stream: streamId => `${Routes.ALERTS.NEW_CONDITION}?stream_id=${streamId}`,
 
   dashboard_show: dashboardId => `/dashboards/${dashboardId}`,
 

--- a/graylog2-web-interface/src/stores/alertconditions/AlertConditionsStore.js
+++ b/graylog2-web-interface/src/stores/alertconditions/AlertConditionsStore.js
@@ -5,20 +5,18 @@ import UserNotification from 'util/UserNotification';
 import URLUtils from 'util/URLUtils';
 import ApiRoutes from 'routing/ApiRoutes';
 import fetch from 'logic/rest/FetchProvider';
-
 import ActionsProvider from 'injection/ActionsProvider';
+
 const AlertConditionsActions = ActionsProvider.getActions('AlertConditions');
 
 const AlertConditionsStore = Reflux.createStore({
   listenables: AlertConditionsActions,
-
-  init() {
-    this.available();
-  },
+  allAlertConditions: undefined,
+  availableConditions: undefined,
 
   getInitialState() {
     return {
-      types: this.types,
+      availableConditions: this.availableConditions,
       allAlertConditions: this.allAlertConditions,
     };
   },
@@ -26,8 +24,8 @@ const AlertConditionsStore = Reflux.createStore({
   available() {
     const url = URLUtils.qualifyUrl(ApiRoutes.AlertConditionsApiController.available().url);
     const promise = fetch('GET', url).then((response) => {
-      this.types = response;
-      this.trigger(this.getInitialState());
+      this.availableConditions = response;
+      this.trigger({ availableConditions: this.availableConditions });
     });
 
     AlertConditionsActions.available.promise(promise);

--- a/graylog2-web-interface/src/stores/alerts/AlertsStore.js
+++ b/graylog2-web-interface/src/stores/alerts/AlertsStore.js
@@ -5,8 +5,8 @@ import fetch from 'logic/rest/FetchProvider';
 
 import URLUtils from 'util/URLUtils';
 import UserNotification from 'util/UserNotification';
-
 import ActionsProvider from 'injection/ActionsProvider';
+
 const AlertsActions = ActionsProvider.getActions('Alerts');
 
 const AlertsStore = Reflux.createStore({

--- a/graylog2-web-interface/src/stores/alerts/AlertsStore.js
+++ b/graylog2-web-interface/src/stores/alerts/AlertsStore.js
@@ -26,8 +26,8 @@ const AlertsStore = Reflux.createStore({
     AlertsActions.list.promise(promise);
   },
 
-  listPaginated(streamId, skip, limit) {
-    const url = URLUtils.qualifyUrl(ApiRoutes.AlertsApiController.listPaginated(streamId, skip, limit).url);
+  listPaginated(streamId, skip, limit, state = 'any') {
+    const url = URLUtils.qualifyUrl(ApiRoutes.AlertsApiController.listPaginated(streamId, skip, limit, state).url);
     const promise = fetch('GET', url);
     promise
       .then(


### PR DESCRIPTION
This PR introduces a new Stream alerting overview page, where users can see all alerts, conditions, and notifications for a single stream in context.

To ensure we could reuse much of the code we already had in place, some components have been modified to be more reusable and up-to-date with newer parts of our code. Additionally there were also changes to improve workflows when working from the context of a stream.

This PR needs to be cherry-picked into 2.5.