### PR TITLE
Add throttling to the AWS Flow Logs/Logs inputs (#5218)

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/plugin/inputs/transports/ThrottleableTransport.java
+++ b/graylog2-server/src/main/java/org/graylog2/plugin/inputs/transports/ThrottleableTransport.java
@@ -28,6 +28,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 /**
@@ -56,8 +57,8 @@ public abstract class ThrottleableTransport implements Transport {
                     "Allow throttling this input.",
                     false,
                     "If enabled, no new messages will be read from this input until Graylog catches up with its message load. " +
-                            "This is typically useful for inputs reading from files or message queue systems like AMQP or Kafka. " +
-                            "If you regularly poll an external system, e.g. via HTTP, you normally want to leave this disabled."
+                    "This is typically useful for inputs reading from files or message queue systems like AMQP or Kafka. " +
+                    "If you regularly poll an external system, e.g. via HTTP, you normally want to leave this disabled."
 
             ));
             return request;
@@ -113,7 +114,7 @@ public abstract class ThrottleableTransport implements Transport {
     protected abstract void doStop();
 
     /**
-     * Only executed if this input is allowed to be throttled at all
+     * Only executed if the Allow Throttling checkbox is set in the input's configuration.
      * @param throttleState current processing system state
      */
     @Subscribe
@@ -135,11 +136,22 @@ public abstract class ThrottleableTransport implements Transport {
                 return;
             }
             currentlyThrottled.set(false);
+            handleChangedThrottledState(false);
             blockLatch.countDown();
         } else if (throttled) {
             currentlyThrottled.set(true);
+            handleChangedThrottledState(true);
             blockLatch = new CountDownLatch(1);
         }
+    }
+
+    /**
+     * Transports can override this to be notified when the throttled state changes. Only called when throttled state changes.
+     *
+     * @param isThrottled the current throttled state.
+     */
+    public void handleChangedThrottledState(boolean isThrottled) {
+
     }
 
     public boolean isThrottled() {
@@ -199,7 +211,10 @@ public abstract class ThrottleableTransport implements Transport {
         log.debug("[{}] [unthrottled] fall through", transportName);
         return false;
     }
-    
+
+    /**
+     * Blocks until the blockLatch is released.
+     */
     public void blockUntilUnthrottled() {
         // sanity: if there's no latch, don't try to access it
         if (blockLatch == null) {
@@ -210,6 +225,27 @@ public abstract class ThrottleableTransport implements Transport {
             blockLatch.await();
         } catch (InterruptedException e) {
             // ignore
+        }
+    }
+
+    /**
+     * Blocks until the blockLatch is released or until the timeout is exceeded.
+     *
+     * @param timeout the maximum time to wait
+     * @param unit    the time unit for the {@code timeout} argument.
+     * @return        {@code true} if the blockLatch was released before the {@code timeout} elapsed. and
+     *                {@code false} if the {@code timeout} was exceeded before the blockLatch was released.
+     */
+    public boolean blockUntilUnthrottled(long timeout, TimeUnit unit) {
+        // sanity: if there's no latch, don't try to access it
+        if (blockLatch == null) {
+            return false;
+        }
+        // purposely allow interrupts as a means to let the caller check if it should exit its run loop
+        try {
+            return blockLatch.await(timeout, unit);
+        } catch (InterruptedException e) {
+            return false;
         }
     }
 }


### PR DESCRIPTION
* Add blockUntilUnthrottled method with timeout

This allows an input to block while throttled during a timeout period. If the block latch is not cleared in the timeout period, the latch will expire and allow execution to proceed.

* Add throttled state change callback

* Document return for method ThrottleableTransport.blockUntilUnthrottled()

* Fixed documentation typo

(cherry picked from commit 72c6126d29ecb366a3f02a854362ec51c2a31c7c)