### PR TITLE
Content Pack Dependency Resolution for Grok Extractors in Inputs

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/contentpacks/facades/InputFacade.java
+++ b/graylog2-server/src/main/java/org/graylog2/contentpacks/facades/InputFacade.java
@@ -496,7 +496,7 @@ public class InputFacade implements EntityFacade<InputWithExtractors> {
         inputWithExtractors.extractors().stream()
                 .filter(e -> e.getType().equals(Extractor.Type.GROK))
                 .map(e -> (String) e.getExtractorConfig().get(GrokExtractor.CONFIG_GROK_PATTERN))
-                .map(namedPattern -> GrokPatternService.extractPatternNames(namedPattern))
+                .map(GrokPatternService::extractPatternNames)
                 .flatMap(Collection::stream)
                 .forEach(patternName -> {
                     grokPatternService.loadByName(patternName).ifPresent(depPattern -> {
@@ -569,7 +569,7 @@ public class InputFacade implements EntityFacade<InputWithExtractors> {
                 .filter(e -> e.type().asString(parameters).equals(Extractor.Type.GROK.toString()))
                 .map(ExtractorEntity::configuration)
                 .map(c -> ((ValueReference) c.get(GrokExtractor.CONFIG_GROK_PATTERN)).asString(parameters))
-                .map(namedPattern -> GrokPatternService.extractPatternNames(namedPattern))
+                .map(GrokPatternService::extractPatternNames)
                 .flatMap(Collection::stream)
                 .forEach(patternName -> {
                     entities.entrySet().stream()

--- a/graylog2-server/src/main/java/org/graylog2/grok/GrokPatternService.java
+++ b/graylog2-server/src/main/java/org/graylog2/grok/GrokPatternService.java
@@ -16,15 +16,18 @@
  */
 package org.graylog2.grok;
 
+import io.krakens.grok.api.GrokUtils;
 import io.krakens.grok.api.exception.GrokException;
 import org.graylog2.database.NotFoundException;
 import org.graylog2.plugin.database.ValidationException;
 
 import java.util.Collection;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+import java.util.regex.Matcher;
 
 public interface GrokPatternService {
     GrokPattern load(String patternId) throws NotFoundException;
@@ -48,4 +51,16 @@ public interface GrokPatternService {
     int delete(String patternId);
 
     int deleteAll();
+
+    static Set<String> extractPatternNames(String namedPattern) {
+        final Set<String> result = new HashSet<>();
+        final Set<String> namedGroups = GrokUtils.getNameGroups(GrokUtils.GROK_PATTERN.pattern());
+        final Matcher matcher = GrokUtils.GROK_PATTERN.matcher(namedPattern);
+        while (matcher.find()) {
+            final Map<String, String> group = GrokUtils.namedGroups(matcher, namedGroups);
+            final String patternName = group.get("pattern");
+            result.add(patternName);
+        }
+        return result;
+    }
 }

--- a/graylog2-server/src/main/java/org/graylog2/inputs/InputServiceImpl.java
+++ b/graylog2-server/src/main/java/org/graylog2/inputs/InputServiceImpl.java
@@ -282,6 +282,10 @@ public class InputServiceImpl extends PersistedServiceImpl implements InputServi
             // SOFT MIGRATION: does this extractor have an order set? Implemented for issue: #726
             Long order = 0L;
             if (ex.containsField(Extractor.FIELD_ORDER)) {
+                /* We use json format to describe our test fixtures
+                   This format will only return Integer on this place,
+                   which can't be converted to long. So I first cast
+                   it to Number and eventually to long */
                 Number num = (Number) ex.get(Extractor.FIELD_ORDER);
                 order = num.longValue(); // mongodb driver gives us a java.lang.Long
             }

--- a/graylog2-server/src/main/java/org/graylog2/inputs/InputServiceImpl.java
+++ b/graylog2-server/src/main/java/org/graylog2/inputs/InputServiceImpl.java
@@ -282,7 +282,8 @@ public class InputServiceImpl extends PersistedServiceImpl implements InputServi
             // SOFT MIGRATION: does this extractor have an order set? Implemented for issue: #726
             Long order = 0L;
             if (ex.containsField(Extractor.FIELD_ORDER)) {
-                order = (Long) ex.get(Extractor.FIELD_ORDER); // mongodb driver gives us a java.lang.Long
+                Number num = (Number) ex.get(Extractor.FIELD_ORDER);
+                order = num.longValue(); // mongodb driver gives us a java.lang.Long
             }
 
             try {

--- a/graylog2-server/src/main/java/org/graylog2/inputs/extractors/GrokExtractor.java
+++ b/graylog2-server/src/main/java/org/graylog2/inputs/extractors/GrokExtractor.java
@@ -35,6 +35,7 @@ import java.util.Map;
 import java.util.Set;
 
 public class GrokExtractor extends Extractor {
+    public static final String CONFIG_GROK_PATTERN = "grok_pattern";
     private static final Logger log = LoggerFactory.getLogger(GrokExtractor.class);
 
     private final Grok grok;
@@ -66,7 +67,7 @@ public class GrokExtractor extends Extractor {
               converters,
               conditionType,
               conditionValue);
-        if (extractorConfig == null || Strings.isNullOrEmpty((String) extractorConfig.get("grok_pattern"))) {
+        if (extractorConfig == null || Strings.isNullOrEmpty((String) extractorConfig.get(CONFIG_GROK_PATTERN))) {
             throw new ConfigurationException("grok_pattern not set");
         }
 
@@ -78,7 +79,7 @@ public class GrokExtractor extends Extractor {
                 grokCompiler.register(grokPattern.name(), grokPattern.pattern());
             }
 
-            grok = grokCompiler.compile((String) extractorConfig.get("grok_pattern"), namedCapturesOnly);
+            grok = grokCompiler.compile((String) extractorConfig.get(CONFIG_GROK_PATTERN), namedCapturesOnly);
         } catch (GrokException e) {
             log.error("Unable to parse grok patterns", e);
             throw new ConfigurationException("Unable to parse grok patterns");

--- a/graylog2-server/src/test/java/org/graylog2/contentpacks/facades/InputFacadeTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/contentpacks/facades/InputFacadeTest.java
@@ -155,6 +155,7 @@ public class InputFacadeTest {
                 inputService,
                 inputRegistry,
                 dbLookupTableService,
+                grokPatternService,
                 messageInputFactory,
                 extractorFactory,
                 converterFactory,

--- a/graylog2-server/src/test/java/org/graylog2/contentpacks/facades/InputFacadeTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/contentpacks/facades/InputFacadeTest.java
@@ -27,6 +27,7 @@ import com.lordofthejars.nosqlunit.core.LoadStrategyEnum;
 import com.lordofthejars.nosqlunit.mongodb.InMemoryMongoDb;
 import org.apache.commons.collections.map.HashedMap;
 import org.graylog2.contentpacks.model.ModelId;
+import org.graylog2.contentpacks.model.ModelType;
 import org.graylog2.contentpacks.model.ModelTypes;
 import org.graylog2.contentpacks.model.entities.ConverterEntity;
 import org.graylog2.contentpacks.model.entities.Entity;
@@ -35,6 +36,7 @@ import org.graylog2.contentpacks.model.entities.EntityExcerpt;
 import org.graylog2.contentpacks.model.entities.EntityV1;
 import org.graylog2.contentpacks.model.entities.EntityWithConstraints;
 import org.graylog2.contentpacks.model.entities.ExtractorEntity;
+import org.graylog2.contentpacks.model.entities.GrokPatternEntity;
 import org.graylog2.contentpacks.model.entities.InputEntity;
 import org.graylog2.contentpacks.model.entities.LookupTableEntity;
 import org.graylog2.contentpacks.model.entities.NativeEntity;
@@ -53,6 +55,7 @@ import org.graylog2.inputs.InputService;
 import org.graylog2.inputs.InputServiceImpl;
 import org.graylog2.inputs.converters.ConverterFactory;
 import org.graylog2.inputs.extractors.ExtractorFactory;
+import org.graylog2.inputs.extractors.GrokExtractor;
 import org.graylog2.inputs.extractors.LookupTableExtractor;
 import org.graylog2.inputs.random.FakeHttpMessageInput;
 import org.graylog2.inputs.raw.udp.RawUDPInput;
@@ -279,8 +282,15 @@ public class InputFacadeTest {
                 .title("TEST PLAIN TEXT")
                 .build();
 
+        final EntityExcerpt expectedEntityExcerpt4 = EntityExcerpt.builder()
+                .id(ModelId.of("5ae2ebbeef27464477f0fd8b"))
+                .type(ModelTypes.INPUT_V1)
+                .title("TEST PLAIN TEXT")
+                .build();
+
         final Set<EntityExcerpt> entityExcerpts = facade.listEntityExcerpts();
-        assertThat(entityExcerpts).containsOnly(expectedEntityExcerpt1, expectedEntityExcerpt2, expectedEntityExcerpt3);
+        assertThat(entityExcerpts).containsOnly(expectedEntityExcerpt1,
+                expectedEntityExcerpt2, expectedEntityExcerpt3, expectedEntityExcerpt4);
     }
 
     @Test
@@ -367,17 +377,27 @@ public class InputFacadeTest {
         final Input input = inputService.find("5acc84f84b900a4ff290d9a7");
         final InputWithExtractors inputWithExtractors = InputWithExtractors.create(input);
 
-        assertThat(inputService.totalCount()).isEqualTo(3L);
+        assertThat(inputService.totalCount()).isEqualTo(4L);
         facade.delete(inputWithExtractors);
 
-        assertThat(inputService.totalCount()).isEqualTo(2L);
+        assertThat(inputService.totalCount()).isEqualTo(3L);
         assertThatThrownBy(() -> inputService.find("5acc84f84b900a4ff290d9a7"))
                 .isInstanceOf(NotFoundException.class);
     }
 
     @Test
     @UsingDataSet(locations = "/org/graylog2/contentpacks/inputs.json", loadStrategy = LoadStrategyEnum.CLEAN_INSERT)
-    public void resolveNativeEntity() throws NotFoundException {
+    public void resolveNativeEntityGrokPattern() throws NotFoundException {
+        final Input input = inputService.find("5ae2ebbeef27464477f0fd8b");
+        EntityDescriptor entityDescriptor = EntityDescriptor.create(ModelId.of(input.getId()), ModelTypes.INPUT_V1);
+        EntityDescriptor expectedDescriptor = EntityDescriptor.create(ModelId.of("1"), ModelTypes.GROK_PATTERN_V1);
+        Graph<EntityDescriptor> graph = facade.resolveNativeEntity(entityDescriptor);
+        assertThat(graph.nodes()).contains(expectedDescriptor);
+    }
+
+    @Test
+    @UsingDataSet(locations = "/org/graylog2/contentpacks/inputs.json", loadStrategy = LoadStrategyEnum.CLEAN_INSERT)
+    public void resolveNativeEntityLookupTable() throws NotFoundException {
         when(lookupuptableBuilder.lookupTable("whois")).thenReturn(lookupuptableBuilder);
         when(lookupuptableBuilder.lookupTable("tor-exit-node-list")).thenReturn(lookupuptableBuilder);
         when(lookupuptableBuilder.build()).thenReturn(lookupTable);
@@ -402,7 +422,7 @@ public class InputFacadeTest {
 
     @Test
     @UsingDataSet(locations = "/org/graylog2/contentpacks/inputs.json", loadStrategy = LoadStrategyEnum.CLEAN_INSERT)
-    public void resolveForInstallation() throws NotFoundException {
+    public void resolveForInstallationLookupTable() throws NotFoundException {
         when(lookupuptableBuilder.lookupTable("whois")).thenReturn(lookupuptableBuilder);
         when(lookupuptableBuilder.lookupTable("tor-exit-node-list")).thenReturn(lookupuptableBuilder);
         when(lookupuptableBuilder.build()).thenReturn(lookupTable);
@@ -486,5 +506,50 @@ public class InputFacadeTest {
         Graph<Entity> graph = facade.resolveForInstallation(entity, Collections.emptyMap(), entityDescriptorEntityMap);
         assertThat(graph.nodes()).contains(expectedWhoIsEntity);
         assertThat(graph.nodes()).contains(expectedTorEntity);
+    }
+
+    @Test
+    @UsingDataSet(locations = "/org/graylog2/contentpacks/inputs.json", loadStrategy = LoadStrategyEnum.CLEAN_INSERT)
+    public void resolveForInstallationGrokPattern() throws NotFoundException {
+        final Input input = inputService.find("5ae2ebbeef27464477f0fd8b");
+        final InputWithExtractors inputWithExtractors = InputWithExtractors.create(input, inputService.getExtractors(input));
+        final GrokExtractor grokExtractor = (GrokExtractor) inputWithExtractors.extractors().iterator().next();
+        final ExtractorEntity extractorEntity = ExtractorEntity.create(
+                ValueReference.of(grokExtractor.getTitle()),
+                ValueReference.of(grokExtractor.getType()),
+                ValueReference.of(grokExtractor.getCursorStrategy()),
+                ValueReference.of(grokExtractor.getTargetField()),
+                ValueReference.of(grokExtractor.getSourceField()),
+                ReferenceMapUtils.toReferenceMap(grokExtractor.getExtractorConfig()),
+                Collections.emptyList(),
+                ValueReference.of(grokExtractor.getConditionType()),
+                ValueReference.of(grokExtractor.getConditionValue()),
+                ValueReference.of(grokExtractor.getOrder()));
+        List<ExtractorEntity> extractorEntities = new ArrayList<>(1);
+        extractorEntities.add(extractorEntity);
+        InputEntity inputEntity = InputEntity.create(
+                ValueReference.of(input.getTitle()),
+                ReferenceMapUtils.toReferenceMap(input.getConfiguration()),
+                Collections.emptyMap(),
+                ValueReference.of(input.getType()),
+                ValueReference.of(input.isGlobal()),
+                extractorEntities);
+        Entity entity = EntityV1.builder()
+                .id(ModelId.of(input.getId()))
+                .type(ModelTypes.INPUT_V1)
+                .data(objectMapper.convertValue(inputEntity, JsonNode.class))
+                .build();
+        final GrokPatternEntity grokPatternEntity = GrokPatternEntity.create(ValueReference.of("GREEDY"),
+                ValueReference.of(".*"));
+        final Entity expectedEntity = EntityV1.builder()
+                .id(ModelId.of("dead-feed"))
+                .data(objectMapper.convertValue(grokPatternEntity, JsonNode.class))
+                .type(ModelTypes.GROK_PATTERN_V1)
+                .build();
+        final EntityDescriptor entityDescriptor = expectedEntity.toEntityDescriptor();
+        final Map<EntityDescriptor, Entity> entities = new HashMap<>(1);
+        entities.put(entityDescriptor, expectedEntity);
+        Graph<Entity> graph = facade.resolveForInstallation(entity, Collections.emptyMap(), entities);
+        assertThat(graph.nodes()).contains(expectedEntity);
     }
 }

--- a/graylog2-server/src/test/resources/org/graylog2/contentpacks/inputs.json
+++ b/graylog2-server/src/test/resources/org/graylog2/contentpacks/inputs.json
@@ -205,7 +205,56 @@
           "id" : "7e7aee30-d212-11e8-bda9-00e18cb9c35a"
         }
       ]
+    },
+    {
+      "_id": {
+        "$oid": "5ae2ebbeef27464477f0fd8b"
+      },
+      "creator_user_id" : "admin",
+      "configuration" : {
+        "recv_buffer_size" : 1048576,
+        "tcp_keepalive" : false,
+        "use_null_delimiter" : false,
+        "number_worker_threads" : 8,
+        "tls_client_auth_cert_file" : "",
+        "bind_address" : "127.0.0.1",
+        "tls_cert_file" : "",
+        "port" : 5555,
+        "tls_key_file" : "",
+        "tls_enable" : false,
+        "tls_key_password" : "",
+        "max_message_size" : 2097152,
+        "tls_client_auth" : "disabled",
+        "override_source" : null
+      },
+      "name" : "Raw/Plaintext TCP",
+      "created_at": {
+        "$date": "2018-10-18T12:38:01.645Z"
+      },
+      "global" : false,
+      "type" : "org.graylog2.inputs.raw.tcp.RawTCPInput",
+      "title" : "TEST PLAIN TEXT",
+      "content_pack" : null,
+      "node_id" : "f3bd37d4-61d2-4157-8d72-8b26d1777c3f",
+      "extractors" : [
+        {
+          "creator_user_id" : "admin",
+          "source_field" : "message",
+          "condition_type" : "none",
+          "title" : "GROK-EXTRACTOR",
+          "type" : "grok",
+          "cursor_strategy" : "copy",
+          "target_field" : "",
+          "extractor_config" : {
+            "grok_pattern" : "%{TIMESTAMP_ISO8601:karl} %{WORD:gott}",
+            "named_captures_only" : true
+          },
+          "condition_value" : "",
+          "converters" : [],
+          "id" : "3192e960-fc8d-11e8-913b-00e18cb9c35a",
+          "order" : 0
+        }
+      ]
     }
-
   ]
 }

--- a/graylog2-server/src/test/resources/org/graylog2/contentpacks/inputs.json
+++ b/graylog2-server/src/test/resources/org/graylog2/contentpacks/inputs.json
@@ -246,7 +246,7 @@
           "cursor_strategy" : "copy",
           "target_field" : "",
           "extractor_config" : {
-            "grok_pattern" : "%{TIMESTAMP_ISO8601:karl} %{WORD:gott}",
+            "grok_pattern" : "%{GREEDY:gott}",
             "named_captures_only" : true
           },
           "condition_value" : "",


### PR DESCRIPTION
## Description
Add support to the InputFacade for resolving grok pattern extractors in inputs.

## Motivation and Context
If a user wants to add a input to a content pack with a grok extractor he also wants the
grok extractor as part of the content pack.

## How Has This Been Tested?
Created a new content pack, edit it, installed and uninstalled it.

## Known Issue
The Grok Patterns get uninstalled even though a installation exists. This will be
addressed by a different issue (Refs #5399)

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

Fixes: #5273 
