### PR TITLE
Drop `users:list` permission from sidecar role (#5607)

### DIFF
--- a/graylog2-server/src/main/java/org/graylog/plugins/sidecar/migrations/V20180323150000_AddSidecarUser.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/sidecar/migrations/V20180323150000_AddSidecarUser.java
@@ -22,7 +22,6 @@ import org.graylog.plugins.sidecar.common.SidecarPluginConfiguration;
 import org.graylog.plugins.sidecar.permissions.SidecarRestPermissions;
 import org.graylog2.migrations.Migration;
 import org.graylog2.migrations.MigrationHelpers;
-import org.graylog2.shared.security.RestPermissions;
 import org.graylog2.users.RoleService;
 
 import javax.inject.Inject;
@@ -56,8 +55,7 @@ public class V20180323150000_AddSidecarUser extends Migration {
                 ImmutableSet.of(
                         SidecarRestPermissions.COLLECTORS_READ,
                         SidecarRestPermissions.CONFIGURATIONS_READ,
-                        SidecarRestPermissions.SIDECARS_UPDATE,
-                        RestPermissions.USERS_LIST));
+                        SidecarRestPermissions.SIDECARS_UPDATE));
 
         helpers.ensureUser(
                 sidecarUser,


### PR DESCRIPTION
There is no need for the sidecar role to have this permission.

(cherry picked from commit e5c4d0cef3c4ecb30c4961ca3eaaf77603b5e4fe)
