### PR TITLE
Do not show an "(optional)" for boolean configuration fields

### DIFF
--- a/graylog2-web-interface/src/components/configurationforms/FieldHelpers.jsx
+++ b/graylog2-web-interface/src/components/configurationforms/FieldHelpers.jsx
@@ -5,7 +5,7 @@ const FieldHelpers = {
     return ary.indexOf(attribute) > -1;
   },
   optionalMarker: (field) => {
-    return field.is_optional ? <span className="configuration-field-optional">(optional)</span> : null;
+    return field.is_optional && field.type !== 'boolean' ? <span className="configuration-field-optional">(optional)</span> : null;
   },
 };
 


### PR DESCRIPTION
Booleans are always optional and in some cases, the text leads
to confusion.
For example, on a checkbox named `[x] Enable TLS (optional)` the user
could expect that non working TLS will fallback to plaintext,
which is not the case.
