### PR TITLE
Add new pipeline function "grok_exists"

### DIFF
--- a/graylog2-server/src/main/java/org/graylog/plugins/pipelineprocessor/functions/GrokExists.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/pipelineprocessor/functions/GrokExists.java
@@ -1,0 +1,79 @@
+/**
+ * This file is part of Graylog.
+ *
+ * Graylog is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.graylog.plugins.pipelineprocessor.functions;
+
+import io.krakens.grok.api.Grok;
+import org.graylog.plugins.pipelineprocessor.EvaluationContext;
+import org.graylog.plugins.pipelineprocessor.ast.functions.AbstractFunction;
+import org.graylog.plugins.pipelineprocessor.ast.functions.FunctionArgs;
+import org.graylog.plugins.pipelineprocessor.ast.functions.FunctionDescriptor;
+import org.graylog.plugins.pipelineprocessor.ast.functions.ParameterDescriptor;
+import org.graylog2.grok.GrokPatternRegistry;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import static com.google.common.collect.ImmutableList.of;
+
+import javax.inject.Inject;
+
+public class GrokExists extends AbstractFunction<Boolean> {
+
+    private static final Logger log = LoggerFactory.getLogger(GrokExists.class);
+    public static final String NAME = "grok_exists";
+
+    private final ParameterDescriptor<String, String> patternParam;
+    private final ParameterDescriptor<Boolean, Boolean> doLog;
+
+    private final GrokPatternRegistry grokPatternRegistry;
+
+    @Inject
+    public GrokExists(GrokPatternRegistry grokPatternRegistry) {
+        this.grokPatternRegistry = grokPatternRegistry;
+
+        patternParam = ParameterDescriptor.string("pattern")
+                .description("The Grok Pattern which is to be tested for existance.").build();
+        doLog = ParameterDescriptor.bool("do_log").optional()
+                .description("Log if the Grok Pattern is missing.").build();
+    }
+
+    @Override
+    public Boolean evaluate(FunctionArgs args, EvaluationContext context) {
+        final String pattern = patternParam.required(args, context);
+        final boolean logWhenNotFound = doLog.optional(args, context).orElse(false);
+
+        if (pattern == null) {
+            return null;
+        }
+
+        final boolean patternExists = grokPatternRegistry.grokPatternExists(pattern);
+        if (!patternExists && logWhenNotFound) {
+           log.info("Grok Pattern " + pattern + " was not found in pipeline rule function execution");
+        }
+
+        return patternExists;
+    }
+
+    @Override
+    public FunctionDescriptor<Boolean> descriptor() {
+       return FunctionDescriptor.<Boolean>builder()
+               .name(NAME)
+               .returnType(Boolean.class)
+               .params(of(patternParam, doLog))
+               .description("Tests if the searched Grok Pattern exists.")
+               .build();
+    }
+}

--- a/graylog2-server/src/main/java/org/graylog/plugins/pipelineprocessor/functions/GrokExists.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/pipelineprocessor/functions/GrokExists.java
@@ -1,4 +1,4 @@
-/*
+/**
  * This file is part of Graylog.
  *
  * Graylog is free software: you can redistribute it and/or modify

--- a/graylog2-server/src/main/java/org/graylog/plugins/pipelineprocessor/functions/GrokExists.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/pipelineprocessor/functions/GrokExists.java
@@ -1,4 +1,4 @@
-/**
+/*
  * This file is part of Graylog.
  *
  * Graylog is free software: you can redistribute it and/or modify
@@ -16,7 +16,6 @@
  */
 package org.graylog.plugins.pipelineprocessor.functions;
 
-import io.krakens.grok.api.Grok;
 import org.graylog.plugins.pipelineprocessor.EvaluationContext;
 import org.graylog.plugins.pipelineprocessor.ast.functions.AbstractFunction;
 import org.graylog.plugins.pipelineprocessor.ast.functions.FunctionArgs;
@@ -46,8 +45,9 @@ public class GrokExists extends AbstractFunction<Boolean> {
 
         patternParam = ParameterDescriptor.string("pattern")
                 .description("The Grok Pattern which is to be tested for existance.").build();
-        doLog = ParameterDescriptor.bool("do_log").optional()
-                .description("Log if the Grok Pattern is missing.").build();
+        doLog = ParameterDescriptor.bool("log_missing").optional()
+                .description("Log if the Grok Pattern is missing. Warning: Switching on this flag can lead" +
+                        " to a high volume of logs.").build();
     }
 
     @Override
@@ -61,7 +61,7 @@ public class GrokExists extends AbstractFunction<Boolean> {
 
         final boolean patternExists = grokPatternRegistry.grokPatternExists(pattern);
         if (!patternExists && logWhenNotFound) {
-           log.info("Grok Pattern " + pattern + " was not found in pipeline rule function execution");
+           log.info("Grok Pattern " + pattern + " does not exists.");
         }
 
         return patternExists;
@@ -73,7 +73,7 @@ public class GrokExists extends AbstractFunction<Boolean> {
                .name(NAME)
                .returnType(Boolean.class)
                .params(of(patternParam, doLog))
-               .description("Tests if the searched Grok Pattern exists.")
+               .description("Checks if the given Grok pattern exists.")
                .build();
     }
 }

--- a/graylog2-server/src/main/java/org/graylog/plugins/pipelineprocessor/functions/ProcessorFunctionsModule.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/pipelineprocessor/functions/ProcessorFunctionsModule.java
@@ -164,6 +164,7 @@ public class ProcessorFunctionsModule extends PluginModule {
         addMessageProcessorFunction(RegexMatch.NAME, RegexMatch.class);
         addMessageProcessorFunction(RegexReplace.NAME, RegexReplace.class);
         addMessageProcessorFunction(GrokMatch.NAME, GrokMatch.class);
+        addMessageProcessorFunction(GrokExists.NAME, GrokExists.class);
 
         // string functions
         addMessageProcessorFunction(Abbreviate.NAME, Abbreviate.class);

--- a/graylog2-server/src/main/java/org/graylog/plugins/pipelineprocessor/functions/strings/GrokMatch.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/pipelineprocessor/functions/strings/GrokMatch.java
@@ -92,6 +92,4 @@ public class GrokMatch extends AbstractFunction<GrokMatch.GrokResult> {
             return captures.size() > 0;
         }
     }
-
-
 }

--- a/graylog2-server/src/main/java/org/graylog2/grok/GrokPatternRegistry.java
+++ b/graylog2-server/src/main/java/org/graylog2/grok/GrokPatternRegistry.java
@@ -83,6 +83,10 @@ public class GrokPatternRegistry {
         reload();
     }
 
+    public boolean grokPatternExists(String patternName) {
+        return grokPatternService.loadByName(patternName).isPresent();
+    }
+
     public Grok cachedGrokForPattern(String pattern) {
         return cachedGrokForPattern(pattern, false);
     }

--- a/graylog2-server/src/main/java/org/graylog2/grok/GrokPatternRegistry.java
+++ b/graylog2-server/src/main/java/org/graylog2/grok/GrokPatternRegistry.java
@@ -84,7 +84,7 @@ public class GrokPatternRegistry {
     }
 
     public boolean grokPatternExists(String patternName) {
-        return grokPatternService.loadByName(patternName).isPresent();
+        return patterns.get().stream().anyMatch(pattern -> pattern.name().contains(patternName));
     }
 
     public Grok cachedGrokForPattern(String pattern) {

--- a/graylog2-server/src/test/java/org/graylog/plugins/pipelineprocessor/functions/FunctionsSnippetsTest.java
+++ b/graylog2-server/src/test/java/org/graylog/plugins/pipelineprocessor/functions/FunctionsSnippetsTest.java
@@ -34,6 +34,7 @@ import com.google.common.net.InetAddresses;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.Executors;
 import javax.inject.Provider;
@@ -301,7 +302,9 @@ public class FunctionsSnippetsTest extends BaseParserTest {
         functions.put(IsUrl.NAME, new IsUrl());
 
         final GrokPatternService grokPatternService = mock(GrokPatternService.class);
+        final GrokPattern greedyPattern = GrokPattern.create("GREEDY", ".*");
         Set<GrokPattern> patterns = Sets.newHashSet(
+                greedyPattern,
                 GrokPattern.create("GREEDY", ".*"),
                 GrokPattern.create("BASE10NUM", "(?<![0-9.+-])(?>[+-]?(?:(?:[0-9]+(?:\\.[0-9]+)?)|(?:\\.[0-9]+)))"),
                 GrokPattern.create("NUMBER", "(?:%{BASE10NUM:UNWANTED})"),
@@ -309,11 +312,13 @@ public class FunctionsSnippetsTest extends BaseParserTest {
                 GrokPattern.create("NUM", "%{BASE10NUM}")
         );
         when(grokPatternService.loadAll()).thenReturn(patterns);
+        when(grokPatternService.loadByName("GREEDY")).thenReturn(Optional.of(greedyPattern));
         final EventBus clusterBus = new EventBus();
         final GrokPatternRegistry grokPatternRegistry = new GrokPatternRegistry(clusterBus,
                                                                                 grokPatternService,
                                                                                 Executors.newScheduledThreadPool(1));
         functions.put(GrokMatch.NAME, new GrokMatch(grokPatternRegistry));
+        functions.put(GrokExists.NAME, new GrokExists(grokPatternRegistry));
 
         functionRegistry = new FunctionRegistry(functions);
     }
@@ -463,6 +468,14 @@ public class FunctionsSnippetsTest extends BaseParserTest {
 
     @Test
     public void digests() {
+        final Rule rule = parser.parseRule(ruleForTest(), false);
+        evaluateRule(rule);
+
+        assertThat(actionsTriggered.get()).isTrue();
+    }
+
+    @Test
+    public void grok_exists() {
         final Rule rule = parser.parseRule(ruleForTest(), false);
         evaluateRule(rule);
 

--- a/graylog2-server/src/test/java/org/graylog/plugins/pipelineprocessor/functions/FunctionsSnippetsTest.java
+++ b/graylog2-server/src/test/java/org/graylog/plugins/pipelineprocessor/functions/FunctionsSnippetsTest.java
@@ -483,6 +483,14 @@ public class FunctionsSnippetsTest extends BaseParserTest {
     }
 
     @Test
+    public void grok_exists_not() {
+        final Rule rule = parser.parseRule(ruleForTest(), false);
+        evaluateRule(rule);
+
+        assertThat(actionsTriggered.get()).isFalse();
+    }
+
+    @Test
     public void encodings() {
         final Rule rule = parser.parseRule(ruleForTest(), false);
         evaluateRule(rule);

--- a/graylog2-server/src/test/resources/org/graylog/plugins/pipelineprocessor/functions/grok_exists.txt
+++ b/graylog2-server/src/test/resources/org/graylog/plugins/pipelineprocessor/functions/grok_exists.txt
@@ -1,0 +1,6 @@
+rule "grok_exists"
+when
+    grok_exists("GREEDY")
+then
+    trigger_test();
+end

--- a/graylog2-server/src/test/resources/org/graylog/plugins/pipelineprocessor/functions/grok_exists_not.txt
+++ b/graylog2-server/src/test/resources/org/graylog/plugins/pipelineprocessor/functions/grok_exists_not.txt
@@ -1,0 +1,6 @@
+rule "grok_exists_not"
+when
+    grok_exists("DOESNOTEXISTS")
+then
+    trigger_test();
+end


### PR DESCRIPTION
## Description
Prior to this change, a missing grok pattern would
raise a error in the pipeline processor when using the "grok"
function. But the user would like to able to make one rule
which uses a grok pattern dynamicaly depending on if
a grok pattern exists or not.

This change adds a new function "grok_exists" which will
return true or false depending if a grok pattern exists.
Additionally it will make a entry to the graylog-server.log
if the second argument of the function is true and
the pattern was not found.

## How Has This Been Tested?
- Add a grok pattern named "KONRAD"
- Add a new pipeline rule:
```
rule "grok exists true"
when
    grok_exists("KONRAD")
then
    debug("grok exists");
end
```
- Check that debug log got raised
- Changed Pattern name and checked that debug log got not raised.

Fixes #5689 

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
