### PR TITLE
Paginated grok patterns

### DIFF
--- a/UPGRADING.rst
+++ b/UPGRADING.rst
@@ -11,6 +11,16 @@ Prior to v3.3.3, the certificates of LDAP servers which are connected to using a
 
 A `CVE <https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2020-15813>`_ is tracked for this issue.
 
+Deprecation of API endpoint for unpaginated listing of grok patterns
+====================================================================
+
+In 3.0 we introduce a new API endpoint to retrieve grok patterns from the backend: '/system/grok/paginated' which allows
+to pass pagination parameters.
+We therefore mark '/system/grok' as deprecated. Users who use this endpoint for scripting purpose should change
+their scripts to the format of the new endpoint, so they only need to to change the URL when '/system/grok/paginated' will become
+'/system/grok'.
+
+
 Deprecation of API endpoint for unpaginated listing of streams
 ==============================================================
 

--- a/graylog2-server/src/main/java/org/graylog2/grok/GrokPattern.java
+++ b/graylog2-server/src/main/java/org/graylog2/grok/GrokPattern.java
@@ -31,7 +31,12 @@ import javax.annotation.Nullable;
 @JsonAutoDetect
 public abstract class GrokPattern {
 
-    @JsonProperty("id")
+    public static final String FIELD_ID = "id";
+    public static final String FIELD_NAME = "name";
+    public static final String FIELD_PATTERN = "pattern";
+    public static final String FIELD_CONTENT_PACK = "content_pack";
+
+    @JsonProperty(FIELD_ID)
     @Nullable
     @Id
     @ObjectId
@@ -49,9 +54,9 @@ public abstract class GrokPattern {
 
     @JsonCreator
     public static GrokPattern create(@Id @ObjectId @JsonProperty("_id") @Nullable String id,
-                                     @JsonProperty("name") String name,
-                                     @JsonProperty("pattern") String pattern,
-                                     @JsonProperty("content_pack") @Nullable String contentPack) {
+                                     @JsonProperty(FIELD_NAME) String name,
+                                     @JsonProperty(FIELD_PATTERN) String pattern,
+                                     @JsonProperty(FIELD_CONTENT_PACK) @Nullable String contentPack) {
         return builder()
                 .id(id)
                 .name(name)

--- a/graylog2-server/src/main/java/org/graylog2/grok/PaginatedGrokPatternService.java
+++ b/graylog2-server/src/main/java/org/graylog2/grok/PaginatedGrokPatternService.java
@@ -1,0 +1,47 @@
+/**
+ * This file is part of Graylog.
+ *
+ * Graylog is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.graylog2.grok;
+
+import com.google.inject.Inject;
+import org.graylog2.bindings.providers.MongoJackObjectMapperProvider;
+import org.graylog2.database.MongoConnection;
+import org.graylog2.database.PaginatedDbService;
+import org.graylog2.database.PaginatedList;
+import org.graylog2.search.SearchQuery;
+import org.mongojack.DBQuery;
+import org.mongojack.DBSort;
+
+public class PaginatedGrokPatternService extends PaginatedDbService<GrokPattern> {
+    private static final String COLLECTION_NAME = "grok_patterns";
+
+    @Inject
+    public PaginatedGrokPatternService(MongoConnection mongoConnection,
+                                  MongoJackObjectMapperProvider mapper)
+    {
+        super(mongoConnection, mapper, GrokPattern.class, COLLECTION_NAME);
+    }
+
+    public long count() {
+        return db.count();
+    }
+
+    public PaginatedList<GrokPattern> findPaginated(SearchQuery searchQuery, int page, int perPage, String sortField, String order) {
+        final DBQuery.Query dbQuery = searchQuery.toDBQuery();
+        final DBSort.SortBuilder sortBuilder = getSortBuilder(order, sortField);
+        return findPaginatedWithQueryAndSort(dbQuery, sortBuilder, page, perPage);
+    }
+}

--- a/graylog2-server/src/main/java/org/graylog2/rest/models/system/responses/GrokPatternPageList.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/models/system/responses/GrokPatternPageList.java
@@ -1,0 +1,67 @@
+/**
+ * This file is part of Graylog.
+ *
+ * Graylog is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.graylog2.rest.models.system.responses;
+
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.auto.value.AutoValue;
+import org.graylog.autovalue.WithBeanGetter;
+import org.graylog2.database.PaginatedList;
+import org.graylog2.grok.GrokPattern;
+
+import javax.annotation.Nullable;
+import java.util.Collection;
+
+@AutoValue
+@WithBeanGetter
+@JsonAutoDetect
+public abstract class GrokPatternPageList {
+    @Nullable
+    @JsonProperty
+    public abstract String query();
+
+
+    @JsonProperty("pagination")
+    public abstract PaginatedList.PaginationInfo paginationInfo();
+
+    @JsonProperty
+    public abstract long total();
+
+    @Nullable
+    @JsonProperty
+    public abstract String sort();
+
+    @Nullable
+    @JsonProperty
+    public abstract String order();
+
+    @JsonProperty
+    public abstract Collection<GrokPattern> patterns();
+
+
+    @JsonCreator
+    public static GrokPatternPageList create(
+            @JsonProperty("query") @Nullable String query,
+            @JsonProperty("pagination") PaginatedList.PaginationInfo paginationInfo,
+            @JsonProperty("total") long total,
+            @JsonProperty("sort") @Nullable String sort,
+            @JsonProperty("order") @Nullable String order,
+            @JsonProperty("patterns") Collection<GrokPattern> patternList) {
+        return new AutoValue_GrokPatternPageList(query, paginationInfo, total, sort, order, patternList);
+    }
+}

--- a/graylog2-server/src/main/java/org/graylog2/rest/resources/system/GrokResource.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/resources/system/GrokResource.java
@@ -107,7 +107,7 @@ public class GrokResource extends RestResource {
 
     @GET
     @Timed
-    @Path("/page")
+    @Path("/paginated")
     @ApiOperation("Get existing grok patterns paged")
     @Produces(MediaType.APPLICATION_JSON)
     public GrokPatternPageList getPage(@ApiParam(name = "page") @QueryParam("page") @DefaultValue("1") int page,

--- a/graylog2-server/src/main/java/org/graylog2/rest/resources/system/GrokResource.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/resources/system/GrokResource.java
@@ -32,9 +32,9 @@ import org.graylog2.grok.GrokPattern;
 import org.graylog2.grok.GrokPatternService;
 import org.graylog2.grok.PaginatedGrokPatternService;
 import org.graylog2.plugin.database.ValidationException;
+import org.graylog2.rest.models.PaginatedResponse;
 import org.graylog2.rest.models.system.grokpattern.requests.GrokPatternTestRequest;
 import org.graylog2.rest.models.system.responses.GrokPatternList;
-import org.graylog2.rest.models.system.responses.GrokPatternPageList;
 import org.graylog2.search.SearchQuery;
 import org.graylog2.search.SearchQueryField;
 import org.graylog2.search.SearchQueryParser;
@@ -110,15 +110,15 @@ public class GrokResource extends RestResource {
     @Path("/paginated")
     @ApiOperation("Get existing grok patterns paged")
     @Produces(MediaType.APPLICATION_JSON)
-    public GrokPatternPageList getPage(@ApiParam(name = "page") @QueryParam("page") @DefaultValue("1") int page,
-                                       @ApiParam(name = "per_page") @QueryParam("per_page") @DefaultValue("50") int perPage,
-                                       @ApiParam(name = "query") @QueryParam("query") @DefaultValue("") String query,
-                                       @ApiParam(name = "sort",
+    public PaginatedResponse<GrokPattern> getPage(@ApiParam(name = "page") @QueryParam("page") @DefaultValue("1") int page,
+                                     @ApiParam(name = "per_page") @QueryParam("per_page") @DefaultValue("50") int perPage,
+                                     @ApiParam(name = "query") @QueryParam("query") @DefaultValue("") String query,
+                                     @ApiParam(name = "sort",
                                                value = "The field to sort the result on",
                                                required = true,
                                                allowableValues = "title,description,id")
                                        @DefaultValue(GrokPattern.FIELD_NAME) @QueryParam("sort") String sort,
-                                       @ApiParam(name = "order", value = "The sort direction", allowableValues = "asc, desc")
+                                     @ApiParam(name = "order", value = "The sort direction", allowableValues = "asc, desc")
                                        @DefaultValue("asc") @QueryParam("order") String order) {
         checkPermission(RestPermissions.INPUTS_READ);
 
@@ -130,9 +130,8 @@ public class GrokResource extends RestResource {
         }
         final PaginatedList<GrokPattern> result = paginatedGrokPatternService
                 .findPaginated(searchQuery, page, perPage, sort, order);
-        final long total = paginatedGrokPatternService.count();
 
-        return GrokPatternPageList.create(query, result.pagination(), total, sort, order, result);
+        return PaginatedResponse.create("patterns", result);
     }
 
     @GET

--- a/graylog2-server/src/main/java/org/graylog2/rest/resources/system/GrokResource.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/resources/system/GrokResource.java
@@ -69,7 +69,6 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
-
 @RequiresAuthentication
 @Path("/system/grok")
 @Produces("application/json")
@@ -98,6 +97,7 @@ public class GrokResource extends RestResource {
 
     @GET
     @Timed
+    @Deprecated
     @ApiOperation("Get all existing grok patterns")
     public GrokPatternList listGrokPatterns() {
         checkPermission(RestPermissions.INPUTS_READ);

--- a/graylog2-web-interface/src/components/common/PaginatedList.jsx
+++ b/graylog2-web-interface/src/components/common/PaginatedList.jsx
@@ -58,7 +58,9 @@ const PaginatedList = ({
   const numberPages = Math.ceil(totalItems / pageSize);
 
   useEffect(() => {
-    setCurrentPage(activePage);
+    if (activePage && activePage > 0) {
+      setCurrentPage(activePage);
+    }
   }, [activePage]);
 
   useEffect(() => {

--- a/graylog2-web-interface/src/components/common/PaginatedList.jsx
+++ b/graylog2-web-interface/src/components/common/PaginatedList.jsx
@@ -58,7 +58,7 @@ const PaginatedList = ({
   const numberPages = Math.ceil(totalItems / pageSize);
 
   useEffect(() => {
-    if (activePage && activePage > 0) {
+    if (activePage > 0) {
       setCurrentPage(activePage);
     }
   }, [activePage]);

--- a/graylog2-web-interface/src/components/grok-patterns/GrokPatternQueryHelper.jsx
+++ b/graylog2-web-interface/src/components/grok-patterns/GrokPatternQueryHelper.jsx
@@ -1,0 +1,35 @@
+// @flow strict
+import React from 'react';
+
+import { Popover, Table } from 'components/graylog';
+
+const GrokPatternQueryHelper = () => (
+  <Popover id="search-query-help" className="popover-wide" title="Search Syntax Help">
+    <p><strong>Available search fields</strong></p>
+    <Table condensed>
+      <thead>
+        <tr>
+          <th>Field</th>
+          <th>Description</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td>name</td>
+          <td>The grok patterns name</td>
+        </tr>
+        <tr>
+          <td>pattern</td>
+          <td>The pattern of the grok pattern</td>
+        </tr>
+      </tbody>
+    </Table>
+    <p><strong>Examples</strong></p>
+    <p>
+      Find grok patterns containing COMMON in the pattern:<br />
+      <kbd>pattern:COMMON</kbd><br />
+    </p>
+  </Popover>
+);
+
+export default GrokPatternQueryHelper;

--- a/graylog2-web-interface/src/components/grok-patterns/GrokPatternQueryHelper.jsx
+++ b/graylog2-web-interface/src/components/grok-patterns/GrokPatternQueryHelper.jsx
@@ -1,5 +1,5 @@
 // @flow strict
-import React from 'react';
+import * as React from 'react';
 
 import { Popover, Table } from 'components/graylog';
 

--- a/graylog2-web-interface/src/components/grok-patterns/GrokPatterns.jsx
+++ b/graylog2-web-interface/src/components/grok-patterns/GrokPatterns.jsx
@@ -1,13 +1,17 @@
 import React from 'react';
 import styled from 'styled-components';
 
-import { Icon, PaginatedList, SearchForm } from 'components/common';
+import {
+  DataTable,
+  Icon,
+  IfPermitted,
+  PageHeader,
+  PaginatedList,
+  SearchForm,
+} from 'components/common';
 import { Button, Col, Row, OverlayTrigger } from 'components/graylog';
-import PageHeader from 'components/common/PageHeader';
 import EditPatternModal from 'components/grok-patterns/EditPatternModal';
 import BulkLoadPatternModal from 'components/grok-patterns/BulkLoadPatternModal';
-import DataTable from 'components/common/DataTable';
-import IfPermitted from 'components/common/IfPermitted';
 import StoreProvider from 'injection/StoreProvider';
 
 import GrokPatternQueryHelper from './GrokPatternQueryHelper';
@@ -51,8 +55,7 @@ class GrokPatterns extends React.Component {
   }
 
   loadData = (callback) => {
-    const { pagination: pagination1 } = this.state;
-    const { page, perPage, query } = pagination1;
+    const { pagination: { page, perPage, query } } = this.state;
 
     this.loadPromise = GrokPatternsStore.searchPaginated(page, perPage, query)
       .then(({ patterns, pagination }) => {
@@ -63,10 +66,7 @@ class GrokPatterns extends React.Component {
         if (!this.loadPromise.isCancelled()) {
           this.loadPromise = undefined;
 
-          this.setState({
-            patterns: patterns,
-            pagination,
-          });
+          this.setState({ patterns, pagination });
         }
       });
   };
@@ -135,8 +135,8 @@ class GrokPatterns extends React.Component {
   };
 
   _patternFormatter = (pattern) => {
-    const { patterns: patterns1 } = this.state;
-    const patterns = patterns1.filter((p) => p.name !== pattern.name);
+    const { patterns: unfilteredPatterns } = this.state;
+    const patterns = unfilteredPatterns.filter((p) => p.name !== pattern.name);
 
     return (
       <tr key={pattern.id}>
@@ -216,8 +216,6 @@ class GrokPatterns extends React.Component {
                 <Col md={12}>
                   <PaginatedList onChange={this._onPageChange}
                                  totalItems={pagination.total}>
-                    <br />
-                    <br />
                     <GrokPatternsList id="grok-pattern-list"
                                       className="table-striped table-hover"
                                       headers={headers}

--- a/graylog2-web-interface/src/components/grok-patterns/GrokPatterns.jsx
+++ b/graylog2-web-interface/src/components/grok-patterns/GrokPatterns.jsx
@@ -1,14 +1,16 @@
 import React from 'react';
 import styled from 'styled-components';
 
-import { PaginatedList, SearchForm } from 'components/common';
-import { Button, Col, Row } from 'components/graylog';
+import { Icon, PaginatedList, SearchForm } from 'components/common';
+import { Button, Col, Row, OverlayTrigger } from 'components/graylog';
 import PageHeader from 'components/common/PageHeader';
 import EditPatternModal from 'components/grok-patterns/EditPatternModal';
 import BulkLoadPatternModal from 'components/grok-patterns/BulkLoadPatternModal';
 import DataTable from 'components/common/DataTable';
 import IfPermitted from 'components/common/IfPermitted';
 import StoreProvider from 'injection/StoreProvider';
+
+import GrokPatternQueryHelper from './GrokPatternQueryHelper';
 
 const GrokPatternsStore = StoreProvider.getStore('GrokPatterns');
 
@@ -167,6 +169,14 @@ class GrokPatterns extends React.Component {
     const headers = ['Name', 'Pattern', 'Actions'];
     const { pagination, patterns } = this.state;
 
+    const queryHelperComponent = (
+      <OverlayTrigger trigger="click" rootClose placement="bottom" overlay={<GrokPatternQueryHelper />}>
+        <Button bsStyle="link" className="archive-search-help-button">
+          <Icon name="question-circle" fixedWidth />
+        </Button>
+      </OverlayTrigger>
+    );
+
     return (
       <div>
         <PageHeader title="Grok patterns">
@@ -196,7 +206,10 @@ class GrokPatterns extends React.Component {
             <IfPermitted permissions="inputs:read">
               <Row className="row-sm">
                 <Col md={8}>
-                  <SearchForm onSearch={this._onSearch} onReset={this._onReset} useLoadingState />
+                  <SearchForm onSearch={this._onSearch}
+                              onReset={this._onReset}
+                              queryHelpComponent={queryHelperComponent}
+                              useLoadingState />
                 </Col>
               </Row>
               <Row>

--- a/graylog2-web-interface/src/components/grok-patterns/GrokPatterns.jsx
+++ b/graylog2-web-interface/src/components/grok-patterns/GrokPatterns.jsx
@@ -25,6 +25,7 @@ const GrokPatternsList = styled(DataTable)`
 class GrokPatterns extends React.Component {
   constructor(props) {
     super(props);
+
     this.state = {
       patterns: [],
       pagination: {
@@ -50,6 +51,7 @@ class GrokPatterns extends React.Component {
   loadData = (callback) => {
     const { pagination: pagination1 } = this.state;
     const { page, perPage, query } = pagination1;
+
     this.loadPromise = GrokPatternsStore.searchPaginated(page, perPage, query)
       .then(({ patterns, pagination }) => {
         if (callback) {
@@ -58,6 +60,7 @@ class GrokPatterns extends React.Component {
 
         if (!this.loadPromise.isCancelled()) {
           this.loadPromise = undefined;
+
           this.setState({
             patterns: patterns,
             pagination,
@@ -69,6 +72,7 @@ class GrokPatterns extends React.Component {
   validPatternName = (name) => {
     // Check if patterns already contain a pattern with the given name.
     const { patterns } = this.state;
+
     return !patterns.some((pattern) => pattern.name === name);
   };
 
@@ -131,6 +135,7 @@ class GrokPatterns extends React.Component {
   _patternFormatter = (pattern) => {
     const { patterns: patterns1 } = this.state;
     const patterns = patterns1.filter((p) => p.name !== pattern.name);
+
     return (
       <tr key={pattern.id}>
         <td>{pattern.name}</td>
@@ -161,6 +166,7 @@ class GrokPatterns extends React.Component {
   render() {
     const headers = ['Name', 'Pattern', 'Actions'];
     const { pagination, patterns } = this.state;
+
     return (
       <div>
         <PageHeader title="Grok patterns">

--- a/graylog2-web-interface/src/components/grok-patterns/GrokPatterns.jsx
+++ b/graylog2-web-interface/src/components/grok-patterns/GrokPatterns.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import createReactClass from 'create-react-class';
 import styled from 'styled-components';
 
+import { PaginatedList, SearchForm } from 'components/common';
 import { Row, Col, Button } from 'components/graylog';
 import PageHeader from 'components/common/PageHeader';
 import EditPatternModal from 'components/grok-patterns/EditPatternModal';
@@ -28,6 +29,13 @@ const GrokPatterns = createReactClass({
   getInitialState() {
     return {
       patterns: [],
+      pagination: {
+        page: 1,
+        perPage: 10,
+        count: 0,
+        total: 0,
+        query: '',
+      },
     };
   },
 
@@ -41,16 +49,22 @@ const GrokPatterns = createReactClass({
     }
   },
 
-  loadData() {
-    this.loadPromise = GrokPatternsStore.loadPatterns((patterns) => {
-      if (!this.loadPromise.isCancelled()) {
-        this.loadPromise = undefined;
+  loadData(callback) {
+    const { page, perPage, query } = this.state.pagination;
+    this.loadPromise = GrokPatternsStore.searchPaginated(page, perPage, query)
+      .then(({ patterns, pagination }) => {
+        if (callback) {
+          callback();
+        }
 
-        this.setState({
-          patterns: patterns,
-        });
-      }
-    });
+        if (!this.loadPromise.isCancelled()) {
+          this.loadPromise = undefined;
+          this.setState({
+            patterns: patterns,
+            pagination,
+          });
+        }
+      });
   },
 
   validPatternName(name) {
@@ -67,6 +81,27 @@ const GrokPatterns = createReactClass({
 
   testPattern(pattern, callback, errCallback) {
     GrokPatternsStore.testPattern(pattern, callback, errCallback);
+  },
+
+  _onPageChange(newPage, newPerPage) {
+    const pagination = this.state.pagination;
+    const newPagination = Object.assign(pagination, {
+      page: newPage,
+      perPage: newPerPage,
+    });
+    this.setState({ pagination, newPagination }, this.loadData);
+  },
+
+  _onSearch(query, resetLoadingCallback) {
+    const pagination = this.state.pagination;
+    const newPagination = Object.assign(pagination, { query: query });
+    this.setState({ pagination, newPagination }, () => this.loadData(resetLoadingCallback));
+  },
+
+  _onReset() {
+    const pagination = this.state.pagination;
+    const newPagination = Object.assign(pagination, { query: '' });
+    this.setState({ pagination, newPagination }, this.loadData);
   },
 
   confirmedRemove(pattern) {
@@ -124,7 +159,6 @@ const GrokPatterns = createReactClass({
 
   render() {
     const headers = ['Name', 'Pattern', 'Actions'];
-    const filterKeys = ['name'];
 
     return (
       <div>
@@ -153,15 +187,29 @@ const GrokPatterns = createReactClass({
         <Row className="content">
           <Col md={12}>
             <IfPermitted permissions="inputs:read">
-              <GrokPatternsList id="grok-pattern-list"
-                                className="table-striped table-hover"
-                                headers={headers}
-                                headerCellFormatter={this._headerCellFormatter}
-                                sortByKey="name"
-                                rows={this.state.patterns}
-                                dataRowFormatter={this._patternFormatter}
-                                filterLabel="Filter patterns"
-                                filterKeys={filterKeys} />
+              <Row className="row-sm">
+                <Col md={8}>
+                  <SearchForm onSearch={this._onSearch} onReset={this._onReset} useLoadingState />
+                </Col>
+              </Row>
+              <Row>
+                <Col md={12}>
+                  <PaginatedList onChange={this._onPageChange}
+                                 totalItems={this.state.pagination.total}>
+                    <br />
+                    <br />
+                    <GrokPatternsList id="grok-pattern-list"
+                                      className="table-striped table-hover"
+                                      headers={headers}
+                                      headerCellFormatter={this._headerCellFormatter}
+                                      sortByKey="name"
+                                      rows={this.state.patterns}
+                                      dataRowFormatter={this._patternFormatter}
+                                      filterLabel="Filter patterns"
+                                      filterKeys={filterKeys} />
+                  </PaginatedList>
+                </Col>
+              </Row>
             </IfPermitted>
           </Col>
         </Row>

--- a/graylog2-web-interface/src/routing/ApiRoutes.js
+++ b/graylog2-web-interface/src/routing/ApiRoutes.js
@@ -58,6 +58,7 @@ const ApiRoutes = {
   },
   GrokPatternsController: {
     test: () => { return { url: '/system/grok/test' }; },
+    indexPage: () => { return { url: '/system/grok/page' }; },
   },
   DashboardsApiController: {
     create: () => { return { url: '/dashboards' }; },

--- a/graylog2-web-interface/src/routing/ApiRoutes.js
+++ b/graylog2-web-interface/src/routing/ApiRoutes.js
@@ -58,7 +58,7 @@ const ApiRoutes = {
   },
   GrokPatternsController: {
     test: () => { return { url: '/system/grok/test' }; },
-    indexPage: () => { return { url: '/system/grok/page' }; },
+    paginated: () => { return { url: '/system/grok/paginated' }; },
   },
   DashboardsApiController: {
     create: () => { return { url: '/dashboards' }; },

--- a/graylog2-web-interface/src/stores/grok-patterns/GrokPatternsStore.js
+++ b/graylog2-web-interface/src/stores/grok-patterns/GrokPatternsStore.js
@@ -49,7 +49,7 @@ const GrokPatternsStore = Reflux.createStore({
   },
 
   searchPaginated(page, perPage, query) {
-    const url = PaginationHelper.urlGenerator(ApiRoutes.GrokPatternsController.indexPage().url, page, perPage, query);
+    const url = PaginationHelper.urlGenerator(ApiRoutes.GrokPatternsController.paginated().url, page, perPage, query);
     const promise = fetch('GET', URLUtils.qualifyUrl(url))
       .then((response: any) => {
         const pagination = {

--- a/graylog2-web-interface/src/stores/grok-patterns/GrokPatternsStore.js
+++ b/graylog2-web-interface/src/stores/grok-patterns/GrokPatternsStore.js
@@ -4,7 +4,7 @@ import Reflux from 'reflux';
 import fetch, { fetchPlainText } from 'logic/rest/FetchProvider';
 import PaginationURL from 'util/PaginationURL';
 import ApiRoutes from 'routing/ApiRoutes';
-import URLUtils from 'util/URLUtils';
+import { qualifyUrl } from 'util/URLUtils';
 import UserNotification from 'util/UserNotification';
 
 type GrokPattern = {
@@ -21,7 +21,7 @@ type GrokPatternTest = {
 };
 
 const GrokPatternsStore = Reflux.createStore({
-  URL: URLUtils.qualifyUrl('/system/grok'),
+  URL: qualifyUrl('/system/grok'),
 
   loadPatterns(callback: (patterns: Array<GrokPattern>) => void) {
     const failCallback = (error) => {
@@ -50,7 +50,7 @@ const GrokPatternsStore = Reflux.createStore({
 
   searchPaginated(page, perPage, query) {
     const url = PaginationURL(ApiRoutes.GrokPatternsController.paginated().url, page, perPage, query);
-    const promise = fetch('GET', URLUtils.qualifyUrl(url))
+    const promise = fetch('GET', qualifyUrl(url))
       .then((response: any) => {
         const pagination = {
           count: response.pagination.count,
@@ -91,7 +91,7 @@ const GrokPatternsStore = Reflux.createStore({
       sampleData: pattern.sampleData,
     };
 
-    fetch('POST', URLUtils.qualifyUrl(ApiRoutes.GrokPatternsController.test().url), requestPatternTest)
+    fetch('POST', qualifyUrl(ApiRoutes.GrokPatternsController.test().url), requestPatternTest)
       .then(
         (response) => {
           callback(response);

--- a/graylog2-web-interface/src/stores/grok-patterns/GrokPatternsStore.js
+++ b/graylog2-web-interface/src/stores/grok-patterns/GrokPatternsStore.js
@@ -53,12 +53,13 @@ const GrokPatternsStore = Reflux.createStore({
     const promise = fetch('GET', qualifyUrl(url))
       .then((response: any) => {
         const pagination = {
-          count: response.pagination.count,
-          total: response.pagination.total,
-          page: response.pagination.page,
-          perPage: response.pagination.per_page,
-          query: response.pagination.query,
+          count: response.count,
+          total: response.total,
+          page: response.page,
+          perPage: response.per_page,
+          query: query,
         };
+
         return {
           patterns: response.patterns,
           pagination: pagination,
@@ -68,6 +69,7 @@ const GrokPatternsStore = Reflux.createStore({
         UserNotification.error(`Loading patterns failed with status: ${errorThrown}`,
           'Could not load streams');
       });
+
     return promise;
   },
 

--- a/graylog2-web-interface/src/stores/grok-patterns/GrokPatternsStore.js
+++ b/graylog2-web-interface/src/stores/grok-patterns/GrokPatternsStore.js
@@ -2,6 +2,7 @@
 import Reflux from 'reflux';
 
 import fetch, { fetchPlainText } from 'logic/rest/FetchProvider';
+import PaginationHelper from 'util/PaginationHelper';
 import ApiRoutes from 'routing/ApiRoutes';
 import URLUtils from 'util/URLUtils';
 import UserNotification from 'util/UserNotification';
@@ -45,6 +46,29 @@ const GrokPatternsStore = Reflux.createStore({
         },
         failCallback,
       );
+  },
+
+  searchPaginated(page, perPage, query) {
+    const url = PaginationHelper.urlGenerator(ApiRoutes.GrokPatternsController.indexPage().url, page, perPage, query);
+    const promise = fetch('GET', URLUtils.qualifyUrl(url))
+      .then((response: any) => {
+        const pagination = {
+          count: response.pagination.count,
+          total: response.pagination.total,
+          page: response.pagination.page,
+          perPage: response.pagination.per_page,
+          query: response.pagination.query,
+        };
+        return {
+          patterns: response.patterns,
+          pagination: pagination,
+        };
+      })
+      .catch((errorThrown) => {
+        UserNotification.error(`Loading patterns failed with status: ${errorThrown}`,
+          'Could not load streams');
+      });
+    return promise;
   },
 
   testPattern(pattern: GrokPatternTest, callback: (request: any) => void, errCallback: (errorMessage: string) => void) {

--- a/graylog2-web-interface/src/stores/grok-patterns/GrokPatternsStore.js
+++ b/graylog2-web-interface/src/stores/grok-patterns/GrokPatternsStore.js
@@ -14,6 +14,14 @@ type GrokPattern = {
   content_pack: string,
 };
 
+type PaginatedResponse = {
+  count: number,
+  total: number,
+  page: number,
+  per_page: number,
+  patterns: Array<GrokPattern>,
+};
+
 type GrokPatternTest = {
   name: string,
   pattern: string,
@@ -50,8 +58,9 @@ const GrokPatternsStore = Reflux.createStore({
 
   searchPaginated(page, perPage, query) {
     const url = PaginationURL(ApiRoutes.GrokPatternsController.paginated().url, page, perPage, query);
-    const promise = fetch('GET', qualifyUrl(url))
-      .then((response: any) => {
+
+    return fetch('GET', qualifyUrl(url))
+      .then((response: PaginatedResponse) => {
         const pagination = {
           count: response.count,
           total: response.total,
@@ -69,8 +78,6 @@ const GrokPatternsStore = Reflux.createStore({
         UserNotification.error(`Loading patterns failed with status: ${errorThrown}`,
           'Could not load streams');
       });
-
-    return promise;
   },
 
   testPattern(pattern: GrokPatternTest, callback: (request: any) => void, errCallback: (errorMessage: string) => void) {

--- a/graylog2-web-interface/src/stores/grok-patterns/GrokPatternsStore.js
+++ b/graylog2-web-interface/src/stores/grok-patterns/GrokPatternsStore.js
@@ -2,7 +2,7 @@
 import Reflux from 'reflux';
 
 import fetch, { fetchPlainText } from 'logic/rest/FetchProvider';
-import PaginationHelper from 'util/PaginationHelper';
+import PaginationURL from 'util/PaginationURL';
 import ApiRoutes from 'routing/ApiRoutes';
 import URLUtils from 'util/URLUtils';
 import UserNotification from 'util/UserNotification';
@@ -49,7 +49,7 @@ const GrokPatternsStore = Reflux.createStore({
   },
 
   searchPaginated(page, perPage, query) {
-    const url = PaginationHelper.urlGenerator(ApiRoutes.GrokPatternsController.paginated().url, page, perPage, query);
+    const url = PaginationURL(ApiRoutes.GrokPatternsController.paginated().url, page, perPage, query);
     const promise = fetch('GET', URLUtils.qualifyUrl(url))
       .then((response: any) => {
         const pagination = {


### PR DESCRIPTION
## Description
Add pagination to the grok patterns overview page together with filtering.

## Motivation and Context
A good overview page should have: Search and Pagination.
This PR add pagination and uses the search on the backend site.
The code is mainly copied from lookup table.
The list all API endpoint is kept since it makes sense when using  scripts to avoid stepping
through all dashboards with pages.

## How Has This Been Tested?
Add more than 10 grok patterns and stepped through the pages and searched for patterns.
Created, updated and deleted grok patterns and ensured that table refreshes accordingly.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

# Caution
This PR is based on #5675 and #5679 and must be merged **after** these PRs.

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
