### PR TITLE
Fix http input keep-alive handling (#5728)

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/inputs/transports/netty/HttpHandler.java
+++ b/graylog2-server/src/main/java/org/graylog2/inputs/transports/netty/HttpHandler.java
@@ -22,7 +22,7 @@ import io.netty.channel.ChannelFuture;
 import io.netty.channel.ChannelFutureListener;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.SimpleChannelInboundHandler;
-import io.netty.handler.codec.http.DefaultHttpResponse;
+import io.netty.handler.codec.http.DefaultFullHttpResponse;
 import io.netty.handler.codec.http.FullHttpRequest;
 import io.netty.handler.codec.http.HttpHeaderNames;
 import io.netty.handler.codec.http.HttpHeaderValues;
@@ -74,7 +74,7 @@ public class HttpHandler extends SimpleChannelInboundHandler<HttpRequest> {
                                HttpVersion httpRequestVersion,
                                HttpResponseStatus status,
                                String origin) {
-        final HttpResponse response = new DefaultHttpResponse(httpRequestVersion, status);
+        final HttpResponse response = new DefaultFullHttpResponse(httpRequestVersion, status);
 
         response.headers().set(HttpHeaderNames.CONTENT_LENGTH, 0);
         response.headers().set(HttpHeaderNames.CONNECTION, keepAlive ? HttpHeaderValues.KEEP_ALIVE : HttpHeaderValues.CLOSE);
@@ -87,8 +87,6 @@ public class HttpHandler extends SimpleChannelInboundHandler<HttpRequest> {
 
         final ChannelFuture channelFuture = channel.writeAndFlush(response);
 
-        if (!keepAlive) {
-            channelFuture.addListener(ChannelFutureListener.CLOSE);
-        }
+        channelFuture.addListener(keepAlive ? ChannelFutureListener.CLOSE_ON_FAILURE : ChannelFutureListener.CLOSE);
     }
 }


### PR DESCRIPTION
We were only responding to the first request on an http keep-alive connection
with a 202.
Any following requests would not be answered, leading to a timeout in the client.

Configuring a ChannelFuture for CLOSE_ON_FAILURE did expose the reason
for the bug:

`io.netty.handler.codec.EncoderException:
java.lang.IllegalStateException: unexpected message type:
DefaultHttpResponse, state: 1`

We ought to use `DefaultFullHttpResponse` instead of `DefaultHttpResponse`.
Also keep the `CLOSE_ON_FAILURE` to make this more robust for future bugs.

Fixes #5720

(cherry picked from commit 9f34e09602236afb6cecbb0ff80832bbac287aee)
