### PR TITLE
Stop autofilling 'facility' field in new Beats input

### DIFF
--- a/graylog2-server/src/main/java/org/graylog/plugins/beats/Beats2Codec.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/beats/Beats2Codec.java
@@ -89,7 +89,6 @@ public class Beats2Codec extends AbstractCodec {
 
         final Message gelfMessage = new Message(message, hostname, timestamp);
         gelfMessage.addField("beats_type", beatsType);
-        gelfMessage.addField("facility", "beats");
 
         addFlattened(gelfMessage, rootPath, event);
         return gelfMessage;

--- a/graylog2-server/src/test/java/org/graylog/plugins/beats/Beats2CodecTest.java
+++ b/graylog2-server/src/test/java/org/graylog/plugins/beats/Beats2CodecTest.java
@@ -65,7 +65,6 @@ public class Beats2CodecTest {
         assertThat(message).isNotNull();
         assertThat(message.getMessage()).isEqualTo("TEST");
         assertThat(message.getTimestamp()).isEqualTo(new DateTime(2016, 4, 1, 0, 0, DateTimeZone.UTC));
-        assertThat(message.getField("facility")).isEqualTo("beats");
         assertThat(message.getField("beats_type")).isEqualTo("filebeat");
         assertThat(message.getField("source")).isEqualTo("/tmp/test.log");
         assertThat(message.getField("input_type")).isEqualTo("log");
@@ -82,7 +81,6 @@ public class Beats2CodecTest {
         assertThat(message.getMessage()).isEqualTo("TEST");
         assertThat(message.getSource()).isEqualTo("example.local");
         assertThat(message.getTimestamp()).isEqualTo(new DateTime(2016, 4, 1, 0, 0, DateTimeZone.UTC));
-        assertThat(message.getField("facility")).isEqualTo("beats");
         assertThat(message.getField("beats_type")).isEqualTo("filebeat");
         assertThat(message.getField("filebeat_source")).isEqualTo("/tmp/test.log");
         assertThat(message.getField("filebeat_input_type")).isEqualTo("log");
@@ -98,7 +96,6 @@ public class Beats2CodecTest {
         assertThat(message).isNotNull();
         assertThat(message.getSource()).isEqualTo("example.local");
         assertThat(message.getTimestamp()).isEqualTo(new DateTime(2016, 4, 1, 0, 0, DateTimeZone.UTC));
-        assertThat(message.getField("facility")).isEqualTo("beats");
         assertThat(message.getField("beats_type")).isEqualTo("packetbeat");
         assertThat(message.getField("packetbeat_type")).isEqualTo("dns");
         assertThat(message.getField("packetbeat_status")).isEqualTo("OK");
@@ -113,7 +110,6 @@ public class Beats2CodecTest {
         assertThat(message).isNotNull();
         assertThat(message.getSource()).isEqualTo("example.local");
         assertThat(message.getTimestamp()).isEqualTo(new DateTime(2016, 4, 1, 0, 0, DateTimeZone.UTC));
-        assertThat(message.getField("facility")).isEqualTo("beats");
         assertThat(message.getField("beats_type")).isEqualTo("topbeat");
         assertThat(message.getField("topbeat_type")).isEqualTo("system");
     }
@@ -124,7 +120,6 @@ public class Beats2CodecTest {
         assertThat(message).isNotNull();
         assertThat(message.getSource()).isEqualTo("example.local");
         assertThat(message.getTimestamp()).isEqualTo(new DateTime(2016, 11, 24, 12, 13, DateTimeZone.UTC));
-        assertThat(message.getField("facility")).isEqualTo("beats");
         assertThat(message.getField("beats_type")).isEqualTo("winlogbeat");
         assertThat(message.getField("winlogbeat_type")).isEqualTo("wineventlog");
         assertThat(message.getField("winlogbeat_level")).isEqualTo("Information");
@@ -139,7 +134,6 @@ public class Beats2CodecTest {
         assertThat(message).isNotNull();
         assertThat(message.getSource()).isEqualTo("unknown");
         assertThat(message.getTimestamp()).isEqualTo(new DateTime(2016, 4, 1, 0, 0, DateTimeZone.UTC));
-        assertThat(message.getField("facility")).isEqualTo("beats");
         assertThat(message.getField("beats_type")).isEqualTo("beat");
         assertThat(message.getField("beat_foo")).isEqualTo("bar");
     }
@@ -150,7 +144,6 @@ public class Beats2CodecTest {
         assertThat(message).isNotNull();
         assertThat(message.getSource()).isEqualTo("unknown");
         assertThat(message.getTimestamp()).isEqualTo(new DateTime(2016, 4, 1, 0, 0, DateTimeZone.UTC));
-        assertThat(message.getField("facility")).isEqualTo("beats");
         assertThat(message.getField("beats_type")).isEqualTo("beat");
         assertThat(message.getField("beat_foo")).isEqualTo("bar");
         assertThat(message.getField("beat_fields_foo_field")).isEqualTo("bar");
@@ -182,7 +175,6 @@ public class Beats2CodecTest {
             assertThat(message).isNotNull();
             assertThat(message.getSource()).isEqualTo("example.local");
             assertThat(message.getTimestamp()).isEqualTo(new DateTime(2016, 12, 14, 12, 0, DateTimeZone.UTC));
-            assertThat(message.getField("facility")).isEqualTo("beats");
             assertThat(message.getField("beats_type")).isEqualTo("metricbeat");
         }
     }
@@ -194,7 +186,6 @@ public class Beats2CodecTest {
         assertThat(message.getMessage()).isEqualTo("-");
         assertThat(message.getSource()).isEqualTo("unknown");
         assertThat(message.getTimestamp()).isEqualTo(new DateTime(2016, 4, 1, 0, 0, DateTimeZone.UTC));
-        assertThat(message.getField("facility")).isEqualTo("beats");
         assertThat(message.getField("beats_type")).isEqualTo("beat");
         assertThat(message.getField("beat_foo")).isEqualTo("bar");
         assertThat(message.getField("beat_docker_id")).isEqualTo("123");
@@ -209,7 +200,6 @@ public class Beats2CodecTest {
         assertThat(message.getMessage()).isEqualTo("-");
         assertThat(message.getSource()).isEqualTo("unknown");
         assertThat(message.getTimestamp()).isEqualTo(new DateTime(2016, 4, 1, 0, 0, DateTimeZone.UTC));
-        assertThat(message.getField("facility")).isEqualTo("beats");
         assertThat(message.getField("beats_type")).isEqualTo("beat");
         assertThat(message.getField("beat_foo")).isEqualTo("bar");
         assertThat(message.getField("beat_kubernetes_pod_name")).isEqualTo("testpod");
@@ -224,7 +214,6 @@ public class Beats2CodecTest {
         assertThat(message.getMessage()).isEqualTo("-");
         assertThat(message.getSource()).isEqualTo("unknown");
         assertThat(message.getTimestamp()).isEqualTo(new DateTime(2016, 4, 1, 0, 0, DateTimeZone.UTC));
-        assertThat(message.getField("facility")).isEqualTo("beats");
         assertThat(message.getField("beats_type")).isEqualTo("beat");
         assertThat(message.getField("beat_foo")).isEqualTo("bar");
         assertThat(message.getField("beat_meta_cloud_provider")).isEqualTo("ecs");
@@ -240,7 +229,6 @@ public class Beats2CodecTest {
         assertThat(message.getMessage()).isEqualTo("-");
         assertThat(message.getSource()).isEqualTo("unknown");
         assertThat(message.getTimestamp()).isEqualTo(new DateTime(2016, 4, 1, 0, 0, DateTimeZone.UTC));
-        assertThat(message.getField("facility")).isEqualTo("beats");
         assertThat(message.getField("beats_type")).isEqualTo("beat");
         assertThat(message.getField("beat_foo")).isEqualTo("bar");
         assertThat(message.getField("beat_meta_cloud_provider")).isEqualTo("digitalocean");
@@ -255,7 +243,6 @@ public class Beats2CodecTest {
         assertThat(message.getMessage()).isEqualTo("-");
         assertThat(message.getSource()).isEqualTo("unknown");
         assertThat(message.getTimestamp()).isEqualTo(new DateTime(2016, 4, 1, 0, 0, DateTimeZone.UTC));
-        assertThat(message.getField("facility")).isEqualTo("beats");
         assertThat(message.getField("beats_type")).isEqualTo("beat");
         assertThat(message.getField("beat_foo")).isEqualTo("bar");
         assertThat(message.getField("beat_meta_cloud_provider")).isEqualTo("ec2");
@@ -272,7 +259,6 @@ public class Beats2CodecTest {
         assertThat(message.getMessage()).isEqualTo("-");
         assertThat(message.getSource()).isEqualTo("unknown");
         assertThat(message.getTimestamp()).isEqualTo(new DateTime(2016, 4, 1, 0, 0, DateTimeZone.UTC));
-        assertThat(message.getField("facility")).isEqualTo("beats");
         assertThat(message.getField("beats_type")).isEqualTo("beat");
         assertThat(message.getField("beat_foo")).isEqualTo("bar");
         assertThat(message.getField("beat_meta_cloud_provider")).isEqualTo("gce");
@@ -289,7 +275,6 @@ public class Beats2CodecTest {
         assertThat(message.getMessage()).isEqualTo("-");
         assertThat(message.getSource()).isEqualTo("unknown");
         assertThat(message.getTimestamp()).isEqualTo(new DateTime(2016, 4, 1, 0, 0, DateTimeZone.UTC));
-        assertThat(message.getField("facility")).isEqualTo("beats");
         assertThat(message.getField("beats_type")).isEqualTo("beat");
         assertThat(message.getField("beat_foo")).isEqualTo("bar");
         assertThat(message.getField("beat_meta_cloud_provider")).isEqualTo("qcloud");


### PR DESCRIPTION
This field got inherited from the legacy Beats input.
Since the new input is breaking backwards compat anyway, this is a good
time to remove it.
There are enough metadata fields sent by beats, which makes that field
quite redundant.

Fixes #5421 