### PR TITLE
Add reporting to docs helper

### DIFF
--- a/graylog2-web-interface/src/util/DocsHelper.js
+++ b/graylog2-web-interface/src/util/DocsHelper.js
@@ -22,6 +22,7 @@ class DocsHelper {
     PIPELINE_FUNCTIONS: 'pipelines/functions.html',
     PIPELINE_RULES: 'pipelines/rules.html',
     PIPELINES: 'pipelines.html',
+    REPORTING: 'reporting.html',
     SEARCH_QUERY_LANGUAGE: 'queries.html',
     STREAMS: 'streams.html',
     STREAM_PROCESSING_RUNTIME_LIMITS: 'streams.html#stream-processing-runtime-limits',


### PR DESCRIPTION
To add a Documentation Link to the Reporting overview page as done in [#793](https://github.com/Graylog2/graylog-plugin-enterprise/pull/793) the DocsHelper needs to be adjusted.