### PR TITLE
Fix AdjustDashboardPosition Migration

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/dashboards/DashboardImpl.java
+++ b/graylog2-server/src/main/java/org/graylog2/dashboards/DashboardImpl.java
@@ -91,10 +91,10 @@ public class DashboardImpl extends PersistedImpl implements Dashboard {
         final List<WidgetPosition> result = new ArrayList<>(positions.size());
         for ( String positionId : positions.keySet() ) {
             final BasicDBObject position = (BasicDBObject) positions.get(positionId);
-            final int width = parseInt(position.get("width").toString());
-            final int height = parseInt(position.get("height").toString());
-            final int col = parseInt(position.get("col").toString());
-            final int row = parseInt(position.get("row").toString());
+            final int width = parseInt(position.getString("width", "1"));
+            final int height = parseInt(position.getString("height", "1"));
+            final int col = parseInt(position.getString("col", "1"));
+            final int row = parseInt(position.getString("row","1"));
             final WidgetPosition widgetPosition = WidgetPosition.builder()
                     .id(positionId)
                     .width(width)
@@ -112,7 +112,7 @@ public class DashboardImpl extends PersistedImpl implements Dashboard {
         checkNotNull(widgetPositions, "widgetPositions must be given");
         final Map<String, Map<String, Integer>> positions = new HashMap<>(widgetPositions.size());
         for (WidgetPosition widgetPosition : widgetPositions) {
-            Map<String, Integer> position = new HashMap(4);
+            Map<String, Integer> position = new HashMap<>(4);
             position.put("width", widgetPosition.width());
             position.put("height", widgetPosition.height());
             position.put("col", widgetPosition.col());

--- a/graylog2-server/src/main/java/org/graylog2/migrations/V20180214093600_AdjustDashboardPositionToNewResolution.java
+++ b/graylog2-server/src/main/java/org/graylog2/migrations/V20180214093600_AdjustDashboardPositionToNewResolution.java
@@ -64,7 +64,7 @@ public class V20180214093600_AdjustDashboardPositionToNewResolution extends Migr
             return;
         }
 
-        Map<String, String> dashboardIds = new HashMap();
+        Map<String, String> dashboardIds = new HashMap<>();
         for (Dashboard dashboard : dashboardService.all()) {
             final List<WidgetPosition> oldPositions = dashboard.getPositions();
             if (oldPositions.isEmpty()) {
@@ -74,10 +74,10 @@ public class V20180214093600_AdjustDashboardPositionToNewResolution extends Migr
             final List<WidgetPosition> widgetPositions = new ArrayList<>(oldPositions.size());
 
             for (WidgetPosition position : oldPositions) {
-                Integer newWidth = position.width() * 2;
-                Integer newHeight = position.height() * 2;
-                Integer newCol = adjustPosition(position.col());
-                Integer newRow = adjustPosition(position.row());
+                int newWidth = position.width() * 2;
+                int newHeight = position.height() * 2;
+                int newCol = adjustPosition(position.col());
+                int newRow = adjustPosition(position.row());
                 widgetPositions.add(WidgetPosition.builder()
                         .id(position.id())
                         .width(newWidth)
@@ -99,7 +99,7 @@ public class V20180214093600_AdjustDashboardPositionToNewResolution extends Migr
 
     /* We double the resolution in space starting with 1.
        To keep widgets on the same position we need to subtract 1 from the result. */
-    private Integer adjustPosition(Integer value) {
+    private int adjustPosition(int value) {
         return value * 2 - 1;
     }
 

--- a/graylog2-server/src/test/java/org/graylog2/migrations/V20180214093600_AdjustDashboardPositionToNewResolutionTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/migrations/V20180214093600_AdjustDashboardPositionToNewResolutionTest.java
@@ -16,6 +16,7 @@
  */
 package org.graylog2.migrations;
 
+import com.google.common.collect.ImmutableList;
 import org.graylog2.dashboards.Dashboard;
 import org.graylog2.dashboards.DashboardService;
 import org.graylog2.dashboards.widgets.WidgetPosition;
@@ -34,7 +35,6 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
@@ -84,44 +84,41 @@ public class V20180214093600_AdjustDashboardPositionToNewResolutionTest {
     @Test
     public void doMigrateOneDashboardsPositions() throws Exception {
         /* Dashboard 1 */
-        final List<WidgetPosition> oldPositions1 = new ArrayList<>(1);
-        oldPositions1.add(WidgetPosition.builder().id("my-position-id").width(5).height(4).col(2).row(2).build());
+        final List<WidgetPosition> oldPositions1 = Collections.singletonList(
+                WidgetPosition.builder().id("my-position-id").width(5).height(4).col(2).row(2).build());
 
-        final List<WidgetPosition> newPositions1 = new ArrayList<>(1);
-        newPositions1.add(WidgetPosition.builder().id("my-position-id").width(10).height(8).col(3).row(3).build());
+        final List<WidgetPosition> newPositions1 = Collections.singletonList(
+                WidgetPosition.builder().id("my-position-id").width(10).height(8).col(3).row(3).build());
 
         final Dashboard dashboard1 = mock(Dashboard.class);
         when(dashboard1.getPositions()).thenReturn(oldPositions1);
         when(dashboard1.getId()).thenReturn("uuu-iii-ddd");
 
         /* Dashboard 2 */
-        final List<WidgetPosition> oldPositions2 = new ArrayList<>(1);
-        oldPositions2.add(WidgetPosition.builder().id("your-position-id").width(1).height(1).col(1).row(1).build());
+        final List<WidgetPosition> oldPositions2 = Collections.singletonList(
+                WidgetPosition.builder().id("your-position-id").width(1).height(1).col(1).row(1).build());
 
-        final List<WidgetPosition> newPositions2 = new ArrayList<>(1);
-        newPositions2.add(WidgetPosition.builder().id("your-position-id").width(2).height(2).col(1).row(1).build());
+        final List<WidgetPosition> newPositions2 = Collections.singletonList(
+                WidgetPosition.builder().id("your-position-id").width(2).height(2).col(1).row(1).build());
 
         final Dashboard dashboard2 = mock(Dashboard.class);
         when(dashboard2.getPositions()).thenReturn(oldPositions2);
         when(dashboard2.getId()).thenReturn("uuu-iii-eee");
 
         /* Dashboard 3 */
-        final List<WidgetPosition> oldPositions3 = new ArrayList<>(1);
-        oldPositions3.add(WidgetPosition.builder().id("his-position-id").width(1).height(1).col(1).row(1).build());
-        oldPositions3.add(WidgetPosition.builder().id("her-position-id").width(2).height(2).col(2).row(2).build());
+        final List<WidgetPosition> oldPositions3 = ImmutableList.of(
+                WidgetPosition.builder().id("his-position-id").width(1).height(1).col(1).row(1).build(),
+                WidgetPosition.builder().id("her-position-id").width(2).height(2).col(2).row(2).build());
 
-        final List<WidgetPosition> newPositions3 = new ArrayList<>(1);
-        newPositions3.add(WidgetPosition.builder().id("his-position-id").width(2).height(2).col(1).row(1).build());
-        newPositions3.add(WidgetPosition.builder().id("her-position-id").width(4).height(4).col(3).row(3).build());
+        final List<WidgetPosition> newPositions3 = ImmutableList.of(
+                WidgetPosition.builder().id("his-position-id").width(2).height(2).col(1).row(1).build(),
+                WidgetPosition.builder().id("her-position-id").width(4).height(4).col(3).row(3).build());
 
         final Dashboard dashboard3 = mock(Dashboard.class);
         when(dashboard3.getPositions()).thenReturn(oldPositions3);
         when(dashboard3.getId()).thenReturn("uuu-iii-eee");
 
-        List<Dashboard> dashboards = new ArrayList<>(2);
-        dashboards.add(dashboard1);
-        dashboards.add(dashboard2);
-        dashboards.add(dashboard3);
+        List<Dashboard> dashboards = ImmutableList.of(dashboard1, dashboard2, dashboard3);
         when(this.dashboardService.all()).thenReturn(dashboards);
 
         this.adjustDashboardResolutionMigration.upgrade();

--- a/graylog2-server/src/test/java/org/graylog2/migrations/V20180214093600_AdjustDashboardPositionToNewResolutionTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/migrations/V20180214093600_AdjustDashboardPositionToNewResolutionTest.java
@@ -1,4 +1,4 @@
-/*
+/**
  * This file is part of Graylog.
  *
  * Graylog is free software: you can redistribute it and/or modify

--- a/graylog2-server/src/test/java/org/graylog2/migrations/V20180214093600_AdjustDashboardPositionToNewResolutionTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/migrations/V20180214093600_AdjustDashboardPositionToNewResolutionTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * This file is part of Graylog.
  *
  * Graylog is free software: you can redistribute it and/or modify
@@ -16,7 +16,6 @@
  */
 package org.graylog2.migrations;
 
-import com.google.common.collect.ImmutableList;
 import org.graylog2.dashboards.Dashboard;
 import org.graylog2.dashboards.DashboardService;
 import org.graylog2.dashboards.widgets.WidgetPosition;
@@ -25,7 +24,6 @@ import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.mockito.Mock;
-import org.mockito.Mockito;
 import org.mockito.junit.MockitoJUnit;
 import org.mockito.junit.MockitoRule;
 
@@ -38,9 +36,7 @@ import static org.mockito.Mockito.when;
 
 import java.util.ArrayList;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 
 public class V20180214093600_AdjustDashboardPositionToNewResolutionTest {
     @Rule
@@ -78,7 +74,7 @@ public class V20180214093600_AdjustDashboardPositionToNewResolutionTest {
         final Dashboard dashboard = mock(Dashboard.class);
         when(dashboard.getId()).thenReturn("uuu-iii-ddd");
         when(dashboard.getPositions()).thenReturn(Collections.emptyList());
-        when(this.dashboardService.all()).thenReturn(ImmutableList.of(dashboard));
+        when(this.dashboardService.all()).thenReturn(Collections.singletonList(dashboard));
 
         this.adjustDashboardResolutionMigration.upgrade();
 
@@ -87,20 +83,54 @@ public class V20180214093600_AdjustDashboardPositionToNewResolutionTest {
 
     @Test
     public void doMigrateOneDashboardsPositions() throws Exception {
-        final List<WidgetPosition> oldPositions = new ArrayList<>(1);
-        oldPositions.add(WidgetPosition.builder().id("my-position-id").width(5).height(4).col(2).row(2).build());
+        /* Dashboard 1 */
+        final List<WidgetPosition> oldPositions1 = new ArrayList<>(1);
+        oldPositions1.add(WidgetPosition.builder().id("my-position-id").width(5).height(4).col(2).row(2).build());
 
-        final List<WidgetPosition> newPositions = new ArrayList<>(1);
-        newPositions.add(WidgetPosition.builder().id("my-position-id").width(10).height(8).col(3).row(3).build());
+        final List<WidgetPosition> newPositions1 = new ArrayList<>(1);
+        newPositions1.add(WidgetPosition.builder().id("my-position-id").width(10).height(8).col(3).row(3).build());
 
-        final Dashboard dashboard = mock(Dashboard.class, Mockito.RETURNS_DEEP_STUBS);
-        when(dashboard.getPositions()).thenReturn(oldPositions);
-        when(dashboard.getId()).thenReturn("uuu-iii-ddd");
-        when(this.dashboardService.all()).thenReturn(ImmutableList.of(dashboard));
+        final Dashboard dashboard1 = mock(Dashboard.class);
+        when(dashboard1.getPositions()).thenReturn(oldPositions1);
+        when(dashboard1.getId()).thenReturn("uuu-iii-ddd");
+
+        /* Dashboard 2 */
+        final List<WidgetPosition> oldPositions2 = new ArrayList<>(1);
+        oldPositions2.add(WidgetPosition.builder().id("your-position-id").width(1).height(1).col(1).row(1).build());
+
+        final List<WidgetPosition> newPositions2 = new ArrayList<>(1);
+        newPositions2.add(WidgetPosition.builder().id("your-position-id").width(2).height(2).col(1).row(1).build());
+
+        final Dashboard dashboard2 = mock(Dashboard.class);
+        when(dashboard2.getPositions()).thenReturn(oldPositions2);
+        when(dashboard2.getId()).thenReturn("uuu-iii-eee");
+
+        /* Dashboard 3 */
+        final List<WidgetPosition> oldPositions3 = new ArrayList<>(1);
+        oldPositions3.add(WidgetPosition.builder().id("his-position-id").width(1).height(1).col(1).row(1).build());
+        oldPositions3.add(WidgetPosition.builder().id("her-position-id").width(2).height(2).col(2).row(2).build());
+
+        final List<WidgetPosition> newPositions3 = new ArrayList<>(1);
+        newPositions3.add(WidgetPosition.builder().id("his-position-id").width(2).height(2).col(1).row(1).build());
+        newPositions3.add(WidgetPosition.builder().id("her-position-id").width(4).height(4).col(3).row(3).build());
+
+        final Dashboard dashboard3 = mock(Dashboard.class);
+        when(dashboard3.getPositions()).thenReturn(oldPositions3);
+        when(dashboard3.getId()).thenReturn("uuu-iii-eee");
+
+        List<Dashboard> dashboards = new ArrayList<>(2);
+        dashboards.add(dashboard1);
+        dashboards.add(dashboard2);
+        dashboards.add(dashboard3);
+        when(this.dashboardService.all()).thenReturn(dashboards);
 
         this.adjustDashboardResolutionMigration.upgrade();
 
-        verify(dashboard).setPositions(newPositions);
-        verify(this.dashboardService, times(1)).save(dashboard);
+        verify(dashboard1).setPositions(newPositions1);
+        verify(this.dashboardService, times(1)).save(dashboard1);
+        verify(dashboard2).setPositions(newPositions2);
+        verify(this.dashboardService, times(1)).save(dashboard2);
+        verify(dashboard3).setPositions(newPositions3);
+        verify(this.dashboardService, times(1)).save(dashboard3);
     }
 }


### PR DESCRIPTION
# Description
Prior to this change, the migration expected that all postions
have a "width", "heigth", "row" and "col" field.
Some users did not have a "width" or "height" field.

This change will add default values for the fields in the
getPositions functions of DashboardImpl.

Also fix some warnings.

Fixes #5737

## How Has This Been Tested?
- Created a dashboard in 2.5 and removed the "width" and "height" from the position
- Upgraded to 3.0

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
