### PR TITLE
Fix slow loading UI after server startup

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/shared/initializers/JerseyService.java
+++ b/graylog2-server/src/main/java/org/graylog2/shared/initializers/JerseyService.java
@@ -54,6 +54,7 @@ import org.graylog2.shared.rest.exceptionmappers.BadRequestExceptionMapper;
 import org.graylog2.shared.rest.exceptionmappers.JacksonPropertyExceptionMapper;
 import org.graylog2.shared.rest.exceptionmappers.JsonProcessingExceptionMapper;
 import org.graylog2.shared.rest.exceptionmappers.WebApplicationExceptionMapper;
+import org.graylog2.shared.security.ShiroSecurityContextFilter;
 import org.graylog2.shared.security.tls.KeyStoreUtils;
 import org.graylog2.shared.security.tls.PemKeyStore;
 import org.slf4j.Logger;
@@ -240,6 +241,7 @@ public class JerseyService extends AbstractIdleService {
                 .register(new PrefixAddingModelProcessor(packagePrefixes))
                 .register(new AuditEventModelProcessor(pluginAuditEventTypes))
                 .registerClasses(
+                        ShiroSecurityContextFilter.class,
                         VerboseCsrfProtectionFilter.class,
                         JacksonJaxbJsonProvider.class,
                         JsonProcessingExceptionMapper.class,

--- a/graylog2-server/src/main/java/org/graylog2/shared/security/ShiroSecurityBinding.java
+++ b/graylog2-server/src/main/java/org/graylog2/shared/security/ShiroSecurityBinding.java
@@ -29,6 +29,10 @@ import javax.ws.rs.container.ResourceInfo;
 import javax.ws.rs.core.FeatureContext;
 import java.lang.reflect.Method;
 
+// Attention!
+// Don't register Providers such as ContainerRequestFilter in DynamicFeature.
+// This will get Jersey to create a ServiceLocator for every existing Resource.
+// Each ServiceLocator will have its own Guice/HK2 Bridge, which is very very inefficient!
 public class ShiroSecurityBinding implements DynamicFeature {
     private static final Logger LOG = LoggerFactory.getLogger(ShiroSecurityBinding.class);
 
@@ -36,8 +40,6 @@ public class ShiroSecurityBinding implements DynamicFeature {
     public void configure(ResourceInfo resourceInfo, FeatureContext context) {
         final Class<?> resourceClass = resourceInfo.getResourceClass();
         final Method resourceMethod = resourceInfo.getResourceMethod();
-
-        context.register(ShiroSecurityContextFilter.class);
 
         if (resourceMethod.isAnnotationPresent(RequiresAuthentication.class) || resourceClass.isAnnotationPresent(RequiresAuthentication.class)) {
             if (resourceMethod.isAnnotationPresent(RequiresGuest.class)) {

--- a/graylog2-server/src/main/java/org/graylog2/shared/security/ShiroSecurityContextFilter.java
+++ b/graylog2-server/src/main/java/org/graylog2/shared/security/ShiroSecurityContextFilter.java
@@ -43,7 +43,8 @@ import java.util.Set;
 
 import static java.util.Objects.requireNonNull;
 
-@Priority(Priorities.AUTHENTICATION)
+// Give this a higher priority so it's run before the authentication filter
+@Priority(Priorities.AUTHENTICATION - 10)
 public class ShiroSecurityContextFilter implements ContainerRequestFilter {
     public static final String REQUEST_HEADERS = "REQUEST_HEADERS";
     private final DefaultSecurityManager securityManager;


### PR DESCRIPTION
Avoid registering ShiroSecurityContextFilter as a DynamicFeature.
Doing so, triggers Jersey to create a ServiceLocator for all
existing (~1600) Resources. [1]
Furthermore, each created ServiceLocator will have its own Guice/HK2 Bridge,
whose JIT resolver cache is cold upon startup and needs to be filled.

Instead of registering the ShiroSecurityContextFilter dynamically, we
register it statically in the JerseyService because every Resource is filtered
through it anyway.
We need to give it a higher priority so it's executed before the authentication filter.

[1]
https://github.com/jersey/jersey/blob/2.25.1/core-server/src/main/java/org/glassfish/jersey/server/model/ResourceMethodInvoker.java#L187
