### PR TITLE
Keep Content Pack entities when creating a new version

### DIFF
--- a/graylog2-web-interface/src/components/common/ExpandableListItem.css
+++ b/graylog2-web-interface/src/components/common/ExpandableListItem.css
@@ -1,4 +1,4 @@
-:local(.listItem) {
+:local(.listItemPadding) {
     padding: 10px 5px;
 }
 

--- a/graylog2-web-interface/src/components/common/ExpandableListItem.jsx
+++ b/graylog2-web-interface/src/components/common/ExpandableListItem.jsx
@@ -35,6 +35,8 @@ class ExpandableListItem extends React.Component {
       PropTypes.element,
       PropTypes.arrayOf(PropTypes.element),
     ]),
+    /** Leave space before and after list item */
+    padded: PropTypes.bool,
   };
 
   static defaultProps = {
@@ -46,6 +48,7 @@ class ExpandableListItem extends React.Component {
     children: [],
     subheader: undefined,
     stayExpanded: false,
+    padded: false,
   };
 
   state = {
@@ -96,9 +99,10 @@ class ExpandableListItem extends React.Component {
     const { checked, expandable, selectable, header, subheader, children, ...otherProps } = this.props;
     const headerToRender = selectable ? (<span role="button" tabIndex={0} onClick={this._clickOnHeader}>{header}</span>) : header;
     const inputProps = this._filterInputProps(otherProps);
+    const liClassName = this.props.padded ? style.listItemPadding : '';
 
     return (
-      <li className={style.listItem}>
+      <li className={liClassName}>
         <div className={style.listItemContainer}>
           {selectable && <Checkbox inputRef={(c) => { this._checkbox = c; }} inline checked={checked} {...inputProps} />}
           {expandable &&

--- a/graylog2-web-interface/src/components/common/ExpandableListItem.jsx
+++ b/graylog2-web-interface/src/components/common/ExpandableListItem.jsx
@@ -48,7 +48,7 @@ class ExpandableListItem extends React.Component {
     children: [],
     subheader: undefined,
     stayExpanded: false,
-    padded: false,
+    padded: true,
   };
 
   state = {
@@ -84,7 +84,7 @@ class ExpandableListItem extends React.Component {
   };
 
   _filterInputProps = (props) => {
-    const { expanded, indetermined, stayExpanded, ...inputProps } = props;
+    const { expanded, indetermined, stayExpanded, padded, ...inputProps } = props;
     return inputProps;
   };
 

--- a/graylog2-web-interface/src/components/common/__snapshots__/ExpandableList.test.jsx.snap
+++ b/graylog2-web-interface/src/components/common/__snapshots__/ExpandableList.test.jsx.snap
@@ -5,7 +5,7 @@ exports[`<ExpandableList /> should render with a Item 1`] = `
   className="list"
 >
   <li
-    className="listItem"
+    className="listItemPadding"
   >
     <div
       className="listItemContainer"
@@ -61,7 +61,7 @@ exports[`<ExpandableList /> should render with a nested ExpandableList 1`] = `
   className="list"
 >
   <li
-    className="listItem"
+    className="listItemPadding"
   >
     <div
       className="listItemContainer"
@@ -112,7 +112,7 @@ exports[`<ExpandableList /> should render with a nested ExpandableList 1`] = `
         className="list"
       >
         <li
-          className="listItem"
+          className="listItemPadding"
         >
           <div
             className="listItemContainer"

--- a/graylog2-web-interface/src/components/content-packs/ContentPackEdit.jsx
+++ b/graylog2-web-interface/src/components/content-packs/ContentPackEdit.jsx
@@ -57,8 +57,8 @@ class ContentPackEdit extends React.Component {
     const typeRegExp = RegExp(/\.type$/);
     const newEntities = this.props.fetchedEntities.map((entity) => {
       const parameters = this.props.appliedParameter[entity.id] || [];
-      const newEntity = ObjectUtils.clone(entity);
-      const entityData = newEntity.data;
+      const newEntityBuilder = entity.toBuilder();
+      const entityData = entity.data;
       const configKeys = ObjectUtils.getPaths(entityData)
         .filter(configKey => typeRegExp.test(configKey))
         .map((configKey) => { return configKey.replace(typeRegExp, ''); });
@@ -72,8 +72,8 @@ class ContentPackEdit extends React.Component {
         }
         ObjectUtils.setValue(entityData, path, newValue);
       });
-      newEntity.data = entityData;
-      return newEntity;
+      newEntityBuilder.data(entityData);
+      return newEntityBuilder.build();
     });
     const newContentPack = this.props.contentPack.toBuilder()
       .entities(newEntities)

--- a/graylog2-web-interface/src/components/content-packs/ContentPackEdit.jsx
+++ b/graylog2-web-interface/src/components/content-packs/ContentPackEdit.jsx
@@ -20,9 +20,11 @@ class ContentPackEdit extends React.Component {
     entityIndex: PropTypes.object,
     selectedEntities: PropTypes.object,
     appliedParameter: PropTypes.object,
+    edit: PropTypes.bool,
   };
 
   static defaultProps = {
+    edit: false,
     contentPack: undefined,
     onGetEntities: () => {},
     onStateChange: () => {},
@@ -113,6 +115,7 @@ class ContentPackEdit extends React.Component {
     const selectionComponent = (
       <ContentPackSelection contentPack={this.props.contentPack}
                             selectedEntities={this.props.selectedEntities}
+                            edit={this.props.edit}
                             onStateChange={this.props.onStateChange}
                             entities={this.props.entityIndex} />);
     const parameterComponent = (

--- a/graylog2-web-interface/src/components/content-packs/ContentPackEntitiesList.jsx
+++ b/graylog2-web-interface/src/components/content-packs/ContentPackEntitiesList.jsx
@@ -40,7 +40,7 @@ class ContentPackEntitiesList extends React.Component {
   }
 
   _filterEntities = (filter, entitiesArg) => {
-    const entities = ObjectUtils.clone(entitiesArg || this.props.contentPack.entities);
+    const entities = entitiesArg || this.props.contentPack.entities;
     if (!filter || filter.length <= 0) {
       this.setState({ filteredEntities: entities, filter: undefined });
       return;
@@ -48,17 +48,9 @@ class ContentPackEntitiesList extends React.Component {
 
     const regexp = RegExp(filter, 'i');
     const filteredEntities = entities.filter((entity) => {
-      return regexp.test(this._entityTitle(entity)) || regexp.test(this._entityDescription(entity));
+      return regexp.test(entity.title) || regexp.test(entity.description);
     });
     this.setState({ filteredEntities: filteredEntities, filter: filter });
-  };
-
-  _entityTitle = (entity) => {
-    return (entity.data.title || entity.data.name || {}).value || '';
-  };
-
-  _entityDescription = (entity) => {
-    return (entity.data.description || {}).value || '';
   };
 
   _entityRowFormatter = (entity) => {
@@ -126,9 +118,9 @@ class ContentPackEntitiesList extends React.Component {
     const appliedParameterCount = (this.props.appliedParameter[entity.id] || []).length;
     return (
       <tr key={entity.id}>
-        <td className={ContentPackEntitiesListStyle.bigColumns}>{this._entityTitle(entity)}</td>
+        <td className={ContentPackEntitiesListStyle.bigColumns}>{entity.title}</td>
         <td>{entity.type.name}</td>
-        <td className={ContentPackEntitiesListStyle.bigColumns}>{this._entityDescription(entity)}</td>
+        <td className={ContentPackEntitiesListStyle.bigColumns}>{entity.description}</td>
         {!this.props.readOnly && <td>{appliedParameterCount}</td>}
         <td>
           <ButtonToolbar>

--- a/graylog2-web-interface/src/components/content-packs/ContentPackEntitiesList.jsx
+++ b/graylog2-web-interface/src/components/content-packs/ContentPackEntitiesList.jsx
@@ -5,7 +5,6 @@ import { Button, Modal, ButtonToolbar } from 'react-bootstrap';
 import { SearchForm, DataTable } from 'components/common';
 import BootstrapModalWrapper from 'components/bootstrap/BootstrapModalWrapper';
 
-import ObjectUtils from 'util/ObjectUtils';
 import ContentPackApplyParameter from './ContentPackApplyParameter';
 import ContentPackEntityConfig from './ContentPackEntityConfig';
 

--- a/graylog2-web-interface/src/components/content-packs/ContentPackParameters.test.jsx
+++ b/graylog2-web-interface/src/components/content-packs/ContentPackParameters.test.jsx
@@ -3,6 +3,7 @@ import renderer from 'react-test-renderer';
 import 'helpers/mocking/react-dom_mock';
 
 import ContentPackParameters from 'components/content-packs/ContentPackParameters';
+import ContentPack from 'logic/content-packs/ContentPack';
 
 describe('<ContentPackParameters />', () => {
   it('should render with empty parameters', () => {
@@ -31,16 +32,17 @@ describe('<ContentPackParameters />', () => {
         },
       },
     };
-    const contentPack = {
-      parameters: [{
-        name: 'A parameter name',
-        title: 'A parameter title',
-        description: 'A parameter descriptions',
-        type: 'string',
-        default_value: 'test',
-      }],
-      entities: [entity],
-    };
+    const contentPack = ContentPack.builder()
+      .parameters(
+        [{
+          name: 'A parameter name',
+          title: 'A parameter title',
+          description: 'A parameter descriptions',
+          type: 'string',
+          default_value: 'test',
+        }])
+      .entities([entity])
+      .build();
     const wrapper = renderer.create(<ContentPackParameters contentPack={contentPack} appliedParameter={{}} />);
     expect(wrapper.toJSON()).toMatchSnapshot();
   });

--- a/graylog2-web-interface/src/components/content-packs/ContentPackSelection.css
+++ b/graylog2-web-interface/src/components/content-packs/ContentPackSelection.css
@@ -1,0 +1,3 @@
+:local(.contentPackEntity) {
+    color: rgba(158, 31, 99, 0.43);
+}

--- a/graylog2-web-interface/src/components/content-packs/ContentPackSelection.jsx
+++ b/graylog2-web-interface/src/components/content-packs/ContentPackSelection.jsx
@@ -3,12 +3,14 @@ import React from 'react';
 import naturalSort from 'javascript-natural-sort';
 import { cloneDeep } from 'lodash';
 
-import { Row, Col, Panel, Label } from 'react-bootstrap';
+import { Row, Col, Panel, HelpBlock } from 'react-bootstrap';
 import { Input } from 'components/bootstrap';
 import { ExpandableList, ExpandableListItem, SearchForm } from 'components/common';
 import FormsUtils from 'util/FormsUtils';
-
 import Entity from 'logic/content-packs/Entity';
+
+import style from './ContentPackSelection.css';
+
 
 class ContentPackSelection extends React.Component {
   static propTypes = {
@@ -16,9 +18,11 @@ class ContentPackSelection extends React.Component {
     onStateChange: PropTypes.func,
     entities: PropTypes.object,
     selectedEntities: PropTypes.object,
+    edit: PropTypes.bool,
   };
 
   static defaultProps = {
+    edit: false,
     onStateChange: () => {},
     entities: {},
     selectedEntities: {},
@@ -160,9 +164,9 @@ class ContentPackSelection extends React.Component {
 
   _entityItemHeader = (entity) => {
     if (entity.constructor.name === Entity.name) {
-      return <span><span>{entity.title}</span>{' '}<Label bsStyle="success"><i className="fa fa-archive" /></Label></span>;
+      return <span><i className={`fa fa-archive ${style.contentPackEntity}`} />{' '}<span>{entity.title}</span></span>;
     }
-    return <span><span>{entity.title}</span>{' '}<Label bsStyle="info"><i className="fa fa-server" /></Label></span>;
+    return <span><i className="fa fa-server" />{' '}<span>{entity.title}</span></span>;
   };
 
   render() {
@@ -262,6 +266,8 @@ class ContentPackSelection extends React.Component {
         <Row>
           <Col smOffset={1} lg={8}>
             <h2>Content Pack selection</h2>
+            {this.props.edit && <HelpBlock>You can select between installed entities from the server (<i className="fa fa-server" />) or
+              entities from the former content pack revision (<i className={`fa fa-archive ${style.contentPackEntity}`} />).</HelpBlock>}
           </Col>
         </Row>
         <Row>

--- a/graylog2-web-interface/src/components/content-packs/ContentPackSelection.jsx
+++ b/graylog2-web-interface/src/components/content-packs/ContentPackSelection.jsx
@@ -3,10 +3,12 @@ import React from 'react';
 import naturalSort from 'javascript-natural-sort';
 import { cloneDeep } from 'lodash';
 
-import { Row, Col, Panel } from 'react-bootstrap';
+import { Row, Col, Panel, Label } from 'react-bootstrap';
 import { Input } from 'components/bootstrap';
 import { ExpandableList, ExpandableListItem, SearchForm } from 'components/common';
 import FormsUtils from 'util/FormsUtils';
+
+import Entity from 'logic/content-packs/Entity';
 
 class ContentPackSelection extends React.Component {
   static propTypes = {
@@ -156,6 +158,13 @@ class ContentPackSelection extends React.Component {
     this.setState({ filteredEntities: filtered, isFiltered: true, filter: filter });
   };
 
+  _entityItemHeader = (entity) => {
+    if (entity.constructor.name === Entity.name) {
+      return <span><span>{entity.title}</span>{' '}<Label bsStyle="success"><i className="fa fa-archive" /></Label></span>;
+    }
+    return <span><span>{entity.title}</span>{' '}<Label bsStyle="info"><i className="fa fa-server" /></Label></span>;
+  };
+
   render() {
     const entitiesComponent = Object.keys(this.state.filteredEntities || {})
       .sort((a, b) => naturalSort(a, b))
@@ -163,11 +172,13 @@ class ContentPackSelection extends React.Component {
         const group = this.state.filteredEntities[entityType];
         const entities = group.sort((a, b) => naturalSort(a.title, b.title)).map((entity) => {
           const checked = this._isSelected(entity);
+          const header = this._entityItemHeader(entity);
           return (<ExpandableListItem onChange={() => this._updateSelectionEntity(entity)}
                                       key={entity.id}
                                       checked={checked}
                                       expandable={false}
-                                      header={entity.title} />);
+                                      padded={false}
+                                      header={header} />);
         });
         if (group.length <= 0) {
           return null;
@@ -179,6 +190,7 @@ class ContentPackSelection extends React.Component {
                               checked={this._isGroupSelected(entityType)}
                               stayExpanded={this.state.isFiltered}
                               expanded={this.state.isFiltered}
+                              padded={false}
                               header={ContentPackSelection._toDisplayTitle(entityType)}>
             <ExpandableList>
               {entities}

--- a/graylog2-web-interface/src/components/content-packs/ContentPackSelection.jsx
+++ b/graylog2-web-interface/src/components/content-packs/ContentPackSelection.jsx
@@ -33,7 +33,7 @@ class ContentPackSelection extends React.Component {
     this._bindValue = this._bindValue.bind(this);
     this.state = {
       contentPack: this.props.contentPack,
-      filteredEntities: cloneDeep(this.props.entities),
+      filteredEntities: this.props.entities,
       filter: '',
       isFiltered: false,
       errors: {},

--- a/graylog2-web-interface/src/components/content-packs/ContentPackSelection.jsx
+++ b/graylog2-web-interface/src/components/content-packs/ContentPackSelection.jsx
@@ -1,12 +1,12 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 import naturalSort from 'javascript-natural-sort';
+import { cloneDeep } from 'lodash';
 
 import { Row, Col, Panel } from 'react-bootstrap';
 import { Input } from 'components/bootstrap';
 import { ExpandableList, ExpandableListItem, SearchForm } from 'components/common';
 import FormsUtils from 'util/FormsUtils';
-import ObjectUtils from 'util/ObjectUtils';
 
 class ContentPackSelection extends React.Component {
   static propTypes = {
@@ -29,10 +29,11 @@ class ContentPackSelection extends React.Component {
 
   constructor(props) {
     super(props);
+
     this._bindValue = this._bindValue.bind(this);
     this.state = {
       contentPack: this.props.contentPack,
-      filteredEntities: ObjectUtils.clone(this.props.entities),
+      filteredEntities: cloneDeep(this.props.entities),
       filter: '',
       isFiltered: false,
       errors: {},
@@ -81,7 +82,7 @@ class ContentPackSelection extends React.Component {
 
   _updateSelectionEntity = (entity) => {
     const typeName = entity.type.name;
-    const newSelection = ObjectUtils.clone(this.props.selectedEntities);
+    const newSelection = cloneDeep(this.props.selectedEntities);
     newSelection[typeName] = (newSelection[typeName] || []);
     const index = newSelection[typeName].findIndex((e) => { return e.id === entity.id; });
     if (index < 0) {
@@ -94,7 +95,7 @@ class ContentPackSelection extends React.Component {
   };
 
   _updateSelectionGroup = (type) => {
-    const newSelection = ObjectUtils.clone(this.props.selectedEntities);
+    const newSelection = cloneDeep(this.props.selectedEntities);
     if (this._isGroupSelected(type)) {
       newSelection[type] = [];
     } else {
@@ -141,11 +142,11 @@ class ContentPackSelection extends React.Component {
   _filterEntities = (filterArg) => {
     const filter = filterArg;
     if (filter.length <= 0) {
-      this.setState({ filteredEntities: ObjectUtils.clone(this.props.entities), isFiltered: false, filter: filter });
+      this.setState({ filteredEntities: cloneDeep(this.props.entities), isFiltered: false, filter: filter });
       return;
     }
     const filtered = Object.keys(this.props.entities).reduce((result, type) => {
-      const filteredEntities = ObjectUtils.clone(result);
+      const filteredEntities = cloneDeep(result);
       filteredEntities[type] = this.props.entities[type].filter((entity) => {
         const regexp = RegExp(filter, 'i');
         return regexp.test(entity.title);

--- a/graylog2-web-interface/src/components/content-packs/ContentPackSelection.test.jsx
+++ b/graylog2-web-interface/src/components/content-packs/ContentPackSelection.test.jsx
@@ -5,6 +5,7 @@ import 'helpers/mocking/react-dom_mock';
 
 import ContentPack from 'logic/content-packs/ContentPack';
 import ContentPackSelection from 'components/content-packs/ContentPackSelection';
+import Entity from 'logic/content-packs/Entity';
 
 describe('<ContentPackSelection />', () => {
   it('should render with empty content pack', () => {
@@ -22,19 +23,21 @@ describe('<ContentPackSelection />', () => {
       .url('http://example.com')
       .build();
 
+    const entity = Entity.builder()
+      .v('1')
+      .type({ name: 'spaceship', version: '1' })
+      .id('beef123')
+      .data({
+        title: { value: 'breq', type: 'string' },
+      })
+      .build();
     const entities = {
-      spaceship: [{
-        title: 'breq',
-        type: {
-          name: 'spaceship',
-          version: '1',
-        },
-        id: 'beef123',
-      }],
+      spaceship: [entity],
     };
 
     const wrapper = renderer.create(
       <ContentPackSelection contentPack={contentPack}
+                            edit
                             entities={entities}
                             selectedEntities={{}}
       />);

--- a/graylog2-web-interface/src/components/content-packs/__snapshots__/ContentPackEdit.test.jsx.snap
+++ b/graylog2-web-interface/src/components/content-packs/__snapshots__/ContentPackEdit.test.jsx.snap
@@ -830,7 +830,7 @@ exports[`<ContentPackEdit /> should render with content pack for edit 1`] = `
               className="list"
             >
               <li
-                className="listItem"
+                className=""
               >
                 <div
                   className="listItemContainer"

--- a/graylog2-web-interface/src/components/content-packs/__snapshots__/ContentPackSelection.test.jsx.snap
+++ b/graylog2-web-interface/src/components/content-packs/__snapshots__/ContentPackSelection.test.jsx.snap
@@ -524,7 +524,7 @@ exports[`<ContentPackSelection /> should render with filled content pack 1`] = `
         className="list"
       >
         <li
-          className="listItem"
+          className=""
         >
           <div
             className="listItemContainer"

--- a/graylog2-web-interface/src/components/content-packs/__snapshots__/ContentPackSelection.test.jsx.snap
+++ b/graylog2-web-interface/src/components/content-packs/__snapshots__/ContentPackSelection.test.jsx.snap
@@ -438,6 +438,19 @@ exports[`<ContentPackSelection /> should render with filled content pack 1`] = `
       <h2>
         Content Pack selection
       </h2>
+      <span
+        className="help-block"
+      >
+        You can select between installed entities from the server (
+        <i
+          className="fa fa-server"
+        />
+        ) or entities from the former content pack revision (
+        <i
+          className="fa fa-archive contentPackEntity"
+        />
+        ).
+      </span>
     </div>
   </div>
   <div

--- a/graylog2-web-interface/src/logic/content-packs/ContentPack.js
+++ b/graylog2-web-interface/src/logic/content-packs/ContentPack.js
@@ -1,5 +1,4 @@
 import { Map } from 'immutable';
-import { concat, remove, cloneDeep } from 'lodash';
 import uuid from 'uuid/v4';
 import Entity from './Entity';
 

--- a/graylog2-web-interface/src/logic/content-packs/ContentPack.js
+++ b/graylog2-web-interface/src/logic/content-packs/ContentPack.js
@@ -10,7 +10,7 @@ export default class ContentPack {
       if (e instanceof Entity) {
         return e;
       }
-      return Entity.of(e);
+      return Entity.fromJSON(e);
     });
 
     this._value = {

--- a/graylog2-web-interface/src/logic/content-packs/ContentPack.js
+++ b/graylog2-web-interface/src/logic/content-packs/ContentPack.js
@@ -1,10 +1,18 @@
 import { Map } from 'immutable';
-import { concat, remove } from 'lodash';
+import { concat, remove, cloneDeep } from 'lodash';
 import uuid from 'uuid/v4';
+import Entity from './Entity';
 
 export default class ContentPack {
   constructor(v, id, rev, name, summary, description, vendor, url, requires,
-    parameters, entities) {
+    parameters, entitieValues) {
+    const entities = entitieValues.map((e) => {
+      if (e instanceof Entity) {
+        return e;
+      }
+      return Entity.of(e);
+    });
+
     this._value = {
       v,
       id,
@@ -108,6 +116,8 @@ export default class ContentPack {
       parameters,
       entities,
     } = this._value;
+
+    const entitiesJSON = entities.map(e => e.toJSON());
     return {
       v,
       id,
@@ -119,7 +129,7 @@ export default class ContentPack {
       url,
       requires,
       parameters,
-      entities,
+      entities: entitiesJSON,
     };
   }
 

--- a/graylog2-web-interface/src/logic/content-packs/ContentPack.js
+++ b/graylog2-web-interface/src/logic/content-packs/ContentPack.js
@@ -1,4 +1,5 @@
 import { Map } from 'immutable';
+import { concat, remove } from 'lodash';
 import uuid from 'uuid/v4';
 import Entity from './Entity';
 

--- a/graylog2-web-interface/src/logic/content-packs/Entity.jsx
+++ b/graylog2-web-interface/src/logic/content-packs/Entity.jsx
@@ -10,7 +10,7 @@ export default class Entity {
     };
   }
 
-  static of(value) {
+  static fromJSON(value) {
     const { v, type, id, data } = value;
     return new Entity(v, type, id, data);
   }

--- a/graylog2-web-interface/src/logic/content-packs/Entity.jsx
+++ b/graylog2-web-interface/src/logic/content-packs/Entity.jsx
@@ -1,0 +1,116 @@
+import { Map } from 'immutable';
+
+export default class Entity {
+  constructor(v, type, id, data) {
+    this._value = {
+      v,
+      type,
+      id,
+      data,
+    };
+  }
+
+  static of(value) {
+    const { v, type, id, data } = value;
+    return new Entity(v, type, id, data);
+  }
+
+  get v() {
+    return this._value.v;
+  }
+
+  get type() {
+    return this._value.type;
+  }
+
+  get id() {
+    return this._value.id;
+  }
+
+  get data() {
+    return this._value.data;
+  }
+
+  get title() {
+    const { data } = this._value;
+    return (data.title || data.name || {}).value || '';
+  }
+
+  get description() {
+    const { data } = this._value;
+    return (data.description || {}).value || '';
+  }
+
+  toBuilder() {
+    const {
+      v,
+      type,
+      id,
+      data,
+    } = this._value;
+    /* eslint-disable-next-line no-use-before-define */
+    return new Builder(Map({
+      v,
+      type,
+      id,
+      data,
+    }));
+  }
+
+
+  static builder() {
+    /* eslint-disable-next-line no-use-before-define */
+    return new Builder();
+  }
+
+  toJSON() {
+    const {
+      v,
+      type,
+      id,
+      data,
+    } = this._value;
+    return {
+      v,
+      type,
+      id,
+      data,
+    };
+  }
+}
+
+class Builder {
+  constructor(value = Map()) {
+    this.value = value;
+  }
+
+  v(value) {
+    this.value = this.value.set('v', value);
+    return this;
+  }
+
+  type(value) {
+    this.value = this.value.set('type', value);
+    return this;
+  }
+
+  id(value) {
+    this.value = this.value.set('id', value);
+    return this;
+  }
+
+  data(value) {
+    this.value = this.value.set('data', value);
+    return this;
+  }
+
+  build() {
+    const {
+      v,
+      type,
+      id,
+      data,
+    } = this.value.toObject();
+    return new Entity(v, type, id, data);
+  }
+}

--- a/graylog2-web-interface/src/logic/content-packs/EntityIndex.js
+++ b/graylog2-web-interface/src/logic/content-packs/EntityIndex.js
@@ -1,0 +1,66 @@
+import Immutable from 'immutable';
+
+export default class EntityIndex {
+  constructor(id, title, type) {
+    this._value = { id, title, type };
+  }
+
+  get id() {
+    return this._value.id;
+  }
+
+  get type() {
+    return this._value.type;
+  }
+
+  get title() {
+    return this._value.title;
+  }
+
+  toBuilder() {
+    const { id, title, type } = this._value;
+    // eslint-disable-next-line no-use-before-define
+    return new Builder(Immutable.Map({ id, title, type }));
+  }
+
+  static create(id, title, type) {
+    return new EntityIndex(id, title, type);
+  }
+
+  toJSON() {
+    const { id, type } = this._value;
+
+    return {
+      id,
+      type,
+    };
+  }
+
+  static fromJSON(value) {
+    const { id, title, type } = value;
+    return EntityIndex.create(id, title, type);
+  }
+}
+
+class Builder {
+  constructor(value = Immutable.Map()) {
+    this.value = value;
+  }
+
+  id(value) {
+    return new Builder(this.value.set('id', value));
+  }
+
+  title(value) {
+    return new Builder(this.value.set('title', value));
+  }
+
+  type(value) {
+    return new Builder(this.value.set('type', value));
+  }
+
+  build() {
+    const { id, title, type } = this.value.toObject();
+    return new EntityIndex(id, title, type);
+  }
+}

--- a/graylog2-web-interface/src/pages/CreateContentPackPage.jsx
+++ b/graylog2-web-interface/src/pages/CreateContentPackPage.jsx
@@ -12,7 +12,7 @@ import { DocumentTitle, PageHeader } from 'components/common';
 import CombinedProvider from 'injection/CombinedProvider';
 import ContentPackEdit from 'components/content-packs/ContentPackEdit';
 import ContentPack from 'logic/content-packs/ContentPack';
-import Entity from "../logic/content-packs/Entity";
+import Entity from 'logic/content-packs/Entity';
 
 
 const { ContentPacksActions } = CombinedProvider.get('ContentPacks');

--- a/graylog2-web-interface/src/pages/CreateContentPackPage.jsx
+++ b/graylog2-web-interface/src/pages/CreateContentPackPage.jsx
@@ -12,6 +12,8 @@ import { DocumentTitle, PageHeader } from 'components/common';
 import CombinedProvider from 'injection/CombinedProvider';
 import ContentPackEdit from 'components/content-packs/ContentPackEdit';
 import ContentPack from 'logic/content-packs/ContentPack';
+import Entity from "../logic/content-packs/Entity";
+
 
 const { ContentPacksActions } = CombinedProvider.get('ContentPacks');
 const { CatalogActions, CatalogStore } = CombinedProvider.get('Catalog');
@@ -55,7 +57,7 @@ const CreateContentPackPage = createReactClass({
   },
 
   _onSave() {
-    ContentPacksActions.create.triggerPromise(this.state.contentPack.toObject())
+    ContentPacksActions.create.triggerPromise(this.state.contentPack.toJSON())
       .then(
         () => {
           UserNotification.success('Content pack imported successfully', 'Success!');
@@ -79,7 +81,8 @@ const CreateContentPackPage = createReactClass({
         .entities(result.entities)
         .requires(result.constraints)
         .build();
-      this.setState({ contentPack: newContentPack, fetchedEntities: result.entities });
+      const fetchedEntities = result.entities.map(e => Entity.fromJSON(e));
+      this.setState({ contentPack: newContentPack, fetchedEntities });
     });
   },
 

--- a/graylog2-web-interface/src/pages/EditContentPackPage.jsx
+++ b/graylog2-web-interface/src/pages/EditContentPackPage.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import Reflux from 'reflux';
 import createReactClass from 'create-react-class';
+import { cloneDeep, groupBy } from 'lodash';
 
 import Routes from 'routing/Routes';
 import { Button } from 'react-bootstrap';
@@ -32,7 +33,9 @@ const EditContentPackPage = createReactClass({
     return {
       selectedEntities: {},
       selectedStep: undefined,
+      contentPackEntities: undefined,
       appliedParameter: {},
+      entityCatalog: {},
     };
   },
 
@@ -40,13 +43,28 @@ const EditContentPackPage = createReactClass({
     ContentPacksActions.get(this.props.params.contentPackId).then(() => {
       const originContentPackRev = this.props.params.contentPackRev;
       const newContentPack = this.state.contentPackRevisions.createNewVersionFromRev(originContentPackRev);
-      this.setState({ contentPack: newContentPack });
+      this.setState({ contentPack: newContentPack, contentPackEntities: cloneDeep(newContentPack.entities) });
 
       CatalogActions.showEntityIndex().then(() => {
+        this._createEntityCatalog();
         this._getSelectedEntities();
         this._getAppliedParameter();
       });
     });
+  },
+
+  _createEntityCatalog() {
+    if (!this.state.contentPack || !this.state.entityIndex) {
+      return;
+    }
+    const groupedContentPackEntities = groupBy(this.state.contentPackEntities, 'type.name');
+    const entityCatalog = Object.keys(this.state.entityIndex)
+      .reduce((result, entityType) => {
+        /* eslint-disable-next-line no-param-reassign */
+        result[entityType] = this.state.entityIndex[entityType].concat(groupedContentPackEntities[entityType] || []);
+        return result;
+      }, {});
+    this.setState({ entityCatalog });
   },
 
   _getSelectedEntities() {
@@ -54,12 +72,11 @@ const EditContentPackPage = createReactClass({
       return;
     }
     const selectedEntities = this.state.contentPack.entities.reduce((result, entity) => {
-      if (this.state.entityIndex[entity.type.name] &&
-        this.state.entityIndex[entity.type.name].findIndex((fetchedEntity) => { return fetchedEntity.id === entity.id; }) >= 0) {
+      if (this.state.entityCatalog[entity.type.name] &&
+        this.state.entityCatalog[entity.type.name].findIndex((fetchedEntity) => { return fetchedEntity.id === entity.id; }) >= 0) {
         const newResult = result;
-        const selectedEntity = { type: entity.type, id: entity.id };
         newResult[entity.type.name] = result[entity.type.name] || [];
-        newResult[entity.type.name].push(selectedEntity);
+        newResult[entity.type.name].push(entity);
         return newResult;
       }
       return result;
@@ -119,11 +136,17 @@ const EditContentPackPage = createReactClass({
 
   _getEntities(selectedEntities) {
     CatalogActions.getSelectedEntities(selectedEntities).then((result) => {
+      const contentPackEntities = Object.keys(selectedEntities)
+        .reduce((acc, entityType) => {
+          return acc.concat(selectedEntities[entityType]);
+        }, []).filter(e => e.constructor.name === Entity.name);
+      const entities = contentPackEntities.concat(result.entities);
       const contentPack = this.state.contentPack.toBuilder()
-        .entities(result.entities)
+        .entities(entities)
+        /* TODO: graylog2-server#5335 */
         .requires(result.constraints)
         .build();
-      const fetchedEntities = result.entities.map(e => Entity.of(e));
+      const fetchedEntities = result.entities.map(e => Entity.fromJSON(e));
       this.setState({ contentPack: contentPack, fetchedEntities });
     });
   },
@@ -153,7 +176,7 @@ const EditContentPackPage = createReactClass({
                            onStateChange={this._onStateChanged}
                            fetchedEntities={this.state.fetchedEntities}
                            selectedEntities={this.state.selectedEntities}
-                           entityIndex={this.state.entityIndex}
+                           entityIndex={this.state.entityCatalog}
                            appliedParameter={this.state.appliedParameter}
                            onSave={this._onSave}
           />

--- a/graylog2-web-interface/src/pages/EditContentPackPage.jsx
+++ b/graylog2-web-interface/src/pages/EditContentPackPage.jsx
@@ -14,6 +14,8 @@ import CombinedProvider from 'injection/CombinedProvider';
 import ObjectUtils from 'util/ObjectUtils';
 import ContentPackEdit from 'components/content-packs/ContentPackEdit';
 
+import Entity from 'logic/content-packs/Entity';
+
 const { CatalogActions, CatalogStore } = CombinedProvider.get('Catalog');
 const { ContentPacksActions, ContentPacksStore } = CombinedProvider.get('ContentPacks');
 
@@ -121,7 +123,8 @@ const EditContentPackPage = createReactClass({
         .entities(result.entities)
         .requires(result.constraints)
         .build();
-      this.setState({ contentPack: contentPack, fetchedEntities: result.entities });
+      const fetchedEntities = result.entities.map(e => Entity.of(e));
+      this.setState({ contentPack: contentPack, fetchedEntities });
     });
   },
 

--- a/graylog2-web-interface/src/pages/EditContentPackPage.jsx
+++ b/graylog2-web-interface/src/pages/EditContentPackPage.jsx
@@ -146,8 +146,7 @@ const EditContentPackPage = createReactClass({
         /* TODO: graylog2-server#5335 */
         .requires(result.constraints)
         .build();
-      const fetchedEntities = result.entities.map(e => Entity.fromJSON(e));
-      this.setState({ contentPack: contentPack, fetchedEntities });
+      this.setState({ contentPack: contentPack, fetchedEntities: contentPack.entities });
     });
   },
 

--- a/graylog2-web-interface/src/pages/EditContentPackPage.jsx
+++ b/graylog2-web-interface/src/pages/EditContentPackPage.jsx
@@ -116,7 +116,7 @@ const EditContentPackPage = createReactClass({
   },
 
   _onSave() {
-    ContentPacksActions.create.triggerPromise(this.state.contentPack.toObject())
+    ContentPacksActions.create.triggerPromise(this.state.contentPack.toJSON())
       .then(
         () => {
           UserNotification.success('Content pack imported successfully', 'Success!');

--- a/graylog2-web-interface/src/pages/EditContentPackPage.jsx
+++ b/graylog2-web-interface/src/pages/EditContentPackPage.jsx
@@ -177,6 +177,7 @@ const EditContentPackPage = createReactClass({
                            selectedEntities={this.state.selectedEntities}
                            entityIndex={this.state.entityCatalog}
                            appliedParameter={this.state.appliedParameter}
+                           edit
                            onSave={this._onSave}
           />
         </span>


### PR DESCRIPTION
## Description
When selecting the entities for a new version of a content pack, we now offer the previous entities of the
content pack. That way a user can modify the original content pack without having the original entities on his system.

When creating a new version of the content pack the user sees now icons behind the entities to distinguish between entities from the server (blue) and original entities from the content pack.

## Motivation and Context
Before when editing a content pack you needed the original entities on your system other wise the
selection would not work, since Graylog could not find them in the database. 

## How Has This Been Tested?
Created a new content pack, and created a new version for it.

## Screenshots (if appropriate):
![graylog - content packs 1](https://user-images.githubusercontent.com/448763/49650714-79477a80-fa2d-11e8-9103-65aff5031e3e.png)


## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
