### PR TITLE
Create random ids for Entities in Content Packs

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/contentpacks/facades/DashboardFacade.java
+++ b/graylog2-server/src/main/java/org/graylog2/contentpacks/facades/DashboardFacade.java
@@ -105,7 +105,6 @@ public class DashboardFacade implements EntityFacade<Dashboard> {
                 dashboardWidgets);
         final JsonNode data = objectMapper.convertValue(dashboardEntity, JsonNode.class);
         final EntityV1 entity = EntityV1.builder()
-                .id(ModelId.of(dashboard.getId()))
                 .type(ModelTypes.DASHBOARD_V1)
                 .data(data)
                 .build();

--- a/graylog2-server/src/main/java/org/graylog2/contentpacks/facades/GrokPatternFacade.java
+++ b/graylog2-server/src/main/java/org/graylog2/contentpacks/facades/GrokPatternFacade.java
@@ -72,7 +72,6 @@ public class GrokPatternFacade implements EntityFacade<GrokPattern> {
                 ValueReference.of(grokPattern.pattern()));
         final JsonNode data = objectMapper.convertValue(grokPatternEntity, JsonNode.class);
         final EntityV1 entity = EntityV1.builder()
-                .id(ModelId.of(grokPattern.id()))
                 .type(ModelTypes.GROK_PATTERN_V1)
                 .data(data)
                 .build();

--- a/graylog2-server/src/main/java/org/graylog2/contentpacks/facades/InputFacade.java
+++ b/graylog2-server/src/main/java/org/graylog2/contentpacks/facades/InputFacade.java
@@ -129,7 +129,6 @@ public class InputFacade implements EntityFacade<InputWithExtractors> {
                 extractors);
         final JsonNode data = objectMapper.convertValue(inputEntity, JsonNode.class);
         final EntityV1 entity = EntityV1.builder()
-                .id(ModelId.of(input.getId()))
                 .type(ModelTypes.INPUT_V1)
                 .data(data)
                 .build();

--- a/graylog2-server/src/main/java/org/graylog2/contentpacks/facades/LookupCacheFacade.java
+++ b/graylog2-server/src/main/java/org/graylog2/contentpacks/facades/LookupCacheFacade.java
@@ -74,7 +74,6 @@ public class LookupCacheFacade implements EntityFacade<CacheDto> {
                 toReferenceMap(configuration));
         final JsonNode data = objectMapper.convertValue(lookupCacheEntity, JsonNode.class);
         final EntityV1 entity = EntityV1.builder()
-                .id(ModelId.of(cacheDto.id()))
                 .type(ModelTypes.LOOKUP_CACHE_V1)
                 .data(data)
                 .build();

--- a/graylog2-server/src/main/java/org/graylog2/contentpacks/facades/LookupDataAdapterFacade.java
+++ b/graylog2-server/src/main/java/org/graylog2/contentpacks/facades/LookupDataAdapterFacade.java
@@ -74,7 +74,6 @@ public class LookupDataAdapterFacade implements EntityFacade<DataAdapterDto> {
                 toReferenceMap(configuration));
         final JsonNode data = objectMapper.convertValue(lookupDataAdapterEntity, JsonNode.class);
         final EntityV1 entity = EntityV1.builder()
-                .id(ModelId.of(dataAdapterDto.id()))
                 .type(ModelTypes.LOOKUP_ADAPTER_V1)
                 .data(data)
                 .build();

--- a/graylog2-server/src/main/java/org/graylog2/contentpacks/facades/LookupTableFacade.java
+++ b/graylog2-server/src/main/java/org/graylog2/contentpacks/facades/LookupTableFacade.java
@@ -77,7 +77,6 @@ public class LookupTableFacade implements EntityFacade<LookupTableDto> {
                 ValueReference.of(lookupTableDto.defaultMultiValueType()));
         final JsonNode data = objectMapper.convertValue(lookupTableEntity, JsonNode.class);
         final EntityV1 entity = EntityV1.builder()
-                .id(ModelId.of(lookupTableDto.id()))
                 .type(ModelTypes.LOOKUP_TABLE_V1)
                 .data(data)
                 .build();

--- a/graylog2-server/src/main/java/org/graylog2/contentpacks/facades/OutputFacade.java
+++ b/graylog2-server/src/main/java/org/graylog2/contentpacks/facades/OutputFacade.java
@@ -82,7 +82,6 @@ public class OutputFacade implements EntityFacade<Output> {
         );
         final JsonNode data = objectMapper.convertValue(outputEntity, JsonNode.class);
         final EntityV1 entity = EntityV1.builder()
-                .id(ModelId.of(output.getId()))
                 .type(ModelTypes.OUTPUT_V1)
                 .data(data)
                 .build();

--- a/graylog2-server/src/main/java/org/graylog2/contentpacks/facades/PipelineFacade.java
+++ b/graylog2-server/src/main/java/org/graylog2/contentpacks/facades/PipelineFacade.java
@@ -92,7 +92,6 @@ public class PipelineFacade implements EntityFacade<PipelineDao> {
                 connectedStreams);
         final JsonNode data = objectMapper.convertValue(pipelineEntity, JsonNode.class);
         final EntityV1 entity = EntityV1.builder()
-                .id(ModelId.of(pipelineDao.title()))
                 .type(ModelTypes.PIPELINE_V1)
                 .data(data)
                 .build();

--- a/graylog2-server/src/main/java/org/graylog2/contentpacks/facades/PipelineRuleFacade.java
+++ b/graylog2-server/src/main/java/org/graylog2/contentpacks/facades/PipelineRuleFacade.java
@@ -67,7 +67,6 @@ public class PipelineRuleFacade implements EntityFacade<RuleDao> {
                 ValueReference.of(ruleDao.source()));
         final JsonNode data = objectMapper.convertValue(ruleEntity, JsonNode.class);
         final EntityV1 entity = EntityV1.builder()
-                .id(ModelId.of(ruleDao.title()))
                 .type(ModelTypes.PIPELINE_RULE_V1)
                 .data(data)
                 .build();

--- a/graylog2-server/src/main/java/org/graylog2/contentpacks/facades/SidecarCollectorConfigurationFacade.java
+++ b/graylog2-server/src/main/java/org/graylog2/contentpacks/facades/SidecarCollectorConfigurationFacade.java
@@ -70,7 +70,6 @@ public class SidecarCollectorConfigurationFacade implements EntityFacade<Configu
                 ValueReference.of(configuration.template()));
         final JsonNode data = objectMapper.convertValue(configurationEntity, JsonNode.class);
         final EntityV1 entity = EntityV1.builder()
-                .id(ModelId.of(configuration.id()))
                 .type(TYPE_V1)
                 .data(data)
                 .build();

--- a/graylog2-server/src/main/java/org/graylog2/contentpacks/facades/SidecarCollectorFacade.java
+++ b/graylog2-server/src/main/java/org/graylog2/contentpacks/facades/SidecarCollectorFacade.java
@@ -72,7 +72,6 @@ public class SidecarCollectorFacade implements EntityFacade<Collector> {
 
         final JsonNode data = objectMapper.convertValue(collectorEntity, JsonNode.class);
         final EntityV1 entity = EntityV1.builder()
-                .id(ModelId.of(collector.id()))
                 .type(TYPE_V1)
                 .data(data)
                 .build();

--- a/graylog2-server/src/main/java/org/graylog2/contentpacks/facades/StreamFacade.java
+++ b/graylog2-server/src/main/java/org/graylog2/contentpacks/facades/StreamFacade.java
@@ -102,7 +102,6 @@ public class StreamFacade implements EntityFacade<Stream> {
 
         final JsonNode data = objectMapper.convertValue(streamEntity, JsonNode.class);
         final EntityV1 entity = EntityV1.builder()
-                .id(ModelId.of(stream.getId()))
                 .type(ModelTypes.STREAM_V1)
                 .data(data)
                 .build();

--- a/graylog2-server/src/main/java/org/graylog2/contentpacks/model/ModelId.java
+++ b/graylog2-server/src/main/java/org/graylog2/contentpacks/model/ModelId.java
@@ -22,7 +22,6 @@ import com.google.auto.value.AutoValue;
 import com.google.common.base.Preconditions;
 import org.apache.commons.lang.StringUtils;
 
-import java.util.UUID;
 
 @AutoValue
 public abstract class ModelId {

--- a/graylog2-server/src/main/java/org/graylog2/contentpacks/model/entities/EntityV1.java
+++ b/graylog2-server/src/main/java/org/graylog2/contentpacks/model/entities/EntityV1.java
@@ -48,7 +48,8 @@ public abstract class EntityV1 implements Entity {
     }
 
     public static Builder builder() {
-        return new AutoValue_EntityV1.Builder();
+        return new AutoValue_EntityV1.Builder()
+            .id(ModelId.of(UUID.randomUUID().toString()));
     }
 
     public static Entity createRoot(ContentPack contentPack) {
@@ -68,7 +69,6 @@ public abstract class EntityV1 implements Entity {
 
         public EntityV1 build() {
             version(ModelVersion.of(VERSION));
-            id(ModelId.of(UUID.randomUUID().toString()));
             return autoBuild();
         }
     }

--- a/graylog2-server/src/main/java/org/graylog2/contentpacks/model/entities/EntityV1.java
+++ b/graylog2-server/src/main/java/org/graylog2/contentpacks/model/entities/EntityV1.java
@@ -26,6 +26,7 @@ import org.graylog2.contentpacks.model.ContentPack;
 import org.graylog2.contentpacks.model.ModelId;
 import org.graylog2.contentpacks.model.ModelTypes;
 import org.graylog2.contentpacks.model.ModelVersion;
+import java.util.UUID;
 
 @AutoValue
 @JsonAutoDetect
@@ -67,6 +68,7 @@ public abstract class EntityV1 implements Entity {
 
         public EntityV1 build() {
             version(ModelVersion.of(VERSION));
+            id(ModelId.of(UUID.randomUUID().toString()));
             return autoBuild();
         }
     }

--- a/graylog2-server/src/test/java/org/graylog2/contentpacks/facades/DashboardFacadeTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/contentpacks/facades/DashboardFacadeTest.java
@@ -141,7 +141,7 @@ public class DashboardFacadeTest {
         final Entity entity = entityWithConstraints.entity();
 
         assertThat(entity).isInstanceOf(EntityV1.class);
-        assertThat(entity.id()).isEqualTo(ModelId.of(dashboard.getId()));
+        assertThat(entity.id()).isNotNull();
         assertThat(entity.type()).isEqualTo(ModelTypes.DASHBOARD_V1);
 
         final EntityV1 entityV1 = (EntityV1) entity;
@@ -177,7 +177,7 @@ public class DashboardFacadeTest {
         final Entity entity = entityWithConstraints.orElseThrow(AssertionError::new).entity();
 
         assertThat(entity).isInstanceOf(EntityV1.class);
-        assertThat(entity.id()).isEqualTo(ModelId.of("5a82f5974b900a7a97caa1e5"));
+        assertThat(entity.id()).isNotNull();
         assertThat(entity.type()).isEqualTo(ModelTypes.DASHBOARD_V1);
 
         final EntityV1 entityV1 = (EntityV1) entity;
@@ -229,7 +229,7 @@ public class DashboardFacadeTest {
                 .containsInstanceOf(EntityV1.class);
 
         final EntityV1 entity = (EntityV1) collectedEntity.map(EntityWithConstraints::entity).orElseThrow(AssertionError::new);
-        assertThat(entity.id()).isEqualTo(ModelId.of("5a82f5974b900a7a97caa1e5"));
+        assertThat(entity.id()).isNotNull();
         assertThat(entity.type()).isEqualTo(ModelTypes.DASHBOARD_V1);
         final DashboardEntity dashboardEntity = objectMapper.convertValue(entity.data(), DashboardEntity.class);
         assertThat(dashboardEntity.title()).isEqualTo(ValueReference.of("Test"));

--- a/graylog2-server/src/test/java/org/graylog2/contentpacks/facades/GrokPatternFacadeTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/contentpacks/facades/GrokPatternFacadeTest.java
@@ -74,7 +74,7 @@ public class GrokPatternFacadeTest {
         final Entity entity = entityWithConstraints.entity();
 
         assertThat(entity).isInstanceOf(EntityV1.class);
-        assertThat(entity.id()).isEqualTo(ModelId.of("01234567890"));
+        assertThat(entity.id()).isNotNull();
         assertThat(entity.type()).isEqualTo(ModelTypes.GROK_PATTERN_V1);
 
         final EntityV1 entityV1 = (EntityV1) entity;
@@ -124,17 +124,13 @@ public class GrokPatternFacadeTest {
                 "name", ValueReference.of("Test1"),
                 "pattern", ValueReference.of("[a-z]+"));
         final JsonNode entityData = objectMapper.convertValue(entity, JsonNode.class);
-        final Entity expectedEntity = EntityV1.builder()
-                .type(ModelTypes.GROK_PATTERN_V1)
-                .id(ModelId.of("1"))
-                .data(entityData)
-                .build();
 
         final Optional<EntityWithConstraints> collectedEntity = facade.exportEntity(EntityDescriptor.create("1", ModelTypes.GROK_PATTERN_V1));
         assertThat(collectedEntity)
-                .isPresent()
-                .map(EntityWithConstraints::entity)
-                .contains(expectedEntity);
+                .isPresent();
+        final EntityV1 entityV1 = (EntityV1) collectedEntity.get().entity();
+        assertThat(entityV1.type()).isEqualTo(ModelTypes.GROK_PATTERN_V1);
+        assertThat(entityV1.data()).isEqualTo(entityData);
     }
 
     @Test
@@ -190,7 +186,9 @@ public class GrokPatternFacadeTest {
         final GrokPattern expectedGrokPattern = GrokPattern.create("1", "Test", "[a-z]+", null);
         final NativeEntityDescriptor expectedDescriptor = NativeEntityDescriptor.create("1", "1", ModelTypes.GROK_PATTERN_V1, "Test");
 
-        assertThat(nativeEntity.descriptor()).isEqualTo(expectedDescriptor);
+        assertThat(nativeEntity.descriptor().title()).isEqualTo(expectedDescriptor.title());
+        assertThat(nativeEntity.descriptor().type()).isEqualTo(expectedDescriptor.type());
+
         assertThat(nativeEntity.entity()).isEqualTo(expectedGrokPattern);
         assertThat(grokPatternService.load("1")).isEqualTo(expectedGrokPattern);
     }

--- a/graylog2-server/src/test/java/org/graylog2/contentpacks/facades/InputFacadeTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/contentpacks/facades/InputFacadeTest.java
@@ -155,7 +155,7 @@ public class InputFacadeTest {
         final Entity entity = entityWithConstraints.entity();
 
         assertThat(entity).isInstanceOf(EntityV1.class);
-        assertThat(entity.id()).isEqualTo(ModelId.of(input.getId()));
+        assertThat(entity.id()).isNotNull();
         assertThat(entity.type()).isEqualTo(ModelTypes.INPUT_V1);
 
         final EntityV1 entityV1 = (EntityV1) entity;
@@ -174,7 +174,7 @@ public class InputFacadeTest {
         final Entity entity = entityWithConstraints.entity();
 
         assertThat(entity).isInstanceOf(EntityV1.class);
-        assertThat(entity.id()).isEqualTo(id);
+        assertThat(entity.id()).isNotNull();
         assertThat(entity.type()).isEqualTo(ModelTypes.INPUT_V1);
 
         final EntityV1 entityV1 = (EntityV1) entity;
@@ -264,7 +264,7 @@ public class InputFacadeTest {
                 .containsInstanceOf(EntityV1.class);
 
         final EntityV1 entity = (EntityV1) collectedEntity.map(EntityWithConstraints::entity).orElseThrow(AssertionError::new);
-        assertThat(entity.id()).isEqualTo(ModelId.of("5adf25294b900a0fdb4e5365"));
+        assertThat(entity.id()).isNotNull();
         assertThat(entity.type()).isEqualTo(ModelTypes.INPUT_V1);
         final InputEntity inputEntity = objectMapper.convertValue(entity.data(), InputEntity.class);
         assertThat(inputEntity.title()).isEqualTo(ValueReference.of("Global Random HTTP"));

--- a/graylog2-server/src/test/java/org/graylog2/contentpacks/facades/LookupCacheFacadeTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/contentpacks/facades/LookupCacheFacadeTest.java
@@ -97,7 +97,7 @@ public class LookupCacheFacadeTest {
         final Entity entity = entityWithConstraints.entity();
 
         assertThat(entity).isInstanceOf(EntityV1.class);
-        assertThat(entity.id()).isEqualTo(ModelId.of("1234567890"));
+        assertThat(entity.id()).isNotNull();
         assertThat(entity.type()).isEqualTo(ModelTypes.LOOKUP_CACHE_V1);
 
         final EntityV1 entityV1 = (EntityV1) entity;
@@ -116,7 +116,7 @@ public class LookupCacheFacadeTest {
         final Entity entity = entityWithConstraints.entity();
 
         assertThat(entity).isInstanceOf(EntityV1.class);
-        assertThat(entity.id()).isEqualTo(ModelId.of("5adf24b24b900a0fdb4e52dd"));
+        assertThat(entity.id()).isNotNull();
         assertThat(entity.type()).isEqualTo(ModelTypes.LOOKUP_CACHE_V1);
 
         final EntityV1 entityV1 = (EntityV1) entity;
@@ -281,7 +281,7 @@ public class LookupCacheFacadeTest {
                 .containsInstanceOf(EntityV1.class);
 
         final EntityV1 entity = (EntityV1) collectedEntity.map(EntityWithConstraints::entity).orElseThrow(AssertionError::new);
-        assertThat(entity.id()).isEqualTo(ModelId.of("5adf24b24b900a0fdb4e52dd"));
+        assertThat(entity.id()).isNotNull();
         assertThat(entity.type()).isEqualTo(ModelTypes.LOOKUP_CACHE_V1);
         final LookupCacheEntity lookupCacheEntity = objectMapper.convertValue(entity.data(), LookupCacheEntity.class);
         assertThat(lookupCacheEntity.name()).isEqualTo(ValueReference.of("no-op-cache"));

--- a/graylog2-server/src/test/java/org/graylog2/contentpacks/facades/LookupDataAdapterFacadeTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/contentpacks/facades/LookupDataAdapterFacadeTest.java
@@ -95,7 +95,7 @@ public class LookupDataAdapterFacadeTest {
         final Entity entity = entityWithConstraints.entity();
 
         assertThat(entity).isInstanceOf(EntityV1.class);
-        assertThat(entity.id()).isEqualTo(ModelId.of("1234567890"));
+        assertThat(entity.id()).isNotNull();
         assertThat(entity.type()).isEqualTo(ModelTypes.LOOKUP_ADAPTER_V1);
 
         final EntityV1 entityV1 = (EntityV1) entity;
@@ -114,7 +114,7 @@ public class LookupDataAdapterFacadeTest {
         final Entity entity = entityWithConstraints.entity();
 
         assertThat(entity).isInstanceOf(EntityV1.class);
-        assertThat(entity.id()).isEqualTo(ModelId.of("5adf24a04b900a0fdb4e52c8"));
+        assertThat(entity.id()).isNotNull();
         assertThat(entity.type()).isEqualTo(ModelTypes.LOOKUP_ADAPTER_V1);
 
         final EntityV1 entityV1 = (EntityV1) entity;
@@ -266,7 +266,7 @@ public class LookupDataAdapterFacadeTest {
                 .containsInstanceOf(EntityV1.class);
 
         final EntityV1 entity = (EntityV1) collectedEntity.map(EntityWithConstraints::entity).orElseThrow(AssertionError::new);
-        assertThat(entity.id()).isEqualTo(ModelId.of("5adf24a04b900a0fdb4e52c8"));
+        assertThat(entity.id()).isNotNull();
         assertThat(entity.type()).isEqualTo(ModelTypes.LOOKUP_ADAPTER_V1);
         final LookupDataAdapterEntity lookupDataAdapterEntity = objectMapper.convertValue(entity.data(), LookupDataAdapterEntity.class);
         assertThat(lookupDataAdapterEntity.name()).isEqualTo(ValueReference.of("http-dsv"));

--- a/graylog2-server/src/test/java/org/graylog2/contentpacks/facades/LookupTableFacadeTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/contentpacks/facades/LookupTableFacadeTest.java
@@ -104,7 +104,7 @@ public class LookupTableFacadeTest {
         final Entity entity = entityWithConstraints.entity();
 
         assertThat(entity).isInstanceOf(EntityV1.class);
-        assertThat(entity.id()).isEqualTo(ModelId.of("1234567890"));
+        assertThat(entity.id()).isNotNull();
         assertThat(entity.type()).isEqualTo(ModelTypes.LOOKUP_TABLE_V1);
 
         final EntityV1 entityV1 = (EntityV1) entity;
@@ -128,7 +128,7 @@ public class LookupTableFacadeTest {
         final Entity entity = entityWithConstraints.entity();
 
         assertThat(entity).isInstanceOf(EntityV1.class);
-        assertThat(entity.id()).isEqualTo(ModelId.of("5adf24dd4b900a0fdb4e530d"));
+        assertThat(entity.id()).isNotNull();
         assertThat(entity.type()).isEqualTo(ModelTypes.LOOKUP_TABLE_V1);
 
         final EntityV1 entityV1 = (EntityV1) entity;
@@ -369,7 +369,7 @@ public class LookupTableFacadeTest {
                 .containsInstanceOf(EntityV1.class);
 
         final EntityV1 entity = (EntityV1) collectedEntity.map(EntityWithConstraints::entity).orElseThrow(AssertionError::new);
-        assertThat(entity.id()).isEqualTo(ModelId.of("5adf24dd4b900a0fdb4e530d"));
+        assertThat(entity.id()).isNotNull();
         assertThat(entity.type()).isEqualTo(ModelTypes.LOOKUP_TABLE_V1);
         final LookupTableEntity lookupTableEntity = objectMapper.convertValue(entity.data(), LookupTableEntity.class);
         assertThat(lookupTableEntity.name()).isEqualTo(ValueReference.of("http-dsv-no-cache"));

--- a/graylog2-server/src/test/java/org/graylog2/contentpacks/facades/OutputFacadeTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/contentpacks/facades/OutputFacadeTest.java
@@ -121,7 +121,7 @@ public class OutputFacadeTest {
         final Entity entity = entityWithConstraints.entity();
 
         assertThat(entity).isInstanceOf(EntityV1.class);
-        assertThat(entity.id()).isEqualTo(ModelId.of("01234567890"));
+        assertThat(entity.id()).isNotNull();
         assertThat(entity.type()).isEqualTo(ModelTypes.OUTPUT_V1);
 
         final EntityV1 entityV1 = (EntityV1) entity;
@@ -140,7 +140,7 @@ public class OutputFacadeTest {
         final Entity entity = entityWithConstraints.entity();
 
         assertThat(entity).isInstanceOf(EntityV1.class);
-        assertThat(entity.id()).isEqualTo(ModelId.of("5adf239e4b900a0fdb4e5197"));
+        assertThat(entity.id()).isNotNull();
         assertThat(entity.type()).isEqualTo(ModelTypes.OUTPUT_V1);
 
         final EntityV1 entityV1 = (EntityV1) entity;
@@ -265,7 +265,7 @@ public class OutputFacadeTest {
                 .containsInstanceOf(EntityV1.class);
 
         final EntityV1 entity = (EntityV1) collectedEntity.map(EntityWithConstraints::entity).orElseThrow(AssertionError::new);
-        assertThat(entity.id()).isEqualTo(ModelId.of("5adf239e4b900a0fdb4e5197"));
+        assertThat(entity.id()).isNotNull();
         assertThat(entity.type()).isEqualTo(ModelTypes.OUTPUT_V1);
         final OutputEntity outputEntity = objectMapper.convertValue(entity.data(), OutputEntity.class);
         assertThat(outputEntity.title()).isEqualTo(ValueReference.of("STDOUT"));

--- a/graylog2-server/src/test/java/org/graylog2/contentpacks/facades/PipelineFacadeTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/contentpacks/facades/PipelineFacadeTest.java
@@ -121,7 +121,7 @@ public class PipelineFacadeTest {
         final Entity entity = entityWithConstraints.entity();
 
         assertThat(entity).isInstanceOf(EntityV1.class);
-        assertThat(entity.id()).isEqualTo(ModelId.of("title"));
+        assertThat(entity.id()).isNotNull();
         assertThat(entity.type()).isEqualTo(ModelTypes.PIPELINE_V1);
 
         final EntityV1 entityV1 = (EntityV1) entity;
@@ -140,7 +140,7 @@ public class PipelineFacadeTest {
         final Entity entity = entityWithConstraints.entity();
 
         assertThat(entity).isInstanceOf(EntityV1.class);
-        assertThat(entity.id()).isEqualTo(ModelId.of("Test"));
+        assertThat(entity.id()).isNotNull();
         assertThat(entity.type()).isEqualTo(ModelTypes.PIPELINE_V1);
 
         final EntityV1 entityV1 = (EntityV1) entity;
@@ -270,7 +270,7 @@ public class PipelineFacadeTest {
                 .containsInstanceOf(EntityV1.class);
 
         final EntityV1 entity = (EntityV1) collectedEntity.map(EntityWithConstraints::entity).orElseThrow(AssertionError::new);
-        assertThat(entity.id()).isEqualTo(ModelId.of("Test"));
+        assertThat(entity.id()).isNotNull();
         assertThat(entity.type()).isEqualTo(ModelTypes.PIPELINE_V1);
         final PipelineEntity pipelineEntity = objectMapper.convertValue(entity.data(), PipelineEntity.class);
         assertThat(pipelineEntity.title()).isEqualTo(ValueReference.of("Test"));

--- a/graylog2-server/src/test/java/org/graylog2/contentpacks/facades/PipelineRuleFacadeTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/contentpacks/facades/PipelineRuleFacadeTest.java
@@ -93,7 +93,7 @@ public class PipelineRuleFacadeTest {
         final Entity entity = entityWithConstraints.entity();
 
         assertThat(entity).isInstanceOf(EntityV1.class);
-        assertThat(entity.id()).isEqualTo(ModelId.of("title"));
+        assertThat(entity.id()).isNotNull();
         assertThat(entity.type()).isEqualTo(ModelTypes.PIPELINE_RULE_V1);
 
         final EntityV1 entityV1 = (EntityV1) entity;
@@ -110,7 +110,7 @@ public class PipelineRuleFacadeTest {
         final EntityWithConstraints entityWithConstraints = facade.exportEntity(descriptor).orElseThrow(AssertionError::new);
         final Entity entity = entityWithConstraints.entity();
 
-        assertThat(entity.id()).isEqualTo(ModelId.of("debug"));
+        assertThat(entity.id()).isNotNull();
         assertThat(entity.type()).isEqualTo(ModelTypes.PIPELINE_RULE_V1);
 
         final EntityV1 entityV1 = (EntityV1) entity;
@@ -234,7 +234,7 @@ public class PipelineRuleFacadeTest {
                 .containsInstanceOf(EntityV1.class);
 
         final EntityV1 entity = (EntityV1) collectedEntity.map(EntityWithConstraints::entity).orElseThrow(AssertionError::new);
-        assertThat(entity.id()).isEqualTo(ModelId.of("debug"));
+        assertThat(entity.id()).isNotNull();
         assertThat(entity.type()).isEqualTo(ModelTypes.PIPELINE_RULE_V1);
         final PipelineRuleEntity pipelineRuleEntity = objectMapper.convertValue(entity.data(), PipelineRuleEntity.class);
         assertThat(pipelineRuleEntity.title()).isEqualTo(ValueReference.of("debug"));

--- a/graylog2-server/src/test/java/org/graylog2/contentpacks/facades/SidecarCollectorFacadeTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/contentpacks/facades/SidecarCollectorFacadeTest.java
@@ -74,7 +74,7 @@ public class SidecarCollectorFacadeTest {
         final EntityWithConstraints entityWithConstraints = facade.exportNativeEntity(collector);
 
         assertThat(entityWithConstraints.constraints()).isEmpty();
-        final Entity expectedEntity = EntityV1.builder()
+        final EntityV1 expectedEntity = EntityV1.builder()
                 .id(ModelId.of("5b4c920b4b900a0024af0001"))
                 .type(ModelTypes.SIDECAR_COLLECTOR_V1)
                 .data(objectMapper.convertValue(SidecarCollectorEntity.create(
@@ -86,7 +86,8 @@ public class SidecarCollectorFacadeTest {
                         ValueReference.of("test config -c %s"),
                         ValueReference.of("")), JsonNode.class))
                 .build();
-        assertThat(entityWithConstraints.entity()).isEqualTo(expectedEntity);
+        assertThat(entityWithConstraints.entity().type()).isEqualTo(expectedEntity.type());
+        assertThat(((EntityV1) entityWithConstraints.entity()).data()).isEqualTo(expectedEntity.data());
     }
 
     @Test
@@ -96,7 +97,7 @@ public class SidecarCollectorFacadeTest {
 
         final EntityWithConstraints entityWithConstraints = facade.exportEntity(descriptor).orElseThrow(AssertionError::new);
         assertThat(entityWithConstraints.constraints()).isEmpty();
-        final Entity expectedEntity = EntityV1.builder()
+        final EntityV1 expectedEntity = EntityV1.builder()
                 .id(ModelId.of("5b4c920b4b900a0024af0001"))
                 .type(ModelTypes.SIDECAR_COLLECTOR_V1)
                 .data(objectMapper.convertValue(SidecarCollectorEntity.create(
@@ -108,7 +109,8 @@ public class SidecarCollectorFacadeTest {
                         ValueReference.of("test config -c %s"),
                         ValueReference.of("")), JsonNode.class))
                 .build();
-        assertThat(entityWithConstraints.entity()).isEqualTo(expectedEntity);
+        assertThat(entityWithConstraints.entity().type()).isEqualTo(expectedEntity.type());
+        assertThat(((EntityV1) entityWithConstraints.entity()).data()).isEqualTo(expectedEntity.data());
     }
 
     @Test

--- a/graylog2-server/src/test/java/org/graylog2/contentpacks/facades/StreamCatalogTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/contentpacks/facades/StreamCatalogTest.java
@@ -151,7 +151,7 @@ public class StreamCatalogTest {
         final Entity entity = entityWithConstraints.entity();
 
         assertThat(entity).isInstanceOf(EntityV1.class);
-        assertThat(entity.id()).isEqualTo(ModelId.of(streamId.toHexString()));
+        assertThat(entity.id()).isNotNull();
         assertThat(entity.type()).isEqualTo(ModelTypes.STREAM_V1);
 
         final EntityV1 entityV1 = (EntityV1) entity;
@@ -204,7 +204,7 @@ public class StreamCatalogTest {
                 .containsInstanceOf(EntityV1.class);
 
         final EntityV1 entity = (EntityV1) collectedEntity.map(EntityWithConstraints::entity).orElseThrow(AssertionError::new);
-        assertThat(entity.id()).isEqualTo(ModelId.of("5adf23894b900a0fdb4e517d"));
+        assertThat(entity.id()).isNotNull();
         assertThat(entity.type()).isEqualTo(ModelTypes.STREAM_V1);
         final StreamEntity streamEntity = objectMapper.convertValue(entity.data(), StreamEntity.class);
         assertThat(streamEntity.title()).isEqualTo(ValueReference.of("Test"));

--- a/graylog2-web-interface/webpack/vendor-module-ids.json
+++ b/graylog2-web-interface/webpack/vendor-module-ids.json
@@ -889,7 +889,9 @@
       "node_modules/react/cjs/react.production.min.js": 24,
       "node_modules/moment/locale sync /^\\.\\/.*$/": 25,
       "node_modules/moment-timezone/node_modules/moment/locale sync /^\\.\\/.*$/": 32,
-      "node_modules/moment/locale/mn.js": 13
+      "node_modules/moment/locale/mn.js": 13,
+      "node_modules/scheduler/index.js": 18,
+      "node_modules/scheduler/cjs/scheduler.production.min.js": 20
     },
     "usedIds": {
       "0": 0,

--- a/graylog2-web-interface/webpack/vendor-module-ids.json
+++ b/graylog2-web-interface/webpack/vendor-module-ids.json
@@ -889,9 +889,7 @@
       "node_modules/react/cjs/react.production.min.js": 24,
       "node_modules/moment/locale sync /^\\.\\/.*$/": 25,
       "node_modules/moment-timezone/node_modules/moment/locale sync /^\\.\\/.*$/": 32,
-      "node_modules/moment/locale/mn.js": 13,
-      "node_modules/scheduler/index.js": 18,
-      "node_modules/scheduler/cjs/scheduler.production.min.js": 20
+      "node_modules/moment/locale/mn.js": 13
     },
     "usedIds": {
       "0": 0,


### PR DESCRIPTION
## Description
A Entity has now a complete random ID unrelated to the NativeEntity from which it was created.
That way it we must ensure that our code must work without any relation to the native entity.
 
## Motivation and Context
The code relied on finding a matching entity id from the native entity id from the server. But
this can't work since the content pack could run on any system other then the one it was created
on.

## How Has This Been Tested?
I rebased the change to #5203 and created and edited a content pack.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
