### PR TITLE
Revert "Treat reindexed indices as managed indices in Graylog (#5300)"

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/indexer/MongoIndexSet.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/MongoIndexSet.java
@@ -65,11 +65,6 @@ public class MongoIndexSet implements IndexSet {
     // TODO 3.0: Remove this in 3.0, only used for pre 2.2 backwards compatibility.
     public static final String RESTORED_ARCHIVE_SUFFIX = "_restored_archive";
 
-    // This is needed to detect re-indexed indices as managed Graylog indices. The number at the end of the suffix
-    // is the Elasticsearch major version. That allows reindexing the same data with different ES major versions if
-    // necessary. (if users need to keep their data in indices for a long time)
-    public static final String REINDEX_SUFFIX = "_reindex_es\\d+";
-
     public interface Factory {
         MongoIndexSet create(IndexSetConfig config);
     }
@@ -108,11 +103,11 @@ public class MongoIndexSet implements IndexSet {
         // Part of the pattern can be configured in IndexSetConfig. If set we use the indexMatchPattern from the config.
         if (isNullOrEmpty(config.indexMatchPattern())) {
             // This pattern requires that we check that each index prefix is unique and unambiguous to avoid false matches.
-            this.indexPattern = Pattern.compile("^" + config.indexPrefix() + SEPARATOR + "\\d+(?:" + RESTORED_ARCHIVE_SUFFIX + "|" + REINDEX_SUFFIX + ")?");
+            this.indexPattern = Pattern.compile("^" + config.indexPrefix() + SEPARATOR + "\\d+(?:" + RESTORED_ARCHIVE_SUFFIX + ")?");
             this.deflectorIndexPattern = Pattern.compile("^" + config.indexPrefix() + SEPARATOR + "\\d+");
         } else {
             // This pattern requires that we check that each index prefix is unique and unambiguous to avoid false matches.
-            this.indexPattern = Pattern.compile("^" + config.indexMatchPattern() + SEPARATOR + "\\d+(?:" + RESTORED_ARCHIVE_SUFFIX + "|" + REINDEX_SUFFIX + ")?");
+            this.indexPattern = Pattern.compile("^" + config.indexMatchPattern() + SEPARATOR + "\\d+(?:" + RESTORED_ARCHIVE_SUFFIX + ")?");
             this.deflectorIndexPattern = Pattern.compile("^" + config.indexMatchPattern() + SEPARATOR + "\\d+");
         }
 

--- a/graylog2-server/src/test/java/org/graylog2/indexer/MongoIndexSetTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/indexer/MongoIndexSetTest.java
@@ -157,18 +157,6 @@ public class MongoIndexSetTest {
         assertFalse(mongoIndexSet.isGraylogDeflectorIndex("graylog_42_restored_archive"));
         assertTrue(mongoIndexSet.isManagedIndex("graylog_42_restored_archive"));
 
-        // The reindexed indices should NOT be taken into account when getting the new deflector number
-        assertFalse(mongoIndexSet.isGraylogDeflectorIndex("graylog_42_reindex_es5"));
-        assertFalse(mongoIndexSet.isGraylogDeflectorIndex("graylog_42_reindex_es6"));
-        // ... but they should be detected as managed index
-        assertTrue(mongoIndexSet.isManagedIndex("graylog_42_reindex_es5"));
-        assertTrue(mongoIndexSet.isManagedIndex("graylog_42_reindex_es6"));
-
-        assertFalse(mongoIndexSet.isGraylogDeflectorIndex("graylog_42_reindex_es6heyna"));
-        assertFalse(mongoIndexSet.isManagedIndex("graylog_42_reindex_es6heyna"));
-        assertFalse(mongoIndexSet.isGraylogDeflectorIndex("graylog_42_reindex_es6_12"));
-        assertFalse(mongoIndexSet.isManagedIndex("graylog_42_reindex_es6_12"));
-
         assertFalse(mongoIndexSet.isGraylogDeflectorIndex("graylog_42_restored_archive123"));
         assertFalse(mongoIndexSet.isManagedIndex("graylog_42_restored_archive123"));
 
@@ -200,8 +188,7 @@ public class MongoIndexSetTest {
                 "graylog_1", Collections.emptySet(),
                 "graylog_2", Collections.emptySet(),
                 "graylog_3", Collections.singleton("graylog_deflector"),
-                "graylog_4_restored_archive", Collections.emptySet(),
-                "graylog_4_reindex_es5", Collections.emptySet());
+                "graylog_4_restored_archive", Collections.emptySet());
 
         when(indices.getIndexNamesAndAliases(anyString())).thenReturn(indexNameAliases);
         final MongoIndexSet mongoIndexSet = new MongoIndexSet(config, indices, nodeId, indexRangeService, auditEventSender, systemJobManager, jobFactory, activityWriter);
@@ -213,7 +200,7 @@ public class MongoIndexSetTest {
     @Test
     public void getAllGraylogIndexNames() {
         final Map<String, Set<String>> indexNameAliases = ImmutableMap.of(
-                "graylog_1_reindex_es5", Collections.emptySet(),
+                "graylog_1", Collections.emptySet(),
                 "graylog_2", Collections.emptySet(),
                 "graylog_3", Collections.emptySet(),
                 "graylog_4_restored_archive", Collections.emptySet(),
@@ -230,7 +217,7 @@ public class MongoIndexSetTest {
     @Test
     public void getAllGraylogDeflectorIndices() {
         final Map<String, Set<String>> indexNameAliases = ImmutableMap.of(
-                "graylog_1_reindex_es5", Collections.emptySet(),
+                "graylog_1", Collections.emptySet(),
                 "graylog_2", Collections.emptySet(),
                 "graylog_3", Collections.emptySet(),
                 "graylog_4_restored_archive", Collections.emptySet(),
@@ -241,7 +228,7 @@ public class MongoIndexSetTest {
         final MongoIndexSet mongoIndexSet = new MongoIndexSet(config, indices, nodeId, indexRangeService, auditEventSender, systemJobManager, jobFactory, activityWriter);
         final Map<String, Set<String>> deflectorIndices = mongoIndexSet.getAllIndexAliases();
 
-        assertThat(deflectorIndices).containsOnlyKeys("graylog_2", "graylog_3", "graylog_5");
+        assertThat(deflectorIndices).containsOnlyKeys("graylog_1", "graylog_2", "graylog_3", "graylog_5");
     }
 
     @Test


### PR DESCRIPTION
We decided to not support the "_reindex_esN" index name suffix for
re-indexed Elasticsearch indices.

This reverts commit 8ccbbf673eef9537af1fa3ff1c5ba611882f682a.