### PR TITLE
Use default_value of parameter for entity title

### DIFF
--- a/graylog2-web-interface/src/components/content-packs/ContentPackEdit.jsx
+++ b/graylog2-web-interface/src/components/content-packs/ContentPackEdit.jsx
@@ -68,7 +68,7 @@ class ContentPackEdit extends React.Component {
           configPaths[path].setParameter(parameters[index].paramName);
         }
       });
-      newEntityBuilder.data(entityData.getData());
+      newEntityBuilder.data(entityData.getData()).parameters(this.props.contentPack.parameters);
       return newEntityBuilder.build();
     });
     const newContentPack = this.props.contentPack.toBuilder()

--- a/graylog2-web-interface/src/components/content-packs/ContentPackEntitiesList.test.jsx
+++ b/graylog2-web-interface/src/components/content-packs/ContentPackEntitiesList.test.jsx
@@ -8,18 +8,26 @@ import ContentPackEntitiesList from 'components/content-packs/ContentPackEntitie
 import Entity from 'logic/content-packs/Entity';
 
 describe('<ContentPackEntitiesList />', () => {
+  const parameter = {
+    title: 'A parameter name',
+    name: 'TITLE',
+    description: 'A parameter descriptions',
+    type: 'string',
+    default_value: 'test',
+  };
+
   const entity1 = Entity.builder()
     .id('111-beef')
     .type({ name: 'Input', version: '1' })
     .v('1.0')
     .data({
-      name: { '@type': 'string', '@value': 'Input' },
-      title: { '@type': 'string', '@value': 'A good input' },
+      title: { '@type': 'parameter', '@value': 'TITLE' },
       configuration: {
         listen_address: { '@type': 'string', '@value': '1.2.3.4' },
         port: { '@type': 'integer', '@value': '23' },
       },
     })
+    .parameters([parameter])
     .build();
 
   const entity2 = Entity.builder()
@@ -36,14 +44,6 @@ describe('<ContentPackEntitiesList />', () => {
     })
     .fromServer(true)
     .build();
-
-  const parameter = {
-    name: 'A parameter name',
-    title: 'A parameter title',
-    description: 'A parameter descriptions',
-    type: 'string',
-    default_value: 'test',
-  };
 
   const contentPack = ContentPack.builder()
     .entities([entity1, entity2])
@@ -66,11 +66,11 @@ describe('<ContentPackEntitiesList />', () => {
 
   it('should filter entities', () => {
     const wrapper = mount(<ContentPackEntitiesList contentPack={contentPack} />);
-    expect(wrapper.find("td[children='A good input']").exists()).toBe(true);
+    expect(wrapper.find("td[children='test']").exists()).toBe(true);
     wrapper.find('input').simulate('change', { target: { value: 'Bad' } });
     wrapper.find('form').simulate('submit');
-    expect(wrapper.find("td[children='A good input']").exists()).toBe(false);
+    expect(wrapper.find("td[children='test']").exists()).toBe(false);
     wrapper.find("button[children='Reset']").simulate('click');
-    expect(wrapper.find("td[children='A good input']").exists()).toBe(true);
+    expect(wrapper.find("td[children='test']").exists()).toBe(true);
   });
 });

--- a/graylog2-web-interface/src/components/content-packs/__snapshots__/ContentPackEntitiesList.test.jsx.snap
+++ b/graylog2-web-interface/src/components/content-packs/__snapshots__/ContentPackEntitiesList.test.jsx.snap
@@ -206,7 +206,7 @@ exports[`<ContentPackEntitiesList /> should render with entities and parameters 
                 <td
                   className="bigColumns"
                 >
-                  A good input
+                  test
                 </td>
                 <td>
                   Input

--- a/graylog2-web-interface/src/logic/content-packs/ContentPack.js
+++ b/graylog2-web-interface/src/logic/content-packs/ContentPack.js
@@ -9,7 +9,7 @@ export default class ContentPack {
       if (e.constructor.name === Entity.name) {
         return e;
       }
-      return Entity.fromJSON(e, false);
+      return Entity.fromJSON(e, false, parameters);
     });
 
     this._value = {

--- a/graylog2-web-interface/src/logic/content-packs/Entity.jsx
+++ b/graylog2-web-interface/src/logic/content-packs/Entity.jsx
@@ -1,9 +1,10 @@
 import { Map } from 'immutable';
+import { findIndex } from 'lodash';
 import ValueRefHelper from 'util/ValueRefHelper';
 import Constraint from './Constraint';
 
 export default class Entity {
-  constructor(v, type, id, data, fromServer = false, constraintValues = []) {
+  constructor(v, type, id, data, fromServer = false, constraintValues = [], parameters = []) {
     const constraints = constraintValues.map((c) => {
       if (c instanceof Constraint) {
         return c;
@@ -18,12 +19,13 @@ export default class Entity {
       data,
       constraints,
       fromServer,
+      parameters,
     };
   }
 
-  static fromJSON(value, fromServer = true) {
+  static fromJSON(value, fromServer = true, parameters = []) {
     const { v, type, id, data, constraints } = value;
-    return new Entity(v, type, id, data, fromServer, constraints);
+    return new Entity(v, type, id, data, fromServer, constraints, parameters);
   }
 
   get v() {
@@ -69,7 +71,14 @@ export default class Entity {
     }
 
     if (ValueRefHelper.dataIsValueRef(data[key])) {
-      return (data[key] || {})[ValueRefHelper.VALUE_REF_VALUE_FIELD];
+      const value = (data[key] || {})[ValueRefHelper.VALUE_REF_VALUE_FIELD];
+      if (ValueRefHelper.dataValueIsParameter(data[key])) {
+        const index = findIndex(this._value.parameters, { name: value });
+        if (index >= 0 && this._value.parameters[index].default_value) {
+          return this._value.parameters[index].default_value;
+        }
+      }
+      return value;
     }
     return data[key];
   }
@@ -82,6 +91,7 @@ export default class Entity {
       data,
       constraints,
       fromServer,
+      parameters,
     } = this._value;
     /* eslint-disable-next-line no-use-before-define */
     return new Builder(Map({
@@ -91,6 +101,7 @@ export default class Entity {
       data,
       constraints,
       fromServer,
+      parameters,
     }));
   }
 
@@ -153,6 +164,11 @@ class Builder {
     return this;
   }
 
+  parameters(value) {
+    this.value = this.value.set('parameters', value);
+    return this;
+  }
+
   build() {
     const {
       v,
@@ -161,7 +177,8 @@ class Builder {
       data,
       constraints,
       fromServer,
+      parameters,
     } = this.value.toObject();
-    return new Entity(v, type, id, data, fromServer, constraints);
+    return new Entity(v, type, id, data, fromServer, constraints, parameters);
   }
 }

--- a/graylog2-web-interface/src/pages/CreateContentPackPage.jsx
+++ b/graylog2-web-interface/src/pages/CreateContentPackPage.jsx
@@ -79,9 +79,9 @@ const CreateContentPackPage = createReactClass({
     CatalogActions.getSelectedEntities(selectedEntities).then((result) => {
       const newContentPack = this.state.contentPack.toBuilder()
         /* Mark entities from server */
-        .entities(result.entities.map(e => Entity.fromJSON(e, true, this.contentPack.parameters)))
+        .entities(result.entities.map(e => Entity.fromJSON(e, true, this.state.contentPack.parameters)))
         .build();
-      const fetchedEntities = result.entities.map(e => Entity.fromJSON(e, false, this.contentPack.parameters));
+      const fetchedEntities = result.entities.map(e => Entity.fromJSON(e, false, this.state.contentPack.parameters));
       this.setState({ contentPack: newContentPack, fetchedEntities });
     });
   },

--- a/graylog2-web-interface/src/pages/CreateContentPackPage.jsx
+++ b/graylog2-web-interface/src/pages/CreateContentPackPage.jsx
@@ -79,9 +79,9 @@ const CreateContentPackPage = createReactClass({
     CatalogActions.getSelectedEntities(selectedEntities).then((result) => {
       const newContentPack = this.state.contentPack.toBuilder()
         /* Mark entities from server */
-        .entities(result.entities.map(e => Entity.fromJSON(e, true)))
+        .entities(result.entities.map(e => Entity.fromJSON(e, true, this.contentPack.parameters)))
         .build();
-      const fetchedEntities = result.entities.map(e => Entity.fromJSON(e));
+      const fetchedEntities = result.entities.map(e => Entity.fromJSON(e, false, this.contentPack.parameters));
       this.setState({ contentPack: newContentPack, fetchedEntities });
     });
   },

--- a/graylog2-web-interface/src/util/ValueRefHelper.js
+++ b/graylog2-web-interface/src/util/ValueRefHelper.js
@@ -16,6 +16,9 @@ export default class ValueRefHelper {
   }
 
   static dataValueIsParameter(data) {
+    if (!data) {
+      return false;
+    }
     if (typeof data.get === 'function') {
       return ValueRefHelper.dataIsValueRef(data) && data.get(ValueRefHelper.VALUE_REF_TYPE_FIELD) === ValueRefHelper.VALUE_REF_PARAMETER_VALUE;
     }

--- a/graylog2-web-interface/src/util/ValueRefHelper.js
+++ b/graylog2-web-interface/src/util/ValueRefHelper.js
@@ -16,7 +16,10 @@ export default class ValueRefHelper {
   }
 
   static dataValueIsParameter(data) {
-    return ValueRefHelper.dataIsValueRef(data) && data.get(ValueRefHelper.VALUE_REF_TYPE_FIELD) === ValueRefHelper.VALUE_REF_PARAMETER_VALUE;
+    if (typeof data.get === 'function') {
+      return ValueRefHelper.dataIsValueRef(data) && data.get(ValueRefHelper.VALUE_REF_TYPE_FIELD) === ValueRefHelper.VALUE_REF_PARAMETER_VALUE;
+    }
+    return ValueRefHelper.dataIsValueRef(data) && data[ValueRefHelper.VALUE_REF_TYPE_FIELD] === ValueRefHelper.VALUE_REF_PARAMETER_VALUE;
   }
 
   static createValueRef(type, value) {

--- a/graylog2-web-interface/src/util/ValueReferenceData.test.js
+++ b/graylog2-web-interface/src/util/ValueReferenceData.test.js
@@ -35,6 +35,7 @@ describe('ValueReferenceData', () => {
             '@value': true,
           },
           foo: 'bar',
+          null_value: null,
         },
         {
           hello: 'world',
@@ -97,6 +98,11 @@ describe('ValueReferenceData', () => {
     expect(paths['stream_rules.0.foo'].getPath()).toEqual('stream_rules.0.foo');
     expect(paths['stream_rules.0.foo'].isValueRef()).toEqual(false);
     expect(paths['stream_rules.0.foo'].isValueParameter()).toEqual(false);
+    expect(paths['stream_rules.0.null_value'].getValue()).toEqual(null);
+    expect(paths['stream_rules.0.null_value'].getValueType()).toEqual('object');
+    expect(paths['stream_rules.0.null_value'].getPath()).toEqual('stream_rules.0.null_value');
+    expect(paths['stream_rules.0.null_value'].isValueRef()).toEqual(false);
+    expect(paths['stream_rules.0.null_value'].isValueParameter()).toEqual(false);
     expect(paths['stream_rules.1.hello'].getValue()).toEqual('world');
     expect(paths['stream_rules.1.hello'].getValueType()).toEqual('string');
     expect(paths['stream_rules.1.hello'].getPath()).toEqual('stream_rules.1.hello');


### PR DESCRIPTION
Prior to this change, a entity with a parameter as title
did display the parameter name as a title.

This change tries to get the default value of the parameter
to display as title. If no default value is given
the fallback is still the name of the parameter.

Fixes #5332

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
