### PR TITLE
Updating module ids of vendor bundle.

### DIFF
--- a/graylog2-web-interface/webpack/vendor-module-ids.json
+++ b/graylog2-web-interface/webpack/vendor-module-ids.json
@@ -889,7 +889,10 @@
       "node_modules/react/cjs/react.production.min.js": 24,
       "node_modules/moment/locale sync /^\\.\\/.*$/": 25,
       "node_modules/moment-timezone/node_modules/moment/locale sync /^\\.\\/.*$/": 32,
-      "node_modules/moment/locale/mn.js": 13
+      "node_modules/moment/locale/mn.js": 13,
+      "node_modules/hoist-non-react-statics/dist/hoist-non-react-statics.cjs.js": 18,
+      "node_modules/scheduler/index.js": 20,
+      "node_modules/scheduler/cjs/scheduler.production.min.js": 29
     },
     "usedIds": {
       "0": 0,


### PR DESCRIPTION
During two dependency updates (#5247 & #5380), a change to the vendor bundle module ids of our webpack build fell through. This change is updating it accordingly.
