### PR TITLE
Update to netty 4.1.36 and netty-tcnative-boringssl 2.0.25

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -128,8 +128,8 @@
         <mongodb-driver.version>3.6.4</mongodb-driver.version>
         <mongojack.version>2.8.2</mongojack.version>
         <natty.version>0.13</natty.version>
-        <netty.version>4.1.33.Final</netty.version>
-        <netty-tcnative-boringssl-static.version>2.0.20.Final</netty-tcnative-boringssl-static.version>
+        <netty.version>4.1.36.Final</netty.version>
+        <netty-tcnative-boringssl-static.version>2.0.25.Final</netty-tcnative-boringssl-static.version>
         <okhttp.version>3.11.0</okhttp.version>
         <opencsv.version>2.3</opencsv.version>
         <os-platform-finder.version>1.2.3</os-platform-finder.version>


### PR DESCRIPTION
Changes since netty 4.1.33:

- https://netty.io/news/2019/03/08/4-1-34-Final.html
- https://netty.io/news/2019/04/17/4-1-35-Final.html
- https://netty.io/news/2019/04/30/4-1-36-Final.html