### PR TITLE
Hide used column in parameter list

### DIFF
--- a/graylog2-web-interface/src/components/content-packs/ContentPackParameterList.jsx
+++ b/graylog2-web-interface/src/components/content-packs/ContentPackParameterList.jsx
@@ -25,7 +25,7 @@ class ContentPackParameterList extends React.Component {
     readOnly: false,
     onDeleteParameter: () => {},
     onAddParameter: () => {},
-    appliedParameter: {},
+    appliedParameter: undefined,
   };
 
   constructor(props) {
@@ -42,6 +42,9 @@ class ContentPackParameterList extends React.Component {
   }
 
   _parameterApplied = (paramName) => {
+    if (!this.props.appliedParameter) {
+      return false;
+    }
     const entityIds = Object.keys(this.props.appliedParameter);
     /* eslint-disable-next-line no-restricted-syntax, guard-for-in */
     for (const i in entityIds) {
@@ -65,7 +68,7 @@ class ContentPackParameterList extends React.Component {
         <td className={ContentPackParameterListStyle.bigColumns}>{parameter.description}</td>
         <td>{parameter.type}</td>
         <td>{ContentPackUtils.convertToString(parameter)}</td>
-        <td><Badge className={bsStyle}><i className={icon} /></Badge></td>
+        {this.props.appliedParameter && <td><Badge className={bsStyle}><i className={icon} /></Badge></td>}
         {!this.props.readOnly &&
         <td>
           <ButtonToolbar>
@@ -154,10 +157,18 @@ class ContentPackParameterList extends React.Component {
     this.setState({ filteredParameters: filteredParameters, filter: filter });
   };
 
-  render() {
-    const headers = this.props.readOnly ?
+  _getHeaders = () => {
+    const headers = this.props.appliedParameter ?
       ['Title', 'Name', 'Description', 'Value Type', 'Default Value', 'Used'] :
-      ['Title', 'Name', 'Description', 'Value Type', 'Default Value', 'Used', 'Action'];
+      ['Title', 'Name', 'Description', 'Value Type', 'Default Value'];
+    if (!this.props.readOnly) {
+      return headers.concat(['Action']);
+    }
+    return headers;
+  };
+
+  render() {
+    const headers = this._getHeaders();
     return (
       <div>
         <h2>Parameters list</h2>

--- a/graylog2-web-interface/src/components/content-packs/__snapshots__/ContentPackParameterList.test.jsx.snap
+++ b/graylog2-web-interface/src/components/content-packs/__snapshots__/ContentPackParameterList.test.jsx.snap
@@ -302,9 +302,6 @@ exports[`<ContentPackParameterList /> should render with parameters with readOnl
                 <th>
                   Default Value
                 </th>
-                <th>
-                  Used
-                </th>
               </tr>
             </thead>
             <tbody>
@@ -327,15 +324,6 @@ exports[`<ContentPackParameterList /> should render with parameters with readOnl
                 </td>
                 <td>
                   test
-                </td>
-                <td>
-                  <span
-                    className="failure badge"
-                  >
-                    <i
-                      className="fa fa-times"
-                    />
-                  </span>
                 </td>
               </tr>
             </tbody>
@@ -464,9 +452,6 @@ exports[`<ContentPackParameterList /> should render with parameters without read
                   Default Value
                 </th>
                 <th>
-                  Used
-                </th>
-                <th>
                   Action
                 </th>
               </tr>
@@ -491,15 +476,6 @@ exports[`<ContentPackParameterList /> should render with parameters without read
                 </td>
                 <td>
                   test
-                </td>
-                <td>
-                  <span
-                    className="failure badge"
-                  >
-                    <i
-                      className="fa fa-times"
-                    />
-                  </span>
                 </td>
                 <td>
                   <div


### PR DESCRIPTION
Prior to this change, the used column was shown
when the parameter list could not calculate the state
and was not necessary to show.

This change does hide the parameter list when not needed.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
