### PR TITLE
Validate series before extracting timerange / update graph data after being empty.

### DIFF
--- a/graylog2-web-interface/src/legacy/Rickshaw.Graph.Graylog2Selector.js
+++ b/graylog2-web-interface/src/legacy/Rickshaw.Graph.Graylog2Selector.js
@@ -116,15 +116,22 @@ const Graylog2Selector = Rickshaw.Class.create({
     }, false);
 
         // Stop at chart boundaries.
-    if (graph.dataDomain()[0] === position.xMin) {
-      graph.window.xMin = undefined;
-    }
-    if (graph.dataDomain()[1] === position.xMax) {
-      graph.window.xMax = undefined;
+    console.log('running', graph.series);
+    if (this._validateSeries(graph.series)) {
+      if (graph.dataDomain()[0] === position.xMin) {
+        graph.window.xMin = undefined;
+      }
+      if (graph.dataDomain()[1] === position.xMax) {
+        graph.window.xMax = undefined;
+      }
     }
 
     graph.window.xMin = position.xMin;
     graph.window.xMax = position.xMax;
+  },
+
+  _validateSeries(series) {
+    return series.map(s => s.data).find(data => !data || !data[0] || !data[0].x || !data[data.length - 1] || !data[data.length - 1].x) === undefined;
   },
 
   update() {

--- a/graylog2-web-interface/src/legacy/Rickshaw.Graph.Graylog2Selector.js
+++ b/graylog2-web-interface/src/legacy/Rickshaw.Graph.Graylog2Selector.js
@@ -116,7 +116,6 @@ const Graylog2Selector = Rickshaw.Class.create({
     }, false);
 
         // Stop at chart boundaries.
-    console.log('running', graph.series);
     if (this._validateSeries(graph.series)) {
       if (graph.dataDomain()[0] === position.xMin) {
         graph.window.xMin = undefined;

--- a/graylog2-web-interface/src/legacy/result-histogram.js
+++ b/graylog2-web-interface/src/legacy/result-histogram.js
@@ -106,13 +106,11 @@ const resultHistogram = {
   },
 
   updateData(newData) {
-    if (this._histogram.length > 0) {
-      if (typeof this._resultHistogramGraph !== 'undefined') {
-        this._histogram = newData;
-        this._resultHistogramGraph.series[0].data = newData;
-        this._resetAlertAnnotator();
-        this._resultHistogramGraph.update();
-      }
+    if (typeof this._resultHistogramGraph !== 'undefined') {
+      this._histogram = newData;
+      this._resultHistogramGraph.series[0].data = newData;
+      this._resetAlertAnnotator();
+      this._resultHistogramGraph.update();
     }
   },
 


### PR DESCRIPTION
## Description
## Motivation and Context
<!--- Describe your changes in detail -->

When a user was searching in "All messages" using a query that returned no results, immediately
followed by a query that did, extracting the timerange for the histogram resulted in an
exception. This happened because graph data was not updated before, due to an apparently
conditional update of the graph data.

This PR is now:

  - verifying that the series are present and valid before extracting the timerange
  - updating the graph data even if no series were present at the time of the update

Fixes #5548.

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Reproducing the issue described in #5548 ensuring that it does not reoccur.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.