### PR TITLE
Fix auto-completion in several drop-down fields

### DIFF
--- a/graylog2-web-interface/src/components/extractors/converters_configuration/LookupTableConverterConfiguration.jsx
+++ b/graylog2-web-interface/src/components/extractors/converters_configuration/LookupTableConverterConfiguration.jsx
@@ -96,7 +96,7 @@ class LookupTableConverterConfiguration extends React.Component {
                 <Select placeholder="Select a lookup table"
                         clearable={false}
                         options={lookupTables}
-                        matchProp="value"
+                        matchProp="label"
                         onChange={this._onSelect('lookup_table_name')}
                         value={this.props.configuration.lookup_table_name} />
               </Input>

--- a/graylog2-web-interface/src/components/extractors/extractors_configuration/LookupTableExtractorConfiguration.jsx
+++ b/graylog2-web-interface/src/components/extractors/extractors_configuration/LookupTableExtractorConfiguration.jsx
@@ -104,7 +104,7 @@ class LookupTableExtractorConfiguration extends React.Component {
               <Select placeholder="Select a lookup table"
                       clearable={false}
                       options={lookupTables}
-                      matchProp="value"
+                      matchProp="label"
                       onChange={this._onSelect('lookup_table_name')}
                       value={this.props.configuration.lookup_table_name} />
             </Col>

--- a/graylog2-web-interface/src/components/indices/IndexMaintenanceStrategiesConfiguration.jsx
+++ b/graylog2-web-interface/src/components/indices/IndexMaintenanceStrategiesConfiguration.jsx
@@ -111,7 +111,7 @@ class IndexMaintenanceStrategiesConfiguration extends React.Component {
         <Input id="strategy-select" label={this.props.selectPlaceholder}>
           <Select placeholder={this.props.selectPlaceholder}
                   options={this._availableSelectOptions()}
-                  matchProp="value"
+                  matchProp="label"
                   value={this._activeSelection()}
                   onChange={this._onSelect} />
         </Input>

--- a/graylog2-web-interface/src/components/lookup-tables/CacheCreate.jsx
+++ b/graylog2-web-interface/src/components/lookup-tables/CacheCreate.jsx
@@ -65,7 +65,7 @@ class CacheCreate extends React.Component {
               <Select placeholder="Select Cache Type"
                       clearable={false}
                       options={sortedCaches}
-                      matchProp="value"
+                      matchProp="label"
                       onChange={this._onTypeSelect}
                       value={null} />
             </Input>

--- a/graylog2-web-interface/src/components/lookup-tables/CachePicker.jsx
+++ b/graylog2-web-interface/src/components/lookup-tables/CachePicker.jsx
@@ -42,7 +42,7 @@ class CachePicker extends React.Component {
           <Select placeholder="Select a cache"
                   clearable={false}
                   options={sortedCaches}
-                  matchProp="value"
+                  matchProp="label"
                   onChange={this.props.onSelect}
                   value={this.props.selectedId} />
         </Input>

--- a/graylog2-web-interface/src/components/lookup-tables/DataAdapterCreate.jsx
+++ b/graylog2-web-interface/src/components/lookup-tables/DataAdapterCreate.jsx
@@ -69,7 +69,7 @@ class DataAdapterCreate extends React.Component {
               <Select placeholder="Select Data Adapter Type"
                       clearable={false}
                       options={sortedAdapters}
-                      matchProp="value"
+                      matchProp="label"
                       onChange={this._onTypeSelect}
                       value={null} />
             </Input>

--- a/graylog2-web-interface/src/components/lookup-tables/DataAdapterPicker.jsx
+++ b/graylog2-web-interface/src/components/lookup-tables/DataAdapterPicker.jsx
@@ -42,7 +42,7 @@ class DataAdapterPicker extends React.Component {
           <Select placeholder="Select a data adapter"
                   clearable={false}
                   options={sortedAdapters}
-                  matchProp="value"
+                  matchProp="label"
                   onChange={this.props.onSelect}
                   value={this.props.selectedId} />
         </Input>

--- a/graylog2-web-interface/src/components/lookup-tables/__snapshots__/DataAdapterCreate.test.jsx.snap
+++ b/graylog2-web-interface/src/components/lookup-tables/__snapshots__/DataAdapterCreate.test.jsx.snap
@@ -23,7 +23,7 @@ exports[`<DataAdapterCreate /> should render for types with defined frontend com
         >
           <select-mock
             clearable={false}
-            matchProp="value"
+            matchProp="label"
             onChange={[Function]}
             options={
               Array [
@@ -66,7 +66,7 @@ exports[`<DataAdapterCreate /> should render with empty parameters 1`] = `
         >
           <select-mock
             clearable={false}
-            matchProp="value"
+            matchProp="label"
             onChange={[Function]}
             options={Array []}
             placeholder="Select Data Adapter Type"
@@ -102,7 +102,7 @@ exports[`<DataAdapterCreate /> with mocked console.error should render for types
         >
           <select-mock
             clearable={false}
-            matchProp="value"
+            matchProp="label"
             onChange={[Function]}
             options={
               Array [

--- a/graylog2-web-interface/src/components/lookup-tables/adapters/DnsAdapterFieldSet.jsx
+++ b/graylog2-web-interface/src/components/lookup-tables/adapters/DnsAdapterFieldSet.jsx
@@ -66,7 +66,7 @@ class DnsAdapterFieldSet extends React.Component {
           <Select placeholder="Select the type of DNS lookup"
                   clearable={false}
                   options={lookupTypes}
-                  matchProp="value"
+                  matchProp="label"
                   onChange={this._onLookupTypeSelect}
                   value={config.lookup_type} />
         </Input>

--- a/graylog2-web-interface/src/components/maps/adapter/MaxmindAdapterFieldSet.jsx
+++ b/graylog2-web-interface/src/components/maps/adapter/MaxmindAdapterFieldSet.jsx
@@ -60,7 +60,7 @@ class MaxmindAdapterFieldSet extends React.Component {
         <Select placeholder="Select the type of database file"
                 clearable={false}
                 options={databaseTypes}
-                matchProp="value"
+                matchProp="label"
                 onChange={this._onDbTypeSelect}
                 value={config.database_type} />
       </Input>

--- a/graylog2-web-interface/src/components/maps/configurations/GeoIpResolverConfig.jsx
+++ b/graylog2-web-interface/src/components/maps/configurations/GeoIpResolverConfig.jsx
@@ -129,7 +129,7 @@ const GeoIpResolverConfig = createReactClass({
               <Select placeholder="Select MaxMind database type"
                       required
                       options={this._availableDatabaseTypes()}
-                      matchProp="value"
+                      matchProp="label"
                       value={this.state.config.db_type}
                       onChange={this._onDbTypeSelect} />
             </Input>


### PR DESCRIPTION
Backport of #5665 

In all these cases the matchProp needs to be set to "label" and not "value"
because the value contains the object ID or another identifier.

After this, the auto-completion is looking at same data that the user
is seeing.

Cherry-picked from fbb6923154b25d747298dcf7fee35edf6ad590d4 and resolved a few merge conflicts.