### PR TITLE
Mask password fields of inputs

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/rest/resources/system/inputs/InputsResource.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/resources/system/inputs/InputsResource.java
@@ -64,6 +64,7 @@ import javax.ws.rs.Produces;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 import java.net.URI;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -231,7 +232,7 @@ public class InputsResource extends RestResource {
                     final ConfigurationField field = configurationRequest.getField(entry.getKey());
                     if (field instanceof TextField) {
                         final TextField textField = (TextField)field;
-                        if (textField.getAttributes().contains(TextField.Attribute.IS_PASSWORD.toString().toLowerCase())
+                        if (textField.getAttributes().contains(TextField.Attribute.IS_PASSWORD.toString().toLowerCase(Locale.ENGLISH))
                                 && !Strings.isNullOrEmpty((String)entry.getValue())) {
                             return "<password set>";
                         }

--- a/graylog2-server/src/main/java/org/graylog2/rest/resources/system/inputs/InputsResource.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/resources/system/inputs/InputsResource.java
@@ -222,6 +222,9 @@ public class InputsResource extends RestResource {
 
     @VisibleForTesting
     Map<String, Object> maskPasswordsInConfiguration(Map<String, Object> configuration, ConfigurationRequest configurationRequest) {
+        if (configuration == null || configurationRequest == null) {
+            return configuration;
+        }
         return configuration.entrySet()
                 .stream()
                 .collect(Collectors.toMap(Map.Entry::getKey, entry -> {

--- a/graylog2-server/src/main/java/org/graylog2/rest/resources/system/inputs/InputsResource.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/resources/system/inputs/InputsResource.java
@@ -208,6 +208,8 @@ public class InputsResource extends RestResource {
         final InputDescription inputDescription = this.availableInputs.get(input.getType());
         final String name = inputDescription != null ? inputDescription.getName() : "Unknown Input (" + input.getType() + ")";
         final ConfigurationRequest configurationRequest = inputDescription != null ? inputDescription.getConfigurationRequest() : null;
+        final Map<String, Object> configuration = isPermitted(RestPermissions.INPUTS_EDIT, input.getId()) ?
+                input.getConfiguration() : maskPasswordsInConfiguration(input.getConfiguration(), configurationRequest);
         return InputSummary.create(input.getTitle(),
                 input.isGlobal(),
                 name,
@@ -216,7 +218,7 @@ public class InputsResource extends RestResource {
                 input.getCreatedAt(),
                 input.getType(),
                 input.getCreatorUserId(),
-                maskPasswordsInConfiguration(input.getConfiguration(), configurationRequest),
+                configuration,
                 input.getStaticFields(),
                 input.getNodeId()
         );

--- a/graylog2-server/src/main/java/org/graylog2/shared/inputs/InputDescription.java
+++ b/graylog2-server/src/main/java/org/graylog2/shared/inputs/InputDescription.java
@@ -16,6 +16,7 @@
  */
 package org.graylog2.shared.inputs;
 
+import org.graylog2.plugin.configuration.ConfigurationRequest;
 import org.graylog2.plugin.inputs.MessageInput;
 
 import java.util.Map;
@@ -43,5 +44,9 @@ public class InputDescription {
 
     public Map<String, Map<String, Object>> getRequestedConfiguration() {
         return config.combinedRequestedConfiguration().asList();
+    }
+
+    public ConfigurationRequest getConfigurationRequest() {
+        return config.combinedRequestedConfiguration();
     }
 }

--- a/graylog2-server/src/test/java/org/graylog2/rest/resources/system/inputs/InputsResourceMaskingPasswordsTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/rest/resources/system/inputs/InputsResourceMaskingPasswordsTest.java
@@ -144,6 +144,21 @@ public class InputsResourceMaskingPasswordsTest {
     }
 
     @Test
+    public void testMaskingOfNullValueInMap() {
+        final TextField passwordInput = mock(TextField.class);
+
+        when(passwordInput.getName()).thenReturn("nopassword");
+        when(passwordInput.getAttributes()).thenReturn(ImmutableList.of());
+        final ConfigurationRequest configurationRequest = ConfigurationRequest.createWithFields(passwordInput);
+        final Map<String, Object> configuration = Collections.singletonMap("nopassword", null);
+
+        final Map<String, Object> resultingAttributes = this.inputsResource.maskPasswordsInConfiguration(configuration, configurationRequest);
+
+        assertThat(resultingAttributes).hasSize(1);
+        assertThat(resultingAttributes).containsEntry("nopassword", null);
+    }
+
+    @Test
     public void testRetrievalOfInputWithPasswordField() throws NotFoundException {
         final String inputId = "myinput";
         final String inputType = "dummyinput";
@@ -182,8 +197,6 @@ public class InputsResourceMaskingPasswordsTest {
         final String inputType = "dummyinput";
 
         final Input input = getInput(inputId, inputType);
-
-        when(inputService.find(inputId)).thenReturn(input);
 
         final ConfigurationField fooInput = mock(ConfigurationField.class);
         when(fooInput.getName()).thenReturn("foo");

--- a/graylog2-server/src/test/java/org/graylog2/rest/resources/system/inputs/InputsResourceMaskingPasswordsTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/rest/resources/system/inputs/InputsResourceMaskingPasswordsTest.java
@@ -39,6 +39,7 @@ import org.mockito.junit.MockitoRule;
 
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.Locale;
 import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -88,7 +89,7 @@ public class InputsResourceMaskingPasswordsTest {
 
         when(fooInput.getName()).thenReturn("foo");
         when(passwordInput.getName()).thenReturn("password");
-        when(passwordInput.getAttributes()).thenReturn(ImmutableList.of(TextField.Attribute.IS_PASSWORD.toString().toLowerCase()));
+        when(passwordInput.getAttributes()).thenReturn(ImmutableList.of(TextField.Attribute.IS_PASSWORD.toString().toLowerCase(Locale.ENGLISH)));
         final ConfigurationRequest configurationRequest = ConfigurationRequest.createWithFields(fooInput, passwordInput);
         final Map<String, Object> configuration = ImmutableMap.of(
                 "foo", 42,
@@ -217,7 +218,7 @@ public class InputsResourceMaskingPasswordsTest {
         final TextField passwordInput = mock(TextField.class);
 
         when(passwordInput.getName()).thenReturn(name);
-        when(passwordInput.getAttributes()).thenReturn(ImmutableList.of(TextField.Attribute.IS_PASSWORD.toString().toLowerCase()));
+        when(passwordInput.getAttributes()).thenReturn(ImmutableList.of(TextField.Attribute.IS_PASSWORD.toString().toLowerCase(Locale.ENGLISH)));
         return passwordInput;
     }
 

--- a/graylog2-server/src/test/java/org/graylog2/rest/resources/system/inputs/InputsResourceMaskingPasswordsTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/rest/resources/system/inputs/InputsResourceMaskingPasswordsTest.java
@@ -1,0 +1,98 @@
+package org.graylog2.rest.resources.system.inputs;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import org.graylog2.inputs.InputService;
+import org.graylog2.plugin.configuration.ConfigurationRequest;
+import org.graylog2.plugin.configuration.fields.ConfigurationField;
+import org.graylog2.plugin.configuration.fields.TextField;
+import org.graylog2.shared.inputs.MessageInputFactory;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnit;
+import org.mockito.junit.MockitoRule;
+
+import java.util.Collections;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class InputsResourceMaskingPasswordsTest {
+    @Rule
+    public final MockitoRule mockitoRule = MockitoJUnit.rule();
+
+    @Mock
+    private InputService inputService;
+
+    @Mock
+    private MessageInputFactory messageInputFactory;
+
+    private InputsResource inputsResource;
+
+    @Before
+    public void setUp() throws Exception {
+        this.inputsResource = new InputsResource(inputService, messageInputFactory);
+    }
+
+    @Test
+    public void testMaskingOfPasswordFields() {
+        final ConfigurationField fooInput = mock(ConfigurationField.class);
+        final TextField passwordInput = mock(TextField.class);
+
+        when(fooInput.getName()).thenReturn("foo");
+        when(passwordInput.getName()).thenReturn("password");
+        when(passwordInput.getAttributes()).thenReturn(ImmutableList.of(TextField.Attribute.IS_PASSWORD.toString().toLowerCase()));
+        final ConfigurationRequest configurationRequest = ConfigurationRequest.createWithFields(fooInput, passwordInput);
+        final Map<String, Object> configuration = ImmutableMap.of(
+                "foo", 42,
+                "password", "verysecret"
+        );
+
+        final Map<String, Object> resultingAttributes = this.inputsResource.maskPasswordsInConfiguration(configuration, configurationRequest);
+
+        assertThat(resultingAttributes).containsEntry("password", "<password set>");
+        assertThat(resultingAttributes).containsEntry("foo", 42);
+    }
+
+    @Test
+    public void testMaskingOfNonPasswordFields() {
+        final TextField passwordInput = mock(TextField.class);
+
+        when(passwordInput.getName()).thenReturn("nopassword");
+        when(passwordInput.getAttributes()).thenReturn(ImmutableList.of());
+        final ConfigurationRequest configurationRequest = ConfigurationRequest.createWithFields(passwordInput);
+        final Map<String, Object> configuration = ImmutableMap.of(
+                "nopassword", "lasers in space"
+        );
+
+        final Map<String, Object> resultingAttributes = this.inputsResource.maskPasswordsInConfiguration(configuration, configurationRequest);
+
+        assertThat(resultingAttributes).containsEntry("nopassword", "lasers in space");
+    }
+
+    @Test
+    public void testMaskingOfFieldWithoutType() {
+        final ConfigurationRequest configurationRequest = ConfigurationRequest.createWithFields();
+        final Map<String, Object> configuration = ImmutableMap.of(
+                "nopassword", "lasers in space"
+        );
+
+        final Map<String, Object> resultingAttributes = this.inputsResource.maskPasswordsInConfiguration(configuration, configurationRequest);
+
+        assertThat(resultingAttributes).containsEntry("nopassword", "lasers in space");
+    }
+
+    @Test
+    public void testMaskingOfEmptyMap() {
+        final ConfigurationRequest configurationRequest = ConfigurationRequest.createWithFields();
+        final Map<String, Object> configuration = Collections.emptyMap();
+
+        final Map<String, Object> resultingAttributes = this.inputsResource.maskPasswordsInConfiguration(configuration, configurationRequest);
+
+        assertThat(resultingAttributes).isEmpty();
+    }
+}

--- a/graylog2-web-interface/src/components/sidecars/configuration-forms/ConfigurationForm.jsx
+++ b/graylog2-web-interface/src/components/sidecars/configuration-forms/ConfigurationForm.jsx
@@ -149,8 +149,8 @@ const ConfigurationForm = createReactClass({
       // Wait for the promise to resolve and then update the whole formData state
       defaultTemplatePromise.then((defaultTemplate) => {
         this._onTemplateChange(defaultTemplate);
+        nextFormData.template = defaultTemplate;
       });
-      return;
     }
 
     this.setState({ formData: nextFormData });


### PR DESCRIPTION
Cherry-Pick from https://github.com/Graylog2/graylog2-server/pull/5432

<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Before this change, input details returned by the REST API would contain
all configuration fields without any modification. This implies that
password fields are also contained using their original value, showing
configured password for inputs in clear text.

For users which are not allowed to edit an input, this change now iterates over configuration fields checking for the presence of password fields and replace their content with `<password set>` instead of the original value if they are not empty.

For users which possess the required permission to edit an input, the original value is returned as it is used to set the value of the password field and would be used for updating the input if left unchanged.

This is a middle ground between a quick fix improving the situation (not everybody who is able to view inputs can also see passwords) and a proper fix that would require more work and attention to consistency, which will happen in a future version.

Refs #5408 and partially fixes it.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
