### PR TITLE
Make truncating of messages in preview configurable

### DIFF
--- a/graylog2-web-interface/src/components/search/FieldAnalyzersSidebar.jsx
+++ b/graylog2-web-interface/src/components/search/FieldAnalyzersSidebar.jsx
@@ -17,10 +17,12 @@ class FieldAnalyzersSidebar extends React.Component {
     searchConfig: PropTypes.object.isRequired,
     selectedFields: PropTypes.object,
     shouldHighlight: PropTypes.bool,
+    shouldTruncate: PropTypes.bool,
     showAllFields: PropTypes.bool,
     showHighlightToggle: PropTypes.bool,
     togglePageFields: PropTypes.func,
     toggleShouldHighlight: PropTypes.func,
+    toggleShouldTruncate: PropTypes.func,
   };
 
   state = {
@@ -179,6 +181,13 @@ class FieldAnalyzersSidebar extends React.Component {
                onClick={this._showAllFields}>all fields</a>.
           </span>
           <br />
+          <Input id="truncate-results-checkbox"
+                 type="checkbox"
+                 bsSize="small"
+                 checked={this.props.shouldTruncate}
+                 onChange={this.props.toggleShouldTruncate}
+                 label="Truncate results"
+                 wrapperClassName="result-truncate-control" />
           {shouldHighlightToggle}
         </div>
       </div>

--- a/graylog2-web-interface/src/components/search/ResultTable.jsx
+++ b/graylog2-web-interface/src/components/search/ResultTable.jsx
@@ -16,6 +16,7 @@ class ResultTable extends React.Component {
   static propTypes = {
     disableSurroundingSearch: PropTypes.bool,
     highlight: PropTypes.bool.isRequired,
+    truncate: PropTypes.bool.isRequired,
     inputs: PropTypes.object.isRequired,
     messages: PropTypes.array.isRequired,
     nodes: PropTypes.object.isRequired,
@@ -192,6 +193,7 @@ class ResultTable extends React.Component {
                                        allStreams={this.state.allStreams}
                                        allStreamsLoaded={this.state.allStreamsLoaded}
                                        nodes={this.props.nodes}
+                                       truncate={this.props.truncate}
                                        highlight={this.props.highlight}
                                        highlightMessage={SearchStore.highlightMessage}
                                        expandAllRenderAsync={this.state.expandAllRenderAsync}

--- a/graylog2-web-interface/src/components/search/SearchResult.jsx
+++ b/graylog2-web-interface/src/components/search/SearchResult.jsx
@@ -156,10 +156,15 @@ class SearchResult extends React.Component {
     this.setState({ shouldHighlight: !this.state.shouldHighlight });
   };
 
+  _toggleShouldTruncate = () => {
+    this.setState({ shouldTruncate: !this.state.shouldTruncate });
+  };
+
   state = {
     selectedFields: this.sortFields(SearchStore.fields),
     showAllFields: false,
     shouldHighlight: true,
+    shouldTruncate: true,
     savedSearch: SearchStore.savedSearch,
   };
 
@@ -197,7 +202,9 @@ class SearchResult extends React.Component {
                          predefinedFieldSelection={this.predefinedFieldSelection}
                          showHighlightToggle={anyHighlightRanges}
                          shouldHighlight={this.state.shouldHighlight}
+                         shouldTruncate={this.state.shouldTruncate}
                          toggleShouldHighlight={this._toggleShouldHighlight}
+                         toggleShouldTruncate={this._toggleShouldTruncate}
                          currentSavedSearch={SearchStore.savedSearch}
                          searchInStream={this.props.searchInStream}
                          permissions={this.props.permissions}
@@ -225,6 +232,7 @@ class SearchResult extends React.Component {
                        streams={this.props.streams}
                        nodes={this.props.nodes}
                        highlight={this.state.shouldHighlight}
+                       truncate={this.state.shouldTruncate}
                        searchConfig={this.props.searchConfig} />
 
           {loadingIndicator}

--- a/graylog2-web-interface/src/components/search/SearchSidebar.jsx
+++ b/graylog2-web-interface/src/components/search/SearchSidebar.jsx
@@ -43,10 +43,12 @@ const SearchSidebar = createReactClass({
     searchInStream: PropTypes.object,
     selectedFields: PropTypes.object,
     shouldHighlight: PropTypes.bool,
+    shouldTruncate: PropTypes.bool,
     showAllFields: PropTypes.bool,
     showHighlightToggle: PropTypes.bool,
     togglePageFields: PropTypes.func,
     toggleShouldHighlight: PropTypes.func,
+    toggleShouldTruncate: PropTypes.func,
     loadingSearch: PropTypes.bool,
     searchConfig: PropTypes.object.isRequired,
   },
@@ -262,10 +264,12 @@ const SearchSidebar = createReactClass({
                                      searchConfig={this.props.searchConfig}
                                      selectedFields={this.props.selectedFields}
                                      shouldHighlight={this.props.shouldHighlight}
+                                     shouldTruncate={this.props.shouldTruncate}
                                      showAllFields={this.props.showAllFields}
                                      showHighlightToggle={this.props.showHighlightToggle}
                                      togglePageFields={this.props.togglePageFields}
-                                     toggleShouldHighlight={this.props.toggleShouldHighlight} />
+                                     toggleShouldHighlight={this.props.toggleShouldHighlight} 
+                                     toggleShouldTruncate={this.props.toggleShouldTruncate} />
             </Tab>
 
             <Tab eventKey={2} title={<h4>Decorators</h4>}>


### PR DESCRIPTION
Make truncating of messages in preview configurable

## Description

The truncating of messages in the preview makes it hard to find the actual log data. Searching for X, when X is a class/method in a long stack trace, wont' show up in the results page unless you click on the specific event, but then you have all the other fields to look through and you (I at least) get lost in all the noise.

## Motivation and Context

see above

## How Has This Been Tested?

Ran the web UI locally pointing to a running greylog backend, clicked on the toggle button a few times to makes sure short, null and long message were handled as I expected.

## Screenshots (if appropriate):

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly:  Graylog2/documentation#552
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
