### PR TITLE
Cleaning up JS Warnings

### DIFF
--- a/graylog2-web-interface/src/components/navigation/Navigation.css
+++ b/graylog2-web-interface/src/components/navigation/Navigation.css
@@ -5,10 +5,11 @@
 
 :local(.dev-badge-wrap) > a {
   padding: 0 !important;
+  cursor: default;
 }
 
 :local(.dev-badge-wrap) .dev-badge {
-  margin: 0 15px;
+  margin: 0 10px;
 }
 
 @media (max-width: 991px) {

--- a/graylog2-web-interface/src/components/navigation/Navigation.jsx
+++ b/graylog2-web-interface/src/components/navigation/Navigation.jsx
@@ -2,7 +2,7 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import { withRouter } from 'react-router';
 
-import { Badge, Navbar, Nav, NavItem, NavDropdown, MenuItem } from 'react-bootstrap';
+import { Badge, Navbar, Nav, NavItem, NavDropdown } from 'react-bootstrap';
 import { LinkContainer } from 'react-router-bootstrap';
 import naturalSort from 'javascript-natural-sort';
 
@@ -27,6 +27,7 @@ import NotificationBadge from './NotificationBadge';
 import NavigationLink from './NavigationLink';
 import SystemMenu from './SystemMenu';
 import styles from './Navigation.css';
+import InactiveNavItem from './InactiveNavItem';
 
 const CurrentUserStore = StoreProvider.getStore('CurrentUser');
 const { isPermitted } = PermissionsMixin;
@@ -117,9 +118,9 @@ const Navigation = ({ permissions, fullName, location, loginName }) => {
           {
           AppConfig.gl2DevMode()
             && (
-              <MenuItem className={styles['dev-badge-wrap']}>
+              <InactiveNavItem className={styles['dev-badge-wrap']}>
                 <Badge className={`dev-badge ${badgeStyles.badgeDanger}`}>DEV</Badge>
-              </MenuItem>
+              </InactiveNavItem>
             )
           }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Removes two JS warnings/errors

## Motivation and Context
There are two Warnings that show up on almost every page load

```Warning: React does not recognize the `activeKey` prop on a DOM element. If you intentionally want it to appear in the DOM as a custom attribute, spell it as lowercase `activekey` instead. If you accidentally passed it from a parent component, remove it from the DOM element.```

and

```Warning: React does not recognize the `activeHref` prop on a DOM element. If you intentionally want it to appear in the DOM as a custom attribute, spell it as lowercase `activehref` instead. If you accidentally passed it from a parent component, remove it from the DOM element.```

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
