### PR TITLE
Fix gui test after release

### DIFF
--- a/graylog2-web-interface/src/routing/__snapshots__/AppErrorBoundary.test.jsx.snap
+++ b/graylog2-web-interface/src/routing/__snapshots__/AppErrorBoundary.test.jsx.snap
@@ -127,7 +127,7 @@ exports[`AppErrorBoundary displays error after catching 1`] = `
                                 text="documentation"
                               >
                                 <a
-                                  href="http://docs.graylog.org/en/3.0"
+                                  href="http://docs.graylog.org/en/3.1"
                                   target="_blank"
                                 >
                                   documentation


### PR DESCRIPTION
Prior to this change, the release did change the doc path
and a snapshot test would fail.

This change will update the failing snapshot.