### PR TITLE
Fix changing index rotation and retention settings

### DIFF
--- a/graylog2-web-interface/src/components/indices/IndexSetConfigurationForm.jsx
+++ b/graylog2-web-interface/src/components/indices/IndexSetConfigurationForm.jsx
@@ -34,9 +34,13 @@ class IndexSetConfigurationForm extends React.Component {
   };
 
   _updateConfig = (fieldName, value) => {
-    const config = lodash.cloneDeep(this.state.indexSet);
-    config[fieldName] = value;
-    this.setState({ indexSet: config });
+    // Use `setState()` with updater function so consecutive calls to `_updateConfig()` always refer to the state
+    // at the time the change is applied, resulting in all different keys of the object being updated.
+    this.setState((state) => {
+      const config = lodash.cloneDeep(state.indexSet);
+      config[fieldName] = value;
+      return { indexSet: config };
+    });
   };
 
   _validateIndexPrefix = (event) => {


### PR DESCRIPTION
The fixes in #5595 corrected the code in `IndexSetConfigurationForm` to avoid modifying the React state directly. Creating a clone of the state had an unexpected consequence: the `_updateConfig()` method updates different object keys stored in the `indexSet` state key. When consecutive calls to `_updateConfig()` are made, each of them will create a clone of the state at the time of the call, but that state does not represent the actual current state, since React enqueues changes to the state.

In order to avoid that issue, we make use of the update function to set the state, which guarantees that the current state (including any queued modifications) are passed to the function.

Fixes #5617
