### PR TITLE
Mask password fields of inputs 3.0

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/rest/resources/system/inputs/InputsResource.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/resources/system/inputs/InputsResource.java
@@ -18,6 +18,7 @@ package org.graylog2.rest.resources.system.inputs;
 
 import com.codahale.metrics.annotation.Timed;
 import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.Strings;
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
 import io.swagger.annotations.ApiParam;
@@ -25,7 +26,6 @@ import io.swagger.annotations.ApiResponse;
 import io.swagger.annotations.ApiResponses;
 import org.apache.shiro.authz.annotation.RequiresAuthentication;
 import org.apache.shiro.authz.annotation.RequiresPermissions;
-import org.elasticsearch.common.Strings;
 import org.graylog2.audit.AuditEventTypes;
 import org.graylog2.audit.jersey.AuditEvent;
 import org.graylog2.inputs.Input;

--- a/graylog2-server/src/main/java/org/graylog2/shared/inputs/InputDescription.java
+++ b/graylog2-server/src/main/java/org/graylog2/shared/inputs/InputDescription.java
@@ -16,6 +16,7 @@
  */
 package org.graylog2.shared.inputs;
 
+import org.graylog2.plugin.configuration.ConfigurationRequest;
 import org.graylog2.plugin.inputs.MessageInput;
 
 import java.util.Map;
@@ -43,5 +44,9 @@ public class InputDescription {
 
     public Map<String, Map<String, Object>> getRequestedConfiguration() {
         return config.combinedRequestedConfiguration().asList();
+    }
+
+    public ConfigurationRequest getConfigurationRequest() {
+        return config.combinedRequestedConfiguration();
     }
 }

--- a/graylog2-server/src/test/java/org/graylog2/rest/resources/system/inputs/InputsResourceMaskingPasswordsTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/rest/resources/system/inputs/InputsResourceMaskingPasswordsTest.java
@@ -1,0 +1,332 @@
+/**
+ * This file is part of Graylog.
+ *
+ * Graylog is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.graylog2.rest.resources.system.inputs;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import org.apache.shiro.subject.Subject;
+import org.graylog2.database.NotFoundException;
+import org.graylog2.inputs.Input;
+import org.graylog2.inputs.InputService;
+import org.graylog2.plugin.configuration.ConfigurationRequest;
+import org.graylog2.plugin.configuration.fields.ConfigurationField;
+import org.graylog2.plugin.configuration.fields.TextField;
+import org.graylog2.rest.models.system.inputs.responses.InputSummary;
+import org.graylog2.rest.models.system.inputs.responses.InputsList;
+import org.graylog2.shared.inputs.InputDescription;
+import org.graylog2.shared.inputs.MessageInputFactory;
+import org.graylog2.shared.security.RestPermissions;
+import org.joda.time.DateTime;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnit;
+import org.mockito.junit.MockitoRule;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Locale;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class InputsResourceMaskingPasswordsTest {
+    @Rule
+    public final MockitoRule mockitoRule = MockitoJUnit.rule();
+
+    @Mock
+    private InputService inputService;
+
+    @Mock
+    private MessageInputFactory messageInputFactory;
+
+    @Mock
+    private Subject currentSubject;
+
+    private Map<String, InputDescription> availableInputs;
+
+    private InputsResource inputsResource;
+
+    class InputsTestResource extends InputsResource {
+        public InputsTestResource(InputService inputService, MessageInputFactory messageInputFactory) {
+            super(inputService, messageInputFactory);
+        }
+
+        @Override
+        protected Subject getSubject() {
+            return currentSubject;
+        }
+    }
+
+    @Before
+    public void setUp() throws Exception {
+        this.availableInputs = new HashMap<>();
+        when(messageInputFactory.getAvailableInputs()).thenReturn(this.availableInputs);
+        this.inputsResource = new InputsTestResource(inputService, messageInputFactory);
+    }
+
+    @Test
+    public void testMaskingOfPasswordFields() {
+        final ConfigurationField fooInput = mock(ConfigurationField.class);
+        final TextField passwordInput = mock(TextField.class);
+
+        when(fooInput.getName()).thenReturn("foo");
+        when(passwordInput.getName()).thenReturn("password");
+        when(passwordInput.getAttributes()).thenReturn(ImmutableList.of(TextField.Attribute.IS_PASSWORD.toString().toLowerCase(Locale.ENGLISH)));
+        final ConfigurationRequest configurationRequest = ConfigurationRequest.createWithFields(fooInput, passwordInput);
+        final Map<String, Object> configuration = ImmutableMap.of(
+                "foo", 42,
+                "password", "verysecret"
+        );
+
+        final Map<String, Object> resultingAttributes = this.inputsResource.maskPasswordsInConfiguration(configuration, configurationRequest);
+
+        assertThat(resultingAttributes).hasSize(2);
+        assertThat(resultingAttributes).containsEntry("password", "<password set>");
+        assertThat(resultingAttributes).containsEntry("foo", 42);
+    }
+
+    @Test
+    public void testMaskingOfNonPasswordFields() {
+        final TextField passwordInput = mock(TextField.class);
+
+        when(passwordInput.getName()).thenReturn("nopassword");
+        when(passwordInput.getAttributes()).thenReturn(ImmutableList.of());
+        final ConfigurationRequest configurationRequest = ConfigurationRequest.createWithFields(passwordInput);
+        final Map<String, Object> configuration = ImmutableMap.of(
+                "nopassword", "lasers in space"
+        );
+
+        final Map<String, Object> resultingAttributes = this.inputsResource.maskPasswordsInConfiguration(configuration, configurationRequest);
+
+        assertThat(resultingAttributes).hasSize(1);
+        assertThat(resultingAttributes).containsEntry("nopassword", "lasers in space");
+    }
+
+    @Test
+    public void testMaskingOfFieldWithoutType() {
+        final ConfigurationRequest configurationRequest = ConfigurationRequest.createWithFields();
+        final Map<String, Object> configuration = ImmutableMap.of(
+                "nopassword", "lasers in space"
+        );
+
+        final Map<String, Object> resultingAttributes = this.inputsResource.maskPasswordsInConfiguration(configuration, configurationRequest);
+
+        assertThat(resultingAttributes).hasSize(1);
+        assertThat(resultingAttributes).containsEntry("nopassword", "lasers in space");
+    }
+
+    @Test
+    public void testMaskingOfEmptyMap() {
+        final ConfigurationRequest configurationRequest = ConfigurationRequest.createWithFields();
+        final Map<String, Object> configuration = Collections.emptyMap();
+
+        final Map<String, Object> resultingAttributes = this.inputsResource.maskPasswordsInConfiguration(configuration, configurationRequest);
+
+        assertThat(resultingAttributes).isEmpty();
+    }
+
+    @Test
+    public void testMaskingOfNullValueInMap() {
+        final TextField passwordInput = mock(TextField.class);
+
+        when(passwordInput.getName()).thenReturn("nopassword");
+        when(passwordInput.getAttributes()).thenReturn(ImmutableList.of());
+        final ConfigurationRequest configurationRequest = ConfigurationRequest.createWithFields(passwordInput);
+        final Map<String, Object> configuration = Collections.singletonMap("nopassword", null);
+
+        final Map<String, Object> resultingAttributes = this.inputsResource.maskPasswordsInConfiguration(configuration, configurationRequest);
+
+        assertThat(resultingAttributes).hasSize(1);
+        assertThat(resultingAttributes).containsEntry("nopassword", null);
+    }
+
+    @Test
+    public void testRetrievalOfInputWithPasswordFieldIfUserIsNotAllowedToEditInput() throws NotFoundException {
+        final String inputId = "myinput";
+        final String inputType = "dummyinput";
+
+        final Input input = getInput(inputId, inputType);
+
+        when(inputService.find(inputId)).thenReturn(input);
+
+        final ConfigurationField fooInput = mock(ConfigurationField.class);
+        when(fooInput.getName()).thenReturn("foo");
+
+        final TextField passwordInput = getPasswordField("password");
+
+        final ConfigurationRequest configurationRequest = ConfigurationRequest.createWithFields(fooInput, passwordInput);
+
+        final InputDescription inputDescription = getInputDescription(configurationRequest);
+        this.availableInputs.put(inputType, inputDescription);
+        when(currentSubject.isPermitted(RestPermissions.INPUTS_READ + ":" + inputId)).thenReturn(true);
+        when(currentSubject.isPermitted(RestPermissions.INPUTS_EDIT + ":" + inputId)).thenReturn(false);
+
+        final Map<String, Object> configuration = ImmutableMap.of(
+                "foo", 42,
+                "password", "verysecret"
+        );
+        when(input.getConfiguration()).thenReturn(configuration);
+
+        final InputSummary summary = this.inputsResource.get(inputId);
+
+        assertThat(summary.attributes()).hasSize(2);
+        assertThat(summary.attributes()).containsEntry("password", "<password set>");
+        assertThat(summary.attributes()).containsEntry("foo", 42);
+    }
+
+    @Test
+    public void testRetrievalOfInputWithPasswordFieldIfUserIsAllowedToEditInput() throws NotFoundException {
+        final String inputId = "myinput";
+        final String inputType = "dummyinput";
+
+        final Input input = getInput(inputId, inputType);
+
+        when(inputService.find(inputId)).thenReturn(input);
+
+        final ConfigurationField fooInput = mock(ConfigurationField.class);
+        when(fooInput.getName()).thenReturn("foo");
+
+        final TextField passwordInput = getPasswordField("password");
+
+        final ConfigurationRequest configurationRequest = ConfigurationRequest.createWithFields(fooInput, passwordInput);
+
+        final InputDescription inputDescription = getInputDescription(configurationRequest);
+        this.availableInputs.put(inputType, inputDescription);
+        when(currentSubject.isPermitted(RestPermissions.INPUTS_READ + ":" + inputId)).thenReturn(true);
+        when(currentSubject.isPermitted(RestPermissions.INPUTS_EDIT + ":" + inputId)).thenReturn(true);
+
+        final Map<String, Object> configuration = ImmutableMap.of(
+                "foo", 42,
+                "password", "verysecret"
+        );
+        when(input.getConfiguration()).thenReturn(configuration);
+
+        final InputSummary summary = this.inputsResource.get(inputId);
+
+        assertThat(summary.attributes()).hasSize(2);
+        assertThat(summary.attributes()).containsEntry("password", "verysecret");
+        assertThat(summary.attributes()).containsEntry("foo", 42);
+    }
+
+    @Test
+    public void testRetrievalOfAllInputsWithPasswordFieldForUserNotAllowedToEditInput() throws NotFoundException {
+        final String inputId = "myinput";
+        final String inputType = "dummyinput";
+
+        final Input input = getInput(inputId, inputType);
+
+        final ConfigurationField fooInput = mock(ConfigurationField.class);
+        when(fooInput.getName()).thenReturn("foo");
+
+        final TextField passwordInput = getPasswordField("password");
+
+        final ConfigurationRequest configurationRequest = ConfigurationRequest.createWithFields(fooInput, passwordInput);
+
+        final InputDescription inputDescription = getInputDescription(configurationRequest);
+        this.availableInputs.put(inputType, inputDescription);
+        when(currentSubject.isPermitted(RestPermissions.INPUTS_READ + ":" + inputId)).thenReturn(true);
+        when(currentSubject.isPermitted(RestPermissions.INPUTS_EDIT + ":" + inputId)).thenReturn(false);
+
+        final Map<String, Object> configuration = ImmutableMap.of(
+                "foo", 42,
+                "password", "verysecret"
+        );
+        when(input.getConfiguration()).thenReturn(configuration);
+        when(inputService.all()).thenReturn(Collections.singletonList(input));
+
+        final InputsList inputsList = this.inputsResource.list();
+
+        assertThat(inputsList.inputs()).isNotEmpty();
+        assertThat(inputsList.inputs()).allMatch(summary -> {
+            assertThat(summary.attributes()).hasSize(2);
+            assertThat(summary.attributes()).containsEntry("password", "<password set>");
+            assertThat(summary.attributes()).containsEntry("foo", 42);
+            return true;
+        });
+    }
+
+    @Test
+    public void testRetrievalOfAllInputsWithPasswordFieldForUserAllowedToEditInput() throws NotFoundException {
+        final String inputId = "myinput";
+        final String inputType = "dummyinput";
+
+        final Input input = getInput(inputId, inputType);
+
+        final ConfigurationField fooInput = mock(ConfigurationField.class);
+        when(fooInput.getName()).thenReturn("foo");
+
+        final TextField passwordInput = getPasswordField("password");
+
+        final ConfigurationRequest configurationRequest = ConfigurationRequest.createWithFields(fooInput, passwordInput);
+
+        final InputDescription inputDescription = getInputDescription(configurationRequest);
+        this.availableInputs.put(inputType, inputDescription);
+        when(currentSubject.isPermitted(RestPermissions.INPUTS_READ + ":" + inputId)).thenReturn(true);
+        when(currentSubject.isPermitted(RestPermissions.INPUTS_EDIT + ":" + inputId)).thenReturn(true);
+
+        final Map<String, Object> configuration = ImmutableMap.of(
+                "foo", 42,
+                "password", "verysecret"
+        );
+        when(input.getConfiguration()).thenReturn(configuration);
+        when(inputService.all()).thenReturn(Collections.singletonList(input));
+
+        final InputsList inputsList = this.inputsResource.list();
+
+        assertThat(inputsList.inputs()).isNotEmpty();
+        assertThat(inputsList.inputs()).allMatch(summary -> {
+            assertThat(summary.attributes()).hasSize(2);
+            assertThat(summary.attributes()).containsEntry("password", "verysecret");
+            assertThat(summary.attributes()).containsEntry("foo", 42);
+            return true;
+        });
+    }
+
+    private TextField getPasswordField(String name) {
+        final TextField passwordInput = mock(TextField.class);
+
+        when(passwordInput.getName()).thenReturn(name);
+        when(passwordInput.getAttributes()).thenReturn(ImmutableList.of(TextField.Attribute.IS_PASSWORD.toString().toLowerCase(Locale.ENGLISH)));
+        return passwordInput;
+    }
+
+    private InputDescription getInputDescription(ConfigurationRequest configurationRequest) {
+        final InputDescription inputDescription = mock(InputDescription.class);
+        when(inputDescription.getConfigurationRequest()).thenReturn(configurationRequest);
+        when(inputDescription.getName()).thenReturn("Dummy Input");
+        return inputDescription;
+    }
+
+    private Input getInput(String inputId, String inputType) {
+        final Input input = mock(Input.class);
+        when(input.getTitle()).thenReturn("My Input");
+        when(input.getType()).thenReturn(inputType);
+        when(input.isGlobal()).thenReturn(false);
+        when(input.getContentPack()).thenReturn(null);
+        when(input.getId()).thenReturn(inputId);
+        when(input.getCreatedAt()).thenReturn(DateTime.parse("2018-12-20T15:36:42.234Z"));
+        when(input.getType()).thenReturn(inputType);
+        when(input.getCreatorUserId()).thenReturn("gary");
+        when(input.getStaticFields()).thenReturn(Collections.emptyMap());
+        when(input.getNodeId()).thenReturn("deadbeef");
+        return input;
+    }
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Before this change, input details returned by the REST API would contain
all configuration fields without any modification. This implies that
password fields are also contained using their original value, showing
configured password for inputs in clear text.

For users which are not allowed to edit an input, this change now iterates over configuration fields checking for the presence of password fields and replace their content with `<password set>` instead of the original value if they are not empty.

For users which possess the required permission to edit an input, the original value is returned as it is used to set the value of the password field and would be used for updating the input if left unchanged.

This is a middle ground between a quick fix improving the situation (not everybody who is able to view inputs can also see passwords) and a proper fix that would require more work and attention to consistency, which will happen in a future version.

Refs #5408 and partially fixes it.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
