### PR TITLE
Fix Backslash Escaping for Phrase Searches (#4477)

### DIFF
--- a/graylog2-web-interface/src/stores/search/SearchStore.test.jsx
+++ b/graylog2-web-interface/src/stores/search/SearchStore.test.jsx
@@ -1,0 +1,37 @@
+import StoreProvider from 'injection/StoreProvider';
+
+const SearchStore = StoreProvider.getStore('Search');
+
+describe('SearchStore', () => {
+  beforeEach(() => {
+    SearchStore.query = '';
+  });
+
+  it('should add a query', () => {
+    SearchStore.addSearchTerm('field', 'value');
+    expect(SearchStore.query).toEqual('field:value');
+  });
+
+  it('should append a new query with "AND"', () => {
+    SearchStore.addSearchTerm('field1', 'value1');
+    SearchStore.addSearchTerm('field2', 'value2');
+    expect(SearchStore.query).toEqual('field1:value1 AND field2:value2');
+  });
+
+  describe('escaping', () => {
+    it('should escape a query with spaces and backslashes', () => {
+      SearchStore.addSearchTerm('field', '&& || : \\ / + - ! ( ) { } [ ] ^ " ~ * ?');
+      expect(SearchStore.query).toEqual('field:"&& || : \\\\ / + - ! ( ) { } [ ] ^ \\" ~ * ?"');
+    });
+
+    it('should escape a query with spaces and backslashes like Windows File Path', () => {
+      SearchStore.addSearchTerm('field', 'C:\\Program Files\\Atlassian\\Application Data\\Graylog\\log\\some.log');
+      expect(SearchStore.query).toEqual('field:"C:\\\\Program Files\\\\Atlassian\\\\Application Data\\\\Graylog\\\\log\\\\some.log"');
+    });
+
+    it('should escape a query with special chars and no spaces', () => {
+      SearchStore.addSearchTerm('field', '&&||:\\/+-!(){}[]^"~*?');
+      expect(SearchStore.query).toEqual('field:\\&&\\||\\:\\\\\\/\\+\\-\\!\\(\\)\\{\\}\\[\\]\\^\\"\\~\\*\\?');
+    });
+  });
+});

--- a/graylog2-web-interface/src/stores/search/SearchStore.ts
+++ b/graylog2-web-interface/src/stores/search/SearchStore.ts
@@ -332,7 +332,7 @@ class SearchStore {
         escapedTerm = escapedTerm.replace(/<br>/g, " ");
 
         if (this.isPhrase(escapedTerm)) {
-            escapedTerm = String(escapedTerm).replace(/\"/g, '\\"');
+            escapedTerm = String(escapedTerm).replace(/(\"|\\)/g, '\\$&');
             escapedTerm = '"' + escapedTerm + '"';
         } else {
             // Escape all lucene special characters from the source: && || : \ / + - ! ( ) { } [ ] ^ " ~ * ?


### PR DESCRIPTION
The add search term button (eg. in the Quick Values view)
is adding search terms to the search bar. A search term
with spaces will be treated as a phrase and therefor will
only surrounded by double quotes. But those phrases did
not escape backslashes which is still needed to perform
the search.

Now phrases will also get the backslashes escaped.

Also: Add some tests for adding a search term.

Fixes #4111
Fixes #5266

(cherry picked from commit bfc4a9f8b325961c926ff51dfd2dc0972df21cec)