### PR TITLE
Update plugin list in System -> Enterprise page

### DIFF
--- a/graylog2-web-interface/src/components/enterprise/PluginList.css
+++ b/graylog2-web-interface/src/components/enterprise/PluginList.css
@@ -1,4 +1,4 @@
-.enterprise-plugins {
+:local(.enterprisePlugins) {
   margin-left: 0;
   padding-left: 0;
 }

--- a/graylog2-web-interface/src/components/enterprise/PluginList.jsx
+++ b/graylog2-web-interface/src/components/enterprise/PluginList.jsx
@@ -3,19 +3,10 @@ import createReactClass from 'create-react-class';
 import { Row, Col } from 'react-bootstrap';
 
 import { PluginStore } from 'graylog-web-plugin/plugin';
+import style from './PluginList.css';
 
 const PluginList = createReactClass({
   displayName: 'PluginList',
-
-  componentDidMount() {
-    this.style.use();
-  },
-
-  componentWillUnmount() {
-    this.style.unuse();
-  },
-
-  style: require('!style/useable!css!./PluginList.css'),
 
   ENTERPRISE_PLUGINS: {
     'graylog-plugin-enterprise': 'Graylog Plugin Enterprise',
@@ -25,7 +16,7 @@ const PluginList = createReactClass({
     const plugin = PluginStore.get().filter(p => p.metadata.name === pluginName)[0];
     return (
       <li key={pluginName} className={plugin ? 'text-success' : 'text-danger'}>
-        <i className={`fa fa-${plugin ? 'check-circle' : 'minus-circle'}`}/>&nbsp;
+        <i className={`fa fa-${plugin ? 'check-circle' : 'minus-circle'}`} />&nbsp;
         {this.ENTERPRISE_PLUGINS[pluginName]} is {plugin ? 'installed' : 'not installed'}
       </li>
     );
@@ -38,7 +29,7 @@ const PluginList = createReactClass({
       <Row className="content">
         <Col md={12}>
           <p>This is the status of Graylog Enterprise modules in this cluster:</p>
-          <ul className="enterprise-plugins">
+          <ul className={style.enterprisePlugins}>
             {enterprisePluginList}
           </ul>
         </Col>

--- a/graylog2-web-interface/src/components/enterprise/PluginList.jsx
+++ b/graylog2-web-interface/src/components/enterprise/PluginList.jsx
@@ -18,9 +18,7 @@ const PluginList = createReactClass({
   style: require('!style/useable!css!./PluginList.css'),
 
   ENTERPRISE_PLUGINS: {
-    ArchivePlugin: 'Archive plugin',
-    LicensePlugin: 'License plugin',
-    'graylog-plugin-auditlog': 'Audit log plugin',
+    'graylog-plugin-enterprise': 'Graylog Plugin Enterprise',
   },
 
   _formatPlugin(pluginName) {

--- a/graylog2-web-interface/src/pages/EnterprisePage.jsx
+++ b/graylog2-web-interface/src/pages/EnterprisePage.jsx
@@ -41,7 +41,7 @@ const EnterprisePage = createReactClass({
           </PageHeader>
 
           <GraylogClusterOverview />
-          <PluginList/>
+          <PluginList />
         </div>
       </DocumentTitle>
     );


### PR DESCRIPTION
The plugin list in the _System -> Enterprise_ page was outdated, since we now ship all enterprise modules in a single plugin. This PR takes care of correcting that and fixes a few linter issues we had in there.

Fixes #4600