### PR TITLE
Add name property on input component and add it to login page

### DIFF
--- a/graylog2-web-interface/src/components/bootstrap/Input.jsx
+++ b/graylog2-web-interface/src/components/bootstrap/Input.jsx
@@ -14,6 +14,7 @@ import InputWrapper from './InputWrapper';
 class Input extends React.Component {
   static propTypes = {
     id: PropTypes.string.isRequired,
+    name: PropTypes.string,
     type: PropTypes.string,
     label: PropTypes.oneOfType([
       PropTypes.element,
@@ -48,6 +49,7 @@ class Input extends React.Component {
 
   static defaultProps = {
     type: undefined,
+    name: undefined,
     label: '',
     labelClassName: undefined,
     formGroupClassName: undefined,

--- a/graylog2-web-interface/src/pages/LoginPage.jsx
+++ b/graylog2-web-interface/src/pages/LoginPage.jsx
@@ -96,9 +96,9 @@ const LoginPage = createReactClass({
 
                 {alert}
 
-                <Input ref={(username) => { this.username = username; }} id="username" type="text" placeholder="Username" autoFocus />
+                <Input ref={(username) => { this.username = username; }} id="username" name="username" type="text" placeholder="Username" autoFocus />
 
-                <Input ref={(password) => { this.password = password; }} id="password" type="password" placeholder="Password" />
+                <Input ref={(password) => { this.password = password; }} id="password" name="password" type="password" placeholder="Password" />
 
                 <FormGroup>
                   <Button type="submit" bsStyle="info" disabled={this.state.loading}>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Add a name props on Input component.
Add name props on Login page for username input and password input.

## Motivation and Context

For permit to extensions like password managers (enpass e.g.) to permit auto-login,
and for permit global companies configuration to provide an auth form based e.g Onelogin.
We need to have a name attribute on inputs in the login form to allow this kinds of services to login users automatically.

## How Has This Been Tested?

I tried to launch devServer to test it in real time but it doesn't work. The devServer has never been ready yet and the message "wait bundle finished" remained for each page's refresh.
![image](https://user-images.githubusercontent.com/12797391/50634643-b2510d00-0f4f-11e9-994f-32d49490a457.png)

I started the documentation server to test if the property is available in the list of the input documentation and it's OK.

It's not a big PR, so if someone can run a devServer to try it fast ;).

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
