### PR TITLE
Paginated dashboard overview list

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/dashboards/DashboardDTO.java
+++ b/graylog2-server/src/main/java/org/graylog2/dashboards/DashboardDTO.java
@@ -1,0 +1,121 @@
+/**
+ * This file is part of Graylog.
+ *
+ * Graylog is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.graylog2.dashboards;
+
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.auto.value.AutoValue;
+import org.graylog.autovalue.WithBeanGetter;
+import org.graylog2.dashboards.widgets.WidgetPosition;
+
+import javax.annotation.Nullable;
+import java.util.Collection;
+
+@AutoValue
+@WithBeanGetter
+@JsonAutoDetect
+public abstract class DashboardDTO {
+    public static final String FIELD_ID = "_id";
+    public static final String FIELD_TITLE = "title";
+    public static final String FIELD_DESCRIPTION = "description";
+    public static final String FIELD_CONTENT_PACK = "content_pack";
+    public static final String FIELD_CREATOR_USER_ID = "creator_user_id";
+    public static final String FIELD_CREATED_AT = "created_at";
+    public static final String EMBEDDED_WIDGETS = "widgets";
+    public static final String EMBEDDED_POSITIONS = "positions";
+
+    @JsonProperty("id")
+    public abstract String id();
+
+    @JsonProperty(FIELD_TITLE)
+    public abstract String title();
+
+    @JsonProperty(FIELD_DESCRIPTION)
+    public abstract String description();
+
+    @JsonProperty(FIELD_CREATOR_USER_ID)
+    public abstract String creatorUserId();
+
+    @JsonProperty(FIELD_CREATED_AT)
+    public abstract String createdAt();
+
+    @JsonProperty(FIELD_CONTENT_PACK)
+    @Nullable
+    public abstract String contentPack();
+
+    @JsonProperty(EMBEDDED_WIDGETS)
+    @Nullable
+    public abstract Collection<DashboardWidgetDTO> widgets();
+
+    @JsonProperty(EMBEDDED_POSITIONS)
+    @Nullable
+    public abstract Collection<WidgetPosition> positions();
+
+    public abstract Builder toBuilder();
+
+    @JsonCreator
+    public static DashboardDTO create(@JsonProperty(FIELD_ID) String id,
+                        @JsonProperty(FIELD_TITLE) String title,
+                        @JsonProperty(FIELD_DESCRIPTION) String description,
+                        @JsonProperty(FIELD_CREATOR_USER_ID) String creatorUserId,
+                        @JsonProperty(FIELD_CREATED_AT) String createdAt,
+                        @JsonProperty(FIELD_CONTENT_PACK) @Nullable String contentPack,
+                        @JsonProperty(EMBEDDED_WIDGETS) @Nullable Collection<DashboardWidgetDTO> widgets,
+                        @JsonProperty(EMBEDDED_POSITIONS) @Nullable Collection<WidgetPosition> positions) {
+        return new AutoValue_DashboardDTO(
+                id,
+                title,
+                description,
+                creatorUserId,
+                createdAt,
+                contentPack,
+                widgets,
+                positions);
+    }
+
+    @AutoValue.Builder
+    public abstract static class Builder {
+        @JsonCreator Builder create() { return new AutoValue_DashboardDTO.Builder(); }
+
+        @JsonProperty("id")
+        public abstract Builder id(String id);
+
+        @JsonProperty(FIELD_TITLE)
+        public abstract Builder title(String title);
+
+        @JsonProperty(FIELD_DESCRIPTION)
+        public abstract Builder description(String description);
+
+        @JsonProperty(FIELD_CONTENT_PACK)
+        public abstract Builder contentPack(String contentPack);
+
+        @JsonProperty(FIELD_CREATOR_USER_ID)
+        public abstract Builder creatorUserId(String creatorUserId);
+
+        @JsonProperty(FIELD_CREATED_AT)
+        public abstract Builder createdAt(String createdAt);
+
+        @JsonProperty(EMBEDDED_WIDGETS)
+        public abstract Builder widgets(Collection<DashboardWidgetDTO> widgets);
+
+        @JsonProperty(EMBEDDED_POSITIONS)
+        public abstract Builder positions(Collection<WidgetPosition> positions);
+
+        public abstract DashboardDTO build();
+    }
+}

--- a/graylog2-server/src/main/java/org/graylog2/dashboards/DashboardWidgetDTO.java
+++ b/graylog2-server/src/main/java/org/graylog2/dashboards/DashboardWidgetDTO.java
@@ -1,0 +1,66 @@
+/**
+ * This file is part of Graylog.
+ *
+ * Graylog is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.graylog2.dashboards;
+
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.auto.value.AutoValue;
+import org.graylog.autovalue.WithBeanGetter;
+
+import java.util.Map;
+
+@AutoValue
+@WithBeanGetter
+@JsonAutoDetect
+public abstract class DashboardWidgetDTO {
+    public static final String FIELD_ID = "id";
+    public static final String FIELD_TYPE = "type";
+    public static final String FIELD_DESCRIPTION = "description";
+    public static final String FIELD_CACHE_TIME = "cache_time";
+    public static final String FIELD_CREATOR_USER_ID = "creator_user_id";
+    public static final String FIELD_CONFIG = "config";
+
+    @JsonProperty(FIELD_ID)
+    public abstract String id();
+
+    @JsonProperty(FIELD_DESCRIPTION)
+    public abstract String description();
+
+    @JsonProperty(FIELD_TYPE)
+    public abstract String type();
+
+    @JsonProperty(FIELD_CACHE_TIME)
+    public abstract String cacheTime();
+
+    @JsonProperty(FIELD_CREATOR_USER_ID)
+    public abstract String creatorUserId();
+
+    @JsonProperty(FIELD_CONFIG)
+    public abstract Map<String, Object> config();
+
+    @JsonCreator
+    public static DashboardWidgetDTO create(@JsonProperty(FIELD_ID) String id,
+                              @JsonProperty(FIELD_TYPE) String type,
+                              @JsonProperty(FIELD_DESCRIPTION) String description,
+                              @JsonProperty(FIELD_CACHE_TIME) String cacheTime,
+                              @JsonProperty(FIELD_CREATOR_USER_ID) String creatorUserId,
+                              @JsonProperty(FIELD_CONFIG) Map<String, Object> config) {
+
+        return new AutoValue_DashboardWidgetDTO(id, type, description, cacheTime, creatorUserId, config);
+    }
+}

--- a/graylog2-server/src/main/java/org/graylog2/dashboards/PaginatedDashboardService.java
+++ b/graylog2-server/src/main/java/org/graylog2/dashboards/PaginatedDashboardService.java
@@ -1,0 +1,48 @@
+/**
+ * This file is part of Graylog.
+ *
+ * Graylog is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.graylog2.dashboards;
+
+import org.graylog2.bindings.providers.MongoJackObjectMapperProvider;
+import org.graylog2.database.MongoConnection;
+import org.graylog2.database.PaginatedDbService;
+import org.graylog2.database.PaginatedList;
+import org.graylog2.search.SearchQuery;
+import org.mongojack.DBQuery;
+import org.mongojack.DBSort;
+
+import javax.inject.Inject;
+
+public class PaginatedDashboardService extends PaginatedDbService<DashboardDTO> {
+    private static final String COLLECTION_NAME = "dashboards";
+
+    @Inject
+    public PaginatedDashboardService(MongoConnection mongoConnection,
+                                     MongoJackObjectMapperProvider mapper)
+    {
+        super(mongoConnection, mapper, DashboardDTO.class, COLLECTION_NAME);
+    }
+
+    public long count() {
+        return db.count();
+    }
+
+    public PaginatedList<DashboardDTO> findPaginated(SearchQuery searchQuery, int page, int perPage, String sortField, String order) {
+        final DBQuery.Query dbQuery = searchQuery.toDBQuery();
+        final DBSort.SortBuilder sortBuilder = getSortBuilder(order, sortField);
+        return findPaginatedWithQueryAndSort(dbQuery, sortBuilder, page, perPage);
+    }
+}

--- a/graylog2-server/src/main/java/org/graylog2/dashboards/PaginatedDashboardService.java
+++ b/graylog2-server/src/main/java/org/graylog2/dashboards/PaginatedDashboardService.java
@@ -25,6 +25,7 @@ import org.mongojack.DBQuery;
 import org.mongojack.DBSort;
 
 import javax.inject.Inject;
+import java.util.function.Predicate;
 
 public class PaginatedDashboardService extends PaginatedDbService<DashboardDTO> {
     private static final String COLLECTION_NAME = "dashboards";
@@ -40,9 +41,10 @@ public class PaginatedDashboardService extends PaginatedDbService<DashboardDTO> 
         return db.count();
     }
 
-    public PaginatedList<DashboardDTO> findPaginated(SearchQuery searchQuery, int page, int perPage, String sortField, String order) {
+    public PaginatedList<DashboardDTO> findPaginated(SearchQuery searchQuery, Predicate<DashboardDTO> filter, int page,
+                                                     int perPage, String sortField, String order) {
         final DBQuery.Query dbQuery = searchQuery.toDBQuery();
         final DBSort.SortBuilder sortBuilder = getSortBuilder(order, sortField);
-        return findPaginatedWithQueryAndSort(dbQuery, sortBuilder, page, perPage);
+        return findPaginatedWithQueryFilterAndSort(dbQuery, filter, sortBuilder, page, perPage);
     }
 }

--- a/graylog2-server/src/main/java/org/graylog2/rest/models/dashboards/responses/DashboardPageList.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/models/dashboards/responses/DashboardPageList.java
@@ -1,0 +1,66 @@
+/**
+ * This file is part of Graylog.
+ *
+ * Graylog is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.graylog2.rest.models.dashboards.responses;
+
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.auto.value.AutoValue;
+import org.graylog.autovalue.WithBeanGetter;
+import org.graylog2.dashboards.DashboardDTO;
+import org.graylog2.database.PaginatedList;
+import org.graylog2.streams.StreamDTO;
+
+import javax.annotation.Nullable;
+import java.util.Collection;
+
+@JsonAutoDetect
+@AutoValue
+@WithBeanGetter
+public abstract class DashboardPageList {
+    @Nullable
+    @JsonProperty
+    public abstract String query();
+
+    @JsonProperty("pagination")
+    public abstract PaginatedList.PaginationInfo paginationInfo();
+
+    @JsonProperty
+    public abstract long total();
+
+    @Nullable
+    @JsonProperty
+    public abstract String sort();
+
+    @Nullable
+    @JsonProperty
+    public abstract String order();
+
+    @JsonProperty
+    public abstract Collection<DashboardDTO> dashboards();
+
+    @JsonCreator
+    public static DashboardPageList create(
+            @JsonProperty("query") @Nullable String query,
+            @JsonProperty("pagination") PaginatedList.PaginationInfo paginationInfo,
+            @JsonProperty("total") long total,
+            @JsonProperty("sort") @Nullable String sort,
+            @JsonProperty("order") @Nullable String order,
+            @JsonProperty("dashboards") Collection<DashboardDTO> dashboards) {
+        return new AutoValue_DashboardPageList(query, paginationInfo, total, sort, order, dashboards);
+    }
+}

--- a/graylog2-server/src/main/java/org/graylog2/rest/models/dashboards/responses/DashboardPageList.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/models/dashboards/responses/DashboardPageList.java
@@ -23,7 +23,6 @@ import com.google.auto.value.AutoValue;
 import org.graylog.autovalue.WithBeanGetter;
 import org.graylog2.dashboards.DashboardDTO;
 import org.graylog2.database.PaginatedList;
-import org.graylog2.streams.StreamDTO;
 
 import javax.annotation.Nullable;
 import java.util.Collection;

--- a/graylog2-server/src/main/java/org/graylog2/rest/models/streams/alerts/AlertConditionSummary.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/models/streams/alerts/AlertConditionSummary.java
@@ -65,7 +65,6 @@ public abstract class AlertConditionSummary {
                                                @JsonProperty("parameters") Map<String, Object> parameters,
                                                @JsonProperty("in_grace") Boolean inGrace,
                                                @JsonProperty("title") @Nullable String title) {
-        checkNotNull(inGrace);
         return new AutoValue_AlertConditionSummary(id, type, creatorUserId, createdAt, parameters, inGrace, title);
     }
 

--- a/graylog2-server/src/main/java/org/graylog2/rest/resources/dashboards/DashboardsResource.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/resources/dashboards/DashboardsResource.java
@@ -71,6 +71,7 @@ import javax.ws.rs.core.Response;
 import java.net.URI;
 import java.util.List;
 import java.util.Map;
+import java.util.function.Predicate;
 
 @RequiresAuthentication
 @Api(value = "Dashboards", description = "Manage dashboards")
@@ -165,8 +166,9 @@ public class DashboardsResource extends RestResource {
         } catch (IllegalArgumentException e) {
             throw new BadRequestException("Invalid argument in search query: " + e.getMessage());
         }
+        final Predicate<DashboardDTO> permissionFilter = dashboardDTO -> isPermitted(RestPermissions.DASHBOARDS_READ, dashboardDTO.id());
         final PaginatedList<DashboardDTO> result = paginatedDashboardService
-                .findPaginated(searchQuery, page, perPage, sort, order);
+                .findPaginated(searchQuery, permissionFilter, page, perPage, sort, order);
         final long total = paginatedDashboardService.count();
         return DashboardPageList.create(query, result.pagination(), total, sort, order, result);
     }

--- a/graylog2-server/src/main/java/org/graylog2/rest/resources/streams/StreamResource.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/resources/streams/StreamResource.java
@@ -39,6 +39,7 @@ import org.graylog2.audit.AuditEventTypes;
 import org.graylog2.audit.jersey.AuditEvent;
 import org.graylog2.audit.jersey.NoAuditEvent;
 import org.graylog2.database.NotFoundException;
+import org.graylog2.database.PaginatedList;
 import org.graylog2.indexer.IndexSet;
 import org.graylog2.indexer.IndexSetRegistry;
 import org.graylog2.plugin.Message;
@@ -59,10 +60,16 @@ import org.graylog2.rest.models.system.outputs.responses.OutputSummary;
 import org.graylog2.rest.resources.streams.requests.CloneStreamRequest;
 import org.graylog2.rest.resources.streams.requests.CreateStreamRequest;
 import org.graylog2.rest.resources.streams.responses.StreamListResponse;
+import org.graylog2.rest.resources.streams.responses.StreamPageListResponse;
 import org.graylog2.rest.resources.streams.responses.StreamResponse;
 import org.graylog2.rest.resources.streams.responses.TestMatchResponse;
+import org.graylog2.search.SearchQuery;
+import org.graylog2.search.SearchQueryField;
+import org.graylog2.search.SearchQueryParser;
 import org.graylog2.shared.rest.resources.RestResource;
 import org.graylog2.shared.security.RestPermissions;
+import org.graylog2.streams.PaginatedStreamService;
+import org.graylog2.streams.StreamDTO;
 import org.graylog2.streams.StreamImpl;
 import org.graylog2.streams.StreamRouterEngine;
 import org.graylog2.streams.StreamRuleImpl;
@@ -81,12 +88,14 @@ import javax.validation.constraints.NotNull;
 import javax.ws.rs.BadRequestException;
 import javax.ws.rs.Consumes;
 import javax.ws.rs.DELETE;
+import javax.ws.rs.DefaultValue;
 import javax.ws.rs.GET;
 import javax.ws.rs.POST;
 import javax.ws.rs.PUT;
 import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
 import javax.ws.rs.Produces;
+import javax.ws.rs.QueryParam;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 import java.net.URI;
@@ -111,15 +120,23 @@ import static com.google.common.base.MoreObjects.firstNonNull;
 public class StreamResource extends RestResource {
     private static final Logger LOG = LoggerFactory.getLogger(StreamResource.class);
 
+    protected static final ImmutableMap<String, SearchQueryField> SEARCH_FIELD_MAPPING = ImmutableMap.<String, SearchQueryField>builder()
+            .put("title", SearchQueryField.create(StreamImpl.FIELD_TITLE))
+            .put("description", SearchQueryField.create(StreamImpl.FIELD_DESCRIPTION))
+            .build();
+
+    private final PaginatedStreamService paginatedStreamService;
     private final StreamService streamService;
     private final StreamRuleService streamRuleService;
     private final StreamRouterEngine.Factory streamRouterEngineFactory;
     private final IndexSetRegistry indexSetRegistry;
     private final AlarmCallbackConfigurationService alarmCallbackConfigurationService;
     private final AlertService alertService;
+    private final SearchQueryParser searchQueryParser;
 
     @Inject
     public StreamResource(StreamService streamService,
+                          PaginatedStreamService paginatedStreamService,
                           StreamRuleService streamRuleService,
                           StreamRouterEngine.Factory streamRouterEngineFactory,
                           IndexSetRegistry indexSetRegistry,
@@ -131,6 +148,8 @@ public class StreamResource extends RestResource {
         this.indexSetRegistry = indexSetRegistry;
         this.alarmCallbackConfigurationService = alarmCallbackConfigurationService;
         this.alertService = alertService;
+        this.paginatedStreamService = paginatedStreamService;
+        this.searchQueryParser = new SearchQueryParser(StreamImpl.FIELD_TITLE, SEARCH_FIELD_MAPPING);
     }
 
     @POST
@@ -187,6 +206,34 @@ public class StreamResource extends RestResource {
         }
 
         return permissionsChanged;
+    }
+
+    @GET
+    @Timed
+    @Path("/page")
+    @ApiOperation(value = "Get a list of all streams")
+    @Produces(MediaType.APPLICATION_JSON)
+    public StreamPageListResponse getPage(@ApiParam(name = "page") @QueryParam("page") @DefaultValue("1") int page,
+        @ApiParam(name = "per_page") @QueryParam("per_page") @DefaultValue("50") int perPage,
+        @ApiParam(name = "query") @QueryParam("query") @DefaultValue("") String query,
+        @ApiParam(name = "sort",
+                value = "The field to sort the result on",
+                required = true,
+                allowableValues = "title,description,id")
+        @DefaultValue(StreamImpl.FIELD_TITLE) @QueryParam("sort") String sort,
+        @ApiParam(name = "order", value = "The sort direction", allowableValues = "asc, desc")
+        @DefaultValue("asc") @QueryParam("order") String order) {
+
+        SearchQuery searchQuery;
+        try {
+            searchQuery = searchQueryParser.parse(query);
+        } catch (IllegalArgumentException e) {
+            throw new BadRequestException("Invalid argument in search query: " + e.getMessage());
+        }
+        final PaginatedList<StreamDTO> streams = paginatedStreamService
+                .findPaginated(searchQuery, page, perPage, sort, order);
+        final long total = paginatedStreamService.count();
+        return StreamPageListResponse.create(query, streams.pagination(), total, sort, order, streams);
     }
 
     @GET

--- a/graylog2-server/src/main/java/org/graylog2/rest/resources/streams/StreamResource.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/resources/streams/StreamResource.java
@@ -110,6 +110,7 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import java.util.function.Predicate;
 import java.util.stream.Collectors;
 
 import static com.google.common.base.MoreObjects.firstNonNull;
@@ -230,8 +231,9 @@ public class StreamResource extends RestResource {
         } catch (IllegalArgumentException e) {
             throw new BadRequestException("Invalid argument in search query: " + e.getMessage());
         }
+        final Predicate<StreamDTO> permissionFilter = streamDTO -> isPermitted(RestPermissions.STREAMS_READ, streamDTO.id());
         final PaginatedList<StreamDTO> result = paginatedStreamService
-                .findPaginated(searchQuery, page, perPage, sort, order);
+                .findPaginated(searchQuery, permissionFilter, page, perPage, sort, order);
         final List<StreamDTO> streams = result.stream().map(streamDTO -> {
             List<StreamRule> rules = streamRuleService.loadForStreamId(streamDTO.id());
             return streamDTO.toBuilder().rules(rules).build();

--- a/graylog2-server/src/main/java/org/graylog2/rest/resources/streams/StreamResource.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/resources/streams/StreamResource.java
@@ -121,8 +121,8 @@ public class StreamResource extends RestResource {
     private static final Logger LOG = LoggerFactory.getLogger(StreamResource.class);
 
     protected static final ImmutableMap<String, SearchQueryField> SEARCH_FIELD_MAPPING = ImmutableMap.<String, SearchQueryField>builder()
-            .put("title", SearchQueryField.create(StreamImpl.FIELD_TITLE))
-            .put("description", SearchQueryField.create(StreamImpl.FIELD_DESCRIPTION))
+            .put(StreamDTO.FIELD_TITLE, SearchQueryField.create(StreamDTO.FIELD_TITLE))
+            .put(StreamDTO.FIELD_DESCRIPTION, SearchQueryField.create(StreamDTO.FIELD_DESCRIPTION))
             .build();
 
     private final PaginatedStreamService paginatedStreamService;
@@ -219,7 +219,7 @@ public class StreamResource extends RestResource {
         @ApiParam(name = "sort",
                 value = "The field to sort the result on",
                 required = true,
-                allowableValues = "title,description,id")
+                allowableValues = "title,description")
         @DefaultValue(StreamImpl.FIELD_TITLE) @QueryParam("sort") String sort,
         @ApiParam(name = "order", value = "The sort direction", allowableValues = "asc, desc")
         @DefaultValue("asc") @QueryParam("order") String order) {

--- a/graylog2-server/src/main/java/org/graylog2/rest/resources/streams/responses/StreamPageListResponse.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/resources/streams/responses/StreamPageListResponse.java
@@ -1,0 +1,65 @@
+/**
+ * This file is part of Graylog.
+ *
+ * Graylog is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.graylog2.rest.resources.streams.responses;
+
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.auto.value.AutoValue;
+import org.graylog.autovalue.WithBeanGetter;
+import org.graylog2.database.PaginatedList;
+import org.graylog2.streams.StreamDTO;
+
+import javax.annotation.Nullable;
+import java.util.Collection;
+
+@JsonAutoDetect
+@AutoValue
+@WithBeanGetter
+public abstract class StreamPageListResponse {
+    @Nullable
+    @JsonProperty
+    public abstract String query();
+
+    @JsonProperty("pagination")
+    public abstract PaginatedList.PaginationInfo paginationInfo();
+
+    @JsonProperty
+    public abstract long total();
+
+    @Nullable
+    @JsonProperty
+    public abstract String sort();
+
+    @Nullable
+    @JsonProperty
+    public abstract String order();
+
+    @JsonProperty
+    public abstract Collection<StreamDTO> streams();
+
+    @JsonCreator
+    public static StreamPageListResponse create(
+            @JsonProperty("query") @Nullable String query,
+            @JsonProperty("pagination") PaginatedList.PaginationInfo paginationInfo,
+            @JsonProperty("total") long total,
+            @JsonProperty("sort") @Nullable String sort,
+            @JsonProperty("order") @Nullable String order,
+            @JsonProperty("streams") Collection<StreamDTO> streams) {
+        return new AutoValue_StreamPageListResponse(query, paginationInfo, total, sort, order, streams);
+    }
+}

--- a/graylog2-server/src/main/java/org/graylog2/streams/PaginatedStreamService.java
+++ b/graylog2-server/src/main/java/org/graylog2/streams/PaginatedStreamService.java
@@ -25,6 +25,7 @@ import org.mongojack.DBQuery;
 import org.mongojack.DBSort;
 
 import javax.inject.Inject;
+import java.util.function.Predicate;
 
 public class PaginatedStreamService extends PaginatedDbService<StreamDTO> {
     private static final String COLLECTION_NAME = "streams";
@@ -40,9 +41,10 @@ public class PaginatedStreamService extends PaginatedDbService<StreamDTO> {
         return db.count();
     }
 
-    public PaginatedList<StreamDTO> findPaginated(SearchQuery searchQuery, int page, int perPage, String sortField, String order) {
+    public PaginatedList<StreamDTO> findPaginated(SearchQuery searchQuery, Predicate<StreamDTO> filter, int page,
+                                                  int perPage, String sortField, String order) {
         final DBQuery.Query dbQuery = searchQuery.toDBQuery();
         final DBSort.SortBuilder sortBuilder = getSortBuilder(order, sortField);
-        return findPaginatedWithQueryAndSort(dbQuery, sortBuilder, page, perPage);
+        return findPaginatedWithQueryFilterAndSort(dbQuery, filter, sortBuilder, page, perPage);
     }
 }

--- a/graylog2-server/src/main/java/org/graylog2/streams/PaginatedStreamService.java
+++ b/graylog2-server/src/main/java/org/graylog2/streams/PaginatedStreamService.java
@@ -1,3 +1,19 @@
+/**
+ * This file is part of Graylog.
+ *
+ * Graylog is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package org.graylog2.streams;
 
 import org.graylog2.bindings.providers.MongoJackObjectMapperProvider;

--- a/graylog2-server/src/main/java/org/graylog2/streams/PaginatedStreamService.java
+++ b/graylog2-server/src/main/java/org/graylog2/streams/PaginatedStreamService.java
@@ -1,0 +1,32 @@
+package org.graylog2.streams;
+
+import org.graylog2.bindings.providers.MongoJackObjectMapperProvider;
+import org.graylog2.database.MongoConnection;
+import org.graylog2.database.PaginatedDbService;
+import org.graylog2.database.PaginatedList;
+import org.graylog2.search.SearchQuery;
+import org.mongojack.DBQuery;
+import org.mongojack.DBSort;
+
+import javax.inject.Inject;
+
+public class PaginatedStreamService extends PaginatedDbService<StreamDTO> {
+    private static final String COLLECTION_NAME = "streams";
+
+    @Inject
+    public PaginatedStreamService(MongoConnection mongoConnection,
+                                  MongoJackObjectMapperProvider mapper)
+    {
+        super(mongoConnection, mapper, StreamDTO.class, COLLECTION_NAME);
+    }
+
+    public long count() {
+        return db.count();
+    }
+
+    public PaginatedList<StreamDTO> findPaginated(SearchQuery searchQuery, int page, int perPage, String sortField, String order) {
+        final DBQuery.Query dbQuery = searchQuery.toDBQuery();
+        final DBSort.SortBuilder sortBuilder = getSortBuilder(order, sortField);
+        return findPaginatedWithQueryAndSort(dbQuery, sortBuilder, page, perPage);
+    }
+}

--- a/graylog2-server/src/main/java/org/graylog2/streams/StreamDTO.java
+++ b/graylog2-server/src/main/java/org/graylog2/streams/StreamDTO.java
@@ -36,45 +36,61 @@ import static com.google.common.base.MoreObjects.firstNonNull;
 @WithBeanGetter
 @JsonAutoDetect
 public abstract class StreamDTO {
+    public static final String FIELD_ID = "_id";
+    public static final String FIELD_TITLE = "title";
+    public static final String FIELD_DESCRIPTION = "description";
+    public static final String FIELD_RULES = "rules";
+    public static final String FIELD_OUTPUTS = "outputs";
+    public static final String FIELD_CONTENT_PACK = "content_pack";
+    public static final String FIELD_ALERT_RECEIVERS = "alert_receivers";
+    public static final String FIELD_DISABLED = "disabled";
+    public static final String FIELD_CREATED_AT = "created_at";
+    public static final String FIELD_CREATOR_USER_ID = "creator_user_id";
+    public static final String FIELD_MATCHING_TYPE = "matching_type";
+    public static final String FIELD_DEFAULT_STREAM = "is_default_stream";
+    public static final String FIELD_REMOVE_MATCHES_FROM_DEFAULT_STREAM = "remove_matches_from_default_stream";
+    public static final String FIELD_INDEX_SET_ID = "index_set_id";
+    public static final String EMBEDDED_ALERT_CONDITIONS = "alert_conditions";
+
     @JsonProperty("id")
     public abstract String id();
 
-    @JsonProperty("creator_user_id")
+    @JsonProperty(FIELD_CREATOR_USER_ID)
     public abstract String creatorUserId();
 
-    @JsonProperty("outputs")
+    @JsonProperty(FIELD_OUTPUTS)
     @Nullable
     public abstract Collection<OutputSummary> outputs();
 
-    @JsonProperty("matching_type")
+    @JsonProperty(FIELD_MATCHING_TYPE)
     public abstract String matchingType();
 
-    @JsonProperty("description")
+    @JsonProperty(FIELD_DESCRIPTION)
     @Nullable
     public abstract String description();
 
-    @JsonProperty("created_at")
+    @JsonProperty(FIELD_CREATED_AT)
     public abstract String createdAt();
 
-    @JsonProperty("rules")
+    @JsonProperty(FIELD_RULES)
     @Nullable
     public abstract Collection<StreamRule> rules();
 
-    @JsonProperty("disabled")
+    @JsonProperty(FIELD_DISABLED)
     public abstract boolean disabled();
 
-    @JsonProperty("alert_conditions")
+    @JsonProperty(EMBEDDED_ALERT_CONDITIONS)
     @Nullable
     public abstract Collection<AlertConditionSummary> alertConditions();
 
-    @JsonProperty("alert_receivers")
+    @JsonProperty(FIELD_ALERT_RECEIVERS)
     @Nullable
     public abstract AlertReceivers alertReceivers();
 
-    @JsonProperty("title")
+    @JsonProperty(FIELD_TITLE)
     public abstract String title();
 
-    @JsonProperty("content_pack")
+    @JsonProperty(FIELD_CONTENT_PACK)
     @Nullable
     public abstract String contentPack();
 
@@ -82,31 +98,31 @@ public abstract class StreamDTO {
     @Nullable
     public abstract Boolean isDefault();
 
-    @JsonProperty("remove_matches_from_default_stream")
+    @JsonProperty(FIELD_REMOVE_MATCHES_FROM_DEFAULT_STREAM)
     @Nullable
     public abstract Boolean removeMatchesFromDefaultStream();
 
-    @JsonProperty("index_set_id")
+    @JsonProperty(FIELD_INDEX_SET_ID)
     public abstract String indexSetId();
 
     public abstract Builder toBuilder();
 
     @JsonCreator
-    public static StreamDTO create(@JsonProperty("_id") String id,
-                                   @JsonProperty("creator_user_id") String creatorUserId,
-                                   @JsonProperty("outputs") @Nullable Collection<OutputSummary> outputs,
-                                   @JsonProperty("matching_type") String matchingType,
-                                   @JsonProperty("description") @Nullable String description,
-                                   @JsonProperty("created_at") String createdAt,
-                                   @JsonProperty("disabled") boolean disabled,
-                                   @JsonProperty("rules") @Nullable Collection<StreamRule> rules,
-                                   @JsonProperty("alert_conditions") @Nullable Collection<AlertConditionSummary> alertConditions,
-                                   @JsonProperty("alert_receivers") @Nullable AlertReceivers alertReceivers,
-                                   @JsonProperty("title") String title,
-                                   @JsonProperty("content_pack") @Nullable String contentPack,
-                                   @JsonProperty("is_default_stream") @Nullable Boolean isDefault,
-                                   @JsonProperty("remove_matches_from_default_stream") @Nullable Boolean removeMatchesFromDefaultStream,
-                                   @JsonProperty("index_set_id") String indexSetId) {
+    public static StreamDTO create(@JsonProperty(FIELD_ID) String id,
+                                   @JsonProperty(FIELD_CREATOR_USER_ID) String creatorUserId,
+                                   @JsonProperty(FIELD_OUTPUTS) @Nullable Collection<OutputSummary> outputs,
+                                   @JsonProperty(FIELD_MATCHING_TYPE) String matchingType,
+                                   @JsonProperty(FIELD_DESCRIPTION) @Nullable String description,
+                                   @JsonProperty(FIELD_CREATED_AT) String createdAt,
+                                   @JsonProperty(FIELD_DISABLED) boolean disabled,
+                                   @JsonProperty(FIELD_RULES) @Nullable Collection<StreamRule> rules,
+                                   @JsonProperty(EMBEDDED_ALERT_CONDITIONS) @Nullable Collection<AlertConditionSummary> alertConditions,
+                                   @JsonProperty(FIELD_ALERT_RECEIVERS) @Nullable AlertReceivers alertReceivers,
+                                   @JsonProperty(FIELD_TITLE) String title,
+                                   @JsonProperty(FIELD_CONTENT_PACK) @Nullable String contentPack,
+                                   @JsonProperty(FIELD_DEFAULT_STREAM) @Nullable Boolean isDefault,
+                                   @JsonProperty(FIELD_REMOVE_MATCHES_FROM_DEFAULT_STREAM) @Nullable Boolean removeMatchesFromDefaultStream,
+                                   @JsonProperty(FIELD_INDEX_SET_ID) String indexSetId) {
         return new AutoValue_StreamDTO(
                 id,
                 creatorUserId,
@@ -132,49 +148,49 @@ public abstract class StreamDTO {
             return new AutoValue_StreamDTO.Builder();
         }
 
-        @JsonProperty("id")
+        @JsonProperty(FIELD_ID)
         public abstract Builder id(String id);
 
-        @JsonProperty("creator_user_id")
+        @JsonProperty(FIELD_CREATOR_USER_ID)
         public abstract Builder creatorUserId(String creatorUserId);
 
-        @JsonProperty("outputs")
+        @JsonProperty(FIELD_OUTPUTS)
         public abstract Builder outputs(Collection<OutputSummary> outputs);
 
-        @JsonProperty("matching_type")
+        @JsonProperty(FIELD_MATCHING_TYPE)
         public abstract Builder matchingType(String matchingType);
 
-        @JsonProperty("description")
+        @JsonProperty(FIELD_DESCRIPTION)
         public abstract Builder description(String description);
 
-        @JsonProperty("created_at")
+        @JsonProperty(FIELD_CREATED_AT)
         public abstract Builder createdAt(String createdAt);
 
-        @JsonProperty("content_pack")
+        @JsonProperty(FIELD_CONTENT_PACK)
         public abstract Builder contentPack(String contentPack);
 
-        @JsonProperty("disabled")
+        @JsonProperty(FIELD_DISABLED)
         public abstract Builder disabled(boolean disabled);
 
-        @JsonProperty("alert_conditions")
+        @JsonProperty(EMBEDDED_ALERT_CONDITIONS)
         public abstract Builder alertConditions(Collection<AlertConditionSummary> alertConditions);
 
-        @JsonProperty("rules")
+        @JsonProperty(FIELD_RULES)
         public abstract Builder rules(Collection<StreamRule> rules);
 
-        @JsonProperty("alert_receivers")
+        @JsonProperty(FIELD_ALERT_RECEIVERS)
         public abstract Builder alertReceivers(AlertReceivers receivers);
 
-        @JsonProperty("title")
+        @JsonProperty(FIELD_TITLE)
         public abstract Builder title(String title);
 
-        @JsonProperty("is_default_stream")
+        @JsonProperty(FIELD_DEFAULT_STREAM)
         public abstract Builder isDefault(Boolean isDefault);
 
-        @JsonProperty("remove_matches_from_default_stream")
+        @JsonProperty(FIELD_REMOVE_MATCHES_FROM_DEFAULT_STREAM)
         public abstract Builder removeMatchesFromDefaultStream(Boolean removeMatchesFromDefaultStream);
 
-        @JsonProperty("index_set_id")
+        @JsonProperty(FIELD_INDEX_SET_ID)
         public abstract Builder indexSetId(String indexSetId);
 
         public abstract StreamDTO build();

--- a/graylog2-server/src/main/java/org/graylog2/streams/StreamDTO.java
+++ b/graylog2-server/src/main/java/org/graylog2/streams/StreamDTO.java
@@ -21,12 +21,14 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.auto.value.AutoValue;
 import org.graylog.autovalue.WithBeanGetter;
+import org.graylog2.plugin.streams.StreamRule;
 import org.graylog2.rest.models.alarmcallbacks.requests.AlertReceivers;
 import org.graylog2.rest.models.streams.alerts.AlertConditionSummary;
 import org.graylog2.rest.models.system.outputs.responses.OutputSummary;
 
 import javax.annotation.Nullable;
 import java.util.Collection;
+import java.util.Collections;
 
 import static com.google.common.base.MoreObjects.firstNonNull;
 
@@ -53,6 +55,10 @@ public abstract class StreamDTO {
 
     @JsonProperty("created_at")
     public abstract String createdAt();
+
+    @JsonProperty("rules")
+    @Nullable
+    public abstract Collection<StreamRule> rules();
 
     @JsonProperty("disabled")
     public abstract boolean disabled();
@@ -83,21 +89,24 @@ public abstract class StreamDTO {
     @JsonProperty("index_set_id")
     public abstract String indexSetId();
 
+    public abstract Builder toBuilder();
+
     @JsonCreator
     public static StreamDTO create(@JsonProperty("_id") String id,
-                                        @JsonProperty("creator_user_id") String creatorUserId,
-                                        @JsonProperty("outputs") @Nullable Collection<OutputSummary> outputs,
-                                        @JsonProperty("matching_type") String matchingType,
-                                        @JsonProperty("description") @Nullable String description,
-                                        @JsonProperty("created_at") String createdAt,
-                                        @JsonProperty("disabled") boolean disabled,
-                                        @JsonProperty("alert_conditions") @Nullable Collection<AlertConditionSummary> alertConditions,
-                                        @JsonProperty("alert_receivers") @Nullable AlertReceivers alertReceivers,
-                                        @JsonProperty("title") String title,
-                                        @JsonProperty("content_pack") @Nullable String contentPack,
-                                        @JsonProperty("is_default_stream") @Nullable Boolean isDefault,
-                                        @JsonProperty("remove_matches_from_default_stream") @Nullable Boolean removeMatchesFromDefaultStream,
-                                        @JsonProperty("index_set_id") String indexSetId) {
+                                   @JsonProperty("creator_user_id") String creatorUserId,
+                                   @JsonProperty("outputs") @Nullable Collection<OutputSummary> outputs,
+                                   @JsonProperty("matching_type") String matchingType,
+                                   @JsonProperty("description") @Nullable String description,
+                                   @JsonProperty("created_at") String createdAt,
+                                   @JsonProperty("disabled") boolean disabled,
+                                   @JsonProperty("rules") @Nullable Collection<StreamRule> rules,
+                                   @JsonProperty("alert_conditions") @Nullable Collection<AlertConditionSummary> alertConditions,
+                                   @JsonProperty("alert_receivers") @Nullable AlertReceivers alertReceivers,
+                                   @JsonProperty("title") String title,
+                                   @JsonProperty("content_pack") @Nullable String contentPack,
+                                   @JsonProperty("is_default_stream") @Nullable Boolean isDefault,
+                                   @JsonProperty("remove_matches_from_default_stream") @Nullable Boolean removeMatchesFromDefaultStream,
+                                   @JsonProperty("index_set_id") String indexSetId) {
         return new AutoValue_StreamDTO(
                 id,
                 creatorUserId,
@@ -105,6 +114,7 @@ public abstract class StreamDTO {
                 matchingType,
                 description,
                 createdAt,
+                rules,
                 disabled,
                 alertConditions,
                 alertReceivers,
@@ -113,5 +123,60 @@ public abstract class StreamDTO {
                 firstNonNull(isDefault, false),
                 firstNonNull(removeMatchesFromDefaultStream, false),
                 indexSetId);
+    }
+
+    @AutoValue.Builder
+    public abstract static class Builder {
+        @JsonCreator
+        public static Builder create() {
+            return new AutoValue_StreamDTO.Builder();
+        }
+
+        @JsonProperty("id")
+        public abstract Builder id(String id);
+
+        @JsonProperty("creator_user_id")
+        public abstract Builder creatorUserId(String creatorUserId);
+
+        @JsonProperty("outputs")
+        public abstract Builder outputs(Collection<OutputSummary> outputs);
+
+        @JsonProperty("matching_type")
+        public abstract Builder matchingType(String matchingType);
+
+        @JsonProperty("description")
+        public abstract Builder description(String description);
+
+        @JsonProperty("created_at")
+        public abstract Builder createdAt(String createdAt);
+
+        @JsonProperty("content_pack")
+        public abstract Builder contentPack(String contentPack);
+
+        @JsonProperty("disabled")
+        public abstract Builder disabled(boolean disabled);
+
+        @JsonProperty("alert_conditions")
+        public abstract Builder alertConditions(Collection<AlertConditionSummary> alertConditions);
+
+        @JsonProperty("rules")
+        public abstract Builder rules(Collection<StreamRule> rules);
+
+        @JsonProperty("alert_receivers")
+        public abstract Builder alertReceivers(AlertReceivers receivers);
+
+        @JsonProperty("title")
+        public abstract Builder title(String title);
+
+        @JsonProperty("is_default_stream")
+        public abstract Builder isDefault(Boolean isDefault);
+
+        @JsonProperty("remove_matches_from_default_stream")
+        public abstract Builder removeMatchesFromDefaultStream(Boolean removeMatchesFromDefaultStream);
+
+        @JsonProperty("index_set_id")
+        public abstract Builder indexSetId(String indexSetId);
+
+        public abstract StreamDTO build();
     }
 }

--- a/graylog2-server/src/main/java/org/graylog2/streams/StreamDTO.java
+++ b/graylog2-server/src/main/java/org/graylog2/streams/StreamDTO.java
@@ -1,0 +1,117 @@
+/**
+ * This file is part of Graylog.
+ *
+ * Graylog is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.graylog2.streams;
+
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.auto.value.AutoValue;
+import org.graylog.autovalue.WithBeanGetter;
+import org.graylog2.rest.models.alarmcallbacks.requests.AlertReceivers;
+import org.graylog2.rest.models.streams.alerts.AlertConditionSummary;
+import org.graylog2.rest.models.system.outputs.responses.OutputSummary;
+
+import javax.annotation.Nullable;
+import java.util.Collection;
+
+import static com.google.common.base.MoreObjects.firstNonNull;
+
+@AutoValue
+@WithBeanGetter
+@JsonAutoDetect
+public abstract class StreamDTO {
+    @JsonProperty("id")
+    public abstract String id();
+
+    @JsonProperty("creator_user_id")
+    public abstract String creatorUserId();
+
+    @JsonProperty("outputs")
+    @Nullable
+    public abstract Collection<OutputSummary> outputs();
+
+    @JsonProperty("matching_type")
+    public abstract String matchingType();
+
+    @JsonProperty("description")
+    @Nullable
+    public abstract String description();
+
+    @JsonProperty("created_at")
+    public abstract String createdAt();
+
+    @JsonProperty("disabled")
+    public abstract boolean disabled();
+
+    @JsonProperty("alert_conditions")
+    @Nullable
+    public abstract Collection<AlertConditionSummary> alertConditions();
+
+    @JsonProperty("alert_receivers")
+    @Nullable
+    public abstract AlertReceivers alertReceivers();
+
+    @JsonProperty("title")
+    public abstract String title();
+
+    @JsonProperty("content_pack")
+    @Nullable
+    public abstract String contentPack();
+
+    @JsonProperty("is_default")
+    @Nullable
+    public abstract Boolean isDefault();
+
+    @JsonProperty("remove_matches_from_default_stream")
+    @Nullable
+    public abstract Boolean removeMatchesFromDefaultStream();
+
+    @JsonProperty("index_set_id")
+    public abstract String indexSetId();
+
+    @JsonCreator
+    public static StreamDTO create(@JsonProperty("_id") String id,
+                                        @JsonProperty("creator_user_id") String creatorUserId,
+                                        @JsonProperty("outputs") @Nullable Collection<OutputSummary> outputs,
+                                        @JsonProperty("matching_type") String matchingType,
+                                        @JsonProperty("description") @Nullable String description,
+                                        @JsonProperty("created_at") String createdAt,
+                                        @JsonProperty("disabled") boolean disabled,
+                                        @JsonProperty("alert_conditions") @Nullable Collection<AlertConditionSummary> alertConditions,
+                                        @JsonProperty("alert_receivers") @Nullable AlertReceivers alertReceivers,
+                                        @JsonProperty("title") String title,
+                                        @JsonProperty("content_pack") @Nullable String contentPack,
+                                        @JsonProperty("is_default_stream") @Nullable Boolean isDefault,
+                                        @JsonProperty("remove_matches_from_default_stream") @Nullable Boolean removeMatchesFromDefaultStream,
+                                        @JsonProperty("index_set_id") String indexSetId) {
+        return new AutoValue_StreamDTO(
+                id,
+                creatorUserId,
+                outputs,
+                matchingType,
+                description,
+                createdAt,
+                disabled,
+                alertConditions,
+                alertReceivers,
+                title,
+                contentPack,
+                firstNonNull(isDefault, false),
+                firstNonNull(removeMatchesFromDefaultStream, false),
+                indexSetId);
+    }
+}

--- a/graylog2-server/src/test/java/org/graylog2/rest/resources/dashboards/DashboardsResourceTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/rest/resources/dashboards/DashboardsResourceTest.java
@@ -19,6 +19,7 @@ package org.graylog2.rest.resources.dashboards;
 import org.apache.shiro.subject.Subject;
 import org.graylog2.dashboards.Dashboard;
 import org.graylog2.dashboards.DashboardService;
+import org.graylog2.dashboards.PaginatedDashboardService;
 import org.graylog2.plugin.database.users.User;
 import org.graylog2.rest.models.dashboards.requests.CreateDashboardRequest;
 import org.graylog2.shared.bindings.GuiceInjectorHolder;
@@ -63,6 +64,8 @@ public class DashboardsResourceTest {
     private UserService userService;
     @Mock
     private User user;
+    @Mock
+    private PaginatedDashboardService paginatedDashboardService;
 
     private DashboardsTestResource dashboardsResource;
 
@@ -70,10 +73,11 @@ public class DashboardsResourceTest {
         private final Subject subject;
 
         DashboardsTestResource(DashboardService dashboardService,
+                               PaginatedDashboardService paginatedDashboardService,
                                ActivityWriter activityWriter,
                                Subject subject,
                                UserService userService) {
-            super(dashboardService, activityWriter);
+            super(dashboardService, paginatedDashboardService, activityWriter);
             this.subject = subject;
             this.userService = userService;
         }
@@ -113,7 +117,7 @@ public class DashboardsResourceTest {
         when(userService.load(eq(testuserName))).thenReturn(user);
         when(user.getName()).thenReturn(testuserName);
 
-        this.dashboardsResource = new DashboardsTestResource(dashboardService, activityWriter, subject, userService);
+        this.dashboardsResource = new DashboardsTestResource(dashboardService, paginatedDashboardService, activityWriter, subject, userService);
     }
 
     @Test

--- a/graylog2-web-interface/src/actions/dashboards/DashboardsActions.js
+++ b/graylog2-web-interface/src/actions/dashboards/DashboardsActions.js
@@ -5,6 +5,7 @@ const DashboardsActions = Reflux.createActions({
   delete: { asyncResult: true },
   get: { asyncResult: true },
   list: { asyncResult: true },
+  listPage: { asyncResult: true },
   update: { asyncResult: true },
   updatePositions: { asyncResult: true },
 });

--- a/graylog2-web-interface/src/components/streams/Stream.jsx
+++ b/graylog2-web-interface/src/components/streams/Stream.jsx
@@ -48,7 +48,7 @@ const Stream = createReactClass({
     if (stream.is_default) {
       return 'The default stream contains all messages.';
     }
-    if (stream.rules.length === 0) {
+    if (!stream.rules || stream.rules.length === 0) {
       return 'No configured rules.';
     }
 

--- a/graylog2-web-interface/src/components/streams/StreamComponent.jsx
+++ b/graylog2-web-interface/src/components/streams/StreamComponent.jsx
@@ -1,17 +1,15 @@
 import PropTypes from 'prop-types';
 import React from 'react';
-import { Row, Col, Alert } from 'react-bootstrap';
-
-import { IfPermitted, TypeAheadDataFilter } from 'components/common';
+import { Row, Col } from 'react-bootstrap';
+import { PaginatedList, SearchForm } from 'components/common';
 
 import StoreProvider from 'injection/StoreProvider';
+import Spinner from 'components/common/Spinner';
+import StreamList from './StreamList';
+
 const StreamsStore = StoreProvider.getStore('Streams');
 const StreamRulesStore = StoreProvider.getStore('StreamRules');
 
-import StreamList from './StreamList';
-import Spinner from 'components/common/Spinner';
-
-import CreateStreamButton from './CreateStreamButton';
 
 class StreamComponent extends React.Component {
   static propTypes = {
@@ -20,7 +18,15 @@ class StreamComponent extends React.Component {
     indexSets: PropTypes.array.isRequired,
   };
 
-  state = {};
+  state = {
+    pagination: {
+      page: 1,
+      perPage: 10,
+      count: 0,
+      total: 0,
+      query: '',
+    },
+  };
 
   componentDidMount() {
     this.loadData();
@@ -31,38 +37,50 @@ class StreamComponent extends React.Component {
     StreamRulesStore.onChange(this.loadData);
   }
 
-  componentDidUpdate() {
-    if (this.state.filteredStreams === null) {
-      this._filterStreams();
-    }
-  }
-
   componentWillUnmount() {
     StreamsStore.unregister(this.loadData);
     StreamRulesStore.unregister(this.loadData);
   }
 
-  loadData = () => {
-    StreamsStore.load((streams) => {
-      this.setState({
-        streams: streams,
-        filteredStreams: null,
+  loadData = (callback) => {
+    const { page, perPage, query } = this.state.pagination;
+    StreamsStore.searchPaginated(page, perPage, query)
+      .then(({ streams, pagination }) => {
+        this.setState({
+          streams: streams,
+          pagination: pagination,
+        });
+      })
+      .then(() => {
+        if (callback) {
+          callback();
+        }
       });
-    });
-  };
-
-  _filterStreams = () => {
-    if (this.streamFilter) {
-      this.streamFilter.filterData();
-    }
-  };
-
-  _updateFilteredStreams = (filteredStreams) => {
-    this.setState({ filteredStreams: filteredStreams });
   };
 
   _isLoading = () => {
     return !(this.state.streams && this.state.streamRuleTypes);
+  };
+
+  _onPageChange = (newPage, newPerPage) => {
+    const pagination = this.state.pagination;
+    const newPagination = Object.assign(pagination, {
+      page: newPage,
+      perPage: newPerPage,
+    });
+    this.setState({ pagination, newPagination }, this.loadData);
+  };
+
+  _onSearch = (query, resetLoadingCallback) => {
+    const pagination = this.state.pagination;
+    const newPagination = Object.assign(pagination, { query: query });
+    this.setState({ pagination, newPagination }, () => this.loadData(resetLoadingCallback));
+  };
+
+  _onReset = () => {
+    const pagination = this.state.pagination;
+    const newPagination = Object.assign(pagination, { query: '' });
+    this.setState({ pagination, newPagination }, this.loadData);
   };
 
   render() {
@@ -74,44 +92,28 @@ class StreamComponent extends React.Component {
       );
     }
 
-    if (this.state.streams.length === 0) {
-      const createStreamButton = (
-        <IfPermitted permissions="streams:create">
-          <CreateStreamButton bsSize="small" bsStyle="link" className="btn-text"
-                              buttonText="Create one now"
-                              indexSets={this.props.indexSets}
-                              onSave={this.props.onStreamSave} />
-        </IfPermitted>
-      );
-
-      return (
-        <Alert bsStyle="warning">
-          <i className="fa fa-info-circle" />&nbsp;No streams configured. {createStreamButton}
-        </Alert>
-      );
-    }
-
-    const streamsList = this.state.filteredStreams ? (<StreamList streams={this.state.filteredStreams} streamRuleTypes={this.state.streamRuleTypes}
-                                                                  permissions={this.props.currentUser.permissions} user={this.props.currentUser}
-                                                                  onStreamSave={this.props.onStreamSave} indexSets={this.props.indexSets} />) : <Spinner />;
+    const streamsList = (<StreamList streams={this.state.streams}
+                                    streamRuleTypes={this.state.streamRuleTypes}
+                                    permissions={this.props.currentUser.permissions}
+                                    user={this.props.currentUser}
+                                    onStreamSave={this.props.onStreamSave}
+                                    indexSets={this.props.indexSets} />);
 
     return (
       <div>
         <Row className="row-sm">
           <Col md={8}>
-            <TypeAheadDataFilter id="stream-data-filter"
-                                 ref={(streamFilter) => { this.streamFilter = streamFilter; }}
-                                 label="Filter streams"
-                                 data={this.state.streams}
-                                 displayKey={'title'}
-                                 filterSuggestions={[]}
-                                 searchInKeys={['title', 'description']}
-                                 onDataFiltered={this._updateFilteredStreams} />
+            <SearchForm onSearch={this._onSearch} onReset={this._onReset} useLoadingState />
           </Col>
         </Row>
         <Row>
           <Col md={12}>
-            {streamsList}
+            <PaginatedList onChange={this._onPageChange}
+                           totalItems={this.state.pagination.total}>
+              <br />
+              <br />
+              <div>{streamsList}</div>
+            </PaginatedList>
           </Col>
         </Row>
       </div>

--- a/graylog2-web-interface/src/routing/ApiRoutes.js
+++ b/graylog2-web-interface/src/routing/ApiRoutes.js
@@ -183,6 +183,7 @@ const ApiRoutes = {
   },
   StreamsApiController: {
     index: () => { return { url: '/streams' }; },
+    indexPage: () => { return { url: '/streams/page' }; },
     get: (streamId) => { return { url: `/streams/${streamId}` }; },
     create: () => { return { url: '/streams' }; },
     update: (streamId) => { return { url: `/streams/${streamId}` }; },

--- a/graylog2-web-interface/src/routing/ApiRoutes.js
+++ b/graylog2-web-interface/src/routing/ApiRoutes.js
@@ -59,6 +59,7 @@ const ApiRoutes = {
   DashboardsApiController: {
     create: () => { return { url: '/dashboards' }; },
     index: () => { return { url: '/dashboards' }; },
+    pageIndex: () => { return { url: '/dashboards/page' }; },
     get: (id) => { return { url: `/dashboards/${id}` }; },
     delete: (id) => { return { url: `/dashboards/${id}` }; },
     update: (id) => { return { url: `/dashboards/${id}` }; },

--- a/graylog2-web-interface/src/stores/lookup-tables/LookupTablesStore.js
+++ b/graylog2-web-interface/src/stores/lookup-tables/LookupTablesStore.js
@@ -1,6 +1,7 @@
 import Reflux from 'reflux';
 
 import UserNotification from 'util/UserNotification';
+import PaginationHelper from 'util/PaginationHelper';
 import URLUtils from 'util/URLUtils';
 import fetch from 'logic/rest/FetchProvider';
 
@@ -40,13 +41,7 @@ const LookupTablesStore = Reflux.createStore({
   },
 
   searchPaginated(page, perPage, query) {
-    let url;
-    if (query) {
-      url = this._url(
-        `tables?page=${page}&per_page=${perPage}&query=${encodeURIComponent(query)}&resolve=true`);
-    } else {
-      url = this._url(`tables?page=${page}&per_page=${perPage}&resolve=true`);
-    }
+    const url = this._url(PaginationHelper.urlGenerator('tables', page, perPage, query));
     const promise = fetch('GET', url);
 
     promise.then((response) => {

--- a/graylog2-web-interface/src/stores/streams/StreamsStore.ts
+++ b/graylog2-web-interface/src/stores/streams/StreamsStore.ts
@@ -1,5 +1,6 @@
 const UserNotification = require('util/UserNotification');
 const URLUtils = require('util/URLUtils');
+const PaginationHelper = require('util/PaginationHelper');
 import ApiRoutes = require('routing/ApiRoutes');
 const fetch = require('logic/rest/FetchProvider').default;
 const lodash = require('lodash');
@@ -42,6 +43,28 @@ class StreamsStore {
           UserNotification.error("Loading streams failed with status: " + errorThrown,
               "Could not load streams");
         });
+    return promise;
+  }
+  searchPaginated(page, perPage, query) {
+    const url = PaginationHelper.urlGenerator("/streams/page", page, perPage, query);
+    const promise = fetch('GET', URLUtils.qualifyUrl(url))
+      .then(response => {
+        const pagination = {
+          count: response.pagination.count,
+          total: response.pagination.total,
+          page: response.pagination.page,
+          perPage: response.pagination.per_page,
+          query: response.pagination.query,
+        };
+        return {
+          streams: response.streams,
+          pagination: pagination,
+        };
+      })
+      .catch((errorThrown) => {
+        UserNotification.error("Loading streams failed with status: " + errorThrown,
+          "Could not load streams");
+      });
     return promise;
   }
   load(callback: ((streams: Array<Stream>) => void)) {

--- a/graylog2-web-interface/src/stores/streams/StreamsStore.ts
+++ b/graylog2-web-interface/src/stores/streams/StreamsStore.ts
@@ -46,7 +46,7 @@ class StreamsStore {
     return promise;
   }
   searchPaginated(page, perPage, query) {
-    const url = PaginationHelper.urlGenerator("/streams/page", page, perPage, query);
+    const url = PaginationHelper.urlGenerator(ApiRoutes.StreamsApiController.indexPage().url, page, perPage, query);
     const promise = fetch('GET', URLUtils.qualifyUrl(url))
       .then(response => {
         const pagination = {

--- a/graylog2-web-interface/src/util/PaginationHelper.js
+++ b/graylog2-web-interface/src/util/PaginationHelper.js
@@ -1,0 +1,13 @@
+const PaginationHelper = {
+  urlGenerator: (destUrl, page, perPage, query) => {
+    let url;
+    if (query) {
+      url = `${destUrl}?page=${page}&per_page=${perPage}&query=${encodeURIComponent(query)}&resolve=true`;
+    } else {
+      url = `${destUrl}?page=${page}&per_page=${perPage}&resolve=true`;
+    }
+    return url;
+  },
+};
+
+export default PaginationHelper;


### PR DESCRIPTION
## Description
Add pagination to the dashboard overview page together with filtering.

## Motivation and Context
A good overview page should have: Search and Pagination.
This PR add pagination and uses the search on the backend site.
The code is mainly copied from lookup table.
The list all API endpoint is kept since it makes sense when using  scripts to avoid stepping
through all dashboards with pages.

## How Has This Been Tested?
Add more than 10 dashboards and stepped through the pages and searched for streams.
Created, updated and deleted dashboards and ensured that table refreshes accordingly.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

# Caution
This PR is based on #5675 and must be merged **after** that PR.

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
