### PR TITLE
Display entity title in installation modal

### DIFF
--- a/graylog2-web-interface/src/components/content-packs/ContentPackEntitiesList.jsx
+++ b/graylog2-web-interface/src/components/content-packs/ContentPackEntitiesList.jsx
@@ -127,7 +127,7 @@ class ContentPackEntitiesList extends React.Component {
         <td className={ContentPackEntitiesListStyle.bigColumns}>{entity.title}</td>
         <td>{entity.type.name}</td>
         <td className={ContentPackEntitiesListStyle.bigColumns}>{entity.description}</td>
-        <td>{this._entityIcon(entity)}</td>
+        {!this.props.readOnly && <td>{this._entityIcon(entity)}</td>}
         {!this.props.readOnly && <td>{appliedParameterCount}</td>}
         <td>
           <ButtonToolbar>
@@ -156,7 +156,7 @@ class ContentPackEntitiesList extends React.Component {
 
   render() {
     const headers = this.props.readOnly ?
-      ['Title', 'Type', 'Description', 'Origin', 'Action'] :
+      ['Title', 'Type', 'Description', 'Action'] :
       ['Title', 'Type', 'Description', 'Origin', 'Used Parameters', 'Action'];
 
     return (

--- a/graylog2-web-interface/src/components/content-packs/ContentPackInstall.jsx
+++ b/graylog2-web-interface/src/components/content-packs/ContentPackInstall.jsx
@@ -1,6 +1,8 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 
+import ContentPack from 'logic/content-packs/ContentPack';
+
 import { Row, Col } from 'react-bootstrap';
 import { Input } from 'components/bootstrap';
 import ValueRefHelper from 'util/ValueRefHelper';
@@ -104,6 +106,8 @@ class ContentPackInstall extends React.Component {
     const parameterInput = this.props.contentPack.parameters.map((parameter) => {
       return this.renderParameter(parameter);
     });
+    const contentPack = ContentPack.fromJSON(this.props.contentPack);
+
     return (<div>
       <Row>
         <Col smOffset={1} sm={10}>
@@ -133,7 +137,7 @@ class ContentPackInstall extends React.Component {
       </Row>}
       <Row>
         <Col smOffset={1} sm={10}>
-          <ContentPackEntitiesList contentPack={this.props.contentPack} readOnly />
+          <ContentPackEntitiesList contentPack={contentPack} readOnly />
         </Col>
       </Row>
     </div>);

--- a/graylog2-web-interface/src/components/content-packs/__snapshots__/ContentPackInstall.test.jsx.snap
+++ b/graylog2-web-interface/src/components/content-packs/__snapshots__/ContentPackInstall.test.jsx.snap
@@ -184,9 +184,6 @@ exports[`<ContentPackInstall /> should render a install 1`] = `
                         Description
                       </th>
                       <th>
-                        Origin
-                      </th>
-                      <th>
                         Action
                       </th>
                     </tr>
@@ -205,14 +202,6 @@ exports[`<ContentPackInstall /> should render a install 1`] = `
                         className="bigColumns"
                       >
                         
-                      </td>
-                      <td>
-                        <span>
-                          <i
-                            className="fa fa-archive contentPackEntity"
-                            title="Content Pack"
-                          />
-                        </span>
                       </td>
                       <td>
                         <div


### PR DESCRIPTION
Prior this change, the title of an entity was missing
when clicking on install from content pack list.

This change will convert the content pack hash to
a content pack object to access the title easy
via getter.

Fixes: #5423 

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
