### PR TITLE
Add metrics for sidecar resources

### DIFF
--- a/graylog2-server/src/main/java/org/graylog/plugins/sidecar/rest/resources/CollectorResource.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/sidecar/rest/resources/CollectorResource.java
@@ -16,6 +16,7 @@
  */
 package org.graylog.plugins.sidecar.rest.resources;
 
+import com.codahale.metrics.annotation.Timed;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.hash.Hashing;
 import io.swagger.annotations.Api;
@@ -123,6 +124,7 @@ public class CollectorResource extends RestResource implements PluginRestResourc
     }
 
     @GET
+    @Timed
     @RequiresPermissions(SidecarRestPermissions.COLLECTORS_READ)
     @Produces(MediaType.APPLICATION_JSON)
     @ApiOperation(value = "List all collectors")

--- a/graylog2-server/src/main/java/org/graylog/plugins/sidecar/rest/resources/ConfigurationResource.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/sidecar/rest/resources/ConfigurationResource.java
@@ -16,6 +16,7 @@
  */
 package org.graylog.plugins.sidecar.rest.resources;
 
+import com.codahale.metrics.annotation.Timed;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.hash.Hashing;
 import io.swagger.annotations.Api;
@@ -196,6 +197,7 @@ public class ConfigurationResource extends RestResource implements PluginRestRes
     }
 
     @GET
+    @Timed
     @Path("/render/{sidecarId}/{configurationId}")
     @Produces(MediaType.APPLICATION_JSON)
     @RequiresPermissions(SidecarRestPermissions.CONFIGURATIONS_READ)


### PR DESCRIPTION
These endpoints are used periodically by every sidecar.
It makes sense to have these metrics in case we want
to diagnose a performance bottle neck.
