### PR TITLE
Add correct @JsonProperty for RegistrationResponse

### DIFF
--- a/graylog2-server/src/main/java/org/graylog/plugins/sidecar/rest/responses/RegistrationResponse.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/sidecar/rest/responses/RegistrationResponse.java
@@ -31,17 +31,17 @@ import java.util.List;
 @AutoValue
 @JsonAutoDetect
 public abstract class RegistrationResponse {
-    @JsonProperty
-    public abstract SidecarRegistrationConfiguration collectorRegistrationConfiguration();
+    @JsonProperty("configuration")
+    public abstract SidecarRegistrationConfiguration sidecarRegistrationConfiguration();
 
-    @JsonProperty
+    @JsonProperty("configuration_override")
     public abstract boolean configurationOverride();
 
-    @JsonProperty
+    @JsonProperty("actions")
     @Nullable
     public abstract List<CollectorAction> actions();
 
-    @JsonProperty
+    @JsonProperty("assignments")
     @Nullable
     public abstract List<ConfigurationAssignment> assignments();
 

--- a/graylog2-server/src/main/java/org/graylog/plugins/sidecar/rest/responses/RegistrationResponse.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/sidecar/rest/responses/RegistrationResponse.java
@@ -32,7 +32,7 @@ import java.util.List;
 @JsonAutoDetect
 public abstract class RegistrationResponse {
     @JsonProperty("configuration")
-    public abstract SidecarRegistrationConfiguration sidecarRegistrationConfiguration();
+    public abstract SidecarRegistrationConfiguration configuration();
 
     @JsonProperty("configuration_override")
     public abstract boolean configurationOverride();
@@ -47,12 +47,12 @@ public abstract class RegistrationResponse {
 
     @JsonCreator
     public static RegistrationResponse create(
-            @JsonProperty("configuration") SidecarRegistrationConfiguration sidecarRegistrationConfiguration,
+            @JsonProperty("configuration") SidecarRegistrationConfiguration configuration,
             @JsonProperty("configuration_override") boolean configurationOverride,
             @JsonProperty("actions") @Nullable List<CollectorAction> actions,
             @JsonProperty("assignments") @Nullable List<ConfigurationAssignment> assignments) {
         return new AutoValue_RegistrationResponse(
-                sidecarRegistrationConfiguration,
+                configuration,
                 configurationOverride,
                 actions,
                 assignments);


### PR DESCRIPTION
The response returned the SidecarRegistrationConfiguration as
`collector_registration_configuration` while the sidecar
expects this as `configuration`

Fixes #5487 
