### PR TITLE
Implement receive & processing time tracking

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/commands/Server.java
+++ b/graylog2-server/src/main/java/org/graylog2/commands/Server.java
@@ -78,6 +78,7 @@ import org.graylog2.shared.bindings.ObjectMapperModule;
 import org.graylog2.shared.bindings.RestApiBindings;
 import org.graylog2.shared.system.activities.Activity;
 import org.graylog2.shared.system.activities.ActivityWriter;
+import org.graylog2.system.processing.ProcessingStatusConfig;
 import org.graylog2.system.shutdown.GracefulShutdown;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -107,6 +108,7 @@ public class Server extends ServerBootstrap {
     private final NettyTransportConfiguration nettyTransportConfiguration = new NettyTransportConfiguration();
     private final PipelineConfig pipelineConfiguration = new PipelineConfig();
     private final ViewsConfig viewsConfiguration = new ViewsConfig();
+    private final ProcessingStatusConfig processingStatusConfig = new ProcessingStatusConfig();
 
     public Server() {
         super("server", configuration);
@@ -170,7 +172,8 @@ public class Server extends ServerBootstrap {
                 kafkaJournalConfiguration,
                 nettyTransportConfiguration,
                 pipelineConfiguration,
-                viewsConfiguration);
+                viewsConfiguration,
+                processingStatusConfig);
     }
 
     @Override

--- a/graylog2-server/src/main/java/org/graylog2/indexer/messages/Messages.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/messages/Messages.java
@@ -172,7 +172,7 @@ public class Messages {
     }
 
     private void recordTimestamp(List<Map.Entry<IndexSet, Message>> messageList, Set<String> failedIds) {
-        for (Map.Entry<IndexSet, Message> entry : messageList) {
+        for (final Map.Entry<IndexSet, Message> entry : messageList) {
             final Message message = entry.getValue();
 
             if (failedIds.contains(message.getId())) {

--- a/graylog2-server/src/main/java/org/graylog2/indexer/messages/Messages.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/messages/Messages.java
@@ -42,6 +42,7 @@ import org.graylog2.indexer.IndexSet;
 import org.graylog2.indexer.results.ResultMessage;
 import org.graylog2.plugin.GlobalMetricNames;
 import org.graylog2.plugin.Message;
+import org.graylog2.system.processing.ProcessingStatusRecorder;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -52,6 +53,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.TimeUnit;
@@ -81,17 +83,20 @@ public class Messages {
 
     private final Meter invalidTimestampMeter;
     private final JestClient client;
+    private final ProcessingStatusRecorder processingStatusRecorder;
     private final LinkedBlockingQueue<List<IndexFailure>> indexFailureQueue;
     private final Counter outputByteCounter;
     private final Counter systemTrafficCounter;
 
     @Inject
     public Messages(MetricRegistry metricRegistry,
-                    JestClient client) {
+                    JestClient client,
+                    ProcessingStatusRecorder processingStatusRecorder) {
         invalidTimestampMeter = metricRegistry.meter(name(Messages.class, "invalid-timestamps"));
         outputByteCounter = metricRegistry.counter(GlobalMetricNames.OUTPUT_TRAFFIC);
         systemTrafficCounter = metricRegistry.counter(GlobalMetricNames.SYSTEM_OUTPUT_TRAFFIC);
         this.client = client;
+        this.processingStatusRecorder = processingStatusRecorder;
 
         // TODO: Magic number
         this.indexFailureQueue =  new LinkedBlockingQueue<>(1000);
@@ -157,9 +162,24 @@ public class Messages {
         }
 
         if (!failedItems.isEmpty()) {
+            final Set<String> failedIds = failedItems.stream().map(item -> item.id).collect(Collectors.toSet());
+            recordTimestamp(messageList, failedIds);
             return propagateFailure(failedItems, messageList, result.getErrorMessage());
         } else {
+            recordTimestamp(messageList, Collections.emptySet());
             return Collections.emptyList();
+        }
+    }
+
+    private void recordTimestamp(List<Map.Entry<IndexSet, Message>> messageList, Set<String> failedIds) {
+        for (Map.Entry<IndexSet, Message> entry : messageList) {
+            final Message message = entry.getValue();
+
+            if (failedIds.contains(message.getId())) {
+                continue;
+            }
+
+            processingStatusRecorder.updatePostIndexingMaxReceiveTime(message.getReceiveTime());
         }
     }
 

--- a/graylog2-server/src/main/java/org/graylog2/indexer/messages/Messages.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/messages/Messages.java
@@ -179,7 +179,7 @@ public class Messages {
                 continue;
             }
 
-            processingStatusRecorder.updatePostIndexingMaxReceiveTime(message.getReceiveTime());
+            processingStatusRecorder.updatePostIndexingReceiveTime(message.getReceiveTime());
         }
     }
 

--- a/graylog2-server/src/main/java/org/graylog2/plugin/Message.java
+++ b/graylog2-server/src/main/java/org/graylog2/plugin/Message.java
@@ -35,6 +35,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import javax.annotation.concurrent.NotThreadSafe;
 import java.net.InetAddress;
 import java.time.Instant;
@@ -226,6 +227,9 @@ public class Message implements Messages {
      * was involved.
      */
     private long journalOffset = Long.MIN_VALUE;
+
+    private DateTime receiveTime;
+    private DateTime processingTime;
 
     private ArrayList<Recording> recordings;
 
@@ -752,6 +756,30 @@ public class Message implements Messages {
 
     public long getJournalOffset() {
         return journalOffset;
+    }
+
+    @Nullable
+    public DateTime getReceiveTime() {
+        return receiveTime;
+    }
+
+    public void setReceiveTime(DateTime receiveTime) {
+        // TODO: In Graylog 3.2 we can set this as field in the message because at that point we have a mapping entry
+        if (receiveTime != null) {
+            this.receiveTime = receiveTime;
+        }
+    }
+
+    @Nullable
+    public DateTime getProcessingTime() {
+        return processingTime;
+    }
+
+    public void setProcessingTime(DateTime processingTime) {
+        // TODO: In Graylog 3.2 we can set this as field in the message because at that point we have a mapping entry
+        if (processingTime != null) {
+            this.processingTime = processingTime;
+        }
     }
 
     // helper methods to optionally record timing information per message, useful for debugging or benchmarking

--- a/graylog2-server/src/main/java/org/graylog2/rest/models/system/processing/ProcessingStatusSummary.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/models/system/processing/ProcessingStatusSummary.java
@@ -27,10 +27,10 @@ import org.joda.time.DateTime;
 @AutoValue
 @JsonDeserialize(builder = ProcessingStatusSummary.Builder.class)
 public abstract class ProcessingStatusSummary {
-    public static final String FIELD_MAX_RECEIVE_TIMES = "max_receive_times";
+    public static final String FIELD_RECEIVE_TIMES = "receive_times";
 
-    @JsonProperty(FIELD_MAX_RECEIVE_TIMES)
-    public abstract MaxReceiveTimes maxReceiveTimes();
+    @JsonProperty(FIELD_RECEIVE_TIMES)
+    public abstract ReceiveTimes receiveTimes();
 
     public static Builder builder() {
         return Builder.create();
@@ -38,20 +38,20 @@ public abstract class ProcessingStatusSummary {
 
     public static ProcessingStatusSummary of(ProcessingStatusRecorder processingStatusRecorder) {
         return builder()
-                .maxReceiveTimes(MaxReceiveTimes.builder()
-                        .preJournal(processingStatusRecorder.getPreJournalMaxReceiveTime())
-                        .postProcessing(processingStatusRecorder.getPostProcessingMaxReceiveTime())
-                        .postIndexing(processingStatusRecorder.getPostIndexingMaxReceiveTime())
+                .receiveTimes(ReceiveTimes.builder()
+                        .preJournal(processingStatusRecorder.getPreJournalReceiveTime())
+                        .postProcessing(processingStatusRecorder.getPostProcessingReceiveTime())
+                        .postIndexing(processingStatusRecorder.getPostIndexingReceiveTime())
                         .build())
                 .build();
     }
 
     public static ProcessingStatusSummary of(ProcessingStatusDto dto) {
         return builder()
-                .maxReceiveTimes(MaxReceiveTimes.builder()
-                        .preJournal(dto.maxReceiveTimes().preJournal())
-                        .postProcessing(dto.maxReceiveTimes().postProcessing())
-                        .postIndexing(dto.maxReceiveTimes().postIndexing())
+                .receiveTimes(ReceiveTimes.builder()
+                        .preJournal(dto.receiveTimes().preJournal())
+                        .postProcessing(dto.receiveTimes().postProcessing())
+                        .postIndexing(dto.receiveTimes().postIndexing())
                         .build())
                 .build();
     }
@@ -65,15 +65,15 @@ public abstract class ProcessingStatusSummary {
             return new AutoValue_ProcessingStatusSummary.Builder();
         }
 
-        @JsonProperty(FIELD_MAX_RECEIVE_TIMES)
-        public abstract Builder maxReceiveTimes(MaxReceiveTimes maxReceiveTimes);
+        @JsonProperty(FIELD_RECEIVE_TIMES)
+        public abstract Builder receiveTimes(ReceiveTimes receiveTimes);
 
         public abstract ProcessingStatusSummary build();
     }
 
     @AutoValue
-    @JsonDeserialize(builder = MaxReceiveTimes.Builder.class)
-    public static abstract class MaxReceiveTimes {
+    @JsonDeserialize(builder = ReceiveTimes.Builder.class)
+    public static abstract class ReceiveTimes {
         public static final String FIELD_PRE_JOURNAL = "pre_journal";
         public static final String FIELD_POST_PROCESSING = "post_processing";
         public static final String FIELD_POST_INDEXING = "post_indexing";
@@ -95,7 +95,7 @@ public abstract class ProcessingStatusSummary {
         public static abstract class Builder {
             @JsonCreator
             public static Builder create() {
-                return new AutoValue_ProcessingStatusSummary_MaxReceiveTimes.Builder();
+                return new AutoValue_ProcessingStatusSummary_ReceiveTimes.Builder();
             }
 
             @JsonProperty(FIELD_PRE_JOURNAL)
@@ -107,7 +107,7 @@ public abstract class ProcessingStatusSummary {
             @JsonProperty(FIELD_POST_INDEXING)
             public abstract Builder postIndexing(DateTime timestamp);
 
-            public abstract MaxReceiveTimes build();
+            public abstract ReceiveTimes build();
         }
     }
 }

--- a/graylog2-server/src/main/java/org/graylog2/rest/models/system/processing/ProcessingStatusSummary.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/models/system/processing/ProcessingStatusSummary.java
@@ -39,7 +39,7 @@ public abstract class ProcessingStatusSummary {
     public static ProcessingStatusSummary of(ProcessingStatusRecorder processingStatusRecorder) {
         return builder()
                 .receiveTimes(ReceiveTimes.builder()
-                        .preJournal(processingStatusRecorder.getPreJournalReceiveTime())
+                        .ingest(processingStatusRecorder.getIngestReceiveTime())
                         .postProcessing(processingStatusRecorder.getPostProcessingReceiveTime())
                         .postIndexing(processingStatusRecorder.getPostIndexingReceiveTime())
                         .build())
@@ -49,7 +49,7 @@ public abstract class ProcessingStatusSummary {
     public static ProcessingStatusSummary of(ProcessingStatusDto dto) {
         return builder()
                 .receiveTimes(ReceiveTimes.builder()
-                        .preJournal(dto.receiveTimes().preJournal())
+                        .ingest(dto.receiveTimes().ingest())
                         .postProcessing(dto.receiveTimes().postProcessing())
                         .postIndexing(dto.receiveTimes().postIndexing())
                         .build())
@@ -74,12 +74,12 @@ public abstract class ProcessingStatusSummary {
     @AutoValue
     @JsonDeserialize(builder = ReceiveTimes.Builder.class)
     public static abstract class ReceiveTimes {
-        public static final String FIELD_PRE_JOURNAL = "pre_journal";
+        public static final String FIELD_INGEST = "ingest";
         public static final String FIELD_POST_PROCESSING = "post_processing";
         public static final String FIELD_POST_INDEXING = "post_indexing";
 
-        @JsonProperty(FIELD_PRE_JOURNAL)
-        public abstract DateTime preJournal();
+        @JsonProperty(FIELD_INGEST)
+        public abstract DateTime ingest();
 
         @JsonProperty(FIELD_POST_PROCESSING)
         public abstract DateTime postProcessing();
@@ -98,8 +98,8 @@ public abstract class ProcessingStatusSummary {
                 return new AutoValue_ProcessingStatusSummary_ReceiveTimes.Builder();
             }
 
-            @JsonProperty(FIELD_PRE_JOURNAL)
-            public abstract Builder preJournal(DateTime timestamp);
+            @JsonProperty(FIELD_INGEST)
+            public abstract Builder ingest(DateTime timestamp);
 
             @JsonProperty(FIELD_POST_PROCESSING)
             public abstract Builder postProcessing(DateTime timestamp);

--- a/graylog2-server/src/main/java/org/graylog2/rest/models/system/processing/ProcessingStatusSummary.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/models/system/processing/ProcessingStatusSummary.java
@@ -1,0 +1,102 @@
+/**
+ * This file is part of Graylog.
+ *
+ * Graylog is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.graylog2.rest.models.system.processing;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.google.auto.value.AutoValue;
+import org.graylog2.system.processing.ProcessingStatusRecorder;
+import org.joda.time.DateTime;
+
+@AutoValue
+@JsonDeserialize(builder = ProcessingStatusSummary.Builder.class)
+public abstract class ProcessingStatusSummary {
+    public static final String FIELD_MAX_RECEIVE_TIMES = "max_receive_times";
+
+    @JsonProperty(FIELD_MAX_RECEIVE_TIMES)
+    public abstract MaxReceiveTimes maxReceiveTimes();
+
+    public static Builder builder() {
+        return Builder.create();
+    }
+
+    public static ProcessingStatusSummary of(ProcessingStatusRecorder processingStatusRecorder) {
+        return builder()
+                .maxReceiveTimes(MaxReceiveTimes.builder()
+                        .preJournal(processingStatusRecorder.getPreJournalMaxReceiveTime())
+                        .postProcessing(processingStatusRecorder.getPostProcessingMaxReceiveTime())
+                        .postIndexing(processingStatusRecorder.getPostIndexingMaxReceiveTime())
+                        .build())
+                .build();
+    }
+
+    public abstract Builder toBuilder();
+
+    @AutoValue.Builder
+    public static abstract class Builder {
+        @JsonCreator
+        public static Builder create() {
+            return new AutoValue_ProcessingStatusSummary.Builder();
+        }
+
+        @JsonProperty(FIELD_MAX_RECEIVE_TIMES)
+        public abstract Builder maxReceiveTimes(MaxReceiveTimes maxReceiveTimes);
+
+        public abstract ProcessingStatusSummary build();
+    }
+
+    @AutoValue
+    @JsonDeserialize(builder = MaxReceiveTimes.Builder.class)
+    public static abstract class MaxReceiveTimes {
+        public static final String FIELD_PRE_JOURNAL = "pre_journal";
+        public static final String FIELD_POST_PROCESSING = "post_processing";
+        public static final String FIELD_POST_INDEXING = "post_indexing";
+
+        @JsonProperty(FIELD_PRE_JOURNAL)
+        public abstract DateTime preJournal();
+
+        @JsonProperty(FIELD_POST_PROCESSING)
+        public abstract DateTime postProcessing();
+
+        @JsonProperty(FIELD_POST_INDEXING)
+        public abstract DateTime postIndexing();
+
+        public static Builder builder() {
+            return Builder.create();
+        }
+
+        @AutoValue.Builder
+        public static abstract class Builder {
+            @JsonCreator
+            public static Builder create() {
+                return new AutoValue_ProcessingStatusSummary_MaxReceiveTimes.Builder();
+            }
+
+            @JsonProperty(FIELD_PRE_JOURNAL)
+            public abstract Builder preJournal(DateTime timestamp);
+
+            @JsonProperty(FIELD_POST_PROCESSING)
+            public abstract Builder postProcessing(DateTime timestamp);
+
+            @JsonProperty(FIELD_POST_INDEXING)
+            public abstract Builder postIndexing(DateTime timestamp);
+
+            public abstract MaxReceiveTimes build();
+        }
+    }
+}

--- a/graylog2-server/src/main/java/org/graylog2/rest/models/system/processing/ProcessingStatusSummary.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/models/system/processing/ProcessingStatusSummary.java
@@ -20,6 +20,7 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.google.auto.value.AutoValue;
+import org.graylog2.system.processing.ProcessingStatusDto;
 import org.graylog2.system.processing.ProcessingStatusRecorder;
 import org.joda.time.DateTime;
 
@@ -41,6 +42,16 @@ public abstract class ProcessingStatusSummary {
                         .preJournal(processingStatusRecorder.getPreJournalMaxReceiveTime())
                         .postProcessing(processingStatusRecorder.getPostProcessingMaxReceiveTime())
                         .postIndexing(processingStatusRecorder.getPostIndexingMaxReceiveTime())
+                        .build())
+                .build();
+    }
+
+    public static ProcessingStatusSummary of(ProcessingStatusDto dto) {
+        return builder()
+                .maxReceiveTimes(MaxReceiveTimes.builder()
+                        .preJournal(dto.maxReceiveTimes().preJournal())
+                        .postProcessing(dto.maxReceiveTimes().postProcessing())
+                        .postIndexing(dto.maxReceiveTimes().postIndexing())
                         .build())
                 .build();
     }

--- a/graylog2-server/src/main/java/org/graylog2/rest/resources/system/processing/ClusterProcessingStatusResource.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/resources/system/processing/ClusterProcessingStatusResource.java
@@ -52,8 +52,16 @@ public class ClusterProcessingStatusResource extends ProxiedResource {
 
     @GET
     @Timed
-    @ApiOperation(value = "Get processing progress from all nodes in the cluster")
-    public Map<String, Optional<ProcessingStatusSummary>> getProgress() {
+    @ApiOperation(value = "Get processing status from all nodes in the cluster")
+    public Map<String, Optional<ProcessingStatusSummary>> getStatus() {
         return getForAllNodes(RemoteSystemProcessingStatusResource::getStatus, createRemoteInterfaceProvider(RemoteSystemProcessingStatusResource.class));
+    }
+
+    @GET
+    @Path("/persisted")
+    @Timed
+    @ApiOperation(value = "Get persisted processing status from all nodes in the cluster")
+    public Map<String, Optional<ProcessingStatusSummary>> getPersistedStatus() {
+        return getForAllNodes(RemoteSystemProcessingStatusResource::getPersistedStatus, createRemoteInterfaceProvider(RemoteSystemProcessingStatusResource.class));
     }
 }

--- a/graylog2-server/src/main/java/org/graylog2/rest/resources/system/processing/ClusterProcessingStatusResource.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/resources/system/processing/ClusterProcessingStatusResource.java
@@ -1,0 +1,59 @@
+/**
+ * This file is part of Graylog.
+ *
+ * Graylog is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.graylog2.rest.resources.system.processing;
+
+import com.codahale.metrics.annotation.Timed;
+import io.swagger.annotations.Api;
+import io.swagger.annotations.ApiOperation;
+import org.apache.shiro.authz.annotation.RequiresAuthentication;
+import org.graylog2.cluster.NodeService;
+import org.graylog2.rest.RemoteInterfaceProvider;
+import org.graylog2.rest.models.system.processing.ProcessingStatusSummary;
+import org.graylog2.shared.rest.resources.ProxiedResource;
+
+import javax.inject.Inject;
+import javax.inject.Named;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.Context;
+import javax.ws.rs.core.HttpHeaders;
+import javax.ws.rs.core.MediaType;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.ExecutorService;
+
+@RequiresAuthentication
+@Api(value = "Cluster/Processing/Status")
+@Path("/cluster/processing/status")
+@Produces(MediaType.APPLICATION_JSON)
+public class ClusterProcessingStatusResource extends ProxiedResource {
+    @Inject
+    public ClusterProcessingStatusResource(NodeService nodeService,
+                                           RemoteInterfaceProvider remoteInterfaceProvider,
+                                           @Context HttpHeaders httpHeaders,
+                                           @Named("proxiedRequestsExecutorService") ExecutorService executorService) {
+        super(httpHeaders, nodeService, remoteInterfaceProvider, executorService);
+    }
+
+    @GET
+    @Timed
+    @ApiOperation(value = "Get processing progress from all nodes in the cluster")
+    public Map<String, Optional<ProcessingStatusSummary>> getProgress() {
+        return getForAllNodes(RemoteSystemProcessingStatusResource::getStatus, createRemoteInterfaceProvider(RemoteSystemProcessingStatusResource.class));
+    }
+}

--- a/graylog2-server/src/main/java/org/graylog2/rest/resources/system/processing/RemoteSystemProcessingStatusResource.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/resources/system/processing/RemoteSystemProcessingStatusResource.java
@@ -23,4 +23,7 @@ import retrofit2.http.GET;
 public interface RemoteSystemProcessingStatusResource {
     @GET("system/processing/status")
     Call<ProcessingStatusSummary> getStatus();
+
+    @GET("system/processing/status/persisted")
+    Call<ProcessingStatusSummary> getPersistedStatus();
 }

--- a/graylog2-server/src/main/java/org/graylog2/rest/resources/system/processing/RemoteSystemProcessingStatusResource.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/resources/system/processing/RemoteSystemProcessingStatusResource.java
@@ -1,0 +1,26 @@
+/**
+ * This file is part of Graylog.
+ *
+ * Graylog is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.graylog2.rest.resources.system.processing;
+
+import org.graylog2.rest.models.system.processing.ProcessingStatusSummary;
+import retrofit2.Call;
+import retrofit2.http.GET;
+
+public interface RemoteSystemProcessingStatusResource {
+    @GET("system/processing/status")
+    Call<ProcessingStatusSummary> getStatus();
+}

--- a/graylog2-server/src/main/java/org/graylog2/rest/resources/system/processing/SystemProcessingStatusResource.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/resources/system/processing/SystemProcessingStatusResource.java
@@ -1,0 +1,51 @@
+/**
+ * This file is part of Graylog.
+ *
+ * Graylog is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.graylog2.rest.resources.system.processing;
+
+import com.codahale.metrics.annotation.Timed;
+import io.swagger.annotations.Api;
+import io.swagger.annotations.ApiOperation;
+import org.apache.shiro.authz.annotation.RequiresAuthentication;
+import org.graylog2.rest.models.system.processing.ProcessingStatusSummary;
+import org.graylog2.shared.rest.resources.RestResource;
+import org.graylog2.system.processing.ProcessingStatusRecorder;
+
+import javax.inject.Inject;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
+
+@Api(value = "System/Processing/Status")
+@Path("/system/processing/status")
+@RequiresAuthentication
+@Produces(MediaType.APPLICATION_JSON)
+public class SystemProcessingStatusResource extends RestResource {
+    private final ProcessingStatusRecorder processingStatusRecorder;
+
+    @Inject
+    public SystemProcessingStatusResource(ProcessingStatusRecorder processingStatusRecorder) {
+        this.processingStatusRecorder = processingStatusRecorder;
+    }
+
+    @GET
+    @Timed
+    @ApiOperation(value = "Get processing status summary from node")
+    public ProcessingStatusSummary getProgress() {
+        return ProcessingStatusSummary.of(processingStatusRecorder);
+    }
+}

--- a/graylog2-server/src/main/java/org/graylog2/shared/bindings/GenericInitializerBindings.java
+++ b/graylog2-server/src/main/java/org/graylog2/shared/bindings/GenericInitializerBindings.java
@@ -19,18 +19,23 @@ package org.graylog2.shared.bindings;
 import com.google.common.util.concurrent.Service;
 import com.google.inject.AbstractModule;
 import com.google.inject.multibindings.Multibinder;
-import org.graylog2.system.shutdown.GracefulShutdownService;
 import org.graylog2.shared.initializers.InputSetupService;
 import org.graylog2.shared.initializers.JerseyService;
 import org.graylog2.shared.initializers.PeriodicalsService;
+import org.graylog2.system.processing.MongoDBProcessingStatusRecorderService;
+import org.graylog2.system.processing.ProcessingStatusRecorder;
+import org.graylog2.system.shutdown.GracefulShutdownService;
 
 public class GenericInitializerBindings extends AbstractModule {
     @Override
     protected void configure() {
+        bind(ProcessingStatusRecorder.class).to(MongoDBProcessingStatusRecorderService.class).asEagerSingleton();
+
         Multibinder<Service> serviceBinder = Multibinder.newSetBinder(binder(), Service.class);
         serviceBinder.addBinding().to(InputSetupService.class);
         serviceBinder.addBinding().to(PeriodicalsService.class);
         serviceBinder.addBinding().to(JerseyService.class);
         serviceBinder.addBinding().to(GracefulShutdownService.class).asEagerSingleton();
+        serviceBinder.addBinding().to(MongoDBProcessingStatusRecorderService.class).asEagerSingleton();
     }
 }

--- a/graylog2-server/src/main/java/org/graylog2/shared/buffers/DirectMessageHandler.java
+++ b/graylog2-server/src/main/java/org/graylog2/shared/buffers/DirectMessageHandler.java
@@ -17,21 +17,30 @@
 package org.graylog2.shared.buffers;
 
 import com.lmax.disruptor.WorkHandler;
+import org.graylog2.plugin.journal.RawMessage;
+import org.graylog2.system.processing.ProcessingStatusRecorder;
 
 import javax.inject.Inject;
 
 class DirectMessageHandler implements WorkHandler<RawMessageEvent> {
 
     private final ProcessBuffer processBuffer;
+    private final ProcessingStatusRecorder processingStatusRecorder;
 
     @Inject
-    public DirectMessageHandler(ProcessBuffer processBuffer) {
+    public DirectMessageHandler(ProcessBuffer processBuffer,
+                                ProcessingStatusRecorder processingStatusRecorder) {
         this.processBuffer = processBuffer;
+        this.processingStatusRecorder = processingStatusRecorder;
     }
 
     @Override
     public void onEvent(RawMessageEvent event) throws Exception {
-        processBuffer.insertBlocking(event.getRawMessage());
+        final RawMessage rawMessage = event.getRawMessage();
+        processBuffer.insertBlocking(rawMessage);
+        if (rawMessage != null) {
+            processingStatusRecorder.updateIngestReceiveTime(rawMessage.getTimestamp());
+        }
         // clear out for gc and to avoid promoting the raw message event to a tenured gen
         event.setRawMessage(null);
     }

--- a/graylog2-server/src/main/java/org/graylog2/shared/buffers/JournallingMessageHandler.java
+++ b/graylog2-server/src/main/java/org/graylog2/shared/buffers/JournallingMessageHandler.java
@@ -105,7 +105,7 @@ public class JournallingMessageHandler implements EventHandler<RawMessageEvent> 
 
                 // The converter computed the latest receive timestamp of all messages in the batch so we don't have to
                 // call the update on the recorder service for every message. (less contention)
-                processingStatusRecorder.updatePreJournalReceiveTime(converter.getLatestReceiveTime());
+                processingStatusRecorder.updateIngestReceiveTime(converter.getLatestReceiveTime());
             } catch (Exception e) {
                 log.error("Unable to write to journal - retrying", e);
 

--- a/graylog2-server/src/main/java/org/graylog2/shared/buffers/JournallingMessageHandler.java
+++ b/graylog2-server/src/main/java/org/graylog2/shared/buffers/JournallingMessageHandler.java
@@ -27,6 +27,9 @@ import com.google.common.base.Predicate;
 import com.google.common.collect.Lists;
 import com.lmax.disruptor.EventHandler;
 import org.graylog2.shared.journal.Journal;
+import org.graylog2.system.processing.ProcessingStatusRecorder;
+import org.joda.time.DateTime;
+import org.joda.time.DateTimeZone;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -61,11 +64,16 @@ public class JournallingMessageHandler implements EventHandler<RawMessageEvent> 
     private final List<RawMessageEvent> batch = Lists.newArrayList();
     private final Counter byteCounter;
     private final Journal journal;
+    private final ProcessingStatusRecorder processingStatusRecorder;
     private final Semaphore journalFilled;
 
     @Inject
-    public JournallingMessageHandler(MetricRegistry metrics, Journal journal, @Named("JournalSignal") Semaphore journalFilled) {
+    public JournallingMessageHandler(MetricRegistry metrics,
+                                     Journal journal,
+                                     ProcessingStatusRecorder processingStatusRecorder,
+                                     @Named("JournalSignal") Semaphore journalFilled) {
         this.journal = journal;
+        this.processingStatusRecorder = processingStatusRecorder;
         this.journalFilled = journalFilled;
         byteCounter = metrics.counter(MetricRegistry.name(JournallingMessageHandler.class, "written_bytes"));
     }
@@ -94,6 +102,10 @@ public class JournallingMessageHandler implements EventHandler<RawMessageEvent> 
             // continue.
             try {
                 writeToJournal(converter, entries);
+
+                // The converter computed the max receive timestamp of all messages in the batch so we don't have to
+                // call the update on the recorder service for every message. (less contention)
+                processingStatusRecorder.updatePreJournalMaxReceiveTime(converter.getMaxReceiveTime());
             } catch (Exception e) {
                 log.error("Unable to write to journal - retrying", e);
 
@@ -119,9 +131,14 @@ public class JournallingMessageHandler implements EventHandler<RawMessageEvent> 
 
     private class Converter implements Function<RawMessageEvent, Journal.Entry> {
         private long bytesWritten = 0;
+        private DateTime maxReceiveTime = new DateTime(0L, DateTimeZone.UTC);
 
         public long getBytesWritten() {
             return bytesWritten;
+        }
+
+        public DateTime getMaxReceiveTime() {
+            return maxReceiveTime;
         }
 
         @Nullable
@@ -139,9 +156,15 @@ public class JournallingMessageHandler implements EventHandler<RawMessageEvent> 
                 bytesWritten += size;
                 byteCounter.inc(size);
 
+                final DateTime messageTimestamp = input.getMessageTimestamp();
+                if (messageTimestamp != null) {
+                    maxReceiveTime = maxReceiveTime.isBefore(messageTimestamp) ? messageTimestamp : maxReceiveTime;
+                }
+
                 // clear for gc and to avoid promotion to tenured space
                 input.setMessageIdBytes(null);
                 input.setEncodedRawMessage(null);
+                input.setMessageTimestamp(null);
                 // convert to journal entry
                 return journal.createEntry(messageIdBytes, encodedRawMessage);
             } catch (Exception e) {

--- a/graylog2-server/src/main/java/org/graylog2/shared/buffers/RawMessageEncoderHandler.java
+++ b/graylog2-server/src/main/java/org/graylog2/shared/buffers/RawMessageEncoderHandler.java
@@ -45,7 +45,10 @@ public class RawMessageEncoderHandler implements WorkHandler<RawMessageEvent> {
             log.trace("Serialized message {} for journal, size {} bytes",
                       event.getRawMessage().getId(), event.getEncodedRawMessage().length);
         }
-        
+
+        // Set timestamp in event to retain access to it after we clear the raw message object below
+        event.setMessageTimestamp(event.getRawMessage().getTimestamp());
+
         // clear for gc and to avoid promotion to tenured space
         event.setRawMessage(null);
     }

--- a/graylog2-server/src/main/java/org/graylog2/shared/buffers/RawMessageEvent.java
+++ b/graylog2-server/src/main/java/org/graylog2/shared/buffers/RawMessageEvent.java
@@ -21,6 +21,7 @@ import com.google.common.base.MoreObjects;
 import com.lmax.disruptor.EventFactory;
 import com.lmax.disruptor.EventTranslatorOneArg;
 import org.graylog2.plugin.journal.RawMessage;
+import org.joda.time.DateTime;
 
 import java.nio.ByteBuffer;
 
@@ -32,6 +33,9 @@ public class RawMessageEvent {
     // once these fields are set, do NOT rely on rawMessage still being non-null!
     private byte[] messageIdBytes;
     private byte[] encodedRawMessage;
+
+    // We need access to the raw message timestamp after the raw message has been cleared
+    private DateTime messageTimestamp;
 
     public static final EventFactory<RawMessageEvent> FACTORY = new EventFactory<RawMessageEvent>() {
         @Override
@@ -77,6 +81,14 @@ public class RawMessageEvent {
 
     public byte[] getMessageIdBytes() {
         return messageIdBytes;
+    }
+
+    public DateTime getMessageTimestamp() {
+        return messageTimestamp;
+    }
+
+    public void setMessageTimestamp(DateTime messageTimestamp) {
+        this.messageTimestamp = messageTimestamp;
     }
 
     // performance doesn't matter, it's only being called during tracing

--- a/graylog2-server/src/main/java/org/graylog2/shared/buffers/processors/DecodingProcessor.java
+++ b/graylog2-server/src/main/java/org/graylog2/shared/buffers/processors/DecodingProcessor.java
@@ -249,6 +249,10 @@ public class DecodingProcessor implements EventHandler<MessageEvent> {
             message.setSource("unknown");
         }
 
+        // The raw message timestamp is the receive time of the message. It has been created before writing the raw
+        // message to the journal.
+        message.setReceiveTime(raw.getTimestamp());
+
         metricRegistry.meter(name(baseMetricName, "processedMessages")).mark();
         decodedTrafficCounter.inc(message.getSize());
         return message;

--- a/graylog2-server/src/main/java/org/graylog2/shared/buffers/processors/ProcessBufferProcessor.java
+++ b/graylog2-server/src/main/java/org/graylog2/shared/buffers/processors/ProcessBufferProcessor.java
@@ -124,7 +124,7 @@ public class ProcessBufferProcessor implements WorkHandler<MessageEvent> {
         for (Message message : messages) {
             // The processing time should only be set once all message processors have finished
             message.setProcessingTime(Tools.nowUTC());
-            processingStatusRecorder.updatePostProcessingMaxReceiveTime(message.getReceiveTime());
+            processingStatusRecorder.updatePostProcessingReceiveTime(message.getReceiveTime());
 
             outputBuffer.insertBlocking(message);
         }

--- a/graylog2-server/src/main/java/org/graylog2/system/processing/DBProcessingStatusService.java
+++ b/graylog2-server/src/main/java/org/graylog2/system/processing/DBProcessingStatusService.java
@@ -1,0 +1,76 @@
+/**
+ * This file is part of Graylog.
+ *
+ * Graylog is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.graylog2.system.processing;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.collect.ImmutableList;
+import com.mongodb.BasicDBObject;
+import org.bson.types.ObjectId;
+import org.graylog2.bindings.providers.MongoJackObjectMapperProvider;
+import org.graylog2.database.MongoConnection;
+import org.graylog2.plugin.system.NodeId;
+import org.joda.time.DateTime;
+import org.joda.time.DateTimeZone;
+import org.mongojack.DBQuery;
+import org.mongojack.DBSort;
+import org.mongojack.JacksonDBCollection;
+
+import javax.inject.Inject;
+import java.util.List;
+
+public class DBProcessingStatusService {
+    private static final String COLLECTION_NAME = "processing_status";
+
+    private final String nodeId;
+    private final JacksonDBCollection<ProcessingStatusDto, ObjectId> db;
+
+    @Inject
+    public DBProcessingStatusService(MongoConnection mongoConnection,
+                                     NodeId nodeId,
+                                     MongoJackObjectMapperProvider mapper) {
+        this.nodeId = nodeId.toString();
+        this.db = JacksonDBCollection.wrap(mongoConnection.getDatabase().getCollection(COLLECTION_NAME),
+                ProcessingStatusDto.class,
+                ObjectId.class,
+                mapper.get());
+
+        db.createIndex(new BasicDBObject(ProcessingStatusDto.FIELD_NODE_ID, 1), new BasicDBObject("unique", true));
+    }
+
+    public List<ProcessingStatusDto> all() {
+        return ImmutableList.copyOf(db.find().sort(DBSort.desc("_id")).iterator());
+    }
+
+    public ProcessingStatusDto save(ProcessingStatusRecorder processingStatusRecorder) {
+        return save(processingStatusRecorder, DateTime.now(DateTimeZone.UTC));
+    }
+
+    @VisibleForTesting
+    ProcessingStatusDto save(ProcessingStatusRecorder processingStatusRecorder, DateTime updatedAt) {
+        // TODO: Using a timestamp provided by the node for "updated_at" can be bad if the node clock is skewed.
+        //       Ideally we would use MongoDB's "$currentDate" but there doesn't seem to be a way to use that
+        //       with mongojack.
+        return db.findAndModify(
+                DBQuery.is(ProcessingStatusDto.FIELD_NODE_ID, nodeId),
+                null,
+                null,
+                false,
+                ProcessingStatusDto.of(nodeId, processingStatusRecorder, updatedAt),
+                true, // We want to return the updated document to the caller
+                true);
+    }
+}

--- a/graylog2-server/src/main/java/org/graylog2/system/processing/DBProcessingStatusService.java
+++ b/graylog2-server/src/main/java/org/graylog2/system/processing/DBProcessingStatusService.java
@@ -31,7 +31,11 @@ import org.mongojack.JacksonDBCollection;
 
 import javax.inject.Inject;
 import java.util.List;
+import java.util.Optional;
 
+/**
+ * Manages the database collection for processing status.
+ */
 public class DBProcessingStatusService {
     private static final String COLLECTION_NAME = "processing_status";
 
@@ -51,10 +55,31 @@ public class DBProcessingStatusService {
         db.createIndex(new BasicDBObject(ProcessingStatusDto.FIELD_NODE_ID, 1), new BasicDBObject("unique", true));
     }
 
+    /**
+     * Rerturns all existing processing status entries from the database.
+     *
+     * @return a list of all processing status entries
+     */
     public List<ProcessingStatusDto> all() {
         return ImmutableList.copyOf(db.find().sort(DBSort.desc("_id")).iterator());
     }
 
+    /**
+     * Returns the processing status entry for the calling node.
+     *
+     * @return the processing status entry or an empty optional if none exists
+     */
+    public Optional<ProcessingStatusDto> get() {
+        return Optional.ofNullable(db.findOne(DBQuery.is(ProcessingStatusDto.FIELD_NODE_ID, nodeId)));
+    }
+
+    /**
+     * Create or update (upsert) a processing status entry for the given {@link ProcessingStatusRecorder} using the
+     * caller's node ID.
+     *
+     * @param processingStatusRecorder the processing recorder object to create/update
+     * @return the created/updated entry
+     */
     public ProcessingStatusDto save(ProcessingStatusRecorder processingStatusRecorder) {
         return save(processingStatusRecorder, DateTime.now(DateTimeZone.UTC));
     }

--- a/graylog2-server/src/main/java/org/graylog2/system/processing/InMemoryProcessingStatusRecorder.java
+++ b/graylog2-server/src/main/java/org/graylog2/system/processing/InMemoryProcessingStatusRecorder.java
@@ -28,47 +28,47 @@ import static org.joda.time.DateTimeZone.UTC;
  */
 @Singleton
 public class InMemoryProcessingStatusRecorder implements ProcessingStatusRecorder {
-    private final AtomicReference<DateTime> preJournalMaxReceiveTime = new AtomicReference<>(new DateTime(0L, UTC));
-    private final AtomicReference<DateTime> postProcessingMaxReceiveTime = new AtomicReference<>(new DateTime(0L, UTC));
-    private final AtomicReference<DateTime> postIndexMaxReceiveTime = new AtomicReference<>(new DateTime(0L, UTC));
+    private final AtomicReference<DateTime> preJournalReceiveTime = new AtomicReference<>(new DateTime(0L, UTC));
+    private final AtomicReference<DateTime> postProcessingReceiveTime = new AtomicReference<>(new DateTime(0L, UTC));
+    private final AtomicReference<DateTime> postIndexReceiveTime = new AtomicReference<>(new DateTime(0L, UTC));
 
     @Override
-    public DateTime getPreJournalMaxReceiveTime() {
-        return preJournalMaxReceiveTime.get();
+    public DateTime getPreJournalReceiveTime() {
+        return preJournalReceiveTime.get();
     }
 
     @Override
-    public DateTime getPostProcessingMaxReceiveTime() {
-        return postProcessingMaxReceiveTime.get();
+    public DateTime getPostProcessingReceiveTime() {
+        return postProcessingReceiveTime.get();
     }
 
     @Override
-    public DateTime getPostIndexingMaxReceiveTime() {
-        return postIndexMaxReceiveTime.get();
+    public DateTime getPostIndexingReceiveTime() {
+        return postIndexReceiveTime.get();
     }
 
     @Override
-    public void updatePreJournalMaxReceiveTime(DateTime newTimestamp) {
+    public void updatePreJournalReceiveTime(DateTime newTimestamp) {
         if (newTimestamp != null) {
-            preJournalMaxReceiveTime.updateAndGet(timestamp -> maxTimestamp(timestamp, newTimestamp));
+            preJournalReceiveTime.updateAndGet(timestamp -> latestTimestamp(timestamp, newTimestamp));
         }
     }
 
     @Override
-    public void updatePostProcessingMaxReceiveTime(DateTime newTimestamp) {
+    public void updatePostProcessingReceiveTime(DateTime newTimestamp) {
         if (newTimestamp != null) {
-            postProcessingMaxReceiveTime.updateAndGet(timestamp -> maxTimestamp(timestamp, newTimestamp));
+            postProcessingReceiveTime.updateAndGet(timestamp -> latestTimestamp(timestamp, newTimestamp));
         }
     }
 
     @Override
-    public void updatePostIndexingMaxReceiveTime(DateTime newTimestamp) {
+    public void updatePostIndexingReceiveTime(DateTime newTimestamp) {
         if (newTimestamp != null) {
-            postIndexMaxReceiveTime.updateAndGet(timestamp -> maxTimestamp(timestamp, newTimestamp));
+            postIndexReceiveTime.updateAndGet(timestamp -> latestTimestamp(timestamp, newTimestamp));
         }
     }
 
-    private DateTime maxTimestamp(DateTime timestamp, DateTime newTimestamp) {
+    private DateTime latestTimestamp(DateTime timestamp, DateTime newTimestamp) {
         return newTimestamp.isAfter(timestamp) ? newTimestamp : timestamp;
     }
 }

--- a/graylog2-server/src/main/java/org/graylog2/system/processing/InMemoryProcessingStatusRecorder.java
+++ b/graylog2-server/src/main/java/org/graylog2/system/processing/InMemoryProcessingStatusRecorder.java
@@ -28,13 +28,13 @@ import static org.joda.time.DateTimeZone.UTC;
  */
 @Singleton
 public class InMemoryProcessingStatusRecorder implements ProcessingStatusRecorder {
-    private final AtomicReference<DateTime> preJournalReceiveTime = new AtomicReference<>(new DateTime(0L, UTC));
+    private final AtomicReference<DateTime> ingestReceiveTime = new AtomicReference<>(new DateTime(0L, UTC));
     private final AtomicReference<DateTime> postProcessingReceiveTime = new AtomicReference<>(new DateTime(0L, UTC));
     private final AtomicReference<DateTime> postIndexReceiveTime = new AtomicReference<>(new DateTime(0L, UTC));
 
     @Override
-    public DateTime getPreJournalReceiveTime() {
-        return preJournalReceiveTime.get();
+    public DateTime getIngestReceiveTime() {
+        return ingestReceiveTime.get();
     }
 
     @Override
@@ -48,9 +48,9 @@ public class InMemoryProcessingStatusRecorder implements ProcessingStatusRecorde
     }
 
     @Override
-    public void updatePreJournalReceiveTime(DateTime newTimestamp) {
+    public void updateIngestReceiveTime(DateTime newTimestamp) {
         if (newTimestamp != null) {
-            preJournalReceiveTime.updateAndGet(timestamp -> latestTimestamp(timestamp, newTimestamp));
+            ingestReceiveTime.updateAndGet(timestamp -> latestTimestamp(timestamp, newTimestamp));
         }
     }
 

--- a/graylog2-server/src/main/java/org/graylog2/system/processing/InMemoryProcessingStatusRecorder.java
+++ b/graylog2-server/src/main/java/org/graylog2/system/processing/InMemoryProcessingStatusRecorder.java
@@ -23,6 +23,9 @@ import java.util.concurrent.atomic.AtomicReference;
 
 import static org.joda.time.DateTimeZone.UTC;
 
+/**
+ * This {@link ProcessingStatusRecorder} implementation should only be used for tests.
+ */
 @Singleton
 public class InMemoryProcessingStatusRecorder implements ProcessingStatusRecorder {
     private final AtomicReference<DateTime> preJournalMaxReceiveTime = new AtomicReference<>(new DateTime(0L, UTC));

--- a/graylog2-server/src/main/java/org/graylog2/system/processing/InMemoryProcessingStatusRecorder.java
+++ b/graylog2-server/src/main/java/org/graylog2/system/processing/InMemoryProcessingStatusRecorder.java
@@ -1,0 +1,71 @@
+/**
+ * This file is part of Graylog.
+ *
+ * Graylog is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.graylog2.system.processing;
+
+import org.joda.time.DateTime;
+
+import javax.inject.Singleton;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.joda.time.DateTimeZone.UTC;
+
+@Singleton
+public class InMemoryProcessingStatusRecorder implements ProcessingStatusRecorder {
+    private final AtomicReference<DateTime> preJournalMaxReceiveTime = new AtomicReference<>(new DateTime(0L, UTC));
+    private final AtomicReference<DateTime> postProcessingMaxReceiveTime = new AtomicReference<>(new DateTime(0L, UTC));
+    private final AtomicReference<DateTime> postIndexMaxReceiveTime = new AtomicReference<>(new DateTime(0L, UTC));
+
+    @Override
+    public DateTime getPreJournalMaxReceiveTime() {
+        return preJournalMaxReceiveTime.get();
+    }
+
+    @Override
+    public DateTime getPostProcessingMaxReceiveTime() {
+        return postProcessingMaxReceiveTime.get();
+    }
+
+    @Override
+    public DateTime getPostIndexingMaxReceiveTime() {
+        return postIndexMaxReceiveTime.get();
+    }
+
+    @Override
+    public void updatePreJournalMaxReceiveTime(DateTime newTimestamp) {
+        if (newTimestamp != null) {
+            preJournalMaxReceiveTime.updateAndGet(timestamp -> maxTimestamp(timestamp, newTimestamp));
+        }
+    }
+
+    @Override
+    public void updatePostProcessingMaxReceiveTime(DateTime newTimestamp) {
+        if (newTimestamp != null) {
+            postProcessingMaxReceiveTime.updateAndGet(timestamp -> maxTimestamp(timestamp, newTimestamp));
+        }
+    }
+
+    @Override
+    public void updatePostIndexingMaxReceiveTime(DateTime newTimestamp) {
+        if (newTimestamp != null) {
+            postIndexMaxReceiveTime.updateAndGet(timestamp -> maxTimestamp(timestamp, newTimestamp));
+        }
+    }
+
+    private DateTime maxTimestamp(DateTime timestamp, DateTime newTimestamp) {
+        return newTimestamp.isAfter(timestamp) ? newTimestamp : timestamp;
+    }
+}

--- a/graylog2-server/src/main/java/org/graylog2/system/processing/MongoDBProcessingStatusRecorderService.java
+++ b/graylog2-server/src/main/java/org/graylog2/system/processing/MongoDBProcessingStatusRecorderService.java
@@ -16,13 +16,18 @@
  */
 package org.graylog2.system.processing;
 
+import com.github.joschi.jadconfig.util.Duration;
 import com.google.common.util.concurrent.AbstractIdleService;
 import org.joda.time.DateTime;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import javax.inject.Inject;
+import javax.inject.Named;
 import javax.inject.Singleton;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 
 import static org.joda.time.DateTimeZone.UTC;
@@ -31,25 +36,64 @@ import static org.joda.time.DateTimeZone.UTC;
 public class MongoDBProcessingStatusRecorderService extends AbstractIdleService implements ProcessingStatusRecorder {
     private static final Logger LOG = LoggerFactory.getLogger(MongoDBProcessingStatusRecorderService.class);
 
-    private final AtomicReference<DateTime> preJournalMaxReceiveTime = new AtomicReference<>(new DateTime(0L, UTC));
-    private final AtomicReference<DateTime> postProcessingMaxReceiveTime = new AtomicReference<>(new DateTime(0L, UTC));
-    private final AtomicReference<DateTime> postIndexMaxReceiveTime = new AtomicReference<>(new DateTime(0L, UTC));
+    private static final DateTime DEFAULT_RECEIVE_TIME = new DateTime(0L, UTC);
+
+    private final AtomicReference<DateTime> preJournalMaxReceiveTime = new AtomicReference<>(DEFAULT_RECEIVE_TIME);
+    private final AtomicReference<DateTime> postProcessingMaxReceiveTime = new AtomicReference<>(DEFAULT_RECEIVE_TIME);
+    private final AtomicReference<DateTime> postIndexMaxReceiveTime = new AtomicReference<>(DEFAULT_RECEIVE_TIME);
 
     private final DBProcessingStatusService dbService;
+    private final Duration persistInterval;
+    private final ScheduledExecutorService scheduler;
+    private ScheduledFuture<?> future;
 
     @Inject
-    public MongoDBProcessingStatusRecorderService(DBProcessingStatusService dbService) {
+    public MongoDBProcessingStatusRecorderService(DBProcessingStatusService dbService,
+                                                  @Named(ProcessingStatusConfig.PERSIST_INTERVAL) Duration persistInterval,
+                                                  @Named("daemonScheduler") ScheduledExecutorService scheduler) {
         this.dbService = dbService;
+        this.persistInterval = persistInterval;
+        this.scheduler = scheduler;
     }
 
     @Override
-    protected void startUp() throws Exception {
-        // TODO: Load persisted state from database and use maxTimestamp to avoid overwriting already updated values
+    protected void startUp() {
+        LOG.debug("Starting processing status recorder service");
+        try {
+            dbService.get().ifPresent(processingStatus -> {
+                LOG.debug("Loaded persisted processing status: {}", processingStatus);
+
+                // Do not directly set the timestamps on the atomic reference to make sure maxTimestamp() is used.
+                // The timestamps could already have been updated once the database call is finished.
+                final ProcessingStatusDto.MaxReceiveTimes maxReceiveTimes = processingStatus.maxReceiveTimes();
+                updatePreJournalMaxReceiveTime(maxReceiveTimes.preJournal());
+                updatePostProcessingMaxReceiveTime(maxReceiveTimes.postProcessing());
+                updatePostIndexingMaxReceiveTime(maxReceiveTimes.postIndexing());
+            });
+        } catch (Exception e) {
+            LOG.error("Couldn't load persisted processing status", e);
+        }
+
+        final long interval = persistInterval.toMilliseconds();
+        future = scheduler.scheduleWithFixedDelay(this::doPersist, interval, interval, TimeUnit.MILLISECONDS);
     }
 
     @Override
-    protected void shutDown() throws Exception {
-        // TODO: Persist state to database
+    protected void shutDown() {
+        LOG.debug("Shutting down processing status recorder service");
+        if (future != null) {
+            future.cancel(true);
+        }
+        doPersist();
+    }
+
+    private void doPersist() {
+        try {
+            final ProcessingStatusDto dto = dbService.save(this);
+            LOG.debug("Persisted processing status: {}", dto);
+        } catch (Exception e) {
+            LOG.error("Couldn't persist processing status", e);
+        }
     }
 
     @Override

--- a/graylog2-server/src/main/java/org/graylog2/system/processing/MongoDBProcessingStatusRecorderService.java
+++ b/graylog2-server/src/main/java/org/graylog2/system/processing/MongoDBProcessingStatusRecorderService.java
@@ -38,7 +38,7 @@ public class MongoDBProcessingStatusRecorderService extends AbstractIdleService 
 
     private static final DateTime DEFAULT_RECEIVE_TIME = new DateTime(0L, UTC);
 
-    private final AtomicReference<DateTime> preJournalReceiveTime = new AtomicReference<>(DEFAULT_RECEIVE_TIME);
+    private final AtomicReference<DateTime> ingestReceiveTime = new AtomicReference<>(DEFAULT_RECEIVE_TIME);
     private final AtomicReference<DateTime> postProcessingReceiveTime = new AtomicReference<>(DEFAULT_RECEIVE_TIME);
     private final AtomicReference<DateTime> postIndexReceiveTime = new AtomicReference<>(DEFAULT_RECEIVE_TIME);
 
@@ -66,7 +66,7 @@ public class MongoDBProcessingStatusRecorderService extends AbstractIdleService 
                 // Do not directly set the timestamps on the atomic reference to make sure latestTimestamp() is used.
                 // The timestamps could already have been updated once the database call is finished.
                 final ProcessingStatusDto.ReceiveTimes receiveTimes = processingStatus.receiveTimes();
-                updatePreJournalReceiveTime(receiveTimes.preJournal());
+                updateIngestReceiveTime(receiveTimes.ingest());
                 updatePostProcessingReceiveTime(receiveTimes.postProcessing());
                 updatePostIndexingReceiveTime(receiveTimes.postIndexing());
             });
@@ -97,8 +97,8 @@ public class MongoDBProcessingStatusRecorderService extends AbstractIdleService 
     }
 
     @Override
-    public DateTime getPreJournalReceiveTime() {
-        return preJournalReceiveTime.get();
+    public DateTime getIngestReceiveTime() {
+        return ingestReceiveTime.get();
     }
 
     @Override
@@ -112,9 +112,9 @@ public class MongoDBProcessingStatusRecorderService extends AbstractIdleService 
     }
 
     @Override
-    public void updatePreJournalReceiveTime(DateTime newTimestamp) {
+    public void updateIngestReceiveTime(DateTime newTimestamp) {
         if (newTimestamp != null) {
-            preJournalReceiveTime.updateAndGet(timestamp -> latestTimestamp(timestamp, newTimestamp));
+            ingestReceiveTime.updateAndGet(timestamp -> latestTimestamp(timestamp, newTimestamp));
         }
     }
 

--- a/graylog2-server/src/main/java/org/graylog2/system/processing/MongoDBProcessingStatusRecorderService.java
+++ b/graylog2-server/src/main/java/org/graylog2/system/processing/MongoDBProcessingStatusRecorderService.java
@@ -1,0 +1,94 @@
+/**
+ * This file is part of Graylog.
+ *
+ * Graylog is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.graylog2.system.processing;
+
+import com.google.common.util.concurrent.AbstractIdleService;
+import org.joda.time.DateTime;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.inject.Inject;
+import javax.inject.Singleton;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.joda.time.DateTimeZone.UTC;
+
+@Singleton
+public class MongoDBProcessingStatusRecorderService extends AbstractIdleService implements ProcessingStatusRecorder {
+    private static final Logger LOG = LoggerFactory.getLogger(MongoDBProcessingStatusRecorderService.class);
+
+    private final AtomicReference<DateTime> preJournalMaxReceiveTime = new AtomicReference<>(new DateTime(0L, UTC));
+    private final AtomicReference<DateTime> postProcessingMaxReceiveTime = new AtomicReference<>(new DateTime(0L, UTC));
+    private final AtomicReference<DateTime> postIndexMaxReceiveTime = new AtomicReference<>(new DateTime(0L, UTC));
+
+    private final DBProcessingStatusService dbService;
+
+    @Inject
+    public MongoDBProcessingStatusRecorderService(DBProcessingStatusService dbService) {
+        this.dbService = dbService;
+    }
+
+    @Override
+    protected void startUp() throws Exception {
+        // TODO: Load persisted state from database and use maxTimestamp to avoid overwriting already updated values
+    }
+
+    @Override
+    protected void shutDown() throws Exception {
+        // TODO: Persist state to database
+    }
+
+    @Override
+    public DateTime getPreJournalMaxReceiveTime() {
+        return preJournalMaxReceiveTime.get();
+    }
+
+    @Override
+    public DateTime getPostProcessingMaxReceiveTime() {
+        return postProcessingMaxReceiveTime.get();
+    }
+
+    @Override
+    public DateTime getPostIndexingMaxReceiveTime() {
+        return postIndexMaxReceiveTime.get();
+    }
+
+    @Override
+    public void updatePreJournalMaxReceiveTime(DateTime newTimestamp) {
+        if (newTimestamp != null) {
+            preJournalMaxReceiveTime.updateAndGet(timestamp -> maxTimestamp(timestamp, newTimestamp));
+        }
+    }
+
+    @Override
+    public void updatePostProcessingMaxReceiveTime(DateTime newTimestamp) {
+        if (newTimestamp != null) {
+            postProcessingMaxReceiveTime.updateAndGet(timestamp -> maxTimestamp(timestamp, newTimestamp));
+        }
+    }
+
+    @Override
+    public void updatePostIndexingMaxReceiveTime(DateTime newTimestamp) {
+        if (newTimestamp != null) {
+            postIndexMaxReceiveTime.updateAndGet(timestamp -> maxTimestamp(timestamp, newTimestamp));
+        }
+    }
+
+    private DateTime maxTimestamp(DateTime timestamp, DateTime newTimestamp) {
+        return newTimestamp.isAfter(timestamp) ? newTimestamp : timestamp;
+    }
+}

--- a/graylog2-server/src/main/java/org/graylog2/system/processing/ProcessingStatusConfig.java
+++ b/graylog2-server/src/main/java/org/graylog2/system/processing/ProcessingStatusConfig.java
@@ -1,0 +1,43 @@
+/**
+ * This file is part of Graylog.
+ *
+ * Graylog is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.graylog2.system.processing;
+
+import com.github.joschi.jadconfig.Parameter;
+import com.github.joschi.jadconfig.ValidationException;
+import com.github.joschi.jadconfig.Validator;
+import com.github.joschi.jadconfig.util.Duration;
+import com.github.joschi.jadconfig.validators.PositiveDurationValidator;
+
+public class ProcessingStatusConfig {
+    public static final String PERSIST_INTERVAL = "processing_status_persist_interval";
+
+    @Parameter(value = PERSIST_INTERVAL, validators = {PositiveDurationValidator.class, Minimum1SecondValidator.class})
+    private Duration processingStatusPersistInterval = Duration.seconds(5);
+
+    public Duration getProcessingStatusPersistInterval() {
+        return processingStatusPersistInterval;
+    }
+
+    public static class Minimum1SecondValidator implements Validator<Duration> {
+        @Override
+        public void validate(final String name, final Duration value) throws ValidationException {
+            if (value != null && value.compareTo(Duration.seconds(1)) < 0) {
+                throw new ValidationException("Parameter " + name + " should be at least 1 second (found " + value + ")");
+            }
+        }
+    }
+}

--- a/graylog2-server/src/main/java/org/graylog2/system/processing/ProcessingStatusDto.java
+++ b/graylog2-server/src/main/java/org/graylog2/system/processing/ProcessingStatusDto.java
@@ -1,0 +1,133 @@
+/**
+ * This file is part of Graylog.
+ *
+ * Graylog is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.graylog2.system.processing;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.google.auto.value.AutoValue;
+import org.joda.time.DateTime;
+import org.mongojack.Id;
+import org.mongojack.ObjectId;
+
+import javax.annotation.Nullable;
+
+@AutoValue
+@JsonDeserialize(builder = ProcessingStatusDto.Builder.class)
+public abstract class ProcessingStatusDto {
+    private static final String FIELD_ID = "id";
+    static final String FIELD_NODE_ID = "node_id";
+    static final String FIELD_UPDATED_AT = "updated_at";
+    private static final String FIELD_MAX_RECEIVE_TIMES = "max_receive_times";
+
+    @Id
+    @ObjectId
+    @Nullable
+    @JsonProperty(FIELD_ID)
+    public abstract String id();
+
+    @JsonProperty(FIELD_NODE_ID)
+    public abstract String nodeId();
+
+    @JsonProperty(FIELD_UPDATED_AT)
+    public abstract DateTime updatedAt();
+
+    @JsonProperty(FIELD_MAX_RECEIVE_TIMES)
+    public abstract MaxReceiveTimes maxReceiveTimes();
+
+    public static ProcessingStatusDto of(String nodeId, ProcessingStatusRecorder processingStatusRecorder, DateTime updatedAt) {
+        return builder()
+                .nodeId(nodeId)
+                .updatedAt(updatedAt)
+                .maxReceiveTimes(MaxReceiveTimes.builder()
+                        .preJournal(processingStatusRecorder.getPreJournalMaxReceiveTime())
+                        .postProcessing(processingStatusRecorder.getPostProcessingMaxReceiveTime())
+                        .postIndexing(processingStatusRecorder.getPostIndexingMaxReceiveTime())
+                        .build())
+                .build();
+    }
+
+    public static Builder builder() {
+        return Builder.create();
+    }
+
+    public abstract Builder toBuilder();
+
+    @AutoValue.Builder
+    public static abstract class Builder {
+        @JsonCreator
+        public static Builder create() {
+            return new AutoValue_ProcessingStatusDto.Builder();
+        }
+
+        @Id
+        @ObjectId
+        @JsonProperty(FIELD_ID)
+        public abstract Builder id(String id);
+
+        @JsonProperty(FIELD_NODE_ID)
+        public abstract Builder nodeId(String nodeId);
+
+        @JsonProperty(FIELD_UPDATED_AT)
+        public abstract Builder updatedAt(DateTime updatedAt);
+
+        @JsonProperty(FIELD_MAX_RECEIVE_TIMES)
+        public abstract Builder maxReceiveTimes(MaxReceiveTimes maxReceiveTimes);
+
+        public abstract ProcessingStatusDto build();
+    }
+
+    @AutoValue
+    @JsonDeserialize(builder = MaxReceiveTimes.Builder.class)
+    public static abstract class MaxReceiveTimes {
+        public static final String FIELD_PRE_JOURNAL = "pre_journal";
+        public static final String FIELD_POST_PROCESSING = "post_processing";
+        public static final String FIELD_POST_INDEXING = "post_indexing";
+
+        @JsonProperty(FIELD_PRE_JOURNAL)
+        public abstract DateTime preJournal();
+
+        @JsonProperty(FIELD_POST_PROCESSING)
+        public abstract DateTime postProcessing();
+
+        @JsonProperty(FIELD_POST_INDEXING)
+        public abstract DateTime postIndexing();
+
+        public static Builder builder() {
+            return Builder.create();
+        }
+
+        @AutoValue.Builder
+        public static abstract class Builder {
+            @JsonCreator
+            public static Builder create() {
+                return new AutoValue_ProcessingStatusDto_MaxReceiveTimes.Builder();
+            }
+
+            @JsonProperty(FIELD_PRE_JOURNAL)
+            public abstract Builder preJournal(DateTime timestamp);
+
+            @JsonProperty(FIELD_POST_PROCESSING)
+            public abstract Builder postProcessing(DateTime timestamp);
+
+            @JsonProperty(FIELD_POST_INDEXING)
+            public abstract Builder postIndexing(DateTime timestamp);
+
+            public abstract MaxReceiveTimes build();
+        }
+    }
+}

--- a/graylog2-server/src/main/java/org/graylog2/system/processing/ProcessingStatusDto.java
+++ b/graylog2-server/src/main/java/org/graylog2/system/processing/ProcessingStatusDto.java
@@ -32,7 +32,7 @@ public abstract class ProcessingStatusDto {
     private static final String FIELD_ID = "id";
     static final String FIELD_NODE_ID = "node_id";
     static final String FIELD_UPDATED_AT = "updated_at";
-    private static final String FIELD_MAX_RECEIVE_TIMES = "max_receive_times";
+    static final String FIELD_MAX_RECEIVE_TIMES = "max_receive_times";
 
     @Id
     @ObjectId
@@ -94,9 +94,9 @@ public abstract class ProcessingStatusDto {
     @AutoValue
     @JsonDeserialize(builder = MaxReceiveTimes.Builder.class)
     public static abstract class MaxReceiveTimes {
-        public static final String FIELD_PRE_JOURNAL = "pre_journal";
-        public static final String FIELD_POST_PROCESSING = "post_processing";
-        public static final String FIELD_POST_INDEXING = "post_indexing";
+        private static final String FIELD_PRE_JOURNAL = "pre_journal";
+        private static final String FIELD_POST_PROCESSING = "post_processing";
+        static final String FIELD_POST_INDEXING = "post_indexing";
 
         @JsonProperty(FIELD_PRE_JOURNAL)
         public abstract DateTime preJournal();

--- a/graylog2-server/src/main/java/org/graylog2/system/processing/ProcessingStatusDto.java
+++ b/graylog2-server/src/main/java/org/graylog2/system/processing/ProcessingStatusDto.java
@@ -54,7 +54,7 @@ public abstract class ProcessingStatusDto {
                 .nodeId(nodeId)
                 .updatedAt(updatedAt)
                 .receiveTimes(ReceiveTimes.builder()
-                        .preJournal(processingStatusRecorder.getPreJournalReceiveTime())
+                        .ingest(processingStatusRecorder.getIngestReceiveTime())
                         .postProcessing(processingStatusRecorder.getPostProcessingReceiveTime())
                         .postIndexing(processingStatusRecorder.getPostIndexingReceiveTime())
                         .build())
@@ -94,12 +94,12 @@ public abstract class ProcessingStatusDto {
     @AutoValue
     @JsonDeserialize(builder = ReceiveTimes.Builder.class)
     public static abstract class ReceiveTimes {
-        private static final String FIELD_PRE_JOURNAL = "pre_journal";
+        private static final String FIELD_INGEST = "ingest";
         private static final String FIELD_POST_PROCESSING = "post_processing";
         static final String FIELD_POST_INDEXING = "post_indexing";
 
-        @JsonProperty(FIELD_PRE_JOURNAL)
-        public abstract DateTime preJournal();
+        @JsonProperty(FIELD_INGEST)
+        public abstract DateTime ingest();
 
         @JsonProperty(FIELD_POST_PROCESSING)
         public abstract DateTime postProcessing();
@@ -118,8 +118,8 @@ public abstract class ProcessingStatusDto {
                 return new AutoValue_ProcessingStatusDto_ReceiveTimes.Builder();
             }
 
-            @JsonProperty(FIELD_PRE_JOURNAL)
-            public abstract Builder preJournal(DateTime timestamp);
+            @JsonProperty(FIELD_INGEST)
+            public abstract Builder ingest(DateTime timestamp);
 
             @JsonProperty(FIELD_POST_PROCESSING)
             public abstract Builder postProcessing(DateTime timestamp);

--- a/graylog2-server/src/main/java/org/graylog2/system/processing/ProcessingStatusDto.java
+++ b/graylog2-server/src/main/java/org/graylog2/system/processing/ProcessingStatusDto.java
@@ -32,7 +32,7 @@ public abstract class ProcessingStatusDto {
     private static final String FIELD_ID = "id";
     static final String FIELD_NODE_ID = "node_id";
     static final String FIELD_UPDATED_AT = "updated_at";
-    static final String FIELD_MAX_RECEIVE_TIMES = "max_receive_times";
+    static final String FIELD_RECEIVE_TIMES = "receive_times";
 
     @Id
     @ObjectId
@@ -46,17 +46,17 @@ public abstract class ProcessingStatusDto {
     @JsonProperty(FIELD_UPDATED_AT)
     public abstract DateTime updatedAt();
 
-    @JsonProperty(FIELD_MAX_RECEIVE_TIMES)
-    public abstract MaxReceiveTimes maxReceiveTimes();
+    @JsonProperty(FIELD_RECEIVE_TIMES)
+    public abstract ReceiveTimes receiveTimes();
 
     public static ProcessingStatusDto of(String nodeId, ProcessingStatusRecorder processingStatusRecorder, DateTime updatedAt) {
         return builder()
                 .nodeId(nodeId)
                 .updatedAt(updatedAt)
-                .maxReceiveTimes(MaxReceiveTimes.builder()
-                        .preJournal(processingStatusRecorder.getPreJournalMaxReceiveTime())
-                        .postProcessing(processingStatusRecorder.getPostProcessingMaxReceiveTime())
-                        .postIndexing(processingStatusRecorder.getPostIndexingMaxReceiveTime())
+                .receiveTimes(ReceiveTimes.builder()
+                        .preJournal(processingStatusRecorder.getPreJournalReceiveTime())
+                        .postProcessing(processingStatusRecorder.getPostProcessingReceiveTime())
+                        .postIndexing(processingStatusRecorder.getPostIndexingReceiveTime())
                         .build())
                 .build();
     }
@@ -85,15 +85,15 @@ public abstract class ProcessingStatusDto {
         @JsonProperty(FIELD_UPDATED_AT)
         public abstract Builder updatedAt(DateTime updatedAt);
 
-        @JsonProperty(FIELD_MAX_RECEIVE_TIMES)
-        public abstract Builder maxReceiveTimes(MaxReceiveTimes maxReceiveTimes);
+        @JsonProperty(FIELD_RECEIVE_TIMES)
+        public abstract Builder receiveTimes(ReceiveTimes receiveTimes);
 
         public abstract ProcessingStatusDto build();
     }
 
     @AutoValue
-    @JsonDeserialize(builder = MaxReceiveTimes.Builder.class)
-    public static abstract class MaxReceiveTimes {
+    @JsonDeserialize(builder = ReceiveTimes.Builder.class)
+    public static abstract class ReceiveTimes {
         private static final String FIELD_PRE_JOURNAL = "pre_journal";
         private static final String FIELD_POST_PROCESSING = "post_processing";
         static final String FIELD_POST_INDEXING = "post_indexing";
@@ -115,7 +115,7 @@ public abstract class ProcessingStatusDto {
         public static abstract class Builder {
             @JsonCreator
             public static Builder create() {
-                return new AutoValue_ProcessingStatusDto_MaxReceiveTimes.Builder();
+                return new AutoValue_ProcessingStatusDto_ReceiveTimes.Builder();
             }
 
             @JsonProperty(FIELD_PRE_JOURNAL)
@@ -127,7 +127,7 @@ public abstract class ProcessingStatusDto {
             @JsonProperty(FIELD_POST_INDEXING)
             public abstract Builder postIndexing(DateTime timestamp);
 
-            public abstract MaxReceiveTimes build();
+            public abstract ReceiveTimes build();
         }
     }
 }

--- a/graylog2-server/src/main/java/org/graylog2/system/processing/ProcessingStatusRecorder.java
+++ b/graylog2-server/src/main/java/org/graylog2/system/processing/ProcessingStatusRecorder.java
@@ -23,32 +23,32 @@ import org.joda.time.DateTime;
  */
 public interface ProcessingStatusRecorder {
     /**
-     * Update max receive time for the "pre-journal" measurement point. This is done right before a raw messages gets
+     * Update the receive time for the "pre-journal" measurement point. This is done right before a raw messages gets
      * written to the disk journal.
      *
      * @param newTimestamp the new timestamp to record
      */
-    void updatePreJournalMaxReceiveTime(DateTime newTimestamp);
+    void updatePreJournalReceiveTime(DateTime newTimestamp);
 
-    DateTime getPreJournalMaxReceiveTime();
+    DateTime getPreJournalReceiveTime();
 
     /**
-     * Update max receive time for the "post-processing" measurement point. This is done right after all message
+     * Update the receive time for the "post-processing" measurement point. This is done right after all message
      * processors have run.
      *
      * @param newTimestamp the new timestamp to record
      */
-    void updatePostProcessingMaxReceiveTime(DateTime newTimestamp);
+    void updatePostProcessingReceiveTime(DateTime newTimestamp);
 
-    DateTime getPostProcessingMaxReceiveTime();
+    DateTime getPostProcessingReceiveTime();
 
     /**
-     * Update max receive time for the "post-indexing" measurement point. This is done right after messages
+     * Update receive time for the "post-indexing" measurement point. This is done right after messages
      * have been written to Elasticsearch.
      *
      * @param newTimestamp the new timestamp to record
      */
-    void updatePostIndexingMaxReceiveTime(DateTime newTimestamp);
+    void updatePostIndexingReceiveTime(DateTime newTimestamp);
 
-    DateTime getPostIndexingMaxReceiveTime();
+    DateTime getPostIndexingReceiveTime();
 }

--- a/graylog2-server/src/main/java/org/graylog2/system/processing/ProcessingStatusRecorder.java
+++ b/graylog2-server/src/main/java/org/graylog2/system/processing/ProcessingStatusRecorder.java
@@ -23,14 +23,14 @@ import org.joda.time.DateTime;
  */
 public interface ProcessingStatusRecorder {
     /**
-     * Update the receive time for the "pre-journal" measurement point. This is done right before a raw messages gets
+     * Update the receive time for the "ingest" measurement point. This is done right before a raw messages gets
      * written to the disk journal.
      *
      * @param newTimestamp the new timestamp to record
      */
-    void updatePreJournalReceiveTime(DateTime newTimestamp);
+    void updateIngestReceiveTime(DateTime newTimestamp);
 
-    DateTime getPreJournalReceiveTime();
+    DateTime getIngestReceiveTime();
 
     /**
      * Update the receive time for the "post-processing" measurement point. This is done right after all message

--- a/graylog2-server/src/main/java/org/graylog2/system/processing/ProcessingStatusRecorder.java
+++ b/graylog2-server/src/main/java/org/graylog2/system/processing/ProcessingStatusRecorder.java
@@ -1,0 +1,54 @@
+/**
+ * This file is part of Graylog.
+ *
+ * Graylog is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.graylog2.system.processing;
+
+import org.joda.time.DateTime;
+
+/**
+ * This is used to track processing status on a single Graylog node.
+ */
+public interface ProcessingStatusRecorder {
+    /**
+     * Update max receive time for the "pre-journal" measurement point. This is done right before a raw messages gets
+     * written to the disk journal.
+     *
+     * @param newTimestamp the new timestamp to record
+     */
+    void updatePreJournalMaxReceiveTime(DateTime newTimestamp);
+
+    DateTime getPreJournalMaxReceiveTime();
+
+    /**
+     * Update max receive time for the "post-processing" measurement point. This is done right after all message
+     * processors have run.
+     *
+     * @param newTimestamp the new timestamp to record
+     */
+    void updatePostProcessingMaxReceiveTime(DateTime newTimestamp);
+
+    DateTime getPostProcessingMaxReceiveTime();
+
+    /**
+     * Update max receive time for the "post-indexing" measurement point. This is done right after messages
+     * have been written to Elasticsearch.
+     *
+     * @param newTimestamp the new timestamp to record
+     */
+    void updatePostIndexingMaxReceiveTime(DateTime newTimestamp);
+
+    DateTime getPostIndexingMaxReceiveTime();
+}

--- a/graylog2-server/src/test/java/org/graylog2/indexer/fieldtypes/IndexFieldTypePollerIT.java
+++ b/graylog2-server/src/test/java/org/graylog2/indexer/fieldtypes/IndexFieldTypePollerIT.java
@@ -37,6 +37,7 @@ import org.graylog2.indexer.rotation.strategies.MessageCountRotationStrategy;
 import org.graylog2.indexer.rotation.strategies.MessageCountRotationStrategyConfig;
 import org.graylog2.plugin.system.NodeId;
 import org.graylog2.shared.bindings.providers.ObjectMapperProvider;
+import org.graylog2.system.processing.InMemoryProcessingStatusRecorder;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -87,7 +88,7 @@ public class IndexFieldTypePollerIT extends ElasticsearchBase {
         final Indices indices = new Indices(client(),
                 new ObjectMapperProvider().get(),
                 new IndexMappingFactory(new Node(client())),
-                new Messages(new MetricRegistry(), client()),
+                new Messages(new MetricRegistry(), client(), new InMemoryProcessingStatusRecorder()),
                 mock(NodeId.class),
                 new NullAuditEventSender(),
                 new EventBus("index-field-type-poller-it"));

--- a/graylog2-server/src/test/java/org/graylog2/indexer/indices/IndicesGetAllMessageFieldsIT.java
+++ b/graylog2-server/src/test/java/org/graylog2/indexer/indices/IndicesGetAllMessageFieldsIT.java
@@ -27,6 +27,7 @@ import org.graylog2.indexer.IndexMappingFactory;
 import org.graylog2.indexer.cluster.Node;
 import org.graylog2.indexer.messages.Messages;
 import org.graylog2.plugin.system.NodeId;
+import org.graylog2.system.processing.InMemoryProcessingStatusRecorder;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
@@ -53,7 +54,7 @@ public class IndicesGetAllMessageFieldsIT extends ElasticsearchBase {
         indices = new Indices(client(),
                 new ObjectMapper(),
                 new IndexMappingFactory(node),
-                new Messages(new MetricRegistry(), client()),
+                new Messages(new MetricRegistry(), client(), new InMemoryProcessingStatusRecorder()),
                 mock(NodeId.class),
                 new NullAuditEventSender(),
                 new EventBus());

--- a/graylog2-server/src/test/java/org/graylog2/indexer/indices/IndicesIT.java
+++ b/graylog2-server/src/test/java/org/graylog2/indexer/indices/IndicesIT.java
@@ -50,6 +50,7 @@ import org.graylog2.indexer.searches.IndexRangeStats;
 import org.graylog2.jackson.TypeReferences;
 import org.graylog2.plugin.system.NodeId;
 import org.graylog2.shared.bindings.providers.ObjectMapperProvider;
+import org.graylog2.system.processing.InMemoryProcessingStatusRecorder;
 import org.joda.time.DateTime;
 import org.joda.time.DateTimeZone;
 import org.junit.Before;
@@ -115,7 +116,7 @@ public class IndicesIT extends ElasticsearchBase {
         indices = new Indices(client(),
                 new ObjectMapperProvider().get(),
                 indexMappingFactory,
-                new Messages(new MetricRegistry(), client()),
+                new Messages(new MetricRegistry(), client(), new InMemoryProcessingStatusRecorder()),
                 mock(NodeId.class),
                 new NullAuditEventSender(),
                 eventBus);

--- a/graylog2-server/src/test/java/org/graylog2/indexer/messages/MessagesIT.java
+++ b/graylog2-server/src/test/java/org/graylog2/indexer/messages/MessagesIT.java
@@ -23,6 +23,7 @@ import io.searchbox.core.Index;
 import org.graylog2.ElasticsearchBase;
 import org.graylog2.indexer.results.ResultMessage;
 import org.graylog2.plugin.Message;
+import org.graylog2.system.processing.InMemoryProcessingStatusRecorder;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -37,7 +38,7 @@ public class MessagesIT extends ElasticsearchBase {
 
     @Before
     public void setUp() throws Exception {
-        messages = new Messages(new MetricRegistry(), client());
+        messages = new Messages(new MetricRegistry(), client(), new InMemoryProcessingStatusRecorder());
     }
 
     @Test

--- a/graylog2-server/src/test/java/org/graylog2/indexer/messages/MockedMessagesTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/indexer/messages/MockedMessagesTest.java
@@ -23,6 +23,7 @@ import io.searchbox.client.JestClient;
 import io.searchbox.core.BulkResult;
 import org.graylog2.indexer.IndexSet;
 import org.graylog2.plugin.Message;
+import org.graylog2.system.processing.InMemoryProcessingStatusRecorder;
 import org.joda.time.DateTime;
 import org.joda.time.DateTimeZone;
 import org.junit.Before;
@@ -72,7 +73,7 @@ public class MockedMessagesTest {
 
     @Before
     public void setUp() throws Exception {
-        this.messages = new Messages(new MetricRegistry(), jestClient);
+        this.messages = new Messages(new MetricRegistry(), jestClient, new InMemoryProcessingStatusRecorder());
     }
 
     @Test

--- a/graylog2-server/src/test/java/org/graylog2/system/processing/DBProcessingStatusServiceTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/system/processing/DBProcessingStatusServiceTest.java
@@ -87,10 +87,10 @@ public class DBProcessingStatusServiceTest {
             assertThat(dto.nodeId()).isEqualTo("abc-123");
             assertThat(dto.updatedAt()).isEqualByComparingTo(DateTime.parse("2019-01-01T00:03:00.000Z"));
 
-            assertThat(dto.maxReceiveTimes()).satisfies(maxReceiveTimes -> {
-                assertThat(maxReceiveTimes.preJournal()).isEqualByComparingTo(DateTime.parse("2019-01-01T00:03:00.000Z"));
-                assertThat(maxReceiveTimes.postProcessing()).isEqualByComparingTo(DateTime.parse("2019-01-01T00:02:00.000Z"));
-                assertThat(maxReceiveTimes.postIndexing()).isEqualByComparingTo(DateTime.parse("2019-01-01T00:01:00.000Z"));
+            assertThat(dto.receiveTimes()).satisfies(receiveTimes -> {
+                assertThat(receiveTimes.preJournal()).isEqualByComparingTo(DateTime.parse("2019-01-01T00:03:00.000Z"));
+                assertThat(receiveTimes.postProcessing()).isEqualByComparingTo(DateTime.parse("2019-01-01T00:02:00.000Z"));
+                assertThat(receiveTimes.postIndexing()).isEqualByComparingTo(DateTime.parse("2019-01-01T00:01:00.000Z"));
             });
         });
 
@@ -99,10 +99,10 @@ public class DBProcessingStatusServiceTest {
             assertThat(dto.nodeId()).isEqualTo("abc-456");
             assertThat(dto.updatedAt()).isEqualByComparingTo(DateTime.parse("2019-01-01T01:03:00.000Z"));
 
-            assertThat(dto.maxReceiveTimes()).satisfies(maxReceiveTimes -> {
-                assertThat(maxReceiveTimes.preJournal()).isEqualByComparingTo(DateTime.parse("2019-01-01T01:03:00.000Z"));
-                assertThat(maxReceiveTimes.postProcessing()).isEqualByComparingTo(DateTime.parse("2019-01-01T01:02:00.000Z"));
-                assertThat(maxReceiveTimes.postIndexing()).isEqualByComparingTo(DateTime.parse("2019-01-01T02:01:00.000Z"));
+            assertThat(dto.receiveTimes()).satisfies(receiveTimes -> {
+                assertThat(receiveTimes.preJournal()).isEqualByComparingTo(DateTime.parse("2019-01-01T01:03:00.000Z"));
+                assertThat(receiveTimes.postProcessing()).isEqualByComparingTo(DateTime.parse("2019-01-01T01:02:00.000Z"));
+                assertThat(receiveTimes.postIndexing()).isEqualByComparingTo(DateTime.parse("2019-01-01T02:01:00.000Z"));
             });
         });
 
@@ -111,10 +111,10 @@ public class DBProcessingStatusServiceTest {
             assertThat(dto.nodeId()).isEqualTo("abc-789");
             assertThat(dto.updatedAt()).isEqualByComparingTo(DateTime.parse("2019-01-01T02:03:00.000Z"));
 
-            assertThat(dto.maxReceiveTimes()).satisfies(maxReceiveTimes -> {
-                assertThat(maxReceiveTimes.preJournal()).isEqualByComparingTo(DateTime.parse("2019-01-01T02:03:00.000Z"));
-                assertThat(maxReceiveTimes.postProcessing()).isEqualByComparingTo(DateTime.parse("2019-01-01T02:02:00.000Z"));
-                assertThat(maxReceiveTimes.postIndexing()).isEqualByComparingTo(DateTime.parse("2019-01-01T01:01:00.000Z"));
+            assertThat(dto.receiveTimes()).satisfies(receiveTimes -> {
+                assertThat(receiveTimes.preJournal()).isEqualByComparingTo(DateTime.parse("2019-01-01T02:03:00.000Z"));
+                assertThat(receiveTimes.postProcessing()).isEqualByComparingTo(DateTime.parse("2019-01-01T02:02:00.000Z"));
+                assertThat(receiveTimes.postIndexing()).isEqualByComparingTo(DateTime.parse("2019-01-01T01:01:00.000Z"));
             });
         });
     }
@@ -125,19 +125,19 @@ public class DBProcessingStatusServiceTest {
         final InMemoryProcessingStatusRecorder statusRecorder = new InMemoryProcessingStatusRecorder();
         final DateTime now = DateTime.now(DateTimeZone.UTC);
 
-        statusRecorder.updatePreJournalMaxReceiveTime(now);
-        statusRecorder.updatePostProcessingMaxReceiveTime(now.minusSeconds(1));
-        statusRecorder.updatePostIndexingMaxReceiveTime(now.minusSeconds(2));
+        statusRecorder.updatePreJournalReceiveTime(now);
+        statusRecorder.updatePostProcessingReceiveTime(now.minusSeconds(1));
+        statusRecorder.updatePostIndexingReceiveTime(now.minusSeconds(2));
 
         assertThat(dbService.save(statusRecorder, now)).satisfies(dto -> {
             assertThat(dto.id()).isNotBlank();
             assertThat(dto.nodeId()).isEqualTo(NODE_ID);
             assertThat(dto.updatedAt()).isEqualByComparingTo(now);
 
-            assertThat(dto.maxReceiveTimes()).satisfies(maxReceiveTimes -> {
-                assertThat(maxReceiveTimes.preJournal()).isEqualByComparingTo(now);
-                assertThat(maxReceiveTimes.postProcessing()).isEqualByComparingTo(now.minusSeconds(1));
-                assertThat(maxReceiveTimes.postIndexing()).isEqualByComparingTo(now.minusSeconds(2));
+            assertThat(dto.receiveTimes()).satisfies(receiveTimes -> {
+                assertThat(receiveTimes.preJournal()).isEqualByComparingTo(now);
+                assertThat(receiveTimes.postProcessing()).isEqualByComparingTo(now.minusSeconds(1));
+                assertThat(receiveTimes.postIndexing()).isEqualByComparingTo(now.minusSeconds(2));
             });
         });
 
@@ -146,9 +146,9 @@ public class DBProcessingStatusServiceTest {
         // Advance time and update the status recorder
         final DateTime tomorrow = now.plusDays(1);
 
-        statusRecorder.updatePreJournalMaxReceiveTime(tomorrow);
-        statusRecorder.updatePostProcessingMaxReceiveTime(tomorrow.minusSeconds(1));
-        statusRecorder.updatePostIndexingMaxReceiveTime(tomorrow.minusSeconds(2));
+        statusRecorder.updatePreJournalReceiveTime(tomorrow);
+        statusRecorder.updatePostProcessingReceiveTime(tomorrow.minusSeconds(1));
+        statusRecorder.updatePostIndexingReceiveTime(tomorrow.minusSeconds(2));
 
         // Save the updated recorder
         assertThat(dbService.save(statusRecorder, tomorrow)).satisfies(dto -> {
@@ -156,10 +156,10 @@ public class DBProcessingStatusServiceTest {
             assertThat(dto.nodeId()).isEqualTo(NODE_ID);
             assertThat(dto.updatedAt()).isEqualByComparingTo(tomorrow);
 
-            assertThat(dto.maxReceiveTimes()).satisfies(maxReceiveTimes -> {
-                assertThat(maxReceiveTimes.preJournal()).isEqualByComparingTo(tomorrow);
-                assertThat(maxReceiveTimes.postProcessing()).isEqualByComparingTo(tomorrow.minusSeconds(1));
-                assertThat(maxReceiveTimes.postIndexing()).isEqualByComparingTo(tomorrow.minusSeconds(2));
+            assertThat(dto.receiveTimes()).satisfies(receiveTimes -> {
+                assertThat(receiveTimes.preJournal()).isEqualByComparingTo(tomorrow);
+                assertThat(receiveTimes.postProcessing()).isEqualByComparingTo(tomorrow.minusSeconds(1));
+                assertThat(receiveTimes.postIndexing()).isEqualByComparingTo(tomorrow.minusSeconds(2));
             });
         });
 
@@ -179,7 +179,7 @@ public class DBProcessingStatusServiceTest {
 
     @Test
     @UsingDataSet(locations = "processing-status.json", loadStrategy = LoadStrategyEnum.CLEAN_INSERT)
-    public void maxIndexedTimestamp() {
+    public void earliestPostIndexingTimestamp() {
         when(node1.getNodeId()).thenReturn("abc-123");
         when(node2.getNodeId()).thenReturn("abc-456");
         when(node3.getNodeId()).thenReturn("abc-789");
@@ -189,29 +189,29 @@ public class DBProcessingStatusServiceTest {
                 "abc-789", node3
         ));
 
-        // With all three nodes, abc-123 has the oldest max indexed timestamp
-        assertThat(dbService.maxIndexedTimestamp()).isPresent().get().isEqualTo(DateTime.parse("2019-01-01T00:01:00.000Z"));
+        // With all three nodes, abc-123 has the earliest indexed timestamp
+        assertThat(dbService.earliestPostIndexingTimestamp()).isPresent().get().isEqualTo(DateTime.parse("2019-01-01T00:01:00.000Z"));
 
         when(nodeService.allActive()).thenReturn(ImmutableMap.of(
                 "abc-456", node2,
                 "abc-789", node3
         ));
 
-        // With only abc-456 and abc-789 nodes, the last one has the oldest max indexed timestamp
-        assertThat(dbService.maxIndexedTimestamp()).isPresent().get().isEqualTo(DateTime.parse("2019-01-01T01:01:00.000Z"));
+        // With only abc-456 and abc-789 nodes, the last one has the earliest indexed timestamp
+        assertThat(dbService.earliestPostIndexingTimestamp()).isPresent().get().isEqualTo(DateTime.parse("2019-01-01T01:01:00.000Z"));
     }
 
     @Test
     @UsingDataSet(locations = "processing-status.json", loadStrategy = LoadStrategyEnum.CLEAN_INSERT)
-    public void maxIndexedTimestampWithoutAnyNodes() {
+    public void earliestPostIndexingTimestampWithoutAnyNodes() {
         when(nodeService.allActive()).thenReturn(ImmutableMap.of());
 
-        assertThat(dbService.maxIndexedTimestamp()).isNotPresent();
+        assertThat(dbService.earliestPostIndexingTimestamp()).isNotPresent();
     }
 
     @Test
     @UsingDataSet(loadStrategy = LoadStrategyEnum.DELETE_ALL)
-    public void maxIndexedTimestampWithoutData() {
+    public void earliestPostIndexingTimestampWithoutData() {
         when(node1.getNodeId()).thenReturn("abc-123");
         when(node2.getNodeId()).thenReturn("abc-456");
         when(node3.getNodeId()).thenReturn("abc-789");
@@ -221,6 +221,6 @@ public class DBProcessingStatusServiceTest {
                 "abc-789", node3
         ));
 
-        assertThat(dbService.maxIndexedTimestamp()).isNotPresent();
+        assertThat(dbService.earliestPostIndexingTimestamp()).isNotPresent();
     }
 }

--- a/graylog2-server/src/test/java/org/graylog2/system/processing/DBProcessingStatusServiceTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/system/processing/DBProcessingStatusServiceTest.java
@@ -88,7 +88,7 @@ public class DBProcessingStatusServiceTest {
             assertThat(dto.updatedAt()).isEqualByComparingTo(DateTime.parse("2019-01-01T00:03:00.000Z"));
 
             assertThat(dto.receiveTimes()).satisfies(receiveTimes -> {
-                assertThat(receiveTimes.preJournal()).isEqualByComparingTo(DateTime.parse("2019-01-01T00:03:00.000Z"));
+                assertThat(receiveTimes.ingest()).isEqualByComparingTo(DateTime.parse("2019-01-01T00:03:00.000Z"));
                 assertThat(receiveTimes.postProcessing()).isEqualByComparingTo(DateTime.parse("2019-01-01T00:02:00.000Z"));
                 assertThat(receiveTimes.postIndexing()).isEqualByComparingTo(DateTime.parse("2019-01-01T00:01:00.000Z"));
             });
@@ -100,7 +100,7 @@ public class DBProcessingStatusServiceTest {
             assertThat(dto.updatedAt()).isEqualByComparingTo(DateTime.parse("2019-01-01T01:03:00.000Z"));
 
             assertThat(dto.receiveTimes()).satisfies(receiveTimes -> {
-                assertThat(receiveTimes.preJournal()).isEqualByComparingTo(DateTime.parse("2019-01-01T01:03:00.000Z"));
+                assertThat(receiveTimes.ingest()).isEqualByComparingTo(DateTime.parse("2019-01-01T01:03:00.000Z"));
                 assertThat(receiveTimes.postProcessing()).isEqualByComparingTo(DateTime.parse("2019-01-01T01:02:00.000Z"));
                 assertThat(receiveTimes.postIndexing()).isEqualByComparingTo(DateTime.parse("2019-01-01T02:01:00.000Z"));
             });
@@ -112,7 +112,7 @@ public class DBProcessingStatusServiceTest {
             assertThat(dto.updatedAt()).isEqualByComparingTo(DateTime.parse("2019-01-01T02:03:00.000Z"));
 
             assertThat(dto.receiveTimes()).satisfies(receiveTimes -> {
-                assertThat(receiveTimes.preJournal()).isEqualByComparingTo(DateTime.parse("2019-01-01T02:03:00.000Z"));
+                assertThat(receiveTimes.ingest()).isEqualByComparingTo(DateTime.parse("2019-01-01T02:03:00.000Z"));
                 assertThat(receiveTimes.postProcessing()).isEqualByComparingTo(DateTime.parse("2019-01-01T02:02:00.000Z"));
                 assertThat(receiveTimes.postIndexing()).isEqualByComparingTo(DateTime.parse("2019-01-01T01:01:00.000Z"));
             });
@@ -125,7 +125,7 @@ public class DBProcessingStatusServiceTest {
         final InMemoryProcessingStatusRecorder statusRecorder = new InMemoryProcessingStatusRecorder();
         final DateTime now = DateTime.now(DateTimeZone.UTC);
 
-        statusRecorder.updatePreJournalReceiveTime(now);
+        statusRecorder.updateIngestReceiveTime(now);
         statusRecorder.updatePostProcessingReceiveTime(now.minusSeconds(1));
         statusRecorder.updatePostIndexingReceiveTime(now.minusSeconds(2));
 
@@ -135,7 +135,7 @@ public class DBProcessingStatusServiceTest {
             assertThat(dto.updatedAt()).isEqualByComparingTo(now);
 
             assertThat(dto.receiveTimes()).satisfies(receiveTimes -> {
-                assertThat(receiveTimes.preJournal()).isEqualByComparingTo(now);
+                assertThat(receiveTimes.ingest()).isEqualByComparingTo(now);
                 assertThat(receiveTimes.postProcessing()).isEqualByComparingTo(now.minusSeconds(1));
                 assertThat(receiveTimes.postIndexing()).isEqualByComparingTo(now.minusSeconds(2));
             });
@@ -146,7 +146,7 @@ public class DBProcessingStatusServiceTest {
         // Advance time and update the status recorder
         final DateTime tomorrow = now.plusDays(1);
 
-        statusRecorder.updatePreJournalReceiveTime(tomorrow);
+        statusRecorder.updateIngestReceiveTime(tomorrow);
         statusRecorder.updatePostProcessingReceiveTime(tomorrow.minusSeconds(1));
         statusRecorder.updatePostIndexingReceiveTime(tomorrow.minusSeconds(2));
 
@@ -157,7 +157,7 @@ public class DBProcessingStatusServiceTest {
             assertThat(dto.updatedAt()).isEqualByComparingTo(tomorrow);
 
             assertThat(dto.receiveTimes()).satisfies(receiveTimes -> {
-                assertThat(receiveTimes.preJournal()).isEqualByComparingTo(tomorrow);
+                assertThat(receiveTimes.ingest()).isEqualByComparingTo(tomorrow);
                 assertThat(receiveTimes.postProcessing()).isEqualByComparingTo(tomorrow.minusSeconds(1));
                 assertThat(receiveTimes.postIndexing()).isEqualByComparingTo(tomorrow.minusSeconds(2));
             });

--- a/graylog2-server/src/test/java/org/graylog2/system/processing/DBProcessingStatusServiceTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/system/processing/DBProcessingStatusServiceTest.java
@@ -17,10 +17,13 @@
 package org.graylog2.system.processing;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.collect.ImmutableMap;
 import com.lordofthejars.nosqlunit.annotation.UsingDataSet;
 import com.lordofthejars.nosqlunit.core.LoadStrategyEnum;
 import com.lordofthejars.nosqlunit.mongodb.InMemoryMongoDb;
 import org.graylog2.bindings.providers.MongoJackObjectMapperProvider;
+import org.graylog2.cluster.Node;
+import org.graylog2.cluster.NodeService;
 import org.graylog2.database.MongoConnectionRule;
 import org.graylog2.plugin.system.NodeId;
 import org.graylog2.shared.bindings.providers.ObjectMapperProvider;
@@ -52,6 +55,16 @@ public class DBProcessingStatusServiceTest {
     @Mock
     private NodeId nodeId;
 
+    @Mock
+    private NodeService nodeService;
+
+    @Mock
+    private Node node1;
+    @Mock
+    private Node node2;
+    @Mock
+    private Node node3;
+
     private DBProcessingStatusService dbService;
 
     @Before
@@ -61,13 +74,13 @@ public class DBProcessingStatusServiceTest {
         final ObjectMapper objectMapper = new ObjectMapperProvider().get();
         final MongoJackObjectMapperProvider mapperProvider = new MongoJackObjectMapperProvider(objectMapper);
 
-        dbService = new DBProcessingStatusService(mongoRule.getMongoConnection(), nodeId, mapperProvider);
+        dbService = new DBProcessingStatusService(mongoRule.getMongoConnection(), nodeId, nodeService, mapperProvider);
     }
 
     @Test
     @UsingDataSet(locations = "processing-status.json", loadStrategy = LoadStrategyEnum.CLEAN_INSERT)
     public void loadPersisted() {
-        assertThat(dbService.all()).hasSize(1);
+        assertThat(dbService.all()).hasSize(3);
 
         assertThat(dbService.all().get(0)).satisfies(dto -> {
             assertThat(dto.id()).isEqualTo("54e3deadbeefdeadbeef0000");
@@ -78,6 +91,30 @@ public class DBProcessingStatusServiceTest {
                 assertThat(maxReceiveTimes.preJournal()).isEqualByComparingTo(DateTime.parse("2019-01-01T00:03:00.000Z"));
                 assertThat(maxReceiveTimes.postProcessing()).isEqualByComparingTo(DateTime.parse("2019-01-01T00:02:00.000Z"));
                 assertThat(maxReceiveTimes.postIndexing()).isEqualByComparingTo(DateTime.parse("2019-01-01T00:01:00.000Z"));
+            });
+        });
+
+        assertThat(dbService.all().get(1)).satisfies(dto -> {
+            assertThat(dto.id()).isEqualTo("54e3deadbeefdeadbeef0001");
+            assertThat(dto.nodeId()).isEqualTo("abc-456");
+            assertThat(dto.updatedAt()).isEqualByComparingTo(DateTime.parse("2019-01-01T01:03:00.000Z"));
+
+            assertThat(dto.maxReceiveTimes()).satisfies(maxReceiveTimes -> {
+                assertThat(maxReceiveTimes.preJournal()).isEqualByComparingTo(DateTime.parse("2019-01-01T01:03:00.000Z"));
+                assertThat(maxReceiveTimes.postProcessing()).isEqualByComparingTo(DateTime.parse("2019-01-01T01:02:00.000Z"));
+                assertThat(maxReceiveTimes.postIndexing()).isEqualByComparingTo(DateTime.parse("2019-01-01T02:01:00.000Z"));
+            });
+        });
+
+        assertThat(dbService.all().get(2)).satisfies(dto -> {
+            assertThat(dto.id()).isEqualTo("54e3deadbeefdeadbeef0002");
+            assertThat(dto.nodeId()).isEqualTo("abc-789");
+            assertThat(dto.updatedAt()).isEqualByComparingTo(DateTime.parse("2019-01-01T02:03:00.000Z"));
+
+            assertThat(dto.maxReceiveTimes()).satisfies(maxReceiveTimes -> {
+                assertThat(maxReceiveTimes.preJournal()).isEqualByComparingTo(DateTime.parse("2019-01-01T02:03:00.000Z"));
+                assertThat(maxReceiveTimes.postProcessing()).isEqualByComparingTo(DateTime.parse("2019-01-01T02:02:00.000Z"));
+                assertThat(maxReceiveTimes.postIndexing()).isEqualByComparingTo(DateTime.parse("2019-01-01T01:01:00.000Z"));
             });
         });
     }
@@ -138,5 +175,52 @@ public class DBProcessingStatusServiceTest {
         dbService.save(new InMemoryProcessingStatusRecorder());
 
         assertThat(dbService.get()).isPresent();
+    }
+
+    @Test
+    @UsingDataSet(locations = "processing-status.json", loadStrategy = LoadStrategyEnum.CLEAN_INSERT)
+    public void maxIndexedTimestamp() {
+        when(node1.getNodeId()).thenReturn("abc-123");
+        when(node2.getNodeId()).thenReturn("abc-456");
+        when(node3.getNodeId()).thenReturn("abc-789");
+        when(nodeService.allActive()).thenReturn(ImmutableMap.of(
+                "abc-123", node1,
+                "abc-456", node2,
+                "abc-789", node3
+        ));
+
+        // With all three nodes, abc-123 has the oldest max indexed timestamp
+        assertThat(dbService.maxIndexedTimestamp()).isPresent().get().isEqualTo(DateTime.parse("2019-01-01T00:01:00.000Z"));
+
+        when(nodeService.allActive()).thenReturn(ImmutableMap.of(
+                "abc-456", node2,
+                "abc-789", node3
+        ));
+
+        // With only abc-456 and abc-789 nodes, the last one has the oldest max indexed timestamp
+        assertThat(dbService.maxIndexedTimestamp()).isPresent().get().isEqualTo(DateTime.parse("2019-01-01T01:01:00.000Z"));
+    }
+
+    @Test
+    @UsingDataSet(locations = "processing-status.json", loadStrategy = LoadStrategyEnum.CLEAN_INSERT)
+    public void maxIndexedTimestampWithoutAnyNodes() {
+        when(nodeService.allActive()).thenReturn(ImmutableMap.of());
+
+        assertThat(dbService.maxIndexedTimestamp()).isNotPresent();
+    }
+
+    @Test
+    @UsingDataSet(loadStrategy = LoadStrategyEnum.DELETE_ALL)
+    public void maxIndexedTimestampWithoutData() {
+        when(node1.getNodeId()).thenReturn("abc-123");
+        when(node2.getNodeId()).thenReturn("abc-456");
+        when(node3.getNodeId()).thenReturn("abc-789");
+        when(nodeService.allActive()).thenReturn(ImmutableMap.of(
+                "abc-123", node1,
+                "abc-456", node2,
+                "abc-789", node3
+        ));
+
+        assertThat(dbService.maxIndexedTimestamp()).isNotPresent();
     }
 }

--- a/graylog2-server/src/test/java/org/graylog2/system/processing/DBProcessingStatusServiceTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/system/processing/DBProcessingStatusServiceTest.java
@@ -1,0 +1,132 @@
+/**
+ * This file is part of Graylog.
+ *
+ * Graylog is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.graylog2.system.processing;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.lordofthejars.nosqlunit.annotation.UsingDataSet;
+import com.lordofthejars.nosqlunit.core.LoadStrategyEnum;
+import com.lordofthejars.nosqlunit.mongodb.InMemoryMongoDb;
+import org.graylog2.bindings.providers.MongoJackObjectMapperProvider;
+import org.graylog2.database.MongoConnectionRule;
+import org.graylog2.plugin.system.NodeId;
+import org.graylog2.shared.bindings.providers.ObjectMapperProvider;
+import org.joda.time.DateTime;
+import org.joda.time.DateTimeZone;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnit;
+import org.mockito.junit.MockitoRule;
+
+import static com.lordofthejars.nosqlunit.mongodb.InMemoryMongoDb.InMemoryMongoRuleBuilder.newInMemoryMongoDbRule;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+
+public class DBProcessingStatusServiceTest {
+    private static final String NODE_ID = "abc-123";
+
+    @ClassRule
+    public static final InMemoryMongoDb IN_MEMORY_MONGO_DB = newInMemoryMongoDbRule().build();
+
+    @Rule
+    public MongoConnectionRule mongoRule = MongoConnectionRule.build("test");
+    @Rule
+    public final MockitoRule mockitoRule = MockitoJUnit.rule();
+
+    @Mock
+    private NodeId nodeId;
+
+    private DBProcessingStatusService dbService;
+
+    @Before
+    public void setUp() throws Exception {
+        when(nodeId.toString()).thenReturn(NODE_ID);
+
+        final ObjectMapper objectMapper = new ObjectMapperProvider().get();
+        final MongoJackObjectMapperProvider mapperProvider = new MongoJackObjectMapperProvider(objectMapper);
+
+        dbService = new DBProcessingStatusService(mongoRule.getMongoConnection(), nodeId, mapperProvider);
+    }
+
+    @Test
+    @UsingDataSet(locations = "processing-status.json", loadStrategy = LoadStrategyEnum.CLEAN_INSERT)
+    public void loadPersisted() {
+        assertThat(dbService.all()).hasSize(1);
+
+        assertThat(dbService.all().get(0)).satisfies(dto -> {
+            assertThat(dto.id()).isEqualTo("54e3deadbeefdeadbeef0000");
+            assertThat(dto.nodeId()).isEqualTo("abc-123");
+            assertThat(dto.updatedAt()).isEqualByComparingTo(DateTime.parse("2019-01-01T00:03:00.000Z"));
+
+            assertThat(dto.maxReceiveTimes()).satisfies(maxReceiveTimes -> {
+                assertThat(maxReceiveTimes.preJournal()).isEqualByComparingTo(DateTime.parse("2019-01-01T00:03:00.000Z"));
+                assertThat(maxReceiveTimes.postProcessing()).isEqualByComparingTo(DateTime.parse("2019-01-01T00:02:00.000Z"));
+                assertThat(maxReceiveTimes.postIndexing()).isEqualByComparingTo(DateTime.parse("2019-01-01T00:01:00.000Z"));
+            });
+        });
+    }
+
+    @Test
+    @UsingDataSet(loadStrategy = LoadStrategyEnum.DELETE_ALL)
+    public void persistAndUpdate() {
+        final InMemoryProcessingStatusRecorder statusRecorder = new InMemoryProcessingStatusRecorder();
+        final DateTime now = DateTime.now(DateTimeZone.UTC);
+
+        statusRecorder.updatePreJournalMaxReceiveTime(now);
+        statusRecorder.updatePostProcessingMaxReceiveTime(now.minusSeconds(1));
+        statusRecorder.updatePostIndexingMaxReceiveTime(now.minusSeconds(2));
+
+        assertThat(dbService.save(statusRecorder, now)).satisfies(dto -> {
+            assertThat(dto.id()).isNotBlank();
+            assertThat(dto.nodeId()).isEqualTo(NODE_ID);
+            assertThat(dto.updatedAt()).isEqualByComparingTo(now);
+
+            assertThat(dto.maxReceiveTimes()).satisfies(maxReceiveTimes -> {
+                assertThat(maxReceiveTimes.preJournal()).isEqualByComparingTo(now);
+                assertThat(maxReceiveTimes.postProcessing()).isEqualByComparingTo(now.minusSeconds(1));
+                assertThat(maxReceiveTimes.postIndexing()).isEqualByComparingTo(now.minusSeconds(2));
+            });
+        });
+
+        assertThat(dbService.all()).hasSize(1);
+
+        // Advance time and update the status recorder
+        final DateTime tomorrow = now.plusDays(1);
+
+        statusRecorder.updatePreJournalMaxReceiveTime(tomorrow);
+        statusRecorder.updatePostProcessingMaxReceiveTime(tomorrow.minusSeconds(1));
+        statusRecorder.updatePostIndexingMaxReceiveTime(tomorrow.minusSeconds(2));
+
+        // Save the updated recorder
+        assertThat(dbService.save(statusRecorder, tomorrow)).satisfies(dto -> {
+            assertThat(dto.id()).isNotBlank();
+            assertThat(dto.nodeId()).isEqualTo(NODE_ID);
+            assertThat(dto.updatedAt()).isEqualByComparingTo(tomorrow);
+
+            assertThat(dto.maxReceiveTimes()).satisfies(maxReceiveTimes -> {
+                assertThat(maxReceiveTimes.preJournal()).isEqualByComparingTo(tomorrow);
+                assertThat(maxReceiveTimes.postProcessing()).isEqualByComparingTo(tomorrow.minusSeconds(1));
+                assertThat(maxReceiveTimes.postIndexing()).isEqualByComparingTo(tomorrow.minusSeconds(2));
+            });
+        });
+
+        // The save() should be an upsert so we should only have one document
+        assertThat(dbService.all()).hasSize(1);
+    }
+}

--- a/graylog2-server/src/test/java/org/graylog2/system/processing/DBProcessingStatusServiceTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/system/processing/DBProcessingStatusServiceTest.java
@@ -129,4 +129,14 @@ public class DBProcessingStatusServiceTest {
         // The save() should be an upsert so we should only have one document
         assertThat(dbService.all()).hasSize(1);
     }
+
+    @Test
+    @UsingDataSet(loadStrategy = LoadStrategyEnum.DELETE_ALL)
+    public void get() {
+        assertThat(dbService.get()).isNotPresent();
+
+        dbService.save(new InMemoryProcessingStatusRecorder());
+
+        assertThat(dbService.get()).isPresent();
+    }
 }

--- a/graylog2-server/src/test/resources/org/graylog2/system/processing/processing-status.json
+++ b/graylog2-server/src/test/resources/org/graylog2/system/processing/processing-status.json
@@ -19,6 +19,46 @@
           "$date": "2019-01-01T00:01:00.000Z"
         }
       }
+    },
+    {
+      "_id": {
+        "$oid": "54e3deadbeefdeadbeef0001"
+      },
+      "node_id": "abc-456",
+      "updated_at": {
+        "$date": "2019-01-01T01:03:00.000Z"
+      },
+      "max_receive_times": {
+        "pre_journal": {
+          "$date": "2019-01-01T01:03:00.000Z"
+        },
+        "post_processing": {
+          "$date": "2019-01-01T01:02:00.000Z"
+        },
+        "post_indexing": {
+          "$date": "2019-01-01T02:01:00.000Z"
+        }
+      }
+    },
+    {
+      "_id": {
+        "$oid": "54e3deadbeefdeadbeef0002"
+      },
+      "node_id": "abc-789",
+      "updated_at": {
+        "$date": "2019-01-01T02:03:00.000Z"
+      },
+      "max_receive_times": {
+        "pre_journal": {
+          "$date": "2019-01-01T02:03:00.000Z"
+        },
+        "post_processing": {
+          "$date": "2019-01-01T02:02:00.000Z"
+        },
+        "post_indexing": {
+          "$date": "2019-01-01T01:01:00.000Z"
+        }
+      }
     }
   ]
 }

--- a/graylog2-server/src/test/resources/org/graylog2/system/processing/processing-status.json
+++ b/graylog2-server/src/test/resources/org/graylog2/system/processing/processing-status.json
@@ -8,7 +8,7 @@
       "updated_at": {
         "$date": "2019-01-01T00:03:00.000Z"
       },
-      "max_receive_times": {
+      "receive_times": {
         "pre_journal": {
           "$date": "2019-01-01T00:03:00.000Z"
         },
@@ -28,7 +28,7 @@
       "updated_at": {
         "$date": "2019-01-01T01:03:00.000Z"
       },
-      "max_receive_times": {
+      "receive_times": {
         "pre_journal": {
           "$date": "2019-01-01T01:03:00.000Z"
         },
@@ -48,7 +48,7 @@
       "updated_at": {
         "$date": "2019-01-01T02:03:00.000Z"
       },
-      "max_receive_times": {
+      "receive_times": {
         "pre_journal": {
           "$date": "2019-01-01T02:03:00.000Z"
         },

--- a/graylog2-server/src/test/resources/org/graylog2/system/processing/processing-status.json
+++ b/graylog2-server/src/test/resources/org/graylog2/system/processing/processing-status.json
@@ -1,0 +1,24 @@
+{
+  "processing_status": [
+    {
+      "_id": {
+        "$oid": "54e3deadbeefdeadbeef0000"
+      },
+      "node_id": "abc-123",
+      "updated_at": {
+        "$date": "2019-01-01T00:03:00.000Z"
+      },
+      "max_receive_times": {
+        "pre_journal": {
+          "$date": "2019-01-01T00:03:00.000Z"
+        },
+        "post_processing": {
+          "$date": "2019-01-01T00:02:00.000Z"
+        },
+        "post_indexing": {
+          "$date": "2019-01-01T00:01:00.000Z"
+        }
+      }
+    }
+  ]
+}

--- a/graylog2-server/src/test/resources/org/graylog2/system/processing/processing-status.json
+++ b/graylog2-server/src/test/resources/org/graylog2/system/processing/processing-status.json
@@ -9,7 +9,7 @@
         "$date": "2019-01-01T00:03:00.000Z"
       },
       "receive_times": {
-        "pre_journal": {
+        "ingest": {
           "$date": "2019-01-01T00:03:00.000Z"
         },
         "post_processing": {
@@ -29,7 +29,7 @@
         "$date": "2019-01-01T01:03:00.000Z"
       },
       "receive_times": {
-        "pre_journal": {
+        "ingest": {
           "$date": "2019-01-01T01:03:00.000Z"
         },
         "post_processing": {
@@ -49,7 +49,7 @@
         "$date": "2019-01-01T02:03:00.000Z"
       },
       "receive_times": {
-        "pre_journal": {
+        "ingest": {
           "$date": "2019-01-01T02:03:00.000Z"
         },
         "post_processing": {

--- a/misc/graylog.conf
+++ b/misc/graylog.conf
@@ -637,3 +637,8 @@ mongodb_threads_allowed_to_block_multiplier = 5
 # of threads available for this. Increase it, if '/cluster/*' requests take long to complete.
 # Should be http_thread_pool_size * average_cluster_size if you have a high number of concurrent users.
 proxied_requests_thread_pool_size = 32
+
+# The server is writing processing status information to the database on a regular basis. This setting controls how
+# often the data is written to the database.
+# Default: 5s (cannot be less than 1s)
+#processing_status_persist_interval = 5s


### PR DESCRIPTION
This PR introduces two timestamps that will be tracked through the message processing flow.

1. Receive time - this is the point in time the message was received on an input.
1. Processing time - this is the point in time after all message processors have been run and before the message is indexed

Both timestamp are currently not written to Elasticsearch because we need to adjust the index templates to make sure we can store them as date type with a `gl2_` prefix. We will adjust the index templates for 3.1 and start indexing the new timestamps in 3.2.

The receive time will be tracked per Graylog node so we are able to determine if processing is slow or behind. (e.g. peak hours with lots of messages in the journal) This processing status will be used by the new alerting to decide if messages can be queried for a certain timerange to create alerts.

Closes #5883 