### PR TITLE
Server changes for Forwarder

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/initializers/OutputSetupService.java
+++ b/graylog2-server/src/main/java/org/graylog2/initializers/OutputSetupService.java
@@ -22,6 +22,7 @@ import com.google.common.util.concurrent.AbstractIdleService;
 import com.google.common.util.concurrent.ThreadFactoryBuilder;
 import org.graylog2.outputs.OutputRegistry;
 import org.graylog2.plugin.outputs.MessageOutput;
+import org.graylog2.system.shutdown.GracefulShutdownHook;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -64,6 +65,12 @@ public class OutputSetupService extends AbstractIdleService {
 
     private void shutDownRunningOutputs() {
         for (MessageOutput output : outputRegistry.getMessageOutputs()) {
+
+            // Do not execute the stop() method for Outputs that implement the GracefulShutdown mechanism.
+            if (output instanceof GracefulShutdownHook) {
+                continue;
+            }
+
             try {
                 // TODO: change to debug
                 LOG.info("Stopping output {}", output.getClass().getName());

--- a/graylog2-server/src/main/java/org/graylog2/outputs/MessageOutputFactory.java
+++ b/graylog2-server/src/main/java/org/graylog2/outputs/MessageOutputFactory.java
@@ -48,7 +48,7 @@ public class MessageOutputFactory {
 
         Preconditions.checkArgument(factory != null, "Output type is not supported: %s!", outputType);
 
-        return factory.create(stream, configuration);
+        return factory.create(output, stream, configuration);
     }
 
 

--- a/graylog2-server/src/main/java/org/graylog2/outputs/MessageOutputFactory.java
+++ b/graylog2-server/src/main/java/org/graylog2/outputs/MessageOutputFactory.java
@@ -54,6 +54,8 @@ public class MessageOutputFactory {
         final MessageOutput.Factory2<? extends MessageOutput> factory2 = this.availableOutputs2.get(outputType);
         final MessageOutput.Factory<? extends MessageOutput> factory = this.availableOutputs.get(outputType);
 
+        // If the same outputType value exists in both output factory maps for some reason, we want to prefer the
+        // one that is using the more recent interface.
         if (factory2 != null) {
             return factory2.create(output, stream, configuration);
         } else if (factory != null) {

--- a/graylog2-server/src/main/java/org/graylog2/plugin/GlobalMetricNames.java
+++ b/graylog2-server/src/main/java/org/graylog2/plugin/GlobalMetricNames.java
@@ -22,6 +22,7 @@ public final class GlobalMetricNames {
 
     private GlobalMetricNames() {}
 
+    public static final String OLDEST_SEGMENT_SUFFIX = "oldest-segment";
     public static final String RATE_SUFFIX = "1-sec-rate";
 
     public static final String INPUT_THROUGHPUT = "org.graylog2.throughput.input";
@@ -50,5 +51,5 @@ public final class GlobalMetricNames {
     public static final String JOURNAL_SIZE = "org.graylog2.journal.size";
     public static final String JOURNAL_SIZE_LIMIT = "org.graylog2.journal.size-limit";
     public static final String JOURNAL_UTILIZATION_RATIO = "org.graylog2.journal.utilization-ratio";
-    public static final String JOURNAL_OLDEST_SEGMENT = "org.graylog2.journal.oldest-segment";
+    public static final String JOURNAL_OLDEST_SEGMENT = name("org.graylog2.journal", OLDEST_SEGMENT_SUFFIX);
 }

--- a/graylog2-server/src/main/java/org/graylog2/plugin/GlobalMetricNames.java
+++ b/graylog2-server/src/main/java/org/graylog2/plugin/GlobalMetricNames.java
@@ -50,4 +50,5 @@ public final class GlobalMetricNames {
     public static final String JOURNAL_SIZE = "org.graylog2.journal.size";
     public static final String JOURNAL_SIZE_LIMIT = "org.graylog2.journal.size-limit";
     public static final String JOURNAL_UTILIZATION_RATIO = "org.graylog2.journal.utilization-ratio";
+    public static final String JOURNAL_OLDEST_SEGMENT = "org.graylog2.journal.oldest-segment";
 }

--- a/graylog2-server/src/main/java/org/graylog2/plugin/GlobalMetricNames.java
+++ b/graylog2-server/src/main/java/org/graylog2/plugin/GlobalMetricNames.java
@@ -50,6 +50,4 @@ public final class GlobalMetricNames {
     public static final String JOURNAL_SIZE = "org.graylog2.journal.size";
     public static final String JOURNAL_SIZE_LIMIT = "org.graylog2.journal.size-limit";
     public static final String JOURNAL_UTILIZATION_RATIO = "org.graylog2.journal.utilization-ratio";
-    public static final String JOURNAL_OLDEST_SEGMENT = "org.graylog2.journal.oldest-segment";
-
 }

--- a/graylog2-server/src/main/java/org/graylog2/plugin/PluginModule.java
+++ b/graylog2-server/src/main/java/org/graylog2/plugin/PluginModule.java
@@ -94,13 +94,24 @@ public abstract class PluginModule extends Graylog2Module {
         serviceBinder.addBinding().to(initializerClass);
     }
 
+    // This should only be used by plugins that have been built before Graylog 3.0.1.
+    // See comments in MessageOutput.Factory and MessageOutput.Factory2 for details
     protected void addMessageOutput(Class<? extends MessageOutput> messageOutputClass) {
         installOutput(outputsMapBinder(), messageOutputClass);
     }
 
+    // This should only be used by plugins that have been built before Graylog 3.0.1.
+    // See comments in MessageOutput.Factory and MessageOutput.Factory2 for details
     protected <T extends MessageOutput> void addMessageOutput(Class<T> messageOutputClass,
                                                               Class<? extends MessageOutput.Factory<T>> factory) {
         installOutput(outputsMapBinder(), messageOutputClass, factory);
+    }
+
+    // This should be used by plugins that have been built for 3.0.1 or later.
+    // See comments in MessageOutput.Factory and MessageOutput.Factory2 for details
+    protected <T extends MessageOutput> void addMessageOutput2(Class<T> messageOutputClass,
+                                                              Class<? extends MessageOutput.Factory2<T>> factory) {
+        installOutput2(outputsMapBinder2(), messageOutputClass, factory);
     }
 
     protected void addRestResource(Class<? extends PluginRestResource> restResourceClass) {

--- a/graylog2-server/src/main/java/org/graylog2/plugin/inject/Graylog2Module.java
+++ b/graylog2-server/src/main/java/org/graylog2/plugin/inject/Graylog2Module.java
@@ -241,6 +241,8 @@ public abstract class Graylog2Module extends AbstractModule {
         installInput(inputMapBinder, target, factoryClass);
     }
 
+    // This should only be used by plugins that have been built before Graylog 3.0.1.
+    // See comments in MessageOutput.Factory and MessageOutput.Factory2 for details
     protected MapBinder<String, MessageOutput.Factory<? extends MessageOutput>> outputsMapBinder() {
         return MapBinder.newMapBinder(binder(),
                 TypeLiteral.get(String.class),
@@ -248,9 +250,29 @@ public abstract class Graylog2Module extends AbstractModule {
                 });
     }
 
+    // This should only be used by plugins that have been built before Graylog 3.0.1.
+    // See comments in MessageOutput.Factory and MessageOutput.Factory2 for details
     protected <T extends MessageOutput> void installOutput(MapBinder<String, MessageOutput.Factory<? extends MessageOutput>> outputMapBinder,
                                                            Class<T> target,
                                                            Class<? extends MessageOutput.Factory<T>> targetFactory) {
+        install(new FactoryModuleBuilder().implement(MessageOutput.class, target).build(targetFactory));
+        outputMapBinder.addBinding(target.getCanonicalName()).to(Key.get(targetFactory));
+    }
+
+    // This should be used by plugins that have been built for 3.0.1 or later.
+    // See comments in MessageOutput.Factory and MessageOutput.Factory2 for details
+    protected MapBinder<String, MessageOutput.Factory2<? extends MessageOutput>> outputsMapBinder2() {
+        return MapBinder.newMapBinder(binder(),
+                TypeLiteral.get(String.class),
+                new TypeLiteral<MessageOutput.Factory2<? extends MessageOutput>>() {
+                });
+    }
+
+    // This should be used by plugins that have been built for 3.0.1 or later.
+    // See comments in MessageOutput.Factory and MessageOutput.Factory2 for details
+    protected <T extends MessageOutput> void installOutput2(MapBinder<String, MessageOutput.Factory2<? extends MessageOutput>> outputMapBinder,
+                                                           Class<T> target,
+                                                           Class<? extends MessageOutput.Factory2<T>> targetFactory) {
         install(new FactoryModuleBuilder().implement(MessageOutput.class, target).build(targetFactory));
         outputMapBinder.addBinding(target.getCanonicalName()).to(Key.get(targetFactory));
     }

--- a/graylog2-server/src/main/java/org/graylog2/plugin/outputs/MessageOutput.java
+++ b/graylog2-server/src/main/java/org/graylog2/plugin/outputs/MessageOutput.java
@@ -21,6 +21,7 @@ import org.graylog2.plugin.Message;
 import org.graylog2.plugin.Stoppable;
 import org.graylog2.plugin.configuration.Configuration;
 import org.graylog2.plugin.configuration.ConfigurationRequest;
+import org.graylog2.plugin.streams.Output;
 import org.graylog2.plugin.streams.Stream;
 
 import java.util.List;
@@ -28,6 +29,12 @@ import java.util.List;
 public interface MessageOutput extends Stoppable {
     interface Factory<T> {
         T create(Stream stream, Configuration configuration);
+
+        // Backwards compatible.
+        default T create(Output output, Stream stream, Configuration configuration) {
+
+            return create(stream, configuration);
+        }
         Config getConfig();
         Descriptor getDescriptor();
     }

--- a/graylog2-server/src/main/java/org/graylog2/plugin/outputs/MessageOutput.java
+++ b/graylog2-server/src/main/java/org/graylog2/plugin/outputs/MessageOutput.java
@@ -27,14 +27,19 @@ import org.graylog2.plugin.streams.Stream;
 import java.util.List;
 
 public interface MessageOutput extends Stoppable {
+    // This factory is implemented by output plugins that have been built before Graylog 3.0.1.
+    // We have to keep it around to make sure older plugins still load with Graylog >=3.0.1.
+    // It can be removed once we decide to stop supporting old plugins.
     interface Factory<T> {
         T create(Stream stream, Configuration configuration);
+        Config getConfig();
+        Descriptor getDescriptor();
+    }
 
-        // Backwards compatible.
-        default T create(Output output, Stream stream, Configuration configuration) {
-
-            return create(stream, configuration);
-        }
+    // This is the factory that should be implemented by output plugins which target Graylog 3.0.1 and later.
+    // The only change compared to Factory is that it also takes the Output instance parameter.
+    interface Factory2<T> {
+        T create(Output output, Stream stream, Configuration configuration);
         Config getConfig();
         Descriptor getDescriptor();
     }

--- a/graylog2-server/src/main/java/org/graylog2/shared/journal/KafkaJournal.java
+++ b/graylog2-server/src/main/java/org/graylog2/shared/journal/KafkaJournal.java
@@ -342,14 +342,16 @@ public class KafkaJournal extends AbstractIdleService implements Journal {
     }
 
     private void setupKafkaLogMetrics(final MetricRegistry metricRegistry) {
-        metricRegistry.register(name(KafkaJournal.class, "size"), (Gauge<Long>) kafkaLog::size);
-        metricRegistry.register(name(KafkaJournal.class, "logEndOffset"), (Gauge<Long>) kafkaLog::logEndOffset);
-        metricRegistry.register(name(KafkaJournal.class, "numberOfSegments"), (Gauge<Integer>) kafkaLog::numberOfSegments);
-        metricRegistry.register(name(KafkaJournal.class, "unflushedMessages"), (Gauge<Long>) kafkaLog::unflushedMessages);
-        metricRegistry.register(name(KafkaJournal.class, "recoveryPoint"), (Gauge<Long>) kafkaLog::recoveryPoint);
-        metricRegistry.register(name(KafkaJournal.class, "lastFlushTime"), (Gauge<Long>) kafkaLog::lastFlushTime);
+        metricRegistry.register(name(this.getClass(), "size"), (Gauge<Long>) kafkaLog::size);
+        metricRegistry.register(name(this.getClass(), "logEndOffset"), (Gauge<Long>) kafkaLog::logEndOffset);
+        metricRegistry.register(name(this.getClass(), "numberOfSegments"), (Gauge<Integer>) kafkaLog::numberOfSegments);
+        metricRegistry.register(name(this.getClass(), "unflushedMessages"), (Gauge<Long>) kafkaLog::unflushedMessages);
+        metricRegistry.register(name(this.getClass(), "recoveryPoint"), (Gauge<Long>) kafkaLog::recoveryPoint);
+        metricRegistry.register(name(this.getClass(), "lastFlushTime"), (Gauge<Long>) kafkaLog::lastFlushTime);
         // must not be a lambda, because the serialization cannot determine the proper Metric type :(
-        metricRegistry.register(GlobalMetricNames.JOURNAL_OLDEST_SEGMENT, (Gauge<Date>) new Gauge<Date>() {
+
+        // TODO Dan: Verify that it's ok to change this metric name in order to support subclass instances of KafkaJournal
+        metricRegistry.register(name(this.getClass(), "oldest-segment"), (Gauge<Date>) new Gauge<Date>() {
             @Override
             public Date getValue() {
                 long oldestSegment = Long.MAX_VALUE;

--- a/graylog2-server/src/main/java/org/graylog2/shared/journal/KafkaJournal.java
+++ b/graylog2-server/src/main/java/org/graylog2/shared/journal/KafkaJournal.java
@@ -350,7 +350,7 @@ public class KafkaJournal extends AbstractIdleService implements Journal {
         metricRegistry.register(name(this.getClass(), "lastFlushTime"), (Gauge<Long>) kafkaLog::lastFlushTime);
         // must not be a lambda, because the serialization cannot determine the proper Metric type :(
 
-        // TODO Dan: Verify that it's ok to change this metric name in order to support subclass instances of KafkaJournal
+        // TODO Dan: Verify that it's ok to change this metric name in order to support multiple instances of KafkaJournal)
         metricRegistry.register(name(this.getClass(), "oldest-segment"), (Gauge<Date>) new Gauge<Date>() {
             @Override
             public Date getValue() {

--- a/graylog2-server/src/main/java/org/graylog2/shared/journal/KafkaJournal.java
+++ b/graylog2-server/src/main/java/org/graylog2/shared/journal/KafkaJournal.java
@@ -374,7 +374,7 @@ public class KafkaJournal extends AbstractIdleService implements Journal {
          * for instances. */
         String journalOldestSegmentMetricName = GlobalMetricNames.JOURNAL_OLDEST_SEGMENT;
         if (!KafkaJournal.class.getName().equals(journalOldestSegmentMetricName)) {
-            journalOldestSegmentMetricName = name(metricPrefix, "oldest-segment");
+            journalOldestSegmentMetricName = name(metricPrefix, GlobalMetricNames.OLDEST_SEGMENT_SUFFIX);
         }
 
         // must not be a lambda, because the serialization cannot determine the proper Metric type :(

--- a/graylog2-server/src/main/java/org/graylog2/shared/journal/KafkaJournal.java
+++ b/graylog2-server/src/main/java/org/graylog2/shared/journal/KafkaJournal.java
@@ -374,7 +374,7 @@ public class KafkaJournal extends AbstractIdleService implements Journal {
          * for instances. */
         String journalOldestSegmentMetricName = GlobalMetricNames.JOURNAL_OLDEST_SEGMENT;
         if (!KafkaJournal.class.getName().equals(journalOldestSegmentMetricName)) {
-            journalOldestSegmentMetricName = metricPrefix;
+            journalOldestSegmentMetricName = name(metricPrefix, "oldest-segment");
         }
 
         // must not be a lambda, because the serialization cannot determine the proper Metric type :(

--- a/graylog2-server/src/main/java/org/graylog2/shared/journal/KafkaJournal.java
+++ b/graylog2-server/src/main/java/org/graylog2/shared/journal/KafkaJournal.java
@@ -373,7 +373,7 @@ public class KafkaJournal extends AbstractIdleService implements Journal {
          * of KafkaJournal. This is an override to provide the old metric name for the input journal, and unique names
          * for instances. */
         String journalOldestSegmentMetricName = GlobalMetricNames.JOURNAL_OLDEST_SEGMENT;
-        if (!KafkaJournal.class.getName().equals(journalOldestSegmentMetricName)) {
+        if (!KafkaJournal.class.getName().equals(metricPrefix)) {
             journalOldestSegmentMetricName = name(metricPrefix, GlobalMetricNames.OLDEST_SEGMENT_SUFFIX);
         }
 

--- a/graylog2-server/src/test/java/org/graylog2/contentpacks/ContentPackServiceTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/contentpacks/ContentPackServiceTest.java
@@ -97,6 +97,7 @@ public class ContentPackServiceTest {
     private ContentPackService contentPackService;
     private Set<PluginMetaData> pluginMetaData;
     private Map<String, MessageOutput.Factory<? extends MessageOutput>> outputFactories;
+    private Map<String, MessageOutput.Factory2<? extends MessageOutput>> outputFactories2;
 
     private ContentPackV1 contentPack;
     private ContentPackInstallation contentPackInstallation;
@@ -110,10 +111,11 @@ public class ContentPackServiceTest {
         final Set<ConstraintChecker> constraintCheckers = Collections.emptySet();
         pluginMetaData = new HashSet<>();
         outputFactories = new HashMap<>();
+        outputFactories2 = new HashMap<>();
         final Map<ModelType, EntityFacade<?>> entityFacades = ImmutableMap.of(
                 ModelTypes.GROK_PATTERN_V1, new GrokPatternFacade(objectMapper, patternService),
                 ModelTypes.STREAM_V1, new StreamFacade(objectMapper, streamService, streamRuleService, alertService, alarmCallbackConfigurationService, new HashSet<>(), indexSetService),
-                ModelTypes.OUTPUT_V1, new OutputFacade(objectMapper, outputService, pluginMetaData, outputFactories)
+                ModelTypes.OUTPUT_V1, new OutputFacade(objectMapper, outputService, pluginMetaData, outputFactories, outputFactories2)
         );
 
         contentPackService = new ContentPackService(contentPackInstallationPersistenceService, constraintCheckers, entityFacades);

--- a/graylog2-server/src/test/java/org/graylog2/contentpacks/facades/OutputFacadeTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/contentpacks/facades/OutputFacadeTest.java
@@ -89,18 +89,20 @@ public class OutputFacadeTest {
     private OutputService outputService;
     private OutputFacade facade;
     private Map<String, MessageOutput.Factory<? extends MessageOutput>> outputFactories;
+    private Map<String, MessageOutput.Factory2<? extends MessageOutput>> outputFactories2;
 
     @Before
     public void setUp() throws Exception {
         outputService = new OutputServiceImpl(mongoRule.getMongoConnection(), new MongoJackObjectMapperProvider(objectMapper), streamService, outputRegistry);
         pluginMetaData = new HashSet<>();
         outputFactories = new HashMap<>();
+        outputFactories2 = new HashMap<>();
         final LoggingOutput.Factory factory = mock(LoggingOutput.Factory.class);
         final LoggingOutput.Descriptor descriptor = mock(LoggingOutput.Descriptor.class);
         when(factory.getDescriptor()).thenReturn(descriptor);
         outputFactories.put("org.graylog2.outputs.LoggingOutput", factory);
 
-        facade = new OutputFacade(objectMapper, outputService, pluginMetaData, outputFactories);
+        facade = new OutputFacade(objectMapper, outputService, pluginMetaData, outputFactories, outputFactories2);
     }
 
     @Test

--- a/graylog2-server/src/test/java/org/graylog2/outputs/MessageOutputFactoryTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/outputs/MessageOutputFactoryTest.java
@@ -38,16 +38,18 @@ public class MessageOutputFactoryTest {
     public final MockitoRule mockitoRule = MockitoJUnit.rule();
 
     private final Map<String, MessageOutput.Factory<? extends MessageOutput>> availableOutputs;
+    private final Map<String, MessageOutput.Factory2<? extends MessageOutput>> availableOutputs2;
 
     private MessageOutputFactory messageOutputFactory;
 
     public MessageOutputFactoryTest() {
         this.availableOutputs = Maps.newHashMap();
+        this.availableOutputs2 = Maps.newHashMap();
     }
 
     @Before
     public void setUp() throws Exception {
-        this.messageOutputFactory = new MessageOutputFactory(availableOutputs);
+        this.messageOutputFactory = new MessageOutputFactory(availableOutputs, availableOutputs2);
     }
 
     @Test(expected = IllegalArgumentException.class)

--- a/graylog2-server/src/test/java/org/graylog2/shared/journal/KafkaJournalTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/shared/journal/KafkaJournalTest.java
@@ -105,16 +105,17 @@ public class KafkaJournalTest {
     @Test
     public void writeAndRead() throws IOException {
         final Journal journal = new KafkaJournal(journalDirectory.toPath(),
-                scheduler,
-                Size.megabytes(100L),
-                Duration.standardHours(1),
-                Size.megabytes(5L),
-                Duration.standardHours(1),
-                1_000_000,
-                Duration.standardMinutes(1),
-                100,
-                new MetricRegistry(),
-                serverStatus);
+                                                 scheduler,
+                                                 Size.megabytes(100L),
+                                                 Duration.standardHours(1),
+                                                 Size.megabytes(5L),
+                                                 Duration.standardHours(1),
+                                                 1_000_000,
+                                                 Duration.standardMinutes(1),
+                                                 100,
+                                                 new MetricRegistry(),
+                                                 serverStatus,
+                                                 null);
 
         final byte[] idBytes = "id".getBytes(UTF_8);
         final byte[] messageBytes = "message".getBytes(UTF_8);
@@ -130,16 +131,17 @@ public class KafkaJournalTest {
     @Test
     public void readAtLeastOne() throws Exception {
         final Journal journal = new KafkaJournal(journalDirectory.toPath(),
-                scheduler,
-                Size.megabytes(100L),
-                Duration.standardHours(1),
-                Size.megabytes(5L),
-                Duration.standardHours(1),
-                1_000_000,
-                Duration.standardMinutes(1),
-                100,
-                new MetricRegistry(),
-                serverStatus);
+                                                 scheduler,
+                                                 Size.megabytes(100L),
+                                                 Duration.standardHours(1),
+                                                 Size.megabytes(5L),
+                                                 Duration.standardHours(1),
+                                                 1_000_000,
+                                                 Duration.standardMinutes(1),
+                                                 100,
+                                                 new MetricRegistry(),
+                                                 serverStatus,
+                                                 null);
 
         final byte[] idBytes = "id".getBytes(UTF_8);
         final byte[] messageBytes = "message1".getBytes(UTF_8);
@@ -186,16 +188,17 @@ public class KafkaJournalTest {
     public void maxSegmentSize() throws Exception {
         final Size segmentSize = Size.kilobytes(1L);
         final KafkaJournal journal = new KafkaJournal(journalDirectory.toPath(),
-                scheduler,
-                segmentSize,
-                Duration.standardHours(1),
-                Size.kilobytes(10L),
-                Duration.standardDays(1),
-                1_000_000,
-                Duration.standardMinutes(1),
-                100,
-                new MetricRegistry(),
-                serverStatus);
+                                                      scheduler,
+                                                      segmentSize,
+                                                      Duration.standardHours(1),
+                                                      Size.kilobytes(10L),
+                                                      Duration.standardDays(1),
+                                                      1_000_000,
+                                                      Duration.standardMinutes(1),
+                                                      100,
+                                                      new MetricRegistry(),
+                                                      serverStatus,
+                                                      null);
 
         long size = 0L;
         long maxSize = segmentSize.toBytes();
@@ -218,16 +221,17 @@ public class KafkaJournalTest {
     public void maxMessageSize() throws Exception {
         final Size segmentSize = Size.kilobytes(1L);
         final KafkaJournal journal = new KafkaJournal(journalDirectory.toPath(),
-                scheduler,
-                segmentSize,
-                Duration.standardHours(1),
-                Size.kilobytes(10L),
-                Duration.standardDays(1),
-                1_000_000,
-                Duration.standardMinutes(1),
-                100,
-                new MetricRegistry(),
-                serverStatus);
+                                                      scheduler,
+                                                      segmentSize,
+                                                      Duration.standardHours(1),
+                                                      Size.kilobytes(10L),
+                                                      Duration.standardDays(1),
+                                                      1_000_000,
+                                                      Duration.standardMinutes(1),
+                                                      100,
+                                                      new MetricRegistry(),
+                                                      serverStatus,
+                                                      null);
 
         long size = 0L;
         long maxSize = segmentSize.toBytes();
@@ -258,16 +262,17 @@ public class KafkaJournalTest {
     public void segmentRotation() throws Exception {
         final Size segmentSize = Size.kilobytes(1L);
         final KafkaJournal journal = new KafkaJournal(journalDirectory.toPath(),
-                scheduler,
-                segmentSize,
-                Duration.standardHours(1),
-                Size.kilobytes(10L),
-                Duration.standardDays(1),
-                1_000_000,
-                Duration.standardMinutes(1),
-                100,
-                new MetricRegistry(),
-                serverStatus);
+                                                      scheduler,
+                                                      segmentSize,
+                                                      Duration.standardHours(1),
+                                                      Size.kilobytes(10L),
+                                                      Duration.standardDays(1),
+                                                      1_000_000,
+                                                      Duration.standardMinutes(1),
+                                                      100,
+                                                      new MetricRegistry(),
+                                                      serverStatus,
+                                                      null);
 
         createBulkChunks(journal, segmentSize, 3);
 
@@ -276,10 +281,10 @@ public class KafkaJournalTest {
         assertTrue("there should be files in the journal directory", files.length > 0);
 
         final File[] messageJournalDir = journalDirectory.listFiles((FileFilter) and(directoryFileFilter(),
-                nameFileFilter("messagejournal-0")));
+                                                                                     nameFileFilter("messagejournal-0")));
         assertTrue(messageJournalDir.length == 1);
         final File[] logFiles = messageJournalDir[0].listFiles((FileFilter) and(fileFileFilter(),
-                suffixFileFilter(".log")));
+                                                                                suffixFileFilter(".log")));
         assertEquals("should have two journal segments", 3, logFiles.length);
     }
 
@@ -287,16 +292,17 @@ public class KafkaJournalTest {
     public void segmentSizeCleanup() throws Exception {
         final Size segmentSize = Size.kilobytes(1L);
         final KafkaJournal journal = new KafkaJournal(journalDirectory.toPath(),
-                scheduler,
-                segmentSize,
-                Duration.standardHours(1),
-                Size.kilobytes(1L),
-                Duration.standardDays(1),
-                1_000_000,
-                Duration.standardMinutes(1),
-                100,
-                new MetricRegistry(),
-                serverStatus);
+                                                      scheduler,
+                                                      segmentSize,
+                                                      Duration.standardHours(1),
+                                                      Size.kilobytes(1L),
+                                                      Duration.standardDays(1),
+                                                      1_000_000,
+                                                      Duration.standardMinutes(1),
+                                                      100,
+                                                      new MetricRegistry(),
+                                                      serverStatus,
+                                                      null);
         final File messageJournalDir = new File(journalDirectory, "messagejournal-0");
         assertTrue(messageJournalDir.exists());
 
@@ -323,16 +329,17 @@ public class KafkaJournalTest {
         try {
             final Size segmentSize = Size.kilobytes(1L);
             final KafkaJournal journal = new KafkaJournal(journalDirectory.toPath(),
-                    scheduler,
-                    segmentSize,
-                    Duration.standardHours(1),
-                    Size.kilobytes(10L),
-                    Duration.standardMinutes(1),
-                    1_000_000,
-                    Duration.standardMinutes(1),
-                    100,
-                    new MetricRegistry(),
-                    serverStatus);
+                                                          scheduler,
+                                                          segmentSize,
+                                                          Duration.standardHours(1),
+                                                          Size.kilobytes(10L),
+                                                          Duration.standardMinutes(1),
+                                                          1_000_000,
+                                                          Duration.standardMinutes(1),
+                                                          100,
+                                                          new MetricRegistry(),
+                                                          serverStatus,
+                                                          null);
             final File messageJournalDir = new File(journalDirectory, "messagejournal-0");
             assertTrue(messageJournalDir.exists());
 
@@ -377,16 +384,17 @@ public class KafkaJournalTest {
     public void segmentCommittedCleanup() throws Exception {
         final Size segmentSize = Size.kilobytes(1L);
         final KafkaJournal journal = new KafkaJournal(journalDirectory.toPath(),
-                scheduler,
-                segmentSize,
-                Duration.standardHours(1),
-                Size.petabytes(1L), // never clean by size in this test
-                Duration.standardDays(1),
-                1_000_000,
-                Duration.standardMinutes(1),
-                100,
-                new MetricRegistry(),
-                serverStatus);
+                                                      scheduler,
+                                                      segmentSize,
+                                                      Duration.standardHours(1),
+                                                      Size.petabytes(1L), // never clean by size in this test
+                                                      Duration.standardDays(1),
+                                                      1_000_000,
+                                                      Duration.standardMinutes(1),
+                                                      100,
+                                                      new MetricRegistry(),
+                                                      serverStatus,
+                                                      null);
         final File messageJournalDir = new File(journalDirectory, "messagejournal-0");
         assertTrue(messageJournalDir.exists());
 
@@ -428,22 +436,23 @@ public class KafkaJournalTest {
 
         try {
             new KafkaJournal(journalDirectory.toPath(),
-                scheduler,
-                Size.megabytes(100L),
-                Duration.standardHours(1),
-                Size.megabytes(5L),
-                Duration.standardHours(1),
-                1_000_000,
-                Duration.standardMinutes(1),
-                100,
-                new MetricRegistry(),
-                serverStatus);
+                             scheduler,
+                             Size.megabytes(100L),
+                             Duration.standardHours(1),
+                             Size.megabytes(5L),
+                             Duration.standardHours(1),
+                             1_000_000,
+                             Duration.standardMinutes(1),
+                             100,
+                             new MetricRegistry(),
+                             serverStatus,
+                             null);
             fail("Expected exception");
         } catch (Exception e) {
             assertThat(e)
-                .isExactlyInstanceOf(RuntimeException.class)
-                .hasMessageStartingWith("kafka.common.KafkaException: Failed to acquire lock on file .lock in")
-                .hasCauseExactlyInstanceOf(KafkaException.class);
+                    .isExactlyInstanceOf(RuntimeException.class)
+                    .hasMessageStartingWith("kafka.common.KafkaException: Failed to acquire lock on file .lock in")
+                    .hasCauseExactlyInstanceOf(KafkaException.class);
         }
     }
 
@@ -454,16 +463,17 @@ public class KafkaJournalTest {
 
         final Size segmentSize = Size.kilobytes(1L);
         final KafkaJournal journal = new KafkaJournal(journalDirectory.toPath(),
-            scheduler,
-            segmentSize,
-            Duration.standardSeconds(1L),
-            Size.kilobytes(4L),
-            Duration.standardHours(1L),
-            1_000_000,
-            Duration.standardSeconds(1L),
-            90,
-            new MetricRegistry(),
-            serverStatus);
+                                                      scheduler,
+                                                      segmentSize,
+                                                      Duration.standardSeconds(1L),
+                                                      Size.kilobytes(4L),
+                                                      Duration.standardHours(1L),
+                                                      1_000_000,
+                                                      Duration.standardSeconds(1L),
+                                                      90,
+                                                      new MetricRegistry(),
+                                                      serverStatus,
+                                                      null);
 
         createBulkChunks(journal, segmentSize, 4);
         journal.flushDirtyLogs();
@@ -477,16 +487,17 @@ public class KafkaJournalTest {
 
         final Size segmentSize = Size.kilobytes(1L);
         final KafkaJournal journal = new KafkaJournal(journalDirectory.toPath(),
-            scheduler,
-            segmentSize,
-            Duration.standardSeconds(1L),
-            Size.kilobytes(4L),
-            Duration.standardHours(1L),
-            1_000_000,
-            Duration.standardSeconds(1L),
-            90,
-            new MetricRegistry(),
-            serverStatus);
+                                                      scheduler,
+                                                      segmentSize,
+                                                      Duration.standardSeconds(1L),
+                                                      Size.kilobytes(4L),
+                                                      Duration.standardHours(1L),
+                                                      1_000_000,
+                                                      Duration.standardSeconds(1L),
+                                                      90,
+                                                      new MetricRegistry(),
+                                                      serverStatus,
+                                                      null);
 
         journal.flushDirtyLogs();
         journal.cleanupLogs();

--- a/graylog2-server/src/test/java/org/graylog2/shared/journal/KafkaJournalTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/shared/journal/KafkaJournalTest.java
@@ -114,8 +114,7 @@ public class KafkaJournalTest {
                                                  Duration.standardMinutes(1),
                                                  100,
                                                  new MetricRegistry(),
-                                                 serverStatus,
-                                                 null);
+                                                 serverStatus);
 
         final byte[] idBytes = "id".getBytes(UTF_8);
         final byte[] messageBytes = "message".getBytes(UTF_8);
@@ -140,8 +139,7 @@ public class KafkaJournalTest {
                                                  Duration.standardMinutes(1),
                                                  100,
                                                  new MetricRegistry(),
-                                                 serverStatus,
-                                                 null);
+                                                 serverStatus);
 
         final byte[] idBytes = "id".getBytes(UTF_8);
         final byte[] messageBytes = "message1".getBytes(UTF_8);
@@ -197,8 +195,7 @@ public class KafkaJournalTest {
                                                       Duration.standardMinutes(1),
                                                       100,
                                                       new MetricRegistry(),
-                                                      serverStatus,
-                                                      null);
+                                                      serverStatus);
 
         long size = 0L;
         long maxSize = segmentSize.toBytes();
@@ -230,8 +227,7 @@ public class KafkaJournalTest {
                                                       Duration.standardMinutes(1),
                                                       100,
                                                       new MetricRegistry(),
-                                                      serverStatus,
-                                                      null);
+                                                      serverStatus);
 
         long size = 0L;
         long maxSize = segmentSize.toBytes();
@@ -271,8 +267,7 @@ public class KafkaJournalTest {
                                                       Duration.standardMinutes(1),
                                                       100,
                                                       new MetricRegistry(),
-                                                      serverStatus,
-                                                      null);
+                                                      serverStatus);
 
         createBulkChunks(journal, segmentSize, 3);
 
@@ -301,8 +296,7 @@ public class KafkaJournalTest {
                                                       Duration.standardMinutes(1),
                                                       100,
                                                       new MetricRegistry(),
-                                                      serverStatus,
-                                                      null);
+                                                      serverStatus);
         final File messageJournalDir = new File(journalDirectory, "messagejournal-0");
         assertTrue(messageJournalDir.exists());
 
@@ -338,8 +332,7 @@ public class KafkaJournalTest {
                                                           Duration.standardMinutes(1),
                                                           100,
                                                           new MetricRegistry(),
-                                                          serverStatus,
-                                                          null);
+                                                          serverStatus);
             final File messageJournalDir = new File(journalDirectory, "messagejournal-0");
             assertTrue(messageJournalDir.exists());
 
@@ -393,8 +386,7 @@ public class KafkaJournalTest {
                                                       Duration.standardMinutes(1),
                                                       100,
                                                       new MetricRegistry(),
-                                                      serverStatus,
-                                                      null);
+                                                      serverStatus);
         final File messageJournalDir = new File(journalDirectory, "messagejournal-0");
         assertTrue(messageJournalDir.exists());
 
@@ -445,8 +437,7 @@ public class KafkaJournalTest {
                              Duration.standardMinutes(1),
                              100,
                              new MetricRegistry(),
-                             serverStatus,
-                             null);
+                             serverStatus);
             fail("Expected exception");
         } catch (Exception e) {
             assertThat(e)
@@ -472,8 +463,7 @@ public class KafkaJournalTest {
                                                       Duration.standardSeconds(1L),
                                                       90,
                                                       new MetricRegistry(),
-                                                      serverStatus,
-                                                      null);
+                                                      serverStatus);
 
         createBulkChunks(journal, segmentSize, 4);
         journal.flushDirtyLogs();
@@ -496,8 +486,7 @@ public class KafkaJournalTest {
                                                       Duration.standardSeconds(1L),
                                                       90,
                                                       new MetricRegistry(),
-                                                      serverStatus,
-                                                      null);
+                                                      serverStatus);
 
         journal.flushDirtyLogs();
         journal.cleanupLogs();


### PR DESCRIPTION
The Graylog Server will need several changes in order for the Graylog Forwarder to be implemented.

1) The Graylog Forwarder feature uses the same Journaling capability that exists in the Graylog Server currently. The `KafkaJournal` class has been reworked to allow support for instance-based metric names.

2) Output implementations do not currently have access to the output id. A change has been made that allows the output implementation to access the output instance and therefore the id.

See https://github.com/Graylog2/graylog-plugin-enterprise-integrations/pull/30 for the core Forwarder PR.