### PR TITLE
Prevent double prefixing paths for navigation items in system menu.

### DIFF
--- a/graylog2-web-interface/src/components/navigation/NavigationLink.jsx
+++ b/graylog2-web-interface/src/components/navigation/NavigationLink.jsx
@@ -6,7 +6,7 @@ import { LinkContainer } from 'react-router-bootstrap';
 import URLUtils from 'util/URLUtils';
 
 const NavigationLink = ({ description, path, ...rest }) => (
-  <LinkContainer key={path} to={URLUtils.appPrefixed(path)} {...rest}>
+  <LinkContainer key={path} to={path} {...rest}>
     <MenuItem>{description}</MenuItem>
   </LinkContainer>
 );

--- a/graylog2-web-interface/src/components/navigation/NavigationLink.jsx
+++ b/graylog2-web-interface/src/components/navigation/NavigationLink.jsx
@@ -3,8 +3,6 @@ import PropTypes from 'prop-types';
 import { MenuItem } from 'react-bootstrap';
 import { LinkContainer } from 'react-router-bootstrap';
 
-import URLUtils from 'util/URLUtils';
-
 const NavigationLink = ({ description, path, ...rest }) => (
   <LinkContainer key={path} to={path} {...rest}>
     <MenuItem>{description}</MenuItem>

--- a/graylog2-web-interface/src/components/navigation/NavigationLink.test.jsx
+++ b/graylog2-web-interface/src/components/navigation/NavigationLink.test.jsx
@@ -1,17 +1,25 @@
 import React from 'react';
 import { mount, shallow } from 'enzyme';
 import NavigationLink from './NavigationLink';
+import URLUtils from '../../util/URLUtils';
 
-jest.mock('util/URLUtils', () => ({ appPrefixed: path => `/prefix${path}` }));
+jest.mock('util/URLUtils', () => ({ appPrefixed: jest.fn(path => path) }));
 
 describe('NavigationLink', () => {
   it('renders with simple props', () => {
     const wrapper = mount(<NavigationLink description="Hello there!" path="/hello" />);
-    expect(wrapper.find('LinkContainer')).toHaveProp('to', '/prefix/hello');
+    expect(wrapper.find('LinkContainer')).toHaveProp('to', '/hello');
     expect(wrapper.find('MenuItem')).toHaveText('Hello there!');
   });
   it('passes props to LinkContainer', () => {
     const wrapper = shallow(<NavigationLink description="Hello there!" path="/hello" someProp={42} />);
     expect(wrapper.find('LinkContainer')).toHaveProp('someProp', 42);
+  });
+  it('does not prefix URL with app prefix', () => {
+    URLUtils.appPrefixed.mockImplementation(path => `/someprefix${path}`);
+    const wrapper = shallow(<NavigationLink description="Hello there!" path="/hello" someProp={42} />);
+    const linkContainer = wrapper.find('LinkContainer');
+    expect(linkContainer.props().to).not.toContain('/someprefix');
+    expect(URLUtils.appPrefixed).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## Description
## Motivation and Context

In #5193, the newly created `NavigationLink` component performs
prefixing the path passed to it with the application prefix. This is
happening although in `Routes.jsx` all routes are already being prefixed
before being exported.

This change is removing the prefixing in `NavigationLink`.

Fixes #5702.

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.