### PR TITLE
Fix widget creation modal with custom configuration (#5510)

### DIFF
--- a/graylog2-web-interface/src/components/widgets/WidgetCreationModal.jsx
+++ b/graylog2-web-interface/src/components/widgets/WidgetCreationModal.jsx
@@ -1,6 +1,7 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 import createReactClass from 'create-react-class';
+import lodash from 'lodash';
 import { Input } from 'components/bootstrap';
 import { PluginStore } from 'graylog-web-plugin/plugin';
 
@@ -10,6 +11,31 @@ import FormsUtils from 'util/FormsUtils';
 import ObjectUtils from 'util/ObjectUtils';
 import StringUtils from 'util/StringUtils';
 
+/**
+ * Widget plugins that want to customize the create modal by adding some inputs need to additionally set the
+ * initial configuration for them. This can be achieved in two different ways:
+ *
+ * ## Setting `initialConfiguration` class property
+ * This is preferred, and it should be used every time configuration does not depend on any external state or props.
+ * Example:
+ * ```
+ *    static initialConfiguration = { shouldShowChart: true, description: 'Initial description' };
+ * ```
+ *
+ * ## Calling `setInitialConfiguration` prop
+ * This component passes a function called `setInitialConfiguration` to the `configurationCreateComponent` defined
+ * for the widget. That function can be called on `constructor` or `componentDidMount` to set the initial configuration
+ * values if any of them is derived from state or other props.
+ * Note that any configuration key set through this function will have precedence over configuration keys set by
+ * `initialConfiguration`.
+ * Example:
+ * ```
+ *    constructor(props) {
+ *      super(props);
+ *      props.setInitialConfiguration({ field: props.fields[0] });
+ *    }
+ * ```
+ */
 const WidgetCreationModal = createReactClass({
   displayName: 'WidgetCreationModal',
 
@@ -23,21 +49,25 @@ const WidgetCreationModal = createReactClass({
 
   getDefaultProps() {
     return {
+      fields: [],
       loading: false,
+      onModalHidden: () => {},
     };
   },
 
   getInitialState() {
     this.widgetPlugin = this._getWidgetPlugin(this.props.widgetType);
+
     return {
       title: this._getDefaultWidgetTitle(this.widgetPlugin),
-      config: {},
+      config: this._getInitialConfiguration(this.widgetPlugin),
     };
   },
 
   componentWillReceiveProps(nextProps) {
     if (this.props.widgetType !== nextProps.widgetType) {
       this.widgetPlugin = this._getWidgetPlugin(nextProps.widgetType);
+      this.setState({ config: this._getInitialConfiguration(this.widgetPlugin) });
     }
   },
 
@@ -45,15 +75,13 @@ const WidgetCreationModal = createReactClass({
     return PluginStore.exports('widgets').filter(widget => widget.type.toUpperCase() === widgetType.toUpperCase())[0];
   },
 
-  _getInitialConfiguration() {
-    if (!this.pluginConfiguration) {
-      return;
-    }
+  _getInitialConfiguration(widgetPlugin) {
+    return lodash.get(widgetPlugin.configurationCreateComponent, 'initialConfiguration', {});
+  },
 
-    const configKeys = Object.keys(this.state.config);
-    if (configKeys.length === 0) {
-      this.setState({ config: this.pluginConfiguration.getInitialConfiguration() });
-    }
+  _setInitialDerivedConfiguration(initialConfig) {
+    const nextConfig = Object.assign({}, this.state.config, initialConfig);
+    this.setState({ config: nextConfig });
   },
 
   open() {
@@ -112,23 +140,12 @@ const WidgetCreationModal = createReactClass({
     return (widgetPlugin.displayName ? StringUtils.capitalizeFirstLetter(widgetPlugin.displayName) : '');
   },
 
-  _getSpecificWidgetInputs() {
-    if (this.widgetPlugin.configurationCreateComponent) {
-      return React.createElement(this.widgetPlugin.configurationCreateComponent, {
-        ref: (elem) => { this.pluginConfiguration = elem; },
-        config: this.state.config,
-        fields: this.props.fields,
-        onChange: this._onConfigurationValueChange,
-      });
-    }
-  },
-
   render() {
     const loading = this.props.loading;
+    const CustomCreateDialog = this.widgetPlugin.configurationCreateComponent;
     return (
       <BootstrapModalForm ref={(createModal) => { this.createModal = createModal; }}
                           title="Create Dashboard Widget"
-                          onModalOpen={this._getInitialConfiguration}
                           onModalClose={this.props.onModalHidden}
                           onSubmitForm={this.save}
                           submitButtonText={loading ? 'Creating...' : 'Create'}
@@ -143,7 +160,12 @@ const WidgetCreationModal = createReactClass({
                  onChange={this._bindValue}
                  help="Type a name that describes your widget."
                  autoFocus />
-          {this._getSpecificWidgetInputs()}
+          {CustomCreateDialog && (
+            <CustomCreateDialog config={this.state.config}
+                                fields={this.props.fields}
+                                onChange={this._onConfigurationValueChange}
+                                setInitialConfiguration={this._setInitialDerivedConfiguration} />
+          )}
         </fieldset>
       </BootstrapModalForm>
     );

--- a/graylog2-web-interface/src/components/widgets/WidgetCreationModal.test.jsx
+++ b/graylog2-web-interface/src/components/widgets/WidgetCreationModal.test.jsx
@@ -1,0 +1,87 @@
+import React from 'react';
+import { mount } from 'enzyme';
+import { PluginManifest, PluginStore } from 'graylog-web-plugin/plugin';
+import WidgetCreationModal from './WidgetCreationModal';
+
+/* eslint react/prop-types: "off", react/no-multi-comp: "off" */
+const CustomModalStaticConfig = class extends React.Component {
+  static initialConfiguration = {
+    foo: '1',
+  };
+  render() {
+    return null;
+  }
+};
+
+const CustomModalDynamicConfig = class extends React.Component {
+  constructor(props) {
+    super(props);
+    props.setInitialConfiguration({
+      foo: '2',
+    });
+  }
+  render() {
+    return null;
+  }
+};
+
+const CustomModalBothConfigs = class extends React.Component {
+  static initialConfiguration = {
+    foo: '3',
+  };
+  constructor(props) {
+    super(props);
+    props.setInitialConfiguration({
+      foo: '4',
+    });
+  }
+  render() {
+    return null;
+  }
+};
+
+PluginStore.register(new PluginManifest({}, {
+  widgets: [
+    {
+      type: 'STATIC',
+      configurationCreateComponent: CustomModalStaticConfig,
+    },
+    {
+      type: 'DYNAMIC',
+      configurationCreateComponent: CustomModalDynamicConfig,
+    },
+    {
+      type: 'BOTH',
+      configurationCreateComponent: CustomModalBothConfigs,
+    },
+  ],
+}));
+
+describe('<WidgetCreationModal />', () => {
+  describe('with static initialConfiguration', () => {
+    it('should set initial configuration', () => {
+      const wrapper = mount(<WidgetCreationModal onConfigurationSaved={() => {}} widgetType="STATIC" />);
+      expect(wrapper.state('config').foo).toEqual('1');
+      wrapper.instance().open();
+      expect(wrapper.state('config').foo).toEqual('1');
+    });
+  });
+
+  describe('with dynamic setInitialConfiguration', () => {
+    it('should set initial configuration', () => {
+      const wrapper = mount(<WidgetCreationModal onConfigurationSaved={() => {}} widgetType="DYNAMIC" />);
+      expect(wrapper.state('config').foo).toEqual(undefined);
+      wrapper.instance().open();
+      expect(wrapper.state('config').foo).toEqual('2');
+    });
+  });
+
+  describe('with both initialConfiguration and setInitialConfiguration', () => {
+    it('should set initial configuration', () => {
+      const wrapper = mount(<WidgetCreationModal onConfigurationSaved={() => {}} widgetType="BOTH" />);
+      expect(wrapper.state('config').foo).toEqual('3');
+      wrapper.instance().open();
+      expect(wrapper.state('config').foo).toEqual('4');
+    });
+  });
+});

--- a/graylog2-web-interface/src/components/widgets/configurations/CountWidgetCreateConfiguration.jsx
+++ b/graylog2-web-interface/src/components/widgets/configurations/CountWidgetCreateConfiguration.jsx
@@ -8,11 +8,9 @@ class CountWidgetCreateConfiguration extends React.Component {
     onChange: PropTypes.func.isRequired,
   };
 
-  getInitialConfiguration = () => {
-    return {
-      trend: false,
-      lower_is_better: false,
-    };
+  static initialConfiguration = {
+    trend: false,
+    lower_is_better: false,
   };
 
   render() {

--- a/graylog2-web-interface/src/components/widgets/configurations/QuickValuesHistogramWidgetCreateConfiguration.jsx
+++ b/graylog2-web-interface/src/components/widgets/configurations/QuickValuesHistogramWidgetCreateConfiguration.jsx
@@ -1,15 +1,7 @@
-import PropTypes from 'prop-types';
 import React from 'react';
 
 class QuickValuesHistogramWidgetCreateConfiguration extends React.Component {
-  static propTypes = {
-    config: PropTypes.object.isRequired,
-    onChange: PropTypes.func.isRequired,
-  };
-
-  getInitialConfiguration = () => {
-    return {};
-  };
+  static initialConfiguration = {};
 
   render() {
     return null;

--- a/graylog2-web-interface/src/components/widgets/configurations/QuickValuesWidgetCreateConfiguration.jsx
+++ b/graylog2-web-interface/src/components/widgets/configurations/QuickValuesWidgetCreateConfiguration.jsx
@@ -8,11 +8,9 @@ class QuickValuesWidgetCreateConfiguration extends React.Component {
     onChange: PropTypes.func.isRequired,
   };
 
-  getInitialConfiguration = () => {
-    return {
-      show_pie_chart: true,
-      show_data_table: true,
-    };
+  static initialConfiguration = {
+    show_pie_chart: true,
+    show_data_table: true,
   };
 
   render() {

--- a/graylog2-web-interface/src/components/widgets/configurations/StatisticalCountWidgetCreateConfiguration.jsx
+++ b/graylog2-web-interface/src/components/widgets/configurations/StatisticalCountWidgetCreateConfiguration.jsx
@@ -6,44 +6,46 @@ import naturalSort from 'javascript-natural-sort';
 import { CountWidgetCreateConfiguration } from 'components/widgets/configurations';
 
 import StoreProvider from 'injection/StoreProvider';
+
 const FieldStatisticsStore = StoreProvider.getStore('FieldStatistics');
+
+const sortFields = (fields) => {
+  return fields.sort((a, b) => naturalSort(a.toLowerCase(), b.toLowerCase()));
+};
+
+const sortStatisticalFunctions = (statisticalFunctions) => {
+  return statisticalFunctions.sort();
+};
 
 class StatisticalCountWidgetCreateConfiguration extends React.Component {
   static propTypes = {
     config: PropTypes.object.isRequired,
     fields: PropTypes.array.isRequired,
     onChange: PropTypes.func.isRequired,
+    setInitialConfiguration: PropTypes.func.isRequired,
   };
+
+  static initialConfiguration = CountWidgetCreateConfiguration.initialConfiguration;
+
+  constructor(props) {
+    super(props);
+
+    this.state = {
+      sortedFields: sortFields(this.props.fields),
+      sortedStatisticalFunctions: sortStatisticalFunctions(FieldStatisticsStore.FUNCTIONS.keySeq().toJS()),
+    };
+
+    props.setInitialConfiguration({
+      field: this.state.sortedFields[0],
+      stats_function: this.state.sortedStatisticalFunctions[0],
+    });
+  }
 
   componentWillReceiveProps(nextProps) {
     if (this.props.fields !== nextProps.fields) {
-      this.setState({ sortedFields: this._sortFields(nextProps.fields) });
+      this.setState({ sortedFields: sortFields(nextProps.fields) });
     }
   }
-
-  _sortFields = (fields) => {
-    return fields.sort((a, b) => naturalSort(a.toLowerCase(), b.toLowerCase()));
-  };
-
-  _sortStatisticalFunctions = (statisticalFunctions) => {
-    return statisticalFunctions.sort();
-  };
-
-  getInitialConfiguration = () => {
-    const countConfiguration = this.countConfiguration.getInitialConfiguration();
-    const initialConfiguration = {};
-
-    Object.keys(countConfiguration).forEach(key => initialConfiguration[key] = countConfiguration[key]);
-    initialConfiguration.field = this.state.sortedFields[0];
-    initialConfiguration.stats_function = this.state.sortedStatisticalFunctions[0];
-
-    return initialConfiguration;
-  };
-
-  state = {
-    sortedFields: this._sortFields(this.props.fields),
-    sortedStatisticalFunctions: this._sortStatisticalFunctions(FieldStatisticsStore.FUNCTIONS.keySeq().toJS()),
-  };
 
   render() {
     return (
@@ -79,7 +81,7 @@ class StatisticalCountWidgetCreateConfiguration extends React.Component {
           })}
         </Input>
 
-        <CountWidgetCreateConfiguration ref={(countConfiguration) => { this.countConfiguration = countConfiguration; }} {...this.props} />
+        <CountWidgetCreateConfiguration {...this.props} />
       </fieldset>
     );
   }


### PR DESCRIPTION
* Use JSX to create custom configuration element.

* Fix linter errors

* Fix widget creation modal with custom config

Due to performance improvements in 3.0, components rendered inside a modal
are only mounted when they will be visible. That broke the way that
`WidgetCreationModal` extends its initial state with custom configuration
set in plugins, as it required components to be mounted when the modal was
opened and this is no longer the case. It is also not easy to know when
custom components are mounted to get their initial configuration, so
we need to make this code more robust to make this work reliable.

This commit changes how custom create configuration can set their
initial configuration. There are two ways of achieving this:

- Set the `initialConfiguration` static property
  This is the preferred way of setting initial configuration, and it is
  used by most of our components extending the widget creation modal,
  as the configurations are static and known when writing the code.

- Set derived configuration with `setInitialConfiguration`
  This is meant to allow components extending the widget creation modal
  to set initial configuration that is derived from props or state. As it
  sets the initial configuration, this should be called in the
  `constructor` or `componentDidMount` of the component.

It is also possible to combine both methods to set the initial
configuration. In case of duplicated configuration keys, the ones passed
through `setInitialConfiguration` will override the ones set in
`initialConfiguration`.

Fixes #5499

Backport of #5510