### PR TITLE
Add JDK 11 support

### DIFF
--- a/graylog-project-parent/pom.xml
+++ b/graylog-project-parent/pom.xml
@@ -336,7 +336,7 @@
             </dependency>
 
             <dependency>
-                <groupId>com.eaio.uuid</groupId>
+                <groupId>org.graylog2.repackaged</groupId>
                 <artifactId>uuid</artifactId>
                 <version>${uuid.version}</version>
             </dependency>
@@ -393,6 +393,12 @@
                 <groupId>javax.inject</groupId>
                 <artifactId>javax.inject</artifactId>
                 <version>${javax.inject.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>javax.xml.bind</groupId>
+                <artifactId>jaxb-api</artifactId>
+                <version>${jaxb-api.version}</version>
             </dependency>
 
             <dependency>

--- a/graylog2-server/pom.xml
+++ b/graylog2-server/pom.xml
@@ -248,6 +248,10 @@
             <groupId>javax.ws.rs</groupId>
             <artifactId>javax.ws.rs-api</artifactId>
         </dependency>
+        <dependency>
+            <groupId>javax.xml.bind</groupId>
+            <artifactId>jaxb-api</artifactId>
+        </dependency>
 
         <dependency>
             <groupId>org.reflections</groupId>
@@ -294,7 +298,7 @@
         </dependency>
 
         <dependency>
-            <groupId>com.eaio.uuid</groupId>
+            <groupId>org.graylog2.repackaged</groupId>
             <artifactId>uuid</artifactId>
         </dependency>
         <dependency>

--- a/graylog2-server/src/main/java/org/graylog2/rest/models/system/responses/LocalesResponse.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/models/system/responses/LocalesResponse.java
@@ -22,8 +22,9 @@ import com.google.auto.value.AutoValue;
 import com.google.common.collect.ImmutableMap;
 
 import java.util.Arrays;
+import java.util.HashMap;
 import java.util.Locale;
-import java.util.function.Function;
+import java.util.Map;
 
 @JsonAutoDetect
 @AutoValue
@@ -32,13 +33,11 @@ public abstract class LocalesResponse {
     public abstract ImmutableMap<String, LocaleDescription> locales();
 
     public static LocalesResponse create(Locale[] locales) {
-        final ImmutableMap<String, LocaleDescription> localeMap = Arrays.stream(locales)
+        final Map<String, LocaleDescription> localeMap = new HashMap<>();
+        Arrays.stream(locales)
                 .map(LocaleDescription::create)
-                .collect(ImmutableMap.toImmutableMap(
-                        LocaleDescription::languageTag,
-                        Function.identity()
-                ));
-        return new AutoValue_LocalesResponse(localeMap);
+                .forEach(localeDescription -> localeMap.put(localeDescription.languageTag(), localeDescription));
+        return new AutoValue_LocalesResponse(ImmutableMap.copyOf(localeMap));
     }
 
     @JsonAutoDetect

--- a/pom.xml
+++ b/pom.xml
@@ -115,6 +115,7 @@
         <javax.el-api.version>3.0.0</javax.el-api.version>
         <javax.inject.version>1</javax.inject.version>
         <javax.ws.rs-api.version>2.1.1</javax.ws.rs-api.version>
+        <jaxb-api.version>2.3.0</jaxb-api.version>
         <jbcrypt.version>0.4</jbcrypt.version>
         <jcip-annotations.version>1.0</jcip-annotations.version>
         <jdot.version>1.0</jdot.version>
@@ -147,7 +148,7 @@
         <swagger.version>1.5.13</swagger.version>
         <syslog4j.version>0.9.60</syslog4j.version>
         <ulid.version>8.2.0</ulid.version>
-        <uuid.version>3.2</uuid.version>
+        <uuid.version>3.2.1</uuid.version>
         <validation-api.version>2.0.1.Final</validation-api.version>
         <zkclient.version>0.7</zkclient.version>
         <zookeeper.version>3.5.5</zookeeper.version>


### PR DESCRIPTION
This PR updates the server code base to support JDK 11.

This also requires updates to a few plugins due to the UUID changes.

There is a warning that is printed on server startup:

```
WARNING: An illegal reflective access operation has occurred
WARNING: Illegal reflective access by com.google.inject.assistedinject.FactoryProvider2$MethodHandleWrapper (file:/home/bernd/.m2/repository/com/google/inject/extensions/guice-assistedinject/4.2.2/guice-assistedinject-4.2.2.jar) to constructor java.lang.invoke.MethodHandles$Lookup(java.lang.Class,int)
WARNING: Please consider reporting this to the maintainers of com.google.inject.assistedinject.FactoryProvider2$MethodHandleWrapper
WARNING: Use --illegal-access=warn to enable warnings of further illegal reflective access operations
WARNING: All illegal access operations will be denied in a future release
```

Seems to be related to https://github.com/google/guice/issues/1216 and https://github.com/google/guice/issues/1133.