### PR TITLE
Removing own AMQP reconnecting in favor of the library's.

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/inputs/transports/AmqpConsumer.java
+++ b/graylog2-server/src/main/java/org/graylog2/inputs/transports/AmqpConsumer.java
@@ -16,15 +16,12 @@
  */
 package org.graylog2.inputs.transports;
 
-import com.google.common.util.concurrent.Uninterruptibles;
 import com.rabbitmq.client.AMQP;
 import com.rabbitmq.client.Channel;
 import com.rabbitmq.client.Connection;
 import com.rabbitmq.client.ConnectionFactory;
 import com.rabbitmq.client.DefaultConsumer;
 import com.rabbitmq.client.Envelope;
-import com.rabbitmq.client.ShutdownListener;
-import com.rabbitmq.client.ShutdownSignalException;
 import org.graylog2.plugin.inputs.MessageInput;
 import org.graylog2.plugin.journal.RawMessage;
 import org.slf4j.Logger;
@@ -95,12 +92,7 @@ public class AmqpConsumer {
         this.requeueInvalid = requeueInvalid;
         this.amqpTransport = amqpTransport;
 
-        scheduler.scheduleAtFixedRate(new Runnable() {
-            @Override
-            public void run() {
-                lastSecBytesRead.set(lastSecBytesReadTmp.getAndSet(0));
-            }
-        }, 1, 1, TimeUnit.SECONDS);
+        scheduler.scheduleAtFixedRate(() -> lastSecBytesRead.set(lastSecBytesReadTmp.getAndSet(0)), 1, 1, TimeUnit.SECONDS);
     }
 
     public void run() throws IOException {
@@ -156,6 +148,8 @@ public class AmqpConsumer {
         factory.setPort(port);
         factory.setVirtualHost(virtualHost);
         factory.setRequestedHeartbeat(heartbeatTimeout);
+        // explicitly setting this, to ensure it is true even if the default changes.
+        factory.setAutomaticRecoveryEnabled(true);
 
         if (tls) {
             try {
@@ -187,35 +181,15 @@ public class AmqpConsumer {
         if (null != channel && prefetchCount > 0) {
             channel.basicQos(prefetchCount);
 
-            LOG.info("AMQP prefetch count overriden to <{}>.", prefetchCount);
+            LOG.debug("AMQP prefetch count overriden to <{}>.", prefetchCount);
         }
 
-        connection.addShutdownListener(new ShutdownListener() {
-            @Override
-            public void shutdownCompleted(ShutdownSignalException cause) {
-                if (cause.isInitiatedByApplication()) {
-                    LOG.info("Not reconnecting connection, we disconnected explicitly.");
-                    return;
-                }
-                while (true) {
-                    try {
-                        LOG.error("AMQP connection lost! Trying reconnect in 1 second.");
-
-                        Uninterruptibles.sleepUninterruptibly(1, TimeUnit.SECONDS);
-
-                        connect();
-
-                        LOG.info("Connected! Re-starting consumer.");
-
-                        run();
-
-                        LOG.info("Consumer running.");
-                        break;
-                    } catch (IOException e) {
-                        LOG.error("Could not re-connect to AMQP broker.", e);
-                    }
-                }
+        connection.addShutdownListener(cause -> {
+            if (cause.isInitiatedByApplication()) {
+                LOG.info("Shutting down AMPQ consumer.");
+                return;
             }
+            LOG.warn("AMQP connection lost! Reconnecting ...");
         });
     }
 


### PR DESCRIPTION
## Description
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Before this change, the `AMQPConsumer`, triggered by a connection
shutdown callback, tried to reconnect to the broker, supposedly because
the library did not support auto recovery at the time of implementation.

Current version of the rabbit AMQP client library do support it and in
the version used it is enabled per default. This lead to creating
another connection needlessly, wasting resources and leaving one of the
connections in a state that it is operating on a closed channel,
therefore throwing an exception and NACKing the first incoming
exception, ceasing operation afterwards. Also, stopping an input after it
was reconnected at least once left a number of dangling threads that were
still connected to the broker.

This change is doing these things to improve the situation:

  * Enable auto recovery explicitly in case the default changes in the
future
  * Removing custom reconnection code, leaving only a short logging call

Fixes #4474.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

  - Dropping a connection from the RabbitMQ web console and publishing messages afterwards: lead to exceptions before the change and the number of connections increased by one
  - Restarting the broker and publishing messages afterwards: same

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
