### PR TITLE
Set default value for email sender to empty value

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/alarmcallbacks/EmailAlarmCallback.java
+++ b/graylog2-server/src/main/java/org/graylog2/alarmcallbacks/EmailAlarmCallback.java
@@ -174,7 +174,7 @@ public class EmailAlarmCallback implements AlarmCallback {
         ConfigurationRequest configurationRequest = new ConfigurationRequest();
         configurationRequest.addField(new TextField("sender",
                 "Sender",
-                "graylog@example.org",
+                "",
                 "The sender of sent out mail alerts",
                 ConfigurationField.Optional.OPTIONAL));
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

The previous default (`@example.org`) is problematic for use cases where
the email server rejects sender domains which are not validated / owned
by the graylog server owners (e.g. amazon ses).

In our use case users often forgot to empty the value and left the
default in which resulted in notifications which where not sent out.

With this change the default is empty and if I understand the code
correctly the result would be that the default which is set in the
server configuration should be used.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Fired up a test instance and took a look at the empty field value.

## Screenshots (if appropriate):

Sorry, did not take any :(

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.