### PR TITLE
Fixes for index set field type refresh interval value

### DIFF
--- a/graylog2-server/src/test/java/org/graylog2/indexer/IndexSetValidatorTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/indexer/IndexSetValidatorTest.java
@@ -17,6 +17,7 @@
 package org.graylog2.indexer;
 
 import org.graylog2.indexer.indexset.IndexSetConfig;
+import org.joda.time.Duration;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -51,12 +52,14 @@ public class IndexSetValidatorTest {
     @Test
     public void validate() throws Exception {
         final String prefix = "graylog_index";
+        final Duration fieldTypeRefreshInterval = Duration.standardSeconds(1L);
         final IndexSetConfig newConfig = mock(IndexSetConfig.class);
         final IndexSet indexSet = mock(IndexSet.class);
 
         when(indexSet.getIndexPrefix()).thenReturn("foo");
         when(indexSetRegistry.iterator()).thenReturn(Collections.singleton(indexSet).iterator());
         when(newConfig.indexPrefix()).thenReturn(prefix);
+        when(newConfig.fieldTypeRefreshInterval()).thenReturn(fieldTypeRefreshInterval);
 
         final Optional<IndexSetValidator.Violation> violation = validator.validate(newConfig);
 
@@ -105,6 +108,23 @@ public class IndexSetValidatorTest {
         // Existing index prefix starts with new index prefix
         when(indexSet.getIndexPrefix()).thenReturn("graylog");
         when(newConfig.indexPrefix()).thenReturn("gray");
+
+        final Optional<IndexSetValidator.Violation> violation = validator.validate(newConfig);
+
+        assertThat(violation).isPresent();
+    }
+
+    @Test
+    public void validateWithInvalidFieldTypeRefreshInterval() throws Exception {
+        final Duration fieldTypeRefreshInterval = Duration.millis(999);
+        final IndexSetConfig newConfig = mock(IndexSetConfig.class);
+        final IndexSet indexSet = mock(IndexSet.class);
+
+        when(indexSetRegistry.iterator()).thenReturn(Collections.singleton(indexSet).iterator());
+        when(indexSet.getIndexPrefix()).thenReturn("foo");
+        when(newConfig.indexPrefix()).thenReturn("graylog_index");
+
+        when(newConfig.fieldTypeRefreshInterval()).thenReturn(fieldTypeRefreshInterval);
 
         final Optional<IndexSetValidator.Violation> violation = validator.validate(newConfig);
 

--- a/graylog2-web-interface/src/components/common/TimeUnitInput.jsx
+++ b/graylog2-web-interface/src/components/common/TimeUnitInput.jsx
@@ -9,6 +9,17 @@ import lodash from 'lodash';
 import { InputWrapper } from 'components/bootstrap';
 import FormsUtils from 'util/FormsUtils';
 
+const unitValues = [
+  'NANOSECONDS',
+  'MICROSECONDS',
+  'MILLISECONDS',
+  'SECONDS',
+  'MINUTES',
+  'HOURS',
+  'DAYS',
+];
+const unitType = PropTypes.oneOf(unitValues);
+
 /**
  * Component that renders a form field for a time unit value. The field has
  * a checkbox that enables/disables the input, a input for the time value,
@@ -39,7 +50,9 @@ const TimeUnitInput = createReactClass({
     /** Indicates the default value to use, in case value is not provided or set. */
     defaultValue: PropTypes.number,
     /** Indicates which unit is used for the value. */
-    unit: PropTypes.oneOf(['NANOSECONDS', 'MICROSECONDS', 'MILLISECONDS', 'SECONDS', 'MINUTES', 'HOURS', 'DAYS']),
+    unit: unitType,
+    /** Specifies which units should be available in the form. */
+    units: PropTypes.arrayOf(unitType),
     /** Add an additional class to the label. */
     labelClassName: PropTypes.string,
     /** Add an additional class to the input wrapper. */
@@ -51,6 +64,7 @@ const TimeUnitInput = createReactClass({
       defaultValue: 1,
       value: undefined,
       unit: 'SECONDS',
+      units: unitValues,
       label: '',
       help: '',
       required: false,
@@ -60,18 +74,26 @@ const TimeUnitInput = createReactClass({
     };
   },
 
-  OPTIONS: [
-    { value: 'NANOSECONDS', label: 'nanoseconds' },
-    { value: 'MICROSECONDS', label: 'microseconds' },
-    { value: 'MILLISECONDS', label: 'milliseconds' },
-    { value: 'SECONDS', label: 'seconds' },
-    { value: 'MINUTES', label: 'minutes' },
-    { value: 'HOURS', label: 'hours' },
-    { value: 'DAYS', label: 'days' },
-  ],
+  getInitialState() {
+    return {
+      unitOptions: this._getUnitOptions(this.props.units),
+    };
+  },
+
+  componentWillReceiveProps(nextProps) {
+    if (!lodash.isEqual(this.props.units, nextProps.units)) {
+      this.setState({ unitOptions: this._getUnitOptions(nextProps.units) });
+    }
+  },
 
   _getEffectiveValue() {
     return lodash.defaultTo(this.props.value, this.props.defaultValue);
+  },
+
+  _getUnitOptions(units) {
+    return unitValues
+      .filter(value => units.includes(value))
+      .map(value => ({ value: value, label: value.toLowerCase() }));
   },
 
   _isChecked() {
@@ -102,7 +124,7 @@ const TimeUnitInput = createReactClass({
   },
 
   render() {
-    const options = this.OPTIONS.map((o) => {
+    const options = this.state.unitOptions.map((o) => {
       return <MenuItem key={o.value} onSelect={() => this._onUnitSelect(o.value)}>{o.label}</MenuItem>;
     });
 
@@ -119,7 +141,7 @@ const TimeUnitInput = createReactClass({
             <FormControl type="number" disabled={!this._isChecked()} onChange={this._onUpdate} value={this._getEffectiveValue()} />
             <DropdownButton componentClass={InputGroup.Button}
                             id="input-dropdown-addon"
-                            title={this.OPTIONS.filter(o => o.value === this.props.unit)[0].label}>
+                            title={this.state.unitOptions.filter(o => o.value === this.props.unit)[0].label}>
               {options}
             </DropdownButton>
           </InputGroup>

--- a/graylog2-web-interface/src/components/common/TimeUnitInput.md
+++ b/graylog2-web-interface/src/components/common/TimeUnitInput.md
@@ -21,6 +21,7 @@ const TimeUnitInputExample = createReactClass({
         <p>{enabled ? `${value} ${unit}` : 'Disabled'}</p>
         <TimeUnitInput value={value}
                        unit={unit}
+                       units={['SECONDS', 'MINUTES', 'DAYS']}
                        enabled={enabled}
                        update={this.onChange}
                        defaultValue={7} />

--- a/graylog2-web-interface/src/components/indices/IndexSetConfigurationForm.jsx
+++ b/graylog2-web-interface/src/components/indices/IndexSetConfigurationForm.jsx
@@ -125,7 +125,7 @@ class IndexSetConfigurationForm extends React.Component {
   };
 
   render() {
-    const indexSet = this.props.indexSet;
+    const indexSet = this.state.indexSet;
     const validationErrors = this.state.validationErrors;
 
     let rotationConfig;

--- a/graylog2-web-interface/src/components/indices/IndexSetConfigurationForm.jsx
+++ b/graylog2-web-interface/src/components/indices/IndexSetConfigurationForm.jsx
@@ -2,6 +2,7 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import { LinkContainer } from 'react-router-bootstrap';
 import { Button, Col, Row } from 'react-bootstrap';
+import moment from 'moment';
 import lodash from 'lodash';
 
 import { Input } from 'components/bootstrap';
@@ -28,6 +29,7 @@ class IndexSetConfigurationForm extends React.Component {
 
   state = {
     indexSet: this.props.indexSet,
+    fieldTypeRefreshIntervalUnit: 'SECONDS',
     validationErrors: {},
   };
 
@@ -94,38 +96,12 @@ class IndexSetConfigurationForm extends React.Component {
   };
 
   _onFieldTypeRefreshIntervalChange = (value, unit) => {
-    let interval;
-    switch (unit) {
-      case 'NANOSECONDS':
-        interval = value / 1000.0 / 1000.0;
-        break;
-      case 'MICROSECONDS':
-        interval = value / 1000.0;
-        break;
-      case 'MILLISECONDS':
-        interval = value;
-        break;
-      case 'SECONDS':
-        interval = value * 1000;
-        break;
-      case 'MINUTES':
-        interval = value * 1000 * 60;
-        break;
-      case 'HOURS':
-        interval = value * 1000 * 60 * 60;
-        break;
-      case 'DAYS':
-        interval = value * 1000 * 60 * 60 * 24;
-        break;
-      default:
-        throw new Error(`Invalid field type refresh interval unit: ${unit}`);
-    }
-
-    this._updateConfig('field_type_refresh_interval', interval);
+    this._updateConfig('field_type_refresh_interval', moment.duration(value, unit).asMilliseconds());
+    this.setState({ fieldTypeRefreshIntervalUnit: unit });
   };
 
   render() {
-    const indexSet = this.state.indexSet;
+    const { indexSet, fieldTypeRefreshIntervalUnit } = this.state;
     const validationErrors = this.state.validationErrors;
 
     let rotationConfig;
@@ -254,8 +230,8 @@ class IndexSetConfigurationForm extends React.Component {
                 <TimeUnitInput id="field-type-refresh-interval"
                                label="Field type refresh interval"
                                help="How often the field type information for the active write index will be updated."
-                               value={indexSet.field_type_refresh_interval / 1000.0}
-                               unit="SECONDS"
+                               value={moment.duration(indexSet.field_type_refresh_interval, 'milliseconds').as(fieldTypeRefreshIntervalUnit)}
+                               unit={fieldTypeRefreshIntervalUnit}
                                units={['SECONDS', 'MINUTES']}
                                required
                                update={this._onFieldTypeRefreshIntervalChange} />

--- a/graylog2-web-interface/src/components/indices/IndexSetConfigurationForm.jsx
+++ b/graylog2-web-interface/src/components/indices/IndexSetConfigurationForm.jsx
@@ -2,6 +2,7 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import { LinkContainer } from 'react-router-bootstrap';
 import { Button, Col, Row } from 'react-bootstrap';
+import lodash from 'lodash';
 
 import { Input } from 'components/bootstrap';
 import { Spinner, TimeUnitInput } from 'components/common';
@@ -31,7 +32,7 @@ class IndexSetConfigurationForm extends React.Component {
   };
 
   _updateConfig = (fieldName, value) => {
-    const config = this.state.indexSet;
+    const config = lodash.cloneDeep(this.state.indexSet);
     config[fieldName] = value;
     this.setState({ indexSet: config });
   };

--- a/graylog2-web-interface/src/components/indices/IndexSetConfigurationForm.jsx
+++ b/graylog2-web-interface/src/components/indices/IndexSetConfigurationForm.jsx
@@ -256,6 +256,7 @@ class IndexSetConfigurationForm extends React.Component {
                                help="How often the field type information for the active write index will be updated."
                                value={indexSet.field_type_refresh_interval / 1000.0}
                                unit="SECONDS"
+                               units={['SECONDS', 'MINUTES']}
                                required
                                update={this._onFieldTypeRefreshIntervalChange} />
               </Col>

--- a/graylog2-web-interface/src/components/indices/IndexSetConfigurationForm.jsx
+++ b/graylog2-web-interface/src/components/indices/IndexSetConfigurationForm.jsx
@@ -21,6 +21,10 @@ class IndexSetConfigurationForm extends React.Component {
     cancelLink: PropTypes.string.isRequired,
   };
 
+  static defaultProps = {
+    create: false,
+  };
+
   state = {
     indexSet: this.props.indexSet,
     validationErrors: {},
@@ -164,7 +168,7 @@ class IndexSetConfigurationForm extends React.Component {
       const indexPrefixHelp = (
         <span>
           A <strong>unique</strong> prefix used in Elasticsearch indices belonging to this index set.
-          The prefix must start with a letter or number, and can only contain letters, numbers, '_', '-' and '+'.
+          The prefix must start with a letter or number, and can only contain letters, numbers, &apos;_&apos;, &apos;-&apos; and &apos;+&apos;.
         </span>
       );
       readOnlyconfig = (

--- a/graylog2-web-interface/src/pages/IndexSetCreationPage.jsx
+++ b/graylog2-web-interface/src/pages/IndexSetCreationPage.jsx
@@ -8,15 +8,14 @@ import { DocumentTitle, PageHeader, Spinner } from 'components/common';
 import { IndexSetConfigurationForm } from 'components/indices';
 import { DocumentationLink } from 'components/support';
 import DateTime from 'logic/datetimes/DateTime';
+import history from 'util/History';
+import DocsHelper from 'util/DocsHelper';
+import Routes from 'routing/Routes';
 
 import CombinedProvider from 'injection/CombinedProvider';
 
 const { IndexSetsStore, IndexSetsActions } = CombinedProvider.get('IndexSets');
 const { IndicesConfigurationStore, IndicesConfigurationActions } = CombinedProvider.get('IndicesConfiguration');
-
-import history from 'util/History';
-import DocsHelper from 'util/DocsHelper';
-import Routes from 'routing/Routes';
 
 const IndexSetCreationPage = createReactClass({
   displayName: 'IndexSetCreationPage',

--- a/graylog2-web-interface/src/pages/IndexSetCreationPage.jsx
+++ b/graylog2-web-interface/src/pages/IndexSetCreationPage.jsx
@@ -43,6 +43,7 @@ const IndexSetCreationPage = createReactClass({
         index_analyzer: 'standard',
         index_optimization_max_num_segments: 1,
         index_optimization_disabled: false,
+        field_type_refresh_interval: 5 * 1000, // 5 seconds
       },
     };
   },


### PR DESCRIPTION
This PR makes some improvements around how we handle the field type refresh interval for index sets:

- Set a default value in the frontend, fixing #4724 
- Let Moment.js handle durations for us in the frontend
- Restrict time units displayed in the form for this field to only display those that are reasonable
- As too short values may have a performance impact, validate the field in the backend to ensure the refresh interval is one second or longer