### PR TITLE
Add correct @JsonProperty for RegistrationResponse (#5502)

### DIFF
--- a/graylog2-server/src/main/java/org/graylog/plugins/sidecar/rest/responses/RegistrationResponse.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/sidecar/rest/responses/RegistrationResponse.java
@@ -31,28 +31,28 @@ import java.util.List;
 @AutoValue
 @JsonAutoDetect
 public abstract class RegistrationResponse {
-    @JsonProperty
-    public abstract SidecarRegistrationConfiguration collectorRegistrationConfiguration();
+    @JsonProperty("configuration")
+    public abstract SidecarRegistrationConfiguration configuration();
 
-    @JsonProperty
+    @JsonProperty("configuration_override")
     public abstract boolean configurationOverride();
 
-    @JsonProperty
+    @JsonProperty("actions")
     @Nullable
     public abstract List<CollectorAction> actions();
 
-    @JsonProperty
+    @JsonProperty("assignments")
     @Nullable
     public abstract List<ConfigurationAssignment> assignments();
 
     @JsonCreator
     public static RegistrationResponse create(
-            @JsonProperty("configuration") SidecarRegistrationConfiguration sidecarRegistrationConfiguration,
+            @JsonProperty("configuration") SidecarRegistrationConfiguration configuration,
             @JsonProperty("configuration_override") boolean configurationOverride,
             @JsonProperty("actions") @Nullable List<CollectorAction> actions,
             @JsonProperty("assignments") @Nullable List<ConfigurationAssignment> assignments) {
         return new AutoValue_RegistrationResponse(
-                sidecarRegistrationConfiguration,
+                configuration,
                 configurationOverride,
                 actions,
                 assignments);


### PR DESCRIPTION
* Add correct @JsonProperty for RegistrationResponse

The response returned the SidecarRegistrationConfiguration as
`collector_registration_configuration` while the sidecar
expects this as `configuration`

Fixes #5487

* Rename method to match property

(cherry picked from commit bae6d2b5316f553f39e1f3497b594b121d0bcac0)

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
