### PR TITLE
Fix IllegalReferenceCountException in GELF HTTP input (#5514)

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/inputs/transports/netty/HttpHandler.java
+++ b/graylog2-server/src/main/java/org/graylog2/inputs/transports/netty/HttpHandler.java
@@ -63,7 +63,7 @@ public class HttpHandler extends SimpleChannelInboundHandler<HttpRequest> {
 
             // send on to raw message handler
             writeResponse(channel, keepAlive, httpRequestVersion, HttpResponseStatus.ACCEPTED, origin);
-            ctx.fireChannelRead(buffer);
+            ctx.fireChannelRead(buffer.retain());
         } else {
             writeResponse(channel, keepAlive, httpRequestVersion, HttpResponseStatus.NOT_FOUND, origin);
         }


### PR DESCRIPTION
Call "#retain()" on the buffer that we pass on to other handlers to
avoid a IllegalReferenceCountException:

  Error in Input [GELF HTTP/5c35eca53d274637c3007582] (channel [id:
  0xc4d569f2, L:/127.0.0.1:12201 ! R:/127.0.0.1:37774]) (cause
  io.netty.util.IllegalReferenceCountException: refCnt: 0, decrement: 1)

Fixes #5503

(cherry picked from commit 95c117ca4fecd1531a314d90e46cf5eb7629e816)