### PR TITLE
Do not duplicate message in Beats input

### DIFF
--- a/graylog2-server/src/main/java/org/graylog/plugins/beats/Beats2Codec.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/beats/Beats2Codec.java
@@ -18,6 +18,7 @@ package org.graylog.plugins.beats;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.google.inject.assistedinject.Assisted;
 import org.graylog2.plugin.Message;
 import org.graylog2.plugin.Tools;
@@ -90,6 +91,18 @@ public class Beats2Codec extends AbstractCodec {
         final Message gelfMessage = new Message(message, hostname, timestamp);
         gelfMessage.addField("beats_type", beatsType);
 
+        // This field should be stored without a prefix
+        final String gl2SourceCollector = event.path(Message.FIELD_GL2_SOURCE_COLLECTOR).asText();
+        if (!gl2SourceCollector.isEmpty()) {
+            gelfMessage.addField(Message.FIELD_GL2_SOURCE_COLLECTOR, gl2SourceCollector);
+        }
+
+        // Remove fields that should not be duplicated with a prefix
+        if (event.isObject()) {
+            ObjectNode onode = (ObjectNode) event;
+            onode.remove("message");
+            onode.remove(Message.FIELD_GL2_SOURCE_COLLECTOR);
+        }
         addFlattened(gelfMessage, rootPath, event);
         return gelfMessage;
     }

--- a/graylog2-server/src/main/java/org/graylog2/plugin/Message.java
+++ b/graylog2-server/src/main/java/org/graylog2/plugin/Message.java
@@ -75,6 +75,7 @@ public class Message implements Messages {
     public static final String FIELD_TIMESTAMP = "timestamp";
     public static final String FIELD_LEVEL = "level";
     public static final String FIELD_STREAMS = "streams";
+    public static final String FIELD_GL2_SOURCE_COLLECTOR = "gl2_source_collector";
 
     private static final Pattern VALID_KEY_CHARS = Pattern.compile("^[\\w\\.\\-@]*$");
     private static final char KEY_REPLACEMENT_CHAR = '_';
@@ -86,7 +87,7 @@ public class Message implements Messages {
         "gl2_source_radio",
         "gl2_source_radio_input",
 
-        "gl2_source_collector",
+        FIELD_GL2_SOURCE_COLLECTOR,
         "gl2_source_collector_input",
         "gl2_remote_ip",
         "gl2_remote_port",

--- a/graylog2-server/src/test/java/org/graylog/plugins/beats/Beats2CodecTest.java
+++ b/graylog2-server/src/test/java/org/graylog/plugins/beats/Beats2CodecTest.java
@@ -70,6 +70,8 @@ public class Beats2CodecTest {
         assertThat(message.getField("input_type")).isEqualTo("log");
         assertThat(message.getField("count")).isEqualTo(1);
         assertThat(message.getField("offset")).isEqualTo(0);
+        assertThat(message.getField(Message.FIELD_GL2_SOURCE_COLLECTOR)).isEqualTo("1234-5678-1234-5678");
+        assertThat(message.getField("filebeat_" + Message.FIELD_GL2_SOURCE_COLLECTOR)).isNull();
         @SuppressWarnings("unchecked") final List<String> tags = (List<String>) message.getField("tags");
         assertThat(tags).containsOnly("foobar", "test");
     }
@@ -86,6 +88,9 @@ public class Beats2CodecTest {
         assertThat(message.getField("filebeat_input_type")).isEqualTo("log");
         assertThat(message.getField("filebeat_count")).isEqualTo(1);
         assertThat(message.getField("filebeat_offset")).isEqualTo(0);
+        assertThat(message.getField(Message.FIELD_GL2_SOURCE_COLLECTOR)).isEqualTo("1234-5678-1234-5678");
+        assertThat(message.getField("filebeat_message")).isNull(); //should not be duplicated from "message"
+        assertThat(message.getField("filebeat_" + Message.FIELD_GL2_SOURCE_COLLECTOR)).isNull();
         @SuppressWarnings("unchecked") final List<String> tags = (List<String>) message.getField("filebeat_tags");
         assertThat(tags).containsOnly("foobar", "test");
     }

--- a/graylog2-server/src/test/resources/org/graylog/plugins/beats/filebeat.json
+++ b/graylog2-server/src/test/resources/org/graylog/plugins/beats/filebeat.json
@@ -17,5 +17,6 @@
     "foobar",
     "test"
   ],
-  "type": "log"
+  "type": "log",
+  "gl2_source_collector": "1234-5678-1234-5678"
 }


### PR DESCRIPTION
If the new Beats input was configured to add the
beats type as a prefix to every field (the default),
it would duplicate the entire message field to
`<beats-type>_message.`

Fix this and additionally, keep the `gl2_source_collector` field
from being prefixed. This is needed for the "show messages" button on
the sidecar view.
