### PR TITLE
Use nicer local css style class names for development

### DIFF
--- a/graylog2-web-interface/webpack.config.js
+++ b/graylog2-web-interface/webpack.config.js
@@ -26,6 +26,16 @@ const BABELLOADER = { loader: 'babel-loader', options: BABELOPTIONS };
 // eslint-disable-next-line import/no-dynamic-require
 const BOOTSTRAPVARS = require(path.resolve(ROOT_PATH, 'public', 'stylesheets', 'bootstrap-config.json')).vars;
 
+const getCssLoaderOptions = () => {
+  // Development
+  if (TARGET === 'start') {
+    return {
+      localIdentName: '[name]__[local]--[hash:base64:5]',
+    };
+  }
+  return {};
+};
+
 const webpackConfig = {
   name: 'app',
   dependencies: ['vendor'],
@@ -58,7 +68,14 @@ const webpackConfig = {
         ],
       },
       { test: /\.less$/, use: ['style-loader', 'css-loader', 'less-loader'], exclude: /bootstrap\.less$/ },
-      { test: /\.css$/, use: ['style-loader', 'css-loader'] },
+      { test: /\.css$/,
+        use: [
+          'style-loader',
+          {
+            loader: 'css-loader',
+            options: getCssLoaderOptions(),
+          },
+        ] },
     ],
   },
   resolve: {


### PR DESCRIPTION
This makes it easier to grep for a certain style in our code.

See https://github.com/webpack-contrib/css-loader#localidentname