### PR TITLE
Make `Timestamp` accept seconds from epoch.

### DIFF
--- a/graylog2-web-interface/src/components/common/Timestamp.jsx
+++ b/graylog2-web-interface/src/components/common/Timestamp.jsx
@@ -50,6 +50,8 @@ class Timestamp extends React.Component {
 
   static defaultProps = {
     format: DateTime.Formats.TIMESTAMP,
+    relative: false,
+    tz: undefined,
   };
 
   _formatDateTime = () => {

--- a/graylog2-web-interface/src/components/common/Timestamp.jsx
+++ b/graylog2-web-interface/src/components/common/Timestamp.jsx
@@ -20,9 +20,10 @@ class Timestamp extends React.Component {
   static propTypes = {
     /**
      * Date time to be displayed in the component. You can provide an ISO
-     * 8601 string, a JS native `Date` object, or a moment `Date` object.
+     * 8601 string, a JS native `Date` object, a moment `Date` object, or
+     * a number containing seconds after UNIX epoch.
      */
-    dateTime: PropTypes.oneOfType([PropTypes.string, PropTypes.object]).isRequired,
+    dateTime: PropTypes.oneOfType([PropTypes.string, PropTypes.object, PropTypes.number]).isRequired,
     /**
      * Format to use to represent the date time. It supports any format
      * supported by momentjs http://momentjs.com/docs/#/displaying/format/.

--- a/graylog2-web-interface/src/components/common/Timestamp.jsx
+++ b/graylog2-web-interface/src/components/common/Timestamp.jsx
@@ -67,7 +67,6 @@ class Timestamp extends React.Component {
         return dateTime.toBrowserLocalTime().toString(this.props.format);
       default:
         return dateTime.toTimeZone(this.props.tz).toString(this.props.format);
-
     }
   };
 

--- a/graylog2-web-interface/src/components/common/Timestamp.md
+++ b/graylog2-web-interface/src/components/common/Timestamp.md
@@ -16,6 +16,11 @@ const DateTime = require('logic/datetimes/DateTime');
 <Timestamp dateTime={new Date().toISOString()} format={DateTime.Formats.COMPLETE} />
 ```
 
+Showing date/time of Unix Timestamp (in millis):
+```js
+<Timestamp datetime={1554121284687} />
+```
+
 Time zone conversions:
 ```js
 const moment = require('moment');


### PR DESCRIPTION
## Description
## Motivation and Context

Before this change, passing a number containing a timestamp based on
seconds after epoch resulted in a proper output, but also raised a prop
type validation error.

This change is now adding `number` to be a valid prop type for
`dateTime` and documents the possibility to use seconds after epoch for
`Timestamp`.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.