### PR TITLE
Avoid failing JSON deser. if ext. type is present, but prop is not.

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/shared/bindings/providers/ObjectMapperProvider.java
+++ b/graylog2-server/src/main/java/org/graylog2/shared/bindings/providers/ObjectMapperProvider.java
@@ -71,6 +71,7 @@ public class ObjectMapperProvider implements Provider<ObjectMapper> {
         this.objectMapper = mapper
                 .disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS)
                 .disable(DeserializationFeature.ADJUST_DATES_TO_CONTEXT_TIME_ZONE)
+                .disable(DeserializationFeature.FAIL_ON_MISSING_EXTERNAL_TYPE_ID_PROPERTY)
                 .setPropertyNamingStrategy(new PropertyNamingStrategy.SnakeCaseStrategy())
                 .setSubtypeResolver(subtypeResolver)
                 .setTypeFactory(typeFactory)

--- a/graylog2-server/src/test/java/org/graylog2/shared/bindings/providers/SerializeSubtypedOptionalPropertiesTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/shared/bindings/providers/SerializeSubtypedOptionalPropertiesTest.java
@@ -1,0 +1,86 @@
+package org.graylog2.shared.bindings.providers;
+
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.jsontype.NamedType;
+import com.google.auto.value.AutoValue;
+import com.google.common.collect.ImmutableSet;
+import org.junit.Test;
+
+import javax.annotation.Nullable;
+import java.io.IOException;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class SerializeSubtypedOptionalPropertiesTest {
+    @AutoValue
+    @JsonAutoDetect
+    @JsonDeserialize(builder = SerializeSubtypedOptionalPropertiesTest.Foo.Builder.class)
+    abstract static class Foo {
+        static final String FIELD_TYPE = "type";
+        static final String FIELD_BAR = "bar";
+
+        @JsonProperty(FIELD_TYPE)
+        public abstract String type();
+
+        @JsonProperty(FIELD_BAR)
+        public abstract Optional<Bar> bar();
+
+        @AutoValue.Builder
+        public abstract static class Builder {
+            @JsonProperty(FIELD_TYPE)
+            public abstract Builder type(String type);
+
+            @JsonProperty(FIELD_BAR)
+            @JsonTypeInfo(use = JsonTypeInfo.Id.NAME,
+                    include = JsonTypeInfo.As.EXTERNAL_PROPERTY,
+                    property = FIELD_TYPE)
+            @Nullable
+            public abstract Builder bar(Bar bar);
+
+            public abstract Foo build();
+
+            @JsonCreator
+            public static Builder builder() {
+                return new AutoValue_SerializeSubtypedOptionalPropertiesTest_Foo.Builder();
+            }
+        }
+    }
+
+    interface Bar {}
+
+    @JsonAutoDetect
+    @AutoValue
+    static abstract class Qux implements Bar {
+        @JsonProperty("value")
+        public abstract Integer value();
+
+        @JsonCreator
+        public static Qux create(@JsonProperty("value") Integer value) {
+            return new AutoValue_SerializeSubtypedOptionalPropertiesTest_Qux(value);
+        }
+    }
+
+    @Test
+    public void deserializingSubtypeWithExternalPropertyWorks() throws IOException {
+        final ObjectMapperProvider objectMapperProvider = new ObjectMapperProvider(this.getClass().getClassLoader(), ImmutableSet.of(new NamedType(Qux.class, "Qux")));
+        final ObjectMapper objectMapper = objectMapperProvider.get();
+        final Foo foo = objectMapper.readValue("{ \"type\":\"Qux\", \"bar\": { \"value\": 42 } }", Foo.class);
+        assertThat(foo.bar())
+                .isPresent()
+                .containsInstanceOf(Qux.class);
+    }
+
+    @Test
+    public void deserializingOptionalSubtypeWithExternalPropertyWorks() throws IOException {
+        final ObjectMapperProvider objectMapperProvider = new ObjectMapperProvider(this.getClass().getClassLoader(), ImmutableSet.of(new NamedType(Qux.class, "Qux")));
+        final ObjectMapper objectMapper = objectMapperProvider.get();
+        final Foo foo = objectMapper.readValue("{ \"type\":\"Qux\" }", Foo.class);
+        assertThat(foo.bar()).isEmpty();
+    }
+}

--- a/graylog2-server/src/test/java/org/graylog2/shared/bindings/providers/SerializeSubtypedOptionalPropertiesTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/shared/bindings/providers/SerializeSubtypedOptionalPropertiesTest.java
@@ -1,3 +1,19 @@
+/**
+ * This file is part of Graylog.
+ *
+ * Graylog is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package org.graylog2.shared.bindings.providers;
 
 import com.fasterxml.jackson.annotation.JsonAutoDetect;


### PR DESCRIPTION
This change allows deserializing classes which fulfill the following:

  * They contain a property `V` which is subtyped
  * They contain an additional property `T` defining the type of the
property `V` (and maybe the types of additional properties or of the
class itself)
  * `V` is optional, so it might be present or not
  * `T` is always present

The important point is the optionality of `V`. Jackson assumes that if a property that is used as an external property with `@JsonTypeInfo` is present, that the property annotated with `@JsonTypeInfo` must be present as well. This is not always the case, especially when `T` is used to indicate of the class itself and `V`'s type depends on `T` but the property itself is optional.

This change is disabling Jackson's [`FAIL_ON_MISSING_CREATOR_PROPERTIES`](https://fasterxml.github.io/jackson-databind/javadoc/2.9/com/fasterxml/jackson/databind/DeserializationFeature.html#FAIL_ON_MISSING_CREATOR_PROPERTIES) feature, which allows us to use the forementioned constellation.

All current usages of `@JsonTypeInfo` were investigated and the change is safe as we do not even have any usages of `@JsonTypeInfo` for properties of a class, it is used only to annotate complete classes.
