### PR TITLE
Handle missing field type of selected field in MessageTableEntry.

### DIFF
--- a/graylog2-web-interface/src/views/components/TypeSpecificValue.jsx
+++ b/graylog2-web-interface/src/views/components/TypeSpecificValue.jsx
@@ -21,7 +21,7 @@ const _formatValue = (field, value, truncate, render, type) => {
 
 type Props = {
   field: string,
-  value: any,
+  value?: any,
   type: FieldType,
   truncate?: boolean,
   render?: React.ComponentType<ValueRendererProps>,
@@ -43,11 +43,12 @@ const TypeSpecificValue = ({ field, value, render = defaultComponent, type = Fie
 TypeSpecificValue.propTypes = {
   truncate: PropTypes.bool,
   type: CustomPropTypes.FieldType,
-  value: PropTypes.any.isRequired,
+  value: PropTypes.any,
 };
 
 TypeSpecificValue.defaultProps = {
   render: defaultComponent,
+  value: undefined,
 };
 
 export default TypeSpecificValue;

--- a/graylog2-web-interface/src/views/components/messagelist/CustomHighlighting.jsx
+++ b/graylog2-web-interface/src/views/components/messagelist/CustomHighlighting.jsx
@@ -2,7 +2,6 @@
 import * as React from 'react';
 import PropTypes from 'prop-types';
 
-// $FlowFixMe: imports from core need to be fixed in flow
 import connect from 'stores/connect';
 
 import { HighlightingRulesStore } from 'views/stores/HighlightingRulesStore';
@@ -16,7 +15,7 @@ type Props = {
   children: React.Node,
   field: string,
   highlightingRules: { [string]: Array<HighlightingRule> },
-  value: any,
+  value?: any,
 };
 
 const CustomHighlighting = ({ children, field: fieldName, value: fieldValue, highlightingRules }: Props) => {
@@ -53,7 +52,11 @@ const CustomHighlighting = ({ children, field: fieldName, value: fieldValue, hig
 CustomHighlighting.propTypes = {
   children: PropTypes.node.isRequired,
   field: PropTypes.string.isRequired,
-  value: PropTypes.any.isRequired,
+  value: PropTypes.any,
+};
+
+CustomHighlighting.defaultProps = {
+  value: undefined,
 };
 
 export default connect(CustomHighlighting,

--- a/graylog2-web-interface/src/views/components/messagelist/MessageFields.jsx
+++ b/graylog2-web-interface/src/views/components/messagelist/MessageFields.jsx
@@ -21,7 +21,7 @@ const MessageFields = ({ message, fields }: Props) => {
   const renderedFields = Object.keys(formattedFields)
     .sort()
     .map((key) => {
-      const { type } = fields.find(t => t.name === key, FieldTypeMapping.create(key, FieldType.Unknown));
+      const { type } = fields.find(t => t.name === key, undefined, FieldTypeMapping.create(key, FieldType.Unknown));
       return (
         <CustomHighlighting key={key}
                             field={key}

--- a/graylog2-web-interface/src/views/components/messagelist/MessageTableEntry.jsx
+++ b/graylog2-web-interface/src/views/components/messagelist/MessageTableEntry.jsx
@@ -2,10 +2,8 @@
 import * as React from 'react';
 import PropTypes from 'prop-types';
 import * as Immutable from 'immutable';
-// $FlowFixMe: imports from core need to be fixed in flow
 import connect from 'stores/connect';
 
-// $FlowFixMe: imports from core need to be fixed in flow
 import CombinedProvider from 'injection/CombinedProvider';
 
 import { StreamsStore } from 'views/stores/StreamsStore';
@@ -49,13 +47,19 @@ const ConnectedMessageDetail = connect(
   },
 );
 
+type Message = {|
+  id: string,
+  index: string,
+  fields: { [string]: any },
+|};
+
 type Props = {
   disableSurroundingSearch?: boolean,
   expandAllRenderAsync: boolean,
   expanded: boolean,
   fields: FieldTypeMappingsList,
   highlightMessage?: string,
-  message: { [string]: any },
+  message: Message,
   selectedFields?: Immutable.OrderedSet<string>,
   showMessageRow?: boolean,
   toggleDetail: (string) => void,
@@ -92,12 +96,12 @@ const MessageTableEntry = ({
   if (message.id === highlightMessage) {
     classes += ' message-highlight';
   }
-  const messageFieldType = fields.find(type => type.name === 'message', FieldTypeMapping.create('message', FieldType.Unknown)).type;
+  const messageFieldType = fields.find(type => type.name === 'message', undefined, FieldTypeMapping.create('message', FieldType.Unknown)).type;
   return (
     <tbody className={classes}>
       <tr className="fields-row" onClick={_toggleDetail}>
         { selectedFields.toArray().map((selectedFieldName, idx) => {
-          const { type } = fields.find(t => t.name === selectedFieldName, FieldTypeMapping.create(selectedFieldName, FieldType.Unknown));
+          const { type } = fields.find(t => t.name === selectedFieldName, undefined, FieldTypeMapping.create(selectedFieldName, FieldType.Unknown));
           return (
             <td className={style.fieldsRowField} key={selectedFieldName}>
               {_renderStrong(

--- a/graylog2-web-interface/src/views/components/messagelist/MessageTableEntry.test.jsx
+++ b/graylog2-web-interface/src/views/components/messagelist/MessageTableEntry.test.jsx
@@ -12,7 +12,7 @@ describe('MessageTableEntry', () => {
       index: 'test_0',
       fields: {
         message: 'Something happened!',
-      }
+      },
     };
     const wrapper = mount((
       <table>

--- a/graylog2-web-interface/src/views/components/messagelist/MessageTableEntry.test.jsx
+++ b/graylog2-web-interface/src/views/components/messagelist/MessageTableEntry.test.jsx
@@ -1,0 +1,29 @@
+// @flow strict
+import * as React from 'react';
+import { mount } from 'enzyme';
+import * as Immutable from 'immutable';
+
+import MessageTableEntry from './MessageTableEntry';
+
+describe('MessageTableEntry', () => {
+  it('renders message for unknown selected fields', () => {
+    const message = {
+      id: 'deadbeef',
+      index: 'test_0',
+      fields: {
+        message: 'Something happened!',
+      }
+    };
+    const wrapper = mount((
+      <table>
+        <MessageTableEntry expandAllRenderAsync
+                           toggleDetail={() => {}}
+                           fields={Immutable.List()}
+                           message={message}
+                           selectedFields={Immutable.OrderedSet(['message', 'notexisting'])}
+                           expanded={false} />
+      </table>
+    ));
+    expect(wrapper).toIncludeText('Something happened!');
+  });
+});


### PR DESCRIPTION
## Description
## Motivation and Context

Before this change, using `Immutable.List#find` to lookup a field type
used the wrong parameter count. Instead of (what the intention was)
passing a default value for cases where the field type is not present,
it was passing the `context`[*] instead. This is fixed and a test is
added.

Fixes Graylog2/graylog-plugin-enterprise#1090.

[*]: https://immutable-js.github.io/immutable-js/docs/#/List/find

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.