### PR TITLE
Improve Sidecar API validations

### DIFF
--- a/graylog2-server/src/main/java/org/graylog/plugins/sidecar/rest/models/Collector.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/sidecar/rest/models/Collector.java
@@ -63,6 +63,7 @@ public abstract class Collector {
     public abstract String validationParameters();
 
     @JsonProperty(FIELD_DEFAULT_TEMPLATE)
+    @Nullable
     public abstract String defaultTemplate();
 
     public static Builder builder() {
@@ -92,7 +93,7 @@ public abstract class Collector {
                                    @JsonProperty(FIELD_EXECUTABLE_PATH) String executablePath,
                                    @JsonProperty(FIELD_EXECUTE_PARAMETERS) @Nullable String executeParameters,
                                    @JsonProperty(FIELD_VALIDATION_PARAMETERS) @Nullable String validationParameters,
-                                   @JsonProperty(FIELD_DEFAULT_TEMPLATE) String defaultTemplate) {
+                                   @JsonProperty(FIELD_DEFAULT_TEMPLATE) @Nullable String defaultTemplate) {
         return builder()
                 .id(id)
                 .name(name)

--- a/graylog2-server/src/main/java/org/graylog/plugins/sidecar/rest/resources/CollectorResource.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/sidecar/rest/resources/CollectorResource.java
@@ -77,8 +77,8 @@ import java.util.stream.Collectors;
 @RequiresAuthentication
 public class CollectorResource extends RestResource implements PluginRestResource {
     private static final Pattern VALID_COLLECTOR_NAME_PATTERN = Pattern.compile("^[A-Za-z0-9_.-]+$");
-    // exclude special characters from path ; : * ? " < > | &
-    private static final Pattern VALID_PATH_PATTERN = Pattern.compile("^[^;:*?\"<>|&]+$");
+    // exclude special characters from path ; * ? " < > | &
+    private static final Pattern VALID_PATH_PATTERN = Pattern.compile("^[^;*?\"<>|&]+$");
     private static final List<String> VALID_LINUX_SERVICE_TYPES = Arrays.asList("exec");
     private static final List<String> VALID_WINDOWS_SERVICE_TYPES = Arrays.asList("exec", "svc");
     private static final List<String> VALID_OPERATING_SYSTEMS = Arrays.asList("linux", "windows");
@@ -278,7 +278,7 @@ public class CollectorResource extends RestResource implements PluginRestResourc
         }
 
         if (!validatePath(toValidate.executablePath())) {
-            validation.addError("executable_path", "Collector binary path can not contain the following characters: ; : * ? \" < > | &");
+            validation.addError("executable_path", "Collector binary path can not contain the following characters: ; * ? \" < > | &");
         }
 
         if (toValidate.nodeOperatingSystem() != null) {

--- a/graylog2-server/src/main/java/org/graylog/plugins/sidecar/rest/resources/CollectorResource.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/sidecar/rest/resources/CollectorResource.java
@@ -300,7 +300,7 @@ public class CollectorResource extends RestResource implements PluginRestResourc
             collector = collectorOptional.get();
             if (!collector.id().equals(toValidate.id())) {
                 // a collector exists with a different id, so the name is already in use, fail validation
-                validation.addError("name", "Collector with name \"" + toValidate.name() + "\" already exists");
+                validation.addError("name", "Collector \"" + toValidate.name() + "\" already exists for the \"" + collector.nodeOperatingSystem() + "\" operating system.");
             }
         }
         return validation;

--- a/graylog2-server/src/main/java/org/graylog/plugins/sidecar/rest/resources/CollectorResource.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/sidecar/rest/resources/CollectorResource.java
@@ -285,10 +285,6 @@ public class CollectorResource extends RestResource implements PluginRestResourc
                 validation.addError("executable_path", "Collector binary path cannot contain the following characters: ; * ? \" < > | &");
         }
 
-        if (toValidate.defaultTemplate().isEmpty()) {
-            validation.addError("default_template", "Collector default template cannot be empty.");
-        }
-
         if (toValidate.nodeOperatingSystem() != null) {
             if (!validateOperatingSystem(toValidate.nodeOperatingSystem())) {
                 validation.addError("node_operating_system", "Operating system can only be 'linux' or 'windows'.");

--- a/graylog2-server/src/main/java/org/graylog/plugins/sidecar/rest/resources/CollectorResource.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/sidecar/rest/resources/CollectorResource.java
@@ -275,19 +275,14 @@ public class CollectorResource extends RestResource implements PluginRestResourc
 
         if (toValidate.name().isEmpty()) {
             validation.addError("name", "Collector name cannot be empty.");
-        } else {
-
-            if (!validateCollectorName(toValidate.name())) {
+        } else if (!validateCollectorName(toValidate.name())) {
                 validation.addError("name", "Collector name can only contain the following characters: A-Z,a-z,0-9,_,-,.");
-            }
         }
 
         if (toValidate.executablePath().isEmpty()) {
             validation.addError("executable_path", "Collector binary path cannot be empty.");
-        } else {
-            if (!validatePath(toValidate.executablePath())) {
+        } else if (!validatePath(toValidate.executablePath())) {
                 validation.addError("executable_path", "Collector binary path cannot contain the following characters: ; * ? \" < > | &");
-            }
         }
 
         if (toValidate.defaultTemplate().isEmpty()) {

--- a/graylog2-server/src/main/java/org/graylog/plugins/sidecar/rest/resources/CollectorResource.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/sidecar/rest/resources/CollectorResource.java
@@ -273,12 +273,25 @@ public class CollectorResource extends RestResource implements PluginRestResourc
         final Collector collector;
         final ValidationResult validation = new ValidationResult();
 
-        if (!validateCollectorName(toValidate.name())) {
-            validation.addError("name", "Collector name can only contain the following characters: A-Z,a-z,0-9,_,-,.");
+        if (toValidate.name().isEmpty()) {
+            validation.addError("name", "Collector name cannot be empty.");
+        } else {
+
+            if (!validateCollectorName(toValidate.name())) {
+                validation.addError("name", "Collector name can only contain the following characters: A-Z,a-z,0-9,_,-,.");
+            }
         }
 
-        if (!validatePath(toValidate.executablePath())) {
-            validation.addError("executable_path", "Collector binary path can not contain the following characters: ; * ? \" < > | &");
+        if (toValidate.executablePath().isEmpty()) {
+            validation.addError("executable_path", "Collector binary path cannot be empty.");
+        } else {
+            if (!validatePath(toValidate.executablePath())) {
+                validation.addError("executable_path", "Collector binary path cannot contain the following characters: ; * ? \" < > | &");
+            }
+        }
+
+        if (toValidate.defaultTemplate().isEmpty()) {
+            validation.addError("default_template", "Collector default template cannot be empty.");
         }
 
         if (toValidate.nodeOperatingSystem() != null) {

--- a/graylog2-server/src/main/java/org/graylog/plugins/sidecar/rest/resources/ConfigurationResource.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/sidecar/rest/resources/ConfigurationResource.java
@@ -74,6 +74,7 @@ import javax.ws.rs.core.Response;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
+import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
 import static com.google.common.base.MoreObjects.firstNonNull;
@@ -84,6 +85,9 @@ import static com.google.common.base.MoreObjects.firstNonNull;
 @Produces(MediaType.APPLICATION_JSON)
 @RequiresAuthentication
 public class ConfigurationResource extends RestResource implements PluginRestResource {
+    // a file is created by the Sidecar based on the configuration name so we basically check for invalid paths here
+    private static final Pattern VALID_NAME_PATTERN = Pattern.compile("^[^;*?\"<>|&]+$");
+
     private final ConfigurationService configurationService;
     private final SidecarService sidecarService;
     private final EtagService etagService;
@@ -196,6 +200,10 @@ public class ConfigurationResource extends RestResource implements PluginRestRes
                 validation.addError("name", "Configuration \"" + toValidate.name() + "\" already exists");
             }
         }
+        if (!VALID_NAME_PATTERN.matcher(toValidate.name()).matches()) {
+            validation.addError("name", "Configuration name can not include the following characters: ; * ? \" < > | &" );
+        }
+
         return validation;
     }
 

--- a/graylog2-server/src/main/java/org/graylog/plugins/sidecar/rest/resources/ConfigurationResource.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/sidecar/rest/resources/ConfigurationResource.java
@@ -355,11 +355,8 @@ public class ConfigurationResource extends RestResource implements PluginRestRes
 
         if (toValidate.name().isEmpty()) {
             validation.addError("name", "Configuration name cannot be empty.");
-        } else {
-
-            if (!VALID_NAME_PATTERN.matcher(toValidate.name()).matches()) {
+        } else if (!VALID_NAME_PATTERN.matcher(toValidate.name()).matches()) {
                 validation.addError("name", "Configuration name can not include the following characters: ; * ? \" < > | &");
-            }
         }
 
         if (toValidate.collectorId().isEmpty()) {

--- a/graylog2-server/src/main/java/org/graylog/plugins/sidecar/rest/resources/ConfigurationResource.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/sidecar/rest/resources/ConfigurationResource.java
@@ -352,8 +352,26 @@ public class ConfigurationResource extends RestResource implements PluginRestRes
                 validation.addError("name", "Configuration \"" + toValidate.name() + "\" already exists");
             }
         }
-        if (!VALID_NAME_PATTERN.matcher(toValidate.name()).matches()) {
-            validation.addError("name", "Configuration name can not include the following characters: ; * ? \" < > | &" );
+
+        if (toValidate.name().isEmpty()) {
+            validation.addError("name", "Configuration name cannot be empty.");
+        } else {
+
+            if (!VALID_NAME_PATTERN.matcher(toValidate.name()).matches()) {
+                validation.addError("name", "Configuration name can not include the following characters: ; * ? \" < > | &");
+            }
+        }
+
+        if (toValidate.collectorId().isEmpty()) {
+            validation.addError("collector_id", "Associated collector ID cannot be empty.");
+        }
+
+        if (toValidate.color().isEmpty()) {
+            validation.addError("color", "Collector color cannot be empty.");
+        }
+
+        if (toValidate.template().isEmpty()) {
+            validation.addError("template", "Collector template cannot be empty.");
         }
 
         return validation;

--- a/graylog2-server/src/main/java/org/graylog/plugins/sidecar/rest/resources/ConfigurationVariableResource.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/sidecar/rest/resources/ConfigurationVariableResource.java
@@ -37,6 +37,7 @@ import org.graylog2.shared.rest.resources.RestResource;
 import javax.inject.Inject;
 import javax.validation.Valid;
 import javax.validation.constraints.NotNull;
+import javax.ws.rs.BadRequestException;
 import javax.ws.rs.Consumes;
 import javax.ws.rs.DELETE;
 import javax.ws.rs.GET;
@@ -104,7 +105,8 @@ public class ConfigurationVariableResource extends RestResource implements Plugi
                                              @Valid @NotNull ConfigurationVariable request) {
         ValidationResult validationResult = validateConfigurationVariableHelper(request);
         if (validationResult.failed()) {
-            return Response.status(Response.Status.BAD_REQUEST).entity(validationResult).build();
+            final String errorMessage = "Cannot create variable. " + validationResult.getErrors().toString();
+            throw new BadRequestException(errorMessage);
         }
         final ConfigurationVariable configurationVariable = persistConfigurationVariable(null, request);
         return Response.ok().entity(configurationVariable).build();
@@ -124,7 +126,8 @@ public class ConfigurationVariableResource extends RestResource implements Plugi
 
         ValidationResult validationResult = validateConfigurationVariableHelper(request);
         if (validationResult.failed()) {
-            return Response.status(Response.Status.BAD_REQUEST).entity(validationResult).build();
+            final String errorMessage = "Cannot update variable. " + validationResult.getErrors().toString();
+            throw new BadRequestException(errorMessage);
         }
         if (!previousConfigurationVariable.name().equals(request.name())) {
             configurationService.replaceVariableNames(previousConfigurationVariable.fullName(), request.fullName());

--- a/graylog2-server/src/main/java/org/graylog/plugins/sidecar/rest/resources/ConfigurationVariableResource.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/sidecar/rest/resources/ConfigurationVariableResource.java
@@ -49,6 +49,7 @@ import javax.ws.rs.Produces;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 import java.util.List;
+import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
 @Api(value = "Sidecar/ConfigurationVariables", description = "Manage collector configuration variables")
@@ -57,6 +58,9 @@ import java.util.stream.Collectors;
 @Produces(MediaType.APPLICATION_JSON)
 @RequiresAuthentication
 public class ConfigurationVariableResource extends RestResource implements PluginRestResource {
+    private static final Pattern VALID_NAME_PATTERN = Pattern.compile("^[A-Za-z0-9_]+$");
+    private static final Pattern INVALID_NAME_PREFIX = Pattern.compile("^[0-9].*");
+
     private final ConfigurationVariableService configurationVariableService;
     private final ConfigurationService configurationService;
     private final EtagService etagService;
@@ -170,9 +174,9 @@ public class ConfigurationVariableResource extends RestResource implements Plugi
         final ValidationResult validationResult = new ValidationResult();
         if (confVar.name().isEmpty()) {
             validationResult.addError("name", "Variable name can not be empty.");
-        } else if (!confVar.name().matches("^[A-Za-z0-9_]+$")) {
+        } else if (!VALID_NAME_PATTERN.matcher(confVar.name()).matches()) {
             validationResult.addError("name", "Variable name can only contain the following characters: A-Z,a-z,0-9,_");
-        } else if (confVar.name().matches("^[0-9].*")) {
+        } else if (INVALID_NAME_PREFIX.matcher(confVar.name()).matches()) {
             validationResult.addError("name", "Variable name can not start with numbers.");
         }
 

--- a/graylog2-server/src/main/java/org/graylog/plugins/sidecar/rest/resources/ConfigurationVariableResource.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/sidecar/rest/resources/ConfigurationVariableResource.java
@@ -186,6 +186,11 @@ public class ConfigurationVariableResource extends RestResource implements Plugi
         if (configurationVariableService.hasConflict(confVar)) {
             validationResult.addError("name", "A variable with that name already exists.");
         }
+
+        if (confVar.content().isEmpty()) {
+            validationResult.addError("content", "Variable content can not be empty.");
+        }
+
         return validationResult;
     }
 

--- a/graylog2-server/src/main/java/org/graylog/plugins/sidecar/rest/resources/ConfigurationVariableResource.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/sidecar/rest/resources/ConfigurationVariableResource.java
@@ -138,7 +138,6 @@ public class ConfigurationVariableResource extends RestResource implements Plugi
     @RequiresPermissions(SidecarRestPermissions.CONFIGURATIONS_READ)
     public ValidationResult validateConfigurationVariable(@ApiParam(name = "JSON body", required = true)
                                                      @Valid @NotNull ConfigurationVariable toValidate) {
-        final ValidationResult validation = new ValidationResult();
         return validateConfigurationVariableHelper(toValidate);
     }
 

--- a/graylog2-server/src/main/java/org/graylog/plugins/sidecar/rest/resources/ConfigurationVariableResource.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/sidecar/rest/resources/ConfigurationVariableResource.java
@@ -37,7 +37,6 @@ import org.graylog2.shared.rest.resources.RestResource;
 import javax.inject.Inject;
 import javax.validation.Valid;
 import javax.validation.constraints.NotNull;
-import javax.ws.rs.BadRequestException;
 import javax.ws.rs.Consumes;
 import javax.ws.rs.DELETE;
 import javax.ws.rs.GET;
@@ -105,8 +104,7 @@ public class ConfigurationVariableResource extends RestResource implements Plugi
                                              @Valid @NotNull ConfigurationVariable request) {
         ValidationResult validationResult = validateConfigurationVariableHelper(request);
         if (validationResult.failed()) {
-            final String errorMessage = "Cannot create variable. " + validationResult.getErrors().toString();
-            throw new BadRequestException(errorMessage);
+            return Response.status(Response.Status.BAD_REQUEST).entity(validationResult).build();
         }
         final ConfigurationVariable configurationVariable = persistConfigurationVariable(null, request);
         return Response.ok().entity(configurationVariable).build();
@@ -126,8 +124,7 @@ public class ConfigurationVariableResource extends RestResource implements Plugi
 
         ValidationResult validationResult = validateConfigurationVariableHelper(request);
         if (validationResult.failed()) {
-            final String errorMessage = "Cannot update variable. " + validationResult.getErrors().toString();
-            throw new BadRequestException(errorMessage);
+            return Response.status(Response.Status.BAD_REQUEST).entity(validationResult).build();
         }
         if (!previousConfigurationVariable.name().equals(request.name())) {
             configurationService.replaceVariableNames(previousConfigurationVariable.fullName(), request.fullName());

--- a/graylog2-server/src/main/java/org/graylog/plugins/sidecar/services/CollectorService.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/sidecar/services/CollectorService.java
@@ -54,6 +54,15 @@ public class CollectorService extends PaginatedDbService<Collector> {
     }
 
     @Nullable
+    public Collector findByNameAndOs(String name, String operatingSystem) {
+        return db.findOne(
+                DBQuery.and(
+                        DBQuery.is("name", name),
+                        DBQuery.is("node_operating_system", operatingSystem))
+        );
+    }
+
+    @Nullable
     public Collector findByNameExcludeId(String name, String id) {
         return db.findOne(
                 DBQuery.and(

--- a/graylog2-web-interface/src/components/sidecars/configuration-forms/CollectorForm.jsx
+++ b/graylog2-web-interface/src/components/sidecars/configuration-forms/CollectorForm.jsx
@@ -165,7 +165,8 @@ const CollectorForm = createReactClass({
                    autoFocus
                    required />
 
-            <FormGroup controlId="service_type">
+            <FormGroup controlId="service_type"
+                       validationState={this._validationState('service_type')}>
               <ControlLabel>Process management</ControlLabel>
               <Select inputProps={{ id: 'service_type' }}
                       options={this._formatServiceTypes()}
@@ -173,10 +174,11 @@ const CollectorForm = createReactClass({
                       onChange={this._formDataUpdate('service_type')}
                       placeholder="Service Type"
                       required />
-              <HelpBlock>Choose the service type this collector is meant for.</HelpBlock>
+              <HelpBlock>{this._formatValidationMessage('service_type', 'Choose the service type this collector is meant for.')}</HelpBlock>
             </FormGroup>
 
-            <FormGroup controlId="operating_system">
+            <FormGroup controlId="operating_system"
+                       validationState={this._validationState('node_operating_system')}>
               <ControlLabel>Operating System</ControlLabel>
               <Select inputProps={{ id: 'node_operating_system' }}
                       options={this._formatOperatingSystems()}
@@ -184,7 +186,7 @@ const CollectorForm = createReactClass({
                       onChange={this._formDataUpdate('node_operating_system')}
                       placeholder="Name"
                       required />
-              <HelpBlock>Choose the operating system this collector is meant for.</HelpBlock>
+              <HelpBlock>{this._formatValidationMessage('node_operating_system', 'Choose the operating system this collector is meant for.')}</HelpBlock>
             </FormGroup>
 
             <Input type="text"

--- a/graylog2-web-interface/src/components/sidecars/configuration-forms/CollectorForm.jsx
+++ b/graylog2-web-interface/src/components/sidecars/configuration-forms/CollectorForm.jsx
@@ -161,7 +161,7 @@ const CollectorForm = createReactClass({
                    onChange={this._onNameChange}
                    bsStyle={this._validationState('name')}
                    help={this._formatValidationMessage('name', 'Name for this collector')}
-                   value={this.state.formData.name}
+                   value={this.state.formData.name || ''}
                    autoFocus
                    required />
 
@@ -195,7 +195,7 @@ const CollectorForm = createReactClass({
                    onChange={this._onInputChange('executable_path')}
                    bsStyle={this._validationState('executable_path')}
                    help={this._formatValidationMessage('executable_path', 'Path to the collector executable')}
-                   value={this.state.formData.executable_path}
+                   value={this.state.formData.executable_path || ''}
                    required />
 
             <Input type="text"
@@ -203,14 +203,14 @@ const CollectorForm = createReactClass({
                    label="Execute Parameters"
                    onChange={this._onInputChange('execute_parameters')}
                    help={<span>Parameters the collector is started with.<strong> %s will be replaced by the path to the configuration file.</strong></span>}
-                   value={executeParameters} />
+                   value={executeParameters || ''} />
 
             <Input type="text"
                    id="validationParameters"
                    label="Parameters for Configuration Validation"
                    onChange={this._onInputChange('validation_parameters')}
                    help={<span>Parameters that validate the configuration file. <strong> %s will be replaced by the path to the configuration file.</strong></span>}
-                   value={validationParameters} />
+                   value={validationParameters || ''} />
 
             <FormGroup controlId="defaultTemplate">
               <ControlLabel>Default Template</ControlLabel>

--- a/graylog2-web-interface/src/components/sidecars/configuration-forms/CollectorForm.jsx
+++ b/graylog2-web-interface/src/components/sidecars/configuration-forms/CollectorForm.jsx
@@ -196,20 +196,20 @@ const CollectorForm = createReactClass({
 
             <Input type="text"
                    id="executeParameters"
-                   label="Execute Parameters"
+                   label={<span>Execute Parameters <small className="text-muted">(Optional)</small></span>}
                    onChange={this._onInputChange('execute_parameters')}
                    help={<span>Parameters the collector is started with.<strong> %s will be replaced by the path to the configuration file.</strong></span>}
                    value={executeParameters || ''} />
 
             <Input type="text"
                    id="validationParameters"
-                   label="Parameters for Configuration Validation"
+                   label={<span>Parameters for Configuration Validation <small className="text-muted">(Optional)</small></span>}
                    onChange={this._onInputChange('validation_parameters')}
                    help={<span>Parameters that validate the configuration file. <strong> %s will be replaced by the path to the configuration file.</strong></span>}
                    value={validationParameters || ''} />
 
             <FormGroup controlId="defaultTemplate">
-              <ControlLabel>Default Template</ControlLabel>
+              <ControlLabel><span>Default Template <small className="text-muted">(Optional)</small></span></ControlLabel>
               <SourceCodeEditor id="template"
                                 value={this.state.formData.default_template}
                                 onChange={this._formDataUpdate('default_template')} />

--- a/graylog2-web-interface/src/components/sidecars/configuration-forms/CollectorForm.jsx
+++ b/graylog2-web-interface/src/components/sidecars/configuration-forms/CollectorForm.jsx
@@ -81,9 +81,7 @@ const CollectorForm = createReactClass({
   },
 
   _validateFormData(nextFormData) {
-    if (
-      nextFormData.name &&
-      nextFormData.node_operating_system) {
+    if (nextFormData.name && nextFormData.node_operating_system) {
       CollectorsActions.validate(nextFormData).then(validation => (
         this.setState({ validation_errors: validation.errors, error: validation.failed })
       ));
@@ -128,9 +126,7 @@ const CollectorForm = createReactClass({
 
   _formatValidationMessage(fieldName, defaultText) {
     if (this.state.validation_errors[fieldName]) {
-      return (<div>
-        <span><b>{this.state.validation_errors[fieldName][0]}</b></span>
-      </div>);
+      return <span>{this.state.validation_errors[fieldName][0]}</span>;
     }
     return <span>{defaultText}</span>;
   },

--- a/graylog2-web-interface/src/components/sidecars/configuration-forms/CollectorForm.jsx
+++ b/graylog2-web-interface/src/components/sidecars/configuration-forms/CollectorForm.jsx
@@ -51,6 +51,10 @@ const CollectorForm = createReactClass({
     };
   },
 
+  componentWillMount() {
+    this._debouncedValidateFormData = lodash.debounce(this._validateFormData, 200);
+  },
+
   componentDidMount() {
     CollectorsActions.all();
     CollectorConfigurationsActions.all();
@@ -75,7 +79,7 @@ const CollectorForm = createReactClass({
     return (nextValue) => {
       const nextFormData = lodash.cloneDeep(this.state.formData);
       nextFormData[key] = nextValue;
-      this._validateFormData(nextFormData);
+      this._debouncedValidateFormData(nextFormData);
       this.setState({ formData: nextFormData });
     };
   },

--- a/graylog2-web-interface/src/components/sidecars/configuration-forms/ConfigurationForm.jsx
+++ b/graylog2-web-interface/src/components/sidecars/configuration-forms/ConfigurationForm.jsx
@@ -42,8 +42,8 @@ const ConfigurationForm = createReactClass({
 
   getInitialState() {
     return {
-      parseErrors: [],
-      errors: {},
+      error: false,
+      validation_errors: {},
       formData: {
         id: this.props.configuration.id,
         name: this.props.configuration.name,
@@ -65,24 +65,25 @@ const ConfigurationForm = createReactClass({
   },
 
   _hasErrors() {
-    return Object.keys(this.state.errors).length !== 0 ||
-      this.state.parseErrors.length !== 0 ||
+    return this.state.error ||
       !this._isTemplateSet(this.state.formData.template);
   },
 
-  _validateTemplate(template) {
-    const validation = { key: 'template' };
-    if (!this._isTemplateSet(template)) {
-      validation.hasError = true;
-      validation.message = 'Please fill out the configuration field.';
-    }
-    this._updateValidationError(validation);
+  _validateFormData(nextFormData, checkForRequiredFields) {
+    CollectorConfigurationsActions.validate(nextFormData).then((validation) => {
+      const nextValidation = lodash.clone(validation);
+      if (checkForRequiredFields && !this._isTemplateSet(nextFormData.template)) {
+        nextValidation.errors.template = ['Please fill out the configuration field.'];
+        nextValidation.failed = true;
+      }
+      this.setState({ validation_errors: nextValidation.errors, error: nextValidation.failed });
+    });
   },
 
   _save() {
     if (this._hasErrors()) {
       // Ensure we display an error on the template field, as this is not validated by the browser
-      this._validateTemplate(this.state.formData.template);
+      this._validateFormData(this.state.formData, true);
       return;
     }
 
@@ -98,16 +99,9 @@ const ConfigurationForm = createReactClass({
     return (nextValue, _, hideCallback) => {
       const nextFormData = lodash.cloneDeep(this.state.formData);
       nextFormData[key] = nextValue;
+      this._validateFormData(nextFormData, false);
       this.setState({ formData: nextFormData }, hideCallback);
     };
-  },
-
-  _updateValidationError({ key, hasError, message }) {
-    const nextErrors = lodash.omit(this.state.errors, key);
-    if (hasError) {
-      nextErrors[key] = message;
-    }
-    this.setState({ errors: nextErrors });
   },
 
   replaceConfigurationVariableName(oldname, newname) {
@@ -122,9 +116,6 @@ const ConfigurationForm = createReactClass({
   _onNameChange(event) {
     const nextName = event.target.value;
     this._formDataUpdate('name')(nextName);
-    CollectorConfigurationsActions.validate(nextName).then(validation => (
-      this._updateValidationError({ key: 'name', hasError: validation.error, message: validation.error_message })
-    ));
   },
 
   _getCollectorDefaultTemplate(collectorId) {
@@ -165,7 +156,6 @@ const ConfigurationForm = createReactClass({
 
   _onTemplateChange(nextTemplate) {
     this._formDataUpdate('template')(nextTemplate);
-    this._validateTemplate(nextTemplate);
   },
 
   _onSubmit(event) {
@@ -201,6 +191,22 @@ const ConfigurationForm = createReactClass({
     }
 
     return options;
+  },
+
+  _formatValidationMessage(fieldName, defaultText) {
+    if (this.state.validation_errors[fieldName]) {
+      return (<div>
+        <span><b>{this.state.validation_errors[fieldName][0]}</b></span>
+      </div>);
+    }
+    return <span>{defaultText}</span>;
+  },
+
+  _validationState(fieldName) {
+    if (this.state.validation_errors[fieldName]) {
+      return 'error';
+    }
+    return null;
   },
 
   _renderCollectorTypeField(collectorId, collectors, configurationSidecars) {
@@ -241,9 +247,9 @@ const ConfigurationForm = createReactClass({
                    id="name"
                    label="Name"
                    onChange={this._onNameChange}
-                   bsStyle={this.state.errors.name ? 'error' : null}
-                   help={this.state.errors.name ? this.state.errors.name : 'Required. Name for this configuration'}
-                   value={this.state.formData.name}
+                   bsStyle={this._validationState('name')}
+                   help={this._formatValidationMessage('name', 'Required. Name for this configuration')}
+                   value={this.state.formData.name || ''}
                    autoFocus
                    required />
 
@@ -267,7 +273,8 @@ const ConfigurationForm = createReactClass({
               {this._renderCollectorTypeField(this.state.formData.collector_id, this.state.collectors, this.props.configurationSidecars)}
             </FormGroup>
 
-            <FormGroup controlId="template" validationState={this.state.errors.template ? 'error' : null}>
+            <FormGroup controlId="template"
+                       validationState={this._validationState('template')}>
               <ControlLabel>Configuration</ControlLabel>
               <SourceCodeEditor id="template"
                                 height={400}
@@ -286,9 +293,7 @@ const ConfigurationForm = createReactClass({
                 Migrate
               </Button>
               <HelpBlock>
-                {this.state.errors.template ?
-                  this.state.errors.template :
-                  'Required. Collector configuration, see quick reference for more information.'}
+                {this._formatValidationMessage('template', 'Required. Collector configuration, see quick reference for more information.')}
               </HelpBlock>
             </FormGroup>
           </fieldset>

--- a/graylog2-web-interface/src/components/sidecars/configuration-forms/ConfigurationForm.jsx
+++ b/graylog2-web-interface/src/components/sidecars/configuration-forms/ConfigurationForm.jsx
@@ -195,9 +195,7 @@ const ConfigurationForm = createReactClass({
 
   _formatValidationMessage(fieldName, defaultText) {
     if (this.state.validation_errors[fieldName]) {
-      return (<div>
-        <span><b>{this.state.validation_errors[fieldName][0]}</b></span>
-      </div>);
+      return <span>{this.state.validation_errors[fieldName][0]}</span>;
     }
     return <span>{defaultText}</span>;
   },

--- a/graylog2-web-interface/src/components/sidecars/configuration-forms/ConfigurationForm.jsx
+++ b/graylog2-web-interface/src/components/sidecars/configuration-forms/ConfigurationForm.jsx
@@ -300,7 +300,7 @@ const ConfigurationForm = createReactClass({
             <Col md={12}>
               <FormGroup>
                 <ButtonToolbar>
-                  <Button type="submit" bsStyle="primary">
+                  <Button type="submit" bsStyle="primary" disabled={this._hasErrors()}>
                     {this.props.action === 'create' ? 'Create' : 'Update'}
                   </Button>
                   <Button type="button" onClick={this._onCancel}>

--- a/graylog2-web-interface/src/components/sidecars/configuration-forms/ConfigurationForm.jsx
+++ b/graylog2-web-interface/src/components/sidecars/configuration-forms/ConfigurationForm.jsx
@@ -54,6 +54,10 @@ const ConfigurationForm = createReactClass({
     };
   },
 
+  componentWillMount() {
+    this._debouncedValidateFormData = lodash.debounce(this._validateFormData, 200);
+  },
+
   componentDidMount() {
     CollectorsActions.all();
   },
@@ -99,7 +103,7 @@ const ConfigurationForm = createReactClass({
     return (nextValue, _, hideCallback) => {
       const nextFormData = lodash.cloneDeep(this.state.formData);
       nextFormData[key] = nextValue;
-      this._validateFormData(nextFormData, false);
+      this._debouncedValidateFormData(nextFormData, false);
       this.setState({ formData: nextFormData }, hideCallback);
     };
   },

--- a/graylog2-web-interface/src/components/sidecars/configuration-forms/ConfigurationVariablesHelper.jsx
+++ b/graylog2-web-interface/src/components/sidecars/configuration-forms/ConfigurationVariablesHelper.jsx
@@ -96,10 +96,10 @@ class ConfigurationVariablesHelper extends React.Component {
     return !(this.state.configurationVariables);
   };
 
-  _saveConfigurationVariable = (configurationVariable, callback) => {
+  _saveConfigurationVariable = (configurationVariable, oldName, callback) => {
     ConfigurationVariableActions.save.triggerPromise(configurationVariable)
       .then(() => this._onSuccessfulUpdate(() => {
-        this.props.onVariableRename(configurationVariable.savedName, configurationVariable.name);
+        this.props.onVariableRename(oldName, configurationVariable.name);
         callback();
       }));
   };

--- a/graylog2-web-interface/src/components/sidecars/configuration-forms/EditConfigurationVariableModal.jsx
+++ b/graylog2-web-interface/src/components/sidecars/configuration-forms/EditConfigurationVariableModal.jsx
@@ -68,11 +68,13 @@ class EditConfigurationVariableModal extends React.Component {
     });
   };
 
+  _debouncedValidateFormData = lodash.debounce(this._validateFormData, 200);
+
   _formDataUpdate = (key) => {
     return (nextValue) => {
       const nextFormData = lodash.cloneDeep(this.state.formData);
       nextFormData[key] = nextValue;
-      this._validateFormData(nextFormData);
+      this._debouncedValidateFormData(nextFormData);
       this.setState({ formData: nextFormData });
     };
   };

--- a/graylog2-web-interface/src/components/sidecars/configuration-forms/EditConfigurationVariableModal.jsx
+++ b/graylog2-web-interface/src/components/sidecars/configuration-forms/EditConfigurationVariableModal.jsx
@@ -87,19 +87,8 @@ class EditConfigurationVariableModal extends React.Component {
     this.props.saveConfigurationVariable(this.state.formData, this.state.savedName, this._saved);
   };
 
-  _changeName = (event) => {
-    const nextName = event.target.value;
-    this._formDataUpdate('name')(nextName);
-  };
-
-  _changeDescription = (event) => {
-    const nextName = event.target.value;
-    this._formDataUpdate('description')(nextName);
-  };
-
-  _changeContent = (event) => {
-    const nextName = event.target.value;
-    this._formDataUpdate('content')(nextName);
+  _handleInputChange = (event) => {
+    this._formDataUpdate(event.target.name)(event.target.value);
   };
 
   _formatValidationMessage = (fieldName, defaultText) => {
@@ -142,8 +131,9 @@ class EditConfigurationVariableModal extends React.Component {
             <Input type="text"
                    id={this._getId('variable-name')}
                    label="Name"
+                   name="name"
                    defaultValue={this.state.formData.name}
-                   onChange={this._changeName}
+                   onChange={this._handleInputChange}
                    bsStyle={this._validationState('name')}
                    help={this._formatValidationMessage('name', 'Type a name for this variable')}
                    autoFocus
@@ -152,17 +142,19 @@ class EditConfigurationVariableModal extends React.Component {
             <Input type="text"
                    id={this._getId('variable-description')}
                    label={<span>Description <small className="text-muted">(Optional)</small></span>}
+                   name="description"
                    defaultValue={this.state.formData.description}
-                   onChange={this._changeDescription}
+                   onChange={this._handleInputChange}
                    help="Type a description for this variable"
                    spellCheck={false} />
             <Input type="textarea"
                    id={this._getId('variable-content')}
                    label="Content"
+                   name="content"
                    rows="10"
                    className={ConfigurationHelperStyle.monoSpaceFont}
                    defaultValue={this.state.formData.content}
-                   onChange={this._changeContent}
+                   onChange={this._handleInputChange}
                    bsStyle={this._validationState('content')}
                    help={this._formatValidationMessage('content', 'Write your variable content')}
                    spellCheck={false}

--- a/graylog2-web-interface/src/components/sidecars/configuration-forms/EditConfigurationVariableModal.jsx
+++ b/graylog2-web-interface/src/components/sidecars/configuration-forms/EditConfigurationVariableModal.jsx
@@ -122,7 +122,7 @@ class EditConfigurationVariableModal extends React.Component {
                    required />
             <Input type="text"
                    id={this._getId('variable-description')}
-                   label="Description"
+                   label={<span>Description <small className="text-muted">(Optional)</small></span>}
                    defaultValue={this.state.description}
                    onChange={this._changeDescription}
                    bsStyle={this.state.error ? 'error' : null}

--- a/graylog2-web-interface/src/components/sidecars/configuration-forms/EditConfigurationVariableModal.jsx
+++ b/graylog2-web-interface/src/components/sidecars/configuration-forms/EditConfigurationVariableModal.jsx
@@ -80,15 +80,11 @@ class EditConfigurationVariableModal extends React.Component {
   _save = () => {
     if (this._hasErrors()) {
       // Ensure we display an error on the content field, as this is not validated by the browser
-      this._validateFormData(this.state.formData, true);
+      this._validateFormData(this.state.formData);
       return;
     }
 
-    const configuration = this.state.formData;
-
-    if (!configuration.error) {
-      this.props.saveConfigurationVariable(configuration, this._saved);
-    }
+    this.props.saveConfigurationVariable(this.state.formData, this.state.savedName, this._saved);
   };
 
   _changeName = (event) => {

--- a/graylog2-web-interface/src/components/sidecars/configurations/CollectorList.jsx
+++ b/graylog2-web-interface/src/components/sidecars/configurations/CollectorList.jsx
@@ -1,14 +1,19 @@
 import React from 'react';
 import createReactClass from 'create-react-class';
+import Reflux from 'reflux';
+import CombinedProvider from 'injection/CombinedProvider';
 import PropTypes from 'prop-types';
 import { Button, Col, Row } from 'react-bootstrap';
 import { LinkContainer } from 'react-router-bootstrap';
+import lodash from 'lodash';
 
 import { DataTable, PaginatedList, SearchForm } from 'components/common';
 import Routes from 'routing/Routes';
 import CollectorRow from './CollectorRow';
 
 import style from './CollectorList.css';
+
+const { CollectorsStore, CollectorsActions } = CombinedProvider.get('Collectors');
 
 const CollectorList = createReactClass({
   propTypes: {
@@ -20,8 +25,9 @@ const CollectorList = createReactClass({
     onDelete: PropTypes.func.isRequired,
     onPageChange: PropTypes.func.isRequired,
     onQueryChange: PropTypes.func.isRequired,
-    validateCollector: PropTypes.func.isRequired,
   },
+
+  mixins: [Reflux.connect(CollectorsStore, 'collectors')],
 
   headerCellFormatter(header) {
     const className = (header === 'Actions' ? style.actionsColumn : '');
@@ -29,12 +35,21 @@ const CollectorList = createReactClass({
   },
 
   collectorFormatter(collector) {
-    const { onClone, onDelete, validateCollector } = this.props;
+    const { onClone, onDelete } = this.props;
     return (<CollectorRow collector={collector}
                           onClone={onClone}
                           onDelete={onDelete}
-                          validateCollector={validateCollector} />);
+                          validateCollector={this.validateCollector(collector)} />);
   },
+
+  validateCollector(collector) {
+    return (name) => {
+      const nextCollector = lodash.cloneDeep(collector);
+      nextCollector.name = name;
+      return CollectorsActions.validate(nextCollector);
+    };
+  },
+
 
   render() {
     const { collectors, pagination, query, total, onPageChange, onQueryChange } = this.props;

--- a/graylog2-web-interface/src/components/sidecars/configurations/CollectorList.jsx
+++ b/graylog2-web-interface/src/components/sidecars/configurations/CollectorList.jsx
@@ -45,6 +45,7 @@ const CollectorList = createReactClass({
   validateCollector(collector) {
     return (name) => {
       const nextCollector = lodash.cloneDeep(collector);
+      nextCollector.id = ' ';
       nextCollector.name = name;
       return CollectorsActions.validate(nextCollector);
     };

--- a/graylog2-web-interface/src/components/sidecars/configurations/CollectorList.jsx
+++ b/graylog2-web-interface/src/components/sidecars/configurations/CollectorList.jsx
@@ -1,19 +1,14 @@
 import React from 'react';
 import createReactClass from 'create-react-class';
-import Reflux from 'reflux';
-import CombinedProvider from 'injection/CombinedProvider';
 import PropTypes from 'prop-types';
 import { Button, Col, Row } from 'react-bootstrap';
 import { LinkContainer } from 'react-router-bootstrap';
-import lodash from 'lodash';
 
 import { DataTable, PaginatedList, SearchForm } from 'components/common';
 import Routes from 'routing/Routes';
 import CollectorRow from './CollectorRow';
 
 import style from './CollectorList.css';
-
-const { CollectorsStore, CollectorsActions } = CombinedProvider.get('Collectors');
 
 const CollectorList = createReactClass({
   propTypes: {
@@ -25,9 +20,8 @@ const CollectorList = createReactClass({
     onDelete: PropTypes.func.isRequired,
     onPageChange: PropTypes.func.isRequired,
     onQueryChange: PropTypes.func.isRequired,
+    validateCollector: PropTypes.func.isRequired,
   },
-
-  mixins: [Reflux.connect(CollectorsStore, 'collectors')],
 
   headerCellFormatter(header) {
     const className = (header === 'Actions' ? style.actionsColumn : '');
@@ -35,22 +29,12 @@ const CollectorList = createReactClass({
   },
 
   collectorFormatter(collector) {
-    const { onClone, onDelete } = this.props;
+    const { onClone, onDelete, validateCollector } = this.props;
     return (<CollectorRow collector={collector}
                           onClone={onClone}
                           onDelete={onDelete}
-                          validateCollector={this.validateCollector(collector)} />);
+                          validateCollector={validateCollector} />);
   },
-
-  validateCollector(collector) {
-    return (name) => {
-      const nextCollector = lodash.cloneDeep(collector);
-      nextCollector.id = ' ';
-      nextCollector.name = name;
-      return CollectorsActions.validate(nextCollector);
-    };
-  },
-
 
   render() {
     const { collectors, pagination, query, total, onPageChange, onQueryChange } = this.props;

--- a/graylog2-web-interface/src/components/sidecars/configurations/CollectorListContainer.jsx
+++ b/graylog2-web-interface/src/components/sidecars/configurations/CollectorListContainer.jsx
@@ -40,10 +40,6 @@ const CollectorListContainer = createReactClass({
     CollectorsActions.list({ query: query, pageSize: pageSize }).finally(callback);
   },
 
-  validateCollector(name) {
-    return CollectorsActions.validate(name);
-  },
-
   render() {
     const { collectors } = this.state;
     if (!collectors || !collectors.paginatedCollectors) {
@@ -58,8 +54,7 @@ const CollectorListContainer = createReactClass({
                      onPageChange={this.handlePageChange}
                      onQueryChange={this.handleQueryChange}
                      onClone={this.handleClone}
-                     onDelete={this.handleDelete}
-                     validateCollector={this.validateCollector} />
+                     onDelete={this.handleDelete} />
     );
   },
 });

--- a/graylog2-web-interface/src/components/sidecars/configurations/CollectorListContainer.jsx
+++ b/graylog2-web-interface/src/components/sidecars/configurations/CollectorListContainer.jsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import createReactClass from 'create-react-class';
 import Reflux from 'reflux';
-import lodash from 'lodash';
 
 import CombinedProvider from 'injection/CombinedProvider';
 import { Spinner } from 'components/common';

--- a/graylog2-web-interface/src/components/sidecars/configurations/CollectorListContainer.jsx
+++ b/graylog2-web-interface/src/components/sidecars/configurations/CollectorListContainer.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import createReactClass from 'create-react-class';
 import Reflux from 'reflux';
+import lodash from 'lodash';
 
 import CombinedProvider from 'injection/CombinedProvider';
 import { Spinner } from 'components/common';
@@ -40,6 +41,10 @@ const CollectorListContainer = createReactClass({
     CollectorsActions.list({ query: query, pageSize: pageSize }).finally(callback);
   },
 
+  validateCollector(collector) {
+    return CollectorsActions.validate(collector);
+  },
+
   render() {
     const { collectors } = this.state;
     if (!collectors || !collectors.paginatedCollectors) {
@@ -54,7 +59,8 @@ const CollectorListContainer = createReactClass({
                      onPageChange={this.handlePageChange}
                      onQueryChange={this.handleQueryChange}
                      onClone={this.handleClone}
-                     onDelete={this.handleDelete} />
+                     onDelete={this.handleDelete}
+                     validateCollector={this.validateCollector} />
     );
   },
 });

--- a/graylog2-web-interface/src/components/sidecars/configurations/CollectorRow.jsx
+++ b/graylog2-web-interface/src/components/sidecars/configurations/CollectorRow.jsx
@@ -45,7 +45,7 @@ const CollectorRow = createReactClass({
               <Button bsStyle="info" bsSize="xsmall">Edit</Button>
             </LinkContainer>
             <DropdownButton id={`more-actions-${collector.id}`} title="More actions" bsSize="xsmall" pullRight>
-              <CopyCollectorModal id={collector.id}
+              <CopyCollectorModal collector={collector}
                                   validateCollector={this.props.validateCollector}
                                   copyCollector={this.props.onClone} />
               <MenuItem divider />

--- a/graylog2-web-interface/src/components/sidecars/configurations/ConfigurationListContainer.jsx
+++ b/graylog2-web-interface/src/components/sidecars/configurations/ConfigurationListContainer.jsx
@@ -21,8 +21,8 @@ const ConfigurationListContainer = createReactClass({
     CollectorsActions.all();
   },
 
-  validateConfiguration(name) {
-    return CollectorConfigurationsActions.validate(name);
+  validateConfiguration(configuration) {
+    return CollectorConfigurationsActions.validate(configuration);
   },
 
   handlePageChange(page, pageSize) {

--- a/graylog2-web-interface/src/components/sidecars/configurations/ConfigurationRow.jsx
+++ b/graylog2-web-interface/src/components/sidecars/configurations/ConfigurationRow.jsx
@@ -51,7 +51,7 @@ class ConfigurationRow extends React.Component {
                             title="More actions"
                             bsSize="xsmall"
                             pullRight>
-              <CopyConfigurationModal id={configuration.id}
+              <CopyConfigurationModal configuration={configuration}
                                       validateConfiguration={this.props.validateConfiguration}
                                       copyConfiguration={this.props.onCopy} />
               <MenuItem divider />

--- a/graylog2-web-interface/src/components/sidecars/configurations/CopyCollectorModal.jsx
+++ b/graylog2-web-interface/src/components/sidecars/configurations/CopyCollectorModal.jsx
@@ -53,9 +53,9 @@ class CopyCollectorModal extends React.Component {
   _changeName = (event) => {
     const nextName = event.target.value;
     this.setState({ name: nextName });
-    this.props.validateCollector(nextName).then(validation => (
-      this.setState({ error: validation.error, error_message: validation.error_message })
-    ));
+    this.props.validateCollector(nextName).then((validation) => {
+      this.setState({ error: validation.failed, error_message: validation.errors.name });
+    });
   };
 
   render() {

--- a/graylog2-web-interface/src/components/sidecars/configurations/CopyCollectorModal.jsx
+++ b/graylog2-web-interface/src/components/sidecars/configurations/CopyCollectorModal.jsx
@@ -54,7 +54,11 @@ class CopyCollectorModal extends React.Component {
     const nextName = event.target.value;
     this.setState({ name: nextName });
     this.props.validateCollector(nextName).then((validation) => {
-      this.setState({ error: validation.failed, error_message: validation.errors.name });
+      let errorMessage = '';
+      if (validation.errors.name) {
+        errorMessage = validation.errors.name[0];
+      }
+      this.setState({ error: validation.failed, error_message: errorMessage });
     });
   };
 

--- a/graylog2-web-interface/src/components/sidecars/configurations/CopyCollectorModal.jsx
+++ b/graylog2-web-interface/src/components/sidecars/configurations/CopyCollectorModal.jsx
@@ -1,5 +1,6 @@
 import PropTypes from 'prop-types';
 import React from 'react';
+import lodash from 'lodash';
 import { MenuItem } from 'react-bootstrap';
 
 import { BootstrapModalForm, Input } from 'components/bootstrap';
@@ -8,7 +9,7 @@ import style from './CopyModal.css';
 
 class CopyCollectorModal extends React.Component {
   static propTypes = {
-    id: PropTypes.string,
+    collector: PropTypes.object.isRequired,
     copyCollector: PropTypes.func.isRequired,
     validateCollector: PropTypes.func.isRequired,
   };
@@ -19,7 +20,7 @@ class CopyCollectorModal extends React.Component {
   };
 
   state = {
-    id: this.props.id,
+    id: this.props.collector.id,
     name: '',
     error: false,
     error_message: '',
@@ -30,7 +31,7 @@ class CopyCollectorModal extends React.Component {
   };
 
   _getId = (prefixIdName) => {
-    return `${prefixIdName}-${this.props.id}`;
+    return `${prefixIdName}-${this.state.id}`;
   };
 
   _closeModal = () => {
@@ -46,14 +47,19 @@ class CopyCollectorModal extends React.Component {
     const collector = this.state;
 
     if (!collector.error) {
-      this.props.copyCollector(this.props.id, this.state.name, this._saved);
+      this.props.copyCollector(this.state.id, this.state.name, this._saved);
     }
   };
 
   _changeName = (event) => {
     const nextName = event.target.value;
     this.setState({ name: nextName });
-    this.props.validateCollector(nextName).then((validation) => {
+
+    const nextCollector = lodash.cloneDeep(this.props.collector);
+    nextCollector.name = nextName;
+    nextCollector.id = '';
+
+    this.props.validateCollector(nextCollector).then((validation) => {
       let errorMessage = '';
       if (validation.errors.name) {
         errorMessage = validation.errors.name[0];

--- a/graylog2-web-interface/src/components/sidecars/configurations/CopyConfigurationModal.jsx
+++ b/graylog2-web-interface/src/components/sidecars/configurations/CopyConfigurationModal.jsx
@@ -8,7 +8,7 @@ import style from './CopyModal.css';
 
 class CopyConfigurationModal extends React.Component {
   static propTypes = {
-    id: PropTypes.string,
+    configuration: PropTypes.object.isRequired,
     copyConfiguration: PropTypes.func.isRequired,
     validateConfiguration: PropTypes.func.isRequired,
   };
@@ -19,7 +19,7 @@ class CopyConfigurationModal extends React.Component {
   };
 
   state = {
-    id: this.props.id,
+    id: this.props.configuration.id,
     name: '',
     error: false,
     error_message: '',
@@ -30,7 +30,7 @@ class CopyConfigurationModal extends React.Component {
   };
 
   _getId = (prefixIdName) => {
-    return `${prefixIdName}-${this.props.id}`;
+    return `${prefixIdName}-${this.state.id}`;
   };
 
   _closeModal = () => {
@@ -46,7 +46,7 @@ class CopyConfigurationModal extends React.Component {
     const configuration = this.state;
 
     if (!configuration.error) {
-      this.props.copyConfiguration(this.props.id, this.state.name, this._saved);
+      this.props.copyConfiguration(this.state.id, this.state.name, this._saved);
     }
   };
 

--- a/graylog2-web-interface/src/components/sidecars/configurations/CopyConfigurationModal.jsx
+++ b/graylog2-web-interface/src/components/sidecars/configurations/CopyConfigurationModal.jsx
@@ -53,9 +53,13 @@ class CopyConfigurationModal extends React.Component {
   _changeName = (event) => {
     const nextName = event.target.value;
     this.setState({ name: nextName });
-    this.props.validateConfiguration(nextName).then(validation => (
-      this.setState({ error: validation.error, error_message: validation.error_message })
-    ));
+    this.props.validateConfiguration({ name: nextName }).then((validation) => {
+      let errorMessage = '';
+      if (validation.errors.name) {
+        errorMessage = validation.errors.name[0];
+      }
+      this.setState({ error: validation.failed, error_message: errorMessage });
+    });
   };
 
   render() {

--- a/graylog2-web-interface/src/stores/sidecars/CollectorConfigurationsStore.js
+++ b/graylog2-web-interface/src/stores/sidecars/CollectorConfigurationsStore.js
@@ -1,11 +1,11 @@
 import Reflux from 'reflux';
 import URI from 'urijs';
+import lodash from 'lodash';
 
 import URLUtils from 'util/URLUtils';
 import UserNotification from 'util/UserNotification';
 import fetch from 'logic/rest/FetchProvider';
 import CombinedProvider from 'injection/CombinedProvider';
-import lodash from "lodash";
 
 const { CollectorConfigurationsActions } = CombinedProvider.get('CollectorConfigurations');
 

--- a/graylog2-web-interface/src/stores/sidecars/CollectorConfigurationsStore.js
+++ b/graylog2-web-interface/src/stores/sidecars/CollectorConfigurationsStore.js
@@ -5,6 +5,7 @@ import URLUtils from 'util/URLUtils';
 import UserNotification from 'util/UserNotification';
 import fetch from 'logic/rest/FetchProvider';
 import CombinedProvider from 'injection/CombinedProvider';
+import lodash from "lodash";
 
 const { CollectorConfigurationsActions } = CombinedProvider.get('CollectorConfigurations');
 
@@ -224,13 +225,22 @@ const CollectorConfigurationsStore = Reflux.createStore({
     CollectorConfigurationsActions.delete.promise(promise);
   },
 
-  validate(name) {
-    const promise = fetch('GET', URLUtils.qualifyUrl(`${this.sourceUrl}/configurations/validate/?name=${name}`));
+  validate(configuration) {
+    // set minimum api defaults for faster validation feedback
+    const payload = {
+      name: '',
+      collector_id: '',
+      color: '',
+      template: '',
+    };
+    lodash.merge(payload, configuration);
+
+    const promise = fetch('POST', URLUtils.qualifyUrl(`${this.sourceUrl}/configurations/validate`), payload);
     promise
       .then(
         response => response,
         error => (
-          UserNotification.error(`Validating configuration with name "${name}" failed with status: ${error.message}`,
+          UserNotification.error(`Validating configuration "${payload.name}" failed with status: ${error.message}`,
             'Could not validate configuration')
         ));
 

--- a/graylog2-web-interface/src/stores/sidecars/CollectorConfigurationsStore.js
+++ b/graylog2-web-interface/src/stores/sidecars/CollectorConfigurationsStore.js
@@ -228,10 +228,10 @@ const CollectorConfigurationsStore = Reflux.createStore({
   validate(configuration) {
     // set minimum api defaults for faster validation feedback
     const payload = {
-      name: '',
-      collector_id: '',
-      color: '',
-      template: '',
+      name: ' ',
+      collector_id: ' ',
+      color: ' ',
+      template: ' ',
     };
     lodash.merge(payload, configuration);
 

--- a/graylog2-web-interface/src/stores/sidecars/CollectorsStore.js
+++ b/graylog2-web-interface/src/stores/sidecars/CollectorsStore.js
@@ -1,5 +1,6 @@
 import Reflux from 'reflux';
 import URI from 'urijs';
+import lodash from 'lodash';
 
 import URLUtils from 'util/URLUtils';
 import fetch from 'logic/rest/FetchProvider';
@@ -177,21 +178,23 @@ const CollectorsStore = Reflux.createStore({
     CollectorsActions.copy.promise(promise);
   },
 
-  validate(name, collectorId) {
-    const search = {
-      name: name,
+  validate(collector) {
+    // set minimum api defaults for faster validation feedback
+    const payload = {
+      id: ' ',
+      service_type: 'exec',
+      executable_path: ' ',
+      default_template: ' ',
     };
-    if (collectorId) {
-      search.id = collectorId;
-    }
-    const url = URI(`${this.sourceUrl}/collectors/validate`).search(search).toString();
-    const promise = fetch('GET', URLUtils.qualifyUrl(url));
+    lodash.merge(payload, collector);
+
+    const promise = fetch('POST', URLUtils.qualifyUrl(`${this.sourceUrl}/collectors/validate`), payload);
 
     promise
       .then(
         response => response,
         error => (
-          UserNotification.error(`Validating collector with name "${name}" failed with status: ${error.message}`,
+          UserNotification.error(`Validating collector "${payload.name}" failed with status: ${error.message}`,
             'Could not validate collector')
         ));
 

--- a/graylog2-web-interface/src/stores/sidecars/ConfigurationVariableStore.js
+++ b/graylog2-web-interface/src/stores/sidecars/ConfigurationVariableStore.js
@@ -4,6 +4,7 @@ import URLUtils from 'util/URLUtils';
 import UserNotification from 'util/UserNotification';
 import fetch from 'logic/rest/FetchProvider';
 import CombinedProvider from 'injection/CombinedProvider';
+import lodash from "lodash";
 
 const { ConfigurationVariableActions } = CombinedProvider.get('ConfigurationVariable');
 
@@ -80,16 +81,15 @@ const ConfigurationVariableStore = Reflux.createStore({
   },
 
   validate(configurationVariable) {
-    const request = {
-      id: configurationVariable.id,
-      name: configurationVariable.name,
-      description: configurationVariable.description,
-      content: configurationVariable.content,
+    // set minimum api defaults for faster validation feedback
+    const payload = {
+      id: ' ',
+      name: ' ',
+      content: ' ',
     };
-    const url = URLUtils.qualifyUrl(`${this.sourceUrl}/validate`);
-    const method = 'POST';
+    lodash.merge(payload, configurationVariable);
 
-    const promise = fetch(method, url, request);
+    const promise = fetch('POST', URLUtils.qualifyUrl(`${this.sourceUrl}/validate`), payload);
     promise.catch(
       (error) => {
         UserNotification.error(`Validating variable "${configurationVariable.name}" failed with status: ${error.message}`,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Sidecar validates most entities on the server side. This PR cleans up the code there and brings the API calls in a consistent state. It also adds validations for empty fields. Collector names now are unique per operating systems. This allows to have a `nxlog` collector for linux as well as for windows as an example.
 
