### PR TITLE
Fix ES alias request for Indices#getIndexNamesAndAliases() method

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/indexer/indices/Indices.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/indices/Indices.java
@@ -299,11 +299,19 @@ public class Indices {
         }
     }
 
+    /**
+     * Returns index names and their aliases. This only returns indices which actually have an alias.
+     */
     @NotNull
     public Map<String, Set<String>> getIndexNamesAndAliases(String indexPattern) {
         // only request indices matching the name or pattern in `indexPattern` and only get the alias names for each index,
         // not the settings or mappings
-        final GetAliases request = new GetAliases.Builder().addIndex(indexPattern).build();
+        final GetAliases request = new GetAliases.Builder()
+                .addIndex(indexPattern)
+                // ES 6 changed the "expand_wildcards" default value for the /_alias API from "open" to "all".
+                // Since our code expects only open indices to be returned, we have to explicitly set the parameter now.
+                .setParameter("expand_wildcards", "open")
+                .build();
 
         final JestResult jestResult = JestUtils.execute(jestClient, request, () -> "Couldn't collect aliases for index pattern " + indexPattern);
 
@@ -311,10 +319,11 @@ public class Indices {
         final Iterator<Map.Entry<String, JsonNode>> it = jestResult.getJsonObject().fields();
         while (it.hasNext()) {
             final Map.Entry<String, JsonNode> entry = it.next();
-            final JsonNode aliasMetaData = entry.getValue();
+            final String indexName = entry.getKey();
+            final JsonNode aliasMetaData = entry.getValue().path("aliases");
             if (aliasMetaData.isObject()) {
-                final ImmutableSet<String> aliasesBuilder = ImmutableSet.copyOf(aliasMetaData.fieldNames());
-                indexAliasesBuilder.put(entry.getKey(), aliasesBuilder);
+                final ImmutableSet<String> aliasNames = ImmutableSet.copyOf(aliasMetaData.fieldNames());
+                indexAliasesBuilder.put(indexName, aliasNames);
             }
         }
 
@@ -322,6 +331,9 @@ public class Indices {
     }
 
     public Optional<String> aliasTarget(String alias) throws TooManyAliasesException {
+        // TODO: This is basically getting all indices and later we filter out the alias we want to check for.
+        //       This can be done in a more efficient way by either using the /_cat/aliases/<alias-name> API or
+        //       the regular /_alias/<alias-name> API.
         final GetAliases request = new GetAliases.Builder().build();
         final JestResult jestResult = JestUtils.execute(jestClient, request, () -> "Couldn't collect indices for alias " + alias);
 


### PR DESCRIPTION
ES 5 and earlier didn't return closed indices when using the "/_alias"
API by default. In ES 6 that behavior changed to return all indices by
default. (even closed ones)

ES 6 effectively changed the default value for the "expand_wildcards"
parameter from "open" to "all" so we have to explicitly set it to "open"
to restore the old behavior.

While we are here, fix an old bug where the set of alias names for an
index was set to the string "alias" instead of the actual alias names.
This was probably introduced when we switched to the ES HTTP API but
never had any negative effect because we use the alias names only in
index retention and there it had no negative effect unless you set the
max number of indices to 0. (which no one does)

Also leave a TODO to improve the efficiency of the Indices#aliasTarget()
method.

Fixes #5336