### PR TITLE
Invert "add beats prefix" option

### DIFF
--- a/graylog2-server/src/main/java/org/graylog/plugins/beats/Beats2Codec.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/beats/Beats2Codec.java
@@ -49,16 +49,16 @@ public class Beats2Codec extends AbstractCodec {
     private static final Logger LOG = LoggerFactory.getLogger(Beats2Codec.class);
     private static final String MAP_KEY_SEPARATOR = "_";
     private static final String BEATS_UNKNOWN = "unknown";
-    private static final String CK_BEATS_PREFIX = "beats_prefix";
+    private static final String CK_NO_BEATS_PREFIX = "no_beats_prefix";
 
     private final ObjectMapper objectMapper;
-    private final boolean useBeatPrefix;
+    private final boolean noBeatsPrefix;
 
     @Inject
     public Beats2Codec(@Assisted Configuration configuration, ObjectMapper objectMapper) {
         super(configuration);
 
-        this.useBeatPrefix = configuration.getBoolean(CK_BEATS_PREFIX, false);
+        this.noBeatsPrefix = configuration.getBoolean(CK_NO_BEATS_PREFIX, false);
         this.objectMapper = requireNonNull(objectMapper);
     }
 
@@ -79,7 +79,7 @@ public class Beats2Codec extends AbstractCodec {
 
     private Message parseEvent(JsonNode event) {
         final String beatsType = event.path("@metadata").path("beat").asText("beat");
-        final String rootPath = useBeatPrefix ? beatsType : "";
+        final String rootPath = noBeatsPrefix ? "" : beatsType;
         final String message = event.path("message").asText("-");
         final String timestampField = event.path("@timestamp").asText();
         final DateTime timestamp = Tools.dateTimeFromString(timestampField);
@@ -158,10 +158,10 @@ public class Beats2Codec extends AbstractCodec {
             final ConfigurationRequest configurationRequest = super.getRequestedConfiguration();
 
             configurationRequest.addField(new BooleanField(
-                    CK_BEATS_PREFIX,
-                    "Add Beats type as prefix",
+                    CK_NO_BEATS_PREFIX,
+                    "Do not add Beats type as prefix",
                     false,
-                    "Use the Beats type as prefix for each field, e. g. \"filebeat_source\"."
+                    "Do not prefix each field with the Beats type, e. g. \"source\" -> \"filebeat_source\"."
             ));
 
             return configurationRequest;

--- a/graylog2-server/src/test/java/org/graylog/plugins/beats/Beats2CodecTest.java
+++ b/graylog2-server/src/test/java/org/graylog/plugins/beats/Beats2CodecTest.java
@@ -47,7 +47,7 @@ public class Beats2CodecTest {
 
     @Before
     public void setUp() throws Exception {
-        configuration = new Configuration(Collections.singletonMap("beats_prefix", true));
+        configuration = new Configuration(Collections.singletonMap("no_beats_prefix", false));
         codec = new Beats2Codec(configuration, objectMapper);
     }
 
@@ -58,7 +58,7 @@ public class Beats2CodecTest {
 
     @Test
     public void decodeMessagesHandlesFilebeatMessagesWithoutPrefix() throws Exception {
-        configuration = new Configuration(Collections.singletonMap("beats_prefix", false));
+        configuration = new Configuration(Collections.singletonMap("no_beats_prefix", true));
         codec = new Beats2Codec(configuration, objectMapper);
 
         final Message message = codec.decode(messageFromJson("filebeat.json"));


### PR DESCRIPTION
This option was added to keep the Beats backwards compatible.
Later it was decided to fork the Beats input altogether,
so we don't have to worry about breaking compatibility.

Therefore invert and enable the Beats prefix option by default
on the new input.
Having the prefix avoids field collisions.
One example is that filebeat would fill the `source` field to the
filename, not to the hostname, which is more Graylog like.

Refs https://github.com/Graylog2/graylog-plugin-beats/pull/29
