### PR TITLE
Wizard component style customization

### DIFF
--- a/graylog2-web-interface/src/components/common/Wizard.jsx
+++ b/graylog2-web-interface/src/components/common/Wizard.jsx
@@ -55,36 +55,45 @@ class Wizard extends React.Component {
   }
 
   _wizardChanged = (eventKey) => {
-    this.props.onStepChange(eventKey);
+    const { onStepChange } = this.props;
+    onStepChange(eventKey);
     this.setState({ selectedStep: eventKey });
   };
 
   _disableButton = (direction) => {
-    const len = this.props.steps.length;
+    const { steps } = this.props;
+    const { selectedStep } = this.state;
+    const len = steps.length;
     const disabledPosition = direction === 'next' ? (len - 1) : 0;
-    const currentPosition = this.props.steps.findIndex(step => step.key === this.state.selectedStep);
+    const currentPosition = steps.findIndex(step => step.key === selectedStep);
     const otherPosition = direction === 'next' ? (currentPosition + 1) : (currentPosition - 1);
-    const otherStep = (this.props.steps[otherPosition] || {});
-    return this.props.steps[disabledPosition].key === this.state.selectedStep || otherStep.disabled;
+    const otherStep = (steps[otherPosition] || {});
+    return steps[disabledPosition].key === selectedStep || otherStep.disabled;
   };
 
   _onNext = () => {
-    this._wizardChanged(this.props.steps[this._getSelectedIndex() + 1].key);
+    const { steps } = this.props;
+    this._wizardChanged(steps[this._getSelectedIndex() + 1].key);
   };
 
   _onPrevious = () => {
-    this._wizardChanged(this.props.steps[this._getSelectedIndex() - 1].key);
+    const { steps } = this.props;
+    this._wizardChanged(steps[this._getSelectedIndex() - 1].key);
   };
 
   _getSelectedIndex = () => {
-    return this.props.steps.map(step => step.key).indexOf(this.state.selectedStep);
+    const { steps } = this.props;
+    const { selectedStep } = this.state;
+    return steps.map(step => step.key).indexOf(selectedStep);
   };
 
   _renderVerticalStepNav = () => {
+    const { steps } = this.props;
+    const { selectedStep } = this.state;
     return (
       <Col md={2} className={WizardStyle.subnavigation}>
-        <Nav stacked bsStyle="pills" activeKey={this.state.selectedStep} onSelect={this._wizardChanged}>
-          {this.props.steps.map((navItem) => {
+        <Nav stacked bsStyle="pills" activeKey={selectedStep} onSelect={this._wizardChanged}>
+          {steps.map((navItem) => {
             return (<NavItem key={navItem.key} eventKey={navItem.key} disabled={navItem.disabled}>{navItem.title}</NavItem>);
           })}
         </Nav>
@@ -102,6 +111,8 @@ class Wizard extends React.Component {
   };
 
   _renderHorizontalStepNav = () => {
+    const { selectedStep } = this.state;
+    const { steps } = this.props;
     return (
       <Col sm={12} className={WizardStyle.horizontal}>
         <div className="pull-right">
@@ -114,8 +125,8 @@ class Wizard extends React.Component {
             </Button>
           </ButtonToolbar>
         </div>
-        <Nav bsStyle="pills" activeKey={this.state.selectedStep} onSelect={this._wizardChanged}>
-          {this.props.steps.map((navItem) => {
+        <Nav bsStyle="pills" activeKey={selectedStep} onSelect={this._wizardChanged}>
+          {steps.map((navItem) => {
             return (<NavItem key={navItem.key} eventKey={navItem.key} disabled={navItem.disabled}>{navItem.title}</NavItem>);
           })}
         </Nav>
@@ -124,20 +135,19 @@ class Wizard extends React.Component {
   };
 
   render() {
-    const rightComponentCols = this.props.horizontal ? 5 : 3; // If horizontal, use more space for this component
+    const { steps, horizontal, containerClassName, children } = this.props;
+    const rightComponentCols = horizontal ? 5 : 3; // If horizontal, use more space for this component
     return (
-      <Row className={this.props.containerClassName}>
-        {this.props.horizontal ? this._renderHorizontalStepNav() : this._renderVerticalStepNav()}
+      <Row className={containerClassName}>
+        {horizontal ? this._renderHorizontalStepNav() : this._renderVerticalStepNav()}
         <Col md={7}>
-          {this.props.steps[this._getSelectedIndex()].component}
+          {steps[this._getSelectedIndex()].component}
         </Col>
-        {this.props.children
-          && (
+        {children && (
           <Col md={rightComponentCols}>
-            {this.props.children}
+            {children}
           </Col>
-          )
-        }
+        )}
       </Row>
     );
   }

--- a/graylog2-web-interface/src/components/common/Wizard.jsx
+++ b/graylog2-web-interface/src/components/common/Wizard.jsx
@@ -35,15 +35,21 @@ class Wizard extends React.Component {
     children: PropTypes.element,
     /** Indicates if wizard should be rendered in horizontal or vertical */
     horizontal: PropTypes.bool,
+    /** Indicates if wizard should take the full width of their parent */
+    justified: PropTypes.bool,
     /** Customize the container CSS class used by this component */
     containerClassName: PropTypes.string,
+    /** Customize the navigation CSS class used by this component */
+    navigationClassName: PropTypes.string,
   };
 
   static defaultProps = {
     children: undefined,
     onStepChange: () => {},
     horizontal: false,
+    justified: false,
     containerClassName: 'content',
+    navigationClassName: '',
   };
 
   constructor(props) {
@@ -88,13 +94,20 @@ class Wizard extends React.Component {
   };
 
   _renderVerticalStepNav = () => {
-    const { steps } = this.props;
+    const { justified, navigationClassName, steps } = this.props;
     const { selectedStep } = this.state;
     return (
       <Col md={2} className={WizardStyle.subnavigation}>
-        <Nav stacked bsStyle="pills" activeKey={selectedStep} onSelect={this._wizardChanged}>
+        <Nav stacked
+             bsStyle="pills"
+             className={navigationClassName}
+             activeKey={selectedStep}
+             onSelect={this._wizardChanged}
+             justified={justified}>
           {steps.map((navItem) => {
-            return (<NavItem key={navItem.key} eventKey={navItem.key} disabled={navItem.disabled}>{navItem.title}</NavItem>);
+            return (
+              <NavItem key={navItem.key} eventKey={navItem.key} disabled={navItem.disabled}>{navItem.title}</NavItem>
+            );
           })}
         </Nav>
         <br />
@@ -112,7 +125,7 @@ class Wizard extends React.Component {
 
   _renderHorizontalStepNav = () => {
     const { selectedStep } = this.state;
-    const { steps } = this.props;
+    const { justified, navigationClassName, steps } = this.props;
     return (
       <Col sm={12} className={WizardStyle.horizontal}>
         <div className="pull-right">
@@ -125,9 +138,14 @@ class Wizard extends React.Component {
             </Button>
           </ButtonToolbar>
         </div>
-        <Nav bsStyle="pills" activeKey={selectedStep} onSelect={this._wizardChanged}>
+        <Nav bsStyle="pills"
+             className={navigationClassName}
+             activeKey={selectedStep}
+             onSelect={this._wizardChanged}
+             justified={justified}>
           {steps.map((navItem) => {
-            return (<NavItem key={navItem.key} eventKey={navItem.key} disabled={navItem.disabled}>{navItem.title}</NavItem>);
+            return (
+              <NavItem key={navItem.key} eventKey={navItem.key} disabled={navItem.disabled}>{navItem.title}</NavItem>);
           })}
         </Nav>
       </Col>

--- a/graylog2-web-interface/src/components/common/Wizard.jsx
+++ b/graylog2-web-interface/src/components/common/Wizard.jsx
@@ -47,6 +47,8 @@ class Wizard extends React.Component {
     containerClassName: PropTypes.string,
     /** Customize the navigation CSS class used by this component */
     navigationClassName: PropTypes.string,
+    /** Indicates if wizard should render next/previous buttons or not */
+    hidePreviousNextButtons: PropTypes.bool,
   };
 
   static defaultProps = {
@@ -57,6 +59,7 @@ class Wizard extends React.Component {
     justified: false,
     containerClassName: 'content',
     navigationClassName: '',
+    hidePreviousNextButtons: false,
   };
 
   constructor(props) {
@@ -132,7 +135,7 @@ class Wizard extends React.Component {
   };
 
   _renderVerticalStepNav = () => {
-    const { justified, navigationClassName, steps } = this.props;
+    const { justified, navigationClassName, steps, hidePreviousNextButtons } = this.props;
     const selectedStep = this._getSelectedStep();
     return (
       <Col md={2} className={WizardStyle.subnavigation}>
@@ -148,34 +151,51 @@ class Wizard extends React.Component {
             );
           })}
         </Nav>
-        <br />
-        <Row>
-          <Col xs={6}>
-            <Button onClick={this._onPrevious} bsSize="small" bsStyle="info" disabled={this._disableButton('previous')}>Previous</Button>
-          </Col>
-          <Col className="text-right" xs={6}>
-            <Button onClick={this._onNext} bsSize="small" bsStyle="info" disabled={this._disableButton('next')}>Next</Button>
-          </Col>
-        </Row>
+        {!hidePreviousNextButtons && (
+          <React.Fragment>
+            <br />
+            <Row>
+              <Col xs={6}>
+                <Button onClick={this._onPrevious}
+                        bsSize="small"
+                        bsStyle="info"
+                        disabled={this._disableButton('previous')}>Previous
+                </Button>
+              </Col>
+              <Col className="text-right" xs={6}>
+                <Button onClick={this._onNext}
+                        bsSize="small"
+                        bsStyle="info"
+                        disabled={this._disableButton('next')}>Next
+                </Button>
+              </Col>
+            </Row>
+          </React.Fragment>
+        )}
       </Col>
     );
   };
 
   _renderHorizontalStepNav = () => {
     const selectedStep = this._getSelectedStep();
-    const { justified, navigationClassName, steps } = this.props;
+    const { justified, navigationClassName, steps, hidePreviousNextButtons } = this.props;
     return (
       <Col sm={12} className={WizardStyle.horizontal}>
-        <div className="pull-right">
-          <ButtonToolbar className={WizardStyle.horizontalPreviousNextButtons}>
-            <Button onClick={this._onPrevious} bsSize="xsmall" bsStyle="info" disabled={this._disableButton('previous')}>
-              <i className="fa fa-caret-left" />
-            </Button>
-            <Button onClick={this._onNext} bsSize="xsmall" bsStyle="info" disabled={this._disableButton('next')}>
-              <i className="fa fa-caret-right" />
-            </Button>
-          </ButtonToolbar>
-        </div>
+        {!hidePreviousNextButtons && (
+          <div className="pull-right">
+            <ButtonToolbar className={WizardStyle.horizontalPreviousNextButtons}>
+              <Button onClick={this._onPrevious}
+                      bsSize="xsmall"
+                      bsStyle="info"
+                      disabled={this._disableButton('previous')}>
+                <i className="fa fa-caret-left" />
+              </Button>
+              <Button onClick={this._onNext} bsSize="xsmall" bsStyle="info" disabled={this._disableButton('next')}>
+                <i className="fa fa-caret-right" />
+              </Button>
+            </ButtonToolbar>
+          </div>
+        )}
         <Nav bsStyle="pills"
              className={navigationClassName}
              activeKey={selectedStep}

--- a/graylog2-web-interface/src/components/common/Wizard.jsx
+++ b/graylog2-web-interface/src/components/common/Wizard.jsx
@@ -62,15 +62,37 @@ class Wizard extends React.Component {
   constructor(props) {
     super(props);
 
+    this._warnOnInvalidActiveStep(props.activeStep, props.steps);
     this.state = {
       selectedStep: props.steps[0].key,
     };
   }
 
+  componentDidUpdate() {
+    const { activeStep, steps } = this.props;
+    this._warnOnInvalidActiveStep(activeStep, steps);
+  }
+
+  _warnOnInvalidActiveStep = (activeStep, steps) => {
+    if (activeStep === undefined || activeStep === null) {
+      return;
+    }
+    if (!this._isValidActiveStep(activeStep, steps)) {
+      console.warn(`activeStep ${activeStep} is not a key in any element of the 'steps' prop!`);
+    }
+  };
+
+  _isValidActiveStep = (activeStep, steps) => {
+    if (activeStep === undefined || activeStep === null) {
+      return false;
+    }
+    return lodash.find(steps, { key: activeStep });
+  };
+
   _getSelectedStep = () => {
-    const { activeStep } = this.props;
+    const { activeStep, steps } = this.props;
     const { selectedStep } = this.state;
-    return lodash.defaultTo(activeStep, selectedStep);
+    return (this._isValidActiveStep(activeStep, steps) ? activeStep : selectedStep);
   };
 
   _wizardChanged = (eventKey) => {

--- a/graylog2-web-interface/src/components/common/Wizard.jsx
+++ b/graylog2-web-interface/src/components/common/Wizard.jsx
@@ -214,11 +214,12 @@ class Wizard extends React.Component {
 
   render() {
     const { steps, horizontal, containerClassName, children } = this.props;
+    const leftComponentCols = children ? 7 : 12; // Use all available width if no preview will be rendered
     const rightComponentCols = horizontal ? 5 : 3; // If horizontal, use more space for this component
     return (
       <Row className={containerClassName}>
         {horizontal ? this._renderHorizontalStepNav() : this._renderVerticalStepNav()}
-        <Col md={7}>
+        <Col md={leftComponentCols}>
           {steps[this._getSelectedIndex()].component}
         </Col>
         {children && (

--- a/graylog2-web-interface/src/components/common/Wizard.jsx
+++ b/graylog2-web-interface/src/components/common/Wizard.jsx
@@ -19,11 +19,13 @@ class Wizard extends React.Component {
      * a 'component' attribute which will hold the component which is to render for the step.
      *
      * e.g:
-     * [\[<br />
-     * &nbsp;&nbsp;{key: 'key1', title: 'General Information', component: (&lt;Acomponent1 /&gt;)},<br />
-     * &nbsp;&nbsp;{key: 'key2', title: 'Details', component: (&lt;Acomponent2 /&gt;), disabled: true},<br />
-     * &nbsp;&nbsp;{key: 'key3', title: 'Preview', component: (&lt;Acomponent3 /&gt;), disabled: true},<br />
-     * \]]
+     * <pre>
+     * [
+     *   {key: 'key1', title: 'General Information', component: (<Acomponent1 />)},
+     *   {key: 'key2', title: 'Details', component: (<Acomponent2 />), disabled: true},
+     *   {key: 'key3', title: 'Preview', component: (<Acomponent3 />), disabled: true},
+     * ]
+     * </pre>
      */
     steps: PropTypes.arrayOf(PropTypes.object).isRequired,
     /**

--- a/graylog2-web-interface/src/components/common/Wizard.jsx
+++ b/graylog2-web-interface/src/components/common/Wizard.jsx
@@ -29,6 +29,7 @@ class Wizard extends React.Component {
     /**
      * Indicates the active step that should be rendered, in case the step state is stored outside this
      * component, and it is being used in a controlled way.
+     * The prop **must** take the value of one of the keys in `steps`, otherwise a warning is logged in the console.
      */
     activeStep: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
     /**
@@ -65,6 +66,12 @@ class Wizard extends React.Component {
       selectedStep: props.steps[0].key,
     };
   }
+
+  _getSelectedStep = () => {
+    const { activeStep } = this.props;
+    const { selectedStep } = this.state;
+    return lodash.defaultTo(activeStep, selectedStep);
+  };
 
   _wizardChanged = (eventKey) => {
     const { activeStep, onStepChange } = this.props;
@@ -160,12 +167,6 @@ class Wizard extends React.Component {
       </Col>
     );
   };
-
-  _getSelectedStep() {
-    const { activeStep } = this.props;
-    const { selectedStep } = this.state;
-    return lodash.defaultTo(activeStep, selectedStep);
-  }
 
   render() {
     const { steps, horizontal, containerClassName, children } = this.props;

--- a/graylog2-web-interface/src/components/common/Wizard.md
+++ b/graylog2-web-interface/src/components/common/Wizard.md
@@ -32,7 +32,7 @@ const WizardExample = createReactClass({
       { key: 'Key2', title: 'Title2', component: (<div>Component2</div>), disabled: this.enableNext() },
       { key: 'Key3', title: 'Title3', component: (<div>Component3</div>), disabled: this.enableNext() },
     ];
- 
+
     return (
       <Wizard steps={steps} horizontal={this.props.horizontal}>
         <div>Preview: {this.state.input_value}</div>
@@ -73,7 +73,7 @@ const ControlledWizardExample = createReactClass({
   onChange(e) {
     this.setState({ input_value: e.target.value });
   },
-  
+
   changeStep(nextStep) {
     if (nextStep === 'Key2') {
       this.setState({ activeStep: 'Key3' });
@@ -90,7 +90,7 @@ const ControlledWizardExample = createReactClass({
       { key: 'Key3', title: 'Title3', component: (<div>Component3</div>), disabled: false },
       { key: 'Key4', title: 'Title4', component: (<div>Component4</div>), disabled: false },
     ];
- 
+
     return (
       <Wizard activeStep={this.state.activeStep} steps={steps} horizontal={this.props.horizontal} onStepChange={this.changeStep} hidePreviousNextButtons>
         <div>Preview: {this.state.input_value}</div>

--- a/graylog2-web-interface/src/components/common/Wizard.md
+++ b/graylog2-web-interface/src/components/common/Wizard.md
@@ -49,7 +49,7 @@ const WizardExample = createReactClass({
 
 ```
 
-Using `Wizard` as controlled component:
+Using `Wizard` as controlled component with no previous/next buttons:
 ```js
 const createReactClass = require('create-react-class');
 
@@ -92,7 +92,7 @@ const ControlledWizardExample = createReactClass({
     ];
  
     return (
-      <Wizard activeStep={this.state.activeStep} steps={steps} horizontal={this.props.horizontal} onStepChange={this.changeStep}>
+      <Wizard activeStep={this.state.activeStep} steps={steps} horizontal={this.props.horizontal} onStepChange={this.changeStep} hidePreviousNextButtons>
         <div>Preview: {this.state.input_value}</div>
       </Wizard>
     );

--- a/graylog2-web-interface/src/components/common/Wizard.md
+++ b/graylog2-web-interface/src/components/common/Wizard.md
@@ -49,11 +49,11 @@ const WizardExample = createReactClass({
 
 ```
 
-Using `Wizard` as controlled component with no previous/next buttons:
+Using `Wizard` as controlled component with no previous/next buttons and no preview:
 ```js
 const createReactClass = require('create-react-class');
 
-const Componente1 = createReactClass({
+const Component1 = createReactClass({
 
   render() {
     return (<span>
@@ -85,16 +85,14 @@ const ControlledWizardExample = createReactClass({
 
   render() {
     const steps = [
-      { key: 'Key1', title: 'Title1', component: (<Componente1 input_value={this.state.input_value} onChange={this.onChange}/>) },
+      { key: 'Key1', title: 'Title1', component: (<Component1 input_value={this.state.input_value} onChange={this.onChange}/>) },
       { key: 'Key2', title: 'Title2', component: (<div>Component2</div>), disabled: false },
-      { key: 'Key3', title: 'Title3', component: (<div>Component3</div>), disabled: false },
+      { key: 'Key3', title: 'Title3', component: (<div style={{ backgroundColor: 'lightblue' }}>Component3</div>), disabled: false },
       { key: 'Key4', title: 'Title4', component: (<div>Component4</div>), disabled: false },
     ];
 
     return (
-      <Wizard activeStep={this.state.activeStep} steps={steps} horizontal={this.props.horizontal} onStepChange={this.changeStep} hidePreviousNextButtons>
-        <div>Preview: {this.state.input_value}</div>
-      </Wizard>
+      <Wizard activeStep={this.state.activeStep} steps={steps} horizontal={this.props.horizontal} onStepChange={this.changeStep} hidePreviousNextButtons />
     );
   },
 });

--- a/graylog2-web-interface/src/components/common/Wizard.md
+++ b/graylog2-web-interface/src/components/common/Wizard.md
@@ -1,3 +1,4 @@
+Using `Wizard` as uncontrolled component:
 ```js
 const createReactClass = require('create-react-class');
 
@@ -46,4 +47,60 @@ const WizardExample = createReactClass({
     <WizardExample horizontal />
 </div>
 
+```
+
+Using `Wizard` as controlled component:
+```js
+const createReactClass = require('create-react-class');
+
+const Componente1 = createReactClass({
+
+  render() {
+    return (<span>
+      Type 'hello': <input value={this.props.input_value} onChange={this.props.onChange} />
+    </span>);
+  },
+});
+
+const ControlledWizardExample = createReactClass({
+  getInitialState() {
+    return {
+      activeStep: 'Key3',
+      input_value: "",
+    };
+  },
+
+  onChange(e) {
+    this.setState({ input_value: e.target.value });
+  },
+  
+  changeStep(nextStep) {
+    if (nextStep === 'Key2') {
+      this.setState({ activeStep: 'Key3' });
+      return;
+    }
+
+    this.setState({ activeStep: nextStep });
+  },
+
+  render() {
+    const steps = [
+      { key: 'Key1', title: 'Title1', component: (<Componente1 input_value={this.state.input_value} onChange={this.onChange}/>) },
+      { key: 'Key2', title: 'Title2', component: (<div>Component2</div>), disabled: false },
+      { key: 'Key3', title: 'Title3', component: (<div>Component3</div>), disabled: false },
+      { key: 'Key4', title: 'Title4', component: (<div>Component4</div>), disabled: false },
+    ];
+ 
+    return (
+      <Wizard activeStep={this.state.activeStep} steps={steps} horizontal={this.props.horizontal} onStepChange={this.changeStep}>
+        <div>Preview: {this.state.input_value}</div>
+      </Wizard>
+    );
+  },
+});
+
+<div>
+    <p>Goes to <em>Title3</em> when selecting <em>Title2</em>.</p>
+    <ControlledWizardExample horizontal />
+</div>
 ```

--- a/graylog2-web-interface/src/components/common/Wizard.test.jsx
+++ b/graylog2-web-interface/src/components/common/Wizard.test.jsx
@@ -156,4 +156,24 @@ describe('<Wizard />', () => {
     expect(wrapper.find('div[children="Component2"]').exists()).toBe(false);
     expect(wrapper.find('div[children="Component3"]').exists()).toBe(false);
   });
+
+  it('should render next/previous buttons by default', () => {
+    const wrapperV = mount(<Wizard steps={steps} />);
+    expect(wrapperV.find('button[children="Next"]').exists()).toBe(true);
+    expect(wrapperV.find('button[children="Previous"]').exists()).toBe(true);
+
+    const wrapperH = mount(<Wizard steps={steps} horizontal />);
+    expect(wrapperH.find('button > i.fa-caret-left').exists()).toBe(true);
+    expect(wrapperH.find('button > i.fa-caret-right').exists()).toBe(true);
+  });
+
+  it('should hide next/previous buttons if hidePreviousNextButtons is set', () => {
+    const wrapperV = mount(<Wizard steps={steps} hidePreviousNextButtons />);
+    expect(wrapperV.find('button[children="Next"]').exists()).toBe(false);
+    expect(wrapperV.find('button[children="Previous"]').exists()).toBe(false);
+
+    const wrapperH = mount(<Wizard steps={steps} horizontal hidePreviousNextButtons />);
+    expect(wrapperH.find('button > i.fa-caret-left').exists()).toBe(false);
+    expect(wrapperH.find('button > i.fa-caret-right').exists()).toBe(false);
+  });
 });

--- a/graylog2-web-interface/src/components/common/Wizard.test.jsx
+++ b/graylog2-web-interface/src/components/common/Wizard.test.jsx
@@ -110,6 +110,22 @@ describe('<Wizard />', () => {
       expect(wrapper.find('div[children="Component2"]').exists()).toBe(false);
       expect(wrapper.find('div[children="Component3"]').exists()).toBe(false);
     });
+
+    it('should show a warning when activeStep is not a key in steps', () => {
+      const consoleWarn = console.warn;
+      console.warn = jest.fn();
+      const wrapper = mount(<Wizard steps={steps} activeStep={0} />);
+      expect(wrapper.find('div[children="Component1"]').exists()).toBe(true);
+      expect(wrapper.find('div[children="Component2"]').exists()).toBe(false);
+      expect(wrapper.find('div[children="Component3"]').exists()).toBe(false);
+      expect(console.warn.mock.calls.length).toBe(1);
+      wrapper.setProps({ activeStep: 'Key12314' });
+      expect(wrapper.find('div[children="Component1"]').exists()).toBe(true);
+      expect(wrapper.find('div[children="Component2"]').exists()).toBe(false);
+      expect(wrapper.find('div[children="Component3"]').exists()).toBe(false);
+      expect(console.warn.mock.calls.length).toBe(2);
+      console.warn = consoleWarn;
+    });
   });
 
   it('should give callback step when changing the step', () => {

--- a/graylog2-web-interface/src/components/common/Wizard.test.jsx
+++ b/graylog2-web-interface/src/components/common/Wizard.test.jsx
@@ -32,58 +32,84 @@ describe('<Wizard />', () => {
     expect(wrapper.toJSON()).toMatchSnapshot();
   });
 
-  it('should render step 1 when nothing was clicked', () => {
-    const wrapper = mount(<Wizard steps={steps} />);
-    expect(wrapper.find('div[children="Component1"]').exists()).toBe(true);
-    expect(wrapper.find('div[children="Component2"]').exists()).toBe(false);
-    expect(wrapper.find('div[children="Component3"]').exists()).toBe(false);
-    expect(wrapper.find('button[children="Previous"]').prop('disabled')).toBe(true);
-    expect(wrapper.find('button[children="Next"]').prop('disabled')).toBe(false);
+  describe('When used in an uncontrolled way', () => {
+    it('should render step 1 when nothing was clicked', () => {
+      const wrapper = mount(<Wizard steps={steps} />);
+      expect(wrapper.find('div[children="Component1"]').exists()).toBe(true);
+      expect(wrapper.find('div[children="Component2"]').exists()).toBe(false);
+      expect(wrapper.find('div[children="Component3"]').exists()).toBe(false);
+      expect(wrapper.find('button[children="Previous"]').prop('disabled')).toBe(true);
+      expect(wrapper.find('button[children="Next"]').prop('disabled')).toBe(false);
+    });
+
+    it('should render step 2 when clicked on step 2', () => {
+      const wrapper = mount(<Wizard steps={steps} />);
+      wrapper.find('a[children="Title2"]').simulate('click');
+      expect(wrapper.find('div[children="Component1"]').exists()).toBe(false);
+      expect(wrapper.find('div[children="Component2"]').exists()).toBe(true);
+      expect(wrapper.find('div[children="Component3"]').exists()).toBe(false);
+      expect(wrapper.find('button[children="Previous"]').prop('disabled')).toBe(false);
+      expect(wrapper.find('button[children="Next"]').prop('disabled')).toBe(false);
+    });
+
+    it('should render step 2 when clicked on next', () => {
+      const wrapper = mount(<Wizard steps={steps} />);
+      wrapper.find('button[children="Next"]').simulate('click');
+      expect(wrapper.find('div[children="Component1"]').exists()).toBe(false);
+      expect(wrapper.find('div[children="Component2"]').exists()).toBe(true);
+      expect(wrapper.find('div[children="Component3"]').exists()).toBe(false);
+      expect(wrapper.find('button[children="Previous"]').prop('disabled')).toBe(false);
+      expect(wrapper.find('button[children="Next"]').prop('disabled')).toBe(false);
+    });
+
+    it('should render step 3 when two times clicked on next', () => {
+      const wrapper = mount(<Wizard steps={steps} />);
+      wrapper.find('button[children="Next"]').simulate('click');
+      wrapper.find('button[children="Next"]').simulate('click');
+      expect(wrapper.find('div[children="Component1"]').exists()).toBe(false);
+      expect(wrapper.find('div[children="Component2"]').exists()).toBe(false);
+      expect(wrapper.find('div[children="Component3"]').exists()).toBe(true);
+      expect(wrapper.find('button[children="Previous"]').prop('disabled')).toBe(false);
+      expect(wrapper.find('button[children="Next"]').prop('disabled')).toBe(true);
+    });
+
+    it('should render step 2 when two times clicked on next and one time clicked on previous', () => {
+      const changeFn = jest.fn(() => {});
+      const wrapper = mount(<Wizard steps={steps} onStepChange={changeFn} />);
+      wrapper.find('button[children="Next"]').simulate('click');
+      wrapper.find('button[children="Next"]').simulate('click');
+      wrapper.find('button[children="Previous"]').simulate('click');
+      expect(wrapper.find('div[children="Component1"]').exists()).toBe(false);
+      expect(wrapper.find('div[children="Component2"]').exists()).toBe(true);
+      expect(wrapper.find('div[children="Component3"]').exists()).toBe(false);
+      expect(wrapper.find('button[children="Previous"]').prop('disabled')).toBe(false);
+      expect(wrapper.find('button[children="Next"]').prop('disabled')).toBe(false);
+      expect(changeFn.mock.calls.length).toBe(3);
+    });
   });
 
-  it('should render step 2 when clicked on step 2', () => {
-    const wrapper = mount(<Wizard steps={steps} />);
-    wrapper.find('a[children="Title2"]').simulate('click');
-    expect(wrapper.find('div[children="Component1"]').exists()).toBe(false);
-    expect(wrapper.find('div[children="Component2"]').exists()).toBe(true);
-    expect(wrapper.find('div[children="Component3"]').exists()).toBe(false);
-    expect(wrapper.find('button[children="Previous"]').prop('disabled')).toBe(false);
-    expect(wrapper.find('button[children="Next"]').prop('disabled')).toBe(false);
-  });
+  describe('When used in a controlled way', () => {
+    it('should render active step given from prop', () => {
+      const wrapper = mount(<Wizard steps={steps} activeStep="Key2" />);
+      expect(wrapper.find('div[children="Component1"]').exists()).toBe(false);
+      expect(wrapper.find('div[children="Component2"]').exists()).toBe(true);
+      expect(wrapper.find('div[children="Component3"]').exists()).toBe(false);
+      wrapper.find('button[children="Next"]').simulate('click');
+      expect(wrapper.find('div[children="Component1"]').exists()).toBe(false);
+      expect(wrapper.find('div[children="Component2"]').exists()).toBe(true);
+      expect(wrapper.find('div[children="Component3"]').exists()).toBe(false);
+    });
 
-  it('should render step 2 when clicked on next', () => {
-    const wrapper = mount(<Wizard steps={steps} />);
-    wrapper.find('button[children="Next"]').simulate('click');
-    expect(wrapper.find('div[children="Component1"]').exists()).toBe(false);
-    expect(wrapper.find('div[children="Component2"]').exists()).toBe(true);
-    expect(wrapper.find('div[children="Component3"]').exists()).toBe(false);
-    expect(wrapper.find('button[children="Previous"]').prop('disabled')).toBe(false);
-    expect(wrapper.find('button[children="Next"]').prop('disabled')).toBe(false);
-  });
-
-  it('should render step 3 when two times clicked on next', () => {
-    const wrapper = mount(<Wizard steps={steps} />);
-    wrapper.find('button[children="Next"]').simulate('click');
-    wrapper.find('button[children="Next"]').simulate('click');
-    expect(wrapper.find('div[children="Component1"]').exists()).toBe(false);
-    expect(wrapper.find('div[children="Component2"]').exists()).toBe(false);
-    expect(wrapper.find('div[children="Component3"]').exists()).toBe(true);
-    expect(wrapper.find('button[children="Previous"]').prop('disabled')).toBe(false);
-    expect(wrapper.find('button[children="Next"]').prop('disabled')).toBe(true);
-  });
-
-  it('should render step 2 when two times clicked on next and one time clicked on previous', () => {
-    const changeFn = jest.fn(() => {});
-    const wrapper = mount(<Wizard steps={steps} onStepChange={changeFn} />);
-    wrapper.find('button[children="Next"]').simulate('click');
-    wrapper.find('button[children="Next"]').simulate('click');
-    wrapper.find('button[children="Previous"]').simulate('click');
-    expect(wrapper.find('div[children="Component1"]').exists()).toBe(false);
-    expect(wrapper.find('div[children="Component2"]').exists()).toBe(true);
-    expect(wrapper.find('div[children="Component3"]').exists()).toBe(false);
-    expect(wrapper.find('button[children="Previous"]').prop('disabled')).toBe(false);
-    expect(wrapper.find('button[children="Next"]').prop('disabled')).toBe(false);
-    expect(changeFn.mock.calls.length).toBe(3);
+    it('should change the active step when prop changes', () => {
+      const wrapper = mount(<Wizard steps={steps} activeStep="Key2" />);
+      expect(wrapper.find('div[children="Component1"]').exists()).toBe(false);
+      expect(wrapper.find('div[children="Component2"]').exists()).toBe(true);
+      expect(wrapper.find('div[children="Component3"]').exists()).toBe(false);
+      wrapper.setProps({ activeStep: 'Key1' });
+      expect(wrapper.find('div[children="Component1"]').exists()).toBe(true);
+      expect(wrapper.find('div[children="Component2"]').exists()).toBe(false);
+      expect(wrapper.find('div[children="Component3"]').exists()).toBe(false);
+    });
   });
 
   it('should give callback step when changing the step', () => {
@@ -94,6 +120,10 @@ describe('<Wizard />', () => {
     const wrapper = mount(<Wizard steps={steps} onStepChange={changeFn} />);
     wrapper.find('button[children="Next"]').simulate('click');
     expect(changeFn.mock.calls.length).toBe(1);
+
+    const controlledWrapped = mount(<Wizard steps={steps} onStepChange={changeFn} activeStep="Key1" />);
+    controlledWrapped.find('button[children="Next"]').simulate('click');
+    expect(changeFn.mock.calls.length).toBe(2);
   });
 
   it('should respect disabled flag for a step', () => {

--- a/graylog2-web-interface/src/components/common/__snapshots__/Wizard.test.jsx.snap
+++ b/graylog2-web-interface/src/components/common/__snapshots__/Wizard.test.jsx.snap
@@ -271,7 +271,7 @@ exports[`<Wizard /> should render with 3 steps 1`] = `
     </div>
   </div>
   <div
-    className="col-md-7"
+    className="col-md-12"
   >
     <div>
       Component1

--- a/graylog2-web-interface/src/components/common/__snapshots__/Wizard.test.jsx.snap
+++ b/graylog2-web-interface/src/components/common/__snapshots__/Wizard.test.jsx.snap
@@ -82,7 +82,7 @@ exports[`<Wizard /> should render in horizontal mode with 3 steps 1`] = `
     </ul>
   </div>
   <div
-    className="col-md-7"
+    className="col-md-12"
   >
     <div>
       Component1


### PR DESCRIPTION
This change allows customers of the `Wizard` component to customize its appearance in two different ways:

- The `justified` prop allows the navigation to take the full width of its container
- The `navigationClassName` prop allows consumers to set a CSS class for the navigation, so it is possible to alter the way the navigation looks without changing its code

Screenshot:

![preview](https://user-images.githubusercontent.com/716185/59033653-748f4200-8869-11e9-99c8-b3e64aca3199.png)

