### PR TITLE
Add a customizable badge to the header

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/configuration/Customization.java
+++ b/graylog2-server/src/main/java/org/graylog2/configuration/Customization.java
@@ -1,0 +1,51 @@
+/**
+ * This file is part of Graylog.
+ *
+ * Graylog is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.graylog2.configuration;
+
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.auto.value.AutoValue;
+import org.graylog.autovalue.WithBeanGetter;
+
+import javax.annotation.Nullable;
+
+@AutoValue
+@WithBeanGetter
+@JsonAutoDetect
+public abstract class Customization {
+    private final static String BADGE_TEXT = "badge_text";
+    private final static String BADGE_COLOR = "badge_color";
+    private final static String BADGE_ENABLE = "badge_enable";
+
+    @JsonProperty(BADGE_TEXT)
+    @Nullable
+    public abstract String badgeText();
+
+    @JsonProperty(BADGE_COLOR)
+    public abstract String badgeColor();
+
+    @JsonProperty(BADGE_ENABLE)
+    public abstract boolean badgeEnable();
+
+    @JsonCreator
+    public static Customization create(@JsonProperty(BADGE_TEXT) String badgeText,
+                                       @JsonProperty(BADGE_COLOR) String badgeColor,
+                                       @JsonProperty(BADGE_ENABLE) boolean badgeEnable) {
+        return new AutoValue_Customization(badgeText, badgeColor, badgeEnable);
+    }
+}

--- a/graylog2-web-interface/src/components/configurations/CustomizationConfig.jsx
+++ b/graylog2-web-interface/src/components/configurations/CustomizationConfig.jsx
@@ -1,17 +1,14 @@
 import PropTypes from 'prop-types';
 import React from 'react';
-import createReactClass from 'create-react-class';
-import { Badge, Button } from 'react-bootstrap';
+import { Badge, Button } from 'components/graylog';
 import { BootstrapModalForm, Input } from 'components/bootstrap';
 import { ColorPickerPopover, IfPermitted } from 'components/common';
 import ObjectUtils from 'util/ObjectUtils';
 import FormUtils from 'util/FormsUtils';
 import StringUtils from 'util/StringUtils';
 
-const CustomizationConfig = createReactClass({
-  displayName: 'CustomizationConfig',
-
-  propTypes: {
+class CustomizationConfig extends React.Component {
+  static propTypes = {
     config: PropTypes.shape({
       badge_text: PropTypes.string,
       badge_color: PropTypes.string,
@@ -21,46 +18,47 @@ const CustomizationConfig = createReactClass({
       badge_text: PropTypes.string,
     }),
     updateConfig: PropTypes.func.isRequired,
-  },
+  };
 
-  getDefaultProps() {
-    return {
-      config: {
-        badge_text: 'PROD',
-        badge_color: 'primary',
-        badge_enable: false,
-      },
-      error: {
-        badge_text: null,
-      },
-    };
-  },
+  static defaultProps = {
+    config: {
+      badge_text: 'PROD',
+      badge_color: 'primary',
+      badge_enable: false,
+    },
+    error: {
+      badge_text: null,
+    },
+  };
 
-  getInitialState() {
-    const { config } = this.props;
-    return {
+  constructor(props) {
+    super(props);
+
+    const { config } = props;
+    this.state = {
       config: ObjectUtils.clone(config),
     };
-  },
+  }
 
   componentWillReceiveProps(newProps) {
     this.setState({ config: ObjectUtils.clone(newProps.config) });
-  },
+  }
 
-  _openModal() {
+  _openModal = () => {
     this.configModal.open();
-  },
+  };
 
-  _closeModal() {
+  _closeModal = () => {
     this.configModal.close();
-  },
+  };
 
-  _resetConfig() {
+  _resetConfig = () => {
+    const { config } = this.props;
     // Reset to initial state when the modal is closed without saving.
-    this.setState(this.getInitialState());
-  },
+    this.setState({ config });
+  };
 
-  _saveConfig() {
+  _saveConfig = () => {
     const { error, config } = this.state;
     const { updateConfig } = this.props;
     if ((error || {}).badge_text) {
@@ -69,9 +67,9 @@ const CustomizationConfig = createReactClass({
     updateConfig(config).then(() => {
       this._closeModal();
     });
-  },
+  };
 
-  _onUpdate(field) {
+  _onUpdate = (field) => {
     const { config } = this.state;
     return (value) => {
       const update = ObjectUtils.clone(config);
@@ -82,17 +80,17 @@ const CustomizationConfig = createReactClass({
       }
       this.setState({ config: update }, this.validate);
     };
-  },
+  };
 
-  handleColorChange(color, _, hidePopover) {
+  handleColorChange = (color, _, hidePopover) => {
     const { config } = this.state;
     hidePopover();
     const update = ObjectUtils.clone(config);
     update.badge_color = color;
     this.setState({ config: update });
-  },
+  };
 
-  validate() {
+  validate = () => {
     const { error = {}, config } = this.state;
 
     if (config.badge_text.length > 5) {
@@ -101,7 +99,7 @@ const CustomizationConfig = createReactClass({
       error.badge_text = null;
     }
     this.setState({ error });
-  },
+  };
 
   render() {
     const { error = {}, config } = this.state;
@@ -149,7 +147,7 @@ const CustomizationConfig = createReactClass({
         </BootstrapModalForm>
       </div>
     );
-  },
-});
+  }
+}
 
 export default CustomizationConfig;

--- a/graylog2-web-interface/src/components/configurations/CustomizationConfig.jsx
+++ b/graylog2-web-interface/src/components/configurations/CustomizationConfig.jsx
@@ -1,9 +1,9 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 import createReactClass from 'create-react-class';
-import { Button, Badge } from 'react-bootstrap';
+import { Badge, Button } from 'react-bootstrap';
 import { BootstrapModalForm, Input } from 'components/bootstrap';
-import { IfPermitted, ColorPickerPopover } from 'components/common';
+import { ColorPickerPopover, IfPermitted } from 'components/common';
 import ObjectUtils from 'util/ObjectUtils';
 import FormUtils from 'util/FormsUtils';
 import StringUtils from 'util/StringUtils';
@@ -16,6 +16,9 @@ const CustomizationConfig = createReactClass({
       badge_text: PropTypes.string,
       badge_color: PropTypes.string,
       badge_enable: PropTypes.bool,
+    }),
+    error: PropTypes.shape({
+      badge_text: PropTypes.string,
     }),
     updateConfig: PropTypes.func.isRequired,
   },
@@ -34,8 +37,9 @@ const CustomizationConfig = createReactClass({
   },
 
   getInitialState() {
+    const { config } = this.props;
     return {
-      config: ObjectUtils.clone(this.props.config),
+      config: ObjectUtils.clone(config),
     };
   },
 
@@ -57,17 +61,20 @@ const CustomizationConfig = createReactClass({
   },
 
   _saveConfig() {
-    if ((this.state.error || {}).badge_text) {
+    const { error, config } = this.state;
+    const { updateConfig } = this.props;
+    if ((error || {}).badge_text) {
       return;
     }
-    this.props.updateConfig(this.state.config).then(() => {
+    updateConfig(config).then(() => {
       this._closeModal();
     });
   },
 
   _onUpdate(field) {
+    const { config } = this.state;
     return (value) => {
-      const update = ObjectUtils.clone(this.state.config);
+      const update = ObjectUtils.clone(config);
       if (typeof value === 'object') {
         update[field] = FormUtils.getValueFromInput(value.target);
       } else {
@@ -78,15 +85,17 @@ const CustomizationConfig = createReactClass({
   },
 
   handleColorChange(color, _, hidePopover) {
+    const { config } = this.state;
     hidePopover();
-    const update = ObjectUtils.clone(this.state.config);
+    const update = ObjectUtils.clone(config);
     update.badge_color = color;
     this.setState({ config: update });
   },
 
   validate() {
-    const error = this.state.error || {};
-    if (this.state.config.badge_text.length > 5) {
+    const { error = {}, config } = this.state;
+
+    if (config.badge_text.length > 5) {
       error.badge_text = 'Can be maximal 5 characters long';
     } else {
       error.badge_text = null;
@@ -95,17 +104,17 @@ const CustomizationConfig = createReactClass({
   },
 
   render() {
-    const badge = this.state.config.badge_text ?
-      <Badge style={{ backgroundColor: this.state.config.badge_color }} className={this.state.config.badge_color}><span>{this.state.config.badge_text}</span></Badge> :
-      <span>No badge defined</span>;
+    const { error = {}, config } = this.state;
+    const badge = config.badge_text
+      ? <Badge style={{ backgroundColor: config.badge_color }} className={config.badge_color}><span>{config.badge_text}</span></Badge>
+      : <span>No badge defined</span>;
 
-    const error = this.state.error || {};
     return (
       <div>
         <h2>UI Customization</h2>
         <dl className="deflist">
           <dt>Badge Enabled</dt>
-          <dd>{StringUtils.capitalizeFirstLetter(this.state.config.badge_enable.toString())}</dd>
+          <dd>{StringUtils.capitalizeFirstLetter(config.badge_enable.toString())}</dd>
           <dt>Badge</dt>
           <dd>{badge}</dd>
         </dl>
@@ -122,26 +131,25 @@ const CustomizationConfig = createReactClass({
           <Input type="checkbox"
                  id="badge-enable"
                  label="Enable Header Badge"
-                 checked={this.state.config.badge_enable}
+                 checked={config.badge_enable}
                  onChange={this._onUpdate('badge_enable')}
                  help="Activate Header Badge" />
           <Input type="text"
                  id="badge-text"
                  label="Badge Text"
                  bsStyle={error.badge_text ? 'error' : null}
-                 value={this.state.config.badge_text}
+                 value={config.badge_text}
                  onChange={this._onUpdate('badge_text')}
                  help={error.badge_text ? error.badge_text : 'The text of the badge. Not more than five characters.'} />
           <ColorPickerPopover id="badge-color"
                               placement="right"
-                              color={this.state.config.badge_color}
+                              color={config.badge_color}
                               triggerNode={<Button bsStyle="primary">Select background color</Button>}
                               onChange={this.handleColorChange} />
         </BootstrapModalForm>
       </div>
     );
   },
-
 });
 
 export default CustomizationConfig;

--- a/graylog2-web-interface/src/components/configurations/CustomizationConfig.jsx
+++ b/graylog2-web-interface/src/components/configurations/CustomizationConfig.jsx
@@ -35,7 +35,7 @@ class CustomizationConfig extends React.Component {
   static defaultProps = {
     config: {
       badge_text: '',
-      badge_color: '',
+      badge_color: '#689f38',
       badge_enable: false,
     },
     warning: {

--- a/graylog2-web-interface/src/components/configurations/CustomizationConfig.jsx
+++ b/graylog2-web-interface/src/components/configurations/CustomizationConfig.jsx
@@ -1,7 +1,7 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 import styled from 'styled-components';
-import {util} from 'theme';
+import { util } from 'theme';
 
 import { Badge, Button } from 'components/graylog';
 import { Icon } from 'components/common';

--- a/graylog2-web-interface/src/components/configurations/CustomizationConfig.jsx
+++ b/graylog2-web-interface/src/components/configurations/CustomizationConfig.jsx
@@ -1,6 +1,10 @@
 import PropTypes from 'prop-types';
 import React from 'react';
+import styled from 'styled-components';
+import {util} from 'theme';
+
 import { Badge, Button } from 'components/graylog';
+import { Icon } from 'components/common';
 import { BootstrapModalForm, Input } from 'components/bootstrap';
 import { ColorPickerPopover, IfPermitted } from 'components/common';
 import ObjectUtils from 'util/ObjectUtils';
@@ -14,7 +18,7 @@ class CustomizationConfig extends React.Component {
       badge_color: PropTypes.string,
       badge_enable: PropTypes.bool,
     }),
-    error: PropTypes.shape({
+    warning: PropTypes.shape({
       badge_text: PropTypes.string,
     }),
     updateConfig: PropTypes.func.isRequired,
@@ -26,7 +30,7 @@ class CustomizationConfig extends React.Component {
       badge_color: 'primary',
       badge_enable: false,
     },
-    error: {
+    warning: {
       badge_text: null,
     },
   };
@@ -55,15 +59,12 @@ class CustomizationConfig extends React.Component {
   _resetConfig = () => {
     const { config } = this.props;
     // Reset to initial state when the modal is closed without saving.
-    this.setState({ config });
+    this.setState({ config, warning: {} });
   };
 
   _saveConfig = () => {
-    const { error, config } = this.state;
+    const { config } = this.state;
     const { updateConfig } = this.props;
-    if ((error || {}).badge_text) {
-      return;
-    }
     updateConfig(config).then(() => {
       this._closeModal();
     });
@@ -91,21 +92,26 @@ class CustomizationConfig extends React.Component {
   };
 
   validate = () => {
-    const { error = {}, config } = this.state;
+    const { warning = {}, config } = this.state;
 
     if (config.badge_text.length > 5) {
-      error.badge_text = 'Can be maximal 5 characters long';
+      warning.badge_text = 'Should be maximum 5 characters long';
     } else {
-      error.badge_text = null;
+      warning.badge_text = null;
     }
-    this.setState({ error });
+    this.setState({ warning });
   };
 
   render() {
-    const { error = {}, config } = this.state;
+    const { warning = {}, config } = this.state;
     const badge = config.badge_text
       ? <Badge style={{ backgroundColor: config.badge_color }} className={config.badge_color}><span>{config.badge_text}</span></Badge>
       : <span>No badge defined</span>;
+
+    const SelectBackgroundButton = styled(({ selectedBgColor, ...props }) => <Button {...props} />)`
+      background-color: ${props => (props.selectedBgColor)}; 
+      color: ${props => (util.contrastingColor(props.selectedBgColor))};
+    `;
 
     return (
       <div>
@@ -135,14 +141,18 @@ class CustomizationConfig extends React.Component {
           <Input type="text"
                  id="badge-text"
                  label="Badge Text"
-                 bsStyle={error.badge_text ? 'error' : null}
+                 bsStyle={warning.badge_text ? 'warning' : null}
                  value={config.badge_text}
                  onChange={this._onUpdate('badge_text')}
-                 help={error.badge_text ? error.badge_text : 'The text of the badge. Not more than five characters.'} />
+                 help={warning.badge_text ? warning.badge_text : 'The text of the badge. Not more than five characters.'} />
           <ColorPickerPopover id="badge-color"
                               placement="right"
                               color={config.badge_color}
-                              triggerNode={<Button bsStyle="primary">Select background color</Button>}
+                              triggerNode={(
+                                <SelectBackgroundButton selectedBgColor={config.badge_color}>
+                                  <Icon name="paint-brush" /> Background
+                                </SelectBackgroundButton>
+                              )}
                               onChange={this.handleColorChange} />
         </BootstrapModalForm>
       </div>

--- a/graylog2-web-interface/src/components/configurations/CustomizationConfig.jsx
+++ b/graylog2-web-interface/src/components/configurations/CustomizationConfig.jsx
@@ -4,6 +4,7 @@ import styled from 'styled-components';
 import { util } from 'theme';
 
 import { Badge, Button } from 'components/graylog';
+import { Icon } from 'components/common';
 import { BootstrapModalForm, Input } from 'components/bootstrap';
 import { ColorPickerPopover, IfPermitted, Icon } from 'components/common';
 import ObjectUtils from 'util/ObjectUtils';

--- a/graylog2-web-interface/src/components/configurations/CustomizationConfig.jsx
+++ b/graylog2-web-interface/src/components/configurations/CustomizationConfig.jsx
@@ -56,26 +56,10 @@ class CustomizationConfig extends React.Component {
     this.setState({ config: ObjectUtils.clone(newProps.config) });
   }
 
-  _openModal = () => {
-    this.configModal.open();
-  };
-
-  _closeModal = () => {
-    this.configModal.close();
-  };
-
-  _resetConfig = () => {
-    const { config } = this.props;
-    // Reset to initial state when the modal is closed without saving.
-    this.setState({ config, warning: {} });
-  };
-
   _saveConfig = () => {
     const { config } = this.state;
     const { updateConfig } = this.props;
-    updateConfig(config).then(() => {
-      this._closeModal();
-    });
+    updateConfig(config);
   };
 
   _onUpdate = (field) => {
@@ -158,6 +142,8 @@ class CustomizationConfig extends React.Component {
           </InputGroup>
 
           <HelpBlock>{warning.badge_text ? warning.badge_text : 'The text of the badge. Not more than five characters.'}</HelpBlock>
+
+          <Button bsSize="xsmall" bsStyle="info" onClick={this._saveConfig}>Update Badge</Button>
         </FormGroup>
 
       </div>

--- a/graylog2-web-interface/src/components/configurations/CustomizationConfig.jsx
+++ b/graylog2-web-interface/src/components/configurations/CustomizationConfig.jsx
@@ -4,9 +4,8 @@ import styled from 'styled-components';
 import { util } from 'theme';
 
 import { Badge, Button } from 'components/graylog';
-import { Icon } from 'components/common';
 import { BootstrapModalForm, Input } from 'components/bootstrap';
-import { ColorPickerPopover, IfPermitted } from 'components/common';
+import { ColorPickerPopover, IfPermitted, Icon } from 'components/common';
 import ObjectUtils from 'util/ObjectUtils';
 import FormUtils from 'util/FormsUtils';
 import StringUtils from 'util/StringUtils';

--- a/graylog2-web-interface/src/components/configurations/CustomizationConfig.jsx
+++ b/graylog2-web-interface/src/components/configurations/CustomizationConfig.jsx
@@ -26,7 +26,7 @@ class CustomizationConfig extends React.Component {
   static defaultProps = {
     config: {
       badge_text: 'PROD',
-      badge_color: 'primary',
+      badge_color: '#AD0707',
       badge_enable: false,
     },
     warning: {

--- a/graylog2-web-interface/src/components/configurations/CustomizationConfig.jsx
+++ b/graylog2-web-interface/src/components/configurations/CustomizationConfig.jsx
@@ -1,0 +1,147 @@
+import PropTypes from 'prop-types';
+import React from 'react';
+import createReactClass from 'create-react-class';
+import { Button, Badge } from 'react-bootstrap';
+import { BootstrapModalForm, Input } from 'components/bootstrap';
+import { IfPermitted, ColorPickerPopover } from 'components/common';
+import ObjectUtils from 'util/ObjectUtils';
+import FormUtils from 'util/FormsUtils';
+import StringUtils from 'util/StringUtils';
+
+const CustomizationConfig = createReactClass({
+  displayName: 'CustomizationConfig',
+
+  propTypes: {
+    config: PropTypes.shape({
+      badge_text: PropTypes.string,
+      badge_color: PropTypes.string,
+      badge_enable: PropTypes.bool,
+    }),
+    updateConfig: PropTypes.func.isRequired,
+  },
+
+  getDefaultProps() {
+    return {
+      config: {
+        badge_text: 'PROD',
+        badge_color: 'primary',
+        badge_enable: false,
+      },
+      error: {
+        badge_text: null,
+      },
+    };
+  },
+
+  getInitialState() {
+    return {
+      config: ObjectUtils.clone(this.props.config),
+    };
+  },
+
+  componentWillReceiveProps(newProps) {
+    this.setState({ config: ObjectUtils.clone(newProps.config) });
+  },
+
+  _openModal() {
+    this.configModal.open();
+  },
+
+  _closeModal() {
+    this.configModal.close();
+  },
+
+  _resetConfig() {
+    // Reset to initial state when the modal is closed without saving.
+    this.setState(this.getInitialState());
+  },
+
+  _saveConfig() {
+    if ((this.state.error || {}).badge_text) {
+      return;
+    }
+    this.props.updateConfig(this.state.config).then(() => {
+      this._closeModal();
+    });
+  },
+
+  _onUpdate(field) {
+    return (value) => {
+      const update = ObjectUtils.clone(this.state.config);
+      if (typeof value === 'object') {
+        update[field] = FormUtils.getValueFromInput(value.target);
+      } else {
+        update[field] = value;
+      }
+      this.setState({ config: update }, this.validate);
+    };
+  },
+
+  handleColorChange(color, _, hidePopover) {
+    hidePopover();
+    const update = ObjectUtils.clone(this.state.config);
+    update.badge_color = color;
+    this.setState({ config: update });
+  },
+
+  validate() {
+    const error = this.state.error || {};
+    if (this.state.config.badge_text.length > 5) {
+      error.badge_text = 'Can be maximal 5 characters long';
+    } else {
+      error.badge_text = null;
+    }
+    this.setState({ error });
+  },
+
+  render() {
+    const badge = this.state.config.badge_text ?
+      <Badge style={{ backgroundColor: this.state.config.badge_color }} className={this.state.config.badge_color}><span>{this.state.config.badge_text}</span></Badge> :
+      <span>No badge defined</span>;
+
+    const error = this.state.error || {};
+    return (
+      <div>
+        <h2>UI Customization</h2>
+        <dl className="deflist">
+          <dt>Badge Enabled</dt>
+          <dd>{StringUtils.capitalizeFirstLetter(this.state.config.badge_enable.toString())}</dd>
+          <dt>Badge</dt>
+          <dd>{badge}</dd>
+        </dl>
+
+        <IfPermitted permissions="clusterconfigentry:edit">
+          <Button bsStyle="info" bsSize="xs" onClick={this._openModal}>Update</Button>
+        </IfPermitted>
+
+        <BootstrapModalForm ref={(node) => { this.configModal = node; }}
+                            title="Update UI Customization Configuration"
+                            onSubmitForm={this._saveConfig}
+                            onModalClose={this._resetConfig}
+                            submitButtonText="Save">
+          <Input type="checkbox"
+                 id="badge-enable"
+                 label="Enable Header Badge"
+                 checked={this.state.config.badge_enable}
+                 onChange={this._onUpdate('badge_enable')}
+                 help="Activate Header Badge" />
+          <Input type="text"
+                 id="badge-text"
+                 label="Badge Text"
+                 bsStyle={error.badge_text ? 'error' : null}
+                 value={this.state.config.badge_text}
+                 onChange={this._onUpdate('badge_text')}
+                 help={error.badge_text ? error.badge_text : 'The text of the badge. Not more than five characters.'} />
+          <ColorPickerPopover id="badge-color"
+                              placement="right"
+                              color={this.state.config.badge_color}
+                              triggerNode={<Button bsStyle="primary">Select background color</Button>}
+                              onChange={this.handleColorChange} />
+        </BootstrapModalForm>
+      </div>
+    );
+  },
+
+});
+
+export default CustomizationConfig;

--- a/graylog2-web-interface/src/components/configurations/CustomizationConfig.jsx
+++ b/graylog2-web-interface/src/components/configurations/CustomizationConfig.jsx
@@ -4,7 +4,6 @@ import styled from 'styled-components';
 import { util } from 'theme';
 
 import { Badge, Button } from 'components/graylog';
-import { Icon } from 'components/common';
 import { BootstrapModalForm, Input } from 'components/bootstrap';
 import { ColorPickerPopover, IfPermitted, Icon } from 'components/common';
 import ObjectUtils from 'util/ObjectUtils';

--- a/graylog2-web-interface/src/components/configurations/CustomizationConfig.jsx
+++ b/graylog2-web-interface/src/components/configurations/CustomizationConfig.jsx
@@ -25,8 +25,8 @@ class CustomizationConfig extends React.Component {
 
   static defaultProps = {
     config: {
-      badge_text: 'PROD',
-      badge_color: '#AD0707',
+      badge_text: '',
+      badge_color: '',
       badge_enable: false,
     },
     warning: {
@@ -108,8 +108,8 @@ class CustomizationConfig extends React.Component {
       : <span>No badge defined</span>;
 
     const SelectBackgroundButton = styled(({ selectedBgColor, ...props }) => <Button {...props} />)`
-      background-color: ${props => (props.selectedBgColor)}; 
-      color: ${props => (util.contrastingColor(props.selectedBgColor))};
+      background-color: ${props => (props.selectedBgColor || props.theme.color.tertiary.uno)};
+      color: ${props => (util.contrastingColor(props.selectedBgColor || props.theme.color.tertiary.uno))};
     `;
 
     return (

--- a/graylog2-web-interface/src/components/navigation/HeaderBadge.jsx
+++ b/graylog2-web-interface/src/components/navigation/HeaderBadge.jsx
@@ -21,8 +21,9 @@ const HeaderBadge = ({ configuration }) => {
 
   if (badgeEnabled) {
     const StyledBadge = styled(Badge)`
-      background-color: ${config.badge_color}
+      background-color: ${config.badge_color};
     `;
+
     return (<StyledBadge className="dev-badge">{config.badge_text}</StyledBadge>);
   }
 

--- a/graylog2-web-interface/src/components/navigation/HeaderBadge.jsx
+++ b/graylog2-web-interface/src/components/navigation/HeaderBadge.jsx
@@ -1,27 +1,14 @@
-import React, { useEffect, useState } from 'react';
+import React, { useContext } from 'react';
 import styled from 'styled-components';
 
-import CombinedProvider from 'injection/CombinedProvider';
 import AppConfig from 'util/AppConfig';
 import { Badge } from 'components/graylog';
-import connect from 'stores/connect';
-
-const { ConfigurationsActions, ConfigurationsStore } = CombinedProvider.get('Configurations');
-
-const CUSTOMIZATION_CONFIG = 'org.graylog2.configuration.Customization';
+import { CustomUiContext } from 'contexts/CustomUi';
 
 const HeaderBadge = () => {
-  const [badgeEnabled, setBadgeEnabled] = useState(false);
-  const [badgeConfig, setBadgeConfig] = useState({});
+  const { badgeConfig } = useContext(CustomUiContext);
 
-  useEffect(() => {
-    ConfigurationsActions.list(CUSTOMIZATION_CONFIG).then((configs) => {
-      setBadgeEnabled(configs.badge_enable);
-      setBadgeConfig(configs);
-    });
-  }, []);
-
-  if (badgeEnabled) {
+  if (badgeConfig.badge_enable) {
     const StyledBadge = styled(Badge)`
       background-color: ${badgeConfig.badge_color};
     `;
@@ -34,7 +21,4 @@ const HeaderBadge = () => {
     : null;
 };
 
-export default connect(HeaderBadge, { configurations: ConfigurationsStore }, ({ configurations, ...otherProps }) => ({
-  ...configurations,
-  ...otherProps,
-}));
+export default HeaderBadge;

--- a/graylog2-web-interface/src/components/navigation/HeaderBadge.jsx
+++ b/graylog2-web-interface/src/components/navigation/HeaderBadge.jsx
@@ -1,0 +1,38 @@
+import React from 'react';
+import createReactClass from 'create-react-class';
+import Reflux from 'reflux';
+import CombinedProvider from "injection/CombinedProvider";
+import { Badge } from 'react-bootstrap';
+import AppConfig from 'util/AppConfig';
+import badgeStyles from 'components/bootstrap/Badge.css';
+
+const { ConfigurationsActions, ConfigurationsStore } = CombinedProvider.get('Configurations');
+
+const HeaderBadge = createReactClass({
+  displayName: 'HeaderBadge',
+  mixins: [Reflux.connect(ConfigurationsStore)],
+
+  componentDidMount() {
+    ConfigurationsActions.list(this.CUSTOMIZATION_CONFIG);
+  },
+
+  CUSTOMIZATION_CONFIG: 'org.graylog2.configuration.Customization',
+
+  render() {
+    const { configuration = {} } = this.state;
+    const config = configuration[this.CUSTOMIZATION_CONFIG];
+    const badgeEnabled = config && config.badge_enable;
+
+    const devBadge = AppConfig.gl2DevMode()
+      ? <Badge className={`dev-badge ${badgeStyles.badgeDanger}`}>DEV</Badge>
+      : null;
+
+    if (!badgeEnabled) {
+      return devBadge || null;
+    }
+
+    return (<Badge className="dev-badge" style={{ backgroundColor: config.badge_color }}>{config.badge_text}</Badge>);
+  },
+});
+
+export default HeaderBadge;

--- a/graylog2-web-interface/src/components/navigation/HeaderBadge.jsx
+++ b/graylog2-web-interface/src/components/navigation/HeaderBadge.jsx
@@ -32,7 +32,11 @@ const HeaderBadge = ({ configuration }) => {
 };
 
 HeaderBadge.propTypes = {
-  configuration: PropTypes.object.isRequired,
+  configuration: PropTypes.object,
+};
+
+HeaderBadge.defaultProps = {
+  configuration: {},
 };
 
 export default connect(HeaderBadge, { configurations: ConfigurationsStore }, ({ configurations, ...otherProps }) => ({

--- a/graylog2-web-interface/src/components/navigation/HeaderBadge.jsx
+++ b/graylog2-web-interface/src/components/navigation/HeaderBadge.jsx
@@ -23,15 +23,13 @@ const HeaderBadge = createReactClass({
     const config = configuration[this.CUSTOMIZATION_CONFIG];
     const badgeEnabled = config && config.badge_enable;
 
-    const devBadge = AppConfig.gl2DevMode()
-      ? <Badge className={`dev-badge ${badgeStyles.badgeDanger}`}>DEV</Badge>
-      : null;
-
-    if (!badgeEnabled) {
-      return devBadge || null;
+    if (badgeEnabled) {
+      return (<Badge className="dev-badge" style={{ backgroundColor: config.badge_color }}>{config.badge_text}</Badge>);
     }
 
-    return (<Badge className="dev-badge" style={{ backgroundColor: config.badge_color }}>{config.badge_text}</Badge>);
+    return AppConfig.gl2DevMode()
+      ? <Badge className={`dev-badge ${badgeStyles.badgeDanger}`}>DEV</Badge>
+      : null;
   },
 });
 

--- a/graylog2-web-interface/src/components/navigation/HeaderBadge.jsx
+++ b/graylog2-web-interface/src/components/navigation/HeaderBadge.jsx
@@ -1,5 +1,6 @@
 import React, { useEffect } from 'react';
 import PropTypes from 'prop-types';
+import styled from 'styled-components';
 
 import CombinedProvider from 'injection/CombinedProvider';
 import AppConfig from 'util/AppConfig';
@@ -19,11 +20,14 @@ const HeaderBadge = ({ configuration }) => {
   const badgeEnabled = config && config.badge_enable;
 
   if (badgeEnabled) {
-    return (<Badge className="dev-badge" style={{ backgroundColor: config.badge_color }}>{config.badge_text}</Badge>);
+    const StyledBadge = styled(Badge)`
+      background-color: ${config.badge_color}
+    `;
+    return (<StyledBadge className="dev-badge">{config.badge_text}</StyledBadge>);
   }
 
   return AppConfig.gl2DevMode()
-    ? <Badge className={`dev-badge danger`}>DEV</Badge>
+    ? <Badge className="dev-badge" bsStyle="danger">DEV</Badge>
     : null;
 };
 

--- a/graylog2-web-interface/src/components/navigation/HeaderBadge.jsx
+++ b/graylog2-web-interface/src/components/navigation/HeaderBadge.jsx
@@ -1,5 +1,4 @@
-import React, { useEffect } from 'react';
-import PropTypes from 'prop-types';
+import React, { useEffect, useState } from 'react';
 import styled from 'styled-components';
 
 import CombinedProvider from 'injection/CombinedProvider';
@@ -11,33 +10,28 @@ const { ConfigurationsActions, ConfigurationsStore } = CombinedProvider.get('Con
 
 const CUSTOMIZATION_CONFIG = 'org.graylog2.configuration.Customization';
 
-const HeaderBadge = ({ configuration }) => {
-  useEffect(() => {
-    ConfigurationsActions.list(CUSTOMIZATION_CONFIG);
-  }, []);
+const HeaderBadge = () => {
+  const [badgeEnabled, setBadgeEnabled] = useState(false);
+  const [badgeConfig, setBadgeConfig] = useState({});
 
-  const config = configuration[CUSTOMIZATION_CONFIG];
-  const badgeEnabled = config && config.badge_enable;
+  useEffect(() => {
+    ConfigurationsActions.list(CUSTOMIZATION_CONFIG).then((configs) => {
+      setBadgeEnabled(configs.badge_enable);
+      setBadgeConfig(configs);
+    });
+  }, []);
 
   if (badgeEnabled) {
     const StyledBadge = styled(Badge)`
-      background-color: ${config.badge_color};
+      background-color: ${badgeConfig.badge_color};
     `;
 
-    return (<StyledBadge className="dev-badge">{config.badge_text}</StyledBadge>);
+    return (<StyledBadge className="dev-badge">{badgeConfig.badge_text}</StyledBadge>);
   }
 
   return AppConfig.gl2DevMode()
     ? <Badge className="dev-badge" bsStyle="danger">DEV</Badge>
     : null;
-};
-
-HeaderBadge.propTypes = {
-  configuration: PropTypes.object,
-};
-
-HeaderBadge.defaultProps = {
-  configuration: {},
 };
 
 export default connect(HeaderBadge, { configurations: ConfigurationsStore }, ({ configurations, ...otherProps }) => ({

--- a/graylog2-web-interface/src/components/navigation/HeaderBadge.jsx
+++ b/graylog2-web-interface/src/components/navigation/HeaderBadge.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import createReactClass from 'create-react-class';
 import Reflux from 'reflux';
-import CombinedProvider from "injection/CombinedProvider";
+import CombinedProvider from 'injection/CombinedProvider';
 import { Badge } from 'react-bootstrap';
 import AppConfig from 'util/AppConfig';
 import badgeStyles from 'components/bootstrap/Badge.css';

--- a/graylog2-web-interface/src/components/navigation/Navigation.jsx
+++ b/graylog2-web-interface/src/components/navigation/Navigation.jsx
@@ -11,7 +11,7 @@ import StoreProvider from 'injection/StoreProvider';
 import PermissionsMixin from 'util/PermissionsMixin';
 
 import Routes from 'routing/Routes';
-import URLUtils from 'util/URLUtils';
+import { appPrefixed } from 'util/URLUtils';
 
 import { PluginStore } from 'graylog-web-plugin/plugin';
 
@@ -33,11 +33,11 @@ const CurrentUserStore = StoreProvider.getStore('CurrentUser');
 const { isPermitted } = PermissionsMixin;
 
 const _isActive = (requestPath, prefix) => {
-  return requestPath.indexOf(URLUtils.appPrefixed(prefix)) === 0;
+  return requestPath.indexOf(appPrefixed(prefix)) === 0;
 };
 
 const formatSinglePluginRoute = ({ description, path, permissions }) => {
-  const link = <NavigationLink key={description} description={description} path={URLUtils.appPrefixed(path)} />;
+  const link = <NavigationLink key={description} description={description} path={appPrefixed(path)} />;
   if (permissions) {
     return <IfPermitted key={description} permissions={permissions}>{link}</IfPermitted>;
   }

--- a/graylog2-web-interface/src/components/navigation/Navigation.jsx
+++ b/graylog2-web-interface/src/components/navigation/Navigation.jsx
@@ -2,7 +2,7 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import { withRouter } from 'react-router';
 
-import { Badge, Navbar, Nav, NavItem, NavDropdown } from 'components/graylog';
+import { Navbar, Nav, NavItem, NavDropdown } from 'components/graylog';
 import { LinkContainer } from 'react-router-bootstrap';
 import naturalSort from 'javascript-natural-sort';
 

--- a/graylog2-web-interface/src/components/navigation/Navigation.jsx
+++ b/graylog2-web-interface/src/components/navigation/Navigation.jsx
@@ -8,7 +8,7 @@ import naturalSort from 'javascript-natural-sort';
 
 import connect from 'stores/connect';
 import StoreProvider from 'injection/StoreProvider';
-import PermissionsMixin from 'util/PermissionsMixin';
+import { isPermitted } from 'util/PermissionsMixin';
 
 import Routes from 'routing/Routes';
 import URLUtils from 'util/URLUtils';
@@ -30,7 +30,6 @@ import InactiveNavItem from './InactiveNavItem';
 import ScratchpadToggle from './ScratchpadToggle';
 
 const CurrentUserStore = StoreProvider.getStore('CurrentUser');
-const { isPermitted } = PermissionsMixin;
 
 const _isActive = (requestPath, prefix) => {
   return requestPath.indexOf(URLUtils.appPrefixed(prefix)) === 0;

--- a/graylog2-web-interface/src/components/navigation/Navigation.jsx
+++ b/graylog2-web-interface/src/components/navigation/Navigation.jsx
@@ -12,7 +12,6 @@ import PermissionsMixin from 'util/PermissionsMixin';
 
 import Routes from 'routing/Routes';
 import URLUtils from 'util/URLUtils';
-import AppConfig from 'util/AppConfig';
 
 import { PluginStore } from 'graylog-web-plugin/plugin';
 
@@ -24,6 +23,7 @@ import { IfPermitted } from 'components/common';
 import NavigationBrand from './NavigationBrand';
 import NotificationBadge from './NotificationBadge';
 import NavigationLink from './NavigationLink';
+import HeaderBadge from './HeaderBadge';
 import SystemMenu from './SystemMenu';
 import styles from './Navigation.css';
 import InactiveNavItem from './InactiveNavItem';
@@ -66,6 +66,8 @@ const Navigation = ({ permissions, fullName, location, loginName }) => {
     .sort((route1, route2) => naturalSort(route1.description.toLowerCase(), route2.description.toLowerCase()))
     .map(pluginRoute => formatPluginRoute(pluginRoute, permissions, location));
 
+  const headerBadge = <HeaderBadge />;
+
   return (
     <Navbar inverse fluid fixedTop>
       <Navbar.Header>
@@ -75,11 +77,7 @@ const Navigation = ({ permissions, fullName, location, loginName }) => {
           </LinkContainer>
         </Navbar.Brand>
         <Navbar.Toggle />
-
-        {
-        AppConfig.gl2DevMode()
-          && <Badge bsStyle="danger" className="dev-badge">DEV</Badge>
-        }
+        <HeaderBadge />
       </Navbar.Header>
       <Navbar.Collapse>
         <Nav navbar>
@@ -110,10 +108,10 @@ const Navigation = ({ permissions, fullName, location, loginName }) => {
 
         <Nav navbar pullRight className={styles['header-meta-nav']}>
           {
-          AppConfig.gl2DevMode()
+            headerBadge
             && (
               <InactiveNavItem className={styles['dev-badge-wrap']}>
-                <Badge bsStyle="danger" className="dev-badge">DEV</Badge>
+                {headerBadge}
               </InactiveNavItem>
             )
           }

--- a/graylog2-web-interface/src/components/navigation/Navigation.jsx
+++ b/graylog2-web-interface/src/components/navigation/Navigation.jsx
@@ -11,7 +11,7 @@ import StoreProvider from 'injection/StoreProvider';
 import PermissionsMixin from 'util/PermissionsMixin';
 
 import Routes from 'routing/Routes';
-import { appPrefixed } from 'util/URLUtils';
+import URLUtils from 'util/URLUtils';
 
 import { PluginStore } from 'graylog-web-plugin/plugin';
 
@@ -33,11 +33,11 @@ const CurrentUserStore = StoreProvider.getStore('CurrentUser');
 const { isPermitted } = PermissionsMixin;
 
 const _isActive = (requestPath, prefix) => {
-  return requestPath.indexOf(appPrefixed(prefix)) === 0;
+  return requestPath.indexOf(URLUtils.appPrefixed(prefix)) === 0;
 };
 
 const formatSinglePluginRoute = ({ description, path, permissions }) => {
-  const link = <NavigationLink key={description} description={description} path={appPrefixed(path)} />;
+  const link = <NavigationLink key={description} description={description} path={URLUtils.appPrefixed(path)} />;
   if (permissions) {
     return <IfPermitted key={description} permissions={permissions}>{link}</IfPermitted>;
   }

--- a/graylog2-web-interface/src/components/navigation/Navigation.test.jsx
+++ b/graylog2-web-interface/src/components/navigation/Navigation.test.jsx
@@ -21,6 +21,8 @@ jest.mock('util/AppConfig', () => ({
 
 const findLink = (wrapper, title) => wrapper.find(`NavigationLink[description="${title}"]`);
 
+jest.mock('./HeaderBadge', () => () => <span />);
+
 describe('Navigation', () => {
   let currentUser;
   let Navigation;
@@ -31,10 +33,12 @@ describe('Navigation', () => {
       listen: jest.fn(),
       get: jest.fn(),
     };
+
     jest.doMock('injection/StoreProvider', () => ({ getStore: () => CurrentUserStore }));
     // eslint-disable-next-line global-require
     Navigation = require('./Navigation');
   });
+
   describe('has common elements', () => {
     let wrapper;
     beforeEach(() => {

--- a/graylog2-web-interface/src/components/navigation/Navigation.test.jsx
+++ b/graylog2-web-interface/src/components/navigation/Navigation.test.jsx
@@ -154,8 +154,8 @@ describe('Navigation', () => {
     };
     it.each`
     permissions                    | count | links
-    ${[]}                          | ${4}  | ${['Streams', 'Alerts', 'Dashboards']}
-    ${['searches:absolute', 'searches:relative', 'searches:keyword']} | ${5}  | ${['Search']}
+    ${[]}                          | ${5}  | ${['Streams', 'Alerts', 'Dashboards']}
+    ${['searches:absolute', 'searches:relative', 'searches:keyword']} | ${6}  | ${['Search']}
   `('shows $links for user with $permissions permissions', verifyPermissions);
   });
 });

--- a/graylog2-web-interface/src/contexts/CustomUi.jsx
+++ b/graylog2-web-interface/src/contexts/CustomUi.jsx
@@ -1,0 +1,37 @@
+import React, { createContext, useEffect, useState } from 'react';
+import PropTypes from 'prop-types';
+
+import CombinedProvider from 'injection/CombinedProvider';
+
+const { ConfigurationsActions } = CombinedProvider.get('Configurations');
+
+const DEFAULT_UI_CONTEXT = {};
+const CUSTOMIZATION_CONFIG = 'org.graylog2.configuration.Customization';
+
+export const CustomUiContext = createContext(DEFAULT_UI_CONTEXT);
+
+const CustomUiProvider = ({ children }) => {
+  const [badgeConfig, setBadgeConfig] = useState(DEFAULT_UI_CONTEXT);
+
+  useEffect(() => {
+    ConfigurationsActions.list(CUSTOMIZATION_CONFIG).then((configs) => {
+      setBadgeConfig(configs);
+    });
+  }, []);
+
+  const badgeUpdate = (newConfig) => {
+    setBadgeConfig(newConfig);
+  };
+
+  return (
+    <CustomUiContext.Provider value={{ badgeConfig, badgeUpdate }}>
+      {children}
+    </CustomUiContext.Provider>
+  );
+};
+
+CustomUiProvider.propTypes = {
+  children: PropTypes.node.isRequired,
+};
+
+export default CustomUiProvider;

--- a/graylog2-web-interface/src/contexts/CustomUi.jsx
+++ b/graylog2-web-interface/src/contexts/CustomUi.jsx
@@ -5,17 +5,27 @@ import CombinedProvider from 'injection/CombinedProvider';
 
 const { ConfigurationsActions } = CombinedProvider.get('Configurations');
 
-const DEFAULT_UI_CONTEXT = {};
+const DEFAULT_UI_CONTEXT = {
+  badgeConfig: {
+    badge_enable: false,
+    badge_color: '#689f38',
+    badge_text: '',
+  },
+};
 const CUSTOMIZATION_CONFIG = 'org.graylog2.configuration.Customization';
 
 export const CustomUiContext = createContext(DEFAULT_UI_CONTEXT);
 
 const CustomUiProvider = ({ children }) => {
-  const [badgeConfig, setBadgeConfig] = useState(DEFAULT_UI_CONTEXT);
+  const [badgeConfig, setBadgeConfig] = useState(DEFAULT_UI_CONTEXT.badgeConfig);
 
   useEffect(() => {
     ConfigurationsActions.list(CUSTOMIZATION_CONFIG).then((configs) => {
-      setBadgeConfig(configs);
+      if (configs) {
+        setBadgeConfig(configs);
+      } else {
+        setBadgeConfig(DEFAULT_UI_CONTEXT.badgeConfig);
+      }
     });
   }, []);
 

--- a/graylog2-web-interface/src/pages/ConfigurationsPage.jsx
+++ b/graylog2-web-interface/src/pages/ConfigurationsPage.jsx
@@ -14,7 +14,7 @@ import SidecarConfig from 'components/configurations/SidecarConfig';
 import CustomizationConfig from 'components/configurations/CustomizationConfig';
 import EventsConfig from 'components/configurations/EventsConfig';
 import UrlWhiteListConfig from 'components/configurations/UrlWhiteListConfig';
-import DecoratorsConfig from 'components/configurations/DecoratorsConfig';
+import DecoratorsConfig from '../components/configurations/DecoratorsConfig';
 import {} from 'components/maps/configurations';
 
 // eslint-disable-next-line import/no-webpack-loader-syntax
@@ -23,12 +23,14 @@ import style from '!style/useable!css!components/configurations/ConfigurationSty
 const { CurrentUserStore } = CombinedProvider.get('CurrentUser');
 const { ConfigurationsActions, ConfigurationsStore } = CombinedProvider.get('Configurations');
 
-const SEARCHES_CLUSTER_CONFIG = 'org.graylog2.indexer.searches.SearchesClusterConfig';
-const MESSAGE_PROCESSORS_CONFIG = 'org.graylog2.messageprocessors.MessageProcessorsConfig';
-const SIDECAR_CONFIG = 'org.graylog.plugins.sidecar.system.SidecarConfiguration';
-const EVENTS_CONFIG = 'org.graylog.events.configuration.EventsConfiguration';
-const URL_WHITELIST_CONFIG = 'org.graylog2.system.urlwhitelist.UrlWhitelist';
-const CUSTOMIZATION_CONFIG = 'org.graylog2.configuration.Customization';
+const CONFIG = {
+  SEARCHES_CLUSTER: 'org.graylog2.indexer.searches.SearchesClusterConfig',
+  MESSAGE_PROCESSORS: 'org.graylog2.messageprocessors.MessageProcessorsConfig',
+  SIDECAR: 'org.graylog.plugins.sidecar.system.SidecarConfiguration',
+  EVENTS: 'org.graylog.events.configuration.EventsConfiguration',
+  URL_WHITELIST: 'org.graylog2.system.urlwhitelist.UrlWhitelist',
+  CUSTOMIZATION: 'org.graylog2.configuration.Customization',
+};
 
 class ConfigurationsPage extends React.Component {
   state = {
@@ -38,18 +40,18 @@ class ConfigurationsPage extends React.Component {
   checkLoadedTimer = undefined
 
   componentDidMount() {
-    style.use();
     const { currentUser: { permissions } } = this.props;
+    style.use();
     this._checkConfig();
 
-    ConfigurationsActions.list(SEARCHES_CLUSTER_CONFIG);
-    ConfigurationsActions.listMessageProcessorsConfig(MESSAGE_PROCESSORS_CONFIG);
-    ConfigurationsActions.list(SIDECAR_CONFIG);
-    ConfigurationsActions.list(EVENTS_CONFIG);
-    ConfigurationsActions.list(CUSTOMIZATION_CONFIG);
+    ConfigurationsActions.list(CONFIG.SEARCHES_CLUSTER);
+    ConfigurationsActions.listMessageProcessorsConfig(CONFIG.MESSAGE_PROCESSORS);
+    ConfigurationsActions.list(CONFIG.SIDECAR);
+    ConfigurationsActions.list(CONFIG.EVENTS);
+    ConfigurationsActions.list(CONFIG.CUSTOMIZATION);
 
     if (isPermitted(permissions, ['urlwhitelist:read'])) {
-      ConfigurationsActions.listWhiteListConfig(URL_WHITELIST_CONFIG);
+      ConfigurationsActions.listWhiteListConfig(CONFIG.URL_WHITELIST);
     }
 
     PluginStore.exports('systemConfigurations').forEach((systemConfig) => {
@@ -73,9 +75,9 @@ class ConfigurationsPage extends React.Component {
   _onUpdate = (configType) => {
     return (config) => {
       switch (configType) {
-        case MESSAGE_PROCESSORS_CONFIG:
+        case CONFIG.MESSAGE_PROCESSORS:
           return ConfigurationsActions.updateMessageProcessorsConfig(configType, config);
-        case URL_WHITELIST_CONFIG:
+        case CONFIG.URL_WHITELIST:
           return ConfigurationsActions.updateWhitelist(configType, config);
         default:
           return ConfigurationsActions.update(configType, config);
@@ -119,8 +121,9 @@ class ConfigurationsPage extends React.Component {
 
   _checkConfig = () => {
     const { configuration } = this.props;
+
     this.checkLoadedTimer = setTimeout(() => {
-      if (Object.keys(configuration).length > 0) {
+      if (Object.keys(configuration).length >= Object.keys(CONFIG).length) {
         this.setState({ loaded: true }, this._clearTimeout);
         return;
       }
@@ -138,6 +141,7 @@ class ConfigurationsPage extends React.Component {
   render() {
     const { loaded } = this.state;
     const { currentUser: { permissions } } = this.props;
+    let pluginConfigRows = [];
     let Output = (
       <Col md={12}>
         <Spinner text="Loading Configuration Panel..." />
@@ -145,39 +149,40 @@ class ConfigurationsPage extends React.Component {
     );
 
     if (loaded) {
-      const searchesConfig = this._getConfig(SEARCHES_CLUSTER_CONFIG);
-      const messageProcessorsConfig = this._getConfig(MESSAGE_PROCESSORS_CONFIG);
-      const sidecarConfig = this._getConfig(SIDECAR_CONFIG);
-      const eventsConfig = this._getConfig(EVENTS_CONFIG);
-      const urlWhiteListConfig = this._getConfig(URL_WHITELIST_CONFIG);
-      const customizationConfig = this._getConfig(CUSTOMIZATION_CONFIG);
+      pluginConfigRows = this._pluginConfigRows();
+      const searchesConfig = this._getConfig(CONFIG.SEARCHES_CLUSTER);
+      const messageProcessorsConfig = this._getConfig(CONFIG.MESSAGE_PROCESSORS);
+      const sidecarConfig = this._getConfig(CONFIG.SIDECAR);
+      const eventsConfig = this._getConfig(CONFIG.EVENTS);
+      const urlWhiteListConfig = this._getConfig(CONFIG.URL_WHITELIST);
+      const customizationConfig = this._getConfig(CONFIG.CUSTOMIZATION);
 
       Output = (
         <>
           <Col md={6}>
             <SearchesConfig config={searchesConfig}
-                            updateConfig={this._onUpdate(SEARCHES_CLUSTER_CONFIG)} />
+                            updateConfig={this._onUpdate(CONFIG.SEARCHES_CLUSTER)} />
           </Col>
           <Col md={6}>
             <MessageProcessorsConfig config={messageProcessorsConfig}
-                                     updateConfig={this._onUpdate(MESSAGE_PROCESSORS_CONFIG)} />
+                                     updateConfig={this._onUpdate(CONFIG.MESSAGE_PROCESSORS)} />
           </Col>
           <Col md={6}>
             <SidecarConfig config={sidecarConfig}
-                           updateConfig={this._onUpdate(SIDECAR_CONFIG)} />
+                           updateConfig={this._onUpdate(CONFIG.SIDECAR)} />
           </Col>
           <Col md={6}>
             <CustomizationConfig config={customizationConfig}
-                                 updateConfig={this._onUpdate(CUSTOMIZATION_CONFIG)} />
+                                 updateConfig={this._onUpdate(CONFIG.CUSTOMIZATION)} />
           </Col>
           <Col md={6}>
             <EventsConfig config={eventsConfig}
-                          updateConfig={this._onUpdate(EVENTS_CONFIG)} />
+                          updateConfig={this._onUpdate(CONFIG.EVENTS)} />
           </Col>
           {isPermitted(permissions, ['urlwhitelist:read']) && (
           <Col md={6}>
             <UrlWhiteListConfig config={urlWhiteListConfig}
-                                updateConfig={this._onUpdate(URL_WHITELIST_CONFIG)} />
+                                updateConfig={this._onUpdate(CONFIG.URL_WHITELIST)} />
           </Col>
           )}
           <Col md={6}>
@@ -186,8 +191,6 @@ class ConfigurationsPage extends React.Component {
         </>
       );
     }
-
-    const pluginConfigRows = this._pluginConfigRows();
 
     return (
       <DocumentTitle title="Configurations">

--- a/graylog2-web-interface/src/pages/ConfigurationsPage.jsx
+++ b/graylog2-web-interface/src/pages/ConfigurationsPage.jsx
@@ -46,7 +46,7 @@ class ConfigurationsPage extends React.Component {
     ConfigurationsActions.listMessageProcessorsConfig(MESSAGE_PROCESSORS_CONFIG);
     ConfigurationsActions.list(SIDECAR_CONFIG);
     ConfigurationsActions.list(EVENTS_CONFIG);
-    ConfigurationsActions.list(this.CUSTOMIZATION_CONFIG);
+    ConfigurationsActions.list(CUSTOMIZATION_CONFIG);
 
     if (isPermitted(permissions, ['urlwhitelist:read'])) {
       ConfigurationsActions.listWhiteListConfig(URL_WHITELIST_CONFIG);
@@ -84,10 +84,10 @@ class ConfigurationsPage extends React.Component {
   };
 
   _pluginConfigs = () => {
-    return PluginStore.exports('systemConfigurations').map((systemConfig, idx) => {
+    return PluginStore.exports('systemConfigurations').map((systemConfig) => {
       return React.createElement(systemConfig.component, {
         // eslint-disable-next-line react/no-array-index-key
-        key: `system-configuration-${idx}`,
+        key: `system-configuration-${systemConfig.configType}`,
         config: this._getConfig(systemConfig.configType) || undefined,
         updateConfig: this._onUpdate(systemConfig.configType),
       });

--- a/graylog2-web-interface/src/pages/ConfigurationsPage.jsx
+++ b/graylog2-web-interface/src/pages/ConfigurationsPage.jsx
@@ -1,18 +1,20 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+
 import { Col, Row } from 'components/graylog';
 import { DocumentTitle, PageHeader, Spinner } from 'components/common';
 import { PluginStore } from 'graylog-web-plugin/plugin';
 import connect from 'stores/connect';
 import CombinedProvider from 'injection/CombinedProvider';
-
 import { isPermitted } from 'util/PermissionsMixin';
+
 import SearchesConfig from 'components/configurations/SearchesConfig';
 import MessageProcessorsConfig from 'components/configurations/MessageProcessorsConfig';
 import SidecarConfig from 'components/configurations/SidecarConfig';
+import CustomizationConfig from 'components/configurations/CustomizationConfig';
 import EventsConfig from 'components/configurations/EventsConfig';
 import UrlWhiteListConfig from 'components/configurations/UrlWhiteListConfig';
-import DecoratorsConfig from '../components/configurations/DecoratorsConfig';
+import DecoratorsConfig from 'components/configurations/DecoratorsConfig';
 import {} from 'components/maps/configurations';
 
 // eslint-disable-next-line import/no-webpack-loader-syntax
@@ -26,6 +28,7 @@ const MESSAGE_PROCESSORS_CONFIG = 'org.graylog2.messageprocessors.MessageProcess
 const SIDECAR_CONFIG = 'org.graylog.plugins.sidecar.system.SidecarConfiguration';
 const EVENTS_CONFIG = 'org.graylog.events.configuration.EventsConfiguration';
 const URL_WHITELIST_CONFIG = 'org.graylog2.system.urlwhitelist.UrlWhitelist';
+const CUSTOMIZATION_CONFIG = 'org.graylog2.configuration.Customization';
 
 class ConfigurationsPage extends React.Component {
   state = {
@@ -43,9 +46,12 @@ class ConfigurationsPage extends React.Component {
     ConfigurationsActions.listMessageProcessorsConfig(MESSAGE_PROCESSORS_CONFIG);
     ConfigurationsActions.list(SIDECAR_CONFIG);
     ConfigurationsActions.list(EVENTS_CONFIG);
+    ConfigurationsActions.list(this.CUSTOMIZATION_CONFIG);
+
     if (isPermitted(permissions, ['urlwhitelist:read'])) {
       ConfigurationsActions.listWhiteListConfig(URL_WHITELIST_CONFIG);
     }
+
     PluginStore.exports('systemConfigurations').forEach((systemConfig) => {
       ConfigurationsActions.list(systemConfig.configType);
     });
@@ -144,6 +150,7 @@ class ConfigurationsPage extends React.Component {
       const sidecarConfig = this._getConfig(SIDECAR_CONFIG);
       const eventsConfig = this._getConfig(EVENTS_CONFIG);
       const urlWhiteListConfig = this._getConfig(URL_WHITELIST_CONFIG);
+      const customizationConfig = this._getConfig(CUSTOMIZATION_CONFIG);
 
       Output = (
         <>
@@ -158,6 +165,10 @@ class ConfigurationsPage extends React.Component {
           <Col md={6}>
             <SidecarConfig config={sidecarConfig}
                            updateConfig={this._onUpdate(SIDECAR_CONFIG)} />
+          </Col>
+          <Col md={6}>
+            <CustomizationConfig config={customizationConfig}
+                                 updateConfig={this._onUpdate(CUSTOMIZATION_CONFIG)} />
           </Col>
           <Col md={6}>
             <EventsConfig config={eventsConfig}

--- a/graylog2-web-interface/src/pages/ConfigurationsPage.jsx
+++ b/graylog2-web-interface/src/pages/ConfigurationsPage.jsx
@@ -64,12 +64,12 @@ class ConfigurationsPage extends React.Component {
     this._clearTimeout();
   }
 
-  _getConfig = (configType) => {
+  _getConfig = (configType, fallback = null) => {
     const { configuration } = this.props;
     if (configuration && configuration[configType]) {
       return configuration[configType];
     }
-    return null;
+    return fallback;
   };
 
   _onUpdate = (configType) => {
@@ -155,7 +155,8 @@ class ConfigurationsPage extends React.Component {
       const sidecarConfig = this._getConfig(CONFIG.SIDECAR);
       const eventsConfig = this._getConfig(CONFIG.EVENTS);
       const urlWhiteListConfig = this._getConfig(CONFIG.URL_WHITELIST);
-      const customizationConfig = this._getConfig(CONFIG.CUSTOMIZATION);
+      const customizationConfig = this._getConfig(CONFIG.CUSTOMIZATION, {});
+      console.log("ConfigurationPage", customizationConfig);
 
       Output = (
         <>

--- a/graylog2-web-interface/src/pages/ConfigurationsPage.jsx
+++ b/graylog2-web-interface/src/pages/ConfigurationsPage.jsx
@@ -156,7 +156,6 @@ class ConfigurationsPage extends React.Component {
       const eventsConfig = this._getConfig(CONFIG.EVENTS);
       const urlWhiteListConfig = this._getConfig(CONFIG.URL_WHITELIST);
       const customizationConfig = this._getConfig(CONFIG.CUSTOMIZATION, {});
-      console.log("ConfigurationPage", customizationConfig);
 
       Output = (
         <>

--- a/graylog2-web-interface/src/routing/AppFacade.jsx
+++ b/graylog2-web-interface/src/routing/AppFacade.jsx
@@ -6,6 +6,7 @@ import ServerUnavailablePage from 'pages/ServerUnavailablePage';
 import StoreProvider from 'injection/StoreProvider';
 import connect from 'stores/connect';
 import GlobalThemeStyles from 'theme/GlobalThemeStyles';
+import CustomUiProvider from 'contexts/CustomUi';
 
 import 'bootstrap/less/bootstrap.less';
 import 'opensans-npm-webfont';
@@ -42,10 +43,10 @@ export const AppFacade = ({ currentUser, server, sessionId }) => {
   }
 
   return (
-    <>
+    <CustomUiProvider>
       <GlobalThemeStyles />
       {Page}
-    </>
+    </CustomUiProvider>
   );
 };
 

--- a/graylog2-web-interface/src/routing/AppRouter.test.jsx
+++ b/graylog2-web-interface/src/routing/AppRouter.test.jsx
@@ -18,7 +18,16 @@ jest.mock('injection/CombinedProvider', () => {
       permissions: ['*'],
     },
   })]);
+
+  const mockConfigurationsStoretore = MockStore('get', 'listen', ['getInitialState', () => ({
+    configuatration: { },
+  })]);
+
   return new MockCombinedProvider({
+    Configurations: {
+      ConfigurationsStore: mockConfigurationsStoretore,
+      ConfigurationsActions: { list: jest.fn() },
+    },
     CurrentUser: { CurrentUserStore: mockCurrentUserStoretore },
     Notifications: { NotificationsActions: { list: jest.fn() } },
   });

--- a/graylog2-web-interface/src/util/URLUtils.js
+++ b/graylog2-web-interface/src/util/URLUtils.js
@@ -69,7 +69,6 @@ export default URLUtils;
 
 export const {
   parser,
-  appPrefixed,
   getParsedHash,
   getParsedSearch,
   qualifyUrl,

--- a/graylog2-web-interface/test/integration-environment.js
+++ b/graylog2-web-interface/test/integration-environment.js
@@ -31,6 +31,7 @@ class IntegrationEnvironment extends JSDomEnvironment {
     api.get(`${prefix}system/sessions`, (req, res) => res.json({ session_id: null, username: null, is_valid: false }));
     api.get(`${prefix}system/notifications`, (req, res) => res.json([]));
     api.get(`${prefix}system/cluster/nodes`, (req, res) => res.json({ nodes: [], total: 0 }));
+    api.get(`${prefix}system/cluster_config/org.graylog2.configuration.Customization`, (req, res) => res.json({}));
     api.get(`${prefix}system/cluster_config/org.graylog2.indexer.searches.SearchesClusterConfig`, (req, res) => res.json({
       relative_timerange_options: {},
       query_time_range_limit: 'P5M',


### PR DESCRIPTION
## Description
Prior to this change, the graylog in DEV mode provided
a badge in the header which helped developers to seperate
the GUI they are working on from production builds.
Users asked for something like this, so the can seperate
there graylog instances between production, staging and
testing.

This change adds a Cluster configuration which can be
changed in 'System -> Configuration'. You can enable
or disable the header badge, provide a 5 characters long
text and change the background color.

## How Has This Been Tested?
Add and removed a header badge.

## Screenshots (if appropriate):
![graylog - configurations](https://user-images.githubusercontent.com/448763/53179141-6e938f00-35f3-11e9-80d6-3e67bba7360d.png)

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
