### PR TITLE
Fixing `displayKey`/`valueKey` props in `Select` component.

### DIFF
--- a/graylog2-web-interface/src/components/common/Select.jsx
+++ b/graylog2-web-interface/src/components/common/Select.jsx
@@ -206,7 +206,8 @@ class Select extends React.Component<Props, State> {
                          onChange={onReactSelectChange || this._onChange}
                          isMulti={isMulti}
                          isDisabled={isDisabled}
-                         labelKey={displayKey}
+                         getOptionLabel={option => option[displayKey]}
+                         getOptionValue={option => option[valueKey]}
                          components={_components}
                          styles={_styles}
                          value={formattedValue} />


### PR DESCRIPTION
## Description
## Motivation and Context

The `labelKey` & `valueKey` props in `react-select` have become
deprecated and replaced by `getOptionLabel`/`getOptionValue` functions.
This PR is changing our wrapper component to reflect this.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.