### PR TITLE
Set Modals to only close with ESC key or Cancel & X buttons

### DIFF
--- a/graylog2-web-interface/src/components/bootstrap/BootstrapModalWrapper.jsx
+++ b/graylog2-web-interface/src/components/bootstrap/BootstrapModalWrapper.jsx
@@ -12,6 +12,7 @@ class BootstrapModalWrapper extends React.Component {
     onClose: () => {},
     onHide: () => {},
     bsSize: undefined,
+    backdrop: 'static',
   };
 
   static propTypes = {
@@ -26,6 +27,7 @@ class BootstrapModalWrapper extends React.Component {
     bsSize: PropTypes.oneOf([
       'large', 'lg', 'small', 'sm',
     ]),
+    backdrop: PropTypes.oneOf(['static', true, false]),
   };
 
   state = {
@@ -46,7 +48,12 @@ class BootstrapModalWrapper extends React.Component {
 
   render() {
     return (
-      <Modal show={this.state.showModal} onHide={this.hide} bsSize={this.props.bsSize}>
+      <Modal
+        show={this.state.showModal}
+        onHide={this.hide}
+        bsSize={this.props.bsSize}
+        backdrop={this.props.backdrop}
+      >
         {this.props.children}
       </Modal>
     );

--- a/graylog2-web-interface/src/components/users/__snapshots__/UserPreferencesButton.test.jsx.snap
+++ b/graylog2-web-interface/src/components/users/__snapshots__/UserPreferencesButton.test.jsx.snap
@@ -38,6 +38,7 @@ exports[`UserPreferencesButton should load user data when user clicks edit butto
         title="Preferences for user Full"
       >
         <BootstrapModalWrapper
+          backdrop="static"
           onClose={[Function]}
           onHide={[Function]}
           onOpen={[Function]}
@@ -46,7 +47,7 @@ exports[`UserPreferencesButton should load user data when user clicks edit butto
           <Modal
             animation={true}
             autoFocus={true}
-            backdrop={true}
+            backdrop="static"
             bsClass="modal"
             dialogComponentClass={[Function]}
             enforceFocus={true}
@@ -70,7 +71,7 @@ exports[`UserPreferencesButton should load user data when user clicks edit butto
           >
             <Modal
               autoFocus={true}
-              backdrop={true}
+              backdrop="static"
               backdropClassName="modal-backdrop"
               backdropTransitionTimeout={150}
               containerClassName="modal-open"


### PR DESCRIPTION
## Description
Set default for Modal component to not automatically close when outside of component is clicked.

## Motivation and Context
Closes #5803 
https://react-bootstrap.github.io/components/modal/#modals-props

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
