### PR TITLE
 Include alert conditions and alarm callbacks in content packs

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/contentpacks/facades/StreamFacade.java
+++ b/graylog2-server/src/main/java/org/graylog2/contentpacks/facades/StreamFacade.java
@@ -59,6 +59,8 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 
+import static com.google.common.base.Strings.nullToEmpty;
+
 public class StreamFacade implements EntityFacade<Stream> {
     private static final Logger LOG = LoggerFactory.getLogger(StreamFacade.class);
     private static final String DUMMY_STREAM_ID = "ffffffffffffffffffffffff";
@@ -112,9 +114,9 @@ public class StreamFacade implements EntityFacade<Stream> {
         return StreamRuleEntity.create(
                 ValueReference.of(streamRule.getType()),
                 ValueReference.of(streamRule.getField()),
-                ValueReference.of(streamRule.getValue()),
+                ValueReference.of(nullToEmpty(streamRule.getValue())), // Rule value can be null!
                 ValueReference.of(streamRule.getInverted()),
-                ValueReference.of(streamRule.getDescription()));
+                ValueReference.of(nullToEmpty(streamRule.getDescription()))); // Rule description can be null!
     }
 
     @Override

--- a/graylog2-server/src/main/java/org/graylog2/contentpacks/facades/StreamFacade.java
+++ b/graylog2-server/src/main/java/org/graylog2/contentpacks/facades/StreamFacade.java
@@ -23,10 +23,15 @@ import com.google.common.graph.GraphBuilder;
 import com.google.common.graph.ImmutableGraph;
 import com.google.common.graph.MutableGraph;
 import org.bson.types.ObjectId;
+import org.graylog2.alarmcallbacks.AlarmCallbackConfiguration;
+import org.graylog2.alarmcallbacks.AlarmCallbackConfigurationService;
+import org.graylog2.alerts.AlertService;
 import org.graylog2.contentpacks.exceptions.ContentPackException;
 import org.graylog2.contentpacks.model.ModelId;
 import org.graylog2.contentpacks.model.ModelType;
 import org.graylog2.contentpacks.model.ModelTypes;
+import org.graylog2.contentpacks.model.constraints.Constraint;
+import org.graylog2.contentpacks.model.constraints.PluginVersionConstraint;
 import org.graylog2.contentpacks.model.entities.Entity;
 import org.graylog2.contentpacks.model.entities.EntityDescriptor;
 import org.graylog2.contentpacks.model.entities.EntityExcerpt;
@@ -34,16 +39,24 @@ import org.graylog2.contentpacks.model.entities.EntityV1;
 import org.graylog2.contentpacks.model.entities.EntityWithConstraints;
 import org.graylog2.contentpacks.model.entities.NativeEntity;
 import org.graylog2.contentpacks.model.entities.NativeEntityDescriptor;
+import org.graylog2.contentpacks.model.entities.StreamAlarmCallbackEntity;
+import org.graylog2.contentpacks.model.entities.StreamAlertConditionEntity;
 import org.graylog2.contentpacks.model.entities.StreamEntity;
 import org.graylog2.contentpacks.model.entities.StreamRuleEntity;
+import org.graylog2.contentpacks.model.entities.references.ReferenceMapUtils;
 import org.graylog2.contentpacks.model.entities.references.ValueReference;
 import org.graylog2.database.NotFoundException;
 import org.graylog2.indexer.indexset.IndexSetService;
+import org.graylog2.plugin.PluginMetaData;
+import org.graylog2.plugin.alarms.AlertCondition;
+import org.graylog2.plugin.configuration.ConfigurationException;
 import org.graylog2.plugin.database.ValidationException;
 import org.graylog2.plugin.streams.Output;
 import org.graylog2.plugin.streams.Stream;
 import org.graylog2.plugin.streams.StreamRule;
 import org.graylog2.plugin.streams.StreamRuleType;
+import org.graylog2.rest.models.alarmcallbacks.requests.CreateAlarmCallbackRequest;
+import org.graylog2.rest.models.streams.alerts.requests.CreateConditionRequest;
 import org.graylog2.rest.resources.streams.requests.CreateStreamRequest;
 import org.graylog2.rest.resources.streams.rules.requests.CreateStreamRuleRequest;
 import org.graylog2.streams.StreamRuleService;
@@ -70,16 +83,25 @@ public class StreamFacade implements EntityFacade<Stream> {
     private final ObjectMapper objectMapper;
     private final StreamService streamService;
     private final StreamRuleService streamRuleService;
+    private final AlertService streamAlertService;
+    private final AlarmCallbackConfigurationService alarmCallbackConfigurationService;
+    private final Set<PluginMetaData> pluginMetaData;
     private final IndexSetService indexSetService;
 
     @Inject
     public StreamFacade(ObjectMapper objectMapper,
                         StreamService streamService,
                         StreamRuleService streamRuleService,
+                        AlertService streamAlertService,
+                        AlarmCallbackConfigurationService alarmCallbackConfigurationService,
+                        Set<PluginMetaData> pluginMetaData,
                         IndexSetService indexSetService) {
         this.objectMapper = objectMapper;
         this.streamService = streamService;
         this.streamRuleService = streamRuleService;
+        this.streamAlertService = streamAlertService;
+        this.alarmCallbackConfigurationService = alarmCallbackConfigurationService;
+        this.pluginMetaData = pluginMetaData;
         this.indexSetService = indexSetService;
     }
 
@@ -87,6 +109,12 @@ public class StreamFacade implements EntityFacade<Stream> {
     public EntityWithConstraints exportNativeEntity(Stream stream) {
         final List<StreamRuleEntity> streamRules = stream.getStreamRules().stream()
                 .map(this::encodeStreamRule)
+                .collect(Collectors.toList());
+        final List<StreamAlertConditionEntity> streamAlertConditions = streamService.getAlertConditions(stream).stream()
+                .map(this::encodeStreamAlertCondition)
+                .collect(Collectors.toList());
+        final List<StreamAlarmCallbackEntity> streamAlarmCallbacks = alarmCallbackConfigurationService.getForStream(stream).stream()
+                .map(this::encodeStreamAlarmCallback)
                 .collect(Collectors.toList());
         final Set<ValueReference> outputIds = stream.getOutputs().stream()
                 .map(Output::getId)
@@ -98,6 +126,8 @@ public class StreamFacade implements EntityFacade<Stream> {
                 ValueReference.of(stream.getDisabled()),
                 ValueReference.of(stream.getMatchingType()),
                 streamRules,
+                streamAlertConditions,
+                streamAlarmCallbacks,
                 outputIds,
                 ValueReference.of(stream.isDefaultStream()),
                 ValueReference.of(stream.getRemoveMatchesFromDefaultStream()));
@@ -107,7 +137,18 @@ public class StreamFacade implements EntityFacade<Stream> {
                 .type(ModelTypes.STREAM_V1)
                 .data(data)
                 .build();
-        return EntityWithConstraints.create(entity);
+        return EntityWithConstraints.create(entity, versionConstraints(streamAlarmCallbacks));
+    }
+
+    private Set<Constraint> versionConstraints(List<StreamAlarmCallbackEntity> alarmCallbacks) {
+        // Try to collect plugin dependencies by looking that the package names of the alarm callbacks and the loaded
+        // plugins
+        return alarmCallbacks.stream()
+                .map(StreamAlarmCallbackEntity::type)
+                .flatMap(packageName -> pluginMetaData.stream()
+                        .filter(metaData -> packageName.startsWith(metaData.getClass().getPackage().getName()))
+                        .map(PluginVersionConstraint::of))
+                .collect(Collectors.toSet());
     }
 
     private StreamRuleEntity encodeStreamRule(StreamRule streamRule) {
@@ -117,6 +158,21 @@ public class StreamFacade implements EntityFacade<Stream> {
                 ValueReference.of(nullToEmpty(streamRule.getValue())), // Rule value can be null!
                 ValueReference.of(streamRule.getInverted()),
                 ValueReference.of(nullToEmpty(streamRule.getDescription()))); // Rule description can be null!
+    }
+
+    private StreamAlertConditionEntity encodeStreamAlertCondition(AlertCondition alertCondition) {
+        return StreamAlertConditionEntity.create(
+                alertCondition.getType(),
+                ValueReference.of(alertCondition.getTitle()),
+                ReferenceMapUtils.toReferenceMap(alertCondition.getParameters()));
+    }
+
+    private StreamAlarmCallbackEntity encodeStreamAlarmCallback(AlarmCallbackConfiguration alarmCallback) {
+        return StreamAlarmCallbackEntity.create(
+                alarmCallback.getType(),
+                ValueReference.of(alarmCallback.getTitle()),
+                alarmCallback.getStreamId(),
+                ReferenceMapUtils.toReferenceMap(alarmCallback.getConfiguration()));
     }
 
     @Override
@@ -149,9 +205,30 @@ public class StreamFacade implements EntityFacade<Stream> {
                 .map(streamRuleEntity -> createStreamRuleRequest(streamRuleEntity, parameters))
                 .map(request -> streamRuleService.create(DUMMY_STREAM_ID, request))
                 .collect(Collectors.toList());
+        final List<AlertCondition> alertConditions = streamEntity.alertConditions().stream()
+                .map(alertCondition -> createStreamAlertConditionRequest(alertCondition, parameters))
+                .map(request -> {
+                    try {
+                        return streamAlertService.fromRequest(request, stream, username);
+                    } catch (ConfigurationException e) {
+                        throw new ContentPackException("Couldn't create entity " + entity.toEntityDescriptor(), e);
+                    }
+                })
+                .collect(Collectors.toList());
+        final List<AlarmCallbackConfiguration> alarmCallbacks = streamEntity.alarmCallbacks().stream()
+                .map(alarmCallback -> createStreamAlarmCallbackRequest(alarmCallback, parameters))
+                .map(request -> alarmCallbackConfigurationService.create(stream.getId(), request, username))
+                .collect(Collectors.toList());
         final String savedStreamId;
         try {
             savedStreamId = streamService.saveWithRules(stream, streamRules);
+
+            for (final AlertCondition alertCondition : alertConditions) {
+                streamService.addAlertCondition(stream, alertCondition);
+            }
+            for (final AlarmCallbackConfiguration alarmCallback : alarmCallbacks) {
+                alarmCallbackConfigurationService.save(alarmCallback);
+            }
         } catch (ValidationException e) {
             throw new ContentPackException("Couldn't create entity " + entity.toEntityDescriptor(), e);
         }
@@ -168,6 +245,24 @@ public class StreamFacade implements EntityFacade<Stream> {
 
         return NativeEntity.create(entity.id(), savedStreamId, TYPE_V1, stream.getTitle(), stream);
     }
+
+    private CreateConditionRequest createStreamAlertConditionRequest(StreamAlertConditionEntity alertCondition,
+                                                                     Map<String, ValueReference> parameters) {
+        return CreateConditionRequest.builder()
+                .setType(alertCondition.type())
+                .setTitle(alertCondition.title().asString(parameters))
+                .setParameters(ReferenceMapUtils.toValueMap(alertCondition.parameters(), parameters))
+                .build();
+    }
+
+    private CreateAlarmCallbackRequest createStreamAlarmCallbackRequest(StreamAlarmCallbackEntity alarmCallback,
+                                                                        Map<String, ValueReference> parameters) {
+        return CreateAlarmCallbackRequest.create(
+                alarmCallback.type(),
+                alarmCallback.title().asString(parameters),
+                ReferenceMapUtils.toValueMap(alarmCallback.configuration(), parameters));
+    }
+
 
     private CreateStreamRuleRequest createStreamRuleRequest(StreamRuleEntity streamRuleEntity, Map<String, ValueReference> parameters) {
         return CreateStreamRuleRequest.create(

--- a/graylog2-server/src/main/java/org/graylog2/contentpacks/model/entities/NativeEntityDescriptor.java
+++ b/graylog2-server/src/main/java/org/graylog2/contentpacks/model/entities/NativeEntityDescriptor.java
@@ -49,7 +49,7 @@ public abstract class NativeEntityDescriptor implements Identified, Typed {
     }
 
     /**
-     * Shortcut for {@link #create(String, String, ModelType)}
+     * Shortcut for {@link #create(String, String, ModelType, String)}
      */
     public static NativeEntityDescriptor create(String contentPackEntityId, String nativeId, ModelType type, String title) {
         return create(ModelId.of(contentPackEntityId), ModelId.of(nativeId), type, title);

--- a/graylog2-server/src/main/java/org/graylog2/contentpacks/model/entities/StreamAlarmCallbackEntity.java
+++ b/graylog2-server/src/main/java/org/graylog2/contentpacks/model/entities/StreamAlarmCallbackEntity.java
@@ -1,0 +1,53 @@
+/**
+ * This file is part of Graylog.
+ *
+ * Graylog is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.graylog2.contentpacks.model.entities;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.auto.value.AutoValue;
+import org.graylog.autovalue.WithBeanGetter;
+import org.graylog2.contentpacks.model.entities.references.ReferenceMap;
+import org.graylog2.contentpacks.model.entities.references.ValueReference;
+
+import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.NotNull;
+
+@AutoValue
+@WithBeanGetter
+public abstract class StreamAlarmCallbackEntity {
+    @JsonProperty("type")
+    @NotBlank
+    public abstract String type();
+
+    @JsonProperty("title")
+    @NotBlank
+    public abstract ValueReference title();
+
+    @JsonProperty("stream_id")
+    public abstract String streamId();
+
+    @JsonProperty("configuration")
+    @NotNull
+    public abstract ReferenceMap configuration();
+    @JsonCreator
+    public static StreamAlarmCallbackEntity create(@JsonProperty("type") @NotBlank String type,
+                                                   @JsonProperty("title") @NotBlank ValueReference title,
+                                                   @JsonProperty("stream_id") @NotBlank String streamId,
+                                                   @JsonProperty("configuration") @NotNull ReferenceMap configuration) {
+        return new AutoValue_StreamAlarmCallbackEntity(type, title, streamId, configuration);
+    }
+}

--- a/graylog2-server/src/main/java/org/graylog2/contentpacks/model/entities/StreamAlertConditionEntity.java
+++ b/graylog2-server/src/main/java/org/graylog2/contentpacks/model/entities/StreamAlertConditionEntity.java
@@ -1,0 +1,51 @@
+/**
+ * This file is part of Graylog.
+ *
+ * Graylog is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.graylog2.contentpacks.model.entities;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.auto.value.AutoValue;
+import org.graylog.autovalue.WithBeanGetter;
+import org.graylog2.contentpacks.model.entities.references.ReferenceMap;
+import org.graylog2.contentpacks.model.entities.references.ValueReference;
+
+import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.NotNull;
+
+@AutoValue
+@WithBeanGetter
+public abstract class StreamAlertConditionEntity {
+    @JsonProperty("type")
+    @NotBlank
+    public abstract String type();
+
+    @JsonProperty("title")
+    @NotBlank
+    public abstract ValueReference title();
+
+    @JsonProperty("parameters")
+    @NotNull
+    public abstract ReferenceMap parameters();
+
+    @JsonCreator
+    public static StreamAlertConditionEntity create(
+            @JsonProperty("type") @NotBlank String type,
+            @JsonProperty("title") @NotBlank ValueReference title,
+            @JsonProperty("parameters") @NotNull ReferenceMap parameters) {
+        return new AutoValue_StreamAlertConditionEntity(type, title, parameters);
+    }
+}

--- a/graylog2-server/src/main/java/org/graylog2/contentpacks/model/entities/StreamEntity.java
+++ b/graylog2-server/src/main/java/org/graylog2/contentpacks/model/entities/StreamEntity.java
@@ -22,7 +22,6 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.auto.value.AutoValue;
 import org.graylog.autovalue.WithBeanGetter;
 import org.graylog2.contentpacks.model.entities.references.ValueReference;
-import org.graylog2.plugin.streams.Stream;
 
 import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.NotNull;
@@ -50,6 +49,14 @@ public abstract class StreamEntity {
     @NotNull
     public abstract List<StreamRuleEntity> streamRules();
 
+    @JsonProperty("alert_conditions")
+    @NotNull
+    public abstract List<StreamAlertConditionEntity> alertConditions();
+
+    @JsonProperty("alarm_callbacks")
+    @NotNull
+    public abstract List<StreamAlarmCallbackEntity> alarmCallbacks();
+
     @JsonProperty("outputs")
     @NotNull
     public abstract Set<ValueReference> outputs();
@@ -67,6 +74,8 @@ public abstract class StreamEntity {
             @JsonProperty("disabled") ValueReference disabled,
             @JsonProperty("matching_type") ValueReference matchingType,
             @JsonProperty("stream_rules") @NotNull List<StreamRuleEntity> streamRules,
+            @JsonProperty("alert_conditions") @NotNull List<StreamAlertConditionEntity> alertConditions,
+            @JsonProperty("alarm_callbacks") @NotNull List<StreamAlarmCallbackEntity> streamAlarmCallbacks,
             @JsonProperty("outputs") @NotNull Set<ValueReference> outputs,
             @JsonProperty("default_stream") ValueReference defaultStream,
             @JsonProperty("remove_matches") ValueReference removeMatches) {
@@ -76,6 +85,8 @@ public abstract class StreamEntity {
                 disabled,
                 matchingType,
                 streamRules,
+                alertConditions,
+                streamAlarmCallbacks,
                 outputs,
                 defaultStream,
                 removeMatches);

--- a/graylog2-server/src/test/java/org/graylog2/contentpacks/ContentPackServiceTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/contentpacks/ContentPackServiceTest.java
@@ -20,6 +20,8 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
+import org.graylog2.alarmcallbacks.AlarmCallbackConfigurationService;
+import org.graylog2.alerts.AlertService;
 import org.graylog2.contentpacks.constraints.ConstraintChecker;
 import org.graylog2.contentpacks.facades.EntityFacade;
 import org.graylog2.contentpacks.facades.GrokPatternFacade;
@@ -76,6 +78,10 @@ public class ContentPackServiceTest {
     private final ObjectMapper objectMapper = new ObjectMapperProvider().get();
 
     @Mock
+    private AlertService alertService;
+    @Mock
+    private AlarmCallbackConfigurationService alarmCallbackConfigurationService;
+    @Mock
     private StreamService streamService;
     @Mock
     private StreamRuleService streamRuleService;
@@ -106,7 +112,7 @@ public class ContentPackServiceTest {
         outputFactories = new HashMap<>();
         final Map<ModelType, EntityFacade<?>> entityFacades = ImmutableMap.of(
                 ModelTypes.GROK_PATTERN_V1, new GrokPatternFacade(objectMapper, patternService),
-                ModelTypes.STREAM_V1, new StreamFacade(objectMapper, streamService, streamRuleService, indexSetService),
+                ModelTypes.STREAM_V1, new StreamFacade(objectMapper, streamService, streamRuleService, alertService, alarmCallbackConfigurationService, new HashSet<>(), indexSetService),
                 ModelTypes.OUTPUT_V1, new OutputFacade(objectMapper, outputService, pluginMetaData, outputFactories)
         );
 

--- a/graylog2-server/src/test/java/org/graylog2/contentpacks/facades/DashboardFacadeTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/contentpacks/facades/DashboardFacadeTest.java
@@ -296,6 +296,8 @@ public class DashboardFacadeTest {
                         ValueReference.of(false),
                         ValueReference.of("AND"),
                         Collections.emptyList(),
+                        Collections.emptyList(),
+                        Collections.emptyList(),
                         Collections.emptySet(),
                         ValueReference.of(false),
                         ValueReference.of(false)), JsonNode.class))

--- a/graylog2-server/src/test/java/org/graylog2/contentpacks/facades/StreamCatalogTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/contentpacks/facades/StreamCatalogTest.java
@@ -67,6 +67,7 @@ import org.mockito.junit.MockitoRule;
 
 import java.util.Collections;
 import java.util.Date;
+import java.util.HashSet;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.Executors;
@@ -121,7 +122,7 @@ public class StreamCatalogTest {
                 OutputImpl.create("5adf239e4b900a0fdb4e5197", "Title", "Type", "admin", Collections.emptyMap(), new Date(1524654085L), null)
         );
 
-        facade = new StreamFacade(objectMapper, streamService, streamRuleService, indexSetService);
+        facade = new StreamFacade(objectMapper, streamService, streamRuleService, alertService, alarmCallbackConfigurationService, new HashSet<>(), indexSetService);
     }
 
     @Test


### PR DESCRIPTION
Since both are bound to streams I decided to put them into the stream entity for now.

I also fixed the following smaller issues:

- Avoid NullPointerException for stream rule fileds
- Fix javadoc comment

Fixes #1758