### PR TITLE
Fix transport_email_use_ssl to actual default

### DIFF
--- a/misc/graylog.conf
+++ b/misc/graylog.conf
@@ -560,7 +560,7 @@ mongodb_threads_allowed_to_block_multiplier = 5
 
 # Use SMTP over SSL (SMTPS), see https://en.wikipedia.org/wiki/SMTPS
 # This is deprecated on most SMTP services!
-#transport_email_use_ssl = true
+#transport_email_use_ssl = false
 
 
 # Specify and uncomment this if you want to include links to the stream in your stream alert mails.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
`transport_email_use_ssl` default value is set to false in the code, this needs to be reflected in the server configuration as well.
 
See https://github.com/Graylog2/graylog2-server/blob/9e34d4ff9ee08951bbee9f8b788a3c70a7b0949d/graylog2-server/src/main/java/org/graylog2/configuration/EmailConfiguration.java#L43

## Description
<!--- Describe your changes in detail -->
Update comment in server configuration

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
