### PR TITLE
Improve Sidecar API validations (#5495)

### DIFF
--- a/graylog2-server/src/main/java/org/graylog/plugins/sidecar/rest/models/Collector.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/sidecar/rest/models/Collector.java
@@ -63,6 +63,7 @@ public abstract class Collector {
     public abstract String validationParameters();
 
     @JsonProperty(FIELD_DEFAULT_TEMPLATE)
+    @Nullable
     public abstract String defaultTemplate();
 
     public static Builder builder() {
@@ -92,7 +93,7 @@ public abstract class Collector {
                                    @JsonProperty(FIELD_EXECUTABLE_PATH) String executablePath,
                                    @JsonProperty(FIELD_EXECUTE_PARAMETERS) @Nullable String executeParameters,
                                    @JsonProperty(FIELD_VALIDATION_PARAMETERS) @Nullable String validationParameters,
-                                   @JsonProperty(FIELD_DEFAULT_TEMPLATE) String defaultTemplate) {
+                                   @JsonProperty(FIELD_DEFAULT_TEMPLATE) @Nullable String defaultTemplate) {
         return builder()
                 .id(id)
                 .name(name)

--- a/graylog2-server/src/main/java/org/graylog/plugins/sidecar/rest/resources/CollectorResource.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/sidecar/rest/resources/CollectorResource.java
@@ -29,25 +29,46 @@ import org.graylog.plugins.sidecar.rest.models.Collector;
 import org.graylog.plugins.sidecar.rest.models.CollectorSummary;
 import org.graylog.plugins.sidecar.rest.responses.CollectorListResponse;
 import org.graylog.plugins.sidecar.rest.responses.CollectorSummaryResponse;
-import org.graylog.plugins.sidecar.rest.responses.ValidationResponse;
 import org.graylog.plugins.sidecar.services.CollectorService;
 import org.graylog.plugins.sidecar.services.ConfigurationService;
 import org.graylog.plugins.sidecar.services.EtagService;
 import org.graylog2.audit.jersey.AuditEvent;
+import org.graylog2.audit.jersey.NoAuditEvent;
 import org.graylog2.database.PaginatedList;
-import org.graylog2.plugin.database.ValidationException;
 import org.graylog2.plugin.rest.PluginRestResource;
+import org.graylog2.plugin.rest.ValidationResult;
 import org.graylog2.search.SearchQuery;
 import org.graylog2.search.SearchQueryField;
 import org.graylog2.search.SearchQueryParser;
 import org.graylog2.shared.rest.resources.RestResource;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import javax.inject.Inject;
 import javax.validation.Valid;
 import javax.validation.constraints.NotNull;
-import javax.ws.rs.*;
-import javax.ws.rs.core.*;
+import javax.ws.rs.BadRequestException;
+import javax.ws.rs.Consumes;
+import javax.ws.rs.DELETE;
+import javax.ws.rs.DefaultValue;
+import javax.ws.rs.GET;
+import javax.ws.rs.NotFoundException;
+import javax.ws.rs.POST;
+import javax.ws.rs.PUT;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+import javax.ws.rs.Produces;
+import javax.ws.rs.QueryParam;
+import javax.ws.rs.core.CacheControl;
+import javax.ws.rs.core.Context;
+import javax.ws.rs.core.EntityTag;
+import javax.ws.rs.core.HttpHeaders;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+import java.util.Arrays;
 import java.util.List;
+import java.util.Optional;
+import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
 @Api(value = "Sidecar/Collectors", description = "Manage collectors")
@@ -56,6 +77,15 @@ import java.util.stream.Collectors;
 @Produces(MediaType.APPLICATION_JSON)
 @RequiresAuthentication
 public class CollectorResource extends RestResource implements PluginRestResource {
+    private static final Logger LOG = LoggerFactory.getLogger(CollectorResource.class);
+
+    private static final Pattern VALID_COLLECTOR_NAME_PATTERN = Pattern.compile("^[A-Za-z0-9_.-]+$");
+    // exclude special characters from path ; * ? " < > | &
+    private static final Pattern VALID_PATH_PATTERN = Pattern.compile("^[^;*?\"<>|&]+$");
+    private static final List<String> VALID_LINUX_SERVICE_TYPES = Arrays.asList("exec");
+    private static final List<String> VALID_WINDOWS_SERVICE_TYPES = Arrays.asList("exec", "svc");
+    private static final List<String> VALID_OPERATING_SYSTEMS = Arrays.asList("linux", "windows");
+
     private final CollectorService collectorService;
     private final ConfigurationService configurationService;
     private final EtagService etagService;
@@ -164,15 +194,15 @@ public class CollectorResource extends RestResource implements PluginRestResourc
     @Produces(MediaType.APPLICATION_JSON)
     @ApiOperation(value = "Create a new collector")
     @AuditEvent(type = SidecarAuditEventTypes.COLLECTOR_CREATE)
-    public Collector createCollector(@ApiParam(name = "JSON body", required = true)
-                                     @Valid @NotNull Collector request) throws ValidationException {
-        final ValidationResponse validation = validate(request.name(), null);
-        if (validation.error()) {
-            throw new ValidationException(validation.errorMessage());
+    public Response createCollector(@ApiParam(name = "JSON body", required = true)
+                                     @Valid @NotNull Collector request) throws BadRequestException {
+        Collector collector = collectorService.fromRequest(request);
+        final ValidationResult validationResult = validate(collector);
+        if (validationResult.failed()) {
+            return Response.status(Response.Status.BAD_REQUEST).entity(validationResult).build();
         }
         etagService.invalidateAll();
-        Collector collector = collectorService.fromRequest(request);
-        return collectorService.save(collector);
+        return Response.ok().entity(collectorService.save(collector)).build();
     }
 
     @PUT
@@ -181,17 +211,17 @@ public class CollectorResource extends RestResource implements PluginRestResourc
     @Produces(MediaType.APPLICATION_JSON)
     @ApiOperation(value = "Update a collector")
     @AuditEvent(type = SidecarAuditEventTypes.COLLECTOR_UPDATE)
-    public Collector updateCollector(@ApiParam(name = "id", required = true)
+    public Response updateCollector(@ApiParam(name = "id", required = true)
                                      @PathParam("id") String id,
                                      @ApiParam(name = "JSON body", required = true)
-                                     @Valid @NotNull Collector request) throws ValidationException {
-        final ValidationResponse validation = validate(request.name(), id);
-        if (validation.error()) {
-            throw new ValidationException(validation.errorMessage());
+                                     @Valid @NotNull Collector request) throws BadRequestException {
+        Collector collector = collectorService.fromRequest(id, request);
+        final ValidationResult validationResult = validate(collector);
+        if (validationResult.failed()) {
+            return Response.status(Response.Status.BAD_REQUEST).entity(validationResult).build();
         }
         etagService.invalidateAll();
-        Collector collector = collectorService.fromRequest(id, request);
-        return collectorService.save(collector);
+        return Response.ok().entity(collectorService.save(collector)).build();
     }
 
     @POST
@@ -202,13 +232,13 @@ public class CollectorResource extends RestResource implements PluginRestResourc
     public Response copyCollector(@ApiParam(name = "id", required = true)
                                   @PathParam("id") String id,
                                   @ApiParam(name = "name", required = true)
-                                  @PathParam("name") String name) throws NotFoundException {
-        final ValidationResponse validation = validate(name, null);
-        if (validation.error()) {
-            return Response.status(Response.Status.BAD_REQUEST).entity(validation).build();
+                                  @PathParam("name") String name) throws NotFoundException, BadRequestException {
+        final Collector collector = collectorService.copy(id, name);
+        final ValidationResult validationResult = validate(collector);
+        if (validationResult.failed()) {
+            return Response.status(Response.Status.BAD_REQUEST).entity(validationResult).build();
         }
         etagService.invalidateAll();
-        final Collector collector = collectorService.copy(id, name);
         collectorService.save(collector);
         return Response.accepted().build();
     }
@@ -236,31 +266,81 @@ public class CollectorResource extends RestResource implements PluginRestResourc
         return Response.accepted().build();
     }
 
-    @GET
+    @POST
     @Path("/validate")
+    @NoAuditEvent("Validation only")
     @RequiresPermissions(SidecarRestPermissions.CONFIGURATIONS_READ)
     @Produces(MediaType.APPLICATION_JSON)
-    @ApiOperation(value = "Validates collector name")
-    public ValidationResponse validateCollector(
-            @ApiParam(name = "name", required = true) @QueryParam("name") String name,
-            @ApiParam(name = "id", required = false) @QueryParam("id") String id) {
-        return validate(name, id);
+    @ApiOperation(value = "Validates collector parameters")
+    public ValidationResult validateCollector(
+            @Valid @ApiParam("collector") Collector toValidate) {
+        return validate(toValidate);
     }
 
-    private ValidationResponse validate(String name, String id) {
-        if (!name.matches("^[A-Za-z0-9_.-]+$")) {
-            return ValidationResponse.create(true, "Collector name can only contain the following characters: A-Z,a-z,0-9,_,-,.");
-        }
+    private ValidationResult validate(Collector toValidate) {
+        final Optional<Collector> collectorOptional;
         final Collector collector;
-        if (id == null) {
-            collector = collectorService.findByName(name);
+        final ValidationResult validation = new ValidationResult();
+
+        if (toValidate.name().isEmpty()) {
+            validation.addError("name", "Collector name cannot be empty.");
+        } else if (!validateCollectorName(toValidate.name())) {
+                validation.addError("name", "Collector name can only contain the following characters: A-Z,a-z,0-9,_,-,.");
+        }
+
+        if (toValidate.executablePath().isEmpty()) {
+            validation.addError("executable_path", "Collector binary path cannot be empty.");
+        } else if (!validatePath(toValidate.executablePath())) {
+                validation.addError("executable_path", "Collector binary path cannot contain the following characters: ; * ? \" < > | &");
+        }
+
+        if (toValidate.nodeOperatingSystem() != null) {
+            if (!validateOperatingSystem(toValidate.nodeOperatingSystem())) {
+                validation.addError("node_operating_system", "Operating system can only be 'linux' or 'windows'.");
+            }
+            if (!validateServiceType(toValidate.serviceType(), toValidate.nodeOperatingSystem())) {
+                validation.addError("service_type", "Linux collectors only support 'Foreground execution' while Windows collectors additionally support 'Windows service'.");
+            }
+            collectorOptional = Optional.ofNullable(collectorService.findByNameAndOs(toValidate.name(), toValidate.nodeOperatingSystem()));
         } else {
-            collector = collectorService.findByNameExcludeId(name, id);
+            collectorOptional = Optional.ofNullable(collectorService.findByName(toValidate.name()));
         }
-        if (collector == null) {
-            return ValidationResponse.create(false, null);
+        if (collectorOptional.isPresent()) {
+            collector = collectorOptional.get();
+            if (!collector.id().equals(toValidate.id())) {
+                // a collector exists with a different id, so the name is already in use, fail validation
+                validation.addError("name", "Collector \"" + toValidate.name() + "\" already exists for the \"" + collector.nodeOperatingSystem() + "\" operating system.");
+            }
         }
-        return ValidationResponse.create(true, "Collector with name \"" + name + "\" already exists");
+        return validation;
+    }
+
+    private boolean validateCollectorName(String name) {
+        return VALID_COLLECTOR_NAME_PATTERN.matcher(name).matches();
+    }
+
+    private boolean validateServiceType(String type, String operatingSystem) {
+        switch(operatingSystem) {
+            case "linux":
+                if (VALID_LINUX_SERVICE_TYPES.contains(type)) {
+                    return true;
+                }
+                break;
+            case "windows":
+                if (VALID_WINDOWS_SERVICE_TYPES.contains(type)) {
+                    return true;
+                }
+                break;
+        }
+        return false;
+    }
+
+    private boolean validateOperatingSystem(String operatingSystem) {
+        return VALID_OPERATING_SYSTEMS.contains(operatingSystem);
+    }
+
+    private boolean validatePath(String path) {
+        return VALID_PATH_PATTERN.matcher(path).matches();
     }
 
     private String collectorsToEtag(CollectorListResponse collectors) {

--- a/graylog2-server/src/main/java/org/graylog/plugins/sidecar/rest/resources/ConfigurationResource.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/sidecar/rest/resources/ConfigurationResource.java
@@ -35,7 +35,6 @@ import org.graylog.plugins.sidecar.rest.responses.CollectorUploadListResponse;
 import org.graylog.plugins.sidecar.rest.responses.ConfigurationListResponse;
 import org.graylog.plugins.sidecar.rest.responses.ConfigurationPreviewRenderResponse;
 import org.graylog.plugins.sidecar.rest.responses.ConfigurationSidecarsResponse;
-import org.graylog.plugins.sidecar.rest.responses.ValidationResponse;
 import org.graylog.plugins.sidecar.services.ConfigurationService;
 import org.graylog.plugins.sidecar.services.EtagService;
 import org.graylog.plugins.sidecar.services.ImportService;
@@ -45,10 +44,13 @@ import org.graylog2.audit.jersey.AuditEvent;
 import org.graylog2.audit.jersey.NoAuditEvent;
 import org.graylog2.database.PaginatedList;
 import org.graylog2.plugin.rest.PluginRestResource;
+import org.graylog2.plugin.rest.ValidationResult;
 import org.graylog2.search.SearchQuery;
 import org.graylog2.search.SearchQueryField;
 import org.graylog2.search.SearchQueryParser;
 import org.graylog2.shared.rest.resources.RestResource;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import javax.inject.Inject;
 import javax.validation.Valid;
@@ -73,6 +75,8 @@ import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
+import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
 import static com.google.common.base.MoreObjects.firstNonNull;
@@ -83,6 +87,11 @@ import static com.google.common.base.MoreObjects.firstNonNull;
 @Produces(MediaType.APPLICATION_JSON)
 @RequiresAuthentication
 public class ConfigurationResource extends RestResource implements PluginRestResource {
+    private static final Logger LOG = LoggerFactory.getLogger(ConfigurationResource.class);
+
+    // a file is created by the Sidecar based on the configuration name so we basically check for invalid paths here
+    private static final Pattern VALID_NAME_PATTERN = Pattern.compile("^[^;*?\"<>|&]+$");
+
     private final ConfigurationService configurationService;
     private final SidecarService sidecarService;
     private final EtagService etagService;
@@ -176,17 +185,14 @@ public class ConfigurationResource extends RestResource implements PluginRestRes
         return ConfigurationSidecarsResponse.create(configuration.id(), sidecarsWithConfiguration);
     }
 
-    @GET
+    @POST
     @Path("/validate")
+    @NoAuditEvent("Validation only")
     @RequiresPermissions(SidecarRestPermissions.CONFIGURATIONS_READ)
     @Produces(MediaType.APPLICATION_JSON)
-    @ApiOperation(value = "Validates configuration name")
-    public ValidationResponse validateConfiguration(@ApiParam(name = "name", required = true) @QueryParam("name") String name) {
-        final Configuration configuration = this.configurationService.findByName(name);
-        if (configuration == null) {
-            return ValidationResponse.create(false, null);
-        }
-        return ValidationResponse.create(true, "Configuration with name \"" + name + "\" already exists");
+    @ApiOperation(value = "Validates configuration parameters")
+    public ValidationResult validateConfiguration(@Valid @ApiParam("configuration") Configuration toValidate) {
+        return validate(toValidate);
     }
 
     @GET
@@ -266,9 +272,15 @@ public class ConfigurationResource extends RestResource implements PluginRestRes
     @Produces(MediaType.APPLICATION_JSON)
     @ApiOperation(value = "Create new configuration")
     @AuditEvent(type = SidecarAuditEventTypes.CONFIGURATION_CREATE)
-    public Configuration createConfiguration(@ApiParam(name = "JSON body", required = true)
+    public Response createConfiguration(@ApiParam(name = "JSON body", required = true)
                                              @Valid @NotNull Configuration request) {
-        return persistConfiguration(null, request);
+        final Configuration configuration = configurationFromRequest(null, request);
+        final ValidationResult validationResult = validate(configuration);
+        if (validationResult.failed()) {
+            return Response.status(Response.Status.BAD_REQUEST).entity(validationResult).build();
+        }
+
+        return Response.ok().entity(configurationService.save(configuration)).build();
     }
 
     @POST
@@ -280,6 +292,10 @@ public class ConfigurationResource extends RestResource implements PluginRestRes
                                       @PathParam("id") String id,
                                       @PathParam("name") String name) throws NotFoundException {
         final Configuration configuration = configurationService.copyConfiguration(id, name);
+        final ValidationResult validationResult = validate(configuration);
+        if (validationResult.failed()) {
+            return Response.status(Response.Status.BAD_REQUEST).entity(validationResult).build();
+        }
         configurationService.save(configuration);
         return Response.accepted().build();
     }
@@ -290,7 +306,7 @@ public class ConfigurationResource extends RestResource implements PluginRestRes
     @Produces(MediaType.APPLICATION_JSON)
     @ApiOperation(value = "Update a configuration")
     @AuditEvent(type = SidecarAuditEventTypes.CONFIGURATION_UPDATE)
-    public Configuration updateConfiguration(@ApiParam(name = "id", required = true)
+    public Response updateConfiguration(@ApiParam(name = "id", required = true)
                                              @PathParam("id") String id,
                                              @ApiParam(name = "JSON body", required = true)
                                              @Valid @NotNull Configuration request) {
@@ -306,10 +322,14 @@ public class ConfigurationResource extends RestResource implements PluginRestRes
             }
         }
 
-        final Configuration updatedConfiguration = persistConfiguration(id, request);
+        final Configuration updatedConfiguration = configurationFromRequest(id, request);
+        final ValidationResult validationResult = validate(updatedConfiguration);
+        if (validationResult.failed()) {
+            return Response.status(Response.Status.BAD_REQUEST).entity(validationResult).build();
+        }
         etagService.invalidateAll();
 
-        return updatedConfiguration;
+        return Response.ok().entity(configurationService.save(updatedConfiguration)).build();
     }
 
     @DELETE
@@ -332,6 +352,47 @@ public class ConfigurationResource extends RestResource implements PluginRestRes
         return Response.accepted().build();
     }
 
+    private ValidationResult validate(Configuration toValidate) {
+        final Optional<Configuration> configurationOptional;
+        final Configuration configuration;
+        final ValidationResult validation = new ValidationResult();
+
+        configurationOptional = Optional.ofNullable(configurationService.findByName(toValidate.name()));
+        if (configurationOptional.isPresent()) {
+            configuration = configurationOptional.get();
+            if (!configuration.id().equals(toValidate.id())) {
+                // a configuration exists with a different id, so the name is already in use, fail validation
+                validation.addError("name", "Configuration \"" + toValidate.name() + "\" already exists");
+            }
+        }
+
+        if (toValidate.name().isEmpty()) {
+            validation.addError("name", "Configuration name cannot be empty.");
+        } else if (!VALID_NAME_PATTERN.matcher(toValidate.name()).matches()) {
+                validation.addError("name", "Configuration name can not include the following characters: ; * ? \" < > | &");
+        }
+
+        if (toValidate.collectorId().isEmpty()) {
+            validation.addError("collector_id", "Associated collector ID cannot be empty.");
+        }
+
+        if (toValidate.color().isEmpty()) {
+            validation.addError("color", "Collector color cannot be empty.");
+        }
+
+        if (toValidate.template().isEmpty()) {
+            validation.addError("template", "Collector template cannot be empty.");
+        }
+
+        try {
+            this.configurationService.renderPreview(toValidate.template());
+        } catch (RenderTemplateException e) {
+            validation.addError("template", "Template error: " + e.getMessage());
+        }
+
+        return validation;
+    }
+
     private boolean isConfigurationInUse(String configurationId) {
         return sidecarService.all().stream().anyMatch(sidecar -> isConfigurationAssignedToSidecar(configurationId, sidecar));
     }
@@ -347,19 +408,13 @@ public class ConfigurationResource extends RestResource implements PluginRestRes
                 .toString();
     }
 
-    private Configuration persistConfiguration(String id, Configuration request) {
-        try {
-            this.configurationService.renderPreview(request.template());
-        } catch (RenderTemplateException e) {
-            throw new BadRequestException("Configuration template validation failed: " + e.getMessage());
-        }
-
+    private Configuration configurationFromRequest(String id, Configuration request) {
         Configuration configuration;
         if (id == null) {
             configuration = configurationService.fromRequest(request);
         } else {
             configuration = configurationService.fromRequest(id, request);
         }
-        return configurationService.save(configuration);
+        return configuration;
     }
 }

--- a/graylog2-server/src/main/java/org/graylog/plugins/sidecar/services/CollectorService.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/sidecar/services/CollectorService.java
@@ -54,6 +54,15 @@ public class CollectorService extends PaginatedDbService<Collector> {
     }
 
     @Nullable
+    public Collector findByNameAndOs(String name, String operatingSystem) {
+        return db.findOne(
+                DBQuery.and(
+                        DBQuery.is("name", name),
+                        DBQuery.is("node_operating_system", operatingSystem))
+        );
+    }
+
+    @Nullable
     public Collector findByNameExcludeId(String name, String id) {
         return db.findOne(
                 DBQuery.and(

--- a/graylog2-web-interface/src/components/sidecars/configuration-forms/ConfigurationVariablesHelper.jsx
+++ b/graylog2-web-interface/src/components/sidecars/configuration-forms/ConfigurationVariablesHelper.jsx
@@ -96,10 +96,10 @@ class ConfigurationVariablesHelper extends React.Component {
     return !(this.state.configurationVariables);
   };
 
-  _saveConfigurationVariable = (configurationVariable, callback) => {
+  _saveConfigurationVariable = (configurationVariable, oldName, callback) => {
     ConfigurationVariableActions.save.triggerPromise(configurationVariable)
       .then(() => this._onSuccessfulUpdate(() => {
-        this.props.onVariableRename(configurationVariable.savedName, configurationVariable.name);
+        this.props.onVariableRename(oldName, configurationVariable.name);
         callback();
       }));
   };

--- a/graylog2-web-interface/src/components/sidecars/configurations/CollectorListContainer.jsx
+++ b/graylog2-web-interface/src/components/sidecars/configurations/CollectorListContainer.jsx
@@ -40,8 +40,8 @@ const CollectorListContainer = createReactClass({
     CollectorsActions.list({ query: query, pageSize: pageSize }).finally(callback);
   },
 
-  validateCollector(name) {
-    return CollectorsActions.validate(name);
+  validateCollector(collector) {
+    return CollectorsActions.validate(collector);
   },
 
   render() {

--- a/graylog2-web-interface/src/components/sidecars/configurations/CollectorRow.jsx
+++ b/graylog2-web-interface/src/components/sidecars/configurations/CollectorRow.jsx
@@ -45,7 +45,7 @@ const CollectorRow = createReactClass({
               <Button bsStyle="info" bsSize="xsmall">Edit</Button>
             </LinkContainer>
             <DropdownButton id={`more-actions-${collector.id}`} title="More actions" bsSize="xsmall" pullRight>
-              <CopyCollectorModal id={collector.id}
+              <CopyCollectorModal collector={collector}
                                   validateCollector={this.props.validateCollector}
                                   copyCollector={this.props.onClone} />
               <MenuItem divider />

--- a/graylog2-web-interface/src/components/sidecars/configurations/ConfigurationListContainer.jsx
+++ b/graylog2-web-interface/src/components/sidecars/configurations/ConfigurationListContainer.jsx
@@ -21,8 +21,8 @@ const ConfigurationListContainer = createReactClass({
     CollectorsActions.all();
   },
 
-  validateConfiguration(name) {
-    return CollectorConfigurationsActions.validate(name);
+  validateConfiguration(configuration) {
+    return CollectorConfigurationsActions.validate(configuration);
   },
 
   handlePageChange(page, pageSize) {

--- a/graylog2-web-interface/src/components/sidecars/configurations/ConfigurationRow.jsx
+++ b/graylog2-web-interface/src/components/sidecars/configurations/ConfigurationRow.jsx
@@ -51,7 +51,7 @@ class ConfigurationRow extends React.Component {
                             title="More actions"
                             bsSize="xsmall"
                             pullRight>
-              <CopyConfigurationModal id={configuration.id}
+              <CopyConfigurationModal configuration={configuration}
                                       validateConfiguration={this.props.validateConfiguration}
                                       copyConfiguration={this.props.onCopy} />
               <MenuItem divider />

--- a/graylog2-web-interface/src/components/sidecars/configurations/CopyCollectorModal.jsx
+++ b/graylog2-web-interface/src/components/sidecars/configurations/CopyCollectorModal.jsx
@@ -1,5 +1,6 @@
 import PropTypes from 'prop-types';
 import React from 'react';
+import lodash from 'lodash';
 import { MenuItem } from 'react-bootstrap';
 
 import { BootstrapModalForm, Input } from 'components/bootstrap';
@@ -8,7 +9,7 @@ import style from './CopyModal.css';
 
 class CopyCollectorModal extends React.Component {
   static propTypes = {
-    id: PropTypes.string,
+    collector: PropTypes.object.isRequired,
     copyCollector: PropTypes.func.isRequired,
     validateCollector: PropTypes.func.isRequired,
   };
@@ -19,7 +20,7 @@ class CopyCollectorModal extends React.Component {
   };
 
   state = {
-    id: this.props.id,
+    id: this.props.collector.id,
     name: '',
     error: false,
     error_message: '',
@@ -30,7 +31,7 @@ class CopyCollectorModal extends React.Component {
   };
 
   _getId = (prefixIdName) => {
-    return `${prefixIdName}-${this.props.id}`;
+    return `${prefixIdName}-${this.state.id}`;
   };
 
   _closeModal = () => {
@@ -46,16 +47,25 @@ class CopyCollectorModal extends React.Component {
     const collector = this.state;
 
     if (!collector.error) {
-      this.props.copyCollector(this.props.id, this.state.name, this._saved);
+      this.props.copyCollector(this.state.id, this.state.name, this._saved);
     }
   };
 
   _changeName = (event) => {
     const nextName = event.target.value;
     this.setState({ name: nextName });
-    this.props.validateCollector(nextName).then(validation => (
-      this.setState({ error: validation.error, error_message: validation.error_message })
-    ));
+
+    const nextCollector = lodash.cloneDeep(this.props.collector);
+    nextCollector.name = nextName;
+    nextCollector.id = '';
+
+    this.props.validateCollector(nextCollector).then((validation) => {
+      let errorMessage = '';
+      if (validation.errors.name) {
+        errorMessage = validation.errors.name[0];
+      }
+      this.setState({ error: validation.failed, error_message: errorMessage });
+    });
   };
 
   render() {

--- a/graylog2-web-interface/src/components/sidecars/configurations/CopyConfigurationModal.jsx
+++ b/graylog2-web-interface/src/components/sidecars/configurations/CopyConfigurationModal.jsx
@@ -8,7 +8,7 @@ import style from './CopyModal.css';
 
 class CopyConfigurationModal extends React.Component {
   static propTypes = {
-    id: PropTypes.string,
+    configuration: PropTypes.object.isRequired,
     copyConfiguration: PropTypes.func.isRequired,
     validateConfiguration: PropTypes.func.isRequired,
   };
@@ -19,7 +19,7 @@ class CopyConfigurationModal extends React.Component {
   };
 
   state = {
-    id: this.props.id,
+    id: this.props.configuration.id,
     name: '',
     error: false,
     error_message: '',
@@ -30,7 +30,7 @@ class CopyConfigurationModal extends React.Component {
   };
 
   _getId = (prefixIdName) => {
-    return `${prefixIdName}-${this.props.id}`;
+    return `${prefixIdName}-${this.state.id}`;
   };
 
   _closeModal = () => {
@@ -46,16 +46,20 @@ class CopyConfigurationModal extends React.Component {
     const configuration = this.state;
 
     if (!configuration.error) {
-      this.props.copyConfiguration(this.props.id, this.state.name, this._saved);
+      this.props.copyConfiguration(this.state.id, this.state.name, this._saved);
     }
   };
 
   _changeName = (event) => {
     const nextName = event.target.value;
     this.setState({ name: nextName });
-    this.props.validateConfiguration(nextName).then(validation => (
-      this.setState({ error: validation.error, error_message: validation.error_message })
-    ));
+    this.props.validateConfiguration({ name: nextName }).then((validation) => {
+      let errorMessage = '';
+      if (validation.errors.name) {
+        errorMessage = validation.errors.name[0];
+      }
+      this.setState({ error: validation.failed, error_message: errorMessage });
+    });
   };
 
   render() {

--- a/graylog2-web-interface/src/stores/sidecars/CollectorConfigurationsStore.js
+++ b/graylog2-web-interface/src/stores/sidecars/CollectorConfigurationsStore.js
@@ -1,5 +1,6 @@
 import Reflux from 'reflux';
 import URI from 'urijs';
+import lodash from 'lodash';
 
 import URLUtils from 'util/URLUtils';
 import UserNotification from 'util/UserNotification';
@@ -224,13 +225,22 @@ const CollectorConfigurationsStore = Reflux.createStore({
     CollectorConfigurationsActions.delete.promise(promise);
   },
 
-  validate(name) {
-    const promise = fetch('GET', URLUtils.qualifyUrl(`${this.sourceUrl}/configurations/validate/?name=${name}`));
+  validate(configuration) {
+    // set minimum api defaults for faster validation feedback
+    const payload = {
+      name: ' ',
+      collector_id: ' ',
+      color: ' ',
+      template: ' ',
+    };
+    lodash.merge(payload, configuration);
+
+    const promise = fetch('POST', URLUtils.qualifyUrl(`${this.sourceUrl}/configurations/validate`), payload);
     promise
       .then(
         response => response,
         error => (
-          UserNotification.error(`Validating configuration with name "${name}" failed with status: ${error.message}`,
+          UserNotification.error(`Validating configuration "${payload.name}" failed with status: ${error.message}`,
             'Could not validate configuration')
         ));
 

--- a/graylog2-web-interface/src/stores/sidecars/CollectorsStore.js
+++ b/graylog2-web-interface/src/stores/sidecars/CollectorsStore.js
@@ -1,5 +1,6 @@
 import Reflux from 'reflux';
 import URI from 'urijs';
+import lodash from 'lodash';
 
 import URLUtils from 'util/URLUtils';
 import fetch from 'logic/rest/FetchProvider';
@@ -177,21 +178,23 @@ const CollectorsStore = Reflux.createStore({
     CollectorsActions.copy.promise(promise);
   },
 
-  validate(name, collectorId) {
-    const search = {
-      name: name,
+  validate(collector) {
+    // set minimum api defaults for faster validation feedback
+    const payload = {
+      id: ' ',
+      service_type: 'exec',
+      executable_path: ' ',
+      default_template: ' ',
     };
-    if (collectorId) {
-      search.id = collectorId;
-    }
-    const url = URI(`${this.sourceUrl}/collectors/validate`).search(search).toString();
-    const promise = fetch('GET', URLUtils.qualifyUrl(url));
+    lodash.merge(payload, collector);
+
+    const promise = fetch('POST', URLUtils.qualifyUrl(`${this.sourceUrl}/collectors/validate`), payload);
 
     promise
       .then(
         response => response,
         error => (
-          UserNotification.error(`Validating collector with name "${name}" failed with status: ${error.message}`,
+          UserNotification.error(`Validating collector "${payload.name}" failed with status: ${error.message}`,
             'Could not validate collector')
         ));
 

--- a/graylog2-web-interface/src/stores/sidecars/ConfigurationVariableStore.js
+++ b/graylog2-web-interface/src/stores/sidecars/ConfigurationVariableStore.js
@@ -4,6 +4,7 @@ import URLUtils from 'util/URLUtils';
 import UserNotification from 'util/UserNotification';
 import fetch from 'logic/rest/FetchProvider';
 import CombinedProvider from 'injection/CombinedProvider';
+import lodash from "lodash";
 
 const { ConfigurationVariableActions } = CombinedProvider.get('ConfigurationVariable');
 
@@ -80,16 +81,15 @@ const ConfigurationVariableStore = Reflux.createStore({
   },
 
   validate(configurationVariable) {
-    const request = {
-      id: configurationVariable.id,
-      name: configurationVariable.name,
-      description: configurationVariable.description,
-      content: configurationVariable.content,
+    // set minimum api defaults for faster validation feedback
+    const payload = {
+      id: ' ',
+      name: ' ',
+      content: ' ',
     };
-    const url = URLUtils.qualifyUrl(`${this.sourceUrl}/validate`);
-    const method = 'POST';
+    lodash.merge(payload, configurationVariable);
 
-    const promise = fetch(method, url, request);
+    const promise = fetch('POST', URLUtils.qualifyUrl(`${this.sourceUrl}/validate`), payload);
     promise.catch(
       (error) => {
         UserNotification.error(`Validating variable "${configurationVariable.name}" failed with status: ${error.message}`,


### PR DESCRIPTION
* Improve collector validation

  * Respect that collectors can exists with the same name if the operating system differs
  * To be consistend with other API validation resources:
    * Use POST instead of GET
    * Return build-in ValidationResult instead of custom ValidationResponse
    * Expect full object as validation input instead of single attributes
  * Add basic validation for special characters in executable path

* Prevent undefined help string

* Reset collector ID to prevent clones with same name like currently

* Add validation for OS dependent service_type check

* Prevent uncontrolled input warning

* Allow : to fix windows paths

* Adopt CollectorConfiguration to common validation pattern

* Remove unused variable

* Move validation back to CollectorListContainer to keep server access at one place

* Provide full Configuration object to modal to be consistend with CopyCollectorModal

* Add validation for configuration name

* Use precompiled Pattern instead of inline regex

* Throw proper http error in case of a failed validation

* Add validation to copy/create call

* Throw exception to make clear something went wrong

* Check empty mandatory Collector fields

* Check empty mandatory Configuration fields

* Improve syntax

* Check empty mandatory ConfigurationVariables fields

* Cleanup minor style issues

* Fix syntax

* Make Collector default template optional

* Add validation note about OS based namespaces for collectors

* Mark fields as optional

* Fix Configuration validation during clone

* Adopt ConfigurationVariables form to ValidationResult response

* Fix variable rename replacement in ace editor

* Combine change handler

* Disable create button if form has errors

* Return structured validation error if available

* Add validation debouncing back and extend it to all configuration forms

(cherry picked from commit 334fd8633b9943eb6c95a25ff5b7562b89338c73)
