### PR TITLE
Add support of wildcards in query parser (3.0)

### DIFF
--- a/graylog2-web-interface/src/logic/search/queryParser.test.js
+++ b/graylog2-web-interface/src/logic/search/queryParser.test.js
@@ -264,6 +264,11 @@ describe('Query Parser', function () {
     expectIdentityDump(query);
   });
 
+  it('can parse wildcards inside term', function () {
+    var query = 'st?rt *middle* end?"';
+    expectIdentityDump(query);
+  });
+
   it('can parse a unary NOT expression', function () {
     var query = "NOT submit";
     var parser = new QueryParser(query);
@@ -524,6 +529,20 @@ describe('Query Parser', function () {
     expect(ast.isInclusiveRange()).toBeTruthy();
     expect(ast.isExclusiveRange()).toBeFalsy();
     expectIdentityDump(query);
+  });
+
+
+  it('can parse pure wildcard', function () {
+    var query = 'http_response_code:*"';
+    expectIdentityDump(query);
+  });
+
+  it('reports an error when using question mark as pure wildcard', function () {
+    var query = 'http_response_code:?"';
+    var parser = new QueryParser(query);
+    parser.parse();
+    expect(parser.errors.length).toBe(1);
+    expectIdentityDump(query, true);
   });
 
   it('can parse an exclusive range search', function () {

--- a/graylog2-web-interface/src/logic/search/queryParser.ts
+++ b/graylog2-web-interface/src/logic/search/queryParser.ts
@@ -296,12 +296,20 @@ class QueryLexer {
         return char === '}';
     }
 
+    isWildcard(char) {
+        return char === '?' || this.isPureWildcard(char);
+    }
+
+    isPureWildcard(char) {
+        return char === '*';
+    }
+
     isTermStart(char) {
-        return char !== null && !this.isWhitespace(char) && (!this.isSpecial(char) || this.isRangeStart(char));
+        return char !== null && !this.isWhitespace(char) && (!this.isSpecial(char) || this.isRangeStart(char) || this.isPureWildcard(char));
     }
 
     isTerm(char) {
-        return this.isTermStart(char) || this.isOneOf('+-', char);
+        return this.isTermStart(char) || this.isOneOf('+-', char) || this.isWildcard(char);
     }
 
     isEscaped(char) {

--- a/graylog2-web-interface/src/logic/search/queryParser.ts
+++ b/graylog2-web-interface/src/logic/search/queryParser.ts
@@ -401,7 +401,7 @@ export class QueryParser {
         return skippedTokens;
     }
 
-    private syncTo(syncTo: TokenType[]): Array<Token> {
+    private syncTo(syncTo: TokenType[] = []): Array<Token> {
         var skippedTokens = [];
         while (this.lookAhead().type !== TokenType.EOF && syncTo.every((type) => type !== this.lookAhead().type)) {
             skippedTokens.push(this.lookAhead());


### PR DESCRIPTION
Until now our custom Lucene query parser used for search auto-completion did not support wildcards. This caused the parser to throw exceptions in the background, which in 3.0 could cause the "something went wrong" page to come out, as described in #5719.

This PR adds support for wildcards in the query parser, and also modifies the code throwing the exception, ensuring that no error is thrown if a similar situation occurs.

Fixes #5719