### PR TITLE
Fix endless loop after deleting a widget from a dashboard

### DIFF
--- a/graylog2-web-interface/src/components/widgets/Widget.jsx
+++ b/graylog2-web-interface/src/components/widgets/Widget.jsx
@@ -122,8 +122,9 @@ const Widget = createReactClass({
   },
 
   _calculateWidgetSize() {
-    const $widgetNode = $(this._getWidgetNode());
-    if (!$widgetNode) { return; }
+    const widgetNode = this._getWidgetNode();
+    if (!widgetNode) { return; }
+    const $widgetNode = $(widgetNode);
     // .height() give us the height of the whole widget without counting paddings, we need to remove the size
     // of the header and footer from that.
     const availableHeight = $widgetNode.height() - (this.WIDGET_HEADER_HEIGHT + this.WIDGET_FOOTER_HEIGHT);

--- a/graylog2-web-interface/src/components/widgets/Widget.jsx
+++ b/graylog2-web-interface/src/components/widgets/Widget.jsx
@@ -57,7 +57,9 @@ const Widget = createReactClass({
   },
 
   componentDidUpdate() {
-    this._calculateWidgetSize();
+    if (!this.state.deleted) {
+      this._calculateWidgetSize();
+    }
   },
 
   componentWillUnmount() {


### PR DESCRIPTION
Deleting a widget from a dashboard resulted in `_calculateWidgetSize()` being called endlessly, as the check we had for an empty widget DOM node did not work as expected.

This PR rewrites that check to ensure we can detect this situation and not update the state. Additionally it disables the widget size calculation when a widget is marked as deleted, as it is not needed at that stage.

Fixes #5498 