### PR TITLE
Fix checkboxes on lookup tables

### DIFF
--- a/graylog2-web-interface/src/components/common/TimeUnitInput.jsx
+++ b/graylog2-web-interface/src/components/common/TimeUnitInput.jsx
@@ -45,6 +45,8 @@ const TimeUnitInput = createReactClass({
     required: PropTypes.bool,
     /** Specifies if the input is enabled or disabled. */
     enabled: PropTypes.bool,
+    /** Indicates the default enabled state, in case the consumer does not want to handle the enabled state. */
+    defaultEnabled: PropTypes.bool,
     /** Specifies the value of the input. */
     value: PropTypes.number,
     /** Indicates the default value to use, in case value is not provided or set. */
@@ -68,7 +70,8 @@ const TimeUnitInput = createReactClass({
       label: '',
       help: '',
       required: false,
-      enabled: false,
+      enabled: undefined,
+      defaultEnabled: false,
       labelClassName: undefined,
       wrapperClassName: undefined,
     };
@@ -76,6 +79,7 @@ const TimeUnitInput = createReactClass({
 
   getInitialState() {
     return {
+      enabled: lodash.defaultTo(this.props.enabled, this.props.defaultEnabled),
       unitOptions: this._getUnitOptions(this.props.units),
     };
   },
@@ -97,7 +101,10 @@ const TimeUnitInput = createReactClass({
   },
 
   _isChecked() {
-    return this.props.required || this.props.enabled;
+    if (this.props.required) {
+      return this.props.required;
+    }
+    return lodash.defaultTo(this.props.enabled, this.state.enabled);
   },
 
   _propagateInput(update) {
@@ -111,7 +118,9 @@ const TimeUnitInput = createReactClass({
   },
 
   _onToggleEnable(e) {
-    this._propagateInput({ checked: e.target.checked });
+    const isChecked = e.target.checked;
+    this.setState({ enabled: isChecked });
+    this._propagateInput({ checked: isChecked });
   },
 
   _onUpdate(e) {

--- a/graylog2-web-interface/src/components/common/TimeUnitInput.test.jsx
+++ b/graylog2-web-interface/src/components/common/TimeUnitInput.test.jsx
@@ -1,0 +1,59 @@
+import React from 'react';
+import { mount } from 'enzyme';
+import TimeUnitInput from './TimeUnitInput';
+
+describe('<TimeUnitInput />', () => {
+  it('should have right default values from props', () => {
+    const onUpdate = (value, unit, checked) => {
+      expect(value).toBe(1);
+      expect(unit).toBe('SECONDS');
+      expect(checked).toBe(true);
+    };
+
+    const wrapper = mount(<TimeUnitInput update={onUpdate} />);
+    const checkbox = wrapper.find('input[type="checkbox"]');
+    expect(checkbox.prop('checked')).toBe(false);
+    expect(wrapper.find('input[type="number"]').prop('value')).toBe(1);
+    checkbox.simulate('click');
+  });
+
+  it('should use custom default values', () => {
+    const onUpdate = (value, unit, checked) => {
+      expect(value).toBe(42);
+      expect(unit).toBe('SECONDS');
+      expect(checked).toBe(false);
+    };
+
+    const wrapper = mount(<TimeUnitInput update={onUpdate} defaultValue={42} defaultEnabled />);
+    const checkbox = wrapper.find('input[type="checkbox"]');
+    expect(checkbox.prop('checked')).toBe(true);
+    expect(wrapper.find('input[type="number"]').prop('value')).toBe(42);
+    checkbox.simulate('click');
+  });
+
+  it('should use values before default values', () => {
+    const onUpdate = (value, unit, checked) => {
+      expect(value).toBe(124);
+      expect(unit).toBe('SECONDS');
+      expect(checked).toBe(true);
+    };
+
+    const wrapper = mount(<TimeUnitInput update={onUpdate} value={124} defaultValue={42} enabled={false} defaultEnabled />);
+    const checkbox = wrapper.find('input[type="checkbox"]');
+    expect(checkbox.prop('checked')).toBe(false);
+    expect(wrapper.find('input[type="number"]').prop('value')).toBe(124);
+    checkbox.simulate('click');
+  });
+
+  it('should use required before enabled and default enabled', () => {
+    const onUpdate = (value, unit, checked) => {
+      expect(value).toBe(42);
+      expect(unit).toBe('SECONDS');
+      expect(checked).toBe(true);
+    };
+
+    const wrapper = mount(<TimeUnitInput update={onUpdate} required enabled={false} defaultEnabled={false} />);
+    expect(wrapper.find('input[type="checkbox"]').length).toBe(0);
+    wrapper.find('input[type="number"]').simulate('change', { target: { value: 42 } });
+  });
+});

--- a/graylog2-web-interface/src/components/lookup-tables/caches/GuavaCacheFieldSet.jsx
+++ b/graylog2-web-interface/src/components/lookup-tables/caches/GuavaCacheFieldSet.jsx
@@ -10,9 +10,9 @@ class GuavaCacheFieldSet extends React.Component {
     config: PropTypes.object.isRequired,
     updateConfig: PropTypes.func.isRequired,
     handleFormEvent: PropTypes.func.isRequired,
-// eslint-disable-next-line react/no-unused-prop-types
+    // eslint-disable-next-line react/no-unused-prop-types
     validationState: PropTypes.func.isRequired,
-// eslint-disable-next-line react/no-unused-prop-types
+    // eslint-disable-next-line react/no-unused-prop-types
     validationMessage: PropTypes.func.isRequired,
   };
 
@@ -29,10 +29,6 @@ class GuavaCacheFieldSet extends React.Component {
 
   updateAfterWrite = (value, unit, enabled) => {
     this._update(value, unit, enabled, 'expire_after_write');
-  };
-
-  updateRefresh = (value, unit, enabled) => {
-    this._update(value, unit, enabled, 'refresh_after_write');
   };
 
   render() {
@@ -55,7 +51,7 @@ class GuavaCacheFieldSet extends React.Component {
                      update={this.updateAfterAccess}
                      value={config.expire_after_access}
                      unit={config.expire_after_access_unit || 'SECONDS'}
-                     enabled={config.expire_after_access > 0}
+                     defaultEnabled={config.expire_after_access > 0}
                      labelClassName="col-sm-3"
                      wrapperClassName="col-sm-9" />
       <TimeUnitInput label="Expire after write"
@@ -63,7 +59,7 @@ class GuavaCacheFieldSet extends React.Component {
                      update={this.updateAfterWrite}
                      value={config.expire_after_write}
                      unit={config.expire_after_write_unit || 'SECONDS'}
-                     enabled={config.expire_after_write > 0}
+                     defaultEnabled={config.expire_after_write > 0}
                      labelClassName="col-sm-3"
                      wrapperClassName="col-sm-9" />
     </fieldset>);

--- a/graylog2-web-interface/src/components/maps/adapter/MaxmindAdapterFieldSet.jsx
+++ b/graylog2-web-interface/src/components/maps/adapter/MaxmindAdapterFieldSet.jsx
@@ -8,7 +8,6 @@ import { Select, TimeUnitInput } from 'components/common';
 class MaxmindAdapterFieldSet extends React.Component {
   static propTypes = {
     config: PropTypes.object.isRequired,
-// eslint-disable-next-line react/no-unused-prop-types
     updateConfig: PropTypes.func.isRequired,
     handleFormEvent: PropTypes.func.isRequired,
     validationState: PropTypes.func.isRequired,
@@ -70,7 +69,7 @@ class MaxmindAdapterFieldSet extends React.Component {
                      update={this.updateCheckInterval}
                      value={config.check_interval}
                      unit={config.check_interval_unit || 'MINUTES'}
-                     enabled={config.check_interval > 0}
+                     defaultEnabled={config.check_interval > 0}
                      labelClassName="col-sm-3"
                      wrapperClassName="col-sm-9" />
     </fieldset>);


### PR DESCRIPTION
Lookup table components do not always keep the enabled state, as the `TimeUnitInput` component did that for them before https://github.com/Graylog2/graylog2-server/pull/5077.

This PR introduces a `defaultEnabled` prop, that let consumers use the component in an uncontrolled way, similarly to React inputs.

Fixes #5658
