### PR TITLE
clarify definition of `web_endpoint_uri`

### DIFF
--- a/misc/graylog.conf
+++ b/misc/graylog.conf
@@ -131,7 +131,7 @@ rest_listen_uri = http://127.0.0.1:9000/api/
 # for the application.context configuration parameter in pre-2.0 versions of the Graylog web interface.
 #web_listen_uri = http://127.0.0.1:9000/
 
-# Web interface endpoint URI. This setting can be overriden on a per-request basis with the X-Graylog-Server-URL header.
+# Web interface REST endpoint URI. Used by browsers to receive steams. This setting can be overriden on a per-request basis with the X-Graylog-Server-URL header.
 # Default: $rest_transport_uri
 #web_endpoint_uri =
 

--- a/misc/graylog.conf
+++ b/misc/graylog.conf
@@ -131,7 +131,7 @@ rest_listen_uri = http://127.0.0.1:9000/api/
 # for the application.context configuration parameter in pre-2.0 versions of the Graylog web interface.
 #web_listen_uri = http://127.0.0.1:9000/
 
-# Web interface REST endpoint URI. Used by browsers to receive steams. This setting can be overriden on a per-request basis with the X-Graylog-Server-URL header.
+# Web interface REST endpoint URI. Must be reachable from the user's browser. This setting can be overriden on a per-request basis with the X-Graylog-Server-URL header.
 # Default: $rest_transport_uri
 #web_endpoint_uri =
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Definition provided in context of web endpoint is vague as REST is not clarified.
<!--- Describe your changes in detail -->

<!--- Why is this change required? What problem does it solve? -->
We spent way too long chasing `rest_transport_uri` and `rest_listen_uri` as solutions to what controlled what was promoted into the browser for REST calls. Searching "REST" in the config misses `web_endpoint_uri`.
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
