### PR TITLE
Fixing imports of `Strings.isNullOrEmpty`.

### DIFF
--- a/graylog2-server/src/main/java/org/graylog/plugins/pipelineprocessor/rest/SimulatorResource.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/pipelineprocessor/rest/SimulatorResource.java
@@ -16,9 +16,12 @@
  */
 package org.graylog.plugins.pipelineprocessor.rest;
 
+import com.google.common.base.Strings;
+import io.swagger.annotations.Api;
+import io.swagger.annotations.ApiOperation;
+import io.swagger.annotations.ApiParam;
 import org.apache.shiro.authz.annotation.RequiresAuthentication;
 import org.apache.shiro.authz.annotation.RequiresPermissions;
-import org.elasticsearch.common.Strings;
 import org.graylog.plugins.pipelineprocessor.processors.ConfigurationStateUpdater;
 import org.graylog.plugins.pipelineprocessor.processors.PipelineInterpreter;
 import org.graylog.plugins.pipelineprocessor.simulator.PipelineInterpreterTracer;
@@ -32,9 +35,6 @@ import org.graylog2.shared.rest.resources.RestResource;
 import org.graylog2.shared.security.RestPermissions;
 import org.graylog2.streams.StreamService;
 
-import java.util.ArrayList;
-import java.util.List;
-
 import javax.inject.Inject;
 import javax.validation.constraints.NotNull;
 import javax.ws.rs.Consumes;
@@ -42,10 +42,8 @@ import javax.ws.rs.POST;
 import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
 import javax.ws.rs.core.MediaType;
-
-import io.swagger.annotations.Api;
-import io.swagger.annotations.ApiOperation;
-import io.swagger.annotations.ApiParam;
+import java.util.ArrayList;
+import java.util.List;
 
 @Api(value = "Pipelines/Simulator", description = "Simulate pipeline message processor")
 @Path("/system/pipelines/simulate")


### PR DESCRIPTION
This small change is correcting the import of the `Strings` helper class
used for the `isNullOrEmpty` method, which is incorrectly imported from
an elastic bundle instead of guava.
