### PR TITLE
 Remove nonexistent "consistency" parameter from index/bulk requests

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/indexer/indices/Indices.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/indices/Indices.java
@@ -177,8 +177,6 @@ public class Indices {
                 bulkRequestBuilder.addAction(messages.prepareIndexRequest(target, doc, id));
             }
 
-            bulkRequestBuilder.setParameter(Parameters.CONSISTENCY, "one");
-
             final BulkResult bulkResult = JestUtils.execute(jestClient, bulkRequestBuilder.build(), () -> "Couldn't bulk index messages into index " + target);
 
             final boolean hasFailedItems = !bulkResult.getFailedItems().isEmpty();

--- a/graylog2-server/src/main/java/org/graylog2/indexer/messages/Messages.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/messages/Messages.java
@@ -35,7 +35,6 @@ import io.searchbox.core.DocumentResult;
 import io.searchbox.core.Get;
 import io.searchbox.core.Index;
 import io.searchbox.indices.Analyze;
-import io.searchbox.params.Parameters;
 import org.graylog2.indexer.IndexFailure;
 import org.graylog2.indexer.IndexFailureImpl;
 import org.graylog2.indexer.IndexMapping;
@@ -222,7 +221,6 @@ public class Messages {
                 .index(index)
                 .type(IndexMapping.TYPE_MESSAGE)
                 .id(id)
-                .setParameter(Parameters.CONSISTENCY, "one")
                 .build();
     }
 

--- a/graylog2-server/src/test/java/org/graylog2/indexer/messages/MessagesIT.java
+++ b/graylog2-server/src/test/java/org/graylog2/indexer/messages/MessagesIT.java
@@ -31,7 +31,6 @@ import java.util.Map;
 import java.util.UUID;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assume.assumeTrue;
 
 public class MessagesIT extends ElasticsearchBase {
     private Messages messages;
@@ -50,7 +49,8 @@ public class MessagesIT extends ElasticsearchBase {
         source.put("timestamp", "2017-04-13 15:29:00.000");
         final Index indexRequest = messages.prepareIndexRequest(index, source, "1");
         final DocumentResult indexResponse = client().execute(indexRequest);
-        assumeTrue(indexResponse.isSucceeded());
+
+        assertThat(indexResponse.isSucceeded()).isTrue();
 
         final ResultMessage resultMessage = messages.get("1", index);
         final Message message = resultMessage.getMessage();


### PR DESCRIPTION
The parameter has been removed from Elasticsearch about 2.5 years ago
before the release of 5.0 and requests have it will fail.

This hasn't been noticed so far because it only happens when the
Indices#move() method runs. That method is only called by the
FixDeflectorByMoveJob periodical. The job doesn't run that often,
apparently.

Also the only test that is using it is the MessagesIT test and that is
using "assumeTrue()" so it doesn't fail but gets skipped.