### PR TITLE
Allowing to retrieve current state from `InputsStore`.

### DIFF
--- a/graylog2-web-interface/src/stores/inputs/InputsStore.js
+++ b/graylog2-web-interface/src/stores/inputs/InputsStore.js
@@ -17,8 +17,16 @@ const InputsStore = Reflux.createStore({
   input: undefined,
 
   init() {
-    this.trigger({ inputs: this.inputs, input: this.input });
+    this.trigger(this._state());
     this.listenTo(InputStaticFieldsStore, this.list);
+  },
+
+  getInitialState() {
+    return this._state();
+  },
+
+  _state() {
+    return { inputs: this.inputs, input: this.input };
   },
 
   list() {
@@ -27,7 +35,7 @@ const InputsStore = Reflux.createStore({
       .then(
         (response) => {
           this.inputs = response.inputs;
-          this.trigger({ inputs: this.inputs });
+          this.trigger(this._state());
 
           return this.inputs;
         },
@@ -50,16 +58,16 @@ const InputsStore = Reflux.createStore({
       .then(
         (response) => {
           this.input = response;
-          this.trigger({ input: this.input });
+          this.trigger(this._state());
 
           return this.input;
         },
         (error) => {
           if (showError) {
             UserNotification.error(`Fetching input ${inputId} failed with status: ${error}`,
-                                   'Could not retrieve input');
+              'Could not retrieve input');
           } else {
-            this.trigger({ input: {} });
+            this.trigger(this._state());
           }
         });
 

--- a/graylog2-web-interface/src/stores/inputs/InputsStore.js
+++ b/graylog2-web-interface/src/stores/inputs/InputsStore.js
@@ -5,9 +5,9 @@ import fetch from 'logic/rest/FetchProvider';
 import UserNotification from 'util/UserNotification';
 
 import StoreProvider from 'injection/StoreProvider';
-const InputStaticFieldsStore = StoreProvider.getStore('InputStaticFields');
-
 import ActionsProvider from 'injection/ActionsProvider';
+
+const InputStaticFieldsStore = StoreProvider.getStore('InputStaticFields');
 const InputsActions = ActionsProvider.getActions('Inputs');
 
 const InputsStore = Reflux.createStore({


### PR DESCRIPTION
## Description
## Motivation and Context

Before this change, the `InputsStore` did not contain a
`getInitialState` function, allowing consumers (especially `connect`) to
retrieve the current state without triggering an update.

This is required by `connect` to get its initial seed. Also it
alleviates the need to ensure that the consumer is listening to the
store _before_ a `list` action is triggered.

<!--- Provide a general summary of your changes in the Title above -->

<!--- Describe your changes in detail -->

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.