### PR TITLE
Fix assets compression on production builds (#5527)

### DIFF
--- a/graylog2-web-interface/webpack.config.js
+++ b/graylog2-web-interface/webpack.config.js
@@ -160,6 +160,10 @@ if (TARGET === 'build') {
           minimize: true,
           sourceMap: true,
           compress: {
+            // Conditionals compression caused issue #5450 so they should be disabled for now.
+            // Looking at uglify-js issues, it seems that the latest changes in version 3.4.9 broke conditionals
+            // compression. For example: https://github.com/mishoo/UglifyJS2/issues/3269
+            conditionals: false,
             warnings: false,
           },
           mangle: {


### PR DESCRIPTION
Due to a bug in uglify-js 3.4.9, compressing conditionals during asset
minimization is broken, leading to #5450.

This commit disables conditionals compression until we can test it is fixed
in a future uglify-js release.

There are several reports in the upstream project, one of them is:
https://github.com/mishoo/UglifyJS2/issues/3269

Fixes #5450

Backport of #5527