### PR TITLE
Implement events index template

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/indexer/EventsIndexMapping.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/EventsIndexMapping.java
@@ -1,0 +1,223 @@
+/**
+ * This file is part of Graylog.
+ *
+ * Graylog is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.graylog2.indexer;
+
+import com.github.zafarkhaja.semver.Version;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+import org.graylog2.indexer.indexset.IndexSetConfig;
+
+import java.util.Map;
+
+public class EventsIndexMapping implements IndexMappingTemplate {
+    private final Version elasticsearchVersion;
+
+    EventsIndexMapping(Version elasticsearchVersion) {
+        this.elasticsearchVersion = elasticsearchVersion;
+    }
+
+    @Override
+    public Map<String, Object> toTemplate(IndexSetConfig indexSetConfig, String indexPattern, int order) {
+        final String indexPatternsField;
+        final Object indexPatternsValue;
+
+        if (elasticsearchVersion.satisfies("^5.0.0")) {
+            indexPatternsField = "template";
+            indexPatternsValue = indexPattern;
+        } else if (elasticsearchVersion.satisfies("^6.0.0")) {
+            indexPatternsField = "index_patterns";
+            indexPatternsValue = ImmutableSet.of(indexPattern);
+        } else {
+            throw new ElasticsearchException("Unsupported Elasticsearch version: " + elasticsearchVersion);
+        }
+
+        final String indexRefreshInterval = "1s"; // TODO: Index refresh interval must be configurable
+
+        return map()
+                .put(indexPatternsField, indexPatternsValue)
+                .put("order", order)
+                .put("settings", map()
+                        .put("index.refresh_interval", indexRefreshInterval)
+                        .build())
+                .put("mappings", map()
+                        .put(IndexMapping.TYPE_MESSAGE, map() // TODO: Type name is "message" because the index field type poller is using that
+                                .put("_source", map()
+                                        .put("enabled", true)
+                                        .build())
+                                .put("dynamic", false)
+                                .put("dynamic_templates", list()
+                                        .add(map()
+                                                .put("fields", map()
+                                                        .put("path_match", "fields.*")
+                                                        .put("mapping", map()
+                                                                .put("type", "keyword")
+                                                                .put("doc_values", true)
+                                                                .put("index", true)
+                                                                .build())
+                                                        .build())
+                                                .build())
+                                        /* TODO: Enable the typed fields once we decided if that's the way to go
+                                        .add(map()
+                                                .put("fields-typed-long", map()
+                                                        .put("path_match", "fields_typed.long.*")
+                                                        .put("mapping", map()
+                                                                .put("type", "long")
+                                                                .put("doc_values", true)
+                                                                .put("index", true)
+                                                                .build())
+                                                        .build())
+                                                .build())
+                                        .add(map()
+                                                .put("fields-typed-double", map()
+                                                        .put("path_match", "fields_typed.double.*")
+                                                        .put("mapping", map()
+                                                                .put("type", "double")
+                                                                .put("doc_values", true)
+                                                                .put("index", true)
+                                                                .build())
+                                                        .build())
+                                                .build())
+                                        .add(map()
+                                                .put("fields-typed-boolean", map()
+                                                        .put("path_match", "fields_typed.boolean.*")
+                                                        .put("mapping", map()
+                                                                .put("type", "boolean")
+                                                                .put("doc_values", true)
+                                                                .put("index", true)
+                                                                .build())
+                                                        .build())
+                                                .build())
+                                        .add(map()
+                                                .put("fields-typed-ip", map()
+                                                        .put("path_match", "fields_typed.ip.*")
+                                                        .put("mapping", map()
+                                                                .put("type", "ip")
+                                                                .put("doc_values", true)
+                                                                .put("index", true)
+                                                                .build())
+                                                        .build())
+                                                .build())
+                                         */
+                                        .build())
+                                .put("properties", map()
+                                        .put("id", map()
+                                                .put("type", "keyword")
+                                                .build())
+                                        .put("creator_type", map()
+                                                .put("type", "keyword")
+                                                .build())
+                                        .put("creator_id", map()
+                                                .put("type", "keyword")
+                                                .build())
+                                        .put("timestamp", map()
+                                                .put("type", "date")
+                                                // Use the same format we use for the "message" mapping to make sure we
+                                                // can use the search.
+                                                .put("format", "yyyy-MM-dd HH:mm:ss.SSS")
+                                                .build())
+                                        .put("timestamp_processing", map()
+                                                .put("type", "date")
+                                                // Use the same format we use for the "message" mapping to make sure we
+                                                // can use the search.
+                                                .put("format", "yyyy-MM-dd HH:mm:ss.SSS")
+                                                .build())
+                                        .put("timerange_start", map()
+                                                .put("type", "date")
+                                                // Use the same format we use for the "message" mapping to make sure we
+                                                // can use the search.
+                                                .put("format", "yyyy-MM-dd HH:mm:ss.SSS")
+                                                .build())
+                                        .put("timerange_end", map()
+                                                .put("type", "date")
+                                                // Use the same format we use for the "message" mapping to make sure we
+                                                // can use the search.
+                                                .put("format", "yyyy-MM-dd HH:mm:ss.SSS")
+                                                .build())
+                                        .put("streams", map()
+                                                .put("type", "keyword")
+                                                .build())
+                                        .put("message", map()
+                                                .put("type", "text")
+                                                .put("analyzer", "standard")
+                                                .put("norms", false)
+                                                .put("fields", map()
+                                                        .put("keyword", map()
+                                                                .put("type", "keyword")
+                                                                .build())
+                                                        .build())
+                                                .build())
+                                        .put("source", map()
+                                                .put("type", "keyword")
+                                                .build())
+                                        .put("key", map()
+                                                .put("type", "keyword")
+                                                .build())
+                                        .put("key_tuple", map()
+                                                .put("type", "keyword")
+                                                .build())
+                                        .put("priority", map()
+                                                .put("type", "long")
+                                                .build())
+                                        .put("fields", map()
+                                                .put("type", "object")
+                                                .put("dynamic", true)
+                                                .build())
+                                        /* TODO: Enable the typed fields once we decided if that's the way to go
+                                        .put("fields_typed", map()
+                                                .put("type", "object")
+                                                .put("properties", map()
+                                                        .put("long", map()
+                                                                .put("type", "object")
+                                                                .put("dynamic", true)
+                                                                .build())
+                                                        .put("double", map()
+                                                                .put("type", "object")
+                                                                .put("dynamic", true)
+                                                                .build())
+                                                        .put("boolean", map()
+                                                                .put("type", "object")
+                                                                .put("dynamic", true)
+                                                                .build())
+                                                        .put("ip", map()
+                                                                .put("type", "object")
+                                                                .put("dynamic", true)
+                                                                .build())
+                                                        .build())
+                                                .build())
+                                         */
+                                        .put("triggered_tasks", map()
+                                                .put("type", "keyword")
+                                                .build())
+                                        .build())
+                                .build())
+                        .build())
+                .build();
+    }
+
+    private ImmutableMap.Builder<String, Object> map() {
+        return ImmutableMap.builder();
+    }
+
+    private ImmutableList.Builder<Object> list() {
+        return ImmutableList.builder();
+    }
+
+    private ImmutableSet.Builder<Object> set() {
+        return ImmutableSet.builder();
+    }
+}

--- a/graylog2-server/src/main/java/org/graylog2/indexer/EventsIndexMapping.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/EventsIndexMapping.java
@@ -21,6 +21,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import org.graylog2.indexer.indexset.IndexSetConfig;
+import org.graylog2.plugin.Tools;
 
 import java.util.Map;
 
@@ -128,25 +129,25 @@ public class EventsIndexMapping implements IndexMappingTemplate {
                                                 .put("type", "date")
                                                 // Use the same format we use for the "message" mapping to make sure we
                                                 // can use the search.
-                                                .put("format", "yyyy-MM-dd HH:mm:ss.SSS")
+                                                .put("format", Tools.ES_DATE_FORMAT)
                                                 .build())
                                         .put("timestamp_processing", map()
                                                 .put("type", "date")
                                                 // Use the same format we use for the "message" mapping to make sure we
                                                 // can use the search.
-                                                .put("format", "yyyy-MM-dd HH:mm:ss.SSS")
+                                                .put("format", Tools.ES_DATE_FORMAT)
                                                 .build())
                                         .put("timerange_start", map()
                                                 .put("type", "date")
                                                 // Use the same format we use for the "message" mapping to make sure we
                                                 // can use the search.
-                                                .put("format", "yyyy-MM-dd HH:mm:ss.SSS")
+                                                .put("format", Tools.ES_DATE_FORMAT)
                                                 .build())
                                         .put("timerange_end", map()
                                                 .put("type", "date")
                                                 // Use the same format we use for the "message" mapping to make sure we
                                                 // can use the search.
-                                                .put("format", "yyyy-MM-dd HH:mm:ss.SSS")
+                                                .put("format", Tools.ES_DATE_FORMAT)
                                                 .build())
                                         .put("streams", map()
                                                 .put("type", "keyword")

--- a/graylog2-server/src/main/java/org/graylog2/indexer/IndexMapping.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/IndexMapping.java
@@ -18,6 +18,7 @@ package org.graylog2.indexer;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
+import org.graylog2.indexer.indexset.IndexSetConfig;
 import org.graylog2.plugin.Tools;
 
 import java.util.List;
@@ -27,8 +28,13 @@ import java.util.Map;
  * Representing the message type mapping in Elasticsearch. This is giving ES more
  * information about what the fields look like and how it should analyze them.
  */
-public abstract class IndexMapping {
+public abstract class IndexMapping implements IndexMappingTemplate {
     public static final String TYPE_MESSAGE = "message";
+
+    @Override
+    public Map<String, Object> toTemplate(IndexSetConfig indexSetConfig, String indexPattern, int order) {
+        return messageTemplate(indexPattern, indexSetConfig.indexAnalyzer(), order);
+    }
 
     public Map<String, Object> messageTemplate(final String template, final String analyzer) {
         return messageTemplate(template, analyzer, -1);

--- a/graylog2-server/src/main/java/org/graylog2/indexer/IndexMappingFactory.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/IndexMappingFactory.java
@@ -18,6 +18,7 @@ package org.graylog2.indexer;
 
 import com.github.zafarkhaja.semver.Version;
 import org.graylog2.indexer.cluster.Node;
+import org.graylog2.indexer.indexset.IndexSetConfig;
 
 import javax.inject.Inject;
 import javax.inject.Singleton;
@@ -31,8 +32,13 @@ public class IndexMappingFactory {
         this.node = node;
     }
 
-    public IndexMapping createIndexMapping() {
+    public IndexMappingTemplate createIndexMapping(String templateType) {
         final Version elasticsearchVersion = node.getVersion().orElseThrow(() -> new ElasticsearchException("Unable to retrieve Elasticsearch version."));
+
+        if (IndexSetConfig.INDEX_TEMPLATE_TYPE_EVENTS.equals(templateType)) {
+            return new EventsIndexMapping(elasticsearchVersion);
+        }
+
         if (elasticsearchVersion.satisfies("^5.0.0")) {
             return new IndexMapping5();
         } else if (elasticsearchVersion.satisfies("^6.0.0")) {

--- a/graylog2-server/src/main/java/org/graylog2/indexer/IndexMappingFactory.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/IndexMappingFactory.java
@@ -32,10 +32,10 @@ public class IndexMappingFactory {
         this.node = node;
     }
 
-    public IndexMappingTemplate createIndexMapping(String templateType) {
+    public IndexMappingTemplate createIndexMapping(IndexSetConfig.TemplateType templateType) {
         final Version elasticsearchVersion = node.getVersion().orElseThrow(() -> new ElasticsearchException("Unable to retrieve Elasticsearch version."));
 
-        if (IndexSetConfig.INDEX_TEMPLATE_TYPE_EVENTS.equals(templateType)) {
+        if (IndexSetConfig.TemplateType.EVENTS.equals(templateType)) {
             return new EventsIndexMapping(elasticsearchVersion);
         }
 

--- a/graylog2-server/src/main/java/org/graylog2/indexer/IndexMappingTemplate.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/IndexMappingTemplate.java
@@ -1,0 +1,47 @@
+/**
+ * This file is part of Graylog.
+ *
+ * Graylog is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.graylog2.indexer;
+
+import org.graylog2.indexer.indexset.IndexSetConfig;
+
+import java.util.Map;
+
+/**
+ * Implementing classes provide an index mapping template representation that can be stored in Elasticsearch.
+ */
+public interface IndexMappingTemplate {
+    /**
+     * Returns the index template as a map.
+     *
+     * @param indexSetConfig the index set configuration
+     * @param indexPattern   the index pattern the returned template should be applied to
+     * @param order          the order value of the index template
+     * @return the index template
+     */
+    Map<String, Object> toTemplate(IndexSetConfig indexSetConfig, String indexPattern, int order);
+
+    /**
+     * Returns the index template as a map. (with an default order of -1)
+     *
+     * @param indexSetConfig the index set configuration
+     * @param indexPattern   the index pattern the returned template should be applied to
+     * @return the index template
+     */
+    default Map<String, Object> toTemplate(IndexSetConfig indexSetConfig, String indexPattern) {
+        return toTemplate(indexSetConfig, indexPattern, -1);
+    }
+}

--- a/graylog2-server/src/main/java/org/graylog2/indexer/indexset/IndexSetConfig.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/indexset/IndexSetConfig.java
@@ -35,6 +35,7 @@ import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.NotNull;
 import javax.validation.constraints.Pattern;
 import java.time.ZonedDateTime;
+import java.util.Optional;
 
 import static com.google.common.base.Strings.isNullOrEmpty;
 
@@ -50,7 +51,7 @@ public abstract class IndexSetConfig implements Comparable<IndexSetConfig> {
     public static final String INDEX_PREFIX_REGEX = "^[a-z0-9][a-z0-9_+-]*$";
 
     private static final Duration DEFAULT_FIELD_TYPE_REFRESH_INTERVAL = Duration.standardSeconds(5L);
-    private static final TemplateType DEFAULT_INDEX_TEMPLATE_TYPE = TemplateType.MESSAGES;
+    public static final TemplateType DEFAULT_INDEX_TEMPLATE_TYPE = TemplateType.MESSAGES;
 
     public enum TemplateType {
         @JsonProperty("messages")
@@ -127,7 +128,7 @@ public abstract class IndexSetConfig implements Comparable<IndexSetConfig> {
 
     @JsonProperty("index_template_type")
     @NotBlank
-    public abstract TemplateType indexTemplateType();
+    public abstract Optional<TemplateType> indexTemplateType();
 
     @JsonProperty("index_optimization_max_num_segments")
     @Min(1L)
@@ -161,8 +162,6 @@ public abstract class IndexSetConfig implements Comparable<IndexSetConfig> {
                                         @JsonProperty("index_optimization_disabled") @Nullable Boolean indexOptimizationDisabled,
                                         @JsonProperty("field_type_refresh_interval") @Nullable Duration fieldTypeRefreshInterval) {
 
-        final TemplateType templateType = indexTemplateType == null ? DEFAULT_INDEX_TEMPLATE_TYPE : indexTemplateType;
-
         final boolean writableValue = isWritable == null ? true : isWritable;
 
         Duration fieldTypeRefreshIntervalValue = fieldTypeRefreshInterval;
@@ -188,7 +187,7 @@ public abstract class IndexSetConfig implements Comparable<IndexSetConfig> {
                 .creationDate(creationDate)
                 .indexAnalyzer(isNullOrEmpty(indexAnalyzer) ? "standard" : indexAnalyzer)
                 .indexTemplateName(isNullOrEmpty(indexTemplateName) ? indexPrefix + "-template" : indexTemplateName)
-                .indexTemplateType(templateType)
+                .indexTemplateType(indexTemplateType)
                 .indexOptimizationMaxNumSegments(maxNumSegments == null ? 1 : maxNumSegments)
                 .indexOptimizationDisabled(indexOptimizationDisabled == null ? false : indexOptimizationDisabled)
                 .fieldTypeRefreshInterval(fieldTypeRefreshIntervalValue)
@@ -304,7 +303,6 @@ public abstract class IndexSetConfig implements Comparable<IndexSetConfig> {
         return new AutoValue_IndexSetConfig.Builder()
                 // Index sets are writable by default.
                 .isWritable(true)
-                .indexTemplateType(DEFAULT_INDEX_TEMPLATE_TYPE)
                 .fieldTypeRefreshInterval(DEFAULT_FIELD_TYPE_REFRESH_INTERVAL);
     }
 
@@ -342,7 +340,7 @@ public abstract class IndexSetConfig implements Comparable<IndexSetConfig> {
 
         public abstract Builder indexTemplateName(String templateName);
 
-        public abstract Builder indexTemplateType(TemplateType templateType);
+        public abstract Builder indexTemplateType(@Nullable TemplateType templateType);
 
         public abstract Builder indexOptimizationMaxNumSegments(int indexOptimizationMaxNumSegments);
 

--- a/graylog2-server/src/main/java/org/graylog2/indexer/indexset/IndexSetConfig.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/indexset/IndexSetConfig.java
@@ -50,6 +50,7 @@ public abstract class IndexSetConfig implements Comparable<IndexSetConfig> {
     public static final String INDEX_PREFIX_REGEX = "^[a-z0-9][a-z0-9_+-]*$";
 
     private static final Duration DEFAULT_FIELD_TYPE_REFRESH_INTERVAL = Duration.standardSeconds(5L);
+    private static final String DEFAULT_INDEX_TEMPLATE_TYPE = "messages";
 
     @JsonProperty("id")
     @Nullable
@@ -117,6 +118,10 @@ public abstract class IndexSetConfig implements Comparable<IndexSetConfig> {
     @NotBlank
     public abstract String indexTemplateName();
 
+    @JsonProperty("index_template_type")
+    @NotBlank
+    public abstract String indexTemplateType();
+
     @JsonProperty("index_optimization_max_num_segments")
     @Min(1L)
     public abstract int indexOptimizationMaxNumSegments();
@@ -144,6 +149,7 @@ public abstract class IndexSetConfig implements Comparable<IndexSetConfig> {
                                         @JsonProperty(FIELD_CREATION_DATE) @NotNull ZonedDateTime creationDate,
                                         @JsonProperty("index_analyzer") @Nullable String indexAnalyzer,
                                         @JsonProperty("index_template_name") @Nullable String indexTemplateName,
+                                        @JsonProperty("index_template_type") @Nullable String indexTemplateType,
                                         @JsonProperty("index_optimization_max_num_segments") @Nullable Integer maxNumSegments,
                                         @JsonProperty("index_optimization_disabled") @Nullable Boolean indexOptimizationDisabled,
                                         @JsonProperty("field_type_refresh_interval") @Nullable Duration fieldTypeRefreshInterval) {
@@ -173,6 +179,7 @@ public abstract class IndexSetConfig implements Comparable<IndexSetConfig> {
                 .creationDate(creationDate)
                 .indexAnalyzer(isNullOrEmpty(indexAnalyzer) ? "standard" : indexAnalyzer)
                 .indexTemplateName(isNullOrEmpty(indexTemplateName) ? indexPrefix + "-template" : indexTemplateName)
+                .indexTemplateType(isNullOrEmpty(indexTemplateType) ? DEFAULT_INDEX_TEMPLATE_TYPE : indexTemplateType)
                 .indexOptimizationMaxNumSegments(maxNumSegments == null ? 1 : maxNumSegments)
                 .indexOptimizationDisabled(indexOptimizationDisabled == null ? false : indexOptimizationDisabled)
                 .fieldTypeRefreshInterval(fieldTypeRefreshIntervalValue)
@@ -193,12 +200,13 @@ public abstract class IndexSetConfig implements Comparable<IndexSetConfig> {
                                         ZonedDateTime creationDate,
                                         String indexAnalyzer,
                                         String indexTemplateName,
+                                        String indexTemplateType,
                                         int indexOptimizationMaxNumSegments,
                                         boolean indexOptimizationDisabled,
                                         Duration fieldTypeRefreshInterval) {
         return create(id, title, description, isWritable, indexPrefix, null, null, shards, replicas,
                 rotationStrategyClass, rotationStrategy, retentionStrategyClass, retentionStrategy, creationDate,
-                indexAnalyzer, indexTemplateName, indexOptimizationMaxNumSegments, indexOptimizationDisabled,
+                indexAnalyzer, indexTemplateName, indexTemplateType, indexOptimizationMaxNumSegments, indexOptimizationDisabled,
                 fieldTypeRefreshInterval);
     }
 
@@ -215,12 +223,13 @@ public abstract class IndexSetConfig implements Comparable<IndexSetConfig> {
                                         ZonedDateTime creationDate,
                                         String indexAnalyzer,
                                         String indexTemplateName,
+                                        String indexTemplateType,
                                         int indexOptimizationMaxNumSegments,
                                         boolean indexOptimizationDisabled,
                                         Duration fieldTypeRefreshInterval) {
         return create(null, title, description, isWritable, indexPrefix, null, null, shards, replicas,
                 rotationStrategyClass, rotationStrategy, retentionStrategyClass, retentionStrategy, creationDate,
-                indexAnalyzer, indexTemplateName, indexOptimizationMaxNumSegments, indexOptimizationDisabled,
+                indexAnalyzer, indexTemplateName, indexTemplateType, indexOptimizationMaxNumSegments, indexOptimizationDisabled,
                 fieldTypeRefreshInterval);
     }
 
@@ -239,11 +248,12 @@ public abstract class IndexSetConfig implements Comparable<IndexSetConfig> {
                                         ZonedDateTime creationDate,
                                         String indexAnalyzer,
                                         String indexTemplateName,
+                                        String indexTemplateType,
                                         int indexOptimizationMaxNumSegments,
                                         boolean indexOptimizationDisabled) {
         return create(id, title, description, isWritable, indexPrefix, null, null, shards, replicas,
                 rotationStrategyClass, rotationStrategy, retentionStrategyClass, retentionStrategy, creationDate,
-                indexAnalyzer, indexTemplateName, indexOptimizationMaxNumSegments, indexOptimizationDisabled,
+                indexAnalyzer, indexTemplateName, indexTemplateType, indexOptimizationMaxNumSegments, indexOptimizationDisabled,
                 DEFAULT_FIELD_TYPE_REFRESH_INTERVAL);
     }
 
@@ -261,11 +271,12 @@ public abstract class IndexSetConfig implements Comparable<IndexSetConfig> {
                                         ZonedDateTime creationDate,
                                         String indexAnalyzer,
                                         String indexTemplateName,
+                                        String indexTemplateType,
                                         int indexOptimizationMaxNumSegments,
                                         boolean indexOptimizationDisabled) {
         return create(null, title, description, isWritable, indexPrefix, null, null, shards, replicas,
                 rotationStrategyClass, rotationStrategy, retentionStrategyClass, retentionStrategy, creationDate,
-                indexAnalyzer, indexTemplateName, indexOptimizationMaxNumSegments, indexOptimizationDisabled,
+                indexAnalyzer, indexTemplateName, indexTemplateType, indexOptimizationMaxNumSegments, indexOptimizationDisabled,
                 DEFAULT_FIELD_TYPE_REFRESH_INTERVAL);
     }
 
@@ -284,6 +295,7 @@ public abstract class IndexSetConfig implements Comparable<IndexSetConfig> {
         return new AutoValue_IndexSetConfig.Builder()
                 // Index sets are writable by default.
                 .isWritable(true)
+                .indexTemplateType(DEFAULT_INDEX_TEMPLATE_TYPE)
                 .fieldTypeRefreshInterval(DEFAULT_FIELD_TYPE_REFRESH_INTERVAL);
     }
 
@@ -320,6 +332,8 @@ public abstract class IndexSetConfig implements Comparable<IndexSetConfig> {
         public abstract Builder indexAnalyzer(String analyzer);
 
         public abstract Builder indexTemplateName(String templateName);
+
+        public abstract Builder indexTemplateType(String templateType);
 
         public abstract Builder indexOptimizationMaxNumSegments(int indexOptimizationMaxNumSegments);
 

--- a/graylog2-server/src/main/java/org/graylog2/indexer/indexset/IndexSetConfig.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/indexset/IndexSetConfig.java
@@ -53,9 +53,11 @@ public abstract class IndexSetConfig implements Comparable<IndexSetConfig> {
     public static final String INDEX_PREFIX_REGEX = "^[a-z0-9][a-z0-9_+-]*$";
 
     private static final Duration DEFAULT_FIELD_TYPE_REFRESH_INTERVAL = Duration.standardSeconds(5L);
-    public static final String DEFAULT_INDEX_TEMPLATE_TYPE = "messages";
 
-    private static final Set<String> AVAILABLE_INDEX_TEMPLATE_TYPES = ImmutableSet.of(DEFAULT_INDEX_TEMPLATE_TYPE, "events");
+    private static final String INDEX_TEMPLATE_TYPE_MESSAGES = "messages";
+    public static final String INDEX_TEMPLATE_TYPE_EVENTS = "events";
+    private static final String DEFAULT_INDEX_TEMPLATE_TYPE = INDEX_TEMPLATE_TYPE_MESSAGES;
+    private static final Set<String> AVAILABLE_INDEX_TEMPLATE_TYPES = ImmutableSet.of(INDEX_TEMPLATE_TYPE_MESSAGES, INDEX_TEMPLATE_TYPE_EVENTS);
 
     private static Consumer<String> INDEX_TEMPLATE_TYPE_VALIDATOR = (indexTemplateType) -> {
         if (!AVAILABLE_INDEX_TEMPLATE_TYPES.contains(indexTemplateType)) {

--- a/graylog2-server/src/main/java/org/graylog2/indexer/indices/Indices.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/indices/Indices.java
@@ -71,6 +71,7 @@ import org.graylog2.audit.AuditEventSender;
 import org.graylog2.indexer.ElasticsearchException;
 import org.graylog2.indexer.IndexMapping;
 import org.graylog2.indexer.IndexMappingFactory;
+import org.graylog2.indexer.IndexMappingTemplate;
 import org.graylog2.indexer.IndexNotFoundException;
 import org.graylog2.indexer.IndexSet;
 import org.graylog2.indexer.cluster.jest.JestUtils;
@@ -360,8 +361,8 @@ public class Indices {
     public void ensureIndexTemplate(IndexSet indexSet) {
         final IndexSetConfig indexSetConfig = indexSet.getConfig();
         final String templateName = indexSetConfig.indexTemplateName();
-        final IndexMapping indexMapping = indexMappingFactory.createIndexMapping();
-        final Map<String, Object> template = indexMapping.messageTemplate(indexSet.getIndexWildcard(), indexSetConfig.indexAnalyzer(), -1);
+        final IndexMappingTemplate indexMapping = indexMappingFactory.createIndexMapping(indexSetConfig.indexTemplateType());
+        final Map<String, Object> template = indexMapping.toTemplate(indexSetConfig, indexSet.getIndexWildcard(), -1);
 
         final PutTemplate request = new PutTemplate.Builder(templateName, template).build();
 
@@ -380,9 +381,8 @@ public class Indices {
      */
     public Map<String, Object> getIndexTemplate(IndexSet indexSet) {
         final String indexWildcard = indexSet.getIndexWildcard();
-        final String analyzer = indexSet.getConfig().indexAnalyzer();
 
-        return indexMappingFactory.createIndexMapping().messageTemplate(indexWildcard, analyzer);
+        return indexMappingFactory.createIndexMapping(indexSet.getConfig().indexTemplateType()).toTemplate(indexSet.getConfig(), indexWildcard);
     }
 
     public void deleteIndexTemplate(IndexSet indexSet) {

--- a/graylog2-server/src/main/java/org/graylog2/indexer/indices/Indices.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/indices/Indices.java
@@ -361,7 +361,7 @@ public class Indices {
     public void ensureIndexTemplate(IndexSet indexSet) {
         final IndexSetConfig indexSetConfig = indexSet.getConfig();
         final String templateName = indexSetConfig.indexTemplateName();
-        final IndexMappingTemplate indexMapping = indexMappingFactory.createIndexMapping(indexSetConfig.indexTemplateType());
+        final IndexMappingTemplate indexMapping = indexMappingFactory.createIndexMapping(indexSetConfig.indexTemplateType().orElse(IndexSetConfig.DEFAULT_INDEX_TEMPLATE_TYPE));
         final Map<String, Object> template = indexMapping.toTemplate(indexSetConfig, indexSet.getIndexWildcard(), -1);
 
         final PutTemplate request = new PutTemplate.Builder(templateName, template).build();
@@ -382,7 +382,7 @@ public class Indices {
     public Map<String, Object> getIndexTemplate(IndexSet indexSet) {
         final String indexWildcard = indexSet.getIndexWildcard();
 
-        return indexMappingFactory.createIndexMapping(indexSet.getConfig().indexTemplateType()).toTemplate(indexSet.getConfig(), indexWildcard);
+        return indexMappingFactory.createIndexMapping(indexSet.getConfig().indexTemplateType().orElse(IndexSetConfig.DEFAULT_INDEX_TEMPLATE_TYPE)).toTemplate(indexSet.getConfig(), indexWildcard);
     }
 
     public void deleteIndexTemplate(IndexSet indexSet) {

--- a/graylog2-server/src/test/java/org/graylog2/indexer/EventsIndexMappingTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/indexer/EventsIndexMappingTest.java
@@ -1,0 +1,172 @@
+/**
+ * This file is part of Graylog.
+ *
+ * Graylog is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.graylog2.indexer;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.github.zafarkhaja.semver.Version;
+import com.jayway.jsonpath.Configuration;
+import com.jayway.jsonpath.DocumentContext;
+import com.jayway.jsonpath.JsonPath;
+import com.jayway.jsonpath.Option;
+import com.jayway.jsonpath.spi.json.JacksonJsonProvider;
+import com.jayway.jsonpath.spi.json.JsonProvider;
+import com.jayway.jsonpath.spi.mapper.JacksonMappingProvider;
+import com.jayway.jsonpath.spi.mapper.MappingProvider;
+import com.revinate.assertj.json.JsonPathAssert;
+import org.graylog2.indexer.indexset.IndexSetConfig;
+import org.graylog2.shared.bindings.providers.ObjectMapperProvider;
+import org.junit.BeforeClass;
+import org.junit.Rule;
+import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnit;
+import org.mockito.junit.MockitoRule;
+
+import java.util.Collections;
+import java.util.EnumSet;
+import java.util.Map;
+import java.util.Set;
+import java.util.function.Consumer;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+public class EventsIndexMappingTest {
+    @Rule
+    public final MockitoRule mockitoRule = MockitoJUnit.rule();
+
+    @Mock
+    private IndexSetConfig indexSetConfig;
+
+    private static final ObjectMapper objectMapper = new ObjectMapperProvider().get();
+
+    @BeforeClass
+    public static void classSetUp() {
+        Configuration.setDefaults(new Configuration.Defaults() {
+            private final JsonProvider jsonProvider = new JacksonJsonProvider(objectMapper);
+            private final MappingProvider mappingProvider = new JacksonMappingProvider(objectMapper);
+
+            @Override
+            public JsonProvider jsonProvider() {
+                return jsonProvider;
+            }
+
+            @Override
+            public Set<Option> options() {
+                return EnumSet.noneOf(Option.class);
+            }
+
+            @Override
+            public MappingProvider mappingProvider() {
+                return mappingProvider;
+            }
+        });
+    }
+
+    private void assertJsonPath(Map<String, Object> map, Consumer<JsonPathAssert> consumer) throws Exception {
+        final DocumentContext context = JsonPath.parse(objectMapper.writeValueAsString(map));
+        final JsonPathAssert jsonPathAssert = JsonPathAssert.assertThat(context);
+
+        consumer.accept(jsonPathAssert);
+    }
+
+    private void assertStandardMappingValues(JsonPathAssert at) {
+        at.jsonPathAsString("$.settings['index.refresh_interval']").isEqualTo("1s");
+
+        at.jsonPathAsBoolean("$.mappings.message._source.enabled").isTrue();
+        at.jsonPathAsBoolean("$.mappings.message.dynamic").isFalse();
+
+        at.jsonPathAsString("$.mappings.message.dynamic_templates[0]fields.path_match").isEqualTo("fields.*");
+        at.jsonPathAsString("$.mappings.message.dynamic_templates[0]fields.mapping.type").isEqualTo("keyword");
+        at.jsonPathAsBoolean("$.mappings.message.dynamic_templates[0]fields.mapping.doc_values").isTrue();
+        at.jsonPathAsBoolean("$.mappings.message.dynamic_templates[0]fields.mapping.index").isTrue();
+
+        at.jsonPathAsString("$.mappings.message.properties.id.type").isEqualTo("keyword");
+        at.jsonPathAsString("$.mappings.message.properties.creator_type.type").isEqualTo("keyword");
+        at.jsonPathAsString("$.mappings.message.properties.creator_id.type").isEqualTo("keyword");
+        at.jsonPathAsString("$.mappings.message.properties.timestamp.type").isEqualTo("date");
+        at.jsonPathAsString("$.mappings.message.properties.timestamp.format").isEqualTo("yyyy-MM-dd HH:mm:ss.SSS");
+        at.jsonPathAsString("$.mappings.message.properties.timestamp_processing.type").isEqualTo("date");
+        at.jsonPathAsString("$.mappings.message.properties.timestamp_processing.format").isEqualTo("yyyy-MM-dd HH:mm:ss.SSS");
+        at.jsonPathAsString("$.mappings.message.properties.timerange_start.type").isEqualTo("date");
+        at.jsonPathAsString("$.mappings.message.properties.timerange_start.format").isEqualTo("yyyy-MM-dd HH:mm:ss.SSS");
+        at.jsonPathAsString("$.mappings.message.properties.timerange_end.type").isEqualTo("date");
+        at.jsonPathAsString("$.mappings.message.properties.timerange_end.format").isEqualTo("yyyy-MM-dd HH:mm:ss.SSS");
+        at.jsonPathAsString("$.mappings.message.properties.streams.type").isEqualTo("keyword");
+        at.jsonPathAsString("$.mappings.message.properties.message.type").isEqualTo("text");
+        at.jsonPathAsString("$.mappings.message.properties.message.analyzer").isEqualTo("standard");
+        at.jsonPathAsBoolean("$.mappings.message.properties.message.norms").isFalse();
+        at.jsonPathAsString("$.mappings.message.properties.message.fields.keyword.type").isEqualTo("keyword");
+        at.jsonPathAsString("$.mappings.message.properties.source.type").isEqualTo("keyword");
+        at.jsonPathAsString("$.mappings.message.properties.key.type").isEqualTo("keyword");
+        at.jsonPathAsString("$.mappings.message.properties.key_tuple.type").isEqualTo("keyword");
+        at.jsonPathAsString("$.mappings.message.properties.priority.type").isEqualTo("long");
+        at.jsonPathAsString("$.mappings.message.properties.fields.type").isEqualTo("object");
+        at.jsonPathAsBoolean("$.mappings.message.properties.fields.dynamic").isTrue();
+        at.jsonPathAsString("$.mappings.message.properties.triggered_tasks.type").isEqualTo("keyword");
+    }
+
+    @Test
+    public void templateWithES5() throws Exception {
+        final EventsIndexMapping mapping = new EventsIndexMapping(Version.valueOf("5.0.0"));
+
+        assertJsonPath(mapping.toTemplate(indexSetConfig, "test_*"), at -> {
+            at.jsonPathAsString("$.template").isEqualTo("test_*");
+            at.jsonPathAsInteger("$.order").isEqualTo(-1);
+            assertStandardMappingValues(at);
+        });
+
+        assertJsonPath(mapping.toTemplate(indexSetConfig, "test_*", 23), at -> {
+            at.jsonPathAsString("$.template").isEqualTo("test_*");
+            at.jsonPathAsInteger("$.order").isEqualTo(23);
+            assertStandardMappingValues(at);
+        });
+    }
+
+    @Test
+    public void templateWithES6() throws Exception {
+        final EventsIndexMapping mapping = new EventsIndexMapping(Version.valueOf("6.0.0"));
+
+        assertJsonPath(mapping.toTemplate(indexSetConfig, "test_*"), at -> {
+            at.jsonPathAsListOf("$.index_patterns", String.class).isEqualTo(Collections.singletonList("test_*"));
+            at.jsonPathAsInteger("$.order").isEqualTo(-1);
+            assertStandardMappingValues(at);
+        });
+
+        assertJsonPath(mapping.toTemplate(indexSetConfig, "test_*", 42), at -> {
+            at.jsonPathAsListOf("$.index_patterns", String.class).isEqualTo(Collections.singletonList("test_*"));
+            at.jsonPathAsInteger("$.order").isEqualTo(42);
+            assertStandardMappingValues(at);
+        });
+    }
+
+    @Test
+    public void templateWithUnsupportedESVersions() {
+        final String indexPattern = "test_*";
+
+        assertThatThrownBy(() -> new EventsIndexMapping(Version.valueOf("8.0.0")).toTemplate(indexSetConfig, indexPattern))
+                .isInstanceOf(ElasticsearchException.class)
+                .hasMessageContaining("Unsupported Elasticsearch version: 8.0.0");
+
+        assertThatThrownBy(() -> new EventsIndexMapping(Version.valueOf("7.0.0")).toTemplate(indexSetConfig, indexPattern))
+                .isInstanceOf(ElasticsearchException.class)
+                .hasMessageContaining("Unsupported Elasticsearch version: 7.0.0");
+
+        assertThatThrownBy(() -> new EventsIndexMapping(Version.valueOf("2.4.0")).toTemplate(indexSetConfig, indexPattern))
+                .isInstanceOf(ElasticsearchException.class)
+                .hasMessageContaining("Unsupported Elasticsearch version: 2.4.0");
+    }
+}

--- a/graylog2-server/src/test/java/org/graylog2/indexer/IndexMappingFactoryTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/indexer/IndexMappingFactoryTest.java
@@ -18,6 +18,7 @@ package org.graylog2.indexer;
 
 import com.github.zafarkhaja.semver.Version;
 import org.graylog2.indexer.cluster.Node;
+import org.graylog2.indexer.indexset.IndexSetConfig;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -55,7 +56,7 @@ public class IndexMappingFactoryTest {
     public void createIndexMappingFailsIfElasticsearch1VersionIsTooLow() throws Exception {
         when(node.getVersion()).thenReturn(Optional.of(Version.valueOf("1.7.3")));
 
-        assertThatThrownBy(() -> indexMappingFactory.createIndexMapping("messages"))
+        assertThatThrownBy(() -> indexMappingFactory.createIndexMapping(IndexSetConfig.TemplateType.MESSAGES))
                 .isInstanceOf(ElasticsearchException.class)
                 .hasMessageStartingWith("Unsupported Elasticsearch version: 1.7.3")
                 .hasNoCause();
@@ -65,7 +66,7 @@ public class IndexMappingFactoryTest {
     public void createIndexMappingFailsIfElasticsearch2VersionIsTooLow() throws Exception {
         when(node.getVersion()).thenReturn(Optional.of(Version.valueOf("2.0.0")));
 
-        assertThatThrownBy(() -> indexMappingFactory.createIndexMapping("messages"))
+        assertThatThrownBy(() -> indexMappingFactory.createIndexMapping(IndexSetConfig.TemplateType.MESSAGES))
                 .isInstanceOf(ElasticsearchException.class)
                 .hasMessageStartingWith("Unsupported Elasticsearch version: 2.0.0")
                 .hasNoCause();
@@ -75,7 +76,7 @@ public class IndexMappingFactoryTest {
     public void createIndexMappingFailsIfElasticsearch6VersionIsTooHigh() throws Exception {
         when(node.getVersion()).thenReturn(Optional.of(Version.valueOf("7.0.0")));
 
-        assertThatThrownBy(() -> indexMappingFactory.createIndexMapping("messages"))
+        assertThatThrownBy(() -> indexMappingFactory.createIndexMapping(IndexSetConfig.TemplateType.MESSAGES))
                 .isInstanceOf(ElasticsearchException.class)
                 .hasMessageStartingWith("Unsupported Elasticsearch version: 7.0.0")
                 .hasNoCause();
@@ -86,24 +87,21 @@ public class IndexMappingFactoryTest {
         @Parameterized.Parameters
         public static Collection<Object[]> data() {
             return Arrays.asList(new Object[][]{
-                    {"5.0.0", "messages", IndexMapping5.class},
-                    {"5.1.0", "messages", IndexMapping5.class},
-                    {"5.2.0", "messages", IndexMapping5.class},
-                    {"5.3.0", "messages", IndexMapping5.class},
-                    {"5.4.0", "messages", IndexMapping5.class},
-                    {"6.3.1", "messages", IndexMapping6.class},
-                    {"6.8.1", "messages", IndexMapping6.class},
+                    {"5.0.0", IndexSetConfig.TemplateType.MESSAGES, IndexMapping5.class},
+                    {"5.1.0", IndexSetConfig.TemplateType.MESSAGES, IndexMapping5.class},
+                    {"5.2.0", IndexSetConfig.TemplateType.MESSAGES, IndexMapping5.class},
+                    {"5.3.0", IndexSetConfig.TemplateType.MESSAGES, IndexMapping5.class},
+                    {"5.4.0", IndexSetConfig.TemplateType.MESSAGES, IndexMapping5.class},
+                    {"6.3.1", IndexSetConfig.TemplateType.MESSAGES, IndexMapping6.class},
+                    {"6.8.1", IndexSetConfig.TemplateType.MESSAGES, IndexMapping6.class},
 
-                    {"5.0.0", "events", EventsIndexMapping.class},
-                    {"5.1.0", "events", EventsIndexMapping.class},
-                    {"5.2.0", "events", EventsIndexMapping.class},
-                    {"5.3.0", "events", EventsIndexMapping.class},
-                    {"5.4.0", "events", EventsIndexMapping.class},
-                    {"6.3.1", "events", EventsIndexMapping.class},
-                    {"6.8.1", "events", EventsIndexMapping.class},
-
-                    {"5.0.0", "__does_not_exist__", IndexMapping5.class},
-                    {"6.0.0", "__does_not_exist__", IndexMapping6.class},
+                    {"5.0.0", IndexSetConfig.TemplateType.EVENTS, EventsIndexMapping.class},
+                    {"5.1.0", IndexSetConfig.TemplateType.EVENTS, EventsIndexMapping.class},
+                    {"5.2.0", IndexSetConfig.TemplateType.EVENTS, EventsIndexMapping.class},
+                    {"5.3.0", IndexSetConfig.TemplateType.EVENTS, EventsIndexMapping.class},
+                    {"5.4.0", IndexSetConfig.TemplateType.EVENTS, EventsIndexMapping.class},
+                    {"6.3.1", IndexSetConfig.TemplateType.EVENTS, EventsIndexMapping.class},
+                    {"6.8.1", IndexSetConfig.TemplateType.EVENTS, EventsIndexMapping.class},
             });
         }
 
@@ -111,7 +109,7 @@ public class IndexMappingFactoryTest {
         public final MockitoRule mockitoRule = MockitoJUnit.rule();
 
         private final String version;
-        private final String templateType;
+        private final IndexSetConfig.TemplateType templateType;
         private final Class<? extends IndexMapping> expectedMapping;
 
         @Mock
@@ -120,7 +118,7 @@ public class IndexMappingFactoryTest {
         private IndexMappingFactory indexMappingFactory;
 
 
-        public ParameterizedTest(String version, String templateType, Class<? extends IndexMapping> expectedMapping) {
+        public ParameterizedTest(String version, IndexSetConfig.TemplateType templateType, Class<? extends IndexMapping> expectedMapping) {
             this.version = version;
             this.templateType = templateType;
             this.expectedMapping = expectedMapping;

--- a/graylog2-server/src/test/java/org/graylog2/indexer/IndexMappingFactoryTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/indexer/IndexMappingFactoryTest.java
@@ -41,6 +41,8 @@ public class IndexMappingFactoryTest {
 
     @Mock
     private Node node;
+    @Mock
+    private IndexSet indexSet;
 
     private IndexMappingFactory indexMappingFactory;
 
@@ -53,7 +55,7 @@ public class IndexMappingFactoryTest {
     public void createIndexMappingFailsIfElasticsearch1VersionIsTooLow() throws Exception {
         when(node.getVersion()).thenReturn(Optional.of(Version.valueOf("1.7.3")));
 
-        assertThatThrownBy(indexMappingFactory::createIndexMapping)
+        assertThatThrownBy(() -> indexMappingFactory.createIndexMapping("messages"))
                 .isInstanceOf(ElasticsearchException.class)
                 .hasMessageStartingWith("Unsupported Elasticsearch version: 1.7.3")
                 .hasNoCause();
@@ -63,7 +65,7 @@ public class IndexMappingFactoryTest {
     public void createIndexMappingFailsIfElasticsearch2VersionIsTooLow() throws Exception {
         when(node.getVersion()).thenReturn(Optional.of(Version.valueOf("2.0.0")));
 
-        assertThatThrownBy(indexMappingFactory::createIndexMapping)
+        assertThatThrownBy(() -> indexMappingFactory.createIndexMapping("messages"))
                 .isInstanceOf(ElasticsearchException.class)
                 .hasMessageStartingWith("Unsupported Elasticsearch version: 2.0.0")
                 .hasNoCause();
@@ -73,7 +75,7 @@ public class IndexMappingFactoryTest {
     public void createIndexMappingFailsIfElasticsearch6VersionIsTooHigh() throws Exception {
         when(node.getVersion()).thenReturn(Optional.of(Version.valueOf("7.0.0")));
 
-        assertThatThrownBy(indexMappingFactory::createIndexMapping)
+        assertThatThrownBy(() -> indexMappingFactory.createIndexMapping("messages"))
                 .isInstanceOf(ElasticsearchException.class)
                 .hasMessageStartingWith("Unsupported Elasticsearch version: 7.0.0")
                 .hasNoCause();
@@ -84,12 +86,24 @@ public class IndexMappingFactoryTest {
         @Parameterized.Parameters
         public static Collection<Object[]> data() {
             return Arrays.asList(new Object[][]{
-                    {"5.0.0", IndexMapping5.class},
-                    {"5.1.0", IndexMapping5.class},
-                    {"5.2.0", IndexMapping5.class},
-                    {"5.3.0", IndexMapping5.class},
-                    {"5.4.0", IndexMapping5.class},
-                    {"6.3.1", IndexMapping6.class},
+                    {"5.0.0", "messages", IndexMapping5.class},
+                    {"5.1.0", "messages", IndexMapping5.class},
+                    {"5.2.0", "messages", IndexMapping5.class},
+                    {"5.3.0", "messages", IndexMapping5.class},
+                    {"5.4.0", "messages", IndexMapping5.class},
+                    {"6.3.1", "messages", IndexMapping6.class},
+                    {"6.8.1", "messages", IndexMapping6.class},
+
+                    {"5.0.0", "events", EventsIndexMapping.class},
+                    {"5.1.0", "events", EventsIndexMapping.class},
+                    {"5.2.0", "events", EventsIndexMapping.class},
+                    {"5.3.0", "events", EventsIndexMapping.class},
+                    {"5.4.0", "events", EventsIndexMapping.class},
+                    {"6.3.1", "events", EventsIndexMapping.class},
+                    {"6.8.1", "events", EventsIndexMapping.class},
+
+                    {"5.0.0", "__does_not_exist__", IndexMapping5.class},
+                    {"6.0.0", "__does_not_exist__", IndexMapping6.class},
             });
         }
 
@@ -97,6 +111,7 @@ public class IndexMappingFactoryTest {
         public final MockitoRule mockitoRule = MockitoJUnit.rule();
 
         private final String version;
+        private final String templateType;
         private final Class<? extends IndexMapping> expectedMapping;
 
         @Mock
@@ -105,8 +120,9 @@ public class IndexMappingFactoryTest {
         private IndexMappingFactory indexMappingFactory;
 
 
-        public ParameterizedTest(String version, Class<? extends IndexMapping> expectedMapping) {
+        public ParameterizedTest(String version, String templateType, Class<? extends IndexMapping> expectedMapping) {
             this.version = version;
+            this.templateType = templateType;
             this.expectedMapping = expectedMapping;
         }
 
@@ -118,7 +134,7 @@ public class IndexMappingFactoryTest {
 
         @Test
         public void test() throws Exception {
-            assertThat(indexMappingFactory.createIndexMapping()).isInstanceOf(expectedMapping);
+            assertThat(indexMappingFactory.createIndexMapping(templateType)).isInstanceOf(expectedMapping);
         }
     }
 }

--- a/graylog2-server/src/test/java/org/graylog2/indexer/MongoIndexSetTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/indexer/MongoIndexSetTest.java
@@ -92,7 +92,7 @@ public class MongoIndexSetTest {
             ZonedDateTime.of(2016, 11, 8, 0, 0, 0, 0, ZoneOffset.UTC),
             "standard",
             "index-template",
-            "messages",
+            IndexSetConfig.TemplateType.MESSAGES,
             1,
             false
     );

--- a/graylog2-server/src/test/java/org/graylog2/indexer/MongoIndexSetTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/indexer/MongoIndexSetTest.java
@@ -92,6 +92,7 @@ public class MongoIndexSetTest {
             ZonedDateTime.of(2016, 11, 8, 0, 0, 0, 0, ZoneOffset.UTC),
             "standard",
             "index-template",
+            "messages",
             1,
             false
     );

--- a/graylog2-server/src/test/java/org/graylog2/indexer/indexset/IndexSetConfigTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/indexer/indexset/IndexSetConfigTest.java
@@ -26,6 +26,7 @@ import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 public class IndexSetConfigTest {
     @Test
@@ -63,7 +64,7 @@ public class IndexSetConfigTest {
                 .replicas(0)
                 .creationDate(ZonedDateTime.now(ZoneOffset.UTC))
                 .indexTemplateName("graylog2-template")
-                .indexTemplateType("yolo")
+                .indexTemplateType("events")
                 .indexAnalyzer("standard")
                 .indexOptimizationMaxNumSegments(1)
                 .indexOptimizationDisabled(false)
@@ -84,7 +85,7 @@ public class IndexSetConfigTest {
                 ZonedDateTime.now(ZoneOffset.UTC),
                 "standard",
                 "graylog3-template",
-                "template-type",
+                "events",
                 1,
                 false
         );
@@ -114,10 +115,56 @@ public class IndexSetConfigTest {
         assertThat(config1.indexTemplateType()).isEqualTo("messages");
 
         // Types can be set with the builder and the create() method
-        assertThat(config2.indexTemplateType()).isEqualTo("yolo");
-        assertThat(config3.indexTemplateType()).isEqualTo("template-type");
+        assertThat(config2.indexTemplateType()).isEqualTo("events");
+        assertThat(config3.indexTemplateType()).isEqualTo("events");
 
         // A template type value of "null" should result in the default value
         assertThat(config4.indexTemplateType()).isEqualTo("messages");
+    }
+
+    @Test
+    public void indexTemplateTypeWithInvalidValue() {
+        assertThatThrownBy(() -> IndexSetConfig.builder()
+                .isWritable(false)
+                .title("Test 1")
+                .description("A test index-set.")
+                .indexPrefix("graylog1")
+                .indexWildcard("graylog1_*")
+                .rotationStrategy(MessageCountRotationStrategyConfig.create(Integer.MAX_VALUE))
+                .rotationStrategyClass(MessageCountRotationStrategy.class.getCanonicalName())
+                .retentionStrategy(NoopRetentionStrategyConfig.create(Integer.MAX_VALUE))
+                .retentionStrategyClass(NoopRetentionStrategy.class.getCanonicalName())
+                .shards(4)
+                .replicas(0)
+                .creationDate(ZonedDateTime.now(ZoneOffset.UTC))
+                .indexTemplateName("graylog1-template")
+                .indexTemplateType("yolo")
+                .indexAnalyzer("standard")
+                .indexOptimizationMaxNumSegments(1)
+                .indexOptimizationDisabled(false)
+                .build()
+        ).isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("yolo");
+
+        assertThatThrownBy(() -> IndexSetConfig.create(
+                "57f3d721a43c2d59cb750001",
+                "Test 2",
+                "A test index-set.",
+                true,
+                "graylog2",
+                4,
+                1,
+                MessageCountRotationStrategy.class.getCanonicalName(),
+                MessageCountRotationStrategyConfig.create(1000),
+                NoopRetentionStrategy.class.getCanonicalName(),
+                NoopRetentionStrategyConfig.create(10),
+                ZonedDateTime.now(ZoneOffset.UTC),
+                "standard",
+                "graylog2-template",
+                "yolo",
+                1,
+                false
+        )).isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("yolo");
     }
 }

--- a/graylog2-server/src/test/java/org/graylog2/indexer/indexset/IndexSetConfigTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/indexer/indexset/IndexSetConfigTest.java
@@ -1,0 +1,123 @@
+/**
+ * This file is part of Graylog.
+ *
+ * Graylog is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.graylog2.indexer.indexset;
+
+import org.graylog2.indexer.retention.strategies.NoopRetentionStrategy;
+import org.graylog2.indexer.retention.strategies.NoopRetentionStrategyConfig;
+import org.graylog2.indexer.rotation.strategies.MessageCountRotationStrategy;
+import org.graylog2.indexer.rotation.strategies.MessageCountRotationStrategyConfig;
+import org.junit.Test;
+
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class IndexSetConfigTest {
+    @Test
+    public void indexTemplateTypeDefault() {
+        final IndexSetConfig config1 = IndexSetConfig.builder()
+                .isWritable(true)
+                .title("Test 1")
+                .description("A test index-set.")
+                .indexPrefix("graylog1")
+                .indexWildcard("graylog1_*")
+                .rotationStrategy(MessageCountRotationStrategyConfig.create(Integer.MAX_VALUE))
+                .rotationStrategyClass(MessageCountRotationStrategy.class.getCanonicalName())
+                .retentionStrategy(NoopRetentionStrategyConfig.create(Integer.MAX_VALUE))
+                .retentionStrategyClass(NoopRetentionStrategy.class.getCanonicalName())
+                .shards(4)
+                .replicas(0)
+                .creationDate(ZonedDateTime.now(ZoneOffset.UTC))
+                .indexTemplateName("graylog1-template")
+                .indexAnalyzer("standard")
+                .indexOptimizationMaxNumSegments(1)
+                .indexOptimizationDisabled(false)
+                .build();
+
+        final IndexSetConfig config2 = IndexSetConfig.builder()
+                .isWritable(false)
+                .title("Test 2")
+                .description("A test index-set.")
+                .indexPrefix("graylog2")
+                .indexWildcard("graylog2_*")
+                .rotationStrategy(MessageCountRotationStrategyConfig.create(Integer.MAX_VALUE))
+                .rotationStrategyClass(MessageCountRotationStrategy.class.getCanonicalName())
+                .retentionStrategy(NoopRetentionStrategyConfig.create(Integer.MAX_VALUE))
+                .retentionStrategyClass(NoopRetentionStrategy.class.getCanonicalName())
+                .shards(4)
+                .replicas(0)
+                .creationDate(ZonedDateTime.now(ZoneOffset.UTC))
+                .indexTemplateName("graylog2-template")
+                .indexTemplateType("yolo")
+                .indexAnalyzer("standard")
+                .indexOptimizationMaxNumSegments(1)
+                .indexOptimizationDisabled(false)
+                .build();
+
+        final IndexSetConfig config3 = IndexSetConfig.create(
+                "57f3d721a43c2d59cb750001",
+                "Test 3",
+                "A test index-set.",
+                true,
+                "graylog3",
+                4,
+                1,
+                MessageCountRotationStrategy.class.getCanonicalName(),
+                MessageCountRotationStrategyConfig.create(1000),
+                NoopRetentionStrategy.class.getCanonicalName(),
+                NoopRetentionStrategyConfig.create(10),
+                ZonedDateTime.now(ZoneOffset.UTC),
+                "standard",
+                "graylog3-template",
+                "template-type",
+                1,
+                false
+        );
+
+        final IndexSetConfig config4 = IndexSetConfig.create(
+                "57f3d721a43c2d59cb750001",
+                "Test 3",
+                "A test index-set.",
+                true,
+                "graylog3",
+                4,
+                1,
+                MessageCountRotationStrategy.class.getCanonicalName(),
+                MessageCountRotationStrategyConfig.create(1000),
+                NoopRetentionStrategy.class.getCanonicalName(),
+                NoopRetentionStrategyConfig.create(10),
+                ZonedDateTime.now(ZoneOffset.UTC),
+                "standard",
+                "graylog3-template",
+                null,
+                1,
+                false
+        );
+
+
+        // Not using the indexTemplateType(String) builder method should result in the default value
+        assertThat(config1.indexTemplateType()).isEqualTo("messages");
+
+        // Types can be set with the builder and the create() method
+        assertThat(config2.indexTemplateType()).isEqualTo("yolo");
+        assertThat(config3.indexTemplateType()).isEqualTo("template-type");
+
+        // A template type value of "null" should result in the default value
+        assertThat(config4.indexTemplateType()).isEqualTo("messages");
+    }
+}

--- a/graylog2-server/src/test/java/org/graylog2/indexer/indexset/IndexSetConfigTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/indexer/indexset/IndexSetConfigTest.java
@@ -26,7 +26,6 @@ import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 public class IndexSetConfigTest {
     @Test
@@ -64,7 +63,7 @@ public class IndexSetConfigTest {
                 .replicas(0)
                 .creationDate(ZonedDateTime.now(ZoneOffset.UTC))
                 .indexTemplateName("graylog2-template")
-                .indexTemplateType("events")
+                .indexTemplateType(IndexSetConfig.TemplateType.EVENTS)
                 .indexAnalyzer("standard")
                 .indexOptimizationMaxNumSegments(1)
                 .indexOptimizationDisabled(false)
@@ -85,7 +84,7 @@ public class IndexSetConfigTest {
                 ZonedDateTime.now(ZoneOffset.UTC),
                 "standard",
                 "graylog3-template",
-                "events",
+                IndexSetConfig.TemplateType.EVENTS,
                 1,
                 false
         );
@@ -112,59 +111,13 @@ public class IndexSetConfigTest {
 
 
         // Not using the indexTemplateType(String) builder method should result in the default value
-        assertThat(config1.indexTemplateType()).isEqualTo("messages");
+        assertThat(config1.indexTemplateType()).isEqualTo(IndexSetConfig.TemplateType.MESSAGES);
 
         // Types can be set with the builder and the create() method
-        assertThat(config2.indexTemplateType()).isEqualTo("events");
-        assertThat(config3.indexTemplateType()).isEqualTo("events");
+        assertThat(config2.indexTemplateType()).isEqualTo(IndexSetConfig.TemplateType.EVENTS);
+        assertThat(config3.indexTemplateType()).isEqualTo(IndexSetConfig.TemplateType.EVENTS);
 
         // A template type value of "null" should result in the default value
-        assertThat(config4.indexTemplateType()).isEqualTo("messages");
-    }
-
-    @Test
-    public void indexTemplateTypeWithInvalidValue() {
-        assertThatThrownBy(() -> IndexSetConfig.builder()
-                .isWritable(false)
-                .title("Test 1")
-                .description("A test index-set.")
-                .indexPrefix("graylog1")
-                .indexWildcard("graylog1_*")
-                .rotationStrategy(MessageCountRotationStrategyConfig.create(Integer.MAX_VALUE))
-                .rotationStrategyClass(MessageCountRotationStrategy.class.getCanonicalName())
-                .retentionStrategy(NoopRetentionStrategyConfig.create(Integer.MAX_VALUE))
-                .retentionStrategyClass(NoopRetentionStrategy.class.getCanonicalName())
-                .shards(4)
-                .replicas(0)
-                .creationDate(ZonedDateTime.now(ZoneOffset.UTC))
-                .indexTemplateName("graylog1-template")
-                .indexTemplateType("yolo")
-                .indexAnalyzer("standard")
-                .indexOptimizationMaxNumSegments(1)
-                .indexOptimizationDisabled(false)
-                .build()
-        ).isInstanceOf(IllegalArgumentException.class)
-                .hasMessageContaining("yolo");
-
-        assertThatThrownBy(() -> IndexSetConfig.create(
-                "57f3d721a43c2d59cb750001",
-                "Test 2",
-                "A test index-set.",
-                true,
-                "graylog2",
-                4,
-                1,
-                MessageCountRotationStrategy.class.getCanonicalName(),
-                MessageCountRotationStrategyConfig.create(1000),
-                NoopRetentionStrategy.class.getCanonicalName(),
-                NoopRetentionStrategyConfig.create(10),
-                ZonedDateTime.now(ZoneOffset.UTC),
-                "standard",
-                "graylog2-template",
-                "yolo",
-                1,
-                false
-        )).isInstanceOf(IllegalArgumentException.class)
-                .hasMessageContaining("yolo");
+        assertThat(config4.indexTemplateType()).isEqualTo(IndexSetConfig.TemplateType.MESSAGES);
     }
 }

--- a/graylog2-server/src/test/java/org/graylog2/indexer/indexset/IndexSetConfigTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/indexer/indexset/IndexSetConfigTest.java
@@ -110,14 +110,14 @@ public class IndexSetConfigTest {
         );
 
 
-        // Not using the indexTemplateType(String) builder method should result in the default value
-        assertThat(config1.indexTemplateType()).isEqualTo(IndexSetConfig.TemplateType.MESSAGES);
+        // Not using the indexTemplateType(String) builder method should result in an empty template type
+        assertThat(config1.indexTemplateType()).isNotPresent();
 
         // Types can be set with the builder and the create() method
-        assertThat(config2.indexTemplateType()).isEqualTo(IndexSetConfig.TemplateType.EVENTS);
-        assertThat(config3.indexTemplateType()).isEqualTo(IndexSetConfig.TemplateType.EVENTS);
+        assertThat(config2.indexTemplateType()).isPresent().get().isEqualTo(IndexSetConfig.TemplateType.EVENTS);
+        assertThat(config3.indexTemplateType()).isPresent().get().isEqualTo(IndexSetConfig.TemplateType.EVENTS);
 
-        // A template type value of "null" should result in the default value
-        assertThat(config4.indexTemplateType()).isEqualTo(IndexSetConfig.TemplateType.MESSAGES);
+        // A template type value of "null" should result in an empty template type
+        assertThat(config4.indexTemplateType()).isNotPresent();
     }
 }

--- a/graylog2-server/src/test/java/org/graylog2/indexer/indexset/MongoIndexSetServiceTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/indexer/indexset/MongoIndexSetServiceTest.java
@@ -110,6 +110,7 @@ public class MongoIndexSetServiceTest {
                                 ZonedDateTime.of(2016, 10, 4, 17, 0, 0, 0, ZoneOffset.UTC),
                                 "standard",
                                 "test_1",
+                                "messages",
                                 1,
                                 false
                         )
@@ -138,6 +139,7 @@ public class MongoIndexSetServiceTest {
                                 ZonedDateTime.of(2016, 10, 4, 17, 0, 0, 0, ZoneOffset.UTC),
                                 "standard",
                                 "test_1",
+                                "messages",
                                 1,
                                 false
                         )
@@ -185,7 +187,7 @@ public class MongoIndexSetServiceTest {
 
         assertThat(configs)
                 .isNotEmpty()
-                .hasSize(2)
+                .hasSize(3)
                 .containsExactly(
                         IndexSetConfig.create(
                                 "57f3d721a43c2d59cb750001",
@@ -202,6 +204,7 @@ public class MongoIndexSetServiceTest {
                                 ZonedDateTime.of(2016, 10, 4, 17, 0, 0, 0, ZoneOffset.UTC),
                                 "standard",
                                 "test_1",
+                                "messages",
                                 1,
                                 false
                         ),
@@ -220,6 +223,26 @@ public class MongoIndexSetServiceTest {
                                 ZonedDateTime.of(2016, 10, 4, 18, 0, 0, 0, ZoneOffset.UTC),
                                 "standard",
                                 "test_2",
+                                "messages",
+                                1,
+                                false
+                        ),
+                        IndexSetConfig.create(
+                                "57f3d721a43c2d59cb750003",
+                                "Test 3",
+                                "This is the index set configuration for Test 3 - with an index set index template",
+                                true,
+                                "test_3",
+                                1,
+                                0,
+                                MessageCountRotationStrategy.class.getCanonicalName(),
+                                MessageCountRotationStrategyConfig.create(2500),
+                                NoopRetentionStrategy.class.getCanonicalName(),
+                                NoopRetentionStrategyConfig.create(25),
+                                ZonedDateTime.of(2016, 10, 4, 18, 0, 0, 0, ZoneOffset.UTC),
+                                "standard",
+                                "test_3",
+                                "events",
                                 1,
                                 false
                         )
@@ -245,6 +268,7 @@ public class MongoIndexSetServiceTest {
                 ZonedDateTime.of(2016, 10, 4, 12, 0, 0, 0, ZoneOffset.UTC),
                 "standard",
                 "index-template",
+                "messages",
                 1,
                 false
         );
@@ -296,11 +320,11 @@ public class MongoIndexSetServiceTest {
         final IndexSetDeletedSubscriber subscriber = new IndexSetDeletedSubscriber();
         clusterEventBus.registerClusterEventSubscriber(subscriber);
 
-        final int deletedEntries = indexSetService.delete("57f3d721a43c2d59cb750003");
+        final int deletedEntries = indexSetService.delete("57f3d721a43c2d59cb750009");
         assertThat(deletedEntries).isEqualTo(0);
         assertThat(indexSetService.get("57f3d721a43c2d59cb750001")).isPresent();
-        assertThat(indexSetService.get("57f3d721a43c2d59cb750003")).isEmpty();
-        assertThat(indexSetService.findAll()).hasSize(2);
+        assertThat(indexSetService.get("57f3d721a43c2d59cb750009")).isEmpty();
+        assertThat(indexSetService.findAll()).hasSize(3);
 
         assertThat(subscriber.getEvents()).isEmpty();
     }
@@ -321,7 +345,7 @@ public class MongoIndexSetServiceTest {
         final int deletedEntries = indexSetService.delete(streamId);
         assertThat(deletedEntries).isEqualTo(0);
         assertThat(indexSetService.get(streamId)).isPresent();
-        assertThat(indexSetService.findAll()).hasSize(2);
+        assertThat(indexSetService.findAll()).hasSize(3);
 
         assertThat(subscriber.getEvents()).isEmpty();
     }

--- a/graylog2-server/src/test/java/org/graylog2/indexer/indexset/MongoIndexSetServiceTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/indexer/indexset/MongoIndexSetServiceTest.java
@@ -110,7 +110,7 @@ public class MongoIndexSetServiceTest {
                                 ZonedDateTime.of(2016, 10, 4, 17, 0, 0, 0, ZoneOffset.UTC),
                                 "standard",
                                 "test_1",
-                                IndexSetConfig.TemplateType.MESSAGES,
+                                null,
                                 1,
                                 false
                         )
@@ -139,7 +139,7 @@ public class MongoIndexSetServiceTest {
                                 ZonedDateTime.of(2016, 10, 4, 17, 0, 0, 0, ZoneOffset.UTC),
                                 "standard",
                                 "test_1",
-                                IndexSetConfig.TemplateType.MESSAGES,
+                                null,
                                 1,
                                 false
                         )
@@ -204,7 +204,7 @@ public class MongoIndexSetServiceTest {
                                 ZonedDateTime.of(2016, 10, 4, 17, 0, 0, 0, ZoneOffset.UTC),
                                 "standard",
                                 "test_1",
-                                IndexSetConfig.TemplateType.MESSAGES,
+                                null,
                                 1,
                                 false
                         ),
@@ -223,7 +223,7 @@ public class MongoIndexSetServiceTest {
                                 ZonedDateTime.of(2016, 10, 4, 18, 0, 0, 0, ZoneOffset.UTC),
                                 "standard",
                                 "test_2",
-                                IndexSetConfig.TemplateType.MESSAGES,
+                                null,
                                 1,
                                 false
                         ),

--- a/graylog2-server/src/test/java/org/graylog2/indexer/indexset/MongoIndexSetServiceTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/indexer/indexset/MongoIndexSetServiceTest.java
@@ -110,7 +110,7 @@ public class MongoIndexSetServiceTest {
                                 ZonedDateTime.of(2016, 10, 4, 17, 0, 0, 0, ZoneOffset.UTC),
                                 "standard",
                                 "test_1",
-                                "messages",
+                                IndexSetConfig.TemplateType.MESSAGES,
                                 1,
                                 false
                         )
@@ -139,7 +139,7 @@ public class MongoIndexSetServiceTest {
                                 ZonedDateTime.of(2016, 10, 4, 17, 0, 0, 0, ZoneOffset.UTC),
                                 "standard",
                                 "test_1",
-                                "messages",
+                                IndexSetConfig.TemplateType.MESSAGES,
                                 1,
                                 false
                         )
@@ -204,7 +204,7 @@ public class MongoIndexSetServiceTest {
                                 ZonedDateTime.of(2016, 10, 4, 17, 0, 0, 0, ZoneOffset.UTC),
                                 "standard",
                                 "test_1",
-                                "messages",
+                                IndexSetConfig.TemplateType.MESSAGES,
                                 1,
                                 false
                         ),
@@ -223,7 +223,7 @@ public class MongoIndexSetServiceTest {
                                 ZonedDateTime.of(2016, 10, 4, 18, 0, 0, 0, ZoneOffset.UTC),
                                 "standard",
                                 "test_2",
-                                "messages",
+                                IndexSetConfig.TemplateType.MESSAGES,
                                 1,
                                 false
                         ),
@@ -242,7 +242,7 @@ public class MongoIndexSetServiceTest {
                                 ZonedDateTime.of(2016, 10, 4, 18, 0, 0, 0, ZoneOffset.UTC),
                                 "standard",
                                 "test_3",
-                                "events",
+                                IndexSetConfig.TemplateType.EVENTS,
                                 1,
                                 false
                         )
@@ -268,7 +268,7 @@ public class MongoIndexSetServiceTest {
                 ZonedDateTime.of(2016, 10, 4, 12, 0, 0, 0, ZoneOffset.UTC),
                 "standard",
                 "index-template",
-                "messages",
+                IndexSetConfig.TemplateType.EVENTS,
                 1,
                 false
         );

--- a/graylog2-server/src/test/java/org/graylog2/indexer/indices/IndicesIT.java
+++ b/graylog2-server/src/test/java/org/graylog2/indexer/indices/IndicesIT.java
@@ -305,7 +305,7 @@ public class IndicesIT extends ElasticsearchBase {
             assertThat(actualAfterMapping.path(IndexMapping.TYPE_MESSAGE).isObject()).isTrue();
 
             final Map<String, Object> mapping = mapper.convertValue(actualAfterMapping, TypeReferences.MAP_STRING_OBJECT);
-            final Map<String, Object> expectedTemplate = indexMappingFactory.createIndexMapping().messageTemplate(indexSet.getIndexWildcard(), indexSetConfig.indexAnalyzer());
+            final Map<String, Object> expectedTemplate = indexMappingFactory.createIndexMapping("messages").toTemplate(indexSetConfig, indexSet.getIndexWildcard());
             assertThat(mapping).isEqualTo(expectedTemplate.get("mappings"));
         } finally {
             deleteTemplate(templateName);

--- a/graylog2-server/src/test/java/org/graylog2/indexer/indices/IndicesIT.java
+++ b/graylog2-server/src/test/java/org/graylog2/indexer/indices/IndicesIT.java
@@ -305,7 +305,7 @@ public class IndicesIT extends ElasticsearchBase {
             assertThat(actualAfterMapping.path(IndexMapping.TYPE_MESSAGE).isObject()).isTrue();
 
             final Map<String, Object> mapping = mapper.convertValue(actualAfterMapping, TypeReferences.MAP_STRING_OBJECT);
-            final Map<String, Object> expectedTemplate = indexMappingFactory.createIndexMapping("messages").toTemplate(indexSetConfig, indexSet.getIndexWildcard());
+            final Map<String, Object> expectedTemplate = indexMappingFactory.createIndexMapping(IndexSetConfig.TemplateType.MESSAGES).toTemplate(indexSetConfig, indexSet.getIndexWildcard());
             assertThat(mapping).isEqualTo(expectedTemplate.get("mappings"));
         } finally {
             deleteTemplate(templateName);

--- a/graylog2-server/src/test/java/org/graylog2/rest/resources/system/indexer/IndexSetsResourceTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/rest/resources/system/indexer/IndexSetsResourceTest.java
@@ -129,7 +129,7 @@ public class IndexSetsResourceTest {
                 ZonedDateTime.of(2016, 10, 10, 12, 0, 0, 0, ZoneOffset.UTC),
                 "standard",
                 "index-template",
-                "messages",
+                IndexSetConfig.TemplateType.MESSAGES,
                 1,
                 false
         );
@@ -164,7 +164,7 @@ public class IndexSetsResourceTest {
                 ZonedDateTime.of(2016, 10, 10, 12, 0, 0, 0, ZoneOffset.UTC),
                 "standard",
                 "index-template",
-                "messages",
+                IndexSetConfig.TemplateType.MESSAGES,
                 1,
                 false
         );
@@ -211,7 +211,7 @@ public class IndexSetsResourceTest {
                 ZonedDateTime.of(2016, 10, 10, 12, 0, 0, 0, ZoneOffset.UTC),
                 "standard",
                 "index-template",
-                "messages",
+                IndexSetConfig.TemplateType.MESSAGES,
                 1,
                 false
         );
@@ -311,7 +311,7 @@ public class IndexSetsResourceTest {
                 ZonedDateTime.of(2016, 10, 10, 12, 0, 0, 0, ZoneOffset.UTC),
                 "standard",
                 "prefix-template",
-                "messages",
+                IndexSetConfig.TemplateType.MESSAGES,
                 1,
                 false
         );
@@ -348,7 +348,7 @@ public class IndexSetsResourceTest {
                 ZonedDateTime.of(2016, 10, 10, 12, 0, 0, 0, ZoneOffset.UTC),
                 "standard",
                 "index-template",
-                "messages",
+                IndexSetConfig.TemplateType.MESSAGES,
                 1,
                 false
         );
@@ -380,7 +380,7 @@ public class IndexSetsResourceTest {
                 ZonedDateTime.of(2016, 10, 10, 12, 0, 0, 0, ZoneOffset.UTC),
                 "standard",
                 "index-template",
-                "messages",
+                IndexSetConfig.TemplateType.MESSAGES,
                 1,
                 false
         );
@@ -423,7 +423,7 @@ public class IndexSetsResourceTest {
                 ZonedDateTime.of(2016, 10, 10, 12, 0, 0, 0, ZoneOffset.UTC),
                 "standard",
                 "index-template",
-                "messages",
+                IndexSetConfig.TemplateType.MESSAGES,
                 1,
                 false
         );
@@ -456,7 +456,7 @@ public class IndexSetsResourceTest {
             ZonedDateTime.of(2016, 10, 10, 12, 0, 0, 0, ZoneOffset.UTC),
             "standard",
             "index-template",
-             "messages",
+             IndexSetConfig.TemplateType.MESSAGES,
             1,
             false
         );
@@ -642,7 +642,7 @@ public class IndexSetsResourceTest {
             ZonedDateTime.of(2016, 10, 10, 12, 0, 0, 0, ZoneOffset.UTC),
             "standard",
             "index-template",
-            "messages",
+            IndexSetConfig.TemplateType.MESSAGES,
             1,
             false
         );
@@ -710,7 +710,7 @@ public class IndexSetsResourceTest {
             ZonedDateTime.of(2016, 10, 10, 12, 0, 0, 0, ZoneOffset.UTC),
             "standard",
             "index-template",
-            "messages",
+            IndexSetConfig.TemplateType.MESSAGES,
             1,
             false
         );

--- a/graylog2-server/src/test/java/org/graylog2/rest/resources/system/indexer/IndexSetsResourceTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/rest/resources/system/indexer/IndexSetsResourceTest.java
@@ -129,7 +129,7 @@ public class IndexSetsResourceTest {
                 ZonedDateTime.of(2016, 10, 10, 12, 0, 0, 0, ZoneOffset.UTC),
                 "standard",
                 "index-template",
-                IndexSetConfig.TemplateType.MESSAGES,
+                null,
                 1,
                 false
         );
@@ -164,7 +164,7 @@ public class IndexSetsResourceTest {
                 ZonedDateTime.of(2016, 10, 10, 12, 0, 0, 0, ZoneOffset.UTC),
                 "standard",
                 "index-template",
-                IndexSetConfig.TemplateType.MESSAGES,
+                null,
                 1,
                 false
         );
@@ -211,7 +211,7 @@ public class IndexSetsResourceTest {
                 ZonedDateTime.of(2016, 10, 10, 12, 0, 0, 0, ZoneOffset.UTC),
                 "standard",
                 "index-template",
-                IndexSetConfig.TemplateType.MESSAGES,
+                null,
                 1,
                 false
         );
@@ -311,7 +311,7 @@ public class IndexSetsResourceTest {
                 ZonedDateTime.of(2016, 10, 10, 12, 0, 0, 0, ZoneOffset.UTC),
                 "standard",
                 "prefix-template",
-                IndexSetConfig.TemplateType.MESSAGES,
+                null,
                 1,
                 false
         );
@@ -348,7 +348,7 @@ public class IndexSetsResourceTest {
                 ZonedDateTime.of(2016, 10, 10, 12, 0, 0, 0, ZoneOffset.UTC),
                 "standard",
                 "index-template",
-                IndexSetConfig.TemplateType.MESSAGES,
+                null,
                 1,
                 false
         );
@@ -380,7 +380,7 @@ public class IndexSetsResourceTest {
                 ZonedDateTime.of(2016, 10, 10, 12, 0, 0, 0, ZoneOffset.UTC),
                 "standard",
                 "index-template",
-                IndexSetConfig.TemplateType.MESSAGES,
+                null,
                 1,
                 false
         );
@@ -423,7 +423,7 @@ public class IndexSetsResourceTest {
                 ZonedDateTime.of(2016, 10, 10, 12, 0, 0, 0, ZoneOffset.UTC),
                 "standard",
                 "index-template",
-                IndexSetConfig.TemplateType.MESSAGES,
+                null,
                 1,
                 false
         );
@@ -456,7 +456,7 @@ public class IndexSetsResourceTest {
             ZonedDateTime.of(2016, 10, 10, 12, 0, 0, 0, ZoneOffset.UTC),
             "standard",
             "index-template",
-             IndexSetConfig.TemplateType.MESSAGES,
+            null,
             1,
             false
         );
@@ -642,7 +642,7 @@ public class IndexSetsResourceTest {
             ZonedDateTime.of(2016, 10, 10, 12, 0, 0, 0, ZoneOffset.UTC),
             "standard",
             "index-template",
-            IndexSetConfig.TemplateType.MESSAGES,
+            null,
             1,
             false
         );
@@ -710,7 +710,7 @@ public class IndexSetsResourceTest {
             ZonedDateTime.of(2016, 10, 10, 12, 0, 0, 0, ZoneOffset.UTC),
             "standard",
             "index-template",
-            IndexSetConfig.TemplateType.MESSAGES,
+            null,
             1,
             false
         );

--- a/graylog2-server/src/test/java/org/graylog2/rest/resources/system/indexer/IndexSetsResourceTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/rest/resources/system/indexer/IndexSetsResourceTest.java
@@ -129,6 +129,7 @@ public class IndexSetsResourceTest {
                 ZonedDateTime.of(2016, 10, 10, 12, 0, 0, 0, ZoneOffset.UTC),
                 "standard",
                 "index-template",
+                "messages",
                 1,
                 false
         );
@@ -163,6 +164,7 @@ public class IndexSetsResourceTest {
                 ZonedDateTime.of(2016, 10, 10, 12, 0, 0, 0, ZoneOffset.UTC),
                 "standard",
                 "index-template",
+                "messages",
                 1,
                 false
         );
@@ -209,6 +211,7 @@ public class IndexSetsResourceTest {
                 ZonedDateTime.of(2016, 10, 10, 12, 0, 0, 0, ZoneOffset.UTC),
                 "standard",
                 "index-template",
+                "messages",
                 1,
                 false
         );
@@ -308,6 +311,7 @@ public class IndexSetsResourceTest {
                 ZonedDateTime.of(2016, 10, 10, 12, 0, 0, 0, ZoneOffset.UTC),
                 "standard",
                 "prefix-template",
+                "messages",
                 1,
                 false
         );
@@ -344,6 +348,7 @@ public class IndexSetsResourceTest {
                 ZonedDateTime.of(2016, 10, 10, 12, 0, 0, 0, ZoneOffset.UTC),
                 "standard",
                 "index-template",
+                "messages",
                 1,
                 false
         );
@@ -375,6 +380,7 @@ public class IndexSetsResourceTest {
                 ZonedDateTime.of(2016, 10, 10, 12, 0, 0, 0, ZoneOffset.UTC),
                 "standard",
                 "index-template",
+                "messages",
                 1,
                 false
         );
@@ -417,6 +423,7 @@ public class IndexSetsResourceTest {
                 ZonedDateTime.of(2016, 10, 10, 12, 0, 0, 0, ZoneOffset.UTC),
                 "standard",
                 "index-template",
+                "messages",
                 1,
                 false
         );
@@ -449,6 +456,7 @@ public class IndexSetsResourceTest {
             ZonedDateTime.of(2016, 10, 10, 12, 0, 0, 0, ZoneOffset.UTC),
             "standard",
             "index-template",
+             "messages",
             1,
             false
         );
@@ -634,6 +642,7 @@ public class IndexSetsResourceTest {
             ZonedDateTime.of(2016, 10, 10, 12, 0, 0, 0, ZoneOffset.UTC),
             "standard",
             "index-template",
+            "messages",
             1,
             false
         );
@@ -701,6 +710,7 @@ public class IndexSetsResourceTest {
             ZonedDateTime.of(2016, 10, 10, 12, 0, 0, 0, ZoneOffset.UTC),
             "standard",
             "index-template",
+            "messages",
             1,
             false
         );

--- a/graylog2-server/src/test/java/org/graylog2/streams/StreamMock.java
+++ b/graylog2-server/src/test/java/org/graylog2/streams/StreamMock.java
@@ -83,7 +83,7 @@ public class StreamMock implements Stream {
                 ZonedDateTime.of(2017, 3, 29, 12, 0, 0, 0, ZoneOffset.UTC),
                 "standard",
                 "template",
-                "messages",
+                IndexSetConfig.TemplateType.MESSAGES,
                 1,
                 false));
     }

--- a/graylog2-server/src/test/java/org/graylog2/streams/StreamMock.java
+++ b/graylog2-server/src/test/java/org/graylog2/streams/StreamMock.java
@@ -40,8 +40,6 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 
-import static org.mockito.Mockito.mock;
-
 public class StreamMock implements Stream {
     private String id;
     private String title;
@@ -85,6 +83,7 @@ public class StreamMock implements Stream {
                 ZonedDateTime.of(2017, 3, 29, 12, 0, 0, 0, ZoneOffset.UTC),
                 "standard",
                 "template",
+                "messages",
                 1,
                 false));
     }

--- a/graylog2-server/src/test/resources/org/graylog2/indexer/indexset/MongoIndexSetServiceTest.json
+++ b/graylog2-server/src/test/resources/org/graylog2/indexer/indexset/MongoIndexSetServiceTest.json
@@ -52,6 +52,34 @@
       "index_template_name": "test_2",
       "index_optimization_max_num_segments": 1,
       "index_optimization_disabled": false
+    },
+    {
+      "_id": {
+        "$oid": "57f3d721a43c2d59cb750003"
+      },
+      "title": "Test 3",
+      "description": "This is the index set configuration for Test 3 - with an index set index template",
+      "index_prefix": "test_3",
+      "shards": 1,
+      "replicas": 0,
+      "rotation_strategy_class": "org.graylog2.indexer.rotation.strategies.MessageCountRotationStrategy",
+      "rotation_strategy": {
+        "type": "org.graylog2.indexer.rotation.strategies.MessageCountRotationStrategyConfig",
+        "max_docs_per_index": 2500
+      },
+      "retention_strategy_class": "org.graylog2.indexer.retention.strategies.NoopRetentionStrategy",
+      "retention_strategy": {
+        "type": "org.graylog2.indexer.retention.strategies.NoopRetentionStrategyConfig",
+        "max_number_of_indices": 25
+      },
+      "creation_date": {
+        "$date": "2016-10-04T18:00:00Z"
+      },
+      "index_analyzer": "standard",
+      "index_template_name": "test_3",
+      "index_template_type": "events",
+      "index_optimization_max_num_segments": 1,
+      "index_optimization_disabled": false
     }
   ]
 }


### PR DESCRIPTION
This introduces index template types so we can install different index mapping templates for different index sets depending on the value of `index_template_type`.

This also adds an "events" index template that will be used for the events/alerting system.

Closes #5884