### PR TITLE
Fix regression that came in with PR #5376

### DIFF
--- a/graylog2-web-interface/src/components/sidecars/configuration-forms/ConfigurationForm.jsx
+++ b/graylog2-web-interface/src/components/sidecars/configuration-forms/ConfigurationForm.jsx
@@ -149,8 +149,8 @@ const ConfigurationForm = createReactClass({
       // Wait for the promise to resolve and then update the whole formData state
       defaultTemplatePromise.then((defaultTemplate) => {
         this._onTemplateChange(defaultTemplate);
+        nextFormData.template = defaultTemplate;
       });
-      return;
     }
 
     this.setState({ formData: nextFormData });


### PR DESCRIPTION
After merging PR #5376 the collectorId was not updated on the ConfigurationForm in the state anymore when a collector backend was selected in the drop-down. This leads to an error when a fresh configuration is created.

See also:
https://github.com/Graylog2/graylog2-server/pull/5376#discussion_r239521862

## Description
We dont exit the _onCollectorChange() function anymore before collectorId and template is updated.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
