### PR TITLE
Fixed shebang path.

### DIFF
--- a/bin/graylogctl
+++ b/bin/graylogctl
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 CMD=$1
 NOHUP=${NOHUP:=$(which nohup)}


### PR DESCRIPTION
Currently doesn't work on FreeBSD as is. Not all distros use /bin/bash either.

/usr/bin/env bash should always point to the correct shell.

## Description

Changed ```/bin/bash``` to ```/usr/bin/env bash```.

https://en.wikipedia.org/wiki/Env

## Motivation and Context

Doesn't work on FreeBSD as tested.

## How Has This Been Tested?

```/usr/bin/env``` has been fairly tested. There are implementations on almost every major POSIX environment.

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [X ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
