### PR TITLE
Flatten grok pattern result when applied with OR

### DIFF
--- a/graylog2-server/src/main/java/org/graylog/plugins/pipelineprocessor/functions/strings/GrokMatch.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/pipelineprocessor/functions/strings/GrokMatch.java
@@ -63,7 +63,7 @@ public class GrokMatch extends AbstractFunction<GrokMatch.GrokResult> {
         final Grok grok = grokPatternRegistry.cachedGrokForPattern(pattern, onlyNamedCaptures);
 
         final Match match = grok.match(value);;
-        return new GrokResult(match.capture());
+        return new GrokResult(match.captureFlattened());
     }
 
     @Override

--- a/graylog2-server/src/main/java/org/graylog2/grok/InMemoryGrokPatternService.java
+++ b/graylog2-server/src/main/java/org/graylog2/grok/InMemoryGrokPatternService.java
@@ -161,7 +161,7 @@ public class InMemoryGrokPatternService implements GrokPatternService {
         }
         grokCompiler.register(pattern.name(), pattern.pattern());
         Grok grok = grokCompiler.compile("%{" + pattern.name() + "}");
-        return grok.capture(sampleData);
+        return grok.match(sampleData).captureFlattened();
     }
 
     @Override

--- a/graylog2-server/src/main/java/org/graylog2/grok/MongoDbGrokPatternService.java
+++ b/graylog2-server/src/main/java/org/graylog2/grok/MongoDbGrokPatternService.java
@@ -198,7 +198,7 @@ public class MongoDbGrokPatternService implements GrokPatternService {
         }
         grokCompiler.register(pattern.name(), pattern.pattern());
         Grok grok = grokCompiler.compile("%{" + pattern.name() + "}");
-        return grok.capture(sampleData);
+        return grok.match(sampleData).captureFlattened();
     }
 
     @Override

--- a/graylog2-server/src/main/java/org/graylog2/inputs/extractors/GrokExtractor.java
+++ b/graylog2-server/src/main/java/org/graylog2/inputs/extractors/GrokExtractor.java
@@ -91,7 +91,7 @@ public class GrokExtractor extends Extractor {
 
         // the extractor instance is rebuilt every second anyway
         final Match match = grok.match(value);
-        final Map<String, Object> matches = match.capture();
+        final Map<String, Object> matches = match.captureFlattened();
         final List<Result> results = new ArrayList<>(matches.size());
 
         for (final Map.Entry<String, Object> entry : matches.entrySet()) {

--- a/graylog2-server/src/main/java/org/graylog2/rest/resources/tools/GrokTesterResource.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/resources/tools/GrokTesterResource.java
@@ -92,7 +92,7 @@ public class GrokTesterResource extends RestResource {
         }
 
         final Match match = grok.match(string);
-        final Map<String, Object> matches = match.capture();
+        final Map<String, Object> matches = match.captureFlattened();
 
         final GrokTesterResponse response;
         if (matches.isEmpty()) {

--- a/graylog2-server/src/test/java/org/graylog2/inputs/extractors/GrokExtractorTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/inputs/extractors/GrokExtractorTest.java
@@ -240,6 +240,23 @@ public class GrokExtractorTest {
                 );
     }
 
+    @Test
+    public void testIssue4773() throws Exception {
+        // See: https://github.com/Graylog2/graylog2-server/issues/4773
+        final Map<String, Object> config = new HashMap<>();
+
+        config.put("named_captures_only", true);
+
+        // Using an OR with the same named capture should only return one value "2015" instead of "[2015, null]"
+        final GrokExtractor extractor = makeExtractor("(%{BASE10NUM:num}|%{BASE10NUM:num})", config);
+
+        assertThat(extractor.run("2015"))
+                .hasSize(1)
+                .containsOnly(
+                        new Extractor.Result("2015", "num", -1, -1)
+                );
+    }
+
     private GrokExtractor makeExtractor(String pattern) {
         return makeExtractor(pattern, new HashMap<>());
     }


### PR DESCRIPTION
## Description
Prior to this change, a named grok pattern containing a OR like

`(%{INT:login}|%{WORD:login}})`

would result in array like

`[null, found]`

This change will flatten the result (remove the null) and
only print the single left value instead of the array like
syntax:

`found`.

Fixes: #4773 

## How Has This Been Tested?
- Add first grok pattern `{name: "TEST1", pattern: "test1"}`
- Add second pattern `{name; "TEST2",  pattern: "test2"}`
- Add a extractor using the patterns: `(%{TEST1:found}|%{TEST2:found})`
- Send a gelf message containing a message containing `test1` 
- Look that extractor result is `found: test1`
- Send a gelf message containing a message containing `test2` 
- Look that extractor result is `found: test2`

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
