### PR TITLE
Prevent clearing of parameters origin from Content Pack

### DIFF
--- a/graylog2-web-interface/src/components/content-packs/ContentPackApplyParameter.jsx
+++ b/graylog2-web-interface/src/components/content-packs/ContentPackApplyParameter.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import { findIndex } from 'lodash';
 
 import { Row, Col, Button } from 'react-bootstrap';
 import { Input } from 'components/bootstrap';
@@ -35,11 +36,16 @@ class ContentPackApplyParameter extends React.Component {
   }
 
   _configKeyRowFormatter = (paramMap) => {
+    const enableClear = findIndex(this.props.appliedParameter,
+      { paramName: paramMap.paramName, configKey: paramMap.configKey, readOnly: true }) < 0;
+    const lastCol = enableClear ?
+      <td><Button bsStyle="info" bsSize="small" onClick={() => { this._parameterClear(paramMap.configKey); }}>Clear</Button></td> :
+      <td />;
     return (
       <tr key={paramMap.configKey}>
         <td>{paramMap.configKey}</td>
         <td>{paramMap.paramName}</td>
-        <td><Button bsStyle="info" bsSize="small" onClick={() => { this._parameterClear(paramMap.configKey); }}>Clear</Button></td>
+        { lastCol }
       </tr>
     );
   };

--- a/graylog2-web-interface/src/components/content-packs/ContentPackApplyParameter.test.jsx
+++ b/graylog2-web-interface/src/components/content-packs/ContentPackApplyParameter.test.jsx
@@ -2,30 +2,42 @@ import React from 'react';
 import renderer from 'react-test-renderer';
 import { mount } from 'enzyme';
 import 'helpers/mocking/react-dom_mock';
+import Entity from 'logic/content-packs/Entity';
 
 import ContentPackApplyParameter from 'components/content-packs/ContentPackApplyParameter';
 
 describe('<ContentPackApplyParameter />', () => {
-  const entity = {
-    id: '111-beef',
-    v: '1.0',
-    data: {
+  const entity = Entity.builder()
+    .id('111-beef')
+    .v('1.0')
+    .data({
       name: { '@type': 'string', '@value': 'Input' },
       title: { '@type': 'string', '@value': 'A good input' },
       configuration: {
         listen_address: { '@type': 'string', '@value': '1.2.3.4' },
         port: { '@type': 'integer', '@value': '23' },
       },
-    },
-  };
+    })
+    .build();
+
   const parameter = { title: 'Port', name: 'PORT', type: 'integer', default_value: '23' };
   const appliedParameter = { configKey: 'configuration.port', paramName: parameter.name };
+  const appliedParameterReadOnly = { configKey: 'configuration.port', paramName: parameter.name, readOnly: true };
 
   it('should render with full props', () => {
     const wrapper = renderer.create(<ContentPackApplyParameter
       entity={entity}
       parameters={[parameter]}
       appliedParameter={[appliedParameter]}
+    />);
+    expect(wrapper.toJSON()).toMatchSnapshot();
+  });
+
+  it('should render with readOnly', () => {
+    const wrapper = renderer.create(<ContentPackApplyParameter
+      entity={entity}
+      parameters={[parameter]}
+      appliedParameter={[appliedParameterReadOnly]}
     />);
     expect(wrapper.toJSON()).toMatchSnapshot();
   });

--- a/graylog2-web-interface/src/components/content-packs/ContentPackEntitiesList.css
+++ b/graylog2-web-interface/src/components/content-packs/ContentPackEntitiesList.css
@@ -14,3 +14,7 @@
 :local(.bigColumns) {
     word-wrap: break-word;
 }
+
+:local(.contentPackEntity) {
+    color: rgba(158, 31, 99, 0.43);
+}

--- a/graylog2-web-interface/src/components/content-packs/ContentPackEntitiesList.jsx
+++ b/graylog2-web-interface/src/components/content-packs/ContentPackEntitiesList.jsx
@@ -73,7 +73,7 @@ class ContentPackEntitiesList extends React.Component {
     const applyModal = (
       <BootstrapModalWrapper ref={(node) => { applyModalRef = node; }} bsSize="large">
         <Modal.Header closeButton>
-          <Modal.Title>Apply Parameter</Modal.Title>
+          <Modal.Title>Edit</Modal.Title>
         </Modal.Header>
         <Modal.Body>
           {applyParamComponent}
@@ -130,7 +130,7 @@ class ContentPackEntitiesList extends React.Component {
                     onClick={() => {
                       open();
                     }}>
-              Apply Parameter
+              Edit
             </Button>
             }
             <Button bsStyle="info"
@@ -149,7 +149,7 @@ class ContentPackEntitiesList extends React.Component {
   render() {
     const headers = this.props.readOnly ?
       ['Title', 'Type', 'Description', 'Action'] :
-      ['Title', 'Type', 'Description', 'Applied Parameter', 'Action'];
+      ['Title', 'Type', 'Description', 'Used Parameters', 'Action'];
 
     return (
       <div>

--- a/graylog2-web-interface/src/components/content-packs/ContentPackEntitiesList.jsx
+++ b/graylog2-web-interface/src/components/content-packs/ContentPackEntitiesList.jsx
@@ -4,7 +4,6 @@ import React from 'react';
 import { Button, Modal, ButtonToolbar } from 'react-bootstrap';
 import { SearchForm, DataTable } from 'components/common';
 import BootstrapModalWrapper from 'components/bootstrap/BootstrapModalWrapper';
-import Entity from 'logic/content-packs/Entity';
 
 import ContentPackApplyParameter from './ContentPackApplyParameter';
 import ContentPackEntityConfig from './ContentPackEntityConfig';

--- a/graylog2-web-interface/src/components/content-packs/ContentPackEntitiesList.jsx
+++ b/graylog2-web-interface/src/components/content-packs/ContentPackEntitiesList.jsx
@@ -4,6 +4,7 @@ import React from 'react';
 import { Button, Modal, ButtonToolbar } from 'react-bootstrap';
 import { SearchForm, DataTable } from 'components/common';
 import BootstrapModalWrapper from 'components/bootstrap/BootstrapModalWrapper';
+import Entity from 'logic/content-packs/Entity';
 
 import ContentPackApplyParameter from './ContentPackApplyParameter';
 import ContentPackEntityConfig from './ContentPackEntityConfig';
@@ -50,6 +51,13 @@ class ContentPackEntitiesList extends React.Component {
       return regexp.test(entity.title) || regexp.test(entity.description);
     });
     this.setState({ filteredEntities: filteredEntities, filter: filter });
+  };
+
+  _entityIcon = (entity) => {
+    if (!entity.fromServer) {
+      return <span><i title="Content Pack" className={`fa fa-archive ${ContentPackEntitiesListStyle.contentPackEntity}`} /></span>;
+    }
+    return <span><i title="Server" className="fa fa-server" /></span>;
   };
 
   _entityRowFormatter = (entity) => {
@@ -120,6 +128,7 @@ class ContentPackEntitiesList extends React.Component {
         <td className={ContentPackEntitiesListStyle.bigColumns}>{entity.title}</td>
         <td>{entity.type.name}</td>
         <td className={ContentPackEntitiesListStyle.bigColumns}>{entity.description}</td>
+        <td>{this._entityIcon(entity)}</td>
         {!this.props.readOnly && <td>{appliedParameterCount}</td>}
         <td>
           <ButtonToolbar>
@@ -148,8 +157,8 @@ class ContentPackEntitiesList extends React.Component {
 
   render() {
     const headers = this.props.readOnly ?
-      ['Title', 'Type', 'Description', 'Action'] :
-      ['Title', 'Type', 'Description', 'Used Parameters', 'Action'];
+      ['Title', 'Type', 'Description', 'Origin', 'Action'] :
+      ['Title', 'Type', 'Description', 'Origin', 'Used Parameters', 'Action'];
 
     return (
       <div>

--- a/graylog2-web-interface/src/components/content-packs/ContentPackEntitiesList.test.jsx
+++ b/graylog2-web-interface/src/components/content-packs/ContentPackEntitiesList.test.jsx
@@ -5,40 +5,37 @@ import 'helpers/mocking/react-dom_mock';
 
 import ContentPack from 'logic/content-packs/ContentPack';
 import ContentPackEntitiesList from 'components/content-packs/ContentPackEntitiesList';
+import Entity from 'logic/content-packs/Entity';
 
 describe('<ContentPackEntitiesList />', () => {
-  const entity1 = {
-    id: '111-beef',
-    type: {
-      name: 'Input',
-      version: '1',
-    },
-    v: '1.0',
-    data: {
+  const entity1 = Entity.builder()
+    .id('111-beef')
+    .type({ name: 'Input', version: '1'})
+    .v('1.0')
+    .data({
       name: { '@type': 'string', '@value': 'Input' },
       title: { '@type': 'string', '@value': 'A good input' },
       configuration: {
         listen_address: { '@type': 'string', '@value': '1.2.3.4' },
         port: { '@type': 'integer', '@value': '23' },
       },
-    },
-  };
-  const entity2 = {
-    id: '121-beef',
-    type: {
-      name: 'Input',
-      version: '1',
-    },
-    v: '1.0',
-    data: {
+    })
+    .build();
+
+  const entity2 = Entity.builder()
+    .id('121-beef')
+    .type({ name: 'Input', version: '1' })
+    .v('1.0')
+    .data({
       name: { '@type': 'string', '@value': 'BadInput' },
       title: { '@type': 'string', '@value': 'A bad input' },
       configuration: {
         listen_address: { '@type': 'string', '@value': '1.2.3.4' },
         port: { '@type': 'integer', '@value': '22' },
       },
-    },
-  };
+    })
+    .fromServer(true)
+    .build();
 
   const parameter = {
     name: 'A parameter name',

--- a/graylog2-web-interface/src/components/content-packs/ContentPackEntitiesList.test.jsx
+++ b/graylog2-web-interface/src/components/content-packs/ContentPackEntitiesList.test.jsx
@@ -10,7 +10,7 @@ import Entity from 'logic/content-packs/Entity';
 describe('<ContentPackEntitiesList />', () => {
   const entity1 = Entity.builder()
     .id('111-beef')
-    .type({ name: 'Input', version: '1'})
+    .type({ name: 'Input', version: '1' })
     .v('1.0')
     .data({
       name: { '@type': 'string', '@value': 'Input' },

--- a/graylog2-web-interface/src/components/content-packs/ContentPackParameterList.jsx
+++ b/graylog2-web-interface/src/components/content-packs/ContentPackParameterList.jsx
@@ -1,12 +1,12 @@
 import PropTypes from 'prop-types';
 import React from 'react';
+import { findIndex } from 'lodash';
 
 import { Button, Modal, ButtonToolbar, Badge } from 'react-bootstrap';
 import BootstrapModalWrapper from 'components/bootstrap/BootstrapModalWrapper';
 import { DataTable, SearchForm } from 'components/common';
 
 import ObjectUtils from 'util/ObjectUtils';
-import ValueReferenceData from 'util/ValueReferenceData';
 import ContentPackEditParameter from 'components/content-packs/ContentPackEditParameter';
 
 import ContentPackParameterListStyle from './ContentPackParameterList.css';
@@ -18,12 +18,14 @@ class ContentPackParameterList extends React.Component {
     readOnly: PropTypes.bool,
     onDeleteParameter: PropTypes.func,
     onAddParameter: PropTypes.func,
+    appliedParameter: PropTypes.object,
   };
 
   static defaultProps = {
     readOnly: false,
     onDeleteParameter: () => {},
     onAddParameter: () => {},
+    appliedParameter: {},
   };
 
   constructor(props) {
@@ -40,21 +42,15 @@ class ContentPackParameterList extends React.Component {
   }
 
   _parameterApplied = (paramName) => {
-    const { contentPack } = this.props;
-    if (!contentPack || !contentPack.entities) {
-      return false;
+    const entityIds = Object.keys(this.props.appliedParameter);
+    /* eslint-disable-next-line no-restricted-syntax, guard-for-in */
+    for (const i in entityIds) {
+      const params = this.props.appliedParameter[entityIds[i]];
+      if (findIndex(params, { paramName: paramName }) >= 0) {
+        return true;
+      }
     }
-    return contentPack.entities.reduce((result, entity) => {
-      const entityData = new ValueReferenceData(entity.data);
-      const configPaths = entityData.getPaths();
-
-      const parameterNames = Object.keys(configPaths).filter((path) => {
-        return configPaths[path].isValueParameter();
-      }).map((path) => {
-        return configPaths[path].getValue();
-      });
-      return result.concat(parameterNames);
-    }, []).includes(paramName);
+    return false;
   };
 
   _parameterRowFormatter = (parameter) => {

--- a/graylog2-web-interface/src/components/content-packs/ContentPackParameterList.test.jsx
+++ b/graylog2-web-interface/src/components/content-packs/ContentPackParameterList.test.jsx
@@ -88,13 +88,17 @@ describe('<ContentPackParameterList />', () => {
       type: 'string',
       default_value: 'test',
     }];
+    const appliedParameter = {
+      'dead-beef': [{ paramName: 'PARAM', configKey: 'title' }],
+    };
     const contentPack = ContentPack.builder()
       .parameters(parameters)
       .entities([entity])
       .build();
 
     const wrapper = mount(<ContentPackParameterList contentPack={contentPack}
-                                                    onDeleteParameter={deleteFn} />);
+                                                    onDeleteParameter={deleteFn}
+                                                    appliedParameter={appliedParameter} />);
     wrapper.find('button[children="Delete"]').simulate('click');
     expect(deleteFn.mock.calls.length).toBe(0);
   });

--- a/graylog2-web-interface/src/components/content-packs/ContentPackParameterList.test.jsx
+++ b/graylog2-web-interface/src/components/content-packs/ContentPackParameterList.test.jsx
@@ -4,6 +4,7 @@ import renderer from 'react-test-renderer';
 import 'helpers/mocking/react-dom_mock';
 
 import ContentPack from 'logic/content-packs/ContentPack';
+import Entity from 'logic/content-packs/Entity';
 import ContentPackParameterList from 'components/content-packs/ContentPackParameterList';
 
 describe('<ContentPackParameterList />', () => {
@@ -15,7 +16,7 @@ describe('<ContentPackParameterList />', () => {
 
   it('should render with parameters with readOnly', () => {
     const parameters = [{
-      name: 'A parameter name',
+      name: 'PARAM',
       title: 'A parameter title',
       description: 'A parameter descriptions',
       type: 'string',
@@ -36,7 +37,7 @@ describe('<ContentPackParameterList />', () => {
 
   it('should render with parameters without readOnly', () => {
     const parameters = [{
-      name: 'A parameter name',
+      name: 'PARAM',
       title: 'A parameter title',
       description: 'A parameter descriptions',
       type: 'string',
@@ -51,10 +52,10 @@ describe('<ContentPackParameterList />', () => {
 
   it('should delete a parameter', () => {
     const deleteFn = jest.fn((parameter) => {
-      expect(parameter.name).toEqual('A parameter name');
+      expect(parameter.name).toEqual('PARAM');
     });
     const parameters = [{
-      name: 'A parameter name',
+      name: 'PARAM',
       title: 'A parameter title',
       description: 'A parameter descriptions',
       type: 'string',
@@ -65,20 +66,48 @@ describe('<ContentPackParameterList />', () => {
       .build();
 
     const wrapper = mount(<ContentPackParameterList contentPack={contentPack}
-                                                 onDeleteParameter={deleteFn} />);
+                                                    onDeleteParameter={deleteFn} />);
     wrapper.find('button[children="Delete"]').simulate('click');
     expect(deleteFn.mock.calls.length).toBe(1);
   });
 
+  it('should not delete a used parameter', () => {
+    const entity = Entity.builder()
+      .v(1)
+      .type('input')
+      .id('dead-beef')
+      .data({ title: { '@type': 'parameter', '@value': 'PARAM' } })
+      .build();
+    const deleteFn = jest.fn((parameter) => {
+      expect(parameter.name).toEqual('PARAM');
+    });
+    const parameters = [{
+      name: 'PARAM',
+      title: 'A parameter title',
+      description: 'A parameter descriptions',
+      type: 'string',
+      default_value: 'test',
+    }];
+    const contentPack = ContentPack.builder()
+      .parameters(parameters)
+      .entities([entity])
+      .build();
+
+    const wrapper = mount(<ContentPackParameterList contentPack={contentPack}
+                                                    onDeleteParameter={deleteFn} />);
+    wrapper.find('button[children="Delete"]').simulate('click');
+    expect(deleteFn.mock.calls.length).toBe(0);
+  });
+
   it('should filter parameters', () => {
     const parameters = [{
-      name: 'A parameter name',
+      name: 'PARAM',
       title: 'A parameter title',
       description: 'A parameter descriptions',
       type: 'string',
       default_value: 'test',
     }, {
-      name: 'A bad parameter',
+      name: 'BAD_PARAM',
       title: 'real bad',
       description: 'The dark ones own parameter',
       type: 'string',
@@ -88,11 +117,11 @@ describe('<ContentPackParameterList />', () => {
       .parameters(parameters)
       .build();
     const wrapper = mount(<ContentPackParameterList contentPack={contentPack} />);
-    expect(wrapper.find("td[children='A parameter name']").exists()).toBe(true);
+    expect(wrapper.find("td[children='PARAM']").exists()).toBe(true);
     wrapper.find('input').simulate('change', { target: { value: 'Bad' } });
     wrapper.find('form').simulate('submit');
-    expect(wrapper.find("td[children='A parameter name']").exists()).toBe(false);
+    expect(wrapper.find("td[children='PARAM']").exists()).toBe(false);
     wrapper.find("button[children='Reset']").simulate('click');
-    expect(wrapper.find("td[children='A parameter name']").exists()).toBe(true);
+    expect(wrapper.find("td[children='PARAM']").exists()).toBe(true);
   });
 });

--- a/graylog2-web-interface/src/components/content-packs/ContentPackParameters.jsx
+++ b/graylog2-web-interface/src/components/content-packs/ContentPackParameters.jsx
@@ -115,7 +115,7 @@ class ContentPackParameters extends React.Component {
             <ContentPackParameterList contentPack={this.props.contentPack}
                                       onAddParameter={this._addNewParameter}
                                       onDeleteParameter={this._openConfirmModal}
-            />
+                                      appliedParameter={this.props.appliedParameter} />
             {this._confirmationModal()}
           </Col>
         </Row>

--- a/graylog2-web-interface/src/components/content-packs/__snapshots__/ContentPackApplyParameter.test.jsx.snap
+++ b/graylog2-web-interface/src/components/content-packs/__snapshots__/ContentPackApplyParameter.test.jsx.snap
@@ -330,3 +330,178 @@ exports[`<ContentPackApplyParameter /> should render with minimal props 1`] = `
   </div>
 </div>
 `;
+
+exports[`<ContentPackApplyParameter /> should render with readOnly 1`] = `
+<div>
+  <form
+    className="apply-parameter-form"
+    id="apply-parameter-form"
+    onSubmit={[Function]}
+  >
+    <div
+      className="applyParameter row"
+    >
+      <div
+        className="col-sm-5 col-sm-offset-1"
+      >
+        <div
+          className="form-group"
+        >
+          <label
+            className="control-label"
+            htmlFor="config_key"
+          >
+            Config Key
+          </label>
+          <span>
+            <select
+              className="form-control"
+              id="config_key"
+              label="Config Key"
+              name="config_key"
+              onChange={[Function]}
+              placeholder=""
+              required={true}
+              type="select"
+              value=""
+            >
+              <option
+                value=""
+              >
+                Choose Config Key
+              </option>
+              <option
+                value="configuration.listen_address"
+              >
+                configuration.listen_address
+              </option>
+              <option
+                value="name"
+              >
+                name
+              </option>
+              <option
+                value="title"
+              >
+                title
+              </option>
+            </select>
+            
+          </span>
+        </div>
+      </div>
+      <div
+        className="col-sm-5"
+      >
+        <div
+          className="form-group"
+        >
+          <label
+            className="control-label"
+            htmlFor="parameter"
+          >
+            Parameter
+          </label>
+          <span>
+            <select
+              className="form-control"
+              id="parameter"
+              label="Parameter"
+              name="parameter"
+              onChange={[Function]}
+              placeholder=""
+              required={true}
+              type="select"
+              value=""
+            >
+              <option
+                value=""
+              >
+                Choose...
+              </option>
+              <option
+                value="PORT"
+              >
+                Port
+                 (
+                PORT
+                )
+              </option>
+            </select>
+            
+          </span>
+        </div>
+      </div>
+      <div
+        className="col-sm-1"
+      />
+    </div>
+    <div
+      className="row"
+    >
+      <div
+        className="col-sm-2 col-sm-offset-10"
+      >
+        <button
+          className="btn btn-primary"
+          disabled={true}
+          type="submit"
+        >
+          Apply
+        </button>
+      </div>
+    </div>
+  </form>
+  <div
+    className="row"
+  >
+    <div
+      className="col-sm-10 col-sm-offset-1"
+    >
+      <div>
+        <div
+          className="row "
+        >
+          <div
+            className="col-md-12"
+          >
+            <div
+              className="data-table table-responsive"
+              id="config-key-list"
+            >
+              <table
+                className="table undefined"
+              >
+                <thead>
+                  <tr>
+                    <th>
+                      Config Key
+                    </th>
+                    <th>
+                      Parameter
+                    </th>
+                    <th>
+                      Action
+                    </th>
+                  </tr>
+                </thead>
+                <tbody>
+                  <tr>
+                    <td>
+                      configuration.port
+                    </td>
+                    <td>
+                      PORT
+                    </td>
+                    <td />
+                  </tr>
+                </tbody>
+              </table>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;

--- a/graylog2-web-interface/src/components/content-packs/__snapshots__/ContentPackEntitiesList.test.jsx.snap
+++ b/graylog2-web-interface/src/components/content-packs/__snapshots__/ContentPackEntitiesList.test.jsx.snap
@@ -191,6 +191,9 @@ exports[`<ContentPackEntitiesList /> should render with entities and parameters 
                   Description
                 </th>
                 <th>
+                  Origin
+                </th>
+                <th>
                   Used Parameters
                 </th>
                 <th>
@@ -212,6 +215,14 @@ exports[`<ContentPackEntitiesList /> should render with entities and parameters 
                   className="bigColumns"
                 >
                   
+                </td>
+                <td>
+                  <span>
+                    <i
+                      className="fa fa-archive contentPackEntity"
+                      title="Content Pack"
+                    />
+                  </span>
                 </td>
                 <td>
                   1
@@ -253,6 +264,14 @@ exports[`<ContentPackEntitiesList /> should render with entities and parameters 
                   className="bigColumns"
                 >
                   
+                </td>
+                <td>
+                  <span>
+                    <i
+                      className="fa fa-server"
+                      title="Server"
+                    />
+                  </span>
                 </td>
                 <td>
                   0

--- a/graylog2-web-interface/src/components/content-packs/__snapshots__/ContentPackEntitiesList.test.jsx.snap
+++ b/graylog2-web-interface/src/components/content-packs/__snapshots__/ContentPackEntitiesList.test.jsx.snap
@@ -191,7 +191,7 @@ exports[`<ContentPackEntitiesList /> should render with entities and parameters 
                   Description
                 </th>
                 <th>
-                  Applied Parameter
+                  Used Parameters
                 </th>
                 <th>
                   Action
@@ -227,7 +227,7 @@ exports[`<ContentPackEntitiesList /> should render with entities and parameters 
                       onClick={[Function]}
                       type="button"
                     >
-                      Apply Parameter
+                      Edit
                     </button>
                     <button
                       className="btn btn-xs btn-info"
@@ -268,7 +268,7 @@ exports[`<ContentPackEntitiesList /> should render with entities and parameters 
                       onClick={[Function]}
                       type="button"
                     >
-                      Apply Parameter
+                      Edit
                     </button>
                     <button
                       className="btn btn-xs btn-info"

--- a/graylog2-web-interface/src/components/content-packs/__snapshots__/ContentPackInstall.test.jsx.snap
+++ b/graylog2-web-interface/src/components/content-packs/__snapshots__/ContentPackInstall.test.jsx.snap
@@ -184,6 +184,9 @@ exports[`<ContentPackInstall /> should render a install 1`] = `
                         Description
                       </th>
                       <th>
+                        Origin
+                      </th>
+                      <th>
                         Action
                       </th>
                     </tr>
@@ -202,6 +205,14 @@ exports[`<ContentPackInstall /> should render a install 1`] = `
                         className="bigColumns"
                       >
                         
+                      </td>
+                      <td>
+                        <span>
+                          <i
+                            className="fa fa-archive contentPackEntity"
+                            title="Content Pack"
+                          />
+                        </span>
                       </td>
                       <td>
                         <div

--- a/graylog2-web-interface/src/components/content-packs/__snapshots__/ContentPackParameterList.test.jsx.snap
+++ b/graylog2-web-interface/src/components/content-packs/__snapshots__/ContentPackParameterList.test.jsx.snap
@@ -103,6 +103,7 @@ exports[`<ContentPackParameterList /> should render with empty parameters withou
     className="btn btn-sm btn-info"
     disabled={false}
     onClick={[Function]}
+    title="Edit Modal"
     type="button"
   >
     Create parameter
@@ -301,6 +302,9 @@ exports[`<ContentPackParameterList /> should render with parameters with readOnl
                 <th>
                   Default Value
                 </th>
+                <th>
+                  Used
+                </th>
               </tr>
             </thead>
             <tbody>
@@ -311,7 +315,7 @@ exports[`<ContentPackParameterList /> should render with parameters with readOnl
                   A parameter title
                 </td>
                 <td>
-                  A parameter name
+                  PARAM
                 </td>
                 <td
                   className="bigColumns"
@@ -323,6 +327,15 @@ exports[`<ContentPackParameterList /> should render with parameters with readOnl
                 </td>
                 <td>
                   test
+                </td>
+                <td>
+                  <span
+                    className="failure badge"
+                  >
+                    <i
+                      className="fa fa-times"
+                    />
+                  </span>
                 </td>
               </tr>
             </tbody>
@@ -344,6 +357,7 @@ exports[`<ContentPackParameterList /> should render with parameters without read
     className="btn btn-sm btn-info"
     disabled={false}
     onClick={[Function]}
+    title="Edit Modal"
     type="button"
   >
     Create parameter
@@ -450,6 +464,9 @@ exports[`<ContentPackParameterList /> should render with parameters without read
                   Default Value
                 </th>
                 <th>
+                  Used
+                </th>
+                <th>
                   Action
                 </th>
               </tr>
@@ -462,7 +479,7 @@ exports[`<ContentPackParameterList /> should render with parameters without read
                   A parameter title
                 </td>
                 <td>
-                  A parameter name
+                  PARAM
                 </td>
                 <td
                   className="bigColumns"
@@ -476,6 +493,15 @@ exports[`<ContentPackParameterList /> should render with parameters without read
                   test
                 </td>
                 <td>
+                  <span
+                    className="failure badge"
+                  >
+                    <i
+                      className="fa fa-times"
+                    />
+                  </span>
+                </td>
+                <td>
                   <div
                     className="btn-toolbar"
                     role="toolbar"
@@ -484,6 +510,7 @@ exports[`<ContentPackParameterList /> should render with parameters without read
                       className="btn btn-xs btn-primary"
                       disabled={false}
                       onClick={[Function]}
+                      title="Delete Parameter"
                       type="button"
                     >
                       Delete
@@ -492,6 +519,7 @@ exports[`<ContentPackParameterList /> should render with parameters without read
                       className="btn btn-xs btn-info"
                       disabled={false}
                       onClick={[Function]}
+                      title="Edit Modal"
                       type="button"
                     >
                       Edit

--- a/graylog2-web-interface/src/components/content-packs/__snapshots__/ContentPackParameters.test.jsx.snap
+++ b/graylog2-web-interface/src/components/content-packs/__snapshots__/ContentPackParameters.test.jsx.snap
@@ -17,6 +17,7 @@ exports[`<ContentPackParameters /> should render a parameter 1`] = `
           className="btn btn-sm btn-info"
           disabled={false}
           onClick={[Function]}
+          title="Edit Modal"
           type="button"
         >
           Create parameter
@@ -123,6 +124,9 @@ exports[`<ContentPackParameters /> should render a parameter 1`] = `
                         Default Value
                       </th>
                       <th>
+                        Used
+                      </th>
+                      <th>
                         Action
                       </th>
                     </tr>
@@ -149,6 +153,15 @@ exports[`<ContentPackParameters /> should render a parameter 1`] = `
                         test
                       </td>
                       <td>
+                        <span
+                          className="failure badge"
+                        >
+                          <i
+                            className="fa fa-times"
+                          />
+                        </span>
+                      </td>
+                      <td>
                         <div
                           className="btn-toolbar"
                           role="toolbar"
@@ -157,6 +170,7 @@ exports[`<ContentPackParameters /> should render a parameter 1`] = `
                             className="btn btn-xs btn-primary"
                             disabled={false}
                             onClick={[Function]}
+                            title="Delete Parameter"
                             type="button"
                           >
                             Delete
@@ -165,6 +179,7 @@ exports[`<ContentPackParameters /> should render a parameter 1`] = `
                             className="btn btn-xs btn-info"
                             disabled={false}
                             onClick={[Function]}
+                            title="Edit Modal"
                             type="button"
                           >
                             Edit
@@ -284,7 +299,7 @@ exports[`<ContentPackParameters /> should render a parameter 1`] = `
                         Description
                       </th>
                       <th>
-                        Applied Parameter
+                        Used Parameters
                       </th>
                       <th>
                         Action
@@ -320,7 +335,7 @@ exports[`<ContentPackParameters /> should render a parameter 1`] = `
                             onClick={[Function]}
                             type="button"
                           >
-                            Apply Parameter
+                            Edit
                           </button>
                           <button
                             className="btn btn-xs btn-info"
@@ -362,6 +377,7 @@ exports[`<ContentPackParameters /> should render with empty parameters 1`] = `
           className="btn btn-sm btn-info"
           disabled={false}
           onClick={[Function]}
+          title="Edit Modal"
           type="button"
         >
           Create parameter

--- a/graylog2-web-interface/src/components/content-packs/__snapshots__/ContentPackParameters.test.jsx.snap
+++ b/graylog2-web-interface/src/components/content-packs/__snapshots__/ContentPackParameters.test.jsx.snap
@@ -299,6 +299,9 @@ exports[`<ContentPackParameters /> should render a parameter 1`] = `
                         Description
                       </th>
                       <th>
+                        Origin
+                      </th>
+                      <th>
                         Used Parameters
                       </th>
                       <th>
@@ -320,6 +323,14 @@ exports[`<ContentPackParameters /> should render a parameter 1`] = `
                         className="bigColumns"
                       >
                         
+                      </td>
+                      <td>
+                        <span>
+                          <i
+                            className="fa fa-archive contentPackEntity"
+                            title="Content Pack"
+                          />
+                        </span>
                       </td>
                       <td>
                         0

--- a/graylog2-web-interface/src/logic/content-packs/ContentPack.js
+++ b/graylog2-web-interface/src/logic/content-packs/ContentPack.js
@@ -6,10 +6,10 @@ import Entity from './Entity';
 export default class ContentPack {
   constructor(v, id, rev, name, summary, description, vendor, url, parameters, entitieValues) {
     const entities = entitieValues.map((e) => {
-      if (e instanceof Entity) {
+      if (e.constructor.name === Entity.name) {
         return e;
       }
-      return Entity.fromJSON(e);
+      return Entity.fromJSON(e, false);
     });
 
     this._value = {

--- a/graylog2-web-interface/src/logic/content-packs/Entity.jsx
+++ b/graylog2-web-interface/src/logic/content-packs/Entity.jsx
@@ -3,7 +3,7 @@ import ValueRefHelper from 'util/ValueRefHelper';
 import Constraint from './Constraint';
 
 export default class Entity {
-  constructor(v, type, id, data, constraintValues = []) {
+  constructor(v, type, id, data, fromServer = false, constraintValues = []) {
     const constraints = constraintValues.map((c) => {
       if (c instanceof Constraint) {
         return c;
@@ -17,12 +17,13 @@ export default class Entity {
       id,
       data,
       constraints,
+      fromServer,
     };
   }
 
-  static fromJSON(value) {
+  static fromJSON(value, fromServer = true) {
     const { v, type, id, data, constraints } = value;
-    return new Entity(v, type, id, data, constraints);
+    return new Entity(v, type, id, data, fromServer, constraints);
   }
 
   get v() {
@@ -39,6 +40,10 @@ export default class Entity {
 
   get data() {
     return this._value.data;
+  }
+
+  get fromServer() {
+    return this._value.fromServer;
   }
 
   get constraints() {
@@ -76,6 +81,7 @@ export default class Entity {
       id,
       data,
       constraints,
+      fromServer,
     } = this._value;
     /* eslint-disable-next-line no-use-before-define */
     return new Builder(Map({
@@ -84,6 +90,7 @@ export default class Entity {
       id,
       data,
       constraints,
+      fromServer,
     }));
   }
 
@@ -136,6 +143,11 @@ class Builder {
     return this;
   }
 
+  fromServer(value) {
+    this.value = this.value.set('fromServer', value);
+    return this;
+  }
+
   constraints(value) {
     this.value = this.value.set('constraints', value);
     return this;
@@ -148,7 +160,8 @@ class Builder {
       id,
       data,
       constraints,
+      fromServer,
     } = this.value.toObject();
-    return new Entity(v, type, id, data, constraints);
+    return new Entity(v, type, id, data, fromServer, constraints);
   }
 }

--- a/graylog2-web-interface/src/pages/CreateContentPackPage.jsx
+++ b/graylog2-web-interface/src/pages/CreateContentPackPage.jsx
@@ -78,7 +78,8 @@ const CreateContentPackPage = createReactClass({
   _getEntities(selectedEntities) {
     CatalogActions.getSelectedEntities(selectedEntities).then((result) => {
       const newContentPack = this.state.contentPack.toBuilder()
-        .entities(result.entities)
+        /* Mark entities from server */
+        .entities(result.entities.map(e => Entity.fromJSON(e, true)))
         .build();
       const fetchedEntities = result.entities.map(e => Entity.fromJSON(e));
       this.setState({ contentPack: newContentPack, fetchedEntities });

--- a/graylog2-web-interface/src/pages/EditContentPackPage.jsx
+++ b/graylog2-web-interface/src/pages/EditContentPackPage.jsx
@@ -92,7 +92,7 @@ const EditContentPackPage = createReactClass({
       const paramMap = Object.keys(configPaths).filter((path) => {
         return configPaths[path].isValueParameter();
       }).map((path) => {
-        return { configKey: path, paramName: configPaths[path].getValue() };
+        return { configKey: path, paramName: configPaths[path].getValue(), readOnly: true };
       });
       const newResult = result;
       if (paramMap.length > 0) {

--- a/graylog2-web-interface/src/pages/EditContentPackPage.jsx
+++ b/graylog2-web-interface/src/pages/EditContentPackPage.jsx
@@ -139,7 +139,8 @@ const EditContentPackPage = createReactClass({
         .reduce((acc, entityType) => {
           return acc.concat(selectedEntities[entityType]);
         }, []).filter(e => e.constructor.name === Entity.name);
-      const entities = contentPackEntities.concat(result.entities);
+      /* Mark entities from server */
+      const entities = contentPackEntities.concat(result.entities.map(e => Entity.fromJSON(e, true)));
       const contentPack = this.state.contentPack.toBuilder()
         .entities(entities)
         .build();


### PR DESCRIPTION
## Description
We now prevent clearing a parameter, when the parameter was applied in a former version
of the content pack.

## Motivation and Context
Since we do not have the original value of the config key in the entity we can't replace a parameter.
In the future we might solve this by asking the user, but this is not as easy as it sounds without
confusing the user.

## How Has This Been Tested?
- Created a content pack with applied parameter
- Created a new version and tried to clear the parameter.

## Screenshots (if appropriate):
![graylog - content packs 3](https://user-images.githubusercontent.com/448763/50964275-1be09680-14cf-11e9-9d19-70289f05852f.png)

## Additionally
Prevent deletion of used parameters and display usage and origin of a parameter.

Fixes #5426 

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
