### PR TITLE
Upgrade jquery to 3.4.1

### DIFF
--- a/graylog2-web-interface/package.json
+++ b/graylog2-web-interface/package.json
@@ -153,7 +153,7 @@
   },
   "resolutions": {
     "@types/jquery": "3.3.0",
-    "jquery": "3.3.1",
+    "jquery": "3.4.1",
     "upath": "1.0.5"
   }
 }

--- a/graylog2-web-interface/packages/graylog-web-plugin/package.json
+++ b/graylog2-web-interface/packages/graylog-web-plugin/package.json
@@ -39,7 +39,7 @@
     "eslint-config-graylog": "file:../eslint-config-graylog",
     "html-webpack-plugin": "3.2.0",
     "javascript-natural-sort": "0.7.1",
-    "jquery": "3.3.1",
+    "jquery": "3.4.1",
     "moment": "2.22.2",
     "moment-timezone": "0.5.23",
     "prop-types": "15.6.2",

--- a/graylog2-web-interface/yarn.lock
+++ b/graylog2-web-interface/yarn.lock
@@ -4802,7 +4802,7 @@ graceful-fs@^4.1.11, graceful-fs@^4.1.2, graceful-fs@^4.1.6, graceful-fs@^4.1.9:
     eslint-config-graylog "file:../../../../Library/Caches/Yarn/v4/npm-graylog-web-plugin-3.1.0-SNAPSHOT-dcfa4288-1287-4cc0-bdef-cfe9a4910805-1556178983986/node_modules/eslint-config-graylog"
     html-webpack-plugin "3.2.0"
     javascript-natural-sort "0.7.1"
-    jquery "3.3.1"
+    jquery "3.4.1"
     moment "2.22.2"
     moment-timezone "0.5.23"
     prop-types "15.6.2"
@@ -6402,10 +6402,10 @@ jquery-ui@1.12.x:
   resolved "https://registry.yarnpkg.com/jquery-ui/-/jquery-ui-1.12.1.tgz#bcb4045c8dd0539c134bc1488cdd3e768a7a9e51"
   integrity sha1-vLQEXI3QU5wTS8FIjN0+dop6nlE=
 
-jquery@3.3.1, jquery@>=1.12.0, jquery@>=1.7:
-  version "3.3.1"
-  resolved "https://registry.yarnpkg.com/jquery/-/jquery-3.3.1.tgz#958ce29e81c9790f31be7792df5d4d95fc57fbca"
-  integrity sha512-Ubldcmxp5np52/ENotGxlLe6aGMvmF4R8S6tZjsP6Knsaxd/xp3Zrh50cG93lR6nPXyUFwzN3ZSOQI0wRJNdGg==
+jquery@3.4.1, jquery@>=1.12.0, jquery@>=1.7:
+  version "3.4.1"
+  resolved "https://registry.yarnpkg.com/jquery/-/jquery-3.4.1.tgz#714f1f8d9dde4bdfa55764ba37ef214630d80ef2"
+  integrity sha512-36+AdBzCL+y6qjw5Tx7HgzeGCzC81MDDgaUP8ld2zhx58HdqXGoBd+tHdrBMiyjGQs0Hxs/MLZTu/eHNJJuWPw==
 
 js-base64@^2.1.9:
   version "2.4.3"


### PR DESCRIPTION
This update includes security fixes.

<details>
<summary> Vulnerability</summary>

Vulnerable versions: < 3.4.0

jQuery before 3.4.0, as used in Drupal, Backdrop CMS, and other products, mishandles jQuery.extend(true, {}, ...) because of Object.prototype pollution. If an unsanitized source object contained an enumerable proto property, it could extend the native Object.prototype.
</details>
