### PR TITLE
Disable content pack parameter type when editing

### DIFF
--- a/graylog2-web-interface/src/components/content-packs/ContentPackEditParameter.jsx
+++ b/graylog2-web-interface/src/components/content-packs/ContentPackEditParameter.jsx
@@ -144,6 +144,7 @@ class ContentPackEditParameter extends React.Component {
 
   render() {
     const header = this.props.parameterToEdit ? 'Edit parameter' : 'Create parameter';
+    const disableType = !!this.props.parameterToEdit;
     return (
       <div>
         <h2>{header}</h2>
@@ -187,6 +188,7 @@ class ContentPackEditParameter extends React.Component {
             <Input name="type"
                    id="type"
                    type="select"
+                   disabled={disableType}
                    value={this.state.newParameter.type}
                    onChange={this._bindValue}
                    label="Value Type"

--- a/graylog2-web-interface/src/components/content-packs/ContentPackEditParameter.test.jsx
+++ b/graylog2-web-interface/src/components/content-packs/ContentPackEditParameter.test.jsx
@@ -11,7 +11,7 @@ describe('<ContentPackEditParameters />', () => {
     expect(wrapper.toJSON()).toMatchSnapshot();
   });
 
-  it('should render a parameter', () => {
+  it('should render a form for creation', () => {
     const parameters = [{
       name: 'A parameter name',
       title: 'A parameter title',
@@ -20,6 +20,27 @@ describe('<ContentPackEditParameters />', () => {
       default_value: 'test',
     }];
     const wrapper = renderer.create(<ContentPackEditParameter parameters={parameters} />);
+    expect(wrapper.toJSON()).toMatchSnapshot();
+  });
+
+  it('should render a form for edition', () => {
+    const parameters = [{
+      name: 'A parameter name',
+      title: 'A parameter title',
+      description: 'A parameter descriptions',
+      type: 'string',
+      default_value: 'test',
+    }];
+
+    const parameterToEdit = {
+      name: 'A parameter name',
+      title: 'A parameter title',
+      description: 'A parameter descriptions',
+      type: 'string',
+      default_value: 'test',
+    };
+    const wrapper = renderer.create(<ContentPackEditParameter parameters={parameters}
+                                                              parameterToEdit={parameterToEdit} />);
     expect(wrapper.toJSON()).toMatchSnapshot();
   });
 

--- a/graylog2-web-interface/src/components/content-packs/__snapshots__/ContentPackEditParameter.test.jsx.snap
+++ b/graylog2-web-interface/src/components/content-packs/__snapshots__/ContentPackEditParameter.test.jsx.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`<ContentPackEditParameters /> should render a parameter 1`] = `
+exports[`<ContentPackEditParameters /> should render a form for creation 1`] = `
 <div>
   <h2>
     Create parameter
@@ -111,6 +111,7 @@ exports[`<ContentPackEditParameters /> should render a parameter 1`] = `
         <span>
           <select
             className="form-control"
+            disabled={false}
             id="type"
             label="Value Type"
             name="type"
@@ -168,6 +169,188 @@ exports[`<ContentPackEditParameters /> should render a parameter 1`] = `
             placeholder=""
             type="text"
             value=""
+          />
+          <span
+            className="help-block"
+          >
+            Give a default value if the parameter is not optional.
+          </span>
+        </span>
+      </div>
+    </fieldset>
+  </form>
+</div>
+`;
+
+exports[`<ContentPackEditParameters /> should render a form for edition 1`] = `
+<div>
+  <h2>
+    Edit parameter
+  </h2>
+  <br />
+  <form
+    className="parameter-form"
+    id="parameter-form"
+    onSubmit={[Function]}
+  >
+    <fieldset>
+      <div
+        className="form-group"
+      >
+        <label
+          className="control-label"
+          htmlFor="title"
+        >
+          Title
+        </label>
+        <span>
+          <input
+            className="form-control"
+            id="title"
+            label="Title"
+            maxLength={250}
+            name="title"
+            onChange={[Function]}
+            placeholder=""
+            required={true}
+            type="text"
+            value="A parameter title"
+          />
+          <span
+            className="help-block"
+          >
+            Give a descriptive title for this content pack.
+          </span>
+        </span>
+      </div>
+      <div
+        className="form-group"
+      >
+        <label
+          className="control-label"
+          htmlFor="name"
+        >
+          Name
+        </label>
+        <span>
+          <input
+            className="form-control"
+            id="name"
+            label="Name"
+            maxLength={250}
+            name="name"
+            onChange={[Function]}
+            placeholder=""
+            required={true}
+            type="text"
+            value="A parameter name"
+          />
+          <span
+            className="help-block"
+          >
+            This is used as the parameter reference and must not contain a space.
+          </span>
+        </span>
+      </div>
+      <div
+        className="form-group"
+      >
+        <label
+          className="control-label"
+          htmlFor="description"
+        >
+          Description
+        </label>
+        <span>
+          <input
+            className="form-control"
+            id="description"
+            label="Description"
+            maxLength={250}
+            name="description"
+            onChange={[Function]}
+            placeholder=""
+            required={true}
+            type="text"
+            value="A parameter descriptions"
+          />
+          <span
+            className="help-block"
+          >
+            Give a description explaining what will be done with this parameter.
+          </span>
+        </span>
+      </div>
+      <div
+        className="form-group"
+      >
+        <label
+          className="control-label"
+          htmlFor="type"
+        >
+          Value Type
+        </label>
+        <span>
+          <select
+            className="form-control"
+            disabled={true}
+            id="type"
+            label="Value Type"
+            name="type"
+            onChange={[Function]}
+            placeholder=""
+            required={true}
+            type="select"
+            value="string"
+          >
+            <option
+              value="string"
+            >
+              String
+            </option>
+            <option
+              value="integer"
+            >
+              Integer
+            </option>
+            <option
+              value="double"
+            >
+              Double
+            </option>
+            <option
+              value="boolean"
+            >
+              Boolean
+            </option>
+          </select>
+          <span
+            className="help-block"
+          >
+            Give the type of the parameter.
+          </span>
+        </span>
+      </div>
+      <div
+        className="form-group"
+      >
+        <label
+          className="control-label"
+          htmlFor="default_value"
+        >
+          Default value
+        </label>
+        <span>
+          <input
+            className="form-control"
+            id="default_value"
+            label="Default value"
+            maxLength={250}
+            name="default_value"
+            onChange={[Function]}
+            placeholder=""
+            type="text"
+            value="test"
           />
           <span
             className="help-block"
@@ -292,6 +475,7 @@ exports[`<ContentPackEditParameters /> should render with empty parameters 1`] =
         <span>
           <select
             className="form-control"
+            disabled={false}
             id="type"
             label="Value Type"
             name="type"


### PR DESCRIPTION
Prior to this change, the type of a parameter could be changed
which led to problems if the parameter was already applied to
configuration values. Since the value type and the parameter type
must match.

This change will prevent the change of a parameter type. If the user
wishes the change of a parameter type, he has to delete and recreate
a parameter.

Fixes #5404 

Needs backport to [3.0](https://github.com/Graylog2/graylog2-server/milestone/57)
## How Has This Been Tested?
Edit a content pack with parameters and tried to change the type. Also I add a new
parameter where I was still able to change the parameter.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
