### PR TITLE
Allow updating a grok pattern

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/grok/GrokPatternService.java
+++ b/graylog2-server/src/main/java/org/graylog2/grok/GrokPatternService.java
@@ -40,6 +40,8 @@ public interface GrokPatternService {
 
     GrokPattern save(GrokPattern pattern) throws ValidationException;
 
+    GrokPattern update(GrokPattern pattern) throws ValidationException;
+
     List<GrokPattern> saveAll(Collection<GrokPattern> patterns, boolean replace) throws ValidationException;
 
     Map<String, Object> match(GrokPattern pattern, String sampleData) throws GrokException;

--- a/graylog2-server/src/main/java/org/graylog2/grok/InMemoryGrokPatternService.java
+++ b/graylog2-server/src/main/java/org/graylog2/grok/InMemoryGrokPatternService.java
@@ -118,7 +118,6 @@ public class InMemoryGrokPatternService implements GrokPatternService {
         try {
             return save(pattern);
         } catch (ValidationException e) {
-            System.out.println(e.getMessage());
             return null;
         }
     }

--- a/graylog2-server/src/main/java/org/graylog2/grok/InMemoryGrokPatternService.java
+++ b/graylog2-server/src/main/java/org/graylog2/grok/InMemoryGrokPatternService.java
@@ -80,26 +80,20 @@ public class InMemoryGrokPatternService implements GrokPatternService {
         return Sets.newHashSet(store.values());
     }
 
-    @Override
-    public GrokPattern save(GrokPattern pattern) throws ValidationException {
-        return save(pattern, false);
-    }
 
     @Override
     public GrokPattern update(GrokPattern pattern) throws ValidationException {
-        return save(pattern, true);
+        return save(pattern);
     }
 
-    private GrokPattern save(GrokPattern pattern, boolean update) throws ValidationException {
+    @Override
+    public GrokPattern save(GrokPattern pattern) throws ValidationException {
         try {
             if (!validate(pattern)) {
                 throw new ValidationException("Pattern " + pattern.name() + " invalid.");
             }
         } catch (GrokException | PatternSyntaxException e) {
             throw new ValidationException("Invalid pattern " + pattern + "\n" + e.getMessage());
-        }
-        if (!update && loadByName(pattern.name()).isPresent()) {
-            throw new ValidationException("Grok pattern " + pattern.name() + " already exists");
         }
 
         GrokPattern toSave;
@@ -124,6 +118,7 @@ public class InMemoryGrokPatternService implements GrokPatternService {
         try {
             return save(pattern);
         } catch (ValidationException e) {
+            System.out.println(e.getMessage());
             return null;
         }
     }

--- a/graylog2-server/src/main/java/org/graylog2/grok/InMemoryGrokPatternService.java
+++ b/graylog2-server/src/main/java/org/graylog2/grok/InMemoryGrokPatternService.java
@@ -82,6 +82,15 @@ public class InMemoryGrokPatternService implements GrokPatternService {
 
     @Override
     public GrokPattern save(GrokPattern pattern) throws ValidationException {
+        return save(pattern, false);
+    }
+
+    @Override
+    public GrokPattern update(GrokPattern pattern) throws ValidationException {
+        return save(pattern, true);
+    }
+
+    private GrokPattern save(GrokPattern pattern, boolean update) throws ValidationException {
         try {
             if (!validate(pattern)) {
                 throw new ValidationException("Pattern " + pattern.name() + " invalid.");
@@ -89,6 +98,10 @@ public class InMemoryGrokPatternService implements GrokPatternService {
         } catch (GrokException | PatternSyntaxException e) {
             throw new ValidationException("Invalid pattern " + pattern + "\n" + e.getMessage());
         }
+        if (!update && loadByName(pattern.name()).isPresent()) {
+            throw new ValidationException("Grok pattern " + pattern.name() + " already exists");
+        }
+
         GrokPattern toSave;
         if (pattern.id() == null) {
             toSave = pattern.toBuilder().id(createId()).build();

--- a/graylog2-server/src/main/java/org/graylog2/grok/MongoDbGrokPatternService.java
+++ b/graylog2-server/src/main/java/org/graylog2/grok/MongoDbGrokPatternService.java
@@ -134,6 +134,27 @@ public class MongoDbGrokPatternService implements GrokPatternService {
     }
 
     @Override
+    public GrokPattern update(GrokPattern pattern) throws ValidationException {
+        try {
+            if (!validate(pattern)) {
+                throw new ValidationException("Invalid pattern " + pattern);
+            }
+        } catch (GrokException | PatternSyntaxException e) {
+            throw new ValidationException("Invalid pattern " + pattern + "\n" + e.getMessage());
+        }
+
+        if (pattern.id() == null) {
+            throw new ValidationException("Invalid pattern " + pattern);
+        }
+        WriteResult<GrokPattern, ObjectId> result = dbCollection.update(DBQuery.is("_id", new ObjectId(pattern.id())), pattern);
+        if (result.isUpdateOfExisting()) {
+            clusterBus.post(GrokPatternsUpdatedEvent.create(ImmutableSet.of(pattern.name())));
+            return pattern;
+        }
+        throw new ValidationException("Invalid pattern " + pattern);
+    }
+
+    @Override
     public List<GrokPattern> saveAll(Collection<GrokPattern> patterns, boolean replace) throws ValidationException {
         if (!replace) {
             for (GrokPattern pattern : loadAll()) {

--- a/graylog2-server/src/main/java/org/graylog2/rest/resources/system/GrokResource.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/resources/system/GrokResource.java
@@ -211,7 +211,7 @@ public class GrokResource extends RestResource {
                 .pattern(pattern.pattern())
                 .build();
 
-        return grokPatternService.save(grokPattern);
+        return grokPatternService.update(grokPattern);
     }
 
     @DELETE

--- a/graylog2-server/src/test/java/org/graylog2/grok/MongoDbGrokPatternServiceTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/grok/MongoDbGrokPatternServiceTest.java
@@ -46,6 +46,7 @@ import java.util.concurrent.Executors;
 import static com.lordofthejars.nosqlunit.mongodb.InMemoryMongoDb.InMemoryMongoRuleBuilder.newInMemoryMongoDbRule;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.Assertions.fail;
 
 public class MongoDbGrokPatternServiceTest {
     @ClassRule
@@ -306,5 +307,59 @@ public class MongoDbGrokPatternServiceTest {
         assertThat(service.validate(GrokPattern.create("Test", "%{"))).isFalse();
         assertThat(service.validate(GrokPattern.create("Test", ""))).isFalse();
         assertThat(service.validate(GrokPattern.create("", "[a-z]+"))).isFalse();
+    }
+
+    @Test
+    @UsingDataSet(loadStrategy = LoadStrategyEnum.CLEAN_INSERT)
+    public void update() throws ValidationException {
+        assertThat(collection.count()).isEqualTo(3);
+
+        GrokPattern toUpdate1 = GrokPattern.builder()
+                .id("56250da2d400000000000001")
+                .name("Test1")
+                .pattern("123")
+                .build();
+        final GrokPattern updatedPattern1 = service.update(toUpdate1);
+        assertThat(updatedPattern1.name()).matches(toUpdate1.name());
+        assertThat(updatedPattern1.pattern()).matches(toUpdate1.pattern());
+        assertThat(collection.count()).isEqualTo(3);
+
+        GrokPattern toUpdate2 = GrokPattern.builder()
+                .id("56250da2d400000000000001")
+                .name("Testxxx")
+                .pattern("123")
+                .build();
+        final GrokPattern updatedPattern2 = service.update(toUpdate2);
+        assertThat(updatedPattern2.name()).matches(toUpdate2.name());
+        assertThat(updatedPattern2.pattern()).matches(toUpdate2.pattern());
+        assertThat(collection.count()).isEqualTo(3);
+
+        GrokPattern toUpdate3 = GrokPattern.builder()
+                .name("Testxxx")
+                .pattern("123")
+                .build();
+        boolean thrown = false;
+        try {
+            service.update(toUpdate3);
+        } catch (ValidationException e) {
+            thrown = true;
+        }
+        assertThat(thrown).isTrue();
+        assertThat(collection.count()).isEqualTo(3);
+
+        GrokPattern toUpdate4 = GrokPattern.builder()
+                .id("56250da2d400000000000321")
+                .name("Testxxx")
+                .pattern("123")
+                .build();
+        thrown = false;
+        try {
+            service.update(toUpdate4);
+        } catch (ValidationException e) {
+            thrown = true;
+        }
+        assertThat(thrown).isTrue();
+        assertThat(collection.count()).isEqualTo(3);
+
     }
 }


### PR DESCRIPTION
Prior to this change, the unique name validation would
prevent a update of a existing content pack.

This change adds a update function to GrokPatternService
to find a Pattern with a matching ID and uses the
new pattern data to update the grok pattern.

## How Has This Been Tested?
- Created a grok pattern
- Open Edit dialog and saved it without error
- Open Edit dialog changed name and saved it 
- Deleted grok pattern

Fixes #5549 

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
