### PR TITLE
Do not initialize `inputs` variable to prevent merging duplicate key in.

### DIFF
--- a/graylog2-web-interface/src/pages/ExtractorsPage.jsx
+++ b/graylog2-web-interface/src/pages/ExtractorsPage.jsx
@@ -44,23 +44,12 @@ const ExtractorsPage = createReactClass({
   },
 
   onNodesChange(nodes) {
-    let inputNode;
     const { params } = this.props;
-    if (params.nodeId) {
-      inputNode = nodes.nodes[params.nodeId];
-    } else {
-      const nodeIds = Object.keys(nodes.nodes);
-      for (let i = 0; i < nodeIds.length && !inputNode; i++) {
-        const tempNode = nodes.nodes[nodeIds[i]];
-        if (tempNode.is_master) {
-          inputNode = tempNode;
-        }
-      }
-    }
+    const newNode = params.nodeId ? nodes.nodes[params.nodeId] : Object.values(nodes.nodes).filter(node => node.is_master);
 
     const { node } = this.state;
-    if (!node || node.node_id !== inputNode.node_id) {
-      this.setState({ node: inputNode });
+    if (!node || node.node_id !== newNode.node_id) {
+      this.setState({ node: newNode });
     }
   },
 

--- a/graylog2-web-interface/src/pages/ExtractorsPage.jsx
+++ b/graylog2-web-interface/src/pages/ExtractorsPage.jsx
@@ -20,7 +20,6 @@ import DocsHelper from 'util/DocsHelper';
 const NodesActions = ActionsProvider.getActions('Nodes');
 const InputsActions = ActionsProvider.getActions('Inputs');
 const NodesStore = StoreProvider.getStore('Nodes');
-const InputsStore = StoreProvider.getStore('Inputs');
 
 const ExtractorsPage = createReactClass({
   displayName: 'ExtractorsPage',
@@ -29,7 +28,7 @@ const ExtractorsPage = createReactClass({
     params: PropTypes.object.isRequired,
   },
 
-  mixins: [Reflux.connect(InputsStore), Reflux.listenTo(NodesStore, 'onNodesChange')],
+  mixins: [Reflux.listenTo(NodesStore, 'onNodesChange')],
 
   getInitialState() {
     return {
@@ -39,8 +38,8 @@ const ExtractorsPage = createReactClass({
 
   componentDidMount() {
     const { params } = this.props;
-    InputsActions.get.triggerPromise(params.inputId);
-    NodesActions.list.triggerPromise();
+    InputsActions.get(params.inputId).then(input => this.setState({ input }));
+    NodesActions.list();
   },
 
   onNodesChange(nodes) {

--- a/graylog2-web-interface/src/pages/ExtractorsPage.jsx
+++ b/graylog2-web-interface/src/pages/ExtractorsPage.jsx
@@ -1,21 +1,21 @@
-import PropTypes from 'prop-types';
-import React from 'react';
-import createReactClass from 'create-react-class';
-import Reflux from 'reflux';
-import { DropdownButton, MenuItem } from 'react-bootstrap';
-import { LinkContainer } from 'react-router-bootstrap';
+import { DocumentTitle, Spinner } from 'components/common';
 
 import PageHeader from 'components/common/PageHeader';
 import ExtractorsList from 'components/extractors/ExtractorsList';
-import { DocumentTitle, Spinner } from 'components/common';
 import DocumentationLink from 'components/support/DocumentationLink';
-
-import Routes from 'routing/Routes';
-import DocsHelper from 'util/DocsHelper';
+import createReactClass from 'create-react-class';
 
 import ActionsProvider from 'injection/ActionsProvider';
 
 import StoreProvider from 'injection/StoreProvider';
+import PropTypes from 'prop-types';
+import React from 'react';
+import { DropdownButton, MenuItem } from 'react-bootstrap';
+import { LinkContainer } from 'react-router-bootstrap';
+import Reflux from 'reflux';
+
+import Routes from 'routing/Routes';
+import DocsHelper from 'util/DocsHelper';
 
 const NodesActions = ActionsProvider.getActions('Nodes');
 const InputsActions = ActionsProvider.getActions('Inputs');
@@ -33,20 +33,21 @@ const ExtractorsPage = createReactClass({
 
   getInitialState() {
     return {
-      input: undefined,
       node: undefined,
     };
   },
 
   componentDidMount() {
-    InputsActions.get.triggerPromise(this.props.params.inputId);
+    const { params } = this.props;
+    InputsActions.get.triggerPromise(params.inputId);
     NodesActions.list.triggerPromise();
   },
 
   onNodesChange(nodes) {
     let inputNode;
-    if (this.props.params.nodeId) {
-      inputNode = nodes.nodes[this.props.params.nodeId];
+    const { params } = this.props;
+    if (params.nodeId) {
+      inputNode = nodes.nodes[params.nodeId];
     } else {
       const nodeIds = Object.keys(nodes.nodes);
       for (let i = 0; i < nodeIds.length && !inputNode; i++) {
@@ -57,13 +58,15 @@ const ExtractorsPage = createReactClass({
       }
     }
 
-    if (!this.state.node || this.state.node.node_id !== inputNode.node_id) {
+    const { node } = this.state;
+    if (!node || node.node_id !== inputNode.node_id) {
       this.setState({ node: inputNode });
     }
   },
 
   _isLoading() {
-    return !(this.state.input && this.state.node);
+    const { node, input } = this.state;
+    return !(input && node);
   },
 
   render() {
@@ -71,10 +74,11 @@ const ExtractorsPage = createReactClass({
       return <Spinner />;
     }
 
+    const { node, input } = this.state;
     return (
-      <DocumentTitle title={`Extractors of ${this.state.input.title}`}>
+      <DocumentTitle title={`Extractors of ${input.title}`}>
         <div>
-          <PageHeader title={<span>Extractors of <em>{this.state.input.title}</em></span>}>
+          <PageHeader title={<span>Extractors of <em>{input.title}</em></span>}>
             <span>
               Extractors are applied on every message that is received by this input. Use them to extract and transform{' '}
               any text data into fields that allow you easy filtering and analysis later on.{' '}
@@ -88,15 +92,15 @@ const ExtractorsPage = createReactClass({
             </span>
 
             <DropdownButton bsStyle="info" bsSize="large" id="extractor-actions-dropdown" title="Actions" pullRight>
-              <LinkContainer to={Routes.import_extractors(this.state.node.node_id, this.state.input.id)}>
+              <LinkContainer to={Routes.import_extractors(node.node_id, input.id)}>
                 <MenuItem>Import extractors</MenuItem>
               </LinkContainer>
-              <LinkContainer to={Routes.export_extractors(this.state.node.node_id, this.state.input.id)}>
+              <LinkContainer to={Routes.export_extractors(node.node_id, input.id)}>
                 <MenuItem>Export extractors</MenuItem>
               </LinkContainer>
             </DropdownButton>
           </PageHeader>
-          <ExtractorsList input={this.state.input} node={this.state.node} />
+          <ExtractorsList input={input} node={node} />
         </div>
       </DocumentTitle>
     );


### PR DESCRIPTION
## Description
## Motivation and Context

This change is fixing an issue that is related to the introduction of
its supplied state even during first initialization, leading to an
attempt to merge a duplicate key when mounting the `ExtractorsPage`
component. Removing the `inputs` key in the initial state of that
component is fixing it.

Fixes #5948.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.