### PR TITLE
Include re-indexed indices in index retention

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/indexer/MongoIndexSet.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/MongoIndexSet.java
@@ -211,12 +211,7 @@ public class MongoIndexSet implements IndexSet {
 
     @Override
     public Map<String, Set<String>> getAllIndexAliases() {
-        final Map<String, Set<String>> indexNamesAndAliases = indices.getIndexNamesAndAliases(getIndexWildcard());
-
-        // filter out the restored archives from the result set
-        return indexNamesAndAliases.entrySet().stream()
-                .filter(e -> isGraylogDeflectorIndex(e.getKey()))
-                .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
+        return indices.getIndexNamesAndAliases(getIndexWildcard());
     }
 
     @Override

--- a/graylog2-server/src/test/java/org/graylog2/indexer/MongoIndexSetTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/indexer/MongoIndexSetTest.java
@@ -241,7 +241,7 @@ public class MongoIndexSetTest {
         final MongoIndexSet mongoIndexSet = new MongoIndexSet(config, indices, nodeId, indexRangeService, auditEventSender, systemJobManager, jobFactory, activityWriter);
         final Map<String, Set<String>> deflectorIndices = mongoIndexSet.getAllIndexAliases();
 
-        assertThat(deflectorIndices).containsOnlyKeys("graylog_2", "graylog_3", "graylog_5");
+        assertThat(deflectorIndices).containsOnlyKeys("graylog_1_reindex_es5", "graylog_2", "graylog_3", "graylog_4_restored_archive", "graylog_5");
     }
 
     @Test


### PR DESCRIPTION
This also includes the legacy "restored_archive" indices in the
automatic retention. That should be okay because archives are restored
into a separate index set for some time now.

Fixes #5337