### PR TITLE
Fix HTTP 100 handling in http inputs

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/inputs/transports/HttpTransport.java
+++ b/graylog2-server/src/main/java/org/graylog2/inputs/transports/HttpTransport.java
@@ -93,8 +93,8 @@ public class HttpTransport extends AbstractTcpTransport {
 
         handlers.put("decoder", () -> new HttpRequestDecoder(DEFAULT_MAX_INITIAL_LINE_LENGTH, DEFAULT_MAX_HEADER_SIZE, maxChunkSize));
         handlers.put("decompressor", HttpContentDecompressor::new);
-        handlers.put("aggregator", () -> new HttpObjectAggregator(maxChunkSize));
         handlers.put("encoder", HttpResponseEncoder::new);
+        handlers.put("aggregator", () -> new HttpObjectAggregator(maxChunkSize));
         handlers.put("http-handler", () -> new HttpHandler(enableCors));
         handlers.putAll(super.getCustomChildChannelHandlers(input));
 


### PR DESCRIPTION
Requests with `Expect: 100-Continue` would lead to an exception and
terminate the request.
This got broken with the netty upgrade, which exchanged the
`HttpChunkedAggregator` to the new `HttpObjectAggregator`.

The aggregator needs to be registered after the `HttpResponseEncoder`
in the ChannelPipeline.
Ref: https://netty.io/4.1/api/io/netty/handler/codec/http/HttpObjectAggregator.html

Fixes #5690
