### PR TITLE
Reduce time range on 'Show received messages' button

### DIFF
--- a/changelog/unreleased/issue-5620.toml
+++ b/changelog/unreleased/issue-5620.toml
@@ -1,0 +1,9 @@
+# PLEASE REMOVE COMMENTS AND OPTIONAL FIELDS! THANKS!
+
+# Entry type according to https://keepachangelog.com/en/1.0.0/
+# One of: a(dded), c(hanged), d(eprecated), r(emoved), f(ixed), s(ecurity)
+type = "c"
+message = "Shorten time range of show received messages button."
+
+issues = ["5620"]
+pulls = ["5621"]

--- a/changelog/unreleased/issue-5620.toml
+++ b/changelog/unreleased/issue-5620.toml
@@ -1,9 +1,5 @@
-# PLEASE REMOVE COMMENTS AND OPTIONAL FIELDS! THANKS!
-
-# Entry type according to https://keepachangelog.com/en/1.0.0/
-# One of: a(dded), c(hanged), d(eprecated), r(emoved), f(ixed), s(ecurity)
 type = "c"
-message = "Shorten time range of show received messages button."
+message = "Shorten time range of show received messages buttons."
 
 issues = ["5620"]
 pulls = ["5621"]

--- a/changelog/unreleased/issue-5620.toml
+++ b/changelog/unreleased/issue-5620.toml
@@ -1,5 +1,5 @@
 type = "c"
-message = "Shorten time range of show received messages buttons."
+message = "Shorten time range of show received messages buttons on inputs, forwarder profiles and sidecars."
 
 issues = ["5620"]
 pulls = ["5621"]

--- a/graylog2-web-interface/src/components/inputs/InputListItem.jsx
+++ b/graylog2-web-interface/src/components/inputs/InputListItem.jsx
@@ -27,6 +27,8 @@ import { EntityListItem, IfPermitted, LinkToNode, Spinner } from 'components/com
 import { ConfigurationWell } from 'components/configurationforms';
 import PermissionsMixin from 'util/PermissionsMixin';
 import Routes from 'routing/Routes';
+import { recentMessagesTimeRange } from 'views/logic/TimeRange';
+
 import {
   InputForm,
   InputStateBadge,
@@ -116,7 +118,7 @@ const InputListItem = createReactClass({
     if (this.isPermitted(this.props.permissions, ['searches:relative'])) {
       actions.push(
         <LinkContainer key={`received-messages-${this.props.input.id}`}
-                       to={Routes.search(`${queryField}:${this.props.input.id}`, { relative: 0 })}>
+                       to={Routes.search(`${queryField}:${this.props.input.id}`, recentMessagesTimeRange())}>
           <Button onClick={() => {
             sendTelemetry(TELEMETRY_EVENT_TYPE.INPUTS.SHOW_RECEIVED_MESSAGES_CLICKED, {
               app_pathname: getPathnameWithoutId(location.pathname),

--- a/graylog2-web-interface/src/components/inputs/InputListItem.jsx
+++ b/graylog2-web-interface/src/components/inputs/InputListItem.jsx
@@ -27,7 +27,7 @@ import { EntityListItem, IfPermitted, LinkToNode, Spinner } from 'components/com
 import { ConfigurationWell } from 'components/configurationforms';
 import PermissionsMixin from 'util/PermissionsMixin';
 import Routes from 'routing/Routes';
-import { recentMessagesTimeRange } from 'views/logic/TimeRange';
+import recentMessagesTimeRange from 'util/TimeRangeHelper';
 import {
   InputForm,
   InputStateBadge,

--- a/graylog2-web-interface/src/components/inputs/InputListItem.jsx
+++ b/graylog2-web-interface/src/components/inputs/InputListItem.jsx
@@ -28,7 +28,6 @@ import { ConfigurationWell } from 'components/configurationforms';
 import PermissionsMixin from 'util/PermissionsMixin';
 import Routes from 'routing/Routes';
 import { recentMessagesTimeRange } from 'views/logic/TimeRange';
-
 import {
   InputForm,
   InputStateBadge,

--- a/graylog2-web-interface/src/components/sidecars/sidecars/SidecarRow.jsx
+++ b/graylog2-web-interface/src/components/sidecars/sidecars/SidecarRow.jsx
@@ -25,6 +25,7 @@ import Routes from 'routing/Routes';
 import OperatingSystemIcon from 'components/sidecars/common/OperatingSystemIcon';
 import StatusIndicator from 'components/sidecars/common/StatusIndicator';
 import SidecarStatusEnum from 'logic/sidecar/SidecarStatusEnum';
+import { recentMessagesTimeRange } from 'views/logic/TimeRange';
 
 import style from './SidecarRow.css';
 
@@ -75,7 +76,7 @@ class SidecarRow extends React.Component {
             {sidecar.node_name}
           </Link>
         </td>
-        <td>
+        <td aria-label="Status">
           <StatusIndicator status={sidecarStatus.status}
                            message={sidecarStatus.message}
                            id={sidecarStatus.id}
@@ -102,7 +103,7 @@ class SidecarRow extends React.Component {
             <LinkContainer to={`${Routes.SYSTEM.SIDECARS.ADMINISTRATION}?node_id=${sidecar.node_id}`}>
               <Button bsSize="xsmall" bsStyle="info">Manage sidecar</Button>
             </LinkContainer>
-            <LinkContainer to={Routes.search_with_query(`gl2_source_collector:${sidecar.node_id}`, 'relative', { relative: 604800 })}>
+            <LinkContainer to={Routes.search_with_query(`gl2_source_collector:${sidecar.node_id}`, 'absolute', recentMessagesTimeRange())}>
               <Button bsSize="xsmall" bsStyle="info">Show messages</Button>
             </LinkContainer>
           </ButtonToolbar>

--- a/graylog2-web-interface/src/components/sidecars/sidecars/SidecarRow.jsx
+++ b/graylog2-web-interface/src/components/sidecars/sidecars/SidecarRow.jsx
@@ -25,7 +25,7 @@ import Routes from 'routing/Routes';
 import OperatingSystemIcon from 'components/sidecars/common/OperatingSystemIcon';
 import StatusIndicator from 'components/sidecars/common/StatusIndicator';
 import SidecarStatusEnum from 'logic/sidecar/SidecarStatusEnum';
-import { recentMessagesTimeRange } from 'views/logic/TimeRange';
+import recentMessagesTimeRange from 'util/TimeRangeHelper';
 
 import style from './SidecarRow.css';
 

--- a/graylog2-web-interface/src/util/TimeRangeHelper.ts
+++ b/graylog2-web-interface/src/util/TimeRangeHelper.ts
@@ -25,7 +25,7 @@ import type { AbsoluteRangeQueryParameter } from 'views/logic/TimeRange';
 const recentMessagesTimeRange = (): AbsoluteRangeQueryParameter => {
   const now = Date.now();
   // The biggest possible time difference on earth is 26 hours.
-  // It's between Kiribati is UTC+14 and the Howland Islands UTC-12
+  // It's between Kiribati (UTC+14) and the Howland Islands (UTC-12)
   // So we are going to create an absolute range
   // from 26 hours in the past to 26 hours into the future.
   const fromDate = new Date(now - 26 * 60 * 60000).toISOString();

--- a/graylog2-web-interface/src/util/TimeRangeHelper.ts
+++ b/graylog2-web-interface/src/util/TimeRangeHelper.ts
@@ -1,0 +1,37 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
+
+import type { AbsoluteRangeQueryParameter } from 'views/logic/TimeRange';
+
+/**
+ * Creates an absolute time range that can be used to look up recently received messages.
+ * It accommodates for the eventuality that messages can have timestamps from the future
+ * due to wrong timezone parsing or wrong system clocks.
+ */
+const recentMessagesTimeRange = (): AbsoluteRangeQueryParameter => {
+  const now = Date.now();
+  // The biggest possible time difference on earth is 26 hours.
+  // It's between Kiribati is UTC+14 and the Howland Islands UTC-12
+  // So we are going to create an absolute range
+  // from 26 hours in the past to 26 hours into the future.
+  const fromDate = new Date(now - 26 * 60 * 60000).toISOString();
+  const toDate = new Date(now + 26 * 60 * 60000).toISOString();
+
+  return { rangetype: 'absolute', from: fromDate, to: toDate };
+};
+
+export default recentMessagesTimeRange;

--- a/graylog2-web-interface/src/views/logic/TimeRange.ts
+++ b/graylog2-web-interface/src/views/logic/TimeRange.ts
@@ -31,7 +31,7 @@ type RelativeRangeWithEndQueryParameter = {
 
 type RelativeRangeQueryParameter = RelativeRangeStartOnlyQueryParameter | RelativeRangeWithEndQueryParameter;
 
-type AbsoluteRangeQueryParameter = {
+export type AbsoluteRangeQueryParameter = {
   rangetype: 'absolute',
   from: string,
   to: string,
@@ -106,21 +106,4 @@ export const timeRangeFromQueryParameter = (range: TimeRangeQueryParameter): Tim
     default:
       return assertUnreachable(range, 'Unsupported range type in range: ');
   }
-};
-
-/**
- * Creates an absolute time range that can be used to look up recently received messages.
- * It accommodates for the eventuality that messages can have timestamps from the future
- * due to wrong timezone parsing or wrong system clocks.
- */
-export const recentMessagesTimeRange = (): AbsoluteRangeQueryParameter => {
-  const now = Date.now();
-  // The biggest possible time difference on earth is 26 hours.
-  // It's between Kiribati is UTC+14 and the Howland Islands UTC-12
-  // So we are going to create an absolute range
-  // from 26 hours in the past to 26 hours into the future.
-  const fromDate = new Date(now - 26 * 60 * 60000).toISOString();
-  const toDate = new Date(now + 26 * 60 * 60000).toISOString();
-
-  return { rangetype: 'absolute', from: fromDate, to: toDate };
 };

--- a/graylog2-web-interface/src/views/logic/TimeRange.ts
+++ b/graylog2-web-interface/src/views/logic/TimeRange.ts
@@ -110,12 +110,17 @@ export const timeRangeFromQueryParameter = (range: TimeRangeQueryParameter): Tim
 
 /**
  * Creates an absolute time range that can be used to look up recently received messages.
- * It accomodates for the eventuality that messages can have timestamps from the future due to wrong system clocks.
+ * It accommodates for the eventuality that messages can have timestamps from the future
+ * due to wrong timezone parsing or wrong system clocks.
  */
 export const recentMessagesTimeRange = (): AbsoluteRangeQueryParameter => {
   const now = Date.now();
-  const fromDate = new Date(now - 5 * 60000).toISOString();
-  const toDate = new Date(now +  60 * 60000).toISOString();
+  // The biggest possible time difference on earth is 26 hours.
+  // It's between Kiribati is UTC+14 and the Howland Islands UTC-12
+  // So we are going to create an absolute range
+  // from 26 hours in the past to 26 hours into the future.
+  const fromDate = new Date(now - 26 * 60 * 60000).toISOString();
+  const toDate = new Date(now + 26 * 60 * 60000).toISOString();
 
   return { rangetype: 'absolute', from: fromDate, to: toDate };
 };

--- a/graylog2-web-interface/src/views/logic/TimeRange.ts
+++ b/graylog2-web-interface/src/views/logic/TimeRange.ts
@@ -107,3 +107,15 @@ export const timeRangeFromQueryParameter = (range: TimeRangeQueryParameter): Tim
       return assertUnreachable(range, 'Unsupported range type in range: ');
   }
 };
+
+/**
+ * Creates an absolute time range that can be used to look up recently received messages.
+ * It accomodates for the eventuality that messages can have timestamps from the future due to wrong system clocks.
+ */
+export const recentMessagesTimeRange = (): AbsoluteRangeQueryParameter => {
+  const now = Date.now();
+  const fromDate = new Date(now - 5 * 60000).toISOString();
+  const toDate = new Date(now +  60 * 60000).toISOString();
+
+  return { rangetype: 'absolute', from: fromDate, to: toDate };
+};


### PR DESCRIPTION
Defaulting to search in all messages is expensive and might trigger
OOM scenarios much easier.

Instead of searching all messages, we are searching only
messages in a range of past and future 26 hours.

26 hours because that's the largest possible timezone mistake a user can make.

Fixes #5620
