### PR TITLE
Add Script Alert Notification section to graylog.conf

### DIFF
--- a/misc/graylog.conf
+++ b/misc/graylog.conf
@@ -574,7 +574,7 @@ mongodb_threads_allowed_to_block_multiplier = 5
 #integrations_script_alert_web_interface_url = https://graylog.example.com
 
 # The directory within which scripts are permitted to be executed. All subdirectories of the specified path ar always permitted.
-# Default: /usr/share/graylog-server/scripts.
+# Default: /usr/share/graylog-server/scripts
 #integrations_script_alert_permitted_script_root_path = /usr/share/graylog-server/scripts
 
 # The default connect timeout for outgoing HTTP connections.

--- a/misc/graylog.conf
+++ b/misc/graylog.conf
@@ -567,6 +567,16 @@ mongodb_threads_allowed_to_block_multiplier = 5
 # This should define the fully qualified base url to your web interface exactly the same way as it is accessed by your users.
 #transport_email_web_interface_url = https://graylog.example.com
 
+# Script Alert Notification (requires the Enterprise Integrations plugin and an enterprise license).
+
+# Fully qualified base url used to access relevant messages for a particular alert. Provide a URL exactly the same way
+# as it is accessed by your users.
+#integrations_script_alert_web_interface_url = https://graylog.example.com
+
+# The directory within which scripts are permitted to be executed. All subdirectories of the specified path ar always permitted.
+# Default: /usr/share/graylog-server/scripts.
+#integrations_script_alert_permitted_script_root_path = /usr/share/graylog-server/scripts
+
 # The default connect timeout for outgoing HTTP connections.
 # Values must be a positive duration (and between 1 and 2147483647 when converted to milliseconds).
 # Default: 5s

--- a/misc/graylog.conf
+++ b/misc/graylog.conf
@@ -575,7 +575,7 @@ mongodb_threads_allowed_to_block_multiplier = 5
 
 # The directory within which scripts are permitted to be executed. All subdirectories of the specified path ar always permitted.
 # Default: /usr/share/graylog-server/scripts
-#integrations_script_alert_permitted_script_root_path = /usr/share/graylog-server/scripts
+#integrations_script_alert_permitted_root_path = /usr/share/graylog-server/scripts
 
 # The default connect timeout for outgoing HTTP connections.
 # Values must be a positive duration (and between 1 and 2147483647 when converted to milliseconds).


### PR DESCRIPTION
Add a new section to the default graylog.conf file for Script Alert Notification that includes the available parameters and default values.

@bernd Did I make this change in the correct place?

This change is needed for the Script Alert Notification feature https://github.com/Graylog2/graylog-plugin-enterprise-integrations/pull/11

I will cherry-pick into 3.0 branch once merged.