### PR TITLE
Stream alerting overview (#5310)

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/rest/resources/alerts/AlertResource.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/resources/alerts/AlertResource.java
@@ -93,7 +93,7 @@ public class AlertResource extends RestResource {
                                           @ApiParam(name = "limit", value = "The maximum number of elements to return.", required = true)
                                           @QueryParam("limit") @DefaultValue("300") int limit,
                                           @ApiParam(name = "state", value = "Alert state (resolved/unresolved)", required = false)
-                                          @QueryParam("state") String state) throws NotFoundException {
+                                          @QueryParam("state") String state) {
         final List<String> allowedStreamIds = getAllowedStreamIds();
 
         AlertState alertState;

--- a/graylog2-server/src/main/java/org/graylog2/rest/resources/streams/alerts/StreamAlertConditionResource.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/resources/streams/alerts/StreamAlertConditionResource.java
@@ -147,7 +147,7 @@ public class StreamAlertConditionResource extends RestResource {
             @ApiResponse(code = 404, message = "Stream not found."),
             @ApiResponse(code = 400, message = "Invalid ObjectId.")
     })
-    public AlertConditionListSummary list(@ApiParam(name = "streamId", value = "The stream id this new alert condition belongs to.", required = true)
+    public AlertConditionListSummary list(@ApiParam(name = "streamId", value = "The id of the stream whose alert conditions we want.", required = true)
                                           @PathParam("streamId") String streamid) throws NotFoundException {
         checkPermission(RestPermissions.STREAMS_READ, streamid);
 

--- a/graylog2-server/src/main/java/org/graylog2/rest/resources/streams/alerts/StreamAlertResource.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/resources/streams/alerts/StreamAlertResource.java
@@ -22,6 +22,7 @@ import com.google.common.base.Throwables;
 import com.google.common.cache.Cache;
 import com.google.common.cache.CacheBuilder;
 import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.Lists;
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
 import io.swagger.annotations.ApiParam;
@@ -149,13 +150,23 @@ public class StreamAlertResource extends RestResource {
                                           @ApiParam(name = "skip", value = "The number of elements to skip (offset).", required = true)
                                           @QueryParam("skip") @DefaultValue("0") int skip,
                                           @ApiParam(name = "limit", value = "The maximum number of elements to return.", required = true)
-                                          @QueryParam("limit") @DefaultValue("300") int limit) throws NotFoundException {
+                                          @QueryParam("limit") @DefaultValue("300") int limit,
+                                          @ApiParam(name = "state", value = "Alert state (resolved/unresolved)")
+                                          @QueryParam("state") String state) throws NotFoundException {
         checkPermission(RestPermissions.STREAMS_READ, streamId);
 
-        final Stream stream = streamService.load(streamId);
-        final List<AlertSummary> conditions = toSummaryList(alertService.listForStreamId(stream.getId(), skip, limit));
+        Alert.AlertState alertState;
+        try {
+            alertState = Alert.AlertState.fromString(state);
+        } catch (IllegalArgumentException e) {
+            alertState = Alert.AlertState.ANY;
+        }
 
-        return AlertListSummary.create(alertService.totalCountForStream(streamId), conditions);
+        final Stream stream = streamService.load(streamId);
+        final List<String> streamIdList = Lists.newArrayList(stream.getId());
+        final List<AlertSummary> conditions = toSummaryList(alertService.listForStreamIds(streamIdList, alertState, skip, limit));
+
+        return AlertListSummary.create(alertService.totalCountForStreams(streamIdList, alertState), conditions);
     }
 
     @GET

--- a/graylog2-web-interface/src/components/alertconditions/AlertCondition.jsx
+++ b/graylog2-web-interface/src/components/alertconditions/AlertCondition.jsx
@@ -82,7 +82,7 @@ const AlertCondition = createReactClass({
     }
 
     return (
-      <React.Fragment>
+      <div>
         <AlertConditionForm ref={(updateForm) => { this.updateForm = updateForm; }}
                             conditionType={conditionType}
                             alertCondition={condition}
@@ -92,7 +92,7 @@ const AlertCondition = createReactClass({
                                stream={stream}
                                actions={actions}
                                isDetailsView={this.props.isDetailsView} />
-      </React.Fragment>
+      </div>
     );
   },
 });

--- a/graylog2-web-interface/src/components/alertconditions/AlertCondition.jsx
+++ b/graylog2-web-interface/src/components/alertconditions/AlertCondition.jsx
@@ -1,35 +1,63 @@
 import PropTypes from 'prop-types';
 import React from 'react';
+import createReactClass from 'create-react-class';
 import Reflux from 'reflux';
 import { DropdownButton, MenuItem } from 'react-bootstrap';
+import { LinkContainer } from 'react-router-bootstrap';
 
+import { AlertConditionForm, AlertConditionSummary, UnknownAlertCondition } from 'components/alertconditions';
+import PermissionsMixin from 'util/PermissionsMixin';
 import CombinedProvider from 'injection/CombinedProvider';
-const { AlertConditionsActions, AlertConditionsStore } = CombinedProvider.get('AlertConditions');
+import Routes from 'routing/Routes';
+
+const { AlertConditionsActions } = CombinedProvider.get('AlertConditions');
 const { CurrentUserStore } = CombinedProvider.get('CurrentUser');
 
-import { AlertConditionSummary, UnknownAlertCondition } from 'components/alertconditions';
-import PermissionsMixin from 'util/PermissionsMixin';
+const AlertCondition = createReactClass({
+  displayName: 'AlertCondition',
 
-const AlertCondition = React.createClass({
   propTypes: {
     alertCondition: PropTypes.object.isRequired,
-    stream: PropTypes.object,
+    conditionType: PropTypes.object.isRequired,
+    stream: PropTypes.object.isRequired,
+    isDetailsView: PropTypes.bool,
+    isStreamView: PropTypes.bool,
+    onUpdate: PropTypes.func,
+    onDelete: PropTypes.func,
   },
-  mixins: [Reflux.connect(AlertConditionsStore), Reflux.connect(CurrentUserStore), PermissionsMixin],
+  mixins: [Reflux.connect(CurrentUserStore), PermissionsMixin],
+
+  getDefaultProps() {
+    return {
+      isDetailsView: false,
+      isStreamView: false,
+      onUpdate: () => {},
+      onDelete: () => {},
+    };
+  },
+
+  _onEdit() {
+    this.updateForm.open();
+  },
+
+  _onUpdate(request) {
+    AlertConditionsActions.update(this.props.stream.id, this.props.alertCondition.id, request)
+      .then(() => this.props.onUpdate(this.props.stream.id, this.props.alertCondition.id));
+  },
 
   _onDelete() {
     if (window.confirm('Really delete alert condition?')) {
-      AlertConditionsActions.delete(this.props.stream.id, this.props.alertCondition.id);
+      AlertConditionsActions.delete(this.props.stream.id, this.props.alertCondition.id)
+        .then(() => this.props.onDelete(this.props.stream.id, this.props.alertCondition.id));
     }
   },
 
   render() {
-    const type = this.props.alertCondition.type;
     const stream = this.props.stream;
     const condition = this.props.alertCondition;
-    const typeDefinition = this.state.types[type];
+    const conditionType = this.props.conditionType;
 
-    if (!typeDefinition) {
+    if (!conditionType) {
       return <UnknownAlertCondition alertCondition={condition} onDelete={this._onDelete} stream={stream} />;
     }
 
@@ -37,16 +65,34 @@ const AlertCondition = React.createClass({
     let actions = [];
     if (this.isPermitted(permissions, `streams:edit:${stream.id}`)) {
       actions = [
-        <DropdownButton key="more-actions-button" title="Actions" pullRight
+        <DropdownButton key="more-actions-button"
+                        title="Actions"
+                        pullRight
                         id={`more-actions-dropdown-${condition.id}`}>
+          {!this.props.isStreamView && (
+            <LinkContainer to={Routes.stream_alerts(stream.id)}>
+              <MenuItem>Alerting overview for Stream</MenuItem>
+            </LinkContainer>
+          )}
+          <MenuItem onSelect={this._onEdit}>Edit</MenuItem>
+          <MenuItem divider />
           <MenuItem onSelect={this._onDelete}>Delete</MenuItem>
         </DropdownButton>,
       ];
     }
 
     return (
-      <AlertConditionSummary alertCondition={condition} typeDefinition={typeDefinition} stream={stream}
-                             actions={actions} linkToDetails />
+      <React.Fragment>
+        <AlertConditionForm ref={(updateForm) => { this.updateForm = updateForm; }}
+                            conditionType={conditionType}
+                            alertCondition={condition}
+                            onSubmit={this._onUpdate} />
+        <AlertConditionSummary alertCondition={condition}
+                               conditionType={conditionType}
+                               stream={stream}
+                               actions={actions}
+                               isDetailsView={this.props.isDetailsView} />
+      </React.Fragment>
     );
   },
 });

--- a/graylog2-web-interface/src/components/alertconditions/AlertConditionForm.jsx
+++ b/graylog2-web-interface/src/components/alertconditions/AlertConditionForm.jsx
@@ -6,23 +6,23 @@ import { ControlLabel, FormControl, FormGroup } from 'react-bootstrap';
 import { ConfigurationForm } from 'components/configurationforms';
 
 import CombinedProvider from 'injection/CombinedProvider';
+
 const { AlertConditionsStore } = CombinedProvider.get('AlertConditions');
 
 const AlertConditionForm = React.createClass({
   propTypes: {
     alertCondition: PropTypes.object,
+    conditionType: PropTypes.object.isRequired,
     onCancel: PropTypes.func,
     onSubmit: PropTypes.func.isRequired,
-    type: PropTypes.string.isRequired,
   },
   mixins: [Reflux.connect(AlertConditionsStore)],
 
   getDefaultProps() {
     return {
-      onCancel: () => {
-      },
-      onSubmit: () => {
-      },
+      alertCondition: undefined,
+      onCancel: () => {},
+      onSubmit: () => {},
     };
   },
 
@@ -30,7 +30,7 @@ const AlertConditionForm = React.createClass({
     const values = this.refs.configurationForm.getValue();
     return {
       title: values.title,
-      type: this.props.type,
+      type: this.props.conditionType.type,
       parameters: values.configuration,
     };
   },
@@ -51,24 +51,23 @@ const AlertConditionForm = React.createClass({
   },
 
   render() {
-    const type = this.props.type;
     const alertCondition = this.props.alertCondition;
-    const typeDefinition = this.state.types[type];
+    const conditionType = this.props.conditionType;
 
     return (
       <ConfigurationForm ref="configurationForm"
                          key="configuration-form-alert-condition"
-                         configFields={typeDefinition.requested_configuration}
-                         title={this._formatTitle(alertCondition, typeDefinition.name)}
-                         typeName={type}
+                         configFields={conditionType.requested_configuration}
+                         title={this._formatTitle(alertCondition, conditionType.name)}
+                         typeName={conditionType.name}
                          submitAction={this._onSubmit}
                          cancelAction={this._onCancel}
                          titleValue={alertCondition ? alertCondition.title : ''}
                          helpBlock="The alert condition title"
                          values={alertCondition ? alertCondition.parameters : {}}>
         <FormGroup>
-          <ControlLabel>{`${typeDefinition.name} description`}</ControlLabel>
-          <FormControl.Static>{typeDefinition.human_name}</FormControl.Static>
+          <ControlLabel>{`${conditionType.name} description`}</ControlLabel>
+          <FormControl.Static>{conditionType.human_name}</FormControl.Static>
         </FormGroup>
       </ConfigurationForm>
     );

--- a/graylog2-web-interface/src/components/alertconditions/AlertConditionSummary.jsx
+++ b/graylog2-web-interface/src/components/alertconditions/AlertConditionSummary.jsx
@@ -1,7 +1,7 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 import { Col } from 'react-bootstrap';
-import { LinkContainer } from 'react-router-bootstrap';
+import { Link } from 'react-router';
 
 import Routes from 'routing/Routes';
 
@@ -10,21 +10,26 @@ import { EntityListItem } from 'components/common';
 import { GenericAlertConditionSummary } from 'components/alertconditions';
 import { PluginStore } from 'graylog-web-plugin/plugin';
 
-const AlertConditionSummary = React.createClass({
-  propTypes: {
+class AlertConditionSummary extends React.Component {
+  static propTypes = {
     alertCondition: PropTypes.object.isRequired,
-    typeDefinition: PropTypes.object.isRequired,
+    conditionType: PropTypes.object.isRequired,
     stream: PropTypes.object,
     actions: PropTypes.array.isRequired,
-    linkToDetails: PropTypes.bool,
-  },
+    isDetailsView: PropTypes.bool,
+  };
+
+  static defaultProps = {
+    stream: undefined,
+    isDetailsView: false,
+  };
 
   render() {
     const stream = this.props.stream;
     const condition = this.props.alertCondition;
-    const typeDefinition = this.props.typeDefinition;
-    const conditionType = PluginStore.exports('alertConditions').find(c => c.type === condition.type) || {};
-    const SummaryComponent = conditionType.summaryComponent || GenericAlertConditionSummary;
+    const conditionType = this.props.conditionType;
+    const conditionPlugin = PluginStore.exports('alertConditions').find(c => c.type === condition.type) || {};
+    const SummaryComponent = conditionPlugin.summaryComponent || GenericAlertConditionSummary;
 
     const description = (stream ?
       <span>Alerting on stream <em>{stream.title}</em></span> : 'Not alerting on any stream');
@@ -36,25 +41,25 @@ const AlertConditionSummary = React.createClass({
     );
 
     let title;
-    if (this.props.linkToDetails) {
-      title = (
-        <LinkContainer to={Routes.show_alert_condition(stream.id, condition.id)}>
-          <a>{condition.title ? condition.title : 'Untitled'}</a>
-        </LinkContainer>
-      );
-    } else {
+    if (this.props.isDetailsView) {
       title = (condition.title ? condition.title : 'Untitled');
+    } else {
+      title = (
+        <Link to={Routes.show_alert_condition(stream.id, condition.id)}>
+          {condition.title ? condition.title : 'Untitled'}
+        </Link>
+      );
     }
 
     return (
       <EntityListItem key={`entry-list-${condition.id}`}
                       title={title}
-                      titleSuffix={`(${typeDefinition.name})`}
+                      titleSuffix={`(${conditionType.name})`}
                       description={description}
                       actions={this.props.actions}
                       contentRow={content} />
     );
-  },
-});
+  }
+}
 
 export default AlertConditionSummary;

--- a/graylog2-web-interface/src/components/alertconditions/AlertConditionsComponent.jsx
+++ b/graylog2-web-interface/src/components/alertconditions/AlertConditionsComponent.jsx
@@ -10,6 +10,7 @@ import { AlertConditionsList } from 'components/alertconditions';
 import Routes from 'routing/Routes';
 
 import CombinedProvider from 'injection/CombinedProvider';
+
 const { StreamsStore } = CombinedProvider.get('Streams');
 const { AlertConditionsStore, AlertConditionsActions } = CombinedProvider.get('AlertConditions');
 
@@ -32,10 +33,11 @@ const AlertConditionsComponent = React.createClass({
     });
 
     AlertConditionsActions.listAll();
+    AlertConditionsActions.available();
   },
 
   _isLoading() {
-    return !this.state.streams || !this.state.allAlertConditions;
+    return !this.state.streams || !this.state.allAlertConditions || !this.state.availableConditions;
   },
 
   render() {
@@ -58,7 +60,11 @@ const AlertConditionsComponent = React.createClass({
         </div>
         <h2>Conditions</h2>
         <p>These are all configured alert conditions.</p>
-        <AlertConditionsList alertConditions={alertConditions} streams={this.state.streams} />
+        <AlertConditionsList alertConditions={alertConditions}
+                             availableConditions={this.state.availableConditions}
+                             streams={this.state.streams}
+                             onConditionUpdate={this._loadData}
+                             onConditionDelete={this._loadData} />
       </div>
     );
   },

--- a/graylog2-web-interface/src/components/alertconditions/AlertConditionsList.jsx
+++ b/graylog2-web-interface/src/components/alertconditions/AlertConditionsList.jsx
@@ -4,45 +4,69 @@ import React from 'react';
 import { AlertCondition } from 'components/alertconditions';
 import { EntityList, PaginatedList } from 'components/common';
 
-const AlertConditionsList = React.createClass({
-  propTypes: {
+class AlertConditionsList extends React.Component {
+  static propTypes = {
     alertConditions: PropTypes.array.isRequired,
+    availableConditions: PropTypes.object.isRequired,
     streams: PropTypes.array.isRequired,
-  },
+    onConditionUpdate: PropTypes.func,
+    onConditionDelete: PropTypes.func,
+    isStreamView: PropTypes.bool,
+  };
 
-  getInitialState() {
-    return {
-      currentPage: 0,
-    };
-  },
+  static defaultProps = {
+    onConditionUpdate: () => {},
+    onConditionDelete: () => {},
+    isStreamView: false,
+  };
 
-  PAGE_SIZE: 10,
+  state = {
+    currentPage: 0,
+  };
 
-  _onChangePaginatedList(currentPage) {
+  PAGE_SIZE = 10;
+
+  _onChangePaginatedList = (currentPage) => {
     this.setState({ currentPage: currentPage - 1 });
-  },
+  };
 
-  _paginatedConditions() {
+  _paginatedConditions = () => {
     return this.props.alertConditions.slice(this.state.currentPage * this.PAGE_SIZE, (this.state.currentPage + 1) * this.PAGE_SIZE);
-  },
+  };
 
-  _formatCondition(condition) {
+  _formatCondition = (condition) => {
     const stream = this.props.streams.find(s => s.alert_conditions.find(c => c.id === condition.id));
-    return <AlertCondition key={condition.id} alertCondition={condition} stream={stream} />;
-  },
+    // Condition was deleted while rendering, don't render anything at this stage
+    if (!stream) {
+      return null;
+    }
+    const conditionType = this.props.availableConditions[condition.type];
+
+    return (
+      <AlertCondition key={condition.id}
+                      alertCondition={condition}
+                      conditionType={conditionType}
+                      stream={stream}
+                      onUpdate={this.props.onConditionUpdate}
+                      onDelete={this.props.onConditionDelete}
+                      isStreamView={this.props.isStreamView} />
+    );
+  };
 
   render() {
     const alertConditions = this.props.alertConditions;
 
     return (
-      <PaginatedList totalItems={alertConditions.length} onChange={this._onChangePaginatedList}
-                     showPageSizeSelect={false} pageSize={this.PAGE_SIZE}>
+      <PaginatedList totalItems={alertConditions.length}
+                     onChange={this._onChangePaginatedList}
+                     showPageSizeSelect={false}
+                     pageSize={this.PAGE_SIZE}>
         <EntityList bsNoItemsStyle="info"
                     noItemsText="There are no configured conditions."
                     items={this._paginatedConditions().map(condition => this._formatCondition(condition))} />
       </PaginatedList>
     );
-  },
-});
+  }
+}
 
 export default AlertConditionsList;

--- a/graylog2-web-interface/src/components/alertconditions/EditAlertConditionForm.jsx
+++ b/graylog2-web-interface/src/components/alertconditions/EditAlertConditionForm.jsx
@@ -1,75 +1,52 @@
 import PropTypes from 'prop-types';
 import React from 'react';
+import createReactClass from 'create-react-class';
 import Reflux from 'reflux';
-import { Button } from 'react-bootstrap';
 
-import { EntityList, Spinner } from 'components/common';
-import { AlertConditionForm, AlertConditionSummary } from 'components/alertconditions';
+import { EntityList } from 'components/common';
+import { AlertCondition } from 'components/alertconditions';
 import PermissionsMixin from 'util/PermissionsMixin';
 
 import CombinedProvider from 'injection/CombinedProvider';
-const { AlertConditionsActions, AlertConditionsStore } = CombinedProvider.get('AlertConditions');
+
 const { CurrentUserStore } = CombinedProvider.get('CurrentUser');
 
-const EditAlertConditionForm = React.createClass({
+const EditAlertConditionForm = createReactClass({
+  displayName: 'EditAlertConditionForm',
+
   propTypes: {
     alertCondition: PropTypes.object.isRequired,
+    conditionType: PropTypes.object.isRequired,
     stream: PropTypes.object.isRequired,
+    onUpdate: PropTypes.func,
+    onDelete: PropTypes.func,
   },
 
-  mixins: [Reflux.connect(AlertConditionsStore), Reflux.connect(CurrentUserStore), PermissionsMixin],
+  mixins: [Reflux.connect(CurrentUserStore), PermissionsMixin],
 
-  _onEdit() {
-    this.refs.updateForm.open();
-  },
-
-  _onUpdate(request) {
-    AlertConditionsActions.update(this.props.stream.id, this.props.alertCondition.id, request).then(() => {
-      AlertConditionsActions.get(this.props.stream.id, this.props.alertCondition.id);
-    });
-  },
-
-  _formatCondition() {
-    const type = this.props.alertCondition.type;
-    const stream = this.props.stream;
-    const condition = this.props.alertCondition;
-    const typeDefinition = this.state.types[type];
-
-    const permissions = this.state.currentUser.permissions;
-    let actions = [];
-    if (this.isPermitted(permissions, `streams:edit:${stream.id}`)) {
-      actions = [
-        <Button key="edit-button" bsStyle="info" onClick={this._onEdit}>Edit</Button>,
-      ];
-    }
-
-    return [
-      <AlertConditionSummary key={`alert-condition-${condition.id}`} alertCondition={condition}
-                             typeDefinition={typeDefinition} stream={stream}
-                             actions={actions} />,
-    ];
-  },
-
-  _isLoading() {
-    return !this.state.types;
+  getDefaultProps() {
+    return {
+      onUpdate: () => {},
+      onDelete: () => {},
+    };
   },
 
   render() {
-    if (this._isLoading()) {
-      return <Spinner />;
-    }
-
-    const condition = this.props.alertCondition;
+    const { alertCondition, conditionType, stream } = this.props;
 
     return (
       <div>
         <h2>Condition details</h2>
         <p>Define the condition to evaluate when triggering a new alert.</p>
-        <AlertConditionForm ref="updateForm"
-                            type={condition.type}
-                            alertCondition={condition}
-                            onSubmit={this._onUpdate} />
-        <EntityList items={this._formatCondition()} />
+        <EntityList items={[
+          <AlertCondition key={alertCondition.id}
+                          stream={stream}
+                          alertCondition={alertCondition}
+                          conditionType={conditionType}
+                          onUpdate={this.props.onUpdate}
+                          onDelete={this.props.onDelete}
+                          isDetailsView />,
+        ]} />
       </div>
     );
   },

--- a/graylog2-web-interface/src/components/alertconditions/StreamAlertConditions.jsx
+++ b/graylog2-web-interface/src/components/alertconditions/StreamAlertConditions.jsx
@@ -1,0 +1,56 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import createReactClass from 'create-react-class';
+import { Button } from 'react-bootstrap';
+import { LinkContainer } from 'react-router-bootstrap';
+import naturalSort from 'javascript-natural-sort';
+
+import { AlertConditionsList } from 'components/alertconditions';
+
+import Routes from 'routing/Routes';
+
+const StreamAlertConditions = createReactClass({
+  displayName: 'StreamAlertConditions',
+  propTypes: {
+    stream: PropTypes.object.isRequired,
+    alertConditions: PropTypes.array.isRequired,
+    availableConditions: PropTypes.object.isRequired,
+    onConditionUpdate: PropTypes.func,
+    onConditionDelete: PropTypes.func,
+  },
+
+  getDefaultProps() {
+    return {
+      onConditionUpdate: () => {},
+      onConditionDelete: () => {},
+    };
+  },
+
+  render() {
+    const alertConditions = this.props.alertConditions.sort((a1, a2) => {
+      const t1 = a1.title || 'Untitled';
+      const t2 = a2.title || 'Untitled';
+      return naturalSort(t1.toLowerCase(), t2.toLowerCase());
+    });
+
+    return (
+      <div>
+        <div className="pull-right">
+          <LinkContainer to={Routes.new_alert_condition_for_stream(this.props.stream.id)}>
+            <Button bsStyle="success">Add new condition</Button>
+          </LinkContainer>
+        </div>
+        <h2>Conditions</h2>
+        <p className="description">Alert Conditions define when an Alert should be triggered for this Stream.</p>
+        <AlertConditionsList alertConditions={alertConditions}
+                             availableConditions={this.props.availableConditions}
+                             streams={[this.props.stream]}
+                             onConditionUpdate={this.props.onConditionUpdate}
+                             onConditionDelete={this.props.onConditionDelete}
+                             isStreamView />
+      </div>
+    );
+  },
+});
+
+export default StreamAlertConditions;

--- a/graylog2-web-interface/src/components/alertconditions/index.jsx
+++ b/graylog2-web-interface/src/components/alertconditions/index.jsx
@@ -1,18 +1,18 @@
+import { PluginManifest, PluginStore } from 'graylog-web-plugin/plugin';
+import { FieldContentConditionSummary } from 'components/alertconditions/fieldcontentcondition';
+import { FieldValueConditionSummary } from 'components/alertconditions/fieldvaluecondition';
+import { MessageCountConditionSummary } from 'components/alertconditions/messagecountcondition';
+
 export { default as AlertCondition } from './AlertCondition';
 export { default as AlertConditionForm } from './AlertConditionForm';
 export { default as AlertConditionSummary } from './AlertConditionSummary';
 export { default as AlertConditionsComponent } from './AlertConditionsComponent';
 export { default as AlertConditionsList } from './AlertConditionsList';
-export { default as ConditionAlertNotifications } from './ConditionAlertNotifications';
 export { default as CreateAlertConditionInput } from './CreateAlertConditionInput';
 export { default as EditAlertConditionForm } from './EditAlertConditionForm';
 export { default as GenericAlertConditionSummary } from './GenericAlertConditionSummary';
+export { default as StreamAlertConditions } from './StreamAlertConditions';
 export { default as UnknownAlertCondition } from './UnknownAlertCondition';
-
-import { PluginManifest, PluginStore } from 'graylog-web-plugin/plugin';
-import { FieldContentConditionSummary } from 'components/alertconditions/fieldcontentcondition';
-import { FieldValueConditionSummary } from 'components/alertconditions/fieldvaluecondition';
-import { MessageCountConditionSummary } from 'components/alertconditions/messagecountcondition';
 
 PluginStore.register(new PluginManifest({}, {
   alertConditions: [

--- a/graylog2-web-interface/src/components/alertnotifications/AlertNotification.jsx
+++ b/graylog2-web-interface/src/components/alertnotifications/AlertNotification.jsx
@@ -2,30 +2,41 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import Reflux from 'reflux';
 import { Button, Col, DropdownButton, MenuItem } from 'react-bootstrap';
+import { LinkContainer } from 'react-router-bootstrap';
 
 import PermissionsMixin from 'util/PermissionsMixin';
-
 import CombinedProvider from 'injection/CombinedProvider';
+
+import { EntityListItem, IfPermitted, Spinner } from 'components/common';
+import { UnknownAlertNotification } from 'components/alertnotifications';
+import { ConfigurationForm, ConfigurationWell } from 'components/configurationforms';
+import Routes from 'routing/Routes';
+
 const { AlertNotificationsStore } = CombinedProvider.get('AlertNotifications');
 const { AlarmCallbacksActions } = CombinedProvider.get('AlarmCallbacks');
 const { CurrentUserStore } = CombinedProvider.get('CurrentUser');
-
-import { EntityListItem, Spinner } from 'components/common';
-import { UnknownAlertNotification } from 'components/alertnotifications';
-import { ConfigurationForm, ConfigurationWell } from 'components/configurationforms';
 
 const AlertNotification = React.createClass({
   propTypes: {
     alertNotification: PropTypes.object.isRequired,
     stream: PropTypes.object,
-    onNotificationUpdate: PropTypes.func,
-    onNotificationDelete: PropTypes.func,
+    onNotificationUpdate: PropTypes.func.isRequired,
+    onNotificationDelete: PropTypes.func.isRequired,
+    isStreamView: PropTypes.bool,
   },
   mixins: [Reflux.connect(AlertNotificationsStore), Reflux.connect(CurrentUserStore), PermissionsMixin],
+
+  getDefaultProps() {
+    return {
+      stream: undefined,
+      isStreamView: false,
+    };
+  },
 
   getInitialState() {
     return {
       isTestingAlert: false,
+      isConfigurationShown: false,
     };
   },
 
@@ -41,22 +52,18 @@ const AlertNotification = React.createClass({
 
   _onSubmit(data) {
     AlarmCallbacksActions.update(this.props.alertNotification.stream_id, this.props.alertNotification.id, data)
-      .then(() => {
-        if (typeof this.props.onNotificationUpdate === 'function') {
-          this.props.onNotificationUpdate();
-        }
-      });
+      .then(this.props.onNotificationUpdate);
   },
 
   _onDelete() {
     if (window.confirm('Really delete alert notification?')) {
       AlarmCallbacksActions.delete(this.props.alertNotification.stream_id, this.props.alertNotification.id)
-        .then(() => {
-          if (typeof this.props.onNotificationUpdate === 'function') {
-            this.props.onNotificationUpdate();
-          }
-        });
+        .then(this.props.onNotificationDelete);
     }
+  },
+
+  _toggleIsConfigurationShown() {
+    this.setState({ isConfigurationShown: !this.state.isConfigurationShown });
   },
 
   render() {
@@ -66,27 +73,48 @@ const AlertNotification = React.createClass({
 
     const notification = this.props.alertNotification;
     const stream = this.props.stream;
+    const { isConfigurationShown } = this.state;
     const typeDefinition = this.state.availableNotifications[notification.type];
 
     if (!typeDefinition) {
       return <UnknownAlertNotification alertNotification={notification} onDelete={this._onDelete} />;
     }
 
-    const description = (stream ?
-      <span>Executed once per triggered alert condition in stream <em>{stream.title}</em></span>
-      : 'Not executed, as it is not connected to a stream');
+    const toggleConfigurationLink = (
+      <a href="#toggleconfiguration" onClick={this._toggleIsConfigurationShown}>
+        {isConfigurationShown ? 'Hide' : 'Show'} configuration
+      </a>
+    );
 
-    const actions = this.isPermitted(this.state.currentUser.permissions, [`streams:edit:${stream.id}`]) && [
-      <Button key="test-button" bsStyle="info" disabled={this.state.isTestingAlert} onClick={this._onTestNotification}>
-        {this.state.isTestingAlert ? 'Testing...' : 'Test'}
-      </Button>,
-      <DropdownButton key="more-actions-button" title="More actions" pullRight
-                      id={`more-actions-dropdown-${notification.id}`}>
-        <MenuItem onSelect={this._onEdit}>Edit</MenuItem>
-        <MenuItem divider />
-        <MenuItem onSelect={this._onDelete}>Delete</MenuItem>
-      </DropdownButton>,
-    ];
+    const description = (stream ?
+      <span>Executed once per triggered alert condition in stream <em>{stream.title}</em>. {toggleConfigurationLink}</span> :
+      <span>Not executed, as it is not connected to a stream. {toggleConfigurationLink}</span>);
+
+    const actions = stream && (
+      <IfPermitted permissions={`streams:edit:${stream.id}`}>
+        <React.Fragment>
+          <Button key="test-button"
+                  bsStyle="info"
+                  disabled={this.state.isTestingAlert}
+                  onClick={this._onTestNotification}>
+            {this.state.isTestingAlert ? 'Testing...' : 'Test'}
+          </Button>
+          <DropdownButton key="more-actions-button"
+                          title="More actions"
+                          pullRight
+                          id={`more-actions-dropdown-${notification.id}`}>
+            {!this.props.isStreamView && (
+              <LinkContainer to={Routes.stream_alerts(stream.id)}>
+                <MenuItem>Alerting overview for Stream</MenuItem>
+              </LinkContainer>
+            )}
+            <MenuItem onSelect={this._onEdit}>Edit</MenuItem>
+            <MenuItem divider />
+            <MenuItem onSelect={this._onDelete}>Delete</MenuItem>
+          </DropdownButton>
+        </React.Fragment>
+      </IfPermitted>
+    );
 
     const content = (
       <Col md={12}>
@@ -99,7 +127,9 @@ const AlertNotification = React.createClass({
                              titleValue={notification.title}
                              submitAction={this._onSubmit}
                              values={notification.configuration} />
-          <ConfigurationWell configuration={notification.configuration} typeDefinition={typeDefinition} />
+          {isConfigurationShown &&
+            <ConfigurationWell configuration={notification.configuration} typeDefinition={typeDefinition} />
+          }
         </div>
       </Col>
     );

--- a/graylog2-web-interface/src/components/alertnotifications/AlertNotification.jsx
+++ b/graylog2-web-interface/src/components/alertnotifications/AlertNotification.jsx
@@ -1,7 +1,7 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 import Reflux from 'reflux';
-import { Button, Col, DropdownButton, MenuItem } from 'react-bootstrap';
+import { Button, ButtonToolbar, Col, DropdownButton, MenuItem } from 'react-bootstrap';
 import { LinkContainer } from 'react-router-bootstrap';
 
 import PermissionsMixin from 'util/PermissionsMixin';
@@ -92,7 +92,7 @@ const AlertNotification = React.createClass({
 
     const actions = stream && (
       <IfPermitted permissions={`streams:edit:${stream.id}`}>
-        <React.Fragment>
+        <ButtonToolbar>
           <Button key="test-button"
                   bsStyle="info"
                   disabled={this.state.isTestingAlert}
@@ -112,7 +112,7 @@ const AlertNotification = React.createClass({
             <MenuItem divider />
             <MenuItem onSelect={this._onDelete}>Delete</MenuItem>
           </DropdownButton>
-        </React.Fragment>
+        </ButtonToolbar>
       </IfPermitted>
     );
 

--- a/graylog2-web-interface/src/components/alertnotifications/AlertNotificationsComponent.jsx
+++ b/graylog2-web-interface/src/components/alertnotifications/AlertNotificationsComponent.jsx
@@ -8,8 +8,8 @@ import { Spinner } from 'components/common';
 import { AlertNotificationsList } from 'components/alertnotifications';
 
 import Routes from 'routing/Routes';
-
 import CombinedProvider from 'injection/CombinedProvider';
+
 const { AlertNotificationsStore, AlertNotificationsActions } = CombinedProvider.get('AlertNotifications');
 const { StreamsStore } = CombinedProvider.get('Streams');
 
@@ -59,8 +59,10 @@ const AlertNotificationsComponent = React.createClass({
         </div>
         <h2>Notifications</h2>
         <p>These are all configured alert notifications.</p>
-        <AlertNotificationsList alertNotifications={notifications} streams={this.state.streams}
-                                onNotificationUpdate={this._loadData} onNotificationDelete={this._loadData} />
+        <AlertNotificationsList alertNotifications={notifications}
+                                streams={this.state.streams}
+                                onNotificationUpdate={this._loadData}
+                                onNotificationDelete={this._loadData} />
       </div>
     );
   },

--- a/graylog2-web-interface/src/components/alertnotifications/AlertNotificationsList.jsx
+++ b/graylog2-web-interface/src/components/alertnotifications/AlertNotificationsList.jsx
@@ -4,51 +4,61 @@ import React from 'react';
 import { AlertNotification } from 'components/alertnotifications';
 import { EntityList, PaginatedList } from 'components/common';
 
-const AlertNotificationsList = React.createClass({
-  propTypes: {
+class AlertNotificationsList extends React.Component {
+  static propTypes = {
     alertNotifications: PropTypes.array.isRequired,
     streams: PropTypes.array.isRequired,
     onNotificationUpdate: PropTypes.func,
     onNotificationDelete: PropTypes.func,
-  },
+    isStreamView: PropTypes.bool,
+  };
 
-  getInitialState() {
-    return {
-      currentPage: 0,
-    };
-  },
+  static defaultProps = {
+    onNotificationUpdate: () => {},
+    onNotificationDelete: () => {},
+    isStreamView: false,
+  };
 
-  PAGE_SIZE: 10,
+  state = {
+    currentPage: 0,
+  };
 
-  _onChangePaginatedList(currentPage) {
+  PAGE_SIZE = 10;
+
+  _onChangePaginatedList = (currentPage) => {
     this.setState({ currentPage: currentPage - 1 });
-  },
+  };
 
-  _paginatedNotifications() {
+  _paginatedNotifications = () => {
     return this.props.alertNotifications.slice(this.state.currentPage * this.PAGE_SIZE, (this.state.currentPage + 1) * this.PAGE_SIZE);
-  },
+  };
 
-  _formatNotification(notification) {
+  _formatNotification = (notification) => {
     const stream = this.props.streams.find(s => s.id === notification.stream_id);
     return (
-      <AlertNotification key={notification.id} alertNotification={notification} stream={stream}
+      <AlertNotification key={notification.id}
+                         alertNotification={notification}
+                         stream={stream}
                          onNotificationUpdate={this.props.onNotificationUpdate}
-                         onNotificationDelete={this.props.onNotificationDelete} />
+                         onNotificationDelete={this.props.onNotificationDelete}
+                         isStreamView={this.props.isStreamView} />
     );
-  },
+  };
 
   render() {
     const notifications = this.props.alertNotifications;
 
     return (
-      <PaginatedList totalItems={notifications.length} onChange={this._onChangePaginatedList}
-                     showPageSizeSelect={false} pageSize={this.PAGE_SIZE}>
+      <PaginatedList totalItems={notifications.length}
+                     onChange={this._onChangePaginatedList}
+                     showPageSizeSelect={false}
+                     pageSize={this.PAGE_SIZE}>
         <EntityList bsNoItemsStyle="info"
                     noItemsText="There are no configured notifications."
                     items={this._paginatedNotifications().map(notification => this._formatNotification(notification))} />
       </PaginatedList>
     );
-  },
-});
+  }
+}
 
 export default AlertNotificationsList;

--- a/graylog2-web-interface/src/components/alertnotifications/StreamAlertNotifications.jsx
+++ b/graylog2-web-interface/src/components/alertnotifications/StreamAlertNotifications.jsx
@@ -1,39 +1,40 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 import naturalSort from 'javascript-natural-sort';
+import { Button } from 'react-bootstrap';
+import { LinkContainer } from 'react-router-bootstrap';
 
-import { Pluralize, Spinner } from 'components/common';
+import { Spinner } from 'components/common';
 import { AlertNotificationsList } from 'components/alertnotifications';
 
 import CombinedProvider from 'injection/CombinedProvider';
+import Routes from 'routing/Routes';
+
 const { AlarmCallbacksActions } = CombinedProvider.get('AlarmCallbacks');
 const { AlertNotificationsActions } = CombinedProvider.get('AlertNotifications');
 
-const ConditionAlertNotifications = React.createClass({
-  propTypes: {
-    alertCondition: PropTypes.object.isRequired,
+class StreamAlertNotifications extends React.Component {
+  static propTypes = {
     stream: PropTypes.object.isRequired,
-  },
+  };
 
-  getInitialState() {
-    return {
-      conditionNotifications: undefined,
-    };
-  },
+  state = {
+    conditionNotifications: undefined,
+  };
 
   componentDidMount() {
     this._loadData();
-  },
+  }
 
-  _loadData() {
+  _loadData = () => {
     AlertNotificationsActions.available();
     AlarmCallbacksActions.list(this.props.stream.id)
       .then(callbacks => this.setState({ conditionNotifications: callbacks }));
-  },
+  };
 
-  _isLoading() {
+  _isLoading = () => {
     return !this.state.conditionNotifications;
-  },
+  };
 
   render() {
     if (this._isLoading()) {
@@ -50,17 +51,24 @@ const ConditionAlertNotifications = React.createClass({
 
     return (
       <div>
+        <div className="pull-right">
+          <LinkContainer to={Routes.new_alert_notification_for_stream(stream.id)}>
+            <Button bsStyle="success">Add new notification</Button>
+          </LinkContainer>
+        </div>
         <h2>Notifications</h2>
-        <p>
-          <Pluralize value={notifications.length} singular="This is" plural="These are" /> the notifications set
-          for the stream <em>{stream.title}</em>. They will be triggered when the alert condition is satisfied.
+        <p className="description">
+          Alert Notifications will be executed when a Condition belonging to this Stream is satisfied.
         </p>
 
-        <AlertNotificationsList alertNotifications={notifications} streams={[this.props.stream]}
-                                onNotificationUpdate={this._loadData} onNotificationDelete={this._loadData} />
+        <AlertNotificationsList alertNotifications={notifications}
+                                streams={[this.props.stream]}
+                                onNotificationUpdate={this._loadData}
+                                onNotificationDelete={this._loadData}
+                                isStreamView />
       </div>
     );
-  },
-});
+  }
+}
 
-export default ConditionAlertNotifications;
+export default StreamAlertNotifications;

--- a/graylog2-web-interface/src/components/alertnotifications/index.jsx
+++ b/graylog2-web-interface/src/components/alertnotifications/index.jsx
@@ -2,4 +2,5 @@ export { default as AlertNotification } from './AlertNotification';
 export { default as AlertNotificationsComponent } from './AlertNotificationsComponent';
 export { default as AlertNotificationsList } from './AlertNotificationsList';
 export { default as CreateAlertNotificationInput } from './CreateAlertNotificationInput';
+export { default as StreamAlertNotifications } from './StreamAlertNotifications';
 export { default as UnknownAlertNotification } from './UnknownAlertNotification';

--- a/graylog2-web-interface/src/components/alerts/Alert.jsx
+++ b/graylog2-web-interface/src/components/alerts/Alert.jsx
@@ -1,7 +1,7 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 import { Col, Label } from 'react-bootstrap';
-import { LinkContainer } from 'react-router-bootstrap';
+import { Link } from 'react-router';
 
 import { EntityListItem, Timestamp } from 'components/common';
 
@@ -10,33 +10,32 @@ import DateTime from 'logic/datetimes/DateTime';
 
 import styles from './Alert.css';
 
-const Alert = React.createClass({
-  propTypes: {
+class Alert extends React.Component {
+  static propTypes = {
     alert: PropTypes.object.isRequired,
-    alertConditions: PropTypes.array.isRequired,
-    streams: PropTypes.array.isRequired,
-    conditionTypes: PropTypes.object.isRequired,
-  },
+    alertCondition: PropTypes.object,
+    stream: PropTypes.object.isRequired,
+    conditionType: PropTypes.object.isRequired,
+  };
 
-  getInitialState() {
-    return {
-      showAlarmCallbackHistory: false,
-    };
-  },
+  static defaultProps = {
+    alertCondition: {},
+  };
+
+  state = {
+    showAlarmCallbackHistory: false,
+  };
 
   render() {
-    const alert = this.props.alert;
-    const condition = this.props.alertConditions.find(alertCondition => alertCondition.id === alert.condition_id);
-    const stream = this.props.streams.find(s => s.id === alert.stream_id);
-    const conditionType = condition ? this.props.conditionTypes[condition.type] : {};
+    const { alert, alertCondition, stream, conditionType } = this.props;
 
     let alertTitle;
-    if (condition) {
+    if (alertCondition) {
       alertTitle = (
         <span>
-          <LinkContainer to={Routes.show_alert(alert.id)}>
-            <a>{condition.title || 'Untitled alert'}</a>
-          </LinkContainer>
+          <Link to={Routes.show_alert(alert.id)}>
+            {alertCondition.title || 'Untitled alert'}
+          </Link>
           {' '}
           <small>on stream <em>{stream.title}</em></small>
         </span>
@@ -44,7 +43,7 @@ const Alert = React.createClass({
     } else {
       alertTitle = (
         <span>
-          <LinkContainer to={Routes.show_alert(alert.id)}><a>Unknown alert</a></LinkContainer>
+          <Link to={Routes.show_alert(alert.id)}>Unknown alert</Link>
         </span>
       );
     }
@@ -92,7 +91,7 @@ const Alert = React.createClass({
                       description={alertTime}
                       contentRow={content} />
     );
-  },
-});
+  }
+}
 
 export default Alert;

--- a/graylog2-web-interface/src/components/alerts/AlertsComponent.jsx
+++ b/graylog2-web-interface/src/components/alerts/AlertsComponent.jsx
@@ -3,13 +3,15 @@ import Reflux from 'reflux';
 import { Button } from 'react-bootstrap';
 import Promise from 'bluebird';
 
+import { Alert } from 'components/alerts';
+import { EntityList, PaginatedList, Spinner } from 'components/common';
 import CombinedProvider from 'injection/CombinedProvider';
+
 const { AlertsStore, AlertsActions } = CombinedProvider.get('Alerts');
 const { AlertConditionsStore, AlertConditionsActions } = CombinedProvider.get('AlertConditions');
 const { StreamsStore } = CombinedProvider.get('Streams');
 
-import { Alert } from 'components/alerts';
-import { EntityList, PaginatedList, Spinner } from 'components/common';
+const ALERTS_REFRESH_INTERVAL = 10000;
 
 const AlertsComponent = React.createClass({
   mixins: [Reflux.connect(AlertsStore), Reflux.connect(AlertConditionsStore)],
@@ -23,6 +25,13 @@ const AlertsComponent = React.createClass({
 
   componentDidMount() {
     this.loadData(this.currentPage, this.pageSize);
+    this.interval = setInterval(() => this.fetchData(this.currentPage, this.pageSize), ALERTS_REFRESH_INTERVAL);
+  },
+
+  componentWillUnmount() {
+    if (this.interval) {
+      clearInterval(this.interval);
+    }
   },
 
   currentPage: 1,
@@ -30,19 +39,23 @@ const AlertsComponent = React.createClass({
 
   loadData(pageNo, limit) {
     this.setState({ loading: true });
-    const promises = [
-      AlertsActions.listAllPaginated((pageNo - 1) * limit, limit, this.state.displayAllAlerts ? 'all' : 'unresolved'),
+    const promises = this.fetchData(pageNo, limit);
+
+    Promise.all(promises).finally(() => this.setState({ loading: false }));
+  },
+
+  fetchData(pageNo, limit) {
+    return [
+      AlertsActions.listAllPaginated((pageNo - 1) * limit, limit, this.state.displayAllAlerts ? 'any' : 'unresolved'),
       AlertConditionsActions.listAll(),
       AlertConditionsActions.available(),
       StreamsStore.listStreams().then((streams) => {
         this.setState({ streams: streams });
       }),
     ];
-
-    Promise.all(promises).finally(() => this.setState({ loading: false }));
   },
 
-  _refreshData() {
+  refreshData() {
     this.loadData(this.currentPage, this.pageSize);
   },
 
@@ -59,14 +72,21 @@ const AlertsComponent = React.createClass({
   },
 
   _formatAlert(alert) {
+    const condition = this.state.allAlertConditions.find(alertCondition => alertCondition.id === alert.condition_id);
+    const stream = this.state.streams.find(s => s.id === alert.stream_id);
+    const conditionType = condition ? this.state.availableConditions[condition.type] : {};
+
     return (
-      <Alert key={alert.id} alert={alert} alertConditions={this.state.allAlertConditions} streams={this.state.streams}
-             conditionTypes={this.state.types} />
+      <Alert key={alert.id}
+             alert={alert}
+             alertCondition={condition}
+             stream={stream}
+             conditionType={conditionType} />
     );
   },
 
   _isLoading() {
-    return !this.state.alerts || !this.state.allAlertConditions || !this.state.types || !this.state.streams;
+    return !this.state.alerts || !this.state.allAlertConditions || !this.state.availableConditions || !this.state.streams;
   },
 
   render() {
@@ -77,7 +97,7 @@ const AlertsComponent = React.createClass({
     return (
       <div>
         <div className="pull-right">
-          <Button bsStyle="info" onClick={this._refreshData} disabled={this.state.loading}>
+          <Button bsStyle="info" onClick={this.refreshData} disabled={this.state.loading}>
             {this.state.loading ? 'Refreshing...' : 'Refresh'}
           </Button>
           &nbsp;
@@ -91,7 +111,9 @@ const AlertsComponent = React.createClass({
           {this.state.displayAllAlerts ? 'all' : 'unresolved'} alerts.
         </p>
 
-        <PaginatedList totalItems={this.state.alerts.total} pageSize={this.pageSize} onChange={this._onChangePaginatedList}
+        <PaginatedList totalItems={this.state.alerts.total}
+                       pageSize={this.pageSize}
+                       onChange={this._onChangePaginatedList}
                        showPageSizeSelect={false}>
           <EntityList bsNoItemsStyle={this.state.displayAllAlerts ? 'info' : 'success'}
                       noItemsText={this.state.displayAllAlerts ? 'There are no alerts to display' : 'Good news! Currently there are no unresolved alerts.'}

--- a/graylog2-web-interface/src/components/alerts/AlertsHeaderToolbar.jsx
+++ b/graylog2-web-interface/src/components/alerts/AlertsHeaderToolbar.jsx
@@ -1,0 +1,36 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { Button, ButtonToolbar } from 'react-bootstrap';
+import { LinkContainer } from 'react-router-bootstrap';
+
+import Routes from 'routing/Routes';
+
+class AlertsHeaderToolbar extends React.Component {
+  static propTypes = {
+    active: PropTypes.string.isRequired,
+  };
+
+  _isActive = (active, route) => {
+    return active === route ? 'active' : '';
+  };
+
+  render() {
+    const { active } = this.props;
+
+    return (
+      <ButtonToolbar>
+        <LinkContainer to={Routes.ALERTS.LIST}>
+          <Button bsStyle="info" className={this._isActive(active, Routes.ALERTS.LIST)}>Alerts</Button>
+        </LinkContainer>
+        <LinkContainer to={Routes.ALERTS.CONDITIONS}>
+          <Button bsStyle="info" className={this._isActive(active, Routes.ALERTS.CONDITIONS)}>Conditions</Button>
+        </LinkContainer>
+        <LinkContainer to={Routes.ALERTS.NOTIFICATIONS}>
+          <Button bsStyle="info" className={this._isActive(active, Routes.ALERTS.NOTIFICATIONS)}>Notifications</Button>
+        </LinkContainer>
+      </ButtonToolbar>
+    );
+  }
+}
+
+export default AlertsHeaderToolbar;

--- a/graylog2-web-interface/src/components/alerts/StreamAlerts.jsx
+++ b/graylog2-web-interface/src/components/alerts/StreamAlerts.jsx
@@ -1,0 +1,98 @@
+import React from 'react';
+import createReactClass from 'create-react-class';
+import PropTypes from 'prop-types';
+import Reflux from 'reflux';
+
+import { Alert } from 'components/alerts';
+import { EntityList, PaginatedList, Spinner } from 'components/common';
+import CombinedProvider from 'injection/CombinedProvider';
+
+const { AlertsStore, AlertsActions } = CombinedProvider.get('Alerts');
+
+const ALERTS_REFRESH_INTERVAL = 10000;
+
+const StreamAlerts = createReactClass({
+  displayName: 'StreamAlerts',
+  propTypes: {
+    stream: PropTypes.object.isRequired,
+    alertConditions: PropTypes.array.isRequired,
+    availableConditions: PropTypes.object.isRequired,
+  },
+  mixins: [Reflux.connect(AlertsStore)],
+
+  getInitialState() {
+    return {
+      loading: true,
+    };
+  },
+
+  componentDidMount() {
+    this.loadData(this.currentPage, this.pageSize);
+    this.interval = setInterval(() => this.fetchData(this.currentPage, this.pageSize), ALERTS_REFRESH_INTERVAL);
+  },
+
+  componentWillUnmount() {
+    if (this.interval) {
+      clearInterval(this.interval);
+    }
+  },
+
+  currentPage: 1,
+  pageSize: 3,
+
+  loadData(pageNo, limit) {
+    this.setState({ loading: true });
+    this.fetchData(pageNo, limit).finally(() => this.setState({ loading: false }));
+  },
+
+  // Loads data without setting the loading state, which makes the page jump
+  fetchData(pageNo, limit) {
+    return AlertsActions.listPaginated(this.props.stream.id, (pageNo - 1) * limit, limit, 'unresolved');
+  },
+
+  _onChangePaginatedList(page, size) {
+    this.currentPage = page;
+    this.pageSize = size;
+    this.loadData(page, size);
+  },
+
+  _formatAlert(alert) {
+    const condition = this.props.alertConditions.find(alertCondition => alertCondition.id === alert.condition_id);
+    const conditionType = condition ? this.props.availableConditions[condition.type] : {};
+
+    return (
+      <Alert key={alert.id}
+             alert={alert}
+             alertCondition={condition}
+             stream={this.props.stream}
+             conditionType={conditionType} />
+    );
+  },
+
+  render() {
+    if (this.state.loading) {
+      return <Spinner />;
+    }
+
+    return (
+      <div>
+        <h2>Unresolved Alerts</h2>
+        <p className="description">
+          These are the Alerts for this Stream that require your attention. Alerts will be resolved automatically
+          when the Condition that triggered them is no longer satisfied.
+        </p>
+
+        <PaginatedList totalItems={this.state.alerts.total}
+                       pageSize={this.pageSize}
+                       onChange={this._onChangePaginatedList}
+                       showPageSizeSelect={false}>
+          <EntityList bsNoItemsStyle="success"
+                      noItemsText="Good news! Currently there are no unresolved alerts on this stream."
+                      items={this.state.alerts.alerts.map(alert => this._formatAlert(alert))} />
+        </PaginatedList>
+      </div>
+    );
+  },
+});
+
+export default StreamAlerts;

--- a/graylog2-web-interface/src/components/alerts/StreamAlertsOverviewContainer.jsx
+++ b/graylog2-web-interface/src/components/alerts/StreamAlertsOverviewContainer.jsx
@@ -1,0 +1,82 @@
+import React from 'react';
+import createReactClass from 'create-react-class';
+import PropTypes from 'prop-types';
+import { Col, Row } from 'react-bootstrap';
+import Reflux from 'reflux';
+import Promise from 'bluebird';
+
+import { Spinner } from 'components/common';
+import { StreamAlerts } from 'components/alerts';
+import { StreamAlertConditions } from 'components/alertconditions';
+import { StreamAlertNotifications } from 'components/alertnotifications';
+import CombinedProvider from 'injection/CombinedProvider';
+
+const { AlertConditionsStore, AlertConditionsActions } = CombinedProvider.get('AlertConditions');
+
+const StreamAlertsOverviewContainer = createReactClass({
+  propTypes: {
+    stream: PropTypes.object.isRequired,
+  },
+  mixins: [Reflux.connect(AlertConditionsStore)],
+
+  getInitialState() {
+    return {
+      loading: true,
+    };
+  },
+
+  componentDidMount() {
+    this.loadData();
+  },
+
+  loadData() {
+    this.setState({ loading: true });
+    const promises = this.fetchData();
+
+    Promise.all(promises).finally(() => this.setState({ loading: false }));
+  },
+
+  fetchData() {
+    return [
+      AlertConditionsActions.list(this.props.stream.id),
+      AlertConditionsActions.available(),
+    ];
+  },
+
+  render() {
+    if (this.state.loading) {
+      return <Spinner />;
+    }
+
+    const stream = this.props.stream;
+    const { alertConditions, availableConditions } = this.state;
+
+    return (
+      <React.Fragment>
+        <Row className="content">
+          <Col md={12}>
+            <StreamAlerts stream={stream} alertConditions={alertConditions} availableConditions={availableConditions} />
+          </Col>
+        </Row>
+
+        <Row className="content">
+          <Col md={12}>
+            <StreamAlertConditions stream={stream}
+                                   alertConditions={alertConditions}
+                                   availableConditions={availableConditions}
+                                   onConditionUpdate={this.fetchData}
+                                   onConditionDelete={this.fetchData} />
+          </Col>
+        </Row>
+
+        <Row className="content">
+          <Col md={12}>
+            <StreamAlertNotifications stream={stream} />
+          </Col>
+        </Row>
+      </React.Fragment>
+    );
+  },
+});
+
+export default StreamAlertsOverviewContainer;

--- a/graylog2-web-interface/src/components/alerts/StreamAlertsOverviewContainer.jsx
+++ b/graylog2-web-interface/src/components/alerts/StreamAlertsOverviewContainer.jsx
@@ -52,7 +52,7 @@ const StreamAlertsOverviewContainer = createReactClass({
     const { alertConditions, availableConditions } = this.state;
 
     return (
-      <React.Fragment>
+      <div>
         <Row className="content">
           <Col md={12}>
             <StreamAlerts stream={stream} alertConditions={alertConditions} availableConditions={availableConditions} />
@@ -74,7 +74,7 @@ const StreamAlertsOverviewContainer = createReactClass({
             <StreamAlertNotifications stream={stream} />
           </Col>
         </Row>
-      </React.Fragment>
+      </div>
     );
   },
 });

--- a/graylog2-web-interface/src/components/alerts/index.jsx
+++ b/graylog2-web-interface/src/components/alerts/index.jsx
@@ -3,3 +3,5 @@ export { default as AlertDetails } from './AlertDetails';
 export { default as AlertMessages } from './AlertMessages';
 export { default as AlertsComponent } from './AlertsComponent';
 export { default as AlertTimeline } from './AlertTimeline';
+export { default as StreamAlerts } from './StreamAlerts';
+export { default as StreamAlertsOverviewContainer } from './StreamAlertsOverviewContainer';

--- a/graylog2-web-interface/src/components/alerts/index.jsx
+++ b/graylog2-web-interface/src/components/alerts/index.jsx
@@ -2,6 +2,7 @@ export { default as Alert } from './Alert';
 export { default as AlertDetails } from './AlertDetails';
 export { default as AlertMessages } from './AlertMessages';
 export { default as AlertsComponent } from './AlertsComponent';
+export { default as AlertsHeaderToolbar } from './AlertsHeaderToolbar';
 export { default as AlertTimeline } from './AlertTimeline';
 export { default as StreamAlerts } from './StreamAlerts';
 export { default as StreamAlertsOverviewContainer } from './StreamAlertsOverviewContainer';

--- a/graylog2-web-interface/src/components/common/ExternalLinkButton.jsx
+++ b/graylog2-web-interface/src/components/common/ExternalLinkButton.jsx
@@ -32,7 +32,7 @@ const ExternalLinkButton = React.createClass({
   getDefaultProps() {
     return {
       bsStyle: 'default',
-      bsSize: '',
+      bsSize: undefined,
       target: '_blank',
       iconClass: 'fa-external-link',
       className: '',

--- a/graylog2-web-interface/src/components/streams/Stream.jsx
+++ b/graylog2-web-interface/src/components/streams/Stream.jsx
@@ -1,25 +1,31 @@
 import PropTypes from 'prop-types';
 import React from 'react';
+import createReactClass from 'create-react-class';
+import { Button, Tooltip } from 'react-bootstrap';
+import { Link } from 'react-router';
+import { LinkContainer } from 'react-router-bootstrap';
+
+import { OverlayElement, Pluralize } from 'components/common';
+import CollapsibleStreamRuleList from 'components/streamrules/CollapsibleStreamRuleList';
+import StreamRuleForm from 'components/streamrules/StreamRuleForm';
+
+import PermissionsMixin from 'util/PermissionsMixin';
+import UserNotification from 'util/UserNotification';
+import StoreProvider from 'injection/StoreProvider';
+import Routes from 'routing/Routes';
+
 import StreamThroughput from './StreamThroughput';
 import StreamControls from './StreamControls';
 import StreamStateBadge from './StreamStateBadge';
-import CollapsibleStreamRuleList from 'components/streamrules/CollapsibleStreamRuleList';
-import PermissionsMixin from 'util/PermissionsMixin';
-
-import StoreProvider from 'injection/StoreProvider';
-const StreamsStore = StoreProvider.getStore('Streams');
-const StreamRulesStore = StoreProvider.getStore('StreamRules');
-
-import StreamRuleForm from 'components/streamrules/StreamRuleForm';
-import { OverlayElement, Pluralize } from 'components/common';
-import UserNotification from 'util/UserNotification';
-import { Button, Tooltip } from 'react-bootstrap';
-import { LinkContainer } from 'react-router-bootstrap';
-import Routes from 'routing/Routes';
 
 import style from './Stream.css';
 
-const Stream = React.createClass({
+const StreamsStore = StoreProvider.getStore('Streams');
+const StreamRulesStore = StoreProvider.getStore('StreamRules');
+
+const Stream = createReactClass({
+  displayName: 'Stream',
+
   propTypes() {
     return {
       stream: PropTypes.object.isRequired,
@@ -29,6 +35,7 @@ const Stream = React.createClass({
       indexSets: PropTypes.array.isRequired,
     };
   },
+
   mixins: [PermissionsMixin],
 
   getInitialState() {
@@ -59,6 +66,7 @@ const Stream = React.createClass({
       </span>
     );
   },
+
   _onDelete(stream) {
     if (window.confirm('Do you really want to remove this stream?')) {
       StreamsStore.remove(stream.id, (response) => {
@@ -67,23 +75,27 @@ const Stream = React.createClass({
       });
     }
   },
+
   _onResume() {
     this.setState({ loading: true });
     StreamsStore.resume(this.props.stream.id, response => response)
       .finally(() => this.setState({ loading: false }));
   },
+
   _onUpdate(streamId, stream) {
     StreamsStore.update(streamId, stream, (response) => {
       UserNotification.success(`Stream '${stream.title}' was updated successfully.`, 'Success');
       return response;
     });
   },
+
   _onClone(streamId, stream) {
     StreamsStore.cloneStream(streamId, stream, (response) => {
       UserNotification.success(`Stream was successfully cloned as '${stream.title}'.`, 'Success');
       return response;
     });
   },
+
   _onPause() {
     if (window.confirm(`Do you really want to pause stream '${this.props.stream.title}'?`)) {
       this.setState({ loading: true });
@@ -91,12 +103,15 @@ const Stream = React.createClass({
         .finally(() => this.setState({ loading: false }));
     }
   },
+
   _onQuickAdd() {
-    this.refs.quickAddStreamRuleForm.open();
+    this.quickAddStreamRuleForm.open();
   },
+
   _onSaveStreamRule(streamRuleId, streamRule) {
     StreamRulesStore.create(this.props.stream.id, streamRule, () => UserNotification.success('Stream rule was created successfully.', 'Success'));
   },
+
   render() {
     const stream = this.props.stream;
     const permissions = this.props.permissions;
@@ -117,6 +132,12 @@ const Stream = React.createClass({
         </OverlayElement>
       );
 
+      manageAlertsLink = (
+        <LinkContainer to={Routes.stream_alerts(stream.id)}>
+          <Button bsStyle="info">Manage Alerts</Button>
+        </LinkContainer>
+      );
+
       if (this.isPermitted(permissions, ['stream_outputs:read'])) {
         manageOutputsLink = (
           <LinkContainer to={Routes.stream_outputs(stream.id)}>
@@ -131,7 +152,9 @@ const Stream = React.createClass({
       if (stream.disabled) {
         toggleStreamLink = (
           <OverlayElement overlay={defaultStreamTooltip} placement="top" useOverlay={isDefaultStream}>
-            <Button bsStyle="success" className="toggle-stream-button" onClick={this._onResume}
+            <Button bsStyle="success"
+                    className="toggle-stream-button"
+                    onClick={this._onResume}
                     disabled={isDefaultStream || this.state.loading}>
               {this.state.loading ? 'Starting...' : 'Start Stream'}
             </Button>
@@ -140,7 +163,9 @@ const Stream = React.createClass({
       } else {
         toggleStreamLink = (
           <OverlayElement overlay={defaultStreamTooltip} placement="top" useOverlay={isDefaultStream}>
-            <Button bsStyle="primary" className="toggle-stream-button" onClick={this._onPause}
+            <Button bsStyle="primary"
+                    className="toggle-stream-button"
+                    onClick={this._onPause}
                     disabled={isDefaultStream || this.state.loading}>
               {this.state.loading ? 'Pausing...' : 'Pause Stream'}
             </Button>
@@ -153,15 +178,17 @@ const Stream = React.createClass({
       <i className="fa fa-cube" title="Created from content pack" /> : null);
 
     const streamRuleList = isDefaultStream ? null :
-                           (<CollapsibleStreamRuleList key={`streamRules-${stream.id}`}
-                                 stream={stream}
-                                 streamRuleTypes={this.props.streamRuleTypes}
-                                 permissions={this.props.permissions} />);
+      (<CollapsibleStreamRuleList key={`streamRules-${stream.id}`}
+                                  stream={stream}
+                                  streamRuleTypes={this.props.streamRuleTypes}
+                                  permissions={this.props.permissions} />);
     const streamControls = (
       <OverlayElement overlay={defaultStreamTooltip} placement="top" useOverlay={isDefaultStream}>
-        <StreamControls stream={stream} permissions={this.props.permissions}
+        <StreamControls stream={stream}
+                        permissions={this.props.permissions}
                         user={this.props.user}
-                        onDelete={this._onDelete} onUpdate={this._onUpdate}
+                        onDelete={this._onDelete}
+                        onUpdate={this._onUpdate}
                         onClone={this._onClone}
                         onQuickAdd={this._onQuickAdd}
                         indexSets={this.props.indexSets}
@@ -184,9 +211,7 @@ const Stream = React.createClass({
         </div>
 
         <h2 className={style.streamTitle}>
-          <LinkContainer to={Routes.stream_search(stream.id)}>
-            <a>{stream.title}</a>
-          </LinkContainer>
+          <Link to={Routes.stream_search(stream.id)}>{stream.title}</Link>
           {' '}
           <small>{indexSetDetails}<StreamStateBadge stream={stream} /></small>
         </h2>
@@ -202,7 +227,8 @@ const Stream = React.createClass({
             {streamRuleList}
           </div>
         </div>
-        <StreamRuleForm ref="quickAddStreamRuleForm" title="New Stream Rule"
+        <StreamRuleForm ref={(quickAddStreamRuleForm) => { this.quickAddStreamRuleForm = quickAddStreamRuleForm; }}
+                        title="New Stream Rule"
                         onSubmit={this._onSaveStreamRule}
                         streamRuleTypes={this.props.streamRuleTypes} />
       </li>

--- a/graylog2-web-interface/src/components/streams/StreamControls.jsx
+++ b/graylog2-web-interface/src/components/streams/StreamControls.jsx
@@ -1,15 +1,19 @@
 import PropTypes from 'prop-types';
 import React from 'react';
+import createReactClass from 'create-react-class';
 import { DropdownButton, MenuItem } from 'react-bootstrap';
 
 import { IfPermitted } from 'components/common';
-import StreamForm from './StreamForm';
 import PermissionsMixin from 'util/PermissionsMixin';
-
 import StoreProvider from 'injection/StoreProvider';
+
+import StreamForm from './StreamForm';
+
 const StartpageStore = StoreProvider.getStore('Startpage');
 
-const StreamControls = React.createClass({
+const StreamControls = createReactClass({
+  displayName: 'StreamControls',
+
   propTypes: {
     stream: PropTypes.object.isRequired,
     user: PropTypes.object.isRequired,
@@ -20,40 +24,48 @@ const StreamControls = React.createClass({
     onUpdate: PropTypes.func.isRequired,
     isDefaultStream: PropTypes.bool,
   },
+
   mixins: [PermissionsMixin],
-  getInitialState() {
-    return {};
+
+  getDefaultProps() {
+    return {
+      isDefaultStream: false,
+    };
   },
-  _onDelete(_, event) {
-    event.preventDefault();
+
+  _onDelete() {
     this.props.onDelete(this.props.stream);
   },
-  _onEdit(_, event) {
-    event.preventDefault();
-    this.refs.streamForm.open();
+
+  _onEdit() {
+    this.streamForm.open();
   },
-  _onClone(_, event) {
-    event.preventDefault();
-    this.refs.cloneForm.open();
+
+  _onClone() {
+    this.cloneForm.open();
   },
+
   _onCloneSubmit(_, stream) {
     this.props.onClone(this.props.stream.id, stream);
   },
-  _onQuickAdd(_, event) {
-    event.preventDefault();
+
+  _onQuickAdd() {
     this.props.onQuickAdd(this.props.stream.id);
   },
-  _setStartpage(_, event) {
-    event.preventDefault();
+
+  _setStartpage() {
     StartpageStore.set(this.props.user.username, 'stream', this.props.stream.id);
   },
+
   render() {
     const stream = this.props.stream;
 
     return (
       <span>
-        <DropdownButton title="More Actions" ref="dropdownButton" pullRight
-                        id={`more-actions-dropdown-${stream.id}`} disabled={this.props.isDefaultStream}>
+        <DropdownButton title="More Actions"
+                        pullRight
+                        id={`more-actions-dropdown-${stream.id}`}
+                        disabled={this.props.isDefaultStream}>
           <IfPermitted permissions={`streams:edit:${stream.id}`}>
             <MenuItem key={`editStreams-${stream.id}`} onSelect={this._onEdit}>Edit stream</MenuItem>
           </IfPermitted>
@@ -75,8 +87,8 @@ const StreamControls = React.createClass({
             </MenuItem>
           </IfPermitted>
         </DropdownButton>
-        <StreamForm ref="streamForm" title="Editing Stream" onSubmit={this.props.onUpdate} stream={stream} indexSets={this.props.indexSets} />
-        <StreamForm ref="cloneForm" title="Cloning Stream" onSubmit={this._onCloneSubmit} indexSets={this.props.indexSets} />
+        <StreamForm ref={(streamForm) => { this.streamForm = streamForm; }} title="Editing Stream" onSubmit={this.props.onUpdate} stream={stream} indexSets={this.props.indexSets} />
+        <StreamForm ref={(cloneForm) => { this.cloneForm = cloneForm; }} title="Cloning Stream" onSubmit={this._onCloneSubmit} indexSets={this.props.indexSets} />
       </span>
     );
   },

--- a/graylog2-web-interface/src/components/streams/StreamList.jsx
+++ b/graylog2-web-interface/src/components/streams/StreamList.jsx
@@ -2,8 +2,8 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import { Alert } from 'react-bootstrap';
 
-import Stream from './Stream';
 import PermissionsMixin from 'util/PermissionsMixin';
+import Stream from './Stream';
 
 const StreamList = React.createClass({
   propTypes: {
@@ -12,7 +12,6 @@ const StreamList = React.createClass({
     indexSets: PropTypes.array.isRequired,
     user: PropTypes.object.isRequired,
     permissions: PropTypes.array.isRequired,
-    onStreamSave: PropTypes.func.isRequired,
   },
   mixins: [PermissionsMixin],
 
@@ -22,8 +21,12 @@ const StreamList = React.createClass({
 
   _formatStream(stream) {
     return (
-      <Stream key={`stream-${stream.id}`} stream={stream} streamRuleTypes={this.props.streamRuleTypes}
-                   permissions={this.props.permissions} user={this.props.user} indexSets={this.props.indexSets} />
+      <Stream key={`stream-${stream.id}`}
+              stream={stream}
+              streamRuleTypes={this.props.streamRuleTypes}
+              permissions={this.props.permissions}
+              user={this.props.user}
+              indexSets={this.props.indexSets} />
     );
   },
 
@@ -44,7 +47,7 @@ const StreamList = React.createClass({
     return (
       <Alert bsStyle="info">
         <i className="fa fa-info-circle" />&nbsp;No streams match your search filter.
-        </Alert>
+      </Alert>
     );
   },
 });

--- a/graylog2-web-interface/src/pages/AlertConditionsPage.jsx
+++ b/graylog2-web-interface/src/pages/AlertConditionsPage.jsx
@@ -1,10 +1,10 @@
 import React from 'react';
 import Reflux from 'reflux';
-import { Button, Col, Row } from 'react-bootstrap';
-import { LinkContainer } from 'react-router-bootstrap';
+import { Col, Row } from 'react-bootstrap';
 
 import DocumentationLink from 'components/support/DocumentationLink';
 import { DocumentTitle, PageHeader } from 'components/common';
+import { AlertsHeaderToolbar } from 'components/alerts';
 import { AlertConditionsComponent } from 'components/alertconditions';
 
 import Routes from 'routing/Routes';
@@ -30,9 +30,7 @@ const AlertConditionsPage = React.createClass({
             </span>
 
             <span>
-              <LinkContainer to={Routes.ALERTS.NOTIFICATIONS}>
-                <Button bsStyle="info">Manage notifications</Button>
-              </LinkContainer>
+              <AlertsHeaderToolbar active={Routes.ALERTS.CONDITIONS} />
             </span>
           </PageHeader>
 

--- a/graylog2-web-interface/src/pages/AlertNotificationsPage.jsx
+++ b/graylog2-web-interface/src/pages/AlertNotificationsPage.jsx
@@ -1,9 +1,9 @@
 import React from 'react';
 import Reflux from 'reflux';
-import { Button, Col, Row } from 'react-bootstrap';
-import { LinkContainer } from 'react-router-bootstrap';
+import { Col, Row } from 'react-bootstrap';
 
 import { DocumentTitle, PageHeader } from 'components/common';
+import { AlertsHeaderToolbar } from 'components/alerts';
 import { AlertNotificationsComponent } from 'components/alertnotifications';
 import Routes from 'routing/Routes';
 
@@ -27,13 +27,7 @@ const AlertNotificationsPage = React.createClass({
             </span>
 
             <span>
-              <LinkContainer to={Routes.ALERTS.CONDITIONS}>
-                <Button bsStyle="info">Manage conditions</Button>
-              </LinkContainer>
-              &nbsp;
-              <Button bsStyle="info" href="https://marketplace.graylog.org/" target="_blank">
-                <i className="fa fa-external-link" />&nbsp; Find more notifications
-              </Button>
+              <AlertsHeaderToolbar active={Routes.ALERTS.NOTIFICATIONS} />
             </span>
           </PageHeader>
 

--- a/graylog2-web-interface/src/pages/AlertsPage.jsx
+++ b/graylog2-web-interface/src/pages/AlertsPage.jsx
@@ -1,9 +1,8 @@
 import React from 'react';
 import Reflux from 'reflux';
-import { Button, Col, Row } from 'react-bootstrap';
-import { LinkContainer } from 'react-router-bootstrap';
+import { Col, Row } from 'react-bootstrap';
 
-import { AlertsComponent } from 'components/alerts';
+import { AlertsComponent, AlertsHeaderToolbar } from 'components/alerts';
 
 import DocumentationLink from 'components/support/DocumentationLink';
 import { DocumentTitle, PageHeader } from 'components/common';
@@ -31,13 +30,7 @@ const AlertsPage = React.createClass({
             </span>
 
             <span>
-              <LinkContainer to={Routes.ALERTS.CONDITIONS}>
-                <Button bsStyle="info">Manage conditions</Button>
-              </LinkContainer>
-              &nbsp;
-              <LinkContainer to={Routes.ALERTS.NOTIFICATIONS}>
-                <Button bsStyle="info">Manage notifications</Button>
-              </LinkContainer>
+              <AlertsHeaderToolbar active={Routes.ALERTS.LIST} />
             </span>
           </PageHeader>
 

--- a/graylog2-web-interface/src/pages/EditAlertConditionPage.jsx
+++ b/graylog2-web-interface/src/pages/EditAlertConditionPage.jsx
@@ -1,22 +1,27 @@
 import PropTypes from 'prop-types';
 import React from 'react';
+import createReactClass from 'create-react-class';
 import Reflux from 'reflux';
-import { Button, Col, Row } from 'react-bootstrap';
-import { LinkContainer } from 'react-router-bootstrap';
+import { Col, Row } from 'react-bootstrap';
 
 import DocumentationLink from 'components/support/DocumentationLink';
 import { DocumentTitle, PageHeader, Spinner } from 'components/common';
-import { ConditionAlertNotifications, EditAlertConditionForm } from 'components/alertconditions';
+import { AlertsHeaderToolbar } from 'components/alerts';
+import { EditAlertConditionForm } from 'components/alertconditions';
+import { StreamAlertNotifications } from 'components/alertnotifications';
 
 import Routes from 'routing/Routes';
 import DocsHelper from 'util/DocsHelper';
-
+import history from 'util/History';
 import CombinedProvider from 'injection/CombinedProvider';
+
 const { CurrentUserStore } = CombinedProvider.get('CurrentUser');
 const { StreamsStore } = CombinedProvider.get('Streams');
 const { AlertConditionsStore, AlertConditionsActions } = CombinedProvider.get('AlertConditions');
 
-const EditAlertConditionPage = React.createClass({
+const EditAlertConditionPage = createReactClass({
+  displayName: 'EditAlertConditionPage',
+
   propTypes: {
     params: PropTypes.object.isRequired,
   },
@@ -35,10 +40,19 @@ const EditAlertConditionPage = React.createClass({
     });
 
     AlertConditionsActions.get(this.props.params.streamId, this.props.params.conditionId);
+    AlertConditionsActions.available();
+  },
+
+  _handleUpdate(streamId, conditionId) {
+    AlertConditionsActions.get(streamId, conditionId);
+  },
+
+  _handleDelete() {
+    history.push(Routes.ALERTS.CONDITIONS);
   },
 
   _isLoading() {
-    return !this.state.stream || !this.state.alertCondition;
+    return !this.state.stream || !this.state.alertCondition || !this.state.availableConditions;
   },
 
   render() {
@@ -47,6 +61,7 @@ const EditAlertConditionPage = React.createClass({
     }
 
     const condition = this.state.alertCondition;
+    const conditionType = this.state.availableConditions[condition.type];
     const stream = this.state.stream;
 
     return (
@@ -64,25 +79,23 @@ const EditAlertConditionPage = React.createClass({
             </span>
 
             <span>
-              <LinkContainer to={Routes.ALERTS.CONDITIONS}>
-                <Button bsStyle="info">Manage conditions</Button>
-              </LinkContainer>
-              &nbsp;
-              <LinkContainer to={Routes.ALERTS.NOTIFICATIONS}>
-                <Button bsStyle="info">Manage notifications</Button>
-              </LinkContainer>
+              <AlertsHeaderToolbar active={Routes.ALERTS.CONDITIONS} />
             </span>
           </PageHeader>
 
           <Row className="content">
             <Col md={12}>
-              <EditAlertConditionForm alertCondition={condition} stream={stream} />
+              <EditAlertConditionForm alertCondition={condition}
+                                      conditionType={conditionType}
+                                      stream={stream}
+                                      onUpdate={this._handleUpdate}
+                                      onDelete={this._handleDelete} />
             </Col>
           </Row>
 
           <Row className="content">
             <Col md={12}>
-              <ConditionAlertNotifications alertCondition={condition} stream={stream} />
+              <StreamAlertNotifications stream={stream} />
             </Col>
           </Row>
         </div>

--- a/graylog2-web-interface/src/pages/NewAlertConditionPage.jsx
+++ b/graylog2-web-interface/src/pages/NewAlertConditionPage.jsx
@@ -1,21 +1,30 @@
 import React from 'react';
+import createReactClass from 'create-react-class';
+import PropTypes from 'prop-types';
 import Reflux from 'reflux';
-import { Button, Col, Row } from 'react-bootstrap';
-import { LinkContainer } from 'react-router-bootstrap';
+import { Col, Row } from 'react-bootstrap';
 
 import DocumentationLink from 'components/support/DocumentationLink';
 import { DocumentTitle, PageHeader } from 'components/common';
+import { AlertsHeaderToolbar } from 'components/alerts';
 import { CreateAlertConditionInput } from 'components/alertconditions';
 
 import Routes from 'routing/Routes';
 import DocsHelper from 'util/DocsHelper';
-
 import StoreProvider from 'injection/StoreProvider';
+
 const CurrentUserStore = StoreProvider.getStore('CurrentUser');
 
-const NewAlertConditionPage = React.createClass({
+const NewAlertConditionPage = createReactClass({
+  displayName: 'NewAlertConditionPage',
+  propTypes: {
+    location: PropTypes.object.isRequired,
+  },
   mixins: [Reflux.connect(CurrentUserStore)],
+
   render() {
+    const streamId = this.props.location.query.stream_id;
+
     return (
       <DocumentTitle title="New alert condition">
         <div>
@@ -31,19 +40,13 @@ const NewAlertConditionPage = React.createClass({
             </span>
 
             <span>
-              <LinkContainer to={Routes.ALERTS.CONDITIONS}>
-                <Button bsStyle="info">Manage conditions</Button>
-              </LinkContainer>
-              &nbsp;
-              <LinkContainer to={Routes.ALERTS.NOTIFICATIONS}>
-                <Button bsStyle="info">Manage notifications</Button>
-              </LinkContainer>
+              <AlertsHeaderToolbar active={Routes.ALERTS.CONDITIONS} />
             </span>
           </PageHeader>
 
           <Row className="content">
             <Col md={12}>
-              <CreateAlertConditionInput />
+              <CreateAlertConditionInput initialSelectedStream={streamId} />
             </Col>
           </Row>
         </div>

--- a/graylog2-web-interface/src/pages/NewAlertNotificationPage.jsx
+++ b/graylog2-web-interface/src/pages/NewAlertNotificationPage.jsx
@@ -1,19 +1,28 @@
 import React from 'react';
+import createReactClass from 'create-react-class';
+import PropTypes from 'prop-types';
 import Reflux from 'reflux';
-import { Button, Col, Row } from 'react-bootstrap';
-import { LinkContainer } from 'react-router-bootstrap';
+import { Col, Row } from 'react-bootstrap';
 
 import { DocumentTitle, PageHeader } from 'components/common';
+import { AlertsHeaderToolbar } from 'components/alerts';
 import { CreateAlertNotificationInput } from 'components/alertnotifications';
 
 import Routes from 'routing/Routes';
-
 import StoreProvider from 'injection/StoreProvider';
+
 const CurrentUserStore = StoreProvider.getStore('CurrentUser');
 
-const NewAlertNotificationPage = React.createClass({
+const NewAlertNotificationPage = createReactClass({
+  displayName: 'NewAlertNotificationPage',
+  propTypes: {
+    location: PropTypes.object.isRequired,
+  },
   mixins: [Reflux.connect(CurrentUserStore)],
+
   render() {
+    const streamId = this.props.location.query.stream_id;
+
     return (
       <DocumentTitle title="New alert notification">
         <div>
@@ -27,19 +36,13 @@ const NewAlertNotificationPage = React.createClass({
             </span>
 
             <span>
-              <LinkContainer to={Routes.ALERTS.NOTIFICATIONS}>
-                <Button bsStyle="info">Manage notifications</Button>
-              </LinkContainer>
-              &nbsp;
-              <Button bsStyle="info" href="https://marketplace.graylog.org/" target="_blank">
-                <i className="fa fa-external-link" />&nbsp; Find more notifications
-              </Button>
+              <AlertsHeaderToolbar active={Routes.ALERTS.NOTIFICATIONS} />
             </span>
           </PageHeader>
 
           <Row className="content">
             <Col md={12}>
-              <CreateAlertNotificationInput />
+              <CreateAlertNotificationInput initialSelectedStream={streamId} />
             </Col>
           </Row>
         </div>

--- a/graylog2-web-interface/src/pages/ShowAlertPage.jsx
+++ b/graylog2-web-interface/src/pages/ShowAlertPage.jsx
@@ -1,8 +1,9 @@
 import PropTypes from 'prop-types';
 import React from 'react';
+import createReactClass from 'create-react-class';
 import Reflux from 'reflux';
 import { LinkContainer } from 'react-router-bootstrap';
-import { Button, Label, Tooltip } from 'react-bootstrap';
+import { Button, ButtonToolbar, Label, Tooltip } from 'react-bootstrap';
 
 import { DocumentTitle, OverlayElement, PageHeader, Spinner, Timestamp } from 'components/common';
 import { AlertDetails } from 'components/alerts';
@@ -12,13 +13,15 @@ import UserNotification from 'util/UserNotification';
 import Routes from 'routing/Routes';
 
 import CombinedProvider from 'injection/CombinedProvider';
+import style from './ShowAlertPage.css';
+
 const { AlertsStore, AlertsActions } = CombinedProvider.get('Alerts');
 const { AlertConditionsStore, AlertConditionsActions } = CombinedProvider.get('AlertConditions');
 const { StreamsStore } = CombinedProvider.get('Streams');
 
-import style from './ShowAlertPage.css';
+const ShowAlertPage = createReactClass({
+  displayName: 'ShowAlertPage',
 
-const ShowAlertPage = React.createClass({
   propTypes: {
     params: PropTypes.object.isRequired,
   },
@@ -61,7 +64,7 @@ const ShowAlertPage = React.createClass({
   },
 
   _isLoading() {
-    return !this.state.alert || !this.state.alertCondition || !this.state.types || !this.state.stream;
+    return !this.state.alert || !this.state.alertCondition || !this.state.availableConditions || !this.state.stream;
   },
 
   render() {
@@ -72,7 +75,7 @@ const ShowAlertPage = React.createClass({
     const alert = this.state.alert;
     const condition = this.state.alertCondition;
     const conditionExists = Object.keys(condition).length > 0;
-    const type = this.state.types[condition.type] || {};
+    const conditionType = this.state.availableConditions[condition.type] || {};
     const stream = this.state.stream;
 
     let statusLabel;
@@ -127,20 +130,23 @@ const ShowAlertPage = React.createClass({
             </span>
 
             <span>
-              <OverlayElement overlay={conditionDetailsTooltip} placement="top" useOverlay={!condition.id}
-                              trigger={['hover', 'focus']}>
-                <LinkContainer to={Routes.show_alert_condition(stream.id, condition.id)} disabled={!condition.id}>
-                  <Button bsStyle="info">Condition details</Button>
+              <ButtonToolbar>
+                <LinkContainer to={Routes.ALERTS.LIST}>
+                  <Button bsStyle="info" className="active">Alerts</Button>
                 </LinkContainer>
-              </OverlayElement>
-              &nbsp;
-              <LinkContainer to={Routes.ALERTS.LIST}>
-                <Button bsStyle="info">Alerts overview</Button>
-              </LinkContainer>
+                <OverlayElement overlay={conditionDetailsTooltip}
+                                placement="top"
+                                useOverlay={!condition.id}
+                                trigger={['hover', 'focus']}>
+                  <LinkContainer to={Routes.show_alert_condition(stream.id, condition.id)} disabled={!condition.id}>
+                    <Button bsStyle="info">Condition details</Button>
+                  </LinkContainer>
+                </OverlayElement>
+              </ButtonToolbar>
             </span>
           </PageHeader>
 
-          <AlertDetails alert={alert} condition={conditionExists && condition} conditionType={type} stream={stream} />
+          <AlertDetails alert={alert} condition={conditionExists && condition} conditionType={conditionType} stream={stream} />
         </div>
       </DocumentTitle>
     );

--- a/graylog2-web-interface/src/pages/StreamAlertsOverviewPage.jsx
+++ b/graylog2-web-interface/src/pages/StreamAlertsOverviewPage.jsx
@@ -1,0 +1,75 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { Button, ButtonToolbar } from 'react-bootstrap';
+import { LinkContainer } from 'react-router-bootstrap';
+
+import { DocumentTitle, PageHeader, Spinner } from 'components/common';
+
+import Routes from 'routing/Routes';
+import CombinedProvider from 'injection/CombinedProvider';
+import { StreamAlertsOverviewContainer } from 'components/alerts';
+import DocumentationLink from 'components/support/DocumentationLink';
+import DocsHelper from 'util/DocsHelper';
+
+const { StreamsStore } = CombinedProvider.get('Streams');
+
+class StreamAlertsOverviewPage extends React.Component {
+  static propTypes = {
+    params: PropTypes.object.isRequired,
+  };
+
+  state = {
+    stream: undefined,
+  };
+
+  componentDidMount() {
+    StreamsStore.get(this.props.params.streamId, (stream) => {
+      this.setState({ stream: stream });
+    });
+  }
+
+  render() {
+    const { stream } = this.state;
+    const isLoading = !stream;
+
+    if (isLoading) {
+      return <DocumentTitle title="Stream Alerts Overview"><Spinner /></DocumentTitle>;
+    }
+
+    return (
+      <DocumentTitle title={`Alerting overview for Stream ${stream.title}`}>
+        <div>
+          <PageHeader title={<span>Alerting overview for Stream &raquo;{stream.title}&laquo;</span>}>
+            <span>
+              This is an overview of alerts, conditions, and notifications belonging to the Stream{' '}
+              <em>{stream.title}</em>.
+            </span>
+
+            <span>
+              Read more about alerting in the <DocumentationLink page={DocsHelper.PAGES.ALERTS} text="documentation" />.
+            </span>
+
+            <ButtonToolbar>
+              <LinkContainer to={Routes.STREAMS}>
+                <Button bsStyle="info">Streams</Button>
+              </LinkContainer>
+              <LinkContainer to={Routes.ALERTS.LIST}>
+                <Button bsStyle="info">All Alerts</Button>
+              </LinkContainer>
+              <LinkContainer to={Routes.ALERTS.CONDITIONS}>
+                <Button bsStyle="info">All Conditions</Button>
+              </LinkContainer>
+              <LinkContainer to={Routes.ALERTS.NOTIFICATIONS}>
+                <Button bsStyle="info">All Notifications</Button>
+              </LinkContainer>
+            </ButtonToolbar>
+          </PageHeader>
+
+          <StreamAlertsOverviewContainer stream={stream} />
+        </div>
+      </DocumentTitle>
+    );
+  }
+}
+
+export default StreamAlertsOverviewPage;

--- a/graylog2-web-interface/src/routing/ApiRoutes.js
+++ b/graylog2-web-interface/src/routing/ApiRoutes.js
@@ -16,7 +16,7 @@ const ApiRoutes = {
   AlertsApiController: {
     get: (alertId) => { return { url: `/streams/alerts/${alertId}` }; },
     list: (streamId, since) => { return { url: `/streams/${streamId}/alerts?since=${since}` }; },
-    listPaginated: (streamId, skip, limit) => { return { url: `/streams/${streamId}/alerts/paginated?skip=${skip}&limit=${limit}` }; },
+    listPaginated: (streamId, skip, limit, state) => { return { url: `/streams/${streamId}/alerts/paginated?skip=${skip}&limit=${limit}&state=${state}` }; },
     listAllPaginated: (skip, limit, state) => { return { url: `/streams/alerts/paginated?skip=${skip}&limit=${limit}&state=${state}` }; },
     listAllStreams: (since) => { return { url: `/streams/alerts?since=${since}` }; },
   },

--- a/graylog2-web-interface/src/routing/AppRouter.jsx
+++ b/graylog2-web-interface/src/routing/AppRouter.jsx
@@ -25,6 +25,7 @@ import EditAlertConditionPage from 'pages/EditAlertConditionPage';
 import StreamEditPage from 'pages/StreamEditPage';
 import StreamOutputsPage from 'pages/StreamOutputsPage';
 import StreamSearchPage from 'pages/StreamSearchPage';
+import StreamAlertsOverviewPage from 'pages/StreamAlertsOverviewPage';
 import DashboardsPage from 'pages/DashboardsPage';
 import ShowDashboardPage from 'pages/ShowDashboardPage';
 import SourcesPage from 'pages/SourcesPage';
@@ -84,6 +85,7 @@ const AppRouter = React.createClass({
               <Route path={Routes.STREAMS} component={StreamsPage} />
               <Route path={Routes.stream_edit(':streamId')} component={StreamEditPage} />
               <Route path={Routes.stream_outputs(':streamId')} component={StreamOutputsPage} />
+              <Route path={Routes.stream_alerts(':streamId')} component={StreamAlertsOverviewPage} />
               <Route path={Routes.ALERTS.LIST} component={AlertsPage} />
               <Route path={Routes.ALERTS.CONDITIONS} component={AlertConditionsPage} />
               <Route path={Routes.ALERTS.NEW_CONDITION} component={NewAlertConditionPage} />

--- a/graylog2-web-interface/src/routing/Routes.jsx
+++ b/graylog2-web-interface/src/routing/Routes.jsx
@@ -156,10 +156,13 @@ const Routes = {
   stream_search: (streamId, query, timeRange, resolution) => {
     return Routes._common_search_url(`${Routes.STREAMS}/${streamId}/search`, query, timeRange, resolution);
   },
-  legacy_stream_search: streamId => `/streams/${streamId}/messages`,
+  stream_alerts: streamId => `/streams/${streamId}/alerts`,
 
+  legacy_stream_search: streamId => `/streams/${streamId}/messages`,
   show_alert: alertId => `${Routes.ALERTS.LIST}/${alertId}`,
   show_alert_condition: (streamId, conditionId) => `${Routes.ALERTS.CONDITIONS}/${streamId}/${conditionId}`,
+  new_alert_condition_for_stream: streamId => `${Routes.ALERTS.NEW_CONDITION}?stream_id=${streamId}`,
+  new_alert_notification_for_stream: streamId => `${Routes.ALERTS.NEW_NOTIFICATION}?stream_id=${streamId}`,
 
   dashboard_show: dashboardId => `/dashboards/${dashboardId}`,
 

--- a/graylog2-web-interface/src/stores/alertconditions/AlertConditionsStore.js
+++ b/graylog2-web-interface/src/stores/alertconditions/AlertConditionsStore.js
@@ -5,20 +5,18 @@ import UserNotification from 'util/UserNotification';
 import URLUtils from 'util/URLUtils';
 import ApiRoutes from 'routing/ApiRoutes';
 import fetch from 'logic/rest/FetchProvider';
-
 import ActionsProvider from 'injection/ActionsProvider';
+
 const AlertConditionsActions = ActionsProvider.getActions('AlertConditions');
 
 const AlertConditionsStore = Reflux.createStore({
   listenables: AlertConditionsActions,
-
-  init() {
-    this.available();
-  },
+  allAlertConditions: undefined,
+  availableConditions: undefined,
 
   getInitialState() {
     return {
-      types: this.types,
+      availableConditions: this.availableConditions,
       allAlertConditions: this.allAlertConditions,
     };
   },
@@ -26,8 +24,8 @@ const AlertConditionsStore = Reflux.createStore({
   available() {
     const url = URLUtils.qualifyUrl(ApiRoutes.AlertConditionsApiController.available().url);
     const promise = fetch('GET', url).then((response) => {
-      this.types = response;
-      this.trigger(this.getInitialState());
+      this.availableConditions = response;
+      this.trigger({ availableConditions: this.availableConditions });
     });
 
     AlertConditionsActions.available.promise(promise);

--- a/graylog2-web-interface/src/stores/alerts/AlertsStore.js
+++ b/graylog2-web-interface/src/stores/alerts/AlertsStore.js
@@ -5,8 +5,8 @@ import fetch from 'logic/rest/FetchProvider';
 
 import URLUtils from 'util/URLUtils';
 import UserNotification from 'util/UserNotification';
-
 import ActionsProvider from 'injection/ActionsProvider';
+
 const AlertsActions = ActionsProvider.getActions('Alerts');
 
 const AlertsStore = Reflux.createStore({
@@ -26,8 +26,8 @@ const AlertsStore = Reflux.createStore({
     AlertsActions.list.promise(promise);
   },
 
-  listPaginated(streamId, skip, limit) {
-    const url = URLUtils.qualifyUrl(ApiRoutes.AlertsApiController.listPaginated(streamId, skip, limit).url);
+  listPaginated(streamId, skip, limit, state = 'any') {
+    const url = URLUtils.qualifyUrl(ApiRoutes.AlertsApiController.listPaginated(streamId, skip, limit, state).url);
     const promise = fetch('GET', url);
     promise
       .then(


### PR DESCRIPTION
Backport of https://github.com/Graylog2/graylog2-server/pull/5310 into 2.5.

The original code required some changes to remove conflicts (mostly due to loadable components and the different way in which we require some components now), and to adapt to 2.5. As not all pages had the same page header buttons, I modified that as well to match the status in master, which is way less confusing.