### PR TITLE
Guarding against `undefined` in `isPermitted`/`isAnyPermitted`.

### DIFF
--- a/graylog2-web-interface/src/components/common/IfPermitted.test.jsx
+++ b/graylog2-web-interface/src/components/common/IfPermitted.test.jsx
@@ -38,6 +38,13 @@ describe('IfPermitted', () => {
         </IfPermitted>
       ));
     });
+    it('user has undefined permissions', () => {
+      wrapper = mount((
+        <IfPermitted permissions={['somepermission']} currentUser={{ permissions: undefined }}>
+          {element}
+        </IfPermitted>
+      ));
+    });
     it('user has different permissions', () => {
       wrapper = mount((
         <IfPermitted permissions={['somepermission']} currentUser={{ permissions: ['someotherpermission'] }}>
@@ -87,6 +94,13 @@ describe('IfPermitted', () => {
       ));
     });
     it('empty permissions were passed and no user is present', () => {
+      wrapper = mount((
+        <IfPermitted permissions={[]}>
+          {element}
+        </IfPermitted>
+      ));
+    });
+    it('undefined permissions were passed and no user is present', () => {
       wrapper = mount((
         <IfPermitted permissions={[]}>
           {element}

--- a/graylog2-web-interface/src/util/PermissionsMixin.js
+++ b/graylog2-web-interface/src/util/PermissionsMixin.js
@@ -18,6 +18,9 @@ const _permissionPredicate = (permissionSet, p) => {
 
 const PermissionsMixin = {
   isPermitted(possessedPermissions, requiredPermissions) {
+    if (!requiredPermissions || requiredPermissions.length === 0) {
+      return true;
+    }
     if (!possessedPermissions) {
       return false;
     }
@@ -31,6 +34,9 @@ const PermissionsMixin = {
   },
 
   isAnyPermitted(possessedPermissions, requiredPermissions) {
+    if (!requiredPermissions || requiredPermissions.length === 0) {
+      return true;
+    }
     if (!possessedPermissions) {
       return false;
     }

--- a/graylog2-web-interface/src/util/PermissionsMixin.test.js
+++ b/graylog2-web-interface/src/util/PermissionsMixin.test.js
@@ -1,0 +1,76 @@
+import PermissionsMixin from './PermissionsMixin';
+
+const { isPermitted, isAnyPermitted } = PermissionsMixin;
+
+describe('PermissionsMixin', () => {
+  describe('isPermitted', () => {
+    it('returns `true` when required permissions are `undefined`', () => {
+      expect(isPermitted([], undefined)).toBeTruthy();
+    });
+    it('returns `true` when required permissions are empty list', () => {
+      expect(isPermitted([], [])).toBeTruthy();
+    });
+    it('returns `false` when possessed permissions are `undefined` and required permissions are empty', () => {
+      expect(isPermitted(undefined, ['foo'])).toBeFalsy();
+    });
+    it('returns `false` when possessed permissions are `undefined`', () => {
+      expect(isPermitted(undefined, ['foo'])).toBeFalsy();
+    });
+    it('returns `true` when wildcard permission is possessed', () => {
+      expect(isPermitted(['*'], undefined)).toBeTruthy();
+      expect(isPermitted(['*'], [])).toBeTruthy();
+      expect(isPermitted(['*'], ['foo'])).toBeTruthy();
+      expect(isPermitted(['*'], ['foo', 'bar'])).toBeTruthy();
+    });
+    it('returns `true` when possessed are identical to required permissions', () => {
+      expect(isPermitted(['foo'], ['foo'])).toBeTruthy();
+      expect(isPermitted(['foo', 'bar'], ['foo', 'bar'])).toBeTruthy();
+      expect(isPermitted(['bar', 'foo'], ['foo', 'bar'])).toBeTruthy();
+    });
+    it('returns `true` when possessed contain all required permissions', () => {
+      expect(isPermitted(['foo', 'bar'], ['foo'])).toBeTruthy();
+      expect(isPermitted(['foo', 'bar', 'baz'], ['foo', 'bar'])).toBeTruthy();
+      expect(isPermitted(['bar', 'baz', 'foo'], ['foo', 'bar'])).toBeTruthy();
+    });
+    it('returns `false` when possessed do not contain all required permissions', () => {
+      expect(isPermitted(['foo'], ['foo', 'bar'])).toBeFalsy();
+      expect(isPermitted(['foo', 'bar'], ['foo', 'bar', 'baz'])).toBeFalsy();
+      expect(isPermitted(['bar', 'foo'], ['foo', 'bar', 'baz'])).toBeFalsy();
+    });
+  });
+  describe('isAnyPermitted', () => {
+    it('returns `true` when required permissions are `undefined`', () => {
+      expect(isAnyPermitted([], undefined)).toBeTruthy();
+    });
+    it('returns `true` when required permissions are empty list', () => {
+      expect(isAnyPermitted([], [])).toBeTruthy();
+    });
+    it('returns `false` when possessed permissions are `undefined` and required permissions are empty', () => {
+      expect(isAnyPermitted(undefined, ['foo'])).toBeFalsy();
+    });
+    it('returns `false` when possessed permissions are `undefined`', () => {
+      expect(isAnyPermitted(undefined, ['foo'])).toBeFalsy();
+    });
+    it('returns `true` when wildcard permission is possessed', () => {
+      expect(isAnyPermitted(['*'], undefined)).toBeTruthy();
+      expect(isAnyPermitted(['*'], [])).toBeTruthy();
+      expect(isAnyPermitted(['*'], ['foo'])).toBeTruthy();
+      expect(isAnyPermitted(['*'], ['foo', 'bar'])).toBeTruthy();
+    });
+    it('returns `true` when possessed are identical to required permissions', () => {
+      expect(isAnyPermitted(['foo'], ['foo'])).toBeTruthy();
+      expect(isAnyPermitted(['foo', 'bar'], ['foo', 'bar'])).toBeTruthy();
+      expect(isAnyPermitted(['bar', 'foo'], ['foo', 'bar'])).toBeTruthy();
+    });
+    it('returns `true` when possessed contain all required permissions', () => {
+      expect(isAnyPermitted(['foo', 'bar'], ['foo'])).toBeTruthy();
+      expect(isAnyPermitted(['foo', 'bar', 'baz'], ['foo', 'bar'])).toBeTruthy();
+      expect(isAnyPermitted(['bar', 'baz', 'foo'], ['foo', 'bar'])).toBeTruthy();
+    });
+    it('returns `false` when possessed do not contain all required permissions', () => {
+      expect(isAnyPermitted(['foo'], ['foo', 'bar'])).toBeTruthy();
+      expect(isAnyPermitted(['foo', 'bar'], ['foo', 'bar', 'baz'])).toBeTruthy();
+      expect(isAnyPermitted(['bar', 'foo'], ['foo', 'bar', 'baz'])).toBeTruthy();
+    });
+  });
+});


### PR DESCRIPTION
## Description
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Before this change, passing `undefined` for the permission set that
`isPermitted`/`isAnyPermitted` check against, both functions would throw
an exception.

After this change, both functions return proper results based on the set
of required permissions. If it is empty, the functions return `true`, if
it is non-empty, both return `false`.

Fixes #5193.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
