### PR TITLE
Protect used content pack entities from uninstall

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/contentpacks/ContentPackInstallationPersistenceService.java
+++ b/graylog2-server/src/main/java/org/graylog2/contentpacks/ContentPackInstallationPersistenceService.java
@@ -143,14 +143,11 @@ public class ContentPackInstallationPersistenceService {
     }
 
     public long countInstallationOfEntityByIdAndFoundOnSystem(ModelId entityId) {
-        final String foundOnSystemField = String.format(Locale.ROOT, "%s.%s", ContentPackInstallation.FIELD_ENTITIES, NativeEntityDescriptor.FIELD_ENTITY_FOUND_ON_SYSTEM);
+        final DBQuery.Query query = DBQuery.elemMatch(ContentPackInstallation.FIELD_ENTITIES,
+                DBQuery.and(
+                        DBQuery.is(NativeEntityDescriptor.FIELD_ENTITY_FOUND_ON_SYSTEM, true),
+                        DBQuery.is(NativeEntityDescriptor.FIELD_META_ID, entityId.id())));
 
-        DBCursor<ContentPackInstallation> dbInstallations = dbCollection.find(DBQuery.is(foundOnSystemField, true));
-        ImmutableSet<ContentPackInstallation> installations =  ImmutableSet.copyOf((Iterator<ContentPackInstallation>) dbInstallations);
-        return installations.stream().map(ContentPackInstallation::entities)
-                .flatMap(Collection::stream)
-                .filter(nativeEntityDescriptor -> nativeEntityDescriptor.id().toString().matches(entityId.toString()) &&
-                        nativeEntityDescriptor.foundOnSystem() != null && nativeEntityDescriptor.foundOnSystem())
-                .count();
+        return dbCollection.getCount(query);
     }
 }

--- a/graylog2-server/src/main/java/org/graylog2/contentpacks/ContentPackInstallationPersistenceService.java
+++ b/graylog2-server/src/main/java/org/graylog2/contentpacks/ContentPackInstallationPersistenceService.java
@@ -131,12 +131,12 @@ public class ContentPackInstallationPersistenceService {
 
     /**
      * Returns the number of installations the given content pack entity ID is used in.
-     * @param contentPackEntityId the content pack entity ID
+     * @param entityId the native entity ID
      * @return number of installations
      */
-    public long countInstallationOfEntityById(ModelId contentPackEntityId) {
-        final String field = String.format(Locale.ROOT, "%s.%s", ContentPackInstallation.FIELD_ENTITIES, NativeEntityDescriptor.FIELD_ENTITY_ID);
+    public long countInstallationOfEntityById(ModelId entityId) {
+        final String field = String.format(Locale.ROOT, "%s.%s", ContentPackInstallation.FIELD_ENTITIES, NativeEntityDescriptor.FIELD_META_ID);
 
-        return dbCollection.getCount(DBQuery.is(field, contentPackEntityId));
+        return dbCollection.getCount(DBQuery.is(field, entityId));
     }
 }

--- a/graylog2-server/src/main/java/org/graylog2/contentpacks/ContentPackService.java
+++ b/graylog2-server/src/main/java/org/graylog2/contentpacks/ContentPackService.java
@@ -42,6 +42,7 @@ import org.graylog2.contentpacks.model.ContentPackUninstallDetails;
 import org.graylog2.contentpacks.model.ContentPackUninstallation;
 import org.graylog2.contentpacks.model.ContentPackV1;
 import org.graylog2.contentpacks.model.LegacyContentPack;
+import org.graylog2.contentpacks.model.ModelId;
 import org.graylog2.contentpacks.model.ModelType;
 import org.graylog2.contentpacks.model.constraints.Constraint;
 import org.graylog2.contentpacks.model.constraints.ConstraintCheckResult;
@@ -131,7 +132,17 @@ public class ContentPackService {
                 if (existingEntity.isPresent()) {
                     LOG.trace("Found existing entity for {}", entityDescriptor);
                     final NativeEntity<?> nativeEntity = existingEntity.get();
-                    allEntityDescriptors.add(nativeEntity.descriptor());
+                    final NativeEntityDescriptor nativeEntityDescriptor = nativeEntity.descriptor();
+                    /* Found entity but no installation */
+                    if (contentPackInstallationPersistenceService.countInstallationOfEntityById(nativeEntityDescriptor.id()) <= 0 ||
+                        contentPackInstallationPersistenceService.countInstallationOfEntityByIdAndFoundOnSystem(nativeEntityDescriptor.id()) > 0) {
+                          final NativeEntityDescriptor serverDescriptor = nativeEntityDescriptor.toBuilder()
+                                  .foundOnSystem(true)
+                                  .build();
+                        allEntityDescriptors.add(serverDescriptor);
+                    } else {
+                        allEntityDescriptors.add(nativeEntity.descriptor());
+                    }
                     allEntities.put(entityDescriptor, nativeEntity.entity());
                 } else {
                     LOG.trace("Creating new entity for {}", entityDescriptor);
@@ -255,9 +266,13 @@ public class ContentPackService {
                 if (nativeEntityDescriptorOptional.isPresent()) {
                     final NativeEntityDescriptor nativeEntityDescriptor = nativeEntityDescriptorOptional.get();
                     final Optional nativeEntityOptional = facade.loadNativeEntity(nativeEntityDescriptor);
+                    final ModelId entityId = nativeEntityDescriptor.id();
+                    final long installCount = contentPackInstallationPersistenceService
+                            .countInstallationOfEntityById(entityId);
+                    final long systemFoundCount = contentPackInstallationPersistenceService.
+                            countInstallationOfEntityByIdAndFoundOnSystem(entityId);
 
-                    if (contentPackInstallationPersistenceService
-                            .countInstallationOfEntityById(nativeEntityDescriptor.id()) > 1) {
+                    if (installCount > 1 || (installCount == 1 && systemFoundCount >= 1)) {
                        skippedEntities.add(nativeEntityDescriptor);
                        LOG.debug("Did not remove entity since other content pack installations still use them: {}",
                                nativeEntityDescriptor);

--- a/graylog2-server/src/main/java/org/graylog2/contentpacks/ContentPackService.java
+++ b/graylog2-server/src/main/java/org/graylog2/contentpacks/ContentPackService.java
@@ -133,7 +133,7 @@ public class ContentPackService {
                     LOG.trace("Found existing entity for {}", entityDescriptor);
                     final NativeEntity<?> nativeEntity = existingEntity.get();
                     final NativeEntityDescriptor nativeEntityDescriptor = nativeEntity.descriptor();
-                    /* Found entity but no installation */
+                    /* Found entity on the system or we found a other installation which stated that */
                     if (contentPackInstallationPersistenceService.countInstallationOfEntityById(nativeEntityDescriptor.id()) <= 0 ||
                         contentPackInstallationPersistenceService.countInstallationOfEntityByIdAndFoundOnSystem(nativeEntityDescriptor.id()) > 0) {
                           final NativeEntityDescriptor serverDescriptor = nativeEntityDescriptor.toBuilder()

--- a/graylog2-server/src/main/java/org/graylog2/contentpacks/ContentPackService.java
+++ b/graylog2-server/src/main/java/org/graylog2/contentpacks/ContentPackService.java
@@ -202,7 +202,7 @@ public class ContentPackService {
             if (nativeEntityDescriptorOptional.isPresent()) {
                 NativeEntityDescriptor nativeEntityDescriptor = nativeEntityDescriptorOptional.get();
                 if (contentPackInstallationPersistenceService
-                        .countInstallationOfEntityById(nativeEntityDescriptor.contentPackEntityId()) <= 1) {
+                        .countInstallationOfEntityById(nativeEntityDescriptor.id()) <= 1) {
                     nativeEntityDescriptors.add(nativeEntityDescriptor);
                 }
             }
@@ -257,7 +257,7 @@ public class ContentPackService {
                     final Optional nativeEntityOptional = facade.loadNativeEntity(nativeEntityDescriptor);
 
                     if (contentPackInstallationPersistenceService
-                            .countInstallationOfEntityById(nativeEntityDescriptor.contentPackEntityId()) > 1) {
+                            .countInstallationOfEntityById(nativeEntityDescriptor.id()) > 1) {
                        skippedEntities.add(nativeEntityDescriptor);
                        LOG.debug("Did not remove entity since other content pack installations still use them: {}",
                                nativeEntityDescriptor);

--- a/graylog2-server/src/main/java/org/graylog2/contentpacks/facades/LookupCacheFacade.java
+++ b/graylog2-server/src/main/java/org/graylog2/contentpacks/facades/LookupCacheFacade.java
@@ -117,7 +117,7 @@ public class LookupCacheFacade implements EntityFacade<CacheDto> {
                 .build();
 
         final CacheDto savedCacheDto = cacheService.save(cacheDto);
-        return NativeEntity.create(entity.id(), savedCacheDto.name(), TYPE_V1, savedCacheDto.title(), savedCacheDto);
+        return NativeEntity.create(entity.id(), savedCacheDto.id(), TYPE_V1, savedCacheDto.title(), savedCacheDto);
     }
 
     @Override

--- a/graylog2-server/src/main/java/org/graylog2/contentpacks/facades/LookupDataAdapterFacade.java
+++ b/graylog2-server/src/main/java/org/graylog2/contentpacks/facades/LookupDataAdapterFacade.java
@@ -117,7 +117,7 @@ public class LookupDataAdapterFacade implements EntityFacade<DataAdapterDto> {
                 .build();
 
         final DataAdapterDto savedDataAdapterDto = dataAdapterService.save(dataAdapterDto);
-        return NativeEntity.create(entity.id(), savedDataAdapterDto.name(), TYPE_V1, savedDataAdapterDto.title(), savedDataAdapterDto);
+        return NativeEntity.create(entity.id(), savedDataAdapterDto.id(), TYPE_V1, savedDataAdapterDto.title(), savedDataAdapterDto);
     }
 
     @Override

--- a/graylog2-server/src/main/java/org/graylog2/contentpacks/model/entities/NativeEntity.java
+++ b/graylog2-server/src/main/java/org/graylog2/contentpacks/model/entities/NativeEntity.java
@@ -33,12 +33,12 @@ public abstract class NativeEntity<T> {
     /**
      * Shortcut for {@link #create(NativeEntityDescriptor, Object)}
      */
-    public static <T> NativeEntity<T> create(String entityId, String nativeId, ModelType type, String title, Boolean foundOnServer, T entity) {
-        return create(NativeEntityDescriptor.create(entityId, nativeId, type, title, foundOnServer), entity);
+    public static <T> NativeEntity<T> create(String entityId, String nativeId, ModelType type, String title, boolean foundOnSystem, T entity) {
+        return create(NativeEntityDescriptor.create(entityId, nativeId, type, title, foundOnSystem), entity);
     }
 
-    public static <T> NativeEntity<T> create(ModelId entityId, String nativeId, ModelType type, String title, Boolean foundOnServer, T entity) {
-        return create(NativeEntityDescriptor.create(entityId, nativeId, type, title, foundOnServer), entity);
+    public static <T> NativeEntity<T> create(ModelId entityId, String nativeId, ModelType type, String title, boolean foundOnSystem, T entity) {
+        return create(NativeEntityDescriptor.create(entityId, nativeId, type, title, foundOnSystem), entity);
     }
 
     public static <T> NativeEntity<T> create(ModelId entityId, String nativeId, ModelType type, String title, T entity) {

--- a/graylog2-server/src/main/java/org/graylog2/contentpacks/model/entities/NativeEntity.java
+++ b/graylog2-server/src/main/java/org/graylog2/contentpacks/model/entities/NativeEntity.java
@@ -42,6 +42,6 @@ public abstract class NativeEntity<T> {
     }
 
     public static <T> NativeEntity<T> create(ModelId entityId, String nativeId, ModelType type, String title, T entity) {
-        return create(NativeEntityDescriptor.create(entityId, nativeId, type, title, null), entity);
+        return create(NativeEntityDescriptor.create(entityId, nativeId, type, title, false), entity);
     }
 }

--- a/graylog2-server/src/main/java/org/graylog2/contentpacks/model/entities/NativeEntity.java
+++ b/graylog2-server/src/main/java/org/graylog2/contentpacks/model/entities/NativeEntity.java
@@ -33,11 +33,15 @@ public abstract class NativeEntity<T> {
     /**
      * Shortcut for {@link #create(NativeEntityDescriptor, Object)}
      */
-    public static <T> NativeEntity<T> create(String entityId, String nativeId, ModelType type, String title, T entity) {
-        return create(NativeEntityDescriptor.create(entityId, nativeId, type, title), entity);
+    public static <T> NativeEntity<T> create(String entityId, String nativeId, ModelType type, String title, Boolean foundOnServer, T entity) {
+        return create(NativeEntityDescriptor.create(entityId, nativeId, type, title, foundOnServer), entity);
+    }
+
+    public static <T> NativeEntity<T> create(ModelId entityId, String nativeId, ModelType type, String title, Boolean foundOnServer, T entity) {
+        return create(NativeEntityDescriptor.create(entityId, nativeId, type, title, foundOnServer), entity);
     }
 
     public static <T> NativeEntity<T> create(ModelId entityId, String nativeId, ModelType type, String title, T entity) {
-        return create(NativeEntityDescriptor.create(entityId, nativeId, type, title), entity);
+        return create(NativeEntityDescriptor.create(entityId, nativeId, type, title, null), entity);
     }
 }

--- a/graylog2-server/src/main/java/org/graylog2/contentpacks/model/entities/NativeEntityDescriptor.java
+++ b/graylog2-server/src/main/java/org/graylog2/contentpacks/model/entities/NativeEntityDescriptor.java
@@ -16,6 +16,7 @@
  */
 package org.graylog2.contentpacks.model.entities;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.google.auto.value.AutoValue;
@@ -24,13 +25,11 @@ import org.graylog2.contentpacks.model.ModelId;
 import org.graylog2.contentpacks.model.ModelType;
 import org.graylog2.contentpacks.model.Typed;
 
-import javax.annotation.Nullable;
-
 /**
  * The unique description of a native entity by ID and type.
  */
 @AutoValue
-@JsonDeserialize(builder = AutoValue_NativeEntityDescriptor.Builder.class)
+@JsonDeserialize(builder = NativeEntityDescriptor.Builder.class)
 public abstract class NativeEntityDescriptor implements Identified, Typed {
     public static final String FIELD_ENTITY_ID = "content_pack_entity_id";
     public static final String FIELD_ENTITY_FOUND_ON_SYSTEM = "found_on_system";
@@ -89,11 +88,15 @@ public abstract class NativeEntityDescriptor implements Identified, Typed {
     }
 
     public static Builder builder() {
-        return new AutoValue_NativeEntityDescriptor.Builder();
+        return NativeEntityDescriptor.Builder.create();
     }
 
     @AutoValue.Builder
     public abstract static class Builder implements IdBuilder<Builder>, TypeBuilder<Builder> {
+        @JsonCreator
+        public static Builder create() {
+            return new AutoValue_NativeEntityDescriptor.Builder().foundOnSystem(false);
+        }
 
         @JsonProperty(FIELD_ENTITY_ID)
         abstract Builder contentPackEntityId(ModelId contentPackEntityId);

--- a/graylog2-server/src/main/java/org/graylog2/contentpacks/model/entities/NativeEntityDescriptor.java
+++ b/graylog2-server/src/main/java/org/graylog2/contentpacks/model/entities/NativeEntityDescriptor.java
@@ -43,7 +43,6 @@ public abstract class NativeEntityDescriptor implements Identified, Typed {
     public abstract String title();
 
     @JsonProperty(FIELD_ENTITY_FOUND_ON_SYSTEM)
-    @Nullable
     public abstract Boolean foundOnSystem();
 
     public abstract Builder toBuilder();

--- a/graylog2-server/src/main/java/org/graylog2/contentpacks/model/entities/NativeEntityDescriptor.java
+++ b/graylog2-server/src/main/java/org/graylog2/contentpacks/model/entities/NativeEntityDescriptor.java
@@ -24,6 +24,8 @@ import org.graylog2.contentpacks.model.ModelId;
 import org.graylog2.contentpacks.model.ModelType;
 import org.graylog2.contentpacks.model.Typed;
 
+import javax.annotation.Nullable;
+
 /**
  * The unique description of a native entity by ID and type.
  */
@@ -31,6 +33,7 @@ import org.graylog2.contentpacks.model.Typed;
 @JsonDeserialize(builder = AutoValue_NativeEntityDescriptor.Builder.class)
 public abstract class NativeEntityDescriptor implements Identified, Typed {
     public static final String FIELD_ENTITY_ID = "content_pack_entity_id";
+    public static final String FIELD_ENTITY_FOUND_ON_SYSTEM = "found_on_system";
     public static final String FIELD_ENTITY_TITLE = "title";
 
     @JsonProperty(FIELD_ENTITY_ID)
@@ -38,6 +41,12 @@ public abstract class NativeEntityDescriptor implements Identified, Typed {
 
     @JsonProperty(FIELD_ENTITY_TITLE)
     public abstract String title();
+
+    @JsonProperty(FIELD_ENTITY_FOUND_ON_SYSTEM)
+    @Nullable
+    public abstract Boolean foundOnSystem();
+
+    public abstract Builder toBuilder();
 
     public static NativeEntityDescriptor create(ModelId contentPackEntityId, ModelId id, ModelType type, String title) {
         return builder()
@@ -48,15 +57,36 @@ public abstract class NativeEntityDescriptor implements Identified, Typed {
                 .build();
     }
 
+    public static NativeEntityDescriptor create(ModelId contentPackEntityId, ModelId id, ModelType type, String title,
+                                                Boolean foundOnServer) {
+        return builder()
+                .contentPackEntityId(contentPackEntityId)
+                .id(id)
+                .title(title)
+                .type(type)
+                .foundOnSystem(foundOnServer)
+                .build();
+    }
+
     /**
-     * Shortcut for {@link #create(String, String, ModelType, String)}
+     * Shortcut for {@link #create(String, String, ModelType, String, Boolean)}
      */
+    public static NativeEntityDescriptor create(String contentPackEntityId, String nativeId, ModelType type, String title,
+                                                Boolean foundOnServer) {
+        return create(ModelId.of(contentPackEntityId), ModelId.of(nativeId), type, title, foundOnServer);
+    }
+
     public static NativeEntityDescriptor create(String contentPackEntityId, String nativeId, ModelType type, String title) {
-        return create(ModelId.of(contentPackEntityId), ModelId.of(nativeId), type, title);
+        return create(ModelId.of(contentPackEntityId), ModelId.of(nativeId), type, title, false);
+    }
+
+    public static NativeEntityDescriptor create(ModelId contentPackEntityId, String nativeId, ModelType type, String title,
+                                                Boolean foundOnServer) {
+        return create(contentPackEntityId, ModelId.of(nativeId), type, title, foundOnServer);
     }
 
     public static NativeEntityDescriptor create(ModelId contentPackEntityId, String nativeId, ModelType type, String title) {
-        return create(contentPackEntityId, ModelId.of(nativeId), type, title);
+        return create(contentPackEntityId, ModelId.of(nativeId), type, title, false);
     }
 
     public static Builder builder() {
@@ -71,6 +101,9 @@ public abstract class NativeEntityDescriptor implements Identified, Typed {
 
         @JsonProperty(FIELD_ENTITY_TITLE)
         abstract Builder title(String title);
+
+        @JsonProperty(FIELD_ENTITY_FOUND_ON_SYSTEM)
+        public abstract Builder foundOnSystem(Boolean foundOnServer);
 
         public abstract NativeEntityDescriptor build();
     }

--- a/graylog2-server/src/main/java/org/graylog2/contentpacks/model/entities/NativeEntityDescriptor.java
+++ b/graylog2-server/src/main/java/org/graylog2/contentpacks/model/entities/NativeEntityDescriptor.java
@@ -43,7 +43,7 @@ public abstract class NativeEntityDescriptor implements Identified, Typed {
     public abstract String title();
 
     @JsonProperty(FIELD_ENTITY_FOUND_ON_SYSTEM)
-    public abstract Boolean foundOnSystem();
+    public abstract boolean foundOnSystem();
 
     public abstract Builder toBuilder();
 
@@ -57,22 +57,22 @@ public abstract class NativeEntityDescriptor implements Identified, Typed {
     }
 
     public static NativeEntityDescriptor create(ModelId contentPackEntityId, ModelId id, ModelType type, String title,
-                                                Boolean foundOnServer) {
+                                                boolean foundOnSystem) {
         return builder()
                 .contentPackEntityId(contentPackEntityId)
                 .id(id)
                 .title(title)
                 .type(type)
-                .foundOnSystem(foundOnServer)
+                .foundOnSystem(foundOnSystem)
                 .build();
     }
 
     /**
-     * Shortcut for {@link #create(String, String, ModelType, String, Boolean)}
+     * Shortcut for {@link #create(String, String, ModelType, String, boolean)}
      */
     public static NativeEntityDescriptor create(String contentPackEntityId, String nativeId, ModelType type, String title,
-                                                Boolean foundOnServer) {
-        return create(ModelId.of(contentPackEntityId), ModelId.of(nativeId), type, title, foundOnServer);
+                                                boolean foundOnSystem) {
+        return create(ModelId.of(contentPackEntityId), ModelId.of(nativeId), type, title, foundOnSystem);
     }
 
     public static NativeEntityDescriptor create(String contentPackEntityId, String nativeId, ModelType type, String title) {
@@ -80,8 +80,8 @@ public abstract class NativeEntityDescriptor implements Identified, Typed {
     }
 
     public static NativeEntityDescriptor create(ModelId contentPackEntityId, String nativeId, ModelType type, String title,
-                                                Boolean foundOnServer) {
-        return create(contentPackEntityId, ModelId.of(nativeId), type, title, foundOnServer);
+                                                boolean foundOnSystem) {
+        return create(contentPackEntityId, ModelId.of(nativeId), type, title, foundOnSystem);
     }
 
     public static NativeEntityDescriptor create(ModelId contentPackEntityId, String nativeId, ModelType type, String title) {
@@ -102,7 +102,7 @@ public abstract class NativeEntityDescriptor implements Identified, Typed {
         abstract Builder title(String title);
 
         @JsonProperty(FIELD_ENTITY_FOUND_ON_SYSTEM)
-        public abstract Builder foundOnSystem(Boolean foundOnServer);
+        public abstract Builder foundOnSystem(boolean foundOnSystem);
 
         public abstract NativeEntityDescriptor build();
     }

--- a/graylog2-server/src/test/java/org/graylog2/contentpacks/ContentPackInstallationPersistenceServiceTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/contentpacks/ContentPackInstallationPersistenceServiceTest.java
@@ -170,13 +170,13 @@ public class ContentPackInstallationPersistenceServiceTest {
     @Test
     @UsingDataSet(loadStrategy = LoadStrategyEnum.CLEAN_INSERT)
     public void countInstallationOfEntityById() {
-        final long countedInstallations1 = persistenceService.countInstallationOfEntityById(ModelId.of("5b1a49eb3d274631fe07c86a"));
+        final long countedInstallations1 = persistenceService.countInstallationOfEntityById(ModelId.of("5b4c920b4b900a0024af2b5d"));
         assertThat(countedInstallations1).isEqualTo(2);
 
         final long countedInstallations2 = persistenceService.countInstallationOfEntityById(ModelId.of("non-exsistant"));
         assertThat(countedInstallations2).isEqualTo(0);
 
-        final long countedInstallations3 = persistenceService.countInstallationOfEntityById(ModelId.of("5b1a49eb3d274631fe07befa"));
+        final long countedInstallations3 = persistenceService.countInstallationOfEntityById(ModelId.of("5b4c920b4b900abeefaf2b5c"));
         assertThat(countedInstallations3).isEqualTo(1);
     }
 }

--- a/graylog2-server/src/test/java/org/graylog2/contentpacks/ContentPackServiceTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/contentpacks/ContentPackServiceTest.java
@@ -228,7 +228,7 @@ public class ContentPackServiceTest {
         assertThat(resultSuccess).isEqualTo(expectSuccess);
 
        /* Test skipped uninstall */
-        when(contentPackInstallService.countInstallationOfEntityById(ModelId.of("12345"))).thenReturn((long) 2);
+        when(contentPackInstallService.countInstallationOfEntityById(ModelId.of("dead-beef1"))).thenReturn((long) 2);
         ContentPackUninstallation expectSkip = ContentPackUninstallation.builder()
                 .skippedEntities(nativeEntityDescriptors)
                 .failedEntities(ImmutableSet.of())
@@ -237,8 +237,20 @@ public class ContentPackServiceTest {
         ContentPackUninstallation resultSkip = contentPackService.uninstallContentPack(contentPack, contentPackInstallation);
         assertThat(resultSkip).isEqualTo(expectSkip);
 
+        /* Test skipped uninstall */
+        when(contentPackInstallService.countInstallationOfEntityById(ModelId.of("dead-beef1"))).thenReturn((long) 1);
+        when(contentPackInstallService.countInstallationOfEntityByIdAndFoundOnSystem(ModelId.of("dead-beef1"))).thenReturn((long) 1);
+        ContentPackUninstallation expectSkip2 = ContentPackUninstallation.builder()
+                .skippedEntities(nativeEntityDescriptors)
+                .failedEntities(ImmutableSet.of())
+                .entities(ImmutableSet.of())
+                .build();
+        ContentPackUninstallation resultSkip2 = contentPackService.uninstallContentPack(contentPack, contentPackInstallation);
+        assertThat(resultSkip2).isEqualTo(expectSkip2);
+
         /* Test not found while uninstall */
-        when(contentPackInstallService.countInstallationOfEntityById(ModelId.of("12345"))).thenReturn((long) 1);
+        when(contentPackInstallService.countInstallationOfEntityById(ModelId.of("dead-beef1"))).thenReturn((long) 1);
+        when(contentPackInstallService.countInstallationOfEntityByIdAndFoundOnSystem(ModelId.of("dead-beef1"))).thenReturn((long) 0);
         when(patternService.load("dead-beef1")).thenThrow(new NotFoundException("Not found."));
         ContentPackUninstallation expectFailure = ContentPackUninstallation.builder()
                 .skippedEntities(ImmutableSet.of())
@@ -253,13 +265,13 @@ public class ContentPackServiceTest {
     @Test
     public void getUninstallDetails() throws NotFoundException {
         /* Test will be uninstalled */
-        when(contentPackInstallService.countInstallationOfEntityById(ModelId.of("12345"))).thenReturn((long) 1);
+        when(contentPackInstallService.countInstallationOfEntityById(ModelId.of("dead-beef1"))).thenReturn((long) 1);
         ContentPackUninstallDetails expect = ContentPackUninstallDetails.create(nativeEntityDescriptors);
         ContentPackUninstallDetails result = contentPackService.getUninstallDetails(contentPack, contentPackInstallation);
         assertThat(result).isEqualTo(expect);
 
         /* Test nothing will be uninstalled */
-        when(contentPackInstallService.countInstallationOfEntityById(ModelId.of("12345"))).thenReturn((long) 2);
+        when(contentPackInstallService.countInstallationOfEntityById(ModelId.of("dead-beef1"))).thenReturn((long) 2);
         ContentPackUninstallDetails expectNon = ContentPackUninstallDetails.create(ImmutableSet.of());
         ContentPackUninstallDetails resultNon = contentPackService.getUninstallDetails(contentPack, contentPackInstallation);
         assertThat(resultNon).isEqualTo(expectNon);

--- a/graylog2-server/src/test/java/org/graylog2/contentpacks/facades/DashboardFacadeTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/contentpacks/facades/DashboardFacadeTest.java
@@ -358,7 +358,7 @@ public class DashboardFacadeTest {
         assertThat(dashboard.getWidgets().size()).isEqualTo(1);
         assertThat(dashboard.getWidgets()).containsKeys("12345");
 
-        final NativeEntityDescriptor expectedDescriptor = NativeEntityDescriptor.create(dashboardEntity.id(), savedDashboard.getId(), ModelTypes.DASHBOARD_V1, savedDashboard.getTitle(), null);
+        final NativeEntityDescriptor expectedDescriptor = NativeEntityDescriptor.create(dashboardEntity.id(), savedDashboard.getId(), ModelTypes.DASHBOARD_V1, savedDashboard.getTitle(), false);
         assertThat(nativeEntity.descriptor()).isEqualTo(expectedDescriptor);
     }
 }

--- a/graylog2-server/src/test/java/org/graylog2/contentpacks/facades/DashboardFacadeTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/contentpacks/facades/DashboardFacadeTest.java
@@ -358,7 +358,7 @@ public class DashboardFacadeTest {
         assertThat(dashboard.getWidgets().size()).isEqualTo(1);
         assertThat(dashboard.getWidgets()).containsKeys("12345");
 
-        final NativeEntityDescriptor expectedDescriptor = NativeEntityDescriptor.create(dashboardEntity.id(), savedDashboard.getId(), ModelTypes.DASHBOARD_V1, savedDashboard.getTitle());
+        final NativeEntityDescriptor expectedDescriptor = NativeEntityDescriptor.create(dashboardEntity.id(), savedDashboard.getId(), ModelTypes.DASHBOARD_V1, savedDashboard.getTitle(), null);
         assertThat(nativeEntity.descriptor()).isEqualTo(expectedDescriptor);
     }
 }

--- a/graylog2-server/src/test/java/org/graylog2/contentpacks/facades/GrokPatternFacadeTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/contentpacks/facades/GrokPatternFacadeTest.java
@@ -163,7 +163,7 @@ public class GrokPatternFacadeTest {
                 .data(objectMapper.convertValue(GrokPatternEntity.create("Test","[a-z]+"), JsonNode.class))
                 .build();
         final Optional<NativeEntity<GrokPattern>> existingGrokPattern = facade.findExisting(grokPatternEntity, Collections.emptyMap());
-        final NativeEntityDescriptor expectedDescriptor = NativeEntityDescriptor.create(grokPatternEntity.id(), "1", ModelTypes.GROK_PATTERN_V1, grokPattern.name(), null);
+        final NativeEntityDescriptor expectedDescriptor = NativeEntityDescriptor.create(grokPatternEntity.id(), "1", ModelTypes.GROK_PATTERN_V1, grokPattern.name(), false);
         assertThat(existingGrokPattern)
                 .isPresent()
                 .get()

--- a/graylog2-server/src/test/java/org/graylog2/contentpacks/facades/GrokPatternFacadeTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/contentpacks/facades/GrokPatternFacadeTest.java
@@ -163,7 +163,7 @@ public class GrokPatternFacadeTest {
                 .data(objectMapper.convertValue(GrokPatternEntity.create("Test","[a-z]+"), JsonNode.class))
                 .build();
         final Optional<NativeEntity<GrokPattern>> existingGrokPattern = facade.findExisting(grokPatternEntity, Collections.emptyMap());
-        final NativeEntityDescriptor expectedDescriptor = NativeEntityDescriptor.create(grokPatternEntity.id(), "1", ModelTypes.GROK_PATTERN_V1, grokPattern.name());
+        final NativeEntityDescriptor expectedDescriptor = NativeEntityDescriptor.create(grokPatternEntity.id(), "1", ModelTypes.GROK_PATTERN_V1, grokPattern.name(), null);
         assertThat(existingGrokPattern)
                 .isPresent()
                 .get()

--- a/graylog2-server/src/test/java/org/graylog2/contentpacks/facades/LookupCacheFacadeTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/contentpacks/facades/LookupCacheFacadeTest.java
@@ -147,7 +147,7 @@ public class LookupCacheFacadeTest {
         final NativeEntityDescriptor descriptor = nativeEntity.descriptor();
         final CacheDto cacheDto = nativeEntity.entity();
 
-        assertThat(descriptor.id()).isEqualTo(ModelId.of("no-op-cache"));
+        assertThat(nativeEntity.descriptor().id()).isNotNull();
         assertThat(descriptor.type()).isEqualTo(ModelTypes.LOOKUP_CACHE_V1);
         assertThat(cacheDto.name()).isEqualTo("no-op-cache");
         assertThat(cacheDto.title()).isEqualTo("No-op cache");

--- a/graylog2-server/src/test/java/org/graylog2/contentpacks/facades/LookupDataAdapterFacadeTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/contentpacks/facades/LookupDataAdapterFacadeTest.java
@@ -142,7 +142,7 @@ public class LookupDataAdapterFacadeTest {
 
         final NativeEntity<DataAdapterDto> nativeEntity = facade.createNativeEntity(entity, Collections.emptyMap(), Collections.emptyMap(), "username");
 
-        assertThat(nativeEntity.descriptor().id()).isEqualTo(ModelId.of("http-dsv"));
+        assertThat(nativeEntity.descriptor().id()).isNotNull();
         assertThat(nativeEntity.descriptor().type()).isEqualTo(ModelTypes.LOOKUP_ADAPTER_V1);
         assertThat(nativeEntity.entity().name()).isEqualTo("http-dsv");
         assertThat(nativeEntity.entity().title()).isEqualTo("HTTP DSV");

--- a/graylog2-server/src/test/java/org/graylog2/contentpacks/facades/SidecarCollectorFacadeTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/contentpacks/facades/SidecarCollectorFacadeTest.java
@@ -139,7 +139,7 @@ public class SidecarCollectorFacadeTest {
         final Collector collector = collectorService.findByName("filebeat");
         assertThat(collector).isNotNull();
 
-        final NativeEntityDescriptor expectedDescriptor = NativeEntityDescriptor.create(entity.id(), collector.id(), ModelTypes.SIDECAR_COLLECTOR_V1, collector.name(), null);
+        final NativeEntityDescriptor expectedDescriptor = NativeEntityDescriptor.create(entity.id(), collector.id(), ModelTypes.SIDECAR_COLLECTOR_V1, collector.name(), false);
         assertThat(nativeEntity.descriptor()).isEqualTo(expectedDescriptor);
         assertThat(nativeEntity.entity()).isEqualTo(collector);
     }
@@ -166,7 +166,7 @@ public class SidecarCollectorFacadeTest {
         final Collector collector = collectorService.findByName("filebeat");
         assertThat(collector).isNotNull();
 
-        final NativeEntityDescriptor expectedDescriptor = NativeEntityDescriptor.create(entity.id(), collector.id(), ModelTypes.SIDECAR_COLLECTOR_V1, collector.name(), null);
+        final NativeEntityDescriptor expectedDescriptor = NativeEntityDescriptor.create(entity.id(), collector.id(), ModelTypes.SIDECAR_COLLECTOR_V1, collector.name(), false);
         assertThat(existingCollector.descriptor()).isEqualTo(expectedDescriptor);
         assertThat(existingCollector.entity()).isEqualTo(collector);
     }

--- a/graylog2-server/src/test/java/org/graylog2/contentpacks/facades/SidecarCollectorFacadeTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/contentpacks/facades/SidecarCollectorFacadeTest.java
@@ -139,7 +139,7 @@ public class SidecarCollectorFacadeTest {
         final Collector collector = collectorService.findByName("filebeat");
         assertThat(collector).isNotNull();
 
-        final NativeEntityDescriptor expectedDescriptor = NativeEntityDescriptor.create(entity.id(), collector.id(), ModelTypes.SIDECAR_COLLECTOR_V1, collector.name());
+        final NativeEntityDescriptor expectedDescriptor = NativeEntityDescriptor.create(entity.id(), collector.id(), ModelTypes.SIDECAR_COLLECTOR_V1, collector.name(), null);
         assertThat(nativeEntity.descriptor()).isEqualTo(expectedDescriptor);
         assertThat(nativeEntity.entity()).isEqualTo(collector);
     }
@@ -166,7 +166,7 @@ public class SidecarCollectorFacadeTest {
         final Collector collector = collectorService.findByName("filebeat");
         assertThat(collector).isNotNull();
 
-        final NativeEntityDescriptor expectedDescriptor = NativeEntityDescriptor.create(entity.id(), collector.id(), ModelTypes.SIDECAR_COLLECTOR_V1, collector.name());
+        final NativeEntityDescriptor expectedDescriptor = NativeEntityDescriptor.create(entity.id(), collector.id(), ModelTypes.SIDECAR_COLLECTOR_V1, collector.name(), null);
         assertThat(existingCollector.descriptor()).isEqualTo(expectedDescriptor);
         assertThat(existingCollector.entity()).isEqualTo(collector);
     }

--- a/graylog2-server/src/test/resources/org/graylog2/contentpacks/ContentPackInstallationPersistenceServiceTest.json
+++ b/graylog2-server/src/test/resources/org/graylog2/contentpacks/ContentPackInstallationPersistenceServiceTest.json
@@ -24,6 +24,7 @@
             "version": "1"
           },
           "title": "A Collector",
+          "found_on_system": false,
           "content_pack_entity_id": "5b1a49eb3d274631fe07c86a"
         },
         {
@@ -33,6 +34,7 @@
             "version": "1"
           },
           "title": "Another Collector",
+          "found_on_system": false,
           "content_pack_entity_id": "5b1a49eb3d274631fe07beff"
         },
         {
@@ -42,6 +44,7 @@
             "version": "1"
           },
           "title": "And another Collector",
+          "found_on_system": false,
           "content_pack_entity_id": "5b1a49eb3d274631fe07abfe"
         }
       ],
@@ -69,6 +72,7 @@
             "version": "1"
           },
           "title": "A dashboard",
+          "found_on_system": false,
           "content_pack_entity_id": "beef49eb3d274631fe07abfe"
         },
         {
@@ -78,6 +82,7 @@
             "version": "1"
           },
           "title": "A grok pattern",
+          "found_on_system": false,
           "content_pack_entity_id": "bee149eb3d274631fe07abfe"
         },
         {
@@ -87,6 +92,7 @@
             "version": "1"
           },
           "title": "An input",
+          "found_on_system": false,
           "content_pack_entity_id": "bee249eb3d274631fe07abfe"
         },
         {
@@ -96,6 +102,7 @@
             "version": "1"
           },
           "title": "An output",
+          "found_on_system": false,
           "content_pack_entity_id": "bee349eb3d274631fe07abfe"
         },
         {
@@ -105,6 +112,7 @@
             "version": "1"
           },
           "title": "A stream",
+          "found_on_system": false,
           "content_pack_entity_id": "bee449eb3d274631fe07abfe"
         }
       ],
@@ -132,6 +140,7 @@
             "version": "1"
           },
           "title": "A pipeline rule",
+          "found_on_system": false,
           "content_pack_entity_id": "bee549eb3d274631fe07abfe"
         },
         {
@@ -141,6 +150,7 @@
             "version": "1"
           },
           "title": "A pipeline",
+          "found_on_system": false,
           "content_pack_entity_id": "bee649eb3d274631fe07abfe"
         },
         {
@@ -150,6 +160,7 @@
             "version": "1"
           },
           "title": "A lookup adapter",
+          "found_on_system": false,
           "content_pack_entity_id": "bee749eb3d274631fe07abfe"
         },
         {
@@ -159,6 +170,7 @@
             "version": "1"
           },
           "title": "A lookup cache",
+          "found_on_system": false,
           "content_pack_entity_id": "bee849eb3d274631fe07abfe"
         },
         {
@@ -168,6 +180,7 @@
             "version": "1"
           },
           "title": "A lookup table",
+          "found_on_system": false,
           "content_pack_entity_id": "bee949eb3d274631fe07abfe"
         }
       ],
@@ -199,6 +212,7 @@
             "version": "1"
           },
           "title": "A Collector",
+          "found_on_system": false,
           "content_pack_entity_id": "5b1a49eb3d274631fe07c86a"
         },
         {
@@ -208,6 +222,7 @@
             "version": "1"
           },
           "title": "Another Collector",
+          "found_on_system": false,
           "content_pack_entity_id": "5b1a49eb3d274631fe07befa"
         },
         {
@@ -217,12 +232,13 @@
             "version": "1"
           },
           "title": "And another Collector",
+          "found_on_system": false,
           "content_pack_entity_id": "5b1a49eb3d274631fe07abfe"
         }
       ],
       "comment": "comment1",
       "created_at": "2018-07-16T12:00:00.000Z",
       "created_by": "admin"
-    },
+    }
   ]
 }


### PR DESCRIPTION
## Description
This PR will protect used content pack entities from removal through uninstall if they are either
still in use bye a other content pack installation, or were on the system before installing a content
pack.

## Motivation and Context
If a content pack would delete all its entities, other installations would stop working, since we 
can't install the same grok pattern twice.

## How Has This Been Tested?
1. Create a grok pattern (as it exists in the default grok pattern)
2. installed default pattern
3. install a content pack using a pattern from the default content pack
4. uninstall the last content pack
5. check that grok pattern is still there
6. Uninstall default grok patterns
7 check that grok pattern is still there 

Fixes: #5399 

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
