### PR TITLE
Fix GELF HTTP input to accept compressed payloads again

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/inputs/transports/HttpTransport.java
+++ b/graylog2-server/src/main/java/org/graylog2/inputs/transports/HttpTransport.java
@@ -92,9 +92,9 @@ public class HttpTransport extends AbstractTcpTransport {
         }
 
         handlers.put("decoder", () -> new HttpRequestDecoder(DEFAULT_MAX_INITIAL_LINE_LENGTH, DEFAULT_MAX_HEADER_SIZE, maxChunkSize));
+        handlers.put("decompressor", HttpContentDecompressor::new);
         handlers.put("aggregator", () -> new HttpObjectAggregator(maxChunkSize));
         handlers.put("encoder", HttpResponseEncoder::new);
-        handlers.put("decompressor", HttpContentDecompressor::new);
         handlers.put("http-handler", () -> new HttpHandler(enableCors));
         handlers.putAll(super.getCustomChildChannelHandlers(input));
 


### PR DESCRIPTION
The "HttpContentDecompressor" handler needs to run before the
"HttpObjectAggregator" in the pipeline so the aggregator can handle
compressed requests.

This fixes a 404 response when sending compressed payloads to the input.

Fixes #5143

**Note:** This needs to be cherry-picked into 3.0