### PR TITLE
Fix missing guice bindings for MessageOutput.Factory2 (#5771)

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/bindings/ServerBindings.java
+++ b/graylog2-server/src/main/java/org/graylog2/bindings/ServerBindings.java
@@ -116,6 +116,10 @@ public class ServerBindings extends Graylog2Module {
         install(new GrokModule());
         install(new LookupModule());
         install(new FieldTypesModule());
+
+        // Just to create the binders so they are present in the injector. Prevents a server startup error when no
+        // outputs are bound that implement MessageOutput.Factory2.
+        outputsMapBinder2();
     }
 
     private void bindProviders() {


### PR DESCRIPTION
We have to call the outputsMapBinder2() method during startup to always
create the map binder for MessageOutput.Factory2. Otherwise the server
doesn't start when there is no output that is using the factory.

(cherry picked from commit 7ab91b012e3695a9328e244e11a91a59850f9db2)