### PR TITLE
Fix problem with captureFlattened

### DIFF
--- a/graylog2-server/src/test/java/org/graylog2/inputs/extractors/GrokExtractorTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/inputs/extractors/GrokExtractorTest.java
@@ -29,6 +29,8 @@ import org.junit.Before;
 import org.junit.Test;
 
 import java.time.Instant;
+import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
@@ -50,10 +52,19 @@ public class GrokExtractorTest {
         final GrokPattern baseNum = GrokPattern.create("BASE10NUM", "(?<![0-9.+-])(?>[+-]?(?:(?:[0-9]+(?:\\.[0-9]+)?)|(?:\\.[0-9]+)))");
         final GrokPattern number = GrokPattern.create("NUMBER", "(?:%{BASE10NUM:UNWANTED})");
         final GrokPattern data = GrokPattern.create("GREEDY", ".*");
+        final GrokPattern twoBaseNums = GrokPattern.create("TWOBASENUMS", "%{BASE10NUM} %{BASE10NUM}");
+        final GrokPattern test1 = GrokPattern.create("TEST1", "test1");
+        final GrokPattern test2 = GrokPattern.create("TEST2", "test2");
+        final GrokPattern orPattern = GrokPattern.create("ORTEST", "(%{TEST1:test}|%{TEST2:test})");
 
         patternSet.add(baseNum);
         patternSet.add(number);
         patternSet.add(data);
+        patternSet.add(twoBaseNums);
+        patternSet.add(test1);
+        patternSet.add(test2);
+        patternSet.add(orPattern);
+
     }
 
     @Test
@@ -199,6 +210,19 @@ public class GrokExtractorTest {
         assertEquals(5, date.getMinuteOfHour());
         assertEquals(36, date.getSecondOfMinute());
         assertEquals(773, date.getMillisOfSecond());
+    }
+
+    @Test
+    public void testFlattenValue() throws Exception {
+        final Map<String, Object> config = new HashMap<>();
+
+        final GrokExtractor extractor1 = makeExtractor("%{TWOBASENUMS}", config);
+
+        Extractor.Result[] result = extractor1.run("22 23");
+        assertThat(result)
+                .hasSize(2)
+                .contains(new Extractor.Result("22 23", "TWOBASENUMS", -1, -1),
+                        new Extractor.Result(Arrays.asList("22", "23"), "BASE10NUM", -1, -1));
     }
 
     @Test

--- a/graylog2-server/src/test/java/org/graylog2/inputs/extractors/GrokExtractorTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/inputs/extractors/GrokExtractorTest.java
@@ -218,11 +218,19 @@ public class GrokExtractorTest {
 
         final GrokExtractor extractor1 = makeExtractor("%{TWOBASENUMS}", config);
 
-        Extractor.Result[] result = extractor1.run("22 23");
-        assertThat(result)
+        /* Test flatten with a multiple non unique result [ 22, 23 ] */
+        Extractor.Result[] result1 = extractor1.run("22 23");
+        assertThat(result1)
                 .hasSize(2)
                 .contains(new Extractor.Result("22 23", "TWOBASENUMS", -1, -1),
                         new Extractor.Result(Arrays.asList("22", "23"), "BASE10NUM", -1, -1));
+
+        /* Test flatten with a multiple but unique result [ 22, 22 ] */
+        Extractor.Result[] result2 = extractor1.run("22 22");
+        assertThat(result2)
+                .hasSize(2)
+                .contains(new Extractor.Result("22 22", "TWOBASENUMS", -1, -1),
+                        new Extractor.Result("22", "BASE10NUM", -1, -1));
     }
 
     @Test

--- a/pom.xml
+++ b/pom.xml
@@ -100,7 +100,7 @@
         <jest.version>2.4.15+jackson</jest.version>
         <gelfclient.version>1.4.4</gelfclient.version>
         <geoip2.version>2.12.0</geoip2.version>
-        <grok.version>0.1.9-graylog-1</grok.version>
+        <grok.version>0.1.9-graylog-2</grok.version>
         <guava-retrying.version>2.0.0</guava-retrying.version>
         <guava.version>25.1-jre</guava.version>
         <guice.version>4.2.0</guice.version>


### PR DESCRIPTION
## Description
`caputeFlattend` raised a exception when it got a result containing multiple non-null results
and tried to flatten that.
We now will remove all null values and reduce the result to a single value if only a single
value is left.

## Motivation and Context
For some reason the java-grok library was raising this error instead of just removing the null
values.

## How Has This Been Tested?
- Adding a grok extractor with following grok: `%{INT:first} %{INT:second}` without
`named caputure only`
- Send in a log message with "22 23"
- See that no exception was raised

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
