### PR TITLE
Allow kafka group.id to be configured

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/inputs/transports/KafkaTransport.java
+++ b/graylog2-server/src/main/java/org/graylog2/inputs/transports/KafkaTransport.java
@@ -72,13 +72,13 @@ import java.util.concurrent.atomic.AtomicLong;
 import static com.codahale.metrics.MetricRegistry.name;
 
 public class KafkaTransport extends ThrottleableTransport {
-    public static final String GROUP_ID = "graylog2";
     public static final String CK_FETCH_MIN_BYTES = "fetch_min_bytes";
     public static final String CK_FETCH_WAIT_MAX = "fetch_wait_max";
     public static final String CK_ZOOKEEPER = "zookeeper";
     public static final String CK_TOPIC_FILTER = "topic_filter";
     public static final String CK_THREADS = "threads";
     public static final String CK_OFFSET_RESET = "offset_reset";
+    public static final String CK_GROUP_ID = "group_id";
 
     // See https://kafka.apache.org/090/documentation.html for available values for "auto.offset.reset".
     private static final ImmutableMap<String, String> OFFSET_RESET_VALUES = ImmutableMap.of(
@@ -87,6 +87,7 @@ public class KafkaTransport extends ThrottleableTransport {
     );
 
     private static final String DEFAULT_OFFSET_RESET = "largest";
+    private static final String DEFAULT_GROUP_ID = "graylog2";
 
     private static final Logger LOG = LoggerFactory.getLogger(KafkaTransport.class);
 
@@ -185,7 +186,7 @@ public class KafkaTransport extends ThrottleableTransport {
 
         final Properties props = new Properties();
 
-        props.put("group.id", GROUP_ID);
+        props.put("group.id", configuration.getString(CK_GROUP_ID, DEFAULT_GROUP_ID));
         props.put("client.id", "gl2-" + nodeId + "-" + input.getId());
 
         props.put("fetch.min.bytes", String.valueOf(configuration.getInt(CK_FETCH_MIN_BYTES)));
@@ -380,6 +381,13 @@ public class KafkaTransport extends ThrottleableTransport {
                     DEFAULT_OFFSET_RESET,
                     OFFSET_RESET_VALUES,
                     "What to do when there is no initial offset in ZooKeeper or if an offset is out of range",
+                    ConfigurationField.Optional.OPTIONAL));
+
+            cr.addField(new TextField(
+                    CK_GROUP_ID,
+                    "Consumer group id",
+                    DEFAULT_GROUP_ID,
+                    "Name of the consumer group the Kafka input belongs to",
                     ConfigurationField.Optional.OPTIONAL));
 
             return cr;


### PR DESCRIPTION
Signed-off-by: Pierre De Paepe <pierre.de-paepe@corp.ovh.com>

## Description

This little patch will allow graylog administrators to define a custom Kafka group_id in related input panel.
To avoid update issue, current group "graylog2" remains the default value.

## Motivation and Context

If you have a big Kafka cluster with multiple graylog clusters subscribed on, each time a unhealthy consumer flaps, the rebalancing order is sent to all graylog nodes introducing unecessary stress on log ingestion.
An easy way to avoid it, consists to define for each graylog cluster a specific consumer group name.

## How Has This Been Tested?
In production : ~20 graylog clusters for one kafka.

## Screenshots (if appropriate):

![group id](https://user-images.githubusercontent.com/11463691/45109993-5a410000-b141-11e8-8ab2-e4d25fc246c5.png)

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x ] My code follows the code style of this project.
- [x ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.