### PR TITLE
Add GracefulShutdownService

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/shared/bindings/GenericInitializerBindings.java
+++ b/graylog2-server/src/main/java/org/graylog2/shared/bindings/GenericInitializerBindings.java
@@ -19,6 +19,7 @@ package org.graylog2.shared.bindings;
 import com.google.common.util.concurrent.Service;
 import com.google.inject.AbstractModule;
 import com.google.inject.multibindings.Multibinder;
+import org.graylog2.system.shutdown.GracefulShutdownService;
 import org.graylog2.shared.initializers.InputSetupService;
 import org.graylog2.shared.initializers.JerseyService;
 import org.graylog2.shared.initializers.PeriodicalsService;
@@ -30,5 +31,6 @@ public class GenericInitializerBindings extends AbstractModule {
         serviceBinder.addBinding().to(InputSetupService.class);
         serviceBinder.addBinding().to(PeriodicalsService.class);
         serviceBinder.addBinding().to(JerseyService.class);
+        serviceBinder.addBinding().to(GracefulShutdownService.class).asEagerSingleton();
     }
 }

--- a/graylog2-server/src/main/java/org/graylog2/system/shutdown/GracefulShutdownHook.java
+++ b/graylog2-server/src/main/java/org/graylog2/system/shutdown/GracefulShutdownHook.java
@@ -1,0 +1,71 @@
+/**
+ * This file is part of Graylog.
+ *
+ * Graylog is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.graylog2.system.shutdown;
+
+/**
+ * Services can implement this to participate in a graceful shutdown of the server.
+ * <p>
+ * A service can register itself with the {@link GracefulShutdownService} like this:
+ *
+ * <pre> {@code
+ * class MyService implements GracefulShutdownHook {
+ *     private final GracefulShutdownService shutdownService;
+ *
+ *     @Inject
+ *     public MyService(GracefulShutdownService shutdownService) {
+ *         this.shutdownService = shutdownService;
+ *     }
+ *
+ *     // This will be executed by the GracefulShutdownService on server shutdown
+ *     @Override
+ *     void doGracefulShutdown() throws Exception {
+ *         runShutdownTasks();
+ *     }
+ *
+ *     public void start() {
+ *         // Let the GracefulShutdownService know about this service
+ *         this.shutdownService.register(this);
+ *     }
+ *
+ *     // This will be executed by some service manager when this service is stopped
+ *     public void stop() {
+ *         // Remove this service from the GracefulShutdownService because it's stopped before server shutdown and
+ *         // we don't need any graceful shutdown for it anymore
+ *         this.shutdownService.unregister(this);
+ *         runShutdownTasks();
+ *     }
+ *
+ *     private void runShutdownTasks() {
+ *         // Run the actual shutdown tasks for the service here
+ *     }
+ * }
+ * }</pre>
+ */
+public interface GracefulShutdownHook {
+    /**
+     * Execute shutdown tasks for the service that implements this interface.
+     * <h3>Warning:</h3>
+     * <ul>
+     *     <li>This method is called from another thread so the class that implements {@link GracefulShutdownHook} must be thread-safe.</li>
+     *     <li>The server shutdown is waiting for this method call to complete. Blocking this method will block the server
+     * shutdown!</li>
+     * </ul>
+     *
+     * @throws Exception
+     */
+    void doGracefulShutdown() throws Exception;
+}

--- a/graylog2-server/src/main/java/org/graylog2/system/shutdown/GracefulShutdownService.java
+++ b/graylog2-server/src/main/java/org/graylog2/system/shutdown/GracefulShutdownService.java
@@ -36,7 +36,8 @@ import java.util.concurrent.atomic.AtomicBoolean;
  * A service that participates in the Graylog server graceful shutdown.
  * <p>
  * Services can implement {@link GracefulShutdownHook} and register themselves with this service to make sure they
- * get shut down properly on server shutdown.
+ * get shut down properly on server shutdown. During shutdown the registered hooks will be called in no particular
+ * order.
  * <p>
  * Make sure to use {@link #unregister(GracefulShutdownHook)} if a registered service is shutting down before the
  * server shutdown to avoid leaking service instances in the {@link GracefulShutdownService}.

--- a/graylog2-server/src/main/java/org/graylog2/system/shutdown/GracefulShutdownService.java
+++ b/graylog2-server/src/main/java/org/graylog2/system/shutdown/GracefulShutdownService.java
@@ -32,6 +32,8 @@ import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 
+import static java.util.Objects.requireNonNull;
+
 /**
  * A service that participates in the Graylog server graceful shutdown.
  * <p>
@@ -98,13 +100,14 @@ public class GracefulShutdownService extends AbstractIdleService {
      * Register a shutdown hook with the service.
      * @param shutdownHook a class that implements {@link GracefulShutdownHook}
      * @throws IllegalStateException if the server shutdown is already in progress and the hook cannot be registered
+     * @throws NullPointerException if the shutdown hook argument is null
      */
     public void register(GracefulShutdownHook shutdownHook) {
         if (isShuttingDown.get()) {
             // Avoid any changes to the shutdown hooks set when the shutdown is already in progress
             throw new IllegalStateException("Couldn't register shutdown hook because shutdown is already in progress");
         }
-        shutdownHooks.add(shutdownHook);
+        shutdownHooks.add(requireNonNull(shutdownHook, "shutdownHook cannot be null"));
     }
 
     /**
@@ -113,13 +116,14 @@ public class GracefulShutdownService extends AbstractIdleService {
      * This needs to be called if a registered service will be stopped before the server shuts down.
      * @param shutdownHook a class that implements {@link GracefulShutdownHook}
      * @throws IllegalStateException if the server shutdown is already in progress and the hook cannot be unregistered
+     * @throws NullPointerException if the shutdown hook argument is null
      */
     public void unregister(GracefulShutdownHook shutdownHook) {
         if (isShuttingDown.get()) {
             // Avoid any changes to the shutdown hooks set when the shutdown is already in progress
             throw new IllegalStateException("Couldn't unregister shutdown hook because shutdown is already in progress");
         }
-        shutdownHooks.remove(shutdownHook);
+        shutdownHooks.remove(requireNonNull(shutdownHook, "shutdownHook cannot be null"));
     }
 
     private ExecutorService executorService(final int maxThreads) {

--- a/graylog2-server/src/main/java/org/graylog2/system/shutdown/GracefulShutdownService.java
+++ b/graylog2-server/src/main/java/org/graylog2/system/shutdown/GracefulShutdownService.java
@@ -16,6 +16,7 @@
  */
 package org.graylog2.system.shutdown;
 
+import com.google.common.base.Stopwatch;
 import com.google.common.util.concurrent.AbstractIdleService;
 import com.google.common.util.concurrent.ThreadFactoryBuilder;
 import org.slf4j.Logger;
@@ -70,7 +71,9 @@ public class GracefulShutdownService extends AbstractIdleService {
                 for (final GracefulShutdownHook shutdownHook : shutdownHooks) {
                     executor.submit(() -> {
                         try {
+                            final Stopwatch stopwatch = Stopwatch.createStarted();
                             shutdownHook.doGracefulShutdown();
+                            LOG.debug("Finished shutdown of <{}> (took {} ms)", shutdownHook, stopwatch.stop().elapsed(TimeUnit.MILLISECONDS));
                         } catch (Exception e) {
                             LOG.error("Problem shutting down <{}>", shutdownHook, e);
                         } finally {

--- a/graylog2-server/src/main/java/org/graylog2/system/shutdown/GracefulShutdownService.java
+++ b/graylog2-server/src/main/java/org/graylog2/system/shutdown/GracefulShutdownService.java
@@ -1,0 +1,118 @@
+/**
+ * This file is part of Graylog.
+ *
+ * Graylog is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.graylog2.system.shutdown;
+
+import com.google.common.util.concurrent.AbstractIdleService;
+import com.google.common.util.concurrent.ThreadFactoryBuilder;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.inject.Singleton;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.SynchronousQueue;
+import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * A service that participates in the Graylog server graceful shutdown.
+ * <p>
+ * Services can implement {@link GracefulShutdownHook} and register themselves with this service to make sure they
+ * get shut down properly on server shutdown.
+ * <p>
+ * Make sure to use {@link #unregister(GracefulShutdownHook)} if a registered service is shutting down before the
+ * server shutdown to avoid leaking service instances in the {@link GracefulShutdownService}.
+ *
+ * See {@link GracefulShutdownHook} for an example.
+ */
+@Singleton
+public class GracefulShutdownService extends AbstractIdleService {
+    private static final Logger LOG = LoggerFactory.getLogger(GracefulShutdownService.class);
+
+    private final Set<GracefulShutdownHook> shutdownHooks = ConcurrentHashMap.newKeySet();
+
+    @Override
+    protected void startUp() throws Exception {
+        // Nothing to do
+    }
+
+    @Override
+    protected void shutDown() throws Exception {
+        if (shutdownHooks.isEmpty()) {
+            return;
+        }
+
+        // Make sure we don't run this in parallel
+        synchronized (shutdownHooks) {
+            try {
+                // Use an executor to run the shutdown hooks in parallel but don't start too many threads
+                // TODO: Make max number of threads user configurable
+                final ExecutorService executor = executorService(Math.min(shutdownHooks.size(), 10));
+                final CountDownLatch latch = new CountDownLatch(shutdownHooks.size());
+
+                LOG.info("Running graceful shutdown for <{}> shutdown hooks", shutdownHooks.size());
+                for (final GracefulShutdownHook shutdownHook : shutdownHooks) {
+                    executor.submit(() -> {
+                        try {
+                            shutdownHook.doGracefulShutdown();
+                        } catch (Exception e) {
+                            LOG.error("Problem shutting down <{}>", shutdownHook, e);
+                        } finally {
+                            latch.countDown();
+                        }
+                    });
+                }
+
+                latch.await();
+                executor.shutdown();
+                executor.awaitTermination(1, TimeUnit.MINUTES);
+            } catch (Exception e) {
+                LOG.error("Problem shutting down registered hooks", e);
+            }
+        }
+    }
+
+    /**
+     * Register a shutdown hook with the service.
+     * @param shutdownHook a class that implements {@link GracefulShutdownHook}
+     */
+    public void register(GracefulShutdownHook shutdownHook) {
+        shutdownHooks.add(shutdownHook);
+    }
+
+    /**
+     * Remove a previously registered shutdown hook from the service.
+     * <p>
+     * This needs to be called if a registered service will be stopped before the server shuts down.
+     * @param shutdownHook a class that implements {@link GracefulShutdownHook}
+     */
+    public void unregister(GracefulShutdownHook shutdownHook) {
+        shutdownHooks.remove(shutdownHook);
+    }
+
+    private ExecutorService executorService(final int maxThreads) {
+        return new ThreadPoolExecutor(0,
+                maxThreads,
+                60L, TimeUnit.SECONDS,
+                new SynchronousQueue<>(),
+                new ThreadFactoryBuilder()
+                        .setNameFormat("graceful-shutdown-service-%d")
+                        .build());
+    }
+}

--- a/graylog2-server/src/main/java/org/graylog2/system/shutdown/GracefulShutdownService.java
+++ b/graylog2-server/src/main/java/org/graylog2/system/shutdown/GracefulShutdownService.java
@@ -72,13 +72,14 @@ public class GracefulShutdownService extends AbstractIdleService {
             LOG.info("Running graceful shutdown for <{}> shutdown hooks", shutdownHooks.size());
             for (final GracefulShutdownHook shutdownHook : shutdownHooks) {
                 executor.submit(() -> {
+                    final String hookName = shutdownHook.getClass().getSimpleName();
                     try {
-                        LOG.info("Initiate shutdown for <{}>", shutdownHook);
+                        LOG.info("Initiate shutdown for <{}>", hookName);
                         final Stopwatch stopwatch = Stopwatch.createStarted();
                         shutdownHook.doGracefulShutdown();
-                        LOG.info("Finished shutdown for <{}>, took {} ms", shutdownHook, stopwatch.stop().elapsed(TimeUnit.MILLISECONDS));
+                        LOG.info("Finished shutdown for <{}>, took {} ms", hookName, stopwatch.stop().elapsed(TimeUnit.MILLISECONDS));
                     } catch (Exception e) {
-                        LOG.error("Problem shutting down <{}>", shutdownHook, e);
+                        LOG.error("Problem shutting down <{}>", hookName, e);
                     } finally {
                         latch.countDown();
                     }

--- a/graylog2-server/src/main/java/org/graylog2/system/shutdown/GracefulShutdownService.java
+++ b/graylog2-server/src/main/java/org/graylog2/system/shutdown/GracefulShutdownService.java
@@ -90,7 +90,6 @@ public class GracefulShutdownService extends AbstractIdleService {
 
             latch.await();
             executor.shutdown();
-            executor.awaitTermination(1, TimeUnit.MINUTES);
         } catch (Exception e) {
             LOG.error("Problem shutting down registered hooks", e);
         }

--- a/graylog2-server/src/main/java/org/graylog2/system/shutdown/GracefulShutdownService.java
+++ b/graylog2-server/src/main/java/org/graylog2/system/shutdown/GracefulShutdownService.java
@@ -72,9 +72,10 @@ public class GracefulShutdownService extends AbstractIdleService {
             for (final GracefulShutdownHook shutdownHook : shutdownHooks) {
                 executor.submit(() -> {
                     try {
+                        LOG.info("Initiate shutdown for <{}>", shutdownHook);
                         final Stopwatch stopwatch = Stopwatch.createStarted();
                         shutdownHook.doGracefulShutdown();
-                        LOG.debug("Finished shutdown of <{}> (took {} ms)", shutdownHook, stopwatch.stop().elapsed(TimeUnit.MILLISECONDS));
+                        LOG.info("Finished shutdown for <{}>, took {} ms", shutdownHook, stopwatch.stop().elapsed(TimeUnit.MILLISECONDS));
                     } catch (Exception e) {
                         LOG.error("Problem shutting down <{}>", shutdownHook, e);
                     } finally {

--- a/graylog2-server/src/test/java/org/graylog2/system/shutdown/GracefulShutdownServiceTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/system/shutdown/GracefulShutdownServiceTest.java
@@ -19,7 +19,6 @@ package org.graylog2.system.shutdown;
 import org.junit.Before;
 import org.junit.Test;
 
-import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -125,12 +124,11 @@ public class GracefulShutdownServiceTest {
 
     @Test
     public void failRegisterAndUnregisterDuringShutdown() throws Exception {
-        final CountDownLatch latch = new CountDownLatch(1);
-        final GracefulShutdownHook hook = latch::await;
+        final GracefulShutdownHook hook = () -> {};
 
         shutdownService.register(hook);
 
-        shutdownService.stopAsync();
+        shutdownService.stopAsync().awaitTerminated();
 
         assertThatThrownBy(() -> shutdownService.register(hook), "register during shutdown should not work")
                 .hasMessageContaining("register")
@@ -139,8 +137,5 @@ public class GracefulShutdownServiceTest {
         assertThatThrownBy(() -> shutdownService.unregister(hook), "unregister during shutdown should not work")
                 .hasMessageContaining("unregister")
                 .isInstanceOf(IllegalStateException.class);
-
-        latch.countDown();
-        shutdownService.awaitTerminated();
     }
 }

--- a/graylog2-server/src/test/java/org/graylog2/system/shutdown/GracefulShutdownServiceTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/system/shutdown/GracefulShutdownServiceTest.java
@@ -1,0 +1,110 @@
+/**
+ * This file is part of Graylog.
+ *
+ * Graylog is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.graylog2.system.shutdown;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class GracefulShutdownServiceTest {
+    private GracefulShutdownService shutdownService;
+
+    @Before
+    public void setUp() throws Exception {
+        this.shutdownService = new GracefulShutdownService();
+        shutdownService.startAsync().awaitRunning();
+    }
+
+    private void stop(GracefulShutdownService service) throws Exception {
+        service.stopAsync().awaitTerminated(1, TimeUnit.MINUTES);
+    }
+
+    @Test
+    public void registerAndShutdown() throws Exception {
+        final AtomicBoolean hook1Called = new AtomicBoolean(false);
+        final AtomicBoolean hook2Called = new AtomicBoolean(false);
+
+        shutdownService.register(() -> hook1Called.set(true));
+        shutdownService.register(() -> hook2Called.set(true));
+
+        assertThat(hook1Called).isFalse();
+        assertThat(hook2Called).isFalse();
+
+        stop(shutdownService);
+
+        assertThat(hook1Called).isTrue();
+        assertThat(hook2Called).isTrue();
+    }
+
+    @Test
+    public void withExceptionOnShutdown() throws Exception {
+        final AtomicBoolean hook1Called = new AtomicBoolean(false);
+        final AtomicBoolean hook2Called = new AtomicBoolean(false);
+
+        shutdownService.register(() -> hook1Called.set(true));
+        shutdownService.register(() -> { throw new Exception("eek"); });
+
+        stop(shutdownService);
+
+        assertThat(hook1Called).isTrue();
+        assertThat(hook2Called).isFalse();
+    }
+
+    @Test
+    public void registerAndUnregister() throws Exception {
+        final AtomicBoolean hook1Called = new AtomicBoolean(false);
+        final AtomicBoolean hook2Called = new AtomicBoolean(false);
+
+        final GracefulShutdownHook hook1 = () -> hook1Called.set(true);
+        final GracefulShutdownHook hook2 = () -> hook2Called.set(true);
+
+        shutdownService.register(hook1);
+        shutdownService.register(hook2);
+
+        assertThat(hook1Called).isFalse();
+        assertThat(hook2Called).isFalse();
+
+        shutdownService.unregister(hook1);
+
+        stop(shutdownService);
+
+        assertThat(hook1Called).isFalse();
+        assertThat(hook2Called).isTrue();
+    }
+
+    @Test
+    public void registerMoreThanOnce() throws Exception {
+        final AtomicInteger value = new AtomicInteger(0);
+
+        final GracefulShutdownHook hook = value::incrementAndGet;
+
+        shutdownService.register(hook);
+        shutdownService.register(hook);
+        shutdownService.register(hook);
+
+        assertThat(value.get()).isEqualTo(0);
+
+        stop(shutdownService);
+
+        assertThat(value.get()).isEqualTo(1);
+    }
+}

--- a/graylog2-server/src/test/java/org/graylog2/system/shutdown/GracefulShutdownServiceTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/system/shutdown/GracefulShutdownServiceTest.java
@@ -94,6 +94,19 @@ public class GracefulShutdownServiceTest {
     }
 
     @Test
+    public void registerAndUnregisterNull() throws Exception {
+        assertThatThrownBy(() -> shutdownService.register(null))
+                .hasMessageContaining("shutdownHook")
+                .isInstanceOf(NullPointerException.class);
+
+        assertThatThrownBy(() -> shutdownService.unregister(null))
+                .hasMessageContaining("shutdownHook")
+                .isInstanceOf(NullPointerException.class);
+
+        stop(shutdownService);
+    }
+
+    @Test
     public void registerMoreThanOnce() throws Exception {
         final AtomicInteger value = new AtomicInteger(0);
 


### PR DESCRIPTION
Services can register themselves with the GracefulShutdownService to
make sure they will be stopped gracefully on server shutdown.

This allows plugins to participate in a graceful server shutdown to
make sure the server is not terminated before the plugin shutdown
routine is done.