### PR TITLE
Move web build and cache directory into target/

### DIFF
--- a/graylog-plugin-archetype/src/main/resources/archetype-resources/pom.xml
+++ b/graylog-plugin-archetype/src/main/resources/archetype-resources/pom.xml
@@ -96,7 +96,7 @@
 
     <build>
         <resources>
-            <resource><directory>build</directory></resource>
+            <resource><directory>${web.build-dir}</directory></resource>
             <resource>
               <directory>src/main/resources</directory>
               <filtering>true</filtering>

--- a/graylog-plugin-parent/pom.xml
+++ b/graylog-plugin-parent/pom.xml
@@ -37,6 +37,7 @@
 
     <properties>
         <graylog.plugin-dir>/usr/share/graylog-server/plugin</graylog.plugin-dir>
+        <web.build-dir>${project.build.directory}/web/build</web.build-dir>
 
         <!-- Dependencies -->
         <auto-service.version>1.0-rc4</auto-service.version>
@@ -100,7 +101,6 @@
                         <fileset>
                             <directory>${basedir}</directory>
                             <includes>
-                                <include>build/**/*</include>
                                 <include>node_modules/**/*</include>
                             </includes>
                             <followSymlinks>false</followSymlinks>

--- a/graylog2-server/pom.xml
+++ b/graylog2-server/pom.xml
@@ -607,7 +607,7 @@
         <finalName>graylog</finalName>
         <resources>
             <resource>
-                <directory>${webInterface.path}/build</directory>
+                <directory>${webInterface.path}/target/web/build</directory>
                 <targetPath>web-interface/assets</targetPath>
             </resource>
             <resource>
@@ -833,7 +833,7 @@
                                 <fileset>
                                     <directory>${webInterface.path}</directory>
                                     <includes>
-                                        <include>build/**/*</include>
+                                        <include>target/**/*</include>
                                         <include>node_modules/**/*</include>
                                     </includes>
                                     <followSymlinks>false</followSymlinks>

--- a/graylog2-web-interface/packages/graylog-web-plugin/src/PluginWebpackConfig.js
+++ b/graylog2-web-interface/packages/graylog-web-plugin/src/PluginWebpackConfig.js
@@ -7,7 +7,7 @@ const defaultRootPath = path.resolve(module.parent.parent.filename, '../');
 const defaultOptions = {
   root_path: defaultRootPath,
   entry_path: path.resolve(defaultRootPath, 'src/web/index.jsx'),
-  build_path: path.resolve(defaultRootPath, 'build'),
+  build_path: path.resolve(defaultRootPath, 'target/web/build'),
 };
 
 function getPluginFullName(fqcn) {

--- a/graylog2-web-interface/webpack.config.js
+++ b/graylog2-web-interface/webpack.config.js
@@ -9,7 +9,7 @@ const UniqueChunkIdPlugin = require('./webpack/UniqueChunkIdPlugin');
 
 const ROOT_PATH = path.resolve(__dirname);
 const APP_PATH = path.resolve(ROOT_PATH, 'src');
-const BUILD_PATH = path.resolve(ROOT_PATH, 'build');
+const BUILD_PATH = path.resolve(ROOT_PATH, 'target/web/build');
 const MANIFESTS_PATH = path.resolve(ROOT_PATH, 'manifests');
 const VENDOR_MANIFEST_PATH = path.resolve(MANIFESTS_PATH, 'vendor-manifest.json');
 const TARGET = process.env.npm_lifecycle_event;
@@ -17,7 +17,7 @@ process.env.BABEL_ENV = TARGET;
 
 const BABELRC = path.resolve(ROOT_PATH, 'babel.config.js');
 const BABELOPTIONS = {
-  cacheDirectory: 'cache',
+  cacheDirectory: 'target/web/cache',
   extends: BABELRC,
 };
 
@@ -98,7 +98,7 @@ const webpackConfig = {
       filename: 'index.html',
       inject: false,
       template: path.resolve(ROOT_PATH, 'templates/index.html.template'),
-      vendorModule: () => JSON.parse(fs.readFileSync(path.resolve(ROOT_PATH, 'build/vendor-module.json'), 'utf8')),
+      vendorModule: () => JSON.parse(fs.readFileSync(path.resolve(BUILD_PATH, 'vendor-module.json'), 'utf8')),
       chunksSortMode: (c1, c2) => {
         // Render the polyfill chunk first
         if (c1.names[0] === 'polyfill') {

--- a/graylog2-web-interface/webpack.vendor.js
+++ b/graylog2-web-interface/webpack.vendor.js
@@ -7,7 +7,7 @@ const merge = require('webpack-merge');
 const UglifyJsPlugin = require('uglifyjs-webpack-plugin');
 
 const ROOT_PATH = path.resolve(__dirname);
-const BUILD_PATH = path.resolve(ROOT_PATH, 'build');
+const BUILD_PATH = path.resolve(ROOT_PATH, 'target/web/build');
 const MANIFESTS_PATH = path.resolve(ROOT_PATH, 'manifests');
 
 const vendorModules = require('./vendor.modules');


### PR DESCRIPTION
The "build" and "cache" directories are currently located in the project
root of plugins. This change moves them to the "target/web" directory.

That way we don't need any custom configuration to remove these
directories on "mvn clean" and they should also not be indexed by
IntelliJ and consume resources. (most developers exclude the "build" and
"cache" directories in IntelliJ for performance reasons)