### PR TITLE
Change default linux filebeat path

### DIFF
--- a/graylog2-server/src/main/java/org/graylog/plugins/sidecar/migrations/V20180212165000_AddDefaultCollectors.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/sidecar/migrations/V20180212165000_AddDefaultCollectors.java
@@ -67,7 +67,7 @@ public class V20180212165000_AddDefaultCollectors extends Migration {
                 "filebeat",
                 "exec",
                 "linux",
-                "/usr/lib/graylog-sidecar/filebeat",
+                "/usr/share/filebeat/bin/filebeat",
                 "-c  %s",
                 "test config -c %s",
                 beatsPreambel +


### PR DESCRIPTION
We don't ship filebeat in the linux sidecar packages anymore.
Adopt the path to the elastic beats package.

Refs https://github.com/Graylog2/collector-sidecar/pull/326