### PR TITLE
Change default collector configs

### DIFF
--- a/graylog2-server/src/main/java/org/graylog/plugins/sidecar/migrations/V20180212165000_AddDefaultCollectors.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/sidecar/migrations/V20180212165000_AddDefaultCollectors.java
@@ -79,8 +79,8 @@ public class V20180212165000_AddDefaultCollectors extends Migration {
                         "output.logstash:\n" +
                         "   hosts: [\"192.168.1.1:5044\"]\n" +
                         "path:\n" +
-                        "  data: /var/cache/graylog-sidecar/filebeat/data\n" +
-                        "  logs: /var/log/graylog-sidecar"
+                        "  data: /var/lib/graylog-sidecar/collectors/filebeat/data\n" +
+                        "  logs: /var/lib/graylog-sidecar/collectors/filebeat/log"
         );
         ensureCollector(
                 "winlogbeat",
@@ -126,9 +126,9 @@ public class V20180212165000_AddDefaultCollectors extends Migration {
                         "Group nxlog\n" +
                         "\n" +
                         "Moduledir /usr/lib/nxlog/modules\n" +
-                        "CacheDir /var/spool/collector-sidecar/nxlog\n" +
-                        "PidFile /var/run/graylog-sidecar/nxlog.pid\n" +
-                        "LogFile /var/log/graylog-sidecar/nxlog.log\n" +
+                        "CacheDir /var/spool/nxlog/data\n" +
+                        "PidFile /var/run/nxlog/nxlog.pid\n" +
+                        "LogFile /var/log/nxlog/nxlog.log\n" +
                         "LogLevel INFO\n" +
                         "\n" +
                         "\n" +


### PR DESCRIPTION
For filebeat use the directory structure under
`/var/lib/graylog-sidecar/collectors/...`
which we will probably reccomend in the future.

For nxlog, stick to the directories provided
by the official package, because it does not create
missing directories on startup.

Refs https://github.com/Graylog2/collector-sidecar/issues/331