### PR TITLE
Add the CONTAINS rule as one not requiring the field to be present

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/streams/StreamRouterEngine.java
+++ b/graylog2-server/src/main/java/org/graylog2/streams/StreamRouterEngine.java
@@ -54,7 +54,7 @@ import java.util.concurrent.TimeUnit;
 public class StreamRouterEngine {
     private static final Logger LOG = LoggerFactory.getLogger(StreamRouterEngine.class);
 
-    private final EnumSet<StreamRuleType> ruleTypesNotNeedingFieldPresence = EnumSet.of(StreamRuleType.PRESENCE, StreamRuleType.EXACT, StreamRuleType.REGEX, StreamRuleType.ALWAYS_MATCH);
+    private final EnumSet<StreamRuleType> ruleTypesNotNeedingFieldPresence = EnumSet.of(StreamRuleType.PRESENCE, StreamRuleType.EXACT, StreamRuleType.REGEX, StreamRuleType.ALWAYS_MATCH, StreamRuleType.CONTAINS);
     private final List<Stream> streams;
     private final StreamFaultManager streamFaultManager;
     private final StreamMetrics streamMetrics;

--- a/graylog2-server/src/test/java/org/graylog2/streams/StreamRouterEngineTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/streams/StreamRouterEngineTest.java
@@ -189,6 +189,39 @@ public class StreamRouterEngineTest {
     }
 
     @Test
+    public void testInvertedContainsMatch() throws Exception {
+        final StreamMock stream = getStreamMock("test");
+        final StreamRuleMock rule = new StreamRuleMock(
+            ImmutableMap.<String, Object>builder()
+                .put("_id", new ObjectId())
+                .put("field", "testfield")
+                .put("inverted", true)
+                .put("value", "testvalue")
+                .put("type", StreamRuleType.CONTAINS.toInteger())
+                .put("stream_id", stream.getId())
+                .build()
+        );
+
+        stream.setStreamRules(Lists.newArrayList(rule));
+
+        final StreamRouterEngine engine = newEngine(Lists.newArrayList(stream));
+        final Message message = getMessage();
+
+        // Without the field
+        assertEquals(Lists.newArrayList(stream), engine.match(message));
+
+        // Without the matching value in the field
+        message.addField("testfield", "no-foobar");
+
+        assertEquals(Lists.newArrayList(stream), engine.match(message));
+
+        // With matching value in the field.
+        message.addField("testfield", "hello testvalue");
+
+        assertTrue(engine.match(message).isEmpty());
+    }
+
+    @Test
     public void testGreaterMatch() throws Exception {
         final StreamMock stream = getStreamMock("test");
         final StreamRuleMock rule = new StreamRuleMock(ImmutableMap.of(

--- a/graylog2-server/src/test/java/org/graylog2/streams/StreamRouterEngineTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/streams/StreamRouterEngineTest.java
@@ -177,6 +177,9 @@ public class StreamRouterEngineTest {
         final StreamRouterEngine engine = newEngine(Lists.newArrayList(stream));
         final Message message = getMessage();
 
+        // Without the field
+        assertTrue(engine.match(message).isEmpty());
+
         // With wrong value for field.
         message.addField("testfield", "no-foobar");
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
The CONTAINS rule evaluates the match to false when the rule is inverted (I.E. "field does not contain value") and the field is missing (which can be seen in [tests](https://github.com/Graylog2/graylog2-server/blob/0fb0b2ee3de22a1258abe5787e19e79bc9e84eff/graylog2-server/src/test/java/org/graylog2/streams/matchers/ContainsMatcherTest.java#L76-L83)), but because the rule is not in the [`ruleTypesNotNeedingFieldPresence` list](https://github.com/Graylog2/graylog2-server/blob/0fb0b2ee3de22a1258abe5787e19e79bc9e84eff/graylog2-server/src/main/java/org/graylog2/streams/StreamRouterEngine.java#L57) the rule is [not tested when the field doesn't exist](https://github.com/Graylog2/graylog2-server/blob/0fb0b2ee3de22a1258abe5787e19e79bc9e84eff/graylog2-server/src/main/java/org/graylog2/streams/StreamRouterEngine.java#L176-L179).

## Motivation and Context
Having an error stream from which we wanted to exclude some noisy errors, we added a rule "Field Exception must not contain Server cannot set status after HTTP headers have been sent". Following that change, messages that did not contain the Exception field were no longer being added to the stream.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
