### PR TITLE
Change order of drop down menues

### DIFF
--- a/graylog2-web-interface/src/components/content-packs/ContentPackVersions.jsx
+++ b/graylog2-web-interface/src/components/content-packs/ContentPackVersions.jsx
@@ -105,10 +105,10 @@ class ContentPackVersions extends React.Component {
           <ButtonToolbar className="pull-right">
             <Button bsStyle="success" bsSize="small" onClick={() => { downloadRef.open(); }}>Download</Button>
             <DropdownButton id={`action-${pack.rev}`} bsStyle="info" title="Actions" bsSize="small">
+              <MenuItem onClick={openFunc}>Install</MenuItem>
               <LinkContainer to={Routes.SYSTEM.CONTENTPACKS.edit(encodeURIComponent(pack.id), encodeURIComponent(pack.rev))}>
                 <MenuItem >Create New From Revision</MenuItem>
               </LinkContainer>
-              <MenuItem onClick={openFunc}>Install</MenuItem>
               <MenuItem divider />
               <MenuItem onClick={() => { this.props.onDeletePack(pack.id, pack.rev); }}>Delete</MenuItem>
               {installModal}

--- a/graylog2-web-interface/src/components/content-packs/ContentPacksList.jsx
+++ b/graylog2-web-interface/src/components/content-packs/ContentPacksList.jsx
@@ -121,11 +121,15 @@ class ContentPacksList extends React.Component {
               {installModal}
               &nbsp;
               <DropdownButton id={`more-actions-${item.id}`} title="More Actions" bsSize="small" pullRight>
-                <MenuItem onSelect={() => { this.props.onDeletePack(item.id); }}>Delete All Versions</MenuItem>
+                <LinkContainer to={Routes.SYSTEM.CONTENTPACKS.show(item.id)}>
+                  <MenuItem>Show</MenuItem>
+                </LinkContainer>
                 <LinkContainer to={Routes.SYSTEM.CONTENTPACKS.edit(encodeURIComponent(item.id), encodeURIComponent(item.rev))}>
                   <MenuItem>Create New Version</MenuItem>
                 </LinkContainer>
                 <MenuItem onSelect={() => { downloadRef.open(); }}>Download</MenuItem>
+                <MenuItem divider />
+                <MenuItem onSelect={() => { this.props.onDeletePack(item.id); }}>Delete All Versions</MenuItem>
               </DropdownButton>
               {downloadModal}
             </Col>

--- a/graylog2-web-interface/src/components/content-packs/__snapshots__/ContentPackVersions.test.jsx.snap
+++ b/graylog2-web-interface/src/components/content-packs/__snapshots__/ContentPackVersions.test.jsx.snap
@@ -88,6 +88,20 @@ exports[`<ContentPackVersions /> should render with content pack versions 1`] = 
                         role="presentation"
                       >
                         <a
+                          href="#"
+                          onClick={[Function]}
+                          onKeyDown={[Function]}
+                          role="menuitem"
+                          tabIndex="-1"
+                        >
+                          Install
+                        </a>
+                      </li>
+                      <li
+                        className=""
+                        role="presentation"
+                      >
+                        <a
                           action="push"
                           href="#"
                           onClick={[Function]}
@@ -96,20 +110,6 @@ exports[`<ContentPackVersions /> should render with content pack versions 1`] = 
                           tabIndex="-1"
                         >
                           Create New From Revision
-                        </a>
-                      </li>
-                      <li
-                        className=""
-                        role="presentation"
-                      >
-                        <a
-                          href="#"
-                          onClick={[Function]}
-                          onKeyDown={[Function]}
-                          role="menuitem"
-                          tabIndex="-1"
-                        >
-                          Install
                         </a>
                       </li>
                       <li
@@ -193,6 +193,20 @@ exports[`<ContentPackVersions /> should render with content pack versions 1`] = 
                         role="presentation"
                       >
                         <a
+                          href="#"
+                          onClick={[Function]}
+                          onKeyDown={[Function]}
+                          role="menuitem"
+                          tabIndex="-1"
+                        >
+                          Install
+                        </a>
+                      </li>
+                      <li
+                        className=""
+                        role="presentation"
+                      >
+                        <a
                           action="push"
                           href="#"
                           onClick={[Function]}
@@ -201,20 +215,6 @@ exports[`<ContentPackVersions /> should render with content pack versions 1`] = 
                           tabIndex="-1"
                         >
                           Create New From Revision
-                        </a>
-                      </li>
-                      <li
-                        className=""
-                        role="presentation"
-                      >
-                        <a
-                          href="#"
-                          onClick={[Function]}
-                          onKeyDown={[Function]}
-                          role="menuitem"
-                          tabIndex="-1"
-                        >
-                          Install
                         </a>
                       </li>
                       <li
@@ -298,6 +298,20 @@ exports[`<ContentPackVersions /> should render with content pack versions 1`] = 
                         role="presentation"
                       >
                         <a
+                          href="#"
+                          onClick={[Function]}
+                          onKeyDown={[Function]}
+                          role="menuitem"
+                          tabIndex="-1"
+                        >
+                          Install
+                        </a>
+                      </li>
+                      <li
+                        className=""
+                        role="presentation"
+                      >
+                        <a
                           action="push"
                           href="#"
                           onClick={[Function]}
@@ -306,20 +320,6 @@ exports[`<ContentPackVersions /> should render with content pack versions 1`] = 
                           tabIndex="-1"
                         >
                           Create New From Revision
-                        </a>
-                      </li>
-                      <li
-                        className=""
-                        role="presentation"
-                      >
-                        <a
-                          href="#"
-                          onClick={[Function]}
-                          onKeyDown={[Function]}
-                          role="menuitem"
-                          tabIndex="-1"
-                        >
-                          Install
                         </a>
                       </li>
                       <li
@@ -403,6 +403,20 @@ exports[`<ContentPackVersions /> should render with content pack versions 1`] = 
                         role="presentation"
                       >
                         <a
+                          href="#"
+                          onClick={[Function]}
+                          onKeyDown={[Function]}
+                          role="menuitem"
+                          tabIndex="-1"
+                        >
+                          Install
+                        </a>
+                      </li>
+                      <li
+                        className=""
+                        role="presentation"
+                      >
+                        <a
                           action="push"
                           href="#"
                           onClick={[Function]}
@@ -411,20 +425,6 @@ exports[`<ContentPackVersions /> should render with content pack versions 1`] = 
                           tabIndex="-1"
                         >
                           Create New From Revision
-                        </a>
-                      </li>
-                      <li
-                        className=""
-                        role="presentation"
-                      >
-                        <a
-                          href="#"
-                          onClick={[Function]}
-                          onKeyDown={[Function]}
-                          role="menuitem"
-                          tabIndex="-1"
-                        >
-                          Install
                         </a>
                       </li>
                       <li

--- a/graylog2-web-interface/src/components/content-packs/__snapshots__/ContentPacksList.test.jsx.snap
+++ b/graylog2-web-interface/src/components/content-packs/__snapshots__/ContentPacksList.test.jsx.snap
@@ -298,13 +298,14 @@ exports[`<ContentPacksList /> should render with content packs 1`] = `
                   role="presentation"
                 >
                   <a
+                    action="push"
                     href="#"
                     onClick={[Function]}
                     onKeyDown={[Function]}
                     role="menuitem"
                     tabIndex="-1"
                   >
-                    Delete All Versions
+                    Show
                   </a>
                 </li>
                 <li
@@ -334,6 +335,25 @@ exports[`<ContentPacksList /> should render with content packs 1`] = `
                     tabIndex="-1"
                   >
                     Download
+                  </a>
+                </li>
+                <li
+                  className="divider"
+                  onKeyDown={[Function]}
+                  role="separator"
+                />
+                <li
+                  className=""
+                  role="presentation"
+                >
+                  <a
+                    href="#"
+                    onClick={[Function]}
+                    onKeyDown={[Function]}
+                    role="menuitem"
+                    tabIndex="-1"
+                  >
+                    Delete All Versions
                   </a>
                 </li>
               </ul>
@@ -430,13 +450,14 @@ exports[`<ContentPacksList /> should render with content packs 1`] = `
                   role="presentation"
                 >
                   <a
+                    action="push"
                     href="#"
                     onClick={[Function]}
                     onKeyDown={[Function]}
                     role="menuitem"
                     tabIndex="-1"
                   >
-                    Delete All Versions
+                    Show
                   </a>
                 </li>
                 <li
@@ -466,6 +487,25 @@ exports[`<ContentPacksList /> should render with content packs 1`] = `
                     tabIndex="-1"
                   >
                     Download
+                  </a>
+                </li>
+                <li
+                  className="divider"
+                  onKeyDown={[Function]}
+                  role="separator"
+                />
+                <li
+                  className=""
+                  role="presentation"
+                >
+                  <a
+                    href="#"
+                    onClick={[Function]}
+                    onKeyDown={[Function]}
+                    role="menuitem"
+                    tabIndex="-1"
+                  >
+                    Delete All Versions
                   </a>
                 </li>
               </ul>
@@ -551,13 +591,14 @@ exports[`<ContentPacksList /> should render with content packs 1`] = `
                   role="presentation"
                 >
                   <a
+                    action="push"
                     href="#"
                     onClick={[Function]}
                     onKeyDown={[Function]}
                     role="menuitem"
                     tabIndex="-1"
                   >
-                    Delete All Versions
+                    Show
                   </a>
                 </li>
                 <li
@@ -587,6 +628,25 @@ exports[`<ContentPacksList /> should render with content packs 1`] = `
                     tabIndex="-1"
                   >
                     Download
+                  </a>
+                </li>
+                <li
+                  className="divider"
+                  onKeyDown={[Function]}
+                  role="separator"
+                />
+                <li
+                  className=""
+                  role="presentation"
+                >
+                  <a
+                    href="#"
+                    onClick={[Function]}
+                    onKeyDown={[Function]}
+                    role="menuitem"
+                    tabIndex="-1"
+                  >
+                    Delete All Versions
                   </a>
                 </li>
               </ul>
@@ -672,13 +732,14 @@ exports[`<ContentPacksList /> should render with content packs 1`] = `
                   role="presentation"
                 >
                   <a
+                    action="push"
                     href="#"
                     onClick={[Function]}
                     onKeyDown={[Function]}
                     role="menuitem"
                     tabIndex="-1"
                   >
-                    Delete All Versions
+                    Show
                   </a>
                 </li>
                 <li
@@ -708,6 +769,25 @@ exports[`<ContentPacksList /> should render with content packs 1`] = `
                     tabIndex="-1"
                   >
                     Download
+                  </a>
+                </li>
+                <li
+                  className="divider"
+                  onKeyDown={[Function]}
+                  role="separator"
+                />
+                <li
+                  className=""
+                  role="presentation"
+                >
+                  <a
+                    href="#"
+                    onClick={[Function]}
+                    onKeyDown={[Function]}
+                    role="menuitem"
+                    tabIndex="-1"
+                  >
+                    Delete All Versions
                   </a>
                 </li>
               </ul>
@@ -793,13 +873,14 @@ exports[`<ContentPacksList /> should render with content packs 1`] = `
                   role="presentation"
                 >
                   <a
+                    action="push"
                     href="#"
                     onClick={[Function]}
                     onKeyDown={[Function]}
                     role="menuitem"
                     tabIndex="-1"
                   >
-                    Delete All Versions
+                    Show
                   </a>
                 </li>
                 <li
@@ -829,6 +910,25 @@ exports[`<ContentPacksList /> should render with content packs 1`] = `
                     tabIndex="-1"
                   >
                     Download
+                  </a>
+                </li>
+                <li
+                  className="divider"
+                  onKeyDown={[Function]}
+                  role="separator"
+                />
+                <li
+                  className=""
+                  role="presentation"
+                >
+                  <a
+                    href="#"
+                    onClick={[Function]}
+                    onKeyDown={[Function]}
+                    role="menuitem"
+                    tabIndex="-1"
+                  >
+                    Delete All Versions
                   </a>
                 </li>
               </ul>
@@ -914,13 +1014,14 @@ exports[`<ContentPacksList /> should render with content packs 1`] = `
                   role="presentation"
                 >
                   <a
+                    action="push"
                     href="#"
                     onClick={[Function]}
                     onKeyDown={[Function]}
                     role="menuitem"
                     tabIndex="-1"
                   >
-                    Delete All Versions
+                    Show
                   </a>
                 </li>
                 <li
@@ -950,6 +1051,25 @@ exports[`<ContentPacksList /> should render with content packs 1`] = `
                     tabIndex="-1"
                   >
                     Download
+                  </a>
+                </li>
+                <li
+                  className="divider"
+                  onKeyDown={[Function]}
+                  role="separator"
+                />
+                <li
+                  className=""
+                  role="presentation"
+                >
+                  <a
+                    href="#"
+                    onClick={[Function]}
+                    onKeyDown={[Function]}
+                    role="menuitem"
+                    tabIndex="-1"
+                  >
+                    Delete All Versions
                   </a>
                 </li>
               </ul>
@@ -1035,13 +1155,14 @@ exports[`<ContentPacksList /> should render with content packs 1`] = `
                   role="presentation"
                 >
                   <a
+                    action="push"
                     href="#"
                     onClick={[Function]}
                     onKeyDown={[Function]}
                     role="menuitem"
                     tabIndex="-1"
                   >
-                    Delete All Versions
+                    Show
                   </a>
                 </li>
                 <li
@@ -1071,6 +1192,25 @@ exports[`<ContentPacksList /> should render with content packs 1`] = `
                     tabIndex="-1"
                   >
                     Download
+                  </a>
+                </li>
+                <li
+                  className="divider"
+                  onKeyDown={[Function]}
+                  role="separator"
+                />
+                <li
+                  className=""
+                  role="presentation"
+                >
+                  <a
+                    href="#"
+                    onClick={[Function]}
+                    onKeyDown={[Function]}
+                    role="menuitem"
+                    tabIndex="-1"
+                  >
+                    Delete All Versions
                   </a>
                 </li>
               </ul>
@@ -1156,13 +1296,14 @@ exports[`<ContentPacksList /> should render with content packs 1`] = `
                   role="presentation"
                 >
                   <a
+                    action="push"
                     href="#"
                     onClick={[Function]}
                     onKeyDown={[Function]}
                     role="menuitem"
                     tabIndex="-1"
                   >
-                    Delete All Versions
+                    Show
                   </a>
                 </li>
                 <li
@@ -1192,6 +1333,25 @@ exports[`<ContentPacksList /> should render with content packs 1`] = `
                     tabIndex="-1"
                   >
                     Download
+                  </a>
+                </li>
+                <li
+                  className="divider"
+                  onKeyDown={[Function]}
+                  role="separator"
+                />
+                <li
+                  className=""
+                  role="presentation"
+                >
+                  <a
+                    href="#"
+                    onClick={[Function]}
+                    onKeyDown={[Function]}
+                    role="menuitem"
+                    tabIndex="-1"
+                  >
+                    Delete All Versions
                   </a>
                 </li>
               </ul>
@@ -1277,13 +1437,14 @@ exports[`<ContentPacksList /> should render with content packs 1`] = `
                   role="presentation"
                 >
                   <a
+                    action="push"
                     href="#"
                     onClick={[Function]}
                     onKeyDown={[Function]}
                     role="menuitem"
                     tabIndex="-1"
                   >
-                    Delete All Versions
+                    Show
                   </a>
                 </li>
                 <li
@@ -1313,6 +1474,25 @@ exports[`<ContentPacksList /> should render with content packs 1`] = `
                     tabIndex="-1"
                   >
                     Download
+                  </a>
+                </li>
+                <li
+                  className="divider"
+                  onKeyDown={[Function]}
+                  role="separator"
+                />
+                <li
+                  className=""
+                  role="presentation"
+                >
+                  <a
+                    href="#"
+                    onClick={[Function]}
+                    onKeyDown={[Function]}
+                    role="menuitem"
+                    tabIndex="-1"
+                  >
+                    Delete All Versions
                   </a>
                 </li>
               </ul>
@@ -1398,13 +1578,14 @@ exports[`<ContentPacksList /> should render with content packs 1`] = `
                   role="presentation"
                 >
                   <a
+                    action="push"
                     href="#"
                     onClick={[Function]}
                     onKeyDown={[Function]}
                     role="menuitem"
                     tabIndex="-1"
                   >
-                    Delete All Versions
+                    Show
                   </a>
                 </li>
                 <li
@@ -1434,6 +1615,25 @@ exports[`<ContentPacksList /> should render with content packs 1`] = `
                     tabIndex="-1"
                   >
                     Download
+                  </a>
+                </li>
+                <li
+                  className="divider"
+                  onKeyDown={[Function]}
+                  role="separator"
+                />
+                <li
+                  className=""
+                  role="presentation"
+                >
+                  <a
+                    href="#"
+                    onClick={[Function]}
+                    onKeyDown={[Function]}
+                    role="menuitem"
+                    tabIndex="-1"
+                  >
+                    Delete All Versions
                   </a>
                 </li>
               </ul>


### PR DESCRIPTION
Prior to this change, the delete action was prior the
create new version and install after create new version.

This change will change the order of drop downs to:
- Show
- Install
- Create New Verison
- Divider
- Delete

Fixes: #5239