### PR TITLE
Replace `react-ace` with `react-ace-builds`.

### DIFF
--- a/graylog2-web-interface/package.json
+++ b/graylog2-web-interface/package.json
@@ -70,7 +70,7 @@
     "numeral": "^1.5.3",
     "opensans-npm-webfont": "^1.0.0",
     "qs": "^6.3.0",
-    "react-ace": "^5.9.0",
+    "react-ace-builds": "^7.2.4",
     "react-color": "^2.14.0",
     "react-day-picker": "^5.0.0",
     "react-dnd": "^7.0.2",

--- a/graylog2-web-interface/src/components/common/SourceCodeEditor.jsx
+++ b/graylog2-web-interface/src/components/common/SourceCodeEditor.jsx
@@ -2,20 +2,13 @@ import React from 'react';
 import lodash from 'lodash';
 import { PropTypes } from 'prop-types';
 import { Resizable } from 'react-resizable';
-import 'brace';
-import AceEditor from 'react-ace';
+import AceEditor from 'react-ace-builds';
 import { Button, ButtonGroup, ButtonToolbar, OverlayTrigger, Tooltip } from 'react-bootstrap';
 
 import { ClipboardButton } from 'components/common';
 
-import 'brace/mode/json';
-import 'brace/mode/lua';
-import 'brace/mode/markdown';
-import 'brace/mode/text';
-import 'brace/mode/yaml';
-import 'brace/theme/tomorrow';
-import 'brace/theme/monokai';
 import style from './SourceCodeEditor.css';
+import './webpack-resolver';
 
 /**
  * Component that renders a source code editor input. This is what powers the pipeline rules and collector

--- a/graylog2-web-interface/src/components/common/SourceCodeEditor.jsx
+++ b/graylog2-web-interface/src/components/common/SourceCodeEditor.jsx
@@ -67,7 +67,7 @@ class SourceCodeEditor extends React.Component {
     toolbar: true,
     value: '',
     width: Infinity,
-  }
+  };
 
   constructor(props) {
     super(props);
@@ -79,7 +79,8 @@ class SourceCodeEditor extends React.Component {
   }
 
   componentDidUpdate(prevProps) {
-    if (this.props.height !== prevProps.height || this.props.width !== prevProps.width) {
+    const { height, width } = this.props;
+    if (height !== prevProps.height || width !== prevProps.width) {
       this.reloadEditor();
     }
   }
@@ -87,53 +88,72 @@ class SourceCodeEditor extends React.Component {
   handleResize = (event, { size }) => {
     const { height, width } = size;
     this.setState({ height: height, width: width }, this.reloadEditor);
-  }
+  };
 
   reloadEditor = () => {
-    if (this.props.resizable) {
+    const { resizable } = this.props;
+    if (resizable) {
       this.reactAce.editor.resize();
     }
-  }
+  };
 
+  /* eslint-disable-next-line react/destructuring-assignment */
   isCopyDisabled = () => this.props.readOnly || this.state.selectedText === '';
 
+  /* eslint-disable-next-line react/destructuring-assignment */
   isPasteDisabled = () => this.props.readOnly;
 
+  /* eslint-disable-next-line react/destructuring-assignment */
   isRedoDisabled = () => this.props.readOnly || !this.reactAce || !this.reactAce.editor.getSession().getUndoManager().hasRedo();
 
+  /* eslint-disable-next-line react/destructuring-assignment */
   isUndoDisabled = () => this.props.readOnly || !this.reactAce || !this.reactAce.editor.getSession().getUndoManager().hasUndo();
 
   handleRedo = () => {
     this.reactAce.editor.redo();
     this.focusEditor();
-  }
+  };
 
   handleUndo = () => {
     this.reactAce.editor.undo();
     this.focusEditor();
-  }
+  };
 
   handleSelectionChange = (selection) => {
-    if (!this.reactAce || !this.props.toolbar || this.props.readOnly) {
+    const { toolbar, readOnly } = this.props;
+    if (!this.reactAce || !toolbar || readOnly) {
       return;
     }
     const selectedText = this.reactAce.editor.getSession().getTextRange(selection.getRange());
     this.setState({ selectedText: selectedText });
-  }
+  };
 
   focusEditor = () => {
     this.reactAce.editor.focus();
-  }
+  };
 
   render() {
-    const { height, width } = this.state;
-    const { theme, resizable } = this.props;
+    const { height, width, selectedText } = this.state;
+    const {
+      theme,
+      resizable,
+      toolbar,
+      annotations,
+      focus,
+      fontSize,
+      mode,
+      id,
+      onLoad,
+      onChange,
+      readOnly,
+      value,
+    } = this.props;
     const validCssWidth = lodash.isFinite(width) ? width : '100%';
     const containerStyle = `${style.sourceCodeEditor} ${theme !== 'light' && style.darkMode} ${!resizable && style.static}`;
     const overlay = <Tooltip id="paste-button-tooltip">Press Ctrl+V (&#8984;V in macOS) or select Edit&thinsp;&rarr;&thinsp;Paste to paste from clipboard.</Tooltip>;
     return (
       <div>
-        {this.props.toolbar
+        {toolbar
           && (
           <div className={style.toolbar} style={{ width: validCssWidth }}>
             <ButtonToolbar>
@@ -142,7 +162,7 @@ class SourceCodeEditor extends React.Component {
                                  bsStyle="link"
                                  bsSize="sm"
                                  onSuccess={this.focusEditor}
-                                 text={this.state.selectedText}
+                                 text={selectedText}
                                  buttonTitle="Copy (Ctrl+C / &#8984;C)"
                                  disabled={this.isCopyDisabled()} />
                 <OverlayTrigger placement="top" trigger="click" overlay={overlay} rootClose>
@@ -177,19 +197,19 @@ class SourceCodeEditor extends React.Component {
                    onResize={this.handleResize}>
           <div className={containerStyle} style={{ height: height, width: validCssWidth }}>
             <AceEditor ref={(c) => { this.reactAce = c; }}
-                       annotations={this.props.annotations}
+                       annotations={annotations}
                        editorProps={{ $blockScrolling: 'Infinity' }}
-                       focus={this.props.focus}
-                       fontSize={this.props.fontSize}
-                       mode={this.props.mode}
-                       theme={this.props.theme === 'light' ? 'tomorrow' : 'monokai'}
-                       name={this.props.id}
+                       focus={focus}
+                       fontSize={fontSize}
+                       mode={mode}
+                       theme={theme === 'light' ? 'tomorrow' : 'monokai'}
+                       name={id}
                        height="100%"
-                       onLoad={this.props.onLoad}
-                       onChange={this.props.onChange}
+                       onLoad={onLoad}
+                       onChange={onChange}
                        onSelectionChange={this.handleSelectionChange}
-                       readOnly={this.props.readOnly}
-                       value={this.props.value}
+                       readOnly={readOnly}
+                       value={value}
                        width="100%" />
           </div>
         </Resizable>

--- a/graylog2-web-interface/src/components/common/webpack-resolver.js
+++ b/graylog2-web-interface/src/components/common/webpack-resolver.js
@@ -1,0 +1,25 @@
+/* eslint-disable */
+const modes = [
+  'json',
+  'lua',
+  'markdown',
+  'text',
+  'yaml',
+];
+
+modes.forEach((mode) => {
+  ace.config.setModuleUrl(
+    `ace/mode/${mode}`, require(`file-loader!ace-builds/src-min-noconflict/mode-${mode}.js`)
+  );
+});
+
+const themes = [
+  'tomorrow',
+  'monokai',
+];
+
+themes.forEach((theme) => {
+  ace.config.setModuleUrl(
+    `ace/theme/${theme}`, require(`file-loader!ace-builds/src-min-noconflict/theme-${theme}.js`)
+  );
+});

--- a/graylog2-web-interface/webpack/vendor-module-ids.json
+++ b/graylog2-web-interface/webpack/vendor-module-ids.json
@@ -892,7 +892,9 @@
       "node_modules/moment/locale/mn.js": 13,
       "node_modules/hoist-non-react-statics/dist/hoist-non-react-statics.cjs.js": 18,
       "node_modules/scheduler/index.js": 20,
-      "node_modules/scheduler/cjs/scheduler.production.min.js": 29
+      "node_modules/scheduler/cjs/scheduler.production.min.js": 29,
+      "node_modules/react-dom/node_modules/scheduler/index.js": 20,
+      "node_modules/react-dom/node_modules/scheduler/cjs/scheduler.production.min.js": 29
     },
     "usedIds": {
       "0": 0,

--- a/graylog2-web-interface/yarn.lock
+++ b/graylog2-web-interface/yarn.lock
@@ -1124,6 +1124,11 @@ accepts@~1.3.4, accepts@~1.3.5:
     mime-types "~2.1.18"
     negotiator "0.6.1"
 
+ace-builds@^1.4.4:
+  version "1.4.4"
+  resolved "https://registry.yarnpkg.com/ace-builds/-/ace-builds-1.4.4.tgz#b1ad500f99b451710ce51d20f43313027e9fb73a"
+  integrity sha512-EQArUYup9c3lBv8meKBjisff/qhhQmU/6LnLhVDfxe+Bnjr0Lz7qhL4Mp8HpwNQzmCqLunjdPFuBtCELVVG6zw==
+
 acorn-dynamic-import@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/acorn-dynamic-import/-/acorn-dynamic-import-3.0.0.tgz#901ceee4c7faaef7e07ad2a47e890675da50a278"
@@ -1935,11 +1940,6 @@ brace-expansion@^1.0.0, brace-expansion@^1.1.7:
   dependencies:
     balanced-match "^1.0.0"
     concat-map "0.0.1"
-
-brace@^0.11.0:
-  version "0.11.1"
-  resolved "https://registry.yarnpkg.com/brace/-/brace-0.11.1.tgz#4896fcc9d544eef45f4bb7660db320d3b379fe58"
-  integrity sha1-SJb8ydVE7vRfS7dmDbMg07N5/lg=
 
 braces@^1.8.2:
   version "1.8.5"
@@ -3305,6 +3305,11 @@ detect-port-alt@1.1.6:
     address "^1.0.1"
     debug "^2.6.0"
 
+diff-match-patch@^1.0.4:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/diff-match-patch/-/diff-match-patch-1.0.4.tgz#6ac4b55237463761c4daf0dc603eb869124744b1"
+  integrity sha512-Uv3SW8bmH9nAtHKaKSanOQmj2DnlH65fUpcrMdfdaOxUG02QQ4YGZ8AE7kKOMisF7UqvOlGKVYWRvezdncW9lg==
+
 diff@^3.2.0:
   version "3.5.0"
   resolved "https://registry.yarnpkg.com/diff/-/diff-3.5.0.tgz#800c0dd1e0a8bfbc95835c202ad220fe317e5a12"
@@ -3763,10 +3768,10 @@ eslint-config-airbnb@17.1.0:
   dependencies:
     eslint "5.16.0"
     eslint-config-airbnb "17.1.0"
-    eslint-import-resolver-webpack "0.11.0"
-    eslint-plugin-import "2.16.0"
+    eslint-import-resolver-webpack "0.11.1"
+    eslint-plugin-import "2.17.3"
     eslint-plugin-jsx-a11y "6.2.1"
-    eslint-plugin-react "7.12.4"
+    eslint-plugin-react "7.13.0"
 
 eslint-import-resolver-node@^0.3.2:
   version "0.3.2"
@@ -3776,10 +3781,10 @@ eslint-import-resolver-node@^0.3.2:
     debug "^2.6.9"
     resolve "^1.5.0"
 
-eslint-import-resolver-webpack@0.11.0:
-  version "0.11.0"
-  resolved "https://registry.yarnpkg.com/eslint-import-resolver-webpack/-/eslint-import-resolver-webpack-0.11.0.tgz#75d08ee06fc55eb24bd75147b7b4b6756886b12f"
-  integrity sha512-vX8rYSPdKtTLkK2FoU1ZRyEsl6wP1FB40ytjrEgMhzUkEkBLuZAkv1KNR+2Ml7lzMOObXI3yaEDiaQ/Yvoczhw==
+eslint-import-resolver-webpack@0.11.1:
+  version "0.11.1"
+  resolved "https://registry.yarnpkg.com/eslint-import-resolver-webpack/-/eslint-import-resolver-webpack-0.11.1.tgz#fcf1fd57a775f51e18f442915f85dd6ba45d2f26"
+  integrity sha512-eK3zR7xVQR/MaoBWwGuD+CULYVuqe5QFlDukman71aI6IboCGzggDUohHNfu1ZeBnbHcUHJc0ywWoXUBNB6qdg==
   dependencies:
     array-find "^1.0.0"
     debug "^2.6.8"
@@ -3789,7 +3794,7 @@ eslint-import-resolver-webpack@0.11.0:
     interpret "^1.0.0"
     lodash "^4.17.4"
     node-libs-browser "^1.0.0 || ^2.0.0"
-    resolve "^1.4.0"
+    resolve "^1.10.0"
     semver "^5.3.0"
 
 eslint-loader@^1.6.3:
@@ -3803,29 +3808,30 @@ eslint-loader@^1.6.3:
     object-hash "^1.1.4"
     rimraf "^2.6.1"
 
-eslint-module-utils@^2.3.0:
-  version "2.3.0"
-  resolved "https://registry.yarnpkg.com/eslint-module-utils/-/eslint-module-utils-2.3.0.tgz#546178dab5e046c8b562bbb50705e2456d7bda49"
-  integrity sha512-lmDJgeOOjk8hObTysjqH7wyMi+nsHwwvfBykwfhjR1LNdd7C2uFJBvx4OpWYpXOw4df1yE1cDEVd1yLHitk34w==
+eslint-module-utils@^2.4.0:
+  version "2.4.0"
+  resolved "https://registry.yarnpkg.com/eslint-module-utils/-/eslint-module-utils-2.4.0.tgz#8b93499e9b00eab80ccb6614e69f03678e84e09a"
+  integrity sha512-14tltLm38Eu3zS+mt0KvILC3q8jyIAH518MlG+HO0p+yK885Lb1UHTY/UgR91eOyGdmxAPb+OLoW4znqIT6Ndw==
   dependencies:
     debug "^2.6.8"
     pkg-dir "^2.0.0"
 
-eslint-plugin-import@2.16.0:
-  version "2.16.0"
-  resolved "https://registry.yarnpkg.com/eslint-plugin-import/-/eslint-plugin-import-2.16.0.tgz#97ac3e75d0791c4fac0e15ef388510217be7f66f"
-  integrity sha512-z6oqWlf1x5GkHIFgrSvtmudnqM6Q60KM4KvpWi5ubonMjycLjndvd5+8VAZIsTlHC03djdgJuyKG6XO577px6A==
+eslint-plugin-import@2.17.3:
+  version "2.17.3"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-import/-/eslint-plugin-import-2.17.3.tgz#00548b4434c18faebaba04b24ae6198f280de189"
+  integrity sha512-qeVf/UwXFJbeyLbxuY8RgqDyEKCkqV7YC+E5S5uOjAp4tOc8zj01JP3ucoBM8JcEqd1qRasJSg6LLlisirfy0Q==
   dependencies:
+    array-includes "^3.0.3"
     contains-path "^0.1.0"
     debug "^2.6.9"
     doctrine "1.5.0"
     eslint-import-resolver-node "^0.3.2"
-    eslint-module-utils "^2.3.0"
+    eslint-module-utils "^2.4.0"
     has "^1.0.3"
     lodash "^4.17.11"
     minimatch "^3.0.4"
     read-pkg-up "^2.0.0"
-    resolve "^1.9.0"
+    resolve "^1.11.0"
 
 eslint-plugin-jsx-a11y@6.2.1:
   version "6.2.1"
@@ -3841,18 +3847,18 @@ eslint-plugin-jsx-a11y@6.2.1:
     has "^1.0.3"
     jsx-ast-utils "^2.0.1"
 
-eslint-plugin-react@7.12.4:
-  version "7.12.4"
-  resolved "https://registry.yarnpkg.com/eslint-plugin-react/-/eslint-plugin-react-7.12.4.tgz#b1ecf26479d61aee650da612e425c53a99f48c8c"
-  integrity sha512-1puHJkXJY+oS1t467MjbqjvX53uQ05HXwjqDgdbGBqf5j9eeydI54G3KwiJmWciQ0HTBacIKw2jgwSBSH3yfgQ==
+eslint-plugin-react@7.13.0:
+  version "7.13.0"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-react/-/eslint-plugin-react-7.13.0.tgz#bc13fd7101de67996ea51b33873cd9dc2b7e5758"
+  integrity sha512-uA5LrHylu8lW/eAH3bEQe9YdzpPaFd9yAJTwTi/i/BKTD7j6aQMKVAdGM/ML72zD6womuSK7EiGtMKuK06lWjQ==
   dependencies:
     array-includes "^3.0.3"
     doctrine "^2.1.0"
     has "^1.0.3"
-    jsx-ast-utils "^2.0.1"
+    jsx-ast-utils "^2.1.0"
     object.fromentries "^2.0.0"
-    prop-types "^15.6.2"
-    resolve "^1.9.0"
+    prop-types "^15.7.2"
+    resolve "^1.10.1"
 
 eslint-restricted-globals@^0.1.1:
   version "0.1.1"
@@ -4799,24 +4805,24 @@ graceful-fs@^4.1.11, graceful-fs@^4.1.2, graceful-fs@^4.1.6, graceful-fs@^4.1.9:
   dependencies:
     "@babel/preset-env" "7.2.3"
     babel-eslint "9.0.0"
-    eslint-config-graylog "file:../../../../Library/Caches/Yarn/v4/npm-graylog-web-plugin-3.1.0-SNAPSHOT-dcfa4288-1287-4cc0-bdef-cfe9a4910805-1556178983986/node_modules/eslint-config-graylog"
+    eslint-config-graylog "file:../../../../.cache/yarn/v4/npm-graylog-web-plugin-3.1.0-SNAPSHOT-af795db9-9f90-4c13-9f10-22085afdfe61-1559550118207/node_modules/eslint-config-graylog"
     html-webpack-plugin "3.2.0"
     javascript-natural-sort "0.7.1"
     jquery "3.4.1"
     moment "2.22.2"
     moment-timezone "0.5.23"
-    prop-types "15.6.2"
+    prop-types "15.7.2"
     react "16.8.3"
     react-addons-pure-render-mixin "15.6.2"
     react-bootstrap "0.31.5"
-    react-dom "16.8.3"
+    react-dom "16.8.6"
     react-router "3.2.1"
     react-router-bootstrap "0.23.2"
     reflux "0.2.13"
     webpack "4.27.0"
     webpack-cleanup-plugin "0.5.1"
     webpack-cli "3.1.1"
-    webpack-merge "4.1.4"
+    webpack-merge "4.2.1"
 
 growly@^1.3.0:
   version "1.3.0"
@@ -6638,6 +6644,13 @@ jsx-ast-utils@^2.0.1:
   dependencies:
     array-includes "^3.0.3"
 
+jsx-ast-utils@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/jsx-ast-utils/-/jsx-ast-utils-2.1.0.tgz#0ee4e2c971fb9601c67b5641b71be80faecf0b36"
+  integrity sha512-yDGDG2DS4JcqhA6blsuYbtsT09xL8AoLuUR2Gb5exrw7UEM19sBcOTq+YBBhrNbl0PUC4R4LnFu+dHg2HKeVvA==
+  dependencies:
+    array-includes "^3.0.3"
+
 kew@^0.7.0:
   version "0.7.0"
   resolved "https://registry.yarnpkg.com/kew/-/kew-0.7.0.tgz#79d93d2d33363d6fdd2970b335d9141ad591d79b"
@@ -6949,7 +6962,7 @@ lodash.isequal@^3.0:
     lodash._baseisequal "^3.0.0"
     lodash._bindcallback "^3.0.0"
 
-lodash.isequal@^4.0.0, lodash.isequal@^4.1.1, lodash.isequal@^4.5.0:
+lodash.isequal@^4.0.0, lodash.isequal@^4.5.0:
   version "4.5.0"
   resolved "https://registry.yarnpkg.com/lodash.isequal/-/lodash.isequal-4.5.0.tgz#415c4478f2bcc30120c22ce10ed3226f7d3e18e0"
   integrity sha1-QVxEePK8wwEgwizhDtMib30+GOA=
@@ -8767,13 +8780,14 @@ prop-types-extra@^1.0.1:
   dependencies:
     warning "^3.0.0"
 
-prop-types@15.6.2, prop-types@^15.5.6, prop-types@^15.6.0, prop-types@^15.6.2:
-  version "15.6.2"
-  resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.6.2.tgz#05d5ca77b4453e985d60fc7ff8c859094a497102"
-  integrity sha512-3pboPvLiWD7dkI3qf3KbUe6hKFKa52w+AE0VCqECtf+QHAKgOL37tTaNCnuX1nAAQ4ZhyP+kYVKf8rLmJ/feDQ==
+prop-types@15.7.2, prop-types@^15.7.2:
+  version "15.7.2"
+  resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.7.2.tgz#52c41e75b8c87e72b9d9360e0206b99dcbffa6c5"
+  integrity sha512-8QQikdH7//R2vurIJSutZ1smHYTcLpRWEOlHnzcWHmBYrOGUysKwSsrC89BCiFj3CbrfJ/nXFdJepOVrY1GCHQ==
   dependencies:
-    loose-envify "^1.3.1"
+    loose-envify "^1.4.0"
     object-assign "^4.1.1"
+    react-is "^16.8.1"
 
 prop-types@15.x, prop-types@^15.5.10, prop-types@^15.5.8, prop-types@^15.6.1:
   version "15.6.1"
@@ -8781,6 +8795,14 @@ prop-types@15.x, prop-types@^15.5.10, prop-types@^15.5.8, prop-types@^15.6.1:
   integrity sha512-4ec7bY1Y66LymSUOH/zARVYObB23AT2h8cf6e/O6ZALB/N0sqZFEx7rq6EYPX2MkOdKORuooI/H5k9TlR4q7kQ==
   dependencies:
     fbjs "^0.8.16"
+    loose-envify "^1.3.1"
+    object-assign "^4.1.1"
+
+prop-types@^15.5.6, prop-types@^15.6.0, prop-types@^15.6.2:
+  version "15.6.2"
+  resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.6.2.tgz#05d5ca77b4453e985d60fc7ff8c859094a497102"
+  integrity sha512-3pboPvLiWD7dkI3qf3KbUe6hKFKa52w+AE0VCqECtf+QHAKgOL37tTaNCnuX1nAAQ4ZhyP+kYVKf8rLmJ/feDQ==
+  dependencies:
     loose-envify "^1.3.1"
     object-assign "^4.1.1"
 
@@ -9007,15 +9029,15 @@ rc@^1.2.7:
     minimist "^1.2.0"
     strip-json-comments "~2.0.1"
 
-react-ace@^5.9.0:
-  version "5.10.0"
-  resolved "https://registry.yarnpkg.com/react-ace/-/react-ace-5.10.0.tgz#e328b37ac52759f700be5afdb86ada2f5ec84c5e"
-  integrity sha512-aEK/XZCowP8IXq91e2DYqOtGhabk1bbjt+fyeW0UBcIkzDzP/RX/MeJKeyW7wsZcwElACVwyy9nnwXBTqgky3A==
+react-ace-builds@^7.2.4:
+  version "7.2.4"
+  resolved "https://registry.yarnpkg.com/react-ace-builds/-/react-ace-builds-7.2.4.tgz#15224253608b94394e1ce63665bc02842d773c64"
+  integrity sha512-Qb3CPfVwF9xbpQYQd6IW/NfYAqZftG2saOS7cYLEpGU//8fy0gGnJ6dtErLAJpJ/5MbbLp9QBt8hNN5IECdT1A==
   dependencies:
-    brace "^0.11.0"
+    ace-builds "^1.4.4"
+    diff-match-patch "^1.0.4"
     lodash.get "^4.4.2"
-    lodash.isequal "^4.1.1"
-    prop-types "^15.5.8"
+    lodash.isequal "^4.5.0"
 
 react-addons-pure-render-mixin@15.6.2:
   version "15.6.2"
@@ -9132,15 +9154,15 @@ react-docgen@^3.0.0-beta11:
     node-dir "^0.1.10"
     recast "^0.12.6"
 
-react-dom@16.8.3:
-  version "16.8.3"
-  resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-16.8.3.tgz#ae236029e66210783ac81999d3015dfc475b9c32"
-  integrity sha512-ttMem9yJL4/lpItZAQ2NTFAbV7frotHk5DZEHXUOws2rMmrsvh1Na7ThGT0dTzUIl6pqTOi5tYREfL8AEna3lA==
+react-dom@16.8.6:
+  version "16.8.6"
+  resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-16.8.6.tgz#71d6303f631e8b0097f56165ef608f051ff6e10f"
+  integrity sha512-1nL7PIq9LTL3fthPqwkvr2zY7phIPjYrT0jp4HjyEQrEROnw4dG41VVwi/wfoCneoleqrNX7iAD+pXebJZwrwA==
   dependencies:
     loose-envify "^1.1.0"
     object-assign "^4.1.1"
     prop-types "^15.6.2"
-    scheduler "^0.13.3"
+    scheduler "^0.13.6"
 
 react-draggable@^2.2.6:
   version "2.2.6"
@@ -9213,6 +9235,11 @@ react-is@^16.6.1:
   version "16.6.3"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.6.3.tgz#d2d7462fcfcbe6ec0da56ad69047e47e56e7eac0"
   integrity sha512-u7FDWtthB4rWibG/+mFbVd5FvdI20yde86qKGx4lVUTWmPlSWQ4QxbBIrrs+HnXGbxOUlUzTAP/VDmvCwaP2yA==
+
+react-is@^16.8.1:
+  version "16.8.6"
+  resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.8.6.tgz#5bbc1e2d29141c9fbdfed456343fe2bc430a6a16"
+  integrity sha512-aUk3bHfZ2bRSVFFbbeVS4i+lNPZr3/WM5jT2J5omUVV1zzcs1nAaf3l51ctA5FFvCRbhrH0bdAsRRQddFJZPtA==
 
 react-is@^16.8.3:
   version "16.8.3"
@@ -9893,10 +9920,10 @@ resolve@1.x, resolve@^1.3.2:
   dependencies:
     path-parse "^1.0.5"
 
-resolve@^1.4.0, resolve@^1.9.0:
-  version "1.10.0"
-  resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.10.0.tgz#3bdaaeaf45cc07f375656dfd2e54ed0810b101ba"
-  integrity sha512-3sUr9aq5OfSg2S9pNtPA9hL1FVEAjvfOC4leW0SNf/mpnaakz2a9femSd6LqAww2RaFctwyf1lCqnTHuF1rxDg==
+resolve@^1.10.0, resolve@^1.10.1, resolve@^1.11.0:
+  version "1.11.0"
+  resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.11.0.tgz#4014870ba296176b86343d50b60f3b50609ce232"
+  integrity sha512-WL2pBDjqT6pGUNSUzMw00o4T7If+z4H2x3Gz893WoUQ5KW8Vr9txp00ykiP16VBaZF5+j/OcXJHZ9+PCvdiDKw==
   dependencies:
     path-parse "^1.0.6"
 
@@ -10043,6 +10070,14 @@ scheduler@^0.13.3:
   version "0.13.3"
   resolved "https://registry.yarnpkg.com/scheduler/-/scheduler-0.13.3.tgz#bed3c5850f62ea9c716a4d781f9daeb9b2a58896"
   integrity sha512-UxN5QRYWtpR1egNWzJcVLk8jlegxAugswQc984lD3kU7NuobsO37/sRfbpTdBjtnD5TBNFA2Q2oLV5+UmPSmEQ==
+  dependencies:
+    loose-envify "^1.1.0"
+    object-assign "^4.1.1"
+
+scheduler@^0.13.6:
+  version "0.13.6"
+  resolved "https://registry.yarnpkg.com/scheduler/-/scheduler-0.13.6.tgz#466a4ec332467b31a91b9bf74e5347072e4cd889"
+  integrity sha512-IWnObHt413ucAYKsD9J1QShUKkbKLQQHdxRyw73sw4FN26iWr3DY/H34xGPe4nmL1DwXyWmSWmMrA9TfQbE/XQ==
   dependencies:
     loose-envify "^1.1.0"
     object-assign "^4.1.1"
@@ -11713,10 +11748,10 @@ webpack-log@^2.0.0:
     ansi-colors "^3.0.0"
     uuid "^3.3.2"
 
-webpack-merge@4.1.4, webpack-merge@^4.1.4:
-  version "4.1.4"
-  resolved "https://registry.yarnpkg.com/webpack-merge/-/webpack-merge-4.1.4.tgz#0fde38eabf2d5fd85251c24a5a8c48f8a3f4eb7b"
-  integrity sha512-TmSe1HZKeOPey3oy1Ov2iS3guIZjWvMT2BBJDzzT5jScHTjVC3mpjJofgueEzaEd6ibhxRDD6MIblDr8tzh8iQ==
+webpack-merge@4.2.1:
+  version "4.2.1"
+  resolved "https://registry.yarnpkg.com/webpack-merge/-/webpack-merge-4.2.1.tgz#5e923cf802ea2ace4fd5af1d3247368a633489b4"
+  integrity sha512-4p8WQyS98bUJcCvFMbdGZyZmsKuWjWVnVHnAS3FFg0HDaRVrPbkivx2RYCre8UiemD67RsiFFLfn4JhLAin8Vw==
   dependencies:
     lodash "^4.17.5"
 
@@ -11724,6 +11759,13 @@ webpack-merge@^4.1.2:
   version "4.1.2"
   resolved "https://registry.yarnpkg.com/webpack-merge/-/webpack-merge-4.1.2.tgz#5d372dddd3e1e5f8874f5bf5a8e929db09feb216"
   integrity sha512-/0QYwW/H1N/CdXYA2PNPVbsxO3u2Fpz34vs72xm03SRfg6bMNGfMJIQEpQjKRvkG2JvT6oRJFpDtSrwbX8Jzvw==
+  dependencies:
+    lodash "^4.17.5"
+
+webpack-merge@^4.1.4:
+  version "4.1.4"
+  resolved "https://registry.yarnpkg.com/webpack-merge/-/webpack-merge-4.1.4.tgz#0fde38eabf2d5fd85251c24a5a8c48f8a3f4eb7b"
+  integrity sha512-TmSe1HZKeOPey3oy1Ov2iS3guIZjWvMT2BBJDzzT5jScHTjVC3mpjJofgueEzaEd6ibhxRDD6MIblDr8tzh8iQ==
   dependencies:
     lodash "^4.17.5"
 


### PR DESCRIPTION
## Description
Replace `react-ace` with `react-ace-builds`.

`react-ace-builds` is an `ace` library without `brace`. `brace` is lacking behind the actual
ace implementation and seems to be not maintained anymore (https://github.com/thlorenz/brace/issues/135), so `react-ace-builds` provides an `ace` implementation for `react` based on `ace-builds`, which is part of the official ace distribution.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
