### PR TITLE
Add message to NoTargetIndexException to avoid NPE in logging

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/indexer/MongoIndexSet.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/MongoIndexSet.java
@@ -151,7 +151,7 @@ public class MongoIndexSet implements IndexSet {
         final Set<String> indexNames = indices.getIndexNamesAndAliases(getIndexWildcard()).keySet();
 
         if (indexNames.isEmpty()) {
-            throw new NoTargetIndexException();
+            throw new NoTargetIndexException("Couldn't find any indices for wildcard " + getIndexWildcard());
         }
 
         int highestIndexNumber = -1;
@@ -167,7 +167,7 @@ public class MongoIndexSet implements IndexSet {
         }
 
         if (highestIndexNumber == -1) {
-            throw new NoTargetIndexException();
+            throw new NoTargetIndexException("Couldn't get newest index number for indices " + indexNames);
         }
 
         return highestIndexNumber;

--- a/graylog2-server/src/main/java/org/graylog2/indexer/NoTargetIndexException.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/NoTargetIndexException.java
@@ -17,4 +17,7 @@
 package org.graylog2.indexer;
 
 public class NoTargetIndexException extends ElasticsearchException {
+    public NoTargetIndexException(String message) {
+        super(message);
+    }
 }


### PR DESCRIPTION
Logging a NoTargetIndexException would throw a NullPointerException
because there is no message string.