### PR TITLE
Fix JAR shading issue after bouncycastle addition

### DIFF
--- a/graylog2-server/pom.xml
+++ b/graylog2-server/pom.xml
@@ -675,6 +675,16 @@
                                 <exclude>org/apache/commons/collections/functors/InvokerTransformer.class</exclude>
                             </excludes>
                         </filter>
+                        <!-- Bouncycastle's JARs are signed. When building a shaded JAR, either remove the signatures, or
+                             add dependency to the main JAR's manifest. Otherwise running the application will fail. -->
+                        <filter>
+                            <artifact>org.bouncycastle:*</artifact>
+                            <excludes>
+                                <exclude>META-INF/*.SF</exclude>
+                                <exclude>META-INF/*.DSA</exclude>
+                                <exclude>META-INF/*.RSA</exclude>
+                            </excludes>
+                        </filter>
                     </filters>
                 </configuration>
                 <executions>


### PR DESCRIPTION
Fixes the following error when running the JAR:

    java.lang.SecurityException: Invalid signature file digest for
    Manifest main attributes