### PR TITLE
Explicitly register Bouncy Castle as security provider

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/bootstrap/Main.java
+++ b/graylog2-server/src/main/java/org/graylog2/bootstrap/Main.java
@@ -19,9 +19,11 @@ package org.graylog2.bootstrap;
 import com.github.rvesse.airline.Cli;
 import com.github.rvesse.airline.builder.CliBuilder;
 import com.google.common.collect.ImmutableSet;
+import org.bouncycastle.jce.provider.BouncyCastleProvider;
 import org.graylog2.bootstrap.commands.CliCommandHelp;
 import org.graylog2.bootstrap.commands.ShowVersion;
 
+import java.security.Security;
 import java.util.ServiceLoader;
 
 public class Main {
@@ -41,6 +43,10 @@ public class Main {
 
         final Cli<CliCommand> cli = builder.build();
         final Runnable command = cli.parse(args);
+
+        // Explicitly register Bouncy Castle as security provider.
+        // This allows us to use more key formats than with JCE
+        Security.addProvider(new BouncyCastleProvider());
         command.run();
     }
 }


### PR DESCRIPTION
Adding the dependency was not enough, we need to register BC,
so it can be used for parsing keys that JCE does not support.

Refs #5216

