### PR TITLE
Add "test-jar" goal to maven-jar-plugin configuration

### DIFF
--- a/graylog-plugin-archetype/src/main/resources/archetype-resources/pom.xml
+++ b/graylog-plugin-archetype/src/main/resources/archetype-resources/pom.xml
@@ -92,6 +92,14 @@
             <version>${graylog.version}</version>
             <scope>provided</scope>
         </dependency>
+        <!-- Include source from test-jar to reuse test classes. -->
+        <dependency>
+            <groupId>org.graylog2</groupId>
+            <artifactId>graylog2-server</artifactId>
+            <version>${graylog.version}</version>
+            <type>test-jar</type>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/graylog2-server/pom.xml
+++ b/graylog2-server/pom.xml
@@ -715,6 +715,35 @@
                         </manifest>
                     </archive>
                 </configuration>
+                <executions>
+                    <execution>
+                        <goals>
+                            <!-- Building a test-jar allows us to share common test infrastructure classes like
+                              ~  elasticsearch test base classes in other maven modules. (e.g. plugins)
+                              ~
+                              ~  A module that wants to use the test-jar classes needs to define an additional
+                              ~  graylog2-server dependency in it's pom.xml:
+                              ~
+                              ~     <dependency>
+                              ~         <groupId>org.graylog2</groupId>
+                              ~         <artifactId>graylog2-server</artifactId>
+                              ~         <version>${graylog.version}</version>
+                              ~         <type>test-jar</type>
+                              ~         <scope>test</scope>
+                              ~     </dependency>
+                              ~
+                              ~ One problem with this is, that transitive test-scoped dependencies will be lost so
+                              ~ the module's pom.xml needs to explicitly add them.
+                              ~
+                              ~ More details:
+                              ~   - https://maven.apache.org/plugins/maven-jar-plugin/examples/create-test-jar.html
+                              ~     (don't use the "<classifier>" though)
+                              ~   - https://stackoverflow.com/a/174670
+                              -->
+                            <goal>test-jar</goal>
+                        </goals>
+                    </execution>
+                </executions>
             </plugin>
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>


### PR DESCRIPTION
This allows us to share test classes in other maven modules like
plugins and avoids copying classes over to other repositories.
(e.g. MongoConnectionRule, ElasticsearchBase)

Also adjust the pom.xml template in the archetype to include the
test-jar dependency.