### PR TITLE
Allow specifying view for `PaginatedService`.

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/database/PaginatedDbService.java
+++ b/graylog2-server/src/main/java/org/graylog2/database/PaginatedDbService.java
@@ -57,10 +57,19 @@ public abstract class PaginatedDbService<DTO> {
                                  MongoJackObjectMapperProvider mapper,
                                  Class<DTO> dtoClass,
                                  String collectionName) {
+        this(mongoConnection, mapper, dtoClass, collectionName, null);
+    }
+
+    protected PaginatedDbService(MongoConnection mongoConnection,
+                                 MongoJackObjectMapperProvider mapper,
+                                 Class<DTO> dtoClass,
+                                 String collectionName,
+                                 Class<?> view) {
         this.db = JacksonDBCollection.wrap(mongoConnection.getDatabase().getCollection(collectionName),
                 dtoClass,
                 ObjectId.class,
-                mapper.get());
+                mapper.get(),
+                view);
     }
 
     /**


### PR DESCRIPTION
## Description
## Motivation and Context

Using the `PaginatedService` with a DTO that utilizes Jackson's JSON
views to customize (de-)serialization e.g. for persistence vs. REST does
not work currently, as a view needs to be passed to MongoJack in order
to enable views processing.

This change is adding a second constructor to `PaginatedService`
allowing consumers to specify a view class as additional parameter.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.