### PR TITLE
Fix problem with captureFlattened (#5818)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -100,7 +100,7 @@
         <jest.version>2.4.15+jackson</jest.version>
         <gelfclient.version>1.4.4</gelfclient.version>
         <geoip2.version>2.12.0</geoip2.version>
-        <grok.version>0.1.9-graylog-1</grok.version>
+        <grok.version>0.1.9-graylog-2</grok.version>
         <guava-retrying.version>2.0.0</guava-retrying.version>
         <guava.version>25.1-jre</guava.version>
         <guice.version>4.2.0</guice.version>


### PR DESCRIPTION
* Add test for flatten with multiple non-null-values

* Upgrade to fixed version of java grok

and add a addional test case

Fixes #4773

(cherry picked from commit d41e60fe0935edd9277b128a6d2f82c8149513a1)