### PR TITLE
Security update to jackson 2.8.11.3 (bom 2.8.11.20181123)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -107,7 +107,7 @@
         <HdrHistogram.version>2.1.10</HdrHistogram.version>
         <hibernate-validator.version>6.0.13.Final</hibernate-validator.version>
         <hk2.version>2.5.0-b32</hk2.version> <!-- The HK2 version should match the version being used by Jersey -->
-        <jackson.version>2.8.11.20180608</jackson.version>
+        <jackson.version>2.8.11.20181123</jackson.version>
         <jadconfig.version>0.13.0</jadconfig.version>
         <java-semver.version>0.9.0</java-semver.version>
         <javapoet.version>1.11.1</javapoet.version>


### PR DESCRIPTION
Contains fixes for:

CVE-2018-14718
CVE-2018-14721
CVE-2018-19360
CVE-2018-19361
CVE-2018-19362

See the following page for details:
https://github.com/FasterXML/jackson/wiki/Jackson-Release-2.8