### PR TITLE
Also return ES "caused_by" error message for failed searches

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/indexer/searches/SearchFailure.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/searches/SearchFailure.java
@@ -1,3 +1,19 @@
+/**
+ * This file is part of Graylog.
+ *
+ * Graylog is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package org.graylog2.indexer.searches;
 
 import com.fasterxml.jackson.databind.JsonNode;

--- a/graylog2-server/src/main/java/org/graylog2/indexer/searches/SearchFailure.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/searches/SearchFailure.java
@@ -1,0 +1,37 @@
+package org.graylog2.indexer.searches;
+
+import com.fasterxml.jackson.databind.JsonNode;
+
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.StreamSupport;
+
+public class SearchFailure {
+
+    final private List<String> errors;
+
+    public SearchFailure(JsonNode shards) {
+        errors = StreamSupport.stream(shards.path("failures").spliterator(), false)
+                .map(failure -> {
+                    final String error = failure.path("reason").path("reason").asText();
+                    final String caused_by = failure.path("reason").path("caused_by").toString();
+                    if (!caused_by.isEmpty()) {
+                        return error + " caused_by: " + caused_by;
+                    }
+                    return error;
+                })
+                .filter(s -> !s.isEmpty())
+                .collect(Collectors.toList());
+    }
+
+    public List<String> getErrors() {
+        return errors;
+    }
+
+    public List<String> getNonNumericFieldErrors() {
+        return errors.stream().filter(error ->
+                error.startsWith("Expected numeric type on field") ||
+                error.contains("\"type\":\"number_format_exception")).
+                collect(Collectors.toList());
+    }
+}

--- a/graylog2-server/src/main/java/org/graylog2/indexer/searches/Searches.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/searches/Searches.java
@@ -710,7 +710,8 @@ public class Searches {
                 .collect(Collectors.toList());
 
             final List<String> nonNumericFieldErrors = errors.stream()
-                .filter(error -> error.startsWith("Expected numeric type on field"))
+                .filter(error -> error.startsWith("Expected numeric type on field") ||
+                        error.contains("\"type\":\"number_format_exception"))
                 .collect(Collectors.toList());
             if (!nonNumericFieldErrors.isEmpty()) {
                 throw new FieldTypeException("Unable to perform search query", nonNumericFieldErrors);

--- a/graylog2-server/src/main/java/org/graylog2/indexer/searches/Searches.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/searches/Searches.java
@@ -698,7 +698,14 @@ public class Searches {
 
         if (failedShards > 0) {
             final List<String> errors = StreamSupport.stream(shards.path("failures").spliterator(), false)
-                .map(failure -> failure.path("reason").path("reason").asText())
+                .map(failure -> {
+                    final String error = failure.path("reason").path("reason").asText();
+                    final String caused_by = failure.path("reason").path("caused_by").toString();
+                    if (!caused_by.isEmpty()) {
+                        return error + " caused_by: " + caused_by;
+                    }
+                    return error;
+                })
                 .filter(s -> !s.isEmpty())
                 .collect(Collectors.toList());
 

--- a/graylog2-server/src/main/java/org/graylog2/indexer/searches/Searches.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/searches/Searches.java
@@ -95,7 +95,6 @@ import java.util.function.Supplier;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
-import java.util.stream.StreamSupport;
 
 import static com.codahale.metrics.MetricRegistry.name;
 import static com.google.common.base.Strings.isNullOrEmpty;
@@ -697,27 +696,14 @@ public class Searches {
         final double failedShards = shards.path("failed").asDouble();
 
         if (failedShards > 0) {
-            final List<String> errors = StreamSupport.stream(shards.path("failures").spliterator(), false)
-                .map(failure -> {
-                    final String error = failure.path("reason").path("reason").asText();
-                    final String caused_by = failure.path("reason").path("caused_by").toString();
-                    if (!caused_by.isEmpty()) {
-                        return error + " caused_by: " + caused_by;
-                    }
-                    return error;
-                })
-                .filter(s -> !s.isEmpty())
-                .collect(Collectors.toList());
+            final SearchFailure searchFailure = new SearchFailure(shards);
+            final List<String> nonNumericFieldErrors = searchFailure.getNonNumericFieldErrors();
 
-            final List<String> nonNumericFieldErrors = errors.stream()
-                .filter(error -> error.startsWith("Expected numeric type on field") ||
-                        error.contains("\"type\":\"number_format_exception"))
-                .collect(Collectors.toList());
             if (!nonNumericFieldErrors.isEmpty()) {
                 throw new FieldTypeException("Unable to perform search query", nonNumericFieldErrors);
             }
 
-            throw new ElasticsearchException("Unable to perform search query", errors);
+            throw new ElasticsearchException("Unable to perform search query", searchFailure.getErrors());
         }
 
         return result;

--- a/graylog2-server/src/test/java/org/graylog2/indexer/searches/SearchFailureTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/indexer/searches/SearchFailureTest.java
@@ -1,3 +1,19 @@
+/**
+ * This file is part of Graylog.
+ *
+ * Graylog is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package org.graylog2.indexer.searches;
 
 import com.fasterxml.jackson.databind.JsonNode;

--- a/graylog2-server/src/test/java/org/graylog2/indexer/searches/SearchFailureTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/indexer/searches/SearchFailureTest.java
@@ -1,0 +1,53 @@
+package org.graylog2.indexer.searches;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.Test;
+
+import java.io.IOException;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class SearchFailureTest {
+
+    @Test
+    public void extractNumericFieldErrors() throws IOException {
+        final String searchResult =
+                " {\n" +
+                "      \"took\" : 2,\n" +
+                "      \"timed_out\" : false,\n" +
+                "      \"_shards\" : {\n" +
+                "        \"total\" : 64,\n" +
+                "        \"failures\" : [\n" +
+                "          {\n" +
+                "            \"shard\" : 0,\n" +
+                "            \"index\" : \"graylog_0\",\n" +
+                "            \"reason\" : {\n" +
+                "              \"type\" : \"query_shard_exception\",\n" +
+                "              \"reason\" : \"failed to create query: { [QUERY] }\",\n" +
+                "              \"index\" : \"graylog_0\",\n" +
+                "              \"caused_by\" : {\n" +
+                "                \"type\" : \"number_format_exception\",\n" +
+                "                \"reason\" : \"For input string: \\\"BADQUERYSTRING\\\"\"\n" +
+                "              }\n" +
+                "            }\n" +
+                "          }\n" +
+                "        ]\n" +
+                "      },\n" +
+                "      \"hits\" : {\n" +
+                "        \"total\" : 0,\n" +
+                "        \"max_score\" : null,\n" +
+                "        \"hits\" : [ ]\n" +
+                "      }\n" +
+                "    }\n";
+
+        ObjectMapper mapper = new ObjectMapper();
+        JsonNode jsonNode = mapper.readTree(searchResult);
+        final SearchFailure searchFailure = new SearchFailure(jsonNode.path("_shards"));
+        final String expectedResult = "failed to create query: { [QUERY] }" +
+                " caused_by: {\"type\":\"number_format_exception\",\"reason\":\"For input string: \\\"BADQUERYSTRING\\\"\"}";
+        assertThat(searchFailure.getNonNumericFieldErrors()).hasSize(1);
+        assertThat(searchFailure.getNonNumericFieldErrors().get(0)).isEqualTo(expectedResult);
+        assertThat(searchFailure.getErrors().get(0)).isEqualTo(expectedResult);
+    }
+}


### PR DESCRIPTION
If you search on a field that is mapped to a numeric,
you won't see the real reason on why this has failed.
I assume the error format has changed in recent ES versions,
and the info is now hidden in the `caused_by` field on shard failures.

For reference, this is the response:
```
{
  "took" : 2,
  "timed_out" : false,
  "_shards" : {
    "total" : 64,
    "failures" : [
      {
        "shard" : 0,
        "index" : "graylog_0",
        "reason" : {
          "type" : "query_shard_exception",
          "reason" : "failed to create query: {\n [....]  }\n}",
          "index" : "graylog_0",
          "caused_by" : {
            "type" : "number_format_exception",
            "reason" : "For input string: \"foo\""
          }
        }
      }
    ]
  },
  "hits" : {
    "total" : 0,
    "max_score" : null,
    "hits" : [ ]
  }
}
```