### PR TITLE
Fix problems with resolving dependencies in content packs

### DIFF
--- a/graylog2-server/src/main/java/org/graylog/plugins/pipelineprocessor/db/RuleService.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/pipelineprocessor/db/RuleService.java
@@ -19,6 +19,7 @@ package org.graylog.plugins.pipelineprocessor.db;
 import org.graylog2.database.NotFoundException;
 
 import java.util.Collection;
+import java.util.Optional;
 
 public interface RuleService {
     RuleDao save(RuleDao rule);
@@ -26,6 +27,15 @@ public interface RuleService {
     RuleDao load(String id) throws NotFoundException;
 
     RuleDao loadByName(String name) throws NotFoundException;
+
+    default Optional<RuleDao> findByName(String name) {
+        try {
+           RuleDao ruleDao = this.loadByName(name);
+           return Optional.of(ruleDao);
+        } catch (NotFoundException e) {
+            return Optional.empty();
+        }
+    }
 
     Collection<RuleDao> loadAll();
 

--- a/graylog2-server/src/main/java/org/graylog2/contentpacks/facades/DashboardFacade.java
+++ b/graylog2-server/src/main/java/org/graylog2/contentpacks/facades/DashboardFacade.java
@@ -115,9 +115,11 @@ public class DashboardFacade implements EntityFacade<Dashboard> {
     private DashboardWidgetEntity encodeWidget(DashboardWidget widget, @Nullable WidgetPosition position,
                                                EntityDescriptorIds entityDescriptorIds) {
         final Map<String, Object> config = widget.getConfig();
-        final String streamId = (String) config.get("stream_id");
+        final String streamId = (String) config.getOrDefault("stream_id", "");
 
-        entityDescriptorIds.get(streamId, ModelTypes.STREAM_V1).ifPresent(e -> config.put("stream_id", e));
+        if (!streamId.isEmpty()) {
+            entityDescriptorIds.get(streamId, ModelTypes.STREAM_V1).ifPresent(e -> config.put("stream_id", e));
+        }
 
         return DashboardWidgetEntity.create(
                 ValueReference.of(widget.getId()),

--- a/graylog2-server/src/main/java/org/graylog2/contentpacks/facades/DashboardFacade.java
+++ b/graylog2-server/src/main/java/org/graylog2/contentpacks/facades/DashboardFacade.java
@@ -98,7 +98,7 @@ public class DashboardFacade implements EntityFacade<Dashboard> {
         final Map<String, WidgetPosition> positionsById = dashboard.getPositions().stream()
                 .collect(Collectors.toMap(WidgetPosition::id, v -> v));
         final List<DashboardWidgetEntity> dashboardWidgets = dashboard.getWidgets().entrySet().stream()
-                .map(widget -> encodeWidget(widget.getValue(), positionsById.get(widget.getKey())))
+                .map(widget -> encodeWidget(widget.getValue(), positionsById.get(widget.getKey()), entityDescriptorIds))
                 .collect(Collectors.toList());
         final DashboardEntity dashboardEntity = DashboardEntity.create(
                 ValueReference.of(dashboard.getTitle()),
@@ -112,14 +112,20 @@ public class DashboardFacade implements EntityFacade<Dashboard> {
                 .build();
     }
 
-    private DashboardWidgetEntity encodeWidget(DashboardWidget widget, @Nullable WidgetPosition position) {
+    private DashboardWidgetEntity encodeWidget(DashboardWidget widget, @Nullable WidgetPosition position,
+                                               EntityDescriptorIds entityDescriptorIds) {
+        final Map<String, Object> config = widget.getConfig();
+        final String streamId = (String) config.get("stream_id");
+
+        entityDescriptorIds.get(streamId, ModelTypes.STREAM_V1).ifPresent(e -> config.put("stream_id", e));
+
         return DashboardWidgetEntity.create(
                 ValueReference.of(widget.getId()),
                 ValueReference.of(widget.getDescription()),
                 ValueReference.of(widget.getType()),
                 ValueReference.of(widget.getCacheTime()),
                 TimeRangeEntity.of(widget.getTimeRange()),
-                toReferenceMap(widget.getConfig()),
+                toReferenceMap(config),
                 encodePosition(position));
     }
 

--- a/graylog2-server/src/test/java/org/graylog2/contentpacks/facades/PipelineFacadeTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/contentpacks/facades/PipelineFacadeTest.java
@@ -30,8 +30,10 @@ import org.graylog.plugins.pipelineprocessor.ast.expressions.LogicalExpression;
 import org.graylog.plugins.pipelineprocessor.db.PipelineDao;
 import org.graylog.plugins.pipelineprocessor.db.PipelineService;
 import org.graylog.plugins.pipelineprocessor.db.PipelineStreamConnectionsService;
+import org.graylog.plugins.pipelineprocessor.db.RuleService;
 import org.graylog.plugins.pipelineprocessor.db.mongodb.MongoDbPipelineService;
 import org.graylog.plugins.pipelineprocessor.db.mongodb.MongoDbPipelineStreamConnectionsService;
+import org.graylog.plugins.pipelineprocessor.db.mongodb.MongoDbRuleService;
 import org.graylog.plugins.pipelineprocessor.parser.PipelineRuleParser;
 import org.graylog.plugins.pipelineprocessor.rest.PipelineConnections;
 import org.graylog2.bindings.providers.MongoJackObjectMapperProvider;
@@ -90,6 +92,7 @@ public class PipelineFacadeTest {
     private PipelineRuleParser pipelineRuleParser;
     private PipelineService pipelineService;
     private PipelineStreamConnectionsService connectionsService;
+    private RuleService ruleService;
 
     private PipelineFacade facade;
 
@@ -102,8 +105,9 @@ public class PipelineFacadeTest {
 
         pipelineService = new MongoDbPipelineService(mongoConnection, mapperProvider, clusterEventBus);
         connectionsService = new MongoDbPipelineStreamConnectionsService(mongoConnection, mapperProvider, clusterEventBus);
+        ruleService = new MongoDbRuleService(mongoConnection, mapperProvider, clusterEventBus);
 
-        facade = new PipelineFacade(objectMapper, pipelineService, connectionsService, pipelineRuleParser);
+        facade = new PipelineFacade(objectMapper, pipelineService, connectionsService, pipelineRuleParser, ruleService);
     }
 
     @Test

--- a/graylog2-server/src/test/java/org/graylog2/contentpacks/facades/PipelineFacadeTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/contentpacks/facades/PipelineFacadeTest.java
@@ -30,6 +30,7 @@ import org.graylog.plugins.pipelineprocessor.ast.expressions.LogicalExpression;
 import org.graylog.plugins.pipelineprocessor.db.PipelineDao;
 import org.graylog.plugins.pipelineprocessor.db.PipelineService;
 import org.graylog.plugins.pipelineprocessor.db.PipelineStreamConnectionsService;
+import org.graylog.plugins.pipelineprocessor.db.RuleDao;
 import org.graylog.plugins.pipelineprocessor.db.RuleService;
 import org.graylog.plugins.pipelineprocessor.db.mongodb.MongoDbPipelineService;
 import org.graylog.plugins.pipelineprocessor.db.mongodb.MongoDbPipelineStreamConnectionsService;
@@ -92,6 +93,7 @@ public class PipelineFacadeTest {
     private PipelineRuleParser pipelineRuleParser;
     private PipelineService pipelineService;
     private PipelineStreamConnectionsService connectionsService;
+    @Mock
     private RuleService ruleService;
 
     private PipelineFacade facade;
@@ -105,7 +107,6 @@ public class PipelineFacadeTest {
 
         pipelineService = new MongoDbPipelineService(mongoConnection, mapperProvider, clusterEventBus);
         connectionsService = new MongoDbPipelineStreamConnectionsService(mongoConnection, mapperProvider, clusterEventBus);
-        ruleService = new MongoDbRuleService(mongoConnection, mapperProvider, clusterEventBus);
 
         facade = new PipelineFacade(objectMapper, pipelineService, connectionsService, pipelineRuleParser, ruleService);
     }
@@ -225,18 +226,25 @@ public class PipelineFacadeTest {
                 .ruleReferences(Collections.singletonList("no-op"))
                 .build();
         final Pipeline pipeline = Pipeline.builder()
-                .id("id")
+                .id("5a85c4854b900afd5d662be3")
                 .name("Test")
                 .stages(ImmutableSortedSet.of(stage))
                 .build();
         when(pipelineRuleParser.parsePipeline("dummy", "pipeline \"Test\"\nstage 0 match either\nrule \"debug\"\nrule \"no-op\"\nend"))
                 .thenReturn(pipeline);
-        final EntityDescriptor descriptor = EntityDescriptor.create("Test", ModelTypes.PIPELINE_V1);
+        RuleDao ruleDao = RuleDao.builder()
+                .id("2342353045938450345")
+                .title("no-op")
+                .source("rule \\\"debug\\\"\\nrule \\\"no-op\\\"\\nend\"")
+                .build();
+
+        when(ruleService.findByName("no-op")).thenReturn(Optional.of(ruleDao));
+        final EntityDescriptor descriptor = EntityDescriptor.create("5a85c4854b900afd5d662be3", ModelTypes.PIPELINE_V1);
         final Graph<EntityDescriptor> graph = facade.resolveNativeEntity(descriptor);
         assertThat(graph.nodes()).containsOnly(
                 descriptor,
                 EntityDescriptor.create("5adf23894b900a0fdb4e517d", ModelTypes.STREAM_V1),
-                EntityDescriptor.create("no-op", ModelTypes.PIPELINE_RULE_V1));
+                EntityDescriptor.create("2342353045938450345", ModelTypes.PIPELINE_RULE_V1));
     }
 
     @Test
@@ -295,11 +303,23 @@ public class PipelineFacadeTest {
                 .matchAll(false)
                 .ruleReferences(ImmutableList.of("debug", "no-op"))
                 .build();
+
+        RuleDao ruleDao1 = RuleDao.builder()
+                .id("2342353045938450345")
+                .title("debug")
+                .source("rule \\\"debug\\\"\\nrule \\\"no-op\\\"\\nend\"")
+                .build();
         org.graylog.plugins.pipelineprocessor.ast.Rule rule1 = org.graylog.plugins.pipelineprocessor.ast.Rule.builder()
                 .id("1")
                 .name("debug")
                 .when(mock(LogicalExpression.class))
                 .then(Collections.emptyList())
+                .build();
+
+        RuleDao ruleDao2 = RuleDao.builder()
+                .id("2342353045938450346")
+                .title("no-op")
+                .source("rule \\\"debug\\\"\\nrule \\\"no-op\\\"\\nend\"")
                 .build();
         org.graylog.plugins.pipelineprocessor.ast.Rule rule2 = org.graylog.plugins.pipelineprocessor.ast.Rule.builder()
                 .id("2")
@@ -309,17 +329,20 @@ public class PipelineFacadeTest {
                 .build();
         stage.setRules(ImmutableList.of(rule1, rule2));
         final Pipeline pipeline = Pipeline.builder()
+                .id("5a85c4854b900afd5d662be3")
                 .name("Test")
                 .stages(ImmutableSortedSet.of(stage))
                 .build();
         when(pipelineRuleParser.parsePipeline(eq("dummy"), anyString())).thenReturn(pipeline);
-        final EntityDescriptor pipelineEntity = EntityDescriptor.create("Test", ModelTypes.PIPELINE_V1);
+        when(ruleService.findByName("no-op")).thenReturn(Optional.of(ruleDao1));
+        when(ruleService.findByName("debug")).thenReturn(Optional.of(ruleDao2));
+        final EntityDescriptor pipelineEntity = EntityDescriptor.create("5a85c4854b900afd5d662be3", ModelTypes.PIPELINE_V1);
 
         final Graph<EntityDescriptor> graph = facade.resolveNativeEntity(pipelineEntity);
 
         final EntityDescriptor streamEntity = EntityDescriptor.create("5adf23894b900a0fdb4e517d", ModelTypes.STREAM_V1);
-        final EntityDescriptor ruleEntity1 = EntityDescriptor.create("debug", ModelTypes.PIPELINE_RULE_V1);
-        final EntityDescriptor ruleEntity2 = EntityDescriptor.create("no-op", ModelTypes.PIPELINE_RULE_V1);
+        final EntityDescriptor ruleEntity1 = EntityDescriptor.create("2342353045938450345", ModelTypes.PIPELINE_RULE_V1);
+        final EntityDescriptor ruleEntity2 = EntityDescriptor.create("2342353045938450346", ModelTypes.PIPELINE_RULE_V1);
         assertThat(graph.nodes())
                 .containsOnly(pipelineEntity, streamEntity, ruleEntity1, ruleEntity2);
     }


### PR DESCRIPTION
## Description
This PR solves 2 Problems:
 - Fixup stream_id after dependency resolution
   Prior to this change, a pipeline would search for a rule
   with the name of the rule to resolve the entity. Since
   the rule reference is the name of the rule.
- Use rule id for reference instead of name in content pack
    Prior to this change, a pipeline would search for a rule
    with the name of the rule to resolve the entity. Since
    the rule reference is the name of the rule.

## How Has This Been Tested?
Creating a content pack with a dashboard linked to a stream and installed it and de-installed it.
Creating a content pack with a pipeline with pipeline rules and installed it and de-installed it.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
