### PR TITLE
Give usefull message on default grok patterns fail

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/migrations/V20180924111644_AddDefaultGrokPatterns.java
+++ b/graylog2-server/src/main/java/org/graylog2/migrations/V20180924111644_AddDefaultGrokPatterns.java
@@ -81,8 +81,8 @@ public class V20180924111644_AddDefaultGrokPatterns extends Migration {
                 contentPackService.installContentPack(pack, Collections.emptyMap(), "Add default Grok patterns", "admin");
             } catch(ContentPackException e) {
                 LOG.warn("Could not install default grok patterns: the installation found some modified default grok" +
-                        "patterns in your setup and did not update them. If you wish to use to the default grok" +
-                        "patterns we provide, please delete the grok pattern and install the 'Default grok" +
+                        "patterns in your setup and did not update them. If you wish to use the default grok" +
+                        "patterns we provide, please delete the modified grok pattern and install the 'Default grok" +
                         "patterns' content pack manually.");
             }
 

--- a/graylog2-server/src/main/java/org/graylog2/migrations/V20180924111644_AddDefaultGrokPatterns.java
+++ b/graylog2-server/src/main/java/org/graylog2/migrations/V20180924111644_AddDefaultGrokPatterns.java
@@ -24,6 +24,7 @@ import com.google.auto.value.AutoValue;
 import org.graylog.autovalue.WithBeanGetter;
 import org.graylog2.contentpacks.ContentPackPersistenceService;
 import org.graylog2.contentpacks.ContentPackService;
+import org.graylog2.contentpacks.exceptions.ContentPackException;
 import org.graylog2.contentpacks.model.ContentPack;
 import org.graylog2.plugin.cluster.ClusterConfigService;
 import org.slf4j.Logger;
@@ -71,9 +72,19 @@ public class V20180924111644_AddDefaultGrokPatterns extends Migration {
                     .getResource("V20180924111644_AddDefaultGrokPatterns_Default_Grok_Patterns.json");
             final ContentPack contentPack = this.objectMapper.readValue(contentPackURL, ContentPack.class);
             final ContentPack pack = this.contentPackPersistenceService.insert(contentPack)
-                    .orElseThrow(() -> new Error("Content pack " + contentPack.id() + " with this revision " + contentPack.revision() + " already found!"));
+                    .orElseThrow(() -> {
+                        configService.write(MigrationCompleted.create(contentPack.id().toString()));
+                        return new ContentPackException("Content pack " + contentPack.id() + " with this revision " + contentPack.revision() + " already found!");
+                    });
 
-            contentPackService.installContentPack(pack, Collections.emptyMap(), "Add default Grok patterns", "admin");
+            try {
+                contentPackService.installContentPack(pack, Collections.emptyMap(), "Add default Grok patterns", "admin");
+            } catch(ContentPackException e) {
+                LOG.warn("Could not install default grok patterns: the installation found some modified default grok" +
+                        "patterns in your setup and did not update them. If you wish to use to the default grok" +
+                        "patterns we provide, please delete the grok pattern and install the 'Default grok" +
+                        "patterns' content pack manually.");
+            }
 
             configService.write(MigrationCompleted.create(pack.id().toString()));
         } catch (IOException e) {


### PR DESCRIPTION
Prior to this change, when a user had modfied the a default
grok pattern, the installation would fail. With a cryptic
error message.

This change catches the error and prints a hopefully more useful
error message.

Also: do not use `new Error` which is not catched.
Also: we will write the clusterConfig to avoid running into a already found content pack after every restart.
Fixes #5626 

## How Has This Been Tested?
- Removed Content Pack Installation
- Removed Content Pack
- Removed corresponding cluster config
- Edited one default grok pattern
- Restarted server and looked for the warning message

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
