### PR TITLE
Add test button to alert conditions

### DIFF
--- a/graylog2-web-interface/src/actions/alertconditions/AlertConditionsActions.jsx
+++ b/graylog2-web-interface/src/actions/alertconditions/AlertConditionsActions.jsx
@@ -8,6 +8,7 @@ const AlertConditionsActions = Reflux.createActions({
   save: { asyncResult: true },
   update: { asyncResult: true },
   get: { asyncResult: true },
+  test: { asyncResult: true },
 });
 
 export default AlertConditionsActions;

--- a/graylog2-web-interface/src/components/alertconditions/AlertCondition.jsx
+++ b/graylog2-web-interface/src/components/alertconditions/AlertCondition.jsx
@@ -71,7 +71,7 @@ const AlertCondition = createReactClass({
       actions = [
         <Button key="test-button" bsStyle="info" onClick={this._openTestModal}>Test</Button>,
         <DropdownButton key="more-actions-button"
-                        title="Actions"
+                        title="More actions"
                         pullRight
                         id={`more-actions-dropdown-${condition.id}`}>
           {!this.props.isStreamView && (

--- a/graylog2-web-interface/src/components/alertconditions/AlertCondition.jsx
+++ b/graylog2-web-interface/src/components/alertconditions/AlertCondition.jsx
@@ -2,10 +2,10 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import createReactClass from 'create-react-class';
 import Reflux from 'reflux';
-import { DropdownButton, MenuItem } from 'react-bootstrap';
+import { Button, DropdownButton, MenuItem } from 'react-bootstrap';
 import { LinkContainer } from 'react-router-bootstrap';
 
-import { AlertConditionForm, AlertConditionSummary, UnknownAlertCondition } from 'components/alertconditions';
+import { AlertConditionForm, AlertConditionSummary, AlertConditionTestModal, UnknownAlertCondition } from 'components/alertconditions';
 import PermissionsMixin from 'util/PermissionsMixin';
 import CombinedProvider from 'injection/CombinedProvider';
 import Routes from 'routing/Routes';
@@ -52,6 +52,10 @@ const AlertCondition = createReactClass({
     }
   },
 
+  _openTestModal() {
+    this.modal.open();
+  },
+
   render() {
     const stream = this.props.stream;
     const condition = this.props.alertCondition;
@@ -65,6 +69,7 @@ const AlertCondition = createReactClass({
     let actions = [];
     if (this.isPermitted(permissions, `streams:edit:${stream.id}`)) {
       actions = [
+        <Button key="test-button" bsStyle="info" onClick={this._openTestModal}>Test</Button>,
         <DropdownButton key="more-actions-button"
                         title="Actions"
                         pullRight
@@ -87,6 +92,9 @@ const AlertCondition = createReactClass({
                             conditionType={conditionType}
                             alertCondition={condition}
                             onSubmit={this._onUpdate} />
+        <AlertConditionTestModal ref={(c) => { this.modal = c; }}
+                                 stream={stream}
+                                 condition={condition} />
         <AlertConditionSummary alertCondition={condition}
                                conditionType={conditionType}
                                stream={stream}

--- a/graylog2-web-interface/src/components/alertconditions/AlertConditionTestModal.css
+++ b/graylog2-web-interface/src/components/alertconditions/AlertConditionTestModal.css
@@ -1,3 +1,12 @@
 ul:local(.errorMessages) {
     list-style-type: disc;
 }
+
+:local(.testResultText) {
+    padding-left: 20px;
+}
+
+:local(.testResultIcon) {
+    float: left;
+    line-height: inherit;
+}

--- a/graylog2-web-interface/src/components/alertconditions/AlertConditionTestModal.css
+++ b/graylog2-web-interface/src/components/alertconditions/AlertConditionTestModal.css
@@ -1,0 +1,3 @@
+ul:local(.errorMessages) {
+    list-style-type: disc;
+}

--- a/graylog2-web-interface/src/components/alertconditions/AlertConditionTestModal.jsx
+++ b/graylog2-web-interface/src/components/alertconditions/AlertConditionTestModal.jsx
@@ -73,14 +73,23 @@ class AlertConditionTestModal extends React.Component {
   renderSatisfiedCondition = (testResults) => {
     return (
       <span>
-        <p>Condition was satisfied and an Alert would be triggered.</p>
-        <p><b>Details</b>: {testResults.description}</p>
+        <i className={`fa fa-bell ${style.testResultIcon}`} />
+        <p className={style.testResultText}>Condition was satisfied and an Alert would be triggered.<br />
+          <b>Details</b>: {testResults.description}
+        </p>
       </span>
     );
   };
 
   renderUnsatisfiedCondition = () => {
-    return <p>Condition was <b>not</b> satisfied and an Alert would <b>not</b> be triggered.</p>;
+    return (
+      <div>
+        <i className={`fa fa-bell-slash ${style.testResultIcon}`} />
+        <p className={style.testResultText}>
+          Condition was <b>not</b> satisfied and an Alert would <b>not</b> be triggered.
+        </p>
+      </div>
+    );
   };
 
   renderTestResults = (testResults) => {

--- a/graylog2-web-interface/src/components/alertconditions/AlertConditionTestModal.jsx
+++ b/graylog2-web-interface/src/components/alertconditions/AlertConditionTestModal.jsx
@@ -1,0 +1,123 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { Alert, Button, Modal } from 'react-bootstrap';
+
+import { BootstrapModalWrapper } from 'components/bootstrap';
+import { Spinner } from 'components/common';
+import CombinedProvider from 'injection/CombinedProvider';
+import style from './AlertConditionTestModal.css';
+
+const { AlertConditionsActions } = CombinedProvider.get('AlertConditions');
+
+class AlertConditionTestModal extends React.Component {
+  static propTypes = {
+    stream: PropTypes.object.isRequired,
+    condition: PropTypes.object.isRequired,
+  };
+
+  state = {
+    testResults: undefined,
+    isTesting: false,
+  };
+
+  open = () => {
+    this.modal.open();
+    this.testCondition();
+  };
+
+  close = () => {
+    this.modal.close();
+  };
+
+  testCondition = () => {
+    this.setState({ isTesting: true, testResults: undefined });
+    AlertConditionsActions.test(this.props.stream.id, this.props.condition.id)
+      .then(
+        testResults => this.setState({ testResults: testResults }),
+        (error) => {
+          if (error.status === 400) {
+            // Condition testing failed but we should still get results in the body
+            this.setState({ testResults: error.additional.body });
+            return;
+          }
+          // Create a default error message to display in frontend
+          this.setState({
+            testResults: {
+              error: true,
+              error_messages: [{
+                type: 'Unexpected error',
+                message: 'Could not test Condition, please try again or check your server logs for more information.',
+              }],
+            },
+          });
+        },
+      )
+      .finally(() => this.setState({ isTesting: false }));
+  };
+
+  renderErroneousCondition = (testResults) => {
+    return (
+      <span>
+        <p><b>There was an error testing the Condition.</b></p>
+        <p>
+          <ul className={style.errorMessages}>
+            {testResults.error_messages.map(({ message, type }) => (
+              <li key={`${type}-${message}`}>{message} ({type})</li>
+            ))}
+          </ul>
+        </p>
+      </span>
+    );
+  };
+
+  renderSatisfiedCondition = (testResults) => {
+    return (
+      <span>
+        <p>Condition was satisfied and an Alert would be triggered.</p>
+        <p><b>Details</b>: {testResults.description}</p>
+      </span>
+    );
+  };
+
+  renderUnsatisfiedCondition = () => {
+    return <p>Condition was <b>not</b> satisfied and an Alert would <b>not</b> be triggered.</p>;
+  };
+
+  renderTestResults = (testResults) => {
+    if (testResults.error) {
+      return this.renderErroneousCondition(testResults);
+    }
+
+    return testResults.triggered ? this.renderSatisfiedCondition(testResults) : this.renderUnsatisfiedCondition(testResults);
+  };
+
+  render() {
+    const { condition } = this.props;
+    const { isTesting, testResults } = this.state;
+
+    return (
+      <BootstrapModalWrapper ref={(c) => { this.modal = c; }} bsSize="large">
+        <Modal.Header closeButton>
+          <Modal.Title>Alert Condition <em>{condition.title}</em> test results</Modal.Title>
+        </Modal.Header>
+        <Modal.Body>
+          {testResults ? (
+            <Alert bsStyle={testResults.error ? 'danger' : 'info'}>
+              {this.renderTestResults(testResults)}
+            </Alert>
+          ) : (
+            <Spinner text="Testing alert condition, please wait..." />
+          )}
+        </Modal.Body>
+        <Modal.Footer>
+          <Button onClick={this.close}>Close</Button>
+          <Button bsStyle="primary" onClick={this.testCondition} disabled={isTesting}>
+            {isTesting ? 'Testing...' : 'Test again'}
+          </Button>
+        </Modal.Footer>
+      </BootstrapModalWrapper>
+    );
+  }
+}
+
+export default AlertConditionTestModal;

--- a/graylog2-web-interface/src/components/alertconditions/index.jsx
+++ b/graylog2-web-interface/src/components/alertconditions/index.jsx
@@ -8,6 +8,7 @@ export { default as AlertConditionForm } from './AlertConditionForm';
 export { default as AlertConditionSummary } from './AlertConditionSummary';
 export { default as AlertConditionsComponent } from './AlertConditionsComponent';
 export { default as AlertConditionsList } from './AlertConditionsList';
+export { default as AlertConditionTestModal } from './AlertConditionTestModal';
 export { default as CreateAlertConditionInput } from './CreateAlertConditionInput';
 export { default as EditAlertConditionForm } from './EditAlertConditionForm';
 export { default as GenericAlertConditionSummary } from './GenericAlertConditionSummary';

--- a/graylog2-web-interface/src/routing/ApiRoutes.js
+++ b/graylog2-web-interface/src/routing/ApiRoutes.js
@@ -178,6 +178,7 @@ const ApiRoutes = {
     list: (streamId) => { return { url: `/streams/${streamId}/alerts/conditions` }; },
     update: (streamId, alertConditionId) => { return { url: `/streams/${streamId}/alerts/conditions/${alertConditionId}` }; },
     sendDummyAlert: (streamId) => { return { url: `/streams/${streamId}/alerts/sendDummyAlert` }; },
+    test: (streamId, conditionId) => { return { url: `/streams/${streamId}/alerts/conditions/${conditionId}/test` }; },
   },
   StreamsApiController: {
     index: () => { return { url: '/streams' }; },

--- a/graylog2-web-interface/src/stores/alertconditions/AlertConditionsStore.js
+++ b/graylog2-web-interface/src/stores/alertconditions/AlertConditionsStore.js
@@ -132,6 +132,13 @@ const AlertConditionsStore = Reflux.createStore({
 
     AlertConditionsActions.get.promise(promise);
   },
+
+  test(streamId, conditionId) {
+    const url = URLUtils.qualifyUrl(ApiRoutes.StreamAlertsApiController.test(streamId, conditionId).url);
+    const promise = fetch('POST', url);
+
+    AlertConditionsActions.test.promise(promise);
+  },
 });
 
 export default AlertConditionsStore;


### PR DESCRIPTION
The last changes in the alerting API introduced an endpoint to test alert conditions. This PR adds UI for it, so users can test if a certain alert condition would trigger an alert or not at that point of time.

This needs to be cherry-picked into 2.5.