### PR TITLE
Avoid collisions when merging `InputsStore` state into components state.

### DIFF
--- a/graylog2-web-interface/src/components/inputs/CreateInputControl.jsx
+++ b/graylog2-web-interface/src/components/inputs/CreateInputControl.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import createReactClass from 'create-react-class';
 import Reflux from 'reflux';
-import { Button, Row, Col } from 'react-bootstrap';
+import { Button, Col, Row } from 'react-bootstrap';
 
 import { ExternalLinkButton, Select } from 'components/common';
 
@@ -29,10 +29,11 @@ const CreateInputControl = createReactClass({
   _formatSelectOptions() {
     let options = [];
 
-    if (this.state.inputTypes) {
-      const inputTypesIds = Object.keys(this.state.inputTypes);
+    const { inputTypes } = this.state;
+    if (inputTypes) {
+      const inputTypesIds = Object.keys(inputTypes);
       options = inputTypesIds.map((id) => {
-        return { value: id, label: this.state.inputTypes[id] };
+        return { value: id, label: inputTypes[id] };
       });
       options.sort((inputTypeA, inputTypeB) => inputTypeA.label.toLowerCase().localeCompare(inputTypeB.label.toLowerCase()));
     } else {
@@ -64,15 +65,16 @@ const CreateInputControl = createReactClass({
 
   render() {
     let inputModal;
-    if (this.state.selectedInputDefinition) {
-      const inputTypeName = this.state.inputTypes[this.state.selectedInput];
+    const { selectedInputDefinition, selectedInput, inputTypes } = this.state;
+    if (selectedInputDefinition) {
+      const inputTypeName = inputTypes[selectedInput];
       inputModal = (
         <InputForm ref={(configurationForm) => { this.configurationForm = configurationForm; }}
                    key="configuration-form-input"
-                   configFields={this.state.selectedInputDefinition.requested_configuration}
+                   configFields={selectedInputDefinition.requested_configuration}
                    title={<span>Launch new <em>{inputTypeName}</em> input</span>}
                    helpBlock="Select a name of your new input that describes it."
-                   typeName={this.state.selectedInput}
+                   typeName={selectedInput}
                    submitAction={this._createInput} />
       );
     }
@@ -85,10 +87,10 @@ const CreateInputControl = createReactClass({
                       options={this._formatSelectOptions()}
                       matchProp="label"
                       onChange={this._onInputSelect}
-                      value={this.state.selectedInput} />
+                      value={selectedInput} />
             </div>
             &nbsp;
-            <Button bsStyle="success" type="submit" disabled={!this.state.selectedInput}>Launch new input</Button>
+            <Button bsStyle="success" type="submit" disabled={!selectedInput}>Launch new input</Button>
             <ExternalLinkButton href="https://marketplace.graylog.org/"
                                 bsStyle="info"
                                 style={{ marginLeft: 10 }}>

--- a/graylog2-web-interface/src/pages/CreateExtractorsPage.jsx
+++ b/graylog2-web-interface/src/pages/CreateExtractorsPage.jsx
@@ -40,7 +40,6 @@ const CreateExtractorsPage = createReactClass({
     return {
       extractor: ExtractorsStore.new(query.extractor_type, query.field),
       exampleMessage: undefined,
-      extractorType: query.extractor_type,
       field: query.field,
       exampleIndex: query.example_index,
       exampleId: query.example_id,

--- a/graylog2-web-interface/src/pages/CreateExtractorsPage.jsx
+++ b/graylog2-web-interface/src/pages/CreateExtractorsPage.jsx
@@ -34,11 +34,11 @@ const CreateExtractorsPage = createReactClass({
   mixins: [Reflux.connect(InputsStore)],
 
   getInitialState() {
-    const { query } = this.props.location;
+    const { location } = this.props;
+    const { query } = location;
 
     return {
       extractor: ExtractorsStore.new(query.extractor_type, query.field),
-      input: undefined,
       exampleMessage: undefined,
       extractorType: query.extractor_type,
       field: query.field,
@@ -48,21 +48,26 @@ const CreateExtractorsPage = createReactClass({
   },
 
   componentDidMount() {
-    InputsActions.get.triggerPromise(this.props.params.inputId);
-    MessagesActions.loadMessage.triggerPromise(this.state.exampleIndex, this.state.exampleId)
+    const { params } = this.props;
+    InputsActions.get.triggerPromise(params.inputId);
+    const { exampleIndex, exampleId } = this.state;
+    MessagesActions.loadMessage.triggerPromise(exampleIndex, exampleId)
       .then(message => this.setState({ exampleMessage: message }));
   },
 
   _isLoading() {
-    return !(this.state.input && this.state.exampleMessage);
+    const { exampleMessage, input } = this.state;
+    return !(input && exampleMessage);
   },
 
   _extractorSaved() {
     let url;
-    if (this.state.input.global) {
-      url = Routes.global_input_extractors(this.props.params.inputId);
+    const { params } = this.props;
+    const { input } = this.state;
+    if (input.global) {
+      url = Routes.global_input_extractors(params.inputId);
     } else {
-      url = Routes.local_input_extractors(this.props.params.nodeId, this.props.params.inputId);
+      url = Routes.local_input_extractors(params.nodeId, params.inputId);
     }
 
     history.push(url);
@@ -73,12 +78,13 @@ const CreateExtractorsPage = createReactClass({
       return <Spinner />;
     }
 
-    const exampleMessage = StringUtils.stringify(this.state.exampleMessage.fields[this.state.field]);
+    const { field, exampleMessage, extractor, input } = this.state;
+    const stringifiedExampleMessage = StringUtils.stringify(exampleMessage.fields[field]);
 
     return (
-      <DocumentTitle title={`New extractor for input ${this.state.input.title}`}>
+      <DocumentTitle title={`New extractor for input ${input.title}`}>
         <div>
-          <PageHeader title={<span>New extractor for input <em>{this.state.input.title}</em></span>}>
+          <PageHeader title={<span>New extractor for input <em>{input.title}</em></span>}>
             <span>
               Extractors are applied on every message that is received by an input. Use them to extract and
               transform any text data into fields that allow you easy filtering and analysis later on.
@@ -90,9 +96,9 @@ const CreateExtractorsPage = createReactClass({
             </span>
           </PageHeader>
           <EditExtractor action="create"
-                         extractor={this.state.extractor}
-                         inputId={this.state.input.id}
-                         exampleMessage={exampleMessage}
+                         extractor={extractor}
+                         inputId={input.id}
+                         exampleMessage={stringifiedExampleMessage}
                          onSave={this._extractorSaved} />
         </div>
       </DocumentTitle>

--- a/graylog2-web-interface/src/pages/EditExtractorsPage.jsx
+++ b/graylog2-web-interface/src/pages/EditExtractorsPage.jsx
@@ -33,7 +33,6 @@ const EditExtractorsPage = createReactClass({
   getInitialState() {
     return {
       extractor: undefined,
-      input: undefined,
       exampleMessage: undefined,
     };
   },

--- a/graylog2-web-interface/src/pages/EditExtractorsPage.jsx
+++ b/graylog2-web-interface/src/pages/EditExtractorsPage.jsx
@@ -38,9 +38,10 @@ const EditExtractorsPage = createReactClass({
   },
 
   componentDidMount() {
-    InputsActions.get.triggerPromise(this.props.params.inputId);
-    ExtractorsActions.get.triggerPromise(this.props.params.inputId, this.props.params.extractorId);
-    UniversalSearchstore.search('relative', `gl2_source_input:${this.props.params.inputId} OR gl2_source_radio_input:${this.props.params.inputId}`, { relative: 3600 }, undefined, 1)
+    const { params } = this.props;
+    InputsActions.get.triggerPromise(params.inputId);
+    ExtractorsActions.get.triggerPromise(params.inputId, params.extractorId);
+    UniversalSearchstore.search('relative', `gl2_source_input:${params.inputId} OR gl2_source_radio_input:${params.inputId}`, { relative: 3600 }, undefined, 1)
       .then((response) => {
         if (response.total_results > 0) {
           this.setState({ exampleMessage: response.messages[0] });
@@ -51,15 +52,18 @@ const EditExtractorsPage = createReactClass({
   },
 
   _isLoading() {
+    // eslint-disable-next-line react/destructuring-assignment
     return !(this.state.input && this.state.extractor && this.state.exampleMessage);
   },
 
   _extractorSaved() {
     let url;
-    if (this.state.input.global) {
-      url = Routes.global_input_extractors(this.props.params.inputId);
+    const { input } = this.state;
+    const { params } = this.props;
+    if (input.global) {
+      url = Routes.global_input_extractors(params.inputId);
     } else {
-      url = Routes.local_input_extractors(this.props.params.nodeId, this.props.params.inputId);
+      url = Routes.local_input_extractors(params.nodeId, params.inputId);
     }
 
     history.push(url);
@@ -73,10 +77,11 @@ const EditExtractorsPage = createReactClass({
       return <Spinner />;
     }
 
+    const { extractor, exampleMessage, input } = this.state;
     return (
-      <DocumentTitle title={`Edit extractor ${this.state.extractor.title}`}>
+      <DocumentTitle title={`Edit extractor ${extractor.title}`}>
         <div>
-          <PageHeader title={<span>Edit extractor <em>{this.state.extractor.title}</em> for input <em>{this.state.input.title}</em></span>}>
+          <PageHeader title={<span>Edit extractor <em>{extractor.title}</em> for input <em>{input.title}</em></span>}>
             <span>
               Extractors are applied on every message that is received by an input. Use them to extract and transform{' '}
               any text data into fields that allow you easy filtering and analysis later on.
@@ -88,9 +93,9 @@ const EditExtractorsPage = createReactClass({
             </span>
           </PageHeader>
           <EditExtractor action="edit"
-                         extractor={this.state.extractor}
-                         inputId={this.state.input.id}
-                         exampleMessage={this.state.exampleMessage.fields ? this.state.exampleMessage.fields[this.state.extractor.source_field] : undefined}
+                         extractor={extractor}
+                         inputId={input.id}
+                         exampleMessage={exampleMessage.fields ? exampleMessage.fields[extractor.source_field] : undefined}
                          onSave={this._extractorSaved} />
         </div>
       </DocumentTitle>

--- a/graylog2-web-interface/src/pages/ExportExtractorsPage.jsx
+++ b/graylog2-web-interface/src/pages/ExportExtractorsPage.jsx
@@ -22,17 +22,13 @@ const ExportExtractorsPage = createReactClass({
 
   mixins: [Reflux.connect(InputsStore)],
 
-  getInitialState() {
-    return {
-      input: undefined,
-    };
-  },
-
   componentDidMount() {
-    InputsActions.get.triggerPromise(this.props.params.inputId);
+    const { params } = this.props;
+    InputsActions.get.triggerPromise(params.inputId);
   },
 
   _isLoading() {
+    // eslint-disable-next-line react/destructuring-assignment
     return !this.state.input;
   },
 
@@ -41,16 +37,17 @@ const ExportExtractorsPage = createReactClass({
       return <Spinner />;
     }
 
+    const { input } = this.state;
     return (
-      <DocumentTitle title={`Export extractors of ${this.state.input.title}`}>
+      <DocumentTitle title={`Export extractors of ${input.title}`}>
         <div>
-          <PageHeader title={<span>Export extractors of <em>{this.state.input.title}</em></span>}>
+          <PageHeader title={<span>Export extractors of <em>{input.title}</em></span>}>
             <span>
               The extractors of an input can be exported to JSON for importing into other setups
-              or sharing in <a href="https://marketplace.graylog.org/" target="_blank">the Graylog Marketplace</a>.
+              or sharing in <a href="https://marketplace.graylog.org/" rel="noopener noreferrer" target="_blank">the Graylog Marketplace</a>.
             </span>
           </PageHeader>
-          <ExportExtractors input={this.state.input} />
+          <ExportExtractors input={input} />
         </div>
       </DocumentTitle>
     );

--- a/graylog2-web-interface/src/pages/ImportExtractorsPage.jsx
+++ b/graylog2-web-interface/src/pages/ImportExtractorsPage.jsx
@@ -22,17 +22,13 @@ const ImportExtractorsPage = createReactClass({
 
   mixins: [Reflux.connect(InputsStore)],
 
-  getInitialState() {
-    return {
-      input: undefined,
-    };
-  },
-
   componentDidMount() {
-    InputsActions.get.triggerPromise(this.props.params.inputId).then(input => this.setState({ input: input }));
+    const { params } = this.props;
+    InputsActions.get.triggerPromise(params.inputId).then(input => this.setState({ input: input }));
   },
 
   _isLoading() {
+    // eslint-disable-next-line react/destructuring-assignment
     return !this.state.input;
   },
 
@@ -41,18 +37,20 @@ const ImportExtractorsPage = createReactClass({
       return <Spinner />;
     }
 
+    const { input } = this.state;
     return (
-      <DocumentTitle title={`Import extractors to ${this.state.input.title}`}>
+      <DocumentTitle title={`Import extractors to ${input.title}`}>
         <div>
-          <PageHeader title={<span>Import extractors to <em>{this.state.input.title}</em></span>}>
+          <PageHeader title={<span>Import extractors to <em>{input.title}</em></span>}>
             <span>
               Exported extractors can be imported to an input. All you need is the JSON export of extractors from any
-              other Graylog setup or from <a href="https://marketplace.graylog.org/" target="_blank">the Graylog
-              Marketplace
+              other Graylog setup or from{' '}
+              <a href="https://marketplace.graylog.org/" rel="noopener noreferrer" target="_blank">
+                the Graylog Marketplace
               </a>.
             </span>
           </PageHeader>
-          <ImportExtractors input={this.state.input} />
+          <ImportExtractors input={input} />
         </div>
       </DocumentTitle>
     );


### PR DESCRIPTION
## Description
## Motivation and Context

Before this PR, mounting one of the affected components lead to a
collision when merging the state of the `InputsStore`, as returned by
its `getInitialState` function into the state of the components, because
the `input` key was already defined. This PR is removing the initial
assignment of this key and fixes linter hints.

Fixes #5997.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.