### PR TITLE
Add reporting support to quick values histogram

### DIFF
--- a/graylog2-web-interface/src/components/visualizations/QuickValuesHistogramVisualization.jsx
+++ b/graylog2-web-interface/src/components/visualizations/QuickValuesHistogramVisualization.jsx
@@ -29,6 +29,7 @@ const QuickValuesHistogramVisualization = createReactClass({
     width: PropTypes.number,
     height: PropTypes.number,
     interactive: PropTypes.bool,
+    onRenderComplete: PropTypes.func,
   },
 
   getDefaultProps() {
@@ -38,6 +39,7 @@ const QuickValuesHistogramVisualization = createReactClass({
       height: this.DEFAULT_HEIGHT,
       data: undefined,
       interactive: true,
+      onRenderComplete: () => {},
     };
   },
 
@@ -242,6 +244,8 @@ const QuickValuesHistogramVisualization = createReactClass({
       .tickFormat((value) => {
         return Math.abs(value) > 1e+30 ? value.toPrecision(1) : d3.format('.2s')(value);
       });
+
+    this._chart.on('postRender', this.props.onRenderComplete());
 
     this._chart.render();
   },

--- a/graylog2-web-interface/src/components/visualizations/QuickValuesHistogramVisualization.jsx
+++ b/graylog2-web-interface/src/components/visualizations/QuickValuesHistogramVisualization.jsx
@@ -8,7 +8,6 @@ import d3 from 'd3';
 import _ from 'lodash';
 import Immutable from 'immutable';
 import deepEqual from 'deep-equal';
-import naturalSort from 'javascript-natural-sort';
 import graphHelper from 'legacy/graphHelper';
 
 import D3Utils from 'util/D3Utils';
@@ -18,16 +17,6 @@ import D3Utils from 'util/D3Utils';
  */
 const QuickValuesHistogramVisualization = createReactClass({
   displayName: 'QuickValuesHistogramVisualization',
-
-  DEFAULT_CONFIG: {
-    limit: 5,
-    sort_order: 'desc',
-  },
-
-  DEFAULT_HEIGHT: 220,
-
-  // dc.js is modifying the margins passed into the graph so make sure this is immutable
-  CHART_MARGINS: Immutable.fromJS({ left: 50, right: 15, top: 10, bottom: 45 }),
 
   propTypes: {
     id: PropTypes.string.isRequired,
@@ -40,10 +29,6 @@ const QuickValuesHistogramVisualization = createReactClass({
     width: PropTypes.number,
     height: PropTypes.number,
   },
-
-  _chartRef: undefined,
-  _chart: undefined,
-  _crossfilter: undefined,
 
   getDefaultProps() {
     return {
@@ -88,6 +73,20 @@ const QuickValuesHistogramVisualization = createReactClass({
       this._updateData(nextProps);
     }
   },
+
+  DEFAULT_CONFIG: {
+    limit: 5,
+    sort_order: 'desc',
+  },
+
+  DEFAULT_HEIGHT: 220,
+
+  // dc.js is modifying the margins passed into the graph so make sure this is immutable
+  CHART_MARGINS: Immutable.fromJS({ left: 50, right: 15, top: 10, bottom: 45 }),
+
+  _chartRef: undefined,
+  _chart: undefined,
+  _crossfilter: undefined,
 
   _updateData({ data, config, width, height }) {
     this.setState({

--- a/graylog2-web-interface/src/components/visualizations/QuickValuesHistogramVisualization.jsx
+++ b/graylog2-web-interface/src/components/visualizations/QuickValuesHistogramVisualization.jsx
@@ -28,6 +28,7 @@ const QuickValuesHistogramVisualization = createReactClass({
     data: PropTypes.object,
     width: PropTypes.number,
     height: PropTypes.number,
+    interactive: PropTypes.bool,
   },
 
   getDefaultProps() {
@@ -36,6 +37,7 @@ const QuickValuesHistogramVisualization = createReactClass({
       width: undefined,
       height: this.DEFAULT_HEIGHT,
       data: undefined,
+      interactive: true,
     };
   },
 
@@ -55,6 +57,8 @@ const QuickValuesHistogramVisualization = createReactClass({
   },
 
   componentDidMount() {
+    this.disableTransitions = dc.disableTransitions;
+    dc.disableTransitions = !this.props.interactive;
     this._renderChart();
     // Resize the chart after rendering it to get the actual width and height of the container
     this._resizeChart(this._chartRef.clientWidth, this._chartRef.clientHeight);
@@ -72,6 +76,10 @@ const QuickValuesHistogramVisualization = createReactClass({
     if (nextProps.data) {
       this._updateData(nextProps);
     }
+  },
+
+  componentWillUnmount() {
+    dc.disableTransitions = this.disableTransitions;
   },
 
   DEFAULT_CONFIG: {
@@ -214,8 +222,6 @@ const QuickValuesHistogramVisualization = createReactClass({
       .xAxisLabel('Time')
       .yAxisLabel(this.props.config.field)
       .colors(D3Utils.glColourPalette())
-      .transitionDelay(0)
-      .transitionDuration(0)
       .title(function getTitle(d) {
         const entry = _.find(d.terms, t => t.term === this.layer);
         if (entry) {

--- a/graylog2-web-interface/src/components/visualizations/QuickValuesHistogramVisualization.jsx
+++ b/graylog2-web-interface/src/components/visualizations/QuickValuesHistogramVisualization.jsx
@@ -92,7 +92,7 @@ const QuickValuesHistogramVisualization = createReactClass({
   DEFAULT_HEIGHT: 220,
 
   // dc.js is modifying the margins passed into the graph so make sure this is immutable
-  CHART_MARGINS: Immutable.fromJS({ left: 50, right: 15, top: 10, bottom: 45 }),
+  CHART_MARGINS: Immutable.fromJS({ left: 50, right: 15, top: 10, bottom: 35 }),
 
   _chartRef: undefined,
   _chart: undefined,
@@ -184,7 +184,7 @@ const QuickValuesHistogramVisualization = createReactClass({
       .y(height - 15)
       .itemHeight(12)
       .autoItemWidth(true)
-      .gap(5)
+      .gap(10)
       .legendWidth(width - padding)
       .legendText(d => d.name);
 
@@ -221,7 +221,7 @@ const QuickValuesHistogramVisualization = createReactClass({
       .xUnits(d3.time[interval].utc.range)
       .renderHorizontalGridLines(true)
       .brushOn(false)
-      .xAxisLabel('Time')
+      .xAxisLabel('Time', 25)
       .yAxisLabel(this.props.config.field)
       .colors(D3Utils.glColourPalette())
       .title(function getTitle(d) {


### PR DESCRIPTION
Adapt quick values histogram visualization to be able to use it on reports. In this case, we need to enable or disable transitions depending on the value of the `interactive` prop, and use the `onRenderComplete()` prop when the visualization is fully rendered.