### PR TITLE
Add Etag caching for Sidecar UpdateRegistration results

### DIFF
--- a/graylog2-server/src/main/java/org/graylog/plugins/sidecar/rest/resources/AdministrationResource.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/sidecar/rest/resources/AdministrationResource.java
@@ -44,6 +44,7 @@ import org.graylog.plugins.sidecar.rest.responses.SidecarListResponse;
 import org.graylog.plugins.sidecar.services.ActionService;
 import org.graylog.plugins.sidecar.services.CollectorService;
 import org.graylog.plugins.sidecar.services.ConfigurationService;
+import org.graylog.plugins.sidecar.services.EtagService;
 import org.graylog.plugins.sidecar.services.SidecarService;
 import org.graylog.plugins.sidecar.system.SidecarConfiguration;
 import org.graylog2.audit.jersey.AuditEvent;
@@ -88,6 +89,7 @@ public class AdministrationResource extends RestResource implements PluginRestRe
     private final AdministrationFiltersFactory administrationFiltersFactory;
     private final ActiveSidecarFilter activeSidecarFilter;
     private final SidecarStatusMapper sidecarStatusMapper;
+    private final EtagService etagService;
 
     @Inject
     public AdministrationResource(SidecarService sidecarService,
@@ -96,7 +98,8 @@ public class AdministrationResource extends RestResource implements PluginRestRe
                                   ActionService actionService,
                                   AdministrationFiltersFactory administrationFiltersFactory,
                                   ClusterConfigService clusterConfigService,
-                                  SidecarStatusMapper sidecarStatusMapper) {
+                                  SidecarStatusMapper sidecarStatusMapper,
+                                  EtagService etagService) {
         final SidecarConfiguration sidecarConfiguration = clusterConfigService.getOrDefault(SidecarConfiguration.class, SidecarConfiguration.defaultConfiguration());
         this.sidecarService = sidecarService;
         this.configurationService = configurationService;
@@ -104,6 +107,7 @@ public class AdministrationResource extends RestResource implements PluginRestRe
         this.actionService = actionService;
         this.administrationFiltersFactory = administrationFiltersFactory;
         this.sidecarStatusMapper = sidecarStatusMapper;
+        this.etagService = etagService;
         this.activeSidecarFilter = new ActiveSidecarFilter(sidecarConfiguration.sidecarInactiveThreshold());
         this.searchQueryParser = new SearchQueryParser(Sidecar.FIELD_NODE_NAME, SidecarResource.SEARCH_FIELD_MAPPING);
     }
@@ -165,6 +169,7 @@ public class AdministrationResource extends RestResource implements PluginRestRe
             final CollectorActions collectorActions = actionService.fromRequest(bulkActionRequest.sidecarId(), actions);
             actionService.saveAction(collectorActions);
         }
+        etagService.invalidateAll();
 
         return Response.accepted().build();
     }

--- a/graylog2-server/src/main/java/org/graylog/plugins/sidecar/rest/resources/SidecarResource.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/sidecar/rest/resources/SidecarResource.java
@@ -19,6 +19,7 @@ package org.graylog.plugins.sidecar.rest.resources;
 import com.codahale.metrics.annotation.Timed;
 import com.google.common.base.Function;
 import com.google.common.collect.ImmutableMap;
+import com.google.common.hash.Hashing;
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
 import io.swagger.annotations.ApiParam;
@@ -42,6 +43,7 @@ import org.graylog.plugins.sidecar.rest.requests.RegistrationRequest;
 import org.graylog.plugins.sidecar.rest.responses.RegistrationResponse;
 import org.graylog.plugins.sidecar.rest.responses.SidecarListResponse;
 import org.graylog.plugins.sidecar.services.ActionService;
+import org.graylog.plugins.sidecar.services.EtagService;
 import org.graylog.plugins.sidecar.services.SidecarService;
 import org.graylog.plugins.sidecar.system.SidecarConfiguration;
 import org.graylog2.audit.jersey.AuditEvent;
@@ -71,6 +73,9 @@ import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
 import javax.ws.rs.Produces;
 import javax.ws.rs.QueryParam;
+import javax.ws.rs.core.Context;
+import javax.ws.rs.core.EntityTag;
+import javax.ws.rs.core.HttpHeaders;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 import java.util.List;
@@ -97,6 +102,7 @@ public class SidecarResource extends RestResource implements PluginRestResource 
 
     private final SidecarService sidecarService;
     private final ActionService actionService;
+    private final EtagService etagService;
     private final ActiveSidecarFilter activeSidecarFilter;
     private final SearchQueryParser searchQueryParser;
     private final SidecarStatusMapper sidecarStatusMapper;
@@ -106,12 +112,14 @@ public class SidecarResource extends RestResource implements PluginRestResource 
     public SidecarResource(SidecarService sidecarService,
                            ActionService actionService,
                            ClusterConfigService clusterConfigService,
-                           SidecarStatusMapper sidecarStatusMapper) {
+                           SidecarStatusMapper sidecarStatusMapper,
+                           EtagService etagService) {
         this.sidecarService = sidecarService;
         this.sidecarConfiguration = clusterConfigService.getOrDefault(SidecarConfiguration.class, SidecarConfiguration.defaultConfiguration());
         this.actionService = actionService;
         this.activeSidecarFilter = new ActiveSidecarFilter(sidecarConfiguration.sidecarInactiveThreshold());
         this.sidecarStatusMapper = sidecarStatusMapper;
+        this.etagService = etagService;
         this.searchQueryParser = new SearchQueryParser(Sidecar.FIELD_NODE_NAME, SEARCH_FIELD_MAPPING);
     }
 
@@ -196,7 +204,11 @@ public class SidecarResource extends RestResource implements PluginRestResource 
                              @PathParam("sidecarId") @NotEmpty String sidecarId,
                              @ApiParam(name = "JSON body", required = true)
                              @Valid @NotNull RegistrationRequest request,
+                             @Context HttpHeaders httpHeaders,
                              @HeaderParam(value = "X-Graylog-Sidecar-Version") @NotEmpty String sidecarVersion) {
+
+        String ifNoneMatch = httpHeaders.getHeaderString("If-None-Match");
+        Boolean etagCached = false;
         final Sidecar newSidecar;
         final Sidecar oldSidecar = sidecarService.findByNodeId(sidecarId);
         List<ConfigurationAssignment> assignments = null;
@@ -213,6 +225,18 @@ public class SidecarResource extends RestResource implements PluginRestResource 
         }
         sidecarService.save(newSidecar);
 
+        Response.ResponseBuilder builder = Response.noContent();
+        // check if client is up to date with a known valid etag
+        if (ifNoneMatch != null) {
+            EntityTag etag = new EntityTag(ifNoneMatch.replaceAll("\"", ""));
+            if (etagService.isPresent(etag.toString())) {
+                etagCached = true;
+                builder = Response.notModified();
+                builder.tag(etag);
+                return builder.build();
+            }
+        }
+
         final CollectorActions collectorActions = actionService.findActionBySidecar(sidecarId, true);
         List<CollectorAction> collectorAction = null;
         if (collectorActions != null) {
@@ -225,7 +249,19 @@ public class SidecarResource extends RestResource implements PluginRestResource 
                 this.sidecarConfiguration.sidecarConfigurationOverride(),
                 collectorAction,
                 assignments);
-        return Response.accepted(sidecarRegistrationResponse).build();
+        // add new etag to cache
+        String etagString = registrationResponseToEtag(sidecarRegistrationResponse);
+        EntityTag collectorConfigurationEtag = new EntityTag(etagString);
+        builder = Response.accepted(sidecarRegistrationResponse);
+        builder.tag(collectorConfigurationEtag);
+        etagService.put(collectorConfigurationEtag.toString());
+        return builder.build();
+    }
+
+    private String registrationResponseToEtag(RegistrationResponse registrationResponse) {
+        return Hashing.md5()
+                .hashInt(registrationResponse.hashCode())  // avoid negative values
+                .toString();
     }
 
     @PUT
@@ -249,6 +285,7 @@ public class SidecarResource extends RestResource implements PluginRestResource 
             try {
                 Sidecar sidecar = sidecarService.assignConfiguration(nodeId, nodeRelations);
                 sidecarService.save(sidecar);
+                etagService.invalidateAll();
             } catch (org.graylog2.database.NotFoundException e) {
                 throw new NotFoundException(e.getMessage());
             }

--- a/graylog2-server/src/test/java/org/graylog/plugins/sidecar/collectors/rest/SidecarResourceTest.java
+++ b/graylog2-server/src/test/java/org/graylog/plugins/sidecar/collectors/rest/SidecarResourceTest.java
@@ -17,6 +17,7 @@
 package org.graylog.plugins.sidecar.collectors.rest;
 
 import com.google.common.collect.Lists;
+import okhttp3.Headers;
 import org.graylog.plugins.sidecar.collectors.rest.resources.RestResourceBaseTest;
 import org.graylog.plugins.sidecar.filter.ActiveSidecarFilter;
 import org.graylog.plugins.sidecar.mapper.SidecarStatusMapper;
@@ -26,6 +27,7 @@ import org.graylog.plugins.sidecar.rest.models.SidecarSummary;
 import org.graylog.plugins.sidecar.rest.requests.RegistrationRequest;
 import org.graylog.plugins.sidecar.rest.resources.SidecarResource;
 import org.graylog.plugins.sidecar.services.ActionService;
+import org.graylog.plugins.sidecar.services.EtagService;
 import org.graylog.plugins.sidecar.services.SidecarService;
 import org.graylog.plugins.sidecar.system.SidecarConfiguration;
 import org.graylog2.plugin.cluster.ClusterConfigService;
@@ -38,13 +40,12 @@ import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
 
 import javax.ws.rs.NotFoundException;
+import javax.ws.rs.core.HttpHeaders;
 import javax.ws.rs.core.Response;
 import java.util.List;
 
 import static org.graylog.plugins.sidecar.collectors.rest.assertj.ResponseAssert.assertThat;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
+import static org.junit.Assert.*;
 import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -53,6 +54,7 @@ import static org.mockito.Mockito.when;
 public class SidecarResourceTest extends RestResourceBaseTest {
     private SidecarResource resource;
     private List<Sidecar> sidecars;
+    private Headers httpHeaders;
 
     @Mock
     private SidecarService sidecarService;
@@ -67,7 +69,13 @@ public class SidecarResourceTest extends RestResourceBaseTest {
     private ClusterConfigService clusterConfigService;
 
     @Mock
+    private EtagService etagService;
+
+    @Mock
     private SidecarConfiguration sidecarConfiguration;
+
+    @Mock
+    private HttpHeaders headers;
 
     @Before
     public void setUp() throws Exception {
@@ -78,7 +86,8 @@ public class SidecarResourceTest extends RestResourceBaseTest {
                 sidecarService,
                 actionService,
                 clusterConfigService,
-                statusMapper);
+                statusMapper,
+                etagService);
     }
 
     @Test(expected = NotFoundException.class)
@@ -129,7 +138,7 @@ public class SidecarResourceTest extends RestResourceBaseTest {
                 )
         );
 
-        final Response response = this.resource.register("sidecarId", input, "0.0.1");
+        final Response response = this.resource.register("sidecarId", input, headers, "0.0.1");
 
         assertThat(response).isSuccess();
     }
@@ -148,7 +157,7 @@ public class SidecarResourceTest extends RestResourceBaseTest {
                 )
         );
 
-        final Response response = this.resource.register("", invalid, "0.0.1");
+        final Response response = this.resource.register("", invalid, headers, "0.0.1");
 
         assertThat(response).isError();
         assertThat(response).isStatus(Response.Status.BAD_REQUEST);
@@ -168,7 +177,7 @@ public class SidecarResourceTest extends RestResourceBaseTest {
                 )
         );
 
-        final Response response = this.resource.register("sidecarId", invalid, "0.0.1");
+        final Response response = this.resource.register("sidecarId", invalid, headers, "0.0.1");
 
         assertThat(response).isError();
         assertThat(response).isStatus(Response.Status.BAD_REQUEST);
@@ -182,7 +191,7 @@ public class SidecarResourceTest extends RestResourceBaseTest {
                 null
         );
 
-        final Response response = this.resource.register("sidecarId", invalid, "0.0.1");
+        final Response response = this.resource.register("sidecarId", invalid, headers, "0.0.1");
 
         assertThat(response).isError();
         assertThat(response).isStatus(Response.Status.BAD_REQUEST);
@@ -202,7 +211,7 @@ public class SidecarResourceTest extends RestResourceBaseTest {
                 )
         );
 
-        final Response response = this.resource.register("sidecarId", invalid, "0.0.1");
+        final Response response = this.resource.register("sidecarId", invalid, headers, "0.0.1");
 
         assertThat(response).isError();
         assertThat(response).isStatus(Response.Status.BAD_REQUEST);


### PR DESCRIPTION
The response to the registration PUT request contains
configuration assignments, which can be cached as well.

This requires us to invalidate the sidecar Etag cache in more
situations:
 - Configuration assignments
 - User triggered collector actions (stop, start, restart)

