### PR TITLE
Fixes for index set field type refresh interval value (#5595)

### DIFF
--- a/graylog2-server/src/test/java/org/graylog2/indexer/IndexSetValidatorTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/indexer/IndexSetValidatorTest.java
@@ -17,6 +17,7 @@
 package org.graylog2.indexer;
 
 import org.graylog2.indexer.indexset.IndexSetConfig;
+import org.joda.time.Duration;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -51,12 +52,14 @@ public class IndexSetValidatorTest {
     @Test
     public void validate() throws Exception {
         final String prefix = "graylog_index";
+        final Duration fieldTypeRefreshInterval = Duration.standardSeconds(1L);
         final IndexSetConfig newConfig = mock(IndexSetConfig.class);
         final IndexSet indexSet = mock(IndexSet.class);
 
         when(indexSet.getIndexPrefix()).thenReturn("foo");
         when(indexSetRegistry.iterator()).thenReturn(Collections.singleton(indexSet).iterator());
         when(newConfig.indexPrefix()).thenReturn(prefix);
+        when(newConfig.fieldTypeRefreshInterval()).thenReturn(fieldTypeRefreshInterval);
 
         final Optional<IndexSetValidator.Violation> violation = validator.validate(newConfig);
 
@@ -105,6 +108,23 @@ public class IndexSetValidatorTest {
         // Existing index prefix starts with new index prefix
         when(indexSet.getIndexPrefix()).thenReturn("graylog");
         when(newConfig.indexPrefix()).thenReturn("gray");
+
+        final Optional<IndexSetValidator.Violation> violation = validator.validate(newConfig);
+
+        assertThat(violation).isPresent();
+    }
+
+    @Test
+    public void validateWithInvalidFieldTypeRefreshInterval() throws Exception {
+        final Duration fieldTypeRefreshInterval = Duration.millis(999);
+        final IndexSetConfig newConfig = mock(IndexSetConfig.class);
+        final IndexSet indexSet = mock(IndexSet.class);
+
+        when(indexSetRegistry.iterator()).thenReturn(Collections.singleton(indexSet).iterator());
+        when(indexSet.getIndexPrefix()).thenReturn("foo");
+        when(newConfig.indexPrefix()).thenReturn("graylog_index");
+
+        when(newConfig.fieldTypeRefreshInterval()).thenReturn(fieldTypeRefreshInterval);
 
         final Optional<IndexSetValidator.Violation> violation = validator.validate(newConfig);
 

--- a/graylog2-web-interface/src/components/common/TimeUnitInput.jsx
+++ b/graylog2-web-interface/src/components/common/TimeUnitInput.jsx
@@ -9,6 +9,17 @@ import lodash from 'lodash';
 import { InputWrapper } from 'components/bootstrap';
 import FormsUtils from 'util/FormsUtils';
 
+const unitValues = [
+  'NANOSECONDS',
+  'MICROSECONDS',
+  'MILLISECONDS',
+  'SECONDS',
+  'MINUTES',
+  'HOURS',
+  'DAYS',
+];
+const unitType = PropTypes.oneOf(unitValues);
+
 /**
  * Component that renders a form field for a time unit value. The field has
  * a checkbox that enables/disables the input, a input for the time value,
@@ -39,7 +50,9 @@ const TimeUnitInput = createReactClass({
     /** Indicates the default value to use, in case value is not provided or set. */
     defaultValue: PropTypes.number,
     /** Indicates which unit is used for the value. */
-    unit: PropTypes.oneOf(['NANOSECONDS', 'MICROSECONDS', 'MILLISECONDS', 'SECONDS', 'MINUTES', 'HOURS', 'DAYS']),
+    unit: unitType,
+    /** Specifies which units should be available in the form. */
+    units: PropTypes.arrayOf(unitType),
     /** Add an additional class to the label. */
     labelClassName: PropTypes.string,
     /** Add an additional class to the input wrapper. */
@@ -51,6 +64,7 @@ const TimeUnitInput = createReactClass({
       defaultValue: 1,
       value: undefined,
       unit: 'SECONDS',
+      units: unitValues,
       label: '',
       help: '',
       required: false,
@@ -60,18 +74,26 @@ const TimeUnitInput = createReactClass({
     };
   },
 
-  OPTIONS: [
-    { value: 'NANOSECONDS', label: 'nanoseconds' },
-    { value: 'MICROSECONDS', label: 'microseconds' },
-    { value: 'MILLISECONDS', label: 'milliseconds' },
-    { value: 'SECONDS', label: 'seconds' },
-    { value: 'MINUTES', label: 'minutes' },
-    { value: 'HOURS', label: 'hours' },
-    { value: 'DAYS', label: 'days' },
-  ],
+  getInitialState() {
+    return {
+      unitOptions: this._getUnitOptions(this.props.units),
+    };
+  },
+
+  componentWillReceiveProps(nextProps) {
+    if (!lodash.isEqual(this.props.units, nextProps.units)) {
+      this.setState({ unitOptions: this._getUnitOptions(nextProps.units) });
+    }
+  },
 
   _getEffectiveValue() {
     return lodash.defaultTo(this.props.value, this.props.defaultValue);
+  },
+
+  _getUnitOptions(units) {
+    return unitValues
+      .filter(value => units.includes(value))
+      .map(value => ({ value: value, label: value.toLowerCase() }));
   },
 
   _isChecked() {
@@ -102,7 +124,7 @@ const TimeUnitInput = createReactClass({
   },
 
   render() {
-    const options = this.OPTIONS.map((o) => {
+    const options = this.state.unitOptions.map((o) => {
       return <MenuItem key={o.value} onSelect={() => this._onUnitSelect(o.value)}>{o.label}</MenuItem>;
     });
 
@@ -119,7 +141,7 @@ const TimeUnitInput = createReactClass({
             <FormControl type="number" disabled={!this._isChecked()} onChange={this._onUpdate} value={this._getEffectiveValue()} />
             <DropdownButton componentClass={InputGroup.Button}
                             id="input-dropdown-addon"
-                            title={this.OPTIONS.filter(o => o.value === this.props.unit)[0].label}>
+                            title={this.state.unitOptions.filter(o => o.value === this.props.unit)[0].label}>
               {options}
             </DropdownButton>
           </InputGroup>

--- a/graylog2-web-interface/src/components/common/TimeUnitInput.md
+++ b/graylog2-web-interface/src/components/common/TimeUnitInput.md
@@ -21,6 +21,7 @@ const TimeUnitInputExample = createReactClass({
         <p>{enabled ? `${value} ${unit}` : 'Disabled'}</p>
         <TimeUnitInput value={value}
                        unit={unit}
+                       units={['SECONDS', 'MINUTES', 'DAYS']}
                        enabled={enabled}
                        update={this.onChange}
                        defaultValue={7} />

--- a/graylog2-web-interface/src/pages/IndexSetCreationPage.jsx
+++ b/graylog2-web-interface/src/pages/IndexSetCreationPage.jsx
@@ -8,15 +8,14 @@ import { DocumentTitle, PageHeader, Spinner } from 'components/common';
 import { IndexSetConfigurationForm } from 'components/indices';
 import { DocumentationLink } from 'components/support';
 import DateTime from 'logic/datetimes/DateTime';
+import history from 'util/History';
+import DocsHelper from 'util/DocsHelper';
+import Routes from 'routing/Routes';
 
 import CombinedProvider from 'injection/CombinedProvider';
 
 const { IndexSetsStore, IndexSetsActions } = CombinedProvider.get('IndexSets');
 const { IndicesConfigurationStore, IndicesConfigurationActions } = CombinedProvider.get('IndicesConfiguration');
-
-import history from 'util/History';
-import DocsHelper from 'util/DocsHelper';
-import Routes from 'routing/Routes';
 
 const IndexSetCreationPage = createReactClass({
   displayName: 'IndexSetCreationPage',
@@ -44,6 +43,7 @@ const IndexSetCreationPage = createReactClass({
         index_analyzer: 'standard',
         index_optimization_max_num_segments: 1,
         index_optimization_disabled: false,
+        field_type_refresh_interval: 5 * 1000, // 5 seconds
       },
     };
   },


### PR DESCRIPTION
* Fix linter errors

* Add default value to `field_type_refresh_interval`

Use same default value as the server.

Fixes #4724

* Allow restricting units in TimeUnitInput

This allows consumers of the component to only display supported units
in the form.

* Ensure we do not modify the state directly

* Ensure we render the current state in the form

The state is initialized from the props, but changes in the form are
persisted in the state. To ensure any computed value from state is still
correctly rendered, use the state values instead of the props.

* Restrict available units to seconds and minutes

* Rely on moment.duration to get right values

On change, always convert the given value and unit to milliseconds, which
is what the server expects.

For rendering, convert the given time in milliseconds to the selected
unit.

* Check fieldTypeRefreshInterval 1 second or longer

Refreshing field type information too often may have a big performance
impact. This change ensures the refresh interval is not shorter than one
second, which seems to be a reasonable low value for it.

(cherry picked from commit 198cc699f6a14493278c9ffcf42e895e8325b9cb)

Backport of #5595